### PR TITLE
Add Buck2 test targets for all crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,8 +82,8 @@ jobs:
     - name: Buck2 build
       run: buck2 build //crates/rue:rue
     
-    - name: Buck2 test (lexer)
-      run: cargo test -p rue-lexer  # Buck2 test support coming later
+    - name: Buck2 test
+      run: buck2 test //crates/...
     
     - name: Buck2 run
       run: buck2 run //crates/rue:rue

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,7 +17,14 @@ For complete language and implementation details, see [spec.md](./spec.md).
 
 ## Development Commands
 
-*To be added once Buck2 build configuration is set up*
+### Building
+- `buck2 build //crates/rue:rue` - Build the main rue compiler
+- `buck2 build //crates/...` - Build all crates
+
+### Testing  
+- `buck2 test //crates/...` - Run all tests
+- `buck2 test //crates/rue-lexer:test` - Run lexer tests
+- `buck2 test //crates/rue-parser:test` - Run parser tests
 
 ## Architecture
 

--- a/crates/rue-ast/BUCK
+++ b/crates/rue-ast/BUCK
@@ -10,3 +10,13 @@ cargo.rust_library(
     ],
     visibility = ["PUBLIC"],
 )
+
+rust_test(
+    name = "test",
+    srcs = glob(["src/**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2021",
+    deps = [
+        "//crates/rue-lexer:rue-lexer",
+    ],
+)

--- a/crates/rue-codegen/BUCK
+++ b/crates/rue-codegen/BUCK
@@ -10,3 +10,13 @@ cargo.rust_library(
     ],
     visibility = ["PUBLIC"],
 )
+
+rust_test(
+    name = "test",
+    srcs = glob(["src/**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2024",
+    deps = [
+        "//crates/rue-ast:rue-ast",
+    ],
+)

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -13,3 +13,16 @@ cargo.rust_library(
     ],
     visibility = ["PUBLIC"],
 )
+
+rust_test(
+    name = "test",
+    srcs = glob(["src/**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2024",
+    deps = [
+        "//crates/rue-ast:rue-ast",
+        "//crates/rue-lexer:rue-lexer",
+        "//crates/rue-parser:rue-parser",
+        "//:salsa",
+    ],
+)

--- a/crates/rue-lexer/BUCK
+++ b/crates/rue-lexer/BUCK
@@ -7,3 +7,10 @@ cargo.rust_library(
     edition = "2021",
     visibility = ["PUBLIC"],
 )
+
+rust_test(
+    name = "test",
+    srcs = glob(["src/**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2021",
+)

--- a/crates/rue-parser/BUCK
+++ b/crates/rue-parser/BUCK
@@ -11,3 +11,14 @@ cargo.rust_library(
     ],
     visibility = ["PUBLIC"],
 )
+
+rust_test(
+    name = "test",
+    srcs = glob(["src/**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2021",
+    deps = [
+        "//crates/rue-ast:rue-ast",
+        "//crates/rue-lexer:rue-lexer",
+    ],
+)

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -1,6 +1,8 @@
 load("@prelude//toolchains:rust.bzl", "system_rust_toolchain")
 load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain")
 load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
+load("@prelude//tests:test_toolchain.bzl", "noop_test_toolchain")
+load(":remote_test_execution.bzl", "noop_remote_test_execution_toolchain")
 
 system_rust_toolchain(
     name = "rust",
@@ -14,5 +16,15 @@ system_python_bootstrap_toolchain(
 
 system_cxx_toolchain(
     name = "cxx",
+    visibility = ["PUBLIC"],
+)
+
+noop_test_toolchain(
+    name = "test",
+    visibility = ["PUBLIC"],
+)
+
+noop_remote_test_execution_toolchain(
+    name = "remote_test_execution",
     visibility = ["PUBLIC"],
 )

--- a/toolchains/remote_test_execution.bzl
+++ b/toolchains/remote_test_execution.bzl
@@ -1,0 +1,17 @@
+load("@prelude//tests:remote_test_execution_toolchain.bzl", "RemoteTestExecutionToolchainInfo")
+
+def _remote_test_execution_impl(ctx):
+    return [
+        DefaultInfo(),
+        RemoteTestExecutionToolchainInfo(
+            default_profile = None,
+            profiles = {},
+            default_run_as_bundle = False,
+        )
+    ]
+
+noop_remote_test_execution_toolchain = rule(
+    impl = _remote_test_execution_impl,
+    attrs = {},
+    is_toolchain_rule = True,
+)


### PR DESCRIPTION
- Add rust_test targets to all crate BUCK files (rue-lexer, rue-parser, rue-ast, rue-codegen, rue-compiler)
- Set up Buck2 test infrastructure with test and remote_test_execution toolchains
- Update CI to use 'buck2 test //crates/...' instead of cargo test
- Update CLAUDE.md with Buck2 testing commands
- All 9 existing tests now pass through Buck2