### PR TITLE
Add comment support to Rue

### DIFF
--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -116,7 +116,11 @@ impl<'a> Lexer<'a> {
                 }
             }
             '*' => self.make_token(TokenKind::Star, start),
-            '/' => self.make_token(TokenKind::Slash, start),
+            '/' => {
+                // Check if it's a comment start, but since comments are handled
+                // in skip_whitespace, if we get here it's a division operator
+                self.make_token(TokenKind::Slash, start)
+            }
             '%' => self.make_token(TokenKind::Percent, start),
             ':' => self.make_token(TokenKind::Colon, start),
             '(' => self.make_token(TokenKind::LeftParen, start),
@@ -267,9 +271,56 @@ impl<'a> Lexer<'a> {
     }
 
     fn skip_whitespace(&mut self) {
-        while self.current_char().is_whitespace() {
+        loop {
+            if self.current_char().is_whitespace() {
+                self.advance();
+            } else if self.current_char() == '/' && self.peek_char() == '/' {
+                self.skip_single_line_comment();
+            } else if self.current_char() == '/' && self.peek_char() == '*' {
+                self.skip_multi_line_comment();
+            } else {
+                break;
+            }
+        }
+    }
+
+    fn skip_single_line_comment(&mut self) {
+        self.advance(); // Skip first '/'
+        self.advance(); // Skip second '/'
+
+        while !self.is_at_end() && self.current_char() != '\n' {
             self.advance();
         }
+    }
+
+    fn skip_multi_line_comment(&mut self) {
+        let start = self.position;
+        self.advance(); // Skip '/'
+        self.advance(); // Skip '*'
+
+        let mut depth = 1;
+
+        while !self.is_at_end() && depth > 0 {
+            if self.current_char() == '/' && self.peek_char() == '*' {
+                depth += 1;
+                self.advance();
+                self.advance();
+            } else if self.current_char() == '*' && self.peek_char() == '/' {
+                depth -= 1;
+                self.advance();
+                self.advance();
+            } else {
+                self.advance();
+            }
+        }
+
+        if depth > 0 {
+            panic!("Unterminated comment starting at position {start}");
+        }
+    }
+
+    fn peek_char(&self) -> char {
+        self.input.chars().nth(self.position + 1).unwrap_or('\0')
     }
 
     fn current_char(&self) -> char {
@@ -377,5 +428,153 @@ fn factorial(n) {
         assert_eq!(tokens[11].kind, TokenKind::Arrow);
         assert_eq!(tokens[12].kind, TokenKind::I32);
         assert_eq!(tokens[13].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_single_line_comment() {
+        let mut lexer = Lexer::new("// This is a comment\n42");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[1].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_single_line_comment_at_eof() {
+        let mut lexer = Lexer::new("42 // Comment at EOF");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[1].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_multiple_single_line_comments() {
+        let mut lexer = Lexer::new("// Comment 1\n42\n// Comment 2\n+ 3");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[1].kind, TokenKind::Plus);
+        assert_eq!(tokens[2].kind, TokenKind::Integer(3));
+        assert_eq!(tokens[3].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_empty_single_line_comment() {
+        let mut lexer = Lexer::new("//\n42");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[1].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_basic_multi_line_comment() {
+        let mut lexer = Lexer::new("/* comment */ 42");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[1].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_multi_line_comment_spanning_lines() {
+        let mut lexer = Lexer::new("42 /* comment\nspanning\nmultiple lines */ + 3");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[1].kind, TokenKind::Plus);
+        assert_eq!(tokens[2].kind, TokenKind::Integer(3));
+        assert_eq!(tokens[3].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_empty_multi_line_comment() {
+        let mut lexer = Lexer::new("/**/ 42");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[1].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_nested_multi_line_comments() {
+        let mut lexer = Lexer::new("/* outer /* inner */ still comment */ 42");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[1].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_deeply_nested_comments() {
+        let mut lexer = Lexer::new("/* a /* b /* c */ b */ a */ 42");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[1].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    #[should_panic(expected = "Unterminated comment")]
+    fn test_unterminated_comment() {
+        let mut lexer = Lexer::new("/* unterminated");
+        lexer.tokenize();
+    }
+
+    #[test]
+    #[should_panic(expected = "Unterminated comment")]
+    fn test_unterminated_nested_comment() {
+        let mut lexer = Lexer::new("/* outer /* inner */");
+        lexer.tokenize();
+    }
+
+    #[test]
+    fn test_mixed_comments() {
+        let mut lexer = Lexer::new("// single\n/* multi */ 42 // end");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[1].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_comments_between_tokens() {
+        let mut lexer = Lexer::new("42 /* comment */ + /* another */ 3");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[1].kind, TokenKind::Plus);
+        assert_eq!(tokens[2].kind, TokenKind::Integer(3));
+        assert_eq!(tokens[3].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_single_line_in_multi_line() {
+        let mut lexer = Lexer::new("/* // this is still a comment */ 42");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[1].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_multi_line_markers_in_single_line() {
+        let mut lexer = Lexer::new("// /* */ still a comment\n42");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[1].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_division_not_comment() {
+        let mut lexer = Lexer::new("42 / 6");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[1].kind, TokenKind::Slash);
+        assert_eq!(tokens[2].kind, TokenKind::Integer(6));
+        assert_eq!(tokens[3].kind, TokenKind::Eof);
     }
 }

--- a/docs/sessions/session-11-comments/design-decisions.md
+++ b/docs/sessions/session-11-comments/design-decisions.md
@@ -1,0 +1,35 @@
+# Design Decisions: Comments
+
+## Overview
+This document records the design decisions made for adding comment support to Rue.
+
+## Comment Syntax
+
+### Single-line Comments
+- **Decision**: Use `//` for single-line comments (Rust-style)
+- **Rationale**: Following Rust as our primary language influence, familiar to modern programmers
+- **Alternative considered**: `#` (Python/Ruby style) - rejected for consistency with Rust
+
+### Multi-line Comments
+- **Decision**: Use `/* */` for multi-line comments with nesting support (Rust-style)
+- **Rationale**: Rust's approach to nested comments is superior to C's, allows commenting out code blocks that contain comments
+- **Alternative considered**: `(* *)` (ML-style) - rejected for consistency with Rust
+
+## Implementation Approach
+
+### Lexer Integration
+- **Decision**: Handle comments entirely in the lexer, don't pass them to parser
+- **Rationale**: Comments are not part of the AST, simpler implementation
+- **Trade-off**: Cannot preserve comments for documentation generation later
+
+### Nested Comments
+- **Decision**: Support nested multi-line comments
+- **Rationale**: More flexible, allows commenting out code that already contains comments
+- **Implementation**: Track nesting depth when lexing `/*` and `*/` tokens
+
+## Edge Cases
+
+### Comment Placement
+- Comments can appear anywhere whitespace is allowed
+- Comments at end of file don't require trailing newline
+- Empty comments are valid (`//` with nothing after, `/**/`)

--- a/docs/sessions/session-11-comments/session-summary.md
+++ b/docs/sessions/session-11-comments/session-summary.md
@@ -1,0 +1,22 @@
+# Session 11: Comments
+
+## Session Overview
+Add comment support to the Rue programming language.
+
+## Goals
+- [x] Add single-line comment support (`//`)
+- [x] Add multi-line comment support (`/* */`) with nesting
+- [x] Update language specification
+- [x] Implement lexer support for comments
+- [x] Add comprehensive tests
+
+## Status
+**Completed** - Comments fully implemented with Rust-style nested multi-line comment support
+
+## Summary
+Successfully added comment support to Rue:
+- Single-line comments using `//` syntax
+- Multi-line comments using `/* */` syntax with full nesting support
+- Comments are handled entirely in the lexer as whitespace
+- Added comprehensive test coverage including edge cases
+- Created example program demonstrating comment usage

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -47,7 +47,23 @@ boolean_literal ::= "true" | "false"
 Whitespace consists of spaces, tabs, and newlines. Whitespace is ignored except as a token separator.
 
 #### 2.2.7 Comments
-Currently, Rue does not support comments.
+Rue supports two styles of comments:
+
+**Single-line comments** begin with `//` and extend to the end of the line:
+```
+// This is a single-line comment
+let x: i32 = 42; // Comments can appear after code
+```
+
+**Multi-line comments** begin with `/*` and end with `*/`. Multi-line comments can be nested:
+```
+/* This is a multi-line comment
+   that spans multiple lines */
+
+/* Nested /* comments are */ supported */
+```
+
+Comments are treated as whitespace and can appear anywhere whitespace is allowed.
 
 ## 3. Syntax
 

--- a/examples/comments.rue
+++ b/examples/comments.rue
@@ -1,0 +1,16 @@
+// This is a simple Rue program demonstrating comment support
+
+fn main() -> i32 {
+    // Single-line comments work great!
+    let x: i32 = 42;
+    
+    /* Multi-line comments
+       can span multiple
+       lines */
+    let y: i32 = 10;
+    
+    /* Nested /* comments are */ supported too! */
+    
+    // Comments can be at the end of lines
+    x + y // This will return 52
+}


### PR DESCRIPTION
- Add single-line comments (//) and multi-line comments (/* */)
- Support nested multi-line comments (Rust-style)
- Handle comments entirely in the lexer as whitespace
- Add comprehensive test coverage for all comment scenarios
- Update language specification with comment syntax
- Add example program demonstrating comment usage