### PR TITLE
Add ELF section headers to fix objdump compatibility

### DIFF
--- a/crates/rue-codegen/Cargo.toml
+++ b/crates/rue-codegen/Cargo.toml
@@ -12,6 +12,7 @@ rue-runtime = { path = "../rue-runtime" }
 rue-ir = { path = "../rue-ir" }
 indexmap = "2"
 thiserror = "2.0.12"
+object = { version = "0.37.1", features = ["write"] }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/crates/rue-codegen/src/elf_writer.rs
+++ b/crates/rue-codegen/src/elf_writer.rs
@@ -18,6 +18,34 @@ impl ElfWriter {
     pub fn generate_elf(&self, machine_code: &[u8], symbols: &HashMap<String, usize>) -> Vec<u8> {
         let mut elf = Vec::new();
 
+        // Calculate sizes and offsets
+        let elf_header_size = 64;
+        let program_header_size = 56;
+        let headers_size = elf_header_size + program_header_size;
+
+        // Section header string table
+        let shstrtab = b"\0.text\0.shstrtab\0";
+        let text_name_offset = 1; // ".text" starts at offset 1
+        let shstrtab_name_offset = 7; // ".shstrtab" starts at offset 7
+
+        // Layout:
+        // - ELF header (64 bytes)
+        // - Program header (56 bytes)
+        // - Machine code (aligned to 16 bytes)
+        // - String table
+        // - Section headers (at end)
+
+        let code_offset = headers_size;
+        let code_size = machine_code.len();
+        let code_end = code_offset + code_size;
+
+        // Align string table to 8 bytes
+        let shstrtab_offset = (code_end + 7) & !7;
+        let shstrtab_size = shstrtab.len();
+
+        // Section headers at the end
+        let section_headers_offset = shstrtab_offset + shstrtab_size;
+
         // Find the _start symbol position
         let start_offset = symbols
             .get("_start")
@@ -25,10 +53,10 @@ impl ElfWriter {
             .copied()
             .unwrap_or(0);
 
-        let entry_point = self.base_addr + 0x78 + start_offset as u64;
+        let entry_point = self.base_addr + code_offset as u64 + start_offset as u64;
 
         // ELF Header
-        self.write_elf_header(&mut elf, entry_point);
+        self.write_elf_header(&mut elf, entry_point, section_headers_offset as u64);
 
         // Program Header
         self.write_program_header(&mut elf, machine_code.len());
@@ -36,10 +64,38 @@ impl ElfWriter {
         // Machine code
         elf.extend_from_slice(machine_code);
 
+        // Padding before string table
+        while elf.len() < shstrtab_offset {
+            elf.push(0);
+        }
+
+        // String table
+        elf.extend_from_slice(shstrtab);
+
+        // Section headers
+        // Section 0: NULL section (required)
+        self.write_null_section_header(&mut elf);
+
+        // Section 1: .text
+        self.write_text_section_header(
+            &mut elf,
+            code_offset as u64,
+            code_size as u64,
+            text_name_offset,
+        );
+
+        // Section 2: .shstrtab
+        self.write_shstrtab_section_header(
+            &mut elf,
+            shstrtab_offset as u64,
+            shstrtab_size as u64,
+            shstrtab_name_offset,
+        );
+
         elf
     }
 
-    fn write_elf_header(&self, elf: &mut Vec<u8>, entry_point: u64) {
+    fn write_elf_header(&self, elf: &mut Vec<u8>, entry_point: u64, section_headers_offset: u64) {
         // ELF identification
         elf.extend_from_slice(&[0x7f, 0x45, 0x4c, 0x46]); // ELF magic
         elf.push(0x02); // 64-bit
@@ -54,14 +110,14 @@ impl ElfWriter {
         elf.extend_from_slice(&1u32.to_le_bytes()); // EV_CURRENT - Version
         elf.extend_from_slice(&entry_point.to_le_bytes()); // Entry point address
         elf.extend_from_slice(&64u64.to_le_bytes()); // Program header offset
-        elf.extend_from_slice(&0u64.to_le_bytes()); // Section header offset (none)
+        elf.extend_from_slice(&section_headers_offset.to_le_bytes()); // Section header offset
         elf.extend_from_slice(&0u32.to_le_bytes()); // Processor-specific flags
         elf.extend_from_slice(&64u16.to_le_bytes()); // ELF header size
         elf.extend_from_slice(&56u16.to_le_bytes()); // Program header entry size
         elf.extend_from_slice(&1u16.to_le_bytes()); // Program header entry count
-        elf.extend_from_slice(&0u16.to_le_bytes()); // Section header entry size
-        elf.extend_from_slice(&0u16.to_le_bytes()); // Section header entry count
-        elf.extend_from_slice(&0u16.to_le_bytes()); // Section name string table index
+        elf.extend_from_slice(&64u16.to_le_bytes()); // Section header entry size
+        elf.extend_from_slice(&3u16.to_le_bytes()); // Section header entry count
+        elf.extend_from_slice(&2u16.to_le_bytes()); // Section name string table index (.shstrtab)
     }
 
     fn write_program_header(&self, elf: &mut Vec<u8>, code_size: usize) {
@@ -84,6 +140,49 @@ impl ElfWriter {
         elf.extend_from_slice(&total_file_size.to_le_bytes()); // Size in file
         elf.extend_from_slice(&total_memory_size.to_le_bytes()); // Size in memory
         elf.extend_from_slice(&self.page_size.to_le_bytes()); // Alignment
+    }
+
+    fn write_null_section_header(&self, elf: &mut Vec<u8>) {
+        // NULL section (all zeros)
+        elf.extend_from_slice(&[0; 64]);
+    }
+
+    fn write_text_section_header(
+        &self,
+        elf: &mut Vec<u8>,
+        offset: u64,
+        size: u64,
+        name_offset: u32,
+    ) {
+        elf.extend_from_slice(&name_offset.to_le_bytes()); // sh_name
+        elf.extend_from_slice(&1u32.to_le_bytes()); // sh_type: SHT_PROGBITS
+        elf.extend_from_slice(&6u64.to_le_bytes()); // sh_flags: SHF_ALLOC | SHF_EXECINSTR
+        elf.extend_from_slice(&(self.base_addr + offset).to_le_bytes()); // sh_addr
+        elf.extend_from_slice(&offset.to_le_bytes()); // sh_offset
+        elf.extend_from_slice(&size.to_le_bytes()); // sh_size
+        elf.extend_from_slice(&0u32.to_le_bytes()); // sh_link
+        elf.extend_from_slice(&0u32.to_le_bytes()); // sh_info
+        elf.extend_from_slice(&16u64.to_le_bytes()); // sh_addralign
+        elf.extend_from_slice(&0u64.to_le_bytes()); // sh_entsize
+    }
+
+    fn write_shstrtab_section_header(
+        &self,
+        elf: &mut Vec<u8>,
+        offset: u64,
+        size: u64,
+        name_offset: u32,
+    ) {
+        elf.extend_from_slice(&name_offset.to_le_bytes()); // sh_name
+        elf.extend_from_slice(&3u32.to_le_bytes()); // sh_type: SHT_STRTAB
+        elf.extend_from_slice(&0u64.to_le_bytes()); // sh_flags
+        elf.extend_from_slice(&0u64.to_le_bytes()); // sh_addr
+        elf.extend_from_slice(&offset.to_le_bytes()); // sh_offset
+        elf.extend_from_slice(&size.to_le_bytes()); // sh_size
+        elf.extend_from_slice(&0u32.to_le_bytes()); // sh_link
+        elf.extend_from_slice(&0u32.to_le_bytes()); // sh_info
+        elf.extend_from_slice(&1u64.to_le_bytes()); // sh_addralign
+        elf.extend_from_slice(&0u64.to_le_bytes()); // sh_entsize
     }
 }
 


### PR DESCRIPTION
The compiler now generates proper ELF section headers (.text and .shstrtab)  so that standard ELF analysis tools like objdump, readelf, and nm can properly  analyze Rue executables. This Fixes #44 where objdump couldn't disassemble  the generated binaries.

The executables remain minimal but now include the necessary metadata for  debugging and analysis tools to work correctly.