### PR TITLE
Add negative number literals to the language

### DIFF
--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -105,6 +105,9 @@ impl<'a> Lexer<'a> {
                             end: self.position,
                         },
                     }
+                } else if self.current_char().is_ascii_digit() {
+                    // Handle negative number literal
+                    self.lex_number(start)
                 } else {
                     Token {
                         kind: TokenKind::Minus,
@@ -576,5 +579,48 @@ fn factorial(n) {
         assert_eq!(tokens[1].kind, TokenKind::Slash);
         assert_eq!(tokens[2].kind, TokenKind::Integer(6));
         assert_eq!(tokens[3].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_negative_number_literal() {
+        let mut lexer = Lexer::new("-5");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(-5));
+        assert_eq!(tokens[1].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_negative_number_in_expression() {
+        let mut lexer = Lexer::new("let x = -42;");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Let);
+        assert_eq!(tokens[1].kind, TokenKind::Ident("x".to_string()));
+        assert_eq!(tokens[2].kind, TokenKind::Assign);
+        assert_eq!(tokens[3].kind, TokenKind::Integer(-42));
+        assert_eq!(tokens[4].kind, TokenKind::Semicolon);
+        assert_eq!(tokens[5].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_subtraction_vs_negative() {
+        let mut lexer = Lexer::new("5 - 3");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Integer(5));
+        assert_eq!(tokens[1].kind, TokenKind::Minus);
+        assert_eq!(tokens[2].kind, TokenKind::Integer(3));
+        assert_eq!(tokens[3].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_negative_with_spaces() {
+        let mut lexer = Lexer::new("- 5");
+        let tokens = lexer.tokenize();
+
+        assert_eq!(tokens[0].kind, TokenKind::Minus);
+        assert_eq!(tokens[1].kind, TokenKind::Integer(5));
+        assert_eq!(tokens[2].kind, TokenKind::Eof);
     }
 }

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -613,6 +613,59 @@ mod tests {
     }
 
     #[test]
+    fn test_negative_number() {
+        let result = lex_and_parse("-42;");
+        assert!(result.is_ok());
+        let cst = result.unwrap();
+        assert_eq!(cst.items.len(), 1);
+
+        match &cst.items[0] {
+            CstNode::Statement(stmt) => match &**stmt {
+                StatementNode::Expression(expr_stmt) => match &expr_stmt.expression {
+                    ExpressionNode::Literal(token) => match &token.kind {
+                        TokenKind::Integer(value) => assert_eq!(*value, -42),
+                        _ => panic!("Expected integer token"),
+                    },
+                    _ => panic!("Expected literal expression"),
+                },
+                _ => panic!("Expected expression statement with literal"),
+            },
+            _ => panic!("Expected statement"),
+        }
+    }
+
+    #[test]
+    fn test_negative_number_in_let() {
+        let result = lex_and_parse("let x = -5;");
+        assert!(result.is_ok());
+        let cst = result.unwrap();
+        assert_eq!(cst.items.len(), 1);
+
+        match &cst.items[0] {
+            CstNode::Statement(stmt) => match &**stmt {
+                StatementNode::Let(let_stmt) => {
+                    // Check variable name
+                    match &let_stmt.name.kind {
+                        TokenKind::Ident(name) => assert_eq!(name, "x"),
+                        _ => panic!("Expected identifier token for variable name"),
+                    }
+
+                    // Check value
+                    match &let_stmt.value {
+                        ExpressionNode::Literal(token) => match &token.kind {
+                            TokenKind::Integer(value) => assert_eq!(*value, -5),
+                            _ => panic!("Expected integer token for value"),
+                        },
+                        _ => panic!("Expected literal for value"),
+                    }
+                }
+                _ => panic!("Expected let statement"),
+            },
+            _ => panic!("Expected statement"),
+        }
+    }
+
+    #[test]
     fn test_simple_identifier() {
         let result = lex_and_parse("foo;");
         assert!(result.is_ok());

--- a/crates/rue/tests/comprehensive_sample_tests.rs
+++ b/crates/rue/tests/comprehensive_sample_tests.rs
@@ -121,6 +121,7 @@ fn analyze_expected_exit_code(content: &str, filename: &str) -> Option<i32> {
         "while_demo" => Some(30), // test_while_false(5) + test_while_nested(7) = 10 + 20 = 30
         "assignment_spec_example" => Some(15), // let x = 10; x = x + 5; x  =>  15
         "simple_assignment" => Some(100), // Need to check what this actually returns
+        "negative_literals" => Some(209), // -47 as unsigned 8-bit = 209
         _ => None,
     }
 }

--- a/crates/rue/tests/integration_tests.rs
+++ b/crates/rue/tests/integration_tests.rs
@@ -123,17 +123,23 @@ fn test_large_div_immediate_program() {
 }
 
 #[test]
+fn test_negative_literals_program() {
+    test_rue_program("negative_literals", 256 - 47); // -5 + -42 = -47, exit code wraps to 209
+}
+
+#[test]
 fn test_all_samples_compile() {
     // Test samples that should compile successfully
     let successful_samples = [
         ("simple", 42),
         ("factorial", 120),
-        ("countdown", 42),          // simple_while(10) returns 42 since 10 > 3
-        ("if_demo", 5),             // if 1 <= 2 { 5 } else { 10 } returns 5
-        ("assignment_demo", 6),     // test_assignment_in_while() returns sum of 0+1+2+3 = 6
-        ("division_test", 10),      // 100 / 10 = 10
-        ("large_immediate", 0),     // Tests 64-bit immediate handling
-        ("large_div_immediate", 1), // Tests division by large immediate
+        ("countdown", 42),               // simple_while(10) returns 42 since 10 > 3
+        ("if_demo", 5),                  // if 1 <= 2 { 5 } else { 10 } returns 5
+        ("assignment_demo", 6),          // test_assignment_in_while() returns sum of 0+1+2+3 = 6
+        ("division_test", 10),           // 100 / 10 = 10
+        ("negative_literals", 256 - 47), // -5 + -42 = -47
+        ("large_immediate", 0),          // Tests 64-bit immediate handling
+        ("large_div_immediate", 1),      // Tests division by large immediate
     ];
 
     for (sample_name, expected_exit_code) in successful_samples {

--- a/samples/negative_literals.rue
+++ b/samples/negative_literals.rue
@@ -1,0 +1,5 @@
+fn main() -> i32 {
+    let x = -5;
+    let y = -42;
+    x + y  // Should be -47
+}


### PR DESCRIPTION
The lexer now recognizes negative number literals when a minus sign is  immediately followed by a digit (e.g., -42, -5). This allows expressions  like 'let x = -5;' to work correctly.

- Modified lexer to check for digits after minus sign
- Added lexer tests for negative literals
- Added parser tests for negative literals in expressions
- Added integration test with negative_literals.rue sample
- Fixes #42