### PR TITLE
Add error formatting function to rue-lexer

### DIFF
--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -79,6 +79,67 @@ pub struct Span {
     pub end: usize,
 }
 
+/// Formats an error message with source context
+pub fn format_error_with_context(
+    source: &str,
+    span: Span,
+    message: &str,
+    error_type: &str,
+) -> String {
+    let lines: Vec<&str> = source.lines().collect();
+    let mut line_start = 0;
+    let mut line_num = 0;
+    let mut col_num = 0;
+
+    // Find line and column for the error position
+    for (idx, line) in lines.iter().enumerate() {
+        let line_end = line_start + line.len();
+        if span.start >= line_start && span.start <= line_end {
+            line_num = idx + 1;
+            col_num = span.start - line_start + 1;
+            break;
+        }
+        line_start = line_end + 1; // +1 for newline
+    }
+
+    // Build the error message
+    let mut result = format!("{error_type}: {message}\n");
+
+    // Add location info
+    result.push_str(&format!(" --> {}:{}:{}\n", "input", line_num, col_num));
+
+    // Add source context
+    if line_num > 0 && line_num <= lines.len() {
+        let line_idx = line_num - 1;
+        let line = lines[line_idx];
+
+        // Line number padding
+        let line_num_str = line_num.to_string();
+        let padding = " ".repeat(line_num_str.len());
+
+        result.push_str(&format!("  {padding} |\n"));
+        result.push_str(&format!("{line_num_str} | {line}\n"));
+
+        // Add underline
+        let underline_start = col_num - 1;
+        let underline_len = (span.end - span.start).max(1);
+
+        result.push_str(&format!(
+            "  {} |{}{}",
+            padding,
+            " ".repeat(underline_start),
+            "^".repeat(underline_len)
+        ));
+
+        // Add label on same line as carets
+        if !message.is_empty() {
+            result.push_str(&format!(" {message}"));
+        }
+    }
+
+    result
+}
+
 pub struct Lexer<'a> {
     input: &'a str,
     position: usize,

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -1,5 +1,5 @@
 use rue_ast::*;
-use rue_lexer::{Span, TokenKind};
+use rue_lexer::{Span, TokenKind, format_error_with_context};
 
 pub struct Parser {
     tokens: Vec<TokenNode>,
@@ -12,6 +12,12 @@ pub type ParseResult<T> = Result<T, ParseError>;
 pub struct ParseError {
     pub message: String,
     pub span: Span,
+}
+
+impl ParseError {
+    pub fn format_with_source(&self, source: &str) -> String {
+        format_error_with_context(source, self.span, &self.message, "parse error")
+    }
 }
 
 impl Parser {

--- a/crates/rue-semantic/src/lib.rs
+++ b/crates/rue-semantic/src/lib.rs
@@ -1,4 +1,5 @@
 use rue_ast::{CstRoot, ExpressionNode, FunctionNode, StatementNode};
+use rue_lexer::format_error_with_context;
 use std::collections::HashMap;
 use std::fmt;
 
@@ -7,6 +8,12 @@ use std::fmt;
 pub struct SemanticError {
     pub message: String,
     pub span: rue_lexer::Span,
+}
+
+impl SemanticError {
+    pub fn format_with_source(&self, source: &str) -> String {
+        format_error_with_context(source, self.span, &self.message, "error")
+    }
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -199,7 +206,7 @@ fn analyze_function(scope: &mut Scope, func: &FunctionNode) -> Result<(), Semant
     if actual_return_type != return_type {
         return Err(SemanticError {
             message: format!(
-                "Type mismatch: Function '{func_name}' declared to return {return_type} but returns {actual_return_type}"
+                "Type mismatch: function '{func_name}' is declared to return '{return_type}' but returns '{actual_return_type}'"
             ),
             span: func.body.close_brace.span,
         });
@@ -240,7 +247,7 @@ fn analyze_statement(scope: &mut Scope, stmt: &StatementNode) -> Result<(), Sema
                     if !is_valid {
                         return Err(SemanticError {
                             message: format!(
-                                "Type mismatch: variable declared as {decl_type} but initialized with {value_type}"
+                                "Type mismatch: variable declared as '{decl_type}' but initialized with expression of type '{value_type}'"
                             ),
                             span: let_stmt.equals.span,
                         });
@@ -263,7 +270,7 @@ fn analyze_statement(scope: &mut Scope, stmt: &StatementNode) -> Result<(), Sema
                     if *var_type != value_type {
                         return Err(SemanticError {
                             message: format!(
-                                "Type mismatch: cannot assign {value_type} to variable of type {var_type}"
+                                "Type mismatch: cannot assign value of type '{value_type}' to variable of type '{var_type}'"
                             ),
                             span: assign_stmt.equals.span,
                         });
@@ -380,7 +387,7 @@ fn analyze_expression(scope: &mut Scope, expr: &ExpressionNode) -> Result<RueTyp
                     if left_type != right_type {
                         return Err(SemanticError {
                             message: format!(
-                                "Type mismatch: cannot apply operator to {left_type} and {right_type}"
+                                "Type mismatch: binary operator cannot be applied to types '{left_type}' and '{right_type}'"
                             ),
                             span: binary_expr.operator.span,
                         });
@@ -408,7 +415,7 @@ fn analyze_expression(scope: &mut Scope, expr: &ExpressionNode) -> Result<RueTyp
                     if left_type != right_type {
                         return Err(SemanticError {
                             message: format!(
-                                "Type mismatch: cannot compare {left_type} and {right_type}"
+                                "Type mismatch: cannot compare values of types '{left_type}' and '{right_type}'"
                             ),
                             span: binary_expr.operator.span,
                         });
@@ -455,7 +462,7 @@ fn analyze_expression(scope: &mut Scope, expr: &ExpressionNode) -> Result<RueTyp
                             if arg_type != *expected_type {
                                 return Err(SemanticError {
                                     message: format!(
-                                        "Type mismatch in argument {} of function '{}': expected {}, found {}",
+                                        "Type mismatch in argument {} of function '{}': expected '{}', found '{}'",
                                         i + 1,
                                         func_name,
                                         expected_type,
@@ -861,7 +868,7 @@ fn get_number() -> i32 {
         assert!(
             error
                 .message
-                .contains("declared to return i32 but returns bool")
+                .contains("declared to return 'i32' but returns 'bool'")
         );
     }
 


### PR DESCRIPTION
Adds format_error_with_context() to provide consistent error formatting with source location and context display across the compiler.