### PR TITLE
Add --emit-asm flag to generate assembly output

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,14 @@ For implementation details, see [docs/implementation.md](./docs/implementation.m
 - `./samples/simple` - Run the compiled executable (created in same directory as source)
 - `echo $?` - Check the exit code of the last program
 
+**Command-line Options:**
+- `-o <output>` - Specify output file name (defaults to input name without extension)
+- `--emit-asm` - Generate assembly file (.s) instead of executable
+- Examples:
+  - `cargo run -p rue samples/simple.rue -- --emit-asm` - Creates samples/simple.s
+  - `cargo run -p rue samples/simple.rue -- -o myprogram` - Creates executable named myprogram
+  - `cargo run -p rue samples/simple.rue -- --emit-asm -o output.s` - Creates assembly file output.s
+
 ### Example Programs
 - `samples/simple.rue` - Basic program that returns 42
 - `samples/factorial.rue` - Recursive factorial function (returns 120 for factorial(5))

--- a/README.md
+++ b/README.md
@@ -172,6 +172,14 @@ cargo run -p rue samples/simple.rue
 # Run the compiled program (executable created in same directory as source)
 ./samples/simple; echo $?  # Shows the program's return value
 
+# Generate assembly instead of executable
+cargo run -p rue samples/simple.rue -- --emit-asm
+# This creates samples/simple.s with x86-64 assembly
+
+# Specify output file
+cargo run -p rue samples/simple.rue -- -o myprogram
+cargo run -p rue samples/simple.rue -- --emit-asm -o myprogram.s
+
 # Try other example programs
 cargo run -p rue samples/factorial.rue && ./samples/factorial; echo $?
 cargo run -p rue samples/fibonacci.rue && ./samples/fibonacci; echo $?
@@ -184,8 +192,13 @@ cargo run -p rue samples/assignment_demo.rue && ./samples/assignment_demo; echo 
 ### With Buck2
 
 ```bash
+# Compile to executable
 buck2 run //crates/rue:rue samples/simple.rue
 ./samples/simple; echo $?
+
+# Generate assembly
+buck2 run //crates/rue:rue samples/simple.rue -- --emit-asm
+# Creates samples/simple.s
 ```
 
 ### Running Tests

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -972,5 +972,503 @@ pub fn compile_to_executable(ast: &CstRoot, scope: &Scope) -> Result<Vec<u8>, Co
     Ok(elf)
 }
 
+// Compile to assembly text instead of executable
+pub fn compile_to_assembly(ast: &CstRoot, scope: &Scope) -> Result<String, CodegenError> {
+    // Phase 0: Generate runtime code from rue-runtime crate
+    let (runtime_instructions, runtime_labels) =
+        rue_runtime::generate_runtime().map_err(|e| CodegenError { message: e })?;
+
+    // Phase 1: Generate high-level IR instructions
+    let mut codegen = Codegen::new();
+    let instructions = codegen.generate(ast, scope)?;
+    let function_labels = codegen.function_labels.clone();
+
+    // Phase 2: Identify function boundaries and allocate registers per function
+    let mut function_boundaries = Vec::new();
+    let mut current_start = 0;
+
+    for (i, instr) in instructions.iter().enumerate() {
+        if let Instruction::Label(label_id) = instr {
+            if function_labels.values().any(|&id| id == *label_id) {
+                if current_start < i {
+                    function_boundaries.push((current_start, i));
+                }
+                current_start = i;
+            }
+        }
+    }
+    if current_start < instructions.len() {
+        function_boundaries.push((current_start, instructions.len()));
+    }
+
+    // Phase 3: Lower each function separately with its own register allocator
+    let mut all_machine_instructions = Vec::new();
+    let mut label_id_counter = 0u32;
+    let mut ir_to_machine_labels = HashMap::new();
+
+    // First pass: scan for labels and assign machine instruction label IDs
+    for instr in &instructions {
+        if let Instruction::Label(label_id) = instr {
+            ir_to_machine_labels.entry(*label_id).or_insert_with(|| {
+                let id = label_id_counter;
+                label_id_counter += 1;
+                id
+            });
+        }
+    }
+
+    // Second pass: lower each function with its own allocator
+    for (start, end) in function_boundaries {
+        let function_instrs = &instructions[start..end];
+
+        // Create a fresh register allocator for this function
+        let mut function_allocator = RegisterAllocator::new();
+        let mut function_machine_instrs = Vec::new();
+        let next_label_id;
+
+        {
+            let mut lowering = Lowering::new(&mut function_allocator, label_id_counter);
+            lowering.set_function_labels(function_labels.clone());
+            lowering.set_label_map(ir_to_machine_labels.clone());
+
+            // Process all non-label instructions for this function
+            let mut function_instrs_without_labels = Vec::new();
+
+            for instr in function_instrs {
+                match instr {
+                    Instruction::Label(label_id) => {
+                        // First, lower any accumulated instructions
+                        if !function_instrs_without_labels.is_empty() {
+                            let machine_instrs = lowering
+                                .lower(&function_instrs_without_labels)
+                                .map_err(|e| CodegenError { message: e })?;
+                            function_machine_instrs.extend(machine_instrs);
+                            function_instrs_without_labels.clear();
+                        }
+
+                        // Then emit the label
+                        let machine_label_id = ir_to_machine_labels[label_id];
+                        function_machine_instrs.push(MachineInstr::Label {
+                            id: machine_label_id,
+                        });
+                    }
+                    _ => {
+                        function_instrs_without_labels.push(instr.clone());
+                    }
+                }
+            }
+
+            // Lower any remaining instructions
+            if !function_instrs_without_labels.is_empty() {
+                let machine_instrs = lowering
+                    .lower(&function_instrs_without_labels)
+                    .map_err(|e| CodegenError { message: e })?;
+                function_machine_instrs.extend(machine_instrs);
+            }
+
+            next_label_id = lowering.next_label_id();
+        }
+
+        // Patch stack allocation with actual required space
+        Lowering::patch_stack_allocation(&mut function_machine_instrs, &function_allocator);
+
+        // Add this function's instructions to the overall list
+        all_machine_instructions.extend(function_machine_instrs);
+
+        // Update the global label counter for the next function
+        label_id_counter = next_label_id;
+    }
+
+    // Phase 4: Combine runtime and user code
+    let mut final_instructions = Vec::new();
+
+    // Add runtime instructions first
+    final_instructions.extend(runtime_instructions);
+
+    // Adjust user code labels to account for runtime labels
+    let runtime_label_count = runtime_labels.values().max().copied().unwrap_or(0) + 1;
+
+    // Adjust all label IDs in user code
+    for instr in all_machine_instructions {
+        match instr {
+            MachineInstr::Label { id } => {
+                final_instructions.push(MachineInstr::Label {
+                    id: id + runtime_label_count,
+                });
+            }
+            MachineInstr::Jmp { target } => {
+                let adjusted_target = match target {
+                    LabelRef::Local(id) => LabelRef::Local(id + runtime_label_count),
+                    global => global,
+                };
+                final_instructions.push(MachineInstr::Jmp {
+                    target: adjusted_target,
+                });
+            }
+            MachineInstr::JmpCC { cc, target } => {
+                let adjusted_target = match target {
+                    LabelRef::Local(id) => LabelRef::Local(id + runtime_label_count),
+                    global => global,
+                };
+                final_instructions.push(MachineInstr::JmpCC {
+                    cc,
+                    target: adjusted_target,
+                });
+            }
+            other => final_instructions.push(other),
+        }
+    }
+
+    // Phase 5: Generate assembly text
+    let mut all_function_labels = HashMap::new();
+
+    // Add runtime labels
+    for (name, &id) in &runtime_labels {
+        all_function_labels.insert(name.clone(), crate::LabelId(id));
+    }
+
+    // Add user function labels (adjusted)
+    for (name, ir_label_id) in &function_labels {
+        if let Some(&machine_label_id) = ir_to_machine_labels.get(ir_label_id) {
+            all_function_labels.insert(
+                name.clone(),
+                crate::LabelId(machine_label_id + runtime_label_count),
+            );
+        }
+    }
+
+    // Convert machine instructions to assembly text
+    let asm_text = format_instructions_as_assembly(&final_instructions, &all_function_labels);
+    Ok(asm_text)
+}
+
+// Convert machine instructions to AT&T assembly syntax
+fn format_instructions_as_assembly(
+    instructions: &[MachineInstr],
+    function_labels: &HashMap<String, LabelId>,
+) -> String {
+    use rue_ir::target::ConditionCode;
+
+    let mut output = String::new();
+
+    // Assembly header
+    output.push_str(".section .text\n");
+    output.push_str(".global _start\n\n");
+
+    // Reverse map for labels
+    let mut label_names: HashMap<u32, String> = HashMap::new();
+    for (name, LabelId(id)) in function_labels {
+        label_names.insert(*id, name.clone());
+    }
+
+    for instr in instructions {
+        match instr {
+            MachineInstr::Label { id } => {
+                if let Some(name) = label_names.get(id) {
+                    output.push_str(&format!("{name}:\n"));
+                } else {
+                    output.push_str(&format!(".L{id}:\n"));
+                }
+            }
+            MachineInstr::MovRR { dest, src } => {
+                output.push_str(&format!(
+                    "    movq %{}, %{}\n",
+                    reg_name(src),
+                    reg_name(dest)
+                ));
+            }
+            MachineInstr::MovRI32 { dest, imm } => {
+                output.push_str(&format!("    movl ${}, %{}\n", imm, reg_name(dest)));
+            }
+            MachineInstr::MovRI64 { dest, imm } => {
+                output.push_str(&format!("    movabsq ${}, %{}\n", imm, reg_name(dest)));
+            }
+            MachineInstr::MovRM { dest, base, offset } => {
+                if *offset == 0 {
+                    output.push_str(&format!(
+                        "    movq (%{}), %{}\n",
+                        reg_name(base),
+                        reg_name(dest)
+                    ));
+                } else {
+                    output.push_str(&format!(
+                        "    movq {}(%{}), %{}\n",
+                        offset,
+                        reg_name(base),
+                        reg_name(dest)
+                    ));
+                }
+            }
+            MachineInstr::MovMR { base, offset, src } => {
+                if *offset == 0 {
+                    output.push_str(&format!(
+                        "    movq %{}, (%{})\n",
+                        reg_name(src),
+                        reg_name(base)
+                    ));
+                } else {
+                    output.push_str(&format!(
+                        "    movq %{}, {}(%{})\n",
+                        reg_name(src),
+                        offset,
+                        reg_name(base)
+                    ));
+                }
+            }
+            MachineInstr::MovMR8 { base, offset, src } => {
+                if *offset == 0 {
+                    output.push_str(&format!(
+                        "    movb %{}, (%{})\n",
+                        reg_name_8(src),
+                        reg_name(base)
+                    ));
+                } else {
+                    output.push_str(&format!(
+                        "    movb %{}, {}(%{})\n",
+                        reg_name_8(src),
+                        offset,
+                        reg_name(base)
+                    ));
+                }
+            }
+            MachineInstr::MovRM8 { dest, base, offset } => {
+                if *offset == 0 {
+                    output.push_str(&format!(
+                        "    movb (%{}), %{}\n",
+                        reg_name(base),
+                        reg_name_8(dest)
+                    ));
+                } else {
+                    output.push_str(&format!(
+                        "    movb {}(%{}), %{}\n",
+                        offset,
+                        reg_name(base),
+                        reg_name_8(dest)
+                    ));
+                }
+            }
+            MachineInstr::AddRR { dest, src } => {
+                output.push_str(&format!(
+                    "    addq %{}, %{}\n",
+                    reg_name(src),
+                    reg_name(dest)
+                ));
+            }
+            MachineInstr::AddRI { dest, imm } => {
+                output.push_str(&format!("    addq ${}, %{}\n", imm, reg_name(dest)));
+            }
+            MachineInstr::SubRR { dest, src } => {
+                output.push_str(&format!(
+                    "    subq %{}, %{}\n",
+                    reg_name(src),
+                    reg_name(dest)
+                ));
+            }
+            MachineInstr::SubRI { dest, imm } => {
+                output.push_str(&format!("    subq ${}, %{}\n", imm, reg_name(dest)));
+            }
+            MachineInstr::ImulRR { dest, src } => {
+                output.push_str(&format!(
+                    "    imulq %{}, %{}\n",
+                    reg_name(src),
+                    reg_name(dest)
+                ));
+            }
+            MachineInstr::ImulRI { dest, imm } => {
+                output.push_str(&format!("    imulq ${}, %{}\n", imm, reg_name(dest)));
+            }
+            MachineInstr::Idiv { divisor } => {
+                output.push_str(&format!("    idivq %{}\n", reg_name(divisor)));
+            }
+            MachineInstr::Cqo => {
+                output.push_str("    cqo\n");
+            }
+            MachineInstr::AndRR { dest, src } => {
+                output.push_str(&format!(
+                    "    andq %{}, %{}\n",
+                    reg_name(src),
+                    reg_name(dest)
+                ));
+            }
+            MachineInstr::Shl { dest, count: _ } => {
+                output.push_str(&format!("    shlq %cl, %{}\n", reg_name(dest)));
+            }
+            MachineInstr::Sar { dest, count: _ } => {
+                output.push_str(&format!("    sarq %cl, %{}\n", reg_name(dest)));
+            }
+            MachineInstr::CmpRR { left, right } => {
+                output.push_str(&format!(
+                    "    cmpq %{}, %{}\n",
+                    reg_name(right),
+                    reg_name(left)
+                ));
+            }
+            MachineInstr::CmpRI { reg, imm } => {
+                output.push_str(&format!("    cmpq ${}, %{}\n", imm, reg_name(reg)));
+            }
+            MachineInstr::SetCC { cc, dest } => {
+                let cc_str = match cc {
+                    ConditionCode::Equal => "sete",
+                    ConditionCode::NotEqual => "setne",
+                    ConditionCode::Less => "setl",
+                    ConditionCode::LessEqual => "setle",
+                    ConditionCode::Greater => "setg",
+                    ConditionCode::GreaterEqual => "setge",
+                };
+                output.push_str(&format!("    {} %{}\n", cc_str, reg_name_8(dest)));
+            }
+            MachineInstr::Movzx { dest, src } => {
+                output.push_str(&format!(
+                    "    movzbq %{}, %{}\n",
+                    reg_name_8(src),
+                    reg_name(dest)
+                ));
+            }
+            MachineInstr::Movsxd { dest, src } => {
+                output.push_str(&format!(
+                    "    movslq %{}, %{}\n",
+                    reg_name_32(src),
+                    reg_name(dest)
+                ));
+            }
+            MachineInstr::Push { reg } => {
+                output.push_str(&format!("    pushq %{}\n", reg_name(reg)));
+            }
+            MachineInstr::Pop { reg } => {
+                output.push_str(&format!("    popq %{}\n", reg_name(reg)));
+            }
+            MachineInstr::Call { target } => {
+                output.push_str(&format!("    call {target}\n"));
+            }
+            MachineInstr::Ret => {
+                output.push_str("    ret\n");
+            }
+            MachineInstr::Jmp { target } => match target {
+                LabelRef::Local(id) => {
+                    if let Some(name) = label_names.get(id) {
+                        output.push_str(&format!("    jmp {name}\n"));
+                    } else {
+                        output.push_str(&format!("    jmp .L{id}\n"));
+                    }
+                }
+                LabelRef::Global(name) => {
+                    output.push_str(&format!("    jmp {name}\n"));
+                }
+            },
+            MachineInstr::JmpCC { cc, target } => {
+                let cc_str = match cc {
+                    ConditionCode::Equal => "je",
+                    ConditionCode::NotEqual => "jne",
+                    ConditionCode::Less => "jl",
+                    ConditionCode::LessEqual => "jle",
+                    ConditionCode::Greater => "jg",
+                    ConditionCode::GreaterEqual => "jge",
+                };
+                match target {
+                    LabelRef::Local(id) => {
+                        if let Some(name) = label_names.get(id) {
+                            output.push_str(&format!("    {cc_str} {name}\n"));
+                        } else {
+                            output.push_str(&format!("    {cc_str} .L{id}\n"));
+                        }
+                    }
+                    LabelRef::Global(name) => {
+                        output.push_str(&format!("    {cc_str} {name}\n"));
+                    }
+                }
+            }
+            MachineInstr::Syscall => {
+                output.push_str("    syscall\n");
+            }
+            MachineInstr::AllocStack { size } => {
+                output.push_str(&format!("    subq ${size}, %rsp\n"));
+            }
+            MachineInstr::LeaLabel { dest, label } => {
+                output.push_str(&format!("    leaq {}(%rip), %{}\n", label, reg_name(dest)));
+            }
+            MachineInstr::Cld => {
+                output.push_str("    cld\n");
+            }
+            MachineInstr::RepStosb => {
+                output.push_str("    rep stosb\n");
+            }
+            MachineInstr::EnterFrame => {
+                output.push_str("    pushq %rbp\n");
+                output.push_str("    movq %rsp, %rbp\n");
+            }
+            MachineInstr::LeaveFrame => {
+                output.push_str("    movq %rbp, %rsp\n");
+                output.push_str("    popq %rbp\n");
+            }
+        }
+    }
+
+    output
+}
+
+// Helper functions for register names
+fn reg_name(reg: &Register) -> &'static str {
+    match reg {
+        Register::Rax => "rax",
+        Register::Rbx => "rbx",
+        Register::Rcx => "rcx",
+        Register::Rdx => "rdx",
+        Register::Rsi => "rsi",
+        Register::Rdi => "rdi",
+        Register::Rbp => "rbp",
+        Register::Rsp => "rsp",
+        Register::R8 => "r8",
+        Register::R9 => "r9",
+        Register::R10 => "r10",
+        Register::R11 => "r11",
+        Register::R12 => "r12",
+        Register::R13 => "r13",
+        Register::R14 => "r14",
+        Register::R15 => "r15",
+    }
+}
+
+fn reg_name_8(reg: &Register) -> &'static str {
+    match reg {
+        Register::Rax => "al",
+        Register::Rbx => "bl",
+        Register::Rcx => "cl",
+        Register::Rdx => "dl",
+        Register::Rsi => "sil",
+        Register::Rdi => "dil",
+        Register::Rbp => "bpl",
+        Register::Rsp => "spl",
+        Register::R8 => "r8b",
+        Register::R9 => "r9b",
+        Register::R10 => "r10b",
+        Register::R11 => "r11b",
+        Register::R12 => "r12b",
+        Register::R13 => "r13b",
+        Register::R14 => "r14b",
+        Register::R15 => "r15b",
+    }
+}
+
+fn reg_name_32(reg: &Register) -> &'static str {
+    match reg {
+        Register::Rax => "eax",
+        Register::Rbx => "ebx",
+        Register::Rcx => "ecx",
+        Register::Rdx => "edx",
+        Register::Rsi => "esi",
+        Register::Rdi => "edi",
+        Register::Rbp => "ebp",
+        Register::Rsp => "esp",
+        Register::R8 => "r8d",
+        Register::R9 => "r9d",
+        Register::R10 => "r10d",
+        Register::R11 => "r11d",
+        Register::R12 => "r12d",
+        Register::R13 => "r13d",
+        Register::R14 => "r14d",
+        Register::R15 => "r15d",
+    }
+}
+
 #[cfg(test)]
 mod test;

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -386,3 +386,34 @@ pub fn compile_file(
         Err(e) => Err(Arc::new(CompileError { message: e.message })),
     }
 }
+
+#[salsa::tracked]
+pub fn compile_file_to_assembly(
+    db: &dyn salsa::Database,
+    file: SourceFile,
+) -> Result<Arc<String>, Arc<CompileError>> {
+    // Parse and analyze the file first
+    let scope = match analyze_file(db, file) {
+        Ok(scope) => scope,
+        Err(semantic_error) => {
+            return Err(Arc::new(CompileError {
+                message: format!("Semantic error: {}", semantic_error.message),
+            }));
+        }
+    };
+
+    let ast = match parse_file(db, file) {
+        Ok(ast) => ast,
+        Err(parse_error) => {
+            return Err(Arc::new(CompileError {
+                message: format!("Parse error: {}", parse_error.message),
+            }));
+        }
+    };
+
+    // Generate assembly
+    match rue_codegen::compile_to_assembly(&ast, &scope) {
+        Ok(assembly) => Ok(Arc::new(assembly)),
+        Err(e) => Err(Arc::new(CompileError { message: e.message })),
+    }
+}

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1,5 +1,5 @@
 use bpaf::{Parser, construct};
-use rue_compiler::{RueDatabase, SourceFile, compile_file};
+use rue_compiler::{RueDatabase, SourceFile, compile_file, compile_file_to_assembly};
 use std::fs;
 use std::path::PathBuf;
 
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 struct Args {
     output: Option<PathBuf>,
     input: PathBuf,
+    emit_asm: bool,
 }
 
 fn parser() -> impl Parser<Args> {
@@ -16,9 +17,17 @@ fn parser() -> impl Parser<Args> {
         .argument::<PathBuf>("OUTPUT")
         .optional();
 
+    let emit_asm = bpaf::long("emit-asm")
+        .help("Emit assembly instead of executable")
+        .switch();
+
     let input = bpaf::positional::<PathBuf>("INPUT").help("Input Rue source file");
 
-    construct!(Args { output, input })
+    construct!(Args {
+        output,
+        input,
+        emit_asm
+    })
 }
 
 fn main() {
@@ -28,7 +37,12 @@ fn main() {
         .run();
 
     let input_path = opts.input;
-    let output_path = opts.output.unwrap_or_else(|| input_path.with_extension(""));
+    let output_path = if opts.emit_asm {
+        opts.output
+            .unwrap_or_else(|| input_path.with_extension("s"))
+    } else {
+        opts.output.unwrap_or_else(|| input_path.with_extension(""))
+    };
 
     // Read source file
     let source = match fs::read_to_string(&input_path) {
@@ -44,20 +58,15 @@ fn main() {
     let file = SourceFile::new(&db, input_path.to_string_lossy().to_string(), source);
 
     // Compile
-    match compile_file(&db, file) {
-        Ok(executable) => {
-            match fs::write(&output_path, &*executable) {
+    if opts.emit_asm {
+        // Generate assembly
+        match compile_file_to_assembly(&db, file) {
+            Ok(assembly) => match fs::write(&output_path, &*assembly) {
                 Ok(()) => {
-                    // Make executable on Unix systems
-                    #[cfg(unix)]
-                    {
-                        use std::os::unix::fs::PermissionsExt;
-                        let mut perms = fs::metadata(&output_path).unwrap().permissions();
-                        perms.set_mode(0o755);
-                        fs::set_permissions(&output_path, perms).unwrap();
-                    }
-
-                    println!("Successfully compiled to '{}'", output_path.display());
+                    println!(
+                        "Successfully generated assembly to '{}'",
+                        output_path.display()
+                    );
                 }
                 Err(e) => {
                     eprintln!(
@@ -67,11 +76,43 @@ fn main() {
                     );
                     std::process::exit(1);
                 }
+            },
+            Err(error) => {
+                eprintln!("Compilation failed: {}", error.message);
+                std::process::exit(1);
             }
         }
-        Err(error) => {
-            eprintln!("Compilation failed: {}", error.message);
-            std::process::exit(1);
+    } else {
+        // Generate executable
+        match compile_file(&db, file) {
+            Ok(executable) => {
+                match fs::write(&output_path, &*executable) {
+                    Ok(()) => {
+                        // Make executable on Unix systems
+                        #[cfg(unix)]
+                        {
+                            use std::os::unix::fs::PermissionsExt;
+                            let mut perms = fs::metadata(&output_path).unwrap().permissions();
+                            perms.set_mode(0o755);
+                            fs::set_permissions(&output_path, perms).unwrap();
+                        }
+
+                        println!("Successfully compiled to '{}'", output_path.display());
+                    }
+                    Err(e) => {
+                        eprintln!(
+                            "Error writing output file '{}': {}",
+                            output_path.display(),
+                            e
+                        );
+                        std::process::exit(1);
+                    }
+                }
+            }
+            Err(error) => {
+                eprintln!("Compilation failed: {}", error.message);
+                std::process::exit(1);
+            }
         }
     }
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -21,6 +21,7 @@
 - Type checking and inference for literals
 - Improved error messages with clear diagnostics
 - Boolean literals: `true` and `false` keywords
+- Assembly output: `--emit-asm` flag for debugging and inspection
 
 ## Near-Term Goals (v0.1.0)
 


### PR DESCRIPTION
This adds a new command-line flag that allows the compiler to emit x86-64 assembly text instead of an executable binary. This is useful for debugging the compiler itself and for educational purposes to see what code is being generated.

The flag works with both Cargo and Buck2 build systems and defaults to creating .s files when no output name is specified.

Fixes #55