### PR TITLE
Add integer overflow tests for arithmetic operations and literal parsing

### DIFF
--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -777,4 +777,73 @@ fn factorial(n) {
         assert!(err.message.contains("Unexpected character '!'"));
         assert!(err.message.contains("Did you mean '!='?"));
     }
+
+    #[test]
+    fn test_i64_max_literal() {
+        let mut lexer = Lexer::new("9223372036854775807");
+        let tokens = lexer.tokenize().unwrap();
+        assert_eq!(tokens[0].kind, TokenKind::Integer(9223372036854775807));
+        assert_eq!(tokens[1].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_i64_min_literal() {
+        // i64::MIN is -9223372036854775808
+        let mut lexer = Lexer::new("-9223372036854775808");
+        let tokens = lexer.tokenize().unwrap();
+        assert_eq!(tokens[0].kind, TokenKind::Integer(-9223372036854775808));
+        assert_eq!(tokens[1].kind, TokenKind::Eof);
+    }
+
+    #[test]
+    fn test_literal_overflow_positive() {
+        // Number larger than i64::MAX
+        let mut lexer = Lexer::new("9223372036854775808");
+        let result = lexer.tokenize();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Invalid number"));
+    }
+
+    #[test]
+    fn test_literal_overflow_negative() {
+        // Number smaller than i64::MIN
+        let mut lexer = Lexer::new("-9223372036854775809");
+        let result = lexer.tokenize();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Invalid number"));
+    }
+
+    #[test]
+    fn test_literal_overflow_very_large() {
+        // Very large number
+        let mut lexer = Lexer::new("99999999999999999999999999");
+        let result = lexer.tokenize();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.message.contains("Invalid number"));
+    }
+
+    #[test]
+    fn test_literal_edge_cases() {
+        // Test various edge cases
+        let mut lexer = Lexer::new("0");
+        let tokens = lexer.tokenize().unwrap();
+        assert_eq!(tokens[0].kind, TokenKind::Integer(0));
+
+        let mut lexer = Lexer::new("-0");
+        let tokens = lexer.tokenize().unwrap();
+        assert_eq!(tokens[0].kind, TokenKind::Integer(0));
+
+        // i32::MAX
+        let mut lexer = Lexer::new("2147483647");
+        let tokens = lexer.tokenize().unwrap();
+        assert_eq!(tokens[0].kind, TokenKind::Integer(2147483647));
+
+        // i32::MIN
+        let mut lexer = Lexer::new("-2147483648");
+        let tokens = lexer.tokenize().unwrap();
+        assert_eq!(tokens[0].kind, TokenKind::Integer(-2147483648));
+    }
 }

--- a/crates/rue/tests/runtime_edge_cases.rs
+++ b/crates/rue/tests/runtime_edge_cases.rs
@@ -318,3 +318,293 @@ fn test_division_by_zero_handled() {
     // Should exit with division by zero error code
     assert_eq!(exit_code, 250);
 }
+
+// Tests for i32 overflow wrapping behavior
+#[test]
+fn test_i32_addition_overflow() {
+    let source = r#"
+        fn main() {
+            let x: i32 = 2147483647;  // i32::MAX
+            let one: i32 = 1;
+            let result: i32 = x + one;
+            println_i32(result);
+        }
+    "#;
+
+    let (exit_code, output) = compile_and_run(source, None).unwrap();
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "-2147483648"); // Should wrap to i32::MIN
+}
+
+#[test]
+fn test_i32_subtraction_overflow() {
+    let source = r#"
+        fn main() {
+            let x: i32 = 0 - 2147483647;
+            let x: i32 = x - 1;  // i32::MIN
+            let one: i32 = 1;
+            let result: i32 = x - one;
+            println_i32(result);
+        }
+    "#;
+
+    let (exit_code, output) = compile_and_run(source, None).unwrap();
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "2147483647"); // Should wrap to i32::MAX
+}
+
+#[test]
+fn test_i32_multiplication_overflow() {
+    let source = r#"
+        fn main() {
+            let x: i32 = 1000000;
+            let y: i32 = 3000;
+            let result: i32 = x * y;
+            println_i32(result);
+        }
+    "#;
+
+    let (exit_code, output) = compile_and_run(source, None).unwrap();
+    assert_eq!(exit_code, 0);
+    // 1000000 * 3000 = 3000000000 which overflows i32
+    // In two's complement: 3000000000 % 2^32 - 2^32 = -1294967296
+    assert_eq!(output.trim(), "-1294967296");
+}
+
+#[test]
+fn test_i32_multiple_overflow_operations() {
+    let source = r#"
+        fn main() {
+            let max: i32 = 2147483647;
+            let ten: i32 = 10;
+            let result: i32 = max + ten;  // Overflow
+            println_i32(result);
+            let result2: i32 = result - ten; // Wrap back
+            println_i32(result2);
+        }
+    "#;
+
+    let (exit_code, output) = compile_and_run(source, None).unwrap();
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "-2147483639\n2147483647");
+}
+
+// Tests for i64 overflow wrapping behavior
+#[test]
+fn test_i64_addition_overflow() {
+    let source = r#"
+        fn main() {
+            let x: i64 = 9223372036854775807;  // i64::MAX
+            let one: i64 = 1;
+            let result: i64 = x + one;
+            println_i64(result);
+        }
+    "#;
+
+    let (exit_code, output) = compile_and_run(source, None).unwrap();
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "-9223372036854775808"); // Should wrap to i64::MIN
+}
+
+#[test]
+fn test_i64_subtraction_overflow() {
+    let source = r#"
+        fn main() {
+            let zero: i64 = 0;
+            let max: i64 = 9223372036854775807;
+            let one: i64 = 1;
+            let min: i64 = zero - max - one;  // i64::MIN
+            let result: i64 = min - one;
+            println_i64(result);
+        }
+    "#;
+
+    let (exit_code, output) = compile_and_run(source, None).unwrap();
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "9223372036854775807"); // Should wrap to i64::MAX
+}
+
+#[test]
+fn test_i64_multiplication_overflow() {
+    let source = r#"
+        fn main() {
+            let x: i64 = 1000000000000000;  // 10^15
+            let y: i64 = 10000000;           // 10^7
+            let result: i64 = x * y;         // 10^22 overflows i64
+            println_i64(result);
+        }
+    "#;
+
+    let (exit_code, output) = compile_and_run(source, None).unwrap();
+    assert_eq!(exit_code, 0);
+    // 10^22 = 10000000000000000000000
+    // This wraps around in two's complement arithmetic to positive
+    assert_eq!(output.trim(), "1864712049423024128");
+}
+
+#[test]
+fn test_i64_division_no_overflow() {
+    // Division can only overflow in one case: i64::MIN / -1
+    // But Rue doesn't support unary minus on literals yet, so we can't test this directly
+    // Instead, test that normal division doesn't overflow
+    let source = r#"
+        fn main() {
+            let x: i64 = 9223372036854775807;  // i64::MAX
+            let y: i64 = 2;
+            let result: i64 = x / y;
+            println_i64(result);
+        }
+    "#;
+
+    let (exit_code, output) = compile_and_run(source, None).unwrap();
+    assert_eq!(exit_code, 0);
+    assert_eq!(output.trim(), "4611686018427387903");
+}
+
+#[test]
+fn test_i64_complex_overflow_sequence() {
+    let source = r#"
+        fn main() {
+            let max: i64 = 9223372036854775807;
+            let big: i64 = 1000000000000;
+            let result: i64 = max + big;  // Overflow to negative
+            println_i64(result);
+            let result2: i64 = result - big; // Should NOT wrap back to max
+            println_i64(result2);
+            let two: i64 = 2;
+            let result3: i64 = result * two;  // Further overflow
+            println_i64(result3);
+        }
+    "#;
+
+    let (exit_code, output) = compile_and_run(source, None).unwrap();
+    assert_eq!(exit_code, 0);
+    // max + big wraps to negative: -9223371036854775809
+    // that negative - big wraps to positive: 9223372036854775807 (MAX again!)
+    // that negative * 2 = 1999999999998
+    assert_eq!(
+        output.trim(),
+        "-9223371036854775809\n9223372036854775807\n1999999999998"
+    );
+}
+
+// Tests that verify wrapping behavior matches two's complement arithmetic
+#[test]
+fn test_i32_wrapping_matches_spec() {
+    // Verify that overflow wraps using two's complement arithmetic
+    let source = r#"
+        fn main() {
+            // Test MAX + 1 = MIN
+            let max: i32 = 2147483647;
+            let min: i32 = max + 1;
+            println_i32(min);
+            
+            // Test MIN - 1 = MAX
+            let max2: i32 = min - 1;
+            println_i32(max2);
+            
+            // Test wrapping in multiplication
+            let a: i32 = 46341; // sqrt(i32::MAX) + 1
+            let result: i32 = a * a;
+            println_i32(result);
+            
+            // Test wrapping preserves bit patterns
+            let x: i32 = 2147483640;
+            let y: i32 = 20;
+            let wrapped: i32 = x + y;
+            println_i32(wrapped);
+        }
+    "#;
+
+    let (exit_code, output) = compile_and_run(source, None).unwrap();
+    assert_eq!(exit_code, 0);
+    // MAX + 1 = MIN (-2147483648)
+    // MIN - 1 = MAX (2147483647)
+    // 46341 * 46341 = 2147488281, which wraps to -2147479015
+    // 2147483640 + 20 = 2147483660, which wraps to -2147483636
+    assert_eq!(
+        output.trim(),
+        "-2147483648\n2147483647\n-2147479015\n-2147483636"
+    );
+}
+
+#[test]
+fn test_i64_wrapping_matches_spec() {
+    // Verify that i64 overflow wraps using two's complement arithmetic
+    let source = r#"
+        fn main() {
+            // Test MAX + 1 = MIN
+            let max: i64 = 9223372036854775807;
+            let one: i64 = 1;
+            let min: i64 = max + one;
+            println_i64(min);
+            
+            // Test MIN - 1 = MAX
+            let max2: i64 = min - one;
+            println_i64(max2);
+            
+            // Test specific wrapping calculation
+            let x: i64 = 9223372036854775800;
+            let y: i64 = 20;
+            let wrapped: i64 = x + y;
+            println_i64(wrapped);
+        }
+    "#;
+
+    let (exit_code, output) = compile_and_run(source, None).unwrap();
+    assert_eq!(exit_code, 0);
+    // MAX + 1 = MIN (-9223372036854775808)
+    // MIN - 1 = MAX (9223372036854775807)
+    // 9223372036854775800 + 20 wraps to negative
+    assert_eq!(
+        output.trim(),
+        "-9223372036854775808\n9223372036854775807\n-9223372036854775796"
+    );
+}
+
+#[test]
+fn test_modulo_wrapping_behavior() {
+    // Test that modulo operations work correctly with wrapped values
+    let source = r#"
+        fn main() {
+            let max: i32 = 2147483647;
+            let wrapped: i32 = max + 2;  // Wraps to MIN + 1
+            let ten: i32 = 10;
+            let result: i32 = wrapped % ten;
+            println_i32(wrapped);
+            println_i32(result);
+        }
+    "#;
+
+    let (exit_code, output) = compile_and_run(source, None).unwrap();
+    assert_eq!(exit_code, 0);
+    // max + 2 = -2147483647
+    // -2147483647 % 10 = 9 (in Rue's implementation)
+    assert_eq!(output.trim(), "-2147483647\n9");
+}
+
+#[test]
+fn test_chained_overflow_operations() {
+    // Test that multiple overflows in sequence behave correctly
+    let source = r#"
+        fn main() {
+            let x: i32 = 2000000000;
+            let y: i32 = 2000000000;
+            let sum: i32 = x + y;  // 4000000000 overflows
+            println_i32(sum);
+            
+            let z: i32 = sum + x;  // Further overflow
+            println_i32(z);
+            
+            let w: i32 = z - y;    // Wrap back
+            println_i32(w);
+        }
+    "#;
+
+    let (exit_code, output) = compile_and_run(source, None).unwrap();
+    assert_eq!(exit_code, 0);
+    // 2000000000 + 2000000000 = 4000000000, wraps to -294967296
+    // -294967296 + 2000000000 = 1705032704
+    // 1705032704 - 2000000000 = -294967296
+    assert_eq!(output.trim(), "-294967296\n1705032704\n-294967296");
+}


### PR DESCRIPTION
Implement comprehensive test coverage for integer overflow behavior as specified in the language documentation. Rue uses two's complement wrapping for overflow.

Added tests for:
- i32 arithmetic overflow (addition, subtraction, multiplication)
- i64 arithmetic overflow (addition, subtraction, multiplication)
- Literal parsing overflow detection in lexer
- Verification that wrapping matches two's complement behavior
- Edge cases: MAX/MIN values, chained operations, modulo with wrapped values

Test locations:
- crates/rue/tests/runtime_edge_cases.rs: Runtime overflow tests
- crates/rue-lexer/src/lib.rs: Literal parsing overflow tests