### PR TITLE
Add unary negation operator support

### DIFF
--- a/crates/rue-ast/src/lib.rs
+++ b/crates/rue-ast/src/lib.rs
@@ -140,6 +140,7 @@ pub struct WhileStatementNode {
 #[derive(Debug, Clone, PartialEq)]
 pub enum ExpressionNode {
     Binary(BinaryExprNode),
+    Unary(UnaryExprNode),
     Call(CallExprNode),
     If(Box<IfStatementNode>),
     While(Box<WhileStatementNode>),
@@ -152,6 +153,13 @@ pub struct BinaryExprNode {
     pub left: Box<ExpressionNode>,
     pub operator: TokenNode,
     pub right: Box<ExpressionNode>,
+    pub trivia: Trivia,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct UnaryExprNode {
+    pub operator: TokenNode,
+    pub operand: Box<ExpressionNode>,
     pub trivia: Trivia,
 }
 

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -392,6 +392,7 @@ impl Codegen {
                 self.expression_contains_call(&while_expr.condition)
                     || self.block_contains_call(&while_expr.body)
             }
+            ExpressionNode::Unary(unary_expr) => self.expression_contains_call(&unary_expr.operand),
             ExpressionNode::Literal(_) | ExpressionNode::Identifier(_) => false,
         }
     }
@@ -776,6 +777,32 @@ impl Codegen {
                 });
 
                 Ok(zero_vreg)
+            }
+            ExpressionNode::Unary(unary_expr) => {
+                let operand_vreg = self.generate_expression(&unary_expr.operand, _scope)?;
+                let dest = self.next_vreg();
+
+                match &unary_expr.operator.kind {
+                    rue_lexer::TokenKind::Minus => {
+                        // Generate negation as 0 - operand
+                        self.emit(Instruction::BinaryOp {
+                            dest,
+                            op: BinOp::Sub,
+                            lhs: Value::Immediate(0),
+                            rhs: Value::VReg(operand_vreg),
+                        });
+                    }
+                    _ => {
+                        return Err(CodegenError {
+                            message: format!(
+                                "Unknown unary operator: {:?}",
+                                unary_expr.operator.kind
+                            ),
+                        });
+                    }
+                }
+
+                Ok(dest)
             }
         }
     }

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -417,7 +417,7 @@ impl Parser {
     }
 
     fn parse_multiplication(&mut self) -> ParseResult<ExpressionNode> {
-        let mut expr = self.parse_call()?;
+        let mut expr = self.parse_unary()?;
 
         while self.check_kind(&TokenKind::Star)
             || self.check_kind(&TokenKind::Slash)
@@ -425,7 +425,7 @@ impl Parser {
         {
             let leading_trivia = self.consume_trivia();
             let operator = self.advance();
-            let right = self.parse_call()?;
+            let right = self.parse_unary()?;
             expr = ExpressionNode::Binary(BinaryExprNode {
                 left: Box::new(expr),
                 operator,
@@ -438,6 +438,24 @@ impl Parser {
         }
 
         Ok(expr)
+    }
+
+    fn parse_unary(&mut self) -> ParseResult<ExpressionNode> {
+        if self.check_kind(&TokenKind::Minus) {
+            let leading_trivia = self.consume_trivia();
+            let operator = self.advance();
+            let operand = self.parse_unary()?;
+            Ok(ExpressionNode::Unary(UnaryExprNode {
+                operator,
+                operand: Box::new(operand),
+                trivia: Trivia {
+                    leading: leading_trivia,
+                    trailing: self.consume_trivia(),
+                },
+            }))
+        } else {
+            self.parse_call()
+        }
     }
 
     fn parse_call(&mut self) -> ParseResult<ExpressionNode> {
@@ -1448,10 +1466,6 @@ if true {
         assert!(result.is_ok());
 
         // Test complex mixed nesting
-        // TODO: This test currently fails with "Unexpected token: Minus"
-        // The parser has trouble distinguishing between negative numbers and
-        // subtraction in certain contexts like "-factorial(-x)"
-        /*
         let complex = r#"
 fn complex(x: i32) -> i32 {
     if x > 0 {
@@ -1466,10 +1480,9 @@ fn complex(x: i32) -> i32 {
 }"#;
         let result = lex_and_parse(complex);
         if let Err(e) = &result {
-            eprintln!("Error parsing complex mixed nesting: {:?}", e);
+            eprintln!("Error parsing complex mixed nesting: {e:?}");
         }
         assert!(result.is_ok());
-        */
     }
 
     #[test]

--- a/crates/rue-semantic/src/lib.rs
+++ b/crates/rue-semantic/src/lib.rs
@@ -583,6 +583,29 @@ fn analyze_expression(scope: &mut Scope, expr: &ExpressionNode) -> Result<RueTyp
             // While expressions always return unit
             Ok(RueType::Unit)
         }
+        ExpressionNode::Unary(unary_expr) => {
+            // Analyze operand
+            let operand_type = analyze_expression(scope, &unary_expr.operand)?;
+
+            // Check operator type
+            match &unary_expr.operator.kind {
+                rue_lexer::TokenKind::Minus => {
+                    // Unary minus only works on numeric types
+                    if operand_type == RueType::I32 || operand_type == RueType::I64 {
+                        Ok(operand_type)
+                    } else {
+                        Err(SemanticError {
+                            message: format!("Cannot negate type {operand_type}"),
+                            span: unary_expr.operator.span,
+                        })
+                    }
+                }
+                _ => Err(SemanticError {
+                    message: format!("Unknown unary operator: {:?}", unary_expr.operator.kind),
+                    span: unary_expr.operator.span,
+                }),
+            }
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #60 - Parser now properly handles expressions like -factorial(-x)

- Add parse_unary() function to parser between multiplication and call precedence
- Add UnaryExprNode to AST with Unary variant in ExpressionNode
- Update semantic analyzer to validate unary minus only on numeric types
- Implement codegen for unary negation as 0 - operand
- Enable previously failing test for complex nested expressions with negation

The parser can now distinguish between unary minus (negation) and binary minus (subtraction) based on parsing context.