### PR TITLE
Handle comments in parser when lexer supports them

### DIFF
--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -64,6 +64,7 @@ pub enum TokenKind {
     Comma,
 
     // Special
+    Comment(String),
     Eof,
 }
 
@@ -154,7 +155,10 @@ impl<'a> Lexer<'a> {
         let mut tokens = Vec::new();
 
         while !self.is_at_end() {
-            self.skip_whitespace()?;
+            // Handle whitespace and collect any comment tokens
+            let comment_tokens = self.skip_whitespace_and_collect_comments()?;
+            tokens.extend(comment_tokens);
+
             if !self.is_at_end() {
                 tokens.push(self.next_token()?);
             }
@@ -364,35 +368,52 @@ impl<'a> Lexer<'a> {
         })
     }
 
-    fn skip_whitespace(&mut self) -> LexResult<()> {
+    fn skip_whitespace_and_collect_comments(&mut self) -> LexResult<Vec<Token>> {
+        let mut comment_tokens = Vec::new();
+
         loop {
             if self.current_char().is_whitespace() {
                 self.advance();
             } else if self.current_char() == '/' && self.peek_char() == '/' {
-                self.skip_single_line_comment();
+                let token = self.lex_single_line_comment()?;
+                comment_tokens.push(token);
             } else if self.current_char() == '/' && self.peek_char() == '*' {
-                self.skip_multi_line_comment()?;
+                let token = self.lex_multi_line_comment()?;
+                comment_tokens.push(token);
             } else {
                 break;
             }
         }
-        Ok(())
+        Ok(comment_tokens)
     }
 
-    fn skip_single_line_comment(&mut self) {
+    fn lex_single_line_comment(&mut self) -> LexResult<Token> {
+        let start = self.position;
         self.advance(); // Skip first '/'
         self.advance(); // Skip second '/'
 
+        let content_start = self.position;
         while !self.is_at_end() && self.current_char() != '\n' {
             self.advance();
         }
+
+        let comment_content = self.input[content_start..self.position].to_string();
+
+        Ok(Token {
+            kind: TokenKind::Comment(comment_content),
+            span: Span {
+                start,
+                end: self.position,
+            },
+        })
     }
 
-    fn skip_multi_line_comment(&mut self) -> LexResult<()> {
+    fn lex_multi_line_comment(&mut self) -> LexResult<Token> {
         let start = self.position;
         self.advance(); // Skip '/'
         self.advance(); // Skip '*'
 
+        let content_start = self.position;
         let mut depth = 1;
 
         while !self.is_at_end() && depth > 0 {
@@ -415,7 +436,18 @@ impl<'a> Lexer<'a> {
                 position: start,
             });
         }
-        Ok(())
+
+        // Extract comment content, excluding the outer /* */
+        let content_end = self.position - 2; // before the closing */
+        let comment_content = self.input[content_start..content_end].to_string();
+
+        Ok(Token {
+            kind: TokenKind::Comment(comment_content),
+            span: Span {
+                start,
+                end: self.position,
+            },
+        })
     }
 
     fn peek_char(&self) -> char {
@@ -552,8 +584,12 @@ fn factorial(n) {
         let mut lexer = Lexer::new("// This is a comment\n42");
         let tokens = lexer.tokenize().unwrap();
 
-        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Eof);
+        assert_eq!(
+            tokens[0].kind,
+            TokenKind::Comment(" This is a comment".to_string())
+        );
+        assert_eq!(tokens[1].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[2].kind, TokenKind::Eof);
     }
 
     #[test]
@@ -562,7 +598,11 @@ fn factorial(n) {
         let tokens = lexer.tokenize().unwrap();
 
         assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Eof);
+        assert_eq!(
+            tokens[1].kind,
+            TokenKind::Comment(" Comment at EOF".to_string())
+        );
+        assert_eq!(tokens[2].kind, TokenKind::Eof);
     }
 
     #[test]
@@ -570,10 +610,12 @@ fn factorial(n) {
         let mut lexer = Lexer::new("// Comment 1\n42\n// Comment 2\n+ 3");
         let tokens = lexer.tokenize().unwrap();
 
-        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Plus);
-        assert_eq!(tokens[2].kind, TokenKind::Integer(3));
-        assert_eq!(tokens[3].kind, TokenKind::Eof);
+        assert_eq!(tokens[0].kind, TokenKind::Comment(" Comment 1".to_string()));
+        assert_eq!(tokens[1].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[2].kind, TokenKind::Comment(" Comment 2".to_string()));
+        assert_eq!(tokens[3].kind, TokenKind::Plus);
+        assert_eq!(tokens[4].kind, TokenKind::Integer(3));
+        assert_eq!(tokens[5].kind, TokenKind::Eof);
     }
 
     #[test]
@@ -581,8 +623,9 @@ fn factorial(n) {
         let mut lexer = Lexer::new("//\n42");
         let tokens = lexer.tokenize().unwrap();
 
-        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Eof);
+        assert_eq!(tokens[0].kind, TokenKind::Comment("".to_string()));
+        assert_eq!(tokens[1].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[2].kind, TokenKind::Eof);
     }
 
     #[test]
@@ -590,8 +633,9 @@ fn factorial(n) {
         let mut lexer = Lexer::new("/* comment */ 42");
         let tokens = lexer.tokenize().unwrap();
 
-        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Eof);
+        assert_eq!(tokens[0].kind, TokenKind::Comment(" comment ".to_string()));
+        assert_eq!(tokens[1].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[2].kind, TokenKind::Eof);
     }
 
     #[test]
@@ -600,9 +644,13 @@ fn factorial(n) {
         let tokens = lexer.tokenize().unwrap();
 
         assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Plus);
-        assert_eq!(tokens[2].kind, TokenKind::Integer(3));
-        assert_eq!(tokens[3].kind, TokenKind::Eof);
+        assert_eq!(
+            tokens[1].kind,
+            TokenKind::Comment(" comment\nspanning\nmultiple lines ".to_string())
+        );
+        assert_eq!(tokens[2].kind, TokenKind::Plus);
+        assert_eq!(tokens[3].kind, TokenKind::Integer(3));
+        assert_eq!(tokens[4].kind, TokenKind::Eof);
     }
 
     #[test]
@@ -610,8 +658,9 @@ fn factorial(n) {
         let mut lexer = Lexer::new("/**/ 42");
         let tokens = lexer.tokenize().unwrap();
 
-        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Eof);
+        assert_eq!(tokens[0].kind, TokenKind::Comment("".to_string()));
+        assert_eq!(tokens[1].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[2].kind, TokenKind::Eof);
     }
 
     #[test]
@@ -619,8 +668,12 @@ fn factorial(n) {
         let mut lexer = Lexer::new("/* outer /* inner */ still comment */ 42");
         let tokens = lexer.tokenize().unwrap();
 
-        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Eof);
+        assert_eq!(
+            tokens[0].kind,
+            TokenKind::Comment(" outer /* inner */ still comment ".to_string())
+        );
+        assert_eq!(tokens[1].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[2].kind, TokenKind::Eof);
     }
 
     #[test]
@@ -628,8 +681,12 @@ fn factorial(n) {
         let mut lexer = Lexer::new("/* a /* b /* c */ b */ a */ 42");
         let tokens = lexer.tokenize().unwrap();
 
-        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Eof);
+        assert_eq!(
+            tokens[0].kind,
+            TokenKind::Comment(" a /* b /* c */ b */ a ".to_string())
+        );
+        assert_eq!(tokens[1].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[2].kind, TokenKind::Eof);
     }
 
     #[test]
@@ -655,8 +712,11 @@ fn factorial(n) {
         let mut lexer = Lexer::new("// single\n/* multi */ 42 // end");
         let tokens = lexer.tokenize().unwrap();
 
-        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Eof);
+        assert_eq!(tokens[0].kind, TokenKind::Comment(" single".to_string()));
+        assert_eq!(tokens[1].kind, TokenKind::Comment(" multi ".to_string()));
+        assert_eq!(tokens[2].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[3].kind, TokenKind::Comment(" end".to_string()));
+        assert_eq!(tokens[4].kind, TokenKind::Eof);
     }
 
     #[test]
@@ -665,9 +725,11 @@ fn factorial(n) {
         let tokens = lexer.tokenize().unwrap();
 
         assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Plus);
-        assert_eq!(tokens[2].kind, TokenKind::Integer(3));
-        assert_eq!(tokens[3].kind, TokenKind::Eof);
+        assert_eq!(tokens[1].kind, TokenKind::Comment(" comment ".to_string()));
+        assert_eq!(tokens[2].kind, TokenKind::Plus);
+        assert_eq!(tokens[3].kind, TokenKind::Comment(" another ".to_string()));
+        assert_eq!(tokens[4].kind, TokenKind::Integer(3));
+        assert_eq!(tokens[5].kind, TokenKind::Eof);
     }
 
     #[test]
@@ -675,8 +737,12 @@ fn factorial(n) {
         let mut lexer = Lexer::new("/* // this is still a comment */ 42");
         let tokens = lexer.tokenize().unwrap();
 
-        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Eof);
+        assert_eq!(
+            tokens[0].kind,
+            TokenKind::Comment(" // this is still a comment ".to_string())
+        );
+        assert_eq!(tokens[1].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[2].kind, TokenKind::Eof);
     }
 
     #[test]
@@ -684,8 +750,12 @@ fn factorial(n) {
         let mut lexer = Lexer::new("// /* */ still a comment\n42");
         let tokens = lexer.tokenize().unwrap();
 
-        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Eof);
+        assert_eq!(
+            tokens[0].kind,
+            TokenKind::Comment(" /* */ still a comment".to_string())
+        );
+        assert_eq!(tokens[1].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[2].kind, TokenKind::Eof);
     }
 
     #[test]
@@ -870,40 +940,61 @@ fn factorial(n) {
         // Test Japanese characters
         let mut lexer = Lexer::new("// こんにちは世界\n42;");
         let tokens = lexer.tokenize().unwrap();
-        assert_eq!(tokens.len(), 3); // 42, ;, EOF
-        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Semicolon);
-        assert_eq!(tokens[2].kind, TokenKind::Eof);
+        assert_eq!(tokens.len(), 4); // comment, 42, ;, EOF
+        assert_eq!(
+            tokens[0].kind,
+            TokenKind::Comment(" こんにちは世界".to_string())
+        );
+        assert_eq!(tokens[1].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[2].kind, TokenKind::Semicolon);
+        assert_eq!(tokens[3].kind, TokenKind::Eof);
 
         // Test Chinese characters
         let mut lexer = Lexer::new("// 你好世界\n100;");
         let tokens = lexer.tokenize().unwrap();
-        assert_eq!(tokens.len(), 3);
-        assert_eq!(tokens[0].kind, TokenKind::Integer(100));
+        assert_eq!(tokens.len(), 4);
+        assert_eq!(tokens[0].kind, TokenKind::Comment(" 你好世界".to_string()));
+        assert_eq!(tokens[1].kind, TokenKind::Integer(100));
 
         // Test Arabic characters
         let mut lexer = Lexer::new("// مرحبا بالعالم\n200;");
         let tokens = lexer.tokenize().unwrap();
-        assert_eq!(tokens.len(), 3);
-        assert_eq!(tokens[0].kind, TokenKind::Integer(200));
+        assert_eq!(tokens.len(), 4);
+        assert_eq!(
+            tokens[0].kind,
+            TokenKind::Comment(" مرحبا بالعالم".to_string())
+        );
+        assert_eq!(tokens[1].kind, TokenKind::Integer(200));
 
         // Test emojis
         let mut lexer = Lexer::new("// 🚀🎉🎊🎈🎁🎂\n300;");
         let tokens = lexer.tokenize().unwrap();
-        assert_eq!(tokens.len(), 3);
-        assert_eq!(tokens[0].kind, TokenKind::Integer(300));
+        assert_eq!(tokens.len(), 4);
+        assert_eq!(
+            tokens[0].kind,
+            TokenKind::Comment(" 🚀🎉🎊🎈🎁🎂".to_string())
+        );
+        assert_eq!(tokens[1].kind, TokenKind::Integer(300));
 
         // Test box drawing characters
         let mut lexer = Lexer::new("// ┌─────────┐\n400;");
         let tokens = lexer.tokenize().unwrap();
-        assert_eq!(tokens.len(), 3);
-        assert_eq!(tokens[0].kind, TokenKind::Integer(400));
+        assert_eq!(tokens.len(), 4);
+        assert_eq!(
+            tokens[0].kind,
+            TokenKind::Comment(" ┌─────────┐".to_string())
+        );
+        assert_eq!(tokens[1].kind, TokenKind::Integer(400));
 
         // Test accented characters
         let mut lexer = Lexer::new("// café, naïve, résumé\n500;");
         let tokens = lexer.tokenize().unwrap();
-        assert_eq!(tokens.len(), 3);
-        assert_eq!(tokens[0].kind, TokenKind::Integer(500));
+        assert_eq!(tokens.len(), 4);
+        assert_eq!(
+            tokens[0].kind,
+            TokenKind::Comment(" café, naïve, résumé".to_string())
+        );
+        assert_eq!(tokens[1].kind, TokenKind::Integer(500));
     }
 
     #[test]
@@ -919,17 +1010,19 @@ fn factorial(n) {
 
         let mut lexer = Lexer::new(input);
         let tokens = lexer.tokenize().unwrap();
-        assert_eq!(tokens.len(), 3); // 42, ;, EOF
-        assert_eq!(tokens[0].kind, TokenKind::Integer(42));
-        assert_eq!(tokens[1].kind, TokenKind::Semicolon);
-        assert_eq!(tokens[2].kind, TokenKind::Eof);
+        assert_eq!(tokens.len(), 4); // comment, 42, ;, EOF
+        assert!(matches!(tokens[0].kind, TokenKind::Comment(_)));
+        assert_eq!(tokens[1].kind, TokenKind::Integer(42));
+        assert_eq!(tokens[2].kind, TokenKind::Semicolon);
+        assert_eq!(tokens[3].kind, TokenKind::Eof);
 
         // Test nested comments with unicode
         let input2 = r#"/* outer /* inner with unicode: 你好 */ back to outer */ 100;"#;
         let mut lexer = Lexer::new(input2);
         let tokens = lexer.tokenize().unwrap();
-        assert_eq!(tokens.len(), 3);
-        assert_eq!(tokens[0].kind, TokenKind::Integer(100));
+        assert_eq!(tokens.len(), 4);
+        assert!(matches!(tokens[0].kind, TokenKind::Comment(_)));
+        assert_eq!(tokens[1].kind, TokenKind::Integer(100));
     }
 
     #[test]
@@ -946,13 +1039,19 @@ fn factorial(n) {
         let tokens = lexer.tokenize().unwrap();
 
         // Verify we get the expected tokens (ignoring comments)
-        let non_eof_tokens: Vec<_> = tokens.iter().filter(|t| t.kind != TokenKind::Eof).collect();
+        let non_comment_non_eof_tokens: Vec<_> = tokens
+            .iter()
+            .filter(|t| !matches!(t.kind, TokenKind::Eof | TokenKind::Comment(_)))
+            .collect();
 
-        assert_eq!(non_eof_tokens.len(), 19); // let x = 10 ; let y = 20 ; let z = x + y ; z ;
+        assert_eq!(non_comment_non_eof_tokens.len(), 19); // let x = 10 ; let y = 20 ; let z = x + y ; z ;
 
         // Check a few key tokens
-        assert_eq!(non_eof_tokens[0].kind, TokenKind::Let);
-        assert_eq!(non_eof_tokens[1].kind, TokenKind::Ident("x".to_string()));
-        assert_eq!(non_eof_tokens[3].kind, TokenKind::Integer(10));
+        assert_eq!(non_comment_non_eof_tokens[0].kind, TokenKind::Let);
+        assert_eq!(
+            non_comment_non_eof_tokens[1].kind,
+            TokenKind::Ident("x".to_string())
+        );
+        assert_eq!(non_comment_non_eof_tokens[3].kind, TokenKind::Integer(10));
     }
 }

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -110,6 +110,8 @@ impl Parser {
             }
         }
 
+        // Skip comments before close paren
+        self.skip_comments();
         let close_paren = self.expect_kind(&TokenKind::RightParen)?;
 
         Ok(ParamListNode {
@@ -152,6 +154,14 @@ impl Parser {
         let mut final_expr = None;
 
         while !self.check_kind(&TokenKind::RightBrace) && !self.is_at_end() {
+            // Skip any comments before checking what's next
+            self.skip_comments();
+
+            // Check again after skipping comments
+            if self.check_kind(&TokenKind::RightBrace) {
+                break;
+            }
+
             // Try to parse as statement first
             if self.is_statement_start() {
                 statements.push(self.parse_statement()?);
@@ -178,6 +188,8 @@ impl Parser {
             }
         }
 
+        // Skip comments before expecting closing brace
+        self.skip_comments();
         let close_brace = self.expect_kind(&TokenKind::RightBrace)?;
 
         Ok(BlockNode {
@@ -476,6 +488,8 @@ impl Parser {
                 }
             }
 
+            // Skip comments before close paren
+            self.skip_comments();
             let close_paren = self.expect_kind(&TokenKind::RightParen)?;
 
             expr = ExpressionNode::Call(CallExprNode {
@@ -521,6 +535,7 @@ impl Parser {
                     // Parenthesized expression
                     self.advance(); // consume '('
                     let expr = self.parse_expression()?;
+                    self.skip_comments(); // Skip comments before close paren
                     self.expect_kind(&TokenKind::RightParen)?;
                     Ok(expr)
                 }
@@ -584,9 +599,20 @@ impl Parser {
     }
 
     fn consume_trivia(&mut self) -> Vec<TokenNode> {
-        // Note: lexer already skips whitespace, so no trivia to consume for now
-        // TODO: Handle comments when lexer supports them
-        Vec::new()
+        let mut trivia = Vec::new();
+
+        // Consume any comment tokens
+        while self.check_kind(&TokenKind::Comment(String::new())) {
+            trivia.push(self.advance());
+        }
+
+        trivia
+    }
+
+    fn skip_comments(&mut self) {
+        while self.check_kind(&TokenKind::Comment(String::new())) {
+            self.advance();
+        }
     }
 
     fn parse_type(&mut self) -> ParseResult<TypeNode> {
@@ -597,6 +623,7 @@ impl Parser {
             TokenKind::LeftParen => {
                 // Unit type: ()
                 self.advance(); // consume '('
+                self.skip_comments(); // Skip comments before close paren
                 self.expect_kind(&TokenKind::RightParen)?;
                 Ok(TypeNode::Unit)
             }
@@ -1514,6 +1541,41 @@ fn complex(x: i32) -> i32 {
         // Test identifiers with keyword prefixes/suffixes
         let result = lex_and_parse("let function = 1; let my_fn = 2; let if_condition = 3;");
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_comment_preservation() {
+        // Test that comments are preserved in the CST
+        let result = lex_and_parse("// This is a comment\nlet x = 42;");
+        assert!(result.is_ok());
+        let cst = result.unwrap();
+        assert_eq!(cst.items.len(), 1);
+
+        // The comment should be in the root's leading trivia
+        assert!(!cst.trivia.leading.is_empty());
+        assert_eq!(cst.trivia.leading.len(), 1);
+        match &cst.trivia.leading[0].kind {
+            TokenKind::Comment(text) => {
+                assert_eq!(text, " This is a comment");
+            }
+            _ => panic!("Expected a comment token"),
+        }
+
+        // Test multi-line comment preservation
+        let result2 = lex_and_parse("/* This is a\nmulti-line comment */\nlet x = 42;");
+        assert!(result2.is_ok());
+        let cst2 = result2.unwrap();
+        assert_eq!(cst2.items.len(), 1);
+
+        // The multi-line comment should be in the root's leading trivia
+        assert!(!cst2.trivia.leading.is_empty());
+        assert_eq!(cst2.trivia.leading.len(), 1);
+        match &cst2.trivia.leading[0].kind {
+            TokenKind::Comment(text) => {
+                assert_eq!(text, " This is a\nmulti-line comment ");
+            }
+            _ => panic!("Expected a comment token"),
+        }
     }
 
     #[test]


### PR DESCRIPTION
This change addresses the TODO in rue-parser/src/lib.rs by implementing proper comment handling now that the lexer supports comment tokens.

Changes:
- Add Comment(String) variant to TokenKind enum in the lexer
- Modify lexer to emit comment tokens instead of skipping them
- Update parser's consume_trivia() to collect comment tokens
- Add skip_comments() method to parser for skipping comments in appropriate places
- Update parse_block() and other parsing methods to skip comments where needed
- Add tests for comment preservation in both lexer and parser
- Update all existing lexer tests to expect comment tokens

The lexer now preserves both single-line (//) and multi-line (/* */) comments as tokens, allowing the parser to attach them as trivia to AST nodes. This enables future features like documentation generation or code formatting that preserve comments.

Fixes #62