### PR TITLE
Fix block-level scoping to match language specification

### DIFF
--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -132,13 +132,64 @@ pub enum Instruction {
     LeaveFrame,
 }
 
+/// Stack-based variable scope management for code generation
+#[derive(Debug, Clone)]
+struct VarScopeStack {
+    scopes: Vec<HashMap<String, VReg>>,
+}
+
+impl VarScopeStack {
+    /// Create a new scope stack with an initial empty scope
+    fn new() -> Self {
+        Self {
+            scopes: vec![HashMap::new()],
+        }
+    }
+
+    /// Push a new scope onto the stack
+    fn push_scope(&mut self) {
+        self.scopes.push(HashMap::new());
+    }
+
+    /// Pop the innermost scope from the stack
+    fn pop_scope(&mut self) {
+        if self.scopes.len() > 1 {
+            self.scopes.pop();
+        }
+    }
+
+    /// Declare a variable in the current (innermost) scope
+    fn declare_variable(&mut self, name: String, vreg: VReg) {
+        if let Some(current_scope) = self.scopes.last_mut() {
+            current_scope.insert(name, vreg);
+        }
+    }
+
+    /// Look up a variable, searching from innermost to outermost scope
+    fn lookup_variable(&self, name: &str) -> Option<&VReg> {
+        // Search from innermost (last) to outermost (first) scope
+        for scope in self.scopes.iter().rev() {
+            if let Some(vreg) = scope.get(name) {
+                return Some(vreg);
+            }
+        }
+        None
+    }
+
+    /// Clear all scopes (used when starting a new function)
+    fn clear(&mut self) {
+        self.scopes.clear();
+        self.scopes.push(HashMap::new());
+    }
+}
+
 // Code generator state
 pub struct Codegen {
     instructions: Vec<Instruction>,
     vreg_counter: u32,
     label_counter: u32,
     stack_offset: i64,
-    variables: HashMap<String, VReg>, // Variable -> virtual register
+    variables: VarScopeStack, // Hierarchical variable -> virtual register mapping
     function_labels: HashMap<String, LabelId>, // Function name -> label ID
 }
 
@@ -149,7 +200,7 @@ impl Codegen {
             vreg_counter: 0,
             label_counter: 0,
             stack_offset: 0,
-            variables: HashMap::new(),
+            variables: VarScopeStack::new(),
             function_labels: HashMap::new(),
         }
     }
@@ -281,7 +332,8 @@ impl Codegen {
             if let rue_lexer::TokenKind::Ident(param_name) = &param.name.kind {
                 // Assign parameter to a new VReg
                 let param_vreg = self.next_vreg();
-                self.variables.insert(param_name.clone(), param_vreg);
+                self.variables
+                    .declare_variable(param_name.clone(), param_vreg);
 
                 // Move parameter from register to parameter VReg
                 self.emit(Instruction::Copy {
@@ -332,7 +384,8 @@ impl Codegen {
 
                 // Store in variable mapping
                 if let rue_lexer::TokenKind::Ident(var_name) = &let_stmt.name.kind {
-                    self.variables.insert(var_name.clone(), value_vreg);
+                    self.variables
+                        .declare_variable(var_name.clone(), value_vreg);
                 } else {
                     return Err(CodegenError {
                         message: "Invalid variable name in let statement".to_string(),
@@ -346,7 +399,7 @@ impl Codegen {
 
                 // Update existing variable
                 if let rue_lexer::TokenKind::Ident(var_name) = &assign_stmt.name.kind {
-                    if let Some(&existing_vreg) = self.variables.get(var_name) {
+                    if let Some(&existing_vreg) = self.variables.lookup_variable(var_name) {
                         // Copy the new value to the existing variable's location
                         self.emit(Instruction::Copy {
                             dest: existing_vreg,
@@ -469,7 +522,7 @@ impl Codegen {
             }
             ExpressionNode::Identifier(token) => {
                 if let rue_lexer::TokenKind::Ident(name) = &token.kind {
-                    if let Some(&var_vreg) = self.variables.get(name) {
+                    if let Some(&var_vreg) = self.variables.lookup_variable(name) {
                         let dest = self.next_vreg();
                         self.emit(Instruction::Copy {
                             dest,
@@ -664,6 +717,9 @@ impl Codegen {
                 // Generate then block
                 self.emit(Instruction::Label(then_label));
 
+                // Push new scope for then block
+                self.variables.push_scope();
+
                 // Generate then block statements
                 for stmt in &if_stmt.then_block.statements {
                     self.generate_statement(stmt, _scope)?;
@@ -681,6 +737,9 @@ impl Codegen {
                     zero_vreg
                 };
 
+                // Pop then block scope
+                self.variables.pop_scope();
+
                 // Copy then result to shared result register
                 self.emit(Instruction::Copy {
                     dest: result_vreg,
@@ -694,10 +753,13 @@ impl Codegen {
                 let else_result = if let Some(else_clause) = &if_stmt.else_clause {
                     match &else_clause.body {
                         rue_ast::ElseBodyNode::Block(block) => {
+                            // Push new scope for else block
+                            self.variables.push_scope();
+
                             for stmt in &block.statements {
                                 self.generate_statement(stmt, _scope)?;
                             }
-                            if let Some(final_expr) = &block.final_expr {
+                            let result = if let Some(final_expr) = &block.final_expr {
                                 self.generate_expression(final_expr, _scope)?
                             } else {
                                 let zero_vreg = self.next_vreg();
@@ -706,7 +768,11 @@ impl Codegen {
                                     src: Value::Immediate(0),
                                 });
                                 zero_vreg
-                            }
+                            };
+
+                            // Pop else block scope
+                            self.variables.pop_scope();
+                            result
                         }
                         rue_ast::ElseBodyNode::If(nested_if) => self
                             .generate_expression(&ExpressionNode::If(nested_if.clone()), _scope)?,
@@ -754,6 +820,9 @@ impl Codegen {
                 // Generate loop body
                 self.emit(Instruction::Label(body_label));
 
+                // Push new scope for loop body
+                self.variables.push_scope();
+
                 // Generate loop body statements
                 for stmt in &while_stmt.body.statements {
                     self.generate_statement(stmt, _scope)?;
@@ -762,6 +831,9 @@ impl Codegen {
                 if let Some(final_expr) = &while_stmt.body.final_expr {
                     let _result = self.generate_expression(final_expr, _scope)?;
                 }
+
+                // Pop loop body scope
+                self.variables.pop_scope();
 
                 // Jump back to condition check
                 self.emit(Instruction::Jump(loop_start));

--- a/crates/rue-semantic/src/lib.rs
+++ b/crates/rue-semantic/src/lib.rs
@@ -43,6 +43,51 @@ pub struct Scope {
     pub functions: HashMap<String, FunctionSignature>,
 }
 
+/// Stack-based scope management for block-level scoping
+#[derive(Debug, Clone)]
+pub struct ScopeStack {
+    scopes: Vec<HashMap<String, RueType>>,
+}
+
+impl ScopeStack {
+    /// Create a new scope stack with an initial empty scope
+    fn new() -> Self {
+        Self {
+            scopes: vec![HashMap::new()],
+        }
+    }
+
+    /// Push a new scope onto the stack
+    fn push_scope(&mut self) {
+        self.scopes.push(HashMap::new());
+    }
+
+    /// Pop the innermost scope from the stack
+    fn pop_scope(&mut self) {
+        if self.scopes.len() > 1 {
+            self.scopes.pop();
+        }
+    }
+
+    /// Declare a variable in the current (innermost) scope
+    fn declare_variable(&mut self, name: String, var_type: RueType) {
+        if let Some(current_scope) = self.scopes.last_mut() {
+            current_scope.insert(name, var_type);
+        }
+    }
+
+    /// Look up a variable, searching from innermost to outermost scope
+    fn lookup_variable(&self, name: &str) -> Option<&RueType> {
+        // Search from innermost (last) to outermost (first) scope
+        for scope in self.scopes.iter().rev() {
+            if let Some(var_type) = scope.get(name) {
+                return Some(var_type);
+            }
+        }
+        None
+    }
+}
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct FunctionSignature {
     pub param_types: Vec<RueType>,
@@ -136,28 +181,30 @@ fn add_builtin_functions(scope: &mut Scope) {
 
 // Semantic analysis functions
 pub fn analyze_cst(ast: &CstRoot) -> Result<Scope, SemanticError> {
-    let mut scope = Scope::default();
+    let mut global_scope = Scope::default();
 
     // Add built-in functions
-    add_builtin_functions(&mut scope);
+    add_builtin_functions(&mut global_scope);
 
     for item in &ast.items {
         match item {
             rue_ast::CstNode::Function(func) => {
-                analyze_function(&mut scope, func)?;
+                analyze_function(&mut global_scope, func)?;
             }
             rue_ast::CstNode::Statement(stmt) => {
-                analyze_statement(&mut scope, stmt)?;
+                // Top-level statements use an empty variable scope
+                let mut var_scope = ScopeStack::new();
+                analyze_statement(&mut var_scope, &global_scope.functions, stmt)?;
             }
             _ => {} // Skip other node types for now
         }
     }
 
-    Ok(scope)
+    Ok(global_scope)
 }
 
 // Helper functions for semantic analysis
-fn analyze_function(scope: &mut Scope, func: &FunctionNode) -> Result<(), SemanticError> {
+fn analyze_function(global_scope: &mut Scope, func: &FunctionNode) -> Result<(), SemanticError> {
     // Extract function name
     let func_name = match &func.name.kind {
         rue_lexer::TokenKind::Ident(name) => name.clone(),
@@ -187,8 +234,8 @@ fn analyze_function(scope: &mut Scope, func: &FunctionNode) -> Result<(), Semant
         RueType::Unit // Default to unit if no return type specified
     };
 
-    // Register function in scope
-    scope.functions.insert(
+    // Register function in global scope
+    global_scope.functions.insert(
         func_name.clone(),
         FunctionSignature {
             param_types: param_types.clone(),
@@ -196,26 +243,29 @@ fn analyze_function(scope: &mut Scope, func: &FunctionNode) -> Result<(), Semant
         },
     );
 
-    // Create local scope for function body
-    let mut local_scope = scope.clone();
+    // Create variable scope stack for function body
+    let mut var_scope = ScopeStack::new();
 
-    // Add parameters to local scope
+    // Add parameters to function scope
     for (i, param) in func.param_list.params.iter().enumerate() {
         if let rue_lexer::TokenKind::Ident(param_name) = &param.name.kind {
-            local_scope
-                .variables
-                .insert(param_name.clone(), param_types[i].clone());
+            var_scope.declare_variable(param_name.clone(), param_types[i].clone());
         }
     }
 
     // Analyze function body statements
     for stmt in &func.body.statements {
-        analyze_statement(&mut local_scope, stmt)?;
+        analyze_statement(&mut var_scope, &global_scope.functions, stmt)?;
     }
 
     // Analyze final expression and check return type
     let actual_return_type = if let Some(final_expr) = &func.body.final_expr {
-        analyze_literal_with_expected_type(&mut local_scope, final_expr, &return_type)?
+        analyze_literal_with_expected_type(
+            &mut var_scope,
+            &global_scope.functions,
+            final_expr,
+            &return_type,
+        )?
     } else {
         RueType::Unit // No final expression means unit return
     };
@@ -233,7 +283,11 @@ fn analyze_function(scope: &mut Scope, func: &FunctionNode) -> Result<(), Semant
     Ok(())
 }
 
-fn analyze_statement(scope: &mut Scope, stmt: &StatementNode) -> Result<(), SemanticError> {
+fn analyze_statement(
+    var_scope: &mut ScopeStack,
+    functions: &HashMap<String, FunctionSignature>,
+    stmt: &StatementNode,
+) -> Result<(), SemanticError> {
     match stmt {
         StatementNode::Let(let_stmt) => {
             // Get declared type if present
@@ -244,9 +298,14 @@ fn analyze_statement(scope: &mut Scope, stmt: &StatementNode) -> Result<(), Sema
 
             // Analyze the value expression with type context
             let value_type = if let Some(expected_type) = &declared_type {
-                analyze_literal_with_expected_type(scope, &let_stmt.value, expected_type)?
+                analyze_literal_with_expected_type(
+                    var_scope,
+                    functions,
+                    &let_stmt.value,
+                    expected_type,
+                )?
             } else {
-                analyze_expression(scope, &let_stmt.value)?
+                analyze_expression(var_scope, functions, &let_stmt.value)?
             };
 
             // Determine final type
@@ -273,18 +332,18 @@ fn analyze_statement(scope: &mut Scope, stmt: &StatementNode) -> Result<(), Sema
                 }
             }
 
-            // Add variable to scope
+            // Add variable to current scope
             if let rue_lexer::TokenKind::Ident(var_name) = &let_stmt.name.kind {
-                scope.variables.insert(var_name.clone(), final_type);
+                var_scope.declare_variable(var_name.clone(), final_type);
             }
         }
         StatementNode::Assign(assign_stmt) => {
             // Analyze the value expression
-            let value_type = analyze_expression(scope, &assign_stmt.value)?;
+            let value_type = analyze_expression(var_scope, functions, &assign_stmt.value)?;
 
             // Check that variable exists in scope and types match
             if let rue_lexer::TokenKind::Ident(var_name) = &assign_stmt.name.kind {
-                if let Some(var_type) = scope.variables.get(var_name) {
+                if let Some(var_type) = var_scope.lookup_variable(var_name) {
                     if *var_type != value_type {
                         return Err(SemanticError {
                             message: format!(
@@ -302,7 +361,7 @@ fn analyze_statement(scope: &mut Scope, stmt: &StatementNode) -> Result<(), Sema
             }
         }
         StatementNode::Expression(expr_stmt) => {
-            analyze_expression(scope, &expr_stmt.expression)?;
+            analyze_expression(var_scope, functions, &expr_stmt.expression)?;
         }
     }
     Ok(())
@@ -321,7 +380,8 @@ fn analyze_statement(scope: &mut Scope, stmt: &StatementNode) -> Result<(), Sema
 /// For non-literal expressions, this delegates to `analyze_expression` since they
 /// have fixed types that don't depend on context.
 fn analyze_literal_with_expected_type(
-    scope: &mut Scope,
+    var_scope: &mut ScopeStack,
+    functions: &HashMap<String, FunctionSignature>,
     expr: &ExpressionNode,
     expected_type: &RueType,
 ) -> Result<RueType, SemanticError> {
@@ -343,7 +403,7 @@ fn analyze_literal_with_expected_type(
                 }),
             }
         }
-        _ => analyze_expression(scope, expr), // For non-literals, use regular analysis
+        _ => analyze_expression(var_scope, functions, expr), // For non-literals, use regular analysis
     }
 }
 
@@ -359,7 +419,11 @@ fn analyze_literal_with_expected_type(
 /// Note: This function always infers integer literals as i32. When type context
 /// is available (e.g., from type annotations), use `analyze_literal_with_expected_type`
 /// instead to allow integer literals to be inferred as i64 when needed.
-fn analyze_expression(scope: &mut Scope, expr: &ExpressionNode) -> Result<RueType, SemanticError> {
+fn analyze_expression(
+    var_scope: &mut ScopeStack,
+    functions: &HashMap<String, FunctionSignature>,
+    expr: &ExpressionNode,
+) -> Result<RueType, SemanticError> {
     match expr {
         ExpressionNode::Literal(token) => {
             match &token.kind {
@@ -374,7 +438,7 @@ fn analyze_expression(scope: &mut Scope, expr: &ExpressionNode) -> Result<RueTyp
         }
         ExpressionNode::Identifier(token) => {
             if let rue_lexer::TokenKind::Ident(name) = &token.kind {
-                if let Some(var_type) = scope.variables.get(name) {
+                if let Some(var_type) = var_scope.lookup_variable(name) {
                     Ok(var_type.clone())
                 } else {
                     Err(SemanticError {
@@ -391,8 +455,8 @@ fn analyze_expression(scope: &mut Scope, expr: &ExpressionNode) -> Result<RueTyp
         }
         ExpressionNode::Binary(binary_expr) => {
             // Analyze both operands
-            let left_type = analyze_expression(scope, &binary_expr.left)?;
-            let right_type = analyze_expression(scope, &binary_expr.right)?;
+            let left_type = analyze_expression(var_scope, functions, &binary_expr.left)?;
+            let right_type = analyze_expression(var_scope, functions, &binary_expr.right)?;
 
             // Check operator type
             match &binary_expr.operator.kind {
@@ -452,7 +516,7 @@ fn analyze_expression(scope: &mut Scope, expr: &ExpressionNode) -> Result<RueTyp
             if let ExpressionNode::Identifier(func_token) = &*call_expr.function {
                 if let rue_lexer::TokenKind::Ident(func_name) = &func_token.kind {
                     // Check if function exists
-                    if let Some(signature) = scope.functions.get(func_name).cloned() {
+                    if let Some(signature) = functions.get(func_name).cloned() {
                         // Check argument count
                         if call_expr.args.len() != signature.param_types.len() {
                             return Err(SemanticError {
@@ -472,9 +536,14 @@ fn analyze_expression(scope: &mut Scope, expr: &ExpressionNode) -> Result<RueTyp
 
                             // Try to analyze with expected type for better inference
                             let arg_type = if let ExpressionNode::Literal(_) = arg {
-                                analyze_literal_with_expected_type(scope, arg, expected_type)?
+                                analyze_literal_with_expected_type(
+                                    var_scope,
+                                    functions,
+                                    arg,
+                                    expected_type,
+                                )?
                             } else {
-                                analyze_expression(scope, arg)?
+                                analyze_expression(var_scope, functions, arg)?
                             };
 
                             if arg_type != *expected_type {
@@ -513,7 +582,7 @@ fn analyze_expression(scope: &mut Scope, expr: &ExpressionNode) -> Result<RueTyp
         }
         ExpressionNode::If(if_stmt) => {
             // Analyze condition - must be bool
-            let condition_type = analyze_expression(scope, &if_stmt.condition)?;
+            let condition_type = analyze_expression(var_scope, functions, &if_stmt.condition)?;
             if condition_type != RueType::Bool {
                 return Err(SemanticError {
                     message: format!("If condition must be bool, found {condition_type}"),
@@ -521,32 +590,39 @@ fn analyze_expression(scope: &mut Scope, expr: &ExpressionNode) -> Result<RueTyp
                 });
             }
 
-            // Analyze then block
+            // Analyze then block with new scope
+            var_scope.push_scope();
             for stmt in &if_stmt.then_block.statements {
-                analyze_statement(scope, stmt)?;
+                analyze_statement(var_scope, functions, stmt)?;
             }
             let then_type = if let Some(final_expr) = &if_stmt.then_block.final_expr {
-                analyze_expression(scope, final_expr)?
+                analyze_expression(var_scope, functions, final_expr)?
             } else {
                 RueType::Unit // blocks without final expression return unit
             };
+            var_scope.pop_scope();
 
             // Analyze else block if it exists
             let else_type = if let Some(else_clause) = &if_stmt.else_clause {
                 match &else_clause.body {
                     rue_ast::ElseBodyNode::Block(block) => {
+                        var_scope.push_scope();
                         for stmt in &block.statements {
-                            analyze_statement(scope, stmt)?;
+                            analyze_statement(var_scope, functions, stmt)?;
                         }
-                        if let Some(final_expr) = &block.final_expr {
-                            analyze_expression(scope, final_expr)?
+                        let result_type = if let Some(final_expr) = &block.final_expr {
+                            analyze_expression(var_scope, functions, final_expr)?
                         } else {
                             RueType::Unit
-                        }
+                        };
+                        var_scope.pop_scope();
+                        result_type
                     }
-                    rue_ast::ElseBodyNode::If(nested_if) => {
-                        analyze_expression(scope, &ExpressionNode::If(nested_if.clone()))?
-                    }
+                    rue_ast::ElseBodyNode::If(nested_if) => analyze_expression(
+                        var_scope,
+                        functions,
+                        &ExpressionNode::If(nested_if.clone()),
+                    )?,
                 }
             } else {
                 RueType::Unit // missing else defaults to unit
@@ -564,7 +640,7 @@ fn analyze_expression(scope: &mut Scope, expr: &ExpressionNode) -> Result<RueTyp
         }
         ExpressionNode::While(while_stmt) => {
             // Analyze condition - must be bool
-            let condition_type = analyze_expression(scope, &while_stmt.condition)?;
+            let condition_type = analyze_expression(var_scope, functions, &while_stmt.condition)?;
             if condition_type != RueType::Bool {
                 return Err(SemanticError {
                     message: format!("While condition must be bool, found {condition_type}"),
@@ -572,20 +648,22 @@ fn analyze_expression(scope: &mut Scope, expr: &ExpressionNode) -> Result<RueTyp
                 });
             }
 
-            // Analyze body
+            // Analyze body with new scope
+            var_scope.push_scope();
             for stmt in &while_stmt.body.statements {
-                analyze_statement(scope, stmt)?;
+                analyze_statement(var_scope, functions, stmt)?;
             }
             if let Some(final_expr) = &while_stmt.body.final_expr {
-                analyze_expression(scope, final_expr)?;
+                analyze_expression(var_scope, functions, final_expr)?;
             }
+            var_scope.pop_scope();
 
             // While expressions always return unit
             Ok(RueType::Unit)
         }
         ExpressionNode::Unary(unary_expr) => {
             // Analyze operand
-            let operand_type = analyze_expression(scope, &unary_expr.operand)?;
+            let operand_type = analyze_expression(var_scope, functions, &unary_expr.operand)?;
 
             // Check operator type
             match &unary_expr.operator.kind {

--- a/crates/rue/tests/semantic_error_tests.rs
+++ b/crates/rue/tests/semantic_error_tests.rs
@@ -275,10 +275,6 @@ fn main() -> i32 {
         "Undefined variable",
     );
 
-    // TODO: This test is commented out due to a bug in Rue's scoping rules
-    // Variables defined in if/else branches should not be accessible outside
-    // the branch, but currently they are.
-    /*
     // Using variable only defined in else branch
     test_compile_error(
         "variable_only_in_else",
@@ -295,7 +291,59 @@ fn main() -> i32 {
 "#,
         "Undefined variable",
     );
-    */
+
+    // Using variable only defined in then branch
+    test_compile_error(
+        "variable_only_in_then",
+        r#"
+fn main() -> i32 {
+    if false {
+        let y: i32 = 10;
+        0
+    } else {
+        0
+    };
+    y  // y not defined outside if block
+}
+"#,
+        "Undefined variable",
+    );
+
+    // Variable defined in nested if block not accessible outside
+    test_compile_error(
+        "variable_in_nested_if",
+        r#"
+fn main() -> i32 {
+    if true {
+        if true {
+            let z: i32 = 15;
+            z
+        } else {
+            0
+        }
+    } else {
+        0
+    };
+    z  // z not defined outside nested if
+}
+"#,
+        "Undefined variable",
+    );
+
+    // Variable defined in while loop not accessible outside
+    test_compile_error(
+        "variable_in_while_loop",
+        r#"
+fn main() -> i32 {
+    while false {
+        let w: i32 = 20;
+        w;
+    };
+    w  // w not defined outside while loop
+}
+"#,
+        "Undefined variable",
+    );
 
     // Variable defined in both branches but different types
     test_compile_error(

--- a/crates/rue/tests/variable_shadowing_tests.rs
+++ b/crates/rue/tests/variable_shadowing_tests.rs
@@ -1,0 +1,263 @@
+mod common;
+
+use common::get_project_root;
+use std::fs;
+use std::process::Command;
+
+fn test_program_succeeds(name: &str, program: &str, expected_exit_code: i32) {
+    let project_root = get_project_root();
+    let test_file = project_root.join(format!("test_shadowing_temp_{name}.rue"));
+
+    // Write the test program
+    fs::write(&test_file, program).expect("Failed to write test file");
+
+    // Compile the rue program
+    let compile_output = if std::env::var("CARGO_MANIFEST_DIR").is_err() {
+        // Buck2 build environment
+        Command::new("buck2")
+            .args(["run", "//crates/rue:rue", "--"])
+            .arg(&test_file)
+            .current_dir(project_root)
+            .output()
+            .expect("Failed to execute rue compiler via Buck2")
+    } else {
+        // Cargo build environment
+        Command::new("cargo")
+            .args(["run", "-p", "rue", "--"])
+            .arg(&test_file)
+            .current_dir(project_root)
+            .output()
+            .expect("Failed to execute rue compiler via Cargo")
+    };
+
+    // Clean up test file
+    fs::remove_file(&test_file).expect("Failed to remove test file");
+
+    assert!(
+        compile_output.status.success(),
+        "Compilation failed for test '{name}':\n{}",
+        String::from_utf8_lossy(&compile_output.stderr)
+    );
+
+    // Run the compiled program
+    let exe_path = test_file.with_extension("");
+    if exe_path.exists() {
+        let run_output = Command::new(&exe_path)
+            .output()
+            .expect("Failed to execute compiled program");
+
+        // Clean up executable
+        fs::remove_file(&exe_path).expect("Failed to remove executable");
+
+        // Check exit code
+        let exit_code = run_output.status.code().unwrap_or(-1);
+        assert_eq!(
+            exit_code, expected_exit_code,
+            "Test '{name}' failed: Expected exit code {expected_exit_code}, got {exit_code}"
+        );
+    } else {
+        panic!("Compiled executable not found for test '{name}'");
+    }
+}
+
+#[test]
+fn test_basic_variable_shadowing() {
+    // Variable shadowing in nested blocks
+    test_program_succeeds(
+        "basic_shadowing",
+        r#"
+fn main() -> i32 {
+    let x: i32 = 10;
+    if true {
+        let x: i32 = 20;  // Shadows outer x
+        x  // Returns 20
+    } else {
+        x  // Would return 10
+    }
+}
+"#,
+        20,
+    );
+}
+
+#[test]
+fn test_multiple_level_shadowing() {
+    // Multiple levels of shadowing
+    test_program_succeeds(
+        "multiple_level_shadowing",
+        r#"
+fn main() -> i32 {
+    let x: i32 = 1;
+    if true {
+        let x: i32 = 2;
+        if true {
+            let x: i32 = 3;
+            x  // Returns 3
+        } else {
+            x  // Would return 2
+        }
+    } else {
+        x  // Would return 1
+    }
+}
+"#,
+        3,
+    );
+}
+
+#[test]
+fn test_shadowing_with_assignment() {
+    // Shadowing with assignment
+    test_program_succeeds(
+        "shadowing_with_assignment",
+        r#"
+fn main() -> i32 {
+    let x: i32 = 5;
+    x = 10;  // Modifies outer x
+    if true {
+        let x: i32 = 20;  // Shadows outer x
+        x = 30;  // Modifies inner x
+        x  // Returns 30
+    } else {
+        x  // Would return 10
+    }
+}
+"#,
+        30,
+    );
+}
+
+#[test]
+fn test_outer_variable_still_accessible() {
+    // Outer variable is still accessible after inner scope
+    test_program_succeeds(
+        "outer_var_accessible",
+        r#"
+fn main() -> i32 {
+    let x: i32 = 100;
+    if true {
+        let x: i32 = 200;
+        x;  // Inner x = 200
+        0  // Need to return same type from both branches
+    } else {
+        0
+    };
+    x  // Outer x = 100
+}
+"#,
+        100,
+    );
+}
+
+#[test]
+fn test_while_loop_shadowing() {
+    // Variable shadowing in while loops
+    test_program_succeeds(
+        "while_loop_shadowing",
+        r#"
+fn main() -> i32 {
+    let x: i32 = 50;
+    let count: i32 = 0;
+    while count < 1 {
+        let x: i32 = 75;  // Shadows outer x
+        count = count + 1;
+        x;  // Inner x = 75
+    };
+    x  // Outer x = 50
+}
+"#,
+        50,
+    );
+}
+
+#[test]
+fn test_function_parameter_shadowing() {
+    // Function parameters can be shadowed
+    test_program_succeeds(
+        "param_shadowing",
+        r#"
+fn process(x: i32) -> i32 {
+    if x > 10 {
+        let x: i32 = 10;  // Shadows parameter
+        x  // Returns 10
+    } else {
+        x  // Returns parameter value
+    }
+}
+
+fn main() -> i32 {
+    process(20)  // Should return 10
+}
+"#,
+        10,
+    );
+}
+
+#[test]
+fn test_shadowing_different_types() {
+    // Variables can be shadowed with different types
+    test_program_succeeds(
+        "shadow_different_type",
+        r#"
+fn main() -> i32 {
+    let x: i32 = 42;
+    if true {
+        let x: bool = true;  // Shadows with different type
+        if x {
+            1
+        } else {
+            0
+        }
+    } else {
+        x  // Original i32 x
+    }
+}
+"#,
+        1,
+    );
+}
+
+#[test]
+fn test_same_scope_shadowing() {
+    // Variables can be shadowed within the same scope
+    test_program_succeeds(
+        "same_scope_shadow",
+        r#"
+fn main() -> i32 {
+    let x: i32 = 10;
+    let x: i32 = 20;  // Shadows in same scope
+    let x: i32 = 30;  // Shadows again
+    x  // Returns 30
+}
+"#,
+        30,
+    );
+}
+
+#[test]
+fn test_complex_shadowing_scenario() {
+    // Complex scenario with multiple variables and shadowing
+    test_program_succeeds(
+        "complex_shadowing",
+        r#"
+fn main() -> i32 {
+    let a: i32 = 1;
+    let b: i32 = 2;
+    
+    if true {
+        let a: i32 = 10;  // Shadow a
+        
+        if true {
+            let b: i32 = 20;  // Shadow b
+            a + b  // 10 + 20 = 30
+        } else {
+            a + b  // Would be 10 + 2 = 12
+        }
+    } else {
+        a + b  // Would be 1 + 2 = 3
+    }
+}
+"#,
+        30,
+    );
+}

--- a/docs/implementation.md
+++ b/docs/implementation.md
@@ -121,6 +121,30 @@ The Rue compiler is organized into multiple crates for modularity and clean sepa
 4. **Call Graph**: Build function dependency graph
 5. **Type Inference**: Deduce types for expressions from context
 
+#### Variable Scoping Implementation
+
+The semantic analyzer implements block-level scoping using a hierarchical scope stack:
+
+**ScopeStack Structure**:
+- Maintains a stack of HashMap<String, RueType> for variable lookups
+- Each block (function body, if/else branches, while loops) creates a new scope
+- Variable declarations add to the innermost scope
+- Variable lookups search from innermost to outermost scope
+
+**Scope Management**:
+1. **Function entry**: Creates new scope, adds parameters
+2. **Block entry** (if/else/while): Pushes new scope onto stack
+3. **Block exit**: Pops scope from stack
+4. **Variable declaration**: Adds to current (innermost) scope
+5. **Variable reference**: Searches scopes from inner to outer
+
+**Variable Shadowing**:
+- Variables in inner scopes can shadow outer scope variables
+- Each scope maintains its own variable-to-type mapping
+- Shadowed variables remain accessible when inner scope exits
+
+The code generator mirrors this structure with a VarScopeStack that maps variables to virtual registers (VRegs), ensuring consistent scoping behavior throughout compilation.
+
 ### Intermediate Representations (`rue-ir` and `rue-codegen`)
 
 #### Overview

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -124,10 +124,181 @@ Operators of the same precedence are left-associative.
 ## 4. Static Semantics
 
 ### 4.1 Scoping Rules
+
+#### 4.1.1 Basic Scoping Principles
 - Function parameters are scoped to their function body
 - Variables declared with `let` are scoped to the block in which they are declared
-- Functions are globally scoped
-- Variable shadowing is not permitted within the same scope
+- Functions are globally scoped and visible throughout the program
+- Variable shadowing is permitted both within the same scope and across nested scopes
+
+#### 4.1.2 Block Scopes
+A new scope is created when entering:
+- Function bodies
+- If expression blocks (both `then` and `else` branches)
+- While expression bodies
+
+When a block is exited, all variables declared within that block become inaccessible.
+
+#### 4.1.3 Variable Shadowing
+Variable shadowing occurs when a new variable declaration has the same name as an existing variable:
+- Variables can shadow other variables in the same scope or in outer scopes
+- The new variable "hides" all previous variables with the same name
+- The previous variables become permanently inaccessible (they cannot be "unshadowed")
+- Each `let` declaration creates a new variable, even if the name already exists
+
+Example of cross-scope shadowing:
+```rue
+fn main() -> i32 {
+    let x: i32 = 10;      // Outer x
+    if true {
+        let x: i32 = 20;  // Inner x shadows outer x
+        x                 // Returns 20
+    } else {
+        x                 // Would return 10 (outer x)
+    }
+}
+```
+
+Example of same-scope shadowing:
+```rue
+fn main() -> i32 {
+    let x: i32 = 10;      // First x
+    let x: i32 = 20;      // Second x shadows first x
+    x                     // Returns 20 (first x is no longer accessible)
+}
+```
+
+Shadowing with different types:
+```rue
+fn main() -> i32 {
+    let x: i32 = 42;      // x is i32
+    let x: bool = true;   // x is now bool, previous x is shadowed
+    if x {                // Uses the bool x
+        let x: i32 = 100; // x is i32 again in this scope
+        x                 // Returns 100
+    } else {
+        0
+    }
+}
+
+#### 4.1.4 Scope Resolution
+When resolving a variable reference:
+1. Search starts in the current (innermost) scope
+2. If not found, search proceeds to the next outer scope
+3. Continue until the variable is found or all scopes are exhausted
+4. If the variable is not found in any accessible scope, a compile error occurs
+
+#### 4.1.5 If Expression Scopes
+Each branch of an if expression creates its own scope:
+```rue
+fn main() -> i32 {
+    let x: i32 = 1;
+    if condition {
+        let y: i32 = 2;   // y is only accessible in this branch
+        x + y             // Can access outer x and inner y
+    } else {
+        let z: i32 = 3;   // z is only accessible in this branch
+        x + z             // Can access outer x and inner z
+    }
+    // Neither y nor z are accessible here
+}
+```
+
+Nested if expressions (else if) each create their own scope:
+```rue
+fn main() -> i32 {
+    let x: i32 = 1;
+    if condition1 {
+        let a: i32 = 10;
+        a
+    } else if condition2 {
+        let b: i32 = 20;  // b is only accessible in this branch
+        b
+    } else {
+        let c: i32 = 30;  // c is only accessible in this branch
+        c
+    }
+    // None of a, b, or c are accessible here
+}
+```
+
+#### 4.1.6 While Expression Scopes
+The body of a while expression creates a new scope for each iteration:
+```rue
+fn main() -> i32 {
+    let x: i32 = 0;
+    while x < 10 {
+        let y: i32 = x * 2;  // y is created fresh each iteration
+        x = x + 1;           // Modifies outer x
+    };
+    // y is not accessible here
+    x
+}
+```
+
+#### 4.1.7 Function Parameter Shadowing
+Function parameters can be shadowed within the function body:
+```rue
+fn process(x: i32) -> i32 {
+    if x > 10 {
+        let x: i32 = 10;  // Shadows the parameter x
+        x                 // Returns 10
+    } else {
+        x                 // Returns the parameter value
+    }
+}
+```
+
+#### 4.1.8 Assignment and Scoping
+Assignment statements always modify the variable in the scope where it was declared:
+```rue
+fn main() -> i32 {
+    let x: i32 = 10;
+    if true {
+        x = 20;           // Modifies the outer x
+        let x: i32 = 30;  // Creates a new inner x
+        x = 40;           // Modifies the inner x
+    };
+    x                     // Returns 20 (outer x was modified)
+}
+```
+
+Note that assignment requires the variable to already exist - you cannot create a new variable with assignment:
+```rue
+fn main() -> i32 {
+    y = 10;  // Error: undefined variable y
+    0
+}
+```
+
+#### 4.1.9 Comprehensive Scoping Example
+This example demonstrates multiple scoping concepts:
+```rue
+fn calculate(n: i32) -> i32 {
+    let result: i32 = 0;        // Function scope
+    let multiplier: i32 = 2;    // Function scope
+    
+    if n > 0 {
+        let temp: i32 = n * multiplier;  // If-block scope
+        result = temp;                    // Modifies function-scope result
+        
+        if n > 10 {
+            let multiplier: i32 = 3;      // Shadows function-scope multiplier
+            let temp: i32 = n * multiplier;  // Shadows if-block temp
+            result = temp;                // Still modifies function-scope result
+        };                                // Inner multiplier and temp go out of scope
+        
+        // Here, temp refers to the if-block temp, not the inner one
+        result = result + temp;
+    } else {
+        let temp: i32 = -1;              // Different temp in else-block
+        result = temp;
+    };
+    // No temp variable is accessible here
+    
+    result * multiplier  // Uses function-scope multiplier (2)
+}
+```
 
 ### 4.2 Name Resolution
 - All identifiers must be declared before use


### PR DESCRIPTION
- Add hierarchical ScopeStack in semantic analyzer for proper block scoping
- Add VarScopeStack in code generator to mirror semantic scoping
- Push/pop scopes when entering/exiting blocks (if/else, while loops)
- Enable variable shadowing across nested scopes and within scopes
- Fix issue where variables in if/else blocks were accessible outside
- Add comprehensive tests for scoping and variable shadowing
- Update documentation with scoping implementation details

Fixes #64