### PR TITLE
Fix register-aliasing bug in binary operations

### DIFF
--- a/crates/rue-codegen/src/lowering.rs
+++ b/crates/rue-codegen/src/lowering.rs
@@ -166,7 +166,7 @@ impl<'a> Lowering<'a> {
                 let dest_reg = match lhs {
                     Value::VReg(vreg) => {
                         let lhs_reg = self.allocator.ensure_reg(*vreg, &[])?;
-                        let dest_reg = self.allocator.ensure_reg(dest, &[])?;
+                        let dest_reg = self.allocator.ensure_reg(dest, &[lhs_reg])?;
                         // Emit any pending spill/reload operations before moving
                         self.emit_spill_reload_ops();
                         if lhs_reg != dest_reg {
@@ -591,7 +591,7 @@ impl<'a> Lowering<'a> {
             _ => unreachable!(),
         };
 
-        let dest_reg = self.allocator.ensure_reg(dest, &[])?;
+        let dest_reg = self.allocator.ensure_reg(dest, &[lhs_reg])?;
         self.emit_spill_reload_ops();
         self.emit(MachineInstr::SetCC { dest: dest_reg, cc });
         self.emit(MachineInstr::Movzx {


### PR DESCRIPTION
Ensure destination register cannot alias with source register when lowering binary operations. Previously, dest and lhs could be assigned the same physical register, causing lhs to be overwritten before use.

This fixes incorrect results in code like Fibonacci where recursive operations depend on preserving source values.