### PR TITLE
Refactor label adjustment logic into reusable helper function

### DIFF
--- a/crates/rue-codegen/src/compile_hir.rs
+++ b/crates/rue-codegen/src/compile_hir.rs
@@ -5,10 +5,11 @@
 use crate::CodegenError;
 use crate::elf_writer::ElfWriter;
 use crate::hir_codegen::HirCodegen;
+use crate::label_utils::adjust_label_ids;
 use crate::x86_emitter::X86Emitter;
 use crate::{Instruction, Lowering, RegisterAllocator, format_instructions_as_assembly};
 use rue_ir::hir::HirProgram;
-use rue_ir::target::{LabelRef, MachineInstr};
+use rue_ir::target::MachineInstr;
 use std::collections::HashMap;
 
 /// Compile HIR to assembly text
@@ -130,35 +131,9 @@ pub fn compile_hir_to_assembly(hir: &HirProgram) -> Result<String, CodegenError>
     let runtime_label_count = runtime_labels.values().max().copied().unwrap_or(0) + 1;
 
     // Adjust all label IDs in user code
-    for instr in all_machine_instructions {
-        match instr {
-            MachineInstr::Label { id } => {
-                final_instructions.push(MachineInstr::Label {
-                    id: id + runtime_label_count,
-                });
-            }
-            MachineInstr::Jmp { target } => {
-                let adjusted_target = match target {
-                    LabelRef::Local(id) => LabelRef::Local(id + runtime_label_count),
-                    global => global,
-                };
-                final_instructions.push(MachineInstr::Jmp {
-                    target: adjusted_target,
-                });
-            }
-            MachineInstr::JmpCC { cc, target } => {
-                let adjusted_target = match target {
-                    LabelRef::Local(id) => LabelRef::Local(id + runtime_label_count),
-                    global => global,
-                };
-                final_instructions.push(MachineInstr::JmpCC {
-                    cc,
-                    target: adjusted_target,
-                });
-            }
-            other => final_instructions.push(other),
-        }
-    }
+    let adjusted_user_instructions =
+        adjust_label_ids(all_machine_instructions, runtime_label_count);
+    final_instructions.extend(adjusted_user_instructions);
 
     // Phase 5: Generate assembly text
     let mut all_function_labels = HashMap::new();
@@ -302,35 +277,9 @@ pub fn compile_hir_to_executable(hir: &HirProgram) -> Result<Vec<u8>, CodegenErr
     let runtime_label_count = runtime_labels.values().max().copied().unwrap_or(0) + 1;
 
     // Adjust all label IDs in user code
-    for instr in all_machine_instructions {
-        match instr {
-            MachineInstr::Label { id } => {
-                final_instructions.push(MachineInstr::Label {
-                    id: id + runtime_label_count,
-                });
-            }
-            MachineInstr::Jmp { target } => {
-                let adjusted_target = match target {
-                    LabelRef::Local(id) => LabelRef::Local(id + runtime_label_count),
-                    global => global,
-                };
-                final_instructions.push(MachineInstr::Jmp {
-                    target: adjusted_target,
-                });
-            }
-            MachineInstr::JmpCC { cc, target } => {
-                let adjusted_target = match target {
-                    LabelRef::Local(id) => LabelRef::Local(id + runtime_label_count),
-                    global => global,
-                };
-                final_instructions.push(MachineInstr::JmpCC {
-                    cc,
-                    target: adjusted_target,
-                });
-            }
-            other => final_instructions.push(other),
-        }
-    }
+    let adjusted_user_instructions =
+        adjust_label_ids(all_machine_instructions, runtime_label_count);
+    final_instructions.extend(adjusted_user_instructions);
 
     // Phase 5: Emit machine code
     let mut x86_emitter = X86Emitter::new();

--- a/crates/rue-codegen/src/compile_hir_with_mir.rs
+++ b/crates/rue-codegen/src/compile_hir_with_mir.rs
@@ -4,6 +4,7 @@
 //! It's an alternative to compile_hir that uses MIR for potential optimizations.
 
 use crate::elf_writer::ElfWriter;
+use crate::label_utils::adjust_label_ids;
 use crate::mir_to_instructions::MirToInstructions;
 use crate::x86_emitter::X86Emitter;
 use crate::{
@@ -14,7 +15,7 @@ use rue_ir::mir_lowering::MirBuilder;
 use rue_ir::mir_passes::{CommonSubexpressionElimination, ConstProp, DeadCodeElimination};
 #[cfg(debug_assertions)]
 use rue_ir::mir_verifier::MirVerifier;
-use rue_ir::target::{LabelRef, MachineInstr};
+use rue_ir::target::MachineInstr;
 use std::collections::HashMap;
 use std::path::Path;
 
@@ -180,41 +181,9 @@ pub fn compile_hir_via_mir_to_assembly(hir: &HirProgram) -> Result<String, Codeg
     let runtime_label_count = _runtime_labels.values().max().copied().unwrap_or(0) + 1;
 
     // Adjust all label IDs in user code
-    for instr in all_machine_instructions {
-        match instr {
-            MachineInstr::Label { id } => {
-                final_instructions.push(MachineInstr::Label {
-                    id: id + runtime_label_count,
-                });
-            }
-            MachineInstr::Jmp { target } => {
-                let adjusted_target = match target {
-                    LabelRef::Local(id) => LabelRef::Local(id + runtime_label_count),
-                    global => global,
-                };
-                final_instructions.push(MachineInstr::Jmp {
-                    target: adjusted_target,
-                });
-            }
-            MachineInstr::JmpCC { cc, target } => {
-                let adjusted_target = match target {
-                    LabelRef::Local(id) => LabelRef::Local(id + runtime_label_count),
-                    global => global,
-                };
-                final_instructions.push(MachineInstr::JmpCC {
-                    cc,
-                    target: adjusted_target,
-                });
-            }
-            MachineInstr::Call { target } => {
-                // Call uses String, not LabelRef
-                final_instructions.push(MachineInstr::Call {
-                    target: target.clone(),
-                });
-            }
-            other => final_instructions.push(other),
-        }
-    }
+    let adjusted_user_instructions =
+        adjust_label_ids(all_machine_instructions, runtime_label_count);
+    final_instructions.extend(adjusted_user_instructions);
 
     // Build final function labels map
     let mut all_function_labels = HashMap::new();
@@ -402,41 +371,9 @@ pub fn compile_hir_via_mir_to_executable(
 
     let runtime_label_count = runtime_labels.values().max().copied().unwrap_or(0) + 1;
 
-    for instr in all_machine_instructions {
-        match instr {
-            MachineInstr::Label { id } => {
-                final_instructions.push(MachineInstr::Label {
-                    id: id + runtime_label_count,
-                });
-            }
-            MachineInstr::Jmp { target } => {
-                let adjusted_target = match target {
-                    LabelRef::Local(id) => LabelRef::Local(id + runtime_label_count),
-                    global => global,
-                };
-                final_instructions.push(MachineInstr::Jmp {
-                    target: adjusted_target,
-                });
-            }
-            MachineInstr::JmpCC { cc, target } => {
-                let adjusted_target = match target {
-                    LabelRef::Local(id) => LabelRef::Local(id + runtime_label_count),
-                    global => global,
-                };
-                final_instructions.push(MachineInstr::JmpCC {
-                    cc,
-                    target: adjusted_target,
-                });
-            }
-            MachineInstr::Call { target } => {
-                // Call uses String, not LabelRef
-                final_instructions.push(MachineInstr::Call {
-                    target: target.clone(),
-                });
-            }
-            other => final_instructions.push(other),
-        }
-    }
+    let adjusted_user_instructions =
+        adjust_label_ids(all_machine_instructions, runtime_label_count);
+    final_instructions.extend(adjusted_user_instructions);
 
     let mut all_function_labels = HashMap::new();
 

--- a/crates/rue-codegen/src/label_utils.rs
+++ b/crates/rue-codegen/src/label_utils.rs
@@ -1,0 +1,43 @@
+//! Utilities for label manipulation in machine instructions
+
+use rue_ir::target::{LabelRef, MachineInstr};
+
+/// Adjusts all label IDs in a list of machine instructions by adding an offset.
+///
+/// This function is used when combining runtime code with user code, where user
+/// code labels need to be shifted to avoid conflicts with runtime labels.
+///
+/// # Arguments
+/// * `instructions` - The machine instructions to adjust
+/// * `offset` - The amount to add to each local label ID
+///
+/// # Returns
+/// A new vector of machine instructions with adjusted label IDs
+pub fn adjust_label_ids(instructions: Vec<MachineInstr>, offset: u32) -> Vec<MachineInstr> {
+    instructions
+        .into_iter()
+        .map(|instr| match instr {
+            MachineInstr::Label { id } => MachineInstr::Label { id: id + offset },
+            MachineInstr::Jmp { target } => {
+                let adjusted_target = match target {
+                    LabelRef::Local(id) => LabelRef::Local(id + offset),
+                    global => global,
+                };
+                MachineInstr::Jmp {
+                    target: adjusted_target,
+                }
+            }
+            MachineInstr::JmpCC { cc, target } => {
+                let adjusted_target = match target {
+                    LabelRef::Local(id) => LabelRef::Local(id + offset),
+                    global => global,
+                };
+                MachineInstr::JmpCC {
+                    cc,
+                    target: adjusted_target,
+                }
+            }
+            other => other,
+        })
+        .collect()
+}

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -10,6 +10,7 @@ mod compile_hir;
 mod compile_hir_with_mir;
 mod elf_writer;
 mod hir_codegen;
+mod label_utils;
 mod lowering;
 mod mir_to_instructions;
 mod regalloc;


### PR DESCRIPTION
Extract duplicated label-shifting code from compile_hir* and *_via_mir*  functions into a new adjust_label_ids helper in label_utils module. This eliminates code duplication across four compilation paths while maintaining the same functionality.