### PR TITLE
Replace imperative label bookkeeping with type-safe Label struct

### DIFF
--- a/crates/rue-codegen/src/backend_driver.rs
+++ b/crates/rue-codegen/src/backend_driver.rs
@@ -1,5 +1,5 @@
 use crate::label_utils::adjust_label_ids;
-use crate::{CodegenError, Instruction, LabelId, Lowering, RegisterAllocator};
+use crate::{CodegenError, Instruction, Label, Lowering, RegisterAllocator};
 use rue_ir::target::MachineInstr;
 use std::collections::HashMap;
 
@@ -21,20 +21,25 @@ impl BackendDriver {
         })
     }
 
+    /// Get the runtime label count
+    pub fn runtime_label_count(&self) -> u32 {
+        self.runtime_labels.values().max().copied().unwrap_or(0) + 1
+    }
+
     /// Discover function boundaries by scanning for labels that correspond to function entry points
     pub fn discover_function_boundaries(
         &self,
         instructions: &[Instruction],
-        function_labels: &HashMap<String, LabelId>,
+        function_labels: &HashMap<String, Label>,
     ) -> Vec<(usize, usize)> {
         let mut function_boundaries = Vec::new();
         let mut current_start = 0;
 
         for (i, instr) in instructions.iter().enumerate() {
-            if let Instruction::Label(label_id) = instr {
+            if let Instruction::Label(label) = instr {
                 if function_labels
                     .values()
-                    .any(|&LabelId(id)| id == label_id.0)
+                    .any(|&func_label| func_label == *label)
                 {
                     if current_start < i {
                         function_boundaries.push((current_start, i));
@@ -55,13 +60,13 @@ impl BackendDriver {
         &self,
         instructions: &[Instruction],
         starting_id: u32,
-    ) -> (HashMap<LabelId, u32>, u32) {
+    ) -> (HashMap<Label, u32>, u32) {
         let mut ir_to_machine_labels = HashMap::new();
         let mut label_id_counter = starting_id;
 
         for instr in instructions {
-            if let Instruction::Label(label_id) = instr {
-                ir_to_machine_labels.entry(*label_id).or_insert_with(|| {
+            if let Instruction::Label(label) = instr {
+                ir_to_machine_labels.entry(*label).or_insert_with(|| {
                     let id = label_id_counter;
                     label_id_counter += 1;
                     id
@@ -76,9 +81,9 @@ impl BackendDriver {
     pub fn lower_functions(
         &self,
         instructions: &[Instruction],
-        function_labels: HashMap<String, LabelId>,
+        function_labels: HashMap<String, Label>,
         boundaries: Vec<(usize, usize)>,
-        ir_to_machine_labels: HashMap<LabelId, u32>,
+        ir_to_machine_labels: HashMap<Label, u32>,
         starting_label_id: u32,
     ) -> Result<Vec<MachineInstr>, CodegenError> {
         let mut all_machine_instructions = Vec::new();
@@ -101,7 +106,7 @@ impl BackendDriver {
 
                 for instr in function_instrs {
                     match instr {
-                        Instruction::Label(label_id) => {
+                        Instruction::Label(label) => {
                             // First, lower any accumulated instructions
                             if !function_instrs_without_labels.is_empty() {
                                 let machine_instrs = lowering
@@ -112,7 +117,7 @@ impl BackendDriver {
                             }
 
                             // Then emit the label
-                            let machine_label_id = ir_to_machine_labels[label_id];
+                            let machine_label_id = ir_to_machine_labels[label];
                             function_machine_instrs.push(MachineInstr::Label {
                                 id: machine_label_id,
                             });
@@ -170,24 +175,20 @@ impl BackendDriver {
     /// Build the final function labels map, combining runtime and user labels
     pub fn build_final_labels(
         &self,
-        function_labels: &HashMap<String, LabelId>,
-        ir_to_machine_labels: &HashMap<LabelId, u32>,
-    ) -> HashMap<String, LabelId> {
+        function_labels: &HashMap<String, Label>,
+        ir_to_machine_labels: &HashMap<Label, u32>,
+    ) -> HashMap<String, Label> {
         let mut all_function_labels = HashMap::new();
 
         // Add runtime labels
         for (name, &id) in &self.runtime_labels {
-            all_function_labels.insert(name.clone(), LabelId(id));
+            all_function_labels.insert(name.clone(), Label::runtime(id));
         }
 
-        // Add user function labels (adjusted)
-        let runtime_label_count = self.runtime_labels.values().max().copied().unwrap_or(0) + 1;
+        // Add user function labels
         for (name, ir_label_id) in function_labels {
             if let Some(&machine_label_id) = ir_to_machine_labels.get(ir_label_id) {
-                all_function_labels.insert(
-                    name.clone(),
-                    LabelId(machine_label_id + runtime_label_count),
-                );
+                all_function_labels.insert(name.clone(), Label::user(machine_label_id));
             }
         }
 

--- a/crates/rue-codegen/src/compile_hir.rs
+++ b/crates/rue-codegen/src/compile_hir.rs
@@ -40,9 +40,14 @@ pub fn compile_hir_to_assembly(hir: &HirProgram) -> Result<String, CodegenError>
 
     // Phase 5: Generate assembly text
     let all_function_labels = driver.build_final_labels(&function_labels, &ir_to_machine_labels);
+    let runtime_label_count = driver.runtime_label_count();
 
     // Convert machine instructions to assembly text
-    let asm_text = format_instructions_as_assembly(&final_instructions, &all_function_labels);
+    let asm_text = format_instructions_as_assembly(
+        &final_instructions,
+        &all_function_labels,
+        runtime_label_count,
+    );
     Ok(asm_text)
 }
 
@@ -79,7 +84,8 @@ pub fn compile_hir_to_executable(hir: &HirProgram) -> Result<Vec<u8>, CodegenErr
 
     // Set up all labels (runtime + user)
     let all_function_labels = driver.build_final_labels(&function_labels, &ir_to_machine_labels);
-    x86_emitter.set_function_labels(all_function_labels);
+    let runtime_label_count = driver.runtime_label_count();
+    x86_emitter.set_function_labels(all_function_labels, runtime_label_count);
 
     let code = x86_emitter
         .emit_all(&final_instructions)

--- a/crates/rue-codegen/src/compile_hir_with_mir.rs
+++ b/crates/rue-codegen/src/compile_hir_with_mir.rs
@@ -90,11 +90,13 @@ pub fn compile_hir_via_mir_to_assembly(hir: &HirProgram) -> Result<String, Codeg
 
     // Step 9: Build final labels and generate assembly
     let all_function_labels = driver.build_final_labels(&function_labels, &ir_to_machine_labels);
+    let runtime_label_count = driver.runtime_label_count();
 
     // Generate assembly
     Ok(format_instructions_as_assembly(
         &final_instructions,
         &all_function_labels,
+        runtime_label_count,
     ))
 }
 
@@ -173,10 +175,11 @@ pub fn compile_hir_via_mir_to_executable(
 
     // Step 9: Build final labels
     let all_function_labels = driver.build_final_labels(&function_labels, &ir_to_machine_labels);
+    let runtime_label_count = driver.runtime_label_count();
 
     // Step 10: Generate x86 code
     let mut emitter = X86Emitter::new();
-    emitter.set_function_labels(all_function_labels);
+    emitter.set_function_labels(all_function_labels, runtime_label_count);
     let code = emitter
         .emit_all(&final_instructions)
         .map_err(|e| CodegenError { message: e })?;

--- a/crates/rue-codegen/src/hir_codegen.rs
+++ b/crates/rue-codegen/src/hir_codegen.rs
@@ -2,7 +2,7 @@
 //!
 //! This module generates platform-independent instructions from HIR.
 
-use crate::{BinOp, CodegenError, Instruction, LabelId, VReg, Value};
+use crate::{BinOp, CodegenError, Instruction, Label, VReg, Value};
 use rue_ir::hir::{
     BinOp as HirBinOp, HirBlock, HirExpr, HirFunction, HirLiteral, HirProgram, HirStatement,
     UnaryOp as HirUnaryOp,
@@ -16,7 +16,7 @@ pub struct HirCodegen {
     vreg_counter: u32,
     label_counter: u32,
     variables: HashMap<String, VReg>, // Variable name -> virtual register
-    function_labels: HashMap<String, LabelId>, // Function name -> label ID
+    function_labels: HashMap<String, Label>, // Function name -> label
 }
 
 impl HirCodegen {
@@ -38,8 +38,8 @@ impl HirCodegen {
     }
 
     // Generate a unique label
-    fn next_label(&mut self) -> LabelId {
-        let label = LabelId(self.label_counter);
+    fn next_label(&mut self) -> Label {
+        let label = Label::user(self.label_counter);
         self.label_counter += 1;
         label
     }
@@ -611,7 +611,7 @@ impl HirCodegen {
     }
 
     /// Get the generated instructions and function labels
-    pub fn get_output(self) -> (Vec<Instruction>, HashMap<String, LabelId>) {
+    pub fn get_output(self) -> (Vec<Instruction>, HashMap<String, Label>) {
         (self.instructions, self.function_labels)
     }
 }

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -63,9 +63,76 @@ pub enum BinOp {
     Ne,
 }
 
-/// Label for control flow jumps
+/// Label space to distinguish between runtime and user labels
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum LabelSpace {
+    Runtime,
+    User,
+}
+
+/// Type-safe label that tracks which space it belongs to
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Label {
+    id: u32,
+    space: LabelSpace,
+}
+
+impl Label {
+    /// Create a new runtime label
+    pub fn runtime(id: u32) -> Self {
+        Label {
+            id,
+            space: LabelSpace::Runtime,
+        }
+    }
+
+    /// Create a new user label
+    pub fn user(id: u32) -> Self {
+        Label {
+            id,
+            space: LabelSpace::User,
+        }
+    }
+
+    /// Get the raw ID without offset
+    pub fn id(&self) -> u32 {
+        self.id
+    }
+
+    /// Get the label space
+    pub fn space(&self) -> LabelSpace {
+        self.space
+    }
+
+    /// Convert to a machine label ID with proper offset
+    /// Runtime labels keep their IDs, user labels are offset by runtime_label_count
+    pub fn to_machine_id(&self, runtime_label_count: u32) -> u32 {
+        match self.space {
+            LabelSpace::Runtime => self.id,
+            LabelSpace::User => self.id + runtime_label_count,
+        }
+    }
+
+    /// Create a label from a machine ID, determining its space based on offset
+    pub fn from_machine_id(machine_id: u32, runtime_label_count: u32) -> Self {
+        if machine_id < runtime_label_count {
+            Label::runtime(machine_id)
+        } else {
+            Label::user(machine_id - runtime_label_count)
+        }
+    }
+}
+
+/// Label for control flow jumps (legacy compatibility)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct LabelId(pub u32);
+
+impl From<Label> for LabelId {
+    fn from(label: Label) -> Self {
+        // This conversion loses space information - use only for legacy code
+        LabelId(label.id)
+    }
+}
 
 /// Platform-independent instruction set
 ///
@@ -108,12 +175,12 @@ pub enum Instruction {
     }, // Pop from stack to register
 
     // Control flow
-    Label(LabelId),
-    Jump(LabelId),
+    Label(Label),
+    Jump(Label),
     Branch {
         condition: VReg,
-        true_label: LabelId,
-        false_label: LabelId,
+        true_label: Label,
+        false_label: Label,
     },
 
     // Function operations
@@ -149,7 +216,8 @@ pub enum Instruction {
 // Convert machine instructions to AT&T assembly syntax
 pub fn format_instructions_as_assembly(
     instructions: &[MachineInstr],
-    function_labels: &HashMap<String, LabelId>,
+    function_labels: &HashMap<String, Label>,
+    runtime_label_count: u32,
 ) -> String {
     use rue_ir::target::ConditionCode;
 
@@ -161,8 +229,8 @@ pub fn format_instructions_as_assembly(
 
     // Reverse map for labels
     let mut label_names: HashMap<u32, String> = HashMap::new();
-    for (name, LabelId(id)) in function_labels {
-        label_names.insert(*id, name.clone());
+    for (name, label) in function_labels {
+        label_names.insert(label.to_machine_id(runtime_label_count), name.clone());
     }
 
     for instr in instructions {

--- a/crates/rue-codegen/src/lowering.rs
+++ b/crates/rue-codegen/src/lowering.rs
@@ -1,5 +1,5 @@
 use crate::{
-    BinOp, Instruction, LabelId, VReg, Value,
+    BinOp, Instruction, Label, VReg, Value,
     regalloc::{RegisterAllocator, SpillReloadOp},
 };
 use rue_ir::target::{ConditionCode, LabelRef, MachineInstr, Register};
@@ -11,11 +11,11 @@ use std::collections::HashMap;
 pub struct Lowering<'a> {
     allocator: &'a mut RegisterAllocator,
     instructions: Vec<MachineInstr>,
-    label_map: HashMap<LabelId, u32>,
+    label_map: HashMap<Label, u32>,
     next_label_id: u32,
-    function_labels: HashMap<String, LabelId>,
+    function_labels: HashMap<String, Label>,
     /// External label map to use (if provided)
-    external_label_map: Option<HashMap<LabelId, u32>>,
+    external_label_map: Option<HashMap<Label, u32>>,
     /// Track number of pushes since function entry for stack alignment
     push_count: u32,
 }
@@ -34,11 +34,11 @@ impl<'a> Lowering<'a> {
     }
 
     /// Set an external label map to use for label resolution
-    pub fn set_label_map(&mut self, label_map: HashMap<LabelId, u32>) {
+    pub fn set_label_map(&mut self, label_map: HashMap<Label, u32>) {
         self.external_label_map = Some(label_map);
     }
 
-    pub fn set_function_labels(&mut self, labels: HashMap<String, LabelId>) {
+    pub fn set_function_labels(&mut self, labels: HashMap<String, Label>) {
         self.function_labels = labels;
     }
 
@@ -642,7 +642,7 @@ impl<'a> Lowering<'a> {
         Ok(())
     }
 
-    fn lower_jump(&mut self, target: LabelId) -> Result<(), String> {
+    fn lower_jump(&mut self, target: Label) -> Result<(), String> {
         let machine_label_id = self.get_or_create_label(target);
         self.emit(MachineInstr::Jmp {
             target: LabelRef::Local(machine_label_id),
@@ -653,8 +653,8 @@ impl<'a> Lowering<'a> {
     fn lower_branch(
         &mut self,
         condition: VReg,
-        true_label: LabelId,
-        false_label: LabelId,
+        true_label: Label,
+        false_label: Label,
     ) -> Result<(), String> {
         let cond_reg = self.allocator.ensure_reg(condition, &[])?;
         self.emit_spill_reload_ops();
@@ -1042,7 +1042,7 @@ impl<'a> Lowering<'a> {
         Ok(())
     }
 
-    fn get_or_create_label(&mut self, label_id: LabelId) -> u32 {
+    fn get_or_create_label(&mut self, label_id: Label) -> u32 {
         // First check external label map if provided
         if let Some(ref external_map) = self.external_label_map {
             if let Some(&machine_id) = external_map.get(&label_id) {

--- a/crates/rue-codegen/src/mir_to_instructions.rs
+++ b/crates/rue-codegen/src/mir_to_instructions.rs
@@ -3,7 +3,7 @@
 //! This module converts MIR (in SSA form with block parameters) to the
 //! platform-independent Instruction representation with virtual registers.
 
-use crate::{BinOp, Instruction, LabelId, VReg, Value};
+use crate::{BinOp, Instruction, Label, VReg, Value};
 use rue_ir::mir::{
     BasicBlock, BlockId, MirBinOp, MirConst, MirFunction, MirProgram, MirStatement, MirTerminator,
     MirUnaryOp, MirValue, Temp,
@@ -22,9 +22,9 @@ pub struct MirToInstructions {
     /// Mapping from MIR temps to virtual registers
     temp_to_vreg: HashMap<Temp, VReg>,
     /// Mapping from block IDs to labels
-    block_to_label: HashMap<BlockId, LabelId>,
+    block_to_label: HashMap<BlockId, Label>,
     /// Function labels for calls
-    function_labels: HashMap<String, LabelId>,
+    function_labels: HashMap<String, Label>,
     /// Current function blocks (needed for block parameter lookup)
     current_blocks: Vec<BasicBlock>,
 }
@@ -50,8 +50,8 @@ impl MirToInstructions {
     }
 
     /// Generate a fresh label
-    fn fresh_label(&mut self) -> LabelId {
-        let label = LabelId(self.label_counter);
+    fn fresh_label(&mut self) -> Label {
+        let label = Label::user(self.label_counter);
         self.label_counter += 1;
         label
     }
@@ -68,7 +68,7 @@ impl MirToInstructions {
     }
 
     /// Get or create a label for a block
-    fn get_label(&mut self, block: BlockId) -> LabelId {
+    fn get_label(&mut self, block: BlockId) -> Label {
         if let Some(&label) = self.block_to_label.get(&block) {
             label
         } else {
@@ -103,7 +103,7 @@ impl MirToInstructions {
     }
 
     /// Get the function labels mapping
-    pub fn get_function_labels(&self) -> HashMap<String, LabelId> {
+    pub fn get_function_labels(&self) -> HashMap<String, Label> {
         self.function_labels.clone()
     }
 

--- a/crates/rue-codegen/src/x86_emitter.rs
+++ b/crates/rue-codegen/src/x86_emitter.rs
@@ -8,7 +8,8 @@ pub struct X86Emitter {
     code: Vec<u8>,
     label_positions: HashMap<u32, usize>,
     pending_fixups: Vec<(usize, LabelRef)>,
-    function_labels: HashMap<String, crate::LabelId>,
+    function_labels: HashMap<String, crate::Label>,
+    runtime_label_count: u32,
 }
 
 impl X86Emitter {
@@ -18,12 +19,18 @@ impl X86Emitter {
             label_positions: HashMap::new(),
             pending_fixups: Vec::new(),
             function_labels: HashMap::new(),
+            runtime_label_count: 0,
         }
     }
 
-    pub fn set_function_labels(&mut self, labels: HashMap<String, crate::LabelId>) {
+    pub fn set_function_labels(
+        &mut self,
+        labels: HashMap<String, crate::Label>,
+        runtime_label_count: u32,
+    ) {
         // We'll use this to map function names to their label IDs
         self.function_labels = labels;
+        self.runtime_label_count = runtime_label_count;
     }
 
     /// Emit machine instructions to bytes
@@ -506,8 +513,9 @@ impl X86Emitter {
                         .ok_or_else(|| format!("Unknown function: {name}"))?;
 
                     // Get the position of this label
+                    let machine_id = label_id.to_machine_id(self.runtime_label_count);
                     self.label_positions
-                        .get(&label_id.0)
+                        .get(&machine_id)
                         .copied()
                         .ok_or_else(|| format!("Undefined label for function: {name}"))?
                 }
@@ -599,7 +607,8 @@ impl X86Emitter {
 
         // Add function names to symbol table
         for (name, label_id) in &self.function_labels {
-            if let Some(&pos) = self.label_positions.get(&label_id.0) {
+            let machine_id = label_id.to_machine_id(self.runtime_label_count);
+            if let Some(&pos) = self.label_positions.get(&machine_id) {
                 symbols.insert(name.clone(), pos);
             }
         }


### PR DESCRIPTION
Introduce Label struct with LabelSpace enum to distinguish between runtime and user labels. This eliminates manual offset calculations and prevents label ID conflicts.

- Add Label struct with Runtime/User space tracking
- Add to_machine_id() method to handle offset calculations  
- Update all codegen components to use Label instead of raw LabelId
- Preserve existing offset behavior but encapsulate it within the type system