### PR TITLE
Fix i32 arithmetic truncation after operations

### DIFF
--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -190,6 +190,14 @@ pub enum Instruction {
         rhs: Value,
         op: BinOp,
     },
+    // Type-aware binary operations (for proper i32 overflow handling)
+    TypedBinaryOp {
+        dest: VReg,
+        lhs: Value,
+        rhs: Value,
+        op: BinOp,
+        ty: rue_ir::types::RueType,
+    },
 
     // Memory operations
     Load {

--- a/crates/rue-codegen/src/lowering.rs
+++ b/crates/rue-codegen/src/lowering.rs
@@ -145,6 +145,13 @@ impl<'a> Lowering<'a> {
             Instruction::BinaryOp { dest, lhs, rhs, op } => {
                 self.lower_binary_op(*dest, lhs, rhs, op)
             }
+            Instruction::TypedBinaryOp {
+                dest,
+                lhs,
+                rhs,
+                op,
+                ty,
+            } => self.lower_typed_binary_op(*dest, lhs, rhs, op, ty),
             Instruction::Load { dest, offset } => self.lower_load(*dest, *offset),
             Instruction::Store { src, offset } => self.lower_store(*src, *offset),
             Instruction::Push { src } => self.lower_push(src),
@@ -495,6 +502,59 @@ impl<'a> Lowering<'a> {
                 self.lower_comparison(dest, lhs, rhs, op)
             }
         }
+    }
+
+    /// Lower a typed binary operation, handling i32 overflow properly
+    fn lower_typed_binary_op(
+        &mut self,
+        dest: VReg,
+        lhs: &Value,
+        rhs: &Value,
+        op: &BinOp,
+        ty: &rue_ir::types::RueType,
+    ) -> Result<(), LoweringError> {
+        use rue_ir::types::RueType;
+
+        if std::env::var("RUE_DEBUG").is_ok() {
+            eprintln!("lower_typed_binary_op: dest={dest:?}, op={op:?}, ty={ty:?}");
+        }
+
+        // For non-arithmetic operations, delegate to regular binary operation
+        if matches!(
+            op,
+            BinOp::Lt
+                | BinOp::Le
+                | BinOp::Gt
+                | BinOp::Ge
+                | BinOp::Eq
+                | BinOp::Ne
+                | BinOp::Div
+                | BinOp::Mod
+        ) {
+            return self.lower_binary_op(dest, lhs, rhs, op);
+        }
+
+        // First, perform the operation using regular binary operation logic
+        self.lower_binary_op(dest, lhs, rhs, op)?;
+
+        // For i32 operations, add truncation to handle overflow correctly
+        if matches!(ty, RueType::I32) {
+            let dest_reg = self.allocator.ensure_reg(dest, &[])?;
+            self.emit_spill_reload_ops();
+
+            if std::env::var("RUE_DEBUG").is_ok() {
+                eprintln!("Adding i32 truncation: dest_reg={dest_reg:?}");
+            }
+
+            // Truncate to 32-bit and sign-extend back to 64-bit
+            // This ensures i32 overflow wraps correctly (movsxd automatically truncates and sign-extends)
+            self.emit(MachineInstr::Movsxd {
+                dest: dest_reg,
+                src: dest_reg,
+            });
+        }
+
+        Ok(())
     }
 
     fn lower_modulo(&mut self, dest: VReg, lhs: &Value, rhs: &Value) -> Result<(), LoweringError> {

--- a/crates/rue-codegen/src/mir_to_instructions.rs
+++ b/crates/rue-codegen/src/mir_to_instructions.rs
@@ -36,6 +36,8 @@ pub struct MirToInstructions {
     block_param_stack_offset: i64,
     /// Stack offset per function (function name -> lowest stack offset used)
     function_stack_offsets: HashMap<String, i64>,
+    /// Type information for the current function's temporaries
+    current_temp_types: HashMap<Temp, rue_ir::types::RueType>,
 }
 
 impl MirToInstructions {
@@ -52,6 +54,7 @@ impl MirToInstructions {
             block_param_slots: HashMap::new(),
             block_param_stack_offset: -8, // Start after saved RBP
             function_stack_offsets: HashMap::new(),
+            current_temp_types: HashMap::new(),
         }
     }
 
@@ -150,6 +153,7 @@ impl MirToInstructions {
         // Note: We don't clear return_param_vregs because it needs to accumulate
         // across all functions in the program
         self.current_blocks = func.blocks.clone();
+        self.current_temp_types = func.temp_types.clone();
 
         // CRITICAL: Pre-allocate stack slots for ALL block parameters
         // This ensures consistent memory locations across all predecessor blocks
@@ -315,12 +319,26 @@ impl MirToInstructions {
                     MirBinOp::Ne => BinOp::Ne,
                 };
 
-                self.emit(Instruction::BinaryOp {
-                    dest,
-                    lhs: Value::VReg(lhs_vreg),
-                    rhs: Value::VReg(rhs_vreg),
-                    op: instr_op,
-                });
+                // Check if we have type information for the LHS operand
+                // For arithmetic operations, the result type should match the operand type
+                if let Some(lhs_ty) = self.current_temp_types.get(lhs) {
+                    // Use typed binary operation when type information is available
+                    self.emit(Instruction::TypedBinaryOp {
+                        dest,
+                        lhs: Value::VReg(lhs_vreg),
+                        rhs: Value::VReg(rhs_vreg),
+                        op: instr_op,
+                        ty: lhs_ty.clone(),
+                    });
+                } else {
+                    // Fall back to untyped operation
+                    self.emit(Instruction::BinaryOp {
+                        dest,
+                        lhs: Value::VReg(lhs_vreg),
+                        rhs: Value::VReg(rhs_vreg),
+                        op: instr_op,
+                    });
+                }
             }
             MirValue::UnaryOp { op, operand } => {
                 let operand_vreg = self.get_vreg(*operand);
@@ -556,6 +574,7 @@ mod tests {
             ],
             return_type: RueType::I32,
             entry_block: BlockId(0),
+            temp_types: std::collections::HashMap::new(),
             span: rue_lexer::Span::dummy(),
             blocks: vec![BasicBlock {
                 id: BlockId(0),

--- a/crates/rue-codegen/src/mir_to_instructions_test.rs
+++ b/crates/rue-codegen/src/mir_to_instructions_test.rs
@@ -14,6 +14,7 @@ fn make_simple_program(blocks: Vec<BasicBlock>) -> MirProgram {
             params: vec![],
             return_type: RueType::I32,
             entry_block: BlockId(0),
+            temp_types: std::collections::HashMap::new(),
             blocks,
             span: Span::dummy(),
         }],
@@ -347,6 +348,7 @@ fn test_lower_multiple_functions() {
                 params: vec![],
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
+                temp_types: std::collections::HashMap::new(),
                 blocks: vec![BasicBlock {
                     id: BlockId(0),
                     params: vec![],
@@ -371,6 +373,7 @@ fn test_lower_multiple_functions() {
                 params: vec![],
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
+                temp_types: std::collections::HashMap::new(),
                 blocks: vec![BasicBlock {
                     id: BlockId(0),
                     params: vec![],

--- a/crates/rue-ir/src/cfg.rs
+++ b/crates/rue-ir/src/cfg.rs
@@ -160,6 +160,7 @@ mod tests {
             params: vec![],
             return_type: RueType::I32,
             entry_block: BlockId(0),
+            temp_types: std::collections::HashMap::new(),
             span: Span::dummy(),
             blocks: vec![
                 BasicBlock {
@@ -203,6 +204,7 @@ mod tests {
             params: vec![],
             return_type: RueType::I32,
             entry_block: BlockId(0),
+            temp_types: std::collections::HashMap::new(),
             span: Span::dummy(),
             blocks: vec![
                 BasicBlock {

--- a/crates/rue-ir/src/mir.rs
+++ b/crates/rue-ir/src/mir.rs
@@ -62,6 +62,8 @@ pub struct MirFunction {
     pub blocks: Vec<BasicBlock>,
     /// The entry block ID (always the first block)
     pub entry_block: BlockId,
+    /// Type information for all temporaries in this function
+    pub temp_types: std::collections::HashMap<Temp, RueType>,
     /// Source span for debugging
     pub span: Span,
 }
@@ -553,6 +555,7 @@ mod tests {
             ],
             return_type: RueType::I32,
             entry_block: BlockId(0),
+            temp_types: std::collections::HashMap::new(),
             span: Span::dummy(),
             blocks: vec![BasicBlock {
                 id: BlockId(0),
@@ -638,6 +641,7 @@ mod tests {
             params: vec![("x".to_string(), RueType::I32)],
             return_type: RueType::I32,
             entry_block: BlockId(0),
+            temp_types: std::collections::HashMap::new(),
             span: Span::dummy(),
             blocks: vec![
                 BasicBlock {

--- a/crates/rue-ir/src/mir_lowering.rs
+++ b/crates/rue-ir/src/mir_lowering.rs
@@ -204,6 +204,7 @@ impl MirBuilder {
             return_type: func.return_type.clone(),
             blocks: builder.blocks,
             entry_block,
+            temp_types: builder.temp_types,
             span: func.span,
         };
 

--- a/crates/rue-lowering/src/hir_to_mir.rs
+++ b/crates/rue-lowering/src/hir_to_mir.rs
@@ -230,6 +230,7 @@ impl MirBuilder {
             return_type: func.return_type.clone(),
             blocks: builder.blocks,
             entry_block,
+            temp_types: builder.temp_types,
             span: func.span,
         };
 

--- a/crates/rue-lowering/src/verifier.rs
+++ b/crates/rue-lowering/src/verifier.rs
@@ -514,6 +514,8 @@ mod tests {
                 params: vec![],
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
+                temp_types: HashMap::new(),
+                span: Span::dummy(),
                 blocks: vec![BasicBlock {
                     id: BlockId(0),
                     params: vec![],
@@ -527,7 +529,6 @@ mod tests {
                         span: None,
                     },
                 }],
-                span: Span::dummy(),
             }],
         };
 
@@ -543,6 +544,8 @@ mod tests {
                 params: vec![],
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
+                temp_types: HashMap::new(),
+                span: Span::dummy(),
                 blocks: vec![BasicBlock {
                     id: BlockId(0),
                     params: vec![],
@@ -552,7 +555,6 @@ mod tests {
                         span: None,
                     },
                 }],
-                span: Span::dummy(),
             }],
         };
 
@@ -572,6 +574,8 @@ mod tests {
                 params: vec![],
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
+                temp_types: HashMap::new(),
+                span: Span::dummy(),
                 blocks: vec![BasicBlock {
                     id: BlockId(0),
                     params: vec![],
@@ -592,7 +596,6 @@ mod tests {
                         span: None,
                     },
                 }],
-                span: Span::dummy(),
             }],
         };
 
@@ -611,6 +614,8 @@ mod tests {
                 params: vec![],
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
+                temp_types: HashMap::new(),
+                span: Span::dummy(),
                 blocks: vec![
                     BasicBlock {
                         id: BlockId(0),
@@ -632,7 +637,6 @@ mod tests {
                         },
                     },
                 ],
-                span: Span::dummy(),
             }],
         };
 

--- a/crates/rue-optimize/src/passes/const_prop.rs
+++ b/crates/rue-optimize/src/passes/const_prop.rs
@@ -214,6 +214,7 @@ mod tests {
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
                 span: Span::dummy(),
+                temp_types: HashMap::new(),
                 blocks: vec![BasicBlock {
                     id: BlockId(0),
                     params: vec![],
@@ -274,6 +275,7 @@ mod tests {
                 return_type: RueType::Unit,
                 entry_block: BlockId(0),
                 span: Span::dummy(),
+                temp_types: HashMap::new(),
                 blocks: vec![
                     BasicBlock {
                         id: BlockId(0),

--- a/crates/rue-optimize/src/passes/cse.rs
+++ b/crates/rue-optimize/src/passes/cse.rs
@@ -153,6 +153,7 @@ mod tests {
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
                 span: Span::dummy(),
+                temp_types: HashMap::new(),
                 blocks: vec![BasicBlock {
                     id: BlockId(0),
                     params: vec![],
@@ -224,6 +225,7 @@ mod tests {
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
                 span: Span::dummy(),
+                temp_types: HashMap::new(),
                 blocks: vec![BasicBlock {
                     id: BlockId(0),
                     params: vec![],
@@ -293,6 +295,7 @@ mod tests {
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
                 span: Span::dummy(),
+                temp_types: HashMap::new(),
                 blocks: vec![BasicBlock {
                     id: BlockId(0),
                     params: vec![],

--- a/crates/rue-optimize/src/passes/dead_code.rs
+++ b/crates/rue-optimize/src/passes/dead_code.rs
@@ -275,6 +275,7 @@ mod tests {
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
                 span: Span::dummy(),
+                temp_types: HashMap::new(),
                 blocks: vec![BasicBlock {
                     id: BlockId(0),
                     params: vec![],
@@ -345,6 +346,7 @@ mod tests {
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
                 span: Span::dummy(),
+                temp_types: HashMap::new(),
                 blocks: vec![BasicBlock {
                     id: BlockId(0),
                     params: vec![],

--- a/crates/rue/tests/runtime_edge_cases.rs
+++ b/crates/rue/tests/runtime_edge_cases.rs
@@ -578,12 +578,9 @@ fn test_modulo_wrapping_behavior() {
 
     let (exit_code, output) = compile_and_run(source, None).unwrap();
     assert_eq!(exit_code, 0);
-    // max + 2 = -2147483647 (in true i32)
-    // However, our i32 values are stored in 64-bit registers
-    // So max + 2 = 2147483649 (no wrap in 64-bit)
-    // 2147483649 % 10 = 9
-    // TODO: Fix i32 arithmetic to properly truncate to 32 bits after operations
-    assert_eq!(output.trim(), "-2147483647\n9");
+    // max + 2 = -2147483647 (properly wrapped in i32)
+    // -2147483647 % 10 = -7 (using truncated division)
+    assert_eq!(output.trim(), "-2147483647\n-7");
 }
 
 #[test]

--- a/docs/spec.md
+++ b/docs/spec.md
@@ -357,12 +357,20 @@ Variable references evaluate to the current value of the variable.
 Binary operations are evaluated left-to-right according to precedence:
 
 **Arithmetic Operations** (require matching numeric types):
-- `+`: Addition (wrapping on overflow)
-- `-`: Subtraction (wrapping on overflow)  
-- `*`: Multiplication (wrapping on overflow)
+- `+`: Addition (wrapping on overflow using two's complement)
+- `-`: Subtraction (wrapping on overflow using two's complement)  
+- `*`: Multiplication (wrapping on overflow using two's complement)
 - `/`: Division (program aborts on division by zero)
 - `%`: Modulo (program aborts on division by zero)
-  - TODO: Specify that modulo uses truncated division (same as Rust/C)
+  - Modulo uses truncated division semantics (same as Rust/C)
+  - For negative dividends: `-5 % 3 = -2`, `5 % -3 = 2`, `-5 % -3 = -2`
+
+**Overflow Behavior**:
+- Both `i32` and `i64` arithmetic operations wrap on overflow using two's complement arithmetic
+- For `i32`: operations are performed, then the result is truncated to 32 bits
+  - Example: `2147483647 + 1` wraps to `-2147483648` (i32::MAX + 1 = i32::MIN)
+- For `i64`: operations wrap at 64-bit boundaries
+  - Example: `9223372036854775807 + 1` wraps to `-9223372036854775808` (i64::MAX + 1 = i64::MIN)
 
 **Comparison Operations** (require matching types, return `bool`):
 - `<=`, `>=`, `<`, `>`: Comparison (returns `true` or `false`)


### PR DESCRIPTION
Previously, i32 arithmetic operations were performed in 64-bit registers without truncating the result back to 32 bits. This caused overflow behavior to differ from the specification.

The fix adds type information propagation through the compilation pipeline:
- Added temp_types field to MirFunction to preserve type information
- Created TypedBinaryOp instruction for type-aware code generation
- Added movsxd instruction after i32 arithmetic to truncate to 32 bits

This ensures i32 values properly wrap at 32-bit boundaries per the spec.

Fixes #85