### PR TITLE
Add function signature tracking to MIR and refactor emit helpers

### DIFF
--- a/crates/rue-codegen/src/mir_to_instructions.rs
+++ b/crates/rue-codegen/src/mir_to_instructions.rs
@@ -597,6 +597,7 @@ mod tests {
 
         let mir_program = MirProgram {
             functions: vec![mir_func],
+            function_signatures: HashMap::new(),
         };
 
         let mut lowerer = MirToInstructions::new();

--- a/crates/rue-codegen/src/mir_to_instructions_test.rs
+++ b/crates/rue-codegen/src/mir_to_instructions_test.rs
@@ -18,6 +18,7 @@ fn make_simple_program(blocks: Vec<BasicBlock>) -> MirProgram {
             blocks,
             span: Span::dummy(),
         }],
+        function_signatures: std::collections::HashMap::new(),
     }
 }
 
@@ -390,6 +391,7 @@ fn test_lower_multiple_functions() {
                 span: Span::dummy(),
             },
         ],
+        function_signatures: std::collections::HashMap::new(),
     };
 
     let mut lowerer = MirToInstructions::new();

--- a/crates/rue-ir/src/lib.rs
+++ b/crates/rue-ir/src/lib.rs
@@ -7,5 +7,7 @@
 pub mod cfg;
 pub mod hir;
 pub mod mir;
+pub mod mir_lowering;
+pub mod mir_verifier;
 pub mod target;
 pub mod types;

--- a/crates/rue-ir/src/mir.rs
+++ b/crates/rue-ir/src/mir.rs
@@ -32,6 +32,7 @@
 
 use crate::types::RueType;
 use rue_lexer::Span;
+use std::collections::HashMap;
 use std::fmt;
 
 /// A unique identifier for a basic block
@@ -42,11 +43,22 @@ pub struct BlockId(pub u32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Temp(pub u32);
 
+/// Function signature information
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FunctionSignature {
+    /// Parameter types in order
+    pub param_types: Vec<RueType>,
+    /// Return type
+    pub return_type: RueType,
+}
+
 /// A complete MIR program
 #[derive(Debug, Clone, PartialEq)]
 pub struct MirProgram {
     /// All functions in the program
     pub functions: Vec<MirFunction>,
+    /// Function signatures for all functions (builtin and user-defined)
+    pub function_signatures: HashMap<String, FunctionSignature>,
 }
 
 /// A function in MIR form
@@ -304,6 +316,24 @@ impl fmt::Display for Temp {
 
 impl fmt::Display for MirProgram {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Display function signatures first if any exist
+        if !self.function_signatures.is_empty() {
+            writeln!(f, "// Function signatures:")?;
+            let mut sigs: Vec<_> = self.function_signatures.iter().collect();
+            sigs.sort_by_key(|(name, _)| *name);
+            for (name, sig) in sigs {
+                write!(f, "// {name}(")?;
+                for (i, ty) in sig.param_types.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{ty}")?;
+                }
+                writeln!(f, ") -> {}", sig.return_type)?;
+            }
+            writeln!(f)?;
+        }
+
         for (i, func) in self.functions.iter().enumerate() {
             if i > 0 {
                 writeln!(f)?;
@@ -555,7 +585,7 @@ mod tests {
             ],
             return_type: RueType::I32,
             entry_block: BlockId(0),
-            temp_types: std::collections::HashMap::new(),
+            temp_types: HashMap::new(),
             span: Span::dummy(),
             blocks: vec![BasicBlock {
                 id: BlockId(0),
@@ -641,7 +671,7 @@ mod tests {
             params: vec![("x".to_string(), RueType::I32)],
             return_type: RueType::I32,
             entry_block: BlockId(0),
-            temp_types: std::collections::HashMap::new(),
+            temp_types: HashMap::new(),
             span: Span::dummy(),
             blocks: vec![
                 BasicBlock {

--- a/crates/rue-ir/src/mir_lowering.rs
+++ b/crates/rue-ir/src/mir_lowering.rs
@@ -11,8 +11,8 @@ use crate::hir::{
     UnaryOp as HirUnaryOp,
 };
 use crate::mir::{
-    BasicBlock, BlockId, MirBinOp, MirConst, MirFunction, MirProgram, MirStatement, MirTerminator,
-    MirUnaryOp, MirValue, Temp,
+    BasicBlock, BlockId, FunctionSignature, MirBinOp, MirConst, MirFunction, MirProgram,
+    MirStatement, MirTerminator, MirUnaryOp, MirValue, Temp,
 };
 use crate::types::RueType;
 use std::collections::HashMap;
@@ -88,7 +88,14 @@ impl MirBuilder {
     }
 
     /// Create a new temporary and assign a binary operation to it
-    fn emit_binop(&mut self, op: MirBinOp, lhs: Temp, rhs: Temp, result_ty: RueType, span: Option<rue_lexer::Span>) -> Temp {
+    fn emit_binop(
+        &mut self,
+        op: MirBinOp,
+        lhs: Temp,
+        rhs: Temp,
+        result_ty: RueType,
+        span: Option<rue_lexer::Span>,
+    ) -> Temp {
         let temp = self.fresh_temp(result_ty);
         self.add_statement(MirStatement::Assign {
             dest: temp,
@@ -99,7 +106,13 @@ impl MirBuilder {
     }
 
     /// Create a new temporary and assign a unary operation to it
-    fn emit_unop(&mut self, op: MirUnaryOp, operand: Temp, result_ty: RueType, span: Option<rue_lexer::Span>) -> Temp {
+    fn emit_unop(
+        &mut self,
+        op: MirUnaryOp,
+        operand: Temp,
+        result_ty: RueType,
+        span: Option<rue_lexer::Span>,
+    ) -> Temp {
         let temp = self.fresh_temp(result_ty);
         self.add_statement(MirStatement::Assign {
             dest: temp,
@@ -110,7 +123,14 @@ impl MirBuilder {
     }
 
     /// Create a new temporary and assign a function call to it
-    fn emit_call(&mut self, func: String, args: Vec<Temp>, kind: crate::mir::CallKind, return_ty: RueType, span: Option<rue_lexer::Span>) -> Temp {
+    fn emit_call(
+        &mut self,
+        func: String,
+        args: Vec<Temp>,
+        kind: crate::mir::CallKind,
+        return_ty: RueType,
+        span: Option<rue_lexer::Span>,
+    ) -> Temp {
         let temp = self.fresh_temp(return_ty);
         self.add_statement(MirStatement::Assign {
             dest: temp,
@@ -129,7 +149,10 @@ impl MirBuilder {
             id,
             params,
             statements: Vec::new(),
-            terminator: MirTerminator::Return { value: None, span: None }, // Placeholder
+            terminator: MirTerminator::Return {
+                value: None,
+                span: None,
+            }, // Placeholder
         });
     }
 
@@ -157,13 +180,117 @@ impl MirBuilder {
     /// Lower a HIR program to MIR
     pub fn lower_program(hir: &HirProgram) -> MirProgram {
         let mut functions = Vec::new();
+        let mut function_signatures = HashMap::new();
 
+        // First pass: collect all function signatures (both user-defined and builtin)
+        // Add builtin function signatures
+        Self::add_builtin_function_signatures(&mut function_signatures);
+
+        // Add user-defined function signatures
+        for hir_func in &hir.functions {
+            let sig = FunctionSignature {
+                param_types: hir_func.params.iter().map(|(_, ty)| ty.clone()).collect(),
+                return_type: hir_func.return_type.clone(),
+            };
+            function_signatures.insert(hir_func.name.clone(), sig);
+        }
+
+        // Second pass: lower functions to MIR
         for hir_func in &hir.functions {
             let mir_func = Self::lower_function(hir_func);
             functions.push(mir_func);
         }
 
-        MirProgram { functions }
+        MirProgram {
+            functions,
+            function_signatures,
+        }
+    }
+
+    /// Add builtin function signatures to the function registry
+    fn add_builtin_function_signatures(signatures: &mut HashMap<String, FunctionSignature>) {
+        // I/O functions
+        signatures.insert(
+            "println_i32".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::I32],
+                return_type: RueType::Unit,
+            },
+        );
+        signatures.insert(
+            "println_i64".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::I64],
+                return_type: RueType::Unit,
+            },
+        );
+        signatures.insert(
+            "println_bool".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::Bool],
+                return_type: RueType::Unit,
+            },
+        );
+        signatures.insert(
+            "println_unit".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::Unit],
+                return_type: RueType::Unit,
+            },
+        );
+        signatures.insert(
+            "input".to_string(),
+            FunctionSignature {
+                param_types: vec![],
+                return_type: RueType::I64,
+            },
+        );
+        signatures.insert(
+            "input_i32".to_string(),
+            FunctionSignature {
+                param_types: vec![],
+                return_type: RueType::I32,
+            },
+        );
+        signatures.insert(
+            "input_i64".to_string(),
+            FunctionSignature {
+                param_types: vec![],
+                return_type: RueType::I64,
+            },
+        );
+
+        // Type conversion functions
+        signatures.insert(
+            "to_i32".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::I64],
+                return_type: RueType::I32,
+            },
+        );
+        signatures.insert(
+            "to_i64".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::I32],
+                return_type: RueType::I64,
+            },
+        );
+        signatures.insert(
+            "to_bool".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::I32],
+                return_type: RueType::Bool,
+            },
+        );
+
+        // System functions
+        signatures.insert(
+            "exit".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::I64],
+                return_type: RueType::Unit,
+            },
+        );
     }
 
     /// Lower a HIR function to MIR
@@ -194,7 +321,10 @@ impl MirBuilder {
 
         // Set return terminator if we haven't already returned
         if builder.current_block.is_some() {
-            builder.set_terminator(MirTerminator::Return { value: result, span: None });
+            builder.set_terminator(MirTerminator::Return {
+                value: result,
+                span: None,
+            });
             builder.finish_block();
         }
 
@@ -288,14 +418,7 @@ impl MirBuilder {
                     HirLiteral::Bool(b) => MirConst::Bool(*b),
                     HirLiteral::Unit => MirConst::Unit,
                 };
-                let ty = const_val.ty();
-                let temp = self.fresh_temp(ty);
-                self.add_statement(MirStatement::Assign {
-                    dest: temp,
-                    value: MirValue::Const(const_val),
-                    span: Some(*span),
-                });
-                temp
+                self.emit_const(const_val, Some(*span))
             }
             HirExpr::Var {
                 name,
@@ -332,7 +455,6 @@ impl MirBuilder {
 
                 // Restore is_function_body
                 self.is_function_body = saved_is_function_body;
-                let result_temp = self.fresh_temp(ty.clone());
 
                 let mir_op = match op {
                     HirBinOp::Add => MirBinOp::Add,
@@ -348,16 +470,7 @@ impl MirBuilder {
                     HirBinOp::Ne => MirBinOp::Ne,
                 };
 
-                self.add_statement(MirStatement::Assign {
-                    dest: result_temp,
-                    value: MirValue::BinaryOp {
-                        op: mir_op,
-                        lhs: lhs_temp,
-                        rhs: rhs_temp,
-                    },
-                    span: Some(*span),
-                });
-                result_temp
+                self.emit_binop(mir_op, lhs_temp, rhs_temp, ty.clone(), Some(*span))
             }
             HirExpr::Unary { op, expr, ty, span } => {
                 // Save and clear is_function_body for sub-expressions
@@ -368,21 +481,12 @@ impl MirBuilder {
 
                 // Restore is_function_body
                 self.is_function_body = saved_is_function_body;
-                let result_temp = self.fresh_temp(ty.clone());
 
                 let mir_op = match op {
                     HirUnaryOp::Neg => MirUnaryOp::Neg,
                 };
 
-                self.add_statement(MirStatement::Assign {
-                    dest: result_temp,
-                    value: MirValue::UnaryOp {
-                        op: mir_op,
-                        operand: operand_temp,
-                    },
-                    span: Some(*span),
-                });
-                result_temp
+                self.emit_unop(mir_op, operand_temp, ty.clone(), Some(*span))
             }
             HirExpr::Call {
                 func,
@@ -398,17 +502,17 @@ impl MirBuilder {
 
                 // Restore is_function_body
                 self.is_function_body = saved_is_function_body;
-                
+
                 // For now, assume all function calls are impure (conservative approach)
                 // This can be refined later with function signature analysis or annotations
-                let result_temp = self.emit_call(
-                    func.clone(), 
-                    arg_temps, 
-                    crate::mir::CallKind::Impure, 
-                    ty.clone(), 
-                    Some(*span)
-                );
-                result_temp
+
+                self.emit_call(
+                    func.clone(),
+                    arg_temps,
+                    crate::mir::CallKind::Impure,
+                    ty.clone(),
+                    Some(*span),
+                )
             }
             HirExpr::If {
                 cond,
@@ -420,12 +524,7 @@ impl MirBuilder {
             HirExpr::While { cond, body, span } => {
                 self.lower_while_expr(cond, body);
                 // While always returns unit
-                let unit_temp = self.fresh_temp(RueType::Unit);
-                self.add_statement(MirStatement::Assign {
-                    dest: unit_temp,
-                    value: MirValue::Const(MirConst::Unit),
-                    span: Some(*span),
-                });
+                let unit_temp = self.emit_const(MirConst::Unit, Some(*span));
                 if std::env::var("RUE_DEBUG").is_ok() {
                     eprintln!("While expr returns unit temp: {unit_temp:?}");
                 }
@@ -529,13 +628,7 @@ impl MirBuilder {
         self.is_function_body = false;
         let then_result = then_value.unwrap_or_else(|| {
             // If no expression, use unit
-            let temp = self.fresh_temp(RueType::Unit);
-            self.add_statement(MirStatement::Assign {
-                dest: temp,
-                value: MirValue::Const(MirConst::Unit),
-                span: None,
-            });
-            temp
+            self.emit_const(MirConst::Unit, None)
         });
 
         // Collect variables after then block
@@ -602,24 +695,10 @@ impl MirBuilder {
         self.is_function_body = saved_is_function_body;
         let else_result = if let Some(else_blk) = else_block {
             let else_value = self.lower_block(else_blk);
-            else_value.unwrap_or_else(|| {
-                let temp = self.fresh_temp(RueType::Unit);
-                self.add_statement(MirStatement::Assign {
-                    dest: temp,
-                    value: MirValue::Const(MirConst::Unit),
-                    span: None,
-                });
-                temp
-            })
+            else_value.unwrap_or_else(|| self.emit_const(MirConst::Unit, None))
         } else {
             // No else block - return unit
-            let temp = self.fresh_temp(RueType::Unit);
-            self.add_statement(MirStatement::Assign {
-                dest: temp,
-                value: MirValue::Const(MirConst::Unit),
-                span: None,
-            });
-            temp
+            self.emit_const(MirConst::Unit, None)
         };
         self.is_function_body = false;
 

--- a/crates/rue-ir/src/mir_verifier.rs
+++ b/crates/rue-ir/src/mir_verifier.rs
@@ -22,6 +22,7 @@ pub struct VerificationError {
 pub struct MirVerifier {
     errors: Vec<VerificationError>,
     current_function: String,
+    function_signatures: HashMap<String, crate::mir::FunctionSignature>,
 }
 
 impl Default for MirVerifier {
@@ -35,11 +36,15 @@ impl MirVerifier {
         Self {
             errors: Vec::new(),
             current_function: String::new(),
+            function_signatures: HashMap::new(),
         }
     }
 
     /// Verify an entire MIR program
     pub fn verify_program(&mut self, program: &MirProgram) -> Result<(), Vec<VerificationError>> {
+        // Store function signatures for use during verification
+        self.function_signatures = program.function_signatures.clone();
+
         for function in &program.functions {
             self.verify_function(function);
         }
@@ -150,9 +155,11 @@ impl MirVerifier {
                     MirValue::Call { args, func, .. } => {
                         // Debug output
                         if std::env::var("RUE_DEBUG_MIR").is_ok() {
-                            eprintln!("DEBUG: Processing call assignment: {dest:?} = {func}({args:?})");
+                            eprintln!(
+                                "DEBUG: Processing call assignment: {dest:?} = {func}({args:?})"
+                            );
                         }
-                        
+
                         // Verify all arguments are defined
                         for arg in args {
                             if !defined_temps.contains_key(arg) {
@@ -162,15 +169,54 @@ impl MirVerifier {
                                 );
                             }
                         }
-                        
-                        // For calls, we infer the return type from the function signature
-                        // For now, we'll use a placeholder approach and mark the dest as defined
-                        // with an inferred type based on common function signatures
-                        let inferred_type = self.infer_call_return_type(func);
-                        if std::env::var("RUE_DEBUG_MIR").is_ok() {
-                            eprintln!("DEBUG: Inferred type for {func}: {inferred_type:?}, marking {dest:?} as defined");
+
+                        // Look up the function signature
+                        if let Some(signature) = self.function_signatures.get(func).cloned() {
+                            // Verify argument count
+                            if args.len() != signature.param_types.len() {
+                                self.add_error(
+                                    format!(
+                                        "Function {func} expects {} arguments but got {}",
+                                        signature.param_types.len(),
+                                        args.len()
+                                    ),
+                                    Some(block_id),
+                                );
+                            } else {
+                                // Verify argument types match
+                                for (i, (arg, expected_ty)) in
+                                    args.iter().zip(&signature.param_types).enumerate()
+                                {
+                                    if let Some(arg_ty) = defined_temps.get(arg) {
+                                        if arg_ty != expected_ty {
+                                            self.add_error(
+                                                format!(
+                                                    "Type mismatch in call to {func}: argument {i} has type {arg_ty:?} but expected {expected_ty:?}"
+                                                ),
+                                                Some(block_id),
+                                            );
+                                        }
+                                    }
+                                }
+                            }
+
+                            // Mark destination with the function's return type
+                            if std::env::var("RUE_DEBUG_MIR").is_ok() {
+                                eprintln!(
+                                    "DEBUG: Function {func} returns {:?}, marking {dest:?} as defined",
+                                    signature.return_type
+                                );
+                            }
+                            defined_temps.insert(*dest, signature.return_type);
+                        } else {
+                            // Unknown function - this should have been caught during semantic analysis
+                            self.add_error(
+                                format!("Call to unknown function: {func}"),
+                                Some(block_id),
+                            );
+                            // Mark dest with a placeholder type to avoid cascading errors
+                            defined_temps.insert(*dest, RueType::I32);
                         }
-                        defined_temps.insert(*dest, inferred_type);
                     }
                     _ => {
                         // For non-call values, use the original logic
@@ -270,14 +316,43 @@ impl MirVerifier {
                 func,
                 kind: _,
             } => {
-                // Verify all arguments are defined
-                for arg in args {
-                    if !defined_temps.contains_key(arg) {
+                // Verify all arguments are defined and have correct types
+                if let Some(signature) = self.function_signatures.get(func).cloned() {
+                    // Verify argument count
+                    if args.len() != signature.param_types.len() {
                         self.add_error(
-                            format!("Use of undefined temp {arg:?} in call to {func}"),
+                            format!(
+                                "Function {func} expects {} arguments but got {}",
+                                signature.param_types.len(),
+                                args.len()
+                            ),
                             Some(block_id),
                         );
                     }
+
+                    // Verify each argument
+                    for (i, (arg, expected_ty)) in
+                        args.iter().zip(&signature.param_types).enumerate()
+                    {
+                        if let Some(arg_ty) = defined_temps.get(arg) {
+                            if arg_ty != expected_ty {
+                                self.add_error(
+                                    format!(
+                                        "Type mismatch in call to {func}: argument {i} has type {arg_ty:?} but expected {expected_ty:?}"
+                                    ),
+                                    Some(block_id),
+                                );
+                            }
+                        } else {
+                            self.add_error(
+                                format!("Use of undefined temp {arg:?} in call to {func}"),
+                                Some(block_id),
+                            );
+                        }
+                    }
+                } else {
+                    // Unknown function
+                    self.add_error(format!("Call to unknown function: {func}"), Some(block_id));
                 }
                 // Call return type needs to be determined from assignment context
                 // For now, return None to indicate the type should come from the dest
@@ -335,7 +410,13 @@ impl MirVerifier {
 
                 // Verify all target jumps
                 for (_, target_block, target_args) in targets {
-                    self.verify_jump(*target_block, target_args, block_id, block_map, defined_temps);
+                    self.verify_jump(
+                        *target_block,
+                        target_args,
+                        block_id,
+                        block_map,
+                        defined_temps,
+                    );
                 }
 
                 // Verify default jump
@@ -443,9 +524,7 @@ impl MirVerifier {
                         worklist.push(*else_block);
                     }
                     MirTerminator::Switch {
-                        targets,
-                        default,
-                        ..
+                        targets, default, ..
                     } => {
                         // Add all target blocks from switch cases
                         for (_, target_block, _) in targets {
@@ -460,38 +539,6 @@ impl MirVerifier {
         }
 
         reachable
-    }
-
-    /// Infer the return type of a function call based on its name
-    /// This is a temporary solution until we have proper function signature tracking
-    fn infer_call_return_type(&self, func_name: &str) -> RueType {
-        match func_name {
-            // Casting functions
-            "to_i32" => RueType::I32,
-            "to_i64" => RueType::I64,
-            "to_bool" => RueType::Bool,
-            
-            // I/O functions  
-            "println_i32" | "println_i64" | "println_bool" => RueType::Unit,
-            "input_i32" => RueType::I32,
-            "input_i64" => RueType::I64,
-            
-            // For recursive functions, we need to infer from context
-            // For now, assume i32 as a reasonable default for unknown functions
-            _ => {
-                // Try to infer from the current function context
-                // If we're in a function that returns a specific type, assume that
-                // This is a heuristic for recursive calls
-                if func_name == self.current_function {
-                    // For recursive calls, we'd need to look up the function's return type
-                    // For now, assume i32 as the most common case
-                    RueType::I32
-                } else {
-                    // For unknown functions, assume i32 as default
-                    RueType::I32
-                }
-            }
-        }
     }
 
     /// Add an error to the list
@@ -518,6 +565,7 @@ mod tests {
                 params: vec![],
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
+                temp_types: HashMap::new(),
                 blocks: vec![BasicBlock {
                     id: BlockId(0),
                     params: vec![],
@@ -533,6 +581,7 @@ mod tests {
                 }],
                 span: Span::dummy(),
             }],
+            function_signatures: HashMap::new(),
         };
 
         let mut verifier = MirVerifier::new();
@@ -547,6 +596,7 @@ mod tests {
                 params: vec![],
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
+                temp_types: HashMap::new(),
                 blocks: vec![BasicBlock {
                     id: BlockId(0),
                     params: vec![],
@@ -558,6 +608,7 @@ mod tests {
                 }],
                 span: Span::dummy(),
             }],
+            function_signatures: HashMap::new(),
         };
 
         let mut verifier = MirVerifier::new();
@@ -576,6 +627,7 @@ mod tests {
                 params: vec![],
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
+                temp_types: HashMap::new(),
                 blocks: vec![BasicBlock {
                     id: BlockId(0),
                     params: vec![],
@@ -598,6 +650,7 @@ mod tests {
                 }],
                 span: Span::dummy(),
             }],
+            function_signatures: HashMap::new(),
         };
 
         let mut verifier = MirVerifier::new();
@@ -615,6 +668,7 @@ mod tests {
                 params: vec![],
                 return_type: RueType::I32,
                 entry_block: BlockId(0),
+                temp_types: HashMap::new(),
                 blocks: vec![
                     BasicBlock {
                         id: BlockId(0),
@@ -638,6 +692,7 @@ mod tests {
                 ],
                 span: Span::dummy(),
             }],
+            function_signatures: HashMap::new(),
         };
 
         let mut verifier = MirVerifier::new();

--- a/crates/rue-ir/src/types.rs
+++ b/crates/rue-ir/src/types.rs
@@ -1,6 +1,6 @@
 use std::fmt;
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RueType {
     I32,
     I64,

--- a/crates/rue-lowering/src/hir_to_mir.rs
+++ b/crates/rue-lowering/src/hir_to_mir.rs
@@ -11,8 +11,8 @@ use rue_ir::hir::{
     UnaryOp as HirUnaryOp,
 };
 use rue_ir::mir::{
-    BasicBlock, BlockId, MirBinOp, MirConst, MirFunction, MirProgram, MirStatement, MirTerminator,
-    MirUnaryOp, MirValue, Temp,
+    BasicBlock, BlockId, FunctionSignature, MirBinOp, MirConst, MirFunction, MirProgram,
+    MirStatement, MirTerminator, MirUnaryOp, MirValue, Temp,
 };
 use rue_ir::types::RueType;
 use std::collections::HashMap;
@@ -180,13 +180,117 @@ impl MirBuilder {
     /// Lower a HIR program to MIR
     pub fn lower_program(hir: &HirProgram) -> MirProgram {
         let mut functions = Vec::new();
+        let mut function_signatures = HashMap::new();
 
+        // First pass: collect all function signatures (both user-defined and builtin)
+        // Add builtin function signatures
+        Self::add_builtin_function_signatures(&mut function_signatures);
+
+        // Add user-defined function signatures
+        for hir_func in &hir.functions {
+            let sig = FunctionSignature {
+                param_types: hir_func.params.iter().map(|(_, ty)| ty.clone()).collect(),
+                return_type: hir_func.return_type.clone(),
+            };
+            function_signatures.insert(hir_func.name.clone(), sig);
+        }
+
+        // Second pass: lower functions to MIR
         for hir_func in &hir.functions {
             let mir_func = Self::lower_function(hir_func);
             functions.push(mir_func);
         }
 
-        MirProgram { functions }
+        MirProgram {
+            functions,
+            function_signatures,
+        }
+    }
+
+    /// Add builtin function signatures to the function registry
+    fn add_builtin_function_signatures(signatures: &mut HashMap<String, FunctionSignature>) {
+        // I/O functions
+        signatures.insert(
+            "println_i32".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::I32],
+                return_type: RueType::Unit,
+            },
+        );
+        signatures.insert(
+            "println_i64".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::I64],
+                return_type: RueType::Unit,
+            },
+        );
+        signatures.insert(
+            "println_bool".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::Bool],
+                return_type: RueType::Unit,
+            },
+        );
+        signatures.insert(
+            "println_unit".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::Unit],
+                return_type: RueType::Unit,
+            },
+        );
+        signatures.insert(
+            "input".to_string(),
+            FunctionSignature {
+                param_types: vec![],
+                return_type: RueType::I64,
+            },
+        );
+        signatures.insert(
+            "input_i32".to_string(),
+            FunctionSignature {
+                param_types: vec![],
+                return_type: RueType::I32,
+            },
+        );
+        signatures.insert(
+            "input_i64".to_string(),
+            FunctionSignature {
+                param_types: vec![],
+                return_type: RueType::I64,
+            },
+        );
+
+        // Type conversion functions
+        signatures.insert(
+            "to_i32".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::I64],
+                return_type: RueType::I32,
+            },
+        );
+        signatures.insert(
+            "to_i64".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::I32],
+                return_type: RueType::I64,
+            },
+        );
+        signatures.insert(
+            "to_bool".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::I32],
+                return_type: RueType::Bool,
+            },
+        );
+
+        // System functions
+        signatures.insert(
+            "exit".to_string(),
+            FunctionSignature {
+                param_types: vec![RueType::I64],
+                return_type: RueType::Unit,
+            },
+        );
     }
 
     /// Lower a HIR function to MIR

--- a/crates/rue-lowering/src/verifier.rs
+++ b/crates/rue-lowering/src/verifier.rs
@@ -530,6 +530,7 @@ mod tests {
                     },
                 }],
             }],
+            function_signatures: HashMap::new(),
         };
 
         let mut verifier = MirVerifier::new();
@@ -556,6 +557,7 @@ mod tests {
                     },
                 }],
             }],
+            function_signatures: HashMap::new(),
         };
 
         let mut verifier = MirVerifier::new();
@@ -597,6 +599,7 @@ mod tests {
                     },
                 }],
             }],
+            function_signatures: HashMap::new(),
         };
 
         let mut verifier = MirVerifier::new();
@@ -638,6 +641,7 @@ mod tests {
                     },
                 ],
             }],
+            function_signatures: HashMap::new(),
         };
 
         let mut verifier = MirVerifier::new();

--- a/crates/rue-optimize/src/passes/const_prop.rs
+++ b/crates/rue-optimize/src/passes/const_prop.rs
@@ -245,6 +245,7 @@ mod tests {
                     },
                 }],
             }],
+            function_signatures: HashMap::new(),
         };
 
         // Run constant propagation
@@ -314,6 +315,7 @@ mod tests {
                     },
                 ],
             }],
+            function_signatures: HashMap::new(),
         };
 
         // Run constant propagation

--- a/crates/rue-optimize/src/passes/cse.rs
+++ b/crates/rue-optimize/src/passes/cse.rs
@@ -193,6 +193,7 @@ mod tests {
                     },
                 }],
             }],
+            function_signatures: HashMap::new(),
         };
 
         // Run CSE
@@ -265,6 +266,7 @@ mod tests {
                     },
                 }],
             }],
+            function_signatures: HashMap::new(),
         };
 
         // Run CSE
@@ -317,6 +319,7 @@ mod tests {
                     },
                 }],
             }],
+            function_signatures: HashMap::new(),
         };
 
         // Run CSE

--- a/crates/rue-optimize/src/passes/dead_code.rs
+++ b/crates/rue-optimize/src/passes/dead_code.rs
@@ -311,6 +311,7 @@ mod tests {
                     },
                 }],
             }],
+            function_signatures: HashMap::new(),
         };
 
         // Run dead code elimination
@@ -372,6 +373,7 @@ mod tests {
                     },
                 }],
             }],
+            function_signatures: HashMap::new(),
         };
 
         // Run dead code elimination


### PR DESCRIPTION
- Add function_signatures HashMap to MirProgram to track all function signatures
- Implement proper function signature verification in MirVerifier
- Replace temporary infer_call_return_type with signature lookups
- Add builtin function signatures (I/O, type conversion, system functions)
- Collect user-defined function signatures during MIR lowering
- Fix unused emit_const/emit_binop/emit_unop helpers by using them
- Update all test files to include function_signatures field

This improves type safety by properly tracking and verifying function signatures throughout the MIR pipeline, catching argument count and type mismatches at compile time.

Fixes https://github.com/steveklabnik/rue/issues/88.

But hilariously, also Fixes https://github.com/steveklabnik/rue/issues/94, at least in the current paradigm of Rue.
Because this works like this:

1. First pass: Collects all function signatures from all functions defined in
   the HIR program
2. Second pass: Lowers functions to MIR (where function calls
   are verified)

We end up supporting forward delcarations. We don't in the sense of separate
compilation, but we don't have separate compilation right now, and so making
sure this works with that will be the job of that feature.