### PR TITLE
Replace ad-hoc debug prints with structured logging using tracing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,6 +52,27 @@ When working on features:
 - `cargo test -p rue` - Integration tests
 - `cargo test` - All tests
 
+### Debugging and Logging
+
+The compiler uses structured logging via the `tracing` crate. Control logging with:
+
+**Environment Variable:**
+- `RUST_LOG=rue=info` - Default info level
+- `RUST_LOG=rue=debug` - Debug information
+- `RUST_LOG=rue=trace` - Detailed trace information
+
+**Specific Targets:**
+- `RUST_LOG=rue::mir=debug` - MIR generation and optimization
+- `RUST_LOG=rue::codegen=trace` - Instruction generation details
+- `RUST_LOG=rue::optimize=debug` - Optimization passes
+
+**CLI Flags:**
+- `rue -v` - Info level logging
+- `rue -vv` - Debug level logging  
+- `rue -vvv` - Trace level logging
+- `rue --log-format=tree` - Hierarchical log output (good for compiler phases)
+- `rue --log-filter="rue::mir=trace"` - Custom filter
+
 ## Version Control
 
 **IMPORTANT**: This project uses jj (Jujutsu) exclusively. NEVER use git commands.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ edition = "2024"
 version = "0.1.0"
 
 [workspace.dependencies]
+atty = "0.2"
 bpaf = "0.9.20"
 criterion = "0.5.0"
 indexmap = "2.0.0"
@@ -31,3 +32,6 @@ tempfile = "3.8.0"
 thiserror = "2.0.12"
 tokio = { version = "1.0", features = ["full"] }
 tower-lsp = "0.20"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
+tracing-tree = "0.3"

--- a/crates/rue-codegen/BUCK
+++ b/crates/rue-codegen/BUCK
@@ -15,6 +15,7 @@ cargo.rust_library(
         "//crates/rue-runtime:rue-runtime",
         "//crates/rue-ir:rue-ir",
         "//third-party/rust:indexmap",
+        "//third-party/rust:tracing",
     ],
     visibility = ["PUBLIC"],
 )
@@ -35,5 +36,6 @@ rust_test(
         "//crates/rue-ir:rue-ir",
         "//third-party/rust:indexmap",
         "//third-party/rust:regex",
+        "//third-party/rust:tracing",
     ],
 )

--- a/crates/rue-codegen/Cargo.toml
+++ b/crates/rue-codegen/Cargo.toml
@@ -15,6 +15,7 @@ rue-optimize = { path = "../rue-optimize" }
 indexmap.workspace = true
 thiserror.workspace = true
 object.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 criterion.workspace = true

--- a/crates/rue-codegen/src/backend.rs
+++ b/crates/rue-codegen/src/backend.rs
@@ -3,6 +3,7 @@ use crate::regalloc::RegisterAllocator;
 use crate::{CodegenError, Instruction, Label};
 use rue_ir::target::MachineInstr;
 use std::collections::HashMap;
+use tracing::debug;
 
 /// Backend that handles compilation from high-level IR to machine instructions.
 /// Manages function boundaries, label assignment, and register allocation.
@@ -116,9 +117,12 @@ impl Backend {
             // Set the initial stack offset based on block parameters used in this function
             if let Some(ref name) = function_name {
                 let stack_offset = mir_lowerer.get_function_stack_offset(name);
-                if std::env::var("RUE_DEBUG").is_ok() {
-                    eprintln!("Setting initial stack offset for function '{name}': {stack_offset}");
-                }
+                debug!(
+                    target: "rue::codegen",
+                    function = %name,
+                    stack_offset,
+                    "Setting initial stack offset for function"
+                );
                 function_allocator.set_initial_stack_offset(stack_offset);
             }
 

--- a/crates/rue-codegen/src/compile_hir_with_mir.rs
+++ b/crates/rue-codegen/src/compile_hir_with_mir.rs
@@ -14,8 +14,10 @@ use rue_lowering::MirBuilder;
 #[cfg(debug_assertions)]
 use rue_lowering::MirVerifier;
 use rue_optimize::{CommonSubexpressionElimination, ConstProp, DeadCodeElimination};
+use tracing::{debug, info, instrument};
 
 /// Helper function to optimize and verify MIR
+#[instrument(skip_all, fields(optimize = enable_optimizations))]
 fn optimize_and_verify_mir(
     mir: &mut MirProgram,
     enable_optimizations: bool,
@@ -28,8 +30,8 @@ fn optimize_and_verify_mir(
         // We run multiple iterations because optimizations can enable further optimizations
         // For example: const prop might enable dead code elimination, which might enable more const prop
         for iteration in 0..MAX_ITERATIONS {
-            if std::env::var("RUE_DUMP_MIR").is_ok() && iteration > 0 {
-                eprintln!("=== MIR optimization iteration {} ===", iteration + 1);
+            if iteration > 0 {
+                debug!("MIR optimization iteration {}", iteration + 1);
             }
 
             // Run constant propagation first
@@ -48,11 +50,7 @@ fn optimize_and_verify_mir(
         }
     }
 
-    if std::env::var("RUE_DUMP_MIR").is_ok() {
-        eprintln!("=== MIR (after optimization) ===");
-        eprintln!("{mir}");
-        eprintln!("=== END MIR ===");
-    }
+    debug!(target: "rue::mir", mir = %mir, "MIR after optimization");
 
     // Verify MIR if in debug mode
     // Note: This is debug-only for performance reasons. The verifier will panic (via error return)
@@ -62,9 +60,8 @@ fn optimize_and_verify_mir(
     {
         let mut verifier = MirVerifier::new();
         if let Err(errors) = verifier.verify_program(mir) {
-            eprintln!("MIR verification failed:");
-            for error in errors {
-                eprintln!("  - [{}] {}", error.function, error.message);
+            for error in &errors {
+                tracing::error!(target: "rue::mir::verify", function = %error.function, "{}", error.message);
             }
             return Err(CodegenError::MirVerificationFailed);
         }
@@ -77,24 +74,26 @@ fn optimize_and_verify_mir(
 ///
 /// This function demonstrates the MIR pipeline:
 /// HIR → MIR → (optimizations) → Instructions → Assembly
+#[instrument(skip_all, fields(optimize = enable_optimizations))]
 pub fn compile_hir_via_mir_to_assembly(
     hir: &HirProgram,
     enable_optimizations: bool,
 ) -> Result<String, CodegenError> {
     // Step 1: Lower HIR to MIR
+    info!(target: "rue::mir", "Lowering HIR to MIR");
     let mut mir = MirBuilder::lower_program(hir);
 
-    // Step 2: Print MIR for debugging (optional)
-    if std::env::var("RUE_DUMP_MIR").is_ok() {
-        eprintln!("=== MIR (before optimization) ===");
-        eprintln!("{mir}");
-        eprintln!("=== END MIR ===");
-    }
+    // Step 2: Print MIR for debugging
+    debug!(target: "rue::mir", mir = %mir, "MIR before optimization");
 
     // Step 3: Apply MIR optimizations and verify
+    if enable_optimizations {
+        info!(target: "rue::optimize", "Running optimization passes");
+    }
     optimize_and_verify_mir(&mut mir, enable_optimizations)?;
 
     // Step 4: Lower MIR to Instructions
+    info!(target: "rue::codegen", "Lowering MIR to instructions");
     let mut mir_lowerer = MirToInstructions::new();
     let instructions = mir_lowerer.lower_program(&mir);
     let function_labels = mir_lowerer.get_function_labels();
@@ -126,6 +125,7 @@ pub fn compile_hir_via_mir_to_assembly(
     let all_function_labels = driver.build_final_labels(&function_labels, &ir_to_machine_labels);
 
     // Generate assembly
+    info!(target: "rue::codegen", "Generating assembly");
     Ok(format_instructions_as_assembly(
         &final_instructions,
         &all_function_labels,
@@ -134,24 +134,26 @@ pub fn compile_hir_via_mir_to_assembly(
 }
 
 /// Compile HIR to executable via MIR
+#[instrument(skip_all, fields(optimize = enable_optimizations))]
 pub fn compile_hir_via_mir_to_executable(
     hir: &HirProgram,
     enable_optimizations: bool,
 ) -> Result<Vec<u8>, CodegenError> {
     // Step 1: Lower HIR to MIR
+    info!(target: "rue::mir", "Lowering HIR to MIR");
     let mut mir = MirBuilder::lower_program(hir);
 
-    // Step 2: Print MIR for debugging (optional)
-    if std::env::var("RUE_DUMP_MIR").is_ok() {
-        eprintln!("=== MIR (before optimization) ===");
-        eprintln!("{mir}");
-        eprintln!("=== END MIR ===");
-    }
+    // Step 2: Print MIR for debugging
+    debug!(target: "rue::mir", mir = %mir, "MIR before optimization");
 
     // Step 3: Apply MIR optimizations and verify
+    if enable_optimizations {
+        info!(target: "rue::optimize", "Running optimization passes");
+    }
     optimize_and_verify_mir(&mut mir, enable_optimizations)?;
 
     // Step 4: Lower MIR to Instructions
+    info!(target: "rue::codegen", "Lowering MIR to instructions");
     let mut mir_lowerer = MirToInstructions::new();
     let instructions = mir_lowerer.lower_program(&mir);
     let function_labels = mir_lowerer.get_function_labels();
@@ -184,6 +186,7 @@ pub fn compile_hir_via_mir_to_executable(
     let runtime_label_count = driver.runtime_label_count();
 
     // Step 10: Generate x86 code
+    info!(target: "rue::elf", "Generating ELF executable");
     let mut emitter = X86Emitter::new();
     emitter.set_function_labels(all_function_labels, runtime_label_count);
     let code = emitter
@@ -233,9 +236,9 @@ mod tests {
             }],
         };
 
-        // Note: We would need to set RUE_DUMP_MIR=1 environment variable
+        // Note: We would need to set RUST_LOG=rue::mir=debug environment variable
         // to see MIR output, but we don't modify environment in tests
-        // as it's not thread-safe. Run with RUE_DUMP_MIR=1 cargo test
+        // as it's not thread-safe. Run with RUST_LOG=rue::mir=debug cargo test
         // to see MIR output during debugging.
 
         // Compile via MIR

--- a/crates/rue-codegen/src/lowering.rs
+++ b/crates/rue-codegen/src/lowering.rs
@@ -2,6 +2,7 @@ use crate::regalloc::RegisterAllocator;
 use crate::{BinOp, Instruction, Label, VReg, Value};
 use rue_ir::target::{ConditionCode, LabelRef, MachineInstr, Register};
 use std::collections::HashMap;
+use tracing::{debug, trace};
 
 /// Errors that can occur during lowering
 #[derive(Debug, Clone, PartialEq)]
@@ -515,9 +516,11 @@ impl<'a> Lowering<'a> {
     ) -> Result<(), LoweringError> {
         use rue_ir::types::RueType;
 
-        if std::env::var("RUE_DEBUG").is_ok() {
-            eprintln!("lower_typed_binary_op: dest={dest:?}, op={op:?}, ty={ty:?}");
-        }
+        debug!(
+            target: "rue::codegen",
+            ?dest, ?op, ?ty,
+            "Lowering typed binary operation"
+        );
 
         // For non-arithmetic operations, delegate to regular binary operation
         if matches!(
@@ -542,9 +545,11 @@ impl<'a> Lowering<'a> {
             let dest_reg = self.allocator.ensure_reg(dest, &[])?;
             self.emit_spill_reload_ops();
 
-            if std::env::var("RUE_DEBUG").is_ok() {
-                eprintln!("Adding i32 truncation: dest_reg={dest_reg:?}");
-            }
+            debug!(
+                target: "rue::codegen",
+                ?dest_reg,
+                "Adding i32 truncation"
+            );
 
             // Truncate to 32-bit and sign-extend back to 64-bit
             // This ensures i32 overflow wraps correctly (movsxd automatically truncates and sign-extends)
@@ -998,9 +1003,12 @@ impl<'a> Lowering<'a> {
     }
 
     fn lower_store(&mut self, src: VReg, offset: i64) -> Result<(), LoweringError> {
-        if std::env::var("RUE_DEBUG").is_ok() {
-            eprintln!("lower_store: storing vreg {src:?} to offset {offset}");
-        }
+        debug!(
+            target: "rue::codegen",
+            ?src,
+            offset,
+            "Lowering store operation"
+        );
 
         // Check if this is a block parameter store
         let is_block_param = self.block_param_offsets.contains(&offset);
@@ -1014,9 +1022,12 @@ impl<'a> Lowering<'a> {
 
         let src_reg = self.allocator.ensure_reg(src, &[])?;
         self.emit_spill_reload_ops();
-        if std::env::var("RUE_DEBUG").is_ok() {
-            eprintln!("lower_store: vreg {src:?} is in register {src_reg:?}");
-        }
+        trace!(
+            target: "rue::codegen",
+            ?src,
+            ?src_reg,
+            "Store: vreg is in register"
+        );
         self.emit(MachineInstr::MovMR {
             // store to stack slot
             base: Register::Rbp, // <- use the frame-pointer
@@ -1400,16 +1411,21 @@ impl<'a> Lowering<'a> {
         self.emit_spill_reload_ops();
 
         if let Some(vreg) = value {
-            if std::env::var("RUE_DEBUG").is_ok() {
-                eprintln!("lower_return: returning vreg {vreg:?}");
-            }
+            debug!(
+                target: "rue::codegen",
+                ?vreg,
+                "Lowering return with value"
+            );
             // Now load the return value after all other values have been flushed
             // This ensures the return value register won't be used as a scratch register
             let value_reg = self.allocator.ensure_reg(*vreg, &[])?;
             self.emit_spill_reload_ops();
-            if std::env::var("RUE_DEBUG").is_ok() {
-                eprintln!("lower_return: vreg {vreg:?} in register {value_reg:?}");
-            }
+            trace!(
+                target: "rue::codegen",
+                ?vreg,
+                ?value_reg,
+                "Return: vreg in register"
+            );
             if value_reg != Register::Rax {
                 self.emit(MachineInstr::MovRR {
                     dest: Register::Rax,
@@ -1600,11 +1616,12 @@ impl<'a> Lowering<'a> {
                 // This is a store to stack - find which VReg this corresponds to
                 if let Some(vreg) = self.allocator.find_vreg_for_slot(*offset as i64) {
                     self.allocator.mark_vreg_initialized(vreg);
-                    if std::env::var("RUE_DEBUG").is_ok() {
-                        eprintln!(
-                            "Marking VReg {vreg:?} as initialized (stored to offset {offset})"
-                        );
-                    }
+                    trace!(
+                        target: "rue::codegen::regalloc",
+                        ?vreg,
+                        offset,
+                        "Marking VReg as initialized (stored to stack)"
+                    );
                 }
             }
         }

--- a/crates/rue-codegen/src/mir_to_instructions.rs
+++ b/crates/rue-codegen/src/mir_to_instructions.rs
@@ -10,6 +10,7 @@ use rue_ir::mir::{
 };
 use rue_ir::target::Register;
 use std::collections::HashMap;
+use tracing::{debug, trace};
 
 /// Lowers MIR to Instructions
 pub struct MirToInstructions {
@@ -75,16 +76,12 @@ impl MirToInstructions {
     /// Get or create a virtual register for a temp
     fn get_vreg(&mut self, temp: Temp) -> VReg {
         if let Some(&vreg) = self.temp_to_vreg.get(&temp) {
-            if std::env::var("RUE_DEBUG_VREGS").is_ok() {
-                eprintln!("get_vreg: temp {temp:?} -> existing vreg {vreg:?}");
-            }
+            trace!(target: "rue::codegen::regalloc", ?temp, ?vreg, "get_vreg: temp -> existing vreg");
             vreg
         } else {
             let vreg = self.fresh_vreg();
             self.temp_to_vreg.insert(temp, vreg);
-            if std::env::var("RUE_DEBUG_VREGS").is_ok() {
-                eprintln!("get_vreg: temp {temp:?} -> new vreg {vreg:?}");
-            }
+            trace!(target: "rue::codegen::regalloc", ?temp, ?vreg, "get_vreg: temp -> new vreg");
             vreg
         }
     }
@@ -102,9 +99,7 @@ impl MirToInstructions {
 
     /// Emit an instruction
     fn emit(&mut self, instr: Instruction) {
-        if std::env::var("RUE_DEBUG_INSTRUCTIONS").is_ok() {
-            eprintln!("EMIT: {instr:?}");
-        }
+        debug!(target: "rue::codegen::instructions", ?instr, "Emitting instruction");
         self.instructions.push(instr);
     }
 
@@ -169,12 +164,13 @@ impl MirToInstructions {
                 self.block_param_slots
                     .insert((block.id, i), self.block_param_stack_offset);
 
-                if std::env::var("RUE_DEBUG").is_ok() {
-                    eprintln!(
-                        "Allocated block param slot: block {:?}, param {} -> offset {}",
-                        block.id, i, self.block_param_stack_offset
-                    );
-                }
+                debug!(
+                    target: "rue::codegen",
+                    block = ?block.id,
+                    param_index = i,
+                    offset = self.block_param_stack_offset,
+                    "Allocated block param slot"
+                );
             }
         }
 
@@ -244,12 +240,15 @@ impl MirToInstructions {
                         offset: slot_offset,
                     });
 
-                    if std::env::var("RUE_DEBUG").is_ok() {
-                        eprintln!(
-                            "Loading block param: block {:?}, param {} (temp {:?}) from offset {} into vreg {:?}",
-                            block.id, i, param_temp, slot_offset, param_vreg
-                        );
-                    }
+                    debug!(
+                        target: "rue::codegen",
+                        block = ?block.id,
+                        param_index = i,
+                        ?param_temp,
+                        offset = slot_offset,
+                        ?param_vreg,
+                        "Loading block param from stack"
+                    );
                 }
             }
         }
@@ -498,9 +497,7 @@ impl MirToInstructions {
             MirTerminator::Return { value, .. } => {
                 if let Some(val) = value {
                     let vreg = self.get_vreg(*val);
-                    if std::env::var("RUE_DEBUG").is_ok() {
-                        eprintln!("Return terminator: temp {val:?} -> vreg {vreg:?}");
-                    }
+                    debug!(target: "rue::codegen", ?val, ?vreg, "Return terminator: temp -> vreg");
                     self.emit(Instruction::Return { value: Some(vreg) });
                 } else {
                     self.emit(Instruction::Return { value: None });
@@ -526,11 +523,15 @@ impl MirToInstructions {
                 // Get VReg for the argument value
                 let arg_vreg = self.get_vreg(arg_temp);
 
-                if std::env::var("RUE_DEBUG_BLOCK_ARGS").is_ok() {
-                    eprintln!(
-                        "About to store block arg: target block {target_block:?}, arg {i} (temp {arg_temp:?}, vreg {arg_vreg:?}) to offset {slot_offset}"
-                    );
-                }
+                trace!(
+                    target: "rue::mir::blocks",
+                    ?target_block,
+                    arg_index = i,
+                    ?arg_temp,
+                    ?arg_vreg,
+                    offset = slot_offset,
+                    "About to store block arg to stack"
+                );
 
                 // Store the argument value to the dedicated slot
                 self.emit(Instruction::Store {
@@ -538,16 +539,18 @@ impl MirToInstructions {
                     offset: slot_offset,
                 });
 
-                if std::env::var("RUE_DEBUG").is_ok()
-                    || std::env::var("RUE_DEBUG_BLOCK_ARGS").is_ok()
-                {
-                    eprintln!(
-                        "Storing block arg: target block {target_block:?}, arg {i} (temp {arg_temp:?}, vreg {arg_vreg:?}) to offset {slot_offset}"
-                    );
-                    // Also print what instruction we just emitted
-                    if let Some(last_inst) = self.instructions.last() {
-                        eprintln!("  Emitted: {last_inst:?}");
-                    }
+                debug!(
+                    target: "rue::mir::blocks",
+                    ?target_block,
+                    arg_index = i,
+                    ?arg_temp,
+                    ?arg_vreg,
+                    offset = slot_offset,
+                    "Storing block arg to stack"
+                );
+                // Also log what instruction we just emitted
+                if let Some(last_inst) = self.instructions.last() {
+                    trace!(target: "rue::mir::blocks", ?last_inst, "Last emitted instruction");
                 }
             }
         }

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -26,6 +26,7 @@
 use crate::VReg;
 use rue_ir::target::{MachineInstr, Register};
 use std::collections::HashMap;
+use tracing::{debug, trace};
 
 /// Size of a stack slot in bytes
 const SLOT_SIZE: i64 = 8;
@@ -141,12 +142,12 @@ impl RegisterAllocator {
         *self.home_slots.entry(vreg).or_insert_with(|| {
             // Allocate 8-byte slot (will be enhanced for variable sizes)
             self.stack_offset -= SLOT_SIZE;
-            if std::env::var("RUE_DEBUG").is_ok() {
-                eprintln!(
-                    "Allocating home slot for {:?} at offset {}",
-                    vreg, self.stack_offset
-                );
-            }
+            debug!(
+                target: "rue::codegen::regalloc",
+                ?vreg,
+                offset = self.stack_offset,
+                "Allocating home slot for VReg"
+            );
             self.stack_offset
         })
     }
@@ -316,12 +317,13 @@ impl RegisterAllocator {
                     if *v == vreg && !forbidden.contains(&state.reg) =>
                 {
                     // Already in this register, no need to reload
-                    if std::env::var("RUE_DEBUG").is_ok() {
-                        eprintln!(
-                            "ensure_reg: VReg {:?} found in register {:?} (state: {:?})",
-                            vreg, state.reg, state.state
-                        );
-                    }
+                    trace!(
+                        target: "rue::codegen::regalloc",
+                        ?vreg,
+                        register = ?state.reg,
+                        state = ?state.state,
+                        "ensure_reg: VReg found in register"
+                    );
                     return Ok(state.reg);
                 }
                 _ => {}
@@ -361,13 +363,12 @@ impl RegisterAllocator {
         // (like the result of "n - 1") were loading garbage from uninitialized memory.
         let should_load = self.initialized_vregs.contains(&vreg);
 
-        if std::env::var("RUE_DEBUG").is_ok() {
-            if should_load {
-                eprintln!("ensure_reg: VReg {vreg:?} is initialized, loading from memory");
-            } else {
-                eprintln!("ensure_reg: VReg {vreg:?} is uninitialized, treating as new value");
-            }
-        }
+        debug!(
+            target: "rue::codegen::regalloc",
+            ?vreg,
+            initialized = should_load,
+            "ensure_reg: VReg initialization status"
+        );
 
         if should_load {
             // Load from home slot

--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -13,6 +13,10 @@ cargo.rust_library(
         "//crates/rue-semantic:rue-semantic",
         "//crates/rue-codegen:rue-codegen",
         "//third-party/rust:salsa",
+        "//third-party/rust:tracing",
+        "//third-party/rust:tracing-subscriber",
+        "//third-party/rust:atty",
+        "//third-party/rust:tracing-tree",
     ],
     visibility = ["PUBLIC"],
 )
@@ -30,6 +34,10 @@ rust_test(
         "//crates/rue-semantic:rue-semantic",
         "//crates/rue-codegen:rue-codegen",
         "//third-party/rust:salsa",
+        "//third-party/rust:tracing",
+        "//third-party/rust:tracing-subscriber",
+        "//third-party/rust:atty",
+        "//third-party/rust:tracing-tree",
     ],
 )
 

--- a/crates/rue-compiler/Cargo.toml
+++ b/crates/rue-compiler/Cargo.toml
@@ -11,3 +11,7 @@ rue-parser = { path = "../rue-parser" }
 rue-semantic = { path = "../rue-semantic" }
 rue-codegen = { path = "../rue-codegen" }
 salsa.workspace = true
+tracing.workspace = true
+tracing-subscriber.workspace = true
+tracing-tree.workspace = true
+atty.workspace = true

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -5,6 +5,8 @@ use rue_parser::ParseError;
 use rue_semantic::{SemanticError, analyze_cst};
 use std::sync::Arc;
 
+pub mod logging;
+
 // Input structs
 #[salsa::input]
 pub struct SourceFile {

--- a/crates/rue-compiler/src/logging.rs
+++ b/crates/rue-compiler/src/logging.rs
@@ -1,0 +1,159 @@
+//! Logging infrastructure for the Rue compiler
+//!
+//! This module provides structured logging using the `tracing` crate.
+//!
+//! ## Log Levels
+//! - ERROR: Compilation failures, invalid IR, verification failures
+//! - WARN: Deprecations, non-optimal code patterns, recoverable issues
+//! - INFO: Major phase transitions (parsing → HIR → MIR → codegen)
+//! - DEBUG: Detailed compiler state (variable lookups, block transitions)
+//! - TRACE: Instruction-level details, register allocation steps
+//!
+//! ## Targets
+//! Log filtering can be controlled by target:
+//! - `rue::lexer` - Token generation
+//! - `rue::parser` - AST construction  
+//! - `rue::semantic` - Type checking, HIR building
+//! - `rue::mir` - MIR generation and verification
+//! - `rue::optimize` - Optimization passes (const prop, DCE, CSE)
+//! - `rue::codegen` - Instruction generation, register allocation
+//! - `rue::elf` - Binary generation
+//!
+//! ## Usage
+//! Set the RUST_LOG environment variable to control logging:
+//! - `RUST_LOG=rue=debug` - Enable debug logging for all rue modules
+//! - `RUST_LOG=rue::mir=trace` - Enable trace logging for MIR
+//! - `RUST_LOG=rue::mir::vars=trace` - Very detailed variable tracking
+
+use tracing_subscriber::{EnvFilter, Layer, layer::SubscriberExt, util::SubscriberInitExt};
+
+/// Output format for logs
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogFormat {
+    /// Human-readable format with colors (default for terminals)
+    Pretty,
+    /// JSON format for machine processing
+    Json,
+    /// Compact single-line format
+    Compact,
+    /// Hierarchical tree format (best for debugging compiler phases)
+    Tree,
+}
+
+/// Logging configuration
+pub struct LogConfig {
+    /// Output format
+    pub format: LogFormat,
+    /// Custom filter string (overrides default)
+    pub filter: Option<String>,
+    /// Whether to include source code locations
+    pub with_source_location: bool,
+    /// Whether to include thread IDs
+    pub with_thread_ids: bool,
+    /// Whether to include timestamps
+    pub with_timestamps: bool,
+}
+
+impl Default for LogConfig {
+    fn default() -> Self {
+        Self {
+            format: if atty::is(atty::Stream::Stderr) {
+                LogFormat::Pretty
+            } else {
+                LogFormat::Compact
+            },
+            filter: None,
+            with_source_location: false,
+            with_thread_ids: false,
+            with_timestamps: true,
+        }
+    }
+}
+
+/// Initialize the global tracing subscriber
+///
+/// This should be called once at the start of the program.
+/// Subsequent calls will be ignored.
+pub fn init_tracing(config: LogConfig) -> Result<(), Box<dyn std::error::Error>> {
+    // Create the env filter
+    let filter = config.filter.as_deref().unwrap_or("rue=info");
+    let env_filter = EnvFilter::try_new(filter)?;
+
+    match config.format {
+        LogFormat::Pretty => {
+            let fmt_layer = tracing_subscriber::fmt::layer()
+                .with_target(true)
+                .with_thread_ids(config.with_thread_ids)
+                .with_file(config.with_source_location)
+                .with_line_number(config.with_source_location)
+                .with_ansi(atty::is(atty::Stream::Stderr))
+                .pretty()
+                .with_filter(env_filter);
+
+            tracing_subscriber::registry().with(fmt_layer).try_init()?;
+        }
+        LogFormat::Json => {
+            let fmt_layer = tracing_subscriber::fmt::layer()
+                .json()
+                .with_current_span(true)
+                .with_span_list(true)
+                .with_target(true)
+                .with_file(config.with_source_location)
+                .with_line_number(config.with_source_location)
+                .with_thread_ids(config.with_thread_ids)
+                .with_filter(env_filter);
+
+            tracing_subscriber::registry().with(fmt_layer).try_init()?;
+        }
+        LogFormat::Compact => {
+            let fmt_layer = tracing_subscriber::fmt::layer()
+                .compact()
+                .with_target(true)
+                .with_thread_ids(config.with_thread_ids)
+                .with_file(config.with_source_location)
+                .with_line_number(config.with_source_location)
+                .with_ansi(atty::is(atty::Stream::Stderr))
+                .with_filter(env_filter);
+
+            tracing_subscriber::registry().with(fmt_layer).try_init()?;
+        }
+        LogFormat::Tree => {
+            // Use tracing-tree for hierarchical output
+            let tree_layer = tracing_tree::HierarchicalLayer::new(2)
+                .with_targets(true)
+                .with_bracketed_fields(true)
+                .with_thread_ids(config.with_thread_ids)
+                .with_verbose_exit(false)
+                .with_verbose_entry(false)
+                .with_indent_amount(2)
+                .with_ansi(atty::is(atty::Stream::Stderr))
+                .with_filter(env_filter);
+
+            tracing_subscriber::registry().with(tree_layer).try_init()?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Initialize tracing with default configuration
+///
+/// This is a convenience function that uses sensible defaults.
+pub fn init_default() -> Result<(), Box<dyn std::error::Error>> {
+    init_tracing(LogConfig::default())
+}
+
+/// Parse verbosity level into a RUST_LOG filter string
+///
+/// - 0 (default): "rue=warn"
+/// - 1 (-v): "rue=info"  
+/// - 2 (-vv): "rue=debug"
+/// - 3+ (-vvv): "rue=trace"
+pub fn verbosity_to_filter(verbosity: u8) -> &'static str {
+    match verbosity {
+        0 => "rue=warn",
+        1 => "rue=info",
+        2 => "rue=debug",
+        _ => "rue=trace",
+    }
+}

--- a/crates/rue-ir/BUCK
+++ b/crates/rue-ir/BUCK
@@ -7,6 +7,7 @@ cargo.rust_library(
     edition = "2021",
     deps = [
         "//crates/rue-lexer:rue-lexer",
+        "//third-party/rust:tracing",
     ],
     visibility = ["PUBLIC"],
 )
@@ -18,5 +19,6 @@ rust_test(
     edition = "2021",
     deps = [
         "//crates/rue-lexer:rue-lexer",
+        "//third-party/rust:tracing",
     ],
 )

--- a/crates/rue-ir/Cargo.toml
+++ b/crates/rue-ir/Cargo.toml
@@ -5,3 +5,4 @@ version.workspace = true
 
 [dependencies]
 rue-lexer = { path = "../rue-lexer" }
+tracing.workspace = true

--- a/crates/rue-ir/src/mir_lowering.rs
+++ b/crates/rue-ir/src/mir_lowering.rs
@@ -16,6 +16,7 @@ use crate::mir::{
 };
 use crate::types::RueType;
 use std::collections::HashMap;
+use tracing::{debug, trace};
 
 /// Builder for constructing MIR from HIR
 pub struct MirBuilder {
@@ -315,9 +316,7 @@ impl MirBuilder {
         let result = builder.lower_block(&func.body);
         builder.is_function_body = false;
 
-        if std::env::var("RUE_DEBUG").is_ok() {
-            eprintln!("Function {} body result: {:?}", func.name, result);
-        }
+        debug!(target: "rue::mir", function = %func.name, ?result, "Function body lowering result");
 
         // Set return terminator if we haven't already returned
         if builder.current_block.is_some() {
@@ -339,11 +338,7 @@ impl MirBuilder {
         };
 
         // Debug: print MIR if enabled
-        if std::env::var("RUE_DEBUG_MIR").is_ok() {
-            eprintln!("=== MIR for {} ===", mir_func.name);
-            eprintln!("{mir_func}");
-            eprintln!("=================");
-        }
+        trace!(target: "rue::mir", function = %mir_func.name, mir = %mir_func, "Generated MIR for function");
 
         mir_func
     }
@@ -366,13 +361,12 @@ impl MirBuilder {
         // Lower the final expression if present
         let result = block.expr.as_ref().map(|expr| self.lower_expr(expr));
 
-        if std::env::var("RUE_DEBUG").is_ok() {
-            eprintln!(
-                "Block result: {:?}, has_expr: {}",
-                result,
-                block.expr.is_some()
-            );
-        }
+        debug!(
+            target: "rue::mir::blocks",
+            ?result,
+            has_expr = block.expr.is_some(),
+            "Block lowering result"
+        );
 
         result
     }
@@ -431,12 +425,13 @@ impl MirBuilder {
                     .get(name)
                     .copied()
                     .unwrap_or_else(|| panic!("Undefined variable: {name}"));
-                if std::env::var("RUE_DEBUG_VAR").is_ok() || std::env::var("RUE_DEBUG").is_ok() {
-                    eprintln!(
-                        "Variable lookup: {} -> {:?} (current vars: {:?})",
-                        name, temp, self.variables
-                    );
-                }
+                trace!(
+                    target: "rue::mir::vars",
+                    variable = %name,
+                    ?temp,
+                    ?self.variables,
+                    "Variable lookup"
+                );
                 temp
             }
             HirExpr::Binary {
@@ -525,9 +520,7 @@ impl MirBuilder {
                 self.lower_while_expr(cond, body);
                 // While always returns unit
                 let unit_temp = self.emit_const(MirConst::Unit, Some(*span));
-                if std::env::var("RUE_DEBUG").is_ok() {
-                    eprintln!("While expr returns unit temp: {unit_temp:?}");
-                }
+                debug!(target: "rue::mir", ?unit_temp, "While expression returns unit temp");
                 unit_temp
             }
         }
@@ -911,26 +904,30 @@ impl MirBuilder {
 
                 if self.assigned_variables.contains(name) {
                     // Variable was assigned in the loop body - pass the new value
-                    if std::env::var("RUE_DEBUG").is_ok() {
-                        eprintln!(
-                            "While loop: {name} was assigned, passing new value: {current_temp:?}"
-                        );
-                    }
+                    debug!(
+                        target: "rue::mir::vars",
+                        variable = %name,
+                        ?current_temp,
+                        "While loop: variable was assigned, passing new value"
+                    );
                     loop_back_args.push(current_temp);
                 } else {
                     // Variable was not assigned (only shadowed) - pass the loop-carried value
-                    if std::env::var("RUE_DEBUG").is_ok() {
-                        eprintln!(
-                            "While loop: {name} was not assigned, passing loop-carried value: {loop_entry_temp:?}"
-                        );
-                    }
+                    debug!(
+                        target: "rue::mir::vars",
+                        variable = %name,
+                        ?loop_entry_temp,
+                        "While loop: variable was not assigned, passing loop-carried value"
+                    );
                     loop_back_args.push(loop_entry_temp);
                 }
             } else {
                 // This shouldn't happen in well-formed code
-                if std::env::var("RUE_DEBUG").is_ok() {
-                    eprintln!("While loop variable {name} not found in current scope");
-                }
+                debug!(
+                    target: "rue::mir::vars",
+                    variable = %name,
+                    "While loop variable not found in current scope"
+                );
             }
         }
 

--- a/crates/rue-ir/src/mir_verifier.rs
+++ b/crates/rue-ir/src/mir_verifier.rs
@@ -11,6 +11,7 @@ use crate::mir::{
 };
 use crate::types::RueType;
 use std::collections::{HashMap, HashSet};
+use tracing::trace;
 
 #[derive(Debug)]
 pub struct VerificationError {
@@ -154,11 +155,11 @@ impl MirVerifier {
                 match value {
                     MirValue::Call { args, func, .. } => {
                         // Debug output
-                        if std::env::var("RUE_DEBUG_MIR").is_ok() {
-                            eprintln!(
-                                "DEBUG: Processing call assignment: {dest:?} = {func}({args:?})"
-                            );
-                        }
+                        trace!(
+                            target: "rue::mir::verify",
+                            ?dest, func, ?args,
+                            "Processing call assignment"
+                        );
 
                         // Verify all arguments are defined
                         for arg in args {
@@ -201,12 +202,13 @@ impl MirVerifier {
                             }
 
                             // Mark destination with the function's return type
-                            if std::env::var("RUE_DEBUG_MIR").is_ok() {
-                                eprintln!(
-                                    "DEBUG: Function {func} returns {:?}, marking {dest:?} as defined",
-                                    signature.return_type
-                                );
-                            }
+                            trace!(
+                                target: "rue::mir::verify",
+                                func,
+                                return_type = ?signature.return_type,
+                                ?dest,
+                                "Function return type, marking destination as defined"
+                            );
                             defined_temps.insert(*dest, signature.return_type);
                         } else {
                             // Unknown function - this should have been caught during semantic analysis

--- a/crates/rue-lowering/BUCK
+++ b/crates/rue-lowering/BUCK
@@ -8,6 +8,7 @@ cargo.rust_library(
     deps = [
         "//crates/rue-ir:rue-ir",
         "//crates/rue-lexer:rue-lexer",
+        "//third-party/rust:tracing",
     ],
     visibility = ["PUBLIC"],
 )
@@ -20,5 +21,6 @@ rust_test(
     deps = [
         "//crates/rue-ir:rue-ir",
         "//crates/rue-lexer:rue-lexer",
+        "//third-party/rust:tracing",
     ],
 )

--- a/crates/rue-lowering/Cargo.toml
+++ b/crates/rue-lowering/Cargo.toml
@@ -6,5 +6,6 @@ edition.workspace = true
 [dependencies]
 rue-ir = { path = "../rue-ir" }
 rue-lexer = { path = "../rue-lexer" }
+tracing.workspace = true
 
 [dev-dependencies]

--- a/crates/rue-lowering/src/hir_to_mir.rs
+++ b/crates/rue-lowering/src/hir_to_mir.rs
@@ -16,6 +16,7 @@ use rue_ir::mir::{
 };
 use rue_ir::types::RueType;
 use std::collections::HashMap;
+use tracing::{debug, trace};
 
 /// Builder for constructing MIR from HIR
 pub struct MirBuilder {
@@ -315,9 +316,7 @@ impl MirBuilder {
         let result = builder.lower_block(&func.body);
         builder.is_function_body = false;
 
-        if std::env::var("RUE_DEBUG").is_ok() {
-            eprintln!("Function {} body result: {:?}", func.name, result);
-        }
+        debug!(target: "rue::mir", function = %func.name, ?result, "Function body lowering result");
 
         // Set return terminator if we haven't already returned
         if builder.current_block.is_some() {
@@ -339,11 +338,7 @@ impl MirBuilder {
         };
 
         // Debug: print MIR if enabled
-        if std::env::var("RUE_DEBUG_MIR").is_ok() {
-            eprintln!("=== MIR for {} ===", mir_func.name);
-            eprintln!("{mir_func}");
-            eprintln!("=================");
-        }
+        trace!(target: "rue::mir", function = %mir_func.name, mir = %mir_func, "Generated MIR for function");
 
         mir_func
     }
@@ -366,13 +361,12 @@ impl MirBuilder {
         // Lower the final expression if present
         let result = block.expr.as_ref().map(|expr| self.lower_expr(expr));
 
-        if std::env::var("RUE_DEBUG").is_ok() {
-            eprintln!(
-                "Block result: {:?}, has_expr: {}",
-                result,
-                block.expr.is_some()
-            );
-        }
+        debug!(
+            target: "rue::mir::blocks",
+            ?result,
+            has_expr = block.expr.is_some(),
+            "Block lowering result"
+        );
 
         result
     }
@@ -431,12 +425,13 @@ impl MirBuilder {
                     .get(name)
                     .copied()
                     .unwrap_or_else(|| panic!("Undefined variable: {name}"));
-                if std::env::var("RUE_DEBUG_VAR").is_ok() || std::env::var("RUE_DEBUG").is_ok() {
-                    eprintln!(
-                        "Variable lookup: {} -> {:?} (current vars: {:?})",
-                        name, temp, self.variables
-                    );
-                }
+                trace!(
+                    target: "rue::mir::vars",
+                    variable = %name,
+                    ?temp,
+                    ?self.variables,
+                    "Variable lookup"
+                );
                 temp
             }
             HirExpr::Binary {
@@ -525,9 +520,7 @@ impl MirBuilder {
                 self.lower_while_expr(cond, body);
                 // While always returns unit
                 let unit_temp = self.emit_const(MirConst::Unit, Some(*span));
-                if std::env::var("RUE_DEBUG").is_ok() {
-                    eprintln!("While expr returns unit temp: {unit_temp:?}");
-                }
+                debug!(target: "rue::mir", ?unit_temp, "While expression returns unit temp");
                 unit_temp
             }
         }
@@ -911,26 +904,30 @@ impl MirBuilder {
 
                 if self.assigned_variables.contains(name) {
                     // Variable was assigned in the loop body - pass the new value
-                    if std::env::var("RUE_DEBUG").is_ok() {
-                        eprintln!(
-                            "While loop: {name} was assigned, passing new value: {current_temp:?}"
-                        );
-                    }
+                    debug!(
+                        target: "rue::mir::vars",
+                        variable = %name,
+                        ?current_temp,
+                        "While loop: variable was assigned, passing new value"
+                    );
                     loop_back_args.push(current_temp);
                 } else {
                     // Variable was not assigned (only shadowed) - pass the loop-carried value
-                    if std::env::var("RUE_DEBUG").is_ok() {
-                        eprintln!(
-                            "While loop: {name} was not assigned, passing loop-carried value: {loop_entry_temp:?}"
-                        );
-                    }
+                    debug!(
+                        target: "rue::mir::vars",
+                        variable = %name,
+                        ?loop_entry_temp,
+                        "While loop: variable was not assigned, passing loop-carried value"
+                    );
                     loop_back_args.push(loop_entry_temp);
                 }
             } else {
                 // This shouldn't happen in well-formed code
-                if std::env::var("RUE_DEBUG").is_ok() {
-                    eprintln!("While loop variable {name} not found in current scope");
-                }
+                debug!(
+                    target: "rue::mir::vars",
+                    variable = %name,
+                    "While loop variable not found in current scope"
+                );
             }
         }
 

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -9,6 +9,7 @@ cargo.rust_binary(
         "//crates/rue-compiler:rue-compiler",
         "//crates/rue-codegen:rue-codegen",
         "//third-party/rust:bpaf",
+        "//third-party/rust:tracing",
     ],
     visibility = ["PUBLIC"],
 )

--- a/crates/rue/Cargo.toml
+++ b/crates/rue/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 rue-compiler = { path = "../rue-compiler" }
 rue-codegen = { path = "../rue-codegen" }
 bpaf.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -2,9 +2,11 @@ use bpaf::{Parser, construct};
 use rue_compiler::{
     CompileOptions, RueDatabase, SourceFile, compile_file_to_assembly_with_options,
     compile_file_with_options,
+    logging::{LogConfig, LogFormat, init_tracing, verbosity_to_filter},
 };
 use std::fs;
 use std::path::PathBuf;
+use tracing::info;
 
 #[derive(Debug, Clone)]
 struct Args {
@@ -12,6 +14,9 @@ struct Args {
     input: PathBuf,
     emit_asm: bool,
     optimize: bool,
+    verbose: u8,
+    log_format: Option<String>,
+    log_filter: Option<String>,
 }
 
 fn parser() -> impl Parser<Args> {
@@ -28,12 +33,32 @@ fn parser() -> impl Parser<Args> {
 
     let optimize = bpaf::short('O').help("Enable MIR optimizations").switch();
 
+    let verbose = bpaf::short('v')
+        .long("verbose")
+        .help("Increase verbosity (can be repeated: -v, -vv, -vvv)")
+        .req_flag(())
+        .many()
+        .map(|v| v.len() as u8);
+
+    let log_format = bpaf::long("log-format")
+        .help("Log output format: pretty, json, compact, tree")
+        .argument::<String>("FORMAT")
+        .optional();
+
+    let log_filter = bpaf::long("log-filter")
+        .help("Custom log filter (overrides -v)")
+        .argument::<String>("FILTER")
+        .optional();
+
     let input = bpaf::positional::<PathBuf>("INPUT").help("Input Rue source file");
 
     construct!(Args {
         output,
         emit_asm,
         optimize,
+        verbose,
+        log_format,
+        log_filter,
         input,
     })
 }
@@ -43,6 +68,36 @@ fn main() {
         .to_options()
         .descr("The Rue programming language compiler")
         .run();
+
+    // Initialize logging
+    let log_config = LogConfig {
+        format: match opts.log_format.as_deref() {
+            Some("json") => LogFormat::Json,
+            Some("compact") => LogFormat::Compact,
+            Some("tree") => LogFormat::Tree,
+            Some("pretty") | None => LogFormat::Pretty,
+            Some(fmt) => {
+                eprintln!("Unknown log format: {fmt}, using 'pretty'");
+                LogFormat::Pretty
+            }
+        },
+        filter: opts.log_filter.or_else(|| {
+            if opts.verbose > 0 {
+                Some(verbosity_to_filter(opts.verbose).to_string())
+            } else {
+                // Check RUST_LOG environment variable
+                std::env::var("RUST_LOG").ok()
+            }
+        }),
+        with_source_location: opts.verbose >= 3,
+        with_thread_ids: false,
+        with_timestamps: matches!(opts.log_format.as_deref(), Some("json")),
+    };
+
+    if let Err(e) = init_tracing(log_config) {
+        eprintln!("Failed to initialize logging: {e}");
+        // Continue without logging
+    }
 
     let input_path = opts.input;
     let output_path = if opts.emit_asm {
@@ -62,6 +117,7 @@ fn main() {
     };
 
     // Set up Salsa database
+    info!("Starting compilation of {}", input_path.display());
     let db = RueDatabase::default();
     let file = SourceFile::new(&db, input_path.to_string_lossy().to_string(), source);
     let options = CompileOptions::new(&db, opts.optimize);
@@ -73,6 +129,10 @@ fn main() {
         match result {
             Ok(assembly) => match fs::write(&output_path, &*assembly) {
                 Ok(()) => {
+                    info!(
+                        "Successfully generated assembly to '{}'",
+                        output_path.display()
+                    );
                     println!(
                         "Successfully generated assembly to '{}'",
                         output_path.display()
@@ -108,6 +168,7 @@ fn main() {
                             fs::set_permissions(&output_path, perms).unwrap();
                         }
 
+                        info!("Successfully compiled to '{}'", output_path.display());
                         println!("Successfully compiled to '{}'", output_path.display());
                     }
                     Err(e) => {

--- a/third-party/rust/BUCK
+++ b/third-party/rust/BUCK
@@ -125,6 +125,49 @@ cargo.rust_library(
     ],
 )
 
+alias(
+    name = "atty",
+    actual = ":atty-0.2.14",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "atty-0.2.14.crate",
+    sha256 = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8",
+    strip_prefix = "atty-0.2.14",
+    urls = ["https://static.crates.io/crates/atty/0.2.14/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "atty-0.2.14",
+    srcs = [":atty-0.2.14.crate"],
+    crate = "atty",
+    crate_root = "atty-0.2.14.crate/src/lib.rs",
+    edition = "2015",
+    platform = {
+        "linux-arm64": dict(
+            deps = [":libc-0.2.174"],
+        ),
+        "linux-x86_64": dict(
+            deps = [":libc-0.2.174"],
+        ),
+        "macos-arm64": dict(
+            deps = [":libc-0.2.174"],
+        ),
+        "macos-x86_64": dict(
+            deps = [":libc-0.2.174"],
+        ),
+        "windows-gnu": dict(
+            deps = [":winapi-0.3.9"],
+        ),
+        "windows-msvc": dict(
+            deps = [":winapi-0.3.9"],
+        ),
+    },
+    visibility = [],
+)
+
 http_archive(
     name = "auto_impl-1.3.0.crate",
     sha256 = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7",
@@ -1531,6 +1574,23 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "lazy_static-1.5.0.crate",
+    sha256 = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe",
+    strip_prefix = "lazy_static-1.5.0",
+    urls = ["https://static.crates.io/crates/lazy_static/1.5.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "lazy_static-1.5.0",
+    srcs = [":lazy_static-1.5.0.crate"],
+    crate = "lazy_static",
+    crate_root = "lazy_static-1.5.0.crate/src/lib.rs",
+    edition = "2015",
+    visibility = [],
+)
+
+http_archive(
     name = "libc-0.2.174.crate",
     sha256 = "1171693293099992e19cddea4e8b849964e9846f4acee11b3948bcc337be8776",
     strip_prefix = "libc-0.2.174",
@@ -1673,6 +1733,24 @@ buildscript_run(
 )
 
 http_archive(
+    name = "log-0.4.27.crate",
+    sha256 = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94",
+    strip_prefix = "log-0.4.27",
+    urls = ["https://static.crates.io/crates/log/0.4.27/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "log-0.4.27",
+    srcs = [":log-0.4.27.crate"],
+    crate = "log",
+    crate_root = "log-0.4.27.crate/src/lib.rs",
+    edition = "2021",
+    features = ["std"],
+    visibility = [],
+)
+
+http_archive(
     name = "lsp-types-0.94.1.crate",
     sha256 = "c66bfd44a06ae10647fe3f8214762e9369fd4248df1350924b4ef9e770a85ea1",
     strip_prefix = "lsp-types-0.94.1",
@@ -1695,6 +1773,24 @@ cargo.rust_library(
         ":serde_repr-0.1.20",
         ":url-2.5.4",
     ],
+)
+
+http_archive(
+    name = "matchers-0.1.0.crate",
+    sha256 = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558",
+    strip_prefix = "matchers-0.1.0",
+    urls = ["https://static.crates.io/crates/matchers/0.1.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "matchers-0.1.0",
+    srcs = [":matchers-0.1.0.crate"],
+    crate = "matchers",
+    crate_root = "matchers-0.1.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [":regex-automata-0.1.10"],
 )
 
 http_archive(
@@ -1775,6 +1871,61 @@ cargo.rust_library(
         ),
         "windows-msvc": dict(
             deps = [":windows-sys-0.59.0"],
+        ),
+    },
+    visibility = [],
+)
+
+http_archive(
+    name = "nu-ansi-term-0.46.0.crate",
+    sha256 = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84",
+    strip_prefix = "nu-ansi-term-0.46.0",
+    urls = ["https://static.crates.io/crates/nu-ansi-term/0.46.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "nu-ansi-term-0.46.0",
+    srcs = [":nu-ansi-term-0.46.0.crate"],
+    crate = "nu_ansi_term",
+    crate_root = "nu-ansi-term-0.46.0.crate/src/lib.rs",
+    edition = "2018",
+    platform = {
+        "windows-gnu": dict(
+            deps = [":winapi-0.3.9"],
+        ),
+        "windows-msvc": dict(
+            deps = [":winapi-0.3.9"],
+        ),
+    },
+    visibility = [],
+    deps = [":overload-0.1.1"],
+)
+
+http_archive(
+    name = "nu-ansi-term-0.50.1.crate",
+    sha256 = "d4a28e057d01f97e61255210fcff094d74ed0466038633e95017f5beb68e4399",
+    strip_prefix = "nu-ansi-term-0.50.1",
+    urls = ["https://static.crates.io/crates/nu-ansi-term/0.50.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "nu-ansi-term-0.50.1",
+    srcs = [":nu-ansi-term-0.50.1.crate"],
+    crate = "nu_ansi_term",
+    crate_root = "nu-ansi-term-0.50.1.crate/src/lib.rs",
+    edition = "2021",
+    platform = {
+        "windows-gnu": dict(
+            named_deps = {
+                "windows": ":windows-sys-0.52.0",
+            },
+        ),
+        "windows-msvc": dict(
+            named_deps = {
+                "windows": ":windows-sys-0.52.0",
+            },
         ),
     },
     visibility = [],
@@ -1914,6 +2065,23 @@ cargo.rust_library(
     srcs = [":oorandom-11.1.5.crate"],
     crate = "oorandom",
     crate_root = "oorandom-11.1.5.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+)
+
+http_archive(
+    name = "overload-0.1.1.crate",
+    sha256 = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39",
+    strip_prefix = "overload-0.1.1",
+    urls = ["https://static.crates.io/crates/overload/0.1.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "overload-0.1.1",
+    srcs = [":overload-0.1.1.crate"],
+    crate = "overload",
+    crate_root = "overload-0.1.1.crate/src/lib.rs",
     edition = "2018",
     visibility = [],
 )
@@ -2444,6 +2612,29 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "regex-automata-0.1.10.crate",
+    sha256 = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132",
+    strip_prefix = "regex-automata-0.1.10",
+    urls = ["https://static.crates.io/crates/regex-automata/0.1.10/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "regex-automata-0.1.10",
+    srcs = [":regex-automata-0.1.10.crate"],
+    crate = "regex_automata",
+    crate_root = "regex-automata-0.1.10.crate/src/lib.rs",
+    edition = "2015",
+    features = [
+        "default",
+        "regex-syntax",
+        "std",
+    ],
+    visibility = [],
+    deps = [":regex-syntax-0.6.29"],
+)
+
+http_archive(
     name = "regex-automata-0.4.9.crate",
     sha256 = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908",
     strip_prefix = "regex-automata-0.4.9",
@@ -2487,6 +2678,34 @@ cargo.rust_library(
         ":memchr-2.7.5",
         ":regex-syntax-0.8.5",
     ],
+)
+
+http_archive(
+    name = "regex-syntax-0.6.29.crate",
+    sha256 = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1",
+    strip_prefix = "regex-syntax-0.6.29",
+    urls = ["https://static.crates.io/crates/regex-syntax/0.6.29/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "regex-syntax-0.6.29",
+    srcs = [":regex-syntax-0.6.29.crate"],
+    crate = "regex_syntax",
+    crate_root = "regex-syntax-0.6.29.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "unicode",
+        "unicode-age",
+        "unicode-bool",
+        "unicode-case",
+        "unicode-gencat",
+        "unicode-perl",
+        "unicode-script",
+        "unicode-segment",
+    ],
+    visibility = [],
 )
 
 http_archive(
@@ -2977,6 +3196,24 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "sharded-slab-0.1.7.crate",
+    sha256 = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6",
+    strip_prefix = "sharded-slab-0.1.7",
+    urls = ["https://static.crates.io/crates/sharded-slab/0.1.7/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "sharded-slab-0.1.7",
+    srcs = [":sharded-slab-0.1.7.crate"],
+    crate = "sharded_slab",
+    crate_root = "sharded-slab-0.1.7.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [":lazy_static-1.5.0"],
+)
+
+http_archive(
     name = "signal-hook-registry-1.4.5.crate",
     sha256 = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410",
     strip_prefix = "signal-hook-registry-1.4.5",
@@ -3289,6 +3526,24 @@ cargo.rust_library(
         ":quote-1.0.40",
         ":syn-2.0.104",
     ],
+)
+
+http_archive(
+    name = "thread_local-1.1.9.crate",
+    sha256 = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185",
+    strip_prefix = "thread_local-1.1.9",
+    urls = ["https://static.crates.io/crates/thread_local/1.1.9/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "thread_local-1.1.9",
+    srcs = [":thread_local-1.1.9.crate"],
+    crate = "thread_local",
+    crate_root = "thread_local-1.1.9.crate/src/lib.rs",
+    edition = "2021",
+    visibility = [],
+    deps = [":cfg-if-1.0.1"],
 )
 
 http_archive(
@@ -3619,6 +3874,12 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "tracing",
+    actual = ":tracing-0.1.41",
+    visibility = ["PUBLIC"],
+)
+
 http_archive(
     name = "tracing-0.1.41.crate",
     sha256 = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0",
@@ -3685,11 +3946,152 @@ cargo.rust_library(
     crate_root = "tracing-core-0.1.34.crate/src/lib.rs",
     edition = "2018",
     features = [
+        "default",
         "once_cell",
         "std",
     ],
     visibility = [],
     deps = [":once_cell-1.21.3"],
+)
+
+http_archive(
+    name = "tracing-log-0.2.0.crate",
+    sha256 = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3",
+    strip_prefix = "tracing-log-0.2.0",
+    urls = ["https://static.crates.io/crates/tracing-log/0.2.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tracing-log-0.2.0",
+    srcs = [":tracing-log-0.2.0.crate"],
+    crate = "tracing_log",
+    crate_root = "tracing-log-0.2.0.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "log-tracer",
+        "std",
+    ],
+    visibility = [],
+    deps = [
+        ":log-0.4.27",
+        ":once_cell-1.21.3",
+        ":tracing-core-0.1.34",
+    ],
+)
+
+http_archive(
+    name = "tracing-serde-0.2.0.crate",
+    sha256 = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1",
+    strip_prefix = "tracing-serde-0.2.0",
+    urls = ["https://static.crates.io/crates/tracing-serde/0.2.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tracing-serde-0.2.0",
+    srcs = [":tracing-serde-0.2.0.crate"],
+    crate = "tracing_serde",
+    crate_root = "tracing-serde-0.2.0.crate/src/lib.rs",
+    edition = "2018",
+    visibility = [],
+    deps = [
+        ":serde-1.0.219",
+        ":tracing-core-0.1.34",
+    ],
+)
+
+alias(
+    name = "tracing-subscriber",
+    actual = ":tracing-subscriber-0.3.19",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "tracing-subscriber-0.3.19.crate",
+    sha256 = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008",
+    strip_prefix = "tracing-subscriber-0.3.19",
+    urls = ["https://static.crates.io/crates/tracing-subscriber/0.3.19/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tracing-subscriber-0.3.19",
+    srcs = [":tracing-subscriber-0.3.19.crate"],
+    crate = "tracing_subscriber",
+    crate_root = "tracing-subscriber-0.3.19.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "alloc",
+        "ansi",
+        "default",
+        "env-filter",
+        "fmt",
+        "json",
+        "matchers",
+        "nu-ansi-term",
+        "once_cell",
+        "regex",
+        "registry",
+        "serde",
+        "serde_json",
+        "sharded-slab",
+        "smallvec",
+        "std",
+        "thread_local",
+        "tracing",
+        "tracing-log",
+        "tracing-serde",
+    ],
+    visibility = [],
+    deps = [
+        ":matchers-0.1.0",
+        ":nu-ansi-term-0.46.0",
+        ":once_cell-1.21.3",
+        ":regex-1.11.1",
+        ":serde-1.0.219",
+        ":serde_json-1.0.141",
+        ":sharded-slab-0.1.7",
+        ":smallvec-1.15.1",
+        ":thread_local-1.1.9",
+        ":tracing-0.1.41",
+        ":tracing-core-0.1.34",
+        ":tracing-log-0.2.0",
+        ":tracing-serde-0.2.0",
+    ],
+)
+
+alias(
+    name = "tracing-tree",
+    actual = ":tracing-tree-0.3.1",
+    visibility = ["PUBLIC"],
+)
+
+http_archive(
+    name = "tracing-tree-0.3.1.crate",
+    sha256 = "b56c62d2c80033cb36fae448730a2f2ef99410fe3ecbffc916681a32f6807dbe",
+    strip_prefix = "tracing-tree-0.3.1",
+    urls = ["https://static.crates.io/crates/tracing-tree/0.3.1/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "tracing-tree-0.3.1",
+    srcs = [":tracing-tree-0.3.1.crate"],
+    crate = "tracing_tree",
+    crate_root = "tracing-tree-0.3.1.crate/src/lib.rs",
+    edition = "2018",
+    features = [
+        "default",
+        "tracing-log",
+    ],
+    visibility = [],
+    deps = [
+        ":nu-ansi-term-0.50.1",
+        ":tracing-core-0.1.34",
+        ":tracing-log-0.2.0",
+        ":tracing-subscriber-0.3.19",
+    ],
 )
 
 http_archive(
@@ -3799,6 +4201,38 @@ cargo.rust_library(
 )
 
 http_archive(
+    name = "winapi-0.3.9.crate",
+    sha256 = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419",
+    strip_prefix = "winapi-0.3.9",
+    urls = ["https://static.crates.io/crates/winapi/0.3.9/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "winapi-0.3.9",
+    srcs = [":winapi-0.3.9.crate"],
+    crate = "winapi",
+    crate_root = "winapi-0.3.9.crate/src/lib.rs",
+    edition = "2015",
+    features = [
+        "consoleapi",
+        "errhandlingapi",
+        "fileapi",
+        "handleapi",
+        "minwinbase",
+        "minwindef",
+        "processenv",
+        "winbase",
+    ],
+    platform = {
+        "windows-gnu": dict(
+            deps = [":winapi-x86_64-pc-windows-gnu-0.4.0"],
+        ),
+    },
+    visibility = [],
+)
+
+http_archive(
     name = "winapi-util-0.1.9.crate",
     sha256 = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb",
     strip_prefix = "winapi-util-0.1.9",
@@ -3821,6 +4255,51 @@ cargo.rust_library(
         ),
     },
     visibility = [],
+)
+
+http_archive(
+    name = "winapi-x86_64-pc-windows-gnu-0.4.0.crate",
+    sha256 = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f",
+    strip_prefix = "winapi-x86_64-pc-windows-gnu-0.4.0",
+    urls = ["https://static.crates.io/crates/winapi-x86_64-pc-windows-gnu/0.4.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "winapi-x86_64-pc-windows-gnu-0.4.0",
+    srcs = [":winapi-x86_64-pc-windows-gnu-0.4.0.crate"],
+    crate = "winapi_x86_64_pc_windows_gnu",
+    crate_root = "winapi-x86_64-pc-windows-gnu-0.4.0.crate/src/lib.rs",
+    edition = "2015",
+    visibility = [],
+)
+
+http_archive(
+    name = "windows-sys-0.52.0.crate",
+    sha256 = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d",
+    strip_prefix = "windows-sys-0.52.0",
+    urls = ["https://static.crates.io/crates/windows-sys/0.52.0/download"],
+    visibility = [],
+)
+
+cargo.rust_library(
+    name = "windows-sys-0.52.0",
+    srcs = [":windows-sys-0.52.0.crate"],
+    crate = "windows_sys",
+    crate_root = "windows-sys-0.52.0.crate/src/lib.rs",
+    edition = "2021",
+    features = [
+        "Win32",
+        "Win32_Foundation",
+        "Win32_Security",
+        "Win32_Storage",
+        "Win32_Storage_FileSystem",
+        "Win32_System",
+        "Win32_System_Console",
+        "default",
+    ],
+    visibility = [],
+    deps = [":windows-targets-0.52.6"],
 )
 
 http_archive(

--- a/third-party/rust/Cargo.toml
+++ b/third-party/rust/Cargo.toml
@@ -23,6 +23,7 @@ edition = "2024"
 version = "0.1.0"
 
 [dependencies]
+atty = "0.2"
 bpaf = "0.9.20"
 criterion = "0.5.0"
 indexmap = "2.0.0"
@@ -34,4 +35,7 @@ tempfile = "3.8.0"
 thiserror = "2.0.12"
 tokio = { version = "1.0", features = ["full"] }
 tower-lsp = "0.20"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
+tracing-tree = "0.3"
 # END: DEPENDENCIES


### PR DESCRIPTION
- Add tracing crate dependencies to all relevant crates
- Create logging infrastructure module with configurable formats and filters
- Replace all RUE_* environment variable checks with tracing macros
- Add CLI flags: -v/-vv/-vvv for verbosity, --log-format, --log-filter
- Use hierarchical targets for fine-grained control (rue::mir, rue::codegen, etc.)
- Support multiple output formats: pretty, json, compact, tree
- Update documentation to reflect new logging approach