### PR TITLE
Standardize build system to use Rust edition 2024

### DIFF
--- a/crates/rue-lsp/Cargo.toml
+++ b/crates/rue-lsp/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rue-lsp"
-version = "0.1.0"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [[bin]]
 name = "rue-lsp"

--- a/crates/rue-lsp/src/lib.rs
+++ b/crates/rue-lsp/src/lib.rs
@@ -2,8 +2,8 @@ mod position;
 
 use position::PositionCalculator;
 use rue_lexer::Lexer;
-use rue_parser::{parse, ParseError};
-use rue_semantic::{analyze_cst, SemanticError};
+use rue_parser::{ParseError, parse};
+use rue_semantic::{SemanticError, analyze_cst};
 use std::collections::HashMap;
 use tokio::sync::RwLock;
 use tower_lsp::jsonrpc::Result;


### PR DESCRIPTION
Update rue-lsp to use workspace edition and version configuration, ensuring all crates consistently use edition 2024 and workspace-level dependency management.