### PR TITLE
Add aggregate type support to MIR

### DIFF
--- a/crates/rue-ir/src/mir.rs
+++ b/crates/rue-ir/src/mir.rs
@@ -30,10 +30,11 @@
 //!     return result
 //! ```
 
-use crate::types::RueType;
+use crate::types::{FieldId, RueType, StructId};
 use rue_lexer::Span;
 use std::collections::HashMap;
 use std::fmt;
+use std::rc::Rc;
 
 /// A unique identifier for a basic block
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
@@ -124,10 +125,47 @@ pub enum MirValue {
         args: Vec<Temp>,
         kind: CallKind,
     },
+    /// Construct an aggregate value (struct, tuple, or array)
+    ConstructAggregate {
+        /// Type of the aggregate being constructed
+        ty: RueType,
+        /// Values for each field/element in order
+        fields: Vec<Temp>,
+    },
+    /// Extract a field from an aggregate value
+    GetField {
+        /// The aggregate value to extract from
+        base: Temp,
+        /// Which field to extract
+        field: FieldId,
+    },
+    /// Update a field in an aggregate value (creates new aggregate)
+    SetField {
+        /// The aggregate value to update
+        base: Temp,
+        /// Which field to update
+        field: FieldId,
+        /// New value for the field
+        value: Temp,
+    },
+    /// Partial struct update (functional update syntax)
+    /// Creates a new struct with some fields from base and some overridden
+    ///
+    /// **MVS Semantics**: This operation CONSUMES the base struct.
+    /// The base temp is moved into the result and should not be used after
+    /// this operation. This is important for move/ownership tracking.
+    StructUpdate {
+        /// The base struct to copy from (consumed by this operation)
+        base: Temp,
+        /// Fields to override (field_id, new_value)
+        updates: Vec<(FieldId, Temp)>,
+        /// Type of the struct (for validation)
+        struct_type: StructId,
+    },
 }
 
 /// Constant values in MIR
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum MirConst {
     /// 32-bit integer constant
     Int32(i32),
@@ -137,6 +175,14 @@ pub enum MirConst {
     Bool(bool),
     /// Unit constant
     Unit,
+    /// Aggregate constant (struct, tuple, or array)
+    Aggregate {
+        /// Type of the aggregate
+        ty: RueType,
+        /// Constant values for each field/element
+        /// Uses Rc to allow cheap cloning
+        fields: Rc<[MirConst]>,
+    },
 }
 
 /// Binary operations in MIR
@@ -266,6 +312,23 @@ impl MirConst {
             MirConst::Int64(_) => RueType::I64,
             MirConst::Bool(_) => RueType::Bool,
             MirConst::Unit => RueType::Unit,
+            MirConst::Aggregate { ty, .. } => ty.clone(),
+        }
+    }
+
+    /// Create an aggregate constant from a vector of fields
+    pub fn aggregate(ty: RueType, fields: Vec<MirConst>) -> Self {
+        MirConst::Aggregate {
+            ty,
+            fields: fields.into(), // Vec<T> converts to Rc<[T]>
+        }
+    }
+
+    /// Get fields of an aggregate (returns empty slice for non-aggregates)
+    pub fn fields(&self) -> &[MirConst] {
+        match self {
+            MirConst::Aggregate { fields, .. } => fields,
+            _ => &[],
         }
     }
 }
@@ -295,6 +358,28 @@ impl MirValue {
                 // Call types must be determined from assignment context
                 // The destination temp of the assignment contains the type
                 None
+            }
+            MirValue::ConstructAggregate { ty, .. } => Some(ty.clone()),
+            MirValue::GetField { base, field } => {
+                let base_ty = temp_types(*base);
+                // Extract field type from aggregate type
+                match (&base_ty, field) {
+                    (RueType::Tuple(types), FieldId::Index(idx)) => types.get(*idx).cloned(),
+                    (RueType::Array(elem_ty, _), FieldId::Index(_)) => {
+                        Some(elem_ty.as_ref().clone())
+                    }
+                    // For structs, we'd need the struct definition to get field type
+                    // For now, return None (type must be determined from context)
+                    _ => None,
+                }
+            }
+            MirValue::SetField { base, .. } => {
+                // SetField creates a new aggregate of the same type as base
+                Some(temp_types(*base))
+            }
+            MirValue::StructUpdate { struct_type, .. } => {
+                // StructUpdate creates a new struct of the given type
+                Some(RueType::Struct(*struct_type))
             }
         }
     }
@@ -424,6 +509,36 @@ impl fmt::Display for MirValue {
                 }
                 write!(f, ")")
             }
+            MirValue::ConstructAggregate { ty, fields } => {
+                write!(f, "ConstructAggregate {ty} {{")?;
+                for (i, field) in fields.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{field}")?;
+                }
+                write!(f, "}}")
+            }
+            MirValue::GetField { base, field } => {
+                write!(f, "{base}.{field}")
+            }
+            MirValue::SetField { base, field, value } => {
+                write!(f, "SetField {base}.{field} = {value}")
+            }
+            MirValue::StructUpdate {
+                base,
+                updates,
+                struct_type,
+            } => {
+                write!(f, "StructUpdate({struct_type}) {{ ")?;
+                for (i, (field, value)) in updates.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{field}: {value}")?;
+                }
+                write!(f, ", ..{base} }}")
+            }
         }
     }
 }
@@ -435,6 +550,16 @@ impl fmt::Display for MirConst {
             MirConst::Int64(n) => write!(f, "{n}_i64"),
             MirConst::Bool(b) => write!(f, "{b}"),
             MirConst::Unit => write!(f, "()"),
+            MirConst::Aggregate { ty, fields } => {
+                write!(f, "const {ty} {{")?;
+                for (i, field) in fields.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{field}")?;
+                }
+                write!(f, "}}")
+            }
         }
     }
 }
@@ -735,3 +860,8 @@ mod tests {
         assert!(output.contains("default B3"));
     }
 }
+
+// Include aggregate tests module
+#[cfg(test)]
+#[path = "mir_aggregate_tests.rs"]
+mod mir_aggregate_tests;

--- a/crates/rue-ir/src/mir_aggregate_tests.rs
+++ b/crates/rue-ir/src/mir_aggregate_tests.rs
@@ -1,0 +1,484 @@
+//! Tests for MIR aggregate type support
+//!
+//! These tests create synthetic MIR programs to test aggregate type handling
+//! without requiring parser or HIR support.
+
+#[cfg(test)]
+mod tests {
+    use crate::mir::*;
+    use crate::types::{FieldId, RueType, StructId};
+    use std::collections::HashMap;
+
+    /// Helper to create a simple MIR program with one function
+    fn create_test_program(name: &str, blocks: Vec<BasicBlock>) -> MirProgram {
+        let func = MirFunction {
+            name: name.to_string(),
+            params: vec![],
+            return_type: RueType::Unit,
+            blocks,
+            entry_block: BlockId(0),
+            temp_types: HashMap::new(),
+            span: rue_lexer::Span::dummy(),
+        };
+
+        MirProgram {
+            functions: vec![func],
+            function_signatures: HashMap::new(),
+        }
+    }
+
+    #[test]
+    fn test_aggregate_construction() {
+        // Test: t0 = ConstructAggregate Point { t1, t2 }
+        let struct_id = StructId::new(1);
+        let t1 = Temp(1);
+        let t2 = Temp(2);
+        let t0 = Temp(0);
+
+        let block = BasicBlock {
+            id: BlockId(0),
+            params: vec![],
+            statements: vec![
+                MirStatement::Assign {
+                    dest: t1,
+                    value: MirValue::Const(MirConst::Int32(10)),
+                    span: None,
+                },
+                MirStatement::Assign {
+                    dest: t2,
+                    value: MirValue::Const(MirConst::Int32(20)),
+                    span: None,
+                },
+                MirStatement::Assign {
+                    dest: t0,
+                    value: MirValue::ConstructAggregate {
+                        ty: RueType::Struct(struct_id),
+                        fields: vec![t1, t2],
+                    },
+                    span: None,
+                },
+            ],
+            terminator: MirTerminator::Return {
+                value: None,
+                span: None,
+            },
+        };
+
+        let program = create_test_program("test_construct", vec![block]);
+        let output = format!("{program}");
+
+        assert!(output.contains("ConstructAggregate"));
+        assert!(output.contains("struct#1"));
+    }
+
+    #[test]
+    fn test_field_access() {
+        // Test: t2 = GetField t1.0
+        let t1 = Temp(1);
+        let t2 = Temp(2);
+
+        let block = BasicBlock {
+            id: BlockId(0),
+            params: vec![],
+            statements: vec![
+                MirStatement::Assign {
+                    dest: t1,
+                    value: MirValue::ConstructAggregate {
+                        ty: RueType::Tuple(vec![RueType::I32, RueType::I32]),
+                        fields: vec![],
+                    },
+                    span: None,
+                },
+                MirStatement::Assign {
+                    dest: t2,
+                    value: MirValue::GetField {
+                        base: t1,
+                        field: FieldId::Index(0),
+                    },
+                    span: None,
+                },
+            ],
+            terminator: MirTerminator::Return {
+                value: Some(t2),
+                span: None,
+            },
+        };
+
+        let program = create_test_program("test_field", vec![block]);
+        let output = format!("{program}");
+
+        assert!(output.contains("t1.0"));
+        assert!(output.contains("GetField") || output.contains("."));
+    }
+
+    #[test]
+    fn test_struct_update() {
+        // Test: t3 = StructUpdate t1 { x: t2 }
+        let struct_id = StructId::new(2);
+        let t1 = Temp(1);
+        let t2 = Temp(2);
+        let t3 = Temp(3);
+
+        let block = BasicBlock {
+            id: BlockId(0),
+            params: vec![],
+            statements: vec![MirStatement::Assign {
+                dest: t3,
+                value: MirValue::StructUpdate {
+                    base: t1,
+                    updates: vec![(FieldId::Named("x".to_string()), t2)],
+                    struct_type: struct_id,
+                },
+                span: None,
+            }],
+            terminator: MirTerminator::Return {
+                value: None,
+                span: None,
+            },
+        };
+
+        let program = create_test_program("test_update", vec![block]);
+        let output = format!("{program}");
+
+        assert!(output.contains("StructUpdate"));
+        assert!(output.contains("..t1"));
+    }
+
+    #[test]
+    fn test_aggregate_constant() {
+        // Test: const Tuple(i32, i32) { 1, 2 }
+        let const_val = MirConst::aggregate(
+            RueType::Tuple(vec![RueType::I32, RueType::I32]),
+            vec![MirConst::Int32(1), MirConst::Int32(2)],
+        );
+
+        let t0 = Temp(0);
+
+        let block = BasicBlock {
+            id: BlockId(0),
+            params: vec![],
+            statements: vec![MirStatement::Assign {
+                dest: t0,
+                value: MirValue::Const(const_val),
+                span: None,
+            }],
+            terminator: MirTerminator::Return {
+                value: None,
+                span: None,
+            },
+        };
+
+        let program = create_test_program("test_const", vec![block]);
+        let output = format!("{program}");
+
+        assert!(output.contains("const"));
+        // Check for the actual tuple format in the output
+        assert!(output.contains("(i32, i32)"));
+    }
+
+    #[test]
+    fn test_array_type() {
+        // Test array construction and access
+        let array_ty = RueType::Array(Box::new(RueType::I32), 3);
+        let t0 = Temp(0);
+        let t1 = Temp(1);
+
+        let block = BasicBlock {
+            id: BlockId(0),
+            params: vec![],
+            statements: vec![
+                MirStatement::Assign {
+                    dest: t0,
+                    value: MirValue::ConstructAggregate {
+                        ty: array_ty.clone(),
+                        fields: vec![],
+                    },
+                    span: None,
+                },
+                MirStatement::Assign {
+                    dest: t1,
+                    value: MirValue::GetField {
+                        base: t0,
+                        field: FieldId::Index(1),
+                    },
+                    span: None,
+                },
+            ],
+            terminator: MirTerminator::Return {
+                value: None,
+                span: None,
+            },
+        };
+
+        let program = create_test_program("test_array", vec![block]);
+        let output = format!("{program}");
+
+        assert!(output.contains("[i32; 3]"));
+        assert!(output.contains("t0.1"));
+    }
+
+    #[test]
+    fn test_nested_aggregates() {
+        // Test: Tuple containing a struct
+        let struct_id = StructId::new(3);
+        let nested_ty = RueType::Tuple(vec![RueType::Struct(struct_id), RueType::I32]);
+
+        let t0 = Temp(0);
+
+        let block = BasicBlock {
+            id: BlockId(0),
+            params: vec![],
+            statements: vec![MirStatement::Assign {
+                dest: t0,
+                value: MirValue::ConstructAggregate {
+                    ty: nested_ty,
+                    fields: vec![],
+                },
+                span: None,
+            }],
+            terminator: MirTerminator::Return {
+                value: None,
+                span: None,
+            },
+        };
+
+        let program = create_test_program("test_nested", vec![block]);
+        let output = format!("{program}");
+
+        // Check for tuple containing struct
+        assert!(output.contains("(struct#3, i32)"));
+    }
+
+    #[test]
+    fn test_set_field() {
+        // Test: t2 = SetField t0.field = t1
+        let t0 = Temp(0);
+        let t1 = Temp(1);
+        let t2 = Temp(2);
+
+        let block = BasicBlock {
+            id: BlockId(0),
+            params: vec![],
+            statements: vec![MirStatement::Assign {
+                dest: t2,
+                value: MirValue::SetField {
+                    base: t0,
+                    field: FieldId::Named("value".to_string()),
+                    value: t1,
+                },
+                span: None,
+            }],
+            terminator: MirTerminator::Return {
+                value: None,
+                span: None,
+            },
+        };
+
+        let program = create_test_program("test_set_field", vec![block]);
+        let output = format!("{program}");
+
+        assert!(output.contains("SetField"));
+        assert!(output.contains("t0.value"));
+    }
+
+    #[test]
+    fn test_nested_field_access() {
+        // Test: p.sub_point.x - accessing field of nested aggregate
+        // This demonstrates accessing a field of a struct that is itself a field
+
+        let t0 = Temp(0); // outer struct (assumed to have a sub_point field)
+        let t1 = Temp(1); // inner struct (result of first GetField)
+        let t2 = Temp(2); // final value (result of second GetField)
+
+        let block = BasicBlock {
+            id: BlockId(0),
+            params: vec![(t0, RueType::Struct(StructId::new(11)))], // t0 is passed as param
+            statements: vec![
+                // t1 = t0.sub_point (get inner struct)
+                MirStatement::Assign {
+                    dest: t1,
+                    value: MirValue::GetField {
+                        base: t0,
+                        field: FieldId::Named("sub_point".to_string()),
+                    },
+                    span: None,
+                },
+                // t2 = t1.x (get field from inner struct)
+                MirStatement::Assign {
+                    dest: t2,
+                    value: MirValue::GetField {
+                        base: t1,
+                        field: FieldId::Named("x".to_string()),
+                    },
+                    span: None,
+                },
+            ],
+            terminator: MirTerminator::Return {
+                value: Some(t2),
+                span: None,
+            },
+        };
+
+        let program = create_test_program("test_nested_access", vec![block]);
+        let output = format!("{program}");
+
+        // Should show chained field access
+        assert!(output.contains("t0.sub_point"));
+        assert!(output.contains("t1.x"));
+    }
+
+    #[test]
+    fn test_zero_field_structs() {
+        // Test: Empty struct and unit tuple
+        let empty_struct = StructId::new(20);
+        let unit_tuple = RueType::Tuple(vec![]);
+
+        let t0 = Temp(0);
+        let t1 = Temp(1);
+
+        let block = BasicBlock {
+            id: BlockId(0),
+            params: vec![],
+            statements: vec![
+                // Construct empty struct
+                MirStatement::Assign {
+                    dest: t0,
+                    value: MirValue::ConstructAggregate {
+                        ty: RueType::Struct(empty_struct),
+                        fields: vec![],
+                    },
+                    span: None,
+                },
+                // Construct unit tuple
+                MirStatement::Assign {
+                    dest: t1,
+                    value: MirValue::ConstructAggregate {
+                        ty: unit_tuple,
+                        fields: vec![],
+                    },
+                    span: None,
+                },
+            ],
+            terminator: MirTerminator::Return {
+                value: None,
+                span: None,
+            },
+        };
+
+        let program = create_test_program("test_zero_fields", vec![block]);
+        let output = format!("{program}");
+
+        // Should handle empty aggregates without panic
+        assert!(output.contains("struct#20 {}"));
+        assert!(output.contains("() {}"));
+    }
+
+    #[test]
+    fn test_array_constant() {
+        // Test: const [i32; 3] { 1, 2, 3 }
+        let array_const = MirConst::aggregate(
+            RueType::Array(Box::new(RueType::I32), 3),
+            vec![MirConst::Int32(1), MirConst::Int32(2), MirConst::Int32(3)],
+        );
+
+        let t0 = Temp(0);
+
+        let block = BasicBlock {
+            id: BlockId(0),
+            params: vec![],
+            statements: vec![MirStatement::Assign {
+                dest: t0,
+                value: MirValue::Const(array_const),
+                span: None,
+            }],
+            terminator: MirTerminator::Return {
+                value: Some(t0),
+                span: None,
+            },
+        };
+
+        let program = create_test_program("test_array_const", vec![block]);
+        let output = format!("{program}");
+
+        // Should show array constant
+        assert!(output.contains("const [i32; 3]"));
+        assert!(output.contains("1_i32") && output.contains("2_i32") && output.contains("3_i32"));
+    }
+
+    #[test]
+    fn test_struct_update_consumption() {
+        // Test: StructUpdate consumes base (important for MVS)
+        // After StructUpdate, base should not be usable
+        let struct_id = StructId::new(30);
+        let t0 = Temp(0); // base struct
+        let t1 = Temp(1); // new value
+        let t2 = Temp(2); // result of StructUpdate
+
+        let block = BasicBlock {
+            id: BlockId(0),
+            params: vec![],
+            statements: vec![
+                // t2 = StructUpdate t0 { field: t1 }
+                // This CONSUMES t0 - it's moved into t2
+                MirStatement::Assign {
+                    dest: t2,
+                    value: MirValue::StructUpdate {
+                        base: t0,
+                        updates: vec![(FieldId::Named("field".to_string()), t1)],
+                        struct_type: struct_id,
+                    },
+                    span: None,
+                },
+                // NOTE: Using t0 after this point would be invalid in MVS
+                // This is a semantic test - the MIR represents the consumption
+            ],
+            terminator: MirTerminator::Return {
+                value: Some(t2),
+                span: None,
+            },
+        };
+
+        let program = create_test_program("test_update_consumes", vec![block]);
+        let output = format!("{program}");
+
+        // The output shows the consumption pattern
+        assert!(output.contains("StructUpdate"));
+        assert!(output.contains("..t0"));
+        // Comment documents that t0 is consumed
+    }
+
+    #[test]
+    fn test_pretty_printer_determinism() {
+        // Test: Pretty-printer produces stable output
+        let ty = RueType::Tuple(vec![RueType::I32, RueType::Bool]);
+        let t0 = Temp(0);
+
+        let block = BasicBlock {
+            id: BlockId(0),
+            params: vec![],
+            statements: vec![MirStatement::Assign {
+                dest: t0,
+                value: MirValue::ConstructAggregate {
+                    ty: ty.clone(),
+                    fields: vec![],
+                },
+                span: None,
+            }],
+            terminator: MirTerminator::Return {
+                value: None,
+                span: None,
+            },
+        };
+
+        let program = create_test_program("test_determinism", vec![block]);
+
+        // Generate output multiple times
+        let output1 = format!("{program}");
+        let output2 = format!("{program}");
+        let output3 = format!("{program}");
+
+        // All outputs should be identical
+        assert_eq!(output1, output2);
+        assert_eq!(output2, output3);
+    }
+}

--- a/crates/rue-ir/src/types.rs
+++ b/crates/rue-ir/src/types.rs
@@ -1,5 +1,72 @@
 use std::fmt;
 
+/// Unique identifier for a struct type definition
+///
+/// This is an opaque handle that references a struct definition in a type registry.
+/// The internal u32 provides efficient copying and comparison.
+///
+/// # Design Notes
+/// - Uses newtype pattern for type safety (can't mix with other u32s)
+/// - Derives standard traits for use in collections
+/// - Display implementation shows human-readable format for debugging
+/// - Forward-compatible with future type registry implementation
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct StructId(pub u32);
+
+impl fmt::Display for StructId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "struct#{}", self.0)
+    }
+}
+
+impl StructId {
+    /// Create a new StructId with the given numeric value
+    ///
+    /// This is a stub implementation for now. In the future, this will
+    /// be replaced by proper registration in a type context/registry.
+    pub fn new(id: u32) -> Self {
+        Self(id)
+    }
+
+    /// Get the raw numeric ID
+    pub fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+/// Identifier for a field within a struct
+///
+/// Fields can be identified either by numeric index (for tuples/arrays)
+/// or by name (for named structs). This enum captures both cases.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum FieldId {
+    /// Numeric field index (0-based)
+    Index(usize),
+    /// Named field (stored as string for now, could be interned later)
+    Named(String),
+}
+
+impl fmt::Display for FieldId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            FieldId::Index(idx) => write!(f, "{idx}"),
+            FieldId::Named(name) => write!(f, "{name}"),
+        }
+    }
+}
+
+impl FieldId {
+    /// Create a field ID from a numeric index
+    pub fn from_index(idx: usize) -> Self {
+        FieldId::Index(idx)
+    }
+
+    /// Create a field ID from a field name
+    pub fn from_name(name: impl Into<String>) -> Self {
+        FieldId::Named(name.into())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum RueType {
     I32,
@@ -7,6 +74,53 @@ pub enum RueType {
     Bool,
     Unit,
     Unknown,
+
+    // Aggregate types
+    /// Struct type identified by its StructId
+    Struct(StructId),
+    /// Tuple type with ordered component types
+    Tuple(Vec<RueType>),
+    /// Array type with element type and fixed size
+    Array(Box<RueType>, usize),
+}
+
+impl RueType {
+    /// Check if this type is an aggregate (struct, tuple, or array)
+    pub fn is_aggregate(&self) -> bool {
+        matches!(
+            self,
+            RueType::Struct(_) | RueType::Tuple(_) | RueType::Array(_, _)
+        )
+    }
+
+    /// Check if this type is a primitive scalar type
+    pub fn is_scalar(&self) -> bool {
+        matches!(self, RueType::I32 | RueType::I64 | RueType::Bool)
+    }
+
+    /// Get the size of an array type, if this is an array
+    pub fn array_len(&self) -> Option<usize> {
+        match self {
+            RueType::Array(_, len) => Some(*len),
+            _ => None,
+        }
+    }
+
+    /// Get the element type of an array, if this is an array
+    pub fn array_element_type(&self) -> Option<&RueType> {
+        match self {
+            RueType::Array(elem_ty, _) => Some(elem_ty),
+            _ => None,
+        }
+    }
+
+    /// Get the component types of a tuple, if this is a tuple
+    pub fn tuple_types(&self) -> Option<&[RueType]> {
+        match self {
+            RueType::Tuple(types) => Some(types),
+            _ => None,
+        }
+    }
 }
 
 impl fmt::Display for RueType {
@@ -17,6 +131,57 @@ impl fmt::Display for RueType {
             RueType::Bool => write!(f, "bool"),
             RueType::Unit => write!(f, "()"),
             RueType::Unknown => write!(f, "unknown"),
+            RueType::Struct(id) => write!(f, "{id}"),
+            RueType::Tuple(types) => {
+                write!(f, "(")?;
+                for (i, ty) in types.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{ty}")?;
+                }
+                write!(f, ")")
+            }
+            RueType::Array(elem_ty, len) => write!(f, "[{elem_ty}; {len}]"),
         }
+    }
+}
+
+/// Stub struct definition for future use
+///
+/// This will eventually hold the actual struct field definitions.
+/// For now, it's a placeholder to demonstrate the API design.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StructDef {
+    /// The struct's unique ID
+    pub id: StructId,
+    /// The struct's name (for debugging/display)
+    pub name: String,
+    /// Field definitions (name -> type)
+    /// Using Vec to preserve field order
+    pub fields: Vec<(String, RueType)>,
+}
+
+impl StructDef {
+    /// Create a stub struct definition
+    pub fn stub(id: StructId, name: impl Into<String>) -> Self {
+        Self {
+            id,
+            name: name.into(),
+            fields: Vec::new(),
+        }
+    }
+
+    /// Get the type of a field by name
+    pub fn field_type(&self, name: &str) -> Option<&RueType> {
+        self.fields
+            .iter()
+            .find(|(field_name, _)| field_name == name)
+            .map(|(_, ty)| ty)
+    }
+
+    /// Get the type of a field by index
+    pub fn field_type_by_index(&self, index: usize) -> Option<&RueType> {
+        self.fields.get(index).map(|(_, ty)| ty)
     }
 }

--- a/crates/rue-lowering/src/mir_to_pir.rs
+++ b/crates/rue-lowering/src/mir_to_pir.rs
@@ -300,6 +300,10 @@ impl MirToPir {
                         }
                     }
                     MirConst::Unit => 0,
+                    MirConst::Aggregate { .. } => {
+                        // Aggregate constants not yet supported in lowering
+                        panic!("Aggregate constants not yet supported in MIR to PIR lowering");
+                    }
                 };
                 self.emit(PIR::Copy {
                     dest,
@@ -372,6 +376,19 @@ impl MirToPir {
                     function: func.clone(),
                     args: arg_vregs,
                 });
+            }
+            // Aggregate operations not yet supported in lowering
+            MirValue::ConstructAggregate { .. } => {
+                panic!("Aggregate construction not yet supported in MIR to PIR lowering");
+            }
+            MirValue::GetField { .. } => {
+                panic!("Field access not yet supported in MIR to PIR lowering");
+            }
+            MirValue::SetField { .. } => {
+                panic!("Field update not yet supported in MIR to PIR lowering");
+            }
+            MirValue::StructUpdate { .. } => {
+                panic!("Struct update not yet supported in MIR to PIR lowering");
             }
         }
     }

--- a/crates/rue-lowering/src/verifier.rs
+++ b/crates/rue-lowering/src/verifier.rs
@@ -276,6 +276,70 @@ impl MirVerifier {
                 // For now, return None to indicate the type should come from the dest
                 None
             }
+            // Aggregate operations - not yet fully verified
+            MirValue::ConstructAggregate { ty, fields } => {
+                // Verify all field temps are defined
+                for field in fields {
+                    if !defined_temps.contains_key(field) {
+                        self.add_error(
+                            format!("Use of undefined temp {field:?} in aggregate construction"),
+                            Some(block_id),
+                        );
+                    }
+                }
+                Some(ty.clone())
+            }
+            MirValue::GetField { base, .. } => {
+                // Verify base is defined
+                if !defined_temps.contains_key(base) {
+                    self.add_error(
+                        format!("Use of undefined temp {base:?} in field access"),
+                        Some(block_id),
+                    );
+                }
+                // Field type would need struct definition to determine
+                None
+            }
+            MirValue::SetField { base, value, .. } => {
+                // Verify base and value are defined
+                if !defined_temps.contains_key(base) {
+                    self.add_error(
+                        format!("Use of undefined temp {base:?} in field update"),
+                        Some(block_id),
+                    );
+                }
+                if !defined_temps.contains_key(value) {
+                    self.add_error(
+                        format!("Use of undefined temp {value:?} in field update"),
+                        Some(block_id),
+                    );
+                }
+                // Result type is same as base type
+                defined_temps.get(base).cloned()
+            }
+            MirValue::StructUpdate {
+                base,
+                updates,
+                struct_type,
+            } => {
+                // Verify base is defined
+                if !defined_temps.contains_key(base) {
+                    self.add_error(
+                        format!("Use of undefined temp {base:?} in struct update"),
+                        Some(block_id),
+                    );
+                }
+                // Verify all update values are defined
+                for (_, value) in updates {
+                    if !defined_temps.contains_key(value) {
+                        self.add_error(
+                            format!("Use of undefined temp {value:?} in struct update"),
+                            Some(block_id),
+                        );
+                    }
+                }
+                Some(RueType::Struct(*struct_type))
+            }
         }
     }
 

--- a/crates/rue-optimize/src/passes/const_prop.rs
+++ b/crates/rue-optimize/src/passes/const_prop.rs
@@ -54,7 +54,7 @@ impl ConstProp {
         match value {
             MirValue::Use(temp) => {
                 if let Some(const_val) = self.constants.get(temp) {
-                    *value = MirValue::Const(*const_val);
+                    *value = MirValue::Const(const_val.clone());
                 }
             }
             MirValue::BinaryOp { .. } => {
@@ -71,7 +71,7 @@ impl ConstProp {
     /// Try to evaluate a value as a constant
     fn evaluate_value(&self, value: &MirValue) -> Option<MirConst> {
         match value {
-            MirValue::Const(c) => Some(*c),
+            MirValue::Const(c) => Some(c.clone()),
             MirValue::Use(temp) => self.constants.get(temp).cloned(),
             MirValue::BinaryOp { op, lhs, rhs } => {
                 // Get constant values for both operands
@@ -89,6 +89,11 @@ impl ConstProp {
                 Self::fold_unop(*op, operand_const)
             }
             MirValue::Call { .. } => None, // Calls cannot be constant-folded
+            // Aggregate operations cannot be constant-folded yet
+            MirValue::ConstructAggregate { .. } => None,
+            MirValue::GetField { .. } => None,
+            MirValue::SetField { .. } => None,
+            MirValue::StructUpdate { .. } => None,
         }
     }
 
@@ -206,14 +211,14 @@ impl MirMutVisitor for ConstProp {
 
                 if let Some(const_val) = new_value {
                     // Record this temp as a constant
-                    self.constants.insert(*dest, const_val);
+                    self.constants.insert(*dest, const_val.clone());
 
                     // Replace with constant value
                     *value = MirValue::Const(const_val);
                     self.transformations += 1;
                 } else if let MirValue::Const(c) = value {
                     // If the value is already a constant, record it
-                    self.constants.insert(*dest, *c);
+                    self.constants.insert(*dest, c.clone());
                 }
             }
         }

--- a/crates/rue-optimize/src/passes/cse.rs
+++ b/crates/rue-optimize/src/passes/cse.rs
@@ -68,7 +68,7 @@ impl CommonSubexpressionElimination {
     /// Convert a MIR value to an expression if possible
     fn value_to_expression(&self, value: &MirValue) -> Option<Expression> {
         match value {
-            MirValue::Const(c) => Some(Expression::Const(*c)),
+            MirValue::Const(c) => Some(Expression::Const(c.clone())),
             MirValue::BinaryOp { op, lhs, rhs } => {
                 // For commutative operations, normalize the order
                 let (lhs, rhs) = if self.is_commutative(*op) && lhs > rhs {
@@ -85,6 +85,11 @@ impl CommonSubexpressionElimination {
             }),
             MirValue::Use(_) => None, // Simple uses aren't expressions we eliminate
             MirValue::Call { .. } => None, // Function calls have side effects
+            // Aggregate operations not yet handled by CSE
+            MirValue::ConstructAggregate { .. } => None,
+            MirValue::GetField { .. } => None,
+            MirValue::SetField { .. } => None,
+            MirValue::StructUpdate { .. } => None,
         }
     }
 

--- a/crates/rue-optimize/src/passes/dead_code.rs
+++ b/crates/rue-optimize/src/passes/dead_code.rs
@@ -224,6 +224,11 @@ impl DeadAssignmentRemover {
                     rue_ir::mir::CallKind::Impure => false, // Impure calls have side effects
                 }
             }
+            // Aggregate operations are pure (no side effects)
+            MirValue::ConstructAggregate { .. }
+            | MirValue::GetField { .. }
+            | MirValue::SetField { .. }
+            | MirValue::StructUpdate { .. } => true,
         }
     }
 }

--- a/crates/rue-optimize/src/visitor.rs
+++ b/crates/rue-optimize/src/visitor.rs
@@ -414,6 +414,37 @@ pub fn walk_value<V: MirVisitor + ?Sized>(visitor: &mut V, value: &MirValue) -> 
             }
             VisitorControl::Continue
         }
+        // Aggregate operations
+        MirValue::ConstructAggregate { fields, .. } => {
+            for field in fields {
+                let control = visitor.visit_temp(field);
+                if !control.should_continue() {
+                    return control;
+                }
+            }
+            VisitorControl::Continue
+        }
+        MirValue::GetField { base, .. } => visitor.visit_temp(base),
+        MirValue::SetField { base, value, .. } => {
+            let control = visitor.visit_temp(base);
+            if !control.should_continue() {
+                return control;
+            }
+            visitor.visit_temp(value)
+        }
+        MirValue::StructUpdate { base, updates, .. } => {
+            let control = visitor.visit_temp(base);
+            if !control.should_continue() {
+                return control;
+            }
+            for (_, value) in updates {
+                let control = visitor.visit_temp(value);
+                if !control.should_continue() {
+                    return control;
+                }
+            }
+            VisitorControl::Continue
+        }
     }
 }
 
@@ -606,6 +637,37 @@ pub fn walk_value_mut<V: MirMutVisitor + ?Sized>(
             }
             VisitorControl::Continue
         }
+        // Aggregate operations
+        MirValue::ConstructAggregate { fields, .. } => {
+            for field in fields {
+                let control = visitor.visit_temp(field);
+                if !control.should_continue() {
+                    return control;
+                }
+            }
+            VisitorControl::Continue
+        }
+        MirValue::GetField { base, .. } => visitor.visit_temp(base),
+        MirValue::SetField { base, value, .. } => {
+            let control = visitor.visit_temp(base);
+            if !control.should_continue() {
+                return control;
+            }
+            visitor.visit_temp(value)
+        }
+        MirValue::StructUpdate { base, updates, .. } => {
+            let control = visitor.visit_temp(base);
+            if !control.should_continue() {
+                return control;
+            }
+            for (_, value) in updates {
+                let control = visitor.visit_temp(value);
+                if !control.should_continue() {
+                    return control;
+                }
+            }
+            VisitorControl::Continue
+        }
     }
 }
 
@@ -755,6 +817,42 @@ pub fn fold_value<F: MirFolder + ?Sized>(
                 func,
                 args: new_args,
                 kind,
+            }
+        }
+        // Aggregate operations
+        MirValue::ConstructAggregate { ty, fields } => {
+            let mut new_fields = Vec::with_capacity(fields.len());
+            for field in fields {
+                new_fields.push(folder.fold_temp(field)?);
+            }
+            MirValue::ConstructAggregate {
+                ty,
+                fields: new_fields,
+            }
+        }
+        MirValue::GetField { base, field } => MirValue::GetField {
+            base: folder.fold_temp(base)?,
+            field,
+        },
+        MirValue::SetField { base, field, value } => MirValue::SetField {
+            base: folder.fold_temp(base)?,
+            field,
+            value: folder.fold_temp(value)?,
+        },
+        MirValue::StructUpdate {
+            base,
+            updates,
+            struct_type,
+        } => {
+            let base = folder.fold_temp(base)?;
+            let mut new_updates = Vec::with_capacity(updates.len());
+            for (field, value) in updates {
+                new_updates.push((field, folder.fold_temp(value)?));
+            }
+            MirValue::StructUpdate {
+                base,
+                updates: new_updates,
+                struct_type,
             }
         }
     })

--- a/test_type_ids.rs
+++ b/test_type_ids.rs
@@ -1,0 +1,46 @@
+// Quick test to verify the type ID design compiles and works
+
+use rue_ir::types::{RueType, StructId, FieldId, StructDef};
+
+fn main() {
+    // Test StructId
+    let struct_id1 = StructId::new(1);
+    let struct_id2 = StructId::new(2);
+    
+    println!("StructId display: {}", struct_id1);
+    println!("StructId raw: {}", struct_id1.as_u32());
+    assert_ne!(struct_id1, struct_id2);
+    
+    // Test FieldId
+    let field1 = FieldId::from_index(0);
+    let field2 = FieldId::from_name("x");
+    
+    println!("Indexed field: {}", field1);
+    println!("Named field: {}", field2);
+    
+    // Test aggregate types
+    let int_type = RueType::I32;
+    let struct_type = RueType::Struct(struct_id1);
+    let tuple_type = RueType::Tuple(vec![RueType::I32, RueType::Bool]);
+    let array_type = RueType::Array(Box::new(RueType::I64), 10);
+    
+    println!("Struct type: {}", struct_type);
+    println!("Tuple type: {}", tuple_type);
+    println!("Array type: {}", array_type);
+    
+    // Test helper methods
+    assert!(struct_type.is_aggregate());
+    assert!(int_type.is_scalar());
+    assert_eq!(array_type.array_len(), Some(10));
+    assert_eq!(tuple_type.tuple_types().map(|t| t.len()), Some(2));
+    
+    // Test StructDef stub
+    let mut struct_def = StructDef::stub(struct_id1, "Point");
+    struct_def.fields.push(("x".to_string(), RueType::I32));
+    struct_def.fields.push(("y".to_string(), RueType::I32));
+    
+    assert_eq!(struct_def.field_type("x"), Some(&RueType::I32));
+    assert_eq!(struct_def.field_type_by_index(1), Some(&RueType::I32));
+    
+    println!("\nAll tests passed!");
+}


### PR DESCRIPTION
Extend MIR to express aggregates (structs, tuples, arrays) as design-enablement for future aggregate feature implementation. MIR now supports first-class aggregates with partial initialization preserved for debuggability.

Key changes:
- Add StructId, FieldId types and extend RueType with aggregate variants
- Add MirValue variants: ConstructAggregate, GetField, SetField, StructUpdate
- Extend MirConst with Aggregate variant using Rc for efficient cloning
- Update optimization passes and visitors to handle aggregate operations
- Add comprehensive synthetic MIR tests for aggregate operations

No breaking changes - existing primitive-only programs continue to work.