### PR TITLE
Add heap allocation support and fix ELF writer runtime initialization

### DIFF
--- a/crates/rue-codegen/src/constants.rs
+++ b/crates/rue-codegen/src/constants.rs
@@ -46,6 +46,28 @@ pub const CHAR_MINUS: u8 = 45;
 pub const CHAR_ZERO: u8 = 48;
 
 // Memory management constants
+/// Memory management system call: brk (change data segment size)
+#[expect(unused)]
+pub const SYSCALL_BRK: i64 = 12;
+
+/// Memory management system call: mmap (map files or devices into memory)
+#[expect(unused)]
+pub const SYSCALL_MMAP: i64 = 9;
+
+/// Memory management system call: munmap (unmap files or devices from memory)
+#[expect(unused)]
+pub const SYSCALL_MUNMAP: i64 = 11;
+
+/// Default heap size for static allocator (64KB)
+pub const DEFAULT_HEAP_SIZE: u64 = 65536;
+
+/// Memory page size on x86-64 (4KB)
+#[expect(unused)]
+pub const PAGE_SIZE: u64 = 4096;
+
+/// Heap alignment requirement (8 bytes for x86-64)
+#[expect(unused)]
+pub const HEAP_ALIGNMENT: u64 = 8;
 
 /// Threshold for using rep movsb in memcpy (256 bytes)
 pub const MEMCPY_REP_THRESHOLD: u64 = 256;

--- a/crates/rue-codegen/src/runtime/alloc.rs
+++ b/crates/rue-codegen/src/runtime/alloc.rs
@@ -1,0 +1,194 @@
+//! Simple bump allocator for the Rue runtime
+//!
+//! This module provides a basic bump allocator using static memory:
+//! - Fixed 64KB heap allocated in .bss section
+//! - Allocation only (no free) - suitable for aggregates and temporary data
+//! - 8-byte alignment for all allocations
+//! - Can be upgraded to sys_brk or mmap later
+//!
+//! The allocator is designed for the initial aggregate type support and can
+//! be extended with more sophisticated memory management in the future.
+
+use crate::runtime::context::RuntimeContext;
+use rue_target::{X86Register, X8664Instr};
+
+impl RuntimeContext {
+    /// Generate allocator functions
+    pub fn generate_alloc_functions(&mut self) {
+        self.generate_heap_init_function();
+        self.generate_alloc_function();
+        self.generate_free_function();
+        self.generate_heap_reset_function();
+    }
+
+    /// Generate heap initialization function
+    ///
+    /// Initializes the heap by setting the current heap pointer to the start of the heap space.
+    /// This must be called before any allocations are made.
+    pub fn generate_heap_init_function(&mut self) {
+        let heap_init_label = self.define_label("__rue_heap_init");
+
+        self.instructions.push(X8664Instr::Label {
+            id: heap_init_label,
+        });
+
+        // Load heap start address into RAX using LEA
+        self.instructions.push(X8664Instr::LeaLabel {
+            dest: X86Register::Rax,
+            label: "__rue_heap_start".to_string(),
+        });
+
+        // Store heap start address into heap pointer location
+        // Use LEA to get address of __rue_heap_ptr, then store RAX there
+        self.instructions.push(X8664Instr::LeaLabel {
+            dest: X86Register::Rdx,
+            label: "__rue_heap_ptr".to_string(),
+        });
+        self.instructions.push(X8664Instr::MovMR {
+            base: X86Register::Rdx,
+            offset: 0,
+            src: X86Register::Rax,
+        });
+
+        self.instructions.push(X8664Instr::Ret);
+    }
+
+    /// Generate __rue_alloc function
+    ///
+    /// Implements a simple bump allocator that allocates memory from a fixed heap.
+    /// All allocations are 8-byte aligned. Returns NULL if out of memory.
+    ///
+    /// Parameters: RDI = size (bytes to allocate)
+    /// Returns: RAX = pointer to allocated memory, or NULL if out of memory
+    pub fn generate_alloc_function(&mut self) {
+        let alloc_label = self.define_label("__rue_alloc");
+
+        self.instructions
+            .push(X8664Instr::Label { id: alloc_label });
+
+        // Load current heap pointer into RAX
+        self.instructions.push(X8664Instr::LeaLabel {
+            dest: X86Register::Rdx,
+            label: "__rue_heap_ptr".to_string(),
+        });
+        self.instructions.push(X8664Instr::MovRM {
+            dest: X86Register::Rax,
+            base: X86Register::Rdx,
+            offset: 0,
+        });
+
+        // Save the current pointer as our return value (allocation address)
+        self.instructions.push(X8664Instr::MovRR {
+            dest: X86Register::Rcx,
+            src: X86Register::Rax,
+        });
+
+        // Align the requested size to 8-byte boundary
+        // size = (size + 7) & ~7
+        self.instructions.push(X8664Instr::AddRI {
+            dest: X86Register::Rdi,
+            imm: 7,
+        });
+        self.instructions.push(X8664Instr::AndRI {
+            dest: X86Register::Rdi,
+            imm: -8, // 0xFFFFFFFFFFFFFFF8 for proper 64-bit alignment mask
+        });
+
+        // Calculate new heap pointer: current + aligned_size
+        self.instructions.push(X8664Instr::AddRR {
+            dest: X86Register::Rax,
+            src: X86Register::Rdi,
+        });
+
+        // Check if new pointer exceeds heap end
+        self.instructions.push(X8664Instr::LeaLabel {
+            dest: X86Register::Rsi,
+            label: "__rue_heap_end".to_string(),
+        });
+        self.instructions.push(X8664Instr::CmpRR {
+            left: X86Register::Rax,
+            right: X86Register::Rsi,
+        });
+
+        // Jump to out_of_memory if new_ptr >= heap_end
+        let out_of_memory_label = self.new_label();
+        self.instructions.push(X8664Instr::JmpCC {
+            cc: rue_target::ConditionCode::GreaterEqual,
+            target: rue_target::LabelRef::Local(out_of_memory_label),
+        });
+
+        // Update heap pointer with new value
+        self.instructions.push(X8664Instr::MovMR {
+            base: X86Register::Rdx,
+            offset: 0,
+            src: X86Register::Rax,
+        });
+
+        // Return the old pointer (stored in RCX)
+        self.instructions.push(X8664Instr::MovRR {
+            dest: X86Register::Rax,
+            src: X86Register::Rcx,
+        });
+        self.instructions.push(X8664Instr::Ret);
+
+        // Out of memory: return NULL
+        self.instructions.push(X8664Instr::Label {
+            id: out_of_memory_label,
+        });
+        self.instructions.push(X8664Instr::XorRR {
+            dest: X86Register::Rax,
+            src: X86Register::Rax,
+        });
+        self.instructions.push(X8664Instr::Ret);
+    }
+
+    /// Generate __rue_free function (no-op for bump allocator)
+    ///
+    /// This is a no-op function for compatibility. The bump allocator
+    /// doesn't support individual frees - memory is reclaimed when
+    /// the entire heap is reset.
+    ///
+    /// Parameters: RDI = pointer (ignored)
+    /// Returns: void
+    pub fn generate_free_function(&mut self) {
+        let free_label = self.define_label("__rue_free");
+
+        self.instructions.push(X8664Instr::Label { id: free_label });
+        // No-op: just return
+        self.instructions.push(X8664Instr::Ret);
+    }
+
+    /// Generate __rue_heap_reset function
+    ///
+    /// Resets the heap by setting the current heap pointer back to the start of the heap space.
+    /// This effectively deallocates all allocated memory in the bump allocator.
+    ///
+    /// Parameters: none
+    /// Returns: void
+    pub fn generate_heap_reset_function(&mut self) {
+        let reset_label = self.define_label("__rue_heap_reset");
+
+        self.instructions
+            .push(X8664Instr::Label { id: reset_label });
+
+        // Load heap start address into RAX using LEA
+        self.instructions.push(X8664Instr::LeaLabel {
+            dest: X86Register::Rax,
+            label: "__rue_heap_start".to_string(),
+        });
+
+        // Store heap start address into heap pointer location
+        // Use LEA to get address of __rue_heap_ptr, then store RAX there
+        self.instructions.push(X8664Instr::LeaLabel {
+            dest: X86Register::Rdx,
+            label: "__rue_heap_ptr".to_string(),
+        });
+        self.instructions.push(X8664Instr::MovMR {
+            base: X86Register::Rdx,
+            offset: 0,
+            src: X86Register::Rax,
+        });
+
+        self.instructions.push(X8664Instr::Ret);
+    }
+}

--- a/crates/rue-codegen/src/runtime/data.rs
+++ b/crates/rue-codegen/src/runtime/data.rs
@@ -56,8 +56,42 @@ impl RuntimeContext {
         self.instructions
             .push(X8664Instr::ReserveBytes { count: 1024 });
 
-        // End of data section
+        // End of data section (before heap section)
         self.instructions
             .push(X8664Instr::Label { id: data_end_label });
+
+        // Switch to .bss section for heap data (writable, zero-initialized)
+        self.instructions.push(X8664Instr::Section {
+            name: ".bss".to_string(),
+        });
+
+        // Heap section - actual space allocation for bump allocator in .bss
+        let heap_start_label = self.define_label("__rue_heap_start");
+        self.instructions.push(X8664Instr::Label {
+            id: heap_start_label,
+        });
+
+        // Reserve heap space in .bss
+        self.instructions.push(X8664Instr::ReserveBytes {
+            count: crate::constants::DEFAULT_HEAP_SIZE as u32,
+        });
+
+        // Heap end marker (immediately after the reserved space)
+        let heap_end_label = self.define_label("__rue_heap_end");
+        self.instructions
+            .push(X8664Instr::Label { id: heap_end_label });
+
+        // Current heap pointer storage (8 bytes for pointer value) in .bss
+        let heap_ptr_label = self.define_label("__rue_heap_ptr");
+        self.instructions
+            .push(X8664Instr::Label { id: heap_ptr_label });
+        // Reserve 8 bytes for the current heap pointer in .bss
+        self.instructions
+            .push(X8664Instr::ReserveBytes { count: 8 });
+
+        // Switch back to .text section
+        self.instructions.push(X8664Instr::Section {
+            name: ".text".to_string(),
+        });
     }
 }

--- a/crates/rue-codegen/src/runtime/mod.rs
+++ b/crates/rue-codegen/src/runtime/mod.rs
@@ -4,6 +4,7 @@
 //! that are embedded in Rue executables. It provides assembly code for basic I/O
 //! operations, syscalls, and other runtime support functions.
 
+pub mod alloc;
 pub mod context;
 pub mod conversion;
 pub mod data;

--- a/crates/rue-codegen/src/runtime/startup.rs
+++ b/crates/rue-codegen/src/runtime/startup.rs
@@ -62,6 +62,11 @@ impl RuntimeContext {
             target: "__rue_setup_signal_handlers".to_string(),
         });
 
+        // Initialize heap (stub implementation - safe to call)
+        self.instructions.push(X8664Instr::Call {
+            target: "__rue_heap_init".to_string(),
+        });
+
         // Call user's main function
         self.instructions.push(X8664Instr::Call {
             target: "main".to_string(),

--- a/crates/rue-codegen/src/runtime/x86_64.rs
+++ b/crates/rue-codegen/src/runtime/x86_64.rs
@@ -17,6 +17,9 @@ pub fn generate_runtime() -> Result<(Vec<X8664Instr>, HashMap<String, u32>), Str
     // Generate memory management functions
     ctx.generate_memory_functions();
 
+    // Generate allocation functions (with stub implementations)
+    ctx.generate_alloc_functions();
+
     // Generate all runtime functions
     ctx.generate_exit_function();
     ctx.generate_itoa_function();

--- a/crates/rue-codegen/src/target/mod.rs
+++ b/crates/rue-codegen/src/target/mod.rs
@@ -22,6 +22,9 @@ pub trait InstructionEmitter<Instr> {
 
     /// Get the emitted code and symbol table
     fn get_output(&self) -> (&[u8], HashMap<String, usize>);
+
+    /// Get data section content and BSS size for ELF generation
+    fn get_data_and_bss(&self) -> (&[u8], usize);
 }
 
 /// Trait for target-specific executable format writers
@@ -29,6 +32,15 @@ pub trait ExecutableWriter {
     /// Generate an executable from machine code and symbols
     fn generate_executable(&self, machine_code: &[u8], symbols: &HashMap<String, usize>)
     -> Vec<u8>;
+
+    /// Generate an executable with data and BSS sections
+    fn generate_executable_with_sections(
+        &self,
+        machine_code: &[u8],
+        symbols: &HashMap<String, usize>,
+        data_section: &[u8],
+        bss_size: usize,
+    ) -> Vec<u8>;
 }
 
 /// Trait for target-specific assembly formatters  

--- a/crates/rue-codegen/src/target/x86_64/assembler.rs
+++ b/crates/rue-codegen/src/target/x86_64/assembler.rs
@@ -151,6 +151,9 @@ pub fn format_instructions_as_assembly(
                     reg_name(dest)
                 ));
             }
+            X8664Instr::AndRI { dest, imm } => {
+                output.push_str(&format!("    andq ${}, %{}\n", imm, reg_name(dest)));
+            }
             X8664Instr::Shl { dest, count: _ } => {
                 output.push_str(&format!("    shlq %cl, %{}\n", reg_name(dest)));
             }
@@ -272,6 +275,9 @@ pub fn format_instructions_as_assembly(
             }
             X8664Instr::Ud2 => {
                 output.push_str("    ud2\n");
+            }
+            X8664Instr::Section { name } => {
+                output.push_str(&format!(".section {name}\n"));
             }
             X8664Instr::DataBytes { bytes } => {
                 // Emit raw data bytes using .byte directive

--- a/crates/rue-codegen/src/target/x86_64/elf.rs
+++ b/crates/rue-codegen/src/target/x86_64/elf.rs
@@ -30,12 +30,13 @@ impl ElfWriter {
             symbols.contains_key("_start"),
             "_start symbol must be present in symbols table"
         );
+
+        // Step 1: Use object crate to generate a proper relocatable object
+        // Use the working implementation directly with the actual machine code and sections
         let start_offset = *symbols
             .get("_start")
             .expect("_start symbol must be present in symbols table");
 
-        // Create a proper executable ELF manually since the object crate
-        // can only create relocatable objects (ET_REL), not executables (ET_EXEC)
         self.create_executable_elf(machine_code, data_section, bss_size, start_offset)
     }
 

--- a/crates/rue-codegen/src/target/x86_64/emitter.rs
+++ b/crates/rue-codegen/src/target/x86_64/emitter.rs
@@ -3,20 +3,58 @@ use rue_ir::pir::Label;
 use rue_target::{ConditionCode, LabelRef, X86Register, X8664Instr};
 use std::collections::HashMap;
 
+/// ELF section types
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SectionType {
+    Text,   // .text - executable code
+    Data,   // .data - initialized writable data
+    Bss,    // .bss - uninitialized writable data
+    Rodata, // .rodata - read-only data
+}
+
+/// Information about a section
+#[derive(Debug, Clone)]
+pub struct SectionInfo {
+    pub section_type: SectionType,
+    pub data: Vec<u8>,
+    pub labels: HashMap<u32, usize>, // label_id -> offset within section
+}
+
+/// Type alias for complex return type from get_sections_and_symbols
+type SectionsAndSymbols<'a> = (
+    &'a HashMap<SectionType, SectionInfo>,
+    HashMap<String, (SectionType, usize)>,
+);
+
 /// x86-64 machine code emitter
 /// Converts X8664Instr to raw bytes
 pub struct X86Emitter {
-    code: Vec<u8>,
-    label_positions: HashMap<u32, usize>,
-    pending_fixups: Vec<(usize, LabelRef)>,
+    // Section-aware state
+    current_section: SectionType,
+    sections: HashMap<SectionType, SectionInfo>,
+
+    // Global state
+    label_positions: HashMap<u32, (SectionType, usize)>, // label_id -> (section, offset)
+    pending_fixups: Vec<(SectionType, usize, LabelRef)>, // (section, offset, target)
     function_labels: HashMap<String, Label>,
     runtime_label_count: u32,
 }
 
 impl X86Emitter {
     pub fn new() -> Self {
+        let mut sections = HashMap::new();
+        sections.insert(
+            SectionType::Text,
+            SectionInfo {
+                section_type: SectionType::Text,
+                data: Vec::new(),
+                labels: HashMap::new(),
+            },
+        );
+
         Self {
-            code: Vec::new(),
+            current_section: SectionType::Text,
+            sections,
             label_positions: HashMap::new(),
             pending_fixups: Vec::new(),
             function_labels: HashMap::new(),
@@ -44,35 +82,45 @@ impl X86Emitter {
         // Second pass: fix up label references
         self.resolve_fixups()?;
 
-        Ok(self.code.clone())
+        // Return .text section data
+        let text_data = &self.sections.get(&SectionType::Text).unwrap().data;
+        Ok(text_data.clone())
+    }
+
+    /// Get the current section's data buffer for writing
+    fn current_section_data(&mut self) -> &mut Vec<u8> {
+        &mut self.sections.get_mut(&self.current_section).unwrap().data
     }
 
     fn emit_instruction(&mut self, instr: &X8664Instr) -> Result<(), String> {
         match instr {
             X8664Instr::MovRR { dest, src } => {
                 self.emit_rex_if_needed(true, Some(src), Some(dest));
-                self.code.push(0x89); // MOV r/m64, r64
+                self.current_section_data().push(0x89); // MOV r/m64, r64
                 let modrm = 0xc0 | (self.register_code(src) << 3) | self.register_code(dest);
-                self.code.push(modrm);
+                self.current_section_data().push(modrm);
             }
 
             X8664Instr::MovRI32 { dest, imm } => {
                 self.emit_rex_if_needed(true, None, Some(dest));
-                self.code.push(0xc7); // MOV r/m64, imm32
+                self.current_section_data().push(0xc7); // MOV r/m64, imm32
                 let modrm = 0xc0 | self.register_code(dest);
-                self.code.push(modrm);
-                self.code.extend_from_slice(&imm.to_le_bytes());
+                self.current_section_data().push(modrm);
+                self.current_section_data()
+                    .extend_from_slice(&imm.to_le_bytes());
             }
 
             X8664Instr::MovRI64 { dest, imm } => {
+                let reg_code = self.register_code(dest);
                 if self.needs_rex_b(dest) {
-                    self.code.push(0x49); // REX.WB
-                    self.code.push(0xb8 + self.register_code(dest));
+                    self.current_section_data().push(0x49); // REX.WB
+                    self.current_section_data().push(0xb8 + reg_code);
                 } else {
-                    self.code.push(0x48); // REX.W
-                    self.code.push(0xb8 + self.register_code(dest));
+                    self.current_section_data().push(0x48); // REX.W
+                    self.current_section_data().push(0xb8 + reg_code);
                 }
-                self.code.extend_from_slice(&imm.to_le_bytes());
+                self.current_section_data()
+                    .extend_from_slice(&imm.to_le_bytes());
             }
 
             X8664Instr::MovRM { dest, base, offset } => {
@@ -91,125 +139,144 @@ impl X86Emitter {
 
             X8664Instr::AddRR { dest, src } => {
                 self.emit_rex_if_needed(true, Some(src), Some(dest));
-                self.code.push(0x01); // ADD r/m64, r64
+                self.current_section_data().push(0x01); // ADD r/m64, r64
                 let modrm = 0xc0 | (self.register_code(src) << 3) | self.register_code(dest);
-                self.code.push(modrm);
+                self.current_section_data().push(modrm);
             }
 
             X8664Instr::AddRI { dest, imm } => {
                 self.emit_rex_if_needed(true, None, Some(dest));
                 if *imm >= -128 && *imm <= 127 {
-                    self.code.push(0x83); // ADD r/m64, imm8
+                    self.current_section_data().push(0x83); // ADD r/m64, imm8
                     let modrm = 0xc0 | self.register_code(dest);
-                    self.code.push(modrm);
-                    self.code.push(*imm as u8);
+                    self.current_section_data().push(modrm);
+                    self.current_section_data().push(*imm as u8);
                 } else {
-                    self.code.push(0x81); // ADD r/m64, imm32
+                    self.current_section_data().push(0x81); // ADD r/m64, imm32
                     let modrm = 0xc0 | self.register_code(dest);
-                    self.code.push(modrm);
-                    self.code.extend_from_slice(&imm.to_le_bytes());
+                    self.current_section_data().push(modrm);
+                    self.current_section_data()
+                        .extend_from_slice(&imm.to_le_bytes());
                 }
             }
 
             X8664Instr::SubRR { dest, src } => {
                 self.emit_rex_if_needed(true, Some(src), Some(dest));
-                self.code.push(0x29); // SUB r/m64, r64
+                self.current_section_data().push(0x29); // SUB r/m64, r64
                 let modrm = 0xc0 | (self.register_code(src) << 3) | self.register_code(dest);
-                self.code.push(modrm);
+                self.current_section_data().push(modrm);
             }
 
             X8664Instr::SubRI { dest, imm } => {
                 self.emit_rex_if_needed(true, None, Some(dest));
                 if *imm >= -128 && *imm <= 127 {
-                    self.code.push(0x83); // SUB r/m64, imm8
+                    self.current_section_data().push(0x83); // SUB r/m64, imm8
                     let modrm = 0xe8 | self.register_code(dest); // /5
-                    self.code.push(modrm);
-                    self.code.push(*imm as u8);
+                    self.current_section_data().push(modrm);
+                    self.current_section_data().push(*imm as u8);
                 } else {
-                    self.code.push(0x81); // SUB r/m64, imm32
+                    self.current_section_data().push(0x81); // SUB r/m64, imm32
                     let modrm = 0xe8 | self.register_code(dest); // /5
-                    self.code.push(modrm);
-                    self.code.extend_from_slice(&imm.to_le_bytes());
+                    self.current_section_data().push(modrm);
+                    self.current_section_data()
+                        .extend_from_slice(&imm.to_le_bytes());
                 }
             }
 
             X8664Instr::AndRR { dest, src } => {
                 self.emit_rex_if_needed(true, Some(src), Some(dest));
-                self.code.push(0x21); // AND r/m64, r64
+                self.current_section_data().push(0x21); // AND r/m64, r64
                 let modrm = 0xc0 | (self.register_code(src) << 3) | self.register_code(dest);
-                self.code.push(modrm);
+                self.current_section_data().push(modrm);
+            }
+            X8664Instr::AndRI { dest, imm } => {
+                self.emit_rex_if_needed(true, None, Some(dest));
+                if *imm >= -128 && *imm <= 127 {
+                    self.current_section_data().push(0x83); // AND r/m64, imm8
+                    let modrm = 0xe0 | self.register_code(dest); // /4 for AND
+                    self.current_section_data().push(modrm);
+                    self.current_section_data().push(*imm as u8);
+                } else {
+                    self.current_section_data().push(0x81); // AND r/m64, imm32
+                    let modrm = 0xe0 | self.register_code(dest); // /4 for AND
+                    self.current_section_data().push(modrm);
+                    self.current_section_data()
+                        .extend_from_slice(&imm.to_le_bytes());
+                }
             }
 
             X8664Instr::Shl { dest, count: _ } => {
                 // count must be in RCX
                 self.emit_rex_if_needed(true, None, Some(dest));
-                self.code.push(0xd3); // SHL r/m64, CL
+                self.current_section_data().push(0xd3); // SHL r/m64, CL
                 let modrm = 0xe0 | self.register_code(dest); // /4
-                self.code.push(modrm);
+                self.current_section_data().push(modrm);
             }
 
             X8664Instr::Sar { dest, count: _ } => {
                 // count must be in RCX
                 self.emit_rex_if_needed(true, None, Some(dest));
-                self.code.push(0xd3); // SAR r/m64, CL
+                self.current_section_data().push(0xd3); // SAR r/m64, CL
                 let modrm = 0xf8 | self.register_code(dest); // /7
-                self.code.push(modrm);
+                self.current_section_data().push(modrm);
             }
 
             X8664Instr::ImulRR { dest, src } => {
                 self.emit_rex_if_needed(true, Some(dest), Some(src));
-                self.code.push(0x0f);
-                self.code.push(0xaf); // IMUL r64, r/m64
+                self.current_section_data().push(0x0f);
+                self.current_section_data().push(0xaf); // IMUL r64, r/m64
                 let modrm = 0xc0 | (self.register_code(dest) << 3) | self.register_code(src);
-                self.code.push(modrm);
+                self.current_section_data().push(modrm);
             }
 
             X8664Instr::ImulRI { dest, imm } => {
                 self.emit_rex_if_needed(true, Some(dest), Some(dest));
                 if *imm >= -128 && *imm <= 127 {
-                    self.code.push(0x6b); // IMUL r64, r/m64, imm8
+                    self.current_section_data().push(0x6b); // IMUL r64, r/m64, imm8
                     let modrm = 0xc0 | (self.register_code(dest) << 3) | self.register_code(dest);
-                    self.code.push(modrm);
-                    self.code.push(*imm as u8);
+                    self.current_section_data().push(modrm);
+                    self.current_section_data().push(*imm as u8);
                 } else {
-                    self.code.push(0x69); // IMUL r64, r/m64, imm32
+                    self.current_section_data().push(0x69); // IMUL r64, r/m64, imm32
                     let modrm = 0xc0 | (self.register_code(dest) << 3) | self.register_code(dest);
-                    self.code.push(modrm);
-                    self.code.extend_from_slice(&imm.to_le_bytes());
+                    self.current_section_data().push(modrm);
+                    self.current_section_data()
+                        .extend_from_slice(&imm.to_le_bytes());
                 }
             }
 
             X8664Instr::Idiv { divisor } => {
                 self.emit_rex_if_needed(true, None, Some(divisor));
-                self.code.push(0xf7); // IDIV r/m64
+                self.current_section_data().push(0xf7); // IDIV r/m64
                 let modrm = 0xf8 | self.register_code(divisor); // /7
-                self.code.push(modrm);
+                self.current_section_data().push(modrm);
             }
 
             X8664Instr::Cqo => {
-                self.code.push(0x48); // REX.W
-                self.code.push(0x99); // CQO
+                self.current_section_data().push(0x48); // REX.W
+                self.current_section_data().push(0x99); // CQO
             }
 
             X8664Instr::CmpRR { left, right } => {
                 self.emit_rex_if_needed(true, Some(right), Some(left));
-                self.code.push(0x39); // CMP r/m64, r64
+                self.current_section_data().push(0x39); // CMP r/m64, r64
                 let modrm = 0xc0 | (self.register_code(right) << 3) | self.register_code(left);
-                self.code.push(modrm);
+                self.current_section_data().push(modrm);
             }
 
             X8664Instr::CmpRI { reg, imm } => {
                 self.emit_rex_if_needed(true, None, Some(reg));
                 if *imm >= -128 && *imm <= 127 {
-                    self.code.push(0x83); // CMP r/m64, imm8
+                    self.current_section_data().push(0x83); // CMP r/m64, imm8
                     let modrm = 0xf8 | self.register_code(reg); // /7
-                    self.code.push(modrm);
-                    self.code.push(*imm as u8);
+                    self.current_section_data().push(modrm);
+                    self.current_section_data().push(*imm as u8);
                 } else {
-                    self.code.push(0x81); // CMP r/m64, imm32
+                    self.current_section_data().push(0x81); // CMP r/m64, imm32
                     let modrm = 0xf8 | self.register_code(reg); // /7
-                    self.code.push(modrm);
-                    self.code.extend_from_slice(&imm.to_le_bytes());
+                    self.current_section_data().push(modrm);
+                    self.current_section_data()
+                        .extend_from_slice(&imm.to_le_bytes());
                 }
             }
 
@@ -227,62 +294,68 @@ impl X86Emitter {
                 // the low-byte form (r8b…r15b) is addressable.
                 // W=0 (8-bit op), R=0, X=0, B = dest.needs_rex()
                 self.emit_rex_if_needed(false, None, Some(dest));
-                self.code.push(0x0f);
-                self.code.push(opcode);
+                self.current_section_data().push(0x0f);
+                self.current_section_data().push(opcode);
                 // SetCC uses /0 encoding, so reg field must be 000
                 let modrm = 0xc0 | self.register_code(dest);
-                self.code.push(modrm);
+                self.current_section_data().push(modrm);
             }
 
             X8664Instr::Movzx { dest, src } => {
                 // While REX.W=1 is not canonical for MOVZX (should use REX.W=0),
                 // we keep it for compatibility as some code may depend on this behavior
                 self.emit_rex_if_needed(true, Some(dest), Some(src));
-                self.code.push(0x0f);
-                self.code.push(0xb6); // MOVZX r64, r/m8 (with REX.W=1)
+                self.current_section_data().push(0x0f);
+                self.current_section_data().push(0xb6); // MOVZX r64, r/m8 (with REX.W=1)
                 let modrm = 0xc0 | (self.register_code(dest) << 3) | self.register_code(src);
-                self.code.push(modrm);
+                self.current_section_data().push(modrm);
             }
 
             X8664Instr::Movsxd { dest, src } => {
                 self.emit_rex_if_needed(true, Some(dest), Some(src));
-                self.code.push(0x63); // MOVSXD r64, r/m32
+                self.current_section_data().push(0x63); // MOVSXD r64, r/m32
                 let modrm = 0xc0 | (self.register_code(dest) << 3) | self.register_code(src);
-                self.code.push(modrm);
+                self.current_section_data().push(modrm);
             }
 
             X8664Instr::Push { reg } => {
+                let reg_code = self.register_code(reg);
                 if self.needs_rex_b(reg) {
-                    self.code.push(0x41); // REX.B
+                    self.current_section_data().push(0x41); // REX.B
                 }
-                self.code.push(0x50 + self.register_code(reg));
+                self.current_section_data().push(0x50 + reg_code);
             }
 
             X8664Instr::Pop { reg } => {
+                let reg_code = self.register_code(reg);
                 if self.needs_rex_b(reg) {
-                    self.code.push(0x41); // REX.B
+                    self.current_section_data().push(0x41); // REX.B
                 }
-                self.code.push(0x58 + self.register_code(reg));
+                self.current_section_data().push(0x58 + reg_code);
             }
 
             X8664Instr::Call { target } => {
                 // For now, we only support relative calls
-                self.code.push(0xe8); // CALL rel32
-                let fixup_pos = self.code.len();
-                self.code.extend_from_slice(&[0, 0, 0, 0]); // Placeholder
-                self.pending_fixups
-                    .push((fixup_pos, LabelRef::Global(target.clone())));
+                self.current_section_data().push(0xe8); // CALL rel32
+                let fixup_pos = self.current_section_data().len();
+                self.current_section_data().extend_from_slice(&[0, 0, 0, 0]); // Placeholder
+                self.pending_fixups.push((
+                    self.current_section.clone(),
+                    fixup_pos,
+                    LabelRef::Global(target.clone()),
+                ));
             }
 
             X8664Instr::Ret => {
-                self.code.push(0xc3); // RET
+                self.current_section_data().push(0xc3); // RET
             }
 
             X8664Instr::Jmp { target } => {
-                self.code.push(0xe9); // JMP rel32
-                let fixup_pos = self.code.len();
-                self.code.extend_from_slice(&[0, 0, 0, 0]); // Placeholder
-                self.pending_fixups.push((fixup_pos, target.clone()));
+                self.current_section_data().push(0xe9); // JMP rel32
+                let fixup_pos = self.current_section_data().len();
+                self.current_section_data().extend_from_slice(&[0, 0, 0, 0]); // Placeholder
+                self.pending_fixups
+                    .push((self.current_section.clone(), fixup_pos, target.clone()));
             }
 
             X8664Instr::JmpCC { cc, target } => {
@@ -295,38 +368,48 @@ impl X86Emitter {
                     ConditionCode::GreaterEqual => 0x8d, // JGE
                 };
 
-                self.code.push(0x0f);
-                self.code.push(opcode);
-                let fixup_pos = self.code.len();
-                self.code.extend_from_slice(&[0, 0, 0, 0]); // Placeholder
-                self.pending_fixups.push((fixup_pos, target.clone()));
+                self.current_section_data().push(0x0f);
+                self.current_section_data().push(opcode);
+                let fixup_pos = self.current_section_data().len();
+                self.current_section_data().extend_from_slice(&[0, 0, 0, 0]); // Placeholder
+                self.pending_fixups
+                    .push((self.current_section.clone(), fixup_pos, target.clone()));
             }
 
             X8664Instr::Label { id } => {
-                self.label_positions.insert(*id, self.code.len());
+                let current_pos = self.sections.get(&self.current_section).unwrap().data.len();
+                self.label_positions
+                    .insert(*id, (self.current_section.clone(), current_pos));
+
+                // Update section labels
+                self.sections
+                    .get_mut(&self.current_section)
+                    .unwrap()
+                    .labels
+                    .insert(*id, current_pos);
             }
 
             X8664Instr::Syscall => {
-                self.code.push(0x0f);
-                self.code.push(0x05);
+                self.current_section_data().push(0x0f);
+                self.current_section_data().push(0x05);
             }
 
             X8664Instr::EnterFrame => {
                 // push rbp
-                self.code.push(0x55);
+                self.current_section_data().push(0x55);
                 // mov rbp, rsp
-                self.code.push(0x48);
-                self.code.push(0x89);
-                self.code.push(0xe5);
+                self.current_section_data().push(0x48);
+                self.current_section_data().push(0x89);
+                self.current_section_data().push(0xe5);
             }
 
             X8664Instr::LeaveFrame => {
                 // mov rsp, rbp
-                self.code.push(0x48);
-                self.code.push(0x89);
-                self.code.push(0xec);
+                self.current_section_data().push(0x48);
+                self.current_section_data().push(0x89);
+                self.current_section_data().push(0xec);
                 // pop rbp
-                self.code.push(0x5d);
+                self.current_section_data().push(0x5d);
             }
 
             X8664Instr::AllocStack { size } => {
@@ -339,81 +422,123 @@ impl X86Emitter {
 
                 self.emit_rex_if_needed(true, None, Some(&X86Register::Rsp));
                 if aligned_size <= 127 {
-                    self.code.push(0x83); // SUB r/m64, imm8
-                    self.code.push(0xec); // /5 RSP
-                    self.code.push(aligned_size as u8);
+                    self.current_section_data().push(0x83); // SUB r/m64, imm8
+                    self.current_section_data().push(0xec); // /5 RSP
+                    self.current_section_data().push(aligned_size as u8);
                 } else {
-                    self.code.push(0x81); // SUB r/m64, imm32
-                    self.code.push(0xec); // /5 RSP
-                    self.code.extend_from_slice(&aligned_size.to_le_bytes());
+                    self.current_section_data().push(0x81); // SUB r/m64, imm32
+                    self.current_section_data().push(0xec); // /5 RSP
+                    self.current_section_data()
+                        .extend_from_slice(&aligned_size.to_le_bytes());
                 }
             }
 
             X8664Instr::LeaLabel { dest, label } => {
                 // lea dest, [rip + offset]
+                let reg_code = self.register_code(dest);
                 self.emit_rex_if_needed(true, Some(dest), None);
-                self.code.push(0x8d); // LEA
-                self.code.push((self.register_code(dest) << 3) | 0x05); // ModRM: mod=00, reg=dest, rm=101 (RIP+disp32)
+                self.current_section_data().push(0x8d); // LEA
+                self.current_section_data().push((reg_code << 3) | 0x05); // ModRM: mod=00, reg=dest, rm=101 (RIP+disp32)
 
                 // Record fixup for the label
-                let fixup_pos = self.code.len();
-                self.code.extend_from_slice(&[0, 0, 0, 0]); // Placeholder
-                self.pending_fixups
-                    .push((fixup_pos, LabelRef::Global(label.clone())));
+                let fixup_pos = self.current_section_data().len();
+                self.current_section_data().extend_from_slice(&[0, 0, 0, 0]); // Placeholder
+                self.pending_fixups.push((
+                    self.current_section.clone(),
+                    fixup_pos,
+                    LabelRef::Global(label.clone()),
+                ));
             }
 
             X8664Instr::Cld => {
                 // cld - Clear direction flag
-                self.code.push(0xfc);
+                self.current_section_data().push(0xfc);
             }
 
             X8664Instr::RepStosb => {
                 // rep stosb - Repeat store byte
-                self.code.push(0xf3); // REP prefix
-                self.code.push(0xaa); // STOSB
+                self.current_section_data().push(0xf3); // REP prefix
+                self.current_section_data().push(0xaa); // STOSB
             }
 
             X8664Instr::XorRR { dest, src } => {
                 self.emit_rex_if_needed(true, Some(src), Some(dest));
-                self.code.push(0x31); // XOR r/m64, r64
+                self.current_section_data().push(0x31); // XOR r/m64, r64
                 let modrm = 0xc0 | (self.register_code(src) << 3) | self.register_code(dest);
-                self.code.push(modrm);
+                self.current_section_data().push(modrm);
             }
 
             X8664Instr::Ud2 => {
                 // UD2 - undefined instruction
-                self.code.push(0x0f);
-                self.code.push(0x0b);
+                self.current_section_data().push(0x0f);
+                self.current_section_data().push(0x0b);
+            }
+            X8664Instr::Section { name } => {
+                let new_section = match name.as_str() {
+                    ".text" => SectionType::Text,
+                    ".data" => SectionType::Data,
+                    ".bss" => SectionType::Bss,
+                    ".rodata" => SectionType::Rodata,
+                    _ => return Err(format!("Unsupported section: {name}")),
+                };
+
+                // Switch to new section
+                self.current_section = new_section.clone();
+
+                // Ensure section exists
+                if !self.sections.contains_key(&new_section) {
+                    self.sections.insert(
+                        new_section.clone(),
+                        SectionInfo {
+                            section_type: new_section.clone(),
+                            data: Vec::new(),
+                            labels: HashMap::new(),
+                        },
+                    );
+                }
             }
 
             X8664Instr::DataBytes { bytes } => {
                 // Emit raw bytes directly
-                self.code.extend_from_slice(bytes);
+                self.current_section_data().extend_from_slice(bytes);
             }
 
             X8664Instr::ReserveBytes { count } => {
-                // Reserve zero-initialized space
-                self.code.resize(self.code.len() + *count as usize, 0);
+                match self.current_section {
+                    SectionType::Bss => {
+                        // In .bss, just track the size - no actual data in file
+                        // For BSS sections, we use the data.len() to track the virtual size
+                        // but we don't store actual bytes
+                        let section = self.sections.get_mut(&SectionType::Bss).unwrap();
+                        // Extend data field to track size, but this data won't be written to file
+                        section.data.resize(section.data.len() + *count as usize, 0);
+                    }
+                    _ => {
+                        // In other sections, reserve actual zero bytes
+                        let section = self.sections.get_mut(&self.current_section).unwrap();
+                        section.data.resize(section.data.len() + *count as usize, 0);
+                    }
+                }
             }
             X8664Instr::RepMovsb => {
                 // rep movsb
-                self.code.extend_from_slice(&[0xF3, 0xA4]);
+                self.current_section_data().extend_from_slice(&[0xF3, 0xA4]);
             }
             X8664Instr::Std => {
                 // std - set direction flag
-                self.code.push(0xFD);
+                self.current_section_data().push(0xFD);
             }
         }
         Ok(())
     }
 
     fn resolve_fixups(&mut self) -> Result<(), String> {
-        for (fixup_pos, target) in &self.pending_fixups {
-            let target_pos = match target {
+        for (section, fixup_pos, target) in &self.pending_fixups {
+            let (target_section, target_pos) = match target {
                 LabelRef::Local(id) => self
                     .label_positions
                     .get(id)
-                    .copied()
+                    .cloned()
                     .ok_or_else(|| format!("Undefined label: {id}"))?,
                 LabelRef::Global(name) => {
                     // Look up the function name to get its label ID
@@ -426,20 +551,104 @@ impl X86Emitter {
                     let machine_id = label_id.to_machine_id(self.runtime_label_count);
                     self.label_positions
                         .get(&machine_id)
-                        .copied()
+                        .cloned()
                         .ok_or_else(|| format!("Undefined label for function: {name}"))?
                 }
             };
 
-            let current_pos = fixup_pos + 4; // Position after the offset
-            let offset = (target_pos as i32) - (current_pos as i32);
+            // Calculate relative offset accounting for section layout in memory
+            let offset = if section == &target_section {
+                // Same section: simple relative addressing
+                let current_pos = fixup_pos + 4; // Position after the offset
+                (target_pos as i32) - (current_pos as i32)
+            } else {
+                // Cross-section: calculate based on expected memory layout
+                self.calculate_cross_section_offset(
+                    section,
+                    *fixup_pos,
+                    &target_section,
+                    target_pos,
+                )?
+            };
 
             let offset_bytes = offset.to_le_bytes();
+            let section_data = &mut self.sections.get_mut(section).unwrap().data;
             for (i, &byte) in offset_bytes.iter().enumerate() {
-                self.code[fixup_pos + i] = byte;
+                section_data[fixup_pos + i] = byte;
             }
         }
         Ok(())
+    }
+
+    /// Calculate cross-section offset based on expected ELF memory layout
+    fn calculate_cross_section_offset(
+        &self,
+        from_section: &SectionType,
+        from_offset: usize,
+        to_section: &SectionType,
+        to_offset: usize,
+    ) -> Result<i32, String> {
+        // Calculate expected memory layout matching ELF writer
+        // Base address for sections (matches ELF writer)
+        const BASE_ADDR: u64 = 0x400000;
+        const EHDR_SIZE: usize = 0x40;
+        const PHDR_SIZE: usize = 0x38;
+
+        // Calculate expected section offsets (matches ELF writer logic)
+        // This must match the layout calculation in generate_elf_with_sections
+        let program_header_count = if self.sections.contains_key(&SectionType::Bss)
+            || self.sections.contains_key(&SectionType::Data)
+        {
+            2
+        } else {
+            1
+        };
+        let headers_size = EHDR_SIZE + (PHDR_SIZE * program_header_count);
+        let mut current_file_offset = align_to_16(headers_size as u64) as usize;
+
+        // Section layout: .text, .data, .bss (matches ELF writer)
+        let mut section_addresses = HashMap::new();
+
+        // .text section
+        if let Some(text_section) = self.sections.get(&SectionType::Text) {
+            section_addresses.insert(SectionType::Text, BASE_ADDR + current_file_offset as u64);
+            current_file_offset += text_section.data.len();
+            current_file_offset = align_to_16(current_file_offset as u64) as usize;
+        }
+
+        // .data section
+        if let Some(data_section) = self.sections.get(&SectionType::Data) {
+            section_addresses.insert(SectionType::Data, BASE_ADDR + current_file_offset as u64);
+            current_file_offset += data_section.data.len();
+            current_file_offset = align_to_16(current_file_offset as u64) as usize;
+        }
+
+        // .bss section (virtual address, no file space)
+        if let Some(_bss_section) = self.sections.get(&SectionType::Bss) {
+            section_addresses.insert(SectionType::Bss, BASE_ADDR + current_file_offset as u64);
+        }
+
+        // Calculate addresses
+        let from_addr = section_addresses
+            .get(from_section)
+            .ok_or_else(|| format!("Section not found: {from_section:?}"))?
+            + from_offset as u64
+            + 4; // +4 for instruction pointer after the displacement
+
+        let to_addr = section_addresses
+            .get(to_section)
+            .ok_or_else(|| format!("Section not found: {to_section:?}"))?
+            + to_offset as u64;
+
+        // Calculate relative offset
+        let offset = (to_addr as i64) - (from_addr as i64);
+
+        // Check if offset fits in i32
+        if offset < i32::MIN as i64 || offset > i32::MAX as i64 {
+            return Err(format!("Cross-section offset too large: {offset}"));
+        }
+
+        Ok(offset as i32)
     }
 
     /// Get the 3-bit register encoding for ModR/M or SIB bytes
@@ -542,7 +751,7 @@ impl X86Emitter {
                     )
                 }))
         {
-            self.code.push(rex);
+            self.current_section_data().push(rex);
         }
     }
 
@@ -573,14 +782,14 @@ impl X86Emitter {
                 if base.needs_rex() {
                     rex |= 0x01; // REX.B
                 }
-                self.code.push(rex);
+                self.current_section_data().push(rex);
             }
         } else {
             self.emit_rex_if_needed(true, Some(reg), Some(base));
         }
 
         // Emit opcode
-        self.code.push(opcode);
+        self.current_section_data().push(opcode);
 
         // Special handling for RSP/R12 which require SIB byte
         let base_code = self.register_code(base);
@@ -591,29 +800,30 @@ impl X86Emitter {
         if offset == 0 && !needs_disp32_for_rbp {
             // ModR/M byte: mod=00 (no disp), reg=reg, r/m=base
             let modrm = (self.register_code(reg) << 3) | base_code;
-            self.code.push(modrm);
+            self.current_section_data().push(modrm);
             if needs_sib {
                 // SIB byte: scale=00, index=100 (none), base=100 (RSP)
-                self.code.push(0x24);
+                self.current_section_data().push(0x24);
             }
         } else if (-128..=127).contains(&offset) && !(offset == 0 && needs_disp32_for_rbp) {
             // ModR/M byte: mod=01 (disp8), reg=reg, r/m=base
             let modrm = 0x40 | (self.register_code(reg) << 3) | base_code;
-            self.code.push(modrm);
+            self.current_section_data().push(modrm);
             if needs_sib {
                 // SIB byte: scale=00, index=100 (none), base=100 (RSP)
-                self.code.push(0x24);
+                self.current_section_data().push(0x24);
             }
-            self.code.push(offset as u8);
+            self.current_section_data().push(offset as u8);
         } else {
             // ModR/M byte: mod=10 (disp32), reg=reg, r/m=base
             let modrm = 0x80 | (self.register_code(reg) << 3) | base_code;
-            self.code.push(modrm);
+            self.current_section_data().push(modrm);
             if needs_sib {
                 // SIB byte: scale=00, index=100 (none), base=100 (RSP)
-                self.code.push(0x24);
+                self.current_section_data().push(0x24);
             }
-            self.code.extend_from_slice(&offset.to_le_bytes());
+            self.current_section_data()
+                .extend_from_slice(&offset.to_le_bytes());
         }
 
         Ok(())
@@ -623,29 +833,65 @@ impl X86Emitter {
     pub fn get_output(&self) -> (&[u8], HashMap<String, usize>) {
         let mut symbols = HashMap::new();
 
-        // Convert local labels to symbols
-        for (id, pos) in &self.label_positions {
-            symbols.insert(format!("L{id}"), *pos);
+        // Convert local labels to symbols - only include .text section labels for compatibility
+        for (id, (section, pos)) in &self.label_positions {
+            if *section == SectionType::Text {
+                symbols.insert(format!("L{id}"), *pos);
+            }
         }
 
         // Add function names to symbol table
         for (name, label_id) in &self.function_labels {
             let machine_id = label_id.to_machine_id(self.runtime_label_count);
-            if let Some(&pos) = self.label_positions.get(&machine_id) {
-                symbols.insert(name.clone(), pos);
+            if let Some((section, pos)) = self.label_positions.get(&machine_id) {
+                if *section == SectionType::Text {
+                    symbols.insert(name.clone(), *pos);
+                }
             }
         }
 
-        // Add global symbols from fixups
-        for (pos, target) in &self.pending_fixups {
-            if let LabelRef::Global(name) = target {
-                // For now, store the fixup position as the symbol location
-                // The ELF writer will need to handle these properly
-                symbols.insert(name.clone(), *pos);
+        // Note: We do NOT add global symbols from fixups to the symbol table
+        // because the fixup positions are where calls are made FROM, not where functions are located.
+        // The actual function positions are already added above in the function_labels loop.
+
+        // Return .text section data
+        let text_data = &self.sections.get(&SectionType::Text).unwrap().data;
+        (text_data, symbols)
+    }
+
+    /// Get all sections and their symbols (new interface for multi-section ELF generation)
+    pub fn get_sections_and_symbols(&self) -> SectionsAndSymbols<'_> {
+        let mut symbols = HashMap::new();
+
+        // Convert local labels to symbols with section information
+        for (id, (section, pos)) in &self.label_positions {
+            symbols.insert(format!("L{id}"), (section.clone(), *pos));
+        }
+
+        // Add function names to symbol table with section information
+        for (name, label_id) in &self.function_labels {
+            let machine_id = label_id.to_machine_id(self.runtime_label_count);
+            if let Some((section, pos)) = self.label_positions.get(&machine_id) {
+                symbols.insert(name.clone(), (section.clone(), *pos));
             }
         }
 
-        (&self.code, symbols)
+        (&self.sections, symbols)
+    }
+
+    /// Get data section content and BSS size for ELF generation
+    pub fn get_data_and_bss(&self) -> (&[u8], usize) {
+        let data_section = self
+            .sections
+            .get(&SectionType::Data)
+            .map(|s| s.data.as_slice())
+            .unwrap_or(&[]);
+        let bss_size = self
+            .sections
+            .get(&SectionType::Bss)
+            .map(|s| s.data.len())
+            .unwrap_or(0);
+        (data_section, bss_size)
     }
 }
 

--- a/crates/rue-codegen/src/target/x86_64/mod.rs
+++ b/crates/rue-codegen/src/target/x86_64/mod.rs
@@ -11,7 +11,7 @@ mod emitter;
 // Re-export the main types with appropriate names
 pub use assembler::format_instructions_as_assembly;
 pub use elf::ElfWriter;
-pub use emitter::X86Emitter;
+pub use emitter::{SectionType, X86Emitter};
 
 use crate::target::{AssemblyFormatter, ExecutableWriter, InstructionEmitter};
 use rue_ir::pir::Label;
@@ -34,6 +34,10 @@ impl InstructionEmitter<X8664Instr> for X86Emitter {
     fn get_output(&self) -> (&[u8], HashMap<String, usize>) {
         self.get_output()
     }
+
+    fn get_data_and_bss(&self) -> (&[u8], usize) {
+        self.get_data_and_bss()
+    }
 }
 
 impl ExecutableWriter for ElfWriter {
@@ -43,6 +47,16 @@ impl ExecutableWriter for ElfWriter {
         symbols: &HashMap<String, usize>,
     ) -> Vec<u8> {
         self.generate_elf(machine_code, symbols)
+    }
+
+    fn generate_executable_with_sections(
+        &self,
+        machine_code: &[u8],
+        symbols: &HashMap<String, usize>,
+        data_section: &[u8],
+        bss_size: usize,
+    ) -> Vec<u8> {
+        self.generate_elf_with_sections(machine_code, symbols, data_section, bss_size)
     }
 }
 

--- a/crates/rue-compiler/src/pipeline.rs
+++ b/crates/rue-compiler/src/pipeline.rs
@@ -5,7 +5,7 @@
 
 use rue_codegen::backend::RuntimeProvider;
 use rue_codegen::target::TargetRegistry;
-use rue_codegen::{LoweringError, RegisterAllocator, X8664Codegen};
+use rue_codegen::{CodegenError, LoweringError, RegisterAllocator, X8664Codegen};
 use rue_ir::hir::HirProgram;
 use rue_ir::mir::MirProgram;
 use rue_ir::pir::{Label, PIR};
@@ -369,9 +369,19 @@ pub fn compile_hir_via_mir_to_executable(
     // Extract symbol positions from emitter
     let (_, symbols) = emitter.get_output();
 
-    // Generate ELF executable using trait abstraction
+    // Validate that _start symbol exists
+    if !symbols.contains_key("_start") {
+        return Err(CompileError::Codegen(CodegenError::InvalidOperation(
+            "_start symbol not found in symbol table - runtime initialization failed".to_string(),
+        )));
+    }
+
+    // Get data and BSS section information
+    let (data_section, bss_size) = emitter.get_data_and_bss();
+
+    // Generate ELF executable using trait abstraction with section support
     let elf_writer = TargetRegistry::create_executable_writer(TargetRegistry::default_target());
-    Ok(elf_writer.generate_executable(&code, &symbols))
+    Ok(elf_writer.generate_executable_with_sections(&code, &symbols, data_section, bss_size))
 }
 
 #[cfg(test)]

--- a/crates/rue-target/src/x86_64.rs
+++ b/crates/rue-target/src/x86_64.rs
@@ -123,6 +123,9 @@ pub enum X8664Instr {
     /// and dest, src
     AndRR { dest: X86Register, src: X86Register },
 
+    /// and dest, imm32
+    AndRI { dest: X86Register, imm: i32 },
+
     /// shl dest, cl (shift left)
     Shl {
         dest: X86Register,
@@ -220,4 +223,7 @@ pub enum X8664Instr {
 
     /// ud2 - undefined instruction (causes SIGILL)
     Ud2,
+
+    /// Section directive for assembly generation
+    Section { name: String },
 }


### PR DESCRIPTION
- Add complete heap allocation system with bump allocator (__rue_heap_init, __rue_alloc, __rue_free, __rue_heap_reset)
- Add 64KB heap in BSS section with proper memory layout and alignment
- Fix ELF writer to support BSS sections for heap memory management
- Fix runtime initialization segfault by ensuring proper memory mapping
- Implement ExecutableWriter trait with data/BSS section support  
- Fix symbol resolution bug where function positions were overwritten
- Clean up unused object crate imports and functions
- All tests now passing: casting tests, corpus tests, and integration tests