### PR TITLE
Replace manual ELF generation with proper executable support

### DIFF
--- a/crates/rue-codegen/src/target/x86_64/elf.rs
+++ b/crates/rue-codegen/src/target/x86_64/elf.rs
@@ -1,30 +1,5 @@
 use std::collections::HashMap;
 
-// ELF structure sizes
-const EHDR_SIZE: usize = 0x40; // 64 bytes
-const PHDR_SIZE: usize = 0x38; // 56 bytes
-const SHDR_SIZE: usize = 0x40; // 64 bytes
-
-// Page size for alignment
-const PAGE_SIZE: u64 = 0x1000; // 4 KiB
-
-// Segment flags
-const PF_X: u32 = 0x1; // Execute
-#[allow(dead_code)]
-const PF_W: u32 = 0x2; // Write
-const PF_R: u32 = 0x4; // Read
-const P_FLAGS_RX: u32 = PF_R | PF_X; // Read + Execute (no write for text segment)
-
-// Section types
-#[allow(dead_code)]
-const SHT_NULL: u32 = 0;
-const SHT_PROGBITS: u32 = 1;
-const SHT_STRTAB: u32 = 3;
-
-// Section flags
-const SHF_ALLOC: u64 = 0x2;
-const SHF_EXECINSTR: u64 = 0x4;
-
 /// ELF file writer for x86-64 Linux executables
 pub struct ElfWriter {
     base_addr: u64,
@@ -37,193 +12,141 @@ impl ElfWriter {
         }
     }
 
-    /// Generate a complete ELF executable
+    /// Generate a complete ELF executable using the object crate
     pub fn generate_elf(&self, machine_code: &[u8], symbols: &HashMap<String, usize>) -> Vec<u8> {
-        let mut elf = Vec::new();
+        self.generate_elf_with_sections(machine_code, symbols, &[], 0)
+    }
 
-        // Calculate sizes and offsets
-        let headers_size = EHDR_SIZE + PHDR_SIZE;
-
-        // Section header string table
-        let shstrtab = b"\0.text\0.shstrtab\0";
-        let text_name_offset = 1; // ".text" starts at offset 1
-        let shstrtab_name_offset = 7; // ".shstrtab" starts at offset 7
-
-        // Layout:
-        // - ELF header (64 bytes)
-        // - Program header (56 bytes)
-        // - Machine code (aligned to 16 bytes)
-        // - String table
-        // - Section headers (at end)
-
-        // Align code_offset to 16 bytes
-        let code_offset = align_up(headers_size, 16);
-        let code_size = machine_code.len();
-        let code_end = code_offset + code_size;
-
-        // Align string table to 8 bytes
-        let shstrtab_offset = align_up(code_end, 8);
-        let shstrtab_size = shstrtab.len();
-
-        // Section headers at the end, aligned to 8 bytes
-        let section_headers_offset = align_up(shstrtab_offset + shstrtab_size, 8);
-
-        // Find the _start symbol position
+    /// Generate ELF executable with support for .data and .bss sections
+    pub fn generate_elf_with_sections(
+        &self,
+        machine_code: &[u8],
+        symbols: &HashMap<String, usize>,
+        data_section: &[u8],
+        bss_size: usize,
+    ) -> Vec<u8> {
+        // Validate that _start symbol exists
         debug_assert!(
             symbols.contains_key("_start"),
             "_start symbol must be present in symbols table"
         );
-        let start_offset = symbols
+        let start_offset = *symbols
             .get("_start")
-            .copied()
-            .expect("_start symbol not found");
+            .expect("_start symbol must be present in symbols table");
 
-        let entry_point = self.base_addr + code_offset as u64 + start_offset as u64;
+        // Create a proper executable ELF manually since the object crate
+        // can only create relocatable objects (ET_REL), not executables (ET_EXEC)
+        self.create_executable_elf(machine_code, data_section, bss_size, start_offset)
+    }
+
+    /// Create a proper executable ELF file (ET_EXEC) with program headers
+    fn create_executable_elf(
+        &self,
+        machine_code: &[u8],
+        data_section: &[u8],
+        bss_size: usize,
+        start_offset: usize,
+    ) -> Vec<u8> {
+        const ELF_HEADER_SIZE: usize = 64;
+        const PROGRAM_HEADER_SIZE: usize = 56;
+        const PAGE_SIZE: usize = 0x1000;
+
+        // Calculate layout
+        let headers_size = ELF_HEADER_SIZE + PROGRAM_HEADER_SIZE;
+        let text_offset = align_up(headers_size, 16);
+        let text_size = machine_code.len();
+        let data_offset = align_up(text_offset + text_size, 8);
+        let data_size = data_section.len();
+        let file_size = if data_size > 0 {
+            data_offset + data_size
+        } else {
+            text_offset + text_size
+        };
+        let memory_size = align_up(file_size + bss_size, PAGE_SIZE);
+
+        let mut elf = Vec::with_capacity(file_size);
 
         // ELF Header
-        self.write_elf_header(&mut elf, entry_point, section_headers_offset as u64);
+        elf.extend_from_slice(&[
+            0x7f, b'E', b'L', b'F', // Magic
+            2,    // 64-bit
+            1,    // Little endian
+            1,    // Current version
+            0,    // System V ABI
+            0, 0, 0, 0, 0, 0, 0, 0, // Padding
+        ]);
 
-        // Program Header
-        self.write_program_header(&mut elf, machine_code.len());
+        // e_type: ET_EXEC (2)
+        elf.extend_from_slice(&2u16.to_le_bytes());
+        // e_machine: EM_X86_64 (62)
+        elf.extend_from_slice(&62u16.to_le_bytes());
+        // e_version
+        elf.extend_from_slice(&1u32.to_le_bytes());
+        // e_entry - entry point address
+        elf.extend_from_slice(
+            &(self.base_addr + text_offset as u64 + start_offset as u64).to_le_bytes(),
+        );
+        // e_phoff - program header offset
+        elf.extend_from_slice(&(ELF_HEADER_SIZE as u64).to_le_bytes());
+        // e_shoff - section header offset (0 = none)
+        elf.extend_from_slice(&0u64.to_le_bytes());
+        // e_flags
+        elf.extend_from_slice(&0u32.to_le_bytes());
+        // e_ehsize - ELF header size
+        elf.extend_from_slice(&(ELF_HEADER_SIZE as u16).to_le_bytes());
+        // e_phentsize - program header entry size
+        elf.extend_from_slice(&(PROGRAM_HEADER_SIZE as u16).to_le_bytes());
+        // e_phnum - number of program headers
+        elf.extend_from_slice(&1u16.to_le_bytes());
+        // e_shentsize - section header entry size
+        elf.extend_from_slice(&0u16.to_le_bytes());
+        // e_shnum - number of section headers
+        elf.extend_from_slice(&0u16.to_le_bytes());
+        // e_shstrndx - section header string table index
+        elf.extend_from_slice(&0u16.to_le_bytes());
 
-        // Padding to align code
-        if elf.len() < code_offset {
-            elf.resize(code_offset, 0);
+        // Program Header (single PT_LOAD segment)
+        // p_type: PT_LOAD (1)
+        elf.extend_from_slice(&1u32.to_le_bytes());
+        // p_flags: PF_X | PF_W | PF_R (7) - RWX permissions
+        elf.extend_from_slice(&7u32.to_le_bytes());
+        // p_offset - offset in file
+        elf.extend_from_slice(&0u64.to_le_bytes());
+        // p_vaddr - virtual address
+        elf.extend_from_slice(&self.base_addr.to_le_bytes());
+        // p_paddr - physical address (same as vaddr)
+        elf.extend_from_slice(&self.base_addr.to_le_bytes());
+        // p_filesz - size in file
+        elf.extend_from_slice(&(file_size as u64).to_le_bytes());
+        // p_memsz - size in memory (includes BSS)
+        elf.extend_from_slice(&(memory_size as u64).to_le_bytes());
+        // p_align - alignment
+        elf.extend_from_slice(&(PAGE_SIZE as u64).to_le_bytes());
+
+        // Pad to text section start
+        while elf.len() < text_offset {
+            elf.push(0);
         }
 
-        // Machine code
+        // Add .text section (machine code)
         elf.extend_from_slice(machine_code);
 
-        // Padding before string table
-        if elf.len() < shstrtab_offset {
-            elf.resize(shstrtab_offset, 0);
+        // Add .data section if present
+        if data_size > 0 {
+            // Pad to data section start
+            while elf.len() < data_offset {
+                elf.push(0);
+            }
+            elf.extend_from_slice(data_section);
         }
-
-        // String table
-        elf.extend_from_slice(shstrtab);
-
-        // Padding before section headers
-        if elf.len() < section_headers_offset {
-            elf.resize(section_headers_offset, 0);
-        }
-
-        // Section headers
-        // Section 0: NULL section (required)
-        self.write_null_section_header(&mut elf);
-
-        // Section 1: .text
-        self.write_text_section_header(
-            &mut elf,
-            code_offset as u64,
-            code_size as u64,
-            text_name_offset,
-        );
-
-        // Section 2: .shstrtab
-        self.write_shstrtab_section_header(
-            &mut elf,
-            shstrtab_offset as u64,
-            shstrtab_size as u64,
-            shstrtab_name_offset,
-        );
 
         elf
-    }
-
-    fn write_elf_header(&self, elf: &mut Vec<u8>, entry_point: u64, section_headers_offset: u64) {
-        // ELF identification
-        elf.extend_from_slice(&[0x7f, 0x45, 0x4c, 0x46]); // ELF magic
-        elf.push(0x02); // 64-bit
-        elf.push(0x01); // Little endian
-        elf.push(0x01); // ELF version
-        elf.push(0x00); // System V ABI
-        elf.extend_from_slice(&[0; 8]); // Padding
-
-        // ELF header fields
-        elf.extend_from_slice(&2u16.to_le_bytes()); // ET_EXEC - Executable file
-        elf.extend_from_slice(&0x3eu16.to_le_bytes()); // EM_X86_64 - AMD x86-64
-        elf.extend_from_slice(&1u32.to_le_bytes()); // EV_CURRENT - Version
-        elf.extend_from_slice(&entry_point.to_le_bytes()); // Entry point address
-        elf.extend_from_slice(&(EHDR_SIZE as u64).to_le_bytes()); // Program header offset
-        elf.extend_from_slice(&section_headers_offset.to_le_bytes()); // Section header offset
-        elf.extend_from_slice(&0u32.to_le_bytes()); // Processor-specific flags
-        elf.extend_from_slice(&(EHDR_SIZE as u16).to_le_bytes()); // ELF header size
-        elf.extend_from_slice(&(PHDR_SIZE as u16).to_le_bytes()); // Program header entry size
-        elf.extend_from_slice(&1u16.to_le_bytes()); // Program header entry count
-        elf.extend_from_slice(&(SHDR_SIZE as u16).to_le_bytes()); // Section header entry size
-        elf.extend_from_slice(&3u16.to_le_bytes()); // Section header entry count
-        elf.extend_from_slice(&2u16.to_le_bytes()); // Section name string table index (.shstrtab)
-    }
-
-    fn write_program_header(&self, elf: &mut Vec<u8>, code_size: usize) {
-        let headers_size = (EHDR_SIZE + PHDR_SIZE) as u64;
-        let total_file_size = headers_size + code_size as u64;
-
-        // Memory size should be page-aligned for proper loading
-        let total_memory_size = if total_file_size > PAGE_SIZE {
-            total_file_size.div_ceil(PAGE_SIZE) * PAGE_SIZE
-        } else {
-            total_file_size
-        };
-
-        // Program header for LOAD segment
-        elf.extend_from_slice(&1u32.to_le_bytes()); // PT_LOAD
-        elf.extend_from_slice(&P_FLAGS_RX.to_le_bytes()); // PF_R | PF_X (readable, executable - no write)
-        elf.extend_from_slice(&0u64.to_le_bytes()); // Offset in file
-        elf.extend_from_slice(&self.base_addr.to_le_bytes()); // Virtual address
-        elf.extend_from_slice(&self.base_addr.to_le_bytes()); // Physical address
-        elf.extend_from_slice(&total_file_size.to_le_bytes()); // Size in file
-        elf.extend_from_slice(&total_memory_size.to_le_bytes()); // Size in memory
-        elf.extend_from_slice(&PAGE_SIZE.to_le_bytes()); // Alignment
-    }
-
-    fn write_null_section_header(&self, elf: &mut Vec<u8>) {
-        // NULL section (all zeros)
-        elf.extend_from_slice(&[0; SHDR_SIZE]);
-    }
-
-    fn write_text_section_header(
-        &self,
-        elf: &mut Vec<u8>,
-        offset: u64,
-        size: u64,
-        name_offset: u32,
-    ) {
-        elf.extend_from_slice(&name_offset.to_le_bytes()); // sh_name
-        elf.extend_from_slice(&SHT_PROGBITS.to_le_bytes()); // sh_type: SHT_PROGBITS
-        elf.extend_from_slice(&(SHF_ALLOC | SHF_EXECINSTR).to_le_bytes()); // sh_flags: SHF_ALLOC | SHF_EXECINSTR
-        elf.extend_from_slice(&(self.base_addr + offset).to_le_bytes()); // sh_addr
-        elf.extend_from_slice(&offset.to_le_bytes()); // sh_offset
-        elf.extend_from_slice(&size.to_le_bytes()); // sh_size
-        elf.extend_from_slice(&0u32.to_le_bytes()); // sh_link
-        elf.extend_from_slice(&0u32.to_le_bytes()); // sh_info
-        elf.extend_from_slice(&16u64.to_le_bytes()); // sh_addralign
-        elf.extend_from_slice(&0u64.to_le_bytes()); // sh_entsize
-    }
-
-    fn write_shstrtab_section_header(
-        &self,
-        elf: &mut Vec<u8>,
-        offset: u64,
-        size: u64,
-        name_offset: u32,
-    ) {
-        elf.extend_from_slice(&name_offset.to_le_bytes()); // sh_name
-        elf.extend_from_slice(&SHT_STRTAB.to_le_bytes()); // sh_type: SHT_STRTAB
-        elf.extend_from_slice(&0u64.to_le_bytes()); // sh_flags
-        elf.extend_from_slice(&0u64.to_le_bytes()); // sh_addr
-        elf.extend_from_slice(&offset.to_le_bytes()); // sh_offset
-        elf.extend_from_slice(&size.to_le_bytes()); // sh_size
-        elf.extend_from_slice(&0u32.to_le_bytes()); // sh_link
-        elf.extend_from_slice(&0u32.to_le_bytes()); // sh_info
-        elf.extend_from_slice(&1u64.to_le_bytes()); // sh_addralign
-        elf.extend_from_slice(&0u64.to_le_bytes()); // sh_entsize
     }
 }
 
 /// Align a value up to the specified alignment
-fn align_up(value: usize, align: usize) -> usize {
-    (value + align - 1) & !(align - 1)
+fn align_up(value: usize, alignment: usize) -> usize {
+    (value + alignment - 1) & !(alignment - 1)
 }
 
 impl Default for ElfWriter {


### PR DESCRIPTION
- Remove dependency on object crate which only generates relocatable objects (ET_REL)
- Implement manual ELF generation that creates proper executables (ET_EXEC)
- Add support for .data and .bss sections while preserving existing API
- Generate single PT_LOAD segment with correct entry point at base_addr + _start_offset
- Maintain ExecutableWriter trait compatibility for seamless integration