### PR TITLE
Add missing Buck2 integration test targets to match Cargo coverage

### DIFF
--- a/crates/rue-lowering/BUCK
+++ b/crates/rue-lowering/BUCK
@@ -26,3 +26,31 @@ rust_test(
         "//third-party/rust:tracing",
     ],
 )
+
+rust_test(
+    name = "aggregate_integration_tests",
+    srcs = glob(["tests/**/*.rs"]),
+    crate_root = "tests/aggregate_integration_tests.rs",
+    edition = "2024",
+    deps = [
+        ":rue-lowering",
+        "//crates/rue-ir:rue-ir",
+        "//crates/rue-lexer:rue-lexer",
+        "//crates/rue-target:rue-target",
+        "//third-party/rust:tracing",
+    ],
+)
+
+rust_test(
+    name = "test_direct_returns",
+    srcs = glob(["tests/**/*.rs"]),
+    crate_root = "tests/test_direct_returns.rs",
+    edition = "2024",
+    deps = [
+        ":rue-lowering",
+        "//crates/rue-ir:rue-ir",
+        "//crates/rue-lexer:rue-lexer",
+        "//crates/rue-target:rue-target",
+        "//third-party/rust:tracing",
+    ],
+)

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -55,3 +55,106 @@ rust_test(
         "CARGO_MANIFEST_DIR": ".",
     },
 )
+
+rust_test(
+    name = "aggregate_runtime_integration_tests",
+    srcs = glob(["tests/**/*.rs"]),
+    crate_root = "tests/aggregate_runtime_integration_tests.rs",
+    edition = "2024",
+    deps = [
+        "//crates/rue-compiler:rue-compiler",
+        "//crates/rue-codegen:rue-codegen",
+    ],
+    env = {
+        "CARGO_MANIFEST_DIR": ".",
+    },
+)
+
+rust_test(
+    name = "casting_tests",
+    srcs = glob(["tests/**/*.rs"]),
+    crate_root = "tests/casting_tests.rs",
+    edition = "2024",
+    deps = [
+        "//crates/rue-compiler:rue-compiler",
+        "//crates/rue-codegen:rue-codegen",
+        "//third-party/rust:tempfile",
+    ],
+    env = {
+        "CARGO_MANIFEST_DIR": ".",
+        "CARGO_BIN_EXE_rue": "$(location :rue)",
+    },
+)
+
+rust_test(
+    name = "compiler",
+    srcs = glob(["tests/**/*.rs"]),
+    crate_root = "tests/compiler.rs",
+    edition = "2024",
+    deps = [
+        "//crates/rue-compiler:rue-compiler",
+        "//crates/rue-codegen:rue-codegen",
+        "//third-party/rust:tempfile",
+    ],
+    env = {
+        "CARGO_MANIFEST_DIR": ".",
+        "CARGO_BIN_EXE_rue": "$(location :rue)",
+    },
+)
+
+rust_test(
+    name = "runtime_edge_cases",
+    srcs = glob(["tests/**/*.rs"]),
+    crate_root = "tests/runtime_edge_cases.rs",
+    edition = "2024",
+    deps = [
+        "//crates/rue-compiler:rue-compiler",
+        "//crates/rue-codegen:rue-codegen",
+        "//third-party/rust:tempfile",
+    ],
+    env = {
+        "CARGO_MANIFEST_DIR": ".",
+    },
+)
+
+rust_test(
+    name = "runtime_tests",
+    srcs = glob(["tests/**/*.rs"]),
+    crate_root = "tests/runtime_tests.rs",
+    edition = "2024",
+    deps = [
+        "//crates/rue-compiler:rue-compiler",
+        "//crates/rue-codegen:rue-codegen",
+    ],
+    env = {
+        "CARGO_MANIFEST_DIR": ".",
+    },
+)
+
+rust_test(
+    name = "test_recursive_debug",
+    srcs = glob(["tests/**/*.rs"]),
+    crate_root = "tests/test_recursive_debug.rs",
+    edition = "2024",
+    deps = [
+        "//crates/rue-compiler:rue-compiler",
+        "//crates/rue-codegen:rue-codegen",
+    ],
+    env = {
+        "CARGO_MANIFEST_DIR": ".",
+    },
+)
+
+rust_test(
+    name = "variable_shadowing_tests",
+    srcs = glob(["tests/**/*.rs"]),
+    crate_root = "tests/variable_shadowing_tests.rs",
+    edition = "2024",
+    deps = [
+        "//crates/rue-compiler:rue-compiler",
+        "//crates/rue-codegen:rue-codegen",
+    ],
+    env = {
+        "CARGO_MANIFEST_DIR": ".",
+    },
+)


### PR DESCRIPTION
- Add 7 missing test targets in rue/BUCK: casting_tests, compiler, runtime_edge_cases, runtime_tests, aggregate_runtime_integration_tests, test_recursive_debug, variable_shadowing_tests
- Add 2 missing test targets in rue-lowering/BUCK: aggregate_integration_tests, test_direct_returns  
- Include required tempfile dependencies and CARGO_BIN_EXE_rue environment variables
- Buck2 now has 13 integration test targets matching Cargo's comprehensive test coverage