### PR TITLE
Move buck builds to Rust 2024

### DIFF
--- a/crates/rue-ast/BUCK
+++ b/crates/rue-ast/BUCK
@@ -4,7 +4,7 @@ cargo.rust_library(
     name = "rue-ast",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-lexer:rue-lexer",
     ],
@@ -15,7 +15,7 @@ rust_test(
     name = "test",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-lexer:rue-lexer",
     ],

--- a/crates/rue-diagnostic/BUCK
+++ b/crates/rue-diagnostic/BUCK
@@ -4,7 +4,7 @@ cargo.rust_library(
     name = "rue-diagnostic",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-lexer:rue-lexer",
         "//third-party/rust:thiserror",
@@ -16,7 +16,7 @@ rust_test(
     name = "test",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-lexer:rue-lexer",
         "//third-party/rust:thiserror",

--- a/crates/rue-ir/BUCK
+++ b/crates/rue-ir/BUCK
@@ -4,7 +4,7 @@ cargo.rust_library(
     name = "rue-ir",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-lexer:rue-lexer",
         "//crates/rue-target:rue-target",
@@ -17,7 +17,7 @@ rust_test(
     name = "test",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-lexer:rue-lexer",
         "//crates/rue-target:rue-target",

--- a/crates/rue-lexer/BUCK
+++ b/crates/rue-lexer/BUCK
@@ -4,7 +4,7 @@ cargo.rust_library(
     name = "rue-lexer",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     visibility = ["PUBLIC"],
     deps = ["//third-party/rust:thiserror"],
 )
@@ -13,6 +13,6 @@ rust_test(
     name = "test",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = ["//third-party/rust:thiserror"],
 )

--- a/crates/rue-parser/BUCK
+++ b/crates/rue-parser/BUCK
@@ -4,7 +4,7 @@ cargo.rust_library(
     name = "rue-parser",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-ast:rue-ast",
         "//crates/rue-diagnostic:rue-diagnostic",
@@ -21,7 +21,7 @@ rust_test(
     name = "test",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-ast:rue-ast",
         "//crates/rue-diagnostic:rue-diagnostic",

--- a/crates/rue-target/BUCK
+++ b/crates/rue-target/BUCK
@@ -4,6 +4,6 @@ cargo.rust_library(
     name = "rue-target",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     visibility = ["PUBLIC"],
 )


### PR DESCRIPTION
These were incorrectly Rust 2021, whereas cargo was all 2024. Oops!