### PR TITLE
Move Buck to Rust 2024 and get clippy clean for 1.89.0

### DIFF
--- a/crates/rue-ast/BUCK
+++ b/crates/rue-ast/BUCK
@@ -4,7 +4,7 @@ cargo.rust_library(
     name = "rue-ast",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-lexer:rue-lexer",
     ],
@@ -15,7 +15,7 @@ rust_test(
     name = "test",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-lexer:rue-lexer",
     ],

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -477,10 +477,10 @@ impl RegisterAllocator {
         // CRITICAL: Mark excepted dirty registers as Clean after the flush
         // This prevents them from being stored again in a later flush_stores()
         for state in &mut self.scratch_states {
-            if except.contains(&state.reg) {
-                if let RegState::Dirty(vreg) = state.state {
-                    state.state = RegState::Clean(vreg);
-                }
+            if except.contains(&state.reg)
+                && let RegState::Dirty(vreg) = state.state
+            {
+                state.state = RegState::Clean(vreg);
             }
         }
     }
@@ -1056,11 +1056,11 @@ mod tests {
         // Find the spill of v1
         let mut found_v1_spill = false;
         for op in &ops {
-            if let X8664Instr::MovMR { offset, .. } = op {
-                if *offset == -8 {
-                    // VReg(1)'s slot
-                    found_v1_spill = true;
-                }
+            if let X8664Instr::MovMR { offset, .. } = op
+                && *offset == -8
+            {
+                // VReg(1)'s slot
+                found_v1_spill = true;
             }
         }
         assert!(found_v1_spill, "VReg(1) should have been spilled");

--- a/crates/rue-codegen/src/target/x86_64/emitter.rs
+++ b/crates/rue-codegen/src/target/x86_64/emitter.rs
@@ -821,22 +821,22 @@ impl X86Emitter {
             rex |= 0x08; // REX.W
         }
 
-        if let Some(reg) = r_reg {
-            if self.needs_rex_r(reg) {
-                rex |= 0x04; // REX.R
-            }
+        if let Some(reg) = r_reg
+            && self.needs_rex_r(reg)
+        {
+            rex |= 0x04; // REX.R
         }
 
-        if let Some(reg) = x_reg {
-            if reg.needs_rex() {
-                rex |= 0x02; // REX.X for SIB index
-            }
+        if let Some(reg) = x_reg
+            && reg.needs_rex()
+        {
+            rex |= 0x02; // REX.X for SIB index
         }
 
-        if let Some(reg) = b_reg {
-            if self.needs_rex_b(reg) {
-                rex |= 0x01; // REX.B
-            }
+        if let Some(reg) = b_reg
+            && self.needs_rex_b(reg)
+        {
+            rex |= 0x01; // REX.B
         }
 
         // For SetCC and other 8-bit operations on RSP, RBP, RSI, RDI,
@@ -943,10 +943,10 @@ impl X86Emitter {
         // Add function names to symbol table
         for (name, label_id) in &self.function_labels {
             let machine_id = label_id.to_machine_id(self.runtime_label_count);
-            if let Some((section, pos)) = self.label_positions.get(&machine_id) {
-                if *section == SectionType::Text {
-                    symbols.insert(name.clone(), *pos);
-                }
+            if let Some((section, pos)) = self.label_positions.get(&machine_id)
+                && *section == SectionType::Text
+            {
+                symbols.insert(name.clone(), *pos);
             }
         }
 

--- a/crates/rue-codegen/src/x86_64_backend.rs
+++ b/crates/rue-codegen/src/x86_64_backend.rs
@@ -2591,10 +2591,10 @@ impl<'a> X8664Codegen<'a> {
 
     fn get_or_create_label(&mut self, label_id: Label) -> u32 {
         // First check external label map if provided
-        if let Some(external_map) = self.external_label_map {
-            if let Some(&machine_id) = external_map.get(&label_id) {
-                return machine_id;
-            }
+        if let Some(external_map) = self.external_label_map
+            && let Some(&machine_id) = external_map.get(&label_id)
+        {
+            return machine_id;
         }
 
         // Check if we already have this label
@@ -2651,18 +2651,17 @@ impl<'a> X8664Codegen<'a> {
             base,
             offset,
         } = &instr
+            && *base == X86Register::Rbp
         {
-            if *base == X86Register::Rbp {
-                // This is a store to stack - find which VReg this corresponds to
-                if let Some(vreg) = self.allocator.find_vreg_for_slot(*offset as i64) {
-                    self.allocator.mark_vreg_initialized(vreg);
-                    trace!(
-                        target: "rue::codegen::regalloc",
-                        ?vreg,
-                        offset,
-                        "Marking VReg as initialized (stored to stack)"
-                    );
-                }
+            // This is a store to stack - find which VReg this corresponds to
+            if let Some(vreg) = self.allocator.find_vreg_for_slot(*offset as i64) {
+                self.allocator.mark_vreg_initialized(vreg);
+                trace!(
+                    target: "rue::codegen::regalloc",
+                    ?vreg,
+                    offset,
+                    "Marking VReg as initialized (stored to stack)"
+                );
             }
         }
 

--- a/crates/rue-compiler/src/pipeline.rs
+++ b/crates/rue-compiler/src/pipeline.rs
@@ -49,16 +49,15 @@ fn discover_function_boundaries(
     let mut current_start = 0;
 
     for (i, instr) in instructions.iter().enumerate() {
-        if let PIR::Label(label) = instr {
-            if function_labels
+        if let PIR::Label(label) = instr
+            && function_labels
                 .values()
                 .any(|&func_label| func_label == *label)
-            {
-                if current_start < i {
-                    function_boundaries.push((current_start, i));
-                }
-                current_start = i;
+        {
+            if current_start < i {
+                function_boundaries.push((current_start, i));
             }
+            current_start = i;
         }
     }
     if current_start < instructions.len() {

--- a/crates/rue-diagnostic/BUCK
+++ b/crates/rue-diagnostic/BUCK
@@ -4,7 +4,7 @@ cargo.rust_library(
     name = "rue-diagnostic",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-lexer:rue-lexer",
         "//third-party/rust:thiserror",
@@ -16,7 +16,7 @@ rust_test(
     name = "test",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-lexer:rue-lexer",
         "//third-party/rust:thiserror",

--- a/crates/rue-diagnostic/src/formatter.rs
+++ b/crates/rue-diagnostic/src/formatter.rs
@@ -45,20 +45,19 @@ impl DiagnosticFormatter {
         self.write_header(&mut output, diagnostic)?;
 
         // Write source location and context
-        if let Some(source) = source_manager.get_source(&diagnostic.source_id) {
-            if let Some(primary_label) = diagnostic
+        if let Some(source) = source_manager.get_source(&diagnostic.source_id)
+            && let Some(primary_label) = diagnostic
                 .labels
                 .iter()
                 .find(|l| l.style == LabelStyle::Primary)
-            {
-                self.write_location(
-                    &mut output,
-                    &diagnostic.source_id,
-                    primary_label.span,
-                    &source.line_starts,
-                )?;
-                self.write_source_context(&mut output, diagnostic, source_manager)?;
-            }
+        {
+            self.write_location(
+                &mut output,
+                &diagnostic.source_id,
+                primary_label.span,
+                &source.line_starts,
+            )?;
+            self.write_source_context(&mut output, diagnostic, source_manager)?;
         }
 
         // Write help text

--- a/crates/rue-ir/BUCK
+++ b/crates/rue-ir/BUCK
@@ -4,7 +4,7 @@ cargo.rust_library(
     name = "rue-ir",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-lexer:rue-lexer",
         "//crates/rue-target:rue-target",
@@ -17,7 +17,7 @@ rust_test(
     name = "test",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-lexer:rue-lexer",
         "//crates/rue-target:rue-target",

--- a/crates/rue-lexer/BUCK
+++ b/crates/rue-lexer/BUCK
@@ -4,7 +4,7 @@ cargo.rust_library(
     name = "rue-lexer",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     visibility = ["PUBLIC"],
     deps = ["//third-party/rust:thiserror"],
 )
@@ -13,6 +13,6 @@ rust_test(
     name = "test",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = ["//third-party/rust:thiserror"],
 )

--- a/crates/rue-lowering/src/verifier.rs
+++ b/crates/rue-lowering/src/verifier.rs
@@ -108,15 +108,13 @@ impl MirVerifier {
     ) {
         // Add block parameters as defined
         for (temp, ty) in &block.params {
-            if let Some(existing_ty) = defined_temps.insert(*temp, ty.clone()) {
-                if existing_ty != *ty {
-                    self.add_error(
-                        format!(
-                            "Block parameter {temp:?} type mismatch: {existing_ty:?} vs {ty:?}"
-                        ),
-                        Some(block.id),
-                    );
-                }
+            if let Some(existing_ty) = defined_temps.insert(*temp, ty.clone())
+                && existing_ty != *ty
+            {
+                self.add_error(
+                    format!("Block parameter {temp:?} type mismatch: {existing_ty:?} vs {ty:?}"),
+                    Some(block.id),
+                );
             }
         }
 
@@ -165,13 +163,13 @@ impl MirVerifier {
             }
             MirStatement::Return { value, .. } => {
                 // Verify that return value temp is defined if present
-                if let Some(temp) = value {
-                    if !defined_temps.contains_key(temp) {
-                        self.add_error(
-                            format!("Return statement uses undefined temporary {temp:?}"),
-                            Some(block_id),
-                        );
-                    }
+                if let Some(temp) = value
+                    && !defined_temps.contains_key(temp)
+                {
+                    self.add_error(
+                        format!("Return statement uses undefined temporary {temp:?}"),
+                        Some(block_id),
+                    );
                 }
                 // Type checking for return statements was already done in semantic analysis
             }
@@ -358,13 +356,10 @@ impl MirVerifier {
                 // Unreachable terminators are always valid (they should never be reached)
             }
             MirTerminator::Return { value, .. } => {
-                if let Some(val) = value {
-                    if !defined_temps.contains_key(val) {
-                        self.add_error(
-                            format!("Return value {val:?} is undefined"),
-                            Some(block_id),
-                        );
-                    }
+                if let Some(val) = value
+                    && !defined_temps.contains_key(val)
+                {
+                    self.add_error(format!("Return value {val:?} is undefined"), Some(block_id));
                 }
             }
         }

--- a/crates/rue-optimize/src/passes/const_prop.rs
+++ b/crates/rue-optimize/src/passes/const_prop.rs
@@ -224,11 +224,11 @@ impl MirMutVisitor for ConstProp {
             }
             MirStatement::Return { value, .. } => {
                 // Propagate constants in return value if present
-                if let Some(temp) = value {
-                    if let Some(_const_val) = self.constants.get(temp) {
-                        // Could optimize by replacing return temp with constant,
-                        // but this doesn't affect correctness, just efficiency
-                    }
+                if let Some(temp) = value
+                    && let Some(_const_val) = self.constants.get(temp)
+                {
+                    // Could optimize by replacing return temp with constant,
+                    // but this doesn't affect correctness, just efficiency
                 }
             }
         }
@@ -242,10 +242,10 @@ impl MirMutVisitor for ConstProp {
 
     fn visit_terminator(&mut self, term: &mut MirTerminator) -> VisitorControl {
         // First propagate constants in the terminator
-        if let MirTerminator::Branch { condition, .. } = term {
-            if let Some(_const_val) = self.constants.get(condition) {
-                // We know the condition value, but we need to let optimize_terminator handle the transformation
-            }
+        if let MirTerminator::Branch { condition, .. } = term
+            && let Some(_const_val) = self.constants.get(condition)
+        {
+            // We know the condition value, but we need to let optimize_terminator handle the transformation
         }
         self.optimize_terminator(term);
         VisitorControl::Continue

--- a/crates/rue-parser/BUCK
+++ b/crates/rue-parser/BUCK
@@ -4,7 +4,7 @@ cargo.rust_library(
     name = "rue-parser",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-ast:rue-ast",
         "//crates/rue-diagnostic:rue-diagnostic",
@@ -21,7 +21,7 @@ rust_test(
     name = "test",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-ast:rue-ast",
         "//crates/rue-diagnostic:rue-diagnostic",

--- a/crates/rue-parser/src/error_recovery.rs
+++ b/crates/rue-parser/src/error_recovery.rs
@@ -269,12 +269,12 @@ impl RecoveringParser {
         let current_pos = self.parser.current_position();
 
         // If we're at the same position as last recovery, force advance
-        if let Some(last_pos) = self.last_recovery_position {
-            if current_pos == last_pos {
-                // We're stuck at the same position, force advance to prevent infinite loop
-                if !self.parser.is_at_end() {
-                    self.parser.advance();
-                }
+        if let Some(last_pos) = self.last_recovery_position
+            && current_pos == last_pos
+        {
+            // We're stuck at the same position, force advance to prevent infinite loop
+            if !self.parser.is_at_end() {
+                self.parser.advance();
             }
         }
 

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -108,15 +108,13 @@ impl Parser {
             let field = self.parse_struct_field_def()?;
 
             // Check for duplicate field names
-            if let TokenKind::Ident(field_name) = &field.name.kind {
-                if !field_names.insert(field_name.clone()) {
-                    return Err(ParseError {
-                        message: format!(
-                            "Duplicate field name '{field_name}' in struct definition"
-                        ),
-                        span: field.name.span,
-                    });
-                }
+            if let TokenKind::Ident(field_name) = &field.name.kind
+                && !field_names.insert(field_name.clone())
+            {
+                return Err(ParseError {
+                    message: format!("Duplicate field name '{field_name}' in struct definition"),
+                    span: field.name.span,
+                });
             }
 
             fields.push(field);
@@ -726,13 +724,13 @@ impl Parser {
             let field = self.parse_struct_field_init()?;
 
             // Check for duplicate field names
-            if let TokenKind::Ident(field_name) = &field.name.kind {
-                if !field_names.insert(field_name.clone()) {
-                    return Err(ParseError {
-                        message: format!("Duplicate field name '{field_name}' in struct literal"),
-                        span: field.name.span,
-                    });
-                }
+            if let TokenKind::Ident(field_name) = &field.name.kind
+                && !field_names.insert(field_name.clone())
+            {
+                return Err(ParseError {
+                    message: format!("Duplicate field name '{field_name}' in struct literal"),
+                    span: field.name.span,
+                });
             }
 
             fields.push(field);
@@ -1138,13 +1136,13 @@ impl Parser {
         let size = self.expect_integer()?;
 
         // Validate array size is non-negative
-        if let TokenKind::Integer(size_value) = &size.kind {
-            if *size_value < 0 {
-                return Err(ParseError {
-                    message: format!("Array size must be non-negative, found {size_value}"),
-                    span: size.span,
-                });
-            }
+        if let TokenKind::Integer(size_value) = &size.kind
+            && *size_value < 0
+        {
+            return Err(ParseError {
+                message: format!("Array size must be non-negative, found {size_value}"),
+                span: size.span,
+            });
         }
 
         self.skip_comments();

--- a/crates/rue-semantic/src/hir_validator.rs
+++ b/crates/rue-semantic/src/hir_validator.rs
@@ -393,16 +393,16 @@ impl HirValidator {
                 // Validate each argument
                 for (i, arg) in args.iter().enumerate() {
                     let arg_type = self.validate_expression(arg);
-                    if let Some(expected_type) = param_types.get(i) {
-                        if arg_type != *expected_type {
-                            self.errors.push(SemanticError {
+                    if let Some(expected_type) = param_types.get(i)
+                        && arg_type != *expected_type
+                    {
+                        self.errors.push(SemanticError {
                                 message: format!(
                                     "Argument {} to function '{func}': expected {expected_type}, found {arg_type}",
                                     i + 1
                                 ),
                                 span: arg.span(),
                             });
-                        }
                     }
                 }
 

--- a/crates/rue-semantic/src/type_checker.rs
+++ b/crates/rue-semantic/src/type_checker.rs
@@ -734,30 +734,30 @@ impl TypeChecker {
                     };
 
                     // Validate that the return type matches the function's return type
-                    if let Some(expected_type) = expected_return_type {
-                        if hir_expr.ty() != expected_type {
-                            return Err(SemanticError {
-                                message: format!(
-                                    "Return type mismatch: expected {expected_type}, found {}",
-                                    hir_expr.ty()
-                                ),
-                                span: expr.span(),
-                            });
-                        }
+                    if let Some(expected_type) = expected_return_type
+                        && hir_expr.ty() != expected_type
+                    {
+                        return Err(SemanticError {
+                            message: format!(
+                                "Return type mismatch: expected {expected_type}, found {}",
+                                hir_expr.ty()
+                            ),
+                            span: expr.span(),
+                        });
                     }
 
                     Some(hir_expr)
                 } else {
                     // Bare return; - should be unit type
-                    if let Some(expected_type) = expected_return_type {
-                        if *expected_type != RueType::Unit {
-                            return Err(SemanticError {
-                                message: format!(
-                                    "Return type mismatch: expected {expected_type}, found unit (bare return)"
-                                ),
-                                span: return_stmt.return_token.span,
-                            });
-                        }
+                    if let Some(expected_type) = expected_return_type
+                        && *expected_type != RueType::Unit
+                    {
+                        return Err(SemanticError {
+                            message: format!(
+                                "Return type mismatch: expected {expected_type}, found unit (bare return)"
+                            ),
+                            span: return_stmt.return_token.span,
+                        });
                     }
                     None
                 };

--- a/crates/rue-semantic/src/type_checker_diagnostics.rs
+++ b/crates/rue-semantic/src/type_checker_diagnostics.rs
@@ -204,10 +204,10 @@ impl DiagnosticTypeChecker {
 
     /// Extract variable name from error message
     fn extract_variable_name(&self, message: &str) -> Option<String> {
-        if let Some(start) = message.find('\'') {
-            if let Some(end) = message[start + 1..].find('\'') {
-                return Some(message[start + 1..start + 1 + end].to_string());
-            }
+        if let Some(start) = message.find('\'')
+            && let Some(end) = message[start + 1..].find('\'')
+        {
+            return Some(message[start + 1..start + 1 + end].to_string());
         }
         None
     }

--- a/crates/rue-target/BUCK
+++ b/crates/rue-target/BUCK
@@ -4,6 +4,6 @@ cargo.rust_library(
     name = "rue-target",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     visibility = ["PUBLIC"],
 )

--- a/docs/sessions/002-parser/implementation-notes.md
+++ b/docs/sessions/002-parser/implementation-notes.md
@@ -209,7 +209,7 @@ cargo.rust_library(
     name = "rue-ast",
     srcs = glob(["src/**/*.rs"]),
     crate_root = "src/lib.rs",
-    edition = "2021",
+    edition = "2024",
     deps = [
         "//crates/rue-lexer:rue-lexer",  # Added this line
     ],


### PR DESCRIPTION
While getting clippy clean for Rust 1.89.0, I found out that the Buck builds were doing Rust 2021 instead of Rust 2024. Oops!

Since I want CI to be green, we have to do these together, as they'll each fail without the other.