### PR TITLE
Fix rustfmt scripts to use find instead of git ls-files

### DIFF
--- a/tools/rustfmt/fmt_check.sh
+++ b/tools/rustfmt/fmt_check.sh
@@ -3,12 +3,9 @@ set -euo pipefail
 
 edition="${1:-2024}"
 
-# Prefer git for speed and correctness; fall back to find if not a git repo.
-if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  mapfile -t files < <(git ls-files 'crates/**/*.rs')
-else
-  mapfile -t files < <(find crates -type f -name '*.rs')
-fi
+# Always use find to get actual files on disk
+# This works correctly with both git and jj
+mapfile -t files < <(find crates -type f -name '*.rs')
 
 if [[ ${#files[@]} -eq 0 ]]; then
   echo "No Rust files under crates/."

--- a/tools/rustfmt/fmt_fix.sh
+++ b/tools/rustfmt/fmt_fix.sh
@@ -3,11 +3,9 @@ set -euo pipefail
 
 edition="${1:-2024}"
 
-if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
-  mapfile -t files < <(git ls-files 'crates/**/*.rs')
-else
-  mapfile -t files < <(find crates -type f -name '*.rs')
-fi
+# Always use find to get actual files on disk
+# This works correctly with both git and jj
+mapfile -t files < <(find crates -type f -name '*.rs')
 
 if [[ ${#files[@]} -eq 0 ]]; then
   echo "No Rust files under crates/."


### PR DESCRIPTION
The rustfmt scripts were failing because they used 'git ls-files' which reads from git's index. When using jj, the git index isn't updated until git operations like push, causing the scripts to reference files that were moved or deleted.

Changed both fmt_check.sh and fmt_fix.sh to always use 'find' to discover Rust files. This works correctly with both git and jj since it looks at the actual filesystem rather than version control metadata.
