### PR TITLE
docs: fix typo in "License" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,9 +270,9 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for development guidance and
 
 Licensed under either of
 
-* Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or
-  http://www.apache.org/licenses/LICENSE-2.0) MIT license
-* ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+* Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
+  http://www.apache.org/licenses/LICENSE-2.0)
+* MIT License ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
 
 at your option.
 


### PR DESCRIPTION
### Summary

Fix a small typo in the "License" section of the README that I just stumbled upon while looking at the project

### Details

- "MIT License" should be in the second bullet (not at the end of the first)
  - also capitalize "L" for consistency