### PR TITLE
docs: update outdated struct layout comment in tests

### DIFF
--- a/crates/rue/tests/aggregate_runtime_integration_tests.rs
+++ b/crates/rue/tests/aggregate_runtime_integration_tests.rs
@@ -27,8 +27,7 @@
 //! - ✅ Memory allocation strategies
 //!
 //! ### Known Limitations:
-//! - 🔄 Struct field names are mapped to offsets via heuristics (x=0, y=8, z=16, etc.)
-//! - 🔄 Struct size assumes 2 x i64 fields (16 bytes) - needs proper struct definition lookup
+//! - None! Struct layout is fully implemented with proper field offset and size calculation
 //!
 //! ### Test Organization:
 //!


### PR DESCRIPTION
The comment claimed struct layout used heuristics, but this was outdated. The proper TypeContext-based layout calculation infrastructure was implemented on the same day (Aug 6, 2025) and is fully functional.

The infrastructure includes:
- TypeContext::compute_layout() for size/alignment calculation
- StructDef::compute_layout() for field offset computation
- Proper integration through scope_to_type_context()

This was just a stale comment from when the work was in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)