### PR TITLE
Add overflow checking to relocation bounds validation

### DIFF
--- a/crates/rue-codegen/src/linker/mod.rs
+++ b/crates/rue-codegen/src/linker/mod.rs
@@ -279,24 +279,36 @@ impl Linker {
                 // R_X86_64_64: 64-bit absolute address
                 let value = (target_address as i64 + relocation.addend) as u64;
                 let offset = relocation.offset as usize;
-                if offset + 8 > section.data.len() {
+
+                // Check for overflow and bounds
+                let end_offset = offset.checked_add(8).ok_or_else(|| {
+                    CodegenError::InvalidOperation("Relocation offset would overflow".to_string())
+                })?;
+
+                if end_offset > section.data.len() {
                     return Err(CodegenError::InvalidOperation(
                         "Relocation offset out of bounds".to_string(),
                     ));
                 }
-                section.data[offset..offset + 8].copy_from_slice(&value.to_le_bytes());
+                section.data[offset..end_offset].copy_from_slice(&value.to_le_bytes());
             }
             RelocationKind::PC32 => {
                 // R_X86_64_PC32: 32-bit PC-relative address
                 let pc = section.base_address + relocation.offset;
                 let value = (target_address as i64 - pc as i64 + relocation.addend) as i32;
                 let offset = relocation.offset as usize;
-                if offset + 4 > section.data.len() {
+
+                // Check for overflow and bounds
+                let end_offset = offset.checked_add(4).ok_or_else(|| {
+                    CodegenError::InvalidOperation("Relocation offset would overflow".to_string())
+                })?;
+
+                if end_offset > section.data.len() {
                     return Err(CodegenError::InvalidOperation(
                         "Relocation offset out of bounds".to_string(),
                     ));
                 }
-                section.data[offset..offset + 4].copy_from_slice(&value.to_le_bytes());
+                section.data[offset..end_offset].copy_from_slice(&value.to_le_bytes());
             }
         }
 


### PR DESCRIPTION
Relocation bounds checks used simple addition (offset + size) which could overflow if offset was near usize::MAX. While unlikely with valid object files, malformed input could trigger undefined behavior.

Use checked_add() to detect overflow before accessing section data, returning an error if overflow would occur. This provides better error messages and prevents potential security issues from malformed object files.