### PR TITLE
Add power-of-2 validation for alignment values

### DIFF
--- a/crates/rue-codegen/src/linker/mod.rs
+++ b/crates/rue-codegen/src/linker/mod.rs
@@ -364,6 +364,12 @@ fn align_to(value: u64, alignment: u64) -> u64 {
     if alignment == 0 {
         value
     } else {
+        // Alignment must be a power of 2 for bitwise alignment to work correctly
+        debug_assert!(
+            alignment.is_power_of_two(),
+            "Alignment must be a power of 2, got {}",
+            alignment
+        );
         (value + alignment - 1) & !(alignment - 1)
     }
 }


### PR DESCRIPTION
The align_to() function uses bitwise operations that only work correctly when alignment is a power of 2. Using non-power-of-2 alignments (like 3) produces incorrect results.

Add debug_assert to validate alignment is a power of 2. This catches malformed object files in debug builds without adding overhead to release builds. Valid ELF files always use power-of-2 alignments (1, 2, 4, 8, 16, etc).