### PR TITLE
Clarify boolean logic with explicit parentheses

### DIFF
--- a/crates/rue-codegen/src/linker/object_file.rs
+++ b/crates/rue-codegen/src/linker/object_file.rs
@@ -74,7 +74,7 @@ impl ObjectFile {
             let name = section.name().unwrap_or("<unknown>").to_string();
 
             // Skip sections we don't care about
-            if name.is_empty() || name.starts_with('.') && !self.is_important_section(&name) {
+            if name.is_empty() || (name.starts_with('.') && !self.is_important_section(&name)) {
                 continue;
             }
 


### PR DESCRIPTION
The condition 'name.is_empty() || name.starts_with('.') && \!self.is_important_section(&name)' relies on operator precedence where && binds tighter than ||. While technically correct, it's not immediately obvious to readers.

Add explicit parentheses to make the intent clear: skip if empty OR (starts with '.' AND not important). This improves code readability without changing behavior.