### PR TITLE
Complete Phase 2: Implement syscall foundation

### DIFF
--- a/crates/rue-runtime/src/buffered_io.rs
+++ b/crates/rue-runtime/src/buffered_io.rs
@@ -7,18 +7,8 @@
 use core::cell::UnsafeCell;
 use core::sync::atomic::{AtomicUsize, Ordering};
 
-/// Buffer size for stdout buffering (4KB)
-const STDOUT_BUFFER_SIZE: usize = 4096;
-
-/// Linux syscall numbers
-const SYS_WRITE: i64 = 1;
-const SYS_EXIT: i64 = 60;
-
-/// File descriptors
-const STDOUT_FD: i32 = 1;
-
-/// Exit codes
-const EXIT_CODE_SYSCALL_FAILED: i32 = 253;
+use crate::abi::*;
+use crate::syscall::{sys_exit, sys_write};
 
 /// A wrapper that provides interior mutability for the buffer
 struct BufferWrapper {
@@ -156,64 +146,18 @@ impl BufferedStdout {
             return Ok(());
         }
 
-        let result = unsafe {
-            syscall3(
-                SYS_WRITE,
-                STDOUT_FD as i64,
-                data.as_ptr() as i64,
-                data.len() as i64,
-            )
-        };
+        let result = unsafe { sys_write(STDOUT_FD, data.as_ptr(), data.len()) };
 
-        if result < 0 {
-            // Exit on syscall failure
-            unsafe {
-                syscall1(SYS_EXIT, EXIT_CODE_SYSCALL_FAILED as i64);
+        match result {
+            Ok(_) => Ok(()),
+            Err(_) => {
+                // Exit on syscall failure
+                unsafe {
+                    sys_exit(EXIT_SYSCALL_FAILED);
+                }
             }
-            // This should never be reached, but return error for completeness
-            Err(EXIT_CODE_SYSCALL_FAILED)
-        } else {
-            Ok(())
         }
     }
-}
-
-/// Raw syscall wrapper for 1 argument
-#[inline(always)]
-unsafe fn syscall1(syscall_num: i64, arg1: i64) -> i64 {
-    let ret: i64;
-    unsafe {
-        core::arch::asm!(
-            "syscall",
-            in("rax") syscall_num,
-            in("rdi") arg1,
-            lateout("rax") ret,
-            out("rcx") _,
-            out("r11") _,
-            options(nostack, preserves_flags)
-        );
-    }
-    ret
-}
-
-/// Raw syscall wrapper for 3 arguments
-#[inline(always)]
-unsafe fn syscall3(syscall_num: i64, arg1: i64, arg2: i64, arg3: i64) -> i64 {
-    let ret: i64;
-    unsafe {
-        core::arch::asm!(
-            "syscall",
-            in("rax") syscall_num,
-            in("rdi") arg1,
-            in("rsi") arg2,
-            in("rdx") arg3,
-            lateout("rax") ret,
-            out("rcx") _,
-            out("r11") _,
-            options(nostack, preserves_flags)
-        );
-    }
-    ret
 }
 
 /// C ABI function: Write a single byte to buffered stdout

--- a/crates/rue-runtime/src/syscall.rs
+++ b/crates/rue-runtime/src/syscall.rs
@@ -2,11 +2,170 @@
 //!
 //! This module provides safe wrappers around Linux system calls using inline assembly.
 //! All syscalls follow the System V AMD64 ABI.
+//!
+//! # Syscall Mechanism
+//!
+//! Linux x86-64 syscalls use the following registers:
+//! - RAX: syscall number
+//! - RDI: arg1
+//! - RSI: arg2
+//! - RDX: arg3
+//! - R10: arg4 (note: not RCX)
+//! - R8: arg5
+//! - R9: arg6
+//! - Return value: RAX (negative on error)
+//!
+//! The `syscall` instruction clobbers RCX and R11.
 
-// This module will be implemented in Phase 2
-// For now, just re-export the syscall helpers from buffered_io
+use crate::abi::*;
 
 /// Result type for syscall operations
+///
+/// On success, contains the return value (usually bytes transferred or 0).
+/// On error, contains the negated errno value.
 pub type SyscallResult<T> = Result<T, i32>;
 
-// Syscall implementation will be added in Phase 2
+/// Execute a syscall with 0 arguments
+#[inline(always)]
+pub unsafe fn syscall0(num: i64) -> i64 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            in("rax") num,
+            lateout("rax") ret,
+            out("rcx") _,  // clobbered by syscall
+            out("r11") _,  // clobbered by syscall
+            options(nostack, preserves_flags)
+        );
+    }
+    ret
+}
+
+/// Execute a syscall with 1 argument
+#[inline(always)]
+pub unsafe fn syscall1(num: i64, arg1: i64) -> i64 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            in("rax") num,
+            in("rdi") arg1,
+            lateout("rax") ret,
+            out("rcx") _,
+            out("r11") _,
+            options(nostack, preserves_flags)
+        );
+    }
+    ret
+}
+
+/// Execute a syscall with 2 arguments
+#[inline(always)]
+pub unsafe fn syscall2(num: i64, arg1: i64, arg2: i64) -> i64 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            in("rax") num,
+            in("rdi") arg1,
+            in("rsi") arg2,
+            lateout("rax") ret,
+            out("rcx") _,
+            out("r11") _,
+            options(nostack, preserves_flags)
+        );
+    }
+    ret
+}
+
+/// Execute a syscall with 3 arguments
+#[inline(always)]
+pub unsafe fn syscall3(num: i64, arg1: i64, arg2: i64, arg3: i64) -> i64 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            in("rax") num,
+            in("rdi") arg1,
+            in("rsi") arg2,
+            in("rdx") arg3,
+            lateout("rax") ret,
+            out("rcx") _,
+            out("r11") _,
+            options(nostack, preserves_flags)
+        );
+    }
+    ret
+}
+
+/// Write to a file descriptor
+///
+/// # Safety
+/// - `buf` must be valid for `len` bytes
+pub unsafe fn sys_write(fd: i32, buf: *const u8, len: usize) -> SyscallResult<usize> {
+    let ret = unsafe { syscall3(SYS_WRITE, fd as i64, buf as i64, len as i64) };
+    if ret < 0 {
+        Err((-ret) as i32)
+    } else {
+        Ok(ret as usize)
+    }
+}
+
+/// Read from a file descriptor
+///
+/// # Safety
+/// - `buf` must be valid for `len` bytes
+pub unsafe fn sys_read(fd: i32, buf: *mut u8, len: usize) -> SyscallResult<usize> {
+    let ret = unsafe { syscall3(SYS_READ, fd as i64, buf as i64, len as i64) };
+    if ret < 0 {
+        Err((-ret) as i32)
+    } else {
+        Ok(ret as usize)
+    }
+}
+
+/// Exit the process
+///
+/// # Safety
+/// This function never returns
+pub unsafe fn sys_exit(code: i32) -> ! {
+    unsafe {
+        syscall1(SYS_EXIT, code as i64);
+    }
+    // Should never reach here, but Rust requires unreachable code annotation
+    core::hint::unreachable_unchecked()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sys_write_stdout() {
+        let msg = b"test\n";
+        let result = unsafe { sys_write(STDOUT_FD, msg.as_ptr(), msg.len()) };
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), msg.len());
+    }
+
+    #[test]
+    fn test_sys_write_invalid_fd() {
+        let msg = b"test\n";
+        let result = unsafe { sys_write(-1, msg.as_ptr(), msg.len()) };
+        assert!(result.is_err());
+        // EBADF is error 9
+        assert_eq!(result.unwrap_err(), 9);
+    }
+
+    #[test]
+    fn test_sys_read_empty() {
+        let mut buf = [0u8; 16];
+        // Reading from a non-blocking stdin might return EAGAIN or 0
+        // We just test that the syscall doesn't crash
+        let result = unsafe { sys_read(STDIN_FD, buf.as_mut_ptr(), 0) };
+        // Reading 0 bytes should succeed and return 0
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 0);
+    }
+}

--- a/docs/sessions/021-rust-runtime/implementation-plan.md
+++ b/docs/sessions/021-rust-runtime/implementation-plan.md
@@ -26,21 +26,21 @@
   - [x] **1.3c** Create integration test plan
 
 ### Phase 2: Syscall Foundation (Building Blocks)
-- [ ] **2.1** Implement syscall wrappers
-  - [ ] **2.1a** Create `syscall.rs` module
-  - [ ] **2.1b** Implement `sys_write(fd, buf, len) -> Result<usize, i32>`
-  - [ ] **2.1c** Implement `sys_read(fd, buf, len) -> Result<usize, i32>`
-  - [ ] **2.1d** Implement `sys_exit(code) -> !`
-  - [ ] **2.1e** Add error type and Result helpers
-  - [ ] **2.1f** Write unit tests for syscall wrappers
-- [ ] **2.2** Implement buffered stdout (migrate from existing)
-  - [ ] **2.2a** Review existing `buffered_io.rs` implementation
-  - [ ] **2.2b** Create new version with improvements
-  - [ ] **2.2c** Implement `__rue_write_byte(byte: u8)`
-  - [ ] **2.2d** Implement `__rue_write_bytes(buf: *const u8, len: usize)`
-  - [ ] **2.2e** Implement `__rue_flush_stdout()`
-  - [ ] **2.2f** Write unit tests for buffering logic
-  - [ ] **2.2g** Test edge cases (full buffer, large writes, etc.)
+- [x] **2.1** Implement syscall wrappers
+  - [x] **2.1a** Create `syscall.rs` module
+  - [x] **2.1b** Implement `sys_write(fd, buf, len) -> Result<usize, i32>`
+  - [x] **2.1c** Implement `sys_read(fd, buf, len) -> Result<usize, i32>`
+  - [x] **2.1d** Implement `sys_exit(code) -> !`
+  - [x] **2.1e** Add error type and Result helpers
+  - [x] **2.1f** Write unit tests for syscall wrappers
+- [x] **2.2** Implement buffered stdout (migrate from existing)
+  - [x] **2.2a** Review existing `buffered_io.rs` implementation
+  - [x] **2.2b** Create new version with improvements
+  - [x] **2.2c** Implement `__rue_write_byte(byte: u8)`
+  - [x] **2.2d** Implement `__rue_write_bytes(buf: *const u8, len: usize)`
+  - [x] **2.2e** Implement `__rue_flush_stdout()`
+  - [x] **2.2f** Write unit tests for buffering logic
+  - [x] **2.2g** Test edge cases (full buffer, large writes, etc.)
 
 ### Phase 3: String Conversion Functions (Simple, Testable)
 - [ ] **3.1** Implement `itoa` (integer to ASCII)


### PR DESCRIPTION
Add comprehensive syscall wrappers (syscall0-3, sys_write, sys_read, sys_exit) with proper error handling. Refactor buffered_io to use centralized syscall module. Include unit tests for syscalls.