### PR TITLE
Add Buck2 test target and enable runtime tests

### DIFF
--- a/crates/rue-runtime/BUCK
+++ b/crates/rue-runtime/BUCK
@@ -20,3 +20,11 @@ clippy_rust_library(
     preferred_linkage = "static",
     visibility = ["PUBLIC"],
 )
+
+# Test target
+rust_test(
+    name = "test",
+    srcs = glob(["src/**/*.rs"]),
+    crate_root = "src/lib.rs",
+    edition = "2024",
+)

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -48,14 +48,11 @@
 
 // Module declarations
 pub mod abi;
+pub mod buffered_io;
 pub mod conversion;
 pub mod io;
 pub mod memory;
 pub mod syscall;
-
-// Buffered I/O (current implementation from Session 020)
-#[cfg(not(test))]
-pub mod buffered_io;
 
 // Re-export C ABI functions at crate root for easier linking
 #[cfg(not(test))]


### PR DESCRIPTION
- Add rust_test target to crates/rue-runtime/BUCK
- Remove cfg(not(test)) gate from buffered_io module
- All 31 runtime tests now pass successfully