### PR TITLE
Configure Buck2 to build runtime as staticlib (.a)

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -58,6 +58,9 @@
 [python_bootstrap]
   toolchain = toolchains//:python_bootstrap
 
+[genrule]
+  toolchain = toolchains//:genrule
+
 [project]
   # Project-specific settings
   check_user_defined_attributes = true

--- a/crates/rue-runtime/BUCK
+++ b/crates/rue-runtime/BUCK
@@ -1,13 +1,27 @@
 load("@prelude//rust:cargo_package.bzl", "cargo")
 load("//tools/rust:defs.bzl", "clippy_rust_library")
 
-# Rust library for runtime functions
+# Rust library for runtime functions (generates .rlib for Rust-to-Rust linking)
 cargo.rust_library(
-    name = "rue-runtime",
+    name = "rue-runtime-rlib",
     srcs = glob(["src/**/*.rs"]),
     edition = "2024",
     crate_root = "src/lib.rs",
     preferred_linkage = "static",
+    rustc_flags = ["-Cpanic=abort"],
+    visibility = ["PUBLIC"],
+)
+
+# Static library (.a file) for linking with assembly code and C ABI
+# Use this target when you need a C-linkable static library
+#
+# This uses a genrule to invoke rustc directly with --crate-type=staticlib
+# because Buck2's rust_library doesn't support building .a files for C FFI.
+genrule(
+    name = "rue-runtime",
+    srcs = glob(["src/**/*.rs"]),
+    out = "librue_runtime.a",
+    cmd = "cd $SRCDIR && rustc --crate-type=staticlib --crate-name=rue_runtime --edition=2024 -Cpanic=abort -O src/lib.rs -o $OUT",
     visibility = ["PUBLIC"],
 )
 

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -1,6 +1,7 @@
 load("@prelude//toolchains:rust.bzl", "system_rust_toolchain")
 load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain")
 load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
+load("@prelude//toolchains:genrule.bzl", "system_genrule_toolchain")
 load("@prelude//tests:test_toolchain.bzl", "noop_test_toolchain")
 load(":remote_test_execution.bzl", "noop_remote_test_execution_toolchain")
 
@@ -16,6 +17,11 @@ system_python_bootstrap_toolchain(
 
 system_cxx_toolchain(
     name = "cxx",
+    visibility = ["PUBLIC"],
+)
+
+system_genrule_toolchain(
+    name = "genrule",
     visibility = ["PUBLIC"],
 )
 


### PR DESCRIPTION
- Add genrule to crates/rue-runtime/BUCK that builds librue_runtime.a
- Use rustc --crate-type=staticlib for C ABI linking
- Add genrule toolchain configuration to .buckconfig and toolchains/BUCK
- Staticlib exports all 15 __rue_* runtime functions
- 7.0 MB output ready for linking with generated assembly