### PR TITLE
Thread use_rust_runtime flag through codegen pipeline

### DIFF
--- a/crates/rue-codegen/src/backend.rs
+++ b/crates/rue-codegen/src/backend.rs
@@ -11,13 +11,26 @@ pub struct RuntimeProvider {
 
 impl RuntimeProvider {
     /// Create a new RuntimeProvider with runtime instructions loaded
-    pub fn new() -> Result<Self, CodegenError> {
-        let (runtime_instructions, runtime_labels) =
-            crate::runtime::generate_runtime().map_err(|_| CodegenError::Io)?;
-        Ok(Self {
-            runtime_instructions,
-            runtime_labels,
-        })
+    ///
+    /// If `use_rust_runtime` is true, returns empty vectors since runtime functions
+    /// will be provided by linking with librue_runtime.a instead.
+    pub fn new(use_rust_runtime: bool) -> Result<Self, CodegenError> {
+        if use_rust_runtime {
+            // When using Rust runtime, we don't generate runtime instructions
+            // The runtime functions will be provided by linking with librue_runtime.a
+            Ok(Self {
+                runtime_instructions: Vec::new(),
+                runtime_labels: HashMap::new(),
+            })
+        } else {
+            // Generate runtime instructions as before
+            let (runtime_instructions, runtime_labels) =
+                crate::runtime::generate_runtime().map_err(|_| CodegenError::Io)?;
+            Ok(Self {
+                runtime_instructions,
+                runtime_labels,
+            })
+        }
     }
 
     /// Get the runtime label count

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -84,7 +84,7 @@ pub fn compile_with_ast(source: &str) -> Result<Vec<u8>, RueError> {
 
     // Compile to executable using the HIR
     let type_context = rue_semantic::scope_to_type_context(&analysis.scope);
-    pipeline::compile_hir_via_mir_to_executable(&analysis.hir, type_context, false)
+    pipeline::compile_hir_via_mir_to_executable(&analysis.hir, type_context, false, false)
         .map_err(RueError::from)
 }
 
@@ -470,7 +470,7 @@ pub fn compile_file(
     // Parse, analyze, and compile with functional chaining
     let analysis = analyze_file(db, file)?;
     let type_context = scope_to_type_context(&analysis.scope);
-    pipeline::compile_hir_via_mir_to_executable(&analysis.hir, type_context, false)
+    pipeline::compile_hir_via_mir_to_executable(&analysis.hir, type_context, false, false)
         .map(Arc::new)
         .map_err(|e| Arc::new(RueError::from(e)))
 }
@@ -490,7 +490,7 @@ pub fn compile_file_to_assembly(
 
     // Generate assembly from HIR via MIR (without optimizations)
     let type_context = scope_to_type_context(&analysis.scope);
-    match pipeline::compile_hir_via_mir_to_assembly(&analysis.hir, type_context, false) {
+    match pipeline::compile_hir_via_mir_to_assembly(&analysis.hir, type_context, false, false) {
         Ok(assembly) => Ok(Arc::new(assembly)),
         Err(e) => Err(Arc::new(RueError::from(e))),
     }
@@ -516,6 +516,7 @@ pub fn compile_file_with_options(
         &analysis.hir,
         type_context,
         options.optimize(db),
+        options.use_rust_runtime(db),
     ) {
         Ok(executable) => Ok(Arc::new(executable)),
         Err(e) => Err(Arc::new(RueError::from(e))),
@@ -542,6 +543,7 @@ pub fn compile_file_to_assembly_with_options(
         &analysis.hir,
         type_context,
         options.optimize(db),
+        options.use_rust_runtime(db),
     ) {
         Ok(assembly) => Ok(Arc::new(assembly)),
         Err(e) => Err(Arc::new(RueError::from(e))),
@@ -586,6 +588,7 @@ pub fn compile_file_with_diagnostics(
                 &analysis.hir,
                 type_context,
                 options.optimize(db),
+                options.use_rust_runtime(db),
             ) {
                 Ok(executable) => Ok(Arc::new(executable)),
                 Err(e) => {

--- a/crates/rue-compiler/src/pipeline.rs
+++ b/crates/rue-compiler/src/pipeline.rs
@@ -263,11 +263,12 @@ fn optimize_and_verify_mir(
 ///
 /// This function contains the common compilation steps used by both assembly and executable generation.
 /// It performs HIR → MIR → optimizations → instructions → machine code generation.
-#[instrument(skip_all, fields(optimize = enable_optimizations))]
+#[instrument(skip_all, fields(optimize = enable_optimizations, use_rust_runtime))]
 pub fn compile_hir_via_mir_to_intermediate(
     hir: &Hir,
     type_context: TypeContext,
     enable_optimizations: bool,
+    use_rust_runtime: bool,
 ) -> Result<CompilationIntermediateResult, CompileError> {
     // Step 1: Lower HIR to MIR with TypeContext
     info!(target: "rue::mir", "Lowering HIR to MIR");
@@ -289,7 +290,7 @@ pub fn compile_hir_via_mir_to_intermediate(
     let function_labels = mir_lowerer.get_function_labels();
 
     // Step 5: Create runtime provider
-    let runtime_provider = RuntimeProvider::new()?;
+    let runtime_provider = RuntimeProvider::new(use_rust_runtime)?;
 
     // Step 6: Identify function boundaries
     let function_boundaries = discover_function_boundaries(&instructions, &function_labels);
@@ -326,15 +327,16 @@ pub fn compile_hir_via_mir_to_intermediate(
 ///
 /// This function uses the unified compilation pipeline and formats the result as assembly.
 /// HIR → MIR → (optimizations) → Instructions → Assembly
-#[instrument(skip_all, fields(optimize = enable_optimizations))]
+#[instrument(skip_all, fields(optimize = enable_optimizations, use_rust_runtime))]
 pub fn compile_hir_via_mir_to_assembly(
     hir: &Hir,
     type_context: TypeContext,
     enable_optimizations: bool,
+    use_rust_runtime: bool,
 ) -> Result<String, CompileError> {
     // Use the unified compilation pipeline
     let intermediate =
-        compile_hir_via_mir_to_intermediate(hir, type_context, enable_optimizations)?;
+        compile_hir_via_mir_to_intermediate(hir, type_context, enable_optimizations, use_rust_runtime)?;
 
     // Generate assembly from intermediate results
     info!(target: "rue::codegen", "Generating assembly");
@@ -349,15 +351,16 @@ pub fn compile_hir_via_mir_to_assembly(
 /// Compile HIR to executable via MIR
 ///
 /// This function uses the unified compilation pipeline and generates an ELF executable.
-#[instrument(skip_all, fields(optimize = enable_optimizations))]
+#[instrument(skip_all, fields(optimize = enable_optimizations, use_rust_runtime))]
 pub fn compile_hir_via_mir_to_executable(
     hir: &Hir,
     type_context: TypeContext,
     enable_optimizations: bool,
+    use_rust_runtime: bool,
 ) -> Result<Vec<u8>, CompileError> {
     // Use the unified compilation pipeline
     let intermediate =
-        compile_hir_via_mir_to_intermediate(hir, type_context, enable_optimizations)?;
+        compile_hir_via_mir_to_intermediate(hir, type_context, enable_optimizations, use_rust_runtime)?;
 
     // Generate machine code from intermediate results using trait abstraction
     info!(target: "rue::elf", "Generating ELF executable");


### PR DESCRIPTION
- Add use_rust_runtime parameter to pipeline functions
- Pass flag from CompileOptions to RuntimeProvider
- Modify RuntimeProvider::new() to skip generation when using Rust runtime
- When flag is true, return empty instructions (runtime comes from librue_runtime.a)
- Update all callers in lib.rs to pass the flag correctly