### PR TITLE
Selective runtime generation based on use_rust_runtime flag

### DIFF
--- a/crates/rue-codegen/src/backend.rs
+++ b/crates/rue-codegen/src/backend.rs
@@ -12,25 +12,16 @@ pub struct RuntimeProvider {
 impl RuntimeProvider {
     /// Create a new RuntimeProvider with runtime instructions loaded
     ///
-    /// If `use_rust_runtime` is true, returns empty vectors since runtime functions
-    /// will be provided by linking with librue_runtime.a instead.
+    /// If `use_rust_runtime` is true, only generates startup infrastructure and signal handlers.
+    /// Runtime I/O functions will be provided by linking with librue_runtime.a instead.
     pub fn new(use_rust_runtime: bool) -> Result<Self, CodegenError> {
-        if use_rust_runtime {
-            // When using Rust runtime, we don't generate runtime instructions
-            // The runtime functions will be provided by linking with librue_runtime.a
-            Ok(Self {
-                runtime_instructions: Vec::new(),
-                runtime_labels: HashMap::new(),
-            })
-        } else {
-            // Generate runtime instructions as before
-            let (runtime_instructions, runtime_labels) =
-                crate::runtime::generate_runtime().map_err(|_| CodegenError::Io)?;
-            Ok(Self {
-                runtime_instructions,
-                runtime_labels,
-            })
-        }
+        // Generate runtime with selective generation based on flag
+        let (runtime_instructions, runtime_labels) =
+            crate::runtime::generate_runtime(use_rust_runtime).map_err(|_| CodegenError::Io)?;
+        Ok(Self {
+            runtime_instructions,
+            runtime_labels,
+        })
     }
 
     /// Get the runtime label count

--- a/crates/rue-codegen/src/runtime/x86_64.rs
+++ b/crates/rue-codegen/src/runtime/x86_64.rs
@@ -5,36 +5,44 @@ use rue_target::X8664Instr;
 use std::collections::HashMap;
 
 /// Generate runtime machine code and symbols
-pub fn generate_runtime() -> Result<(Vec<X8664Instr>, HashMap<String, u32>), String> {
+///
+/// If `use_rust_runtime` is true, only generates startup infrastructure (_start, __rue_main)
+/// and signal handlers. Runtime I/O and conversion functions are expected to come from
+/// librue_runtime.a instead.
+pub fn generate_runtime(use_rust_runtime: bool) -> Result<(Vec<X8664Instr>, HashMap<String, u32>), String> {
     let mut ctx = RuntimeContext::new();
 
-    // Generate startup function first
+    // Always generate startup function (entry point)
     ctx.generate_startup_function();
 
-    // Generate data section
-    ctx.generate_data_section();
+    if !use_rust_runtime {
+        // Generate data section (only needed for generated runtime)
+        ctx.generate_data_section();
 
-    // Generate CPU feature detection and dispatch
-    ctx.generate_cpu_feature_detection();
-    ctx.generate_erms_stubs();
+        // Generate CPU feature detection and dispatch
+        ctx.generate_cpu_feature_detection();
+        ctx.generate_erms_stubs();
 
-    // Generate memory management functions
-    ctx.generate_memory_functions();
+        // Generate memory management functions
+        ctx.generate_memory_functions();
 
-    // Generate allocation functions (with stub implementations)
-    ctx.generate_alloc_functions();
+        // Generate allocation functions (with stub implementations)
+        ctx.generate_alloc_functions();
 
-    // Generate all runtime functions
-    ctx.generate_exit_function();
-    ctx.generate_itoa_function();
-    ctx.generate_println_i64_function();
-    ctx.generate_println_i32_function();
-    ctx.generate_println_bool_function();
-    ctx.generate_println_unit_function();
-    ctx.generate_atoi_function();
-    ctx.generate_input_function();
-    ctx.generate_to_i32_function();
-    ctx.generate_to_i64_function();
+        // Generate all runtime functions
+        ctx.generate_exit_function();
+        ctx.generate_itoa_function();
+        ctx.generate_println_i64_function();
+        ctx.generate_println_i32_function();
+        ctx.generate_println_bool_function();
+        ctx.generate_println_unit_function();
+        ctx.generate_atoi_function();
+        ctx.generate_input_function();
+        ctx.generate_to_i32_function();
+        ctx.generate_to_i64_function();
+    }
+
+    // Always generate signal handlers (small, not worth moving to Rust runtime)
     ctx.generate_signal_handlers();
     ctx.generate_setup_signal_handlers();
 


### PR DESCRIPTION
- Modify generate_runtime() to take use_rust_runtime parameter
- When true, only generate _start, __rue_main, and signal handlers
- Skip I/O, memory, and conversion functions (come from librue_runtime.a)
- Update RuntimeProvider to pass flag to generate_runtime()
- Preserves _start symbol so ELF generation doesn't fail