### PR TITLE
Add object file emission capability for Rust runtime integration

### DIFF
--- a/crates/rue-codegen/src/runtime/x86_64.rs
+++ b/crates/rue-codegen/src/runtime/x86_64.rs
@@ -9,7 +9,9 @@ use std::collections::HashMap;
 /// If `use_rust_runtime` is true, only generates startup infrastructure (_start, __rue_main)
 /// and signal handlers. Runtime I/O and conversion functions are expected to come from
 /// librue_runtime.a instead.
-pub fn generate_runtime(use_rust_runtime: bool) -> Result<(Vec<X8664Instr>, HashMap<String, u32>), String> {
+pub fn generate_runtime(
+    use_rust_runtime: bool,
+) -> Result<(Vec<X8664Instr>, HashMap<String, u32>), String> {
     let mut ctx = RuntimeContext::new();
 
     // Always generate startup function (entry point)

--- a/crates/rue-codegen/src/target/x86_64/emitter.rs
+++ b/crates/rue-codegen/src/target/x86_64/emitter.rs
@@ -38,6 +38,10 @@ pub struct X86Emitter {
     pending_fixups: Vec<(SectionType, usize, LabelRef)>, // (section, offset, target)
     function_labels: HashMap<String, Label>,
     runtime_label_count: u32,
+
+    // External symbols (for object file emission)
+    external_symbols: std::collections::HashSet<String>,
+    use_rust_runtime: bool,
 }
 
 impl X86Emitter {
@@ -59,6 +63,8 @@ impl X86Emitter {
             pending_fixups: Vec::new(),
             function_labels: HashMap::new(),
             runtime_label_count: 0,
+            external_symbols: std::collections::HashSet::new(),
+            use_rust_runtime: false,
         }
     }
 
@@ -70,6 +76,36 @@ impl X86Emitter {
         // We'll use this to map function names to their label IDs
         self.function_labels = labels;
         self.runtime_label_count = runtime_label_count;
+    }
+
+    /// Set whether we're using the Rust runtime (affects symbol resolution)
+    pub fn set_use_rust_runtime(&mut self, use_rust_runtime: bool) {
+        self.use_rust_runtime = use_rust_runtime;
+
+        // When using Rust runtime, mark known runtime symbols as external
+        if use_rust_runtime {
+            let runtime_symbols = vec![
+                "__rue_detect_cpu_features",
+                "__rue_println_i64",
+                "__rue_println_i32",
+                "__rue_println_bool",
+                "__rue_println_unit",
+                "__rue_input",
+                "__rue_itoa",
+                "__rue_atoi",
+                "__rue_memcpy",
+                "__rue_memmove",
+                "__rue_memset",
+                "__rue_memzero",
+                "__rue_write_byte",
+                "__rue_write_bytes",
+                "__rue_flush_stdout",
+            ];
+
+            for sym in runtime_symbols {
+                self.external_symbols.insert(sym.to_string());
+            }
+        }
     }
 
     /// Emit machine instructions to bytes
@@ -815,6 +851,13 @@ impl X86Emitter {
                     .cloned()
                     .ok_or_else(|| format!("Undefined label: {id}"))?,
                 LabelRef::Global(name) => {
+                    // If this is an external symbol and we're using Rust runtime, skip fixup
+                    // (will be resolved during linking)
+                    if self.use_rust_runtime && self.external_symbols.contains(name) {
+                        // Leave the placeholder zeros - will be filled by linker
+                        continue;
+                    }
+
                     // Look up the function name to get its label ID
                     let label_id = self
                         .function_labels
@@ -1227,6 +1270,60 @@ impl X86Emitter {
         }
 
         Ok(())
+    }
+
+    /// Emit as a relocatable object file (.o) for linking
+    ///
+    /// This is used when --use-rust-runtime is set to generate an object file
+    /// that can be linked with librue_runtime.a
+    pub fn emit_as_object_file(&self) -> Result<Vec<u8>, String> {
+        use super::object::{ObjectFileEmitter, RelocationInfo};
+
+        let mut object = ObjectFileEmitter::new();
+
+        // Add section data
+        for (section_type, section_info) in &self.sections {
+            object.add_section_data(section_type.clone(), section_info.data.clone());
+        }
+
+        // Add defined symbols from our label_positions
+        for (label_id, (section, offset)) in &self.label_positions {
+            // Try to find the symbol name from function_labels
+            let symbol_name = self
+                .function_labels
+                .iter()
+                .find(|(_, label)| {
+                    let machine_id = label.to_machine_id(self.runtime_label_count);
+                    &machine_id == label_id
+                })
+                .map(|(name, _)| name.clone());
+
+            if let Some(name) = symbol_name {
+                // Check if this is a global symbol (starts with certain patterns)
+                let is_global = name == "_start"
+                    || name == "main"
+                    || name == "__rue_main"
+                    || name.starts_with("__rue_");
+
+                object.add_defined_symbol(name, section.clone(), *offset as u64, is_global);
+            }
+        }
+
+        // Add relocations for external symbols
+        for (section, offset, target) in &self.pending_fixups {
+            if let LabelRef::Global(name) = target {
+                if self.external_symbols.contains(name) {
+                    object.add_relocation(RelocationInfo {
+                        section: section.clone(),
+                        offset: *offset as u64,
+                        symbol_name: name.clone(),
+                        addend: -4, // PC-relative call: addend is -4 (size of displacement field)
+                    });
+                }
+            }
+        }
+
+        object.write()
     }
 }
 

--- a/crates/rue-codegen/src/target/x86_64/mod.rs
+++ b/crates/rue-codegen/src/target/x86_64/mod.rs
@@ -2,16 +2,19 @@
 ///
 /// This module provides x86_64-specific implementations for:
 /// - Instruction emission (machine code generation)
-/// - ELF executable generation  
+/// - ELF executable generation
 /// - Assembly formatting
+/// - Object file generation (relocatable .o files)
 mod assembler;
 mod elf;
 mod emitter;
+pub mod object;
 
 // Re-export the main types with appropriate names
 pub use assembler::format_instructions_as_assembly;
 pub use elf::ElfWriter;
 pub use emitter::{SectionType, X86Emitter};
+pub use object::{ObjectFileEmitter, RelocationInfo};
 
 use crate::target::{AssemblyFormatter, ExecutableWriter, InstructionEmitter};
 use rue_ir::pir::Label;

--- a/crates/rue-codegen/src/target/x86_64/object.rs
+++ b/crates/rue-codegen/src/target/x86_64/object.rs
@@ -1,0 +1,148 @@
+//! Object file emission for x86-64
+//!
+//! Generates relocatable ELF object files (.o) that can be linked with external libraries.
+
+use object::write::{Object, Relocation, StandardSection, Symbol, SymbolSection};
+use object::{Architecture, BinaryFormat, Endianness, SymbolFlags, SymbolKind, SymbolScope};
+use std::collections::HashMap;
+
+use super::emitter::SectionType;
+
+/// Converts our SectionType to object crate's StandardSection
+fn section_type_to_standard(section_type: &SectionType) -> StandardSection {
+    match section_type {
+        SectionType::Text => StandardSection::Text,
+        SectionType::Data => StandardSection::Data,
+        SectionType::Bss => StandardSection::UninitializedData,
+        SectionType::Rodata => StandardSection::ReadOnlyData,
+    }
+}
+
+/// Information about a relocation that needs to be applied
+#[derive(Debug, Clone)]
+pub struct RelocationInfo {
+    pub section: SectionType,
+    pub offset: u64,
+    pub symbol_name: String,
+    pub addend: i64,
+}
+
+/// Object file emitter for generating relocatable .o files
+pub struct ObjectFileEmitter {
+    object: Object<'static>,
+    section_ids: HashMap<SectionType, object::write::SectionId>,
+    symbol_ids: HashMap<String, object::write::SymbolId>,
+}
+
+impl ObjectFileEmitter {
+    /// Create a new object file emitter
+    pub fn new() -> Self {
+        let mut object = Object::new(BinaryFormat::Elf, Architecture::X86_64, Endianness::Little);
+
+        // Pre-create standard sections
+        let mut section_ids = HashMap::new();
+
+        let text_id = object.section_id(StandardSection::Text);
+        section_ids.insert(SectionType::Text, text_id);
+
+        let data_id = object.section_id(StandardSection::Data);
+        section_ids.insert(SectionType::Data, data_id);
+
+        let rodata_id = object.section_id(StandardSection::ReadOnlyData);
+        section_ids.insert(SectionType::Rodata, rodata_id);
+
+        let bss_id = object.section_id(StandardSection::UninitializedData);
+        section_ids.insert(SectionType::Bss, bss_id);
+
+        Self {
+            object,
+            section_ids,
+            symbol_ids: HashMap::new(),
+        }
+    }
+
+    /// Add section data
+    pub fn add_section_data(&mut self, section_type: SectionType, data: Vec<u8>) {
+        let section_id = self.section_ids[&section_type];
+        self.object.append_section_data(section_id, &data, 16);
+    }
+
+    /// Add a defined symbol (e.g., _start, main, __rue_main)
+    pub fn add_defined_symbol(
+        &mut self,
+        name: String,
+        section: SectionType,
+        offset: u64,
+        is_global: bool,
+    ) {
+        let section_id = self.section_ids[&section];
+
+        let symbol = Symbol {
+            name: name.as_bytes().to_vec(),
+            value: offset,
+            size: 0,
+            kind: SymbolKind::Text,
+            scope: if is_global {
+                SymbolScope::Linkage
+            } else {
+                SymbolScope::Compilation
+            },
+            weak: false,
+            section: SymbolSection::Section(section_id),
+            flags: SymbolFlags::None,
+        };
+
+        let symbol_id = self.object.add_symbol(symbol);
+        self.symbol_ids.insert(name, symbol_id);
+    }
+
+    /// Add an undefined external symbol (e.g., __rue_println_i64)
+    pub fn add_undefined_symbol(&mut self, name: String) {
+        let symbol = Symbol {
+            name: name.as_bytes().to_vec(),
+            value: 0,
+            size: 0,
+            kind: SymbolKind::Text,
+            scope: SymbolScope::Linkage,
+            weak: false,
+            section: SymbolSection::Undefined,
+            flags: SymbolFlags::None,
+        };
+
+        let symbol_id = self.object.add_symbol(symbol);
+        self.symbol_ids.insert(name, symbol_id);
+    }
+
+    /// Add a relocation for an external symbol
+    pub fn add_relocation(&mut self, reloc: RelocationInfo) {
+        let section_id = self.section_ids[&reloc.section];
+
+        // Get or create the symbol
+        let symbol_id = if let Some(&id) = self.symbol_ids.get(&reloc.symbol_name) {
+            id
+        } else {
+            // Symbol not defined, add as undefined external
+            self.add_undefined_symbol(reloc.symbol_name.clone());
+            self.symbol_ids[&reloc.symbol_name]
+        };
+
+        // PC-relative call uses R_X86_64_PLT32 relocation
+        let relocation = Relocation {
+            offset: reloc.offset,
+            symbol: symbol_id,
+            addend: reloc.addend,
+            flags: object::RelocationFlags::Elf {
+                r_type: object::elf::R_X86_64_PLT32,
+            },
+        };
+
+        self.object.add_relocation(section_id, relocation).unwrap();
+    }
+
+    /// Write the object file to bytes
+    pub fn write(self) -> Result<Vec<u8>, String> {
+        self.object
+            .write()
+            .map_err(|e| format!("Failed to write object file: {}", e))
+    }
+}

--- a/crates/rue-compiler/src/pipeline.rs
+++ b/crates/rue-compiler/src/pipeline.rs
@@ -335,8 +335,12 @@ pub fn compile_hir_via_mir_to_assembly(
     use_rust_runtime: bool,
 ) -> Result<String, CompileError> {
     // Use the unified compilation pipeline
-    let intermediate =
-        compile_hir_via_mir_to_intermediate(hir, type_context, enable_optimizations, use_rust_runtime)?;
+    let intermediate = compile_hir_via_mir_to_intermediate(
+        hir,
+        type_context,
+        enable_optimizations,
+        use_rust_runtime,
+    )?;
 
     // Generate assembly from intermediate results
     info!(target: "rue::codegen", "Generating assembly");
@@ -359,8 +363,12 @@ pub fn compile_hir_via_mir_to_executable(
     use_rust_runtime: bool,
 ) -> Result<Vec<u8>, CompileError> {
     // Use the unified compilation pipeline
-    let intermediate =
-        compile_hir_via_mir_to_intermediate(hir, type_context, enable_optimizations, use_rust_runtime)?;
+    let intermediate = compile_hir_via_mir_to_intermediate(
+        hir,
+        type_context,
+        enable_optimizations,
+        use_rust_runtime,
+    )?;
 
     // Generate machine code from intermediate results using trait abstraction
     info!(target: "rue::elf", "Generating ELF executable");


### PR DESCRIPTION
- Create ObjectFileEmitter for generating relocatable .o files using object crate
- Add external symbol tracking to X86Emitter
- Implement set_use_rust_runtime() to mark runtime symbols as external
- Modify fixup_pending_references() to skip external symbols
- Add emit_as_object_file() method to generate relocatable object files
- External symbols generate R_X86_64_PLT32 relocations for linking