### PR TITLE
Add rustfmt checking to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,19 @@ on:
     branches: [trunk]
 
 jobs:
+  fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: ./fmt.sh check
+
   test:
     strategy:
       matrix:

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -144,10 +144,7 @@ pub enum AirInstData {
     },
 
     /// While loop
-    Loop {
-        cond: AirRef,
-        body: AirRef,
-    },
+    Loop { cond: AirRef, body: AirRef },
 
     /// Break: exits the innermost loop
     Break,
@@ -275,16 +272,18 @@ impl fmt::Display for Air {
                 AirInstData::Or(lhs, rhs) => writeln!(f, "or {}, {}", lhs, rhs)?,
                 AirInstData::Neg(operand) => writeln!(f, "neg {}", operand)?,
                 AirInstData::Not(operand) => writeln!(f, "not {}", operand)?,
-                AirInstData::Branch { cond, then_value, else_value } => {
+                AirInstData::Branch {
+                    cond,
+                    then_value,
+                    else_value,
+                } => {
                     if let Some(else_v) = else_value {
                         writeln!(f, "branch {}, {}, {}", cond, then_value, else_v)?
                     } else {
                         writeln!(f, "branch {}, {}", cond, then_value)?
                     }
                 }
-                AirInstData::Loop { cond, body } => {
-                    writeln!(f, "loop {}, {}", cond, body)?
-                }
+                AirInstData::Loop { cond, body } => writeln!(f, "loop {}, {}", cond, body)?,
                 AirInstData::Break => writeln!(f, "break")?,
                 AirInstData::Continue => writeln!(f, "continue")?,
                 AirInstData::Alloc { slot, init } => writeln!(f, "alloc ${} = {}", slot, init)?,
@@ -332,11 +331,24 @@ impl fmt::Display for Air {
                     }
                     writeln!(f, "}}")?;
                 }
-                AirInstData::FieldGet { base, struct_id, field_index } => {
+                AirInstData::FieldGet {
+                    base,
+                    struct_id,
+                    field_index,
+                } => {
                     writeln!(f, "field_get {}.#{}.{}", base, struct_id.0, field_index)?;
                 }
-                AirInstData::FieldSet { slot, struct_id, field_index, value } => {
-                    writeln!(f, "field_set ${}.#{}.{} = {}", slot, struct_id.0, field_index, value)?;
+                AirInstData::FieldSet {
+                    slot,
+                    struct_id,
+                    field_index,
+                    value,
+                } => {
+                    writeln!(
+                        f,
+                        "field_set ${}.#{}.{} = {}",
+                        slot, struct_id.0, field_index, value
+                    )?;
                 }
             }
         }

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -178,7 +178,8 @@ impl<'a> Sema<'a> {
                     })
                     .collect::<CompileResult<Vec<_>>>()?;
 
-                let (air, num_locals, num_param_slots) = self.analyze_function(ret_type, &param_info, *body)?;
+                let (air, num_locals, num_param_slots) =
+                    self.analyze_function(ret_type, &param_info, *body)?;
 
                 result.push(AnalyzedFunction {
                     name: fn_name,
@@ -356,7 +357,11 @@ impl<'a> Sema<'a> {
 
             InstData::Add { lhs, rhs } => {
                 // Use expected type if it's an integer, otherwise default to i32
-                let op_type = if expected_type.is_integer() { expected_type } else { Type::I32 };
+                let op_type = if expected_type.is_integer() {
+                    expected_type
+                } else {
+                    Type::I32
+                };
                 let lhs_ref = self.analyze_inst(air, *lhs, op_type, ctx)?;
                 let rhs_ref = self.analyze_inst(air, *rhs, op_type, ctx)?;
 
@@ -368,7 +373,11 @@ impl<'a> Sema<'a> {
             }
 
             InstData::Sub { lhs, rhs } => {
-                let op_type = if expected_type.is_integer() { expected_type } else { Type::I32 };
+                let op_type = if expected_type.is_integer() {
+                    expected_type
+                } else {
+                    Type::I32
+                };
                 let lhs_ref = self.analyze_inst(air, *lhs, op_type, ctx)?;
                 let rhs_ref = self.analyze_inst(air, *rhs, op_type, ctx)?;
 
@@ -380,7 +389,11 @@ impl<'a> Sema<'a> {
             }
 
             InstData::Mul { lhs, rhs } => {
-                let op_type = if expected_type.is_integer() { expected_type } else { Type::I32 };
+                let op_type = if expected_type.is_integer() {
+                    expected_type
+                } else {
+                    Type::I32
+                };
                 let lhs_ref = self.analyze_inst(air, *lhs, op_type, ctx)?;
                 let rhs_ref = self.analyze_inst(air, *rhs, op_type, ctx)?;
 
@@ -392,7 +405,11 @@ impl<'a> Sema<'a> {
             }
 
             InstData::Div { lhs, rhs } => {
-                let op_type = if expected_type.is_integer() { expected_type } else { Type::I32 };
+                let op_type = if expected_type.is_integer() {
+                    expected_type
+                } else {
+                    Type::I32
+                };
                 let lhs_ref = self.analyze_inst(air, *lhs, op_type, ctx)?;
                 let rhs_ref = self.analyze_inst(air, *rhs, op_type, ctx)?;
 
@@ -404,7 +421,11 @@ impl<'a> Sema<'a> {
             }
 
             InstData::Mod { lhs, rhs } => {
-                let op_type = if expected_type.is_integer() { expected_type } else { Type::I32 };
+                let op_type = if expected_type.is_integer() {
+                    expected_type
+                } else {
+                    Type::I32
+                };
                 let lhs_ref = self.analyze_inst(air, *lhs, op_type, ctx)?;
                 let rhs_ref = self.analyze_inst(air, *rhs, op_type, ctx)?;
 
@@ -506,7 +527,11 @@ impl<'a> Sema<'a> {
             }
 
             InstData::Neg { operand } => {
-                let op_type = if expected_type.is_integer() { expected_type } else { Type::I32 };
+                let op_type = if expected_type.is_integer() {
+                    expected_type
+                } else {
+                    Type::I32
+                };
 
                 // Special case: -2147483648 (MIN_I32)
                 // The literal 2147483648 exceeds i32::MAX, but -2147483648 is valid.
@@ -542,7 +567,11 @@ impl<'a> Sema<'a> {
                 }))
             }
 
-            InstData::Branch { cond, then_block, else_block } => {
+            InstData::Branch {
+                cond,
+                then_block,
+                else_block,
+            } => {
                 // Condition must be bool
                 let cond_ref = self.analyze_inst(air, *cond, Type::Bool, ctx)?;
 
@@ -562,7 +591,11 @@ impl<'a> Sema<'a> {
                     // If then branch is Never, use expected_type for else (so it determines the result)
                     // Otherwise use then_type as the expectation
                     ctx.locals = saved_locals.clone();
-                    let else_expected = if then_type.is_never() { expected_type } else { then_type };
+                    let else_expected = if then_type.is_never() {
+                        expected_type
+                    } else {
+                        then_type
+                    };
                     let else_ref = self.analyze_inst(air, *else_b, else_expected, ctx)?;
                     let else_type = air.get(else_ref).ty;
 
@@ -576,7 +609,10 @@ impl<'a> Sema<'a> {
                         (false, true) => then_type,
                         (false, false) => {
                             // Neither diverges - types must match exactly
-                            if then_type != else_type && !then_type.is_error() && !else_type.is_error() {
+                            if then_type != else_type
+                                && !then_type.is_error()
+                                && !else_type.is_error()
+                            {
                                 return Err(CompileError::new(
                                     ErrorKind::TypeMismatch {
                                         expected: then_type.name().to_string(),
@@ -661,7 +697,12 @@ impl<'a> Sema<'a> {
                 }))
             }
 
-            InstData::Alloc { name, is_mut, ty, init } => {
+            InstData::Alloc {
+                name,
+                is_mut,
+                ty,
+                init,
+            } => {
                 // Determine the type from annotation or infer from initializer
                 let var_type = if let Some(type_sym) = ty {
                     // Resolve the type annotation (supports structs too)
@@ -677,7 +718,9 @@ impl<'a> Sema<'a> {
                 // Allocate slots - structs need multiple slots (one per field)
                 let slot = ctx.next_slot;
                 let num_slots = match var_type {
-                    Type::Struct(struct_id) => self.struct_defs[struct_id.0 as usize].field_count() as u32,
+                    Type::Struct(struct_id) => {
+                        self.struct_defs[struct_id.0 as usize].field_count() as u32
+                    }
                     _ => 1,
                 };
                 ctx.next_slot += num_slots;
@@ -695,7 +738,10 @@ impl<'a> Sema<'a> {
 
                 // Emit the alloc instruction
                 Ok(air.add_inst(AirInst {
-                    data: AirInstData::Alloc { slot, init: init_ref },
+                    data: AirInstData::Alloc {
+                        slot,
+                        init: init_ref,
+                    },
                     ty: Type::Unit,
                     span: inst.span,
                 }))
@@ -707,7 +753,10 @@ impl<'a> Sema<'a> {
                     let ty = param_info.ty;
 
                     // Type check - allow Unit context (value is discarded)
-                    if ty != expected_type && expected_type != Type::Unit && !expected_type.is_error() {
+                    if ty != expected_type
+                        && expected_type != Type::Unit
+                        && !expected_type.is_error()
+                    {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
                                 expected: expected_type.name().to_string(),
@@ -788,7 +837,10 @@ impl<'a> Sema<'a> {
 
                 // Emit store instruction
                 Ok(air.add_inst(AirInst {
-                    data: AirInstData::Store { slot, value: value_ref },
+                    data: AirInstData::Store {
+                        slot,
+                        value: value_ref,
+                    },
                     ty: Type::Unit,
                     span: inst.span,
                 }))
@@ -797,10 +849,7 @@ impl<'a> Sema<'a> {
             InstData::Break => {
                 // Validate that we're inside a loop
                 if ctx.loop_depth == 0 {
-                    return Err(CompileError::new(
-                        ErrorKind::BreakOutsideLoop,
-                        inst.span,
-                    ));
+                    return Err(CompileError::new(ErrorKind::BreakOutsideLoop, inst.span));
                 }
 
                 // Break has the never type - it diverges (doesn't produce a value)
@@ -814,10 +863,7 @@ impl<'a> Sema<'a> {
             InstData::Continue => {
                 // Validate that we're inside a loop
                 if ctx.loop_depth == 0 {
-                    return Err(CompileError::new(
-                        ErrorKind::ContinueOutsideLoop,
-                        inst.span,
-                    ));
+                    return Err(CompileError::new(ErrorKind::ContinueOutsideLoop, inst.span));
                 }
 
                 // Continue has the never type - it diverges (doesn't produce a value)
@@ -916,10 +962,7 @@ impl<'a> Sema<'a> {
                 // Look up the function
                 let fn_name_str = self.interner.get(*name).to_string();
                 let fn_info = self.functions.get(name).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::UndefinedFunction(fn_name_str.clone()),
-                        inst.span,
-                    )
+                    CompileError::new(ErrorKind::UndefinedFunction(fn_name_str.clone()), inst.span)
                 })?;
 
                 // Check argument count
@@ -944,7 +987,10 @@ impl<'a> Sema<'a> {
                 }
 
                 // Check that return type matches expected type (if we have an expectation)
-                if expected_type != Type::Unit && return_type != expected_type && !return_type.is_error() {
+                if expected_type != Type::Unit
+                    && return_type != expected_type
+                    && !return_type.is_error()
+                {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: expected_type.name().to_string(),
@@ -989,14 +1035,14 @@ impl<'a> Sema<'a> {
                 unreachable!("StructDecl should not appear in expression context")
             }
 
-            InstData::StructInit { type_name, fields: field_inits } => {
+            InstData::StructInit {
+                type_name,
+                fields: field_inits,
+            } => {
                 // Look up the struct type
                 let type_name_str = self.interner.get(*type_name);
                 let struct_id = *self.structs.get(type_name).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::UnknownType(type_name_str.to_string()),
-                        inst.span,
-                    )
+                    CompileError::new(ErrorKind::UnknownType(type_name_str.to_string()), inst.span)
                 })?;
 
                 // Clone struct def data before mutable borrow
@@ -1004,7 +1050,10 @@ impl<'a> Sema<'a> {
                 let struct_type = Type::Struct(struct_id);
 
                 // Type check: verify expected type matches
-                if struct_type != expected_type && expected_type != Type::Unit && !expected_type.is_error() {
+                if struct_type != expected_type
+                    && expected_type != Type::Unit
+                    && !expected_type.is_error()
+                {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: expected_type.name().to_string(),
@@ -1095,20 +1144,24 @@ impl<'a> Sema<'a> {
                 let struct_def = &self.struct_defs[struct_id.0 as usize];
                 let field_name_str = self.interner.get(*field).to_string();
 
-                let (field_index, struct_field) = struct_def.find_field(&field_name_str).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::UnknownField {
-                            struct_name: struct_def.name.clone(),
-                            field_name: field_name_str.clone(),
-                        },
-                        inst.span,
-                    )
-                })?;
+                let (field_index, struct_field) =
+                    struct_def.find_field(&field_name_str).ok_or_else(|| {
+                        CompileError::new(
+                            ErrorKind::UnknownField {
+                                struct_name: struct_def.name.clone(),
+                                field_name: field_name_str.clone(),
+                            },
+                            inst.span,
+                        )
+                    })?;
 
                 let field_type = struct_field.ty;
 
                 // Type check
-                if field_type != expected_type && expected_type != Type::Unit && !expected_type.is_error() {
+                if field_type != expected_type
+                    && expected_type != Type::Unit
+                    && !expected_type.is_error()
+                {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: expected_type.name().to_string(),
@@ -1178,15 +1231,16 @@ impl<'a> Sema<'a> {
                 let struct_def = &self.struct_defs[struct_id.0 as usize];
                 let field_name_str = self.interner.get(*field).to_string();
 
-                let (field_index, struct_field) = struct_def.find_field(&field_name_str).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::UnknownField {
-                            struct_name: struct_def.name.clone(),
-                            field_name: field_name_str.clone(),
-                        },
-                        inst.span,
-                    )
-                })?;
+                let (field_index, struct_field) =
+                    struct_def.find_field(&field_name_str).ok_or_else(|| {
+                        CompileError::new(
+                            ErrorKind::UnknownField {
+                                struct_name: struct_def.name.clone(),
+                                field_name: field_name_str.clone(),
+                            },
+                            inst.span,
+                        )
+                    })?;
 
                 let field_type = struct_field.ty;
 
@@ -1372,7 +1426,11 @@ impl<'a> Sema<'a> {
                     self.infer_type(last_ref, locals, params)
                 }
             }
-            InstData::Branch { then_block, else_block, .. } => {
+            InstData::Branch {
+                then_block,
+                else_block,
+                ..
+            } => {
                 // The type of an if/else comes from the non-divergent branch.
                 // If both branches diverge (both Never), the result is Never.
                 // If one branch is Never, the result is the other branch's type.
@@ -1410,7 +1468,10 @@ impl<'a> Sema<'a> {
                 })?;
                 Ok(param_info.ty)
             }
-            InstData::Alloc { .. } | InstData::Assign { .. } | InstData::Ret(_) | InstData::Loop { .. } => Ok(Type::Unit),
+            InstData::Alloc { .. }
+            | InstData::Assign { .. }
+            | InstData::Ret(_)
+            | InstData::Loop { .. } => Ok(Type::Unit),
             InstData::Break | InstData::Continue => Ok(Type::Never),
             InstData::FnDecl { .. } | InstData::StructDecl { .. } => {
                 unreachable!("FnDecl/StructDecl should not appear in expression context")
@@ -1419,10 +1480,7 @@ impl<'a> Sema<'a> {
                 // Look up the struct type
                 let struct_id = self.structs.get(type_name).ok_or_else(|| {
                     let type_name_str = self.interner.get(*type_name);
-                    CompileError::new(
-                        ErrorKind::UnknownType(type_name_str.to_string()),
-                        inst.span,
-                    )
+                    CompileError::new(ErrorKind::UnknownType(type_name_str.to_string()), inst.span)
                 })?;
                 Ok(Type::Struct(*struct_id))
             }
@@ -1444,15 +1502,16 @@ impl<'a> Sema<'a> {
                 let struct_def = &self.struct_defs[struct_id.0 as usize];
                 let field_name_str = self.interner.get(*field).to_string();
 
-                let (_, struct_field) = struct_def.find_field(&field_name_str).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::UnknownField {
-                            struct_name: struct_def.name.clone(),
-                            field_name: field_name_str.clone(),
-                        },
-                        inst.span,
-                    )
-                })?;
+                let (_, struct_field) =
+                    struct_def.find_field(&field_name_str).ok_or_else(|| {
+                        CompileError::new(
+                            ErrorKind::UnknownField {
+                                struct_name: struct_def.name.clone(),
+                                field_name: field_name_str.clone(),
+                            },
+                            inst.span,
+                        )
+                    })?;
 
                 Ok(struct_field.ty)
             }
@@ -1559,7 +1618,10 @@ mod tests {
 
         // Check alloc instruction
         let alloc_inst = air.get(AirRef::from_raw(1));
-        assert!(matches!(alloc_inst.data, AirInstData::Alloc { slot: 0, .. }));
+        assert!(matches!(
+            alloc_inst.data,
+            AirInstData::Alloc { slot: 0, .. }
+        ));
 
         // Check load instruction
         let load_inst = air.get(AirRef::from_raw(2));
@@ -1580,7 +1642,10 @@ mod tests {
 
         // Check store instruction
         let store_inst = air.get(AirRef::from_raw(3));
-        assert!(matches!(store_inst.data, AirInstData::Store { slot: 0, .. }));
+        assert!(matches!(
+            store_inst.data,
+            AirInstData::Store { slot: 0, .. }
+        ));
 
         // Check block instruction groups statements
         let block_inst = air.get(AirRef::from_raw(5));
@@ -1605,7 +1670,8 @@ mod tests {
 
     #[test]
     fn test_multiple_variables() {
-        let functions = compile_to_air("fn main() -> i32 { let x = 10; let y = 20; x + y }").unwrap();
+        let functions =
+            compile_to_air("fn main() -> i32 { let x = 10; let y = 20; x + y }").unwrap();
 
         assert_eq!(functions[0].num_locals, 2);
     }

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -60,10 +60,7 @@ pub struct StructField {
 impl StructDef {
     /// Find a field by name and return its index and definition.
     pub fn find_field(&self, name: &str) -> Option<(usize, &StructField)> {
-        self.fields
-            .iter()
-            .enumerate()
-            .find(|(_, f)| f.name == name)
+        self.fields.iter().enumerate().find(|(_, f)| f.name == name)
     }
 
     /// Get the number of fields in this struct.

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -45,15 +45,15 @@ pub struct CfgBuilder<'a> {
 
 impl<'a> CfgBuilder<'a> {
     /// Build a CFG from AIR.
-    pub fn build(
-        air: &'a Air,
-        num_locals: u32,
-        num_params: u32,
-        fn_name: &str,
-    ) -> Cfg {
+    pub fn build(air: &'a Air, num_locals: u32, num_params: u32, fn_name: &str) -> Cfg {
         let mut builder = CfgBuilder {
             air,
-            cfg: Cfg::new(air.return_type(), num_locals, num_params, fn_name.to_string()),
+            cfg: Cfg::new(
+                air.return_type(),
+                num_locals,
+                num_params,
+                fn_name.to_string(),
+            ),
             current_block: BlockId(0),
             loop_stack: Vec::new(),
             value_cache: vec![None; air.len()],
@@ -251,21 +251,27 @@ impl<'a> CfgBuilder<'a> {
 
                 // Branch: if lhs is false, go to join with false; else evaluate rhs
                 let false_val = self.emit(CfgInstData::BoolConst(false), Type::Bool, span);
-                self.cfg.set_terminator(self.current_block, Terminator::Branch {
-                    cond: lhs_val,
-                    then_block: rhs_block,
-                    then_args: vec![],
-                    else_block: join_block,
-                    else_args: vec![false_val],
-                });
+                self.cfg.set_terminator(
+                    self.current_block,
+                    Terminator::Branch {
+                        cond: lhs_val,
+                        then_block: rhs_block,
+                        then_args: vec![],
+                        else_block: join_block,
+                        else_args: vec![false_val],
+                    },
+                );
 
                 // In rhs_block, evaluate rhs and go to join
                 self.current_block = rhs_block;
                 let rhs_val = self.lower_inst(*rhs).value.unwrap();
-                self.cfg.set_terminator(self.current_block, Terminator::Goto {
-                    target: join_block,
-                    args: vec![rhs_val],
-                });
+                self.cfg.set_terminator(
+                    self.current_block,
+                    Terminator::Goto {
+                        target: join_block,
+                        args: vec![rhs_val],
+                    },
+                );
 
                 // Continue in join block
                 self.current_block = join_block;
@@ -288,21 +294,27 @@ impl<'a> CfgBuilder<'a> {
 
                 // Branch: if lhs is true, go to join with true; else evaluate rhs
                 let true_val = self.emit(CfgInstData::BoolConst(true), Type::Bool, span);
-                self.cfg.set_terminator(self.current_block, Terminator::Branch {
-                    cond: lhs_val,
-                    then_block: join_block,
-                    then_args: vec![true_val],
-                    else_block: rhs_block,
-                    else_args: vec![],
-                });
+                self.cfg.set_terminator(
+                    self.current_block,
+                    Terminator::Branch {
+                        cond: lhs_val,
+                        then_block: join_block,
+                        then_args: vec![true_val],
+                        else_block: rhs_block,
+                        else_args: vec![],
+                    },
+                );
 
                 // In rhs_block, evaluate rhs and go to join
                 self.current_block = rhs_block;
                 let rhs_val = self.lower_inst(*rhs).value.unwrap();
-                self.cfg.set_terminator(self.current_block, Terminator::Goto {
-                    target: join_block,
-                    args: vec![rhs_val],
-                });
+                self.cfg.set_terminator(
+                    self.current_block,
+                    Terminator::Goto {
+                        target: join_block,
+                        args: vec![rhs_val],
+                    },
+                );
 
                 // Continue in join block
                 self.current_block = join_block;
@@ -336,10 +348,17 @@ impl<'a> CfgBuilder<'a> {
             AirInstData::Alloc { slot, init } => {
                 let init_result = self.lower_inst(*init);
                 // If init produces a value, use it; otherwise use a dummy Unit value
-                let init_val = init_result.value.unwrap_or_else(|| {
-                    self.emit(CfgInstData::Const(0), Type::Unit, span)
-                });
-                self.emit(CfgInstData::Alloc { slot: *slot, init: init_val }, Type::Unit, span);
+                let init_val = init_result
+                    .value
+                    .unwrap_or_else(|| self.emit(CfgInstData::Const(0), Type::Unit, span));
+                self.emit(
+                    CfgInstData::Alloc {
+                        slot: *slot,
+                        init: init_val,
+                    },
+                    Type::Unit,
+                    span,
+                );
                 ExprResult {
                     value: None,
                     continuation: Continuation::Continues,
@@ -357,7 +376,14 @@ impl<'a> CfgBuilder<'a> {
 
             AirInstData::Store { slot, value } => {
                 let val = self.lower_inst(*value).value.unwrap();
-                self.emit(CfgInstData::Store { slot: *slot, value: val }, Type::Unit, span);
+                self.emit(
+                    CfgInstData::Store {
+                        slot: *slot,
+                        value: val,
+                    },
+                    Type::Unit,
+                    span,
+                );
                 ExprResult {
                     value: None,
                     continuation: Continuation::Continues,
@@ -370,7 +396,10 @@ impl<'a> CfgBuilder<'a> {
                     arg_vals.push(self.lower_inst(*arg).value.unwrap());
                 }
                 let value = self.emit(
-                    CfgInstData::Call { name: name.clone(), args: arg_vals },
+                    CfgInstData::Call {
+                        name: name.clone(),
+                        args: arg_vals,
+                    },
                     ty,
                     span,
                 );
@@ -387,7 +416,10 @@ impl<'a> CfgBuilder<'a> {
                     arg_vals.push(self.lower_inst(*arg).value.unwrap());
                 }
                 let value = self.emit(
-                    CfgInstData::Intrinsic { name: name.clone(), args: arg_vals },
+                    CfgInstData::Intrinsic {
+                        name: name.clone(),
+                        args: arg_vals,
+                    },
                     ty,
                     span,
                 );
@@ -403,7 +435,10 @@ impl<'a> CfgBuilder<'a> {
                     field_vals.push(self.lower_inst(*field).value.unwrap());
                 }
                 let value = self.emit(
-                    CfgInstData::StructInit { struct_id: *struct_id, fields: field_vals },
+                    CfgInstData::StructInit {
+                        struct_id: *struct_id,
+                        fields: field_vals,
+                    },
                     ty,
                     span,
                 );
@@ -414,7 +449,11 @@ impl<'a> CfgBuilder<'a> {
                 }
             }
 
-            AirInstData::FieldGet { base, struct_id, field_index } => {
+            AirInstData::FieldGet {
+                base,
+                struct_id,
+                field_index,
+            } => {
                 let base_val = self.lower_inst(*base).value.unwrap();
                 let value = self.emit(
                     CfgInstData::FieldGet {
@@ -431,7 +470,12 @@ impl<'a> CfgBuilder<'a> {
                 }
             }
 
-            AirInstData::FieldSet { slot, struct_id, field_index, value } => {
+            AirInstData::FieldSet {
+                slot,
+                struct_id,
+                field_index,
+                value,
+            } => {
                 let val = self.lower_inst(*value).value.unwrap();
                 self.emit(
                     CfgInstData::FieldSet {
@@ -465,7 +509,11 @@ impl<'a> CfgBuilder<'a> {
                 self.lower_inst(*value)
             }
 
-            AirInstData::Branch { cond, then_value, else_value } => {
+            AirInstData::Branch {
+                cond,
+                then_value,
+                else_value,
+            } => {
                 let cond_val = self.lower_inst(*cond).value.unwrap();
 
                 let then_block = self.cfg.new_block();
@@ -477,13 +525,16 @@ impl<'a> CfgBuilder<'a> {
                 let else_type = else_value.map(|e| self.air.get(e).ty);
 
                 // Branch to then/else
-                self.cfg.set_terminator(self.current_block, Terminator::Branch {
-                    cond: cond_val,
-                    then_block,
-                    then_args: vec![],
-                    else_block,
-                    else_args: vec![],
-                });
+                self.cfg.set_terminator(
+                    self.current_block,
+                    Terminator::Branch {
+                        cond: cond_val,
+                        then_block,
+                        then_args: vec![],
+                        else_block,
+                        else_args: vec![],
+                    },
+                );
 
                 // Lower then branch
                 self.current_block = then_block;
@@ -532,26 +583,40 @@ impl<'a> CfgBuilder<'a> {
                 // Wire up non-divergent branches to join
                 if !then_diverged {
                     let args = if let Some(val) = then_result.value {
-                        if result_param.is_some() { vec![val] } else { vec![] }
+                        if result_param.is_some() {
+                            vec![val]
+                        } else {
+                            vec![]
+                        }
                     } else {
                         vec![]
                     };
-                    self.cfg.set_terminator(then_exit_block, Terminator::Goto {
-                        target: join_block,
-                        args,
-                    });
+                    self.cfg.set_terminator(
+                        then_exit_block,
+                        Terminator::Goto {
+                            target: join_block,
+                            args,
+                        },
+                    );
                 }
 
                 if !else_diverged {
                     let args = if let Some(val) = else_result.value {
-                        if result_param.is_some() { vec![val] } else { vec![] }
+                        if result_param.is_some() {
+                            vec![val]
+                        } else {
+                            vec![]
+                        }
                     } else {
                         vec![]
                     };
-                    self.cfg.set_terminator(else_exit_block, Terminator::Goto {
-                        target: join_block,
-                        args,
-                    });
+                    self.cfg.set_terminator(
+                        else_exit_block,
+                        Terminator::Goto {
+                            target: join_block,
+                            args,
+                        },
+                    );
                 }
 
                 self.current_block = join_block;
@@ -572,10 +637,13 @@ impl<'a> CfgBuilder<'a> {
                 let exit_block = self.cfg.new_block();
 
                 // Jump to header
-                self.cfg.set_terminator(self.current_block, Terminator::Goto {
-                    target: header_block,
-                    args: vec![],
-                });
+                self.cfg.set_terminator(
+                    self.current_block,
+                    Terminator::Goto {
+                        target: header_block,
+                        args: vec![],
+                    },
+                );
 
                 // Push loop context
                 self.loop_stack.push(LoopContext {
@@ -588,13 +656,16 @@ impl<'a> CfgBuilder<'a> {
                 let cond_val = self.lower_inst(*cond).value.unwrap();
 
                 // Branch: if true go to body, if false exit
-                self.cfg.set_terminator(self.current_block, Terminator::Branch {
-                    cond: cond_val,
-                    then_block: body_block,
-                    then_args: vec![],
-                    else_block: exit_block,
-                    else_args: vec![],
-                });
+                self.cfg.set_terminator(
+                    self.current_block,
+                    Terminator::Branch {
+                        cond: cond_val,
+                        then_block: body_block,
+                        then_args: vec![],
+                        else_block: exit_block,
+                        else_args: vec![],
+                    },
+                );
 
                 // Lower body
                 self.current_block = body_block;
@@ -602,10 +673,13 @@ impl<'a> CfgBuilder<'a> {
 
                 // After body, go back to header (unless diverged)
                 if !matches!(body_result.continuation, Continuation::Diverged) {
-                    self.cfg.set_terminator(self.current_block, Terminator::Goto {
-                        target: header_block,
-                        args: vec![],
-                    });
+                    self.cfg.set_terminator(
+                        self.current_block,
+                        Terminator::Goto {
+                            target: header_block,
+                            args: vec![],
+                        },
+                    );
                 }
 
                 self.loop_stack.pop();
@@ -621,10 +695,13 @@ impl<'a> CfgBuilder<'a> {
 
             AirInstData::Break => {
                 let ctx = self.loop_stack.last().expect("break outside loop");
-                self.cfg.set_terminator(self.current_block, Terminator::Goto {
-                    target: ctx.exit,
-                    args: vec![],
-                });
+                self.cfg.set_terminator(
+                    self.current_block,
+                    Terminator::Goto {
+                        target: ctx.exit,
+                        args: vec![],
+                    },
+                );
 
                 ExprResult {
                     value: None,
@@ -634,10 +711,13 @@ impl<'a> CfgBuilder<'a> {
 
             AirInstData::Continue => {
                 let ctx = self.loop_stack.last().expect("continue outside loop");
-                self.cfg.set_terminator(self.current_block, Terminator::Goto {
-                    target: ctx.header,
-                    args: vec![],
-                });
+                self.cfg.set_terminator(
+                    self.current_block,
+                    Terminator::Goto {
+                        target: ctx.header,
+                        args: vec![],
+                    },
+                );
 
                 ExprResult {
                     value: None,
@@ -647,7 +727,8 @@ impl<'a> CfgBuilder<'a> {
 
             AirInstData::Ret(value) => {
                 let val = self.lower_inst(*value).value.unwrap();
-                self.cfg.set_terminator(self.current_block, Terminator::Return { value: val });
+                self.cfg
+                    .set_terminator(self.current_block, Terminator::Return { value: val });
 
                 ExprResult {
                     value: None,
@@ -659,7 +740,8 @@ impl<'a> CfgBuilder<'a> {
 
     /// Emit an instruction in the current block.
     fn emit(&mut self, data: CfgInstData, ty: Type, span: rue_span::Span) -> CfgValue {
-        self.cfg.add_inst_to_block(self.current_block, CfgInst { data, ty, span })
+        self.cfg
+            .add_inst_to_block(self.current_block, CfgInst { data, ty, span })
     }
 
     /// Cache a value for an AIR ref.

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -77,11 +77,15 @@ pub enum CfgInstData {
     BoolConst(bool),
 
     /// Reference to a function parameter
-    Param { index: u32 },
+    Param {
+        index: u32,
+    },
 
     /// Block parameter (like phi, but explicit)
     /// Only valid at the start of a block
-    BlockParam { index: u32 },
+    BlockParam {
+        index: u32,
+    },
 
     // Binary arithmetic operations
     Add(CfgValue, CfgValue),
@@ -108,22 +112,48 @@ pub enum CfgInstData {
 
     // Variable operations
     /// Allocate local variable with initial value
-    Alloc { slot: u32, init: CfgValue },
+    Alloc {
+        slot: u32,
+        init: CfgValue,
+    },
     /// Load value from local variable
-    Load { slot: u32 },
+    Load {
+        slot: u32,
+    },
     /// Store value to local variable
-    Store { slot: u32, value: CfgValue },
+    Store {
+        slot: u32,
+        value: CfgValue,
+    },
 
     // Function calls
-    Call { name: String, args: Vec<CfgValue> },
+    Call {
+        name: String,
+        args: Vec<CfgValue>,
+    },
 
     /// Intrinsic call (e.g., @dbg)
-    Intrinsic { name: String, args: Vec<CfgValue> },
+    Intrinsic {
+        name: String,
+        args: Vec<CfgValue>,
+    },
 
     // Struct operations
-    StructInit { struct_id: StructId, fields: Vec<CfgValue> },
-    FieldGet { base: CfgValue, struct_id: StructId, field_index: u32 },
-    FieldSet { slot: u32, struct_id: StructId, field_index: u32, value: CfgValue },
+    StructInit {
+        struct_id: StructId,
+        fields: Vec<CfgValue>,
+    },
+    FieldGet {
+        base: CfgValue,
+        struct_id: StructId,
+        field_index: u32,
+    },
+    FieldSet {
+        slot: u32,
+        struct_id: StructId,
+        field_index: u32,
+        value: CfgValue,
+    },
 }
 
 /// Block terminator - how control leaves a basic block.
@@ -331,7 +361,11 @@ impl Cfg {
                 Terminator::Goto { target, .. } => {
                     edges.push((block.id, *target));
                 }
-                Terminator::Branch { then_block, else_block, .. } => {
+                Terminator::Branch {
+                    then_block,
+                    else_block,
+                    ..
+                } => {
                     edges.push((block.id, *then_block));
                     edges.push((block.id, *else_block));
                 }
@@ -348,7 +382,12 @@ impl Cfg {
 
 impl fmt::Display for Cfg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        writeln!(f, "cfg {} (return_type: {}) {{", self.fn_name, self.return_type.name())?;
+        writeln!(
+            f,
+            "cfg {} (return_type: {}) {{",
+            self.fn_name,
+            self.return_type.name()
+        )?;
         for block in &self.blocks {
             write!(f, "  {}:", block.id)?;
             if !block.params.is_empty() {
@@ -399,7 +438,13 @@ impl fmt::Display for Cfg {
                         write!(f, ")")?;
                     }
                 }
-                Terminator::Branch { cond, then_block, then_args, else_block, else_args } => {
+                Terminator::Branch {
+                    cond,
+                    then_block,
+                    then_args,
+                    else_block,
+                    else_args,
+                } => {
                     write!(f, "branch {}, {}", cond, then_block)?;
                     if !then_args.is_empty() {
                         write!(f, "(")?;
@@ -495,11 +540,24 @@ impl Cfg {
                 }
                 write!(f, "}}")
             }
-            CfgInstData::FieldGet { base, struct_id, field_index } => {
+            CfgInstData::FieldGet {
+                base,
+                struct_id,
+                field_index,
+            } => {
                 write!(f, "field_get {}.#{}.{}", base, struct_id.0, field_index)
             }
-            CfgInstData::FieldSet { slot, struct_id, field_index, value } => {
-                write!(f, "field_set ${}.#{}.{} = {}", slot, struct_id.0, field_index, value)
+            CfgInstData::FieldSet {
+                slot,
+                struct_id,
+                field_index,
+                value,
+            } => {
+                write!(
+                    f,
+                    "field_set ${}.#{}.{} = {}",
+                    slot, struct_id.0, field_index, value
+                )
             }
         }
     }
@@ -525,11 +583,14 @@ mod tests {
         let entry = cfg.new_block();
         cfg.entry = entry;
 
-        let const_val = cfg.add_inst_to_block(entry, CfgInst {
-            data: CfgInstData::Const(42),
-            ty: Type::I32,
-            span: Span::new(0, 2),
-        });
+        let const_val = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(42),
+                ty: Type::I32,
+                span: Span::new(0, 2),
+            },
+        );
 
         cfg.set_terminator(entry, Terminator::Return { value: const_val });
 

--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -16,13 +16,11 @@
 //! AIR (structured) → CFG (explicit control flow) → X86Mir (machine code)
 //! ```
 
-mod inst;
 mod build;
+mod inst;
 
-pub use inst::{
-    BlockId, Cfg, BasicBlock, CfgInst, CfgInstData, CfgValue, Terminator,
-};
 pub use build::CfgBuilder;
+pub use inst::{BasicBlock, BlockId, Cfg, CfgInst, CfgInstData, CfgValue, Terminator};
 
 // Re-export types from rue-air that we use
 pub use rue_air::{StructDef, StructId, Type};

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -595,7 +595,9 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Call the function - the linker will add the underscore prefix for macOS
-                self.mir.push(Aarch64Inst::Bl { symbol: name.clone() });
+                self.mir.push(Aarch64Inst::Bl {
+                    symbol: name.clone(),
+                });
 
                 // Clean up stack space after call
                 if stack_space > 0 {

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -145,7 +145,12 @@ pub struct Emitter<'a> {
 
 impl<'a> Emitter<'a> {
     /// Create a new emitter.
-    pub fn new(mir: &'a Aarch64Mir, num_locals: u32, num_params: u32, callee_saved: &[Reg]) -> Self {
+    pub fn new(
+        mir: &'a Aarch64Mir,
+        num_locals: u32,
+        num_params: u32,
+        callee_saved: &[Reg],
+    ) -> Self {
         Self {
             mir,
             code: Vec::new(),
@@ -223,7 +228,14 @@ impl<'a> Emitter<'a> {
         //
         // AAPCS64: first 8 args in x0-x7
         let param_regs = [
-            Reg::X0, Reg::X1, Reg::X2, Reg::X3, Reg::X4, Reg::X5, Reg::X6, Reg::X7,
+            Reg::X0,
+            Reg::X1,
+            Reg::X2,
+            Reg::X3,
+            Reg::X4,
+            Reg::X5,
+            Reg::X6,
+            Reg::X7,
         ];
         let callee_saved_size = self.callee_saved_stack_size();
         for i in 0..self.num_params.min(8) as usize {
@@ -557,16 +569,22 @@ impl<'a> Emitter<'a> {
                 match fixup.kind {
                     FixupKind::Branch => {
                         // B instruction: imm26
-                        let inst =
-                            u32::from_le_bytes(self.code[fixup.offset..fixup.offset + 4].try_into().unwrap());
+                        let inst = u32::from_le_bytes(
+                            self.code[fixup.offset..fixup.offset + 4]
+                                .try_into()
+                                .unwrap(),
+                        );
                         let new_inst = (inst & 0xFC000000) | ((offset as u32) & 0x03FFFFFF);
                         self.code[fixup.offset..fixup.offset + 4]
                             .copy_from_slice(&new_inst.to_le_bytes());
                     }
                     FixupKind::CondBranch => {
                         // Conditional branch: imm19
-                        let inst =
-                            u32::from_le_bytes(self.code[fixup.offset..fixup.offset + 4].try_into().unwrap());
+                        let inst = u32::from_le_bytes(
+                            self.code[fixup.offset..fixup.offset + 4]
+                                .try_into()
+                                .unwrap(),
+                        );
                         let new_inst = (inst & 0xFF00001F) | (((offset as u32) & 0x7FFFF) << 5);
                         self.code[fixup.offset..fixup.offset + 4]
                             .copy_from_slice(&new_inst.to_le_bytes());
@@ -622,7 +640,8 @@ impl<'a> Emitter<'a> {
 
             // MOVN Xd, #imm16, LSL #(first_idx * 16)
             let hw = first_idx as u32;
-            let inst = OPCODE_MOVN_X | (hw << 21) | ((first_val as u32) << 5) | rd.encoding() as u32;
+            let inst =
+                OPCODE_MOVN_X | (hw << 21) | ((first_val as u32) << 5) | rd.encoding() as u32;
             self.emit_u32(inst);
 
             // Use MOVK for remaining non-0xFFFF chunks in original value
@@ -646,18 +665,21 @@ impl<'a> Emitter<'a> {
 
             // If more bits needed, use MOVK
             if (uimm >> 16) & 0xFFFF != 0 {
-                let inst =
-                    OPCODE_MOVK_X_LSL16 | (((uimm >> 16) & 0xFFFF) << 5) as u32 | rd.encoding() as u32;
+                let inst = OPCODE_MOVK_X_LSL16
+                    | (((uimm >> 16) & 0xFFFF) << 5) as u32
+                    | rd.encoding() as u32;
                 self.emit_u32(inst);
             }
             if (uimm >> 32) & 0xFFFF != 0 {
-                let inst =
-                    OPCODE_MOVK_X_LSL32 | (((uimm >> 32) & 0xFFFF) << 5) as u32 | rd.encoding() as u32;
+                let inst = OPCODE_MOVK_X_LSL32
+                    | (((uimm >> 32) & 0xFFFF) << 5) as u32
+                    | rd.encoding() as u32;
                 self.emit_u32(inst);
             }
             if (uimm >> 48) & 0xFFFF != 0 {
-                let inst =
-                    OPCODE_MOVK_X_LSL48 | (((uimm >> 48) & 0xFFFF) << 5) as u32 | rd.encoding() as u32;
+                let inst = OPCODE_MOVK_X_LSL48
+                    | (((uimm >> 48) & 0xFFFF) << 5) as u32
+                    | rd.encoding() as u32;
                 self.emit_u32(inst);
             }
         }
@@ -690,10 +712,8 @@ impl<'a> Emitter<'a> {
         } else {
             // Use unscaled offset (LDUR)
             let imm9 = (offset as u32) & 0x1FF;
-            let inst = OPCODE_LDUR
-                | (imm9 << 12)
-                | (base.encoding() as u32) << 5
-                | rd.encoding() as u32;
+            let inst =
+                OPCODE_LDUR | (imm9 << 12) | (base.encoding() as u32) << 5 | rd.encoding() as u32;
             self.emit_u32(inst);
         }
     }
@@ -710,10 +730,8 @@ impl<'a> Emitter<'a> {
         } else {
             // Use unscaled offset (STUR)
             let imm9 = (offset as u32) & 0x1FF;
-            let inst = OPCODE_STUR
-                | (imm9 << 12)
-                | (base.encoding() as u32) << 5
-                | rs.encoding() as u32;
+            let inst =
+                OPCODE_STUR | (imm9 << 12) | (base.encoding() as u32) << 5 | rs.encoding() as u32;
             self.emit_u32(inst);
         }
     }
@@ -721,10 +739,8 @@ impl<'a> Emitter<'a> {
     fn emit_str_pre(&mut self, rs: Reg, offset: i32) {
         // STR Xt, [SP, #imm]!
         let imm9 = (offset as u32) & 0x1FF;
-        let inst = OPCODE_STR_PRE
-            | (imm9 << 12)
-            | (Reg::Sp.encoding() as u32) << 5
-            | rs.encoding() as u32;
+        let inst =
+            OPCODE_STR_PRE | (imm9 << 12) | (Reg::Sp.encoding() as u32) << 5 | rs.encoding() as u32;
         self.emit_u32(inst);
     }
 
@@ -762,7 +778,11 @@ impl<'a> Emitter<'a> {
 
     fn emit_add_rr(&mut self, rd: Reg, rn: Reg, rm: Reg, set_flags: bool) {
         // When set_flags is true, use 32-bit (W) form for proper i32 overflow detection.
-        let base = if set_flags { OPCODE_ADDS_W } else { OPCODE_ADD_X };
+        let base = if set_flags {
+            OPCODE_ADDS_W
+        } else {
+            OPCODE_ADD_X
+        };
         let inst = base
             | (rm.encoding() as u32) << 16
             | (rn.encoding() as u32) << 5
@@ -781,7 +801,11 @@ impl<'a> Emitter<'a> {
 
     fn emit_sub_rr(&mut self, rd: Reg, rn: Reg, rm: Reg, set_flags: bool) {
         // When set_flags is true, use 32-bit (W) form for proper i32 overflow detection.
-        let base = if set_flags { OPCODE_SUBS_W } else { OPCODE_SUB_X };
+        let base = if set_flags {
+            OPCODE_SUBS_W
+        } else {
+            OPCODE_SUB_X
+        };
         let inst = base
             | (rm.encoding() as u32) << 16
             | (rn.encoding() as u32) << 5
@@ -791,7 +815,11 @@ impl<'a> Emitter<'a> {
 
     fn emit_sub64_rr(&mut self, rd: Reg, rn: Reg, rm: Reg, set_flags: bool) {
         // 64-bit subtract for comparing 64-bit values (e.g., SMULL results).
-        let base = if set_flags { OPCODE_SUBS_X } else { OPCODE_SUB_X };
+        let base = if set_flags {
+            OPCODE_SUBS_X
+        } else {
+            OPCODE_SUB_X
+        };
         let inst = base
             | (rm.encoding() as u32) << 16
             | (rn.encoding() as u32) << 5
@@ -1052,7 +1080,8 @@ mod tests {
                     .unwrap_or((0, 0));
 
                 let hw = first_idx as u32;
-                let inst = OPCODE_MOVN_X | (hw << 21) | ((first_val as u32) << 5) | rd.encoding() as u32;
+                let inst =
+                    OPCODE_MOVN_X | (hw << 21) | ((first_val as u32) << 5) | rd.encoding() as u32;
                 self.emit_u32(inst);
 
                 for (i, &chunk) in chunks.iter().enumerate() {
@@ -1073,18 +1102,21 @@ mod tests {
                 self.emit_u32(inst);
 
                 if (uimm >> 16) & 0xFFFF != 0 {
-                    let inst =
-                        OPCODE_MOVK_X_LSL16 | (((uimm >> 16) & 0xFFFF) << 5) as u32 | rd.encoding() as u32;
+                    let inst = OPCODE_MOVK_X_LSL16
+                        | (((uimm >> 16) & 0xFFFF) << 5) as u32
+                        | rd.encoding() as u32;
                     self.emit_u32(inst);
                 }
                 if (uimm >> 32) & 0xFFFF != 0 {
-                    let inst =
-                        OPCODE_MOVK_X_LSL32 | (((uimm >> 32) & 0xFFFF) << 5) as u32 | rd.encoding() as u32;
+                    let inst = OPCODE_MOVK_X_LSL32
+                        | (((uimm >> 32) & 0xFFFF) << 5) as u32
+                        | rd.encoding() as u32;
                     self.emit_u32(inst);
                 }
                 if (uimm >> 48) & 0xFFFF != 0 {
-                    let inst =
-                        OPCODE_MOVK_X_LSL48 | (((uimm >> 48) & 0xFFFF) << 5) as u32 | rd.encoding() as u32;
+                    let inst = OPCODE_MOVK_X_LSL48
+                        | (((uimm >> 48) & 0xFFFF) << 5) as u32
+                        | rd.encoding() as u32;
                     self.emit_u32(inst);
                 }
             }
@@ -1115,7 +1147,11 @@ mod tests {
         let mut emitter = TestEmitter::new();
         emitter.emit_mov_imm(Reg::X1, 42);
 
-        assert_eq!(emitter.code.len(), 4, "Small immediate should be 1 instruction");
+        assert_eq!(
+            emitter.code.len(),
+            4,
+            "Small immediate should be 1 instruction"
+        );
 
         let inst = u32::from_le_bytes(emitter.code[0..4].try_into().unwrap());
         // MOVZ: 0xD2800000
@@ -1148,7 +1184,11 @@ mod tests {
         emitter.emit_mov_imm(Reg::X3, 0x12345678);
 
         // Should be MOVZ for low 16 bits + MOVK for high 16 bits
-        assert_eq!(emitter.code.len(), 8, "Large positive should be 2 instructions");
+        assert_eq!(
+            emitter.code.len(),
+            8,
+            "Large positive should be 2 instructions"
+        );
 
         let inst1 = u32::from_le_bytes(emitter.code[0..4].try_into().unwrap());
         let inst2 = u32::from_le_bytes(emitter.code[4..8].try_into().unwrap());
@@ -1161,7 +1201,11 @@ mod tests {
 
         // Second instruction: MOVK X3, #0x1234, LSL #16
         // MOVK LSL#16 uses top bits 0xF2A (sf=1, opc=11, hw=01)
-        assert_eq!(inst2 & 0xFFE00000, 0xF2A00000, "Second should be MOVK LSL#16");
+        assert_eq!(
+            inst2 & 0xFFE00000,
+            0xF2A00000,
+            "Second should be MOVK LSL#16"
+        );
         assert_eq!((inst2 >> 5) & 0xFFFF, 0x1234, "High 16 bits");
         assert_eq!(inst2 & 0x1F, 3, "Destination should be X3");
     }

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -284,10 +284,7 @@ fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
             add_if_virtual(src, &mut result);
         }
         Aarch64Inst::Msub {
-            src1,
-            src2,
-            src3,
-            ..
+            src1, src2, src3, ..
         } => {
             add_if_virtual(src1, &mut result);
             add_if_virtual(src2, &mut result);
@@ -554,7 +551,10 @@ mod tests {
         // v0 should be live from definition (0) through use in CBZ (1) and MOV (2)
         let v0_range = info.ranges.get(&v0).expect("v0 should have a range");
         assert_eq!(v0_range.start, 0);
-        assert!(v0_range.end >= 2, "v0 should be live through its last use at instruction 2");
+        assert!(
+            v0_range.end >= 2,
+            "v0 should be live through its last use at instruction 2"
+        );
 
         // v1 should be live from first definition through final use
         let v1_range = info.ranges.get(&v1).expect("v1 should have a range");

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -500,7 +500,11 @@ pub enum Aarch64Inst {
     },
 
     /// `eor dst, src, #imm` - XOR with immediate.
-    EorImm { dst: Operand, src: Operand, imm: u64 },
+    EorImm {
+        dst: Operand,
+        src: Operand,
+        imm: u64,
+    },
 
     // === Comparison instructions ===
     /// `cmp src1, src2` - Compare (subtract and set flags, discard result). Uses 32-bit form.

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -45,11 +45,13 @@ pub fn generate(
 
     // Phase 3: Allocate physical registers
     let existing_slots = num_locals + num_params;
-    let (mir, num_spills, used_callee_saved) = RegAlloc::new(mir, existing_slots).allocate_with_spills();
+    let (mir, num_spills, used_callee_saved) =
+        RegAlloc::new(mir, existing_slots).allocate_with_spills();
 
     // Phase 4: Emit machine code bytes
     let total_locals = num_locals + num_spills;
-    let (code, relocations) = Emitter::new(&mir, total_locals, num_params, &used_callee_saved).emit();
+    let (code, relocations) =
+        Emitter::new(&mir, total_locals, num_params, &used_callee_saved).emit();
 
     MachineCode { code, relocations }
 }

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -23,7 +23,15 @@ use super::mir::{Aarch64Inst, Aarch64Mir, Operand, Reg, VReg};
 /// - X30 (LR): Link register
 /// - SP: Stack pointer
 const ALLOCATABLE_REGS: &[Reg] = &[
-    Reg::X19, Reg::X20, Reg::X21, Reg::X22, Reg::X23, Reg::X24, Reg::X25, Reg::X26, Reg::X27,
+    Reg::X19,
+    Reg::X20,
+    Reg::X21,
+    Reg::X22,
+    Reg::X23,
+    Reg::X24,
+    Reg::X25,
+    Reg::X26,
+    Reg::X27,
     Reg::X28,
 ];
 
@@ -217,32 +225,30 @@ impl RegAlloc {
                 }
             }
 
-            Aarch64Inst::Ldr { dst, base, offset } => {
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Physical(reg),
-                            base,
-                            offset,
-                        });
-                    }
-                    Some(Allocation::Spill(spill_offset)) => {
-                        mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Physical(Reg::X9),
-                            base,
-                            offset,
-                        });
-                        mir.push(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
-                            base: Reg::Fp,
-                            offset: spill_offset,
-                        });
-                    }
-                    None => {
-                        mir.push(Aarch64Inst::Ldr { dst, base, offset });
-                    }
+            Aarch64Inst::Ldr { dst, base, offset } => match self.get_allocation(dst) {
+                Some(Allocation::Register(reg)) => {
+                    mir.push(Aarch64Inst::Ldr {
+                        dst: Operand::Physical(reg),
+                        base,
+                        offset,
+                    });
                 }
-            }
+                Some(Allocation::Spill(spill_offset)) => {
+                    mir.push(Aarch64Inst::Ldr {
+                        dst: Operand::Physical(Reg::X9),
+                        base,
+                        offset,
+                    });
+                    mir.push(Aarch64Inst::Str {
+                        src: Operand::Physical(Reg::X9),
+                        base: Reg::Fp,
+                        offset: spill_offset,
+                    });
+                }
+                None => {
+                    mir.push(Aarch64Inst::Ldr { dst, base, offset });
+                }
+            },
 
             Aarch64Inst::Str { src, base, offset } => {
                 let src_op = self.load_operand(mir, src, Reg::X9);
@@ -424,7 +430,11 @@ impl RegAlloc {
                         });
                     }
                     None => {
-                        mir.push(Aarch64Inst::EorImm { dst, src: src_op, imm });
+                        mir.push(Aarch64Inst::EorImm {
+                            dst,
+                            src: src_op,
+                            imm,
+                        });
                     }
                 }
             }
@@ -454,44 +464,36 @@ impl RegAlloc {
 
             Aarch64Inst::Cbz { src, label } => {
                 let src_op = self.load_operand(mir, src, Reg::X9);
-                mir.push(Aarch64Inst::Cbz {
-                    src: src_op,
-                    label,
-                });
+                mir.push(Aarch64Inst::Cbz { src: src_op, label });
             }
 
             Aarch64Inst::Cbnz { src, label } => {
                 let src_op = self.load_operand(mir, src, Reg::X9);
-                mir.push(Aarch64Inst::Cbnz {
-                    src: src_op,
-                    label,
-                });
+                mir.push(Aarch64Inst::Cbnz { src: src_op, label });
             }
 
-            Aarch64Inst::Cset { dst, cond } => {
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(Aarch64Inst::Cset {
-                            dst: Operand::Physical(reg),
-                            cond,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(Aarch64Inst::Cset {
-                            dst: Operand::Physical(Reg::X9),
-                            cond,
-                        });
-                        mir.push(Aarch64Inst::Str {
-                            src: Operand::Physical(Reg::X9),
-                            base: Reg::Fp,
-                            offset,
-                        });
-                    }
-                    None => {
-                        mir.push(Aarch64Inst::Cset { dst, cond });
-                    }
+            Aarch64Inst::Cset { dst, cond } => match self.get_allocation(dst) {
+                Some(Allocation::Register(reg)) => {
+                    mir.push(Aarch64Inst::Cset {
+                        dst: Operand::Physical(reg),
+                        cond,
+                    });
                 }
-            }
+                Some(Allocation::Spill(offset)) => {
+                    mir.push(Aarch64Inst::Cset {
+                        dst: Operand::Physical(Reg::X9),
+                        cond,
+                    });
+                    mir.push(Aarch64Inst::Str {
+                        src: Operand::Physical(Reg::X9),
+                        base: Reg::Fp,
+                        offset,
+                    });
+                }
+                None => {
+                    mir.push(Aarch64Inst::Cset { dst, cond });
+                }
+            },
 
             Aarch64Inst::TstRR { src1, src2 } => {
                 let src1_op = self.load_operand(mir, src1, Reg::X9);
@@ -768,10 +770,14 @@ mod tests {
         let result = RegAlloc::new(mir, 0).allocate();
 
         // Verify the Msub instruction was generated
-        let has_msub = result.instructions().iter().any(|inst| {
-            matches!(inst, Aarch64Inst::Msub { .. })
-        });
-        assert!(has_msub, "MSUB instruction should be present after allocation");
+        let has_msub = result
+            .instructions()
+            .iter()
+            .any(|inst| matches!(inst, Aarch64Inst::Msub { .. }));
+        assert!(
+            has_msub,
+            "MSUB instruction should be present after allocation"
+        );
     }
 
     #[test]
@@ -841,7 +847,11 @@ mod tests {
         let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills();
 
         // With 15 vregs and 10 allocatable registers, we should have spills
-        assert!(num_spills >= 5, "Should have at least 5 spills, got {}", num_spills);
+        assert!(
+            num_spills >= 5,
+            "Should have at least 5 spills, got {}",
+            num_spills
+        );
 
         // Verify all virtual registers are replaced with physical
         for inst in mir.instructions() {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -5,7 +5,9 @@
 
 use std::collections::HashMap;
 
-use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, StructDef, StructId, Terminator, Type};
+use rue_cfg::{
+    BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, StructDef, StructId, Terminator, Type,
+};
 
 use super::mir::{Operand, Reg, VReg, X86Inst, X86Mir};
 
@@ -54,7 +56,7 @@ impl<'a> CfgLower<'a> {
             num_locals,
             num_params,
             fn_name: cfg.fn_name().to_string(),
-        struct_field_vregs: HashMap::new(),
+            struct_field_vregs: HashMap::new(),
         }
     }
 
@@ -100,7 +102,8 @@ impl<'a> CfgLower<'a> {
         for block in self.cfg.blocks() {
             for (param_idx, (param_val, _ty)) in block.params.iter().enumerate() {
                 let vreg = self.mir.alloc_vreg();
-                self.block_param_vregs.insert((block.id, param_idx as u32), vreg);
+                self.block_param_vregs
+                    .insert((block.id, param_idx as u32), vreg);
                 self.value_map.insert(*param_val, vreg);
             }
         }
@@ -213,8 +216,12 @@ impl<'a> CfgLower<'a> {
 
                 // Overflow check
                 let ok_label = self.new_label("add_ok");
-                self.mir.push(X86Inst::Jno { label: ok_label.clone() });
-                self.mir.push(X86Inst::CallRel { symbol: "__rue_overflow".to_string() });
+                self.mir.push(X86Inst::Jno {
+                    label: ok_label.clone(),
+                });
+                self.mir.push(X86Inst::CallRel {
+                    symbol: "__rue_overflow".to_string(),
+                });
                 self.mir.push(X86Inst::Label { name: ok_label });
             }
 
@@ -235,8 +242,12 @@ impl<'a> CfgLower<'a> {
                 });
 
                 let ok_label = self.new_label("sub_ok");
-                self.mir.push(X86Inst::Jno { label: ok_label.clone() });
-                self.mir.push(X86Inst::CallRel { symbol: "__rue_overflow".to_string() });
+                self.mir.push(X86Inst::Jno {
+                    label: ok_label.clone(),
+                });
+                self.mir.push(X86Inst::CallRel {
+                    symbol: "__rue_overflow".to_string(),
+                });
                 self.mir.push(X86Inst::Label { name: ok_label });
             }
 
@@ -257,8 +268,12 @@ impl<'a> CfgLower<'a> {
                 });
 
                 let ok_label = self.new_label("mul_ok");
-                self.mir.push(X86Inst::Jno { label: ok_label.clone() });
-                self.mir.push(X86Inst::CallRel { symbol: "__rue_overflow".to_string() });
+                self.mir.push(X86Inst::Jno {
+                    label: ok_label.clone(),
+                });
+                self.mir.push(X86Inst::CallRel {
+                    symbol: "__rue_overflow".to_string(),
+                });
                 self.mir.push(X86Inst::Label { name: ok_label });
             }
 
@@ -275,8 +290,12 @@ impl<'a> CfgLower<'a> {
                     src1: Operand::Virtual(rhs_vreg),
                     src2: Operand::Virtual(rhs_vreg),
                 });
-                self.mir.push(X86Inst::Jnz { label: ok_label.clone() });
-                self.mir.push(X86Inst::CallRel { symbol: "__rue_div_by_zero".to_string() });
+                self.mir.push(X86Inst::Jnz {
+                    label: ok_label.clone(),
+                });
+                self.mir.push(X86Inst::CallRel {
+                    symbol: "__rue_div_by_zero".to_string(),
+                });
                 self.mir.push(X86Inst::Label { name: ok_label });
 
                 self.mir.push(X86Inst::MovRR {
@@ -305,8 +324,12 @@ impl<'a> CfgLower<'a> {
                     src1: Operand::Virtual(rhs_vreg),
                     src2: Operand::Virtual(rhs_vreg),
                 });
-                self.mir.push(X86Inst::Jnz { label: ok_label.clone() });
-                self.mir.push(X86Inst::CallRel { symbol: "__rue_div_by_zero".to_string() });
+                self.mir.push(X86Inst::Jnz {
+                    label: ok_label.clone(),
+                });
+                self.mir.push(X86Inst::CallRel {
+                    symbol: "__rue_div_by_zero".to_string(),
+                });
                 self.mir.push(X86Inst::Label { name: ok_label });
 
                 self.mir.push(X86Inst::MovRR {
@@ -338,8 +361,12 @@ impl<'a> CfgLower<'a> {
                 });
 
                 let ok_label = self.new_label("neg_ok");
-                self.mir.push(X86Inst::Jno { label: ok_label.clone() });
-                self.mir.push(X86Inst::CallRel { symbol: "__rue_overflow".to_string() });
+                self.mir.push(X86Inst::Jno {
+                    label: ok_label.clone(),
+                });
+                self.mir.push(X86Inst::CallRel {
+                    symbol: "__rue_overflow".to_string(),
+                });
                 self.mir.push(X86Inst::Label { name: ok_label });
             }
 
@@ -361,37 +388,49 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::Eq(lhs, rhs) => {
                 self.emit_comparison(value, *lhs, *rhs, |mir, vreg| {
-                    mir.push(X86Inst::Sete { dst: Operand::Virtual(vreg) });
+                    mir.push(X86Inst::Sete {
+                        dst: Operand::Virtual(vreg),
+                    });
                 });
             }
 
             CfgInstData::Ne(lhs, rhs) => {
                 self.emit_comparison(value, *lhs, *rhs, |mir, vreg| {
-                    mir.push(X86Inst::Setne { dst: Operand::Virtual(vreg) });
+                    mir.push(X86Inst::Setne {
+                        dst: Operand::Virtual(vreg),
+                    });
                 });
             }
 
             CfgInstData::Lt(lhs, rhs) => {
                 self.emit_comparison(value, *lhs, *rhs, |mir, vreg| {
-                    mir.push(X86Inst::Setl { dst: Operand::Virtual(vreg) });
+                    mir.push(X86Inst::Setl {
+                        dst: Operand::Virtual(vreg),
+                    });
                 });
             }
 
             CfgInstData::Gt(lhs, rhs) => {
                 self.emit_comparison(value, *lhs, *rhs, |mir, vreg| {
-                    mir.push(X86Inst::Setg { dst: Operand::Virtual(vreg) });
+                    mir.push(X86Inst::Setg {
+                        dst: Operand::Virtual(vreg),
+                    });
                 });
             }
 
             CfgInstData::Le(lhs, rhs) => {
                 self.emit_comparison(value, *lhs, *rhs, |mir, vreg| {
-                    mir.push(X86Inst::Setle { dst: Operand::Virtual(vreg) });
+                    mir.push(X86Inst::Setle {
+                        dst: Operand::Virtual(vreg),
+                    });
                 });
             }
 
             CfgInstData::Ge(lhs, rhs) => {
                 self.emit_comparison(value, *lhs, *rhs, |mir, vreg| {
-                    mir.push(X86Inst::Setge { dst: Operand::Virtual(vreg) });
+                    mir.push(X86Inst::Setge {
+                        dst: Operand::Virtual(vreg),
+                    });
                 });
             }
 
@@ -701,7 +740,10 @@ impl<'a> CfgLower<'a> {
                 }
             }
 
-            CfgInstData::StructInit { struct_id: _, fields } => {
+            CfgInstData::StructInit {
+                struct_id: _,
+                fields,
+            } => {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
 
@@ -726,7 +768,11 @@ impl<'a> CfgLower<'a> {
                 self.struct_field_vregs.insert(value, field_vregs);
             }
 
-            CfgInstData::FieldGet { base, struct_id: _, field_index } => {
+            CfgInstData::FieldGet {
+                base,
+                struct_id: _,
+                field_index,
+            } => {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
 
@@ -760,7 +806,12 @@ impl<'a> CfgLower<'a> {
                 }
             }
 
-            CfgInstData::FieldSet { slot, struct_id: _, field_index, value: val } => {
+            CfgInstData::FieldSet {
+                slot,
+                struct_id: _,
+                field_index,
+                value: val,
+            } => {
                 let val_vreg = self.get_vreg(*val);
                 let actual_slot = slot + field_index;
                 let offset = self.local_offset(actual_slot);
@@ -818,7 +869,13 @@ impl<'a> CfgLower<'a> {
                 }
             }
 
-            Terminator::Branch { cond, then_block, then_args, else_block, else_args } => {
+            Terminator::Branch {
+                cond,
+                then_block,
+                then_args,
+                else_block,
+                else_args,
+            } => {
                 let cond_vreg = self.get_vreg(*cond);
 
                 // Test condition
@@ -955,7 +1012,9 @@ impl<'a> CfgLower<'a> {
         // Not yet lowered - lower it now
         self.lower_value(value);
 
-        self.value_map.get(&value).copied()
+        self.value_map
+            .get(&value)
+            .copied()
             .expect("value should have been lowered")
     }
 }
@@ -963,8 +1022,8 @@ impl<'a> CfgLower<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use rue_cfg::CfgBuilder;
     use rue_air::Sema;
+    use rue_cfg::CfgBuilder;
     use rue_intern::Interner;
     use rue_lexer::Lexer;
     use rue_parser::Parser;

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -5,8 +5,8 @@
 
 use std::collections::HashMap;
 
-use super::mir::{Reg, X86Inst, X86Mir};
 use super::EmittedRelocation;
+use super::mir::{Reg, X86Inst, X86Mir};
 
 /// Kind of jump fixup (rel8 or rel32).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -169,7 +169,9 @@ impl<'a> Emitter<'a> {
     /// Apply all fixups for forward jumps.
     fn apply_fixups(&mut self) {
         for fixup in &self.fixups {
-            let target_offset = self.labels.get(&fixup.label)
+            let target_offset = self
+                .labels
+                .get(&fixup.label)
                 .unwrap_or_else(|| panic!("undefined label: {}", fixup.label));
 
             match fixup.kind {
@@ -1159,8 +1161,8 @@ impl<'a> Emitter<'a> {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use super::super::mir::Operand;
+    use super::*;
 
     fn emit_single(inst: X86Inst) -> Vec<u8> {
         let mut mir = X86Mir::new();
@@ -1297,9 +1299,9 @@ mod tests {
             code,
             vec![
                 0x41, 0xBA, 0x2A, 0x00, 0x00, 0x00, // mov r10d, 42
-                0x4C, 0x89, 0xD7,                   // mov rdi, r10
-                0xB8, 0x3C, 0x00, 0x00, 0x00,       // mov eax, 60
-                0x0F, 0x05                          // syscall
+                0x4C, 0x89, 0xD7, // mov rdi, r10
+                0xB8, 0x3C, 0x00, 0x00, 0x00, // mov eax, 60
+                0x0F, 0x05 // syscall
             ]
         );
     }
@@ -1536,8 +1538,8 @@ mod tests {
         assert_eq!(
             code,
             vec![
-                0x55,                               // push rbp
-                0x48, 0x89, 0xE5,                   // mov rbp, rsp
+                0x55, // push rbp
+                0x48, 0x89, 0xE5, // mov rbp, rsp
                 0x48, 0x81, 0xEC, 0x10, 0x00, 0x00, 0x00, // sub rsp, 16
             ]
         );

--- a/crates/rue-codegen/src/x86_64/lower.rs
+++ b/crates/rue-codegen/src/x86_64/lower.rs
@@ -185,8 +185,12 @@ impl<'a> Lower<'a> {
                 });
                 // Check for overflow and call error handler if set
                 let ok_label = self.new_label("add_ok");
-                self.mir.push(X86Inst::Jno { label: ok_label.clone() });
-                self.mir.push(X86Inst::CallRel { symbol: "__rue_overflow".to_string() });
+                self.mir.push(X86Inst::Jno {
+                    label: ok_label.clone(),
+                });
+                self.mir.push(X86Inst::CallRel {
+                    symbol: "__rue_overflow".to_string(),
+                });
                 self.mir.push(X86Inst::Label { name: ok_label });
             }
 
@@ -207,8 +211,12 @@ impl<'a> Lower<'a> {
                 });
                 // Check for overflow and call error handler if set
                 let ok_label = self.new_label("sub_ok");
-                self.mir.push(X86Inst::Jno { label: ok_label.clone() });
-                self.mir.push(X86Inst::CallRel { symbol: "__rue_overflow".to_string() });
+                self.mir.push(X86Inst::Jno {
+                    label: ok_label.clone(),
+                });
+                self.mir.push(X86Inst::CallRel {
+                    symbol: "__rue_overflow".to_string(),
+                });
                 self.mir.push(X86Inst::Label { name: ok_label });
             }
 
@@ -230,8 +238,12 @@ impl<'a> Lower<'a> {
                 });
                 // Check for overflow and call error handler if set
                 let ok_label = self.new_label("mul_ok");
-                self.mir.push(X86Inst::Jno { label: ok_label.clone() });
-                self.mir.push(X86Inst::CallRel { symbol: "__rue_overflow".to_string() });
+                self.mir.push(X86Inst::Jno {
+                    label: ok_label.clone(),
+                });
+                self.mir.push(X86Inst::CallRel {
+                    symbol: "__rue_overflow".to_string(),
+                });
                 self.mir.push(X86Inst::Label { name: ok_label });
             }
 
@@ -248,8 +260,12 @@ impl<'a> Lower<'a> {
                     src1: Operand::Virtual(rhs_vreg),
                     src2: Operand::Virtual(rhs_vreg),
                 });
-                self.mir.push(X86Inst::Jnz { label: ok_label.clone() });
-                self.mir.push(X86Inst::CallRel { symbol: "__rue_div_by_zero".to_string() });
+                self.mir.push(X86Inst::Jnz {
+                    label: ok_label.clone(),
+                });
+                self.mir.push(X86Inst::CallRel {
+                    symbol: "__rue_div_by_zero".to_string(),
+                });
                 self.mir.push(X86Inst::Label { name: ok_label });
 
                 // Division on x86 uses EDX:EAX / divisor -> quotient in EAX, remainder in EDX
@@ -288,8 +304,12 @@ impl<'a> Lower<'a> {
                     src1: Operand::Virtual(rhs_vreg),
                     src2: Operand::Virtual(rhs_vreg),
                 });
-                self.mir.push(X86Inst::Jnz { label: ok_label.clone() });
-                self.mir.push(X86Inst::CallRel { symbol: "__rue_div_by_zero".to_string() });
+                self.mir.push(X86Inst::Jnz {
+                    label: ok_label.clone(),
+                });
+                self.mir.push(X86Inst::CallRel {
+                    symbol: "__rue_div_by_zero".to_string(),
+                });
                 self.mir.push(X86Inst::Label { name: ok_label });
 
                 // Modulo uses the same idiv instruction, but takes remainder from EDX
@@ -327,8 +347,12 @@ impl<'a> Lower<'a> {
                 });
                 // Check for overflow (only happens when negating i32::MIN)
                 let ok_label = self.new_label("neg_ok");
-                self.mir.push(X86Inst::Jno { label: ok_label.clone() });
-                self.mir.push(X86Inst::CallRel { symbol: "__rue_overflow".to_string() });
+                self.mir.push(X86Inst::Jno {
+                    label: ok_label.clone(),
+                });
+                self.mir.push(X86Inst::CallRel {
+                    symbol: "__rue_overflow".to_string(),
+                });
                 self.mir.push(X86Inst::Label { name: ok_label });
             }
 
@@ -579,7 +603,9 @@ impl<'a> Lower<'a> {
                     src: Operand::Virtual(lhs_vreg),
                     imm: 0,
                 });
-                self.mir.push(X86Inst::Jz { label: false_label.clone() });
+                self.mir.push(X86Inst::Jz {
+                    label: false_label.clone(),
+                });
 
                 // LHS was true - evaluate RHS (demand-driven, only lowered here)
                 let rhs_vreg = self.get_vreg(*rhs);
@@ -587,7 +613,9 @@ impl<'a> Lower<'a> {
                     dst: Operand::Virtual(vreg),
                     src: Operand::Virtual(rhs_vreg),
                 });
-                self.mir.push(X86Inst::Jmp { label: end_label.clone() });
+                self.mir.push(X86Inst::Jmp {
+                    label: end_label.clone(),
+                });
 
                 // Short-circuit path: result is false
                 self.mir.push(X86Inst::Label { name: false_label });
@@ -617,7 +645,9 @@ impl<'a> Lower<'a> {
                     src: Operand::Virtual(lhs_vreg),
                     imm: 0,
                 });
-                self.mir.push(X86Inst::Jnz { label: true_label.clone() });
+                self.mir.push(X86Inst::Jnz {
+                    label: true_label.clone(),
+                });
 
                 // LHS was false - evaluate RHS (demand-driven, only lowered here)
                 let rhs_vreg = self.get_vreg(*rhs);
@@ -625,7 +655,9 @@ impl<'a> Lower<'a> {
                     dst: Operand::Virtual(vreg),
                     src: Operand::Virtual(rhs_vreg),
                 });
-                self.mir.push(X86Inst::Jmp { label: end_label.clone() });
+                self.mir.push(X86Inst::Jmp {
+                    label: end_label.clone(),
+                });
 
                 // Short-circuit path: result is true
                 self.mir.push(X86Inst::Label { name: true_label });
@@ -637,7 +669,11 @@ impl<'a> Lower<'a> {
                 self.mir.push(X86Inst::Label { name: end_label });
             }
 
-            AirInstData::Branch { cond, then_value, else_value } => {
+            AirInstData::Branch {
+                cond,
+                then_value,
+                else_value,
+            } => {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map[air_ref.as_u32() as usize] = Some(vreg);
 
@@ -657,7 +693,9 @@ impl<'a> Lower<'a> {
                         src: Operand::Virtual(cond_vreg),
                         imm: 0,
                     });
-                    self.mir.push(X86Inst::Jz { label: else_label.clone() });
+                    self.mir.push(X86Inst::Jz {
+                        label: else_label.clone(),
+                    });
 
                     // Then branch
                     // If then is Never (divergent), just lower it for side effects (the jump)
@@ -671,7 +709,9 @@ impl<'a> Lower<'a> {
                             dst: Operand::Virtual(vreg),
                             src: Operand::Virtual(then_vreg),
                         });
-                        self.mir.push(X86Inst::Jmp { label: end_label.clone() });
+                        self.mir.push(X86Inst::Jmp {
+                            label: end_label.clone(),
+                        });
                     }
 
                     // Else branch
@@ -699,7 +739,9 @@ impl<'a> Lower<'a> {
                         src: Operand::Virtual(cond_vreg),
                         imm: 0,
                     });
-                    self.mir.push(X86Inst::Jz { label: end_label.clone() });
+                    self.mir.push(X86Inst::Jz {
+                        label: end_label.clone(),
+                    });
 
                     // Then branch - even if it's Never, we still lower it
                     if then_type.is_never() {
@@ -742,7 +784,9 @@ impl<'a> Lower<'a> {
                 });
 
                 // Loop start label
-                self.mir.push(X86Inst::Label { name: loop_start.clone() });
+                self.mir.push(X86Inst::Label {
+                    name: loop_start.clone(),
+                });
 
                 // Evaluate condition fresh each iteration
                 // We need to re-lower it each time, but since we're in a loop,
@@ -757,15 +801,17 @@ impl<'a> Lower<'a> {
                 // Solution: Generate the condition check inline each iteration
                 // by re-lowering the condition instructions.
                 self.demand_lower(*cond);
-                let cond_vreg = self.value_map[cond.as_u32() as usize]
-                    .expect("condition should be lowered");
+                let cond_vreg =
+                    self.value_map[cond.as_u32() as usize].expect("condition should be lowered");
 
                 // If condition is false (zero), exit loop
                 self.mir.push(X86Inst::CmpRI {
                     src: Operand::Virtual(cond_vreg),
                     imm: 0,
                 });
-                self.mir.push(X86Inst::Jz { label: loop_end.clone() });
+                self.mir.push(X86Inst::Jz {
+                    label: loop_end.clone(),
+                });
 
                 // Execute body
                 self.demand_lower(*body);
@@ -807,7 +853,10 @@ impl<'a> Lower<'a> {
             AirInstData::Break => {
                 // Break: exit the innermost loop by jumping to its end label.
                 // The loop context was validated by Sema, so we know we're in a loop.
-                let ctx = self.loop_stack.last().expect("break outside loop should be caught by sema");
+                let ctx = self
+                    .loop_stack
+                    .last()
+                    .expect("break outside loop should be caught by sema");
                 let break_label = ctx.break_label.clone();
 
                 // Jump to loop end. No vreg allocation needed - break is a diverging
@@ -821,12 +870,17 @@ impl<'a> Lower<'a> {
                 // The values will be cleared when we reach the jump back at the normal
                 // end of the loop body. If we cleared here, we'd corrupt the ongoing
                 // lowering process.
-                let ctx = self.loop_stack.last().expect("continue outside loop should be caught by sema");
+                let ctx = self
+                    .loop_stack
+                    .last()
+                    .expect("continue outside loop should be caught by sema");
                 let continue_label = ctx.continue_label.clone();
 
                 // Jump to loop start (condition check). No vreg allocation needed -
                 // continue is a diverging control flow statement.
-                self.mir.push(X86Inst::Jmp { label: continue_label });
+                self.mir.push(X86Inst::Jmp {
+                    label: continue_label,
+                });
             }
 
             AirInstData::Ret(value_ref) => {
@@ -869,7 +923,9 @@ impl<'a> Lower<'a> {
                         AirInstData::StructInit { .. } => {
                             // Returning a struct literal - get field vregs from struct_field_vregs
                             self.demand_lower(*value_ref);
-                            if let Some(field_vregs) = self.struct_field_vregs.get(value_ref).cloned() {
+                            if let Some(field_vregs) =
+                                self.struct_field_vregs.get(value_ref).cloned()
+                            {
                                 // Move each field to the corresponding return register
                                 for (i, field_vreg) in field_vregs.iter().enumerate() {
                                     if i < RET_REGS.len() {
@@ -910,7 +966,9 @@ impl<'a> Lower<'a> {
                             // Returning result of another function call that returns a struct
                             // The call will have already set up struct_field_vregs for us
                             self.demand_lower(*value_ref);
-                            if let Some(field_vregs) = self.struct_field_vregs.get(value_ref).cloned() {
+                            if let Some(field_vregs) =
+                                self.struct_field_vregs.get(value_ref).cloned()
+                            {
                                 for (i, field_vreg) in field_vregs.iter().enumerate() {
                                     if i < RET_REGS.len() {
                                         self.mir.push(X86Inst::MovRR {
@@ -927,7 +985,9 @@ impl<'a> Lower<'a> {
                             // For now, just lower the branch and use its result
                             // (this works for single-field structs but needs more work for multi-field)
                             self.demand_lower(*value_ref);
-                            if let Some(field_vregs) = self.struct_field_vregs.get(value_ref).cloned() {
+                            if let Some(field_vregs) =
+                                self.struct_field_vregs.get(value_ref).cloned()
+                            {
                                 for (i, field_vreg) in field_vregs.iter().enumerate() {
                                     if i < RET_REGS.len() {
                                         self.mir.push(X86Inst::MovRR {
@@ -1326,7 +1386,10 @@ impl<'a> Lower<'a> {
                 }
             }
 
-            AirInstData::StructInit { struct_id: _, fields } => {
+            AirInstData::StructInit {
+                struct_id: _,
+                fields,
+            } => {
                 // Struct initialization: evaluate all fields and save their vregs.
                 // The actual storage to stack slots is handled by Alloc.
                 let vreg = self.mir.alloc_vreg();
@@ -1357,7 +1420,11 @@ impl<'a> Lower<'a> {
                 self.struct_field_vregs.insert(air_ref, field_vregs);
             }
 
-            AirInstData::FieldGet { base, struct_id: _, field_index } => {
+            AirInstData::FieldGet {
+                base,
+                struct_id: _,
+                field_index,
+            } => {
                 // Field access: load from base_slot + field_index.
                 // The base can be:
                 // - Load: struct is a local variable
@@ -1403,7 +1470,12 @@ impl<'a> Lower<'a> {
                 }
             }
 
-            AirInstData::FieldSet { slot, struct_id: _, field_index, value } => {
+            AirInstData::FieldSet {
+                slot,
+                struct_id: _,
+                field_index,
+                value,
+            } => {
                 // Field assignment: store value to slot + field_index
                 let value_vreg = self.get_vreg(*value);
 
@@ -1452,8 +1524,7 @@ impl<'a> Lower<'a> {
         self.lower_inst(air_ref, &data);
 
         // Should be lowered now
-        self.value_map[air_ref.as_u32() as usize]
-            .expect("instruction should have been lowered")
+        self.value_map[air_ref.as_u32() as usize].expect("instruction should have been lowered")
     }
 
     /// Lower an instruction for its side effects only, not expecting a value.
@@ -1536,7 +1607,11 @@ impl<'a> Lower<'a> {
                 }
                 self.clear_transitive_deps(value);
             }
-            AirInstData::Branch { cond, then_value, else_value } => {
+            AirInstData::Branch {
+                cond,
+                then_value,
+                else_value,
+            } => {
                 self.clear_transitive_deps(cond);
                 self.clear_transitive_deps(then_value);
                 if let Some(else_v) = else_value {

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -186,10 +186,18 @@ pub enum X86Inst {
     MovRR { dst: Operand, src: Operand },
 
     /// `mov dst, [base + offset]` - Load from memory (stack local).
-    MovRM { dst: Operand, base: Reg, offset: i32 },
+    MovRM {
+        dst: Operand,
+        base: Reg,
+        offset: i32,
+    },
 
     /// `mov [base + offset], src` - Store to memory (stack local).
-    MovMR { base: Reg, offset: i32, src: Operand },
+    MovMR {
+        base: Reg,
+        offset: i32,
+        src: Operand,
+    },
 
     // Arithmetic instructions
     /// `add dst, src` - Add src to dst (dst = dst + src).

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -23,7 +23,7 @@ mod regalloc;
 pub use cfg_lower::CfgLower;
 pub use emit::Emitter;
 pub use lower::Lower;
-pub use mir::{Operand, Reg, VReg, X86Mir, X86Inst};
+pub use mir::{Operand, Reg, VReg, X86Inst, X86Mir};
 pub use regalloc::RegAlloc;
 
 use rue_air::{Air, StructDef};
@@ -52,12 +52,14 @@ pub fn generate(
     // Phase 3: Allocate physical registers (may add spill slots)
     // Spill slots go after both locals AND parameters to avoid conflicts
     let existing_slots = num_locals + num_params;
-    let (mir, num_spills, used_callee_saved) = RegAlloc::new(mir, existing_slots).allocate_with_spills();
+    let (mir, num_spills, used_callee_saved) =
+        RegAlloc::new(mir, existing_slots).allocate_with_spills();
 
     // Phase 4: Emit machine code bytes (with prologue for stack frame setup)
     // Total local slots = local variables + spill slots (params handled separately)
     let total_locals = num_locals + num_spills;
-    let (code, relocations) = Emitter::new(&mir, total_locals, num_params, &used_callee_saved).emit();
+    let (code, relocations) =
+        Emitter::new(&mir, total_locals, num_params, &used_callee_saved).emit();
 
     MachineCode { code, relocations }
 }

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -240,30 +240,28 @@ impl RegAlloc {
                 }
             }
 
-            X86Inst::MovRI64 { dst, imm } => {
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(X86Inst::MovRI64 {
-                            dst: Operand::Physical(reg),
-                            imm,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(X86Inst::MovRI64 {
-                            dst: Operand::Physical(Reg::Rax),
-                            imm,
-                        });
-                        mir.push(X86Inst::MovMR {
-                            base: Reg::Rbp,
-                            offset,
-                            src: Operand::Physical(Reg::Rax),
-                        });
-                    }
-                    None => {
-                        mir.push(X86Inst::MovRI64 { dst, imm });
-                    }
+            X86Inst::MovRI64 { dst, imm } => match self.get_allocation(dst) {
+                Some(Allocation::Register(reg)) => {
+                    mir.push(X86Inst::MovRI64 {
+                        dst: Operand::Physical(reg),
+                        imm,
+                    });
                 }
-            }
+                Some(Allocation::Spill(offset)) => {
+                    mir.push(X86Inst::MovRI64 {
+                        dst: Operand::Physical(Reg::Rax),
+                        imm,
+                    });
+                    mir.push(X86Inst::MovMR {
+                        base: Reg::Rbp,
+                        offset,
+                        src: Operand::Physical(Reg::Rax),
+                    });
+                }
+                None => {
+                    mir.push(X86Inst::MovRI64 { dst, imm });
+                }
+            },
 
             X86Inst::MovRR { dst, src } => {
                 let src_op = self.load_operand(mir, src, Reg::Rax);
@@ -573,28 +571,26 @@ impl RegAlloc {
                 }
             }
 
-            X86Inst::Pop { dst } => {
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(X86Inst::Pop {
-                            dst: Operand::Physical(reg),
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(X86Inst::Pop {
-                            dst: Operand::Physical(Reg::Rax),
-                        });
-                        mir.push(X86Inst::MovMR {
-                            base: Reg::Rbp,
-                            offset,
-                            src: Operand::Physical(Reg::Rax),
-                        });
-                    }
-                    None => {
-                        mir.push(X86Inst::Pop { dst });
-                    }
+            X86Inst::Pop { dst } => match self.get_allocation(dst) {
+                Some(Allocation::Register(reg)) => {
+                    mir.push(X86Inst::Pop {
+                        dst: Operand::Physical(reg),
+                    });
                 }
-            }
+                Some(Allocation::Spill(offset)) => {
+                    mir.push(X86Inst::Pop {
+                        dst: Operand::Physical(Reg::Rax),
+                    });
+                    mir.push(X86Inst::MovMR {
+                        base: Reg::Rbp,
+                        offset,
+                        src: Operand::Physical(Reg::Rax),
+                    });
+                }
+                None => {
+                    mir.push(X86Inst::Pop { dst });
+                }
+            },
 
             X86Inst::Push { src } => {
                 let src_op = self.load_operand(mir, src, Reg::Rax);

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -504,7 +504,10 @@ mod tests {
         let magic = &output.elf[0..4];
         let is_elf = magic == &[0x7F, b'E', b'L', b'F'];
         let is_macho = magic == &0xFEEDFACF_u32.to_le_bytes(); // Mach-O 64-bit
-        assert!(is_elf || is_macho, "should produce valid ELF or Mach-O binary");
+        assert!(
+            is_elf || is_macho,
+            "should produce valid ELF or Mach-O binary"
+        );
     }
 
     #[test]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -164,18 +164,44 @@ impl fmt::Display for ErrorKind {
                     write!(f, "expected {} arguments, found {}", expected, found)
                 }
             }
-            ErrorKind::WrongFieldCount { struct_name, expected, found } => {
+            ErrorKind::WrongFieldCount {
+                struct_name,
+                expected,
+                found,
+            } => {
                 if *expected == 1 {
-                    write!(f, "struct '{}' has {} field, but {} were supplied", struct_name, expected, found)
+                    write!(
+                        f,
+                        "struct '{}' has {} field, but {} were supplied",
+                        struct_name, expected, found
+                    )
                 } else {
-                    write!(f, "struct '{}' has {} fields, but {} were supplied", struct_name, expected, found)
+                    write!(
+                        f,
+                        "struct '{}' has {} fields, but {} were supplied",
+                        struct_name, expected, found
+                    )
                 }
             }
-            ErrorKind::MissingField { struct_name, field_name } => {
-                write!(f, "missing field '{}' in struct '{}'", field_name, struct_name)
+            ErrorKind::MissingField {
+                struct_name,
+                field_name,
+            } => {
+                write!(
+                    f,
+                    "missing field '{}' in struct '{}'",
+                    field_name, struct_name
+                )
             }
-            ErrorKind::UnknownField { struct_name, field_name } => {
-                write!(f, "unknown field '{}' in struct '{}'", field_name, struct_name)
+            ErrorKind::UnknownField {
+                struct_name,
+                field_name,
+            } => {
+                write!(
+                    f,
+                    "unknown field '{}' in struct '{}'",
+                    field_name, struct_name
+                )
             }
             ErrorKind::FieldAccessOnNonStruct { found } => {
                 write!(f, "field access on non-struct type '{}'", found)
@@ -186,7 +212,11 @@ impl fmt::Display for ErrorKind {
             ErrorKind::BreakOutsideLoop => write!(f, "'break' outside of loop"),
             ErrorKind::ContinueOutsideLoop => write!(f, "'continue' outside of loop"),
             ErrorKind::UnknownIntrinsic(name) => write!(f, "unknown intrinsic '@{}'", name),
-            ErrorKind::IntrinsicWrongArgCount { name, expected, found } => {
+            ErrorKind::IntrinsicWrongArgCount {
+                name,
+                expected,
+                found,
+            } => {
                 if *expected == 1 {
                     write!(
                         f,
@@ -201,7 +231,11 @@ impl fmt::Display for ErrorKind {
                     )
                 }
             }
-            ErrorKind::IntrinsicTypeMismatch { name, expected, found } => {
+            ErrorKind::IntrinsicTypeMismatch {
+                name,
+                expected,
+                found,
+            } => {
                 write!(
                     f,
                     "intrinsic '@{}' expects {}, found {}",
@@ -326,9 +360,7 @@ mod tests {
 
     #[test]
     fn test_unexpected_eof_message() {
-        let error = CompileError::without_span(ErrorKind::UnexpectedEof {
-            expected: "'}'",
-        });
+        let error = CompileError::without_span(ErrorKind::UnexpectedEof { expected: "'}'" });
         assert_eq!(error.to_string(), "unexpected end of file, expected '}'");
     }
 
@@ -385,7 +417,8 @@ mod tests {
 
     #[test]
     fn test_link_error_message() {
-        let error = CompileError::without_span(ErrorKind::LinkError("undefined symbol".to_string()));
+        let error =
+            CompileError::without_span(ErrorKind::LinkError("undefined symbol".to_string()));
         assert_eq!(error.to_string(), "link error: undefined symbol");
     }
 

--- a/crates/rue-intern/src/lib.rs
+++ b/crates/rue-intern/src/lib.rs
@@ -126,7 +126,9 @@ impl Interner {
     /// Get the well-known symbols.
     #[inline]
     pub fn well_known(&self) -> &WellKnown {
-        self.well_known.as_ref().expect("well_known not initialized")
+        self.well_known
+            .as_ref()
+            .expect("well_known not initialized")
     }
 
     /// Internal interning used during initialization.

--- a/crates/rue-linker/src/archive.rs
+++ b/crates/rue-linker/src/archive.rs
@@ -92,9 +92,9 @@ impl Archive {
             let size_str = std::str::from_utf8(&header[48..58])
                 .map_err(|_| ArchiveError::InvalidHeader("invalid size encoding".into()))?
                 .trim();
-            let size: usize = size_str
-                .parse()
-                .map_err(|_| ArchiveError::InvalidHeader(format!("invalid size: '{}'", size_str)))?;
+            let size: usize = size_str.parse().map_err(|_| {
+                ArchiveError::InvalidHeader(format!("invalid size: '{}'", size_str))
+            })?;
 
             // Header terminator should be "`\n"
             if &header[58..60] != b"`\n" {

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -18,7 +18,12 @@ fn read_u16(data: &[u8], offset: usize) -> u16 {
 /// Panics if offset + 4 > slice.len(), so caller must ensure bounds.
 #[inline]
 fn read_u32(data: &[u8], offset: usize) -> u32 {
-    u32::from_le_bytes([data[offset], data[offset + 1], data[offset + 2], data[offset + 3]])
+    u32::from_le_bytes([
+        data[offset],
+        data[offset + 1],
+        data[offset + 2],
+        data[offset + 3],
+    ])
 }
 
 /// Helper to read a u64 from a byte slice at a given offset.
@@ -26,8 +31,14 @@ fn read_u32(data: &[u8], offset: usize) -> u32 {
 #[inline]
 fn read_u64(data: &[u8], offset: usize) -> u64 {
     u64::from_le_bytes([
-        data[offset], data[offset + 1], data[offset + 2], data[offset + 3],
-        data[offset + 4], data[offset + 5], data[offset + 6], data[offset + 7],
+        data[offset],
+        data[offset + 1],
+        data[offset + 2],
+        data[offset + 3],
+        data[offset + 4],
+        data[offset + 5],
+        data[offset + 6],
+        data[offset + 7],
     ])
 }
 
@@ -36,8 +47,14 @@ fn read_u64(data: &[u8], offset: usize) -> u64 {
 #[inline]
 fn read_i64(data: &[u8], offset: usize) -> i64 {
     i64::from_le_bytes([
-        data[offset], data[offset + 1], data[offset + 2], data[offset + 3],
-        data[offset + 4], data[offset + 5], data[offset + 6], data[offset + 7],
+        data[offset],
+        data[offset + 1],
+        data[offset + 2],
+        data[offset + 3],
+        data[offset + 4],
+        data[offset + 5],
+        data[offset + 6],
+        data[offset + 7],
     ])
 }
 
@@ -276,7 +293,9 @@ impl ObjectFile {
 
         // ELF64 section headers are 64 bytes
         if e_shentsize < 64 && e_shnum > 0 {
-            return Err(ParseError::InvalidSection("section header size too small".into()));
+            return Err(ParseError::InvalidSection(
+                "section header size too small".into(),
+            ));
         }
 
         // Parse section headers
@@ -303,7 +322,9 @@ impl ObjectFile {
         for i in 0..e_shnum {
             let sh_offset = e_shoff + i * e_shentsize;
             if sh_offset + e_shentsize > data.len() {
-                return Err(ParseError::InvalidSection("section header out of bounds".into()));
+                return Err(ParseError::InvalidSection(
+                    "section header out of bounds".into(),
+                ));
             }
 
             let sh = &data[sh_offset..sh_offset + e_shentsize];
@@ -344,7 +365,9 @@ impl ObjectFile {
             return Err(ParseError::InvalidShstrndx);
         }
         let shstrtab = &raw_sections[e_shstrndx];
-        let shstrtab_end = shstrtab.offset.checked_add(shstrtab.size)
+        let shstrtab_end = shstrtab
+            .offset
+            .checked_add(shstrtab.size)
             .ok_or_else(|| ParseError::SectionOutOfBounds("shstrtab overflow".into()))?;
         if shstrtab_end as usize > data.len() {
             return Err(ParseError::SectionOutOfBounds("shstrtab".into()));
@@ -383,7 +406,9 @@ impl ObjectFile {
             }
 
             let section_data = if raw.size > 0 && raw.offset > 0 {
-                let section_end = raw.offset.checked_add(raw.size)
+                let section_end = raw
+                    .offset
+                    .checked_add(raw.size)
                     .ok_or_else(|| ParseError::SectionOutOfBounds(format!("{} overflow", name)))?;
                 if section_end as usize > data.len() {
                     return Err(ParseError::SectionOutOfBounds(name.clone()));
@@ -425,7 +450,9 @@ impl ObjectFile {
             let strtab = &raw_sections[strtab_i];
 
             // Validate strtab bounds
-            let strtab_end = strtab.offset.checked_add(strtab.size)
+            let strtab_end = strtab
+                .offset
+                .checked_add(strtab.size)
                 .ok_or_else(|| ParseError::InvalidSymbol("strtab overflow".into()))?;
             if strtab_end as usize > data.len() {
                 return Err(ParseError::InvalidSymbol("strtab out of bounds".into()));
@@ -433,7 +460,9 @@ impl ObjectFile {
             let strtab_data = &data[strtab.offset as usize..strtab_end as usize];
 
             // Validate symtab bounds
-            let symtab_end = symtab.offset.checked_add(symtab.size)
+            let symtab_end = symtab
+                .offset
+                .checked_add(symtab.size)
                 .ok_or_else(|| ParseError::InvalidSymbol("symtab overflow".into()))?;
             if symtab_end as usize > data.len() {
                 return Err(ParseError::InvalidSymbol("symtab out of bounds".into()));
@@ -447,7 +476,9 @@ impl ObjectFile {
             for i in 0..sym_count {
                 let sym_offset = (i * symtab.entsize) as usize;
                 if sym_offset + 24 > symtab_data.len() {
-                    return Err(ParseError::InvalidSymbol("symbol entry out of bounds".into()));
+                    return Err(ParseError::InvalidSymbol(
+                        "symbol entry out of bounds".into(),
+                    ));
                 }
                 let sym = &symtab_data[sym_offset..sym_offset + 24];
 
@@ -508,7 +539,9 @@ impl ObjectFile {
             }
 
             // Validate relocation section bounds
-            let rela_end = raw.offset.checked_add(raw.size)
+            let rela_end = raw
+                .offset
+                .checked_add(raw.size)
                 .ok_or(ParseError::RelocationOutOfBounds)?;
             if rela_end as usize > data.len() {
                 return Err(ParseError::RelocationOutOfBounds);
@@ -559,8 +592,8 @@ impl ObjectFile {
     /// Get all global/defined symbols.
     pub fn defined_symbols(&self) -> impl Iterator<Item = &Symbol> {
         self.symbols.iter().filter(|s| {
-            s.section_index.is_some() &&
-            (s.binding == SymbolBinding::Global || s.binding == SymbolBinding::Weak)
+            s.section_index.is_some()
+                && (s.binding == SymbolBinding::Global || s.binding == SymbolBinding::Weak)
         })
     }
 }
@@ -571,31 +604,70 @@ mod tests {
 
     #[test]
     fn test_parse_error_display() {
-        assert_eq!(ParseError::InvalidMagic.to_string(), "invalid ELF magic number");
-        assert_eq!(ParseError::TooShort.to_string(), "file is too short to be a valid ELF");
+        assert_eq!(
+            ParseError::InvalidMagic.to_string(),
+            "invalid ELF magic number"
+        );
+        assert_eq!(
+            ParseError::TooShort.to_string(),
+            "file is too short to be a valid ELF"
+        );
         assert_eq!(ParseError::Not64Bit.to_string(), "not a 64-bit ELF file");
-        assert_eq!(ParseError::NotLittleEndian.to_string(), "not a little-endian ELF file");
-        assert_eq!(ParseError::NotRelocatable.to_string(), "not a relocatable object file");
-        assert_eq!(ParseError::NotX86_64.to_string(), "not an x86-64 object file");
-        assert_eq!(ParseError::InvalidSection("test".into()).to_string(), "invalid section: test");
-        assert_eq!(ParseError::InvalidSymbol("test".into()).to_string(), "invalid symbol: test");
-        assert_eq!(ParseError::InvalidStringTable.to_string(), "invalid string table");
-        assert_eq!(ParseError::InvalidShstrndx.to_string(), "invalid section header string table index");
-        assert_eq!(ParseError::SectionOutOfBounds("test".into()).to_string(), "section data out of bounds: test");
-        assert_eq!(ParseError::RelocationOutOfBounds.to_string(), "relocation data out of bounds");
+        assert_eq!(
+            ParseError::NotLittleEndian.to_string(),
+            "not a little-endian ELF file"
+        );
+        assert_eq!(
+            ParseError::NotRelocatable.to_string(),
+            "not a relocatable object file"
+        );
+        assert_eq!(
+            ParseError::NotX86_64.to_string(),
+            "not an x86-64 object file"
+        );
+        assert_eq!(
+            ParseError::InvalidSection("test".into()).to_string(),
+            "invalid section: test"
+        );
+        assert_eq!(
+            ParseError::InvalidSymbol("test".into()).to_string(),
+            "invalid symbol: test"
+        );
+        assert_eq!(
+            ParseError::InvalidStringTable.to_string(),
+            "invalid string table"
+        );
+        assert_eq!(
+            ParseError::InvalidShstrndx.to_string(),
+            "invalid section header string table index"
+        );
+        assert_eq!(
+            ParseError::SectionOutOfBounds("test".into()).to_string(),
+            "section data out of bounds: test"
+        );
+        assert_eq!(
+            ParseError::RelocationOutOfBounds.to_string(),
+            "relocation data out of bounds"
+        );
     }
 
     #[test]
     fn test_too_short() {
         let data = [0u8; 32];
-        assert!(matches!(ObjectFile::parse(&data), Err(ParseError::TooShort)));
+        assert!(matches!(
+            ObjectFile::parse(&data),
+            Err(ParseError::TooShort)
+        ));
     }
 
     #[test]
     fn test_invalid_magic() {
         let mut data = [0u8; 64];
         data[0..4].copy_from_slice(b"NOTF");
-        assert!(matches!(ObjectFile::parse(&data), Err(ParseError::InvalidMagic)));
+        assert!(matches!(
+            ObjectFile::parse(&data),
+            Err(ParseError::InvalidMagic)
+        ));
     }
 
     #[test]
@@ -603,7 +675,10 @@ mod tests {
         let mut data = [0u8; 64];
         data[0..4].copy_from_slice(b"\x7FELF");
         data[4] = 1; // 32-bit
-        assert!(matches!(ObjectFile::parse(&data), Err(ParseError::Not64Bit)));
+        assert!(matches!(
+            ObjectFile::parse(&data),
+            Err(ParseError::Not64Bit)
+        ));
     }
 
     #[test]
@@ -612,7 +687,10 @@ mod tests {
         data[0..4].copy_from_slice(b"\x7FELF");
         data[4] = 2; // 64-bit
         data[5] = 2; // Big endian
-        assert!(matches!(ObjectFile::parse(&data), Err(ParseError::NotLittleEndian)));
+        assert!(matches!(
+            ObjectFile::parse(&data),
+            Err(ParseError::NotLittleEndian)
+        ));
     }
 
     #[test]
@@ -622,7 +700,10 @@ mod tests {
         data[4] = 2; // 64-bit
         data[5] = 1; // Little endian
         data[16..18].copy_from_slice(&2_u16.to_le_bytes()); // ET_EXEC instead of ET_REL
-        assert!(matches!(ObjectFile::parse(&data), Err(ParseError::NotRelocatable)));
+        assert!(matches!(
+            ObjectFile::parse(&data),
+            Err(ParseError::NotRelocatable)
+        ));
     }
 
     #[test]
@@ -633,7 +714,10 @@ mod tests {
         data[5] = 1; // Little endian
         data[16..18].copy_from_slice(&1_u16.to_le_bytes()); // ET_REL
         data[18..20].copy_from_slice(&0x03_u16.to_le_bytes()); // EM_386 instead of EM_X86_64
-        assert!(matches!(ObjectFile::parse(&data), Err(ParseError::NotX86_64)));
+        assert!(matches!(
+            ObjectFile::parse(&data),
+            Err(ParseError::NotX86_64)
+        ));
     }
 
     #[test]
@@ -646,7 +730,10 @@ mod tests {
         data[18..20].copy_from_slice(&0x3E_u16.to_le_bytes()); // EM_X86_64
         data[58..60].copy_from_slice(&32_u16.to_le_bytes()); // e_shentsize = 32 (too small)
         data[60..62].copy_from_slice(&1_u16.to_le_bytes()); // e_shnum = 1
-        assert!(matches!(ObjectFile::parse(&data), Err(ParseError::InvalidSection(_))));
+        assert!(matches!(
+            ObjectFile::parse(&data),
+            Err(ParseError::InvalidSection(_))
+        ));
     }
 
     #[test]
@@ -660,7 +747,10 @@ mod tests {
         data[58..60].copy_from_slice(&64_u16.to_le_bytes()); // e_shentsize = 64
         data[60..62].copy_from_slice(&0_u16.to_le_bytes()); // e_shnum = 0
         data[62..64].copy_from_slice(&5_u16.to_le_bytes()); // e_shstrndx = 5 (invalid)
-        assert!(matches!(ObjectFile::parse(&data), Err(ParseError::InvalidShstrndx)));
+        assert!(matches!(
+            ObjectFile::parse(&data),
+            Err(ParseError::InvalidShstrndx)
+        ));
     }
 
     #[test]
@@ -685,7 +775,10 @@ mod tests {
         data[sh_offset + 24..sh_offset + 32].copy_from_slice(&1000_u64.to_le_bytes());
         data[sh_offset + 32..sh_offset + 40].copy_from_slice(&100_u64.to_le_bytes()); // size
 
-        assert!(matches!(ObjectFile::parse(&data), Err(ParseError::SectionOutOfBounds(_))));
+        assert!(matches!(
+            ObjectFile::parse(&data),
+            Err(ParseError::SectionOutOfBounds(_))
+        ));
     }
 
     #[test]
@@ -748,6 +841,9 @@ mod tests {
         data[62..64].copy_from_slice(&0_u16.to_le_bytes()); // e_shstrndx = 0
 
         // This should fail because shstrndx=0 but there are no sections
-        assert!(matches!(ObjectFile::parse(&data), Err(ParseError::InvalidShstrndx)));
+        assert!(matches!(
+            ObjectFile::parse(&data),
+            Err(ParseError::InvalidShstrndx)
+        ));
     }
 }

--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -76,7 +76,7 @@ impl ObjectBuilder {
 
         // String tables
         let mut shstrtab = vec![0u8]; // Section header string table
-        let mut strtab = vec![0u8];   // Symbol string table
+        let mut strtab = vec![0u8]; // Symbol string table
 
         // Add section names to shstrtab
         let shstrtab_text = shstrtab.len();
@@ -122,7 +122,7 @@ impl ObjectBuilder {
         // Symbol 1: .text section symbol
         symtab.extend_from_slice(&0_u32.to_le_bytes()); // st_name (empty)
         symtab.push(0x03); // st_info: STB_LOCAL, STT_SECTION
-        symtab.push(0);    // st_other
+        symtab.push(0); // st_other
         symtab.extend_from_slice(&1_u16.to_le_bytes()); // st_shndx: .text section
         symtab.extend_from_slice(&0_u64.to_le_bytes()); // st_value
         symtab.extend_from_slice(&0_u64.to_le_bytes()); // st_size
@@ -130,7 +130,7 @@ impl ObjectBuilder {
         // Symbol 2: the function (global)
         symtab.extend_from_slice(&(strtab_name as u32).to_le_bytes()); // st_name
         symtab.push(0x12); // st_info: STB_GLOBAL, STT_FUNC
-        symtab.push(0);    // st_other
+        symtab.push(0); // st_other
         symtab.extend_from_slice(&1_u16.to_le_bytes()); // st_shndx: .text
         symtab.extend_from_slice(&0_u64.to_le_bytes()); // st_value
         symtab.extend_from_slice(&(self.code.len() as u64).to_le_bytes()); // st_size
@@ -140,7 +140,7 @@ impl ObjectBuilder {
         for (i, _sym) in extern_symbols.iter().enumerate() {
             symtab.extend_from_slice(&(extern_symbol_offsets[i] as u32).to_le_bytes()); // st_name
             symtab.push(0x10); // st_info: STB_GLOBAL, STT_NOTYPE
-            symtab.push(0);    // st_other
+            symtab.push(0); // st_other
             symtab.extend_from_slice(&0_u16.to_le_bytes()); // st_shndx: SHN_UNDEF
             symtab.extend_from_slice(&0_u64.to_le_bytes()); // st_value
             symtab.extend_from_slice(&0_u64.to_le_bytes()); // st_size
@@ -149,7 +149,11 @@ impl ObjectBuilder {
         // Build relocation table
         let mut rela = Vec::new();
         for reloc in &self.relocations {
-            let sym_idx = extern_symbols.iter().position(|s| s == &reloc.symbol).unwrap() + first_extern_sym;
+            let sym_idx = extern_symbols
+                .iter()
+                .position(|s| s == &reloc.symbol)
+                .unwrap()
+                + first_extern_sym;
             let r_type: u32 = match reloc.rel_type {
                 RelocationType::Abs64 => 1,
                 RelocationType::Pc32 => 2,
@@ -442,7 +446,9 @@ impl ObjectBuilder {
         macho.extend_from_slice(&2_u32.to_le_bytes()); // align (2^2 = 4 byte alignment)
         macho.extend_from_slice(&(reloc_offset as u32).to_le_bytes()); // reloff
         macho.extend_from_slice(&(num_relocs as u32).to_le_bytes()); // nreloc
-        macho.extend_from_slice(&(S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS).to_le_bytes()); // flags
+        macho.extend_from_slice(
+            &(S_ATTR_PURE_INSTRUCTIONS | S_ATTR_SOME_INSTRUCTIONS).to_le_bytes(),
+        ); // flags
         macho.extend_from_slice(&0_u32.to_le_bytes()); // reserved1
         macho.extend_from_slice(&0_u32.to_le_bytes()); // reserved2
         macho.extend_from_slice(&0_u32.to_le_bytes()); // reserved3 (64-bit only)
@@ -506,7 +512,7 @@ impl ObjectBuilder {
                 | (1 << 24)  // r_pcrel (bit 24)
                 | (2 << 25)  // r_length (bits 25-26) - 2 means 4 bytes
                 | (1 << 27)  // r_extern (bit 27)
-                | (r_type << 28);  // r_type (bits 28-31)
+                | (r_type << 28); // r_type (bits 28-31)
             macho.extend_from_slice(&info.to_le_bytes());
         }
 
@@ -524,7 +530,7 @@ impl ObjectBuilder {
         // n_value: 8 bytes
 
         // Symbol constants
-        const N_EXT: u8 = 0x01;  // External symbol
+        const N_EXT: u8 = 0x01; // External symbol
         const N_SECT: u8 = 0x0E; // Defined in section
 
         // Local symbol: the function itself
@@ -685,10 +691,16 @@ mod tests {
         assert!(callee.section_index.is_none(), "callee should be undefined");
 
         // Verify relocations exist
-        let text_section = parsed.sections.iter()
+        let text_section = parsed
+            .sections
+            .iter()
             .find(|s| s.name == ".text")
             .expect("should have .text section");
-        assert_eq!(text_section.relocations.len(), 1, "should have one relocation");
+        assert_eq!(
+            text_section.relocations.len(),
+            1,
+            "should have one relocation"
+        );
         assert_eq!(text_section.relocations[0].offset, 1);
         assert_eq!(text_section.relocations[0].addend, -4);
     }
@@ -725,15 +737,19 @@ mod tests {
         let parsed = ObjectFile::parse(&built).expect("should parse built object");
 
         // Verify the text section has 3 relocations
-        let text_section = parsed.sections.iter()
+        let text_section = parsed
+            .sections
+            .iter()
             .find(|s| s.name == ".text")
             .expect("should have .text section");
-        assert_eq!(text_section.relocations.len(), 3, "should have three relocations");
+        assert_eq!(
+            text_section.relocations.len(),
+            3,
+            "should have three relocations"
+        );
 
         // func1 should only appear once in the symbol table
-        let func1_count = parsed.symbols.iter()
-            .filter(|s| s.name == "func1")
-            .count();
+        let func1_count = parsed.symbols.iter().filter(|s| s.name == "func1").count();
         assert_eq!(func1_count, 1, "func1 should appear once in symbol table");
     }
 
@@ -772,9 +788,12 @@ mod tests {
             })
             .build();
 
-        let parsed = ObjectFile::parse(&built).expect("should parse object with various reloc types");
+        let parsed =
+            ObjectFile::parse(&built).expect("should parse object with various reloc types");
 
-        let text_section = parsed.sections.iter()
+        let text_section = parsed
+            .sections
+            .iter()
             .find(|s| s.name == ".text")
             .expect("should have .text section");
         assert_eq!(text_section.relocations.len(), 3);

--- a/crates/rue-linker/src/lib.rs
+++ b/crates/rue-linker/src/lib.rs
@@ -16,6 +16,6 @@ mod emit;
 mod linker;
 
 pub use archive::{Archive, ArchiveError};
-pub use elf::{ObjectFile, Section, Symbol, Relocation, RelocationType};
-pub use emit::{ObjectBuilder, CodeRelocation};
-pub use linker::{Linker, LinkError};
+pub use elf::{ObjectFile, Relocation, RelocationType, Section, Symbol};
+pub use emit::{CodeRelocation, ObjectBuilder};
+pub use linker::{LinkError, Linker};

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -67,21 +67,24 @@ impl Linker {
 
         // Collect global symbols
         for sym in &obj.symbols {
-            if sym.section_index.is_some() &&
-               (sym.binding == SymbolBinding::Global || sym.binding == SymbolBinding::Weak) &&
-               !sym.name.is_empty()
+            if sym.section_index.is_some()
+                && (sym.binding == SymbolBinding::Global || sym.binding == SymbolBinding::Weak)
+                && !sym.name.is_empty()
             {
                 if let Some((_, existing)) = self.global_symbols.get(&sym.name) {
                     // Allow weak symbols to be overridden
-                    if existing.binding != SymbolBinding::Weak && sym.binding != SymbolBinding::Weak {
+                    if existing.binding != SymbolBinding::Weak && sym.binding != SymbolBinding::Weak
+                    {
                         return Err(LinkError::DuplicateSymbol(sym.name.clone()));
                     }
                     // Keep the non-weak one
                     if existing.binding == SymbolBinding::Weak {
-                        self.global_symbols.insert(sym.name.clone(), (obj_index, sym.clone()));
+                        self.global_symbols
+                            .insert(sym.name.clone(), (obj_index, sym.clone()));
                     }
                 } else {
-                    self.global_symbols.insert(sym.name.clone(), (obj_index, sym.clone()));
+                    self.global_symbols
+                        .insert(sym.name.clone(), (obj_index, sym.clone()));
                 }
             }
         }
@@ -132,11 +135,8 @@ impl Linker {
 
         // Track which archive objects we've selected and which symbols are defined
         let mut selected: Vec<bool> = vec![false; archive_objects.len()];
-        let mut defined_symbols: std::collections::HashSet<String> = self
-            .global_symbols
-            .keys()
-            .cloned()
-            .collect();
+        let mut defined_symbols: std::collections::HashSet<String> =
+            self.global_symbols.keys().cloned().collect();
 
         // Iterate until we reach a fixed point
         loop {
@@ -268,7 +268,8 @@ impl Linker {
                 }
 
                 let align = section.align.max(1);
-                let padding = align_up(merged_rodata.len() as u64, align) - merged_rodata.len() as u64;
+                let padding =
+                    align_up(merged_rodata.len() as u64, align) - merged_rodata.len() as u64;
                 merged_rodata.extend(std::iter::repeat(0).take(padding as usize));
 
                 let offset = merged_rodata.len() as u64;
@@ -305,9 +306,10 @@ impl Linker {
                         let addr = base + section_offset + sym.value;
 
                         // Only add global symbols, or section symbols for relocation
-                        if sym.binding == SymbolBinding::Global ||
-                           sym.binding == SymbolBinding::Weak ||
-                           !symbol_addresses.contains_key(&sym.name) {
+                        if sym.binding == SymbolBinding::Global
+                            || sym.binding == SymbolBinding::Weak
+                            || !symbol_addresses.contains_key(&sym.name)
+                        {
                             symbol_addresses.insert(sym.name.clone(), addr);
                         }
                     }
@@ -329,7 +331,8 @@ impl Linker {
         }
 
         // Find entry point
-        let entry_addr = *symbol_addresses.get(entry_point)
+        let entry_addr = *symbol_addresses
+            .get(entry_point)
             .ok_or_else(|| LinkError::UndefinedSymbol(entry_point.to_string()))?;
 
         // Apply relocations
@@ -372,9 +375,10 @@ impl Linker {
                         });
                     }
                     if patch_offset + 4 > merged_code.len() {
-                        return Err(LinkError::UnsupportedRelocation(
-                            format!("patch offset {} out of bounds", patch_offset)
-                        ));
+                        return Err(LinkError::UnsupportedRelocation(format!(
+                            "patch offset {} out of bounds",
+                            patch_offset
+                        )));
                     }
                     merged_code[patch_offset..patch_offset + 4]
                         .copy_from_slice(&(value as i32).to_le_bytes());
@@ -382,9 +386,10 @@ impl Linker {
                 RelocationType::Abs64 => {
                     let value = (target_addr as i64 + addend) as u64;
                     if patch_offset + 8 > merged_code.len() {
-                        return Err(LinkError::UnsupportedRelocation(
-                            format!("patch offset {} out of bounds", patch_offset)
-                        ));
+                        return Err(LinkError::UnsupportedRelocation(format!(
+                            "patch offset {} out of bounds",
+                            patch_offset
+                        )));
                     }
                     merged_code[patch_offset..patch_offset + 8]
                         .copy_from_slice(&value.to_le_bytes());
@@ -399,9 +404,10 @@ impl Linker {
                         });
                     }
                     if patch_offset + 4 > merged_code.len() {
-                        return Err(LinkError::UnsupportedRelocation(
-                            format!("patch offset {} out of bounds", patch_offset)
-                        ));
+                        return Err(LinkError::UnsupportedRelocation(format!(
+                            "patch offset {} out of bounds",
+                            patch_offset
+                        )));
                     }
                     merged_code[patch_offset..patch_offset + 4]
                         .copy_from_slice(&(value as u32).to_le_bytes());
@@ -416,9 +422,10 @@ impl Linker {
                         });
                     }
                     if patch_offset + 4 > merged_code.len() {
-                        return Err(LinkError::UnsupportedRelocation(
-                            format!("patch offset {} out of bounds", patch_offset)
-                        ));
+                        return Err(LinkError::UnsupportedRelocation(format!(
+                            "patch offset {} out of bounds",
+                            patch_offset
+                        )));
                     }
                     merged_code[patch_offset..patch_offset + 4]
                         .copy_from_slice(&(value as i32).to_le_bytes());
@@ -437,20 +444,26 @@ impl Linker {
                         });
                     }
                     if patch_offset + 4 > merged_code.len() {
-                        return Err(LinkError::UnsupportedRelocation(
-                            format!("patch offset {} out of bounds", patch_offset)
-                        ));
+                        return Err(LinkError::UnsupportedRelocation(format!(
+                            "patch offset {} out of bounds",
+                            patch_offset
+                        )));
                     }
                     // Read existing instruction and patch the immediate field
                     let mut inst = u32::from_le_bytes(
-                        merged_code[patch_offset..patch_offset + 4].try_into().unwrap()
+                        merged_code[patch_offset..patch_offset + 4]
+                            .try_into()
+                            .unwrap(),
                     );
                     inst = (inst & 0xFC000000) | ((offset as u32) & 0x03FFFFFF);
                     merged_code[patch_offset..patch_offset + 4]
                         .copy_from_slice(&inst.to_le_bytes());
                 }
                 RelocationType::Unknown(t) => {
-                    return Err(LinkError::UnsupportedRelocation(format!("unknown type {}", t)));
+                    return Err(LinkError::UnsupportedRelocation(format!(
+                        "unknown type {}",
+                        t
+                    )));
                 }
             }
         }
@@ -518,8 +531,8 @@ fn align_up(value: u64, align: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::emit::{ObjectBuilder, CodeRelocation};
     use crate::elf::ObjectFile;
+    use crate::emit::{CodeRelocation, ObjectBuilder};
 
     // Use X86_64Linux explicitly for ELF tests since ObjectFile only parses ELF
     // and the Linker produces ELF executables
@@ -559,7 +572,8 @@ mod tests {
             LinkError::RelocationOverflow {
                 symbol: "sym".into(),
                 rel_type: "Pc32".into(),
-            }.to_string(),
+            }
+            .to_string(),
             "relocation overflow for sym (Pc32)"
         );
     }
@@ -570,7 +584,7 @@ mod tests {
         let obj_bytes = ObjectBuilder::new(ELF_TARGET, "main")
             .code(vec![
                 0xB8, 0x2A, 0x00, 0x00, 0x00, // mov eax, 42
-                0xC3,                         // ret
+                0xC3, // ret
             ])
             .build();
 
@@ -608,7 +622,7 @@ mod tests {
         let callee_bytes = ObjectBuilder::new(ELF_TARGET, "callee")
             .code(vec![
                 0xB8, 0x01, 0x00, 0x00, 0x00, // mov eax, 1
-                0xC3,                         // ret
+                0xC3, // ret
             ])
             .build();
 
@@ -616,7 +630,7 @@ mod tests {
         let caller_bytes = ObjectBuilder::new(ELF_TARGET, "main")
             .code(vec![
                 0xE8, 0x00, 0x00, 0x00, 0x00, // call callee (placeholder)
-                0xC3,                         // ret
+                0xC3, // ret
             ])
             .relocation(CodeRelocation {
                 offset: 1,
@@ -699,16 +713,19 @@ mod tests {
         let elf = linker.link("main").unwrap();
 
         // Check ELF header fields
-        assert_eq!(&elf[0..4], b"\x7FELF");  // Magic
-        assert_eq!(elf[4], 2);               // 64-bit
-        assert_eq!(elf[5], 1);               // Little endian
-        assert_eq!(elf[6], 1);               // ELF version
-        assert_eq!(elf[16], 2);              // ET_EXEC
+        assert_eq!(&elf[0..4], b"\x7FELF"); // Magic
+        assert_eq!(elf[4], 2); // 64-bit
+        assert_eq!(elf[5], 1); // Little endian
+        assert_eq!(elf[6], 1); // ELF version
+        assert_eq!(elf[16], 2); // ET_EXEC
         assert_eq!(u16::from_le_bytes([elf[18], elf[19]]), 0x3E); // x86-64
 
         // Check entry point is set (bytes 24-31)
         let entry = u64::from_le_bytes(elf[24..32].try_into().unwrap());
-        assert!(entry >= 0x400000, "entry point should be at or above base address");
+        assert!(
+            entry >= 0x400000,
+            "entry point should be at or above base address"
+        );
     }
 
     #[test]
@@ -728,11 +745,11 @@ mod tests {
         let ph_offset = 64;
 
         // p_type = PT_LOAD (1)
-        let p_type = u32::from_le_bytes(elf[ph_offset..ph_offset+4].try_into().unwrap());
+        let p_type = u32::from_le_bytes(elf[ph_offset..ph_offset + 4].try_into().unwrap());
         assert_eq!(p_type, 1);
 
         // p_flags = PF_R | PF_W | PF_X (7)
-        let p_flags = u32::from_le_bytes(elf[ph_offset+4..ph_offset+8].try_into().unwrap());
+        let p_flags = u32::from_le_bytes(elf[ph_offset + 4..ph_offset + 8].try_into().unwrap());
         assert_eq!(p_flags, 7);
     }
 
@@ -754,7 +771,7 @@ mod tests {
         let helper1_bytes = ObjectBuilder::new(ELF_TARGET, "helper1")
             .code(vec![
                 0xB8, 0x0A, 0x00, 0x00, 0x00, // mov eax, 10
-                0xC3,                         // ret
+                0xC3, // ret
             ])
             .build();
 
@@ -762,7 +779,7 @@ mod tests {
         let helper2_bytes = ObjectBuilder::new(ELF_TARGET, "helper2")
             .code(vec![
                 0xB8, 0x20, 0x00, 0x00, 0x00, // mov eax, 32
-                0xC3,                         // ret
+                0xC3, // ret
             ])
             .build();
 
@@ -773,14 +790,11 @@ mod tests {
                 // call helper1
                 0xE8, 0x00, 0x00, 0x00, 0x00, // call helper1 (offset 1)
                 // push rax (save result)
-                0x50,
-                // call helper2
+                0x50, // call helper2
                 0xE8, 0x00, 0x00, 0x00, 0x00, // call helper2 (offset 7)
                 // pop rbx
-                0x5B,
-                // add eax, ebx
-                0x01, 0xD8,
-                // ret
+                0x5B, // add eax, ebx
+                0x01, 0xD8, // ret
                 0xC3,
             ])
             .relocation(CodeRelocation {

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -10,8 +10,8 @@ use crate::ast::{
     UnaryExpr, UnaryOp, WhileExpr,
 };
 use chumsky::input::{Input as ChumskyInput, Stream, ValueInput};
-use chumsky::prelude::*;
 use chumsky::pratt::{infix, left, prefix};
+use chumsky::prelude::*;
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_lexer::TokenKind;
 use rue_span::Span;
@@ -50,8 +50,8 @@ where
 }
 
 /// Parser for struct field declarations: name: type
-fn field_decl_parser<'src, I>(
-) -> impl Parser<'src, I, FieldDecl, extra::Err<Rich<'src, TokenKind>>> + Clone
+fn field_decl_parser<'src, I>()
+-> impl Parser<'src, I, FieldDecl, extra::Err<Rich<'src, TokenKind>>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
@@ -66,8 +66,8 @@ where
 }
 
 /// Parser for comma-separated struct field declarations
-fn field_decls_parser<'src, I>(
-) -> impl Parser<'src, I, Vec<FieldDecl>, extra::Err<Rich<'src, TokenKind>>> + Clone
+fn field_decls_parser<'src, I>()
+-> impl Parser<'src, I, Vec<FieldDecl>, extra::Err<Rich<'src, TokenKind>>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
@@ -78,8 +78,8 @@ where
 }
 
 /// Parser for comma-separated parameters
-fn params_parser<'src, I>(
-) -> impl Parser<'src, I, Vec<Param>, extra::Err<Rich<'src, TokenKind>>> + Clone
+fn params_parser<'src, I>()
+-> impl Parser<'src, I, Vec<Param>, extra::Err<Rich<'src, TokenKind>>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
@@ -95,8 +95,7 @@ fn args_parser<'src, I>(
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    expr.separated_by(just(TokenKind::Comma))
-        .collect()
+    expr.separated_by(just(TokenKind::Comma)).collect()
 }
 
 /// Parser for struct field initializers: name: expr
@@ -354,10 +353,7 @@ where
     // Intrinsic call: @name(args)
     let intrinsic_call = just(TokenKind::At)
         .ignore_then(ident_parser())
-        .then(
-            args_parser(expr)
-                .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
-        )
+        .then(args_parser(expr).delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)))
         .map_with(|(name, args), e| {
             Expr::IntrinsicCall(IntrinsicCallExpr {
                 name,
@@ -384,9 +380,7 @@ where
     // Field access suffix: .field
     // Handles chains like a.b.c
     primary.foldl(
-        just(TokenKind::Dot)
-            .ignore_then(ident_parser())
-            .repeated(),
+        just(TokenKind::Dot).ignore_then(ident_parser()).repeated(),
         |base, field| {
             let span = Span::new(base.span().start, field.span.end);
             Expr::Field(FieldExpr {
@@ -432,8 +426,8 @@ where
 
 /// Parser for assignment target: either a simple variable or field access chain
 /// Parses: name or name.field or name.field.field...
-fn assign_target_parser<'src, I>(
-) -> impl Parser<'src, I, AssignTarget, extra::Err<Rich<'src, TokenKind>>> + Clone
+fn assign_target_parser<'src, I>()
+-> impl Parser<'src, I, AssignTarget, extra::Err<Rich<'src, TokenKind>>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
@@ -493,7 +487,10 @@ where
 
 /// Returns true if the expression can be used as a statement without a semicolon
 fn is_control_flow_expr(e: &Expr) -> bool {
-    matches!(e, Expr::If(_) | Expr::While(_) | Expr::Break(_) | Expr::Continue(_))
+    matches!(
+        e,
+        Expr::If(_) | Expr::While(_) | Expr::Break(_) | Expr::Continue(_)
+    )
 }
 
 /// Parser for a single block item (statement or expression).
@@ -538,7 +535,13 @@ where
         .then_ignore(just(TokenKind::RBrace).rewind())
         .map(BlockItem::Expr);
 
-    choice((let_stmt, assign_stmt, expr_with_semi, control_flow_stmt, final_expr))
+    choice((
+        let_stmt,
+        assign_stmt,
+        expr_with_semi,
+        control_flow_stmt,
+        final_expr,
+    ))
 }
 
 /// Process block items into statements and final expression
@@ -625,8 +628,8 @@ where
 }
 
 /// Parser for function definitions: fn name(params) -> Type { body }
-fn function_parser<'src, I>(
-) -> impl Parser<'src, I, Function, extra::Err<Rich<'src, TokenKind>>> + Clone
+fn function_parser<'src, I>()
+-> impl Parser<'src, I, Function, extra::Err<Rich<'src, TokenKind>>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
@@ -648,8 +651,8 @@ where
 }
 
 /// Parser for struct definitions: struct Name { field: Type, ... }
-fn struct_parser<'src, I>(
-) -> impl Parser<'src, I, StructDecl, extra::Err<Rich<'src, TokenKind>>> + Clone
+fn struct_parser<'src, I>()
+-> impl Parser<'src, I, StructDecl, extra::Err<Rich<'src, TokenKind>>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
@@ -736,10 +739,7 @@ pub struct ChumskyParser {
 impl ChumskyParser {
     /// Create a new parser from tokens produced by the lexer.
     pub fn new(tokens: Vec<rue_lexer::Token>) -> Self {
-        let source_len = tokens
-            .last()
-            .map(|t| t.span.end as usize)
-            .unwrap_or(0);
+        let source_len = tokens.last().map(|t| t.span.end as usize).unwrap_or(0);
 
         let spanned_tokens: Vec<(TokenKind, SimpleSpan)> = tokens
             .into_iter()
@@ -895,7 +895,8 @@ mod tests {
 
     #[test]
     fn test_function_calls() {
-        let ast = parse("fn add(a: i32, b: i32) -> i32 { a + b } fn main() -> i32 { add(1, 2) }").unwrap();
+        let ast = parse("fn add(a: i32, b: i32) -> i32 { a + b } fn main() -> i32 { add(1, 2) }")
+            .unwrap();
         assert_eq!(ast.items.len(), 2);
     }
 
@@ -907,7 +908,8 @@ mod tests {
 
     #[test]
     fn test_nested_control_flow() {
-        let ast = parse("fn main() -> i32 { let mut x = 0; while x < 10 { x = x + 1; } x }").unwrap();
+        let ast =
+            parse("fn main() -> i32 { let mut x = 0; while x < 10 { x = x + 1; } x }").unwrap();
         assert_eq!(ast.items.len(), 1);
     }
 }

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -6,9 +6,8 @@ pub mod ast;
 mod chumsky_parser;
 
 pub use ast::{
-    AssignStatement, AssignTarget, Ast, BinaryExpr, BinaryOp, BlockExpr, CallExpr, Expr,
-    FieldDecl, FieldExpr, FieldInit, Function, Ident, IntLit, IntrinsicCallExpr, Item,
-    LetStatement, Param, ParenExpr, Statement, StructDecl, StructLitExpr, UnaryExpr, UnaryOp,
-    WhileExpr,
+    AssignStatement, AssignTarget, Ast, BinaryExpr, BinaryOp, BlockExpr, CallExpr, Expr, FieldDecl,
+    FieldExpr, FieldInit, Function, Ident, IntLit, IntrinsicCallExpr, Item, LetStatement, Param,
+    ParenExpr, Statement, StructDecl, StructLitExpr, UnaryExpr, UnaryOp, WhileExpr,
 };
 pub use chumsky_parser::ChumskyParser as Parser;

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -4,7 +4,9 @@
 //! This is analogous to Zig's AstGen phase.
 
 use rue_intern::Interner;
-use rue_parser::{AssignTarget, Ast, BinaryOp, Expr, Function, Item, Statement, StructDecl, UnaryOp};
+use rue_parser::{
+    AssignTarget, Ast, BinaryOp, Expr, Function, Item, Statement, StructDecl, UnaryOp,
+};
 
 use crate::inst::{Inst, InstData, InstRef, Rir};
 
@@ -151,9 +153,7 @@ impl<'a> AstGen<'a> {
                 // Parentheses are transparent in the IR - just generate the inner expression
                 self.gen_expr(&paren.inner)
             }
-            Expr::Block(block) => {
-                self.gen_block(block)
-            }
+            Expr::Block(block) => self.gen_block(block),
             Expr::If(if_expr) => {
                 let cond = self.gen_expr(&if_expr.cond);
                 let then_block = self.gen_block(&if_expr.then_block);
@@ -303,7 +303,6 @@ impl<'a> AstGen<'a> {
             }
         }
     }
-
 }
 
 #[cfg(test)]
@@ -443,19 +442,34 @@ mod tests {
     fn test_gen_all_binary_ops() {
         // Test all binary operators generate correct instructions
         let (rir, _) = gen_rir("fn main() -> i32 { 1 + 2 }");
-        assert!(matches!(rir.get(InstRef::from_raw(2)).data, InstData::Add { .. }));
+        assert!(matches!(
+            rir.get(InstRef::from_raw(2)).data,
+            InstData::Add { .. }
+        ));
 
         let (rir, _) = gen_rir("fn main() -> i32 { 1 - 2 }");
-        assert!(matches!(rir.get(InstRef::from_raw(2)).data, InstData::Sub { .. }));
+        assert!(matches!(
+            rir.get(InstRef::from_raw(2)).data,
+            InstData::Sub { .. }
+        ));
 
         let (rir, _) = gen_rir("fn main() -> i32 { 1 * 2 }");
-        assert!(matches!(rir.get(InstRef::from_raw(2)).data, InstData::Mul { .. }));
+        assert!(matches!(
+            rir.get(InstRef::from_raw(2)).data,
+            InstData::Mul { .. }
+        ));
 
         let (rir, _) = gen_rir("fn main() -> i32 { 1 / 2 }");
-        assert!(matches!(rir.get(InstRef::from_raw(2)).data, InstData::Div { .. }));
+        assert!(matches!(
+            rir.get(InstRef::from_raw(2)).data,
+            InstData::Div { .. }
+        ));
 
         let (rir, _) = gen_rir("fn main() -> i32 { 1 % 2 }");
-        assert!(matches!(rir.get(InstRef::from_raw(2)).data, InstData::Mod { .. }));
+        assert!(matches!(
+            rir.get(InstRef::from_raw(2)).data,
+            InstData::Mod { .. }
+        ));
     }
 
     #[test]
@@ -463,14 +477,19 @@ mod tests {
         let (rir, interner) = gen_rir("fn main() -> i32 { let x = 42; x }");
 
         // Find the Alloc instruction
-        let alloc_inst = rir.iter().find(|(_, inst)| {
-            matches!(inst.data, InstData::Alloc { .. })
-        });
+        let alloc_inst = rir
+            .iter()
+            .find(|(_, inst)| matches!(inst.data, InstData::Alloc { .. }));
         assert!(alloc_inst.is_some());
 
         let (_, inst) = alloc_inst.unwrap();
         match &inst.data {
-            InstData::Alloc { name, is_mut, ty, init } => {
+            InstData::Alloc {
+                name,
+                is_mut,
+                ty,
+                init,
+            } => {
                 assert_eq!(interner.get(*name), "x");
                 assert!(!is_mut);
                 assert!(ty.is_none());
@@ -484,9 +503,9 @@ mod tests {
     fn test_gen_let_mut() {
         let (rir, interner) = gen_rir("fn main() -> i32 { let mut x = 10; x }");
 
-        let alloc_inst = rir.iter().find(|(_, inst)| {
-            matches!(inst.data, InstData::Alloc { .. })
-        });
+        let alloc_inst = rir
+            .iter()
+            .find(|(_, inst)| matches!(inst.data, InstData::Alloc { .. }));
         assert!(alloc_inst.is_some());
 
         let (_, inst) = alloc_inst.unwrap();
@@ -534,9 +553,9 @@ mod tests {
         let (rir, interner) = gen_rir("fn main() -> i32 { let mut x = 10; x = 20; x }");
 
         // Find the Assign instruction
-        let assign_inst = rir.iter().find(|(_, inst)| {
-            matches!(inst.data, InstData::Assign { .. })
-        });
+        let assign_inst = rir
+            .iter()
+            .find(|(_, inst)| matches!(inst.data, InstData::Assign { .. }));
         assert!(assign_inst.is_some());
 
         let (_, inst) = assign_inst.unwrap();
@@ -554,9 +573,10 @@ mod tests {
         let (rir, _interner) = gen_rir("fn main() -> i32 { let x = 1; let y = 2; x + y }");
 
         // Count Alloc instructions
-        let alloc_count = rir.iter().filter(|(_, inst)| {
-            matches!(inst.data, InstData::Alloc { .. })
-        }).count();
+        let alloc_count = rir
+            .iter()
+            .filter(|(_, inst)| matches!(inst.data, InstData::Alloc { .. }))
+            .count();
         assert_eq!(alloc_count, 2);
 
         // Check the body is a Block containing the allocs and the Add

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -161,10 +161,7 @@ pub enum InstData {
     },
 
     /// While loop: while cond { body }
-    Loop {
-        cond: InstRef,
-        body: InstRef,
-    },
+    Loop { cond: InstRef, body: InstRef },
 
     /// Break: exits the innermost loop
     Break,
@@ -356,7 +353,11 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 InstData::Not { operand } => {
                     out.push_str(&format!("not {}\n", operand));
                 }
-                InstData::Branch { cond, then_block, else_block } => {
+                InstData::Branch {
+                    cond,
+                    then_block,
+                    else_block,
+                } => {
                     if let Some(else_b) = else_block {
                         out.push_str(&format!("branch {}, {}, {}\n", cond, then_block, else_b));
                     } else {
@@ -372,7 +373,12 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 InstData::Continue => {
                     out.push_str("continue\n");
                 }
-                InstData::FnDecl { name, params, return_type, body } => {
+                InstData::FnDecl {
+                    name,
+                    params,
+                    return_type,
+                    body,
+                } => {
                     let name_str = self.interner.get(*name);
                     let ret_str = self.interner.get(*return_type);
                     let params_str: Vec<String> = params
@@ -405,7 +411,11 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 InstData::Intrinsic { name, args } => {
                     let name_str = self.interner.get(*name);
                     let args_str: Vec<String> = args.iter().map(|a| format!("{}", a)).collect();
-                    out.push_str(&format!("intrinsic @{}({})\n", name_str, args_str.join(", ")));
+                    out.push_str(&format!(
+                        "intrinsic @{}({})\n",
+                        name_str,
+                        args_str.join(", ")
+                    ));
                 }
                 InstData::ParamRef { index, name } => {
                     let name_str = self.interner.get(*name);
@@ -414,11 +424,21 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 InstData::Block { extra_start, len } => {
                     out.push_str(&format!("block({}, {})\n", extra_start, len));
                 }
-                InstData::Alloc { name, is_mut, ty, init } => {
+                InstData::Alloc {
+                    name,
+                    is_mut,
+                    ty,
+                    init,
+                } => {
                     let name_str = self.interner.get(*name);
                     let mut_str = if *is_mut { "mut " } else { "" };
-                    let ty_str = ty.map(|t| format!(": {}", self.interner.get(t))).unwrap_or_default();
-                    out.push_str(&format!("alloc {}{}{}= {}\n", mut_str, name_str, ty_str, init));
+                    let ty_str = ty
+                        .map(|t| format!(": {}", self.interner.get(t)))
+                        .unwrap_or_default();
+                    out.push_str(&format!(
+                        "alloc {}{}{}= {}\n",
+                        mut_str, name_str, ty_str, init
+                    ));
                 }
                 InstData::VarRef { name } => {
                     let name_str = self.interner.get(*name);
@@ -450,9 +470,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     let type_str = self.interner.get(*type_name);
                     let fields_str: Vec<String> = fields
                         .iter()
-                        .map(|(fname, value)| {
-                            format!("{}: {}", self.interner.get(*fname), value)
-                        })
+                        .map(|(fname, value)| format!("{}: {}", self.interner.get(*fname), value))
                         .collect();
                     out.push_str(&format!(
                         "struct_init {} {{ {} }}\n",

--- a/crates/rue-runtime/src/aarch64_macos.rs
+++ b/crates/rue-runtime/src/aarch64_macos.rs
@@ -85,11 +85,7 @@ pub fn write(fd: u64, buf: *const u8, len: usize) -> i64 {
     }
 
     // If carry flag was set, result is errno (positive), negate it
-    if err_flag != 0 {
-        -result
-    } else {
-        result
-    }
+    if err_flag != 0 { -result } else { result }
 }
 
 /// Write all bytes to a file descriptor, handling partial writes.

--- a/crates/rue-span/src/lib.rs
+++ b/crates/rue-span/src/lib.rs
@@ -25,7 +25,10 @@ impl Span {
     /// Create an empty span at a single position.
     #[inline]
     pub const fn point(pos: u32) -> Self {
-        Self { start: pos, end: pos }
+        Self {
+            start: pos,
+            end: pos,
+        }
     }
 
     /// Create a span covering two spans (from start of first to end of second).

--- a/crates/rue-spec/src/main.rs
+++ b/crates/rue-spec/src/main.rs
@@ -73,7 +73,10 @@ fn load_spec_files(cases_dir: &Path) -> Vec<(String, SpecFile)> {
     let mut specs = Vec::new();
 
     if !cases_dir.exists() {
-        eprintln!("Warning: cases directory not found: {}", cases_dir.display());
+        eprintln!(
+            "Warning: cases directory not found: {}",
+            cases_dir.display()
+        );
         return specs;
     }
 
@@ -146,7 +149,8 @@ fn check_golden(actual: &str, expected: &str, label: &str) -> Result<(), Failed>
         return Err(format!(
             "{} mismatch:\n--- expected ---\n{}\n--- actual ---\n{}\n",
             label, expected_normalized, actual_normalized
-        ).into());
+        )
+        .into());
     }
     Ok(())
 }
@@ -159,8 +163,8 @@ fn run_test_case(case: &Case, rue_binary: &Path) -> Result<(), Failed> {
     let output_path = temp_dir.path().join("test");
 
     // Write source to file
-    let mut source_file =
-        fs::File::create(&source_path).map_err(|e| format!("Failed to create source file: {}", e))?;
+    let mut source_file = fs::File::create(&source_path)
+        .map_err(|e| format!("Failed to create source file: {}", e))?;
     source_file
         .write_all(case.source.as_bytes())
         .map_err(|e| format!("Failed to write source: {}", e))?;
@@ -179,7 +183,8 @@ fn run_test_case(case: &Case, rue_binary: &Path) -> Result<(), Failed> {
                 return Err(format!(
                     "rue --dump-rir failed:\n{}",
                     String::from_utf8_lossy(&output.stderr)
-                ).into());
+                )
+                .into());
             }
 
             let actual = String::from_utf8_lossy(&output.stdout);
@@ -197,7 +202,8 @@ fn run_test_case(case: &Case, rue_binary: &Path) -> Result<(), Failed> {
                 return Err(format!(
                     "rue --dump-air failed:\n{}",
                     String::from_utf8_lossy(&output.stderr)
-                ).into());
+                )
+                .into());
             }
 
             let actual = String::from_utf8_lossy(&output.stdout);
@@ -215,7 +221,8 @@ fn run_test_case(case: &Case, rue_binary: &Path) -> Result<(), Failed> {
                 return Err(format!(
                     "rue --dump-mir failed:\n{}",
                     String::from_utf8_lossy(&output.stderr)
-                ).into());
+                )
+                .into());
             }
 
             let actual = String::from_utf8_lossy(&output.stdout);
@@ -253,7 +260,8 @@ fn run_test_case(case: &Case, rue_binary: &Path) -> Result<(), Failed> {
                 return Err(format!(
                     "Error mismatch:\n--- expected ---\n{}\n--- actual ---\n{}\n",
                     expected_normalized, actual_normalized
-                ).into());
+                )
+                .into());
             }
         }
 
@@ -391,10 +399,7 @@ fn main() {
                     }
                 }
             }
-            let possible_paths = [
-                "../rue/rue",
-                "./rue",
-            ];
+            let possible_paths = ["../rue/rue", "./rue"];
             for path in possible_paths {
                 let p = Path::new(path);
                 if p.exists() {
@@ -410,11 +415,7 @@ fn main() {
         .map(std::path::PathBuf::from)
         .unwrap_or_else(|_| {
             // Try to find it relative to the current directory
-            let possible_paths = [
-                "crates/rue-spec/cases",
-                "cases",
-                "../rue-spec/cases",
-            ];
+            let possible_paths = ["crates/rue-spec/cases", "cases", "../rue-spec/cases"];
             for path in possible_paths {
                 let p = Path::new(path);
                 if p.exists() {

--- a/crates/rue-target/src/lib.rs
+++ b/crates/rue-target/src/lib.rs
@@ -141,7 +141,11 @@ impl Target {
 
     /// Returns all supported targets.
     pub fn all() -> &'static [Target] {
-        &[Target::X86_64Linux, Target::Aarch64Linux, Target::Aarch64Macos]
+        &[
+            Target::X86_64Linux,
+            Target::Aarch64Linux,
+            Target::Aarch64Macos,
+        ]
     }
 }
 
@@ -183,15 +187,11 @@ impl FromStr for Target {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "x86-64-linux" | "x86_64-linux" | "x86_64-unknown-linux-gnu" => {
-                Ok(Target::X86_64Linux)
-            }
+            "x86-64-linux" | "x86_64-linux" | "x86_64-unknown-linux-gnu" => Ok(Target::X86_64Linux),
             "aarch64-linux" | "arm64-linux" | "aarch64-unknown-linux-gnu" => {
                 Ok(Target::Aarch64Linux)
             }
-            "aarch64-macos" | "arm64-macos" | "aarch64-apple-darwin" => {
-                Ok(Target::Aarch64Macos)
-            }
+            "aarch64-macos" | "arm64-macos" | "aarch64-apple-darwin" => Ok(Target::Aarch64Macos),
             _ => Err(ParseTargetError {
                 input: s.to_string(),
             }),
@@ -241,13 +241,34 @@ mod tests {
 
     #[test]
     fn test_target_parsing() {
-        assert_eq!("x86-64-linux".parse::<Target>().unwrap(), Target::X86_64Linux);
-        assert_eq!("x86_64-linux".parse::<Target>().unwrap(), Target::X86_64Linux);
-        assert_eq!("aarch64-linux".parse::<Target>().unwrap(), Target::Aarch64Linux);
-        assert_eq!("arm64-linux".parse::<Target>().unwrap(), Target::Aarch64Linux);
-        assert_eq!("aarch64-macos".parse::<Target>().unwrap(), Target::Aarch64Macos);
-        assert_eq!("arm64-macos".parse::<Target>().unwrap(), Target::Aarch64Macos);
-        assert_eq!("aarch64-apple-darwin".parse::<Target>().unwrap(), Target::Aarch64Macos);
+        assert_eq!(
+            "x86-64-linux".parse::<Target>().unwrap(),
+            Target::X86_64Linux
+        );
+        assert_eq!(
+            "x86_64-linux".parse::<Target>().unwrap(),
+            Target::X86_64Linux
+        );
+        assert_eq!(
+            "aarch64-linux".parse::<Target>().unwrap(),
+            Target::Aarch64Linux
+        );
+        assert_eq!(
+            "arm64-linux".parse::<Target>().unwrap(),
+            Target::Aarch64Linux
+        );
+        assert_eq!(
+            "aarch64-macos".parse::<Target>().unwrap(),
+            Target::Aarch64Macos
+        );
+        assert_eq!(
+            "arm64-macos".parse::<Target>().unwrap(),
+            Target::Aarch64Macos
+        );
+        assert_eq!(
+            "aarch64-apple-darwin".parse::<Target>().unwrap(),
+            Target::Aarch64Macos
+        );
     }
 
     #[test]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -5,8 +5,8 @@ use std::path::Path;
 
 use annotate_snippets::{Level, Renderer, Snippet};
 use rue_compiler::{
-    compile_to_air, compile_with_options, generate_mir, CompileError, CompileOptions,
-    CompileWarning, LinkerMode,
+    CompileError, CompileOptions, CompileWarning, LinkerMode, compile_to_air, compile_with_options,
+    generate_mir,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;

--- a/fmt.sh
+++ b/fmt.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -euo pipefail
+
+# Format or check Rust code formatting
+#
+# Usage:
+#   ./fmt.sh        # Format all Rust files
+#   ./fmt.sh check  # Check formatting (for CI)
+
+MODE="${1:-format}"
+
+RUST_FILES=$(find crates -name "*.rs" -type f)
+
+if [ -z "$RUST_FILES" ]; then
+    echo "No Rust files found"
+    exit 0
+fi
+
+if [ "$MODE" = "check" ]; then
+    echo "Checking Rust formatting..."
+    echo "$RUST_FILES" | xargs rustfmt --edition 2024 --check
+    echo "All files formatted correctly!"
+else
+    echo "Formatting Rust files..."
+    echo "$RUST_FILES" | xargs rustfmt --edition 2024
+    echo "Done!"
+fi


### PR DESCRIPTION
Add fmt.sh script for formatting Rust code:
- ./fmt.sh        # Format all Rust files
- ./fmt.sh check  # Check formatting (for CI)

Add fmt job to CI workflow that runs rustfmt --check.