### PR TITLE
Replace --dump-* flags with unified --emit flag

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,20 +43,39 @@ You will need to source `~/.profile` before running any commands.
 ./buck2 run //crates/rue:rue -- source.rue output
 ./output
 
-# Dump intermediate representations
-./buck2 run //crates/rue:rue -- --dump-rir source.rue  # Untyped IR
-./buck2 run //crates/rue:rue -- --dump-air source.rue  # Typed IR
-./buck2 run //crates/rue:rue -- --dump-mir source.rue  # Machine IR
+# Emit intermediate representations (can specify multiple stages)
+./buck2 run //crates/rue:rue -- --emit tokens source.rue  # Lexer tokens
+./buck2 run //crates/rue:rue -- --emit ast source.rue     # Abstract syntax tree
+./buck2 run //crates/rue:rue -- --emit rir source.rue     # Untyped IR
+./buck2 run //crates/rue:rue -- --emit air source.rue     # Typed IR
+./buck2 run //crates/rue:rue -- --emit cfg source.rue     # Control flow graph
+./buck2 run //crates/rue:rue -- --emit mir source.rue     # Machine IR (virtual registers)
+./buck2 run //crates/rue:rue -- --emit asm source.rue     # Assembly (physical registers)
+
+# Chain multiple stages to see the full pipeline
+./buck2 run //crates/rue:rue -- --emit tokens --emit ast --emit rir source.rue
 ```
 
 ## Architecture
 
 The compiler pipeline transforms source through successive IRs:
 
+```mermaid
+graph LR
+    Source --> Lexer --> Parser --> AstGen --> Sema --> CfgBuilder --> Lower --> RegAlloc --> Emit --> Link
 ```
-Source → Lexer → Parser → AstGen → Sema → Lower → RegAlloc → Emit → Link
-         tokens   AST      RIR      AIR    X86Mir          bytes   ELF
-```
+
+| Stage | Pass | IR Produced | `--emit` flag |
+|-------|------|-------------|---------------|
+| 1 | Lexer | tokens | `tokens` |
+| 2 | Parser | AST | `ast` |
+| 3 | AstGen | RIR (untyped) | `rir` |
+| 4 | Sema | AIR (typed) | `air` |
+| 5 | CfgBuilder | CFG | `cfg` |
+| 6 | Lower | MIR (machine) | `mir` |
+| 7 | RegAlloc | MIR (allocated) | `asm` |
+| 8 | Emit | bytes | - |
+| 9 | Link | ELF | - |
 
 ### Crate Responsibilities
 

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -491,8 +491,29 @@ fn link_system_macos(
 }
 
 /// Generate X86Mir from CFG (for debugging/inspection).
+///
+/// This returns the MIR before register allocation, with virtual registers.
 pub fn generate_mir(cfg: &Cfg, struct_defs: &[StructDef]) -> X86Mir {
     rue_codegen::x86_64::CfgLower::new(cfg, struct_defs).lower()
+}
+
+/// Generate X86Mir after register allocation (for debugging/inspection).
+///
+/// This returns the MIR after register allocation, with physical registers.
+/// This is closer to the final assembly that will be emitted.
+pub fn generate_allocated_mir(cfg: &Cfg, struct_defs: &[StructDef]) -> X86Mir {
+    let num_locals = cfg.num_locals();
+    let num_params = cfg.num_params();
+
+    // Lower CFG to X86Mir with virtual registers
+    let mir = rue_codegen::x86_64::CfgLower::new(cfg, struct_defs).lower();
+
+    // Allocate physical registers
+    let existing_slots = num_locals + num_params;
+    let (mir, _num_spills, _used_callee_saved) =
+        rue_codegen::x86_64::RegAlloc::new(mir, existing_slots).allocate_with_spills();
+
+    mir
 }
 
 #[cfg(test)]

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -128,3 +128,64 @@ pub struct Token {
     pub kind: TokenKind,
     pub span: Span,
 }
+
+impl std::fmt::Display for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{:>4}..{:<4} {}",
+            self.span.start, self.span.end, self.kind
+        )
+    }
+}
+
+impl std::fmt::Display for TokenKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TokenKind::Fn => write!(f, "FN"),
+            TokenKind::Let => write!(f, "LET"),
+            TokenKind::Mut => write!(f, "MUT"),
+            TokenKind::If => write!(f, "IF"),
+            TokenKind::Else => write!(f, "ELSE"),
+            TokenKind::Match => write!(f, "MATCH"),
+            TokenKind::While => write!(f, "WHILE"),
+            TokenKind::Loop => write!(f, "LOOP"),
+            TokenKind::Break => write!(f, "BREAK"),
+            TokenKind::Continue => write!(f, "CONTINUE"),
+            TokenKind::Return => write!(f, "RETURN"),
+            TokenKind::True => write!(f, "TRUE"),
+            TokenKind::False => write!(f, "FALSE"),
+            TokenKind::Struct => write!(f, "STRUCT"),
+            TokenKind::Underscore => write!(f, "UNDERSCORE"),
+            TokenKind::Int(v) => write!(f, "INT({})", v),
+            TokenKind::Ident(s) => write!(f, "IDENT({})", s),
+            TokenKind::Plus => write!(f, "PLUS"),
+            TokenKind::Minus => write!(f, "MINUS"),
+            TokenKind::Star => write!(f, "STAR"),
+            TokenKind::Slash => write!(f, "SLASH"),
+            TokenKind::Percent => write!(f, "PERCENT"),
+            TokenKind::Eq => write!(f, "EQ"),
+            TokenKind::EqEq => write!(f, "EQEQ"),
+            TokenKind::Bang => write!(f, "BANG"),
+            TokenKind::BangEq => write!(f, "BANGEQ"),
+            TokenKind::Lt => write!(f, "LT"),
+            TokenKind::Gt => write!(f, "GT"),
+            TokenKind::LtEq => write!(f, "LTEQ"),
+            TokenKind::GtEq => write!(f, "GTEQ"),
+            TokenKind::AmpAmp => write!(f, "AMPAMP"),
+            TokenKind::PipePipe => write!(f, "PIPEPIPE"),
+            TokenKind::LParen => write!(f, "LPAREN"),
+            TokenKind::RParen => write!(f, "RPAREN"),
+            TokenKind::LBrace => write!(f, "LBRACE"),
+            TokenKind::RBrace => write!(f, "RBRACE"),
+            TokenKind::Arrow => write!(f, "ARROW"),
+            TokenKind::FatArrow => write!(f, "FATARROW"),
+            TokenKind::Colon => write!(f, "COLON"),
+            TokenKind::Semi => write!(f, "SEMI"),
+            TokenKind::Comma => write!(f, "COMMA"),
+            TokenKind::Dot => write!(f, "DOT"),
+            TokenKind::At => write!(f, "AT"),
+            TokenKind::Eof => write!(f, "EOF"),
+        }
+    }
+}

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -4,6 +4,8 @@
 //! It closely mirrors the source syntax and preserves all information
 //! needed for error reporting.
 
+use std::fmt;
+
 use rue_span::Span;
 
 /// A complete source file (list of items).
@@ -399,6 +401,215 @@ impl Expr {
             Expr::StructLit(struct_lit) => struct_lit.span,
             Expr::Field(field_expr) => field_expr.span,
             Expr::IntrinsicCall(intrinsic) => intrinsic.span,
+        }
+    }
+}
+
+// Display implementations for AST pretty-printing
+
+/// Helper for indented printing.
+struct AstPrinter<'a> {
+    ast: &'a Ast,
+}
+
+impl fmt::Display for Ast {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let printer = AstPrinter { ast: self };
+        printer.fmt(f)
+    }
+}
+
+impl<'a> fmt::Display for AstPrinter<'a> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        for item in &self.ast.items {
+            match item {
+                Item::Function(func) => fmt_function(f, func, 0)?,
+                Item::Struct(s) => fmt_struct(f, s, 0)?,
+            }
+        }
+        Ok(())
+    }
+}
+
+fn indent(f: &mut fmt::Formatter<'_>, level: usize) -> fmt::Result {
+    for _ in 0..level {
+        write!(f, "  ")?;
+    }
+    Ok(())
+}
+
+fn fmt_struct(f: &mut fmt::Formatter<'_>, s: &StructDecl, level: usize) -> fmt::Result {
+    indent(f, level)?;
+    writeln!(f, "Struct {}", s.name.name)?;
+    for field in &s.fields {
+        indent(f, level + 1)?;
+        writeln!(f, "Field {} : {}", field.name.name, field.ty.name)?;
+    }
+    Ok(())
+}
+
+fn fmt_function(f: &mut fmt::Formatter<'_>, func: &Function, level: usize) -> fmt::Result {
+    indent(f, level)?;
+    write!(f, "Function {}", func.name.name)?;
+    if !func.params.is_empty() {
+        write!(f, "(")?;
+        for (i, param) in func.params.iter().enumerate() {
+            if i > 0 {
+                write!(f, ", ")?;
+            }
+            write!(f, "{}: {}", param.name.name, param.ty.name)?;
+        }
+        write!(f, ")")?;
+    }
+    if let Some(ref ret) = func.return_type {
+        write!(f, " -> {}", ret.name)?;
+    }
+    writeln!(f)?;
+    fmt_expr(f, &func.body, level + 1)?;
+    Ok(())
+}
+
+fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Result {
+    indent(f, level)?;
+    match expr {
+        Expr::Int(lit) => writeln!(f, "Int({})", lit.value),
+        Expr::Bool(lit) => writeln!(f, "Bool({})", lit.value),
+        Expr::Ident(ident) => writeln!(f, "Ident({})", ident.name),
+        Expr::Binary(bin) => {
+            writeln!(f, "Binary {:?}", bin.op)?;
+            fmt_expr(f, &bin.left, level + 1)?;
+            fmt_expr(f, &bin.right, level + 1)
+        }
+        Expr::Unary(un) => {
+            writeln!(f, "Unary {:?}", un.op)?;
+            fmt_expr(f, &un.operand, level + 1)
+        }
+        Expr::Paren(paren) => {
+            writeln!(f, "Paren")?;
+            fmt_expr(f, &paren.inner, level + 1)
+        }
+        Expr::Block(block) => {
+            writeln!(f, "Block")?;
+            for stmt in &block.statements {
+                fmt_stmt(f, stmt, level + 1)?;
+            }
+            fmt_expr(f, &block.expr, level + 1)
+        }
+        Expr::If(if_expr) => {
+            writeln!(f, "If")?;
+            indent(f, level + 1)?;
+            writeln!(f, "Cond:")?;
+            fmt_expr(f, &if_expr.cond, level + 2)?;
+            indent(f, level + 1)?;
+            writeln!(f, "Then:")?;
+            fmt_block_expr(f, &if_expr.then_block, level + 2)?;
+            if let Some(ref else_block) = if_expr.else_block {
+                indent(f, level + 1)?;
+                writeln!(f, "Else:")?;
+                fmt_block_expr(f, else_block, level + 2)?;
+            }
+            Ok(())
+        }
+        Expr::Match(match_expr) => {
+            writeln!(f, "Match")?;
+            indent(f, level + 1)?;
+            writeln!(f, "Scrutinee:")?;
+            fmt_expr(f, &match_expr.scrutinee, level + 2)?;
+            for arm in &match_expr.arms {
+                indent(f, level + 1)?;
+                writeln!(f, "Arm {:?} =>", arm.pattern)?;
+                fmt_expr(f, &arm.body, level + 2)?;
+            }
+            Ok(())
+        }
+        Expr::While(while_expr) => {
+            writeln!(f, "While")?;
+            indent(f, level + 1)?;
+            writeln!(f, "Cond:")?;
+            fmt_expr(f, &while_expr.cond, level + 2)?;
+            indent(f, level + 1)?;
+            writeln!(f, "Body:")?;
+            fmt_block_expr(f, &while_expr.body, level + 2)
+        }
+        Expr::Loop(loop_expr) => {
+            writeln!(f, "Loop")?;
+            fmt_block_expr(f, &loop_expr.body, level + 1)
+        }
+        Expr::Call(call) => {
+            writeln!(f, "Call {}", call.name.name)?;
+            for arg in &call.args {
+                fmt_expr(f, arg, level + 1)?;
+            }
+            Ok(())
+        }
+        Expr::IntrinsicCall(intrinsic) => {
+            writeln!(f, "Intrinsic @{}", intrinsic.name.name)?;
+            for arg in &intrinsic.args {
+                fmt_expr(f, arg, level + 1)?;
+            }
+            Ok(())
+        }
+        Expr::Break(_) => writeln!(f, "Break"),
+        Expr::Continue(_) => writeln!(f, "Continue"),
+        Expr::Return(ret) => {
+            if let Some(ref value) = ret.value {
+                writeln!(f, "Return")?;
+                fmt_expr(f, value, level + 1)
+            } else {
+                writeln!(f, "Return (unit)")
+            }
+        }
+        Expr::StructLit(lit) => {
+            writeln!(f, "StructLit {}", lit.name.name)?;
+            for field in &lit.fields {
+                indent(f, level + 1)?;
+                writeln!(f, "{} =", field.name.name)?;
+                fmt_expr(f, &field.value, level + 2)?;
+            }
+            Ok(())
+        }
+        Expr::Field(field) => {
+            writeln!(f, "Field .{}", field.field.name)?;
+            fmt_expr(f, &field.base, level + 1)
+        }
+    }
+}
+
+fn fmt_block_expr(f: &mut fmt::Formatter<'_>, block: &BlockExpr, level: usize) -> fmt::Result {
+    for stmt in &block.statements {
+        fmt_stmt(f, stmt, level)?;
+    }
+    fmt_expr(f, &block.expr, level)
+}
+
+fn fmt_stmt(f: &mut fmt::Formatter<'_>, stmt: &Statement, level: usize) -> fmt::Result {
+    indent(f, level)?;
+    match stmt {
+        Statement::Let(let_stmt) => {
+            write!(f, "Let")?;
+            if let_stmt.is_mut {
+                write!(f, " mut")?;
+            }
+            write!(f, " {}", let_stmt.name.name)?;
+            if let Some(ref ty) = let_stmt.ty {
+                write!(f, ": {}", ty.name)?;
+            }
+            writeln!(f)?;
+            fmt_expr(f, &let_stmt.init, level + 1)
+        }
+        Statement::Assign(assign) => {
+            match &assign.target {
+                AssignTarget::Var(ident) => writeln!(f, "Assign {}", ident.name)?,
+                AssignTarget::Field(field) => {
+                    writeln!(f, "Assign field .{}", field.field.name)?;
+                    fmt_expr(f, &field.base, level + 1)?;
+                }
+            }
+            fmt_expr(f, &assign.value, level + 1)
+        }
+        Statement::Expr(expr) => {
+            writeln!(f, "ExprStmt")?;
+            fmt_expr(f, expr, level + 1)
         }
     }
 }

--- a/crates/rue-spec/cases/06-ir-dumps.toml
+++ b/crates/rue-spec/cases/06-ir-dumps.toml
@@ -3,6 +3,98 @@ id = "4.1"
 name = "IR Dumps"
 description = "Golden tests for intermediate representation dumps."
 
+# =============================================================================
+# Tokens
+# =============================================================================
+
+[[case]]
+name = "simple_return_tokens"
+source = "fn main() -> i32 { 42 }"
+expected_tokens = """
+   0..2    FN
+   3..7    IDENT(main)
+   7..8    LPAREN
+   8..9    RPAREN
+  10..12   ARROW
+  13..16   IDENT(i32)
+  17..18   LBRACE
+  19..21   INT(42)
+  22..23   RBRACE
+  23..23   EOF
+"""
+
+[[case]]
+name = "binary_expr_tokens"
+source = "fn main() -> i32 { 1 + 2 }"
+expected_tokens = """
+   0..2    FN
+   3..7    IDENT(main)
+   7..8    LPAREN
+   8..9    RPAREN
+  10..12   ARROW
+  13..16   IDENT(i32)
+  17..18   LBRACE
+  19..20   INT(1)
+  21..22   PLUS
+  23..24   INT(2)
+  25..26   RBRACE
+  26..26   EOF
+"""
+
+# =============================================================================
+# AST
+# =============================================================================
+
+[[case]]
+name = "simple_return_ast"
+source = "fn main() -> i32 { 42 }"
+expected_ast = """
+Function main -> i32
+  Block
+    Int(42)
+"""
+
+[[case]]
+name = "binary_expr_ast"
+source = "fn main() -> i32 { 1 + 2 }"
+expected_ast = """
+Function main -> i32
+  Block
+    Binary Add
+      Int(1)
+      Int(2)
+"""
+
+[[case]]
+name = "let_binding_ast"
+source = "fn main() -> i32 { let x = 42; x }"
+expected_ast = """
+Function main -> i32
+  Block
+    Let x
+      Int(42)
+    Ident(x)
+"""
+
+[[case]]
+name = "if_else_ast"
+source = "fn main() -> i32 { if true { 1 } else { 2 } }"
+expected_ast = """
+Function main -> i32
+  Block
+    If
+      Cond:
+        Bool(true)
+      Then:
+        Int(1)
+      Else:
+        Int(2)
+"""
+
+# =============================================================================
+# RIR
+# =============================================================================
+
 [[case]]
 name = "simple_return_rir"
 source = "fn main() -> i32 { 42 }"

--- a/crates/rue-spec/src/main.rs
+++ b/crates/rue-spec/src/main.rs
@@ -35,6 +35,12 @@ struct Case {
     /// Expected exact error output (golden test)
     #[serde(default)]
     expected_error: Option<String>,
+    /// Expected tokens dump (golden test)
+    #[serde(default)]
+    expected_tokens: Option<String>,
+    /// Expected AST dump (golden test)
+    #[serde(default)]
+    expected_ast: Option<String>,
     /// Expected RIR dump (golden test)
     #[serde(default)]
     expected_rir: Option<String>,
@@ -143,6 +149,16 @@ fn normalize_error_output(s: &str, source_path: &Path) -> String {
     normalize_golden(&normalized)
 }
 
+/// Strip the emit header (e.g., "=== RIR ===") from the output.
+fn strip_emit_header(output: &str, stage: &str) -> String {
+    let header = format!("=== {} ===", stage);
+    output
+        .lines()
+        .filter(|line| line.trim() != header)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
 /// Compare actual output against expected golden output.
 fn check_golden(actual: &str, expected: &str, label: &str) -> Result<(), Failed> {
     let actual_normalized = normalize_golden(actual);
@@ -172,63 +188,121 @@ fn run_test_case(case: &Case, rue_binary: &Path) -> Result<(), Failed> {
         .write_all(case.source.as_bytes())
         .map_err(|e| format!("Failed to write source: {}", e))?;
 
-    // Check for golden IR tests (RIR, AIR, MIR)
-    if case.expected_rir.is_some() || case.expected_air.is_some() || case.expected_mir.is_some() {
+    // Check for golden IR tests (tokens, AST, RIR, AIR, MIR)
+    if case.expected_tokens.is_some()
+        || case.expected_ast.is_some()
+        || case.expected_rir.is_some()
+        || case.expected_air.is_some()
+        || case.expected_mir.is_some()
+    {
         // Run dump commands and check golden output
-        if let Some(ref expected) = case.expected_rir {
+        if let Some(ref expected) = case.expected_tokens {
             let output = Command::new(rue_binary)
-                .arg("--dump-rir")
+                .arg("--emit")
+                .arg("tokens")
                 .arg(&source_path)
                 .output()
-                .map_err(|e| format!("Failed to run rue --dump-rir: {}", e))?;
+                .map_err(|e| format!("Failed to run rue --emit tokens: {}", e))?;
 
             if !output.status.success() {
                 return Err(format!(
-                    "rue --dump-rir failed:\n{}",
+                    "rue --emit tokens failed:\n{}",
                     String::from_utf8_lossy(&output.stderr)
                 )
                 .into());
             }
 
             let actual = String::from_utf8_lossy(&output.stdout);
+            // Strip the "=== Tokens ===" header for golden comparison
+            let actual = strip_emit_header(&actual, "Tokens");
+            check_golden(&actual, expected, "Tokens")?;
+        }
+
+        if let Some(ref expected) = case.expected_ast {
+            let output = Command::new(rue_binary)
+                .arg("--emit")
+                .arg("ast")
+                .arg(&source_path)
+                .output()
+                .map_err(|e| format!("Failed to run rue --emit ast: {}", e))?;
+
+            if !output.status.success() {
+                return Err(format!(
+                    "rue --emit ast failed:\n{}",
+                    String::from_utf8_lossy(&output.stderr)
+                )
+                .into());
+            }
+
+            let actual = String::from_utf8_lossy(&output.stdout);
+            // Strip the "=== AST ===" header for golden comparison
+            let actual = strip_emit_header(&actual, "AST");
+            check_golden(&actual, expected, "AST")?;
+        }
+
+        if let Some(ref expected) = case.expected_rir {
+            let output = Command::new(rue_binary)
+                .arg("--emit")
+                .arg("rir")
+                .arg(&source_path)
+                .output()
+                .map_err(|e| format!("Failed to run rue --emit rir: {}", e))?;
+
+            if !output.status.success() {
+                return Err(format!(
+                    "rue --emit rir failed:\n{}",
+                    String::from_utf8_lossy(&output.stderr)
+                )
+                .into());
+            }
+
+            let actual = String::from_utf8_lossy(&output.stdout);
+            // Strip the "=== RIR ===" header for golden comparison
+            let actual = strip_emit_header(&actual, "RIR");
             check_golden(&actual, expected, "RIR")?;
         }
 
         if let Some(ref expected) = case.expected_air {
             let output = Command::new(rue_binary)
-                .arg("--dump-air")
+                .arg("--emit")
+                .arg("air")
                 .arg(&source_path)
                 .output()
-                .map_err(|e| format!("Failed to run rue --dump-air: {}", e))?;
+                .map_err(|e| format!("Failed to run rue --emit air: {}", e))?;
 
             if !output.status.success() {
                 return Err(format!(
-                    "rue --dump-air failed:\n{}",
+                    "rue --emit air failed:\n{}",
                     String::from_utf8_lossy(&output.stderr)
                 )
                 .into());
             }
 
             let actual = String::from_utf8_lossy(&output.stdout);
+            // Strip the "=== AIR ===" header for golden comparison
+            let actual = strip_emit_header(&actual, "AIR");
             check_golden(&actual, expected, "AIR")?;
         }
 
         if let Some(ref expected) = case.expected_mir {
             let output = Command::new(rue_binary)
-                .arg("--dump-mir")
+                .arg("--emit")
+                .arg("mir")
                 .arg(&source_path)
                 .output()
-                .map_err(|e| format!("Failed to run rue --dump-mir: {}", e))?;
+                .map_err(|e| format!("Failed to run rue --emit mir: {}", e))?;
 
             if !output.status.success() {
                 return Err(format!(
-                    "rue --dump-mir failed:\n{}",
+                    "rue --emit mir failed:\n{}",
                     String::from_utf8_lossy(&output.stderr)
                 )
                 .into());
             }
 
             let actual = String::from_utf8_lossy(&output.stdout);
+            // Strip the "=== MIR ===" header for golden comparison
+            let actual = strip_emit_header(&actual, "MIR");
             check_golden(&actual, expected, "MIR")?;
         }
 

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -2,6 +2,7 @@ rust_binary(
     name = "rue",
     srcs = ["src/main.rs"],
     deps = [
+        "//crates/rue-codegen:rue-codegen",
         "//crates/rue-compiler:rue-compiler",
         "//crates/rue-rir:rue-rir",
         "//crates/rue-target:rue-target",

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -5,24 +5,54 @@ use std::path::Path;
 
 use annotate_snippets::{Level, Renderer, Snippet};
 use rue_compiler::{
-    CompileError, CompileOptions, CompileWarning, LinkerMode, compile_frontend,
-    compile_with_options, generate_mir,
+    CompileError, CompileOptions, CompileWarning, Lexer, LinkerMode, Parser, compile_frontend,
+    compile_with_options, generate_allocated_mir, generate_mir,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
 
+/// Compilation stages that can be emitted.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum DumpMode {
-    None,
+enum EmitStage {
+    /// Emit tokens from the lexer.
+    Tokens,
+    /// Emit the abstract syntax tree.
+    Ast,
+    /// Emit RIR (untyped intermediate representation).
     Rir,
+    /// Emit AIR (typed intermediate representation).
     Air,
+    /// Emit CFG (control flow graph).
+    Cfg,
+    /// Emit MIR (machine intermediate representation).
     Mir,
+    /// Emit assembly text.
+    Asm,
+}
+
+impl EmitStage {
+    fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "tokens" => Some(EmitStage::Tokens),
+            "ast" => Some(EmitStage::Ast),
+            "rir" => Some(EmitStage::Rir),
+            "air" => Some(EmitStage::Air),
+            "cfg" => Some(EmitStage::Cfg),
+            "mir" => Some(EmitStage::Mir),
+            "asm" => Some(EmitStage::Asm),
+            _ => None,
+        }
+    }
+
+    fn all_names() -> &'static str {
+        "tokens, ast, rir, air, cfg, mir, asm"
+    }
 }
 
 struct Options {
     source_path: String,
     output_path: String,
-    dump_mode: DumpMode,
+    emit_stages: Vec<EmitStage>,
     target: Target,
     linker: LinkerMode,
 }
@@ -36,9 +66,9 @@ fn print_usage() {
     eprintln!("  --linker <linker>  Set linker to use (default: internal)");
     eprintln!("                     Use 'internal' for built-in linker, or a command");
     eprintln!("                     like 'clang', 'gcc', or 'ld' for system linker");
-    eprintln!("  --dump-rir         Dump RIR (untyped intermediate representation)");
-    eprintln!("  --dump-air         Dump AIR (typed intermediate representation)");
-    eprintln!("  --dump-mir         Dump MIR (machine intermediate representation)");
+    eprintln!("  --emit <stage>     Emit intermediate representation and exit");
+    eprintln!("                     Can be specified multiple times for multiple outputs");
+    eprintln!("                     Stages: tokens, ast, rir, air, cfg, mir, asm");
     eprintln!("  --help             Show this help message");
 }
 
@@ -50,7 +80,7 @@ fn parse_args() -> Option<Options> {
         return None;
     }
 
-    let mut dump_mode = DumpMode::None;
+    let mut emit_stages = Vec::new();
     let mut target: Option<Target> = None;
     let mut linker: Option<LinkerMode> = None;
     let mut positional = Vec::new();
@@ -58,9 +88,21 @@ fn parse_args() -> Option<Options> {
 
     while let Some(arg) = args_iter.next() {
         match arg.as_str() {
-            "--dump-rir" => dump_mode = DumpMode::Rir,
-            "--dump-air" => dump_mode = DumpMode::Air,
-            "--dump-mir" => dump_mode = DumpMode::Mir,
+            "--emit" => {
+                let Some(stage_str) = args_iter.next() else {
+                    eprintln!("Error: --emit requires a value");
+                    eprintln!("Valid stages: {}", EmitStage::all_names());
+                    return None;
+                };
+                match EmitStage::from_str(stage_str) {
+                    Some(stage) => emit_stages.push(stage),
+                    None => {
+                        eprintln!("Error: unknown emit stage '{}'", stage_str);
+                        eprintln!("Valid stages: {}", EmitStage::all_names());
+                        return None;
+                    }
+                }
+            }
             "--target" => {
                 let Some(target_str) = args_iter.next() else {
                     eprintln!("Error: --target requires a value");
@@ -115,7 +157,7 @@ fn parse_args() -> Option<Options> {
     Some(Options {
         source_path,
         output_path,
-        dump_mode,
+        emit_stages,
         target: target.unwrap_or_else(Target::host),
         linker: linker.unwrap_or_default(),
     })
@@ -133,33 +175,10 @@ fn main() {
         std::process::exit(1);
     });
 
-    // Handle dump modes
-    if options.dump_mode != DumpMode::None {
-        match compile_frontend(&source) {
-            Ok(state) => match options.dump_mode {
-                DumpMode::Rir => {
-                    let printer = RirPrinter::new(&state.rir, &state.interner);
-                    println!("{}", printer);
-                }
-                DumpMode::Air => {
-                    for func in &state.functions {
-                        println!("function {}:", func.analyzed.name);
-                        println!("{}", func.analyzed.air);
-                    }
-                }
-                DumpMode::Mir => {
-                    for func in &state.functions {
-                        let mir = generate_mir(&func.cfg, &state.struct_defs);
-                        println!("function {}:", func.analyzed.name);
-                        println!("{}", mir);
-                    }
-                }
-                DumpMode::None => unreachable!(),
-            },
-            Err(e) => {
-                print_error(&e, &source, &options.source_path);
-                std::process::exit(1);
-            }
+    // Handle emit modes
+    if !options.emit_stages.is_empty() {
+        if let Err(()) = handle_emit(&source, &options) {
+            std::process::exit(1);
         }
         return;
     }
@@ -215,6 +234,158 @@ fn main() {
         Err(e) => {
             print_error(&e, &source, &options.source_path);
             std::process::exit(1);
+        }
+    }
+}
+
+/// Handle emit stages - print requested IRs and exit.
+///
+/// Note: When emitting both AST and later stages (rir, air, etc.), this
+/// function parses the source twice - once for AST output and again inside
+/// compile_frontend(). This is acceptable for a debugging tool but could
+/// be optimized if needed (see tree1-tr8).
+fn handle_emit(source: &str, options: &Options) -> Result<(), ()> {
+    // For early stages (tokens, ast), we don't need the full frontend
+    // For later stages, we compile incrementally and cache results
+
+    // Track what we need to compute
+    let needs_tokens = options.emit_stages.contains(&EmitStage::Tokens);
+    let needs_ast = options.emit_stages.contains(&EmitStage::Ast);
+    let needs_frontend = options.emit_stages.iter().any(|s| {
+        matches!(
+            s,
+            EmitStage::Rir | EmitStage::Air | EmitStage::Cfg | EmitStage::Mir | EmitStage::Asm
+        )
+    });
+
+    // Compute tokens if needed (for tokens stage or later stages)
+    let tokens = if needs_tokens || needs_ast || needs_frontend {
+        let mut lexer = Lexer::new(source);
+        match lexer.tokenize() {
+            Ok(tokens) => tokens,
+            Err(e) => {
+                print_error(&e, source, &options.source_path);
+                return Err(());
+            }
+        }
+    } else {
+        Vec::new()
+    };
+
+    // Compute AST if needed
+    let ast = if needs_ast || needs_frontend {
+        let mut parser = Parser::new(tokens.clone());
+        match parser.parse() {
+            Ok(ast) => Some(ast),
+            Err(e) => {
+                print_error(&e, source, &options.source_path);
+                return Err(());
+            }
+        }
+    } else {
+        None
+    };
+
+    // Compute full frontend if needed
+    let frontend_state = if needs_frontend {
+        match compile_frontend(source) {
+            Ok(state) => Some(state),
+            Err(e) => {
+                print_error(&e, source, &options.source_path);
+                return Err(());
+            }
+        }
+    } else {
+        None
+    };
+
+    // Now emit in order
+    for stage in &options.emit_stages {
+        match stage {
+            EmitStage::Tokens => {
+                println!("=== Tokens ===");
+                for token in &tokens {
+                    println!("{}", token);
+                }
+                println!();
+            }
+            EmitStage::Ast => {
+                println!("=== AST ===");
+                if let Some(ref ast) = ast {
+                    print!("{}", ast);
+                }
+                println!();
+            }
+            EmitStage::Rir => {
+                println!("=== RIR ===");
+                if let Some(ref state) = frontend_state {
+                    let printer = RirPrinter::new(&state.rir, &state.interner);
+                    println!("{}", printer);
+                }
+                println!();
+            }
+            EmitStage::Air => {
+                println!("=== AIR ===");
+                if let Some(ref state) = frontend_state {
+                    for func in &state.functions {
+                        println!("function {}:", func.analyzed.name);
+                        println!("{}", func.analyzed.air);
+                    }
+                }
+                println!();
+            }
+            EmitStage::Cfg => {
+                println!("=== CFG ===");
+                if let Some(ref state) = frontend_state {
+                    for func in &state.functions {
+                        println!("{}", func.cfg);
+                    }
+                }
+                println!();
+            }
+            EmitStage::Mir => {
+                println!("=== MIR ===");
+                if let Some(ref state) = frontend_state {
+                    for func in &state.functions {
+                        let mir = generate_mir(&func.cfg, &state.struct_defs);
+                        println!("function {}:", func.analyzed.name);
+                        println!("{}", mir);
+                    }
+                }
+                println!();
+            }
+            EmitStage::Asm => {
+                println!("=== Assembly (x86-64) ===");
+                if let Some(ref state) = frontend_state {
+                    for func in &state.functions {
+                        println!(".globl {}", func.analyzed.name);
+                        println!("{}:", func.analyzed.name);
+                        let mir = generate_allocated_mir(&func.cfg, &state.struct_defs);
+                        print_assembly(&mir);
+                        println!();
+                    }
+                }
+                println!();
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Print x86-64 assembly from MIR.
+///
+/// This prints the MIR instructions in assembly-like format.
+/// When called with allocated MIR (post-regalloc), physical registers
+/// like rax, rbx, r12 are shown.
+fn print_assembly(mir: &rue_compiler::X86Mir) {
+    use rue_codegen::x86_64::X86Inst;
+
+    // Print instructions
+    for inst in mir.instructions() {
+        match inst {
+            X86Inst::Label { name } => println!("{}:", name),
+            _ => println!("    {}", inst),
         }
     }
 }


### PR DESCRIPTION
Consolidates the separate --dump-rir, --dump-air, and --dump-mir flags into a single --emit <stage> flag that can be specified multiple times.

New emit stages:
- tokens: Lexer output with spans
- ast: Parsed abstract syntax tree
- rir: Untyped intermediate representation
- air: Typed intermediate representation
- cfg: Control flow graph
- mir: Machine intermediate representation
- asm: x86-64 assembly text

This provides a more consistent interface for inspecting compiler internals and allows viewing multiple stages in a single invocation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)