### PR TITLE
Add duplicate struct field detection

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -339,6 +339,21 @@ impl<'a> Sema<'a> {
                 let struct_id = StructId(self.struct_defs.len() as u32);
                 let struct_name = self.interner.get(*name).to_string();
 
+                // Check for duplicate field names
+                let mut seen_fields: HashSet<Symbol> = HashSet::new();
+                for (field_name, _) in fields {
+                    if !seen_fields.insert(*field_name) {
+                        let field_name_str = self.interner.get(*field_name).to_string();
+                        return Err(CompileError::new(
+                            ErrorKind::DuplicateField {
+                                struct_name: struct_name.clone(),
+                                field_name: field_name_str,
+                            },
+                            inst.span,
+                        ));
+                    }
+                }
+
                 // Resolve field types (can only be primitive types for now, or other structs)
                 let mut resolved_fields = Vec::new();
                 for (field_name, field_type) in fields {

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -61,6 +61,10 @@ pub enum ErrorKind {
         struct_name: String,
         field_name: String,
     },
+    DuplicateField {
+        struct_name: String,
+        field_name: String,
+    },
     FieldAccessOnNonStruct {
         found: String,
     },
@@ -219,6 +223,16 @@ impl fmt::Display for ErrorKind {
                 write!(
                     f,
                     "unknown field '{}' in struct '{}'",
+                    field_name, struct_name
+                )
+            }
+            ErrorKind::DuplicateField {
+                struct_name,
+                field_name,
+            } => {
+                write!(
+                    f,
+                    "duplicate field '{}' in struct '{}'",
                     field_name, struct_name
                 )
             }

--- a/crates/rue-spec/cases/15-structs.toml
+++ b/crates/rue-spec/cases/15-structs.toml
@@ -481,6 +481,20 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = "cannot assign"
 
+[[case]]
+name = "struct_duplicate_field"
+description = "Duplicate field names in struct definition"
+source = """
+struct Bad {
+    x: i32,
+    x: i32,
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "duplicate"
+
 # =============================================================================
 # Structs as Function Parameters
 # =============================================================================


### PR DESCRIPTION
Detect and reject struct definitions with duplicate field names during semantic analysis. Previously, defining the same field twice would silently compile but produce undefined behavior.

- Add DuplicateField error variant to rue-error
- Check for duplicate field names in sema before resolving types
- Add spec test for compile-fail case

Closes bd-tree1-q41