### PR TITLE
Add error for unsupported aarch64-linux target

### DIFF
--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -367,6 +367,14 @@ fn link_system(
 
 /// Compile for AArch64 target.
 fn compile_aarch64(state: &CompileState, options: &CompileOptions) -> CompileResult<CompileOutput> {
+    // AArch64 Linux is not yet supported - only macOS works for now.
+    // The internal ELF linker needs testing with AArch64 relocations before enabling.
+    if options.target == Target::Aarch64Linux {
+        return Err(CompileError::without_span(ErrorKind::UnsupportedTarget(
+            "aarch64-linux is not yet supported; use aarch64-macos or x86-64-linux".into(),
+        )));
+    }
+
     // Generate machine code for all functions using the aarch64 backend
     let mut object_files: Vec<Vec<u8>> = Vec::new();
 

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -108,6 +108,9 @@ pub enum ErrorKind {
 
     // Linker errors
     LinkError(String),
+
+    // Target errors
+    UnsupportedTarget(String),
 }
 
 impl CompileError {
@@ -309,6 +312,7 @@ impl fmt::Display for ErrorKind {
                 write!(f, "type annotation required for empty array")
             }
             ErrorKind::LinkError(msg) => write!(f, "link error: {}", msg),
+            ErrorKind::UnsupportedTarget(msg) => write!(f, "unsupported target: {}", msg),
         }
     }
 }


### PR DESCRIPTION
AArch64 Linux is not yet supported - only macOS works for the AArch64 backend. The internal ELF linker needs testing with AArch64 relocations before this target can be enabled.

Previously, attempting to compile for aarch64-linux would route to the macOS linker path, producing incorrect output. Now we return a clear error message directing users to use aarch64-macos or x86-64-linux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)