### PR TITLE
Replace String labels with LabelId newtype in AArch64 MIR

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -10,7 +10,7 @@ use rue_cfg::{
     BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, StructDef, StructId, Terminator, Type,
 };
 
-use super::mir::{Aarch64Inst, Aarch64Mir, Cond, Operand, Reg, VReg};
+use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Operand, Reg, VReg};
 
 /// Argument passing registers per AAPCS64.
 const ARG_REGS: [Reg; 8] = [
@@ -47,14 +47,12 @@ pub struct CfgLower<'a> {
     value_map: HashMap<CfgValue, VReg>,
     /// Maps block parameters to vregs (block_id, param_index) -> vreg
     block_param_vregs: HashMap<(BlockId, u32), VReg>,
-    /// Label counter for generating unique labels
-    label_counter: u32,
     /// Number of local variable slots
     num_locals: u32,
     /// Number of parameter slots
     num_params: u32,
-    /// Function name
-    fn_name: String,
+    /// Function name (needed to detect main function)
+    fn_name: &'a str,
     /// Maps StructInit CFG values to their field vregs
     struct_field_vregs: HashMap<CfgValue, Vec<VReg>>,
 }
@@ -75,10 +73,9 @@ impl<'a> CfgLower<'a> {
             mir: Aarch64Mir::new(),
             value_map: HashMap::new(),
             block_param_vregs: HashMap::new(),
-            label_counter: 0,
             num_locals,
             num_params,
-            fn_name: cfg.fn_name().to_string(),
+            fn_name: cfg.fn_name(),
             struct_field_vregs: HashMap::new(),
         }
     }
@@ -124,10 +121,10 @@ impl<'a> CfgLower<'a> {
         });
 
         // If index < length (unsigned), branch to ok label; otherwise call bounds check
-        let ok_label = self.new_label("bounds_ok");
+        let ok_label = self.mir.alloc_label();
         self.mir.push(Aarch64Inst::BCond {
             cond: Cond::Lo, // Lower (unsigned <)
-            label: ok_label.clone(),
+            label: ok_label,
         });
 
         // Call the bounds check error handler (never returns)
@@ -136,20 +133,12 @@ impl<'a> CfgLower<'a> {
         });
 
         // Continue with valid access
-        self.mir.push(Aarch64Inst::Label { name: ok_label });
-    }
-
-    /// Generate a unique label name.
-    fn new_label(&mut self, prefix: &str) -> String {
-        // macOS requires symbols to start with underscore
-        let label = format!("_L{}_{}_{}", self.fn_name, prefix, self.label_counter);
-        self.label_counter += 1;
-        label
+        self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
     /// Get the label for a block.
-    fn block_label(&self, block_id: BlockId) -> String {
-        format!("_L{}_{}", self.fn_name, block_id.as_u32())
+    fn block_label(&self, block_id: BlockId) -> LabelId {
+        Aarch64Mir::block_label(block_id.as_u32())
     }
 
     /// Get or compute field vregs for a struct value.
@@ -279,7 +268,7 @@ impl<'a> CfgLower<'a> {
         // Emit block label (except for entry block)
         if block.id != self.cfg.entry {
             self.mir.push(Aarch64Inst::Label {
-                name: self.block_label(block.id),
+                id: self.block_label(block.id),
             });
         }
 
@@ -374,7 +363,7 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Overflow check - use appropriate flag based on signedness
-                self.emit_overflow_check_add(ty, vreg, "add_ok");
+                self.emit_overflow_check_add(ty, vreg);
             }
 
             CfgInstData::Sub(lhs, rhs) => {
@@ -400,7 +389,7 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Overflow check - use appropriate flag based on signedness
-                self.emit_overflow_check_sub(ty, vreg, "sub_ok");
+                self.emit_overflow_check_sub(ty, vreg);
             }
 
             CfgInstData::Mul(lhs, rhs) => {
@@ -411,7 +400,7 @@ impl<'a> CfgLower<'a> {
                 let rhs_vreg = self.get_vreg(*rhs);
 
                 // Overflow check for multiplication
-                self.emit_overflow_check_mul(ty, vreg, lhs_vreg, rhs_vreg, "mul_ok");
+                self.emit_overflow_check_mul(ty, vreg, lhs_vreg, rhs_vreg);
             }
 
             CfgInstData::Div(lhs, rhs) => {
@@ -422,15 +411,15 @@ impl<'a> CfgLower<'a> {
                 let rhs_vreg = self.get_vreg(*rhs);
 
                 // Division by zero check
-                let ok_label = self.new_label("div_ok");
+                let ok_label = self.mir.alloc_label();
                 self.mir.push(Aarch64Inst::Cbnz {
                     src: Operand::Virtual(rhs_vreg),
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
                 self.mir.push(Aarch64Inst::Bl {
                     symbol: "__rue_div_by_zero".to_string(),
                 });
-                self.mir.push(Aarch64Inst::Label { name: ok_label });
+                self.mir.push(Aarch64Inst::Label { id: ok_label });
 
                 self.mir.push(Aarch64Inst::SdivRR {
                     dst: Operand::Virtual(vreg),
@@ -447,15 +436,15 @@ impl<'a> CfgLower<'a> {
                 let rhs_vreg = self.get_vreg(*rhs);
 
                 // Division by zero check
-                let ok_label = self.new_label("mod_ok");
+                let ok_label = self.mir.alloc_label();
                 self.mir.push(Aarch64Inst::Cbnz {
                     src: Operand::Virtual(rhs_vreg),
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
                 self.mir.push(Aarch64Inst::Bl {
                     symbol: "__rue_div_by_zero".to_string(),
                 });
-                self.mir.push(Aarch64Inst::Label { name: ok_label });
+                self.mir.push(Aarch64Inst::Label { id: ok_label });
 
                 // Compute quotient first
                 let quot_vreg = self.mir.alloc_vreg();
@@ -493,7 +482,7 @@ impl<'a> CfgLower<'a> {
                 // Overflow check - use appropriate flag based on signedness
                 // For signed: V flag indicates overflow (when negating MIN_VALUE)
                 // For unsigned: C flag indicates non-zero operand (0 - x wraps for x != 0)
-                self.emit_overflow_check_neg(ty, vreg, "neg_ok");
+                self.emit_overflow_check_neg(ty, vreg);
             }
 
             CfgInstData::Not(operand) => {
@@ -1117,8 +1106,8 @@ impl<'a> CfgLower<'a> {
     /// - Unsigned (u32, u64): C (carry) flag - C=1 means overflow, so branch on Lo (C=0)
     ///
     /// For sub-word types, check if result fits in the type's range.
-    fn emit_overflow_check_add(&mut self, ty: Type, result_vreg: VReg, label_prefix: &str) {
-        let ok_label = self.new_label(label_prefix);
+    fn emit_overflow_check_add(&mut self, ty: Type, result_vreg: VReg) {
+        let ok_label = self.mir.alloc_label();
 
         match ty {
             // 32-bit and 64-bit unsigned: C=1 means overflow (carry out)
@@ -1126,14 +1115,12 @@ impl<'a> CfgLower<'a> {
             Type::U32 | Type::U64 => {
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Lo, // Lo = C=0 (no carry)
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
             }
             // 32-bit and 64-bit signed: V flag indicates overflow
             Type::I32 | Type::I64 => {
-                self.mir.push(Aarch64Inst::Bvc {
-                    label: ok_label.clone(),
-                });
+                self.mir.push(Aarch64Inst::Bvc { label: ok_label });
             }
             // Sub-word unsigned types: check if result fits in range [0, max]
             Type::U8 => {
@@ -1145,7 +1132,7 @@ impl<'a> CfgLower<'a> {
                 // Branch if below or same (unsigned <=)
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Ls,
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
             }
             Type::U16 => {
@@ -1161,7 +1148,7 @@ impl<'a> CfgLower<'a> {
                 });
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Ls,
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
             }
             // Sub-word signed types: check if result fits in range [min, max]
@@ -1178,7 +1165,7 @@ impl<'a> CfgLower<'a> {
                 });
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Eq,
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
             }
             Type::I16 => {
@@ -1194,7 +1181,7 @@ impl<'a> CfgLower<'a> {
                 });
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Eq,
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
             }
             // Other types don't have arithmetic
@@ -1205,7 +1192,7 @@ impl<'a> CfgLower<'a> {
         self.mir.push(Aarch64Inst::Bl {
             symbol: "__rue_overflow".to_string(),
         });
-        self.mir.push(Aarch64Inst::Label { name: ok_label });
+        self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
     /// Emit overflow check for SUB based on the type.
@@ -1213,8 +1200,8 @@ impl<'a> CfgLower<'a> {
     /// For ARM64 SUBS:
     /// - Signed: V flag indicates overflow
     /// - Unsigned: C=0 means borrow (underflow), C=1 means no borrow
-    fn emit_overflow_check_sub(&mut self, ty: Type, result_vreg: VReg, label_prefix: &str) {
-        let ok_label = self.new_label(label_prefix);
+    fn emit_overflow_check_sub(&mut self, ty: Type, result_vreg: VReg) {
+        let ok_label = self.mir.alloc_label();
 
         match ty {
             // 32-bit and 64-bit unsigned: C=0 means borrow (underflow)
@@ -1222,14 +1209,12 @@ impl<'a> CfgLower<'a> {
             Type::U32 | Type::U64 => {
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Hs, // Hs = C=1 (no borrow)
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
             }
             // 32-bit and 64-bit signed: V flag indicates overflow
             Type::I32 | Type::I64 => {
-                self.mir.push(Aarch64Inst::Bvc {
-                    label: ok_label.clone(),
-                });
+                self.mir.push(Aarch64Inst::Bvc { label: ok_label });
             }
             // Sub-word types: same as ADD - check range
             Type::U8 | Type::U16 | Type::I8 | Type::I16 => {
@@ -1243,7 +1228,7 @@ impl<'a> CfgLower<'a> {
                         });
                         self.mir.push(Aarch64Inst::BCond {
                             cond: Cond::Ls,
-                            label: ok_label.clone(),
+                            label: ok_label,
                         });
                     }
                     Type::U16 => {
@@ -1258,7 +1243,7 @@ impl<'a> CfgLower<'a> {
                         });
                         self.mir.push(Aarch64Inst::BCond {
                             cond: Cond::Ls,
-                            label: ok_label.clone(),
+                            label: ok_label,
                         });
                     }
                     Type::I8 => {
@@ -1273,7 +1258,7 @@ impl<'a> CfgLower<'a> {
                         });
                         self.mir.push(Aarch64Inst::BCond {
                             cond: Cond::Eq,
-                            label: ok_label.clone(),
+                            label: ok_label,
                         });
                     }
                     Type::I16 => {
@@ -1288,7 +1273,7 @@ impl<'a> CfgLower<'a> {
                         });
                         self.mir.push(Aarch64Inst::BCond {
                             cond: Cond::Eq,
-                            label: ok_label.clone(),
+                            label: ok_label,
                         });
                     }
                     _ => unreachable!(),
@@ -1301,7 +1286,7 @@ impl<'a> CfgLower<'a> {
         self.mir.push(Aarch64Inst::Bl {
             symbol: "__rue_overflow".to_string(),
         });
-        self.mir.push(Aarch64Inst::Label { name: ok_label });
+        self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
     /// Emit overflow check for MUL based on the type.
@@ -1315,9 +1300,8 @@ impl<'a> CfgLower<'a> {
         result_vreg: VReg,
         lhs_vreg: VReg,
         rhs_vreg: VReg,
-        label_prefix: &str,
     ) {
-        let ok_label = self.new_label(label_prefix);
+        let ok_label = self.mir.alloc_label();
 
         match ty {
             // 32-bit signed: SMULL gives 64-bit result
@@ -1346,7 +1330,7 @@ impl<'a> CfgLower<'a> {
                 });
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Eq,
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
             }
             // 32-bit unsigned: UMULL gives 64-bit result
@@ -1371,7 +1355,7 @@ impl<'a> CfgLower<'a> {
                 });
                 self.mir.push(Aarch64Inst::Cbz {
                     src: Operand::Virtual(high_vreg),
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
             }
             // 64-bit signed: Use SMULH for high bits
@@ -1403,7 +1387,7 @@ impl<'a> CfgLower<'a> {
                 });
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Eq,
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
             }
             // 64-bit unsigned: Use UMULH for high bits
@@ -1424,7 +1408,7 @@ impl<'a> CfgLower<'a> {
                 // If high bits are zero, no overflow
                 self.mir.push(Aarch64Inst::Cbz {
                     src: Operand::Virtual(high_vreg),
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
             }
             // Sub-word types: do the multiply, then check range
@@ -1444,7 +1428,7 @@ impl<'a> CfgLower<'a> {
                         });
                         self.mir.push(Aarch64Inst::BCond {
                             cond: Cond::Ls,
-                            label: ok_label.clone(),
+                            label: ok_label,
                         });
                     }
                     Type::U16 => {
@@ -1459,7 +1443,7 @@ impl<'a> CfgLower<'a> {
                         });
                         self.mir.push(Aarch64Inst::BCond {
                             cond: Cond::Ls,
-                            label: ok_label.clone(),
+                            label: ok_label,
                         });
                     }
                     Type::I8 => {
@@ -1474,7 +1458,7 @@ impl<'a> CfgLower<'a> {
                         });
                         self.mir.push(Aarch64Inst::BCond {
                             cond: Cond::Eq,
-                            label: ok_label.clone(),
+                            label: ok_label,
                         });
                     }
                     Type::I16 => {
@@ -1489,7 +1473,7 @@ impl<'a> CfgLower<'a> {
                         });
                         self.mir.push(Aarch64Inst::BCond {
                             cond: Cond::Eq,
-                            label: ok_label.clone(),
+                            label: ok_label,
                         });
                     }
                     _ => unreachable!(),
@@ -1501,7 +1485,7 @@ impl<'a> CfgLower<'a> {
         self.mir.push(Aarch64Inst::Bl {
             symbol: "__rue_overflow".to_string(),
         });
-        self.mir.push(Aarch64Inst::Label { name: ok_label });
+        self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
     /// Emit overflow check for NEG based on the type.
@@ -1509,8 +1493,8 @@ impl<'a> CfgLower<'a> {
     /// For NEGS (0 - x):
     /// - Signed: V flag indicates overflow (when negating MIN_VALUE)
     /// - Unsigned: Any non-zero value causes overflow (since 0 - x wraps)
-    fn emit_overflow_check_neg(&mut self, ty: Type, result_vreg: VReg, label_prefix: &str) {
-        let ok_label = self.new_label(label_prefix);
+    fn emit_overflow_check_neg(&mut self, ty: Type, result_vreg: VReg) {
+        let ok_label = self.mir.alloc_label();
 
         match ty {
             // Unsigned: NEGS sets C=0 for non-zero operands (which is overflow)
@@ -1518,14 +1502,12 @@ impl<'a> CfgLower<'a> {
             Type::U32 | Type::U64 => {
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Hs, // Hs = C=1
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
             }
             // Signed: V flag indicates overflow
             Type::I32 | Type::I64 => {
-                self.mir.push(Aarch64Inst::Bvc {
-                    label: ok_label.clone(),
-                });
+                self.mir.push(Aarch64Inst::Bvc { label: ok_label });
             }
             // Sub-word types: check range
             Type::U8 | Type::U16 => {
@@ -1533,7 +1515,7 @@ impl<'a> CfgLower<'a> {
                 // Result must be 0 for no overflow
                 self.mir.push(Aarch64Inst::Cbz {
                     src: Operand::Virtual(result_vreg),
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
             }
             Type::I8 => {
@@ -1548,7 +1530,7 @@ impl<'a> CfgLower<'a> {
                 });
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Eq,
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
             }
             Type::I16 => {
@@ -1563,7 +1545,7 @@ impl<'a> CfgLower<'a> {
                 });
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Eq,
-                    label: ok_label.clone(),
+                    label: ok_label,
                 });
             }
             _ => return,
@@ -1572,7 +1554,7 @@ impl<'a> CfgLower<'a> {
         self.mir.push(Aarch64Inst::Bl {
             symbol: "__rue_overflow".to_string(),
         });
-        self.mir.push(Aarch64Inst::Label { name: ok_label });
+        self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
     /// Emit a comparison instruction.
@@ -1633,12 +1615,12 @@ impl<'a> CfgLower<'a> {
                 let cond_vreg = self.get_vreg(*cond);
 
                 // Generate a unique label for the else path argument setup
-                let else_setup_label = self.new_label("else_setup");
+                let else_setup_label = self.mir.alloc_label();
 
                 // If zero, jump to else setup (where we copy else_args)
                 self.mir.push(Aarch64Inst::Cbz {
                     src: Operand::Virtual(cond_vreg),
-                    label: else_setup_label.clone(),
+                    label: else_setup_label,
                 });
 
                 // Copy then_args to then_block's params
@@ -1665,7 +1647,7 @@ impl<'a> CfgLower<'a> {
 
                 // Else setup: copy else_args to else_block's params
                 self.mir.push(Aarch64Inst::Label {
-                    name: else_setup_label,
+                    id: else_setup_label,
                 });
                 for (i, &arg) in else_args.iter().enumerate() {
                     let arg_type = self.cfg.get_inst(arg).ty;

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -5,7 +5,7 @@
 
 use std::collections::HashMap;
 
-use super::mir::{Aarch64Inst, Aarch64Mir, Cond, Reg};
+use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Reg};
 use crate::EmittedRelocation;
 
 // ========== AArch64 Instruction Encoding Constants ==========
@@ -120,8 +120,8 @@ const OPCODE_UBFM_X: u32 = 0xD3400000;
 struct Fixup {
     /// Offset of the instruction in the code.
     offset: usize,
-    /// Target label name.
-    label: String,
+    /// Target label ID.
+    label: LabelId,
     /// Kind of branch (for calculating offset).
     kind: FixupKind,
 }
@@ -139,7 +139,7 @@ pub struct Emitter<'a> {
     mir: &'a Aarch64Mir,
     code: Vec<u8>,
     relocations: Vec<EmittedRelocation>,
-    labels: HashMap<String, usize>,
+    labels: HashMap<LabelId, usize>,
     fixups: Vec<Fixup>,
     num_locals: u32,
     num_params: u32,
@@ -491,12 +491,12 @@ impl<'a> Emitter<'a> {
 
             Aarch64Inst::Cbz { src, label } => {
                 let rt = src.as_physical();
-                self.emit_cbz(rt, label, false);
+                self.emit_cbz(rt, *label, false);
             }
 
             Aarch64Inst::Cbnz { src, label } => {
                 let rt = src.as_physical();
-                self.emit_cbz(rt, label, true);
+                self.emit_cbz(rt, *label, true);
             }
 
             Aarch64Inst::Cset { dst, cond } => {
@@ -542,25 +542,25 @@ impl<'a> Emitter<'a> {
             }
 
             Aarch64Inst::B { label } => {
-                self.emit_b(label);
+                self.emit_b(*label);
             }
 
             Aarch64Inst::BCond { cond, label } => {
-                self.emit_bcond(*cond, label);
+                self.emit_bcond(*cond, *label);
             }
 
             Aarch64Inst::Bvs { label } => {
                 // B.VS = branch if overflow set (cond = 0110)
-                self.emit_bcond_raw(6, label);
+                self.emit_bcond_raw(6, *label);
             }
 
             Aarch64Inst::Bvc { label } => {
                 // B.VC = branch if overflow clear (cond = 0111)
-                self.emit_bcond_raw(7, label);
+                self.emit_bcond_raw(7, *label);
             }
 
-            Aarch64Inst::Label { name } => {
-                self.labels.insert(name.clone(), self.code.len());
+            Aarch64Inst::Label { id } => {
+                self.labels.insert(*id, self.code.len());
             }
 
             Aarch64Inst::Bl { symbol } => {
@@ -1115,7 +1115,7 @@ impl<'a> Emitter<'a> {
         self.emit_u32(inst);
     }
 
-    fn emit_cbz(&mut self, rt: Reg, label: &str, is_nz: bool) {
+    fn emit_cbz(&mut self, rt: Reg, label: LabelId, is_nz: bool) {
         // CBZ/CBNZ Xt, label
         let op = if is_nz { 1 } else { 0 };
         let offset = self.code.len();
@@ -1126,7 +1126,7 @@ impl<'a> Emitter<'a> {
 
         self.fixups.push(Fixup {
             offset,
-            label: label.to_string(),
+            label,
             kind: FixupKind::CondBranch,
         });
     }
@@ -1158,38 +1158,38 @@ impl<'a> Emitter<'a> {
         self.emit_u32(inst);
     }
 
-    fn emit_b(&mut self, label: &str) {
+    fn emit_b(&mut self, label: LabelId) {
         // B label
         let offset = self.code.len();
         self.emit_u32(OPCODE_B);
 
         self.fixups.push(Fixup {
             offset,
-            label: label.to_string(),
+            label,
             kind: FixupKind::Branch,
         });
     }
 
-    fn emit_bcond(&mut self, cond: Cond, label: &str) {
+    fn emit_bcond(&mut self, cond: Cond, label: LabelId) {
         let offset = self.code.len();
         let inst = OPCODE_BCOND | cond.encoding() as u32;
         self.emit_u32(inst);
 
         self.fixups.push(Fixup {
             offset,
-            label: label.to_string(),
+            label,
             kind: FixupKind::CondBranch,
         });
     }
 
-    fn emit_bcond_raw(&mut self, cond: u8, label: &str) {
+    fn emit_bcond_raw(&mut self, cond: u8, label: LabelId) {
         let offset = self.code.len();
         let inst = OPCODE_BCOND | cond as u32;
         self.emit_u32(inst);
 
         self.fixups.push(Fixup {
             offset,
-            label: label.to_string(),
+            label,
             kind: FixupKind::CondBranch,
         });
     }

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -11,7 +11,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use super::mir::{Aarch64Inst, Aarch64Mir, Operand, Reg, VReg};
+use super::mir::{Aarch64Inst, Aarch64Mir, LabelId, Operand, Reg, VReg};
 
 /// Live range for a virtual register.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -96,10 +96,10 @@ pub fn analyze(mir: &Aarch64Mir) -> LivenessInfo {
     }
 
     // Step 1: Build label -> instruction index map
-    let mut label_to_idx: HashMap<&str, usize> = HashMap::new();
+    let mut label_to_idx: HashMap<LabelId, usize> = HashMap::new();
     for (idx, inst) in instructions.iter().enumerate() {
-        if let Aarch64Inst::Label { name } = inst {
-            label_to_idx.insert(name.as_str(), idx);
+        if let Aarch64Inst::Label { id } = inst {
+            label_to_idx.insert(*id, idx);
         }
     }
 
@@ -109,7 +109,7 @@ pub fn analyze(mir: &Aarch64Mir) -> LivenessInfo {
         match inst {
             // Unconditional branch - only successor is the target
             Aarch64Inst::B { label } => {
-                if let Some(&target) = label_to_idx.get(label.as_str()) {
+                if let Some(&target) = label_to_idx.get(label) {
                     successors[idx].push(target);
                 }
             }
@@ -124,7 +124,7 @@ pub fn analyze(mir: &Aarch64Mir) -> LivenessInfo {
                     successors[idx].push(idx + 1);
                 }
                 // Branch target
-                if let Some(&target) = label_to_idx.get(label.as_str()) {
+                if let Some(&target) = label_to_idx.get(label) {
                     successors[idx].push(target);
                 }
             }
@@ -536,6 +536,8 @@ mod tests {
         let mut mir = Aarch64Mir::new();
         let v0 = mir.alloc_vreg();
         let v1 = mir.alloc_vreg();
+        let label_else = mir.alloc_label();
+        let label_end = mir.alloc_label();
 
         // v0 = 1
         mir.push(Aarch64Inst::MovImm {
@@ -546,7 +548,7 @@ mod tests {
         // cbz v0, label_else
         mir.push(Aarch64Inst::Cbz {
             src: Operand::Virtual(v0),
-            label: "label_else".to_string(),
+            label: label_else,
         });
 
         // v1 = v0 (then branch)
@@ -556,14 +558,10 @@ mod tests {
         });
 
         // b label_end
-        mir.push(Aarch64Inst::B {
-            label: "label_end".to_string(),
-        });
+        mir.push(Aarch64Inst::B { label: label_end });
 
         // label_else:
-        mir.push(Aarch64Inst::Label {
-            name: "label_else".to_string(),
-        });
+        mir.push(Aarch64Inst::Label { id: label_else });
 
         // v1 = 2 (else branch)
         mir.push(Aarch64Inst::MovImm {
@@ -572,9 +570,7 @@ mod tests {
         });
 
         // label_end:
-        mir.push(Aarch64Inst::Label {
-            name: "label_end".to_string(),
-        });
+        mir.push(Aarch64Inst::Label { id: label_end });
 
         // Use v1 at the end
         mir.push(Aarch64Inst::MovRR {
@@ -604,6 +600,7 @@ mod tests {
         // Test B.cond handling
         let mut mir = Aarch64Mir::new();
         let v0 = mir.alloc_vreg();
+        let skip_label = mir.alloc_label();
 
         mir.push(Aarch64Inst::MovImm {
             dst: Operand::Virtual(v0),
@@ -617,7 +614,7 @@ mod tests {
 
         mir.push(Aarch64Inst::BCond {
             cond: Cond::Eq,
-            label: "skip".to_string(),
+            label: skip_label,
         });
 
         // v0 is used after the conditional branch
@@ -626,9 +623,7 @@ mod tests {
             src: Operand::Virtual(v0),
         });
 
-        mir.push(Aarch64Inst::Label {
-            name: "skip".to_string(),
-        });
+        mir.push(Aarch64Inst::Label { id: skip_label });
 
         mir.push(Aarch64Inst::Ret);
 
@@ -653,6 +648,7 @@ mod tests {
         let mut mir = Aarch64Mir::new();
         let v0 = mir.alloc_vreg();
         let v1 = mir.alloc_vreg();
+        let loop_label = mir.alloc_label();
 
         // v0 = 10
         mir.push(Aarch64Inst::MovImm {
@@ -661,9 +657,7 @@ mod tests {
         });
 
         // loop:
-        mir.push(Aarch64Inst::Label {
-            name: "loop".to_string(),
-        });
+        mir.push(Aarch64Inst::Label { id: loop_label });
 
         // v1 = v0
         mir.push(Aarch64Inst::MovRR {
@@ -681,7 +675,7 @@ mod tests {
         // cbnz v0, loop
         mir.push(Aarch64Inst::Cbnz {
             src: Operand::Virtual(v0),
-            label: "loop".to_string(),
+            label: loop_label,
         });
 
         mir.push(Aarch64Inst::Ret);

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -34,6 +34,33 @@ impl fmt::Display for VReg {
     }
 }
 
+/// A label identifier.
+///
+/// Labels are local to a function and are represented as a lightweight u32 index
+/// rather than as heap-allocated strings. This avoids allocations during codegen.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LabelId(u32);
+
+impl LabelId {
+    /// Create a new label with the given index.
+    #[inline]
+    pub const fn new(index: u32) -> Self {
+        Self(index)
+    }
+
+    /// Get the index of this label.
+    #[inline]
+    pub const fn index(self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for LabelId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, ".L{}", self.0)
+    }
+}
+
 /// A physical AArch64 register.
 ///
 /// AArch64 has 31 general-purpose registers (X0-X30), plus SP and XZR.
@@ -573,10 +600,10 @@ pub enum Aarch64Inst {
     CmpImm { src: Operand, imm: i32 },
 
     /// `cbz src, label` - Compare and branch if zero.
-    Cbz { src: Operand, label: String },
+    Cbz { src: Operand, label: LabelId },
 
     /// `cbnz src, label` - Compare and branch if not zero.
-    Cbnz { src: Operand, label: String },
+    Cbnz { src: Operand, label: LabelId },
 
     /// `cset dst, cond` - Conditional set: dst = 1 if cond, else 0.
     Cset { dst: Operand, cond: Cond },
@@ -604,19 +631,19 @@ pub enum Aarch64Inst {
 
     // === Control flow ===
     /// `b label` - Unconditional branch.
-    B { label: String },
+    B { label: LabelId },
 
     /// `b.cond label` - Conditional branch.
-    BCond { cond: Cond, label: String },
+    BCond { cond: Cond, label: LabelId },
 
     /// `b.vs label` - Branch if overflow set.
-    Bvs { label: String },
+    Bvs { label: LabelId },
 
     /// `b.vc label` - Branch if overflow clear.
-    Bvc { label: String },
+    Bvc { label: LabelId },
 
     /// Label marker (not a real instruction).
-    Label { name: String },
+    Label { id: LabelId },
 
     /// `bl symbol` - Branch with link (call).
     Bl { symbol: String },
@@ -776,7 +803,7 @@ impl fmt::Display for Aarch64Inst {
             Aarch64Inst::BCond { cond, label } => write!(f, "b.{} {}", cond, label),
             Aarch64Inst::Bvs { label } => write!(f, "b.vs {}", label),
             Aarch64Inst::Bvc { label } => write!(f, "b.vc {}", label),
-            Aarch64Inst::Label { name } => write!(f, "{}:", name),
+            Aarch64Inst::Label { id } => write!(f, "{}:", id),
             Aarch64Inst::Bl { symbol } => write!(f, "bl {}", symbol),
             Aarch64Inst::Ret => write!(f, "ret"),
             Aarch64Inst::StpPre { src1, src2, offset } => {
@@ -796,6 +823,8 @@ pub struct Aarch64Mir {
     instructions: Vec<Aarch64Inst>,
     /// The next virtual register index.
     next_vreg: u32,
+    /// The next label index.
+    next_label: u32,
 }
 
 impl Aarch64Mir {
@@ -804,6 +833,7 @@ impl Aarch64Mir {
         Self {
             instructions: Vec::new(),
             next_vreg: 0,
+            next_label: 0,
         }
     }
 
@@ -812,6 +842,23 @@ impl Aarch64Mir {
         let vreg = VReg::new(self.next_vreg);
         self.next_vreg += 1;
         vreg
+    }
+
+    /// Allocate a new label.
+    pub fn alloc_label(&mut self) -> LabelId {
+        let label = LabelId::new(self.next_label);
+        self.next_label += 1;
+        label
+    }
+
+    /// Get the label for a block.
+    ///
+    /// Block IDs are mapped to label IDs with a simple offset to avoid
+    /// collisions with other allocated labels. Block labels use IDs starting
+    /// at u32::MAX / 2.
+    pub fn block_label(block_id: u32) -> LabelId {
+        // Use high label IDs for blocks to avoid collision with alloc_label()
+        LabelId::new(u32::MAX / 2 + block_id)
     }
 
     /// Get the number of virtual registers allocated.

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -720,7 +720,7 @@ impl RegAlloc {
             Aarch64Inst::BCond { cond, label } => mir.push(Aarch64Inst::BCond { cond, label }),
             Aarch64Inst::Bvs { label } => mir.push(Aarch64Inst::Bvs { label }),
             Aarch64Inst::Bvc { label } => mir.push(Aarch64Inst::Bvc { label }),
-            Aarch64Inst::Label { name } => mir.push(Aarch64Inst::Label { name }),
+            Aarch64Inst::Label { id } => mir.push(Aarch64Inst::Label { id }),
             Aarch64Inst::Bl { symbol } => mir.push(Aarch64Inst::Bl { symbol }),
             Aarch64Inst::Ret => mir.push(Aarch64Inst::Ret),
         }


### PR DESCRIPTION
This mirrors the x86_64 change from commit cb61ed6, applying the same optimization to the AArch64 backend. Labels are now represented as lightweight u32 indices rather than heap-allocated strings, avoiding allocations during codegen.

Key changes:
- Add LabelId newtype to mir.rs with alloc_label() for generating unique labels
- Add block_label() helper that maps block IDs to label IDs
- Update all branch instructions (B, BCond, Cbz, Cbnz, Bvs, Bvc) to use LabelId
- Update cfg_lower.rs to use mir.alloc_label() instead of new_label() method
- Remove the label_counter field and new_label() helper from Lowerer
- Update emit.rs and liveness.rs to work with LabelId instead of String

🤖 Generated with [Claude Code](https://claude.com/claude-code)