### PR TITLE
Require struct fields to be initialized in declaration order

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -1351,6 +1351,22 @@ impl<'a> Sema<'a> {
                     ));
                 }
 
+                // Check that fields are in declaration order
+                for (i, (init_field_name, _)) in field_inits.iter().enumerate() {
+                    let init_name = self.interner.get(*init_field_name);
+                    let expected_name = &struct_def.fields[i].name;
+                    if init_name != expected_name {
+                        return Err(CompileError::new(
+                            ErrorKind::FieldWrongOrder {
+                                struct_name: struct_def.name.clone(),
+                                expected_field: expected_name.clone(),
+                                found_field: init_name.to_string(),
+                            },
+                            inst.span,
+                        ));
+                    }
+                }
+
                 // Analyze field values in declaration order
                 // First, build a map from field name to its value
                 let mut field_map: HashMap<String, InstRef> = HashMap::new();

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -65,6 +65,11 @@ pub enum ErrorKind {
         struct_name: String,
         field_name: String,
     },
+    FieldWrongOrder {
+        struct_name: String,
+        expected_field: String,
+        found_field: String,
+    },
     FieldAccessOnNonStruct {
         found: String,
     },
@@ -237,6 +242,17 @@ impl fmt::Display for ErrorKind {
                     f,
                     "duplicate field '{}' in struct '{}'",
                     field_name, struct_name
+                )
+            }
+            ErrorKind::FieldWrongOrder {
+                struct_name,
+                expected_field,
+                found_field,
+            } => {
+                write!(
+                    f,
+                    "struct '{}' fields must be initialized in declaration order: expected '{}', found '{}'",
+                    struct_name, expected_field, found_field
                 )
             }
             ErrorKind::FieldAccessOnNonStruct { found } => {

--- a/crates/rue-spec/cases/15-structs.toml
+++ b/crates/rue-spec/cases/15-structs.toml
@@ -334,8 +334,8 @@ exit_code = 10
 # =============================================================================
 
 [[case]]
-name = "struct_field_order_independence"
-description = "Field order in literal doesn't matter (matches definition order)"
+name = "struct_field_wrong_order"
+description = "Fields must be initialized in declaration order"
 source = """
 struct Point {
     x: i32,
@@ -347,7 +347,8 @@ fn main() -> i32 {
     p.x + p.y
 }
 """
-exit_code = 42
+compile_fail = true
+error_contains = "order"
 
 [[case]]
 name = "struct_same_field_names_different_structs"


### PR DESCRIPTION
Previously, struct field initializers could be specified in any order and would be matched to the correct fields by name. This change enforces that fields must be initialized in the same order they are declared in the struct definition.

This simplifies the semantic analysis and makes struct initialization more predictable and readable.