### PR TITLE
Add else if chain support to parser

### DIFF
--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -386,24 +386,38 @@ where
             })
         });
 
-    // If expression
-    let if_expr = just(TokenKind::If)
-        .ignore_then(expr.clone())
-        .then(maybe_unit_block_parser(expr.clone()))
-        .then(
-            just(TokenKind::Else)
-                .ignore_then(maybe_unit_block_parser(expr.clone()))
-                .or_not(),
-        )
-        .map_with(|((cond, then_block), else_block), e| {
-            Expr::If(IfExpr {
-                cond: Box::new(cond),
-                then_block,
-                else_block,
-                span: to_rue_span(e.span()),
+    // If expression - defined with recursive reference to allow `else if` chains
+    let if_expr = recursive(|if_expr_rec| {
+        just(TokenKind::If)
+            .ignore_then(expr.clone())
+            .then(maybe_unit_block_parser(expr.clone()))
+            .then(
+                just(TokenKind::Else)
+                    .ignore_then(choice((
+                        // else if: wrap the nested if in a synthetic block
+                        if_expr_rec.map_with(|nested_if, e| {
+                            let span = to_rue_span(e.span());
+                            BlockExpr {
+                                statements: Vec::new(),
+                                expr: Box::new(nested_if),
+                                span,
+                            }
+                        }),
+                        // else { ... }: parse a regular block
+                        maybe_unit_block_parser(expr.clone()),
+                    )))
+                    .or_not(),
+            )
+            .map_with(|((cond, then_block), else_block), e| {
+                Expr::If(IfExpr {
+                    cond: Box::new(cond),
+                    then_block,
+                    else_block,
+                    span: to_rue_span(e.span()),
+                })
             })
-        })
-        .boxed();
+    })
+    .boxed();
 
     // While expression
     let while_expr = just(TokenKind::While)

--- a/crates/rue-spec/cases/10-conditionals.toml
+++ b/crates/rue-spec/cases/10-conditionals.toml
@@ -303,3 +303,101 @@ fn main() -> i32 {
 }
 """
 exit_code = 3
+
+# =============================================================================
+# Else If Chains
+# =============================================================================
+
+[[case]]
+name = "else_if_basic"
+source = """
+fn main() -> i32 {
+    let x = 2;
+    if x == 1 { 10 }
+    else if x == 2 { 20 }
+    else { 0 }
+}
+"""
+exit_code = 20
+
+[[case]]
+name = "else_if_chain"
+source = """
+fn main() -> i32 {
+    let x = 2;
+    if x == 1 { 10 }
+    else if x == 2 { 20 }
+    else if x == 3 { 30 }
+    else { 0 }
+}
+"""
+exit_code = 20
+
+[[case]]
+name = "else_if_first_branch"
+source = """
+fn main() -> i32 {
+    let x = 1;
+    if x == 1 { 10 }
+    else if x == 2 { 20 }
+    else if x == 3 { 30 }
+    else { 0 }
+}
+"""
+exit_code = 10
+
+[[case]]
+name = "else_if_last_branch"
+source = """
+fn main() -> i32 {
+    let x = 3;
+    if x == 1 { 10 }
+    else if x == 2 { 20 }
+    else if x == 3 { 30 }
+    else { 0 }
+}
+"""
+exit_code = 30
+
+[[case]]
+name = "else_if_fallthrough"
+source = """
+fn main() -> i32 {
+    let x = 99;
+    if x == 1 { 10 }
+    else if x == 2 { 20 }
+    else if x == 3 { 30 }
+    else { 0 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "else_if_with_complex_conditions"
+source = """
+fn main() -> i32 {
+    let x = 15;
+    if x < 10 { 1 }
+    else if x < 20 { 2 }
+    else if x < 30 { 3 }
+    else { 4 }
+}
+"""
+exit_code = 2
+
+[[case]]
+name = "else_if_nested_in_else_if"
+source = """
+fn main() -> i32 {
+    let x = 2;
+    let y = 1;
+    if x == 1 { 10 }
+    else if x == 2 {
+        if y == 1 { 21 }
+        else if y == 2 { 22 }
+        else { 20 }
+    }
+    else { 0 }
+}
+"""
+exit_code = 21

--- a/docs/language.md
+++ b/docs/language.md
@@ -425,7 +425,18 @@ fn main() -> i32 {
 }
 ```
 
-If/else can be nested:
+If/else can be chained with `else if`:
+
+```rue
+fn main() -> i32 {
+    let x = 5;
+    if x < 3 { 1 }
+    else if x < 7 { 2 }
+    else { 3 }
+}
+```
+
+This is syntactic sugar for nested if/else:
 
 ```rue
 fn main() -> i32 {
@@ -831,7 +842,7 @@ primary        = INTEGER | BOOL | IDENT | "(" expression ")" | block_expr
 array_literal  = "[" [ expression { "," expression } ] "]" ;
 return_expr    = "return" expression ;
 block_expr     = "{" block "}" ;
-if_expr        = "if" expression "{" block "}" [ "else" "{" block "}" ] ;
+if_expr        = "if" expression "{" block "}" [ "else" ( if_expr | "{" block "}" ) ] ;
 match_expr     = "match" expression "{" { match_arm "," } [ match_arm ] "}" ;
 match_arm      = pattern "=>" expression ;
 pattern        = "_" | INTEGER | BOOL ;


### PR DESCRIPTION
The parser now handles `else if` as syntactic sugar for nested if/else. When parsing `else if`, the nested if expression is wrapped in a synthetic block, maintaining the existing AST structure while providing the familiar chained conditional syntax.