### PR TITLE
Add bidirectional type inference for integer literals

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -2001,9 +2001,9 @@ impl<'a> Sema<'a> {
 
     /// Analyze a comparison operator with bidirectional type inference.
     ///
-    /// Synthesizes the type from the left operand in a single traversal, then checks
-    /// the right operand against it. This eliminates the double traversal that was
-    /// previously required by infer_type + analyze_inst.
+    /// Uses bidirectional type inference: if the LHS is an integer literal and
+    /// the RHS has a known integer type, the literal adopts that type. Otherwise,
+    /// synthesizes the type from the left operand.
     ///
     /// For equality operators (`==`, `!=`), both integers and booleans are allowed.
     /// For ordering operators (`<`, `>`, `<=`, `>=`), only integers are allowed.
@@ -2020,8 +2020,24 @@ impl<'a> Sema<'a> {
     where
         F: FnOnce(AirRef, AirRef) -> AirInstData,
     {
-        // SINGLE TRAVERSAL: synthesize type AND emit AIR in one pass
-        let lhs_result = self.analyze_inst(air, lhs, TypeExpectation::Synthesize, ctx)?;
+        // Bidirectional type inference for integer literals:
+        // If LHS is an integer literal, peek at RHS to get a type hint
+        let lhs_expectation = if self.is_integer_literal(lhs) {
+            if let Some(rhs_type) = self.peek_type(rhs, ctx) {
+                if rhs_type.is_integer() {
+                    // Use the RHS type for the LHS literal
+                    TypeExpectation::Check(rhs_type)
+                } else {
+                    TypeExpectation::Synthesize
+                }
+            } else {
+                TypeExpectation::Synthesize
+            }
+        } else {
+            TypeExpectation::Synthesize
+        };
+
+        let lhs_result = self.analyze_inst(air, lhs, lhs_expectation, ctx)?;
         let lhs_type = lhs_result.ty;
 
         // Propagate Never/Error without additional type errors
@@ -2084,6 +2100,101 @@ impl<'a> Sema<'a> {
                     None
                 }
             }
+            _ => None,
+        }
+    }
+
+    /// Check if an RIR instruction is an integer literal.
+    ///
+    /// This is used for bidirectional type inference to detect when the LHS
+    /// of a binary operator is a literal that can adopt its type from the RHS.
+    fn is_integer_literal(&self, inst_ref: InstRef) -> bool {
+        matches!(self.rir.get(inst_ref).data, InstData::IntConst(_))
+    }
+
+    /// Peek at the type of an expression without emitting AIR.
+    ///
+    /// This is a lightweight type inference pass used for bidirectional type inference.
+    /// When the LHS of a binary operator is an integer literal, we peek at the RHS type
+    /// to determine what type the literal should adopt.
+    ///
+    /// Returns `None` if the type cannot be determined (e.g., for complex expressions
+    /// that would require full analysis), in which case we fall back to default behavior.
+    fn peek_type(&self, inst_ref: InstRef, ctx: &AnalysisContext) -> Option<Type> {
+        let inst = self.rir.get(inst_ref);
+        match &inst.data {
+            // Literals have known types (except integers which default to i32)
+            InstData::IntConst(_) => Some(Type::I32),
+            InstData::BoolConst(_) => Some(Type::Bool),
+
+            // Variables have their declared types
+            InstData::VarRef { name } => {
+                if let Some(local) = ctx.locals.get(name) {
+                    Some(local.ty)
+                } else if let Some(param) = ctx.params.get(name) {
+                    Some(param.ty)
+                } else {
+                    None
+                }
+            }
+
+            // Function parameters have their declared types
+            InstData::ParamRef { name, .. } => ctx.params.get(name).map(|p| p.ty),
+
+            // Function calls have their declared return type
+            InstData::Call { name, .. } => self.functions.get(name).map(|f| f.return_type),
+
+            // Binary arithmetic operations: peek at operands to find integer type
+            InstData::Add { lhs, rhs }
+            | InstData::Sub { lhs, rhs }
+            | InstData::Mul { lhs, rhs }
+            | InstData::Div { lhs, rhs }
+            | InstData::Mod { lhs, rhs } => {
+                // Try LHS first, then RHS
+                if let Some(ty) = self.peek_type(*lhs, ctx) {
+                    if ty.is_integer() {
+                        return Some(ty);
+                    }
+                }
+                if let Some(ty) = self.peek_type(*rhs, ctx) {
+                    if ty.is_integer() {
+                        return Some(ty);
+                    }
+                }
+                Some(Type::I32) // Default if both are literals
+            }
+
+            // Unary negation: peek at operand
+            InstData::Neg { operand } => self.peek_type(*operand, ctx),
+
+            // Comparisons return bool
+            InstData::Eq { .. }
+            | InstData::Ne { .. }
+            | InstData::Lt { .. }
+            | InstData::Gt { .. }
+            | InstData::Le { .. }
+            | InstData::Ge { .. } => Some(Type::Bool),
+
+            // Logical operators return bool
+            InstData::And { .. } | InstData::Or { .. } | InstData::Not { .. } => Some(Type::Bool),
+
+            // Array index: get element type from array type
+            InstData::IndexGet { base, .. } => {
+                if let Some(array_ty) = self.peek_type(*base, ctx) {
+                    if let Type::Array(id) = array_ty {
+                        // Get the element type from the array type definition
+                        self.array_type_defs
+                            .get(id.0 as usize)
+                            .map(|def| def.element_type)
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            }
+
+            // For other expressions, we can't easily peek
             _ => None,
         }
     }

--- a/crates/rue-spec/cases/16-integer-types.toml
+++ b/crates/rue-spec/cases/16-integer-types.toml
@@ -751,3 +751,245 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Bidirectional Type Inference for Literals (literal on left side)
+# =============================================================================
+# These tests verify that integer literals on the LEFT side of binary operators
+# correctly infer their type from the RIGHT operand. This enables code like
+# `100 == x` where x: i64 to work (literal adopts i64 type from x).
+
+# --- Comparison operators with literal on left ---
+
+[[case]]
+name = "literal_left_comparison_i64_eq"
+description = "Literal on left should infer type from i64 variable on right"
+source = """
+fn main() -> i32 {
+    let x: i64 = 100;
+    if 100 == x { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_comparison_i64_ne"
+description = "Literal != with i64 variable on right"
+source = """
+fn main() -> i32 {
+    let x: i64 = 100;
+    if 50 != x { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_comparison_i64_lt"
+description = "Literal < with i64 variable on right"
+source = """
+fn main() -> i32 {
+    let x: i64 = 100;
+    if 50 < x { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_comparison_i64_gt"
+description = "Literal > with i64 variable on right"
+source = """
+fn main() -> i32 {
+    let x: i64 = 50;
+    if 100 > x { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_comparison_i64_le"
+description = "Literal <= with i64 variable on right"
+source = """
+fn main() -> i32 {
+    let x: i64 = 100;
+    if 100 <= x { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_comparison_i64_ge"
+description = "Literal >= with i64 variable on right"
+source = """
+fn main() -> i32 {
+    let x: i64 = 100;
+    if 100 >= x { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_comparison_i8"
+description = "Literal on left should infer type from i8 variable"
+source = """
+fn main() -> i32 {
+    let x: i8 = 42;
+    if 42 == x { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_comparison_u64"
+description = "Literal on left should infer type from u64 variable"
+source = """
+fn main() -> i32 {
+    let x: u64 = 1000;
+    if 500 < x { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_comparison_u8"
+description = "Literal on left should infer type from u8 variable"
+source = """
+fn main() -> i32 {
+    let x: u8 = 200;
+    if 100 < x { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+# --- Arithmetic operators with literal on left ---
+
+[[case]]
+name = "literal_left_add_i64"
+description = "Literal + i64 variable should infer literal as i64"
+source = """
+fn main() -> i32 {
+    let x: i64 = 100;
+    let result: i64 = 50 + x;
+    if result == 150 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_sub_i64"
+description = "Literal - i64 variable should infer literal as i64"
+source = """
+fn main() -> i32 {
+    let x: i64 = 50;
+    let result: i64 = 100 - x;
+    if result == 50 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_mul_i64"
+description = "Literal * i64 variable should infer literal as i64"
+source = """
+fn main() -> i32 {
+    let x: i64 = 10;
+    let result: i64 = 5 * x;
+    if result == 50 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_div_i64"
+description = "Literal / i64 variable should infer literal as i64"
+source = """
+fn main() -> i32 {
+    let x: i64 = 10;
+    let result: i64 = 100 / x;
+    if result == 10 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_mod_i64"
+description = "Literal % i64 variable should infer literal as i64"
+source = """
+fn main() -> i32 {
+    let x: i64 = 7;
+    let result: i64 = 100 % x;
+    if result == 2 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_add_u64"
+description = "Literal + u64 variable should infer literal as u64"
+source = """
+fn main() -> i32 {
+    let x: u64 = 100;
+    let result: u64 = 50 + x;
+    if result == 150 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_add_i8"
+description = "Literal + i8 variable should infer literal as i8"
+source = """
+fn main() -> i32 {
+    let x: i8 = 20;
+    let result: i8 = 10 + x;
+    if result == 30 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+# --- Both operands are literals (should still default to i32) ---
+
+[[case]]
+name = "both_literals_comparison"
+description = "Two literals in comparison should both be i32"
+source = """
+fn main() -> i32 {
+    if 100 == 100 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "both_literals_arithmetic"
+description = "Two literals in arithmetic should both be i32"
+source = """
+fn main() -> i32 {
+    50 + 50
+}
+"""
+exit_code = 100
+
+# --- Nested expressions with literals ---
+
+[[case]]
+name = "literal_left_complex_expr"
+description = "Literal compared to arithmetic expression"
+source = """
+fn main() -> i32 {
+    let x: i64 = 50;
+    let y: i64 = 50;
+    if 100 == x + y { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "literal_left_function_call"
+description = "Literal compared to function returning i64"
+source = """
+fn get_value() -> i64 { 42 }
+
+fn main() -> i32 {
+    if 42 == get_value() { 1 } else { 0 }
+}
+"""
+exit_code = 1

--- a/docs/language.md
+++ b/docs/language.md
@@ -350,12 +350,23 @@ fn main() -> i32 {
 }
 ```
 
-The type of a comparison is inferred from the left operand, and the right operand is checked against it:
+Integer literals in binary operations use bidirectional type inference—they adopt the type of the other operand when possible:
 
 ```rue
 fn main() -> i32 {
     let x: i64 = 100;
     if x == 100 { 1 } else { 0 }  // 100 is inferred as i64
+    if 100 == x { 1 } else { 0 }  // Also works: literal adopts type from x
+}
+```
+
+This applies to both comparison and arithmetic operators:
+
+```rue
+fn main() -> i32 {
+    let x: i64 = 50;
+    let y: i64 = 50 + x;  // 50 is inferred as i64
+    if y == 100 { 1 } else { 0 }
 }
 ```
 


### PR DESCRIPTION
Previously, comparison and arithmetic operators always synthesized the type from the left operand and checked the right operand against it. This meant `100 == x` where x: i64 would fail with a type mismatch because the literal 100 defaulted to i32.

Now, when the left operand is an integer literal, we peek at the right operand's type first. If it's an integer type, the literal adopts that type. This enables natural code like:

    let x: i64 = 100;
    if 100 == x { ... }  // literal 100 becomes i64

The implementation adds two helper methods to Sema:
- is_integer_literal(): detects when LHS is an integer literal
- peek_type(): lightweight type inference without emitting AIR

🤖 Generated with [Claude Code](https://claude.com/claude-code)