### PR TITLE
Store integer literals as u64 for full unsigned range

### DIFF
--- a/.claude/commands/code-review.md
+++ b/.claude/commands/code-review.md
@@ -34,5 +34,6 @@ For the Rue compiler specifically, also check:
 - Index-based references used correctly (no dangling indices)
 - IR transformations preserve semantics
 - Span tracking maintained for error reporting
+- **Multi-backend consistency**: If changes touch `rue-codegen`, verify that equivalent changes were made to ALL backends (x86_64 and aarch64). Check mir.rs, emit.rs, regalloc.rs, liveness.rs, and cfg_lower.rs in both directories.
 
 Provide specific, actionable feedback with file:line references. File new bugs with `bd` for simple non-blocking improvements, but the feedback given here is things that we should land before we merge this change.

--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -23,6 +23,7 @@ Follow this workflow:
 7. **Add spec tests** - Add test cases to `crates/rue-spec/cases/` with `spec = ["X.Y:Z"]` references linking to the spec paragraphs.
 8. **Add UI tests** - If the feature includes warnings, lints, or diagnostic changes, add tests to `crates/rue-ui-tests/cases/`.
 9. **Implement incrementally** - Make changes, keeping tests passing as you go
+   - **If touching rue-codegen**: Implement changes in ALL backends (x86_64 and aarch64). See "Codegen: Multi-Backend Considerations" in CLAUDE.md.
 10. **Verify** - Run `./test.sh` to ensure:
     - All tests pass
     - Traceability check passes (100% spec coverage)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -338,6 +338,29 @@ When adding or changing language features, follow this checklist:
 
 9. **Run `./test.sh`** to verify all tests pass and traceability is maintained
 
+## Codegen: Multi-Backend Considerations
+
+**IMPORTANT**: The `rue-codegen` crate contains multiple architecture backends:
+- `x86_64/` - Linux x86-64
+- `aarch64/` - macOS ARM64
+
+When making changes to codegen, **always check if the same change is needed in all backends**. Common areas that require parallel changes:
+
+- **New MIR instructions**: Add to both `x86_64/mir.rs` and `aarch64/mir.rs`
+- **Instruction emission**: Update both `x86_64/emit.rs` and `aarch64/emit.rs`
+- **Register allocation**: Update both `x86_64/regalloc.rs` and `aarch64/regalloc.rs`
+- **Liveness analysis**: Update both `x86_64/liveness.rs` and `aarch64/liveness.rs`
+- **CFG lowering**: Update both `x86_64/cfg_lower.rs` and `aarch64/cfg_lower.rs`
+
+Example: If adding a new comparison instruction variant (e.g., 64-bit compare):
+1. Add `Cmp64RR` to both MIR definitions
+2. Add emission logic to both emitters
+3. Add register allocation handling to both allocators
+4. Add liveness tracking to both liveness analyzers
+5. Update CFG lowering in both backends to use the new instruction where appropriate
+
+**Testing across backends**: The spec tests run on the host architecture only. If you only have access to one platform, note in your commit message that the other backend may need verification.
+
 ## Version Control
 
 Uses Jujutsu (jj): `jj status`, `jj diff`, `jj commit -m "msg"`, `jj log`

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -13,7 +13,7 @@ pub enum AirPattern {
     /// Wildcard pattern `_` - matches anything
     Wildcard,
     /// Integer literal pattern
-    Int(i64),
+    Int(u64),
     /// Boolean literal pattern
     Bool(bool),
 }
@@ -103,7 +103,7 @@ pub struct AirInst {
 #[derive(Debug, Clone)]
 pub enum AirInstData {
     /// Integer constant (typed)
-    Const(i64),
+    Const(u64),
 
     /// Boolean constant
     BoolConst(bool),

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -626,6 +626,7 @@ impl<'a> Sema<'a> {
                 // Special case: -2147483648 (MIN_I32)
                 // The literal 2147483648 exceeds i32::MAX, but -2147483648 is valid.
                 // We check this first regardless of expectation mode.
+                // Handle special case of negating 2^31 to get i32::MIN
                 let operand_inst = self.rir.get(*operand);
                 if let InstData::IntConst(value) = &operand_inst.data {
                     if *value == 2147483648 {
@@ -635,8 +636,11 @@ impl<'a> Sema<'a> {
                             _ => Type::I32,
                         };
                         if ty == Type::I32 {
+                            // Store i32::MIN as its u64 bit pattern
+                            // i32::MIN = -2147483648, which as u64 bit pattern is 0xFFFFFFFF80000000
+                            // But we just need the 32-bit representation interpreted correctly
                             let air_ref = air.add_inst(AirInst {
-                                data: AirInstData::Const(-2147483648_i64),
+                                data: AirInstData::Const((-2147483648_i32) as u32 as u64),
                                 ty,
                                 span: inst.span,
                             });
@@ -2129,12 +2133,16 @@ impl<'a> Sema<'a> {
     fn try_get_const_index(&self, inst_ref: InstRef) -> Option<i64> {
         let inst = self.rir.get(inst_ref);
         match &inst.data {
-            InstData::IntConst(value) => Some(*value),
+            InstData::IntConst(value) => {
+                // Convert u64 to i64, returning None if it would overflow
+                i64::try_from(*value).ok()
+            }
             InstData::Neg { operand } => {
                 // Handle negative literal: -N
                 let operand_inst = self.rir.get(*operand);
                 if let InstData::IntConst(value) = &operand_inst.data {
-                    Some(-value)
+                    // Negate the value; this can overflow for very large values
+                    i64::try_from(*value).ok().and_then(|v| v.checked_neg())
                 } else {
                     None
                 }

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -71,7 +71,7 @@ pub struct CfgInst {
 #[derive(Debug, Clone)]
 pub enum CfgInstData {
     /// Integer constant (typed)
-    Const(i64),
+    Const(u64),
 
     /// Boolean constant
     BoolConst(bool),
@@ -199,7 +199,7 @@ pub enum Terminator {
         /// The value to switch on
         scrutinee: CfgValue,
         /// Cases: (value, target_block)
-        cases: Vec<(i64, BlockId)>,
+        cases: Vec<(u64, BlockId)>,
         /// Default block (for wildcard pattern)
         default: BlockId,
     },

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -296,9 +296,10 @@ impl<'a> CfgLower<'a> {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
 
+                // Cast u64 to i64 to preserve bit pattern
                 self.mir.push(Aarch64Inst::MovImm {
                     dst: Operand::Virtual(vreg),
-                    imm: *v,
+                    imm: *v as i64,
                 });
             }
 
@@ -1565,10 +1566,19 @@ impl<'a> CfgLower<'a> {
         let lhs_vreg = self.get_vreg(lhs);
         let rhs_vreg = self.get_vreg(rhs);
 
-        self.mir.push(Aarch64Inst::CmpRR {
-            src1: Operand::Virtual(lhs_vreg),
-            src2: Operand::Virtual(rhs_vreg),
-        });
+        // Use 64-bit compare for i64/u64 types
+        let lhs_ty = self.cfg.get_inst(lhs).ty;
+        if matches!(lhs_ty, Type::I64 | Type::U64) {
+            self.mir.push(Aarch64Inst::Cmp64RR {
+                src1: Operand::Virtual(lhs_vreg),
+                src2: Operand::Virtual(rhs_vreg),
+            });
+        } else {
+            self.mir.push(Aarch64Inst::CmpRR {
+                src1: Operand::Virtual(lhs_vreg),
+                src2: Operand::Virtual(rhs_vreg),
+            });
+        }
         self.mir.push(Aarch64Inst::Cset {
             dst: Operand::Virtual(vreg),
             cond,
@@ -1684,10 +1694,11 @@ impl<'a> CfgLower<'a> {
                 // Generate comparison and jump for each case
                 for (value, target) in cases {
                     // Compare scrutinee with case value
+                    // Cast to i64 to preserve bit pattern
                     let imm_vreg = self.mir.alloc_vreg();
                     self.mir.push(Aarch64Inst::MovImm {
                         dst: Operand::Virtual(imm_vreg),
-                        imm: *value,
+                        imm: *value as i64,
                     });
                     self.mir.push(Aarch64Inst::CmpRR {
                         src1: Operand::Virtual(scrutinee_vreg),

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -303,15 +303,19 @@ impl<'a> CfgLower<'a> {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
 
-                if *v >= i32::MIN as i64 && *v <= i32::MAX as i64 {
+                // Use 32-bit immediate if value fits in unsigned 32-bit range
+                // (this is safe because mov r32, imm32 zero-extends to 64-bit)
+                if *v <= u32::MAX as u64 {
                     self.mir.push(X86Inst::MovRI32 {
                         dst: Operand::Virtual(vreg),
                         imm: *v as i32,
                     });
                 } else {
+                    // For values > u32::MAX, use 64-bit move
+                    // Cast to i64 to preserve the bit pattern
                     self.mir.push(X86Inst::MovRI64 {
                         dst: Operand::Virtual(vreg),
-                        imm: *v,
+                        imm: *v as i64,
                     });
                 }
             }
@@ -1322,10 +1326,19 @@ impl<'a> CfgLower<'a> {
         let lhs_vreg = self.get_vreg(lhs);
         let rhs_vreg = self.get_vreg(rhs);
 
-        self.mir.push(X86Inst::CmpRR {
-            src1: Operand::Virtual(lhs_vreg),
-            src2: Operand::Virtual(rhs_vreg),
-        });
+        // Use 64-bit compare for i64/u64 types
+        let lhs_ty = self.cfg.get_inst(lhs).ty;
+        if matches!(lhs_ty, Type::I64 | Type::U64) {
+            self.mir.push(X86Inst::Cmp64RR {
+                src1: Operand::Virtual(lhs_vreg),
+                src2: Operand::Virtual(rhs_vreg),
+            });
+        } else {
+            self.mir.push(X86Inst::CmpRR {
+                src1: Operand::Virtual(lhs_vreg),
+                src2: Operand::Virtual(rhs_vreg),
+            });
+        }
         emit_setcc(&mut self.mir, vreg);
         self.mir.push(X86Inst::Movzx {
             dst: Operand::Virtual(vreg),
@@ -1446,11 +1459,12 @@ impl<'a> CfgLower<'a> {
 
                 // Generate comparison and jump for each case
                 for (value, target) in cases {
-                    // Load case value into a register to handle full i64 range
+                    // Load case value into a register to handle full u64 range
+                    // Cast to i64 to preserve bit pattern
                     let case_vreg = self.mir.alloc_vreg();
                     self.mir.push(X86Inst::MovRI64 {
                         dst: Operand::Virtual(case_vreg),
-                        imm: *value,
+                        imm: *value as i64,
                     });
                     self.mir.push(X86Inst::CmpRR {
                         src1: Operand::Virtual(scrutinee_vreg),

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -344,6 +344,9 @@ impl<'a> Emitter<'a> {
             X86Inst::CmpRR { src1, src2 } => {
                 self.emit_cmp_rr(src1.as_physical(), src2.as_physical());
             }
+            X86Inst::Cmp64RR { src1, src2 } => {
+                self.emit_cmp64_rr(src1.as_physical(), src2.as_physical());
+            }
             X86Inst::CmpRI { src, imm } => {
                 self.emit_cmp_ri(src.as_physical(), *imm);
             }
@@ -1170,6 +1173,27 @@ impl<'a> Emitter<'a> {
         }
 
         // Opcode: 39 (cmp r/m32, r32)
+        self.code.push(0x39);
+
+        // ModR/M: mod=11, reg=src2, r/m=src1
+        let modrm = 0xC0 | ((src2_enc & 7) << 3) | (src1_enc & 7);
+        self.code.push(modrm);
+    }
+
+    /// Emit `cmp r64, r64`.
+    ///
+    /// Encoding: REX.W 39 /r (cmp r/m64, r64)
+    fn emit_cmp64_rr(&mut self, src1: Reg, src2: Reg) {
+        let src1_enc = src1.encoding();
+        let src2_enc = src2.encoding();
+
+        // REX.W prefix (always needed for 64-bit operands)
+        let rex = 0x48
+            | if src2.needs_rex() { 0x04 } else { 0x00 }  // REX.R
+            | if src1.needs_rex() { 0x01 } else { 0x00 }; // REX.B
+        self.code.push(rex);
+
+        // Opcode: 39 (cmp r/m64, r64)
         self.code.push(0x39);
 
         // ModR/M: mod=11, reg=src2, r/m=src1

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -205,7 +205,7 @@ fn uses(inst: &X86Inst) -> Vec<VReg> {
             add_if_virtual(src1, &mut result);
             add_if_virtual(src2, &mut result);
         }
-        X86Inst::CmpRR { src1, src2 } => {
+        X86Inst::CmpRR { src1, src2 } | X86Inst::Cmp64RR { src1, src2 } => {
             add_if_virtual(src1, &mut result);
             add_if_virtual(src2, &mut result);
         }
@@ -315,7 +315,10 @@ fn defs(inst: &X86Inst) -> Vec<VReg> {
         X86Inst::IdivR { .. } => {
             // Implicitly defines RAX (quotient) and RDX (remainder), but those are physical
         }
-        X86Inst::TestRR { .. } | X86Inst::CmpRR { .. } | X86Inst::CmpRI { .. } => {
+        X86Inst::TestRR { .. }
+        | X86Inst::CmpRR { .. }
+        | X86Inst::Cmp64RR { .. }
+        | X86Inst::CmpRI { .. } => {
             // Only sets flags, no register def
         }
         X86Inst::Sete { dst }

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -279,8 +279,11 @@ pub enum X86Inst {
     IdivR { src: Operand },
 
     // Comparison and control flow
-    /// `cmp src1, src2` - Compare (subtract and set flags, discard result).
+    /// `cmp src1, src2` - Compare 32-bit (subtract and set flags, discard result).
     CmpRR { src1: Operand, src2: Operand },
+
+    /// `cmp src1, src2` - Compare 64-bit (subtract and set flags, discard result).
+    Cmp64RR { src1: Operand, src2: Operand },
 
     /// `cmp src, imm` - Compare register with immediate.
     CmpRI { src: Operand, imm: i32 },
@@ -474,6 +477,7 @@ impl fmt::Display for X86Inst {
             X86Inst::Cdq => write!(f, "cdq"),
             X86Inst::IdivR { src } => write!(f, "idiv {}", src),
             X86Inst::CmpRR { src1, src2 } => write!(f, "cmp {}, {}", src1, src2),
+            X86Inst::Cmp64RR { src1, src2 } => write!(f, "cmpq {}, {}", src1, src2),
             X86Inst::CmpRI { src, imm } => write!(f, "cmp {}, {}", src, imm),
             X86Inst::Sete { dst } => write!(f, "sete {}", dst),
             X86Inst::Setne { dst } => write!(f, "setne {}", dst),

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -402,6 +402,15 @@ impl RegAlloc {
                 });
             }
 
+            X86Inst::Cmp64RR { src1, src2 } => {
+                let src1_op = self.load_operand(mir, src1, Reg::Rax);
+                let src2_op = self.load_operand(mir, src2, Reg::R10);
+                mir.push(X86Inst::Cmp64RR {
+                    src1: src1_op,
+                    src2: src2_op,
+                });
+            }
+
             X86Inst::CmpRI { src, imm } => {
                 let src_op = self.load_operand(mir, src, Reg::Rax);
                 mir.push(X86Inst::CmpRI { src: src_op, imm });

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -42,7 +42,7 @@ pub enum TokenKind {
     Underscore, // _ (wildcard pattern)
 
     // Literals
-    Int(i64),
+    Int(u64),
 
     // Identifiers
     Ident(String),

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -76,8 +76,8 @@ pub enum LogosTokenKind {
     Underscore,
 
     // Integer literals
-    #[regex(r"[0-9]+", |lex| lex.slice().parse::<i64>().ok())]
-    Int(i64),
+    #[regex(r"[0-9]+", |lex| lex.slice().parse::<u64>().ok())]
+    Int(u64),
 
     // Identifiers (lower priority than keywords)
     #[regex(r"[a-zA-Z_][a-zA-Z0-9_]*", |lex| lex.slice().to_string(), priority = 1)]

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -174,7 +174,7 @@ pub enum Expr {
 /// An integer literal.
 #[derive(Debug, Clone)]
 pub struct IntLit {
-    pub value: i64,
+    pub value: u64,
     pub span: Span,
 }
 

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -34,7 +34,7 @@ pub enum RirPattern {
     /// Wildcard pattern `_` - matches anything
     Wildcard,
     /// Integer literal pattern
-    Int(i64),
+    Int(u64),
     /// Boolean literal pattern
     Bool(bool),
 }
@@ -120,7 +120,7 @@ pub struct Inst {
 #[derive(Debug, Clone)]
 pub enum InstData {
     /// Integer constant
-    IntConst(i64),
+    IntConst(u64),
 
     /// Boolean constant
     BoolConst(bool),

--- a/crates/rue-spec/cases/types/integers.toml
+++ b/crates/rue-spec/cases/types/integers.toml
@@ -840,3 +840,72 @@ fn main() -> i32 {
 }
 """
 exit_code = 1
+
+# =============================================================================
+# Large u64 Literals (values > i64::MAX)
+# =============================================================================
+# These tests verify that integer literals larger than i64::MAX can be parsed
+# and used correctly with u64 type. i64::MAX is 9223372036854775807 (2^63 - 1).
+
+[[case]]
+name = "u64_i64_max_plus_one"
+spec = ["3.1:12"]
+description = "u64 literal that is exactly i64::MAX + 1 (2^63)"
+source = """
+fn main() -> i32 {
+    let x: u64 = 9223372036854775808;
+    if x > 0 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "u64_large_literal"
+spec = ["3.1:12"]
+description = "u64 literal significantly larger than i64::MAX"
+source = """
+fn main() -> i32 {
+    let x: u64 = 10000000000000000000;
+    if x > 0 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "u64_max"
+spec = ["3.1:12"]
+description = "u64::MAX literal (2^64 - 1)"
+source = """
+fn main() -> i32 {
+    let x: u64 = 18446744073709551615;
+    if x > 0 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "u64_large_arithmetic"
+spec = ["3.1:12"]
+description = "Arithmetic with large u64 values"
+source = """
+fn main() -> i32 {
+    let x: u64 = 9223372036854775808;
+    let y: u64 = 1;
+    let z: u64 = x + y;
+    if z > x { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "u64_large_comparison"
+spec = ["3.1:12"]
+description = "Comparison between large u64 values"
+source = """
+fn main() -> i32 {
+    let x: u64 = 9223372036854775808;
+    let y: u64 = 9223372036854775809;
+    if y > x { 1 } else { 0 }
+}
+"""
+exit_code = 1


### PR DESCRIPTION
Previously integer literals were stored as i64 throughout the compiler (lexer, parser, IR layers). This prevented parsing literals larger than i64::MAX (9223372036854775807), making u64::MAX and other large unsigned values impossible to write.

Now literals are stored as u64, allowing the full 0 to 2^64-1 range. The semantic analysis phase handles signedness appropriately when literals are used with signed types (e.g., storing i32::MIN as its u64 bit pattern representation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)