### PR TITLE
Add rich diagnostic system with labels, notes, and help messages

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -273,11 +273,14 @@ impl<'a> Sema<'a> {
                 continue;
             }
 
-            // Emit warning
-            self.warnings.push(CompileWarning::new(
-                WarningKind::UnusedVariable(name.to_string()),
-                local.span,
-            ));
+            // Emit warning with help suggestion
+            self.warnings.push(
+                CompileWarning::new(WarningKind::UnusedVariable(name.to_string()), local.span)
+                    .with_help(format!(
+                        "if this is intentional, prefix it with an underscore: `_{}`",
+                        name
+                    )),
+            );
         }
     }
 
@@ -703,19 +706,17 @@ impl<'a> Sema<'a> {
                     ctx.push_scope();
                     let then_result = self.analyze_inst(air, *then_block, expectation, ctx)?;
                     let then_type = then_result.ty;
+                    let then_span = self.rir.get(*then_block).span;
                     ctx.pop_scope();
 
                     // Analyze else branch with its own scope
-                    // If then branch is Never, use original expectation for else (so it determines the result)
-                    // Otherwise use then_type as the expectation
+                    // Use Synthesize to get the actual else type, then compare ourselves
+                    // This allows us to provide better error messages with secondary labels
                     ctx.push_scope();
-                    let else_expectation = if then_type.is_never() {
-                        expectation
-                    } else {
-                        TypeExpectation::Check(then_type)
-                    };
-                    let else_result = self.analyze_inst(air, *else_b, else_expectation, ctx)?;
+                    let else_result =
+                        self.analyze_inst(air, *else_b, TypeExpectation::Synthesize, ctx)?;
                     let else_type = else_result.ty;
+                    let else_span = self.rir.get(*else_b).span;
                     ctx.pop_scope();
 
                     // Compute the unified result type using never type coercion:
@@ -737,8 +738,13 @@ impl<'a> Sema<'a> {
                                         expected: then_type.name().to_string(),
                                         found: else_type.name().to_string(),
                                     },
-                                    self.rir.get(*else_b).span,
-                                ));
+                                    else_span,
+                                )
+                                .with_label(
+                                    format!("this is of type `{}`", then_type.name()),
+                                    then_span,
+                                )
+                                .with_note("if and else branches must have compatible types"));
                             }
                             then_type
                         }
@@ -771,6 +777,10 @@ impl<'a> Sema<'a> {
                                 found: then_type.name().to_string(),
                             },
                             self.rir.get(*then_block).span,
+                        )
+                        .with_help(
+                            "if expressions without else must have unit type; \
+                             consider adding an else branch or making the body return ()",
                         ));
                     }
 
@@ -1086,7 +1096,12 @@ impl<'a> Sema<'a> {
                     return Err(CompileError::new(
                         ErrorKind::AssignToImmutable(name_str.to_string()),
                         inst.span,
-                    ));
+                    )
+                    .with_label("variable declared as immutable here", local.span)
+                    .with_help(format!(
+                        "consider making `{}` mutable: `let mut {}`",
+                        name_str, name_str
+                    )));
                 }
 
                 let slot = local.slot;

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -526,6 +526,9 @@ impl<'a> CfgBuilder<'a> {
                 for (i, stmt) in statements.iter().enumerate() {
                     let result = self.lower_inst(*stmt);
                     if matches!(result.continuation, Continuation::Diverged) {
+                        // Get the span of the diverging statement for the secondary label
+                        let diverging_span = self.air.get(*stmt).span;
+
                         // Check if there are remaining statements or a value expression
                         // that will never be executed
                         let remaining = &statements[i + 1..];
@@ -533,10 +536,17 @@ impl<'a> CfgBuilder<'a> {
                             // Warn about the first unreachable statement
                             let unreachable_stmt = remaining[0];
                             let unreachable_span = self.air.get(unreachable_stmt).span;
-                            self.warnings.push(CompileWarning::new(
-                                WarningKind::UnreachableCode,
-                                unreachable_span,
-                            ));
+                            self.warnings.push(
+                                CompileWarning::new(WarningKind::UnreachableCode, unreachable_span)
+                                    .with_label(
+                                        "any code following this expression is unreachable",
+                                        diverging_span,
+                                    )
+                                    .with_note(
+                                        "this warning occurs because the preceding expression \
+                                         diverges (e.g., returns, breaks, or continues)",
+                                    ),
+                            );
                         } else {
                             // The final value expression is unreachable.
                             // However, don't warn about synthetic unit values (created by parser
@@ -545,10 +555,17 @@ impl<'a> CfgBuilder<'a> {
                             let value_span = self.air.get(*value).span;
                             let is_synthetic = value_span.start == value_span.end;
                             if !is_synthetic {
-                                self.warnings.push(CompileWarning::new(
-                                    WarningKind::UnreachableCode,
-                                    value_span,
-                                ));
+                                self.warnings.push(
+                                    CompileWarning::new(WarningKind::UnreachableCode, value_span)
+                                        .with_label(
+                                            "any code following this expression is unreachable",
+                                            diverging_span,
+                                        )
+                                        .with_note(
+                                            "this warning occurs because the preceding expression \
+                                             diverges (e.g., returns, breaks, or continues)",
+                                        ),
+                                );
                             }
                         }
                         return ExprResult {

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -2,18 +2,137 @@
 //!
 //! This crate provides the error infrastructure used throughout the compilation
 //! pipeline. Errors carry source location information for diagnostic rendering.
+//!
+//! # Diagnostic System
+//!
+//! Errors and warnings can include rich diagnostic information:
+//! - **Labels**: Secondary spans pointing to related code locations
+//! - **Notes**: Informational context about the error/warning
+//! - **Helps**: Actionable suggestions for fixing the issue
+//!
+//! Example:
+//! ```ignore
+//! CompileError::new(ErrorKind::TypeMismatch { ... }, span)
+//!     .with_label("expected because of this", other_span)
+//!     .with_help("consider using a type conversion")
+//! ```
 
 use rue_span::Span;
 use std::fmt;
+
+// ============================================================================
+// Diagnostic Types
+// ============================================================================
+
+/// A secondary label pointing to related code.
+///
+/// Labels appear as additional annotations in the source snippet,
+/// helping users understand the relationship between different parts of code.
+#[derive(Debug, Clone)]
+pub struct Label {
+    /// The message explaining this location's relevance.
+    pub message: String,
+    /// The source location to highlight.
+    pub span: Span,
+}
+
+impl Label {
+    /// Create a new label with a message and span.
+    pub fn new(message: impl Into<String>, span: Span) -> Self {
+        Self {
+            message: message.into(),
+            span,
+        }
+    }
+}
+
+/// An informational note providing context.
+///
+/// Notes appear as footer messages and explain why something happened
+/// or provide additional context about the diagnostic.
+#[derive(Debug, Clone)]
+pub struct Note(pub String);
+
+impl Note {
+    /// Create a new note.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl std::fmt::Display for Note {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// An actionable help suggestion.
+///
+/// Helps appear as footer messages and suggest specific actions
+/// the user can take to resolve the issue.
+#[derive(Debug, Clone)]
+pub struct Help(pub String);
+
+impl Help {
+    /// Create a new help suggestion.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self(message.into())
+    }
+}
+
+impl std::fmt::Display for Help {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+/// Rich diagnostic information for errors and warnings.
+///
+/// This struct collects all supplementary information that can be
+/// attached to a diagnostic message.
+#[derive(Debug, Clone, Default)]
+pub struct Diagnostic {
+    /// Secondary labels pointing to related code locations.
+    pub labels: Vec<Label>,
+    /// Informational notes providing context.
+    pub notes: Vec<Note>,
+    /// Actionable help suggestions.
+    pub helps: Vec<Help>,
+}
+
+impl Diagnostic {
+    /// Create an empty diagnostic.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Check if this diagnostic has any content.
+    pub fn is_empty(&self) -> bool {
+        self.labels.is_empty() && self.notes.is_empty() && self.helps.is_empty()
+    }
+}
+
+// ============================================================================
+// Compile Errors
+// ============================================================================
 
 /// A compilation error with optional source location information.
 ///
 /// Some errors (like `NoMainFunction` or `LinkError`) don't have a meaningful
 /// source location. Use `has_span()` to check before rendering location info.
+///
+/// Errors can include rich diagnostic information using the builder methods:
+/// ```ignore
+/// CompileError::new(ErrorKind::TypeMismatch { ... }, span)
+///     .with_label("expected because of this", other_span)
+///     .with_note("types must match exactly")
+///     .with_help("consider adding a type conversion")
+/// ```
 #[derive(Debug, Clone)]
 pub struct CompileError {
     pub kind: ErrorKind,
     span: Option<Span>,
+    diagnostic: Diagnostic,
 }
 
 /// The kind of compilation error.
@@ -125,6 +244,7 @@ impl CompileError {
         Self {
             kind,
             span: Some(span),
+            diagnostic: Diagnostic::new(),
         }
     }
 
@@ -134,7 +254,11 @@ impl CompileError {
     /// such as "no main function found" or linker errors.
     #[inline]
     pub fn without_span(kind: ErrorKind) -> Self {
-        Self { kind, span: None }
+        Self {
+            kind,
+            span: None,
+            diagnostic: Diagnostic::new(),
+        }
     }
 
     /// Create an error at a specific position (zero-length span).
@@ -143,6 +267,7 @@ impl CompileError {
         Self {
             kind,
             span: Some(Span::point(pos)),
+            diagnostic: Diagnostic::new(),
         }
     }
 
@@ -156,6 +281,39 @@ impl CompileError {
     #[inline]
     pub fn span(&self) -> Option<Span> {
         self.span
+    }
+
+    /// Get the diagnostic information.
+    #[inline]
+    pub fn diagnostic(&self) -> &Diagnostic {
+        &self.diagnostic
+    }
+
+    /// Add a secondary label pointing to related code.
+    ///
+    /// Labels appear as additional annotations in the source snippet.
+    #[inline]
+    pub fn with_label(mut self, message: impl Into<String>, span: Span) -> Self {
+        self.diagnostic.labels.push(Label::new(message, span));
+        self
+    }
+
+    /// Add an informational note.
+    ///
+    /// Notes appear as footer messages providing context.
+    #[inline]
+    pub fn with_note(mut self, message: impl Into<String>) -> Self {
+        self.diagnostic.notes.push(Note::new(message));
+        self
+    }
+
+    /// Add a help suggestion.
+    ///
+    /// Helps appear as footer messages with actionable advice.
+    #[inline]
+    pub fn with_help(mut self, message: impl Into<String>) -> Self {
+        self.diagnostic.helps.push(Help::new(message));
+        self
     }
 }
 
@@ -350,10 +508,17 @@ pub enum WarningKind {
 /// A compilation warning with optional source location information.
 ///
 /// Warnings don't stop compilation but indicate potential issues in the code.
+///
+/// Warnings can include rich diagnostic information using the builder methods:
+/// ```ignore
+/// CompileWarning::new(WarningKind::UnusedVariable("x".into()), span)
+///     .with_help("if this is intentional, prefix it with an underscore: `_x`")
+/// ```
 #[derive(Debug, Clone)]
 pub struct CompileWarning {
     pub kind: WarningKind,
     span: Option<Span>,
+    diagnostic: Diagnostic,
 }
 
 impl CompileWarning {
@@ -363,13 +528,18 @@ impl CompileWarning {
         Self {
             kind,
             span: Some(span),
+            diagnostic: Diagnostic::new(),
         }
     }
 
     /// Create a warning without a source location.
     #[inline]
     pub fn without_span(kind: WarningKind) -> Self {
-        Self { kind, span: None }
+        Self {
+            kind,
+            span: None,
+            diagnostic: Diagnostic::new(),
+        }
     }
 
     /// Returns true if this warning has source location information.
@@ -382,6 +552,39 @@ impl CompileWarning {
     #[inline]
     pub fn span(&self) -> Option<Span> {
         self.span
+    }
+
+    /// Get the diagnostic information.
+    #[inline]
+    pub fn diagnostic(&self) -> &Diagnostic {
+        &self.diagnostic
+    }
+
+    /// Add a secondary label pointing to related code.
+    ///
+    /// Labels appear as additional annotations in the source snippet.
+    #[inline]
+    pub fn with_label(mut self, message: impl Into<String>, span: Span) -> Self {
+        self.diagnostic.labels.push(Label::new(message, span));
+        self
+    }
+
+    /// Add an informational note.
+    ///
+    /// Notes appear as footer messages providing context.
+    #[inline]
+    pub fn with_note(mut self, message: impl Into<String>) -> Self {
+        self.diagnostic.notes.push(Note::new(message));
+        self
+    }
+
+    /// Add a help suggestion.
+    ///
+    /// Helps appear as footer messages with actionable advice.
+    #[inline]
+    pub fn with_help(mut self, message: impl Into<String>) -> Self {
+        self.diagnostic.helps.push(Help::new(message));
+        self
     }
 }
 
@@ -522,5 +725,178 @@ mod tests {
     fn test_error_implements_std_error() {
         fn assert_error<T: std::error::Error>() {}
         assert_error::<CompileError>();
+    }
+
+    // ========================================================================
+    // Diagnostic tests
+    // ========================================================================
+
+    #[test]
+    fn test_diagnostic_empty_by_default() {
+        let diag = Diagnostic::new();
+        assert!(diag.is_empty());
+        assert!(diag.labels.is_empty());
+        assert!(diag.notes.is_empty());
+        assert!(diag.helps.is_empty());
+    }
+
+    #[test]
+    fn test_diagnostic_not_empty_with_label() {
+        let mut diag = Diagnostic::new();
+        diag.labels.push(Label::new("test", Span::new(0, 10)));
+        assert!(!diag.is_empty());
+    }
+
+    #[test]
+    fn test_diagnostic_not_empty_with_note() {
+        let mut diag = Diagnostic::new();
+        diag.notes.push(Note::new("test note"));
+        assert!(!diag.is_empty());
+    }
+
+    #[test]
+    fn test_diagnostic_not_empty_with_help() {
+        let mut diag = Diagnostic::new();
+        diag.helps.push(Help::new("test help"));
+        assert!(!diag.is_empty());
+    }
+
+    #[test]
+    fn test_label_creation() {
+        let span = Span::new(10, 20);
+        let label = Label::new("expected type here", span);
+        assert_eq!(label.message, "expected type here");
+        assert_eq!(label.span, span);
+    }
+
+    #[test]
+    fn test_note_display() {
+        let note = Note::new("types must match exactly");
+        assert_eq!(note.to_string(), "types must match exactly");
+    }
+
+    #[test]
+    fn test_help_display() {
+        let help = Help::new("consider adding a type annotation");
+        assert_eq!(help.to_string(), "consider adding a type annotation");
+    }
+
+    #[test]
+    fn test_error_with_label() {
+        let span = Span::new(10, 20);
+        let label_span = Span::new(0, 5);
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            span,
+        )
+        .with_label("expected because of this", label_span);
+
+        let diag = error.diagnostic();
+        assert_eq!(diag.labels.len(), 1);
+        assert_eq!(diag.labels[0].message, "expected because of this");
+        assert_eq!(diag.labels[0].span, label_span);
+    }
+
+    #[test]
+    fn test_error_with_note() {
+        let span = Span::new(10, 20);
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            span,
+        )
+        .with_note("if and else branches must have compatible types");
+
+        let diag = error.diagnostic();
+        assert_eq!(diag.notes.len(), 1);
+        assert_eq!(
+            diag.notes[0].to_string(),
+            "if and else branches must have compatible types"
+        );
+    }
+
+    #[test]
+    fn test_error_with_help() {
+        let span = Span::new(10, 20);
+        let error = CompileError::new(ErrorKind::AssignToImmutable("x".to_string()), span)
+            .with_help("consider making `x` mutable: `let mut x`");
+
+        let diag = error.diagnostic();
+        assert_eq!(diag.helps.len(), 1);
+        assert_eq!(
+            diag.helps[0].to_string(),
+            "consider making `x` mutable: `let mut x`"
+        );
+    }
+
+    #[test]
+    fn test_error_with_multiple_diagnostics() {
+        let span = Span::new(10, 20);
+        let label_span = Span::new(0, 5);
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            span,
+        )
+        .with_label("then branch is here", label_span)
+        .with_note("if and else branches must have compatible types")
+        .with_help("consider using a type conversion");
+
+        let diag = error.diagnostic();
+        assert_eq!(diag.labels.len(), 1);
+        assert_eq!(diag.notes.len(), 1);
+        assert_eq!(diag.helps.len(), 1);
+    }
+
+    #[test]
+    fn test_error_diagnostic_empty_by_default() {
+        let span = Span::new(10, 20);
+        let error = CompileError::new(ErrorKind::InvalidInteger, span);
+        assert!(error.diagnostic().is_empty());
+    }
+
+    #[test]
+    fn test_warning_with_help() {
+        let span = Span::new(10, 20);
+        let warning = CompileWarning::new(WarningKind::UnusedVariable("foo".to_string()), span)
+            .with_help("if this is intentional, prefix it with an underscore: `_foo`");
+
+        let diag = warning.diagnostic();
+        assert_eq!(diag.helps.len(), 1);
+        assert_eq!(
+            diag.helps[0].to_string(),
+            "if this is intentional, prefix it with an underscore: `_foo`"
+        );
+    }
+
+    #[test]
+    fn test_warning_with_label_and_note() {
+        let span = Span::new(20, 25);
+        let diverging_span = Span::new(10, 18);
+        let warning = CompileWarning::new(WarningKind::UnreachableCode, span)
+            .with_label(
+                "any code following this expression is unreachable",
+                diverging_span,
+            )
+            .with_note("this warning occurs because the preceding expression diverges");
+
+        let diag = warning.diagnostic();
+        assert_eq!(diag.labels.len(), 1);
+        assert_eq!(diag.labels[0].span, diverging_span);
+        assert_eq!(diag.notes.len(), 1);
+    }
+
+    #[test]
+    fn test_warning_diagnostic_empty_by_default() {
+        let span = Span::new(10, 20);
+        let warning = CompileWarning::new(WarningKind::UnreachableCode, span);
+        assert!(warning.diagnostic().is_empty());
     }
 }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -407,20 +407,46 @@ fn print_assembly(mir: &rue_compiler::X86Mir) {
 fn print_error(error: &CompileError, source: &str, source_path: &str) {
     let message = error.to_string();
     let renderer = Renderer::plain();
+    let diagnostic = error.diagnostic();
 
-    // For errors without a span, just print the message
+    // For errors without a span, just print the message with any footers
     let Some(span) = error.span() else {
-        let report = Level::Error.title(&message);
+        let mut report = Level::Error.title(&message);
+        // Add notes and helps as footers
+        for note in &diagnostic.notes {
+            report = report.footer(Level::Note.title(note.0.as_str()));
+        }
+        for help in &diagnostic.helps {
+            report = report.footer(Level::Help.title(help.0.as_str()));
+        }
         eprintln!("{}", renderer.render(report));
         return;
     };
 
-    let report = Level::Error.title(&message).snippet(
-        Snippet::source(source)
-            .origin(source_path)
-            .fold(true)
-            .annotation(Level::Error.span(span.start as usize..span.end as usize)),
-    );
+    // Build snippet with primary annotation
+    let mut snippet = Snippet::source(source)
+        .origin(source_path)
+        .fold(true)
+        .annotation(Level::Error.span(span.start as usize..span.end as usize));
+
+    // Add secondary labels as Info annotations
+    for label in &diagnostic.labels {
+        snippet = snippet.annotation(
+            Level::Info
+                .span(label.span.start as usize..label.span.end as usize)
+                .label(&label.message),
+        );
+    }
+
+    let mut report = Level::Error.title(&message).snippet(snippet);
+
+    // Add notes and helps as footers
+    for note in &diagnostic.notes {
+        report = report.footer(Level::Note.title(note.0.as_str()));
+    }
+    for help in &diagnostic.helps {
+        report = report.footer(Level::Help.title(help.0.as_str()));
+    }
 
     eprintln!("{}", renderer.render(report));
 }
@@ -428,20 +454,46 @@ fn print_error(error: &CompileError, source: &str, source_path: &str) {
 fn print_warning(warning: &CompileWarning, source: &str, source_path: &str) {
     let message = warning.to_string();
     let renderer = Renderer::plain();
+    let diagnostic = warning.diagnostic();
 
-    // For warnings without a span, just print the message
+    // For warnings without a span, just print the message with any footers
     let Some(span) = warning.span() else {
-        let report = Level::Warning.title(&message);
+        let mut report = Level::Warning.title(&message);
+        // Add notes and helps as footers
+        for note in &diagnostic.notes {
+            report = report.footer(Level::Note.title(note.0.as_str()));
+        }
+        for help in &diagnostic.helps {
+            report = report.footer(Level::Help.title(help.0.as_str()));
+        }
         eprintln!("{}", renderer.render(report));
         return;
     };
 
-    let report = Level::Warning.title(&message).snippet(
-        Snippet::source(source)
-            .origin(source_path)
-            .fold(true)
-            .annotation(Level::Warning.span(span.start as usize..span.end as usize)),
-    );
+    // Build snippet with primary annotation
+    let mut snippet = Snippet::source(source)
+        .origin(source_path)
+        .fold(true)
+        .annotation(Level::Warning.span(span.start as usize..span.end as usize));
+
+    // Add secondary labels as Info annotations
+    for label in &diagnostic.labels {
+        snippet = snippet.annotation(
+            Level::Info
+                .span(label.span.start as usize..label.span.end as usize)
+                .label(&label.message),
+        );
+    }
+
+    let mut report = Level::Warning.title(&message).snippet(snippet);
+
+    // Add notes and helps as footers
+    for note in &diagnostic.notes {
+        report = report.footer(Level::Note.title(note.0.as_str()));
+    }
+    for help in &diagnostic.helps {
+        report = report.footer(Level::Help.title(help.0.as_str()));
+    }
 
     eprintln!("{}", renderer.render(report));
 }


### PR DESCRIPTION
Implements a Diagnostic type that can attach secondary labels, notes, and help suggestions to errors and warnings. This provides much better user experience when things go wrong:

- Labels: Secondary spans pointing to related code (e.g., "expected  because of this" pointing to where a type was first inferred)
- Notes: Informational context explaining why something happened
- Helps: Actionable suggestions for how to fix the issue

Updated several diagnostics to use the new system:
- Type mismatch in if/else now shows both branches with labels
- Assignment to immutable shows where the variable was declared
- Unused variable warnings include help about underscore prefixes
- Unreachable code warnings explain which expression caused divergence
- If without else shows help about unit type requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)