### PR TITLE
Fix website base_url for GitHub Pages hosting

### DIFF
--- a/website/config.toml
+++ b/website/config.toml
@@ -1,5 +1,5 @@
 # Rue Language Website
-base_url = "https://rue-lang.org"
+base_url = "https://rue-language.github.io/rue"
 title = "Rue"
 description = "A systems programming language with memory safety and high-level ergonomics"
 compile_sass = true


### PR DESCRIPTION
Changed base_url from rue-lang.org to rue-language.github.io/rue so CSS and assets load correctly.