### PR TITLE
Update website URLs: use rue-lang.dev and rue-language GitHub org

### DIFF
--- a/docs/spec/book.toml
+++ b/docs/spec/book.toml
@@ -14,7 +14,7 @@ command = "mdbook-spec"
 
 [output.html]
 git-repository-url = "https://github.com/rue-language/rue"
-edit-url-template = "https://github.com/rue-language/rue/edit/main/docs/spec/{path}"
+edit-url-template = "https://github.com/rue-language/rue/edit/trunk/docs/spec/{path}"
 site-url = "/spec/"
 additional-css = ["theme/spec.css"]
 additional-js = ["theme/back-to-site.js"]

--- a/website/config.toml
+++ b/website/config.toml
@@ -1,5 +1,5 @@
 # Rue Language Website
-base_url = "https://rue-language.github.io/rue"
+base_url = "https://rue-lang.dev"
 title = "Rue"
 description = "A systems programming language with memory safety and high-level ergonomics"
 compile_sass = true
@@ -12,4 +12,4 @@ highlight_code = true
 highlight_theme = "css"
 
 [extra]
-github_url = "https://github.com/rue-lang/rue"
+github_url = "https://github.com/rue-language/rue"

--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -4,7 +4,7 @@ title = "Getting Started"
 
 ## Installation
 
-Rue is currently in early development. To try it out, you'll need to build from source. If you do try it out, you'll certainly find bugs, and if you do please [file them](https://github.com/rue-lang/rue/issues)!
+Rue is currently in early development. To try it out, you'll need to build from source. If you do try it out, you'll certainly find bugs, and if you do please [file them](https://github.com/rue-language/rue/issues)!
 
 ### Prerequisites
 
@@ -14,7 +14,7 @@ Rue is currently in early development. To try it out, you'll need to build from 
 ### Building from Source
 
 ```bash
-git clone https://github.com/rue-lang/rue
+git clone https://github.com/rue-language/rue
 cd rue
 ./buck2 build //crates/rue:rue
 ```
@@ -42,4 +42,4 @@ echo $?  # prints: 0
 ## Next Steps
 
 - Read the [Language Specification](/spec/) for complete documentation
-- Check out the [GitHub repository](https://github.com/rue-lang/rue) for examples
+- Check out the [GitHub repository](https://github.com/rue-language/rue) for examples


### PR DESCRIPTION
- Set base_url to https://rue-lang.dev
- Standardize all GitHub links to rue-language/rue
- Fix spec edit links to use trunk branch instead of main