### PR TITLE
Add intrinsic expressions to specification

### DIFF
--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -1,0 +1,164 @@
+[section]
+id = "expressions.intrinsics"
+spec_chapter = "4.13"
+name = "Intrinsic Expressions"
+description = "Compiler-provided intrinsic operations."
+
+# =============================================================================
+# Basic Intrinsic Syntax
+# =============================================================================
+
+[[case]]
+name = "intrinsic_syntax"
+spec = ["4.13:1", "4.13:2", "4.13:3"]
+source = """
+fn main() -> i32 {
+    @dbg(42);
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "unknown_intrinsic"
+spec = ["4.13:5"]
+source = """
+fn main() -> i32 {
+    @unknown(42);
+    0
+}
+"""
+compile_fail = true
+error_contains = "unknown intrinsic"
+
+# =============================================================================
+# @dbg Intrinsic
+# =============================================================================
+
+[[case]]
+name = "dbg_signed_integer"
+spec = ["4.13:6", "4.13:7"]
+source = """
+fn main() -> i32 {
+    @dbg(42);
+    @dbg(-17);
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "dbg_unsigned_integer"
+spec = ["4.13:6", "4.13:7"]
+source = """
+fn main() -> i32 {
+    let x: u32 = 100;
+    @dbg(x);
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "dbg_boolean"
+spec = ["4.13:6", "4.13:7"]
+source = """
+fn main() -> i32 {
+    @dbg(true);
+    @dbg(false);
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "dbg_expression"
+spec = ["4.13:6", "4.13:7"]
+source = """
+fn main() -> i32 {
+    @dbg(10 + 5);
+    @dbg(3 > 2);
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "dbg_prints_with_newline"
+spec = ["4.13:8"]
+source = """
+fn main() -> i32 {
+    @dbg(42);
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "dbg_returns_unit"
+spec = ["4.13:9"]
+source = """
+fn takes_unit(x: ()) -> i32 { 0 }
+fn main() -> i32 {
+    takes_unit(@dbg(42))
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "dbg_wrong_arg_count_zero"
+spec = ["4.13:4", "4.13:7"]
+source = """
+fn main() -> i32 {
+    @dbg();
+    0
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "dbg_wrong_arg_count_two"
+spec = ["4.13:4", "4.13:7"]
+source = """
+fn main() -> i32 {
+    @dbg(1, 2);
+    0
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "dbg_invalid_type_unit"
+spec = ["4.13:7"]
+source = """
+fn main() -> i32 {
+    @dbg(());
+    0
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "dbg_invalid_type_array"
+spec = ["4.13:7"]
+source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [1, 2, 3];
+    @dbg(arr);
+    0
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "dbg_invalid_type_struct"
+spec = ["4.13:7"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    @dbg(p);
+    0
+}
+"""
+compile_fail = true

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -1,0 +1,62 @@
+# Intrinsic Expressions
+
+r[4.13.1#normative]
+An intrinsic expression invokes a compiler-provided primitive operation.
+
+r[4.13.2#normative]
+```ebnf
+intrinsic = "@" IDENT "(" [ expression { "," expression } ] ")" ;
+```
+
+r[4.13.3#normative]
+Intrinsics are prefixed with `@` to distinguish them from user-defined functions.
+
+r[4.13.4#normative]
+Each intrinsic has a fixed signature specifying the number and types of arguments it accepts.
+
+r[4.13.5#normative]
+Using an unknown intrinsic name is a compile-time error.
+
+## `@dbg`
+
+r[4.13.6#normative]
+The `@dbg` intrinsic prints a value to standard output for debugging purposes.
+
+r[4.13.7#normative]
+`@dbg` accepts exactly one argument of integer or boolean type.
+
+r[4.13.8#normative]
+`@dbg` prints the value followed by a newline character.
+
+r[4.13.9#normative]
+The return type of `@dbg` is `()`.
+
+r[4.13.10]
+```rue
+fn main() -> i32 {
+    @dbg(42);       // prints: 42
+    @dbg(-17);      // prints: -17
+    @dbg(true);     // prints: true
+    @dbg(false);    // prints: false
+    @dbg(10 + 5);   // prints: 15
+    0
+}
+```
+
+r[4.13.11]
+`@dbg` is useful for inspecting values during development:
+
+```rue
+fn factorial(n: i32) -> i32 {
+    @dbg(n);  // trace each call
+    if n <= 1 {
+        1
+    } else {
+        n * factorial(n - 1)
+    }
+}
+
+fn main() -> i32 {
+    factorial(5)
+}
+```

--- a/docs/spec/src/SUMMARY.md
+++ b/docs/spec/src/SUMMARY.md
@@ -31,6 +31,7 @@
   - [Call Expressions](04-expressions/10-call-expressions.md)
   - [Index Expressions](04-expressions/11-index-expressions.md)
   - [Field Access Expressions](04-expressions/12-field-access.md)
+  - [Intrinsic Expressions](04-expressions/13-intrinsics.md)
 
 - [Statements](05-statements/README.md)
   - [Let Statements](05-statements/01-let-statements.md)

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -42,6 +42,7 @@ additive       = multiplicative { ( "+" | "-" ) multiplicative } ;
 multiplicative = unary { ( "*" | "/" | "%" ) unary } ;
 unary          = "-" unary | "!" unary | postfix ;
 postfix        = primary { "[" expression "]" | "(" [ args ] ")" | "." IDENT } ;
+intrinsic      = "@" IDENT "(" [ args ] ")" ;
 args           = expression { "," expression } ;
 primary        = INTEGER | BOOL | IDENT
                | "(" expression ")"
@@ -52,7 +53,8 @@ primary        = INTEGER | BOOL | IDENT
                | "break" | "continue"
                | return_expr
                | array_literal
-               | struct_literal ;
+               | struct_literal
+               | intrinsic ;
 
 (* Compound expressions *)
 block_expr     = "{" block "}" ;


### PR DESCRIPTION
Document the `@` intrinsic syntax and the `@dbg` debugging intrinsic in chapter 4.13 of the language specification. Includes EBNF grammar, normative rules for argument validation and type checking, and spec test coverage for all specified behaviors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)