### PR TITLE
Add author attribution to blog posts

### DIFF
--- a/website/content/blog/hello-world.md
+++ b/website/content/blog/hello-world.md
@@ -2,6 +2,9 @@
 title = "Hello, World!"
 date = 2025-12-21
 template = "blog-page.html"
+
+[extra]
+authors = ["steve", "claude"]
 +++
 
 Welcome to the Rue programming language blog! This is where we'll share updates about the language's development, design decisions, and announcements.

--- a/website/sass/style.scss
+++ b/website/sass/style.scss
@@ -310,11 +310,20 @@ a {
             }
         }
 
-        time {
-            display: block;
+        .post-meta {
             color: $color-muted;
             font-size: 0.875rem;
             margin-bottom: 0.75rem;
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+
+            .authors {
+                &::before {
+                    content: "·";
+                    margin-right: 0.5rem;
+                }
+            }
         }
 
         p {
@@ -343,8 +352,18 @@ a {
             margin-bottom: 0.5rem;
         }
 
-        time {
+        .post-meta {
             color: $color-muted;
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+
+            .authors {
+                &::before {
+                    content: "·";
+                    margin-right: 0.5rem;
+                }
+            }
         }
     }
 

--- a/website/templates/blog-page.html
+++ b/website/templates/blog-page.html
@@ -7,7 +7,14 @@
     <div class="container">
         <header class="post-header">
             <h1>{{ page.title }}</h1>
-            <time datetime="{{ page.date }}">{{ page.date | date(format="%B %e, %Y") }}</time>
+            <div class="post-meta">
+                <time datetime="{{ page.date }}">{{ page.date | date(format="%B %e, %Y") }}</time>
+                {% if page.extra.authors %}
+                <span class="authors">
+                    by {% for author in page.extra.authors %}{% if loop.index > 1 %}{% if loop.last %} and {% else %}, {% endif %}{% endif %}{% if author == "steve" %}<a href="https://steveklabnik.com">Steve</a>{% elif author == "claude" %}<a href="https://claude.ai">Claude</a>{% else %}{{ author }}{% endif %}{% endfor %}
+                </span>
+                {% endif %}
+            </div>
         </header>
         <div class="post-content">
             {{ page.content | safe }}

--- a/website/templates/blog.html
+++ b/website/templates/blog.html
@@ -22,7 +22,14 @@
             {% for page in pages %}
             <article class="post-preview">
                 <h2><a href="{{ page.permalink }}">{{ page.title }}</a></h2>
-                <time datetime="{{ page.date }}">{{ page.date | date(format="%B %e, %Y") }}</time>
+                <div class="post-meta">
+                    <time datetime="{{ page.date }}">{{ page.date | date(format="%B %e, %Y") }}</time>
+                    {% if page.extra.authors %}
+                    <span class="authors">
+                        by {% for author in page.extra.authors %}{% if loop.index > 1 %}{% if loop.last %} and {% else %}, {% endif %}{% endif %}{% if author == "steve" %}Steve{% elif author == "claude" %}Claude{% else %}{{ author }}{% endif %}{% endfor %}
+                    </span>
+                    {% endif %}
+                </div>
                 {% if page.summary %}
                 <p>{{ page.summary | safe }}</p>
                 {% endif %}


### PR DESCRIPTION
Add support for displaying post authors in blog templates:
- Add extra.authors field to blog post frontmatter
- Display author bylines on both blog index and individual posts
- Link known authors (Steve, Claude) to their respective sites
- Style author display with separator and proper comma/and formatting