### PR TITLE
Remove instructions to source ~/.profile

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -3,5 +3,17 @@
     "allow": [
       "Bash(curl:*)"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'if [ -n \"$CLAUDE_ENV_FILE\" ]; then echo \"source ~/.profile\" >> \"$CLAUDE_ENV_FILE\"; fi'"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,6 @@ Rue is a systems programming language aiming for memory safety without garbage c
 
 This project uses Buck2 (via `./buck2` wrapper script), not Cargo.
 
-You will need to source `~/.profile` before running any commands.
-
 ### Common Commands
 
 ```bash


### PR DESCRIPTION
I set up a session hook to handle this locally, others shouldn't need to care about this, as it is specific to my setup.