### PR TITLE
Update spec paragraph ID format from dot to colon notation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,28 +265,35 @@ docs/spec/src/
 
 #### Spec Paragraph Format
 
-Each normative paragraph has an ID and category:
+Each paragraph has an ID using the format `r[{chapter}.{section}:{paragraph}]` with an optional category:
 
 ```markdown
-<!-- spec:3.1:1 legality-rule -->
+r[3.1:1#normative]
 A signed integer type is one of: `i8`, `i16`, `i32`, or `i64`.
 
-<!-- spec:3.1:2 dynamic-semantics -->
+r[3.1:2#normative]
 Signed integer arithmetic that overflows causes a runtime panic.
 
-<!-- spec:3.1:3 example informative -->
+r[3.1:3#example]
 ```rue
 let x: i32 = 42;
 ```
 ```
 
+The format is `r[X.Y:Z]` or `r[X.Y:Z#category]` where:
+- `X.Y` is the chapter and section (e.g., `3.1` for Chapter 3, Section 1)
+- `Z` is the paragraph number within that section
+- The colon (`:`) separates the structural location from the paragraph number
+- `#category` is optional (defaults to `informative` if omitted)
+
 **Paragraph categories:**
+- `normative` - General normative rule (requires test coverage)
 - `legality-rule` - Compile-time requirements (normative)
 - `dynamic-semantics` - Runtime behavior (normative)
 - `syntax` - Grammar rules (normative)
 - `undefined-behavior` - UB conditions (normative)
 - `example` - Code examples (informative)
-- `informative` - Explanatory text (informative)
+- `informative` - Explanatory text (informative, default)
 
 #### Traceability Report
 
@@ -311,7 +318,7 @@ When adding or changing language features, follow this checklist:
 ### Implementation Steps
 
 1. **Update the specification** (`docs/spec/src/`)
-   - Add/modify spec paragraphs with proper IDs (e.g., `<!-- spec:4.2:3 legality-rule -->`)
+   - Add/modify spec paragraphs with proper IDs (e.g., `r[4.2:3#normative]`)
    - Include normative rules, dynamic semantics, and examples
    - Update the grammar appendix if syntax changes
 

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -272,14 +272,14 @@ impl TraceabilityReport {
 }
 
 /// Parse a spec marker from a line.
-/// Format: r[X.Y.Z] or r[X.Y.Z#category] at the start of a line.
+/// Format: r[X.Y:Z] or r[X.Y:Z#category] at the start of a line.
 /// Category can be: normative, informative, syntax, example
 /// Default category (no #) is informative.
 /// Returns (id, category) if found.
 fn parse_spec_comment(line: &str) -> Option<(String, String)> {
     let line = line.trim();
 
-    // Format: r[X.Y.Z] or r[X.Y.Z#category] at start of line
+    // Format: r[X.Y:Z] or r[X.Y:Z#category] at start of line
     if line.starts_with("r[") && line.ends_with(']') {
         let inner = line.trim_start_matches("r[").trim_end_matches(']');
 
@@ -300,15 +300,12 @@ fn parse_spec_comment(line: &str) -> Option<(String, String)> {
             return None;
         }
 
-        // Convert from dot notation (X.Y.Z) to colon notation (X.Y:Z) for compatibility
-        // The last dot becomes a colon
-        let colon_id = if let Some(last_dot) = id.rfind('.') {
-            format!("{}:{}", &id[..last_dot], &id[last_dot + 1..])
-        } else {
-            id
-        };
+        // Validate that the ID contains a colon (required format: X.Y:Z)
+        if !id.contains(':') {
+            return None;
+        }
 
-        return Some((colon_id, category));
+        return Some((id, category));
     }
 
     None
@@ -511,17 +508,17 @@ mod tests {
     #[test]
     fn test_parse_spec_comment() {
         // Simple rule ID without category defaults to informative
-        let (id, cat) = parse_spec_comment("r[3.1.1]").unwrap();
+        let (id, cat) = parse_spec_comment("r[3.1:1]").unwrap();
         assert_eq!(id, "3.1:1");
         assert_eq!(cat, "informative");
 
         // Rule with explicit normative category
-        let (id, cat) = parse_spec_comment("r[4.2.3#normative]").unwrap();
+        let (id, cat) = parse_spec_comment("r[4.2:3#normative]").unwrap();
         assert_eq!(id, "4.2:3");
         assert_eq!(cat, "normative");
 
         // Rule with explicit syntax category
-        let (id, cat) = parse_spec_comment("r[2.1.1#syntax]").unwrap();
+        let (id, cat) = parse_spec_comment("r[2.1:1#syntax]").unwrap();
         assert_eq!(id, "2.1:1");
         assert_eq!(cat, "syntax");
 
@@ -530,6 +527,10 @@ mod tests {
         assert!(parse_spec_comment("<!-- not spec -->").is_none());
         assert!(parse_spec_comment("r[").is_none()); // Incomplete
         assert!(parse_spec_comment("r[]").is_none()); // Empty
+
+        // Old dot notation is no longer supported
+        assert!(parse_spec_comment("r[3.1.1]").is_none());
+        assert!(parse_spec_comment("r[4.2.3#normative]").is_none());
     }
 
     #[test]
@@ -537,10 +538,10 @@ mod tests {
         let content = r#"
 # Test
 
-r[3.1.1#normative]
+r[3.1:1#normative]
 This is a test paragraph.
 
-r[3.1.2#normative]
+r[3.1:2#normative]
 Another paragraph.
 "#;
         let dir = tempfile::tempdir().unwrap();
@@ -561,7 +562,7 @@ Another paragraph.
     #[test]
     fn test_default_category_is_informative() {
         // Rules without explicit category default to informative
-        let (id, cat) = parse_spec_comment("r[1.1.1]").unwrap();
+        let (id, cat) = parse_spec_comment("r[1.1:1]").unwrap();
         assert_eq!(id, "1.1:1");
         assert_eq!(cat, "informative");
     }
@@ -570,7 +571,7 @@ Another paragraph.
     fn test_explicit_example_category() {
         // Paragraphs can be explicitly marked as examples
         let content = r#"
-r[3.1.5#example]
+r[3.1:5#example]
 ```rue
 fn main() { }
 ```

--- a/docs/spec/src/01-introduction.md
+++ b/docs/spec/src/01-introduction.md
@@ -1,11 +1,11 @@
 # Introduction
 
-r[1.1.1]
+r[1.1:1]
 This document is the Rue Language Specification. It defines the syntax and semantics of the Rue programming language.
 
 ## Scope
 
-r[1.2.1]
+r[1.2:1]
 This specification describes the Rue programming language as implemented by the reference compiler. It covers:
 
 - Lexical structure (tokens, comments, whitespace)
@@ -15,7 +15,7 @@ This specification describes the Rue programming language as implemented by the 
 - Items (functions, struct definitions)
 - Runtime behavior
 
-r[1.2.2]
+r[1.2:2]
 This specification does not cover:
 
 - The standard library (when one exists)
@@ -24,10 +24,10 @@ This specification does not cover:
 
 ## Conformance
 
-r[1.3.1#normative]
+r[1.3:1#normative]
 A conforming implementation must implement all normative requirements of this specification.
 
-r[1.3.2]
+r[1.3:2]
 Paragraphs marked with rule categories are normative unless explicitly marked as informative. The following categories are used:
 
 | Category | Description |
@@ -40,33 +40,33 @@ Paragraphs marked with rule categories are normative unless explicitly marked as
 
 ## Definitions
 
-r[1.4.1]
+r[1.4:1]
 The following terms are used throughout this specification:
 
-r[1.4.2]
+r[1.4:2]
 **Expression**: A syntactic construct that evaluates to a value.
 
-r[1.4.3]
+r[1.4:3]
 **Statement**: A syntactic construct that performs an action but does not produce a value.
 
-r[1.4.4]
+r[1.4:4]
 **Item**: A top-level definition in a program, such as a function or struct.
 
-r[1.4.5]
+r[1.4:5]
 **Type**: A classification that determines what values an expression can produce and what operations are valid on those values.
 
-r[1.4.6]
+r[1.4:6]
 **Normative**: Content that defines required behavior for conforming implementations.
 
-r[1.4.7]
+r[1.4:7]
 **Informative**: Content that provides explanation or context but does not define required behavior.
 
 ## Notation
 
-r[1.5.1]
+r[1.5:1]
 Spec paragraph identifiers follow the format `{chapter}.{section}:{paragraph}`. For example, `3.1:5` refers to Chapter 3, Section 1, Paragraph 5.
 
-r[1.5.2]
+r[1.5:2]
 Grammar rules use Extended Backus-Naur Form (EBNF) notation:
 
 - `=` defines a production
@@ -76,14 +76,14 @@ Grammar rules use Extended Backus-Naur Form (EBNF) notation:
 - `" "` indicates literal text
 - `UPPERCASE` indicates terminal symbols (tokens)
 
-r[1.5.3]
+r[1.5:3]
 ```ebnf
 if_expr = "if" expression "{" block "}" [ "else" "{" block "}" ] ;
 ```
 
 ## Organization
 
-r[1.6.1]
+r[1.6:1]
 This specification is organized as follows:
 
 - **Chapter 2: Lexical Structure** - Tokens, comments, whitespace, keywords
@@ -98,5 +98,5 @@ This specification is organized as follows:
 
 ## Version
 
-r[1.7.1]
+r[1.7:1]
 This specification corresponds to version 0.1.0 of the Rue language.

--- a/docs/spec/src/02-lexical-structure/01-tokens.md
+++ b/docs/spec/src/02-lexical-structure/01-tokens.md
@@ -1,11 +1,11 @@
 # Tokens
 
-r[2.1.1#normative]
+r[2.1:1#normative]
 Tokens are the atomic units of syntax in a Rue program. The lexer processes source text and produces a sequence of tokens.
 
 ## Token Categories
 
-r[2.1.2]
+r[2.1:2]
 Rue tokens fall into the following categories:
 
 | Category | Examples |
@@ -19,7 +19,7 @@ Rue tokens fall into the following categories:
 
 ## Integer Literals
 
-r[2.1.3#normative]
+r[2.1:3#normative]
 An integer literal is a sequence of decimal digits.
 
 ```ebnf
@@ -27,10 +27,10 @@ integer_literal = digit { digit } ;
 digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 ```
 
-r[2.1.4#normative]
+r[2.1:4#normative]
 Integer literals must be representable in their target type. An unadorned integer literal defaults to type `i32`.
 
-r[2.1.5]
+r[2.1:5]
 ```rue
 fn main() -> i32 {
     0        // zero
@@ -41,7 +41,7 @@ fn main() -> i32 {
 
 ## String Literals
 
-r[2.1.6#normative]
+r[2.1:6#normative]
 A string literal is a sequence of characters enclosed in double quotes (`"`).
 
 ```ebnf
@@ -50,13 +50,13 @@ string_char = any_char_except_quote_or_backslash | escape_sequence ;
 escape_sequence = "\\" | "\"" ;
 ```
 
-r[2.1.7#normative]
+r[2.1:7#normative]
 String literals support escape sequences: `\\` for a backslash and `\"` for a double quote.
 
-r[2.1.8#normative]
+r[2.1:8#normative]
 An invalid escape sequence in a string literal is a compile-time error.
 
-r[2.1.9]
+r[2.1:9]
 ```rue
 fn main() -> i32 {
     let a = "hello world";
@@ -68,7 +68,7 @@ fn main() -> i32 {
 
 ## Identifiers
 
-r[2.1.10#normative]
+r[2.1:10#normative]
 An identifier starts with a letter or underscore, followed by any number of letters, digits, or underscores.
 
 ```ebnf
@@ -76,10 +76,10 @@ identifier = (letter | "_") { letter | digit | "_" } ;
 letter = "a" | ... | "z" | "A" | ... | "Z" ;
 ```
 
-r[2.1.11#normative]
+r[2.1:11#normative]
 Identifiers cannot be keywords. The identifier `_` (single underscore) is special and indicates an unused binding.
 
-r[2.1.12]
+r[2.1:12]
 ```rue
 fn main() -> i32 {
     let x = 1;

--- a/docs/spec/src/02-lexical-structure/02-comments.md
+++ b/docs/spec/src/02-lexical-structure/02-comments.md
@@ -1,16 +1,16 @@
 # Comments
 
-r[2.2.1#normative]
+r[2.2:1#normative]
 Line comments begin with `//` and extend to the end of the line.
 
 ```ebnf
 line_comment = "//" { any_char_except_newline } newline ;
 ```
 
-r[2.2.2#normative]
+r[2.2:2#normative]
 Comments are discarded during lexical analysis and do not affect program semantics.
 
-r[2.2.3]
+r[2.2:3]
 ```rue
 // This is a comment
 fn main() -> i32 {
@@ -18,5 +18,5 @@ fn main() -> i32 {
 }
 ```
 
-r[2.2.4]
+r[2.2:4]
 Block comments (`/* ... */`) are not currently supported.

--- a/docs/spec/src/02-lexical-structure/03-whitespace.md
+++ b/docs/spec/src/02-lexical-structure/03-whitespace.md
@@ -1,19 +1,19 @@
 # Whitespace
 
-r[2.3.1#normative]
+r[2.3:1#normative]
 Whitespace consists of spaces, tabs, and newlines.
 
 ```ebnf
 whitespace = " " | "\t" | "\n" | "\r" ;
 ```
 
-r[2.3.2#normative]
+r[2.3:2#normative]
 Whitespace is ignored between tokens except where it serves to separate tokens.
 
-r[2.3.3#normative]
+r[2.3:3#normative]
 Multiple whitespace characters between tokens are equivalent to a single space.
 
-r[2.3.4]
+r[2.3:4]
 ```rue
 // Minimal whitespace
 fn main()->i32{42}

--- a/docs/spec/src/02-lexical-structure/04-keywords.md
+++ b/docs/spec/src/02-lexical-structure/04-keywords.md
@@ -1,11 +1,11 @@
 # Keywords and Reserved Words
 
-r[2.4.1#normative]
+r[2.4:1#normative]
 Keywords are reserved words that have special meaning in the language.
 
 ## Keywords
 
-r[2.4.2#normative]
+r[2.4:2#normative]
 The following words are keywords and cannot be used as identifiers:
 
 | Keyword | Description |
@@ -27,7 +27,7 @@ The following words are keywords and cannot be used as identifiers:
 
 ## Type Names
 
-r[2.4.3#normative]
+r[2.4:3#normative]
 The following are type names and are reserved:
 
 | Type | Description |

--- a/docs/spec/src/02-lexical-structure/README.md
+++ b/docs/spec/src/02-lexical-structure/README.md
@@ -2,5 +2,5 @@
 
 This chapter describes the lexical structure of Rue programs, including tokens, comments, and whitespace.
 
-r[2.0.1]
+r[2.0:1]
 The lexer processes source text and produces a sequence of tokens. Comments and whitespace are handled but do not produce tokens.

--- a/docs/spec/src/03-types/01-integer-types.md
+++ b/docs/spec/src/03-types/01-integer-types.md
@@ -2,25 +2,25 @@
 
 ## Signed Integer Types
 
-r[3.1.1#normative]
+r[3.1:1#normative]
 A signed integer type is one of: `i8`, `i16`, `i32`, or `i64`.
 
-r[3.1.2#normative]
+r[3.1:2#normative]
 The type `i8` represents signed integers in the range [-128, 127].
 
-r[3.1.3#normative]
+r[3.1:3#normative]
 The type `i16` represents signed integers in the range [-32768, 32767].
 
-r[3.1.4#normative]
+r[3.1:4#normative]
 The type `i32` represents signed integers in the range [-2147483648, 2147483647].
 
-r[3.1.5#normative]
+r[3.1:5#normative]
 The type `i64` represents signed integers in the range [-9223372036854775808, 9223372036854775807].
 
-r[3.1.6#normative]
+r[3.1:6#normative]
 Signed integer arithmetic that overflows causes a runtime panic.
 
-r[3.1.7]
+r[3.1:7]
 ```rue
 fn main() -> i32 {
     let a: i8 = 127;
@@ -33,33 +33,33 @@ fn main() -> i32 {
 
 ## Unsigned Integer Types
 
-r[3.1.8#normative]
+r[3.1:8#normative]
 An unsigned integer type is one of: `u8`, `u16`, `u32`, or `u64`.
 
-r[3.1.9#normative]
+r[3.1:9#normative]
 The type `u8` represents unsigned integers in the range [0, 255].
 
-r[3.1.10#normative]
+r[3.1:10#normative]
 The type `u16` represents unsigned integers in the range [0, 65535].
 
-r[3.1.11#normative]
+r[3.1:11#normative]
 The type `u32` represents unsigned integers in the range [0, 4294967295].
 
-r[3.1.12#normative]
+r[3.1:12#normative]
 The type `u64` represents unsigned integers in the range [0, 18446744073709551615].
 
-r[3.1.13#normative]
+r[3.1:13#normative]
 Unsigned integer arithmetic that overflows causes a runtime panic.
 
 ## Integer Literal Type Inference
 
-r[3.1.14#normative]
+r[3.1:14#normative]
 An integer literal without explicit type annotation defaults to type `i32`.
 
-r[3.1.15#normative]
+r[3.1:15#normative]
 When an integer literal appears in a context where the expected type is known (e.g., assignment to a typed variable), the literal is inferred to have that type.
 
-r[3.1.16]
+r[3.1:16]
 ```rue
 fn main() -> i32 {
     let x = 42;           // x has type i32 (default)
@@ -70,10 +70,10 @@ fn main() -> i32 {
 
 ## Integer Literal Range Validation
 
-r[3.1.17#normative]
+r[3.1:17#normative]
 A compile-time error occurs when an integer literal value exceeds the representable range of its target type.
 
-r[3.1.18]
+r[3.1:18]
 ```rue
 fn main() -> i32 {
     let x: i8 = 128;           // error: literal out of range for i8

--- a/docs/spec/src/03-types/02-boolean-type.md
+++ b/docs/spec/src/03-types/02-boolean-type.md
@@ -1,18 +1,18 @@
 # Boolean Type
 
-r[3.2.1#normative]
+r[3.2:1#normative]
 The type `bool` represents boolean values.
 
-r[3.2.2#normative]
+r[3.2:2#normative]
 The only values of type `bool` are `true` and `false`.
 
-r[3.2.3#normative]
+r[3.2:3#normative]
 In memory, `bool` values are represented as a single byte: `false` is 0, `true` is 1.
 
-r[3.2.4#normative]
+r[3.2:4#normative]
 Boolean values support equality comparison (`==`, `!=`) but not ordering comparison (`<`, `>`, `<=`, `>=`).
 
-r[3.2.5]
+r[3.2:5]
 ```rue
 fn main() -> i32 {
     let a = true;

--- a/docs/spec/src/03-types/03-unit-type.md
+++ b/docs/spec/src/03-types/03-unit-type.md
@@ -1,18 +1,18 @@
 # Unit Type
 
-r[3.3.1#normative]
+r[3.3:1#normative]
 The unit type, written `()`, has exactly one value, also written `()`.
 
-r[3.3.2#normative]
+r[3.3:2#normative]
 Functions without an explicit return type annotation implicitly return `()`.
 
-r[3.3.3#normative]
+r[3.3:3#normative]
 Expressions that produce side effects but no meaningful value have type `()`.
 
-r[3.3.4#normative]
+r[3.3:4#normative]
 The unit value `()` occupies zero bytes in memory.
 
-r[3.3.5]
+r[3.3:5]
 ```rue
 fn do_nothing() {
     // Implicitly returns ()

--- a/docs/spec/src/03-types/04-never-type.md
+++ b/docs/spec/src/03-types/04-never-type.md
@@ -1,9 +1,9 @@
 # Never Type
 
-r[3.4.1#normative]
+r[3.4:1#normative]
 The never type, written `!`, is the type of expressions that never produce a value.
 
-r[3.4.2#normative]
+r[3.4:2#normative]
 Expressions of type `!` include:
 - `return` expressions
 - `break` expressions
@@ -12,13 +12,13 @@ Expressions of type `!` include:
 
 ## Type Coercion
 
-r[3.4.3#normative]
+r[3.4:3#normative]
 A type coercion is an implicit type conversion that occurs automatically during type checking. Rue has exactly one coercion: the never type coerces to any type.
 
-r[3.4.4#normative]
+r[3.4:4#normative]
 When type checking requires a value of type `T`, a value of type `!` is accepted. This allows diverging expressions to appear in any context where a value is expected.
 
-r[3.4.5]
+r[3.4:5]
 ```rue
 fn test(x: i32) -> i32 {
     // `return 100` has type !, which coerces to i32
@@ -31,10 +31,10 @@ fn main() -> i32 {
 }
 ```
 
-r[3.4.6#normative]
+r[3.4:6#normative]
 When both branches of an `if` expression or all arms of a `match` expression have type `!`, the entire expression has type `!`.
 
-r[3.4.7]
+r[3.4:7]
 ```rue
 fn diverges(x: i32) -> i32 {
     // Both branches return, so the if has type !
@@ -47,5 +47,5 @@ fn main() -> i32 { diverges(5) }
 
 ## Diverging Functions
 
-r[3.4.8#normative]
+r[3.4:8#normative]
 A function with return type `!` never returns normally.

--- a/docs/spec/src/03-types/05-array-types.md
+++ b/docs/spec/src/03-types/05-array-types.md
@@ -1,18 +1,18 @@
 # Array Types
 
-r[3.5.1#normative]
+r[3.5:1#normative]
 An array type, written `[T; N]`, represents a fixed-size sequence of `N` elements of type `T`.
 
-r[3.5.2#normative]
+r[3.5:2#normative]
 The length `N` must be a non-negative integer literal known at compile time.
 
-r[3.5.3#normative]
+r[3.5:3#normative]
 All elements of an array must have the same type `T`.
 
-r[3.5.4#normative]
+r[3.5:4#normative]
 Arrays are stored contiguously in memory. The size of `[T; N]` is `N * size_of(T)`.
 
-r[3.5.5]
+r[3.5:5]
 ```rue
 fn main() -> i32 {
     let arr: [i32; 3] = [10, 20, 12];
@@ -20,19 +20,19 @@ fn main() -> i32 {
 }
 ```
 
-r[3.5.6#normative]
+r[3.5:6#normative]
 Array elements are accessed using index syntax `arr[index]`.
 
-r[3.5.7#normative]
+r[3.5:7#normative]
 For constant indices, bounds checking is performed at compile time.
 
-r[3.5.8#normative]
+r[3.5:8#normative]
 For variable indices, bounds checking is performed at runtime.
 
-r[3.5.9#normative]
+r[3.5:9#normative]
 Accessing an array with an out-of-bounds index causes a runtime panic.
 
-r[3.5.10]
+r[3.5:10]
 ```rue
 fn main() -> i32 {
     let arr: [i32; 3] = [1, 2, 3];

--- a/docs/spec/src/03-types/06-struct-types.md
+++ b/docs/spec/src/03-types/06-struct-types.md
@@ -1,9 +1,9 @@
 # Struct Types
 
-r[3.6.1#normative]
+r[3.6:1#normative]
 A struct type is a composite type consisting of named fields.
 
-r[3.6.2#normative]
+r[3.6:2#normative]
 A struct is defined using the `struct` keyword:
 
 ```ebnf
@@ -12,7 +12,7 @@ struct_fields = struct_field { "," struct_field } [ "," ] ;
 struct_field = IDENT ":" type ;
 ```
 
-r[3.6.3]
+r[3.6:3]
 ```rue
 struct Point {
     x: i32,
@@ -25,11 +25,11 @@ fn main() -> i32 {
 }
 ```
 
-r[3.6.4#normative]
+r[3.6:4#normative]
 Struct fields are accessed using dot notation: `value.field_name`.
 
-r[3.6.5#normative]
+r[3.6:5#normative]
 All fields must be initialized when creating a struct instance.
 
-r[3.6.6#normative]
+r[3.6:6#normative]
 Field names must be unique within a struct.

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -1,15 +1,15 @@
 # String Type
 
-r[3.7.1#normative]
+r[3.7:1#normative]
 The type `String` represents an immutable sequence of UTF-8 encoded bytes.
 
-r[3.7.2#normative]
+r[3.7:2#normative]
 A `String` value is a fat pointer consisting of a pointer to the string data and the length in bytes.
 
-r[3.7.3#normative]
+r[3.7:3#normative]
 String literals are stored in read-only memory and have static lifetime.
 
-r[3.7.4]
+r[3.7:4]
 ```rue
 fn main() -> i32 {
     let s = "hello";
@@ -19,10 +19,10 @@ fn main() -> i32 {
 
 ## String Literals
 
-r[3.7.5#normative]
+r[3.7:5#normative]
 A string literal is a sequence of characters enclosed in double quotes (`"`).
 
-r[3.7.6#normative]
+r[3.7:6#normative]
 String literals support the following escape sequences:
 
 | Escape | Meaning |
@@ -30,10 +30,10 @@ String literals support the following escape sequences:
 | `\\` | Backslash |
 | `\"` | Double quote |
 
-r[3.7.7#normative]
+r[3.7:7#normative]
 An invalid escape sequence in a string literal is a compile-time error.
 
-r[3.7.8]
+r[3.7:8]
 ```rue
 fn main() -> i32 {
     let a = "hello world";
@@ -45,13 +45,13 @@ fn main() -> i32 {
 
 ## String Equality
 
-r[3.7.9#normative]
+r[3.7:9#normative]
 Strings support the equality operators `==` and `!=`.
 
-r[3.7.10#normative]
+r[3.7:10#normative]
 Two strings are equal if they have the same length and identical byte content.
 
-r[3.7.11]
+r[3.7:11]
 ```rue
 fn main() -> i32 {
     let a = "hello";
@@ -67,10 +67,10 @@ fn main() -> i32 {
 
 ## String Debugging
 
-r[3.7.12#normative]
+r[3.7:12#normative]
 The `@dbg` intrinsic accepts a `String` argument and prints its content followed by a newline.
 
-r[3.7.13]
+r[3.7:13]
 ```rue
 fn main() -> i32 {
     let msg = "Hello, world!";
@@ -81,7 +81,7 @@ fn main() -> i32 {
 
 ## Limitations
 
-r[3.7.14#informative]
+r[3.7:14#informative]
 The current implementation does not support:
 - String concatenation
 - String indexing or slicing

--- a/docs/spec/src/03-types/README.md
+++ b/docs/spec/src/03-types/README.md
@@ -2,5 +2,5 @@
 
 This chapter describes the type system of Rue.
 
-r[3.0.1]
+r[3.0:1]
 Every value in Rue has a type that determines its representation in memory and the operations that can be performed on it.

--- a/docs/spec/src/04-expressions/01-literal-expressions.md
+++ b/docs/spec/src/04-expressions/01-literal-expressions.md
@@ -1,17 +1,17 @@
 # Literal Expressions
 
-r[4.1.1#normative]
+r[4.1:1#normative]
 A literal expression evaluates to a constant value.
 
 ## Integer Literals
 
-r[4.1.2#normative]
+r[4.1:2#normative]
 An integer literal is a sequence of decimal digits that evaluates to an integer value.
 
-r[4.1.3#normative]
+r[4.1:3#normative]
 Integer literals default to type `i32` unless the context requires a different type.
 
-r[4.1.4]
+r[4.1:4]
 ```rue
 fn main() -> i32 {
     0       // zero
@@ -22,10 +22,10 @@ fn main() -> i32 {
 
 ## Boolean Literals
 
-r[4.1.5#normative]
+r[4.1:5#normative]
 The boolean literals are `true` and `false`, both of type `bool`.
 
-r[4.1.6]
+r[4.1:6]
 ```rue
 fn main() -> i32 {
     let a = true;
@@ -36,13 +36,13 @@ fn main() -> i32 {
 
 ## Unit Literal
 
-r[4.1.7#normative]
+r[4.1:7#normative]
 The unit literal `()` is an expression of type `()`.
 
-r[4.1.8#normative]
+r[4.1:8#normative]
 The unit literal evaluates to the single value of the unit type.
 
-r[4.1.9]
+r[4.1:9]
 ```rue
 fn returns_unit() -> () {
     ()
@@ -57,13 +57,13 @@ fn main() -> i32 {
 
 ## String Literals
 
-r[4.1.10#normative]
+r[4.1:10#normative]
 A string literal is a sequence of characters enclosed in double quotes, of type `String`.
 
-r[4.1.11#normative]
+r[4.1:11#normative]
 String literals support escape sequences: `\\` for a backslash and `\"` for a double quote.
 
-r[4.1.12]
+r[4.1:12]
 ```rue
 fn main() -> i32 {
     let a = "hello";

--- a/docs/spec/src/04-expressions/02-arithmetic-operators.md
+++ b/docs/spec/src/04-expressions/02-arithmetic-operators.md
@@ -2,7 +2,7 @@
 
 ## Binary Arithmetic Operators
 
-r[4.2.1#normative]
+r[4.2:1#normative]
 Binary arithmetic operators take two operands of the same integer type and produce a result of that type.
 
 | Operator | Name | Description |
@@ -15,13 +15,13 @@ Binary arithmetic operators take two operands of the same integer type and produ
 
 ## Operator Precedence
 
-r[4.2.2#normative]
+r[4.2:2#normative]
 Multiplicative operators (`*`, `/`, `%`) have higher precedence than additive operators (`+`, `-`).
 
-r[4.2.3#normative]
+r[4.2:3#normative]
 Parentheses can be used to override the default precedence of operators. A parenthesized expression evaluates to the value of its inner expression.
 
-r[4.2.13]
+r[4.2:13]
 ```rue
 fn main() -> i32 {
     1 + 2 * 3    // = 7 (not 9)
@@ -31,10 +31,10 @@ fn main() -> i32 {
 
 ## Associativity
 
-r[4.2.4#normative]
+r[4.2:4#normative]
 All binary arithmetic operators are left-associative.
 
-r[4.2.5#normative]
+r[4.2:5#normative]
 ```rue
 fn main() -> i32 {
     10 - 3 - 2   // = 5, parsed as (10 - 3) - 2
@@ -44,16 +44,16 @@ fn main() -> i32 {
 
 ## Unary Negation
 
-r[4.2.6#normative]
+r[4.2:6#normative]
 The unary negation operator `-` takes a single signed integer operand and produces its arithmetic negation.
 
-r[4.2.14#normative]
+r[4.2:14#normative]
 Unary negation on unsigned integer types is a compile-time error.
 
-r[4.2.7#normative]
+r[4.2:7#normative]
 Unary negation binds tighter than all binary operators.
 
-r[4.2.8]
+r[4.2:8]
 ```rue
 fn main() -> i32 {
     -42      // negation
@@ -64,10 +64,10 @@ fn main() -> i32 {
 
 ## Overflow
 
-r[4.2.9#normative]
+r[4.2:9#normative]
 Arithmetic operations that overflow the range of their type cause a runtime panic.
 
-r[4.2.10]
+r[4.2:10]
 ```rue
 fn main() -> i32 {
     2147483647 + 1  // Runtime error: integer overflow
@@ -76,10 +76,10 @@ fn main() -> i32 {
 
 ## Division by Zero
 
-r[4.2.11#normative]
+r[4.2:11#normative]
 Division or remainder by zero causes a runtime panic.
 
-r[4.2.12]
+r[4.2:12]
 ```rue
 fn main() -> i32 {
     10 / 0  // Runtime error: division by zero

--- a/docs/spec/src/04-expressions/03-comparison-operators.md
+++ b/docs/spec/src/04-expressions/03-comparison-operators.md
@@ -1,11 +1,11 @@
 # Comparison Operators
 
-r[4.3.1#normative]
+r[4.3:1#normative]
 Comparison operators compare two values and produce a `bool` result.
 
 ## Equality Operators
 
-r[4.3.2#normative]
+r[4.3:2#normative]
 Equality operators work on integers, booleans, and strings.
 
 | Operator | Name | Description |
@@ -13,10 +13,10 @@ Equality operators work on integers, booleans, and strings.
 | `==` | Equal | True if operands are equal |
 | `!=` | Not equal | True if operands are not equal |
 
-r[4.3.3#normative]
+r[4.3:3#normative]
 Two strings are equal if they have the same length and identical byte content.
 
-r[4.3.4]
+r[4.3:4]
 ```rue
 fn main() -> i32 {
     let a = 1 == 1;    // true
@@ -29,7 +29,7 @@ fn main() -> i32 {
 
 ## Ordering Operators
 
-r[4.3.5#normative]
+r[4.3:5#normative]
 Ordering operators work only on integers.
 
 | Operator | Name | Description |
@@ -39,10 +39,10 @@ Ordering operators work only on integers.
 | `<=` | Less or equal | True if left <= right |
 | `>=` | Greater or equal | True if left >= right |
 
-r[4.3.6#normative]
+r[4.3:6#normative]
 Ordering operators on boolean or string values are a compile-time error.
 
-r[4.3.7]
+r[4.3:7]
 ```rue
 fn main() -> i32 {
     let a = 1 < 2;     // true
@@ -53,10 +53,10 @@ fn main() -> i32 {
 
 ## Precedence
 
-r[4.3.8#normative]
+r[4.3:8#normative]
 Comparison operators have lower precedence than arithmetic operators.
 
-r[4.3.9]
+r[4.3:9]
 ```rue
 fn main() -> i32 {
     if 1 + 2 == 3 { 1 } else { 0 }  // 1 (comparison after arithmetic)
@@ -65,8 +65,8 @@ fn main() -> i32 {
 
 ## Type Checking
 
-r[4.3.10#normative]
+r[4.3:10#normative]
 Both operands of a comparison must have the same type.
 
-r[4.3.11#normative]
+r[4.3:11#normative]
 When one operand has a known type, the other is inferred to have the same type.

--- a/docs/spec/src/04-expressions/03a-bitwise-operators.md
+++ b/docs/spec/src/04-expressions/03a-bitwise-operators.md
@@ -4,7 +4,7 @@ Bitwise operators perform bit-level operations on integer values.
 
 ## Binary Bitwise Operators
 
-r[4.3a.1#normative]
+r[4.3a:1#normative]
 Binary bitwise operators take two operands of the same integer type and produce a result of that type.
 
 | Operator | Name | Description |
@@ -13,7 +13,7 @@ Binary bitwise operators take two operands of the same integer type and produce 
 | `\|` | Bitwise OR | Sets each bit if either operand bit is 1 |
 | `^` | Bitwise XOR | Sets each bit if exactly one operand bit is 1 |
 
-r[4.3a.2]
+r[4.3a:2]
 ```rue
 fn main() -> i32 {
     let a: i32 = 0b1100;
@@ -27,13 +27,13 @@ fn main() -> i32 {
 
 ## Bitwise NOT
 
-r[4.3a.3#normative]
+r[4.3a:3#normative]
 The bitwise NOT operator `~` inverts all bits of its operand.
 
-r[4.3a.4#normative]
+r[4.3a:4#normative]
 Bitwise NOT takes a single integer operand and produces a result of the same type.
 
-r[4.3a.5]
+r[4.3a:5]
 ```rue
 fn main() -> i32 {
     let a: i32 = 0b0101;
@@ -44,7 +44,7 @@ fn main() -> i32 {
 
 ## Shift Operators
 
-r[4.3a.6#normative]
+r[4.3a:6#normative]
 Shift operators move bits left or right by a specified number of positions.
 
 | Operator | Name | Description |
@@ -52,21 +52,21 @@ Shift operators move bits left or right by a specified number of positions.
 | `<<` | Left Shift | Shifts bits left, filling with zeros |
 | `>>` | Right Shift | Shifts bits right |
 
-r[4.3a.7#normative]
+r[4.3a:7#normative]
 For left shift (`<<`), vacated bit positions are filled with zeros.
 
-r[4.3a.8#normative]
+r[4.3a:8#normative]
 For right shift (`>>`), the behavior depends on the signedness of the operand type:
 - For unsigned types, vacated bit positions are filled with zeros (logical shift).
 - For signed types, vacated bit positions are filled with copies of the sign bit (arithmetic shift).
 
-r[4.3a.9#normative]
+r[4.3a:9#normative]
 The shift amount operand shall have the same type as the value being shifted.
 
-r[4.3a.10#normative]
+r[4.3a:10#normative]
 If the shift amount is greater than or equal to the bit width of the type, the behavior is defined as shifting by the amount modulo the bit width. For example, shifting an `i32` by 33 positions is equivalent to shifting by 1 position.
 
-r[4.3a.11]
+r[4.3a:11]
 ```rue
 fn main() -> i32 {
     let x: i32 = 1;
@@ -78,7 +78,7 @@ fn main() -> i32 {
 
 ## Operator Precedence
 
-r[4.3a.12#normative]
+r[4.3a:12#normative]
 Bitwise operator precedence (highest to lowest within this group):
 1. `~` (bitwise NOT, unary)
 2. `<<`, `>>` (shift operators)
@@ -86,13 +86,13 @@ Bitwise operator precedence (highest to lowest within this group):
 4. `^` (bitwise XOR)
 5. `|` (bitwise OR)
 
-r[4.3a.13#normative]
+r[4.3a:13#normative]
 Shift operators have higher precedence than arithmetic operators. Bitwise AND, XOR, and OR have lower precedence than comparison operators.
 
-r[4.3a.14#normative]
+r[4.3a:14#normative]
 Parentheses can be used to override the default precedence.
 
-r[4.3a.15]
+r[4.3a:15]
 ```rue
 fn main() -> i32 {
     let a: i32 = 1 | 2 & 3;   // = 1 | (2 & 3) = 1 | 2 = 3
@@ -103,10 +103,10 @@ fn main() -> i32 {
 
 ## Associativity
 
-r[4.3a.16#normative]
+r[4.3a:16#normative]
 All binary bitwise operators are left-associative.
 
-r[4.3a.17]
+r[4.3a:17]
 ```rue
 fn main() -> i32 {
     let x: i32 = 1 << 2 << 1;  // = (1 << 2) << 1 = 4 << 1 = 8
@@ -116,8 +116,8 @@ fn main() -> i32 {
 
 ## Type Checking
 
-r[4.3a.18#normative]
+r[4.3a:18#normative]
 Bitwise operators are only valid for integer types (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`).
 
-r[4.3a.19#normative]
+r[4.3a:19#normative]
 Using bitwise operators on boolean or other non-integer types is a compile-time error.

--- a/docs/spec/src/04-expressions/04-logical-operators.md
+++ b/docs/spec/src/04-expressions/04-logical-operators.md
@@ -1,14 +1,14 @@
 # Logical Operators
 
-r[4.4.1#normative]
+r[4.4:1#normative]
 Logical operators operate on `bool` values and produce `bool` results.
 
 ## Logical NOT
 
-r[4.4.2#normative]
+r[4.4:2#normative]
 The logical NOT operator `!` negates its operand.
 
-r[4.4.3]
+r[4.4:3]
 ```rue
 fn main() -> i32 {
     let a = !false;   // true
@@ -20,13 +20,13 @@ fn main() -> i32 {
 
 ## Logical AND
 
-r[4.4.4#normative]
+r[4.4:4#normative]
 The logical AND operator `&&` returns `true` if both operands are `true`.
 
-r[4.4.5#normative]
+r[4.4:5#normative]
 The `&&` operator uses short-circuit evaluation: if the left operand is `false`, the right operand is not evaluated.
 
-r[4.4.6]
+r[4.4:6]
 ```rue
 fn main() -> i32 {
     if true && true { 1 } else { 0 }   // 1
@@ -36,13 +36,13 @@ fn main() -> i32 {
 
 ## Logical OR
 
-r[4.4.7#normative]
+r[4.4:7#normative]
 The logical OR operator `||` returns `true` if either operand is `true`.
 
-r[4.4.8#normative]
+r[4.4:8#normative]
 The `||` operator uses short-circuit evaluation: if the left operand is `true`, the right operand is not evaluated.
 
-r[4.4.9]
+r[4.4:9]
 ```rue
 fn main() -> i32 {
     if false || true { 1 } else { 0 }  // 1
@@ -52,13 +52,13 @@ fn main() -> i32 {
 
 ## Precedence
 
-r[4.4.10#normative]
+r[4.4:10#normative]
 Operator precedence (highest to lowest):
 1. `!` (logical NOT)
 2. `&&` (logical AND)
 3. `||` (logical OR)
 
-r[4.4.11]
+r[4.4:11]
 ```rue
 fn main() -> i32 {
     // true || false && false => true || (false && false) => true
@@ -68,5 +68,5 @@ fn main() -> i32 {
 
 ## Type Checking
 
-r[4.4.12#normative]
+r[4.4:12#normative]
 All operands of logical operators must have type `bool`.

--- a/docs/spec/src/04-expressions/05-block-expressions.md
+++ b/docs/spec/src/04-expressions/05-block-expressions.md
@@ -1,20 +1,20 @@
 # Block Expressions
 
-r[4.5.1#normative]
+r[4.5:1#normative]
 A block expression is a sequence of statements followed by an optional expression, enclosed in braces.
 
-r[4.5.2#normative]
+r[4.5:2#normative]
 ```ebnf
 block_expr = "{" { statement } [ expression ] "}" ;
 ```
 
-r[4.5.3#normative]
+r[4.5:3#normative]
 The type of a block expression is the type of its final expression. If the block ends with a statement, the type is `()`.
 
-r[4.5.4#normative]
+r[4.5:4#normative]
 Variables declared in a block are local to that block and shadow any outer variables with the same name.
 
-r[4.5.5]
+r[4.5:5]
 ```rue
 fn main() -> i32 {
     let x = 1;
@@ -26,5 +26,5 @@ fn main() -> i32 {
 }
 ```
 
-r[4.5.6#normative]
+r[4.5:6#normative]
 When a block exits, all local variables declared in that block are destroyed.

--- a/docs/spec/src/04-expressions/06-if-expressions.md
+++ b/docs/spec/src/04-expressions/06-if-expressions.md
@@ -1,23 +1,23 @@
 # If Expressions
 
-r[4.6.1#normative]
+r[4.6:1#normative]
 An if expression conditionally executes one of two branches based on a boolean condition.
 
-r[4.6.2#normative]
+r[4.6:2#normative]
 ```ebnf
 if_expr = "if" expression "{" block "}" [ "else" "{" block "}" ] ;
 ```
 
-r[4.6.3#normative]
+r[4.6:3#normative]
 The condition expression must have type `bool`.
 
-r[4.6.4#normative]
+r[4.6:4#normative]
 If an `else` branch is present, both branches must have the same type. The type of the if expression is the type of its branches.
 
-r[4.6.5#normative]
+r[4.6:5#normative]
 If no `else` branch is present, the `then` branch must have type `()`.
 
-r[4.6.6]
+r[4.6:6]
 ```rue
 fn main() -> i32 {
     let x = if true { 42 } else { 0 };
@@ -25,10 +25,10 @@ fn main() -> i32 {
 }
 ```
 
-r[4.6.7#normative]
+r[4.6:7#normative]
 If the condition evaluates to `true`, the then-branch is executed. Otherwise, the else-branch is executed (if present).
 
-r[4.6.8]
+r[4.6:8]
 ```rue
 fn main() -> i32 {
     let n = 5;
@@ -36,7 +36,7 @@ fn main() -> i32 {
 }
 ```
 
-r[4.6.9]
+r[4.6:9]
 If expressions can be nested:
 
 ```rue

--- a/docs/spec/src/04-expressions/07-match-expressions.md
+++ b/docs/spec/src/04-expressions/07-match-expressions.md
@@ -1,9 +1,9 @@
 # Match Expressions
 
-r[4.7.1#normative]
+r[4.7:1#normative]
 A match expression provides multi-way branching based on pattern matching.
 
-r[4.7.2#normative]
+r[4.7:2#normative]
 ```ebnf
 match_expr = "match" expression "{" { match_arm "," } [ match_arm ] "}" ;
 match_arm = pattern "=>" expression ;
@@ -13,33 +13,33 @@ enum_variant_pattern = IDENT "::" IDENT ;
 
 ## Patterns
 
-r[4.7.3#normative]
+r[4.7:3#normative]
 A pattern is *irrefutable* if it matches any value of its type.
 A pattern is *refutable* if there exist values of its type that it does not match.
 
-r[4.7.4#normative]
+r[4.7:4#normative]
 The wildcard pattern `_` is irrefutable. It matches any value.
 
-r[4.7.5#normative]
+r[4.7:5#normative]
 An integer literal pattern is refutable. It matches only the specific integer value it denotes.
 
-r[4.7.6#normative]
+r[4.7:6#normative]
 A boolean literal pattern (`true` or `false`) is refutable. It matches only the specific boolean value it denotes.
 
-r[4.7.7#normative]
+r[4.7:7#normative]
 An enum variant pattern is refutable. It matches only values of that specific variant.
 
 ## Exhaustiveness
 
-r[4.7.8#normative]
+r[4.7:8#normative]
 A set of patterns is *exhaustive* for a type if every possible value of that type
 is matched by at least one pattern in the set.
 
-r[4.7.9#normative]
+r[4.7:9#normative]
 A match expression shall have an exhaustive set of patterns for its scrutinee type.
 A match expression with a non-exhaustive pattern set is rejected with a compile-time error.
 
-r[4.7.10#normative]
+r[4.7:10#normative]
 The following rules determine whether a pattern set is exhaustive:
 
 1. Any pattern set containing an irrefutable pattern is exhaustive.
@@ -47,7 +47,7 @@ The following rules determine whether a pattern set is exhaustive:
 3. For an enum type: a pattern set containing a pattern for every variant of that enum is exhaustive.
 4. For integer types: only rule (1) applies; explicit enumeration of integer values is not sufficient to establish exhaustiveness.
 
-r[4.7.11]
+r[4.7:11]
 ```rue
 fn main() -> i32 {
     match 2 {
@@ -60,19 +60,19 @@ fn main() -> i32 {
 
 ## Type Checking
 
-r[4.7.12#normative]
+r[4.7:12#normative]
 All match arms shall have the same type. The type of the match expression is the common type of its arms.
 
-r[4.7.13#normative]
+r[4.7:13#normative]
 The type of each pattern shall be compatible with the type of the scrutinee.
 A pattern with an incompatible type is rejected with a compile-time error.
 
 ## Arm Bodies
 
-r[4.7.14#normative]
+r[4.7:14#normative]
 Match arm bodies may be simple expressions or block expressions.
 
-r[4.7.15]
+r[4.7:15]
 ```rue
 fn main() -> i32 {
     match 2 {
@@ -88,30 +88,30 @@ fn main() -> i32 {
 
 ## Execution
 
-r[4.7.16#normative]
+r[4.7:16#normative]
 Arms are evaluated in order. The first arm whose pattern matches the scrutinee value
 is selected, and its body expression is evaluated. The result of that evaluation
 becomes the value of the match expression.
 
 ## Unreachable Patterns
 
-r[4.7.17#normative]
+r[4.7:17#normative]
 A pattern is *unreachable* if all values it could match are already matched by
 a preceding pattern in the same match expression.
 
-r[4.7.18#normative]
+r[4.7:18#normative]
 A pattern following an irrefutable pattern (such as `_`) is always unreachable,
 since the irrefutable pattern matches all possible values.
 
-r[4.7.19#normative]
+r[4.7:19#normative]
 A pattern that is identical to a preceding pattern in the same match expression
 is unreachable, since the earlier pattern will match first.
 
-r[4.7.20#normative]
+r[4.7:20#normative]
 An unreachable pattern produces a compile-time warning. The program remains
 well-formed and the unreachable arm is not executed at runtime.
 
-r[4.7.21]
+r[4.7:21]
 ```rue
 fn main() -> i32 {
     match 5 {
@@ -121,7 +121,7 @@ fn main() -> i32 {
 }
 ```
 
-r[4.7.22]
+r[4.7:22]
 ```rue
 fn main() -> i32 {
     match 1 {

--- a/docs/spec/src/04-expressions/08-loop-expressions.md
+++ b/docs/spec/src/04-expressions/08-loop-expressions.md
@@ -2,24 +2,24 @@
 
 ## While Loops
 
-r[4.8.1#normative]
+r[4.8:1#normative]
 A while loop repeatedly executes its body while a condition is true.
 
-r[4.8.2#normative]
+r[4.8:2#normative]
 ```ebnf
 while_expr = "while" expression "{" block "}" ;
 ```
 
-r[4.8.3#normative]
+r[4.8:3#normative]
 The condition expression must have type `bool`.
 
-r[4.8.4#normative]
+r[4.8:4#normative]
 A while expression has type `()`.
 
-r[4.8.5#normative]
+r[4.8:5#normative]
 The condition is evaluated before each iteration. If it is `true`, the body is executed and the condition is re-evaluated. If it is `false`, the loop terminates.
 
-r[4.8.6]
+r[4.8:6]
 ```rue
 fn main() -> i32 {
     let mut sum = 0;
@@ -34,21 +34,21 @@ fn main() -> i32 {
 
 ## Infinite Loops
 
-r[4.8.15#normative]
+r[4.8:15#normative]
 An infinite loop repeatedly executes its body unconditionally.
 
-r[4.8.16#normative]
+r[4.8:16#normative]
 ```ebnf
 loop_expr = "loop" "{" block "}" ;
 ```
 
-r[4.8.17#normative]
+r[4.8:17#normative]
 A loop expression has type `!` (never), because it never terminates normally.
 
-r[4.8.18#normative]
+r[4.8:18#normative]
 The only way to exit a `loop` is via `break` or `return`.
 
-r[4.8.19]
+r[4.8:19]
 ```rue
 fn main() -> i32 {
     let mut x = 0;
@@ -62,7 +62,7 @@ fn main() -> i32 {
 }
 ```
 
-r[4.8.20]
+r[4.8:20]
 The `loop` expression is preferred over `while true` for infinite loops:
 
 ```rue
@@ -79,19 +79,19 @@ while true {
 
 ## Break and Continue
 
-r[4.8.7#normative]
+r[4.8:7#normative]
 The `break` expression exits the innermost enclosing loop.
 
-r[4.8.8#normative]
+r[4.8:8#normative]
 The `continue` expression skips to the next iteration of the innermost enclosing loop.
 
-r[4.8.9#normative]
+r[4.8:9#normative]
 Both `break` and `continue` must appear within a loop. Using them outside a loop is a compile-time error.
 
-r[4.8.10#normative]
+r[4.8:10#normative]
 Both `break` and `continue` have the never type `!`.
 
-r[4.8.11]
+r[4.8:11]
 ```rue
 fn main() -> i32 {
     let mut x = 0;
@@ -105,7 +105,7 @@ fn main() -> i32 {
 }
 ```
 
-r[4.8.12]
+r[4.8:12]
 ```rue
 fn main() -> i32 {
     let mut sum = 0;
@@ -123,10 +123,10 @@ fn main() -> i32 {
 
 ## Nested Loops
 
-r[4.8.13#normative]
+r[4.8:13#normative]
 In nested loops, `break` and `continue` affect only the innermost enclosing loop.
 
-r[4.8.14]
+r[4.8:14]
 ```rue
 fn main() -> i32 {
     let mut total = 0;

--- a/docs/spec/src/04-expressions/09-return-expressions.md
+++ b/docs/spec/src/04-expressions/09-return-expressions.md
@@ -1,23 +1,23 @@
 # Return Expressions
 
-r[4.9.1#normative]
+r[4.9:1#normative]
 A return expression exits the current function and provides its return value.
 
-r[4.9.2#normative]
+r[4.9:2#normative]
 ```ebnf
 return_expr = "return" expression? ;
 ```
 
-r[4.9.3#normative]
+r[4.9:3#normative]
 If the expression is omitted, it is equivalent to `return ()`.
 
-r[4.9.4#normative]
+r[4.9:4#normative]
 The expression following `return` (or the implicit `()`) must have a type compatible with the function's declared return type.
 
-r[4.9.5#normative]
+r[4.9:5#normative]
 A return expression has the never type `!` because it never produces a local value.
 
-r[4.9.6]
+r[4.9:6]
 ```rue
 fn abs(x: i32) -> i32 {
     if x < 0 {
@@ -31,13 +31,13 @@ fn main() -> i32 {
 }
 ```
 
-r[4.9.7#normative]
+r[4.9:7#normative]
 When a return expression is evaluated, the function immediately returns the value of the expression. No further code in the function is executed.
 
-r[4.9.8#normative]
+r[4.9:8#normative]
 Because return has type `!`, it can appear in contexts that expect any type.
 
-r[4.9.9]
+r[4.9:9]
 ```rue
 fn test(x: i32) -> i32 {
     // `return 100` has type !, which coerces to i32
@@ -50,7 +50,7 @@ fn main() -> i32 {
 }
 ```
 
-r[4.9.10]
+r[4.9:10]
 ```rue
 fn do_nothing() {
     return;  // equivalent to return ()

--- a/docs/spec/src/04-expressions/10-call-expressions.md
+++ b/docs/spec/src/04-expressions/10-call-expressions.md
@@ -1,23 +1,23 @@
 # Call Expressions
 
-r[4.10.1#normative]
+r[4.10:1#normative]
 A call expression invokes a function with a list of arguments.
 
-r[4.10.2#normative]
+r[4.10:2#normative]
 ```ebnf
 call_expr = expression "(" [ expression { "," expression } ] ")" ;
 ```
 
-r[4.10.3#normative]
+r[4.10:3#normative]
 The number of arguments must match the number of parameters in the function signature.
 
-r[4.10.4#normative]
+r[4.10:4#normative]
 Each argument type must be compatible with the corresponding parameter type.
 
-r[4.10.5#normative]
+r[4.10:5#normative]
 The type of a call expression is the function's return type.
 
-r[4.10.6]
+r[4.10:6]
 ```rue
 fn add(x: i32, y: i32) -> i32 {
     x + y
@@ -28,10 +28,10 @@ fn main() -> i32 {
 }
 ```
 
-r[4.10.7#normative]
+r[4.10:7#normative]
 Arguments are evaluated left-to-right before the function is called, as specified in section 4.0.
 
-r[4.10.8]
+r[4.10:8]
 Call expressions can be nested:
 
 ```rue

--- a/docs/spec/src/04-expressions/11-index-expressions.md
+++ b/docs/spec/src/04-expressions/11-index-expressions.md
@@ -1,23 +1,23 @@
 # Index Expressions
 
-r[4.11.1#normative]
+r[4.11:1#normative]
 An index expression accesses an element of an array.
 
-r[4.11.2#normative]
+r[4.11:2#normative]
 ```ebnf
 index_expr = expression "[" expression "]" ;
 ```
 
-r[4.11.3#normative]
+r[4.11:3#normative]
 The expression before the brackets must have an array type `[T; N]`.
 
-r[4.11.4#normative]
+r[4.11:4#normative]
 The index expression must have an integer type.
 
-r[4.11.5#normative]
+r[4.11:5#normative]
 The type of an index expression is the element type `T`.
 
-r[4.11.6]
+r[4.11:6]
 ```rue
 fn main() -> i32 {
     let arr: [i32; 3] = [10, 42, 100];
@@ -27,16 +27,16 @@ fn main() -> i32 {
 
 ## Bounds Checking
 
-r[4.11.7#normative]
+r[4.11:7#normative]
 For constant indices, bounds checking is performed at compile time.
 
-r[4.11.8#normative]
+r[4.11:8#normative]
 For variable indices, bounds checking is performed at runtime.
 
-r[4.11.9#normative]
+r[4.11:9#normative]
 An out-of-bounds access causes a runtime panic.
 
-r[4.11.10]
+r[4.11:10]
 ```rue
 fn main() -> i32 {
     let arr: [i32; 3] = [1, 2, 3];
@@ -44,7 +44,7 @@ fn main() -> i32 {
 }
 ```
 
-r[4.11.11]
+r[4.11:11]
 ```rue
 fn main() -> i32 {
     let arr: [i32; 3] = [1, 2, 3];
@@ -55,10 +55,10 @@ fn main() -> i32 {
 
 ## Index Assignment
 
-r[4.11.12#normative]
+r[4.11:12#normative]
 For mutable arrays, elements can be assigned using index expressions.
 
-r[4.11.13]
+r[4.11:13]
 ```rue
 fn main() -> i32 {
     let mut arr: [i32; 2] = [0, 0];

--- a/docs/spec/src/04-expressions/12-field-access.md
+++ b/docs/spec/src/04-expressions/12-field-access.md
@@ -1,23 +1,23 @@
 # Field Access Expressions
 
-r[4.12.1#normative]
+r[4.12:1#normative]
 A field access expression accesses a field of a struct.
 
-r[4.12.2#normative]
+r[4.12:2#normative]
 ```ebnf
 field_access = expression "." IDENT ;
 ```
 
-r[4.12.3#normative]
+r[4.12:3#normative]
 The expression before the dot must have a struct type.
 
-r[4.12.4#normative]
+r[4.12:4#normative]
 The identifier must be a valid field name for that struct type.
 
-r[4.12.5#normative]
+r[4.12:5#normative]
 The type of a field access expression is the type of the accessed field.
 
-r[4.12.6]
+r[4.12:6]
 ```rue
 struct Point {
     x: i32,
@@ -32,10 +32,10 @@ fn main() -> i32 {
 
 ## Field Assignment
 
-r[4.12.7#normative]
+r[4.12:7#normative]
 For mutable struct values, fields can be assigned.
 
-r[4.12.8]
+r[4.12:8]
 ```rue
 struct Point {
     x: i32,

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -1,37 +1,37 @@
 # Intrinsic Expressions
 
-r[4.13.1#normative]
+r[4.13:1#normative]
 An intrinsic expression invokes a compiler-provided primitive operation.
 
-r[4.13.2#normative]
+r[4.13:2#normative]
 ```ebnf
 intrinsic = "@" IDENT "(" [ expression { "," expression } ] ")" ;
 ```
 
-r[4.13.3#normative]
+r[4.13:3#normative]
 Intrinsics are prefixed with `@` to distinguish them from user-defined functions.
 
-r[4.13.4#normative]
+r[4.13:4#normative]
 Each intrinsic has a fixed signature specifying the number and types of arguments it accepts.
 
-r[4.13.5#normative]
+r[4.13:5#normative]
 Using an unknown intrinsic name is a compile-time error.
 
 ## `@dbg`
 
-r[4.13.6#normative]
+r[4.13:6#normative]
 The `@dbg` intrinsic prints a value to standard output for debugging purposes.
 
-r[4.13.7#normative]
+r[4.13:7#normative]
 `@dbg` accepts exactly one argument of integer, boolean, or string type.
 
-r[4.13.8#normative]
+r[4.13:8#normative]
 `@dbg` prints the value followed by a newline character.
 
-r[4.13.9#normative]
+r[4.13:9#normative]
 The return type of `@dbg` is `()`.
 
-r[4.13.10]
+r[4.13:10]
 ```rue
 fn main() -> i32 {
     @dbg(42);           // prints: 42
@@ -44,7 +44,7 @@ fn main() -> i32 {
 }
 ```
 
-r[4.13.11]
+r[4.13:11]
 `@dbg` is useful for inspecting values during development:
 
 ```rue

--- a/docs/spec/src/04-expressions/README.md
+++ b/docs/spec/src/04-expressions/README.md
@@ -2,25 +2,25 @@
 
 This chapter describes expressions in Rue.
 
-r[4.0.1]
+r[4.0:1]
 An expression is a syntactic construct that evaluates to a value. Every expression has a type.
 
 ## Evaluation
 
-r[4.0.2#normative]
+r[4.0:2#normative]
 When an expression contains subexpressions, those subexpressions are evaluated in a defined order as specified in this section.
 
-r[4.0.3#normative]
+r[4.0:3#normative]
 For binary operators, the left operand is evaluated before the right operand.
 
-r[4.0.4#normative]
+r[4.0:4#normative]
 For function call expressions, the callee expression is evaluated first, then arguments are evaluated left-to-right.
 
-r[4.0.5#normative]
+r[4.0:5#normative]
 For index expressions of the form `base[index]`, the base expression is evaluated before the index expression.
 
-r[4.0.6#normative]
+r[4.0:6#normative]
 For field access expressions of the form `base.field`, the base expression is evaluated before the field is accessed.
 
-r[4.0.7#normative]
+r[4.0:7#normative]
 Logical operators `&&` and `||` are an exception to the normal left-to-right evaluation. They use short-circuit evaluation as specified in section 4.4: the right operand may not be evaluated depending on the value of the left operand.

--- a/docs/spec/src/05-statements/01-let-statements.md
+++ b/docs/spec/src/05-statements/01-let-statements.md
@@ -1,19 +1,19 @@
 # Let Statements
 
-r[5.1.1#normative]
+r[5.1:1#normative]
 A let statement introduces a new variable binding.
 
-r[5.1.2#normative]
+r[5.1:2#normative]
 ```ebnf
 let_stmt = "let" [ "mut" ] IDENT [ ":" type ] "=" expression ";" ;
 ```
 
 ## Immutable Bindings
 
-r[5.1.3#normative]
+r[5.1:3#normative]
 By default, variables are immutable. An immutable variable cannot be reassigned.
 
-r[5.1.4#normative]
+r[5.1:4#normative]
 ```rue
 fn main() -> i32 {
     let x = 42;
@@ -23,10 +23,10 @@ fn main() -> i32 {
 
 ## Mutable Bindings
 
-r[5.1.5#normative]
+r[5.1:5#normative]
 The `mut` keyword creates a mutable binding that can be reassigned.
 
-r[5.1.6]
+r[5.1:6]
 ```rue
 fn main() -> i32 {
     let mut x = 10;
@@ -37,13 +37,13 @@ fn main() -> i32 {
 
 ## Type Annotations
 
-r[5.1.7#normative]
+r[5.1:7#normative]
 Type annotations are optional when the type can be inferred from the initializer.
 
-r[5.1.8#normative]
+r[5.1:8#normative]
 When a type annotation is present, the initializer must be compatible with that type.
 
-r[5.1.9]
+r[5.1:9]
 ```rue
 fn main() -> i32 {
     let x: i32 = 42;      // explicit type
@@ -55,16 +55,16 @@ fn main() -> i32 {
 
 ## Shadowing
 
-r[5.1.10#normative]
+r[5.1:10#normative]
 A variable can shadow a previous variable of the same name in the same scope.
 
-r[5.1.11#normative]
+r[5.1:11#normative]
 When shadowing, the new variable can have a different type.
 
-r[5.1.12#normative]
+r[5.1:12#normative]
 The scope of a binding introduced by a let statement begins after the complete let statement, including its initializer. The initializer expression is evaluated before the new binding is introduced, so references to a shadowed name within the initializer resolve to the previous binding.
 
-r[5.1.13]
+r[5.1:13]
 ```rue
 fn main() -> i32 {
     let x = 10;

--- a/docs/spec/src/05-statements/02-assignment.md
+++ b/docs/spec/src/05-statements/02-assignment.md
@@ -1,9 +1,9 @@
 # Assignment Statements
 
-r[5.2.1#normative]
+r[5.2:1#normative]
 An assignment statement assigns a new value to a mutable variable.
 
-r[5.2.2#normative]
+r[5.2:2#normative]
 ```ebnf
 assign_stmt = IDENT "=" expression ";"
             | IDENT "[" expression "]" "=" expression ";"
@@ -12,13 +12,13 @@ assign_stmt = IDENT "=" expression ";"
 
 ## Variable Assignment
 
-r[5.2.3#normative]
+r[5.2:3#normative]
 The variable must have been declared with `let mut`.
 
-r[5.2.4#normative]
+r[5.2:4#normative]
 The expression type must be compatible with the variable's type.
 
-r[5.2.5]
+r[5.2:5]
 ```rue
 fn main() -> i32 {
     let mut x = 0;
@@ -29,10 +29,10 @@ fn main() -> i32 {
 
 ## Array Element Assignment
 
-r[5.2.6#normative]
+r[5.2:6#normative]
 Array element assignment requires a mutable array.
 
-r[5.2.7]
+r[5.2:7]
 ```rue
 fn main() -> i32 {
     let mut arr: [i32; 2] = [0, 0];
@@ -44,10 +44,10 @@ fn main() -> i32 {
 
 ## Struct Field Assignment
 
-r[5.2.8#normative]
+r[5.2:8#normative]
 Struct field assignment requires a mutable struct value.
 
-r[5.2.9]
+r[5.2:9]
 ```rue
 struct Point { x: i32, y: i32 }
 
@@ -60,5 +60,5 @@ fn main() -> i32 {
 
 ## Assignment is Not an Expression
 
-r[5.2.10#normative]
+r[5.2:10#normative]
 Assignment is a statement, not an expression. It cannot be used in expression position.

--- a/docs/spec/src/05-statements/03-expression-statements.md
+++ b/docs/spec/src/05-statements/03-expression-statements.md
@@ -1,17 +1,17 @@
 # Expression Statements
 
-r[5.3.1#normative]
+r[5.3:1#normative]
 An expression followed by a semicolon becomes an expression statement.
 
-r[5.3.2#normative]
+r[5.3:2#normative]
 ```ebnf
 expr_stmt = expression ";" ;
 ```
 
-r[5.3.3#normative]
+r[5.3:3#normative]
 The value of the expression is discarded. The type of an expression statement is `()`.
 
-r[5.3.4]
+r[5.3:4]
 ```rue
 fn side_effect() { }
 
@@ -21,5 +21,5 @@ fn main() -> i32 {
 }
 ```
 
-r[5.3.5]
+r[5.3:5]
 Expression statements are useful for calling functions for their side effects while discarding their return values.

--- a/docs/spec/src/05-statements/README.md
+++ b/docs/spec/src/05-statements/README.md
@@ -2,5 +2,5 @@
 
 This chapter describes statements in Rue.
 
-r[5.0.1]
+r[5.0:1]
 A statement is a syntactic construct that performs an action but does not produce a value. Statements have type `()`.

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -1,9 +1,9 @@
 # Functions
 
-r[6.1.1#normative]
+r[6.1:1#normative]
 A function is defined using the `fn` keyword.
 
-r[6.1.2#normative]
+r[6.1:2#normative]
 ```ebnf
 function = "fn" IDENT "(" [ params ] ")" [ "->" type ] "{" block "}" ;
 params = param { "," param } ;
@@ -12,16 +12,16 @@ param = IDENT ":" type ;
 
 ## Function Signature
 
-r[6.1.3#normative]
+r[6.1:3#normative]
 Parameters must have explicit type annotations.
 
-r[6.1.4#normative]
+r[6.1:4#normative]
 If a return type is specified, the function body must produce a value of that type.
 
-r[6.1.5#normative]
+r[6.1:5#normative]
 If no return type is specified, the function returns `()`.
 
-r[6.1.6#normative]
+r[6.1:6#normative]
 ```rue
 fn add(x: i32, y: i32) -> i32 {
     x + y
@@ -34,13 +34,13 @@ fn do_nothing() {
 
 ## Entry Point
 
-r[6.1.7#normative]
+r[6.1:7#normative]
 A program must have a function named `main`.
 
-r[6.1.8#normative]
+r[6.1:8#normative]
 The `main` function must either return `i32` or `()`. When it returns `i32`, that value becomes the program's exit code. When it returns `()`, the exit code is 0.
 
-r[6.1.9]
+r[6.1:9]
 ```rue
 fn main() -> i32 {
     42  // exit code is 42
@@ -49,10 +49,10 @@ fn main() -> i32 {
 
 ## Recursion
 
-r[6.1.10#normative]
+r[6.1:10#normative]
 Functions can call themselves recursively.
 
-r[6.1.11]
+r[6.1:11]
 ```rue
 fn factorial(n: i32) -> i32 {
     if n <= 1 { 1 }
@@ -66,10 +66,10 @@ fn main() -> i32 {
 
 ## Function Visibility
 
-r[6.1.12#normative]
+r[6.1:12#normative]
 Functions can call any function defined in the same module, regardless of definition order.
 
-r[6.1.13]
+r[6.1:13]
 ```rue
 fn main() -> i32 {
     helper()  // can call function defined below

--- a/docs/spec/src/06-items/02-structs.md
+++ b/docs/spec/src/06-items/02-structs.md
@@ -1,9 +1,9 @@
 # Structs
 
-r[6.2.1#normative]
+r[6.2:1#normative]
 A struct is defined using the `struct` keyword.
 
-r[6.2.2#normative]
+r[6.2:2#normative]
 ```ebnf
 struct_def = "struct" IDENT "{" [ struct_fields ] "}" ;
 struct_fields = struct_field { "," struct_field } [ "," ] ;
@@ -12,10 +12,10 @@ struct_field = IDENT ":" type ;
 
 ## Struct Definition
 
-r[6.2.3#normative]
+r[6.2:3#normative]
 Field names must be unique within a struct.
 
-r[6.2.4]
+r[6.2:4]
 ```rue
 struct Point {
     x: i32,
@@ -25,13 +25,13 @@ struct Point {
 
 ## Struct Instantiation
 
-r[6.2.5#normative]
+r[6.2:5#normative]
 All fields must be initialized when creating a struct instance.
 
-r[6.2.6#normative]
+r[6.2:6#normative]
 Field initializers must be provided in the same order as the struct definition.
 
-r[6.2.7]
+r[6.2:7]
 ```rue
 struct Point { x: i32, y: i32 }
 
@@ -43,13 +43,13 @@ fn main() -> i32 {
 
 ## Struct Usage
 
-r[6.2.8#normative]
+r[6.2:8#normative]
 Struct fields are accessed using dot notation.
 
-r[6.2.9#normative]
+r[6.2:9#normative]
 Mutable struct values allow field reassignment.
 
-r[6.2.10]
+r[6.2:10]
 ```rue
 struct Counter { value: i32 }
 

--- a/docs/spec/src/06-items/03-enums.md
+++ b/docs/spec/src/06-items/03-enums.md
@@ -1,9 +1,9 @@
 # Enums
 
-r[6.3.1#normative]
+r[6.3:1#normative]
 An enum is defined using the `enum` keyword.
 
-r[6.3.2#normative]
+r[6.3:2#normative]
 ```ebnf
 enum_def = "enum" IDENT "{" [ enum_variants ] "}" ;
 enum_variants = IDENT { "," IDENT } [ "," ] ;
@@ -11,21 +11,21 @@ enum_variants = IDENT { "," IDENT } [ "," ] ;
 
 ## Enum Definition
 
-r[6.3.3#normative]
+r[6.3:3#normative]
 Variant names must be unique within an enum.
 
-r[6.3.12#normative]
+r[6.3:12#normative]
 An enum with zero variants is valid and represents an uninhabited type.
 A zero-variant enum can never be constructed.
 
-r[6.3.4#normative]
+r[6.3:4#normative]
 Enum variants are referenced using path syntax: `EnumName::VariantName`.
 An error is raised if the enum type does not exist.
 
-r[6.3.5#normative]
+r[6.3:5#normative]
 An error is raised if the variant does not exist within the enum.
 
-r[6.3.6]
+r[6.3:6]
 ```rue
 enum Color {
     Red,
@@ -41,15 +41,15 @@ fn main() -> i32 {
 
 ## Match on Enums
 
-r[6.3.7#normative]
+r[6.3:7#normative]
 Enum values can be matched using pattern matching in `match` expressions.
 Each arm pattern uses the same path syntax as enum variant expressions.
 
-r[6.3.8#normative]
+r[6.3:8#normative]
 Match expressions on enums must be exhaustive: all variants must be covered,
 either explicitly or via a wildcard pattern `_`.
 
-r[6.3.9]
+r[6.3:9]
 ```rue
 enum Color { Red, Green, Blue }
 
@@ -65,10 +65,10 @@ fn main() -> i32 {
 
 ## Enum Types
 
-r[6.3.10#normative]
+r[6.3:10#normative]
 Enums can be used as function parameter types, return types, and struct field types.
 
-r[6.3.11]
+r[6.3:11]
 ```rue
 enum Color { Red, Green, Blue }
 

--- a/docs/spec/src/06-items/README.md
+++ b/docs/spec/src/06-items/README.md
@@ -2,5 +2,5 @@
 
 This chapter describes items in Rue.
 
-r[6.0.1]
+r[6.0:1]
 Items are top-level definitions in a program. Unlike statements, items are visible throughout the module.

--- a/docs/spec/src/07-arrays/01-fixed-arrays.md
+++ b/docs/spec/src/07-arrays/01-fixed-arrays.md
@@ -2,21 +2,21 @@
 
 ## Array Literals
 
-r[7.1.1#normative]
+r[7.1:1#normative]
 ```ebnf
 array_literal = "[" [ expression { "," expression } ] "]" ;
 ```
 
-r[7.1.2#normative]
+r[7.1:2#normative]
 An array literal creates an array with the given elements.
 
-r[7.1.3#normative]
+r[7.1:3#normative]
 All elements must have the same type.
 
-r[7.1.4#normative]
+r[7.1:4#normative]
 The number of elements must match the declared array size.
 
-r[7.1.5]
+r[7.1:5]
 ```rue
 fn main() -> i32 {
     let arr: [i32; 3] = [10, 20, 12];
@@ -26,13 +26,13 @@ fn main() -> i32 {
 
 ## Array Indexing
 
-r[7.1.6#normative]
+r[7.1:6#normative]
 Array elements are accessed using bracket notation `arr[index]`.
 
-r[7.1.7#normative]
+r[7.1:7#normative]
 The index must be an integer type.
 
-r[7.1.8]
+r[7.1:8]
 ```rue
 fn main() -> i32 {
     let arr: [i32; 3] = [100, 42, 200];
@@ -42,21 +42,21 @@ fn main() -> i32 {
 
 ## Bounds Checking
 
-r[7.1.9#normative]
+r[7.1:9#normative]
 For constant indices, bounds are checked at compile time.
 
-r[7.1.10#normative]
+r[7.1:10#normative]
 For variable indices, bounds are checked at runtime.
 
-r[7.1.11#normative]
+r[7.1:11#normative]
 Out-of-bounds access causes a runtime panic.
 
 ## Mutable Arrays
 
-r[7.1.12#normative]
+r[7.1:12#normative]
 Mutable arrays allow element assignment.
 
-r[7.1.13]
+r[7.1:13]
 ```rue
 fn main() -> i32 {
     let mut arr: [i32; 2] = [0, 0];
@@ -68,23 +68,23 @@ fn main() -> i32 {
 
 ## Array Type Syntax
 
-r[7.1.14#normative]
+r[7.1:14#normative]
 ```ebnf
 array_type = "[" type ";" INTEGER "]" ;
 ```
 
-r[7.1.15#normative]
+r[7.1:15#normative]
 The size must be a non-negative integer literal.
 
 ## Nested Arrays
 
-r[7.1.16#normative]
+r[7.1:16#normative]
 Arrays may contain other arrays as elements, forming multi-dimensional arrays.
 
-r[7.1.17#normative]
+r[7.1:17#normative]
 Nested arrays are indexed using chained bracket notation, evaluated left to right.
 
-r[7.1.18]
+r[7.1:18]
 ```rue
 fn main() -> i32 {
     let matrix: [[i32; 2]; 2] = [[1, 2], [3, 4]];
@@ -94,13 +94,13 @@ fn main() -> i32 {
 
 ## Arrays in Structs
 
-r[7.1.19#normative]
+r[7.1:19#normative]
 Struct fields may have array types.
 
-r[7.1.20#normative]
+r[7.1:20#normative]
 Array fields are accessed by combining field access with array indexing.
 
-r[7.1.21]
+r[7.1:21]
 ```rue
 struct Container { values: [i32; 3] }
 
@@ -112,13 +112,13 @@ fn main() -> i32 {
 
 ## Arrays as Function Parameters
 
-r[7.1.22#normative]
+r[7.1:22#normative]
 Functions may accept arrays as parameters.
 
-r[7.1.23#normative]
+r[7.1:23#normative]
 Array parameters are passed by value; the entire array is copied to the function.
 
-r[7.1.24]
+r[7.1:24]
 ```rue
 fn sum(arr: [i32; 3]) -> i32 {
     arr[0] + arr[1] + arr[2]

--- a/docs/spec/src/07-arrays/README.md
+++ b/docs/spec/src/07-arrays/README.md
@@ -2,5 +2,5 @@
 
 This chapter describes fixed-size arrays in Rue.
 
-r[7.0.1]
+r[7.0:1]
 Arrays are fixed-size sequences of elements of the same type.

--- a/docs/spec/src/08-runtime-behavior/01-overflow.md
+++ b/docs/spec/src/08-runtime-behavior/01-overflow.md
@@ -1,31 +1,31 @@
 # Integer Overflow
 
-r[8.1.1#normative]
+r[8.1:1#normative]
 Integer overflow during arithmetic operations causes a runtime panic.
 
-r[8.1.2#normative]
+r[8.1:2#normative]
 On overflow, the program terminates with exit code 101 and prints an error message.
 
-r[8.1.3#normative]
+r[8.1:3#normative]
 The following operations can overflow:
 - Addition (`+`)
 - Subtraction (`-`)
 - Multiplication (`*`)
 - Negation (`-` unary)
 
-r[8.1.4]
+r[8.1:4]
 ```rue
 fn main() -> i32 {
     2147483647 + 1  // Runtime error: integer overflow
 }
 ```
 
-r[8.1.5]
+r[8.1:5]
 ```rue
 fn main() -> i32 {
     -2147483648 - 1  // Runtime error: integer overflow
 }
 ```
 
-r[8.1.6]
+r[8.1:6]
 Future versions of Rue may provide wrapping arithmetic operations that do not panic on overflow.

--- a/docs/spec/src/08-runtime-behavior/02-bounds-checking.md
+++ b/docs/spec/src/08-runtime-behavior/02-bounds-checking.md
@@ -1,21 +1,21 @@
 # Bounds Checking
 
-r[8.2.1#normative]
+r[8.2:1#normative]
 Array access with an out-of-bounds index causes a runtime panic.
 
-r[8.2.2#normative]
+r[8.2:2#normative]
 On out-of-bounds access, the program terminates with exit code 101 and prints an error message.
 
-r[8.2.3#normative]
+r[8.2:3#normative]
 For constant indices, bounds checking is performed at compile time.
 
-r[8.2.4#normative]
+r[8.2:4#normative]
 A constant index is an expression that can be fully evaluated at compile time. This includes integer literals, arithmetic operations on constants, comparison operations on constants, and parenthesized constant expressions.
 
-r[8.2.5#normative]
+r[8.2:5#normative]
 For variable indices, bounds checking is performed at runtime before the access.
 
-r[8.2.6]
+r[8.2:6]
 ```rue
 fn main() -> i32 {
     let arr: [i32; 3] = [1, 2, 3];
@@ -24,7 +24,7 @@ fn main() -> i32 {
 }
 ```
 
-r[8.2.7]
+r[8.2:7]
 ```rue
 fn main() -> i32 {
     let arr: [i32; 3] = [1, 2, 3];
@@ -32,7 +32,7 @@ fn main() -> i32 {
 }
 ```
 
-r[8.2.8]
+r[8.2:8]
 ```rue
 fn main() -> i32 {
     let arr: [i32; 3] = [1, 2, 3];
@@ -40,5 +40,5 @@ fn main() -> i32 {
 }
 ```
 
-r[8.2.9#normative]
+r[8.2:9#normative]
 Negative indices, when used with signed integer types, result in out-of-bounds errors because they represent large unsigned values when converted.

--- a/docs/spec/src/08-runtime-behavior/03-division-by-zero.md
+++ b/docs/spec/src/08-runtime-behavior/03-division-by-zero.md
@@ -1,29 +1,29 @@
 # Division by Zero
 
-r[8.3.1#normative]
+r[8.3:1#normative]
 Division or remainder by zero causes a runtime panic.
 
-r[8.3.2#normative]
+r[8.3:2#normative]
 On division by zero, the program terminates with exit code 101 and prints an error message.
 
-r[8.3.3#normative]
+r[8.3:3#normative]
 Both the division operator (`/`) and remainder operator (`%`) can cause division-by-zero errors.
 
-r[8.3.4]
+r[8.3:4]
 ```rue
 fn main() -> i32 {
     10 / 0  // Runtime error: division by zero
 }
 ```
 
-r[8.3.5]
+r[8.3:5]
 ```rue
 fn main() -> i32 {
     10 % 0  // Runtime error: division by zero
 }
 ```
 
-r[8.3.6]
+r[8.3:6]
 ```rue
 fn main() -> i32 {
     let divisor = 5 - 5;

--- a/docs/spec/src/08-runtime-behavior/README.md
+++ b/docs/spec/src/08-runtime-behavior/README.md
@@ -2,5 +2,5 @@
 
 This chapter describes runtime behavior in Rue, including error conditions and panics.
 
-r[8.0.1]
+r[8.0:1]
 Certain operations can fail at runtime. These failures are detected and cause the program to terminate with a non-zero exit code.

--- a/docs/spec/src/appendices/B-undefined-behavior.md
+++ b/docs/spec/src/appendices/B-undefined-behavior.md
@@ -2,12 +2,12 @@
 
 This appendix summarizes all conditions that cause runtime panics in Rue.
 
-r[B.1.1]
+r[B.1:1]
 Rue detects certain error conditions at runtime and responds with a panic, terminating the program with a specific exit code.
 
 ## Integer Overflow
 
-r[B.1.2]
+r[B.1:2]
 Signed or unsigned integer arithmetic that overflows the representable range causes a runtime panic.
 
 **Operations affected:**
@@ -20,7 +20,7 @@ Signed or unsigned integer arithmetic that overflows the representable range cau
 
 ## Division by Zero
 
-r[B.1.3]
+r[B.1:3]
 Division or remainder with a divisor of zero causes a runtime panic.
 
 **Operations affected:**
@@ -31,7 +31,7 @@ Division or remainder with a divisor of zero causes a runtime panic.
 
 ## Array Bounds Violation
 
-r[B.1.4]
+r[B.1:4]
 Accessing an array element with an index outside the valid range `[0, length)` causes a runtime panic.
 
 **Operations affected:**
@@ -48,5 +48,5 @@ Accessing an array element with an index outside the valid range `[0, length)` c
 | Division by zero | 101 |
 | Array out of bounds | 101 |
 
-r[B.1.5]
+r[B.1:5]
 All runtime panics produce exit code 101, matching Rust's convention for unwinding panics.


### PR DESCRIPTION
Change the spec paragraph ID format from `r[X.Y.Z]` to `r[X.Y:Z]` for clarity - the colon separates the structural location (chapter.section) from the paragraph number. This makes the format more readable and explicitly distinguishes between hierarchical navigation and paragraph enumeration.

Updates:
- All spec files to use colon notation (e.g., `r[3.1:1#normative]`)
- Traceability parser to require colon notation (no longer converts)
- CLAUDE.md documentation to reflect the new format
- Test cases to use the updated format

🤖 Generated with [Claude Code](https://claude.com/claude-code)