### PR TITLE
Remove vendoring step from CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,5 @@ jobs:
       - name: Install dotslash
         run: cargo install dotslash
 
-      - name: Vendor dependencies
-        run: cd third-party && dotslash ../reindeer vendor
-
       - name: Run tests
         run: ./test.sh

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Setup dotslash
         uses: facebook/install-dotslash@latest
 
-      - name: Vendor dependencies
-        run: cd third-party && dotslash ../reindeer vendor
-
       - name: Build mdbook-spec preprocessor
         run: |
           ./buck2 build //docs/spec/tools/mdbook-spec:mdbook-spec || exit 1


### PR DESCRIPTION
Third-party dependencies are now committed to the repository (as of commit 82402e6), so CI no longer needs to run `reindeer vendor` before building. This simplifies the workflows and ensures CI uses the exact same vendored dependencies as local development.