### PR TITLE
Use install-dotslash action in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install dotslash
-        run: cargo install dotslash
+        uses: facebook/install-dotslash@latest
 
       - name: Run tests
         run: ./test.sh


### PR DESCRIPTION
Switch from `cargo install dotslash` to the official `facebook/install-dotslash@latest` GitHub action. This is faster (no compilation needed) and more maintainable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)