### PR TITLE
Reject chained comparison operators with helpful error

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -2513,6 +2513,14 @@ impl<'a> Sema<'a> {
     where
         F: FnOnce(AirRef, AirRef) -> AirInstData,
     {
+        // Check for chained comparisons (e.g., `a < b < c`)
+        // Since the parser is left-associative, `a < b < c` parses as `(a < b) < c`,
+        // so we only need to check if the LHS is a comparison.
+        if self.is_comparison(lhs) {
+            return Err(CompileError::new(ErrorKind::ChainedComparison, span)
+                .with_help("use `&&` to combine comparisons: `a < b && b < c`"));
+        }
+
         // Bidirectional type inference for integer literals:
         // If LHS is an integer literal, peek at RHS to get a type hint
         let lhs_expectation = if self.is_integer_literal(lhs) {
@@ -2761,6 +2769,22 @@ impl<'a> Sema<'a> {
     /// of a binary operator is a literal that can adopt its type from the RHS.
     fn is_integer_literal(&self, inst_ref: InstRef) -> bool {
         matches!(self.rir.get(inst_ref).data, InstData::IntConst(_))
+    }
+
+    /// Check if an RIR instruction is a comparison operation.
+    ///
+    /// This is used to detect chained comparisons (e.g., `a < b < c`) which are
+    /// not allowed in Rue.
+    fn is_comparison(&self, inst_ref: InstRef) -> bool {
+        matches!(
+            self.rir.get(inst_ref).data,
+            InstData::Lt { .. }
+                | InstData::Gt { .. }
+                | InstData::Le { .. }
+                | InstData::Ge { .. }
+                | InstData::Eq { .. }
+                | InstData::Ne { .. }
+        )
     }
 
     /// Peek at the type of an expression without emitting AIR.

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -233,6 +233,7 @@ pub enum ErrorKind {
 
     // Operator errors
     CannotNegateUnsigned(String),
+    ChainedComparison,
 
     // Array errors
     IndexOnNonArray {
@@ -503,6 +504,9 @@ impl fmt::Display for ErrorKind {
             }
             ErrorKind::CannotNegateUnsigned(ty) => {
                 write!(f, "cannot apply unary operator `-` to type '{}'", ty)
+            }
+            ErrorKind::ChainedComparison => {
+                write!(f, "comparison operators cannot be chained")
             }
             ErrorKind::IndexOnNonArray { found } => {
                 write!(f, "cannot index into non-array type '{}'", found)

--- a/crates/rue-spec/cases/expressions/comparison.toml
+++ b/crates/rue-spec/cases/expressions/comparison.toml
@@ -240,3 +240,61 @@ exit_code = 1
 # }
 # """
 # exit_code = 1
+
+# =============================================================================
+# Chained Comparisons Are Rejected
+# =============================================================================
+
+[[case]]
+name = "chained_lt_comparison_error"
+spec = ["4.3:12"]
+source = """
+fn main() -> i32 {
+    if 1 < 2 < 3 { 1 } else { 0 }
+}
+"""
+compile_fail = true
+error_contains = "comparison operators cannot be chained"
+
+[[case]]
+name = "chained_eq_comparison_error"
+spec = ["4.3:12"]
+source = """
+fn main() -> i32 {
+    if 1 == 1 == true { 1 } else { 0 }
+}
+"""
+compile_fail = true
+error_contains = "comparison operators cannot be chained"
+
+[[case]]
+name = "chained_mixed_comparison_error"
+spec = ["4.3:12"]
+source = """
+fn main() -> i32 {
+    if 1 < 2 == true { 1 } else { 0 }
+}
+"""
+compile_fail = true
+error_contains = "comparison operators cannot be chained"
+
+[[case]]
+name = "separate_comparisons_with_and"
+spec = ["4.3:13"]
+source = """
+fn main() -> i32 {
+    if 1 < 2 && 2 < 3 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "parenthesized_comparison_in_chain"
+spec = ["4.3:12"]
+source = """
+fn main() -> i32 {
+    if (1 < 2) < 3 { 1 } else { 0 }
+}
+"""
+compile_fail = true
+error_contains = "comparison operators cannot be chained"

--- a/docs/spec/src/04-expressions/03-comparison-operators.md
+++ b/docs/spec/src/04-expressions/03-comparison-operators.md
@@ -70,3 +70,20 @@ Both operands of a comparison must have the same type.
 
 r[4.3:11#normative]
 When one operand has a known type, the other is inferred to have the same type.
+
+## Associativity
+
+r[4.3:12#legality-rule]
+Comparison operators cannot be chained. Expressions like `a < b < c` or `a == b == c` are compile-time errors.
+
+r[4.3:13#example]
+To compare multiple values, use logical operators:
+
+```rue
+fn main() -> i32 {
+    let a = 1;
+    let b = 2;
+    let c = 3;
+    if a < b && b < c { 1 } else { 0 }  // correct way to chain comparisons
+}
+```


### PR DESCRIPTION
Add compile-time detection for chained comparisons like `a < b < c`, which in many languages silently produce surprising results (comparing a boolean to the third operand). Rue now rejects these with a clear error message and suggests using `&&` to combine comparisons.

- Add ChainedComparison error kind in rue-error
- Detect chained comparisons in sema by checking if LHS is a comparison
- Add spec paragraph r[4.3:12] documenting this as a legality rule
- Add spec tests covering various chaining scenarios

Closes tree1-sgy

🤖 Generated with [Claude Code](https://claude.com/claude-code)