### PR TITLE
Add preview features infrastructure (ADR-020)

### DIFF
--- a/.claude/commands/feature.md
+++ b/.claude/commands/feature.md
@@ -1,33 +1,71 @@
 ---
-description: Plan and implement a new feature
+description: Plan and implement a new feature (convenience wrapper)
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task
 argument-hint: <feature description>
 ---
 
 ## Context
 
-You are working on the Rue programming language compiler. Review the project structure and CLAUDE.md for context.
+You are working on the Rue programming language compiler.
 
 ## Your Task
 
 Plan and implement this feature: $ARGUMENTS
 
-Follow this workflow:
+## Recommended Workflow
 
-1. **Understand the request** - Clarify requirements if needed
-2. **Check for existing issues** - Run `bd ready --json` to see if this is already tracked
-3. **Create a bd issue** - Track this work with `bd create "<title>" -t feature -p 2 --json`
-4. **Plan the implementation** - Identify which crates need changes (see Architecture in CLAUDE.md)
-5. **Ask the user to accept the plan** - before getting started, make sure that they agree to the plan, and refine if necessary.
-6. **Update the specification** - If this changes language semantics, update `docs/spec/src/` with proper spec paragraph IDs (e.g., `<!-- spec:4.2:3 legality-rule -->`).
-7. **Add spec tests** - Add test cases to `crates/rue-spec/cases/` with `spec = ["X.Y:Z"]` references linking to the spec paragraphs.
-8. **Add UI tests** - If the feature includes warnings, lints, or diagnostic changes, add tests to `crates/rue-ui-tests/cases/`.
-9. **Implement incrementally** - Make changes, keeping tests passing as you go
-   - **If touching rue-codegen**: Implement changes in ALL backends (x86_64 and aarch64). See "Codegen: Multi-Backend Considerations" in CLAUDE.md.
-10. **Verify** - Run `./test.sh` to ensure:
-    - All tests pass
-    - Traceability check passes (100% spec coverage)
-11. **Add example** - Consider adding or modifying programs in the `examples` directory that show off this feature.
-12. **Close the issue** - `bd close <id> --reason "Implemented"`
+This command combines planning and implementation. For better context management, consider using the split commands:
 
-Remember: This project uses Buck2 (`./buck2`), not Cargo. Use jj for version control.
+1. **`/plan <description>`** - Creates a plan (ADR or bd issue)
+2. **`/implement <bd-id>`** - Implements a planned feature
+
+The split approach is better for:
+- Large features that span multiple sessions
+- When you want to review the plan before implementing
+- When context window limits are a concern
+
+## Combined Workflow
+
+If proceeding with combined planning + implementation:
+
+### Step 1: Plan (see /plan for details)
+
+1. Understand and research the feature
+2. Assess size (small vs large)
+3. Create bd issue (and ADR for large features)
+4. Present plan to user for approval
+
+### Step 2: Get Approval
+
+Before implementing, confirm with the user:
+- Does the scope look correct?
+- Ready to proceed with implementation?
+
+### Step 3: Implement (see /implement for details)
+
+1. Update specification if needed
+2. Add tests first
+3. Make code changes
+4. Run `./test.sh`
+5. Run `/code-review`
+6. Run `/commit`
+
+## Size Guidelines
+
+**Small Feature** (no preview gate):
+- 1-3 files, single concept, one session
+
+**Large Feature** (requires ADR + preview gate):
+- Many files, multiple phases, may span sessions
+
+| Small | Large |
+|-------|-------|
+| Add `%` operator | Mutable strings |
+| Add `else if` syntax | Inout parameters |
+| New warning type | Trait system |
+
+## Important
+
+- For large features, prefer `/plan` then `/implement` separately
+- Each commit should leave tests passing
+- Always run `/code-review` before `/commit`

--- a/.claude/commands/implement.md
+++ b/.claude/commands/implement.md
@@ -1,0 +1,154 @@
+---
+description: Implement a planned feature from a bd issue
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task
+argument-hint: <bd-id>
+---
+
+## Context
+
+You are working on the Rue programming language compiler. Review the project structure and CLAUDE.md for context.
+
+## Your Task
+
+Implement the feature tracked by: $ARGUMENTS
+
+This command takes a bd issue ID and implements it. Use `/plan` first if you need to create a plan.
+
+## Workflow
+
+### Step 1: Load the Issue
+
+1. Get the issue details:
+   ```bash
+   bd show $ARGUMENTS --json
+   ```
+
+2. If this is an epic (large feature), check for an ADR:
+   - Look in `docs/designs/` for the referenced ADR
+   - Identify which phase you're implementing
+   - If no phase is specified, start with phase 1
+
+3. Mark the issue as in progress:
+   ```bash
+   bd update $ARGUMENTS --status in_progress --json
+   ```
+
+### Step 2: Scope Check
+
+Before implementing, verify the work fits in the current context:
+
+**Good scope (proceed):**
+- Clear, bounded changes
+- 1-5 files to modify
+- Single logical unit of work
+
+**Too large (split it):**
+- More than 5-7 files
+- Multiple unrelated changes
+- Would require extensive exploration
+
+If too large, create subtasks:
+```bash
+bd create "Subtask: <description>" --parent $ARGUMENTS -t task --json
+```
+Then implement subtasks one at a time.
+
+### Step 3: Implement
+
+**For small features / subtasks:**
+
+1. **Update specification** (if changing language semantics)
+   - Add/modify paragraphs in `docs/spec/src/`
+   - Use proper paragraph IDs: `r[X.Y:Z#category]`
+
+2. **Add tests first**
+   - Spec tests in `crates/rue-spec/cases/` with `spec = ["X.Y:Z"]`
+   - UI tests in `crates/rue-ui-tests/cases/` for warnings/diagnostics
+   - Unit tests for internal implementation details (see below)
+
+3. **Make code changes**
+   - If touching `rue-codegen`: implement in ALL backends (x86_64 and aarch64)
+   - Follow existing patterns in the codebase
+
+4. **Verify**
+   ```bash
+   ./test.sh
+   ```
+
+**For large features (with preview gate):**
+
+1. **Add tests with preview flag**
+   - Use `preview = "<feature_name>"` in test cases
+   - These tests run but are allowed to fail
+
+2. **Add semantic gates**
+   - Use `require_preview()` in sema for new syntax/operations
+   - Check `preview_features` in CompileOptions
+
+3. **Implement the phase**
+   - Make incremental progress
+   - Each commit should leave stable tests passing
+
+4. **Verify**
+   ```bash
+   ./test.sh
+   ```
+   - Stable tests must pass
+   - Preview tests for this phase should pass when complete
+
+### Step 4: Review and Commit
+
+1. **Run code review:**
+   ```
+   /code-review
+   ```
+
+2. **Fix any blocking issues** found in review
+
+3. **Commit the changes:**
+   ```
+   /commit
+   ```
+
+   The `/commit` command will:
+   - Close the bd issue before committing
+   - Create an appropriate commit message
+
+### Step 5: Next Steps
+
+**If this was a subtask of a larger feature:**
+- Check if more subtasks remain
+- Tell user what's next: `/implement bd-XX` for next subtask
+
+**If this completes a large feature:**
+1. Remove `preview = "..."` from spec tests
+2. Remove `require_preview()` gates from sema
+3. Remove feature from `PreviewFeature` enum
+4. Update ADR status to "Stable"
+5. Create final commit for stabilization
+
+## Unit Tests
+
+Add unit tests when they make sense for internal implementation details that aren't
+covered by spec or UI tests. Good candidates:
+
+- **Data structure methods**: Parsing helpers, conversion functions, lookup tables
+- **Error formatting**: Ensure error messages render correctly
+- **Internal algorithms**: Register allocation decisions, liveness analysis, IR transforms
+- **Edge cases**: Boundary conditions that are hard to trigger via end-to-end tests
+
+Unit tests go in `#[cfg(test)]` modules within the relevant crate. Ensure the crate
+has a `rust_test` target in its `BUCK` file.
+
+**When NOT to add unit tests:**
+- Behavior already covered by spec tests (avoid duplication)
+- Simple passthrough functions
+- Code that's trivially correct by inspection
+
+## Important Reminders
+
+- This project uses Buck2 (`./buck2`), not Cargo
+- Use `jj` for version control, not git
+- Always run `/code-review` before `/commit`
+- Each commit should leave tests passing
+- Don't bite off more than fits in one context window - split if needed

--- a/.claude/commands/plan.md
+++ b/.claude/commands/plan.md
@@ -1,0 +1,114 @@
+---
+description: Plan a new feature (outputs ADR or bd issue)
+allowed-tools: Bash, Read, Write, Edit, Glob, Grep, Task
+argument-hint: <feature description>
+---
+
+## Context
+
+You are working on the Rue programming language compiler. Review the project structure and CLAUDE.md for context.
+
+## Your Task
+
+Plan this feature: $ARGUMENTS
+
+This command is for **planning only**. It produces either:
+- A bd issue (for small features)
+- An ADR document + bd issue (for large features)
+
+Use `/implement` to execute the plan once approved.
+
+## Workflow
+
+### Step 1: Understand the Feature
+
+1. **Clarify requirements** - Make sure you understand what's being asked
+2. **Research the codebase** - Use Glob/Grep/Read to understand relevant code
+3. **Check for existing work** - Run `bd ready --json` to see if already tracked
+
+### Step 2: Assess Feature Size
+
+**Small Feature** (bd issue only):
+- Touches 1-3 files
+- Single concept (new operator, syntax sugar, simple addition)
+- No new runtime functions
+- No new IR instruction kinds
+- Completable in one focused session
+
+**Large Feature** (requires ADR + preview gate):
+- Touches many files across multiple crates
+- Multiple implementation phases
+- New runtime support functions
+- New IR instruction kinds
+- New type system concepts
+- Could span multiple sessions
+
+Examples:
+| Small | Large |
+|-------|-------|
+| Add `%` operator | Mutable strings |
+| Add `else if` syntax | Inout parameters |
+| Add unary `+` | Enums and pattern matching |
+| New warning type | Trait system |
+
+### Step 3: Create the Plan
+
+**For small features:**
+
+1. Create a bd issue with clear scope:
+   ```bash
+   bd create "<feature title>" -t feature -p 2 --json
+   ```
+
+2. Present a brief implementation plan to the user:
+   - Which files need changes
+   - What spec sections need updates (if any)
+   - What tests need to be added
+   - Estimated complexity
+
+**For large features:**
+
+1. Create a bd issue:
+   ```bash
+   bd create "<feature title>" -t epic -p 2 --json
+   ```
+
+2. Draft an ADR in `docs/designs/adr-NNN-<feature>.md`:
+   - Use the next available ADR number
+   - Include clear implementation phases
+   - Each phase should be independently committable
+   - Reference ADR-020 for preview feature pattern
+
+3. Add the feature to `PreviewFeature` enum in `crates/rue-error/src/lib.rs`
+
+4. Present the ADR to the user for approval
+
+### Step 4: Get Approval
+
+Present your plan and ask the user:
+- Does this scope look correct?
+- For large features: Do the phases make sense?
+- Any adjustments needed before implementation?
+
+**Do not proceed to implementation.** Tell the user to run `/implement <bd-id>` when ready.
+
+## Output Format
+
+Your output should end with something like:
+
+```
+## Plan Complete
+
+**Issue:** bd-XX - <title>
+**Type:** small/large feature
+**Files to modify:** <list>
+
+Ready to implement? Run: `/implement bd-XX`
+```
+
+## Important Notes
+
+- This command is **planning only** - do not write implementation code
+- Keep context usage low - don't read entire codebase
+- For large features, phases should be small enough to complete in one context window
+- The user may want to adjust the plan before implementing

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -30,7 +30,10 @@ pub fn validate_runtime() -> Result<(), String> {
 pub use rue_air::{Air, AnalyzedFunction, ArrayTypeDef, Sema, SemaOutput, StructDef, Type};
 pub use rue_cfg::{Cfg, CfgBuilder, CfgOutput};
 pub use rue_codegen::X86Mir;
-pub use rue_error::{CompileError, CompileResult, CompileWarning, ErrorKind, WarningKind};
+pub use rue_error::{
+    CompileError, CompileResult, CompileWarning, ErrorKind, PreviewFeature, PreviewFeatures,
+    WarningKind,
+};
 pub use rue_intern::{Interner, Symbol};
 pub use rue_lexer::{Lexer, Token, TokenKind};
 pub use rue_linker::{Archive, CodeRelocation, Linker, ObjectBuilder, ObjectFile, RelocationType};
@@ -61,6 +64,8 @@ pub struct CompileOptions {
     pub target: Target,
     /// Which linker to use.
     pub linker: LinkerMode,
+    /// Enabled preview features.
+    pub preview_features: PreviewFeatures,
 }
 
 impl Default for CompileOptions {
@@ -68,6 +73,7 @@ impl Default for CompileOptions {
         Self {
             target: Target::host(),
             linker: LinkerMode::Internal,
+            preview_features: PreviewFeatures::new(),
         }
     }
 }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -18,7 +18,73 @@
 //! ```
 
 use rue_span::Span;
+use std::collections::HashSet;
 use std::fmt;
+
+// ============================================================================
+// Preview Features
+// ============================================================================
+
+/// A preview feature that can be enabled with `--preview`.
+///
+/// Preview features are in-progress language additions that:
+/// - May change or be removed before stabilization
+/// - Require explicit opt-in via `--preview <feature>`
+/// - Allow incremental implementation to be merged to main
+///
+/// See ADR-020 for the full design.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum PreviewFeature {
+    /// Mutable strings with heap allocation and concatenation (ADR-019).
+    MutableStrings,
+}
+
+impl PreviewFeature {
+    /// Get the CLI name for this feature (used with `--preview`).
+    pub fn name(&self) -> &'static str {
+        match self {
+            PreviewFeature::MutableStrings => "mutable_strings",
+        }
+    }
+
+    /// Parse a feature name from a string.
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "mutable_strings" => Some(PreviewFeature::MutableStrings),
+            _ => None,
+        }
+    }
+
+    /// Get the ADR number documenting this feature.
+    pub fn adr(&self) -> &'static str {
+        match self {
+            PreviewFeature::MutableStrings => "ADR-019",
+        }
+    }
+
+    /// Get all available preview features.
+    pub fn all() -> &'static [PreviewFeature] {
+        &[PreviewFeature::MutableStrings]
+    }
+
+    /// Get a comma-separated list of all feature names (for help text).
+    pub fn all_names() -> String {
+        Self::all()
+            .iter()
+            .map(|f| f.name())
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+}
+
+impl fmt::Display for PreviewFeature {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.name())
+    }
+}
+
+/// A set of enabled preview features.
+pub type PreviewFeatures = HashSet<PreviewFeature>;
 
 // ============================================================================
 // Diagnostic Types
@@ -253,6 +319,12 @@ pub enum ErrorKind {
 
     // Target errors
     UnsupportedTarget(String),
+
+    // Preview feature errors
+    PreviewFeatureRequired {
+        feature: PreviewFeature,
+        what: String,
+    },
 }
 
 impl CompileError {
@@ -534,6 +606,9 @@ impl fmt::Display for ErrorKind {
             }
             ErrorKind::LinkError(msg) => write!(f, "link error: {}", msg),
             ErrorKind::UnsupportedTarget(msg) => write!(f, "unsupported target: {}", msg),
+            ErrorKind::PreviewFeatureRequired { feature, what } => {
+                write!(f, "{} requires preview feature `{}`", what, feature.name())
+            }
         }
     }
 }
@@ -948,5 +1023,66 @@ mod tests {
         let span = Span::new(10, 20);
         let warning = CompileWarning::new(WarningKind::UnreachableCode, span);
         assert!(warning.diagnostic().is_empty());
+    }
+
+    // ========================================================================
+    // Preview feature tests
+    // ========================================================================
+
+    #[test]
+    fn test_preview_feature_name() {
+        assert_eq!(PreviewFeature::MutableStrings.name(), "mutable_strings");
+    }
+
+    #[test]
+    fn test_preview_feature_from_str() {
+        assert_eq!(
+            PreviewFeature::from_str("mutable_strings"),
+            Some(PreviewFeature::MutableStrings)
+        );
+        assert_eq!(PreviewFeature::from_str("unknown"), None);
+        assert_eq!(PreviewFeature::from_str(""), None);
+    }
+
+    #[test]
+    fn test_preview_feature_adr() {
+        assert_eq!(PreviewFeature::MutableStrings.adr(), "ADR-019");
+    }
+
+    #[test]
+    fn test_preview_feature_all() {
+        let all = PreviewFeature::all();
+        assert!(!all.is_empty());
+        assert!(all.contains(&PreviewFeature::MutableStrings));
+    }
+
+    #[test]
+    fn test_preview_feature_all_names() {
+        let names = PreviewFeature::all_names();
+        assert!(names.contains("mutable_strings"));
+    }
+
+    #[test]
+    fn test_preview_feature_display() {
+        assert_eq!(
+            format!("{}", PreviewFeature::MutableStrings),
+            "mutable_strings"
+        );
+    }
+
+    #[test]
+    fn test_preview_feature_required_error() {
+        let span = Span::new(10, 20);
+        let error = CompileError::new(
+            ErrorKind::PreviewFeatureRequired {
+                feature: PreviewFeature::MutableStrings,
+                what: "string concatenation".to_string(),
+            },
+            span,
+        );
+        assert_eq!(
+            error.to_string(),
+            "string concatenation requires preview feature `mutable_strings`"
+        );
     }
 }

--- a/crates/rue-spec/src/main.rs
+++ b/crates/rue-spec/src/main.rs
@@ -1,4 +1,4 @@
-use libtest_mimic::{Arguments, Failed, Trial};
+use libtest_mimic::{Arguments, Conclusion, Failed, Trial};
 use rue_test_runner::{Case, find_rue_binary, load_test_files, run_test_case};
 use std::path::{Path, PathBuf};
 
@@ -106,34 +106,89 @@ fn main() {
     // Load all test files
     let specs = load_test_files(&cases_dir);
 
-    // Convert to trials
-    let tests: Vec<Trial> = specs
-        .into_iter()
-        .flat_map(|(_, spec)| {
-            let section_id = spec.section.id.clone();
+    // Separate stable and preview tests
+    let mut stable_tests: Vec<Trial> = Vec::new();
+    let mut preview_tests: Vec<Trial> = Vec::new();
+
+    for (_, spec) in specs {
+        let section_id = spec.section.id.clone();
+
+        for case in spec.case {
+            let test_name = format!("{}::{}", section_id, case.name);
+            let skip = case.skip;
+            let is_preview = case.preview.is_some();
             let rue_binary = rue_binary.clone();
 
-            spec.case.into_iter().map(move |case| {
-                let test_name = format!("{}::{}", section_id, case.name);
-                let skip = case.skip;
-                let rue_binary = rue_binary.clone();
+            let mut trial = Trial::test(test_name, move || run_case_wrapper(&case, &rue_binary));
 
-                let mut trial =
-                    Trial::test(test_name, move || run_case_wrapper(&case, &rue_binary));
+            if skip {
+                trial = trial.with_ignored_flag(true);
+            }
 
-                if skip {
-                    trial = trial.with_ignored_flag(true);
-                }
+            if is_preview {
+                preview_tests.push(trial);
+            } else {
+                stable_tests.push(trial);
+            }
+        }
+    }
 
-                trial
-            })
-        })
-        .collect();
-
-    if tests.is_empty() {
+    if stable_tests.is_empty() && preview_tests.is_empty() {
         eprintln!("Warning: No test cases found in {}", cases_dir.display());
         eprintln!("Make sure spec files exist and have the correct format.");
     }
 
-    libtest_mimic::run(&args, tests).exit();
+    // Run stable tests first - these must all pass
+    let stable_conclusion = if !stable_tests.is_empty() {
+        println!("\n=== Stable Tests ===\n");
+        libtest_mimic::run(&args, stable_tests)
+    } else {
+        Conclusion {
+            num_filtered_out: 0,
+            num_passed: 0,
+            num_failed: 0,
+            num_ignored: 0,
+            num_measured: 0,
+        }
+    };
+
+    // Run preview tests - these are allowed to fail
+    let preview_conclusion = if !preview_tests.is_empty() {
+        println!("\n=== Preview Tests ===\n");
+        libtest_mimic::run(&args, preview_tests)
+    } else {
+        Conclusion {
+            num_filtered_out: 0,
+            num_passed: 0,
+            num_failed: 0,
+            num_ignored: 0,
+            num_measured: 0,
+        }
+    };
+
+    // Print summary
+    println!("\n=== Summary ===\n");
+    println!(
+        "Stable:  {} passed, {} failed",
+        stable_conclusion.num_passed, stable_conclusion.num_failed
+    );
+
+    let preview_total = preview_conclusion.num_passed + preview_conclusion.num_failed;
+    if preview_total > 0 {
+        let percent = (preview_conclusion.num_passed as f64 / preview_total as f64) * 100.0;
+        println!(
+            "Preview: {} passed, {} failed ({:.0}%)",
+            preview_conclusion.num_passed, preview_conclusion.num_failed, percent
+        );
+    }
+
+    // Exit with error only if stable tests failed
+    // Preview test failures are allowed
+    if stable_conclusion.num_failed > 0 {
+        println!("\nResult: FAILED (stable tests failed)");
+        std::process::exit(1);
+    } else {
+        println!("\nResult: PASSED");
+        std::process::exit(0);
+    }
 }

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -81,6 +81,11 @@ pub struct Case {
     #[allow(dead_code)]
     #[serde(default)]
     pub spec: Vec<String>,
+    /// Preview feature required to run this test (e.g., "mutable_strings").
+    /// Tests with this field are compiled with `--preview <feature>` and
+    /// are allowed to fail without failing the overall test suite.
+    #[serde(default)]
+    pub preview: Option<String>,
 }
 
 /// A test file containing a section and its cases.
@@ -214,6 +219,15 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         .write_all(case.source.as_bytes())
         .map_err(|e| format!("Failed to write source: {}", e))?;
 
+    // Build base command with preview flags if needed
+    let build_command = |binary: &Path| -> Command {
+        let mut cmd = Command::new(binary);
+        if let Some(ref feature) = case.preview {
+            cmd.arg("--preview").arg(feature);
+        }
+        cmd
+    };
+
     // Check for golden IR tests (tokens, AST, RIR, AIR, MIR)
     if case.expected_tokens.is_some()
         || case.expected_ast.is_some()
@@ -223,7 +237,7 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
     {
         // Run dump commands and check golden output
         if let Some(ref expected) = case.expected_tokens {
-            let output = Command::new(rue_binary)
+            let output = build_command(rue_binary)
                 .arg("--emit")
                 .arg("tokens")
                 .arg(&source_path)
@@ -244,7 +258,7 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         }
 
         if let Some(ref expected) = case.expected_ast {
-            let output = Command::new(rue_binary)
+            let output = build_command(rue_binary)
                 .arg("--emit")
                 .arg("ast")
                 .arg(&source_path)
@@ -265,7 +279,7 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         }
 
         if let Some(ref expected) = case.expected_rir {
-            let output = Command::new(rue_binary)
+            let output = build_command(rue_binary)
                 .arg("--emit")
                 .arg("rir")
                 .arg(&source_path)
@@ -286,7 +300,7 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         }
 
         if let Some(ref expected) = case.expected_air {
-            let output = Command::new(rue_binary)
+            let output = build_command(rue_binary)
                 .arg("--emit")
                 .arg("air")
                 .arg(&source_path)
@@ -307,7 +321,7 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         }
 
         if let Some(ref expected) = case.expected_mir {
-            let output = Command::new(rue_binary)
+            let output = build_command(rue_binary)
                 .arg("--emit")
                 .arg("mir")
                 .arg(&source_path)
@@ -331,7 +345,7 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
     }
 
     // Compile with rue
-    let compile_output = Command::new(rue_binary)
+    let compile_output = build_command(rue_binary)
         .arg(&source_path)
         .arg(&output_path)
         .output()

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -5,8 +5,9 @@ use std::path::Path;
 
 use annotate_snippets::{Level, Renderer, Snippet};
 use rue_compiler::{
-    CompileError, CompileOptions, CompileWarning, Lexer, LinkerMode, Parser,
-    compile_frontend_from_ast, compile_with_options, generate_allocated_mir, generate_mir,
+    CompileError, CompileOptions, CompileWarning, Lexer, LinkerMode, Parser, PreviewFeature,
+    PreviewFeatures, compile_frontend_from_ast, compile_with_options, generate_allocated_mir,
+    generate_mir,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
@@ -55,21 +56,27 @@ struct Options {
     emit_stages: Vec<EmitStage>,
     target: Target,
     linker: LinkerMode,
+    preview_features: PreviewFeatures,
 }
 
 fn print_usage() {
     eprintln!("Usage: rue [options] <source.rue> [output]");
     eprintln!();
     eprintln!("Options:");
-    eprintln!("  --target <target>  Set compilation target (default: host)");
-    eprintln!("                     Valid targets: x86-64-linux, aarch64-linux");
-    eprintln!("  --linker <linker>  Set linker to use (default: internal)");
-    eprintln!("                     Use 'internal' for built-in linker, or a command");
-    eprintln!("                     like 'clang', 'gcc', or 'ld' for system linker");
-    eprintln!("  --emit <stage>     Emit intermediate representation and exit");
-    eprintln!("                     Can be specified multiple times for multiple outputs");
-    eprintln!("                     Stages: tokens, ast, rir, air, cfg, mir, asm");
-    eprintln!("  --help             Show this help message");
+    eprintln!("  --target <target>    Set compilation target (default: host)");
+    eprintln!("                       Valid targets: x86-64-linux, aarch64-linux");
+    eprintln!("  --linker <linker>    Set linker to use (default: internal)");
+    eprintln!("                       Use 'internal' for built-in linker, or a command");
+    eprintln!("                       like 'clang', 'gcc', or 'ld' for system linker");
+    eprintln!("  --emit <stage>       Emit intermediate representation and exit");
+    eprintln!("                       Can be specified multiple times for multiple outputs");
+    eprintln!("                       Stages: tokens, ast, rir, air, cfg, mir, asm");
+    eprintln!("  --preview <feature>  Enable a preview feature (can be repeated)");
+    eprintln!(
+        "                       Features: {}",
+        PreviewFeature::all_names()
+    );
+    eprintln!("  --help               Show this help message");
 }
 
 fn parse_args() -> Option<Options> {
@@ -83,6 +90,7 @@ fn parse_args() -> Option<Options> {
     let mut emit_stages = Vec::new();
     let mut target: Option<Target> = None;
     let mut linker: Option<LinkerMode> = None;
+    let mut preview_features = PreviewFeatures::new();
     let mut positional = Vec::new();
     let mut args_iter = args.iter().peekable();
 
@@ -129,6 +137,23 @@ fn parse_args() -> Option<Options> {
                     LinkerMode::System(linker_str.clone())
                 });
             }
+            "--preview" => {
+                let Some(feature_str) = args_iter.next() else {
+                    eprintln!("Error: --preview requires a feature name");
+                    eprintln!("Available features: {}", PreviewFeature::all_names());
+                    return None;
+                };
+                match PreviewFeature::from_str(feature_str) {
+                    Some(feature) => {
+                        preview_features.insert(feature);
+                    }
+                    None => {
+                        eprintln!("Error: unknown preview feature '{}'", feature_str);
+                        eprintln!("Available features: {}", PreviewFeature::all_names());
+                        return None;
+                    }
+                }
+            }
             "--help" | "-h" => {
                 print_usage();
                 return None;
@@ -160,6 +185,7 @@ fn parse_args() -> Option<Options> {
         emit_stages,
         target: target.unwrap_or_else(Target::host),
         linker: linker.unwrap_or_default(),
+        preview_features,
     })
 }
 
@@ -187,6 +213,7 @@ fn main() {
     let compile_options = CompileOptions {
         target: options.target,
         linker: options.linker.clone(),
+        preview_features: options.preview_features.clone(),
     };
     match compile_with_options(&source, &compile_options) {
         Ok(output) => {

--- a/docs/designs/adr-020-preview-features.md
+++ b/docs/designs/adr-020-preview-features.md
@@ -1,0 +1,310 @@
+# ADR-020: Preview Features
+
+## Status
+
+Proposed
+
+## Context
+
+Large features in Rue often require multiple implementation phases spanning several commits or development sessions. Examples include:
+
+- **Mutable strings** (ADR-019): Runtime allocator, 3-tuple representation, clone semantics, drop insertion, concatenation
+- **Inout parameters** (future): Parser changes, exclusivity analysis, codegen calling convention
+- **Enums** (future): New type kind, pattern matching, memory layout
+
+When implementing these features in a single commit, several problems arise:
+
+1. **All-or-nothing testing**: Tests only exist for the complete feature, so partial implementations can't be validated
+2. **Hard to debug**: When tests fail, it's unclear which phase introduced the bug
+3. **Can't ship incrementally**: Work-in-progress can't be merged without breaking stable functionality
+4. **Context loss**: If development pauses, the incomplete state is hard to resume
+
+We need a way to:
+- Write tests for a feature before it's complete
+- **Merge partial implementations to main** without breaking stable Rue
+- Track which features are in-progress vs stable
+- Clearly communicate to users what's experimental
+
+The key goal is **continuous integration of incomplete work**. Each commit—even for a partially-implemented feature—should be mergeable to main. This allows:
+- Progress to be preserved across development sessions
+- Multiple contributors to collaborate on large features
+- Bisection to work for debugging regressions
+- No long-lived feature branches that diverge from main
+
+## Decision
+
+Introduce **preview features** - a gating mechanism for in-progress language features.
+
+### Compiler Flag
+
+```bash
+rue --preview mutable_strings source.rue output
+```
+
+Code using preview features without the flag produces a clear error:
+
+```
+error: string concatenation requires preview feature `mutable_strings`
+  --> source.rue:3:13
+   |
+ 3 |     let c = "a" + "b";
+   |             ^^^^^^^^^
+   |
+   = help: compile with `--preview mutable_strings` to enable
+   = note: preview features may change or be removed; see ADR-019
+```
+
+### Feature Registry
+
+```rust
+// rue-compiler/src/features.rs
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum PreviewFeature {
+    MutableStrings,
+}
+
+impl PreviewFeature {
+    pub fn name(&self) -> &'static str {
+        match self {
+            PreviewFeature::MutableStrings => "mutable_strings",
+        }
+    }
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "mutable_strings" => Some(PreviewFeature::MutableStrings),
+            _ => None,
+        }
+    }
+
+    pub fn adr(&self) -> &'static str {
+        match self {
+            PreviewFeature::MutableStrings => "ADR-019",
+        }
+    }
+}
+```
+
+### Compile Options
+
+```rust
+pub struct CompileOptions {
+    pub target: Target,
+    pub linker: LinkerMode,
+    pub preview_features: HashSet<PreviewFeature>,
+}
+```
+
+### Semantic Analysis Gates
+
+When analyzing code that requires a preview feature:
+
+```rust
+// In sema.rs
+fn analyze_binary_op(&mut self, op: BinOp, lhs: AirRef, rhs: AirRef, span: Span) -> Result<...> {
+    if op == BinOp::Add && lhs_type == Type::String && rhs_type == Type::String {
+        self.require_preview(PreviewFeature::MutableStrings, "string concatenation", span)?;
+        // ... proceed with implementation
+    }
+}
+
+fn require_preview(&self, feature: PreviewFeature, what: &str, span: Span) -> Result<(), CompileError> {
+    if !self.options.preview_features.contains(&feature) {
+        return Err(CompileError::new(
+            ErrorKind::PreviewFeatureRequired { feature, what: what.to_string() },
+            span,
+        ));
+    }
+    Ok(())
+}
+```
+
+### Spec Test Integration
+
+Tests can declare which preview feature they require:
+
+```toml
+[[case]]
+name = "string_concat_basic"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let c = "hello" + " world";
+    if c == "hello world" { 1 } else { 0 }
+}
+"""
+exit_code = 1
+```
+
+The test runner:
+1. **Always runs preview tests** (compiling with the appropriate `--preview` flag)
+2. **Allows preview tests to fail** without failing the overall suite
+3. **Reports progress** on each preview feature
+
+### Test Runner Output
+
+```
+Running spec tests...
+
+=== Stable Tests ===
+expressions.arithmetic::add_basic                    ... ok
+expressions.arithmetic::sub_basic                    ... ok
+types.strings::string_literal_eq                     ... ok
+...
+Stable: 750 passed, 0 failed
+
+=== Preview: mutable_strings ===
+types.strings::string_concat_basic                   ... ok
+types.strings::string_concat_chained                 ... FAILED
+types.strings::string_copy_semantics                 ... FAILED
+...
+mutable_strings: 5/18 passed (27%)
+
+=== Summary ===
+Stable: 750/750 PASSED
+Preview: mutable_strings 5/18 (27%)
+
+Result: PASS (all stable tests passed)
+```
+
+### Stabilization
+
+When all tests for a preview feature pass:
+
+1. Remove `preview = "..."` from spec tests
+2. Remove the `require_preview()` gate from sema
+3. Remove the feature from the `PreviewFeature` enum
+4. Update the ADR status to "Stable"
+
+The feature is now part of stable Rue.
+
+### Verifying Gates Work
+
+For each preview feature, add a stable test that verifies the gate:
+
+```toml
+[[case]]
+name = "string_concat_requires_preview"
+source = """
+fn main() -> i32 {
+    let c = "a" + "b";
+    0
+}
+"""
+compile_fail = true
+error_contains = "requires preview feature"
+```
+
+This test runs without any preview flag and ensures the error message is correct.
+
+## Feature Size Guidelines
+
+Not every feature needs preview gating. Use this heuristic:
+
+### Small Features (no preview needed)
+
+- Touches 1-3 files
+- Single concept (new operator, syntax sugar)
+- No new runtime functions
+- No new IR instructions
+- Completable in one session/commit
+
+Examples: `%` operator, `else if` syntax, unary `+`
+
+### Large Features (preview required)
+
+- Touches many files across multiple crates
+- Multiple implementation phases
+- New runtime support functions
+- New IR instruction kinds
+- New type system concepts
+- Multi-session implementation
+
+Examples: mutable strings, inout parameters, enums, traits
+
+### Decision Process
+
+When starting a feature, ask:
+1. Does this need an ADR? → Probably needs preview
+2. Does this add runtime functions? → Probably needs preview
+3. Does this change the type system? → Probably needs preview
+4. Can I finish this in one commit with confidence? → Probably doesn't need preview
+
+## Implementation Plan
+
+### Phase 1: Infrastructure
+
+1. Add `PreviewFeature` enum to `rue-compiler`
+2. Add `preview_features` to `CompileOptions`
+3. Add `--preview` flag to CLI argument parsing
+4. Add `PreviewFeatureRequired` error kind
+
+### Phase 2: Test Runner
+
+1. Add `preview` field to spec test case schema
+2. Update test runner to pass `--preview` when running preview tests
+3. Update test runner to allow preview test failures
+4. Add progress reporting for preview features
+
+### Phase 3: Migration
+
+1. Add `preview = "mutable_strings"` to existing mutable string tests
+2. Add gates to sema for mutable string operations
+3. Verify stable tests still pass
+
+## Consequences
+
+### Positive
+
+- **Incremental progress**: Ship partial implementations behind gates
+- **Test-driven**: Write tests before implementation is complete
+- **Clear status**: Users know what's stable vs experimental
+- **Resumable**: Can pause and resume feature work across sessions
+- **Debuggable**: Smaller commits with focused changes
+
+### Negative
+
+- **Infrastructure overhead**: More code to maintain
+- **Gate maintenance**: Must remember to remove gates on stabilization
+- **Two test modes**: Mental overhead of stable vs preview
+
+### Mitigations
+
+- Keep the feature registry simple (just an enum)
+- Stabilization checklist in ADRs
+- Test runner makes the distinction clear
+
+## Alternatives Considered
+
+### Expected Failures Only
+
+Mark tests as `expected_fail = true` without compiler gates.
+
+Rejected because:
+- Can't actually use the feature (no `--preview` flag)
+- Can't ship incremental working functionality
+- Just tracks "this is broken" not "this is in progress"
+
+### Nightly/Stable Channels
+
+Separate compiler builds like Rust.
+
+Rejected because:
+- Too much infrastructure for a small project
+- "Nightly" implies daily releases, which isn't our cadence
+- Preview features are simpler and sufficient
+
+### No Gating
+
+Just implement features and fix bugs.
+
+Rejected because:
+- This is what we tried with mutable strings
+- 18 failing tests with no isolation of what's broken
+- Can't ship partial progress
+
+## Related
+
+- ADR-019: Mutable Strings (first feature to use preview gating)
+- `.claude/commands/feature.md` (workflow for implementing features)


### PR DESCRIPTION
Introduces a mechanism for gating in-progress language features behind `--preview` flags, allowing partial implementations to be merged to main without breaking stable Rue.

Key changes:
- Add `PreviewFeature` enum and `--preview` CLI flag
- Add `PreviewFeatureRequired` error kind for ungated feature usage
- Update test runner to separate stable and preview tests
- Preview tests are allowed to fail without failing the overall suite
- Update `/feature` command with size triage (small vs large features)

This enables continuous integration of incomplete work - each commit can be merged even if the feature isn't finished, as long as stable tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)