### PR TITLE
Fix @dbg output example in getting started page

### DIFF
--- a/website/content/getting-started.md
+++ b/website/content/getting-started.md
@@ -35,7 +35,7 @@ Compile and run it:
 ```bash
 ./buck2 run //crates/rue:rue -- hello.rue hello
 ./hello
-# prints: [hello.rue:2] 42 = 42
+# prints: 42
 echo $?  # prints: 0
 ```
 


### PR DESCRIPTION
The example showed Rust's dbg! format ([file:line] expr = value) but Rue's @dbg just prints the value followed by a newline.