### PR TITLE
Fix deploy-website workflow for Zola migration

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -25,34 +25,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Rust
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Setup dotslash
         uses: facebook/install-dotslash@latest
 
-      - name: Build mdbook-spec preprocessor
-        run: |
-          ./buck2 build //docs/spec/tools/mdbook-spec:mdbook-spec || exit 1
-          MDBOOK_SPEC="$(./buck2 build //docs/spec/tools/mdbook-spec:mdbook-spec --show-output | tail -1 | awk '{print $2}')"
-          if [ -z "$MDBOOK_SPEC" ]; then echo "Failed to get mdbook-spec path"; exit 1; fi
-          MDBOOK_SPEC_DIR="$PWD/$(dirname "$MDBOOK_SPEC")"
-          # Create symlink with hyphenated name (buck2 uses underscores)
-          ln -sf mdbook_spec "$MDBOOK_SPEC_DIR/mdbook-spec" || { echo "Failed to create symlink"; exit 1; }
-          echo "MDBOOK_SPEC_DIR=$MDBOOK_SPEC_DIR" >> $GITHUB_ENV
-
-      - name: Build specification
-        run: |
-          export PATH="$MDBOOK_SPEC_DIR:$PATH"
-          cd docs/spec && ../../mdbook build
-
       - name: Build website
-        run: cd website && ../zola build
-
-      - name: Combine outputs
         run: |
-          mkdir -p website/public/spec
-          cp -r docs/spec/book/* website/public/spec/
+          website/build.sh
           echo "rue-lang.dev" > website/public/CNAME
 
       - name: Upload artifact


### PR DESCRIPTION
The previous commit removed mdbook but didn't update the GitHub Actions workflow. It was still trying to build the now-deleted mdbook-spec preprocessor.

Now uses website/build.sh which handles copying spec content and building everything with Zola.

Follow-up to https://github.com/rue-language/rue/pull/308