### PR TITLE
Add hermetic Rust toolchain for Buck2

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -13,7 +13,7 @@ fbsource = prelude
 config = prelude
 
 [parser]
-target_platform_detector_spec = target:root//...->prelude//platforms:default
+target_platform_detector_spec = target:root//...->prelude//platforms:default target:toolchains//...->prelude//platforms:default
 
 [rust]
 edition = 2024

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,18 +8,22 @@ on:
   merge_group:
     branches: [trunk]
 
+# Cancel in-progress runs for the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
+      - name: Install dotslash
+        uses: facebook/install-dotslash@latest
 
       - name: Check formatting
+        # Uses hermetic rustfmt from Buck2 toolchain
         run: ./fmt.sh check
 
   test:
@@ -30,11 +34,20 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-
       - name: Install dotslash
         uses: facebook/install-dotslash@latest
 
+      # Cache Buck2 outputs including downloaded Rust toolchain
+      - name: Cache Buck2 outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            buck-out/v2/gen
+            ~/.cache/buck2
+          key: buck2-${{ runner.os }}-${{ hashFiles('**/BUCK', 'toolchains/rust/defs.bzl') }}
+          restore-keys: |
+            buck2-${{ runner.os }}-
+
+      # Uses hermetic Rust toolchain downloaded by Buck2
       - name: Run tests
         run: ./test.sh

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,9 +4,25 @@ This document covers how to build, test, and contribute to the Rue compiler.
 
 ## Prerequisites
 
-- Rust toolchain (rustc, cargo)
-- dotslash, for bootstrapping buck2
-- Linux x86-64 (for running compiled binaries)
+### Required
+
+- **dotslash** - For bootstrapping Buck2. Install via `brew install dotslash` (macOS) or see [dotslash docs](https://dotslash-cli.com/).
+
+### Platform-Specific
+
+The Rust toolchain is downloaded automatically by Buck2 (hermetic build). However, running Rue programs has platform requirements:
+
+| Platform | Requirements |
+|----------|--------------|
+| Linux x86_64 | None (fully hermetic) |
+| macOS ARM64 | Xcode Command Line Tools (`xcode-select --install`) |
+| macOS x86_64 | Xcode Command Line Tools (`xcode-select --install`) |
+
+**Why macOS needs Xcode**: The Rue compiler uses the system `clang` to link executables on macOS. On Linux, Rue uses its own internal ELF linker.
+
+### Optional (for IDE support)
+
+- **Rust toolchain via rustup** - For IDE features (rust-analyzer, etc.). The `rust-toolchain.toml` in the repo root ensures the right version.
 
 ## Repository Structure
 

--- a/fmt.sh
+++ b/fmt.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-# Format or check Rust code formatting
+# Format or check Rust code formatting using the hermetic Rust toolchain
 #
 # Usage:
 #   ./fmt.sh        # Format all Rust files
@@ -9,7 +9,8 @@ set -euo pipefail
 
 MODE="${1:-format}"
 
-RUST_FILES=$(find crates -name "*.rs" -type f)
+# Get absolute paths to all Rust files (buck2 run changes working directory)
+RUST_FILES=$(find "$(pwd)/crates" -name "*.rs" -type f)
 
 if [ -z "$RUST_FILES" ]; then
     echo "No Rust files found"
@@ -18,10 +19,10 @@ fi
 
 if [ "$MODE" = "check" ]; then
     echo "Checking Rust formatting..."
-    echo "$RUST_FILES" | xargs rustfmt --edition 2024 --check
+    echo "$RUST_FILES" | xargs ./buck2 run toolchains//rust:rustfmt -- --edition 2024 --check
     echo "All files formatted correctly!"
 else
     echo "Formatting Rust files..."
-    echo "$RUST_FILES" | xargs rustfmt --edition 2024
+    echo "$RUST_FILES" | xargs ./buck2 run toolchains//rust:rustfmt -- --edition 2024
     echo "Done!"
 fi

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,6 @@
+# This file is for rustup users (IDE integration, running cargo directly).
+# Buck2 uses the hermetic toolchain in toolchains/rust/ instead.
+# Keep the version in sync with RUST_VERSION in toolchains/rust/defs.bzl.
+[toolchain]
+channel = "1.92.0"
+components = ["rustfmt"]

--- a/toolchains/BUCK
+++ b/toolchains/BUCK
@@ -1,7 +1,20 @@
+# Toolchain configuration for Rue
+#
+# Status: Hermetic Rust toolchain
+# - Rust toolchain: Downloaded prebuilt binaries (Rust 1.92.0)
+# - C++ toolchain: System (clang/gcc)
+#
+# The hermetic Rust toolchain downloads prebuilt binaries for each platform,
+# ensuring reproducible builds without depending on system-installed rustc.
+#
+# Note: Building the Rue *compiler* is hermetic. However, *running* the Rue
+# compiler to produce executables has platform-specific requirements:
+# - Linux x86_64: Fully hermetic (uses internal ELF linker)
+# - macOS ARM64/x86_64: Requires Xcode Command Line Tools (uses system clang)
+
 load("@prelude//toolchains:cxx.bzl", "system_cxx_toolchain")
 load("@prelude//toolchains:genrule.bzl", "system_genrule_toolchain")
 load("@prelude//toolchains:python.bzl", "system_python_bootstrap_toolchain")
-load("@prelude//toolchains:rust.bzl", "system_rust_toolchain")
 load("@prelude//tests:test_toolchain.bzl", "noop_test_toolchain")
 load(":remote_test_execution.bzl", "noop_remote_test_execution_toolchain")
 
@@ -20,11 +33,25 @@ system_python_bootstrap_toolchain(
     visibility = ["PUBLIC"],
 )
 
-system_rust_toolchain(
+# Hermetic Rust toolchain - downloads prebuilt Rust binaries
+# Platform selection happens via select() based on host OS and CPU.
+#
+# Supported platforms:
+# - Linux x86_64: toolchains//rust:hermetic-linux-x86_64
+# - macOS ARM64:  toolchains//rust:hermetic-macos-aarch64
+# - macOS x86_64: toolchains//rust:hermetic-macos-x86_64
+toolchain_alias(
     name = "rust",
-    default_edition = "2024",
+    actual = select({
+        "prelude//os:linux": "toolchains//rust:hermetic-linux-x86_64",
+        "prelude//os:macos": select({
+            "prelude//cpu:arm64": "toolchains//rust:hermetic-macos-aarch64",
+            "prelude//cpu:x86_64": "toolchains//rust:hermetic-macos-x86_64",
+        }),
+    }),
     visibility = ["PUBLIC"],
 )
+
 
 noop_test_toolchain(
     name = "test",

--- a/toolchains/linker/BUCK
+++ b/toolchains/linker/BUCK
@@ -1,0 +1,62 @@
+# Hermetic linker configuration (documentation only)
+#
+# This file documents linker options for future use. No build rules are defined here yet.
+#
+# Current Rue compiler linking behavior:
+# - Linux x86_64: Uses internal rue-linker (fully hermetic, emits ELF directly)
+# - macOS ARM64/x86_64: Uses system clang (requires Xcode Command Line Tools)
+#
+# Future: Could use rust-lld from the hermetic Rust toolchain for macOS,
+# but would still need macOS SDK for libSystem and code signing.
+
+# =============================================================================
+# Linker Options
+# =============================================================================
+#
+# RECOMMENDED: Use rust-lld from the Rust toolchain
+#
+# rust-lld is bundled with every Rust installation at:
+#   lib/rustlib/{triple}/bin/rust-lld
+#
+# Benefits:
+# - Cross-platform: Linux, macOS, Windows
+# - Already included in Rust download (~116MB, no extra download)
+# - Drop-in replacement for system linkers
+# - Much faster than GNU ld
+#
+# To use rust-lld with the Rue compiler, pass it as the linker command.
+# The path varies by platform:
+#   Linux:   ~/.rustup/toolchains/{version}-{triple}/lib/rustlib/{triple}/bin/rust-lld
+#   macOS:   ~/.rustup/toolchains/{version}-{triple}/lib/rustlib/{triple}/bin/rust-lld
+#   Windows: %USERPROFILE%\.rustup\toolchains\{version}-{triple}\lib\rustlib\{triple}\bin\rust-lld.exe
+
+# Alternative: mold (Linux only, smaller and faster)
+#
+# mold is a very fast linker but only available for Linux.
+# For cross-platform builds, rust-lld is preferred.
+
+MOLD_VERSION = "2.40.4"
+
+MOLD_RELEASES = {
+    "x86_64-linux": struct(
+        url = "https://github.com/rui314/mold/releases/download/v2.40.4/mold-2.40.4-x86_64-linux.tar.gz",
+        sha256 = "4c999e19ffa31afa5aa429c679b665d5e2ca5a6b6832ad4b79668e8dcf3d8ec1",
+        binary = "bin/mold",
+    ),
+    "aarch64-linux": struct(
+        url = "https://github.com/rui314/mold/releases/download/v2.40.4/mold-2.40.4-aarch64-linux.tar.gz",
+        sha256 = "c799b9ccae8728793da2186718fbe53b76400a9da396184fac0c64aa3298ec37",
+        binary = "bin/mold",
+    ),
+}
+
+# Linker comparison:
+#
+# | Linker    | Platforms           | Size   | Speed     | Notes                    |
+# |-----------|---------------------|--------|-----------|--------------------------|
+# | rust-lld  | Linux, macOS, Win   | ~116MB | Fast      | Bundled with Rust        |
+# | mold      | Linux only          | ~5MB   | Very fast | Separate download        |
+# | lld       | Linux, macOS, Win   | ~1.6GB | Fast      | Full LLVM required       |
+# | ld (GNU)  | Linux               | System | Slow      | System linker            |
+# | ld64      | macOS               | System | Medium    | Xcode required           |
+# | link.exe  | Windows             | System | Medium    | MSVC required            |

--- a/toolchains/rust/BUCK
+++ b/toolchains/rust/BUCK
@@ -1,0 +1,88 @@
+# Hermetic Rust toolchain configuration
+#
+# Downloads prebuilt Rust toolchains for reproducible builds.
+# The toolchain includes rustc, cargo, rust-lld, and the standard library.
+
+load(":defs.bzl", "RUST_VERSION", "RUST_RELEASES", "hermetic_rust_toolchain", "rustfmt", "host_rustfmt")
+
+# Download Rust for Linux x86_64
+http_archive(
+    name = "rust-linux-x86_64",
+    urls = [RUST_RELEASES["x86_64-unknown-linux-gnu"].url],
+    sha256 = RUST_RELEASES["x86_64-unknown-linux-gnu"].sha256,
+    strip_prefix = "rust-{}-x86_64-unknown-linux-gnu".format(RUST_VERSION),
+    type = "tar.xz",
+    visibility = [],
+)
+
+# Download Rust for macOS ARM64 (Apple Silicon)
+http_archive(
+    name = "rust-macos-aarch64",
+    urls = [RUST_RELEASES["aarch64-apple-darwin"].url],
+    sha256 = RUST_RELEASES["aarch64-apple-darwin"].sha256,
+    strip_prefix = "rust-{}-aarch64-apple-darwin".format(RUST_VERSION),
+    type = "tar.xz",
+    visibility = [],
+)
+
+# Download Rust for macOS x86_64 (Intel)
+http_archive(
+    name = "rust-macos-x86_64",
+    urls = [RUST_RELEASES["x86_64-apple-darwin"].url],
+    sha256 = RUST_RELEASES["x86_64-apple-darwin"].sha256,
+    strip_prefix = "rust-{}-x86_64-apple-darwin".format(RUST_VERSION),
+    type = "tar.xz",
+    visibility = [],
+)
+
+# Hermetic toolchain for Linux x86_64
+hermetic_rust_toolchain(
+    name = "hermetic-linux-x86_64",
+    distribution = ":rust-linux-x86_64",
+    target_triple = "x86_64-unknown-linux-gnu",
+    default_edition = "2024",
+    visibility = ["PUBLIC"],
+)
+
+# Hermetic toolchain for macOS ARM64
+hermetic_rust_toolchain(
+    name = "hermetic-macos-aarch64",
+    distribution = ":rust-macos-aarch64",
+    target_triple = "aarch64-apple-darwin",
+    default_edition = "2024",
+    visibility = ["PUBLIC"],
+)
+
+# Hermetic toolchain for macOS x86_64
+hermetic_rust_toolchain(
+    name = "hermetic-macos-x86_64",
+    distribution = ":rust-macos-x86_64",
+    target_triple = "x86_64-apple-darwin",
+    default_edition = "2024",
+    visibility = ["PUBLIC"],
+)
+
+# Rustfmt for each platform
+rustfmt(
+    name = "rustfmt-linux-x86_64",
+    distribution = ":rust-linux-x86_64",
+    visibility = ["PUBLIC"],
+)
+
+rustfmt(
+    name = "rustfmt-macos-aarch64",
+    distribution = ":rust-macos-aarch64",
+    visibility = ["PUBLIC"],
+)
+
+rustfmt(
+    name = "rustfmt-macos-x86_64",
+    distribution = ":rust-macos-x86_64",
+    visibility = ["PUBLIC"],
+)
+
+# Host-platform rustfmt alias - automatically selects the right platform
+host_rustfmt(
+    name = "rustfmt",
+    visibility = ["PUBLIC"],
+)

--- a/toolchains/rust/defs.bzl
+++ b/toolchains/rust/defs.bzl
@@ -1,0 +1,222 @@
+# Hermetic Rust toolchain for Buck2
+#
+# This module downloads prebuilt Rust toolchains and configures them
+# for use with Buck2's Rust rules.
+
+load("@prelude//rust:rust_toolchain.bzl", "PanicRuntime", "RustToolchainInfo")
+
+# Rust 1.92.0 release info
+RUST_VERSION = "1.92.0"
+
+# SHA256 hashes for each platform's Rust distribution
+# These are the official hashes from static.rust-lang.org
+RUST_RELEASES = {
+    "x86_64-unknown-linux-gnu": struct(
+        url = "https://static.rust-lang.org/dist/rust-1.92.0-x86_64-unknown-linux-gnu.tar.xz",
+        sha256 = "d2ccef59dd9f7439f2c694948069f789a044dc1addcc0803613232af8f88ee0c",
+        triple = "x86_64-unknown-linux-gnu",
+    ),
+    "aarch64-apple-darwin": struct(
+        url = "https://static.rust-lang.org/dist/rust-1.92.0-aarch64-apple-darwin.tar.xz",
+        sha256 = "22276ecf826b22e718f099d7bf7ddb8c88aa46230fdba74962ab3c5031472268",
+        triple = "aarch64-apple-darwin",
+    ),
+    "x86_64-apple-darwin": struct(
+        url = "https://static.rust-lang.org/dist/rust-1.92.0-x86_64-apple-darwin.tar.xz",
+        sha256 = "ef71fcdcd50efd3301144e701faf15124113a1b2efe9a111175d7d1e4f2d31d2",
+        triple = "x86_64-apple-darwin",
+    ),
+}
+
+# Paths within the extracted Rust distribution
+# After http_archive extracts and strips the prefix, we have:
+#   rustc/bin/rustc, rustc/bin/rustdoc
+#   rustc/lib/rustlib/{triple}/bin/rust-lld (linker tools)
+#   clippy-preview/bin/clippy-driver
+#   rust-std-{triple}/lib/rustlib/{triple}/lib/*.rlib (stdlib - separate directory!)
+#
+# We need to create a merged sysroot because rustc expects:
+#   {sysroot}/lib/rustlib/{triple}/lib/*.rlib
+# But the stdlib is in rust-std-{triple}/, not in rustc/
+
+def _hermetic_rust_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
+    """Implementation of hermetic_rust_toolchain rule."""
+
+    dist = ctx.attrs.distribution[DefaultInfo].default_outputs[0]
+    triple = ctx.attrs.target_triple
+
+    # Paths to binaries
+    rustc_bin = dist.project("rustc/bin/rustc")
+    rustdoc_bin = dist.project("rustc/bin/rustdoc")
+    clippy_bin = dist.project("clippy-preview/bin/clippy-driver")
+
+    # Create RunInfo for each tool
+    compiler = RunInfo(args = [rustc_bin])
+    clippy_driver = RunInfo(args = [clippy_bin])
+    rustdoc = RunInfo(args = [rustdoc_bin])
+
+    # Build a merged sysroot by running a shell script
+    # The Rust distribution has components in separate directories that need merging:
+    #   rustc/                                      - compiler and core libs
+    #   rust-std-{triple}/lib/rustlib/{triple}/lib/ - stdlib rlibs
+    #
+    # We use a shell action to create symlinks properly merging these.
+    sysroot = ctx.actions.declare_output("sysroot", dir = True)
+    merge_script = ctx.actions.write(
+        "merge_sysroot.sh",
+        [
+            "#!/bin/bash",
+            "set -e",
+            "DIST=$(cd \"$1\" && pwd)",  # Convert to absolute path
+            "SYSROOT=$2",
+            "TRIPLE=$3",
+            "",
+            "# Create sysroot structure",
+            "mkdir -p \"$SYSROOT\"",
+            "",
+            "# Link top-level dirs from rustc",
+            "ln -s \"$DIST/rustc/bin\" \"$SYSROOT/bin\"",
+            "ln -s \"$DIST/rustc/libexec\" \"$SYSROOT/libexec\"",
+            "",
+            "# Create lib structure manually to merge rustlib",
+            "mkdir -p \"$SYSROOT/lib/rustlib/$TRIPLE\"",
+            "",
+            "# Link compiler libs (dylibs at lib/)",
+            "for f in \"$DIST/rustc/lib/\"*; do",
+            "    name=$(basename \"$f\")",
+            "    if [ \"$name\" != \"rustlib\" ]; then",
+            "        ln -s \"$f\" \"$SYSROOT/lib/$name\"",
+            "    fi",
+            "done",
+            "",
+            "# Link rustlib/etc",
+            "ln -s \"$DIST/rustc/lib/rustlib/etc\" \"$SYSROOT/lib/rustlib/etc\"",
+            "",
+            "# Link target bin (rust-lld)",
+            "ln -s \"$DIST/rustc/lib/rustlib/$TRIPLE/bin\" \"$SYSROOT/lib/rustlib/$TRIPLE/bin\"",
+            "",
+            "# Link target lib (stdlib from rust-std)",
+            "ln -s \"$DIST/rust-std-$TRIPLE/lib/rustlib/$TRIPLE/lib\" \"$SYSROOT/lib/rustlib/$TRIPLE/lib\"",
+        ],
+        is_executable = True,
+    )
+
+    ctx.actions.run(
+        cmd_args(
+            "/bin/bash",
+            merge_script,
+            dist,
+            sysroot.as_output(),
+            triple,
+        ),
+        category = "merge_sysroot",
+    )
+
+    return [
+        DefaultInfo(),
+        RustToolchainInfo(
+            compiler = compiler,
+            clippy_driver = clippy_driver,
+            rustdoc = rustdoc,
+            rustc_flags = ctx.attrs.rustc_flags,
+            rustc_binary_flags = ctx.attrs.rustc_binary_flags,
+            rustc_test_flags = ctx.attrs.rustc_test_flags,
+            rustdoc_flags = ctx.attrs.rustdoc_flags,
+            default_edition = ctx.attrs.default_edition,
+            rustc_target_triple = triple,
+            panic_runtime = PanicRuntime("abort"),
+            allow_lints = ctx.attrs.allow_lints,
+            deny_lints = ctx.attrs.deny_lints,
+            warn_lints = ctx.attrs.warn_lints,
+            clippy_toml = ctx.attrs.clippy_toml,
+            nightly_features = ctx.attrs.nightly_features,
+            doctests = ctx.attrs.doctests,
+            report_unused_deps = ctx.attrs.report_unused_deps,
+            # Use the merged sysroot
+            sysroot_path = sysroot,
+        ),
+    ]
+
+hermetic_rust_toolchain = rule(
+    impl = _hermetic_rust_toolchain_impl,
+    attrs = {
+        "distribution": attrs.dep(
+            doc = "The downloaded Rust distribution (from http_archive)",
+        ),
+        "target_triple": attrs.string(
+            doc = "The target triple (e.g., x86_64-unknown-linux-gnu)",
+        ),
+        "default_edition": attrs.option(attrs.string(), default = None),
+        "rustc_flags": attrs.list(attrs.arg(), default = []),
+        "rustc_binary_flags": attrs.list(attrs.arg(), default = []),
+        "rustc_test_flags": attrs.list(attrs.arg(), default = []),
+        "rustdoc_flags": attrs.list(attrs.arg(), default = []),
+        "allow_lints": attrs.list(attrs.string(), default = []),
+        "deny_lints": attrs.list(attrs.string(), default = []),
+        "warn_lints": attrs.list(attrs.string(), default = []),
+        "clippy_toml": attrs.option(attrs.dep(), default = None),
+        "nightly_features": attrs.bool(default = False),
+        "doctests": attrs.bool(default = False),
+        "report_unused_deps": attrs.bool(default = False),
+    },
+    is_toolchain_rule = True,
+)
+
+# Rule to expose rustfmt from the hermetic toolchain
+def _rustfmt_impl(ctx: AnalysisContext) -> list[Provider]:
+    """Exposes rustfmt binary from the Rust distribution.
+
+    rustfmt needs librustc_driver.dylib to be at ../lib/ relative to the binary.
+    We create a wrapper script that sets up the environment correctly.
+    """
+    dist = ctx.attrs.distribution[DefaultInfo].default_outputs[0]
+    rustfmt_bin = dist.project("rustfmt-preview/bin/rustfmt")
+    lib_dir = dist.project("rustc/lib")
+
+    # Create a wrapper script that sets the library path
+    wrapper = ctx.actions.write(
+        "rustfmt_wrapper.sh",
+        [
+            "#!/bin/bash",
+            # Set library path for both macOS and Linux
+            "export DYLD_LIBRARY_PATH=\"$1\"",
+            "export LD_LIBRARY_PATH=\"$1\"",
+            "shift",
+            "exec \"$@\"",
+        ],
+        is_executable = True,
+    )
+
+    return [
+        DefaultInfo(default_output = rustfmt_bin),
+        RunInfo(args = ["/bin/bash", wrapper, lib_dir, rustfmt_bin]),
+    ]
+
+rustfmt = rule(
+    impl = _rustfmt_impl,
+    attrs = {
+        "distribution": attrs.dep(
+            doc = "The downloaded Rust distribution (from http_archive)",
+        ),
+    },
+)
+
+def host_rustfmt(name: str, visibility: list[str] = []):
+    """Create a rustfmt alias that automatically selects the host platform."""
+    os = host_info().os
+    arch = host_info().arch
+
+    if os.is_linux and arch.is_x86_64:
+        actual = ":rustfmt-linux-x86_64"
+    elif os.is_macos and arch.is_aarch64:
+        actual = ":rustfmt-macos-aarch64"
+    elif os.is_macos and arch.is_x86_64:
+        actual = ":rustfmt-macos-x86_64"
+    else:
+        fail("Unsupported platform for rustfmt: {} {}".format(os, arch))
+
+    native.alias(
+        name = name,
+        actual = actual,
+        visibility = visibility,
+    )


### PR DESCRIPTION
Remove dependency on system-installed Rust by downloading prebuilt Rust toolchains directly. This ensures reproducible builds across different developer machines and CI environments.

Key changes:
- New toolchains/rust/ module that downloads Rust 1.92.0 for Linux x86_64, macOS ARM64, and macOS x86_64
- Merged sysroot creation to combine rustc and rust-std components
- Hermetic rustfmt with wrapper script for library path setup
- CI workflow updated to use hermetic toolchain (removes dtolnay action)
- Added Buck2 output caching in CI for faster builds
- rust-toolchain.toml for IDE/rustup compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)