### PR TITLE
Add debug assertions for array type ID validation

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -94,6 +94,11 @@ impl<'a> CfgLower<'a> {
 
     /// Get the length of an array type.
     fn array_length(&self, array_type_id: ArrayTypeId) -> u64 {
+        debug_assert!(
+            (array_type_id.0 as usize) < self.array_types.len(),
+            "invalid array type ID: {:?}",
+            array_type_id
+        );
         self.array_types
             .get(array_type_id.0 as usize)
             .map(|def| def.length)

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -82,6 +82,11 @@ impl<'a> CfgLower<'a> {
 
     /// Get the length of an array type.
     fn array_length(&self, array_type_id: ArrayTypeId) -> u64 {
+        debug_assert!(
+            (array_type_id.0 as usize) < self.array_types.len(),
+            "invalid array type ID: {:?}",
+            array_type_id
+        );
         self.array_types
             .get(array_type_id.0 as usize)
             .map(|def| def.length)


### PR DESCRIPTION
Add debug_assert! in array_length helper in both x86_64 and aarch64 cfg_lower modules to catch invalid array type IDs during development. While the fallback behavior (returning 0) is safe, the assertion helps debug issues earlier.

Fixes tree1-apd

🤖 Generated with [Claude Code](https://claude.com/claude-code)