### PR TITLE
Specify struct memory layout and add @size_of/@align_of intrinsics

### DIFF
--- a/crates/rue-air/src/inference.rs
+++ b/crates/rue-air/src/inference.rs
@@ -1201,6 +1201,15 @@ impl<'a> ConstraintGenerator<'a> {
                 InferType::Concrete(Type::Unit)
             }
 
+            // Type intrinsic (@size_of, @align_of)
+            InstData::TypeIntrinsic {
+                name: _,
+                type_arg: _,
+            } => {
+                // Type intrinsics return i32 (the size or alignment value)
+                InferType::Concrete(Type::I32)
+            }
+
             // Block
             InstData::Block { extra_start, len } => {
                 ctx.push_scope();

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -2030,6 +2030,37 @@ impl<'a> Sema<'a> {
                 Ok(AnalysisResult::new(air_ref, Type::Unit))
             }
 
+            InstData::TypeIntrinsic { name, type_arg } => {
+                let intrinsic_name = self.interner.get(*name).to_string();
+                let ty = self.resolve_type(*type_arg, inst.span)?;
+
+                let value: u64 = match intrinsic_name.as_str() {
+                    "size_of" => {
+                        // Calculate size in bytes (slot count * 8)
+                        let slot_count = self.abi_slot_count(ty);
+                        (slot_count * 8) as u64
+                    }
+                    "align_of" => {
+                        // All types currently have 8-byte alignment
+                        8u64
+                    }
+                    _ => {
+                        return Err(CompileError::new(
+                            ErrorKind::UnknownIntrinsic(intrinsic_name),
+                            inst.span,
+                        ));
+                    }
+                };
+
+                // Emit a constant with the computed value
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::Const(value),
+                    ty: Type::I32,
+                    span: inst.span,
+                });
+                Ok(AnalysisResult::new(air_ref, Type::I32))
+            }
+
             InstData::ArrayInit { elements } => {
                 // Get the array type from HM inference
                 let array_type_id = match ctx.resolved_types.get(&inst_ref).copied() {

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -375,13 +375,22 @@ pub struct CallExpr {
     pub span: Span,
 }
 
-/// An intrinsic call expression (e.g., `@dbg(42)`).
+/// An argument to an intrinsic call (can be an expression or a type).
+#[derive(Debug, Clone)]
+pub enum IntrinsicArg {
+    /// An expression argument (e.g., `@dbg(42)`)
+    Expr(Expr),
+    /// A type argument (e.g., `@size_of(i32)`)
+    Type(TypeExpr),
+}
+
+/// An intrinsic call expression (e.g., `@dbg(42)` or `@size_of(i32)`).
 #[derive(Debug, Clone)]
 pub struct IntrinsicCallExpr {
     /// Intrinsic name (without the @)
     pub name: Ident,
-    /// Arguments
-    pub args: Vec<Expr>,
+    /// Arguments (can be expressions or types)
+    pub args: Vec<IntrinsicArg>,
     pub span: Span,
 }
 
@@ -730,7 +739,13 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
         Expr::IntrinsicCall(intrinsic) => {
             writeln!(f, "Intrinsic @{}", intrinsic.name.name)?;
             for arg in &intrinsic.args {
-                fmt_expr(f, arg, level + 1)?;
+                match arg {
+                    IntrinsicArg::Expr(expr) => fmt_expr(f, expr, level + 1)?,
+                    IntrinsicArg::Type(ty) => {
+                        indent(f, level + 1)?;
+                        writeln!(f, "Type {:?}", ty)?;
+                    }
+                }
             }
             Ok(())
         }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -6,8 +6,8 @@
 use crate::ast::{
     ArrayLitExpr, AssignStatement, AssignTarget, Ast, BinaryExpr, BinaryOp, BlockExpr, BoolLit,
     BreakExpr, CallExpr, ContinueExpr, EnumDecl, EnumVariant, Expr, FieldDecl, FieldExpr,
-    FieldInit, Function, Ident, IfExpr, IndexExpr, IntLit, IntrinsicCallExpr, Item, LetPattern,
-    LetStatement, LoopExpr, MatchArm, MatchExpr, NegIntLit, Param, ParenExpr, PathExpr,
+    FieldInit, Function, Ident, IfExpr, IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr, Item,
+    LetPattern, LetStatement, LoopExpr, MatchArm, MatchExpr, NegIntLit, Param, ParenExpr, PathExpr,
     PathPattern, Pattern, ReturnExpr, Statement, StringLit, StructDecl, StructLitExpr, TypeExpr,
     UnaryExpr, UnaryOp, UnitLit, WhileExpr,
 };
@@ -599,11 +599,62 @@ where
     // Block expression
     let block_expr = block_parser(expr.clone());
 
+    // Intrinsic argument: can be either a type or an expression
+    // We parse as type only for unambiguous type syntax (primitives, (), !, [T;N])
+    // Bare identifiers are parsed as expressions since they could be variables
+    let unambiguous_type = {
+        // Unit type: ()
+        let unit_type = just(TokenKind::LParen)
+            .then(just(TokenKind::RParen))
+            .map_with(|_, e| IntrinsicArg::Type(TypeExpr::Unit(to_rue_span(e.span()))));
+
+        // Never type: !
+        let never_type = just(TokenKind::Bang)
+            .map_with(|_, e| IntrinsicArg::Type(TypeExpr::Never(to_rue_span(e.span()))));
+
+        // Array type: [T; N]
+        let array_type = just(TokenKind::LBracket)
+            .ignore_then(type_parser())
+            .then_ignore(just(TokenKind::Semi))
+            .then(select! {
+                TokenKind::Int(n) => n as u64,
+            })
+            .then_ignore(just(TokenKind::RBracket))
+            .map_with(|(element, length), e| {
+                IntrinsicArg::Type(TypeExpr::Array {
+                    element: Box::new(element),
+                    length,
+                    span: to_rue_span(e.span()),
+                })
+            });
+
+        // Primitive type keywords (these can't be variable names)
+        let primitive_type = select! {
+            TokenKind::I8 = e => IntrinsicArg::Type(TypeExpr::Named(Ident { name: "i8".to_string(), span: to_rue_span(e.span()) })),
+            TokenKind::I16 = e => IntrinsicArg::Type(TypeExpr::Named(Ident { name: "i16".to_string(), span: to_rue_span(e.span()) })),
+            TokenKind::I32 = e => IntrinsicArg::Type(TypeExpr::Named(Ident { name: "i32".to_string(), span: to_rue_span(e.span()) })),
+            TokenKind::I64 = e => IntrinsicArg::Type(TypeExpr::Named(Ident { name: "i64".to_string(), span: to_rue_span(e.span()) })),
+            TokenKind::U8 = e => IntrinsicArg::Type(TypeExpr::Named(Ident { name: "u8".to_string(), span: to_rue_span(e.span()) })),
+            TokenKind::U16 = e => IntrinsicArg::Type(TypeExpr::Named(Ident { name: "u16".to_string(), span: to_rue_span(e.span()) })),
+            TokenKind::U32 = e => IntrinsicArg::Type(TypeExpr::Named(Ident { name: "u32".to_string(), span: to_rue_span(e.span()) })),
+            TokenKind::U64 = e => IntrinsicArg::Type(TypeExpr::Named(Ident { name: "u64".to_string(), span: to_rue_span(e.span()) })),
+            TokenKind::Bool = e => IntrinsicArg::Type(TypeExpr::Named(Ident { name: "bool".to_string(), span: to_rue_span(e.span()) })),
+        };
+
+        choice((unit_type, never_type, array_type, primitive_type))
+    };
+
+    // Try unambiguous type syntax first, then fall back to expression
+    let intrinsic_arg = unambiguous_type.or(expr.clone().map(IntrinsicArg::Expr));
+
     // Intrinsic call: @name(args)
     let intrinsic_call = just(TokenKind::At)
         .ignore_then(ident_parser())
         .then(
-            args_parser(expr.clone())
+            intrinsic_arg
+                .separated_by(just(TokenKind::Comma))
+                .allow_trailing()
+                .collect::<Vec<_>>()
                 .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
         )
         .map_with(|(name, args), e| {

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -8,8 +8,8 @@ mod chumsky_parser;
 pub use ast::{
     ArrayLitExpr, AssignStatement, AssignTarget, Ast, BinaryExpr, BinaryOp, BlockExpr, CallExpr,
     EnumDecl, EnumVariant, Expr, FieldDecl, FieldExpr, FieldInit, Function, Ident, IndexExpr,
-    IntLit, IntrinsicCallExpr, Item, LetPattern, LetStatement, MatchArm, MatchExpr, Param,
-    ParenExpr, PathExpr, PathPattern, Pattern, ReturnExpr, Statement, StructDecl, StructLitExpr,
-    TypeExpr, UnaryExpr, UnaryOp, WhileExpr,
+    IntLit, IntrinsicArg, IntrinsicCallExpr, Item, LetPattern, LetStatement, MatchArm, MatchExpr,
+    Param, ParenExpr, PathExpr, PathPattern, Pattern, ReturnExpr, Statement, StructDecl,
+    StructLitExpr, TypeExpr, UnaryExpr, UnaryOp, WhileExpr,
 };
 pub use chumsky_parser::ChumskyParser as Parser;

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -5,8 +5,8 @@
 
 use rue_intern::Interner;
 use rue_parser::{
-    AssignTarget, Ast, BinaryOp, EnumDecl, Expr, Function, Item, LetPattern, Pattern, Statement,
-    StructDecl, TypeExpr, UnaryOp,
+    AssignTarget, Ast, BinaryOp, EnumDecl, Expr, Function, IntrinsicArg, Item, LetPattern, Pattern,
+    Statement, StructDecl, TypeExpr, UnaryOp,
 };
 
 use crate::inst::{Inst, InstData, InstRef, Rir, RirPattern};
@@ -311,7 +311,41 @@ impl<'a> AstGen<'a> {
             }
             Expr::IntrinsicCall(intrinsic) => {
                 let name = self.interner.intern(&intrinsic.name.name);
-                let args: Vec<_> = intrinsic.args.iter().map(|a| self.gen_expr(a)).collect();
+                let intrinsic_name = &intrinsic.name.name;
+
+                // Check if this is a type intrinsic (size_of, align_of)
+                let is_type_intrinsic = intrinsic_name == "size_of" || intrinsic_name == "align_of";
+
+                if is_type_intrinsic && intrinsic.args.len() == 1 {
+                    // Handle explicit type argument
+                    if let IntrinsicArg::Type(ty) = &intrinsic.args[0] {
+                        let type_arg = self.intern_type(ty);
+                        return self.rir.add_inst(Inst {
+                            data: InstData::TypeIntrinsic { name, type_arg },
+                            span: intrinsic.span,
+                        });
+                    }
+
+                    // Handle identifier expression that should be interpreted as a type
+                    // (e.g., @size_of(Point) where Point is parsed as Ident expression)
+                    if let IntrinsicArg::Expr(Expr::Ident(ident)) = &intrinsic.args[0] {
+                        let type_arg = self.interner.intern(&ident.name);
+                        return self.rir.add_inst(Inst {
+                            data: InstData::TypeIntrinsic { name, type_arg },
+                            span: intrinsic.span,
+                        });
+                    }
+                }
+
+                // Otherwise, treat as an expression intrinsic
+                let args: Vec<_> = intrinsic
+                    .args
+                    .iter()
+                    .filter_map(|a| match a {
+                        IntrinsicArg::Expr(expr) => Some(self.gen_expr(expr)),
+                        IntrinsicArg::Type(_) => None, // This shouldn't happen for expr intrinsics
+                    })
+                    .collect();
 
                 self.rir.add_inst(Inst {
                     data: InstData::Intrinsic { name, args },

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -250,12 +250,20 @@ pub enum InstData {
         args: Vec<InstRef>,
     },
 
-    /// Intrinsic call (e.g., @dbg)
+    /// Intrinsic call with expression arguments (e.g., @dbg)
     Intrinsic {
         /// Intrinsic name (without @)
         name: Symbol,
         /// Argument instruction refs
         args: Vec<InstRef>,
+    },
+
+    /// Intrinsic call with a type argument (e.g., @size_of, @align_of)
+    TypeIntrinsic {
+        /// Intrinsic name (without @)
+        name: Symbol,
+        /// Type argument (as an interned string, e.g., "i32", "Point", "[i32; 4]")
+        type_arg: Symbol,
     },
 
     /// Reference to a function parameter
@@ -580,6 +588,11 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         name_str,
                         args_str.join(", ")
                     ));
+                }
+                InstData::TypeIntrinsic { name, type_arg } => {
+                    let name_str = self.interner.get(*name);
+                    let type_str = self.interner.get(*type_arg);
+                    out.push_str(&format!("type_intrinsic @{}({})\n", name_str, type_str));
                 }
                 InstData::ParamRef { index, name } => {
                     let name_str = self.interner.get(*name);

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -20,6 +20,17 @@ fn main() -> i32 {
 exit_code = 0
 
 [[case]]
+name = "intrinsic_type_argument"
+spec = ["4.13:2a"]
+source = """
+fn main() -> i32 {
+    // Intrinsics can take type arguments
+    @size_of(i32)
+}
+"""
+exit_code = 8
+
+[[case]]
 name = "unknown_intrinsic"
 spec = ["4.13:5"]
 source = """
@@ -162,3 +173,114 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
+
+# =============================================================================
+# @size_of Intrinsic
+# =============================================================================
+
+[[case]]
+name = "size_of_returns_size"
+spec = ["4.13:12", "4.13:13"]
+source = """
+fn main() -> i32 {
+    @size_of(i32)
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "size_of_returns_i32"
+spec = ["4.13:14"]
+source = """
+fn takes_i32(x: i32) -> i32 { x }
+fn main() -> i32 {
+    takes_i32(@size_of(i32))
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "size_of_compile_time"
+spec = ["4.13:15"]
+source = """
+fn main() -> i32 {
+    // Can be used in constant context
+    let size: i32 = @size_of(i32);
+    size
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "size_of_struct"
+spec = ["4.13:12", "4.13:13"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    @size_of(Point)
+}
+"""
+exit_code = 16
+
+[[case]]
+name = "size_of_array"
+spec = ["4.13:12", "4.13:13"]
+source = """
+fn main() -> i32 {
+    @size_of([i32; 3])
+}
+"""
+exit_code = 24
+
+# =============================================================================
+# @align_of Intrinsic
+# =============================================================================
+
+[[case]]
+name = "align_of_returns_alignment"
+spec = ["4.13:18", "4.13:19"]
+source = """
+fn main() -> i32 {
+    @align_of(i32)
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "align_of_returns_i32"
+spec = ["4.13:20"]
+source = """
+fn takes_i32(x: i32) -> i32 { x }
+fn main() -> i32 {
+    takes_i32(@align_of(i32))
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "align_of_compile_time"
+spec = ["4.13:21"]
+source = """
+fn main() -> i32 {
+    // Can be used in constant context
+    let align: i32 = @align_of(i32);
+    align
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "align_of_all_types_8"
+spec = ["4.13:22"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    // All types currently have 8-byte alignment
+    if @align_of(i8) != 8 { return 1; }
+    if @align_of(i64) != 8 { return 2; }
+    if @align_of(bool) != 8 { return 3; }
+    if @align_of(Point) != 8 { return 4; }
+    0
+}
+"""
+exit_code = 0

--- a/crates/rue-spec/cases/types/structs.toml
+++ b/crates/rue-spec/cases/types/structs.toml
@@ -80,3 +80,95 @@ fn main() -> i32 {
 """
 exit_code = 42
 
+# =============================================================================
+# Memory Layout
+# =============================================================================
+
+[[case]]
+name = "scalar_size_8_bytes"
+spec = ["3.6:8"]
+source = """
+fn main() -> i32 {
+    @size_of(i32)
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "bool_size_8_bytes"
+spec = ["3.6:8"]
+source = """
+fn main() -> i32 {
+    @size_of(bool)
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "unit_size_8_bytes"
+spec = ["3.6:8"]
+source = """
+fn main() -> i32 {
+    @size_of(())
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "struct_fields_declaration_order"
+spec = ["3.6:9"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    // Two fields, each 8 bytes = 16 bytes total
+    @size_of(Point)
+}
+"""
+exit_code = 16
+
+[[case]]
+name = "struct_size_sum_of_fields"
+spec = ["3.6:10"]
+source = """
+struct Triple { a: i32, b: i32, c: i32 }
+fn main() -> i32 {
+    // Three fields, each 8 bytes = 24 bytes
+    @size_of(Triple)
+}
+"""
+exit_code = 24
+
+[[case]]
+name = "nested_struct_size"
+spec = ["3.6:10"]
+source = """
+struct Point { x: i32, y: i32 }
+struct Line { start: Point, end: Point }
+fn main() -> i32 {
+    // Two Points, each 16 bytes = 32 bytes
+    @size_of(Line)
+}
+"""
+exit_code = 32
+
+[[case]]
+name = "struct_alignment_8_bytes"
+spec = ["3.6:12"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    @align_of(Point)
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "scalar_alignment_8_bytes"
+spec = ["3.6:12"]
+source = """
+fn main() -> i32 {
+    @align_of(i64)
+}
+"""
+exit_code = 8
+

--- a/docs/spec/src/03-types/06-struct-types.md
+++ b/docs/spec/src/03-types/06-struct-types.md
@@ -45,3 +45,35 @@ All fields must be initialized when creating a struct instance.
 {{ rule(id="3.6:6", cat="normative") }}
 
 Field names must be unique within a struct.
+
+## Memory Layout
+
+{{ rule(id="3.6:7", cat="informative") }}
+
+The memory layout rules described in this section are provisional and may change in future versions of Rue. The current design prioritizes simplicity over space efficiency.
+
+{{ rule(id="3.6:8", cat="normative") }}
+
+All types in Rue occupy one or more 8-byte slots. Scalar types (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `bool`) each occupy one slot. The `unit` type occupies one slot.
+
+{{ rule(id="3.6:9", cat="normative") }}
+
+Struct fields are laid out in memory in declaration order, with each field occupying a number of slots determined by its type.
+
+{{ rule(id="3.6:10", cat="normative") }}
+
+The size of a struct is the sum of the sizes of all its fields. There is no padding between fields or at the end of the struct.
+
+{{ rule(id="3.6:11") }}
+
+```rue
+// A struct with two i32 fields occupies 2 slots (16 bytes)
+struct Point { x: i32, y: i32 }
+
+// A struct with a nested struct occupies the sum of all nested field slots
+struct Line { start: Point, end: Point }  // 4 slots (32 bytes)
+```
+
+{{ rule(id="3.6:12", cat="normative") }}
+
+All structs have 8-byte alignment.

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -13,8 +13,13 @@ An intrinsic expression invokes a compiler-provided primitive operation.
 {{ rule(id="4.13:2", cat="normative") }}
 
 ```ebnf
-intrinsic = "@" IDENT "(" [ expression { "," expression } ] ")" ;
+intrinsic = "@" IDENT "(" [ intrinsic_arg { "," intrinsic_arg } ] ")" ;
+intrinsic_arg = expression | type ;
 ```
+
+{{ rule(id="4.13:2a", cat="normative") }}
+
+Intrinsics may accept expressions, types, or a combination of both as arguments, depending on the specific intrinsic.
 
 {{ rule(id="4.13:3", cat="normative") }}
 
@@ -76,5 +81,71 @@ fn factorial(n: i32) -> i32 {
 
 fn main() -> i32 {
     factorial(5)
+}
+```
+
+## `@size_of`
+
+{{ rule(id="4.13:12", cat="normative") }}
+
+The `@size_of` intrinsic returns the size of a type in bytes.
+
+{{ rule(id="4.13:13", cat="normative") }}
+
+`@size_of` accepts exactly one argument, which must be a type.
+
+{{ rule(id="4.13:14", cat="normative") }}
+
+The return type of `@size_of` is `i32`.
+
+{{ rule(id="4.13:15", cat="normative") }}
+
+The value returned by `@size_of` is determined at compile time.
+
+{{ rule(id="4.13:16") }}
+
+```rue
+fn main() -> i32 {
+    @size_of(i32)     // 8 (one 8-byte slot)
+}
+```
+
+{{ rule(id="4.13:17") }}
+
+```rue
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    @size_of(Point)   // 16 (two 8-byte slots)
+}
+```
+
+## `@align_of`
+
+{{ rule(id="4.13:18", cat="normative") }}
+
+The `@align_of` intrinsic returns the alignment of a type in bytes.
+
+{{ rule(id="4.13:19", cat="normative") }}
+
+`@align_of` accepts exactly one argument, which must be a type.
+
+{{ rule(id="4.13:20", cat="normative") }}
+
+The return type of `@align_of` is `i32`.
+
+{{ rule(id="4.13:21", cat="normative") }}
+
+The value returned by `@align_of` is determined at compile time.
+
+{{ rule(id="4.13:22", cat="normative") }}
+
+All types in Rue currently have 8-byte alignment.
+
+{{ rule(id="4.13:23") }}
+
+```rue
+fn main() -> i32 {
+    @align_of(i32)    // 8
 }
 ```


### PR DESCRIPTION
Document the current slot-based memory layout in the specification:
- All types occupy 8-byte slots (3.6:8)
- Struct fields laid out in declaration order (3.6:9)
- Struct size is sum of field sizes, no padding (3.6:10)
- All types have 8-byte alignment (3.6:12)

Add @size_of and @align_of intrinsics for querying type layout:
- Both accept a type argument and return i32 (4.13:12-23)
- Values computed at compile time (no runtime cost)

The layout semantics are marked as provisional (3.6:7) since this simple approach prioritizes simplicity over space efficiency.

Fixes rue-kvp