### PR TITLE
Add immediate shift optimization for x86_64 and aarch64 backends

### DIFF
--- a/.beads/redirect
+++ b/.beads/redirect
@@ -1,0 +1,1 @@
+../work/.beads

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -974,6 +974,33 @@ impl<'a> CfgLower<'a> {
                 self.value_map.insert(value, vreg);
 
                 let lhs_vreg = self.get_vreg(*lhs);
+
+                // Check if shift amount is a constant within valid range - use immediate form if so
+                // For 64-bit: 0-63, for 32-bit: 0-31
+                let rhs_inst = &self.cfg.get_inst(*rhs).data;
+                let bit_width = if ty.is_64_bit() { 64 } else { 32 };
+                if let CfgInstData::Const(shift_amount) = rhs_inst {
+                    let shift = *shift_amount;
+                    if shift < bit_width {
+                        let imm = shift as u8;
+                        // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
+                        if ty.is_64_bit() {
+                            self.mir.push(Aarch64Inst::LslImm {
+                                dst: Operand::Virtual(vreg),
+                                src: Operand::Virtual(lhs_vreg),
+                                imm,
+                            });
+                        } else {
+                            self.mir.push(Aarch64Inst::Lsl32Imm {
+                                dst: Operand::Virtual(vreg),
+                                src: Operand::Virtual(lhs_vreg),
+                                imm,
+                            });
+                        }
+                        return;
+                    }
+                }
+                // Variable shift amount or out-of-range constant - use register form
                 let rhs_vreg = self.get_vreg(*rhs);
 
                 // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
@@ -998,38 +1025,74 @@ impl<'a> CfgLower<'a> {
                 self.value_map.insert(value, vreg);
 
                 let lhs_vreg = self.get_vreg(*lhs);
+
+                // Check if shift amount is a constant within valid range - use immediate form if so
+                // For 64-bit: 0-63, for 32-bit: 0-31
+                let rhs_inst = &self.cfg.get_inst(*rhs).data;
+                let bit_width = if ty.is_64_bit() { 64 } else { 32 };
+                if let CfgInstData::Const(shift_amount) = rhs_inst {
+                    let shift = *shift_amount;
+                    if shift < bit_width {
+                        let imm = shift as u8;
+                        // Use arithmetic shift (ASR) for signed types, logical shift (LSR) for unsigned
+                        // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
+                        if ty.is_64_bit() && ty.is_signed() {
+                            self.mir.push(Aarch64Inst::Asr64Imm {
+                                dst: Operand::Virtual(vreg),
+                                src: Operand::Virtual(lhs_vreg),
+                                imm,
+                            });
+                        } else if ty.is_64_bit() {
+                            self.mir.push(Aarch64Inst::Lsr64Imm {
+                                dst: Operand::Virtual(vreg),
+                                src: Operand::Virtual(lhs_vreg),
+                                imm,
+                            });
+                        } else if ty.is_signed() {
+                            self.mir.push(Aarch64Inst::Asr32Imm {
+                                dst: Operand::Virtual(vreg),
+                                src: Operand::Virtual(lhs_vreg),
+                                imm,
+                            });
+                        } else {
+                            self.mir.push(Aarch64Inst::Lsr32Imm {
+                                dst: Operand::Virtual(vreg),
+                                src: Operand::Virtual(lhs_vreg),
+                                imm,
+                            });
+                        }
+                        return;
+                    }
+                }
+                // Variable shift amount or out-of-range constant - use register form
                 let rhs_vreg = self.get_vreg(*rhs);
 
                 // Use arithmetic shift (ASR) for signed types, logical shift (LSR) for unsigned
                 // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
-                if ty.is_64_bit() {
-                    if ty.is_signed() {
-                        self.mir.push(Aarch64Inst::AsrRR {
-                            dst: Operand::Virtual(vreg),
-                            src1: Operand::Virtual(lhs_vreg),
-                            src2: Operand::Virtual(rhs_vreg),
-                        });
-                    } else {
-                        self.mir.push(Aarch64Inst::LsrRR {
-                            dst: Operand::Virtual(vreg),
-                            src1: Operand::Virtual(lhs_vreg),
-                            src2: Operand::Virtual(rhs_vreg),
-                        });
-                    }
+                if ty.is_64_bit() && ty.is_signed() {
+                    self.mir.push(Aarch64Inst::AsrRR {
+                        dst: Operand::Virtual(vreg),
+                        src1: Operand::Virtual(lhs_vreg),
+                        src2: Operand::Virtual(rhs_vreg),
+                    });
+                } else if ty.is_64_bit() {
+                    self.mir.push(Aarch64Inst::LsrRR {
+                        dst: Operand::Virtual(vreg),
+                        src1: Operand::Virtual(lhs_vreg),
+                        src2: Operand::Virtual(rhs_vreg),
+                    });
+                } else if ty.is_signed() {
+                    self.mir.push(Aarch64Inst::Asr32RR {
+                        dst: Operand::Virtual(vreg),
+                        src1: Operand::Virtual(lhs_vreg),
+                        src2: Operand::Virtual(rhs_vreg),
+                    });
                 } else {
-                    if ty.is_signed() {
-                        self.mir.push(Aarch64Inst::Asr32RR {
-                            dst: Operand::Virtual(vreg),
-                            src1: Operand::Virtual(lhs_vreg),
-                            src2: Operand::Virtual(rhs_vreg),
-                        });
-                    } else {
-                        self.mir.push(Aarch64Inst::Lsr32RR {
-                            dst: Operand::Virtual(vreg),
-                            src1: Operand::Virtual(lhs_vreg),
-                            src2: Operand::Virtual(rhs_vreg),
-                        });
-                    }
+                    self.mir.push(Aarch64Inst::Lsr32RR {
+                        dst: Operand::Virtual(vreg),
+                        src1: Operand::Virtual(lhs_vreg),
+                        src2: Operand::Virtual(rhs_vreg),
+                    });
                 }
             }
 

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -674,6 +674,24 @@ impl<'a> Emitter<'a> {
                 self.emit_lsl_imm(rd, rn, *imm);
             }
 
+            Aarch64Inst::Lsl32Imm { dst, src, imm } => {
+                let rd = dst.as_physical();
+                let rn = src.as_physical();
+                self.emit_lsl32_imm(rd, rn, *imm);
+            }
+
+            Aarch64Inst::Lsr32Imm { dst, src, imm } => {
+                let rd = dst.as_physical();
+                let rn = src.as_physical();
+                self.emit_lsr32_imm(rd, rn, *imm);
+            }
+
+            Aarch64Inst::Asr32Imm { dst, src, imm } => {
+                let rd = dst.as_physical();
+                let rn = src.as_physical();
+                self.emit_asr32_imm(rd, rn, *imm);
+            }
+
             Aarch64Inst::StringConstPtr { dst, string_id } => {
                 // Load string pointer using ADRP + ADD for PC-relative addressing
                 // This requires relocations to be resolved by the linker
@@ -1405,6 +1423,53 @@ impl<'a> Emitter<'a> {
         let imms = 63 - shift;
         let inst = OPCODE_UBFM_X
             | (immr << 16)
+            | (imms << 10)
+            | (rn.encoding() as u32) << 5
+            | rd.encoding() as u32;
+        self.emit_u32(inst);
+    }
+
+    fn emit_lsl32_imm(&mut self, rd: Reg, rn: Reg, shift: u8) {
+        // LSL Wd, Wn, #shift is an alias for UBFM Wd, Wn, #(-shift mod 32), #(31-shift)
+        // For 32-bit: UBFM with sf=0, N=0
+        // immr = -shift mod 32 = (32 - shift) mod 32
+        // imms = 31 - shift
+        const OPCODE_UBFM_W_BASE: u32 = 0x5300_0000;
+        let shift = shift as u32;
+        let immr = (32 - shift) & 0x1F;
+        let imms = 31 - shift;
+        let inst = OPCODE_UBFM_W_BASE
+            | (immr << 16)
+            | (imms << 10)
+            | (rn.encoding() as u32) << 5
+            | rd.encoding() as u32;
+        self.emit_u32(inst);
+    }
+
+    fn emit_lsr32_imm(&mut self, rd: Reg, rn: Reg, imm: u8) {
+        // LSR Wd, Wn, #imm (32-bit logical shift right by immediate)
+        // Encoded as UBFM Wd, Wn, #imm, #31
+        // UBFM: 0b0101_0011_0000_0000 immr imms Rn Rd
+        // For LSR #imm: immr = imm, imms = 31
+        const OPCODE_UBFM_W: u32 = 0x5300_0000; // 32-bit UBFM base
+        let imms = 31u32;
+        let inst = OPCODE_UBFM_W
+            | ((imm as u32 & 0x1F) << 16)
+            | (imms << 10)
+            | (rn.encoding() as u32) << 5
+            | rd.encoding() as u32;
+        self.emit_u32(inst);
+    }
+
+    fn emit_asr32_imm(&mut self, rd: Reg, rn: Reg, imm: u8) {
+        // ASR Wd, Wn, #imm (32-bit arithmetic shift right by immediate)
+        // Encoded as SBFM Wd, Wn, #imm, #31
+        // SBFM: 0b0001_0011_0000_0000 immr imms Rn Rd
+        // For ASR #imm: immr = imm, imms = 31
+        const OPCODE_SBFM_W: u32 = 0x1300_0000; // 32-bit SBFM base
+        let imms = 31u32;
+        let inst = OPCODE_SBFM_W
+            | ((imm as u32 & 0x1F) << 16)
             | (imms << 10)
             | (rn.encoding() as u32) << 5
             | rd.encoding() as u32;

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -352,7 +352,10 @@ fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
             add_if_virtual(src, &mut result);
             result.push(*base);
         }
-        Aarch64Inst::LslImm { src, .. } => {
+        Aarch64Inst::LslImm { src, .. }
+        | Aarch64Inst::Lsl32Imm { src, .. }
+        | Aarch64Inst::Lsr32Imm { src, .. }
+        | Aarch64Inst::Asr32Imm { src, .. } => {
             add_if_virtual(src, &mut result);
         }
         Aarch64Inst::StringConstPtr { .. } | Aarch64Inst::StringConstLen { .. } => {
@@ -460,7 +463,10 @@ fn defs(inst: &Aarch64Inst) -> Vec<VReg> {
         Aarch64Inst::StrIndexed { .. } => {
             // Writes to memory
         }
-        Aarch64Inst::LslImm { dst, .. } => {
+        Aarch64Inst::LslImm { dst, .. }
+        | Aarch64Inst::Lsl32Imm { dst, .. }
+        | Aarch64Inst::Lsr32Imm { dst, .. }
+        | Aarch64Inst::Asr32Imm { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
         Aarch64Inst::StringConstPtr { dst, .. } | Aarch64Inst::StringConstLen { dst, .. } => {

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -434,8 +434,17 @@ pub enum Aarch64Inst {
     /// `add dst, src, #imm, lsl #12` - Add immediate with shift (for large offsets).
     /// Note: Using regular AddImm for now, this is for future large offset support.
 
-    /// `lsl dst, src, #imm` - Logical shift left by immediate.
+    /// `lsl dst, src, #imm` - Logical shift left by immediate (64-bit).
     LslImm { dst: Operand, src: Operand, imm: u8 },
+
+    /// `lsl dst, src, #imm` - Logical shift left by immediate (32-bit).
+    Lsl32Imm { dst: Operand, src: Operand, imm: u8 },
+
+    /// `lsr dst, src, #imm` - Logical shift right by immediate (32-bit).
+    Lsr32Imm { dst: Operand, src: Operand, imm: u8 },
+
+    /// `asr dst, src, #imm` - Arithmetic shift right by immediate (32-bit).
+    Asr32Imm { dst: Operand, src: Operand, imm: u8 },
 
     // === Arithmetic instructions ===
     /// `add dst, src1, src2` - Add two registers.
@@ -775,6 +784,15 @@ impl fmt::Display for Aarch64Inst {
             Aarch64Inst::LdrIndexed { dst, base } => write!(f, "ldr {}, [{}]", dst, base),
             Aarch64Inst::StrIndexed { src, base } => write!(f, "str {}, [{}]", src, base),
             Aarch64Inst::LslImm { dst, src, imm } => write!(f, "lsl {}, {}, #{}", dst, src, imm),
+            Aarch64Inst::Lsl32Imm { dst, src, imm } => {
+                write!(f, "lsl {}, {}, #{} // 32-bit", dst, src, imm)
+            }
+            Aarch64Inst::Lsr32Imm { dst, src, imm } => {
+                write!(f, "lsr {}, {}, #{} // 32-bit", dst, src, imm)
+            }
+            Aarch64Inst::Asr32Imm { dst, src, imm } => {
+                write!(f, "asr {}, {}, #{} // 32-bit", dst, src, imm)
+            }
             Aarch64Inst::AddRR { dst, src1, src2 } => {
                 write!(f, "add {}, {}, {}", dst, src1, src2)
             }

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -767,6 +767,105 @@ impl RegAlloc {
                 }
             }
 
+            Aarch64Inst::Lsl32Imm { dst, src, imm } => {
+                let src_op = self.load_operand(mir, src, Reg::X10);
+
+                match self.get_allocation(dst) {
+                    Some(Allocation::Register(reg)) => {
+                        mir.push(Aarch64Inst::Lsl32Imm {
+                            dst: Operand::Physical(reg),
+                            src: src_op,
+                            imm,
+                        });
+                    }
+                    Some(Allocation::Spill(offset)) => {
+                        mir.push(Aarch64Inst::Lsl32Imm {
+                            dst: Operand::Physical(Reg::X9),
+                            src: src_op,
+                            imm,
+                        });
+                        mir.push(Aarch64Inst::Str {
+                            src: Operand::Physical(Reg::X9),
+                            base: Reg::Fp,
+                            offset,
+                        });
+                    }
+                    None => {
+                        mir.push(Aarch64Inst::Lsl32Imm {
+                            dst,
+                            src: src_op,
+                            imm,
+                        });
+                    }
+                }
+            }
+
+            Aarch64Inst::Lsr32Imm { dst, src, imm } => {
+                let src_op = self.load_operand(mir, src, Reg::X10);
+
+                match self.get_allocation(dst) {
+                    Some(Allocation::Register(reg)) => {
+                        mir.push(Aarch64Inst::Lsr32Imm {
+                            dst: Operand::Physical(reg),
+                            src: src_op,
+                            imm,
+                        });
+                    }
+                    Some(Allocation::Spill(offset)) => {
+                        mir.push(Aarch64Inst::Lsr32Imm {
+                            dst: Operand::Physical(Reg::X9),
+                            src: src_op,
+                            imm,
+                        });
+                        mir.push(Aarch64Inst::Str {
+                            src: Operand::Physical(Reg::X9),
+                            base: Reg::Fp,
+                            offset,
+                        });
+                    }
+                    None => {
+                        mir.push(Aarch64Inst::Lsr32Imm {
+                            dst,
+                            src: src_op,
+                            imm,
+                        });
+                    }
+                }
+            }
+
+            Aarch64Inst::Asr32Imm { dst, src, imm } => {
+                let src_op = self.load_operand(mir, src, Reg::X10);
+
+                match self.get_allocation(dst) {
+                    Some(Allocation::Register(reg)) => {
+                        mir.push(Aarch64Inst::Asr32Imm {
+                            dst: Operand::Physical(reg),
+                            src: src_op,
+                            imm,
+                        });
+                    }
+                    Some(Allocation::Spill(offset)) => {
+                        mir.push(Aarch64Inst::Asr32Imm {
+                            dst: Operand::Physical(Reg::X9),
+                            src: src_op,
+                            imm,
+                        });
+                        mir.push(Aarch64Inst::Str {
+                            src: Operand::Physical(Reg::X9),
+                            base: Reg::Fp,
+                            offset,
+                        });
+                    }
+                    None => {
+                        mir.push(Aarch64Inst::Asr32Imm {
+                            dst,
+                            src: src_op,
+                            imm,
+                        });
+                    }
+                }
+            }
+
             Aarch64Inst::StringConstPtr { dst, string_id } => match self.get_allocation(dst) {
                 Some(Allocation::Register(reg)) => {
                     mir.push(Aarch64Inst::StringConstPtr {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -811,7 +811,6 @@ impl<'a> CfgLower<'a> {
                 self.value_map.insert(value, vreg);
 
                 let lhs_vreg = self.get_vreg(*lhs);
-                let rhs_vreg = self.get_vreg(*rhs);
 
                 // Move LHS to result
                 self.mir.push(X86Inst::MovRR {
@@ -819,22 +818,43 @@ impl<'a> CfgLower<'a> {
                     src: Operand::Virtual(lhs_vreg),
                 });
 
-                // Move shift amount to RCX (CL is the low byte)
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Physical(Reg::Rcx),
-                    src: Operand::Virtual(rhs_vreg),
-                });
-
-                // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
-                // 32-bit shift masks by 31, 64-bit shift masks by 63
-                if ty.is_64_bit() {
-                    self.mir.push(X86Inst::ShlRCl {
-                        dst: Operand::Virtual(vreg),
-                    });
+                // Check if shift amount is a constant - use immediate form if so
+                let rhs_inst = &self.cfg.get_inst(*rhs).data;
+                if let CfgInstData::Const(shift_amount) = rhs_inst {
+                    let imm = *shift_amount as u8;
+                    // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
+                    if ty.is_64_bit() {
+                        self.mir.push(X86Inst::ShlRI {
+                            dst: Operand::Virtual(vreg),
+                            imm,
+                        });
+                    } else {
+                        self.mir.push(X86Inst::Shl32RI {
+                            dst: Operand::Virtual(vreg),
+                            imm,
+                        });
+                    }
                 } else {
-                    self.mir.push(X86Inst::Shl32RCl {
-                        dst: Operand::Virtual(vreg),
+                    // Variable shift amount - use CL register
+                    let rhs_vreg = self.get_vreg(*rhs);
+
+                    // Move shift amount to RCX (CL is the low byte)
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(Reg::Rcx),
+                        src: Operand::Virtual(rhs_vreg),
                     });
+
+                    // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
+                    // 32-bit shift masks by 31, 64-bit shift masks by 63
+                    if ty.is_64_bit() {
+                        self.mir.push(X86Inst::ShlRCl {
+                            dst: Operand::Virtual(vreg),
+                        });
+                    } else {
+                        self.mir.push(X86Inst::Shl32RCl {
+                            dst: Operand::Virtual(vreg),
+                        });
+                    }
                 }
             }
 
@@ -843,7 +863,6 @@ impl<'a> CfgLower<'a> {
                 self.value_map.insert(value, vreg);
 
                 let lhs_vreg = self.get_vreg(*lhs);
-                let rhs_vreg = self.get_vreg(*rhs);
 
                 // Move LHS to result
                 self.mir.push(X86Inst::MovRR {
@@ -851,26 +870,57 @@ impl<'a> CfgLower<'a> {
                     src: Operand::Virtual(lhs_vreg),
                 });
 
-                // Move shift amount to RCX (CL is the low byte)
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Physical(Reg::Rcx),
-                    src: Operand::Virtual(rhs_vreg),
-                });
-
-                // Use arithmetic shift (SAR) for signed types, logical shift (SHR) for unsigned
-                // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
-                if ty.is_64_bit() {
-                    if ty.is_signed() {
-                        self.mir.push(X86Inst::SarRCl {
+                // Check if shift amount is a constant - use immediate form if so.
+                // Note: x86 shift instructions mask the shift amount (by 31 for 32-bit,
+                // 63 for 64-bit), so we don't need to validate the range here - the
+                // hardware handles out-of-range shifts correctly.
+                let rhs_inst = &self.cfg.get_inst(*rhs).data;
+                if let CfgInstData::Const(shift_amount) = rhs_inst {
+                    let imm = *shift_amount as u8;
+                    // Use arithmetic shift (SAR) for signed types, logical shift (SHR) for unsigned
+                    // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
+                    if ty.is_64_bit() && ty.is_signed() {
+                        self.mir.push(X86Inst::SarRI {
                             dst: Operand::Virtual(vreg),
+                            imm,
+                        });
+                    } else if ty.is_64_bit() {
+                        self.mir.push(X86Inst::ShrRI {
+                            dst: Operand::Virtual(vreg),
+                            imm,
+                        });
+                    } else if ty.is_signed() {
+                        self.mir.push(X86Inst::Sar32RI {
+                            dst: Operand::Virtual(vreg),
+                            imm,
                         });
                     } else {
-                        self.mir.push(X86Inst::ShrRCl {
+                        self.mir.push(X86Inst::Shr32RI {
                             dst: Operand::Virtual(vreg),
+                            imm,
                         });
                     }
                 } else {
-                    if ty.is_signed() {
+                    // Variable shift amount - use CL register
+                    let rhs_vreg = self.get_vreg(*rhs);
+
+                    // Move shift amount to RCX (CL is the low byte)
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(Reg::Rcx),
+                        src: Operand::Virtual(rhs_vreg),
+                    });
+
+                    // Use arithmetic shift (SAR) for signed types, logical shift (SHR) for unsigned
+                    // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
+                    if ty.is_64_bit() && ty.is_signed() {
+                        self.mir.push(X86Inst::SarRCl {
+                            dst: Operand::Virtual(vreg),
+                        });
+                    } else if ty.is_64_bit() {
+                        self.mir.push(X86Inst::ShrRCl {
+                            dst: Operand::Virtual(vreg),
+                        });
+                    } else if ty.is_signed() {
                         self.mir.push(X86Inst::Sar32RCl {
                             dst: Operand::Virtual(vreg),
                         });

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -355,6 +355,9 @@ impl<'a> Emitter<'a> {
             X86Inst::ShlRI { dst, imm } => {
                 self.emit_shl_imm(dst.as_physical(), *imm);
             }
+            X86Inst::Shl32RI { dst, imm } => {
+                self.emit_shl32_imm(dst.as_physical(), *imm);
+            }
             X86Inst::ShrRCl { dst } => {
                 self.emit_shr_cl(dst.as_physical());
             }
@@ -364,6 +367,9 @@ impl<'a> Emitter<'a> {
             X86Inst::ShrRI { dst, imm } => {
                 self.emit_shr_imm(dst.as_physical(), *imm);
             }
+            X86Inst::Shr32RI { dst, imm } => {
+                self.emit_shr32_imm(dst.as_physical(), *imm);
+            }
             X86Inst::SarRCl { dst } => {
                 self.emit_sar_cl(dst.as_physical());
             }
@@ -372,6 +378,9 @@ impl<'a> Emitter<'a> {
             }
             X86Inst::SarRI { dst, imm } => {
                 self.emit_sar_imm(dst.as_physical(), *imm);
+            }
+            X86Inst::Sar32RI { dst, imm } => {
+                self.emit_sar32_imm(dst.as_physical(), *imm);
             }
             X86Inst::Cdq => {
                 self.emit_cdq();
@@ -1308,6 +1317,27 @@ impl<'a> Emitter<'a> {
         self.code.push(imm);
     }
 
+    /// Emit `shl r32, imm8`.
+    ///
+    /// Encoding: C1 /4 imm8 (shl r/m32, imm8) - no REX.W for 32-bit
+    fn emit_shl32_imm(&mut self, dst: Reg, imm: u8) {
+        let dst_enc = dst.encoding();
+
+        // REX prefix only if needed for extended registers (no REX.W for 32-bit)
+        if dst.needs_rex() {
+            self.code.push(0x41); // REX.B
+        }
+
+        // Opcode: C1 (group 2, shift by imm8)
+        self.code.push(0xC1);
+
+        // ModR/M: mod=11, reg=4 (SHL), r/m=dst
+        self.code.push(0xE0 | (dst_enc & 7));
+
+        // Immediate
+        self.code.push(imm);
+    }
+
     /// Emit `shr r64, cl`.
     ///
     /// Encoding: REX.W D3 /5 (shr r/m64, CL)
@@ -1351,6 +1381,27 @@ impl<'a> Emitter<'a> {
         self.code.push(imm);
     }
 
+    /// Emit `shr r32, imm8`.
+    ///
+    /// Encoding: C1 /5 imm8 (shr r/m32, imm8) - no REX.W for 32-bit
+    fn emit_shr32_imm(&mut self, dst: Reg, imm: u8) {
+        let dst_enc = dst.encoding();
+
+        // REX prefix only if needed for extended registers (no REX.W for 32-bit)
+        if dst.needs_rex() {
+            self.code.push(0x41); // REX.B
+        }
+
+        // Opcode: C1 (group 2, shift by imm8)
+        self.code.push(0xC1);
+
+        // ModR/M: mod=11, reg=5 (SHR), r/m=dst
+        self.code.push(0xE8 | (dst_enc & 7));
+
+        // Immediate
+        self.code.push(imm);
+    }
+
     /// Emit `sar r64, cl`.
     ///
     /// Encoding: REX.W D3 /7 (sar r/m64, CL)
@@ -1383,6 +1434,27 @@ impl<'a> Emitter<'a> {
             rex |= 0x01; // REX.B
         }
         self.code.push(rex);
+
+        // Opcode: C1 (group 2, shift by imm8)
+        self.code.push(0xC1);
+
+        // ModR/M: mod=11, reg=7 (SAR), r/m=dst
+        self.code.push(0xF8 | (dst_enc & 7));
+
+        // Immediate
+        self.code.push(imm);
+    }
+
+    /// Emit `sar r32, imm8`.
+    ///
+    /// Encoding: C1 /7 imm8 (sar r/m32, imm8) - no REX.W for 32-bit
+    fn emit_sar32_imm(&mut self, dst: Reg, imm: u8) {
+        let dst_enc = dst.encoding();
+
+        // REX prefix only if needed for extended registers (no REX.W for 32-bit)
+        if dst.needs_rex() {
+            self.code.push(0x41); // REX.B
+        }
 
         // Opcode: C1 (group 2, shift by imm8)
         self.code.push(0xC1);

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -210,7 +210,12 @@ fn uses(inst: &X86Inst) -> Vec<VReg> {
             // dst is both read and written, CL is implicit physical register
             add_if_virtual(dst, &mut result);
         }
-        X86Inst::ShlRI { dst, .. } | X86Inst::ShrRI { dst, .. } | X86Inst::SarRI { dst, .. } => {
+        X86Inst::ShlRI { dst, .. }
+        | X86Inst::Shl32RI { dst, .. }
+        | X86Inst::ShrRI { dst, .. }
+        | X86Inst::Shr32RI { dst, .. }
+        | X86Inst::SarRI { dst, .. }
+        | X86Inst::Sar32RI { dst, .. } => {
             // dst is both read and written
             add_if_virtual(dst, &mut result);
         }
@@ -336,12 +341,15 @@ fn defs(inst: &X86Inst) -> Vec<VReg> {
         | X86Inst::ShlRCl { dst }
         | X86Inst::Shl32RCl { dst }
         | X86Inst::ShlRI { dst, .. }
+        | X86Inst::Shl32RI { dst, .. }
         | X86Inst::ShrRCl { dst }
         | X86Inst::Shr32RCl { dst }
         | X86Inst::ShrRI { dst, .. }
+        | X86Inst::Shr32RI { dst, .. }
         | X86Inst::SarRCl { dst }
         | X86Inst::Sar32RCl { dst }
-        | X86Inst::SarRI { dst, .. } => {
+        | X86Inst::SarRI { dst, .. }
+        | X86Inst::Sar32RI { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
         X86Inst::IdivR { .. } => {

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -283,8 +283,11 @@ pub enum X86Inst {
     /// `shl dst, cl` - Shift left 32-bit by count in CL register (dst = dst << CL).
     Shl32RCl { dst: Operand },
 
-    /// `shl dst, imm` - Shift left by immediate (dst = dst << imm).
+    /// `shl dst, imm` - Shift left 64-bit by immediate (dst = dst << imm).
     ShlRI { dst: Operand, imm: u8 },
+
+    /// `shl dst, imm` - Shift left 32-bit by immediate (dst = dst << imm).
+    Shl32RI { dst: Operand, imm: u8 },
 
     /// `shr dst, cl` - Logical shift right 64-bit by count in CL register (dst = dst >> CL).
     ShrRCl { dst: Operand },
@@ -292,8 +295,11 @@ pub enum X86Inst {
     /// `shr dst, cl` - Logical shift right 32-bit by count in CL register (dst = dst >> CL).
     Shr32RCl { dst: Operand },
 
-    /// `shr dst, imm` - Logical shift right by immediate (dst = dst >> imm).
+    /// `shr dst, imm` - Logical shift right 64-bit by immediate (dst = dst >> imm).
     ShrRI { dst: Operand, imm: u8 },
+
+    /// `shr dst, imm` - Logical shift right 32-bit by immediate (dst = dst >> imm).
+    Shr32RI { dst: Operand, imm: u8 },
 
     /// `sar dst, cl` - Arithmetic shift right 64-bit by count in CL register.
     SarRCl { dst: Operand },
@@ -301,8 +307,11 @@ pub enum X86Inst {
     /// `sar dst, cl` - Arithmetic shift right 32-bit by count in CL register.
     Sar32RCl { dst: Operand },
 
-    /// `sar dst, imm` - Arithmetic shift right by immediate.
+    /// `sar dst, imm` - Arithmetic shift right 64-bit by immediate.
     SarRI { dst: Operand, imm: u8 },
+
+    /// `sar dst, imm` - Arithmetic shift right 32-bit by immediate.
+    Sar32RI { dst: Operand, imm: u8 },
 
     /// `cdq` - Sign-extend EAX into EDX:EAX (for division).
     Cdq,
@@ -517,13 +526,16 @@ impl fmt::Display for X86Inst {
             X86Inst::NotR { dst } => write!(f, "not {}", dst),
             X86Inst::ShlRCl { dst } => write!(f, "shlq {}, cl", dst),
             X86Inst::Shl32RCl { dst } => write!(f, "shll {}, cl", dst),
-            X86Inst::ShlRI { dst, imm } => write!(f, "shl {}, {}", dst, imm),
+            X86Inst::ShlRI { dst, imm } => write!(f, "shlq {}, {}", dst, imm),
+            X86Inst::Shl32RI { dst, imm } => write!(f, "shll {}, {}", dst, imm),
             X86Inst::ShrRCl { dst } => write!(f, "shrq {}, cl", dst),
             X86Inst::Shr32RCl { dst } => write!(f, "shrl {}, cl", dst),
-            X86Inst::ShrRI { dst, imm } => write!(f, "shr {}, {}", dst, imm),
+            X86Inst::ShrRI { dst, imm } => write!(f, "shrq {}, {}", dst, imm),
+            X86Inst::Shr32RI { dst, imm } => write!(f, "shrl {}, {}", dst, imm),
             X86Inst::SarRCl { dst } => write!(f, "sarq {}, cl", dst),
             X86Inst::Sar32RCl { dst } => write!(f, "sarl {}, cl", dst),
-            X86Inst::SarRI { dst, imm } => write!(f, "sar {}, {}", dst, imm),
+            X86Inst::SarRI { dst, imm } => write!(f, "sarq {}, {}", dst, imm),
+            X86Inst::Sar32RI { dst, imm } => write!(f, "sarl {}, {}", dst, imm),
             X86Inst::Cdq => write!(f, "cdq"),
             X86Inst::IdivR { src } => write!(f, "idiv {}", src),
             X86Inst::CmpRR { src1, src2 } => write!(f, "cmp {}, {}", src1, src2),

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -399,6 +399,10 @@ impl RegAlloc {
                 self.emit_unop_imm_u8(mir, dst, imm, |d, i| X86Inst::ShlRI { dst: d, imm: i });
             }
 
+            X86Inst::Shl32RI { dst, imm } => {
+                self.emit_unop_imm_u8(mir, dst, imm, |d, i| X86Inst::Shl32RI { dst: d, imm: i });
+            }
+
             X86Inst::ShrRCl { dst } => {
                 self.emit_unop(mir, dst, |d| X86Inst::ShrRCl { dst: d });
             }
@@ -411,6 +415,10 @@ impl RegAlloc {
                 self.emit_unop_imm_u8(mir, dst, imm, |d, i| X86Inst::ShrRI { dst: d, imm: i });
             }
 
+            X86Inst::Shr32RI { dst, imm } => {
+                self.emit_unop_imm_u8(mir, dst, imm, |d, i| X86Inst::Shr32RI { dst: d, imm: i });
+            }
+
             X86Inst::SarRCl { dst } => {
                 self.emit_unop(mir, dst, |d| X86Inst::SarRCl { dst: d });
             }
@@ -421,6 +429,10 @@ impl RegAlloc {
 
             X86Inst::SarRI { dst, imm } => {
                 self.emit_unop_imm_u8(mir, dst, imm, |d, i| X86Inst::SarRI { dst: d, imm: i });
+            }
+
+            X86Inst::Sar32RI { dst, imm } => {
+                self.emit_unop_imm_u8(mir, dst, imm, |d, i| X86Inst::Sar32RI { dst: d, imm: i });
             }
 
             X86Inst::IdivR { src } => {


### PR DESCRIPTION
When shift amounts are compile-time constants, use immediate shift instructions instead of loading the shift amount into a register.

For x86_64:
- ShlRI/Shl32RI for left shift by immediate
- ShrRI/Shr32RI for logical right shift by immediate  
- SarRI/Sar32RI for arithmetic right shift by immediate
- Avoids moving constant to RCX for CL-based shifts

For aarch64:
- LslImm/Lsl32Imm for left shift by immediate
- LsrImm/Lsr32Imm for logical right shift by immediate
- AsrImm/Asr32Imm for arithmetic right shift by immediate
- Only uses immediate form when shift is in valid range (0 to bit_width-1) to avoid arithmetic overflow in UBFM/SBFM encoding

This optimization reduces register pressure and generates more efficient code for common constant shift patterns.

Addresses rue-4ap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)