### PR TITLE
Spec: document negated MIN literal semantics

### DIFF
--- a/crates/rue-spec/cases/expressions/arithmetic.toml
+++ b/crates/rue-spec/cases/expressions/arithmetic.toml
@@ -364,6 +364,68 @@ source = "fn main() -> i32 { -10 % 3 }"
 exit_code = 255
 
 # =============================================================================
+# Negated MIN Literals (Compile-Time Constant)
+# =============================================================================
+# These tests verify that negated MIN value literals are evaluated at compile
+# time, avoiding runtime overflow.
+
+[[case]]
+name = "negated_min_literal_i8"
+spec = ["4.2:15"]
+description = "Negated i8::MIN literal is a compile-time constant"
+source = """
+fn main() -> i32 {
+    let x: i8 = -128;
+    if x < 0 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "negated_min_literal_i32"
+spec = ["4.2:15"]
+description = "Negated i32::MIN literal is a compile-time constant"
+source = """
+fn main() -> i32 {
+    let x: i32 = -2147483648;
+    if x < 0 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+# =============================================================================
+# Runtime Negation of MIN Value (Overflow)
+# =============================================================================
+# These tests verify that negating a non-literal MIN value at runtime
+# causes an overflow panic.
+
+[[case]]
+name = "runtime_negation_min_i32"
+spec = ["4.2:16"]
+description = "Negating i32::MIN at runtime causes overflow"
+source = """
+fn main() -> i32 {
+    let x: i32 = -2147483648;
+    let y: i32 = -x;
+    y
+}
+"""
+runtime_error = "integer overflow"
+
+[[case]]
+name = "runtime_negation_min_i8"
+spec = ["4.2:16"]
+description = "Negating i8::MIN at runtime causes overflow"
+source = """
+fn main() -> i32 {
+    let x: i8 = -128;
+    let y: i8 = -x;
+    0
+}
+"""
+runtime_error = "integer overflow"
+
+# =============================================================================
 # Unsigned Negation is an Error
 # =============================================================================
 

--- a/crates/rue-spec/cases/types/integers.toml
+++ b/crates/rue-spec/cases/types/integers.toml
@@ -966,7 +966,7 @@ error_contains = "out of range"
 
 [[case]]
 name = "i8_min_via_negation"
-spec = ["3.1:17"]
+spec = ["3.1:18"]
 description = "i8::MIN (-128) via negation is valid"
 source = """
 fn main() -> i32 {
@@ -978,7 +978,7 @@ exit_code = 1
 
 [[case]]
 name = "i16_min_via_negation"
-spec = ["3.1:17"]
+spec = ["3.1:18"]
 description = "i16::MIN (-32768) via negation is valid"
 source = """
 fn main() -> i32 {
@@ -990,7 +990,7 @@ exit_code = 1
 
 [[case]]
 name = "i32_min_via_negation"
-spec = ["3.1:17"]
+spec = ["3.1:18"]
 description = "i32::MIN (-2147483648) via negation is valid"
 source = """
 fn main() -> i32 {
@@ -1002,7 +1002,7 @@ exit_code = 1
 
 [[case]]
 name = "i64_min_via_negation"
-spec = ["3.1:17"]
+spec = ["3.1:18"]
 description = "i64::MIN (-9223372036854775808) via negation is valid"
 source = """
 fn main() -> i32 {

--- a/docs/spec/src/03-types/01-integer-types.md
+++ b/docs/spec/src/03-types/01-integer-types.md
@@ -96,7 +96,23 @@ fn main() -> i32 {
 
 A compile-time error occurs when an integer literal value exceeds the representable range of its target type.
 
-{{ rule(id="3.1:18") }}
+{{ rule(id="3.1:18", cat="normative") }}
+
+When an integer literal is the operand of a unary negation operator, and the negated value would be representable in the target signed integer type, the expression is valid even if the literal value itself exceeds the positive range of that type. This allows the minimum value of each signed integer type to be written as a negated literal.
+
+{{ rule(id="3.1:19") }}
+
+```rue
+fn main() -> i32 {
+    let a: i8 = -128;                       // valid: -128 is in i8 range
+    let b: i8 = 128;                        // error: 128 exceeds i8 range
+    let c: i32 = -2147483648;               // valid: i32 minimum value
+    let d: i64 = -9223372036854775808;      // valid: i64 minimum value
+    0
+}
+```
+
+{{ rule(id="3.1:20") }}
 
 ```rue
 fn main() -> i32 {

--- a/docs/spec/src/04-expressions/02-arithmetic-operators.md
+++ b/docs/spec/src/04-expressions/02-arithmetic-operators.md
@@ -78,6 +78,24 @@ fn main() -> i32 {
 }
 ```
 
+{{ rule(id="4.2:15", cat="normative") }}
+
+When a negated integer literal represents the minimum value of a signed integer type, the compiler evaluates the negation at compile time and produces the minimum value directly. This special case allows expressions like `-128: i8` without runtime overflow.
+
+{{ rule(id="4.2:16", cat="normative") }}
+
+When negation is applied to a non-literal expression holding the minimum value of a signed integer type, the operation overflows and causes a runtime panic.
+
+{{ rule(id="4.2:17") }}
+
+```rue
+fn main() -> i32 {
+    let x: i8 = -128;    // valid: compile-time constant
+    let y: i8 = -x;      // runtime panic: negating -128 overflows
+    0
+}
+```
+
 ## Overflow
 
 {{ rule(id="4.2:9", cat="normative") }}


### PR DESCRIPTION
Add spec paragraphs clarifying how negative minimum signed integer values (like -128 for i8) are handled:

- 3.1:18: Negated literals are valid when the result is in range
- 4.2:15: Compiler evaluates MIN literal negation at compile time
- 4.2:16: Runtime negation of MIN value causes overflow panic

This documents existing behavior where -128: i8 works despite 128 being out of range for i8, because the compiler recognizes this pattern and produces the constant directly.

Fixes rue-tic

🤖 Generated with [Claude Code](https://claude.com/claude-code)