### PR TITLE
Extract shared codegen utilities to types module

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -11,6 +11,7 @@ use rue_cfg::{
 };
 
 use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Operand, Reg, VReg};
+use crate::types;
 
 /// Argument passing registers per AAPCS64.
 const ARG_REGS: [Reg; 8] = [
@@ -137,62 +138,22 @@ impl<'a> CfgLower<'a> {
 
     /// Get the array type definition.
     fn array_type_def(&self, array_type_id: ArrayTypeId) -> Option<&ArrayTypeDef> {
-        self.array_types.get(array_type_id.0 as usize)
+        types::array_type_def(self.array_types, array_type_id)
     }
 
     /// Calculate the total number of slots needed to store a type.
-    /// For scalars, this is 1. For arrays, it's length * slot_count(element_type).
-    /// For structs, this is the sum of slot counts for all fields.
-    /// For nested types, this recursively calculates.
     fn type_slot_count(&self, ty: Type) -> u32 {
-        match ty {
-            Type::Array(array_type_id) => {
-                if let Some(def) = self.array_type_def(array_type_id) {
-                    let elem_slots = self.type_slot_count(def.element_type);
-                    (def.length as u32) * elem_slots
-                } else {
-                    1
-                }
-            }
-            Type::Struct(struct_id) => {
-                // Sum the slot counts of all fields
-                if let Some(struct_def) = self.struct_defs.get(struct_id.0 as usize) {
-                    let mut total = 0u32;
-                    for field in &struct_def.fields {
-                        total += self.type_slot_count(field.ty);
-                    }
-                    total.max(1) // At least 1 slot even for empty struct
-                } else {
-                    1
-                }
-            }
-            _ => 1,
-        }
+        types::type_slot_count(self.struct_defs, self.array_types, ty)
     }
 
     /// Calculate the slot count for a single element of an array type.
     fn array_element_slot_count(&self, array_type_id: ArrayTypeId) -> u32 {
-        if let Some(def) = self.array_type_def(array_type_id) {
-            self.type_slot_count(def.element_type)
-        } else {
-            1
-        }
+        types::array_element_slot_count(self.struct_defs, self.array_types, array_type_id)
     }
 
     /// Calculate the slot offset for a field within a struct.
-    /// This accounts for the sizes of all preceding fields.
     fn struct_field_slot_offset(&self, struct_id: StructId, field_index: u32) -> u32 {
-        if let Some(struct_def) = self.struct_defs.get(struct_id.0 as usize) {
-            let mut offset = 0u32;
-            for i in 0..(field_index as usize) {
-                if let Some(field) = struct_def.fields.get(i) {
-                    offset += self.type_slot_count(field.ty);
-                }
-            }
-            offset
-        } else {
-            field_index // Fallback to field index if struct not found
-        }
+        types::struct_field_slot_offset(self.struct_defs, self.array_types, struct_id, field_index)
     }
 
     /// Trace back through a chain of FieldGet instructions to find the original

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -14,6 +14,7 @@
 //! virtual registers to physical registers before final emission.
 
 pub mod aarch64;
+pub mod types;
 pub mod x86_64;
 
 /// A relocation emitted by the code generator.

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -1,0 +1,81 @@
+//! Shared type utilities for code generation backends.
+//!
+//! This module provides common functions for calculating type sizes and
+//! field offsets, shared between x86_64 and aarch64 backends.
+
+use rue_air::{ArrayTypeDef, ArrayTypeId};
+use rue_cfg::{StructDef, StructId, Type};
+
+/// Get the array type definition for an array type ID.
+pub fn array_type_def<'a>(
+    array_types: &'a [ArrayTypeDef],
+    array_type_id: ArrayTypeId,
+) -> Option<&'a ArrayTypeDef> {
+    array_types.get(array_type_id.0 as usize)
+}
+
+/// Calculate the total number of slots needed to store a type.
+///
+/// For scalars, this is 1. For arrays, it's `length * slot_count(element_type)`.
+/// For structs, this is the sum of slot counts for all fields.
+/// For nested types, this recursively calculates.
+pub fn type_slot_count(struct_defs: &[StructDef], array_types: &[ArrayTypeDef], ty: Type) -> u32 {
+    match ty {
+        Type::Array(array_type_id) => {
+            if let Some(def) = array_type_def(array_types, array_type_id) {
+                let elem_slots = type_slot_count(struct_defs, array_types, def.element_type);
+                (def.length as u32) * elem_slots
+            } else {
+                1
+            }
+        }
+        Type::Struct(struct_id) => {
+            // Sum the slot counts of all fields
+            if let Some(struct_def) = struct_defs.get(struct_id.0 as usize) {
+                let mut total = 0u32;
+                for field in &struct_def.fields {
+                    total += type_slot_count(struct_defs, array_types, field.ty);
+                }
+                total.max(1) // At least 1 slot even for empty struct
+            } else {
+                1
+            }
+        }
+        _ => 1,
+    }
+}
+
+/// Calculate the slot count for a single element of an array type.
+pub fn array_element_slot_count(
+    struct_defs: &[StructDef],
+    array_types: &[ArrayTypeDef],
+    array_type_id: ArrayTypeId,
+) -> u32 {
+    if let Some(def) = array_type_def(array_types, array_type_id) {
+        type_slot_count(struct_defs, array_types, def.element_type)
+    } else {
+        1
+    }
+}
+
+/// Calculate the slot offset for a field within a struct.
+///
+/// This accounts for the sizes of all preceding fields.
+pub fn struct_field_slot_offset(
+    struct_defs: &[StructDef],
+    array_types: &[ArrayTypeDef],
+    struct_id: StructId,
+    field_index: u32,
+) -> u32 {
+    if let Some(struct_def) = struct_defs.get(struct_id.0 as usize) {
+        let mut offset = 0u32;
+        for i in 0..(field_index as usize) {
+            if let Some(field) = struct_def.fields.get(i) {
+                offset += type_slot_count(struct_defs, array_types, field.ty);
+            }
+        }
+        offset
+    } else {
+        field_index // Fallback to field index if struct not found
+    }
+}

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -11,6 +11,7 @@ use rue_cfg::{
 };
 
 use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
+use crate::types;
 
 /// Argument passing registers per System V AMD64 ABI.
 const ARG_REGS: [Reg; 6] = [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9];
@@ -125,62 +126,22 @@ impl<'a> CfgLower<'a> {
 
     /// Get the array type definition.
     fn array_type_def(&self, array_type_id: ArrayTypeId) -> Option<&ArrayTypeDef> {
-        self.array_types.get(array_type_id.0 as usize)
+        types::array_type_def(self.array_types, array_type_id)
     }
 
     /// Calculate the total number of slots needed to store a type.
-    /// For scalars, this is 1. For arrays, it's length * slot_count(element_type).
-    /// For structs, this is the sum of slot counts for all fields.
-    /// For nested types, this recursively calculates.
     fn type_slot_count(&self, ty: Type) -> u32 {
-        match ty {
-            Type::Array(array_type_id) => {
-                if let Some(def) = self.array_type_def(array_type_id) {
-                    let elem_slots = self.type_slot_count(def.element_type);
-                    (def.length as u32) * elem_slots
-                } else {
-                    1
-                }
-            }
-            Type::Struct(struct_id) => {
-                // Sum the slot counts of all fields
-                if let Some(struct_def) = self.struct_defs.get(struct_id.0 as usize) {
-                    let mut total = 0u32;
-                    for field in &struct_def.fields {
-                        total += self.type_slot_count(field.ty);
-                    }
-                    total.max(1) // At least 1 slot even for empty struct
-                } else {
-                    1
-                }
-            }
-            _ => 1,
-        }
+        types::type_slot_count(self.struct_defs, self.array_types, ty)
     }
 
     /// Calculate the slot count for a single element of an array type.
     fn array_element_slot_count(&self, array_type_id: ArrayTypeId) -> u32 {
-        if let Some(def) = self.array_type_def(array_type_id) {
-            self.type_slot_count(def.element_type)
-        } else {
-            1
-        }
+        types::array_element_slot_count(self.struct_defs, self.array_types, array_type_id)
     }
 
     /// Calculate the slot offset for a field within a struct.
-    /// This accounts for the sizes of all preceding fields.
     fn struct_field_slot_offset(&self, struct_id: StructId, field_index: u32) -> u32 {
-        if let Some(struct_def) = self.struct_defs.get(struct_id.0 as usize) {
-            let mut offset = 0u32;
-            for i in 0..(field_index as usize) {
-                if let Some(field) = struct_def.fields.get(i) {
-                    offset += self.type_slot_count(field.ty);
-                }
-            }
-            offset
-        } else {
-            field_index // Fallback to field index if struct not found
-        }
+        types::struct_field_slot_offset(self.struct_defs, self.array_types, struct_id, field_index)
     }
 
     /// Trace back through a chain of FieldGet instructions to find the original


### PR DESCRIPTION
Move duplicated type utility functions from x86_64 and aarch64 backends to a shared crate::types module:
- array_type_def
- type_slot_count  
- array_element_slot_count
- struct_field_slot_offset

Both backends now delegate to these shared functions, reducing code duplication and maintenance burden.

Fixes rue-5y7