### PR TITLE
Add spec tests for let shadowing scope (5.1:12)

### DIFF
--- a/crates/rue-spec/cases/statements/let.toml
+++ b/crates/rue-spec/cases/statements/let.toml
@@ -92,6 +92,30 @@ fn main() -> i32 {
 exit_code = 15
 
 [[case]]
+name = "let_shadow_multiple_refs_in_init"
+spec = ["5.1:12"]
+source = """
+fn main() -> i32 {
+    let x = 5;
+    let x = x + x;
+    x
+}
+"""
+exit_code = 10
+
+[[case]]
+name = "let_shadow_complex_init_expr"
+spec = ["5.1:12"]
+source = """
+fn main() -> i32 {
+    let x = 3;
+    let x = x * (x + 1);
+    x
+}
+"""
+exit_code = 12
+
+[[case]]
 name = "let_shadow_different_type"
 spec = ["5.1:10", "5.1:11"]
 source = """
@@ -102,6 +126,35 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+[[case]]
+name = "let_shadow_in_fn_call"
+spec = ["5.1:12"]
+source = """
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+fn main() -> i32 {
+    let x = 10;
+    let x = add(x, 5);
+    x
+}
+"""
+exit_code = 15
+
+[[case]]
+name = "let_shadow_chained"
+spec = ["5.1:12"]
+source = """
+fn main() -> i32 {
+    let x = 1;
+    let x = x + 1;
+    let x = x + 1;
+    let x = x + 1;
+    x
+}
+"""
+exit_code = 4
 
 [[case]]
 name = "let_complex_expression"


### PR DESCRIPTION
Add 4 additional test cases to strengthen coverage of spec rule 5.1:12, which clarifies that the scope of a let binding begins after the complete statement, so initializer expressions resolve to the previous binding:

- let_shadow_multiple_refs_in_init: x + x uses previous binding twice
- let_shadow_complex_init_expr: nested expression with shadowed variable
- let_shadow_in_fn_call: shadowed variable as function argument
- let_shadow_chained: successive shadowings accumulate correctly

Fixes rue-8p2

🤖 Generated with [Claude Code](https://claude.com/claude-code)