### PR TITLE
Unify VReg and LabelId across codegen backends

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -233,66 +233,19 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Recursively collect all scalar vregs from an array value.
-    /// For nested arrays, this flattens them to a list of scalar vregs.
+    /// Delegates to the shared implementation in `types`.
     fn collect_array_scalar_vregs(&mut self, value: CfgValue) -> Vec<VReg> {
-        let inst = self.cfg.get_inst(value);
-        match &inst.data.clone() {
-            CfgInstData::ArrayInit { elements, .. } => {
-                let mut result = Vec::new();
-                for elem in elements {
-                    let elem_inst = self.cfg.get_inst(*elem);
-                    if matches!(elem_inst.ty, Type::Array(_)) {
-                        // Recursively collect from nested array
-                        result.extend(self.collect_array_scalar_vregs(*elem));
-                    } else {
-                        // Scalar element - get its vreg
-                        result.push(self.get_vreg(*elem));
-                    }
-                }
-                result
-            }
-            _ => {
-                // For non-ArrayInit sources, try struct_slot_vregs cache
-                if let Some(vregs) = self.struct_slot_vregs.get(&value).cloned() {
-                    vregs
-                } else {
-                    vec![self.get_vreg(value)]
-                }
-            }
-        }
+        // Clone struct_slot_vregs to avoid borrow conflict with get_vreg
+        let slot_vregs = self.struct_slot_vregs.clone();
+        types::collect_array_scalar_vregs(self.cfg, &slot_vregs, value, &mut |v| self.get_vreg(v))
     }
 
     /// Recursively collect all scalar vregs from a struct value.
-    /// This flattens any array fields to their scalar elements.
+    /// Delegates to the shared implementation in `types`.
     fn collect_struct_scalar_vregs(&mut self, value: CfgValue) -> Vec<VReg> {
-        let inst = self.cfg.get_inst(value);
-        match &inst.data.clone() {
-            CfgInstData::StructInit { fields, .. } => {
-                let mut result = Vec::new();
-                for field in fields {
-                    let field_inst = self.cfg.get_inst(*field);
-                    if matches!(field_inst.ty, Type::Array(_)) {
-                        // Recursively collect from array field
-                        result.extend(self.collect_array_scalar_vregs(*field));
-                    } else if matches!(field_inst.ty, Type::Struct(_)) {
-                        // Recursively collect from nested struct field
-                        result.extend(self.collect_struct_scalar_vregs(*field));
-                    } else {
-                        // Scalar field - get its vreg
-                        result.push(self.get_vreg(*field));
-                    }
-                }
-                result
-            }
-            _ => {
-                // For non-StructInit sources, try struct_slot_vregs cache
-                if let Some(vregs) = self.struct_slot_vregs.get(&value).cloned() {
-                    vregs
-                } else {
-                    vec![self.get_vreg(value)]
-                }
-            }
-        }
+        // Clone struct_slot_vregs to avoid borrow conflict with get_vreg
+        let slot_vregs = self.struct_slot_vregs.clone();
+        types::collect_struct_scalar_vregs(self.cfg, &slot_vregs, value, &mut |v| self.get_vreg(v))
     }
 
     /// Calculate the stack offset for a local variable slot.

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -7,59 +7,7 @@
 
 use std::fmt;
 
-/// A virtual register.
-///
-/// Virtual registers are unlimited and allocated to physical registers
-/// during register allocation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct VReg(u32);
-
-impl VReg {
-    /// Create a new virtual register with the given index.
-    #[inline]
-    pub const fn new(index: u32) -> Self {
-        Self(index)
-    }
-
-    /// Get the index of this virtual register.
-    #[inline]
-    pub const fn index(self) -> u32 {
-        self.0
-    }
-}
-
-impl fmt::Display for VReg {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "v{}", self.0)
-    }
-}
-
-/// A label identifier.
-///
-/// Labels are local to a function and are represented as a lightweight u32 index
-/// rather than as heap-allocated strings. This avoids allocations during codegen.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct LabelId(u32);
-
-impl LabelId {
-    /// Create a new label with the given index.
-    #[inline]
-    pub const fn new(index: u32) -> Self {
-        Self(index)
-    }
-
-    /// Get the index of this label.
-    #[inline]
-    pub const fn index(self) -> u32 {
-        self.0
-    }
-}
-
-impl fmt::Display for LabelId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, ".L{}", self.0)
-    }
-}
+pub use crate::vreg::{LabelId, VReg};
 
 /// A physical AArch64 register.
 ///

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod aarch64;
 pub mod types;
+pub mod vreg;
 pub mod x86_64;
 
 /// A relocation emitted by the code generator.
@@ -45,8 +46,11 @@ pub struct MachineCode {
 // Re-export the generate function for x86_64 (default)
 pub use x86_64::generate;
 
-// Re-export commonly used types for convenience
-pub use x86_64::{Operand, Reg, VReg, X86Inst, X86Mir};
+// Re-export shared types
+pub use vreg::{LabelId, VReg};
+
+// Re-export commonly used x86_64 types for convenience
+pub use x86_64::{Operand, Reg, X86Inst, X86Mir};
 
 #[cfg(test)]
 mod tests {

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -4,7 +4,10 @@
 //! field offsets, shared between x86_64 and aarch64 backends.
 
 use rue_air::{ArrayTypeDef, ArrayTypeId};
-use rue_cfg::{StructDef, StructId, Type};
+use rue_cfg::{Cfg, CfgInstData, CfgValue, StructDef, StructId, Type};
+use std::collections::HashMap;
+
+use crate::vreg::VReg;
 
 /// Get the array type definition for an array type ID.
 pub fn array_type_def<'a>(
@@ -77,5 +80,111 @@ pub fn struct_field_slot_offset(
         offset
     } else {
         field_index // Fallback to field index if struct not found
+    }
+}
+
+/// Recursively collect all scalar vregs from an array value.
+///
+/// For nested arrays, this flattens them to a list of scalar vregs.
+/// This is used during code generation to handle array arguments that need
+/// to be passed in registers or stored to memory slot by slot.
+///
+/// # Arguments
+/// * `cfg` - The control flow graph containing the instructions
+/// * `struct_slot_vregs` - Cache mapping CFG values to their slot vregs
+/// * `value` - The CFG value to collect vregs from
+/// * `get_vreg` - Closure to get/allocate a vreg for a given CFG value
+pub fn collect_array_scalar_vregs(
+    cfg: &Cfg,
+    struct_slot_vregs: &HashMap<CfgValue, Vec<VReg>>,
+    value: CfgValue,
+    get_vreg: &mut impl FnMut(CfgValue) -> VReg,
+) -> Vec<VReg> {
+    let inst = cfg.get_inst(value);
+    match &inst.data {
+        CfgInstData::ArrayInit { elements, .. } => {
+            let mut result = Vec::new();
+            for elem in elements {
+                let elem_inst = cfg.get_inst(*elem);
+                if matches!(elem_inst.ty, Type::Array(_)) {
+                    // Recursively collect from nested array
+                    result.extend(collect_array_scalar_vregs(
+                        cfg,
+                        struct_slot_vregs,
+                        *elem,
+                        get_vreg,
+                    ));
+                } else {
+                    // Scalar element - get its vreg
+                    result.push(get_vreg(*elem));
+                }
+            }
+            result
+        }
+        _ => {
+            // For non-ArrayInit sources, try struct_slot_vregs cache
+            if let Some(vregs) = struct_slot_vregs.get(&value).cloned() {
+                vregs
+            } else {
+                vec![get_vreg(value)]
+            }
+        }
+    }
+}
+
+/// Recursively collect all scalar vregs from a struct value.
+///
+/// This flattens any array fields to their scalar elements.
+/// This is used during code generation to handle struct arguments that need
+/// to be passed in registers or stored to memory slot by slot.
+///
+/// # Arguments
+/// * `cfg` - The control flow graph containing the instructions
+/// * `struct_slot_vregs` - Cache mapping CFG values to their slot vregs
+/// * `value` - The CFG value to collect vregs from
+/// * `get_vreg` - Closure to get/allocate a vreg for a given CFG value
+pub fn collect_struct_scalar_vregs(
+    cfg: &Cfg,
+    struct_slot_vregs: &HashMap<CfgValue, Vec<VReg>>,
+    value: CfgValue,
+    get_vreg: &mut impl FnMut(CfgValue) -> VReg,
+) -> Vec<VReg> {
+    let inst = cfg.get_inst(value);
+    match &inst.data {
+        CfgInstData::StructInit { fields, .. } => {
+            let mut result = Vec::new();
+            for field in fields {
+                let field_inst = cfg.get_inst(*field);
+                if matches!(field_inst.ty, Type::Array(_)) {
+                    // Recursively collect from array field
+                    result.extend(collect_array_scalar_vregs(
+                        cfg,
+                        struct_slot_vregs,
+                        *field,
+                        get_vreg,
+                    ));
+                } else if matches!(field_inst.ty, Type::Struct(_)) {
+                    // Recursively collect from nested struct field
+                    result.extend(collect_struct_scalar_vregs(
+                        cfg,
+                        struct_slot_vregs,
+                        *field,
+                        get_vreg,
+                    ));
+                } else {
+                    // Scalar field - get its vreg
+                    result.push(get_vreg(*field));
+                }
+            }
+            result
+        }
+        _ => {
+            // For non-StructInit sources, try struct_slot_vregs cache
+            if let Some(vregs) = struct_slot_vregs.get(&value).cloned() {
+                vregs
+            } else {
+                vec![get_vreg(value)]
+            }
+        }
     }
 }

--- a/crates/rue-codegen/src/vreg.rs
+++ b/crates/rue-codegen/src/vreg.rs
@@ -1,0 +1,63 @@
+//! Shared virtual register types for code generation backends.
+//!
+//! Virtual registers are target-independent - they represent values before
+//! physical register allocation. Both x86_64 and aarch64 backends use the
+//! same VReg type, with target-specific physical registers assigned later.
+
+use std::fmt;
+
+/// A virtual register.
+///
+/// Virtual registers are unlimited and allocated to physical registers
+/// during register allocation. They are target-independent; the mapping
+/// to physical registers happens in each backend's register allocator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VReg(u32);
+
+impl VReg {
+    /// Create a new virtual register with the given index.
+    #[inline]
+    pub const fn new(index: u32) -> Self {
+        Self(index)
+    }
+
+    /// Get the index of this virtual register.
+    #[inline]
+    pub const fn index(self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for VReg {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "v{}", self.0)
+    }
+}
+
+/// A label identifier.
+///
+/// Labels are local to a function and are represented as a lightweight u32 index
+/// rather than as heap-allocated strings. This avoids allocations during codegen.
+/// Labels are target-independent; each backend emits them in its own format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct LabelId(u32);
+
+impl LabelId {
+    /// Create a new label with the given index.
+    #[inline]
+    pub const fn new(index: u32) -> Self {
+        Self(index)
+    }
+
+    /// Get the index of this label.
+    #[inline]
+    pub const fn index(self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for LabelId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, ".L{}", self.0)
+    }
+}

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -221,66 +221,19 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Recursively collect all scalar vregs from an array value.
-    /// For nested arrays, this flattens them to a list of scalar vregs.
+    /// Delegates to the shared implementation in `types`.
     fn collect_array_scalar_vregs(&mut self, value: CfgValue) -> Vec<VReg> {
-        let inst = self.cfg.get_inst(value);
-        match &inst.data.clone() {
-            CfgInstData::ArrayInit { elements, .. } => {
-                let mut result = Vec::new();
-                for elem in elements {
-                    let elem_inst = self.cfg.get_inst(*elem);
-                    if matches!(elem_inst.ty, Type::Array(_)) {
-                        // Recursively collect from nested array
-                        result.extend(self.collect_array_scalar_vregs(*elem));
-                    } else {
-                        // Scalar element - get its vreg
-                        result.push(self.get_vreg(*elem));
-                    }
-                }
-                result
-            }
-            _ => {
-                // For non-ArrayInit sources, try struct_slot_vregs cache
-                if let Some(vregs) = self.struct_slot_vregs.get(&value).cloned() {
-                    vregs
-                } else {
-                    vec![self.get_vreg(value)]
-                }
-            }
-        }
+        // Clone struct_slot_vregs to avoid borrow conflict with get_vreg
+        let slot_vregs = self.struct_slot_vregs.clone();
+        types::collect_array_scalar_vregs(self.cfg, &slot_vregs, value, &mut |v| self.get_vreg(v))
     }
 
     /// Recursively collect all scalar vregs from a struct value.
-    /// This flattens any array fields to their scalar elements.
+    /// Delegates to the shared implementation in `types`.
     fn collect_struct_scalar_vregs(&mut self, value: CfgValue) -> Vec<VReg> {
-        let inst = self.cfg.get_inst(value);
-        match &inst.data.clone() {
-            CfgInstData::StructInit { fields, .. } => {
-                let mut result = Vec::new();
-                for field in fields {
-                    let field_inst = self.cfg.get_inst(*field);
-                    if matches!(field_inst.ty, Type::Array(_)) {
-                        // Recursively collect from array field
-                        result.extend(self.collect_array_scalar_vregs(*field));
-                    } else if matches!(field_inst.ty, Type::Struct(_)) {
-                        // Recursively collect from nested struct field
-                        result.extend(self.collect_struct_scalar_vregs(*field));
-                    } else {
-                        // Scalar field - get its vreg
-                        result.push(self.get_vreg(*field));
-                    }
-                }
-                result
-            }
-            _ => {
-                // For non-StructInit sources, try struct_slot_vregs cache
-                if let Some(vregs) = self.struct_slot_vregs.get(&value).cloned() {
-                    vregs
-                } else {
-                    vec![self.get_vreg(value)]
-                }
-            }
-        }
+        // Clone struct_slot_vregs to avoid borrow conflict with get_vreg
+        let slot_vregs = self.struct_slot_vregs.clone();
+        types::collect_struct_scalar_vregs(self.cfg, &slot_vregs, value, &mut |v| self.get_vreg(v))
     }
 
     /// Calculate the stack offset for a local variable slot.

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -7,59 +7,7 @@
 
 use std::fmt;
 
-/// A virtual register.
-///
-/// Virtual registers are unlimited and allocated to physical registers
-/// during register allocation.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct VReg(u32);
-
-impl VReg {
-    /// Create a new virtual register with the given index.
-    #[inline]
-    pub const fn new(index: u32) -> Self {
-        Self(index)
-    }
-
-    /// Get the index of this virtual register.
-    #[inline]
-    pub const fn index(self) -> u32 {
-        self.0
-    }
-}
-
-impl fmt::Display for VReg {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "v{}", self.0)
-    }
-}
-
-/// A label identifier.
-///
-/// Labels are local to a function and are represented as a lightweight u32 index
-/// rather than as heap-allocated strings. This avoids allocations during codegen.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct LabelId(u32);
-
-impl LabelId {
-    /// Create a new label with the given index.
-    #[inline]
-    pub const fn new(index: u32) -> Self {
-        Self(index)
-    }
-
-    /// Get the index of this label.
-    #[inline]
-    pub const fn index(self) -> u32 {
-        self.0
-    }
-}
-
-impl fmt::Display for LabelId {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, ".L{}", self.0)
-    }
-}
+pub use crate::vreg::{LabelId, VReg};
 
 /// A physical x86-64 register.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]


### PR DESCRIPTION
Extract VReg and LabelId types from x86_64/mir.rs and aarch64/mir.rs into a shared vreg.rs module. These types are target-independent since virtual registers only become physical registers during register allocation.

Also extract collect_array_scalar_vregs and collect_struct_scalar_vregs from both cfg_lower.rs files into the shared types.rs module. The backends now use thin wrapper methods that delegate to the shared implementations via closures.

Fixes rue-ug59

🤖 Generated with [Claude Code](https://claude.com/claude-code)