### PR TITLE
Add explicit undefined behavior section to spec

### DIFF
--- a/crates/rue-spec/cases/runtime/bounds.toml
+++ b/crates/rue-spec/cases/runtime/bounds.toml
@@ -10,7 +10,7 @@ description = "Out-of-bounds array access causes a runtime panic with exit code 
 
 [[case]]
 name = "out_of_bounds_panic"
-spec = ["8.2:1", "B.1:4"]
+spec = ["8.2:1", "B.2:4"]
 source = """
 fn main() -> i32 {
     let arr: [i32; 3] = [10, 20, 30];

--- a/crates/rue-spec/cases/runtime/division.toml
+++ b/crates/rue-spec/cases/runtime/division.toml
@@ -10,7 +10,7 @@ description = "Division or remainder by zero causes a runtime panic with exit co
 
 [[case]]
 name = "div_by_zero_exit_101"
-spec = ["8.3:2", "B.1:3"]
+spec = ["8.3:2", "B.2:3"]
 source = """
 fn main() -> i32 {
     let x: i32 = 10;
@@ -21,7 +21,7 @@ exit_code = 101
 
 [[case]]
 name = "mod_by_zero_exit_101"
-spec = ["8.3:2", "B.1:3"]
+spec = ["8.3:2", "B.2:3"]
 source = """
 fn main() -> i32 {
     let x: i32 = 10;

--- a/crates/rue-spec/cases/runtime/overflow.toml
+++ b/crates/rue-spec/cases/runtime/overflow.toml
@@ -10,7 +10,7 @@ description = "Integer overflow causes a runtime panic with exit code 101."
 
 [[case]]
 name = "overflow_add_exit_101"
-spec = ["8.1:2", "B.1:2"]
+spec = ["8.1:2", "B.2:2"]
 source = """
 fn main() -> i32 {
     let x: i32 = 2147483647;
@@ -21,7 +21,7 @@ exit_code = 101
 
 [[case]]
 name = "overflow_sub_exit_101"
-spec = ["8.1:2", "B.1:2"]
+spec = ["8.1:2", "B.2:2"]
 source = """
 fn main() -> i32 {
     let x: i32 = -2147483648;
@@ -32,7 +32,7 @@ exit_code = 101
 
 [[case]]
 name = "overflow_mul_exit_101"
-spec = ["8.1:2", "B.1:2"]
+spec = ["8.1:2", "B.2:2"]
 source = """
 fn main() -> i32 {
     let x: i32 = 2147483647;

--- a/docs/spec/src/appendices/B-undefined-behavior.md
+++ b/docs/spec/src/appendices/B-undefined-behavior.md
@@ -1,20 +1,32 @@
 +++
-title = "Runtime Panics"
+title = "Undefined Behavior and Runtime Panics"
 weight = 2
 template = "spec/page.html"
 +++
 
-# Appendix B: Runtime Panics
-
-This appendix summarizes all conditions that cause runtime panics in Rue.
+# Appendix B: Undefined Behavior and Runtime Panics
 
 {{ rule(id="B.1:1") }}
+
+Rue currently has no undefined behavior. All operations in Rue have defined semantics: they either complete successfully, fail to compile, or cause a runtime panic.
+
+{{ rule(id="B.1:2") }}
+
+This is a deliberate design choice. Where other systems languages define certain conditions as undefined behavior (allowing implementations to assume they never occur), Rue instead detects these conditions and responds with a defined runtime panic.
+
+{{ rule(id="B.1:3") }}
+
+Future versions of Rue may introduce undefined behavior for specific low-level operations (such as unchecked arithmetic or raw pointer manipulation), but these will be explicitly marked as such and will require opt-in syntax.
+
+## Runtime Panics
+
+{{ rule(id="B.2:1") }}
 
 Rue detects certain error conditions at runtime and responds with a panic, terminating the program with a specific exit code.
 
 ## Integer Overflow
 
-{{ rule(id="B.1:2") }}
+{{ rule(id="B.2:2") }}
 
 Signed or unsigned integer arithmetic that overflows the representable range causes a runtime panic.
 
@@ -28,7 +40,7 @@ Signed or unsigned integer arithmetic that overflows the representable range cau
 
 ## Division by Zero
 
-{{ rule(id="B.1:3") }}
+{{ rule(id="B.2:3") }}
 
 Division or remainder with a divisor of zero causes a runtime panic.
 
@@ -40,7 +52,7 @@ Division or remainder with a divisor of zero causes a runtime panic.
 
 ## Array Bounds Violation
 
-{{ rule(id="B.1:4") }}
+{{ rule(id="B.2:4") }}
 
 Accessing an array element with an index outside the valid range `[0, length)` causes a runtime panic.
 
@@ -58,6 +70,6 @@ Accessing an array element with an index outside the valid range `[0, length)` c
 | Division by zero | 101 |
 | Array out of bounds | 101 |
 
-{{ rule(id="B.1:5") }}
+{{ rule(id="B.2:5") }}
 
 All runtime panics produce exit code 101, matching Rust's convention for unwinding panics.


### PR DESCRIPTION
Rue currently has no undefined behavior - all operations either succeed, fail to compile, or cause a defined runtime panic. This documents that design choice and notes that future low-level operations may introduce opt-in UB.

Updates Appendix B from "Runtime Panics" to "Undefined Behavior and Runtime Panics" with reorganized rule IDs (B.1.x for UB, B.2.x for panics).

Fixes rue-01x

🤖 Generated with [Claude Code](https://claude.com/claude-code)