### PR TITLE
Fix intrinsic grammar in appendix to allow type arguments

### DIFF
--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -56,7 +56,6 @@ additive       = multiplicative { ( "+" | "-" ) multiplicative } ;
 multiplicative = unary { ( "*" | "/" | "%" ) unary } ;
 unary          = "-" unary | "!" unary | "~" unary | postfix ;
 postfix        = primary { "[" expression "]" | "(" [ args ] ")" | "." IDENT } ;
-intrinsic      = "@" IDENT "(" [ args ] ")" ;
 args           = expression { "," expression } ;
 primary        = INTEGER | BOOL | IDENT | enum_variant_expr
                | "(" expression ")"
@@ -71,6 +70,9 @@ primary        = INTEGER | BOOL | IDENT | enum_variant_expr
                | struct_literal
                | intrinsic ;
 enum_variant_expr = IDENT "::" IDENT ;
+intrinsic      = "@" IDENT "(" [ intrinsic_args ] ")" ;
+intrinsic_args = intrinsic_arg { "," intrinsic_arg } ;
+intrinsic_arg  = expression | type ;
 
 (* Compound expressions *)
 block_expr     = "{" block "}" ;


### PR DESCRIPTION
Move intrinsic rule adjacent to primary where it's used, and add intrinsic_args/intrinsic_arg productions to match the intrinsic spec (4.13:2) which allows types as arguments for intrinsics like @size_of.

Fixes rue-95h7

🤖 Generated with [Claude Code](https://claude.com/claude-code)