### PR TITLE
Specify maximal munch lexer principle

### DIFF
--- a/crates/rue-spec/cases/lexical/tokens.toml
+++ b/crates/rue-spec/cases/lexical/tokens.toml
@@ -166,3 +166,126 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Maximal Munch (lexer longest-match principle)
+# =============================================================================
+
+[[case]]
+name = "maximal_munch_left_shift"
+spec = ["2.0:2"]
+source = """
+fn main() -> i32 {
+    let x = 1 << 2;
+    x
+}
+"""
+exit_code = 4
+
+[[case]]
+name = "maximal_munch_right_shift"
+spec = ["2.0:2"]
+source = """
+fn main() -> i32 {
+    let x = 16 >> 2;
+    x
+}
+"""
+exit_code = 4
+
+[[case]]
+name = "maximal_munch_less_than_or_equal"
+spec = ["2.0:2"]
+source = """
+fn main() -> i32 {
+    if 5 <= 10 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "maximal_munch_greater_than_or_equal"
+spec = ["2.0:2"]
+source = """
+fn main() -> i32 {
+    if 10 >= 5 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "maximal_munch_logical_and"
+spec = ["2.0:2"]
+source = """
+fn main() -> i32 {
+    if true && true { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "maximal_munch_logical_or"
+spec = ["2.0:2"]
+source = """
+fn main() -> i32 {
+    if false || true { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "maximal_munch_equal_equal"
+spec = ["2.0:2"]
+source = """
+fn main() -> i32 {
+    if 5 == 5 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "maximal_munch_not_equal"
+spec = ["2.0:2"]
+source = """
+fn main() -> i32 {
+    if 5 != 10 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "maximal_munch_arrow"
+spec = ["2.0:2"]
+source = """
+fn foo() -> i32 { 42 }
+fn main() -> i32 { foo() }
+"""
+exit_code = 42
+
+[[case]]
+name = "maximal_munch_fat_arrow"
+spec = ["2.0:2"]
+source = """
+fn main() -> i32 {
+    match 1 {
+        1 => 42,
+        _ => 0,
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "maximal_munch_colon_colon"
+spec = ["2.0:2"]
+source = """
+enum Color { Red, Green, Blue }
+fn main() -> i32 {
+    match Color::Red {
+        Color::Red => 1,
+        Color::Green => 2,
+        Color::Blue => 3,
+    }
+}
+"""
+exit_code = 1

--- a/docs/spec/src/02-lexical-structure/_index.md
+++ b/docs/spec/src/02-lexical-structure/_index.md
@@ -13,3 +13,23 @@ This chapter describes the lexical structure of Rue programs, including tokens, 
 {{ rule(id="2.0:1") }}
 
 The lexer processes source text and produces a sequence of tokens. Comments and whitespace are handled but do not produce tokens.
+
+## Maximal Munch
+
+{{ rule(id="2.0:2", cat="normative") }}
+
+The lexer uses the *maximal munch* (or *longest match*) principle: at each position in the source text, the lexer consumes the longest sequence of characters that forms a valid token.
+
+{{ rule(id="2.0:3", cat="informative") }}
+
+This principle resolves ambiguity when multiple token patterns could match at a position. For example, `<=` is lexed as a single `<=` token rather than `<` followed by `=`, and `&&` is lexed as a single logical AND token rather than two `&` tokens.
+
+{{ rule(id="2.0:4", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    let x = 1 << 2;   // << is a single left-shift token
+    let y = x <= 10;  // <= is a single less-than-or-equal token
+    if true && false { 0 } else { 1 }  // && is a single logical AND token
+}
+```


### PR DESCRIPTION
Documents the longest-match rule used by the lexer when tokenizing source text. This is a fundamental property of the lexer that resolves ambiguity when multiple token patterns could match at a position.

Fixes rue-kce

🤖 Generated with [Claude Code](https://claude.com/claude-code)