### PR TITLE
Add UI tests for deeply nested variable shadowing (3+ levels)

### DIFF
--- a/crates/rue-ui-tests/cases/warnings/unused.toml
+++ b/crates/rue-ui-tests/cases/warnings/unused.toml
@@ -122,6 +122,64 @@ exit_code = 0
 warning_contains = ["unused variable"]
 expected_warning_count = 2
 
+[[case]]
+name = "deeply_nested_shadowing_all_unused"
+source = """
+fn main() -> i32 {
+    let x = 1;
+    {
+        let x = 2;
+        {
+            let x = 3;
+            {
+                let x = 4;
+            };
+        };
+    };
+    0
+}
+"""
+exit_code = 0
+warning_contains = ["unused variable", "'x'"]
+expected_warning_count = 4
+
+[[case]]
+name = "deeply_nested_shadowing_innermost_used"
+source = """
+fn main() -> i32 {
+    let x = 1;
+    {
+        let x = 2;
+        {
+            let x = 3;
+            x
+        }
+    }
+}
+"""
+exit_code = 3
+# When innermost is used as the return value, shadowed outer variables
+# are not warned about (consistent with used_shadowed_variable_no_warning)
+no_warnings = true
+
+[[case]]
+name = "deeply_nested_shadowing_outermost_used"
+source = """
+fn main() -> i32 {
+    let x = 1;
+    {
+        let x = 2;
+        {
+            let x = 3;
+        };
+    };
+    x
+}
+"""
+exit_code = 1
+warning_contains = ["unused variable", "'x'"]
+expected_warning_count = 2
+
 # =============================================================================
 # Unused Functions
 # =============================================================================


### PR DESCRIPTION
Add three test cases for variable shadowing at 3+ nested block levels:

- deeply_nested_shadowing_all_unused: 4 levels of shadowing, all unused, expects 4 warnings
- deeply_nested_shadowing_innermost_used: 3 levels where innermost is returned, expects no warnings (consistent with existing behavior)
- deeply_nested_shadowing_outermost_used: 3 levels where outermost is returned, inner two unused, expects 2 warnings

Closes rue-kos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)