### PR TITLE
Standardize spec normative language using RFC 2119 keywords

### DIFF
--- a/docs/spec/src/01-introduction.md
+++ b/docs/spec/src/01-introduction.md
@@ -49,33 +49,63 @@ Paragraphs marked with rule categories are normative unless explicitly marked as
 | `informative` | Explanatory text that is not normative |
 | `example` | Code examples that are not normative |
 
-## Definitions
+## Normative Language
 
 {{ rule(id="1.4:1") }}
 
+This specification uses terminology from [RFC 2119](https://datatracker.ietf.org/doc/html/rfc2119) to indicate requirement levels. The key words are interpreted as follows:
+
+{{ rule(id="1.4:2", cat="informative") }}
+
+**MUST** and **SHALL**: An absolute requirement. A conforming implementation is required to satisfy this.
+
+{{ rule(id="1.4:3", cat="informative") }}
+
+**MUST NOT** and **SHALL NOT**: An absolute prohibition. A conforming implementation is required not to do this.
+
+{{ rule(id="1.4:4", cat="informative") }}
+
+**SHOULD** and **RECOMMENDED**: There may be valid reasons to ignore this requirement, but the implications must be understood.
+
+{{ rule(id="1.4:5", cat="informative") }}
+
+**SHOULD NOT** and **NOT RECOMMENDED**: There may be valid reasons to accept this behavior, but the implications must be understood.
+
+{{ rule(id="1.4:6", cat="informative") }}
+
+**MAY** and **OPTIONAL**: An item is truly optional. Implementations may or may not include it.
+
+{{ rule(id="1.4:7") }}
+
+These keywords appear in **bold** throughout this specification to distinguish normative requirements from descriptive text.
+
+## Definitions
+
+{{ rule(id="1.4:8") }}
+
 The following terms are used throughout this specification:
 
-{{ rule(id="1.4:2") }}
+{{ rule(id="1.4:9") }}
 
 **Expression**: A syntactic construct that evaluates to a value.
 
-{{ rule(id="1.4:3") }}
+{{ rule(id="1.4:10") }}
 
 **Statement**: A syntactic construct that performs an action but does not produce a value.
 
-{{ rule(id="1.4:4") }}
+{{ rule(id="1.4:11") }}
 
 **Item**: A top-level definition in a program, such as a function or struct.
 
-{{ rule(id="1.4:5") }}
+{{ rule(id="1.4:12") }}
 
 **Type**: A classification that determines what values an expression can produce and what operations are valid on those values.
 
-{{ rule(id="1.4:6") }}
+{{ rule(id="1.4:13") }}
 
 **Normative**: Content that defines required behavior for conforming implementations.
 
-{{ rule(id="1.4:7") }}
+{{ rule(id="1.4:14") }}
 
 **Informative**: Content that provides explanation or context but does not define required behavior.
 

--- a/docs/spec/src/03-types/01-integer-types.md
+++ b/docs/spec/src/03-types/01-integer-types.md
@@ -28,9 +28,9 @@ The type `i32` represents signed integers in the range [-2147483648, 2147483647]
 
 The type `i64` represents signed integers in the range [-9223372036854775808, 9223372036854775807].
 
-{{ rule(id="3.1:6", cat="normative") }}
+{{ rule(id="3.1:6", cat="dynamic-semantics") }}
 
-Signed integer arithmetic that overflows causes a runtime panic.
+Signed integer arithmetic that overflows **MUST** cause a runtime panic.
 
 {{ rule(id="3.1:7") }}
 
@@ -66,9 +66,9 @@ The type `u32` represents unsigned integers in the range [0, 4294967295].
 
 The type `u64` represents unsigned integers in the range [0, 18446744073709551615].
 
-{{ rule(id="3.1:13", cat="normative") }}
+{{ rule(id="3.1:13", cat="dynamic-semantics") }}
 
-Unsigned integer arithmetic that overflows causes a runtime panic.
+Unsigned integer arithmetic that overflows **MUST** cause a runtime panic.
 
 ## Integer Literal Type Inference
 
@@ -92,9 +92,9 @@ fn main() -> i32 {
 
 ## Integer Literal Range Validation
 
-{{ rule(id="3.1:17", cat="normative") }}
+{{ rule(id="3.1:17", cat="legality-rule") }}
 
-A compile-time error occurs when an integer literal value exceeds the representable range of its target type.
+A compiler **MUST** reject programs where an integer literal value exceeds the representable range of its target type.
 
 {{ rule(id="3.1:18", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/02-arithmetic-operators.md
+++ b/docs/spec/src/04-expressions/02-arithmetic-operators.md
@@ -60,9 +60,9 @@ fn main() -> i32 {
 
 The unary negation operator `-` takes a single signed integer operand and produces its arithmetic negation.
 
-{{ rule(id="4.2:14", cat="normative") }}
+{{ rule(id="4.2:14", cat="legality-rule") }}
 
-Unary negation on unsigned integer types is a compile-time error.
+A compiler **MUST** reject unary negation applied to unsigned integer types.
 
 {{ rule(id="4.2:7", cat="normative") }}
 
@@ -82,9 +82,9 @@ fn main() -> i32 {
 
 When a negated integer literal represents the minimum value of a signed integer type, the compiler evaluates the negation at compile time and produces the minimum value directly. This special case allows expressions like `-128: i8` without runtime overflow.
 
-{{ rule(id="4.2:16", cat="normative") }}
+{{ rule(id="4.2:16", cat="dynamic-semantics") }}
 
-When negation is applied to a non-literal expression holding the minimum value of a signed integer type, the operation overflows and causes a runtime panic.
+When negation is applied to a non-literal expression holding the minimum value of a signed integer type, the operation overflows and **MUST** cause a runtime panic.
 
 {{ rule(id="4.2:17") }}
 
@@ -98,9 +98,9 @@ fn main() -> i32 {
 
 ## Overflow
 
-{{ rule(id="4.2:9", cat="normative") }}
+{{ rule(id="4.2:9", cat="dynamic-semantics") }}
 
-Arithmetic operations that overflow the range of their type cause a runtime panic.
+Arithmetic operations that overflow the range of their type **MUST** cause a runtime panic.
 
 {{ rule(id="4.2:10") }}
 
@@ -112,9 +112,9 @@ fn main() -> i32 {
 
 ## Division by Zero
 
-{{ rule(id="4.2:11", cat="normative") }}
+{{ rule(id="4.2:11", cat="dynamic-semantics") }}
 
-Division or remainder by zero causes a runtime panic.
+Division or remainder by zero **MUST** cause a runtime panic.
 
 {{ rule(id="4.2:12") }}
 

--- a/docs/spec/src/04-expressions/03-comparison-operators.md
+++ b/docs/spec/src/04-expressions/03-comparison-operators.md
@@ -72,9 +72,9 @@ Ordering operators work only on integers.
 | `<=` | Less or equal | True if left <= right |
 | `>=` | Greater or equal | True if left >= right |
 
-{{ rule(id="4.3:6", cat="normative") }}
+{{ rule(id="4.3:6", cat="legality-rule") }}
 
-Ordering operators on boolean, string, unit, or struct values are a compile-time error.
+Ordering operators on boolean, string, unit, or struct values are a compile-time error. Implementations **MUST** reject such programs.
 
 {{ rule(id="4.3:7") }}
 
@@ -102,9 +102,9 @@ fn main() -> i32 {
 
 ## Type Checking
 
-{{ rule(id="4.3:10", cat="normative") }}
+{{ rule(id="4.3:10", cat="legality-rule") }}
 
-Both operands of a comparison must have the same type.
+Both operands of a comparison **MUST** have the same type.
 
 {{ rule(id="4.3:11", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/04-logical-operators.md
+++ b/docs/spec/src/04-expressions/04-logical-operators.md
@@ -85,6 +85,6 @@ fn main() -> i32 {
 
 ## Type Checking
 
-{{ rule(id="4.4:12", cat="normative") }}
+{{ rule(id="4.4:12", cat="legality-rule") }}
 
-All operands of logical operators must have type `bool`.
+All operands of logical operators **MUST** have type `bool`.

--- a/docs/spec/src/04-expressions/06-if-expressions.md
+++ b/docs/spec/src/04-expressions/06-if-expressions.md
@@ -17,17 +17,17 @@ if_expr     = "if" expression "{" block "}" [ else_clause ] ;
 else_clause = "else" ( "{" block "}" | if_expr ) ;
 ```
 
-{{ rule(id="4.6:3", cat="normative") }}
+{{ rule(id="4.6:3", cat="legality-rule") }}
 
-The condition expression must have type `bool`.
+The condition expression **MUST** have type `bool`.
 
-{{ rule(id="4.6:4", cat="normative") }}
+{{ rule(id="4.6:4", cat="legality-rule") }}
 
-If an `else` branch is present, both branches must have the same type. The type of the if expression is the type of its branches.
+If an `else` branch is present, both branches **MUST** have the same type. The type of the if expression is the type of its branches.
 
-{{ rule(id="4.6:5", cat="normative") }}
+{{ rule(id="4.6:5", cat="legality-rule") }}
 
-If no `else` branch is present, the `then` branch must have type `()`.
+If no `else` branch is present, the `then` branch **MUST** have type `()`.
 
 {{ rule(id="4.6:6") }}
 

--- a/docs/spec/src/04-expressions/08-loop-expressions.md
+++ b/docs/spec/src/04-expressions/08-loop-expressions.md
@@ -18,9 +18,9 @@ A while loop repeatedly executes its body while a condition is true.
 while_expr = "while" expression "{" block "}" ;
 ```
 
-{{ rule(id="4.8:3", cat="normative") }}
+{{ rule(id="4.8:3", cat="legality-rule") }}
 
-The condition expression must have type `bool`.
+The condition expression **MUST** have type `bool`.
 
 {{ rule(id="4.8:4", cat="normative") }}
 
@@ -105,9 +105,9 @@ The `break` expression exits the innermost enclosing loop.
 
 The `continue` expression skips to the next iteration of the innermost enclosing loop.
 
-{{ rule(id="4.8:9", cat="normative") }}
+{{ rule(id="4.8:9", cat="legality-rule") }}
 
-Both `break` and `continue` must appear within a loop. Using them outside a loop is a compile-time error.
+Both `break` and `continue` **MUST** appear within a loop. Using them outside a loop is a compile-time error.
 
 {{ rule(id="4.8:10", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/09-return-expressions.md
+++ b/docs/spec/src/04-expressions/09-return-expressions.md
@@ -20,9 +20,9 @@ return_expr = "return" expression? ;
 
 If the expression is omitted, it is equivalent to `return ()`.
 
-{{ rule(id="4.9:4", cat="normative") }}
+{{ rule(id="4.9:4", cat="legality-rule") }}
 
-The expression following `return` (or the implicit `()`) must have a type compatible with the function's declared return type.
+The expression following `return` (or the implicit `()`) **MUST** have a type compatible with the function's declared return type.
 
 {{ rule(id="4.9:5", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/10-call-expressions.md
+++ b/docs/spec/src/04-expressions/10-call-expressions.md
@@ -16,13 +16,13 @@ A call expression invokes a function with a list of arguments.
 call_expr = expression "(" [ expression { "," expression } ] ")" ;
 ```
 
-{{ rule(id="4.10:3", cat="normative") }}
+{{ rule(id="4.10:3", cat="legality-rule") }}
 
-The number of arguments must match the number of parameters in the function signature.
+The number of arguments **MUST** match the number of parameters in the function signature.
 
-{{ rule(id="4.10:4", cat="normative") }}
+{{ rule(id="4.10:4", cat="legality-rule") }}
 
-Each argument type must be compatible with the corresponding parameter type.
+Each argument type **MUST** be compatible with the corresponding parameter type.
 
 {{ rule(id="4.10:5", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/11-index-expressions.md
+++ b/docs/spec/src/04-expressions/11-index-expressions.md
@@ -16,13 +16,13 @@ An index expression accesses an element of an array.
 index_expr = expression "[" expression "]" ;
 ```
 
-{{ rule(id="4.11:3", cat="normative") }}
+{{ rule(id="4.11:3", cat="legality-rule") }}
 
-The expression before the brackets must have an array type `[T; N]`.
+The expression before the brackets **MUST** have an array type `[T; N]`.
 
-{{ rule(id="4.11:4", cat="normative") }}
+{{ rule(id="4.11:4", cat="legality-rule") }}
 
-The index expression must have an unsigned integer type (`u8`, `u16`, `u32`, or `u64`).
+The index expression **MUST** have an unsigned integer type (`u8`, `u16`, `u32`, or `u64`).
 
 {{ rule(id="4.11:5", cat="normative") }}
 
@@ -39,17 +39,17 @@ fn main() -> i32 {
 
 ## Bounds Checking
 
-{{ rule(id="4.11:7", cat="normative") }}
+{{ rule(id="4.11:7", cat="legality-rule") }}
 
-For constant indices, bounds checking is performed at compile time.
+For constant indices, bounds checking **MUST** be performed at compile time.
 
-{{ rule(id="4.11:8", cat="normative") }}
+{{ rule(id="4.11:8", cat="dynamic-semantics") }}
 
-For variable indices, bounds checking is performed at runtime.
+For variable indices, bounds checking **MUST** be performed at runtime.
 
-{{ rule(id="4.11:9", cat="normative") }}
+{{ rule(id="4.11:9", cat="dynamic-semantics") }}
 
-An out-of-bounds access causes a runtime panic.
+An out-of-bounds access **MUST** cause a runtime panic.
 
 {{ rule(id="4.11:10") }}
 

--- a/docs/spec/src/05-statements/01-let-statements.md
+++ b/docs/spec/src/05-statements/01-let-statements.md
@@ -18,9 +18,9 @@ let_stmt = "let" [ "mut" ] IDENT [ ":" type ] "=" expression ";" ;
 
 ## Immutable Bindings
 
-{{ rule(id="5.1:3", cat="normative") }}
+{{ rule(id="5.1:3", cat="legality-rule") }}
 
-By default, variables are immutable. An immutable variable cannot be reassigned.
+By default, variables are immutable. An immutable variable **MUST NOT** be reassigned.
 
 {{ rule(id="5.1:4", cat="normative") }}
 
@@ -35,7 +35,7 @@ fn main() -> i32 {
 
 {{ rule(id="5.1:5", cat="normative") }}
 
-The `mut` keyword creates a mutable binding that can be reassigned.
+The `mut` keyword creates a mutable binding that **MAY** be reassigned.
 
 {{ rule(id="5.1:6") }}
 
@@ -53,9 +53,9 @@ fn main() -> i32 {
 
 Type annotations are optional when the type can be inferred from the initializer.
 
-{{ rule(id="5.1:8", cat="normative") }}
+{{ rule(id="5.1:8", cat="legality-rule") }}
 
-When a type annotation is present, the initializer must be compatible with that type.
+When a type annotation is present, the initializer **MUST** be compatible with that type.
 
 {{ rule(id="5.1:9") }}
 
@@ -72,11 +72,11 @@ fn main() -> i32 {
 
 {{ rule(id="5.1:10", cat="normative") }}
 
-A variable can shadow a previous variable of the same name in the same scope.
+A variable **MAY** shadow a previous variable of the same name in the same scope.
 
 {{ rule(id="5.1:11", cat="normative") }}
 
-When shadowing, the new variable can have a different type.
+When shadowing, the new variable **MAY** have a different type.
 
 {{ rule(id="5.1:12", cat="normative") }}
 

--- a/docs/spec/src/05-statements/02-assignment.md
+++ b/docs/spec/src/05-statements/02-assignment.md
@@ -20,13 +20,13 @@ assign_stmt = IDENT "=" expression ";"
 
 ## Variable Assignment
 
-{{ rule(id="5.2:3", cat="normative") }}
+{{ rule(id="5.2:3", cat="legality-rule") }}
 
-The variable must have been declared with `let mut`.
+The variable **MUST** have been declared with `let mut`.
 
-{{ rule(id="5.2:4", cat="normative") }}
+{{ rule(id="5.2:4", cat="legality-rule") }}
 
-The expression type must be compatible with the variable's type.
+The expression type **MUST** be compatible with the variable's type.
 
 {{ rule(id="5.2:5") }}
 
@@ -98,6 +98,6 @@ fn main() -> i32 {
 
 ## Assignment is Not an Expression
 
-{{ rule(id="5.2:10", cat="normative") }}
+{{ rule(id="5.2:10", cat="legality-rule") }}
 
-Assignment is a statement, not an expression. It cannot be used in expression position.
+Assignment is a statement, not an expression. It **MUST NOT** be used in expression position.

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -20,13 +20,13 @@ param = IDENT ":" type ;
 
 ## Function Signature
 
-{{ rule(id="6.1:3", cat="normative") }}
+{{ rule(id="6.1:3", cat="legality-rule") }}
 
-Parameters must have explicit type annotations.
+Parameters **MUST** have explicit type annotations.
 
-{{ rule(id="6.1:4", cat="normative") }}
+{{ rule(id="6.1:4", cat="legality-rule") }}
 
-If a return type is specified, the function body must produce a value of that type.
+If a return type is specified, the function body **MUST** produce a value of that type.
 
 {{ rule(id="6.1:5", cat="normative") }}
 
@@ -46,13 +46,13 @@ fn do_nothing() {
 
 ## Entry Point
 
-{{ rule(id="6.1:7", cat="normative") }}
+{{ rule(id="6.1:7", cat="legality-rule") }}
 
-A program must have a function named `main`.
+A program **MUST** have a function named `main`.
 
-{{ rule(id="6.1:8", cat="normative") }}
+{{ rule(id="6.1:8", cat="legality-rule") }}
 
-The `main` function must either return `i32` or `()`. When it returns `i32`, that value becomes the program's exit code. When it returns `()`, the exit code is 0.
+The `main` function **MUST** return either `i32` or `()`. When it returns `i32`, that value becomes the program's exit code. When it returns `()`, the exit code is 0.
 
 {{ rule(id="6.1:9") }}
 
@@ -66,7 +66,7 @@ fn main() -> i32 {
 
 {{ rule(id="6.1:10", cat="normative") }}
 
-Functions can call themselves recursively.
+Functions **MAY** call themselves recursively.
 
 {{ rule(id="6.1:11") }}
 
@@ -85,7 +85,7 @@ fn main() -> i32 {
 
 {{ rule(id="6.1:12", cat="normative") }}
 
-Functions can call any function defined in the same module, regardless of definition order.
+Functions **MAY** call any function defined in the same module, regardless of definition order.
 
 {{ rule(id="6.1:13") }}
 

--- a/docs/spec/src/06-items/02-structs.md
+++ b/docs/spec/src/06-items/02-structs.md
@@ -20,9 +20,9 @@ struct_field = IDENT ":" type ;
 
 ## Struct Definition
 
-{{ rule(id="6.2:3", cat="normative") }}
+{{ rule(id="6.2:3", cat="legality-rule") }}
 
-Field names must be unique within a struct.
+Field names **MUST** be unique within a struct.
 
 {{ rule(id="6.2:4") }}
 
@@ -35,13 +35,13 @@ struct Point {
 
 ## Struct Instantiation
 
-{{ rule(id="6.2:5", cat="normative") }}
+{{ rule(id="6.2:5", cat="legality-rule") }}
 
-All fields must be initialized when creating a struct instance.
+All fields **MUST** be initialized when creating a struct instance.
 
 {{ rule(id="6.2:6", cat="normative") }}
 
-Field initializers may be provided in any order.
+Field initializers **MAY** be provided in any order.
 
 {{ rule(id="6.2:7") }}
 

--- a/docs/spec/src/07-arrays/01-fixed-arrays.md
+++ b/docs/spec/src/07-arrays/01-fixed-arrays.md
@@ -18,13 +18,13 @@ array_literal = "[" [ expression { "," expression } ] "]" ;
 
 An array literal creates an array with the given elements.
 
-{{ rule(id="7.1:3", cat="normative") }}
+{{ rule(id="7.1:3", cat="legality-rule") }}
 
-All elements must have the same type.
+All elements **MUST** have the same type.
 
-{{ rule(id="7.1:4", cat="normative") }}
+{{ rule(id="7.1:4", cat="legality-rule") }}
 
-The number of elements must match the declared array size.
+The number of elements **MUST** match the declared array size.
 
 {{ rule(id="7.1:5") }}
 
@@ -41,9 +41,9 @@ fn main() -> i32 {
 
 Array elements are accessed using bracket notation `arr[index]`.
 
-{{ rule(id="7.1:7", cat="normative") }}
+{{ rule(id="7.1:7", cat="legality-rule") }}
 
-The index must be an integer type.
+The index **MUST** be an integer type.
 
 {{ rule(id="7.1:8") }}
 
@@ -56,17 +56,17 @@ fn main() -> i32 {
 
 ## Bounds Checking
 
-{{ rule(id="7.1:9", cat="normative") }}
+{{ rule(id="7.1:9", cat="legality-rule") }}
 
-For constant indices, bounds are checked at compile time.
+For constant indices, bounds **MUST** be checked at compile time.
 
-{{ rule(id="7.1:10", cat="normative") }}
+{{ rule(id="7.1:10", cat="dynamic-semantics") }}
 
-For variable indices, bounds are checked at runtime.
+For variable indices, bounds **MUST** be checked at runtime.
 
-{{ rule(id="7.1:11", cat="normative") }}
+{{ rule(id="7.1:11", cat="dynamic-semantics") }}
 
-Out-of-bounds access causes a runtime panic.
+Out-of-bounds access **MUST** cause a runtime panic.
 
 ## Mutable Arrays
 
@@ -93,15 +93,15 @@ fn main() -> i32 {
 array_type = "[" type ";" INTEGER "]" ;
 ```
 
-{{ rule(id="7.1:15", cat="normative") }}
+{{ rule(id="7.1:15", cat="legality-rule") }}
 
-The size must be a non-negative integer literal.
+The size **MUST** be a non-negative integer literal.
 
 ## Nested Arrays
 
 {{ rule(id="7.1:16", cat="normative") }}
 
-Arrays may contain other arrays as elements, forming multi-dimensional arrays.
+Arrays **MAY** contain other arrays as elements, forming multi-dimensional arrays.
 
 {{ rule(id="7.1:17", cat="normative") }}
 
@@ -120,7 +120,7 @@ fn main() -> i32 {
 
 {{ rule(id="7.1:19", cat="normative") }}
 
-Struct fields may have array types.
+Struct fields **MAY** have array types.
 
 {{ rule(id="7.1:20", cat="normative") }}
 
@@ -141,7 +141,7 @@ fn main() -> i32 {
 
 {{ rule(id="7.1:22", cat="normative") }}
 
-Functions may accept arrays as parameters.
+Functions **MAY** accept arrays as parameters.
 
 {{ rule(id="7.1:23", cat="normative") }}
 

--- a/docs/spec/src/08-runtime-behavior/01-overflow.md
+++ b/docs/spec/src/08-runtime-behavior/01-overflow.md
@@ -6,17 +6,17 @@ template = "spec/page.html"
 
 # Integer Overflow
 
-{{ rule(id="8.1:1", cat="normative") }}
+{{ rule(id="8.1:1", cat="dynamic-semantics") }}
 
-Integer overflow during arithmetic operations causes a runtime panic.
+Integer overflow during arithmetic operations **MUST** cause a runtime panic.
 
-{{ rule(id="8.1:2", cat="normative") }}
+{{ rule(id="8.1:2", cat="dynamic-semantics") }}
 
-On overflow, the program terminates with exit code 101 and prints an error message.
+On overflow, the program **MUST** terminate with exit code 101 and print an error message.
 
 {{ rule(id="8.1:3", cat="normative") }}
 
-The following operations can overflow:
+The following operations **MAY** overflow:
 - Addition (`+`)
 - Subtraction (`-`)
 - Multiplication (`*`)

--- a/docs/spec/src/08-runtime-behavior/02-bounds-checking.md
+++ b/docs/spec/src/08-runtime-behavior/02-bounds-checking.md
@@ -6,25 +6,25 @@ template = "spec/page.html"
 
 # Bounds Checking
 
-{{ rule(id="8.2:1", cat="normative") }}
+{{ rule(id="8.2:1", cat="dynamic-semantics") }}
 
-Array access with an out-of-bounds index causes a runtime panic.
+Array access with an out-of-bounds index **MUST** cause a runtime panic.
 
-{{ rule(id="8.2:2", cat="normative") }}
+{{ rule(id="8.2:2", cat="dynamic-semantics") }}
 
-On out-of-bounds access, the program terminates with exit code 101 and prints an error message.
+On out-of-bounds access, the program **MUST** terminate with exit code 101 and print an error message.
 
-{{ rule(id="8.2:3", cat="normative") }}
+{{ rule(id="8.2:3", cat="legality-rule") }}
 
-For constant indices, bounds checking is performed at compile time.
+For constant indices, bounds checking **MUST** be performed at compile time.
 
 {{ rule(id="8.2:4", cat="normative") }}
 
 A constant index is an expression that can be fully evaluated at compile time. This includes integer literals, arithmetic operations on constants, comparison operations on constants, and parenthesized constant expressions.
 
-{{ rule(id="8.2:5", cat="normative") }}
+{{ rule(id="8.2:5", cat="dynamic-semantics") }}
 
-For variable indices, bounds checking is performed at runtime before the access.
+For variable indices, bounds checking **MUST** be performed at runtime before the access.
 
 {{ rule(id="8.2:6") }}
 

--- a/docs/spec/src/08-runtime-behavior/03-division-by-zero.md
+++ b/docs/spec/src/08-runtime-behavior/03-division-by-zero.md
@@ -6,17 +6,17 @@ template = "spec/page.html"
 
 # Division by Zero
 
-{{ rule(id="8.3:1", cat="normative") }}
+{{ rule(id="8.3:1", cat="dynamic-semantics") }}
 
-Division or remainder by zero causes a runtime panic.
+Division or remainder by zero **MUST** cause a runtime panic.
 
-{{ rule(id="8.3:2", cat="normative") }}
+{{ rule(id="8.3:2", cat="dynamic-semantics") }}
 
-On division by zero, the program terminates with exit code 101 and prints an error message.
+On division by zero, the program **MUST** terminate with exit code 101 and print an error message.
 
 {{ rule(id="8.3:3", cat="normative") }}
 
-Both the division operator (`/`) and remainder operator (`%`) can cause division-by-zero errors.
+Both the division operator (`/`) and remainder operator (`%`) **MAY** cause division-by-zero errors.
 
 {{ rule(id="8.3:4") }}
 

--- a/docs/spec/src/appendices/B-undefined-behavior.md
+++ b/docs/spec/src/appendices/B-undefined-behavior.md
@@ -26,9 +26,9 @@ Rue detects certain error conditions at runtime and responds with a panic, termi
 
 ## Integer Overflow
 
-{{ rule(id="B.2:2") }}
+{{ rule(id="B.2:2", cat="dynamic-semantics") }}
 
-Signed or unsigned integer arithmetic that overflows the representable range causes a runtime panic.
+Signed or unsigned integer arithmetic that overflows the representable range **MUST** cause a runtime panic.
 
 **Operations affected:**
 - Addition (`+`)
@@ -40,9 +40,9 @@ Signed or unsigned integer arithmetic that overflows the representable range cau
 
 ## Division by Zero
 
-{{ rule(id="B.2:3") }}
+{{ rule(id="B.2:3", cat="dynamic-semantics") }}
 
-Division or remainder with a divisor of zero causes a runtime panic.
+Division or remainder with a divisor of zero **MUST** cause a runtime panic.
 
 **Operations affected:**
 - Division (`/`)
@@ -52,9 +52,9 @@ Division or remainder with a divisor of zero causes a runtime panic.
 
 ## Array Bounds Violation
 
-{{ rule(id="B.2:4") }}
+{{ rule(id="B.2:4", cat="dynamic-semantics") }}
 
-Accessing an array element with an index outside the valid range `[0, length)` causes a runtime panic.
+Accessing an array element with an index outside the valid range `[0, length)` **MUST** cause a runtime panic.
 
 **Operations affected:**
 - Array indexing (`arr[i]`)


### PR DESCRIPTION
Add RFC 2119 definitions section to the introduction explaining the meaning of MUST, SHALL, SHOULD, MAY and their negatives. Update all spec files to use these standardized keywords in bold for normative requirements, replacing informal language like "causes a runtime panic" with "**MUST** cause a runtime panic".

This change also properly categorizes paragraphs:
- legality-rule: compile-time requirements (MUST/MUST NOT)
- dynamic-semantics: runtime behavior requirements (MUST)
- normative: general rules (MAY for optional behavior)

Closes rue-loz

🤖 Generated with [Claude Code](https://claude.com/claude-code)