### PR TITLE
Split spec paragraph 4.0:1 into definition and normative type require…

### DIFF
--- a/crates/rue-spec/cases/expressions/evaluation-order.toml
+++ b/crates/rue-spec/cases/expressions/evaluation-order.toml
@@ -10,7 +10,7 @@ description = "Evaluation order of subexpressions within compound expressions."
 
 [[case]]
 name = "binary_add_left_to_right"
-spec = ["4.0:2", "4.0:3"]
+spec = ["4.0:3", "4.0:4"]
 source = """
 fn main() -> i32 {
     1 + 2
@@ -20,7 +20,7 @@ exit_code = 3
 
 [[case]]
 name = "binary_sub_left_to_right"
-spec = ["4.0:2", "4.0:3"]
+spec = ["4.0:3", "4.0:4"]
 source = """
 fn main() -> i32 {
     50 - 8
@@ -30,7 +30,7 @@ exit_code = 42
 
 [[case]]
 name = "binary_mul_left_to_right"
-spec = ["4.0:2", "4.0:3"]
+spec = ["4.0:3", "4.0:4"]
 source = """
 fn main() -> i32 {
     6 * 7
@@ -40,7 +40,7 @@ exit_code = 42
 
 [[case]]
 name = "binary_div_left_to_right"
-spec = ["4.0:2", "4.0:3"]
+spec = ["4.0:3", "4.0:4"]
 source = """
 fn main() -> i32 {
     84 / 2
@@ -50,7 +50,7 @@ exit_code = 42
 
 [[case]]
 name = "binary_comparison_left_to_right"
-spec = ["4.0:2", "4.0:3"]
+spec = ["4.0:3", "4.0:4"]
 source = """
 fn main() -> i32 {
     if 1 < 2 { 42 } else { 0 }
@@ -64,7 +64,7 @@ exit_code = 42
 
 [[case]]
 name = "call_args_left_to_right"
-spec = ["4.0:2", "4.0:4"]
+spec = ["4.0:3", "4.0:5"]
 source = """
 fn sub(x: i32, y: i32) -> i32 { x - y }
 fn main() -> i32 { sub(50, 8) }
@@ -73,7 +73,7 @@ exit_code = 42
 
 [[case]]
 name = "call_nested_args"
-spec = ["4.0:2", "4.0:4"]
+spec = ["4.0:3", "4.0:5"]
 source = """
 fn add(x: i32, y: i32) -> i32 { x + y }
 fn main() -> i32 {
@@ -88,7 +88,7 @@ exit_code = 42
 
 [[case]]
 name = "index_base_before_index"
-spec = ["4.0:2", "4.0:5"]
+spec = ["4.0:3", "4.0:6"]
 source = """
 fn main() -> i32 {
     let arr: [i32; 3] = [10, 42, 100];
@@ -99,7 +99,7 @@ exit_code = 42
 
 [[case]]
 name = "index_nested"
-spec = ["4.0:2", "4.0:5"]
+spec = ["4.0:3", "4.0:6"]
 source = """
 fn main() -> i32 {
     let arr: [[i32; 2]; 2] = [[1, 2], [3, 42]];
@@ -114,7 +114,7 @@ exit_code = 42
 
 [[case]]
 name = "field_base_before_field"
-spec = ["4.0:2", "4.0:6"]
+spec = ["4.0:3", "4.0:7"]
 source = """
 struct Point { x: i32, y: i32 }
 fn main() -> i32 {
@@ -126,7 +126,7 @@ exit_code = 42
 
 [[case]]
 name = "field_chained"
-spec = ["4.0:2", "4.0:6"]
+spec = ["4.0:3", "4.0:7"]
 source = """
 struct Inner { value: i32 }
 struct Outer { inner: Inner }
@@ -143,7 +143,7 @@ exit_code = 42
 
 [[case]]
 name = "short_circuit_and_skips_right"
-spec = ["4.0:7"]
+spec = ["4.0:8"]
 source = """
 fn main() -> i32 {
     if false && true { 1 } else { 42 }
@@ -153,7 +153,7 @@ exit_code = 42
 
 [[case]]
 name = "short_circuit_or_skips_right"
-spec = ["4.0:7"]
+spec = ["4.0:8"]
 source = """
 fn main() -> i32 {
     if true || false { 42 } else { 0 }
@@ -167,7 +167,7 @@ exit_code = 42
 
 [[case]]
 name = "struct_init_source_order"
-spec = ["4.0:2", "4.0:8"]
+spec = ["4.0:3", "4.0:9"]
 source = """
 struct Point { x: i32, y: i32 }
 fn main() -> i32 {
@@ -179,7 +179,7 @@ exit_code = 42
 
 [[case]]
 name = "struct_init_reverse_order"
-spec = ["4.0:2", "4.0:8"]
+spec = ["4.0:3", "4.0:9"]
 source = """
 struct Point { x: i32, y: i32 }
 fn main() -> i32 {
@@ -193,7 +193,7 @@ exit_code = 42
 
 [[case]]
 name = "struct_init_nested"
-spec = ["4.0:2", "4.0:8"]
+spec = ["4.0:3", "4.0:9"]
 source = """
 struct Inner { value: i32 }
 struct Outer { first: Inner, second: Inner }
@@ -210,7 +210,7 @@ exit_code = 42
 
 [[case]]
 name = "struct_init_source_order_observable"
-spec = ["4.0:2", "4.0:8"]
+spec = ["4.0:3", "4.0:9"]
 source = """
 fn side_effect(val: i32) -> i32 {
     @dbg(val);

--- a/crates/rue-spec/cases/expressions/general.toml
+++ b/crates/rue-spec/cases/expressions/general.toml
@@ -1,0 +1,48 @@
+[section]
+id = "expressions.general"
+spec_chapter = "4.0"
+name = "General Expression Properties"
+description = "General properties that apply to all expressions."
+
+# =============================================================================
+# Expression Typing (4.0:2)
+# =============================================================================
+
+# The rule "Every expression has a type" is verified by the type checker.
+# These tests demonstrate that expressions have types by showing the
+# type system rejects type mismatches.
+
+[[case]]
+name = "expression_has_type_literal"
+spec = ["4.0:2"]
+description = "Integer literals have type i32, demonstrated by successful compilation."
+source = """
+fn main() -> i32 {
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "expression_has_type_boolean"
+spec = ["4.0:2"]
+description = "Boolean literals have type bool, demonstrated by successful use in if condition."
+source = """
+fn main() -> i32 {
+    if true { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "expression_type_mismatch_rejected"
+spec = ["4.0:2"]
+description = "Type mismatch is rejected, proving expressions have types that are checked."
+source = """
+fn main() -> i32 {
+    let x: i32 = true;
+    0
+}
+"""
+compile_fail = true
+error_contains = "type mismatch"

--- a/docs/spec/src/04-expressions/_index.md
+++ b/docs/spec/src/04-expressions/_index.md
@@ -12,34 +12,38 @@ This chapter describes expressions in Rue.
 
 {{ rule(id="4.0:1") }}
 
-An expression is a syntactic construct that evaluates to a value. Every expression has a type.
-
-## Evaluation
+An expression is a syntactic construct that evaluates to a value.
 
 {{ rule(id="4.0:2", cat="normative") }}
 
-When an expression contains subexpressions, those subexpressions are evaluated in a defined order as specified in this section.
+Every expression has a type.
+
+## Evaluation
 
 {{ rule(id="4.0:3", cat="normative") }}
 
-For binary operators, the left operand is evaluated before the right operand.
+When an expression contains subexpressions, those subexpressions are evaluated in a defined order as specified in this section.
 
 {{ rule(id="4.0:4", cat="normative") }}
 
-For function call expressions, the callee expression is evaluated first, then arguments are evaluated left-to-right.
+For binary operators, the left operand is evaluated before the right operand.
 
 {{ rule(id="4.0:5", cat="normative") }}
 
-For index expressions of the form `base[index]`, the base expression is evaluated before the index expression.
+For function call expressions, the callee expression is evaluated first, then arguments are evaluated left-to-right.
 
 {{ rule(id="4.0:6", cat="normative") }}
 
-For field access expressions of the form `base.field`, the base expression is evaluated before the field is accessed.
+For index expressions of the form `base[index]`, the base expression is evaluated before the index expression.
 
 {{ rule(id="4.0:7", cat="normative") }}
 
-Logical operators `&&` and `||` are an exception to the normal left-to-right evaluation. They use short-circuit evaluation as specified in section 4.4: the right operand may not be evaluated depending on the value of the left operand.
+For field access expressions of the form `base.field`, the base expression is evaluated before the field is accessed.
 
 {{ rule(id="4.0:8", cat="normative") }}
+
+Logical operators `&&` and `||` are an exception to the normal left-to-right evaluation. They use short-circuit evaluation as specified in section 4.4: the right operand may not be evaluated depending on the value of the left operand.
+
+{{ rule(id="4.0:9", cat="normative") }}
 
 For struct literal expressions of the form `Type { field1: expr1, field2: expr2, ... }`, the field initializer expressions are evaluated in source order (left-to-right as written).


### PR DESCRIPTION
…ment

Split the original 4.0:1 paragraph 'An expression is a syntactic construct that evaluates to a value. Every expression has a type.' into:
- 4.0:1 (informative): The definition of an expression
- 4.0:2 (normative): 'Every expression has a type'

Renumbered subsequent paragraphs 4.0:2-8 to 4.0:3-9 and updated all test references accordingly. Added tests for the new normative paragraph.

Fixes rue-0o5

🤖 Generated with [Claude Code](https://claude.com/claude-code)