### PR TITLE
Add line numbers to unused variable warnings for disambiguation

### DIFF
--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -727,6 +727,33 @@ impl fmt::Display for CompileWarning {
     }
 }
 
+impl WarningKind {
+    /// Returns the variable name if this is an UnusedVariable warning.
+    pub fn unused_variable_name(&self) -> Option<&str> {
+        match self {
+            WarningKind::UnusedVariable(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    /// Format the warning message with an optional line number.
+    ///
+    /// When `line_number` is Some, the line number is appended to the message
+    /// for warnings that have a name (like unused variables). This helps
+    /// disambiguate when multiple variables share the same name.
+    pub fn format_with_line(&self, line_number: Option<usize>) -> String {
+        match (self, line_number) {
+            (WarningKind::UnusedVariable(name), Some(line)) => {
+                format!("unused variable '{}' (line {})", name, line)
+            }
+            (WarningKind::UnusedFunction(name), Some(line)) => {
+                format!("unused function '{}' (line {})", name, line)
+            }
+            _ => self.to_string(),
+        }
+    }
+}
+
 impl fmt::Display for WarningKind {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {

--- a/crates/rue-span/src/lib.rs
+++ b/crates/rue-span/src/lib.rs
@@ -57,6 +57,26 @@ impl Span {
     pub const fn as_range(&self) -> std::ops::Range<usize> {
         self.start as usize..self.end as usize
     }
+
+    /// Compute the 1-based line number for this span's start position.
+    ///
+    /// Returns the line number (1-indexed) where this span begins.
+    #[inline]
+    pub fn line_number(&self, source: &str) -> usize {
+        byte_offset_to_line(source, self.start as usize)
+    }
+}
+
+/// Convert a byte offset to a 1-based line number.
+///
+/// Counts the number of newlines before the given byte offset and adds 1.
+#[inline]
+pub fn byte_offset_to_line(source: &str, offset: usize) -> usize {
+    source[..offset.min(source.len())]
+        .bytes()
+        .filter(|&b| b == b'\n')
+        .count()
+        + 1
 }
 
 impl From<std::ops::Range<usize>> for Span {
@@ -126,5 +146,33 @@ mod tests {
         let span: Span = (5usize..10usize).into();
         assert_eq!(span.start, 5);
         assert_eq!(span.end, 10);
+    }
+
+    #[test]
+    fn test_byte_offset_to_line() {
+        let source = "line1\nline2\nline3";
+        // First line (offset 0-4)
+        assert_eq!(byte_offset_to_line(source, 0), 1);
+        assert_eq!(byte_offset_to_line(source, 4), 1);
+        // Second line (offset 6-10)
+        assert_eq!(byte_offset_to_line(source, 6), 2);
+        assert_eq!(byte_offset_to_line(source, 10), 2);
+        // Third line (offset 12+)
+        assert_eq!(byte_offset_to_line(source, 12), 3);
+        assert_eq!(byte_offset_to_line(source, 16), 3);
+    }
+
+    #[test]
+    fn test_span_line_number() {
+        let source = "let x = 1;\nlet y = 2;\nlet z = 3;";
+        // Span on line 1
+        let span1 = Span::new(0, 10);
+        assert_eq!(span1.line_number(source), 1);
+        // Span on line 2
+        let span2 = Span::new(11, 21);
+        assert_eq!(span2.line_number(source), 2);
+        // Span on line 3
+        let span3 = Span::new(22, 32);
+        assert_eq!(span3.line_number(source), 3);
     }
 }

--- a/crates/rue-ui-tests/cases/warnings/unused.toml
+++ b/crates/rue-ui-tests/cases/warnings/unused.toml
@@ -180,6 +180,22 @@ exit_code = 1
 warning_contains = ["unused variable", "'x'"]
 expected_warning_count = 2
 
+[[case]]
+name = "shadowed_variables_include_line_numbers"
+description = "When multiple unused variables share the same name, include line numbers for disambiguation"
+source = """
+fn main() -> i32 {
+    let x = 1;
+    {
+        let x = 2;
+    };
+    0
+}
+"""
+exit_code = 0
+warning_contains = ["unused variable 'x' (line", "line 2)", "line 4)"]
+expected_warning_count = 2
+
 # =============================================================================
 # Unused Functions
 # =============================================================================

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
@@ -217,10 +218,8 @@ fn main() {
     };
     match compile_with_options(&source, &compile_options) {
         Ok(output) => {
-            // Print warnings first
-            for warning in &output.warnings {
-                print_warning(warning, &source, &options.source_path);
-            }
+            // Print warnings with line numbers when needed for disambiguation
+            print_warnings(&output.warnings, &source, &options.source_path);
 
             // Write output
             if let Err(e) = fs::write(&options.output_path, &output.elf) {
@@ -497,10 +496,50 @@ fn print_error(error: &CompileError, source: &str, source_path: &str) {
     eprintln!("{}", renderer.render(report));
 }
 
-fn print_warning(warning: &CompileWarning, source: &str, source_path: &str) {
-    let message = warning.to_string();
+/// Print all warnings, adding line numbers when multiple variables share the same name.
+///
+/// This improves error messages by disambiguating when there are multiple unused
+/// variables with the same name (e.g., shadowed variables in different scopes).
+fn print_warnings(warnings: &[CompileWarning], source: &str, source_path: &str) {
+    // Count occurrences of each unused variable name
+    let mut var_name_counts: HashMap<&str, usize> = HashMap::new();
+    for warning in warnings {
+        if let Some(name) = warning.kind.unused_variable_name() {
+            *var_name_counts.entry(name).or_insert(0) += 1;
+        }
+    }
+
+    // Print each warning, adding line number if there are duplicates
+    for warning in warnings {
+        let needs_line_number = warning
+            .kind
+            .unused_variable_name()
+            .is_some_and(|name| var_name_counts.get(name).copied().unwrap_or(0) > 1);
+
+        print_warning(warning, source, source_path, needs_line_number);
+    }
+}
+
+fn print_warning(
+    warning: &CompileWarning,
+    source: &str,
+    source_path: &str,
+    include_line_number: bool,
+) {
     let renderer = Renderer::plain();
     let diagnostic = warning.diagnostic();
+
+    // Get the message, optionally with line number
+    let message = if include_line_number {
+        if let Some(span) = warning.span() {
+            let line = span.line_number(source);
+            warning.kind.format_with_line(Some(line))
+        } else {
+            warning.to_string()
+        }
+    } else {
+        warning.to_string()
+    };
 
     // For warnings without a span, just print the message with any footers
     let Some(span) = warning.span() else {


### PR DESCRIPTION
When multiple unused variables share the same name (e.g., shadowed variables in different scopes), the warning message now includes the line number to help distinguish between them.

Example: "unused variable 'x' (line 4)" instead of just "unused variable 'x'"

Line numbers are only added when disambiguation is needed - single occurrences of a variable name still use the simpler message format.

Fixes rue-1q4

🤖 Generated with [Claude Code](https://claude.com/claude-code)