### PR TITLE
Implement zero-sized type semantics

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -2079,8 +2079,9 @@ impl<'a> Sema<'a> {
                         (slot_count * 8) as u64
                     }
                     "align_of" => {
-                        // All types currently have 8-byte alignment
-                        8u64
+                        // Zero-sized types have 1-byte alignment, others have 8-byte
+                        let slot_count = self.abi_slot_count(ty);
+                        if slot_count == 0 { 1u64 } else { 8u64 }
                     }
                     _ => {
                         return Err(CompileError::new(
@@ -2433,6 +2434,7 @@ impl<'a> Sema<'a> {
     /// Get the number of ABI slots required for a type.
     /// Scalar types (i8, i16, i32, i64, u8, u16, u32, u64, bool) use 1 slot,
     /// structs use 1 slot per field, arrays use 1 slot per element.
+    /// Zero-sized types (unit, never, empty structs, zero-length arrays) use 0 slots.
     fn abi_slot_count(&self, ty: Type) -> u32 {
         match ty {
             Type::I8
@@ -2444,15 +2446,16 @@ impl<'a> Sema<'a> {
             | Type::U32
             | Type::U64
             | Type::Bool
-            | Type::Unit
-            | Type::Error
-            | Type::Never => 1,
+            | Type::Error => 1,
+            // Zero-sized types use 0 slots
+            Type::Unit | Type::Never => 0,
             // Enums are represented as their discriminant type (a scalar), so 1 slot
             Type::Enum(_) => 1,
             // Strings are fat pointers (ptr + len), so 2 slots
             Type::String => 2,
             Type::Struct(struct_id) => {
                 // Sum the slot counts of all fields (handles arrays and nested structs)
+                // Empty structs naturally get 0 slots here
                 let struct_def = &self.struct_defs[struct_id.0 as usize];
                 struct_def
                     .fields
@@ -2461,6 +2464,7 @@ impl<'a> Sema<'a> {
                     .sum()
             }
             Type::Array(array_type_id) => {
+                // Zero-length arrays naturally get 0 slots (0 * element_slots)
                 let array_def = &self.array_type_defs[array_type_id.0 as usize];
                 let element_slots = self.abi_slot_count(array_def.element_type);
                 element_slots * array_def.length as u32

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -22,9 +22,13 @@ pub fn array_type_def<'a>(
 /// For scalars, this is 1. For arrays, it's `length * slot_count(element_type)`.
 /// For structs, this is the sum of slot counts for all fields.
 /// For nested types, this recursively calculates.
+/// Zero-sized types (unit, never, empty structs, zero-length arrays) return 0.
 pub fn type_slot_count(struct_defs: &[StructDef], array_types: &[ArrayTypeDef], ty: Type) -> u32 {
     match ty {
+        // Zero-sized types
+        Type::Unit | Type::Never => 0,
         Type::Array(array_type_id) => {
+            // Zero-length arrays naturally get 0 slots (0 * element_slots)
             if let Some(def) = array_type_def(array_types, array_type_id) {
                 let elem_slots = type_slot_count(struct_defs, array_types, def.element_type);
                 (def.length as u32) * elem_slots
@@ -34,12 +38,13 @@ pub fn type_slot_count(struct_defs: &[StructDef], array_types: &[ArrayTypeDef], 
         }
         Type::Struct(struct_id) => {
             // Sum the slot counts of all fields
+            // Empty structs naturally get 0 slots here
             if let Some(struct_def) = struct_defs.get(struct_id.0 as usize) {
                 let mut total = 0u32;
                 for field in &struct_def.fields {
                     total += type_slot_count(struct_defs, array_types, field.ty);
                 }
-                total.max(1) // At least 1 slot even for empty struct
+                total
             } else {
                 1
             }

--- a/crates/rue-spec/cases/types/arrays.toml
+++ b/crates/rue-spec/cases/types/arrays.toml
@@ -121,3 +121,38 @@ fn main() -> i32 {
 }
 """
 exit_code = 101
+
+# =============================================================================
+# Zero-Length Arrays (Zero-Sized Types)
+# =============================================================================
+
+[[case]]
+name = "zero_length_array_size"
+spec = ["3.5:4", "3.0:2", "3.0:3"]
+source = """
+fn main() -> i32 {
+    @size_of([i32; 0])
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "zero_length_array_alignment"
+spec = ["3.5:4", "3.0:4"]
+source = """
+fn main() -> i32 {
+    @align_of([i32; 0])
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "zero_length_array_definition"
+spec = ["3.5:4", "3.0:2"]
+source = """
+fn main() -> i32 {
+    let arr: [i32; 0] = [];
+    42
+}
+"""
+exit_code = 42

--- a/crates/rue-spec/cases/types/never.toml
+++ b/crates/rue-spec/cases/types/never.toml
@@ -150,3 +150,27 @@ fn diverge(x: i32) -> i32 {
 fn main() -> i32 { diverge(5) }
 """
 exit_code = 5
+
+# =============================================================================
+# Memory Representation (3.4:9)
+# =============================================================================
+
+[[case]]
+name = "never_size_zero"
+spec = ["3.4:9", "3.0:2", "3.0:3"]
+source = """
+fn main() -> i32 {
+    @size_of(!)
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "never_alignment_one"
+spec = ["3.4:9", "3.0:4"]
+source = """
+fn main() -> i32 {
+    @align_of(!)
+}
+"""
+exit_code = 1

--- a/crates/rue-spec/cases/types/structs.toml
+++ b/crates/rue-spec/cases/types/structs.toml
@@ -105,14 +105,14 @@ fn main() -> i32 {
 exit_code = 8
 
 [[case]]
-name = "unit_size_8_bytes"
-spec = ["3.6:8"]
+name = "unit_size_zero"
+spec = ["3.0:2", "3.0:3", "3.3:4"]
 source = """
 fn main() -> i32 {
     @size_of(())
 }
 """
-exit_code = 8
+exit_code = 0
 
 [[case]]
 name = "struct_fields_declaration_order"
@@ -171,4 +171,93 @@ fn main() -> i32 {
 }
 """
 exit_code = 8
+
+# =============================================================================
+# Empty Struct (Zero-Sized Type)
+# =============================================================================
+
+[[case]]
+name = "empty_struct_definition"
+spec = ["3.6:13", "3.0:2"]
+source = """
+struct Empty {}
+fn main() -> i32 {
+    let e = Empty {};
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "empty_struct_size_zero"
+spec = ["3.6:13", "3.0:2"]
+source = """
+struct Empty {}
+fn main() -> i32 {
+    @size_of(Empty)
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "empty_struct_alignment_one"
+spec = ["3.6:12", "3.0:4"]
+source = """
+struct Empty {}
+fn main() -> i32 {
+    @align_of(Empty)
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "empty_struct_pass_by_value"
+spec = ["3.6:13", "3.0:2"]
+source = """
+struct Empty {}
+fn take_empty(e: Empty) -> i32 { 42 }
+fn main() -> i32 {
+    let e = Empty {};
+    take_empty(e)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "empty_struct_return_by_value"
+spec = ["3.6:13", "3.0:2"]
+source = """
+struct Empty {}
+fn make_empty() -> Empty { Empty {} }
+fn main() -> i32 {
+    let e = make_empty();
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "struct_with_empty_field"
+spec = ["3.6:10", "3.6:13"]
+source = """
+struct Empty {}
+struct Container { value: i32, marker: Empty }
+fn main() -> i32 {
+    // Empty field contributes 0 bytes, so size is just value's 8 bytes
+    @size_of(Container)
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "nested_empty_structs"
+spec = ["3.6:10", "3.6:13"]
+source = """
+struct Empty {}
+struct AlsoEmpty { e: Empty }
+fn main() -> i32 {
+    @size_of(AlsoEmpty)
+}
+"""
+exit_code = 0
 

--- a/crates/rue-spec/cases/types/unit.toml
+++ b/crates/rue-spec/cases/types/unit.toml
@@ -64,7 +64,27 @@ exit_code = 3
 
 [[case]]
 name = "unit_zero_size"
-spec = ["3.3:4"]
+spec = ["3.3:4", "3.0:2", "3.0:3"]
+source = """
+fn main() -> i32 {
+    @size_of(())
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "unit_alignment_one"
+spec = ["3.3:4", "3.0:4"]
+source = """
+fn main() -> i32 {
+    @align_of(())
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "unit_pass_and_return"
+spec = ["3.3:4", "3.0:2"]
 source = """
 fn returns_unit() -> () {}
 fn main() -> i32 {

--- a/docs/spec/src/03-types/03-unit-type.md
+++ b/docs/spec/src/03-types/03-unit-type.md
@@ -20,7 +20,7 @@ Expressions that produce side effects but no meaningful value have type `()`.
 
 {{ rule(id="3.3:4", cat="normative") }}
 
-The unit value `()` occupies zero bytes in memory.
+The unit type is a zero-sized type. See [Zero-Sized Types](../#zero-sized-types) for the general definition.
 
 {{ rule(id="3.3:5") }}
 

--- a/docs/spec/src/03-types/04-never-type.md
+++ b/docs/spec/src/03-types/04-never-type.md
@@ -63,3 +63,9 @@ fn main() -> i32 { diverges(5) }
 {{ rule(id="3.4:8", cat="normative") }}
 
 A function with return type `!` never returns normally.
+
+## Memory Representation
+
+{{ rule(id="3.4:9", cat="normative") }}
+
+The never type is a zero-sized type. See [Zero-Sized Types](../#zero-sized-types) for the general definition.

--- a/docs/spec/src/03-types/05-array-types.md
+++ b/docs/spec/src/03-types/05-array-types.md
@@ -20,7 +20,7 @@ All elements of an array must have the same type `T`.
 
 {{ rule(id="3.5:4", cat="normative") }}
 
-Arrays are stored contiguously in memory. The size of `[T; N]` is `N * size_of(T)`.
+Arrays are stored contiguously in memory. The size of `[T; N]` is `N * size_of(T)`. Zero-length arrays `[T; 0]` are zero-sized types. See [Zero-Sized Types](../#zero-sized-types) for the general definition.
 
 {{ rule(id="3.5:5") }}
 

--- a/docs/spec/src/03-types/06-struct-types.md
+++ b/docs/spec/src/03-types/06-struct-types.md
@@ -54,7 +54,7 @@ The memory layout rules described in this section are provisional and may change
 
 {{ rule(id="3.6:8", cat="normative") }}
 
-All types in Rue occupy one or more 8-byte slots. Scalar types (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `bool`) each occupy one slot. The `unit` type occupies one slot.
+Non-zero-sized types in Rue occupy one or more 8-byte slots. Scalar types (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `bool`) each occupy one slot.
 
 {{ rule(id="3.6:9", cat="normative") }}
 
@@ -76,4 +76,20 @@ struct Line { start: Point, end: Point }  // 4 slots (32 bytes)
 
 {{ rule(id="3.6:12", cat="normative") }}
 
-All structs have 8-byte alignment.
+Structs with one or more fields have 8-byte alignment. Empty structs (zero-sized types) have 1-byte alignment.
+
+{{ rule(id="3.6:13", cat="normative") }}
+
+A struct with no fields is a zero-sized type. See [Zero-Sized Types](../#zero-sized-types) for the general definition.
+
+{{ rule(id="3.6:14") }}
+
+```rue
+// An empty struct is a zero-sized type
+struct Empty {}
+
+fn main() -> i32 {
+    let e = Empty {};
+    @size_of(Empty)  // 0
+}
+```

--- a/docs/spec/src/03-types/_index.md
+++ b/docs/spec/src/03-types/_index.md
@@ -13,3 +13,21 @@ This chapter describes the type system of Rue.
 {{ rule(id="3.0:1") }}
 
 Every value in Rue has a type that determines its representation in memory and the operations that can be performed on it.
+
+## Zero-Sized Types
+
+{{ rule(id="3.0:2", cat="normative") }}
+
+A zero-sized type (ZST) is a type with a size of zero bytes. Zero-sized types can be instantiated and passed by value, but they occupy no storage.
+
+{{ rule(id="3.0:3", cat="normative") }}
+
+The following types are zero-sized:
+- The unit type `()`
+- The never type `!`
+- Empty structs (structs with no fields)
+- Zero-length arrays `[T; 0]` for any type `T`
+
+{{ rule(id="3.0:4", cat="normative") }}
+
+Zero-sized types have an alignment of 1 byte.


### PR DESCRIPTION
Zero-sized types (ZSTs) now have correct size (0 bytes) and alignment (1 byte). This affects:
- Unit type `()`
- Never type `!`  
- Empty structs (structs with no fields)
- Zero-length arrays `[T; 0]`

Previously these types incorrectly occupied 8 bytes with 8-byte alignment. The spec now defines ZSTs centrally in the Types chapter with references from each ZST type's section.

Fixes rue-rae6

🤖 Generated with [Claude Code](https://claude.com/claude-code)