### PR TITLE
Implement @allow(unused_variable) directive

### DIFF
--- a/crates/rue-air/src/inference.rs
+++ b/crates/rue-air/src/inference.rs
@@ -1148,6 +1148,7 @@ impl<'a> ConstraintGenerator<'a> {
 
             // Local variable allocation
             InstData::Alloc {
+                directives: _,
                 name,
                 is_mut,
                 ty: type_annotation,

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -15,7 +15,7 @@ use crate::types::{
 };
 use rue_error::{CompileError, CompileResult, CompileWarning, ErrorKind, WarningKind};
 use rue_intern::{Interner, Symbol};
-use rue_rir::{InstData, InstRef, Rir, RirPattern};
+use rue_rir::{InstData, InstRef, Rir, RirDirective, RirPattern};
 use rue_span::Span;
 
 /// A value that can be computed at compile time.
@@ -92,6 +92,8 @@ struct LocalVar {
     is_mut: bool,
     /// Span of the variable declaration (for unused variable warnings)
     span: Span,
+    /// Whether @allow(unused_variable) was applied to this binding
+    allow_unused: bool,
 }
 
 /// Information about a function parameter.
@@ -252,6 +254,23 @@ impl<'a> Sema<'a> {
         id
     }
 
+    /// Check if directives contain @allow for a specific warning name.
+    fn has_allow_directive(&self, directives: &[RirDirective], warning_name: &str) -> bool {
+        let allow_sym = self.interner.get_symbol("allow");
+        let warning_sym = self.interner.get_symbol(warning_name);
+
+        for directive in directives {
+            if Some(directive.name) == allow_sym {
+                for arg in &directive.args {
+                    if Some(*arg) == warning_sym {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
     /// Check for unused local variables in the current scope (before popping it).
     /// Uses the scope stack to determine which variables were added in the current scope.
     fn check_unused_locals_in_current_scope(&mut self, ctx: &AnalysisContext) {
@@ -276,6 +295,11 @@ impl<'a> Sema<'a> {
 
             // Skip variables starting with underscore (convention for intentionally unused)
             if name.starts_with('_') {
+                continue;
+            }
+
+            // Skip if @allow(unused_variable) was applied
+            if local.allow_unused {
                 continue;
             }
 
@@ -308,6 +332,7 @@ impl<'a> Sema<'a> {
 
         for (_, inst) in self.rir.iter() {
             if let InstData::FnDecl {
+                directives: _,
                 name,
                 params,
                 return_type,
@@ -1398,6 +1423,7 @@ impl<'a> Sema<'a> {
             }
 
             InstData::Alloc {
+                directives,
                 name,
                 is_mut,
                 ty: _,
@@ -1419,6 +1445,9 @@ impl<'a> Sema<'a> {
                     return Ok(AnalysisResult::new(init_result.air_ref, Type::Unit));
                 };
 
+                // Check if @allow(unused_variable) directive is present
+                let allow_unused = self.has_allow_directive(directives, "unused_variable");
+
                 // Allocate slots - structs and arrays need multiple slots
                 // Use abi_slot_count which recursively computes total slots for nested types
                 let slot = ctx.next_slot;
@@ -1433,6 +1462,7 @@ impl<'a> Sema<'a> {
                         ty: var_type,
                         is_mut: *is_mut,
                         span: inst.span,
+                        allow_unused,
                     },
                 );
 

--- a/crates/rue-intern/src/lib.rs
+++ b/crates/rue-intern/src/lib.rs
@@ -190,6 +190,13 @@ impl Interner {
         Some(&self.data[start..end])
     }
 
+    /// Look up a string's symbol without interning it.
+    /// Returns None if the string has not been interned.
+    #[inline]
+    pub fn get_symbol(&self, s: &str) -> Option<Symbol> {
+        self.map.get(s).copied()
+    }
+
     /// Returns the number of interned strings.
     #[inline]
     pub fn len(&self) -> usize {

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -14,6 +14,27 @@ pub struct Ast {
     pub items: Vec<Item>,
 }
 
+/// A directive that modifies compiler behavior for the following item or statement.
+///
+/// Directives use the `@name(args)` syntax and appear before items or statements.
+/// For example: `@allow(unused_variable)`
+#[derive(Debug, Clone)]
+pub struct Directive {
+    /// The directive name (without the @)
+    pub name: Ident,
+    /// Arguments to the directive
+    pub args: Vec<DirectiveArg>,
+    /// Span covering the entire directive
+    pub span: Span,
+}
+
+/// An argument to a directive.
+#[derive(Debug, Clone)]
+pub enum DirectiveArg {
+    /// An identifier argument (e.g., `unused_variable` in `@allow(unused_variable)`)
+    Ident(Ident),
+}
+
 /// A top-level item in a source file.
 #[derive(Debug, Clone)]
 pub enum Item {
@@ -67,6 +88,8 @@ pub struct EnumVariant {
 /// A function definition.
 #[derive(Debug, Clone)]
 pub struct Function {
+    /// Directives applied to this function
+    pub directives: Vec<Directive>,
     /// Function name
     pub name: Ident,
     /// Function parameters
@@ -485,6 +508,8 @@ impl LetPattern {
 /// A let binding statement.
 #[derive(Debug, Clone)]
 pub struct LetStatement {
+    /// Directives applied to this let binding
+    pub directives: Vec<Directive>,
     /// Whether the binding is mutable
     pub is_mut: bool,
     /// The binding pattern (identifier or wildcard)

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -5,11 +5,11 @@
 
 use crate::ast::{
     ArrayLitExpr, AssignStatement, AssignTarget, Ast, BinaryExpr, BinaryOp, BlockExpr, BoolLit,
-    BreakExpr, CallExpr, ContinueExpr, EnumDecl, EnumVariant, Expr, FieldDecl, FieldExpr,
-    FieldInit, Function, Ident, IfExpr, IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr, Item,
-    LetPattern, LetStatement, LoopExpr, MatchArm, MatchExpr, NegIntLit, Param, ParenExpr, PathExpr,
-    PathPattern, Pattern, ReturnExpr, Statement, StringLit, StructDecl, StructLitExpr, TypeExpr,
-    UnaryExpr, UnaryOp, UnitLit, WhileExpr,
+    BreakExpr, CallExpr, ContinueExpr, Directive, DirectiveArg, EnumDecl, EnumVariant, Expr,
+    FieldDecl, FieldExpr, FieldInit, Function, Ident, IfExpr, IndexExpr, IntLit, IntrinsicArg,
+    IntrinsicCallExpr, Item, LetPattern, LetStatement, LoopExpr, MatchArm, MatchExpr, NegIntLit,
+    Param, ParenExpr, PathExpr, PathPattern, Pattern, ReturnExpr, Statement, StringLit, StructDecl,
+    StructLitExpr, TypeExpr, UnaryExpr, UnaryOp, UnitLit, WhileExpr,
 };
 use chumsky::input::{Input as ChumskyInput, Stream, ValueInput};
 use chumsky::pratt::{infix, left, prefix};
@@ -144,6 +144,38 @@ where
     param_parser()
         .separated_by(just(TokenKind::Comma))
         .collect()
+}
+
+/// Parser for a single directive: @name(arg1, arg2, ...)
+fn directive_parser<'src, I>()
+-> impl Parser<'src, I, Directive, extra::Err<Rich<'src, TokenKind>>> + Clone
+where
+    I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
+{
+    just(TokenKind::At)
+        .ignore_then(ident_parser())
+        .then(
+            ident_parser()
+                .map(DirectiveArg::Ident)
+                .separated_by(just(TokenKind::Comma))
+                .allow_trailing()
+                .collect::<Vec<_>>()
+                .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
+        )
+        .map_with(|(name, args), e| Directive {
+            name,
+            args,
+            span: to_rue_span(e.span()),
+        })
+}
+
+/// Parser for zero or more directives
+fn directives_parser<'src, I>()
+-> impl Parser<'src, I, Vec<Directive>, extra::Err<Rich<'src, TokenKind>>> + Clone
+where
+    I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
+{
+    directive_parser().repeated().collect()
 }
 
 /// Parser for comma-separated expression arguments
@@ -756,22 +788,23 @@ where
     ident.or(wildcard)
 }
 
-/// Parser for let statements: let [mut] pattern [: type] = expr;
+/// Parser for let statements: [@directive]* let [mut] pattern [: type] = expr;
 fn let_statement_parser<'src, I>(
     expr: impl Parser<'src, I, Expr, extra::Err<Rich<'src, TokenKind>>> + Clone,
 ) -> impl Parser<'src, I, Statement, extra::Err<Rich<'src, TokenKind>>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    just(TokenKind::Let)
-        .ignore_then(just(TokenKind::Mut).or_not().map(|m| m.is_some()))
+    directives_parser()
+        .then(just(TokenKind::Let).ignore_then(just(TokenKind::Mut).or_not().map(|m| m.is_some())))
         .then(let_pattern_parser())
         .then(just(TokenKind::Colon).ignore_then(type_parser()).or_not())
         .then_ignore(just(TokenKind::Eq))
         .then(expr)
         .then_ignore(just(TokenKind::Semi))
-        .map_with(|(((is_mut, pattern), ty), init), e| {
+        .map_with(|((((directives, is_mut), pattern), ty), init), e| {
             Statement::Let(LetStatement {
+                directives,
                 is_mut,
                 pattern,
                 ty,
@@ -1052,7 +1085,7 @@ where
         })
 }
 
-/// Parser for function definitions: fn name(params) -> Type { body }
+/// Parser for function definitions: [@directive]* fn name(params) -> Type { body }
 fn function_parser<'src, I>()
 -> impl Parser<'src, I, Function, extra::Err<Rich<'src, TokenKind>>> + Clone
 where
@@ -1060,18 +1093,21 @@ where
 {
     let expr = expr_parser();
 
-    just(TokenKind::Fn)
-        .ignore_then(ident_parser())
+    directives_parser()
+        .then(just(TokenKind::Fn).ignore_then(ident_parser()))
         .then(params_parser().delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)))
         .then(just(TokenKind::Arrow).ignore_then(type_parser()).or_not())
         .then(block_parser(expr))
-        .map_with(|(((name, params), return_type), body), e| Function {
-            name,
-            params,
-            return_type,
-            body,
-            span: to_rue_span(e.span()),
-        })
+        .map_with(
+            |((((directives, name), params), return_type), body), e| Function {
+                directives,
+                name,
+                params,
+                return_type,
+                body,
+                span: to_rue_span(e.span()),
+            },
+        )
 }
 
 /// Parser for struct definitions: struct Name { field: Type, ... }

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -7,9 +7,9 @@ mod chumsky_parser;
 
 pub use ast::{
     ArrayLitExpr, AssignStatement, AssignTarget, Ast, BinaryExpr, BinaryOp, BlockExpr, CallExpr,
-    EnumDecl, EnumVariant, Expr, FieldDecl, FieldExpr, FieldInit, Function, Ident, IndexExpr,
-    IntLit, IntrinsicArg, IntrinsicCallExpr, Item, LetPattern, LetStatement, MatchArm, MatchExpr,
-    Param, ParenExpr, PathExpr, PathPattern, Pattern, ReturnExpr, Statement, StructDecl,
-    StructLitExpr, TypeExpr, UnaryExpr, UnaryOp, WhileExpr,
+    Directive, DirectiveArg, EnumDecl, EnumVariant, Expr, FieldDecl, FieldExpr, FieldInit,
+    Function, Ident, IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr, Item, LetPattern,
+    LetStatement, MatchArm, MatchExpr, Param, ParenExpr, PathExpr, PathPattern, Pattern,
+    ReturnExpr, Statement, StructDecl, StructLitExpr, TypeExpr, UnaryExpr, UnaryOp, WhileExpr,
 };
 pub use chumsky_parser::ChumskyParser as Parser;

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -9,11 +9,11 @@ use rue_intern::Interner;
 /// These intrinsics operate on types at compile time (e.g., @size_of(i32)).
 const TYPE_INTRINSICS: &[&str] = &["size_of", "align_of"];
 use rue_parser::{
-    AssignTarget, Ast, BinaryOp, EnumDecl, Expr, Function, IntrinsicArg, Item, LetPattern, Pattern,
-    Statement, StructDecl, TypeExpr, UnaryOp,
+    AssignTarget, Ast, BinaryOp, Directive, DirectiveArg, EnumDecl, Expr, Function, IntrinsicArg,
+    Item, LetPattern, Pattern, Statement, StructDecl, TypeExpr, UnaryOp,
 };
 
-use crate::inst::{Inst, InstData, InstRef, Rir, RirPattern};
+use crate::inst::{Inst, InstData, InstRef, Rir, RirDirective, RirPattern};
 
 /// Generates RIR from an AST.
 pub struct AstGen<'a> {
@@ -110,7 +110,28 @@ impl<'a> AstGen<'a> {
         })
     }
 
+    /// Convert AST directives to RIR directives
+    fn convert_directives(&mut self, directives: &[Directive]) -> Vec<RirDirective> {
+        directives
+            .iter()
+            .map(|d| RirDirective {
+                name: self.interner.intern(&d.name.name),
+                args: d
+                    .args
+                    .iter()
+                    .map(|arg| match arg {
+                        DirectiveArg::Ident(ident) => self.interner.intern(&ident.name),
+                    })
+                    .collect(),
+                span: d.span,
+            })
+            .collect()
+    }
+
     fn gen_function(&mut self, func: &Function) -> InstRef {
+        // Convert directives
+        let directives = self.convert_directives(&func.directives);
+
         // Intern the function name and return type
         let name = self.interner.intern(&func.name.name);
         let return_type = match &func.return_type {
@@ -135,6 +156,7 @@ impl<'a> AstGen<'a> {
         // Create function declaration instruction
         self.rir.add_inst(Inst {
             data: InstData::FnDecl {
+                directives,
                 name,
                 params,
                 return_type,
@@ -438,6 +460,7 @@ impl<'a> AstGen<'a> {
     fn gen_statement(&mut self, stmt: &Statement) -> InstRef {
         match stmt {
             Statement::Let(let_stmt) => {
+                let directives = self.convert_directives(&let_stmt.directives);
                 let name = match &let_stmt.pattern {
                     LetPattern::Ident(ident) => Some(self.interner.intern(&ident.name)),
                     LetPattern::Wildcard(_) => None,
@@ -446,6 +469,7 @@ impl<'a> AstGen<'a> {
                 let init = self.gen_expr(&let_stmt.init);
                 self.rir.add_inst(Inst {
                     data: InstData::Alloc {
+                        directives,
                         name,
                         is_mut: let_stmt.is_mut,
                         ty,
@@ -520,6 +544,7 @@ mod tests {
         let (_, fn_inst) = rir.iter().last().unwrap();
         match &fn_inst.data {
             InstData::FnDecl {
+                directives: _,
                 name,
                 params,
                 return_type,
@@ -671,6 +696,7 @@ mod tests {
         let (_, inst) = alloc_inst.unwrap();
         match &inst.data {
             InstData::Alloc {
+                directives: _,
                 name,
                 is_mut,
                 ty,

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -28,6 +28,17 @@ impl InstRef {
     }
 }
 
+/// A directive in the RIR (e.g., @allow(unused_variable))
+#[derive(Debug, Clone)]
+pub struct RirDirective {
+    /// Directive name (e.g., "allow")
+    pub name: Symbol,
+    /// Arguments (e.g., ["unused_variable"])
+    pub args: Vec<Symbol>,
+    /// Span covering the directive
+    pub span: Span,
+}
+
 /// A pattern in a match expression (RIR level - untyped).
 #[derive(Debug, Clone)]
 pub enum RirPattern {
@@ -235,6 +246,8 @@ pub enum InstData {
     /// Function definition
     /// Contains: name symbol, parameters, return type symbol, body instruction ref
     FnDecl {
+        /// Directives applied to this function
+        directives: Vec<RirDirective>,
         name: Symbol,
         /// Parameter symbols and their type symbols: [(param_name, param_type), ...]
         params: Vec<(Symbol, Symbol)>,
@@ -290,6 +303,8 @@ pub enum InstData {
     /// Local variable declaration: allocates storage and initializes
     /// If name is None, this is a wildcard pattern that discards the value
     Alloc {
+        /// Directives applied to this let binding
+        directives: Vec<RirDirective>,
         /// Variable name (None for wildcard `_` pattern that discards the value)
         name: Option<Symbol>,
         /// Whether the variable is mutable
@@ -542,6 +557,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     out.push_str("continue\n");
                 }
                 InstData::FnDecl {
+                    directives: _,
                     name,
                     params,
                     return_type,
@@ -602,6 +618,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     out.push_str(&format!("block({}, {})\n", extra_start, len));
                 }
                 InstData::Alloc {
+                    directives: _,
                     name,
                     is_mut,
                     ty,

--- a/crates/rue-rir/src/lib.rs
+++ b/crates/rue-rir/src/lib.rs
@@ -14,4 +14,4 @@ mod astgen;
 mod inst;
 
 pub use astgen::AstGen;
-pub use inst::{Inst, InstData, InstRef, Rir, RirPattern, RirPrinter};
+pub use inst::{Inst, InstData, InstRef, Rir, RirDirective, RirPattern, RirPrinter};

--- a/crates/rue-spec/cases/lexical/builtins.toml
+++ b/crates/rue-spec/cases/lexical/builtins.toml
@@ -1,0 +1,221 @@
+[section]
+id = "lexical.builtins"
+spec_chapter = "2.5"
+name = "Builtins"
+description = "Builtins are compiler-provided constructs prefixed with @."
+
+# =============================================================================
+# Builtin Syntax
+# =============================================================================
+
+[[case]]
+name = "builtin_at_prefix"
+spec = ["2.5:1", "2.5:3"]
+source = """
+fn main() -> i32 {
+    @dbg(42);
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "builtin_kinds_intrinsic"
+spec = ["2.5:5", "2.5:6"]
+source = """
+fn main() -> i32 {
+    @size_of(i32)
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "builtin_kinds_directive"
+spec = ["2.5:5", "2.5:7", "2.5:8"]
+source = """
+fn main() -> i32 {
+    @allow(unused_variable)
+    let x = 42;
+    0
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "unknown_builtin_error"
+spec = ["2.5:4"]
+source = """
+fn main() -> i32 {
+    @unknown_builtin(42);
+    0
+}
+"""
+compile_fail = true
+error_contains = "unknown intrinsic"
+
+# =============================================================================
+# Directive Syntax
+# =============================================================================
+
+[[case]]
+name = "directive_grammar"
+spec = ["2.5:2", "2.5:9"]
+source = """
+fn main() -> i32 {
+    @allow(unused_variable)
+    let x = 42;
+    0
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "directive_must_precede_item"
+spec = ["2.5:10"]
+skip = true  # TODO: This error isn't implemented yet
+source = """
+fn main() -> i32 {
+    @allow(unused_variable)
+}
+"""
+compile_fail = true
+error_contains = "directive must precede"
+
+# =============================================================================
+# @allow Directive
+# =============================================================================
+
+[[case]]
+name = "allow_suppresses_warnings"
+spec = ["2.5:11"]
+source = """
+fn main() -> i32 {
+    @allow(unused_variable)
+    let x = 42;
+    0
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "allow_accepts_warning_names"
+spec = ["2.5:12", "2.5:13"]
+source = """
+fn main() -> i32 {
+    @allow(unused_variable)
+    let x = 42;
+    0
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "allow_unknown_warning_error"
+spec = ["2.5:14"]
+skip = true  # TODO: This error isn't implemented yet
+source = """
+fn main() -> i32 {
+    @allow(nonexistent_warning)
+    let x = 42;
+    0
+}
+"""
+compile_fail = true
+error_contains = "unrecognized warning"
+
+[[case]]
+name = "allow_unused_variable_on_let"
+spec = ["2.5:15"]
+source = """
+fn main() -> i32 {
+    @allow(unused_variable)
+    let x = 42;
+    0
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "allow_unused_variable_on_function"
+spec = ["2.5:17"]
+skip = true  # TODO: Function-level @allow not yet implemented
+source = """
+@allow(unused_variable)
+fn example() -> i32 {
+    let a = 1;
+    let b = 2;
+    0
+}
+
+fn main() -> i32 {
+    example()
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "allow_unused_function"
+spec = ["2.5:19"]
+skip = true  # TODO: Unused function warnings not yet implemented
+source = """
+@allow(unused_function)
+fn helper() -> i32 { 42 }
+
+fn main() -> i32 {
+    0
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "allow_unreachable_code"
+spec = ["2.5:21"]
+skip = true  # TODO: Need to propagate directives to CFG
+source = """
+@allow(unreachable_code)
+fn example() -> i32 {
+    return 0;
+    let x = 42;
+    x
+}
+
+fn main() -> i32 {
+    example()
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "allow_multiple_warnings"
+spec = ["2.5:23"]
+source = """
+fn main() -> i32 {
+    @allow(unused_variable, unreachable_code)
+    let x = 42;
+    0
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "allow_vs_underscore_prefix"
+spec = ["2.5:25"]
+source = """
+fn main() -> i32 {
+    let _x = 42;
+    @allow(unused_variable)
+    let y = 10;
+    0
+}
+"""
+exit_code = 0
+no_warnings = true

--- a/crates/rue-ui-tests/cases/warnings/unused.toml
+++ b/crates/rue-ui-tests/cases/warnings/unused.toml
@@ -258,6 +258,48 @@ exit_code = 0
 no_warnings = true
 
 # =============================================================================
+# @allow directive tests
+# =============================================================================
+
+[[case]]
+name = "allow_unused_variable_suppresses_warning"
+source = """
+fn main() -> i32 {
+    @allow(unused_variable)
+    let x = 42;
+    0
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "allow_unused_variable_only_affects_annotated"
+source = """
+fn main() -> i32 {
+    @allow(unused_variable)
+    let x = 42;
+    let y = 10;
+    0
+}
+"""
+exit_code = 0
+warning_contains = ["unused variable", "'y'"]
+expected_warning_count = 1
+
+[[case]]
+name = "allow_unused_variable_multiple_args"
+source = """
+fn main() -> i32 {
+    @allow(unused_variable, unreachable_code)
+    let x = 42;
+    0
+}
+"""
+exit_code = 0
+no_warnings = true
+
+# =============================================================================
 # Mixed unused warnings
 # =============================================================================
 

--- a/docs/spec/src/02-lexical-structure/05-builtins.md
+++ b/docs/spec/src/02-lexical-structure/05-builtins.md
@@ -1,0 +1,193 @@
++++
+title = "Builtins"
+weight = 5
+template = "spec/page.html"
++++
+
+# Builtins
+
+{{ rule(id="2.5:1", cat="normative") }}
+
+A builtin is a compiler-provided construct prefixed with `@`.
+
+{{ rule(id="2.5:2", cat="normative") }}
+
+```ebnf
+builtin = "@" IDENT "(" [ builtin_args ] ")" ;
+builtin_args = builtin_arg { "," builtin_arg } ;
+builtin_arg = IDENT | expression | type ;
+```
+
+{{ rule(id="2.5:3", cat="normative") }}
+
+The `@` prefix distinguishes builtins from user-defined constructs.
+
+{{ rule(id="2.5:4", cat="legality-rule") }}
+
+Using an unknown builtin name is a compile-time error.
+
+## Builtin Kinds
+
+{{ rule(id="2.5:5", cat="normative") }}
+
+There are two kinds of builtins, distinguished by their syntactic position:
+
+| Kind | Position | Purpose | Examples |
+|------|----------|---------|----------|
+| Intrinsic | Expression | Produces a value | `@dbg`, `@size_of`, `@align_of` |
+| Directive | Before item/statement | Modifies compiler behavior | `@allow` |
+
+{{ rule(id="2.5:6", cat="normative") }}
+
+An intrinsic builtin appears where an expression is expected and evaluates to a value. See [Intrinsic Expressions](@/04-expressions/13-intrinsics.md) for details.
+
+{{ rule(id="2.5:7", cat="normative") }}
+
+A directive builtin appears before an item or statement and modifies how the compiler processes that construct. See [Directives](#directives) for details.
+
+# Directives
+
+{{ rule(id="2.5:8", cat="normative") }}
+
+A directive is a builtin that modifies the behavior of the immediately following item or statement.
+
+{{ rule(id="2.5:9", cat="normative") }}
+
+```ebnf
+directive = "@" IDENT "(" [ directive_args ] ")" ;
+directive_args = directive_arg { "," directive_arg } ;
+directive_arg = IDENT ;
+```
+
+{{ rule(id="2.5:10", cat="legality-rule") }}
+
+A directive **MUST** be immediately followed by an item or statement. A directive at the end of a file or block without a following construct is a compile-time error.
+
+## `@allow`
+
+{{ rule(id="2.5:11", cat="normative") }}
+
+The `@allow` directive suppresses specific compiler warnings for the following item or statement.
+
+{{ rule(id="2.5:12", cat="normative") }}
+
+`@allow` accepts one or more warning names as arguments.
+
+{{ rule(id="2.5:13", cat="normative") }}
+
+The following warning names are recognized:
+
+| Warning Name | Description |
+|--------------|-------------|
+| `unused_variable` | Variable is declared but never used |
+| `unused_function` | Function is declared but never called |
+| `unreachable_code` | Code that can never be executed |
+| `unreachable_pattern` | Match arm pattern that can never match |
+
+{{ rule(id="2.5:14", cat="legality-rule") }}
+
+Using an unrecognized warning name in `@allow` is a compile-time error.
+
+### Suppressing Unused Variable Warnings
+
+{{ rule(id="2.5:15", cat="normative") }}
+
+When `@allow(unused_variable)` precedes a let statement, no unused variable warning is emitted for that binding.
+
+{{ rule(id="2.5:16") }}
+
+```rue
+fn main() -> i32 {
+    @allow(unused_variable)
+    let x = 42;  // no warning, even though x is unused
+    0
+}
+```
+
+{{ rule(id="2.5:17", cat="normative") }}
+
+When `@allow(unused_variable)` precedes a function definition, no unused variable warnings are emitted for any bindings within that function.
+
+{{ rule(id="2.5:18") }}
+
+```rue
+@allow(unused_variable)
+fn example() -> i32 {
+    let a = 1;  // no warning
+    let b = 2;  // no warning
+    0
+}
+```
+
+### Suppressing Unused Function Warnings
+
+{{ rule(id="2.5:19", cat="normative") }}
+
+When `@allow(unused_function)` precedes a function definition, no unused function warning is emitted for that function.
+
+{{ rule(id="2.5:20") }}
+
+```rue
+@allow(unused_function)
+fn helper() {
+    // This function is never called, but no warning is emitted
+}
+
+fn main() -> i32 {
+    0
+}
+```
+
+### Suppressing Unreachable Code Warnings
+
+{{ rule(id="2.5:21", cat="normative") }}
+
+When `@allow(unreachable_code)` precedes a function definition, no unreachable code warnings are emitted for code within that function.
+
+{{ rule(id="2.5:22") }}
+
+```rue
+@allow(unreachable_code)
+fn example() -> i32 {
+    return 0;
+    let x = 42;  // unreachable, but no warning
+    x
+}
+```
+
+### Multiple Warnings
+
+{{ rule(id="2.5:23", cat="normative") }}
+
+Multiple warning names may be specified in a single `@allow` directive, separated by commas.
+
+{{ rule(id="2.5:24") }}
+
+```rue
+@allow(unused_variable, unreachable_code)
+fn example() -> i32 {
+    let x = 1;
+    return 0;
+    let y = 2;
+    0
+}
+```
+
+### Relationship to Underscore Prefix
+
+{{ rule(id="2.5:25", cat="normative") }}
+
+The underscore prefix convention (e.g., `_unused`) and `@allow(unused_variable)` are both valid ways to suppress unused variable warnings. The underscore prefix is more concise for individual variables; `@allow` is useful when suppressing warnings for an entire function or when the variable name should not have an underscore prefix.
+
+{{ rule(id="2.5:26") }}
+
+```rue
+fn main() -> i32 {
+    let _x = 42;                    // underscore prefix suppresses warning
+
+    @allow(unused_variable)
+    let important_name = 42;        // @allow preserves the meaningful name
+
+    0
+}
+```

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -8,7 +8,7 @@ template = "spec/page.html"
 
 {{ rule(id="4.13:1", cat="normative") }}
 
-An intrinsic expression invokes a compiler-provided primitive operation.
+An intrinsic expression is a [builtin](@/02-lexical-structure/05-builtins.md) that appears in expression position and produces a value.
 
 {{ rule(id="4.13:2", cat="normative") }}
 
@@ -23,15 +23,15 @@ Intrinsics may accept expressions, types, or a combination of both as arguments,
 
 {{ rule(id="4.13:3", cat="normative") }}
 
-Intrinsics are prefixed with `@` to distinguish them from user-defined functions.
-
-{{ rule(id="4.13:4", cat="normative") }}
-
 Each intrinsic has a fixed signature specifying the number and types of arguments it accepts.
 
-{{ rule(id="4.13:5", cat="normative") }}
+{{ rule(id="4.13:4", cat="legality-rule") }}
 
-Using an unknown intrinsic name is a compile-time error.
+It is a compile-time error to call an intrinsic with the wrong number of arguments.
+
+{{ rule(id="4.13:5", cat="legality-rule") }}
+
+It is a compile-time error to use an unknown intrinsic name.
 
 ## `@dbg`
 

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -11,7 +11,15 @@ This appendix contains the complete EBNF grammar for Rue.
 ```ebnf
 (* Program structure *)
 program        = { item } ;
-item           = function | struct_def | enum_def ;
+item           = [ directive ] ( function | struct_def | enum_def ) ;
+
+(* Builtins *)
+directive      = "@" IDENT "(" [ directive_args ] ")" ;
+directive_args = directive_arg { "," directive_arg } ;
+directive_arg  = IDENT ;
+intrinsic      = "@" IDENT "(" [ intrinsic_args ] ")" ;
+intrinsic_args = intrinsic_arg { "," intrinsic_arg } ;
+intrinsic_arg  = expression | type ;
 
 (* Functions *)
 function       = "fn" IDENT "(" [ params ] ")" [ "->" type ] "{" block "}" ;
@@ -29,7 +37,7 @@ enum_def       = "enum" IDENT "{" [ enum_variants ] "}" ;
 enum_variants  = IDENT { "," IDENT } [ "," ] ;
 
 (* Statements *)
-statement      = let_stmt | assign_stmt | expr_stmt ;
+statement      = [ directive ] ( let_stmt | assign_stmt | expr_stmt ) ;
 let_stmt       = "let" [ "mut" ] IDENT [ ":" type ] "=" expression ";" ;
 assign_stmt    = IDENT "=" expression ";"
                | IDENT "[" expression "]" "=" expression ";"
@@ -70,9 +78,6 @@ primary        = INTEGER | BOOL | IDENT | enum_variant_expr
                | struct_literal
                | intrinsic ;
 enum_variant_expr = IDENT "::" IDENT ;
-intrinsic      = "@" IDENT "(" [ intrinsic_args ] ")" ;
-intrinsic_args = intrinsic_arg { "," intrinsic_arg } ;
-intrinsic_arg  = expression | type ;
 
 (* Compound expressions *)
 block_expr     = "{" block "}" ;


### PR DESCRIPTION
Add warning suppression mechanism using @allow(...) syntax, consistent with existing @intrinsic() builtins. This introduces a unified "builtins" concept covering both intrinsics (expression position) and directives (before items).

Changes:
- Add spec section 2.5 for builtins (docs/spec/src/02-lexical-structure/05-builtins.md)
- Update grammar appendix with directive and intrinsic productions
- Add Directive and DirectiveArg AST types to rue-parser
- Add directive parsing to function and let statement parsers
- Add RirDirective representation in rue-rir
- Add allow_unused field to LocalVar in sema
- Add has_allow_directive() helper and get_symbol() to Interner
- Add spec tests for builtins (crates/rue-spec/cases/lexical/builtins.toml)
- Add UI tests for @allow directive

Deferred:
- Function-level @allow affecting all contained variables
- @allow(unused_function) - unused function warnings not yet implemented
- @allow(unreachable_code) - needs CFG integration

Closes rue-11z

🤖 Generated with [Claude Code](https://claude.com/claude-code)