### PR TITLE
Remove duplicate match arms in lexer Display impl

### DIFF
--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -247,8 +247,6 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Comma => write!(f, "COMMA"),
             TokenKind::Dot => write!(f, "DOT"),
             TokenKind::At => write!(f, "AT"),
-            TokenKind::LBracket => write!(f, "LBRACKET"),
-            TokenKind::RBracket => write!(f, "RBRACKET"),
             TokenKind::Eof => write!(f, "EOF"),
         }
     }


### PR DESCRIPTION
The LBracket and RBracket tokens were matched twice in the Display impl for TokenKind. The second occurrence was unreachable dead code.

Fixes rue-id3t

🤖 Generated with [Claude Code](https://claude.com/claude-code)