### PR TITLE
Improve missing struct field error message

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -1815,11 +1815,17 @@ impl<'a> Sema<'a> {
 
                 // Check that all fields are provided
                 if field_inits.len() != struct_def.fields.len() {
+                    // Find which fields are missing
+                    let missing_fields: Vec<String> = struct_def
+                        .fields
+                        .iter()
+                        .filter(|f| !seen_fields.contains(f.name.as_str()))
+                        .map(|f| f.name.clone())
+                        .collect();
                     return Err(CompileError::new(
-                        ErrorKind::WrongFieldCount {
+                        ErrorKind::MissingFields {
                             struct_name: struct_def.name.clone(),
-                            expected: struct_def.fields.len(),
-                            found: field_inits.len(),
+                            missing_fields,
                         },
                         inst.span,
                     ));

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -249,10 +249,9 @@ pub enum ErrorKind {
     },
 
     // Struct errors
-    WrongFieldCount {
+    MissingFields {
         struct_name: String,
-        expected: usize,
-        found: usize,
+        missing_fields: Vec<String>,
     },
     UnknownField {
         struct_name: String,
@@ -460,23 +459,23 @@ impl fmt::Display for ErrorKind {
                     write!(f, "expected {} arguments, found {}", expected, found)
                 }
             }
-            ErrorKind::WrongFieldCount {
+            ErrorKind::MissingFields {
                 struct_name,
-                expected,
-                found,
+                missing_fields,
             } => {
-                if *expected == 1 {
+                if missing_fields.len() == 1 {
                     write!(
                         f,
-                        "struct '{}' has {} field, but {} were supplied",
-                        struct_name, expected, found
+                        "missing field '{}' in struct '{}'",
+                        missing_fields[0], struct_name
                     )
                 } else {
-                    write!(
-                        f,
-                        "struct '{}' has {} fields, but {} were supplied",
-                        struct_name, expected, found
-                    )
+                    let fields = missing_fields
+                        .iter()
+                        .map(|f| format!("'{}'", f))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    write!(f, "missing fields {} in struct '{}'", fields, struct_name)
                 }
             }
             ErrorKind::UnknownField {


### PR DESCRIPTION
Replace the generic "struct has N fields, but M were supplied" error with a specific "missing field 'X' in struct 'Y'" error that tells users exactly which fields they forgot to initialize.

Fixes rue-uk53

🤖 Generated with [Claude Code](https://claude.com/claude-code)