### PR TITLE
Make Shl RCX conflict check run in release builds

### DIFF
--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -542,8 +542,8 @@ impl<'a> Emitter<'a> {
                 }
 
                 // If dst is RCX, that's a conflict (dst would be clobbered by the move above
-                // or would shift itself by itself). Better to assert first.
-                debug_assert!(
+                // or would shift itself by itself).
+                assert!(
                     dst != Reg::Rcx,
                     "Shl dst allocated to RCX, but x86 requires count in CL; \
          regalloc must avoid assigning dst=RCX for Shl"


### PR DESCRIPTION
Change debug_assert! to assert! so the register allocation conflict check (dst != RCX for Shl instructions) runs in release builds. Previously, invalid allocation could silently produce wrong code.

Fixes rue-4dc3

🤖 Generated with [Claude Code](https://claude.com/claude-code)