### PR TITLE
Implement Phase 1 of affine types: move semantics for structs

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -96,6 +96,13 @@ struct LocalVar {
     allow_unused: bool,
 }
 
+/// Information about a variable that has been moved.
+#[derive(Debug, Clone)]
+struct MoveInfo {
+    /// Span where the move occurred
+    moved_at: Span,
+}
+
 /// Information about a function parameter.
 #[derive(Debug, Clone)]
 struct ParamInfo {
@@ -133,6 +140,9 @@ struct AnalysisContext<'a> {
     /// This is populated by running constraint generation and unification
     /// before AIR emission.
     resolved_types: &'a HashMap<InstRef, Type>,
+    /// Variables that have been moved (for affine type checking).
+    /// Maps variable symbol to move information.
+    moved_vars: HashMap<Symbol, MoveInfo>,
 }
 
 impl AnalysisContext<'_> {
@@ -169,6 +179,10 @@ impl AnalysisContext<'_> {
         if let Some(current_scope) = self.scope_stack.last_mut() {
             current_scope.push((symbol, old_value));
         }
+        // When a variable is (re)declared, clear any moved state for it.
+        // This handles shadowing: `let x = moved_val; let x = new_val;`
+        // The new `x` is a fresh binding and shouldn't carry the old moved state.
+        self.moved_vars.remove(&symbol);
     }
 }
 
@@ -525,6 +539,7 @@ impl<'a> Sema<'a> {
             return_type,
             scope_stack: Vec::new(),
             resolved_types: &resolved_types,
+            moved_vars: HashMap::new(),
         };
 
         // ======================================================================
@@ -737,6 +752,136 @@ impl<'a> Sema<'a> {
             // All other types wrap directly
             _ => InferType::Concrete(ty),
         }
+    }
+
+    /// Analyze an RIR instruction for projection (field access).
+    ///
+    /// This is like `analyze_inst` but does NOT mark non-Copy values as moved.
+    /// Used for field access where we're reading from a struct without consuming it.
+    /// We still check that the variable hasn't already been moved.
+    fn analyze_inst_for_projection(
+        &mut self,
+        air: &mut Air,
+        inst_ref: InstRef,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        let inst = self.rir.get(inst_ref);
+
+        // For VarRef, we handle it specially: check for moves but don't mark as moved
+        if let InstData::VarRef { name } = &inst.data {
+            // First check if it's a parameter
+            if let Some(param_info) = ctx.params.get(name) {
+                let ty = param_info.ty;
+
+                // Check if this parameter has been moved
+                if let Some(move_info) = ctx.moved_vars.get(name) {
+                    let name_str = self.interner.get(*name);
+                    return Err(CompileError::new(
+                        ErrorKind::UseAfterMove {
+                            var_name: name_str.to_string(),
+                        },
+                        inst.span,
+                    )
+                    .with_label("value moved here", move_info.moved_at));
+                }
+
+                // NOTE: We do NOT mark as moved here - this is a projection
+
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::Param {
+                        index: param_info.abi_slot,
+                    },
+                    ty,
+                    span: inst.span,
+                });
+                return Ok(AnalysisResult::new(air_ref, ty));
+            }
+
+            // Look up the variable in locals
+            let name_str = self.interner.get(*name);
+            let local = ctx.locals.get(name).ok_or_else(|| {
+                CompileError::new(
+                    ErrorKind::UndefinedVariable(name_str.to_string()),
+                    inst.span,
+                )
+            })?;
+
+            let ty = local.ty;
+            let slot = local.slot;
+
+            // Check if this variable has been moved
+            if let Some(move_info) = ctx.moved_vars.get(name) {
+                return Err(CompileError::new(
+                    ErrorKind::UseAfterMove {
+                        var_name: name_str.to_string(),
+                    },
+                    inst.span,
+                )
+                .with_label("value moved here", move_info.moved_at));
+            }
+
+            // NOTE: We do NOT mark as moved here - this is a projection
+
+            // Mark variable as used
+            ctx.used_locals.insert(*name);
+
+            // Load the variable
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::Load { slot },
+                ty,
+                span: inst.span,
+            });
+            return Ok(AnalysisResult::new(air_ref, ty));
+        }
+
+        // For nested field access (e.g., a.b.c), recursively use projection mode
+        if let InstData::FieldGet { base, field } = &inst.data {
+            let base_result = self.analyze_inst_for_projection(air, *base, ctx)?;
+            let base_type = base_result.ty;
+
+            let struct_id = match base_type {
+                Type::Struct(id) => id,
+                _ => {
+                    return Err(CompileError::new(
+                        ErrorKind::FieldAccessOnNonStruct {
+                            found: base_type.name().to_string(),
+                        },
+                        inst.span,
+                    ));
+                }
+            };
+
+            let struct_def = &self.struct_defs[struct_id.0 as usize];
+            let field_name_str = self.interner.get(*field).to_string();
+
+            let (field_index, struct_field) =
+                struct_def.find_field(&field_name_str).ok_or_else(|| {
+                    CompileError::new(
+                        ErrorKind::UnknownField {
+                            struct_name: struct_def.name.clone(),
+                            field_name: field_name_str.clone(),
+                        },
+                        inst.span,
+                    )
+                })?;
+
+            let field_type = struct_field.ty;
+
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::FieldGet {
+                    base: base_result.air_ref,
+                    struct_id,
+                    field_index: field_index as u32,
+                },
+                ty: field_type,
+                span: inst.span,
+            });
+            return Ok(AnalysisResult::new(air_ref, field_type));
+        }
+
+        // For other expressions, use the normal analyze_inst
+        // (they will trigger move semantics as expected)
+        self.analyze_inst(air, inst_ref, ctx)
     }
 
     /// Analyze an RIR instruction, producing AIR instructions.
@@ -1483,6 +1628,28 @@ impl<'a> Sema<'a> {
                 if let Some(param_info) = ctx.params.get(name) {
                     let ty = param_info.ty;
 
+                    // Check if this parameter has been moved
+                    if let Some(move_info) = ctx.moved_vars.get(name) {
+                        let name_str = self.interner.get(*name);
+                        return Err(CompileError::new(
+                            ErrorKind::UseAfterMove {
+                                var_name: name_str.to_string(),
+                            },
+                            inst.span,
+                        )
+                        .with_label("value moved here", move_info.moved_at));
+                    }
+
+                    // If type is not Copy, mark as moved
+                    if !ty.is_copy() {
+                        ctx.moved_vars.insert(
+                            *name,
+                            MoveInfo {
+                                moved_at: inst.span,
+                            },
+                        );
+                    }
+
                     // Emit Param with the ABI slot (not the parameter index).
                     // For struct parameters, this is the starting slot of the first field.
                     let air_ref = air.add_inst(AirInst {
@@ -1506,6 +1673,27 @@ impl<'a> Sema<'a> {
 
                 let ty = local.ty;
                 let slot = local.slot;
+
+                // Check if this variable has been moved
+                if let Some(move_info) = ctx.moved_vars.get(name) {
+                    return Err(CompileError::new(
+                        ErrorKind::UseAfterMove {
+                            var_name: name_str.to_string(),
+                        },
+                        inst.span,
+                    )
+                    .with_label("value moved here", move_info.moved_at));
+                }
+
+                // If type is not Copy, mark as moved
+                if !ty.is_copy() {
+                    ctx.moved_vars.insert(
+                        *name,
+                        MoveInfo {
+                            moved_at: inst.span,
+                        },
+                    );
+                }
 
                 // Mark variable as used
                 ctx.used_locals.insert(*name);
@@ -1547,6 +1735,10 @@ impl<'a> Sema<'a> {
 
                 // Analyze the value
                 let value_result = self.analyze_inst(air, *value, ctx)?;
+
+                // Assignment to a mutable variable resets its move state.
+                // The variable is now valid again with a new value.
+                ctx.moved_vars.remove(name);
 
                 // Emit store instruction
                 let air_ref = air.add_inst(AirInst {
@@ -1860,8 +2052,10 @@ impl<'a> Sema<'a> {
             }
 
             InstData::FieldGet { base, field } => {
-                // Synthesize the base type in a single traversal
-                let base_result = self.analyze_inst(air, *base, ctx)?;
+                // Field access is a projection - it reads from the struct without consuming it.
+                // We analyze the base in "projection mode" which checks for moves but doesn't
+                // mark the variable as moved.
+                let base_result = self.analyze_inst_for_projection(air, *base, ctx)?;
                 let base_type = base_result.ty;
 
                 let struct_id = match base_type {
@@ -1921,7 +2115,7 @@ impl<'a> Sema<'a> {
                 let mut current_base = *base;
                 let mut field_symbols: Vec<Symbol> = Vec::new();
 
-                let (var_name, root_slot, root_type, is_mut) = loop {
+                let (var_name, root_slot, root_type, is_mut, _root_symbol) = loop {
                     let current_inst = self.rir.get(current_base);
                     match &current_inst.data {
                         InstData::VarRef { name } => {
@@ -1932,7 +2126,25 @@ impl<'a> Sema<'a> {
                                     inst.span,
                                 )
                             })?;
-                            break (name_str.to_string(), local.slot, local.ty, local.is_mut);
+
+                            // Check if this variable has been moved
+                            if let Some(move_info) = ctx.moved_vars.get(name) {
+                                return Err(CompileError::new(
+                                    ErrorKind::UseAfterMove {
+                                        var_name: name_str.to_string(),
+                                    },
+                                    inst.span,
+                                )
+                                .with_label("value moved here", move_info.moved_at));
+                            }
+
+                            break (
+                                name_str.to_string(),
+                                local.slot,
+                                local.ty,
+                                local.is_mut,
+                                *name,
+                            );
                         }
                         InstData::FieldGet {
                             base: inner_base,
@@ -2167,8 +2379,9 @@ impl<'a> Sema<'a> {
             }
 
             InstData::IndexGet { base, index } => {
-                // Synthesize the base type
-                let base_result = self.analyze_inst(air, *base, ctx)?;
+                // Array indexing is a projection - it reads from the array without consuming it.
+                // Like field access, we analyze the base in projection mode.
+                let base_result = self.analyze_inst_for_projection(air, *base, ctx)?;
                 let base_type = base_result.ty;
 
                 let array_type_id = match base_type {
@@ -2236,6 +2449,18 @@ impl<'a> Sema<'a> {
                                 inst.span,
                             )
                         })?;
+
+                        // Check if this variable has been moved
+                        if let Some(move_info) = ctx.moved_vars.get(name) {
+                            return Err(CompileError::new(
+                                ErrorKind::UseAfterMove {
+                                    var_name: name_str.to_string(),
+                                },
+                                inst.span,
+                            )
+                            .with_label("value moved here", move_info.moved_at));
+                        }
+
                         (name_str.to_string(), local.slot, local.ty, local.is_mut)
                     }
                     _ => {
@@ -2577,8 +2802,10 @@ impl<'a> Sema<'a> {
                 .with_help("use `&&` to combine comparisons: `a < b && b < c`"));
         }
 
-        let lhs_result = self.analyze_inst(air, lhs, ctx)?;
-        let rhs_result = self.analyze_inst(air, rhs, ctx)?;
+        // Comparisons read values without consuming them (like projections).
+        // This matches Rust's PartialEq trait which takes references.
+        let lhs_result = self.analyze_inst_for_projection(air, lhs, ctx)?;
+        let rhs_result = self.analyze_inst_for_projection(air, rhs, ctx)?;
         let lhs_type = lhs_result.ty;
 
         // Propagate Never/Error without additional type errors

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -242,6 +242,46 @@ impl Type {
         matches!(self, Type::I8 | Type::I16 | Type::I32 | Type::I64)
     }
 
+    /// Check if this is a Copy type (can be implicitly duplicated).
+    ///
+    /// Copy types are:
+    /// - All integer types (i8-i64, u8-u64)
+    /// - Boolean
+    /// - Unit
+    /// - Enum types
+    /// - Never type and Error type (for convenience in error recovery)
+    ///
+    /// Non-Copy types (move types) are:
+    /// - Struct types
+    /// - String
+    /// - Array types (until we implement Copy arrays with Copy elements)
+    pub fn is_copy(&self) -> bool {
+        match self {
+            // Primitive Copy types
+            Type::I8
+            | Type::I16
+            | Type::I32
+            | Type::I64
+            | Type::U8
+            | Type::U16
+            | Type::U32
+            | Type::U64
+            | Type::Bool
+            | Type::Unit => true,
+            // Enum types are Copy (they're small discriminant values)
+            Type::Enum(_) => true,
+            // Never and Error are Copy for convenience
+            Type::Never | Type::Error => true,
+            // Struct types are move types
+            Type::Struct(_) => false,
+            // String is a move type (owns heap data)
+            Type::String => false,
+            // Arrays are move types for now
+            // TODO: Arrays of Copy types could be Copy
+            Type::Array(_) => false,
+        }
+    }
+
     /// Check if this is a 64-bit type (uses 64-bit operations).
     pub fn is_64_bit(&self) -> bool {
         matches!(self, Type::I64 | Type::U64)

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -340,6 +340,11 @@ pub enum ErrorKind {
         feature: PreviewFeature,
         what: String,
     },
+
+    // Move semantics errors
+    UseAfterMove {
+        var_name: String,
+    },
 }
 
 impl CompileError {
@@ -626,6 +631,9 @@ impl fmt::Display for ErrorKind {
             ErrorKind::UnsupportedTarget(msg) => write!(f, "unsupported target: {}", msg),
             ErrorKind::PreviewFeatureRequired { feature, what } => {
                 write!(f, "{} requires preview feature `{}`", what, feature.name())
+            }
+            ErrorKind::UseAfterMove { var_name } => {
+                write!(f, "use of moved value '{}'", var_name)
             }
         }
     }

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -505,11 +505,10 @@ description = "Accessing nested fields of a struct parameter computes correct sl
 source = """
 struct Inner { a: i32, b: i32 }
 struct Outer { inner: Inner, other: i32 }
-fn get_inner_a(o: Outer) -> i32 { o.inner.a }
-fn get_inner_b(o: Outer) -> i32 { o.inner.b }
+fn get_inner_sum(o: Outer) -> i32 { o.inner.a + o.inner.b }
 fn main() -> i32 {
     let o = Outer { inner: Inner { a: 10, b: 20 }, other: 100 };
-    get_inner_a(o) + get_inner_b(o)
+    get_inner_sum(o)
 }
 """
 exit_code = 30

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -1,0 +1,281 @@
+[section]
+id = "types.move-semantics"
+spec_chapter = "3.8"
+name = "Move Semantics"
+description = "Move and copy semantics for types."
+
+# =============================================================================
+# Value Categories
+# =============================================================================
+
+[[case]]
+name = "types_categorized_by_behavior"
+spec = ["3.8:1"]
+description = "Types are categorized as Copy (can be duplicated) or Move (consumed when used)"
+source = """
+struct MoveType { x: i32 }
+fn main() -> i32 {
+    // Copy type: can use multiple times
+    let n = 42;
+    let a = n;
+    let b = n;
+
+    // Move type: consumed on first use
+    let m = MoveType { x: 10 };
+    let c = m;
+    // m is now invalid
+
+    a + b + c.x
+}
+"""
+exit_code = 94
+
+# =============================================================================
+# Copy Types
+# =============================================================================
+
+[[case]]
+name = "integer_is_copy"
+spec = ["3.8:2", "3.8:9"]
+source = """
+fn main() -> i32 {
+    let x = 42;
+    let a = x;
+    let b = x;
+    a + b
+}
+"""
+exit_code = 84
+
+[[case]]
+name = "bool_is_copy"
+spec = ["3.8:2", "3.8:9"]
+source = """
+fn main() -> i32 {
+    let b = true;
+    let c = b;
+    let d = b;
+    if c && d { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "unit_is_copy"
+spec = ["3.8:2"]
+source = """
+fn main() -> i32 {
+    let u = ();
+    let a = u;
+    let b = u;
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "enum_is_copy"
+spec = ["3.8:2"]
+source = """
+enum Color { Red, Green, Blue }
+fn main() -> i32 {
+    let c = Color::Red;
+    let a = c;
+    let b = c;
+    match a {
+        Color::Red => 1,
+        Color::Green => 2,
+        Color::Blue => 3,
+    }
+}
+"""
+exit_code = 1
+
+# =============================================================================
+# Move Types (Structs)
+# =============================================================================
+
+[[case]]
+name = "struct_is_move_type"
+spec = ["3.8:3", "3.8:4"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    let q = p;
+    q.x + q.y
+}
+"""
+exit_code = 3
+
+[[case]]
+name = "struct_use_after_move_error"
+spec = ["3.8:5", "3.8:6"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    let q = p;
+    let r = p;
+    0
+}
+"""
+compile_fail = true
+error_contains = "use of moved value"
+
+[[case]]
+name = "struct_move_on_assignment"
+spec = ["3.8:7"]
+source = """
+struct Data { value: i32 }
+fn main() -> i32 {
+    let d = Data { value: 42 };
+    let e = d;
+    d.value
+}
+"""
+compile_fail = true
+error_contains = "use of moved value"
+
+[[case]]
+name = "struct_move_on_function_call"
+spec = ["3.8:7", "3.8:8", "3.8:11"]
+source = """
+struct Data { value: i32 }
+fn consume(d: Data) -> i32 { d.value }
+fn main() -> i32 {
+    let d = Data { value: 42 };
+    let result = consume(d);
+    d.value
+}
+"""
+compile_fail = true
+error_contains = "use of moved value"
+
+[[case]]
+name = "struct_move_valid_single_use"
+spec = ["3.8:7", "3.8:8"]
+source = """
+struct Data { value: i32 }
+fn consume(d: Data) -> i32 { d.value }
+fn main() -> i32 {
+    let d = Data { value: 42 };
+    consume(d)
+}
+"""
+exit_code = 42
+
+# =============================================================================
+# Field Access (Projection)
+# =============================================================================
+
+[[case]]
+name = "field_access_no_move"
+spec = ["3.8:3"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { x: 10, y: 20 };
+    p.x + p.y
+}
+"""
+exit_code = 30
+
+[[case]]
+name = "field_access_then_move"
+spec = ["3.8:3", "3.8:7"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    let x = p.x;
+    let q = p;
+    x + q.y
+}
+"""
+exit_code = 3
+
+[[case]]
+name = "field_access_after_move_error"
+spec = ["3.8:5"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    let q = p;
+    p.x
+}
+"""
+compile_fail = true
+error_contains = "use of moved value"
+
+# =============================================================================
+# Mutable Variable Reassignment
+# =============================================================================
+
+[[case]]
+name = "field_assign_after_move_error"
+spec = ["3.8:5"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let mut p = Point { x: 1, y: 2 };
+    let _q = p;
+    p.x = 10;
+    0
+}
+"""
+compile_fail = true
+error_contains = "use of moved value"
+
+# =============================================================================
+# Copy Type Parameters
+# =============================================================================
+
+[[case]]
+name = "copy_type_function_param"
+spec = ["3.8:10", "3.8:11"]
+source = """
+fn double(x: i32) -> i32 { x + x }
+fn main() -> i32 {
+    let n = 21;
+    let result = double(n);
+    n + result
+}
+"""
+exit_code = 63
+
+# =============================================================================
+# Shadowing and Moves
+# =============================================================================
+
+[[case]]
+name = "shadowing_creates_new_binding"
+spec = ["3.8:12"]
+description = "Shadowing creates a new binding, doesn't affect original move state"
+source = """
+struct Data { value: i32 }
+fn main() -> i32 {
+    let d = Data { value: 1 };
+    let _x = d;  // d is moved
+    let d = Data { value: 2 };  // New 'd' shadows the moved one
+    d.value  // This is the new 'd', which is valid
+}
+"""
+exit_code = 2
+
+[[case]]
+name = "shadowing_then_use_original_error"
+spec = ["3.8:12"]
+description = "After shadowing a moved variable, accessing original is still error"
+source = """
+struct Data { value: i32 }
+fn main() -> i32 {
+    let d = Data { value: 1 };
+    let original = d;  // d is moved
+    let d = Data { value: 2 };  // Shadows with new binding
+    let _y = d;  // Use new d
+    original.value  // The original value was moved into 'original'
+}
+"""
+exit_code = 1

--- a/docs/designs/0008-affine-types-mvs.md
+++ b/docs/designs/0008-affine-types-mvs.md
@@ -7,7 +7,7 @@ feature-flag: affine-mvs
 created: 2025-12-24
 accepted: 2025-12-24
 implemented:
-spec-sections: []
+spec-sections: ["3.8"]
 superseded-by:
 ---
 
@@ -372,14 +372,17 @@ Epic: rue-dfr8
 
 This is a large feature requiring multiple phases. Each phase is a **vertical slice** - a complete, testable feature end-to-end. This allows kicking the tires at each step.
 
-### Phase 1: Affine structs (rue-dfr8.1)
+### Phase 1: Affine structs (rue-dfr8.1) ✅ COMPLETE
 
 Make user-defined structs affine by default. Primitives remain implicitly Copy.
 
-- Parse structs as usual (no syntax change)
-- Track moves in semantic analysis
-- Detect use-after-move errors for structs
-- Primitives (i32, bool, etc.) are implicitly Copy - no move tracking
+- [x] Parse structs as usual (no syntax change)
+- [x] Track moves in semantic analysis
+- [x] Detect use-after-move errors for structs
+- [x] Primitives (i32, bool, etc.) are implicitly Copy - no move tracking
+- [x] Field access is a projection (doesn't move the struct)
+- [x] Array indexing is a projection (doesn't move the array)
+- [x] Comparison operators don't consume operands
 
 **Testable**: Define a struct, use it twice, get a compile error.
 

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -1,0 +1,125 @@
++++
+title = "Move Semantics"
+weight = 8
++++
+
+# Move Semantics
+
+This section describes how values are moved and copied in Rue.
+
+## Value Categories
+
+{{ rule(id="3.8:1", cat="normative") }}
+
+Types in Rue are categorized by how they behave when used:
+- **Copy types** can be implicitly duplicated when used. Using a Copy type does not consume the original value.
+- **Move types** (also called affine types) are consumed when used. After using a move type value, the original binding becomes invalid.
+
+{{ rule(id="3.8:2", cat="normative") }}
+
+The following types are Copy types:
+- All integer types (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`)
+- The boolean type (`bool`)
+- The unit type (`()`)
+- Enum types (all variants of an enum)
+
+{{ rule(id="3.8:3", cat="normative") }}
+
+User-defined struct types are move types by default. Using a struct value consumes it.
+
+{{ rule(id="3.8:4", cat="example") }}
+
+```rue
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    let q = p;      // p is moved to q
+    // p is no longer valid here
+    q.x + q.y
+}
+```
+
+## Use After Move
+
+{{ rule(id="3.8:5", cat="legality-rule") }}
+
+It is a compile-time error to use a value that has been moved.
+
+{{ rule(id="3.8:6", cat="example") }}
+
+```rue
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    let q = p;      // p is moved
+    let r = p;      // ERROR: use of moved value 'p'
+    0
+}
+```
+
+{{ rule(id="3.8:7", cat="normative") }}
+
+A value is considered moved when it is:
+- Assigned to another variable
+- Passed as an argument to a function
+- Returned from a function
+
+{{ rule(id="3.8:8", cat="example") }}
+
+```rue
+struct Data { value: i32 }
+
+fn consume(d: Data) -> i32 { d.value }
+
+fn main() -> i32 {
+    let d = Data { value: 42 };
+    let result = consume(d);  // d is moved into the function
+    // d is no longer valid here
+    result
+}
+```
+
+## Copy Types and Multiple Uses
+
+{{ rule(id="3.8:9", cat="normative") }}
+
+Copy types can be used multiple times without being consumed.
+
+{{ rule(id="3.8:10", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    let x = 42;
+    let a = x;  // x is copied
+    let b = x;  // x is copied again
+    a + b       // 84
+}
+```
+
+{{ rule(id="3.8:11", cat="normative") }}
+
+Function parameters of Copy types receive a copy of the argument. Function parameters of move types receive ownership of the argument.
+
+## Shadowing and Moves
+
+{{ rule(id="3.8:12", cat="normative") }}
+
+Shadowing a variable does not prevent it from being moved. A moved variable remains invalid even if a new variable with the same name is introduced in an inner scope.
+
+{{ rule(id="3.8:13", cat="example") }}
+
+```rue
+struct Data { value: i32 }
+
+fn main() -> i32 {
+    let d = Data { value: 1 };
+    let x = d;  // d is moved
+    {
+        let d = Data { value: 2 };  // New 'd' shadows, but doesn't restore old 'd'
+        d.value
+    }
+    // Original 'd' is still invalid here
+}
+```


### PR DESCRIPTION
Add move tracking to semantic analysis so that struct types are affine by default - they can only be used once. Primitives (integers, booleans, unit, enums) remain Copy types that can be used multiple times.

Key changes:
- Add UseAfterMove error kind for use-after-move diagnostics
- Add is_copy() method to Type to distinguish Copy vs move types
- Track moved variables in AnalysisContext during semantic analysis
- Detect use-after-move errors with helpful diagnostics showing where the value was moved
- Add projection mode for field access, array indexing, and comparisons that reads values without consuming them
- Assignment to a mutable variable resets its move state

Add spec section 3.8 (Move Semantics) documenting the behavior and 14 new spec tests covering move semantics.

Fixes rue-dfr8.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)