### PR TITLE
Add parsing for impl blocks and method calls (Phase 1)

### DIFF
--- a/crates/rue-air/src/inference.rs
+++ b/crates/rue-air/src/inference.rs
@@ -1549,9 +1549,13 @@ impl<'a> ConstraintGenerator<'a> {
             }
 
             // Type declarations don't produce values
-            InstData::FnDecl { .. } | InstData::StructDecl { .. } | InstData::EnumDecl { .. } => {
-                InferType::Concrete(Type::Unit)
-            }
+            InstData::FnDecl { .. }
+            | InstData::StructDecl { .. }
+            | InstData::EnumDecl { .. }
+            | InstData::ImplDecl { .. } => InferType::Concrete(Type::Unit),
+
+            // Method call - placeholder for Phase 3 (see ADR-0009)
+            InstData::MethodCall { .. } => InferType::Concrete(Type::Unit),
         };
 
         // Record the type for this expression

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -2600,6 +2600,27 @@ impl<'a> Sema<'a> {
                 });
                 Ok(AnalysisResult::new(air_ref, ty))
             }
+
+            // Impl block declarations are processed during collection phase, skip here
+            InstData::ImplDecl { .. } => {
+                // Return Unit - impl blocks don't produce a value
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::UnitConst,
+                    ty: Type::Unit,
+                    span: inst.span,
+                });
+                Ok(AnalysisResult::new(air_ref, Type::Unit))
+            }
+
+            // Method call - placeholder for Phase 3 (see ADR-0009)
+            InstData::MethodCall { .. } => {
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::UnitConst,
+                    ty: Type::Unit,
+                    span: inst.span,
+                });
+                Ok(AnalysisResult::new(air_ref, Type::Unit))
+            }
         }
     }
 

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -27,6 +27,8 @@ pub enum TokenKind {
     False,
     Struct,
     Enum,
+    Impl,
+    SelfValue, // self (value, not type)
 
     // Type keywords
     I8,
@@ -111,6 +113,8 @@ impl TokenKind {
             TokenKind::False => "'false'",
             TokenKind::Struct => "'struct'",
             TokenKind::Enum => "'enum'",
+            TokenKind::Impl => "'impl'",
+            TokenKind::SelfValue => "'self'",
             TokenKind::I8 => "type 'i8'",
             TokenKind::I16 => "type 'i16'",
             TokenKind::I32 => "type 'i32'",
@@ -199,6 +203,8 @@ impl std::fmt::Display for TokenKind {
             TokenKind::False => write!(f, "FALSE"),
             TokenKind::Struct => write!(f, "STRUCT"),
             TokenKind::Enum => write!(f, "ENUM"),
+            TokenKind::Impl => write!(f, "IMPL"),
+            TokenKind::SelfValue => write!(f, "SELF"),
             TokenKind::I8 => write!(f, "TYPE(i8)"),
             TokenKind::I16 => write!(f, "TYPE(i16)"),
             TokenKind::I32 => write!(f, "TYPE(i32)"),

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -79,6 +79,10 @@ pub enum LogosTokenKind {
     Struct,
     #[token("enum")]
     Enum,
+    #[token("impl")]
+    Impl,
+    #[token("self")]
+    SelfValue,
 
     // Type keywords
     #[token("i8")]
@@ -213,6 +217,8 @@ impl From<LogosTokenKind> for TokenKind {
             LogosTokenKind::False => TokenKind::False,
             LogosTokenKind::Struct => TokenKind::Struct,
             LogosTokenKind::Enum => TokenKind::Enum,
+            LogosTokenKind::Impl => TokenKind::Impl,
+            LogosTokenKind::SelfValue => TokenKind::SelfValue,
             LogosTokenKind::I8 => TokenKind::I8,
             LogosTokenKind::I16 => TokenKind::I16,
             LogosTokenKind::I32 => TokenKind::I32,

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -41,6 +41,7 @@ pub enum Item {
     Function(Function),
     Struct(StructDecl),
     Enum(EnumDecl),
+    Impl(ImplBlock),
 }
 
 /// A struct declaration.
@@ -82,6 +83,43 @@ pub struct EnumVariant {
     /// Variant name
     pub name: Ident,
     /// Span covering the variant
+    pub span: Span,
+}
+
+/// An impl block containing methods for a type.
+#[derive(Debug, Clone)]
+pub struct ImplBlock {
+    /// The type this impl block is for
+    pub type_name: Ident,
+    /// Methods in this impl block
+    pub methods: Vec<Method>,
+    /// Span covering the entire impl block
+    pub span: Span,
+}
+
+/// A method definition in an impl block.
+#[derive(Debug, Clone)]
+pub struct Method {
+    /// Directives applied to this method
+    pub directives: Vec<Directive>,
+    /// Method name
+    pub name: Ident,
+    /// Whether this method takes self (None = associated function, Some = method with receiver)
+    pub receiver: Option<SelfParam>,
+    /// Method parameters (excluding self)
+    pub params: Vec<Param>,
+    /// Return type (None means implicit unit `()`)
+    pub return_type: Option<TypeExpr>,
+    /// Method body
+    pub body: Expr,
+    /// Span covering the entire method
+    pub span: Span,
+}
+
+/// A self parameter in a method.
+#[derive(Debug, Clone)]
+pub struct SelfParam {
+    /// Span covering the `self` keyword
     pub span: Span,
 }
 
@@ -209,6 +247,8 @@ pub enum Expr {
     StructLit(StructLitExpr),
     /// Field access (e.g., `point.x`)
     Field(FieldExpr),
+    /// Method call (e.g., `point.distance()`)
+    MethodCall(MethodCallExpr),
     /// Intrinsic call (e.g., `@dbg(42)`)
     IntrinsicCall(IntrinsicCallExpr),
     /// Array literal (e.g., `[1, 2, 3]`)
@@ -447,6 +487,18 @@ pub struct FieldExpr {
     pub span: Span,
 }
 
+/// A method call expression (e.g., `point.distance()`).
+#[derive(Debug, Clone)]
+pub struct MethodCallExpr {
+    /// Base expression (the receiver)
+    pub receiver: Box<Expr>,
+    /// Method name
+    pub method: Ident,
+    /// Arguments (excluding self)
+    pub args: Vec<Expr>,
+    pub span: Span,
+}
+
 /// An array literal expression (e.g., `[1, 2, 3]`).
 #[derive(Debug, Clone)]
 pub struct ArrayLitExpr {
@@ -603,6 +655,7 @@ impl Expr {
             Expr::Return(return_expr) => return_expr.span,
             Expr::StructLit(struct_lit) => struct_lit.span,
             Expr::Field(field_expr) => field_expr.span,
+            Expr::MethodCall(method_call) => method_call.span,
             Expr::IntrinsicCall(intrinsic) => intrinsic.span,
             Expr::ArrayLit(array_lit) => array_lit.span,
             Expr::Index(index_expr) => index_expr.span,
@@ -632,6 +685,7 @@ impl<'a> fmt::Display for AstPrinter<'a> {
                 Item::Function(func) => fmt_function(f, func, 0)?,
                 Item::Struct(s) => fmt_struct(f, s, 0)?,
                 Item::Enum(e) => fmt_enum(f, e, 0)?,
+                Item::Impl(impl_block) => fmt_impl_block(f, impl_block, 0)?,
             }
         }
         Ok(())
@@ -662,6 +716,40 @@ fn fmt_enum(f: &mut fmt::Formatter<'_>, e: &EnumDecl, level: usize) -> fmt::Resu
         indent(f, level + 1)?;
         writeln!(f, "Variant {}", variant.name.name)?;
     }
+    Ok(())
+}
+
+fn fmt_impl_block(f: &mut fmt::Formatter<'_>, impl_block: &ImplBlock, level: usize) -> fmt::Result {
+    indent(f, level)?;
+    writeln!(f, "Impl {}", impl_block.type_name.name)?;
+    for method in &impl_block.methods {
+        fmt_method(f, method, level + 1)?;
+    }
+    Ok(())
+}
+
+fn fmt_method(f: &mut fmt::Formatter<'_>, method: &Method, level: usize) -> fmt::Result {
+    indent(f, level)?;
+    write!(f, "Method {}", method.name.name)?;
+    write!(f, "(")?;
+    if method.receiver.is_some() {
+        write!(f, "self")?;
+        if !method.params.is_empty() {
+            write!(f, ", ")?;
+        }
+    }
+    for (i, param) in method.params.iter().enumerate() {
+        if i > 0 {
+            write!(f, ", ")?;
+        }
+        write!(f, "{}: {}", param.name.name, param.ty)?;
+    }
+    write!(f, ")")?;
+    if let Some(ref ret) = method.return_type {
+        write!(f, " -> {}", ret)?;
+    }
+    writeln!(f)?;
+    fmt_expr(f, &method.body, level + 1)?;
     Ok(())
 }
 
@@ -796,6 +884,20 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
         Expr::Field(field) => {
             writeln!(f, "Field .{}", field.field.name)?;
             fmt_expr(f, &field.base, level + 1)
+        }
+        Expr::MethodCall(method_call) => {
+            writeln!(f, "MethodCall .{}", method_call.method.name)?;
+            indent(f, level + 1)?;
+            writeln!(f, "Receiver:")?;
+            fmt_expr(f, &method_call.receiver, level + 2)?;
+            if !method_call.args.is_empty() {
+                indent(f, level + 1)?;
+                writeln!(f, "Args:")?;
+                for arg in &method_call.args {
+                    fmt_expr(f, arg, level + 2)?;
+                }
+            }
+            Ok(())
         }
         Expr::ArrayLit(array) => {
             writeln!(f, "ArrayLit")?;

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -6,10 +6,11 @@
 use crate::ast::{
     ArrayLitExpr, AssignStatement, AssignTarget, Ast, BinaryExpr, BinaryOp, BlockExpr, BoolLit,
     BreakExpr, CallExpr, ContinueExpr, Directive, DirectiveArg, EnumDecl, EnumVariant, Expr,
-    FieldDecl, FieldExpr, FieldInit, Function, Ident, IfExpr, IndexExpr, IntLit, IntrinsicArg,
-    IntrinsicCallExpr, Item, LetPattern, LetStatement, LoopExpr, MatchArm, MatchExpr, NegIntLit,
-    Param, ParenExpr, PathExpr, PathPattern, Pattern, ReturnExpr, Statement, StringLit, StructDecl,
-    StructLitExpr, TypeExpr, UnaryExpr, UnaryOp, UnitLit, WhileExpr,
+    FieldDecl, FieldExpr, FieldInit, Function, Ident, IfExpr, ImplBlock, IndexExpr, IntLit,
+    IntrinsicArg, IntrinsicCallExpr, Item, LetPattern, LetStatement, LoopExpr, MatchArm, MatchExpr,
+    Method, MethodCallExpr, NegIntLit, Param, ParenExpr, PathExpr, PathPattern, Pattern,
+    ReturnExpr, SelfParam, Statement, StringLit, StructDecl, StructLitExpr, TypeExpr, UnaryExpr,
+    UnaryOp, UnitLit, WhileExpr,
 };
 use chumsky::input::{Input as ChumskyInput, Stream, ValueInput};
 use chumsky::pratt::{infix, left, prefix};
@@ -729,31 +730,60 @@ where
         block_expr,
     ));
 
-    // Suffix for field access (.field) or indexing ([expr])
+    // Suffix for field access (.field), method call (.method(args)), or indexing ([expr])
     #[derive(Clone)]
     enum Suffix {
         Field(Ident),
+        MethodCall(Ident, Vec<Expr>),
         Index(Expr),
     }
 
+    // Method call: .ident(args)
+    let method_call_suffix = just(TokenKind::Dot)
+        .ignore_then(ident_parser())
+        .then(
+            args_parser(expr.clone())
+                .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
+        )
+        .map(|(method, args)| Suffix::MethodCall(method, args));
+
+    // Field access: .ident (but NOT followed by ()
     let field_suffix = just(TokenKind::Dot)
         .ignore_then(ident_parser())
+        .then_ignore(none_of([TokenKind::LParen]).rewind())
         .map(Suffix::Field);
 
     let index_suffix = expr
         .delimited_by(just(TokenKind::LBracket), just(TokenKind::RBracket))
         .map(Suffix::Index);
 
-    // Field access and indexing suffix: .field or [expr]
-    // Handles chains like a.b.c or a[0][1] or a[0].field
+    // Field access, method call, and indexing suffix: .field, .method(), or [expr]
+    // Method call must come before field access to catch .method(args) before .field
+    // Handles chains like a.b.c or a[0][1] or a[0].field or a.method().field
     primary.foldl(
-        choice((field_suffix, index_suffix)).repeated(),
+        choice((method_call_suffix, field_suffix, index_suffix)).repeated(),
         |base, suffix| match suffix {
             Suffix::Field(field) => {
                 let span = Span::new(base.span().start, field.span.end);
                 Expr::Field(FieldExpr {
                     base: Box::new(base),
                     field,
+                    span,
+                })
+            }
+            Suffix::MethodCall(method, args) => {
+                let end = if args.is_empty() {
+                    // Span ends after the closing paren, but we don't have that span
+                    // We'll use the method name span end + 2 for "()" as approximation
+                    method.span.end + 2
+                } else {
+                    args.last().unwrap().span().end + 1
+                };
+                let span = Span::new(base.span().start, end);
+                Expr::MethodCall(MethodCallExpr {
+                    receiver: Box::new(base),
+                    method,
+                    args,
                     span,
                 })
             }
@@ -1166,7 +1196,79 @@ where
         })
 }
 
-/// Parser for top-level items (functions, structs, and enums)
+/// Parser for method definitions: [@directive]* fn name(self, params) -> Type { body }
+/// Methods differ from functions in that they can have `self` as the first parameter.
+fn method_parser<'src, I>()
+-> impl Parser<'src, I, Method, extra::Err<Rich<'src, TokenKind>>> + Clone
+where
+    I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
+{
+    let expr = expr_parser();
+
+    // Parse optional self parameter
+    let self_param = just(TokenKind::SelfValue).map_with(|_, e| SelfParam {
+        span: to_rue_span(e.span()),
+    });
+
+    // Parse self followed by optional regular params
+    let self_then_params = self_param
+        .then(
+            just(TokenKind::Comma)
+                .ignore_then(params_parser())
+                .or_not()
+                .map(|opt| opt.unwrap_or_default()),
+        )
+        .map(|(self_param, params)| (Some(self_param), params));
+
+    // Parse just regular params (no self) - this is an associated function
+    let just_params = params_parser().map(|params| (None, params));
+
+    // Try self first, then fall back to regular params
+    let params_with_optional_self = self_then_params.or(just_params);
+
+    directives_parser()
+        .then(just(TokenKind::Fn).ignore_then(ident_parser()))
+        .then(
+            params_with_optional_self
+                .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
+        )
+        .then(just(TokenKind::Arrow).ignore_then(type_parser()).or_not())
+        .then(block_parser(expr))
+        .map_with(
+            |((((directives, name), (receiver, params)), return_type), body), e| Method {
+                directives,
+                name,
+                receiver,
+                params,
+                return_type,
+                body,
+                span: to_rue_span(e.span()),
+            },
+        )
+}
+
+/// Parser for impl blocks: impl Type { fn... }
+fn impl_parser<'src, I>()
+-> impl Parser<'src, I, ImplBlock, extra::Err<Rich<'src, TokenKind>>> + Clone
+where
+    I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
+{
+    just(TokenKind::Impl)
+        .ignore_then(ident_parser())
+        .then(
+            method_parser()
+                .repeated()
+                .collect::<Vec<_>>()
+                .delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace)),
+        )
+        .map_with(|(type_name, methods), e| ImplBlock {
+            type_name,
+            methods,
+            span: to_rue_span(e.span()),
+        })
+}
+
+/// Parser for top-level items (functions, structs, enums, and impl blocks)
 fn item_parser<'src, I>() -> impl Parser<'src, I, Item, extra::Err<Rich<'src, TokenKind>>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
@@ -1175,6 +1277,7 @@ where
         function_parser().map(Item::Function),
         struct_parser().map(Item::Struct),
         enum_parser().map(Item::Enum),
+        impl_parser().map(Item::Impl),
     ))
 }
 
@@ -1296,6 +1399,7 @@ mod tests {
             },
             Item::Struct(_) => panic!("parse_expr helper should only be used with functions"),
             Item::Enum(_) => panic!("parse_expr helper should only be used with functions"),
+            Item::Impl(_) => panic!("parse_expr helper should only be used with functions"),
         }
     }
 
@@ -1321,6 +1425,7 @@ mod tests {
             }
             Item::Struct(_) => panic!("expected Function"),
             Item::Enum(_) => panic!("expected Function"),
+            Item::Impl(_) => panic!("expected Function"),
         }
     }
 
@@ -1386,6 +1491,7 @@ mod tests {
             },
             Item::Struct(_) => panic!("expected Function"),
             Item::Enum(_) => panic!("expected Function"),
+            Item::Impl(_) => panic!("expected Function"),
         }
     }
 

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -8,8 +8,9 @@ mod chumsky_parser;
 pub use ast::{
     ArrayLitExpr, AssignStatement, AssignTarget, Ast, BinaryExpr, BinaryOp, BlockExpr, CallExpr,
     Directive, DirectiveArg, EnumDecl, EnumVariant, Expr, FieldDecl, FieldExpr, FieldInit,
-    Function, Ident, IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr, Item, LetPattern,
-    LetStatement, MatchArm, MatchExpr, Param, ParenExpr, PathExpr, PathPattern, Pattern,
-    ReturnExpr, Statement, StructDecl, StructLitExpr, TypeExpr, UnaryExpr, UnaryOp, WhileExpr,
+    Function, Ident, ImplBlock, IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr, Item,
+    LetPattern, LetStatement, MatchArm, MatchExpr, Method, MethodCallExpr, Param, ParenExpr,
+    PathExpr, PathPattern, Pattern, ReturnExpr, SelfParam, Statement, StructDecl, StructLitExpr,
+    TypeExpr, UnaryExpr, UnaryOp, WhileExpr,
 };
 pub use chumsky_parser::ChumskyParser as Parser;

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -9,8 +9,8 @@ use rue_intern::Interner;
 /// These intrinsics operate on types at compile time (e.g., @size_of(i32)).
 const TYPE_INTRINSICS: &[&str] = &["size_of", "align_of"];
 use rue_parser::{
-    AssignTarget, Ast, BinaryOp, Directive, DirectiveArg, EnumDecl, Expr, Function, IntrinsicArg,
-    Item, LetPattern, Pattern, Statement, StructDecl, TypeExpr, UnaryOp,
+    AssignTarget, Ast, BinaryOp, Directive, DirectiveArg, EnumDecl, Expr, Function, ImplBlock,
+    IntrinsicArg, Item, LetPattern, Method, Pattern, Statement, StructDecl, TypeExpr, UnaryOp,
 };
 
 use crate::inst::{Inst, InstData, InstRef, Rir, RirDirective, RirPattern};
@@ -53,6 +53,11 @@ impl<'a> AstGen<'a> {
             }
             Item::Enum(enum_decl) => {
                 self.gen_enum(enum_decl);
+            }
+            Item::Impl(impl_block) => {
+                // Impl blocks are handled in Phase 2 (RIR Generation)
+                // For now, store them for later processing by sema
+                self.gen_impl_block(impl_block);
             }
         }
     }
@@ -107,6 +112,61 @@ impl<'a> AstGen<'a> {
         self.rir.add_inst(Inst {
             data: InstData::EnumDecl { name, variants },
             span: enum_decl.span,
+        })
+    }
+
+    fn gen_impl_block(&mut self, impl_block: &ImplBlock) -> InstRef {
+        let type_name = self.interner.intern(&impl_block.type_name.name);
+
+        // Generate each method in the impl block
+        let methods: Vec<_> = impl_block
+            .methods
+            .iter()
+            .map(|m| self.gen_method(m))
+            .collect();
+
+        self.rir.add_inst(Inst {
+            data: InstData::ImplDecl { type_name, methods },
+            span: impl_block.span,
+        })
+    }
+
+    fn gen_method(&mut self, method: &Method) -> InstRef {
+        // Convert directives
+        let directives = self.convert_directives(&method.directives);
+
+        // Intern the method name and return type
+        let name = self.interner.intern(&method.name.name);
+        let return_type = match &method.return_type {
+            Some(ty) => self.intern_type(ty),
+            None => self.interner.intern("()"), // Default to unit type
+        };
+
+        // Intern parameters (excluding self, which is handled specially by sema)
+        let params: Vec<_> = method
+            .params
+            .iter()
+            .map(|p| {
+                let param_name = self.interner.intern(&p.name.name);
+                let param_type = self.intern_type(&p.ty);
+                (param_name, param_type)
+            })
+            .collect();
+
+        // Generate body expression
+        let body = self.gen_expr(&method.body);
+
+        // For now, we emit methods as regular FnDecl instructions.
+        // Sema will handle the method resolution and self parameter.
+        self.rir.add_inst(Inst {
+            data: InstData::FnDecl {
+                directives,
+                name,
+                params,
+                return_type,
+                body,
+            },
+            span: method.span,
         })
     }
 
@@ -405,6 +465,20 @@ impl<'a> AstGen<'a> {
                 self.rir.add_inst(Inst {
                     data: InstData::EnumVariant { type_name, variant },
                     span: path_expr.span,
+                })
+            }
+            Expr::MethodCall(method_call) => {
+                let receiver = self.gen_expr(&method_call.receiver);
+                let method = self.interner.intern(&method_call.method.name);
+                let args: Vec<_> = method_call.args.iter().map(|a| self.gen_expr(a)).collect();
+
+                self.rir.add_inst(Inst {
+                    data: InstData::MethodCall {
+                        receiver,
+                        method,
+                        args,
+                    },
+                    span: method_call.span,
                 })
             }
         }

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -405,6 +405,25 @@ pub enum InstData {
         /// Value to store
         value: InstRef,
     },
+
+    // Method operations (preview: methods)
+    /// Impl block declaration
+    ImplDecl {
+        /// Type name this impl block is for
+        type_name: Symbol,
+        /// Methods defined in this impl block (references to FnDecl instructions)
+        methods: Vec<InstRef>,
+    },
+
+    /// Method call: receiver.method(args)
+    MethodCall {
+        /// Receiver expression (the struct value)
+        receiver: InstRef,
+        /// Method name
+        method: Symbol,
+        /// Argument instruction refs
+        args: Vec<InstRef>,
+    },
 }
 
 impl fmt::Display for InstRef {
@@ -709,6 +728,30 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 }
                 InstData::IndexSet { base, index, value } => {
                     out.push_str(&format!("index_set {}[{}] = {}\n", base, index, value));
+                }
+                InstData::ImplDecl { type_name, methods } => {
+                    let type_str = self.interner.get(*type_name);
+                    let methods_str: Vec<String> =
+                        methods.iter().map(|m| format!("{}", m)).collect();
+                    out.push_str(&format!(
+                        "impl {} {{ {} }}\n",
+                        type_str,
+                        methods_str.join(", ")
+                    ));
+                }
+                InstData::MethodCall {
+                    receiver,
+                    method,
+                    args,
+                } => {
+                    let method_str = self.interner.get(*method);
+                    let args_str: Vec<String> = args.iter().map(|a| format!("{}", a)).collect();
+                    out.push_str(&format!(
+                        "method_call {}.{}({})\n",
+                        receiver,
+                        method_str,
+                        args_str.join(", ")
+                    ));
                 }
             }
         }

--- a/crates/rue-spec/cases/items/impl-blocks.toml
+++ b/crates/rue-spec/cases/items/impl-blocks.toml
@@ -1,0 +1,114 @@
+[section]
+id = "items.impl-blocks"
+spec_chapter = "6.4"
+name = "Impl Blocks and Methods"
+description = "Impl block definitions and method calls."
+
+# =============================================================================
+# Basic Impl Block Syntax (Parsing Only - Phase 1)
+# =============================================================================
+
+# These tests verify that impl blocks and method calls parse correctly.
+# They are expected to fail at later compilation stages until Phase 2-4 are complete.
+
+[[case]]
+name = "impl_block_basic_parse"
+preview = "methods"
+source = """
+struct Point { x: i32, y: i32 }
+
+impl Point {
+    fn get_x(self) -> i32 {
+        self.x
+    }
+}
+
+fn main() -> i32 {
+    let p = Point { x: 42, y: 10 };
+    p.get_x()
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "impl_block_associated_function"
+preview = "methods"
+source = """
+struct Point { x: i32, y: i32 }
+
+impl Point {
+    fn origin() -> Point {
+        Point { x: 0, y: 0 }
+    }
+}
+
+fn main() -> i32 {
+    let p = Point::origin();
+    p.x
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "impl_block_method_with_args"
+preview = "methods"
+source = """
+struct Point { x: i32, y: i32 }
+
+impl Point {
+    fn add(self, dx: i32, dy: i32) -> Point {
+        Point { x: self.x + dx, y: self.y + dy }
+    }
+}
+
+fn main() -> i32 {
+    let p = Point { x: 10, y: 20 };
+    let p2 = p.add(32, 0);
+    p2.x
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "method_call_chain"
+preview = "methods"
+source = """
+struct Counter { value: i32 }
+
+impl Counter {
+    fn inc(self) -> Counter {
+        Counter { value: self.value + 1 }
+    }
+}
+
+fn main() -> i32 {
+    let c = Counter { value: 39 };
+    c.inc().inc().inc().value
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "multiple_impl_blocks"
+preview = "methods"
+source = """
+struct Point { x: i32, y: i32 }
+
+impl Point {
+    fn get_x(self) -> i32 {
+        self.x
+    }
+}
+
+impl Point {
+    fn get_y(self) -> i32 {
+        self.y
+    }
+}
+
+fn main() -> i32 {
+    let p = Point { x: 42, y: 10 };
+    p.get_x()
+}
+"""
+exit_code = 42

--- a/docs/designs/0009-struct-methods.md
+++ b/docs/designs/0009-struct-methods.md
@@ -132,7 +132,7 @@ Methods can only be defined for structs in the same compilation unit. (This is a
 
 ## Implementation Phases
 
-- [ ] **Phase 1: Parsing** - rue-qs3z.1
+- [x] **Phase 1: Parsing** - rue-qs3z.1
   - Add `impl` keyword to lexer
   - Parse `impl Type { fn... }` blocks
   - Add `Item::ImplBlock` to AST
@@ -148,6 +148,11 @@ Methods can only be defined for structs in the same compilation unit. (This is a
   - Type check impl blocks
   - Resolve method calls to their definitions
   - Handle `self` parameter binding
+  - Method resolution requires:
+    1. Looking up the receiver type
+    2. Finding the impl block for that type
+    3. Resolving the method name
+    4. Type checking the arguments against method signature
 
 - [ ] **Phase 4: Code Generation** - rue-qs3z.4
   - Lower method calls to regular calls with receiver as first argument


### PR DESCRIPTION
Implement Phase 1 of ADR-0009 (struct methods):
- Add `impl` and `self` keywords to lexer
- Parse `impl Type { fn... }` blocks with Method AST nodes
- Parse method calls (`.method()`) as distinct from field access
- Add ImplDecl and MethodCall to RIR with placeholder sema handling
- Add preview tests (gated on `methods` feature flag)

Methods currently return Unit type as placeholders - actual type checking and code generation are in Phase 3 and Phase 4 respectively.

Related to rue-qs3z

🤖 Generated with [Claude Code](https://claude.com/claude-code)