### PR TITLE
Add RIR generation for struct methods (Phase 2)

### DIFF
--- a/crates/rue-air/src/inference.rs
+++ b/crates/rue-air/src/inference.rs
@@ -1556,6 +1556,9 @@ impl<'a> ConstraintGenerator<'a> {
 
             // Method call - placeholder for Phase 3 (see ADR-0009)
             InstData::MethodCall { .. } => InferType::Concrete(Type::Unit),
+
+            // Associated function call - placeholder for Phase 3 (see ADR-0009)
+            InstData::AssocFnCall { .. } => InferType::Concrete(Type::Unit),
         };
 
         // Record the type for this expression

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -2621,6 +2621,16 @@ impl<'a> Sema<'a> {
                 });
                 Ok(AnalysisResult::new(air_ref, Type::Unit))
             }
+
+            // Associated function call - placeholder for Phase 3 (see ADR-0009)
+            InstData::AssocFnCall { .. } => {
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::UnitConst,
+                    ty: Type::Unit,
+                    span: inst.span,
+                });
+                Ok(AnalysisResult::new(air_ref, Type::Unit))
+            }
         }
     }
 

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -257,6 +257,8 @@ pub enum Expr {
     Index(IndexExpr),
     /// Path expression (e.g., `Color::Red`)
     Path(PathExpr),
+    /// Associated function call (e.g., `Point::origin()`)
+    AssocFnCall(AssocFnCallExpr),
 }
 
 /// An integer literal.
@@ -527,6 +529,18 @@ pub struct PathExpr {
     pub span: Span,
 }
 
+/// An associated function call expression (e.g., `Point::origin()`).
+#[derive(Debug, Clone)]
+pub struct AssocFnCallExpr {
+    /// The type name (e.g., `Point`)
+    pub type_name: Ident,
+    /// The function name (e.g., `origin`)
+    pub function: Ident,
+    /// Arguments
+    pub args: Vec<Expr>,
+    pub span: Span,
+}
+
 /// A statement (does not produce a value).
 #[derive(Debug, Clone)]
 pub enum Statement {
@@ -660,6 +674,7 @@ impl Expr {
             Expr::ArrayLit(array_lit) => array_lit.span,
             Expr::Index(index_expr) => index_expr.span,
             Expr::Path(path_expr) => path_expr.span,
+            Expr::AssocFnCall(assoc_fn_call) => assoc_fn_call.span,
         }
     }
 }
@@ -917,6 +932,18 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
         }
         Expr::Path(path) => {
             writeln!(f, "Path {}::{}", path.type_name.name, path.variant.name)
+        }
+        Expr::AssocFnCall(assoc_fn_call) => {
+            writeln!(
+                f,
+                "AssocFnCall {}::{}",
+                assoc_fn_call.type_name.name, assoc_fn_call.function.name
+            )?;
+            for arg in &assoc_fn_call.args {
+                indent(f, level + 1)?;
+                fmt_expr(f, arg, level + 1)?;
+            }
+            Ok(())
         }
     }
 }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -4,13 +4,13 @@
 //! with Pratt parsing for expression precedence.
 
 use crate::ast::{
-    ArrayLitExpr, AssignStatement, AssignTarget, Ast, BinaryExpr, BinaryOp, BlockExpr, BoolLit,
-    BreakExpr, CallExpr, ContinueExpr, Directive, DirectiveArg, EnumDecl, EnumVariant, Expr,
-    FieldDecl, FieldExpr, FieldInit, Function, Ident, IfExpr, ImplBlock, IndexExpr, IntLit,
-    IntrinsicArg, IntrinsicCallExpr, Item, LetPattern, LetStatement, LoopExpr, MatchArm, MatchExpr,
-    Method, MethodCallExpr, NegIntLit, Param, ParenExpr, PathExpr, PathPattern, Pattern,
-    ReturnExpr, SelfParam, Statement, StringLit, StructDecl, StructLitExpr, TypeExpr, UnaryExpr,
-    UnaryOp, UnitLit, WhileExpr,
+    ArrayLitExpr, AssignStatement, AssignTarget, AssocFnCallExpr, Ast, BinaryExpr, BinaryOp,
+    BlockExpr, BoolLit, BreakExpr, CallExpr, ContinueExpr, Directive, DirectiveArg, EnumDecl,
+    EnumVariant, Expr, FieldDecl, FieldExpr, FieldInit, Function, Ident, IfExpr, ImplBlock,
+    IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr, Item, LetPattern, LetStatement, LoopExpr,
+    MatchArm, MatchExpr, Method, MethodCallExpr, NegIntLit, Param, ParenExpr, PathExpr,
+    PathPattern, Pattern, ReturnExpr, SelfParam, Statement, StringLit, StructDecl, StructLitExpr,
+    TypeExpr, UnaryExpr, UnaryOp, UnitLit, WhileExpr,
 };
 use chumsky::input::{Input as ChumskyInput, Stream, ValueInput};
 use chumsky::pratt::{infix, left, prefix};
@@ -577,12 +577,13 @@ where
         })
         .boxed();
 
-    // What can follow an identifier: call args, struct fields, path (::variant), or nothing
+    // What can follow an identifier: call args, struct fields, path (::variant), path call (::fn()), or nothing
     #[derive(Clone)]
     enum IdentSuffix {
         Call(Vec<Expr>),
         StructLit(Vec<FieldInit>),
-        Path(Ident), // ::Variant
+        Path(Ident),                // ::Variant (for enum variants)
+        PathCall(Ident, Vec<Expr>), // ::function() (for associated functions)
         None,
     }
 
@@ -598,6 +599,14 @@ where
                 field_inits_parser(expr.clone())
                     .delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace))
                     .map(IdentSuffix::StructLit),
+                // Associated function call: ::function(args)
+                just(TokenKind::ColonColon)
+                    .ignore_then(ident_parser())
+                    .then(
+                        args_parser(expr.clone())
+                            .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
+                    )
+                    .map(|(func, args)| IdentSuffix::PathCall(func, args)),
                 // Path: ::Variant (for enum variants)
                 just(TokenKind::ColonColon)
                     .ignore_then(ident_parser())
@@ -615,6 +624,12 @@ where
             IdentSuffix::StructLit(fields) => Expr::StructLit(StructLitExpr {
                 name,
                 fields,
+                span: to_rue_span(e.span()),
+            }),
+            IdentSuffix::PathCall(function, args) => Expr::AssocFnCall(AssocFnCallExpr {
+                type_name: name,
+                function,
+                args,
                 span: to_rue_span(e.span()),
             }),
             IdentSuffix::Path(variant) => Expr::Path(PathExpr {

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -481,6 +481,24 @@ impl<'a> AstGen<'a> {
                     span: method_call.span,
                 })
             }
+            Expr::AssocFnCall(assoc_fn_call) => {
+                let type_name = self.interner.intern(&assoc_fn_call.type_name.name);
+                let function = self.interner.intern(&assoc_fn_call.function.name);
+                let args: Vec<_> = assoc_fn_call
+                    .args
+                    .iter()
+                    .map(|a| self.gen_expr(a))
+                    .collect();
+
+                self.rir.add_inst(Inst {
+                    data: InstData::AssocFnCall {
+                        type_name,
+                        function,
+                        args,
+                    },
+                    span: assoc_fn_call.span,
+                })
+            }
         }
     }
 

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -424,6 +424,16 @@ pub enum InstData {
         /// Argument instruction refs
         args: Vec<InstRef>,
     },
+
+    /// Associated function call: Type::function(args)
+    AssocFnCall {
+        /// Type name (e.g., Point)
+        type_name: Symbol,
+        /// Function name (e.g., origin)
+        function: Symbol,
+        /// Argument instruction refs
+        args: Vec<InstRef>,
+    },
 }
 
 impl fmt::Display for InstRef {
@@ -750,6 +760,21 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         "method_call {}.{}({})\n",
                         receiver,
                         method_str,
+                        args_str.join(", ")
+                    ));
+                }
+                InstData::AssocFnCall {
+                    type_name,
+                    function,
+                    args,
+                } => {
+                    let type_str = self.interner.get(*type_name);
+                    let func_str = self.interner.get(*function);
+                    let args_str: Vec<String> = args.iter().map(|a| format!("{}", a)).collect();
+                    out.push_str(&format!(
+                        "assoc_fn_call {}::{}({})\n",
+                        type_str,
+                        func_str,
                         args_str.join(", ")
                     ));
                 }

--- a/docs/designs/0009-struct-methods.md
+++ b/docs/designs/0009-struct-methods.md
@@ -138,10 +138,11 @@ Methods can only be defined for structs in the same compilation unit. (This is a
   - Add `Item::ImplBlock` to AST
   - Parse method calls as a variant of field access
 
-- [ ] **Phase 2: RIR Generation** - rue-qs3z.2
-  - Add method info to RIR
+- [x] **Phase 2: RIR Generation** - rue-qs3z.2
+  - Add method info to RIR (ImplDecl, MethodCall, AssocFnCall instructions)
   - Generate RIR for impl blocks
   - Handle method calls in expression generation
+  - Parse associated function calls (Type::fn() syntax)
 
 - [ ] **Phase 3: Type Checking** - rue-qs3z.3
   - Add method registry to struct definitions


### PR DESCRIPTION
Adds RIR instructions and generation for method calls and associated function calls:

- Add AssocFnCall RIR instruction for Type::fn() syntax
- Parse associated function calls in the parser
- Generate RIR for method calls and associated function calls
- Add placeholder handling in sema and inference for Phase 3

Phase 3 (type checking) will implement method resolution and self parameter binding.

Closes rue-qs3z.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)