### PR TITLE
Add type checking for struct methods (Phase 3)

### DIFF
--- a/crates/rue-air/src/inference.rs
+++ b/crates/rue-air/src/inference.rs
@@ -850,6 +850,21 @@ pub struct FunctionSig {
     pub return_type: InferType,
 }
 
+/// Information about a method during constraint generation.
+///
+/// Used for method calls (receiver.method()) and associated function calls (Type::function()).
+#[derive(Debug, Clone)]
+pub struct MethodSig {
+    /// The struct type this method belongs to (as concrete Type::Struct)
+    pub struct_type: Type,
+    /// Whether this is a method (has self) or associated function (no self)
+    pub has_self: bool,
+    /// Parameter types (excluding self), as InferTypes for uniform handling.
+    pub param_types: Vec<InferType>,
+    /// Return type, as InferType for uniform handling.
+    pub return_type: InferType,
+}
+
 /// Context for constraint generation within a single function.
 pub struct ConstraintContext<'a> {
     /// Local variables in scope.
@@ -944,6 +959,8 @@ pub struct ConstraintGenerator<'a> {
     structs: &'a HashMap<Symbol, Type>,
     /// Enum types (name -> Type::Enum(id)).
     enums: &'a HashMap<Symbol, Type>,
+    /// Method signatures: (struct_name, method_name) -> MethodSig
+    methods: &'a HashMap<(Symbol, Symbol), MethodSig>,
     /// Type variables allocated for integer literals.
     /// These start as unbound and need to be defaulted to i32 if unconstrained.
     int_literal_vars: Vec<TypeVarId>,
@@ -957,6 +974,7 @@ impl<'a> ConstraintGenerator<'a> {
         functions: &'a HashMap<Symbol, FunctionSig>,
         structs: &'a HashMap<Symbol, Type>,
         enums: &'a HashMap<Symbol, Type>,
+        methods: &'a HashMap<(Symbol, Symbol), MethodSig>,
     ) -> Self {
         Self {
             rir,
@@ -967,6 +985,7 @@ impl<'a> ConstraintGenerator<'a> {
             functions,
             structs,
             enums,
+            methods,
             int_literal_vars: Vec::new(),
         }
     }
@@ -1554,11 +1573,95 @@ impl<'a> ConstraintGenerator<'a> {
             | InstData::EnumDecl { .. }
             | InstData::ImplDecl { .. } => InferType::Concrete(Type::Unit),
 
-            // Method call - placeholder for Phase 3 (see ADR-0009)
-            InstData::MethodCall { .. } => InferType::Concrete(Type::Unit),
+            // Method call: receiver.method(args)
+            InstData::MethodCall {
+                receiver,
+                method,
+                args,
+            } => {
+                // Generate type for receiver
+                let receiver_info = self.generate(*receiver, ctx);
 
-            // Associated function call - placeholder for Phase 3 (see ADR-0009)
-            InstData::AssocFnCall { .. } => InferType::Concrete(Type::Unit),
+                // Get struct name from receiver type if it's a struct
+                // If we can't determine the struct type, we still generate constraints
+                // for the arguments and return a type variable (actual error is in sema)
+                let result_type = if let InferType::Concrete(Type::Struct(struct_id)) =
+                    &receiver_info.ty
+                {
+                    // Find the struct name symbol
+                    let struct_name = self
+                        .structs
+                        .iter()
+                        .find(|(_, ty)| **ty == Type::Struct(*struct_id))
+                        .map(|(name, _)| *name);
+
+                    if let Some(struct_name) = struct_name {
+                        let method_key = (struct_name, *method);
+                        if let Some(method_sig) = self.methods.get(&method_key) {
+                            // Generate constraints for arguments
+                            for (arg, param_type) in args.iter().zip(method_sig.param_types.iter())
+                            {
+                                let arg_info = self.generate(*arg, ctx);
+                                self.add_constraint(Constraint::equal(
+                                    arg_info.ty,
+                                    param_type.clone(),
+                                    arg_info.span,
+                                ));
+                            }
+                            method_sig.return_type.clone()
+                        } else {
+                            // Method not found - sema will report the error
+                            // Still generate arg types to catch errors in arguments
+                            for arg in args.iter() {
+                                self.generate(*arg, ctx);
+                            }
+                            InferType::Concrete(Type::Error)
+                        }
+                    } else {
+                        // Couldn't find struct name - shouldn't happen but handle gracefully
+                        for arg in args.iter() {
+                            self.generate(*arg, ctx);
+                        }
+                        InferType::Concrete(Type::Error)
+                    }
+                } else {
+                    // Non-struct receiver - sema will report the error
+                    for arg in args.iter() {
+                        self.generate(*arg, ctx);
+                    }
+                    InferType::Concrete(Type::Error)
+                };
+
+                result_type
+            }
+
+            // Associated function call: Type::function(args)
+            InstData::AssocFnCall {
+                type_name,
+                function,
+                args,
+            } => {
+                let method_key = (*type_name, *function);
+                if let Some(method_sig) = self.methods.get(&method_key) {
+                    // Generate constraints for arguments
+                    for (arg, param_type) in args.iter().zip(method_sig.param_types.iter()) {
+                        let arg_info = self.generate(*arg, ctx);
+                        self.add_constraint(Constraint::equal(
+                            arg_info.ty,
+                            param_type.clone(),
+                            arg_info.span,
+                        ));
+                    }
+                    method_sig.return_type.clone()
+                } else {
+                    // Method not found - sema will report the error
+                    // Still generate arg types to catch errors in arguments
+                    for arg in args.iter() {
+                        self.generate(*arg, ctx);
+                    }
+                    InferType::Concrete(Type::Error)
+                }
+            }
         };
 
         // Record the type for this expression
@@ -2002,6 +2105,7 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Add an integer constant to RIR
         let inst_ref = rir.add_inst(rue_rir::Inst {
@@ -2009,7 +2113,8 @@ mod tests {
             span: Span::new(0, 2),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -2029,13 +2134,15 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         let inst_ref = rir.add_inst(rue_rir::Inst {
             data: InstData::BoolConst(true),
             span: Span::new(0, 4),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::Bool);
 
@@ -2051,6 +2158,7 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Create: 1 + 2
         let lhs = rir.add_inst(rue_rir::Inst {
@@ -2066,7 +2174,8 @@ mod tests {
             span: Span::new(0, 5),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -2084,6 +2193,7 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Create: 1 < 2
         let lhs = rir.add_inst(rue_rir::Inst {
@@ -2099,7 +2209,8 @@ mod tests {
             span: Span::new(0, 5),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::Bool);
 
@@ -2117,6 +2228,7 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Create: true && false
         let lhs = rir.add_inst(rue_rir::Inst {
@@ -2132,7 +2244,8 @@ mod tests {
             span: Span::new(0, 13),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::Bool);
 
@@ -2150,6 +2263,7 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Create: -42
         let operand = rir.add_inst(rue_rir::Inst {
@@ -2161,7 +2275,8 @@ mod tests {
             span: Span::new(0, 3),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -2184,6 +2299,7 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Create: return 42
         let value = rir.add_inst(rue_rir::Inst {
@@ -2195,7 +2311,8 @@ mod tests {
             span: Span::new(0, 9),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -2213,6 +2330,7 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Create: if true { 1 } else { 2 }
         let cond = rir.add_inst(rue_rir::Inst {
@@ -2236,7 +2354,8 @@ mod tests {
             span: Span::new(0, 25),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -2254,6 +2373,7 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Create: while true { 0 }
         let cond = rir.add_inst(rue_rir::Inst {
@@ -2269,7 +2389,8 @@ mod tests {
             span: Span::new(0, 15),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::Unit);
 
@@ -2349,6 +2470,7 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Create: loop { 0 }
         let body = rir.add_inst(rue_rir::Inst {
@@ -2360,7 +2482,8 @@ mod tests {
             span: Span::new(0, 10),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::Unit);
 
@@ -2378,13 +2501,15 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         let break_inst = rir.add_inst(rue_rir::Inst {
             data: InstData::Break,
             span: Span::new(0, 5),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::Unit);
 
@@ -2401,6 +2526,7 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Create: arr[0]
         let base = rir.add_inst(rue_rir::Inst {
@@ -2416,7 +2542,8 @@ mod tests {
             span: Span::new(0, 6),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -2438,6 +2565,7 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Create: arr[0] = 42
         let base = rir.add_inst(rue_rir::Inst {
@@ -2457,7 +2585,8 @@ mod tests {
             span: Span::new(0, 11),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::Unit);
 
@@ -2479,6 +2608,7 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Create: { } (empty block)
         let block = rir.add_inst(rue_rir::Inst {
@@ -2489,7 +2619,8 @@ mod tests {
             span: Span::new(0, 2),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::Unit);
 
@@ -2506,6 +2637,7 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Create: !42 (bitwise NOT)
         let operand = rir.add_inst(rue_rir::Inst {
@@ -2517,7 +2649,8 @@ mod tests {
             span: Span::new(0, 3),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -2539,6 +2672,7 @@ mod tests {
         let mut functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Register a function that takes 2 parameters
         let func_name = interner.intern("foo");
@@ -2566,7 +2700,8 @@ mod tests {
             span: Span::new(0, 7),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::Bool);
 
@@ -2584,6 +2719,7 @@ mod tests {
         let functions = HashMap::new(); // Empty - no functions registered
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Create a call to an unknown function
         let unknown_func = interner.intern("unknown");
@@ -2599,7 +2735,8 @@ mod tests {
             span: Span::new(0, 11),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -2617,6 +2754,7 @@ mod tests {
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
+        let methods: HashMap<(Symbol, Symbol), MethodSig> = HashMap::new();
 
         // Create: match x { 1 => 10, 2 => 20, _ => 30 }
         let scrutinee = rir.add_inst(rue_rir::Inst {
@@ -2653,7 +2791,8 @@ mod tests {
             span: Span::new(0, 40),
         });
 
-        let mut cgen = ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums);
+        let mut cgen =
+            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -6,8 +6,8 @@
 use std::collections::{HashMap, HashSet};
 
 use crate::inference::{
-    Constraint, ConstraintContext, ConstraintGenerator, FunctionSig, InferType, ParamVarInfo,
-    Unifier, UnifyResult,
+    Constraint, ConstraintContext, ConstraintGenerator, FunctionSig, InferType, MethodSig,
+    ParamVarInfo, Unifier, UnifyResult,
 };
 use crate::inst::{Air, AirInst, AirInstData, AirPattern, AirRef};
 use crate::types::{
@@ -195,6 +195,25 @@ struct FunctionInfo {
     return_type: Type,
 }
 
+/// Information about a method in an impl block.
+#[derive(Debug, Clone)]
+struct MethodInfo {
+    /// The struct type this method belongs to
+    struct_type: Type,
+    /// Whether this is a method (has self) or associated function (no self)
+    has_self: bool,
+    /// Parameter names (excluding self if present)
+    param_names: Vec<Symbol>,
+    /// Parameter types (excluding self if present)
+    param_types: Vec<Type>,
+    /// Return type
+    return_type: Type,
+    /// The RIR instruction ref for the method body
+    body: InstRef,
+    /// Span of the method declaration
+    span: Span,
+}
+
 /// Result of analyzing an instruction: the AIR reference and its synthesized type.
 #[derive(Debug, Clone, Copy)]
 struct AnalysisResult {
@@ -235,6 +254,10 @@ pub struct Sema<'a> {
     strings: Vec<String>,
     /// Warnings collected during analysis
     warnings: Vec<CompileWarning>,
+    /// Method table: maps (struct_name, method_name) to method info
+    /// Used for resolving method calls (receiver.method()) and associated
+    /// function calls (Type::function())
+    methods: HashMap<(Symbol, Symbol), MethodInfo>,
 }
 
 impl<'a> Sema<'a> {
@@ -253,6 +276,7 @@ impl<'a> Sema<'a> {
             string_table: HashMap::new(),
             strings: Vec::new(),
             warnings: Vec::new(),
+            methods: HashMap::new(),
         }
     }
 
@@ -338,21 +362,39 @@ impl<'a> Sema<'a> {
         self.collect_enum_definitions()?;
         self.collect_struct_definitions()?;
 
-        // Second pass: collect function signatures
+        // Second pass: collect function and method signatures
         self.collect_function_signatures()?;
+        self.collect_method_definitions()?;
 
-        // Third pass: analyze function bodies
+        // Third pass: analyze regular function bodies (not methods)
         let mut functions = Vec::new();
 
+        // Collect method refs from impl blocks so we can skip them in the first pass
+        let mut method_refs: HashSet<InstRef> = HashSet::new();
         for (_, inst) in self.rir.iter() {
+            if let InstData::ImplDecl { methods, .. } = &inst.data {
+                for method_ref in methods {
+                    method_refs.insert(*method_ref);
+                }
+            }
+        }
+
+        // Analyze regular functions (not methods in impl blocks)
+        for (inst_ref, inst) in self.rir.iter() {
             if let InstData::FnDecl {
                 directives: _,
                 name,
                 params,
                 return_type,
                 body,
+                has_self: _,
             } = &inst.data
             {
+                // Skip methods - they'll be analyzed separately with impl block context
+                if method_refs.contains(&inst_ref) {
+                    continue;
+                }
+
                 let fn_name = self.interner.get(*name).to_string();
                 let ret_type = self.resolve_type(*return_type, inst.span)?;
 
@@ -374,6 +416,63 @@ impl<'a> Sema<'a> {
                     num_locals,
                     num_param_slots,
                 });
+            }
+        }
+
+        // Fourth pass: analyze method bodies from impl blocks
+        for (_, inst) in self.rir.iter() {
+            if let InstData::ImplDecl { type_name, methods } = &inst.data {
+                let type_name_str = self.interner.get(*type_name).to_string();
+                let struct_id = *self.structs.get(type_name).unwrap();
+                let struct_type = Type::Struct(struct_id);
+
+                for method_ref in methods {
+                    let method_inst = self.rir.get(*method_ref);
+                    if let InstData::FnDecl {
+                        name: method_name,
+                        params,
+                        return_type,
+                        body,
+                        has_self,
+                        ..
+                    } = &method_inst.data
+                    {
+                        let method_name_str = self.interner.get(*method_name).to_string();
+                        let ret_type = self.resolve_type(*return_type, method_inst.span)?;
+
+                        // Build parameter list, adding self as first parameter for methods
+                        let mut param_info: Vec<(Symbol, Type)> = Vec::new();
+
+                        if *has_self {
+                            // Add self parameter
+                            let self_sym = self.interner.intern("self");
+                            param_info.push((self_sym, struct_type));
+                        }
+
+                        // Add regular parameters
+                        for (pname, ptype) in params.iter() {
+                            let ty = self.resolve_type(*ptype, method_inst.span)?;
+                            param_info.push((*pname, ty));
+                        }
+
+                        let (air, num_locals, num_param_slots) =
+                            self.analyze_function(ret_type, &param_info, *body)?;
+
+                        // Generate method name with struct prefix: "Type.method" or "Type::function"
+                        let full_name = if *has_self {
+                            format!("{}.{}", type_name_str, method_name_str)
+                        } else {
+                            format!("{}::{}", type_name_str, method_name_str)
+                        };
+
+                        functions.push(AnalyzedFunction {
+                            name: full_name,
+                            air,
+                            num_locals,
+                            num_param_slots,
+                        });
+                    }
+                }
             }
         }
 
@@ -495,6 +594,80 @@ impl<'a> Sema<'a> {
         Ok(())
     }
 
+    /// Collect all method definitions from impl blocks.
+    ///
+    /// This processes all ImplDecl instructions and builds the method table
+    /// that maps (struct_name, method_name) to MethodInfo.
+    fn collect_method_definitions(&mut self) -> CompileResult<()> {
+        for (_, inst) in self.rir.iter() {
+            if let InstData::ImplDecl { type_name, methods } = &inst.data {
+                // Check that the type exists
+                let struct_id = match self.structs.get(type_name) {
+                    Some(id) => *id,
+                    None => {
+                        let type_name_str = self.interner.get(*type_name).to_string();
+                        return Err(CompileError::new(
+                            ErrorKind::UnknownType(type_name_str),
+                            inst.span,
+                        ));
+                    }
+                };
+                let struct_type = Type::Struct(struct_id);
+
+                // Process each method in the impl block
+                for method_ref in methods {
+                    let method_inst = self.rir.get(*method_ref);
+                    if let InstData::FnDecl {
+                        name: method_name,
+                        params,
+                        return_type,
+                        body,
+                        has_self,
+                        ..
+                    } = &method_inst.data
+                    {
+                        // Check for duplicate method names
+                        let key = (*type_name, *method_name);
+                        if self.methods.contains_key(&key) {
+                            let type_name_str = self.interner.get(*type_name).to_string();
+                            let method_name_str = self.interner.get(*method_name).to_string();
+                            return Err(CompileError::new(
+                                ErrorKind::DuplicateMethod {
+                                    type_name: type_name_str,
+                                    method_name: method_name_str,
+                                },
+                                method_inst.span,
+                            ));
+                        }
+
+                        // Resolve parameter types
+                        let param_names: Vec<Symbol> =
+                            params.iter().map(|(pname, _)| *pname).collect();
+                        let param_types: Vec<Type> = params
+                            .iter()
+                            .map(|(_, ptype)| self.resolve_type(*ptype, method_inst.span))
+                            .collect::<CompileResult<Vec<_>>>()?;
+                        let ret_type = self.resolve_type(*return_type, method_inst.span)?;
+
+                        self.methods.insert(
+                            key,
+                            MethodInfo {
+                                struct_type,
+                                has_self: *has_self,
+                                param_names,
+                                param_types,
+                                return_type: ret_type,
+                                body: *body,
+                                span: method_inst.span,
+                            },
+                        );
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Analyze a single function, producing AIR.
     /// Returns (air, num_locals, num_param_slots).
     fn analyze_function(
@@ -607,6 +780,27 @@ impl<'a> Sema<'a> {
             .map(|(name, id)| (*name, Type::Enum(*id)))
             .collect();
 
+        // Build method signatures map for the constraint generator
+        let method_sigs: HashMap<(Symbol, Symbol), MethodSig> = self
+            .methods
+            .iter()
+            .map(|((type_name, method_name), info)| {
+                (
+                    (*type_name, *method_name),
+                    MethodSig {
+                        struct_type: info.struct_type,
+                        has_self: info.has_self,
+                        param_types: info
+                            .param_types
+                            .iter()
+                            .map(|t| self.type_to_infer_type(*t))
+                            .collect(),
+                        return_type: self.type_to_infer_type(info.return_type),
+                    },
+                )
+            })
+            .collect();
+
         // Create constraint generator
         let mut cgen = ConstraintGenerator::new(
             self.rir,
@@ -614,6 +808,7 @@ impl<'a> Sema<'a> {
             &func_sigs,
             &struct_types,
             &enum_types,
+            &method_sigs,
         );
 
         // Build parameter map for constraint context.
@@ -2612,24 +2807,169 @@ impl<'a> Sema<'a> {
                 Ok(AnalysisResult::new(air_ref, Type::Unit))
             }
 
-            // Method call - placeholder for Phase 3 (see ADR-0009)
-            InstData::MethodCall { .. } => {
+            // Method call: receiver.method(args)
+            InstData::MethodCall {
+                receiver,
+                method,
+                args,
+            } => {
+                // Analyze the receiver expression
+                let receiver_result = self.analyze_inst(air, *receiver, ctx)?;
+                let receiver_type = receiver_result.ty;
+
+                // Get the method name as a string for error messages
+                let method_name_str = self.interner.get(*method).to_string();
+
+                // Check that receiver is a struct type
+                let struct_id = match receiver_type {
+                    Type::Struct(id) => id,
+                    _ => {
+                        return Err(CompileError::new(
+                            ErrorKind::MethodCallOnNonStruct {
+                                found: receiver_type.name().to_string(),
+                                method_name: method_name_str,
+                            },
+                            inst.span,
+                        ));
+                    }
+                };
+
+                // Look up the struct name by its ID
+                let struct_def = &self.struct_defs[struct_id.0 as usize];
+                let struct_name_str = struct_def.name.clone();
+
+                // Find the struct name symbol for method lookup
+                let struct_name_sym = self.interner.intern(&struct_name_str);
+
+                // Look up the method
+                let method_key = (struct_name_sym, *method);
+                let method_info = self.methods.get(&method_key).ok_or_else(|| {
+                    CompileError::new(
+                        ErrorKind::UndefinedMethod {
+                            type_name: struct_name_str.clone(),
+                            method_name: method_name_str.clone(),
+                        },
+                        inst.span,
+                    )
+                })?;
+
+                // Check that this is a method (has self), not an associated function
+                if !method_info.has_self {
+                    return Err(CompileError::new(
+                        ErrorKind::AssocFnCalledAsMethod {
+                            type_name: struct_name_str,
+                            function_name: method_name_str,
+                        },
+                        inst.span,
+                    ));
+                }
+
+                // Check argument count (method_info.param_types excludes self)
+                if args.len() != method_info.param_types.len() {
+                    return Err(CompileError::new(
+                        ErrorKind::WrongArgumentCount {
+                            expected: method_info.param_types.len(),
+                            found: args.len(),
+                        },
+                        inst.span,
+                    ));
+                }
+
+                // Clone data needed before mutable borrow
+                let return_type = method_info.return_type;
+
+                // Analyze arguments
+                let mut arg_refs = vec![receiver_result.air_ref];
+                for arg in args.iter() {
+                    let arg_result = self.analyze_inst(air, *arg, ctx)?;
+                    arg_refs.push(arg_result.air_ref);
+                }
+
+                // Generate a method call name: Type.method
+                let call_name = format!("{}.{}", struct_name_str, method_name_str);
+
                 let air_ref = air.add_inst(AirInst {
-                    data: AirInstData::UnitConst,
-                    ty: Type::Unit,
+                    data: AirInstData::Call {
+                        name: call_name,
+                        args: arg_refs,
+                    },
+                    ty: return_type,
                     span: inst.span,
                 });
-                Ok(AnalysisResult::new(air_ref, Type::Unit))
+                Ok(AnalysisResult::new(air_ref, return_type))
             }
 
-            // Associated function call - placeholder for Phase 3 (see ADR-0009)
-            InstData::AssocFnCall { .. } => {
+            // Associated function call: Type::function(args)
+            InstData::AssocFnCall {
+                type_name,
+                function,
+                args,
+            } => {
+                // Get the type and function names for error messages
+                let type_name_str = self.interner.get(*type_name).to_string();
+                let function_name_str = self.interner.get(*function).to_string();
+
+                // Check that the type exists and is a struct
+                let _struct_id = self.structs.get(type_name).ok_or_else(|| {
+                    CompileError::new(ErrorKind::UnknownType(type_name_str.clone()), inst.span)
+                })?;
+
+                // Look up the function
+                let method_key = (*type_name, *function);
+                let method_info = self.methods.get(&method_key).ok_or_else(|| {
+                    CompileError::new(
+                        ErrorKind::UndefinedAssocFn {
+                            type_name: type_name_str.clone(),
+                            function_name: function_name_str.clone(),
+                        },
+                        inst.span,
+                    )
+                })?;
+
+                // Check that this is an associated function (no self), not a method
+                if method_info.has_self {
+                    return Err(CompileError::new(
+                        ErrorKind::MethodCalledAsAssocFn {
+                            type_name: type_name_str,
+                            method_name: function_name_str,
+                        },
+                        inst.span,
+                    ));
+                }
+
+                // Check argument count
+                if args.len() != method_info.param_types.len() {
+                    return Err(CompileError::new(
+                        ErrorKind::WrongArgumentCount {
+                            expected: method_info.param_types.len(),
+                            found: args.len(),
+                        },
+                        inst.span,
+                    ));
+                }
+
+                // Clone data needed before mutable borrow
+                let return_type = method_info.return_type;
+
+                // Analyze arguments
+                let mut arg_refs = Vec::new();
+                for arg in args.iter() {
+                    let arg_result = self.analyze_inst(air, *arg, ctx)?;
+                    arg_refs.push(arg_result.air_ref);
+                }
+
+                // Generate a function call name: Type::function
+                let call_name = format!("{}::{}", type_name_str, function_name_str);
+
                 let air_ref = air.add_inst(AirInst {
-                    data: AirInstData::UnitConst,
-                    ty: Type::Unit,
+                    data: AirInstData::Call {
+                        name: call_name,
+                        args: arg_refs,
+                    },
+                    ty: return_type,
                     span: inst.span,
                 });
-                Ok(AnalysisResult::new(air_ref, Type::Unit))
+                Ok(AnalysisResult::new(air_ref, return_type))
             }
         }
     }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -267,6 +267,36 @@ pub enum ErrorKind {
         struct_name: String,
         field_name: String,
     },
+    /// Duplicate method definition in impl blocks for the same type
+    DuplicateMethod {
+        type_name: String,
+        method_name: String,
+    },
+    /// Method not found on a type
+    UndefinedMethod {
+        type_name: String,
+        method_name: String,
+    },
+    /// Associated function not found on a type
+    UndefinedAssocFn {
+        type_name: String,
+        function_name: String,
+    },
+    /// Method call on non-struct type
+    MethodCallOnNonStruct {
+        found: String,
+        method_name: String,
+    },
+    /// Calling a method (with self) as an associated function
+    MethodCalledAsAssocFn {
+        type_name: String,
+        method_name: String,
+    },
+    /// Calling an associated function (without self) as a method
+    AssocFnCalledAsMethod {
+        type_name: String,
+        function_name: String,
+    },
 
     // Enum errors
     DuplicateVariant {
@@ -507,6 +537,59 @@ impl fmt::Display for ErrorKind {
                     f,
                     "duplicate field '{}' in struct '{}'",
                     field_name, struct_name
+                )
+            }
+            ErrorKind::DuplicateMethod {
+                type_name,
+                method_name,
+            } => {
+                write!(
+                    f,
+                    "duplicate method '{}' for type '{}'",
+                    method_name, type_name
+                )
+            }
+            ErrorKind::UndefinedMethod {
+                type_name,
+                method_name,
+            } => {
+                write!(
+                    f,
+                    "no method named '{}' found for type '{}'",
+                    method_name, type_name
+                )
+            }
+            ErrorKind::UndefinedAssocFn {
+                type_name,
+                function_name,
+            } => {
+                write!(
+                    f,
+                    "no associated function named '{}' found for type '{}'",
+                    function_name, type_name
+                )
+            }
+            ErrorKind::MethodCallOnNonStruct { found, method_name } => {
+                write!(f, "no method named '{}' on type '{}'", method_name, found)
+            }
+            ErrorKind::MethodCalledAsAssocFn {
+                type_name,
+                method_name,
+            } => {
+                write!(
+                    f,
+                    "'{}::{}' is a method, not an associated function; use receiver.{}() syntax",
+                    type_name, method_name, method_name
+                )
+            }
+            ErrorKind::AssocFnCalledAsMethod {
+                type_name,
+                function_name,
+            } => {
+                write!(
+                    f,
+                    "'{}' is an associated function, not a method; use {}::{}() syntax",
+                    function_name, type_name, function_name
                 )
             }
             ErrorKind::DuplicateVariant {

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -156,8 +156,11 @@ impl<'a> AstGen<'a> {
         // Generate body expression
         let body = self.gen_expr(&method.body);
 
-        // For now, we emit methods as regular FnDecl instructions.
-        // Sema will handle the method resolution and self parameter.
+        // Track whether this method has a self receiver (method vs associated function)
+        let has_self = method.receiver.is_some();
+
+        // Emit methods as FnDecl instructions with has_self flag.
+        // Sema uses has_self to add the implicit self parameter for methods.
         self.rir.add_inst(Inst {
             data: InstData::FnDecl {
                 directives,
@@ -165,6 +168,7 @@ impl<'a> AstGen<'a> {
                 params,
                 return_type,
                 body,
+                has_self,
             },
             span: method.span,
         })
@@ -214,6 +218,7 @@ impl<'a> AstGen<'a> {
         let body = self.gen_expr(&func.body);
 
         // Create function declaration instruction
+        // Regular functions don't have a self receiver
         self.rir.add_inst(Inst {
             data: InstData::FnDecl {
                 directives,
@@ -221,6 +226,7 @@ impl<'a> AstGen<'a> {
                 params,
                 return_type,
                 body,
+                has_self: false,
             },
             span: func.span,
         })
@@ -641,10 +647,12 @@ mod tests {
                 params,
                 return_type,
                 body,
+                has_self,
             } => {
                 assert_eq!(interner.get(*name), "main");
                 assert!(params.is_empty());
                 assert_eq!(interner.get(*return_type), "i32");
+                assert!(!has_self); // Regular functions don't have self
                 // Body should be the int constant
                 let body_inst = rir.get(*body);
                 assert!(matches!(body_inst.data, InstData::IntConst(42)));

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -253,6 +253,10 @@ pub enum InstData {
         params: Vec<(Symbol, Symbol)>,
         return_type: Symbol,
         body: InstRef,
+        /// Whether this function/method takes `self` as a receiver.
+        /// Only true for methods in impl blocks that have a self parameter.
+        /// Used by sema to know to add the implicit self parameter.
+        has_self: bool,
     },
 
     /// Function call
@@ -591,9 +595,11 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     params,
                     return_type,
                     body,
+                    has_self,
                 } => {
                     let name_str = self.interner.get(*name);
                     let ret_str = self.interner.get(*return_type);
+                    let self_str = if *has_self { "self, " } else { "" };
                     let params_str: Vec<String> = params
                         .iter()
                         .map(|(pname, ptype)| {
@@ -605,8 +611,9 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         })
                         .collect();
                     out.push_str(&format!(
-                        "fn {}({}) -> {} {{\n",
+                        "fn {}({}{}) -> {} {{\n",
                         name_str,
+                        self_str,
                         params_str.join(", "),
                         ret_str
                     ));

--- a/docs/designs/0009-struct-methods.md
+++ b/docs/designs/0009-struct-methods.md
@@ -144,7 +144,7 @@ Methods can only be defined for structs in the same compilation unit. (This is a
   - Handle method calls in expression generation
   - Parse associated function calls (Type::fn() syntax)
 
-- [ ] **Phase 3: Type Checking** - rue-qs3z.3
+- [x] **Phase 3: Type Checking** - rue-qs3z.3
   - Add method registry to struct definitions
   - Type check impl blocks
   - Resolve method calls to their definitions


### PR DESCRIPTION
Implements Phase 3 of ADR-0009 (struct methods):

- Add MethodInfo struct and method registry to sema.rs
- Collect method definitions from ImplDecl instructions
- Resolve method calls (receiver.method()) to their definitions
- Resolve associated function calls (Type::function())
- Handle self parameter binding for method bodies
- Add MethodSig to constraint generator for type inference
- Generate constraints for method call arguments and return types
- Add new error types: DuplicateMethod, UndefinedMethod, UndefinedAssocFn, MethodCallOnNonStruct, MethodCalledAsAssocFn, AssocFnCalledAsMethod

Closes rue-qs3z.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)