### PR TITLE
Convert emit.rs verification panic to proper error (rue-zprf)

### DIFF
--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -5,6 +5,8 @@
 
 use std::collections::HashMap;
 
+use rue_error::{CompileError, CompileResult, ErrorKind};
+
 use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Reg};
 use crate::EmittedRelocation;
 
@@ -197,7 +199,24 @@ impl<'a> Emitter<'a> {
     }
 
     /// Emit machine code for all instructions.
-    pub fn emit(mut self) -> (Vec<u8>, Vec<EmittedRelocation>) {
+    pub fn emit(mut self) -> CompileResult<(Vec<u8>, Vec<EmittedRelocation>)> {
+        // Verify no LdrIndexed or StrIndexed survived into emission
+        // These should have been lowered by regalloc into Ldr/Str with physical registers
+        for (i, inst) in self.mir.iter().enumerate() {
+            if matches!(
+                inst,
+                Aarch64Inst::LdrIndexed { .. } | Aarch64Inst::StrIndexed { .. }
+            ) {
+                return Err(CompileError::without_span(ErrorKind::InternalError(
+                    format!(
+                        "post-regalloc verification failed: instruction {} is {:?}, \
+                         which should have been lowered by regalloc",
+                        i, inst
+                    ),
+                )));
+            }
+        }
+
         if self.num_locals > 0 || self.num_params > 0 || !self.callee_saved.is_empty() {
             self.has_frame = true;
             self.emit_prologue();
@@ -208,7 +227,7 @@ impl<'a> Emitter<'a> {
         }
 
         self.apply_fixups();
-        (self.code, self.relocations)
+        Ok((self.code, self.relocations))
     }
 
     /// Emit function prologue.
@@ -652,20 +671,9 @@ impl<'a> Emitter<'a> {
                 self.emit_ldp_post(rt1, rt2, *offset);
             }
 
-            Aarch64Inst::LdrIndexed { dst, base } => {
-                let rd = dst.as_physical();
-                // base is a VReg; after regalloc it should be allocated to a physical register
-                // We need to look it up in the allocation. For now, assume it's already physical
-                // after regalloc rewrites.
-                // Actually, the regalloc phase should have rewritten this instruction.
-                // For now, emit a simple load from the register
-                self.emit_ldr(rd, Reg::X9, 0); // Temporary - should use allocated base reg
-            }
-
-            Aarch64Inst::StrIndexed { src, base: _ } => {
-                let rs = src.as_physical();
-                // Same as above - regalloc should handle this
-                self.emit_str(rs, Reg::X9, 0);
+            // These instructions should be caught by the verification at the start of emit()
+            Aarch64Inst::LdrIndexed { .. } | Aarch64Inst::StrIndexed { .. } => {
+                unreachable!("LdrIndexed/StrIndexed should be caught by emit() verification")
             }
 
             Aarch64Inst::LslImm { dst, src, imm } => {
@@ -1692,7 +1700,7 @@ mod tests {
     fn emit_single(inst: Aarch64Inst) -> Vec<u8> {
         let mut mir = Aarch64Mir::new();
         mir.push(inst);
-        Emitter::new(&mir, 0, 0, &[], &[]).emit().0
+        Emitter::new(&mir, 0, 0, &[], &[]).emit().unwrap().0
     }
 
     // --- Move instructions ---
@@ -2200,7 +2208,7 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, &[], &[]).emit().unwrap();
 
         // b forward -> 0x14000002 (offset = 2 instructions = 8 bytes / 4)
         let inst = u32::from_le_bytes(code[0..4].try_into().unwrap());
@@ -2219,7 +2227,7 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, &[], &[]).emit().unwrap();
 
         // b.eq -> 0x54000000 + condition (eq = 0)
         let inst = u32::from_le_bytes(code[0..4].try_into().unwrap());
@@ -2237,7 +2245,7 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, &[], &[]).emit().unwrap();
 
         // cbz x0, label
         let inst = u32::from_le_bytes(code[0..4].try_into().unwrap());
@@ -2256,7 +2264,7 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, &[], &[]).emit().unwrap();
 
         // cbnz x0, label
         let inst = u32::from_le_bytes(code[0..4].try_into().unwrap());
@@ -2270,7 +2278,7 @@ mod tests {
             symbol: "test_func".to_string(),
         });
 
-        let (code, relocs) = Emitter::new(&mir, 0, 0, &[], &[]).emit();
+        let (code, relocs) = Emitter::new(&mir, 0, 0, &[], &[]).emit().unwrap();
 
         // bl -> 0x94000000
         let inst = u32::from_le_bytes(code[0..4].try_into().unwrap());

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -51,7 +51,7 @@ pub fn generate(
     // Emit machine code bytes
     let total_locals = num_locals + num_spills;
     let (code, relocations) =
-        Emitter::new(&mir, total_locals, num_params, &used_callee_saved, strings).emit();
+        Emitter::new(&mir, total_locals, num_params, &used_callee_saved, strings).emit()?;
 
     Ok(MachineCode {
         code,

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -5,6 +5,8 @@
 
 use std::collections::HashMap;
 
+use rue_error::{CompileError, CompileResult, ErrorKind};
+
 use super::EmittedRelocation;
 use super::mir::{LabelId, Reg, X86Inst, X86Mir};
 
@@ -81,20 +83,21 @@ impl<'a> Emitter<'a> {
     /// Emit machine code for all instructions.
     ///
     /// Returns (code bytes, relocations).
-    pub fn emit(mut self) -> (Vec<u8>, Vec<EmittedRelocation>) {
+    pub fn emit(mut self) -> CompileResult<(Vec<u8>, Vec<EmittedRelocation>)> {
         // Verify no MovRMIndexed or MovMRIndexed survived into emission
         // These should have been lowered by regalloc into MovRM/MovMR
-        #[cfg(debug_assertions)]
         for (i, inst) in self.mir.iter().enumerate() {
             if matches!(
                 inst,
                 X86Inst::MovRMIndexed { .. } | X86Inst::MovMRIndexed { .. }
             ) {
-                panic!(
-                    "Post-regalloc verification failed: instruction {} is {:?}, \
-                     which should have been lowered by regalloc",
-                    i, inst
-                );
+                return Err(CompileError::without_span(ErrorKind::InternalError(
+                    format!(
+                        "post-regalloc verification failed: instruction {} is {:?}, \
+                         which should have been lowered by regalloc",
+                        i, inst
+                    ),
+                )));
             }
         }
 
@@ -107,7 +110,7 @@ impl<'a> Emitter<'a> {
             self.emit_inst(inst);
         }
         self.apply_fixups();
-        (self.code, self.relocations)
+        Ok((self.code, self.relocations))
     }
 
     /// Emit function prologue to set up the stack frame.
@@ -1791,7 +1794,7 @@ mod tests {
     fn emit_single(inst: X86Inst) -> Vec<u8> {
         let mut mir = X86Mir::new();
         mir.push(inst);
-        Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().0
+        Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap().0
     }
 
     #[test]
@@ -1913,7 +1916,7 @@ mod tests {
         });
         mir.push(X86Inst::Syscall);
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
 
         // 41 BA 2A 00 00 00  mov r10d, 42
         // 4C 89 D7           mov rdi, r10
@@ -1937,7 +1940,7 @@ mod tests {
             symbol: "__rue_exit".into(),
         });
 
-        let (code, relocs) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit();
+        let (code, relocs) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
 
         // call rel32 -> E8 00 00 00 00
         assert_eq!(code, vec![0xE8, 0x00, 0x00, 0x00, 0x00]);
@@ -2164,7 +2167,7 @@ mod tests {
     fn test_prologue_one_local() {
         // With 1 local, we need 8 bytes, aligned to 16 = 16 bytes
         let mir = X86Mir::new();
-        let (code, _) = Emitter::new(&mir, 1, 1, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 1, 1, 0, &[], &[]).emit().unwrap();
 
         // push rbp: 55
         // mov rbp, rsp: 48 89 E5
@@ -2183,7 +2186,7 @@ mod tests {
     fn test_no_prologue_no_locals() {
         // With 0 locals, no prologue should be emitted
         let mir = X86Mir::new();
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
         assert!(code.is_empty());
     }
 
@@ -2701,7 +2704,7 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
 
         // jmp rel32 -> E9 xx xx xx xx (displacement = 5)
         assert_eq!(code[0], 0xE9);
@@ -2723,7 +2726,7 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
 
         // jz rel32 -> 0F 84 xx xx xx xx (displacement = 5)
         assert_eq!(code[0], 0x0F);
@@ -2746,7 +2749,7 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
 
         // jnz rel32 -> 0F 85 xx xx xx xx (displacement = 5)
         assert_eq!(code[0], 0x0F);
@@ -2763,7 +2766,7 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
 
         // jo rel32 -> 0F 80 00 00 00 00
         assert_eq!(&code[0..6], &[0x0F, 0x80, 0x00, 0x00, 0x00, 0x00]);
@@ -2779,7 +2782,7 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
 
         // jno rel32 -> 0F 81 00 00 00 00
         assert_eq!(&code[0..6], &[0x0F, 0x81, 0x00, 0x00, 0x00, 0x00]);
@@ -2795,7 +2798,7 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
 
         // jb rel32 -> 0F 82 00 00 00 00
         assert_eq!(&code[0..6], &[0x0F, 0x82, 0x00, 0x00, 0x00, 0x00]);
@@ -2811,7 +2814,7 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
 
         // jae rel32 -> 0F 83 00 00 00 00
         assert_eq!(&code[0..6], &[0x0F, 0x83, 0x00, 0x00, 0x00, 0x00]);
@@ -2827,7 +2830,7 @@ mod tests {
             id: LabelId::new(0),
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &[]).emit().unwrap();
 
         // jbe rel32 -> 0F 86 00 00 00 00
         assert_eq!(&code[0..6], &[0x0F, 0x86, 0x00, 0x00, 0x00, 0x00]);
@@ -2869,7 +2872,7 @@ mod tests {
             string_id: 0,
         });
 
-        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &strings).emit();
+        let (code, _) = Emitter::new(&mir, 0, 0, 0, &[], &strings).emit().unwrap();
 
         // mov rax, 5 -> 48 B8 05 00 00 00 00 00 00 00
         assert_eq!(

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -64,7 +64,7 @@ pub fn generate(
         &used_callee_saved,
         strings,
     )
-    .emit();
+    .emit()?;
 
     Ok(MachineCode {
         code,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -350,6 +350,9 @@ pub enum ErrorKind {
     UseAfterMove {
         var_name: String,
     },
+
+    // Internal compiler errors (bugs in the compiler itself)
+    InternalError(String),
 }
 
 impl CompileError {
@@ -639,6 +642,9 @@ impl fmt::Display for ErrorKind {
             }
             ErrorKind::UseAfterMove { var_name } => {
                 write!(f, "use of moved value '{}'", var_name)
+            }
+            ErrorKind::InternalError(msg) => {
+                write!(f, "internal compiler error: {}", msg)
             }
         }
     }


### PR DESCRIPTION
Replace panic with CompileError::InternalError when indexed memory instructions survive to emission. This provides a proper error path instead of crashing if regalloc fails to lower these instructions.

Changes:
- Add ErrorKind::InternalError variant for internal compiler bugs
- Change emit() in both x86_64 and aarch64 to return CompileResult
- Replace panic! with Err(CompileError::InternalError(...))
- Update all call sites to propagate errors with ?
- Update test helpers with .unwrap()

Fixes rue-zprf

🤖 Generated with [Claude Code](https://claude.com/claude-code)