### PR TITLE
Mark Phase 4 (Code Generation) complete in struct methods ADR

### DIFF
--- a/docs/designs/0009-struct-methods.md
+++ b/docs/designs/0009-struct-methods.md
@@ -155,7 +155,7 @@ Methods can only be defined for structs in the same compilation unit. (This is a
     3. Resolving the method name
     4. Type checking the arguments against method signature
 
-- [ ] **Phase 4: Code Generation** - rue-qs3z.4
+- [x] **Phase 4: Code Generation** - rue-qs3z.4
   - Lower method calls to regular calls with receiver as first argument
   - Update both x86_64 and aarch64 backends
   - Handle associated function calls (`Type::method()`)


### PR DESCRIPTION
Phase 4 was already implemented by Phase 3. The semantic analysis (sema) lowers method calls to AirInstData::Call with:
- Methods: name 'Type.method', receiver as first arg
- Associated functions: name 'Type::function', just the provided args

Methods are emitted as separate AnalyzedFunctions with these names, and the existing codegen handles Call instructions properly - it just looks up the function symbol and emits CallRel.

All 5 impl-block tests pass (method calls, associated functions, method chaining, multiple impl blocks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)