### PR TITLE
Implement spec and stabilize struct methods (Phase 5)

### DIFF
--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -39,8 +39,6 @@ pub enum PreviewFeature {
     MutableStrings,
     /// Hindley-Milner type inference (ADR-0007).
     HmInference,
-    /// Struct methods and impl blocks (ADR-0009).
-    Methods,
     /// Destructors for automatic cleanup (ADR-0010).
     Destructors,
 }
@@ -51,7 +49,6 @@ impl PreviewFeature {
         match self {
             PreviewFeature::MutableStrings => "mutable_strings",
             PreviewFeature::HmInference => "hm_inference",
-            PreviewFeature::Methods => "methods",
             PreviewFeature::Destructors => "destructors",
         }
     }
@@ -61,7 +58,6 @@ impl PreviewFeature {
         match s {
             "mutable_strings" => Some(PreviewFeature::MutableStrings),
             "hm_inference" => Some(PreviewFeature::HmInference),
-            "methods" => Some(PreviewFeature::Methods),
             "destructors" => Some(PreviewFeature::Destructors),
             _ => None,
         }
@@ -72,7 +68,6 @@ impl PreviewFeature {
         match self {
             PreviewFeature::MutableStrings => "ADR-019",
             PreviewFeature::HmInference => "ADR-0007",
-            PreviewFeature::Methods => "ADR-0009",
             PreviewFeature::Destructors => "ADR-0010",
         }
     }
@@ -82,7 +77,6 @@ impl PreviewFeature {
         &[
             PreviewFeature::MutableStrings,
             PreviewFeature::HmInference,
-            PreviewFeature::Methods,
             PreviewFeature::Destructors,
         ]
     }

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -259,6 +259,8 @@ pub enum Expr {
     Path(PathExpr),
     /// Associated function call (e.g., `Point::origin()`)
     AssocFnCall(AssocFnCallExpr),
+    /// Self expression (e.g., `self` in method bodies)
+    SelfExpr(SelfExpr),
 }
 
 /// An integer literal.
@@ -646,6 +648,12 @@ pub struct ReturnExpr {
     pub span: Span,
 }
 
+/// A self expression (the `self` keyword in method bodies).
+#[derive(Debug, Clone)]
+pub struct SelfExpr {
+    pub span: Span,
+}
+
 impl Expr {
     /// Get the span of this expression.
     pub fn span(&self) -> Span {
@@ -675,6 +683,7 @@ impl Expr {
             Expr::Index(index_expr) => index_expr.span,
             Expr::Path(path_expr) => path_expr.span,
             Expr::AssocFnCall(assoc_fn_call) => assoc_fn_call.span,
+            Expr::SelfExpr(self_expr) => self_expr.span,
         }
     }
 }
@@ -944,6 +953,9 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
                 fmt_expr(f, arg, level + 1)?;
             }
             Ok(())
+        }
+        Expr::SelfExpr(_) => {
+            writeln!(f, "SelfExpr")
         }
     }
 }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -9,8 +9,8 @@ use crate::ast::{
     EnumVariant, Expr, FieldDecl, FieldExpr, FieldInit, Function, Ident, IfExpr, ImplBlock,
     IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr, Item, LetPattern, LetStatement, LoopExpr,
     MatchArm, MatchExpr, Method, MethodCallExpr, NegIntLit, Param, ParenExpr, PathExpr,
-    PathPattern, Pattern, ReturnExpr, SelfParam, Statement, StringLit, StructDecl, StructLitExpr,
-    TypeExpr, UnaryExpr, UnaryOp, UnitLit, WhileExpr,
+    PathPattern, Pattern, ReturnExpr, SelfExpr, SelfParam, Statement, StringLit, StructDecl,
+    StructLitExpr, TypeExpr, UnaryExpr, UnaryOp, UnitLit, WhileExpr,
 };
 use chumsky::input::{Input as ChumskyInput, Stream, ValueInput};
 use chumsky::pratt::{infix, left, prefix};
@@ -491,6 +491,11 @@ where
         TokenKind::Continue = e => Expr::Continue(ContinueExpr { span: to_rue_span(e.span()) }),
     };
 
+    // Self expression (in method bodies)
+    let self_expr = select! {
+        TokenKind::SelfValue = e => Expr::SelfExpr(SelfExpr { span: to_rue_span(e.span()) }),
+    };
+
     // Return expression: return <expr>? (expression is optional for unit-returning functions)
     let return_expr = just(TokenKind::Return)
         .ignore_then(expr.clone().or_not())
@@ -722,6 +727,7 @@ where
 
     // Primary expression (before field access and indexing)
     // Note: unit_lit must come before paren_expr so () is parsed as unit, not empty parens
+    // Note: self_expr must come before ident_or_call_or_struct_or_path since self is a keyword
     let primary = choice((
         int_lit,
         string_lit,
@@ -730,6 +736,7 @@ where
         unit_lit,
         break_expr,
         continue_expr,
+        self_expr,
         return_expr,
         if_expr,
         match_expr,

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -505,6 +505,14 @@ impl<'a> AstGen<'a> {
                     span: assoc_fn_call.span,
                 })
             }
+            Expr::SelfExpr(self_expr) => {
+                // `self` in method bodies is just a variable reference to the implicit self parameter
+                let name = self.interner.intern("self");
+                self.rir.add_inst(Inst {
+                    data: InstData::VarRef { name },
+                    span: self_expr.span,
+                })
+            }
         }
     }
 

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -410,7 +410,7 @@ pub enum InstData {
         value: InstRef,
     },
 
-    // Method operations (preview: methods)
+    // Method operations
     /// Impl block declaration
     ImplDecl {
         /// Type name this impl block is for

--- a/crates/rue-spec/cases/items/impl-blocks.toml
+++ b/crates/rue-spec/cases/items/impl-blocks.toml
@@ -5,15 +5,12 @@ name = "Impl Blocks and Methods"
 description = "Impl block definitions and method calls."
 
 # =============================================================================
-# Basic Impl Block Syntax (Parsing Only - Phase 1)
+# Basic Impl Block Syntax
 # =============================================================================
 
-# These tests verify that impl blocks and method calls parse correctly.
-# They are expected to fail at later compilation stages until Phase 2-4 are complete.
-
 [[case]]
-name = "impl_block_basic_parse"
-preview = "methods"
+name = "impl_block_basic"
+spec = ["6.4:1", "6.4:2", "6.4:3", "6.4:4", "6.4:5"]
 source = """
 struct Point { x: i32, y: i32 }
 
@@ -30,28 +27,13 @@ fn main() -> i32 {
 """
 exit_code = 42
 
-[[case]]
-name = "impl_block_associated_function"
-preview = "methods"
-source = """
-struct Point { x: i32, y: i32 }
-
-impl Point {
-    fn origin() -> Point {
-        Point { x: 0, y: 0 }
-    }
-}
-
-fn main() -> i32 {
-    let p = Point::origin();
-    p.x
-}
-"""
-exit_code = 0
+# =============================================================================
+# Method Calls
+# =============================================================================
 
 [[case]]
-name = "impl_block_method_with_args"
-preview = "methods"
+name = "method_call_with_args"
+spec = ["6.4:6", "6.4:7", "6.4:8", "6.4:9"]
 source = """
 struct Point { x: i32, y: i32 }
 
@@ -69,9 +51,13 @@ fn main() -> i32 {
 """
 exit_code = 42
 
+# =============================================================================
+# Method Chaining
+# =============================================================================
+
 [[case]]
 name = "method_call_chain"
-preview = "methods"
+spec = ["6.4:10", "6.4:11"]
 source = """
 struct Counter { value: i32 }
 
@@ -88,9 +74,55 @@ fn main() -> i32 {
 """
 exit_code = 42
 
+# =============================================================================
+# Associated Functions
+# =============================================================================
+
+[[case]]
+name = "associated_function_basic"
+spec = ["6.4:12", "6.4:13", "6.4:14"]
+source = """
+struct Point { x: i32, y: i32 }
+
+impl Point {
+    fn origin() -> Point {
+        Point { x: 0, y: 0 }
+    }
+}
+
+fn main() -> i32 {
+    let p = Point::origin();
+    p.x
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "associated_function_with_args"
+spec = ["6.4:12", "6.4:13"]
+source = """
+struct Point { x: i32, y: i32 }
+
+impl Point {
+    fn new(x: i32, y: i32) -> Point {
+        Point { x: x, y: y }
+    }
+}
+
+fn main() -> i32 {
+    let p = Point::new(42, 10);
+    p.x
+}
+"""
+exit_code = 42
+
+# =============================================================================
+# Multiple Impl Blocks
+# =============================================================================
+
 [[case]]
 name = "multiple_impl_blocks"
-preview = "methods"
+spec = ["6.4:15", "6.4:17"]
 source = """
 struct Point { x: i32, y: i32 }
 
@@ -105,6 +137,201 @@ impl Point {
         self.y
     }
 }
+
+fn main() -> i32 {
+    let p = Point { x: 42, y: 10 };
+    p.get_x()
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "multiple_impl_blocks_use_both"
+spec = ["6.4:15"]
+source = """
+struct Point { x: i32, y: i32 }
+
+impl Point {
+    fn get_x(self) -> i32 {
+        self.x
+    }
+}
+
+impl Point {
+    fn get_y(self) -> i32 {
+        self.y
+    }
+}
+
+fn main() -> i32 {
+    let p1 = Point { x: 10, y: 32 };
+    let p2 = Point { x: 10, y: 32 };
+    p1.get_x() + p2.get_y()
+}
+"""
+exit_code = 42
+
+# =============================================================================
+# Method and Associated Function Together
+# =============================================================================
+
+[[case]]
+name = "method_and_associated_function"
+spec = ["6.4:3", "6.4:12"]
+source = """
+struct Counter { value: i32 }
+
+impl Counter {
+    fn new(start: i32) -> Counter {
+        Counter { value: start }
+    }
+
+    fn get(self) -> i32 {
+        self.value
+    }
+}
+
+fn main() -> i32 {
+    let c = Counter::new(42);
+    c.get()
+}
+"""
+exit_code = 42
+
+# =============================================================================
+# Self Field Access
+# =============================================================================
+
+[[case]]
+name = "self_field_access"
+spec = ["6.4:4"]
+source = """
+struct Rectangle { width: i32, height: i32 }
+
+impl Rectangle {
+    fn area(self) -> i32 {
+        self.width * self.height
+    }
+}
+
+fn main() -> i32 {
+    let r = Rectangle { width: 6, height: 7 };
+    r.area()
+}
+"""
+exit_code = 42
+
+# =============================================================================
+# Error Cases
+# =============================================================================
+
+[[case]]
+name = "method_on_non_struct_error"
+spec = ["6.4:20"]
+source = """
+fn main() -> i32 {
+    let x: i32 = 42;
+    x.foo()
+}
+"""
+compile_fail = true
+error_contains = "no method named"
+
+[[case]]
+name = "undefined_method_error"
+spec = ["6.4:21"]
+source = """
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 42, y: 10 };
+    p.undefined_method()
+}
+"""
+compile_fail = true
+error_contains = "undefined"
+
+[[case]]
+name = "assoc_fn_called_as_method_error"
+spec = ["6.4:22"]
+source = """
+struct Point { x: i32, y: i32 }
+
+impl Point {
+    fn origin() -> Point {
+        Point { x: 0, y: 0 }
+    }
+}
+
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    let q = p.origin();
+    q.x
+}
+"""
+compile_fail = true
+error_contains = "associated function"
+
+[[case]]
+name = "method_called_as_assoc_fn_error"
+spec = ["6.4:23"]
+source = """
+struct Point { x: i32, y: i32 }
+
+impl Point {
+    fn get_x(self) -> i32 {
+        self.x
+    }
+}
+
+fn main() -> i32 {
+    Point::get_x()
+}
+"""
+compile_fail = true
+error_contains = "method"
+
+[[case]]
+name = "impl_for_undefined_struct_error"
+spec = ["6.4:19"]
+source = """
+impl UndefinedType {
+    fn foo(self) -> i32 { 0 }
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "unknown type"
+
+[[case]]
+name = "duplicate_method_name_error"
+spec = ["6.4:16"]
+source = """
+struct Point { x: i32, y: i32 }
+
+impl Point {
+    fn get_x(self) -> i32 { self.x }
+}
+
+impl Point {
+    fn get_x(self) -> i32 { self.x }
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "duplicate"
+
+[[case]]
+name = "impl_before_struct"
+spec = ["6.4:18"]
+source = """
+impl Point {
+    fn get_x(self) -> i32 { self.x }
+}
+
+struct Point { x: i32, y: i32 }
 
 fn main() -> i32 {
     let p = Point { x: 42, y: 10 };

--- a/docs/designs/0009-struct-methods.md
+++ b/docs/designs/0009-struct-methods.md
@@ -1,13 +1,13 @@
 ---
 id: 0009
 title: Struct Methods
-status: proposal
+status: implemented
 tags: [types, syntax]
 feature-flag: methods
 created: 2025-12-24
-accepted:
-implemented:
-spec-sections: []
+accepted: 2025-12-24
+implemented: 2025-12-25
+spec-sections: ["6.4"]
 superseded-by:
 ---
 
@@ -15,7 +15,7 @@ superseded-by:
 
 ## Status
 
-Proposal
+Implemented
 
 ## Summary
 
@@ -160,7 +160,7 @@ Methods can only be defined for structs in the same compilation unit. (This is a
   - Update both x86_64 and aarch64 backends
   - Handle associated function calls (`Type::method()`)
 
-- [ ] **Phase 5: Specification & Tests** - rue-qs3z.5
+- [x] **Phase 5: Specification & Tests** - rue-qs3z.5
   - Add spec chapter 6.4 for impl blocks and methods
   - Add comprehensive spec tests
   - Ensure traceability coverage

--- a/docs/spec/src/06-items/04-impl-blocks.md
+++ b/docs/spec/src/06-items/04-impl-blocks.md
@@ -1,0 +1,187 @@
++++
+title = "Impl Blocks"
+weight = 4
+template = "spec/page.html"
++++
+
+# Impl Blocks
+
+{{ rule(id="6.4:1", cat="normative") }}
+
+An impl block associates methods and functions with a struct type.
+
+{{ rule(id="6.4:2", cat="syntax") }}
+
+```ebnf
+impl_block = "impl" IDENT "{" { method_def } "}" ;
+method_def = "fn" IDENT "(" [ method_params ] ")" [ "->" type ] block ;
+method_params = method_param { "," method_param } [ "," ] ;
+method_param = "self" | ( IDENT ":" type ) ;
+```
+
+## Methods
+
+{{ rule(id="6.4:3", cat="normative") }}
+
+A method is a function defined inside an impl block that takes `self` as its first parameter.
+
+{{ rule(id="6.4:4", cat="normative") }}
+
+The `self` parameter represents the receiver value and has the type of the impl block's target struct.
+
+{{ rule(id="6.4:5", cat="example") }}
+
+```rue
+struct Point { x: i32, y: i32 }
+
+impl Point {
+    fn get_x(self) -> i32 {
+        self.x
+    }
+}
+
+fn main() -> i32 {
+    let p = Point { x: 42, y: 10 };
+    p.get_x()  // Returns 42
+}
+```
+
+## Method Calls
+
+{{ rule(id="6.4:6", cat="normative") }}
+
+Methods are called using dot notation: `receiver.method(args)`.
+
+{{ rule(id="6.4:7", cat="dynamic-semantics") }}
+
+A method call `receiver.method(args)` is desugared to a function call with the receiver as the first argument.
+
+{{ rule(id="6.4:8", cat="normative") }}
+
+Methods may have additional parameters after `self`.
+
+{{ rule(id="6.4:9", cat="example") }}
+
+```rue
+struct Point { x: i32, y: i32 }
+
+impl Point {
+    fn add(self, dx: i32, dy: i32) -> Point {
+        Point { x: self.x + dx, y: self.y + dy }
+    }
+}
+
+fn main() -> i32 {
+    let p = Point { x: 10, y: 20 };
+    let p2 = p.add(32, 0);
+    p2.x  // Returns 42
+}
+```
+
+## Method Chaining
+
+{{ rule(id="6.4:10", cat="normative") }}
+
+When a method returns the same struct type, method calls may be chained.
+
+{{ rule(id="6.4:11", cat="example") }}
+
+```rue
+struct Counter { value: i32 }
+
+impl Counter {
+    fn inc(self) -> Counter {
+        Counter { value: self.value + 1 }
+    }
+}
+
+fn main() -> i32 {
+    let c = Counter { value: 39 };
+    c.inc().inc().inc().value  // Returns 42
+}
+```
+
+## Associated Functions
+
+{{ rule(id="6.4:12", cat="normative") }}
+
+A function in an impl block that does not take `self` as its first parameter is an associated function.
+
+{{ rule(id="6.4:13", cat="normative") }}
+
+Associated functions are called using path notation: `Type::function(args)`.
+
+{{ rule(id="6.4:14", cat="example") }}
+
+```rue
+struct Point { x: i32, y: i32 }
+
+impl Point {
+    fn origin() -> Point {
+        Point { x: 0, y: 0 }
+    }
+}
+
+fn main() -> i32 {
+    let p = Point::origin();
+    p.x  // Returns 0
+}
+```
+
+## Multiple Impl Blocks
+
+{{ rule(id="6.4:15", cat="normative") }}
+
+Multiple impl blocks for the same struct type are allowed.
+
+{{ rule(id="6.4:16", cat="legality-rule") }}
+
+Method names **MUST** be unique across all impl blocks for a given struct type.
+
+{{ rule(id="6.4:17", cat="example") }}
+
+```rue
+struct Point { x: i32, y: i32 }
+
+impl Point {
+    fn get_x(self) -> i32 { self.x }
+}
+
+impl Point {
+    fn get_y(self) -> i32 { self.y }
+}
+
+fn main() -> i32 {
+    let p = Point { x: 42, y: 10 };
+    p.get_x()  // Returns 42
+}
+```
+
+## Impl Block Ordering
+
+{{ rule(id="6.4:18", cat="informative") }}
+
+An impl block may appear before or after the struct definition it implements.
+Forward references are resolved during semantic analysis.
+
+## Error Conditions
+
+{{ rule(id="6.4:19", cat="legality-rule") }}
+
+An impl block for an undefined struct type is a compile-time error.
+
+{{ rule(id="6.4:20", cat="legality-rule") }}
+
+Calling a method on a non-struct type is a compile-time error.
+
+{{ rule(id="6.4:21", cat="legality-rule") }}
+
+Calling an undefined method is a compile-time error.
+
+{{ rule(id="6.4:22", cat="legality-rule") }}
+
+Calling an associated function with method call syntax (receiver.function()) is a compile-time error.
+
+{{ rule(id="6.4:23", cat="legality-rule") }}
+
+Calling a method with associated function syntax (Type::method()) is a compile-time error.


### PR DESCRIPTION
Add spec section 6.4 for impl blocks and methods:
- 23 spec paragraphs covering methods, associated functions, method calls
- Updated impl-blocks.toml with spec references (6.4:*)
- 16 spec tests covering all major features
- Removed preview = 'methods' flags to stabilize the feature

Fix self expression parsing bug:
- Added Expr::SelfExpr and SelfExpr to AST
- Added self_expr parser in atom_parser
- Added RIR generation for SelfExpr (generates VarRef 'self')
- This was blocking method bodies from compiling

Remove PreviewFeature::Methods since the feature is now stable

Update ADR-0009:
- Status: implemented (was proposal)
- All 5 phases marked complete
- spec-sections: ["6.4"]
- implemented: 2025-12-25

🤖 Generated with [Claude Code](https://claude.com/claude-code)