### PR TITLE
Implement Phase 2 drop elaboration (ADR-0010)

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -343,6 +343,25 @@ pub enum AirInstData {
         /// The value to drop
         value: AirRef,
     },
+
+    // Storage liveness operations (for drop elaboration)
+    /// Marks that a local slot becomes live (storage allocated).
+    /// Emitted when a variable binding is created.
+    /// The type is stored in AirInst.ty for drop elaboration.
+    StorageLive {
+        /// The slot that becomes live
+        slot: u32,
+    },
+
+    /// Marks that a local slot becomes dead (storage can be deallocated).
+    /// Emitted at scope exit for variables declared in that scope.
+    /// The type is stored in AirInst.ty for drop elaboration.
+    /// Drop elaboration will insert a Drop before this if the type needs drop
+    /// and the value wasn't moved.
+    StorageDead {
+        /// The slot that becomes dead
+        slot: u32,
+    },
 }
 
 impl fmt::Display for AirRef {
@@ -537,6 +556,12 @@ impl fmt::Display for Air {
                 }
                 AirInstData::Drop { value } => {
                     writeln!(f, "drop {}", value)?;
+                }
+                AirInstData::StorageLive { slot } => {
+                    writeln!(f, "storage_live ${}", slot)?;
+                }
+                AirInstData::StorageDead { slot } => {
+                    writeln!(f, "storage_dead ${}", slot)?;
                 }
             }
         }

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -1806,8 +1806,15 @@ impl<'a> Sema<'a> {
                     },
                 );
 
+                // Emit StorageLive to mark the slot as live (for drop elaboration)
+                let storage_live_ref = air.add_inst(AirInst {
+                    data: AirInstData::StorageLive { slot },
+                    ty: var_type,
+                    span: inst.span,
+                });
+
                 // Emit the alloc instruction
-                let air_ref = air.add_inst(AirInst {
+                let alloc_ref = air.add_inst(AirInst {
                     data: AirInstData::Alloc {
                         slot,
                         init: init_result.air_ref,
@@ -1815,7 +1822,17 @@ impl<'a> Sema<'a> {
                     ty: Type::Unit,
                     span: inst.span,
                 });
-                Ok(AnalysisResult::new(air_ref, Type::Unit))
+
+                // Return a block containing both StorageLive and Alloc
+                let block_ref = air.add_inst(AirInst {
+                    data: AirInstData::Block {
+                        statements: vec![storage_live_ref],
+                        value: alloc_ref,
+                    },
+                    ty: Type::Unit,
+                    span: inst.span,
+                });
+                Ok(AnalysisResult::new(block_ref, Type::Unit))
             }
 
             InstData::VarRef { name } => {
@@ -3539,22 +3556,29 @@ mod tests {
         assert_eq!(output.functions[0].num_locals, 1);
 
         let air = &output.functions[0].air;
-        // Const(42) + Alloc + Load + Block([Alloc], Load) + Ret = 5 instructions
-        assert_eq!(air.len(), 5);
+        // Const(42) + StorageLive + Alloc + Block([StorageLive], Alloc) + Load + Block([alloc block], Load) + Ret = 7 instructions
+        assert_eq!(air.len(), 7);
+
+        // Check storage_live instruction
+        let storage_live_inst = air.get(AirRef::from_raw(1));
+        assert!(matches!(
+            storage_live_inst.data,
+            AirInstData::StorageLive { slot: 0 }
+        ));
 
         // Check alloc instruction
-        let alloc_inst = air.get(AirRef::from_raw(1));
+        let alloc_inst = air.get(AirRef::from_raw(2));
         assert!(matches!(
             alloc_inst.data,
             AirInstData::Alloc { slot: 0, .. }
         ));
 
         // Check load instruction
-        let load_inst = air.get(AirRef::from_raw(2));
+        let load_inst = air.get(AirRef::from_raw(4));
         assert!(matches!(load_inst.data, AirInstData::Load { slot: 0 }));
 
         // Check block instruction groups the alloc with the load
-        let block_inst = air.get(AirRef::from_raw(3));
+        let block_inst = air.get(AirRef::from_raw(5));
         assert!(matches!(block_inst.data, AirInstData::Block { .. }));
     }
 
@@ -3563,18 +3587,18 @@ mod tests {
         let output = compile_to_air("fn main() -> i32 { let mut x = 10; x = 20; x }").unwrap();
 
         let air = &output.functions[0].air;
-        // Const(10) + Alloc + Const(20) + Store + Load + Block([Alloc, Store], Load) + Ret = 7 instructions
-        assert_eq!(air.len(), 7);
+        // Const(10) + StorageLive + Alloc + Block([StorageLive], Alloc) + Const(20) + Store + Load + Block([alloc block, Store], Load) + Ret = 9 instructions
+        assert_eq!(air.len(), 9);
 
         // Check store instruction
-        let store_inst = air.get(AirRef::from_raw(3));
+        let store_inst = air.get(AirRef::from_raw(5));
         assert!(matches!(
             store_inst.data,
             AirInstData::Store { slot: 0, .. }
         ));
 
         // Check block instruction groups statements
-        let block_inst = air.get(AirRef::from_raw(5));
+        let block_inst = air.get(AirRef::from_raw(7));
         assert!(matches!(block_inst.data, AirInstData::Block { .. }));
     }
 

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -33,6 +33,18 @@ struct LoopContext {
     exit: BlockId,
 }
 
+/// Information about a slot that became live in a scope.
+/// Used for drop elaboration.
+#[derive(Debug, Clone)]
+struct LiveSlot {
+    /// The slot number
+    slot: u32,
+    /// The type of value stored in the slot
+    ty: Type,
+    /// The span where the slot became live (for error reporting)
+    span: rue_span::Span,
+}
+
 /// Builder that converts AIR to CFG.
 pub struct CfgBuilder<'a> {
     air: &'a Air,
@@ -49,6 +61,10 @@ pub struct CfgBuilder<'a> {
     value_cache: Vec<Option<CfgValue>>,
     /// Warnings collected during CFG construction (e.g., unreachable code)
     warnings: Vec<CompileWarning>,
+    /// Stack of scopes for drop elaboration.
+    /// Each scope contains the slots that became live in that scope.
+    /// Used to emit StorageDead (and Drop if needed) at scope exit.
+    scope_stack: Vec<Vec<LiveSlot>>,
 }
 
 impl<'a> CfgBuilder<'a> {
@@ -78,6 +94,7 @@ impl<'a> CfgBuilder<'a> {
             loop_stack: Vec::new(),
             value_cache: vec![None; air.len()],
             warnings: Vec::new(),
+            scope_stack: vec![Vec::new()], // Start with one scope for the function body
         };
 
         // Create entry block
@@ -618,6 +635,18 @@ impl<'a> CfgBuilder<'a> {
             }
 
             AirInstData::Block { statements, value } => {
+                // Check if this is a "wrapper block" that only contains StorageLive statements.
+                // These are synthetic blocks created to pair StorageLive with Alloc, and they
+                // should NOT create a new scope for drop elaboration.
+                let is_storage_live_wrapper = statements.iter().all(|stmt| {
+                    matches!(self.air.get(*stmt).data, AirInstData::StorageLive { .. })
+                });
+
+                // Only push a scope if this is a real syntactic block (not a StorageLive wrapper)
+                if !is_storage_live_wrapper {
+                    self.scope_stack.push(Vec::new());
+                }
+
                 // Lower each statement.
                 //
                 // Design decision: When a statement diverges (break/continue/return), we only
@@ -672,6 +701,8 @@ impl<'a> CfgBuilder<'a> {
                                 );
                             }
                         }
+                        // Note: drops were already emitted by the diverging statement
+                        // (break/continue/return handle their own drops)
                         return ExprResult {
                             value: None,
                             continuation: Continuation::Diverged,
@@ -680,7 +711,33 @@ impl<'a> CfgBuilder<'a> {
                 }
 
                 // Lower the final value
-                self.lower_inst(*value)
+                let result = self.lower_inst(*value);
+
+                // Pop scope and emit StorageDead (with Drop if needed) in reverse order
+                if !is_storage_live_wrapper {
+                    if let Some(scope_slots) = self.scope_stack.pop() {
+                        for live_slot in scope_slots.into_iter().rev() {
+                            // TODO: When we have types that need drop, emit Drop before StorageDead
+                            // if self.type_needs_drop(live_slot.ty) {
+                            //     let slot_val = self.emit(
+                            //         CfgInstData::Load { slot: live_slot.slot },
+                            //         live_slot.ty,
+                            //         live_slot.span,
+                            //     );
+                            //     self.emit(CfgInstData::Drop { value: slot_val }, Type::Unit, live_slot.span);
+                            // }
+                            self.emit(
+                                CfgInstData::StorageDead {
+                                    slot: live_slot.slot,
+                                },
+                                Type::Unit,
+                                live_slot.span,
+                            );
+                        }
+                    }
+                }
+
+                result
             }
 
             AirInstData::Branch {
@@ -1063,11 +1120,14 @@ impl<'a> CfgBuilder<'a> {
             }
 
             AirInstData::Break => {
-                let ctx = self.loop_stack.last().expect("break outside loop");
+                // Emit drops for all live slots before jumping out
+                self.emit_drops_for_all_scopes(span);
+
+                let exit_block = self.loop_stack.last().expect("break outside loop").exit;
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Goto {
-                        target: ctx.exit,
+                        target: exit_block,
                         args: vec![],
                     },
                 );
@@ -1079,11 +1139,18 @@ impl<'a> CfgBuilder<'a> {
             }
 
             AirInstData::Continue => {
-                let ctx = self.loop_stack.last().expect("continue outside loop");
+                // Emit drops for all live slots before jumping out
+                self.emit_drops_for_all_scopes(span);
+
+                let header_block = self
+                    .loop_stack
+                    .last()
+                    .expect("continue outside loop")
+                    .header;
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Goto {
-                        target: ctx.header,
+                        target: header_block,
                         args: vec![],
                     },
                 );
@@ -1111,6 +1178,10 @@ impl<'a> CfgBuilder<'a> {
                     }
                     None => None,
                 };
+
+                // Emit drops for all live slots before returning
+                self.emit_drops_for_all_scopes(span);
+
                 self.cfg
                     .set_terminator(self.current_block, Terminator::Return { value: val });
 
@@ -1228,6 +1299,35 @@ impl<'a> CfgBuilder<'a> {
                     continuation: Continuation::Continues,
                 }
             }
+
+            AirInstData::StorageLive { slot } => {
+                // Emit StorageLive to CFG
+                self.emit(CfgInstData::StorageLive { slot: *slot }, Type::Unit, span);
+
+                // Record this slot as live in the current scope for drop elaboration
+                if let Some(scope) = self.scope_stack.last_mut() {
+                    scope.push(LiveSlot {
+                        slot: *slot,
+                        ty,
+                        span,
+                    });
+                }
+
+                ExprResult {
+                    value: None,
+                    continuation: Continuation::Continues,
+                }
+            }
+
+            AirInstData::StorageDead { slot } => {
+                // StorageDead in AIR is a hint; CFG builder emits these at scope exit
+                // This case handles explicit StorageDead if any (currently unused)
+                self.emit(CfgInstData::StorageDead { slot: *slot }, Type::Unit, span);
+                ExprResult {
+                    value: None,
+                    continuation: Continuation::Continues,
+                }
+            }
         }
     }
 
@@ -1286,6 +1386,39 @@ impl<'a> CfgBuilder<'a> {
                 let array_def = &self.array_types[array_id.0 as usize];
                 self.type_needs_drop(array_def.element_type)
             }
+        }
+    }
+
+    /// Emit drops for all live slots in all scopes (for return/break).
+    /// Drops are emitted in reverse order (LIFO) across all scopes.
+    fn emit_drops_for_all_scopes(&mut self, span: rue_span::Span) {
+        // Collect all live slots in reverse order across all scopes
+        let all_slots: Vec<LiveSlot> = self
+            .scope_stack
+            .iter()
+            .rev()
+            .flat_map(|scope| scope.iter().rev().cloned())
+            .collect();
+
+        for live_slot in all_slots {
+            // Emit Drop if the type needs it
+            if self.type_needs_drop(live_slot.ty) {
+                let slot_val = self.emit(
+                    CfgInstData::Load {
+                        slot: live_slot.slot,
+                    },
+                    live_slot.ty,
+                    span,
+                );
+                self.emit(CfgInstData::Drop { value: slot_val }, Type::Unit, span);
+            }
+            self.emit(
+                CfgInstData::StorageDead {
+                    slot: live_slot.slot,
+                },
+                Type::Unit,
+                span,
+            );
         }
     }
 }

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -196,6 +196,20 @@ pub enum CfgInstData {
     Drop {
         value: CfgValue,
     },
+
+    // Storage liveness operations (for drop elaboration and stack allocation)
+    /// Marks that a local slot becomes live (storage allocated).
+    /// The slot is now valid to write to.
+    StorageLive {
+        slot: u32,
+    },
+
+    /// Marks that a local slot becomes dead (storage can be deallocated).
+    /// The slot is now invalid to read from.
+    /// Drop elaboration inserts Drop before this if the type needs drop.
+    StorageDead {
+        slot: u32,
+    },
 }
 
 /// Block terminator - how control leaves a basic block.
@@ -682,6 +696,12 @@ impl Cfg {
             }
             CfgInstData::Drop { value } => {
                 write!(f, "drop {}", value)
+            }
+            CfgInstData::StorageLive { slot } => {
+                write!(f, "storage_live ${}", slot)
+            }
+            CfgInstData::StorageDead { slot } => {
+                write!(f, "storage_dead ${}", slot)
             }
         }
     }

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1783,6 +1783,18 @@ impl<'a> CfgLower<'a> {
                     "Drop instruction reached codegen but no types currently need drop"
                 );
             }
+
+            CfgInstData::StorageLive { slot: _ } => {
+                // StorageLive marks a slot as valid for use.
+                // Currently a no-op in codegen. In the future, this could be used
+                // for stack slot optimization (LLVM lifetime intrinsics).
+            }
+
+            CfgInstData::StorageDead { slot: _ } => {
+                // StorageDead marks a slot as no longer in use.
+                // Currently a no-op in codegen. In the future, this could be used
+                // for stack slot optimization (LLVM lifetime intrinsics).
+            }
         }
     }
 

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1904,6 +1904,18 @@ impl<'a> CfgLower<'a> {
                     "Drop instruction reached codegen but no types currently need drop"
                 );
             }
+
+            CfgInstData::StorageLive { slot: _ } => {
+                // StorageLive marks a slot as valid for use.
+                // Currently a no-op in codegen. In the future, this could be used
+                // for stack slot optimization (LLVM lifetime intrinsics).
+            }
+
+            CfgInstData::StorageDead { slot: _ } => {
+                // StorageDead marks a slot as no longer in use.
+                // Currently a no-op in codegen. In the future, this could be used
+                // for stack slot optimization (LLVM lifetime intrinsics).
+            }
         }
     }
 

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -237,3 +237,105 @@ source = """
 fn main() -> i32 { 0 }
 """
 exit_code = 0
+
+# =============================================================================
+# Golden Tests: CFG Storage Liveness
+# =============================================================================
+
+# These tests verify that StorageLive/StorageDead instructions are emitted
+# correctly in the CFG for drop elaboration.
+
+[[case]]
+name = "cfg_simple_scope_storage"
+preview = "destructors"
+description = "CFG shows StorageLive at let binding, StorageDead at scope exit"
+source = """
+fn main() -> i32 {
+    let x = 42;
+    x
+}
+"""
+expected_cfg = """
+cfg main (return_type: i32) {
+  bb0:
+    v0 : () = storage_live $0
+    v1 : i32 = const 42
+    v2 : () = alloc $0 = v1
+    v3 : i32 = load $0
+    v4 : () = storage_dead $0
+    return v3
+
+}
+"""
+
+[[case]]
+name = "cfg_multiple_variables_drop_order"
+preview = "destructors"
+description = "CFG shows StorageDead in reverse declaration order (LIFO)"
+source = """
+fn main() -> i32 {
+    let a = 1;
+    let b = 2;
+    a + b
+}
+"""
+expected_cfg = """
+cfg main (return_type: i32) {
+  bb0:
+    v0 : () = storage_live $0
+    v1 : i32 = const 1
+    v2 : () = alloc $0 = v1
+    v3 : () = storage_live $1
+    v4 : i32 = const 2
+    v5 : () = alloc $1 = v4
+    v6 : i32 = load $0
+    v7 : i32 = load $1
+    v8 : i32 = add v6, v7
+    v9 : () = storage_dead $1
+    v10 : () = storage_dead $0
+    return v8
+
+}
+"""
+
+[[case]]
+name = "cfg_early_return_drops"
+preview = "destructors"
+description = "CFG shows StorageDead before early return"
+source = """
+fn foo(cond: bool) -> i32 {
+    let a = 1;
+    if cond {
+        return 42;
+    }
+    a
+}
+"""
+expected_cfg = """
+cfg foo (return_type: i32) {
+  bb0:
+    v0 : () = storage_live $0
+    v1 : i32 = const 1
+    v2 : () = alloc $0 = v1
+    v3 : bool = param 0
+    branch v3, bb1, bb2
+
+  bb1:
+    ; preds: bb0
+    v4 : i32 = const 42
+    v5 : () = storage_dead $0
+    return v4
+
+  bb2:
+    ; preds: bb0
+    v6 : () = const 0
+    goto bb3
+
+  bb3:
+    ; preds: bb2
+    v7 : i32 = load $0
+    v8 : () = storage_dead $0
+    return v7
+
+}
+"""


### PR DESCRIPTION
Add StorageLive/StorageDead instructions for tracking variable liveness:
- Add StorageLive/StorageDead to AIR instructions
- Update Sema to emit StorageLive when variables are declared
- Add StorageLive/StorageDead to CFG instructions  
- Add no-op handlers in both x86_64 and aarch64 codegen backends
- Implement drop elaboration in CFG builder with scope tracking:
  - Track live slots per scope using scope_stack
  - Emit StorageDead in reverse order (LIFO) at block exit
  - Emit StorageDead for all scopes before return/break/continue
- Add golden tests for CFG storage liveness

This enables proper drop placement for when types with destructors are added. Currently all types are trivially droppable, so only StorageLive/StorageDead are emitted (no actual Drop calls yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)