### PR TITLE
Add @copy directive for struct Copy semantics

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -362,6 +362,9 @@ impl<'a> Sema<'a> {
         self.collect_enum_definitions()?;
         self.collect_struct_definitions()?;
 
+        // Validate @copy struct fields are all Copy types
+        self.validate_copy_structs()?;
+
         // Second pass: collect function and method signatures
         self.collect_function_signatures()?;
         self.collect_method_definitions()?;
@@ -486,12 +489,29 @@ impl<'a> Sema<'a> {
         })
     }
 
+    /// Check if a directive list contains the @copy directive
+    fn has_copy_directive(&self, directives: &[RirDirective]) -> bool {
+        let copy_sym = self.interner.get_symbol("copy");
+        for directive in directives {
+            if Some(directive.name) == copy_sym {
+                return true;
+            }
+        }
+        false
+    }
+
     /// Collect all struct definitions from the RIR.
     fn collect_struct_definitions(&mut self) -> CompileResult<()> {
         for (_, inst) in self.rir.iter() {
-            if let InstData::StructDecl { name, fields } = &inst.data {
+            if let InstData::StructDecl {
+                directives,
+                name,
+                fields,
+            } = &inst.data
+            {
                 let struct_id = StructId(self.struct_defs.len() as u32);
                 let struct_name = self.interner.get(*name).to_string();
+                let is_copy = self.has_copy_directive(directives);
 
                 // Check for duplicate field names
                 let mut seen_fields: HashSet<Symbol> = HashSet::new();
@@ -521,6 +541,7 @@ impl<'a> Sema<'a> {
                 self.struct_defs.push(StructDef {
                     name: struct_name,
                     fields: resolved_fields,
+                    is_copy,
                 });
                 self.structs.insert(*name, struct_id);
             }
@@ -561,6 +582,105 @@ impl<'a> Sema<'a> {
                     variants: variant_names,
                 });
                 self.enums.insert(*name, enum_id);
+            }
+        }
+        Ok(())
+    }
+
+    /// Get a human-readable name for a type.
+    fn format_type_name(&self, ty: Type) -> String {
+        match ty {
+            Type::I8 => "i8".to_string(),
+            Type::I16 => "i16".to_string(),
+            Type::I32 => "i32".to_string(),
+            Type::I64 => "i64".to_string(),
+            Type::U8 => "u8".to_string(),
+            Type::U16 => "u16".to_string(),
+            Type::U32 => "u32".to_string(),
+            Type::U64 => "u64".to_string(),
+            Type::Bool => "bool".to_string(),
+            Type::Unit => "()".to_string(),
+            Type::Never => "!".to_string(),
+            Type::Error => "<error>".to_string(),
+            Type::String => "String".to_string(),
+            Type::Struct(struct_id) => self.struct_defs[struct_id.0 as usize].name.clone(),
+            Type::Enum(enum_id) => self.enum_defs[enum_id.0 as usize].name.clone(),
+            Type::Array(array_id) => {
+                let array_def = &self.array_type_defs[array_id.0 as usize];
+                format!(
+                    "[{}; {}]",
+                    self.format_type_name(array_def.element_type),
+                    array_def.length
+                )
+            }
+        }
+    }
+
+    /// Check if a type is a Copy type.
+    /// This differs from Type::is_copy() because it can look up struct definitions
+    /// to check if a struct is marked with @copy.
+    fn is_type_copy(&self, ty: Type) -> bool {
+        match ty {
+            // Primitive Copy types
+            Type::I8
+            | Type::I16
+            | Type::I32
+            | Type::I64
+            | Type::U8
+            | Type::U16
+            | Type::U32
+            | Type::U64
+            | Type::Bool
+            | Type::Unit => true,
+            // Enum types are Copy (they're small discriminant values)
+            Type::Enum(_) => true,
+            // Never and Error are Copy for convenience
+            Type::Never | Type::Error => true,
+            // Struct types: check if marked with @copy
+            Type::Struct(struct_id) => {
+                let struct_def = &self.struct_defs[struct_id.0 as usize];
+                struct_def.is_copy
+            }
+            // String is a move type (owns heap data)
+            Type::String => false,
+            // Arrays are move types for now
+            // TODO: Arrays of Copy types could be Copy
+            Type::Array(_) => false,
+        }
+    }
+
+    /// Validate that @copy structs only contain Copy type fields.
+    /// Must be called after collect_struct_definitions.
+    fn validate_copy_structs(&self) -> CompileResult<()> {
+        for (_, inst) in self.rir.iter() {
+            if let InstData::StructDecl {
+                directives,
+                name,
+                fields: _,
+            } = &inst.data
+            {
+                let is_copy = self.has_copy_directive(directives);
+                if !is_copy {
+                    continue;
+                }
+
+                let struct_name = self.interner.get(*name).to_string();
+                let struct_id = *self.structs.get(name).unwrap();
+                let struct_def = &self.struct_defs[struct_id.0 as usize];
+
+                for field in &struct_def.fields {
+                    if !self.is_type_copy(field.ty) {
+                        let field_type_name = self.format_type_name(field.ty);
+                        return Err(CompileError::new(
+                            ErrorKind::CopyStructNonCopyField {
+                                struct_name,
+                                field_name: field.name.clone(),
+                                field_type: field_type_name,
+                            },
+                            inst.span,
+                        ));
+                    }
+                }
             }
         }
         Ok(())
@@ -1853,7 +1973,7 @@ impl<'a> Sema<'a> {
                     }
 
                     // If type is not Copy, mark as moved
-                    if !ty.is_copy() {
+                    if !self.is_type_copy(ty) {
                         ctx.moved_vars.insert(
                             *name,
                             MoveInfo {
@@ -1898,7 +2018,7 @@ impl<'a> Sema<'a> {
                 }
 
                 // If type is not Copy, mark as moved
-                if !ty.is_copy() {
+                if !self.is_type_copy(ty) {
                     ctx.moved_vars.insert(
                         *name,
                         MoveInfo {

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -61,6 +61,8 @@ pub struct StructDef {
     pub name: String,
     /// Fields in declaration order
     pub fields: Vec<StructField>,
+    /// Whether this struct is marked with @copy (can be implicitly duplicated)
+    pub is_copy: bool,
 }
 
 /// A field in a struct definition.

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -261,6 +261,12 @@ pub enum ErrorKind {
         struct_name: String,
         field_name: String,
     },
+    /// @copy struct contains a field with non-Copy type
+    CopyStructNonCopyField {
+        struct_name: String,
+        field_name: String,
+        field_type: String,
+    },
     /// Duplicate method definition in impl blocks for the same type
     DuplicateMethod {
         type_name: String,
@@ -534,6 +540,17 @@ impl fmt::Display for ErrorKind {
                     f,
                     "duplicate field '{}' in struct '{}'",
                     field_name, struct_name
+                )
+            }
+            ErrorKind::CopyStructNonCopyField {
+                struct_name,
+                field_name,
+                field_type,
+            } => {
+                write!(
+                    f,
+                    "@copy struct '{}' has field '{}' with non-Copy type '{}'",
+                    struct_name, field_name, field_type
                 )
             }
             ErrorKind::DuplicateMethod {

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -47,6 +47,8 @@ pub enum Item {
 /// A struct declaration.
 #[derive(Debug, Clone)]
 pub struct StructDecl {
+    /// Directives applied to this struct (e.g., @copy)
+    pub directives: Vec<Directive>,
     /// Struct name
     pub name: Ident,
     /// Struct fields
@@ -725,6 +727,9 @@ fn indent(f: &mut fmt::Formatter<'_>, level: usize) -> fmt::Result {
 
 fn fmt_struct(f: &mut fmt::Formatter<'_>, s: &StructDecl, level: usize) -> fmt::Result {
     indent(f, level)?;
+    for directive in &s.directives {
+        write!(f, "@{} ", directive.name.name)?;
+    }
     writeln!(f, "Struct {}", s.name.name)?;
     for field in &s.fields {
         indent(f, level + 1)?;

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -1159,16 +1159,17 @@ where
         )
 }
 
-/// Parser for struct definitions: struct Name { field: Type, ... }
+/// Parser for struct definitions: [@directive]* struct Name { field: Type, ... }
 fn struct_parser<'src, I>()
 -> impl Parser<'src, I, StructDecl, extra::Err<Rich<'src, TokenKind>>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    just(TokenKind::Struct)
-        .ignore_then(ident_parser())
+    directives_parser()
+        .then(just(TokenKind::Struct).ignore_then(ident_parser()))
         .then(field_decls_parser().delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace)))
-        .map_with(|(name, fields), e| StructDecl {
+        .map_with(|((directives, name), fields), e| StructDecl {
+            directives,
             name,
             fields,
             span: to_rue_span(e.span()),

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -84,6 +84,7 @@ impl<'a> AstGen<'a> {
     }
 
     fn gen_struct(&mut self, struct_decl: &StructDecl) -> InstRef {
+        let directives = self.convert_directives(&struct_decl.directives);
         let name = self.interner.intern(&struct_decl.name.name);
         let fields: Vec<_> = struct_decl
             .fields
@@ -96,7 +97,11 @@ impl<'a> AstGen<'a> {
             .collect();
 
         self.rir.add_inst(Inst {
-            data: InstData::StructDecl { name, fields },
+            data: InstData::StructDecl {
+                directives,
+                name,
+                fields,
+            },
             span: struct_decl.span,
         })
     }

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -336,6 +336,8 @@ pub enum InstData {
     // Struct operations
     /// Struct type declaration
     StructDecl {
+        /// Directives applied to the struct (e.g., @copy)
+        directives: Vec<RirDirective>,
         /// Struct name
         name: Symbol,
         /// Fields: [(field_name, field_type), ...]
@@ -680,7 +682,11 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     let name_str = self.interner.get(*name);
                     out.push_str(&format!("assign {} = {}\n", name_str, value));
                 }
-                InstData::StructDecl { name, fields } => {
+                InstData::StructDecl {
+                    directives,
+                    name,
+                    fields,
+                } => {
                     let name_str = self.interner.get(*name);
                     let fields_str: Vec<String> = fields
                         .iter()
@@ -692,8 +698,19 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                             )
                         })
                         .collect();
+                    // Format directives
+                    let directives_str = if directives.is_empty() {
+                        String::new()
+                    } else {
+                        let dir_names: Vec<String> = directives
+                            .iter()
+                            .map(|d| format!("@{}", self.interner.get(d.name)))
+                            .collect();
+                        format!("{} ", dir_names.join(" "))
+                    };
                     out.push_str(&format!(
-                        "struct {} {{ {} }}\n",
+                        "{}struct {} {{ {} }}\n",
+                        directives_str,
                         name_str,
                         fields_str.join(", ")
                     ));

--- a/crates/rue-spec/cases/lexical/builtins.toml
+++ b/crates/rue-spec/cases/lexical/builtins.toml
@@ -219,3 +219,41 @@ fn main() -> i32 {
 """
 exit_code = 0
 no_warnings = true
+
+# =============================================================================
+# @copy Directive
+# =============================================================================
+
+[[case]]
+name = "copy_directive_on_struct"
+spec = ["2.5:27", "2.5:28"]
+description = "@copy directive marks a struct as Copy type"
+preview = "affine-mvs"
+source = """
+@copy
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    let q = p;
+    p.x + q.x
+}
+"""
+exit_code = 2
+
+[[case]]
+name = "copy_directive_no_args"
+spec = ["2.5:29"]
+description = "@copy takes no arguments"
+preview = "affine-mvs"
+source = """
+@copy
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 5, y: 10 };
+    let q = p;
+    p.y
+}
+"""
+exit_code = 10

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -407,3 +407,137 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "use of moved value"
+
+# =============================================================================
+# @copy Directive
+# =============================================================================
+
+[[case]]
+name = "copy_struct_multiple_uses"
+spec = ["3.8:14", "3.8:15", "3.8:16", "3.8:17"]
+description = "@copy struct can be used multiple times without moving"
+preview = "affine-mvs"
+source = """
+@copy
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    let q = p;
+    let r = p;
+    p.x + q.x + r.x
+}
+"""
+exit_code = 3
+
+[[case]]
+name = "copy_struct_pass_to_function"
+spec = ["3.8:16"]
+description = "@copy struct can be passed to function and still used"
+preview = "affine-mvs"
+source = """
+@copy
+struct Point { x: i32, y: i32 }
+fn sum(p: Point) -> i32 { p.x + p.y }
+fn main() -> i32 {
+    let p = Point { x: 10, y: 20 };
+    let a = sum(p);
+    let b = sum(p);
+    a + b
+}
+"""
+exit_code = 60
+
+[[case]]
+name = "copy_struct_all_primitive_fields"
+spec = ["3.8:20"]
+description = "@copy struct with all primitive Copy fields"
+preview = "affine-mvs"
+source = """
+@copy
+struct Data { a: i32, b: bool, c: i64 }
+fn main() -> i32 {
+    let d = Data { a: 42, b: true, c: 100 };
+    let e = d;
+    let f = d;
+    d.a + if e.b { 1 } else { 0 }
+}
+"""
+exit_code = 43
+
+[[case]]
+name = "copy_struct_nested_copy"
+spec = ["3.8:20", "3.8:21"]
+description = "@copy struct containing other @copy structs"
+preview = "affine-mvs"
+source = """
+@copy
+struct Point { x: i32, y: i32 }
+
+@copy
+struct Rect { top_left: Point, bottom_right: Point }
+
+fn main() -> i32 {
+    let r = Rect {
+        top_left: Point { x: 0, y: 0 },
+        bottom_right: Point { x: 10, y: 10 }
+    };
+    let r2 = r;
+    r.top_left.x + r2.bottom_right.x
+}
+"""
+exit_code = 10
+
+[[case]]
+name = "copy_struct_non_copy_field_error"
+spec = ["3.8:18", "3.8:19"]
+description = "@copy struct with non-Copy field is a compile error"
+preview = "affine-mvs"
+source = """
+struct Inner { value: i32 }
+
+@copy
+struct Outer { inner: Inner }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "non-Copy type"
+
+[[case]]
+name = "copy_struct_enum_field"
+spec = ["3.8:20"]
+description = "@copy struct with enum field (enums are Copy)"
+preview = "affine-mvs"
+source = """
+enum Status { Active, Inactive }
+
+@copy
+struct Data { status: Status, value: i32 }
+
+fn main() -> i32 {
+    let d = Data { status: Status::Active, value: 10 };
+    let e = d;
+    match d.status {
+        Status::Active => d.value + e.value,
+        Status::Inactive => 0,
+    }
+}
+"""
+exit_code = 20
+
+[[case]]
+name = "non_copy_struct_still_moves"
+spec = ["3.8:3"]
+description = "Struct without @copy still has move semantics"
+preview = "affine-mvs"
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    let q = p;
+    let r = p;
+    0
+}
+"""
+compile_fail = true
+error_contains = "use of moved value"

--- a/docs/designs/0008-affine-types-mvs.md
+++ b/docs/designs/0008-affine-types-mvs.md
@@ -400,9 +400,9 @@ fn main() -> i32 {
 
 Allow opting structs into Copy semantics.
 
-- Add `@copy` directive parsing (piggyback on directive system)
-- `@copy` structs bypass move tracking
-- Validate: `@copy` structs can only contain `@copy` fields
+- [x] Add `@copy` directive parsing (piggyback on directive system)
+- [x] `@copy` structs bypass move tracking
+- [x] Validate: `@copy` structs can only contain `@copy` fields
 
 **Testable**: Mark a struct `@copy`, use it multiple times without error.
 

--- a/docs/spec/src/02-lexical-structure/05-builtins.md
+++ b/docs/spec/src/02-lexical-structure/05-builtins.md
@@ -35,7 +35,7 @@ There are two kinds of builtins, distinguished by their syntactic position:
 | Kind | Position | Purpose | Examples |
 |------|----------|---------|----------|
 | Intrinsic | Expression | Produces a value | `@dbg`, `@size_of`, `@align_of` |
-| Directive | Before item/statement | Modifies compiler behavior | `@allow` |
+| Directive | Before item/statement | Modifies compiler behavior | `@allow`, `@copy` |
 
 {{ rule(id="2.5:6", cat="normative") }}
 
@@ -191,3 +191,34 @@ fn main() -> i32 {
     0
 }
 ```
+
+## `@copy`
+
+{{ rule(id="2.5:27", cat="normative") }}
+
+The `@copy` directive marks a struct type as a Copy type.
+
+{{ rule(id="2.5:28", cat="normative") }}
+
+`@copy` must appear immediately before a struct definition.
+
+{{ rule(id="2.5:29", cat="normative") }}
+
+`@copy` takes no arguments.
+
+{{ rule(id="2.5:30") }}
+
+```rue
+@copy
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    let q = p;  // p is copied, not moved
+    p.x + q.x   // both are valid
+}
+```
+
+{{ rule(id="2.5:31", cat="informative") }}
+
+See [Move Semantics](@/03-types/08-move-semantics.md#the-copy-directive) for the full semantics of `@copy` structs.

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -40,6 +40,72 @@ fn main() -> i32 {
 }
 ```
 
+## The `@copy` Directive
+
+{{ rule(id="3.8:14", cat="normative") }}
+
+A struct type may be declared as a Copy type using the `@copy` directive before the struct definition.
+
+{{ rule(id="3.8:15", cat="syntax") }}
+
+```ebnf
+copy_struct = "@copy" struct_def ;
+```
+
+{{ rule(id="3.8:16", cat="normative") }}
+
+A struct marked with `@copy` is a Copy type. Using a `@copy` struct value does not consume it; the value is implicitly duplicated.
+
+{{ rule(id="3.8:17", cat="example") }}
+
+```rue
+@copy
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    let q = p;      // p is copied, not moved
+    let r = p;      // p can be used again
+    p.x + q.x + r.x // all three are valid
+}
+```
+
+{{ rule(id="3.8:18", cat="legality-rule") }}
+
+A `@copy` struct must contain only fields that are themselves Copy types. It is a compile-time error to mark a struct as `@copy` if any of its fields are move types.
+
+{{ rule(id="3.8:19", cat="example") }}
+
+```rue
+struct Inner { value: i32 }  // move type (no @copy)
+
+@copy
+struct Outer { inner: Inner }  // ERROR: field 'inner' has non-Copy type 'Inner'
+```
+
+{{ rule(id="3.8:20", cat="normative") }}
+
+A `@copy` struct may contain fields of primitive Copy types (integers, booleans, unit), enum types, or other `@copy` struct types.
+
+{{ rule(id="3.8:21", cat="example") }}
+
+```rue
+@copy
+struct Point { x: i32, y: i32 }
+
+@copy
+struct Rect { top_left: Point, bottom_right: Point }  // OK: Point is @copy
+
+fn main() -> i32 {
+    let r = Rect {
+        top_left: Point { x: 0, y: 0 },
+        bottom_right: Point { x: 10, y: 10 }
+    };
+    let r2 = r;     // r is copied
+    r.top_left.x    // r is still valid
+}
+```
+
 ## Use After Move
 
 {{ rule(id="3.8:5", cat="legality-rule") }}


### PR DESCRIPTION
Implements Phase 2 of the affine types MVS feature. Structs can now be marked with @copy to opt into Copy semantics, allowing them to be used multiple times without moving.

Changes:
- Add directives field to StructDecl in AST and RIR
- Add is_copy field to StructDef in AIR
- Add is_type_copy() method that checks struct definitions
- Add validation that @copy structs only contain Copy fields
- Add CopyStructNonCopyField error for invalid @copy structs
- Add spec documentation (3.8:14-21, 2.5:27-31)
- Add comprehensive spec tests (marked preview = affine-mvs)

Closes rue-dfr8.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)