### PR TITLE
Fix integer overflow in archive member size parsing

### DIFF
--- a/crates/rue-linker/src/archive.rs
+++ b/crates/rue-linker/src/archive.rs
@@ -29,6 +29,8 @@ pub enum ArchiveError {
     InvalidHeader(String),
     /// Failed to parse contained object.
     ObjectParse(ParseError),
+    /// Integer overflow in size calculation.
+    Overflow,
 }
 
 impl std::fmt::Display for ArchiveError {
@@ -38,6 +40,7 @@ impl std::fmt::Display for ArchiveError {
             ArchiveError::TooShort => write!(f, "archive too short"),
             ArchiveError::InvalidHeader(s) => write!(f, "invalid archive header: {}", s),
             ArchiveError::ObjectParse(e) => write!(f, "failed to parse object: {}", e),
+            ArchiveError::Overflow => write!(f, "integer overflow in archive size calculation"),
         }
     }
 }
@@ -115,19 +118,20 @@ impl Archive {
                 || name.starts_with("#1/");
 
             if is_special {
-                offset += size;
+                offset = offset.checked_add(size).ok_or(ArchiveError::Overflow)?;
                 // Pad to even boundary
                 if offset % 2 == 1 {
-                    offset += 1;
+                    offset = offset.checked_add(1).ok_or(ArchiveError::Overflow)?;
                 }
                 continue;
             }
 
             // Read member data
-            if offset + size > data.len() {
+            let end_offset = offset.checked_add(size).ok_or(ArchiveError::Overflow)?;
+            if end_offset > data.len() {
                 return Err(ArchiveError::TooShort);
             }
-            let member_data = &data[offset..offset + size];
+            let member_data = &data[offset..end_offset];
 
             // Try to parse as ELF object.
             // Non-ELF members (e.g., LLVM bitcode files from LTO builds) are skipped.
@@ -142,10 +146,10 @@ impl Archive {
                 }
             }
 
-            offset += size;
+            offset = offset.checked_add(size).ok_or(ArchiveError::Overflow)?;
             // Pad to even boundary
             if offset % 2 == 1 {
-                offset += 1;
+                offset = offset.checked_add(1).ok_or(ArchiveError::Overflow)?;
             }
         }
 
@@ -199,6 +203,74 @@ mod tests {
         assert_eq!(
             ArchiveError::InvalidHeader("test".into()).to_string(),
             "invalid archive header: test"
+        );
+        assert_eq!(
+            ArchiveError::Overflow.to_string(),
+            "integer overflow in archive size calculation"
+        );
+    }
+
+    #[test]
+    fn test_overflow_in_member_size() {
+        // Craft a malicious archive with a size field that would cause integer overflow.
+        // The size field is at bytes 48-58 of the header (10 bytes, decimal ASCII).
+        // We use usize::MAX which would overflow when added to any positive offset.
+        let mut data = Vec::new();
+
+        // AR magic
+        data.extend_from_slice(b"!<arch>\n");
+
+        // Member header (60 bytes):
+        // - Name: 16 bytes
+        data.extend_from_slice(b"test.o          "); // 16 bytes, space-padded
+
+        // - Timestamp: 12 bytes
+        data.extend_from_slice(b"0           "); // 12 bytes
+
+        // - Owner ID: 6 bytes
+        data.extend_from_slice(b"0     "); // 6 bytes
+
+        // - Group ID: 6 bytes
+        data.extend_from_slice(b"0     "); // 6 bytes
+
+        // - Mode: 8 bytes
+        data.extend_from_slice(b"644     "); // 8 bytes
+
+        // - Size: 10 bytes - use a huge number that would overflow
+        // usize::MAX on 64-bit is 18446744073709551615 (20 digits), too big for 10 bytes
+        // Use a smaller but still overflowing value: 9999999999 (fits in 10 bytes)
+        // When added to offset (already at 68 = 8 magic + 60 header), this won't overflow
+        // on 64-bit, so we need a different approach.
+        //
+        // Instead, use a value close to usize::MAX that's representable in 10 digits.
+        // The offset after the header is 68. Adding 9999999999 gives ~10 billion, no overflow.
+        // On 32-bit, usize::MAX is 4294967295 (10 digits), so "4294967295" would overflow
+        // when added to 68.
+        //
+        // For a portable test, we can't easily trigger overflow on 64-bit with 10 digits.
+        // However, we can test that the code handles the case correctly by using a size
+        // that's larger than the remaining data, which will give TooShort error but at
+        // least exercises the overflow check path on 32-bit systems.
+        //
+        // For this test, we'll verify that the overflow error variant exists and can be
+        // triggered by the checked_add logic. The actual overflow would require a 32-bit
+        // system or a specially crafted large file, but we can unit test the error path.
+        data.extend_from_slice(b"9999999999"); // 10 bytes - large size
+
+        // - Terminator: 2 bytes
+        data.extend_from_slice(b"`\n");
+
+        let result = Archive::parse(&data);
+        // This should fail with TooShort (since data doesn't have 9999999999 bytes)
+        // On a 32-bit system or with checked arithmetic, overflow would be caught first.
+        // Either error is acceptable for malicious input.
+        assert!(
+            matches!(
+                result,
+                Err(ArchiveError::TooShort) | Err(ArchiveError::Overflow)
+            ),
+            "Expected TooShort or Overflow error, got {:?}",
+            result
         );
     }
 }


### PR DESCRIPTION
With malicious input, adding the member size to the current offset could overflow and wrap around, causing incorrect parsing or potential crashes. Use checked_add() for all offset arithmetic and return a proper Overflow error instead.

Fixes rue-khi4

🤖 Generated with [Claude Code](https://claude.ai/code)