### PR TITLE
Replace custom from_str with FromStr trait implementations

### DIFF
--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -43,6 +43,18 @@ pub enum PreviewFeature {
     Destructors,
 }
 
+/// Error returned when parsing a preview feature name fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsePreviewFeatureError(String);
+
+impl fmt::Display for ParsePreviewFeatureError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "unknown preview feature '{}'", self.0)
+    }
+}
+
+impl std::error::Error for ParsePreviewFeatureError {}
+
 impl PreviewFeature {
     /// Get the CLI name for this feature (used with `--preview`).
     pub fn name(&self) -> &'static str {
@@ -50,16 +62,6 @@ impl PreviewFeature {
             PreviewFeature::MutableStrings => "mutable_strings",
             PreviewFeature::HmInference => "hm_inference",
             PreviewFeature::Destructors => "destructors",
-        }
-    }
-
-    /// Parse a feature name from a string.
-    pub fn from_str(s: &str) -> Option<Self> {
-        match s {
-            "mutable_strings" => Some(PreviewFeature::MutableStrings),
-            "hm_inference" => Some(PreviewFeature::HmInference),
-            "destructors" => Some(PreviewFeature::Destructors),
-            _ => None,
         }
     }
 
@@ -88,6 +90,19 @@ impl PreviewFeature {
             .map(|f| f.name())
             .collect::<Vec<_>>()
             .join(", ")
+    }
+}
+
+impl std::str::FromStr for PreviewFeature {
+    type Err = ParsePreviewFeatureError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "mutable_strings" => Ok(PreviewFeature::MutableStrings),
+            "hm_inference" => Ok(PreviewFeature::HmInference),
+            "destructors" => Ok(PreviewFeature::Destructors),
+            _ => Err(ParsePreviewFeatureError(s.to_string())),
+        }
     }
 }
 
@@ -1178,11 +1193,17 @@ mod tests {
     #[test]
     fn test_preview_feature_from_str() {
         assert_eq!(
-            PreviewFeature::from_str("mutable_strings"),
-            Some(PreviewFeature::MutableStrings)
+            "mutable_strings".parse::<PreviewFeature>(),
+            Ok(PreviewFeature::MutableStrings)
         );
-        assert_eq!(PreviewFeature::from_str("unknown"), None);
-        assert_eq!(PreviewFeature::from_str(""), None);
+        assert!("unknown".parse::<PreviewFeature>().is_err());
+        assert!("".parse::<PreviewFeature>().is_err());
+    }
+
+    #[test]
+    fn test_parse_preview_feature_error_display() {
+        let err = "bad_feature".parse::<PreviewFeature>().unwrap_err();
+        assert_eq!(err.to_string(), "unknown preview feature 'bad_feature'");
     }
 
     #[test]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -32,20 +32,36 @@ enum EmitStage {
     Asm,
 }
 
-impl EmitStage {
-    fn from_str(s: &str) -> Option<Self> {
+/// Error returned when parsing an emit stage name fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct ParseEmitStageError(String);
+
+impl std::fmt::Display for ParseEmitStageError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unknown emit stage '{}'", self.0)
+    }
+}
+
+impl std::error::Error for ParseEmitStageError {}
+
+impl std::str::FromStr for EmitStage {
+    type Err = ParseEmitStageError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "tokens" => Some(EmitStage::Tokens),
-            "ast" => Some(EmitStage::Ast),
-            "rir" => Some(EmitStage::Rir),
-            "air" => Some(EmitStage::Air),
-            "cfg" => Some(EmitStage::Cfg),
-            "mir" => Some(EmitStage::Mir),
-            "asm" => Some(EmitStage::Asm),
-            _ => None,
+            "tokens" => Ok(EmitStage::Tokens),
+            "ast" => Ok(EmitStage::Ast),
+            "rir" => Ok(EmitStage::Rir),
+            "air" => Ok(EmitStage::Air),
+            "cfg" => Ok(EmitStage::Cfg),
+            "mir" => Ok(EmitStage::Mir),
+            "asm" => Ok(EmitStage::Asm),
+            _ => Err(ParseEmitStageError(s.to_string())),
         }
     }
+}
 
+impl EmitStage {
     fn all_names() -> &'static str {
         "tokens, ast, rir, air, cfg, mir, asm"
     }
@@ -103,10 +119,10 @@ fn parse_args() -> Option<Options> {
                     eprintln!("Valid stages: {}", EmitStage::all_names());
                     return None;
                 };
-                match EmitStage::from_str(stage_str) {
-                    Some(stage) => emit_stages.push(stage),
-                    None => {
-                        eprintln!("Error: unknown emit stage '{}'", stage_str);
+                match stage_str.parse::<EmitStage>() {
+                    Ok(stage) => emit_stages.push(stage),
+                    Err(e) => {
+                        eprintln!("Error: {}", e);
                         eprintln!("Valid stages: {}", EmitStage::all_names());
                         return None;
                     }
@@ -144,12 +160,12 @@ fn parse_args() -> Option<Options> {
                     eprintln!("Available features: {}", PreviewFeature::all_names());
                     return None;
                 };
-                match PreviewFeature::from_str(feature_str) {
-                    Some(feature) => {
+                match feature_str.parse::<PreviewFeature>() {
+                    Ok(feature) => {
                         preview_features.insert(feature);
                     }
-                    None => {
-                        eprintln!("Error: unknown preview feature '{}'", feature_str);
+                    Err(e) => {
+                        eprintln!("Error: {}", e);
                         eprintln!("Available features: {}", PreviewFeature::all_names());
                         return None;
                     }


### PR DESCRIPTION
Replaces custom `from_str` methods on `PreviewFeature` and `EmitStage` with proper `std::str::FromStr` trait implementations. This allows using the idiomatic `.parse::<Type>()` syntax at call sites.

Each type now has a dedicated error type (`ParsePreviewFeatureError` and `ParseEmitStageError`) that implements `Display` and `Error` traits.

Fixes rue-aqq1

🤖 Generated with [Claude Code](https://claude.com/claude-code)