### PR TITLE
Remove redundant conditional check in parser

### DIFF
--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -1048,12 +1048,10 @@ fn process_block_items(items: Vec<BlockItem>, block_span: Span) -> (Vec<Statemen
     for item in items {
         match item {
             BlockItem::Statement(stmt) => {
-                if final_expr.is_some() {
-                    // Had a non-semicolon expr before, but now we have more items
-                    // This shouldn't happen with correct grammar, but handle gracefully
-                    if let Some(e) = final_expr.take() {
-                        statements.push(Statement::Expr(e));
-                    }
+                // Had a non-semicolon expr before, but now we have more items
+                // This shouldn't happen with correct grammar, but handle gracefully
+                if let Some(e) = final_expr.take() {
+                    statements.push(Statement::Expr(e));
                 }
                 statements.push(stmt);
             }


### PR DESCRIPTION
The outer `if final_expr.is_some()` was redundant since the inner `if let Some(e) = final_expr.take()` already handles the None case by simply not executing the body.

Fixes rue-3r52

🤖 Generated with [Claude Code](https://claude.com/claude-code)