### PR TITLE
Extract repetitive error wrapping patterns into helper functions

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -13,7 +13,7 @@ use crate::inst::{Air, AirInst, AirInstData, AirPattern, AirRef};
 use crate::types::{
     ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructField, StructId, Type,
 };
-use rue_error::{CompileError, CompileResult, CompileWarning, ErrorKind, WarningKind};
+use rue_error::{CompileError, CompileResult, CompileWarning, ErrorKind, OptionExt, WarningKind};
 use rue_intern::{Interner, Symbol};
 use rue_rir::{InstData, InstRef, Rir, RirDirective, RirPattern};
 use rue_span::Span;
@@ -994,12 +994,10 @@ impl<'a> Sema<'a> {
 
             // Look up the variable in locals
             let name_str = self.interner.get(*name);
-            let local = ctx.locals.get(name).ok_or_else(|| {
-                CompileError::new(
-                    ErrorKind::UndefinedVariable(name_str.to_string()),
-                    inst.span,
-                )
-            })?;
+            let local = ctx.locals.get(name).ok_or_compile_error(
+                ErrorKind::UndefinedVariable(name_str.to_string()),
+                inst.span,
+            )?;
 
             let ty = local.ty;
             let slot = local.slot;
@@ -1050,15 +1048,13 @@ impl<'a> Sema<'a> {
             let field_name_str = self.interner.get(*field).to_string();
 
             let (field_index, struct_field) =
-                struct_def.find_field(&field_name_str).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::UnknownField {
-                            struct_name: struct_def.name.clone(),
-                            field_name: field_name_str.clone(),
-                        },
-                        inst.span,
-                    )
-                })?;
+                struct_def.find_field(&field_name_str).ok_or_compile_error(
+                    ErrorKind::UnknownField {
+                        struct_name: struct_def.name.clone(),
+                        field_name: field_name_str.clone(),
+                    },
+                    inst.span,
+                )?;
 
             let field_type = struct_field.ty;
 
@@ -1637,14 +1633,12 @@ impl<'a> Sema<'a> {
                             type_name, variant, ..
                         } => {
                             // Look up the enum type
-                            let enum_id = self.enums.get(type_name).ok_or_else(|| {
-                                CompileError::new(
-                                    ErrorKind::UnknownEnumType(
-                                        self.interner.get(*type_name).to_string(),
-                                    ),
-                                    pattern_span,
-                                )
-                            })?;
+                            let enum_id = self.enums.get(type_name).ok_or_compile_error(
+                                ErrorKind::UnknownEnumType(
+                                    self.interner.get(*type_name).to_string(),
+                                ),
+                                pattern_span,
+                            )?;
                             let enum_def = &self.enum_defs[enum_id.0 as usize];
 
                             // Check that scrutinee type matches the pattern's enum type
@@ -1661,15 +1655,13 @@ impl<'a> Sema<'a> {
                             // Find the variant index
                             let variant_name = self.interner.get(*variant);
                             let variant_index =
-                                enum_def.find_variant(variant_name).ok_or_else(|| {
-                                    CompileError::new(
-                                        ErrorKind::UnknownVariant {
-                                            enum_name: enum_def.name.clone(),
-                                            variant_name: variant_name.to_string(),
-                                        },
-                                        pattern_span,
-                                    )
-                                })?;
+                                enum_def.find_variant(variant_name).ok_or_compile_error(
+                                    ErrorKind::UnknownVariant {
+                                        enum_name: enum_def.name.clone(),
+                                        variant_name: variant_name.to_string(),
+                                    },
+                                    pattern_span,
+                                )?;
 
                             covered_variants.insert(variant_index as u32);
                             pattern_enum_id = Some(*enum_id);
@@ -1876,12 +1868,10 @@ impl<'a> Sema<'a> {
 
                 // Look up the variable in locals
                 let name_str = self.interner.get(*name);
-                let local = ctx.locals.get(name).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::UndefinedVariable(name_str.to_string()),
-                        inst.span,
-                    )
-                })?;
+                let local = ctx.locals.get(name).ok_or_compile_error(
+                    ErrorKind::UndefinedVariable(name_str.to_string()),
+                    inst.span,
+                )?;
 
                 let ty = local.ty;
                 let slot = local.slot;
@@ -1922,12 +1912,10 @@ impl<'a> Sema<'a> {
             InstData::Assign { name, value } => {
                 // Look up the variable
                 let name_str = self.interner.get(*name);
-                let local = ctx.locals.get(name).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::UndefinedVariable(name_str.to_string()),
-                        inst.span,
-                    )
-                })?;
+                let local = ctx.locals.get(name).ok_or_compile_error(
+                    ErrorKind::UndefinedVariable(name_str.to_string()),
+                    inst.span,
+                )?;
 
                 // Check mutability
                 if !local.is_mut {
@@ -2120,9 +2108,10 @@ impl<'a> Sema<'a> {
             InstData::Call { name, args } => {
                 // Look up the function
                 let fn_name_str = self.interner.get(*name).to_string();
-                let fn_info = self.functions.get(name).ok_or_else(|| {
-                    CompileError::new(ErrorKind::UndefinedFunction(fn_name_str.clone()), inst.span)
-                })?;
+                let fn_info = self.functions.get(name).ok_or_compile_error(
+                    ErrorKind::UndefinedFunction(fn_name_str.clone()),
+                    inst.span,
+                )?;
 
                 // Check argument count
                 if args.len() != fn_info.param_types.len() {
@@ -2158,13 +2147,11 @@ impl<'a> Sema<'a> {
 
             InstData::ParamRef { index: _, name } => {
                 // Look up the parameter type and ABI slot from the params map
-                let param_info = ctx.params.get(name).ok_or_else(|| {
-                    let name_str = self.interner.get(*name);
-                    CompileError::new(
-                        ErrorKind::UndefinedVariable(name_str.to_string()),
-                        inst.span,
-                    )
-                })?;
+                let name_str = self.interner.get(*name);
+                let param_info = ctx.params.get(name).ok_or_compile_error(
+                    ErrorKind::UndefinedVariable(name_str.to_string()),
+                    inst.span,
+                )?;
 
                 let ty = param_info.ty;
 
@@ -2195,9 +2182,10 @@ impl<'a> Sema<'a> {
             } => {
                 // Look up the struct type
                 let type_name_str = self.interner.get(*type_name);
-                let struct_id = *self.structs.get(type_name).ok_or_else(|| {
-                    CompileError::new(ErrorKind::UnknownType(type_name_str.to_string()), inst.span)
-                })?;
+                let struct_id = *self.structs.get(type_name).ok_or_compile_error(
+                    ErrorKind::UnknownType(type_name_str.to_string()),
+                    inst.span,
+                )?;
 
                 // Clone struct def data before mutable borrow
                 let struct_def = self.struct_defs[struct_id.0 as usize].clone();
@@ -2314,15 +2302,13 @@ impl<'a> Sema<'a> {
                 let field_name_str = self.interner.get(*field).to_string();
 
                 let (field_index, struct_field) =
-                    struct_def.find_field(&field_name_str).ok_or_else(|| {
-                        CompileError::new(
-                            ErrorKind::UnknownField {
-                                struct_name: struct_def.name.clone(),
-                                field_name: field_name_str.clone(),
-                            },
-                            inst.span,
-                        )
-                    })?;
+                    struct_def.find_field(&field_name_str).ok_or_compile_error(
+                        ErrorKind::UnknownField {
+                            struct_name: struct_def.name.clone(),
+                            field_name: field_name_str.clone(),
+                        },
+                        inst.span,
+                    )?;
 
                 let field_type = struct_field.ty;
 
@@ -2360,12 +2346,10 @@ impl<'a> Sema<'a> {
                     match &current_inst.data {
                         InstData::VarRef { name } => {
                             let name_str = self.interner.get(*name);
-                            let local = ctx.locals.get(name).ok_or_else(|| {
-                                CompileError::new(
-                                    ErrorKind::UndefinedVariable(name_str.to_string()),
-                                    inst.span,
-                                )
-                            })?;
+                            let local = ctx.locals.get(name).ok_or_compile_error(
+                                ErrorKind::UndefinedVariable(name_str.to_string()),
+                                inst.span,
+                            )?;
 
                             // Check if this variable has been moved
                             if let Some(move_info) = ctx.moved_vars.get(name) {
@@ -2435,15 +2419,13 @@ impl<'a> Sema<'a> {
                     let field_name_str = self.interner.get(*field_sym).to_string();
 
                     let (field_index, struct_field) =
-                        struct_def.find_field(&field_name_str).ok_or_else(|| {
-                            CompileError::new(
-                                ErrorKind::UnknownField {
-                                    struct_name: struct_def.name.clone(),
-                                    field_name: field_name_str.clone(),
-                                },
-                                inst.span,
-                            )
-                        })?;
+                        struct_def.find_field(&field_name_str).ok_or_compile_error(
+                            ErrorKind::UnknownField {
+                                struct_name: struct_def.name.clone(),
+                                field_name: field_name_str.clone(),
+                            },
+                            inst.span,
+                        )?;
 
                     slot_offset += self.field_slot_offset(struct_id, field_index);
                     current_type = struct_field.ty;
@@ -2466,15 +2448,13 @@ impl<'a> Sema<'a> {
                 let field_name_str = self.interner.get(*field).to_string();
 
                 let (field_index, struct_field) =
-                    struct_def.find_field(&field_name_str).ok_or_else(|| {
-                        CompileError::new(
-                            ErrorKind::UnknownField {
-                                struct_name: struct_def.name.clone(),
-                                field_name: field_name_str.clone(),
-                            },
-                            inst.span,
-                        )
-                    })?;
+                    struct_def.find_field(&field_name_str).ok_or_compile_error(
+                        ErrorKind::UnknownField {
+                            struct_name: struct_def.name.clone(),
+                            field_name: field_name_str.clone(),
+                        },
+                        inst.span,
+                    )?;
 
                 let field_type = struct_field.ty;
 
@@ -2683,12 +2663,10 @@ impl<'a> Sema<'a> {
                 let (var_name, slot, base_type, is_mut) = match &base_inst.data {
                     InstData::VarRef { name } => {
                         let name_str = self.interner.get(*name);
-                        let local = ctx.locals.get(name).ok_or_else(|| {
-                            CompileError::new(
-                                ErrorKind::UndefinedVariable(name_str.to_string()),
-                                inst.span,
-                            )
-                        })?;
+                        let local = ctx.locals.get(name).ok_or_compile_error(
+                            ErrorKind::UndefinedVariable(name_str.to_string()),
+                            inst.span,
+                        )?;
 
                         // Check if this variable has been moved
                         if let Some(move_info) = ctx.moved_vars.get(name) {
@@ -2790,25 +2768,21 @@ impl<'a> Sema<'a> {
             // Enum variant expression (e.g., Color::Red)
             InstData::EnumVariant { type_name, variant } => {
                 // Look up the enum type
-                let enum_id = self.enums.get(type_name).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::UnknownEnumType(self.interner.get(*type_name).to_string()),
-                        inst.span,
-                    )
-                })?;
+                let enum_id = self.enums.get(type_name).ok_or_compile_error(
+                    ErrorKind::UnknownEnumType(self.interner.get(*type_name).to_string()),
+                    inst.span,
+                )?;
                 let enum_def = &self.enum_defs[enum_id.0 as usize];
 
                 // Find the variant index
                 let variant_name = self.interner.get(*variant);
-                let variant_index = enum_def.find_variant(variant_name).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::UnknownVariant {
-                            enum_name: enum_def.name.clone(),
-                            variant_name: variant_name.to_string(),
-                        },
-                        inst.span,
-                    )
-                })?;
+                let variant_index = enum_def.find_variant(variant_name).ok_or_compile_error(
+                    ErrorKind::UnknownVariant {
+                        enum_name: enum_def.name.clone(),
+                        variant_name: variant_name.to_string(),
+                    },
+                    inst.span,
+                )?;
 
                 let ty = Type::Enum(*enum_id);
 
@@ -2870,15 +2844,13 @@ impl<'a> Sema<'a> {
 
                 // Look up the method
                 let method_key = (struct_name_sym, *method);
-                let method_info = self.methods.get(&method_key).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::UndefinedMethod {
-                            type_name: struct_name_str.clone(),
-                            method_name: method_name_str.clone(),
-                        },
-                        inst.span,
-                    )
-                })?;
+                let method_info = self.methods.get(&method_key).ok_or_compile_error(
+                    ErrorKind::UndefinedMethod {
+                        type_name: struct_name_str.clone(),
+                        method_name: method_name_str.clone(),
+                    },
+                    inst.span,
+                )?;
 
                 // Check that this is a method (has self), not an associated function
                 if !method_info.has_self {
@@ -2937,21 +2909,20 @@ impl<'a> Sema<'a> {
                 let function_name_str = self.interner.get(*function).to_string();
 
                 // Check that the type exists and is a struct
-                let _struct_id = self.structs.get(type_name).ok_or_else(|| {
-                    CompileError::new(ErrorKind::UnknownType(type_name_str.clone()), inst.span)
-                })?;
+                let _struct_id = self.structs.get(type_name).ok_or_compile_error(
+                    ErrorKind::UnknownType(type_name_str.clone()),
+                    inst.span,
+                )?;
 
                 // Look up the function
                 let method_key = (*type_name, *function);
-                let method_info = self.methods.get(&method_key).ok_or_else(|| {
-                    CompileError::new(
-                        ErrorKind::UndefinedAssocFn {
-                            type_name: type_name_str.clone(),
-                            function_name: function_name_str.clone(),
-                        },
-                        inst.span,
-                    )
-                })?;
+                let method_info = self.methods.get(&method_key).ok_or_compile_error(
+                    ErrorKind::UndefinedAssocFn {
+                        type_name: type_name_str.clone(),
+                        function_name: function_name_str.clone(),
+                    },
+                    inst.span,
+                )?;
 
                 // Check that this is an associated function (no self), not a method
                 if method_info.has_self {

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -10,6 +10,36 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+// ============================================================================
+// Error Helper Functions
+// ============================================================================
+
+/// Convert a displayable error into a `LinkError` without a source span.
+///
+/// This helper simplifies the common pattern of wrapping various error types
+/// (e.g., from I/O operations, parsing, or linking) into `CompileError`.
+///
+/// # Example
+/// ```ignore
+/// linker.add_object(obj).map_err(link_error)?;
+/// ```
+fn link_error<E: std::fmt::Display>(err: E) -> CompileError {
+    CompileError::without_span(ErrorKind::LinkError(err.to_string()))
+}
+
+/// Convert an I/O result into a `CompileResult` with a contextual message.
+///
+/// This helper wraps `std::io::Error` with a descriptive message explaining
+/// what operation failed.
+///
+/// # Example
+/// ```ignore
+/// std::fs::create_dir_all(&path).map_err(|e| io_link_error("failed to create temp directory", e))?;
+/// ```
+fn io_link_error(context: &str, err: std::io::Error) -> CompileError {
+    CompileError::without_span(ErrorKind::LinkError(format!("{}: {}", context, err)))
+}
+
 /// Counter for generating unique temp directory names.
 static TEMP_DIR_COUNTER: AtomicU64 = AtomicU64::new(0);
 
@@ -38,12 +68,8 @@ impl TempLinkDir {
     fn new() -> CompileResult<Self> {
         let unique_id = TEMP_DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
         let path = std::env::temp_dir().join(format!("rue-{}-{}", std::process::id(), unique_id));
-        std::fs::create_dir_all(&path).map_err(|e| {
-            CompileError::without_span(ErrorKind::LinkError(format!(
-                "failed to create temp directory: {}",
-                e
-            )))
-        })?;
+        std::fs::create_dir_all(&path)
+            .map_err(|e| io_link_error("failed to create temp directory", e))?;
 
         let runtime_path = path.join("librue_runtime.a");
         let output_path = path.join("output");
@@ -63,18 +89,10 @@ impl TempLinkDir {
     fn write_object_files(&mut self, object_files: &[Vec<u8>]) -> CompileResult<()> {
         for (i, obj_bytes) in object_files.iter().enumerate() {
             let obj_path = self.path.join(format!("obj{}.o", i));
-            let mut file = std::fs::File::create(&obj_path).map_err(|e| {
-                CompileError::without_span(ErrorKind::LinkError(format!(
-                    "failed to create temp object file: {}",
-                    e
-                )))
-            })?;
-            file.write_all(obj_bytes).map_err(|e| {
-                CompileError::without_span(ErrorKind::LinkError(format!(
-                    "failed to write temp object file: {}",
-                    e
-                )))
-            })?;
+            let mut file = std::fs::File::create(&obj_path)
+                .map_err(|e| io_link_error("failed to create temp object file", e))?;
+            file.write_all(obj_bytes)
+                .map_err(|e| io_link_error("failed to write temp object file", e))?;
             self.obj_paths.push(obj_path);
         }
         Ok(())
@@ -82,22 +100,14 @@ impl TempLinkDir {
 
     /// Write the runtime archive to the temporary directory.
     fn write_runtime(&self, runtime_bytes: &[u8]) -> CompileResult<()> {
-        std::fs::write(&self.runtime_path, runtime_bytes).map_err(|e| {
-            CompileError::without_span(ErrorKind::LinkError(format!(
-                "failed to write runtime archive: {}",
-                e
-            )))
-        })
+        std::fs::write(&self.runtime_path, runtime_bytes)
+            .map_err(|e| io_link_error("failed to write runtime archive", e))
     }
 
     /// Read the linked executable from the output path.
     fn read_output(&self) -> CompileResult<Vec<u8>> {
-        std::fs::read(&self.output_path).map_err(|e| {
-            CompileError::without_span(ErrorKind::LinkError(format!(
-                "failed to read linked executable: {}",
-                e
-            )))
-        })
+        std::fs::read(&self.output_path)
+            .map_err(|e| io_link_error("failed to read linked executable", e))
     }
 }
 
@@ -364,12 +374,8 @@ fn link_internal(
 
     // Add all object files to the linker
     for obj_bytes in object_files {
-        let obj = ObjectFile::parse(obj_bytes)
-            .map_err(|e| CompileError::without_span(ErrorKind::LinkError(e.to_string())))?;
-
-        linker
-            .add_object(obj)
-            .map_err(|e| CompileError::without_span(ErrorKind::LinkError(e.to_string())))?;
+        let obj = ObjectFile::parse(obj_bytes).map_err(link_error)?;
+        linker.add_object(obj).map_err(link_error)?;
     }
 
     // Mark _start as required so it gets pulled from the archive.
@@ -378,17 +384,12 @@ fn link_internal(
     linker.require_symbol("_start");
 
     // Add the runtime library
-    let runtime = Archive::parse(RUNTIME_BYTES)
-        .map_err(|e| CompileError::without_span(ErrorKind::LinkError(e.to_string())))?;
-    linker
-        .add_archive(runtime)
-        .map_err(|e| CompileError::without_span(ErrorKind::LinkError(e.to_string())))?;
+    let runtime = Archive::parse(RUNTIME_BYTES).map_err(link_error)?;
+    linker.add_archive(runtime).map_err(link_error)?;
 
     // Link to executable
     // Use _start from the runtime as the entry point (it will call main)
-    let elf = linker
-        .link("_start")
-        .map_err(|e| CompileError::without_span(ErrorKind::LinkError(e.to_string())))?;
+    let elf = linker.link("_start").map_err(link_error)?;
 
     Ok(CompileOutput {
         elf,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -730,6 +730,34 @@ impl fmt::Display for ErrorKind {
 /// Result type for compilation operations.
 pub type CompileResult<T> = Result<T, CompileError>;
 
+// ============================================================================
+// Error Helper Traits
+// ============================================================================
+
+/// Extension trait for converting `Option<T>` to `CompileResult<T>`.
+///
+/// This trait simplifies the common pattern of converting lookup failures
+/// (returning `None`) into compilation errors with source spans.
+///
+/// # Example
+/// ```ignore
+/// use rue_error::{OptionExt, ErrorKind};
+///
+/// let result = ctx.locals.get(name)
+///     .ok_or_compile_error(ErrorKind::UndefinedVariable(name_str.to_string()), span)?;
+/// ```
+pub trait OptionExt<T> {
+    /// Convert `None` to a `CompileError` with the given kind and span.
+    fn ok_or_compile_error(self, kind: ErrorKind, span: Span) -> CompileResult<T>;
+}
+
+impl<T> OptionExt<T> for Option<T> {
+    #[inline]
+    fn ok_or_compile_error(self, kind: ErrorKind, span: Span) -> CompileResult<T> {
+        self.ok_or_else(|| CompileError::new(kind, span))
+    }
+}
+
 /// The kind of compilation warning.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum WarningKind {
@@ -1225,5 +1253,38 @@ mod tests {
             error.to_string(),
             "string concatenation requires preview feature `mutable_strings`"
         );
+    }
+
+    // ========================================================================
+    // OptionExt trait tests
+    // ========================================================================
+
+    #[test]
+    fn test_option_ext_some() {
+        let span = Span::new(10, 20);
+        let result: CompileResult<i32> =
+            Some(42).ok_or_compile_error(ErrorKind::InvalidInteger, span);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), 42);
+    }
+
+    #[test]
+    fn test_option_ext_none() {
+        let span = Span::new(10, 20);
+        let result: CompileResult<i32> = None.ok_or_compile_error(ErrorKind::InvalidInteger, span);
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.span(), Some(span));
+        matches!(error.kind, ErrorKind::InvalidInteger);
+    }
+
+    #[test]
+    fn test_option_ext_with_complex_error() {
+        let span = Span::new(5, 15);
+        let result: CompileResult<String> =
+            None.ok_or_compile_error(ErrorKind::UndefinedVariable("foo".to_string()), span);
+        assert!(result.is_err());
+        let error = result.unwrap_err();
+        assert_eq!(error.to_string(), "undefined variable 'foo'");
     }
 }


### PR DESCRIPTION
Add OptionExt trait to rue-error with ok_or_compile_error() method for converting Option<T> to CompileResult<T>. Add link_error() and io_link_error() helpers to rue-compiler for link error wrapping.

Refactor ~20 instances of verbose ok_or_else patterns in sema.rs and ~10 instances of I/O error wrapping in rue-compiler to use the new helpers, reducing boilerplate while maintaining identical semantics.

Fixes rue-yshq

🤖 Generated with [Claude Code](https://claude.com/claude-code)