### PR TITLE
Use Cow<str> to avoid allocations in error formatting

### DIFF
--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -18,6 +18,7 @@
 //! ```
 
 use rue_span::Span;
+use std::borrow::Cow;
 use std::collections::HashSet;
 use std::fmt;
 
@@ -241,11 +242,11 @@ pub enum ErrorKind {
 
     // Parser errors
     UnexpectedToken {
-        expected: &'static str,
-        found: String,
+        expected: Cow<'static, str>,
+        found: Cow<'static, str>,
     },
     UnexpectedEof {
-        expected: &'static str,
+        expected: Cow<'static, str>,
     },
 
     // Semantic errors
@@ -945,15 +946,17 @@ mod tests {
     #[test]
     fn test_unexpected_token_message() {
         let error = CompileError::without_span(ErrorKind::UnexpectedToken {
-            expected: "identifier",
-            found: "'+'".to_string(),
+            expected: Cow::Borrowed("identifier"),
+            found: Cow::Borrowed("'+'"),
         });
         assert_eq!(error.to_string(), "expected identifier, found '+'");
     }
 
     #[test]
     fn test_unexpected_eof_message() {
-        let error = CompileError::without_span(ErrorKind::UnexpectedEof { expected: "'}'" });
+        let error = CompileError::without_span(ErrorKind::UnexpectedEof {
+            expected: Cow::Borrowed("'}'"),
+        });
         assert_eq!(error.to_string(), "unexpected end of file, expected '}'");
     }
 

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -18,6 +18,7 @@ use chumsky::prelude::*;
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_lexer::TokenKind;
 use rue_span::Span;
+use std::borrow::Cow;
 
 /// Convert chumsky SimpleSpan to rue_span::Span
 fn to_rue_span(span: SimpleSpan) -> Span {
@@ -1317,26 +1318,27 @@ fn convert_error(err: Rich<'_, TokenKind>) -> CompileError {
 
     match err.reason() {
         chumsky::error::RichReason::ExpectedFound { expected, found } => {
-            let expected_str = if expected.is_empty() {
-                "something".to_string()
+            let expected_str: Cow<'static, str> = if expected.is_empty() {
+                Cow::Borrowed("something")
             } else {
-                expected
-                    .iter()
-                    .take(3) // Limit to first 3 for readability
-                    .map(|e| format!("{:?}", e))
-                    .collect::<Vec<_>>()
-                    .join(" or ")
+                Cow::Owned(
+                    expected
+                        .iter()
+                        .take(3) // Limit to first 3 for readability
+                        .map(|e| format!("{:?}", e))
+                        .collect::<Vec<_>>()
+                        .join(" or "),
+                )
             };
 
-            let found_str = found
-                .as_ref()
-                .map(|t| t.name())
-                .unwrap_or("end of file")
-                .to_string();
+            let found_str: Cow<'static, str> = match found.as_ref() {
+                Some(t) => Cow::Owned(t.name().to_string()),
+                None => Cow::Borrowed("end of file"),
+            };
 
             CompileError::new(
                 ErrorKind::UnexpectedToken {
-                    expected: Box::leak(expected_str.into_boxed_str()),
+                    expected: expected_str,
                     found: found_str,
                 },
                 span,
@@ -1344,8 +1346,8 @@ fn convert_error(err: Rich<'_, TokenKind>) -> CompileError {
         }
         _ => CompileError::new(
             ErrorKind::UnexpectedToken {
-                expected: "valid syntax",
-                found: "parse error".to_string(),
+                expected: Cow::Borrowed("valid syntax"),
+                found: Cow::Borrowed("parse error"),
             },
             span,
         ),


### PR DESCRIPTION
Replace Box::leak memory leak and unnecessary String allocations with Cow<'static, str> for parser error messages. Static strings like "something" and "end of file" now use Cow::Borrowed to avoid allocation entirely.

Fixes rue-efge