### PR TITLE
Use Vec::with_capacity() when size is known

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -319,7 +319,7 @@ impl<'a> CfgLower<'a> {
             CfgInstData::Load { slot } => {
                 // Load slot values from consecutive stack slots
                 let slot_count = self.type_slot_count(Type::Struct(struct_id));
-                let mut vregs = Vec::new();
+                let mut vregs = Vec::with_capacity(slot_count as usize);
                 for i in 0..slot_count {
                     let vreg = self.mir.alloc_vreg();
                     let offset = self.local_offset(slot + i);
@@ -335,7 +335,7 @@ impl<'a> CfgLower<'a> {
             CfgInstData::Param { index } => {
                 // Get slot values from parameter area
                 let slot_count = self.type_slot_count(Type::Struct(struct_id));
-                let mut vregs = Vec::new();
+                let mut vregs = Vec::with_capacity(slot_count as usize);
                 for i in 0..slot_count {
                     let vreg = self.mir.alloc_vreg();
                     let param_slot = self.num_locals + index + i;

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -246,7 +246,8 @@ pub fn analyze(mir: &Aarch64Mir) -> LivenessInfo {
 
 /// Get virtual registers used (read) by an instruction.
 fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
-    let mut result = Vec::new();
+    // Most instructions have 0-2 operands; pre-allocate for common case
+    let mut result = Vec::with_capacity(2);
 
     let add_if_virtual = |op: &Operand, vec: &mut Vec<VReg>| {
         if let Operand::Virtual(vreg) = op {
@@ -377,7 +378,8 @@ fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
 
 /// Get virtual registers defined (written) by an instruction.
 fn defs(inst: &Aarch64Inst) -> Vec<VReg> {
-    let mut result = Vec::new();
+    // Most instructions define 0-1 registers; pre-allocate for common case
+    let mut result = Vec::with_capacity(1);
 
     let add_if_virtual = |op: &Operand, vec: &mut Vec<VReg>| {
         if let Operand::Virtual(vreg) = op {

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -96,7 +96,9 @@ impl RegAlloc {
 
     /// Assign physical registers to all virtual registers using linear scan.
     fn assign_registers(&mut self) {
-        let mut vregs_by_start: Vec<(VReg, LiveRange)> = Vec::new();
+        // Pre-allocate for the maximum possible size (all vregs may have live ranges)
+        let mut vregs_by_start: Vec<(VReg, LiveRange)> =
+            Vec::with_capacity(self.mir.vreg_count() as usize);
         for vreg_idx in 0..self.mir.vreg_count() {
             let vreg = VReg::new(vreg_idx);
             if let Some(&range) = self.liveness.range(vreg) {
@@ -105,7 +107,8 @@ impl RegAlloc {
         }
         vregs_by_start.sort_by_key(|(_, range)| range.start);
 
-        let mut active: Vec<(VReg, Reg, usize)> = Vec::new();
+        // Pre-allocate for typical register pressure (bounded by allocatable registers)
+        let mut active: Vec<(VReg, Reg, usize)> = Vec::with_capacity(ALLOCATABLE_REGS.len());
 
         for (vreg, range) in vregs_by_start {
             active.retain(|&(_, _, end)| end >= range.start);

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -326,7 +326,7 @@ impl<'a> CfgLower<'a> {
             CfgInstData::Load { slot } => {
                 // Load slot values from consecutive stack slots
                 let slot_count = self.type_slot_count(Type::Struct(struct_id));
-                let mut vregs = Vec::new();
+                let mut vregs = Vec::with_capacity(slot_count as usize);
                 for i in 0..slot_count {
                     let vreg = self.mir.alloc_vreg();
                     let offset = self.local_offset(slot + i);
@@ -342,7 +342,7 @@ impl<'a> CfgLower<'a> {
             CfgInstData::Param { index } => {
                 // Get slot values from parameter area
                 let slot_count = self.type_slot_count(Type::Struct(struct_id));
-                let mut vregs = Vec::new();
+                let mut vregs = Vec::with_capacity(slot_count as usize);
                 for i in 0..slot_count {
                     let vreg = self.mir.alloc_vreg();
                     let param_slot = self.num_locals + index + i;

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -148,7 +148,8 @@ pub fn analyze(mir: &X86Mir) -> LivenessInfo {
 
 /// Get virtual registers used (read) by an instruction.
 fn uses(inst: &X86Inst) -> Vec<VReg> {
-    let mut result = Vec::new();
+    // Most instructions have 0-2 operands; pre-allocate for common case
+    let mut result = Vec::with_capacity(2);
 
     let add_if_virtual = |op: &Operand, vec: &mut Vec<VReg>| {
         if let Operand::Virtual(vreg) = op {
@@ -301,7 +302,8 @@ fn uses(inst: &X86Inst) -> Vec<VReg> {
 
 /// Get virtual registers defined (written) by an instruction.
 fn defs(inst: &X86Inst) -> Vec<VReg> {
-    let mut result = Vec::new();
+    // Most instructions define 0-1 registers; pre-allocate for common case
+    let mut result = Vec::with_capacity(1);
 
     let add_if_virtual = |op: &Operand, vec: &mut Vec<VReg>| {
         if let Operand::Virtual(vreg) = op {

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -117,8 +117,9 @@ impl RegAlloc {
 
     /// Assign physical registers to all virtual registers using linear scan.
     fn assign_registers(&mut self) {
-        // Collect vregs with their live ranges, sorted by start position
-        let mut vregs_by_start: Vec<(VReg, LiveRange)> = Vec::new();
+        // Pre-allocate for the maximum possible size (all vregs may have live ranges)
+        let mut vregs_by_start: Vec<(VReg, LiveRange)> =
+            Vec::with_capacity(self.mir.vreg_count() as usize);
         for vreg_idx in 0..self.mir.vreg_count() {
             let vreg = VReg::new(vreg_idx);
             if let Some(&range) = self.liveness.range(vreg) {
@@ -128,8 +129,8 @@ impl RegAlloc {
         vregs_by_start.sort_by_key(|(_, range)| range.start);
 
         // Track which registers are currently in use and when they become free
-        // Map from register to (vreg using it, end of that vreg's live range)
-        let mut active: Vec<(VReg, Reg, usize)> = Vec::new(); // (vreg, reg, end)
+        // Pre-allocate for typical register pressure (bounded by allocatable registers)
+        let mut active: Vec<(VReg, Reg, usize)> = Vec::with_capacity(ALLOCATABLE_REGS.len());
 
         for (vreg, range) in vregs_by_start {
             // Expire old intervals - registers whose vregs are no longer live

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -284,7 +284,8 @@ impl<'a> LogosLexer<'a> {
 
     /// Tokenize the entire source, returning all tokens.
     pub fn tokenize(&mut self) -> CompileResult<Vec<Token>> {
-        let mut tokens = Vec::new();
+        // Estimate capacity: source length / 4 is a rough heuristic for token density
+        let mut tokens = Vec::with_capacity(self.source.len() / 4);
 
         for (result, span) in LogosTokenKind::lexer(self.source).spanned() {
             match result {

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -545,7 +545,8 @@ impl<'a> AstGen<'a> {
             self.gen_expr(&block.expr)
         } else {
             // Collect all instruction refs for the block
-            let mut inst_refs = Vec::new();
+            // statements + 1 for the final expression
+            let mut inst_refs = Vec::with_capacity(block.statements.len() + 1);
 
             // Generate all statements first
             for stmt in &block.statements {

--- a/crates/rue-spec/src/main.rs
+++ b/crates/rue-spec/src/main.rs
@@ -132,7 +132,9 @@ fn main() {
     let specs = load_test_files(&cases_dir);
 
     // Build test trials, separating stable and preview tests
-    let mut tests: Vec<Trial> = Vec::new();
+    // Pre-allocate based on total case count across all specs
+    let total_cases: usize = specs.iter().map(|(_, s)| s.case.len()).sum();
+    let mut tests: Vec<Trial> = Vec::with_capacity(total_cases);
 
     for (_, spec) in specs {
         let section_id = spec.section.id.clone();

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -437,8 +437,9 @@ pub fn parse_test_files(cases_dir: &Path) -> Vec<TestFile> {
             .to_string();
 
         // Get cases
-        let mut cases = Vec::new();
-        if let Some(case_array) = table.get("case").and_then(|c| c.as_array()) {
+        let case_array_opt = table.get("case").and_then(|c| c.as_array());
+        let mut cases = Vec::with_capacity(case_array_opt.map(|a| a.len()).unwrap_or(0));
+        if let Some(case_array) = case_array_opt {
             for case in case_array {
                 let name = case
                     .get("name")


### PR DESCRIPTION
Pre-allocate vectors to avoid reallocations when the final size is known upfront. Applied consistently across both x86_64 and aarch64 backends.

Key optimizations:
- Liveness analysis: uses() and defs() functions
- Register allocation: vreg collection and active register tracking
- CFG lowering: struct field loading
- Lexer: token collection with heuristic capacity
- Spec tests: test trial collection

Fixes rue-43c6

🤖 Generated with [Claude Code](https://claude.com/claude-code)