### PR TITLE
Use entry API for string table deduplication

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -283,13 +283,16 @@ impl<'a> Sema<'a> {
     /// Add a string to the string table, returning its index.
     /// Deduplicates identical strings.
     fn add_string(&mut self, content: String) -> u32 {
-        if let Some(&id) = self.string_table.get(&content) {
-            return id;
+        use std::collections::hash_map::Entry;
+        match self.string_table.entry(content) {
+            Entry::Occupied(e) => *e.get(),
+            Entry::Vacant(e) => {
+                let id = self.strings.len() as u32;
+                self.strings.push(e.key().clone());
+                e.insert(id);
+                id
+            }
         }
-        let id = self.strings.len() as u32;
-        self.string_table.insert(content.clone(), id);
-        self.strings.push(content);
-        id
     }
 
     /// Check if directives contain @allow for a specific warning name.


### PR DESCRIPTION
Refactored add_string() in sema.rs to use HashMap's entry API instead of get-then-insert pattern. This eliminates redundant hash lookups and only clones the string key in the vacant (new string) case.

Fixes: rue-9exk

🤖 Generated with [Claude Code](https://claude.com/claude-code)