### PR TITLE
Add IndexMap<H, V> for type-safe VReg indexing

### DIFF
--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -9,6 +9,7 @@ use rue_error::{CompileError, CompileResult, ErrorKind};
 
 use super::liveness::{self, LiveRange, LivenessInfo};
 use super::mir::{Aarch64Inst, Aarch64Mir, Operand, Reg, VReg};
+use crate::index_map::IndexMap;
 
 /// Available registers for allocation.
 ///
@@ -49,7 +50,8 @@ enum Allocation {
 /// Register allocator for AArch64.
 pub struct RegAlloc {
     mir: Aarch64Mir,
-    allocation: Vec<Option<Allocation>>,
+    /// Maps virtual register to its allocation (register or spill slot).
+    allocation: IndexMap<VReg, Option<Allocation>>,
     liveness: LivenessInfo,
     next_spill_offset: i32,
     num_spills: u32,
@@ -63,9 +65,12 @@ impl RegAlloc {
         let liveness = liveness::analyze(&mir);
         let next_spill_offset = -((existing_locals as i32 + 1) * 8);
 
+        let mut allocation = IndexMap::with_capacity(vreg_count);
+        allocation.resize(vreg_count, None);
+
         Self {
             mir,
-            allocation: vec![None; vreg_count],
+            allocation,
             liveness,
             next_spill_offset,
             num_spills: 0,
@@ -121,7 +126,7 @@ impl RegAlloc {
             }
 
             if let Some(reg) = allocated_reg {
-                self.allocation[vreg.index() as usize] = Some(Allocation::Register(reg));
+                self.allocation[vreg] = Some(Allocation::Register(reg));
                 active.push((vreg, reg, range.end));
                 if !self.used_callee_saved.contains(&reg) {
                     self.used_callee_saved.push(reg);
@@ -139,13 +144,12 @@ impl RegAlloc {
                 if let Some(idx) = longest_idx {
                     let (spilled_vreg, freed_reg, _) = active.remove(idx);
                     let spill_offset = self.alloc_spill_slot();
-                    self.allocation[spilled_vreg.index() as usize] =
-                        Some(Allocation::Spill(spill_offset));
-                    self.allocation[vreg.index() as usize] = Some(Allocation::Register(freed_reg));
+                    self.allocation[spilled_vreg] = Some(Allocation::Spill(spill_offset));
+                    self.allocation[vreg] = Some(Allocation::Register(freed_reg));
                     active.push((vreg, freed_reg, range.end));
                 } else {
                     let spill_offset = self.alloc_spill_slot();
-                    self.allocation[vreg.index() as usize] = Some(Allocation::Spill(spill_offset));
+                    self.allocation[vreg] = Some(Allocation::Spill(spill_offset));
                 }
             }
         }
@@ -929,7 +933,7 @@ impl RegAlloc {
 
     fn get_allocation(&self, operand: Operand) -> Option<Allocation> {
         match operand {
-            Operand::Virtual(vreg) => self.allocation[vreg.index() as usize],
+            Operand::Virtual(vreg) => self.allocation[vreg],
             Operand::Physical(_) => None,
         }
     }
@@ -941,7 +945,7 @@ impl RegAlloc {
         scratch: Reg,
     ) -> CompileResult<Operand> {
         match operand {
-            Operand::Virtual(vreg) => match self.allocation[vreg.index() as usize] {
+            Operand::Virtual(vreg) => match self.allocation[vreg] {
                 Some(Allocation::Register(reg)) => Ok(Operand::Physical(reg)),
                 Some(Allocation::Spill(offset)) => {
                     mir.push(Aarch64Inst::Ldr {

--- a/crates/rue-codegen/src/index_map.rs
+++ b/crates/rue-codegen/src/index_map.rs
@@ -1,0 +1,220 @@
+//! Type-safe index map for handle types.
+//!
+//! This module provides `IndexMap<H, V>`, a vector-backed map that uses
+//! handle types (like `VReg`) as keys. This provides type safety over
+//! raw `Vec<V>` indexing patterns like `vec[handle.index() as usize]`.
+
+use std::marker::PhantomData;
+use std::ops::{Index, IndexMut};
+
+/// A trait for handle types that can be used as keys in an `IndexMap`.
+///
+/// Handle types are lightweight wrappers around indices (typically `u32`)
+/// that provide type safety. Examples include `VReg` and `LabelId`.
+pub trait Handle: Copy {
+    /// Get the underlying index of this handle.
+    fn index(self) -> u32;
+
+    /// Create a handle from an index.
+    fn from_index(index: u32) -> Self;
+}
+
+/// A vector-backed map using handle types as keys.
+///
+/// This provides type-safe indexing over raw vector access patterns.
+/// Instead of `allocation[vreg.index() as usize]`, you can write
+/// `allocation[vreg]`.
+///
+/// # Example
+///
+/// ```ignore
+/// use rue_codegen::index_map::{IndexMap, Handle};
+/// use rue_codegen::VReg;
+///
+/// let mut map: IndexMap<VReg, Option<i32>> = IndexMap::new();
+/// map.resize(10, None);
+///
+/// let vreg = VReg::new(5);
+/// map[vreg] = Some(42);
+/// assert_eq!(map[vreg], Some(42));
+/// ```
+#[derive(Debug, Clone)]
+pub struct IndexMap<H, V> {
+    data: Vec<V>,
+    _marker: PhantomData<H>,
+}
+
+impl<H: Handle, V> IndexMap<H, V> {
+    /// Create a new empty index map.
+    pub fn new() -> Self {
+        Self {
+            data: Vec::new(),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Create an index map with the specified capacity.
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self {
+            data: Vec::with_capacity(capacity),
+            _marker: PhantomData,
+        }
+    }
+
+    /// Get the number of entries in the map.
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Check if the map is empty.
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Get a reference to a value by handle, returning `None` if out of bounds.
+    pub fn get(&self, handle: H) -> Option<&V> {
+        self.data.get(handle.index() as usize)
+    }
+
+    /// Get a mutable reference to a value by handle, returning `None` if out of bounds.
+    pub fn get_mut(&mut self, handle: H) -> Option<&mut V> {
+        self.data.get_mut(handle.index() as usize)
+    }
+
+    /// Push a value and return the handle for it.
+    pub fn push(&mut self, value: V) -> H {
+        let index = self.data.len() as u32;
+        self.data.push(value);
+        H::from_index(index)
+    }
+
+    /// Iterate over all values.
+    pub fn iter(&self) -> impl Iterator<Item = &V> {
+        self.data.iter()
+    }
+
+    /// Iterate over all values mutably.
+    pub fn iter_mut(&mut self) -> impl Iterator<Item = &mut V> {
+        self.data.iter_mut()
+    }
+
+    /// Iterate over (handle, value) pairs.
+    pub fn iter_enumerated(&self) -> impl Iterator<Item = (H, &V)> {
+        self.data
+            .iter()
+            .enumerate()
+            .map(|(i, v)| (H::from_index(i as u32), v))
+    }
+}
+
+impl<H: Handle, V: Clone> IndexMap<H, V> {
+    /// Resize the map to contain `new_len` elements, filling new slots with `value`.
+    pub fn resize(&mut self, new_len: usize, value: V) {
+        self.data.resize(new_len, value);
+    }
+}
+
+impl<H: Handle, V: Default> IndexMap<H, V> {
+    /// Resize the map to contain `new_len` elements, filling new slots with default values.
+    pub fn resize_default(&mut self, new_len: usize) {
+        self.data.resize_with(new_len, V::default);
+    }
+}
+
+impl<H: Handle, V> Default for IndexMap<H, V> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<H: Handle, V> Index<H> for IndexMap<H, V> {
+    type Output = V;
+
+    fn index(&self, handle: H) -> &Self::Output {
+        &self.data[handle.index() as usize]
+    }
+}
+
+impl<H: Handle, V> IndexMut<H> for IndexMap<H, V> {
+    fn index_mut(&mut self, handle: H) -> &mut Self::Output {
+        &mut self.data[handle.index() as usize]
+    }
+}
+
+impl<H: Handle, V> FromIterator<V> for IndexMap<H, V> {
+    fn from_iter<I: IntoIterator<Item = V>>(iter: I) -> Self {
+        Self {
+            data: iter.into_iter().collect(),
+            _marker: PhantomData,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Simple test handle type
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    struct TestHandle(u32);
+
+    impl Handle for TestHandle {
+        fn index(self) -> u32 {
+            self.0
+        }
+
+        fn from_index(index: u32) -> Self {
+            Self(index)
+        }
+    }
+
+    #[test]
+    fn test_index_map_basic() {
+        let mut map: IndexMap<TestHandle, i32> = IndexMap::new();
+        map.resize(10, 0);
+
+        let h5 = TestHandle(5);
+        map[h5] = 42;
+        assert_eq!(map[h5], 42);
+    }
+
+    #[test]
+    fn test_index_map_push() {
+        let mut map: IndexMap<TestHandle, &str> = IndexMap::new();
+
+        let h0 = map.push("first");
+        let h1 = map.push("second");
+
+        assert_eq!(h0.index(), 0);
+        assert_eq!(h1.index(), 1);
+        assert_eq!(map[h0], "first");
+        assert_eq!(map[h1], "second");
+    }
+
+    #[test]
+    fn test_index_map_get() {
+        let mut map: IndexMap<TestHandle, i32> = IndexMap::new();
+        map.resize(5, 0);
+
+        let valid = TestHandle(3);
+        let invalid = TestHandle(10);
+
+        assert!(map.get(valid).is_some());
+        assert!(map.get(invalid).is_none());
+    }
+
+    #[test]
+    fn test_index_map_iter_enumerated() {
+        let mut map: IndexMap<TestHandle, i32> = IndexMap::new();
+        map.push(10);
+        map.push(20);
+        map.push(30);
+
+        let pairs: Vec<_> = map.iter_enumerated().collect();
+        assert_eq!(pairs.len(), 3);
+        assert_eq!(pairs[0].0.index(), 0);
+        assert_eq!(*pairs[0].1, 10);
+        assert_eq!(pairs[2].0.index(), 2);
+        assert_eq!(*pairs[2].1, 30);
+    }
+}

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -14,6 +14,7 @@
 //! virtual registers to physical registers before final emission.
 
 pub mod aarch64;
+pub mod index_map;
 pub mod types;
 pub mod vreg;
 pub mod x86_64;
@@ -152,6 +153,7 @@ pub struct MachineCode {
 pub use x86_64::generate;
 
 // Re-export shared types
+pub use index_map::{Handle, IndexMap};
 pub use vreg::{LabelId, VReg};
 
 // Re-export commonly used x86_64 types for convenience

--- a/crates/rue-codegen/src/vreg.rs
+++ b/crates/rue-codegen/src/vreg.rs
@@ -6,6 +6,8 @@
 
 use std::fmt;
 
+use crate::index_map::Handle;
+
 /// A virtual register.
 ///
 /// Virtual registers are unlimited and allocated to physical registers
@@ -31,6 +33,16 @@ impl VReg {
 impl fmt::Display for VReg {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "v{}", self.0)
+    }
+}
+
+impl Handle for VReg {
+    fn index(self) -> u32 {
+        self.0
+    }
+
+    fn from_index(index: u32) -> Self {
+        Self(index)
     }
 }
 

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -16,6 +16,7 @@ use rue_error::{CompileError, CompileResult, ErrorKind};
 
 use super::liveness::{self, LiveRange, LivenessInfo};
 use super::mir::{Operand, Reg, VReg, X86Inst, X86Mir};
+use crate::index_map::IndexMap;
 
 /// Available registers for allocation.
 ///
@@ -50,8 +51,8 @@ enum Allocation {
 /// Register allocator with liveness-based allocation.
 pub struct RegAlloc {
     mir: X86Mir,
-    /// Maps virtual register index to allocation.
-    allocation: Vec<Option<Allocation>>,
+    /// Maps virtual register to its allocation (register or spill slot).
+    allocation: IndexMap<VReg, Option<Allocation>>,
     /// Liveness information.
     liveness: LivenessInfo,
     /// Next spill slot offset (negative from RBP).
@@ -76,9 +77,12 @@ impl RegAlloc {
         // Each local is 8 bytes, slot 0 is at [rbp-8], etc.
         let next_spill_offset = -((existing_locals as i32 + 1) * 8);
 
+        let mut allocation = IndexMap::with_capacity(vreg_count);
+        allocation.resize(vreg_count, None);
+
         Self {
             mir,
-            allocation: vec![None; vreg_count],
+            allocation,
             liveness,
             next_spill_offset,
             num_spills: 0,
@@ -149,7 +153,7 @@ impl RegAlloc {
 
             if let Some(reg) = allocated_reg {
                 // Assign this register
-                self.allocation[vreg.index() as usize] = Some(Allocation::Register(reg));
+                self.allocation[vreg] = Some(Allocation::Register(reg));
                 active.push((vreg, reg, range.end));
                 // Track callee-saved register usage
                 if !self.used_callee_saved.contains(&reg) {
@@ -174,16 +178,15 @@ impl RegAlloc {
                     // Spill the existing vreg with longest range
                     let (spilled_vreg, freed_reg, _) = active.remove(idx);
                     let spill_offset = self.alloc_spill_slot();
-                    self.allocation[spilled_vreg.index() as usize] =
-                        Some(Allocation::Spill(spill_offset));
+                    self.allocation[spilled_vreg] = Some(Allocation::Spill(spill_offset));
 
                     // Give the freed register to the current vreg
-                    self.allocation[vreg.index() as usize] = Some(Allocation::Register(freed_reg));
+                    self.allocation[vreg] = Some(Allocation::Register(freed_reg));
                     active.push((vreg, freed_reg, range.end));
                 } else {
                     // Current vreg has the longest range, spill it
                     let spill_offset = self.alloc_spill_slot();
-                    self.allocation[vreg.index() as usize] = Some(Allocation::Spill(spill_offset));
+                    self.allocation[vreg] = Some(Allocation::Spill(spill_offset));
                 }
             }
         }
@@ -901,7 +904,7 @@ impl RegAlloc {
     /// Get the allocation for an operand (returns None for physical registers).
     fn get_allocation(&self, operand: Operand) -> Option<Allocation> {
         match operand {
-            Operand::Virtual(vreg) => self.allocation[vreg.index() as usize],
+            Operand::Virtual(vreg) => self.allocation[vreg],
             Operand::Physical(_) => None,
         }
     }
@@ -915,7 +918,7 @@ impl RegAlloc {
         scratch: Reg,
     ) -> CompileResult<Operand> {
         match operand {
-            Operand::Virtual(vreg) => match self.allocation[vreg.index() as usize] {
+            Operand::Virtual(vreg) => match self.allocation[vreg] {
                 Some(Allocation::Register(reg)) => Ok(Operand::Physical(reg)),
                 Some(Allocation::Spill(offset)) => {
                     mir.push(X86Inst::MovRM {


### PR DESCRIPTION
Introduce IndexMap<H, V>, a vector-backed map that uses handle types (like VReg) as keys, providing type safety over raw Vec<V> indexing.

Changes:
- Add index_map.rs with Handle trait and IndexMap struct
- Implement Handle for VReg in vreg.rs
- Update both x86_64 and aarch64 regalloc.rs to use IndexMap instead of Vec<Option<Allocation>>

This eliminates repetitive '.index() as usize' patterns throughout the register allocator, making the code cleaner and more type-safe.

Closes: rue-z790

🤖 Generated with [Claude Code](https://claude.com/claude-code)