### PR TITLE
Remove unnecessary .clone() on Copy type Operand

### DIFF
--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -1194,11 +1194,11 @@ mod tests {
 
         // v0 and v1 should get different registers
         let d0 = match &mir.instructions()[0] {
-            X86Inst::MovRI32 { dst, .. } => dst.clone(),
+            X86Inst::MovRI32 { dst, .. } => *dst,
             _ => panic!("expected MovRI32"),
         };
         let d1 = match &mir.instructions()[1] {
-            X86Inst::MovRI32 { dst, .. } => dst.clone(),
+            X86Inst::MovRI32 { dst, .. } => *dst,
             _ => panic!("expected MovRI32"),
         };
 


### PR DESCRIPTION
Operand is #[derive(Copy, Clone)] so .clone() is redundant. Changed to *dst (dereference) instead of dst.clone().

Closes: rue-52ew

🤖 Generated with [Claude Code](https://claude.com/claude-code)