### PR TITLE
Add DiagnosticFormatter API to decouple CLI from pipeline

### DIFF
--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -17,6 +17,7 @@ rust_library(
         "//crates/rue-rir:rue-rir",
         "//crates/rue-span:rue-span",
         "//crates/rue-target:rue-target",
+        "//third-party:annotate-snippets",
     ],
     visibility = ["PUBLIC"],
 )
@@ -39,5 +40,6 @@ rust_test(
         "//crates/rue-rir:rue-rir",
         "//crates/rue-span:rue-span",
         "//crates/rue-target:rue-target",
+        "//third-party:annotate-snippets",
     ],
 )

--- a/crates/rue-compiler/src/diagnostic.rs
+++ b/crates/rue-compiler/src/diagnostic.rs
@@ -1,0 +1,310 @@
+//! Diagnostic formatting for compiler errors and warnings.
+//!
+//! This module provides utilities for formatting compiler diagnostics into
+//! human-readable output using annotate-snippets for source annotations.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use rue_compiler::{DiagnosticFormatter, SourceInfo};
+//!
+//! let source_info = SourceInfo::new(&source, "example.rue");
+//! let formatter = DiagnosticFormatter::new(&source_info);
+//!
+//! // Format an error
+//! let error_output = formatter.format_error(&error);
+//! eprintln!("{}", error_output);
+//!
+//! // Format warnings
+//! let warning_output = formatter.format_warnings(&warnings);
+//! eprintln!("{}", warning_output);
+//! ```
+
+use std::collections::HashMap;
+
+use annotate_snippets::{Level, Renderer, Snippet};
+
+use crate::{CompileError, CompileWarning, Diagnostic, Span};
+
+/// Source code information for diagnostic rendering.
+///
+/// Contains the source text and file path needed for rendering annotated
+/// error and warning messages.
+#[derive(Debug, Clone)]
+pub struct SourceInfo<'a> {
+    /// The source code text.
+    pub source: &'a str,
+    /// The path to the source file (for display in diagnostics).
+    pub path: &'a str,
+}
+
+impl<'a> SourceInfo<'a> {
+    /// Create a new SourceInfo with the given source and file path.
+    pub fn new(source: &'a str, path: &'a str) -> Self {
+        Self { source, path }
+    }
+}
+
+/// Formatter for compiler diagnostics.
+///
+/// Provides methods to format compilation errors and warnings into
+/// human-readable strings with annotated source snippets.
+pub struct DiagnosticFormatter<'a> {
+    source_info: &'a SourceInfo<'a>,
+    renderer: Renderer,
+}
+
+impl<'a> DiagnosticFormatter<'a> {
+    /// Create a new diagnostic formatter for the given source info.
+    pub fn new(source_info: &'a SourceInfo<'a>) -> Self {
+        Self {
+            source_info,
+            renderer: Renderer::plain(),
+        }
+    }
+
+    /// Format a compilation error into a string.
+    pub fn format_error(&self, error: &CompileError) -> String {
+        self.format_diagnostic_impl(
+            Level::Error,
+            &error.to_string(),
+            error.span(),
+            error.diagnostic(),
+        )
+    }
+
+    /// Format all warnings, adding line numbers when multiple variables share the same name.
+    ///
+    /// This improves error messages by disambiguating when there are multiple unused
+    /// variables with the same name (e.g., shadowed variables in different scopes).
+    pub fn format_warnings(&self, warnings: &[CompileWarning]) -> String {
+        if warnings.is_empty() {
+            return String::new();
+        }
+
+        // Count occurrences of each unused variable name
+        let mut var_name_counts: HashMap<&str, usize> = HashMap::new();
+        for warning in warnings {
+            if let Some(name) = warning.kind.unused_variable_name() {
+                *var_name_counts.entry(name).or_insert(0) += 1;
+            }
+        }
+
+        // Format each warning, adding line number if there are duplicates
+        let mut output = String::new();
+        for warning in warnings {
+            let needs_line_number = warning
+                .kind
+                .unused_variable_name()
+                .is_some_and(|name| var_name_counts.get(name).copied().unwrap_or(0) > 1);
+
+            if !output.is_empty() {
+                output.push('\n');
+            }
+            output.push_str(&self.format_warning_internal(warning, needs_line_number));
+        }
+        output
+    }
+
+    /// Format a single warning into a string.
+    pub fn format_warning(&self, warning: &CompileWarning) -> String {
+        self.format_warning_internal(warning, false)
+    }
+
+    fn format_warning_internal(
+        &self,
+        warning: &CompileWarning,
+        include_line_number: bool,
+    ) -> String {
+        // Get the message, optionally with line number for disambiguation
+        let message = if include_line_number {
+            if let Some(span) = warning.span() {
+                let line = span.line_number(self.source_info.source);
+                warning.kind.format_with_line(Some(line))
+            } else {
+                warning.to_string()
+            }
+        } else {
+            warning.to_string()
+        };
+
+        self.format_diagnostic_impl(
+            Level::Warning,
+            &message,
+            warning.span(),
+            warning.diagnostic(),
+        )
+    }
+
+    /// Internal implementation for formatting diagnostics.
+    fn format_diagnostic_impl(
+        &self,
+        level: Level,
+        message: &str,
+        span: Option<Span>,
+        diagnostic: &Diagnostic,
+    ) -> String {
+        // For diagnostics without a span, just format the message with any footers
+        let Some(span) = span else {
+            let mut report = level.title(message);
+            // Add notes and helps as footers
+            for note in &diagnostic.notes {
+                report = report.footer(Level::Note.title(note.0.as_str()));
+            }
+            for help in &diagnostic.helps {
+                report = report.footer(Level::Help.title(help.0.as_str()));
+            }
+            return format!("{}", self.renderer.render(report));
+        };
+
+        // Build snippet with primary annotation
+        let mut snippet = Snippet::source(self.source_info.source)
+            .origin(self.source_info.path)
+            .fold(true)
+            .annotation(level.span(span.start as usize..span.end as usize));
+
+        // Add secondary labels as Info annotations
+        for label in &diagnostic.labels {
+            snippet = snippet.annotation(
+                Level::Info
+                    .span(label.span.start as usize..label.span.end as usize)
+                    .label(&label.message),
+            );
+        }
+
+        let mut report = level.title(message).snippet(snippet);
+
+        // Add notes and helps as footers
+        for note in &diagnostic.notes {
+            report = report.footer(Level::Note.title(note.0.as_str()));
+        }
+        for help in &diagnostic.helps {
+            report = report.footer(Level::Help.title(help.0.as_str()));
+        }
+
+        format!("{}", self.renderer.render(report))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{ErrorKind, WarningKind};
+
+    #[test]
+    fn test_format_error_with_span() {
+        let source = "fn main() -> i32 { 1 + true }";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = DiagnosticFormatter::new(&source_info);
+
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::new(23, 27),
+        );
+
+        let output = formatter.format_error(&error);
+        assert!(output.contains("type mismatch"));
+        assert!(output.contains("expected i32"));
+        assert!(output.contains("found bool"));
+        assert!(output.contains("test.rue"));
+    }
+
+    #[test]
+    fn test_format_error_without_span() {
+        let source = "fn foo() -> i32 { 42 }";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = DiagnosticFormatter::new(&source_info);
+
+        let error = CompileError::without_span(ErrorKind::NoMainFunction);
+
+        let output = formatter.format_error(&error);
+        assert!(output.contains("no main function"));
+    }
+
+    #[test]
+    fn test_format_warning() {
+        let source = "fn main() -> i32 { let x = 42; 0 }";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = DiagnosticFormatter::new(&source_info);
+
+        let warning = CompileWarning::new(
+            WarningKind::UnusedVariable("x".to_string()),
+            Span::new(23, 24),
+        );
+
+        let output = formatter.format_warning(&warning);
+        assert!(output.contains("unused variable"));
+        assert!(output.contains("'x'"));
+    }
+
+    #[test]
+    fn test_format_warnings_with_duplicates() {
+        let source = "fn main() -> i32 {\n    let x = 1;\n    let x = 2;\n    0\n}";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = DiagnosticFormatter::new(&source_info);
+
+        let warnings = vec![
+            CompileWarning::new(
+                WarningKind::UnusedVariable("x".to_string()),
+                Span::new(23, 24),
+            ),
+            CompileWarning::new(
+                WarningKind::UnusedVariable("x".to_string()),
+                Span::new(36, 37),
+            ),
+        ];
+
+        let output = formatter.format_warnings(&warnings);
+        // Should include line numbers for disambiguation
+        assert!(output.contains("line"));
+    }
+
+    #[test]
+    fn test_format_warnings_empty() {
+        let source = "fn main() -> i32 { 42 }";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = DiagnosticFormatter::new(&source_info);
+
+        let output = formatter.format_warnings(&[]);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn test_format_error_with_help() {
+        let source = "fn main() -> i32 { x = 1; 0 }";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = DiagnosticFormatter::new(&source_info);
+
+        let error = CompileError::new(
+            ErrorKind::AssignToImmutable("x".to_string()),
+            Span::new(19, 20),
+        )
+        .with_help("consider making `x` mutable: `let mut x`");
+
+        let output = formatter.format_error(&error);
+        assert!(output.contains("help"));
+        assert!(output.contains("mutable"));
+    }
+
+    #[test]
+    fn test_format_error_with_label() {
+        let source = "fn main() -> i32 { if true { 1 } else { false } }";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = DiagnosticFormatter::new(&source_info);
+
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::new(40, 45),
+        )
+        .with_label("then branch is here", Span::new(29, 30));
+
+        let output = formatter.format_error(&error);
+        assert!(output.contains("then branch"));
+    }
+}

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -4,6 +4,25 @@
 //! Source -> Lexer -> Parser -> AstGen -> Sema -> CodeGen -> ELF
 //!
 //! It re-exports types from the component crates for convenience.
+//!
+//! # Diagnostic Formatting
+//!
+//! The [`DiagnosticFormatter`] provides a clean API for formatting errors and warnings:
+//!
+//! ```ignore
+//! use rue_compiler::{DiagnosticFormatter, SourceInfo};
+//!
+//! let source_info = SourceInfo::new(&source, "example.rue");
+//! let formatter = DiagnosticFormatter::new(&source_info);
+//!
+//! // Format an error
+//! let error_output = formatter.format_error(&error);
+//! eprintln!("{}", error_output);
+//! ```
+
+mod diagnostic;
+
+pub use diagnostic::{DiagnosticFormatter, SourceInfo};
 
 use std::io::Write;
 use std::path::PathBuf;
@@ -575,6 +594,46 @@ impl std::fmt::Display for Mir {
             Mir::X86_64(mir) => write!(f, "{}", mir),
             Mir::Aarch64(mir) => write!(f, "{}", mir),
         }
+    }
+}
+
+impl Mir {
+    /// Format MIR as assembly text.
+    ///
+    /// This prints the MIR instructions in assembly-like format.
+    /// When called with allocated MIR (post-regalloc), physical registers
+    /// are shown (rax, rbx, r12 for x86-64; x0, x1, x19 for aarch64).
+    pub fn format_assembly(&self) -> String {
+        let mut output = String::new();
+        match self {
+            Mir::X86_64(mir) => {
+                use rue_codegen::x86_64::X86Inst;
+                for inst in mir.instructions() {
+                    match inst {
+                        X86Inst::Label { id } => {
+                            output.push_str(&format!("{}:\n", id));
+                        }
+                        _ => {
+                            output.push_str(&format!("    {}\n", inst));
+                        }
+                    }
+                }
+            }
+            Mir::Aarch64(mir) => {
+                use rue_codegen::aarch64::Aarch64Inst;
+                for inst in mir.instructions() {
+                    match inst {
+                        Aarch64Inst::Label { id } => {
+                            output.push_str(&format!("{}:\n", id));
+                        }
+                        _ => {
+                            output.push_str(&format!("    {}\n", inst));
+                        }
+                    }
+                }
+            }
+        }
+        output
     }
 }
 

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -2,11 +2,9 @@ rust_binary(
     name = "rue",
     srcs = ["src/main.rs"],
     deps = [
-        "//crates/rue-codegen:rue-codegen",
         "//crates/rue-compiler:rue-compiler",
         "//crates/rue-rir:rue-rir",
         "//crates/rue-target:rue-target",
-        "//third-party:annotate-snippets",
     ],
     visibility = ["PUBLIC"],
 )

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1,13 +1,11 @@
-use std::collections::HashMap;
 use std::env;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
-use annotate_snippets::{Level, Renderer, Snippet};
 use rue_compiler::{
-    CompileError, CompileOptions, CompileWarning, Diagnostic, Lexer, LinkerMode, Mir, Parser,
-    PreviewFeature, PreviewFeatures, Span, compile_frontend_from_ast, compile_with_options,
+    CompileOptions, DiagnosticFormatter, Lexer, LinkerMode, Parser, PreviewFeature,
+    PreviewFeatures, SourceInfo, compile_frontend_from_ast, compile_with_options,
     generate_allocated_mir, generate_mir,
 };
 use rue_rir::RirPrinter;
@@ -218,10 +216,13 @@ fn main() {
         std::process::exit(1);
     });
 
+    // Create source info for diagnostic formatting
+    let source_info = SourceInfo::new(&source, &options.source_path);
+    let formatter = DiagnosticFormatter::new(&source_info);
+
     // Handle emit modes
     if !options.emit_stages.is_empty() {
-        if let Err(e) = handle_emit(&source, &options) {
-            print_error(&e, &source, &options.source_path);
+        if let Err(()) = handle_emit(&source, &options, &formatter) {
             std::process::exit(1);
         }
         return;
@@ -235,8 +236,10 @@ fn main() {
     };
     match compile_with_options(&source, &compile_options) {
         Ok(output) => {
-            // Print warnings with line numbers when needed for disambiguation
-            print_warnings(&output.warnings, &source, &options.source_path);
+            // Print warnings using the diagnostic formatter
+            if !output.warnings.is_empty() {
+                eprintln!("{}", formatter.format_warnings(&output.warnings));
+            }
 
             // Write output
             if let Err(e) = fs::write(&options.output_path, &output.elf) {
@@ -275,7 +278,7 @@ fn main() {
             );
         }
         Err(e) => {
-            print_error(&e, &source, &options.source_path);
+            eprintln!("{}", formatter.format_error(&e));
             std::process::exit(1);
         }
     }
@@ -285,7 +288,7 @@ fn main() {
 ///
 /// This uses a single-pass approach: each compilation stage is run at most once,
 /// and the results are reused for later stages.
-fn handle_emit(source: &str, options: &Options) -> Result<(), CompileError> {
+fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter) -> Result<(), ()> {
     // Determine the highest stage we need to compute
     let max_stage = options
         .emit_stages
@@ -304,7 +307,8 @@ fn handle_emit(source: &str, options: &Options) -> Result<(), CompileError> {
         match lexer.tokenize() {
             Ok(tokens) => Some(tokens),
             Err(e) => {
-                return Err(e);
+                eprintln!("{}", formatter.format_error(&e));
+                return Err(());
             }
         }
     } else {
@@ -325,7 +329,8 @@ fn handle_emit(source: &str, options: &Options) -> Result<(), CompileError> {
         match parser.parse() {
             Ok(ast) => (kept_tokens, Some(ast)),
             Err(e) => {
-                return Err(e);
+                eprintln!("{}", formatter.format_error(&e));
+                return Err(());
             }
         }
     } else {
@@ -337,7 +342,8 @@ fn handle_emit(source: &str, options: &Options) -> Result<(), CompileError> {
         match compile_frontend_from_ast(ast.clone().unwrap()) {
             Ok(state) => Some(state),
             Err(e) => {
-                return Err(e);
+                eprintln!("{}", formatter.format_error(&e));
+                return Err(());
             }
         }
     } else {
@@ -425,11 +431,11 @@ fn handle_emit(source: &str, options: &Options) -> Result<(), CompileError> {
                         ) {
                             Ok(mir) => mir,
                             Err(e) => {
-                                return Err(e);
+                                eprintln!("{}", formatter.format_error(&e));
+                                return Err(());
                             }
                         };
-                        print_assembly(&mir);
-                        println!();
+                        print!("{}", mir.format_assembly());
                     }
                 }
                 println!();
@@ -438,152 +444,4 @@ fn handle_emit(source: &str, options: &Options) -> Result<(), CompileError> {
     }
 
     Ok(())
-}
-
-/// Print assembly from MIR.
-///
-/// This prints the MIR instructions in assembly-like format.
-/// When called with allocated MIR (post-regalloc), physical registers
-/// are shown (rax, rbx, r12 for x86-64; x0, x1, x19 for aarch64).
-fn print_assembly(mir: &Mir) {
-    match mir {
-        Mir::X86_64(mir) => {
-            use rue_codegen::x86_64::X86Inst;
-            for inst in mir.instructions() {
-                match inst {
-                    X86Inst::Label { id } => println!("{}:", id),
-                    _ => println!("    {}", inst),
-                }
-            }
-        }
-        Mir::Aarch64(mir) => {
-            use rue_codegen::aarch64::Aarch64Inst;
-            for inst in mir.instructions() {
-                match inst {
-                    Aarch64Inst::Label { id } => println!("{}:", id),
-                    _ => println!("    {}", inst),
-                }
-            }
-        }
-    }
-}
-
-/// Print a diagnostic message (error or warning) to stderr.
-///
-/// This is the common implementation used by both `print_error` and `print_warning`.
-/// It handles building the annotated source snippet and rendering the full diagnostic
-/// with labels, notes, and help messages.
-fn print_diagnostic(
-    level: Level,
-    message: &str,
-    span: Option<Span>,
-    diagnostic: &Diagnostic,
-    source: &str,
-    source_path: &str,
-) {
-    let renderer = Renderer::plain();
-
-    // For diagnostics without a span, just print the message with any footers
-    let Some(span) = span else {
-        let mut report = level.title(message);
-        // Add notes and helps as footers
-        for note in &diagnostic.notes {
-            report = report.footer(Level::Note.title(note.0.as_str()));
-        }
-        for help in &diagnostic.helps {
-            report = report.footer(Level::Help.title(help.0.as_str()));
-        }
-        eprintln!("{}", renderer.render(report));
-        return;
-    };
-
-    // Build snippet with primary annotation
-    let mut snippet = Snippet::source(source)
-        .origin(source_path)
-        .fold(true)
-        .annotation(level.span(span.start as usize..span.end as usize));
-
-    // Add secondary labels as Info annotations
-    for label in &diagnostic.labels {
-        snippet = snippet.annotation(
-            Level::Info
-                .span(label.span.start as usize..label.span.end as usize)
-                .label(&label.message),
-        );
-    }
-
-    let mut report = level.title(message).snippet(snippet);
-
-    // Add notes and helps as footers
-    for note in &diagnostic.notes {
-        report = report.footer(Level::Note.title(note.0.as_str()));
-    }
-    for help in &diagnostic.helps {
-        report = report.footer(Level::Help.title(help.0.as_str()));
-    }
-
-    eprintln!("{}", renderer.render(report));
-}
-
-fn print_error(error: &CompileError, source: &str, source_path: &str) {
-    print_diagnostic(
-        Level::Error,
-        &error.to_string(),
-        error.span(),
-        error.diagnostic(),
-        source,
-        source_path,
-    );
-}
-
-/// Print all warnings, adding line numbers when multiple variables share the same name.
-///
-/// This improves error messages by disambiguating when there are multiple unused
-/// variables with the same name (e.g., shadowed variables in different scopes).
-fn print_warnings(warnings: &[CompileWarning], source: &str, source_path: &str) {
-    // Count occurrences of each unused variable name
-    let mut var_name_counts: HashMap<&str, usize> = HashMap::new();
-    for warning in warnings {
-        if let Some(name) = warning.kind.unused_variable_name() {
-            *var_name_counts.entry(name).or_insert(0) += 1;
-        }
-    }
-
-    // Print each warning, adding line number if there are duplicates
-    for warning in warnings {
-        let needs_line_number = warning
-            .kind
-            .unused_variable_name()
-            .is_some_and(|name| var_name_counts.get(name).copied().unwrap_or(0) > 1);
-
-        print_warning(warning, source, source_path, needs_line_number);
-    }
-}
-
-fn print_warning(
-    warning: &CompileWarning,
-    source: &str,
-    source_path: &str,
-    include_line_number: bool,
-) {
-    // Get the message, optionally with line number for disambiguation
-    let message = if include_line_number {
-        if let Some(span) = warning.span() {
-            let line = span.line_number(source);
-            warning.kind.format_with_line(Some(line))
-        } else {
-            warning.to_string()
-        }
-    } else {
-        warning.to_string()
-    };
-
-    print_diagnostic(
-        Level::Warning,
-        &message,
-        warning.span(),
-        warning.diagnostic(),
-        source,
-        source_path,
-    );
 }


### PR DESCRIPTION
Move diagnostic formatting logic from the CLI into rue-compiler, creating a clean API boundary for error and warning formatting. This makes the formatting reusable for future REPL, IDE, and LSP integration.

- Add DiagnosticFormatter and SourceInfo types to rue-compiler
- Add Mir::format_assembly() method for assembly text output
- Update CLI to use the new formatting API
- Move annotate-snippets dependency from rue to rue-compiler

Fixes rue-5skr

🤖 Generated with [Claude Code](https://claude.com/claude-code)