### PR TITLE
Phase 3: Drop codegen for destructors (rue-wjha.9)

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1771,17 +1771,49 @@ impl<'a> CfgLower<'a> {
                 });
             }
 
-            CfgInstData::Drop { value: _ } => {
+            CfgInstData::Drop {
+                value: dropped_value,
+            } => {
                 // Drop instruction - runs destructor if the type needs one.
                 // The CFG builder already elides Drop for trivially droppable types,
                 // so reaching here means we need to emit actual cleanup code.
                 //
-                // This will be implemented in Phase 3 (rue-wjha.9) when we add
-                // types with destructors (e.g., mutable strings).
-                debug_assert!(
-                    false,
-                    "Drop instruction reached codegen but no types currently need drop"
-                );
+                // Get the type of the value being dropped to determine which
+                // destructor function to call.
+                let dropped_ty = self.cfg.get_inst(*dropped_value).ty;
+
+                // Get the destructor function name based on type.
+                // The naming convention is __rue_drop_<TypeName>.
+                let drop_fn_name = match dropped_ty {
+                    Type::Struct(struct_id) => {
+                        // For structs, use the struct name
+                        let struct_def = &self.struct_defs[struct_id.0 as usize];
+                        format!("__rue_drop_{}", struct_def.name)
+                    }
+                    Type::String => "__rue_drop_String".to_string(),
+                    // Other types that might need drop in the future can be added here
+                    _ => {
+                        // For now, any other type reaching here is unexpected
+                        debug_assert!(
+                            false,
+                            "Drop instruction reached codegen for unexpected type: {:?}",
+                            dropped_ty
+                        );
+                        return;
+                    }
+                };
+
+                // Load the value to drop into the first argument register (X0)
+                let val_vreg = self.get_vreg(*dropped_value);
+                self.mir.push(Aarch64Inst::MovRR {
+                    dst: Operand::Physical(ARG_REGS[0]),
+                    src: Operand::Virtual(val_vreg),
+                });
+
+                // Call the drop function
+                self.mir.push(Aarch64Inst::Bl {
+                    symbol: drop_fn_name,
+                });
             }
 
             CfgInstData::StorageLive { slot: _ } => {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1892,17 +1892,49 @@ impl<'a> CfgLower<'a> {
                 });
             }
 
-            CfgInstData::Drop { value: _ } => {
+            CfgInstData::Drop {
+                value: dropped_value,
+            } => {
                 // Drop instruction - runs destructor if the type needs one.
                 // The CFG builder already elides Drop for trivially droppable types,
                 // so reaching here means we need to emit actual cleanup code.
                 //
-                // This will be implemented in Phase 3 (rue-wjha.9) when we add
-                // types with destructors (e.g., mutable strings).
-                debug_assert!(
-                    false,
-                    "Drop instruction reached codegen but no types currently need drop"
-                );
+                // Get the type of the value being dropped to determine which
+                // destructor function to call.
+                let dropped_ty = self.cfg.get_inst(*dropped_value).ty;
+
+                // Get the destructor function name based on type.
+                // The naming convention is __rue_drop_<TypeName>.
+                let drop_fn_name = match dropped_ty {
+                    Type::Struct(struct_id) => {
+                        // For structs, use the struct name
+                        let struct_def = &self.struct_defs[struct_id.0 as usize];
+                        format!("__rue_drop_{}", struct_def.name)
+                    }
+                    Type::String => "__rue_drop_String".to_string(),
+                    // Other types that might need drop in the future can be added here
+                    _ => {
+                        // For now, any other type reaching here is unexpected
+                        debug_assert!(
+                            false,
+                            "Drop instruction reached codegen for unexpected type: {:?}",
+                            dropped_ty
+                        );
+                        return;
+                    }
+                };
+
+                // Load the value to drop into the first argument register (RDI)
+                let val_vreg = self.get_vreg(*dropped_value);
+                self.mir.push(X86Inst::MovRR {
+                    dst: Operand::Physical(ARG_REGS[0]),
+                    src: Operand::Virtual(val_vreg),
+                });
+
+                // Call the drop function
+                self.mir.push(X86Inst::CallRel {
+                    symbol: drop_fn_name,
+                });
             }
 
             CfgInstData::StorageLive { slot: _ } => {

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -339,3 +339,73 @@ cfg foo (return_type: i32) {
 
 }
 """
+
+# =============================================================================
+# Code Generation Tests
+# =============================================================================
+
+# Tests for spec paragraphs 3.9:18, 3.9:19, 3.9:20
+
+[[case]]
+name = "codegen_nontrivial_drop_call"
+spec = ["3.9:18"]
+preview = "destructors"
+description = "Non-trivially droppable types generate destructor calls"
+skip = true
+source = """
+// Placeholder: will test with mutable String when available
+// Expected behavior: drop instruction generates call to __rue_drop_String
+fn main() -> i32 { 0 }
+"""
+exit_code = 0
+
+[[case]]
+name = "codegen_trivial_no_drop"
+spec = ["3.9:19", "3.9:20"]
+preview = "destructors"
+description = "Trivially droppable types do not generate drop instructions in CFG"
+source = """
+fn main() -> i32 {
+    let x: i32 = 42;
+    let y: bool = true;
+    let z = 10;
+    x + z
+}
+"""
+expected_cfg = """
+cfg main (return_type: i32) {
+  bb0:
+    v0 : () = storage_live $0
+    v1 : i32 = const 42
+    v2 : () = alloc $0 = v1
+    v3 : () = storage_live $1
+    v4 : bool = const true
+    v5 : () = alloc $1 = v4
+    v6 : () = storage_live $2
+    v7 : i32 = const 10
+    v8 : () = alloc $2 = v7
+    v9 : i32 = load $0
+    v10 : i32 = load $2
+    v11 : i32 = add v9, v10
+    v12 : () = storage_dead $2
+    v13 : () = storage_dead $1
+    v14 : () = storage_dead $0
+    return v11
+
+}
+"""
+
+[[case]]
+name = "codegen_trivial_struct_no_drop"
+spec = ["3.9:9", "3.9:19", "3.9:20"]
+preview = "destructors"
+description = "Structs with only trivially droppable fields are trivially droppable"
+source = """
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 10, y: 20 };
+    p.x + p.y
+}
+"""
+exit_code = 30

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -59,6 +59,9 @@ pub struct Case {
     /// Expected MIR dump (golden test)
     #[serde(default)]
     pub expected_mir: Option<String>,
+    /// Expected CFG dump (golden test)
+    #[serde(default)]
+    pub expected_cfg: Option<String>,
     /// Expected runtime error message (program compiles but fails at runtime)
     #[serde(default)]
     pub runtime_error: Option<String>,
@@ -245,11 +248,12 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         cmd
     };
 
-    // Check for golden IR tests (tokens, AST, RIR, AIR, MIR)
+    // Check for golden IR tests (tokens, AST, RIR, AIR, CFG, MIR)
     if case.expected_tokens.is_some()
         || case.expected_ast.is_some()
         || case.expected_rir.is_some()
         || case.expected_air.is_some()
+        || case.expected_cfg.is_some()
         || case.expected_mir.is_some()
     {
         // Run dump commands and check golden output
@@ -335,6 +339,27 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
             // Strip the "=== AIR ===" header for golden comparison
             let actual = strip_emit_header(&actual, "AIR");
             check_golden(&actual, expected, "AIR")?;
+        }
+
+        if let Some(ref expected) = case.expected_cfg {
+            let output = build_command(rue_binary)
+                .arg("--emit")
+                .arg("cfg")
+                .arg(&source_path)
+                .output()
+                .map_err(|e| format!("Failed to run rue --emit cfg: {}", e))?;
+
+            if !output.status.success() {
+                return Err(format!(
+                    "rue --emit cfg failed:\n{}",
+                    String::from_utf8_lossy(&output.stderr)
+                ));
+            }
+
+            let actual = String::from_utf8_lossy(&output.stdout);
+            // Strip the "=== CFG ===" header for golden comparison
+            let actual = strip_emit_header(&actual, "CFG");
+            check_golden(&actual, expected, "CFG")?;
         }
 
         if let Some(ref expected) = case.expected_mir {

--- a/docs/spec/src/03-types/09-destructors.md
+++ b/docs/spec/src/03-types/09-destructors.md
@@ -126,3 +126,17 @@ fn example(condition: bool) -> i32 {
     0  // c dropped, then a dropped
 }
 ```
+
+## Code Generation
+
+{{ rule(id="3.9:18", cat="dynamic-semantics") }}
+
+When a non-trivially droppable value is dropped, the compiler generates a call to the value's destructor function.
+
+{{ rule(id="3.9:19", cat="dynamic-semantics") }}
+
+When a trivially droppable value is dropped, no code is generated. The drop is elided as a no-op.
+
+{{ rule(id="3.9:20", cat="informative") }}
+
+The distinction between trivially droppable and non-trivially droppable types allows the compiler to avoid generating unnecessary cleanup code for simple types like integers and structs containing only integers.


### PR DESCRIPTION
Add code generation support for Drop instructions in both x86_64 and aarch64 backends. This completes Phase 3 of the destructors feature.

Changes:
- Add spec paragraphs 3.9:18-20 for drop code generation semantics
- Implement Drop instruction handling in x86_64 cfg_lower.rs
- Implement Drop instruction handling in aarch64 cfg_lower.rs
- Add expected_cfg support to test runner for CFG golden tests
- Add codegen tests verifying trivially droppable types elide drops

The Drop instruction now generates a call to __rue_drop_<TypeName> for non-trivially droppable types (structs with destructors, String). For trivially droppable types, the CFG builder elides the Drop entirely, so no codegen is needed.

Currently all types are trivially droppable. When mutable strings or other heap-allocated types land, they will use this infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)