### PR TITLE
Implement @copy directive for struct Copy semantics

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -115,14 +115,6 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    /// Get the number of fields for a struct type.
-    fn struct_field_count(&self, struct_id: StructId) -> u32 {
-        self.struct_defs
-            .get(struct_id.0 as usize)
-            .map(|def| def.field_count() as u32)
-            .unwrap_or(1)
-    }
-
     /// Get the length of an array type.
     fn array_length(&self, array_type_id: ArrayTypeId) -> u64 {
         debug_assert!(
@@ -1066,11 +1058,11 @@ impl<'a> CfgLower<'a> {
                         .insert(value, vec![ptr_vreg, len_vreg]);
                     self.value_map.insert(value, ptr_vreg);
                 } else if let Type::Struct(struct_id) = load_type {
-                    // Struct: load all field slots
-                    let field_count = self.struct_field_count(struct_id);
-                    let mut slot_vregs = Vec::with_capacity(field_count as usize);
+                    // Struct: load all field slots (recursively flattened)
+                    let slot_count = self.type_slot_count(Type::Struct(struct_id));
+                    let mut slot_vregs = Vec::with_capacity(slot_count as usize);
 
-                    for i in 0..field_count {
+                    for i in 0..slot_count {
                         let field_vreg = self.mir.alloc_vreg();
                         let field_offset = self.local_offset(slot + i);
                         self.mir.push(Aarch64Inst::Ldr {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -103,14 +103,6 @@ impl<'a> CfgLower<'a> {
         }
     }
 
-    /// Get the number of fields for a struct type.
-    fn struct_field_count(&self, struct_id: StructId) -> u32 {
-        self.struct_defs
-            .get(struct_id.0 as usize)
-            .map(|def| def.field_count() as u32)
-            .unwrap_or(1)
-    }
-
     /// Get the length of an array type.
     fn array_length(&self, array_type_id: ArrayTypeId) -> u64 {
         debug_assert!(
@@ -1173,11 +1165,11 @@ impl<'a> CfgLower<'a> {
                         .insert(value, vec![ptr_vreg, len_vreg]);
                     self.value_map.insert(value, ptr_vreg);
                 } else if let Type::Struct(struct_id) = load_type {
-                    // Struct: load all field slots
-                    let field_count = self.struct_field_count(struct_id);
-                    let mut slot_vregs = Vec::with_capacity(field_count as usize);
+                    // Struct: load all field slots (recursively flattened)
+                    let slot_count = self.type_slot_count(Type::Struct(struct_id));
+                    let mut slot_vregs = Vec::with_capacity(slot_count as usize);
 
-                    for i in 0..field_count {
+                    for i in 0..slot_count {
                         let field_vreg = self.mir.alloc_vreg();
                         let field_offset = self.local_offset(slot + i);
                         self.mir.push(X86Inst::MovRM {

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -155,7 +155,7 @@ where
         .collect()
 }
 
-/// Parser for a single directive: @name(arg1, arg2, ...)
+/// Parser for a single directive: @name or @name(arg1, arg2, ...)
 fn directive_parser<'src, I>()
 -> impl Parser<'src, I, Directive, extra::Err<Rich<'src, TokenKind>>> + Clone
 where
@@ -169,11 +169,12 @@ where
                 .separated_by(just(TokenKind::Comma))
                 .allow_trailing()
                 .collect::<Vec<_>>()
-                .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
+                .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen))
+                .or_not(),
         )
         .map_with(|(name, args), e| Directive {
             name,
-            args,
+            args: args.unwrap_or_default(),
             span: to_rue_span(e.span()),
         })
 }

--- a/crates/rue-spec/cases/lexical/builtins.toml
+++ b/crates/rue-spec/cases/lexical/builtins.toml
@@ -228,7 +228,6 @@ no_warnings = true
 name = "copy_directive_on_struct"
 spec = ["2.5:27", "2.5:28"]
 description = "@copy directive marks a struct as Copy type"
-preview = "affine-mvs"
 source = """
 @copy
 struct Point { x: i32, y: i32 }
@@ -245,7 +244,6 @@ exit_code = 2
 name = "copy_directive_no_args"
 spec = ["2.5:29"]
 description = "@copy takes no arguments"
-preview = "affine-mvs"
 source = """
 @copy
 struct Point { x: i32, y: i32 }

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -416,7 +416,6 @@ error_contains = "use of moved value"
 name = "copy_struct_multiple_uses"
 spec = ["3.8:14", "3.8:15", "3.8:16", "3.8:17"]
 description = "@copy struct can be used multiple times without moving"
-preview = "affine-mvs"
 source = """
 @copy
 struct Point { x: i32, y: i32 }
@@ -433,7 +432,6 @@ exit_code = 3
 name = "copy_struct_pass_to_function"
 spec = ["3.8:16"]
 description = "@copy struct can be passed to function and still used"
-preview = "affine-mvs"
 source = """
 @copy
 struct Point { x: i32, y: i32 }
@@ -451,7 +449,6 @@ exit_code = 60
 name = "copy_struct_all_primitive_fields"
 spec = ["3.8:20"]
 description = "@copy struct with all primitive Copy fields"
-preview = "affine-mvs"
 source = """
 @copy
 struct Data { a: i32, b: bool, c: i64 }
@@ -468,7 +465,6 @@ exit_code = 43
 name = "copy_struct_nested_copy"
 spec = ["3.8:20", "3.8:21"]
 description = "@copy struct containing other @copy structs"
-preview = "affine-mvs"
 source = """
 @copy
 struct Point { x: i32, y: i32 }
@@ -488,10 +484,31 @@ fn main() -> i32 {
 exit_code = 10
 
 [[case]]
+name = "copy_struct_deeply_nested"
+spec = ["3.8:20", "3.8:21"]
+description = "@copy struct with 3+ levels of nesting"
+source = """
+@copy
+struct Level0 { value: i32 }
+
+@copy
+struct Level1 { inner: Level0, x: i32 }
+
+@copy
+struct Level2 { inner: Level1, y: i32 }
+
+fn main() -> i32 {
+    let l = Level2 { inner: Level1 { inner: Level0 { value: 1 }, x: 2 }, y: 3 };
+    let l2 = l;
+    l.inner.inner.value + l2.inner.x + l.y
+}
+"""
+exit_code = 6
+
+[[case]]
 name = "copy_struct_non_copy_field_error"
 spec = ["3.8:18", "3.8:19"]
 description = "@copy struct with non-Copy field is a compile error"
-preview = "affine-mvs"
 source = """
 struct Inner { value: i32 }
 
@@ -507,7 +524,6 @@ error_contains = "non-Copy type"
 name = "copy_struct_enum_field"
 spec = ["3.8:20"]
 description = "@copy struct with enum field (enums are Copy)"
-preview = "affine-mvs"
 source = """
 enum Status { Active, Inactive }
 
@@ -529,7 +545,6 @@ exit_code = 20
 name = "non_copy_struct_still_moves"
 spec = ["3.8:3"]
 description = "Struct without @copy still has move semantics"
-preview = "affine-mvs"
 source = """
 struct Point { x: i32, y: i32 }
 fn main() -> i32 {


### PR DESCRIPTION
Fix the parser to allow directives without arguments (e.g., @copy instead of requiring @copy()). This enables the @copy directive syntax per spec.

Fix a codegen bug where struct-to-struct assignment incorrectly used struct_field_count() (direct fields only) instead of type_slot_count() (recursively flattened slots). This caused nested struct copies to only copy the first N fields instead of all flattened slots.

Remove the now-unused struct_field_count() helper from both backends.

Closes rue-dfr8.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)