### PR TITLE
Document block item parsing strategy

### DIFF
--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -986,48 +986,125 @@ fn is_diverging_expr(e: &Expr) -> bool {
     )
 }
 
-/// Parser for a single block item (statement or expression).
-/// Parses: let statements, assignment statements, expression with semicolon,
-/// or control flow without semicolon (but NOT followed by }).
+/// Parses a single item within a block.
+///
+/// # Block Item Grammar
+///
+/// A block contains zero or more items. Each item is one of:
+/// - **Let statement**: `let x = expr;` (always requires semicolon)
+/// - **Assignment statement**: `target = expr;` (always requires semicolon)
+/// - **Expression statement**: `expr;` (requires semicolon for most expressions)
+/// - **Control flow statement**: `if/while/match/loop/break/continue/return ...`
+///   (no semicolon needed when mid-block)
+/// - **Final expression**: `expr` at the very end of a block (no semicolon, becomes
+///   the block's return value)
+///
+/// # Parsing Strategy: Lookahead with `rewind()`
+///
+/// The challenge is distinguishing between:
+/// 1. `{ foo; bar }` - `foo;` is a statement, `bar` is the final expression
+/// 2. `{ if c { 1 } else { 2 } x }` - the `if` is a statement, `x` is final
+/// 3. `{ if c { 1 } else { 2 } }` - the `if` IS the final expression
+///
+/// We use `rewind()` as a non-consuming lookahead to peek at what follows:
+///
+/// - `none_of([RBrace, Semi]).rewind()`: Succeeds if the NEXT token is neither
+///   `}` nor `;`. The `.rewind()` means we check without consuming the token.
+///   This identifies control flow in the middle of a block.
+///
+/// - `just(RBrace).rewind()`: Succeeds if the NEXT token is `}`. This identifies
+///   the final expression of a block.
+///
+/// # Why `try_map()` for Control Flow?
+///
+/// After parsing an expression followed by a non-`}` non-`;` token, we need to
+/// validate it's actually a control flow expression. If it's something like `x`
+/// followed by `y`, that's a syntax error (missing semicolon). We use `try_map()`
+/// to:
+/// 1. Accept the parse if it's a control flow expression (valid without semicolon)
+/// 2. Reject it otherwise, allowing chumsky to backtrack and try other branches
+///
+/// # Parse Order Matters
+///
+/// The `choice()` tries parsers in order. We must try:
+/// 1. `let_stmt` first (starts with `let` keyword)
+/// 2. `assign_stmt` second (identifier followed by `.`/`[` chain then `=`)
+/// 3. `expr_with_semi` (any expression followed by `;`)
+/// 4. `control_flow_stmt` (control flow NOT followed by `}` - mid-block)
+/// 5. `final_expr` (any expression followed by `}` - end of block)
+///
+/// The assignment parser is tried before general expressions because `x = 5;`
+/// could otherwise be misparsed as expression `x` followed by unexpected `=`.
 fn block_item_parser<'src, I>(
     expr: impl Parser<'src, I, Expr, extra::Err<Rich<'src, TokenKind>>> + Clone + 'src,
 ) -> impl Parser<'src, I, BlockItem, extra::Err<Rich<'src, TokenKind>>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    // Let statement (always needs semicolon)
+    // Let statement: `let x: T = expr;`
+    // Always requires a trailing semicolon.
     let let_stmt = let_statement_parser(expr.clone()).map(BlockItem::Statement);
 
-    // Assignment statement (always needs semicolon)
+    // Assignment statement: `target = expr;`
+    // Target can be: variable (`x`), field (`a.b.c`), or index (`a[i]`).
+    // Always requires a trailing semicolon.
     let assign_stmt = assign_statement_parser(expr.clone()).map(BlockItem::Statement);
 
-    // Expression with semicolon -> statement
+    // Expression followed by semicolon: `expr;`
+    // This makes any expression into a statement (its value is discarded).
     let expr_with_semi = expr
         .clone()
         .then_ignore(just(TokenKind::Semi))
         .map(|e| BlockItem::Statement(Statement::Expr(e)));
 
-    // Control flow expression without semicolon, but NOT at end of block
-    // We check that it's followed by something other than RBrace
-    // This is a statement (no semicolon needed for control flow)
+    // Control flow expression in the MIDDLE of a block (not at the end).
+    //
+    // These expressions don't need semicolons: if, while, match, loop,
+    // break, continue, return.
+    //
+    // How it works:
+    // 1. Parse an expression
+    // 2. Lookahead: verify next token is NOT `}` and NOT `;`
+    //    (If it were `}`, this would be the final expr; if `;`, use expr_with_semi)
+    // 3. Validate via try_map: only control flow expressions are valid here
+    //
+    // The `rewind()` is crucial: it checks the next token WITHOUT consuming it,
+    // so whatever follows (like the next statement) remains available.
     let control_flow_stmt = expr
         .clone()
         .then_ignore(none_of([TokenKind::RBrace, TokenKind::Semi]).rewind())
         .try_map(|e, span| {
             if is_control_flow_expr(&e) {
+                // Valid: control flow doesn't need semicolon mid-block
                 Ok(BlockItem::Statement(Statement::Expr(e)))
             } else {
-                // Not control flow and no semicolon - this is an error
-                // but let's try the final expr path
+                // Invalid: non-control-flow expression without semicolon mid-block
+                // Reject this parse so chumsky can try other alternatives or report error
                 Err(Rich::custom(span, "expected semicolon after expression"))
             }
         });
 
-    // Expression at end of block (followed by }) -> final expression
+    // Final expression: the last item in a block, providing the block's value.
+    //
+    // How it works:
+    // 1. Parse an expression
+    // 2. Lookahead: verify next token IS `}`
+    //    (The `rewind()` ensures we don't consume the `}`, which the block parser needs)
+    //
+    // Examples:
+    // - `{ 42 }` - `42` is the final expression, block evaluates to 42
+    // - `{ x; y }` - `y` is the final expression
+    // - `{ if c { a } else { b } }` - the entire `if` is the final expression
     let final_expr = expr
         .then_ignore(just(TokenKind::RBrace).rewind())
         .map(BlockItem::Expr);
 
+    // Try parsers in order. Earlier parsers take precedence.
+    // This order ensures:
+    // - Keywords (`let`) are matched before being parsed as identifiers
+    // - Assignments (`x = 5;`) are matched before `x` is parsed as an expression
+    // - Semicolon-terminated expressions are matched before semicolon-free variants
+    // - Mid-block control flow is matched before final expressions
     choice((
         let_stmt,
         assign_stmt,


### PR DESCRIPTION
Add comprehensive documentation to block_item_parser explaining:
- The grammar of block items (statements vs final expression)
- Why rewind() is used for non-consuming lookahead
- Why try_map() validates control flow expressions
- The significance of parser ordering in choice()

Fixes rue-odq9

🤖 Generated with [Claude Code](https://claude.com/claude-code)