### PR TITLE
Implement Phase 1: Optimization framework (rue-aapc.1)

### DIFF
--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -18,11 +18,13 @@
 
 mod build;
 mod inst;
+pub mod opt;
 
 use rue_error::CompileWarning;
 
 pub use build::CfgBuilder;
 pub use inst::{BasicBlock, BlockId, Cfg, CfgCallArg, CfgInst, CfgInstData, CfgValue, Terminator};
+pub use opt::OptLevel;
 
 // Re-export types from rue-air that we use
 pub use rue_air::{StructDef, StructId, Type};

--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -1,0 +1,180 @@
+//! CFG optimization passes.
+//!
+//! This module provides optimization passes that transform CFG -> CFG,
+//! improving code quality without changing program semantics.
+//!
+//! ## Optimization Levels
+//!
+//! Rue follows standard compiler conventions for optimization levels:
+//!
+//! - `-O0`: No optimization (default)
+//! - `-O1`: Basic optimizations (constant folding, dead code elimination)
+//! - `-O2`: Standard optimizations (same as -O1 for now)
+//! - `-O3`: Aggressive optimizations (same as -O2 for now)
+//!
+//! ## Pipeline
+//!
+//! Optimizations run after CFG construction and before lowering to MIR:
+//!
+//! ```text
+//! AIR -> CfgBuilder -> CFG -> [optimize] -> CfgLower -> MIR
+//! ```
+
+use crate::Cfg;
+
+/// Optimization level, following standard compiler conventions.
+///
+/// Controls which optimization passes are run during compilation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OptLevel {
+    /// No optimization (`-O0`).
+    ///
+    /// Produces unoptimized code that closely matches the source structure.
+    /// Useful for debugging and faster compilation.
+    #[default]
+    O0,
+
+    /// Basic optimizations (`-O1`).
+    ///
+    /// Enables fundamental optimizations:
+    /// - Constant folding
+    /// - Dead code elimination
+    O1,
+
+    /// Standard optimizations (`-O2`).
+    ///
+    /// Currently the same as O1. Future optimization passes will be
+    /// added at this level.
+    O2,
+
+    /// Aggressive optimizations (`-O3`).
+    ///
+    /// Currently the same as O2. Future aggressive optimizations
+    /// (that may increase compile time significantly) will be added here.
+    O3,
+}
+
+impl OptLevel {
+    /// Returns the name of this optimization level (e.g., "O0", "O1").
+    pub fn name(&self) -> &'static str {
+        match self {
+            OptLevel::O0 => "O0",
+            OptLevel::O1 => "O1",
+            OptLevel::O2 => "O2",
+            OptLevel::O3 => "O3",
+        }
+    }
+
+    /// Returns all available optimization levels.
+    pub fn all() -> &'static [OptLevel] {
+        &[OptLevel::O0, OptLevel::O1, OptLevel::O2, OptLevel::O3]
+    }
+
+    /// Returns a comma-separated string of all level names (for help text).
+    pub fn all_names() -> &'static str {
+        "-O0, -O1, -O2, -O3"
+    }
+}
+
+/// Error returned when parsing an optimization level fails.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseOptLevelError(String);
+
+impl std::fmt::Display for ParseOptLevelError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "unknown optimization level '{}'", self.0)
+    }
+}
+
+impl std::error::Error for ParseOptLevelError {}
+
+impl std::str::FromStr for OptLevel {
+    type Err = ParseOptLevelError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "O0" | "0" => Ok(OptLevel::O0),
+            "O1" | "1" => Ok(OptLevel::O1),
+            "O2" | "2" => Ok(OptLevel::O2),
+            "O3" | "3" => Ok(OptLevel::O3),
+            _ => Err(ParseOptLevelError(s.to_string())),
+        }
+    }
+}
+
+impl std::fmt::Display for OptLevel {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "-{}", self.name())
+    }
+}
+
+/// Run optimization passes on a CFG at the given level.
+///
+/// This is the main entry point for CFG optimization. It runs the
+/// appropriate passes based on the optimization level.
+///
+/// # Arguments
+///
+/// * `cfg` - The control flow graph to optimize (modified in place)
+/// * `level` - The optimization level to use
+///
+/// # Example
+///
+/// ```ignore
+/// let mut cfg = CfgBuilder::build(...);
+/// optimize(&mut cfg, OptLevel::O1);
+/// // cfg is now optimized
+/// ```
+pub fn optimize(cfg: &mut Cfg, level: OptLevel) {
+    match level {
+        OptLevel::O0 => {
+            // No optimization
+        }
+        OptLevel::O1 | OptLevel::O2 | OptLevel::O3 => {
+            // TODO: Add constant folding (Phase 2)
+            // constfold::run(cfg);
+
+            // TODO: Add dead code elimination (Phase 3)
+            // dce::run(cfg);
+
+            // For now, this is a no-op until we implement the passes
+            let _ = cfg;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_opt_level_from_str() {
+        assert_eq!("O0".parse::<OptLevel>().unwrap(), OptLevel::O0);
+        assert_eq!("O1".parse::<OptLevel>().unwrap(), OptLevel::O1);
+        assert_eq!("O2".parse::<OptLevel>().unwrap(), OptLevel::O2);
+        assert_eq!("O3".parse::<OptLevel>().unwrap(), OptLevel::O3);
+
+        // Also accept just the number
+        assert_eq!("0".parse::<OptLevel>().unwrap(), OptLevel::O0);
+        assert_eq!("1".parse::<OptLevel>().unwrap(), OptLevel::O1);
+        assert_eq!("2".parse::<OptLevel>().unwrap(), OptLevel::O2);
+        assert_eq!("3".parse::<OptLevel>().unwrap(), OptLevel::O3);
+
+        // Invalid
+        assert!("O4".parse::<OptLevel>().is_err());
+        assert!("fast".parse::<OptLevel>().is_err());
+    }
+
+    #[test]
+    fn test_opt_level_display() {
+        assert_eq!(format!("{}", OptLevel::O0), "-O0");
+        assert_eq!(format!("{}", OptLevel::O1), "-O1");
+        assert_eq!(format!("{}", OptLevel::O2), "-O2");
+        assert_eq!(format!("{}", OptLevel::O3), "-O3");
+    }
+
+    #[test]
+    fn test_opt_level_default() {
+        assert_eq!(OptLevel::default(), OptLevel::O0);
+    }
+}

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -153,7 +153,7 @@ pub fn validate_runtime() -> Result<(), String> {
 
 // Re-export commonly used types
 pub use rue_air::{Air, AnalyzedFunction, ArrayTypeDef, Sema, SemaOutput, StructDef, Type};
-pub use rue_cfg::{Cfg, CfgBuilder, CfgOutput};
+pub use rue_cfg::{Cfg, CfgBuilder, CfgOutput, OptLevel};
 pub use rue_codegen::{RelocationKind, X86Mir, aarch64::Aarch64Mir};
 pub use rue_error::{
     CompileError, CompileResult, CompileWarning, Diagnostic, ErrorKind, PreviewFeature,
@@ -187,7 +187,7 @@ impl Default for LinkerMode {
 
 /// Configuration options for compilation.
 ///
-/// Controls target architecture, linker selection, and feature flags.
+/// Controls target architecture, linker selection, optimization level, and feature flags.
 ///
 /// # Example
 ///
@@ -195,6 +195,7 @@ impl Default for LinkerMode {
 /// let options = CompileOptions {
 ///     target: Target::host(),
 ///     linker: LinkerMode::Internal,
+///     opt_level: OptLevel::O1,
 ///     preview_features: PreviewFeatures::new(),
 /// };
 /// let output = compile_with_options(source, &options)?;
@@ -205,6 +206,8 @@ pub struct CompileOptions {
     pub target: Target,
     /// Which linker to use.
     pub linker: LinkerMode,
+    /// Optimization level.
+    pub opt_level: OptLevel,
     /// Enabled preview features.
     pub preview_features: PreviewFeatures,
 }
@@ -214,6 +217,7 @@ impl Default for CompileOptions {
         Self {
             target: Target::host(),
             linker: LinkerMode::Internal,
+            opt_level: OptLevel::default(),
             preview_features: PreviewFeatures::new(),
         }
     }
@@ -268,7 +272,21 @@ pub struct CompileOutput {
 ///
 /// This runs: lexing → parsing → AST to RIR → semantic analysis → CFG construction.
 /// Returns the compile state which can be inspected for debugging.
+///
+/// Uses default optimization level (O0). For custom optimization, use
+/// [`compile_frontend_with_options`].
 pub fn compile_frontend(source: &str) -> CompileResult<CompileState> {
+    compile_frontend_with_options(source, OptLevel::default())
+}
+
+/// Compile source code through all frontend phases with optimization.
+///
+/// This runs: lexing → parsing → AST to RIR → semantic analysis → CFG construction → optimization.
+/// Returns the compile state which can be inspected for debugging.
+pub fn compile_frontend_with_options(
+    source: &str,
+    opt_level: OptLevel,
+) -> CompileResult<CompileState> {
     // Lexing
     let mut lexer = Lexer::new(source);
     let tokens = lexer.tokenize()?;
@@ -277,7 +295,7 @@ pub fn compile_frontend(source: &str) -> CompileResult<CompileState> {
     let mut parser = Parser::new(tokens);
     let ast = parser.parse()?;
 
-    compile_frontend_from_ast(ast)
+    compile_frontend_from_ast_with_options(ast, opt_level)
 }
 
 /// Compile from an already-parsed AST through all remaining frontend phases.
@@ -285,7 +303,22 @@ pub fn compile_frontend(source: &str) -> CompileResult<CompileState> {
 /// This runs: AST to RIR → semantic analysis → CFG construction.
 /// Use this when you already have a parsed AST (e.g., for `--emit` modes that
 /// need both AST output and later stage output without double-parsing).
+///
+/// Uses default optimization level (O0). For custom optimization, use
+/// [`compile_frontend_from_ast_with_options`].
 pub fn compile_frontend_from_ast(ast: Ast) -> CompileResult<CompileState> {
+    compile_frontend_from_ast_with_options(ast, OptLevel::default())
+}
+
+/// Compile from an already-parsed AST through all remaining frontend phases with optimization.
+///
+/// This runs: AST to RIR → semantic analysis → CFG construction → optimization.
+/// Use this when you already have a parsed AST (e.g., for `--emit` modes that
+/// need both AST output and later stage output without double-parsing).
+pub fn compile_frontend_from_ast_with_options(
+    ast: Ast,
+    opt_level: OptLevel,
+) -> CompileResult<CompileState> {
     // AST to RIR (untyped IR)
     let mut interner = Interner::new();
     let astgen = AstGen::new(&ast, &mut interner);
@@ -310,9 +343,14 @@ pub fn compile_frontend_from_ast(ast: Ast) -> CompileResult<CompileState> {
             func.param_modes.clone(),
         );
         warnings.extend(cfg_output.warnings);
+
+        // Apply optimizations to the CFG
+        let mut cfg = cfg_output.cfg;
+        rue_cfg::opt::optimize(&mut cfg, opt_level);
+
         functions.push(FunctionWithCfg {
             analyzed: func,
-            cfg: cfg_output.cfg,
+            cfg,
         });
     }
 
@@ -338,12 +376,12 @@ pub fn compile(source: &str) -> CompileResult<CompileOutput> {
 
 /// Compile source code to an ELF binary with the given options.
 ///
-/// This allows specifying the target architecture and other compilation options.
+/// This allows specifying the target architecture, optimization level, and other compilation options.
 pub fn compile_with_options(
     source: &str,
     options: &CompileOptions,
 ) -> CompileResult<CompileOutput> {
-    let state = compile_frontend(source)?;
+    let state = compile_frontend_with_options(source, options.opt_level)?;
 
     // Check for main function
     let _main_fn = state

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -97,6 +97,11 @@ pub struct Case {
     /// Required for MIR golden tests; optional for other test types.
     #[serde(default)]
     pub target: Option<String>,
+    /// Optimization level (0, 1, 2, or 3).
+    /// When specified, the compiler is invoked with `-O<level>`.
+    /// Defaults to 0 (no optimization) if not specified.
+    #[serde(default)]
+    pub opt_level: Option<u8>,
 }
 
 /// A test file containing a section and its cases.
@@ -236,7 +241,7 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         .write_all(case.source.as_bytes())
         .map_err(|e| format!("Failed to write source: {}", e))?;
 
-    // Build base command with target and preview flags if needed
+    // Build base command with target, preview, and optimization flags if needed
     let build_command = |binary: &Path| -> Command {
         let mut cmd = Command::new(binary);
         if let Some(ref target) = case.target {
@@ -244,6 +249,9 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         }
         if let Some(ref feature) = case.preview {
             cmd.arg("--preview").arg(feature);
+        }
+        if let Some(level) = case.opt_level {
+            cmd.arg(format!("-O{}", level));
         }
         cmd
     };

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -4,8 +4,8 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 
 use rue_compiler::{
-    CompileOptions, DiagnosticFormatter, Lexer, LinkerMode, Parser, PreviewFeature,
-    PreviewFeatures, SourceInfo, compile_frontend_from_ast, compile_with_options,
+    CompileOptions, DiagnosticFormatter, Lexer, LinkerMode, OptLevel, Parser, PreviewFeature,
+    PreviewFeatures, SourceInfo, compile_frontend_from_ast_with_options, compile_with_options,
     generate_allocated_mir, generate_mir,
 };
 use rue_rir::RirPrinter;
@@ -71,6 +71,7 @@ struct Options {
     emit_stages: Vec<EmitStage>,
     target: Target,
     linker: LinkerMode,
+    opt_level: OptLevel,
     preview_features: PreviewFeatures,
 }
 
@@ -83,6 +84,8 @@ fn print_usage() {
     eprintln!("  --linker <linker>    Set linker to use (default: internal)");
     eprintln!("                       Use 'internal' for built-in linker, or a command");
     eprintln!("                       like 'clang', 'gcc', or 'ld' for system linker");
+    eprintln!("  -O<level>            Set optimization level (default: -O0)");
+    eprintln!("                       Levels: {}", OptLevel::all_names());
     eprintln!("  --emit <stage>       Emit intermediate representation and exit");
     eprintln!("                       Can be specified multiple times for multiple outputs");
     eprintln!("                       Stages: tokens, ast, rir, air, cfg, mir, asm");
@@ -105,6 +108,7 @@ fn parse_args() -> Option<Options> {
     let mut emit_stages = Vec::new();
     let mut target: Option<Target> = None;
     let mut linker: Option<LinkerMode> = None;
+    let mut opt_level: Option<OptLevel> = None;
     let mut preview_features = PreviewFeatures::new();
     let mut positional = Vec::new();
     let mut args_iter = args.iter().peekable();
@@ -173,6 +177,18 @@ fn parse_args() -> Option<Options> {
                 print_usage();
                 return None;
             }
+            _ if arg.starts_with("-O") => {
+                // Parse -O0, -O1, -O2, -O3
+                let level_str = &arg[2..];
+                match level_str.parse::<OptLevel>() {
+                    Ok(level) => opt_level = Some(level),
+                    Err(e) => {
+                        eprintln!("Error: {}", e);
+                        eprintln!("Valid levels: {}", OptLevel::all_names());
+                        return None;
+                    }
+                }
+            }
             _ if arg.starts_with('-') => {
                 eprintln!("Unknown option: {}", arg);
                 print_usage();
@@ -200,6 +216,7 @@ fn parse_args() -> Option<Options> {
         emit_stages,
         target: target.unwrap_or_else(Target::host),
         linker: linker.unwrap_or_default(),
+        opt_level: opt_level.unwrap_or_default(),
         preview_features,
     })
 }
@@ -232,6 +249,7 @@ fn main() {
     let compile_options = CompileOptions {
         target: options.target,
         linker: options.linker.clone(),
+        opt_level: options.opt_level,
         preview_features: options.preview_features.clone(),
     };
     match compile_with_options(&source, &compile_options) {
@@ -338,8 +356,9 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
     };
 
     // Stage 2: Full frontend (RIR, AIR, CFG) - reuses the already-parsed AST
+    // Applies optimization based on the -O level
     let frontend_state = if max_stage >= 2 {
-        match compile_frontend_from_ast(ast.clone().unwrap()) {
+        match compile_frontend_from_ast_with_options(ast.clone().unwrap(), options.opt_level) {
             Ok(state) => Some(state),
             Err(e) => {
                 eprintln!("{}", formatter.format_error(&e));

--- a/docs/designs/0012-optimization-passes.md
+++ b/docs/designs/0012-optimization-passes.md
@@ -246,7 +246,7 @@ CFG optimization is target-independent - it operates on typed CFG instructions b
 
 ## Implementation Phases
 
-- [ ] **Phase 1: Optimization framework** - rue-aapc.1
+- [x] **Phase 1: Optimization framework** - rue-aapc.1
   - Create `rue-cfg/src/opt/mod.rs` with `OptLevel` enum and pass orchestration
   - Add `-O0` through `-O3` flags to CLI
   - Add UI test infrastructure with `opt_level` support


### PR DESCRIPTION
Add the foundational optimization infrastructure to the Rue compiler:

- Create rue-cfg/src/opt/mod.rs with OptLevel enum (O0, O1, O2, O3)
- Add -O0 through -O3 CLI flags to the rue binary
- Add opt_level field to CompileOptions
- Add compile_frontend_with_options() and compile_frontend_from_ast_with_options() functions that accept an optimization level
- Wire up optimization in the compilation pipeline (after CFG build, before MIR)
- Add opt_level field to test runner Case struct for testing optimization

The optimize() function is currently a no-op skeleton - actual optimization passes (constant folding, dead code elimination) will be added in subsequent phases.

Part of: ADR-0012 (Compiler Optimization Passes)
Closes: rue-aapc.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)