### PR TITLE
Add alloc_dst! macro to reduce regalloc boilerplate

### DIFF
--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -7,6 +7,7 @@ use rue_error::{CompileError, CompileResult, ErrorKind};
 
 use super::liveness::{self, LivenessInfo};
 use super::mir::{Aarch64Inst, Aarch64Mir, Operand, Reg, VReg};
+use crate::alloc_dst;
 use crate::index_map::IndexMap;
 use crate::regalloc::{Allocation, linear_scan};
 
@@ -117,29 +118,18 @@ impl RegAlloc {
     fn rewrite_inst(&self, mir: &mut Aarch64Mir, inst: Aarch64Inst) -> CompileResult<()> {
         match inst {
             Aarch64Inst::MovImm { dst, imm } => {
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(Aarch64Inst::MovImm {
-                            dst: Operand::Physical(reg),
-                            imm,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        // Use X9 as scratch
-                        mir.push(Aarch64Inst::MovImm {
-                            dst: Operand::Physical(Reg::X9),
-                            imm,
-                        });
+                alloc_dst!(self.get_allocation(dst), dst, Reg::X9 =>
+                    emit |dst_op| {
+                        mir.push(Aarch64Inst::MovImm { dst: dst_op, imm });
+                    },
+                    store |offset| {
                         mir.push(Aarch64Inst::Str {
                             src: Operand::Physical(Reg::X9),
                             base: Reg::Fp,
                             offset,
                         });
-                    }
-                    None => {
-                        mir.push(Aarch64Inst::MovImm { dst, imm });
-                    }
-                }
+                    },
+                );
             }
 
             Aarch64Inst::MovRR { dst, src } => {
@@ -172,30 +162,20 @@ impl RegAlloc {
                 }
             }
 
-            Aarch64Inst::Ldr { dst, base, offset } => match self.get_allocation(dst) {
-                Some(Allocation::Register(reg)) => {
-                    mir.push(Aarch64Inst::Ldr {
-                        dst: Operand::Physical(reg),
-                        base,
-                        offset,
-                    });
-                }
-                Some(Allocation::Spill(spill_offset)) => {
-                    mir.push(Aarch64Inst::Ldr {
-                        dst: Operand::Physical(Reg::X9),
-                        base,
-                        offset,
-                    });
-                    mir.push(Aarch64Inst::Str {
-                        src: Operand::Physical(Reg::X9),
-                        base: Reg::Fp,
-                        offset: spill_offset,
-                    });
-                }
-                None => {
-                    mir.push(Aarch64Inst::Ldr { dst, base, offset });
-                }
-            },
+            Aarch64Inst::Ldr { dst, base, offset } => {
+                alloc_dst!(self.get_allocation(dst), dst, Reg::X9 =>
+                    emit |dst_op| {
+                        mir.push(Aarch64Inst::Ldr { dst: dst_op, base, offset });
+                    },
+                    store |spill_offset| {
+                        mir.push(Aarch64Inst::Str {
+                            src: Operand::Physical(Reg::X9),
+                            base: Reg::Fp,
+                            offset: spill_offset,
+                        });
+                    },
+                );
+            }
 
             Aarch64Inst::Str { src, base, offset } => {
                 let src_op = self.load_operand(mir, src, Reg::X9)?;
@@ -345,37 +325,23 @@ impl RegAlloc {
                 let src1_op = self.load_operand(mir, src1, Reg::X10)?;
                 let src2_op = self.load_operand(mir, src2, Reg::X11)?;
                 let src3_op = self.load_operand(mir, src3, Reg::X12)?;
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
+                alloc_dst!(self.get_allocation(dst), dst, Reg::X9 =>
+                    emit |dst_op| {
                         mir.push(Aarch64Inst::Msub {
-                            dst: Operand::Physical(reg),
+                            dst: dst_op,
                             src1: src1_op,
                             src2: src2_op,
                             src3: src3_op,
                         });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(Aarch64Inst::Msub {
-                            dst: Operand::Physical(Reg::X9),
-                            src1: src1_op,
-                            src2: src2_op,
-                            src3: src3_op,
-                        });
+                    },
+                    store |offset| {
                         mir.push(Aarch64Inst::Str {
                             src: Operand::Physical(Reg::X9),
                             base: Reg::Fp,
                             offset,
                         });
-                    }
-                    None => {
-                        mir.push(Aarch64Inst::Msub {
-                            dst,
-                            src1: src1_op,
-                            src2: src2_op,
-                            src3: src3_op,
-                        });
-                    }
-                }
+                    },
+                );
             }
 
             Aarch64Inst::Neg { dst, src } => {
@@ -416,34 +382,18 @@ impl RegAlloc {
 
             Aarch64Inst::EorImm { dst, src, imm } => {
                 let src_op = self.load_operand(mir, src, Reg::X10)?;
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(Aarch64Inst::EorImm {
-                            dst: Operand::Physical(reg),
-                            src: src_op,
-                            imm,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(Aarch64Inst::EorImm {
-                            dst: Operand::Physical(Reg::X9),
-                            src: src_op,
-                            imm,
-                        });
+                alloc_dst!(self.get_allocation(dst), dst, Reg::X9 =>
+                    emit |dst_op| {
+                        mir.push(Aarch64Inst::EorImm { dst: dst_op, src: src_op, imm });
+                    },
+                    store |offset| {
                         mir.push(Aarch64Inst::Str {
                             src: Operand::Physical(Reg::X9),
                             base: Reg::Fp,
                             offset,
                         });
-                    }
-                    None => {
-                        mir.push(Aarch64Inst::EorImm {
-                            dst,
-                            src: src_op,
-                            imm,
-                        });
-                    }
-                }
+                    },
+                );
             }
 
             Aarch64Inst::MvnRR { dst, src } => {
@@ -531,28 +481,20 @@ impl RegAlloc {
                 mir.push(Aarch64Inst::Cbnz { src: src_op, label });
             }
 
-            Aarch64Inst::Cset { dst, cond } => match self.get_allocation(dst) {
-                Some(Allocation::Register(reg)) => {
-                    mir.push(Aarch64Inst::Cset {
-                        dst: Operand::Physical(reg),
-                        cond,
-                    });
-                }
-                Some(Allocation::Spill(offset)) => {
-                    mir.push(Aarch64Inst::Cset {
-                        dst: Operand::Physical(Reg::X9),
-                        cond,
-                    });
-                    mir.push(Aarch64Inst::Str {
-                        src: Operand::Physical(Reg::X9),
-                        base: Reg::Fp,
-                        offset,
-                    });
-                }
-                None => {
-                    mir.push(Aarch64Inst::Cset { dst, cond });
-                }
-            },
+            Aarch64Inst::Cset { dst, cond } => {
+                alloc_dst!(self.get_allocation(dst), dst, Reg::X9 =>
+                    emit |dst_op| {
+                        mir.push(Aarch64Inst::Cset { dst: dst_op, cond });
+                    },
+                    store |offset| {
+                        mir.push(Aarch64Inst::Str {
+                            src: Operand::Physical(Reg::X9),
+                            base: Reg::Fp,
+                            offset,
+                        });
+                    },
+                );
+            }
 
             Aarch64Inst::TstRR { src1, src2 } => {
                 let src1_op = self.load_operand(mir, src1, Reg::X9)?;
@@ -683,181 +625,97 @@ impl RegAlloc {
 
             Aarch64Inst::LslImm { dst, src, imm } => {
                 let src_op = self.load_operand(mir, src, Reg::X10)?;
-
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(Aarch64Inst::LslImm {
-                            dst: Operand::Physical(reg),
-                            src: src_op,
-                            imm,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(Aarch64Inst::LslImm {
-                            dst: Operand::Physical(Reg::X9),
-                            src: src_op,
-                            imm,
-                        });
+                alloc_dst!(self.get_allocation(dst), dst, Reg::X9 =>
+                    emit |dst_op| {
+                        mir.push(Aarch64Inst::LslImm { dst: dst_op, src: src_op, imm });
+                    },
+                    store |offset| {
                         mir.push(Aarch64Inst::Str {
                             src: Operand::Physical(Reg::X9),
                             base: Reg::Fp,
                             offset,
                         });
-                    }
-                    None => {
-                        mir.push(Aarch64Inst::LslImm {
-                            dst,
-                            src: src_op,
-                            imm,
-                        });
-                    }
-                }
+                    },
+                );
             }
 
             Aarch64Inst::Lsl32Imm { dst, src, imm } => {
                 let src_op = self.load_operand(mir, src, Reg::X10)?;
-
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(Aarch64Inst::Lsl32Imm {
-                            dst: Operand::Physical(reg),
-                            src: src_op,
-                            imm,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(Aarch64Inst::Lsl32Imm {
-                            dst: Operand::Physical(Reg::X9),
-                            src: src_op,
-                            imm,
-                        });
+                alloc_dst!(self.get_allocation(dst), dst, Reg::X9 =>
+                    emit |dst_op| {
+                        mir.push(Aarch64Inst::Lsl32Imm { dst: dst_op, src: src_op, imm });
+                    },
+                    store |offset| {
                         mir.push(Aarch64Inst::Str {
                             src: Operand::Physical(Reg::X9),
                             base: Reg::Fp,
                             offset,
                         });
-                    }
-                    None => {
-                        mir.push(Aarch64Inst::Lsl32Imm {
-                            dst,
-                            src: src_op,
-                            imm,
-                        });
-                    }
-                }
+                    },
+                );
             }
 
             Aarch64Inst::Lsr32Imm { dst, src, imm } => {
                 let src_op = self.load_operand(mir, src, Reg::X10)?;
-
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(Aarch64Inst::Lsr32Imm {
-                            dst: Operand::Physical(reg),
-                            src: src_op,
-                            imm,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(Aarch64Inst::Lsr32Imm {
-                            dst: Operand::Physical(Reg::X9),
-                            src: src_op,
-                            imm,
-                        });
+                alloc_dst!(self.get_allocation(dst), dst, Reg::X9 =>
+                    emit |dst_op| {
+                        mir.push(Aarch64Inst::Lsr32Imm { dst: dst_op, src: src_op, imm });
+                    },
+                    store |offset| {
                         mir.push(Aarch64Inst::Str {
                             src: Operand::Physical(Reg::X9),
                             base: Reg::Fp,
                             offset,
                         });
-                    }
-                    None => {
-                        mir.push(Aarch64Inst::Lsr32Imm {
-                            dst,
-                            src: src_op,
-                            imm,
-                        });
-                    }
-                }
+                    },
+                );
             }
 
             Aarch64Inst::Asr32Imm { dst, src, imm } => {
                 let src_op = self.load_operand(mir, src, Reg::X10)?;
-
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(Aarch64Inst::Asr32Imm {
-                            dst: Operand::Physical(reg),
-                            src: src_op,
-                            imm,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(Aarch64Inst::Asr32Imm {
-                            dst: Operand::Physical(Reg::X9),
-                            src: src_op,
-                            imm,
-                        });
+                alloc_dst!(self.get_allocation(dst), dst, Reg::X9 =>
+                    emit |dst_op| {
+                        mir.push(Aarch64Inst::Asr32Imm { dst: dst_op, src: src_op, imm });
+                    },
+                    store |offset| {
                         mir.push(Aarch64Inst::Str {
                             src: Operand::Physical(Reg::X9),
                             base: Reg::Fp,
                             offset,
                         });
-                    }
-                    None => {
-                        mir.push(Aarch64Inst::Asr32Imm {
-                            dst,
-                            src: src_op,
-                            imm,
-                        });
-                    }
-                }
+                    },
+                );
             }
 
-            Aarch64Inst::StringConstPtr { dst, string_id } => match self.get_allocation(dst) {
-                Some(Allocation::Register(reg)) => {
-                    mir.push(Aarch64Inst::StringConstPtr {
-                        dst: Operand::Physical(reg),
-                        string_id,
-                    });
-                }
-                Some(Allocation::Spill(offset)) => {
-                    mir.push(Aarch64Inst::StringConstPtr {
-                        dst: Operand::Physical(Reg::X9),
-                        string_id,
-                    });
-                    mir.push(Aarch64Inst::Str {
-                        src: Operand::Physical(Reg::X9),
-                        base: Reg::Fp,
-                        offset,
-                    });
-                }
-                None => {
-                    mir.push(Aarch64Inst::StringConstPtr { dst, string_id });
-                }
-            },
+            Aarch64Inst::StringConstPtr { dst, string_id } => {
+                alloc_dst!(self.get_allocation(dst), dst, Reg::X9 =>
+                    emit |dst_op| {
+                        mir.push(Aarch64Inst::StringConstPtr { dst: dst_op, string_id });
+                    },
+                    store |offset| {
+                        mir.push(Aarch64Inst::Str {
+                            src: Operand::Physical(Reg::X9),
+                            base: Reg::Fp,
+                            offset,
+                        });
+                    },
+                );
+            }
 
-            Aarch64Inst::StringConstLen { dst, string_id } => match self.get_allocation(dst) {
-                Some(Allocation::Register(reg)) => {
-                    mir.push(Aarch64Inst::StringConstLen {
-                        dst: Operand::Physical(reg),
-                        string_id,
-                    });
-                }
-                Some(Allocation::Spill(offset)) => {
-                    mir.push(Aarch64Inst::StringConstLen {
-                        dst: Operand::Physical(Reg::X9),
-                        string_id,
-                    });
-                    mir.push(Aarch64Inst::Str {
-                        src: Operand::Physical(Reg::X9),
-                        base: Reg::Fp,
-                        offset,
-                    });
-                }
-                None => {
-                    mir.push(Aarch64Inst::StringConstLen { dst, string_id });
-                }
-            },
+            Aarch64Inst::StringConstLen { dst, string_id } => {
+                alloc_dst!(self.get_allocation(dst), dst, Reg::X9 =>
+                    emit |dst_op| {
+                        mir.push(Aarch64Inst::StringConstLen { dst: dst_op, string_id });
+                    },
+                    store |offset| {
+                        mir.push(Aarch64Inst::Str {
+                            src: Operand::Physical(Reg::X9),
+                            base: Reg::Fp,
+                            offset,
+                        });
+                    },
+                );
+            }
 
             // Pass-through instructions
             Aarch64Inst::B { label } => mir.push(Aarch64Inst::B { label }),

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -140,9 +140,98 @@ impl<Reg: Copy + Eq + std::hash::Hash> Default for LivenessInfo<Reg> {
 }
 
 // ============================================================================
-// Register Allocation Types
+// Register Allocation Macros
 // ============================================================================
 
+/// Macro for handling the 3-way allocation match pattern on a destination operand.
+///
+/// This is the most common pattern in register allocation: when rewriting an instruction,
+/// we check whether the destination operand is:
+/// 1. Allocated to a physical register: use that register
+/// 2. Spilled to stack: use scratch register, then store to stack
+/// 3. Already physical (None): pass through unchanged
+///
+/// # Syntax
+///
+/// ```ignore
+/// // Form 1: Different behavior for register vs spill vs passthrough
+/// alloc_dst!(alloc_result =>
+///     Register(reg) => { /* emit with reg */ },
+///     Spill(offset) => { /* emit with scratch */ } then { /* store to offset */ },
+///     Passthrough(dst) => { /* emit with dst unchanged */ }
+/// );
+///
+/// // Form 2: Same emit logic, just different operand
+/// alloc_dst!(alloc_result, dst, scratch =>
+///     emit |dst_op| { mir.push(Inst { dst: dst_op }) },
+///     store |offset| { mir.push(Store { offset, src: scratch }) }
+/// );
+/// ```
+///
+/// # Example: Form 1 (explicit arms)
+///
+/// ```ignore
+/// alloc_dst!(self.get_allocation(dst) =>
+///     Register(reg) => {
+///         mir.push(X86Inst::MovRI32 { dst: Operand::Physical(reg), imm });
+///     },
+///     Spill(offset) => {
+///         mir.push(X86Inst::MovRI32 { dst: Operand::Physical(Reg::Rax), imm });
+///     } then {
+///         mir.push(X86Inst::MovMR { base: Reg::Rbp, offset, src: Operand::Physical(Reg::Rax) });
+///     },
+///     Passthrough(dst) => {
+///         mir.push(X86Inst::MovRI32 { dst, imm });
+///     }
+/// );
+/// ```
+#[macro_export]
+macro_rules! alloc_dst {
+    // Form 1: Explicit arms with different behavior
+    ($alloc:expr =>
+        Register($reg:ident) => $emit_reg:block,
+        Spill($offset:ident) => $emit_spill:block then $store:block,
+        Passthrough($pass_dst:ident) => $emit_pass:block $(,)?
+    ) => {
+        match $alloc {
+            Some($crate::regalloc::Allocation::Register($reg)) => $emit_reg,
+            Some($crate::regalloc::Allocation::Spill($offset)) => {
+                $emit_spill
+                $store
+            }
+            None => {
+                let $pass_dst = $pass_dst;
+                $emit_pass
+            }
+        }
+    };
+
+    // Form 2: Common case - same emit, different operand
+    ($alloc:expr, $dst:expr, $scratch:expr =>
+        emit |$op:ident| $emit:block,
+        store |$off:ident| $store_body:block $(,)?
+    ) => {
+        match $alloc {
+            Some($crate::regalloc::Allocation::Register(reg)) => {
+                let $op = Operand::Physical(reg);
+                $emit
+            }
+            Some($crate::regalloc::Allocation::Spill($off)) => {
+                let $op = Operand::Physical($scratch);
+                $emit
+                $store_body
+            }
+            None => {
+                let $op = $dst;
+                $emit
+            }
+        }
+    };
+}
+
+// ============================================================================
+// Register Allocation Types
+// ============================================================================
 /// Allocation result for a virtual register.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Allocation<Reg: Copy> {

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -14,6 +14,7 @@ use rue_error::{CompileError, CompileResult, ErrorKind};
 
 use super::liveness::{self, LivenessInfo};
 use super::mir::{Operand, Reg, VReg, X86Inst, X86Mir};
+use crate::alloc_dst;
 use crate::index_map::IndexMap;
 use crate::regalloc::{Allocation, linear_scan};
 
@@ -136,55 +137,34 @@ impl RegAlloc {
     fn rewrite_inst(&self, mir: &mut X86Mir, inst: X86Inst) -> CompileResult<()> {
         match inst {
             X86Inst::MovRI32 { dst, imm } => {
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(X86Inst::MovRI32 {
-                            dst: Operand::Physical(reg),
-                            imm,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        // Store immediate to stack via a temp register
-                        // Use RAX as scratch (not in ALLOCATABLE_REGS)
-                        mir.push(X86Inst::MovRI32 {
-                            dst: Operand::Physical(Reg::Rax),
-                            imm,
-                        });
+                alloc_dst!(self.get_allocation(dst), dst, Reg::Rax =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::MovRI32 { dst: dst_op, imm });
+                    },
+                    store |offset| {
                         mir.push(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
                             src: Operand::Physical(Reg::Rax),
                         });
-                    }
-                    None => {
-                        // Physical register, pass through
-                        mir.push(X86Inst::MovRI32 { dst, imm });
-                    }
-                }
+                    },
+                );
             }
 
-            X86Inst::MovRI64 { dst, imm } => match self.get_allocation(dst) {
-                Some(Allocation::Register(reg)) => {
-                    mir.push(X86Inst::MovRI64 {
-                        dst: Operand::Physical(reg),
-                        imm,
-                    });
-                }
-                Some(Allocation::Spill(offset)) => {
-                    mir.push(X86Inst::MovRI64 {
-                        dst: Operand::Physical(Reg::Rax),
-                        imm,
-                    });
-                    mir.push(X86Inst::MovMR {
-                        base: Reg::Rbp,
-                        offset,
-                        src: Operand::Physical(Reg::Rax),
-                    });
-                }
-                None => {
-                    mir.push(X86Inst::MovRI64 { dst, imm });
-                }
-            },
+            X86Inst::MovRI64 { dst, imm } => {
+                alloc_dst!(self.get_allocation(dst), dst, Reg::Rax =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::MovRI64 { dst: dst_op, imm });
+                    },
+                    store |offset| {
+                        mir.push(X86Inst::MovMR {
+                            base: Reg::Rbp,
+                            offset,
+                            src: Operand::Physical(Reg::Rax),
+                        });
+                    },
+                );
+            }
 
             X86Inst::MovRR { dst, src } => {
                 let src_op = self.load_operand(mir, src, Reg::Rax)?;
@@ -218,31 +198,18 @@ impl RegAlloc {
             }
 
             X86Inst::MovRM { dst, base, offset } => {
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(X86Inst::MovRM {
-                            dst: Operand::Physical(reg),
-                            base,
-                            offset,
-                        });
-                    }
-                    Some(Allocation::Spill(spill_offset)) => {
-                        // Load to RAX, then store to spill slot
-                        mir.push(X86Inst::MovRM {
-                            dst: Operand::Physical(Reg::Rax),
-                            base,
-                            offset,
-                        });
+                alloc_dst!(self.get_allocation(dst), dst, Reg::Rax =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::MovRM { dst: dst_op, base, offset });
+                    },
+                    store |spill_offset| {
                         mir.push(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset: spill_offset,
                             src: Operand::Physical(Reg::Rax),
                         });
-                    }
-                    None => {
-                        mir.push(X86Inst::MovRM { dst, base, offset });
-                    }
-                }
+                    },
+                );
             }
 
             X86Inst::MovMR { base, offset, src } => {
@@ -437,180 +404,114 @@ impl RegAlloc {
 
             X86Inst::Movzx { dst, src } => {
                 let src_op = self.load_operand(mir, src, Reg::Rax)?;
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(X86Inst::Movzx {
-                            dst: Operand::Physical(reg),
-                            src: src_op,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(X86Inst::Movzx {
-                            dst: Operand::Physical(Reg::Rax),
-                            src: src_op,
-                        });
+                alloc_dst!(self.get_allocation(dst), dst, Reg::Rax =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::Movzx { dst: dst_op, src: src_op });
+                    },
+                    store |offset| {
                         mir.push(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
                             src: Operand::Physical(Reg::Rax),
                         });
-                    }
-                    None => {
-                        mir.push(X86Inst::Movzx { dst, src: src_op });
-                    }
-                }
+                    },
+                );
             }
 
             X86Inst::Movsx8To64 { dst, src } => {
                 let src_op = self.load_operand(mir, src, Reg::Rax)?;
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(X86Inst::Movsx8To64 {
-                            dst: Operand::Physical(reg),
-                            src: src_op,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(X86Inst::Movsx8To64 {
-                            dst: Operand::Physical(Reg::Rax),
-                            src: src_op,
-                        });
+                alloc_dst!(self.get_allocation(dst), dst, Reg::Rax =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::Movsx8To64 { dst: dst_op, src: src_op });
+                    },
+                    store |offset| {
                         mir.push(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
                             src: Operand::Physical(Reg::Rax),
                         });
-                    }
-                    None => {
-                        mir.push(X86Inst::Movsx8To64 { dst, src: src_op });
-                    }
-                }
+                    },
+                );
             }
 
             X86Inst::Movsx16To64 { dst, src } => {
                 let src_op = self.load_operand(mir, src, Reg::Rax)?;
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(X86Inst::Movsx16To64 {
-                            dst: Operand::Physical(reg),
-                            src: src_op,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(X86Inst::Movsx16To64 {
-                            dst: Operand::Physical(Reg::Rax),
-                            src: src_op,
-                        });
+                alloc_dst!(self.get_allocation(dst), dst, Reg::Rax =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::Movsx16To64 { dst: dst_op, src: src_op });
+                    },
+                    store |offset| {
                         mir.push(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
                             src: Operand::Physical(Reg::Rax),
                         });
-                    }
-                    None => {
-                        mir.push(X86Inst::Movsx16To64 { dst, src: src_op });
-                    }
-                }
+                    },
+                );
             }
 
             X86Inst::Movsx32To64 { dst, src } => {
                 let src_op = self.load_operand(mir, src, Reg::Rax)?;
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(X86Inst::Movsx32To64 {
-                            dst: Operand::Physical(reg),
-                            src: src_op,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(X86Inst::Movsx32To64 {
-                            dst: Operand::Physical(Reg::Rax),
-                            src: src_op,
-                        });
+                alloc_dst!(self.get_allocation(dst), dst, Reg::Rax =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::Movsx32To64 { dst: dst_op, src: src_op });
+                    },
+                    store |offset| {
                         mir.push(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
                             src: Operand::Physical(Reg::Rax),
                         });
-                    }
-                    None => {
-                        mir.push(X86Inst::Movsx32To64 { dst, src: src_op });
-                    }
-                }
+                    },
+                );
             }
 
             X86Inst::Movzx8To64 { dst, src } => {
                 let src_op = self.load_operand(mir, src, Reg::Rax)?;
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(X86Inst::Movzx8To64 {
-                            dst: Operand::Physical(reg),
-                            src: src_op,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(X86Inst::Movzx8To64 {
-                            dst: Operand::Physical(Reg::Rax),
-                            src: src_op,
-                        });
+                alloc_dst!(self.get_allocation(dst), dst, Reg::Rax =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::Movzx8To64 { dst: dst_op, src: src_op });
+                    },
+                    store |offset| {
                         mir.push(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
                             src: Operand::Physical(Reg::Rax),
                         });
-                    }
-                    None => {
-                        mir.push(X86Inst::Movzx8To64 { dst, src: src_op });
-                    }
-                }
+                    },
+                );
             }
 
             X86Inst::Movzx16To64 { dst, src } => {
                 let src_op = self.load_operand(mir, src, Reg::Rax)?;
-                match self.get_allocation(dst) {
-                    Some(Allocation::Register(reg)) => {
-                        mir.push(X86Inst::Movzx16To64 {
-                            dst: Operand::Physical(reg),
-                            src: src_op,
-                        });
-                    }
-                    Some(Allocation::Spill(offset)) => {
-                        mir.push(X86Inst::Movzx16To64 {
-                            dst: Operand::Physical(Reg::Rax),
-                            src: src_op,
-                        });
+                alloc_dst!(self.get_allocation(dst), dst, Reg::Rax =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::Movzx16To64 { dst: dst_op, src: src_op });
+                    },
+                    store |offset| {
                         mir.push(X86Inst::MovMR {
                             base: Reg::Rbp,
                             offset,
                             src: Operand::Physical(Reg::Rax),
                         });
-                    }
-                    None => {
-                        mir.push(X86Inst::Movzx16To64 { dst, src: src_op });
-                    }
-                }
+                    },
+                );
             }
 
-            X86Inst::Pop { dst } => match self.get_allocation(dst) {
-                Some(Allocation::Register(reg)) => {
-                    mir.push(X86Inst::Pop {
-                        dst: Operand::Physical(reg),
-                    });
-                }
-                Some(Allocation::Spill(offset)) => {
-                    mir.push(X86Inst::Pop {
-                        dst: Operand::Physical(Reg::Rax),
-                    });
-                    mir.push(X86Inst::MovMR {
-                        base: Reg::Rbp,
-                        offset,
-                        src: Operand::Physical(Reg::Rax),
-                    });
-                }
-                None => {
-                    mir.push(X86Inst::Pop { dst });
-                }
-            },
+            X86Inst::Pop { dst } => {
+                alloc_dst!(self.get_allocation(dst), dst, Reg::Rax =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::Pop { dst: dst_op });
+                    },
+                    store |offset| {
+                        mir.push(X86Inst::MovMR {
+                            base: Reg::Rbp,
+                            offset,
+                            src: Operand::Physical(Reg::Rax),
+                        });
+                    },
+                );
+            }
 
             X86Inst::Push { src } => {
                 let src_op = self.load_operand(mir, src, Reg::Rax)?;
@@ -623,40 +524,20 @@ impl RegAlloc {
                 index,
                 scale,
                 disp,
-            } => match self.get_allocation(dst) {
-                Some(Allocation::Register(reg)) => {
-                    mir.push(X86Inst::Lea {
-                        dst: Operand::Physical(reg),
-                        base,
-                        index,
-                        scale,
-                        disp,
-                    });
-                }
-                Some(Allocation::Spill(offset)) => {
-                    mir.push(X86Inst::Lea {
-                        dst: Operand::Physical(Reg::Rax),
-                        base,
-                        index,
-                        scale,
-                        disp,
-                    });
-                    mir.push(X86Inst::MovMR {
-                        base: Reg::Rbp,
-                        offset,
-                        src: Operand::Physical(Reg::Rax),
-                    });
-                }
-                None => {
-                    mir.push(X86Inst::Lea {
-                        dst,
-                        base,
-                        index,
-                        scale,
-                        disp,
-                    });
-                }
-            },
+            } => {
+                alloc_dst!(self.get_allocation(dst), dst, Reg::Rax =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::Lea { dst: dst_op, base, index, scale, disp });
+                    },
+                    store |offset| {
+                        mir.push(X86Inst::MovMR {
+                            base: Reg::Rbp,
+                            offset,
+                            src: Operand::Physical(Reg::Rax),
+                        });
+                    },
+                );
+            }
 
             X86Inst::Shl { dst, count } => {
                 // SHL needs count in RCX
@@ -754,51 +635,35 @@ impl RegAlloc {
                 });
             }
 
-            X86Inst::StringConstPtr { dst, string_id } => match self.get_allocation(dst) {
-                Some(Allocation::Register(reg)) => {
-                    mir.push(X86Inst::StringConstPtr {
-                        dst: Operand::Physical(reg),
-                        string_id,
-                    });
-                }
-                Some(Allocation::Spill(offset)) => {
-                    mir.push(X86Inst::StringConstPtr {
-                        dst: Operand::Physical(Reg::Rax),
-                        string_id,
-                    });
-                    mir.push(X86Inst::MovMR {
-                        base: Reg::Rbp,
-                        offset,
-                        src: Operand::Physical(Reg::Rax),
-                    });
-                }
-                None => {
-                    mir.push(X86Inst::StringConstPtr { dst, string_id });
-                }
-            },
+            X86Inst::StringConstPtr { dst, string_id } => {
+                alloc_dst!(self.get_allocation(dst), dst, Reg::Rax =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::StringConstPtr { dst: dst_op, string_id });
+                    },
+                    store |offset| {
+                        mir.push(X86Inst::MovMR {
+                            base: Reg::Rbp,
+                            offset,
+                            src: Operand::Physical(Reg::Rax),
+                        });
+                    },
+                );
+            }
 
-            X86Inst::StringConstLen { dst, string_id } => match self.get_allocation(dst) {
-                Some(Allocation::Register(reg)) => {
-                    mir.push(X86Inst::StringConstLen {
-                        dst: Operand::Physical(reg),
-                        string_id,
-                    });
-                }
-                Some(Allocation::Spill(offset)) => {
-                    mir.push(X86Inst::StringConstLen {
-                        dst: Operand::Physical(Reg::Rax),
-                        string_id,
-                    });
-                    mir.push(X86Inst::MovMR {
-                        base: Reg::Rbp,
-                        offset,
-                        src: Operand::Physical(Reg::Rax),
-                    });
-                }
-                None => {
-                    mir.push(X86Inst::StringConstLen { dst, string_id });
-                }
-            },
+            X86Inst::StringConstLen { dst, string_id } => {
+                alloc_dst!(self.get_allocation(dst), dst, Reg::Rax =>
+                    emit |dst_op| {
+                        mir.push(X86Inst::StringConstLen { dst: dst_op, string_id });
+                    },
+                    store |offset| {
+                        mir.push(X86Inst::MovMR {
+                            base: Reg::Rbp,
+                            offset,
+                            src: Operand::Physical(Reg::Rax),
+                        });
+                    },
+                );
+            }
 
             // Instructions without register operands pass through unchanged
             X86Inst::Cdq => mir.push(X86Inst::Cdq),


### PR DESCRIPTION
Introduce a macro in rue-codegen/src/regalloc.rs that handles the common 3-way match pattern on allocation results:
- Register(reg): emit with physical register
- Spill(offset): emit with scratch, then store to stack
- None: passthrough for already-physical operands

Refactor both x86_64 and aarch64 regalloc modules to use the macro for ~15 instruction types each (MovRI, MovRM/Ldr, Pop, Lea, Movsx/Movzx, shift immediates, StringConst*, Cset, etc.).

Fixes rue-u7b2

🤖 Generated with [Claude Code](https://claude.com/claude-code)