### PR TITLE
Implement exclusive access checking for inout parameters (rue-rpnk)

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -15,7 +15,7 @@ use crate::types::{
 };
 use rue_error::{CompileError, CompileResult, CompileWarning, ErrorKind, OptionExt, WarningKind};
 use rue_intern::{Interner, Symbol};
-use rue_rir::{InstData, InstRef, Rir, RirDirective, RirParamMode, RirPattern};
+use rue_rir::{InstData, InstRef, Rir, RirCallArg, RirDirective, RirParamMode, RirPattern};
 use rue_span::Span;
 
 /// A value that can be computed at compile time.
@@ -357,6 +357,58 @@ impl<'a> Sema<'a> {
                     )),
             );
         }
+    }
+
+    /// Extract the root variable symbol from an expression, if it refers to a variable.
+    ///
+    /// For inout arguments, we need to track which variable is being passed to detect
+    /// when the same variable is passed to multiple inout parameters.
+    ///
+    /// Returns Some(symbol) for:
+    /// - VarRef { name } -> the variable symbol
+    /// - ParamRef { name, .. } -> the parameter symbol
+    /// - FieldGet { base, .. } -> recursively extract from base
+    /// - IndexGet { base, .. } -> recursively extract from base
+    ///
+    /// Returns None for expressions that don't refer to a variable (literals, calls, etc.)
+    fn extract_root_variable(&self, inst_ref: InstRef) -> Option<Symbol> {
+        let inst = self.rir.get(inst_ref);
+        match &inst.data {
+            InstData::VarRef { name } => Some(*name),
+            InstData::ParamRef { name, .. } => Some(*name),
+            InstData::FieldGet { base, .. } => self.extract_root_variable(*base),
+            InstData::IndexGet { base, .. } => self.extract_root_variable(*base),
+            _ => None,
+        }
+    }
+
+    /// Check that the same variable is not passed to multiple inout parameters in a call.
+    ///
+    /// This prevents aliasing of mutable references within a single call, which could
+    /// lead to undefined behavior (e.g., `swap(inout x, inout x)`).
+    fn check_inout_exclusive_access(
+        &self,
+        args: &[RirCallArg],
+        call_span: Span,
+    ) -> CompileResult<()> {
+        use std::collections::HashSet;
+        let mut inout_vars: HashSet<Symbol> = HashSet::new();
+
+        for arg in args {
+            if arg.is_inout {
+                if let Some(var_symbol) = self.extract_root_variable(arg.value) {
+                    if !inout_vars.insert(var_symbol) {
+                        // Duplicate! This variable was already used as an inout argument
+                        let var_name = self.interner.get(var_symbol).to_string();
+                        return Err(CompileError::new(
+                            ErrorKind::InoutExclusiveAccess { variable: var_name },
+                            call_span,
+                        ));
+                    }
+                }
+            }
+        }
+        Ok(())
     }
 
     /// Analyze all functions in the RIR.
@@ -2324,6 +2376,9 @@ impl<'a> Sema<'a> {
                     ));
                 }
 
+                // Check for exclusive access violation: same variable passed to multiple inout params
+                self.check_inout_exclusive_access(args, inst.span)?;
+
                 // Clone the data we need before mutable borrow
                 let param_types = fn_info.param_types.clone();
                 let return_type = fn_info.return_type;
@@ -3085,6 +3140,9 @@ impl<'a> Sema<'a> {
                     ));
                 }
 
+                // Check for exclusive access violation in method args
+                self.check_inout_exclusive_access(args, inst.span)?;
+
                 // Clone data needed before mutable borrow
                 let return_type = method_info.return_type;
 
@@ -3162,6 +3220,9 @@ impl<'a> Sema<'a> {
                         inst.span,
                     ));
                 }
+
+                // Check for exclusive access violation in assoc fn args
+                self.check_inout_exclusive_access(args, inst.span)?;
 
                 // Clone data needed before mutable borrow
                 let return_type = method_info.return_type;

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -345,6 +345,12 @@ pub enum ErrorKind {
         found: String,
     },
     InvalidAssignmentTarget,
+    /// Inout argument is not an lvalue (variable, field, or array element)
+    InoutNonLvalue,
+    /// Same variable passed to multiple inout parameters in a single call
+    InoutExclusiveAccess {
+        variable: String,
+    },
 
     // Control flow errors
     BreakOutsideLoop,
@@ -680,6 +686,19 @@ impl fmt::Display for ErrorKind {
             }
             ErrorKind::InvalidAssignmentTarget => {
                 write!(f, "invalid assignment target")
+            }
+            ErrorKind::InoutNonLvalue => {
+                write!(
+                    f,
+                    "inout argument must be an lvalue (variable, field, or array element)"
+                )
+            }
+            ErrorKind::InoutExclusiveAccess { variable } => {
+                write!(
+                    f,
+                    "cannot pass same variable '{}' to multiple inout parameters",
+                    variable
+                )
             }
             ErrorKind::BreakOutsideLoop => write!(f, "'break' outside of loop"),
             ErrorKind::ContinueOutsideLoop => write!(f, "'continue' outside of loop"),

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -705,3 +705,43 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "lvalue"
+
+[[case]]
+name = "inout_exclusive_access"
+spec = ["6.1:20"]
+description = "Cannot pass same variable to multiple inout parameters"
+preview = "affine_types"
+source = """
+fn swap(inout a: i32, inout b: i32) {
+    let tmp = a;
+    a = b;
+    b = tmp;
+}
+fn main() -> i32 {
+    let mut x = 1;
+    swap(inout x, inout x);
+    0
+}
+"""
+compile_fail = true
+error_contains = "same variable"
+
+[[case]]
+name = "inout_exclusive_access_different_vars"
+spec = ["6.1:20"]
+description = "Different variables can be passed to multiple inout parameters"
+preview = "affine_types"
+source = """
+fn swap(inout a: i32, inout b: i32) {
+    let tmp = a;
+    a = b;
+    b = tmp;
+}
+fn main() -> i32 {
+    let mut x = 1;
+    let mut y = 2;
+    swap(inout x, inout y);
+    x + y * 10
+}
+"""
+exit_code = 12

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -85,6 +85,26 @@ fn main() -> i32 {
 }
 ```
 
+{{ rule(id="6.1:20", cat="legality-rule") }}
+
+A single function call **MUST NOT** pass the same variable to multiple `inout` parameters. This prevents aliasing of mutable references within a single call.
+
+{{ rule(id="6.1:21", cat="example") }}
+
+```rue
+fn swap(inout a: i32, inout b: i32) {
+    let tmp = a;
+    a = b;
+    b = tmp;
+}
+
+fn main() -> i32 {
+    let mut x = 1;
+    swap(inout x, inout x);  // error: cannot pass same variable to multiple inout parameters
+    0
+}
+```
+
 ## Entry Point
 
 {{ rule(id="6.1:7", cat="legality-rule") }}


### PR DESCRIPTION
Prevent passing the same variable to multiple inout parameters in a single function call. This prevents aliasing of mutable references within a call, which could lead to undefined behavior (e.g., `swap(inout x, inout x)`).

The check extracts the root variable from each inout argument by traversing VarRef, ParamRef, FieldGet, and IndexGet nodes, then detects duplicates using a HashSet.

Adds spec rule 6.1:20 as a legality-rule with 100% test coverage.

Fixes rue-rpnk

🤖 Generated with [Claude Code](https://claude.com/claude-code)