### PR TITLE
Add codegen for borrow parameters (Phase 3)

### DIFF
--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -86,9 +86,19 @@ pub struct CfgCallArg {
 }
 
 impl CfgCallArg {
-    /// Returns true if this argument is passed as inout (by reference).
+    /// Returns true if this argument is passed as inout (mutable by reference).
     pub fn is_inout(&self) -> bool {
         self.mode == CfgArgMode::Inout
+    }
+
+    /// Returns true if this argument is passed as borrow (immutable by reference).
+    pub fn is_borrow(&self) -> bool {
+        self.mode == CfgArgMode::Borrow
+    }
+
+    /// Returns true if this argument is passed by reference (either inout or borrow).
+    pub fn is_by_ref(&self) -> bool {
+        matches!(self.mode, CfgArgMode::Inout | CfgArgMode::Borrow)
     }
 }
 

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1224,14 +1224,14 @@ impl<'a> CfgLower<'a> {
                 let result_vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, result_vreg);
 
-                // Flatten struct arguments and handle inout arguments
+                // Flatten struct arguments and handle by-ref arguments (inout and borrow)
                 let mut flattened_vregs: Vec<VReg> = Vec::new();
                 for arg in args {
                     let arg_value = arg.value;
                     let arg_type = self.cfg.get_inst(arg_value).ty;
 
-                    // For inout args, pass address instead of value
-                    if arg.is_inout() {
+                    // For by-ref args (inout or borrow), pass address instead of value
+                    if arg.is_by_ref() {
                         let arg_data = &self.cfg.get_inst(arg_value).data;
                         let addr_vreg = self.mir.alloc_vreg();
 
@@ -1247,9 +1247,9 @@ impl<'a> CfgLower<'a> {
                                 });
                             }
                             CfgInstData::Param { index } => {
-                                // Check if this param is itself an inout param (forwarding case)
+                                // Check if this param is itself a by-ref param (forwarding case)
                                 if self.cfg.is_param_inout(*index) {
-                                    // For inout param, just pass the pointer we received
+                                    // For by-ref param, just pass the pointer we received
                                     if let Some(ptr_vreg) =
                                         self.inout_param_ptrs.get(index).copied()
                                     {
@@ -1259,7 +1259,7 @@ impl<'a> CfgLower<'a> {
                                         });
                                     } else {
                                         panic!(
-                                            "inout param pointer not found for forwarding param {}",
+                                            "by-ref param pointer not found for forwarding param {}",
                                             index
                                         );
                                     }
@@ -1277,7 +1277,7 @@ impl<'a> CfgLower<'a> {
                             _ => {
                                 // For other sources (StructInit, Call result, etc.),
                                 // we can't take an address - this should have been caught earlier
-                                panic!("inout argument must be a variable, not {:?}", arg_data);
+                                panic!("by-ref argument must be a variable, not {:?}", arg_data);
                             }
                         }
                         flattened_vregs.push(addr_vreg);

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1360,14 +1360,14 @@ impl<'a> CfgLower<'a> {
                 let result_vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, result_vreg);
 
-                // Flatten struct arguments and handle inout arguments
+                // Flatten struct arguments and handle by-ref arguments (inout and borrow)
                 let mut flattened_vregs: Vec<VReg> = Vec::new();
                 for arg in args {
                     let arg_value = arg.value;
                     let arg_type = self.cfg.get_inst(arg_value).ty;
 
-                    // For inout args, pass address instead of value
-                    if arg.is_inout() {
+                    // For by-ref args (inout or borrow), pass address instead of value
+                    if arg.is_by_ref() {
                         let arg_data = &self.cfg.get_inst(arg_value).data;
                         let addr_vreg = self.mir.alloc_vreg();
 
@@ -1384,9 +1384,9 @@ impl<'a> CfgLower<'a> {
                                 });
                             }
                             CfgInstData::Param { index } => {
-                                // Check if this param is itself an inout param (forwarding case)
+                                // Check if this param is itself a by-ref param (forwarding case)
                                 if self.cfg.is_param_inout(*index) {
-                                    // For inout param, just pass the pointer we received
+                                    // For by-ref param, just pass the pointer we received
                                     if let Some(ptr_vreg) =
                                         self.inout_param_ptrs.get(index).copied()
                                     {
@@ -1396,7 +1396,7 @@ impl<'a> CfgLower<'a> {
                                         });
                                     } else {
                                         panic!(
-                                            "inout param pointer not found for forwarding param {}",
+                                            "by-ref param pointer not found for forwarding param {}",
                                             index
                                         );
                                     }
@@ -1416,7 +1416,7 @@ impl<'a> CfgLower<'a> {
                             _ => {
                                 // For other sources (StructInit, Call result, etc.),
                                 // we can't take an address - this should have been caught earlier
-                                panic!("inout argument must be a variable, not {:?}", arg_data);
+                                panic!("by-ref argument must be a variable, not {:?}", arg_data);
                             }
                         }
                         flattened_vregs.push(addr_vreg);


### PR DESCRIPTION
Borrow parameters use pass-by-pointer semantics, identical to inout at the ABI level. The difference (immutable vs mutable) is enforced at the semantic analysis level (Phase 2).

Changes:
- Add is_borrow() and is_by_ref() methods to CfgCallArg
- Update x86_64 and aarch64 backends to use is_by_ref() when deciding whether to pass arguments by address

Fixes rue-7lii.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)