### PR TITLE
Add specification and tests for borrow parameters (Phase 4)

### DIFF
--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -746,13 +746,49 @@ fn main() -> i32 {
 """
 exit_code = 12
 
+[[case]]
+name = "inout_allows_mutation_vs_borrow"
+spec = ["6.1:14", "6.1:18"]
+description = "Inout allows mutation while borrow does not (contrast test)"
+preview = "affine_types"
+source = """
+struct Counter { value: i32 }
+fn increment_inout(inout c: Counter) {
+    c.value = c.value + 1;
+}
+fn main() -> i32 {
+    let mut c = Counter { value: 41 };
+    increment_inout(inout c);
+    c.value
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_value_valid_after_call"
+spec = ["6.1:18"]
+description = "Variable is still valid after inout call (no ownership transfer)"
+preview = "affine_types"
+source = """
+fn double(inout x: i32) {
+    x = x * 2;
+}
+fn main() -> i32 {
+    let mut n = 10;
+    double(inout n);
+    double(inout n);
+    n + 2
+}
+"""
+exit_code = 42
+
 # =============================================================================
-# Borrow parameters (Phase 2: Semantic Analysis)
+# Borrow parameters
 # =============================================================================
 
 [[case]]
 name = "borrow_param_read_only"
-spec = ["6.1:14"]
+spec = ["6.1:22", "6.1:23", "6.1:26"]
 description = "Basic borrow parameter that reads a value without ownership transfer"
 preview = "affine_types"
 source = """
@@ -769,8 +805,8 @@ exit_code = 42
 
 [[case]]
 name = "borrow_param_multiple_uses"
-spec = ["6.1:14"]
-description = "Borrowed value can be used multiple times (not moved)"
+spec = ["6.1:22", "6.1:26"]
+description = "Borrowed value can be used multiple times after call (not moved)"
 preview = "affine_types"
 source = """
 struct Point { x: i32, y: i32 }
@@ -789,7 +825,7 @@ exit_code = 42
 
 [[case]]
 name = "borrow_cannot_mutate_field"
-spec = ["6.1:14"]
+spec = ["6.1:24"]
 description = "Cannot mutate fields of a borrowed value"
 preview = "affine_types"
 source = """
@@ -808,7 +844,7 @@ error_contains = "cannot mutate borrowed"
 
 [[case]]
 name = "borrow_cannot_mutate_array"
-spec = ["6.1:14"]
+spec = ["6.1:24"]
 description = "Cannot mutate elements of a borrowed array"
 preview = "affine_types"
 source = """
@@ -826,7 +862,7 @@ error_contains = "cannot mutate borrowed"
 
 [[case]]
 name = "borrow_cannot_move_out"
-spec = ["6.1:14"]
+spec = ["6.1:25"]
 description = "Cannot move out of a borrowed value"
 preview = "affine_types"
 source = """
@@ -845,7 +881,7 @@ error_contains = "cannot move out of borrowed"
 
 [[case]]
 name = "borrow_inout_conflict"
-spec = ["6.1:20"]
+spec = ["6.1:30"]
 description = "Cannot borrow and inout the same variable in one call"
 preview = "affine_types"
 source = """
@@ -863,7 +899,7 @@ error_contains = "borrow"
 
 [[case]]
 name = "borrow_multiple_same_var_ok"
-spec = ["6.1:14"]
+spec = ["6.1:28"]
 description = "Multiple borrows of the same variable is allowed"
 preview = "affine_types"
 source = """
@@ -879,7 +915,7 @@ exit_code = 42
 
 [[case]]
 name = "borrow_with_regular_param"
-spec = ["6.1:14", "6.1:15"]
+spec = ["6.1:22", "6.1:15"]
 description = "Mixing borrow and regular parameters"
 preview = "affine_types"
 source = """
@@ -893,3 +929,109 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+[[case]]
+name = "borrow_value_still_valid_after"
+spec = ["6.1:26", "6.1:27"]
+description = "Value can be used after being borrowed"
+preview = "affine_types"
+source = """
+struct Point { x: i32, y: i32 }
+fn read_x(borrow p: Point) -> i32 {
+    p.x
+}
+fn main() -> i32 {
+    let p = Point { x: 42, y: 10 };
+    let first = read_x(borrow p);
+    let second = p.y;
+    first
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "borrow_integer_param"
+spec = ["6.1:22", "6.1:23"]
+description = "Borrow works with primitive integer types"
+preview = "affine_types"
+source = """
+fn double(borrow x: i32) -> i32 {
+    x + x
+}
+fn main() -> i32 {
+    let n = 21;
+    double(borrow n)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "borrow_array_read"
+spec = ["6.1:22", "6.1:26"]
+description = "Can read elements from a borrowed array"
+preview = "affine_types"
+source = """
+fn first(borrow arr: [i32; 3]) -> i32 {
+    arr[0]
+}
+fn main() -> i32 {
+    let a = [42, 2, 3];
+    first(borrow a)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "borrow_nested_struct"
+spec = ["6.1:22", "6.1:26"]
+description = "Can read nested fields from a borrowed struct"
+preview = "affine_types"
+source = """
+struct Inner { value: i32 }
+struct Outer { inner: Inner }
+fn get_inner_value(borrow o: Outer) -> i32 {
+    o.inner.value
+}
+fn main() -> i32 {
+    let o = Outer { inner: Inner { value: 42 } };
+    get_inner_value(borrow o)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "borrow_call_site_missing_keyword"
+spec = ["6.1:23"]
+description = "Call site must include borrow keyword"
+preview = "affine_types"
+source = """
+struct Point { x: i32, y: i32 }
+fn read(borrow p: Point) -> i32 {
+    p.x
+}
+fn main() -> i32 {
+    let p = Point { x: 1, y: 2 };
+    read(p)
+}
+"""
+compile_fail = true
+error_contains = "borrow"
+
+[[case]]
+name = "borrow_cannot_assign_to_param"
+spec = ["6.1:24"]
+description = "Cannot assign to the borrowed parameter itself"
+preview = "affine_types"
+source = """
+struct Data { value: i32 }
+fn try_reassign(borrow d: Data) -> i32 {
+    d = Data { value: 99 };
+    d.value
+}
+fn main() -> i32 {
+    let d = Data { value: 42 };
+    try_reassign(borrow d)
+}
+"""
+compile_fail = true
+error_contains = "cannot mutate borrowed"

--- a/crates/rue-spec/cases/lexical/keywords.toml
+++ b/crates/rue-spec/cases/lexical/keywords.toml
@@ -92,6 +92,20 @@ spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let struct = 1; 0 }"
 compile_fail = true
 
+[[case]]
+name = "keyword_inout_reserved"
+spec = ["2.4:1", "2.4:2"]
+preview = "affine_types"
+source = "fn main() -> i32 { let inout = 1; 0 }"
+compile_fail = true
+
+[[case]]
+name = "keyword_borrow_reserved"
+spec = ["2.4:1", "2.4:2"]
+preview = "affine_types"
+source = "fn main() -> i32 { let borrow = 1; 0 }"
+compile_fail = true
+
 # =============================================================================
 # Type Names Are Reserved
 # =============================================================================

--- a/docs/designs/0013-borrowing-modes.md
+++ b/docs/designs/0013-borrowing-modes.md
@@ -1,11 +1,11 @@
 ---
 id: 0013
 title: Borrowing Modes
-status: proposal
+status: accepted
 tags: [types, semantics, ownership, borrowing]
 feature-flag: borrowing-modes
 created: 2025-12-25
-accepted:
+accepted: 2025-12-25
 implemented:
 spec-sections: ["6.1"]
 superseded-by:
@@ -15,7 +15,7 @@ superseded-by:
 
 ## Status
 
-Proposal
+Accepted (behind `affine_types` preview feature)
 
 ## Summary
 
@@ -313,31 +313,10 @@ This keeps the type system simple and avoids lifetime complexity.
 
 Epic: rue-7lii
 
-### Phase 1: Parser support - rue-7lii.1
-
-- Add `borrow` keyword
-- Parse `borrow` in parameter declarations
-- Parse `borrow` at call sites
-- Update RIR and AIR to track borrow mode
-
-### Phase 2: Semantic analysis - rue-7lii.2
-
-- Enforce immutability of borrowed values
-- Prevent moving out of borrowed values
-- Implement non-escaping check
-- Law of exclusivity: borrow/inout conflict detection
-
-### Phase 3: Codegen - rue-7lii.3
-
-- Pass borrowed values by pointer (like inout)
-- Generate read-only accesses
-- Optimization: pass small @copy types by value
-
-### Phase 4: Specification and tests - rue-7lii.4
-
-- Add spec section for borrowing
-- Comprehensive test cases
-- Update existing inout tests to show distinction
+- [x] **Phase 1: Parser support** - rue-7lii.1 - Add `borrow` keyword, parse in parameter declarations and call sites
+- [x] **Phase 2: Semantic analysis** - rue-7lii.2 - Enforce immutability, prevent move-out, non-escaping check, exclusivity
+- [x] **Phase 3: Codegen** - rue-7lii.3 - Pass borrowed values by pointer, generate read-only accesses
+- [x] **Phase 4: Specification and tests** - rue-7lii.4 - Add spec sections, comprehensive tests
 
 ## Consequences
 

--- a/docs/spec/src/02-lexical-structure/04-keywords.md
+++ b/docs/spec/src/02-lexical-structure/04-keywords.md
@@ -18,7 +18,9 @@ The following words are keywords and cannot be used as identifiers:
 
 | Keyword | Description |
 |---------|-------------|
+| `borrow` | Borrow parameter mode |
 | `fn` | Function declaration |
+| `inout` | Inout parameter mode |
 | `let` | Variable binding |
 | `mut` | Mutable binding modifier |
 | `if` | Conditional expression |

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -53,7 +53,8 @@ A parameter **MAY** be marked with the `inout` keyword to indicate that it is pa
 {{ rule(id="6.1:15", cat="syntax") }}
 
 ```ebnf
-param = [ "inout" ] IDENT ":" type ;
+param = [ param_mode ] IDENT ":" type ;
+param_mode = "inout" | "borrow" ;
 ```
 
 {{ rule(id="6.1:16", cat="legality-rule") }}
@@ -101,6 +102,85 @@ fn swap(inout a: i32, inout b: i32) {
 fn main() -> i32 {
     let mut x = 1;
     swap(inout x, inout x);  // error: cannot pass same variable to multiple inout parameters
+    0
+}
+```
+
+## Borrow Parameters
+
+{{ rule(id="6.1:22", cat="normative") }}
+
+A parameter **MAY** be marked with the `borrow` keyword to indicate that it is passed by reference for read-only access. The callee cannot mutate the borrowed value, and the value is not consumed (ownership is not transferred).
+
+{{ rule(id="6.1:23", cat="legality-rule") }}
+
+At the call site, an argument passed to a `borrow` parameter **MUST** be marked with the `borrow` keyword.
+
+{{ rule(id="6.1:24", cat="legality-rule") }}
+
+The body of a function **MUST NOT** mutate a `borrow` parameter. This includes:
+- Assignment to the parameter itself
+- Assignment to fields of the parameter
+- Assignment to array elements of the parameter
+
+{{ rule(id="6.1:25", cat="legality-rule") }}
+
+The body of a function **MUST NOT** move out of a `borrow` parameter. A borrowed value cannot be returned, stored in a struct field, or passed to a function expecting an owned value.
+
+{{ rule(id="6.1:26", cat="dynamic-semantics") }}
+
+When a function is called with a `borrow` argument:
+1. The address of the argument is passed to the callee
+2. The callee reads from the argument through this address
+3. After the call returns, the original variable is unchanged and still valid
+
+{{ rule(id="6.1:27", cat="example") }}
+
+```rue
+struct Point { x: i32, y: i32 }
+
+fn sum_coords(borrow p: Point) -> i32 {
+    p.x + p.y
+}
+
+fn main() -> i32 {
+    let p = Point { x: 10, y: 32 };
+    let result = sum_coords(borrow p);
+    result + p.x - p.x  // p is still valid after the borrow
+}
+```
+
+{{ rule(id="6.1:28", cat="normative") }}
+
+Multiple `borrow` parameters **MAY** refer to the same variable. Unlike `inout`, borrows are shared read-only access.
+
+{{ rule(id="6.1:29", cat="example") }}
+
+```rue
+fn sum_both(borrow a: i32, borrow b: i32) -> i32 {
+    a + b
+}
+
+fn main() -> i32 {
+    let x = 21;
+    sum_both(borrow x, borrow x)  // OK: multiple borrows of same variable
+}
+```
+
+{{ rule(id="6.1:30", cat="legality-rule") }}
+
+A single function call **MUST NOT** pass the same variable to both a `borrow` parameter and an `inout` parameter. This enforces the law of exclusivity: either one `inout` or any number of `borrow` accesses, but never both simultaneously.
+
+{{ rule(id="6.1:31", cat="example") }}
+
+```rue
+fn mixed(borrow a: i32, inout b: i32) {
+    b = a + 1;
+}
+
+fn main() -> i32 {
+    let mut x = 41;
+    mixed(borrow x, inout x);  // error: cannot borrow and inout same variable
     0
 }
 ```

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -24,7 +24,8 @@ intrinsic_arg  = expression | type ;
 (* Functions *)
 function       = "fn" IDENT "(" [ params ] ")" [ "->" type ] "{" block "}" ;
 params         = param { "," param } ;
-param          = IDENT ":" type ;
+param          = [ param_mode ] IDENT ":" type ;
+param_mode     = "inout" | "borrow" ;
 block          = { statement } [ expression ] ;
 
 (* Structs *)
@@ -71,7 +72,8 @@ additive       = multiplicative { ( "+" | "-" ) multiplicative } ;
 multiplicative = unary { ( "*" | "/" | "%" ) unary } ;
 unary          = "-" unary | "!" unary | "~" unary | postfix ;
 postfix        = primary { "[" expression "]" | "(" [ args ] ")" | "." IDENT } ;
-args           = expression { "," expression } ;
+args           = arg { "," arg } ;
+arg            = [ param_mode ] expression ;
 primary        = INTEGER | BOOL | IDENT | enum_variant_expr
                | "(" expression ")"
                | block_expr


### PR DESCRIPTION
Completes the borrowing modes feature (rue-7lii) by adding formal specification and comprehensive test coverage for borrow parameters.

Specification changes:
- Add borrow parameter rules 6.1:22-31 to functions spec
- Add borrow/inout keywords to reserved words table
- Update grammar with param_mode production for params and args

Test coverage:
- Basic borrow usage (read-only access, value still valid after)
- Mutation prevention (field assignment, array element, param itself)
- Move-out prevention (cannot return or store borrowed value)
- Multiple borrows of same variable (allowed, unlike inout)
- Borrow/inout conflict detection (exclusivity)
- Call-site keyword requirement
- Various data types (structs, arrays, nested structs, integers)

Also adds contrast tests showing the distinction between inout (allows mutation) and borrow (read-only).

Fixes rue-7lii.4
Fixes rue-7lii

🤖 Generated with [Claude Code](https://claude.com/claude-code)