### PR TITLE
Add inout parameter field access and mutation support

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -281,6 +281,14 @@ pub enum AirInstData {
         value: AirRef,
     },
 
+    /// Store value to a parameter (for inout params)
+    ParamStore {
+        /// Parameter's ABI slot (relative to params, not locals)
+        param_slot: u32,
+        /// Value to store
+        value: AirRef,
+    },
+
     /// Return from function (None for `return;` in unit-returning functions)
     Ret(Option<AirRef>),
 
@@ -339,11 +347,25 @@ pub enum AirInstData {
         field_index: u32,
     },
 
-    /// Store a value to a struct field
+    /// Store a value to a struct field (for local variables)
     FieldSet {
         /// The struct variable slot
         slot: u32,
         /// The struct type
+        struct_id: StructId,
+        /// Field index (0-based, in declaration order)
+        field_index: u32,
+        /// Value to store
+        value: AirRef,
+    },
+
+    /// Store a value to a struct field (for parameters, including inout)
+    ParamFieldSet {
+        /// The parameter's ABI slot (relative to params, not locals)
+        param_slot: u32,
+        /// Offset within the struct for nested field access (e.g., p.inner.x)
+        inner_offset: u32,
+        /// The struct type containing the field being set
         struct_id: StructId,
         /// Field index (0-based, in declaration order)
         field_index: u32,
@@ -494,6 +516,9 @@ impl fmt::Display for Air {
                 AirInstData::Alloc { slot, init } => writeln!(f, "alloc ${} = {}", slot, init)?,
                 AirInstData::Load { slot } => writeln!(f, "load ${}", slot)?,
                 AirInstData::Store { slot, value } => writeln!(f, "store ${} = {}", slot, value)?,
+                AirInstData::ParamStore { param_slot, value } => {
+                    writeln!(f, "param_store %{} = {}", param_slot, value)?
+                }
                 AirInstData::Ret(inner) => {
                     if let Some(inner) = inner {
                         writeln!(f, "ret {}", inner)?
@@ -570,6 +595,19 @@ impl fmt::Display for Air {
                         f,
                         "field_set ${}.#{}.{} = {}",
                         slot, struct_id.0, field_index, value
+                    )?;
+                }
+                AirInstData::ParamFieldSet {
+                    param_slot,
+                    inner_offset,
+                    struct_id,
+                    field_index,
+                    value,
+                } => {
+                    writeln!(
+                        f,
+                        "param_field_set %{}+{}.#{}.{} = {}",
+                        param_slot, inner_offset, struct_id.0, field_index, value
                     )?;
                 }
                 AirInstData::ArrayInit {

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -434,6 +434,42 @@ impl<'a> Sema<'a> {
         Ok(())
     }
 
+    /// Analyze a list of call arguments, handling inout unmove logic.
+    ///
+    /// For inout arguments, the variable is "unmoving" after analysis - this is because
+    /// inout is a mutable borrow, not a move. The value stays valid after the call.
+    fn analyze_call_args(
+        &mut self,
+        air: &mut Air,
+        args: &[RirCallArg],
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<Vec<AirCallArg>> {
+        let mut air_args = Vec::new();
+        for arg in args.iter() {
+            // For inout arguments, extract the variable name before analysis
+            // so we can "unmove" it after - inout is a borrow, not a move
+            let inout_var = if arg.is_inout() {
+                self.extract_root_variable(arg.value)
+            } else {
+                None
+            };
+
+            let arg_result = self.analyze_inst(air, arg.value, ctx)?;
+
+            // If this was an inout argument, the variable shouldn't be marked as moved
+            // because inout is a mutable borrow - the value stays valid after the call
+            if let Some(var_symbol) = inout_var {
+                ctx.moved_vars.remove(&var_symbol);
+            }
+
+            air_args.push(AirCallArg {
+                value: arg_result.air_ref,
+                mode: Self::convert_arg_mode(arg.mode),
+            });
+        }
+        Ok(air_args)
+    }
+
     /// Analyze all functions in the RIR.
     ///
     /// Consumes the Sema and returns a [`SemaOutput`] containing all analyzed
@@ -2213,8 +2249,60 @@ impl<'a> Sema<'a> {
             }
 
             InstData::Assign { name, value } => {
-                // Look up the variable
                 let name_str = self.interner.get(*name);
+
+                // First check if it's a parameter (for inout params)
+                if let Some(param_info) = ctx.params.get(name) {
+                    // Check parameter mode - only inout can be assigned to
+                    match param_info.mode {
+                        RirParamMode::Normal => {
+                            // Non-inout parameters are immutable
+                            return Err(CompileError::new(
+                                ErrorKind::AssignToImmutable(name_str.to_string()),
+                                inst.span,
+                            )
+                            .with_help(format!(
+                                "consider making parameter `{}` inout: `inout {}: {}`",
+                                name_str,
+                                name_str,
+                                param_info.ty.name()
+                            )));
+                        }
+                        RirParamMode::Inout => {
+                            // Inout parameters can be assigned to - that's their purpose
+                        }
+                        RirParamMode::Borrow => {
+                            // Borrow parameters CANNOT be assigned to
+                            return Err(CompileError::new(
+                                ErrorKind::MutateBorrowedValue {
+                                    variable: name_str.to_string(),
+                                },
+                                inst.span,
+                            ));
+                        }
+                    }
+
+                    let abi_slot = param_info.abi_slot;
+
+                    // Analyze the value
+                    let value_result = self.analyze_inst(air, *value, ctx)?;
+
+                    // Assignment to a parameter resets its move state
+                    ctx.moved_vars.remove(name);
+
+                    // Emit store to param slot (codegen will use the inout pointer)
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::ParamStore {
+                            param_slot: abi_slot,
+                            value: value_result.air_ref,
+                        },
+                        ty: Type::Unit,
+                        span: inst.span,
+                    });
+                    return Ok(AnalysisResult::new(air_ref, Type::Unit));
+                }
+
+                // Look up local variable
                 let local = ctx.locals.get(name).ok_or_compile_error(
                     ErrorKind::UndefinedVariable(name_str.to_string()),
                     inst.span,
@@ -2434,14 +2522,7 @@ impl<'a> Sema<'a> {
                 let return_type = fn_info.return_type;
 
                 // Analyze arguments (move checking happens in analyze_inst for VarRef)
-                let mut air_args = Vec::new();
-                for arg in args.iter() {
-                    let arg_result = self.analyze_inst(air, arg.value, ctx)?;
-                    air_args.push(AirCallArg {
-                        value: arg_result.air_ref,
-                        mode: Self::convert_arg_mode(arg.mode),
-                    });
-                }
+                let air_args = self.analyze_call_args(air, args, ctx)?;
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Call {
@@ -2661,10 +2742,6 @@ impl<'a> Sema<'a> {
                     match &current_inst.data {
                         InstData::VarRef { name } => {
                             let name_str = self.interner.get(*name);
-                            let local = ctx.locals.get(name).ok_or_compile_error(
-                                ErrorKind::UndefinedVariable(name_str.to_string()),
-                                inst.span,
-                            )?;
 
                             // Check if this variable has been moved
                             if let Some(move_info) = ctx.moved_vars.get(name) {
@@ -2674,6 +2751,25 @@ impl<'a> Sema<'a> {
                                 )
                                 .with_label("value moved here", move_info.moved_at));
                             }
+
+                            // First check if it's a parameter
+                            if let Some(param_info) = ctx.params.get(name) {
+                                break (
+                                    name_str.to_string(),
+                                    RootKind::Param {
+                                        abi_slot: param_info.abi_slot,
+                                        mode: param_info.mode,
+                                    },
+                                    param_info.ty,
+                                    *name,
+                                );
+                            }
+
+                            // Then check locals
+                            let local = ctx.locals.get(name).ok_or_compile_error(
+                                ErrorKind::UndefinedVariable(name_str.to_string()),
+                                inst.span,
+                            )?;
 
                             break (
                                 name_str.to_string(),
@@ -2741,8 +2837,17 @@ impl<'a> Sema<'a> {
                     RootKind::Param { abi_slot, mode } => {
                         match mode {
                             RirParamMode::Normal => {
-                                // Normal (owned) parameters can be mutated
-                                // (though this is unusual - you'd typically use inout)
+                                // Non-inout parameters are immutable - cannot modify their fields
+                                return Err(CompileError::new(
+                                    ErrorKind::AssignToImmutable(var_name.clone()),
+                                    inst.span,
+                                )
+                                .with_help(format!(
+                                    "consider making parameter `{}` inout: `inout {}: {}`",
+                                    var_name,
+                                    var_name,
+                                    root_type.name()
+                                )));
                             }
                             RirParamMode::Inout => {
                                 // Inout parameters can be mutated - that's their purpose
@@ -2815,7 +2920,7 @@ impl<'a> Sema<'a> {
                 let struct_def = &self.struct_defs[struct_id.0 as usize];
                 let field_name_str = self.interner.get(*field).to_string();
 
-                let (field_index, struct_field) =
+                let (field_index, _struct_field) =
                     struct_def.find_field(&field_name_str).ok_or_compile_error(
                         ErrorKind::UnknownField {
                             struct_name: struct_def.name.clone(),
@@ -2824,25 +2929,42 @@ impl<'a> Sema<'a> {
                         inst.span,
                     )?;
 
-                let field_type = struct_field.ty;
-
-                // Compute the slot of the containing struct (the immediate base).
-                // Codegen will add field_index to get the actual field slot.
-                let base_slot = root_slot + slot_offset;
-
                 // Analyze the value with the expected field type
                 let value_result = self.analyze_inst(air, *value, ctx)?;
 
-                let air_ref = air.add_inst(AirInst {
-                    data: AirInstData::FieldSet {
-                        slot: base_slot,
-                        struct_id,
-                        field_index: field_index as u32,
-                        value: value_result.air_ref,
-                    },
-                    ty: Type::Unit,
-                    span: inst.span,
-                });
+                // Emit the appropriate instruction based on whether root is a local or param
+                let air_ref = match root_kind {
+                    RootKind::Local { slot, .. } => {
+                        // Compute the slot of the containing struct (the immediate base).
+                        // Codegen will add field_index to get the actual field slot.
+                        let base_slot = slot + slot_offset;
+                        air.add_inst(AirInst {
+                            data: AirInstData::FieldSet {
+                                slot: base_slot,
+                                struct_id,
+                                field_index: field_index as u32,
+                                value: value_result.air_ref,
+                            },
+                            ty: Type::Unit,
+                            span: inst.span,
+                        })
+                    }
+                    RootKind::Param { abi_slot, .. } => {
+                        // For inout parameters, emit ParamFieldSet.
+                        // We've already verified is_inout is true above.
+                        air.add_inst(AirInst {
+                            data: AirInstData::ParamFieldSet {
+                                param_slot: abi_slot,
+                                inner_offset: slot_offset,
+                                struct_id,
+                                field_index: field_index as u32,
+                                value: value_result.air_ref,
+                            },
+                            ty: Type::Unit,
+                            span: inst.span,
+                        })
+                    }
+                };
                 Ok(AnalysisResult::new(air_ref, Type::Unit))
             }
 
@@ -3324,13 +3446,7 @@ impl<'a> Sema<'a> {
                     value: receiver_result.air_ref,
                     mode: AirArgMode::Normal, // receiver is not inout
                 }];
-                for arg in args.iter() {
-                    let arg_result = self.analyze_inst(air, arg.value, ctx)?;
-                    air_args.push(AirCallArg {
-                        value: arg_result.air_ref,
-                        mode: Self::convert_arg_mode(arg.mode),
-                    });
-                }
+                air_args.extend(self.analyze_call_args(air, args, ctx)?);
 
                 // Generate a method call name: Type.method
                 let call_name = format!("{}.{}", struct_name_str, method_name_str);
@@ -3401,14 +3517,7 @@ impl<'a> Sema<'a> {
                 let return_type = method_info.return_type;
 
                 // Analyze arguments
-                let mut air_args = Vec::new();
-                for arg in args.iter() {
-                    let arg_result = self.analyze_inst(air, arg.value, ctx)?;
-                    air_args.push(AirCallArg {
-                        value: arg_result.air_ref,
-                        mode: Self::convert_arg_mode(arg.mode),
-                    });
-                }
+                let air_args = self.analyze_call_args(air, args, ctx)?;
 
                 // Generate a function call name: Type::function
                 let call_name = format!("{}::{}", type_name_str, function_name_str);

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -521,6 +521,22 @@ impl<'a> CfgBuilder<'a> {
                 }
             }
 
+            AirInstData::ParamStore { param_slot, value } => {
+                let val = self.lower_inst(*value).value.unwrap();
+                self.emit(
+                    CfgInstData::ParamStore {
+                        param_slot: *param_slot,
+                        value: val,
+                    },
+                    Type::Unit,
+                    span,
+                );
+                ExprResult {
+                    value: None,
+                    continuation: Continuation::Continues,
+                }
+            }
+
             AirInstData::Call { name, args } => {
                 let mut arg_vals = Vec::new();
                 for arg in args {
@@ -629,6 +645,31 @@ impl<'a> CfgBuilder<'a> {
                 self.emit(
                     CfgInstData::FieldSet {
                         slot: *slot,
+                        struct_id: *struct_id,
+                        field_index: *field_index,
+                        value: val,
+                    },
+                    Type::Unit,
+                    span,
+                );
+                ExprResult {
+                    value: None,
+                    continuation: Continuation::Continues,
+                }
+            }
+
+            AirInstData::ParamFieldSet {
+                param_slot,
+                inner_offset,
+                struct_id,
+                field_index,
+                value,
+            } => {
+                let val = self.lower_inst(*value).value.unwrap();
+                self.emit(
+                    CfgInstData::ParamFieldSet {
+                        param_slot: *param_slot,
+                        inner_offset: *inner_offset,
                         struct_id: *struct_id,
                         field_index: *field_index,
                         value: val,

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -174,6 +174,11 @@ pub enum CfgInstData {
         slot: u32,
         value: CfgValue,
     },
+    /// Store value to a parameter (for inout params)
+    ParamStore {
+        param_slot: u32,
+        value: CfgValue,
+    },
 
     // Function calls
     Call {
@@ -199,6 +204,16 @@ pub enum CfgInstData {
     },
     FieldSet {
         slot: u32,
+        struct_id: StructId,
+        field_index: u32,
+        value: CfgValue,
+    },
+    /// Store a value to a struct field (for parameters, including inout)
+    ParamFieldSet {
+        /// The parameter's ABI slot (relative to params, not locals)
+        param_slot: u32,
+        /// Offset within the struct for nested field access
+        inner_offset: u32,
         struct_id: StructId,
         field_index: u32,
         value: CfgValue,
@@ -681,6 +696,9 @@ impl Cfg {
             CfgInstData::Alloc { slot, init } => write!(f, "alloc ${} = {}", slot, init),
             CfgInstData::Load { slot } => write!(f, "load ${}", slot),
             CfgInstData::Store { slot, value } => write!(f, "store ${} = {}", slot, value),
+            CfgInstData::ParamStore { param_slot, value } => {
+                write!(f, "param_store %{} = {}", param_slot, value)
+            }
             CfgInstData::Call { name, args } => {
                 write!(f, "call {}(", name)?;
                 for (i, arg) in args.iter().enumerate() {
@@ -732,6 +750,19 @@ impl Cfg {
                     f,
                     "field_set ${}.#{}.{} = {}",
                     slot, struct_id.0, field_index, value
+                )
+            }
+            CfgInstData::ParamFieldSet {
+                param_slot,
+                inner_offset,
+                struct_id,
+                field_index,
+                value,
+            } => {
+                write!(
+                    f,
+                    "param_field_set %{}+{}.#{}.{} = {}",
+                    param_slot, inner_offset, struct_id.0, field_index, value
                 )
             }
             CfgInstData::ArrayInit {

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -101,7 +101,9 @@ fn has_side_effects(cfg: &Cfg, value: CfgValue) -> bool {
         // Memory writes
         CfgInstData::Alloc { .. } => true,
         CfgInstData::Store { .. } => true,
+        CfgInstData::ParamStore { .. } => true,
         CfgInstData::FieldSet { .. } => true,
+        CfgInstData::ParamFieldSet { .. } => true,
         CfgInstData::IndexSet { .. } => true,
 
         // Drop runs destructors
@@ -174,6 +176,7 @@ fn instruction_uses(cfg: &Cfg, value: CfgValue) -> Vec<CfgValue> {
         CfgInstData::Alloc { init, .. } => vec![*init],
         CfgInstData::Load { .. } => vec![],
         CfgInstData::Store { value, .. } => vec![*value],
+        CfgInstData::ParamStore { value, .. } => vec![*value],
 
         // Function calls
         CfgInstData::Call { args, .. } => args.iter().map(|a| a.value).collect(),
@@ -183,6 +186,7 @@ fn instruction_uses(cfg: &Cfg, value: CfgValue) -> Vec<CfgValue> {
         CfgInstData::StructInit { fields, .. } => fields.clone(),
         CfgInstData::FieldGet { base, .. } => vec![*base],
         CfgInstData::FieldSet { value, .. } => vec![*value],
+        CfgInstData::ParamFieldSet { value, .. } => vec![*value],
 
         // Array operations
         CfgInstData::ArrayInit { elements, .. } => elements.clone(),

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1220,6 +1220,33 @@ impl<'a> CfgLower<'a> {
                 }
             }
 
+            CfgInstData::ParamStore {
+                param_slot,
+                value: val,
+            } => {
+                // ParamStore is used for inout params - store through the pointer
+                let val_vreg = self.get_vreg(*val);
+
+                // For inout params, param_slot is the first ABI slot for that param.
+                // For scalar params, param_slot = param_index.
+                // For struct params, param_slot is the first slot (same as param_index for first param).
+                if self.cfg.is_param_inout(*param_slot) {
+                    if let Some(ptr_vreg) = self.inout_param_ptrs.get(param_slot).copied() {
+                        self.mir.push(Aarch64Inst::StrIndexed {
+                            src: Operand::Virtual(val_vreg),
+                            base: ptr_vreg,
+                        });
+                    } else {
+                        panic!(
+                            "ParamStore: inout param pointer not found for param slot {}",
+                            param_slot
+                        );
+                    }
+                } else {
+                    panic!("ParamStore used on non-inout param slot {}", param_slot);
+                }
+            }
+
             CfgInstData::Call { name, args } => {
                 let result_vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, result_vreg);
@@ -1640,14 +1667,33 @@ impl<'a> CfgLower<'a> {
                             });
                         }
                         FieldChainBase::Param { index } => {
-                            // Chain originates from a Param - compute offset from param slot
-                            let param_slot = self.num_locals + index + total_offset;
-                            let offset = self.local_offset(param_slot);
-                            self.mir.push(Aarch64Inst::Ldr {
-                                dst: Operand::Virtual(vreg),
-                                base: Reg::Fp,
-                                offset,
-                            });
+                            // Check if this is an inout parameter
+                            if self.cfg.is_param_inout(index) {
+                                // For inout params, use the pointer we stored earlier
+                                if let Some(ptr_vreg) = self.inout_param_ptrs.get(&index).copied() {
+                                    // Load from pointer + field offset
+                                    self.mir.push(Aarch64Inst::LdrIndexedOffset {
+                                        dst: Operand::Virtual(vreg),
+                                        base: ptr_vreg,
+                                        offset: (total_offset as i32) * 8,
+                                    });
+                                } else {
+                                    panic!(
+                                        "FieldGet: inout param pointer not found for param index {} - \
+                                         Param instruction must be lowered before FieldGet",
+                                        index
+                                    );
+                                }
+                            } else {
+                                // Non-inout param: struct is copied to our stack
+                                let param_slot = self.num_locals + index + total_offset;
+                                let offset = self.local_offset(param_slot);
+                                self.mir.push(Aarch64Inst::Ldr {
+                                    dst: Operand::Virtual(vreg),
+                                    base: Reg::Fp,
+                                    offset,
+                                });
+                            }
                         }
                     }
                 } else {
@@ -1685,6 +1731,45 @@ impl<'a> CfgLower<'a> {
                     base: Reg::Fp,
                     offset,
                 });
+            }
+
+            CfgInstData::ParamFieldSet {
+                param_slot,
+                inner_offset,
+                struct_id,
+                field_index,
+                value: val,
+            } => {
+                let val_vreg = self.get_vreg(*val);
+                let field_slot_offset = self.struct_field_slot_offset(*struct_id, *field_index);
+                let total_offset = *inner_offset + field_slot_offset;
+
+                // Check if this is an inout parameter
+                if self.cfg.is_param_inout(*param_slot) {
+                    // For inout params, store through the pointer
+                    if let Some(ptr_vreg) = self.inout_param_ptrs.get(param_slot).copied() {
+                        self.mir.push(Aarch64Inst::StrIndexedOffset {
+                            src: Operand::Virtual(val_vreg),
+                            base: ptr_vreg,
+                            offset: (total_offset as i32) * 8,
+                        });
+                    } else {
+                        panic!(
+                            "ParamFieldSet: inout param pointer not found for param slot {} - \
+                             Param instruction must be lowered before ParamFieldSet",
+                            param_slot
+                        );
+                    }
+                } else {
+                    // Non-inout param: struct is on our stack
+                    let param_stack_slot = self.num_locals + *param_slot + total_offset;
+                    let offset = self.local_offset(param_stack_slot);
+                    self.mir.push(Aarch64Inst::Str {
+                        src: Operand::Virtual(val_vreg),
+                        base: Reg::Fp,
+                        offset,
+                    });
+                }
             }
 
             CfgInstData::ArrayInit {

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -232,12 +232,15 @@ impl<'a> Emitter<'a> {
 
     /// Emit machine code for all instructions.
     pub fn emit(mut self) -> CompileResult<(Vec<u8>, Vec<EmittedRelocation>)> {
-        // Verify no LdrIndexed or StrIndexed survived into emission
+        // Verify no LdrIndexed/StrIndexed variants survived into emission
         // These should have been lowered by regalloc into Ldr/Str with physical registers
         for (i, inst) in self.mir.iter().enumerate() {
             if matches!(
                 inst,
-                Aarch64Inst::LdrIndexed { .. } | Aarch64Inst::StrIndexed { .. }
+                Aarch64Inst::LdrIndexed { .. }
+                    | Aarch64Inst::StrIndexed { .. }
+                    | Aarch64Inst::LdrIndexedOffset { .. }
+                    | Aarch64Inst::StrIndexedOffset { .. }
             ) {
                 return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
                     format!(
@@ -386,7 +389,20 @@ impl<'a> Emitter<'a> {
             Aarch64Inst::AddImm { dst, src, imm } => {
                 let rd = dst.as_physical();
                 let rn = src.as_physical();
-                self.emit_add_imm(rd, rn, *imm as u32);
+                // Adjust offset for FP-relative address calculations (same as Ldr/Str).
+                // This is used when computing addresses of locals for inout arguments.
+                let adjusted_imm = if rn == Reg::Fp && *imm < 0 {
+                    let callee_saved_size = self.callee_saved_stack_size();
+                    *imm - callee_saved_size
+                } else {
+                    *imm
+                };
+                if adjusted_imm < 0 {
+                    // Negative immediate: use SUB with the absolute value
+                    self.emit_sub_imm(rd, rn, (-adjusted_imm) as u32);
+                } else {
+                    self.emit_add_imm(rd, rn, adjusted_imm as u32);
+                }
             }
 
             Aarch64Inst::SubRR { dst, src1, src2 } => {
@@ -704,8 +720,13 @@ impl<'a> Emitter<'a> {
             }
 
             // These instructions should be caught by the verification at the start of emit()
-            Aarch64Inst::LdrIndexed { .. } | Aarch64Inst::StrIndexed { .. } => {
-                unreachable!("LdrIndexed/StrIndexed should be caught by emit() verification")
+            Aarch64Inst::LdrIndexed { .. }
+            | Aarch64Inst::StrIndexed { .. }
+            | Aarch64Inst::LdrIndexedOffset { .. }
+            | Aarch64Inst::StrIndexedOffset { .. } => {
+                unreachable!(
+                    "LdrIndexed/StrIndexed variants should be caught by emit() verification"
+                )
             }
 
             Aarch64Inst::LslImm { dst, src, imm } => {

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -296,6 +296,13 @@ fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
             add_if_virtual(src, &mut result);
             result.push(*base);
         }
+        Aarch64Inst::LdrIndexedOffset { base, .. } => {
+            result.push(*base);
+        }
+        Aarch64Inst::StrIndexedOffset { src, base, .. } => {
+            add_if_virtual(src, &mut result);
+            result.push(*base);
+        }
         Aarch64Inst::LslImm { src, .. }
         | Aarch64Inst::Lsl32Imm { src, .. }
         | Aarch64Inst::Lsr32Imm { src, .. }
@@ -406,6 +413,12 @@ fn defs(inst: &Aarch64Inst) -> Vec<VReg> {
             add_if_virtual(dst, &mut result);
         }
         Aarch64Inst::StrIndexed { .. } => {
+            // Writes to memory
+        }
+        Aarch64Inst::LdrIndexedOffset { dst, .. } => {
+            add_if_virtual(dst, &mut result);
+        }
+        Aarch64Inst::StrIndexedOffset { .. } => {
             // Writes to memory
         }
         Aarch64Inst::LslImm { dst, .. }

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -399,6 +399,20 @@ pub enum Aarch64Inst {
     /// `str src, [base]` - Store to memory via register (indexed).
     StrIndexed { src: Operand, base: VReg },
 
+    /// `ldr dst, [base, #offset]` - Load from memory via register with offset.
+    LdrIndexedOffset {
+        dst: Operand,
+        base: VReg,
+        offset: i32,
+    },
+
+    /// `str src, [base, #offset]` - Store to memory via register with offset.
+    StrIndexedOffset {
+        src: Operand,
+        base: VReg,
+        offset: i32,
+    },
+
     /// `add dst, src, #imm, lsl #12` - Add immediate with shift (for large offsets).
     /// Note: Using regular AddImm for now, this is for future large offset support.
 
@@ -751,6 +765,20 @@ impl fmt::Display for Aarch64Inst {
             }
             Aarch64Inst::LdrIndexed { dst, base } => write!(f, "ldr {}, [{}]", dst, base),
             Aarch64Inst::StrIndexed { src, base } => write!(f, "str {}, [{}]", src, base),
+            Aarch64Inst::LdrIndexedOffset { dst, base, offset } => {
+                if *offset == 0 {
+                    write!(f, "ldr {}, [{}]", dst, base)
+                } else {
+                    write!(f, "ldr {}, [{}, #{}]", dst, base, offset)
+                }
+            }
+            Aarch64Inst::StrIndexedOffset { src, base, offset } => {
+                if *offset == 0 {
+                    write!(f, "str {}, [{}]", src, base)
+                } else {
+                    write!(f, "str {}, [{}, #{}]", src, base, offset)
+                }
+            }
             Aarch64Inst::LslImm { dst, src, imm } => write!(f, "lsl {}, {}, #{}", dst, src, imm),
             Aarch64Inst::Lsl32Imm { dst, src, imm } => {
                 write!(f, "lsl {}, {}, #{} // 32-bit", dst, src, imm)

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -623,6 +623,60 @@ impl RegAlloc {
                 });
             }
 
+            Aarch64Inst::LdrIndexedOffset { dst, base, offset } => {
+                // Load base vreg into scratch, then emit load with offset
+                let base_op = Operand::Virtual(base);
+                let base_reg = self.load_operand(mir, base_op, Reg::X9)?;
+                let base_phys = match base_reg {
+                    Operand::Physical(r) => r,
+                    _ => Reg::X9,
+                };
+
+                match self.get_allocation(dst) {
+                    Some(Allocation::Register(reg)) => {
+                        mir.push(Aarch64Inst::Ldr {
+                            dst: Operand::Physical(reg),
+                            base: base_phys,
+                            offset,
+                        });
+                    }
+                    Some(Allocation::Spill(spill_offset)) => {
+                        mir.push(Aarch64Inst::Ldr {
+                            dst: Operand::Physical(Reg::X10),
+                            base: base_phys,
+                            offset,
+                        });
+                        mir.push(Aarch64Inst::Str {
+                            src: Operand::Physical(Reg::X10),
+                            base: Reg::Fp,
+                            offset: spill_offset,
+                        });
+                    }
+                    None => {
+                        mir.push(Aarch64Inst::Ldr {
+                            dst,
+                            base: base_phys,
+                            offset,
+                        });
+                    }
+                }
+            }
+
+            Aarch64Inst::StrIndexedOffset { src, base, offset } => {
+                let src_op = self.load_operand(mir, src, Reg::X9)?;
+                let base_vreg_op = Operand::Virtual(base);
+                let base_reg = self.load_operand(mir, base_vreg_op, Reg::X10)?;
+                let base_phys = match base_reg {
+                    Operand::Physical(r) => r,
+                    _ => Reg::X10,
+                };
+                mir.push(Aarch64Inst::Str {
+                    src: src_op,
+                    base: base_phys,
+                    offset,
+                });
+            }
+
             Aarch64Inst::LslImm { dst, src, imm } => {
                 let src_op = self.load_operand(mir, src, Reg::X10)?;
                 alloc_dst!(self.get_allocation(dst), dst, Reg::X9 =>

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1356,6 +1356,35 @@ impl<'a> CfgLower<'a> {
                 }
             }
 
+            CfgInstData::ParamStore {
+                param_slot,
+                value: val,
+            } => {
+                // ParamStore is used for inout params - store through the pointer
+                let val_vreg = self.get_vreg(*val);
+
+                // For inout params, param_slot is the first ABI slot for that param.
+                // For scalar params, param_slot = param_index.
+                // For struct params, param_slot is the first slot (same as param_index for first param).
+                // We use is_param_inout(param_slot) to check if this slot is inout.
+                if self.cfg.is_param_inout(*param_slot) {
+                    if let Some(ptr_vreg) = self.inout_param_ptrs.get(param_slot).copied() {
+                        self.mir.push(X86Inst::MovMRIndexed {
+                            base: ptr_vreg,
+                            offset: 0,
+                            src: Operand::Virtual(val_vreg),
+                        });
+                    } else {
+                        panic!(
+                            "ParamStore: inout param pointer not found for param slot {}",
+                            param_slot
+                        );
+                    }
+                } else {
+                    panic!("ParamStore used on non-inout param slot {}", param_slot);
+                }
+            }
+
             CfgInstData::Call { name, args } => {
                 let result_vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, result_vreg);
@@ -1778,14 +1807,33 @@ impl<'a> CfgLower<'a> {
                             });
                         }
                         FieldChainBase::Param { index } => {
-                            // Chain originates from a Param - compute offset from param slot
-                            let param_slot = self.num_locals + index + total_offset;
-                            let offset = self.local_offset(param_slot);
-                            self.mir.push(X86Inst::MovRM {
-                                dst: Operand::Virtual(vreg),
-                                base: Reg::Rbp,
-                                offset,
-                            });
+                            // Check if this is an inout parameter
+                            if self.cfg.is_param_inout(index) {
+                                // For inout params, use the pointer we stored earlier
+                                if let Some(ptr_vreg) = self.inout_param_ptrs.get(&index).copied() {
+                                    // Load from pointer + field offset
+                                    self.mir.push(X86Inst::MovRMIndexed {
+                                        dst: Operand::Virtual(vreg),
+                                        base: ptr_vreg,
+                                        offset: (total_offset as i32) * 8,
+                                    });
+                                } else {
+                                    panic!(
+                                        "FieldGet: inout param pointer not found for param index {} - \
+                                         Param instruction must be lowered before FieldGet",
+                                        index
+                                    );
+                                }
+                            } else {
+                                // Non-inout param: struct is copied to our stack
+                                let param_slot = self.num_locals + index + total_offset;
+                                let offset = self.local_offset(param_slot);
+                                self.mir.push(X86Inst::MovRM {
+                                    dst: Operand::Virtual(vreg),
+                                    base: Reg::Rbp,
+                                    offset,
+                                });
+                            }
                         }
                     }
                 } else {
@@ -1823,6 +1871,45 @@ impl<'a> CfgLower<'a> {
                     offset,
                     src: Operand::Virtual(val_vreg),
                 });
+            }
+
+            CfgInstData::ParamFieldSet {
+                param_slot,
+                inner_offset,
+                struct_id,
+                field_index,
+                value: val,
+            } => {
+                let val_vreg = self.get_vreg(*val);
+                let field_slot_offset = self.struct_field_slot_offset(*struct_id, *field_index);
+                let total_offset = *inner_offset + field_slot_offset;
+
+                // Check if this is an inout parameter
+                if self.cfg.is_param_inout(*param_slot) {
+                    // For inout params, store through the pointer
+                    if let Some(ptr_vreg) = self.inout_param_ptrs.get(param_slot).copied() {
+                        self.mir.push(X86Inst::MovMRIndexed {
+                            base: ptr_vreg,
+                            offset: (total_offset as i32) * 8,
+                            src: Operand::Virtual(val_vreg),
+                        });
+                    } else {
+                        panic!(
+                            "ParamFieldSet: inout param pointer not found for param slot {} - \
+                             Param instruction must be lowered before ParamFieldSet",
+                            param_slot
+                        );
+                    }
+                } else {
+                    // Non-inout param: struct is on our stack
+                    let param_stack_slot = self.num_locals + *param_slot + total_offset;
+                    let offset = self.local_offset(param_stack_slot);
+                    self.mir.push(X86Inst::MovMR {
+                        base: Reg::Rbp,
+                        offset,
+                        src: Operand::Virtual(val_vreg),
+                    });
+                }
             }
 
             CfgInstData::ArrayInit {

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -1035,3 +1035,239 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "cannot mutate borrowed"
+
+# =============================================================================
+# Inout parameters with structs
+# =============================================================================
+
+[[case]]
+name = "inout_struct_field_set"
+spec = ["6.1:14", "6.1:15", "6.1:16", "6.1:18"]
+description = "Inout struct parameter allows modifying a field"
+preview = "affine_types"
+source = """
+struct Point { x: i32, y: i32 }
+
+fn increment_x(inout p: Point) {
+    p.x = p.x + 1;
+}
+
+fn main() -> i32 {
+    let mut pt = Point { x: 41, y: 0 };
+    increment_x(inout pt);
+    pt.x
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_struct_field_get"
+spec = ["6.1:14", "6.1:18"]
+description = "Inout struct parameter allows reading fields"
+preview = "affine_types"
+source = """
+struct Point { x: i32, y: i32 }
+
+fn get_sum(inout p: Point) -> i32 {
+    p.x + p.y
+}
+
+fn main() -> i32 {
+    let mut pt = Point { x: 20, y: 22 };
+    get_sum(inout pt)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_struct_multiple_fields"
+spec = ["6.1:14", "6.1:18"]
+description = "Inout struct parameter allows modifying multiple fields"
+preview = "affine_types"
+source = """
+struct Point { x: i32, y: i32 }
+
+fn swap_xy(inout p: Point) {
+    let tmp = p.x;
+    p.x = p.y;
+    p.y = tmp;
+}
+
+fn main() -> i32 {
+    let mut pt = Point { x: 10, y: 42 };
+    swap_xy(inout pt);
+    pt.x
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_struct_return_and_modify"
+spec = ["6.1:14", "6.1:18"]
+description = "Inout struct parameter with return value"
+preview = "affine_types"
+source = """
+struct Point { x: i32, y: i32 }
+
+fn increment_x_return_old(inout p: Point) -> i32 {
+    let old = p.x;
+    p.x = p.x + 1;
+    old
+}
+
+fn main() -> i32 {
+    let mut pt = Point { x: 40, y: 0 };
+    let old = increment_x_return_old(inout pt);
+    old + pt.x
+}
+"""
+exit_code = 81
+
+[[case]]
+name = "inout_struct_multiple_calls"
+spec = ["6.1:14", "6.1:18"]
+description = "Multiple calls with inout struct accumulate changes"
+preview = "affine_types"
+source = """
+struct Counter { value: i32 }
+
+fn increment(inout c: Counter) {
+    c.value = c.value + 1;
+}
+
+fn main() -> i32 {
+    let mut counter = Counter { value: 39 };
+    increment(inout counter);
+    increment(inout counter);
+    increment(inout counter);
+    counter.value
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_struct_with_regular_param"
+spec = ["6.1:14", "6.1:15"]
+description = "Mixing inout struct and regular parameters"
+preview = "affine_types"
+source = """
+struct Counter { value: i32 }
+
+fn add_to(inout c: Counter, amount: i32) {
+    c.value = c.value + amount;
+}
+
+fn main() -> i32 {
+    let mut counter = Counter { value: 32 };
+    add_to(inout counter, 10);
+    counter.value
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_nested_struct"
+spec = ["6.1:14", "6.1:18"]
+description = "Inout with nested struct - modify inner field"
+preview = "affine_types"
+source = """
+struct Inner { value: i32 }
+struct Outer { inner: Inner, extra: i32 }
+
+fn increment_inner(inout o: Outer) {
+    o.inner.value = o.inner.value + 1;
+}
+
+fn main() -> i32 {
+    let mut data = Outer { inner: Inner { value: 41 }, extra: 0 };
+    increment_inner(inout data);
+    data.inner.value
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_forward_struct"
+spec = ["6.1:14", "6.1:18"]
+description = "Forwarding inout struct parameter to another function"
+preview = "affine_types"
+source = """
+struct Counter { value: i32 }
+
+fn increment_by(inout c: Counter, amount: i32) {
+    c.value = c.value + amount;
+}
+
+fn double_increment(inout c: Counter) {
+    increment_by(inout c, 2);
+}
+
+fn main() -> i32 {
+    let mut counter = Counter { value: 40 };
+    double_increment(inout counter);
+    counter.value
+}
+"""
+exit_code = 42
+
+# =============================================================================
+# Parameter immutability (non-inout params cannot be assigned)
+# =============================================================================
+
+[[case]]
+name = "assign_to_non_inout_param"
+spec = ["6.1:32"]
+description = "Cannot assign to a non-inout parameter"
+preview = "affine_types"
+source = """
+fn bad(x: i32) {
+    x = 5;
+}
+fn main() -> i32 {
+    bad(10);
+    0
+}
+"""
+compile_fail = true
+error_contains = "immutable"
+
+[[case]]
+name = "assign_to_non_inout_struct_param_field"
+spec = ["6.1:32"]
+description = "Cannot assign to a field of a non-inout struct parameter"
+preview = "affine_types"
+source = """
+struct Point { x: i32, y: i32 }
+
+fn bad(p: Point) {
+    p.x = 10;
+}
+fn main() -> i32 {
+    let pt = Point { x: 1, y: 2 };
+    bad(pt);
+    0
+}
+"""
+compile_fail = true
+error_contains = "immutable"
+
+[[case]]
+name = "assign_to_non_inout_nested_struct_param_field"
+spec = ["6.1:32"]
+description = "Cannot assign to a nested field of a non-inout struct parameter"
+preview = "affine_types"
+source = """
+struct Inner { value: i32 }
+struct Outer { inner: Inner }
+
+fn bad(o: Outer) {
+    o.inner.value = 10;
+}
+fn main() -> i32 {
+    let data = Outer { inner: Inner { value: 1 } };
+    bad(data);
+    0
+}
+"""
+compile_fail = true
+error_contains = "immutable"

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -185,6 +185,27 @@ fn main() -> i32 {
 }
 ```
 
+## Parameter Immutability
+
+{{ rule(id="6.1:32", cat="legality-rule") }}
+
+A parameter that is not marked `inout` is immutable within the function body. Assigning to such a parameter or modifying its fields is a compile-time error.
+
+{{ rule(id="6.1:33", cat="example") }}
+
+```rue
+fn bad(x: i32) {
+    x = 5;  // error: cannot assign to immutable parameter 'x'
+}
+
+struct Point { x: i32, y: i32 }
+
+fn also_bad(p: Point) {
+    p.x = 10;  // error: cannot assign to immutable parameter 'p'
+}
+```
+
+
 ## Entry Point
 
 {{ rule(id="6.1:7", cat="legality-rule") }}


### PR DESCRIPTION
Extend inout parameter handling to support:
- Direct assignment to inout parameters (ParamStore instruction)
- Field assignment on inout struct parameters (ParamFieldSet instruction)
- Proper unmove semantics for inout arguments (not marked as moved)
- Mutability checks: non-inout params are now immutable

Key changes:
- Add ParamStore/ParamFieldSet instructions to AIR and CFG
- Track is_inout in ParamInfo for compile-time mutability checks
- Emit proper errors for assigning to non-inout parameters
- Add spec rule 6.1:22 making parameter immutability explicit
- Both x86_64 and aarch64 backends updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)