### PR TITLE
Add inout parameter support for array types

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -404,6 +404,18 @@ pub enum AirInstData {
         value: AirRef,
     },
 
+    /// Store a value to an array element of an inout parameter
+    ParamIndexSet {
+        /// The parameter's ABI slot (relative to params, not locals)
+        param_slot: u32,
+        /// The array type
+        array_type_id: ArrayTypeId,
+        /// Index expression
+        index: AirRef,
+        /// Value to store
+        value: AirRef,
+    },
+
     // Enum operations
     /// Create an enum variant value
     EnumVariant {
@@ -640,6 +652,18 @@ impl fmt::Display for Air {
                         f,
                         "index_set ${}(@{})[{}] = {}",
                         slot, array_type_id.0, index, value
+                    )?;
+                }
+                AirInstData::ParamIndexSet {
+                    param_slot,
+                    array_type_id,
+                    index,
+                    value,
+                } => {
+                    writeln!(
+                        f,
+                        "param_index_set param{}(@{})[{}] = {}",
+                        param_slot, array_type_id.0, index, value
                     )?;
                 }
                 AirInstData::EnumVariant {

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -3160,10 +3160,6 @@ impl<'a> Sema<'a> {
                 let (var_name, root_kind, base_type) = match &base_inst.data {
                     InstData::VarRef { name } => {
                         let name_str = self.interner.get(*name);
-                        let local = ctx.locals.get(name).ok_or_compile_error(
-                            ErrorKind::UndefinedVariable(name_str.to_string()),
-                            inst.span,
-                        )?;
 
                         // Check if this variable has been moved
                         if let Some(move_info) = ctx.moved_vars.get(name) {
@@ -3174,14 +3170,32 @@ impl<'a> Sema<'a> {
                             .with_label("value moved here", move_info.moved_at));
                         }
 
-                        (
-                            name_str.to_string(),
-                            IndexSetRootKind::Local {
-                                slot: local.slot,
-                                is_mut: local.is_mut,
-                            },
-                            local.ty,
-                        )
+                        // First check if it's a parameter (like FieldSet does)
+                        if let Some(param_info) = ctx.params.get(name) {
+                            (
+                                name_str.to_string(),
+                                IndexSetRootKind::Param {
+                                    abi_slot: param_info.abi_slot,
+                                    mode: param_info.mode,
+                                },
+                                param_info.ty,
+                            )
+                        } else {
+                            // Then check locals
+                            let local = ctx.locals.get(name).ok_or_compile_error(
+                                ErrorKind::UndefinedVariable(name_str.to_string()),
+                                inst.span,
+                            )?;
+
+                            (
+                                name_str.to_string(),
+                                IndexSetRootKind::Local {
+                                    slot: local.slot,
+                                    is_mut: local.is_mut,
+                                },
+                                local.ty,
+                            )
+                        }
                     }
                     InstData::ParamRef { name, .. } => {
                         let name_str = self.interner.get(*name);
@@ -3217,7 +3231,7 @@ impl<'a> Sema<'a> {
                 };
 
                 // Check mutability based on root kind
-                let slot = match root_kind {
+                let (is_inout_param, slot) = match root_kind {
                     IndexSetRootKind::Local { slot, is_mut } => {
                         if !is_mut {
                             return Err(CompileError::new(
@@ -3225,15 +3239,17 @@ impl<'a> Sema<'a> {
                                 inst.span,
                             ));
                         }
-                        slot
+                        (false, slot)
                     }
                     IndexSetRootKind::Param { abi_slot, mode } => {
-                        match mode {
+                        let is_inout = match mode {
                             RirParamMode::Normal => {
                                 // Normal (owned) parameters can be mutated
+                                false
                             }
                             RirParamMode::Inout => {
                                 // Inout parameters can be mutated
+                                true
                             }
                             RirParamMode::Borrow => {
                                 // Borrow parameters CANNOT be mutated
@@ -3242,8 +3258,8 @@ impl<'a> Sema<'a> {
                                     inst.span,
                                 ));
                             }
-                        }
-                        abi_slot
+                        };
+                        (is_inout, abi_slot)
                     }
                 };
 
@@ -3291,16 +3307,30 @@ impl<'a> Sema<'a> {
                 // Analyze the value with the expected element type
                 let value_result = self.analyze_inst(air, *value, ctx)?;
 
-                let air_ref = air.add_inst(AirInst {
-                    data: AirInstData::IndexSet {
-                        slot,
-                        array_type_id,
-                        index: index_result.air_ref,
-                        value: value_result.air_ref,
-                    },
-                    ty: Type::Unit,
-                    span: inst.span,
-                });
+                // Emit appropriate instruction based on whether this is an inout parameter
+                let air_ref = if is_inout_param {
+                    air.add_inst(AirInst {
+                        data: AirInstData::ParamIndexSet {
+                            param_slot: slot,
+                            array_type_id,
+                            index: index_result.air_ref,
+                            value: value_result.air_ref,
+                        },
+                        ty: Type::Unit,
+                        span: inst.span,
+                    })
+                } else {
+                    air.add_inst(AirInst {
+                        data: AirInstData::IndexSet {
+                            slot,
+                            array_type_id,
+                            index: index_result.air_ref,
+                            value: value_result.air_ref,
+                        },
+                        ty: Type::Unit,
+                        span: inst.span,
+                    })
+                };
                 Ok(AnalysisResult::new(air_ref, Type::Unit))
             }
 

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1309,6 +1309,30 @@ impl<'a> CfgBuilder<'a> {
                 }
             }
 
+            AirInstData::ParamIndexSet {
+                param_slot,
+                array_type_id,
+                index,
+                value,
+            } => {
+                let index_val = self.lower_inst(*index).value.unwrap();
+                let val = self.lower_inst(*value).value.unwrap();
+                self.emit(
+                    CfgInstData::ParamIndexSet {
+                        param_slot: *param_slot,
+                        array_type_id: *array_type_id,
+                        index: index_val,
+                        value: val,
+                    },
+                    Type::Unit,
+                    span,
+                );
+                ExprResult {
+                    value: None,
+                    continuation: Continuation::Continues,
+                }
+            }
+
             AirInstData::EnumVariant {
                 enum_id,
                 variant_index,

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -235,6 +235,17 @@ pub enum CfgInstData {
         index: CfgValue,
         value: CfgValue,
     },
+    /// Store a value to an array element of an inout parameter
+    ParamIndexSet {
+        /// The parameter's ABI slot (relative to params, not locals)
+        param_slot: u32,
+        /// The array type
+        array_type_id: ArrayTypeId,
+        /// Index expression
+        index: CfgValue,
+        /// Value to store
+        value: CfgValue,
+    },
 
     // Enum operations
     /// Create an enum variant (discriminant value)
@@ -795,6 +806,18 @@ impl Cfg {
                     f,
                     "index_set ${}(@{})[{}] = {}",
                     slot, array_type_id.0, index, value
+                )
+            }
+            CfgInstData::ParamIndexSet {
+                param_slot,
+                array_type_id,
+                index,
+                value,
+            } => {
+                write!(
+                    f,
+                    "param_index_set %{}(@{})[{}] = {}",
+                    param_slot, array_type_id.0, index, value
                 )
             }
             CfgInstData::EnumVariant {

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -105,6 +105,7 @@ fn has_side_effects(cfg: &Cfg, value: CfgValue) -> bool {
         CfgInstData::FieldSet { .. } => true,
         CfgInstData::ParamFieldSet { .. } => true,
         CfgInstData::IndexSet { .. } => true,
+        CfgInstData::ParamIndexSet { .. } => true,
 
         // Drop runs destructors
         CfgInstData::Drop { .. } => true,
@@ -192,6 +193,7 @@ fn instruction_uses(cfg: &Cfg, value: CfgValue) -> Vec<CfgValue> {
         CfgInstData::ArrayInit { elements, .. } => elements.clone(),
         CfgInstData::IndexGet { base, index, .. } => vec![*base, *index],
         CfgInstData::IndexSet { index, value, .. } => vec![*index, *value],
+        CfgInstData::ParamIndexSet { index, value, .. } => vec![*index, *value],
 
         // Enum operations
         CfgInstData::EnumVariant { .. } => vec![],

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1840,22 +1840,6 @@ impl<'a> CfgLower<'a> {
                     let array_length = self.array_length(*array_type_id);
                     self.emit_bounds_check(innermost_index_vreg, array_length);
 
-                    // Determine the base offset
-                    let base_offset = match &chain_base {
-                        IndexChainBase::Load { slot } => self.local_offset(*slot),
-                        IndexChainBase::Param { index: param_index } => {
-                            let base_slot = self.num_locals + *param_index as u32;
-                            self.local_offset(base_slot)
-                        }
-                        IndexChainBase::FieldGet {
-                            struct_base_slot,
-                            field_slot_offset,
-                        } => {
-                            let array_base_slot = struct_base_slot + field_slot_offset;
-                            self.local_offset(array_base_slot)
-                        }
-                    };
-
                     // Calculate total offset by summing index * stride for each level
                     let mut total_offset_vreg: Option<VReg> = None;
 
@@ -1900,8 +1884,55 @@ impl<'a> CfgLower<'a> {
                         }
                     }
 
-                    // Compute base address
+                    // Compute base address - different for inout params vs locals/normal params
                     let addr_vreg = self.mir.alloc_vreg();
+
+                    if let IndexChainBase::Param { index: param_index } = &chain_base {
+                        // Check if this is an inout parameter
+                        if self.cfg.is_param_inout(*param_index) {
+                            // For inout params, use the stored pointer
+                            if let Some(ptr_vreg) = self.inout_param_ptrs.get(param_index).copied()
+                            {
+                                self.mir.push(Aarch64Inst::MovRR {
+                                    dst: Operand::Virtual(addr_vreg),
+                                    src: Operand::Virtual(ptr_vreg),
+                                });
+
+                                // Subtract total offset
+                                if let Some(total) = total_offset_vreg {
+                                    self.mir.push(Aarch64Inst::SubRR {
+                                        dst: Operand::Virtual(addr_vreg),
+                                        src1: Operand::Virtual(addr_vreg),
+                                        src2: Operand::Virtual(total),
+                                    });
+                                }
+
+                                // Load from computed address
+                                self.mir.push(Aarch64Inst::LdrIndexed {
+                                    dst: Operand::Virtual(vreg),
+                                    base: addr_vreg,
+                                });
+                                return;
+                            }
+                        }
+                    }
+
+                    // Normal case: compute from FP offset
+                    let base_offset = match &chain_base {
+                        IndexChainBase::Load { slot } => self.local_offset(*slot),
+                        IndexChainBase::Param { index: param_index } => {
+                            let base_slot = self.num_locals + *param_index as u32;
+                            self.local_offset(base_slot)
+                        }
+                        IndexChainBase::FieldGet {
+                            struct_base_slot,
+                            field_slot_offset,
+                        } => {
+                            let array_base_slot = struct_base_slot + field_slot_offset;
+                            self.local_offset(array_base_slot)
+                        }
+                    };
+
                     self.mir.push(Aarch64Inst::SubImm {
                         dst: Operand::Virtual(addr_vreg),
                         src: Operand::Physical(Reg::Fp),
@@ -1974,6 +2005,51 @@ impl<'a> CfgLower<'a> {
                     src: Operand::Virtual(val_vreg),
                     base: addr_vreg,
                 });
+            }
+
+            CfgInstData::ParamIndexSet {
+                param_slot,
+                array_type_id,
+                index,
+                value: val,
+            } => {
+                let val_vreg = self.get_vreg(*val);
+                let index_vreg = self.get_vreg(*index);
+
+                // Emit runtime bounds check
+                let array_length = self.array_length(*array_type_id);
+                self.emit_bounds_check(index_vreg, array_length);
+
+                // Shift left by 3 (multiply by 8)
+                let scaled_index = self.mir.alloc_vreg();
+                self.mir.push(Aarch64Inst::LslImm {
+                    dst: Operand::Virtual(scaled_index),
+                    src: Operand::Virtual(index_vreg),
+                    imm: 3,
+                });
+
+                // For inout params, store through the pointer
+                if let Some(ptr_vreg) = self.inout_param_ptrs.get(param_slot).copied() {
+                    // Calculate address: ptr - (index * 8)
+                    // (Arrays are stored with element 0 at the highest address)
+                    let addr_vreg = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::SubRR {
+                        dst: Operand::Virtual(addr_vreg),
+                        src1: Operand::Virtual(ptr_vreg),
+                        src2: Operand::Virtual(scaled_index),
+                    });
+
+                    self.mir.push(Aarch64Inst::StrIndexed {
+                        src: Operand::Virtual(val_vreg),
+                        base: addr_vreg,
+                    });
+                } else {
+                    panic!(
+                        "ParamIndexSet: inout param pointer not found for param slot {} - \
+                         Param instruction must be lowered before ParamIndexSet",
+                        param_slot
+                    );
+                }
             }
 
             CfgInstData::EnumVariant { variant_index, .. } => {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1982,22 +1982,6 @@ impl<'a> CfgLower<'a> {
                     let array_length = self.array_length(*array_type_id);
                     self.emit_bounds_check(innermost_index_vreg, array_length);
 
-                    // Determine the base offset
-                    let base_offset = match &chain_base {
-                        IndexChainBase::Load { slot } => self.local_offset(*slot),
-                        IndexChainBase::Param { index: param_index } => {
-                            let base_slot = self.num_locals + *param_index as u32;
-                            self.local_offset(base_slot)
-                        }
-                        IndexChainBase::FieldGet {
-                            struct_base_slot,
-                            field_slot_offset,
-                        } => {
-                            let array_base_slot = struct_base_slot + field_slot_offset;
-                            self.local_offset(array_base_slot)
-                        }
-                    };
-
                     // Calculate total offset by summing index * stride for each level
                     let mut total_offset_vreg: Option<VReg> = None;
 
@@ -2048,8 +2032,55 @@ impl<'a> CfgLower<'a> {
                         }
                     }
 
-                    // Compute base address
+                    // Compute base address - different for inout params vs locals/normal params
                     let addr_vreg = self.mir.alloc_vreg();
+
+                    if let IndexChainBase::Param { index: param_index } = &chain_base {
+                        // Check if this is an inout parameter
+                        if self.cfg.is_param_inout(*param_index) {
+                            // For inout params, use the stored pointer
+                            if let Some(ptr_vreg) = self.inout_param_ptrs.get(param_index).copied()
+                            {
+                                self.mir.push(X86Inst::MovRR {
+                                    dst: Operand::Virtual(addr_vreg),
+                                    src: Operand::Virtual(ptr_vreg),
+                                });
+
+                                // Subtract total offset
+                                if let Some(total) = total_offset_vreg {
+                                    self.mir.push(X86Inst::SubRR64 {
+                                        dst: Operand::Virtual(addr_vreg),
+                                        src: Operand::Virtual(total),
+                                    });
+                                }
+
+                                // Load from computed address
+                                self.mir.push(X86Inst::MovRMIndexed {
+                                    dst: Operand::Virtual(vreg),
+                                    base: addr_vreg,
+                                    offset: 0,
+                                });
+                                return;
+                            }
+                        }
+                    }
+
+                    // Normal case: compute from RBP offset
+                    let base_offset = match &chain_base {
+                        IndexChainBase::Load { slot } => self.local_offset(*slot),
+                        IndexChainBase::Param { index: param_index } => {
+                            let base_slot = self.num_locals + *param_index as u32;
+                            self.local_offset(base_slot)
+                        }
+                        IndexChainBase::FieldGet {
+                            struct_base_slot,
+                            field_slot_offset,
+                        } => {
+                            let array_base_slot = struct_base_slot + field_slot_offset;
+                            self.local_offset(array_base_slot)
+                        }
+                    };
+
                     self.mir.push(X86Inst::Lea {
                         dst: Operand::Virtual(addr_vreg),
                         base: Reg::Rbp,
@@ -2129,6 +2160,63 @@ impl<'a> CfgLower<'a> {
                     offset: 0,
                     src: Operand::Virtual(val_vreg),
                 });
+            }
+
+            CfgInstData::ParamIndexSet {
+                param_slot,
+                array_type_id,
+                index,
+                value: val,
+            } => {
+                let val_vreg = self.get_vreg(*val);
+                let index_vreg = self.get_vreg(*index);
+
+                // Emit runtime bounds check
+                let array_length = self.array_length(*array_type_id);
+                self.emit_bounds_check(index_vreg, array_length);
+
+                // Scale index by 8 (element size)
+                let scaled_index = self.mir.alloc_vreg();
+                self.mir.push(X86Inst::MovRR {
+                    dst: Operand::Virtual(scaled_index),
+                    src: Operand::Virtual(index_vreg),
+                });
+                let eight = self.mir.alloc_vreg();
+                self.mir.push(X86Inst::MovRI32 {
+                    dst: Operand::Virtual(eight),
+                    imm: 3,
+                });
+                self.mir.push(X86Inst::Shl {
+                    dst: Operand::Virtual(scaled_index),
+                    count: Operand::Virtual(eight),
+                });
+
+                // For inout params, store through the pointer
+                if let Some(ptr_vreg) = self.inout_param_ptrs.get(param_slot).copied() {
+                    // Calculate address: ptr - (index * 8)
+                    // (Arrays are stored with element 0 at the highest address)
+                    let addr_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(addr_vreg),
+                        src: Operand::Virtual(ptr_vreg),
+                    });
+                    self.mir.push(X86Inst::SubRR64 {
+                        dst: Operand::Virtual(addr_vreg),
+                        src: Operand::Virtual(scaled_index),
+                    });
+
+                    self.mir.push(X86Inst::MovMRIndexed {
+                        base: addr_vreg,
+                        offset: 0,
+                        src: Operand::Virtual(val_vreg),
+                    });
+                } else {
+                    panic!(
+                        "ParamIndexSet: inout param pointer not found for param slot {} - \
+                         Param instruction must be lowered before ParamIndexSet",
+                        param_slot
+                    );
+                }
             }
 
             CfgInstData::EnumVariant { variant_index, .. } => {

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -1271,3 +1271,159 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "immutable"
+
+# =============================================================================
+# Inout parameters with arrays
+# =============================================================================
+
+[[case]]
+name = "inout_array_element_get"
+spec = ["6.1:14", "6.1:18"]
+description = "Inout array parameter allows reading elements"
+preview = "affine_types"
+source = """
+fn get_first(inout arr: [i32; 3]) -> i32 {
+    arr[0]
+}
+
+fn main() -> i32 {
+    let mut a = [42, 0, 0];
+    get_first(inout a)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_array_element_set"
+spec = ["6.1:14", "6.1:18"]
+description = "Inout array parameter allows modifying elements"
+preview = "affine_types"
+source = """
+fn increment_first(inout arr: [i32; 3]) {
+    arr[0] = arr[0] + 1;
+}
+
+fn main() -> i32 {
+    let mut a = [41, 0, 0];
+    increment_first(inout a);
+    a[0]
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_array_multiple_elements"
+spec = ["6.1:14", "6.1:18"]
+description = "Inout array parameter allows modifying multiple elements"
+preview = "affine_types"
+source = """
+fn swap_first_two(inout arr: [i32; 3]) {
+    let tmp = arr[0];
+    arr[0] = arr[1];
+    arr[1] = tmp;
+}
+
+fn main() -> i32 {
+    let mut a = [10, 42, 0];
+    swap_first_two(inout a);
+    a[0]
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_array_return_and_modify"
+spec = ["6.1:14", "6.1:18"]
+description = "Inout array parameter with return value"
+preview = "affine_types"
+source = """
+fn increment_return_old(inout arr: [i32; 3]) -> i32 {
+    let old = arr[0];
+    arr[0] = arr[0] + 1;
+    old
+}
+
+fn main() -> i32 {
+    let mut a = [40, 0, 0];
+    let old = increment_return_old(inout a);
+    old + a[0]
+}
+"""
+exit_code = 81
+
+[[case]]
+name = "inout_array_multiple_calls"
+spec = ["6.1:14", "6.1:18"]
+description = "Multiple calls with inout array accumulate changes"
+preview = "affine_types"
+source = """
+fn increment_first(inout arr: [i32; 3]) {
+    arr[0] = arr[0] + 1;
+}
+
+fn main() -> i32 {
+    let mut a = [39, 0, 0];
+    increment_first(inout a);
+    increment_first(inout a);
+    increment_first(inout a);
+    a[0]
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_array_with_index_variable"
+spec = ["6.1:14", "6.1:18"]
+description = "Inout array with variable index"
+preview = "affine_types"
+source = """
+fn set_element(inout arr: [i32; 3], idx: u64, val: i32) {
+    arr[idx] = val;
+}
+
+fn main() -> i32 {
+    let mut a = [0, 0, 0];
+    set_element(inout a, 1, 42);
+    a[1]
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_array_forward"
+spec = ["6.1:14", "6.1:18"]
+description = "Forwarding inout array parameter to another function"
+preview = "affine_types"
+source = """
+fn increment_by(inout arr: [i32; 3], amount: i32) {
+    arr[0] = arr[0] + amount;
+}
+
+fn double_increment(inout arr: [i32; 3]) {
+    increment_by(inout arr, 2);
+}
+
+fn main() -> i32 {
+    let mut a = [40, 0, 0];
+    double_increment(inout a);
+    a[0]
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_array_sum"
+spec = ["6.1:14", "6.1:18"]
+description = "Reading all elements of an inout array"
+preview = "affine_types"
+source = """
+fn sum_array(inout arr: [i32; 3]) -> i32 {
+    arr[0] + arr[1] + arr[2]
+}
+
+fn main() -> i32 {
+    let mut a = [10, 20, 12];
+    sum_array(inout a)
+}
+"""
+exit_code = 42


### PR DESCRIPTION
Enable reading and modifying array elements through inout parameters. This required:
- Adding ParamIndexSet AIR/CFG instruction for array element mutation
- Fixing IndexSet in sema to check params before locals (like FieldSet)
- Updating IndexGet codegen to use pointer-based access for inout params
- Adding ParamIndexSet handling in both x86_64 and aarch64 backends

Fixes rue-dfr8.9

🤖 Generated with [Claude Code](https://claude.com/claude-code)