### PR TITLE
Stabilize inout and borrow parameter modes

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -27,3 +27,12 @@ pub use sema::{AnalyzedFunction, Sema, SemaOutput};
 pub use types::{
     ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructField, StructId, Type,
 };
+
+/// Sentinel value used to encode parameter slots in AIR instructions.
+///
+/// When a slot value is >= this marker, it indicates a parameter slot rather than
+/// a local variable slot. The actual parameter index is `slot - PARAM_SLOT_MARKER`.
+///
+/// This allows sema to emit Store/Load instructions for parameters without knowing
+/// the total number of locals at analysis time.
+pub const PARAM_SLOT_MARKER: u32 = 0x4000_0000;

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -199,6 +199,8 @@ impl AnalysisContext<'_> {
 struct FunctionInfo {
     /// Parameter types (in order)
     param_types: Vec<Type>,
+    /// Parameter modes (in order)
+    param_modes: Vec<RirParamMode>,
     /// Return type
     return_type: Type,
 }
@@ -400,7 +402,23 @@ impl<'a> Sema<'a> {
         let mut borrow_vars: HashSet<Symbol> = HashSet::new();
 
         for arg in args {
-            if let Some(var_symbol) = self.extract_root_variable(arg.value) {
+            let maybe_var_symbol = self.extract_root_variable(arg.value);
+
+            // Check that inout/borrow arguments are lvalues
+            if arg.is_inout() && maybe_var_symbol.is_none() {
+                return Err(CompileError::new(
+                    ErrorKind::InoutNonLvalue,
+                    self.rir.get(arg.value).span,
+                ));
+            }
+            if arg.is_borrow() && maybe_var_symbol.is_none() {
+                return Err(CompileError::new(
+                    ErrorKind::BorrowNonLvalue,
+                    self.rir.get(arg.value).span,
+                ));
+            }
+
+            if let Some(var_symbol) = maybe_var_symbol {
                 if arg.is_inout() {
                     // Check for duplicate inout access
                     if !inout_vars.insert(var_symbol) {
@@ -446,9 +464,9 @@ impl<'a> Sema<'a> {
     ) -> CompileResult<Vec<AirCallArg>> {
         let mut air_args = Vec::new();
         for arg in args.iter() {
-            // For inout arguments, extract the variable name before analysis
-            // so we can "unmove" it after - inout is a borrow, not a move
-            let inout_var = if arg.is_inout() {
+            // For inout/borrow arguments, extract the variable name before analysis
+            // so we can "unmove" it after - these are borrows, not moves
+            let borrowed_var = if arg.is_inout() || arg.is_borrow() {
                 self.extract_root_variable(arg.value)
             } else {
                 None
@@ -456,9 +474,9 @@ impl<'a> Sema<'a> {
 
             let arg_result = self.analyze_inst(air, arg.value, ctx)?;
 
-            // If this was an inout argument, the variable shouldn't be marked as moved
-            // because inout is a mutable borrow - the value stays valid after the call
-            if let Some(var_symbol) = inout_var {
+            // If this was an inout/borrow argument, the variable shouldn't be marked as moved
+            // because these are borrows - the value stays valid after the call
+            if let Some(var_symbol) = borrowed_var {
                 ctx.moved_vars.remove(&var_symbol);
             }
 
@@ -895,11 +913,13 @@ impl<'a> Sema<'a> {
                     .iter()
                     .map(|p| self.resolve_type(p.ty, inst.span))
                     .collect::<CompileResult<Vec<_>>>()?;
+                let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
 
                 self.functions.insert(
                     *name,
                     FunctionInfo {
                         param_types,
+                        param_modes,
                         return_type: ret_type,
                     },
                 );
@@ -1006,9 +1026,14 @@ impl<'a> Sema<'a> {
                     mode: *mode,
                 },
             );
-            let slot_count = self.abi_slot_count(*ptype);
-            // Both inout and borrow are passed by reference
+            // Both inout and borrow are passed by reference (as a pointer = 1 slot)
             let is_by_ref = *mode != RirParamMode::Normal;
+            let slot_count = if is_by_ref {
+                // By-ref parameters are always 1 slot (pointer)
+                1
+            } else {
+                self.abi_slot_count(*ptype)
+            };
             for _ in 0..slot_count {
                 param_modes.push(is_by_ref);
             }
@@ -2519,7 +2544,33 @@ impl<'a> Sema<'a> {
 
                 // Clone the data we need before mutable borrow
                 let param_types = fn_info.param_types.clone();
+                let param_modes = fn_info.param_modes.clone();
                 let return_type = fn_info.return_type;
+
+                // Check that call-site argument modes match function parameter modes
+                for (i, (arg, expected_mode)) in args.iter().zip(param_modes.iter()).enumerate() {
+                    match expected_mode {
+                        RirParamMode::Inout => {
+                            if arg.mode != RirArgMode::Inout {
+                                return Err(CompileError::new(
+                                    ErrorKind::InoutKeywordMissing,
+                                    self.rir.get(args[i].value).span,
+                                ));
+                            }
+                        }
+                        RirParamMode::Borrow => {
+                            if arg.mode != RirArgMode::Borrow {
+                                return Err(CompileError::new(
+                                    ErrorKind::BorrowKeywordMissing,
+                                    self.rir.get(args[i].value).span,
+                                ));
+                            }
+                        }
+                        RirParamMode::Normal => {
+                            // Normal params accept any mode (for now)
+                        }
+                    }
+                }
 
                 // Analyze arguments (move checking happens in analyze_inst for VarRef)
                 let air_args = self.analyze_call_args(air, args, ctx)?;

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1671,11 +1671,11 @@ impl<'a> CfgLower<'a> {
                             if self.cfg.is_param_inout(index) {
                                 // For inout params, use the pointer we stored earlier
                                 if let Some(ptr_vreg) = self.inout_param_ptrs.get(&index).copied() {
-                                    // Load from pointer + field offset
+                                    // Load from pointer - field offset (negative because stack grows down)
                                     self.mir.push(Aarch64Inst::LdrIndexedOffset {
                                         dst: Operand::Virtual(vreg),
                                         base: ptr_vreg,
-                                        offset: (total_offset as i32) * 8,
+                                        offset: -((total_offset as i32) * 8),
                                     });
                                 } else {
                                     panic!(
@@ -1748,10 +1748,11 @@ impl<'a> CfgLower<'a> {
                 if self.cfg.is_param_inout(*param_slot) {
                     // For inout params, store through the pointer
                     if let Some(ptr_vreg) = self.inout_param_ptrs.get(param_slot).copied() {
+                        // Negative offset because stack grows down
                         self.mir.push(Aarch64Inst::StrIndexedOffset {
                             src: Operand::Virtual(val_vreg),
                             base: ptr_vreg,
-                            offset: (total_offset as i32) * 8,
+                            offset: -((total_offset as i32) * 8),
                         });
                     } else {
                         panic!(

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1811,11 +1811,11 @@ impl<'a> CfgLower<'a> {
                             if self.cfg.is_param_inout(index) {
                                 // For inout params, use the pointer we stored earlier
                                 if let Some(ptr_vreg) = self.inout_param_ptrs.get(&index).copied() {
-                                    // Load from pointer + field offset
+                                    // Load from pointer - field offset (negative because stack grows down)
                                     self.mir.push(X86Inst::MovRMIndexed {
                                         dst: Operand::Virtual(vreg),
                                         base: ptr_vreg,
-                                        offset: (total_offset as i32) * 8,
+                                        offset: -((total_offset as i32) * 8),
                                     });
                                 } else {
                                     panic!(
@@ -1888,9 +1888,10 @@ impl<'a> CfgLower<'a> {
                 if self.cfg.is_param_inout(*param_slot) {
                     // For inout params, store through the pointer
                     if let Some(ptr_vreg) = self.inout_param_ptrs.get(param_slot).copied() {
+                        // Negative offset because stack grows down
                         self.mir.push(X86Inst::MovMRIndexed {
                             base: ptr_vreg,
-                            offset: (total_offset as i32) * 8,
+                            offset: -((total_offset as i32) * 8),
                             src: Operand::Virtual(val_vreg),
                         });
                     } else {

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -356,6 +356,10 @@ pub enum ErrorKind {
     BorrowInoutConflict {
         variable: String,
     },
+    /// Argument to inout parameter is missing `inout` keyword at call site
+    InoutKeywordMissing,
+    /// Argument to borrow parameter is missing `borrow` keyword at call site
+    BorrowKeywordMissing,
 
     // Control flow errors
     BreakOutsideLoop,
@@ -723,6 +727,12 @@ impl fmt::Display for ErrorKind {
                     "cannot borrow '{}' while it is mutably borrowed (inout)",
                     variable
                 )
+            }
+            ErrorKind::InoutKeywordMissing => {
+                write!(f, "argument to inout parameter must use 'inout' keyword")
+            }
+            ErrorKind::BorrowKeywordMissing => {
+                write!(f, "argument to borrow parameter must use 'borrow' keyword")
             }
             ErrorKind::BreakOutsideLoop => write!(f, "'break' outside of loop"),
             ErrorKind::ContinueOutsideLoop => write!(f, "'continue' outside of loop"),

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -584,7 +584,6 @@ exit_code = 42
 name = "inout_param_increment"
 spec = ["6.1:14", "6.1:15", "6.1:16", "6.1:18"]
 description = "Basic inout parameter that modifies a variable"
-preview = "affine_types"
 source = """
 fn increment(inout x: i32) {
     x = x + 1;
@@ -601,7 +600,6 @@ exit_code = 42
 name = "inout_param_double"
 spec = ["6.1:14", "6.1:18"]
 description = "Inout parameter that doubles a value"
-preview = "affine_types"
 source = """
 fn double(inout x: i32) {
     x = x * 2;
@@ -618,7 +616,6 @@ exit_code = 42
 name = "inout_param_swap"
 spec = ["6.1:14", "6.1:18"]
 description = "Multiple inout parameters for swap"
-preview = "affine_types"
 source = """
 fn swap(inout a: i32, inout b: i32) {
     let tmp = a;
@@ -638,7 +635,6 @@ exit_code = 42
 name = "inout_param_with_regular_param"
 spec = ["6.1:14", "6.1:15"]
 description = "Mixing inout and regular parameters"
-preview = "affine_types"
 source = """
 fn add_to(inout x: i32, amount: i32) {
     x = x + amount;
@@ -655,7 +651,6 @@ exit_code = 42
 name = "inout_param_multiple_calls"
 spec = ["6.1:14", "6.1:18"]
 description = "Multiple calls with inout accumulate changes"
-preview = "affine_types"
 source = """
 fn increment(inout x: i32) {
     x = x + 1;
@@ -674,7 +669,6 @@ exit_code = 42
 name = "inout_param_return_value"
 spec = ["6.1:14", "6.1:18"]
 description = "Inout function that also returns a value"
-preview = "affine_types"
 source = """
 fn increment_and_return_old(inout x: i32) -> i32 {
     let old = x;
@@ -693,7 +687,6 @@ exit_code = 42
 name = "inout_requires_lvalue"
 spec = ["6.1:17"]
 description = "Inout argument must be an lvalue (not a literal)"
-preview = "affine_types"
 source = """
 fn increment(inout x: i32) {
     x = x + 1;
@@ -710,7 +703,6 @@ error_contains = "lvalue"
 name = "inout_exclusive_access"
 spec = ["6.1:20"]
 description = "Cannot pass same variable to multiple inout parameters"
-preview = "affine_types"
 source = """
 fn swap(inout a: i32, inout b: i32) {
     let tmp = a;
@@ -730,7 +722,6 @@ error_contains = "same variable"
 name = "inout_exclusive_access_different_vars"
 spec = ["6.1:20"]
 description = "Different variables can be passed to multiple inout parameters"
-preview = "affine_types"
 source = """
 fn swap(inout a: i32, inout b: i32) {
     let tmp = a;
@@ -750,7 +741,6 @@ exit_code = 12
 name = "inout_allows_mutation_vs_borrow"
 spec = ["6.1:14", "6.1:18"]
 description = "Inout allows mutation while borrow does not (contrast test)"
-preview = "affine_types"
 source = """
 struct Counter { value: i32 }
 fn increment_inout(inout c: Counter) {
@@ -768,7 +758,6 @@ exit_code = 42
 name = "inout_value_valid_after_call"
 spec = ["6.1:18"]
 description = "Variable is still valid after inout call (no ownership transfer)"
-preview = "affine_types"
 source = """
 fn double(inout x: i32) {
     x = x * 2;
@@ -790,7 +779,6 @@ exit_code = 42
 name = "borrow_param_read_only"
 spec = ["6.1:22", "6.1:23", "6.1:26"]
 description = "Basic borrow parameter that reads a value without ownership transfer"
-preview = "affine_types"
 source = """
 struct Point { x: i32, y: i32 }
 fn sum(borrow p: Point) -> i32 {
@@ -807,7 +795,6 @@ exit_code = 42
 name = "borrow_param_multiple_uses"
 spec = ["6.1:22", "6.1:26"]
 description = "Borrowed value can be used multiple times after call (not moved)"
-preview = "affine_types"
 source = """
 struct Point { x: i32, y: i32 }
 fn get_x(borrow p: Point) -> i32 {
@@ -827,7 +814,6 @@ exit_code = 42
 name = "borrow_cannot_mutate_field"
 spec = ["6.1:24"]
 description = "Cannot mutate fields of a borrowed value"
-preview = "affine_types"
 source = """
 struct Point { x: i32, y: i32 }
 fn try_mutate(borrow p: Point) -> i32 {
@@ -846,7 +832,6 @@ error_contains = "cannot mutate borrowed"
 name = "borrow_cannot_mutate_array"
 spec = ["6.1:24"]
 description = "Cannot mutate elements of a borrowed array"
-preview = "affine_types"
 source = """
 fn try_mutate(borrow arr: [i32; 3]) -> i32 {
     arr[0] = 99;
@@ -864,7 +849,6 @@ error_contains = "cannot mutate borrowed"
 name = "borrow_cannot_move_out"
 spec = ["6.1:25"]
 description = "Cannot move out of a borrowed value"
-preview = "affine_types"
 source = """
 struct Data { value: i32 }
 fn try_move(borrow d: Data) -> Data {
@@ -883,7 +867,6 @@ error_contains = "cannot move out of borrowed"
 name = "borrow_inout_conflict"
 spec = ["6.1:30"]
 description = "Cannot borrow and inout the same variable in one call"
-preview = "affine_types"
 source = """
 fn conflict(borrow a: i32, inout b: i32) {
     b = a + 1;
@@ -901,7 +884,6 @@ error_contains = "borrow"
 name = "borrow_multiple_same_var_ok"
 spec = ["6.1:28"]
 description = "Multiple borrows of the same variable is allowed"
-preview = "affine_types"
 source = """
 fn sum_both(borrow a: i32, borrow b: i32) -> i32 {
     a + b
@@ -917,7 +899,6 @@ exit_code = 42
 name = "borrow_with_regular_param"
 spec = ["6.1:22", "6.1:15"]
 description = "Mixing borrow and regular parameters"
-preview = "affine_types"
 source = """
 struct Point { x: i32, y: i32 }
 fn offset_x(borrow p: Point, delta: i32) -> i32 {
@@ -934,7 +915,6 @@ exit_code = 42
 name = "borrow_value_still_valid_after"
 spec = ["6.1:26", "6.1:27"]
 description = "Value can be used after being borrowed"
-preview = "affine_types"
 source = """
 struct Point { x: i32, y: i32 }
 fn read_x(borrow p: Point) -> i32 {
@@ -953,7 +933,6 @@ exit_code = 42
 name = "borrow_integer_param"
 spec = ["6.1:22", "6.1:23"]
 description = "Borrow works with primitive integer types"
-preview = "affine_types"
 source = """
 fn double(borrow x: i32) -> i32 {
     x + x
@@ -969,7 +948,6 @@ exit_code = 42
 name = "borrow_array_read"
 spec = ["6.1:22", "6.1:26"]
 description = "Can read elements from a borrowed array"
-preview = "affine_types"
 source = """
 fn first(borrow arr: [i32; 3]) -> i32 {
     arr[0]
@@ -985,7 +963,6 @@ exit_code = 42
 name = "borrow_nested_struct"
 spec = ["6.1:22", "6.1:26"]
 description = "Can read nested fields from a borrowed struct"
-preview = "affine_types"
 source = """
 struct Inner { value: i32 }
 struct Outer { inner: Inner }
@@ -1003,7 +980,6 @@ exit_code = 42
 name = "borrow_call_site_missing_keyword"
 spec = ["6.1:23"]
 description = "Call site must include borrow keyword"
-preview = "affine_types"
 source = """
 struct Point { x: i32, y: i32 }
 fn read(borrow p: Point) -> i32 {
@@ -1021,7 +997,6 @@ error_contains = "borrow"
 name = "borrow_cannot_assign_to_param"
 spec = ["6.1:24"]
 description = "Cannot assign to the borrowed parameter itself"
-preview = "affine_types"
 source = """
 struct Data { value: i32 }
 fn try_reassign(borrow d: Data) -> i32 {

--- a/crates/rue-spec/cases/lexical/keywords.toml
+++ b/crates/rue-spec/cases/lexical/keywords.toml
@@ -95,14 +95,12 @@ compile_fail = true
 [[case]]
 name = "keyword_inout_reserved"
 spec = ["2.4:1", "2.4:2"]
-preview = "affine_types"
 source = "fn main() -> i32 { let inout = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_borrow_reserved"
 spec = ["2.4:1", "2.4:2"]
-preview = "affine_types"
 source = "fn main() -> i32 { let borrow = 1; 0 }"
 compile_fail = true
 

--- a/docs/designs/0013-borrowing-modes.md
+++ b/docs/designs/0013-borrowing-modes.md
@@ -1,12 +1,12 @@
 ---
 id: 0013
 title: Borrowing Modes
-status: accepted
+status: implemented
 tags: [types, semantics, ownership, borrowing]
-feature-flag: borrowing-modes
+feature-flag:
 created: 2025-12-25
 accepted: 2025-12-25
-implemented:
+implemented: 2025-12-25
 spec-sections: ["6.1"]
 superseded-by:
 ---
@@ -15,7 +15,7 @@ superseded-by:
 
 ## Status
 
-Accepted (behind `affine_types` preview feature)
+Implemented
 
 ## Summary
 


### PR DESCRIPTION
Remove the affine_types preview flag from inout and borrow parameters, making these features available without --preview.

Key changes:
- Add call-site mode validation: inout params require 'inout' keyword, borrow params require 'borrow' keyword at the call site
- Fix by-ref parameter slot counting: both inout and borrow use 1 slot (pointer) instead of full struct size
- Fix FieldGet/FieldSet codegen for by-ref params: use negative offsets because stack grows down
- Add lvalue validation: inout/borrow arguments must be variables, not literals
- Export PARAM_SLOT_MARKER constant from rue-air for shared use

Both x86_64 and aarch64 backends updated with matching changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)