### PR TITLE
Fix --help to exit with code 0 instead of 1

### DIFF
--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -175,7 +175,7 @@ fn parse_args() -> Option<Options> {
             }
             "--help" | "-h" => {
                 print_usage();
-                return None;
+                std::process::exit(0);
             }
             _ if arg.starts_with("-O") => {
                 // Parse -O0, -O1, -O2, -O3


### PR DESCRIPTION
The --help and -h flags were exiting with code 1 (indicating error) instead of code 0 (indicating success). This fixes the issue by calling std::process::exit(0) directly instead of returning None.

Fixes rue-7tie

🤖 Generated with [Claude Code](https://claude.com/claude-code)