### PR TITLE
Add spec section 3.10 and tests for mutable strings (Phase 1)

### DIFF
--- a/crates/rue-spec/cases/types/mutable-strings.toml
+++ b/crates/rue-spec/cases/types/mutable-strings.toml
@@ -1,0 +1,499 @@
+[section]
+id = "types.mutable_strings"
+spec_chapter = "3.10"
+name = "Mutable Strings"
+description = "Mutable string capabilities building on the core String type."
+
+# =============================================================================
+# String Representation (3.10:1 - 3.10:3)
+# =============================================================================
+
+# Note: The three-field representation (ptr, len, cap) is tested indirectly
+# through the query methods len() and capacity(). The ptr field is internal.
+
+[[case]]
+name = "string_representation_len_cap"
+spec = ["3.10:1", "3.10:2"]
+description = "String has length and capacity (proving three-field representation)"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let s = "hello";
+    // len and capacity are separately queryable, proving ptr/len/cap structure
+    let l = s.len();
+    let c = s.capacity();
+    // Literal has cap=0, len=5
+    if l == 5 && c == 0 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_literal_read_only"
+spec = ["3.10:2"]
+description = "Literal has capacity zero (pointing to read-only memory)"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let s = "hello world";
+    // capacity == 0 means read-only memory (literal)
+    if s.capacity() == 0 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+# =============================================================================
+# String Ownership (3.10:4 - 3.10:6)
+# =============================================================================
+
+[[case]]
+name = "string_affine_move"
+spec = ["3.10:4", "3.10:5", "3.10:6"]
+description = "String is moved when passed to a function"
+preview = "mutable_strings"
+source = """
+fn takes_string(s: String) -> i32 {
+    0
+}
+
+fn main() -> i32 {
+    var s = "hello";
+    takes_string(s)
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_affine_use_after_move"
+spec = ["3.10:4", "3.10:5"]
+description = "Using a string after move is an error"
+preview = "mutable_strings"
+source = """
+fn takes_string(s: String) -> i32 { 0 }
+
+fn main() -> i32 {
+    var s = "hello";
+    takes_string(s);
+    takes_string(s)
+}
+"""
+compile_fail = true
+error_contains = "use of moved value"
+
+# =============================================================================
+# Construction (3.10:7 - 3.10:9)
+# =============================================================================
+
+[[case]]
+name = "string_new_empty"
+spec = ["3.10:7", "3.10:9"]
+description = "String::new() creates an empty string"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let s = String::new();
+    if s.is_empty() { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_with_capacity"
+spec = ["3.10:8", "3.10:9"]
+description = "String::with_capacity() pre-allocates"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let s = String::with_capacity(100);
+    if s.capacity() >= 100 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+# =============================================================================
+# Query Methods (3.10:10 - 3.10:14)
+# =============================================================================
+
+[[case]]
+name = "string_len_literal"
+spec = ["3.10:10", "3.10:13", "3.10:14"]
+description = "len() returns byte length of string literal"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let s = "hello";
+    if s.len() == 5 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_len_empty"
+spec = ["3.10:10", "3.10:12"]
+description = "len() returns 0 for empty string"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let s = "";
+    if s.len() == 0 && s.is_empty() { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_capacity_literal"
+spec = ["3.10:11", "3.10:13"]
+description = "capacity() returns 0 for string literal"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let s = "hello";
+    if s.capacity() == 0 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_is_empty_true"
+spec = ["3.10:12", "3.10:13"]
+description = "is_empty() returns true for empty string"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let s = "";
+    if s.is_empty() { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_is_empty_false"
+spec = ["3.10:12", "3.10:13"]
+description = "is_empty() returns false for non-empty string"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let s = "hello";
+    if !s.is_empty() { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_query_borrow_valid"
+spec = ["3.10:13"]
+description = "Query methods borrow, string remains valid"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let s = "hello";
+    let len = s.len();
+    let empty = s.is_empty();
+    let cap = s.capacity();
+    if len == 5 && !empty && cap == 0 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+# =============================================================================
+# Mutation Methods (3.10:15 - 3.10:20)
+# =============================================================================
+
+[[case]]
+name = "string_push_str_basic"
+spec = ["3.10:15", "3.10:19", "3.10:20"]
+description = "push_str() appends string content"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    var s = String::new();
+    s.push_str("hello");
+    if s.len() == 5 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_push_str_multiple"
+spec = ["3.10:15", "3.10:20"]
+description = "Multiple push_str() calls accumulate"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    var s = String::new();
+    s.push_str("hello");
+    s.push_str(" world");
+    if s.len() == 11 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_push_byte"
+spec = ["3.10:16", "3.10:19"]
+description = "push() appends a single byte"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    var s = String::new();
+    s.push_str("hello");
+    s.push(33);  // '!'
+    if s.len() == 6 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_clear"
+spec = ["3.10:17", "3.10:19"]
+description = "clear() removes content but retains capacity"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    var s = String::with_capacity(100);
+    s.push_str("hello");
+    let cap_before = s.capacity();
+    s.clear();
+    if s.is_empty() && s.capacity() == cap_before { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_reserve"
+spec = ["3.10:18", "3.10:19"]
+description = "reserve() ensures additional capacity"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    var s = String::new();
+    s.push_str("hi");
+    s.reserve(100);
+    if s.capacity() >= 102 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_mutation_requires_var"
+spec = ["3.10:19"]
+description = "Mutation methods require var binding"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let s = String::new();
+    s.push_str("hello");
+    0
+}
+"""
+compile_fail = true
+error_contains = "cannot assign"
+
+# =============================================================================
+# Heap Promotion (3.10:21 - 3.10:23)
+# =============================================================================
+
+[[case]]
+name = "string_heap_promotion"
+spec = ["3.10:21", "3.10:22", "3.10:23"]
+description = "Literal is promoted to heap on mutation"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    var s = "hello";
+    s.push_str("!");
+    if s.capacity() > 0 && s.len() == 6 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_literal_no_capacity"
+spec = ["3.10:21", "3.10:22"]
+description = "Unmodified literal has zero capacity"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let s = "hello";
+    if s.capacity() == 0 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+# =============================================================================
+# Growth Strategy (3.10:24 - 3.10:25)
+# =============================================================================
+
+[[case]]
+name = "string_growth_on_append"
+spec = ["3.10:24", "3.10:25"]
+description = "String grows capacity when needed"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    var s = String::new();
+    s.push_str("hello");
+    let cap1 = s.capacity();
+    // Append enough to exceed initial capacity
+    s.push_str(" world hello world hello world");
+    let cap2 = s.capacity();
+    if cap2 > cap1 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+# =============================================================================
+# Clone (3.10:26 - 3.10:28)
+# =============================================================================
+
+[[case]]
+name = "string_clone_basic"
+spec = ["3.10:26", "3.10:27", "3.10:28"]
+description = "clone() creates a deep copy"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let a = "hello";
+    let b = a.clone();
+    // Both should be valid and equal
+    if a == b { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_clone_independent"
+spec = ["3.10:26", "3.10:27"]
+description = "Cloned strings are independent"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    var a = "hello";
+    var b = a.clone();
+    b.push_str("!");
+    // a should still be "hello", b should be "hello!"
+    if a.len() == 5 && b.len() == 6 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_clone_borrow"
+spec = ["3.10:27"]
+description = "Clone borrows, original remains valid"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let a = "hello";
+    let b = a.clone();
+    let c = a.clone();  // a still valid after first clone
+    if a.len() == 5 && b.len() == 5 && c.len() == 5 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+# =============================================================================
+# Destructor (3.10:29 - 3.10:31)
+# =============================================================================
+
+# Note: Destructor behavior is tested indirectly through memory correctness.
+# Valgrind testing would verify no leaks.
+
+[[case]]
+name = "string_destructor_heap"
+spec = ["3.10:29", "3.10:30", "3.10:31"]
+description = "Heap-allocated strings are freed when dropped"
+preview = "mutable_strings"
+source = """
+fn make_string() -> i32 {
+    var s = "hello";
+    s.push_str(" world");
+    // s goes out of scope, destructor should free heap
+    42
+}
+
+fn main() -> i32 {
+    let result = make_string();
+    result - 42
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_destructor_literal"
+spec = ["3.10:29", "3.10:30"]
+description = "Literal strings (cap=0) are not freed"
+preview = "mutable_strings"
+source = """
+fn use_literal() -> u64 {
+    let s = "hello";
+    // s is a literal, no heap to free
+    // When s goes out of scope, destructor should be a no-op (cap=0)
+    s.len()
+}
+
+fn main() -> i32 {
+    let len = use_literal();
+    if len == 5 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+# =============================================================================
+# Byte String Semantics (3.10:32 - 3.10:33)
+# =============================================================================
+
+# Note: UTF-8 semantics are informative and don't have strict tests.
+# The type allows any bytes at runtime.
+
+[[case]]
+name = "string_byte_semantics"
+spec = ["3.10:32"]
+description = "Strings are byte sequences"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    var s = String::new();
+    // Push some bytes
+    s.push(72);   // 'H'
+    s.push(105);  // 'i'
+    if s.len() == 2 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+# =============================================================================
+# Integration Tests
+# =============================================================================
+
+[[case]]
+name = "string_building_message"
+spec = ["3.10:15", "3.10:16", "3.10:20"]
+description = "Build a complete message through appending"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    var msg = String::new();
+    msg.push_str("Hello");
+    msg.push_str(", ");
+    msg.push_str("world");
+    msg.push(33);  // '!'
+    // "Hello, world!" is 13 bytes
+    if msg.len() == 13 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_equality_after_mutation"
+spec = ["3.10:15", "3.7:9", "3.7:10"]
+description = "Mutated string can be compared"
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    var s = String::new();
+    s.push_str("hello");
+    if s == "hello" { 0 } else { 1 }
+}
+"""
+exit_code = 0

--- a/docs/designs/0014-mutable-strings.md
+++ b/docs/designs/0014-mutable-strings.md
@@ -277,17 +277,17 @@ Epic: rue-0hef
 
 All functionality is gated behind `--preview mutable_strings`. Spec and tests come first.
 
-### Phase 1: Specification and Feature Gate
+### Phase 1: Specification and Feature Gate - rue-0hef.1 (COMPLETE)
 
 Write the specification first:
 
-- Add `MutableStrings` to `PreviewFeature` enum in `rue-error`
-- Add spec section 3.10 for mutable strings
-- Define String representation (ptr, len, cap)
-- Define all method signatures and semantics
-- Add spec tests with `preview = "mutable_strings"` (these will fail initially)
+- [x] Add `MutableStrings` to `PreviewFeature` enum in `rue-error`
+- [x] Add spec section 3.10 for mutable strings
+- [x] Define String representation (ptr, len, cap)
+- [x] Define all method signatures and semantics
+- [x] Add spec tests with `preview = "mutable_strings"` (these will fail initially)
 
-**Testable**: Spec tests exist and fail with "not yet implemented" or similar.
+**Testable**: Spec tests exist and are ignored (preview feature not yet implemented).
 
 ### Phase 2: Three-Field String Representation
 

--- a/docs/spec/src/03-types/10-mutable-strings.md
+++ b/docs/spec/src/03-types/10-mutable-strings.md
@@ -1,0 +1,225 @@
++++
+title = "Mutable Strings"
+weight = 10
+template = "spec/page.html"
++++
+
+# Mutable Strings
+
+This section describes the mutable string capabilities, building on the core `String` type from section 3.7.
+
+> **Preview Feature**: Mutable strings are a preview feature requiring `--preview mutable_strings`. See ADR-0014 for the design.
+
+## String Representation
+
+{{ rule(id="3.10:1", cat="normative") }}
+
+A `String` value consists of three components: a pointer to the string data, the length in bytes, and the allocated capacity.
+
+{{ rule(id="3.10:2", cat="normative") }}
+
+When capacity is zero, the string data points to read-only memory (a string literal). When capacity is greater than zero, the string data is heap-allocated and can be mutated.
+
+{{ rule(id="3.10:3", cat="informative") }}
+
+This representation allows string literals to remain cheap (no allocation) while enabling mutation when needed. Mutation methods automatically promote read-only strings to the heap.
+
+## String Ownership
+
+{{ rule(id="3.10:4", cat="normative") }}
+
+`String` is an affine type: a `String` value is consumed when used and cannot be used again unless explicitly cloned.
+
+{{ rule(id="3.10:5", cat="normative") }}
+
+`String` is not `@copy`. Passing a string to a function or assigning it to another binding moves the string.
+
+{{ rule(id="3.10:6", cat="example") }}
+
+```rue
+fn takes_string(s: String) -> i32 { 0 }
+
+fn main() -> i32 {
+    var s = "hello";
+    takes_string(s);    // s is moved
+    // takes_string(s); // ERROR: use of moved value
+    0
+}
+```
+
+## Construction
+
+{{ rule(id="3.10:7", cat="normative") }}
+
+`String::new()` returns an empty string with no allocation.
+
+{{ rule(id="3.10:8", cat="normative") }}
+
+`String::with_capacity(cap: u64)` returns an empty string with pre-allocated capacity for `cap` bytes.
+
+{{ rule(id="3.10:9", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    let empty = String::new();
+    let prealloc = String::with_capacity(1024);
+    0
+}
+```
+
+## Query Methods
+
+{{ rule(id="3.10:10", cat="normative") }}
+
+`fn len(borrow self) -> u64` returns the length of the string in bytes.
+
+{{ rule(id="3.10:11", cat="normative") }}
+
+`fn capacity(borrow self) -> u64` returns the allocated capacity of the string. Returns zero for string literals.
+
+{{ rule(id="3.10:12", cat="normative") }}
+
+`fn is_empty(borrow self) -> bool` returns true if the string length is zero.
+
+{{ rule(id="3.10:13", cat="informative") }}
+
+Query methods use `borrow self` to access the string without consuming it, leaving the string valid after the call.
+
+{{ rule(id="3.10:14", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    let s = "hello";
+    if s.len() == 5 && !s.is_empty() {
+        0
+    } else {
+        1
+    }
+}
+```
+
+## Mutation Methods
+
+{{ rule(id="3.10:15", cat="normative") }}
+
+`fn push_str(inout self, other: String)` appends the contents of `other` to the string. If the string is a literal (capacity zero), it is first promoted to the heap.
+
+{{ rule(id="3.10:16", cat="normative") }}
+
+`fn push(inout self, byte: u8)` appends a single byte to the string.
+
+{{ rule(id="3.10:17", cat="normative") }}
+
+`fn clear(inout self)` removes all content from the string but retains the allocated capacity.
+
+{{ rule(id="3.10:18", cat="normative") }}
+
+`fn reserve(inout self, additional: u64)` ensures the string has capacity for at least `additional` more bytes.
+
+{{ rule(id="3.10:19", cat="informative") }}
+
+Mutation methods use `inout self` to modify the string in place. The variable must be declared with `var` to allow mutation.
+
+{{ rule(id="3.10:20", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    var s = String::new();
+    s.push_str("hello");
+    s.push_str(" world");
+    s.push(33);  // '!' character
+    0
+}
+```
+
+## Heap Promotion
+
+{{ rule(id="3.10:21", cat="dynamic-semantics") }}
+
+When a mutation method is called on a string literal (capacity zero), the string is promoted to the heap:
+1. A heap buffer is allocated with capacity for the existing content plus the new content
+2. The existing content is copied from read-only memory to the heap buffer
+3. The string's pointer and capacity are updated
+4. The mutation is performed
+
+{{ rule(id="3.10:22", cat="informative") }}
+
+Heap promotion is transparent to the user. There is no separate "owned" vs "borrowed" string distinction.
+
+{{ rule(id="3.10:23", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    var s = "hello";     // literal: capacity = 0
+    s.push_str("!");     // promotes to heap, then appends
+    // s is now "hello!" with capacity > 0
+    0
+}
+```
+
+## Growth Strategy
+
+{{ rule(id="3.10:24", cat="dynamic-semantics") }}
+
+When appending would exceed the current capacity, a new buffer is allocated with double the current capacity (minimum 16 bytes). The existing content is copied and the old buffer is freed.
+
+{{ rule(id="3.10:25", cat="informative") }}
+
+The doubling growth strategy amortizes allocation cost over many appends, providing O(1) amortized time per append.
+
+## Clone
+
+{{ rule(id="3.10:26", cat="normative") }}
+
+`fn clone(borrow self) -> String` creates a deep copy of the string, allocating a new heap buffer with the same content.
+
+{{ rule(id="3.10:27", cat="informative") }}
+
+Clone borrows `self` so the original string remains valid. Cloning always allocates, even for string literals.
+
+{{ rule(id="3.10:28", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    let a = "hello";
+    let b = a.clone();  // deep copy
+    // Both a and b are valid
+    0
+}
+```
+
+## Destructor
+
+{{ rule(id="3.10:29", cat="dynamic-semantics") }}
+
+When a `String` value is dropped:
+- If capacity is zero (literal), no action is taken
+- If capacity is greater than zero (heap-allocated), the heap buffer is freed
+
+{{ rule(id="3.10:30", cat="informative") }}
+
+The destructor automatically distinguishes between string literals and heap-allocated strings, ensuring correct cleanup.
+
+{{ rule(id="3.10:31", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    var s = "hello";
+    s.push_str("!");  // promotes to heap
+    0
+}  // destructor frees the heap buffer
+```
+
+## Byte String Semantics
+
+{{ rule(id="3.10:32", cat="informative") }}
+
+Rue strings are *conventionally UTF-8* rather than strictly validated:
+- String literals are valid UTF-8 (validated at compile time)
+- At runtime, strings are byte sequences
+- Methods like `push_str` accept any bytes
+- No runtime UTF-8 validation overhead
+
+{{ rule(id="3.10:33", cat="informative") }}
+
+This approach matches Go's `string` and Rust's `bstr` crate: UTF-8 is the convention, but the type does not enforce it at runtime.


### PR DESCRIPTION
Add specification and preview tests for the mutable_strings feature (ADR-0014). This is Phase 1: spec-first development with tests that will be enabled when the feature implementation begins.

Spec section 3.10 covers:
- Three-field string representation (ptr, len, cap)
- Affine ownership semantics
- Construction methods (new, with_capacity)
- Query methods (len, capacity, is_empty)
- Mutation methods (push_str, push, clear, reserve)
- Heap promotion from literals
- Clone method
- Destructor behavior

All tests gated behind preview = "mutable_strings" and will be ignored until the feature is implemented.

Closes rue-0hef.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)