### PR TITLE
Fix --target help text to include aarch64-macos

### DIFF
--- a/crates/rue-target/src/lib.rs
+++ b/crates/rue-target/src/lib.rs
@@ -147,6 +147,11 @@ impl Target {
             Target::Aarch64Macos,
         ]
     }
+
+    /// Returns a comma-separated string of all target names for help text.
+    pub fn all_names() -> &'static str {
+        "x86-64-linux, aarch64-linux, aarch64-macos"
+    }
 }
 
 impl fmt::Display for Target {

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -80,7 +80,10 @@ fn print_usage() {
     eprintln!();
     eprintln!("Options:");
     eprintln!("  --target <target>    Set compilation target (default: host)");
-    eprintln!("                       Valid targets: x86-64-linux, aarch64-linux");
+    eprintln!(
+        "                       Valid targets: {}",
+        Target::all_names()
+    );
     eprintln!("  --linker <linker>    Set linker to use (default: internal)");
     eprintln!("                       Use 'internal' for built-in linker, or a command");
     eprintln!("                       like 'clang', 'gcc', or 'ld' for system linker");
@@ -133,7 +136,7 @@ fn parse_args() -> Option<Options> {
             "--target" => {
                 let Some(target_str) = args_iter.next() else {
                     eprintln!("Error: --target requires a value");
-                    eprintln!("Valid targets: x86-64-linux, aarch64-linux");
+                    eprintln!("Valid targets: {}", Target::all_names());
                     return None;
                 };
                 match target_str.parse::<Target>() {


### PR DESCRIPTION
The help text for the --target flag was missing aarch64-macos from the list of valid targets. This was confusing since the target is fully supported.

Added Target::all_names() method to provide a canonical list of target names for help text, similar to EmitStage::all_names() and OptLevel::all_names(). Updated both help text locations in main.rs to use this method.

Fixes rue-5m43.

🤖 Generated with [Claude Code](https://claude.com/claude-code)