### PR TITLE
Fix unasserted matches! in test_option_ext_none

### DIFF
--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1383,7 +1383,7 @@ mod tests {
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert_eq!(error.span(), Some(span));
-        matches!(error.kind, ErrorKind::InvalidInteger);
+        assert!(matches!(error.kind, ErrorKind::InvalidInteger));
     }
 
     #[test]


### PR DESCRIPTION
The matches! macro was called without wrapping in assert!, meaning the test wasn't actually verifying the error kind.

Fixes: rue-bxa5

🤖 Generated with [Claude Code](https://claude.com/claude-code)