### PR TITLE
Detect unterminated string literals in lexer

### DIFF
--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -17,28 +17,67 @@ pub enum LexError {
     UnterminatedString,
 }
 
-/// Process a string literal, handling escape sequences.
-/// Input includes the surrounding quotes.
-fn process_string_literal(lex: &mut logos::Lexer<LogosTokenKind>) -> Result<String, LexError> {
-    let slice = lex.slice();
-    // Remove surrounding quotes
-    let inner = &slice[1..slice.len() - 1];
-
-    let mut result = String::with_capacity(inner.len());
-    let mut chars = inner.chars().peekable();
+/// Process a string literal starting from an opening quote.
+/// This manually scans for the string content and closing quote,
+/// enabling detection of unterminated strings.
+fn process_string_from_quote(lex: &mut logos::Lexer<LogosTokenKind>) -> Result<String, LexError> {
+    // At this point we've matched just the opening quote "
+    // We need to scan remainder for string content and closing quote
+    let remainder = lex.remainder();
+    let mut chars = remainder.chars();
+    let mut consumed = 0;
+    let mut result = String::new();
+    let mut found_close = false;
 
     while let Some(c) = chars.next() {
-        if c == '\\' {
+        if c == '"' {
+            // Found closing quote
+            consumed += 1;
+            found_close = true;
+            break;
+        } else if c == '\\' {
+            // Escape sequence
+            consumed += c.len_utf8();
             match chars.next() {
-                Some('\\') => result.push('\\'),
-                Some('"') => result.push('"'),
-                Some(_) | None => return Err(LexError::InvalidStringEscape),
+                Some('\\') => {
+                    consumed += 1;
+                    result.push('\\');
+                }
+                Some('"') => {
+                    consumed += 1;
+                    result.push('"');
+                }
+                Some(other) => {
+                    // Invalid escape - consume the char to get better error position
+                    consumed += other.len_utf8();
+                    lex.bump(consumed);
+                    return Err(LexError::InvalidStringEscape);
+                }
+                None => {
+                    // Backslash at end of input
+                    lex.bump(consumed);
+                    return Err(LexError::UnterminatedString);
+                }
             }
+        } else if c == '\n' {
+            // Newline in string - string is unterminated at this line
+            // Don't consume the newline so error span points to string start
+            lex.bump(consumed);
+            return Err(LexError::UnterminatedString);
         } else {
+            consumed += c.len_utf8();
             result.push(c);
         }
     }
 
+    if !found_close {
+        // Reached end of input without closing quote
+        lex.bump(consumed);
+        return Err(LexError::UnterminatedString);
+    }
+
+    // Advance past the string content and closing quote
+    lex.bump(consumed);
     Ok(result)
 }
 
@@ -118,8 +157,9 @@ pub enum LogosTokenKind {
     #[regex(r"[0-9]+", |lex| lex.slice().parse::<u64>().map_err(|_| LexError::InvalidInteger))]
     Int(u64),
 
-    // String literals
-    #[regex(r#""([^"\\]|\\.)*""#, process_string_literal)]
+    // String literals - match opening quote and process content manually
+    // This allows detection of unterminated strings
+    #[token("\"", process_string_from_quote)]
     String(String),
 
     // Identifiers (lower priority than keywords)
@@ -608,5 +648,52 @@ mod tests {
         assert!(matches!(tokens[1].kind, TokenKind::Ident(ref s) if s == "i64ptr"));
         assert!(matches!(tokens[2].kind, TokenKind::Ident(ref s) if s == "boolish"));
         assert!(matches!(tokens[3].kind, TokenKind::Ident(ref s) if s == "u8_data"));
+    }
+
+    #[test]
+    fn test_logos_unterminated_string() {
+        // String without closing quote at end of input
+        let mut lexer = LogosLexer::new(r#""hello"#);
+        let result = lexer.tokenize();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err.kind, ErrorKind::UnterminatedString));
+
+        // String without closing quote followed by newline
+        let mut lexer = LogosLexer::new("\"hello\nworld");
+        let result = lexer.tokenize();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err.kind, ErrorKind::UnterminatedString));
+
+        // Just an opening quote
+        let mut lexer = LogosLexer::new("\"");
+        let result = lexer.tokenize();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err.kind, ErrorKind::UnterminatedString));
+    }
+
+    #[test]
+    fn test_logos_valid_strings() {
+        // Valid complete string
+        let mut lexer = LogosLexer::new(r#""hello""#);
+        let tokens = lexer.tokenize().unwrap();
+        assert!(matches!(tokens[0].kind, TokenKind::String(ref s) if s == "hello"));
+
+        // Empty string
+        let mut lexer = LogosLexer::new(r#""""#);
+        let tokens = lexer.tokenize().unwrap();
+        assert!(matches!(tokens[0].kind, TokenKind::String(ref s) if s.is_empty()));
+
+        // String with escaped quote
+        let mut lexer = LogosLexer::new(r#""hello\"world""#);
+        let tokens = lexer.tokenize().unwrap();
+        assert!(matches!(tokens[0].kind, TokenKind::String(ref s) if s == "hello\"world"));
+
+        // String with escaped backslash
+        let mut lexer = LogosLexer::new(r#""hello\\world""#);
+        let tokens = lexer.tokenize().unwrap();
+        assert!(matches!(tokens[0].kind, TokenKind::String(ref s) if s == "hello\\world"));
     }
 }

--- a/crates/rue-spec/cases/lexical/tokens.toml
+++ b/crates/rue-spec/cases/lexical/tokens.toml
@@ -44,12 +44,99 @@ fn main() -> i32 {
 exit_code = 42
 
 # =============================================================================
+# String Literals (syntax and legality)
+# =============================================================================
+
+[[case]]
+name = "string_literal_basic"
+spec = ["2.1:6"]
+source = """
+fn main() -> i32 {
+    let _s = "hello world";
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_literal_escape_quote"
+spec = ["2.1:6", "2.1:7"]
+source = '''
+fn main() -> i32 {
+    let _s = "with \"quotes\"";
+    0
+}
+'''
+exit_code = 0
+
+[[case]]
+name = "string_literal_escape_backslash"
+spec = ["2.1:6", "2.1:7"]
+source = """
+fn main() -> i32 {
+    let _s = "with \\\\ backslash";
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_literal_empty"
+spec = ["2.1:6"]
+source = '''
+fn main() -> i32 {
+    let _s = "";
+    0
+}
+'''
+exit_code = 0
+
+[[case]]
+name = "string_literal_invalid_escape"
+spec = ["2.1:8"]
+source = '''
+fn main() -> i32 {
+    let _s = "bad \n escape";
+    0
+}
+'''
+compile_fail = true
+error_contains = "invalid escape"
+
+[[case]]
+name = "string_literal_unterminated_eof"
+spec = ["2.1:9"]
+source = '''fn main() -> i32 { let _s = "hello'''
+compile_fail = true
+error_contains = "unterminated string"
+
+[[case]]
+name = "string_literal_unterminated_newline"
+spec = ["2.1:9"]
+source = """
+fn main() -> i32 {
+    let _s = "hello
+world";
+    0
+}
+"""
+compile_fail = true
+error_contains = "unterminated string"
+
+[[case]]
+name = "string_literal_unterminated_just_quote"
+spec = ["2.1:9"]
+source = 'fn main() -> i32 { "'
+compile_fail = true
+error_contains = "unterminated string"
+
+# =============================================================================
 # Identifiers (syntax and legality)
 # =============================================================================
 
 [[case]]
 name = "identifier_letter_start"
-spec = ["2.1:10"]
+spec = ["2.1:11"]
 source = """
 fn main() -> i32 {
     let x = 42;
@@ -60,7 +147,7 @@ exit_code = 42
 
 [[case]]
 name = "identifier_underscore_start"
-spec = ["2.1:10"]
+spec = ["2.1:11"]
 source = """
 fn main() -> i32 {
     let _x = 42;
@@ -71,7 +158,7 @@ exit_code = 42
 
 [[case]]
 name = "identifier_with_digits"
-spec = ["2.1:10"]
+spec = ["2.1:11"]
 source = """
 fn main() -> i32 {
     let x1 = 42;
@@ -82,7 +169,7 @@ exit_code = 42
 
 [[case]]
 name = "identifier_mixed"
-spec = ["2.1:10"]
+spec = ["2.1:11"]
 source = """
 fn main() -> i32 {
     let my_var_123 = 42;
@@ -93,7 +180,7 @@ exit_code = 42
 
 [[case]]
 name = "identifier_uppercase"
-spec = ["2.1:10"]
+spec = ["2.1:11"]
 source = """
 fn main() -> i32 {
     let MyVar = 42;
@@ -104,25 +191,25 @@ exit_code = 42
 
 [[case]]
 name = "identifier_cannot_be_keyword_fn"
-spec = ["2.1:11"]
+spec = ["2.1:12"]
 source = "fn main() -> i32 { let fn = 1; fn }"
 compile_fail = true
 
 [[case]]
 name = "identifier_cannot_be_keyword_let"
-spec = ["2.1:11"]
+spec = ["2.1:12"]
 source = "fn main() -> i32 { let let = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "identifier_cannot_be_keyword_if"
-spec = ["2.1:11"]
+spec = ["2.1:12"]
 source = "fn main() -> i32 { let if = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "identifier_unused_underscore"
-spec = ["2.1:12"]
+spec = ["2.1:13"]
 source = """
 fn main() -> i32 {
     let _ = 100;
@@ -133,7 +220,7 @@ exit_code = 42
 
 [[case]]
 name = "underscore_multiple_bindings"
-spec = ["2.1:14"]
+spec = ["2.1:15"]
 source = """
 fn main() -> i32 {
     let _ = 42;
@@ -146,7 +233,7 @@ exit_code = 0
 
 [[case]]
 name = "underscore_cannot_be_referenced"
-spec = ["2.1:13"]
+spec = ["2.1:14"]
 source = """
 fn main() -> i32 {
     let _ = 42;
@@ -158,7 +245,7 @@ error_contains = "found '_'"
 
 [[case]]
 name = "underscore_prefixed_is_normal_variable"
-spec = ["2.1:16"]
+spec = ["2.1:17"]
 source = """
 fn main() -> i32 {
     let _unused = 42;

--- a/docs/spec/src/02-lexical-structure/01-tokens.md
+++ b/docs/spec/src/02-lexical-structure/01-tokens.md
@@ -66,11 +66,15 @@ escape_sequence = "\\" | "\"" ;
 
 String literals support escape sequences: `\\` for a backslash and `\"` for a double quote.
 
-{{ rule(id="2.1:8", cat="normative") }}
+{{ rule(id="2.1:8", cat="legality-rule") }}
 
 An invalid escape sequence in a string literal is a compile-time error.
 
-{{ rule(id="2.1:9") }}
+{{ rule(id="2.1:9", cat="legality-rule") }}
+
+An unterminated string literal (reaching end-of-file or end-of-line without a closing quote) is a compile-time error.
+
+{{ rule(id="2.1:10") }}
 
 ```rue
 fn main() -> i32 {
@@ -83,7 +87,7 @@ fn main() -> i32 {
 
 ## Identifiers
 
-{{ rule(id="2.1:10", cat="normative") }}
+{{ rule(id="2.1:11", cat="normative") }}
 
 An identifier starts with a letter or underscore, followed by any number of letters, digits, or underscores.
 
@@ -92,25 +96,25 @@ identifier = (letter | "_") { letter | digit | "_" } ;
 letter = "a" | ... | "z" | "A" | ... | "Z" ;
 ```
 
-{{ rule(id="2.1:11", cat="normative") }}
+{{ rule(id="2.1:12", cat="normative") }}
 
 Identifiers cannot be keywords.
 
 ## Underscore Identifier
 
-{{ rule(id="2.1:12", cat="normative") }}
+{{ rule(id="2.1:13", cat="normative") }}
 
 The identifier `_` (single underscore) is a *wildcard* that discards its value without creating a binding. When used in a let statement, the initializer expression is evaluated for its side effects, but no variable is created and no storage is allocated.
 
-{{ rule(id="2.1:13", cat="normative") }}
+{{ rule(id="2.1:14", cat="normative") }}
 
 A reference to `_` as an expression is a compile-time error. The wildcard identifier cannot be used to retrieve a previously discarded value.
 
-{{ rule(id="2.1:14", cat="normative") }}
+{{ rule(id="2.1:15", cat="normative") }}
 
 Multiple occurrences of `_` are permitted in the same scope. Each occurrence independently discards its value.
 
-{{ rule(id="2.1:15") }}
+{{ rule(id="2.1:16") }}
 
 ```rue
 fn main() -> i32 {
@@ -122,11 +126,11 @@ fn main() -> i32 {
 
 ## Underscore-Prefixed Identifiers
 
-{{ rule(id="2.1:16", cat="normative") }}
+{{ rule(id="2.1:17", cat="normative") }}
 
 An identifier that begins with an underscore followed by one or more characters (e.g., `_unused`, `_x`) is a normal identifier that creates a binding. Such identifiers suppress unused variable warnings but can otherwise be used like any other identifier.
 
-{{ rule(id="2.1:17") }}
+{{ rule(id="2.1:18") }}
 
 ```rue
 fn main() -> i32 {


### PR DESCRIPTION
Change string lexing from regex-based to callback-based approach to enable detection of unterminated strings. When the lexer encounters an opening quote, it now manually scans for the string content and closing quote, returning UnterminatedString error if:
- End of input is reached without a closing quote
- A newline is encountered before the closing quote

Also adds spec rule 2.1:9 for unterminated strings and renumbers subsequent identifier rules (2.1:10 → 2.1:18).

Fixes rue-btjv

🤖 Generated with [Claude Code](https://claude.com/claude-code)