### PR TITLE
docs(runtime): update platform support list to include all supported …

### DIFF
--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -16,9 +16,14 @@
 //!
 //! # Platform Requirements
 //!
-//! This runtime only supports **x86-64 Linux**. It uses direct syscalls and
-//! contains platform-specific assembly. Attempting to compile on other platforms
-//! will result in a compile error.
+//! This runtime supports the following platforms:
+//!
+//! - **x86-64 Linux**
+//! - **aarch64 Linux**
+//! - **aarch64 macOS**
+//!
+//! It uses direct syscalls and contains platform-specific assembly.
+//! Attempting to compile on other platforms will result in a compile error.
 //!
 //! # Design Philosophy
 //!


### PR DESCRIPTION
…platforms

The doc comment incorrectly stated that rue-runtime only supports x86-64 Linux, but the code actually supports three platforms:
- x86-64 Linux
- aarch64 Linux  
- aarch64 macOS

The compile_error message and conditional compilation already listed all three platforms correctly; only the doc comment was outdated.

Fixes rue-jciw

🤖 Generated with [Claude Code](https://claude.com/claude-code)