### PR TITLE
Implement @intCast intrinsic with runtime range checking

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -475,13 +475,29 @@ impl<'a> ConstraintGenerator<'a> {
             }
 
             // Intrinsic call
-            InstData::Intrinsic { name: _, args } => {
-                // Generate constraints for arguments (they need to be processed)
-                for arg_ref in args.iter() {
-                    self.generate(*arg_ref, ctx);
+            InstData::Intrinsic { name, args } => {
+                let intrinsic_name = self.interner.get(*name);
+
+                if intrinsic_name == "intCast" {
+                    // @intCast: target type is inferred from context
+                    // The argument must be an integer type
+                    if !args.is_empty() {
+                        let arg_info = self.generate(args[0], ctx);
+                        // Constraint: argument must be an integer
+                        // We'll check this in sema, for now just process the argument
+                        let _ = arg_info;
+                    }
+                    // Return type is inferred from context - create a fresh type variable
+                    let result_var = self.fresh_var();
+                    InferType::Var(result_var)
+                } else {
+                    // Generate constraints for arguments (they need to be processed)
+                    for arg_ref in args.iter() {
+                        self.generate(*arg_ref, ctx);
+                    }
+                    // @dbg returns Unit
+                    InferType::Concrete(Type::Unit)
                 }
-                // Currently only @dbg is supported, which returns Unit
-                InferType::Concrete(Type::Unit)
             }
 
             // Type intrinsic (@size_of, @align_of)

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -425,6 +425,17 @@ pub enum AirInstData {
         variant_index: u32,
     },
 
+    // Type conversion operations
+    /// Integer cast: convert between integer types with runtime range check.
+    /// Panics if the value cannot be represented in the target type.
+    /// The target type is stored in AirInst.ty.
+    IntCast {
+        /// The value to cast
+        value: AirRef,
+        /// The source type (for determining signedness and size)
+        from_ty: Type,
+    },
+
     // Drop/destructor operations
     /// Drop a value, running its destructor if the type has one.
     /// For trivially droppable types, this is a no-op.
@@ -671,6 +682,9 @@ impl fmt::Display for Air {
                     variant_index,
                 } => {
                     writeln!(f, "enum_variant #{}::{}", enum_id.0, variant_index)?;
+                }
+                AirInstData::IntCast { value, from_ty } => {
+                    writeln!(f, "intcast {} from {}", value, from_ty.name())?;
                 }
                 AirInstData::Drop { value } => {
                     writeln!(f, "drop {}", value)?;

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -3022,53 +3022,122 @@ impl<'a> Sema<'a> {
             InstData::Intrinsic { name, args } => {
                 let intrinsic_name = self.interner.get(*name).to_string();
 
-                // Currently only @dbg is supported
-                if intrinsic_name != "dbg" {
-                    return Err(CompileError::new(
+                match intrinsic_name.as_str() {
+                    "dbg" => {
+                        // @dbg expects exactly one argument
+                        if args.len() != 1 {
+                            return Err(CompileError::new(
+                                ErrorKind::IntrinsicWrongArgCount {
+                                    name: intrinsic_name,
+                                    expected: 1,
+                                    found: args.len(),
+                                },
+                                inst.span,
+                            ));
+                        }
+
+                        // Synthesize the argument type in a single traversal
+                        let arg_result = self.analyze_inst(air, args[0], ctx)?;
+                        let arg_type = arg_result.ty;
+
+                        // Check that argument is a supported type (integer, bool, or string)
+                        let is_supported = arg_type.is_integer()
+                            || arg_type == Type::Bool
+                            || arg_type == Type::String;
+                        if !is_supported {
+                            return Err(CompileError::new(
+                                ErrorKind::IntrinsicTypeMismatch {
+                                    name: intrinsic_name,
+                                    expected: "integer, bool, or string".to_string(),
+                                    found: arg_type.name().to_string(),
+                                },
+                                inst.span,
+                            ));
+                        }
+
+                        let air_ref = air.add_inst(AirInst {
+                            data: AirInstData::Intrinsic {
+                                name: intrinsic_name,
+                                args: vec![arg_result.air_ref],
+                            },
+                            ty: Type::Unit,
+                            span: inst.span,
+                        });
+                        Ok(AnalysisResult::new(air_ref, Type::Unit))
+                    }
+                    "intCast" => {
+                        // @intCast expects exactly one argument
+                        if args.len() != 1 {
+                            return Err(CompileError::new(
+                                ErrorKind::IntrinsicWrongArgCount {
+                                    name: intrinsic_name,
+                                    expected: 1,
+                                    found: args.len(),
+                                },
+                                inst.span,
+                            ));
+                        }
+
+                        // Analyze the argument
+                        let arg_result = self.analyze_inst(air, args[0], ctx)?;
+                        let from_ty = arg_result.ty;
+
+                        // Argument must be an integer type
+                        if !from_ty.is_integer() {
+                            return Err(CompileError::new(
+                                ErrorKind::IntrinsicTypeMismatch {
+                                    name: intrinsic_name,
+                                    expected: "integer".to_string(),
+                                    found: from_ty.name().to_string(),
+                                },
+                                inst.span,
+                            ));
+                        }
+
+                        // Get the target type from HM inference
+                        let target_ty = match ctx.resolved_types.get(&inst_ref).copied() {
+                            Some(ty) if ty.is_integer() => ty,
+                            Some(Type::Error) => {
+                                // Error already reported during type inference
+                                return Err(CompileError::new(
+                                    ErrorKind::TypeAnnotationRequired,
+                                    inst.span,
+                                ));
+                            }
+                            Some(ty) => {
+                                return Err(CompileError::new(
+                                    ErrorKind::IntrinsicTypeMismatch {
+                                        name: intrinsic_name,
+                                        expected: "integer".to_string(),
+                                        found: ty.name().to_string(),
+                                    },
+                                    inst.span,
+                                ));
+                            }
+                            None => {
+                                // Type inference couldn't determine the target type
+                                return Err(CompileError::new(
+                                    ErrorKind::TypeAnnotationRequired,
+                                    inst.span,
+                                ));
+                            }
+                        };
+
+                        let air_ref = air.add_inst(AirInst {
+                            data: AirInstData::IntCast {
+                                value: arg_result.air_ref,
+                                from_ty,
+                            },
+                            ty: target_ty,
+                            span: inst.span,
+                        });
+                        Ok(AnalysisResult::new(air_ref, target_ty))
+                    }
+                    _ => Err(CompileError::new(
                         ErrorKind::UnknownIntrinsic(intrinsic_name),
                         inst.span,
-                    ));
+                    )),
                 }
-
-                // @dbg expects exactly one argument
-                if args.len() != 1 {
-                    return Err(CompileError::new(
-                        ErrorKind::IntrinsicWrongArgCount {
-                            name: intrinsic_name,
-                            expected: 1,
-                            found: args.len(),
-                        },
-                        inst.span,
-                    ));
-                }
-
-                // Synthesize the argument type in a single traversal
-                let arg_result = self.analyze_inst(air, args[0], ctx)?;
-                let arg_type = arg_result.ty;
-
-                // Check that argument is a supported type (integer, bool, or string)
-                let is_supported =
-                    arg_type.is_integer() || arg_type == Type::Bool || arg_type == Type::String;
-                if !is_supported {
-                    return Err(CompileError::new(
-                        ErrorKind::IntrinsicTypeMismatch {
-                            name: intrinsic_name,
-                            expected: "integer, bool, or string".to_string(),
-                            found: arg_type.name().to_string(),
-                        },
-                        inst.span,
-                    ));
-                }
-
-                let air_ref = air.add_inst(AirInst {
-                    data: AirInstData::Intrinsic {
-                        name: intrinsic_name,
-                        args: vec![arg_result.air_ref],
-                    },
-                    ty: Type::Unit,
-                    span: inst.span,
-                });
-                Ok(AnalysisResult::new(air_ref, Type::Unit))
             }
 
             InstData::TypeIntrinsic { name, type_arg } => {

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1465,6 +1465,28 @@ impl<'a> CfgBuilder<'a> {
                 }
             }
 
+            AirInstData::IntCast { value, from_ty } => {
+                // Lower the value to cast
+                let Some(val) = self.lower_value(*value) else {
+                    return Self::diverged();
+                };
+
+                // Emit the IntCast instruction
+                let result = self.emit(
+                    CfgInstData::IntCast {
+                        value: val,
+                        from_ty: *from_ty,
+                    },
+                    ty,
+                    span,
+                );
+                self.cache(air_ref, result);
+                ExprResult {
+                    value: Some(result),
+                    continuation: Continuation::Continues,
+                }
+            }
+
             AirInstData::Drop { value } => {
                 // Lower the value to drop
                 let Some(val) = self.lower_value(*value) else {

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -254,6 +254,17 @@ pub enum CfgInstData {
         variant_index: u32,
     },
 
+    // Type conversion operations
+    /// Integer cast: convert between integer types with runtime range check.
+    /// Panics if the value cannot be represented in the target type.
+    /// The target type is stored in CfgInst.ty.
+    IntCast {
+        /// The value to cast
+        value: CfgValue,
+        /// The source type (for determining signedness and size)
+        from_ty: Type,
+    },
+
     // Drop/destructor operations
     /// Drop a value, running its destructor if the type has one.
     /// For trivially droppable types, this is a no-op that will be elided.
@@ -825,6 +836,9 @@ impl Cfg {
                 variant_index,
             } => {
                 write!(f, "enum_variant #{}::{}", enum_id.0, variant_index)
+            }
+            CfgInstData::IntCast { value, from_ty } => {
+                write!(f, "intcast {} from {}", value, from_ty.name())
             }
             CfgInstData::Drop { value } => {
                 write!(f, "drop {}", value)

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -114,6 +114,9 @@ fn has_side_effects(cfg: &Cfg, value: CfgValue) -> bool {
         CfgInstData::StorageLive { .. } => true,
         CfgInstData::StorageDead { .. } => true,
 
+        // IntCast can panic (range check), so it has side effects
+        CfgInstData::IntCast { .. } => true,
+
         // Everything else is pure computation
         _ => false,
     }
@@ -197,6 +200,9 @@ fn instruction_uses(cfg: &Cfg, value: CfgValue) -> Vec<CfgValue> {
 
         // Enum operations
         CfgInstData::EnumVariant { .. } => vec![],
+
+        // Type conversion
+        CfgInstData::IntCast { value, .. } => vec![*value],
 
         // Drop
         CfgInstData::Drop { value } => vec![*value],

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2064,6 +2064,28 @@ impl<'a> CfgLower<'a> {
                 });
             }
 
+            CfgInstData::IntCast {
+                value: src_value,
+                from_ty,
+            } => {
+                // Integer cast with runtime range check
+                let vreg = self.mir.alloc_vreg();
+                self.value_map.insert(value, vreg);
+
+                let src_vreg = self.get_vreg(*src_value);
+                let to_ty = self.cfg.get_inst(value).ty;
+
+                // Emit range check and panic if out of bounds
+                self.emit_int_cast_check(src_vreg, *from_ty, to_ty);
+
+                // Move the value to the result vreg (the bits are already correct
+                // after sign/zero extension from the range check or simple copy)
+                self.mir.push(Aarch64Inst::MovRR {
+                    dst: Operand::Virtual(vreg),
+                    src: Operand::Virtual(src_vreg),
+                });
+            }
+
             CfgInstData::Drop {
                 value: dropped_value,
             } => {
@@ -2477,6 +2499,241 @@ impl<'a> CfgLower<'a> {
             symbol: "__rue_overflow".to_string(),
         });
         self.mir.push(Aarch64Inst::Label { id: ok_label });
+    }
+
+    /// Emit integer cast range check.
+    ///
+    /// Checks if the source value can be represented in the target type.
+    /// Panics via `__rue_intcast_overflow` if the value is out of range.
+    fn emit_int_cast_check(&mut self, src_vreg: VReg, from_ty: Type, to_ty: Type) {
+        // Get type properties
+        let from_signed = from_ty.is_signed();
+        let to_signed = to_ty.is_signed();
+        let from_bits = Self::type_bits(from_ty);
+        let to_bits = Self::type_bits(to_ty);
+
+        // If casting to a larger or equal-sized type with compatible signedness,
+        // and source is unsigned or both are signed, no check needed
+        if to_bits >= from_bits {
+            // Widening or same-size cast
+            if from_signed == to_signed {
+                // Same signedness, widening - always safe
+                return;
+            }
+            if !from_signed && to_signed && to_bits > from_bits {
+                // Unsigned to larger signed - always safe
+                return;
+            }
+            // Signed to same-size unsigned needs check (negative values fail)
+            // Unsigned to same-size signed needs check (large values fail)
+        }
+
+        let ok_label = self.mir.alloc_label();
+
+        // Calculate the min and max values for the target type
+        let (min_val, max_val) = Self::type_range(to_ty);
+
+        if from_signed {
+            // Source is signed - need to check both min and max
+            if to_signed {
+                // Signed to signed: check MIN <= value <= MAX
+                if to_bits < from_bits || (to_bits == from_bits && min_val != i64::MIN) {
+                    // Check lower bound
+                    let min_vreg = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovImm {
+                        dst: Operand::Virtual(min_vreg),
+                        imm: min_val,
+                    });
+                    self.mir.push(Aarch64Inst::CmpRR {
+                        src1: Operand::Virtual(src_vreg),
+                        src2: Operand::Virtual(min_vreg),
+                    });
+                    // For signed comparison, branch if greater or equal
+                    self.mir.push(Aarch64Inst::BCond {
+                        cond: Cond::Ge,
+                        label: ok_label,
+                    });
+
+                    // Below min - panic
+                    self.mir.push(Aarch64Inst::Bl {
+                        symbol: "__rue_intcast_overflow".to_string(),
+                    });
+                    self.mir.push(Aarch64Inst::Label { id: ok_label });
+
+                    let ok_label2 = self.mir.alloc_label();
+                    // Check upper bound
+                    let max_vreg = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovImm {
+                        dst: Operand::Virtual(max_vreg),
+                        imm: max_val,
+                    });
+                    self.mir.push(Aarch64Inst::CmpRR {
+                        src1: Operand::Virtual(src_vreg),
+                        src2: Operand::Virtual(max_vreg),
+                    });
+                    // For signed comparison, branch if less or equal
+                    self.mir.push(Aarch64Inst::BCond {
+                        cond: Cond::Le,
+                        label: ok_label2,
+                    });
+
+                    // Above max - panic
+                    self.mir.push(Aarch64Inst::Bl {
+                        symbol: "__rue_intcast_overflow".to_string(),
+                    });
+                    self.mir.push(Aarch64Inst::Label { id: ok_label2 });
+                }
+            } else {
+                // Signed to unsigned: value must be >= 0 and <= max
+                // Check for negative
+                //
+                // For sub-64-bit types, we need to sign-extend first because
+                // ARM64 32-bit operations zero-extend to 64 bits, which would
+                // make -1 appear as a large positive number in 64-bit compare.
+                let compare_vreg = if from_bits < 64 {
+                    let sext_vreg = self.mir.alloc_vreg();
+                    match from_ty {
+                        Type::I8 => {
+                            self.mir.push(Aarch64Inst::Sxtb {
+                                dst: Operand::Virtual(sext_vreg),
+                                src: Operand::Virtual(src_vreg),
+                            });
+                        }
+                        Type::I16 => {
+                            self.mir.push(Aarch64Inst::Sxth {
+                                dst: Operand::Virtual(sext_vreg),
+                                src: Operand::Virtual(src_vreg),
+                            });
+                        }
+                        Type::I32 => {
+                            self.mir.push(Aarch64Inst::Sxtw {
+                                dst: Operand::Virtual(sext_vreg),
+                                src: Operand::Virtual(src_vreg),
+                            });
+                        }
+                        _ => unreachable!("non-integer type in intcast"),
+                    }
+                    sext_vreg
+                } else {
+                    src_vreg
+                };
+
+                self.mir.push(Aarch64Inst::CmpImm {
+                    src: Operand::Virtual(compare_vreg),
+                    imm: 0,
+                });
+                self.mir.push(Aarch64Inst::BCond {
+                    cond: Cond::Ge,
+                    label: ok_label,
+                });
+
+                // Negative - panic
+                self.mir.push(Aarch64Inst::Bl {
+                    symbol: "__rue_intcast_overflow".to_string(),
+                });
+                self.mir.push(Aarch64Inst::Label { id: ok_label });
+
+                // Also check upper bound if narrowing
+                if to_bits < from_bits {
+                    let ok_label2 = self.mir.alloc_label();
+                    let max_vreg = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovImm {
+                        dst: Operand::Virtual(max_vreg),
+                        imm: max_val,
+                    });
+                    self.mir.push(Aarch64Inst::CmpRR {
+                        src1: Operand::Virtual(src_vreg),
+                        src2: Operand::Virtual(max_vreg),
+                    });
+                    // Unsigned comparison for upper bound check
+                    self.mir.push(Aarch64Inst::BCond {
+                        cond: Cond::Ls, // Ls = unsigned less or same
+                        label: ok_label2,
+                    });
+
+                    // Above max - panic
+                    self.mir.push(Aarch64Inst::Bl {
+                        symbol: "__rue_intcast_overflow".to_string(),
+                    });
+                    self.mir.push(Aarch64Inst::Label { id: ok_label2 });
+                }
+            }
+        } else {
+            // Source is unsigned
+            if to_signed {
+                // Unsigned to signed: value must fit in positive range of target
+                // Check that value <= signed max
+                let max_vreg = self.mir.alloc_vreg();
+                self.mir.push(Aarch64Inst::MovImm {
+                    dst: Operand::Virtual(max_vreg),
+                    imm: max_val,
+                });
+                self.mir.push(Aarch64Inst::CmpRR {
+                    src1: Operand::Virtual(src_vreg),
+                    src2: Operand::Virtual(max_vreg),
+                });
+                // Unsigned comparison (Ls = below or same)
+                self.mir.push(Aarch64Inst::BCond {
+                    cond: Cond::Ls,
+                    label: ok_label,
+                });
+
+                // Above max - panic
+                self.mir.push(Aarch64Inst::Bl {
+                    symbol: "__rue_intcast_overflow".to_string(),
+                });
+                self.mir.push(Aarch64Inst::Label { id: ok_label });
+            } else {
+                // Unsigned to unsigned: narrowing check
+                if to_bits < from_bits {
+                    let max_vreg = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovImm {
+                        dst: Operand::Virtual(max_vreg),
+                        imm: max_val,
+                    });
+                    self.mir.push(Aarch64Inst::CmpRR {
+                        src1: Operand::Virtual(src_vreg),
+                        src2: Operand::Virtual(max_vreg),
+                    });
+                    self.mir.push(Aarch64Inst::BCond {
+                        cond: Cond::Ls,
+                        label: ok_label,
+                    });
+
+                    // Above max - panic
+                    self.mir.push(Aarch64Inst::Bl {
+                        symbol: "__rue_intcast_overflow".to_string(),
+                    });
+                    self.mir.push(Aarch64Inst::Label { id: ok_label });
+                }
+            }
+        }
+    }
+
+    /// Get the bit width of an integer type.
+    fn type_bits(ty: Type) -> u32 {
+        match ty {
+            Type::I8 | Type::U8 => 8,
+            Type::I16 | Type::U16 => 16,
+            Type::I32 | Type::U32 => 32,
+            Type::I64 | Type::U64 => 64,
+            _ => panic!("type_bits called on non-integer type: {:?}", ty),
+        }
+    }
+
+    /// Get the min and max values for an integer type.
+    fn type_range(ty: Type) -> (i64, i64) {
+        match ty {
+            Type::I8 => (i8::MIN as i64, i8::MAX as i64),
+            Type::I16 => (i16::MIN as i64, i16::MAX as i64),
+            Type::I32 => (i32::MIN as i64, i32::MAX as i64),
+            Type::I64 => (i64::MIN, i64::MAX),
+            Type::U8 => (0, u8::MAX as i64),
+            Type::U16 => (0, u16::MAX as i64),
+            Type::U32 => (0, u32::MAX as i64),
+            Type::U64 => (0, i64::MAX), // Can't represent u64::MAX in i64, but we use unsigned compare
+            _ => panic!("type_range called on non-integer type: {:?}", ty),
+        }
     }
 
     /// Emit a comparison instruction.

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2231,6 +2231,28 @@ impl<'a> CfgLower<'a> {
                 });
             }
 
+            CfgInstData::IntCast {
+                value: src_value,
+                from_ty,
+            } => {
+                // Integer cast with runtime range check
+                let vreg = self.mir.alloc_vreg();
+                self.value_map.insert(value, vreg);
+
+                let src_vreg = self.get_vreg(*src_value);
+                let to_ty = self.cfg.get_inst(value).ty;
+
+                // Emit range check and panic if out of bounds
+                self.emit_int_cast_check(src_vreg, *from_ty, to_ty);
+
+                // Move the value to the result vreg (the bits are already correct
+                // after sign/zero extension from the range check or simple copy)
+                self.mir.push(X86Inst::MovRR {
+                    dst: Operand::Virtual(vreg),
+                    src: Operand::Virtual(src_vreg),
+                });
+            }
+
             CfgInstData::Drop {
                 value: dropped_value,
             } => {
@@ -2399,6 +2421,233 @@ impl<'a> CfgLower<'a> {
             symbol: "__rue_overflow".to_string(),
         });
         self.mir.push(X86Inst::Label { id: ok_label });
+    }
+
+    /// Emit integer cast range check.
+    ///
+    /// Checks if the source value can be represented in the target type.
+    /// Panics via `__rue_intcast_overflow` if the value is out of range.
+    fn emit_int_cast_check(&mut self, src_vreg: VReg, from_ty: Type, to_ty: Type) {
+        // Get type properties
+        let from_signed = from_ty.is_signed();
+        let to_signed = to_ty.is_signed();
+        let from_bits = Self::type_bits(from_ty);
+        let to_bits = Self::type_bits(to_ty);
+
+        // If casting to a larger or equal-sized type with compatible signedness,
+        // and source is unsigned or both are signed, no check needed
+        if to_bits >= from_bits {
+            // Widening or same-size cast
+            if from_signed == to_signed {
+                // Same signedness, widening - always safe
+                return;
+            }
+            if !from_signed && to_signed && to_bits > from_bits {
+                // Unsigned to larger signed - always safe
+                return;
+            }
+            // Signed to same-size unsigned needs check (negative values fail)
+            // Unsigned to same-size signed needs check (large values fail)
+        }
+
+        let ok_label = self.new_label();
+
+        // Calculate the min and max values for the target type
+        let (min_val, max_val) = Self::type_range(to_ty);
+
+        if from_signed {
+            // Source is signed - need to check both min and max
+            if to_signed {
+                // Signed to signed: check MIN <= value <= MAX
+                if to_bits < from_bits || (to_bits == from_bits && min_val != i64::MIN) {
+                    // Check lower bound
+                    let min_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRI64 {
+                        dst: Operand::Virtual(min_vreg),
+                        imm: min_val,
+                    });
+                    if from_bits > 32 {
+                        self.mir.push(X86Inst::Cmp64RR {
+                            src1: Operand::Virtual(src_vreg),
+                            src2: Operand::Virtual(min_vreg),
+                        });
+                    } else {
+                        self.mir.push(X86Inst::CmpRR {
+                            src1: Operand::Virtual(src_vreg),
+                            src2: Operand::Virtual(min_vreg),
+                        });
+                    }
+                    // For signed comparison, use Jge (jump if greater or equal to min)
+                    self.mir.push(X86Inst::Jge { label: ok_label });
+
+                    // Below min - panic
+                    self.mir.push(X86Inst::CallRel {
+                        symbol: "__rue_intcast_overflow".to_string(),
+                    });
+                    self.mir.push(X86Inst::Label { id: ok_label });
+
+                    let ok_label2 = self.new_label();
+                    // Check upper bound
+                    let max_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRI64 {
+                        dst: Operand::Virtual(max_vreg),
+                        imm: max_val,
+                    });
+                    if from_bits > 32 {
+                        self.mir.push(X86Inst::Cmp64RR {
+                            src1: Operand::Virtual(src_vreg),
+                            src2: Operand::Virtual(max_vreg),
+                        });
+                    } else {
+                        self.mir.push(X86Inst::CmpRR {
+                            src1: Operand::Virtual(src_vreg),
+                            src2: Operand::Virtual(max_vreg),
+                        });
+                    }
+                    self.mir.push(X86Inst::Jle { label: ok_label2 });
+
+                    // Above max - panic
+                    self.mir.push(X86Inst::CallRel {
+                        symbol: "__rue_intcast_overflow".to_string(),
+                    });
+                    self.mir.push(X86Inst::Label { id: ok_label2 });
+                }
+            } else {
+                // Signed to unsigned: value must be >= 0 and <= max
+                // Check for negative
+                if from_bits > 32 {
+                    self.mir.push(X86Inst::Cmp64RI {
+                        src: Operand::Virtual(src_vreg),
+                        imm: 0,
+                    });
+                } else {
+                    self.mir.push(X86Inst::CmpRI {
+                        src: Operand::Virtual(src_vreg),
+                        imm: 0,
+                    });
+                }
+                self.mir.push(X86Inst::Jge { label: ok_label });
+
+                // Negative - panic
+                self.mir.push(X86Inst::CallRel {
+                    symbol: "__rue_intcast_overflow".to_string(),
+                });
+                self.mir.push(X86Inst::Label { id: ok_label });
+
+                // Also check upper bound if narrowing
+                if to_bits < from_bits {
+                    let ok_label2 = self.new_label();
+                    let max_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRI64 {
+                        dst: Operand::Virtual(max_vreg),
+                        imm: max_val,
+                    });
+                    if from_bits > 32 {
+                        self.mir.push(X86Inst::Cmp64RR {
+                            src1: Operand::Virtual(src_vreg),
+                            src2: Operand::Virtual(max_vreg),
+                        });
+                        // Unsigned comparison for upper bound check
+                        self.mir.push(X86Inst::Jbe { label: ok_label2 });
+                    } else {
+                        self.mir.push(X86Inst::CmpRR {
+                            src1: Operand::Virtual(src_vreg),
+                            src2: Operand::Virtual(max_vreg),
+                        });
+                        self.mir.push(X86Inst::Jbe { label: ok_label2 });
+                    }
+
+                    // Above max - panic
+                    self.mir.push(X86Inst::CallRel {
+                        symbol: "__rue_intcast_overflow".to_string(),
+                    });
+                    self.mir.push(X86Inst::Label { id: ok_label2 });
+                }
+            }
+        } else {
+            // Source is unsigned
+            if to_signed {
+                // Unsigned to signed: value must fit in positive range of target
+                // Check that value <= signed max
+                let max_vreg = self.mir.alloc_vreg();
+                self.mir.push(X86Inst::MovRI64 {
+                    dst: Operand::Virtual(max_vreg),
+                    imm: max_val,
+                });
+                if from_bits > 32 {
+                    self.mir.push(X86Inst::Cmp64RR {
+                        src1: Operand::Virtual(src_vreg),
+                        src2: Operand::Virtual(max_vreg),
+                    });
+                } else {
+                    self.mir.push(X86Inst::CmpRR {
+                        src1: Operand::Virtual(src_vreg),
+                        src2: Operand::Virtual(max_vreg),
+                    });
+                }
+                // Unsigned comparison
+                self.mir.push(X86Inst::Jbe { label: ok_label });
+
+                // Above max - panic
+                self.mir.push(X86Inst::CallRel {
+                    symbol: "__rue_intcast_overflow".to_string(),
+                });
+                self.mir.push(X86Inst::Label { id: ok_label });
+            } else {
+                // Unsigned to unsigned: narrowing check
+                if to_bits < from_bits {
+                    let max_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRI64 {
+                        dst: Operand::Virtual(max_vreg),
+                        imm: max_val,
+                    });
+                    if from_bits > 32 {
+                        self.mir.push(X86Inst::Cmp64RR {
+                            src1: Operand::Virtual(src_vreg),
+                            src2: Operand::Virtual(max_vreg),
+                        });
+                    } else {
+                        self.mir.push(X86Inst::CmpRR {
+                            src1: Operand::Virtual(src_vreg),
+                            src2: Operand::Virtual(max_vreg),
+                        });
+                    }
+                    self.mir.push(X86Inst::Jbe { label: ok_label });
+
+                    // Above max - panic
+                    self.mir.push(X86Inst::CallRel {
+                        symbol: "__rue_intcast_overflow".to_string(),
+                    });
+                    self.mir.push(X86Inst::Label { id: ok_label });
+                }
+            }
+        }
+    }
+
+    /// Get the bit width of an integer type.
+    fn type_bits(ty: Type) -> u32 {
+        match ty {
+            Type::I8 | Type::U8 => 8,
+            Type::I16 | Type::U16 => 16,
+            Type::I32 | Type::U32 => 32,
+            Type::I64 | Type::U64 => 64,
+            _ => panic!("type_bits called on non-integer type: {:?}", ty),
+        }
+    }
+
+    /// Get the min and max values for an integer type.
+    fn type_range(ty: Type) -> (i64, i64) {
+        match ty {
+            Type::I8 => (i8::MIN as i64, i8::MAX as i64),
+            Type::I16 => (i16::MIN as i64, i16::MAX as i64),
+            Type::I32 => (i32::MIN as i64, i32::MAX as i64),
+            Type::I64 => (i64::MIN, i64::MAX),
+            Type::U8 => (0, u8::MAX as i64),
+            Type::U16 => (0, u16::MAX as i64),
+            Type::U32 => (0, u32::MAX as i64),
+            Type::U64 => (0, i64::MAX), // Can't represent u64::MAX in i64, but we use unsigned compare
+            _ => panic!("type_range called on non-integer type: {:?}", ty),
+        }
     }
 
     /// Emit a comparison instruction.

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -492,6 +492,9 @@ impl<'a> Emitter<'a> {
             X86Inst::CmpRI { src, imm } => {
                 self.emit_cmp_ri(src.as_physical(), *imm);
             }
+            X86Inst::Cmp64RI { src, imm } => {
+                self.emit_cmp64_ri(src.as_physical(), *imm);
+            }
             X86Inst::Sete { dst } => {
                 self.emit_setcc(0x94, dst.as_physical()); // SETE opcode
             }
@@ -563,6 +566,12 @@ impl<'a> Emitter<'a> {
             }
             X86Inst::Jbe { label } => {
                 self.emit_jcc(0x76, *label); // JBE rel8 opcode (CF=1 or ZF=1)
+            }
+            X86Inst::Jge { label } => {
+                self.emit_jcc(0x7D, *label); // JGE rel8 opcode (SF=OF)
+            }
+            X86Inst::Jle { label } => {
+                self.emit_jcc(0x7E, *label); // JLE rel8 opcode (ZF=1 or SF≠OF)
             }
             X86Inst::Jmp { label } => {
                 self.emit_jmp(*label);
@@ -1665,6 +1674,30 @@ impl<'a> Emitter<'a> {
         self.code.push(modrm);
 
         // Immediate (32-bit little-endian)
+        self.code.extend_from_slice(&imm.to_le_bytes());
+    }
+
+    /// Emit `cmp r64, imm32` (sign-extended).
+    ///
+    /// Encoding: REX.W 81 /7 imm32 (cmp r/m64, imm32)
+    fn emit_cmp64_ri(&mut self, src: Reg, imm: i32) {
+        let src_enc = src.encoding();
+
+        // REX prefix: REX.W for 64-bit operand size, plus REX.B if extended register
+        let mut rex = 0x48; // REX.W
+        if src.needs_rex() {
+            rex |= 0x01; // REX.B
+        }
+        self.code.push(rex);
+
+        // Opcode: 81 (group 1, /7 for CMP)
+        self.code.push(0x81);
+
+        // ModR/M: mod=11, reg=7 (CMP), r/m=src
+        let modrm = 0xC0 | (7 << 3) | (src_enc & 7);
+        self.code.push(modrm);
+
+        // Immediate (32-bit sign-extended to 64-bit by CPU)
         self.code.extend_from_slice(&imm.to_le_bytes());
     }
 

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -63,7 +63,9 @@ pub fn analyze(mir: &X86Mir) -> LivenessInfo {
             | X86Inst::Jno { label }
             | X86Inst::Jb { label }
             | X86Inst::Jae { label }
-            | X86Inst::Jbe { label } => {
+            | X86Inst::Jbe { label }
+            | X86Inst::Jge { label }
+            | X86Inst::Jle { label } => {
                 // Fall-through to next instruction
                 if idx + 1 < num_insts {
                     successors[idx].push(idx + 1);
@@ -275,7 +277,7 @@ fn uses(inst: &X86Inst) -> Vec<VReg> {
             add_if_virtual(src1, &mut result);
             add_if_virtual(src2, &mut result);
         }
-        X86Inst::CmpRI { src, .. } => {
+        X86Inst::CmpRI { src, .. } | X86Inst::Cmp64RI { src, .. } => {
             add_if_virtual(src, &mut result);
         }
         X86Inst::Sete { .. }
@@ -335,6 +337,8 @@ fn uses(inst: &X86Inst) -> Vec<VReg> {
         | X86Inst::Jb { .. }
         | X86Inst::Jae { .. }
         | X86Inst::Jbe { .. }
+        | X86Inst::Jge { .. }
+        | X86Inst::Jle { .. }
         | X86Inst::Jmp { .. }
         | X86Inst::Label { .. }
         | X86Inst::CallRel { .. }
@@ -407,7 +411,8 @@ fn defs(inst: &X86Inst) -> Vec<VReg> {
         X86Inst::TestRR { .. }
         | X86Inst::CmpRR { .. }
         | X86Inst::Cmp64RR { .. }
-        | X86Inst::CmpRI { .. } => {
+        | X86Inst::CmpRI { .. }
+        | X86Inst::Cmp64RI { .. } => {
             // Only sets flags, no register def
         }
         X86Inst::Sete { dst }
@@ -459,6 +464,8 @@ fn defs(inst: &X86Inst) -> Vec<VReg> {
         | X86Inst::Jb { .. }
         | X86Inst::Jae { .. }
         | X86Inst::Jbe { .. }
+        | X86Inst::Jge { .. }
+        | X86Inst::Jle { .. }
         | X86Inst::Jmp { .. }
         | X86Inst::Label { .. }
         | X86Inst::CallRel { .. }

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -275,8 +275,11 @@ pub enum X86Inst {
     /// `cmp src1, src2` - Compare 64-bit (subtract and set flags, discard result).
     Cmp64RR { src1: Operand, src2: Operand },
 
-    /// `cmp src, imm` - Compare register with immediate.
+    /// `cmp src, imm` - Compare register with immediate (32-bit).
     CmpRI { src: Operand, imm: i32 },
+
+    /// `cmp src, imm` - Compare register with immediate (64-bit).
+    Cmp64RI { src: Operand, imm: i32 },
 
     /// `sete dst` - Set byte if equal (ZF=1).
     Sete { dst: Operand },
@@ -349,6 +352,12 @@ pub enum X86Inst {
 
     /// `jbe label` - Jump if below or equal (unsigned: CF=1 or ZF=1).
     Jbe { label: LabelId },
+
+    /// `jge label` - Jump if greater or equal (signed: SF=OF).
+    Jge { label: LabelId },
+
+    /// `jle label` - Jump if less or equal (signed: ZF=1 or SF≠OF).
+    Jle { label: LabelId },
 
     /// `jmp label` - Unconditional jump.
     Jmp { label: LabelId },
@@ -489,6 +498,7 @@ impl fmt::Display for X86Inst {
             X86Inst::CmpRR { src1, src2 } => write!(f, "cmp {}, {}", src1, src2),
             X86Inst::Cmp64RR { src1, src2 } => write!(f, "cmpq {}, {}", src1, src2),
             X86Inst::CmpRI { src, imm } => write!(f, "cmp {}, {}", src, imm),
+            X86Inst::Cmp64RI { src, imm } => write!(f, "cmpq {}, {}", src, imm),
             X86Inst::Sete { dst } => write!(f, "sete {}", dst),
             X86Inst::Setne { dst } => write!(f, "setne {}", dst),
             X86Inst::Setl { dst } => write!(f, "setl {}", dst),
@@ -513,6 +523,8 @@ impl fmt::Display for X86Inst {
             X86Inst::Jb { label } => write!(f, "jb {}", label),
             X86Inst::Jae { label } => write!(f, "jae {}", label),
             X86Inst::Jbe { label } => write!(f, "jbe {}", label),
+            X86Inst::Jge { label } => write!(f, "jge {}", label),
+            X86Inst::Jle { label } => write!(f, "jle {}", label),
             X86Inst::Jmp { label } => write!(f, "jmp {}", label),
             X86Inst::Label { id } => write!(f, "{}:", id),
             X86Inst::CallRel { symbol } => write!(f, "call {}", symbol),

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -362,6 +362,11 @@ impl RegAlloc {
                 mir.push(X86Inst::CmpRI { src: src_op, imm });
             }
 
+            X86Inst::Cmp64RI { src, imm } => {
+                let src_op = self.load_operand(mir, src, Reg::Rax)?;
+                mir.push(X86Inst::Cmp64RI { src: src_op, imm });
+            }
+
             X86Inst::Sete { dst } => {
                 self.emit_setcc(mir, dst, |d| X86Inst::Sete { dst: d });
             }
@@ -674,6 +679,8 @@ impl RegAlloc {
             X86Inst::Jb { label } => mir.push(X86Inst::Jb { label }),
             X86Inst::Jae { label } => mir.push(X86Inst::Jae { label }),
             X86Inst::Jbe { label } => mir.push(X86Inst::Jbe { label }),
+            X86Inst::Jge { label } => mir.push(X86Inst::Jge { label }),
+            X86Inst::Jle { label } => mir.push(X86Inst::Jle { label }),
             X86Inst::Jmp { label } => mir.push(X86Inst::Jmp { label }),
             X86Inst::Label { id } => mir.push(X86Inst::Label { id }),
             X86Inst::CallRel { symbol } => mir.push(X86Inst::CallRel { symbol }),

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -442,6 +442,44 @@ pub extern "C" fn __rue_overflow() -> ! {
     platform::exit(101)
 }
 
+/// Runtime error: integer cast overflow.
+///
+/// Called when `@intCast` would produce a value that cannot be represented
+/// in the target type. For example, casting `-1i32` to `u8` or `256u32` to `u8`.
+///
+/// # Behavior
+///
+/// 1. Writes `"error: integer cast overflow\n"` to stderr (best-effort)
+/// 2. Exits with code 101
+///
+/// # ABI
+///
+/// ```text
+/// extern "C" fn __rue_intcast_overflow() -> !
+/// ```
+///
+/// No arguments. Never returns.
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn __rue_intcast_overflow() -> ! {
+    platform::write_stderr(b"error: integer cast overflow\n");
+    platform::exit(101)
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn __rue_intcast_overflow() -> ! {
+    platform::write_stderr(b"error: integer cast overflow\n");
+    platform::exit(101)
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+pub extern "C" fn __rue_intcast_overflow() -> ! {
+    platform::write_stderr(b"error: integer cast overflow\n");
+    platform::exit(101)
+}
+
 /// Runtime error: index out of bounds.
 ///
 /// Called when an array index operation accesses an element outside the

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -284,3 +284,246 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
+
+# =============================================================================
+# @intCast Intrinsic
+# =============================================================================
+
+[[case]]
+name = "intcast_i32_to_u8"
+spec = ["4.13:24", "4.13:25", "4.13:26"]
+source = """
+fn main() -> i32 {
+    let x: i32 = 100;
+    let y: u8 = @intCast(x);
+    @intCast(y)
+}
+"""
+exit_code = 100
+
+[[case]]
+name = "intcast_u8_to_i32"
+spec = ["4.13:24", "4.13:25", "4.13:26"]
+source = """
+fn main() -> i32 {
+    let x: u8 = 255;
+    let y: i32 = @intCast(x);
+    y
+}
+"""
+exit_code = 255
+
+[[case]]
+name = "intcast_i64_to_i32"
+spec = ["4.13:24", "4.13:25"]
+source = """
+fn main() -> i32 {
+    let x: i64 = 42;
+    let y: i32 = @intCast(x);
+    y
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "intcast_inferred_from_function_param"
+spec = ["4.13:26"]
+source = """
+fn takes_u8(x: u8) -> i32 {
+    @intCast(x)
+}
+fn main() -> i32 {
+    let x: i32 = 50;
+    takes_u8(@intCast(x))
+}
+"""
+exit_code = 50
+
+[[case]]
+name = "intcast_inferred_from_return"
+spec = ["4.13:26"]
+source = """
+fn cast_to_u8(x: i32) -> u8 {
+    @intCast(x)
+}
+fn main() -> i32 {
+    let y: u8 = cast_to_u8(77);
+    @intCast(y)
+}
+"""
+exit_code = 77
+
+[[case]]
+name = "intcast_type_not_inferred"
+spec = ["4.13:27"]
+source = """
+fn main() -> i32 {
+    let x: i32 = 100;
+    // No context to infer target type
+    @intCast(x);
+    0
+}
+"""
+compile_fail = true
+error_contains = "type annotation required"
+
+[[case]]
+name = "intcast_non_integer_argument"
+spec = ["4.13:25"]
+source = """
+fn main() -> i32 {
+    let x: bool = true;
+    let y: i32 = @intCast(x);
+    y
+}
+"""
+compile_fail = true
+error_contains = "integer"
+
+[[case]]
+name = "intcast_wrong_arg_count_zero"
+spec = ["4.13:4", "4.13:25"]
+source = """
+fn main() -> i32 {
+    let y: i32 = @intCast();
+    y
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "intcast_wrong_arg_count_two"
+spec = ["4.13:4", "4.13:25"]
+source = """
+fn main() -> i32 {
+    let x: i32 = 1;
+    let y: i32 = @intCast(x, x);
+    y
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "intcast_overflow_u8_max"
+spec = ["4.13:28"]
+source = """
+fn main() -> i32 {
+    let x: i32 = 256;
+    let y: u8 = @intCast(x);
+    0
+}
+"""
+exit_code = 101
+stderr_contains = "integer cast overflow"
+
+[[case]]
+name = "intcast_overflow_negative_to_unsigned"
+spec = ["4.13:28"]
+source = """
+fn main() -> i32 {
+    let x: i32 = -1;
+    let y: u32 = @intCast(x);
+    0
+}
+"""
+exit_code = 101
+stderr_contains = "integer cast overflow"
+
+[[case]]
+name = "intcast_overflow_i8_max"
+spec = ["4.13:28"]
+source = """
+fn main() -> i32 {
+    let x: i32 = 128;
+    let y: i8 = @intCast(x);
+    0
+}
+"""
+exit_code = 101
+stderr_contains = "integer cast overflow"
+
+[[case]]
+name = "intcast_overflow_i8_min"
+spec = ["4.13:28"]
+source = """
+fn main() -> i32 {
+    let x: i32 = -129;
+    let y: i8 = @intCast(x);
+    0
+}
+"""
+exit_code = 101
+stderr_contains = "integer cast overflow"
+
+[[case]]
+name = "intcast_boundary_i8_max"
+spec = ["4.13:24", "4.13:28"]
+source = """
+fn main() -> i32 {
+    let x: i32 = 127;
+    let y: i8 = @intCast(x);
+    @intCast(y)
+}
+"""
+exit_code = 127
+
+[[case]]
+name = "intcast_boundary_i8_min"
+spec = ["4.13:24", "4.13:28"]
+source = """
+fn main() -> i32 {
+    let x: i32 = -128;
+    let y: i8 = @intCast(x);
+    @intCast(y)
+}
+"""
+exit_code = 128
+
+[[case]]
+name = "intcast_boundary_u8_max"
+spec = ["4.13:24", "4.13:28"]
+source = """
+fn main() -> i32 {
+    let x: i32 = 255;
+    let y: u8 = @intCast(x);
+    @intCast(y)
+}
+"""
+exit_code = 255
+
+[[case]]
+name = "intcast_signed_to_unsigned_same_size"
+spec = ["4.13:24", "4.13:28"]
+source = """
+fn main() -> i32 {
+    let x: i32 = 100;
+    let y: u32 = @intCast(x);
+    @intCast(y)
+}
+"""
+exit_code = 100
+
+[[case]]
+name = "intcast_unsigned_to_signed_same_size"
+spec = ["4.13:24", "4.13:28"]
+source = """
+fn main() -> i32 {
+    let x: u32 = 100;
+    let y: i32 = @intCast(x);
+    y
+}
+"""
+exit_code = 100
+
+[[case]]
+name = "intcast_unsigned_to_signed_overflow"
+spec = ["4.13:28"]
+source = """
+fn main() -> i32 {
+    let x: u32 = 2147483648;  // i32::MAX + 1
+    let y: i32 = @intCast(x);
+    y
+}
+"""
+exit_code = 101
+stderr_contains = "integer cast overflow"

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -149,3 +149,69 @@ fn main() -> i32 {
     @align_of(i32)    // 8
 }
 ```
+
+## `@intCast`
+
+{{ rule(id="4.13:24", cat="normative") }}
+
+The `@intCast` intrinsic converts an integer value from one integer type to another.
+
+{{ rule(id="4.13:25", cat="normative") }}
+
+`@intCast` accepts exactly one argument, which must be an integer type (any of `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`).
+
+{{ rule(id="4.13:26", cat="normative") }}
+
+The target type of the conversion is inferred from the context where `@intCast` is used.
+
+{{ rule(id="4.13:27", cat="legality-rule") }}
+
+It is a compile-time error if the target type cannot be inferred or is not an integer type.
+
+{{ rule(id="4.13:28", cat="dynamic-semantics") }}
+
+If the source value cannot be exactly represented in the target type, a runtime panic occurs.
+
+{{ rule(id="4.13:29") }}
+
+```rue
+fn main() -> i32 {
+    let x: i32 = 100;
+    let y: u8 = @intCast(x);  // OK: 100 fits in u8
+    @intCast(y)               // Convert back to i32
+}
+```
+
+{{ rule(id="4.13:30") }}
+
+```rue
+fn takes_u8(x: u8) -> u8 { x }
+
+fn main() -> i32 {
+    let x: i32 = 50;
+    takes_u8(@intCast(x));    // Target type inferred from parameter
+    0
+}
+```
+
+{{ rule(id="4.13:31") }}
+
+```rue
+// This panics at runtime: 256 doesn't fit in u8
+fn main() -> i32 {
+    let x: i32 = 256;
+    let y: u8 = @intCast(x);  // panic: integer cast overflow
+    0
+}
+```
+
+{{ rule(id="4.13:32") }}
+
+```rue
+// This panics at runtime: negative values don't fit in unsigned types
+fn main() -> i32 {
+    let x: i32 = -1;
+    let y: u32 = @intCast(x); // panic: integer cast overflow
+    0
+}
+```


### PR DESCRIPTION
Adds the @intCast intrinsic which converts between integer types with runtime bounds checking. The target type is inferred from context (like Zig's @intCast).

Features:
- Type inference for target type from context (variable type, function parameter, return type)
- Compile-time error if target type cannot be inferred
- Runtime panic with 'integer cast overflow' if value doesn't fit
- Handles all integer type combinations (signed/unsigned, widening/narrowing)

Implementation across the compiler pipeline:
- AIR: Added IntCast instruction variant
- Type inference: Returns fresh type variable for context-based inference
- CFG: Added IntCast instruction
- DCE: Marked IntCast as having side effects (can panic)
- x86_64 codegen: Added Jge, Jle, Cmp64RI instructions and range checks
- aarch64 codegen: Added range checks with proper sign extension

Also adds:
- __rue_intcast_overflow panic function in runtime
- Spec documentation (rules 4.13:24-32)
- 19 spec tests covering all edge cases

Closes rue-51f7

🤖 Generated with [Claude Code](https://claude.com/claude-code)