### PR TITLE
Prevent website deploy from forks

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -48,7 +48,7 @@ jobs:
           path: website/public
 
   deploy:
-    if: github.ref == 'refs/heads/trunk'
+    if: github.ref == 'refs/heads/trunk' && github.repository == 'rue-language/rue'
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
Add repository check to deploy job condition to ensure deployments only happen from the main rue-language/rue repository, not from forks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)