### PR TITLE
Enable String destructor integration

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -861,15 +861,21 @@ impl<'a> CfgBuilder<'a> {
                 if !is_storage_live_wrapper {
                     if let Some(scope_slots) = self.scope_stack.pop() {
                         for live_slot in scope_slots.into_iter().rev() {
-                            // TODO: When we have types that need drop, emit Drop before StorageDead
-                            // if self.type_needs_drop(live_slot.ty) {
-                            //     let slot_val = self.emit(
-                            //         CfgInstData::Load { slot: live_slot.slot },
-                            //         live_slot.ty,
-                            //         live_slot.span,
-                            //     );
-                            //     self.emit(CfgInstData::Drop { value: slot_val }, Type::Unit, live_slot.span);
-                            // }
+                            // Emit Drop for types that need cleanup (e.g., heap-allocated String)
+                            if self.type_needs_drop(live_slot.ty) {
+                                let slot_val = self.emit(
+                                    CfgInstData::Load {
+                                        slot: live_slot.slot,
+                                    },
+                                    live_slot.ty,
+                                    live_slot.span,
+                                );
+                                self.emit(
+                                    CfgInstData::Drop { value: slot_val },
+                                    Type::Unit,
+                                    live_slot.span,
+                                );
+                            }
                             self.emit(
                                 CfgInstData::StorageDead {
                                     slot: live_slot.slot,
@@ -1600,9 +1606,10 @@ impl<'a> CfgBuilder<'a> {
             // Enum types are trivially droppable (just discriminant values)
             Type::Enum(_) => false,
 
-            // String will need drop when mutable strings land (heap allocation)
-            // For now, string literals are static and don't need drop
-            Type::String => false,
+            // String needs drop - heap-allocated strings must be freed.
+            // String literals have cap=0 and the runtime __rue_drop_String
+            // function is a no-op for them.
+            Type::String => true,
 
             // Struct types need drop if any field needs drop
             Type::Struct(struct_id) => {

--- a/docs/designs/0014-mutable-strings.md
+++ b/docs/designs/0014-mutable-strings.md
@@ -312,13 +312,13 @@ Add string-specific functions to runtime:
 
 **Testable**: Unit tests in Rust for allocation/reallocation.
 
-### Phase 4: String Destructor Integration
+### Phase 4: String Destructor Integration - rue-0hef.4 (COMPLETE)
 
 Wire String type to use destructors:
 
-- Mark String as `needs_drop` in type system
-- Drop elaboration inserts Drop instructions for String
-- Codegen calls `__rue_drop_String`
+- [x] Mark String as `needs_drop` in type system
+- [x] Drop elaboration inserts Drop instructions for String
+- [x] Codegen calls `__rue_drop_String`
 
 **Testable**: Valgrind-clean string allocation and deallocation.
 


### PR DESCRIPTION
- Mark String as needs_drop in type system (type_needs_drop returns true)
- Enable scope-exit drop elaboration for types needing cleanup
- Drop instructions now emitted before StorageDead for String values
- Runtime __rue_drop_String handles cleanup (no-op for literals with cap=0)

Fixes rue-0hef.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)