### PR TITLE
Remove unnecessary clone in CFG builder

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -134,7 +134,7 @@ impl<'a> CfgBuilder<'a> {
         let span = inst.span;
         let ty = inst.ty;
 
-        match &inst.data.clone() {
+        match &inst.data {
             AirInstData::Const(v) => {
                 let value = self.emit(CfgInstData::Const(*v), ty, span);
                 self.cache(air_ref, value);


### PR DESCRIPTION
Remove the unnecessary .clone() on inst.data in the match statement in CfgBuilder::lower_inst(). Since self.air is a shared reference (&'a Air), the borrow of inst.data doesn't conflict with mutable operations on other CfgBuilder fields.

Fixes rue-5d8a

🤖 Generated with [Claude Code](https://claude.ai/claude-code)