### PR TITLE
rue-intern: add debug assertions for u32 overflow

### DIFF
--- a/crates/rue-intern/src/lib.rs
+++ b/crates/rue-intern/src/lib.rs
@@ -143,6 +143,19 @@ impl Interner {
             return sym;
         }
 
+        // Debug assertions for u32 overflow - these are critical for catching
+        // pathological inputs during development without affecting release perf
+        debug_assert!(
+            self.data.len() <= u32::MAX as usize,
+            "interner data buffer overflow: {} bytes exceeds u32::MAX",
+            self.data.len()
+        );
+        debug_assert!(
+            self.offsets.len() < u32::MAX as usize,
+            "interner symbol count overflow: {} symbols exceeds u32::MAX - 1",
+            self.offsets.len()
+        );
+
         let start = self.data.len() as u32;
         let sym = Symbol::from_raw(self.offsets.len() as u32);
 


### PR DESCRIPTION
Add debug_assert! checks in intern_inner() to catch potential u32 overflow when interning many strings. The assertions verify:

- data buffer length doesn't exceed u32::MAX before cast
- symbol count doesn't exceed u32::MAX - 1 before cast

These compile away in release builds but will catch pathological inputs during development.

Fixes rue-yf6s

🤖 Generated with [Claude Code](https://claude.com/claude-code)