### PR TITLE
feat: implement String::new() and String::with_capacity() constructio…

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -3623,6 +3623,20 @@ impl<'a> Sema<'a> {
                 let type_name_str = self.interner.get(*type_name).to_string();
                 let function_name_str = self.interner.get(*function).to_string();
 
+                // Check if this is a built-in type with associated functions
+                let well_known = self.interner.well_known();
+
+                // Handle String::new() and String::with_capacity()
+                if *type_name == well_known.string {
+                    return self.analyze_string_assoc_fn(
+                        air,
+                        ctx,
+                        &function_name_str,
+                        args,
+                        inst.span,
+                    );
+                }
+
                 // Check that the type exists and is a struct
                 let _struct_id = self.structs.get(type_name).ok_or_compile_error(
                     ErrorKind::UnknownType(type_name_str.clone()),
@@ -4133,6 +4147,97 @@ impl<'a> Sema<'a> {
                 | InstData::Eq { .. }
                 | InstData::Ne { .. }
         )
+    }
+
+    /// Analyze a String associated function call (String::new, String::with_capacity).
+    ///
+    /// These are built-in functions for the String type that construct new String values.
+    fn analyze_string_assoc_fn(
+        &mut self,
+        air: &mut Air,
+        ctx: &mut AnalysisContext,
+        function_name: &str,
+        args: &[RirCallArg],
+        span: Span,
+    ) -> CompileResult<AnalysisResult> {
+        match function_name {
+            "new" => {
+                // String::new() takes no arguments and returns an empty String
+                if !args.is_empty() {
+                    return Err(CompileError::new(
+                        ErrorKind::WrongArgumentCount {
+                            expected: 0,
+                            found: args.len(),
+                        },
+                        span,
+                    ));
+                }
+
+                // Generate a call to String__new (runtime function)
+                // We use double underscore because :: is not valid in C symbol names
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::Call {
+                        name: "String__new".to_string(),
+                        args: vec![],
+                    },
+                    ty: Type::String,
+                    span,
+                });
+                Ok(AnalysisResult::new(air_ref, Type::String))
+            }
+
+            "with_capacity" => {
+                // String::with_capacity(cap: u64) takes one u64 argument
+                if args.len() != 1 {
+                    return Err(CompileError::new(
+                        ErrorKind::WrongArgumentCount {
+                            expected: 1,
+                            found: args.len(),
+                        },
+                        span,
+                    ));
+                }
+
+                // Analyze the capacity argument
+                let cap_result = self.analyze_inst(air, args[0].value, ctx)?;
+
+                // Verify the type is u64
+                if cap_result.ty != Type::U64 && !cap_result.ty.is_error() {
+                    return Err(CompileError::new(
+                        ErrorKind::TypeMismatch {
+                            expected: "u64".to_string(),
+                            found: cap_result.ty.name().to_string(),
+                        },
+                        span,
+                    ));
+                }
+
+                // Generate a call to String__with_capacity (runtime function)
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::Call {
+                        name: "String__with_capacity".to_string(),
+                        args: vec![AirCallArg {
+                            value: cap_result.air_ref,
+                            mode: AirArgMode::Normal,
+                        }],
+                    },
+                    ty: Type::String,
+                    span,
+                });
+                Ok(AnalysisResult::new(air_ref, Type::String))
+            }
+
+            _ => {
+                // Unknown associated function for String
+                Err(CompileError::new(
+                    ErrorKind::UndefinedAssocFn {
+                        type_name: "String".to_string(),
+                        function_name: function_name.to_string(),
+                    },
+                    span,
+                ))
+            }
+        }
     }
 }
 

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1489,7 +1489,7 @@ impl<'a> CfgLower<'a> {
                     });
                 }
 
-                // Handle struct return
+                // Handle struct and string returns (multi-slot types)
                 if let Type::Struct(struct_id) = ty {
                     let slot_count = self.type_slot_count(Type::Struct(struct_id));
                     let mut slot_vregs = Vec::new();
@@ -1510,6 +1510,22 @@ impl<'a> CfgLower<'a> {
                             src: Operand::Virtual(first_vreg),
                         });
                     }
+                } else if ty == Type::String {
+                    // String is 3 slots: ptr (x0), len (x1), cap (x2)
+                    let mut slot_vregs = Vec::new();
+                    for slot_idx in 0..3 {
+                        let slot_vreg = self.mir.alloc_vreg();
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Virtual(slot_vreg),
+                            src: Operand::Physical(RET_REGS[slot_idx]),
+                        });
+                        slot_vregs.push(slot_vreg);
+                    }
+                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(result_vreg),
+                        src: Operand::Virtual(slot_vregs[0]),
+                    });
                 } else {
                     // Move result from X0
                     self.mir.push(Aarch64Inst::MovRR {
@@ -2130,6 +2146,38 @@ impl<'a> CfgLower<'a> {
                 // destructor function to call.
                 let dropped_ty = self.cfg.get_inst(*dropped_value).ty;
 
+                // Handle String specially - it's a fat pointer (ptr, len, cap)
+                if dropped_ty == Type::String {
+                    // String requires all 3 slots as arguments to __rue_drop_String
+                    if let Some(field_vregs) = self.struct_slot_vregs.get(dropped_value).cloned() {
+                        debug_assert_eq!(
+                            field_vregs.len(),
+                            3,
+                            "String should have 3 slots (ptr, len, cap)"
+                        );
+                        // Move all 3 components into argument registers
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Physical(ARG_REGS[0]),
+                            src: Operand::Virtual(field_vregs[0]), // ptr
+                        });
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Physical(ARG_REGS[1]),
+                            src: Operand::Virtual(field_vregs[1]), // len
+                        });
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Physical(ARG_REGS[2]),
+                            src: Operand::Virtual(field_vregs[2]), // cap
+                        });
+                    } else {
+                        unreachable!("String value should have field vregs for fat pointer");
+                    }
+
+                    self.mir.push(Aarch64Inst::Bl {
+                        symbol: "__rue_drop_String".to_string(),
+                    });
+                    return;
+                }
+
                 // Load the value to drop into the first argument register (X0)
                 let val_vreg = self.get_vreg(*dropped_value);
                 self.mir.push(Aarch64Inst::MovRR {
@@ -2161,7 +2209,7 @@ impl<'a> CfgLower<'a> {
                         let struct_def = &self.struct_defs[struct_id.0 as usize];
                         format!("__rue_drop_{}", struct_def.name)
                     }
-                    Type::String => "__rue_drop_String".to_string(),
+                    Type::String => unreachable!("String should be handled above"),
                     // Other types that might need drop in the future can be added here
                     _ => {
                         // For now, any other type reaching here is unexpected

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1624,7 +1624,7 @@ impl<'a> CfgLower<'a> {
                     });
                 }
 
-                // Handle struct return
+                // Handle struct and string returns (multi-slot types)
                 if let Type::Struct(struct_id) = ty {
                     let slot_count = self.type_slot_count(Type::Struct(struct_id));
                     let mut slot_vregs = Vec::new();
@@ -1645,6 +1645,22 @@ impl<'a> CfgLower<'a> {
                             src: Operand::Virtual(first_vreg),
                         });
                     }
+                } else if ty == Type::String {
+                    // String is 3 slots: ptr (rax), len (rdx), cap (rcx)
+                    let mut slot_vregs = Vec::new();
+                    for slot_idx in 0..3 {
+                        let slot_vreg = self.mir.alloc_vreg();
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Virtual(slot_vreg),
+                            src: Operand::Physical(RET_REGS[slot_idx]),
+                        });
+                        slot_vregs.push(slot_vreg);
+                    }
+                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(result_vreg),
+                        src: Operand::Virtual(slot_vregs[0]),
+                    });
                 } else {
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Virtual(result_vreg),
@@ -2297,6 +2313,38 @@ impl<'a> CfgLower<'a> {
                 // destructor function to call.
                 let dropped_ty = self.cfg.get_inst(*dropped_value).ty;
 
+                // Handle String specially - it's a fat pointer (ptr, len, cap)
+                if dropped_ty == Type::String {
+                    // String requires all 3 slots as arguments to __rue_drop_String
+                    if let Some(field_vregs) = self.struct_slot_vregs.get(dropped_value).cloned() {
+                        debug_assert_eq!(
+                            field_vregs.len(),
+                            3,
+                            "String should have 3 slots (ptr, len, cap)"
+                        );
+                        // Move all 3 components into argument registers (rdi, rsi, rdx)
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Physical(ARG_REGS[0]),
+                            src: Operand::Virtual(field_vregs[0]), // ptr
+                        });
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Physical(ARG_REGS[1]),
+                            src: Operand::Virtual(field_vregs[1]), // len
+                        });
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Physical(ARG_REGS[2]),
+                            src: Operand::Virtual(field_vregs[2]), // cap
+                        });
+                    } else {
+                        unreachable!("String value should have field vregs for fat pointer");
+                    }
+
+                    self.mir.push(X86Inst::CallRel {
+                        symbol: "__rue_drop_String".to_string(),
+                    });
+                    return;
+                }
+
                 // Load the value to drop into the first argument register (RDI)
                 let val_vreg = self.get_vreg(*dropped_value);
                 self.mir.push(X86Inst::MovRR {
@@ -2328,7 +2376,7 @@ impl<'a> CfgLower<'a> {
                         let struct_def = &self.struct_defs[struct_id.0 as usize];
                         format!("__rue_drop_{}", struct_def.name)
                     }
-                    Type::String => "__rue_drop_String".to_string(),
+                    Type::String => unreachable!("String should be handled above"),
                     // Other types that might need drop in the future can be added here
                     _ => {
                         // For now, any other type reaching here is unexpected

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -878,6 +878,154 @@ define_for_all_platforms! {
     }
 }
 
+// =========================================================================
+// String Construction Functions
+// =========================================================================
+
+/// Create an empty String with no allocation.
+///
+/// Returns an empty String (ptr=null, len=0, cap=0). This represents an empty
+/// string that points to no data. Any mutation will trigger heap allocation.
+///
+/// Since we want to return 3 values in registers (to match Rue's multi-value
+/// return convention), we return 3 separate u64 values:
+/// - ptr (first return value)
+/// - len (second return value)
+/// - cap (third return value)
+///
+/// This approach avoids struct ABI differences where large structs (>16 bytes
+/// on ARM64) would be returned via pointer.
+///
+/// # ABI
+///
+/// ```text
+/// extern "C" fn String__new() -> u64  // ptr in rax/x0, len in rdx/x1, cap in rcx/x2
+/// ```
+///
+/// Uses assembly to ensure multi-register returns work correctly.
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[unsafe(naked)]
+#[allow(non_snake_case)]
+pub unsafe extern "C" fn String__new() {
+    // Returns: rax=ptr(0), rdx=len(0), rcx=cap(0)
+    core::arch::naked_asm!(
+        "xor eax, eax", // ptr = 0
+        "xor edx, edx", // len = 0
+        "xor ecx, ecx", // cap = 0
+        "ret",
+    );
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[unsafe(no_mangle)]
+#[unsafe(naked)]
+#[allow(non_snake_case)]
+pub unsafe extern "C" fn String__new() {
+    // Returns: x0=ptr(0), x1=len(0), x2=cap(0)
+    core::arch::naked_asm!(
+        "mov x0, xzr", // ptr = 0
+        "mov x1, xzr", // len = 0
+        "mov x2, xzr", // cap = 0
+        "ret",
+    );
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[unsafe(naked)]
+#[allow(non_snake_case)]
+pub unsafe extern "C" fn String__new() {
+    // Returns: x0=ptr(0), x1=len(0), x2=cap(0)
+    core::arch::naked_asm!(
+        "mov x0, xzr", // ptr = 0
+        "mov x1, xzr", // len = 0
+        "mov x2, xzr", // cap = 0
+        "ret",
+    );
+}
+
+/// Create an empty String with pre-allocated capacity.
+///
+/// Allocates a heap buffer with the given capacity (at least STRING_MIN_CAPACITY).
+/// Returns a String with len=0 but capacity available for appending.
+///
+/// # Arguments
+///
+/// * `cap` - Desired capacity in bytes (will be at least STRING_MIN_CAPACITY)
+///
+/// # ABI
+///
+/// ```text
+/// extern "C" fn String__with_capacity(cap: u64) -> (ptr, len, cap)
+/// ```
+///
+/// On x86-64: cap in rdi, returns ptr in rax, len in rdx, cap in rcx
+/// On aarch64: cap in x0, returns ptr in x0, len in x1, cap in x2
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__with_capacity(requested_cap: u64) -> u64 {
+    let actual_cap = if requested_cap < STRING_MIN_CAPACITY {
+        STRING_MIN_CAPACITY
+    } else {
+        requested_cap
+    };
+    let ptr = heap::alloc(actual_cap, 1);
+    // Returns ptr in rax; we need to also set rdx=0 (len) and rcx=actual_cap
+    // We do this via inline asm since the C ABI doesn't support multi-value returns
+    unsafe {
+        core::arch::asm!(
+            "xor edx, edx",     // len = 0
+            in("rcx") actual_cap, // cap = actual_cap
+            options(nostack, nomem),
+        );
+    }
+    ptr as u64
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__with_capacity(requested_cap: u64) -> u64 {
+    let actual_cap = if requested_cap < STRING_MIN_CAPACITY {
+        STRING_MIN_CAPACITY
+    } else {
+        requested_cap
+    };
+    let ptr = heap::alloc(actual_cap, 1);
+    // Returns ptr in x0; we need to also set x1=0 (len) and x2=actual_cap
+    unsafe {
+        core::arch::asm!(
+            "mov x1, xzr",      // len = 0
+            in("x2") actual_cap, // cap = actual_cap
+            options(nostack, nomem),
+        );
+    }
+    ptr as u64
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__with_capacity(requested_cap: u64) -> u64 {
+    let actual_cap = if requested_cap < STRING_MIN_CAPACITY {
+        STRING_MIN_CAPACITY
+    } else {
+        requested_cap
+    };
+    let ptr = heap::alloc(actual_cap, 1);
+    // Returns ptr in x0; we need to also set x1=0 (len) and x2=actual_cap
+    unsafe {
+        core::arch::asm!(
+            "mov x1, xzr",      // len = 0
+            in("x2") actual_cap, // cap = actual_cap
+            options(nostack, nomem),
+        );
+    }
+    ptr as u64
+}
+
 // Re-export platform functions for tests
 #[cfg(all(test, target_arch = "x86_64", target_os = "linux"))]
 pub use x86_64_linux::{exit, write, write_all, write_stderr};

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -459,3 +459,84 @@ fn main() -> i32 {
 }
 """
 exit_code = 1
+
+# =============================================================================
+# Mutable String Construction (preview feature)
+# =============================================================================
+
+[[case]]
+name = "string_new_basic"
+spec = ["3.10:7"]
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let s = String::new();
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_new_equality_with_empty"
+spec = ["3.10:7", "3.7:9"]
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let s = String::new();
+    if s == "" { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "string_with_capacity_basic"
+spec = ["3.10:8"]
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let cap: u64 = 1024;
+    let s = String::with_capacity(cap);
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_with_capacity_zero"
+spec = ["3.10:8"]
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let cap: u64 = 0;
+    let s = String::with_capacity(cap);
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_with_capacity_equality_with_empty"
+spec = ["3.10:8", "3.7:9"]
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let cap: u64 = 64;
+    let s = String::with_capacity(cap);
+    if s == "" { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "string_new_is_empty"
+spec = ["3.10:7", "3.10:9"]
+preview = "mutable_strings"
+source = """
+fn main() -> i32 {
+    let cap: u64 = 1024;
+    let empty = String::new();
+    let prealloc = String::with_capacity(cap);
+    0
+}
+"""
+exit_code = 0


### PR DESCRIPTION
…n methods

Adds Phase 5 of mutable strings feature (ADR-0014):

- String::new() returns an empty String with no heap allocation
- String::with_capacity(cap: u64) pre-allocates capacity (min 16 bytes)

Implementation details:
- sema.rs: Handle String assoc fn calls, validate with_capacity arg type
- x86_64/aarch64 cfg_lower.rs: Handle String 3-slot returns and Drop
- Runtime: Naked functions for proper multi-value return ABI

Gated behind --preview mutable_strings flag.

Closes rue-0hef.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)