### PR TITLE
Replace panic with compile error for HM inference type mismatch

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -3184,9 +3184,24 @@ impl<'a> Sema<'a> {
                             inst.span,
                         ));
                     }
-                    other => {
-                        // HM should have resolved this to an array type
-                        panic!("ArrayInit should have array type from HM, got {:?}", other);
+                    None => {
+                        // HM didn't resolve the type - this is an internal error
+                        return Err(CompileError::new(
+                            ErrorKind::InternalError(
+                                "array type inference failed: type not resolved".to_string(),
+                            ),
+                            inst.span,
+                        ));
+                    }
+                    Some(other) => {
+                        // HM resolved to an unexpected type - this is an internal error
+                        return Err(CompileError::new(
+                            ErrorKind::InternalError(format!(
+                                "array type inference failed: expected array type, got {:?}",
+                                other
+                            )),
+                            inst.span,
+                        ));
                     }
                 };
 


### PR DESCRIPTION
When ArrayInit receives an unexpected type from HM inference (not an array type), the compiler now returns an InternalError instead of panicking. This provides a better user experience and allows the compiler to report the error gracefully.

Fixes rue-hv9g

🤖 Generated with [Claude Code](https://claude.com/claude-code)