### PR TITLE
rue-cfg: fix inconsistent caching in lower_inst

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -576,7 +576,7 @@ impl<'a> CfgBuilder<'a> {
 
             AirInstData::Load { slot } => {
                 let value = self.emit(CfgInstData::Load { slot: *slot }, ty, span);
-                // Don't cache loads - they need to be re-evaluated
+                self.cache(air_ref, value);
                 ExprResult {
                     value: Some(value),
                     continuation: Continuation::Continues,
@@ -661,6 +661,7 @@ impl<'a> CfgBuilder<'a> {
                     ty,
                     span,
                 );
+                self.cache(air_ref, value);
                 ExprResult {
                     value: Some(value),
                     continuation: Continuation::Continues,
@@ -720,6 +721,7 @@ impl<'a> CfgBuilder<'a> {
                     ty,
                     span,
                 );
+                self.cache(air_ref, value);
                 ExprResult {
                     value: Some(value),
                     continuation: Continuation::Continues,
@@ -1389,6 +1391,7 @@ impl<'a> CfgBuilder<'a> {
                     ty,
                     span,
                 );
+                self.cache(air_ref, value);
                 ExprResult {
                     value: Some(value),
                     continuation: Continuation::Continues,


### PR DESCRIPTION
Added missing cache() calls for value-producing instructions that weren't caching their results:
- Load: Now caches after emitting CfgInstData::Load
- FieldGet: Now caches after emitting CfgInstData::FieldGet
- IndexGet: Now caches after emitting CfgInstData::IndexGet
- Intrinsic: Now caches after emitting the intrinsic value

In SSA-style IR, when the same AirRef is used as an operand in multiple instructions, caching ensures we don't emit duplicate CFG instructions. The previous comment on Load ("Don't cache loads - they need to be re-evaluated") was incorrect because each Load AIR instruction represents reading at a specific program point.

Closes: rue-o8wx

🤖 Generated with [Claude Code](https://claude.com/claude-code)