### PR TITLE
feat: implement String query methods (len, capacity, is_empty)

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -3541,12 +3541,40 @@ impl<'a> Sema<'a> {
                 method,
                 args,
             } => {
+                // For String borrow methods, we need to extract the root variable before
+                // analyzing the receiver so we can "unmove" it afterwards. String query
+                // methods (len, capacity, is_empty) use `borrow self` semantics - they
+                // don't consume the String.
+                let receiver_var = self.extract_root_variable(*receiver);
+
                 // Analyze the receiver expression
                 let receiver_result = self.analyze_inst(air, *receiver, ctx)?;
                 let receiver_type = receiver_result.ty;
 
                 // Get the method name as a string for error messages
                 let method_name_str = self.interner.get(*method).to_string();
+
+                // Handle String methods specially
+                if receiver_type == Type::String {
+                    // String query methods (len, capacity, is_empty) use borrow semantics.
+                    // The receiver was marked as moved during analysis, but we need to
+                    // "unmove" it since it's actually being borrowed, not consumed.
+                    let is_borrow_method =
+                        matches!(method_name_str.as_str(), "len" | "capacity" | "is_empty");
+                    if is_borrow_method {
+                        if let Some(var_symbol) = receiver_var {
+                            ctx.moved_vars.remove(&var_symbol);
+                        }
+                    }
+                    return self.analyze_string_method(
+                        air,
+                        ctx,
+                        &method_name_str,
+                        receiver_result,
+                        args,
+                        inst.span,
+                    );
+                }
 
                 // Check that receiver is a struct type
                 let struct_id = match receiver_type {
@@ -4248,6 +4276,123 @@ impl<'a> Sema<'a> {
                     ErrorKind::UndefinedAssocFn {
                         type_name: "String".to_string(),
                         function_name: function_name.to_string(),
+                    },
+                    span,
+                ))
+            }
+        }
+    }
+
+    /// Analyze a String method call (len, capacity, is_empty, etc.).
+    ///
+    /// These are built-in methods for the String type that query the string's state.
+    /// Query methods use `borrow self` semantics - they don't consume the string.
+    fn analyze_string_method(
+        &mut self,
+        air: &mut Air,
+        _ctx: &mut AnalysisContext,
+        method_name: &str,
+        receiver: AnalysisResult,
+        args: &[RirCallArg],
+        span: Span,
+    ) -> CompileResult<AnalysisResult> {
+        match method_name {
+            "len" => {
+                // fn len(borrow self) -> u64
+                // Returns the length of the string in bytes
+                if !args.is_empty() {
+                    return Err(CompileError::new(
+                        ErrorKind::WrongArgumentCount {
+                            expected: 0,
+                            found: args.len(),
+                        },
+                        span,
+                    ));
+                }
+
+                // Generate a call to String__len (runtime function)
+                // We pass the String by value (its 3 fields) but don't consume it semantically.
+                // The caller still owns the String after this call.
+                // Using Normal mode instead of Borrow because String's 3 fields should be
+                // passed directly, not by reference.
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::Call {
+                        name: "String__len".to_string(),
+                        args: vec![AirCallArg {
+                            value: receiver.air_ref,
+                            mode: AirArgMode::Normal,
+                        }],
+                    },
+                    ty: Type::U64,
+                    span,
+                });
+                Ok(AnalysisResult::new(air_ref, Type::U64))
+            }
+
+            "capacity" => {
+                // fn capacity(borrow self) -> u64
+                // Returns the allocated capacity (0 for string literals)
+                if !args.is_empty() {
+                    return Err(CompileError::new(
+                        ErrorKind::WrongArgumentCount {
+                            expected: 0,
+                            found: args.len(),
+                        },
+                        span,
+                    ));
+                }
+
+                // Generate a call to String__capacity (runtime function)
+                // Same pattern as len() - pass by value, don't consume.
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::Call {
+                        name: "String__capacity".to_string(),
+                        args: vec![AirCallArg {
+                            value: receiver.air_ref,
+                            mode: AirArgMode::Normal,
+                        }],
+                    },
+                    ty: Type::U64,
+                    span,
+                });
+                Ok(AnalysisResult::new(air_ref, Type::U64))
+            }
+
+            "is_empty" => {
+                // fn is_empty(borrow self) -> bool
+                // Returns true if the string length is zero
+                if !args.is_empty() {
+                    return Err(CompileError::new(
+                        ErrorKind::WrongArgumentCount {
+                            expected: 0,
+                            found: args.len(),
+                        },
+                        span,
+                    ));
+                }
+
+                // Generate a call to String__is_empty (runtime function)
+                // Same pattern as len() - pass by value, don't consume.
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::Call {
+                        name: "String__is_empty".to_string(),
+                        args: vec![AirCallArg {
+                            value: receiver.air_ref,
+                            mode: AirArgMode::Normal,
+                        }],
+                    },
+                    ty: Type::Bool,
+                    span,
+                });
+                Ok(AnalysisResult::new(air_ref, Type::Bool))
+            }
+
+            _ => {
+                // Unknown method for String
+                Err(CompileError::new(
+                    ErrorKind::UndefinedMethod {
+                        type_name: "String".to_string(),
+                        method_name: method_name.to_string(),
                     },
                     span,
                 ))

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1432,6 +1432,56 @@ impl<'a> CfgLower<'a> {
                                 }
                             }
                         }
+                        Type::String => {
+                            // String has 3 slots: ptr, len, cap
+                            // Handle like a struct with 3 fields
+                            let arg_data = &self.cfg.get_inst(arg_value).data;
+                            match arg_data {
+                                CfgInstData::Load { slot } => {
+                                    // Load all 3 String fields from stack
+                                    for field_idx in 0..3u32 {
+                                        let field_vreg = self.mir.alloc_vreg();
+                                        let field_slot = slot + field_idx;
+                                        let offset = self.local_offset(field_slot);
+                                        self.mir.push(Aarch64Inst::Ldr {
+                                            dst: Operand::Virtual(field_vreg),
+                                            base: Reg::Fp,
+                                            offset,
+                                        });
+                                        flattened_vregs.push(field_vreg);
+                                    }
+                                }
+                                CfgInstData::Param { index } => {
+                                    // Load all 3 String fields from param slots
+                                    for field_idx in 0..3u32 {
+                                        let field_vreg = self.mir.alloc_vreg();
+                                        let param_slot = self.num_locals + index + field_idx;
+                                        let offset = self.local_offset(param_slot);
+                                        self.mir.push(Aarch64Inst::Ldr {
+                                            dst: Operand::Virtual(field_vreg),
+                                            base: Reg::Fp,
+                                            offset,
+                                        });
+                                        flattened_vregs.push(field_vreg);
+                                    }
+                                }
+                                CfgInstData::StringConst(_) | CfgInstData::Call { .. } => {
+                                    // String from a call result or string const - use vregs
+                                    if let Some(field_vregs) =
+                                        self.struct_slot_vregs.get(&arg_value)
+                                    {
+                                        flattened_vregs.extend(field_vregs.iter().copied());
+                                    } else {
+                                        // Single vreg case (shouldn't happen for String)
+                                        flattened_vregs.push(self.get_vreg(arg_value));
+                                    }
+                                }
+                                _ => {
+                                    // Fallback - should be rare for String
+                                    flattened_vregs.push(self.get_vreg(arg_value));
+                                }
+                            }
+                        }
                         _ => {
                             flattened_vregs.push(self.get_vreg(arg_value));
                         }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1573,6 +1573,56 @@ impl<'a> CfgLower<'a> {
                                 }
                             }
                         }
+                        Type::String => {
+                            // String has 3 slots: ptr, len, cap
+                            // Handle like a struct with 3 fields
+                            let arg_data = &self.cfg.get_inst(arg_value).data;
+                            match arg_data {
+                                CfgInstData::Load { slot } => {
+                                    // Load all 3 String fields from stack
+                                    for field_idx in 0..3u32 {
+                                        let field_vreg = self.mir.alloc_vreg();
+                                        let field_slot = slot + field_idx;
+                                        let offset = self.local_offset(field_slot);
+                                        self.mir.push(X86Inst::MovRM {
+                                            dst: Operand::Virtual(field_vreg),
+                                            base: Reg::Rbp,
+                                            offset,
+                                        });
+                                        flattened_vregs.push(field_vreg);
+                                    }
+                                }
+                                CfgInstData::Param { index } => {
+                                    // Load all 3 String fields from param slots
+                                    for field_idx in 0..3u32 {
+                                        let field_vreg = self.mir.alloc_vreg();
+                                        let param_slot = self.num_locals + index + field_idx;
+                                        let offset = self.local_offset(param_slot);
+                                        self.mir.push(X86Inst::MovRM {
+                                            dst: Operand::Virtual(field_vreg),
+                                            base: Reg::Rbp,
+                                            offset,
+                                        });
+                                        flattened_vregs.push(field_vreg);
+                                    }
+                                }
+                                CfgInstData::StringConst(_) | CfgInstData::Call { .. } => {
+                                    // String from a call result or string const - use vregs
+                                    if let Some(field_vregs) =
+                                        self.struct_slot_vregs.get(&arg_value)
+                                    {
+                                        flattened_vregs.extend(field_vregs.iter().copied());
+                                    } else {
+                                        // Single vreg case (shouldn't happen for String)
+                                        flattened_vregs.push(self.get_vreg(arg_value));
+                                    }
+                                }
+                                _ => {
+                                    // Fallback - should be rare for String
+                                    flattened_vregs.push(self.get_vreg(arg_value));
+                                }
+                            }
+                        }
                         _ => {
                             flattened_vregs.push(self.get_vreg(arg_value));
                         }

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -1026,6 +1026,112 @@ pub extern "C" fn String__with_capacity(requested_cap: u64) -> u64 {
     ptr as u64
 }
 
+// =============================================================================
+// String Query Methods (Phase 6: len, capacity, is_empty)
+// =============================================================================
+//
+// These methods take a String (ptr, len, cap) and return a single value.
+// They use `borrow self` semantics - the String is not consumed.
+//
+// ABI: String is passed as 3 separate arguments (ptr, len, cap)
+// - x86-64: ptr in rdi, len in rsi, cap in rdx
+// - aarch64: ptr in x0, len in x1, cap in x2
+//
+// Return value is in rax (x86-64) or x0 (aarch64)
+
+/// Get the length of a String in bytes.
+///
+/// # Arguments
+/// * `_ptr` - Pointer to string data (unused, but part of ABI)
+/// * `len` - Length in bytes
+/// * `_cap` - Capacity (unused, but part of ABI)
+///
+/// # Returns
+/// The length in bytes (u64)
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__len(_ptr: *const u8, len: u64, _cap: u64) -> u64 {
+    len
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__len(_ptr: *const u8, len: u64, _cap: u64) -> u64 {
+    len
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__len(_ptr: *const u8, len: u64, _cap: u64) -> u64 {
+    len
+}
+
+/// Get the capacity of a String in bytes.
+///
+/// Returns 0 for string literals (pointing to rodata).
+/// Returns the allocated heap capacity for mutable strings.
+///
+/// # Arguments
+/// * `_ptr` - Pointer to string data (unused, but part of ABI)
+/// * `_len` - Length (unused, but part of ABI)
+/// * `cap` - Capacity in bytes
+///
+/// # Returns
+/// The capacity in bytes (u64)
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__capacity(_ptr: *const u8, _len: u64, cap: u64) -> u64 {
+    cap
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__capacity(_ptr: *const u8, _len: u64, cap: u64) -> u64 {
+    cap
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__capacity(_ptr: *const u8, _len: u64, cap: u64) -> u64 {
+    cap
+}
+
+/// Check if a String is empty.
+///
+/// # Arguments
+/// * `_ptr` - Pointer to string data (unused, but part of ABI)
+/// * `len` - Length in bytes
+/// * `_cap` - Capacity (unused, but part of ABI)
+///
+/// # Returns
+/// 1 (true) if len == 0, 0 (false) otherwise
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__is_empty(_ptr: *const u8, len: u64, _cap: u64) -> u8 {
+    if len == 0 { 1 } else { 0 }
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__is_empty(_ptr: *const u8, len: u64, _cap: u64) -> u8 {
+    if len == 0 { 1 } else { 0 }
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__is_empty(_ptr: *const u8, len: u64, _cap: u64) -> u8 {
+    if len == 0 { 1 } else { 0 }
+}
+
 // Re-export platform functions for tests
 #[cfg(all(test, target_arch = "x86_64", target_os = "linux"))]
 pub use x86_64_linux::{exit, write, write_all, write_stderr};


### PR DESCRIPTION
This completes Phase 6 of ADR-0014 (Mutable Strings).

Changes:
- Add String method dispatch in sema.rs for len(), capacity(), is_empty()
- Handle borrow semantics: query methods don't consume the String
- Add runtime functions for all 3 platforms (x86-64 Linux, aarch64 macOS/Linux)
- Add String type flattening in codegen for function call arguments

All methods take 'borrow self' and return:
- len() -> u64 (current byte length)
- capacity() -> u64 (allocated capacity, 0 for literals)
- is_empty() -> bool (true if length is 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)