### PR TITLE
feat: implement String mutation methods (push_str, push, clear, reserve)

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -271,6 +271,17 @@ pub struct Sema<'a> {
     methods: HashMap<(Symbol, Symbol), MethodInfo>,
 }
 
+/// Storage location for a String receiver in mutation methods.
+///
+/// This is used by `analyze_string_mutation_method` to store the updated
+/// String back to the original variable after calling the runtime function.
+enum StringReceiverStorage {
+    /// The receiver is a local variable with the given slot.
+    Local { slot: u32 },
+    /// The receiver is a parameter with the given ABI slot.
+    Param { abi_slot: u32 },
+}
+
 impl<'a> Sema<'a> {
     /// Create a new semantic analyzer.
     pub fn new(rir: &'a Rir, interner: &'a mut Interner) -> Self {
@@ -3547,12 +3558,26 @@ impl<'a> Sema<'a> {
                 // don't consume the String.
                 let receiver_var = self.extract_root_variable(*receiver);
 
+                // Get the method name as a string before analyzing receiver
+                let method_name_str = self.interner.get(*method).to_string();
+
+                // Check if this is a String mutation method that needs storage location
+                let is_string_mutation_method = matches!(
+                    method_name_str.as_str(),
+                    "push_str" | "push" | "clear" | "reserve"
+                );
+
+                // For String mutation methods, we need to get the storage location
+                // BEFORE analyzing the receiver (which may mark it as moved)
+                let receiver_storage = if is_string_mutation_method {
+                    self.get_string_receiver_storage(*receiver, ctx, inst.span)?
+                } else {
+                    None
+                };
+
                 // Analyze the receiver expression
                 let receiver_result = self.analyze_inst(air, *receiver, ctx)?;
                 let receiver_type = receiver_result.ty;
-
-                // Get the method name as a string for error messages
-                let method_name_str = self.interner.get(*method).to_string();
 
                 // Handle String methods specially
                 if receiver_type == Type::String {
@@ -3566,6 +3591,24 @@ impl<'a> Sema<'a> {
                             ctx.moved_vars.remove(&var_symbol);
                         }
                     }
+
+                    // String mutation methods need special handling
+                    if is_string_mutation_method {
+                        // Mutation methods use inout semantics - variable remains valid after
+                        if let Some(var_symbol) = receiver_var {
+                            ctx.moved_vars.remove(&var_symbol);
+                        }
+                        return self.analyze_string_mutation_method(
+                            air,
+                            ctx,
+                            &method_name_str,
+                            receiver_result,
+                            receiver_storage,
+                            args,
+                            inst.span,
+                        );
+                    }
+
                     return self.analyze_string_method(
                         air,
                         ctx,
@@ -4281,6 +4324,323 @@ impl<'a> Sema<'a> {
                 ))
             }
         }
+    }
+
+    /// Get the storage location for a String receiver in a mutation method call.
+    ///
+    /// For mutation methods like `push_str`, `push`, `clear`, `reserve`, we need
+    /// to know where to store the updated String after the runtime function returns.
+    ///
+    /// Returns `Some(storage)` if the receiver is a mutable local or inout parameter.
+    /// Returns an error if the receiver is:
+    /// - An immutable binding (`let` instead of `var`)
+    /// - A borrow parameter (can't mutate borrowed values)
+    /// - Not an lvalue (e.g., a function call result)
+    fn get_string_receiver_storage(
+        &self,
+        receiver_ref: InstRef,
+        ctx: &AnalysisContext,
+        span: Span,
+    ) -> CompileResult<Option<StringReceiverStorage>> {
+        let receiver_inst = self.rir.get(receiver_ref);
+
+        match &receiver_inst.data {
+            InstData::VarRef { name } => {
+                // Check if this is a parameter
+                if let Some(param_info) = ctx.params.get(name) {
+                    // Check parameter mode
+                    match param_info.mode {
+                        RirParamMode::Inout => {
+                            return Ok(Some(StringReceiverStorage::Param {
+                                abi_slot: param_info.abi_slot,
+                            }));
+                        }
+                        RirParamMode::Borrow => {
+                            let name_str = self.interner.get(*name);
+                            return Err(CompileError::new(
+                                ErrorKind::MutateBorrowedValue {
+                                    variable: name_str.to_string(),
+                                },
+                                span,
+                            ));
+                        }
+                        RirParamMode::Normal => {
+                            // Normal parameters can be mutated if declared as `var`
+                            // For now, we don't allow mutation of normal params
+                            let name_str = self.interner.get(*name);
+                            return Err(CompileError::new(
+                                ErrorKind::AssignToImmutable(name_str.to_string()),
+                                span,
+                            ));
+                        }
+                    }
+                }
+
+                // Check if it's a local variable
+                if let Some(local) = ctx.locals.get(name) {
+                    if !local.is_mut {
+                        let name_str = self.interner.get(*name);
+                        return Err(CompileError::new(
+                            ErrorKind::AssignToImmutable(name_str.to_string()),
+                            span,
+                        ));
+                    }
+                    return Ok(Some(StringReceiverStorage::Local { slot: local.slot }));
+                }
+
+                // Variable not found
+                let name_str = self.interner.get(*name);
+                Err(CompileError::new(
+                    ErrorKind::UndefinedVariable(name_str.to_string()),
+                    span,
+                ))
+            }
+
+            // For other receiver types (field access, function calls, etc.),
+            // we don't support mutation for now
+            _ => Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span)),
+        }
+    }
+
+    /// Analyze a String mutation method call (push_str, push, clear, reserve).
+    ///
+    /// These methods use `inout self` semantics - they modify the string in place.
+    /// The runtime function returns an updated String (ptr, len, cap) which we
+    /// store back to the original variable.
+    fn analyze_string_mutation_method(
+        &mut self,
+        air: &mut Air,
+        ctx: &mut AnalysisContext,
+        method_name: &str,
+        receiver: AnalysisResult,
+        receiver_storage: Option<StringReceiverStorage>,
+        args: &[RirCallArg],
+        span: Span,
+    ) -> CompileResult<AnalysisResult> {
+        // Storage is required for mutation methods
+        let storage = receiver_storage
+            .ok_or_else(|| CompileError::new(ErrorKind::InvalidAssignmentTarget, span))?;
+
+        match method_name {
+            "push_str" => {
+                // fn push_str(inout self, other: String)
+                if args.len() != 1 {
+                    return Err(CompileError::new(
+                        ErrorKind::WrongArgumentCount {
+                            expected: 1,
+                            found: args.len(),
+                        },
+                        span,
+                    ));
+                }
+
+                // Analyze the other string argument
+                let other_result = self.analyze_inst(air, args[0].value, ctx)?;
+
+                // Type check: other must be String
+                if other_result.ty != Type::String && !other_result.ty.is_error() {
+                    return Err(CompileError::new(
+                        ErrorKind::TypeMismatch {
+                            expected: "String".to_string(),
+                            found: other_result.ty.name().to_string(),
+                        },
+                        span,
+                    ));
+                }
+
+                // Call String__push_str(self, other) -> String
+                let call_ref = air.add_inst(AirInst {
+                    data: AirInstData::Call {
+                        name: "String__push_str".to_string(),
+                        args: vec![
+                            AirCallArg {
+                                value: receiver.air_ref,
+                                mode: AirArgMode::Normal,
+                            },
+                            AirCallArg {
+                                value: other_result.air_ref,
+                                mode: AirArgMode::Normal,
+                            },
+                        ],
+                    },
+                    ty: Type::String,
+                    span,
+                });
+
+                // Store the result back to the receiver
+                self.store_string_result(air, call_ref, storage, span)
+            }
+
+            "push" => {
+                // fn push(inout self, byte: u8)
+                if args.len() != 1 {
+                    return Err(CompileError::new(
+                        ErrorKind::WrongArgumentCount {
+                            expected: 1,
+                            found: args.len(),
+                        },
+                        span,
+                    ));
+                }
+
+                // Analyze the byte argument
+                let byte_result = self.analyze_inst(air, args[0].value, ctx)?;
+
+                // Type check: byte must be u8
+                if byte_result.ty != Type::U8 && !byte_result.ty.is_error() {
+                    return Err(CompileError::new(
+                        ErrorKind::TypeMismatch {
+                            expected: "u8".to_string(),
+                            found: byte_result.ty.name().to_string(),
+                        },
+                        span,
+                    ));
+                }
+
+                // Call String__push(self, byte) -> String
+                let call_ref = air.add_inst(AirInst {
+                    data: AirInstData::Call {
+                        name: "String__push".to_string(),
+                        args: vec![
+                            AirCallArg {
+                                value: receiver.air_ref,
+                                mode: AirArgMode::Normal,
+                            },
+                            AirCallArg {
+                                value: byte_result.air_ref,
+                                mode: AirArgMode::Normal,
+                            },
+                        ],
+                    },
+                    ty: Type::String,
+                    span,
+                });
+
+                // Store the result back to the receiver
+                self.store_string_result(air, call_ref, storage, span)
+            }
+
+            "clear" => {
+                // fn clear(inout self)
+                if !args.is_empty() {
+                    return Err(CompileError::new(
+                        ErrorKind::WrongArgumentCount {
+                            expected: 0,
+                            found: args.len(),
+                        },
+                        span,
+                    ));
+                }
+
+                // Call String__clear(self) -> String
+                let call_ref = air.add_inst(AirInst {
+                    data: AirInstData::Call {
+                        name: "String__clear".to_string(),
+                        args: vec![AirCallArg {
+                            value: receiver.air_ref,
+                            mode: AirArgMode::Normal,
+                        }],
+                    },
+                    ty: Type::String,
+                    span,
+                });
+
+                // Store the result back to the receiver
+                self.store_string_result(air, call_ref, storage, span)
+            }
+
+            "reserve" => {
+                // fn reserve(inout self, additional: u64)
+                if args.len() != 1 {
+                    return Err(CompileError::new(
+                        ErrorKind::WrongArgumentCount {
+                            expected: 1,
+                            found: args.len(),
+                        },
+                        span,
+                    ));
+                }
+
+                // Analyze the additional argument
+                let additional_result = self.analyze_inst(air, args[0].value, ctx)?;
+
+                // Type check: additional must be u64
+                if additional_result.ty != Type::U64 && !additional_result.ty.is_error() {
+                    return Err(CompileError::new(
+                        ErrorKind::TypeMismatch {
+                            expected: "u64".to_string(),
+                            found: additional_result.ty.name().to_string(),
+                        },
+                        span,
+                    ));
+                }
+
+                // Call String__reserve(self, additional) -> String
+                let call_ref = air.add_inst(AirInst {
+                    data: AirInstData::Call {
+                        name: "String__reserve".to_string(),
+                        args: vec![
+                            AirCallArg {
+                                value: receiver.air_ref,
+                                mode: AirArgMode::Normal,
+                            },
+                            AirCallArg {
+                                value: additional_result.air_ref,
+                                mode: AirArgMode::Normal,
+                            },
+                        ],
+                    },
+                    ty: Type::String,
+                    span,
+                });
+
+                // Store the result back to the receiver
+                self.store_string_result(air, call_ref, storage, span)
+            }
+
+            _ => {
+                // This should never happen - caller should only call this for mutation methods
+                Err(CompileError::new(
+                    ErrorKind::UndefinedMethod {
+                        type_name: "String".to_string(),
+                        method_name: method_name.to_string(),
+                    },
+                    span,
+                ))
+            }
+        }
+    }
+
+    /// Store the result of a String mutation method back to the receiver's storage.
+    ///
+    /// Returns a Unit-typed result since mutation methods don't return a value.
+    fn store_string_result(
+        &self,
+        air: &mut Air,
+        call_ref: AirRef,
+        storage: StringReceiverStorage,
+        span: Span,
+    ) -> CompileResult<AnalysisResult> {
+        let store_ref = match storage {
+            StringReceiverStorage::Local { slot } => air.add_inst(AirInst {
+                data: AirInstData::Store {
+                    slot,
+                    value: call_ref,
+                },
+                ty: Type::Unit,
+                span,
+            }),
+            StringReceiverStorage::Param { abi_slot } => air.add_inst(AirInst {
+                data: AirInstData::ParamStore {
+                    param_slot: abi_slot,
+                    value: call_ref,
+                },
+                ty: Type::Unit,
+                span,
+            }),
+        };
+
+        Ok(AnalysisResult::new(store_ref, Type::Unit))
     }
 
     /// Analyze a String method call (len, capacity, is_empty, etc.).

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -1132,6 +1132,417 @@ pub extern "C" fn String__is_empty(_ptr: *const u8, len: u64, _cap: u64) -> u8 {
     if len == 0 { 1 } else { 0 }
 }
 
+// =============================================================================
+// String Mutation Methods (Phase 7: push_str, push, clear, reserve)
+// =============================================================================
+//
+// These methods take a String (ptr, len, cap) and additional arguments,
+// then return an updated String (ptr, len, cap) via multi-value return.
+// They use `inout self` semantics - the String is modified in place.
+//
+// ABI: String is passed as 3 separate arguments (ptr, len, cap)
+// - x86-64: ptr in rdi, len in rsi, cap in rdx; returns ptr in rax, len in rdx, cap in rcx
+// - aarch64: ptr in x0, len in x1, cap in x2; returns ptr in x0, len in x1, cap in x2
+//
+// Heap promotion: If cap == 0, the string is a literal pointing to rodata.
+// Any mutation first promotes to heap by allocating a new buffer and copying.
+
+/// Append another string's content to this string.
+///
+/// # Arguments
+///
+/// * `ptr` - Pointer to the string data
+/// * `len` - Current length in bytes
+/// * `cap` - Current capacity (0 for literals)
+/// * `other_ptr` - Pointer to the other string's data
+/// * `other_len` - Length of the other string
+/// * `other_cap` - Capacity of the other string (unused, but part of ABI)
+///
+/// # Returns
+///
+/// Updated String (ptr, len, cap) with the other string's content appended.
+///
+/// # Behavior
+///
+/// 1. If cap == 0 (literal), promotes to heap first
+/// 2. If len + other_len > cap, grows the buffer
+/// 3. Copies other_ptr[0..other_len] to ptr[len..]
+/// 4. Returns updated (ptr, new_len, cap)
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__push_str(
+    ptr: *mut u8,
+    len: u64,
+    cap: u64,
+    other_ptr: *const u8,
+    other_len: u64,
+    _other_cap: u64,
+) -> u64 {
+    let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, other_len);
+
+    // Copy the other string's content
+    if other_len > 0 && !other_ptr.is_null() {
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                other_ptr,
+                new_ptr.add(len as usize),
+                other_len as usize,
+            );
+        }
+    }
+
+    let new_len = len + other_len;
+
+    // Return ptr in rax, len in rdx, cap in rcx
+    unsafe {
+        core::arch::asm!(
+            "",
+            in("rdx") new_len,
+            in("rcx") new_cap,
+            options(nostack, nomem),
+        );
+    }
+    new_ptr as u64
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__push_str(
+    ptr: *mut u8,
+    len: u64,
+    cap: u64,
+    other_ptr: *const u8,
+    other_len: u64,
+    _other_cap: u64,
+) -> u64 {
+    let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, other_len);
+
+    // Copy the other string's content
+    if other_len > 0 && !other_ptr.is_null() {
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                other_ptr,
+                new_ptr.add(len as usize),
+                other_len as usize,
+            );
+        }
+    }
+
+    let new_len = len + other_len;
+
+    // Return ptr in x0, len in x1, cap in x2
+    unsafe {
+        core::arch::asm!(
+            "",
+            in("x1") new_len,
+            in("x2") new_cap,
+            options(nostack, nomem),
+        );
+    }
+    new_ptr as u64
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__push_str(
+    ptr: *mut u8,
+    len: u64,
+    cap: u64,
+    other_ptr: *const u8,
+    other_len: u64,
+    _other_cap: u64,
+) -> u64 {
+    let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, other_len);
+
+    // Copy the other string's content
+    if other_len > 0 && !other_ptr.is_null() {
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                other_ptr,
+                new_ptr.add(len as usize),
+                other_len as usize,
+            );
+        }
+    }
+
+    let new_len = len + other_len;
+
+    // Return ptr in x0, len in x1, cap in x2
+    unsafe {
+        core::arch::asm!(
+            "",
+            in("x1") new_len,
+            in("x2") new_cap,
+            options(nostack, nomem),
+        );
+    }
+    new_ptr as u64
+}
+
+/// Append a single byte to this string.
+///
+/// # Arguments
+///
+/// * `ptr` - Pointer to the string data
+/// * `len` - Current length in bytes
+/// * `cap` - Current capacity (0 for literals)
+/// * `byte` - The byte to append
+///
+/// # Returns
+///
+/// Updated String (ptr, len, cap) with the byte appended.
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__push(ptr: *mut u8, len: u64, cap: u64, byte: u8) -> u64 {
+    let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, 1);
+
+    // Write the byte
+    unsafe {
+        *new_ptr.add(len as usize) = byte;
+    }
+
+    let new_len = len + 1;
+
+    // Return ptr in rax, len in rdx, cap in rcx
+    unsafe {
+        core::arch::asm!(
+            "",
+            in("rdx") new_len,
+            in("rcx") new_cap,
+            options(nostack, nomem),
+        );
+    }
+    new_ptr as u64
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__push(ptr: *mut u8, len: u64, cap: u64, byte: u8) -> u64 {
+    let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, 1);
+
+    // Write the byte
+    unsafe {
+        *new_ptr.add(len as usize) = byte;
+    }
+
+    let new_len = len + 1;
+
+    // Return ptr in x0, len in x1, cap in x2
+    unsafe {
+        core::arch::asm!(
+            "",
+            in("x1") new_len,
+            in("x2") new_cap,
+            options(nostack, nomem),
+        );
+    }
+    new_ptr as u64
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__push(ptr: *mut u8, len: u64, cap: u64, byte: u8) -> u64 {
+    let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, 1);
+
+    // Write the byte
+    unsafe {
+        *new_ptr.add(len as usize) = byte;
+    }
+
+    let new_len = len + 1;
+
+    // Return ptr in x0, len in x1, cap in x2
+    unsafe {
+        core::arch::asm!(
+            "",
+            in("x1") new_len,
+            in("x2") new_cap,
+            options(nostack, nomem),
+        );
+    }
+    new_ptr as u64
+}
+
+/// Clear the string content, keeping capacity.
+///
+/// # Arguments
+///
+/// * `ptr` - Pointer to the string data
+/// * `len` - Current length in bytes (unused, but part of ABI)
+/// * `cap` - Current capacity
+///
+/// # Returns
+///
+/// Updated String (ptr, 0, cap) with length set to 0.
+///
+/// # Note
+///
+/// For literals (cap == 0), this is a no-op since the string is already empty
+/// or we can't modify rodata. The returned string will have len=0, cap=0.
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__clear(ptr: *mut u8, _len: u64, cap: u64) -> u64 {
+    // Return ptr in rax, len=0 in rdx, cap in rcx
+    unsafe {
+        core::arch::asm!(
+            "xor edx, edx", // len = 0
+            in("rcx") cap,
+            options(nostack, nomem),
+        );
+    }
+    ptr as u64
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__clear(ptr: *mut u8, _len: u64, cap: u64) -> u64 {
+    // Return ptr in x0, len=0 in x1, cap in x2
+    unsafe {
+        core::arch::asm!(
+            "mov x1, xzr", // len = 0
+            in("x2") cap,
+            options(nostack, nomem),
+        );
+    }
+    ptr as u64
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__clear(ptr: *mut u8, _len: u64, cap: u64) -> u64 {
+    // Return ptr in x0, len=0 in x1, cap in x2
+    unsafe {
+        core::arch::asm!(
+            "mov x1, xzr", // len = 0
+            in("x2") cap,
+            options(nostack, nomem),
+        );
+    }
+    ptr as u64
+}
+
+/// Reserve additional capacity in the string.
+///
+/// # Arguments
+///
+/// * `ptr` - Pointer to the string data
+/// * `len` - Current length in bytes
+/// * `cap` - Current capacity (0 for literals)
+/// * `additional` - Number of additional bytes to reserve
+///
+/// # Returns
+///
+/// Updated String (ptr, len, cap) with capacity >= len + additional.
+///
+/// # Behavior
+///
+/// If cap == 0 (literal), promotes to heap with capacity >= len + additional.
+/// If cap < len + additional, grows the buffer.
+/// Otherwise, returns unchanged.
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__reserve(ptr: *mut u8, len: u64, cap: u64, additional: u64) -> u64 {
+    let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, additional);
+
+    // Return ptr in rax, len in rdx, cap in rcx
+    unsafe {
+        core::arch::asm!(
+            "",
+            in("rdx") len,
+            in("rcx") new_cap,
+            options(nostack, nomem),
+        );
+    }
+    new_ptr as u64
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__reserve(ptr: *mut u8, len: u64, cap: u64, additional: u64) -> u64 {
+    let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, additional);
+
+    // Return ptr in x0, len in x1, cap in x2
+    unsafe {
+        core::arch::asm!(
+            "",
+            in("x1") len,
+            in("x2") new_cap,
+            options(nostack, nomem),
+        );
+    }
+    new_ptr as u64
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__reserve(ptr: *mut u8, len: u64, cap: u64, additional: u64) -> u64 {
+    let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, additional);
+
+    // Return ptr in x0, len in x1, cap in x2
+    unsafe {
+        core::arch::asm!(
+            "",
+            in("x1") len,
+            in("x2") new_cap,
+            options(nostack, nomem),
+        );
+    }
+    new_ptr as u64
+}
+
+/// Helper function to ensure a string has enough capacity for additional bytes.
+///
+/// Handles heap promotion (cap == 0) and growth.
+///
+/// # Arguments
+///
+/// * `ptr` - Current pointer
+/// * `len` - Current length
+/// * `cap` - Current capacity (0 for literals)
+/// * `additional` - Number of additional bytes needed
+///
+/// # Returns
+///
+/// (new_ptr, new_cap) with capacity >= len + additional.
+#[inline]
+fn string_ensure_capacity(ptr: *mut u8, len: u64, cap: u64, additional: u64) -> (*mut u8, u64) {
+    let required = len.saturating_add(additional);
+
+    if cap == 0 {
+        // Heap promotion: allocate new buffer and copy existing content
+        let new_cap = required.max(STRING_MIN_CAPACITY);
+        let new_ptr = heap::alloc(new_cap, 1);
+        if len > 0 && !ptr.is_null() {
+            unsafe {
+                core::ptr::copy_nonoverlapping(ptr as *const u8, new_ptr, len as usize);
+            }
+        }
+        (new_ptr, new_cap)
+    } else if required > cap {
+        // Need to grow: use the realloc function which implements growth strategy
+        let new_ptr = heap::realloc(ptr, cap, required, 1);
+        // Calculate actual new capacity (realloc uses 2x growth strategy)
+        let grown_cap = cap.saturating_mul(2);
+        let new_cap = required.max(grown_cap).max(STRING_MIN_CAPACITY);
+        (new_ptr, new_cap)
+    } else {
+        // Capacity is sufficient
+        (ptr, cap)
+    }
+}
+
 // Re-export platform functions for tests
 #[cfg(all(test, target_arch = "x86_64", target_os = "linux"))]
 pub use x86_64_linux::{exit, write, write_all, write_stderr};

--- a/crates/rue-spec/cases/types/mutable-strings.toml
+++ b/crates/rue-spec/cases/types/mutable-strings.toml
@@ -57,7 +57,7 @@ fn takes_string(s: String) -> i32 {
 }
 
 fn main() -> i32 {
-    var s = "hello";
+    let mut s = "hello";
     takes_string(s)
 }
 """
@@ -72,7 +72,7 @@ source = """
 fn takes_string(s: String) -> i32 { 0 }
 
 fn main() -> i32 {
-    var s = "hello";
+    let mut s = "hello";
     takes_string(s);
     takes_string(s)
 }
@@ -206,7 +206,7 @@ description = "push_str() appends string content"
 preview = "mutable_strings"
 source = """
 fn main() -> i32 {
-    var s = String::new();
+    let mut s = String::new();
     s.push_str("hello");
     if s.len() == 5 { 0 } else { 1 }
 }
@@ -220,7 +220,7 @@ description = "Multiple push_str() calls accumulate"
 preview = "mutable_strings"
 source = """
 fn main() -> i32 {
-    var s = String::new();
+    let mut s = String::new();
     s.push_str("hello");
     s.push_str(" world");
     if s.len() == 11 { 0 } else { 1 }
@@ -235,7 +235,7 @@ description = "push() appends a single byte"
 preview = "mutable_strings"
 source = """
 fn main() -> i32 {
-    var s = String::new();
+    let mut s = String::new();
     s.push_str("hello");
     s.push(33);  // '!'
     if s.len() == 6 { 0 } else { 1 }
@@ -250,7 +250,7 @@ description = "clear() removes content but retains capacity"
 preview = "mutable_strings"
 source = """
 fn main() -> i32 {
-    var s = String::with_capacity(100);
+    let mut s = String::with_capacity(100);
     s.push_str("hello");
     let cap_before = s.capacity();
     s.clear();
@@ -266,7 +266,7 @@ description = "reserve() ensures additional capacity"
 preview = "mutable_strings"
 source = """
 fn main() -> i32 {
-    var s = String::new();
+    let mut s = String::new();
     s.push_str("hi");
     s.reserve(100);
     if s.capacity() >= 102 { 0 } else { 1 }
@@ -275,9 +275,9 @@ fn main() -> i32 {
 exit_code = 0
 
 [[case]]
-name = "string_mutation_requires_var"
+name = "string_mutation_requires_let mut"
 spec = ["3.10:19"]
-description = "Mutation methods require var binding"
+description = "Mutation methods require let mut binding"
 preview = "mutable_strings"
 source = """
 fn main() -> i32 {
@@ -300,7 +300,7 @@ description = "Literal is promoted to heap on mutation"
 preview = "mutable_strings"
 source = """
 fn main() -> i32 {
-    var s = "hello";
+    let mut s = "hello";
     s.push_str("!");
     if s.capacity() > 0 && s.len() == 6 { 0 } else { 1 }
 }
@@ -331,7 +331,7 @@ description = "String grows capacity when needed"
 preview = "mutable_strings"
 source = """
 fn main() -> i32 {
-    var s = String::new();
+    let mut s = String::new();
     s.push_str("hello");
     let cap1 = s.capacity();
     // Append enough to exceed initial capacity
@@ -368,8 +368,8 @@ description = "Cloned strings are independent"
 preview = "mutable_strings"
 source = """
 fn main() -> i32 {
-    var a = "hello";
-    var b = a.clone();
+    let mut a = "hello";
+    let mut b = a.clone();
     b.push_str("!");
     // a should still be "hello", b should be "hello!"
     if a.len() == 5 && b.len() == 6 { 0 } else { 1 }
@@ -406,7 +406,7 @@ description = "Heap-allocated strings are freed when dropped"
 preview = "mutable_strings"
 source = """
 fn make_string() -> i32 {
-    var s = "hello";
+    let mut s = "hello";
     s.push_str(" world");
     // s goes out of scope, destructor should free heap
     42
@@ -453,7 +453,7 @@ description = "Strings are byte sequences"
 preview = "mutable_strings"
 source = """
 fn main() -> i32 {
-    var s = String::new();
+    let mut s = String::new();
     // Push some bytes
     s.push(72);   // 'H'
     s.push(105);  // 'i'
@@ -473,7 +473,7 @@ description = "Build a complete message through appending"
 preview = "mutable_strings"
 source = """
 fn main() -> i32 {
-    var msg = String::new();
+    let mut msg = String::new();
     msg.push_str("Hello");
     msg.push_str(", ");
     msg.push_str("world");
@@ -491,7 +491,7 @@ description = "Mutated string can be compared"
 preview = "mutable_strings"
 source = """
 fn main() -> i32 {
-    var s = String::new();
+    let mut s = String::new();
     s.push_str("hello");
     if s == "hello" { 0 } else { 1 }
 }


### PR DESCRIPTION
Phase 7 of mutable strings implementation (ADR-0014):

Runtime functions (rue-runtime/src/lib.rs):
- String__push_str: Append another string's content
- String__push: Append a single byte
- String__clear: Clear content, keep capacity
- String__reserve: Ensure additional capacity
- string_ensure_capacity: Helper for heap promotion and growth

All mutation methods handle:
- Heap promotion (cap==0 -> allocate and copy from rodata)
- Growth strategy (2x capacity when exceeding)
- Multi-value return (ptr, len, cap in registers)

Sema analysis (rue-air/src/sema.rs):
- StringReceiverStorage enum for tracking storage location
- get_string_receiver_storage: Extract storage info from receiver
- analyze_string_mutation_method: Handle inout self semantics
- store_string_result: Store updated String back to variable

The mutation methods use inout self semantics:
1. Check receiver is mutable (let mut, not let)
2. Call runtime function with String fields
3. Store returned String back to receiver's slot

Also fixed spec tests to use 'let mut' instead of 'var'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)