### PR TITLE
Consolidate spec tests using parameterized format (Phase 3)

### DIFF
--- a/crates/rue-spec/cases/expressions/arithmetic.toml
+++ b/crates/rue-spec/cases/expressions/arithmetic.toml
@@ -5,230 +5,108 @@ name = "Arithmetic Operators"
 description = "Arithmetic operators with standard precedence. Unary negation binds tightest, then multiplication/division/modulo, then addition/subtraction. Parentheses can override precedence."
 
 # =============================================================================
-# Basic Operations
+# Basic Operations (Parameterized)
 # =============================================================================
 
 [[case]]
-name = "addition_simple"
+name = "{op}_simple"
 spec = ["4.2:1"]
-source = "fn main() -> i32 { 1 + 2 }"
-exit_code = 3
-
-[[case]]
-name = "subtraction_simple"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 5 - 3 }"
-exit_code = 2
-
-[[case]]
-name = "multiplication_simple"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 3 * 4 }"
-exit_code = 12
-
-[[case]]
-name = "division_simple"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 10 / 3 }"
-exit_code = 3
-
-[[case]]
-name = "modulo_simple"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 10 % 3 }"
-exit_code = 1
+source = "fn main() -> i32 { {expr} }"
+params = [
+  { op = "addition", expr = "1 + 2", exit_code = 3 },
+  { op = "subtraction", expr = "5 - 3", exit_code = 2 },
+  { op = "multiplication", expr = "3 * 4", exit_code = 12 },
+  { op = "division", expr = "10 / 3", exit_code = 3 },
+  { op = "modulo", expr = "10 % 3", exit_code = 1 },
+]
 
 # =============================================================================
 # Operator Precedence
 # =============================================================================
 
 [[case]]
-name = "precedence_mul_over_add"
+name = "precedence_{variant}"
 spec = ["4.2:2"]
-source = "fn main() -> i32 { 1 + 2 * 3 }"
-exit_code = 7
-
-[[case]]
-name = "precedence_mul_over_sub"
-spec = ["4.2:2"]
-source = "fn main() -> i32 { 10 - 2 * 3 }"
-exit_code = 4
-
-[[case]]
-name = "precedence_div_over_add"
-spec = ["4.2:2"]
-source = "fn main() -> i32 { 1 + 6 / 2 }"
-exit_code = 4
-
-[[case]]
-name = "precedence_div_over_sub"
-spec = ["4.2:2"]
-source = "fn main() -> i32 { 10 - 6 / 2 }"
-exit_code = 7
-
-[[case]]
-name = "precedence_mod_over_add"
-spec = ["4.2:2"]
-source = "fn main() -> i32 { 1 + 7 % 3 }"
-exit_code = 2
-
-[[case]]
-name = "precedence_complex"
-spec = ["4.2:2"]
-source = "fn main() -> i32 { 2 + 3 * 4 - 10 / 2 }"
-exit_code = 9
+source = "fn main() -> i32 { {expr} }"
+params = [
+  { variant = "mul_over_add", expr = "1 + 2 * 3", exit_code = 7 },
+  { variant = "mul_over_sub", expr = "10 - 2 * 3", exit_code = 4 },
+  { variant = "div_over_add", expr = "1 + 6 / 2", exit_code = 4 },
+  { variant = "mod_over_add", expr = "1 + 7 % 3", exit_code = 2 },
+  { variant = "complex", expr = "2 + 3 * 4 - 10 / 2", exit_code = 9 },
+]
 
 # =============================================================================
 # Parentheses
 # =============================================================================
 
 [[case]]
-name = "parens_override_precedence"
+name = "parens_{variant}"
 spec = ["4.2:3"]
-source = "fn main() -> i32 { (1 + 2) * 3 }"
-exit_code = 9
-
-[[case]]
-name = "parens_nested"
-spec = ["4.2:3"]
-source = "fn main() -> i32 { ((1 + 2) * (3 + 4)) }"
-exit_code = 21
-
-[[case]]
-name = "parens_unnecessary"
-spec = ["4.2:3"]
-source = "fn main() -> i32 { (2) + (3) }"
-exit_code = 5
-
-[[case]]
-name = "parens_around_single"
-spec = ["4.2:3"]
-source = "fn main() -> i32 { (42) }"
-exit_code = 42
-
-[[case]]
-name = "parens_complex"
-spec = ["4.2:3"]
-source = "fn main() -> i32 { (10 - 2) * (3 + 1) / 4 }"
-exit_code = 8
+source = "fn main() -> i32 { {expr} }"
+params = [
+  { variant = "override_precedence", expr = "(1 + 2) * 3", exit_code = 9 },
+  { variant = "nested", expr = "((1 + 2) * (3 + 4))", exit_code = 21 },
+  { variant = "around_single", expr = "(42)", exit_code = 42 },
+  { variant = "complex", expr = "(10 - 2) * (3 + 1) / 4", exit_code = 8 },
+]
 
 # =============================================================================
 # Associativity (left-to-right)
 # =============================================================================
 
 [[case]]
-name = "left_associative_sub"
+name = "left_associative_{op}"
 spec = ["4.2:4"]
-source = "fn main() -> i32 { 10 - 3 - 2 }"
-exit_code = 5
-
-[[case]]
-name = "left_associative_div"
-spec = ["4.2:4"]
-source = "fn main() -> i32 { 24 / 4 / 2 }"
-exit_code = 3
-
-[[case]]
-name = "left_associative_mod"
-spec = ["4.2:4"]
-source = "fn main() -> i32 { 17 % 10 % 3 }"
-exit_code = 1
-
-[[case]]
-name = "left_associative_mixed"
-spec = ["4.2:4"]
-source = "fn main() -> i32 { 100 - 50 + 20 - 10 }"
-exit_code = 60
+source = "fn main() -> i32 { {expr} }"
+params = [
+  { op = "sub", expr = "10 - 3 - 2", exit_code = 5 },
+  { op = "div", expr = "24 / 4 / 2", exit_code = 3 },
+  { op = "mod", expr = "17 % 10 % 3", exit_code = 1 },
+  { op = "mixed", expr = "100 - 50 + 20 - 10", exit_code = 60 },
+]
 
 # =============================================================================
-# Edge Cases and Boundaries
+# Edge Cases
 # =============================================================================
 
 [[case]]
-name = "add_to_zero"
+name = "edge_{variant}"
 spec = ["4.2:1"]
-source = "fn main() -> i32 { 0 + 42 }"
-exit_code = 42
-
-[[case]]
-name = "multiply_by_zero"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 42 * 0 }"
-exit_code = 0
-
-[[case]]
-name = "multiply_by_one"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 42 * 1 }"
-exit_code = 42
-
-[[case]]
-name = "divide_by_one"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 42 / 1 }"
-exit_code = 42
-
-[[case]]
-name = "mod_by_larger"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 5 % 10 }"
-exit_code = 5
-
-[[case]]
-name = "mod_exact_multiple"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 10 % 5 }"
-exit_code = 0
-
-[[case]]
-name = "zero_divided"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 0 / 5 }"
-exit_code = 0
-
-[[case]]
-name = "zero_mod"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 0 % 5 }"
-exit_code = 0
+source = "fn main() -> i32 { {expr} }"
+params = [
+  { variant = "add_zero", expr = "0 + 42", exit_code = 42 },
+  { variant = "mul_zero", expr = "42 * 0", exit_code = 0 },
+  { variant = "mul_one", expr = "42 * 1", exit_code = 42 },
+  { variant = "div_one", expr = "42 / 1", exit_code = 42 },
+  { variant = "mod_larger", expr = "5 % 10", exit_code = 5 },
+  { variant = "mod_exact", expr = "10 % 5", exit_code = 0 },
+  { variant = "zero_div", expr = "0 / 5", exit_code = 0 },
+  { variant = "zero_mod", expr = "0 % 5", exit_code = 0 },
+]
 
 # =============================================================================
 # Exit Code Wrapping (result mod 256)
 # =============================================================================
 
 [[case]]
-name = "addition_wraps"
+name = "result_wraps"
 spec = ["4.2:1"]
 source = "fn main() -> i32 { 200 + 100 }"
 exit_code = 44
-
-[[case]]
-name = "multiplication_wraps"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 20 * 15 }"
-exit_code = 44
-
-[[case]]
-name = "large_computation"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 100 * 100 }"
-exit_code = 16
 
 # =============================================================================
 # Whitespace Flexibility
 # =============================================================================
 
 [[case]]
-name = "no_spaces"
+name = "whitespace_{variant}"
 spec = ["4.2:1"]
-source = "fn main() -> i32 { 1+2 }"
-exit_code = 3
-
-[[case]]
-name = "extra_spaces"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 1  +  2 }"
-exit_code = 3
+source = "{source}"
+params = [
+  { variant = "no_spaces", source = "fn main() -> i32 { 1+2 }", exit_code = 3 },
+  { variant = "extra_spaces", source = "fn main() -> i32 { 1  +  2 }", exit_code = 3 },
+]
 
 [[case]]
 name = "multiline_expr"
@@ -242,32 +120,9 @@ fn main() -> i32 {
 """
 exit_code = 7
 
-[[case]]
-name = "newline_after_operator"
-spec = ["4.2:1"]
-source = """
-fn main() -> i32 {
-    10 -
-    3
-}
-"""
-exit_code = 7
-
 # =============================================================================
 # Chained Operations
 # =============================================================================
-
-[[case]]
-name = "chain_addition"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 1 + 2 + 3 + 4 + 5 }"
-exit_code = 15
-
-[[case]]
-name = "chain_multiplication"
-spec = ["4.2:1"]
-source = "fn main() -> i32 { 2 * 3 * 4 }"
-exit_code = 24
 
 [[case]]
 name = "chain_mixed"
@@ -280,28 +135,21 @@ exit_code = 21
 # =============================================================================
 
 [[case]]
-name = "negation_simple"
+name = "negation_{variant}"
 spec = ["4.2:5", "4.2:6"]
-source = "fn main() -> i32 { -1 }"
-exit_code = 255
-
-[[case]]
-name = "negation_larger"
-spec = ["4.2:5", "4.2:6"]
-source = "fn main() -> i32 { -42 }"
-exit_code = 214
-
-[[case]]
-name = "negation_zero"
-spec = ["4.2:5"]
-source = "fn main() -> i32 { -0 }"
-exit_code = 0
-
-[[case]]
-name = "negation_in_expression"
-spec = ["4.2:5"]
-source = "fn main() -> i32 { 10 + -3 }"
-exit_code = 7
+source = "fn main() -> i32 { {expr} }"
+params = [
+  { variant = "simple", expr = "-1", exit_code = 255 },
+  { variant = "larger", expr = "-42", exit_code = 214 },
+  { variant = "zero", expr = "-0", exit_code = 0 },
+  { variant = "in_expr", expr = "10 + -3", exit_code = 7 },
+  { variant = "of_expr", expr = "-(1 + 2)", exit_code = 253 },
+  { variant = "double", expr = "--5", exit_code = 5 },
+  { variant = "triple", expr = "---5", exit_code = 251 },
+  { variant = "with_parens", expr = "(-10) + 15", exit_code = 5 },
+  { variant = "subtract_neg", expr = "10 - -5", exit_code = 15, spec_extra = ["4.2:1"] },
+  { variant = "mul_negatives", expr = "-3 * -4", exit_code = 12, spec_extra = ["4.2:1"] },
+]
 
 [[case]]
 name = "negation_binds_tighter_than_mul"
@@ -310,51 +158,9 @@ source = "fn main() -> i32 { -2 * 3 }"
 exit_code = 250
 
 [[case]]
-name = "negation_of_expression"
-spec = ["4.2:5"]
-source = "fn main() -> i32 { -(1 + 2) }"
-exit_code = 253
-
-[[case]]
-name = "double_negation"
-spec = ["4.2:5"]
-source = "fn main() -> i32 { --5 }"
-exit_code = 5
-
-[[case]]
-name = "triple_negation"
-spec = ["4.2:5"]
-source = "fn main() -> i32 { ---5 }"
-exit_code = 251
-
-[[case]]
-name = "negation_with_parens"
-spec = ["4.2:5"]
-source = "fn main() -> i32 { (-10) + 15 }"
-exit_code = 5
-
-[[case]]
-name = "subtract_negative"
-spec = ["4.2:1", "4.2:5"]
-source = "fn main() -> i32 { 10 - -5 }"
-exit_code = 15
-
-[[case]]
-name = "multiply_negatives"
-spec = ["4.2:1", "4.2:5"]
-source = "fn main() -> i32 { -3 * -4 }"
-exit_code = 12
-
-[[case]]
 name = "divide_negative"
 spec = ["4.2:1", "4.2:5"]
 source = "fn main() -> i32 { -10 / 3 }"
-exit_code = 253
-
-[[case]]
-name = "negative_dividend"
-spec = ["4.2:1", "4.2:5"]
-source = "fn main() -> i32 { 10 / -3 }"
 exit_code = 253
 
 [[case]]
@@ -366,108 +172,65 @@ exit_code = 255
 # =============================================================================
 # Negated MIN Literals (Compile-Time Constant)
 # =============================================================================
-# These tests verify that negated MIN value literals are evaluated at compile
-# time, avoiding runtime overflow.
 
 [[case]]
-name = "negated_min_literal_i8"
+name = "negated_min_literal_{type}"
 spec = ["4.2:15"]
-description = "Negated i8::MIN literal is a compile-time constant"
+description = "Negated MIN literal is a compile-time constant"
 source = """
 fn main() -> i32 {
-    let x: i8 = -128;
+    let x: {type} = {value};
     if x < 0 { 1 } else { 0 }
 }
 """
 exit_code = 1
-
-[[case]]
-name = "negated_min_literal_i32"
-spec = ["4.2:15"]
-description = "Negated i32::MIN literal is a compile-time constant"
-source = """
-fn main() -> i32 {
-    let x: i32 = -2147483648;
-    if x < 0 { 1 } else { 0 }
-}
-"""
-exit_code = 1
+params = [
+  { type = "i8", value = "-128" },
+  { type = "i32", value = "-2147483648" },
+]
 
 # =============================================================================
 # Runtime Negation of MIN Value (Overflow)
 # =============================================================================
-# These tests verify that negating a non-literal MIN value at runtime
-# causes an overflow panic.
 
 [[case]]
-name = "runtime_negation_min_i32"
+name = "runtime_negation_min_{type}"
 spec = ["4.2:16"]
-description = "Negating i32::MIN at runtime causes overflow"
+description = "Negating MIN at runtime causes overflow"
 source = """
 fn main() -> i32 {
-    let x: i32 = -2147483648;
-    let y: i32 = -x;
-    y
+    let x: {type} = {value};
+    let y: {type} = -x;
+    {tail}
 }
 """
 runtime_error = "integer overflow"
-
-[[case]]
-name = "runtime_negation_min_i8"
-spec = ["4.2:16"]
-description = "Negating i8::MIN at runtime causes overflow"
-source = """
-fn main() -> i32 {
-    let x: i8 = -128;
-    let y: i8 = -x;
-    0
-}
-"""
-runtime_error = "integer overflow"
+params = [
+  { type = "i32", value = "-2147483648", tail = "y" },
+  { type = "i8", value = "-128", tail = "0" },
+]
 
 # =============================================================================
 # Unsigned Negation is an Error
 # =============================================================================
 
 [[case]]
-name = "negation_unsigned_error"
+name = "negation_unsigned_{type}_error"
 spec = ["4.2:14"]
-description = "Unary negation on unsigned types is a compile-time error"
 source = """
 fn main() -> i32 {
-    let x: u32 = 5;
-    let y: u32 = -x;
+    let x: {type} = 5;
+    let y: {type} = -x;
     0
 }
 """
 compile_fail = true
 error_contains = "cannot apply unary operator"
-
-[[case]]
-name = "negation_unsigned_u8_error"
-spec = ["4.2:14"]
-source = """
-fn main() -> i32 {
-    let x: u8 = 5;
-    let y: u8 = -x;
-    0
-}
-"""
-compile_fail = true
-error_contains = "cannot apply unary operator"
-
-[[case]]
-name = "negation_unsigned_u64_error"
-spec = ["4.2:14"]
-source = """
-fn main() -> i32 {
-    let x: u64 = 5;
-    let y: u64 = -x;
-    0
-}
-"""
-compile_fail = true
-error_contains = "cannot apply unary operator"
+params = [
+  { type = "u32" },
+  { type = "u8" },
+  { type = "u64" },
+]
 
 [[case]]
 name = "negation_unsigned_literal_error"
@@ -487,43 +250,24 @@ error_contains = "cannot apply unary operator"
 # =============================================================================
 
 [[case]]
-name = "division_by_zero"
+name = "division_by_zero_{variant}"
 spec = ["8.3:1", "4.2:11"]
-source = "fn main() -> i32 { 10 / 0 }"
+source = "fn main() -> i32 { {expr} }"
 runtime_error = "division by zero"
+params = [
+  { variant = "literal", expr = "10 / 0" },
+  { variant = "modulo", expr = "10 % 0" },
+  { variant = "computed", expr = "10 / (5 - 5)" },
+]
 
 [[case]]
-name = "mod_by_zero"
-spec = ["8.3:1", "4.2:11"]
-source = "fn main() -> i32 { 10 % 0 }"
-runtime_error = "division by zero"
-
-[[case]]
-name = "division_by_zero_computed"
-spec = ["8.3:1", "4.2:11"]
-source = "fn main() -> i32 { 10 / (5 - 5) }"
-runtime_error = "division by zero"
-
-[[case]]
-name = "overflow_add"
+name = "overflow_{op}"
 spec = ["8.1:1", "4.2:9"]
-source = "fn main() -> i32 { 2147483647 + 1 }"
+source = "fn main() -> i32 { {expr} }"
 runtime_error = "integer overflow"
-
-[[case]]
-name = "overflow_sub"
-spec = ["8.1:1", "4.2:9"]
-source = "fn main() -> i32 { -2147483648 - 1 }"
-runtime_error = "integer overflow"
-
-[[case]]
-name = "overflow_mul"
-spec = ["8.1:1", "4.2:9"]
-source = "fn main() -> i32 { 2147483647 * 2 }"
-runtime_error = "integer overflow"
-
-[[case]]
-name = "overflow_neg"
-spec = ["8.1:1", "4.2:9"]
-source = "fn main() -> i32 { --2147483648 }"
-runtime_error = "integer overflow"
+params = [
+  { op = "add", expr = "2147483647 + 1" },
+  { op = "sub", expr = "-2147483648 - 1" },
+  { op = "mul", expr = "2147483647 * 2" },
+  { op = "neg", expr = "--2147483648" },
+]

--- a/crates/rue-spec/cases/expressions/bitwise.toml
+++ b/crates/rue-spec/cases/expressions/bitwise.toml
@@ -9,169 +9,75 @@ description = "Bitwise operators (&, |, ^, ~, <<, >>) operate on integer values 
 # =============================================================================
 
 [[case]]
-name = "bitwise_and_basic"
+name = "bitwise_{op}_basic"
 spec = ["4.3a:1"]
 source = """
 fn main() -> i32 {
     let a: i32 = 12;  // 0b1100
     let b: i32 = 10;  // 0b1010
-    a & b             // 0b1000 = 8
+    a {oper} b
 }
 """
-exit_code = 8
+params = [
+  { op = "and", oper = "&", exit_code = 8 },
+  { op = "or", oper = "|", exit_code = 14 },
+  { op = "xor", oper = "^", exit_code = 6 },
+]
 
 [[case]]
-name = "bitwise_or_basic"
+name = "bitwise_{op}_identity"
 spec = ["4.3a:1"]
 source = """
 fn main() -> i32 {
-    let a: i32 = 12;  // 0b1100
-    let b: i32 = 10;  // 0b1010
-    a | b             // 0b1110 = 14
+    let a: i32 = {value};
+    a {oper}
 }
 """
-exit_code = 14
-
-[[case]]
-name = "bitwise_xor_basic"
-spec = ["4.3a:1"]
-source = """
-fn main() -> i32 {
-    let a: i32 = 12;  // 0b1100
-    let b: i32 = 10;  // 0b1010
-    a ^ b             // 0b0110 = 6
-}
-"""
-exit_code = 6
-
-[[case]]
-name = "bitwise_and_zero"
-spec = ["4.3a:1"]
-source = """
-fn main() -> i32 {
-    let a: i32 = 255;
-    a & 0
-}
-"""
-exit_code = 0
-
-[[case]]
-name = "bitwise_or_zero"
-spec = ["4.3a:1"]
-source = """
-fn main() -> i32 {
-    let a: i32 = 42;
-    a | 0
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "bitwise_xor_self"
-spec = ["4.3a:1"]
-source = """
-fn main() -> i32 {
-    let a: i32 = 42;
-    a ^ a
-}
-"""
-exit_code = 0
+params = [
+  { op = "and_zero", value = "255", oper = "& 0", exit_code = 0 },
+  { op = "or_zero", value = "42", oper = "| 0", exit_code = 42 },
+  { op = "xor_self", value = "42", oper = "^ a", exit_code = 0 },
+]
 
 # =============================================================================
 # Bitwise NOT
 # =============================================================================
 
 [[case]]
-name = "bitwise_not_zero"
+name = "bitwise_not_{variant}"
 spec = ["4.3a:3", "4.3a:4"]
 source = """
 fn main() -> i32 {
-    let a: i32 = 0;
-    ~a  // All bits set = -1 in two's complement
+    let a: i32 = {value};
+    {expr}
 }
 """
-exit_code = 255  # -1 as exit code wraps to 255
-
-[[case]]
-name = "bitwise_not_negative_one"
-spec = ["4.3a:3", "4.3a:4"]
-source = """
-fn main() -> i32 {
-    let a: i32 = 0 - 1;  // -1
-    ~a  // ~(-1) = 0
-}
-"""
-exit_code = 0
-
-[[case]]
-name = "bitwise_double_not"
-spec = ["4.3a:3", "4.3a:4"]
-source = """
-fn main() -> i32 {
-    let a: i32 = 42;
-    ~~a
-}
-"""
-exit_code = 42
+params = [
+  { variant = "zero", value = "0", expr = "~a", exit_code = 255 },
+  { variant = "negative_one", value = "0 - 1", expr = "~a", exit_code = 0 },
+  { variant = "double", value = "42", expr = "~~a", exit_code = 42 },
+]
 
 # =============================================================================
 # Shift Operators
 # =============================================================================
 
 [[case]]
-name = "shift_left_basic"
-spec = ["4.3a:6", "4.3a:7"]
+name = "shift_{variant}"
+spec = ["4.3a:6"]
 source = """
 fn main() -> i32 {
-    let x: i32 = 1;
-    x << 4  // 16
+    let x: i32 = {value};
+    x {oper}
 }
 """
-exit_code = 16
-
-[[case]]
-name = "shift_right_basic"
-spec = ["4.3a:6", "4.3a:8"]
-source = """
-fn main() -> i32 {
-    let x: i32 = 16;
-    x >> 2  // 4
-}
-"""
-exit_code = 4
-
-[[case]]
-name = "shift_left_zero"
-spec = ["4.3a:6", "4.3a:7"]
-source = """
-fn main() -> i32 {
-    let x: i32 = 42;
-    x << 0
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "shift_right_zero"
-spec = ["4.3a:6", "4.3a:8"]
-source = """
-fn main() -> i32 {
-    let x: i32 = 42;
-    x >> 0
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "shift_left_multiple"
-spec = ["4.3a:6", "4.3a:7"]
-source = """
-fn main() -> i32 {
-    let x: i32 = 3;
-    x << 3  // 24
-}
-"""
-exit_code = 24
+params = [
+  { variant = "left_basic", value = "1", oper = "<< 4", exit_code = 16, spec_extra = ["4.3a:7"] },
+  { variant = "right_basic", value = "16", oper = ">> 2", exit_code = 4, spec_extra = ["4.3a:8"] },
+  { variant = "left_zero", value = "42", oper = "<< 0", exit_code = 42, spec_extra = ["4.3a:7"] },
+  { variant = "right_zero", value = "42", oper = ">> 0", exit_code = 42, spec_extra = ["4.3a:8"] },
+  { variant = "left_multiple", value = "3", oper = "<< 3", exit_code = 24, spec_extra = ["4.3a:7"] },
+]
 
 [[case]]
 name = "shift_left_right_identity"
@@ -213,34 +119,14 @@ exit_code = 2
 # =============================================================================
 
 [[case]]
-name = "precedence_and_or"
+name = "precedence_{variant}"
 spec = ["4.3a:12", "4.3a:13"]
-source = """
-fn main() -> i32 {
-    1 | 2 & 3  // = 1 | (2 & 3) = 1 | 2 = 3
-}
-"""
-exit_code = 3
-
-[[case]]
-name = "precedence_xor_and"
-spec = ["4.3a:12", "4.3a:13"]
-source = """
-fn main() -> i32 {
-    1 ^ 3 & 2  // = 1 ^ (3 & 2) = 1 ^ 2 = 3
-}
-"""
-exit_code = 3
-
-[[case]]
-name = "precedence_or_xor"
-spec = ["4.3a:12", "4.3a:13"]
-source = """
-fn main() -> i32 {
-    1 | 2 ^ 3  // = 1 | (2 ^ 3) = 1 | 1 = 1
-}
-"""
-exit_code = 1
+source = "fn main() -> i32 { {expr} }"
+params = [
+  { variant = "and_or", expr = "1 | 2 & 3", exit_code = 3 },
+  { variant = "xor_and", expr = "1 ^ 3 & 2", exit_code = 3 },
+  { variant = "or_xor", expr = "1 | 2 ^ 3", exit_code = 1 },
+]
 
 [[case]]
 name = "precedence_shift_and"
@@ -268,165 +154,66 @@ exit_code = 3
 # =============================================================================
 
 [[case]]
-name = "associativity_shift_left"
+name = "associativity_{op}"
 spec = ["4.3a:16"]
-source = """
-fn main() -> i32 {
-    let x: i32 = 1 << 2 << 1;  // = (1 << 2) << 1 = 4 << 1 = 8
-    x
-}
-"""
-exit_code = 8
-
-[[case]]
-name = "associativity_and"
-spec = ["4.3a:16"]
-source = """
-fn main() -> i32 {
-    15 & 7 & 3  // = (15 & 7) & 3 = 7 & 3 = 3
-}
-"""
-exit_code = 3
-
-[[case]]
-name = "associativity_or"
-spec = ["4.3a:16"]
-source = """
-fn main() -> i32 {
-    1 | 2 | 4  // = (1 | 2) | 4 = 3 | 4 = 7
-}
-"""
-exit_code = 7
-
-[[case]]
-name = "associativity_xor"
-spec = ["4.3a:16"]
-source = """
-fn main() -> i32 {
-    7 ^ 3 ^ 1  // = (7 ^ 3) ^ 1 = 4 ^ 1 = 5
-}
-"""
-exit_code = 5
+source = "fn main() -> i32 { {expr} }"
+params = [
+  { op = "shift_left", expr = "let x: i32 = 1 << 2 << 1; x", exit_code = 8 },
+  { op = "and", expr = "15 & 7 & 3", exit_code = 3 },
+  { op = "or", expr = "1 | 2 | 4", exit_code = 7 },
+  { op = "xor", expr = "7 ^ 3 ^ 1", exit_code = 5 },
+]
 
 # =============================================================================
 # Type Checking (Integer Types)
 # =============================================================================
 
 [[case]]
-name = "bitwise_i32"
+name = "bitwise_{type}"
 spec = ["4.3a:18"]
-source = """
-fn main() -> i32 {
-    let a: i32 = 5;
-    let b: i32 = 3;
-    a & b
-}
-"""
-exit_code = 1
-
-[[case]]
-name = "bitwise_i8"
-spec = ["4.3a:18"]
-source = """
-fn main() -> i32 {
-    let a: i8 = 5;
-    let b: i8 = 3;
-    let result: i8 = a | b;
-    // Need to use i32 return, so we recompute
-    5 | 3
-}
-"""
-exit_code = 7
-
-[[case]]
-name = "bitwise_u8"
-spec = ["4.3a:18"]
-source = """
-fn main() -> i32 {
-    let a: u8 = 5;
-    let b: u8 = 3;
-    let result: u8 = a ^ b;
-    // Need to use i32 return, so we recompute
-    5 ^ 3
-}
-"""
-exit_code = 6
+source = "{source}"
+params = [
+  { type = "i32", source = "fn main() -> i32 {\n    let a: i32 = 5;\n    let b: i32 = 3;\n    a & b\n}", exit_code = 1 },
+  { type = "i8", source = "fn main() -> i32 {\n    let a: i8 = 5;\n    let b: i8 = 3;\n    let result: i8 = a | b;\n    5 | 3\n}", exit_code = 7 },
+  { type = "u8", source = "fn main() -> i32 {\n    let a: u8 = 5;\n    let b: u8 = 3;\n    let result: u8 = a ^ b;\n    5 ^ 3\n}", exit_code = 6 },
+]
 
 # =============================================================================
 # Type Checking Errors
 # =============================================================================
 
 [[case]]
-name = "bitwise_and_bool_error"
+name = "bitwise_{op}_bool_error"
 spec = ["4.3a:19"]
-source = """
-fn main() -> i32 {
-    let a = true;
-    let b = false;
-    a & b;
-    0
-}
-"""
+source = "{source}"
 compile_fail = true
 error_contains = "type"
-
-[[case]]
-name = "bitwise_not_bool_error"
-spec = ["4.3a:19"]
-source = """
-fn main() -> i32 {
-    let a = true;
-    ~a;
-    0
-}
-"""
-compile_fail = true
-error_contains = "type"
-
-[[case]]
-name = "shift_bool_error"
-spec = ["4.3a:19"]
-source = """
-fn main() -> i32 {
-    let a = true;
-    let b: i32 = 1;
-    a << b;
-    0
-}
-"""
-compile_fail = true
-error_contains = "type"
+params = [
+  { op = "and", source = "fn main() -> i32 {\n    let a = true;\n    let b = false;\n    a & b;\n    0\n}" },
+  { op = "not", source = "fn main() -> i32 {\n    let a = true;\n    ~a;\n    0\n}" },
+  { op = "shift", source = "fn main() -> i32 {\n    let a = true;\n    let b: i32 = 1;\n    a << b;\n    0\n}" },
+]
 
 # =============================================================================
 # Large Shift Amounts (Modulo Bit Width)
 # =============================================================================
 
 [[case]]
-name = "shift_i64_large_amount"
+name = "shift_{type}_large_amount"
 spec = ["4.3a:10"]
 source = """
 fn main() -> i32 {
-    let x: i64 = 1;
-    // Shifting by 65 on i64 (64-bit) is equivalent to shifting by 1
-    let result: i64 = x << 65;
-    // result should be 2, return 1 if true
+    let x: {type} = 1;
+    // Shifting by 65 on 64-bit type is equivalent to shifting by 1
+    let result: {type} = x << 65;
     if result == 2 { 1 } else { 0 }
 }
 """
 exit_code = 1
-
-[[case]]
-name = "shift_u64_large_amount"
-spec = ["4.3a:10"]
-source = """
-fn main() -> i32 {
-    let x: u64 = 1;
-    // Shifting by 65 on u64 (64-bit) is equivalent to shifting by 1
-    let result: u64 = x << 65;
-    if result == 2 { 1 } else { 0 }
-}
-"""
-exit_code = 1
+params = [
+  { type = "i64" },
+  { type = "u64" },
+]
 
 [[case]]
 name = "shift_right_u8"
@@ -435,7 +222,6 @@ source = """
 fn main() -> i32 {
     let x: u8 = 128;
     let result: u8 = x >> 4;  // Logical shift: 8
-    // Return result directly by reconstructing as i32
     if result == 8 { 8 } else { 0 }
 }
 """
@@ -460,9 +246,7 @@ source = """
 fn main() -> i32 {
     let x: i32 = 0 - 8;  // -8
     // Arithmetic shift right by 2 should preserve sign
-    // -8 >> 2 = -2 (sign bit is preserved)
     let result: i32 = x >> 2;
-    // -2 as exit code wraps to 254
     result
 }
 """
@@ -473,10 +257,8 @@ name = "shift_right_unsigned_fills_zeros"
 spec = ["4.3a:8"]
 source = """
 fn main() -> i32 {
-    let x: u32 = 4294967288;  // 0xFFFFFFF8, high bits set
-    // Logical shift right by 4 should fill with zeros
+    let x: u32 = 4294967288;  // 0xFFFFFFF8
     let result: u32 = x >> 4;
-    // 0x0FFFFFFF = 268435455
     if result == 268435455 { 1 } else { 0 }
 }
 """
@@ -493,10 +275,7 @@ source = """
 fn main() -> i32 {
     let x: i32 = 16;
     let shift: i32 = 0 - 2;  // -2
-    // Negative shift amounts are treated as unsigned, so -2 interpreted as u32 is very large
-    // This will effectively shift by (-2 mod 32) which is 30
     let result: i32 = x << shift;
-    // 16 << 30 wraps, result should not be 16
     if result != 16 { 1 } else { 0 }
 }
 """
@@ -511,12 +290,9 @@ name = "bitwise_u32_and"
 spec = ["4.3a:1", "4.3a:18"]
 source = """
 fn main() -> i32 {
-    // 4278255360 = 0xFF00FF00
-    let a: u32 = 4278255360;
-    // 252645135 = 0x0F0F0F0F
-    let b: u32 = 252645135;
+    let a: u32 = 4278255360;  // 0xFF00FF00
+    let b: u32 = 252645135;   // 0x0F0F0F0F
     let result: u32 = a & b;
-    // 0x0F000F00 = 251662080
     if result == 251662080 { 1 } else { 0 }
 }
 """
@@ -540,10 +316,8 @@ name = "bitwise_not_u8"
 spec = ["4.3a:3", "4.3a:18"]
 source = """
 fn main() -> i32 {
-    let a: u8 = 5;    // 0b00000101
-    let b: u8 = ~a;   // 0b11111010 (inverted)
+    let a: u8 = 5;
     let c: u8 = ~~a;  // Should be back to original
-    // Double NOT should give original value
     if c == 5 { 1 } else { 0 }
 }
 """

--- a/crates/rue-spec/cases/expressions/comparison.toml
+++ b/crates/rue-spec/cases/expressions/comparison.toml
@@ -9,208 +9,113 @@ description = "Comparison operators compare values and produce bool results."
 # =============================================================================
 
 [[case]]
-name = "comparison_eq_true"
+name = "comparison_{op}"
 spec = ["4.3:1"]
 source = """
 fn main() -> i32 {
-    if 5 == 5 { 1 } else { 0 }
+    if {expr} { 1 } else { 0 }
 }
 """
-exit_code = 1
-
-[[case]]
-name = "comparison_eq_false"
-spec = ["4.3:1"]
-source = """
-fn main() -> i32 {
-    if 5 == 6 { 1 } else { 0 }
-}
-"""
-exit_code = 0
-
-[[case]]
-name = "comparison_ne_true"
-spec = ["4.3:1"]
-source = """
-fn main() -> i32 {
-    if 5 != 6 { 1 } else { 0 }
-}
-"""
-exit_code = 1
+params = [
+  { op = "eq_true", expr = "5 == 5", exit_code = 1 },
+  { op = "eq_false", expr = "5 == 6", exit_code = 0 },
+  { op = "ne_true", expr = "5 != 6", exit_code = 1 },
+]
 
 # =============================================================================
 # Equality Works on Integers and Booleans
 # =============================================================================
 
 [[case]]
-name = "equality_on_integers"
+name = "equality_{type}"
 spec = ["4.3:2"]
 source = """
 fn main() -> i32 {
-    if 42 == 42 { 1 } else { 0 }
+    if {expr} { 1 } else { 0 }
 }
 """
-exit_code = 1
-
-[[case]]
-name = "equality_on_booleans"
-spec = ["4.3:2"]
-source = """
-fn main() -> i32 {
-    if true == true { 1 } else { 0 }
-}
-"""
-exit_code = 1
-
-[[case]]
-name = "inequality_on_booleans"
-spec = ["4.3:2"]
-source = """
-fn main() -> i32 {
-    if true != false { 1 } else { 0 }
-}
-"""
-exit_code = 1
+params = [
+  { type = "integers", expr = "42 == 42", exit_code = 1 },
+  { type = "booleans_eq", expr = "true == true", exit_code = 1 },
+  { type = "booleans_ne", expr = "true != false", exit_code = 1 },
+]
 
 # =============================================================================
 # Ordering Works Only on Integers
 # =============================================================================
 
 [[case]]
-name = "ordering_lt_integers"
+name = "ordering_{op}_integers"
 spec = ["4.3:4"]
 source = """
 fn main() -> i32 {
-    if 5 < 10 { 1 } else { 0 }
+    if {expr} { 1 } else { 0 }
 }
 """
-exit_code = 1
-
-[[case]]
-name = "ordering_gt_integers"
-spec = ["4.3:4"]
-source = """
-fn main() -> i32 {
-    if 10 > 5 { 1 } else { 0 }
-}
-"""
-exit_code = 1
-
-[[case]]
-name = "ordering_le_integers"
-spec = ["4.3:4"]
-source = """
-fn main() -> i32 {
-    if 5 <= 5 { 1 } else { 0 }
-}
-"""
-exit_code = 1
-
-[[case]]
-name = "ordering_ge_integers"
-spec = ["4.3:4"]
-source = """
-fn main() -> i32 {
-    if 5 >= 5 { 1 } else { 0 }
-}
-"""
-exit_code = 1
+params = [
+  { op = "lt", expr = "5 < 10", exit_code = 1 },
+  { op = "gt", expr = "10 > 5", exit_code = 1 },
+  { op = "le", expr = "5 <= 5", exit_code = 1 },
+  { op = "ge", expr = "5 >= 5", exit_code = 1 },
+]
 
 # =============================================================================
 # Ordering on Booleans is Compile Error
 # =============================================================================
 
 [[case]]
-name = "ordering_lt_on_bool"
+name = "ordering_{op}_on_bool"
 spec = ["4.3:5"]
 source = """
 fn main() -> i32 {
-    if true < false { 1 } else { 0 }
+    if true {op} false { 1 } else { 0 }
 }
 """
 compile_fail = true
-
-[[case]]
-name = "ordering_gt_on_bool"
-spec = ["4.3:5"]
-source = """
-fn main() -> i32 {
-    if true > false { 1 } else { 0 }
-}
-"""
-compile_fail = true
-
-[[case]]
-name = "ordering_le_on_bool"
-spec = ["4.3:5"]
-source = """
-fn main() -> i32 {
-    if true <= false { 1 } else { 0 }
-}
-"""
-compile_fail = true
-
-[[case]]
-name = "ordering_ge_on_bool"
-spec = ["4.3:5"]
-source = """
-fn main() -> i32 {
-    if true >= false { 1 } else { 0 }
-}
-"""
-compile_fail = true
+params = [
+  { op = "<" },
+  { op = ">" },
+  { op = "<=" },
+  { op = ">=" },
+]
 
 # =============================================================================
 # Comparison Precedence Lower Than Arithmetic
 # =============================================================================
 
 [[case]]
-name = "precedence_comparison_after_arithmetic"
+name = "precedence_comparison_{variant}"
 spec = ["4.3:8"]
 source = """
 fn main() -> i32 {
-    if 2 + 3 == 5 { 1 } else { 0 }
+    if {expr} { 1 } else { 0 }
 }
 """
 exit_code = 1
-
-[[case]]
-name = "precedence_lt_after_add"
-spec = ["4.3:8"]
-source = """
-fn main() -> i32 {
-    if 2 + 3 < 10 - 3 { 1 } else { 0 }
-}
-"""
-exit_code = 1
+params = [
+  { variant = "after_add", expr = "2 + 3 == 5" },
+  { variant = "both_sides", expr = "2 + 3 < 10 - 3" },
+]
 
 # =============================================================================
 # Both Operands Must Have Same Type
 # =============================================================================
 
 [[case]]
-name = "type_mismatch_i32_i64"
+name = "type_mismatch_{types}"
 spec = ["4.3:10"]
 source = """
 fn main() -> i32 {
-    let x: i32 = 10;
-    let y: i64 = 10;
+    let x: {from} = 10;
+    let y: {to} = 10;
     if x == y { 1 } else { 0 }
 }
 """
 compile_fail = true
-
-[[case]]
-name = "type_mismatch_i32_u32"
-spec = ["4.3:10"]
-source = """
-fn main() -> i32 {
-    let x: i32 = 10;
-    let y: u32 = 10;
-    if x == y { 1 } else { 0 }
-}
-"""
-compile_fail = true
+params = [
+  { types = "i32_i64", from = "i32", to = "i64" },
+  { types = "i32_u32", from = "i32", to = "u32" },
+]
 
 # =============================================================================
 # Type Inference from One Operand
@@ -227,56 +132,28 @@ fn main() -> i32 {
 """
 exit_code = 1
 
-# NOTE: This test is commented out because the compiler doesn't yet support
-# type inference from the right operand of a comparison.
-# TODO: Implement bidirectional type inference and uncomment the test.
-# [[case]]
-# name = "infer_type_from_right_operand"
-# spec = ["4.3:11"]
-# source = """
-# fn main() -> i32 {
-#     let x: i64 = 100;
-#     if 100 == x { 1 } else { 0 }
-# }
-# """
-# exit_code = 1
+# NOTE: Right-operand inference not yet implemented, see integers.toml for tests
 
 # =============================================================================
 # Chained Comparisons Are Rejected
 # =============================================================================
 
 [[case]]
-name = "chained_lt_comparison_error"
+name = "chained_{variant}_error"
 spec = ["4.3:12"]
 source = """
 fn main() -> i32 {
-    if 1 < 2 < 3 { 1 } else { 0 }
+    if {expr} { 1 } else { 0 }
 }
 """
 compile_fail = true
 error_contains = "comparison operators cannot be chained"
-
-[[case]]
-name = "chained_eq_comparison_error"
-spec = ["4.3:12"]
-source = """
-fn main() -> i32 {
-    if 1 == 1 == true { 1 } else { 0 }
-}
-"""
-compile_fail = true
-error_contains = "comparison operators cannot be chained"
-
-[[case]]
-name = "chained_mixed_comparison_error"
-spec = ["4.3:12"]
-source = """
-fn main() -> i32 {
-    if 1 < 2 == true { 1 } else { 0 }
-}
-"""
-compile_fail = true
-error_contains = "comparison operators cannot be chained"
+params = [
+  { variant = "lt", expr = "1 < 2 < 3" },
+  { variant = "eq", expr = "1 == 1 == true" },
+  { variant = "mixed", expr = "1 < 2 == true" },
+  { variant = "parenthesized", expr = "(1 < 2) < 3" },
+]
 
 [[case]]
 name = "separate_comparisons_with_and"
@@ -288,40 +165,22 @@ fn main() -> i32 {
 """
 exit_code = 1
 
-[[case]]
-name = "parenthesized_comparison_in_chain"
-spec = ["4.3:12"]
-source = """
-fn main() -> i32 {
-    if (1 < 2) < 3 { 1 } else { 0 }
-}
-"""
-compile_fail = true
-error_contains = "comparison operators cannot be chained"
-
 # =============================================================================
 # Unit Type Equality
 # =============================================================================
 
 [[case]]
-name = "unit_equality"
+name = "unit_{op}"
 spec = ["4.3:2", "4.3:3a"]
 source = """
 fn main() -> i32 {
-    if () == () { 1 } else { 0 }
+    if {expr} { 1 } else { 0 }
 }
 """
-exit_code = 1
-
-[[case]]
-name = "unit_inequality"
-spec = ["4.3:2", "4.3:3a"]
-source = """
-fn main() -> i32 {
-    if () != () { 1 } else { 0 }
-}
-"""
-exit_code = 0
+params = [
+  { op = "equality", expr = "() == ()", exit_code = 1 },
+  { op = "inequality", expr = "() != ()", exit_code = 0 },
+]
 
 [[case]]
 name = "unit_ordering_disallowed"
@@ -338,46 +197,22 @@ compile_fail = true
 # =============================================================================
 
 [[case]]
-name = "struct_equality_same_values"
+name = "struct_equality_{variant}"
 spec = ["4.3:2", "4.3:3b"]
 source = """
 struct Point { x: i32, y: i32 }
 
 fn main() -> i32 {
-    let p1 = Point { x: 1, y: 2 };
-    let p2 = Point { x: 1, y: 2 };
-    if p1 == p2 { 1 } else { 0 }
+    let p1 = Point { x: {x1}, y: {y1} };
+    let p2 = Point { x: {x2}, y: {y2} };
+    if p1 {op} p2 { 1 } else { 0 }
 }
 """
-exit_code = 1
-
-[[case]]
-name = "struct_equality_different_values"
-spec = ["4.3:2", "4.3:3b"]
-source = """
-struct Point { x: i32, y: i32 }
-
-fn main() -> i32 {
-    let p1 = Point { x: 1, y: 2 };
-    let p2 = Point { x: 1, y: 3 };
-    if p1 == p2 { 1 } else { 0 }
-}
-"""
-exit_code = 0
-
-[[case]]
-name = "struct_inequality"
-spec = ["4.3:2", "4.3:3b"]
-source = """
-struct Point { x: i32, y: i32 }
-
-fn main() -> i32 {
-    let p1 = Point { x: 1, y: 2 };
-    let p2 = Point { x: 1, y: 3 };
-    if p1 != p2 { 1 } else { 0 }
-}
-"""
-exit_code = 1
+params = [
+  { variant = "same_values", x1 = "1", y1 = "2", x2 = "1", y2 = "2", op = "==", exit_code = 1 },
+  { variant = "different_values", x1 = "1", y1 = "2", x2 = "1", y2 = "3", op = "==", exit_code = 0 },
+  { variant = "inequality", x1 = "1", y1 = "2", x2 = "1", y2 = "3", op = "!=", exit_code = 1 },
+]
 
 [[case]]
 name = "struct_equality_single_field"

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -15,29 +15,14 @@ source = "fn main() -> i32 { 0 }"
 exit_code = 0
 
 [[case]]
-name = "main_returns_value"
+name = "main_basic_{variant}"
 spec = ["6.1:1"]
-source = "fn main() -> i32 { 123 }"
-exit_code = 123
-
-[[case]]
-name = "main_multiline"
-spec = ["6.1:1"]
-source = """
-fn main() -> i32 {
-    42
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "main_with_comment"
-spec = ["6.1:1"]
-source = """
-// Entry point
-fn main() -> i32 { 42 }
-"""
-exit_code = 42
+source = "{source}"
+params = [
+  { variant = "returns_value", source = "fn main() -> i32 { 123 }", exit_code = 123 },
+  { variant = "multiline", source = "fn main() -> i32 {\n    42\n}", exit_code = 42 },
+  { variant = "with_comment", source = "// Entry point\nfn main() -> i32 { 42 }", exit_code = 42 },
+]
 
 [[case]]
 name = "type_annotation_i32"
@@ -50,53 +35,28 @@ exit_code = 99
 # =============================================================================
 
 [[case]]
-name = "function_one_param"
+name = "function_{params}_params"
 spec = ["6.1:3"]
-source = """
-fn identity(x: i32) -> i32 { x }
-fn main() -> i32 { identity(42) }
-"""
-exit_code = 42
+source = "{source}"
+params = [
+  { params = "one", source = "fn identity(x: i32) -> i32 { x }\nfn main() -> i32 { identity(42) }", exit_code = 42 },
+  { params = "two", source = "fn add(x: i32, y: i32) -> i32 { x + y }\nfn main() -> i32 { add(40, 2) }", exit_code = 42 },
+  { params = "three", source = "fn sum3(a: i32, b: i32, c: i32) -> i32 { a + b + c }\nfn main() -> i32 { sum3(10, 20, 12) }", exit_code = 42 },
+]
 
 [[case]]
-name = "function_two_params"
-spec = ["6.1:3"]
-source = """
-fn add(x: i32, y: i32) -> i32 { x + y }
-fn main() -> i32 { add(40, 2) }
-"""
-exit_code = 42
-
-[[case]]
-name = "function_three_params"
-spec = ["6.1:3"]
-source = """
-fn sum3(a: i32, b: i32, c: i32) -> i32 { a + b + c }
-fn main() -> i32 { sum3(10, 20, 12) }
-"""
-exit_code = 42
-
-[[case]]
-name = "function_bool_param"
+name = "function_bool_param_{variant}"
 spec = ["6.1:3"]
 source = """
 fn choose(cond: bool, x: i32, y: i32) -> i32 {
     if cond { x } else { y }
 }
-fn main() -> i32 { choose(true, 42, 0) }
+fn main() -> i32 { choose({cond}, {a}, {b}) }
 """
-exit_code = 42
-
-[[case]]
-name = "function_bool_param_false"
-spec = ["6.1:3"]
-source = """
-fn choose(cond: bool, x: i32, y: i32) -> i32 {
-    if cond { x } else { y }
-}
-fn main() -> i32 { choose(false, 0, 42) }
-"""
-exit_code = 42
+params = [
+  { variant = "true", cond = "true", a = "42", b = "0", exit_code = 42 },
+  { variant = "false", cond = "false", a = "0", b = "42", exit_code = 42 },
+]
 
 [[case]]
 name = "function_returns_bool"
@@ -114,23 +74,13 @@ exit_code = 42
 # =============================================================================
 
 [[case]]
-name = "multiple_functions"
+name = "multiple_functions_{variant}"
 spec = ["6.1:4", "6.1:12"]
-source = """
-fn double(x: i32) -> i32 { x + x }
-fn main() -> i32 { double(21) }
-"""
-exit_code = 42
-
-[[case]]
-name = "function_calls_function"
-spec = ["6.1:4", "6.1:12"]
-source = """
-fn double(x: i32) -> i32 { x + x }
-fn quadruple(x: i32) -> i32 { double(double(x)) }
-fn main() -> i32 { quadruple(10) }
-"""
-exit_code = 40
+source = "{source}"
+params = [
+  { variant = "helper", source = "fn double(x: i32) -> i32 { x + x }\nfn main() -> i32 { double(21) }", exit_code = 42 },
+  { variant = "nested_calls", source = "fn double(x: i32) -> i32 { x + x }\nfn quadruple(x: i32) -> i32 { double(double(x)) }\nfn main() -> i32 { quadruple(10) }", exit_code = 40 },
+]
 
 [[case]]
 name = "multiple_helper_functions"
@@ -174,94 +124,30 @@ exit_code = 5
 # =============================================================================
 
 [[case]]
-name = "recursive_factorial"
+name = "recursive_{variant}"
 spec = ["6.1:5", "6.1:10"]
-source = """
-fn factorial(n: i32) -> i32 {
-    if n <= 1 { 1 }
-    else { n * factorial(n - 1) }
-}
-fn main() -> i32 { factorial(5) }
-"""
-exit_code = 120
-
-[[case]]
-name = "recursive_fibonacci"
-spec = ["6.1:5"]
-source = """
-fn fib(n: i32) -> i32 {
-    if n <= 1 { n }
-    else { fib(n - 1) + fib(n - 2) }
-}
-fn main() -> i32 { fib(10) }
-"""
-exit_code = 55
-
-[[case]]
-name = "recursive_countdown"
-spec = ["6.1:5"]
-source = """
-fn countdown(n: i32) -> i32 {
-    if n == 0 { 42 }
-    else { countdown(n - 1) }
-}
-fn main() -> i32 { countdown(100) }
-"""
-exit_code = 42
+source = "{source}"
+params = [
+  { variant = "factorial", source = "fn factorial(n: i32) -> i32 {\n    if n <= 1 { 1 }\n    else { n * factorial(n - 1) }\n}\nfn main() -> i32 { factorial(5) }", exit_code = 120 },
+  { variant = "fibonacci", source = "fn fib(n: i32) -> i32 {\n    if n <= 1 { n }\n    else { fib(n - 1) + fib(n - 2) }\n}\nfn main() -> i32 { fib(10) }", exit_code = 55 },
+  { variant = "countdown", source = "fn countdown(n: i32) -> i32 {\n    if n == 0 { 42 }\n    else { countdown(n - 1) }\n}\nfn main() -> i32 { countdown(100) }", exit_code = 42 },
+]
 
 # =============================================================================
 # Call expressions
 # =============================================================================
 
 [[case]]
-name = "call_with_expression_args"
+name = "call_{variant}"
 spec = ["4.10:1"]
-source = """
-fn add(x: i32, y: i32) -> i32 { x + y }
-fn main() -> i32 { add(20 + 10, 6 * 2) }
-"""
-exit_code = 42
-
-[[case]]
-name = "nested_call_expressions"
-spec = ["4.10:1"]
-source = """
-fn add(x: i32, y: i32) -> i32 { x + y }
-fn main() -> i32 { add(add(10, 20), add(5, 7)) }
-"""
-exit_code = 42
-
-[[case]]
-name = "call_in_arithmetic"
-spec = ["4.10:1"]
-source = """
-fn square(x: i32) -> i32 { x * x }
-fn main() -> i32 { square(5) + square(4) + 1 }
-"""
-exit_code = 42
-
-[[case]]
-name = "call_in_condition"
-spec = ["4.10:1"]
-source = """
-fn is_even(x: i32) -> bool { x % 2 == 0 }
-fn main() -> i32 {
-    if is_even(4) { 42 } else { 0 }
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "call_in_let_binding"
-spec = ["4.10:1"]
-source = """
-fn compute(x: i32) -> i32 { x * 2 + 1 }
-fn main() -> i32 {
-    let result = compute(20);
-    result + 1
-}
-"""
-exit_code = 42
+source = "{source}"
+params = [
+  { variant = "expression_args", source = "fn add(x: i32, y: i32) -> i32 { x + y }\nfn main() -> i32 { add(20 + 10, 6 * 2) }", exit_code = 42 },
+  { variant = "nested", source = "fn add(x: i32, y: i32) -> i32 { x + y }\nfn main() -> i32 { add(add(10, 20), add(5, 7)) }", exit_code = 42 },
+  { variant = "in_arithmetic", source = "fn square(x: i32) -> i32 { x * x }\nfn main() -> i32 { square(5) + square(4) + 1 }", exit_code = 42 },
+  { variant = "in_condition", source = "fn is_even(x: i32) -> bool { x % 2 == 0 }\nfn main() -> i32 {\n    if is_even(4) { 42 } else { 0 }\n}", exit_code = 42 },
+  { variant = "in_let", source = "fn compute(x: i32) -> i32 { x * 2 + 1 }\nfn main() -> i32 {\n    let result = compute(20);\n    result + 1\n}", exit_code = 42 },
+]
 
 # =============================================================================
 # Parameters and local variables interaction
@@ -310,22 +196,13 @@ exit_code = 50
 # =============================================================================
 
 [[case]]
-name = "zero_return"
+name = "edge_{variant}"
 spec = ["6.1:2"]
-source = """
-fn zero() -> i32 { 0 }
-fn main() -> i32 { zero() }
-"""
-exit_code = 0
-
-[[case]]
-name = "negative_return"
-spec = ["6.1:2"]
-source = """
-fn neg() -> i32 { -1 }
-fn main() -> i32 { neg() + 43 }
-"""
-exit_code = 42
+source = "{source}"
+params = [
+  { variant = "zero_return", source = "fn zero() -> i32 { 0 }\nfn main() -> i32 { zero() }", exit_code = 0 },
+  { variant = "negative_return", source = "fn neg() -> i32 { -1 }\nfn main() -> i32 { neg() + 43 }", exit_code = 42 },
+]
 
 [[case]]
 name = "pass_negative_arg"
@@ -339,52 +216,16 @@ fn main() -> i32 { abs(-42) }
 exit_code = 42
 
 [[case]]
-name = "function_with_six_params"
+name = "function_with_{num}_params"
 spec = ["6.1:3"]
-description = "Test with six parameters (all fit in registers on System V AMD64)"
-source = """
-fn sum6(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32) -> i32 {
-    a + b + c + d + e + f
-}
-fn main() -> i32 { sum6(1, 2, 3, 4, 5, 27) }
-"""
-exit_code = 42
-
-[[case]]
-name = "function_with_seven_params"
-spec = ["6.1:3"]
-description = "Test with seven parameters (7th goes on stack per System V AMD64)"
-source = """
-fn sum7(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32, g: i32) -> i32 {
-    a + b + c + d + e + f + g
-}
-fn main() -> i32 { sum7(1, 2, 3, 4, 5, 6, 21) }
-"""
-exit_code = 42
-
-[[case]]
-name = "function_with_eight_params"
-spec = ["6.1:3"]
-description = "Test with eight parameters (7th and 8th go on stack)"
-source = """
-fn sum8(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32, g: i32, h: i32) -> i32 {
-    a + b + c + d + e + f + g + h
-}
-fn main() -> i32 { sum8(1, 2, 3, 4, 5, 6, 7, 14) }
-"""
-exit_code = 42
-
-[[case]]
-name = "function_with_ten_params"
-spec = ["6.1:3"]
-description = "Test with ten parameters (last four go on stack)"
-source = """
-fn sum10(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32, g: i32, h: i32, i: i32, j: i32) -> i32 {
-    a + b + c + d + e + f + g + h + i + j
-}
-fn main() -> i32 { sum10(1, 2, 3, 4, 5, 6, 7, 8, 9, -3) }
-"""
-exit_code = 42
+description = "Test with varying number of parameters"
+source = "{source}"
+params = [
+  { num = "six", source = "fn sum6(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32) -> i32 {\n    a + b + c + d + e + f\n}\nfn main() -> i32 { sum6(1, 2, 3, 4, 5, 27) }", exit_code = 42 },
+  { num = "seven", source = "fn sum7(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32, g: i32) -> i32 {\n    a + b + c + d + e + f + g\n}\nfn main() -> i32 { sum7(1, 2, 3, 4, 5, 6, 21) }", exit_code = 42 },
+  { num = "eight", source = "fn sum8(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32, g: i32, h: i32) -> i32 {\n    a + b + c + d + e + f + g + h\n}\nfn main() -> i32 { sum8(1, 2, 3, 4, 5, 6, 7, 14) }", exit_code = 42 },
+  { num = "ten", source = "fn sum10(a: i32, b: i32, c: i32, d: i32, e: i32, f: i32, g: i32, h: i32, i: i32, j: i32) -> i32 {\n    a + b + c + d + e + f + g + h + i + j\n}\nfn main() -> i32 { sum10(1, 2, 3, 4, 5, 6, 7, 8, 9, -3) }", exit_code = 42 },
+]
 
 [[case]]
 name = "stack_params_with_expressions"
@@ -416,69 +257,26 @@ exit_code = 42
 # =============================================================================
 
 [[case]]
-name = "implicit_unit_return"
+name = "unit_return_{variant}"
 spec = ["6.1:6"]
-description = "Function without return type annotation implicitly returns ()"
-source = """
-fn do_nothing() { }
-fn main() -> i32 { do_nothing(); 0 }
-"""
+source = "{source}"
+params = [
+  { variant = "implicit", source = "fn do_nothing() { }\nfn main() -> i32 { do_nothing(); 0 }" },
+  { variant = "with_statements", source = "fn setup() {\n    let x = 1;\n    let y = 2;\n}\nfn main() -> i32 { setup(); 0 }" },
+  { variant = "explicit", source = "fn explicit() -> () { }\nfn main() -> i32 { explicit(); 0 }" },
+  { variant = "call_in_expr", source = "fn side_effect() { let x = 1; }\nfn main() -> i32 {\n    side_effect();\n    side_effect();\n    42\n}", exit_code = 42 },
+]
 exit_code = 0
 
 [[case]]
-name = "implicit_unit_with_statements"
-spec = ["6.1:6"]
-description = "Unit-returning function with statements"
-source = """
-fn setup() {
-    let x = 1;
-    let y = 2;
-}
-fn main() -> i32 { setup(); 0 }
-"""
-exit_code = 0
-
-[[case]]
-name = "explicit_unit_return"
-spec = ["6.1:6"]
-description = "Explicit -> () return type"
-source = """
-fn explicit() -> () { }
-fn main() -> i32 { explicit(); 0 }
-"""
-exit_code = 0
-
-[[case]]
-name = "unit_main"
+name = "unit_main_{variant}"
 spec = ["6.1:6", "6.1:7", "6.1:8"]
-description = "Main function can return unit (exits with 0)"
-source = "fn main() { }"
+source = "{source}"
 exit_code = 0
-
-[[case]]
-name = "unit_main_with_statements"
-spec = ["6.1:6"]
-description = "Main returning unit with statements"
-source = """
-fn main() {
-    let x = 42;
-}
-"""
-exit_code = 0
-
-[[case]]
-name = "call_unit_function_in_expression"
-spec = ["6.1:6"]
-description = "Can call unit-returning function and ignore result"
-source = """
-fn side_effect() { let x = 1; }
-fn main() -> i32 {
-    side_effect();
-    side_effect();
-    42
-}
-"""
-exit_code = 42
+params = [
+  { variant = "empty", source = "fn main() { }" },
+  { variant = "with_statements", source = "fn main() {\n    let x = 42;\n}" },
+]
 
 # =============================================================================
 # Struct parameters
@@ -499,49 +297,23 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
-name = "struct_param_nested_field_access"
+name = "struct_param_nested_{variant}"
 spec = ["6.1:3"]
-description = "Accessing nested fields of a struct parameter computes correct slot offsets"
+description = "Struct parameter with nested field access"
 source = """
 struct Inner { a: i32, b: i32 }
 struct Outer { inner: Inner, other: i32 }
-fn get_inner_sum(o: Outer) -> i32 { o.inner.a + o.inner.b }
+fn {fn_name}(o: Outer) -> i32 { {body} }
 fn main() -> i32 {
-    let o = Outer { inner: Inner { a: 10, b: 20 }, other: 100 };
-    get_inner_sum(o)
+    let o = Outer { inner: Inner { a: {a}, b: {b} }, other: {other} };
+    {fn_name}(o)
 }
 """
-exit_code = 30
-
-[[case]]
-name = "struct_param_nested_all_slots"
-spec = ["6.1:3"]
-description = "Accessing all slots of a nested struct parameter uses correct slot counts"
-source = """
-struct Inner { a: i32, b: i32 }
-struct Outer { inner: Inner, other: i32 }
-fn sum_all(o: Outer) -> i32 { o.inner.a + o.inner.b + o.other }
-fn main() -> i32 {
-    let o = Outer { inner: Inner { a: 1, b: 2 }, other: 42 };
-    sum_all(o)
-}
-"""
-exit_code = 45
-
-[[case]]
-name = "struct_param_nested_later_field"
-spec = ["6.1:3"]
-description = "Accessing field after nested struct uses correct slot offset"
-source = """
-struct Inner { a: i32, b: i32 }
-struct Outer { inner: Inner, other: i32 }
-fn get_other(o: Outer) -> i32 { o.other }
-fn main() -> i32 {
-    let o = Outer { inner: Inner { a: 10, b: 20 }, other: 42 };
-    get_other(o)
-}
-"""
-exit_code = 42
+params = [
+  { variant = "sum", fn_name = "get_inner_sum", body = "o.inner.a + o.inner.b", a = "10", b = "20", other = "100", exit_code = 30 },
+  { variant = "all_slots", fn_name = "sum_all", body = "o.inner.a + o.inner.b + o.other", a = "1", b = "2", other = "42", exit_code = 45 },
+  { variant = "later_field", fn_name = "get_other", body = "o.other", a = "10", b = "20", other = "42", exit_code = 42 },
+]
 
 [[case]]
 name = "struct_return_nested"
@@ -577,40 +349,29 @@ fn main() -> i32 {
 exit_code = 42
 
 # =============================================================================
-# Inout parameters
+# Inout parameters (primitives)
 # =============================================================================
 
 [[case]]
-name = "inout_param_increment"
+name = "inout_param_{variant}"
 spec = ["6.1:14", "6.1:15", "6.1:16", "6.1:18"]
-description = "Basic inout parameter that modifies a variable"
+description = "Basic inout parameter operations"
 source = """
-fn increment(inout x: i32) {
-    x = x + 1;
+fn {fn_name}(inout x: i32{extra_params}) {
+    {body}
 }
 fn main() -> i32 {
-    let mut n = 41;
-    increment(inout n);
+    let mut n = {init};
+    {calls};
     n
 }
 """
-exit_code = 42
-
-[[case]]
-name = "inout_param_double"
-spec = ["6.1:14", "6.1:18"]
-description = "Inout parameter that doubles a value"
-source = """
-fn double(inout x: i32) {
-    x = x * 2;
-}
-fn main() -> i32 {
-    let mut n = 21;
-    double(inout n);
-    n
-}
-"""
-exit_code = 42
+params = [
+  { variant = "increment", fn_name = "increment", extra_params = "", body = "x = x + 1;", init = "41", calls = "increment(inout n)", exit_code = 42 },
+  { variant = "double", fn_name = "double", extra_params = "", body = "x = x * 2;", init = "21", calls = "double(inout n)", exit_code = 42 },
+  { variant = "multiple_calls", fn_name = "increment", extra_params = "", body = "x = x + 1;", init = "39", calls = "increment(inout n); increment(inout n); increment(inout n)", exit_code = 42 },
+  { variant = "with_regular", fn_name = "add_to", extra_params = ", amount: i32", body = "x = x + amount;", init = "32", calls = "add_to(inout n, 10)", exit_code = 42, spec_extra = ["6.1:15"] },
+]
 
 [[case]]
 name = "inout_param_swap"
@@ -627,40 +388,6 @@ fn main() -> i32 {
     let mut y = 42;
     swap(inout x, inout y);
     x
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "inout_param_with_regular_param"
-spec = ["6.1:14", "6.1:15"]
-description = "Mixing inout and regular parameters"
-source = """
-fn add_to(inout x: i32, amount: i32) {
-    x = x + amount;
-}
-fn main() -> i32 {
-    let mut n = 32;
-    add_to(inout n, 10);
-    n
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "inout_param_multiple_calls"
-spec = ["6.1:14", "6.1:18"]
-description = "Multiple calls with inout accumulate changes"
-source = """
-fn increment(inout x: i32) {
-    x = x + 1;
-}
-fn main() -> i32 {
-    let mut n = 39;
-    increment(inout n);
-    increment(inout n);
-    increment(inout n);
-    n
 }
 """
 exit_code = 42
@@ -684,77 +411,6 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
-name = "inout_requires_lvalue"
-spec = ["6.1:17"]
-description = "Inout argument must be an lvalue (not a literal)"
-source = """
-fn increment(inout x: i32) {
-    x = x + 1;
-}
-fn main() -> i32 {
-    increment(inout 42);
-    0
-}
-"""
-compile_fail = true
-error_contains = "lvalue"
-
-[[case]]
-name = "inout_exclusive_access"
-spec = ["6.1:20"]
-description = "Cannot pass same variable to multiple inout parameters"
-source = """
-fn swap(inout a: i32, inout b: i32) {
-    let tmp = a;
-    a = b;
-    b = tmp;
-}
-fn main() -> i32 {
-    let mut x = 1;
-    swap(inout x, inout x);
-    0
-}
-"""
-compile_fail = true
-error_contains = "same variable"
-
-[[case]]
-name = "inout_exclusive_access_different_vars"
-spec = ["6.1:20"]
-description = "Different variables can be passed to multiple inout parameters"
-source = """
-fn swap(inout a: i32, inout b: i32) {
-    let tmp = a;
-    a = b;
-    b = tmp;
-}
-fn main() -> i32 {
-    let mut x = 1;
-    let mut y = 2;
-    swap(inout x, inout y);
-    x + y * 10
-}
-"""
-exit_code = 12
-
-[[case]]
-name = "inout_allows_mutation_vs_borrow"
-spec = ["6.1:14", "6.1:18"]
-description = "Inout allows mutation while borrow does not (contrast test)"
-source = """
-struct Counter { value: i32 }
-fn increment_inout(inout c: Counter) {
-    c.value = c.value + 1;
-}
-fn main() -> i32 {
-    let mut c = Counter { value: 41 };
-    increment_inout(inout c);
-    c.value
-}
-"""
-exit_code = 42
-
-[[case]]
 name = "inout_value_valid_after_call"
 spec = ["6.1:18"]
 description = "Variable is still valid after inout call (no ownership transfer)"
@@ -772,78 +428,82 @@ fn main() -> i32 {
 exit_code = 42
 
 # =============================================================================
+# Inout parameter errors
+# =============================================================================
+
+[[case]]
+name = "inout_requires_lvalue"
+spec = ["6.1:17"]
+description = "Inout argument must be an lvalue (not a literal)"
+source = """
+fn increment(inout x: i32) {
+    x = x + 1;
+}
+fn main() -> i32 {
+    increment(inout 42);
+    0
+}
+"""
+compile_fail = true
+error_contains = "lvalue"
+
+[[case]]
+name = "inout_exclusive_access_{variant}"
+spec = ["6.1:20"]
+description = "Inout exclusive access checking"
+source = """
+fn swap(inout a: i32, inout b: i32) {
+    let tmp = a;
+    a = b;
+    b = tmp;
+}
+fn main() -> i32 {
+    let mut x = 1;
+    {second_decl}
+    swap(inout x, inout {second});
+    {result}
+}
+"""
+params = [
+  { variant = "same_var_error", second_decl = "", second = "x", result = "0", compile_fail = true, error_contains = "same variable" },
+  { variant = "different_vars_ok", second_decl = "let mut y = 2;", second = "y", result = "x + y * 10", exit_code = 12, compile_fail = false },
+]
+
+# =============================================================================
 # Borrow parameters
 # =============================================================================
 
 [[case]]
-name = "borrow_param_read_only"
-spec = ["6.1:22", "6.1:23", "6.1:26"]
-description = "Basic borrow parameter that reads a value without ownership transfer"
-source = """
-struct Point { x: i32, y: i32 }
-fn sum(borrow p: Point) -> i32 {
-    p.x + p.y
-}
-fn main() -> i32 {
-    let p = Point { x: 10, y: 32 };
-    sum(borrow p)
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "borrow_param_multiple_uses"
+name = "borrow_param_{variant}"
 spec = ["6.1:22", "6.1:26"]
-description = "Borrowed value can be used multiple times after call (not moved)"
+description = "Basic borrow parameter operations"
 source = """
 struct Point { x: i32, y: i32 }
-fn get_x(borrow p: Point) -> i32 {
-    p.x
-}
-fn get_y(borrow p: Point) -> i32 {
-    p.y
+fn {fn_name}(borrow p: Point) -> i32 {
+    {body}
 }
 fn main() -> i32 {
-    let p = Point { x: 21, y: 21 };
-    get_x(borrow p) + get_y(borrow p)
+    let p = Point { x: {x}, y: {y} };
+    {expr}
 }
 """
-exit_code = 42
+params = [
+  { variant = "read_only", fn_name = "sum", body = "p.x + p.y", x = "10", y = "32", expr = "sum(borrow p)", exit_code = 42, spec_extra = ["6.1:23"] },
+  { variant = "multiple_uses", fn_name = "get_x", body = "p.x", x = "21", y = "21", expr = "get_x(borrow p) + get_x(borrow p)", exit_code = 42 },
+]
 
 [[case]]
-name = "borrow_cannot_mutate_field"
+name = "borrow_cannot_mutate_{kind}"
 spec = ["6.1:24"]
-description = "Cannot mutate fields of a borrowed value"
-source = """
-struct Point { x: i32, y: i32 }
-fn try_mutate(borrow p: Point) -> i32 {
-    p.x = 10;
-    p.x
-}
-fn main() -> i32 {
-    let p = Point { x: 1, y: 2 };
-    try_mutate(borrow p)
-}
-"""
+description = "Cannot mutate borrowed values"
+source = "{source}"
 compile_fail = true
 error_contains = "cannot mutate borrowed"
-
-[[case]]
-name = "borrow_cannot_mutate_array"
-spec = ["6.1:24"]
-description = "Cannot mutate elements of a borrowed array"
-source = """
-fn try_mutate(borrow arr: [i32; 3]) -> i32 {
-    arr[0] = 99;
-    arr[0]
-}
-fn main() -> i32 {
-    let a = [1, 2, 3];
-    try_mutate(borrow a)
-}
-"""
-compile_fail = true
-error_contains = "cannot mutate borrowed"
+params = [
+  { kind = "field", source = "struct Point { x: i32, y: i32 }\nfn try_mutate(borrow p: Point) -> i32 {\n    p.x = 10;\n    p.x\n}\nfn main() -> i32 {\n    let p = Point { x: 1, y: 2 };\n    try_mutate(borrow p)\n}" },
+  { kind = "array", source = "fn try_mutate(borrow arr: [i32; 3]) -> i32 {\n    arr[0] = 99;\n    arr[0]\n}\nfn main() -> i32 {\n    let a = [1, 2, 3];\n    try_mutate(borrow a)\n}" },
+  { kind = "param", source = "struct Data { value: i32 }\nfn try_reassign(borrow d: Data) -> i32 {\n    d = Data { value: 99 };\n    d.value\n}\nfn main() -> i32 {\n    let d = Data { value: 42 };\n    try_reassign(borrow d)\n}" },
+]
 
 [[case]]
 name = "borrow_cannot_move_out"
@@ -930,51 +590,15 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
-name = "borrow_integer_param"
-spec = ["6.1:22", "6.1:23"]
-description = "Borrow works with primitive integer types"
-source = """
-fn double(borrow x: i32) -> i32 {
-    x + x
-}
-fn main() -> i32 {
-    let n = 21;
-    double(borrow n)
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "borrow_array_read"
+name = "borrow_{type}_read"
 spec = ["6.1:22", "6.1:26"]
-description = "Can read elements from a borrowed array"
-source = """
-fn first(borrow arr: [i32; 3]) -> i32 {
-    arr[0]
-}
-fn main() -> i32 {
-    let a = [42, 2, 3];
-    first(borrow a)
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "borrow_nested_struct"
-spec = ["6.1:22", "6.1:26"]
-description = "Can read nested fields from a borrowed struct"
-source = """
-struct Inner { value: i32 }
-struct Outer { inner: Inner }
-fn get_inner_value(borrow o: Outer) -> i32 {
-    o.inner.value
-}
-fn main() -> i32 {
-    let o = Outer { inner: Inner { value: 42 } };
-    get_inner_value(borrow o)
-}
-"""
-exit_code = 42
+description = "Borrow works with various types"
+source = "{source}"
+params = [
+  { type = "integer", source = "fn double(borrow x: i32) -> i32 {\n    x + x\n}\nfn main() -> i32 {\n    let n = 21;\n    double(borrow n)\n}", exit_code = 42, spec_extra = ["6.1:23"] },
+  { type = "array", source = "fn first(borrow arr: [i32; 3]) -> i32 {\n    arr[0]\n}\nfn main() -> i32 {\n    let a = [42, 2, 3];\n    first(borrow a)\n}", exit_code = 42 },
+  { type = "nested_struct", source = "struct Inner { value: i32 }\nstruct Outer { inner: Inner }\nfn get_inner_value(borrow o: Outer) -> i32 {\n    o.inner.value\n}\nfn main() -> i32 {\n    let o = Outer { inner: Inner { value: 42 } };\n    get_inner_value(borrow o)\n}", exit_code = 42 },
+]
 
 [[case]]
 name = "borrow_call_site_missing_keyword"
@@ -993,88 +617,34 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = "borrow"
 
-[[case]]
-name = "borrow_cannot_assign_to_param"
-spec = ["6.1:24"]
-description = "Cannot assign to the borrowed parameter itself"
-source = """
-struct Data { value: i32 }
-fn try_reassign(borrow d: Data) -> i32 {
-    d = Data { value: 99 };
-    d.value
-}
-fn main() -> i32 {
-    let d = Data { value: 42 };
-    try_reassign(borrow d)
-}
-"""
-compile_fail = true
-error_contains = "cannot mutate borrowed"
-
 # =============================================================================
 # Inout parameters with structs
 # =============================================================================
 
 [[case]]
-name = "inout_struct_field_set"
-spec = ["6.1:14", "6.1:15", "6.1:16", "6.1:18"]
-description = "Inout struct parameter allows modifying a field"
-preview = "affine_types"
-source = """
-struct Point { x: i32, y: i32 }
-
-fn increment_x(inout p: Point) {
-    p.x = p.x + 1;
-}
-
-fn main() -> i32 {
-    let mut pt = Point { x: 41, y: 0 };
-    increment_x(inout pt);
-    pt.x
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "inout_struct_field_get"
+name = "inout_struct_{variant}"
 spec = ["6.1:14", "6.1:18"]
-description = "Inout struct parameter allows reading fields"
+description = "Inout struct parameter operations"
 preview = "affine_types"
 source = """
-struct Point { x: i32, y: i32 }
+struct {struct_def}
 
-fn get_sum(inout p: Point) -> i32 {
-    p.x + p.y
+fn {fn_name}(inout {param}: {type}{extra_params}) {return_type} {
+    {body}
 }
 
 fn main() -> i32 {
-    let mut pt = Point { x: 20, y: 22 };
-    get_sum(inout pt)
+    let mut {var} = {init};
+    {calls}
 }
 """
-exit_code = 42
-
-[[case]]
-name = "inout_struct_multiple_fields"
-spec = ["6.1:14", "6.1:18"]
-description = "Inout struct parameter allows modifying multiple fields"
-preview = "affine_types"
-source = """
-struct Point { x: i32, y: i32 }
-
-fn swap_xy(inout p: Point) {
-    let tmp = p.x;
-    p.x = p.y;
-    p.y = tmp;
-}
-
-fn main() -> i32 {
-    let mut pt = Point { x: 10, y: 42 };
-    swap_xy(inout pt);
-    pt.x
-}
-"""
-exit_code = 42
+params = [
+  { variant = "field_set", struct_def = "Point { x: i32, y: i32 }", fn_name = "increment_x", param = "p", type = "Point", extra_params = "", return_type = "", body = "p.x = p.x + 1;", var = "pt", init = "Point { x: 41, y: 0 }", calls = "increment_x(inout pt);\n    pt.x", exit_code = 42, spec_extra = ["6.1:15", "6.1:16"] },
+  { variant = "field_get", struct_def = "Point { x: i32, y: i32 }", fn_name = "get_sum", param = "p", type = "Point", extra_params = "", return_type = "-> i32", body = "p.x + p.y", var = "pt", init = "Point { x: 20, y: 22 }", calls = "get_sum(inout pt)", exit_code = 42 },
+  { variant = "multiple_fields", struct_def = "Point { x: i32, y: i32 }", fn_name = "swap_xy", param = "p", type = "Point", extra_params = "", return_type = "", body = "let tmp = p.x;\n    p.x = p.y;\n    p.y = tmp;", var = "pt", init = "Point { x: 10, y: 42 }", calls = "swap_xy(inout pt);\n    pt.x", exit_code = 42 },
+  { variant = "with_regular", struct_def = "Counter { value: i32 }", fn_name = "add_to", param = "c", type = "Counter", extra_params = ", amount: i32", return_type = "", body = "c.value = c.value + amount;", var = "counter", init = "Counter { value: 32 }", calls = "add_to(inout counter, 10);\n    counter.value", exit_code = 42, spec_extra = ["6.1:15"] },
+  { variant = "multiple_calls", struct_def = "Counter { value: i32 }", fn_name = "increment", param = "c", type = "Counter", extra_params = "", return_type = "", body = "c.value = c.value + 1;", var = "counter", init = "Counter { value: 39 }", calls = "increment(inout counter);\n    increment(inout counter);\n    increment(inout counter);\n    counter.value", exit_code = 42 },
+]
 
 [[case]]
 name = "inout_struct_return_and_modify"
@@ -1097,48 +667,6 @@ fn main() -> i32 {
 }
 """
 exit_code = 81
-
-[[case]]
-name = "inout_struct_multiple_calls"
-spec = ["6.1:14", "6.1:18"]
-description = "Multiple calls with inout struct accumulate changes"
-preview = "affine_types"
-source = """
-struct Counter { value: i32 }
-
-fn increment(inout c: Counter) {
-    c.value = c.value + 1;
-}
-
-fn main() -> i32 {
-    let mut counter = Counter { value: 39 };
-    increment(inout counter);
-    increment(inout counter);
-    increment(inout counter);
-    counter.value
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "inout_struct_with_regular_param"
-spec = ["6.1:14", "6.1:15"]
-description = "Mixing inout struct and regular parameters"
-preview = "affine_types"
-source = """
-struct Counter { value: i32 }
-
-fn add_to(inout c: Counter, amount: i32) {
-    c.value = c.value + amount;
-}
-
-fn main() -> i32 {
-    let mut counter = Counter { value: 32 };
-    add_to(inout counter, 10);
-    counter.value
-}
-"""
-exit_code = 42
 
 [[case]]
 name = "inout_nested_struct"
@@ -1190,161 +718,46 @@ exit_code = 42
 # =============================================================================
 
 [[case]]
-name = "assign_to_non_inout_param"
+name = "assign_to_non_inout_{kind}"
 spec = ["6.1:32"]
-description = "Cannot assign to a non-inout parameter"
+description = "Cannot assign to non-inout parameters"
 preview = "affine_types"
-source = """
-fn bad(x: i32) {
-    x = 5;
-}
-fn main() -> i32 {
-    bad(10);
-    0
-}
-"""
+source = "{source}"
 compile_fail = true
 error_contains = "immutable"
-
-[[case]]
-name = "assign_to_non_inout_struct_param_field"
-spec = ["6.1:32"]
-description = "Cannot assign to a field of a non-inout struct parameter"
-preview = "affine_types"
-source = """
-struct Point { x: i32, y: i32 }
-
-fn bad(p: Point) {
-    p.x = 10;
-}
-fn main() -> i32 {
-    let pt = Point { x: 1, y: 2 };
-    bad(pt);
-    0
-}
-"""
-compile_fail = true
-error_contains = "immutable"
-
-[[case]]
-name = "assign_to_non_inout_nested_struct_param_field"
-spec = ["6.1:32"]
-description = "Cannot assign to a nested field of a non-inout struct parameter"
-preview = "affine_types"
-source = """
-struct Inner { value: i32 }
-struct Outer { inner: Inner }
-
-fn bad(o: Outer) {
-    o.inner.value = 10;
-}
-fn main() -> i32 {
-    let data = Outer { inner: Inner { value: 1 } };
-    bad(data);
-    0
-}
-"""
-compile_fail = true
-error_contains = "immutable"
+params = [
+  { kind = "param", source = "fn bad(x: i32) {\n    x = 5;\n}\nfn main() -> i32 {\n    bad(10);\n    0\n}" },
+  { kind = "struct_field", source = "struct Point { x: i32, y: i32 }\n\nfn bad(p: Point) {\n    p.x = 10;\n}\nfn main() -> i32 {\n    let pt = Point { x: 1, y: 2 };\n    bad(pt);\n    0\n}" },
+  { kind = "nested_field", source = "struct Inner { value: i32 }\nstruct Outer { inner: Inner }\n\nfn bad(o: Outer) {\n    o.inner.value = 10;\n}\nfn main() -> i32 {\n    let data = Outer { inner: Inner { value: 1 } };\n    bad(data);\n    0\n}" },
+]
 
 # =============================================================================
 # Inout parameters with arrays
 # =============================================================================
 
 [[case]]
-name = "inout_array_element_get"
+name = "inout_array_{variant}"
 spec = ["6.1:14", "6.1:18"]
-description = "Inout array parameter allows reading elements"
+description = "Inout array parameter operations"
 preview = "affine_types"
 source = """
-fn get_first(inout arr: [i32; 3]) -> i32 {
-    arr[0]
+fn {fn_name}(inout arr: [i32; 3]{extra_params}) {return_type} {
+    {body}
 }
 
 fn main() -> i32 {
-    let mut a = [42, 0, 0];
-    get_first(inout a)
+    let mut a = {init};
+    {calls}
 }
 """
-exit_code = 42
-
-[[case]]
-name = "inout_array_element_set"
-spec = ["6.1:14", "6.1:18"]
-description = "Inout array parameter allows modifying elements"
-preview = "affine_types"
-source = """
-fn increment_first(inout arr: [i32; 3]) {
-    arr[0] = arr[0] + 1;
-}
-
-fn main() -> i32 {
-    let mut a = [41, 0, 0];
-    increment_first(inout a);
-    a[0]
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "inout_array_multiple_elements"
-spec = ["6.1:14", "6.1:18"]
-description = "Inout array parameter allows modifying multiple elements"
-preview = "affine_types"
-source = """
-fn swap_first_two(inout arr: [i32; 3]) {
-    let tmp = arr[0];
-    arr[0] = arr[1];
-    arr[1] = tmp;
-}
-
-fn main() -> i32 {
-    let mut a = [10, 42, 0];
-    swap_first_two(inout a);
-    a[0]
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "inout_array_return_and_modify"
-spec = ["6.1:14", "6.1:18"]
-description = "Inout array parameter with return value"
-preview = "affine_types"
-source = """
-fn increment_return_old(inout arr: [i32; 3]) -> i32 {
-    let old = arr[0];
-    arr[0] = arr[0] + 1;
-    old
-}
-
-fn main() -> i32 {
-    let mut a = [40, 0, 0];
-    let old = increment_return_old(inout a);
-    old + a[0]
-}
-"""
-exit_code = 81
-
-[[case]]
-name = "inout_array_multiple_calls"
-spec = ["6.1:14", "6.1:18"]
-description = "Multiple calls with inout array accumulate changes"
-preview = "affine_types"
-source = """
-fn increment_first(inout arr: [i32; 3]) {
-    arr[0] = arr[0] + 1;
-}
-
-fn main() -> i32 {
-    let mut a = [39, 0, 0];
-    increment_first(inout a);
-    increment_first(inout a);
-    increment_first(inout a);
-    a[0]
-}
-"""
-exit_code = 42
+params = [
+  { variant = "element_get", fn_name = "get_first", extra_params = "", return_type = "-> i32", body = "arr[0]", init = "[42, 0, 0]", calls = "get_first(inout a)", exit_code = 42 },
+  { variant = "element_set", fn_name = "increment_first", extra_params = "", return_type = "", body = "arr[0] = arr[0] + 1;", init = "[41, 0, 0]", calls = "increment_first(inout a);\n    a[0]", exit_code = 42 },
+  { variant = "swap_elements", fn_name = "swap_first_two", extra_params = "", return_type = "", body = "let tmp = arr[0];\n    arr[0] = arr[1];\n    arr[1] = tmp;", init = "[10, 42, 0]", calls = "swap_first_two(inout a);\n    a[0]", exit_code = 42 },
+  { variant = "return_and_modify", fn_name = "increment_return_old", extra_params = "", return_type = "-> i32", body = "let old = arr[0];\n    arr[0] = arr[0] + 1;\n    old", init = "[40, 0, 0]", calls = "let old = increment_return_old(inout a);\n    old + a[0]", exit_code = 81 },
+  { variant = "multiple_calls", fn_name = "increment_first", extra_params = "", return_type = "", body = "arr[0] = arr[0] + 1;", init = "[39, 0, 0]", calls = "increment_first(inout a);\n    increment_first(inout a);\n    increment_first(inout a);\n    a[0]", exit_code = 42 },
+  { variant = "sum", fn_name = "sum_array", extra_params = "", return_type = "-> i32", body = "arr[0] + arr[1] + arr[2]", init = "[10, 20, 12]", calls = "sum_array(inout a)", exit_code = 42 },
+]
 
 [[case]]
 name = "inout_array_with_index_variable"
@@ -1382,23 +795,6 @@ fn main() -> i32 {
     let mut a = [40, 0, 0];
     double_increment(inout a);
     a[0]
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "inout_array_sum"
-spec = ["6.1:14", "6.1:18"]
-description = "Reading all elements of an inout array"
-preview = "affine_types"
-source = """
-fn sum_array(inout arr: [i32; 3]) -> i32 {
-    arr[0] + arr[1] + arr[2]
-}
-
-fn main() -> i32 {
-    let mut a = [10, 20, 12];
-    sum_array(inout a)
 }
 """
 exit_code = 42

--- a/crates/rue-spec/cases/statements/let.toml
+++ b/crates/rue-spec/cases/statements/let.toml
@@ -20,88 +20,49 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
-name = "let_with_expression"
+name = "let_{variant}"
 spec = ["5.1:1"]
 source = """
 fn main() -> i32 {
-    let x = 1 + 2;
-    x
+    {body}
 }
 """
-exit_code = 3
+params = [
+  { variant = "with_expression", body = "let x = 1 + 2; x", exit_code = 3 },
+  { variant = "multiple", body = "let x = 10; let y = 20; x + y", exit_code = 30 },
+  { variant = "chained", body = "let x = 10; let y = x + 5; let z = y * 2; z", exit_code = 30 },
+  { variant = "negation", body = "let x = -5; let y = -x; y", exit_code = 5 },
+]
 
 [[case]]
-name = "let_multiple"
+name = "let_complex_expression"
 spec = ["5.1:1"]
 source = """
 fn main() -> i32 {
-    let x = 10;
-    let y = 20;
-    x + y
+    let result = (1 + 2) * (3 + 4);
+    result
 }
 """
-exit_code = 30
+exit_code = 21
+
+# =============================================================================
+# Shadowing
+# =============================================================================
 
 [[case]]
-name = "let_use_in_expression"
-spec = ["5.1:1"]
-source = """
-fn main() -> i32 {
-    let a = 5;
-    let b = 3;
-    a * b + 2
-}
-"""
-exit_code = 17
-
-[[case]]
-name = "let_chained"
-spec = ["5.1:1"]
-source = """
-fn main() -> i32 {
-    let x = 10;
-    let y = x + 5;
-    let z = y * 2;
-    z
-}
-"""
-exit_code = 30
-
-[[case]]
-name = "let_shadow"
+name = "let_shadow_{variant}"
 spec = ["5.1:2", "5.1:10"]
 source = """
 fn main() -> i32 {
-    let x = 1;
-    let x = 2;
-    x
+    {body}
 }
 """
-exit_code = 2
-
-[[case]]
-name = "let_shadow_uses_previous"
-spec = ["5.1:2", "5.1:10", "5.1:12"]
-source = """
-fn main() -> i32 {
-    let x = 10;
-    let x = x + 5;
-    x
-}
-"""
-exit_code = 15
-
-[[case]]
-name = "let_shadow_multiple_refs_in_init"
-spec = ["5.1:12"]
-source = """
-fn main() -> i32 {
-    let x = 5;
-    let x = x + x;
-    x
-}
-"""
-exit_code = 10
+params = [
+  { variant = "basic", body = "let x = 1; let x = 2; x", exit_code = 2 },
+  { variant = "uses_previous", body = "let x = 10; let x = x + 5; x", exit_code = 15, spec_extra = ["5.1:12"] },
+  { variant = "multiple_refs", body = "let x = 5; let x = x + x; x", exit_code = 10, spec_extra = ["5.1:12"] },
+  { variant = "chained", body = "let x = 1; let x = x + 1; let x = x + 1; let x = x + 1; x", exit_code = 4, spec_extra = ["5.1:12"] },
+]
 
 [[case]]
 name = "let_shadow_complex_init_expr"
@@ -142,134 +103,42 @@ fn main() -> i32 {
 """
 exit_code = 15
 
-[[case]]
-name = "let_shadow_chained"
-spec = ["5.1:12"]
-source = """
-fn main() -> i32 {
-    let x = 1;
-    let x = x + 1;
-    let x = x + 1;
-    let x = x + 1;
-    x
-}
-"""
-exit_code = 4
-
-[[case]]
-name = "let_complex_expression"
-spec = ["5.1:1"]
-source = """
-fn main() -> i32 {
-    let result = (1 + 2) * (3 + 4);
-    result
-}
-"""
-exit_code = 21
-
-[[case]]
-name = "let_negation"
-spec = ["5.1:1"]
-source = """
-fn main() -> i32 {
-    let x = -5;
-    let y = -x;
-    y
-}
-"""
-exit_code = 5
-
 # =============================================================================
 # Type Annotations
 # =============================================================================
 
 [[case]]
-name = "let_with_type"
+name = "let_with_type_{variant}"
 spec = ["5.1:3", "5.1:8"]
 source = """
 fn main() -> i32 {
-    let x: i32 = 42;
-    x
+    {body}
 }
 """
-exit_code = 42
-
-[[case]]
-name = "let_with_type_expression"
-spec = ["5.1:3"]
-source = """
-fn main() -> i32 {
-    let x: i32 = 10 + 20;
-    x
-}
-"""
-exit_code = 30
-
-[[case]]
-name = "let_multiple_with_types"
-spec = ["5.1:3"]
-source = """
-fn main() -> i32 {
-    let a: i32 = 5;
-    let b: i32 = 7;
-    a + b
-}
-"""
-exit_code = 12
+params = [
+  { variant = "simple", body = "let x: i32 = 42; x", exit_code = 42 },
+  { variant = "expression", body = "let x: i32 = 10 + 20; x", exit_code = 30 },
+  { variant = "multiple", body = "let a: i32 = 5; let b: i32 = 7; a + b", exit_code = 12 },
+]
 
 # =============================================================================
 # Mutable Variables
 # =============================================================================
 
 [[case]]
-name = "let_mut_simple"
+name = "let_mut_{variant}"
 spec = ["5.1:4", "5.1:5"]
 source = """
 fn main() -> i32 {
-    let mut x = 10;
-    x = 20;
-    x
+    {body}
 }
 """
-exit_code = 20
-
-[[case]]
-name = "let_mut_increment"
-spec = ["5.1:4"]
-source = """
-fn main() -> i32 {
-    let mut x = 5;
-    x = x + 1;
-    x
-}
-"""
-exit_code = 6
-
-[[case]]
-name = "let_mut_multiple_assigns"
-spec = ["5.1:4"]
-source = """
-fn main() -> i32 {
-    let mut x = 1;
-    x = 2;
-    x = 3;
-    x = 4;
-    x
-}
-"""
-exit_code = 4
-
-[[case]]
-name = "let_mut_with_type"
-spec = ["5.1:3", "5.1:4"]
-source = """
-fn main() -> i32 {
-    let mut x: i32 = 10;
-    x = 20;
-    x
-}
-"""
-exit_code = 20
+params = [
+  { variant = "simple", body = "let mut x = 10; x = 20; x", exit_code = 20 },
+  { variant = "increment", body = "let mut x = 5; x = x + 1; x", exit_code = 6 },
+  { variant = "multiple_assigns", body = "let mut x = 1; x = 2; x = 3; x = 4; x", exit_code = 4 },
+  { variant = "with_type", body = "let mut x: i32 = 10; x = 20; x", exit_code = 20, spec_extra = ["5.1:3"] },
+]
 
 [[case]]
 name = "let_mut_complex"
@@ -300,72 +169,22 @@ fn main() -> i32 {
 exit_code = 15
 
 [[case]]
-name = "let_mut_shadow"
+name = "let_mut_shadow_{variant}"
 spec = ["5.1:2", "5.1:4"]
 source = """
 fn main() -> i32 {
-    let mut x = 1;
-    let mut x = 2;
-    x = 3;
-    x
+    {body}
 }
 """
-exit_code = 3
-
-[[case]]
-name = "let_immutable_shadow_mutable"
-spec = ["5.1:2"]
-source = """
-fn main() -> i32 {
-    let mut x = 1;
-    x = 10;
-    let x = 42;
-    x
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "let_mutable_shadow_immutable"
-spec = ["5.1:2", "5.1:4"]
-source = """
-fn main() -> i32 {
-    let x = 10;
-    let mut x = x;
-    x = x + 5;
-    x
-}
-"""
-exit_code = 15
+params = [
+  { variant = "mut_to_mut", body = "let mut x = 1; let mut x = 2; x = 3; x", exit_code = 3 },
+  { variant = "mut_to_immut", body = "let mut x = 1; x = 10; let x = 42; x", exit_code = 42 },
+  { variant = "immut_to_mut", body = "let x = 10; let mut x = x; x = x + 5; x", exit_code = 15 },
+]
 
 # =============================================================================
 # Statements and Final Expression
 # =============================================================================
-
-[[case]]
-name = "statements_with_semicolons"
-spec = ["5.1:1"]
-source = """
-fn main() -> i32 {
-    let x = 10;
-    let y = 20;
-    x + y
-}
-"""
-exit_code = 30
-
-[[case]]
-name = "expression_after_statements"
-spec = ["5.1:1"]
-source = """
-fn main() -> i32 {
-    let a = 1;
-    let b = 2;
-    let c = 3;
-    a + b + c
-}
-"""
-exit_code = 6
 
 [[case]]
 name = "assignment_is_statement"
@@ -384,16 +203,13 @@ exit_code = 10
 # =============================================================================
 
 [[case]]
-name = "let_single_line"
+name = "let_formatting_{variant}"
 spec = ["5.1:1"]
-source = "fn main() -> i32 { let x = 42; x }"
-exit_code = 42
-
-[[case]]
-name = "let_compact"
-spec = ["5.1:1"]
-source = "fn main() -> i32 { let x=1+2; x }"
-exit_code = 3
+source = "{source}"
+params = [
+  { variant = "single_line", source = "fn main() -> i32 { let x = 42; x }", exit_code = 42 },
+  { variant = "compact", source = "fn main() -> i32 { let x=1+2; x }", exit_code = 3 },
+]
 
 [[case]]
 name = "let_extra_whitespace"
@@ -423,48 +239,20 @@ exit_code = 42
 # =============================================================================
 
 [[case]]
-name = "let_zero"
+name = "let_edge_{variant}"
 spec = ["5.1:1"]
 source = """
 fn main() -> i32 {
-    let x = 0;
-    x
+    let x = {value};
+    {expr}
 }
 """
-exit_code = 0
-
-[[case]]
-name = "let_negative"
-spec = ["5.1:1"]
-source = """
-fn main() -> i32 {
-    let x = -1;
-    x
-}
-"""
-exit_code = 255
-
-[[case]]
-name = "let_max_i32"
-spec = ["5.1:1"]
-source = """
-fn main() -> i32 {
-    let x = 2147483647;
-    x
-}
-"""
-exit_code = 255
-
-[[case]]
-name = "unused_variable"
-spec = ["5.1:1"]
-source = """
-fn main() -> i32 {
-    let x = 42;
-    0
-}
-"""
-exit_code = 0
+params = [
+  { variant = "zero", value = "0", expr = "x", exit_code = 0 },
+  { variant = "negative", value = "-1", expr = "x", exit_code = 255 },
+  { variant = "max_i32", value = "2147483647", expr = "x", exit_code = 255 },
+  { variant = "unused", value = "42", expr = "0", exit_code = 0 },
+]
 
 [[case]]
 name = "many_variables"
@@ -486,86 +274,40 @@ exit_code = 15
 # =============================================================================
 
 [[case]]
-name = "underscore_name"
+name = "variable_name_{variant}"
 spec = ["5.1:1"]
 source = """
 fn main() -> i32 {
-    let _x = 42;
-    _x
+    {body}
 }
 """
-exit_code = 42
-
-[[case]]
-name = "underscore_only"
-spec = ["5.1:1", "2.1:12"]
-source = """
-fn main() -> i32 {
-    let _ = 42;
-    0
-}
-"""
-exit_code = 0
-
-[[case]]
-name = "long_name"
-spec = ["5.1:1"]
-source = """
-fn main() -> i32 {
-    let my_very_long_variable_name = 42;
-    my_very_long_variable_name
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "name_with_numbers"
-spec = ["5.1:1"]
-source = """
-fn main() -> i32 {
-    let x1 = 10;
-    let x2 = 20;
-    x1 + x2
-}
-"""
-exit_code = 30
-
-[[case]]
-name = "mixed_case_name"
-spec = ["5.1:1"]
-source = """
-fn main() -> i32 {
-    let myVar = 42;
-    myVar
-}
-"""
-exit_code = 42
+params = [
+  { variant = "underscore_prefix", body = "let _x = 42; _x", exit_code = 42 },
+  { variant = "underscore_only", body = "let _ = 42; 0", exit_code = 0, spec_extra = ["2.1:12"] },
+  { variant = "long", body = "let my_very_long_variable_name = 42; my_very_long_variable_name", exit_code = 42 },
+  { variant = "with_numbers", body = "let x1 = 10; let x2 = 20; x1 + x2", exit_code = 30 },
+  { variant = "mixed_case", body = "let myVar = 42; myVar", exit_code = 42 },
+]
 
 # =============================================================================
 # Block Scoping
 # =============================================================================
 
 [[case]]
-name = "nested_block_simple"
+name = "nested_block_{variant}"
 spec = ["4.5:1"]
 source = """
 fn main() -> i32 {
-    let x = 10;
-    { 20 }
+    {body}
 }
 """
-exit_code = 20
-
-[[case]]
-name = "nested_block_uses_outer"
-spec = ["4.5:1"]
-source = """
-fn main() -> i32 {
-    let x = 10;
-    { x + 5 }
-}
-"""
-exit_code = 15
+params = [
+  { variant = "simple", body = "let x = 10; { 20 }", exit_code = 20 },
+  { variant = "uses_outer", body = "let x = 10; { x + 5 }", exit_code = 15 },
+  { variant = "as_expression", body = "{ 42 }", exit_code = 42 },
+  { variant = "with_arithmetic", body = "{ 10 + 20 + 12 }", exit_code = 42 },
+  { variant = "in_expression", body = "1 + { 2 } + 3", exit_code = 6 },
+]
 
 [[case]]
 name = "block_scoped_variable"
@@ -630,26 +372,6 @@ fn main() -> i32 {
 exit_code = 6
 
 [[case]]
-name = "block_as_expression"
-spec = ["4.5:1"]
-source = """
-fn main() -> i32 {
-    { 42 }
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "block_with_arithmetic"
-spec = ["4.5:1"]
-source = """
-fn main() -> i32 {
-    { 10 + 20 + 12 }
-}
-"""
-exit_code = 42
-
-[[case]]
 name = "sequential_blocks"
 spec = ["4.5:1"]
 source = """
@@ -660,16 +382,6 @@ fn main() -> i32 {
 }
 """
 exit_code = 30
-
-[[case]]
-name = "block_in_expression"
-spec = ["4.5:1"]
-source = """
-fn main() -> i32 {
-    1 + { 2 } + 3
-}
-"""
-exit_code = 6
 
 [[case]]
 name = "block_with_mutable_outer"

--- a/docs/designs/0015-test-suite-optimization.md
+++ b/docs/designs/0015-test-suite-optimization.md
@@ -184,10 +184,11 @@ Add a new script `./quick-test.sh` that runs only unit tests for faster iteratio
   - Fixed traceability report to handle parameterized tests with `spec_extra`
   - Verified 100% spec coverage maintained via traceability check
 
-- [ ] **Phase 3: Consolidate Other Spec Tests** - rue-9jdv.3
-  - Consolidate `arithmetic.toml`, `let.toml`, `functions.toml` (inout section)
-  - Review and consolidate remaining test files
-  - Target: Total ~1,083 → ~400-500 cases
+- [x] **Phase 3: Consolidate Other Spec Tests** - rue-9jdv.3
+  - Consolidated `arithmetic.toml` (530→274 lines), `let.toml` (688→400 lines)
+  - Consolidated `functions.toml` (1405→800 lines, heavily reduced inout section)
+  - Consolidated `bitwise.toml` (550→325 lines), `comparison.toml` (439→274 lines)
+  - All 1021 tests pass with 100% normative spec coverage maintained
 
 - [ ] **Phase 4: Integration Unit Tests** - rue-9jdv.4
   - Add `compile_to_air()` and `compile_to_cfg()` test helpers to `rue-compiler`


### PR DESCRIPTION
Reduced test file sizes significantly while maintaining 100% normative spec coverage:
- arithmetic.toml: 530→274 lines
- let.toml: 688→400 lines  
- functions.toml: 1405→800 lines
- bitwise.toml: 550→325 lines
- comparison.toml: 439→274 lines

All 1021 spec tests pass. Traceability check confirms 100% normative coverage.

Implements rue-9jdv.3 from ADR-0015.

🤖 Generated with [Claude Code](https://claude.com/claude-code)