### PR TITLE
feat: implement String::clone method (Phase 8)

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -3584,8 +3584,10 @@ impl<'a> Sema<'a> {
                     // String query methods (len, capacity, is_empty) use borrow semantics.
                     // The receiver was marked as moved during analysis, but we need to
                     // "unmove" it since it's actually being borrowed, not consumed.
-                    let is_borrow_method =
-                        matches!(method_name_str.as_str(), "len" | "capacity" | "is_empty");
+                    let is_borrow_method = matches!(
+                        method_name_str.as_str(),
+                        "len" | "capacity" | "is_empty" | "clone"
+                    );
                     if is_borrow_method {
                         if let Some(var_symbol) = receiver_var {
                             ctx.moved_vars.remove(&var_symbol);
@@ -4745,6 +4747,36 @@ impl<'a> Sema<'a> {
                     span,
                 });
                 Ok(AnalysisResult::new(air_ref, Type::Bool))
+            }
+
+            "clone" => {
+                // fn clone(borrow self) -> String
+                // Creates a deep copy of the string
+                if !args.is_empty() {
+                    return Err(CompileError::new(
+                        ErrorKind::WrongArgumentCount {
+                            expected: 0,
+                            found: args.len(),
+                        },
+                        span,
+                    ));
+                }
+
+                // Generate a call to String__clone (runtime function)
+                // Takes the String (ptr, len, cap) and returns a new String (ptr, len, cap)
+                // where the new ptr points to freshly allocated memory with copied content.
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::Call {
+                        name: "String__clone".to_string(),
+                        args: vec![AirCallArg {
+                            value: receiver.air_ref,
+                            mode: AirArgMode::Normal,
+                        }],
+                    },
+                    ty: Type::String,
+                    span,
+                });
+                Ok(AnalysisResult::new(air_ref, Type::String))
             }
 
             _ => {

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -1133,6 +1133,117 @@ pub extern "C" fn String__is_empty(_ptr: *const u8, len: u64, _cap: u64) -> u8 {
 }
 
 // =============================================================================
+// String Clone Method (Phase 8)
+// =============================================================================
+//
+// Clone creates a deep copy of a String. It uses `borrow self` semantics -
+// the original String is not consumed.
+//
+// ABI: String is passed as 3 separate arguments (ptr, len, cap)
+// - x86-64: ptr in rdi, len in rsi, cap in rdx; returns ptr in rax, len in rdx, cap in rcx
+// - aarch64: ptr in x0, len in x1, cap in x2; returns ptr in x0, len in x1, cap in x2
+
+/// Clone a String, creating a deep copy.
+///
+/// # Arguments
+///
+/// * `ptr` - Pointer to the source string data
+/// * `len` - Length of the string in bytes
+/// * `cap` - Capacity (unused for cloning, but part of ABI)
+///
+/// # Returns
+///
+/// A new String (ptr, len, cap) where:
+/// - ptr points to freshly allocated memory containing a copy of the content
+/// - len is the same as the input len
+/// - cap is at least len (minimum STRING_MIN_CAPACITY)
+///
+/// # Behavior
+///
+/// Always allocates a new heap buffer, even for literals (cap == 0).
+/// The clone is always heap-allocated so it can be mutated.
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__clone(ptr: *const u8, len: u64, _cap: u64) -> u64 {
+    // Allocate new buffer with capacity >= len
+    let new_cap = len.max(STRING_MIN_CAPACITY);
+    let new_ptr = heap::alloc(new_cap, 1);
+
+    // Copy the string content
+    if len > 0 && !ptr.is_null() {
+        unsafe {
+            core::ptr::copy_nonoverlapping(ptr, new_ptr, len as usize);
+        }
+    }
+
+    // Return ptr in rax, len in rdx, cap in rcx
+    unsafe {
+        core::arch::asm!(
+            "",
+            in("rdx") len,
+            in("rcx") new_cap,
+            options(nostack, nomem),
+        );
+    }
+    new_ptr as u64
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__clone(ptr: *const u8, len: u64, _cap: u64) -> u64 {
+    // Allocate new buffer with capacity >= len
+    let new_cap = len.max(STRING_MIN_CAPACITY);
+    let new_ptr = heap::alloc(new_cap, 1);
+
+    // Copy the string content
+    if len > 0 && !ptr.is_null() {
+        unsafe {
+            core::ptr::copy_nonoverlapping(ptr, new_ptr, len as usize);
+        }
+    }
+
+    // Return ptr in x0, len in x1, cap in x2
+    unsafe {
+        core::arch::asm!(
+            "",
+            in("x1") len,
+            in("x2") new_cap,
+            options(nostack, nomem),
+        );
+    }
+    new_ptr as u64
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn String__clone(ptr: *const u8, len: u64, _cap: u64) -> u64 {
+    // Allocate new buffer with capacity >= len
+    let new_cap = len.max(STRING_MIN_CAPACITY);
+    let new_ptr = heap::alloc(new_cap, 1);
+
+    // Copy the string content
+    if len > 0 && !ptr.is_null() {
+        unsafe {
+            core::ptr::copy_nonoverlapping(ptr, new_ptr, len as usize);
+        }
+    }
+
+    // Return ptr in x0, len in x1, cap in x2
+    unsafe {
+        core::arch::asm!(
+            "",
+            in("x1") len,
+            in("x2") new_cap,
+            options(nostack, nomem),
+        );
+    }
+    new_ptr as u64
+}
+
+// =============================================================================
 // String Mutation Methods (Phase 7: push_str, push, clear, reserve)
 // =============================================================================
 //

--- a/docs/designs/0014-mutable-strings.md
+++ b/docs/designs/0014-mutable-strings.md
@@ -354,12 +354,12 @@ Add mutation methods with `inout self` (gated):
 
 **Testable**: Build strings through multiple appends.
 
-### Phase 8: Clone Method
+### Phase 8: Clone Method - rue-0hef.8 (COMPLETE)
 
 Add explicit cloning (gated):
 
-- `fn clone(borrow self) -> String`
-- Deep copy via `__rue_string_clone`
+- [x] `fn clone(borrow self) -> String`
+- [x] Deep copy via `String__clone` runtime function
 
 **Testable**: Clone a string, verify both are independent.
 


### PR DESCRIPTION
Add clone(borrow self) -> String method to mutable strings.

- Add 'clone' to borrow method handling in Sema
- Implement String__clone runtime function for all 3 platforms (x86_64 Linux, aarch64 macOS, aarch64 Linux)
- Clone always allocates a new heap buffer and copies content
- Uses borrow semantics so original string remains valid after clone

Fixes rue-0hef.8

🤖 Generated with [Claude Code](https://claude.com/claude-code)