### PR TITLE
Add tests for spill slot conflicts and large stack frames

### DIFF
--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -1111,4 +1111,284 @@ mod tests {
             }
         }
     }
+
+    // ========================================
+    // Spill slot conflict tests
+    // ========================================
+
+    #[test]
+    fn test_spill_inserts_load_store() {
+        // Force a spill and verify load/store instructions are inserted
+        let mut mir = Aarch64Mir::new();
+
+        // Create 11 vregs to force spilling (10 allocatable regs: X19-X28)
+        let vregs: Vec<VReg> = (0..11).map(|_| mir.alloc_vreg()).collect();
+
+        for (i, &vreg) in vregs.iter().enumerate() {
+            mir.push(Aarch64Inst::MovImm {
+                dst: Operand::Virtual(vreg),
+                imm: i as i64,
+            });
+        }
+
+        for &vreg in &vregs {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+
+        assert_eq!(num_spills, 1, "Should have exactly 1 spill");
+
+        // Verify there's at least one Str (store to stack) and Ldr (load from stack)
+        let has_store = mir
+            .instructions()
+            .iter()
+            .any(|inst| matches!(inst, Aarch64Inst::Str { base: Reg::Fp, .. }));
+        let has_load = mir
+            .instructions()
+            .iter()
+            .any(|inst| matches!(inst, Aarch64Inst::Ldr { base: Reg::Fp, .. }));
+
+        assert!(has_store, "Should have a store to stack");
+        assert!(has_load, "Should have a load from stack");
+    }
+
+    #[test]
+    fn test_multiple_spills_unique_offsets() {
+        // Force multiple spills and verify they get unique stack offsets
+        let mut mir = Aarch64Mir::new();
+
+        // Create 15 vregs to force 5 spills (10 allocatable regs)
+        let vregs: Vec<VReg> = (0..15).map(|_| mir.alloc_vreg()).collect();
+
+        for (i, &vreg) in vregs.iter().enumerate() {
+            mir.push(Aarch64Inst::MovImm {
+                dst: Operand::Virtual(vreg),
+                imm: i as i64,
+            });
+        }
+
+        for &vreg in &vregs {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+
+        assert_eq!(num_spills, 5);
+
+        // Collect all unique stack offsets used in loads/stores
+        let mut offsets = std::collections::HashSet::new();
+        for inst in mir.instructions() {
+            match inst {
+                Aarch64Inst::Str {
+                    base: Reg::Fp,
+                    offset,
+                    ..
+                } => {
+                    offsets.insert(*offset);
+                }
+                Aarch64Inst::Ldr {
+                    base: Reg::Fp,
+                    offset,
+                    ..
+                } => {
+                    offsets.insert(*offset);
+                }
+                _ => {}
+            }
+        }
+
+        // Each spilled vreg should use a unique offset
+        assert_eq!(
+            offsets.len(),
+            5,
+            "Each spill should use a unique stack offset"
+        );
+    }
+
+    #[test]
+    fn test_spill_with_existing_locals() {
+        // Test that spills are placed after existing local variables
+        let mut mir = Aarch64Mir::new();
+
+        // 11 vregs forces 1 spill
+        let vregs: Vec<VReg> = (0..11).map(|_| mir.alloc_vreg()).collect();
+
+        for vreg in &vregs {
+            mir.push(Aarch64Inst::MovImm {
+                dst: Operand::Virtual(*vreg),
+                imm: 42,
+            });
+        }
+        for vreg in &vregs {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(*vreg),
+            });
+        }
+
+        // Pass 5 existing locals - spills should start at -48 (= -(5+1)*8)
+        let (mir, num_spills, _) = RegAlloc::new(mir, 5).allocate_with_spills().unwrap();
+
+        assert_eq!(num_spills, 1);
+
+        // Find the spill offset
+        let spill_offset = mir
+            .instructions()
+            .iter()
+            .find_map(|inst| match inst {
+                Aarch64Inst::Str {
+                    base: Reg::Fp,
+                    offset,
+                    ..
+                } => Some(*offset),
+                _ => None,
+            })
+            .expect("Should have a spill store");
+
+        // First spill with 5 existing locals should be at -48
+        assert_eq!(spill_offset, -48);
+    }
+
+    // ========================================
+    // Large stack frame tests
+    // ========================================
+
+    #[test]
+    fn test_many_vregs_large_frame() {
+        // Test a function with many virtual registers causing a large stack frame
+        let mut mir = Aarch64Mir::new();
+
+        // Create 25 vregs (10 registers + 15 spills)
+        let vregs: Vec<VReg> = (0..25).map(|_| mir.alloc_vreg()).collect();
+
+        for (i, &vreg) in vregs.iter().enumerate() {
+            mir.push(Aarch64Inst::MovImm {
+                dst: Operand::Virtual(vreg),
+                imm: i as i64,
+            });
+        }
+
+        for &vreg in &vregs {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+
+        assert_eq!(num_spills, 15);
+
+        // Verify all virtual registers were replaced with physical
+        for inst in mir.instructions() {
+            match inst {
+                Aarch64Inst::MovImm { dst, .. } => {
+                    assert!(dst.is_physical());
+                }
+                Aarch64Inst::MovRR { dst, src } => {
+                    assert!(dst.is_physical());
+                    assert!(src.is_physical());
+                }
+                Aarch64Inst::Ldr { dst, .. } => {
+                    assert!(dst.is_physical());
+                }
+                Aarch64Inst::Str { src, .. } => {
+                    assert!(src.is_physical());
+                }
+                _ => {}
+            }
+        }
+    }
+
+    #[test]
+    fn test_spill_with_many_locals() {
+        // Test spilling with many existing local variables
+        let mut mir = Aarch64Mir::new();
+
+        // 11 vregs forces 1 spill
+        let vregs: Vec<VReg> = (0..11).map(|_| mir.alloc_vreg()).collect();
+
+        for vreg in &vregs {
+            mir.push(Aarch64Inst::MovImm {
+                dst: Operand::Virtual(*vreg),
+                imm: 1,
+            });
+        }
+        for vreg in &vregs {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(*vreg),
+            });
+        }
+
+        // 50 existing locals - spill at -408 (= -(50+1)*8)
+        let (mir, num_spills, _) = RegAlloc::new(mir, 50).allocate_with_spills().unwrap();
+
+        assert_eq!(num_spills, 1);
+
+        let spill_offset = mir
+            .instructions()
+            .iter()
+            .find_map(|inst| match inst {
+                Aarch64Inst::Str {
+                    base: Reg::Fp,
+                    offset,
+                    ..
+                } => Some(*offset),
+                _ => None,
+            })
+            .expect("Should have a spill store");
+
+        assert_eq!(spill_offset, -408);
+    }
+
+    #[test]
+    fn test_ternop_with_spilled_operands() {
+        // Test that ternary operations work correctly when operands are spilled
+        let mut mir = Aarch64Mir::new();
+
+        // Create enough vregs to force spilling
+        let vregs: Vec<VReg> = (0..13).map(|_| mir.alloc_vreg()).collect();
+
+        // Initialize all
+        for (i, &vreg) in vregs.iter().enumerate() {
+            mir.push(Aarch64Inst::MovImm {
+                dst: Operand::Virtual(vreg),
+                imm: i as i64,
+            });
+        }
+
+        // Add using potentially spilled operands
+        mir.push(Aarch64Inst::AddRR {
+            dst: Operand::Virtual(vregs[0]),
+            src1: Operand::Virtual(vregs[11]),
+            src2: Operand::Virtual(vregs[12]),
+        });
+
+        // Use all to keep them live
+        for &vreg in &vregs {
+            mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+
+        assert!(num_spills >= 3, "Should have some spills");
+
+        // Verify the AddRR was properly rewritten
+        let has_add = mir.instructions().iter().any(|inst| {
+            matches!(inst, Aarch64Inst::AddRR { dst, src1, src2 }
+                if dst.is_physical() && src1.is_physical() && src2.is_physical())
+        });
+        assert!(has_add, "AddRR should be rewritten with physical registers");
+    }
 }

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -528,4 +528,219 @@ mod tests {
         assert_eq!(spill0, -24); // First spill
         assert_eq!(spill1, -32); // Second spill
     }
+
+    // ========================================
+    // Spill slot conflict tests
+    // ========================================
+
+    #[test]
+    fn test_multiple_overlapping_spills_get_unique_offsets() {
+        // With only 1 register and 5 overlapping live ranges,
+        // we need 4 spills with unique offsets.
+        let allocatable = vec![TestReg(0)];
+        let liveness = make_liveness(vec![
+            (0, 0, 10), // v0 - longest
+            (1, 1, 9),  // v1
+            (2, 2, 8),  // v2
+            (3, 3, 7),  // v3
+            (4, 4, 6),  // v4 - gets the register (shortest remaining)
+        ]);
+
+        let (allocation, num_spills, _) = linear_scan(5, &liveness, &allocatable, 0);
+
+        assert_eq!(num_spills, 4);
+
+        // Collect all spill offsets
+        let mut offsets = Vec::new();
+        for vreg_idx in 0..5 {
+            if let Some(Allocation::Spill(off)) = allocation[VReg::new(vreg_idx)] {
+                offsets.push(off);
+            }
+        }
+
+        // All spill offsets should be unique
+        let unique_offsets: std::collections::HashSet<_> = offsets.iter().copied().collect();
+        assert_eq!(
+            offsets.len(),
+            unique_offsets.len(),
+            "Spill offsets must be unique: {:?}",
+            offsets
+        );
+    }
+
+    #[test]
+    fn test_spill_slots_dont_overlap_with_locals() {
+        // With 10 existing locals (slots at -8 through -80), spills should start at -88
+        let allocatable = vec![TestReg(0)];
+        let liveness = make_liveness(vec![
+            (0, 0, 5), // v0 - will be spilled (longer)
+            (1, 1, 4), // v1 - gets the register (shorter)
+        ]);
+
+        let (allocation, num_spills, _) = linear_scan(2, &liveness, &allocatable, 10);
+
+        assert_eq!(num_spills, 1);
+
+        let spill_off = match allocation[VReg::new(0)] {
+            Some(Allocation::Spill(off)) => off,
+            _ => panic!("v0 should be spilled"),
+        };
+
+        // With 10 existing locals, first spill should be at -(10+1)*8 = -88
+        assert_eq!(spill_off, -88);
+    }
+
+    #[test]
+    fn test_many_simultaneous_spills() {
+        // Test a scenario where many vregs are live simultaneously, causing many spills
+        let allocatable = vec![TestReg(0), TestReg(1)]; // Only 2 registers
+
+        // 10 vregs all live for the entire range [0, 20]
+        let liveness = make_liveness((0..10).map(|i| (i, 0, 20)).collect());
+
+        let (allocation, num_spills, _) = linear_scan(10, &liveness, &allocatable, 0);
+
+        // With 10 vregs and 2 registers, we should have 8 spills
+        assert_eq!(num_spills, 8);
+
+        // Verify all spill offsets are unique
+        let spill_offsets: Vec<i32> = (0..10)
+            .filter_map(|i| match allocation[VReg::new(i)] {
+                Some(Allocation::Spill(off)) => Some(off),
+                _ => None,
+            })
+            .collect();
+
+        let unique: std::collections::HashSet<_> = spill_offsets.iter().copied().collect();
+        assert_eq!(
+            spill_offsets.len(),
+            unique.len(),
+            "All spill offsets must be unique"
+        );
+
+        // Verify spill offsets are sequential 8-byte aligned
+        // Offsets are negative, so sorted goes from most negative to least negative
+        let mut sorted = spill_offsets.clone();
+        sorted.sort();
+        for i in 1..sorted.len() {
+            assert_eq!(
+                sorted[i] - sorted[i - 1],
+                8,
+                "Spill offsets should be 8 bytes apart"
+            );
+        }
+    }
+
+    // ========================================
+    // Large stack frame tests
+    // ========================================
+
+    #[test]
+    fn test_large_stack_frame_many_locals() {
+        // Function with 100 locals - spills start after those
+        let allocatable = vec![TestReg(0)];
+        let liveness = make_liveness(vec![
+            (0, 0, 3), // v0 - spilled
+            (1, 1, 2), // v1 - gets register
+        ]);
+
+        let (allocation, num_spills, _) = linear_scan(2, &liveness, &allocatable, 100);
+
+        assert_eq!(num_spills, 1);
+
+        let spill_off = match allocation[VReg::new(0)] {
+            Some(Allocation::Spill(off)) => off,
+            _ => panic!("v0 should be spilled"),
+        };
+
+        // With 100 existing locals, first spill is at -(100+1)*8 = -808
+        assert_eq!(spill_off, -808);
+    }
+
+    #[test]
+    fn test_large_number_of_spills() {
+        // 50 vregs all live simultaneously with only 2 registers = 48 spills
+        let allocatable = vec![TestReg(0), TestReg(1)];
+        let liveness = make_liveness((0..50).map(|i| (i, 0, 100)).collect());
+
+        let (allocation, num_spills, _) = linear_scan(50, &liveness, &allocatable, 0);
+
+        assert_eq!(num_spills, 48);
+
+        // First spill should be at -8, last at -8 * 48 = -384
+        let spill_offsets: Vec<i32> = (0..50)
+            .filter_map(|i| match allocation[VReg::new(i)] {
+                Some(Allocation::Spill(off)) => Some(off),
+                _ => None,
+            })
+            .collect();
+
+        assert_eq!(spill_offsets.len(), 48);
+
+        let min_offset = *spill_offsets.iter().min().unwrap();
+        let max_offset = *spill_offsets.iter().max().unwrap();
+
+        // Most negative offset should be -(48)*8 = -384 (spill slots grow down)
+        assert_eq!(min_offset, -384);
+        // Least negative offset should be -8 (first spill)
+        assert_eq!(max_offset, -8);
+    }
+
+    #[test]
+    fn test_combined_locals_and_spills() {
+        // 20 locals + 30 vregs with 5 registers = 25 spills
+        // Spills should start at -(20+1)*8 = -168
+        let allocatable = vec![TestReg(0), TestReg(1), TestReg(2), TestReg(3), TestReg(4)];
+        let liveness = make_liveness((0..30).map(|i| (i, 0, 50)).collect());
+
+        let (allocation, num_spills, _) = linear_scan(30, &liveness, &allocatable, 20);
+
+        assert_eq!(num_spills, 25);
+
+        let spill_offsets: Vec<i32> = (0..30)
+            .filter_map(|i| match allocation[VReg::new(i)] {
+                Some(Allocation::Spill(off)) => Some(off),
+                _ => None,
+            })
+            .collect();
+
+        // First spill should be at -(20+1)*8 = -168 (after 20 locals)
+        let max_offset = *spill_offsets.iter().max().unwrap();
+        assert_eq!(max_offset, -168);
+
+        // Last spill should be at -(20+25)*8 = -360
+        let min_offset = *spill_offsets.iter().min().unwrap();
+        assert_eq!(min_offset, -360);
+    }
+
+    #[test]
+    fn test_register_reuse_across_non_overlapping_spills() {
+        // If a vreg is spilled but its spill slot is freed, a new spill
+        // can reuse that slot. However, in linear scan, spill slots are
+        // allocated once and not reclaimed (simpler implementation).
+        // This test verifies the current behavior.
+        let allocatable = vec![TestReg(0)];
+        let liveness = make_liveness(vec![
+            (0, 0, 2), // v0 - first
+            (1, 1, 3), // v1 - overlaps v0, one spilled
+            (2, 5, 7), // v2 - non-overlapping, separate spill
+            (3, 6, 8), // v3 - overlaps v2, one spilled
+        ]);
+
+        let (allocation, num_spills, _) = linear_scan(4, &liveness, &allocatable, 0);
+
+        // Two separate spilling events, each spills one vreg
+        assert_eq!(num_spills, 2);
+
+        // Verify both spills have different offsets (no reuse in current impl)
+        let spill_offsets: Vec<i32> = (0..4)
+            .filter_map(|i| match allocation[VReg::new(i)] {
+                Some(Allocation::Spill(off)) => Some(off),
+                _ => None,
+            })
+            .collect();
+
+        let unique: std::collections::HashSet<_> = spill_offsets.iter().copied().collect();
+        assert_eq!(spill_offsets.len(), unique.len());
+    }
 }

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -1010,4 +1010,290 @@ mod tests {
 
         assert_ne!(d0, d1, "interfering vregs should get different registers");
     }
+
+    // ========================================
+    // Spill slot conflict tests
+    // ========================================
+
+    #[test]
+    fn test_spill_inserts_load_store() {
+        // Force a spill and verify load/store instructions are inserted
+        let mut mir = X86Mir::new();
+
+        // Create 6 vregs to force spilling (only 5 allocatable regs: R12-R15, Rbx)
+        let vregs: Vec<VReg> = (0..6).map(|_| mir.alloc_vreg()).collect();
+
+        // Define all vregs
+        for (i, &vreg) in vregs.iter().enumerate() {
+            mir.push(X86Inst::MovRI32 {
+                dst: Operand::Virtual(vreg),
+                imm: i as i32,
+            });
+        }
+
+        // Use all vregs to keep them live
+        for &vreg in &vregs {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+
+        assert_eq!(num_spills, 1, "Should have exactly 1 spill");
+
+        // Verify there's at least one MovMR (store to stack) and MovRM (load from stack)
+        let has_store = mir
+            .instructions()
+            .iter()
+            .any(|inst| matches!(inst, X86Inst::MovMR { base: Reg::Rbp, .. }));
+        let has_load = mir
+            .instructions()
+            .iter()
+            .any(|inst| matches!(inst, X86Inst::MovRM { base: Reg::Rbp, .. }));
+
+        assert!(has_store, "Should have a store to stack");
+        assert!(has_load, "Should have a load from stack");
+    }
+
+    #[test]
+    fn test_multiple_spills_unique_offsets() {
+        // Force multiple spills and verify they get unique stack offsets
+        let mut mir = X86Mir::new();
+
+        // Create 10 vregs to force 5 spills
+        let vregs: Vec<VReg> = (0..10).map(|_| mir.alloc_vreg()).collect();
+
+        for (i, &vreg) in vregs.iter().enumerate() {
+            mir.push(X86Inst::MovRI32 {
+                dst: Operand::Virtual(vreg),
+                imm: i as i32,
+            });
+        }
+
+        for &vreg in &vregs {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+
+        assert_eq!(num_spills, 5);
+
+        // Collect all unique stack offsets used in loads/stores
+        let mut offsets = std::collections::HashSet::new();
+        for inst in mir.instructions() {
+            match inst {
+                X86Inst::MovMR {
+                    base: Reg::Rbp,
+                    offset,
+                    ..
+                } => {
+                    offsets.insert(*offset);
+                }
+                X86Inst::MovRM {
+                    base: Reg::Rbp,
+                    offset,
+                    ..
+                } => {
+                    offsets.insert(*offset);
+                }
+                _ => {}
+            }
+        }
+
+        // Each spilled vreg should use a unique offset
+        assert_eq!(
+            offsets.len(),
+            5,
+            "Each spill should use a unique stack offset"
+        );
+    }
+
+    #[test]
+    fn test_spill_with_existing_locals() {
+        // Test that spills are placed after existing local variables
+        let mut mir = X86Mir::new();
+
+        let v0 = mir.alloc_vreg();
+        let v1 = mir.alloc_vreg();
+        let v2 = mir.alloc_vreg();
+        let v3 = mir.alloc_vreg();
+        let v4 = mir.alloc_vreg();
+        let v5 = mir.alloc_vreg();
+
+        // Define and use all vregs
+        for vreg in [v0, v1, v2, v3, v4, v5] {
+            mir.push(X86Inst::MovRI32 {
+                dst: Operand::Virtual(vreg),
+                imm: 42,
+            });
+        }
+        for vreg in [v0, v1, v2, v3, v4, v5] {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        // Pass 5 existing locals - spills should start at -48 (= -(5+1)*8)
+        let (mir, num_spills, _) = RegAlloc::new(mir, 5).allocate_with_spills().unwrap();
+
+        assert_eq!(num_spills, 1);
+
+        // Find the spill offset
+        let spill_offset = mir
+            .instructions()
+            .iter()
+            .find_map(|inst| match inst {
+                X86Inst::MovMR {
+                    base: Reg::Rbp,
+                    offset,
+                    ..
+                } => Some(*offset),
+                _ => None,
+            })
+            .expect("Should have a spill store");
+
+        // First spill with 5 existing locals should be at -48
+        assert_eq!(spill_offset, -48);
+    }
+
+    // ========================================
+    // Large stack frame tests
+    // ========================================
+
+    #[test]
+    fn test_many_vregs_large_frame() {
+        // Test a function with many virtual registers causing a large stack frame
+        let mut mir = X86Mir::new();
+
+        // Create 20 vregs (5 registers + 15 spills)
+        let vregs: Vec<VReg> = (0..20).map(|_| mir.alloc_vreg()).collect();
+
+        for (i, &vreg) in vregs.iter().enumerate() {
+            mir.push(X86Inst::MovRI32 {
+                dst: Operand::Virtual(vreg),
+                imm: i as i32,
+            });
+        }
+
+        for &vreg in &vregs {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+
+        assert_eq!(num_spills, 15);
+
+        // Verify all virtual registers were replaced with physical
+        for inst in mir.instructions() {
+            match inst {
+                X86Inst::MovRI32 { dst, .. } => {
+                    assert!(dst.is_physical());
+                }
+                X86Inst::MovRR { dst, src } => {
+                    assert!(dst.is_physical());
+                    assert!(src.is_physical());
+                }
+                X86Inst::MovRM { dst, .. } => {
+                    assert!(dst.is_physical());
+                }
+                X86Inst::MovMR { src, .. } => {
+                    assert!(src.is_physical());
+                }
+                _ => {}
+            }
+        }
+    }
+
+    #[test]
+    fn test_spill_with_many_locals() {
+        // Test spilling with many existing local variables
+        let mut mir = X86Mir::new();
+
+        // 6 vregs forces 1 spill
+        let vregs: Vec<VReg> = (0..6).map(|_| mir.alloc_vreg()).collect();
+
+        for vreg in &vregs {
+            mir.push(X86Inst::MovRI32 {
+                dst: Operand::Virtual(*vreg),
+                imm: 1,
+            });
+        }
+        for vreg in &vregs {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(*vreg),
+            });
+        }
+
+        // 50 existing locals - spill at -408 (= -(50+1)*8)
+        let (mir, num_spills, _) = RegAlloc::new(mir, 50).allocate_with_spills().unwrap();
+
+        assert_eq!(num_spills, 1);
+
+        let spill_offset = mir
+            .instructions()
+            .iter()
+            .find_map(|inst| match inst {
+                X86Inst::MovMR {
+                    base: Reg::Rbp,
+                    offset,
+                    ..
+                } => Some(*offset),
+                _ => None,
+            })
+            .expect("Should have a spill store");
+
+        assert_eq!(spill_offset, -408);
+    }
+
+    #[test]
+    fn test_binop_with_spilled_operands() {
+        // Test that binary operations work correctly when operands are spilled
+        let mut mir = X86Mir::new();
+
+        // Create enough vregs to force spilling
+        let vregs: Vec<VReg> = (0..8).map(|_| mir.alloc_vreg()).collect();
+
+        // Initialize all
+        for (i, &vreg) in vregs.iter().enumerate() {
+            mir.push(X86Inst::MovRI32 {
+                dst: Operand::Virtual(vreg),
+                imm: i as i32,
+            });
+        }
+
+        // Add using potentially spilled operands
+        mir.push(X86Inst::AddRR {
+            dst: Operand::Virtual(vregs[0]),
+            src: Operand::Virtual(vregs[7]),
+        });
+
+        // Use all to keep them live
+        for &vreg in &vregs {
+            mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(vreg),
+            });
+        }
+
+        let (mir, num_spills, _) = RegAlloc::new(mir, 0).allocate_with_spills().unwrap();
+
+        assert!(num_spills >= 3, "Should have some spills");
+
+        // Verify the AddRR was properly rewritten
+        let has_add = mir
+            .instructions()
+            .iter()
+            .any(|inst| matches!(inst, X86Inst::AddRR { dst, src } if dst.is_physical() && src.is_physical()));
+        assert!(has_add, "AddRR should be rewritten with physical registers");
+    }
 }


### PR DESCRIPTION
Add comprehensive unit tests to the register allocator verifying:
- Multiple spills get unique stack offsets
- Spill slots don't overlap with existing local variables
- Large numbers of simultaneous spills work correctly
- Large stack frames with many locals handle spills properly
- Binary/ternary operations work with spilled operands

Tests are added to:
- Shared regalloc.rs (algorithm-level tests)
- x86_64/regalloc.rs (backend integration tests)
- aarch64/regalloc.rs (backend integration tests)

Fixes rue-5zr6

🤖 Generated with [Claude Code](https://claude.com/claude-code)