### PR TITLE
Extract shared enums from cfg_lower modules

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -11,6 +11,7 @@ use rue_cfg::{
 };
 
 use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Operand, Reg, VReg};
+use crate::cfg_lower::{FieldChainBase, IndexChainBase, IndexLevel};
 use crate::types;
 
 /// Argument passing registers per AAPCS64.
@@ -36,36 +37,6 @@ const RET_REGS: [Reg; 8] = [
     Reg::X6,
     Reg::X7,
 ];
-
-/// Result of tracing back through FieldGet chains to find the original source.
-enum FieldChainBase {
-    /// Chain originates from a Load instruction with the given slot.
-    Load { slot: u32 },
-    /// Chain originates from a Param instruction with the given index.
-    Param { index: u32 },
-}
-
-/// Result of tracing back through IndexGet chains to find the original source.
-#[derive(Clone)]
-enum IndexChainBase {
-    /// Chain originates from a Load instruction with the given slot.
-    Load { slot: u32 },
-    /// Chain originates from a Param instruction with the given index.
-    Param { index: u32 },
-    /// Chain originates from a FieldGet (array within a struct).
-    FieldGet {
-        struct_base_slot: u32,
-        field_slot_offset: u32,
-    },
-}
-
-/// Represents an index operation in a chain: the index value and the stride (slots per element).
-#[derive(Clone)]
-struct IndexLevel {
-    index: CfgValue,
-    elem_slot_count: u32,
-    array_type_id: ArrayTypeId,
-}
 
 /// CFG to Aarch64Mir lowering.
 pub struct CfgLower<'a> {

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -1,0 +1,37 @@
+//! Shared types for CFG lowering across backends.
+//!
+//! This module contains types used by both x86_64 and aarch64 backends
+//! when tracing through field and index chains during CFG lowering.
+
+use rue_air::ArrayTypeId;
+use rue_cfg::CfgValue;
+
+/// Result of tracing back through FieldGet chains to find the original source.
+pub enum FieldChainBase {
+    /// Chain originates from a Load instruction with the given slot.
+    Load { slot: u32 },
+    /// Chain originates from a Param instruction with the given index.
+    Param { index: u32 },
+}
+
+/// Result of tracing back through IndexGet chains to find the original source.
+#[derive(Clone)]
+pub enum IndexChainBase {
+    /// Chain originates from a Load instruction with the given slot.
+    Load { slot: u32 },
+    /// Chain originates from a Param instruction with the given index.
+    Param { index: u32 },
+    /// Chain originates from a FieldGet (array within a struct).
+    FieldGet {
+        struct_base_slot: u32,
+        field_slot_offset: u32,
+    },
+}
+
+/// Represents an index operation in a chain: the index value and the stride (slots per element).
+#[derive(Clone)]
+pub struct IndexLevel {
+    pub index: CfgValue,
+    pub elem_slot_count: u32,
+    pub array_type_id: ArrayTypeId,
+}

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -14,6 +14,7 @@
 //! virtual registers to physical registers before final emission.
 
 pub mod aarch64;
+pub mod cfg_lower;
 pub mod index_map;
 pub mod liveness;
 pub mod regalloc;

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -31,6 +31,7 @@ use rue_cfg::{
 };
 
 use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
+use crate::cfg_lower::{FieldChainBase, IndexChainBase, IndexLevel};
 use crate::types;
 
 /// Argument passing registers per System V AMD64 ABI.
@@ -38,36 +39,6 @@ const ARG_REGS: [Reg; 6] = [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::Rcx, Reg::R8, Reg
 
 /// Return value registers per System V AMD64 ABI.
 const RET_REGS: [Reg; 6] = [Reg::Rax, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9, Reg::R10];
-
-/// Result of tracing back through FieldGet chains to find the original source.
-enum FieldChainBase {
-    /// Chain originates from a Load instruction with the given slot.
-    Load { slot: u32 },
-    /// Chain originates from a Param instruction with the given index.
-    Param { index: u32 },
-}
-
-/// Result of tracing back through IndexGet chains to find the original source.
-#[derive(Clone)]
-enum IndexChainBase {
-    /// Chain originates from a Load instruction with the given slot.
-    Load { slot: u32 },
-    /// Chain originates from a Param instruction with the given index.
-    Param { index: u32 },
-    /// Chain originates from a FieldGet (array within a struct).
-    FieldGet {
-        struct_base_slot: u32,
-        field_slot_offset: u32,
-    },
-}
-
-/// Represents an index operation in a chain: the index value and the stride (slots per element).
-#[derive(Clone)]
-struct IndexLevel {
-    index: CfgValue,
-    elem_slot_count: u32,
-    array_type_id: ArrayTypeId,
-}
 
 /// CFG to X86Mir lowering.
 pub struct CfgLower<'a> {


### PR DESCRIPTION
Move FieldChainBase, IndexChainBase, and IndexLevel from both x86_64/cfg_lower.rs and aarch64/cfg_lower.rs into a new shared cfg_lower module to eliminate code duplication.

Fixes rue-qgsb

🤖 Generated with [Claude Code](https://claude.com/claude-code)