### PR TITLE
Fix elf_machine() to return Option<u16> for non-ELF targets

### DIFF
--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -382,7 +382,8 @@ impl ObjectBuilder {
             0, 0, 0, 0, 0, 0, 0, 0, // Padding
         ]);
         elf.extend_from_slice(&1_u16.to_le_bytes()); // e_type: ET_REL
-        elf.extend_from_slice(&self.target.elf_machine().to_le_bytes()); // e_machine
+        // Safety: build_elf() is only called for ELF targets (checked in build())
+        elf.extend_from_slice(&self.target.elf_machine().unwrap().to_le_bytes()); // e_machine
         elf.extend_from_slice(&1_u32.to_le_bytes()); // e_version
         elf.extend_from_slice(&0_u64.to_le_bytes()); // e_entry (none for relocatable)
         elf.extend_from_slice(&0_u64.to_le_bytes()); // e_phoff (no program headers)

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -704,7 +704,15 @@ impl Linker {
             0, 0, 0, 0, 0, 0, 0, 0, // Padding
         ]);
         elf.extend_from_slice(&2_u16.to_le_bytes()); // e_type: ET_EXEC
-        elf.extend_from_slice(&self.target.elf_machine().to_le_bytes()); // e_machine
+        // The linker currently only produces ELF executables. For Mach-O targets,
+        // we use the system linker via a separate code path.
+        elf.extend_from_slice(
+            &self
+                .target
+                .elf_machine()
+                .expect("linker only produces ELF executables")
+                .to_le_bytes(),
+        ); // e_machine
         elf.extend_from_slice(&1_u32.to_le_bytes()); // e_version
         elf.extend_from_slice(&entry_addr.to_le_bytes()); // e_entry
         elf.extend_from_slice(&ELF_HEADER_SIZE.to_le_bytes()); // e_phoff

--- a/crates/rue-target/src/lib.rs
+++ b/crates/rue-target/src/lib.rs
@@ -66,13 +66,17 @@ impl Target {
         }
     }
 
-    /// Returns the ELF e_machine value for this target.
+    /// Returns the ELF e_machine value for this target, if it uses ELF format.
     ///
     /// This is used when generating ELF object files and executables.
-    pub fn elf_machine(&self) -> u16 {
+    /// Returns `None` for targets that don't use ELF (e.g., macOS uses Mach-O).
+    pub fn elf_machine(&self) -> Option<u16> {
+        if !self.is_elf() {
+            return None;
+        }
         match self.arch() {
-            Arch::X86_64 => 0x3E,  // EM_X86_64
-            Arch::Aarch64 => 0xB7, // EM_AARCH64
+            Arch::X86_64 => Some(0x3E),  // EM_X86_64
+            Arch::Aarch64 => Some(0xB7), // EM_AARCH64
         }
     }
 
@@ -291,8 +295,10 @@ mod tests {
 
     #[test]
     fn test_elf_machine() {
-        assert_eq!(Target::X86_64Linux.elf_machine(), 0x3E);
-        assert_eq!(Target::Aarch64Linux.elf_machine(), 0xB7);
+        assert_eq!(Target::X86_64Linux.elf_machine(), Some(0x3E));
+        assert_eq!(Target::Aarch64Linux.elf_machine(), Some(0xB7));
+        // Mach-O targets return None since they don't use ELF format
+        assert_eq!(Target::Aarch64Macos.elf_machine(), None);
     }
 
     #[test]


### PR DESCRIPTION
The `elf_machine()` method was returning an ELF machine type for Mach-O targets (aarch64-macos), which is semantically incorrect since Mach-O doesn't use ELF format.

Changed the return type to `Option<u16>` and return `None` for non-ELF targets. Updated callers in rue-linker to unwrap the Option with appropriate safety comments explaining the invariants.

Fixes rue-cefw

🤖 Generated with [Claude Code](https://claude.com/claude-code)