### PR TITLE
rue-codegen: return CompileError instead of panic on undefined labels

### DIFF
--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -261,7 +261,7 @@ impl<'a> Emitter<'a> {
             self.emit_inst(inst);
         }
 
-        self.apply_fixups();
+        self.apply_fixups()?;
         Ok((self.code, self.relocations))
     }
 
@@ -852,38 +852,43 @@ impl<'a> Emitter<'a> {
     }
 
     /// Apply pending fixups for forward branches.
-    fn apply_fixups(&mut self) {
+    fn apply_fixups(&mut self) -> CompileResult<()> {
         for fixup in &self.fixups {
-            if let Some(&target) = self.labels.get(&fixup.label) {
-                let offset = (target as i64 - fixup.offset as i64) / 4;
-                match fixup.kind {
-                    FixupKind::Branch => {
-                        // B instruction: imm26
-                        let inst = u32::from_le_bytes(
-                            self.code[fixup.offset..fixup.offset + 4]
-                                .try_into()
-                                .unwrap(),
-                        );
-                        let new_inst =
-                            (inst & BRANCH_OPCODE_MASK) | ((offset as u32) & BRANCH_OFFSET_MASK);
+            let target = self.labels.get(&fixup.label).ok_or_else(|| {
+                CompileError::without_span(ErrorKind::InternalCodegenError(format!(
+                    "undefined label: {}",
+                    fixup.label
+                )))
+            })?;
+            let offset = (*target as i64 - fixup.offset as i64) / 4;
+            match fixup.kind {
+                FixupKind::Branch => {
+                    // B instruction: imm26
+                    let inst = u32::from_le_bytes(
                         self.code[fixup.offset..fixup.offset + 4]
-                            .copy_from_slice(&new_inst.to_le_bytes());
-                    }
-                    FixupKind::CondBranch => {
-                        // Conditional branch: imm19
-                        let inst = u32::from_le_bytes(
-                            self.code[fixup.offset..fixup.offset + 4]
-                                .try_into()
-                                .unwrap(),
-                        );
-                        let new_inst = (inst & COND_BRANCH_OPCODE_MASK)
-                            | (((offset as u32) & COND_BRANCH_OFFSET_MASK) << 5);
+                            .try_into()
+                            .unwrap(),
+                    );
+                    let new_inst =
+                        (inst & BRANCH_OPCODE_MASK) | ((offset as u32) & BRANCH_OFFSET_MASK);
+                    self.code[fixup.offset..fixup.offset + 4]
+                        .copy_from_slice(&new_inst.to_le_bytes());
+                }
+                FixupKind::CondBranch => {
+                    // Conditional branch: imm19
+                    let inst = u32::from_le_bytes(
                         self.code[fixup.offset..fixup.offset + 4]
-                            .copy_from_slice(&new_inst.to_le_bytes());
-                    }
+                            .try_into()
+                            .unwrap(),
+                    );
+                    let new_inst = (inst & COND_BRANCH_OPCODE_MASK)
+                        | (((offset as u32) & COND_BRANCH_OFFSET_MASK) << 5);
+                    self.code[fixup.offset..fixup.offset + 4]
+                        .copy_from_slice(&new_inst.to_le_bytes());
                 }
             }
         }
+        Ok(())
     }
 
     // ========== Instruction encoding helpers ==========

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -201,7 +201,7 @@ impl<'a> Emitter<'a> {
         for inst in self.mir.iter() {
             self.emit_inst(inst);
         }
-        self.apply_fixups();
+        self.apply_fixups()?;
         Ok((self.code, self.relocations))
     }
 
@@ -298,12 +298,14 @@ impl<'a> Emitter<'a> {
     }
 
     /// Apply all fixups for forward jumps.
-    fn apply_fixups(&mut self) {
+    fn apply_fixups(&mut self) -> CompileResult<()> {
         for fixup in &self.fixups {
-            let target_offset = self
-                .labels
-                .get(&fixup.label)
-                .unwrap_or_else(|| panic!("undefined label: {}", fixup.label));
+            let target_offset = self.labels.get(&fixup.label).ok_or_else(|| {
+                CompileError::without_span(ErrorKind::InternalCodegenError(format!(
+                    "undefined label: {}",
+                    fixup.label
+                )))
+            })?;
 
             match fixup.kind {
                 FixupKind::Rel8 => {
@@ -313,13 +315,15 @@ impl<'a> Emitter<'a> {
                     let relative = *target_offset as i64 - jump_end as i64;
 
                     // rel8 encoding only supports -128 to +127 byte offsets
-                    assert!(
-                        relative >= -128 && relative <= 127,
-                        "jump offset {} exceeds rel8 range (-128..127) for label '{}'; \
-                         consider implementing rel32 fallback",
-                        relative,
-                        fixup.label
-                    );
+                    if relative < -128 || relative > 127 {
+                        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+                            format!(
+                                "jump offset {} exceeds rel8 range (-128..127) for label '{}'; \
+                                 consider implementing rel32 fallback",
+                                relative, fixup.label
+                            ),
+                        )));
+                    }
 
                     self.code[fixup.offset] = relative as u8;
                 }
@@ -330,18 +334,21 @@ impl<'a> Emitter<'a> {
                     let relative = *target_offset as i64 - jump_end as i64;
 
                     // rel32 encoding supports i32 range
-                    assert!(
-                        relative >= i32::MIN as i64 && relative <= i32::MAX as i64,
-                        "jump offset {} exceeds rel32 range for label '{}'",
-                        relative,
-                        fixup.label
-                    );
+                    if relative < i32::MIN as i64 || relative > i32::MAX as i64 {
+                        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
+                            format!(
+                                "jump offset {} exceeds rel32 range for label '{}'",
+                                relative, fixup.label
+                            ),
+                        )));
+                    }
 
                     let bytes = (relative as i32).to_le_bytes();
                     self.code[fixup.offset..fixup.offset + 4].copy_from_slice(&bytes);
                 }
             }
         }
+        Ok(())
     }
 
     /// Emit a single instruction.


### PR DESCRIPTION
Replace panic!/assert! with proper error handling in apply_fixups() for both x86_64 and aarch64 backends:

- x86_64: Change unwrap_or_else(panic!) to ok_or_else(CompileError)
- aarch64: Change silent `if let Some` skip to ok_or_else(CompileError)
- x86_64: Convert assert! range checks to explicit if-else with errors

Fixes rue-9rak

🤖 Generated with [Claude Code](https://claude.com/claude-code)