### PR TITLE
Implement preview feature gating infrastructure

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -14,7 +14,10 @@ use crate::types::{
     ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructField, StructId, Type,
     parse_array_type_syntax,
 };
-use rue_error::{CompileError, CompileResult, CompileWarning, ErrorKind, OptionExt, WarningKind};
+use rue_error::{
+    CompileError, CompileResult, CompileWarning, ErrorKind, OptionExt, PreviewFeature,
+    PreviewFeatures, WarningKind,
+};
 use rue_intern::{Interner, Symbol};
 use rue_rir::{
     InstData, InstRef, Rir, RirArgMode, RirCallArg, RirDirective, RirParamMode, RirPattern,
@@ -269,6 +272,8 @@ pub struct Sema<'a> {
     /// Used for resolving method calls (receiver.method()) and associated
     /// function calls (Type::function())
     methods: HashMap<(Symbol, Symbol), MethodInfo>,
+    /// Enabled preview features
+    preview_features: PreviewFeatures,
 }
 
 /// Storage location for a String receiver in mutation methods.
@@ -284,7 +289,11 @@ enum StringReceiverStorage {
 
 impl<'a> Sema<'a> {
     /// Create a new semantic analyzer.
-    pub fn new(rir: &'a Rir, interner: &'a mut Interner) -> Self {
+    pub fn new(
+        rir: &'a Rir,
+        interner: &'a mut Interner,
+        preview_features: PreviewFeatures,
+    ) -> Self {
         Self {
             rir,
             interner,
@@ -299,6 +308,44 @@ impl<'a> Sema<'a> {
             strings: Vec::new(),
             warnings: Vec::new(),
             methods: HashMap::new(),
+            preview_features,
+        }
+    }
+
+    /// Check if a preview feature is enabled, returning an error if not.
+    ///
+    /// This is the gating mechanism for preview features. Call this method
+    /// when semantic analysis encounters a feature that requires a preview flag.
+    ///
+    /// # Parameters
+    /// - `feature`: The preview feature that is required
+    /// - `what`: A description of what requires the feature (e.g., "string concatenation")
+    /// - `span`: The source location where the feature is used
+    ///
+    /// # Returns
+    /// - `Ok(())` if the feature is enabled
+    /// - `Err(CompileError)` with a helpful message if not enabled
+    fn require_preview(
+        &self,
+        feature: PreviewFeature,
+        what: &str,
+        span: Span,
+    ) -> CompileResult<()> {
+        if self.preview_features.contains(&feature) {
+            Ok(())
+        } else {
+            Err(CompileError::new(
+                ErrorKind::PreviewFeatureRequired {
+                    feature,
+                    what: what.to_string(),
+                },
+                span,
+            )
+            .with_help(format!(
+                "use `--preview {}` to enable this feature ({})",
+                feature.name(),
+                feature.adr()
+            )))
         }
     }
 
@@ -3145,6 +3192,35 @@ impl<'a> Sema<'a> {
                         });
                         Ok(AnalysisResult::new(air_ref, target_ty))
                     }
+                    "test_preview_gate" => {
+                        // @test_preview_gate() - no-op intrinsic gated by test_infra preview feature.
+                        // Used to test that the preview feature gating mechanism works correctly.
+                        self.require_preview(
+                            PreviewFeature::TestInfra,
+                            "@test_preview_gate() intrinsic",
+                            inst.span,
+                        )?;
+
+                        // Takes no arguments
+                        if !args.is_empty() {
+                            return Err(CompileError::new(
+                                ErrorKind::IntrinsicWrongArgCount {
+                                    name: intrinsic_name,
+                                    expected: 0,
+                                    found: args.len(),
+                                },
+                                inst.span,
+                            ));
+                        }
+
+                        // No-op: just return a unit constant
+                        let air_ref = air.add_inst(AirInst {
+                            data: AirInstData::UnitConst,
+                            ty: Type::Unit,
+                            span: inst.span,
+                        });
+                        Ok(AnalysisResult::new(air_ref, Type::Unit))
+                    }
                     _ => Err(CompileError::new(
                         ErrorKind::UnknownIntrinsic(intrinsic_name),
                         inst.span,
@@ -4810,7 +4886,7 @@ mod tests {
         let astgen = AstGen::new(&ast, &mut interner);
         let rir = astgen.generate();
 
-        let sema = Sema::new(&rir, &mut interner);
+        let sema = Sema::new(&rir, &mut interner, PreviewFeatures::new());
         sema.analyze_all()
     }
 

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1716,6 +1716,7 @@ impl<'a> CfgBuilder<'a> {
 mod tests {
     use super::*;
     use rue_air::Sema;
+    use rue_error::PreviewFeatures;
     use rue_intern::Interner;
     use rue_lexer::Lexer;
     use rue_parser::Parser;
@@ -1731,7 +1732,7 @@ mod tests {
         let astgen = AstGen::new(&ast, &mut interner);
         let rir = astgen.generate();
 
-        let mut sema = Sema::new(&rir, &mut interner);
+        let mut sema = Sema::new(&rir, &mut interner, PreviewFeatures::new());
         let output = sema.analyze_all().unwrap();
 
         let func = &output.functions[0];

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -3334,6 +3334,7 @@ mod tests {
     use super::*;
     use rue_air::Sema;
     use rue_cfg::CfgBuilder;
+    use rue_error::PreviewFeatures;
     use rue_intern::Interner;
     use rue_lexer::Lexer;
     use rue_parser::Parser;
@@ -3349,7 +3350,7 @@ mod tests {
         let astgen = AstGen::new(&ast, &mut interner);
         let rir = astgen.generate();
 
-        let sema = Sema::new(&rir, &mut interner);
+        let sema = Sema::new(&rir, &mut interner, PreviewFeatures::new());
         let output = sema.analyze_all().unwrap();
 
         let func = &output.functions[0];

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3209,6 +3209,7 @@ mod tests {
     use super::*;
     use rue_air::Sema;
     use rue_cfg::CfgBuilder;
+    use rue_error::PreviewFeatures;
     use rue_intern::Interner;
     use rue_lexer::Lexer;
     use rue_parser::Parser;
@@ -3224,7 +3225,7 @@ mod tests {
         let astgen = AstGen::new(&ast, &mut interner);
         let rir = astgen.generate();
 
-        let sema = Sema::new(&rir, &mut interner);
+        let sema = Sema::new(&rir, &mut interner, PreviewFeatures::new());
         let output = sema.analyze_all().unwrap();
 
         let func = &output.functions[0];

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -273,10 +273,10 @@ pub struct CompileOutput {
 /// This runs: lexing → parsing → AST to RIR → semantic analysis → CFG construction.
 /// Returns the compile state which can be inspected for debugging.
 ///
-/// Uses default optimization level (O0). For custom optimization, use
-/// [`compile_frontend_with_options`].
+/// Uses default optimization level (O0) and no preview features. For custom options,
+/// use [`compile_frontend_with_options`].
 pub fn compile_frontend(source: &str) -> CompileResult<CompileState> {
-    compile_frontend_with_options(source, OptLevel::default())
+    compile_frontend_with_options(source, OptLevel::default(), &PreviewFeatures::new())
 }
 
 /// Compile source code through all frontend phases with optimization.
@@ -286,6 +286,7 @@ pub fn compile_frontend(source: &str) -> CompileResult<CompileState> {
 pub fn compile_frontend_with_options(
     source: &str,
     opt_level: OptLevel,
+    preview_features: &PreviewFeatures,
 ) -> CompileResult<CompileState> {
     // Lexing
     let mut lexer = Lexer::new(source);
@@ -295,7 +296,7 @@ pub fn compile_frontend_with_options(
     let mut parser = Parser::new(tokens);
     let ast = parser.parse()?;
 
-    compile_frontend_from_ast_with_options(ast, opt_level)
+    compile_frontend_from_ast_with_options(ast, opt_level, preview_features)
 }
 
 /// Compile from an already-parsed AST through all remaining frontend phases.
@@ -304,10 +305,10 @@ pub fn compile_frontend_with_options(
 /// Use this when you already have a parsed AST (e.g., for `--emit` modes that
 /// need both AST output and later stage output without double-parsing).
 ///
-/// Uses default optimization level (O0). For custom optimization, use
-/// [`compile_frontend_from_ast_with_options`].
+/// Uses default optimization level (O0) and no preview features. For custom options,
+/// use [`compile_frontend_from_ast_with_options`].
 pub fn compile_frontend_from_ast(ast: Ast) -> CompileResult<CompileState> {
-    compile_frontend_from_ast_with_options(ast, OptLevel::default())
+    compile_frontend_from_ast_with_options(ast, OptLevel::default(), &PreviewFeatures::new())
 }
 
 /// Compile from an already-parsed AST through all remaining frontend phases with optimization.
@@ -318,6 +319,7 @@ pub fn compile_frontend_from_ast(ast: Ast) -> CompileResult<CompileState> {
 pub fn compile_frontend_from_ast_with_options(
     ast: Ast,
     opt_level: OptLevel,
+    preview_features: &PreviewFeatures,
 ) -> CompileResult<CompileState> {
     // AST to RIR (untyped IR)
     let mut interner = Interner::new();
@@ -325,7 +327,7 @@ pub fn compile_frontend_from_ast_with_options(
     let rir = astgen.generate();
 
     // Semantic analysis (RIR to AIR)
-    let sema = Sema::new(&rir, &mut interner);
+    let sema = Sema::new(&rir, &mut interner, preview_features.clone());
     let sema_output = sema.analyze_all()?;
 
     // Build CFGs from AIR (one per function), collecting warnings
@@ -381,7 +383,8 @@ pub fn compile_with_options(
     source: &str,
     options: &CompileOptions,
 ) -> CompileResult<CompileOutput> {
-    let state = compile_frontend_with_options(source, options.opt_level)?;
+    let state =
+        compile_frontend_with_options(source, options.opt_level, &options.preview_features)?;
 
     // Check for main function
     let _main_fn = state
@@ -784,7 +787,7 @@ pub fn compile_to_air(source: &str) -> CompileResult<AirOutput> {
     let rir = astgen.generate();
 
     // Semantic analysis (RIR to AIR)
-    let sema = Sema::new(&rir, &mut interner);
+    let sema = Sema::new(&rir, &mut interner, PreviewFeatures::new());
     let sema_output = sema.analyze_all()?;
 
     Ok(AirOutput {

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -33,11 +33,14 @@ use std::fmt;
 /// - Require explicit opt-in via `--preview <feature>`
 /// - Allow incremental implementation to be merged to main
 ///
-/// See ADR-020 for the full design.
+/// See ADR-016 for the full design.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum PreviewFeature {
     /// Mutable strings with heap allocation and concatenation (ADR-019).
     MutableStrings,
+    /// Testing infrastructure feature - permanently unstable.
+    /// Used to verify the preview feature gating mechanism works.
+    TestInfra,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -57,6 +60,7 @@ impl PreviewFeature {
     pub fn name(&self) -> &'static str {
         match self {
             PreviewFeature::MutableStrings => "mutable_strings",
+            PreviewFeature::TestInfra => "test_infra",
         }
     }
 
@@ -64,12 +68,13 @@ impl PreviewFeature {
     pub fn adr(&self) -> &'static str {
         match self {
             PreviewFeature::MutableStrings => "ADR-019",
+            PreviewFeature::TestInfra => "ADR-016",
         }
     }
 
     /// Get all available preview features.
     pub fn all() -> &'static [PreviewFeature] {
-        &[PreviewFeature::MutableStrings]
+        &[PreviewFeature::MutableStrings, PreviewFeature::TestInfra]
     }
 
     /// Get a comma-separated list of all feature names (for help text).
@@ -88,6 +93,7 @@ impl std::str::FromStr for PreviewFeature {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "mutable_strings" => Ok(PreviewFeature::MutableStrings),
+            "test_infra" => Ok(PreviewFeature::TestInfra),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }

--- a/crates/rue-spec/cases/runtime/preview-features.toml
+++ b/crates/rue-spec/cases/runtime/preview-features.toml
@@ -1,0 +1,49 @@
+# Preview Feature Gating Tests
+#
+# These tests verify that the preview feature gating mechanism works correctly.
+# The test_infra feature is permanently unstable and exists specifically for
+# testing the gating infrastructure.
+
+[section]
+id = "runtime.preview_features"
+spec_chapter = "8.4"
+name = "Preview Features"
+
+# Test that using @test_preview_gate() without the preview flag fails
+[[case]]
+name = "test_preview_gate_requires_feature"
+spec = ["8.4:1"]
+source = """
+fn main() -> i32 {
+    @test_preview_gate();
+    0
+}
+"""
+compile_fail = true
+error_contains = "requires preview feature"
+
+# Test that using @test_preview_gate() with the preview flag succeeds
+[[case]]
+name = "test_preview_gate_with_feature"
+spec = ["8.4:1"]
+preview = "test_infra"
+source = """
+fn main() -> i32 {
+    @test_preview_gate();
+    0
+}
+"""
+exit_code = 0
+
+# Test that the error message includes the help text
+[[case]]
+name = "test_preview_gate_error_includes_help"
+spec = ["8.4:1"]
+source = """
+fn main() -> i32 {
+    @test_preview_gate();
+    0
+}
+"""
+compile_fail = true
+error_contains = "--preview test_infra"

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -373,7 +373,11 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
     // Stage 2: Full frontend (RIR, AIR, CFG) - reuses the already-parsed AST
     // Applies optimization based on the -O level
     let frontend_state = if max_stage >= 2 {
-        match compile_frontend_from_ast_with_options(ast.clone().unwrap(), options.opt_level) {
+        match compile_frontend_from_ast_with_options(
+            ast.clone().unwrap(),
+            options.opt_level,
+            &options.preview_features,
+        ) {
             Ok(state) => Some(state),
             Err(e) => {
                 eprintln!("{}", formatter.format_error(&e));

--- a/docs/spec/src/08-runtime-behavior/04-preview-features.md
+++ b/docs/spec/src/08-runtime-behavior/04-preview-features.md
@@ -1,0 +1,12 @@
++++
+title = "Preview Features"
+weight = 4
++++
+
+# Preview Features
+
+Preview features are in-progress language additions that require explicit opt-in.
+
+{{ rule(id="8.4:1", cat="normative") }}
+
+Features gated behind a preview flag produce a compile-time error when used without the corresponding `--preview <feature>` flag. The error message includes the required flag name.


### PR DESCRIPTION
Implements the core infrastructure for gating language features behind --preview flags per ADR-016:

- Thread preview_features through compile pipeline to Sema
- Add require_preview() method for feature gating in semantic analysis
- Add TestInfra permanently-unstable feature for testing the mechanism
- Add @test_preview_gate() intrinsic gated by test_infra
- Add spec section 8.4 and tests for preview feature behavior

The test_infra feature exists solely to verify the gating mechanism works correctly without affecting any real language features.

🤖 Generated with [Claude Code](https://claude.com/claude-code)