### PR TITLE
Add preview_should_pass field for spec tests

### DIFF
--- a/crates/rue-spec/src/main.rs
+++ b/crates/rue-spec/src/main.rs
@@ -143,15 +143,19 @@ fn main() {
             let test_name = format!("{}::{}", section_id, case.name);
             let skip = case.skip;
             let is_preview = case.preview.is_some();
+            let preview_should_pass = case.preview_should_pass;
             let rue_binary = rue_binary.clone();
 
-            let trial = if is_preview {
-                // Preview tests use the wrapper that tracks but doesn't fail
+            // Preview tests that should pass use the normal wrapper (fail on error).
+            // Preview tests without preview_should_pass use the lenient wrapper (allow failure).
+            // Non-preview tests always use the normal wrapper.
+            let trial = if is_preview && !preview_should_pass {
+                // Preview tests that are allowed to fail
                 Trial::test(test_name, move |ctx| {
                     run_preview_case_wrapper(&case, &rue_binary, skip, ctx)
                 })
             } else {
-                // Stable tests fail normally
+                // Stable tests and preview tests that should pass fail normally
                 Trial::test(test_name, move |ctx| {
                     run_case_wrapper(&case, &rue_binary, skip, ctx)
                 })
@@ -167,11 +171,11 @@ fn main() {
     }
 
     // Run all tests
-    // Note: libtest2-mimic's Harness::main() calls std::process::exit(),
-    // so we can't run code after it. Preview test summary is printed via
-    // a custom drop handler or we accept the limitation.
     //
-    // Preview tests that fail are marked as "ignored" with a reason,
-    // so they won't cause the overall test run to fail.
+    // Preview tests without `preview_should_pass` are allowed to fail -
+    // failures are marked as "ignored" so they don't break the build.
+    //
+    // Preview tests with `preview_should_pass = true` fail normally,
+    // providing real test output for implemented portions of preview features.
     Harness::with_env().discover(tests).main();
 }

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -105,9 +105,15 @@ pub struct Case {
     pub expected_stdout: Option<String>,
     /// Preview feature required to run this test (e.g., "mutable_strings").
     /// Tests with this field are compiled with `--preview <feature>` and
-    /// are allowed to fail without failing the overall test suite.
+    /// are allowed to fail without failing the overall test suite,
+    /// unless `preview_should_pass` is true.
     #[serde(default)]
     pub preview: Option<String>,
+    /// If true, this preview test should pass and will fail the suite if it doesn't.
+    /// Use this to mark preview tests that are expected to work after implementation.
+    /// This provides real test output for implemented portions of preview features.
+    #[serde(default)]
+    pub preview_should_pass: bool,
     /// Target architecture (e.g., "x86-64-linux", "aarch64-macos").
     /// When specified, the compiler is invoked with `--target <target>`.
     /// Required for MIR golden tests; optional for other test types.
@@ -208,6 +214,7 @@ pub fn expand_case(case: Case) -> Vec<Case> {
                 no_warnings: case.no_warnings,
                 spec: case.spec.clone(),
                 preview: case.preview.clone(),
+                preview_should_pass: case.preview_should_pass,
                 target: case.target.clone(),
                 opt_level: case.opt_level,
 
@@ -259,6 +266,11 @@ pub fn expand_case(case: Case) -> Vec<Case> {
             if let Some(value) = params.get("preview") {
                 if let Some(s) = value.as_str() {
                     expanded.preview = Some(s.to_string());
+                }
+            }
+            if let Some(value) = params.get("preview_should_pass") {
+                if let Some(b) = value.as_bool() {
+                    expanded.preview_should_pass = b;
                 }
             }
 
@@ -760,6 +772,7 @@ mod tests {
             spec: vec!["1.0:1".to_string()],
             expected_stdout: None,
             preview: None,
+            preview_should_pass: false,
             target: None,
             opt_level: None,
             params: vec![],
@@ -803,6 +816,7 @@ mod tests {
             spec: vec!["3.1:1".to_string()],
             expected_stdout: None,
             preview: None,
+            preview_should_pass: false,
             target: None,
             opt_level: None,
             params: vec![ParamSet { values: param1 }, ParamSet { values: param2 }],
@@ -854,6 +868,7 @@ mod tests {
             spec: vec!["3.1:1".to_string()],
             expected_stdout: None,
             preview: None,
+            preview_should_pass: false,
             target: None,
             opt_level: None,
             params: vec![ParamSet { values: params }],
@@ -897,6 +912,7 @@ mod tests {
             spec: vec![],
             expected_stdout: None,
             preview: None,
+            preview_should_pass: false,
             target: None,
             opt_level: None,
             params: vec![ParamSet { values: params }],


### PR DESCRIPTION
When a preview test has preview_should_pass = true, it fails normally instead of being allowed to fail. This provides real test output for implemented portions of preview features.

This is simpler than dynamic progress tracking because:
- Tests explicitly declare which ones should pass
- Failures show up in normal test output
- No runtime state tracking needed

Closes: rue-0juf

🤖 Generated with [Claude Code](https://claude.com/claude-code)