### PR TITLE
Remove MutableStrings references from preview feature tests

### DIFF
--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -715,31 +715,23 @@ mod tests {
 
     #[test]
     fn parse_preview_valid_feature() {
-        let opts = unwrap_options(parse_args_from(&[
-            "--preview",
-            "mutable_strings",
-            "source.rue",
-        ]));
-        assert!(
-            opts.preview_features
-                .contains(&PreviewFeature::MutableStrings)
-        );
+        let opts = unwrap_options(parse_args_from(&["--preview", "test_infra", "source.rue"]));
+        assert!(opts.preview_features.contains(&PreviewFeature::TestInfra));
     }
 
     #[test]
-    fn parse_preview_multiple_features() {
+    fn parse_preview_multiple_flags() {
+        // Test that --preview can be specified multiple times
+        // (currently only one feature exists, but the flag can still be repeated)
         let opts = unwrap_options(parse_args_from(&[
             "--preview",
-            "mutable_strings",
+            "test_infra",
             "--preview",
             "test_infra",
             "source.rue",
         ]));
-        assert!(
-            opts.preview_features
-                .contains(&PreviewFeature::MutableStrings)
-        );
         assert!(opts.preview_features.contains(&PreviewFeature::TestInfra));
+        assert_eq!(opts.preview_features.len(), 1);
     }
 
     #[test]


### PR DESCRIPTION
The MutableStrings variant was removed from PreviewFeature enum during stabilization, but two unit tests still referenced it. Updated tests to use TestInfra (the only remaining preview feature) instead.

Fixes rue-0slf.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)