### PR TITLE
Add rust-project.json generation for rust-analyzer support

### DIFF
--- a/gen-rust-project.sh
+++ b/gen-rust-project.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Generate rust-project.json from Buck2 targets for rust-analyzer support
+#
+# Usage: ./gen-rust-project.sh
+#
+# This queries Buck2 for all Rust targets and generates a rust-project.json
+# file that rust-analyzer can use for IDE support.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+echo "Querying Buck2 for Rust targets..."
+./buck2 targets //crates/... --json 2>/dev/null > /tmp/buck_targets.json
+
+echo "Generating rust-project.json..."
+python3 << 'EOF'
+import json
+import os
+
+with open('/tmp/buck_targets.json') as f:
+    targets = json.load(f)
+
+root = os.getcwd()
+
+# Build crate index
+crates = []
+crate_name_to_idx = {}
+
+for target in targets:
+    ttype = target.get('buck.type', '')
+    name = target.get('name', '')
+
+    if 'rust_library' in ttype or 'rust_binary' in ttype:
+        if not name.endswith('-test'):
+            crate_name_to_idx[name] = len(crates)
+            crates.append(target)
+
+rust_project = {
+    "sysroot_src": None,
+    "crates": []
+}
+
+for idx, target in enumerate(crates):
+    name = target.get('name', '')
+    srcs = target.get('srcs', [])
+    deps = target.get('deps', [])
+
+    # Find crate root
+    root_file = None
+    for src in srcs:
+        src_path = src.replace('root//', '')
+        if src_path.endswith('lib.rs') or src_path.endswith('main.rs'):
+            root_file = src_path
+            break
+
+    if not root_file and srcs:
+        root_file = srcs[0].replace('root//', '')
+
+    if not root_file:
+        continue
+
+    # Convert deps to indices
+    dep_indices = []
+    for dep in deps:
+        if dep.startswith('root//'):
+            dep_name = dep.split(':')[-1]
+            if dep_name in crate_name_to_idx:
+                dep_indices.append({"crate": crate_name_to_idx[dep_name], "name": dep_name.replace('-', '_')})
+
+    # Use relative paths - rust-analyzer resolves them relative to rust-project.json
+    rust_project["crates"].append({
+        "display_name": name,
+        "root_module": root_file,
+        "edition": "2024",
+        "deps": dep_indices,
+        "is_workspace_member": True,
+        "source": {
+            "include_dirs": [os.path.dirname(root_file)],
+            "exclude_dirs": []
+        },
+        "cfg": [],
+        "env": {},
+        "is_proc_macro": False,
+    })
+
+with open(os.path.join(root, 'rust-project.json'), 'w') as f:
+    json.dump(rust_project, f, indent=2)
+    f.write('\n')
+
+print(f"Generated rust-project.json with {len(rust_project['crates'])} crates")
+EOF
+
+echo "Done! rust-analyzer should now work with this project."
+echo "You may need to restart rust-analyzer or reload your IDE."

--- a/rust-project.json
+++ b/rust-project.json
@@ -1,0 +1,449 @@
+{
+  "sysroot_src": null,
+  "crates": [
+    {
+      "display_name": "rue",
+      "root_module": "crates/rue/src/main.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 4,
+          "name": "rue_compiler"
+        },
+        {
+          "crate": 10,
+          "name": "rue_rir"
+        },
+        {
+          "crate": 14,
+          "name": "rue_target"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-air",
+      "root_module": "crates/rue-air/src/lib.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 5,
+          "name": "rue_error"
+        },
+        {
+          "crate": 6,
+          "name": "rue_intern"
+        },
+        {
+          "crate": 7,
+          "name": "rue_lexer"
+        },
+        {
+          "crate": 9,
+          "name": "rue_parser"
+        },
+        {
+          "crate": 10,
+          "name": "rue_rir"
+        },
+        {
+          "crate": 12,
+          "name": "rue_span"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-air/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-cfg",
+      "root_module": "crates/rue-cfg/src/lib.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 1,
+          "name": "rue_air"
+        },
+        {
+          "crate": 5,
+          "name": "rue_error"
+        },
+        {
+          "crate": 12,
+          "name": "rue_span"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-cfg/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-codegen",
+      "root_module": "crates/rue-codegen/src/lib.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 1,
+          "name": "rue_air"
+        },
+        {
+          "crate": 2,
+          "name": "rue_cfg"
+        },
+        {
+          "crate": 5,
+          "name": "rue_error"
+        },
+        {
+          "crate": 12,
+          "name": "rue_span"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-codegen/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-compiler",
+      "root_module": "crates/rue-compiler/src/lib.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 1,
+          "name": "rue_air"
+        },
+        {
+          "crate": 2,
+          "name": "rue_cfg"
+        },
+        {
+          "crate": 3,
+          "name": "rue_codegen"
+        },
+        {
+          "crate": 5,
+          "name": "rue_error"
+        },
+        {
+          "crate": 6,
+          "name": "rue_intern"
+        },
+        {
+          "crate": 7,
+          "name": "rue_lexer"
+        },
+        {
+          "crate": 8,
+          "name": "rue_linker"
+        },
+        {
+          "crate": 9,
+          "name": "rue_parser"
+        },
+        {
+          "crate": 10,
+          "name": "rue_rir"
+        },
+        {
+          "crate": 12,
+          "name": "rue_span"
+        },
+        {
+          "crate": 14,
+          "name": "rue_target"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-compiler/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-error",
+      "root_module": "crates/rue-error/src/lib.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 12,
+          "name": "rue_span"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-error/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-intern",
+      "root_module": "crates/rue-intern/src/lib.rs",
+      "edition": "2024",
+      "deps": [],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-intern/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-lexer",
+      "root_module": "crates/rue-lexer/src/lib.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 5,
+          "name": "rue_error"
+        },
+        {
+          "crate": 12,
+          "name": "rue_span"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-lexer/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-linker",
+      "root_module": "crates/rue-linker/src/lib.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 14,
+          "name": "rue_target"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-linker/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-parser",
+      "root_module": "crates/rue-parser/src/lib.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 5,
+          "name": "rue_error"
+        },
+        {
+          "crate": 7,
+          "name": "rue_lexer"
+        },
+        {
+          "crate": 12,
+          "name": "rue_span"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-parser/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-rir",
+      "root_module": "crates/rue-rir/src/lib.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 6,
+          "name": "rue_intern"
+        },
+        {
+          "crate": 7,
+          "name": "rue_lexer"
+        },
+        {
+          "crate": 9,
+          "name": "rue_parser"
+        },
+        {
+          "crate": 12,
+          "name": "rue_span"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-rir/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-runtime",
+      "root_module": "crates/rue-runtime/src/lib.rs",
+      "edition": "2024",
+      "deps": [],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-runtime/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-span",
+      "root_module": "crates/rue-span/src/lib.rs",
+      "edition": "2024",
+      "deps": [],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-span/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-spec",
+      "root_module": "crates/rue-spec/src/main.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 15,
+          "name": "rue_test_runner"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-spec/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-target",
+      "root_module": "crates/rue-target/src/lib.rs",
+      "edition": "2024",
+      "deps": [],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-target/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-test-runner",
+      "root_module": "crates/rue-test-runner/src/lib.rs",
+      "edition": "2024",
+      "deps": [],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-test-runner/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    },
+    {
+      "display_name": "rue-ui-tests",
+      "root_module": "crates/rue-ui-tests/src/main.rs",
+      "edition": "2024",
+      "deps": [
+        {
+          "crate": 15,
+          "name": "rue_test_runner"
+        }
+      ],
+      "is_workspace_member": true,
+      "source": {
+        "include_dirs": [
+          "crates/rue-ui-tests/src"
+        ],
+        "exclude_dirs": []
+      },
+      "cfg": [],
+      "env": {},
+      "is_proc_macro": false
+    }
+  ]
+}


### PR DESCRIPTION
Add gen-rust-project.sh script that queries Buck2 targets and generates a rust-project.json file for rust-analyzer IDE integration. Uses relative paths for portability across machines.

Filed rue-jbtp for enabling Buck2 execution platforms to use the native BXL-based rust-analyzer integration in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)