### PR TITLE
Add --emit liveness to show live ranges for debugging

### DIFF
--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -14,7 +14,7 @@ use std::collections::{HashMap, HashSet};
 use super::mir::{Aarch64Inst, Aarch64Mir, LabelId, Operand, Reg, VReg};
 
 // Re-export shared types from the regalloc module
-pub use crate::regalloc::LiveRange;
+pub use crate::regalloc::{InstructionLiveness, LiveRange, LivenessDebugInfo};
 
 /// Type alias for aarch64-specific liveness info.
 pub type LivenessInfo = crate::regalloc::LivenessInfo<Reg>;
@@ -184,6 +184,152 @@ pub fn analyze(mir: &Aarch64Mir) -> LivenessInfo {
         ranges,
         live_at,
         clobbers_at,
+    }
+}
+
+/// Compute detailed liveness debug information for Aarch64Mir.
+///
+/// This provides more detailed output than `analyze()`, including per-instruction
+/// live-in/live-out sets and def/use information. Used by `--emit liveness`.
+pub fn analyze_debug(mir: &Aarch64Mir) -> LivenessDebugInfo {
+    let instructions = mir.instructions();
+    let num_insts = instructions.len();
+
+    if num_insts == 0 {
+        return LivenessDebugInfo {
+            instructions: Vec::new(),
+            live_ranges: HashMap::new(),
+            vreg_count: mir.vreg_count(),
+        };
+    }
+
+    // Step 1: Build label -> instruction index map
+    let mut label_to_idx: HashMap<LabelId, usize> = HashMap::new();
+    for (idx, inst) in instructions.iter().enumerate() {
+        if let Aarch64Inst::Label { id } = inst {
+            label_to_idx.insert(*id, idx);
+        }
+    }
+
+    // Step 2: Build successor lists for each instruction
+    let mut successors: Vec<Vec<usize>> = vec![Vec::new(); num_insts];
+    for (idx, inst) in instructions.iter().enumerate() {
+        match inst {
+            Aarch64Inst::B { label } => {
+                if let Some(&target) = label_to_idx.get(label) {
+                    successors[idx].push(target);
+                }
+            }
+            Aarch64Inst::BCond { label, .. }
+            | Aarch64Inst::Bvs { label }
+            | Aarch64Inst::Bvc { label }
+            | Aarch64Inst::Cbz { label, .. }
+            | Aarch64Inst::Cbnz { label, .. } => {
+                if idx + 1 < num_insts {
+                    successors[idx].push(idx + 1);
+                }
+                if let Some(&target) = label_to_idx.get(label) {
+                    successors[idx].push(target);
+                }
+            }
+            Aarch64Inst::Ret => {}
+            Aarch64Inst::Bl { .. } => {
+                if idx + 1 < num_insts {
+                    successors[idx].push(idx + 1);
+                }
+            }
+            _ => {
+                if idx + 1 < num_insts {
+                    successors[idx].push(idx + 1);
+                }
+            }
+        }
+    }
+
+    // Step 3: Backward dataflow analysis
+    let mut live_in: Vec<HashSet<VReg>> = vec![HashSet::new(); num_insts];
+    let mut live_out: Vec<HashSet<VReg>> = vec![HashSet::new(); num_insts];
+
+    let inst_uses: Vec<Vec<VReg>> = instructions.iter().map(uses).collect();
+    let inst_defs: Vec<Vec<VReg>> = instructions.iter().map(defs).collect();
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+
+        for idx in (0..num_insts).rev() {
+            let mut new_live_out = HashSet::new();
+            for &succ in &successors[idx] {
+                new_live_out.extend(&live_in[succ]);
+            }
+
+            let mut new_live_in: HashSet<VReg> = new_live_out.clone();
+            for vreg in &inst_defs[idx] {
+                new_live_in.remove(vreg);
+            }
+            for vreg in &inst_uses[idx] {
+                new_live_in.insert(*vreg);
+            }
+
+            if new_live_in != live_in[idx] || new_live_out != live_out[idx] {
+                changed = true;
+                live_in[idx] = new_live_in;
+                live_out[idx] = new_live_out;
+            }
+        }
+    }
+
+    // Step 4: Build live ranges from dataflow results
+    let mut first_live: HashMap<VReg, usize> = HashMap::new();
+    let mut last_live: HashMap<VReg, usize> = HashMap::new();
+
+    for idx in 0..num_insts {
+        for vreg in &inst_defs[idx] {
+            first_live.entry(*vreg).or_insert(idx);
+            last_live.insert(*vreg, idx);
+        }
+        for vreg in &inst_uses[idx] {
+            first_live.entry(*vreg).or_insert(idx);
+            last_live.insert(*vreg, idx);
+        }
+        for vreg in &live_in[idx] {
+            first_live.entry(*vreg).or_insert(idx);
+            if last_live.get(vreg).map_or(true, |&last| idx > last) {
+                last_live.insert(*vreg, idx);
+            }
+        }
+        for vreg in &live_out[idx] {
+            first_live.entry(*vreg).or_insert(idx);
+            if last_live.get(vreg).map_or(true, |&last| idx > last) {
+                last_live.insert(*vreg, idx);
+            }
+        }
+    }
+
+    // Build ranges
+    let mut live_ranges: HashMap<VReg, crate::regalloc::LiveRange> = HashMap::new();
+    for vreg_idx in 0..mir.vreg_count() {
+        let vreg = VReg::new(vreg_idx);
+        if let (Some(&start), Some(&end)) = (first_live.get(&vreg), last_live.get(&vreg)) {
+            live_ranges.insert(vreg, crate::regalloc::LiveRange::new(start, end));
+        }
+    }
+
+    // Build per-instruction liveness info
+    let instruction_liveness: Vec<InstructionLiveness> = (0..num_insts)
+        .map(|idx| InstructionLiveness {
+            index: idx,
+            live_in: live_in[idx].clone(),
+            live_out: live_out[idx].clone(),
+            defs: inst_defs[idx].clone(),
+            uses: inst_uses[idx].clone(),
+        })
+        .collect();
+
+    LivenessDebugInfo {
+        instructions: instruction_liveness,
+        live_ranges,
+        vreg_count: mir.vreg_count(),
     }
 }
 

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -13,7 +13,7 @@
 
 mod cfg_lower;
 mod emit;
-mod liveness;
+pub mod liveness;
 mod mir;
 mod regalloc;
 

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -267,6 +267,7 @@ pub use x86_64::generate;
 
 // Re-export shared types
 pub use index_map::{Handle, IndexMap};
+pub use regalloc::{InstructionLiveness, LivenessDebugInfo};
 pub use stack_frame::{
     ArgumentLocation, ReturnLocation, StackFrameInfo, StackSlot, generate_stack_frame_info,
 };

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -36,6 +36,118 @@ use crate::vreg::VReg;
 // Liveness Analysis Types
 // ============================================================================
 
+/// Debug information about liveness at a single instruction.
+///
+/// This provides detailed per-instruction information for debugging
+/// register allocation and understanding value lifetimes.
+#[derive(Debug, Clone)]
+pub struct InstructionLiveness {
+    /// Instruction index.
+    pub index: usize,
+    /// Virtual registers live before this instruction executes.
+    pub live_in: HashSet<VReg>,
+    /// Virtual registers live after this instruction executes.
+    pub live_out: HashSet<VReg>,
+    /// Virtual registers defined (written) by this instruction.
+    pub defs: Vec<VReg>,
+    /// Virtual registers used (read) by this instruction.
+    pub uses: Vec<VReg>,
+}
+
+/// Debug information about liveness for an entire function.
+///
+/// This provides detailed liveness information for debugging and
+/// visualization via `--emit liveness`.
+#[derive(Debug, Clone)]
+pub struct LivenessDebugInfo {
+    /// Per-instruction liveness information.
+    pub instructions: Vec<InstructionLiveness>,
+    /// Live ranges for each virtual register.
+    pub live_ranges: HashMap<VReg, LiveRange>,
+    /// Total number of virtual registers.
+    pub vreg_count: u32,
+}
+
+impl std::fmt::Display for LivenessDebugInfo {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        writeln!(f, "=== Liveness Analysis ===")?;
+        writeln!(f)?;
+
+        // Show per-instruction liveness
+        writeln!(f, "Per-Instruction Liveness:")?;
+        for inst in &self.instructions {
+            writeln!(f, "  Instruction {}:", inst.index)?;
+
+            // Format sets in sorted order for consistent output
+            let live_in: Vec<_> = {
+                let mut v: Vec<_> = inst.live_in.iter().collect();
+                v.sort();
+                v
+            };
+            let live_out: Vec<_> = {
+                let mut v: Vec<_> = inst.live_out.iter().collect();
+                v.sort();
+                v
+            };
+
+            writeln!(
+                f,
+                "    live-in:  {{{}}}",
+                live_in
+                    .iter()
+                    .map(|v| format!("{}", v))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )?;
+            writeln!(
+                f,
+                "    live-out: {{{}}}",
+                live_out
+                    .iter()
+                    .map(|v| format!("{}", v))
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            )?;
+
+            if !inst.defs.is_empty() {
+                writeln!(
+                    f,
+                    "    def: {}",
+                    inst.defs
+                        .iter()
+                        .map(|v| format!("{}", v))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )?;
+            }
+            if !inst.uses.is_empty() {
+                writeln!(
+                    f,
+                    "    use: {}",
+                    inst.uses
+                        .iter()
+                        .map(|v| format!("{}", v))
+                        .collect::<Vec<_>>()
+                        .join(", ")
+                )?;
+            }
+        }
+
+        writeln!(f)?;
+        writeln!(f, "Live Ranges (instruction indices):")?;
+
+        // Sort by vreg index for consistent output
+        let mut ranges: Vec<_> = self.live_ranges.iter().collect();
+        ranges.sort_by_key(|(vreg, _)| vreg.index());
+
+        for (vreg, range) in ranges {
+            writeln!(f, "  {}: [{}, {})", vreg, range.start, range.end + 1)?;
+        }
+
+        Ok(())
+    }
+}
+
 /// Live range for a virtual register.
 ///
 /// Represents the instruction range where this vreg's value is needed.

--- a/crates/rue-codegen/src/vreg.rs
+++ b/crates/rue-codegen/src/vreg.rs
@@ -13,7 +13,7 @@ use crate::index_map::Handle;
 /// Virtual registers are unlimited and allocated to physical registers
 /// during register allocation. They are target-independent; the mapping
 /// to physical registers happens in each backend's register allocator.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct VReg(u32);
 
 impl VReg {

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -14,7 +14,7 @@ use std::collections::{HashMap, HashSet};
 use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
 
 // Re-export shared types from the regalloc module
-pub use crate::regalloc::LiveRange;
+pub use crate::regalloc::{InstructionLiveness, LiveRange, LivenessDebugInfo};
 
 /// Type alias for x86_64-specific liveness info.
 pub type LivenessInfo = crate::regalloc::LivenessInfo<Reg>;
@@ -188,6 +188,156 @@ pub fn analyze(mir: &X86Mir) -> LivenessInfo {
         ranges,
         live_at,
         clobbers_at,
+    }
+}
+
+/// Compute detailed liveness debug information for X86Mir.
+///
+/// This provides more detailed output than `analyze()`, including per-instruction
+/// live-in/live-out sets and def/use information. Used by `--emit liveness`.
+pub fn analyze_debug(mir: &X86Mir) -> LivenessDebugInfo {
+    let instructions = mir.instructions();
+    let num_insts = instructions.len();
+
+    if num_insts == 0 {
+        return LivenessDebugInfo {
+            instructions: Vec::new(),
+            live_ranges: HashMap::new(),
+            vreg_count: mir.vreg_count(),
+        };
+    }
+
+    // Step 1: Build label -> instruction index map
+    let mut label_to_idx: HashMap<LabelId, usize> = HashMap::new();
+    for (idx, inst) in instructions.iter().enumerate() {
+        if let X86Inst::Label { id } = inst {
+            label_to_idx.insert(*id, idx);
+        }
+    }
+
+    // Step 2: Build successor lists for each instruction
+    let mut successors: Vec<Vec<usize>> = vec![Vec::new(); num_insts];
+    for (idx, inst) in instructions.iter().enumerate() {
+        match inst {
+            X86Inst::Jmp { label } => {
+                if let Some(&target) = label_to_idx.get(label) {
+                    successors[idx].push(target);
+                }
+            }
+            X86Inst::Jz { label }
+            | X86Inst::Jnz { label }
+            | X86Inst::Jo { label }
+            | X86Inst::Jno { label }
+            | X86Inst::Jb { label }
+            | X86Inst::Jae { label }
+            | X86Inst::Jbe { label }
+            | X86Inst::Jge { label }
+            | X86Inst::Jle { label } => {
+                if idx + 1 < num_insts {
+                    successors[idx].push(idx + 1);
+                }
+                if let Some(&target) = label_to_idx.get(label) {
+                    successors[idx].push(target);
+                }
+            }
+            X86Inst::Ret => {}
+            X86Inst::CallRel { .. } => {
+                if idx + 1 < num_insts {
+                    successors[idx].push(idx + 1);
+                }
+            }
+            _ => {
+                if idx + 1 < num_insts {
+                    successors[idx].push(idx + 1);
+                }
+            }
+        }
+    }
+
+    // Step 3: Backward dataflow analysis
+    let mut live_in: Vec<HashSet<VReg>> = vec![HashSet::new(); num_insts];
+    let mut live_out: Vec<HashSet<VReg>> = vec![HashSet::new(); num_insts];
+
+    let inst_uses: Vec<Vec<VReg>> = instructions.iter().map(uses).collect();
+    let inst_defs: Vec<Vec<VReg>> = instructions.iter().map(defs).collect();
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+
+        for idx in (0..num_insts).rev() {
+            let mut new_live_out = HashSet::new();
+            for &succ in &successors[idx] {
+                new_live_out.extend(&live_in[succ]);
+            }
+
+            let mut new_live_in: HashSet<VReg> = new_live_out.clone();
+            for vreg in &inst_defs[idx] {
+                new_live_in.remove(vreg);
+            }
+            for vreg in &inst_uses[idx] {
+                new_live_in.insert(*vreg);
+            }
+
+            if new_live_in != live_in[idx] || new_live_out != live_out[idx] {
+                changed = true;
+                live_in[idx] = new_live_in;
+                live_out[idx] = new_live_out;
+            }
+        }
+    }
+
+    // Step 4: Build live ranges from dataflow results
+    let mut first_live: HashMap<VReg, usize> = HashMap::new();
+    let mut last_live: HashMap<VReg, usize> = HashMap::new();
+
+    for idx in 0..num_insts {
+        for vreg in &inst_defs[idx] {
+            first_live.entry(*vreg).or_insert(idx);
+            last_live.insert(*vreg, idx);
+        }
+        for vreg in &inst_uses[idx] {
+            first_live.entry(*vreg).or_insert(idx);
+            last_live.insert(*vreg, idx);
+        }
+        for vreg in &live_in[idx] {
+            first_live.entry(*vreg).or_insert(idx);
+            if last_live.get(vreg).is_none_or(|&last| idx > last) {
+                last_live.insert(*vreg, idx);
+            }
+        }
+        for vreg in &live_out[idx] {
+            first_live.entry(*vreg).or_insert(idx);
+            if last_live.get(vreg).is_none_or(|&last| idx > last) {
+                last_live.insert(*vreg, idx);
+            }
+        }
+    }
+
+    // Build ranges
+    let mut live_ranges: HashMap<VReg, crate::regalloc::LiveRange> = HashMap::new();
+    for vreg_idx in 0..mir.vreg_count() {
+        let vreg = VReg::new(vreg_idx);
+        if let (Some(&start), Some(&end)) = (first_live.get(&vreg), last_live.get(&vreg)) {
+            live_ranges.insert(vreg, crate::regalloc::LiveRange::new(start, end));
+        }
+    }
+
+    // Build per-instruction liveness info
+    let instruction_liveness: Vec<InstructionLiveness> = (0..num_insts)
+        .map(|idx| InstructionLiveness {
+            index: idx,
+            live_in: live_in[idx].clone(),
+            live_out: live_out[idx].clone(),
+            defs: inst_defs[idx].clone(),
+            uses: inst_uses[idx].clone(),
+        })
+        .collect();
+
+    LivenessDebugInfo {
+        instructions: instruction_liveness,
+        live_ranges,
+        vreg_count: mir.vreg_count(),
     }
 }
 

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -13,7 +13,7 @@
 
 mod cfg_lower;
 mod emit;
-mod liveness;
+pub mod liveness;
 mod mir;
 mod regalloc;
 

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -745,6 +745,33 @@ pub fn generate_allocated_mir(
     }
 }
 
+/// Generate liveness debug information for a CFG.
+///
+/// This performs liveness analysis on the MIR (before register allocation)
+/// and returns detailed per-instruction liveness information.
+///
+/// Used by `--emit liveness` to visualize which values are live at each program point.
+pub fn generate_liveness_info(
+    cfg: &Cfg,
+    struct_defs: &[StructDef],
+    array_types: &[ArrayTypeDef],
+    strings: &[String],
+    target: Target,
+) -> rue_codegen::LivenessDebugInfo {
+    match target.arch() {
+        Arch::X86_64 => {
+            let mir =
+                rue_codegen::x86_64::CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+            rue_codegen::x86_64::liveness::analyze_debug(&mir)
+        }
+        Arch::Aarch64 => {
+            let mir =
+                rue_codegen::aarch64::CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+            rue_codegen::aarch64::liveness::analyze_debug(&mir)
+        }
+    }
+}
+
 /// Generate the actual emitted assembly text for a CFG.
 ///
 /// Unlike `format_assembly()` on Mir which shows MIR instructions,

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -6,7 +6,8 @@ use std::path::Path;
 use rue_compiler::{
     CompileOptions, DiagnosticFormatter, Lexer, LinkerMode, OptLevel, Parser, PreviewFeature,
     PreviewFeatures, SourceInfo, compile_frontend_from_ast_with_options, compile_with_options,
-    generate_allocated_mir, generate_emitted_asm, generate_mir, generate_stack_frame_info,
+    generate_allocated_mir, generate_emitted_asm, generate_liveness_info, generate_mir,
+    generate_stack_frame_info,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
@@ -26,6 +27,8 @@ enum EmitStage {
     Cfg,
     /// Emit MIR (machine intermediate representation).
     Mir,
+    /// Emit liveness analysis information.
+    Liveness,
     /// Emit assembly text.
     Asm,
     /// Emit stack frame layout per function.
@@ -55,6 +58,7 @@ impl std::str::FromStr for EmitStage {
             "air" => Ok(EmitStage::Air),
             "cfg" => Ok(EmitStage::Cfg),
             "mir" => Ok(EmitStage::Mir),
+            "liveness" => Ok(EmitStage::Liveness),
             "asm" => Ok(EmitStage::Asm),
             "stackframe" => Ok(EmitStage::StackFrame),
             _ => Err(ParseEmitStageError(s.to_string())),
@@ -64,7 +68,7 @@ impl std::str::FromStr for EmitStage {
 
 impl EmitStage {
     fn all_names() -> &'static str {
-        "tokens, ast, rir, air, cfg, mir, asm, stackframe"
+        "tokens, ast, rir, air, cfg, mir, liveness, asm, stackframe"
     }
 }
 
@@ -356,6 +360,7 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
             | EmitStage::Air
             | EmitStage::Cfg
             | EmitStage::Mir
+            | EmitStage::Liveness
             | EmitStage::Asm
             | EmitStage::StackFrame => 2,
         })
@@ -478,6 +483,23 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
                         );
                         println!("function {}:", func.analyzed.name);
                         println!("{}", mir);
+                    }
+                }
+                println!();
+            }
+            EmitStage::Liveness => {
+                println!("=== Liveness Analysis ({}) ===", options.target);
+                if let Some(ref state) = frontend_state {
+                    for func in &state.functions {
+                        println!("function {}:", func.analyzed.name);
+                        let liveness_info = generate_liveness_info(
+                            &func.cfg,
+                            &state.struct_defs,
+                            &state.array_types,
+                            &state.strings,
+                            options.target,
+                        );
+                        println!("{}", liveness_info);
                     }
                 }
                 println!();
@@ -893,6 +915,10 @@ mod tests {
         assert_eq!("air".parse::<EmitStage>().unwrap(), EmitStage::Air);
         assert_eq!("cfg".parse::<EmitStage>().unwrap(), EmitStage::Cfg);
         assert_eq!("mir".parse::<EmitStage>().unwrap(), EmitStage::Mir);
+        assert_eq!(
+            "liveness".parse::<EmitStage>().unwrap(),
+            EmitStage::Liveness
+        );
         assert_eq!("asm".parse::<EmitStage>().unwrap(), EmitStage::Asm);
         assert_eq!(
             "stackframe".parse::<EmitStage>().unwrap(),
@@ -910,7 +936,7 @@ mod tests {
     fn emit_stage_all_names() {
         assert_eq!(
             EmitStage::all_names(),
-            "tokens, ast, rir, air, cfg, mir, asm, stackframe"
+            "tokens, ast, rir, air, cfg, mir, liveness, asm, stackframe"
         );
     }
 
@@ -918,5 +944,11 @@ mod tests {
     fn parse_emit_stackframe() {
         let opts = unwrap_options(parse_args_from(&["--emit", "stackframe", "source.rue"]));
         assert_eq!(opts.emit_stages, vec![EmitStage::StackFrame]);
+    }
+
+    #[test]
+    fn parse_emit_liveness() {
+        let opts = unwrap_options(parse_args_from(&["--emit", "liveness", "source.rue"]));
+        assert_eq!(opts.emit_stages, vec![EmitStage::Liveness]);
     }
 }


### PR DESCRIPTION
Add a new emission stage that displays detailed liveness analysis information including per-instruction live-in/live-out sets and computed live ranges for each virtual register. This helps debug register allocation issues by showing which values are live at each program point.

Fixes rue-ggcb

🤖 Generated with [Claude Code](https://claude.com/claude-code)