### PR TITLE
Enable Buck2 execution platforms for BXL rust-analyzer integration

### DIFF
--- a/.buckconfig
+++ b/.buckconfig
@@ -18,5 +18,8 @@ target_platform_detector_spec = target:root//...->prelude//platforms:default tar
 [rust]
 edition = 2024
 
+[build]
+execution_platforms = prelude//platforms:default
+
 [buck2]
 materializations = deferred

--- a/rust-project.json
+++ b/rust-project.json
@@ -120,6 +120,10 @@
         {
           "crate": 12,
           "name": "rue_span"
+        },
+        {
+          "crate": 14,
+          "name": "rue_target"
         }
       ],
       "is_workspace_member": true,


### PR DESCRIPTION
Add build.execution_platforms setting to .buckconfig pointing to prelude//platforms:default. This allows the prelude's BXL-based rust-analyzer integration (prelude//rust/rust-analyzer:resolve_deps.bxl) to function, which requires execution platforms to use bxl_actions().

The existing gen-rust-project.sh workaround continues to work.

Fixes rue-jbtp

🤖 Generated with [Claude Code](https://claude.com/claude-code)