### PR TITLE
Remove dead And/Or variants from CfgInstData

### DIFF
--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -143,10 +143,6 @@ pub enum CfgInstData {
     Le(CfgValue, CfgValue),
     Ge(CfgValue, CfgValue),
 
-    // Logical operations (return bool)
-    And(CfgValue, CfgValue),
-    Or(CfgValue, CfgValue),
-
     // Bitwise operations
     BitAnd(CfgValue, CfgValue),
     BitOr(CfgValue, CfgValue),
@@ -705,8 +701,6 @@ impl Cfg {
             CfgInstData::Gt(lhs, rhs) => write!(f, "gt {}, {}", lhs, rhs),
             CfgInstData::Le(lhs, rhs) => write!(f, "le {}, {}", lhs, rhs),
             CfgInstData::Ge(lhs, rhs) => write!(f, "ge {}, {}", lhs, rhs),
-            CfgInstData::And(lhs, rhs) => write!(f, "and {}, {}", lhs, rhs),
-            CfgInstData::Or(lhs, rhs) => write!(f, "or {}, {}", lhs, rhs),
             CfgInstData::BitAnd(lhs, rhs) => write!(f, "bit_and {}, {}", lhs, rhs),
             CfgInstData::BitOr(lhs, rhs) => write!(f, "bit_or {}, {}", lhs, rhs),
             CfgInstData::BitXor(lhs, rhs) => write!(f, "bit_xor {}, {}", lhs, rhs),

--- a/crates/rue-cfg/src/opt/constfold.rs
+++ b/crates/rue-cfg/src/opt/constfold.rs
@@ -81,10 +81,6 @@ fn fold_instruction(cfg: &mut Cfg, value: CfgValue) {
             fold_comparison_signed(cfg, *lhs, *rhs, lhs_ty, |a, b| a >= b, |a, b| a >= b)
         }
 
-        // Logical (bool -> bool)
-        CfgInstData::And(lhs, rhs) => fold_logical(cfg, *lhs, *rhs, |a, b| a && b),
-        CfgInstData::Or(lhs, rhs) => fold_logical(cfg, *lhs, *rhs, |a, b| a || b),
-
         // Bitwise
         CfgInstData::BitAnd(lhs, rhs) => fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| Some(a & b)),
         CfgInstData::BitOr(lhs, rhs) => fold_binary_arith(cfg, *lhs, *rhs, ty, |a, b| Some(a | b)),
@@ -162,17 +158,6 @@ where
         unsigned_op(lhs_val, rhs_val)
     };
 
-    Some(CfgInstData::BoolConst(result))
-}
-
-/// Try to fold a logical operation on two constant boolean operands.
-fn fold_logical<F>(cfg: &Cfg, lhs: CfgValue, rhs: CfgValue, op: F) -> Option<CfgInstData>
-where
-    F: FnOnce(bool, bool) -> bool,
-{
-    let lhs_val = get_const_bool(cfg, lhs)?;
-    let rhs_val = get_const_bool(cfg, rhs)?;
-    let result = op(lhs_val, rhs_val);
     Some(CfgInstData::BoolConst(result))
 }
 
@@ -501,31 +486,6 @@ mod tests {
         match &cfg.get_inst(add).data {
             CfgInstData::Add(_, _) => {}
             other => panic!("Expected Add to remain unfold, got {:?}", other),
-        }
-    }
-
-    #[test]
-    fn test_fold_logical_and() {
-        let mut cfg = make_cfg();
-        let c1 = add_bool_const(&mut cfg, true);
-        let c2 = add_bool_const(&mut cfg, false);
-        let entry = cfg.entry;
-        let and_val = cfg.add_inst_to_block(
-            entry,
-            CfgInst {
-                data: CfgInstData::And(c1, c2),
-                ty: Type::Bool,
-                span: Span::new(0, 0),
-            },
-        );
-        finalize_cfg(&mut cfg, and_val);
-
-        run(&mut cfg);
-
-        // true && false = false
-        match &cfg.get_inst(and_val).data {
-            CfgInstData::BoolConst(false) => {}
-            other => panic!("Expected BoolConst(false), got {:?}", other),
         }
     }
 

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -164,8 +164,6 @@ fn instruction_uses(cfg: &Cfg, value: CfgValue) -> Vec<CfgValue> {
         | CfgInstData::Gt(lhs, rhs)
         | CfgInstData::Le(lhs, rhs)
         | CfgInstData::Ge(lhs, rhs)
-        | CfgInstData::And(lhs, rhs)
-        | CfgInstData::Or(lhs, rhs)
         | CfgInstData::BitAnd(lhs, rhs)
         | CfgInstData::BitOr(lhs, rhs)
         | CfgInstData::BitXor(lhs, rhs)

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -827,34 +827,6 @@ impl<'a> CfgLower<'a> {
                 self.emit_comparison(value, *lhs, *rhs, cond);
             }
 
-            CfgInstData::And(lhs, rhs) => {
-                let vreg = self.mir.alloc_vreg();
-                self.value_map.insert(value, vreg);
-
-                let lhs_vreg = self.get_vreg(*lhs);
-                let rhs_vreg = self.get_vreg(*rhs);
-
-                self.mir.push(Aarch64Inst::AndRR {
-                    dst: Operand::Virtual(vreg),
-                    src1: Operand::Virtual(lhs_vreg),
-                    src2: Operand::Virtual(rhs_vreg),
-                });
-            }
-
-            CfgInstData::Or(lhs, rhs) => {
-                let vreg = self.mir.alloc_vreg();
-                self.value_map.insert(value, vreg);
-
-                let lhs_vreg = self.get_vreg(*lhs);
-                let rhs_vreg = self.get_vreg(*rhs);
-
-                self.mir.push(Aarch64Inst::OrrRR {
-                    dst: Operand::Virtual(vreg),
-                    src1: Operand::Virtual(lhs_vreg),
-                    src2: Operand::Virtual(rhs_vreg),
-                });
-            }
-
             CfgInstData::BitNot(operand) => {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1136,40 +1136,6 @@ impl<'a> CfgLower<'a> {
                 });
             }
 
-            CfgInstData::And(lhs, rhs) => {
-                let vreg = self.mir.alloc_vreg();
-                self.value_map.insert(value, vreg);
-
-                let lhs_vreg = self.get_vreg(*lhs);
-                let rhs_vreg = self.get_vreg(*rhs);
-
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(vreg),
-                    src: Operand::Virtual(lhs_vreg),
-                });
-                self.mir.push(X86Inst::AndRR {
-                    dst: Operand::Virtual(vreg),
-                    src: Operand::Virtual(rhs_vreg),
-                });
-            }
-
-            CfgInstData::Or(lhs, rhs) => {
-                let vreg = self.mir.alloc_vreg();
-                self.value_map.insert(value, vreg);
-
-                let lhs_vreg = self.get_vreg(*lhs);
-                let rhs_vreg = self.get_vreg(*rhs);
-
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(vreg),
-                    src: Operand::Virtual(lhs_vreg),
-                });
-                self.mir.push(X86Inst::OrRR {
-                    dst: Operand::Virtual(vreg),
-                    src: Operand::Virtual(rhs_vreg),
-                });
-            }
-
             CfgInstData::Alloc { slot, init } => {
                 let init_type = self.cfg.get_inst(*init).ty;
                 if matches!(init_type, Type::Array(_)) {


### PR DESCRIPTION
The CfgInstData::And and CfgInstData::Or variants were never emitted during CFG construction. The CFG builder lowers AirInstData::And/Or to branching control flow (short-circuit evaluation) instead.

This removes the dead code from:
- CfgInstData enum definition
- Display implementation
- Const folding (including fold_logical helper and its test)
- Dead code elimination
- Both x86_64 and aarch64 codegen backends

Fixes rue-aez6

🤖 Generated with [Claude Code](https://claude.ai/code)