### PR TITLE
Add --emit regalloc for register allocation debug output

### DIFF
--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -27,6 +27,7 @@ use rue_cfg::Cfg;
 use rue_error::CompileResult;
 
 use crate::MachineCode;
+use crate::regalloc::RegAllocDebugInfo;
 
 // Re-export from parent
 pub use super::{EmittedCode, EmittedRelocation};
@@ -97,4 +98,28 @@ pub fn generate_with_asm(
     };
 
     Ok((machine_code, asm))
+}
+
+/// Generate register allocation debug info from CFG.
+///
+/// This returns information about the register allocation process,
+/// including live ranges, interference, and allocation decisions.
+pub fn generate_regalloc_info(
+    cfg: &Cfg,
+    struct_defs: &[StructDef],
+    array_types: &[ArrayTypeDef],
+    strings: &[String],
+) -> CompileResult<RegAllocDebugInfo<Reg>> {
+    let num_locals = cfg.num_locals();
+    let num_params = cfg.num_params();
+
+    // Lower CFG to Aarch64Mir with virtual registers
+    let mir = CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+
+    // Allocate physical registers with debug info
+    let existing_slots = num_locals + num_params;
+    let (_mir, _num_spills, _used_callee_saved, debug_info) =
+        RegAlloc::new(mir, existing_slots).allocate_with_debug()?;
+
+    Ok(debug_info)
 }

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -9,7 +9,7 @@ use super::liveness::{self, LivenessInfo};
 use super::mir::{Aarch64Inst, Aarch64Mir, Operand, Reg, VReg};
 use crate::alloc_dst;
 use crate::index_map::IndexMap;
-use crate::regalloc::{Allocation, linear_scan};
+use crate::regalloc::{Allocation, RegAllocDebugInfo, linear_scan, linear_scan_with_debug};
 
 /// Available registers for allocation.
 ///
@@ -90,6 +90,23 @@ impl RegAlloc {
         Ok((self.mir, num_spills, used_callee_saved))
     }
 
+    /// Perform register allocation and return debug information.
+    ///
+    /// This is used by `--emit regalloc` to show allocation decisions.
+    pub fn allocate_with_debug(
+        mut self,
+    ) -> CompileResult<(Aarch64Mir, u32, Vec<Reg>, RegAllocDebugInfo<Reg>)> {
+        // Phase 1: Assign physical registers with debug info
+        let debug_info = self.assign_registers_with_debug();
+
+        // Phase 2: Rewrite instructions to use physical registers and insert spill code
+        self.rewrite_instructions()?;
+
+        let num_spills = self.num_spills;
+        let used_callee_saved = self.used_callee_saved;
+        Ok((self.mir, num_spills, used_callee_saved, debug_info))
+    }
+
     /// Assign physical registers to all virtual registers using linear scan.
     fn assign_registers(&mut self) {
         let (allocation, num_spills, used_callee_saved) = linear_scan(
@@ -101,6 +118,20 @@ impl RegAlloc {
         self.allocation = allocation;
         self.num_spills = num_spills;
         self.used_callee_saved = used_callee_saved;
+    }
+
+    /// Assign physical registers and also collect debug information.
+    fn assign_registers_with_debug(&mut self) -> RegAllocDebugInfo<Reg> {
+        let (allocation, num_spills, used_callee_saved, debug_info) = linear_scan_with_debug(
+            self.mir.vreg_count(),
+            &self.liveness,
+            ALLOCATABLE_REGS,
+            self.existing_locals,
+        );
+        self.allocation = allocation;
+        self.num_spills = num_spills;
+        self.used_callee_saved = used_callee_saved;
+        debug_info
     }
 
     fn rewrite_instructions(&mut self) -> CompileResult<()> {

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -267,7 +267,9 @@ pub use x86_64::generate;
 
 // Re-export shared types
 pub use index_map::{Handle, IndexMap};
-pub use regalloc::{InstructionLiveness, LivenessDebugInfo};
+pub use regalloc::{
+    Allocation, InstructionLiveness, LivenessDebugInfo, RegAllocDebugInfo, linear_scan_with_debug,
+};
 pub use stack_frame::{
     ArgumentLocation, ReturnLocation, StackFrameInfo, StackSlot, generate_stack_frame_info,
 };

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -28,6 +28,7 @@
 //! longest time.
 
 use std::collections::{HashMap, HashSet};
+use std::fmt;
 
 use crate::index_map::IndexMap;
 use crate::vreg::VReg;
@@ -353,6 +354,85 @@ pub enum Allocation<Reg: Copy> {
     Spill(i32),
 }
 
+// ============================================================================
+// Register Allocation Debug Info
+// ============================================================================
+
+/// Debug information from register allocation.
+///
+/// This captures the decisions made by the register allocator for display
+/// via `--emit regalloc`. It includes live ranges, interference edges,
+/// final allocations, and spill information.
+#[derive(Debug, Clone)]
+pub struct RegAllocDebugInfo<Reg: Copy + Eq + std::hash::Hash> {
+    /// Live range for each virtual register: (vreg_index, start, end).
+    pub live_ranges: Vec<(u32, usize, usize)>,
+    /// Interference edges: pairs of vregs that are both live at the same point.
+    pub interference: Vec<(u32, u32)>,
+    /// Final allocation for each vreg: (vreg_index, allocation).
+    pub allocations: Vec<(u32, Allocation<Reg>)>,
+    /// Virtual registers that were spilled.
+    pub spills: Vec<u32>,
+    /// Callee-saved registers that were used.
+    pub callee_saved_used: Vec<Reg>,
+}
+
+impl<Reg: Copy + Eq + std::hash::Hash + fmt::Display> fmt::Display for RegAllocDebugInfo<Reg> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "Live Ranges:")?;
+        for (vreg, start, end) in &self.live_ranges {
+            writeln!(f, "  v{}: [{}, {})", vreg, start, end)?;
+        }
+        writeln!(f)?;
+
+        writeln!(f, "Interference Graph:")?;
+        if self.interference.is_empty() {
+            writeln!(f, "  (no interference)")?;
+        } else {
+            for (v1, v2) in &self.interference {
+                writeln!(f, "  v{} -- v{}", v1, v2)?;
+            }
+        }
+        writeln!(f)?;
+
+        writeln!(f, "Allocation:")?;
+        for (vreg, alloc) in &self.allocations {
+            match alloc {
+                Allocation::Register(reg) => writeln!(f, "  v{} -> {}", vreg, reg)?,
+                Allocation::Spill(offset) => writeln!(f, "  v{} -> [stack{}]", vreg, offset)?,
+            }
+        }
+        writeln!(f)?;
+
+        writeln!(f, "Spills:")?;
+        if self.spills.is_empty() {
+            writeln!(f, "  none")?;
+        } else {
+            for vreg in &self.spills {
+                write!(f, "  v{}", vreg)?;
+            }
+            writeln!(f)?;
+        }
+        writeln!(f)?;
+
+        writeln!(f, "Callee-saved registers used:")?;
+        if self.callee_saved_used.is_empty() {
+            writeln!(f, "  none")?;
+        } else {
+            write!(f, " ")?;
+            for (i, reg) in self.callee_saved_used.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                write!(f, " {}", reg)?;
+            }
+            writeln!(f)?;
+        }
+
+        Ok(())
+    }
+}
+
 /// Perform linear scan register allocation.
 ///
 /// This function implements the core linear scan algorithm that is shared
@@ -466,6 +546,145 @@ pub fn linear_scan<Reg: Copy + Eq + std::hash::Hash>(
     }
 
     (allocation, num_spills, used_callee_saved)
+}
+
+/// Perform linear scan register allocation and return debug information.
+///
+/// This is the same as [`linear_scan`] but also collects debug information
+/// about the allocation process for display via `--emit regalloc`.
+pub fn linear_scan_with_debug<Reg: Copy + Eq + std::hash::Hash>(
+    vreg_count: u32,
+    liveness: &LivenessInfo<Reg>,
+    allocatable_regs: &[Reg],
+    existing_locals: u32,
+) -> (
+    IndexMap<VReg, Option<Allocation<Reg>>>,
+    u32,
+    Vec<Reg>,
+    RegAllocDebugInfo<Reg>,
+) {
+    let vreg_count_usize = vreg_count as usize;
+
+    // Initialize allocation map
+    let mut allocation: IndexMap<VReg, Option<Allocation<Reg>>> =
+        IndexMap::with_capacity(vreg_count_usize);
+    allocation.resize(vreg_count_usize, None);
+
+    // Spill slots start after existing locals
+    // Each local is 8 bytes, slot 0 is at [fp-8], etc.
+    let mut next_spill_offset = -((existing_locals as i32 + 1) * 8);
+    let mut num_spills = 0u32;
+    let mut used_callee_saved: Vec<Reg> = Vec::new();
+
+    // Debug info collections
+    let mut debug_live_ranges: Vec<(u32, usize, usize)> = Vec::new();
+    let mut debug_interference: Vec<(u32, u32)> = Vec::new();
+    let mut debug_spills: Vec<u32> = Vec::new();
+
+    // Collect vregs with live ranges and sort by start
+    let mut vregs_by_start: Vec<(VReg, LiveRange)> = Vec::with_capacity(vreg_count_usize);
+    for vreg_idx in 0..vreg_count {
+        let vreg = VReg::new(vreg_idx);
+        if let Some(&range) = liveness.range(vreg) {
+            vregs_by_start.push((vreg, range));
+            debug_live_ranges.push((vreg_idx, range.start, range.end));
+        }
+    }
+    vregs_by_start.sort_by_key(|(_, range)| range.start);
+
+    // Build interference graph: vregs that overlap
+    for i in 0..vregs_by_start.len() {
+        for j in (i + 1)..vregs_by_start.len() {
+            let (vreg1, range1) = &vregs_by_start[i];
+            let (vreg2, range2) = &vregs_by_start[j];
+            if range1.overlaps(range2) {
+                debug_interference.push((vreg1.index(), vreg2.index()));
+            }
+        }
+    }
+
+    // Track which registers are currently in use and when they become free
+    // Tuple: (vreg, physical reg, live range end)
+    let mut active: Vec<(VReg, Reg, usize)> = Vec::with_capacity(allocatable_regs.len());
+
+    for (vreg, range) in vregs_by_start {
+        // Expire old intervals - remove registers whose vregs are no longer live
+        active.retain(|&(_, _, end)| end >= range.start);
+
+        // Find registers currently in use
+        let used_regs: HashSet<Reg> = active.iter().map(|&(_, reg, _)| reg).collect();
+
+        // Try to find a free register
+        let mut allocated_reg = None;
+        for &reg in allocatable_regs {
+            if !used_regs.contains(&reg) {
+                allocated_reg = Some(reg);
+                break;
+            }
+        }
+
+        if let Some(reg) = allocated_reg {
+            // Assign this register
+            allocation[vreg] = Some(Allocation::Register(reg));
+            active.push((vreg, reg, range.end));
+            // Track callee-saved register usage
+            if !used_callee_saved.contains(&reg) {
+                used_callee_saved.push(reg);
+            }
+        } else {
+            // No free register - need to spill
+            // Strategy: spill the vreg with the longest remaining live range
+            // (including the current one)
+
+            // Find the vreg with the longest remaining range
+            let mut longest_idx = None;
+            let mut longest_end = range.end;
+            for (i, &(_, _, end)) in active.iter().enumerate() {
+                if end > longest_end {
+                    longest_end = end;
+                    longest_idx = Some(i);
+                }
+            }
+
+            if let Some(idx) = longest_idx {
+                // Spill the existing vreg with longest range
+                let (spilled_vreg, freed_reg, _) = active.remove(idx);
+                let spill_offset = next_spill_offset;
+                next_spill_offset -= 8;
+                num_spills += 1;
+                allocation[spilled_vreg] = Some(Allocation::Spill(spill_offset));
+                debug_spills.push(spilled_vreg.index());
+
+                // Give the freed register to the current vreg
+                allocation[vreg] = Some(Allocation::Register(freed_reg));
+                active.push((vreg, freed_reg, range.end));
+            } else {
+                // Current vreg has the longest range, spill it
+                let spill_offset = next_spill_offset;
+                next_spill_offset -= 8;
+                num_spills += 1;
+                allocation[vreg] = Some(Allocation::Spill(spill_offset));
+                debug_spills.push(vreg.index());
+            }
+        }
+    }
+
+    // Build final allocation list
+    let debug_allocations: Vec<(u32, Allocation<Reg>)> = allocation
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, alloc)| alloc.map(|a| (idx as u32, a)))
+        .collect();
+
+    let debug_info = RegAllocDebugInfo {
+        live_ranges: debug_live_ranges,
+        interference: debug_interference,
+        allocations: debug_allocations,
+        spills: debug_spills,
+        callee_saved_used: used_callee_saved.clone(),
+    };
+
+    (allocation, num_spills, used_callee_saved, debug_info)
 }
 
 #[cfg(test)]

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -22,6 +22,8 @@ pub use emit::Emitter;
 pub use mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
 pub use regalloc::RegAlloc;
 
+use crate::regalloc::RegAllocDebugInfo;
+
 use rue_air::{ArrayTypeDef, StructDef};
 use rue_cfg::Cfg;
 use rue_error::CompileResult;
@@ -114,4 +116,28 @@ pub fn generate_with_asm(
     };
 
     Ok((machine_code, asm))
+}
+
+/// Generate register allocation debug info from CFG.
+///
+/// This returns information about the register allocation process,
+/// including live ranges, interference, and allocation decisions.
+pub fn generate_regalloc_info(
+    cfg: &Cfg,
+    struct_defs: &[StructDef],
+    array_types: &[ArrayTypeDef],
+    strings: &[String],
+) -> CompileResult<RegAllocDebugInfo<Reg>> {
+    let num_locals = cfg.num_locals();
+    let num_params = cfg.num_params();
+
+    // Lower CFG to X86Mir with virtual registers
+    let mir = CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+
+    // Allocate physical registers with debug info
+    let existing_slots = num_locals + num_params;
+    let (_mir, _num_spills, _used_callee_saved, debug_info) =
+        RegAlloc::new(mir, existing_slots).allocate_with_debug()?;
+
+    Ok(debug_info)
 }

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -16,7 +16,7 @@ use super::liveness::{self, LivenessInfo};
 use super::mir::{Operand, Reg, VReg, X86Inst, X86Mir};
 use crate::alloc_dst;
 use crate::index_map::IndexMap;
-use crate::regalloc::{Allocation, linear_scan};
+use crate::regalloc::{Allocation, RegAllocDebugInfo, linear_scan, linear_scan_with_debug};
 
 /// Available registers for allocation.
 ///
@@ -105,6 +105,23 @@ impl RegAlloc {
         Ok((self.mir, num_spills, used_callee_saved))
     }
 
+    /// Perform register allocation and return debug information.
+    ///
+    /// This is used by `--emit regalloc` to show allocation decisions.
+    pub fn allocate_with_debug(
+        mut self,
+    ) -> CompileResult<(X86Mir, u32, Vec<Reg>, RegAllocDebugInfo<Reg>)> {
+        // Phase 1: Assign physical registers with debug info
+        let debug_info = self.assign_registers_with_debug();
+
+        // Phase 2: Rewrite instructions to use physical registers and insert spill code
+        self.rewrite_instructions()?;
+
+        let num_spills = self.num_spills;
+        let used_callee_saved = self.used_callee_saved;
+        Ok((self.mir, num_spills, used_callee_saved, debug_info))
+    }
+
     /// Assign physical registers to all virtual registers using linear scan.
     fn assign_registers(&mut self) {
         let (allocation, num_spills, used_callee_saved) = linear_scan(
@@ -116,6 +133,20 @@ impl RegAlloc {
         self.allocation = allocation;
         self.num_spills = num_spills;
         self.used_callee_saved = used_callee_saved;
+    }
+
+    /// Assign physical registers and also collect debug information.
+    fn assign_registers_with_debug(&mut self) -> RegAllocDebugInfo<Reg> {
+        let (allocation, num_spills, used_callee_saved, debug_info) = linear_scan_with_debug(
+            self.mir.vreg_count(),
+            &self.liveness,
+            ALLOCATABLE_REGS,
+            self.existing_locals,
+        );
+        self.allocation = allocation;
+        self.num_spills = num_spills;
+        self.used_callee_saved = used_callee_saved;
+        debug_info
     }
 
     /// Rewrite all instructions to use physical registers and handle spills.

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -155,7 +155,8 @@ pub fn validate_runtime() -> Result<(), String> {
 pub use rue_air::{Air, AnalyzedFunction, ArrayTypeDef, Sema, SemaOutput, StructDef, Type};
 pub use rue_cfg::{Cfg, CfgBuilder, CfgOutput, OptLevel};
 pub use rue_codegen::{
-    RelocationKind, StackFrameInfo, X86Mir, aarch64::Aarch64Mir, generate_stack_frame_info,
+    RegAllocDebugInfo, RelocationKind, StackFrameInfo, X86Mir, aarch64::Aarch64Mir,
+    generate_stack_frame_info,
 };
 pub use rue_error::{
     CompileError, CompileResult, CompileWarning, Diagnostic, ErrorKind, PreviewFeature,
@@ -798,6 +799,40 @@ pub fn generate_emitted_asm(
             // TODO: Implement emit_all for aarch64 in Phase 2
             let mir = generate_allocated_mir(cfg, struct_defs, array_types, strings, target)?;
             Ok(mir.format_assembly())
+        }
+    }
+}
+
+/// Generate register allocation debug information for a CFG.
+///
+/// This returns information about the register allocation process,
+/// including live ranges, interference edges, and allocation decisions.
+/// The output is formatted as a human-readable string.
+pub fn generate_regalloc_info(
+    cfg: &Cfg,
+    struct_defs: &[StructDef],
+    array_types: &[ArrayTypeDef],
+    strings: &[String],
+    target: Target,
+) -> CompileResult<String> {
+    match target.arch() {
+        Arch::X86_64 => {
+            let debug_info = rue_codegen::x86_64::generate_regalloc_info(
+                cfg,
+                struct_defs,
+                array_types,
+                strings,
+            )?;
+            Ok(debug_info.to_string())
+        }
+        Arch::Aarch64 => {
+            let debug_info = rue_codegen::aarch64::generate_regalloc_info(
+                cfg,
+                struct_defs,
+                array_types,
+                strings,
+            )?;
+            Ok(debug_info.to_string())
         }
     }
 }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -7,7 +7,7 @@ use rue_compiler::{
     CompileOptions, DiagnosticFormatter, Lexer, LinkerMode, OptLevel, Parser, PreviewFeature,
     PreviewFeatures, SourceInfo, compile_frontend_from_ast_with_options, compile_with_options,
     generate_allocated_mir, generate_emitted_asm, generate_liveness_info, generate_mir,
-    generate_stack_frame_info,
+    generate_regalloc_info, generate_stack_frame_info,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
@@ -29,6 +29,8 @@ enum EmitStage {
     Mir,
     /// Emit liveness analysis information.
     Liveness,
+    /// Emit register allocation debug info.
+    RegAlloc,
     /// Emit assembly text.
     Asm,
     /// Emit stack frame layout per function.
@@ -59,6 +61,7 @@ impl std::str::FromStr for EmitStage {
             "cfg" => Ok(EmitStage::Cfg),
             "mir" => Ok(EmitStage::Mir),
             "liveness" => Ok(EmitStage::Liveness),
+            "regalloc" => Ok(EmitStage::RegAlloc),
             "asm" => Ok(EmitStage::Asm),
             "stackframe" => Ok(EmitStage::StackFrame),
             _ => Err(ParseEmitStageError(s.to_string())),
@@ -68,7 +71,7 @@ impl std::str::FromStr for EmitStage {
 
 impl EmitStage {
     fn all_names() -> &'static str {
-        "tokens, ast, rir, air, cfg, mir, liveness, asm, stackframe"
+        "tokens, ast, rir, air, cfg, mir, liveness, regalloc, asm, stackframe"
     }
 }
 
@@ -361,6 +364,7 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
             | EmitStage::Cfg
             | EmitStage::Mir
             | EmitStage::Liveness
+            | EmitStage::RegAlloc
             | EmitStage::Asm
             | EmitStage::StackFrame => 2,
         })
@@ -500,6 +504,29 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
                             options.target,
                         );
                         println!("{}", liveness_info);
+                    }
+                }
+                println!();
+            }
+            EmitStage::RegAlloc => {
+                println!("=== Register Allocation ({}) ===", options.target);
+                if let Some(ref state) = frontend_state {
+                    for func in &state.functions {
+                        println!("function {}:", func.analyzed.name);
+                        let regalloc_info = match generate_regalloc_info(
+                            &func.cfg,
+                            &state.struct_defs,
+                            &state.array_types,
+                            &state.strings,
+                            options.target,
+                        ) {
+                            Ok(info) => info,
+                            Err(e) => {
+                                eprintln!("{}", formatter.format_error(&e));
+                                return Err(());
+                            }
+                        };
+                        print!("{}", regalloc_info);
                     }
                 }
                 println!();
@@ -919,6 +946,10 @@ mod tests {
             "liveness".parse::<EmitStage>().unwrap(),
             EmitStage::Liveness
         );
+        assert_eq!(
+            "regalloc".parse::<EmitStage>().unwrap(),
+            EmitStage::RegAlloc
+        );
         assert_eq!("asm".parse::<EmitStage>().unwrap(), EmitStage::Asm);
         assert_eq!(
             "stackframe".parse::<EmitStage>().unwrap(),
@@ -936,8 +967,14 @@ mod tests {
     fn emit_stage_all_names() {
         assert_eq!(
             EmitStage::all_names(),
-            "tokens, ast, rir, air, cfg, mir, liveness, asm, stackframe"
+            "tokens, ast, rir, air, cfg, mir, liveness, regalloc, asm, stackframe"
         );
+    }
+
+    #[test]
+    fn parse_emit_regalloc() {
+        let opts = unwrap_options(parse_args_from(&["--emit", "regalloc", "source.rue"]));
+        assert_eq!(opts.emit_stages, vec![EmitStage::RegAlloc]);
     }
 
     #[test]


### PR DESCRIPTION
Implements rue-lw6i to add a new emit stage that displays register allocation decisions, including live ranges, interference graph, allocation mappings, spill information, and callee-saved register usage.

This helps debug register allocation issues and understand how the linear scan allocator makes decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)