### PR TITLE
rue-parser: remove unused AstPrinter wrapper

### DIFF
--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -763,21 +763,9 @@ impl Expr {
 
 // Display implementations for AST pretty-printing
 
-/// Helper for indented printing.
-struct AstPrinter<'a> {
-    ast: &'a Ast,
-}
-
 impl fmt::Display for Ast {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let printer = AstPrinter { ast: self };
-        printer.fmt(f)
-    }
-}
-
-impl<'a> fmt::Display for AstPrinter<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        for item in &self.ast.items {
+        for item in &self.items {
             match item {
                 Item::Function(func) => fmt_function(f, func, 0)?,
                 Item::Struct(s) => fmt_struct(f, s, 0)?,


### PR DESCRIPTION
The AstPrinter struct was an unnecessary indirection - it held a reference to Ast and its Display impl simply iterated over the items. Inline this logic directly into Ast's Display implementation.

Fixes rue-nnon

🤖 Generated with [Claude Code](https://claude.com/claude-code)