### PR TITLE
Add #[must_use] to key functions in rue-linker

### DIFF
--- a/crates/rue-linker/src/archive.rs
+++ b/crates/rue-linker/src/archive.rs
@@ -63,6 +63,7 @@ impl Archive {
     ///   - File content (padded to even boundary)
     ///
     /// Special entries like symbol tables (`/`, `//`, `__.SYMDEF`) are skipped.
+    #[must_use = "parsing returns a Result that must be checked"]
     pub fn parse(data: &[u8]) -> Result<Self, ArchiveError> {
         // Check magic
         if data.len() < AR_MAGIC.len() {
@@ -157,11 +158,13 @@ impl Archive {
     }
 
     /// Returns true if the archive contains no object files.
+    #[must_use]
     pub fn is_empty(&self) -> bool {
         self.objects.is_empty()
     }
 
     /// Returns the number of object files in the archive.
+    #[must_use]
     pub fn len(&self) -> usize {
         self.objects.len()
     }

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -97,11 +97,13 @@ impl SectionFlags {
     pub const EXEC: SectionFlags = SectionFlags(0x4);
 
     /// Create empty flags.
+    #[must_use]
     pub const fn empty() -> Self {
         SectionFlags(0)
     }
 
     /// Check if flags contain a specific flag.
+    #[must_use]
     pub const fn contains(self, other: SectionFlags) -> bool {
         (self.0 & other.0) == other.0
     }
@@ -293,6 +295,7 @@ impl std::error::Error for ParseError {}
 
 impl ObjectFile {
     /// Parse an ELF64 relocatable object file.
+    #[must_use = "parsing returns a Result that must be checked"]
     pub fn parse(data: &[u8]) -> Result<Self, ParseError> {
         // Check minimum size for ELF header
         if data.len() < 64 {
@@ -641,11 +644,13 @@ impl ObjectFile {
     }
 
     /// Find a symbol by name.
+    #[must_use]
     pub fn find_symbol(&self, name: &str) -> Option<&Symbol> {
         self.symbols.iter().find(|s| s.name == name)
     }
 
     /// Get all global/defined symbols.
+    #[must_use]
     pub fn defined_symbols(&self) -> impl Iterator<Item = &Symbol> {
         self.symbols.iter().filter(|s| {
             s.section_index.is_some()

--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -111,6 +111,7 @@ pub struct CodeRelocation {
 
 impl ObjectBuilder {
     /// Create a new object builder for the given target.
+    #[must_use]
     pub fn new(target: Target, name: impl Into<String>) -> Self {
         ObjectBuilder {
             target,
@@ -122,18 +123,21 @@ impl ObjectBuilder {
     }
 
     /// Set the machine code.
+    #[must_use]
     pub fn code(mut self, code: Vec<u8>) -> Self {
         self.code = code;
         self
     }
 
     /// Add a relocation.
+    #[must_use]
     pub fn relocation(mut self, reloc: CodeRelocation) -> Self {
         self.relocations.push(reloc);
         self
     }
 
     /// Set string constants.
+    #[must_use]
     pub fn strings(mut self, strings: Vec<String>) -> Self {
         self.strings = strings;
         self
@@ -142,6 +146,7 @@ impl ObjectBuilder {
     /// Build a relocatable object file for the target.
     ///
     /// Generates ELF64 for Linux targets and Mach-O for macOS targets.
+    #[must_use]
     pub fn build(self) -> Vec<u8> {
         if self.target.is_macho() {
             self.build_macho()

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -106,6 +106,7 @@ pub struct Linker {
 
 impl Linker {
     /// Create a new linker for the given target.
+    #[must_use]
     pub fn new(target: Target) -> Self {
         Linker {
             target,
@@ -277,6 +278,7 @@ impl Linker {
     }
 
     /// Link all objects and produce an executable.
+    #[must_use = "linking returns a Result that must be checked"]
     pub fn link(self, entry_point: &str) -> Result<Vec<u8>, LinkError> {
         // Layout constants - use a single program header for simplicity
         const ELF_HEADER_SIZE: u64 = 64;


### PR DESCRIPTION
Add #[must_use] attributes to functions whose return values should not be silently ignored:

- elf.rs: ObjectFile::parse, find_symbol, defined_symbols, SectionFlags::empty, SectionFlags::contains
- linker.rs: Linker::new, Linker::link
- emit.rs: ObjectBuilder::new, code, relocation, strings, build
- archive.rs: Archive::parse, is_empty, len

Fixes rue-cbpw

🤖 Generated with [Claude Code](https://claude.com/claude-code)