### PR TITLE
Add --emit lowering for instruction selection debug output

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -435,6 +435,188 @@ impl<'a> CfgLower<'a> {
         self.mir
     }
 
+    /// Lower CFG to Aarch64Mir with debug information about instruction selection.
+    ///
+    /// This is like `lower()` but also captures detailed information about
+    /// how each CFG instruction maps to MIR instructions.
+    pub fn lower_with_debug(mut self) -> (Aarch64Mir, crate::LoweringDebugInfo) {
+        use crate::cfg_lower::{format_cfg_inst_data, format_terminator};
+        use crate::{
+            BlockLoweringInfo, LoweringDebugInfo, LoweringDecision, TerminatorLoweringDecision,
+        };
+
+        let mut debug_info = LoweringDebugInfo {
+            fn_name: self.fn_name.to_string(),
+            target_arch: "aarch64".to_string(),
+            blocks: Vec::new(),
+        };
+
+        // Pre-allocate vregs for block parameters (same as lower())
+        for block in self.cfg.blocks() {
+            for (param_idx, (param_val, ty)) in block.params.iter().enumerate() {
+                let vreg = self.mir.alloc_vreg();
+                self.block_param_vregs
+                    .insert((block.id, param_idx as u32), vreg);
+                self.value_map.insert(*param_val, vreg);
+
+                if let Type::Struct(struct_id) = ty {
+                    let slot_count = self.type_slot_count(Type::Struct(*struct_id));
+                    let mut slot_vregs = vec![vreg];
+                    for _ in 1..slot_count {
+                        slot_vregs.push(self.mir.alloc_vreg());
+                    }
+                    self.struct_slot_vregs.insert(*param_val, slot_vregs);
+                }
+            }
+        }
+
+        // Lower each block with debug tracking
+        for block in self.cfg.blocks() {
+            let mut block_info = BlockLoweringInfo {
+                block_id: block.id,
+                instructions: Vec::new(),
+                terminator: None,
+            };
+
+            // Emit block label (except for entry block)
+            if block.id != self.cfg.entry {
+                self.mir.push(Aarch64Inst::Label {
+                    id: self.block_label(block.id),
+                });
+            }
+
+            // Lower each instruction with tracking
+            for &value in &block.insts {
+                // Skip if already lowered
+                if self.value_map.contains_key(&value) {
+                    continue;
+                }
+
+                let inst = self.cfg.get_inst(value);
+                let inst_before = self.mir.inst_count();
+
+                // Lower the instruction
+                self.lower_value(value);
+
+                let inst_after = self.mir.inst_count();
+
+                // Capture the generated instructions
+                let mir_insts: Vec<String> = self.mir.instructions()[inst_before..inst_after]
+                    .iter()
+                    .map(|i| format!("{}", i))
+                    .collect();
+
+                // Generate rationale for interesting cases
+                let rationale = self.get_lowering_rationale(&inst.data, inst.ty);
+
+                if !mir_insts.is_empty() {
+                    block_info.instructions.push(LoweringDecision {
+                        cfg_value: value,
+                        cfg_inst_desc: format_cfg_inst_data(&inst.data),
+                        cfg_type: inst.ty.name().to_string(),
+                        mir_insts,
+                        rationale,
+                    });
+                }
+            }
+
+            // Lower terminator with tracking
+            let term_before = self.mir.inst_count();
+            self.lower_terminator(block);
+            let term_after = self.mir.inst_count();
+
+            let term_mir_insts: Vec<String> = self.mir.instructions()[term_before..term_after]
+                .iter()
+                .map(|i| format!("{}", i))
+                .collect();
+
+            let term_rationale = self.get_terminator_rationale(&block.terminator);
+
+            block_info.terminator = Some(TerminatorLoweringDecision {
+                terminator_desc: format_terminator(&block.terminator),
+                mir_insts: term_mir_insts,
+                rationale: term_rationale,
+            });
+
+            debug_info.blocks.push(block_info);
+        }
+
+        (self.mir, debug_info)
+    }
+
+    /// Generate rationale for instruction lowering decisions.
+    fn get_lowering_rationale(&self, data: &CfgInstData, ty: Type) -> Option<String> {
+        match data {
+            CfgInstData::Add(_, _) | CfgInstData::Sub(_, _) | CfgInstData::Mul(_, _) => {
+                Some("With overflow check".to_string())
+            }
+            CfgInstData::Div(_, _) | CfgInstData::Mod(_, _) => {
+                if matches!(ty, Type::I8 | Type::I16 | Type::I32 | Type::I64) {
+                    Some("Signed division".to_string())
+                } else {
+                    Some("Unsigned division".to_string())
+                }
+            }
+            CfgInstData::Shr(_, _) => {
+                if matches!(ty, Type::I8 | Type::I16 | Type::I32 | Type::I64) {
+                    Some("Signed shift right (ASR) preserves sign bit".to_string())
+                } else {
+                    Some("Unsigned shift right (LSR) zero-extends".to_string())
+                }
+            }
+            CfgInstData::Call { args, .. } => {
+                let inout_count = args.iter().filter(|a| a.is_inout()).count();
+                let borrow_count = args.iter().filter(|a| a.is_borrow()).count();
+                if inout_count > 0 || borrow_count > 0 {
+                    Some(format!(
+                        "AAPCS64 with {} inout, {} borrow params (passed as pointers)",
+                        inout_count, borrow_count
+                    ))
+                } else if args.len() > 8 {
+                    Some("AAPCS64 with stack-passed arguments".to_string())
+                } else {
+                    None
+                }
+            }
+            CfgInstData::Param { index } => {
+                if self.cfg.is_param_inout(*index) {
+                    Some("Inout param: load pointer then dereference".to_string())
+                } else if (*index as usize) < ARG_REGS.len() {
+                    Some(format!(
+                        "From register {} (AAPCS64)",
+                        ARG_REGS[*index as usize]
+                    ))
+                } else {
+                    Some("From stack (AAPCS64, args > 8)".to_string())
+                }
+            }
+            CfgInstData::IndexGet { .. } | CfgInstData::IndexSet { .. } => {
+                Some("Includes bounds check".to_string())
+            }
+            _ => None,
+        }
+    }
+
+    /// Generate rationale for terminator lowering decisions.
+    fn get_terminator_rationale(&self, terminator: &Terminator) -> Option<String> {
+        match terminator {
+            Terminator::Branch { .. } => Some("Compare and branch".to_string()),
+            Terminator::Return { value } => {
+                if self.fn_name == "main" {
+                    Some("Main function: return value becomes exit code".to_string())
+                } else if value.is_some() {
+                    Some("Return value in X0 (AAPCS64)".to_string())
+                } else {
+                    None
+                }
+            }
+            Terminator::Switch { cases, .. } => {
+                Some(format!("Linear scan through {} cases", cases.len()))
+            }
+            _ => None,
+        }
+    }
+
     /// Lower a single basic block.
     fn lower_block(&mut self, block: &BasicBlock) {
         // Emit block label (except for entry block)

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -990,6 +990,12 @@ impl Aarch64Mir {
         self.next_vreg
     }
 
+    /// Get the number of instructions.
+    #[inline]
+    pub fn inst_count(&self) -> usize {
+        self.instructions.len()
+    }
+
     /// Add an instruction.
     pub fn push(&mut self, inst: Aarch64Inst) {
         self.instructions.push(inst);

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -3,8 +3,307 @@
 //! This module contains types used by both x86_64 and aarch64 backends
 //! when tracing through field and index chains during CFG lowering.
 
+use std::fmt;
+
 use rue_air::ArrayTypeId;
-use rue_cfg::CfgValue;
+use rue_cfg::{BlockId, CfgValue};
+
+/// A single lowering decision: maps one CFG instruction to its MIR expansion.
+#[derive(Debug, Clone)]
+pub struct LoweringDecision {
+    /// The CFG value (instruction) being lowered.
+    pub cfg_value: CfgValue,
+    /// Human-readable description of the CFG instruction.
+    pub cfg_inst_desc: String,
+    /// The type of the CFG instruction.
+    pub cfg_type: String,
+    /// Generated MIR instructions (as human-readable strings).
+    pub mir_insts: Vec<String>,
+    /// Rationale for the lowering decision (if non-obvious).
+    pub rationale: Option<String>,
+}
+
+/// A lowering decision for a block terminator.
+#[derive(Debug, Clone)]
+pub struct TerminatorLoweringDecision {
+    /// Human-readable description of the terminator.
+    pub terminator_desc: String,
+    /// Generated MIR instructions (as human-readable strings).
+    pub mir_insts: Vec<String>,
+    /// Rationale for the lowering decision.
+    pub rationale: Option<String>,
+}
+
+/// Debug information for a single basic block's lowering.
+#[derive(Debug, Clone)]
+pub struct BlockLoweringInfo {
+    /// The block ID.
+    pub block_id: BlockId,
+    /// Lowering decisions for instructions in this block.
+    pub instructions: Vec<LoweringDecision>,
+    /// Lowering decision for the terminator.
+    pub terminator: Option<TerminatorLoweringDecision>,
+}
+
+/// Debug information from the CFG-to-MIR lowering pass.
+///
+/// This captures how each CFG instruction is expanded into MIR instructions,
+/// including the rationale for instruction selection decisions.
+#[derive(Debug, Clone)]
+pub struct LoweringDebugInfo {
+    /// Function name.
+    pub fn_name: String,
+    /// Target architecture (e.g., "x86_64", "aarch64").
+    pub target_arch: String,
+    /// Per-block lowering information.
+    pub blocks: Vec<BlockLoweringInfo>,
+}
+
+impl fmt::Display for LoweringDebugInfo {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        writeln!(f, "=== Instruction Selection ({}) ===", self.fn_name)?;
+        writeln!(f)?;
+
+        for block_info in &self.blocks {
+            writeln!(f, "{}:", block_info.block_id)?;
+            writeln!(f)?;
+
+            for decision in &block_info.instructions {
+                writeln!(
+                    f,
+                    "  CFG: {} = {} : {}",
+                    decision.cfg_value, decision.cfg_inst_desc, decision.cfg_type
+                )?;
+
+                for mir_inst in &decision.mir_insts {
+                    writeln!(f, "    -> {}", mir_inst)?;
+                }
+
+                if let Some(ref rationale) = decision.rationale {
+                    writeln!(f, "    Decision: {}", rationale)?;
+                }
+                writeln!(f)?;
+            }
+
+            if let Some(ref term) = block_info.terminator {
+                writeln!(f, "  Terminator: {}", term.terminator_desc)?;
+
+                for mir_inst in &term.mir_insts {
+                    writeln!(f, "    -> {}", mir_inst)?;
+                }
+
+                if let Some(ref rationale) = term.rationale {
+                    writeln!(f, "    Decision: {}", rationale)?;
+                }
+                writeln!(f)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Format a CFG instruction data as a human-readable string.
+pub fn format_cfg_inst_data(data: &rue_cfg::CfgInstData) -> String {
+    use rue_cfg::CfgInstData;
+
+    match data {
+        CfgInstData::Const(v) => format!("const {}", v),
+        CfgInstData::BoolConst(v) => format!("const {}", v),
+        CfgInstData::StringConst(idx) => format!("string_const @{}", idx),
+        CfgInstData::Param { index } => format!("param {}", index),
+        CfgInstData::BlockParam { index } => format!("block_param {}", index),
+        CfgInstData::Add(lhs, rhs) => format!("add {}, {}", lhs, rhs),
+        CfgInstData::Sub(lhs, rhs) => format!("sub {}, {}", lhs, rhs),
+        CfgInstData::Mul(lhs, rhs) => format!("mul {}, {}", lhs, rhs),
+        CfgInstData::Div(lhs, rhs) => format!("div {}, {}", lhs, rhs),
+        CfgInstData::Mod(lhs, rhs) => format!("mod {}, {}", lhs, rhs),
+        CfgInstData::Eq(lhs, rhs) => format!("eq {}, {}", lhs, rhs),
+        CfgInstData::Ne(lhs, rhs) => format!("ne {}, {}", lhs, rhs),
+        CfgInstData::Lt(lhs, rhs) => format!("lt {}, {}", lhs, rhs),
+        CfgInstData::Gt(lhs, rhs) => format!("gt {}, {}", lhs, rhs),
+        CfgInstData::Le(lhs, rhs) => format!("le {}, {}", lhs, rhs),
+        CfgInstData::Ge(lhs, rhs) => format!("ge {}, {}", lhs, rhs),
+        CfgInstData::BitAnd(lhs, rhs) => format!("bit_and {}, {}", lhs, rhs),
+        CfgInstData::BitOr(lhs, rhs) => format!("bit_or {}, {}", lhs, rhs),
+        CfgInstData::BitXor(lhs, rhs) => format!("bit_xor {}, {}", lhs, rhs),
+        CfgInstData::Shl(lhs, rhs) => format!("shl {}, {}", lhs, rhs),
+        CfgInstData::Shr(lhs, rhs) => format!("shr {}, {}", lhs, rhs),
+        CfgInstData::Neg(v) => format!("neg {}", v),
+        CfgInstData::Not(v) => format!("not {}", v),
+        CfgInstData::BitNot(v) => format!("bit_not {}", v),
+        CfgInstData::Alloc { slot, init } => format!("alloc ${} = {}", slot, init),
+        CfgInstData::Load { slot } => format!("load ${}", slot),
+        CfgInstData::Store { slot, value } => format!("store ${} = {}", slot, value),
+        CfgInstData::ParamStore { param_slot, value } => {
+            format!("param_store %{} = {}", param_slot, value)
+        }
+        CfgInstData::Call { name, args } => {
+            let args_str = args
+                .iter()
+                .map(|a| format!("{}", a.value))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("call {}({})", name, args_str)
+        }
+        CfgInstData::Intrinsic { name, args } => {
+            let args_str = args
+                .iter()
+                .map(|a| format!("{}", a))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("intrinsic @{}({})", name, args_str)
+        }
+        CfgInstData::StructInit { struct_id, fields } => {
+            let fields_str = fields
+                .iter()
+                .map(|f| format!("{}", f))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("struct_init #{} {{{}}}", struct_id.0, fields_str)
+        }
+        CfgInstData::FieldGet {
+            base,
+            struct_id,
+            field_index,
+        } => format!("field_get {}.#{}.{}", base, struct_id.0, field_index),
+        CfgInstData::FieldSet {
+            slot,
+            struct_id,
+            field_index,
+            value,
+        } => format!(
+            "field_set ${}.#{}.{} = {}",
+            slot, struct_id.0, field_index, value
+        ),
+        CfgInstData::ParamFieldSet {
+            param_slot,
+            inner_offset,
+            struct_id,
+            field_index,
+            value,
+        } => format!(
+            "param_field_set %{}+{}.#{}.{} = {}",
+            param_slot, inner_offset, struct_id.0, field_index, value
+        ),
+        CfgInstData::ArrayInit {
+            array_type_id,
+            elements,
+        } => {
+            let elems_str = elements
+                .iter()
+                .map(|e| format!("{}", e))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("array_init @{} [{}]", array_type_id.0, elems_str)
+        }
+        CfgInstData::IndexGet {
+            base,
+            array_type_id,
+            index,
+        } => format!("index_get {}[@{}][{}]", base, array_type_id.0, index),
+        CfgInstData::IndexSet {
+            slot,
+            array_type_id,
+            index,
+            value,
+        } => format!(
+            "index_set ${}[@{}][{}] = {}",
+            slot, array_type_id.0, index, value
+        ),
+        CfgInstData::ParamIndexSet {
+            param_slot,
+            array_type_id,
+            index,
+            value,
+        } => format!(
+            "param_index_set %{}[@{}][{}] = {}",
+            param_slot, array_type_id.0, index, value
+        ),
+        CfgInstData::EnumVariant {
+            enum_id,
+            variant_index,
+        } => {
+            format!("enum_variant #{}.{}", enum_id.0, variant_index)
+        }
+        CfgInstData::IntCast { value, from_ty } => {
+            format!("int_cast {} : {}", value, from_ty.name())
+        }
+        CfgInstData::Drop { value } => format!("drop {}", value),
+        CfgInstData::StorageLive { slot } => format!("storage_live ${}", slot),
+        CfgInstData::StorageDead { slot } => format!("storage_dead ${}", slot),
+    }
+}
+
+/// Format a CFG terminator as a human-readable string.
+pub fn format_terminator(terminator: &rue_cfg::Terminator) -> String {
+    use rue_cfg::Terminator;
+
+    match terminator {
+        Terminator::Goto { target, args } => {
+            if args.is_empty() {
+                format!("goto {}", target)
+            } else {
+                let args_str = args
+                    .iter()
+                    .map(|a| format!("{}", a))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("goto {}({})", target, args_str)
+            }
+        }
+        Terminator::Branch {
+            cond,
+            then_block,
+            then_args,
+            else_block,
+            else_args,
+        } => {
+            let then_str = if then_args.is_empty() {
+                format!("{}", then_block)
+            } else {
+                let args_str = then_args
+                    .iter()
+                    .map(|a| format!("{}", a))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{}({})", then_block, args_str)
+            };
+            let else_str = if else_args.is_empty() {
+                format!("{}", else_block)
+            } else {
+                let args_str = else_args
+                    .iter()
+                    .map(|a| format!("{}", a))
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                format!("{}({})", else_block, args_str)
+            };
+            format!("branch {}, {}, {}", cond, then_str, else_str)
+        }
+        Terminator::Switch {
+            scrutinee,
+            cases,
+            default,
+        } => {
+            let cases_str = cases
+                .iter()
+                .map(|(val, target)| format!("{} => {}", val, target))
+                .collect::<Vec<_>>()
+                .join(", ");
+            format!("switch {} [{}], default: {}", scrutinee, cases_str, default)
+        }
+        Terminator::Return { value } => {
+            if let Some(val) = value {
+                format!("return {}", val)
+            } else {
+                "return".to_string()
+            }
+        }
+        Terminator::Unreachable => "unreachable".to_string(),
+        Terminator::None => "<no terminator>".to_string(),
+    }
+}
 
 /// Result of tracing back through FieldGet chains to find the original source.
 pub enum FieldChainBase {

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -284,6 +284,10 @@ pub fn format_offset(offset: i32) -> String {
 pub use x86_64::generate;
 
 // Re-export shared types
+pub use cfg_lower::{
+    BlockLoweringInfo, LoweringDebugInfo, LoweringDecision, TerminatorLoweringDecision,
+    format_cfg_inst_data, format_terminator,
+};
 pub use index_map::{Handle, IndexMap};
 pub use regalloc::{
     Allocation, InstructionLiveness, LivenessDebugInfo, RegAllocDebugInfo, linear_scan_with_debug,

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -469,6 +469,204 @@ impl<'a> CfgLower<'a> {
         self.mir
     }
 
+    /// Lower CFG to X86Mir with debug information about instruction selection.
+    ///
+    /// This is like `lower()` but also captures detailed information about
+    /// how each CFG instruction maps to MIR instructions.
+    pub fn lower_with_debug(mut self) -> (X86Mir, crate::LoweringDebugInfo) {
+        use crate::cfg_lower::{format_cfg_inst_data, format_terminator};
+        use crate::{
+            BlockLoweringInfo, LoweringDebugInfo, LoweringDecision, TerminatorLoweringDecision,
+        };
+
+        let mut debug_info = LoweringDebugInfo {
+            fn_name: self.fn_name.to_string(),
+            target_arch: "x86_64".to_string(),
+            blocks: Vec::new(),
+        };
+
+        // Pre-allocate vregs for block parameters (same as lower())
+        for block in self.cfg.blocks() {
+            for (param_idx, (param_val, ty)) in block.params.iter().enumerate() {
+                let vreg = self.mir.alloc_vreg();
+                self.block_param_vregs
+                    .insert((block.id, param_idx as u32), vreg);
+                self.value_map.insert(*param_val, vreg);
+
+                if let Type::Struct(struct_id) = ty {
+                    let slot_count = self.type_slot_count(Type::Struct(*struct_id));
+                    let mut slot_vregs = vec![vreg];
+                    for _ in 1..slot_count {
+                        slot_vregs.push(self.mir.alloc_vreg());
+                    }
+                    self.struct_slot_vregs.insert(*param_val, slot_vregs);
+                }
+            }
+        }
+
+        // Lower each block with debug tracking
+        for block in self.cfg.blocks() {
+            let mut block_info = BlockLoweringInfo {
+                block_id: block.id,
+                instructions: Vec::new(),
+                terminator: None,
+            };
+
+            // Emit block label (except for entry block)
+            if block.id != self.cfg.entry {
+                self.mir.push(X86Inst::Label {
+                    id: self.block_label(block.id),
+                });
+            }
+
+            // Lower each instruction with tracking
+            for &value in &block.insts {
+                // Skip if already lowered
+                if self.value_map.contains_key(&value) {
+                    continue;
+                }
+
+                let inst = self.cfg.get_inst(value);
+                let inst_before = self.mir.inst_count();
+
+                // Lower the instruction
+                self.lower_value(value);
+
+                let inst_after = self.mir.inst_count();
+
+                // Capture the generated instructions
+                let mir_insts: Vec<String> = self.mir.instructions()[inst_before..inst_after]
+                    .iter()
+                    .map(|i| format!("{}", i))
+                    .collect();
+
+                // Generate rationale for interesting cases
+                let rationale = self.get_lowering_rationale(&inst.data, inst.ty);
+
+                if !mir_insts.is_empty() {
+                    block_info.instructions.push(LoweringDecision {
+                        cfg_value: value,
+                        cfg_inst_desc: format_cfg_inst_data(&inst.data),
+                        cfg_type: inst.ty.name().to_string(),
+                        mir_insts,
+                        rationale,
+                    });
+                }
+            }
+
+            // Lower terminator with tracking
+            let term_before = self.mir.inst_count();
+            self.lower_terminator(block);
+            let term_after = self.mir.inst_count();
+
+            let term_mir_insts: Vec<String> = self.mir.instructions()[term_before..term_after]
+                .iter()
+                .map(|i| format!("{}", i))
+                .collect();
+
+            let term_rationale = self.get_terminator_rationale(&block.terminator);
+
+            block_info.terminator = Some(TerminatorLoweringDecision {
+                terminator_desc: format_terminator(&block.terminator),
+                mir_insts: term_mir_insts,
+                rationale: term_rationale,
+            });
+
+            debug_info.blocks.push(block_info);
+        }
+
+        (self.mir, debug_info)
+    }
+
+    /// Generate rationale for instruction lowering decisions.
+    fn get_lowering_rationale(&self, data: &CfgInstData, ty: Type) -> Option<String> {
+        match data {
+            CfgInstData::Add(_, _) | CfgInstData::Sub(_, _) | CfgInstData::Mul(_, _) => {
+                if matches!(ty, Type::I64 | Type::U64) {
+                    Some("64-bit operation with 64-bit overflow check".to_string())
+                } else if matches!(
+                    ty,
+                    Type::I8 | Type::I16 | Type::I32 | Type::U8 | Type::U16 | Type::U32
+                ) {
+                    Some("32-bit operation with overflow check".to_string())
+                } else {
+                    None
+                }
+            }
+            CfgInstData::Div(_, _) | CfgInstData::Mod(_, _) => {
+                if matches!(ty, Type::I8 | Type::I16 | Type::I32 | Type::I64) {
+                    Some("Signed division: uses CDQ/IDIV sequence".to_string())
+                } else {
+                    Some("Unsigned division: uses XOR/DIV sequence".to_string())
+                }
+            }
+            CfgInstData::Shr(_, _) => {
+                if matches!(ty, Type::I8 | Type::I16 | Type::I32 | Type::I64) {
+                    Some("Signed shift right (SAR) preserves sign bit".to_string())
+                } else {
+                    Some("Unsigned shift right (SHR) zero-extends".to_string())
+                }
+            }
+            CfgInstData::Call { args, .. } => {
+                let inout_count = args.iter().filter(|a| a.is_inout()).count();
+                let borrow_count = args.iter().filter(|a| a.is_borrow()).count();
+                if inout_count > 0 || borrow_count > 0 {
+                    Some(format!(
+                        "SysV ABI with {} inout, {} borrow params (passed as pointers)",
+                        inout_count, borrow_count
+                    ))
+                } else if args.len() > 6 {
+                    Some("SysV ABI with stack-passed arguments".to_string())
+                } else {
+                    None
+                }
+            }
+            CfgInstData::Param { index } => {
+                if self.cfg.is_param_inout(*index) {
+                    Some("Inout param: load pointer then dereference".to_string())
+                } else if (*index as usize) < ARG_REGS.len() {
+                    Some(format!(
+                        "From register {} (SysV ABI)",
+                        ARG_REGS[*index as usize]
+                    ))
+                } else {
+                    Some("From stack (SysV ABI, args > 6)".to_string())
+                }
+            }
+            CfgInstData::Const(v) => {
+                if *v <= u32::MAX as u64 {
+                    Some("32-bit immediate (zero-extends to 64-bit)".to_string())
+                } else {
+                    Some("64-bit immediate required".to_string())
+                }
+            }
+            CfgInstData::IndexGet { .. } | CfgInstData::IndexSet { .. } => {
+                Some("Includes bounds check".to_string())
+            }
+            _ => None,
+        }
+    }
+
+    /// Generate rationale for terminator lowering decisions.
+    fn get_terminator_rationale(&self, terminator: &Terminator) -> Option<String> {
+        match terminator {
+            Terminator::Branch { .. } => Some("Compare with zero, conditional jump".to_string()),
+            Terminator::Return { value } => {
+                if self.fn_name == "main" {
+                    Some("Main function: return value becomes exit code".to_string())
+                } else if value.is_some() {
+                    Some("Return value in RAX (SysV ABI)".to_string())
+                } else {
+                    None
+                }
+            }
+            Terminator::Switch { cases, .. } => {
+                Some(format!("Linear scan through {} cases", cases.len()))
+            }
+            _ => None,
+        }
+    }
+
     /// Lower a single basic block.
     fn lower_block(&mut self, block: &BasicBlock) {
         // Emit block label (except for entry block)

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -629,6 +629,12 @@ impl X86Mir {
         self.next_vreg
     }
 
+    /// Get the number of instructions.
+    #[inline]
+    pub fn inst_count(&self) -> usize {
+        self.instructions.len()
+    }
+
     /// Add an instruction.
     pub fn push(&mut self, inst: X86Inst) {
         self.instructions.push(inst);

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -155,8 +155,8 @@ pub fn validate_runtime() -> Result<(), String> {
 pub use rue_air::{Air, AnalyzedFunction, ArrayTypeDef, Sema, SemaOutput, StructDef, Type};
 pub use rue_cfg::{Cfg, CfgBuilder, CfgOutput, OptLevel};
 pub use rue_codegen::{
-    RegAllocDebugInfo, RelocationKind, StackFrameInfo, X86Mir, aarch64::Aarch64Mir,
-    generate_stack_frame_info,
+    LoweringDebugInfo, RegAllocDebugInfo, RelocationKind, StackFrameInfo, X86Mir,
+    aarch64::Aarch64Mir, generate_stack_frame_info,
 };
 pub use rue_error::{
     CompileError, CompileResult, CompileWarning, Diagnostic, ErrorKind, PreviewFeature,
@@ -769,6 +769,35 @@ pub fn generate_liveness_info(
             let mir =
                 rue_codegen::aarch64::CfgLower::new(cfg, struct_defs, array_types, strings).lower();
             rue_codegen::aarch64::liveness::analyze_debug(&mir)
+        }
+    }
+}
+
+/// Generate lowering debug information for a CFG.
+///
+/// This performs CFG-to-MIR lowering (instruction selection) and returns
+/// detailed information about how each CFG instruction maps to MIR instructions.
+///
+/// Used by `--emit lowering` to visualize the instruction selection process.
+pub fn generate_lowering_info(
+    cfg: &Cfg,
+    struct_defs: &[StructDef],
+    array_types: &[ArrayTypeDef],
+    strings: &[String],
+    target: Target,
+) -> rue_codegen::LoweringDebugInfo {
+    match target.arch() {
+        Arch::X86_64 => {
+            let (_mir, debug_info) =
+                rue_codegen::x86_64::CfgLower::new(cfg, struct_defs, array_types, strings)
+                    .lower_with_debug();
+            debug_info
+        }
+        Arch::Aarch64 => {
+            let (_mir, debug_info) =
+                rue_codegen::aarch64::CfgLower::new(cfg, struct_defs, array_types, strings)
+                    .lower_with_debug();
+            debug_info
         }
     }
 }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -6,8 +6,8 @@ use std::path::Path;
 use rue_compiler::{
     CompileOptions, DiagnosticFormatter, Lexer, LinkerMode, OptLevel, Parser, PreviewFeature,
     PreviewFeatures, SourceInfo, compile_frontend_from_ast_with_options, compile_with_options,
-    generate_allocated_mir, generate_emitted_asm, generate_liveness_info, generate_mir,
-    generate_regalloc_info, generate_stack_frame_info,
+    generate_allocated_mir, generate_emitted_asm, generate_liveness_info, generate_lowering_info,
+    generate_mir, generate_regalloc_info, generate_stack_frame_info,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
@@ -25,6 +25,8 @@ enum EmitStage {
     Air,
     /// Emit CFG (control flow graph).
     Cfg,
+    /// Emit lowering (CFG to MIR instruction selection).
+    Lowering,
     /// Emit MIR (machine intermediate representation).
     Mir,
     /// Emit liveness analysis information.
@@ -59,6 +61,7 @@ impl std::str::FromStr for EmitStage {
             "rir" => Ok(EmitStage::Rir),
             "air" => Ok(EmitStage::Air),
             "cfg" => Ok(EmitStage::Cfg),
+            "lowering" => Ok(EmitStage::Lowering),
             "mir" => Ok(EmitStage::Mir),
             "liveness" => Ok(EmitStage::Liveness),
             "regalloc" => Ok(EmitStage::RegAlloc),
@@ -71,7 +74,7 @@ impl std::str::FromStr for EmitStage {
 
 impl EmitStage {
     fn all_names() -> &'static str {
-        "tokens, ast, rir, air, cfg, mir, liveness, regalloc, asm, stackframe"
+        "tokens, ast, rir, air, cfg, lowering, mir, liveness, regalloc, asm, stackframe"
     }
 }
 
@@ -362,6 +365,7 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
             EmitStage::Rir
             | EmitStage::Air
             | EmitStage::Cfg
+            | EmitStage::Lowering
             | EmitStage::Mir
             | EmitStage::Liveness
             | EmitStage::RegAlloc
@@ -470,6 +474,21 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
                 if let Some(ref state) = frontend_state {
                     for func in &state.functions {
                         println!("{}", func.cfg);
+                    }
+                }
+                println!();
+            }
+            EmitStage::Lowering => {
+                if let Some(ref state) = frontend_state {
+                    for func in &state.functions {
+                        let lowering_info = generate_lowering_info(
+                            &func.cfg,
+                            &state.struct_defs,
+                            &state.array_types,
+                            &state.strings,
+                            options.target,
+                        );
+                        print!("{}", lowering_info);
                     }
                 }
                 println!();
@@ -941,6 +960,10 @@ mod tests {
         assert_eq!("rir".parse::<EmitStage>().unwrap(), EmitStage::Rir);
         assert_eq!("air".parse::<EmitStage>().unwrap(), EmitStage::Air);
         assert_eq!("cfg".parse::<EmitStage>().unwrap(), EmitStage::Cfg);
+        assert_eq!(
+            "lowering".parse::<EmitStage>().unwrap(),
+            EmitStage::Lowering
+        );
         assert_eq!("mir".parse::<EmitStage>().unwrap(), EmitStage::Mir);
         assert_eq!(
             "liveness".parse::<EmitStage>().unwrap(),
@@ -967,8 +990,14 @@ mod tests {
     fn emit_stage_all_names() {
         assert_eq!(
             EmitStage::all_names(),
-            "tokens, ast, rir, air, cfg, mir, liveness, regalloc, asm, stackframe"
+            "tokens, ast, rir, air, cfg, lowering, mir, liveness, regalloc, asm, stackframe"
         );
+    }
+
+    #[test]
+    fn parse_emit_lowering() {
+        let opts = unwrap_options(parse_args_from(&["--emit", "lowering", "source.rue"]));
+        assert_eq!(opts.emit_stages, vec![EmitStage::Lowering]);
     }
 
     #[test]


### PR DESCRIPTION
Adds a new --emit lowering CLI option that shows how CFG instructions are lowered to MIR instructions during instruction selection. This is useful for understanding the code generation process and debugging the compiler.

The output shows:
- Each CFG instruction and its type
- The generated MIR instructions
- Rationale for non-obvious lowering decisions (e.g., overflow checks, ABI conventions, bounds checks)

Implements for both x86_64 and aarch64 backends.

Fixes rue-m30l

🤖 Generated with [Claude Code](https://claude.com/claude-code)