### PR TITLE
Consolidate path resolution logic in rue-test-runner

### DIFF
--- a/crates/rue-spec/src/main.rs
+++ b/crates/rue-spec/src/main.rs
@@ -1,45 +1,19 @@
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
-use rue_test_runner::{Case, find_rue_binary, load_test_files, run_test_case};
-use std::path::{Path, PathBuf};
+use rue_test_runner::{Case, find_dir, find_rue_binary, load_test_files, run_test_case};
+use std::path::Path;
 
 mod traceability;
 
-/// Find the spec directory.
-fn find_spec_dir() -> PathBuf {
-    std::env::var("RUE_SPEC_DIR")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            let possible_paths = ["docs/spec/src", "../docs/spec/src", "../../docs/spec/src"];
-            for path in possible_paths {
-                let p = Path::new(path);
-                if p.exists() {
-                    return p.to_path_buf();
-                }
-            }
-            Path::new("docs/spec/src").to_path_buf()
-        })
-}
+/// Possible paths for the spec directory.
+const SPEC_DIR_PATHS: &[&str] = &["docs/spec/src", "../docs/spec/src", "../../docs/spec/src"];
 
-/// Find the cases directory.
-fn find_cases_dir() -> PathBuf {
-    std::env::var("RUE_SPEC_CASES")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            let possible_paths = ["crates/rue-spec/cases", "cases", "../rue-spec/cases"];
-            for path in possible_paths {
-                let p = Path::new(path);
-                if p.exists() {
-                    return p.to_path_buf();
-                }
-            }
-            Path::new("cases").to_path_buf()
-        })
-}
+/// Possible paths for the cases directory.
+const CASES_DIR_PATHS: &[&str] = &["crates/rue-spec/cases", "cases", "../rue-spec/cases"];
 
 /// Run the traceability report.
 fn run_traceability(detailed: bool) {
-    let spec_dir = find_spec_dir();
-    let cases_dir = find_cases_dir();
+    let spec_dir = find_dir("RUE_SPEC_DIR", SPEC_DIR_PATHS, "docs/spec/src");
+    let cases_dir = find_dir("RUE_SPEC_CASES", CASES_DIR_PATHS, "cases");
 
     if !spec_dir.exists() {
         eprintln!("Error: Spec directory not found: {}", spec_dir.display());
@@ -126,7 +100,7 @@ fn main() {
     let rue_binary = find_rue_binary();
 
     // Find the cases directory
-    let cases_dir = find_cases_dir();
+    let cases_dir = find_dir("RUE_SPEC_CASES", CASES_DIR_PATHS, "cases");
 
     // Load all test files
     let specs = load_test_files(&cases_dir);

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -687,6 +687,32 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
     Ok(())
 }
 
+/// Find a directory by checking an environment variable, then a list of possible paths.
+///
+/// This function provides a consistent way to locate directories across different
+/// working directory contexts (project root, crate directory, etc.).
+///
+/// # Arguments
+/// * `env_var` - Environment variable to check first (e.g., "RUE_SPEC_DIR")
+/// * `possible_paths` - List of relative paths to try if env var is not set
+/// * `fallback` - Default path to return if no existing path is found
+///
+/// # Returns
+/// The first existing path found, or the fallback if none exist.
+pub fn find_dir(env_var: &str, possible_paths: &[&str], fallback: &str) -> PathBuf {
+    std::env::var(env_var)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            for path in possible_paths {
+                let p = Path::new(path);
+                if p.exists() {
+                    return p.to_path_buf();
+                }
+            }
+            Path::new(fallback).to_path_buf()
+        })
+}
+
 /// Find the rue binary in common locations.
 pub fn find_rue_binary() -> PathBuf {
     std::env::var("RUE_BINARY")

--- a/crates/rue-ui-tests/src/main.rs
+++ b/crates/rue-ui-tests/src/main.rs
@@ -4,28 +4,15 @@
 //! such as warnings, diagnostics quality, and compiler flags.
 
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
-use rue_test_runner::{Case, find_rue_binary, load_test_files, run_test_case};
-use std::path::{Path, PathBuf};
+use rue_test_runner::{Case, find_dir, find_rue_binary, load_test_files, run_test_case};
+use std::path::Path;
 
-/// Find the cases directory for UI tests.
-fn find_cases_dir() -> PathBuf {
-    std::env::var("RUE_UI_CASES")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| {
-            let possible_paths = [
-                "crates/rue-ui-tests/cases",
-                "cases",
-                "../rue-ui-tests/cases",
-            ];
-            for path in possible_paths {
-                let p = Path::new(path);
-                if p.exists() {
-                    return p.to_path_buf();
-                }
-            }
-            Path::new("cases").to_path_buf()
-        })
-}
+/// Possible paths for the cases directory.
+const CASES_DIR_PATHS: &[&str] = &[
+    "crates/rue-ui-tests/cases",
+    "cases",
+    "../rue-ui-tests/cases",
+];
 
 /// Wrapper to convert TestResult to libtest2_mimic's RunError type.
 fn run_case_wrapper(
@@ -45,7 +32,7 @@ fn main() {
     let rue_binary = find_rue_binary();
 
     // Find the cases directory
-    let cases_dir = find_cases_dir();
+    let cases_dir = find_dir("RUE_UI_CASES", CASES_DIR_PATHS, "cases");
 
     // Load all test files
     let test_files = load_test_files(&cases_dir);


### PR DESCRIPTION
Move duplicated find_spec_dir/find_cases_dir functions to a shared find_dir() function in rue-test-runner. This reduces code duplication between rue-spec and rue-ui-tests.

The new function provides a consistent way to locate directories across different working directory contexts.

Fixes rue-wg02

🤖 Generated with [Claude Code](https://claude.com/claude-code)