### PR TITLE
Consolidate duplicate collect_files_by_ext function

### DIFF
--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -3,6 +3,7 @@
 //! Generates a report showing which spec paragraphs are covered by tests
 //! and which remain uncovered.
 
+use rue_test_runner::collect_files_by_ext;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
@@ -371,25 +372,6 @@ fn parse_spec_file(path: &Path, paragraphs: &mut BTreeMap<String, SpecParagraph>
                     source_file: source_file.clone(),
                 },
             );
-        }
-    }
-}
-
-/// Recursively collect all files with the given extension from a directory.
-fn collect_files_by_ext(dir: &Path, ext: &str, files: &mut Vec<std::path::PathBuf>) {
-    match fs::read_dir(dir) {
-        Ok(entries) => {
-            for entry in entries.flatten() {
-                let path = entry.path();
-                if path.is_dir() {
-                    collect_files_by_ext(&path, ext, files);
-                } else if path.extension().is_some_and(|e| e == ext) {
-                    files.push(path);
-                }
-            }
-        }
-        Err(e) => {
-            eprintln!("Error reading directory {}: {}", dir.display(), e);
         }
     }
 }

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -303,18 +303,25 @@ pub fn expand_test_file(mut test_file: TestFile) -> TestFile {
     test_file
 }
 
-/// Recursively collect all TOML files from a directory.
-pub fn collect_toml_files(dir: &Path, files: &mut Vec<PathBuf>) {
+/// Recursively collect all files with the given extension from a directory.
+pub fn collect_files_by_ext(dir: &Path, ext: &str, files: &mut Vec<PathBuf>) {
     if let Ok(entries) = fs::read_dir(dir) {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_dir() {
-                collect_toml_files(&path, files);
-            } else if path.extension().is_some_and(|ext| ext == "toml") {
+                collect_files_by_ext(&path, ext, files);
+            } else if path.extension().is_some_and(|e| e == ext) {
                 files.push(path);
             }
         }
     }
+}
+
+/// Recursively collect all TOML files from a directory.
+///
+/// This is a convenience wrapper around [`collect_files_by_ext`].
+pub fn collect_toml_files(dir: &Path, files: &mut Vec<PathBuf>) {
+    collect_files_by_ext(dir, "toml", files);
 }
 
 /// Load all test files from a directory (including subdirectories).


### PR DESCRIPTION
Move the generic collect_files_by_ext function to rue-test-runner and have rue-spec import it, eliminating code duplication between the two crates.

Fixes rue-8xnu

🤖 Generated with [Claude Code](https://claude.com/claude-code)