### PR TITLE
Add --time-passes CLI flag for compiler timing

### DIFF
--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -1,6 +1,9 @@
 rust_binary(
     name = "rue",
-    srcs = ["src/main.rs"],
+    srcs = [
+        "src/main.rs",
+        "src/timing.rs",
+    ],
     deps = [
         "//crates/rue-compiler:rue-compiler",
         "//crates/rue-rir:rue-rir",
@@ -13,7 +16,10 @@ rust_binary(
 
 rust_test(
     name = "rue-test",
-    srcs = ["src/main.rs"],
+    srcs = [
+        "src/main.rs",
+        "src/timing.rs",
+    ],
     deps = [
         "//crates/rue-compiler:rue-compiler",
         "//crates/rue-rir:rue-rir",

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -8,6 +8,8 @@ use tracing_subscriber::fmt::format::FmtSpan;
 use tracing_subscriber::prelude::*;
 use tracing_subscriber::{EnvFilter, fmt};
 
+mod timing;
+
 use rue_compiler::{
     CompileOptions, DiagnosticFormatter, Lexer, LinkerMode, OptLevel, Parser, PreviewFeature,
     PreviewFeatures, SourceInfo, compile_frontend_from_ast_with_options, compile_with_options,
@@ -197,6 +199,7 @@ struct Options {
     preview_features: PreviewFeatures,
     log_level: LogLevel,
     log_format: LogFormat,
+    time_passes: bool,
 }
 
 /// Version string for the rue compiler.
@@ -233,6 +236,7 @@ fn print_usage() {
     eprintln!("                       Can also use RUST_LOG environment variable");
     eprintln!("  --log-format <fmt>   Set logging format (default: text)");
     eprintln!("                       Formats: {}", LogFormat::all_names());
+    eprintln!("  --time-passes        Show timing for each compilation pass");
     eprintln!("  --version            Show version information");
     eprintln!("  --help               Show this help message");
 }
@@ -261,6 +265,7 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     let mut preview_features = PreviewFeatures::new();
     let mut log_level: Option<LogLevel> = None;
     let mut log_format: Option<LogFormat> = None;
+    let mut time_passes = false;
     let mut positional = Vec::new();
     let mut args_iter = args.iter().peekable();
 
@@ -354,6 +359,9 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
                     }
                 }
             }
+            "--time-passes" => {
+                time_passes = true;
+            }
             "--help" | "-h" => {
                 print_usage();
                 return ParseResult::Exit;
@@ -405,6 +413,7 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         preview_features,
         log_level: log_level.unwrap_or_default(),
         log_format: log_format.unwrap_or_default(),
+        time_passes,
     })
 }
 
@@ -422,8 +431,18 @@ fn parse_args() -> Option<Options> {
 /// Initialize the tracing subscriber based on CLI options and RUST_LOG.
 ///
 /// Priority: RUST_LOG environment variable takes precedence over --log-level flag.
-/// If neither is set and log_level is Off, no subscriber is installed.
-fn init_tracing(log_level: LogLevel, log_format: LogFormat) {
+/// If neither is set and log_level is Off, no subscriber is installed (unless
+/// `time_passes` is true, in which case a timing-only subscriber is installed).
+///
+/// Returns `Some(TimingData)` if `time_passes` is true, which can be used to
+/// retrieve the timing report after compilation completes.
+fn init_tracing(
+    log_level: LogLevel,
+    log_format: LogFormat,
+    time_passes: bool,
+) -> Option<timing::TimingData> {
+    use tracing_subscriber::layer::SubscriberExt;
+
     // Check if RUST_LOG is set - it takes priority
     let rust_log = env::var("RUST_LOG").ok();
 
@@ -435,33 +454,90 @@ fn init_tracing(log_level: LogLevel, log_format: LogFormat) {
         log_level.to_tracing_level()
     };
 
-    // If logging is effectively off, don't install a subscriber
-    if effective_level.is_none() {
-        return;
+    let logging_enabled = effective_level.is_some();
+
+    // If neither logging nor timing is enabled, don't install a subscriber
+    if !logging_enabled && !time_passes {
+        return None;
     }
 
-    // Build the filter
-    let filter = if let Some(rust_log) = rust_log {
-        // Use RUST_LOG value
-        EnvFilter::try_new(rust_log).unwrap_or_else(|e| {
-            eprintln!("Warning: invalid RUST_LOG value, using default: {}", e);
+    // Create timing data if --time-passes was specified
+    let timing_data = if time_passes {
+        Some(timing::TimingData::new())
+    } else {
+        None
+    };
+
+    // Build the filter (only used if logging is enabled)
+    let filter = if logging_enabled {
+        let f = if let Some(rust_log) = rust_log {
+            // Use RUST_LOG value
+            EnvFilter::try_new(rust_log).unwrap_or_else(|e| {
+                eprintln!("Warning: invalid RUST_LOG value, using default: {}", e);
+                EnvFilter::new(format!(
+                    "{}",
+                    log_level.to_tracing_level().unwrap_or(Level::INFO)
+                ))
+            })
+        } else {
+            // Use --log-level value
             EnvFilter::new(format!(
                 "{}",
                 log_level.to_tracing_level().unwrap_or(Level::INFO)
             ))
-        })
+        };
+        Some(f)
     } else {
-        // Use --log-level value
-        EnvFilter::new(format!(
-            "{}",
-            log_level.to_tracing_level().unwrap_or(Level::INFO)
-        ))
+        None
     };
 
-    // Build and install the subscriber based on format
-    match log_format {
-        LogFormat::Text => {
-            let subscriber = tracing_subscriber::registry().with(filter).with(
+    // Build and install the subscriber
+    // We need to handle all combinations of timing + logging
+    match (time_passes, logging_enabled, log_format) {
+        // Timing only (no logging)
+        (true, false, _) => {
+            let timing_layer = timing::TimingLayer::new(timing_data.clone().unwrap());
+            let subscriber = tracing_subscriber::registry().with(timing_layer);
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("failed to set tracing subscriber");
+        }
+
+        // Timing + text logging
+        (true, true, LogFormat::Text) => {
+            let timing_layer = timing::TimingLayer::new(timing_data.clone().unwrap());
+            let subscriber = tracing_subscriber::registry()
+                .with(filter.unwrap())
+                .with(timing_layer)
+                .with(
+                    fmt::layer()
+                        .with_target(true)
+                        .with_span_events(FmtSpan::CLOSE)
+                        .with_writer(std::io::stderr),
+                );
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("failed to set tracing subscriber");
+        }
+
+        // Timing + JSON logging
+        (true, true, LogFormat::Json) => {
+            let timing_layer = timing::TimingLayer::new(timing_data.clone().unwrap());
+            let subscriber = tracing_subscriber::registry()
+                .with(filter.unwrap())
+                .with(timing_layer)
+                .with(
+                    fmt::layer()
+                        .json()
+                        .with_target(true)
+                        .with_span_events(FmtSpan::CLOSE)
+                        .with_writer(std::io::stderr),
+                );
+            tracing::subscriber::set_global_default(subscriber)
+                .expect("failed to set tracing subscriber");
+        }
+
+        // Text logging only (no timing)
+        (false, true, LogFormat::Text) => {
+            let subscriber = tracing_subscriber::registry().with(filter.unwrap()).with(
                 fmt::layer()
                     .with_target(true)
                     .with_span_events(FmtSpan::CLOSE)
@@ -470,8 +546,10 @@ fn init_tracing(log_level: LogLevel, log_format: LogFormat) {
             tracing::subscriber::set_global_default(subscriber)
                 .expect("failed to set tracing subscriber");
         }
-        LogFormat::Json => {
-            let subscriber = tracing_subscriber::registry().with(filter).with(
+
+        // JSON logging only (no timing)
+        (false, true, LogFormat::Json) => {
+            let subscriber = tracing_subscriber::registry().with(filter.unwrap()).with(
                 fmt::layer()
                     .json()
                     .with_target(true)
@@ -481,7 +559,12 @@ fn init_tracing(log_level: LogLevel, log_format: LogFormat) {
             tracing::subscriber::set_global_default(subscriber)
                 .expect("failed to set tracing subscriber");
         }
+
+        // Neither timing nor logging - already handled above
+        (false, false, _) => unreachable!(),
     }
+
+    timing_data
 }
 
 fn main() {
@@ -491,7 +574,8 @@ fn main() {
     };
 
     // Initialize tracing based on CLI options
-    init_tracing(options.log_level, options.log_format);
+    // Returns timing data if --time-passes was specified
+    let timing_data = init_tracing(options.log_level, options.log_format, options.time_passes);
 
     // Read source
     let source = fs::read_to_string(&options.source_path).unwrap_or_else(|e| {
@@ -507,6 +591,10 @@ fn main() {
     if !options.emit_stages.is_empty() {
         if let Err(()) = handle_emit(&source, &options, &formatter) {
             std::process::exit(1);
+        }
+        // Print timing report if --time-passes was specified
+        if let Some(ref timing) = timing_data {
+            eprintln!("{}", timing.report());
         }
         return;
     }
@@ -560,6 +648,11 @@ fn main() {
                 "Compiled {} -> {} (target: {}, linker: {})",
                 options.source_path, options.output_path, options.target, linker_str
             );
+
+            // Print timing report if --time-passes was specified
+            if let Some(ref timing) = timing_data {
+                eprintln!("{}", timing.report());
+            }
         }
         Err(e) => {
             eprintln!("{}", formatter.format_error(&e));
@@ -1259,6 +1352,34 @@ mod tests {
     fn parse_defaults_log_format() {
         let opts = unwrap_options(parse_args_from(&["source.rue"]));
         assert_eq!(opts.log_format, LogFormat::Text);
+    }
+
+    #[test]
+    fn parse_defaults_time_passes() {
+        let opts = unwrap_options(parse_args_from(&["source.rue"]));
+        assert!(!opts.time_passes);
+    }
+
+    // ========== --time-passes tests ==========
+
+    #[test]
+    fn parse_time_passes() {
+        let opts = unwrap_options(parse_args_from(&["--time-passes", "source.rue"]));
+        assert!(opts.time_passes);
+    }
+
+    #[test]
+    fn parse_time_passes_with_other_options() {
+        let opts = unwrap_options(parse_args_from(&[
+            "--time-passes",
+            "-O2",
+            "--target",
+            "x86_64-linux",
+            "source.rue",
+        ]));
+        assert!(opts.time_passes);
+        assert_eq!(opts.opt_level, OptLevel::O2);
+        assert_eq!(opts.target, Target::X86_64Linux);
     }
 
     // ========== EmitStage FromStr tests ==========

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -1,0 +1,297 @@
+//! Timing infrastructure for `--time-passes`.
+//!
+//! This module provides a tracing layer that collects timing information from
+//! compiler passes. It uses the tracing span lifecycle to measure how long each
+//! pass takes, then formats a summary report.
+//!
+//! # Architecture
+//!
+//! The timing system is built on tracing's layer architecture:
+//!
+//! 1. **Instrumentation** (Phase 4): Compiler passes are wrapped in tracing spans
+//!    like `info_span!("lexer")`. These are zero-cost when no subscriber collects them.
+//!
+//! 2. **Collection** (this module): `TimingLayer` implements `tracing_subscriber::Layer`
+//!    to hook into span enter/exit events and accumulate timing data.
+//!
+//! 3. **Reporting**: After compilation, `TimingData::report()` formats the collected
+//!    timing as a human-readable table.
+//!
+//! # Example
+//!
+//! ```ignore
+//! use crate::timing::{TimingLayer, TimingData};
+//!
+//! let timing_data = TimingData::new();
+//! let timing_layer = TimingLayer::new(timing_data.clone());
+//!
+//! // Install as a tracing subscriber layer
+//! let subscriber = Registry::default().with(timing_layer);
+//! tracing::subscriber::set_global_default(subscriber).unwrap();
+//!
+//! // ... run compilation ...
+//!
+//! // Print the timing report
+//! eprintln!("{}", timing_data.report());
+//! ```
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use tracing::Subscriber;
+use tracing::span::{Attributes, Id};
+use tracing_subscriber::Layer;
+use tracing_subscriber::layer::Context;
+use tracing_subscriber::registry::LookupSpan;
+
+/// Accumulated timing data for all compiler passes.
+///
+/// This is wrapped in `Arc<Mutex<_>>` so it can be shared between the layer
+/// (which collects data) and the caller (which reads the report).
+#[derive(Clone)]
+pub struct TimingData {
+    inner: Arc<Mutex<TimingDataInner>>,
+}
+
+/// The actual timing data storage.
+struct TimingDataInner {
+    /// Accumulated duration per pass name.
+    /// Key is the span name (e.g., "lexer", "parser").
+    passes: HashMap<String, Duration>,
+
+    /// Order in which passes were first seen, for deterministic output.
+    pass_order: Vec<String>,
+}
+
+impl TimingData {
+    /// Create a new empty timing data collector.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(TimingDataInner {
+                passes: HashMap::new(),
+                pass_order: Vec::new(),
+            })),
+        }
+    }
+
+    /// Record a duration for the given pass.
+    fn record(&self, pass: &str, duration: Duration) {
+        let mut inner = self.inner.lock().unwrap();
+        let entry = inner
+            .passes
+            .entry(pass.to_string())
+            .or_insert(Duration::ZERO);
+        *entry += duration;
+
+        // Track order of first occurrence
+        if !inner.pass_order.contains(&pass.to_string()) {
+            inner.pass_order.push(pass.to_string());
+        }
+    }
+
+    /// Generate the timing report.
+    ///
+    /// Returns a formatted string showing each pass's timing and percentage
+    /// of total compilation time.
+    pub fn report(&self) -> String {
+        let inner = self.inner.lock().unwrap();
+
+        if inner.passes.is_empty() {
+            return String::from("No timing data collected (no instrumented passes ran).\n");
+        }
+
+        let total: Duration = inner.passes.values().sum();
+        let total_ms = total.as_secs_f64() * 1000.0;
+
+        let mut output = String::new();
+        output.push_str("=== Compilation Timing ===\n\n");
+
+        // Find the longest pass name for alignment
+        let max_name_len = inner.pass_order.iter().map(|s| s.len()).max().unwrap_or(0);
+
+        for pass in &inner.pass_order {
+            if let Some(&duration) = inner.passes.get(pass) {
+                let ms = duration.as_secs_f64() * 1000.0;
+                let pct = if total_ms > 0.0 {
+                    (ms / total_ms) * 100.0
+                } else {
+                    0.0
+                };
+
+                // Format: "  Lexer:              0.2ms (  1%)"
+                // Capitalize first letter for display
+                let display_name = capitalize(pass);
+                output.push_str(&format!(
+                    "  {:<width$} {:>8.1}ms ({:>3.0}%)\n",
+                    format!("{}:", display_name),
+                    ms,
+                    pct,
+                    width = max_name_len + 1
+                ));
+            }
+        }
+
+        output.push_str(&format!("  {:-<width$}\n", "", width = max_name_len + 20));
+        output.push_str(&format!(
+            "  {:<width$} {:>8.1}ms (100%)\n",
+            "Total:",
+            total_ms,
+            width = max_name_len + 1
+        ));
+
+        output
+    }
+}
+
+impl Default for TimingData {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Capitalize the first letter of a string.
+fn capitalize(s: &str) -> String {
+    let mut chars = s.chars();
+    match chars.next() {
+        None => String::new(),
+        Some(first) => first.to_uppercase().collect::<String>() + chars.as_str(),
+    }
+}
+
+/// A tracing layer that collects timing information from spans.
+///
+/// This layer hooks into the span lifecycle to measure how long each span
+/// is active (entered). It stores timing data in a shared `TimingData`
+/// that can be queried after compilation completes.
+pub struct TimingLayer {
+    data: TimingData,
+}
+
+impl TimingLayer {
+    /// Create a new timing layer that stores data in the given `TimingData`.
+    pub fn new(data: TimingData) -> Self {
+        Self { data }
+    }
+}
+
+/// Per-span storage for timing state.
+///
+/// This is stored in the span's extensions and tracks when the span was entered.
+struct SpanTiming {
+    /// When the span was most recently entered.
+    /// None if the span is not currently entered.
+    entered_at: Option<Instant>,
+    /// Total time accumulated across all enter/exit cycles.
+    accumulated: Duration,
+}
+
+impl<S> Layer<S> for TimingLayer
+where
+    S: Subscriber + for<'a> LookupSpan<'a>,
+{
+    fn on_new_span(&self, _attrs: &Attributes<'_>, id: &Id, ctx: Context<'_, S>) {
+        // Initialize timing state for this span
+        if let Some(span) = ctx.span(id) {
+            let mut extensions = span.extensions_mut();
+            extensions.insert(SpanTiming {
+                entered_at: None,
+                accumulated: Duration::ZERO,
+            });
+        }
+    }
+
+    fn on_enter(&self, id: &Id, ctx: Context<'_, S>) {
+        // Record when the span was entered
+        if let Some(span) = ctx.span(id) {
+            let mut extensions = span.extensions_mut();
+            if let Some(timing) = extensions.get_mut::<SpanTiming>() {
+                timing.entered_at = Some(Instant::now());
+            }
+        }
+    }
+
+    fn on_exit(&self, id: &Id, ctx: Context<'_, S>) {
+        // Calculate duration and accumulate
+        if let Some(span) = ctx.span(id) {
+            let mut extensions = span.extensions_mut();
+            if let Some(timing) = extensions.get_mut::<SpanTiming>() {
+                if let Some(entered_at) = timing.entered_at.take() {
+                    timing.accumulated += entered_at.elapsed();
+                }
+            }
+        }
+    }
+
+    fn on_close(&self, id: Id, ctx: Context<'_, S>) {
+        // When the span is fully closed, record its total time
+        if let Some(span) = ctx.span(&id) {
+            let extensions = span.extensions();
+            if let Some(timing) = extensions.get::<SpanTiming>() {
+                let name = span.name();
+                self.data.record(name, timing.accumulated);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_timing_data_empty_report() {
+        let data = TimingData::new();
+        let report = data.report();
+        assert!(report.contains("No timing data collected"));
+    }
+
+    #[test]
+    fn test_timing_data_record_and_report() {
+        let data = TimingData::new();
+        data.record("lexer", Duration::from_millis(100));
+        data.record("parser", Duration::from_millis(200));
+
+        let report = data.report();
+        assert!(report.contains("Compilation Timing"));
+        assert!(report.contains("Lexer"));
+        assert!(report.contains("Parser"));
+        assert!(report.contains("Total"));
+    }
+
+    #[test]
+    fn test_timing_data_order_preserved() {
+        let data = TimingData::new();
+        data.record("aaa", Duration::from_millis(100));
+        data.record("zzz", Duration::from_millis(100));
+        data.record("mmm", Duration::from_millis(100));
+
+        let report = data.report();
+        let aaa_pos = report.find("Aaa").unwrap();
+        let zzz_pos = report.find("Zzz").unwrap();
+        let mmm_pos = report.find("Mmm").unwrap();
+
+        // Order should be: aaa, zzz, mmm (insertion order)
+        assert!(aaa_pos < zzz_pos);
+        assert!(zzz_pos < mmm_pos);
+    }
+
+    #[test]
+    fn test_timing_data_accumulates() {
+        let data = TimingData::new();
+        data.record("lexer", Duration::from_millis(100));
+        data.record("lexer", Duration::from_millis(50));
+
+        let report = data.report();
+        // Should show ~150ms for lexer
+        assert!(report.contains("150"));
+    }
+
+    #[test]
+    fn test_capitalize() {
+        assert_eq!(capitalize("lexer"), "Lexer");
+        assert_eq!(capitalize("PARSER"), "PARSER");
+        assert_eq!(capitalize(""), "");
+        assert_eq!(capitalize("a"), "A");
+    }
+}

--- a/docs/designs/0018-tracing-infrastructure.md
+++ b/docs/designs/0018-tracing-infrastructure.md
@@ -125,7 +125,7 @@ pub fn compile_frontend_with_options(...) -> CompileResult<...> {
   - Add `--log-format` flag (text/json)
   - Support `RUST_LOG` environment variable
 
-- [ ] **Phase 3: --time-passes** - rue-irz1.3
+- [x] **Phase 3: --time-passes** - rue-irz1.3
   - Implement `--time-passes` using tracing spans
   - Collect timing from spans and format output
   - Closes rue-uxgx


### PR DESCRIPTION
Implements Phase 3 of the tracing infrastructure (ADR-0018):

- Add TimingLayer: a tracing layer that collects span timing data
- Add TimingData: shared storage for accumulated pass timings
- Add --time-passes CLI flag to enable timing collection
- Display formatted timing report after compilation

The infrastructure is complete; actual timing data will be collected once Phase 4 instruments compiler passes with tracing spans.

Fixes rue-irz1.3, rue-uxgx

🤖 Generated with [Claude Code](https://claude.com/claude-code)