### PR TITLE
Move x86_64 epilogue emission from CfgLower to Emitter

### DIFF
--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -58,8 +58,6 @@ pub struct CfgLower<'a> {
     /// Inline labels (for overflow checks, bounds checks, etc.) use IDs from
     /// the lower half of the `u32` space. See module docs for namespace details.
     next_label: u32,
-    /// Whether this function has a stack frame
-    has_frame: bool,
     /// Number of local variable slots
     num_locals: u32,
     /// Number of parameter slots
@@ -93,7 +91,6 @@ impl<'a> CfgLower<'a> {
             value_map: HashMap::new(),
             block_param_vregs: HashMap::new(),
             next_label: 0,
-            has_frame: num_locals > 0 || num_params > 0,
             num_locals,
             num_params,
             fn_name: cfg.fn_name(),
@@ -309,17 +306,6 @@ impl<'a> CfgLower<'a> {
 
         // Continue with valid access
         self.mir.push(X86Inst::Label { id: ok_label });
-    }
-
-    /// Emit function epilogue.
-    fn emit_epilogue(&mut self) {
-        self.mir.push(X86Inst::MovRR {
-            dst: Operand::Physical(Reg::Rsp),
-            src: Operand::Physical(Reg::Rbp),
-        });
-        self.mir.push(X86Inst::Pop {
-            dst: Operand::Physical(Reg::Rbp),
-        });
     }
 
     /// Allocate a new inline label ID.
@@ -3277,9 +3263,6 @@ impl<'a> CfgLower<'a> {
             Terminator::Return { value } => {
                 // Handle `return;` without expression (unit-returning functions)
                 let Some(value) = value else {
-                    if self.has_frame {
-                        self.emit_epilogue();
-                    }
                     self.mir.push(X86Inst::Ret);
                     return;
                 };
@@ -3355,9 +3338,6 @@ impl<'a> CfgLower<'a> {
                         }
                     }
 
-                    if self.has_frame {
-                        self.emit_epilogue();
-                    }
                     self.mir.push(X86Inst::Ret);
                 } else {
                     let val_vreg = self.get_vreg(*value);
@@ -3365,9 +3345,6 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Physical(Reg::Rax),
                         src: Operand::Virtual(val_vreg),
                     });
-                    if self.has_frame {
-                        self.emit_epilogue();
-                    }
                     self.mir.push(X86Inst::Ret);
                 }
             }

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -148,6 +148,8 @@ pub struct Emitter<'a> {
     callee_saved: Vec<Reg>,
     /// String table (indexed by string_id in StringConstPtr/StringConstLen).
     strings: &'a [String],
+    /// Whether a stack frame was emitted (prologue was executed).
+    has_frame: bool,
     /// Byte offset where the current instruction started (for recording).
     inst_start: usize,
 }
@@ -179,6 +181,7 @@ impl<'a> Emitter<'a> {
             num_params,
             callee_saved: callee_saved.to_vec(),
             strings,
+            has_frame: false,
             inst_start: 0,
         }
     }
@@ -273,6 +276,7 @@ impl<'a> Emitter<'a> {
 
         // Emit function prologue if we have local variables, parameters, or callee-saved regs
         if self.num_locals > 0 || self.num_params > 0 || !self.callee_saved.is_empty() {
+            self.has_frame = true;
             self.emit_prologue();
         }
 
@@ -385,6 +389,40 @@ impl<'a> Emitter<'a> {
         }
     }
 
+    /// Emit function epilogue (restore callee-saved registers and frame pointer).
+    ///
+    /// This reverses the prologue:
+    /// ```asm
+    /// lea rsp, [rbp - callee_saved_size]  ; Deallocate locals, point at callee-saved area
+    /// pop r13                              ; Restore callee-saved in reverse order
+    /// pop r12
+    /// pop rbp                              ; Restore caller's frame pointer
+    /// ```
+    fn emit_epilogue(&mut self) {
+        self.record_comment("epilogue");
+
+        // Point RSP at the callee-saved area (skip locals and alignment padding)
+        let size = self.callee_saved_size();
+        if !self.callee_saved.is_empty() || self.num_locals > 0 || self.num_params > 0 {
+            self.begin_inst();
+            self.emit_lea_rsp_rbp_offset(-size);
+            self.end_inst(format!("lea rsp, [rbp{}]", format_offset(-size)));
+        }
+
+        // Pop callee-saved registers in reverse order
+        let callee_saved: Vec<_> = self.callee_saved.iter().rev().copied().collect();
+        for reg in callee_saved {
+            self.begin_inst();
+            self.emit_pop(reg);
+            self.end_inst(format!("pop {}", reg));
+        }
+
+        // Pop rbp to restore caller's frame pointer
+        self.begin_inst();
+        self.emit_pop(Reg::Rbp);
+        self.end_inst("pop rbp");
+    }
+
     /// Apply all fixups for forward jumps.
     fn apply_fixups(&mut self) -> CompileResult<()> {
         for fixup in &self.fixups {
@@ -453,35 +491,9 @@ impl<'a> Emitter<'a> {
                 self.end_inst(format!("mov {}, {}", dst.as_physical(), *imm));
             }
             X86Inst::MovRR { dst, src } => {
-                // Detect epilogue pattern: mov rsp, rbp
-                // With our prologue (push rbp; mov rbp,rsp; push callee_saved...),
-                // callee-saved registers are BELOW rbp on the stack.
-                // We need to restore them before moving rsp to rbp.
-                if dst.as_physical() == Reg::Rsp
-                    && src.as_physical() == Reg::Rbp
-                    && !self.callee_saved.is_empty()
-                {
-                    self.record_comment("epilogue - restore callee-saved");
-                    // Instead of mov rsp, rbp (which skips callee-saved),
-                    // first point rsp at the callee-saved area, pop them, then pop rbp
-                    let size = self.callee_saved_size();
-                    // lea rsp, [rbp - callee_saved_size]
-                    self.begin_inst();
-                    self.emit_lea_rsp_rbp_offset(-size);
-                    self.end_inst(format!("lea rsp, [rbp{}]", -size));
-                    // Pop callee-saved in reverse order (last pushed = first popped)
-                    let callee_saved: Vec<_> = self.callee_saved.iter().rev().copied().collect();
-                    for reg in callee_saved {
-                        self.begin_inst();
-                        self.emit_pop(reg);
-                        self.end_inst(format!("pop {}", reg));
-                    }
-                    // Now rsp points at saved rbp, ready for pop rbp
-                } else {
-                    self.begin_inst();
-                    self.emit_mov_rr(dst.as_physical(), src.as_physical());
-                    self.end_inst(format!("mov {}, {}", dst.as_physical(), src.as_physical()));
-                }
+                self.begin_inst();
+                self.emit_mov_rr(dst.as_physical(), src.as_physical());
+                self.end_inst(format!("mov {}, {}", dst.as_physical(), src.as_physical()));
             }
             X86Inst::MovRM { dst, base, offset } => {
                 let adjusted_offset = self.adjust_fp_offset(*base, *offset);
@@ -852,39 +864,14 @@ impl<'a> Emitter<'a> {
                 self.end_inst("syscall");
             }
             X86Inst::Ret => {
-                // If we have callee-saved registers but no standard epilogue from lowerer,
-                // we still need to emit the epilogue to restore them.
-                // With our prologue order (push rbp; mov rbp,rsp; push callee_saved...; sub rsp,N),
-                // we need to: lea rsp,[rbp-callee_size]; pop callee-saved; pop rbp; ret
-                // We detect "no frame from MIR" by checking if we have callee_saved but
-                // num_locals and num_params are both 0 (meaning lowerer didn't emit epilogue).
-                if !self.callee_saved.is_empty() && self.num_locals == 0 && self.num_params == 0 {
-                    self.record_comment("epilogue - restore callee-saved");
-                    // Point RSP at the callee-saved area (skip any alignment padding)
-                    let size = self.callee_saved_size();
-                    self.begin_inst();
-                    self.emit_lea_rsp_rbp_offset(-size);
-                    self.end_inst(format!("lea rsp, [rbp{}]", -size));
-                    // Pop callee-saved in reverse order
-                    let callee_saved: Vec<_> = self.callee_saved.iter().rev().copied().collect();
-                    for reg in callee_saved {
-                        self.begin_inst();
-                        self.emit_pop(reg);
-                        self.end_inst(format!("pop {}", reg));
-                    }
-                    // Then pop rbp
-                    self.begin_inst();
-                    self.emit_pop(Reg::Rbp);
-                    self.end_inst("pop rbp");
+                if self.has_frame {
+                    self.emit_epilogue();
                 }
                 self.begin_inst();
                 self.emit_ret();
                 self.end_inst("ret");
             }
             X86Inst::Pop { dst } => {
-                // With our new prologue order (push rbp; mov rbp,rsp; push callee_saved...),
-                // callee-saved registers are restored in the MovRR handler when it sees
-                // the epilogue pattern (mov rsp, rbp). So we just emit a simple pop here.
                 self.begin_inst();
                 self.emit_pop(dst.as_physical());
                 self.end_inst(format!("pop {}", dst.as_physical()));


### PR DESCRIPTION
Refactors x86_64 codegen to match the aarch64 pattern for epilogue handling. Previously, CfgLower tracked `has_frame` and emitted epilogue instructions before Ret. Now the Emitter handles all epilogue emission:

- Remove `has_frame` field and `emit_epilogue()` from CfgLower
- Add `has_frame` field to Emitter, set when prologue is emitted
- Add `emit_epilogue()` method to Emitter
- Simplify Ret handling to call emit_epilogue() when has_frame is true
- Remove dead code (MovRR epilogue pattern detection)

This improves consistency between backends and simplifies the MIR.

Fixes rue-t6px

🤖 Generated with [Claude Code](https://claude.com/claude-code)