### PR TITLE
Extract magic numbers to named constants in rue-linker

### DIFF
--- a/crates/rue-linker/src/constants.rs
+++ b/crates/rue-linker/src/constants.rs
@@ -1,0 +1,308 @@
+//! Constants for ELF and Mach-O file formats.
+//!
+//! This module provides named constants for the magic numbers used in
+//! ELF and Mach-O object files, making the code more readable and
+//! less error-prone.
+
+// =============================================================================
+// ELF File Format Constants
+// =============================================================================
+
+/// ELF magic number: "\x7FELF"
+pub const ELF_MAGIC: [u8; 4] = [0x7F, b'E', b'L', b'F'];
+
+// ELF identification (e_ident) indices and values
+
+/// EI_CLASS index in e_ident
+pub const EI_CLASS: usize = 4;
+/// EI_DATA index in e_ident
+pub const EI_DATA: usize = 5;
+/// EI_VERSION index in e_ident
+pub const EI_VERSION: usize = 6;
+/// EI_OSABI index in e_ident
+pub const EI_OSABI: usize = 7;
+
+/// ELFCLASS64: 64-bit objects
+pub const ELFCLASS64: u8 = 2;
+/// ELFDATA2LSB: Little-endian data encoding
+pub const ELFDATA2LSB: u8 = 1;
+/// EV_CURRENT: Current ELF version
+pub const EV_CURRENT: u8 = 1;
+/// ELFOSABI_NONE: System V ABI (also used for Linux)
+pub const ELFOSABI_NONE: u8 = 0;
+
+// ELF header sizes
+
+/// Size of the ELF64 file header in bytes
+pub const ELF64_EHDR_SIZE: usize = 64;
+/// Size of an ELF64 program header entry in bytes
+pub const ELF64_PHDR_SIZE: usize = 56;
+/// Size of an ELF64 section header entry in bytes
+pub const ELF64_SHDR_SIZE: usize = 64;
+/// Size of an ELF64 symbol table entry in bytes
+pub const ELF64_SYM_SIZE: usize = 24;
+/// Size of an ELF64 relocation entry with addend (Rela) in bytes
+pub const ELF64_RELA_SIZE: usize = 24;
+
+// ELF header field offsets
+
+/// Offset of e_type in ELF64 header
+pub const E_TYPE_OFFSET: usize = 16;
+/// Offset of e_machine in ELF64 header
+pub const E_MACHINE_OFFSET: usize = 18;
+/// Offset of e_shoff in ELF64 header
+pub const E_SHOFF_OFFSET: usize = 40;
+/// Offset of e_shentsize in ELF64 header
+pub const E_SHENTSIZE_OFFSET: usize = 58;
+/// Offset of e_shnum in ELF64 header
+pub const E_SHNUM_OFFSET: usize = 60;
+/// Offset of e_shstrndx in ELF64 header
+pub const E_SHSTRNDX_OFFSET: usize = 62;
+
+// ELF file types (e_type)
+
+/// ET_REL: Relocatable file
+pub const ET_REL: u16 = 1;
+/// ET_EXEC: Executable file
+pub const ET_EXEC: u16 = 2;
+/// ET_DYN: Shared object file
+pub const ET_DYN: u16 = 3;
+
+// Machine types (e_machine)
+
+/// EM_386: Intel 80386
+pub const EM_386: u16 = 0x03;
+/// EM_X86_64: AMD x86-64
+pub const EM_X86_64: u16 = 0x3E;
+/// EM_AARCH64: ARM 64-bit
+pub const EM_AARCH64: u16 = 0xB7;
+
+// Section header types (sh_type)
+
+/// SHT_NULL: Inactive section header
+pub const SHT_NULL: u32 = 0;
+/// SHT_PROGBITS: Program-defined data
+pub const SHT_PROGBITS: u32 = 1;
+/// SHT_SYMTAB: Symbol table
+pub const SHT_SYMTAB: u32 = 2;
+/// SHT_STRTAB: String table
+pub const SHT_STRTAB: u32 = 3;
+/// SHT_RELA: Relocation entries with explicit addends
+pub const SHT_RELA: u32 = 4;
+
+// Section header flags (sh_flags)
+
+/// SHF_WRITE: Writable section
+pub const SHF_WRITE: u64 = 0x1;
+/// SHF_ALLOC: Section occupies memory during execution
+pub const SHF_ALLOC: u64 = 0x2;
+/// SHF_EXECINSTR: Section contains executable instructions
+pub const SHF_EXECINSTR: u64 = 0x4;
+/// SHF_INFO_LINK: sh_info contains section header table index
+pub const SHF_INFO_LINK: u64 = 0x40;
+
+// Special section indices
+
+/// SHN_UNDEF: Undefined section reference
+pub const SHN_UNDEF: u16 = 0;
+/// SHN_LORESERVE: Start of reserved section indices
+pub const SHN_LORESERVE: u16 = 0xff00;
+/// SHN_ABS: Absolute value (not relocated)
+pub const SHN_ABS: u16 = 0xfff1;
+
+// Symbol binding (upper 4 bits of st_info)
+
+/// STB_LOCAL: Local symbol
+pub const STB_LOCAL: u8 = 0;
+/// STB_GLOBAL: Global symbol
+pub const STB_GLOBAL: u8 = 1;
+/// STB_WEAK: Weak symbol
+pub const STB_WEAK: u8 = 2;
+
+// Symbol types (lower 4 bits of st_info)
+
+/// STT_NOTYPE: Symbol type not specified
+pub const STT_NOTYPE: u8 = 0;
+/// STT_OBJECT: Data object (variable, array, etc.)
+pub const STT_OBJECT: u8 = 1;
+/// STT_FUNC: Function or other executable code
+pub const STT_FUNC: u8 = 2;
+/// STT_SECTION: Section symbol
+pub const STT_SECTION: u8 = 3;
+/// STT_FILE: Source file name
+pub const STT_FILE: u8 = 4;
+
+/// Build st_info value from binding and type
+#[inline]
+pub const fn elf_st_info(binding: u8, sym_type: u8) -> u8 {
+    (binding << 4) | (sym_type & 0xf)
+}
+
+/// Extract binding from st_info
+#[inline]
+pub const fn elf_st_bind(info: u8) -> u8 {
+    info >> 4
+}
+
+/// Extract type from st_info
+#[inline]
+pub const fn elf_st_type(info: u8) -> u8 {
+    info & 0xf
+}
+
+// x86-64 relocation types
+
+/// R_X86_64_NONE: No relocation
+pub const R_X86_64_NONE: u32 = 0;
+/// R_X86_64_64: 64-bit absolute address
+pub const R_X86_64_64: u32 = 1;
+/// R_X86_64_PC32: 32-bit PC-relative address
+pub const R_X86_64_PC32: u32 = 2;
+/// R_X86_64_PLT32: 32-bit PLT-relative address
+pub const R_X86_64_PLT32: u32 = 4;
+/// R_X86_64_GOTPCREL: 32-bit GOT PC-relative
+pub const R_X86_64_GOTPCREL: u32 = 9;
+/// R_X86_64_32: 32-bit absolute address
+pub const R_X86_64_32: u32 = 10;
+/// R_X86_64_32S: 32-bit signed absolute address
+pub const R_X86_64_32S: u32 = 11;
+/// R_X86_64_GOTPCRELX: Relaxable 32-bit GOT PC-relative
+pub const R_X86_64_GOTPCRELX: u32 = 41;
+/// R_X86_64_REX_GOTPCRELX: Relaxable 32-bit GOT PC-relative with REX prefix
+pub const R_X86_64_REX_GOTPCRELX: u32 = 42;
+
+// AArch64 relocation types
+
+/// R_AARCH64_ABS64: 64-bit absolute address
+pub const R_AARCH64_ABS64: u32 = 257;
+/// R_AARCH64_ADR_PREL_PG_HI21: ADRP instruction page address
+pub const R_AARCH64_ADR_PREL_PG_HI21: u32 = 275;
+/// R_AARCH64_ADD_ABS_LO12_NC: ADD instruction page offset
+pub const R_AARCH64_ADD_ABS_LO12_NC: u32 = 277;
+/// R_AARCH64_JUMP26: Unconditional branch
+pub const R_AARCH64_JUMP26: u32 = 282;
+/// R_AARCH64_CALL26: Branch with link
+pub const R_AARCH64_CALL26: u32 = 283;
+
+// Program header types (p_type)
+
+/// PT_LOAD: Loadable segment
+pub const PT_LOAD: u32 = 1;
+
+// Program header flags (p_flags)
+
+/// PF_X: Execute permission
+pub const PF_X: u32 = 0x1;
+/// PF_W: Write permission
+pub const PF_W: u32 = 0x2;
+/// PF_R: Read permission
+pub const PF_R: u32 = 0x4;
+
+// =============================================================================
+// Mach-O File Format Constants
+// =============================================================================
+
+/// MH_MAGIC_64: Mach-O 64-bit magic number (little-endian)
+pub const MH_MAGIC_64: u32 = 0xFEEDFACF;
+
+// Mach-O file types
+
+/// MH_OBJECT: Relocatable object file
+pub const MH_OBJECT: u32 = 0x1;
+
+// Mach-O CPU types
+
+/// CPU_TYPE_ARM64: ARM 64-bit (includes CPU_ARCH_ABI64)
+pub const CPU_TYPE_ARM64: u32 = 0x0100000C;
+/// CPU_SUBTYPE_ARM64_ALL: All ARM64 subtypes
+pub const CPU_SUBTYPE_ARM64_ALL: u32 = 0;
+
+// Mach-O load commands
+
+/// LC_SEGMENT_64: 64-bit segment load command
+pub const LC_SEGMENT_64: u32 = 0x19;
+/// LC_SYMTAB: Symbol table load command
+pub const LC_SYMTAB: u32 = 0x2;
+/// LC_BUILD_VERSION: Build version load command
+pub const LC_BUILD_VERSION: u32 = 0x32;
+
+// Mach-O section flags
+
+/// S_ATTR_PURE_INSTRUCTIONS: Section contains only machine instructions
+pub const S_ATTR_PURE_INSTRUCTIONS: u32 = 0x80000000;
+/// S_ATTR_SOME_INSTRUCTIONS: Section contains some machine instructions
+pub const S_ATTR_SOME_INSTRUCTIONS: u32 = 0x00000400;
+
+// Mach-O platform constants
+
+/// PLATFORM_MACOS: macOS platform identifier
+pub const PLATFORM_MACOS: u32 = 1;
+
+// Mach-O symbol types
+
+/// N_EXT: External symbol
+pub const N_EXT: u8 = 0x01;
+/// N_SECT: Symbol defined in section
+pub const N_SECT: u8 = 0x0E;
+/// N_UNDF: Undefined symbol
+pub const N_UNDF: u8 = 0x00;
+
+// ARM64 relocation types (Mach-O)
+
+/// ARM64_RELOC_BRANCH26: Branch instruction
+pub const ARM64_RELOC_BRANCH26: u32 = 2;
+/// ARM64_RELOC_PAGE21: ADRP instruction
+pub const ARM64_RELOC_PAGE21: u32 = 3;
+/// ARM64_RELOC_PAGEOFF12: Page offset
+pub const ARM64_RELOC_PAGEOFF12: u32 = 4;
+
+// Mach-O structure sizes
+
+/// Size of Mach-O 64-bit header
+pub const MACHO64_HEADER_SIZE: usize = 32;
+/// Size of Mach-O segment_command_64
+pub const MACHO64_SEGMENT_CMD_SIZE: usize = 72;
+/// Size of Mach-O section_64
+pub const MACHO64_SECTION_SIZE: usize = 80;
+/// Size of Mach-O symtab_command
+pub const MACHO64_SYMTAB_CMD_SIZE: usize = 24;
+/// Size of Mach-O build_version_command (without tool entries)
+pub const MACHO64_BUILD_VERSION_CMD_SIZE: usize = 24;
+/// Size of Mach-O nlist_64 symbol table entry
+pub const MACHO64_NLIST_SIZE: usize = 16;
+/// Size of Mach-O relocation_info entry
+pub const MACHO64_RELOC_SIZE: usize = 8;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_elf_st_info() {
+        // STB_GLOBAL | STT_FUNC = 0x12
+        assert_eq!(elf_st_info(STB_GLOBAL, STT_FUNC), 0x12);
+        // STB_LOCAL | STT_SECTION = 0x03
+        assert_eq!(elf_st_info(STB_LOCAL, STT_SECTION), 0x03);
+        // STB_WEAK | STT_NOTYPE = 0x20
+        assert_eq!(elf_st_info(STB_WEAK, STT_NOTYPE), 0x20);
+    }
+
+    #[test]
+    fn test_elf_st_bind() {
+        assert_eq!(elf_st_bind(0x12), STB_GLOBAL);
+        assert_eq!(elf_st_bind(0x03), STB_LOCAL);
+        assert_eq!(elf_st_bind(0x20), STB_WEAK);
+    }
+
+    #[test]
+    fn test_elf_st_type() {
+        assert_eq!(elf_st_type(0x12), STT_FUNC);
+        assert_eq!(elf_st_type(0x03), STT_SECTION);
+        assert_eq!(elf_st_type(0x00), STT_NOTYPE);
+    }
+
+    #[test]
+    fn test_elf_magic() {
+        assert_eq!(&ELF_MAGIC, b"\x7FELF");
+    }
+}

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -7,6 +7,17 @@
 
 use std::collections::HashMap;
 
+use crate::constants::{
+    E_MACHINE_OFFSET, E_SHENTSIZE_OFFSET, E_SHNUM_OFFSET, E_SHOFF_OFFSET, E_SHSTRNDX_OFFSET,
+    E_TYPE_OFFSET, ELF_MAGIC, ELF64_EHDR_SIZE, ELF64_RELA_SIZE, ELF64_SHDR_SIZE, ELF64_SYM_SIZE,
+    ELFCLASS64, ELFDATA2LSB, EM_AARCH64, EM_X86_64, ET_REL, R_AARCH64_ABS64,
+    R_AARCH64_ADD_ABS_LO12_NC, R_AARCH64_ADR_PREL_PG_HI21, R_AARCH64_CALL26, R_AARCH64_JUMP26,
+    R_X86_64_32, R_X86_64_32S, R_X86_64_64, R_X86_64_GOTPCREL, R_X86_64_GOTPCRELX, R_X86_64_PC32,
+    R_X86_64_PLT32, R_X86_64_REX_GOTPCRELX, SHN_LORESERVE, SHN_UNDEF, SHT_NULL, SHT_RELA,
+    SHT_STRTAB, SHT_SYMTAB, STB_GLOBAL, STB_LOCAL, STB_WEAK, STT_FILE, STT_FUNC, STT_NOTYPE,
+    STT_OBJECT, STT_SECTION,
+};
+
 /// Helper to read a u16 from a byte slice at a given offset.
 /// Panics if offset + 2 > slice.len(), so caller must ensure bounds.
 #[inline]
@@ -219,22 +230,22 @@ impl RelocationType {
     fn from_elf(r_type: u32, machine: ElfMachine) -> Self {
         match machine {
             ElfMachine::X86_64 => match r_type {
-                1 => RelocationType::Abs64,
-                2 => RelocationType::Pc32,
-                4 => RelocationType::Plt32,
-                9 => RelocationType::GotPcRel, // R_X86_64_GOTPCREL
-                10 => RelocationType::Abs32,
-                11 => RelocationType::Abs32S,
-                41 => RelocationType::GotPcRelX, // R_X86_64_GOTPCRELX
-                42 => RelocationType::RexGotPcRelX, // R_X86_64_REX_GOTPCRELX
+                R_X86_64_64 => RelocationType::Abs64,
+                R_X86_64_PC32 => RelocationType::Pc32,
+                R_X86_64_PLT32 => RelocationType::Plt32,
+                R_X86_64_GOTPCREL => RelocationType::GotPcRel,
+                R_X86_64_32 => RelocationType::Abs32,
+                R_X86_64_32S => RelocationType::Abs32S,
+                R_X86_64_GOTPCRELX => RelocationType::GotPcRelX,
+                R_X86_64_REX_GOTPCRELX => RelocationType::RexGotPcRelX,
                 _ => RelocationType::Unknown(r_type),
             },
             ElfMachine::Aarch64 => match r_type {
-                257 => RelocationType::Aarch64Abs64, // R_AARCH64_ABS64
-                275 => RelocationType::AdrpPage21,   // R_AARCH64_ADR_PREL_PG_HI21
-                277 => RelocationType::AddLo12,      // R_AARCH64_ADD_ABS_LO12_NC
-                282 => RelocationType::Jump26,       // R_AARCH64_JUMP26
-                283 => RelocationType::Call26,       // R_AARCH64_CALL26
+                R_AARCH64_ABS64 => RelocationType::Aarch64Abs64,
+                R_AARCH64_ADR_PREL_PG_HI21 => RelocationType::AdrpPage21,
+                R_AARCH64_ADD_ABS_LO12_NC => RelocationType::AddLo12,
+                R_AARCH64_JUMP26 => RelocationType::Jump26,
+                R_AARCH64_CALL26 => RelocationType::Call26,
                 _ => RelocationType::Unknown(r_type),
             },
         }
@@ -298,47 +309,47 @@ impl ObjectFile {
     #[must_use = "parsing returns a Result that must be checked"]
     pub fn parse(data: &[u8]) -> Result<Self, ParseError> {
         // Check minimum size for ELF header
-        if data.len() < 64 {
+        if data.len() < ELF64_EHDR_SIZE {
             return Err(ParseError::TooShort);
         }
 
         // Check ELF magic
-        if &data[0..4] != b"\x7FELF" {
+        if data[0..4] != ELF_MAGIC {
             return Err(ParseError::InvalidMagic);
         }
 
         // Check 64-bit
-        if data[4] != 2 {
+        if data[4] != ELFCLASS64 {
             return Err(ParseError::Not64Bit);
         }
 
         // Check little-endian
-        if data[5] != 1 {
+        if data[5] != ELFDATA2LSB {
             return Err(ParseError::NotLittleEndian);
         }
 
-        // Check relocatable file (e_type == ET_REL == 1)
-        let e_type = u16::from_le_bytes([data[16], data[17]]);
-        if e_type != 1 {
+        // Check relocatable file (e_type == ET_REL)
+        let e_type = u16::from_le_bytes([data[E_TYPE_OFFSET], data[E_TYPE_OFFSET + 1]]);
+        if e_type != ET_REL {
             return Err(ParseError::NotRelocatable);
         }
 
         // Check machine type (x86-64 or aarch64)
-        let e_machine = u16::from_le_bytes([data[18], data[19]]);
+        let e_machine = u16::from_le_bytes([data[E_MACHINE_OFFSET], data[E_MACHINE_OFFSET + 1]]);
         let machine = match e_machine {
-            0x3E => ElfMachine::X86_64,  // EM_X86_64
-            0xB7 => ElfMachine::Aarch64, // EM_AARCH64
+            EM_X86_64 => ElfMachine::X86_64,
+            EM_AARCH64 => ElfMachine::Aarch64,
             _ => return Err(ParseError::UnsupportedMachine(e_machine)),
         };
 
-        // Parse header fields - safe because we checked data.len() >= 64 above
-        let e_shoff = read_u64(data, 40) as usize;
-        let e_shentsize = read_u16(data, 58) as usize;
-        let e_shnum = read_u16(data, 60) as usize;
-        let e_shstrndx = read_u16(data, 62) as usize;
+        // Parse header fields - safe because we checked data.len() >= ELF64_EHDR_SIZE above
+        let e_shoff = read_u64(data, E_SHOFF_OFFSET) as usize;
+        let e_shentsize = read_u16(data, E_SHENTSIZE_OFFSET) as usize;
+        let e_shnum = read_u16(data, E_SHNUM_OFFSET) as usize;
+        let e_shstrndx = read_u16(data, E_SHSTRNDX_OFFSET) as usize;
 
         // ELF64 section headers are 64 bytes
-        if e_shentsize < 64 && e_shnum > 0 {
+        if e_shentsize < ELF64_SHDR_SIZE && e_shnum > 0 {
             return Err(ParseError::InvalidSection(
                 "section header size too small".into(),
             ));
@@ -387,8 +398,7 @@ impl ObjectFile {
             let align = read_u64(sh, 48);
             let entsize = read_u64(sh, 56);
 
-            // SHT_SYMTAB = 2
-            if sh_type == 2 {
+            if sh_type == SHT_SYMTAB {
                 symtab_idx = Some(i);
                 strtab_idx = Some(link as usize);
             }
@@ -436,8 +446,11 @@ impl ObjectFile {
             let name = read_string(shstrtab_data, raw.name_offset as usize)?;
 
             // Skip null section, symtab, strtab, rela sections (we'll handle them separately)
-            // SHT_NULL=0, SHT_SYMTAB=2, SHT_STRTAB=3, SHT_RELA=4
-            if raw.sh_type == 0 || raw.sh_type == 2 || raw.sh_type == 3 || raw.sh_type == 4 {
+            if raw.sh_type == SHT_NULL
+                || raw.sh_type == SHT_SYMTAB
+                || raw.sh_type == SHT_STRTAB
+                || raw.sh_type == SHT_RELA
+            {
                 sections.push(Section {
                     name: name.clone(),
                     data: Vec::new(),
@@ -465,13 +478,13 @@ impl ObjectFile {
             };
 
             let mut flags = SectionFlags::empty();
-            if raw.flags & 0x1 != 0 {
+            if raw.flags & crate::constants::SHF_WRITE != 0 {
                 flags |= SectionFlags::WRITE;
             }
-            if raw.flags & 0x2 != 0 {
+            if raw.flags & crate::constants::SHF_ALLOC != 0 {
                 flags |= SectionFlags::ALLOC;
             }
-            if raw.flags & 0x4 != 0 {
+            if raw.flags & crate::constants::SHF_EXECINSTR != 0 {
                 flags |= SectionFlags::EXEC;
             }
 
@@ -521,12 +534,12 @@ impl ObjectFile {
             let sym_count = symtab.size / symtab.entsize;
             for i in 0..sym_count {
                 let sym_offset = (i * symtab.entsize) as usize;
-                if sym_offset + 24 > symtab_data.len() {
+                if sym_offset + ELF64_SYM_SIZE > symtab_data.len() {
                     return Err(ParseError::InvalidSymbol(
                         "symbol entry out of bounds".into(),
                     ));
                 }
-                let sym = &symtab_data[sym_offset..sym_offset + 24];
+                let sym = &symtab_data[sym_offset..sym_offset + ELF64_SYM_SIZE];
 
                 // Bounds guaranteed by check above (sym_offset + 24 <= symtab_data.len())
                 let st_name = read_u32(sym, 0);
@@ -539,23 +552,22 @@ impl ObjectFile {
                 let name = read_string(strtab_data, st_name as usize)?;
 
                 let binding = match st_info >> 4 {
-                    0 => SymbolBinding::Local,
-                    1 => SymbolBinding::Global,
-                    2 => SymbolBinding::Weak,
+                    STB_LOCAL => SymbolBinding::Local,
+                    STB_GLOBAL => SymbolBinding::Global,
+                    STB_WEAK => SymbolBinding::Weak,
                     _ => SymbolBinding::Local,
                 };
 
                 let sym_type = match st_info & 0xf {
-                    0 => SymbolType::None,
-                    1 => SymbolType::Object,
-                    2 => SymbolType::Func,
-                    3 => SymbolType::Section,
-                    4 => SymbolType::File,
+                    STT_NOTYPE => SymbolType::None,
+                    STT_OBJECT => SymbolType::Object,
+                    STT_FUNC => SymbolType::Func,
+                    STT_SECTION => SymbolType::Section,
+                    STT_FILE => SymbolType::File,
                     _ => SymbolType::None,
                 };
 
-                // SHN_UNDEF = 0, SHN_ABS = 0xfff1
-                let section_index = if st_shndx == 0 || st_shndx >= 0xff00 {
+                let section_index = if st_shndx == SHN_UNDEF || st_shndx >= SHN_LORESERVE {
                     None
                 } else {
                     let idx = st_shndx as usize;
@@ -582,8 +594,7 @@ impl ObjectFile {
 
         // Parse relocations
         for raw in raw_sections.iter() {
-            // SHT_RELA = 4
-            if raw.sh_type != 4 {
+            if raw.sh_type != SHT_RELA {
                 continue;
             }
 
@@ -609,10 +620,10 @@ impl ObjectFile {
 
             for j in 0..rela_count {
                 let rela_offset = (j * raw.entsize) as usize;
-                if rela_offset + 24 > rela_data.len() {
+                if rela_offset + ELF64_RELA_SIZE > rela_data.len() {
                     return Err(ParseError::RelocationOutOfBounds);
                 }
-                let rela = &rela_data[rela_offset..rela_offset + 24];
+                let rela = &rela_data[rela_offset..rela_offset + ELF64_RELA_SIZE];
 
                 // Bounds guaranteed by check above (rela_offset + 24 <= rela_data.len())
                 let r_offset = read_u64(rela, 0);
@@ -662,6 +673,7 @@ impl ObjectFile {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::constants::{EI_CLASS, EI_DATA, EI_VERSION, ELF64_SHDR_SIZE as TEST_SHDR_SIZE};
 
     #[test]
     fn test_parse_error_display() {
@@ -723,7 +735,7 @@ mod tests {
 
     #[test]
     fn test_invalid_magic() {
-        let mut data = [0u8; 64];
+        let mut data = [0u8; ELF64_EHDR_SIZE];
         data[0..4].copy_from_slice(b"NOTF");
         assert!(matches!(
             ObjectFile::parse(&data),
@@ -733,9 +745,9 @@ mod tests {
 
     #[test]
     fn test_not_64bit() {
-        let mut data = [0u8; 64];
-        data[0..4].copy_from_slice(b"\x7FELF");
-        data[4] = 1; // 32-bit
+        let mut data = [0u8; ELF64_EHDR_SIZE];
+        data[0..4].copy_from_slice(&ELF_MAGIC);
+        data[EI_CLASS] = 1; // 32-bit
         assert!(matches!(
             ObjectFile::parse(&data),
             Err(ParseError::Not64Bit)
@@ -744,10 +756,10 @@ mod tests {
 
     #[test]
     fn test_not_little_endian() {
-        let mut data = [0u8; 64];
-        data[0..4].copy_from_slice(b"\x7FELF");
-        data[4] = 2; // 64-bit
-        data[5] = 2; // Big endian
+        let mut data = [0u8; ELF64_EHDR_SIZE];
+        data[0..4].copy_from_slice(&ELF_MAGIC);
+        data[EI_CLASS] = ELFCLASS64;
+        data[EI_DATA] = 2; // Big endian
         assert!(matches!(
             ObjectFile::parse(&data),
             Err(ParseError::NotLittleEndian)
@@ -756,11 +768,12 @@ mod tests {
 
     #[test]
     fn test_not_relocatable() {
-        let mut data = [0u8; 64];
-        data[0..4].copy_from_slice(b"\x7FELF");
-        data[4] = 2; // 64-bit
-        data[5] = 1; // Little endian
-        data[16..18].copy_from_slice(&2_u16.to_le_bytes()); // ET_EXEC instead of ET_REL
+        let mut data = [0u8; ELF64_EHDR_SIZE];
+        data[0..4].copy_from_slice(&ELF_MAGIC);
+        data[EI_CLASS] = ELFCLASS64;
+        data[EI_DATA] = ELFDATA2LSB;
+        data[E_TYPE_OFFSET..E_TYPE_OFFSET + 2]
+            .copy_from_slice(&crate::constants::ET_EXEC.to_le_bytes()); // ET_EXEC instead of ET_REL
         assert!(matches!(
             ObjectFile::parse(&data),
             Err(ParseError::NotRelocatable)
@@ -769,12 +782,13 @@ mod tests {
 
     #[test]
     fn test_unsupported_machine() {
-        let mut data = [0u8; 64];
-        data[0..4].copy_from_slice(b"\x7FELF");
-        data[4] = 2; // 64-bit
-        data[5] = 1; // Little endian
-        data[16..18].copy_from_slice(&1_u16.to_le_bytes()); // ET_REL
-        data[18..20].copy_from_slice(&0x03_u16.to_le_bytes()); // EM_386 (unsupported)
+        let mut data = [0u8; ELF64_EHDR_SIZE];
+        data[0..4].copy_from_slice(&ELF_MAGIC);
+        data[EI_CLASS] = ELFCLASS64;
+        data[EI_DATA] = ELFDATA2LSB;
+        data[E_TYPE_OFFSET..E_TYPE_OFFSET + 2].copy_from_slice(&ET_REL.to_le_bytes());
+        data[E_MACHINE_OFFSET..E_MACHINE_OFFSET + 2]
+            .copy_from_slice(&crate::constants::EM_386.to_le_bytes()); // EM_386 (unsupported)
         assert!(matches!(
             ObjectFile::parse(&data),
             Err(ParseError::UnsupportedMachine(0x03))
@@ -783,14 +797,14 @@ mod tests {
 
     #[test]
     fn test_section_header_size_too_small() {
-        let mut data = [0u8; 64];
-        data[0..4].copy_from_slice(b"\x7FELF");
-        data[4] = 2; // 64-bit
-        data[5] = 1; // Little endian
-        data[16..18].copy_from_slice(&1_u16.to_le_bytes()); // ET_REL
-        data[18..20].copy_from_slice(&0x3E_u16.to_le_bytes()); // EM_X86_64
-        data[58..60].copy_from_slice(&32_u16.to_le_bytes()); // e_shentsize = 32 (too small)
-        data[60..62].copy_from_slice(&1_u16.to_le_bytes()); // e_shnum = 1
+        let mut data = [0u8; ELF64_EHDR_SIZE];
+        data[0..4].copy_from_slice(&ELF_MAGIC);
+        data[EI_CLASS] = ELFCLASS64;
+        data[EI_DATA] = ELFDATA2LSB;
+        data[E_TYPE_OFFSET..E_TYPE_OFFSET + 2].copy_from_slice(&ET_REL.to_le_bytes());
+        data[E_MACHINE_OFFSET..E_MACHINE_OFFSET + 2].copy_from_slice(&EM_X86_64.to_le_bytes());
+        data[E_SHENTSIZE_OFFSET..E_SHENTSIZE_OFFSET + 2].copy_from_slice(&32_u16.to_le_bytes()); // e_shentsize = 32 (too small)
+        data[E_SHNUM_OFFSET..E_SHNUM_OFFSET + 2].copy_from_slice(&1_u16.to_le_bytes()); // e_shnum = 1
         assert!(matches!(
             ObjectFile::parse(&data),
             Err(ParseError::InvalidSection(_))
@@ -799,15 +813,16 @@ mod tests {
 
     #[test]
     fn test_invalid_shstrndx() {
-        let mut data = [0u8; 64];
-        data[0..4].copy_from_slice(b"\x7FELF");
-        data[4] = 2; // 64-bit
-        data[5] = 1; // Little endian
-        data[16..18].copy_from_slice(&1_u16.to_le_bytes()); // ET_REL
-        data[18..20].copy_from_slice(&0x3E_u16.to_le_bytes()); // EM_X86_64
-        data[58..60].copy_from_slice(&64_u16.to_le_bytes()); // e_shentsize = 64
-        data[60..62].copy_from_slice(&0_u16.to_le_bytes()); // e_shnum = 0
-        data[62..64].copy_from_slice(&5_u16.to_le_bytes()); // e_shstrndx = 5 (invalid)
+        let mut data = [0u8; ELF64_EHDR_SIZE];
+        data[0..4].copy_from_slice(&ELF_MAGIC);
+        data[EI_CLASS] = ELFCLASS64;
+        data[EI_DATA] = ELFDATA2LSB;
+        data[E_TYPE_OFFSET..E_TYPE_OFFSET + 2].copy_from_slice(&ET_REL.to_le_bytes());
+        data[E_MACHINE_OFFSET..E_MACHINE_OFFSET + 2].copy_from_slice(&EM_X86_64.to_le_bytes());
+        data[E_SHENTSIZE_OFFSET..E_SHENTSIZE_OFFSET + 2]
+            .copy_from_slice(&(TEST_SHDR_SIZE as u16).to_le_bytes()); // e_shentsize = 64
+        data[E_SHNUM_OFFSET..E_SHNUM_OFFSET + 2].copy_from_slice(&0_u16.to_le_bytes()); // e_shnum = 0
+        data[E_SHSTRNDX_OFFSET..E_SHSTRNDX_OFFSET + 2].copy_from_slice(&5_u16.to_le_bytes()); // e_shstrndx = 5 (invalid)
         assert!(matches!(
             ObjectFile::parse(&data),
             Err(ParseError::InvalidShstrndx)
@@ -817,21 +832,23 @@ mod tests {
     #[test]
     fn test_section_out_of_bounds() {
         // Create a minimal valid ELF header with one section that points out of bounds
-        let mut data = vec![0u8; 64 + 64]; // header + one section header
-        data[0..4].copy_from_slice(b"\x7FELF");
-        data[4] = 2; // 64-bit
-        data[5] = 1; // Little endian
-        data[16..18].copy_from_slice(&1_u16.to_le_bytes()); // ET_REL
-        data[18..20].copy_from_slice(&0x3E_u16.to_le_bytes()); // EM_X86_64
-        data[40..48].copy_from_slice(&64_u64.to_le_bytes()); // e_shoff = 64
-        data[58..60].copy_from_slice(&64_u16.to_le_bytes()); // e_shentsize = 64
-        data[60..62].copy_from_slice(&1_u16.to_le_bytes()); // e_shnum = 1
-        data[62..64].copy_from_slice(&0_u16.to_le_bytes()); // e_shstrndx = 0
+        let mut data = vec![0u8; ELF64_EHDR_SIZE + TEST_SHDR_SIZE]; // header + one section header
+        data[0..4].copy_from_slice(&ELF_MAGIC);
+        data[EI_CLASS] = ELFCLASS64;
+        data[EI_DATA] = ELFDATA2LSB;
+        data[E_TYPE_OFFSET..E_TYPE_OFFSET + 2].copy_from_slice(&ET_REL.to_le_bytes());
+        data[E_MACHINE_OFFSET..E_MACHINE_OFFSET + 2].copy_from_slice(&EM_X86_64.to_le_bytes());
+        data[E_SHOFF_OFFSET..E_SHOFF_OFFSET + 8]
+            .copy_from_slice(&(ELF64_EHDR_SIZE as u64).to_le_bytes()); // e_shoff = 64
+        data[E_SHENTSIZE_OFFSET..E_SHENTSIZE_OFFSET + 2]
+            .copy_from_slice(&(TEST_SHDR_SIZE as u16).to_le_bytes()); // e_shentsize = 64
+        data[E_SHNUM_OFFSET..E_SHNUM_OFFSET + 2].copy_from_slice(&1_u16.to_le_bytes()); // e_shnum = 1
+        data[E_SHSTRNDX_OFFSET..E_SHSTRNDX_OFFSET + 2].copy_from_slice(&0_u16.to_le_bytes()); // e_shstrndx = 0
 
         // Section header at offset 64
         // sh_type = SHT_STRTAB (3) to make it a string table
-        let sh_offset = 64;
-        data[sh_offset + 4..sh_offset + 8].copy_from_slice(&3_u32.to_le_bytes()); // sh_type = SHT_STRTAB
+        let sh_offset = ELF64_EHDR_SIZE;
+        data[sh_offset + 4..sh_offset + 8].copy_from_slice(&SHT_STRTAB.to_le_bytes()); // sh_type = SHT_STRTAB
         // sh_offset pointing way out of bounds
         data[sh_offset + 24..sh_offset + 32].copy_from_slice(&1000_u64.to_le_bytes());
         data[sh_offset + 32..sh_offset + 40].copy_from_slice(&100_u64.to_le_bytes()); // size
@@ -862,11 +879,26 @@ mod tests {
     #[test]
     fn test_relocation_type_from_elf_x86_64() {
         use ElfMachine::X86_64;
-        assert_eq!(RelocationType::from_elf(1, X86_64), RelocationType::Abs64);
-        assert_eq!(RelocationType::from_elf(2, X86_64), RelocationType::Pc32);
-        assert_eq!(RelocationType::from_elf(4, X86_64), RelocationType::Plt32);
-        assert_eq!(RelocationType::from_elf(10, X86_64), RelocationType::Abs32);
-        assert_eq!(RelocationType::from_elf(11, X86_64), RelocationType::Abs32S);
+        assert_eq!(
+            RelocationType::from_elf(R_X86_64_64, X86_64),
+            RelocationType::Abs64
+        );
+        assert_eq!(
+            RelocationType::from_elf(R_X86_64_PC32, X86_64),
+            RelocationType::Pc32
+        );
+        assert_eq!(
+            RelocationType::from_elf(R_X86_64_PLT32, X86_64),
+            RelocationType::Plt32
+        );
+        assert_eq!(
+            RelocationType::from_elf(R_X86_64_32, X86_64),
+            RelocationType::Abs32
+        );
+        assert_eq!(
+            RelocationType::from_elf(R_X86_64_32S, X86_64),
+            RelocationType::Abs32S
+        );
         assert_eq!(
             RelocationType::from_elf(99, X86_64),
             RelocationType::Unknown(99)
@@ -877,23 +909,23 @@ mod tests {
     fn test_relocation_type_from_elf_aarch64() {
         use ElfMachine::Aarch64;
         assert_eq!(
-            RelocationType::from_elf(257, Aarch64),
+            RelocationType::from_elf(R_AARCH64_ABS64, Aarch64),
             RelocationType::Aarch64Abs64
         );
         assert_eq!(
-            RelocationType::from_elf(275, Aarch64),
+            RelocationType::from_elf(R_AARCH64_ADR_PREL_PG_HI21, Aarch64),
             RelocationType::AdrpPage21
         );
         assert_eq!(
-            RelocationType::from_elf(277, Aarch64),
+            RelocationType::from_elf(R_AARCH64_ADD_ABS_LO12_NC, Aarch64),
             RelocationType::AddLo12
         );
         assert_eq!(
-            RelocationType::from_elf(282, Aarch64),
+            RelocationType::from_elf(R_AARCH64_JUMP26, Aarch64),
             RelocationType::Jump26
         );
         assert_eq!(
-            RelocationType::from_elf(283, Aarch64),
+            RelocationType::from_elf(R_AARCH64_CALL26, Aarch64),
             RelocationType::Call26
         );
         assert_eq!(
@@ -924,15 +956,16 @@ mod tests {
     #[test]
     fn test_empty_object_file() {
         // Create a minimal valid ELF with no sections
-        let mut data = vec![0u8; 64];
-        data[0..4].copy_from_slice(b"\x7FELF");
-        data[4] = 2; // 64-bit
-        data[5] = 1; // Little endian
-        data[16..18].copy_from_slice(&1_u16.to_le_bytes()); // ET_REL
-        data[18..20].copy_from_slice(&0x3E_u16.to_le_bytes()); // EM_X86_64
-        data[58..60].copy_from_slice(&64_u16.to_le_bytes()); // e_shentsize = 64
-        data[60..62].copy_from_slice(&0_u16.to_le_bytes()); // e_shnum = 0
-        data[62..64].copy_from_slice(&0_u16.to_le_bytes()); // e_shstrndx = 0
+        let mut data = vec![0u8; ELF64_EHDR_SIZE];
+        data[0..4].copy_from_slice(&ELF_MAGIC);
+        data[EI_CLASS] = ELFCLASS64;
+        data[EI_DATA] = ELFDATA2LSB;
+        data[E_TYPE_OFFSET..E_TYPE_OFFSET + 2].copy_from_slice(&ET_REL.to_le_bytes());
+        data[E_MACHINE_OFFSET..E_MACHINE_OFFSET + 2].copy_from_slice(&EM_X86_64.to_le_bytes());
+        data[E_SHENTSIZE_OFFSET..E_SHENTSIZE_OFFSET + 2]
+            .copy_from_slice(&(TEST_SHDR_SIZE as u16).to_le_bytes()); // e_shentsize = 64
+        data[E_SHNUM_OFFSET..E_SHNUM_OFFSET + 2].copy_from_slice(&0_u16.to_le_bytes()); // e_shnum = 0
+        data[E_SHSTRNDX_OFFSET..E_SHSTRNDX_OFFSET + 2].copy_from_slice(&0_u16.to_le_bytes()); // e_shstrndx = 0
 
         // This should fail because shstrndx=0 but there are no sections
         assert!(matches!(
@@ -958,12 +991,10 @@ mod tests {
         //   - .strtab strings
         //   - .symtab entries
 
-        const ELF_HDR_SIZE: usize = 64;
-        const SHENT_SIZE: usize = 64;
         const NUM_SECTIONS: usize = 4;
-        const SHDR_START: usize = ELF_HDR_SIZE;
-        const SHDR_SIZE: usize = SHENT_SIZE * NUM_SECTIONS;
-        const DATA_START: usize = SHDR_START + SHDR_SIZE;
+        const SHDR_START: usize = ELF64_EHDR_SIZE;
+        const SHDR_TOTAL_SIZE: usize = TEST_SHDR_SIZE * NUM_SECTIONS;
+        const DATA_START: usize = SHDR_START + SHDR_TOTAL_SIZE;
 
         // Section name string table: "\0.shstrtab\0.strtab\0.symtab\0"
         let shstrtab_data = b"\0.shstrtab\0.strtab\0.symtab\0";
@@ -977,12 +1008,11 @@ mod tests {
 
         // Symbol table: one symbol entry (24 bytes) with section index = 99 (way out of bounds)
         let symtab_offset = strtab_offset + strtab_size;
-        const SYM_ENTRY_SIZE: usize = 24;
-        let mut sym_entry = [0u8; SYM_ENTRY_SIZE];
+        let mut sym_entry = [0u8; ELF64_SYM_SIZE];
         // st_name = 1 (offset to "test_symbol" in strtab)
         sym_entry[0..4].copy_from_slice(&1_u32.to_le_bytes());
-        // st_info = 0x10 (STB_GLOBAL << 4 | STT_NOTYPE)
-        sym_entry[4] = 0x10;
+        // st_info = STB_GLOBAL << 4 | STT_NOTYPE
+        sym_entry[4] = crate::constants::elf_st_info(STB_GLOBAL, STT_NOTYPE);
         // st_other = 0
         sym_entry[5] = 0;
         // st_shndx = 99 (out of bounds - we only have 4 sections)
@@ -992,20 +1022,23 @@ mod tests {
         // st_size = 0
         sym_entry[16..24].copy_from_slice(&0_u64.to_le_bytes());
 
-        let total_size = symtab_offset + SYM_ENTRY_SIZE;
+        let total_size = symtab_offset + ELF64_SYM_SIZE;
         let mut data = vec![0u8; total_size];
 
         // ELF header
-        data[0..4].copy_from_slice(b"\x7FELF");
-        data[4] = 2; // 64-bit
-        data[5] = 1; // Little endian
-        data[6] = 1; // EV_CURRENT
-        data[16..18].copy_from_slice(&1_u16.to_le_bytes()); // ET_REL
-        data[18..20].copy_from_slice(&0x3E_u16.to_le_bytes()); // EM_X86_64
-        data[40..48].copy_from_slice(&(SHDR_START as u64).to_le_bytes()); // e_shoff
-        data[58..60].copy_from_slice(&(SHENT_SIZE as u16).to_le_bytes()); // e_shentsize
-        data[60..62].copy_from_slice(&(NUM_SECTIONS as u16).to_le_bytes()); // e_shnum
-        data[62..64].copy_from_slice(&1_u16.to_le_bytes()); // e_shstrndx = 1
+        data[0..4].copy_from_slice(&ELF_MAGIC);
+        data[EI_CLASS] = ELFCLASS64;
+        data[EI_DATA] = ELFDATA2LSB;
+        data[EI_VERSION] = crate::constants::EV_CURRENT;
+        data[E_TYPE_OFFSET..E_TYPE_OFFSET + 2].copy_from_slice(&ET_REL.to_le_bytes());
+        data[E_MACHINE_OFFSET..E_MACHINE_OFFSET + 2].copy_from_slice(&EM_X86_64.to_le_bytes());
+        data[E_SHOFF_OFFSET..E_SHOFF_OFFSET + 8]
+            .copy_from_slice(&(SHDR_START as u64).to_le_bytes()); // e_shoff
+        data[E_SHENTSIZE_OFFSET..E_SHENTSIZE_OFFSET + 2]
+            .copy_from_slice(&(TEST_SHDR_SIZE as u16).to_le_bytes()); // e_shentsize
+        data[E_SHNUM_OFFSET..E_SHNUM_OFFSET + 2]
+            .copy_from_slice(&(NUM_SECTIONS as u16).to_le_bytes()); // e_shnum
+        data[E_SHSTRNDX_OFFSET..E_SHSTRNDX_OFFSET + 2].copy_from_slice(&1_u16.to_le_bytes()); // e_shstrndx = 1
 
         // Section header helper
         fn write_shdr(
@@ -1018,7 +1051,7 @@ mod tests {
             sh_link: u32,
             sh_entsize: u64,
         ) {
-            let base = SHDR_START + index * SHENT_SIZE;
+            let base = SHDR_START + index * TEST_SHDR_SIZE;
             data[base..base + 4].copy_from_slice(&sh_name.to_le_bytes());
             data[base + 4..base + 8].copy_from_slice(&sh_type.to_le_bytes());
             data[base + 24..base + 32].copy_from_slice(&sh_offset.to_le_bytes());
@@ -1028,14 +1061,14 @@ mod tests {
         }
 
         // [0] NULL section
-        write_shdr(&mut data, 0, 0, 0, 0, 0, 0, 0);
+        write_shdr(&mut data, 0, 0, SHT_NULL, 0, 0, 0, 0);
 
         // [1] .shstrtab (name at offset 1 in shstrtab)
         write_shdr(
             &mut data,
             1,
             1, // ".shstrtab" starts at offset 1
-            3, // SHT_STRTAB
+            SHT_STRTAB,
             shstrtab_offset as u64,
             shstrtab_size as u64,
             0,
@@ -1047,7 +1080,7 @@ mod tests {
             &mut data,
             2,
             11, // ".strtab" starts at offset 11
-            3,  // SHT_STRTAB
+            SHT_STRTAB,
             strtab_offset as u64,
             strtab_size as u64,
             0,
@@ -1059,17 +1092,17 @@ mod tests {
             &mut data,
             3,
             19, // ".symtab" starts at offset 19
-            2,  // SHT_SYMTAB
+            SHT_SYMTAB,
             symtab_offset as u64,
-            SYM_ENTRY_SIZE as u64,
+            ELF64_SYM_SIZE as u64,
             2, // sh_link = strtab section
-            SYM_ENTRY_SIZE as u64,
+            ELF64_SYM_SIZE as u64,
         );
 
         // Write section data
         data[shstrtab_offset..shstrtab_offset + shstrtab_size].copy_from_slice(shstrtab_data);
         data[strtab_offset..strtab_offset + strtab_size].copy_from_slice(strtab_data);
-        data[symtab_offset..symtab_offset + SYM_ENTRY_SIZE].copy_from_slice(&sym_entry);
+        data[symtab_offset..symtab_offset + ELF64_SYM_SIZE].copy_from_slice(&sym_entry);
 
         // Parse should fail with InvalidSymbol due to section index out of bounds
         let result = ObjectFile::parse(&data);

--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -6,6 +6,20 @@ use std::collections::HashMap;
 
 use rue_target::Target;
 
+use crate::constants::{
+    ARM64_RELOC_BRANCH26, ARM64_RELOC_PAGE21, ARM64_RELOC_PAGEOFF12, CPU_SUBTYPE_ARM64_ALL,
+    CPU_TYPE_ARM64, ELF_MAGIC, ELF64_EHDR_SIZE, ELF64_SHDR_SIZE, ELF64_SYM_SIZE, ELFCLASS64,
+    ELFDATA2LSB, ET_REL, EV_CURRENT, LC_BUILD_VERSION, LC_SEGMENT_64, LC_SYMTAB,
+    MACHO64_BUILD_VERSION_CMD_SIZE, MACHO64_HEADER_SIZE, MACHO64_NLIST_SIZE, MACHO64_RELOC_SIZE,
+    MACHO64_SECTION_SIZE, MACHO64_SEGMENT_CMD_SIZE, MACHO64_SYMTAB_CMD_SIZE, MH_MAGIC_64,
+    MH_OBJECT, N_EXT, N_SECT, N_UNDF, PLATFORM_MACOS, R_AARCH64_ABS64, R_AARCH64_ADD_ABS_LO12_NC,
+    R_AARCH64_ADR_PREL_PG_HI21, R_AARCH64_CALL26, R_AARCH64_JUMP26, R_X86_64_32, R_X86_64_32S,
+    R_X86_64_64, R_X86_64_GOTPCREL, R_X86_64_GOTPCRELX, R_X86_64_PC32, R_X86_64_PLT32,
+    R_X86_64_REX_GOTPCRELX, S_ATTR_PURE_INSTRUCTIONS, S_ATTR_SOME_INSTRUCTIONS, SHF_ALLOC,
+    SHF_EXECINSTR, SHF_INFO_LINK, SHT_PROGBITS, SHT_RELA, SHT_STRTAB, SHT_SYMTAB, STB_GLOBAL,
+    STB_LOCAL, STT_FUNC, STT_NOTYPE, STT_SECTION, elf_st_info,
+};
+
 /// ELF section layout with explicit indices.
 ///
 /// The section header table layout is:
@@ -240,12 +254,12 @@ impl ObjectBuilder {
 
         let mut symtab = Vec::new();
 
-        // Symbol 0: null symbol (24 bytes)
-        symtab.extend_from_slice(&[0u8; 24]);
+        // Symbol 0: null symbol
+        symtab.extend_from_slice(&[0u8; ELF64_SYM_SIZE]);
 
         // Symbol 1: .text section symbol
         symtab.extend_from_slice(&0_u32.to_le_bytes()); // st_name (empty)
-        symtab.push(0x03); // st_info: STB_LOCAL, STT_SECTION
+        symtab.push(elf_st_info(STB_LOCAL, STT_SECTION)); // st_info
         symtab.push(0); // st_other
         symtab.extend_from_slice(&ElfSectionLayout::TEXT.to_le_bytes()); // st_shndx: .text section
         symtab.extend_from_slice(&0_u64.to_le_bytes()); // st_value
@@ -257,7 +271,7 @@ impl ObjectBuilder {
         // Symbol 2: .rodata section symbol (if has_rodata)
         if has_rodata {
             symtab.extend_from_slice(&0_u32.to_le_bytes()); // st_name (empty)
-            symtab.push(0x03); // st_info: STB_LOCAL, STT_SECTION
+            symtab.push(elf_st_info(STB_LOCAL, STT_SECTION)); // st_info
             symtab.push(0); // st_other
             symtab.extend_from_slice(&layout.rodata().to_le_bytes()); // st_shndx: .rodata section
             symtab.extend_from_slice(&0_u64.to_le_bytes()); // st_value
@@ -269,7 +283,7 @@ impl ObjectBuilder {
         let first_string_sym = next_sym_idx;
         for (i, offset) in string_offsets.iter().enumerate() {
             symtab.extend_from_slice(&(string_symbol_offsets[i] as u32).to_le_bytes()); // st_name
-            symtab.push(0x00); // st_info: STB_LOCAL, STT_NOTYPE
+            symtab.push(elf_st_info(STB_LOCAL, STT_NOTYPE)); // st_info
             symtab.push(0); // st_other
             symtab.extend_from_slice(&layout.rodata_or_null().to_le_bytes()); // st_shndx: .rodata
             symtab.extend_from_slice(&(*offset as u64).to_le_bytes()); // st_value: offset in .rodata
@@ -283,7 +297,7 @@ impl ObjectBuilder {
         // Function symbol (global)
         let func_sym_idx = next_sym_idx;
         symtab.extend_from_slice(&(strtab_name as u32).to_le_bytes()); // st_name
-        symtab.push(0x12); // st_info: STB_GLOBAL, STT_FUNC
+        symtab.push(elf_st_info(STB_GLOBAL, STT_FUNC)); // st_info
         symtab.push(0); // st_other
         symtab.extend_from_slice(&ElfSectionLayout::TEXT.to_le_bytes()); // st_shndx: .text
         symtab.extend_from_slice(&0_u64.to_le_bytes()); // st_value
@@ -295,9 +309,9 @@ impl ObjectBuilder {
         let first_extern_sym = next_sym_idx;
         for (i, _sym) in extern_symbols.iter().enumerate() {
             symtab.extend_from_slice(&(extern_symbol_offsets[i] as u32).to_le_bytes()); // st_name
-            symtab.push(0x10); // st_info: STB_GLOBAL, STT_NOTYPE
+            symtab.push(elf_st_info(STB_GLOBAL, STT_NOTYPE)); // st_info
             symtab.push(0); // st_other
-            symtab.extend_from_slice(&0_u16.to_le_bytes()); // st_shndx: SHN_UNDEF
+            symtab.extend_from_slice(&crate::constants::SHN_UNDEF.to_le_bytes()); // st_shndx: SHN_UNDEF
             symtab.extend_from_slice(&0_u64.to_le_bytes()); // st_value
             symtab.extend_from_slice(&0_u64.to_le_bytes()); // st_size
         }
@@ -321,19 +335,19 @@ impl ObjectBuilder {
             };
 
             let r_type: u32 = match reloc.rel_type {
-                RelocationType::Abs64 => 1,
-                RelocationType::Pc32 => 2,
-                RelocationType::Plt32 => 4,
-                RelocationType::GotPcRel => 9, // R_X86_64_GOTPCREL
-                RelocationType::Abs32 => 10,
-                RelocationType::Abs32S => 11,
-                RelocationType::GotPcRelX => 41, // R_X86_64_GOTPCRELX
-                RelocationType::RexGotPcRelX => 42, // R_X86_64_REX_GOTPCRELX
-                RelocationType::Jump26 => 282,   // R_AARCH64_JUMP26
-                RelocationType::Call26 => 283,   // R_AARCH64_CALL26
-                RelocationType::Aarch64Abs64 => 257, // R_AARCH64_ABS64
-                RelocationType::AdrpPage21 => 275, // R_AARCH64_ADR_PREL_PG_HI21
-                RelocationType::AddLo12 => 277,  // R_AARCH64_ADD_ABS_LO12_NC
+                RelocationType::Abs64 => R_X86_64_64,
+                RelocationType::Pc32 => R_X86_64_PC32,
+                RelocationType::Plt32 => R_X86_64_PLT32,
+                RelocationType::GotPcRel => R_X86_64_GOTPCREL,
+                RelocationType::Abs32 => R_X86_64_32,
+                RelocationType::Abs32S => R_X86_64_32S,
+                RelocationType::GotPcRelX => R_X86_64_GOTPCRELX,
+                RelocationType::RexGotPcRelX => R_X86_64_REX_GOTPCRELX,
+                RelocationType::Jump26 => R_AARCH64_JUMP26,
+                RelocationType::Call26 => R_AARCH64_CALL26,
+                RelocationType::Aarch64Abs64 => R_AARCH64_ABS64,
+                RelocationType::AdrpPage21 => R_AARCH64_ADR_PREL_PG_HI21,
+                RelocationType::AddLo12 => R_AARCH64_ADD_ABS_LO12_NC,
                 RelocationType::Unknown(t) => t,
             };
             let r_info = ((sym_idx as u64) << 32) | (r_type as u64);
@@ -344,11 +358,9 @@ impl ObjectBuilder {
         }
 
         // Calculate section layout (see ElfSectionLayout for section ordering)
-        const ELF_HEADER_SIZE: usize = 64;
-        const SECTION_HEADER_SIZE: usize = 64;
 
         // Sections start right after ELF header
-        let text_offset = ELF_HEADER_SIZE;
+        let text_offset = ELF64_EHDR_SIZE;
         let text_size = self.code.len();
 
         // .rodata follows .text (if present)
@@ -378,26 +390,24 @@ impl ObjectBuilder {
         let sh_offset = align_up(rela_offset + rela_size, 8);
 
         // === ELF Header ===
-        elf.extend_from_slice(&[
-            0x7F, b'E', b'L', b'F', // Magic
-            2,    // 64-bit
-            1,    // Little endian
-            1,    // ELF version
-            0,    // System V ABI
-            0, 0, 0, 0, 0, 0, 0, 0, // Padding
-        ]);
-        elf.extend_from_slice(&1_u16.to_le_bytes()); // e_type: ET_REL
+        elf.extend_from_slice(&ELF_MAGIC);
+        elf.push(ELFCLASS64);
+        elf.push(ELFDATA2LSB);
+        elf.push(EV_CURRENT);
+        elf.push(crate::constants::ELFOSABI_NONE);
+        elf.extend_from_slice(&[0u8; 8]); // Padding
+        elf.extend_from_slice(&ET_REL.to_le_bytes()); // e_type: ET_REL
         // Safety: build_elf() is only called for ELF targets (checked in build())
         elf.extend_from_slice(&self.target.elf_machine().unwrap().to_le_bytes()); // e_machine
-        elf.extend_from_slice(&1_u32.to_le_bytes()); // e_version
+        elf.extend_from_slice(&(EV_CURRENT as u32).to_le_bytes()); // e_version
         elf.extend_from_slice(&0_u64.to_le_bytes()); // e_entry (none for relocatable)
         elf.extend_from_slice(&0_u64.to_le_bytes()); // e_phoff (no program headers)
         elf.extend_from_slice(&(sh_offset as u64).to_le_bytes()); // e_shoff
         elf.extend_from_slice(&0_u32.to_le_bytes()); // e_flags
-        elf.extend_from_slice(&(ELF_HEADER_SIZE as u16).to_le_bytes()); // e_ehsize
+        elf.extend_from_slice(&(ELF64_EHDR_SIZE as u16).to_le_bytes()); // e_ehsize
         elf.extend_from_slice(&0_u16.to_le_bytes()); // e_phentsize
         elf.extend_from_slice(&0_u16.to_le_bytes()); // e_phnum
-        elf.extend_from_slice(&(SECTION_HEADER_SIZE as u16).to_le_bytes()); // e_shentsize
+        elf.extend_from_slice(&(ELF64_SHDR_SIZE as u16).to_le_bytes()); // e_shentsize
         elf.extend_from_slice(&layout.count().to_le_bytes()); // e_shnum
         elf.extend_from_slice(&layout.shstrtab().to_le_bytes()); // e_shstrndx
 
@@ -440,12 +450,12 @@ impl ObjectBuilder {
 
         // Section 0: null (ElfSectionLayout::NULL)
         let _ = ElfSectionLayout::NULL; // Assert this is section 0
-        elf.extend_from_slice(&[0u8; 64]);
+        elf.extend_from_slice(&[0u8; ELF64_SHDR_SIZE]);
 
         // Section 1: .text
         elf.extend_from_slice(&(shstrtab_text as u32).to_le_bytes()); // sh_name
-        elf.extend_from_slice(&1_u32.to_le_bytes()); // sh_type: SHT_PROGBITS
-        elf.extend_from_slice(&0x6_u64.to_le_bytes()); // sh_flags: SHF_ALLOC | SHF_EXECINSTR
+        elf.extend_from_slice(&SHT_PROGBITS.to_le_bytes()); // sh_type: SHT_PROGBITS
+        elf.extend_from_slice(&(SHF_ALLOC | SHF_EXECINSTR).to_le_bytes()); // sh_flags
         elf.extend_from_slice(&0_u64.to_le_bytes()); // sh_addr
         elf.extend_from_slice(&(text_offset as u64).to_le_bytes()); // sh_offset
         elf.extend_from_slice(&(text_size as u64).to_le_bytes()); // sh_size
@@ -457,8 +467,8 @@ impl ObjectBuilder {
         // Section 2: .rodata (if present)
         if has_rodata {
             elf.extend_from_slice(&(shstrtab_rodata as u32).to_le_bytes()); // sh_name
-            elf.extend_from_slice(&1_u32.to_le_bytes()); // sh_type: SHT_PROGBITS
-            elf.extend_from_slice(&0x2_u64.to_le_bytes()); // sh_flags: SHF_ALLOC
+            elf.extend_from_slice(&SHT_PROGBITS.to_le_bytes()); // sh_type: SHT_PROGBITS
+            elf.extend_from_slice(&SHF_ALLOC.to_le_bytes()); // sh_flags: SHF_ALLOC
             elf.extend_from_slice(&0_u64.to_le_bytes()); // sh_addr
             elf.extend_from_slice(&(rodata_offset as u64).to_le_bytes()); // sh_offset
             elf.extend_from_slice(&(rodata_size as u64).to_le_bytes()); // sh_size
@@ -470,7 +480,7 @@ impl ObjectBuilder {
 
         // Section: .symtab
         elf.extend_from_slice(&(shstrtab_symtab as u32).to_le_bytes()); // sh_name
-        elf.extend_from_slice(&2_u32.to_le_bytes()); // sh_type: SHT_SYMTAB
+        elf.extend_from_slice(&SHT_SYMTAB.to_le_bytes()); // sh_type: SHT_SYMTAB
         elf.extend_from_slice(&0_u64.to_le_bytes()); // sh_flags
         elf.extend_from_slice(&0_u64.to_le_bytes()); // sh_addr
         elf.extend_from_slice(&(symtab_offset as u64).to_le_bytes()); // sh_offset
@@ -478,11 +488,11 @@ impl ObjectBuilder {
         elf.extend_from_slice(&(layout.strtab() as u32).to_le_bytes()); // sh_link: .strtab
         elf.extend_from_slice(&(first_global_sym as u32).to_le_bytes()); // sh_info: first non-local symbol
         elf.extend_from_slice(&8_u64.to_le_bytes()); // sh_addralign
-        elf.extend_from_slice(&24_u64.to_le_bytes()); // sh_entsize
+        elf.extend_from_slice(&(ELF64_SYM_SIZE as u64).to_le_bytes()); // sh_entsize
 
         // Section: .strtab
         elf.extend_from_slice(&(shstrtab_strtab as u32).to_le_bytes()); // sh_name
-        elf.extend_from_slice(&3_u32.to_le_bytes()); // sh_type: SHT_STRTAB
+        elf.extend_from_slice(&SHT_STRTAB.to_le_bytes()); // sh_type: SHT_STRTAB
         elf.extend_from_slice(&0_u64.to_le_bytes()); // sh_flags
         elf.extend_from_slice(&0_u64.to_le_bytes()); // sh_addr
         elf.extend_from_slice(&(strtab_offset as u64).to_le_bytes()); // sh_offset
@@ -494,7 +504,7 @@ impl ObjectBuilder {
 
         // Section: .shstrtab
         elf.extend_from_slice(&(shstrtab_shstrtab as u32).to_le_bytes()); // sh_name
-        elf.extend_from_slice(&3_u32.to_le_bytes()); // sh_type: SHT_STRTAB
+        elf.extend_from_slice(&SHT_STRTAB.to_le_bytes()); // sh_type: SHT_STRTAB
         elf.extend_from_slice(&0_u64.to_le_bytes()); // sh_flags
         elf.extend_from_slice(&0_u64.to_le_bytes()); // sh_addr
         elf.extend_from_slice(&(shstrtab_offset as u64).to_le_bytes()); // sh_offset
@@ -506,8 +516,8 @@ impl ObjectBuilder {
 
         // Section: .rela.text
         elf.extend_from_slice(&(shstrtab_rela as u32).to_le_bytes()); // sh_name
-        elf.extend_from_slice(&4_u32.to_le_bytes()); // sh_type: SHT_RELA
-        elf.extend_from_slice(&0x40_u64.to_le_bytes()); // sh_flags: SHF_INFO_LINK
+        elf.extend_from_slice(&SHT_RELA.to_le_bytes()); // sh_type: SHT_RELA
+        elf.extend_from_slice(&SHF_INFO_LINK.to_le_bytes()); // sh_flags: SHF_INFO_LINK
         elf.extend_from_slice(&0_u64.to_le_bytes()); // sh_addr
         elf.extend_from_slice(&(rela_offset as u64).to_le_bytes()); // sh_offset
         elf.extend_from_slice(&(rela_size as u64).to_le_bytes()); // sh_size
@@ -532,41 +542,14 @@ impl ObjectBuilder {
     fn build_macho(self) -> Vec<u8> {
         let mut macho = Vec::new();
 
-        // Mach-O constants
-        const MH_MAGIC_64: u32 = 0xFEEDFACF;
-        const MH_OBJECT: u32 = 0x1;
-        const CPU_TYPE_ARM64: u32 = 0x0100000C; // CPU_TYPE_ARM | CPU_ARCH_ABI64
-        const CPU_SUBTYPE_ARM64_ALL: u32 = 0;
-        const LC_SEGMENT_64: u32 = 0x19;
-        const LC_SYMTAB: u32 = 0x2;
-        const LC_BUILD_VERSION: u32 = 0x32;
-        const S_ATTR_PURE_INSTRUCTIONS: u32 = 0x80000000;
-        const S_ATTR_SOME_INSTRUCTIONS: u32 = 0x00000400;
-
-        // Platform constants for LC_BUILD_VERSION
-        const PLATFORM_MACOS: u32 = 1;
-
-        // ARM64 relocation types
-        const ARM64_RELOC_BRANCH26: u32 = 2;
-        const ARM64_RELOC_PAGE21: u32 = 3;
-        const ARM64_RELOC_PAGEOFF12: u32 = 4;
-
-        // Calculate sizes and offsets
-        const HEADER_SIZE: usize = 32;
-        const SEGMENT_CMD_SIZE: usize = 72;
-        const SECTION_SIZE: usize = 80;
-        const SYMTAB_CMD_SIZE: usize = 24;
-        const BUILD_VERSION_CMD_SIZE: usize = 24; // Without tool entries
-        const NLIST_SIZE: usize = 16;
-        const RELOC_SIZE: usize = 8;
-
         // Determine number of sections (1 for __text, +1 if we have strings for __rodata)
         let has_rodata = !self.strings.is_empty();
         let num_sections = if has_rodata { 2 } else { 1 };
-        let segment_cmd_total = SEGMENT_CMD_SIZE + (SECTION_SIZE * num_sections);
+        let segment_cmd_total = MACHO64_SEGMENT_CMD_SIZE + (MACHO64_SECTION_SIZE * num_sections);
         // Three load commands: LC_SEGMENT_64, LC_BUILD_VERSION, LC_SYMTAB
-        let load_commands_size = segment_cmd_total + BUILD_VERSION_CMD_SIZE + SYMTAB_CMD_SIZE;
-        let header_and_commands = HEADER_SIZE + load_commands_size;
+        let load_commands_size =
+            segment_cmd_total + MACHO64_BUILD_VERSION_CMD_SIZE + MACHO64_SYMTAB_CMD_SIZE;
+        let header_and_commands = MACHO64_HEADER_SIZE + load_commands_size;
 
         // Build rodata content (string constants)
         let mut rodata = Vec::new();
@@ -647,7 +630,10 @@ impl ObjectBuilder {
         }
 
         // Symbol table follows text relocations
-        let symtab_offset = align_up(text_reloc_offset + (num_text_relocs * RELOC_SIZE), 4);
+        let symtab_offset = align_up(
+            text_reloc_offset + (num_text_relocs * MACHO64_RELOC_SIZE),
+            4,
+        );
 
         // In Mach-O, local symbols come first, then external symbols
         // Local symbols: string constants (non-external)
@@ -657,7 +643,7 @@ impl ObjectBuilder {
         let num_syms = num_local_syms + num_extern_syms;
 
         // String table follows symbol table
-        let strtab_offset = symtab_offset + (num_syms * NLIST_SIZE);
+        let strtab_offset = symtab_offset + (num_syms * MACHO64_NLIST_SIZE);
         let strtab_size = strtab.len();
 
         // === Mach-O Header ===
@@ -743,7 +729,7 @@ impl ObjectBuilder {
         // === LC_BUILD_VERSION ===
         // This tells the linker which macOS version this was built for
         macho.extend_from_slice(&LC_BUILD_VERSION.to_le_bytes()); // cmd
-        macho.extend_from_slice(&(BUILD_VERSION_CMD_SIZE as u32).to_le_bytes()); // cmdsize
+        macho.extend_from_slice(&(MACHO64_BUILD_VERSION_CMD_SIZE as u32).to_le_bytes()); // cmdsize
         macho.extend_from_slice(&PLATFORM_MACOS.to_le_bytes()); // platform
         // minos: macOS 11.0.0 (Big Sur) - encoded as major.minor.patch in nibbles
         // 11.0.0 = 0x000B0000
@@ -753,7 +739,7 @@ impl ObjectBuilder {
 
         // === LC_SYMTAB ===
         macho.extend_from_slice(&LC_SYMTAB.to_le_bytes()); // cmd
-        macho.extend_from_slice(&(SYMTAB_CMD_SIZE as u32).to_le_bytes()); // cmdsize
+        macho.extend_from_slice(&(MACHO64_SYMTAB_CMD_SIZE as u32).to_le_bytes()); // cmdsize
         macho.extend_from_slice(&(symtab_offset as u32).to_le_bytes()); // symoff
         macho.extend_from_slice(&(num_syms as u32).to_le_bytes()); // nsyms
         macho.extend_from_slice(&(strtab_offset as u32).to_le_bytes()); // stroff
@@ -845,11 +831,6 @@ impl ObjectBuilder {
         // n_sect: 1 byte (1-indexed section number)
         // n_desc: 2 bytes
         // n_value: 8 bytes
-
-        // Symbol constants
-        const N_EXT: u8 = 0x01; // External symbol
-        const N_SECT: u8 = 0x0E; // Defined in section
-        const N_UNDF: u8 = 0x00; // Undefined symbol
 
         // Mach-O requires local symbols first, then external symbols
 

--- a/crates/rue-linker/src/lib.rs
+++ b/crates/rue-linker/src/lib.rs
@@ -11,6 +11,7 @@
 //! It's intentionally minimal - just enough to link Rue code with its runtime.
 
 mod archive;
+pub mod constants;
 mod elf;
 mod emit;
 mod linker;

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -5,6 +5,10 @@ use std::collections::HashMap;
 use rue_target::Target;
 
 use crate::archive::Archive;
+use crate::constants::{
+    ELF_MAGIC, ELF64_EHDR_SIZE, ELF64_PHDR_SIZE, ELFCLASS64, ELFDATA2LSB, ET_EXEC, EV_CURRENT,
+    PF_R, PF_W, PF_X, PT_LOAD,
+};
 use crate::elf::{ObjectFile, RelocationType, Symbol, SymbolBinding};
 
 /// Linker errors.
@@ -281,10 +285,9 @@ impl Linker {
     #[must_use = "linking returns a Result that must be checked"]
     pub fn link(self, entry_point: &str) -> Result<Vec<u8>, LinkError> {
         // Layout constants - use a single program header for simplicity
-        const ELF_HEADER_SIZE: u64 = 64;
-        const PROGRAM_HEADER_SIZE: u64 = 56;
         const NUM_PROGRAM_HEADERS: u64 = 1;
-        const HEADER_SIZE: u64 = ELF_HEADER_SIZE + PROGRAM_HEADER_SIZE * NUM_PROGRAM_HEADERS;
+        const HEADER_SIZE: u64 =
+            (ELF64_EHDR_SIZE as u64) + (ELF64_PHDR_SIZE as u64) * NUM_PROGRAM_HEADERS;
 
         // Code starts right after headers. For ELF loading to work,
         // (vaddr % page_size) must equal (file_offset % page_size).
@@ -696,16 +699,14 @@ impl Linker {
 
         let mut elf = Vec::with_capacity((HEADER_SIZE as usize) + total_size);
 
-        // ===== ELF Header (64 bytes) =====
-        elf.extend_from_slice(&[
-            0x7F, b'E', b'L', b'F', // Magic
-            2,    // 64-bit
-            1,    // Little endian
-            1,    // ELF version
-            0,    // System V ABI
-            0, 0, 0, 0, 0, 0, 0, 0, // Padding
-        ]);
-        elf.extend_from_slice(&2_u16.to_le_bytes()); // e_type: ET_EXEC
+        // ===== ELF Header =====
+        elf.extend_from_slice(&ELF_MAGIC);
+        elf.push(ELFCLASS64);
+        elf.push(ELFDATA2LSB);
+        elf.push(EV_CURRENT);
+        elf.push(crate::constants::ELFOSABI_NONE);
+        elf.extend_from_slice(&[0u8; 8]); // Padding
+        elf.extend_from_slice(&ET_EXEC.to_le_bytes()); // e_type: ET_EXEC
         // The linker currently only produces ELF executables. For Mach-O targets,
         // we use the system linker via a separate code path.
         elf.extend_from_slice(
@@ -715,21 +716,21 @@ impl Linker {
                 .expect("linker only produces ELF executables")
                 .to_le_bytes(),
         ); // e_machine
-        elf.extend_from_slice(&1_u32.to_le_bytes()); // e_version
+        elf.extend_from_slice(&(EV_CURRENT as u32).to_le_bytes()); // e_version
         elf.extend_from_slice(&entry_addr.to_le_bytes()); // e_entry
-        elf.extend_from_slice(&ELF_HEADER_SIZE.to_le_bytes()); // e_phoff
+        elf.extend_from_slice(&(ELF64_EHDR_SIZE as u64).to_le_bytes()); // e_phoff
         elf.extend_from_slice(&0_u64.to_le_bytes()); // e_shoff (no sections)
         elf.extend_from_slice(&0_u32.to_le_bytes()); // e_flags
-        elf.extend_from_slice(&(ELF_HEADER_SIZE as u16).to_le_bytes()); // e_ehsize
-        elf.extend_from_slice(&(PROGRAM_HEADER_SIZE as u16).to_le_bytes()); // e_phentsize
+        elf.extend_from_slice(&(ELF64_EHDR_SIZE as u16).to_le_bytes()); // e_ehsize
+        elf.extend_from_slice(&(ELF64_PHDR_SIZE as u16).to_le_bytes()); // e_phentsize
         elf.extend_from_slice(&(NUM_PROGRAM_HEADERS as u16).to_le_bytes()); // e_phnum
         elf.extend_from_slice(&0_u16.to_le_bytes()); // e_shentsize
         elf.extend_from_slice(&0_u16.to_le_bytes()); // e_shnum
         elf.extend_from_slice(&0_u16.to_le_bytes()); // e_shstrndx
 
         // ===== Single Program Header (PT_LOAD, R+W+X) =====
-        elf.extend_from_slice(&1_u32.to_le_bytes()); // p_type: PT_LOAD
-        elf.extend_from_slice(&0x7_u32.to_le_bytes()); // p_flags: PF_R | PF_W | PF_X
+        elf.extend_from_slice(&PT_LOAD.to_le_bytes()); // p_type: PT_LOAD
+        elf.extend_from_slice(&(PF_R | PF_W | PF_X).to_le_bytes()); // p_flags: PF_R | PF_W | PF_X
         elf.extend_from_slice(&file_offset.to_le_bytes()); // p_offset
         elf.extend_from_slice(&code_vaddr.to_le_bytes()); // p_vaddr
         elf.extend_from_slice(&code_vaddr.to_le_bytes()); // p_paddr
@@ -761,6 +762,10 @@ fn align_up(value: u64, align: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::constants::{
+        E_MACHINE_OFFSET, E_TYPE_OFFSET, EI_CLASS, EI_DATA, EI_VERSION,
+        ELF64_EHDR_SIZE as TEST_EHDR_SIZE, ELF64_PHDR_SIZE as TEST_PHDR_SIZE, EM_X86_64,
+    };
     use crate::elf::ObjectFile;
     use crate::emit::{CodeRelocation, ObjectBuilder};
 
@@ -826,9 +831,9 @@ mod tests {
         let elf = linker.link("main").unwrap();
 
         // Check ELF magic
-        assert_eq!(&elf[0..4], b"\x7FELF");
+        assert_eq!(&elf[0..4], &ELF_MAGIC);
         // Check it's an executable
-        assert_eq!(elf[16], 2); // ET_EXEC
+        assert_eq!(elf[E_TYPE_OFFSET], ET_EXEC as u8);
     }
 
     #[test]
@@ -880,8 +885,8 @@ mod tests {
         let elf = linker.link("main").unwrap();
 
         // Check it's a valid executable
-        assert_eq!(&elf[0..4], b"\x7FELF");
-        assert_eq!(elf[16], 2); // ET_EXEC
+        assert_eq!(&elf[0..4], &ELF_MAGIC);
+        assert_eq!(elf[E_TYPE_OFFSET], ET_EXEC as u8);
     }
 
     #[test]
@@ -943,12 +948,15 @@ mod tests {
         let elf = linker.link("main").unwrap();
 
         // Check ELF header fields
-        assert_eq!(&elf[0..4], b"\x7FELF"); // Magic
-        assert_eq!(elf[4], 2); // 64-bit
-        assert_eq!(elf[5], 1); // Little endian
-        assert_eq!(elf[6], 1); // ELF version
-        assert_eq!(elf[16], 2); // ET_EXEC
-        assert_eq!(u16::from_le_bytes([elf[18], elf[19]]), 0x3E); // x86-64
+        assert_eq!(&elf[0..4], &ELF_MAGIC); // Magic
+        assert_eq!(elf[EI_CLASS], ELFCLASS64); // 64-bit
+        assert_eq!(elf[EI_DATA], ELFDATA2LSB); // Little endian
+        assert_eq!(elf[EI_VERSION], EV_CURRENT); // ELF version
+        assert_eq!(elf[E_TYPE_OFFSET], ET_EXEC as u8); // ET_EXEC
+        assert_eq!(
+            u16::from_le_bytes([elf[E_MACHINE_OFFSET], elf[E_MACHINE_OFFSET + 1]]),
+            EM_X86_64
+        ); // x86-64
 
         // Check entry point is set (bytes 24-31)
         let entry = u64::from_le_bytes(elf[24..32].try_into().unwrap());
@@ -971,16 +979,16 @@ mod tests {
 
         let elf = linker.link("main").unwrap();
 
-        // Program header starts at offset 64 (after ELF header)
-        let ph_offset = 64;
+        // Program header starts after ELF header
+        let ph_offset = TEST_EHDR_SIZE;
 
-        // p_type = PT_LOAD (1)
+        // p_type = PT_LOAD
         let p_type = u32::from_le_bytes(elf[ph_offset..ph_offset + 4].try_into().unwrap());
-        assert_eq!(p_type, 1);
+        assert_eq!(p_type, PT_LOAD);
 
-        // p_flags = PF_R | PF_W | PF_X (7)
+        // p_flags = PF_R | PF_W | PF_X
         let p_flags = u32::from_le_bytes(elf[ph_offset + 4..ph_offset + 8].try_into().unwrap());
-        assert_eq!(p_flags, 7);
+        assert_eq!(p_flags, PF_R | PF_W | PF_X);
     }
 
     #[test]
@@ -1060,16 +1068,20 @@ mod tests {
         let elf = linker.link("main").expect("link");
 
         // Verify the resulting ELF
-        assert_eq!(&elf[0..4], b"\x7FELF", "should have ELF magic");
-        assert_eq!(elf[16], 2, "should be ET_EXEC");
+        assert_eq!(&elf[0..4], &ELF_MAGIC, "should have ELF magic");
+        assert_eq!(elf[E_TYPE_OFFSET], ET_EXEC as u8, "should be ET_EXEC");
 
         // Verify entry point is reasonable
         let entry = u64::from_le_bytes(elf[24..32].try_into().unwrap());
         assert!(entry >= 0x400000, "entry should be at/above base addr");
         assert!(entry < 0x500000, "entry should be reasonable");
 
-        // Verify we have actual code after headers (offset 120 = 64 + 56)
-        assert!(elf.len() > 120, "should have content after headers");
+        // Verify we have actual code after headers
+        let header_and_phdr_size = TEST_EHDR_SIZE + TEST_PHDR_SIZE;
+        assert!(
+            elf.len() > header_and_phdr_size,
+            "should have content after headers"
+        );
     }
 
     /// Test that unknown relocation types are rejected
@@ -1312,8 +1324,8 @@ mod tests {
         let elf = linker.link("main").unwrap();
 
         // Verify basic ELF structure
-        assert_eq!(&elf[0..4], b"\x7FELF");
-        assert_eq!(elf[16], 2); // ET_EXEC
+        assert_eq!(&elf[0..4], &ELF_MAGIC);
+        assert_eq!(elf[E_TYPE_OFFSET], ET_EXEC as u8);
     }
 
     /// Test that R_X86_64_GOTPCRELX (type 41) relocations are handled correctly.
@@ -1353,8 +1365,8 @@ mod tests {
 
         let elf = linker.link("main").unwrap();
 
-        assert_eq!(&elf[0..4], b"\x7FELF");
-        assert_eq!(elf[16], 2); // ET_EXEC
+        assert_eq!(&elf[0..4], &ELF_MAGIC);
+        assert_eq!(elf[E_TYPE_OFFSET], ET_EXEC as u8);
     }
 
     /// Test that R_X86_64_REX_GOTPCRELX (type 42) relocations are handled correctly.
@@ -1394,8 +1406,8 @@ mod tests {
 
         let elf = linker.link("main").unwrap();
 
-        assert_eq!(&elf[0..4], b"\x7FELF");
-        assert_eq!(elf[16], 2); // ET_EXEC
+        assert_eq!(&elf[0..4], &ELF_MAGIC);
+        assert_eq!(elf[E_TYPE_OFFSET], ET_EXEC as u8);
     }
 
     /// Test GOT relocation with a call instruction.
@@ -1436,7 +1448,7 @@ mod tests {
         let elf = linker.link("main").unwrap();
 
         // Basic validation - if we got here without error, GOT relaxation worked
-        assert_eq!(&elf[0..4], b"\x7FELF");
+        assert_eq!(&elf[0..4], &ELF_MAGIC);
     }
 
     /// Test that all three GOT relocation types produce valid executables
@@ -1496,8 +1508,8 @@ mod tests {
 
         let elf = linker.link("main").unwrap();
 
-        assert_eq!(&elf[0..4], b"\x7FELF");
-        assert_eq!(elf[16], 2); // ET_EXEC
+        assert_eq!(&elf[0..4], &ELF_MAGIC);
+        assert_eq!(elf[E_TYPE_OFFSET], ET_EXEC as u8);
     }
 
     /// Test that GOT relocations with undefined symbols produce appropriate errors.
@@ -1576,8 +1588,8 @@ mod tests {
 
         let elf = linker.link("main").unwrap();
 
-        assert_eq!(&elf[0..4], b"\x7FELF");
-        assert_eq!(elf[16], 2); // ET_EXEC
+        assert_eq!(&elf[0..4], &ELF_MAGIC);
+        assert_eq!(elf[E_TYPE_OFFSET], ET_EXEC as u8);
 
         // Verify entry point is reasonable
         let entry = u64::from_le_bytes(elf[24..32].try_into().unwrap());
@@ -1630,7 +1642,7 @@ mod tests {
 
         let elf = linker.link("main").unwrap();
 
-        assert_eq!(&elf[0..4], b"\x7FELF");
-        assert_eq!(elf[16], 2); // ET_EXEC
+        assert_eq!(&elf[0..4], &ELF_MAGIC);
+        assert_eq!(elf[E_TYPE_OFFSET], ET_EXEC as u8);
     }
 }


### PR DESCRIPTION
Add a new constants.rs module containing named constants for:
- ELF header values (magic, sizes, offsets, class, data encoding)
- Section header types (SHT_NULL, SHT_PROGBITS, SHT_SYMTAB, etc.)
- Section flags (SHF_WRITE, SHF_ALLOC, SHF_EXECINSTR)
- Symbol binding and types (STB_LOCAL, STB_GLOBAL, STT_NOTYPE, etc.)
- Relocation types for x86-64 and AArch64
- Program header types and flags
- Mach-O constants for macOS ARM64

Update elf.rs, emit.rs, and linker.rs to use these named constants instead of magic numbers, improving code readability and maintainability.

Fixes: rue-cjag

🤖 Generated with [Claude Code](https://claude.com/claude-code)