### PR TITLE
rue CLI: add #[cfg(unix)] guard for Unix-specific imports

### DIFF
--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1,6 +1,8 @@
 use std::env;
 use std::fs;
+#[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
+#[cfg(unix)]
 use std::path::Path;
 
 use tracing::Level;
@@ -619,24 +621,27 @@ fn main() {
                 std::process::exit(1);
             }
 
-            // Make executable
-            let path = Path::new(&options.output_path);
-            match fs::metadata(path) {
-                Ok(metadata) => {
-                    let mut perms = metadata.permissions();
-                    perms.set_mode(0o755);
-                    if let Err(e) = fs::set_permissions(path, perms) {
+            // Make executable (Unix only)
+            #[cfg(unix)]
+            {
+                let path = Path::new(&options.output_path);
+                match fs::metadata(path) {
+                    Ok(metadata) => {
+                        let mut perms = metadata.permissions();
+                        perms.set_mode(0o755);
+                        if let Err(e) = fs::set_permissions(path, perms) {
+                            eprintln!(
+                                "Warning: could not set executable permissions on {}: {}",
+                                options.output_path, e
+                            );
+                        }
+                    }
+                    Err(e) => {
                         eprintln!(
-                            "Warning: could not set executable permissions on {}: {}",
+                            "Warning: could not read file metadata for {}: {}",
                             options.output_path, e
                         );
                     }
-                }
-                Err(e) => {
-                    eprintln!(
-                        "Warning: could not read file metadata for {}: {}",
-                        options.output_path, e
-                    );
                 }
             }
 


### PR DESCRIPTION
Add conditional compilation guards for Unix-specific code in the rue CLI:
- Guard the std::os::unix::fs::PermissionsExt import with #[cfg(unix)]
- Guard the std::path::Path import with #[cfg(unix)] (only used in Unix block)
- Wrap the executable permission-setting code block with #[cfg(unix)]

This allows the code to compile on non-Unix platforms (e.g., Windows) where PermissionsExt and set_mode() are not available.

Closes: rue-erlu

🤖 Generated with [Claude Code](https://claude.com/claude-code)