### PR TITLE
rue-codegen: define BLOCK_LABEL_BASE constant for label ID partitioning

### DIFF
--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -18,8 +18,10 @@
 //!
 //! To prevent collisions, we partition the `u32` label ID space:
 //!
-//! - **Inline labels**: IDs `0` to `u32::MAX / 2 - 1` (allocated via [`Aarch64Mir::alloc_label`])
-//! - **Block labels**: IDs `u32::MAX / 2` to `u32::MAX` (computed via [`Aarch64Mir::block_label`])
+//! - **Inline labels**: IDs `0` to `BLOCK_LABEL_BASE - 1` (allocated via [`Aarch64Mir::alloc_label`])
+//! - **Block labels**: IDs `BLOCK_LABEL_BASE` to `u32::MAX` (computed via [`Aarch64Mir::block_label`])
+//!
+//! See [`crate::vreg::BLOCK_LABEL_BASE`] for the constant definition.
 //!
 //! This gives each namespace ~2 billion IDs, which is more than sufficient for
 //! any realistic function. The separation is handled automatically by the
@@ -27,7 +29,7 @@
 
 use std::fmt;
 
-pub use crate::vreg::{LabelId, VReg};
+pub use crate::vreg::{BLOCK_LABEL_BASE, LabelId, VReg};
 
 /// A physical AArch64 register.
 ///
@@ -975,13 +977,13 @@ impl Aarch64Mir {
     /// Get the label for a CFG basic block.
     ///
     /// Block labels use IDs in the upper half of the `u32` space (starting at
-    /// `u32::MAX / 2`) to avoid collisions with inline labels allocated by
+    /// [`BLOCK_LABEL_BASE`]) to avoid collisions with inline labels allocated by
     /// [`Self::alloc_label`]. The mapping is deterministic: `block_id` maps to
-    /// `u32::MAX / 2 + block_id`.
+    /// `BLOCK_LABEL_BASE + block_id`.
     ///
     /// See the module documentation for details on label namespace separation.
     pub fn block_label(block_id: u32) -> LabelId {
-        LabelId::new(u32::MAX / 2 + block_id)
+        LabelId::new(BLOCK_LABEL_BASE + block_id)
     }
 
     /// Get the number of virtual registers allocated.

--- a/crates/rue-codegen/src/vreg.rs
+++ b/crates/rue-codegen/src/vreg.rs
@@ -6,6 +6,18 @@
 
 use std::fmt;
 
+/// Base ID for block labels in the partitioned label ID space.
+///
+/// During codegen, we need labels for two purposes:
+/// - **Inline labels** (IDs `0` to `BLOCK_LABEL_BASE - 1`): Generated during
+///   instruction lowering for overflow checks, bounds checks, etc.
+/// - **Block labels** (IDs `BLOCK_LABEL_BASE` to `u32::MAX`): Each CFG basic
+///   block gets a label computed as `BLOCK_LABEL_BASE + block_id`.
+///
+/// This partitioning gives each namespace ~2 billion IDs, which is more than
+/// sufficient for any realistic function.
+pub const BLOCK_LABEL_BASE: u32 = u32::MAX / 2;
+
 use crate::index_map::Handle;
 
 /// A virtual register.

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -16,8 +16,10 @@
 //!
 //! To prevent collisions, we partition the `u32` label ID space:
 //!
-//! - **Inline labels**: IDs `0` to `u32::MAX / 2 - 1` (allocated via [`CfgLower::new_label`])
-//! - **Block labels**: IDs `u32::MAX / 2` to `u32::MAX` (computed via [`CfgLower::block_label`])
+//! - **Inline labels**: IDs `0` to `BLOCK_LABEL_BASE - 1` (allocated via [`CfgLower::new_label`])
+//! - **Block labels**: IDs `BLOCK_LABEL_BASE` to `u32::MAX` (computed via [`CfgLower::block_label`])
+//!
+//! See [`crate::vreg::BLOCK_LABEL_BASE`] for the constant definition.
 //!
 //! This gives each namespace ~2 billion IDs, which is more than sufficient for
 //! any realistic function. The separation is handled automatically by the
@@ -33,6 +35,7 @@ use rue_cfg::{
 use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
 use crate::cfg_lower::{FieldChainBase, IndexChainBase, IndexLevel};
 use crate::types;
+use crate::vreg::BLOCK_LABEL_BASE;
 
 /// Argument passing registers per System V AMD64 ABI.
 const ARG_REGS: [Reg; 6] = [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9];
@@ -324,13 +327,13 @@ impl<'a> CfgLower<'a> {
     /// Get the label for a CFG basic block.
     ///
     /// Block labels use IDs in the upper half of the `u32` space (starting at
-    /// `u32::MAX / 2`) to avoid collisions with inline labels allocated by
+    /// [`BLOCK_LABEL_BASE`]) to avoid collisions with inline labels allocated by
     /// [`Self::new_label`]. The mapping is deterministic: `block_id` maps to
-    /// `u32::MAX / 2 + block_id`.
+    /// `BLOCK_LABEL_BASE + block_id`.
     ///
     /// See the module documentation for details on label namespace separation.
     fn block_label(&self, block_id: BlockId) -> LabelId {
-        LabelId::new(u32::MAX / 2 + block_id.as_u32())
+        LabelId::new(BLOCK_LABEL_BASE + block_id.as_u32())
     }
 
     /// Get or compute field vregs for a struct value.


### PR DESCRIPTION
Extract the magic number u32::MAX / 2 into a named constant BLOCK_LABEL_BASE in vreg.rs. Update both x86_64 and aarch64 backends to use the shared constant instead of duplicating the magic number.

Fixes rue-83q3

🤖 Generated with [Claude Code](https://claude.com/claude-code)