### PR TITLE
Add logging guidelines to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -534,6 +534,118 @@ Co-Authored-By: Claude <noreply@anthropic.com>"
 - Standard Rust formatting (rustfmt)
 - Rust edition 2024
 
+## Logging Guidelines
+
+Rue uses the `tracing` crate for structured logging, following the **"wide events"** philosophy from [loggingsucks.com](https://loggingsucks.com/). This means:
+
+1. **Canonical log lines** - One rich, structured log per operation containing all debugging context
+2. **Structured format** - Key-value pairs instead of plain strings for queryability
+3. **High-cardinality data** - Include contextual data like function names, counts, sizes
+
+### Using the Logging
+
+```bash
+# Normal compilation (no logging by default)
+rue source.rue output
+
+# Show timing per pass
+rue --time-passes source.rue output
+
+# Enable debug logging
+rue --log-level=debug source.rue output
+RUST_LOG=debug rue source.rue output
+
+# JSON format for tooling integration
+rue --log-format=json --log-level=debug source.rue output
+
+# Filter to specific module
+RUST_LOG=rue_compiler::sema=trace rue source.rue output
+```
+
+### Adding Instrumentation
+
+Each compilation pass should have a tracing span wrapping the work:
+
+```rust
+use tracing::{info_span, info};
+
+pub fn my_pass(input: &Input) -> Result<Output> {
+    // Create a span for the pass - includes timing automatically
+    let _span = info_span!("my_pass").entered();
+
+    // Do the work...
+    let result = process(input)?;
+
+    // Log completion with useful metrics
+    info!(
+        item_count = result.items.len(),
+        "pass complete"
+    );
+
+    Ok(result)
+}
+```
+
+### Logging Levels
+
+| Level | Use for | Example |
+|-------|---------|---------|
+| `error` | Compilation failures, internal compiler errors | ICE, unrecoverable errors |
+| `warn` | Suspicious patterns (surfaced via diagnostics) | Deprecated feature usage |
+| `info` | Per-pass completion with summary metrics | "lexing complete", token counts |
+| `debug` | Decision points, intermediate state | "resolving symbol X to Y" |
+| `trace` | Detailed internal state, individual instructions | Instruction-by-instruction output |
+
+### Good vs Bad Examples
+
+**Good: Wide event with context**
+```rust
+let _span = info_span!(
+    "codegen",
+    arch = "x86_64",
+    function_count = functions.len()
+).entered();
+
+// ... do code generation ...
+
+info!(
+    code_bytes = total_bytes,
+    "code generation complete"
+);
+```
+
+**Bad: Scattered debug statements**
+```rust
+println!("Starting codegen...");
+for func in functions {
+    println!("Generating function: {:?}", func.name);
+    // ...
+}
+println!("Done!");
+```
+
+**Good: Structured key-value data**
+```rust
+info!(
+    token_count = tokens.len(),
+    source_bytes = source.len(),
+    "lexing complete"
+);
+```
+
+**Bad: String interpolation**
+```rust
+println!("Lexed {} tokens from {} bytes", tokens.len(), source.len());
+```
+
+### Key Principles
+
+1. **Spans for timing**: Wrap passes in `info_span!()` - this enables `--time-passes`
+2. **Events for outcomes**: Use `info!()` after completing work with metrics
+3. **Context in spans**: Include high-level context (file, function count) in span fields
+4. **Metrics in events**: Include computed metrics (instruction counts, sizes) in events
+5. **Zero-cost when off**: Tracing has no overhead when no subscriber is active
+
 ## Issue Tracking with bd (beads)
 
 **IMPORTANT**: This project uses **bd (beads)** for ALL issue tracking. Do NOT use markdown TODOs, task lists, or other tracking methods.

--- a/docs/designs/0018-tracing-infrastructure.md
+++ b/docs/designs/0018-tracing-infrastructure.md
@@ -1,12 +1,12 @@
 ---
 id: 0018
 title: Tracing Infrastructure
-status: proposal
+status: implemented
 tags: [infrastructure, tooling]
 feature-flag: n/a
 created: 2025-12-27
-accepted:
-implemented:
+accepted: 2025-12-27
+implemented: 2025-12-27
 spec-sections: []
 superseded-by:
 ---
@@ -15,7 +15,7 @@ superseded-by:
 
 ## Status
 
-Proposal
+Implemented
 
 ## Summary
 
@@ -135,7 +135,7 @@ pub fn compile_frontend_with_options(...) -> CompileResult<...> {
   - Add spans to backend functions
   - Include context: file size, token/instruction counts
 
-- [ ] **Phase 5: Documentation** - rue-irz1.5
+- [x] **Phase 5: Documentation** - rue-irz1.5
   - Add logging guidelines to CLAUDE.md
   - Document the "wide events" philosophy
   - Provide good/bad examples


### PR DESCRIPTION
Document the 'wide events' philosophy for structured logging using the tracing crate. Includes:
- CLI usage examples for --time-passes, --log-level, --log-format
- Code examples for adding spans and events to compiler passes
- Logging level guidelines table
- Good vs bad examples comparing structured logging to println!
- Key principles for effective instrumentation

Also updates ADR-0018 to Implemented status with all phases complete.

Fixes rue-irz1.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)