### PR TITLE
Implement drop glue synthesis for user structs

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2356,28 +2356,69 @@ impl<'a> CfgLower<'a> {
                 // Handle String specially - it's a fat pointer (ptr, len, cap)
                 if dropped_ty == Type::String {
                     // String requires all 3 slots as arguments to __rue_drop_String
-                    if let Some(field_vregs) = self.struct_slot_vregs.get(dropped_value).cloned() {
-                        debug_assert_eq!(
-                            field_vregs.len(),
-                            3,
-                            "String should have 3 slots (ptr, len, cap)"
-                        );
-                        // Move all 3 components into argument registers
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Physical(ARG_REGS[0]),
-                            src: Operand::Virtual(field_vregs[0]), // ptr
-                        });
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Physical(ARG_REGS[1]),
-                            src: Operand::Virtual(field_vregs[1]), // len
-                        });
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Physical(ARG_REGS[2]),
-                            src: Operand::Virtual(field_vregs[2]), // cap
-                        });
-                    } else {
-                        unreachable!("String value should have field vregs for fat pointer");
-                    }
+                    // First, try to get the vregs from cache
+                    let field_vregs =
+                        if let Some(vregs) = self.struct_slot_vregs.get(dropped_value).cloned() {
+                            vregs
+                        } else {
+                            // Not in cache - check if it's a Param instruction
+                            let dropped_inst = &self.cfg.get_inst(*dropped_value).data;
+                            if let CfgInstData::Param { index } = dropped_inst {
+                                // Load all 3 String fields from param slots
+                                let mut vregs = Vec::with_capacity(3);
+                                for field_idx in 0..3u32 {
+                                    let field_vreg = self.mir.alloc_vreg();
+                                    let param_slot = self.num_locals + index + field_idx;
+                                    let offset = self.local_offset(param_slot);
+                                    self.mir.push(Aarch64Inst::Ldr {
+                                        dst: Operand::Virtual(field_vreg),
+                                        base: Reg::Fp,
+                                        offset,
+                                    });
+                                    vregs.push(field_vreg);
+                                }
+                                vregs
+                            } else if let CfgInstData::Load { slot } = dropped_inst {
+                                // Load from local variable slots
+                                let mut vregs = Vec::with_capacity(3);
+                                for field_idx in 0..3u32 {
+                                    let field_vreg = self.mir.alloc_vreg();
+                                    let field_slot = slot + field_idx;
+                                    let offset = self.local_offset(field_slot);
+                                    self.mir.push(Aarch64Inst::Ldr {
+                                        dst: Operand::Virtual(field_vreg),
+                                        base: Reg::Fp,
+                                        offset,
+                                    });
+                                    vregs.push(field_vreg);
+                                }
+                                vregs
+                            } else {
+                                unreachable!(
+                                    "String value should have field vregs or be a Param/Load: {:?}",
+                                    dropped_inst
+                                );
+                            }
+                        };
+
+                    debug_assert_eq!(
+                        field_vregs.len(),
+                        3,
+                        "String should have 3 slots (ptr, len, cap)"
+                    );
+                    // Move all 3 components into argument registers
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Physical(ARG_REGS[0]),
+                        src: Operand::Virtual(field_vregs[0]), // ptr
+                    });
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Physical(ARG_REGS[1]),
+                        src: Operand::Virtual(field_vregs[1]), // len
+                    });
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Physical(ARG_REGS[2]),
+                        src: Operand::Virtual(field_vregs[2]), // cap
+                    });
 
                     self.mir.push(Aarch64Inst::Bl {
                         symbol: "__rue_drop_String".to_string(),
@@ -2385,54 +2426,58 @@ impl<'a> CfgLower<'a> {
                     return;
                 }
 
-                // Load the value to drop into the first argument register (X0)
-                let val_vreg = self.get_vreg(*dropped_value);
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Physical(ARG_REGS[0]),
-                    src: Operand::Virtual(val_vreg),
-                });
-
-                // For structs, check if there's a user-defined destructor to call first
+                // Handle struct drops - need to pass all flattened field values
                 if let Type::Struct(struct_id) = dropped_ty {
                     let struct_def = &self.struct_defs[struct_id.0 as usize];
+
+                    // Collect all scalar vregs for this struct (flattened)
+                    let field_vregs = self.collect_struct_scalar_vregs(*dropped_value);
+
+                    // For now, we only support structs that fit in registers
+                    // This covers the common case. Stack spilling can be added later.
+                    debug_assert!(
+                        field_vregs.len() <= ARG_REGS.len(),
+                        "struct drop with {} fields exceeds {} argument registers",
+                        field_vregs.len(),
+                        ARG_REGS.len()
+                    );
+
+                    // For user-defined destructor, we need to call it first with all fields
                     if let Some(ref destructor_name) = struct_def.destructor {
-                        // Call user-defined destructor first
+                        // Pass all fields to the user destructor
+                        for (i, vreg) in field_vregs.iter().enumerate() {
+                            self.mir.push(Aarch64Inst::MovRR {
+                                dst: Operand::Physical(ARG_REGS[i]),
+                                src: Operand::Virtual(*vreg),
+                            });
+                        }
                         self.mir.push(Aarch64Inst::Bl {
                             symbol: destructor_name.clone(),
                         });
-                        // Reload self into X0 since the call may have clobbered it
+                    }
+
+                    // Now call the drop glue function to drop fields
+                    // Pass all fields again (call may have clobbered registers)
+                    for (i, vreg) in field_vregs.iter().enumerate() {
                         self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Physical(ARG_REGS[0]),
-                            src: Operand::Virtual(val_vreg),
+                            dst: Operand::Physical(ARG_REGS[i]),
+                            src: Operand::Virtual(*vreg),
                         });
                     }
+
+                    let drop_fn_name = format!("__rue_drop_{}", struct_def.name);
+                    self.mir.push(Aarch64Inst::Bl {
+                        symbol: drop_fn_name,
+                    });
+                    return;
                 }
 
-                // Get the destructor function name based on type.
-                // The naming convention is __rue_drop_<TypeName>.
-                let drop_fn_name = match dropped_ty {
-                    Type::Struct(struct_id) => {
-                        // For structs, use the struct name
-                        let struct_def = &self.struct_defs[struct_id.0 as usize];
-                        format!("__rue_drop_{}", struct_def.name)
-                    }
-                    Type::String => unreachable!("String should be handled above"),
-                    // Other types that might need drop in the future can be added here
-                    _ => {
-                        // For now, any other type reaching here is unexpected
-                        debug_assert!(
-                            false,
-                            "Drop instruction reached codegen for unexpected type: {:?}",
-                            dropped_ty
-                        );
-                        return;
-                    }
-                };
-
-                // Call the runtime drop function (handles field drops)
-                self.mir.push(Aarch64Inst::Bl {
-                    symbol: drop_fn_name,
-                });
+                // For other types that might need drop in the future
+                debug_assert!(
+                    false,
+                    "Drop instruction reached codegen for unexpected type: {:?}",
+                    dropped_ty
+                );
             }
 
             CfgInstData::StorageLive { slot: _ } => {

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -121,6 +121,21 @@ pub fn collect_array_scalar_vregs(
                         *elem,
                         get_vreg,
                     ));
+                } else if matches!(elem_inst.ty, Type::Struct(_)) {
+                    // Recursively collect from struct element
+                    result.extend(collect_struct_scalar_vregs(
+                        cfg,
+                        struct_slot_vregs,
+                        *elem,
+                        get_vreg,
+                    ));
+                } else if elem_inst.ty == Type::String {
+                    // String element - has 3 slots (ptr, len, cap)
+                    if let Some(vregs) = struct_slot_vregs.get(elem).cloned() {
+                        result.extend(vregs);
+                    } else {
+                        result.push(get_vreg(*elem));
+                    }
                 } else {
                     // Scalar element - get its vreg
                     result.push(get_vreg(*elem));
@@ -178,6 +193,15 @@ pub fn collect_struct_scalar_vregs(
                         *field,
                         get_vreg,
                     ));
+                } else if field_inst.ty == Type::String {
+                    // String field - has 3 slots (ptr, len, cap)
+                    // Look up the field's slot vregs from the cache
+                    if let Some(vregs) = struct_slot_vregs.get(field).cloned() {
+                        result.extend(vregs);
+                    } else {
+                        // Fallback: just get the main vreg (should not happen for properly lowered String)
+                        result.push(get_vreg(*field));
+                    }
                 } else {
                     // Scalar field - get its vreg
                     result.push(get_vreg(*field));

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2520,28 +2520,69 @@ impl<'a> CfgLower<'a> {
                 // Handle String specially - it's a fat pointer (ptr, len, cap)
                 if dropped_ty == Type::String {
                     // String requires all 3 slots as arguments to __rue_drop_String
-                    if let Some(field_vregs) = self.struct_slot_vregs.get(dropped_value).cloned() {
-                        debug_assert_eq!(
-                            field_vregs.len(),
-                            3,
-                            "String should have 3 slots (ptr, len, cap)"
-                        );
-                        // Move all 3 components into argument registers (rdi, rsi, rdx)
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Physical(ARG_REGS[0]),
-                            src: Operand::Virtual(field_vregs[0]), // ptr
-                        });
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Physical(ARG_REGS[1]),
-                            src: Operand::Virtual(field_vregs[1]), // len
-                        });
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Physical(ARG_REGS[2]),
-                            src: Operand::Virtual(field_vregs[2]), // cap
-                        });
-                    } else {
-                        unreachable!("String value should have field vregs for fat pointer");
-                    }
+                    // First, try to get the vregs from cache
+                    let field_vregs =
+                        if let Some(vregs) = self.struct_slot_vregs.get(dropped_value).cloned() {
+                            vregs
+                        } else {
+                            // Not in cache - check if it's a Param instruction
+                            let dropped_inst = &self.cfg.get_inst(*dropped_value).data;
+                            if let CfgInstData::Param { index } = dropped_inst {
+                                // Load all 3 String fields from param slots
+                                let mut vregs = Vec::with_capacity(3);
+                                for field_idx in 0..3u32 {
+                                    let field_vreg = self.mir.alloc_vreg();
+                                    let param_slot = self.num_locals + index + field_idx;
+                                    let offset = self.local_offset(param_slot);
+                                    self.mir.push(X86Inst::MovRM {
+                                        dst: Operand::Virtual(field_vreg),
+                                        base: Reg::Rbp,
+                                        offset,
+                                    });
+                                    vregs.push(field_vreg);
+                                }
+                                vregs
+                            } else if let CfgInstData::Load { slot } = dropped_inst {
+                                // Load from local variable slots
+                                let mut vregs = Vec::with_capacity(3);
+                                for field_idx in 0..3u32 {
+                                    let field_vreg = self.mir.alloc_vreg();
+                                    let field_slot = slot + field_idx;
+                                    let offset = self.local_offset(field_slot);
+                                    self.mir.push(X86Inst::MovRM {
+                                        dst: Operand::Virtual(field_vreg),
+                                        base: Reg::Rbp,
+                                        offset,
+                                    });
+                                    vregs.push(field_vreg);
+                                }
+                                vregs
+                            } else {
+                                unreachable!(
+                                    "String value should have field vregs or be a Param/Load: {:?}",
+                                    dropped_inst
+                                );
+                            }
+                        };
+
+                    debug_assert_eq!(
+                        field_vregs.len(),
+                        3,
+                        "String should have 3 slots (ptr, len, cap)"
+                    );
+                    // Move all 3 components into argument registers (rdi, rsi, rdx)
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(ARG_REGS[0]),
+                        src: Operand::Virtual(field_vregs[0]), // ptr
+                    });
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(ARG_REGS[1]),
+                        src: Operand::Virtual(field_vregs[1]), // len
+                    });
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(ARG_REGS[2]),
+                        src: Operand::Virtual(field_vregs[2]), // cap
+                    });
 
                     self.mir.push(X86Inst::CallRel {
                         symbol: "__rue_drop_String".to_string(),
@@ -2549,54 +2590,58 @@ impl<'a> CfgLower<'a> {
                     return;
                 }
 
-                // Load the value to drop into the first argument register (RDI)
-                let val_vreg = self.get_vreg(*dropped_value);
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Physical(ARG_REGS[0]),
-                    src: Operand::Virtual(val_vreg),
-                });
-
-                // For structs, check if there's a user-defined destructor to call first
+                // Handle struct drops - need to pass all flattened field values
                 if let Type::Struct(struct_id) = dropped_ty {
                     let struct_def = &self.struct_defs[struct_id.0 as usize];
+
+                    // Collect all scalar vregs for this struct (flattened)
+                    let field_vregs = self.collect_struct_scalar_vregs(*dropped_value);
+
+                    // For now, we only support structs that fit in registers
+                    // This covers the common case. Stack spilling can be added later.
+                    debug_assert!(
+                        field_vregs.len() <= ARG_REGS.len(),
+                        "struct drop with {} fields exceeds {} argument registers",
+                        field_vregs.len(),
+                        ARG_REGS.len()
+                    );
+
+                    // For user-defined destructor, we need to call it first with all fields
                     if let Some(ref destructor_name) = struct_def.destructor {
-                        // Call user-defined destructor first
+                        // Pass all fields to the user destructor
+                        for (i, vreg) in field_vregs.iter().enumerate() {
+                            self.mir.push(X86Inst::MovRR {
+                                dst: Operand::Physical(ARG_REGS[i]),
+                                src: Operand::Virtual(*vreg),
+                            });
+                        }
                         self.mir.push(X86Inst::CallRel {
                             symbol: destructor_name.clone(),
                         });
-                        // Reload self into RDI since the call may have clobbered it
+                    }
+
+                    // Now call the drop glue function to drop fields
+                    // Pass all fields again (call may have clobbered registers)
+                    for (i, vreg) in field_vregs.iter().enumerate() {
                         self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Physical(ARG_REGS[0]),
-                            src: Operand::Virtual(val_vreg),
+                            dst: Operand::Physical(ARG_REGS[i]),
+                            src: Operand::Virtual(*vreg),
                         });
                     }
+
+                    let drop_fn_name = format!("__rue_drop_{}", struct_def.name);
+                    self.mir.push(X86Inst::CallRel {
+                        symbol: drop_fn_name,
+                    });
+                    return;
                 }
 
-                // Get the destructor function name based on type.
-                // The naming convention is __rue_drop_<TypeName>.
-                let drop_fn_name = match dropped_ty {
-                    Type::Struct(struct_id) => {
-                        // For structs, use the struct name
-                        let struct_def = &self.struct_defs[struct_id.0 as usize];
-                        format!("__rue_drop_{}", struct_def.name)
-                    }
-                    Type::String => unreachable!("String should be handled above"),
-                    // Other types that might need drop in the future can be added here
-                    _ => {
-                        // For now, any other type reaching here is unexpected
-                        debug_assert!(
-                            false,
-                            "Drop instruction reached codegen for unexpected type: {:?}",
-                            dropped_ty
-                        );
-                        return;
-                    }
-                };
-
-                // Call the runtime drop function (handles field drops)
-                self.mir.push(X86Inst::CallRel {
-                    symbol: drop_fn_name,
-                });
+                // For other types that might need drop in the future
+                debug_assert!(
+                    false,
+                    "Drop instruction reached codegen for unexpected type: {:?}",
+                    dropped_ty
+                );
             }
 
             CfgInstData::StorageLive { slot: _ } => {

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -1,0 +1,247 @@
+//! Drop glue synthesis for structs with non-trivial fields.
+//!
+//! When a struct has fields that need drop (like String), the compiler needs to
+//! generate a "drop glue" function that drops each field. This is similar to
+//! Rust's drop glue.
+//!
+//! For example, for a struct like:
+//! ```text
+//! struct Container {
+//!     name: String,
+//!     value: i32,
+//! }
+//! ```
+//!
+//! We generate a function `__rue_drop_Container` that:
+//! 1. Receives the struct's flattened fields as parameters
+//! 2. Drops each field that needs dropping (in declaration order)
+
+use rue_air::{Air, AirInst, AirInstData, AirRef, AnalyzedFunction, ArrayTypeDef, StructDef, Type};
+use rue_span::Span;
+
+/// Check if a type needs drop.
+fn type_needs_drop(ty: Type, struct_defs: &[StructDef], array_types: &[ArrayTypeDef]) -> bool {
+    match ty {
+        // Primitive types are trivially droppable
+        Type::I8
+        | Type::I16
+        | Type::I32
+        | Type::I64
+        | Type::U8
+        | Type::U16
+        | Type::U32
+        | Type::U64
+        | Type::Bool
+        | Type::Unit
+        | Type::Never
+        | Type::Error => false,
+
+        // Enum types are trivially droppable (just discriminant values)
+        Type::Enum(_) => false,
+
+        // String needs drop - heap-allocated strings must be freed
+        Type::String => true,
+
+        // Struct types need drop if any field needs drop
+        Type::Struct(struct_id) => {
+            let struct_def = &struct_defs[struct_id.0 as usize];
+            struct_def
+                .fields
+                .iter()
+                .any(|f| type_needs_drop(f.ty, struct_defs, array_types))
+        }
+
+        // Array types need drop if element type needs drop
+        Type::Array(array_id) => {
+            let array_def = &array_types[array_id.0 as usize];
+            type_needs_drop(array_def.element_type, struct_defs, array_types)
+        }
+    }
+}
+
+/// Count the number of ABI slots a type uses (flattened).
+fn type_slot_count(ty: Type, struct_defs: &[StructDef], array_types: &[ArrayTypeDef]) -> u32 {
+    match ty {
+        // Primitives use 1 slot
+        Type::I8
+        | Type::I16
+        | Type::I32
+        | Type::I64
+        | Type::U8
+        | Type::U16
+        | Type::U32
+        | Type::U64
+        | Type::Bool
+        | Type::Unit
+        | Type::Never
+        | Type::Error
+        | Type::Enum(_) => 1,
+
+        // String uses 3 slots (ptr, len, cap)
+        Type::String => 3,
+
+        // Struct uses sum of all field slots
+        Type::Struct(struct_id) => {
+            let struct_def = &struct_defs[struct_id.0 as usize];
+            struct_def
+                .fields
+                .iter()
+                .map(|f| type_slot_count(f.ty, struct_defs, array_types))
+                .sum()
+        }
+
+        // Array uses element slots * length
+        Type::Array(array_id) => {
+            let array_def = &array_types[array_id.0 as usize];
+            type_slot_count(array_def.element_type, struct_defs, array_types)
+                * array_def.length as u32
+        }
+    }
+}
+
+/// Synthesize drop glue functions for all structs that need them.
+///
+/// Returns a list of synthesized functions that should be added to the compilation.
+pub fn synthesize_drop_glue(
+    struct_defs: &[StructDef],
+    array_types: &[ArrayTypeDef],
+) -> Vec<AnalyzedFunction> {
+    let mut drop_glue_functions = Vec::new();
+
+    for (struct_idx, struct_def) in struct_defs.iter().enumerate() {
+        // Skip structs that don't need drop
+        let struct_id = rue_air::StructId(struct_idx as u32);
+        let struct_ty = Type::Struct(struct_id);
+        if !type_needs_drop(struct_ty, struct_defs, array_types) {
+            continue;
+        }
+
+        // Create drop glue function
+        let func = create_drop_glue_function(struct_def, struct_id, struct_defs, array_types);
+        drop_glue_functions.push(func);
+    }
+
+    drop_glue_functions
+}
+
+/// Create a drop glue function for a single struct.
+fn create_drop_glue_function(
+    struct_def: &StructDef,
+    _struct_id: rue_air::StructId,
+    struct_defs: &[StructDef],
+    array_types: &[ArrayTypeDef],
+) -> AnalyzedFunction {
+    let fn_name = format!("__rue_drop_{}", struct_def.name);
+    let span = Span::new(0, 0); // Synthetic span
+
+    // Create AIR for the drop glue function
+    let mut air = Air::new(Type::Unit);
+
+    // Calculate total parameter slots
+    let mut num_param_slots = 0u32;
+    for field in &struct_def.fields {
+        num_param_slots += type_slot_count(field.ty, struct_defs, array_types);
+    }
+
+    // Collect drop statements - these are side-effects that must be executed
+    let mut drop_statements = Vec::new();
+
+    // For each field that needs drop, emit a Drop instruction.
+    // We need to reconstruct the field values from the flattened parameters.
+    let mut current_param_slot = 0u32;
+
+    for field in &struct_def.fields {
+        let field_slot_count = type_slot_count(field.ty, struct_defs, array_types);
+
+        if type_needs_drop(field.ty, struct_defs, array_types) {
+            // Emit Drop for this field
+            // For now, we handle String and nested structs
+            match field.ty {
+                Type::String => {
+                    // String has 3 params (ptr, len, cap)
+                    // We need to load all three and pass them to the Drop instruction
+                    // The Drop instruction in AIR operates on a value, and the CFG/codegen
+                    // will handle the flattening.
+
+                    // For simplicity, emit a Param to get the first slot, then drop it.
+                    // The codegen knows this is a String and will use all 3 slots.
+                    let param_ref = air.add_inst(AirInst {
+                        data: AirInstData::Param {
+                            index: current_param_slot,
+                        },
+                        ty: Type::String,
+                        span,
+                    });
+                    let drop_ref = air.add_inst(AirInst {
+                        data: AirInstData::Drop { value: param_ref },
+                        ty: Type::Unit,
+                        span,
+                    });
+                    drop_statements.push(drop_ref);
+                }
+                Type::Struct(nested_struct_id) => {
+                    // Nested struct - load it and drop it
+                    // The recursive drop glue will handle its fields
+                    let param_ref = air.add_inst(AirInst {
+                        data: AirInstData::Param {
+                            index: current_param_slot,
+                        },
+                        ty: Type::Struct(nested_struct_id),
+                        span,
+                    });
+                    let drop_ref = air.add_inst(AirInst {
+                        data: AirInstData::Drop { value: param_ref },
+                        ty: Type::Unit,
+                        span,
+                    });
+                    drop_statements.push(drop_ref);
+                }
+                // Arrays and other types can be added later
+                _ => {}
+            }
+        }
+
+        current_param_slot += field_slot_count;
+    }
+
+    // Create the unit value for return
+    let unit_const = air.add_inst(AirInst {
+        data: AirInstData::UnitConst,
+        ty: Type::Unit,
+        span,
+    });
+
+    // If we have drop statements, wrap them in a Block so they get executed
+    // The CFG builder uses demand-driven lowering, so statements in a Block
+    // are explicitly included as side-effects.
+    let return_value = if drop_statements.is_empty() {
+        unit_const
+    } else {
+        air.add_inst(AirInst {
+            data: AirInstData::Block {
+                statements: drop_statements,
+                value: unit_const,
+            },
+            ty: Type::Unit,
+            span,
+        })
+    };
+
+    // Add return instruction
+    air.add_inst(AirInst {
+        data: AirInstData::Ret(Some(return_value)),
+        ty: Type::Unit,
+        span,
+    });
+
+    // All parameters are passed by value (normal mode)
+    let param_modes = vec![false; num_param_slots as usize];
+
+    AnalyzedFunction {
+        name: fn_name,
+        air,
+        num_locals: 0,
+        num_param_slots,
+        param_modes,
+    }
+}

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -26,6 +26,7 @@
 //! Use `--log-level info` or `--time-passes` to see timing information.
 
 mod diagnostic;
+mod drop_glue;
 
 use tracing::{info, info_span};
 
@@ -366,13 +367,24 @@ pub fn compile_frontend_from_ast_with_options(
         output
     };
 
+    // Synthesize drop glue functions for structs that need them
+    let drop_glue_functions =
+        drop_glue::synthesize_drop_glue(&sema_output.struct_defs, &sema_output.array_types);
+
+    // Combine user functions with synthesized drop glue functions
+    let all_functions: Vec<_> = sema_output
+        .functions
+        .into_iter()
+        .chain(drop_glue_functions)
+        .collect();
+
     // Build CFGs from AIR (one per function), collecting warnings
     let (functions, warnings) = {
         let _span = info_span!("cfg_construction").entered();
-        let mut functions = Vec::with_capacity(sema_output.functions.len());
+        let mut functions = Vec::with_capacity(all_functions.len());
         let mut warnings = sema_output.warnings;
 
-        for func in sema_output.functions {
+        for func in all_functions {
             let cfg_output = CfgBuilder::build(
                 &func.air,
                 func.num_locals,

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -236,8 +236,6 @@ exit_code = 0
 name = "struct_with_destructor_field"
 spec = ["3.9:12"]
 description = "Struct has destructor if any field has destructor"
-skip = true
-skip_reason = "Synthesized destructors for user structs not yet implemented - compiler generates call but runtime function missing"
 source = """
 struct Container {
     name: String,
@@ -257,8 +255,6 @@ exit_code = 42
 name = "field_drop_order"
 spec = ["3.9:13"]
 description = "Fields dropped in declaration order"
-skip = true
-skip_reason = "Synthesized destructors for user structs not yet implemented - compiler generates call but runtime function missing"
 source = """
 struct TwoStrings {
     first: String,


### PR DESCRIPTION
Structs containing fields that need drop (like String) now have synthesized __rue_drop_<StructName> functions generated at compile time.

Key changes:
- New drop_glue.rs module synthesizes drop functions for non-trivial structs
- Fixed collect_struct_scalar_vregs to properly handle String fields (3 slots)
- Updated both x86_64 and aarch64 backends to pass all flattened struct fields to drop functions
- Enabled struct_with_destructor_field and field_drop_order tests

Fixes rue-wjha

🤖 Generated with [Claude Code](https://claude.com/claude-code)