### PR TITLE
Fix stale compiler binary detection in spec tests

### DIFF
--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -726,6 +726,10 @@ pub fn find_dir(env_var: &str, possible_paths: &[&str], fallback: &str) -> PathB
 }
 
 /// Find the rue binary in common locations.
+///
+/// When multiple Buck2 build outputs exist (each in a UUID-named directory),
+/// this function selects the most recently modified binary to avoid using
+/// stale binaries from previous builds.
 pub fn find_rue_binary() -> PathBuf {
     std::env::var("RUE_BINARY")
         .map(PathBuf::from)
@@ -735,11 +739,26 @@ pub fn find_rue_binary() -> PathBuf {
             let buck_root = Path::new("buck-out/v2/gen/root");
             if buck_root.exists() {
                 if let Ok(entries) = std::fs::read_dir(buck_root) {
-                    for entry in entries.flatten() {
-                        let rue_path = entry.path().join("crates/rue/__rue__/rue");
-                        if rue_path.exists() {
-                            return rue_path;
-                        }
+                    // Collect all valid rue binaries with their modification times
+                    let mut candidates: Vec<(PathBuf, std::time::SystemTime)> = entries
+                        .flatten()
+                        .filter_map(|entry| {
+                            let rue_path = entry.path().join("crates/rue/__rue__/rue");
+                            if rue_path.exists() {
+                                // Get modification time; skip if we can't read it
+                                rue_path.metadata().ok().and_then(|meta| {
+                                    meta.modified().ok().map(|mtime| (rue_path, mtime))
+                                })
+                            } else {
+                                None
+                            }
+                        })
+                        .collect();
+
+                    // Sort by modification time (newest first) and return the most recent
+                    candidates.sort_by(|a, b| b.1.cmp(&a.1));
+                    if let Some((path, _)) = candidates.into_iter().next() {
+                        return path;
                     }
                 }
             }


### PR DESCRIPTION
When Buck2 rebuilds the rue compiler, it creates outputs in a new UUID-named directory under buck-out/v2/gen/root/. The previous find_rue_binary() implementation would return the first binary found, which could be from a stale build in an old UUID directory.

This fix changes find_rue_binary() to:
1. Collect all rue binary candidates from Buck2 output directories
2. Get the modification time of each binary
3. Sort by modification time (newest first)
4. Return the most recently modified binary

This ensures spec tests always use the freshly built compiler binary.

Closes: rue-xkpt

🤖 Generated with [Claude Code](https://claude.com/claude-code)