### PR TITLE
Fix sub-word overflow checking to use 64-bit compare

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2554,7 +2554,8 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(sext_vreg),
                     src: Operand::Virtual(result_vreg),
                 });
-                self.mir.push(Aarch64Inst::CmpRR {
+                // Use 64-bit compare since sext_vreg is a 64-bit value
+                self.mir.push(Aarch64Inst::Cmp64RR {
                     src1: Operand::Virtual(result_vreg),
                     src2: Operand::Virtual(sext_vreg),
                 });
@@ -2570,7 +2571,8 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(sext_vreg),
                     src: Operand::Virtual(result_vreg),
                 });
-                self.mir.push(Aarch64Inst::CmpRR {
+                // Use 64-bit compare since sext_vreg is a 64-bit value
+                self.mir.push(Aarch64Inst::Cmp64RR {
                     src1: Operand::Virtual(result_vreg),
                     src2: Operand::Virtual(sext_vreg),
                 });

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2719,7 +2719,8 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(sext_vreg),
                     src: Operand::Virtual(result_vreg),
                 });
-                self.mir.push(X86Inst::CmpRR {
+                // Use 64-bit compare since sext_vreg is a 64-bit value
+                self.mir.push(X86Inst::Cmp64RR {
                     src1: Operand::Virtual(result_vreg),
                     src2: Operand::Virtual(sext_vreg),
                 });
@@ -2733,7 +2734,8 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(sext_vreg),
                     src: Operand::Virtual(result_vreg),
                 });
-                self.mir.push(X86Inst::CmpRR {
+                // Use 64-bit compare since sext_vreg is a 64-bit value
+                self.mir.push(X86Inst::Cmp64RR {
                     src1: Operand::Virtual(result_vreg),
                     src2: Operand::Virtual(sext_vreg),
                 });


### PR DESCRIPTION
Use Cmp64RR instead of CmpRR when comparing sign-extended i8/i16 values during overflow detection. The sign-extension produces a 64-bit value, so the comparison should also be 64-bit.

Fixes rue-8ecy

🤖 Generated with [Claude Code](https://claude.com/claude-code)