### PR TITLE
Add GitHub Actions workflow for CI benchmark integration

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,121 @@
+name: Benchmarks
+
+on:
+  push:
+    branches: [trunk]
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: 'Number of benchmark iterations'
+        default: '5'
+        type: string
+
+# Only run one benchmark at a time to ensure consistent results
+concurrency:
+  group: benchmarks
+  cancel-in-progress: false
+
+permissions:
+  contents: write  # Needed to push to perf branch
+
+jobs:
+  benchmark:
+    # Run on a consistent runner for reproducible results
+    # macOS provides the most consistent performance on GitHub Actions
+    runs-on: macos-latest
+    steps:
+      - name: Checkout trunk
+        uses: actions/checkout@v4
+        with:
+          ref: trunk
+          fetch-depth: 0  # Full history for commit info
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@latest
+
+      # Cache Buck2 outputs including downloaded Rust toolchain
+      - name: Cache Buck2 outputs
+        uses: actions/cache@v4
+        with:
+          path: |
+            buck-out/v2/gen
+            ~/.cache/buck2
+          key: buck2-macos-release-${{ hashFiles('**/BUCK', 'toolchains/rust/defs.bzl') }}
+          restore-keys: |
+            buck2-macos-release-
+
+      - name: Get commit info
+        id: commit
+        run: |
+          echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "full_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Run benchmarks
+        id: bench
+        run: |
+          iterations="${{ github.event.inputs.iterations || '5' }}"
+          echo "Running benchmarks with $iterations iterations..."
+          ./bench.sh --iterations "$iterations" --output /tmp/results.json --no-history
+
+          # Extract summary for PR comment
+          echo "benchmark_results<<EOF" >> $GITHUB_OUTPUT
+          cat /tmp/results.json >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
+      - name: Checkout perf branch
+        uses: actions/checkout@v4
+        with:
+          ref: perf
+          path: perf-branch
+          fetch-depth: 1
+        continue-on-error: true
+
+      - name: Initialize perf branch if needed
+        run: |
+          if [ ! -d "perf-branch" ]; then
+            mkdir -p perf-branch
+            cd perf-branch
+            git init
+            git checkout -b perf
+            mkdir -p benchmarks
+            echo '{"version": 1, "runs": []}' > benchmarks/history.json
+            echo "# Performance History" > README.md
+            echo "" >> README.md
+            echo "This branch stores benchmark history for the Rue compiler." >> README.md
+            echo "See [Performance Dashboard](https://rue-lang.dev/performance/) for visualization." >> README.md
+          fi
+
+      - name: Append to history
+        run: |
+          python3 scripts/append-benchmark.py /tmp/results.json perf-branch/benchmarks/history.json
+
+      - name: Commit and push to perf branch
+        run: |
+          cd perf-branch
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          git add benchmarks/history.json
+
+          # Only commit if there are changes
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+          else
+            git commit -m "Benchmark results for ${{ steps.commit.outputs.sha }}"
+
+            # Push to perf branch (create if doesn't exist)
+            git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:perf
+          fi
+
+      - name: Summary
+        run: |
+          echo "## Benchmark Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Commit: \`${{ steps.commit.outputs.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "### Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`json" >> $GITHUB_STEP_SUMMARY
+          cat /tmp/results.json >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/bench.sh
+++ b/bench.sh
@@ -216,7 +216,8 @@ done
 
 # Get metadata
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-commit=$(jj log -r @ --no-graph -T 'commit_id' 2>/dev/null | head -c 12 || echo "unknown")
+# Get commit hash - try jj first (for local dev), fall back to git (for CI)
+commit=$(jj log -r @ --no-graph -T 'commit_id' 2>/dev/null | head -c 12 || git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 os=$(uname -s | tr '[:upper:]' '[:lower:]')
 arch=$(uname -m)
 host="${arch}-${os}"

--- a/docs/designs/0019-performance-dashboard.md
+++ b/docs/designs/0019-performance-dashboard.md
@@ -187,7 +187,7 @@ website/
   - Document benchmark workflow
   - Add release/debug build modes via Buck2 modifiers
 
-- [ ] **Phase 4: CI integration** - rue-a5ah.4
+- [x] **Phase 4: CI integration** - rue-a5ah.4
   - GitHub Actions workflow to run benchmarks on trunk commits
   - Push results to `perf` branch
   - Configure consistent benchmark environment


### PR DESCRIPTION
Create benchmarks.yml workflow that:
- Runs on every trunk push and manual dispatch
- Uses macOS runner for consistent performance
- Collects benchmark results via bench.sh
- Pushes results to a dedicated 'perf' branch
- Includes step summary with JSON results

Also update bench.sh to fall back to git for commit hash when jj is not available (for CI environments).

Fixes rue-a5ah.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)