### PR TITLE
Use Symbol instead of String in AirInstData::Call

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -5,6 +5,7 @@
 use std::fmt;
 
 use crate::types::{ArrayTypeId, StructId, Type};
+use rue_intern::Symbol;
 use rue_span::Span;
 
 /// Parameter passing mode in AIR.
@@ -294,8 +295,8 @@ pub enum AirInstData {
 
     /// Function call
     Call {
-        /// Function name
-        name: String,
+        /// Function name (interned symbol)
+        name: Symbol,
         /// Arguments with inout flags
         args: Vec<AirCallArg>,
     },
@@ -550,7 +551,7 @@ impl fmt::Display for Air {
                     }
                 }
                 AirInstData::Call { name, args } => {
-                    write!(f, "call {}(", name)?;
+                    write!(f, "call @{}(", name.as_u32())?;
                     for (i, arg) in args.iter().enumerate() {
                         if i > 0 {
                             write!(f, ", ")?;

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -2632,7 +2632,7 @@ impl<'a> Sema<'a> {
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Call {
-                        name: fn_name_str,
+                        name: *name,
                         args: air_args,
                     },
                     ty: return_type,
@@ -3759,12 +3759,13 @@ impl<'a> Sema<'a> {
                 }];
                 air_args.extend(self.analyze_call_args(air, args, ctx)?);
 
-                // Generate a method call name: Type.method
+                // Generate a method call name: Type.method (intern for AIR)
                 let call_name = format!("{}.{}", struct_name_str, method_name_str);
+                let call_name_sym = self.interner.intern(&call_name);
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Call {
-                        name: call_name,
+                        name: call_name_sym,
                         args: air_args,
                     },
                     ty: return_type,
@@ -3844,12 +3845,13 @@ impl<'a> Sema<'a> {
                 // Analyze arguments
                 let air_args = self.analyze_call_args(air, args, ctx)?;
 
-                // Generate a function call name: Type::function
+                // Generate a function call name: Type::function (intern for AIR)
                 let call_name = format!("{}::{}", type_name_str, function_name_str);
+                let call_name_sym = self.interner.intern(&call_name);
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Call {
-                        name: call_name,
+                        name: call_name_sym,
                         args: air_args,
                     },
                     ty: return_type,
@@ -4335,9 +4337,10 @@ impl<'a> Sema<'a> {
 
                 // Generate a call to String__new (runtime function)
                 // We use double underscore because :: is not valid in C symbol names
+                let call_name = self.interner.intern("String__new");
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Call {
-                        name: "String__new".to_string(),
+                        name: call_name,
                         args: vec![],
                     },
                     ty: Type::String,
@@ -4373,9 +4376,10 @@ impl<'a> Sema<'a> {
                 }
 
                 // Generate a call to String__with_capacity (runtime function)
+                let call_name = self.interner.intern("String__with_capacity");
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Call {
-                        name: "String__with_capacity".to_string(),
+                        name: call_name,
                         args: vec![AirCallArg {
                             value: cap_result.air_ref,
                             mode: AirArgMode::Normal,
@@ -4523,9 +4527,10 @@ impl<'a> Sema<'a> {
                 }
 
                 // Call String__push_str(self, other) -> String
+                let call_name = self.interner.intern("String__push_str");
                 let call_ref = air.add_inst(AirInst {
                     data: AirInstData::Call {
-                        name: "String__push_str".to_string(),
+                        name: call_name,
                         args: vec![
                             AirCallArg {
                                 value: receiver.air_ref,
@@ -4572,9 +4577,10 @@ impl<'a> Sema<'a> {
                 }
 
                 // Call String__push(self, byte) -> String
+                let call_name = self.interner.intern("String__push");
                 let call_ref = air.add_inst(AirInst {
                     data: AirInstData::Call {
-                        name: "String__push".to_string(),
+                        name: call_name,
                         args: vec![
                             AirCallArg {
                                 value: receiver.air_ref,
@@ -4607,9 +4613,10 @@ impl<'a> Sema<'a> {
                 }
 
                 // Call String__clear(self) -> String
+                let call_name = self.interner.intern("String__clear");
                 let call_ref = air.add_inst(AirInst {
                     data: AirInstData::Call {
-                        name: "String__clear".to_string(),
+                        name: call_name,
                         args: vec![AirCallArg {
                             value: receiver.air_ref,
                             mode: AirArgMode::Normal,
@@ -4650,9 +4657,10 @@ impl<'a> Sema<'a> {
                 }
 
                 // Call String__reserve(self, additional) -> String
+                let call_name = self.interner.intern("String__reserve");
                 let call_ref = air.add_inst(AirInst {
                     data: AirInstData::Call {
-                        name: "String__reserve".to_string(),
+                        name: call_name,
                         args: vec![
                             AirCallArg {
                                 value: receiver.air_ref,
@@ -4749,9 +4757,10 @@ impl<'a> Sema<'a> {
                 // The caller still owns the String after this call.
                 // Using Normal mode instead of Borrow because String's 3 fields should be
                 // passed directly, not by reference.
+                let call_name = self.interner.intern("String__len");
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Call {
-                        name: "String__len".to_string(),
+                        name: call_name,
                         args: vec![AirCallArg {
                             value: receiver.air_ref,
                             mode: AirArgMode::Normal,
@@ -4778,9 +4787,10 @@ impl<'a> Sema<'a> {
 
                 // Generate a call to String__capacity (runtime function)
                 // Same pattern as len() - pass by value, don't consume.
+                let call_name = self.interner.intern("String__capacity");
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Call {
-                        name: "String__capacity".to_string(),
+                        name: call_name,
                         args: vec![AirCallArg {
                             value: receiver.air_ref,
                             mode: AirArgMode::Normal,
@@ -4807,9 +4817,10 @@ impl<'a> Sema<'a> {
 
                 // Generate a call to String__is_empty (runtime function)
                 // Same pattern as len() - pass by value, don't consume.
+                let call_name = self.interner.intern("String__is_empty");
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Call {
-                        name: "String__is_empty".to_string(),
+                        name: call_name,
                         args: vec![AirCallArg {
                             value: receiver.air_ref,
                             mode: AirArgMode::Normal,
@@ -4837,9 +4848,10 @@ impl<'a> Sema<'a> {
                 // Generate a call to String__clone (runtime function)
                 // Takes the String (ptr, len, cap) and returns a new String (ptr, len, cap)
                 // where the new ptr points to freshly allocated memory with copied content.
+                let call_name = self.interner.intern("String__clone");
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Call {
-                        name: "String__clone".to_string(),
+                        name: call_name,
                         args: vec![AirCallArg {
                             value: receiver.air_ref,
                             mode: AirArgMode::Normal,

--- a/crates/rue-cfg/BUCK
+++ b/crates/rue-cfg/BUCK
@@ -4,6 +4,7 @@ rust_library(
     deps = [
         "//crates/rue-air:rue-air",
         "//crates/rue-error:rue-error",
+        "//crates/rue-intern:rue-intern",
         "//crates/rue-span:rue-span",
     ],
     visibility = ["PUBLIC"],

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -5,6 +5,7 @@
 
 use rue_air::{Air, AirArgMode, AirInstData, AirPattern, AirRef, ArrayTypeDef, StructDef, Type};
 use rue_error::{CompileWarning, WarningKind};
+use rue_intern::Interner;
 
 use crate::CfgOutput;
 use crate::inst::{
@@ -60,6 +61,8 @@ pub struct CfgBuilder<'a> {
     struct_defs: &'a [StructDef],
     /// Array type definitions for type queries
     array_types: &'a [ArrayTypeDef],
+    /// Interner for resolving symbols to strings
+    interner: &'a Interner,
     /// Current block we're building
     current_block: BlockId,
     /// Stack of loop contexts for nested loops
@@ -78,7 +81,8 @@ impl<'a> CfgBuilder<'a> {
     /// Build a CFG from AIR, returning the CFG and any warnings.
     ///
     /// The `struct_defs` and `array_types` parameters provide type definitions
-    /// needed for queries like `type_needs_drop`.
+    /// needed for queries like `type_needs_drop`. The `interner` is used to
+    /// resolve Symbol values to strings for the CFG.
     pub fn build(
         air: &'a Air,
         num_locals: u32,
@@ -87,6 +91,7 @@ impl<'a> CfgBuilder<'a> {
         struct_defs: &'a [StructDef],
         array_types: &'a [ArrayTypeDef],
         param_modes: Vec<bool>,
+        interner: &'a Interner,
     ) -> CfgOutput {
         let mut builder = CfgBuilder {
             air,
@@ -99,6 +104,7 @@ impl<'a> CfgBuilder<'a> {
             ),
             struct_defs,
             array_types,
+            interner,
             current_block: BlockId(0),
             loop_stack: Vec::new(),
             value_cache: vec![None; air.len()],
@@ -635,9 +641,11 @@ impl<'a> CfgBuilder<'a> {
                         mode: Self::convert_arg_mode(arg.mode),
                     });
                 }
+                // Convert Symbol to String for CFG (CFG will adopt Symbol in rue-iom9)
+                let name_str = self.interner.get(*name).to_string();
                 let value = self.emit(
                     CfgInstData::Call {
-                        name: name.clone(),
+                        name: name_str,
                         args: arg_vals,
                     },
                     ty,
@@ -1744,6 +1752,7 @@ mod tests {
             &output.struct_defs,
             &output.array_types,
             func.param_modes.clone(),
+            &interner,
         )
         .cfg
     }

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -3598,6 +3598,7 @@ mod tests {
             struct_defs,
             array_types,
             func.param_modes.clone(),
+            &interner,
         );
 
         CfgLower::new(&cfg_output.cfg, struct_defs, array_types, strings).lower()

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -305,6 +305,7 @@ mod tests {
     use super::*;
     use rue_air::{Air, AirInst, AirInstData, Type};
     use rue_cfg::CfgBuilder;
+    use rue_intern::Interner;
     use rue_span::Span;
 
     #[test]
@@ -324,7 +325,8 @@ mod tests {
         });
 
         // Build CFG from AIR (no struct/array types in this simple test)
-        let cfg_output = CfgBuilder::build(&air, 0, 0, "main", &[], &[], vec![]);
+        let interner = Interner::new();
+        let cfg_output = CfgBuilder::build(&air, 0, 0, "main", &[], &[], vec![], &interner);
 
         // Test the generate function
         let machine_code = generate(&cfg_output.cfg, &[], &[], &[]).unwrap();

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -555,6 +555,7 @@ mod tests {
     use super::*;
     use rue_air::{Air, AirInst, AirInstData, Type};
     use rue_cfg::CfgBuilder;
+    use rue_intern::Interner;
     use rue_span::Span;
 
     fn create_simple_cfg() -> (rue_cfg::Cfg, Vec<StructDef>, Vec<ArrayTypeDef>) {
@@ -572,7 +573,8 @@ mod tests {
             span: Span::new(0, 2),
         });
 
-        let cfg_output = CfgBuilder::build(&air, 0, 0, "test", &[], &[], vec![]);
+        let interner = Interner::new();
+        let cfg_output = CfgBuilder::build(&air, 0, 0, "test", &[], &[], vec![], &interner);
         (cfg_output.cfg, vec![], vec![])
     }
 

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3461,6 +3461,7 @@ mod tests {
             struct_defs,
             array_types,
             func.param_modes.clone(),
+            &interner,
         );
 
         CfgLower::new(&cfg_output.cfg, struct_defs, array_types, strings).lower()

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -393,6 +393,7 @@ pub fn compile_frontend_from_ast_with_options(
                 &sema_output.struct_defs,
                 &sema_output.array_types,
                 func.param_modes.clone(),
+                &interner,
             );
             warnings.extend(cfg_output.warnings);
 


### PR DESCRIPTION
Change the function name field in AIR Call instructions from String to Symbol to avoid heap allocation. Function names are already interned during parsing, so we pass the Symbol through directly. For constructed names (method calls, associated functions, runtime calls), we intern them at the point of use.

The CFG builder now takes an interner parameter to convert Symbol back to String until rue-iom9 updates CFG to use Symbol as well.

Fixes rue-sg07

🤖 Generated with [Claude Code](https://claude.com/claude-code)