### PR TITLE
Add performance dashboard website visualization (Phase 5)

### DIFF
--- a/docs/designs/0019-performance-dashboard.md
+++ b/docs/designs/0019-performance-dashboard.md
@@ -1,12 +1,12 @@
 ---
 id: 0019
 title: Compiler Performance Dashboard
-status: proposal
+status: implemented
 tags: [tooling, website, performance]
 feature-flag: null
 created: 2025-12-27
-accepted:
-implemented:
+accepted: 2025-12-27
+implemented: 2025-12-27
 spec-sections: []
 superseded-by:
 ---
@@ -15,7 +15,7 @@ superseded-by:
 
 ## Status
 
-Proposal
+Implemented
 
 ## Summary
 
@@ -192,7 +192,7 @@ website/
   - Push results to `perf` branch
   - Configure consistent benchmark environment
 
-- [ ] **Phase 5: Website visualization** - rue-a5ah.5
+- [x] **Phase 5: Website visualization** - rue-a5ah.5
   - Create SVG chart generator (Rust or Python)
   - Create `/performance/` page template
   - Integrate chart generation into website build

--- a/scripts/generate-charts.py
+++ b/scripts/generate-charts.py
@@ -1,0 +1,341 @@
+#!/usr/bin/env python3
+"""
+Generate SVG charts from benchmark history for the performance dashboard.
+
+This script reads benchmark history from JSON and generates two SVG charts:
+1. timeline.svg - Time-series chart showing total compilation time over commits
+2. breakdown.svg - Stacked bar chart showing time per compiler pass
+
+Usage:
+    ./generate-charts.py <history.json> <output-dir>
+
+Example:
+    ./generate-charts.py website/static/benchmarks/history.json website/static/benchmarks/
+"""
+
+import json
+import sys
+from pathlib import Path
+from typing import Optional
+
+# Chart dimensions
+TIMELINE_WIDTH = 800
+TIMELINE_HEIGHT = 300
+BREAKDOWN_WIDTH = 800
+BREAKDOWN_HEIGHT = 350
+
+# Colors for passes (consistent with website theme)
+PASS_COLORS = {
+    "lexer": "#4f6ddb",     # accent blue
+    "parser": "#7c9dff",    # lighter blue
+    "astgen": "#3b82f6",    # sky blue
+    "sema": "#06b6d4",      # cyan
+    "cfg": "#10b981",       # emerald
+    "codegen": "#f59e0b",   # amber
+    "linker": "#ef4444",    # red
+}
+
+# Order of passes in the stack
+PASS_ORDER = ["lexer", "parser", "astgen", "sema", "cfg", "codegen", "linker"]
+
+
+def load_history(path: Path) -> dict:
+    """Load benchmark history from JSON file."""
+    if not path.exists():
+        return {"version": 1, "runs": []}
+
+    with open(path, "r") as f:
+        data = json.load(f)
+
+    # Handle legacy format
+    if isinstance(data, list):
+        return {"version": 1, "runs": data}
+
+    return data
+
+
+def get_pass_times(run: dict) -> dict[str, float]:
+    """Extract pass timing from a benchmark run."""
+    # Look for pass timing data in the benchmarks
+    for bench in run.get("benchmarks", []):
+        if "passes" in bench:
+            # New format with per-pass timing
+            passes = bench["passes"]
+            return {
+                name: passes.get(name, {}).get("mean_ms", 0)
+                for name in PASS_ORDER
+            }
+    return {}
+
+
+def get_total_time(run: dict) -> float:
+    """Get total compilation time from a run."""
+    for bench in run.get("benchmarks", []):
+        if "mean_ms" in bench:
+            return bench["mean_ms"]
+        if "total_ms" in bench:
+            total = bench["total_ms"]
+            if isinstance(total, dict):
+                return total.get("mean", 0)
+            return total
+    return 0
+
+
+def escape_xml(s: str) -> str:
+    """Escape special XML characters."""
+    return s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+
+
+def short_commit(commit: str) -> str:
+    """Get short commit hash."""
+    if commit and len(commit) >= 7:
+        return commit[:7]
+    return commit or "?"
+
+
+def generate_empty_chart(width: int, height: int, message: str) -> str:
+    """Generate an SVG chart showing a message when no data is available."""
+    return f'''<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {width} {height}" class="benchmark-chart">
+  <style>
+    .chart-bg {{ fill: var(--chart-bg, #ffffff); }}
+    .chart-text {{ fill: var(--chart-text, #6b7280); font-family: system-ui, sans-serif; }}
+    @media (prefers-color-scheme: dark) {{
+      .chart-bg {{ fill: #1a1a1a; }}
+      .chart-text {{ fill: #9ca3af; }}
+    }}
+  </style>
+  <rect class="chart-bg" width="{width}" height="{height}" rx="8"/>
+  <text class="chart-text" x="{width/2}" y="{height/2}" text-anchor="middle" font-size="14">{escape_xml(message)}</text>
+</svg>'''
+
+
+def generate_timeline_chart(runs: list[dict]) -> str:
+    """Generate time-series SVG chart of total compilation time."""
+    if not runs:
+        return generate_empty_chart(TIMELINE_WIDTH, TIMELINE_HEIGHT, "No benchmark data available yet")
+
+    # Extract data points
+    points = []
+    for run in runs[-20:]:  # Show last 20 commits
+        total = get_total_time(run)
+        commit = short_commit(run.get("commit", ""))
+        points.append({"commit": commit, "time": total})
+
+    if not points or all(p["time"] == 0 for p in points):
+        return generate_empty_chart(TIMELINE_WIDTH, TIMELINE_HEIGHT, "No timing data in benchmarks")
+
+    # Chart layout
+    margin = {"top": 40, "right": 30, "bottom": 60, "left": 70}
+    chart_width = TIMELINE_WIDTH - margin["left"] - margin["right"]
+    chart_height = TIMELINE_HEIGHT - margin["top"] - margin["bottom"]
+
+    # Scale calculations
+    max_time = max(p["time"] for p in points) * 1.1  # 10% padding
+    if max_time == 0:
+        max_time = 1  # Avoid division by zero
+
+    def scale_x(i: int) -> float:
+        if len(points) == 1:
+            return margin["left"] + chart_width / 2
+        return margin["left"] + (i / (len(points) - 1)) * chart_width
+
+    def scale_y(v: float) -> float:
+        return margin["top"] + chart_height - (v / max_time) * chart_height
+
+    # Build SVG
+    svg_parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {TIMELINE_WIDTH} {TIMELINE_HEIGHT}" class="benchmark-chart">',
+        '''  <style>
+    .chart-bg { fill: var(--chart-bg, #ffffff); }
+    .chart-text { fill: var(--chart-text, #6b7280); font-family: system-ui, sans-serif; }
+    .chart-title { fill: var(--chart-title, #1a1a1a); font-family: system-ui, sans-serif; font-weight: 600; }
+    .chart-line { stroke: var(--chart-accent, #4f6ddb); fill: none; stroke-width: 2; }
+    .chart-point { fill: var(--chart-accent, #4f6ddb); }
+    .chart-grid { stroke: var(--chart-grid, #e5e7eb); stroke-width: 1; }
+    .chart-axis { stroke: var(--chart-axis, #9ca3af); stroke-width: 1; }
+    @media (prefers-color-scheme: dark) {
+      .chart-bg { fill: #1a1a1a; }
+      .chart-text { fill: #9ca3af; }
+      .chart-title { fill: #f0f0f0; }
+      .chart-grid { stroke: #2e2e2e; }
+      .chart-axis { stroke: #4b5563; }
+    }
+  </style>''',
+        f'  <rect class="chart-bg" width="{TIMELINE_WIDTH}" height="{TIMELINE_HEIGHT}" rx="8"/>',
+        f'  <text class="chart-title" x="{TIMELINE_WIDTH/2}" y="25" text-anchor="middle" font-size="16">Compilation Time Over Recent Commits</text>',
+    ]
+
+    # Y-axis grid lines and labels
+    num_grid_lines = 5
+    for i in range(num_grid_lines + 1):
+        y = margin["top"] + (i / num_grid_lines) * chart_height
+        value = max_time * (1 - i / num_grid_lines)
+        svg_parts.append(
+            f'  <line class="chart-grid" x1="{margin["left"]}" y1="{y}" x2="{TIMELINE_WIDTH - margin["right"]}" y2="{y}"/>'
+        )
+        svg_parts.append(
+            f'  <text class="chart-text" x="{margin["left"] - 10}" y="{y + 4}" text-anchor="end" font-size="11">{value:.1f}ms</text>'
+        )
+
+    # Axes
+    svg_parts.append(
+        f'  <line class="chart-axis" x1="{margin["left"]}" y1="{margin["top"]}" x2="{margin["left"]}" y2="{TIMELINE_HEIGHT - margin["bottom"]}"/>'
+    )
+    svg_parts.append(
+        f'  <line class="chart-axis" x1="{margin["left"]}" y1="{TIMELINE_HEIGHT - margin["bottom"]}" x2="{TIMELINE_WIDTH - margin["right"]}" y2="{TIMELINE_HEIGHT - margin["bottom"]}"/>'
+    )
+
+    # Draw line connecting points
+    if len(points) > 1:
+        path_d = "M " + " L ".join(
+            f"{scale_x(i)},{scale_y(p['time'])}"
+            for i, p in enumerate(points)
+        )
+        svg_parts.append(f'  <path class="chart-line" d="{path_d}"/>')
+
+    # Draw points and x-axis labels
+    for i, p in enumerate(points):
+        x = scale_x(i)
+        y = scale_y(p["time"])
+        svg_parts.append(f'  <circle class="chart-point" cx="{x}" cy="{y}" r="4"/>')
+
+        # X-axis label (rotated for readability)
+        label_y = TIMELINE_HEIGHT - margin["bottom"] + 15
+        svg_parts.append(
+            f'  <text class="chart-text" x="{x}" y="{label_y}" text-anchor="end" font-size="10" transform="rotate(-45 {x} {label_y})">{escape_xml(p["commit"])}</text>'
+        )
+
+    svg_parts.append("</svg>")
+    return "\n".join(svg_parts)
+
+
+def generate_breakdown_chart(runs: list[dict]) -> str:
+    """Generate stacked bar chart showing time per compiler pass."""
+    if not runs:
+        return generate_empty_chart(BREAKDOWN_WIDTH, BREAKDOWN_HEIGHT, "No benchmark data available yet")
+
+    # Get the most recent run with pass data
+    pass_times: Optional[dict[str, float]] = None
+    commit = ""
+    for run in reversed(runs):
+        pt = get_pass_times(run)
+        if pt and any(v > 0 for v in pt.values()):
+            pass_times = pt
+            commit = short_commit(run.get("commit", ""))
+            break
+
+    if not pass_times or all(v == 0 for v in pass_times.values()):
+        return generate_empty_chart(BREAKDOWN_WIDTH, BREAKDOWN_HEIGHT, "No pass timing data available")
+
+    # Chart layout
+    margin = {"top": 50, "right": 150, "bottom": 40, "left": 70}
+    chart_width = BREAKDOWN_WIDTH - margin["left"] - margin["right"]
+    chart_height = BREAKDOWN_HEIGHT - margin["top"] - margin["bottom"]
+
+    total = sum(pass_times.values())
+    if total == 0:
+        total = 1
+
+    # Build SVG
+    svg_parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {BREAKDOWN_WIDTH} {BREAKDOWN_HEIGHT}" class="benchmark-chart">',
+        '''  <style>
+    .chart-bg { fill: var(--chart-bg, #ffffff); }
+    .chart-text { fill: var(--chart-text, #6b7280); font-family: system-ui, sans-serif; }
+    .chart-title { fill: var(--chart-title, #1a1a1a); font-family: system-ui, sans-serif; font-weight: 600; }
+    .chart-grid { stroke: var(--chart-grid, #e5e7eb); stroke-width: 1; }
+    .chart-axis { stroke: var(--chart-axis, #9ca3af); stroke-width: 1; }
+    @media (prefers-color-scheme: dark) {
+      .chart-bg { fill: #1a1a1a; }
+      .chart-text { fill: #9ca3af; }
+      .chart-title { fill: #f0f0f0; }
+      .chart-grid { stroke: #2e2e2e; }
+      .chart-axis { stroke: #4b5563; }
+    }
+  </style>''',
+        f'  <rect class="chart-bg" width="{BREAKDOWN_WIDTH}" height="{BREAKDOWN_HEIGHT}" rx="8"/>',
+        f'  <text class="chart-title" x="{BREAKDOWN_WIDTH/2}" y="25" text-anchor="middle" font-size="16">Compilation Time by Pass</text>',
+        f'  <text class="chart-text" x="{BREAKDOWN_WIDTH/2}" y="42" text-anchor="middle" font-size="11">(commit: {escape_xml(commit)})</text>',
+    ]
+
+    # Horizontal stacked bar
+    bar_height = 40
+    bar_y = margin["top"] + (chart_height - bar_height) / 2
+    x_offset = margin["left"]
+
+    for pass_name in PASS_ORDER:
+        time = pass_times.get(pass_name, 0)
+        width = (time / total) * chart_width if time > 0 else 0
+        color = PASS_COLORS.get(pass_name, "#888888")
+
+        if width > 0:
+            svg_parts.append(
+                f'  <rect x="{x_offset}" y="{bar_y}" width="{width}" height="{bar_height}" fill="{color}" rx="2"/>'
+            )
+            # Add time label if bar is wide enough
+            if width > 30:
+                svg_parts.append(
+                    f'  <text x="{x_offset + width/2}" y="{bar_y + bar_height/2 + 4}" text-anchor="middle" font-size="10" fill="white">{time:.1f}ms</text>'
+                )
+            x_offset += width
+
+    # Legend
+    legend_x = BREAKDOWN_WIDTH - margin["right"] + 20
+    legend_y = margin["top"] + 20
+
+    for i, pass_name in enumerate(PASS_ORDER):
+        y = legend_y + i * 22
+        color = PASS_COLORS.get(pass_name, "#888888")
+        time = pass_times.get(pass_name, 0)
+        pct = (time / total) * 100
+
+        svg_parts.append(f'  <rect x="{legend_x}" y="{y}" width="12" height="12" fill="{color}" rx="2"/>')
+        svg_parts.append(
+            f'  <text class="chart-text" x="{legend_x + 18}" y="{y + 10}" font-size="11">{pass_name} ({pct:.0f}%)</text>'
+        )
+
+    # Total time annotation
+    svg_parts.append(
+        f'  <text class="chart-text" x="{margin["left"]}" y="{bar_y + bar_height + 25}" font-size="12">Total: {total:.1f}ms</text>'
+    )
+
+    svg_parts.append("</svg>")
+    return "\n".join(svg_parts)
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(f"Usage: {sys.argv[0]} <history.json> <output-dir>", file=sys.stderr)
+        sys.exit(1)
+
+    history_path = Path(sys.argv[1])
+    output_dir = Path(sys.argv[2])
+
+    # Load history
+    history = load_history(history_path)
+    runs = history.get("runs", [])
+
+    print(f"Loaded {len(runs)} benchmark runs from {history_path}")
+
+    # Ensure output directory exists
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Generate charts
+    timeline_svg = generate_timeline_chart(runs)
+    breakdown_svg = generate_breakdown_chart(runs)
+
+    # Write output files
+    timeline_path = output_dir / "timeline.svg"
+    breakdown_path = output_dir / "breakdown.svg"
+
+    with open(timeline_path, "w") as f:
+        f.write(timeline_svg)
+    print(f"Generated {timeline_path}")
+
+    with open(breakdown_path, "w") as f:
+        f.write(breakdown_svg)
+    print(f"Generated {breakdown_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/website/build.sh
+++ b/website/build.sh
@@ -24,6 +24,12 @@ else
     find website/content/spec -name "*.md" -exec sed -i 's|@/\([0-9]\)|@/spec/\1|g' {} \;
 fi
 
+# Generate benchmark charts
+echo "Generating benchmark charts..."
+python3 "$ROOT/scripts/generate-charts.py" \
+    "$ROOT/website/static/benchmarks/history.json" \
+    "$ROOT/website/static/benchmarks/"
+
 # Build Tailwind CSS
 echo "Building Tailwind CSS..."
 cd website

--- a/website/content/performance.md
+++ b/website/content/performance.md
@@ -1,0 +1,7 @@
++++
+title = "Performance"
+template = "performance.html"
++++
+
+The Rue compiler is designed for fast compilation. This dashboard tracks compilation
+performance over time, helping detect regressions and measure the impact of optimizations.

--- a/website/css/input.css
+++ b/website/css/input.css
@@ -731,3 +731,36 @@ code {
     content: "[*]";
   }
 }
+
+/* ========================================
+   Performance Dashboard Charts
+   ======================================== */
+
+.benchmark-chart-container {
+  overflow-x: auto;
+}
+
+.benchmark-chart-container svg {
+  width: 100%;
+  height: auto;
+  min-width: 600px;
+}
+
+/* Override SVG chart colors for our theme system */
+.benchmark-chart {
+  --chart-bg: var(--color-surface);
+  --chart-text: var(--color-muted);
+  --chart-title: var(--color-fg);
+  --chart-accent: var(--color-accent);
+  --chart-grid: var(--color-border);
+  --chart-axis: var(--color-muted);
+}
+
+.dark .benchmark-chart {
+  --chart-bg: var(--color-surface-dark);
+  --chart-text: var(--color-muted-dark);
+  --chart-title: var(--color-fg-dark);
+  --chart-accent: var(--color-accent-dark);
+  --chart-grid: var(--color-border-dark);
+  --chart-axis: var(--color-muted-dark);
+}

--- a/website/static/benchmarks/breakdown.svg
+++ b/website/static/benchmarks/breakdown.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 350" class="benchmark-chart">
+  <style>
+    .chart-bg { fill: var(--chart-bg, #ffffff); }
+    .chart-text { fill: var(--chart-text, #6b7280); font-family: system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) {
+      .chart-bg { fill: #1a1a1a; }
+      .chart-text { fill: #9ca3af; }
+    }
+  </style>
+  <rect class="chart-bg" width="800" height="350" rx="8"/>
+  <text class="chart-text" x="400.0" y="175.0" text-anchor="middle" font-size="14">No benchmark data available yet</text>
+</svg>

--- a/website/static/benchmarks/timeline.svg
+++ b/website/static/benchmarks/timeline.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 300" class="benchmark-chart">
+  <style>
+    .chart-bg { fill: var(--chart-bg, #ffffff); }
+    .chart-text { fill: var(--chart-text, #6b7280); font-family: system-ui, sans-serif; }
+    @media (prefers-color-scheme: dark) {
+      .chart-bg { fill: #1a1a1a; }
+      .chart-text { fill: #9ca3af; }
+    }
+  </style>
+  <rect class="chart-bg" width="800" height="300" rx="8"/>
+  <text class="chart-text" x="400.0" y="150.0" text-anchor="middle" font-size="14">No benchmark data available yet</text>
+</svg>

--- a/website/templates/base.html
+++ b/website/templates/base.html
@@ -37,6 +37,7 @@
                     <li><a href="{{ get_url(path='/') }}" class="nav-link">Home</a></li>
                     <li><a href="{{ get_url(path='getting-started') }}" class="nav-link">Get Started</a></li>
                     <li><a href="{{ get_url(path='spec') }}" class="nav-link">Specification</a></li>
+                    <li><a href="{{ get_url(path='performance') }}" class="nav-link">Performance</a></li>
                     <li><a href="{{ get_url(path='blog') }}" class="nav-link">Blog</a></li>
                     <li><a href="{{ config.extra.github_url }}" class="nav-link">GitHub</a></li>
                     <li><a href="{{ config.extra.bluesky_url }}" class="nav-link">Bluesky</a></li>

--- a/website/templates/performance.html
+++ b/website/templates/performance.html
@@ -1,0 +1,65 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title }} | {{ config.title }}{% endblock %}
+
+{% block content %}
+<article class="py-12">
+    <div class="max-w-4xl mx-auto px-6">
+        <div class="prose mb-8">
+            <h1>{{ page.title }}</h1>
+            {{ page.content | safe }}
+        </div>
+
+        <!-- Timeline Chart -->
+        <section class="mb-12">
+            <h2 class="text-xl font-semibold mb-4">Compilation Time Trend</h2>
+            <p class="text-muted mb-4">
+                Total compilation time across the last 20 commits. Lower is better.
+            </p>
+            <div class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
+                {% set timeline = load_data(path="static/benchmarks/timeline.svg", format="plain") %}
+                {{ timeline | safe }}
+            </div>
+        </section>
+
+        <!-- Breakdown Chart -->
+        <section class="mb-12">
+            <h2 class="text-xl font-semibold mb-4">Time by Compiler Pass</h2>
+            <p class="text-muted mb-4">
+                Breakdown of where compilation time is spent in the most recent benchmark run.
+            </p>
+            <div class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
+                {% set breakdown = load_data(path="static/benchmarks/breakdown.svg", format="plain") %}
+                {{ breakdown | safe }}
+            </div>
+        </section>
+
+        <!-- Methodology -->
+        <section class="prose">
+            <h2>Methodology</h2>
+            <p>
+                These benchmarks are run automatically on every commit to the main branch.
+                Each benchmark is executed multiple times to reduce noise, and both mean
+                and standard deviation are recorded.
+            </p>
+            <h3>Benchmark Suite</h3>
+            <p>
+                The benchmark corpus includes hand-crafted stress tests that exercise
+                different parts of the compiler:
+            </p>
+            <ul>
+                <li><strong>many_functions</strong> - 100+ functions to stress function handling</li>
+                <li><strong>deep_nesting</strong> - Deeply nested blocks and expressions</li>
+                <li><strong>large_structs</strong> - Many struct types with multiple fields</li>
+                <li><strong>arithmetic_heavy</strong> - Lots of arithmetic expressions</li>
+                <li><strong>control_flow</strong> - Complex if/while/match patterns</li>
+            </ul>
+            <h3>Environment</h3>
+            <p>
+                Benchmarks run on GitHub Actions runners. While there is some variability
+                between runs, running multiple iterations helps smooth out noise.
+            </p>
+        </section>
+    </div>
+</article>
+{% endblock %}


### PR DESCRIPTION
Implement website visualization for the compiler performance dashboard:

- Create scripts/generate-charts.py for SVG chart generation
  - Timeline chart showing total compilation time over commits
  - Breakdown chart showing stacked bar of time per pass
  - Handles empty data gracefully with placeholder messages
  - Theme-aware colors using CSS variables

- Add /performance/ page to website
  - Zola template loading generated SVG charts
  - Methodology section describing benchmark suite
  - Navigation link in header

- Integrate into build pipeline
  - Chart generation runs during website/build.sh
  - Charts regenerated on each build from history.json

Closes rue-a5ah.5 (Phase 5: Website visualization) Closes rue-a5ah (Compiler Performance Dashboard epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)