### PR TITLE
Add file_id to Span for multi-file compilation

### DIFF
--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -7,6 +7,7 @@ mod logos_lexer;
 
 pub use logos_lexer::LogosLexer as Lexer;
 pub use rue_intern::{Interner, Symbol};
+pub use rue_span::FileId;
 use rue_span::Span;
 
 /// Token kinds in the Rue language.

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -6,7 +6,7 @@
 use logos::Logos;
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_intern::{Interner, Symbol};
-use rue_span::Span;
+use rue_span::{FileId, Span};
 
 /// Error type for lexing failures.
 #[derive(Debug, Clone, PartialEq, Eq, Default)]
@@ -331,20 +331,46 @@ impl From<LogosTokenKind> for TokenKind {
 pub struct LogosLexer<'a> {
     source: &'a str,
     interner: Interner,
+    file_id: FileId,
 }
 
 impl<'a> LogosLexer<'a> {
     /// Create a new lexer for the given source text with a fresh interner.
+    ///
+    /// Uses the default file ID. For multi-file compilation, use `with_file_id`.
     pub fn new(source: &'a str) -> Self {
         Self {
             source,
             interner: Interner::new(),
+            file_id: FileId::DEFAULT,
         }
     }
 
     /// Create a new lexer with an existing interner.
     pub fn with_interner(source: &'a str, interner: Interner) -> Self {
-        Self { source, interner }
+        Self {
+            source,
+            interner,
+            file_id: FileId::DEFAULT,
+        }
+    }
+
+    /// Create a new lexer with a specific file ID.
+    pub fn with_file_id(source: &'a str, file_id: FileId) -> Self {
+        Self {
+            source,
+            interner: Interner::new(),
+            file_id,
+        }
+    }
+
+    /// Create a new lexer with both an existing interner and a specific file ID.
+    pub fn with_interner_and_file_id(source: &'a str, interner: Interner, file_id: FileId) -> Self {
+        Self {
+            source,
+            interner,
+            file_id,
+        }
     }
 
     /// Tokenize the entire source, returning all tokens and the interner.
@@ -355,7 +381,6 @@ impl<'a> LogosLexer<'a> {
         let mut lexer = LogosTokenKind::lexer_with_extras(self.source, self.interner);
 
         loop {
-            let span_start = lexer.span().end;
             match lexer.next() {
                 Some(result) => {
                     let span = lexer.span();
@@ -363,11 +388,16 @@ impl<'a> LogosLexer<'a> {
                         Ok(logos_kind) => {
                             tokens.push(Token {
                                 kind: logos_kind.into(),
-                                span: Span::new(span.start as u32, span.end as u32),
+                                span: Span::with_file(
+                                    self.file_id,
+                                    span.start as u32,
+                                    span.end as u32,
+                                ),
                             });
                         }
                         Err(lex_error) => {
-                            let rue_span = Span::new(span.start as u32, span.end as u32);
+                            let rue_span =
+                                Span::with_file(self.file_id, span.start as u32, span.end as u32);
                             let slice = lexer.slice();
                             let error_char = slice.chars().next().unwrap_or('?');
                             let kind = match lex_error {
@@ -397,7 +427,7 @@ impl<'a> LogosLexer<'a> {
         let eof_pos = self.source.len() as u32;
         tokens.push(Token {
             kind: TokenKind::Eof,
-            span: Span::point(eof_pos),
+            span: Span::point_in_file(self.file_id, eof_pos),
         });
 
         // Extract the interner from the logos lexer

--- a/crates/rue-span/src/lib.rs
+++ b/crates/rue-span/src/lib.rs
@@ -3,12 +3,40 @@
 //! This crate provides the fundamental types for tracking source locations
 //! throughout the compilation pipeline.
 
+/// A file identifier used to track which source file a span belongs to.
+///
+/// File IDs are indices into a file table maintained by the compiler.
+/// `FileId(0)` is reserved as the default/unknown file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
+pub struct FileId(pub u32);
+
+impl FileId {
+    /// The default file ID, used for single-file compilation or when
+    /// the file is unknown.
+    pub const DEFAULT: FileId = FileId(0);
+
+    /// Create a new file ID from an index.
+    #[inline]
+    pub const fn new(id: u32) -> Self {
+        Self(id)
+    }
+
+    /// Get the raw index value.
+    #[inline]
+    pub const fn index(self) -> u32 {
+        self.0
+    }
+}
+
 /// A span representing a range in the source code.
 ///
-/// Spans use byte offsets into the source string. They are designed to be
-/// small (8 bytes) and cheap to copy.
+/// Spans use byte offsets into the source string and include a file identifier
+/// for multi-file compilation. They are designed to be small (12 bytes) and
+/// cheap to copy.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
 pub struct Span {
+    /// The file this span belongs to
+    pub file_id: FileId,
     /// Start byte offset (inclusive)
     pub start: u32,
     /// End byte offset (exclusive)
@@ -17,24 +45,56 @@ pub struct Span {
 
 impl Span {
     /// Create a new span from start and end byte offsets.
+    ///
+    /// Uses the default file ID. For multi-file compilation, use `with_file`.
     #[inline]
     pub const fn new(start: u32, end: u32) -> Self {
-        Self { start, end }
+        Self {
+            file_id: FileId::DEFAULT,
+            start,
+            end,
+        }
+    }
+
+    /// Create a new span with a specific file ID.
+    #[inline]
+    pub const fn with_file(file_id: FileId, start: u32, end: u32) -> Self {
+        Self {
+            file_id,
+            start,
+            end,
+        }
     }
 
     /// Create an empty span at a single position.
+    ///
+    /// Uses the default file ID. For multi-file compilation, use `point_in_file`.
     #[inline]
     pub const fn point(pos: u32) -> Self {
         Self {
+            file_id: FileId::DEFAULT,
+            start: pos,
+            end: pos,
+        }
+    }
+
+    /// Create an empty span at a single position in a specific file.
+    #[inline]
+    pub const fn point_in_file(file_id: FileId, pos: u32) -> Self {
+        Self {
+            file_id,
             start: pos,
             end: pos,
         }
     }
 
     /// Create a span covering two spans (from start of first to end of second).
+    ///
+    /// Uses the file ID from span `a`. Both spans should be from the same file.
     #[inline]
     pub const fn cover(a: Span, b: Span) -> Self {
         Self {
+            file_id: a.file_id,
             start: if a.start < b.start { a.start } else { b.start },
             end: if a.end > b.end { a.end } else { b.end },
         }
@@ -309,6 +369,7 @@ impl From<std::ops::Range<usize>> for Span {
     #[inline]
     fn from(range: std::ops::Range<usize>) -> Self {
         Self {
+            file_id: FileId::DEFAULT,
             start: range.start as u32,
             end: range.end as u32,
         }
@@ -319,6 +380,7 @@ impl From<std::ops::Range<u32>> for Span {
     #[inline]
     fn from(range: std::ops::Range<u32>) -> Self {
         Self {
+            file_id: FileId::DEFAULT,
             start: range.start,
             end: range.end,
         }
@@ -331,8 +393,43 @@ mod tests {
 
     #[test]
     fn test_span_size() {
-        // Ensure Span stays small
-        assert_eq!(std::mem::size_of::<Span>(), 8);
+        // Ensure Span stays small (12 bytes with file_id)
+        assert_eq!(std::mem::size_of::<Span>(), 12);
+    }
+
+    #[test]
+    fn test_file_id() {
+        assert_eq!(FileId::DEFAULT.index(), 0);
+        assert_eq!(FileId::new(42).index(), 42);
+    }
+
+    #[test]
+    fn test_span_with_file() {
+        let file = FileId::new(5);
+        let span = Span::with_file(file, 10, 20);
+        assert_eq!(span.file_id, file);
+        assert_eq!(span.start, 10);
+        assert_eq!(span.end, 20);
+    }
+
+    #[test]
+    fn test_span_point_in_file() {
+        let file = FileId::new(3);
+        let span = Span::point_in_file(file, 15);
+        assert_eq!(span.file_id, file);
+        assert_eq!(span.start, 15);
+        assert_eq!(span.end, 15);
+    }
+
+    #[test]
+    fn test_span_cover_preserves_file_id() {
+        let file = FileId::new(7);
+        let a = Span::with_file(file, 5, 10);
+        let b = Span::with_file(file, 15, 20);
+        let covered = Span::cover(a, b);
+        assert_eq!(covered.file_id, file);
+        assert_eq!(covered.start, 5);
+        assert_eq!(covered.end, 20);
     }
 
     #[test]


### PR DESCRIPTION
- Add FileId type to rue-span for tracking source files
- Expand Span from 8 to 12 bytes to include file_id field
- Add Span::with_file() and Span::point_in_file() constructors
- Update Lexer to accept file_id via with_file_id() constructor
- Re-export FileId from rue-lexer for convenience

This enables future multi-file compilation by associating each span with its source file. Currently uses FileId::DEFAULT (0) for single-file compilation, maintaining backward compatibility.

Closes: rue-bdlb

🤖 Generated with [Claude Code](https://claude.com/claude-code)