### PR TITLE
Fix website deploy to fetch benchmark data from perf branch

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -6,13 +6,20 @@ on:
     paths:
       - 'website/**'
       - 'docs/spec/**'
+      - 'scripts/generate-charts.py'
       - '.github/workflows/deploy-website.yml'
   pull_request:
     branches: [trunk]
     paths:
       - 'website/**'
       - 'docs/spec/**'
+      - 'scripts/generate-charts.py'
       - '.github/workflows/deploy-website.yml'
+  # Trigger when benchmarks complete (updates perf branch with new data)
+  workflow_run:
+    workflows: ["Benchmarks"]
+    types: [completed]
+    branches: [trunk]
   workflow_dispatch:
 
 permissions:
@@ -33,6 +40,20 @@ jobs:
 
       - name: Setup dotslash
         uses: facebook/install-dotslash@latest
+
+      - name: Fetch benchmark data from perf branch
+        run: |
+          # Try to fetch benchmark history from the perf branch
+          # This may fail if the perf branch doesn't exist yet (new repos)
+          if git fetch origin perf --depth=1 2>/dev/null; then
+            mkdir -p website/static/benchmarks
+            git show origin/perf:benchmarks/history.json > website/static/benchmarks/history.json 2>/dev/null || echo '{"version": 1, "runs": []}' > website/static/benchmarks/history.json
+            echo "Fetched benchmark history from perf branch"
+          else
+            echo "Perf branch not found, using empty benchmark history"
+            mkdir -p website/static/benchmarks
+            echo '{"version": 1, "runs": []}' > website/static/benchmarks/history.json
+          fi
 
       - name: Build website
         run: website/build.sh


### PR DESCRIPTION
The performance dashboard was showing 'No benchmark data available yet' because the website build wasn't fetching history.json from the perf branch where CI pushes benchmark results.

Changes:
- Add step to fetch benchmarks/history.json from perf branch before building
- Add workflow_run trigger so website rebuilds after Benchmarks workflow completes
- Add scripts/generate-charts.py to path triggers

🤖 Generated with [Claude Code](https://claude.com/claude-code)