### PR TITLE
Use Symbol instead of String in CfgInstData::Call and Intrinsic

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -641,11 +641,9 @@ impl<'a> CfgBuilder<'a> {
                         mode: Self::convert_arg_mode(arg.mode),
                     });
                 }
-                // Convert Symbol to String for CFG (CFG will adopt Symbol in rue-iom9)
-                let name_str = self.interner.get(*name).to_string();
                 let value = self.emit(
                     CfgInstData::Call {
-                        name: name_str,
+                        name: *name,
                         args: arg_vals,
                     },
                     ty,
@@ -666,9 +664,11 @@ impl<'a> CfgBuilder<'a> {
                     };
                     arg_vals.push(val);
                 }
+                // Intern the intrinsic name since AIR still uses String
+                let name_sym = self.interner.intern(name);
                 let value = self.emit(
                     CfgInstData::Intrinsic {
-                        name: name.clone(),
+                        name: name_sym,
                         args: arg_vals,
                     },
                     ty,

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -6,6 +6,7 @@
 use std::fmt;
 
 use rue_air::{ArrayTypeId, EnumId, StructId, Type};
+use rue_intern::Symbol;
 use rue_span::Span;
 
 /// A basic block identifier.
@@ -178,13 +179,15 @@ pub enum CfgInstData {
 
     // Function calls
     Call {
-        name: String,
+        /// Function name (interned symbol)
+        name: Symbol,
         args: Vec<CfgCallArg>,
     },
 
     /// Intrinsic call (e.g., @dbg)
     Intrinsic {
-        name: String,
+        /// Intrinsic name (interned symbol)
+        name: Symbol,
         args: Vec<CfgValue>,
     },
 
@@ -716,7 +719,8 @@ impl Cfg {
                 write!(f, "param_store %{} = {}", param_slot, value)
             }
             CfgInstData::Call { name, args } => {
-                write!(f, "call {}(", name)?;
+                // Display symbol as @{id} since we don't have interner access here
+                write!(f, "call @{}(", name.as_u32())?;
                 for (i, arg) in args.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;
@@ -730,7 +734,8 @@ impl Cfg {
                 write!(f, ")")
             }
             CfgInstData::Intrinsic { name, args } => {
-                write!(f, "intrinsic @{}(", name)?;
+                // Display symbol as @{id} since we don't have interner access here
+                write!(f, "intrinsic @{}(", name.as_u32())?;
                 for (i, arg) in args.iter().enumerate() {
                     if i > 0 {
                         write!(f, ", ")?;

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -288,6 +288,7 @@ mod tests {
     use super::*;
     use crate::{CfgInst, CfgInstData};
     use rue_air::Type;
+    use rue_intern::Interner;
     use rue_span::Span;
 
     fn make_cfg() -> Cfg {
@@ -452,11 +453,13 @@ mod tests {
         let entry = cfg.entry;
 
         // Create a call (side effect) that's not used by return
+        let interner = Interner::new();
+        let side_effect_sym = interner.intern("side_effect");
         let call = cfg.add_inst_to_block(
             entry,
             CfgInst {
                 data: CfgInstData::Call {
-                    name: "side_effect".to_string(),
+                    name: side_effect_sym,
                     args: vec![],
                 },
                 ty: Type::Unit,
@@ -480,7 +483,7 @@ mod tests {
 
         // Call should be preserved (side effect)
         match &cfg.get_inst(call).data {
-            CfgInstData::Call { name, .. } if name == "side_effect" => {}
+            CfgInstData::Call { name, .. } if *name == side_effect_sym => {}
             other => panic!("Expected Call, got {:?}", other),
         }
     }

--- a/crates/rue-codegen/BUCK
+++ b/crates/rue-codegen/BUCK
@@ -5,6 +5,7 @@ rust_library(
         "//crates/rue-air:rue-air",
         "//crates/rue-cfg:rue-cfg",
         "//crates/rue-error:rue-error",
+        "//crates/rue-intern:rue-intern",
         "//crates/rue-span:rue-span",
         "//crates/rue-target:rue-target",
     ],

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -9,6 +9,7 @@ use rue_air::{ArrayTypeDef, ArrayTypeId};
 use rue_cfg::{
     BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, StructDef, StructId, Terminator, Type,
 };
+use rue_intern::Interner;
 
 use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Operand, Reg, VReg};
 use crate::cfg_lower::{FieldChainBase, IndexChainBase, IndexLevel};
@@ -46,6 +47,8 @@ pub struct CfgLower<'a> {
     array_types: &'a [ArrayTypeDef],
     /// String table from semantic analysis (indexed by StringId).
     strings: &'a [String],
+    /// Interner for resolving Symbol to string
+    interner: &'a Interner,
     mir: Aarch64Mir,
     /// Maps CFG values to vregs
     value_map: HashMap<CfgValue, VReg>,
@@ -72,6 +75,7 @@ impl<'a> CfgLower<'a> {
         struct_defs: &'a [StructDef],
         array_types: &'a [ArrayTypeDef],
         strings: &'a [String],
+        interner: &'a Interner,
     ) -> Self {
         let num_locals = cfg.num_locals();
         let num_params = cfg.num_params();
@@ -80,6 +84,7 @@ impl<'a> CfgLower<'a> {
             struct_defs,
             array_types,
             strings,
+            interner,
             mir: Aarch64Mir::new(),
             value_map: HashMap::new(),
             block_param_vregs: HashMap::new(),
@@ -1694,7 +1699,7 @@ impl<'a> CfgLower<'a> {
 
                 // Call the function - the linker will add the underscore prefix for macOS
                 self.mir.push(Aarch64Inst::Bl {
-                    symbol: name.clone(),
+                    symbol: self.interner.get(*name).to_string(),
                 });
 
                 // Clean up stack space after call
@@ -1762,7 +1767,8 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::Intrinsic { name, args } => {
-                if name == "dbg" {
+                let name_str = self.interner.get(*name);
+                if name_str == "dbg" {
                     let arg_val = args[0];
                     let arg_type = self.cfg.get_inst(arg_val).ty;
 
@@ -3600,7 +3606,14 @@ mod tests {
             &interner,
         );
 
-        CfgLower::new(&cfg_output.cfg, struct_defs, array_types, strings).lower()
+        CfgLower::new(
+            &cfg_output.cfg,
+            struct_defs,
+            array_types,
+            strings,
+            &interner,
+        )
+        .lower()
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -25,6 +25,7 @@ pub use regalloc::RegAlloc;
 use rue_air::{ArrayTypeDef, StructDef};
 use rue_cfg::Cfg;
 use rue_error::CompileResult;
+use rue_intern::Interner;
 
 use crate::MachineCode;
 use crate::regalloc::RegAllocDebugInfo;
@@ -40,12 +41,13 @@ pub fn generate(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
 ) -> CompileResult<MachineCode> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+    let mir = CfgLower::new(cfg, struct_defs, array_types, strings, interner).lower();
 
     // Allocate physical registers
     let existing_slots = num_locals + num_params;
@@ -73,12 +75,13 @@ pub fn generate_with_asm(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
 ) -> CompileResult<(MachineCode, String)> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+    let mir = CfgLower::new(cfg, struct_defs, array_types, strings, interner).lower();
 
     // Allocate physical registers
     let existing_slots = num_locals + num_params;
@@ -109,12 +112,13 @@ pub fn generate_regalloc_info(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
 ) -> CompileResult<RegAllocDebugInfo<Reg>> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+    let mir = CfgLower::new(cfg, struct_defs, array_types, strings, interner).lower();
 
     // Allocate physical registers with debug info
     let existing_slots = num_locals + num_params;

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -144,7 +144,8 @@ pub fn format_cfg_inst_data(data: &rue_cfg::CfgInstData) -> String {
                 .map(|a| format!("{}", a.value))
                 .collect::<Vec<_>>()
                 .join(", ");
-            format!("call {}({})", name, args_str)
+            // Display symbol as @{id} since we don't have interner access
+            format!("call @{}({})", name.as_u32(), args_str)
         }
         CfgInstData::Intrinsic { name, args } => {
             let args_str = args
@@ -152,7 +153,8 @@ pub fn format_cfg_inst_data(data: &rue_cfg::CfgInstData) -> String {
                 .map(|a| format!("{}", a))
                 .collect::<Vec<_>>()
                 .join(", ");
-            format!("intrinsic @{}({})", name, args_str)
+            // Display symbol as @{id} since we don't have interner access
+            format!("intrinsic @{}({})", name.as_u32(), args_str)
         }
         CfgInstData::StructInit { struct_id, fields } => {
             let fields_str = fields

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -329,7 +329,7 @@ mod tests {
         let cfg_output = CfgBuilder::build(&air, 0, 0, "main", &[], &[], vec![], &interner);
 
         // Test the generate function
-        let machine_code = generate(&cfg_output.cfg, &[], &[], &[]).unwrap();
+        let machine_code = generate(&cfg_output.cfg, &[], &[], &[], &interner).unwrap();
 
         // Should generate working code
         assert!(!machine_code.code.is_empty());

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -7,6 +7,7 @@
 use rue_air::{ArrayTypeDef, StructDef};
 use rue_cfg::Cfg;
 use rue_error::CompileResult;
+use rue_intern::Interner;
 use rue_target::{Arch, Target};
 
 /// A slot on the stack (local variable or spill slot).
@@ -256,6 +257,7 @@ pub fn generate_stack_frame_info(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
     target: Target,
 ) -> CompileResult<StackFrameInfo> {
     match target.arch() {
@@ -265,6 +267,7 @@ pub fn generate_stack_frame_info(
             struct_defs,
             array_types,
             strings,
+            interner,
             target,
         ),
         Arch::Aarch64 => generate_aarch64_stack_frame(
@@ -273,6 +276,7 @@ pub fn generate_stack_frame_info(
             struct_defs,
             array_types,
             strings,
+            interner,
             target,
         ),
     }
@@ -285,6 +289,7 @@ fn generate_x86_64_stack_frame(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
     target: Target,
 ) -> CompileResult<StackFrameInfo> {
     use crate::x86_64::{CfgLower, RegAlloc};
@@ -293,7 +298,7 @@ fn generate_x86_64_stack_frame(
     let num_params = cfg.num_params();
 
     // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+    let mir = CfgLower::new(cfg, struct_defs, array_types, strings, interner).lower();
 
     // Allocate physical registers (may add spill slots)
     let existing_slots = num_locals + num_params;
@@ -408,6 +413,7 @@ fn generate_aarch64_stack_frame(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
     target: Target,
 ) -> CompileResult<StackFrameInfo> {
     use crate::aarch64::{CfgLower, RegAlloc};
@@ -416,7 +422,7 @@ fn generate_aarch64_stack_frame(
     let num_params = cfg.num_params();
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+    let mir = CfgLower::new(cfg, struct_defs, array_types, strings, interner).lower();
 
     // Allocate physical registers (may add spill slots)
     let existing_slots = num_locals + num_params;
@@ -558,7 +564,7 @@ mod tests {
     use rue_intern::Interner;
     use rue_span::Span;
 
-    fn create_simple_cfg() -> (rue_cfg::Cfg, Vec<StructDef>, Vec<ArrayTypeDef>) {
+    fn create_simple_cfg() -> (rue_cfg::Cfg, Vec<StructDef>, Vec<ArrayTypeDef>, Interner) {
         let mut air = Air::new(Type::I32);
 
         let const_ref = air.add_inst(AirInst {
@@ -575,16 +581,24 @@ mod tests {
 
         let interner = Interner::new();
         let cfg_output = CfgBuilder::build(&air, 0, 0, "test", &[], &[], vec![], &interner);
-        (cfg_output.cfg, vec![], vec![])
+        (cfg_output.cfg, vec![], vec![], interner)
     }
 
     #[test]
     fn test_generate_stack_frame_info_x86_64() {
-        let (cfg, struct_defs, array_types) = create_simple_cfg();
+        let (cfg, struct_defs, array_types, interner) = create_simple_cfg();
         let target = Target::X86_64Linux;
 
-        let info = generate_stack_frame_info(&cfg, "test", &struct_defs, &array_types, &[], target)
-            .unwrap();
+        let info = generate_stack_frame_info(
+            &cfg,
+            "test",
+            &struct_defs,
+            &array_types,
+            &[],
+            &interner,
+            target,
+        )
+        .unwrap();
 
         assert_eq!(info.function_name, "test");
         assert_eq!(info.alignment, 16);

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -31,6 +31,7 @@ use rue_air::{ArrayTypeDef, ArrayTypeId};
 use rue_cfg::{
     BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, StructDef, StructId, Terminator, Type,
 };
+use rue_intern::Interner;
 
 use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
 use crate::cfg_lower::{FieldChainBase, IndexChainBase, IndexLevel};
@@ -51,6 +52,8 @@ pub struct CfgLower<'a> {
     array_types: &'a [ArrayTypeDef],
     /// String table from semantic analysis (indexed by StringId).
     strings: &'a [String],
+    /// Interner for resolving Symbol to string
+    interner: &'a Interner,
     mir: X86Mir,
     /// Maps CFG values to vregs
     value_map: HashMap<CfgValue, VReg>,
@@ -82,6 +85,7 @@ impl<'a> CfgLower<'a> {
         struct_defs: &'a [StructDef],
         array_types: &'a [ArrayTypeDef],
         strings: &'a [String],
+        interner: &'a Interner,
     ) -> Self {
         let num_locals = cfg.num_locals();
         let num_params = cfg.num_params();
@@ -90,6 +94,7 @@ impl<'a> CfgLower<'a> {
             struct_defs,
             array_types,
             strings,
+            interner,
             mir: X86Mir::new(),
             value_map: HashMap::new(),
             block_param_vregs: HashMap::new(),
@@ -1827,7 +1832,7 @@ impl<'a> CfgLower<'a> {
                 }
 
                 self.mir.push(X86Inst::CallRel {
-                    symbol: name.clone(),
+                    symbol: self.interner.get(*name).to_string(),
                 });
 
                 // Clean up stack arguments
@@ -1893,7 +1898,8 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::Intrinsic { name, args } => {
-                if name == "dbg" {
+                let name_str = self.interner.get(*name);
+                if name_str == "dbg" {
                     let arg_val = args[0];
                     let arg_type = self.cfg.get_inst(arg_val).ty;
 
@@ -3463,7 +3469,14 @@ mod tests {
             &interner,
         );
 
-        CfgLower::new(&cfg_output.cfg, struct_defs, array_types, strings).lower()
+        CfgLower::new(
+            &cfg_output.cfg,
+            struct_defs,
+            array_types,
+            strings,
+            &interner,
+        )
+        .lower()
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -27,6 +27,7 @@ use crate::regalloc::RegAllocDebugInfo;
 use rue_air::{ArrayTypeDef, StructDef};
 use rue_cfg::Cfg;
 use rue_error::CompileResult;
+use rue_intern::Interner;
 
 // Re-export from parent
 pub use super::{EmittedCode, EmittedRelocation, MachineCode};
@@ -40,12 +41,13 @@ pub fn generate(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
 ) -> CompileResult<MachineCode> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
 
     // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+    let mir = CfgLower::new(cfg, struct_defs, array_types, strings, interner).lower();
 
     // Allocate physical registers (may add spill slots)
     // Spill slots go after both locals AND parameters to avoid conflicts
@@ -84,12 +86,13 @@ pub fn generate_with_asm(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
 ) -> CompileResult<(MachineCode, String)> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
 
     // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+    let mir = CfgLower::new(cfg, struct_defs, array_types, strings, interner).lower();
 
     // Allocate physical registers (may add spill slots)
     let existing_slots = num_locals + num_params;
@@ -127,12 +130,13 @@ pub fn generate_regalloc_info(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
 ) -> CompileResult<RegAllocDebugInfo<Reg>> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
 
     // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+    let mir = CfgLower::new(cfg, struct_defs, array_types, strings, interner).lower();
 
     // Allocate physical registers with debug info
     let existing_slots = num_locals + num_params;

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -483,6 +483,7 @@ fn compile_x86_64(state: &CompileState, options: &CompileOptions) -> CompileResu
                 &state.struct_defs,
                 &state.array_types,
                 &state.strings,
+                &state.interner,
             )?;
             total_code_bytes += machine_code.code.len();
 
@@ -679,6 +680,7 @@ fn compile_aarch64(state: &CompileState, options: &CompileOptions) -> CompileRes
                 &state.struct_defs,
                 &state.array_types,
                 &state.strings,
+                &state.interner,
             )?;
             total_code_bytes += machine_code.code.len();
 
@@ -791,17 +793,30 @@ pub fn generate_mir(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
     target: Target,
 ) -> Mir {
     match target.arch() {
         Arch::X86_64 => {
-            let mir =
-                rue_codegen::x86_64::CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+            let mir = rue_codegen::x86_64::CfgLower::new(
+                cfg,
+                struct_defs,
+                array_types,
+                strings,
+                interner,
+            )
+            .lower();
             Mir::X86_64(mir)
         }
         Arch::Aarch64 => {
-            let mir =
-                rue_codegen::aarch64::CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+            let mir = rue_codegen::aarch64::CfgLower::new(
+                cfg,
+                struct_defs,
+                array_types,
+                strings,
+                interner,
+            )
+            .lower();
             Mir::Aarch64(mir)
         }
     }
@@ -816,6 +831,7 @@ pub fn generate_allocated_mir(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
     target: Target,
 ) -> CompileResult<Mir> {
     let num_locals = cfg.num_locals();
@@ -825,8 +841,14 @@ pub fn generate_allocated_mir(
     match target.arch() {
         Arch::X86_64 => {
             // Lower CFG to X86Mir with virtual registers
-            let mir =
-                rue_codegen::x86_64::CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+            let mir = rue_codegen::x86_64::CfgLower::new(
+                cfg,
+                struct_defs,
+                array_types,
+                strings,
+                interner,
+            )
+            .lower();
 
             // Allocate physical registers
             let (mir, _num_spills, _used_callee_saved) =
@@ -836,8 +858,14 @@ pub fn generate_allocated_mir(
         }
         Arch::Aarch64 => {
             // Lower CFG to Aarch64Mir with virtual registers
-            let mir =
-                rue_codegen::aarch64::CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+            let mir = rue_codegen::aarch64::CfgLower::new(
+                cfg,
+                struct_defs,
+                array_types,
+                strings,
+                interner,
+            )
+            .lower();
 
             // Allocate physical registers
             let (mir, _num_spills, _used_callee_saved) =
@@ -859,17 +887,30 @@ pub fn generate_liveness_info(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
     target: Target,
 ) -> rue_codegen::LivenessDebugInfo {
     match target.arch() {
         Arch::X86_64 => {
-            let mir =
-                rue_codegen::x86_64::CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+            let mir = rue_codegen::x86_64::CfgLower::new(
+                cfg,
+                struct_defs,
+                array_types,
+                strings,
+                interner,
+            )
+            .lower();
             rue_codegen::x86_64::liveness::analyze_debug(&mir)
         }
         Arch::Aarch64 => {
-            let mir =
-                rue_codegen::aarch64::CfgLower::new(cfg, struct_defs, array_types, strings).lower();
+            let mir = rue_codegen::aarch64::CfgLower::new(
+                cfg,
+                struct_defs,
+                array_types,
+                strings,
+                interner,
+            )
+            .lower();
             rue_codegen::aarch64::liveness::analyze_debug(&mir)
         }
     }
@@ -886,19 +927,30 @@ pub fn generate_lowering_info(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
     target: Target,
 ) -> rue_codegen::LoweringDebugInfo {
     match target.arch() {
         Arch::X86_64 => {
-            let (_mir, debug_info) =
-                rue_codegen::x86_64::CfgLower::new(cfg, struct_defs, array_types, strings)
-                    .lower_with_debug();
+            let (_mir, debug_info) = rue_codegen::x86_64::CfgLower::new(
+                cfg,
+                struct_defs,
+                array_types,
+                strings,
+                interner,
+            )
+            .lower_with_debug();
             debug_info
         }
         Arch::Aarch64 => {
-            let (_mir, debug_info) =
-                rue_codegen::aarch64::CfgLower::new(cfg, struct_defs, array_types, strings)
-                    .lower_with_debug();
+            let (_mir, debug_info) = rue_codegen::aarch64::CfgLower::new(
+                cfg,
+                struct_defs,
+                array_types,
+                strings,
+                interner,
+            )
+            .lower_with_debug();
             debug_info
         }
     }
@@ -917,17 +969,28 @@ pub fn generate_emitted_asm(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
     target: Target,
 ) -> CompileResult<String> {
     match target.arch() {
         Arch::X86_64 => {
-            let (_machine_code, asm) =
-                rue_codegen::x86_64::generate_with_asm(cfg, struct_defs, array_types, strings)?;
+            let (_machine_code, asm) = rue_codegen::x86_64::generate_with_asm(
+                cfg,
+                struct_defs,
+                array_types,
+                strings,
+                interner,
+            )?;
             Ok(asm)
         }
         Arch::Aarch64 => {
-            let (_machine_code, asm) =
-                rue_codegen::aarch64::generate_with_asm(cfg, struct_defs, array_types, strings)?;
+            let (_machine_code, asm) = rue_codegen::aarch64::generate_with_asm(
+                cfg,
+                struct_defs,
+                array_types,
+                strings,
+                interner,
+            )?;
             Ok(asm)
         }
     }
@@ -943,6 +1006,7 @@ pub fn generate_regalloc_info(
     struct_defs: &[StructDef],
     array_types: &[ArrayTypeDef],
     strings: &[String],
+    interner: &Interner,
     target: Target,
 ) -> CompileResult<String> {
     match target.arch() {
@@ -952,6 +1016,7 @@ pub fn generate_regalloc_info(
                 struct_defs,
                 array_types,
                 strings,
+                interner,
             )?;
             Ok(debug_info.to_string())
         }
@@ -961,6 +1026,7 @@ pub fn generate_regalloc_info(
                 struct_defs,
                 array_types,
                 strings,
+                interner,
             )?;
             Ok(debug_info.to_string())
         }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -846,6 +846,7 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
                             &state.struct_defs,
                             &state.array_types,
                             &state.strings,
+                            &state.interner,
                             options.target,
                         );
                         print!("{}", lowering_info);
@@ -862,6 +863,7 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
                             &state.struct_defs,
                             &state.array_types,
                             &state.strings,
+                            &state.interner,
                             options.target,
                         );
                         println!("function {}:", func.analyzed.name);
@@ -880,6 +882,7 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
                             &state.struct_defs,
                             &state.array_types,
                             &state.strings,
+                            &state.interner,
                             options.target,
                         );
                         println!("{}", liveness_info);
@@ -897,6 +900,7 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
                             &state.struct_defs,
                             &state.array_types,
                             &state.strings,
+                            &state.interner,
                             options.target,
                         ) {
                             Ok(info) => info,
@@ -921,6 +925,7 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
                             &state.struct_defs,
                             &state.array_types,
                             &state.strings,
+                            &state.interner,
                             options.target,
                         ) {
                             Ok(asm) => asm,
@@ -943,6 +948,7 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
                             &state.struct_defs,
                             &state.array_types,
                             &state.strings,
+                            &state.interner,
                             options.target,
                         ) {
                             Ok(info) => info,


### PR DESCRIPTION
Change CFG IR to use interned symbols (Symbol) instead of heap-allocated strings for function names in Call and Intrinsic instructions. This reduces memory allocations and is more consistent with AIR which already uses Symbol for function calls.

- Changed CfgInstData::Call.name from String to Symbol
- Changed CfgInstData::Intrinsic.name from String to Symbol  
- Added interner parameter to all codegen functions that resolve symbols
- Updated CFG builder to pass symbols directly for calls
- Updated both x86_64 and aarch64 backends

Fixes rue-iom9

🤖 Generated with [Claude Code](https://claude.ai/code)