### PR TITLE
feat(sema): collect errors from multiple functions

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -15,8 +15,8 @@ use crate::types::{
     parse_array_type_syntax,
 };
 use rue_error::{
-    CompileError, CompileResult, CompileWarning, ErrorKind, OptionExt, PreviewFeature,
-    PreviewFeatures, WarningKind,
+    CompileError, CompileErrors, CompileResult, CompileWarning, ErrorKind, MultiErrorResult,
+    OptionExt, PreviewFeature, PreviewFeatures, WarningKind,
 };
 use rue_intern::{Interner, Symbol};
 use rue_rir::{
@@ -547,24 +547,37 @@ impl<'a> Sema<'a> {
     ///
     /// Consumes the Sema and returns a [`SemaOutput`] containing all analyzed
     /// functions, struct definitions, enum definitions, and any warnings generated during analysis.
-    pub fn analyze_all(mut self) -> CompileResult<SemaOutput> {
+    ///
+    /// This function collects errors from multiple functions instead of stopping at the
+    /// first error, allowing users to see all issues at once. Errors within type/struct
+    /// definitions still cause early termination since they affect all subsequent analysis.
+    pub fn analyze_all(mut self) -> MultiErrorResult<SemaOutput> {
         // First pass: collect type definitions (enums then structs)
         // Enums must be collected first so struct fields can reference enum types
-        self.collect_enum_definitions()?;
-        self.collect_struct_definitions()?;
+        // These are critical and must succeed before we can analyze functions
+        self.collect_enum_definitions()
+            .map_err(CompileErrors::from)?;
+        self.collect_struct_definitions()
+            .map_err(CompileErrors::from)?;
 
         // Validate @copy struct fields are all Copy types
-        self.validate_copy_structs()?;
+        self.validate_copy_structs().map_err(CompileErrors::from)?;
 
         // Collect user-defined destructors
-        self.collect_destructor_definitions()?;
+        self.collect_destructor_definitions()
+            .map_err(CompileErrors::from)?;
 
         // Second pass: collect function and method signatures
-        self.collect_function_signatures()?;
-        self.collect_method_definitions()?;
+        // These are also critical since they affect type checking of calls
+        self.collect_function_signatures()
+            .map_err(CompileErrors::from)?;
+        self.collect_method_definitions()
+            .map_err(CompileErrors::from)?;
 
-        // Third pass: analyze regular function bodies (not methods)
+        // Now analyze function bodies - these can be analyzed independently
+        // so we collect errors from all of them instead of stopping at the first
         let mut functions = Vec::new();
+        let mut errors = CompileErrors::new();
 
         // Collect method refs from impl blocks so we can skip them in the first pass
         let mut method_refs: HashSet<InstRef> = HashSet::new();
@@ -593,27 +606,13 @@ impl<'a> Sema<'a> {
                 }
 
                 let fn_name = self.interner.get(*name).to_string();
-                let ret_type = self.resolve_type(*return_type, inst.span)?;
 
-                // Resolve parameter types and modes
-                let param_info: Vec<(Symbol, Type, RirParamMode)> = params
-                    .iter()
-                    .map(|p| {
-                        let ty = self.resolve_type(p.ty, inst.span)?;
-                        Ok((p.name, ty, p.mode))
-                    })
-                    .collect::<CompileResult<Vec<_>>>()?;
-
-                let (air, num_locals, num_param_slots, param_modes) =
-                    self.analyze_function(ret_type, &param_info, *body)?;
-
-                functions.push(AnalyzedFunction {
-                    name: fn_name,
-                    air,
-                    num_locals,
-                    num_param_slots,
-                    param_modes,
-                });
+                // Try to analyze this function - on error, record it and continue
+                match self.analyze_single_function(&fn_name, *return_type, params, *body, inst.span)
+                {
+                    Ok(analyzed) => functions.push(analyzed),
+                    Err(e) => errors.push(e),
+                }
             }
         }
 
@@ -636,26 +635,6 @@ impl<'a> Sema<'a> {
                     } = &method_inst.data
                     {
                         let method_name_str = self.interner.get(*method_name).to_string();
-                        let ret_type = self.resolve_type(*return_type, method_inst.span)?;
-
-                        // Build parameter list, adding self as first parameter for methods
-                        // Note: self is passed by value (Normal mode) for now
-                        let mut param_info: Vec<(Symbol, Type, RirParamMode)> = Vec::new();
-
-                        if *has_self {
-                            // Add self parameter (Normal mode - passed by value)
-                            let self_sym = self.interner.intern("self");
-                            param_info.push((self_sym, struct_type, RirParamMode::Normal));
-                        }
-
-                        // Add regular parameters with their modes
-                        for p in params.iter() {
-                            let ty = self.resolve_type(p.ty, method_inst.span)?;
-                            param_info.push((p.name, ty, p.mode));
-                        }
-
-                        let (air, num_locals, num_param_slots, param_modes) =
-                            self.analyze_function(ret_type, &param_info, *body)?;
 
                         // Generate method name with struct prefix: "Type.method" or "Type::function"
                         let full_name = if *has_self {
@@ -664,13 +643,19 @@ impl<'a> Sema<'a> {
                             format!("{}::{}", type_name_str, method_name_str)
                         };
 
-                        functions.push(AnalyzedFunction {
-                            name: full_name,
-                            air,
-                            num_locals,
-                            num_param_slots,
-                            param_modes,
-                        });
+                        // Try to analyze this method - on error, record it and continue
+                        match self.analyze_method_function(
+                            &full_name,
+                            *return_type,
+                            params,
+                            *body,
+                            method_inst.span,
+                            struct_type,
+                            *has_self,
+                        ) {
+                            Ok(analyzed) => functions.push(analyzed),
+                            Err(e) => errors.push(e),
+                        }
                     }
                 }
             }
@@ -683,35 +668,125 @@ impl<'a> Sema<'a> {
                 let struct_id = *self.structs.get(type_name).unwrap();
                 let struct_type = Type::Struct(struct_id);
 
-                // Destructors take self parameter and return unit
-                // self is passed by value (Normal mode) - the destructor consumes it
-                let self_sym = self.interner.intern("self");
-                let param_info: Vec<(Symbol, Type, RirParamMode)> =
-                    vec![(self_sym, struct_type, RirParamMode::Normal)];
-
-                let (air, num_locals, num_param_slots, param_modes) =
-                    self.analyze_function(Type::Unit, &param_info, *body)?;
-
                 // Generate destructor name: "TypeName.__drop"
                 let full_name = format!("{}.__drop", type_name_str);
 
-                functions.push(AnalyzedFunction {
-                    name: full_name,
-                    air,
-                    num_locals,
-                    num_param_slots,
-                    param_modes,
-                });
+                // Try to analyze destructor - on error, record it and continue
+                match self.analyze_destructor_function(&full_name, *body, inst.span, struct_type) {
+                    Ok(analyzed) => functions.push(analyzed),
+                    Err(e) => errors.push(e),
+                }
             }
         }
 
-        Ok(SemaOutput {
+        // Return errors if any were collected
+        errors.into_result_with(SemaOutput {
             functions,
             struct_defs: self.struct_defs,
             enum_defs: self.enum_defs,
             array_types: self.array_type_defs,
             strings: self.strings,
             warnings: self.warnings,
+        })
+    }
+
+    /// Analyze a single regular function.
+    ///
+    /// This helper factors out the function analysis logic to make error
+    /// collection cleaner in analyze_all.
+    fn analyze_single_function(
+        &mut self,
+        fn_name: &str,
+        return_type: Symbol,
+        params: &[rue_rir::RirParam],
+        body: InstRef,
+        span: Span,
+    ) -> CompileResult<AnalyzedFunction> {
+        let ret_type = self.resolve_type(return_type, span)?;
+
+        // Resolve parameter types and modes
+        let param_info: Vec<(Symbol, Type, RirParamMode)> = params
+            .iter()
+            .map(|p| {
+                let ty = self.resolve_type(p.ty, span)?;
+                Ok((p.name, ty, p.mode))
+            })
+            .collect::<CompileResult<Vec<_>>>()?;
+
+        let (air, num_locals, num_param_slots, param_modes) =
+            self.analyze_function(ret_type, &param_info, body)?;
+
+        Ok(AnalyzedFunction {
+            name: fn_name.to_string(),
+            air,
+            num_locals,
+            num_param_slots,
+            param_modes,
+        })
+    }
+
+    /// Analyze a method function from an impl block.
+    fn analyze_method_function(
+        &mut self,
+        full_name: &str,
+        return_type: Symbol,
+        params: &[rue_rir::RirParam],
+        body: InstRef,
+        span: Span,
+        struct_type: Type,
+        has_self: bool,
+    ) -> CompileResult<AnalyzedFunction> {
+        let ret_type = self.resolve_type(return_type, span)?;
+
+        // Build parameter list, adding self as first parameter for methods
+        let mut param_info: Vec<(Symbol, Type, RirParamMode)> = Vec::new();
+
+        if has_self {
+            // Add self parameter (Normal mode - passed by value)
+            let self_sym = self.interner.intern("self");
+            param_info.push((self_sym, struct_type, RirParamMode::Normal));
+        }
+
+        // Add regular parameters with their modes
+        for p in params.iter() {
+            let ty = self.resolve_type(p.ty, span)?;
+            param_info.push((p.name, ty, p.mode));
+        }
+
+        let (air, num_locals, num_param_slots, param_modes) =
+            self.analyze_function(ret_type, &param_info, body)?;
+
+        Ok(AnalyzedFunction {
+            name: full_name.to_string(),
+            air,
+            num_locals,
+            num_param_slots,
+            param_modes,
+        })
+    }
+
+    /// Analyze a destructor function.
+    fn analyze_destructor_function(
+        &mut self,
+        full_name: &str,
+        body: InstRef,
+        _span: Span,
+        struct_type: Type,
+    ) -> CompileResult<AnalyzedFunction> {
+        // Destructors take self parameter and return unit
+        let self_sym = self.interner.intern("self");
+        let param_info: Vec<(Symbol, Type, RirParamMode)> =
+            vec![(self_sym, struct_type, RirParamMode::Normal)];
+
+        let (air, num_locals, num_param_slots, param_modes) =
+            self.analyze_function(Type::Unit, &param_info, body)?;
+
+        Ok(AnalyzedFunction {
+            name: full_name.to_string(),
+            air,
+            num_locals,
+            num_param_slots,
+            param_modes,
         })
     }
 
@@ -4946,11 +5021,11 @@ mod tests {
     use rue_parser::Parser;
     use rue_rir::AstGen;
 
-    fn compile_to_air(source: &str) -> CompileResult<SemaOutput> {
+    fn compile_to_air(source: &str) -> MultiErrorResult<SemaOutput> {
         let lexer = Lexer::new(source);
-        let (tokens, interner) = lexer.tokenize()?;
+        let (tokens, interner) = lexer.tokenize().map_err(CompileErrors::from_error)?;
         let parser = Parser::new(tokens, interner);
-        let (ast, mut interner) = parser.parse()?;
+        let (ast, mut interner) = parser.parse().map_err(CompileErrors::from_error)?;
 
         let astgen = AstGen::new(&ast, &mut interner);
         let rir = astgen.generate();
@@ -5081,16 +5156,24 @@ mod tests {
     fn test_undefined_variable() {
         let result = compile_to_air("fn main() -> i32 { x }");
         assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err.kind, ErrorKind::UndefinedVariable(_)));
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(
+            errors.iter().next().unwrap().kind,
+            ErrorKind::UndefinedVariable(_)
+        ));
     }
 
     #[test]
     fn test_assign_to_immutable() {
         let result = compile_to_air("fn main() -> i32 { let x = 10; x = 20; x }");
         assert!(result.is_err());
-        let err = result.unwrap_err();
-        assert!(matches!(err.kind, ErrorKind::AssignToImmutable(_)));
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(
+            errors.iter().next().unwrap().kind,
+            ErrorKind::AssignToImmutable(_)
+        ));
     }
 
     #[test]

--- a/crates/rue-compiler/src/diagnostic.rs
+++ b/crates/rue-compiler/src/diagnostic.rs
@@ -24,7 +24,7 @@ use std::collections::HashMap;
 
 use annotate_snippets::{Level, Renderer, Snippet};
 
-use crate::{CompileError, CompileWarning, Diagnostic, Span};
+use crate::{CompileError, CompileErrors, CompileWarning, Diagnostic, Span};
 
 /// Source code information for diagnostic rendering.
 ///
@@ -71,6 +71,34 @@ impl<'a> DiagnosticFormatter<'a> {
             error.span(),
             error.diagnostic(),
         )
+    }
+
+    /// Format multiple compilation errors into a string.
+    ///
+    /// Each error is formatted on its own line(s). A summary line is added at
+    /// the end if there are multiple errors showing the total count.
+    pub fn format_errors(&self, errors: &CompileErrors) -> String {
+        if errors.is_empty() {
+            return String::new();
+        }
+
+        let mut output = String::new();
+        for error in errors.iter() {
+            if !output.is_empty() {
+                output.push('\n');
+            }
+            output.push_str(&self.format_error(error));
+        }
+
+        // Add summary line if multiple errors
+        if errors.len() > 1 {
+            output.push_str(&format!(
+                "\nerror: aborting due to {} previous errors\n",
+                errors.len()
+            ));
+        }
+
+        output
     }
 
     /// Format all warnings, adding line numbers when multiple variables share the same name.
@@ -306,5 +334,67 @@ mod tests {
 
         let output = formatter.format_error(&error);
         assert!(output.contains("then branch"));
+    }
+
+    #[test]
+    fn test_format_errors_empty() {
+        let source = "fn main() -> i32 { 42 }";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = DiagnosticFormatter::new(&source_info);
+
+        let errors = CompileErrors::new();
+        let output = formatter.format_errors(&errors);
+        assert!(output.is_empty());
+    }
+
+    #[test]
+    fn test_format_errors_single() {
+        let source = "fn main() -> i32 { 1 + true }";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = DiagnosticFormatter::new(&source_info);
+
+        let mut errors = CompileErrors::new();
+        errors.push(CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::new(23, 27),
+        ));
+
+        let output = formatter.format_errors(&errors);
+        assert!(output.contains("type mismatch"));
+        // Single error should not have summary line
+        assert!(!output.contains("aborting"));
+    }
+
+    #[test]
+    fn test_format_errors_multiple() {
+        let source = "fn main() -> i32 {\n    let x = 1 + true;\n    let y = false - 1;\n    0\n}";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = DiagnosticFormatter::new(&source_info);
+
+        let mut errors = CompileErrors::new();
+        errors.push(CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::new(32, 36),
+        ));
+        errors.push(CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "bool".to_string(),
+                found: "i32".to_string(),
+            },
+            Span::new(58, 59),
+        ));
+
+        let output = formatter.format_errors(&errors);
+        // Should contain both errors
+        assert!(output.contains("expected i32, found bool"));
+        assert!(output.contains("expected bool, found i32"));
+        // Should have summary line
+        assert!(output.contains("aborting due to 2 previous errors"));
     }
 }

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -167,8 +167,8 @@ pub use rue_codegen::{
     aarch64::Aarch64Mir, generate_stack_frame_info,
 };
 pub use rue_error::{
-    CompileError, CompileResult, CompileWarning, Diagnostic, ErrorKind, PreviewFeature,
-    PreviewFeatures, WarningKind,
+    CompileError, CompileErrors, CompileResult, CompileWarning, Diagnostic, ErrorKind,
+    MultiErrorResult, PreviewFeature, PreviewFeatures, WarningKind,
 };
 pub use rue_intern::{Interner, Symbol};
 pub use rue_lexer::{Lexer, Token, TokenKind};
@@ -284,9 +284,12 @@ pub struct CompileOutput {
 /// This runs: lexing → parsing → AST to RIR → semantic analysis → CFG construction.
 /// Returns the compile state which can be inspected for debugging.
 ///
+/// This function collects errors from multiple functions instead of stopping at the
+/// first error, allowing users to see all issues at once.
+///
 /// Uses default optimization level (O0) and no preview features. For custom options,
 /// use [`compile_frontend_with_options`].
-pub fn compile_frontend(source: &str) -> CompileResult<CompileState> {
+pub fn compile_frontend(source: &str) -> MultiErrorResult<CompileState> {
     compile_frontend_with_options(source, OptLevel::default(), &PreviewFeatures::new())
 }
 
@@ -294,27 +297,30 @@ pub fn compile_frontend(source: &str) -> CompileResult<CompileState> {
 ///
 /// This runs: lexing → parsing → AST to RIR → semantic analysis → CFG construction → optimization.
 /// Returns the compile state which can be inspected for debugging.
+///
+/// This function collects errors from multiple functions instead of stopping at the
+/// first error, allowing users to see all issues at once.
 pub fn compile_frontend_with_options(
     source: &str,
     opt_level: OptLevel,
     preview_features: &PreviewFeatures,
-) -> CompileResult<CompileState> {
+) -> MultiErrorResult<CompileState> {
     let _span = info_span!("frontend", source_bytes = source.len()).entered();
 
-    // Lexing
+    // Lexing - errors here are fatal (can't continue without tokens)
     let (tokens, interner) = {
         let _span = info_span!("lexer").entered();
         let lexer = Lexer::new(source);
-        let (tokens, interner) = lexer.tokenize()?;
+        let (tokens, interner) = lexer.tokenize().map_err(CompileErrors::from)?;
         info!(token_count = tokens.len(), "lexing complete");
         (tokens, interner)
     };
 
-    // Parsing
+    // Parsing - errors here are fatal (can't continue without AST)
     let (ast, interner) = {
         let _span = info_span!("parser").entered();
         let parser = Parser::new(tokens, interner);
-        let (ast, interner) = parser.parse()?;
+        let (ast, interner) = parser.parse().map_err(CompileErrors::from)?;
         info!(item_count = ast.items.len(), "parsing complete");
         (ast, interner)
     };
@@ -330,7 +336,7 @@ pub fn compile_frontend_with_options(
 ///
 /// Uses default optimization level (O0) and no preview features. For custom options,
 /// use [`compile_frontend_from_ast_with_options`].
-pub fn compile_frontend_from_ast(ast: Ast, interner: Interner) -> CompileResult<CompileState> {
+pub fn compile_frontend_from_ast(ast: Ast, interner: Interner) -> MultiErrorResult<CompileState> {
     compile_frontend_from_ast_with_options(
         ast,
         interner,
@@ -344,12 +350,15 @@ pub fn compile_frontend_from_ast(ast: Ast, interner: Interner) -> CompileResult<
 /// This runs: AST to RIR → semantic analysis → CFG construction → optimization.
 /// Use this when you already have a parsed AST (e.g., for `--emit` modes that
 /// need both AST output and later stage output without double-parsing).
+///
+/// This function collects errors from multiple functions instead of stopping at the
+/// first error, allowing users to see all issues at once.
 pub fn compile_frontend_from_ast_with_options(
     ast: Ast,
     interner: Interner,
     opt_level: OptLevel,
     preview_features: &PreviewFeatures,
-) -> CompileResult<CompileState> {
+) -> MultiErrorResult<CompileState> {
     // AST to RIR (untyped IR)
     let (rir, interner) = {
         let _span = info_span!("astgen").entered();
@@ -359,7 +368,7 @@ pub fn compile_frontend_from_ast_with_options(
         (rir, interner)
     };
 
-    // Semantic analysis (RIR to AIR)
+    // Semantic analysis (RIR to AIR) - this now collects multiple errors
     let sema_output = {
         let _span = info_span!("sema").entered();
         let sema = Sema::new(&rir, &interner, preview_features.clone());
@@ -434,17 +443,23 @@ pub fn compile_frontend_from_ast_with_options(
 ///
 /// This is the main entry point for compilation.
 /// Returns the ELF binary along with any warnings generated during compilation.
-pub fn compile(source: &str) -> CompileResult<CompileOutput> {
+///
+/// This function collects errors from multiple functions instead of stopping at the
+/// first error, allowing users to see all issues at once.
+pub fn compile(source: &str) -> MultiErrorResult<CompileOutput> {
     compile_with_options(source, &CompileOptions::default())
 }
 
 /// Compile source code to an ELF binary with the given options.
 ///
 /// This allows specifying the target architecture, optimization level, and other compilation options.
+///
+/// This function collects errors from multiple functions instead of stopping at the
+/// first error, allowing users to see all issues at once.
 pub fn compile_with_options(
     source: &str,
     options: &CompileOptions,
-) -> CompileResult<CompileOutput> {
+) -> MultiErrorResult<CompileOutput> {
     let _span = info_span!(
         "compile",
         target = %options.target,
@@ -460,7 +475,9 @@ pub fn compile_with_options(
         .functions
         .iter()
         .find(|f| f.analyzed.name == "main")
-        .ok_or_else(|| CompileError::without_span(ErrorKind::NoMainFunction))?;
+        .ok_or_else(|| {
+            CompileErrors::from(CompileError::without_span(ErrorKind::NoMainFunction))
+        })?;
 
     // Dispatch to the appropriate backend based on target architecture
     match options.target.arch() {
@@ -470,7 +487,10 @@ pub fn compile_with_options(
 }
 
 /// Compile for x86-64 target.
-fn compile_x86_64(state: &CompileState, options: &CompileOptions) -> CompileResult<CompileOutput> {
+fn compile_x86_64(
+    state: &CompileState,
+    options: &CompileOptions,
+) -> MultiErrorResult<CompileOutput> {
     // Generate machine code for all functions
     let object_files = {
         let _span = info_span!("codegen", arch = "x86_64").entered();
@@ -484,7 +504,8 @@ fn compile_x86_64(state: &CompileState, options: &CompileOptions) -> CompileResu
                 &state.array_types,
                 &state.strings,
                 &state.interner,
-            )?;
+            )
+            .map_err(CompileErrors::from)?;
             total_code_bytes += machine_code.code.len();
 
             // Build object file for this function
@@ -539,7 +560,7 @@ fn link_internal(
     state: &CompileState,
     options: &CompileOptions,
     object_files: &[Vec<u8>],
-) -> CompileResult<CompileOutput> {
+) -> MultiErrorResult<CompileOutput> {
     let _span = info_span!("linker", mode = "internal").entered();
 
     // For macOS targets, the internal linker doesn't support Mach-O,
@@ -559,8 +580,13 @@ fn link_internal(
 
     // Add all object files to the linker
     for obj_bytes in object_files {
-        let obj = ObjectFile::parse(obj_bytes).map_err(link_error)?;
-        linker.add_object(obj).map_err(link_error)?;
+        let obj = ObjectFile::parse(obj_bytes)
+            .map_err(link_error)
+            .map_err(CompileErrors::from)?;
+        linker
+            .add_object(obj)
+            .map_err(link_error)
+            .map_err(CompileErrors::from)?;
     }
 
     // Mark _start as required so it gets pulled from the archive.
@@ -569,12 +595,20 @@ fn link_internal(
     linker.require_symbol("_start");
 
     // Add the runtime library
-    let runtime = Archive::parse(RUNTIME_BYTES).map_err(link_error)?;
-    linker.add_archive(runtime).map_err(link_error)?;
+    let runtime = Archive::parse(RUNTIME_BYTES)
+        .map_err(link_error)
+        .map_err(CompileErrors::from)?;
+    linker
+        .add_archive(runtime)
+        .map_err(link_error)
+        .map_err(CompileErrors::from)?;
 
     // Link to executable
     // Use _start from the runtime as the entry point (it will call main)
-    let elf = linker.link("_start").map_err(link_error)?;
+    let elf = linker
+        .link("_start")
+        .map_err(link_error)
+        .map_err(CompileErrors::from)?;
     info!(
         object_count = object_files.len(),
         output_bytes = elf.len(),
@@ -595,13 +629,17 @@ fn link_system(
     options: &CompileOptions,
     object_files: &[Vec<u8>],
     linker_cmd: &str,
-) -> CompileResult<CompileOutput> {
+) -> MultiErrorResult<CompileOutput> {
     let _span = info_span!("linker", mode = "system", command = linker_cmd).entered();
 
     // Set up temporary directory with object files and runtime
-    let mut temp_dir = TempLinkDir::new()?;
-    temp_dir.write_object_files(object_files)?;
-    temp_dir.write_runtime(RUNTIME_BYTES)?;
+    let mut temp_dir = TempLinkDir::new().map_err(CompileErrors::from)?;
+    temp_dir
+        .write_object_files(object_files)
+        .map_err(CompileErrors::from)?;
+    temp_dir
+        .write_runtime(RUNTIME_BYTES)
+        .map_err(CompileErrors::from)?;
 
     // Build the linker command
     let mut cmd = Command::new(linker_cmd);
@@ -636,23 +674,22 @@ fn link_system(
 
     // Run the linker
     let output = cmd.output().map_err(|e| {
-        CompileError::without_span(ErrorKind::LinkError(format!(
+        CompileErrors::from(CompileError::without_span(ErrorKind::LinkError(format!(
             "failed to execute linker '{}': {}",
             linker_cmd, e
-        )))
+        ))))
     })?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
         // temp_dir is dropped here, cleaning up automatically
-        return Err(CompileError::without_span(ErrorKind::LinkError(format!(
-            "linker '{}' failed: {}",
-            linker_cmd, stderr
-        ))));
+        return Err(CompileErrors::from(CompileError::without_span(
+            ErrorKind::LinkError(format!("linker '{}' failed: {}", linker_cmd, stderr)),
+        )));
     }
 
     // Read the resulting executable
-    let elf = temp_dir.read_output()?;
+    let elf = temp_dir.read_output().map_err(CompileErrors::from)?;
     info!(
         object_count = object_files.len(),
         output_bytes = elf.len(),
@@ -667,7 +704,10 @@ fn link_system(
 }
 
 /// Compile for AArch64 target.
-fn compile_aarch64(state: &CompileState, options: &CompileOptions) -> CompileResult<CompileOutput> {
+fn compile_aarch64(
+    state: &CompileState,
+    options: &CompileOptions,
+) -> MultiErrorResult<CompileOutput> {
     // Generate machine code for all functions using the aarch64 backend
     let object_files = {
         let _span = info_span!("codegen", arch = "aarch64").entered();
@@ -681,7 +721,8 @@ fn compile_aarch64(state: &CompileState, options: &CompileOptions) -> CompileRes
                 &state.array_types,
                 &state.strings,
                 &state.interner,
-            )?;
+            )
+            .map_err(CompileErrors::from)?;
             total_code_bytes += machine_code.code.len();
 
             let mut obj_builder = ObjectBuilder::new(options.target, &func.analyzed.name)
@@ -1075,14 +1116,14 @@ pub struct AirOutput {
 /// let result = compile_to_air("fn main() -> i32 { 1 + 2 * 3 }");
 /// assert!(result.is_ok());
 /// ```
-pub fn compile_to_air(source: &str) -> CompileResult<AirOutput> {
+pub fn compile_to_air(source: &str) -> MultiErrorResult<AirOutput> {
     // Lexing
     let lexer = Lexer::new(source);
-    let (tokens, interner) = lexer.tokenize()?;
+    let (tokens, interner) = lexer.tokenize().map_err(CompileErrors::from)?;
 
     // Parsing
     let parser = Parser::new(tokens, interner);
-    let (ast, interner) = parser.parse()?;
+    let (ast, interner) = parser.parse().map_err(CompileErrors::from)?;
 
     // AST to RIR (untyped IR)
     let astgen = AstGen::new(&ast, &interner);
@@ -1120,7 +1161,7 @@ pub fn compile_to_air(source: &str) -> CompileResult<AirOutput> {
 /// let state = result.unwrap();
 /// assert_eq!(state.functions.len(), 1);
 /// ```
-pub fn compile_to_cfg(source: &str) -> CompileResult<CompileState> {
+pub fn compile_to_cfg(source: &str) -> MultiErrorResult<CompileState> {
     compile_frontend(source)
 }
 
@@ -1177,6 +1218,84 @@ mod tests {
         let state = compile_frontend("fn main() -> i32 { let x = 42; 0 }").unwrap();
         assert_eq!(state.warnings.len(), 1);
         assert!(state.warnings[0].to_string().contains("unused variable"));
+    }
+
+    #[test]
+    fn test_multiple_errors_collected() {
+        // Test that errors from multiple functions are collected together
+        // Use examples that both result in type mismatch errors
+        let source = r#"
+            fn foo() -> i32 { true }
+            fn bar() -> i32 { false }
+            fn main() -> i32 { 0 }
+        "#;
+        let result = compile_frontend(source);
+        let errors = match result {
+            Ok(_) => panic!("expected error, got success"),
+            Err(e) => e,
+        };
+
+        // Should have at least 2 errors (one from foo, one from bar)
+        assert!(
+            errors.len() >= 2,
+            "expected at least 2 errors, got {}",
+            errors.len()
+        );
+
+        // All errors should be type mismatches (returning bool where i32 expected)
+        for error in errors.iter() {
+            assert!(
+                error.to_string().contains("type mismatch"),
+                "expected type mismatch error, got: {}",
+                error
+            );
+        }
+    }
+
+    #[test]
+    fn test_multiple_errors_display() {
+        // Use examples that both result in type mismatch errors
+        let source = r#"
+            fn foo() -> i32 { true }
+            fn bar() -> i32 { false }
+            fn main() -> i32 { 0 }
+        "#;
+        let errors = match compile_frontend(source) {
+            Ok(_) => panic!("expected error, got success"),
+            Err(e) => e,
+        };
+
+        // Display should show both errors
+        let display = errors.to_string();
+        assert!(
+            display.contains("type mismatch"),
+            "display should contain error message"
+        );
+        if errors.len() > 1 {
+            assert!(
+                display.contains("more error"),
+                "display should indicate more errors"
+            );
+        }
+    }
+
+    #[test]
+    fn test_single_error_still_works() {
+        // Single error should still be collected and returned properly
+        let source = "fn main() -> i32 { true }";
+        let errors = match compile_frontend(source) {
+            Ok(_) => panic!("expected error, got success"),
+            Err(e) => e,
+        };
+
+        assert_eq!(errors.len(), 1);
+        assert!(
+            errors
+                .first()
+                .unwrap()
+                .to_string()
+                .contains("type mismatch")
+        );
     }
 }
 

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -872,6 +872,164 @@ impl fmt::Display for ErrorKind {
 pub type CompileResult<T> = Result<T, CompileError>;
 
 // ============================================================================
+// Multiple Error Collection
+// ============================================================================
+
+/// A collection of compilation errors.
+///
+/// This type supports collecting multiple errors during compilation to provide
+/// users with more comprehensive diagnostics. Instead of stopping at the first
+/// error, the compiler can continue and report multiple issues at once.
+///
+/// # Usage
+///
+/// Use `CompileErrors` when a compilation phase can detect multiple independent
+/// errors. For example, semantic analysis can report multiple type errors in
+/// different functions.
+///
+/// ```ignore
+/// let mut errors = CompileErrors::new();
+/// errors.push(CompileError::new(ErrorKind::TypeMismatch { ... }, span1));
+/// errors.push(CompileError::new(ErrorKind::UndefinedVariable("x".into()), span2));
+///
+/// if !errors.is_empty() {
+///     return Err(errors);
+/// }
+/// ```
+///
+/// # Error Semantics
+///
+/// - An empty `CompileErrors` represents no errors (not a failure)
+/// - A non-empty `CompileErrors` represents one or more compilation failures
+/// - When converted to a single `CompileError`, the first error is used
+#[derive(Debug, Clone)]
+pub struct CompileErrors {
+    errors: Vec<CompileError>,
+}
+
+impl CompileErrors {
+    /// Create a new empty error collection.
+    pub fn new() -> Self {
+        Self { errors: Vec::new() }
+    }
+
+    /// Create an error collection from a single error.
+    pub fn from_error(error: CompileError) -> Self {
+        Self {
+            errors: vec![error],
+        }
+    }
+
+    /// Add an error to the collection.
+    pub fn push(&mut self, error: CompileError) {
+        self.errors.push(error);
+    }
+
+    /// Extend this collection with errors from another collection.
+    pub fn extend(&mut self, other: CompileErrors) {
+        self.errors.extend(other.errors);
+    }
+
+    /// Returns true if there are no errors.
+    pub fn is_empty(&self) -> bool {
+        self.errors.is_empty()
+    }
+
+    /// Returns the number of errors.
+    pub fn len(&self) -> usize {
+        self.errors.len()
+    }
+
+    /// Get the first error, if any.
+    pub fn first(&self) -> Option<&CompileError> {
+        self.errors.first()
+    }
+
+    /// Iterate over all errors.
+    pub fn iter(&self) -> impl Iterator<Item = &CompileError> {
+        self.errors.iter()
+    }
+
+    /// Convert into an iterator over errors.
+    pub fn into_iter(self) -> impl Iterator<Item = CompileError> {
+        self.errors.into_iter()
+    }
+
+    /// Get all errors as a slice.
+    pub fn as_slice(&self) -> &[CompileError] {
+        &self.errors
+    }
+
+    /// Check if the collection contains errors and return as a result.
+    ///
+    /// Returns `Ok(())` if empty, or `Err(self)` if there are errors.
+    pub fn into_result(self) -> Result<(), CompileErrors> {
+        if self.is_empty() { Ok(()) } else { Err(self) }
+    }
+
+    /// Fail with these errors if non-empty, otherwise return the value.
+    ///
+    /// This is useful for combining error checking with a result:
+    /// ```ignore
+    /// let output = SemaOutput { ... };
+    /// errors.into_result_with(output)
+    /// ```
+    pub fn into_result_with<T>(self, value: T) -> Result<T, CompileErrors> {
+        if self.is_empty() {
+            Ok(value)
+        } else {
+            Err(self)
+        }
+    }
+}
+
+impl Default for CompileErrors {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl From<CompileError> for CompileErrors {
+    fn from(error: CompileError) -> Self {
+        Self::from_error(error)
+    }
+}
+
+impl From<CompileErrors> for CompileError {
+    /// Convert a collection to a single error.
+    ///
+    /// Uses the first error in the collection. Panics if the collection is empty.
+    fn from(errors: CompileErrors) -> Self {
+        errors
+            .errors
+            .into_iter()
+            .next()
+            .expect("cannot convert empty CompileErrors to CompileError")
+    }
+}
+
+impl fmt::Display for CompileErrors {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.errors.len() {
+            0 => write!(f, "no errors"),
+            1 => write!(f, "{}", self.errors[0]),
+            n => write!(
+                f,
+                "{} (and {} more error{})",
+                self.errors[0],
+                n - 1,
+                if n == 2 { "" } else { "s" }
+            ),
+        }
+    }
+}
+
+impl std::error::Error for CompileErrors {}
+
+/// Result type for operations that can produce multiple errors.
+pub type MultiErrorResult<T> = Result<T, CompileErrors>;
+
+// ============================================================================
 // Error Helper Traits
 // ============================================================================
 
@@ -1333,5 +1491,140 @@ mod tests {
         assert!(result.is_err());
         let error = result.unwrap_err();
         assert_eq!(error.to_string(), "undefined variable 'foo'");
+    }
+
+    // ========================================================================
+    // CompileErrors tests
+    // ========================================================================
+
+    #[test]
+    fn test_compile_errors_new_is_empty() {
+        let errors = CompileErrors::new();
+        assert!(errors.is_empty());
+        assert_eq!(errors.len(), 0);
+    }
+
+    #[test]
+    fn test_compile_errors_from_error() {
+        let error = CompileError::without_span(ErrorKind::InvalidInteger);
+        let errors = CompileErrors::from_error(error);
+        assert!(!errors.is_empty());
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    fn test_compile_errors_push() {
+        let mut errors = CompileErrors::new();
+        errors.push(CompileError::without_span(ErrorKind::InvalidInteger));
+        errors.push(CompileError::without_span(ErrorKind::NoMainFunction));
+        assert_eq!(errors.len(), 2);
+    }
+
+    #[test]
+    fn test_compile_errors_extend() {
+        let mut errors1 = CompileErrors::new();
+        errors1.push(CompileError::without_span(ErrorKind::InvalidInteger));
+
+        let mut errors2 = CompileErrors::new();
+        errors2.push(CompileError::without_span(ErrorKind::NoMainFunction));
+        errors2.push(CompileError::without_span(ErrorKind::BreakOutsideLoop));
+
+        errors1.extend(errors2);
+        assert_eq!(errors1.len(), 3);
+    }
+
+    #[test]
+    fn test_compile_errors_first() {
+        let mut errors = CompileErrors::new();
+        assert!(errors.first().is_none());
+
+        errors.push(CompileError::without_span(ErrorKind::InvalidInteger));
+        errors.push(CompileError::without_span(ErrorKind::NoMainFunction));
+
+        let first = errors.first().unwrap();
+        assert!(matches!(first.kind, ErrorKind::InvalidInteger));
+    }
+
+    #[test]
+    fn test_compile_errors_iter() {
+        let mut errors = CompileErrors::new();
+        errors.push(CompileError::without_span(ErrorKind::InvalidInteger));
+        errors.push(CompileError::without_span(ErrorKind::NoMainFunction));
+
+        let kinds: Vec<_> = errors.iter().map(|e| &e.kind).collect();
+        assert_eq!(kinds.len(), 2);
+    }
+
+    #[test]
+    fn test_compile_errors_into_result_empty() {
+        let errors = CompileErrors::new();
+        assert!(errors.into_result().is_ok());
+    }
+
+    #[test]
+    fn test_compile_errors_into_result_non_empty() {
+        let mut errors = CompileErrors::new();
+        errors.push(CompileError::without_span(ErrorKind::InvalidInteger));
+        assert!(errors.into_result().is_err());
+    }
+
+    #[test]
+    fn test_compile_errors_into_result_with() {
+        let errors = CompileErrors::new();
+        let result = errors.into_result_with(42);
+        assert_eq!(result.unwrap(), 42);
+
+        let mut errors = CompileErrors::new();
+        errors.push(CompileError::without_span(ErrorKind::InvalidInteger));
+        let result = errors.into_result_with(42);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_compile_errors_from_single_error() {
+        let error = CompileError::without_span(ErrorKind::InvalidInteger);
+        let errors: CompileErrors = error.into();
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    fn test_compile_errors_to_single_error() {
+        let mut errors = CompileErrors::new();
+        errors.push(CompileError::without_span(ErrorKind::InvalidInteger));
+        errors.push(CompileError::without_span(ErrorKind::NoMainFunction));
+
+        let error: CompileError = errors.into();
+        // Should get the first error
+        assert!(matches!(error.kind, ErrorKind::InvalidInteger));
+    }
+
+    #[test]
+    fn test_compile_errors_display_empty() {
+        let errors = CompileErrors::new();
+        assert_eq!(errors.to_string(), "no errors");
+    }
+
+    #[test]
+    fn test_compile_errors_display_single() {
+        let errors =
+            CompileErrors::from_error(CompileError::without_span(ErrorKind::InvalidInteger));
+        assert_eq!(errors.to_string(), "invalid integer literal");
+    }
+
+    #[test]
+    fn test_compile_errors_display_multiple() {
+        let mut errors = CompileErrors::new();
+        errors.push(CompileError::without_span(ErrorKind::InvalidInteger));
+        errors.push(CompileError::without_span(ErrorKind::NoMainFunction));
+        assert_eq!(
+            errors.to_string(),
+            "invalid integer literal (and 1 more error)"
+        );
+
+        errors.push(CompileError::without_span(ErrorKind::BreakOutsideLoop));
+        assert_eq!(
+            errors.to_string(),
+            "invalid integer literal (and 2 more errors)"
+        );
     }
 }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -702,8 +702,8 @@ fn main() {
                 &options.target,
             );
         }
-        Err(e) => {
-            eprintln!("{}", formatter.format_error(&e));
+        Err(errors) => {
+            eprintln!("{}", formatter.format_errors(&errors));
             std::process::exit(1);
         }
     }
@@ -780,8 +780,8 @@ fn handle_emit(source: &str, options: &Options, formatter: &DiagnosticFormatter)
             &options.preview_features,
         ) {
             Ok(state) => Some(state),
-            Err(e) => {
-                eprintln!("{}", formatter.format_error(&e));
+            Err(errors) => {
+                eprintln!("{}", formatter.format_errors(&errors));
                 return Err(());
             }
         }


### PR DESCRIPTION
Instead of stopping at the first error, Sema now collects errors from all function bodies and reports them together. This improves developer experience by showing all issues at once.

- Add CompileErrors type for collecting multiple errors
- Add MultiErrorResult<T> type alias
- Add format_errors() to DiagnosticFormatter
- Refactor analyze_all() to collect errors across functions
- Extract helper methods for cleaner error handling

Type/struct definition errors still cause early termination since they affect all subsequent analysis.

Fixes rue-ozj9

🤖 Generated with [Claude Code](https://claude.ai/code)