### PR TITLE
Replace HashMap with IndexMap for liveness ranges

### DIFF
--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -12,6 +12,7 @@
 use std::collections::{HashMap, HashSet};
 
 use super::mir::{Aarch64Inst, Aarch64Mir, LabelId, Operand, Reg, VReg};
+use crate::index_map::IndexMap;
 
 // Re-export shared types from the regalloc module
 pub use crate::regalloc::{InstructionLiveness, LiveRange, LivenessDebugInfo};
@@ -29,10 +30,11 @@ pub type LivenessInfo = crate::regalloc::LivenessInfo<Reg>;
 pub fn analyze(mir: &Aarch64Mir) -> LivenessInfo {
     let instructions = mir.instructions();
     let num_insts = instructions.len();
+    let vreg_count = mir.vreg_count();
 
     if num_insts == 0 {
         return LivenessInfo {
-            ranges: HashMap::new(),
+            ranges: IndexMap::new(),
             live_at: Vec::new(),
             clobbers_at: Vec::new(),
         };
@@ -161,12 +163,14 @@ pub fn analyze(mir: &Aarch64Mir) -> LivenessInfo {
         }
     }
 
-    // Build ranges
-    let mut ranges: HashMap<VReg, LiveRange> = HashMap::new();
-    for vreg_idx in 0..mir.vreg_count() {
+    // Build ranges using dense Vec storage
+    let mut ranges: IndexMap<VReg, Option<LiveRange>> =
+        IndexMap::with_capacity(vreg_count as usize);
+    ranges.resize(vreg_count as usize, None);
+    for vreg_idx in 0..vreg_count {
         let vreg = VReg::new(vreg_idx);
         if let (Some(&start), Some(&end)) = (first_live.get(&vreg), last_live.get(&vreg)) {
-            ranges.insert(vreg, LiveRange::new(start, end));
+            ranges[vreg] = Some(LiveRange::new(start, end));
         }
     }
 
@@ -194,12 +198,13 @@ pub fn analyze(mir: &Aarch64Mir) -> LivenessInfo {
 pub fn analyze_debug(mir: &Aarch64Mir) -> LivenessDebugInfo {
     let instructions = mir.instructions();
     let num_insts = instructions.len();
+    let vreg_count = mir.vreg_count();
 
     if num_insts == 0 {
         return LivenessDebugInfo {
             instructions: Vec::new(),
-            live_ranges: HashMap::new(),
-            vreg_count: mir.vreg_count(),
+            live_ranges: IndexMap::new(),
+            vreg_count,
         };
     }
 
@@ -306,12 +311,14 @@ pub fn analyze_debug(mir: &Aarch64Mir) -> LivenessDebugInfo {
         }
     }
 
-    // Build ranges
-    let mut live_ranges: HashMap<VReg, crate::regalloc::LiveRange> = HashMap::new();
-    for vreg_idx in 0..mir.vreg_count() {
+    // Build ranges using dense Vec storage
+    let mut live_ranges: IndexMap<VReg, Option<crate::regalloc::LiveRange>> =
+        IndexMap::with_capacity(vreg_count as usize);
+    live_ranges.resize(vreg_count as usize, None);
+    for vreg_idx in 0..vreg_count {
         let vreg = VReg::new(vreg_idx);
         if let (Some(&start), Some(&end)) = (first_live.get(&vreg), last_live.get(&vreg)) {
-            live_ranges.insert(vreg, crate::regalloc::LiveRange::new(start, end));
+            live_ranges[vreg] = Some(crate::regalloc::LiveRange::new(start, end));
         }
     }
 
@@ -616,8 +623,8 @@ mod tests {
 
         let info = analyze(&mir);
 
-        assert_eq!(info.ranges.get(&v0), Some(&LiveRange::new(0, 1)));
-        assert_eq!(info.ranges.get(&v1), Some(&LiveRange::new(1, 1)));
+        assert_eq!(info.range(v0), Some(&LiveRange::new(0, 1)));
+        assert_eq!(info.range(v1), Some(&LiveRange::new(1, 1)));
     }
 
     #[test]
@@ -719,7 +726,7 @@ mod tests {
         let info = analyze(&mir);
 
         // v0 should be live from definition (0) through use in CBZ (1) and MOV (2)
-        let v0_range = info.ranges.get(&v0).expect("v0 should have a range");
+        let v0_range = info.range(v0).expect("v0 should have a range");
         assert_eq!(v0_range.start, 0);
         assert!(
             v0_range.end >= 2,
@@ -727,7 +734,7 @@ mod tests {
         );
 
         // v1 should be live from first definition through final use
-        let v1_range = info.ranges.get(&v1).expect("v1 should have a range");
+        let v1_range = info.range(v1).expect("v1 should have a range");
         assert!(v1_range.end >= 7, "v1 should be live until the MOV to X0");
     }
 
@@ -766,7 +773,7 @@ mod tests {
         let info = analyze(&mir);
 
         // v0 should be live from 0 through at least instruction 3 (use in MOV)
-        let v0_range = info.ranges.get(&v0).expect("v0 should have a range");
+        let v0_range = info.range(v0).expect("v0 should have a range");
         assert_eq!(v0_range.start, 0);
         assert!(v0_range.end >= 3);
     }
@@ -819,7 +826,7 @@ mod tests {
         let info = analyze(&mir);
 
         // v0 should be live throughout the loop (from def to last use in CBNZ)
-        let v0_range = info.ranges.get(&v0).expect("v0 should have a range");
+        let v0_range = info.range(v0).expect("v0 should have a range");
         assert_eq!(v0_range.start, 0);
         assert!(v0_range.end >= 4, "v0 should be live through CBNZ");
     }

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -27,7 +27,7 @@
 //! the longest remaining live range, as this frees up a register for the
 //! longest time.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::fmt;
 
 use crate::index_map::IndexMap;
@@ -63,8 +63,8 @@ pub struct InstructionLiveness {
 pub struct LivenessDebugInfo {
     /// Per-instruction liveness information.
     pub instructions: Vec<InstructionLiveness>,
-    /// Live ranges for each virtual register.
-    pub live_ranges: HashMap<VReg, LiveRange>,
+    /// Live ranges for each virtual register (indexed by vreg index).
+    pub live_ranges: IndexMap<VReg, Option<LiveRange>>,
     /// Total number of virtual registers.
     pub vreg_count: u32,
 }
@@ -137,12 +137,11 @@ impl std::fmt::Display for LivenessDebugInfo {
         writeln!(f)?;
         writeln!(f, "Live Ranges (instruction indices):")?;
 
-        // Sort by vreg index for consistent output
-        let mut ranges: Vec<_> = self.live_ranges.iter().collect();
-        ranges.sort_by_key(|(vreg, _)| vreg.index());
-
-        for (vreg, range) in ranges {
-            writeln!(f, "  {}: [{}, {})", vreg, range.start, range.end + 1)?;
+        // Iterate in vreg index order (already sorted since IndexMap is Vec-backed)
+        for (vreg, range_opt) in self.live_ranges.iter_enumerated() {
+            if let Some(range) = range_opt {
+                writeln!(f, "  {}: [{}, {})", vreg, range.start, range.end + 1)?;
+            }
         }
 
         Ok(())
@@ -183,8 +182,9 @@ impl LiveRange {
 /// by the register allocator. Each backend's `analyze()` function populates
 /// an instance of this type.
 pub struct LivenessInfo<Reg: Copy + Eq + std::hash::Hash> {
-    /// Live range for each virtual register.
-    pub ranges: HashMap<VReg, LiveRange>,
+    /// Live range for each virtual register (indexed by vreg index).
+    /// Uses dense Vec storage since VReg indices are contiguous.
+    pub ranges: IndexMap<VReg, Option<LiveRange>>,
     /// For each instruction, which vregs are live after it executes.
     /// This is useful for determining which registers are in use at any point.
     pub live_at: Vec<HashSet<VReg>>,
@@ -197,7 +197,18 @@ impl<Reg: Copy + Eq + std::hash::Hash> LivenessInfo<Reg> {
     /// Create a new empty liveness info.
     pub fn new() -> Self {
         Self {
-            ranges: HashMap::new(),
+            ranges: IndexMap::new(),
+            live_at: Vec::new(),
+            clobbers_at: Vec::new(),
+        }
+    }
+
+    /// Create liveness info with capacity for the given number of vregs.
+    pub fn with_vreg_capacity(vreg_count: u32) -> Self {
+        let mut ranges = IndexMap::with_capacity(vreg_count as usize);
+        ranges.resize(vreg_count as usize, None);
+        Self {
+            ranges,
             live_at: Vec::new(),
             clobbers_at: Vec::new(),
         }
@@ -210,7 +221,7 @@ impl<Reg: Copy + Eq + std::hash::Hash> LivenessInfo<Reg> {
 
     /// Get the live range for a vreg.
     pub fn range(&self, vreg: VReg) -> Option<&LiveRange> {
-        self.ranges.get(&vreg)
+        self.ranges.get(vreg).and_then(|opt| opt.as_ref())
     }
 
     /// Check if two vregs interfere (have overlapping live ranges).
@@ -218,7 +229,7 @@ impl<Reg: Copy + Eq + std::hash::Hash> LivenessInfo<Reg> {
     /// Two vregs interfere if they are both live at the same program point,
     /// meaning they cannot share the same physical register.
     pub fn interferes(&self, a: VReg, b: VReg) -> bool {
-        match (self.ranges.get(&a), self.ranges.get(&b)) {
+        match (self.range(a), self.range(b)) {
             (Some(ra), Some(rb)) => ra.overlaps(rb),
             _ => false,
         }
@@ -235,7 +246,7 @@ impl<Reg: Copy + Eq + std::hash::Hash> LivenessInfo<Reg> {
     /// This is used to prevent allocating a vreg to a register that would be clobbered
     /// before the vreg's last use.
     pub fn is_clobbered_during(&self, vreg: VReg, reg: Reg) -> bool {
-        if let Some(range) = self.ranges.get(&vreg) {
+        if let Some(range) = self.range(vreg) {
             for idx in range.start..=range.end {
                 if idx < self.clobbers_at.len() && self.clobbers_at[idx].contains(&reg) {
                     return true;
@@ -675,13 +686,16 @@ mod tests {
     struct TestReg(u32);
 
     fn make_liveness(ranges: Vec<(u32, usize, usize)>) -> LivenessInfo<TestReg> {
-        let mut info = LivenessInfo::new();
+        // Find max vreg index and max instruction index
+        let max_vreg = ranges.iter().map(|(v, _, _)| *v).max().unwrap_or(0);
+        let max_inst = ranges.iter().map(|(_, _, e)| *e).max().unwrap_or(0);
+
+        let mut info = LivenessInfo::with_vreg_capacity(max_vreg + 1);
         for (vreg_idx, start, end) in ranges {
-            info.ranges
-                .insert(VReg::new(vreg_idx), LiveRange::new(start, end));
+            info.ranges[VReg::new(vreg_idx)] = Some(LiveRange::new(start, end));
         }
+
         // Initialize live_at and clobbers_at based on max instruction index
-        let max_inst = info.ranges.values().map(|r| r.end).max().unwrap_or(0);
         info.live_at = vec![HashSet::new(); max_inst + 1];
         info.clobbers_at = vec![Vec::new(); max_inst + 1];
         info

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -12,6 +12,7 @@
 use std::collections::{HashMap, HashSet};
 
 use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
+use crate::index_map::IndexMap;
 
 // Re-export shared types from the regalloc module
 pub use crate::regalloc::{InstructionLiveness, LiveRange, LivenessDebugInfo};
@@ -29,10 +30,11 @@ pub type LivenessInfo = crate::regalloc::LivenessInfo<Reg>;
 pub fn analyze(mir: &X86Mir) -> LivenessInfo {
     let instructions = mir.instructions();
     let num_insts = instructions.len();
+    let vreg_count = mir.vreg_count();
 
     if num_insts == 0 {
         return LivenessInfo {
-            ranges: HashMap::new(),
+            ranges: IndexMap::new(),
             live_at: Vec::new(),
             clobbers_at: Vec::new(),
         };
@@ -165,12 +167,14 @@ pub fn analyze(mir: &X86Mir) -> LivenessInfo {
         }
     }
 
-    // Build ranges
-    let mut ranges: HashMap<VReg, LiveRange> = HashMap::new();
-    for vreg_idx in 0..mir.vreg_count() {
+    // Build ranges using dense Vec storage
+    let mut ranges: IndexMap<VReg, Option<LiveRange>> =
+        IndexMap::with_capacity(vreg_count as usize);
+    ranges.resize(vreg_count as usize, None);
+    for vreg_idx in 0..vreg_count {
         let vreg = VReg::new(vreg_idx);
         if let (Some(&start), Some(&end)) = (first_live.get(&vreg), last_live.get(&vreg)) {
-            ranges.insert(vreg, LiveRange::new(start, end));
+            ranges[vreg] = Some(LiveRange::new(start, end));
         }
     }
 
@@ -198,12 +202,13 @@ pub fn analyze(mir: &X86Mir) -> LivenessInfo {
 pub fn analyze_debug(mir: &X86Mir) -> LivenessDebugInfo {
     let instructions = mir.instructions();
     let num_insts = instructions.len();
+    let vreg_count = mir.vreg_count();
 
     if num_insts == 0 {
         return LivenessDebugInfo {
             instructions: Vec::new(),
-            live_ranges: HashMap::new(),
-            vreg_count: mir.vreg_count(),
+            live_ranges: IndexMap::new(),
+            vreg_count,
         };
     }
 
@@ -314,12 +319,14 @@ pub fn analyze_debug(mir: &X86Mir) -> LivenessDebugInfo {
         }
     }
 
-    // Build ranges
-    let mut live_ranges: HashMap<VReg, crate::regalloc::LiveRange> = HashMap::new();
-    for vreg_idx in 0..mir.vreg_count() {
+    // Build ranges using dense Vec storage
+    let mut live_ranges: IndexMap<VReg, Option<crate::regalloc::LiveRange>> =
+        IndexMap::with_capacity(vreg_count as usize);
+    live_ranges.resize(vreg_count as usize, None);
+    for vreg_idx in 0..vreg_count {
         let vreg = VReg::new(vreg_idx);
         if let (Some(&start), Some(&end)) = (first_live.get(&vreg), last_live.get(&vreg)) {
-            live_ranges.insert(vreg, crate::regalloc::LiveRange::new(start, end));
+            live_ranges[vreg] = Some(crate::regalloc::LiveRange::new(start, end));
         }
     }
 
@@ -656,9 +663,9 @@ mod tests {
         let info = analyze(&mir);
 
         // v0 is defined at 0, last used at 1
-        assert_eq!(info.ranges.get(&v0), Some(&LiveRange::new(0, 1)));
+        assert_eq!(info.range(v0), Some(&LiveRange::new(0, 1)));
         // v1 is defined at 1, last used at 1 (no further use)
-        assert_eq!(info.ranges.get(&v1), Some(&LiveRange::new(1, 1)));
+        assert_eq!(info.range(v1), Some(&LiveRange::new(1, 1)));
     }
 
     #[test]
@@ -800,7 +807,7 @@ mod tests {
         let info = analyze(&mir);
 
         // v0 should be live from definition (0) through use in CMP (1) and MOV (3)
-        let v0_range = info.ranges.get(&v0).expect("v0 should have a range");
+        let v0_range = info.range(v0).expect("v0 should have a range");
         assert_eq!(v0_range.start, 0);
         assert!(
             v0_range.end >= 3,
@@ -808,7 +815,7 @@ mod tests {
         );
 
         // v1 should be live from first definition through final use
-        let v1_range = info.ranges.get(&v1).expect("v1 should have a range");
+        let v1_range = info.range(v1).expect("v1 should have a range");
         assert!(v1_range.end >= 8, "v1 should be live until the MOV to RAX");
     }
 
@@ -844,7 +851,7 @@ mod tests {
         let info = analyze(&mir);
 
         // v0 should be live from 0 through at least instruction 3 (use in MOV)
-        let v0_range = info.ranges.get(&v0).expect("v0 should have a range");
+        let v0_range = info.range(v0).expect("v0 should have a range");
         assert_eq!(v0_range.start, 0);
         assert!(v0_range.end >= 3);
     }
@@ -901,7 +908,7 @@ mod tests {
         let info = analyze(&mir);
 
         // v0 should be live throughout the loop (from def to last use in CMP)
-        let v0_range = info.ranges.get(&v0).expect("v0 should have a range");
+        let v0_range = info.range(v0).expect("v0 should have a range");
         assert_eq!(v0_range.start, 0);
         assert!(v0_range.end >= 4, "v0 should be live through CMP");
     }
@@ -930,7 +937,7 @@ mod tests {
         let info = analyze(&mir);
 
         // v0 should have a range starting at 0 (where it's defined)
-        let v0_range = info.ranges.get(&v0).expect("v0 should have a range");
+        let v0_range = info.range(v0).expect("v0 should have a range");
         assert_eq!(v0_range.start, 0, "LEA defines v0 at instruction 0");
 
         // The instruction's uses should NOT include v0


### PR DESCRIPTION
Use dense Vec-backed IndexMap for LivenessInfo.ranges and LivenessDebugInfo.live_ranges instead of HashMap. Since VReg indices are contiguous (0, 1, 2, ..., vreg_count-1), this provides O(1) direct indexing instead of hash-based lookups.

Closes rue-aixs

🤖 Generated with [Claude Code](https://claude.com/claude-code)