### PR TITLE
Fix exponential parsing behavior for deeply nested blocks

### DIFF
--- a/benchmarks/stress/deep_nesting.rue
+++ b/benchmarks/stress/deep_nesting.rue
@@ -1,9 +1,8 @@
 // Stress test: Nested blocks and expressions.
 // Tests the compiler's handling of scope nesting and expression depth.
-// NOTE: Kept to 10 levels as deeper nesting causes exponential compile time.
 
 fn nested_blocks() -> i32 {
-    // 10 levels of nested blocks
+    // 20 levels of nested blocks
     {
         let a = 1;
         {
@@ -24,8 +23,38 @@ fn nested_blocks() -> i32 {
                                         let i = h + 1;
                                         {
                                             let j = i + 1;
-                                            // j = 10
-                                            j
+                                            {
+                                                let k = j + 1;
+                                                {
+                                                    let l = k + 1;
+                                                    {
+                                                        let m = l + 1;
+                                                        {
+                                                            let n = m + 1;
+                                                            {
+                                                                let o = n + 1;
+                                                                {
+                                                                    let p = o + 1;
+                                                                    {
+                                                                        let q = p + 1;
+                                                                        {
+                                                                            let r = q + 1;
+                                                                            {
+                                                                                let s = r + 1;
+                                                                                {
+                                                                                    let t = s + 1;
+                                                                                    // t = 20
+                                                                                    t
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
                                         }
                                     }
                                 }
@@ -86,10 +115,10 @@ fn deeply_nested_expr() -> i32 {
 }
 
 fn main() -> i32 {
-    let a = nested_blocks();       // 10
+    let a = nested_blocks();       // 20
     let b = nested_if(25);         // 30
     let c = nested_while();        // 125 (5*5*5)
     let d = deeply_nested_expr();  // 66
 
-    (a + b + c + d) % 256          // (10 + 30 + 125 + 66) % 256 = 231
+    (a + b + c + d) % 256          // (20 + 30 + 125 + 66) % 256 = 241
 }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -1100,6 +1100,19 @@ enum BlockItem {
     Expr(Expr),
 }
 
+/// What token follows an expression in a block (used to determine its role)
+#[derive(Debug, Clone, Copy)]
+enum ExprFollower {
+    /// Semicolon follows - expression is a statement
+    Semi,
+    /// Right brace follows (not consumed) - expression is the final/return value
+    RBrace,
+    /// Some other token follows - only valid for control flow expressions
+    Other,
+    /// End of input - only valid for control flow expressions
+    End,
+}
+
 /// Parser for a let binding pattern: either an identifier or _ (wildcard/discard)
 fn let_pattern_parser<'src, I>()
 -> impl Parser<'src, I, LetPattern, extra::Err<Rich<'src, TokenKind>>> + Clone
@@ -1343,68 +1356,47 @@ where
     // Always requires a trailing semicolon.
     let assign_stmt = assign_statement_parser(expr.clone()).map(BlockItem::Statement);
 
-    // Expression followed by semicolon: `expr;`
-    // This makes any expression into a statement (its value is discarded).
-    let expr_with_semi = expr
-        .clone()
-        .then_ignore(just(TokenKind::Semi))
-        .map(|e| BlockItem::Statement(Statement::Expr(e)));
-
-    // Control flow expression in the MIDDLE of a block (not at the end).
+    // Expression-based item: parse expression ONCE, then decide based on what follows.
+    // This avoids O(2^n) complexity from repeatedly re-parsing expressions with backtracking.
     //
-    // These expressions don't need semicolons: if, while, match, loop,
-    // break, continue, return.
-    //
-    // How it works:
-    // 1. Parse an expression
-    // 2. Lookahead: verify next token is NOT `}` and NOT `;`
-    //    (If it were `}`, this would be the final expr; if `;`, use expr_with_semi)
-    // 3. Validate via try_map: only control flow expressions are valid here
-    //
-    // The `rewind()` is crucial: it checks the next token WITHOUT consuming it,
-    // so whatever follows (like the next statement) remains available.
-    let control_flow_stmt = expr
-        .clone()
-        .then_ignore(none_of([TokenKind::RBrace, TokenKind::Semi]).rewind())
-        .try_map(|e, span| {
-            if is_control_flow_expr(&e) {
-                // Valid: control flow doesn't need semicolon mid-block
+    // After parsing an expression, we check the next token:
+    // - `;` → expression statement (value discarded)
+    // - `}` → final expression (block's return value)
+    // - other → mid-block control flow (only valid for if/while/match/loop/break/continue/return)
+    let expr_item = expr
+        .then(
+            choice((
+                just(TokenKind::Semi).to(ExprFollower::Semi),
+                just(TokenKind::RBrace).rewind().to(ExprFollower::RBrace),
+                any().rewind().to(ExprFollower::Other),
+            ))
+            .or(end().to(ExprFollower::End)),
+        )
+        .try_map(|(e, follower), span| match follower {
+            ExprFollower::Semi => {
+                // Expression followed by semicolon: `expr;`
                 Ok(BlockItem::Statement(Statement::Expr(e)))
-            } else {
-                // Invalid: non-control-flow expression without semicolon mid-block
-                // Reject this parse so chumsky can try other alternatives or report error
-                Err(Rich::custom(span, "expected semicolon after expression"))
+            }
+            ExprFollower::RBrace => {
+                // Final expression: `{ ... expr }`
+                Ok(BlockItem::Expr(e))
+            }
+            ExprFollower::Other | ExprFollower::End => {
+                // Mid-block control flow (no semicolon, not at end)
+                // Only control flow expressions are valid here
+                if is_control_flow_expr(&e) {
+                    Ok(BlockItem::Statement(Statement::Expr(e)))
+                } else {
+                    Err(Rich::custom(span, "expected semicolon after expression"))
+                }
             }
         });
-
-    // Final expression: the last item in a block, providing the block's value.
-    //
-    // How it works:
-    // 1. Parse an expression
-    // 2. Lookahead: verify next token IS `}`
-    //    (The `rewind()` ensures we don't consume the `}`, which the block parser needs)
-    //
-    // Examples:
-    // - `{ 42 }` - `42` is the final expression, block evaluates to 42
-    // - `{ x; y }` - `y` is the final expression
-    // - `{ if c { a } else { b } }` - the entire `if` is the final expression
-    let final_expr = expr
-        .then_ignore(just(TokenKind::RBrace).rewind())
-        .map(BlockItem::Expr);
 
     // Try parsers in order. Earlier parsers take precedence.
     // This order ensures:
     // - Keywords (`let`) are matched before being parsed as identifiers
     // - Assignments (`x = 5;`) are matched before `x` is parsed as an expression
-    // - Semicolon-terminated expressions are matched before semicolon-free variants
-    // - Mid-block control flow is matched before final expressions
-    choice((
-        let_stmt,
-        assign_stmt,
-        expr_with_semi,
-        control_flow_stmt,
-        final_expr,
-    ))
+    choice((let_stmt, assign_stmt, expr_item))
 }
 
 /// Process block items into statements and final expression


### PR DESCRIPTION
The parser's block_item_parser used choice() with multiple alternatives that each parsed the full expression before checking what followed. This caused O(2^n) complexity with backtracking on deeply nested blocks.

Refactored to parse the expression once, then check the following token to determine its role (statement with ;, final expression before }, or mid-block control flow).

The benchmark stress test now uses 20 levels of nesting instead of 10.

Fixes rue-jw8a

🤖 Generated with [Claude Code](https://claude.com/claude-code)