### PR TITLE
feat(sema): extract TypeContext and FunctionAnalysisState for paralle…

### DIFF
--- a/crates/rue-air/src/analysis_state.rs
+++ b/crates/rue-air/src/analysis_state.rs
@@ -1,0 +1,193 @@
+//! Per-function mutable state for semantic analysis.
+//!
+//! This module contains state that is mutated during function analysis.
+//! Each function can have its own `FunctionAnalysisState`, which is then
+//! merged after parallel analysis completes.
+
+use std::collections::HashMap;
+
+use rue_error::CompileWarning;
+
+use crate::types::{ArrayTypeDef, ArrayTypeId, Type};
+
+/// Per-function mutable state during semantic analysis.
+///
+/// This struct contains all mutable state that is modified during function
+/// body analysis. For parallel analysis, each function gets its own instance,
+/// and results are merged afterward.
+///
+/// # Contents
+///
+/// - Array types created during analysis
+/// - String literals encountered
+/// - Warnings generated
+///
+/// # Merging
+///
+/// After parallel analysis, use `merge_into` to combine results:
+/// - Array types are deduplicated
+/// - Strings are deduplicated
+/// - Warnings are concatenated
+#[derive(Debug, Default)]
+pub struct FunctionAnalysisState {
+    /// Array types created during this function's analysis.
+    /// Key is (element_type, length), value is the ArrayTypeId assigned.
+    pub array_types: HashMap<(Type, u64), ArrayTypeId>,
+    /// Array type definitions in order of creation.
+    pub array_type_defs: Vec<ArrayTypeDef>,
+    /// String table for deduplication.
+    pub string_table: HashMap<String, u32>,
+    /// String literals in order of creation.
+    pub strings: Vec<String>,
+    /// Warnings collected during analysis.
+    pub warnings: Vec<CompileWarning>,
+}
+
+impl FunctionAnalysisState {
+    /// Create a new empty analysis state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a string to the string table, returning its index.
+    /// Deduplicates identical strings.
+    pub fn add_string(&mut self, content: String) -> u32 {
+        use std::collections::hash_map::Entry;
+        match self.string_table.entry(content) {
+            Entry::Occupied(e) => *e.get(),
+            Entry::Vacant(e) => {
+                let id = self.strings.len() as u32;
+                self.strings.push(e.key().clone());
+                e.insert(id);
+                id
+            }
+        }
+    }
+
+    /// Get or create an array type, returning its ID.
+    pub fn get_or_create_array_type(&mut self, element_type: Type, length: u64) -> ArrayTypeId {
+        let key = (element_type, length);
+        if let Some(&id) = self.array_types.get(&key) {
+            return id;
+        }
+
+        let id = ArrayTypeId(self.array_type_defs.len() as u32);
+        self.array_type_defs.push(ArrayTypeDef {
+            element_type,
+            length,
+        });
+        self.array_types.insert(key, id);
+        id
+    }
+
+    /// Add a warning.
+    pub fn add_warning(&mut self, warning: CompileWarning) {
+        self.warnings.push(warning);
+    }
+}
+
+/// Merged state from multiple function analyses.
+///
+/// This is the result of merging all `FunctionAnalysisState` instances
+/// after parallel analysis completes.
+#[derive(Debug, Default)]
+pub struct MergedAnalysisState {
+    /// All array type definitions (deduplicated).
+    pub array_type_defs: Vec<ArrayTypeDef>,
+    /// Mapping from original (element_type, length) to final ArrayTypeId.
+    pub array_type_map: HashMap<(Type, u64), ArrayTypeId>,
+    /// All string literals (deduplicated).
+    pub strings: Vec<String>,
+    /// Mapping from string content to final index.
+    pub string_map: HashMap<String, u32>,
+    /// All warnings from all functions.
+    pub warnings: Vec<CompileWarning>,
+}
+
+impl MergedAnalysisState {
+    /// Create a new empty merged state.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Merge a function's analysis state into this merged state.
+    ///
+    /// Returns a remapping for array type IDs so the function's AIR
+    /// can be updated with the final IDs.
+    pub fn merge_function_state(&mut self, state: FunctionAnalysisState) -> AnalysisStateRemapping {
+        let mut array_remap = HashMap::new();
+        let mut string_remap = HashMap::new();
+
+        // Merge array types (deduplicate by (element_type, length))
+        for (key, old_id) in state.array_types {
+            let new_id = if let Some(&id) = self.array_type_map.get(&key) {
+                id
+            } else {
+                let id = ArrayTypeId(self.array_type_defs.len() as u32);
+                self.array_type_defs.push(ArrayTypeDef {
+                    element_type: key.0,
+                    length: key.1,
+                });
+                self.array_type_map.insert(key, id);
+                id
+            };
+            if old_id != new_id {
+                array_remap.insert(old_id, new_id);
+            }
+        }
+
+        // Merge strings (deduplicate by content)
+        for (content, old_id) in state.string_table {
+            let new_id = if let Some(&id) = self.string_map.get(&content) {
+                id
+            } else {
+                let id = self.strings.len() as u32;
+                self.strings.push(content.clone());
+                self.string_map.insert(content, id);
+                id
+            };
+            if old_id != new_id {
+                string_remap.insert(old_id, new_id);
+            }
+        }
+
+        // Merge warnings (no deduplication needed)
+        self.warnings.extend(state.warnings);
+
+        AnalysisStateRemapping {
+            array_remap,
+            string_remap,
+        }
+    }
+}
+
+/// Remapping information for updating AIR after merging.
+///
+/// When function analysis states are merged, IDs may change due to
+/// deduplication. This struct provides the mapping from old to new IDs.
+#[derive(Debug, Default)]
+pub struct AnalysisStateRemapping {
+    /// Mapping from old ArrayTypeId to new ArrayTypeId.
+    /// Only contains entries where the ID changed.
+    pub array_remap: HashMap<ArrayTypeId, ArrayTypeId>,
+    /// Mapping from old string index to new string index.
+    /// Only contains entries where the index changed.
+    pub string_remap: HashMap<u32, u32>,
+}
+
+impl AnalysisStateRemapping {
+    /// Check if any remapping is needed.
+    pub fn is_empty(&self) -> bool {
+        self.array_remap.is_empty() && self.string_remap.is_empty()
+    }
+
+    /// Remap an array type ID if needed.
+    pub fn remap_array_type(&self, id: ArrayTypeId) -> ArrayTypeId {
+        self.array_remap.get(&id).copied().unwrap_or(id)
+    }
+
+    /// Remap a string index if needed.
+    pub fn remap_string(&self, id: u32) -> u32 {
+        self.string_remap.get(&id).copied().unwrap_or(id)
+    }
+}

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -10,11 +10,14 @@
 //!
 //! Inspired by Zig's AIR (Analyzed Intermediate Representation).
 
+mod analysis_state;
 mod inference;
 mod inst;
 mod sema;
+mod type_context;
 mod types;
 
+pub use analysis_state::{AnalysisStateRemapping, FunctionAnalysisState, MergedAnalysisState};
 pub use inference::{
     Constraint, ConstraintContext, ConstraintGenerator, ExprInfo, FunctionSig, InferType,
     LocalVarInfo, MethodSig, ParamVarInfo, Substitution, TypeVarAllocator, TypeVarId,
@@ -24,6 +27,7 @@ pub use inst::{
     Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirParamMode, AirPattern, AirRef,
 };
 pub use sema::{AnalyzedFunction, Sema, SemaOutput};
+pub use type_context::{FunctionSignature, MethodSignature, TypeContext};
 pub use types::{
     ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructField, StructId, Type,
     parse_array_type_syntax,

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -10,6 +10,7 @@ use crate::inference::{
     ParamVarInfo, Unifier, UnifyResult,
 };
 use crate::inst::{Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirPattern, AirRef};
+use crate::type_context::{FunctionSignature, MethodSignature, TypeContext};
 use crate::types::{
     ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructField, StructId, Type,
     parse_array_type_syntax,
@@ -305,6 +306,66 @@ impl<'a> Sema<'a> {
             warnings: Vec::new(),
             methods: HashMap::new(),
             preview_features,
+        }
+    }
+
+    /// Build a `TypeContext` from the collected type information.
+    ///
+    /// This should be called after the collection phase (after calling
+    /// `collect_struct_definitions`, `collect_enum_definitions`,
+    /// `collect_function_signatures`, and `collect_method_definitions`).
+    ///
+    /// The returned `TypeContext` is immutable and can be shared across
+    /// threads for parallel function analysis.
+    ///
+    /// # Panics
+    ///
+    /// This method clones the type information, so it should only be called
+    /// once per analysis to avoid unnecessary allocations.
+    pub fn build_type_context(&self) -> TypeContext {
+        // Build function signatures
+        let func_sigs: HashMap<Symbol, FunctionSignature> = self
+            .functions
+            .iter()
+            .map(|(name, info)| {
+                (
+                    *name,
+                    FunctionSignature {
+                        param_types: info.param_types.clone(),
+                        param_modes: info.param_modes.clone(),
+                        return_type: info.return_type,
+                    },
+                )
+            })
+            .collect();
+
+        // Build method signatures
+        let method_sigs: HashMap<(Symbol, Symbol), MethodSignature> = self
+            .methods
+            .iter()
+            .map(|((type_name, method_name), info)| {
+                let struct_id = *self.structs.get(type_name).expect("method type must exist");
+                (
+                    (*type_name, *method_name),
+                    MethodSignature {
+                        struct_id,
+                        struct_type: info.struct_type,
+                        has_self: info.has_self,
+                        param_names: info.param_names.clone(),
+                        param_types: info.param_types.clone(),
+                        return_type: info.return_type,
+                    },
+                )
+            })
+            .collect();
+
+        TypeContext {
+            func_sigs,
+            method_sigs,
+            struct_by_name: self.structs.clone(),
+            struct_defs: self.struct_defs.clone(),
+            enum_by_name: self.enums.clone(),
+            enum_defs: self.enum_defs.clone(),
         }
     }
 

--- a/crates/rue-air/src/type_context.rs
+++ b/crates/rue-air/src/type_context.rs
@@ -1,0 +1,126 @@
+//! Type context for semantic analysis.
+//!
+//! This module contains the immutable type information that can be shared
+//! across parallel function analysis. The `TypeContext` is built during the
+//! collection phase and then shared (via `&` or `Arc`) during function analysis.
+
+use std::collections::HashMap;
+
+use rue_intern::Symbol;
+use rue_rir::RirParamMode;
+
+use crate::types::{EnumDef, EnumId, StructDef, StructId, Type};
+
+/// Immutable type context for semantic analysis.
+///
+/// This struct contains all type information that is read-only after the
+/// collection phase. It can be safely shared across threads during parallel
+/// function analysis.
+///
+/// # Separation of Concerns
+///
+/// The `TypeContext` contains:
+/// - Type definitions (structs, enums)
+/// - Function and method signatures
+/// - Type-to-ID mappings
+///
+/// It does NOT contain:
+/// - Array type table (created during analysis)
+/// - String table (created during analysis)
+/// - Warnings (collected during analysis)
+///
+/// Those mutable items live in `FunctionAnalysisState` (per-function) and
+/// are merged after parallel analysis completes.
+#[derive(Debug, Clone)]
+pub struct TypeContext {
+    /// Function signatures: maps function name to signature info.
+    pub func_sigs: HashMap<Symbol, FunctionSignature>,
+    /// Method signatures: maps (type_name, method_name) to signature info.
+    pub method_sigs: HashMap<(Symbol, Symbol), MethodSignature>,
+    /// Struct lookup: maps struct name symbol to StructId.
+    pub struct_by_name: HashMap<Symbol, StructId>,
+    /// Struct definitions indexed by StructId.
+    pub struct_defs: Vec<StructDef>,
+    /// Enum lookup: maps enum name symbol to EnumId.
+    pub enum_by_name: HashMap<Symbol, EnumId>,
+    /// Enum definitions indexed by EnumId.
+    pub enum_defs: Vec<EnumDef>,
+}
+
+/// Signature information for a function.
+#[derive(Debug, Clone)]
+pub struct FunctionSignature {
+    /// Parameter types in order.
+    pub param_types: Vec<Type>,
+    /// Parameter passing modes in order.
+    pub param_modes: Vec<RirParamMode>,
+    /// Return type.
+    pub return_type: Type,
+}
+
+/// Signature information for a method.
+#[derive(Debug, Clone)]
+pub struct MethodSignature {
+    /// The type this method belongs to (as a StructId for lookup).
+    pub struct_id: StructId,
+    /// The struct type (Type::Struct(struct_id)).
+    pub struct_type: Type,
+    /// Whether this is a method (has self) or associated function (no self).
+    pub has_self: bool,
+    /// Parameter names (excluding self if present).
+    pub param_names: Vec<Symbol>,
+    /// Parameter types (excluding self if present).
+    pub param_types: Vec<Type>,
+    /// Return type.
+    pub return_type: Type,
+}
+
+impl TypeContext {
+    /// Create a new empty TypeContext.
+    pub fn new() -> Self {
+        Self {
+            func_sigs: HashMap::new(),
+            method_sigs: HashMap::new(),
+            struct_by_name: HashMap::new(),
+            struct_defs: Vec::new(),
+            enum_by_name: HashMap::new(),
+            enum_defs: Vec::new(),
+        }
+    }
+
+    /// Look up a struct by name.
+    pub fn get_struct(&self, name: Symbol) -> Option<StructId> {
+        self.struct_by_name.get(&name).copied()
+    }
+
+    /// Get a struct definition by ID.
+    pub fn get_struct_def(&self, id: StructId) -> &StructDef {
+        &self.struct_defs[id.0 as usize]
+    }
+
+    /// Look up an enum by name.
+    pub fn get_enum(&self, name: Symbol) -> Option<EnumId> {
+        self.enum_by_name.get(&name).copied()
+    }
+
+    /// Get an enum definition by ID.
+    pub fn get_enum_def(&self, id: EnumId) -> &EnumDef {
+        &self.enum_defs[id.0 as usize]
+    }
+
+    /// Look up a function signature by name.
+    pub fn get_function(&self, name: Symbol) -> Option<&FunctionSignature> {
+        self.func_sigs.get(&name)
+    }
+
+    /// Look up a method signature by type and method name.
+    pub fn get_method(&self, type_name: Symbol, method_name: Symbol) -> Option<&MethodSignature> {
+        self.method_sigs.get(&(type_name, method_name))
+    }
+}
+
+impl Default for TypeContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}


### PR DESCRIPTION
…l analysis

Separate immutable type information from per-function mutable state in Sema:

- TypeContext: Immutable struct containing function signatures, method signatures, struct/enum definitions. Can be shared across threads.

- FunctionAnalysisState: Per-function mutable state for array types, strings, and warnings. Each function gets its own instance during parallel analysis, then results are merged.

- MergedAnalysisState: Handles deduplication when merging multiple function analysis states (array types by key, strings by content).

- Added build_type_context() method to Sema to extract TypeContext after the collection phase.

This prepares the codebase for parallel function analysis by clearly separating what can be shared (TypeContext) from what needs per-thread isolation (FunctionAnalysisState).

Closes: rue-k5vt

🤖 Generated with [Claude Code](https://claude.com/claude-code)