### PR TITLE
Add peephole optimization pass after register allocation

### DIFF
--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -1015,6 +1015,12 @@ impl Aarch64Mir {
         &mut self.instructions
     }
 
+    /// Get mutable access to the instruction vector (for peephole optimization).
+    #[inline]
+    pub fn instructions_vec_mut(&mut self) -> &mut Vec<Aarch64Inst> {
+        &mut self.instructions
+    }
+
     /// Iterate over instructions.
     pub fn iter(&self) -> impl Iterator<Item = &Aarch64Inst> {
         self.instructions.iter()

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -15,6 +15,7 @@ mod cfg_lower;
 mod emit;
 pub mod liveness;
 mod mir;
+mod peephole;
 mod regalloc;
 
 pub use cfg_lower::CfgLower;
@@ -51,8 +52,11 @@ pub fn generate(
 
     // Allocate physical registers
     let existing_slots = num_locals + num_params;
-    let (mir, num_spills, used_callee_saved) =
+    let (mut mir, num_spills, used_callee_saved) =
         RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
+
+    // Apply peephole optimizations after register allocation
+    peephole::optimize(mir.instructions_vec_mut());
 
     // Emit machine code bytes
     let total_locals = num_locals + num_spills;
@@ -85,8 +89,11 @@ pub fn generate_with_asm(
 
     // Allocate physical registers
     let existing_slots = num_locals + num_params;
-    let (mir, num_spills, used_callee_saved) =
+    let (mut mir, num_spills, used_callee_saved) =
         RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
+
+    // Apply peephole optimizations after register allocation
+    peephole::optimize(mir.instructions_vec_mut());
 
     // Emit machine code bytes with assembly text
     let total_locals = num_locals + num_spills;

--- a/crates/rue-codegen/src/aarch64/peephole.rs
+++ b/crates/rue-codegen/src/aarch64/peephole.rs
@@ -1,0 +1,223 @@
+//! Peephole optimization pass for AArch64.
+//!
+//! This pass runs after register allocation and removes redundant instructions
+//! such as:
+//! - `mov x, x` (no-op moves where src == dst)
+//! - `add x, x, #0` / `sub x, x, #0` (identity arithmetic)
+//!
+//! The pass operates in-place on the instruction vector for efficiency.
+
+use super::mir::{Aarch64Inst, Operand};
+
+/// Apply peephole optimizations to the instruction stream.
+///
+/// This modifies the vector in place, removing redundant instructions.
+/// Returns the number of instructions removed.
+pub fn optimize(instructions: &mut Vec<Aarch64Inst>) -> usize {
+    let original_count = instructions.len();
+
+    instructions.retain(|inst| !is_redundant(inst));
+
+    original_count - instructions.len()
+}
+
+/// Check if an instruction is redundant and can be removed.
+fn is_redundant(inst: &Aarch64Inst) -> bool {
+    match inst {
+        // mov r, r where src == dst is a no-op
+        Aarch64Inst::MovRR { dst, src } => operands_equal(dst, src),
+
+        // add r, r, #0 is identity
+        Aarch64Inst::AddImm { dst, src, imm: 0 } => operands_equal(dst, src),
+
+        // sub r, r, #0 is identity
+        Aarch64Inst::SubImm { dst, src, imm: 0 } => operands_equal(dst, src),
+
+        // Other identity patterns could be added here in the future:
+        // - lsl r, r, #0 (shift by 0)
+        // - lsr r, r, #0 (shift by 0)
+        // - and r, r, #-1 (AND with all 1s)
+        // - orr r, r, #0 (OR with 0)
+        _ => false,
+    }
+}
+
+/// Check if two operands refer to the same physical register.
+///
+/// This only works correctly after register allocation, when all operands
+/// are physical registers.
+fn operands_equal(a: &Operand, b: &Operand) -> bool {
+    match (a, b) {
+        (Operand::Physical(ra), Operand::Physical(rb)) => ra == rb,
+        // Virtual registers are not compared - peephole runs after regalloc
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::aarch64::mir::Reg;
+
+    #[test]
+    fn test_remove_redundant_mov() {
+        let mut instructions = vec![
+            Aarch64Inst::MovImm {
+                dst: Operand::Physical(Reg::X0),
+                imm: 42,
+            },
+            // This is redundant: mov x0, x0
+            Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Physical(Reg::X0),
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        let removed = optimize(&mut instructions);
+
+        assert_eq!(removed, 1);
+        assert_eq!(instructions.len(), 2);
+        // Verify the mov x0, x0 was removed
+        assert!(matches!(instructions[0], Aarch64Inst::MovImm { .. }));
+        assert!(matches!(instructions[1], Aarch64Inst::Ret));
+    }
+
+    #[test]
+    fn test_keep_useful_mov() {
+        let mut instructions = vec![
+            Aarch64Inst::MovImm {
+                dst: Operand::Physical(Reg::X0),
+                imm: 42,
+            },
+            // This is NOT redundant: mov x1, x0
+            Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X1),
+                src: Operand::Physical(Reg::X0),
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        let removed = optimize(&mut instructions);
+
+        assert_eq!(removed, 0);
+        assert_eq!(instructions.len(), 3);
+    }
+
+    #[test]
+    fn test_remove_add_zero() {
+        let mut instructions = vec![
+            Aarch64Inst::MovImm {
+                dst: Operand::Physical(Reg::X0),
+                imm: 42,
+            },
+            // This is redundant: add x0, x0, #0
+            Aarch64Inst::AddImm {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Physical(Reg::X0),
+                imm: 0,
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        let removed = optimize(&mut instructions);
+
+        assert_eq!(removed, 1);
+        assert_eq!(instructions.len(), 2);
+    }
+
+    #[test]
+    fn test_remove_sub_zero() {
+        let mut instructions = vec![
+            Aarch64Inst::MovImm {
+                dst: Operand::Physical(Reg::X0),
+                imm: 42,
+            },
+            // This is redundant: sub x0, x0, #0
+            Aarch64Inst::SubImm {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Physical(Reg::X0),
+                imm: 0,
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        let removed = optimize(&mut instructions);
+
+        assert_eq!(removed, 1);
+        assert_eq!(instructions.len(), 2);
+    }
+
+    #[test]
+    fn test_keep_add_nonzero() {
+        let mut instructions = vec![
+            Aarch64Inst::MovImm {
+                dst: Operand::Physical(Reg::X0),
+                imm: 42,
+            },
+            // This is NOT redundant: add x0, x0, #1
+            Aarch64Inst::AddImm {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Physical(Reg::X0),
+                imm: 1,
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        let removed = optimize(&mut instructions);
+
+        assert_eq!(removed, 0);
+        assert_eq!(instructions.len(), 3);
+    }
+
+    #[test]
+    fn test_keep_add_different_dst() {
+        let mut instructions = vec![
+            Aarch64Inst::MovImm {
+                dst: Operand::Physical(Reg::X0),
+                imm: 42,
+            },
+            // This is NOT redundant even with imm=0: add x1, x0, #0 (dst != src)
+            Aarch64Inst::AddImm {
+                dst: Operand::Physical(Reg::X1),
+                src: Operand::Physical(Reg::X0),
+                imm: 0,
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        let removed = optimize(&mut instructions);
+
+        assert_eq!(removed, 0);
+        assert_eq!(instructions.len(), 3);
+    }
+
+    #[test]
+    fn test_multiple_redundant_instructions() {
+        let mut instructions = vec![
+            Aarch64Inst::MovImm {
+                dst: Operand::Physical(Reg::X0),
+                imm: 42,
+            },
+            Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Physical(Reg::X0),
+            },
+            Aarch64Inst::AddImm {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Physical(Reg::X0),
+                imm: 0,
+            },
+            Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X1),
+                src: Operand::Physical(Reg::X1),
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        let removed = optimize(&mut instructions);
+
+        assert_eq!(removed, 3);
+        assert_eq!(instructions.len(), 2);
+    }
+}

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -652,6 +652,12 @@ impl X86Mir {
         &mut self.instructions
     }
 
+    /// Get mutable access to the instruction vector (for peephole optimization).
+    #[inline]
+    pub fn instructions_vec_mut(&mut self) -> &mut Vec<X86Inst> {
+        &mut self.instructions
+    }
+
     /// Iterate over instructions.
     pub fn iter(&self) -> impl Iterator<Item = &X86Inst> {
         self.instructions.iter()

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -15,6 +15,7 @@ mod cfg_lower;
 mod emit;
 pub mod liveness;
 mod mir;
+mod peephole;
 mod regalloc;
 
 pub use cfg_lower::CfgLower;
@@ -52,8 +53,11 @@ pub fn generate(
     // Allocate physical registers (may add spill slots)
     // Spill slots go after both locals AND parameters to avoid conflicts
     let existing_slots = num_locals + num_params;
-    let (mir, num_spills, used_callee_saved) =
+    let (mut mir, num_spills, used_callee_saved) =
         RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
+
+    // Apply peephole optimizations after register allocation
+    peephole::optimize(mir.instructions_vec_mut());
 
     // Emit machine code bytes (with prologue for stack frame setup)
     // Total local slots = local variables + spill slots (params handled separately)
@@ -96,8 +100,11 @@ pub fn generate_with_asm(
 
     // Allocate physical registers (may add spill slots)
     let existing_slots = num_locals + num_params;
-    let (mir, num_spills, used_callee_saved) =
+    let (mut mir, num_spills, used_callee_saved) =
         RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
+
+    // Apply peephole optimizations after register allocation
+    peephole::optimize(mir.instructions_vec_mut());
 
     // Emit machine code bytes with assembly text
     let total_locals = num_locals + num_spills;

--- a/crates/rue-codegen/src/x86_64/peephole.rs
+++ b/crates/rue-codegen/src/x86_64/peephole.rs
@@ -1,0 +1,173 @@
+//! Peephole optimization pass for x86-64.
+//!
+//! This pass runs after register allocation and removes redundant instructions
+//! such as:
+//! - `mov r, r` (no-op moves where src == dst)
+//! - `add r, 0` / `sub r, 0` (identity arithmetic)
+//!
+//! The pass operates in-place on the instruction vector for efficiency.
+
+use super::mir::{Operand, X86Inst};
+
+/// Apply peephole optimizations to the instruction stream.
+///
+/// This modifies the vector in place, removing redundant instructions.
+/// Returns the number of instructions removed.
+pub fn optimize(instructions: &mut Vec<X86Inst>) -> usize {
+    let original_count = instructions.len();
+
+    instructions.retain(|inst| !is_redundant(inst));
+
+    original_count - instructions.len()
+}
+
+/// Check if an instruction is redundant and can be removed.
+fn is_redundant(inst: &X86Inst) -> bool {
+    match inst {
+        // mov r, r where src == dst is a no-op
+        X86Inst::MovRR { dst, src } => operands_equal(dst, src),
+
+        // add r, 0 is identity
+        X86Inst::AddRI { imm: 0, .. } => true,
+
+        // Other identity patterns could be added here in the future:
+        // - sub r, 0 (would need SubRI instruction)
+        // - xor r, 0 (would need XorRI with 0)
+        // - and r, -1 (would need AndRI)
+        // - or r, 0 (would need OrRI)
+        _ => false,
+    }
+}
+
+/// Check if two operands refer to the same physical register.
+///
+/// This only works correctly after register allocation, when all operands
+/// are physical registers.
+fn operands_equal(a: &Operand, b: &Operand) -> bool {
+    match (a, b) {
+        (Operand::Physical(ra), Operand::Physical(rb)) => ra == rb,
+        // Virtual registers are not compared - peephole runs after regalloc
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::x86_64::mir::Reg;
+
+    #[test]
+    fn test_remove_redundant_mov() {
+        let mut instructions = vec![
+            X86Inst::MovRI32 {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 42,
+            },
+            // This is redundant: mov rax, rax
+            X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rax),
+                src: Operand::Physical(Reg::Rax),
+            },
+            X86Inst::Ret,
+        ];
+
+        let removed = optimize(&mut instructions);
+
+        assert_eq!(removed, 1);
+        assert_eq!(instructions.len(), 2);
+        // Verify the mov rax, rax was removed
+        assert!(matches!(instructions[0], X86Inst::MovRI32 { .. }));
+        assert!(matches!(instructions[1], X86Inst::Ret));
+    }
+
+    #[test]
+    fn test_keep_useful_mov() {
+        let mut instructions = vec![
+            X86Inst::MovRI32 {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 42,
+            },
+            // This is NOT redundant: mov rbx, rax
+            X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rbx),
+                src: Operand::Physical(Reg::Rax),
+            },
+            X86Inst::Ret,
+        ];
+
+        let removed = optimize(&mut instructions);
+
+        assert_eq!(removed, 0);
+        assert_eq!(instructions.len(), 3);
+    }
+
+    #[test]
+    fn test_remove_add_zero() {
+        let mut instructions = vec![
+            X86Inst::MovRI32 {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 42,
+            },
+            // This is redundant: add rax, 0
+            X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 0,
+            },
+            X86Inst::Ret,
+        ];
+
+        let removed = optimize(&mut instructions);
+
+        assert_eq!(removed, 1);
+        assert_eq!(instructions.len(), 2);
+    }
+
+    #[test]
+    fn test_keep_add_nonzero() {
+        let mut instructions = vec![
+            X86Inst::MovRI32 {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 42,
+            },
+            // This is NOT redundant: add rax, 1
+            X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 1,
+            },
+            X86Inst::Ret,
+        ];
+
+        let removed = optimize(&mut instructions);
+
+        assert_eq!(removed, 0);
+        assert_eq!(instructions.len(), 3);
+    }
+
+    #[test]
+    fn test_multiple_redundant_instructions() {
+        let mut instructions = vec![
+            X86Inst::MovRI32 {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 42,
+            },
+            X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rax),
+                src: Operand::Physical(Reg::Rax),
+            },
+            X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 0,
+            },
+            X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rbx),
+                src: Operand::Physical(Reg::Rbx),
+            },
+            X86Inst::Ret,
+        ];
+
+        let removed = optimize(&mut instructions);
+
+        assert_eq!(removed, 3);
+        assert_eq!(instructions.len(), 2);
+    }
+}


### PR DESCRIPTION
Implements a peephole optimization pass for both x86_64 and aarch64 backends that removes redundant instructions after register allocation:

x86_64:
- mov r, r where src == dst (no-op moves)
- add r, 0 (identity addition)

aarch64:
- mov r, r where src == dst (no-op moves)
- add r, r, #0 where dst == src (identity addition)
- sub r, r, #0 where dst == src (identity subtraction)

The pass runs after register allocation in both generate() and generate_with_asm() functions, producing cleaner generated code.

Fixes rue-q4ba

🤖 Generated with [Claude Code](https://claude.com/claude-code)