### PR TITLE
Spec: Standardize normative language (RFC 2119 keywords)

### DIFF
--- a/docs/spec/src/01-introduction.md
+++ b/docs/spec/src/01-introduction.md
@@ -35,7 +35,7 @@ This specification does not cover:
 
 {{ rule(id="1.3:1", cat="normative") }}
 
-A conforming implementation must implement all normative requirements of this specification.
+A conforming implementation **MUST** implement all normative requirements of this specification.
 
 {{ rule(id="1.3:2") }}
 

--- a/docs/spec/src/02-lexical-structure/01-tokens.md
+++ b/docs/spec/src/02-lexical-structure/01-tokens.md
@@ -38,7 +38,7 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 
 {{ rule(id="2.1:4", cat="normative") }}
 
-Integer literals must be representable in their target type. An unadorned integer literal defaults to type `i32`.
+Integer literals **MUST** be representable in their target type. An unadorned integer literal defaults to type `i32`.
 
 {{ rule(id="2.1:5") }}
 

--- a/docs/spec/src/02-lexical-structure/05-builtins.md
+++ b/docs/spec/src/02-lexical-structure/05-builtins.md
@@ -159,7 +159,7 @@ fn example() -> i32 {
 
 {{ rule(id="2.5:23", cat="normative") }}
 
-Multiple warning names may be specified in a single `@allow` directive, separated by commas.
+Multiple warning names **MAY** be specified in a single `@allow` directive, separated by commas.
 
 {{ rule(id="2.5:24") }}
 
@@ -200,7 +200,7 @@ The `@copy` directive marks a struct type as a Copy type.
 
 {{ rule(id="2.5:28", cat="normative") }}
 
-`@copy` must appear immediately before a struct definition.
+`@copy` **MUST** appear immediately before a struct definition.
 
 {{ rule(id="2.5:29", cat="normative") }}
 

--- a/docs/spec/src/03-types/05-array-types.md
+++ b/docs/spec/src/03-types/05-array-types.md
@@ -12,11 +12,11 @@ An array type, written `[T; N]`, represents a fixed-size sequence of `N` element
 
 {{ rule(id="3.5:2", cat="normative") }}
 
-The length `N` must be a non-negative integer literal known at compile time.
+The length `N` **MUST** be a non-negative integer literal known at compile time.
 
 {{ rule(id="3.5:3", cat="normative") }}
 
-All elements of an array must have the same type `T`.
+All elements of an array **MUST** have the same type `T`.
 
 {{ rule(id="3.5:4", cat="normative") }}
 

--- a/docs/spec/src/03-types/06-struct-types.md
+++ b/docs/spec/src/03-types/06-struct-types.md
@@ -40,11 +40,11 @@ Struct fields are accessed using dot notation: `value.field_name`.
 
 {{ rule(id="3.6:5", cat="normative") }}
 
-All fields must be initialized when creating a struct instance.
+All fields **MUST** be initialized when creating a struct instance.
 
 {{ rule(id="3.6:6", cat="normative") }}
 
-Field names must be unique within a struct.
+Field names **MUST** be unique within a struct.
 
 ## Memory Layout
 

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -44,7 +44,7 @@ fn main() -> i32 {
 
 {{ rule(id="3.8:14", cat="normative") }}
 
-A struct type may be declared as a Copy type using the `@copy` directive before the struct definition.
+A struct type **MAY** be declared as a Copy type using the `@copy` directive before the struct definition.
 
 {{ rule(id="3.8:15", cat="syntax") }}
 
@@ -72,7 +72,7 @@ fn main() -> i32 {
 
 {{ rule(id="3.8:18", cat="legality-rule") }}
 
-A `@copy` struct must contain only fields that are themselves Copy types. It is a compile-time error to mark a struct as `@copy` if any of its fields are move types.
+A `@copy` struct **MUST** contain only fields that are themselves Copy types. It is a compile-time error to mark a struct as `@copy` if any of its fields are move types.
 
 {{ rule(id="3.8:19", cat="example") }}
 
@@ -85,7 +85,7 @@ struct Outer { inner: Inner }  // ERROR: field 'inner' has non-Copy type 'Inner'
 
 {{ rule(id="3.8:20", cat="normative") }}
 
-A `@copy` struct may contain fields of primitive Copy types (integers, booleans, unit), enum types, or other `@copy` struct types.
+A `@copy` struct **MAY** contain fields of primitive Copy types (integers, booleans, unit), enum types, or other `@copy` struct types.
 
 {{ rule(id="3.8:21", cat="example") }}
 

--- a/docs/spec/src/03-types/09-destructors.md
+++ b/docs/spec/src/03-types/09-destructors.md
@@ -155,11 +155,11 @@ drop fn TypeName(self) {
 
 {{ rule(id="3.9:22", cat="normative") }}
 
-A user-defined destructor must be declared at the top level, outside of any `impl` block. It must take exactly one parameter named `self` and return nothing (implicit unit type).
+A user-defined destructor **MUST** be declared at the top level, outside of any `impl` block. It **MUST** take exactly one parameter named `self` and return nothing (implicit unit type).
 
 {{ rule(id="3.9:23", cat="legality-rule") }}
 
-Each struct type may have at most one user-defined destructor. A compile-time error is raised if multiple destructors are declared for the same type.
+Each struct type **MAY** have at most one user-defined destructor. A compile-time error is raised if multiple destructors are declared for the same type.
 
 {{ rule(id="3.9:24", cat="legality-rule") }}
 

--- a/docs/spec/src/04-expressions/03a-bitwise-operators.md
+++ b/docs/spec/src/04-expressions/03a-bitwise-operators.md
@@ -76,7 +76,7 @@ For right shift (`>>`), the behavior depends on the signedness of the operand ty
 
 {{ rule(id="4.3a:9", cat="normative") }}
 
-The shift amount operand shall have the same type as the value being shifted.
+The shift amount operand **MUST** have the same type as the value being shifted.
 
 {{ rule(id="4.3a:10", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/07-match-expressions.md
+++ b/docs/spec/src/04-expressions/07-match-expressions.md
@@ -51,7 +51,7 @@ is matched by at least one pattern in the set.
 
 {{ rule(id="4.7:9", cat="normative") }}
 
-A match expression shall have an exhaustive set of patterns for its scrutinee type.
+A match expression **MUST** have an exhaustive set of patterns for its scrutinee type.
 A match expression with a non-exhaustive pattern set is rejected with a compile-time error.
 
 {{ rule(id="4.7:10", cat="normative") }}
@@ -79,18 +79,18 @@ fn main() -> i32 {
 
 {{ rule(id="4.7:12", cat="normative") }}
 
-All match arms shall have the same type. The type of the match expression is the common type of its arms.
+All match arms **MUST** have the same type. The type of the match expression is the common type of its arms.
 
 {{ rule(id="4.7:13", cat="normative") }}
 
-The type of each pattern shall be compatible with the type of the scrutinee.
+The type of each pattern **MUST** be compatible with the type of the scrutinee.
 A pattern with an incompatible type is rejected with a compile-time error.
 
 ## Arm Bodies
 
 {{ rule(id="4.7:14", cat="normative") }}
 
-Match arm bodies may be simple expressions or block expressions.
+Match arm bodies **MAY** be simple expressions or block expressions.
 
 {{ rule(id="4.7:15") }}
 

--- a/docs/spec/src/04-expressions/12-field-access.md
+++ b/docs/spec/src/04-expressions/12-field-access.md
@@ -18,11 +18,11 @@ field_access = expression "." IDENT ;
 
 {{ rule(id="4.12:3", cat="normative") }}
 
-The expression before the dot must have a struct type.
+The expression before the dot **MUST** have a struct type.
 
 {{ rule(id="4.12:4", cat="normative") }}
 
-The identifier must be a valid field name for that struct type.
+The identifier **MUST** be a valid field name for that struct type.
 
 {{ rule(id="4.12:5", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -19,7 +19,7 @@ intrinsic_arg = expression | type ;
 
 {{ rule(id="4.13:2a", cat="normative") }}
 
-Intrinsics may accept expressions, types, or a combination of both as arguments, depending on the specific intrinsic.
+Intrinsics **MAY** accept expressions, types, or a combination of both as arguments, depending on the specific intrinsic.
 
 {{ rule(id="4.13:3", cat="normative") }}
 
@@ -92,7 +92,7 @@ The `@size_of` intrinsic returns the size of a type in bytes.
 
 {{ rule(id="4.13:13", cat="normative") }}
 
-`@size_of` accepts exactly one argument, which must be a type.
+`@size_of` accepts exactly one argument, which **MUST** be a type.
 
 {{ rule(id="4.13:14", cat="normative") }}
 
@@ -128,7 +128,7 @@ The `@align_of` intrinsic returns the alignment of a type in bytes.
 
 {{ rule(id="4.13:19", cat="normative") }}
 
-`@align_of` accepts exactly one argument, which must be a type.
+`@align_of` accepts exactly one argument, which **MUST** be a type.
 
 {{ rule(id="4.13:20", cat="normative") }}
 
@@ -158,7 +158,7 @@ The `@intCast` intrinsic converts an integer value from one integer type to anot
 
 {{ rule(id="4.13:25", cat="normative") }}
 
-`@intCast` accepts exactly one argument, which must be an integer type (any of `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`).
+`@intCast` accepts exactly one argument, which **MUST** be an integer type (any of `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`).
 
 {{ rule(id="4.13:26", cat="normative") }}
 

--- a/docs/spec/src/05-statements/02-assignment.md
+++ b/docs/spec/src/05-statements/02-assignment.md
@@ -81,7 +81,7 @@ Fields of nested structs can be assigned through chained field access.
 
 {{ rule(id="5.2:12", cat="normative") }}
 
-All struct values in the chain must be part of a mutable binding.
+All struct values in the chain **MUST** be part of a mutable binding.
 
 {{ rule(id="5.2:13") }}
 

--- a/docs/spec/src/06-items/03-enums.md
+++ b/docs/spec/src/06-items/03-enums.md
@@ -21,7 +21,7 @@ enum_variants = IDENT { "," IDENT } [ "," ] ;
 
 {{ rule(id="6.3:3", cat="normative") }}
 
-Variant names must be unique within an enum.
+Variant names **MUST** be unique within an enum.
 
 {{ rule(id="6.3:12", cat="normative") }}
 
@@ -61,7 +61,7 @@ Each arm pattern uses the same path syntax as enum variant expressions.
 
 {{ rule(id="6.3:8", cat="normative") }}
 
-Match expressions on enums must be exhaustive: all variants must be covered,
+Match expressions on enums **MUST** be exhaustive: all variants **MUST** be covered,
 either explicitly or via a wildcard pattern `_`.
 
 {{ rule(id="6.3:9") }}

--- a/docs/spec/src/06-items/04-impl-blocks.md
+++ b/docs/spec/src/06-items/04-impl-blocks.md
@@ -58,7 +58,7 @@ A method call `receiver.method(args)` is desugared to a function call with the r
 
 {{ rule(id="6.4:8", cat="normative") }}
 
-Methods may have additional parameters after `self`.
+Methods **MAY** have additional parameters after `self`.
 
 {{ rule(id="6.4:9", cat="example") }}
 
@@ -82,7 +82,7 @@ fn main() -> i32 {
 
 {{ rule(id="6.4:10", cat="normative") }}
 
-When a method returns the same struct type, method calls may be chained.
+When a method returns the same struct type, method calls **MAY** be chained.
 
 {{ rule(id="6.4:11", cat="example") }}
 


### PR DESCRIPTION
Replace informal 'must', 'may', 'shall' with RFC 2119 formatted keywords (**MUST**, **MAY**, etc.) throughout the specification. This ensures consistent normative language that clearly distinguishes requirements from informative text.

Files changed:
- docs/spec/src/01-introduction.md
- docs/spec/src/02-lexical-structure/01-tokens.md
- docs/spec/src/02-lexical-structure/05-builtins.md
- docs/spec/src/03-types/05-array-types.md
- docs/spec/src/03-types/06-struct-types.md
- docs/spec/src/03-types/08-move-semantics.md
- docs/spec/src/03-types/09-destructors.md
- docs/spec/src/04-expressions/03a-bitwise-operators.md
- docs/spec/src/04-expressions/07-match-expressions.md
- docs/spec/src/04-expressions/12-field-access.md
- docs/spec/src/04-expressions/13-intrinsics.md
- docs/spec/src/05-statements/02-assignment.md
- docs/spec/src/06-items/03-enums.md
- docs/spec/src/06-items/04-impl-blocks.md

Fixes rue-loz

🤖 Generated with [Claude Code](https://claude.com/claude-code)