### PR TITLE
Add function boundaries to RIR for per-function analysis

### DIFF
--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -16,8 +16,8 @@ use rue_parser::{
 };
 
 use crate::inst::{
-    Inst, InstData, InstRef, Rir, RirArgMode, RirCallArg, RirDirective, RirParam, RirParamMode,
-    RirPattern,
+    FunctionSpan, Inst, InstData, InstRef, Rir, RirArgMode, RirCallArg, RirDirective, RirParam,
+    RirParamMode, RirPattern,
 };
 
 /// Generates RIR from an AST.
@@ -193,6 +193,9 @@ impl<'a> AstGen<'a> {
             .collect();
         let (params_start, params_len) = self.rir.add_params(&params);
 
+        // Record the body start before generating body instructions
+        let body_start = InstRef::from_raw(self.rir.current_inst_index());
+
         // Generate body expression
         let body = self.gen_expr(&method.body);
 
@@ -201,7 +204,7 @@ impl<'a> AstGen<'a> {
 
         // Emit methods as FnDecl instructions with has_self flag.
         // Sema uses has_self to add the implicit self parameter for methods.
-        self.rir.add_inst(Inst {
+        let decl = self.rir.add_inst(Inst {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
@@ -213,7 +216,14 @@ impl<'a> AstGen<'a> {
                 has_self,
             },
             span: method.span,
-        })
+        });
+
+        // Record the function span for per-function analysis
+        // Methods are also tracked as functions for per-function analysis
+        self.rir
+            .add_function_span(FunctionSpan::new(name, body_start, decl));
+
+        decl
     }
 
     /// Convert AST directives to RIR directives
@@ -284,12 +294,15 @@ impl<'a> AstGen<'a> {
             .collect();
         let (params_start, params_len) = self.rir.add_params(&params);
 
+        // Record the body start before generating body instructions
+        let body_start = InstRef::from_raw(self.rir.current_inst_index());
+
         // Generate body expression
         let body = self.gen_expr(&func.body);
 
         // Create function declaration instruction
         // Regular functions don't have a self receiver
-        self.rir.add_inst(Inst {
+        let decl = self.rir.add_inst(Inst {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
@@ -301,7 +314,13 @@ impl<'a> AstGen<'a> {
                 has_self: false,
             },
             span: func.span,
-        })
+        });
+
+        // Record the function span for per-function analysis
+        self.rir
+            .add_function_span(FunctionSpan::new(name, body_start, decl));
+
+        decl
     }
 
     fn gen_expr(&mut self, expr: &Expr) -> InstRef {
@@ -1545,5 +1564,206 @@ mod tests {
         assert!(output.contains("struct_init Point"));
         assert!(output.contains("assoc_fn_call Point::origin"));
         assert!(output.contains("field_get"));
+    }
+
+    // ===== Function span tests =====
+
+    #[test]
+    fn test_function_spans_simple() {
+        let (rir, interner) = gen_rir("fn main() -> i32 { 42 }");
+
+        // Should have exactly one function span
+        assert_eq!(rir.function_count(), 1);
+
+        let spans: Vec<_> = rir.functions().collect();
+        assert_eq!(spans.len(), 1);
+
+        let span = &spans[0];
+        assert_eq!(interner.get(span.name), "main");
+
+        // The function should have 2 instructions: IntConst(42) and FnDecl
+        assert_eq!(span.instruction_count(), 2);
+
+        // The FnDecl should be the last instruction
+        let fn_inst = rir.get(span.decl);
+        assert!(matches!(fn_inst.data, InstData::FnDecl { .. }));
+    }
+
+    #[test]
+    fn test_function_spans_multiple_functions() {
+        let source = r#"
+            fn helper() -> i32 { 1 }
+            fn main() -> i32 { 42 }
+        "#;
+        let (rir, interner) = gen_rir(source);
+
+        // Should have two function spans
+        assert_eq!(rir.function_count(), 2);
+
+        let spans: Vec<_> = rir.functions().collect();
+        assert_eq!(spans.len(), 2);
+
+        // First function: helper
+        assert_eq!(interner.get(spans[0].name), "helper");
+        assert_eq!(spans[0].instruction_count(), 2);
+
+        // Second function: main
+        assert_eq!(interner.get(spans[1].name), "main");
+        assert_eq!(spans[1].instruction_count(), 2);
+
+        // Function spans should be non-overlapping
+        assert!(
+            spans[0].decl.as_u32() < spans[1].body_start.as_u32(),
+            "helper should end before main starts"
+        );
+    }
+
+    #[test]
+    fn test_function_spans_with_methods() {
+        let source = r#"
+            struct Point { x: i32 }
+            impl Point {
+                fn get_x(self) -> i32 { self.x }
+                fn origin() -> Point { Point { x: 0 } }
+            }
+            fn main() -> i32 { 0 }
+        "#;
+        let (rir, interner) = gen_rir(source);
+
+        // Should have three function spans: get_x, origin, main
+        assert_eq!(rir.function_count(), 3);
+
+        let spans: Vec<_> = rir.functions().collect();
+
+        // Methods should be tracked as well
+        let names: Vec<_> = spans.iter().map(|s| interner.get(s.name)).collect();
+        assert!(names.contains(&"get_x"));
+        assert!(names.contains(&"origin"));
+        assert!(names.contains(&"main"));
+    }
+
+    #[test]
+    fn test_function_view() {
+        let source = r#"
+            fn helper(x: i32) -> i32 { x + 1 }
+            fn main() -> i32 { helper(41) }
+        "#;
+        let (rir, interner) = gen_rir(source);
+
+        // Find the main function span
+        let main_span = rir.find_function(interner.intern("main")).unwrap();
+
+        // Get a view of main's instructions
+        let view = rir.function_view(main_span);
+
+        // The view should contain the right number of instructions
+        assert_eq!(view.len(), main_span.instruction_count() as usize);
+
+        // The last instruction should be the FnDecl
+        let fn_decl = view.fn_decl();
+        match &fn_decl.data {
+            InstData::FnDecl { name, .. } => {
+                assert_eq!(interner.get(*name), "main");
+            }
+            _ => panic!("Expected FnDecl"),
+        }
+
+        // We should be able to iterate over the view
+        let mut found_call = false;
+        for (_, inst) in view.iter() {
+            if matches!(inst.data, InstData::Call { .. }) {
+                found_call = true;
+            }
+        }
+        assert!(found_call, "main should contain a call to helper");
+    }
+
+    #[test]
+    fn test_function_span_complex_body() {
+        let source = r#"
+            fn complex() -> i32 {
+                let x = 1;
+                let y = 2;
+                if x < y {
+                    x + y
+                } else {
+                    x - y
+                }
+            }
+        "#;
+        let (rir, interner) = gen_rir(source);
+
+        assert_eq!(rir.function_count(), 1);
+
+        let span = rir.find_function(interner.intern("complex")).unwrap();
+
+        // The function should have multiple instructions for the body
+        // At minimum: 2 IntConsts, 2 Allocs, comparison, branches, operations, FnDecl
+        assert!(
+            span.instruction_count() >= 8,
+            "Complex function should have at least 8 instructions, got {}",
+            span.instruction_count()
+        );
+
+        // Verify the view contains all expected instruction types
+        let view = rir.function_view(span);
+        let mut has_alloc = false;
+        let mut has_branch = false;
+
+        for (_, inst) in view.iter() {
+            if matches!(inst.data, InstData::Alloc { .. }) {
+                has_alloc = true;
+            }
+            if matches!(inst.data, InstData::Branch { .. }) {
+                has_branch = true;
+            }
+        }
+
+        assert!(has_alloc, "Function should have Alloc instructions");
+        assert!(has_branch, "Function should have Branch instruction");
+    }
+
+    #[test]
+    fn test_find_function() {
+        let source = r#"
+            fn foo() -> i32 { 1 }
+            fn bar() -> i32 { 2 }
+            fn baz() -> i32 { 3 }
+        "#;
+        let (rir, interner) = gen_rir(source);
+
+        // Find existing functions
+        let foo_sym = interner.intern("foo");
+        let bar_sym = interner.intern("bar");
+        let baz_sym = interner.intern("baz");
+        let nonexistent_sym = interner.intern("nonexistent");
+
+        assert!(rir.find_function(foo_sym).is_some());
+        assert!(rir.find_function(bar_sym).is_some());
+        assert!(rir.find_function(baz_sym).is_some());
+        assert!(rir.find_function(nonexistent_sym).is_none());
+    }
+
+    #[test]
+    fn test_function_span_ordering() {
+        let source = r#"
+            fn a() -> i32 { 1 }
+            fn b() -> i32 { 2 }
+            fn c() -> i32 { 3 }
+        "#;
+        let (rir, _interner) = gen_rir(source);
+
+        let spans: Vec<_> = rir.functions().collect();
+        assert_eq!(spans.len(), 3);
+
+        // Verify functions are recorded in source order
+        for i in 1..spans.len() {
+            assert!(
+                spans[i - 1].decl.as_u32() < spans[i].body_start.as_u32(),
+                "Function {} should end before function {} starts",
+                i - 1,
+                i
+            );
+        }
     }
 }

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -175,6 +175,99 @@ const FIELD_DECL_SIZE: u32 = 2;
 /// Layout: [name: u32, span_start: u32, span_len: u32, args_len: u32, args...]
 /// Variable size due to args.
 
+/// A span marking the boundaries of a function in the RIR.
+///
+/// This allows efficient per-function analysis by identifying which instructions
+/// belong to each function without scanning the entire instruction array.
+#[derive(Debug, Clone)]
+pub struct FunctionSpan {
+    /// Function name symbol
+    pub name: Symbol,
+    /// Index of the first instruction of this function's body.
+    /// This is the first instruction generated for the function's expressions/statements.
+    pub body_start: InstRef,
+    /// Index of the FnDecl instruction for this function.
+    /// This is always the last instruction of the function.
+    pub decl: InstRef,
+}
+
+impl FunctionSpan {
+    /// Create a new function span.
+    pub fn new(name: Symbol, body_start: InstRef, decl: InstRef) -> Self {
+        Self {
+            name,
+            body_start,
+            decl,
+        }
+    }
+
+    /// Get the number of instructions in this function (including the FnDecl).
+    pub fn instruction_count(&self) -> u32 {
+        self.decl.as_u32() - self.body_start.as_u32() + 1
+    }
+}
+
+/// A view into a function's instructions within the RIR.
+///
+/// This provides a way to iterate over just the instructions belonging to a
+/// specific function, enabling per-function analysis without copying data.
+#[derive(Debug)]
+pub struct RirFunctionView<'a> {
+    rir: &'a Rir,
+    body_start: InstRef,
+    decl: InstRef,
+}
+
+impl<'a> RirFunctionView<'a> {
+    /// Get the instruction at the given reference.
+    ///
+    /// Note: The reference must be within this function's range.
+    #[inline]
+    pub fn get(&self, inst_ref: InstRef) -> &'a Inst {
+        debug_assert!(
+            inst_ref.as_u32() >= self.body_start.as_u32()
+                && inst_ref.as_u32() <= self.decl.as_u32(),
+            "InstRef {} is outside function range [{}, {}]",
+            inst_ref,
+            self.body_start,
+            self.decl
+        );
+        self.rir.get(inst_ref)
+    }
+
+    /// Get the FnDecl instruction for this function.
+    #[inline]
+    pub fn fn_decl(&self) -> &'a Inst {
+        self.rir.get(self.decl)
+    }
+
+    /// Iterate over all instructions in this function (including FnDecl).
+    pub fn iter(&self) -> impl Iterator<Item = (InstRef, &'a Inst)> {
+        let start = self.body_start.as_u32();
+        let end = self.decl.as_u32() + 1;
+        (start..end).map(move |i| {
+            let inst_ref = InstRef::from_raw(i);
+            (inst_ref, self.rir.get(inst_ref))
+        })
+    }
+
+    /// Get the number of instructions in this function view.
+    pub fn len(&self) -> usize {
+        (self.decl.as_u32() - self.body_start.as_u32() + 1) as usize
+    }
+
+    /// Whether this view is empty (should never be true for valid functions).
+    pub fn is_empty(&self) -> bool {
+        self.body_start.as_u32() > self.decl.as_u32()
+    }
+
+    /// Access the underlying RIR for operations that need the full context
+    /// (e.g., accessing extra data).
+    pub fn rir(&self) -> &'a Rir {
+        self.rir
+    }
+}
+
 /// The complete RIR for a source file.
 #[derive(Debug, Default)]
 pub struct Rir {
@@ -182,6 +275,8 @@ pub struct Rir {
     instructions: Vec<Inst>,
     /// Extra data for variable-length instruction payloads
     extra: Vec<u32>,
+    /// Function boundaries for per-function analysis
+    function_spans: Vec<FunctionSpan>,
 }
 
 impl Rir {
@@ -543,6 +638,47 @@ impl Rir {
             directives.push(RirDirective { name, args, span });
         }
         directives
+    }
+
+    // ===== Function span methods =====
+
+    /// Add a function span to track function boundaries.
+    pub fn add_function_span(&mut self, span: FunctionSpan) {
+        self.function_spans.push(span);
+    }
+
+    /// Get all function spans.
+    pub fn function_spans(&self) -> &[FunctionSpan] {
+        &self.function_spans
+    }
+
+    /// Iterate over function spans.
+    pub fn functions(&self) -> impl Iterator<Item = &FunctionSpan> {
+        self.function_spans.iter()
+    }
+
+    /// Get the number of functions.
+    pub fn function_count(&self) -> usize {
+        self.function_spans.len()
+    }
+
+    /// Get a view of just one function's instructions.
+    pub fn function_view(&self, fn_span: &FunctionSpan) -> RirFunctionView<'_> {
+        RirFunctionView {
+            rir: self,
+            body_start: fn_span.body_start,
+            decl: fn_span.decl,
+        }
+    }
+
+    /// Find a function span by name.
+    pub fn find_function(&self, name: Symbol) -> Option<&FunctionSpan> {
+        self.function_spans.iter().find(|span| span.name == name)
+    }
+
+    /// Get the current instruction count (useful for tracking body start).
+    pub fn current_inst_index(&self) -> u32 {
+        self.instructions.len() as u32
     }
 }
 

--- a/crates/rue-rir/src/lib.rs
+++ b/crates/rue-rir/src/lib.rs
@@ -15,6 +15,6 @@ mod inst;
 
 pub use astgen::AstGen;
 pub use inst::{
-    Inst, InstData, InstRef, Rir, RirArgMode, RirCallArg, RirDirective, RirParam, RirParamMode,
-    RirPattern, RirPrinter,
+    FunctionSpan, Inst, InstData, InstRef, Rir, RirArgMode, RirCallArg, RirDirective,
+    RirFunctionView, RirParam, RirParamMode, RirPattern, RirPrinter,
 };


### PR DESCRIPTION
Add FunctionSpan and RirFunctionView types to track function boundaries
in the RIR, enabling efficient per-function analysis without scanning
the entire instruction array.

Key additions:
- FunctionSpan: tracks function name, body start, and FnDecl instruction
- RirFunctionView: provides iteration over a single function's instructions  
- Rir methods: add_function_span, functions, function_view, find_function

AstGen now records function spans during RIR generation for both regular
functions and methods in impl blocks.

This is a foundation for parallel per-function type checking and
incremental recompilation.

Fixes rue-g8lg

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>