### PR TITLE
Optimize emitter format strings with lazy evaluation

### DIFF
--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -6,7 +6,7 @@
 use rue_error::{CompileError, CompileResult, ErrorKind};
 
 use super::mir::{Aarch64Inst, Aarch64Mir, BLOCK_LABEL_BASE, Cond, LabelId, Reg};
-use crate::{EmittedCode, EmittedInst, EmittedRelocation};
+use crate::{EmittedCode, EmittedInst, EmittedRelocation, end_inst};
 
 // ========== AArch64 Instruction Encoding Constants ==========
 //
@@ -298,15 +298,9 @@ impl<'a> Emitter<'a> {
         self.inst_start = self.code.len();
     }
 
-    /// End recording an instruction. Captures bytes emitted since begin_inst().
-    ///
-    /// When `emit_asm` is false, this is a no-op (the bytes are already in `code`).
-    fn end_inst(&mut self, asm: impl Into<String>) {
-        if self.emit_asm {
-            let bytes = self.code[self.inst_start..].to_vec();
-            self.instructions.push(EmittedInst::new(bytes, asm));
-        }
-    }
+    // Note: Use the `end_inst!` macro instead of a method to get lazy format
+    // string evaluation. The macro only evaluates format!(...) when emit_asm
+    // is true, avoiding allocations in normal compilation.
 
     /// Record a label (no bytes, just marks a position in the asm output).
     fn record_label(&mut self, name: impl Into<String>) {
@@ -412,12 +406,12 @@ impl<'a> Emitter<'a> {
         // stp x29, x30, [sp, #-16]!   ; Save FP and LR
         self.begin_inst();
         self.emit_stp_pre(Reg::Fp, Reg::Lr, -16);
-        self.end_inst("stp x29, x30, [sp, #-16]!");
+        end_inst!(self, "stp x29, x30, [sp, #-16]!");
 
         // mov x29, sp                 ; Set up frame pointer
         self.begin_inst();
         self.emit_mov_rr(Reg::Fp, Reg::Sp);
-        self.end_inst("mov x29, sp");
+        end_inst!(self, "mov x29, sp");
 
         // Save callee-saved registers in pairs.
         // Each STP/STR pre-index instruction decrements SP by 16 bytes.
@@ -427,11 +421,12 @@ impl<'a> Emitter<'a> {
             // STP with pre-index: [SP, #-16]! decrements SP by 16 and stores the pair
             self.begin_inst();
             self.emit_stp_pre(callee_saved[i], callee_saved[i + 1], -16);
-            self.end_inst(format!(
+            end_inst!(
+                self,
                 "stp {}, {}, [sp, #-16]!",
                 callee_saved[i],
                 callee_saved[i + 1]
-            ));
+            );
             i += 2;
         }
         // Handle odd register
@@ -439,7 +434,7 @@ impl<'a> Emitter<'a> {
             // STR with pre-index: [SP, #-16]! decrements SP by 16 and stores the register
             self.begin_inst();
             self.emit_str_pre(callee_saved[i], -16);
-            self.end_inst(format!("str {}, [sp, #-16]!", callee_saved[i]));
+            end_inst!(self, "str {}, [sp, #-16]!", callee_saved[i]);
         }
 
         // Allocate space for locals and spilled params
@@ -449,7 +444,7 @@ impl<'a> Emitter<'a> {
             if stack_size > 0 {
                 self.begin_inst();
                 self.emit_sub_imm(Reg::Sp, Reg::Sp, stack_size as u32);
-                self.end_inst(format!("sub sp, sp, #{}", stack_size));
+                end_inst!(self, "sub sp, sp, #{}", stack_size);
             }
         }
 
@@ -479,7 +474,7 @@ impl<'a> Emitter<'a> {
             let offset = -callee_saved_size - ((slot as i32 + 1) * 8);
             self.begin_inst();
             self.emit_str(param_regs[i], Reg::Fp, offset);
-            self.end_inst(format!("str {}, [x29, #{}]", param_regs[i], offset));
+            end_inst!(self, "str {}, [x29, #{}]", param_regs[i], offset);
         }
     }
 
@@ -490,7 +485,7 @@ impl<'a> Emitter<'a> {
                 let rd = dst.as_physical();
                 self.begin_inst();
                 self.emit_mov_imm(rd, *imm);
-                self.end_inst(format!("mov {}, #{}", rd, *imm));
+                end_inst!(self, "mov {}, #{}", rd, *imm);
             }
 
             Aarch64Inst::MovRR { dst, src } => {
@@ -498,7 +493,7 @@ impl<'a> Emitter<'a> {
                 let rs = src.as_physical();
                 self.begin_inst();
                 self.emit_mov_rr(rd, rs);
-                self.end_inst(format!("mov {}, {}", rd, rs));
+                end_inst!(self, "mov {}, {}", rd, rs);
             }
 
             Aarch64Inst::Ldr { dst, base, offset } => {
@@ -506,7 +501,7 @@ impl<'a> Emitter<'a> {
                 let adjusted_offset = self.adjust_fp_offset(*base, *offset);
                 self.begin_inst();
                 self.emit_ldr(rd, *base, adjusted_offset);
-                self.end_inst(format!("ldr {}, [{}, #{}]", rd, base, adjusted_offset));
+                end_inst!(self, "ldr {}, [{}, #{}]", rd, base, adjusted_offset);
             }
 
             Aarch64Inst::Str { src, base, offset } => {
@@ -514,7 +509,7 @@ impl<'a> Emitter<'a> {
                 let adjusted_offset = self.adjust_fp_offset(*base, *offset);
                 self.begin_inst();
                 self.emit_str(rs, *base, adjusted_offset);
-                self.end_inst(format!("str {}, [{}, #{}]", rs, base, adjusted_offset));
+                end_inst!(self, "str {}, [{}, #{}]", rs, base, adjusted_offset);
             }
 
             Aarch64Inst::AddRR { dst, src1, src2 } => {
@@ -523,7 +518,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_add_rr(rd, rn, rm, false);
-                self.end_inst(format!("add {}, {}, {}", rd, rn, rm));
+                end_inst!(self, "add {}, {}, {}", rd, rn, rm);
             }
 
             Aarch64Inst::AddsRR { dst, src1, src2 } => {
@@ -532,7 +527,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_adds_rr32(rd, rn, rm);
-                self.end_inst(format!("adds {}, {}, {}", rd.as_w(), rn.as_w(), rm.as_w()));
+                end_inst!(self, "adds {}, {}, {}", rd.as_w(), rn.as_w(), rm.as_w());
             }
 
             Aarch64Inst::AddsRR64 { dst, src1, src2 } => {
@@ -541,7 +536,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_adds_rr64(rd, rn, rm);
-                self.end_inst(format!("adds {}, {}, {}", rd, rn, rm));
+                end_inst!(self, "adds {}, {}, {}", rd, rn, rm);
             }
 
             Aarch64Inst::AddImm { dst, src, imm } => {
@@ -554,10 +549,10 @@ impl<'a> Emitter<'a> {
                 if adjusted_imm < 0 {
                     // Negative immediate: use SUB with the absolute value
                     self.emit_sub_imm(rd, rn, (-adjusted_imm) as u32);
-                    self.end_inst(format!("sub {}, {}, #{}", rd, rn, -adjusted_imm));
+                    end_inst!(self, "sub {}, {}, #{}", rd, rn, -adjusted_imm);
                 } else {
                     self.emit_add_imm(rd, rn, adjusted_imm as u32);
-                    self.end_inst(format!("add {}, {}, #{}", rd, rn, adjusted_imm));
+                    end_inst!(self, "add {}, {}, #{}", rd, rn, adjusted_imm);
                 }
             }
 
@@ -567,7 +562,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_sub_rr(rd, rn, rm, false);
-                self.end_inst(format!("sub {}, {}, {}", rd, rn, rm));
+                end_inst!(self, "sub {}, {}, {}", rd, rn, rm);
             }
 
             Aarch64Inst::SubsRR { dst, src1, src2 } => {
@@ -576,7 +571,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_subs_rr32(rd, rn, rm);
-                self.end_inst(format!("subs {}, {}, {}", rd.as_w(), rn.as_w(), rm.as_w()));
+                end_inst!(self, "subs {}, {}, {}", rd.as_w(), rn.as_w(), rm.as_w());
             }
 
             Aarch64Inst::SubsRR64 { dst, src1, src2 } => {
@@ -585,7 +580,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_subs_rr64(rd, rn, rm);
-                self.end_inst(format!("subs {}, {}, {}", rd, rn, rm));
+                end_inst!(self, "subs {}, {}, {}", rd, rn, rm);
             }
 
             Aarch64Inst::SubImm { dst, src, imm } => {
@@ -601,7 +596,7 @@ impl<'a> Emitter<'a> {
                 };
                 self.begin_inst();
                 self.emit_sub_imm(rd, rn, adjusted_imm);
-                self.end_inst(format!("sub {}, {}, #{}", rd, rn, adjusted_imm));
+                end_inst!(self, "sub {}, {}, #{}", rd, rn, adjusted_imm);
             }
 
             Aarch64Inst::MulRR { dst, src1, src2 } => {
@@ -610,7 +605,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_mul(rd, rn, rm);
-                self.end_inst(format!("mul {}, {}, {}", rd, rn, rm));
+                end_inst!(self, "mul {}, {}, {}", rd, rn, rm);
             }
 
             Aarch64Inst::SmullRR { dst, src1, src2 } => {
@@ -619,7 +614,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_smull(rd, rn, rm);
-                self.end_inst(format!("smull {}, {}, {}", rd, rn.as_w(), rm.as_w()));
+                end_inst!(self, "smull {}, {}, {}", rd, rn.as_w(), rm.as_w());
             }
 
             Aarch64Inst::UmullRR { dst, src1, src2 } => {
@@ -628,7 +623,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_umull(rd, rn, rm);
-                self.end_inst(format!("umull {}, {}, {}", rd, rn.as_w(), rm.as_w()));
+                end_inst!(self, "umull {}, {}, {}", rd, rn.as_w(), rm.as_w());
             }
 
             Aarch64Inst::SmulhRR { dst, src1, src2 } => {
@@ -637,7 +632,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_smulh(rd, rn, rm);
-                self.end_inst(format!("smulh {}, {}, {}", rd, rn, rm));
+                end_inst!(self, "smulh {}, {}, {}", rd, rn, rm);
             }
 
             Aarch64Inst::UmulhRR { dst, src1, src2 } => {
@@ -646,7 +641,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_umulh(rd, rn, rm);
-                self.end_inst(format!("umulh {}, {}, {}", rd, rn, rm));
+                end_inst!(self, "umulh {}, {}, {}", rd, rn, rm);
             }
 
             Aarch64Inst::Lsr64Imm { dst, src, imm } => {
@@ -654,7 +649,7 @@ impl<'a> Emitter<'a> {
                 let rn = src.as_physical();
                 self.begin_inst();
                 self.emit_lsr_imm(rd, rn, *imm);
-                self.end_inst(format!("lsr {}, {}, #{}", rd, rn, imm));
+                end_inst!(self, "lsr {}, {}, #{}", rd, rn, imm);
             }
 
             Aarch64Inst::Asr64Imm { dst, src, imm } => {
@@ -662,7 +657,7 @@ impl<'a> Emitter<'a> {
                 let rn = src.as_physical();
                 self.begin_inst();
                 self.emit_asr_imm(rd, rn, *imm);
-                self.end_inst(format!("asr {}, {}, #{}", rd, rn, imm));
+                end_inst!(self, "asr {}, {}, #{}", rd, rn, imm);
             }
 
             Aarch64Inst::SdivRR { dst, src1, src2 } => {
@@ -671,7 +666,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_sdiv(rd, rn, rm);
-                self.end_inst(format!("sdiv {}, {}, {}", rd.as_w(), rn.as_w(), rm.as_w()));
+                end_inst!(self, "sdiv {}, {}, {}", rd.as_w(), rn.as_w(), rm.as_w());
             }
 
             Aarch64Inst::Msub {
@@ -686,13 +681,14 @@ impl<'a> Emitter<'a> {
                 let ra = src3.as_physical();
                 self.begin_inst();
                 self.emit_msub(rd, rn, rm, ra);
-                self.end_inst(format!(
+                end_inst!(
+                    self,
                     "msub {}, {}, {}, {}",
                     rd.as_w(),
                     rn.as_w(),
                     rm.as_w(),
                     ra.as_w()
-                ));
+                );
             }
 
             Aarch64Inst::Neg { dst, src } => {
@@ -701,7 +697,7 @@ impl<'a> Emitter<'a> {
                 // NEG is SUB from XZR
                 self.begin_inst();
                 self.emit_sub_rr(rd, Reg::Xzr, rm, false);
-                self.end_inst(format!("neg {}, {}", rd, rm));
+                end_inst!(self, "neg {}, {}", rd, rm);
             }
 
             Aarch64Inst::Negs { dst, src } => {
@@ -710,7 +706,7 @@ impl<'a> Emitter<'a> {
                 // NEGS is SUBS from XZR (64-bit for i64/u64 overflow detection)
                 self.begin_inst();
                 self.emit_subs_rr64(rd, Reg::Xzr, rm);
-                self.end_inst(format!("negs {}, {}", rd, rm));
+                end_inst!(self, "negs {}, {}", rd, rm);
             }
 
             Aarch64Inst::Negs32 { dst, src } => {
@@ -719,7 +715,7 @@ impl<'a> Emitter<'a> {
                 // NEGS is SUBS from WZR (32-bit for i32/u32 and sub-word overflow detection)
                 self.begin_inst();
                 self.emit_subs_rr32(rd, Reg::Xzr, rm);
-                self.end_inst(format!("negs {}, {}", rd.as_w(), rm.as_w()));
+                end_inst!(self, "negs {}, {}", rd.as_w(), rm.as_w());
             }
 
             Aarch64Inst::AndRR { dst, src1, src2 } => {
@@ -728,7 +724,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_and_rr(rd, rn, rm);
-                self.end_inst(format!("and {}, {}, {}", rd, rn, rm));
+                end_inst!(self, "and {}, {}, {}", rd, rn, rm);
             }
 
             Aarch64Inst::OrrRR { dst, src1, src2 } => {
@@ -737,7 +733,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_orr_rr(rd, rn, rm);
-                self.end_inst(format!("orr {}, {}, {}", rd, rn, rm));
+                end_inst!(self, "orr {}, {}, {}", rd, rn, rm);
             }
 
             Aarch64Inst::EorRR { dst, src1, src2 } => {
@@ -746,7 +742,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_eor_rr(rd, rn, rm);
-                self.end_inst(format!("eor {}, {}, {}", rd, rn, rm));
+                end_inst!(self, "eor {}, {}, {}", rd, rn, rm);
             }
 
             Aarch64Inst::EorImm { dst, src, imm } => {
@@ -754,7 +750,7 @@ impl<'a> Emitter<'a> {
                 let rn = src.as_physical();
                 self.begin_inst();
                 self.emit_eor_imm(rd, rn, *imm);
-                self.end_inst(format!("eor {}, {}, #{}", rd, rn, imm));
+                end_inst!(self, "eor {}, {}, #{}", rd, rn, imm);
             }
 
             Aarch64Inst::MvnRR { dst, src } => {
@@ -762,7 +758,7 @@ impl<'a> Emitter<'a> {
                 let rm = src.as_physical();
                 self.begin_inst();
                 self.emit_mvn_rr(rd, rm);
-                self.end_inst(format!("mvn {}, {}", rd, rm));
+                end_inst!(self, "mvn {}, {}", rd, rm);
             }
 
             Aarch64Inst::LslRR { dst, src1, src2 } => {
@@ -771,7 +767,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_lslv_rr(rd, rn, rm);
-                self.end_inst(format!("lsl {}, {}, {}", rd, rn, rm));
+                end_inst!(self, "lsl {}, {}, {}", rd, rn, rm);
             }
 
             Aarch64Inst::Lsl32RR { dst, src1, src2 } => {
@@ -780,7 +776,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_lslv32_rr(rd, rn, rm);
-                self.end_inst(format!("lsl {}, {}, {}", rd.as_w(), rn.as_w(), rm.as_w()));
+                end_inst!(self, "lsl {}, {}, {}", rd.as_w(), rn.as_w(), rm.as_w());
             }
 
             Aarch64Inst::LsrRR { dst, src1, src2 } => {
@@ -789,7 +785,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_lsrv_rr(rd, rn, rm);
-                self.end_inst(format!("lsr {}, {}, {}", rd, rn, rm));
+                end_inst!(self, "lsr {}, {}, {}", rd, rn, rm);
             }
 
             Aarch64Inst::Lsr32RR { dst, src1, src2 } => {
@@ -798,7 +794,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_lsrv32_rr(rd, rn, rm);
-                self.end_inst(format!("lsr {}, {}, {}", rd.as_w(), rn.as_w(), rm.as_w()));
+                end_inst!(self, "lsr {}, {}, {}", rd.as_w(), rn.as_w(), rm.as_w());
             }
 
             Aarch64Inst::AsrRR { dst, src1, src2 } => {
@@ -807,7 +803,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_asrv_rr(rd, rn, rm);
-                self.end_inst(format!("asr {}, {}, {}", rd, rn, rm));
+                end_inst!(self, "asr {}, {}, {}", rd, rn, rm);
             }
 
             Aarch64Inst::Asr32RR { dst, src1, src2 } => {
@@ -816,7 +812,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 self.begin_inst();
                 self.emit_asrv32_rr(rd, rn, rm);
-                self.end_inst(format!("asr {}, {}, {}", rd.as_w(), rn.as_w(), rm.as_w()));
+                end_inst!(self, "asr {}, {}, {}", rd.as_w(), rn.as_w(), rm.as_w());
             }
 
             Aarch64Inst::CmpRR { src1, src2 } => {
@@ -825,7 +821,7 @@ impl<'a> Emitter<'a> {
                 // CMP is SUBS with WZR destination (32-bit form for i32 and sub-word types)
                 self.begin_inst();
                 self.emit_subs_rr32(Reg::Xzr, rn, rm);
-                self.end_inst(format!("cmp {}, {}", rn.as_w(), rm.as_w()));
+                end_inst!(self, "cmp {}, {}", rn.as_w(), rm.as_w());
             }
 
             Aarch64Inst::Cmp64RR { src1, src2 } => {
@@ -834,35 +830,35 @@ impl<'a> Emitter<'a> {
                 // 64-bit CMP is SUBS with XZR destination (64-bit form)
                 self.begin_inst();
                 self.emit_sub64_rr(Reg::Xzr, rn, rm, true);
-                self.end_inst(format!("cmp {}, {}", rn, rm));
+                end_inst!(self, "cmp {}, {}", rn, rm);
             }
 
             Aarch64Inst::CmpImm { src, imm } => {
                 let rn = src.as_physical();
                 self.begin_inst();
                 self.emit_cmp_imm(rn, *imm as u32);
-                self.end_inst(format!("cmp {}, #{}", rn, imm));
+                end_inst!(self, "cmp {}, #{}", rn, imm);
             }
 
             Aarch64Inst::Cbz { src, label } => {
                 let rt = src.as_physical();
                 self.begin_inst();
                 self.emit_cbz(rt, *label, false);
-                self.end_inst(format!("cbz {}, L{}", rt, label));
+                end_inst!(self, "cbz {}, L{}", rt, label);
             }
 
             Aarch64Inst::Cbnz { src, label } => {
                 let rt = src.as_physical();
                 self.begin_inst();
                 self.emit_cbz(rt, *label, true);
-                self.end_inst(format!("cbnz {}, L{}", rt, label));
+                end_inst!(self, "cbnz {}, L{}", rt, label);
             }
 
             Aarch64Inst::Cset { dst, cond } => {
                 let rd = dst.as_physical();
                 self.begin_inst();
                 self.emit_cset(rd, *cond);
-                self.end_inst(format!("cset {}, {}", rd, cond));
+                end_inst!(self, "cset {}, {}", rd, cond);
             }
 
             Aarch64Inst::TstRR { src1, src2 } => {
@@ -871,7 +867,7 @@ impl<'a> Emitter<'a> {
                 // TST is ANDS with XZR destination
                 self.begin_inst();
                 self.emit_ands_rr(Reg::Xzr, rn, rm);
-                self.end_inst(format!("tst {}, {}", rn, rm));
+                end_inst!(self, "tst {}, {}", rn, rm);
             }
 
             Aarch64Inst::Sxtb { dst, src } => {
@@ -879,7 +875,7 @@ impl<'a> Emitter<'a> {
                 let rn = src.as_physical();
                 self.begin_inst();
                 self.emit_sbfm(rd, rn, 0, 7);
-                self.end_inst(format!("sxtb {}, {}", rd, rn.as_w()));
+                end_inst!(self, "sxtb {}, {}", rd, rn.as_w());
             }
 
             Aarch64Inst::Sxth { dst, src } => {
@@ -887,7 +883,7 @@ impl<'a> Emitter<'a> {
                 let rn = src.as_physical();
                 self.begin_inst();
                 self.emit_sbfm(rd, rn, 0, 15);
-                self.end_inst(format!("sxth {}, {}", rd, rn.as_w()));
+                end_inst!(self, "sxth {}, {}", rd, rn.as_w());
             }
 
             Aarch64Inst::Sxtw { dst, src } => {
@@ -895,7 +891,7 @@ impl<'a> Emitter<'a> {
                 let rn = src.as_physical();
                 self.begin_inst();
                 self.emit_sbfm(rd, rn, 0, 31);
-                self.end_inst(format!("sxtw {}, {}", rd, rn.as_w()));
+                end_inst!(self, "sxtw {}, {}", rd, rn.as_w());
             }
 
             Aarch64Inst::Uxtb { dst, src } => {
@@ -903,7 +899,7 @@ impl<'a> Emitter<'a> {
                 let rn = src.as_physical();
                 self.begin_inst();
                 self.emit_ubfm(rd, rn, 0, 7);
-                self.end_inst(format!("uxtb {}, {}", rd.as_w(), rn.as_w()));
+                end_inst!(self, "uxtb {}, {}", rd.as_w(), rn.as_w());
             }
 
             Aarch64Inst::Uxth { dst, src } => {
@@ -911,33 +907,33 @@ impl<'a> Emitter<'a> {
                 let rn = src.as_physical();
                 self.begin_inst();
                 self.emit_ubfm(rd, rn, 0, 15);
-                self.end_inst(format!("uxth {}, {}", rd.as_w(), rn.as_w()));
+                end_inst!(self, "uxth {}, {}", rd.as_w(), rn.as_w());
             }
 
             Aarch64Inst::B { label } => {
                 self.begin_inst();
                 self.emit_b(*label);
-                self.end_inst(format!("b L{}", label));
+                end_inst!(self, "b L{}", label);
             }
 
             Aarch64Inst::BCond { cond, label } => {
                 self.begin_inst();
                 self.emit_bcond(*cond, *label);
-                self.end_inst(format!("b.{} L{}", cond, label));
+                end_inst!(self, "b.{} L{}", cond, label);
             }
 
             Aarch64Inst::Bvs { label } => {
                 // B.VS = branch if overflow set (cond = 0110)
                 self.begin_inst();
                 self.emit_bcond_raw(6, *label);
-                self.end_inst(format!("b.vs L{}", label));
+                end_inst!(self, "b.vs L{}", label);
             }
 
             Aarch64Inst::Bvc { label } => {
                 // B.VC = branch if overflow clear (cond = 0111)
                 self.begin_inst();
                 self.emit_bcond_raw(7, *label);
-                self.end_inst(format!("b.vc L{}", label));
+                end_inst!(self, "b.vc L{}", label);
             }
 
             Aarch64Inst::Label { id } => {
@@ -949,7 +945,7 @@ impl<'a> Emitter<'a> {
                 let symbol = self.mir.get_symbol(*symbol_id);
                 self.begin_inst();
                 self.emit_bl(symbol);
-                self.end_inst(format!("bl {}", symbol));
+                end_inst!(self, "bl {}", symbol);
             }
 
             Aarch64Inst::Ret => {
@@ -958,7 +954,7 @@ impl<'a> Emitter<'a> {
                 }
                 self.begin_inst();
                 self.emit_ret();
-                self.end_inst("ret");
+                end_inst!(self, "ret");
             }
 
             Aarch64Inst::StpPre { src1, src2, offset } => {
@@ -966,7 +962,7 @@ impl<'a> Emitter<'a> {
                 let rt2 = src2.as_physical();
                 self.begin_inst();
                 self.emit_stp_pre(rt1, rt2, *offset);
-                self.end_inst(format!("stp {}, {}, [sp, #{}]!", rt1, rt2, offset));
+                end_inst!(self, "stp {}, {}, [sp, #{}]!", rt1, rt2, offset);
             }
 
             Aarch64Inst::LdpPost { dst1, dst2, offset } => {
@@ -974,7 +970,7 @@ impl<'a> Emitter<'a> {
                 let rt2 = dst2.as_physical();
                 self.begin_inst();
                 self.emit_ldp_post(rt1, rt2, *offset);
-                self.end_inst(format!("ldp {}, {}, [sp], #{}", rt1, rt2, offset));
+                end_inst!(self, "ldp {}, {}, [sp], #{}", rt1, rt2, offset);
             }
 
             // These instructions should be caught by the verification at the start of emit()
@@ -992,7 +988,7 @@ impl<'a> Emitter<'a> {
                 let rn = src.as_physical();
                 self.begin_inst();
                 self.emit_lsl_imm(rd, rn, *imm);
-                self.end_inst(format!("lsl {}, {}, #{}", rd, rn, imm));
+                end_inst!(self, "lsl {}, {}, #{}", rd, rn, imm);
             }
 
             Aarch64Inst::Lsl32Imm { dst, src, imm } => {
@@ -1000,7 +996,7 @@ impl<'a> Emitter<'a> {
                 let rn = src.as_physical();
                 self.begin_inst();
                 self.emit_lsl32_imm(rd, rn, *imm);
-                self.end_inst(format!("lsl {}, {}, #{}", rd.as_w(), rn.as_w(), imm));
+                end_inst!(self, "lsl {}, {}, #{}", rd.as_w(), rn.as_w(), imm);
             }
 
             Aarch64Inst::Lsr32Imm { dst, src, imm } => {
@@ -1008,7 +1004,7 @@ impl<'a> Emitter<'a> {
                 let rn = src.as_physical();
                 self.begin_inst();
                 self.emit_lsr32_imm(rd, rn, *imm);
-                self.end_inst(format!("lsr {}, {}, #{}", rd.as_w(), rn.as_w(), imm));
+                end_inst!(self, "lsr {}, {}, #{}", rd.as_w(), rn.as_w(), imm);
             }
 
             Aarch64Inst::Asr32Imm { dst, src, imm } => {
@@ -1016,7 +1012,7 @@ impl<'a> Emitter<'a> {
                 let rn = src.as_physical();
                 self.begin_inst();
                 self.emit_asr32_imm(rd, rn, *imm);
-                self.end_inst(format!("asr {}, {}, #{}", rd.as_w(), rn.as_w(), imm));
+                end_inst!(self, "asr {}, {}, #{}", rd.as_w(), rn.as_w(), imm);
             }
 
             Aarch64Inst::StringConstPtr { dst, string_id } => {
@@ -1036,7 +1032,7 @@ impl<'a> Emitter<'a> {
                 let symbol = format!(".rodata.str{}", string_id);
                 self.relocations
                     .push(EmittedRelocation::aarch64_adrp(offset as u64, &symbol));
-                self.end_inst(format!("adrp {}, {}", rd, symbol));
+                end_inst!(self, "adrp {}, {}", rd, symbol);
 
                 // ADD dst, dst, <symbol>
                 // This adds the offset within the page
@@ -1048,7 +1044,7 @@ impl<'a> Emitter<'a> {
                 // Record relocation for ADD using the helper
                 self.relocations
                     .push(EmittedRelocation::aarch64_add_lo12(offset as u64, &symbol));
-                self.end_inst(format!("add {}, {}, :lo12:{}", rd, rd, symbol));
+                end_inst!(self, "add {}, {}, :lo12:{}", rd, rd, symbol);
             }
 
             Aarch64Inst::StringConstLen { dst, string_id } => {
@@ -1067,7 +1063,7 @@ impl<'a> Emitter<'a> {
                 // Emit the length as an immediate
                 self.begin_inst();
                 self.emit_mov_imm(rd, len);
-                self.end_inst(format!("mov {}, #{}", rd, len));
+                end_inst!(self, "mov {}, #{}", rd, len);
             }
 
             Aarch64Inst::StringConstCap { dst, string_id: _ } => {
@@ -1076,7 +1072,7 @@ impl<'a> Emitter<'a> {
                 let rd = dst.as_physical();
                 self.begin_inst();
                 self.emit_mov_imm(rd, 0);
-                self.end_inst(format!("mov {}, #0", rd));
+                end_inst!(self, "mov {}, #0", rd);
             }
         }
     }
@@ -1104,7 +1100,7 @@ impl<'a> Emitter<'a> {
             if stack_size > 0 {
                 self.begin_inst();
                 self.emit_add_imm(Reg::Sp, Reg::Sp, stack_size as u32);
-                self.end_inst(format!("add sp, sp, #{}", stack_size));
+                end_inst!(self, "add sp, sp, #{}", stack_size);
             }
         }
 
@@ -1118,7 +1114,7 @@ impl<'a> Emitter<'a> {
             let idx = callee_saved.len() - 1;
             self.begin_inst();
             self.emit_ldr_post(callee_saved[idx], 16);
-            self.end_inst(format!("ldr {}, [sp], #16", callee_saved[idx]));
+            end_inst!(self, "ldr {}, [sp], #16", callee_saved[idx]);
         }
 
         // Pairs in reverse
@@ -1126,17 +1122,18 @@ impl<'a> Emitter<'a> {
             let idx = i * 2;
             self.begin_inst();
             self.emit_ldp_post(callee_saved[idx], callee_saved[idx + 1], 16);
-            self.end_inst(format!(
+            end_inst!(
+                self,
                 "ldp {}, {}, [sp], #16",
                 callee_saved[idx],
                 callee_saved[idx + 1]
-            ));
+            );
         }
 
         // ldp x29, x30, [sp], #16     ; Restore FP and LR
         self.begin_inst();
         self.emit_ldp_post(Reg::Fp, Reg::Lr, 16);
-        self.end_inst("ldp x29, x30, [sp], #16");
+        end_inst!(self, "ldp x29, x30, [sp], #16");
     }
 
     /// Apply pending fixups for forward branches.

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -13,6 +13,34 @@
 //! instructions but uses virtual registers. Register allocation then maps
 //! virtual registers to physical registers before final emission.
 
+/// Ends recording an instruction with lazy format string evaluation.
+///
+/// When `emit_asm` is false (normal compilation), this is a no-op and the
+/// format string arguments are never evaluated. When `emit_asm` is true
+/// (--emit asm mode), the format string is evaluated and stored.
+///
+/// This is more efficient than calling `end_inst(format!(...))` directly,
+/// which would always evaluate the format string.
+///
+/// # Examples
+///
+/// ```ignore
+/// // Instead of:
+/// self.end_inst(format!("mov {}, {}", dst, src));
+///
+/// // Use:
+/// end_inst!(self, "mov {}, {}", dst, src);
+/// ```
+#[macro_export]
+macro_rules! end_inst {
+    ($emitter:expr, $($arg:tt)*) => {
+        if $emitter.emit_asm {
+            let bytes = $emitter.code[$emitter.inst_start..].to_vec();
+            $emitter.instructions.push($crate::EmittedInst::new(bytes, format!($($arg)*)));
+        }
+    };
+}
+
 mod stack_frame;
 
 pub mod aarch64;

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -99,7 +99,7 @@ use rue_error::{CompileError, CompileResult, ErrorKind};
 
 use super::mir::{LabelId, Reg, X86Inst, X86Mir};
 use crate::vreg::BLOCK_LABEL_BASE;
-use crate::{EmittedCode, EmittedInst, EmittedRelocation, format_offset};
+use crate::{EmittedCode, EmittedInst, EmittedRelocation, end_inst, format_offset};
 
 /// Kind of jump fixup (rel8 or rel32).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -248,15 +248,9 @@ impl<'a> Emitter<'a> {
         self.inst_start = self.code.len();
     }
 
-    /// End recording an instruction. Captures bytes emitted since begin_inst().
-    ///
-    /// When `emit_asm` is false, this is a no-op (the bytes are already in `code`).
-    fn end_inst(&mut self, asm: impl Into<String>) {
-        if self.emit_asm {
-            let bytes = self.code[self.inst_start..].to_vec();
-            self.instructions.push(EmittedInst::new(bytes, asm));
-        }
-    }
+    // Note: Use the `end_inst!` macro instead of a method to get lazy format
+    // string evaluation. The macro only evaluates format!(...) when emit_asm
+    // is true, avoiding allocations in normal compilation.
 
     /// Record a label (no bytes, just marks a position in the asm output).
     fn record_label(&mut self, name: impl Into<String>) {
@@ -385,14 +379,14 @@ impl<'a> Emitter<'a> {
         // push rbp: 55
         self.begin_inst();
         self.code.push(0x55);
-        self.end_inst("push rbp");
+        end_inst!(self, "push rbp");
 
         // mov rbp, rsp: 48 89 E5
         self.begin_inst();
         self.code.push(0x48);
         self.code.push(0x89);
         self.code.push(0xE5);
-        self.end_inst("mov rbp, rsp");
+        end_inst!(self, "mov rbp, rsp");
 
         // Save callee-saved registers AFTER rbp setup
         // This ensures stack args are at fixed offsets from rbp
@@ -400,7 +394,7 @@ impl<'a> Emitter<'a> {
         for &reg in &callee_saved {
             self.begin_inst();
             self.emit_push(reg);
-            self.end_inst(format!("push {}", reg));
+            end_inst!(self, "push {}", reg);
         }
 
         // Calculate stack space needed:
@@ -425,7 +419,7 @@ impl<'a> Emitter<'a> {
             self.code.push(0x81);
             self.code.push(0xEC);
             self.code.extend_from_slice(&stack_size.to_le_bytes());
-            self.end_inst(format!("sub rsp, {}", stack_size));
+            end_inst!(self, "sub rsp, {}", stack_size);
         }
 
         // Save incoming parameters from registers to the stack.
@@ -450,7 +444,7 @@ impl<'a> Emitter<'a> {
             // Emit: mov [rbp + offset], reg
             self.begin_inst();
             self.emit_mov_mr(Reg::Rbp, offset, reg);
-            self.end_inst(format!("mov [rbp{}], {}", offset, reg));
+            end_inst!(self, "mov [rbp{}], {}", offset, reg);
         }
     }
 
@@ -471,7 +465,7 @@ impl<'a> Emitter<'a> {
         if !self.callee_saved.is_empty() || self.num_locals > 0 || self.num_params > 0 {
             self.begin_inst();
             self.emit_lea_rsp_rbp_offset(-size);
-            self.end_inst(format!("lea rsp, [rbp{}]", format_offset(-size)));
+            end_inst!(self, "lea rsp, [rbp{}]", format_offset(-size));
         }
 
         // Pop callee-saved registers in reverse order
@@ -479,13 +473,13 @@ impl<'a> Emitter<'a> {
         for reg in callee_saved {
             self.begin_inst();
             self.emit_pop(reg);
-            self.end_inst(format!("pop {}", reg));
+            end_inst!(self, "pop {}", reg);
         }
 
         // Pop rbp to restore caller's frame pointer
         self.begin_inst();
         self.emit_pop(Reg::Rbp);
-        self.end_inst("pop rbp");
+        end_inst!(self, "pop rbp");
     }
 
     /// Apply all fixups for forward jumps.
@@ -548,370 +542,336 @@ impl<'a> Emitter<'a> {
             X86Inst::MovRI32 { dst, imm } => {
                 self.begin_inst();
                 self.emit_mov_ri32(dst.as_physical(), *imm);
-                self.end_inst(format!("mov {}, {}", dst.as_physical(), *imm));
+                end_inst!(self, "mov {}, {}", dst.as_physical(), *imm);
             }
             X86Inst::MovRI64 { dst, imm } => {
                 self.begin_inst();
                 self.emit_mov_ri64(dst.as_physical(), *imm);
-                self.end_inst(format!("mov {}, {}", dst.as_physical(), *imm));
+                end_inst!(self, "mov {}, {}", dst.as_physical(), *imm);
             }
             X86Inst::MovRR { dst, src } => {
                 self.begin_inst();
                 self.emit_mov_rr(dst.as_physical(), src.as_physical());
-                self.end_inst(format!("mov {}, {}", dst.as_physical(), src.as_physical()));
+                end_inst!(self, "mov {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::MovRM { dst, base, offset } => {
                 let adjusted_offset = self.adjust_fp_offset(*base, *offset);
                 self.begin_inst();
                 self.emit_mov_rm(dst.as_physical(), *base, adjusted_offset);
-                self.end_inst(format!(
+                end_inst!(
+                    self,
                     "mov {}, [{}{}]",
                     dst.as_physical(),
                     base,
                     format_offset(adjusted_offset)
-                ));
+                );
             }
             X86Inst::MovMR { base, offset, src } => {
                 let adjusted_offset = self.adjust_fp_offset(*base, *offset);
                 self.begin_inst();
                 self.emit_mov_mr(*base, adjusted_offset, src.as_physical());
-                self.end_inst(format!(
+                end_inst!(
+                    self,
                     "mov [{}{}], {}",
                     base,
                     format_offset(adjusted_offset),
                     src.as_physical()
-                ));
+                );
             }
             X86Inst::AddRR { dst, src } => {
                 self.begin_inst();
                 self.emit_add_rr(dst.as_physical(), src.as_physical());
-                self.end_inst(format!("add {}, {}", dst.as_physical(), src.as_physical()));
+                end_inst!(self, "add {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::AddRR64 { dst, src } => {
                 self.begin_inst();
                 self.emit_add_rr64(dst.as_physical(), src.as_physical());
-                self.end_inst(format!("add {}, {}", dst.as_physical(), src.as_physical()));
+                end_inst!(self, "add {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::AddRI { dst, imm } => {
                 self.begin_inst();
                 self.emit_add_ri(dst.as_physical(), *imm);
-                self.end_inst(format!("add {}, {}", dst.as_physical(), imm));
+                end_inst!(self, "add {}, {}", dst.as_physical(), imm);
             }
             X86Inst::SubRR { dst, src } => {
                 self.begin_inst();
                 self.emit_sub_rr(dst.as_physical(), src.as_physical());
-                self.end_inst(format!("sub {}, {}", dst.as_physical(), src.as_physical()));
+                end_inst!(self, "sub {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::SubRR64 { dst, src } => {
                 self.begin_inst();
                 self.emit_sub_rr64(dst.as_physical(), src.as_physical());
-                self.end_inst(format!("sub {}, {}", dst.as_physical(), src.as_physical()));
+                end_inst!(self, "sub {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::ImulRR { dst, src } => {
                 self.begin_inst();
                 self.emit_imul_rr(dst.as_physical(), src.as_physical());
-                self.end_inst(format!("imul {}, {}", dst.as_physical(), src.as_physical()));
+                end_inst!(self, "imul {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::ImulRR64 { dst, src } => {
                 self.begin_inst();
                 self.emit_imul_rr64(dst.as_physical(), src.as_physical());
-                self.end_inst(format!("imul {}, {}", dst.as_physical(), src.as_physical()));
+                end_inst!(self, "imul {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::Neg { dst } => {
                 self.begin_inst();
                 self.emit_neg(dst.as_physical());
-                self.end_inst(format!("neg {}", dst.as_physical()));
+                end_inst!(self, "neg {}", dst.as_physical());
             }
             X86Inst::Neg64 { dst } => {
                 self.begin_inst();
                 self.emit_neg64(dst.as_physical());
-                self.end_inst(format!("neg {}", dst.as_physical()));
+                end_inst!(self, "neg {}", dst.as_physical());
             }
             X86Inst::XorRI { dst, imm } => {
                 self.begin_inst();
                 self.emit_xor_ri(dst.as_physical(), *imm);
-                self.end_inst(format!("xor {}, {}", dst.as_physical(), imm));
+                end_inst!(self, "xor {}, {}", dst.as_physical(), imm);
             }
             X86Inst::AndRR { dst, src } => {
                 self.begin_inst();
                 self.emit_and_rr(dst.as_physical(), src.as_physical());
-                self.end_inst(format!("and {}, {}", dst.as_physical(), src.as_physical()));
+                end_inst!(self, "and {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::OrRR { dst, src } => {
                 self.begin_inst();
                 self.emit_or_rr(dst.as_physical(), src.as_physical());
-                self.end_inst(format!("or {}, {}", dst.as_physical(), src.as_physical()));
+                end_inst!(self, "or {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::XorRR { dst, src } => {
                 self.begin_inst();
                 self.emit_xor_rr(dst.as_physical(), src.as_physical());
-                self.end_inst(format!("xor {}, {}", dst.as_physical(), src.as_physical()));
+                end_inst!(self, "xor {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::NotR { dst } => {
                 self.begin_inst();
                 self.emit_not(dst.as_physical());
-                self.end_inst(format!("not {}", dst.as_physical()));
+                end_inst!(self, "not {}", dst.as_physical());
             }
             X86Inst::ShlRCl { dst } => {
                 self.begin_inst();
                 self.emit_shl_cl(dst.as_physical());
-                self.end_inst(format!("shl {}, cl", dst.as_physical()));
+                end_inst!(self, "shl {}, cl", dst.as_physical());
             }
             X86Inst::Shl32RCl { dst } => {
                 self.begin_inst();
                 self.emit_shl32_cl(dst.as_physical());
-                self.end_inst(format!("shl {}, cl", dst.as_physical()));
+                end_inst!(self, "shl {}, cl", dst.as_physical());
             }
             X86Inst::ShlRI { dst, imm } => {
                 self.begin_inst();
                 self.emit_shl_imm(dst.as_physical(), *imm);
-                self.end_inst(format!("shl {}, {}", dst.as_physical(), imm));
+                end_inst!(self, "shl {}, {}", dst.as_physical(), imm);
             }
             X86Inst::Shl32RI { dst, imm } => {
                 self.begin_inst();
                 self.emit_shl32_imm(dst.as_physical(), *imm);
-                self.end_inst(format!("shl {}, {}", dst.as_physical(), imm));
+                end_inst!(self, "shl {}, {}", dst.as_physical(), imm);
             }
             X86Inst::ShrRCl { dst } => {
                 self.begin_inst();
                 self.emit_shr_cl(dst.as_physical());
-                self.end_inst(format!("shr {}, cl", dst.as_physical()));
+                end_inst!(self, "shr {}, cl", dst.as_physical());
             }
             X86Inst::Shr32RCl { dst } => {
                 self.begin_inst();
                 self.emit_shr32_cl(dst.as_physical());
-                self.end_inst(format!("shr {}, cl", dst.as_physical()));
+                end_inst!(self, "shr {}, cl", dst.as_physical());
             }
             X86Inst::ShrRI { dst, imm } => {
                 self.begin_inst();
                 self.emit_shr_imm(dst.as_physical(), *imm);
-                self.end_inst(format!("shr {}, {}", dst.as_physical(), imm));
+                end_inst!(self, "shr {}, {}", dst.as_physical(), imm);
             }
             X86Inst::Shr32RI { dst, imm } => {
                 self.begin_inst();
                 self.emit_shr32_imm(dst.as_physical(), *imm);
-                self.end_inst(format!("shr {}, {}", dst.as_physical(), imm));
+                end_inst!(self, "shr {}, {}", dst.as_physical(), imm);
             }
             X86Inst::SarRCl { dst } => {
                 self.begin_inst();
                 self.emit_sar_cl(dst.as_physical());
-                self.end_inst(format!("sar {}, cl", dst.as_physical()));
+                end_inst!(self, "sar {}, cl", dst.as_physical());
             }
             X86Inst::Sar32RCl { dst } => {
                 self.begin_inst();
                 self.emit_sar32_cl(dst.as_physical());
-                self.end_inst(format!("sar {}, cl", dst.as_physical()));
+                end_inst!(self, "sar {}, cl", dst.as_physical());
             }
             X86Inst::SarRI { dst, imm } => {
                 self.begin_inst();
                 self.emit_sar_imm(dst.as_physical(), *imm);
-                self.end_inst(format!("sar {}, {}", dst.as_physical(), imm));
+                end_inst!(self, "sar {}, {}", dst.as_physical(), imm);
             }
             X86Inst::Sar32RI { dst, imm } => {
                 self.begin_inst();
                 self.emit_sar32_imm(dst.as_physical(), *imm);
-                self.end_inst(format!("sar {}, {}", dst.as_physical(), imm));
+                end_inst!(self, "sar {}, {}", dst.as_physical(), imm);
             }
             X86Inst::Cdq => {
                 self.begin_inst();
                 self.emit_cdq();
-                self.end_inst("cdq");
+                end_inst!(self, "cdq");
             }
             X86Inst::IdivR { src } => {
                 self.begin_inst();
                 self.emit_idiv(src.as_physical());
-                self.end_inst(format!("idiv {}", src.as_physical()));
+                end_inst!(self, "idiv {}", src.as_physical());
             }
             X86Inst::CmpRR { src1, src2 } => {
                 self.begin_inst();
                 self.emit_cmp_rr(src1.as_physical(), src2.as_physical());
-                self.end_inst(format!(
-                    "cmp {}, {}",
-                    src1.as_physical(),
-                    src2.as_physical()
-                ));
+                end_inst!(self, "cmp {}, {}", src1.as_physical(), src2.as_physical());
             }
             X86Inst::Cmp64RR { src1, src2 } => {
                 self.begin_inst();
                 self.emit_cmp64_rr(src1.as_physical(), src2.as_physical());
-                self.end_inst(format!(
-                    "cmp {}, {}",
-                    src1.as_physical(),
-                    src2.as_physical()
-                ));
+                end_inst!(self, "cmp {}, {}", src1.as_physical(), src2.as_physical());
             }
             X86Inst::CmpRI { src, imm } => {
                 self.begin_inst();
                 self.emit_cmp_ri(src.as_physical(), *imm);
-                self.end_inst(format!("cmp {}, {}", src.as_physical(), imm));
+                end_inst!(self, "cmp {}, {}", src.as_physical(), imm);
             }
             X86Inst::Cmp64RI { src, imm } => {
                 self.begin_inst();
                 self.emit_cmp64_ri(src.as_physical(), *imm);
-                self.end_inst(format!("cmp {}, {}", src.as_physical(), imm));
+                end_inst!(self, "cmp {}, {}", src.as_physical(), imm);
             }
             X86Inst::Sete { dst } => {
                 self.begin_inst();
                 self.emit_setcc(0x94, dst.as_physical());
-                self.end_inst(format!("sete {}", dst.as_physical()));
+                end_inst!(self, "sete {}", dst.as_physical());
             }
             X86Inst::Setne { dst } => {
                 self.begin_inst();
                 self.emit_setcc(0x95, dst.as_physical());
-                self.end_inst(format!("setne {}", dst.as_physical()));
+                end_inst!(self, "setne {}", dst.as_physical());
             }
             X86Inst::Setl { dst } => {
                 self.begin_inst();
                 self.emit_setcc(0x9C, dst.as_physical());
-                self.end_inst(format!("setl {}", dst.as_physical()));
+                end_inst!(self, "setl {}", dst.as_physical());
             }
             X86Inst::Setg { dst } => {
                 self.begin_inst();
                 self.emit_setcc(0x9F, dst.as_physical());
-                self.end_inst(format!("setg {}", dst.as_physical()));
+                end_inst!(self, "setg {}", dst.as_physical());
             }
             X86Inst::Setle { dst } => {
                 self.begin_inst();
                 self.emit_setcc(0x9E, dst.as_physical());
-                self.end_inst(format!("setle {}", dst.as_physical()));
+                end_inst!(self, "setle {}", dst.as_physical());
             }
             X86Inst::Setge { dst } => {
                 self.begin_inst();
                 self.emit_setcc(0x9D, dst.as_physical());
-                self.end_inst(format!("setge {}", dst.as_physical()));
+                end_inst!(self, "setge {}", dst.as_physical());
             }
             X86Inst::Setb { dst } => {
                 self.begin_inst();
                 self.emit_setcc(0x92, dst.as_physical());
-                self.end_inst(format!("setb {}", dst.as_physical()));
+                end_inst!(self, "setb {}", dst.as_physical());
             }
             X86Inst::Seta { dst } => {
                 self.begin_inst();
                 self.emit_setcc(0x97, dst.as_physical());
-                self.end_inst(format!("seta {}", dst.as_physical()));
+                end_inst!(self, "seta {}", dst.as_physical());
             }
             X86Inst::Setbe { dst } => {
                 self.begin_inst();
                 self.emit_setcc(0x96, dst.as_physical());
-                self.end_inst(format!("setbe {}", dst.as_physical()));
+                end_inst!(self, "setbe {}", dst.as_physical());
             }
             X86Inst::Setae { dst } => {
                 self.begin_inst();
                 self.emit_setcc(0x93, dst.as_physical());
-                self.end_inst(format!("setae {}", dst.as_physical()));
+                end_inst!(self, "setae {}", dst.as_physical());
             }
             X86Inst::Movzx { dst, src } => {
                 self.begin_inst();
                 self.emit_movzx(dst.as_physical(), src.as_physical());
-                self.end_inst(format!(
-                    "movzx {}, {}",
-                    dst.as_physical(),
-                    src.as_physical()
-                ));
+                end_inst!(self, "movzx {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::Movsx8To64 { dst, src } => {
                 self.begin_inst();
                 self.emit_movsx8_to64(dst.as_physical(), src.as_physical());
-                self.end_inst(format!(
-                    "movsx {}, {}",
-                    dst.as_physical(),
-                    src.as_physical()
-                ));
+                end_inst!(self, "movsx {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::Movsx16To64 { dst, src } => {
                 self.begin_inst();
                 self.emit_movsx16_to64(dst.as_physical(), src.as_physical());
-                self.end_inst(format!(
-                    "movsx {}, {}",
-                    dst.as_physical(),
-                    src.as_physical()
-                ));
+                end_inst!(self, "movsx {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::Movsx32To64 { dst, src } => {
                 self.begin_inst();
                 self.emit_movsxd(dst.as_physical(), src.as_physical());
-                self.end_inst(format!(
-                    "movsxd {}, {}",
-                    dst.as_physical(),
-                    src.as_physical()
-                ));
+                end_inst!(self, "movsxd {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::Movzx8To64 { dst, src } => {
                 self.begin_inst();
                 self.emit_movzx8_to64(dst.as_physical(), src.as_physical());
-                self.end_inst(format!(
-                    "movzx {}, {}",
-                    dst.as_physical(),
-                    src.as_physical()
-                ));
+                end_inst!(self, "movzx {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::Movzx16To64 { dst, src } => {
                 self.begin_inst();
                 self.emit_movzx16_to64(dst.as_physical(), src.as_physical());
-                self.end_inst(format!(
-                    "movzx {}, {}",
-                    dst.as_physical(),
-                    src.as_physical()
-                ));
+                end_inst!(self, "movzx {}, {}", dst.as_physical(), src.as_physical());
             }
             X86Inst::TestRR { src1, src2 } => {
                 self.begin_inst();
                 self.emit_test_rr(src1.as_physical(), src2.as_physical());
-                self.end_inst(format!(
-                    "test {}, {}",
-                    src1.as_physical(),
-                    src2.as_physical()
-                ));
+                end_inst!(self, "test {}, {}", src1.as_physical(), src2.as_physical());
             }
             X86Inst::Jz { label } => {
                 self.begin_inst();
                 self.emit_jcc(0x74, *label);
-                self.end_inst(format!("jz {}", label));
+                end_inst!(self, "jz {}", label);
             }
             X86Inst::Jnz { label } => {
                 self.begin_inst();
                 self.emit_jcc(0x75, *label);
-                self.end_inst(format!("jnz {}", label));
+                end_inst!(self, "jnz {}", label);
             }
             X86Inst::Jo { label } => {
                 self.begin_inst();
                 self.emit_jcc(0x70, *label);
-                self.end_inst(format!("jo {}", label));
+                end_inst!(self, "jo {}", label);
             }
             X86Inst::Jno { label } => {
                 self.begin_inst();
                 self.emit_jcc(0x71, *label);
-                self.end_inst(format!("jno {}", label));
+                end_inst!(self, "jno {}", label);
             }
             X86Inst::Jb { label } => {
                 self.begin_inst();
                 self.emit_jcc(0x72, *label);
-                self.end_inst(format!("jb {}", label));
+                end_inst!(self, "jb {}", label);
             }
             X86Inst::Jae { label } => {
                 self.begin_inst();
                 self.emit_jcc(0x73, *label);
-                self.end_inst(format!("jae {}", label));
+                end_inst!(self, "jae {}", label);
             }
             X86Inst::Jbe { label } => {
                 self.begin_inst();
                 self.emit_jcc(0x76, *label);
-                self.end_inst(format!("jbe {}", label));
+                end_inst!(self, "jbe {}", label);
             }
             X86Inst::Jge { label } => {
                 self.begin_inst();
                 self.emit_jcc(0x7D, *label);
-                self.end_inst(format!("jge {}", label));
+                end_inst!(self, "jge {}", label);
             }
             X86Inst::Jle { label } => {
                 self.begin_inst();
                 self.emit_jcc(0x7E, *label);
-                self.end_inst(format!("jle {}", label));
+                end_inst!(self, "jle {}", label);
             }
             X86Inst::Jmp { label } => {
                 self.begin_inst();
                 self.emit_jmp(*label);
-                self.end_inst(format!("jmp {}", label));
+                end_inst!(self, "jmp {}", label);
             }
             X86Inst::Label { id } => {
                 // Record the current code offset for this label
@@ -922,12 +882,12 @@ impl<'a> Emitter<'a> {
                 let symbol = self.mir.get_symbol(*symbol_id);
                 self.begin_inst();
                 self.emit_call_rel(symbol);
-                self.end_inst(format!("call {}", symbol));
+                end_inst!(self, "call {}", symbol);
             }
             X86Inst::Syscall => {
                 self.begin_inst();
                 self.emit_syscall();
-                self.end_inst("syscall");
+                end_inst!(self, "syscall");
             }
             X86Inst::Ret => {
                 if self.has_frame {
@@ -935,17 +895,17 @@ impl<'a> Emitter<'a> {
                 }
                 self.begin_inst();
                 self.emit_ret();
-                self.end_inst("ret");
+                end_inst!(self, "ret");
             }
             X86Inst::Pop { dst } => {
                 self.begin_inst();
                 self.emit_pop(dst.as_physical());
-                self.end_inst(format!("pop {}", dst.as_physical()));
+                end_inst!(self, "pop {}", dst.as_physical());
             }
             X86Inst::Push { src } => {
                 self.begin_inst();
                 self.emit_push(src.as_physical());
-                self.end_inst(format!("push {}", src.as_physical()));
+                end_inst!(self, "push {}", src.as_physical());
             }
             X86Inst::Lea {
                 dst,
@@ -958,12 +918,13 @@ impl<'a> Emitter<'a> {
                 // Simplified: LEA dst, [base + disp] without index
                 self.begin_inst();
                 self.emit_lea_simple(dst.as_physical(), *base, adjusted_disp);
-                self.end_inst(format!(
+                end_inst!(
+                    self,
                     "lea {}, [{}{}]",
                     dst.as_physical(),
                     base,
                     format_offset(adjusted_disp)
-                ));
+                );
             }
             X86Inst::Shl { dst, count } => {
                 let dst_reg = dst.as_physical();
@@ -974,7 +935,7 @@ impl<'a> Emitter<'a> {
                     // NB: this clobbers rcx, which is exactly what we want.
                     self.begin_inst();
                     self.emit_mov_rr(Reg::Rcx, cnt);
-                    self.end_inst(format!("mov rcx, {}", cnt));
+                    end_inst!(self, "mov rcx, {}", cnt);
                 }
 
                 // If dst is RCX, that's a conflict (dst would be clobbered by the move above
@@ -987,7 +948,7 @@ impl<'a> Emitter<'a> {
 
                 self.begin_inst();
                 self.emit_shl_cl(dst_reg);
-                self.end_inst(format!("shl {}, cl", dst_reg));
+                end_inst!(self, "shl {}, cl", dst_reg);
             }
 
             X86Inst::MovRMIndexed { dst, base, offset } => {
@@ -1001,7 +962,7 @@ impl<'a> Emitter<'a> {
                 // This is handled specially - after regalloc the base VReg is in Rax
                 self.begin_inst();
                 self.emit_mov_rm(dst.as_physical(), Reg::Rax, 0);
-                self.end_inst(format!("mov {}, [rax]", dst.as_physical()));
+                end_inst!(self, "mov {}, [rax]", dst.as_physical());
             }
             X86Inst::MovMRIndexed { base, offset, src } => {
                 // MOV [base_vreg + offset], src
@@ -1010,7 +971,7 @@ impl<'a> Emitter<'a> {
                 // Same as above - base should be in Rax after regalloc
                 self.begin_inst();
                 self.emit_mov_mr(Reg::Rax, 0, src.as_physical());
-                self.end_inst(format!("mov [rax], {}", src.as_physical()));
+                end_inst!(self, "mov [rax], {}", src.as_physical());
             }
 
             X86Inst::StringConstPtr { dst, string_id } => {
@@ -1019,11 +980,12 @@ impl<'a> Emitter<'a> {
                 // The relocation will point to .rodata.str{string_id}
                 self.begin_inst();
                 self.emit_string_const_ptr(dst.as_physical(), *string_id);
-                self.end_inst(format!(
+                end_inst!(
+                    self,
                     "lea {}, [rip + .rodata.str{}]",
                     dst.as_physical(),
                     string_id
-                ));
+                );
             }
 
             X86Inst::StringConstLen { dst, string_id } => {
@@ -1035,7 +997,7 @@ impl<'a> Emitter<'a> {
                     .unwrap_or(0);
                 self.begin_inst();
                 self.emit_mov_ri64(dst.as_physical(), string_len);
-                self.end_inst(format!("mov {}, {}", dst.as_physical(), string_len));
+                end_inst!(self, "mov {}, {}", dst.as_physical(), string_len);
             }
 
             X86Inst::StringConstCap { dst, string_id: _ } => {
@@ -1043,7 +1005,7 @@ impl<'a> Emitter<'a> {
                 // This distinguishes rodata strings from heap-allocated ones
                 self.begin_inst();
                 self.emit_mov_ri64(dst.as_physical(), 0);
-                self.end_inst(format!("mov {}, 0", dst.as_physical()));
+                end_inst!(self, "mov {}, 0", dst.as_physical());
             }
         }
     }


### PR DESCRIPTION
Add end_inst! macro that only evaluates format string arguments when emit_asm is true (--emit asm mode). Previously, format!() was always evaluated even when the result was discarded, causing unnecessary allocations during normal compilation.

- Add end_inst! macro to rue-codegen/lib.rs
- Update all 85 call sites in x86_64/emit.rs to use the macro
- Update all 74 call sites in aarch64/emit.rs to use the macro
- Remove the now-unused end_inst method from both emitters

Fixes rue-jrau

🤖 Generated with [Claude Code](https://claude.com/claude-code)