### PR TITLE
Intern intrinsic names in AIR

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -508,8 +508,8 @@ pub enum AirInstData {
 
     /// Intrinsic call (e.g., @dbg)
     Intrinsic {
-        /// Intrinsic name (without @)
-        name: String,
+        /// Intrinsic name (without @, interned)
+        name: Symbol,
         /// Start index into extra array for arguments
         args_start: u32,
         /// Number of arguments
@@ -786,7 +786,7 @@ impl fmt::Display for Air {
                     args_start,
                     args_len,
                 } => {
-                    write!(f, "intrinsic @{}(", name)?;
+                    write!(f, "intrinsic @sym:{}(", name.as_u32())?;
                     for (i, arg) in self.get_air_refs(*args_start, *args_len).enumerate() {
                         if i > 0 {
                             write!(f, ", ")?;

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -3312,15 +3312,15 @@ impl<'a> Sema<'a> {
                 args_len,
             } => {
                 let args = self.rir.get_call_args(*args_start, *args_len);
-                let intrinsic_name = self.interner.get(*name).to_string();
+                let intrinsic_name_str = self.interner.get(*name);
 
-                match intrinsic_name.as_str() {
+                match intrinsic_name_str {
                     "dbg" => {
                         // @dbg expects exactly one argument
                         if args.len() != 1 {
                             return Err(CompileError::new(
                                 ErrorKind::IntrinsicWrongArgCount {
-                                    name: intrinsic_name,
+                                    name: intrinsic_name_str.to_string(),
                                     expected: 1,
                                     found: args.len(),
                                 },
@@ -3340,7 +3340,7 @@ impl<'a> Sema<'a> {
                             return Err(CompileError::new(
                                 ErrorKind::IntrinsicTypeMismatch(Box::new(
                                     IntrinsicTypeMismatchError {
-                                        name: intrinsic_name,
+                                        name: intrinsic_name_str.to_string(),
                                         expected: "integer, bool, or string".to_string(),
                                         found: arg_type.name().to_string(),
                                     },
@@ -3353,7 +3353,7 @@ impl<'a> Sema<'a> {
                         let args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
                         let air_ref = air.add_inst(AirInst {
                             data: AirInstData::Intrinsic {
-                                name: intrinsic_name,
+                                name: *name,
                                 args_start,
                                 args_len: 1,
                             },
@@ -3367,7 +3367,7 @@ impl<'a> Sema<'a> {
                         if args.len() != 1 {
                             return Err(CompileError::new(
                                 ErrorKind::IntrinsicWrongArgCount {
-                                    name: intrinsic_name,
+                                    name: intrinsic_name_str.to_string(),
                                     expected: 1,
                                     found: args.len(),
                                 },
@@ -3384,7 +3384,7 @@ impl<'a> Sema<'a> {
                             return Err(CompileError::new(
                                 ErrorKind::IntrinsicTypeMismatch(Box::new(
                                     IntrinsicTypeMismatchError {
-                                        name: intrinsic_name,
+                                        name: intrinsic_name_str.to_string(),
                                         expected: "integer".to_string(),
                                         found: from_ty.name().to_string(),
                                     },
@@ -3407,7 +3407,7 @@ impl<'a> Sema<'a> {
                                 return Err(CompileError::new(
                                     ErrorKind::IntrinsicTypeMismatch(Box::new(
                                         IntrinsicTypeMismatchError {
-                                            name: intrinsic_name,
+                                            name: intrinsic_name_str.to_string(),
                                             expected: "integer".to_string(),
                                             found: ty.name().to_string(),
                                         },
@@ -3447,7 +3447,7 @@ impl<'a> Sema<'a> {
                         if !args.is_empty() {
                             return Err(CompileError::new(
                                 ErrorKind::IntrinsicWrongArgCount {
-                                    name: intrinsic_name,
+                                    name: intrinsic_name_str.to_string(),
                                     expected: 0,
                                     found: args.len(),
                                 },
@@ -3464,17 +3464,17 @@ impl<'a> Sema<'a> {
                         Ok(AnalysisResult::new(air_ref, Type::Unit))
                     }
                     _ => Err(CompileError::new(
-                        ErrorKind::UnknownIntrinsic(intrinsic_name),
+                        ErrorKind::UnknownIntrinsic(intrinsic_name_str.to_string()),
                         inst.span,
                     )),
                 }
             }
 
             InstData::TypeIntrinsic { name, type_arg } => {
-                let intrinsic_name = self.interner.get(*name).to_string();
+                let intrinsic_name_str = self.interner.get(*name);
                 let ty = self.resolve_type(*type_arg, inst.span)?;
 
-                let value: u64 = match intrinsic_name.as_str() {
+                let value: u64 = match intrinsic_name_str {
                     "size_of" => {
                         // Calculate size in bytes (slot count * 8)
                         let slot_count = self.abi_slot_count(ty);
@@ -3487,7 +3487,7 @@ impl<'a> Sema<'a> {
                     }
                     _ => {
                         return Err(CompileError::new(
-                            ErrorKind::UnknownIntrinsic(intrinsic_name),
+                            ErrorKind::UnknownIntrinsic(intrinsic_name_str.to_string()),
                             inst.span,
                         ));
                     }

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -675,13 +675,11 @@ impl<'a> CfgBuilder<'a> {
                     };
                     arg_vals.push(val);
                 }
-                // Intern the intrinsic name since AIR still uses String
-                let name_sym = self.interner.intern(name);
                 // Store args in extra array
                 let (args_start, args_len) = self.cfg.push_extra(arg_vals);
                 let value = self.emit(
                     CfgInstData::Intrinsic {
-                        name: name_sym,
+                        name: *name,
                         args_start,
                         args_len,
                     },

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -3,6 +3,12 @@
 //! The AST represents the syntactic structure of the source code.
 //! It closely mirrors the source syntax and preserves all information
 //! needed for error reporting.
+//!
+//! Note: AST types use Vec rather than SmallVec because Expr is recursive
+//! (Expr contains CallExpr which contains CallArg which contains Expr).
+//! SmallVec requires fixed-size inline storage, which doesn't work with
+//! recursive types. The IR layers (RIR, AIR, CFG) use index-based references
+//! which avoid this issue and are already efficiently allocated.
 
 use std::fmt;
 


### PR DESCRIPTION
Change AirInstData::Intrinsic.name from String to Symbol to avoid per-intrinsic-call string allocations. The intrinsic name is already interned in the RIR layer, so this change passes the Symbol directly through to CFG instead of converting to String and re-interning.

This is part of the arena allocation investigation (rue-x5ku). Also investigated SmallVec for AST types but found it infeasible due to recursive type constraints (Expr -> CallExpr -> CallArg -> Expr). Added documentation in ast.rs explaining this limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)