### PR TITLE
Add standard escape sequences (\n, \t, \r, \0) to string literals

### DIFF
--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -50,6 +50,22 @@ fn process_string_from_quote(
                     consumed += 1;
                     result.push('"');
                 }
+                Some('n') => {
+                    consumed += 1;
+                    result.push('\n');
+                }
+                Some('t') => {
+                    consumed += 1;
+                    result.push('\t');
+                }
+                Some('r') => {
+                    consumed += 1;
+                    result.push('\r');
+                }
+                Some('0') => {
+                    consumed += 1;
+                    result.push('\0');
+                }
                 Some(other) => {
                     // Invalid escape - consume the char to get better error position
                     consumed += other.len_utf8();
@@ -776,6 +792,63 @@ mod tests {
         assert_eq!(
             get_string_str(&tokens[0].kind, &interner),
             Some("hello\\world")
+        );
+    }
+
+    #[test]
+    fn test_logos_escape_newline() {
+        let lexer = LogosLexer::new(r#""line1\nline2""#);
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        assert_eq!(
+            get_string_str(&tokens[0].kind, &interner),
+            Some("line1\nline2")
+        );
+    }
+
+    #[test]
+    fn test_logos_escape_tab() {
+        let lexer = LogosLexer::new(r#""col1\tcol2""#);
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        assert_eq!(
+            get_string_str(&tokens[0].kind, &interner),
+            Some("col1\tcol2")
+        );
+    }
+
+    #[test]
+    fn test_logos_escape_carriage_return() {
+        let lexer = LogosLexer::new(r#""line\r\n""#);
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        assert_eq!(get_string_str(&tokens[0].kind, &interner), Some("line\r\n"));
+    }
+
+    #[test]
+    fn test_logos_escape_null() {
+        let lexer = LogosLexer::new(r#""null\0byte""#);
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        assert_eq!(
+            get_string_str(&tokens[0].kind, &interner),
+            Some("null\0byte")
+        );
+    }
+
+    #[test]
+    fn test_logos_invalid_escape_q() {
+        let lexer = LogosLexer::new(r#""bad\qescape""#);
+        let result = lexer.tokenize();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err.kind, ErrorKind::InvalidStringEscape('q')));
+    }
+
+    #[test]
+    fn test_logos_all_escapes_combined() {
+        // Test all escape sequences in one string
+        let lexer = LogosLexer::new(r#""\\\"abc\n\t\r\0xyz""#);
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        assert_eq!(
+            get_string_str(&tokens[0].kind, &interner),
+            Some("\\\"abc\n\t\r\0xyz")
         );
     }
 

--- a/crates/rue-spec/cases/lexical/tokens.toml
+++ b/crates/rue-spec/cases/lexical/tokens.toml
@@ -92,11 +92,55 @@ fn main() -> i32 {
 exit_code = 0
 
 [[case]]
+name = "string_literal_escape_newline"
+spec = ["2.1:6", "2.1:7"]
+source = '''
+fn main() -> i32 {
+    let _s = "line1\nline2";
+    0
+}
+'''
+exit_code = 0
+
+[[case]]
+name = "string_literal_escape_tab"
+spec = ["2.1:6", "2.1:7"]
+source = '''
+fn main() -> i32 {
+    let _s = "col1\tcol2";
+    0
+}
+'''
+exit_code = 0
+
+[[case]]
+name = "string_literal_escape_carriage_return"
+spec = ["2.1:6", "2.1:7"]
+source = '''
+fn main() -> i32 {
+    let _s = "line\r\n";
+    0
+}
+'''
+exit_code = 0
+
+[[case]]
+name = "string_literal_escape_null"
+spec = ["2.1:6", "2.1:7"]
+source = '''
+fn main() -> i32 {
+    let _s = "null\0byte";
+    0
+}
+'''
+exit_code = 0
+
+[[case]]
 name = "string_literal_invalid_escape"
 spec = ["2.1:8"]
 source = '''
 fn main() -> i32 {
-    let _s = "bad \n escape";
+    let _s = "bad \q escape";
     0
 }
 '''

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -79,11 +79,55 @@ fn main() -> i32 {
 exit_code = 0
 
 [[case]]
+name = "string_escape_newline"
+spec = ["3.7:6", "2.1:7"]
+source = """
+fn main() -> i32 {
+    let s = "line1\\nline2";
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_escape_tab"
+spec = ["3.7:6", "2.1:7"]
+source = """
+fn main() -> i32 {
+    let s = "col1\\tcol2";
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_escape_carriage_return"
+spec = ["3.7:6", "2.1:7"]
+source = """
+fn main() -> i32 {
+    let s = "line\\r\\n";
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "string_escape_null"
+spec = ["3.7:6", "2.1:7"]
+source = """
+fn main() -> i32 {
+    let s = "null\\0byte";
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
 name = "string_invalid_escape"
 spec = ["3.7:7", "2.1:8"]
 source = """
 fn main() -> i32 {
-    let s = "invalid \\n escape";
+    let s = "invalid \\q escape";
     0
 }
 """
@@ -385,6 +429,30 @@ fn main() -> i32 {
 """
 exit_code = 0
 stdout = "Hello, world!\n"
+
+[[case]]
+name = "string_dbg_with_escaped_newline"
+spec = ["3.7:6", "3.7:12"]
+source = """
+fn main() -> i32 {
+    @dbg("line1\\nline2");
+    0
+}
+"""
+exit_code = 0
+stdout = "line1\nline2\n"
+
+[[case]]
+name = "string_dbg_with_escaped_tab"
+spec = ["3.7:6", "3.7:12"]
+source = """
+fn main() -> i32 {
+    @dbg("col1\\tcol2");
+    0
+}
+"""
+exit_code = 0
+stdout = "col1\tcol2\n"
 
 # =============================================================================
 # String in Complex Expressions

--- a/docs/spec/src/02-lexical-structure/01-tokens.md
+++ b/docs/spec/src/02-lexical-structure/01-tokens.md
@@ -59,12 +59,21 @@ A string literal is a sequence of characters enclosed in double quotes (`"`).
 ```ebnf
 string_literal = '"' { string_char } '"' ;
 string_char = any_char_except_quote_or_backslash | escape_sequence ;
-escape_sequence = "\\" | "\"" ;
+escape_sequence = "\\" | "\"" | "\n" | "\t" | "\r" | "\0" ;
 ```
 
 {{ rule(id="2.1:7", cat="normative") }}
 
-String literals support escape sequences: `\\` for a backslash and `\"` for a double quote.
+String literals support the following escape sequences:
+
+| Escape | Character |
+|--------|-----------|
+| `\\` | Backslash |
+| `\"` | Double quote |
+| `\n` | Newline (line feed, U+000A) |
+| `\t` | Horizontal tab (U+0009) |
+| `\r` | Carriage return (U+000D) |
+| `\0` | Null character (U+0000) |
 
 {{ rule(id="2.1:8", cat="legality-rule") }}
 
@@ -81,6 +90,8 @@ fn main() -> i32 {
     let a = "hello world";
     let b = "with \"quotes\"";
     let c = "with \\ backslash";
+    let d = "line1\nline2";   // newline
+    let e = "col1\tcol2";     // tab
     0
 }
 ```

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -41,6 +41,10 @@ String literals support the following escape sequences:
 |--------|---------|
 | `\\` | Backslash |
 | `\"` | Double quote |
+| `\n` | Newline (line feed, U+000A) |
+| `\t` | Horizontal tab (U+0009) |
+| `\r` | Carriage return (U+000D) |
+| `\0` | Null character (U+0000) |
 
 {{ rule(id="3.7:7", cat="normative") }}
 
@@ -53,6 +57,8 @@ fn main() -> i32 {
     let a = "hello world";
     let b = "with \"quotes\"";
     let c = "with \\ backslash";
+    let d = "line1\nline2";   // newline
+    let e = "col1\tcol2";     // tab
     0
 }
 ```


### PR DESCRIPTION
Previously, only \\ and \" were recognized as valid escape sequences. This adds support for the common escape sequences needed for practical string handling:

- \n: newline (line feed, U+000A)
- \t: horizontal tab (U+0009)
- \r: carriage return (U+000D)
- \0: null character (U+0000)

Updates the specification (chapters 2.1 and 3.7), adds spec tests and unit tests covering each escape sequence.

Fixes rue-yz58

🤖 Generated with [Claude Code](https://claude.ai/code)