### PR TITLE
Use SmallVec for AST directive fields

### DIFF
--- a/crates/rue-parser/BUCK
+++ b/crates/rue-parser/BUCK
@@ -7,6 +7,7 @@ rust_library(
         "//crates/rue-lexer:rue-lexer",
         "//crates/rue-span:rue-span",
         "//third-party:chumsky",
+        "//third-party:smallvec",
     ],
     visibility = ["PUBLIC"],
 )
@@ -20,5 +21,6 @@ rust_test(
         "//crates/rue-lexer:rue-lexer",
         "//crates/rue-span:rue-span",
         "//third-party:chumsky",
+        "//third-party:smallvec",
     ],
 )

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -4,16 +4,35 @@
 //! It closely mirrors the source syntax and preserves all information
 //! needed for error reporting.
 //!
-//! Note: AST types use Vec rather than SmallVec because Expr is recursive
-//! (Expr contains CallExpr which contains CallArg which contains Expr).
-//! SmallVec requires fixed-size inline storage, which doesn't work with
-//! recursive types. The IR layers (RIR, AIR, CFG) use index-based references
-//! which avoid this issue and are already efficiently allocated.
+//! ## SmallVec Usage
+//!
+//! Some non-recursive Vec fields use SmallVec to avoid heap allocation for
+//! common small sizes:
+//! - `Directives` (SmallVec<[Directive; 1]>) - most items have 0-1 directives
+//!
+//! ## Vec Usage (Cannot Use SmallVec)
+//!
+//! Vec fields containing recursive types (Expr) cannot use SmallVec because
+//! Expr's size cannot be determined at compile time. These include:
+//! - `Vec<CallArg>` - CallArg contains Expr
+//! - `Vec<MatchArm>` - contains Expr
+//! - `Vec<FieldInit>` - contains Box<Expr>
+//! - `Vec<IntrinsicArg>` - contains Expr
+//! - `Vec<Statement>` - Statement contains Expr
+//! - `Vec<Expr>` - directly recursive
+//!
+//! The IR layers (RIR, AIR, CFG) use index-based references which avoid
+//! this issue and are already efficiently allocated.
 
 use std::fmt;
 
 use lasso::{Key, Spur};
 use rue_span::Span;
+use smallvec::SmallVec;
+
+/// Type alias for a small vector of directives.
+/// Most items have 0-1 directives, so we inline capacity for 1.
+pub type Directives = SmallVec<[Directive; 1]>;
 
 /// A complete source file (list of items).
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -56,7 +75,7 @@ pub enum Item {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StructDecl {
     /// Directives applied to this struct (e.g., @copy)
-    pub directives: Vec<Directive>,
+    pub directives: Directives,
     /// Struct name
     pub name: Ident,
     /// Struct fields
@@ -126,7 +145,7 @@ pub struct DropFn {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Method {
     /// Directives applied to this method
-    pub directives: Vec<Directive>,
+    pub directives: Directives,
     /// Method name
     pub name: Ident,
     /// Whether this method takes self (None = associated function, Some = method with receiver)
@@ -152,7 +171,7 @@ pub struct SelfParam {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Function {
     /// Directives applied to this function
-    pub directives: Vec<Directive>,
+    pub directives: Directives,
     /// Function name
     pub name: Ident,
     /// Function parameters
@@ -657,7 +676,7 @@ impl LetPattern {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LetStatement {
     /// Directives applied to this let binding
-    pub directives: Vec<Directive>,
+    pub directives: Directives,
     /// Whether the binding is mutable
     pub is_mut: bool,
     /// The binding pattern (identifier or wildcard)

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -6,10 +6,10 @@
 use crate::ast::{
     ArgMode, ArrayLitExpr, AssignStatement, AssignTarget, AssocFnCallExpr, Ast, BinaryExpr,
     BinaryOp, BlockExpr, BoolLit, BreakExpr, CallArg, CallExpr, ContinueExpr, Directive,
-    DirectiveArg, DropFn, EnumDecl, EnumVariant, Expr, FieldDecl, FieldExpr, FieldInit, Function,
-    Ident, IfExpr, ImplBlock, IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr, Item, LetPattern,
-    LetStatement, LoopExpr, MatchArm, MatchExpr, Method, MethodCallExpr, NegIntLit, Param,
-    ParamMode, ParenExpr, PathExpr, PathPattern, Pattern, ReturnExpr, SelfExpr, SelfParam,
+    DirectiveArg, Directives, DropFn, EnumDecl, EnumVariant, Expr, FieldDecl, FieldExpr, FieldInit,
+    Function, Ident, IfExpr, ImplBlock, IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr, Item,
+    LetPattern, LetStatement, LoopExpr, MatchArm, MatchExpr, Method, MethodCallExpr, NegIntLit,
+    Param, ParamMode, ParenExpr, PathExpr, PathPattern, Pattern, ReturnExpr, SelfExpr, SelfParam,
     Statement, StringLit, StructDecl, StructLitExpr, TypeExpr, UnaryExpr, UnaryOp, UnitLit,
     WhileExpr,
 };
@@ -325,11 +325,17 @@ where
 }
 
 /// Parser for zero or more directives
-fn directives_parser<'src, I>() -> impl Parser<'src, I, Vec<Directive>, ParserExtras<'src>> + Clone
+fn directives_parser<'src, I>() -> impl Parser<'src, I, Directives, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    directive_parser().repeated().collect()
+    // Chumsky's collect() requires its Container trait, which SmallVec doesn't implement.
+    // So we collect to Vec first, then convert. The overhead is minimal since most
+    // items have 0-1 directives (Vec is cheap for empty/small collections).
+    directive_parser()
+        .repeated()
+        .collect::<Vec<_>>()
+        .map(|v| v.into_iter().collect())
 }
 
 /// Parser for argument mode: inout or borrow

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -3778,6 +3778,12 @@ cargo.rust_library(
     visibility = [],
 )
 
+alias(
+    name = "smallvec",
+    actual = ":smallvec-1.15.1",
+    visibility = ["PUBLIC"],
+)
+
 cargo.rust_library(
     name = "stacker-0.1.22",
     srcs = [


### PR DESCRIPTION
Replace Vec<Directive> with SmallVec<[Directive; 1]> for directive fields in the AST. Most items have 0-1 directives, so this avoids heap allocations in the common case.

Changes:
- Add Directives type alias (SmallVec<[Directive; 1]>)
- Update StructDecl, Method, Function, LetStatement to use it
- Update parser to construct SmallVec via Vec conversion (Chumsky doesn't implement Container trait for SmallVec)
- Add smallvec dependency to rue-parser
- Add public smallvec alias to third-party BUCK

Fixes rue-e78n

🤖 Generated with [Claude Code](https://claude.com/claude-code)