### PR TITLE
Add compile-time size assertions for IR structs

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -4,6 +4,16 @@
 
 use std::fmt;
 
+// Compile-time size assertions to prevent silent size growth during refactoring.
+// These limits are set slightly above current sizes to allow minor changes,
+// but will catch significant size regressions.
+//
+// Current sizes (as of 2025-12):
+// - AirInst: 40 bytes (AirInstData + Type + Span)
+// - AirInstData: 24 bytes
+const _: () = assert!(std::mem::size_of::<AirInst>() <= 48);
+const _: () = assert!(std::mem::size_of::<AirInstData>() <= 32);
+
 use crate::types::{ArrayTypeId, StructId, Type};
 use lasso::{Key, Spur};
 use rue_span::Span;
@@ -942,6 +952,29 @@ mod tests {
     #[test]
     fn test_air_ref_size() {
         assert_eq!(std::mem::size_of::<AirRef>(), 4);
+    }
+
+    #[test]
+    fn test_air_inst_size() {
+        // Document actual sizes for future reference.
+        // If this test fails, update the const assertions at the top of this file.
+        let air_inst_size = std::mem::size_of::<AirInst>();
+        let air_inst_data_size = std::mem::size_of::<AirInstData>();
+        eprintln!("AirInst size: {} bytes", air_inst_size);
+        eprintln!("AirInstData size: {} bytes", air_inst_data_size);
+
+        // These assertions document the current sizes.
+        // If the layout changes, update both these values and the const assertions.
+        assert!(
+            air_inst_size <= 48,
+            "AirInst grew beyond 48 bytes: {}",
+            air_inst_size
+        );
+        assert!(
+            air_inst_data_size <= 32,
+            "AirInstData grew beyond 32 bytes: {}",
+            air_inst_data_size
+        );
     }
 
     #[test]

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -5,6 +5,16 @@
 
 use std::fmt;
 
+// Compile-time size assertions to prevent silent size growth during refactoring.
+// These limits are set slightly above current sizes to allow minor changes,
+// but will catch significant size regressions.
+//
+// Current sizes (as of 2025-12):
+// - CfgInst: 40 bytes (CfgInstData + Type + Span)
+// - CfgInstData: 24 bytes
+const _: () = assert!(std::mem::size_of::<CfgInst>() <= 48);
+const _: () = assert!(std::mem::size_of::<CfgInstData>() <= 32);
+
 use lasso::{Key, Spur};
 use rue_air::{ArrayTypeId, EnumId, StructId, Type};
 use rue_span::Span;
@@ -940,6 +950,29 @@ mod tests {
     #[test]
     fn test_cfg_value_size() {
         assert_eq!(std::mem::size_of::<CfgValue>(), 4);
+    }
+
+    #[test]
+    fn test_cfg_inst_size() {
+        // Document actual sizes for future reference.
+        // If this test fails, update the const assertions at the top of this file.
+        let cfg_inst_size = std::mem::size_of::<CfgInst>();
+        let cfg_inst_data_size = std::mem::size_of::<CfgInstData>();
+        eprintln!("CfgInst size: {} bytes", cfg_inst_size);
+        eprintln!("CfgInstData size: {} bytes", cfg_inst_data_size);
+
+        // These assertions document the current sizes.
+        // If the layout changes, update both these values and the const assertions.
+        assert!(
+            cfg_inst_size <= 48,
+            "CfgInst grew beyond 48 bytes: {}",
+            cfg_inst_size
+        );
+        assert!(
+            cfg_inst_data_size <= 32,
+            "CfgInstData grew beyond 32 bytes: {}",
+            cfg_inst_data_size
+        );
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -30,6 +30,14 @@
 use std::collections::HashMap;
 use std::fmt;
 
+// Compile-time size assertions to prevent silent size growth during refactoring.
+// These limits are set slightly above current sizes to allow minor changes,
+// but will catch significant size regressions.
+//
+// Current sizes (as of 2025-12):
+// - Aarch64Inst: 40 bytes
+const _: () = assert!(std::mem::size_of::<Aarch64Inst>() <= 48);
+
 pub use crate::vreg::{BLOCK_LABEL_BASE, LabelId, VReg};
 
 /// A physical AArch64 register.
@@ -1115,6 +1123,22 @@ impl fmt::Display for Aarch64Mir {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_aarch64_inst_size() {
+        // Document actual sizes for future reference.
+        // If this test fails, update the const assertions at the top of this file.
+        let aarch64_inst_size = std::mem::size_of::<Aarch64Inst>();
+        eprintln!("Aarch64Inst size: {} bytes", aarch64_inst_size);
+
+        // This assertion documents the current size.
+        // If the layout changes, update both this value and the const assertion.
+        assert!(
+            aarch64_inst_size <= 48,
+            "Aarch64Inst grew beyond 48 bytes: {}",
+            aarch64_inst_size
+        );
+    }
 
     #[test]
     fn test_vreg_allocation() {

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -8,6 +8,14 @@
 use std::collections::HashMap;
 use std::fmt;
 
+// Compile-time size assertions to prevent silent size growth during refactoring.
+// These limits are set slightly above current sizes to allow minor changes,
+// but will catch significant size regressions.
+//
+// Current sizes (as of 2025-12):
+// - X86Inst: 32 bytes
+const _: () = assert!(std::mem::size_of::<X86Inst>() <= 40);
+
 pub use crate::vreg::{LabelId, VReg};
 
 /// A physical x86-64 register.
@@ -752,6 +760,22 @@ impl fmt::Display for X86Mir {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_x86_inst_size() {
+        // Document actual sizes for future reference.
+        // If this test fails, update the const assertions at the top of this file.
+        let x86_inst_size = std::mem::size_of::<X86Inst>();
+        eprintln!("X86Inst size: {} bytes", x86_inst_size);
+
+        // This assertion documents the current size.
+        // If the layout changes, update both this value and the const assertion.
+        assert!(
+            x86_inst_size <= 40,
+            "X86Inst grew beyond 40 bytes: {}",
+            x86_inst_size
+        );
+    }
 
     #[test]
     fn test_vreg_allocation() {


### PR DESCRIPTION
Add const assertions to catch silent size growth in key IR types:
- CfgInst/CfgInstData (≤48/32 bytes) in rue-cfg
- AirInst/AirInstData (≤48/32 bytes) in rue-air  
- X86Inst (≤40 bytes) in rue-codegen x86_64
- Aarch64Inst (≤48 bytes) in rue-codegen aarch64

Also adds runtime tests that print actual sizes for debugging. These assertions will fail at compile time if enum sizes grow significantly during refactoring.

Fixes rue-a1q6

🤖 Generated with [Claude Code](https://claude.com/claude-code)