### PR TITLE
refactor(cfg): pool terminator block arguments in extra array

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -374,14 +374,19 @@ impl<'a> CfgBuilder<'a> {
 
                 // Branch: if lhs is false, go to join with false; else evaluate rhs
                 let false_val = self.emit(CfgInstData::BoolConst(false), Type::Bool, span);
+                let (then_args_start, then_args_len) = self.cfg.push_extra(std::iter::empty());
+                let (else_args_start, else_args_len) =
+                    self.cfg.push_extra(std::iter::once(false_val));
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Branch {
                         cond: lhs_val,
                         then_block: rhs_block,
-                        then_args: vec![],
+                        then_args_start,
+                        then_args_len,
                         else_block: join_block,
-                        else_args: vec![false_val],
+                        else_args_start,
+                        else_args_len,
                     },
                 );
 
@@ -390,11 +395,13 @@ impl<'a> CfgBuilder<'a> {
                 let Some(rhs_val) = self.lower_value(*rhs) else {
                     return Self::diverged();
                 };
+                let (args_start, args_len) = self.cfg.push_extra(std::iter::once(rhs_val));
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Goto {
                         target: join_block,
-                        args: vec![rhs_val],
+                        args_start,
+                        args_len,
                     },
                 );
 
@@ -421,14 +428,19 @@ impl<'a> CfgBuilder<'a> {
 
                 // Branch: if lhs is true, go to join with true; else evaluate rhs
                 let true_val = self.emit(CfgInstData::BoolConst(true), Type::Bool, span);
+                let (then_args_start, then_args_len) =
+                    self.cfg.push_extra(std::iter::once(true_val));
+                let (else_args_start, else_args_len) = self.cfg.push_extra(std::iter::empty());
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Branch {
                         cond: lhs_val,
                         then_block: join_block,
-                        then_args: vec![true_val],
+                        then_args_start,
+                        then_args_len,
                         else_block: rhs_block,
-                        else_args: vec![],
+                        else_args_start,
+                        else_args_len,
                     },
                 );
 
@@ -437,11 +449,13 @@ impl<'a> CfgBuilder<'a> {
                 let Some(rhs_val) = self.lower_value(*rhs) else {
                     return Self::diverged();
                 };
+                let (args_start, args_len) = self.cfg.push_extra(std::iter::once(rhs_val));
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Goto {
                         target: join_block,
-                        args: vec![rhs_val],
+                        args_start,
+                        args_len,
                     },
                 );
 
@@ -959,14 +973,18 @@ impl<'a> CfgBuilder<'a> {
                 let else_type = else_value.map(|e| self.air.get(e).ty);
 
                 // Branch to then/else
+                let (then_args_start, then_args_len) = self.cfg.push_extra(std::iter::empty());
+                let (else_args_start, else_args_len) = self.cfg.push_extra(std::iter::empty());
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Branch {
                         cond: cond_val,
                         then_block,
-                        then_args: vec![],
+                        then_args_start,
+                        then_args_len,
                         else_block,
-                        else_args: vec![],
+                        else_args_start,
+                        else_args_len,
                     },
                 );
 
@@ -1016,7 +1034,7 @@ impl<'a> CfgBuilder<'a> {
 
                 // Wire up non-divergent branches to join
                 if !then_diverged {
-                    let args = if let Some(val) = then_result.value {
+                    let args: Vec<CfgValue> = if let Some(val) = then_result.value {
                         if result_param.is_some() {
                             vec![val]
                         } else {
@@ -1025,17 +1043,19 @@ impl<'a> CfgBuilder<'a> {
                     } else {
                         vec![]
                     };
+                    let (args_start, args_len) = self.cfg.push_extra(args);
                     self.cfg.set_terminator(
                         then_exit_block,
                         Terminator::Goto {
                             target: join_block,
-                            args,
+                            args_start,
+                            args_len,
                         },
                     );
                 }
 
                 if !else_diverged {
-                    let args = if let Some(val) = else_result.value {
+                    let args: Vec<CfgValue> = if let Some(val) = else_result.value {
                         if result_param.is_some() {
                             vec![val]
                         } else {
@@ -1044,11 +1064,13 @@ impl<'a> CfgBuilder<'a> {
                     } else {
                         vec![]
                     };
+                    let (args_start, args_len) = self.cfg.push_extra(args);
                     self.cfg.set_terminator(
                         else_exit_block,
                         Terminator::Goto {
                             target: join_block,
-                            args,
+                            args_start,
+                            args_len,
                         },
                     );
                 }
@@ -1071,11 +1093,13 @@ impl<'a> CfgBuilder<'a> {
                 let exit_block = self.cfg.new_block();
 
                 // Jump to header
+                let (args_start, args_len) = self.cfg.push_extra(std::iter::empty());
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Goto {
                         target: header_block,
-                        args: vec![],
+                        args_start,
+                        args_len,
                     },
                 );
 
@@ -1095,14 +1119,18 @@ impl<'a> CfgBuilder<'a> {
                 };
 
                 // Branch: if true go to body, if false exit
+                let (then_args_start, then_args_len) = self.cfg.push_extra(std::iter::empty());
+                let (else_args_start, else_args_len) = self.cfg.push_extra(std::iter::empty());
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Branch {
                         cond: cond_val,
                         then_block: body_block,
-                        then_args: vec![],
+                        then_args_start,
+                        then_args_len,
                         else_block: exit_block,
-                        else_args: vec![],
+                        else_args_start,
+                        else_args_len,
                     },
                 );
 
@@ -1112,11 +1140,13 @@ impl<'a> CfgBuilder<'a> {
 
                 // After body, go back to header (unless diverged)
                 if !matches!(body_result.continuation, Continuation::Diverged) {
+                    let (args_start, args_len) = self.cfg.push_extra(std::iter::empty());
                     self.cfg.set_terminator(
                         self.current_block,
                         Terminator::Goto {
                             target: header_block,
-                            args: vec![],
+                            args_start,
+                            args_len,
                         },
                     );
                 }
@@ -1148,11 +1178,13 @@ impl<'a> CfgBuilder<'a> {
                 let exit_block = self.cfg.new_block();
 
                 // Jump to body
+                let (args_start, args_len) = self.cfg.push_extra(std::iter::empty());
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Goto {
                         target: body_block,
-                        args: vec![],
+                        args_start,
+                        args_len,
                     },
                 );
 
@@ -1171,11 +1203,13 @@ impl<'a> CfgBuilder<'a> {
 
                 // After body, go back to start (unless diverged via return/break/continue)
                 if !matches!(body_result.continuation, Continuation::Diverged) {
+                    let (args_start, args_len) = self.cfg.push_extra(std::iter::empty());
                     self.cfg.set_terminator(
                         self.current_block,
                         Terminator::Goto {
                             target: body_block,
-                            args: vec![],
+                            args_start,
+                            args_len,
                         },
                     );
                 }
@@ -1264,11 +1298,13 @@ impl<'a> CfgBuilder<'a> {
                 });
 
                 // Set the switch terminator on current block
+                let (cases_start, cases_len) = self.cfg.push_switch_cases(switch_cases);
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Switch {
                         scrutinee: scrutinee_val,
-                        cases: switch_cases,
+                        cases_start,
+                        cases_len,
                         default,
                     },
                 );
@@ -1309,7 +1345,7 @@ impl<'a> CfgBuilder<'a> {
                 // Wire up non-divergent arms to join
                 for (exit_block, body_result, diverged) in arm_results {
                     if !diverged {
-                        let args = if let Some(val) = body_result.value {
+                        let args: Vec<CfgValue> = if let Some(val) = body_result.value {
                             if result_param.is_some() {
                                 vec![val]
                             } else {
@@ -1318,11 +1354,13 @@ impl<'a> CfgBuilder<'a> {
                         } else {
                             vec![]
                         };
+                        let (args_start, args_len) = self.cfg.push_extra(args);
                         self.cfg.set_terminator(
                             exit_block,
                             Terminator::Goto {
                                 target: join_block,
-                                args,
+                                args_start,
+                                args_len,
                             },
                         );
                     }
@@ -1347,11 +1385,13 @@ impl<'a> CfgBuilder<'a> {
                 let exit_block = loop_ctx.exit;
                 self.emit_drops_for_loop_exit(target_depth, span);
 
+                let (args_start, args_len) = self.cfg.push_extra(std::iter::empty());
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Goto {
                         target: exit_block,
-                        args: vec![],
+                        args_start,
+                        args_len,
                     },
                 );
 
@@ -1368,11 +1408,13 @@ impl<'a> CfgBuilder<'a> {
                 let header_block = loop_ctx.header;
                 self.emit_drops_for_loop_exit(target_depth, span);
 
+                let (args_start, args_len) = self.cfg.push_extra(std::iter::empty());
                 self.cfg.set_terminator(
                     self.current_block,
                     Terminator::Goto {
                         target: header_block,
-                        args: vec![],
+                        args_start,
+                        args_len,
                     },
                 );
 

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -318,30 +318,47 @@ pub enum CfgInstData {
 /// Block terminator - how control leaves a basic block.
 ///
 /// Terminators are the ONLY place where control flow happens in the CFG.
-#[derive(Debug, Clone)]
+///
+/// Block arguments are stored in the CFG's `extra` array for efficiency.
+/// Use `Cfg::get_goto_args()`, `Cfg::get_branch_then_args()`, and
+/// `Cfg::get_branch_else_args()` to retrieve the arguments.
+#[derive(Debug, Clone, Copy)]
 pub enum Terminator {
     /// Unconditional jump to another block.
+    /// Arguments are stored in Cfg's extra array.
     Goto {
         target: BlockId,
-        /// Arguments to pass to target block's parameters
-        args: Vec<CfgValue>,
+        /// Start index into Cfg's extra array
+        args_start: u32,
+        /// Number of arguments
+        args_len: u32,
     },
 
     /// Conditional branch.
+    /// Arguments for each branch are stored in Cfg's extra array.
     Branch {
         cond: CfgValue,
         then_block: BlockId,
-        then_args: Vec<CfgValue>,
+        /// Start index into Cfg's extra array for then branch args
+        then_args_start: u32,
+        /// Number of arguments for then branch
+        then_args_len: u32,
         else_block: BlockId,
-        else_args: Vec<CfgValue>,
+        /// Start index into Cfg's extra array for else branch args
+        else_args_start: u32,
+        /// Number of arguments for else branch
+        else_args_len: u32,
     },
 
     /// Multi-way branch (switch/match).
+    /// Cases are stored in Cfg's switch_cases array.
     Switch {
         /// The value to switch on
         scrutinee: CfgValue,
-        /// Cases: (value, target_block) - values are signed to support negative patterns
-        cases: Vec<(i64, BlockId)>,
+        /// Start index into Cfg's switch_cases array
+        cases_start: u32,
+        /// Number of cases
+        cases_len: u32,
         /// Default block (for wildcard pattern)
         default: BlockId,
     },
@@ -397,12 +414,15 @@ pub struct Cfg {
     return_type: Type,
     /// All instructions (values) - blocks reference these by CfgValue
     values: Vec<CfgInst>,
-    /// Extra storage for variable-length CfgValue data (struct fields, array elements, intrinsic args).
-    /// Instructions store (start, len) indices into this array.
+    /// Extra storage for variable-length CfgValue data (struct fields, array elements, intrinsic args,
+    /// and terminator block arguments). Instructions and terminators store (start, len) indices into this array.
     extra: Vec<CfgValue>,
     /// Extra storage for call arguments (CfgCallArg).
     /// Call instructions store (start, len) indices into this array.
     call_args: Vec<CfgCallArg>,
+    /// Extra storage for switch cases (value, target block pairs).
+    /// Switch terminators store (start, len) indices into this array.
+    switch_cases: Vec<(i64, BlockId)>,
     /// Number of local variable slots
     num_locals: u32,
     /// Number of parameter slots
@@ -429,6 +449,7 @@ impl Cfg {
             values: Vec::new(),
             extra: Vec::new(),
             call_args: Vec::new(),
+            switch_cases: Vec::new(),
             num_locals,
             num_params,
             fn_name,
@@ -551,6 +572,76 @@ impl Cfg {
         &self.call_args[start as usize..(start + len) as usize]
     }
 
+    /// Add switch cases to the switch_cases array and return (start, len).
+    ///
+    /// Used for Switch terminator cases.
+    pub fn push_switch_cases(
+        &mut self,
+        cases: impl IntoIterator<Item = (i64, BlockId)>,
+    ) -> (u32, u32) {
+        let start = self.switch_cases.len() as u32;
+        self.switch_cases.extend(cases);
+        let len = self.switch_cases.len() as u32 - start;
+        (start, len)
+    }
+
+    /// Get a slice from the switch_cases array.
+    #[inline]
+    pub fn get_switch_cases(&self, start: u32, len: u32) -> &[(i64, BlockId)] {
+        &self.switch_cases[start as usize..(start + len) as usize]
+    }
+
+    /// Get the block arguments from a Goto terminator.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the terminator is not a Goto.
+    #[inline]
+    pub fn get_goto_args(&self, term: &Terminator) -> &[CfgValue] {
+        match term {
+            Terminator::Goto {
+                args_start,
+                args_len,
+                ..
+            } => self.get_extra(*args_start, *args_len),
+            _ => panic!("get_goto_args called on non-Goto terminator"),
+        }
+    }
+
+    /// Get the then branch arguments from a Branch terminator.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the terminator is not a Branch.
+    #[inline]
+    pub fn get_branch_then_args(&self, term: &Terminator) -> &[CfgValue] {
+        match term {
+            Terminator::Branch {
+                then_args_start,
+                then_args_len,
+                ..
+            } => self.get_extra(*then_args_start, *then_args_len),
+            _ => panic!("get_branch_then_args called on non-Branch terminator"),
+        }
+    }
+
+    /// Get the else branch arguments from a Branch terminator.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the terminator is not a Branch.
+    #[inline]
+    pub fn get_branch_else_args(&self, term: &Terminator) -> &[CfgValue] {
+        match term {
+            Terminator::Branch {
+                else_args_start,
+                else_args_len,
+                ..
+            } => self.get_extra(*else_args_start, *else_args_len),
+            _ => panic!("get_branch_else_args called on non-Branch terminator"),
+        }
+    }
+
     /// Add an instruction to a block.
     pub fn add_inst_to_block(&mut self, block: BlockId, inst: CfgInst) -> CfgValue {
         let value = self.add_inst(inst);
@@ -614,8 +705,13 @@ impl Cfg {
                     edges.push((block.id, *then_block));
                     edges.push((block.id, *else_block));
                 }
-                Terminator::Switch { cases, default, .. } => {
-                    for (_, target) in cases {
+                Terminator::Switch {
+                    cases_start,
+                    cases_len,
+                    default,
+                    ..
+                } => {
+                    for (_, target) in self.get_switch_cases(*cases_start, *cases_len) {
                         edges.push((block.id, *target));
                     }
                     edges.push((block.id, *default));
@@ -676,8 +772,13 @@ impl fmt::Display for Cfg {
             // Print terminator
             write!(f, "    ")?;
             match &block.terminator {
-                Terminator::Goto { target, args } => {
+                Terminator::Goto {
+                    target,
+                    args_start,
+                    args_len,
+                } => {
                     write!(f, "goto {}", target)?;
+                    let args = self.get_extra(*args_start, *args_len);
                     if !args.is_empty() {
                         write!(f, "(")?;
                         for (i, arg) in args.iter().enumerate() {
@@ -692,11 +793,14 @@ impl fmt::Display for Cfg {
                 Terminator::Branch {
                     cond,
                     then_block,
-                    then_args,
+                    then_args_start,
+                    then_args_len,
                     else_block,
-                    else_args,
+                    else_args_start,
+                    else_args_len,
                 } => {
                     write!(f, "branch {}, {}", cond, then_block)?;
+                    let then_args = self.get_extra(*then_args_start, *then_args_len);
                     if !then_args.is_empty() {
                         write!(f, "(")?;
                         for (i, arg) in then_args.iter().enumerate() {
@@ -708,6 +812,7 @@ impl fmt::Display for Cfg {
                         write!(f, ")")?;
                     }
                     write!(f, ", {}", else_block)?;
+                    let else_args = self.get_extra(*else_args_start, *else_args_len);
                     if !else_args.is_empty() {
                         write!(f, "(")?;
                         for (i, arg) in else_args.iter().enumerate() {
@@ -721,10 +826,12 @@ impl fmt::Display for Cfg {
                 }
                 Terminator::Switch {
                     scrutinee,
-                    cases,
+                    cases_start,
+                    cases_len,
                     default,
                 } => {
                     write!(f, "switch {} [", scrutinee)?;
+                    let cases = self.get_switch_cases(*cases_start, *cases_len);
                     for (i, (val, target)) in cases.iter().enumerate() {
                         if i > 0 {
                             write!(f, ", ")?;
@@ -973,6 +1080,15 @@ mod tests {
             "CfgInstData grew beyond 32 bytes: {}",
             cfg_inst_data_size
         );
+    }
+
+    #[test]
+    fn test_terminator_size() {
+        // Terminator should be a reasonable size (no heap allocations inside)
+        // 32 bytes: 8 (CfgValue cond) + 4+4+4+4 (BlockId, start, len x2) + 4+4+4 (else) = 36, rounded to 40
+        // Actually: Branch is the largest with cond(4) + then_block(4) + then_start(4) + then_len(4) + else_block(4) + else_start(4) + else_len(4) = 28 bytes + discriminant
+        let size = std::mem::size_of::<Terminator>();
+        assert!(size <= 40, "Terminator is {} bytes, expected <= 40", size);
     }
 
     #[test]

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -107,7 +107,7 @@ fn compute_live_values(cfg: &Cfg) -> BitSet {
 
     // Pass 2: Mark all values used by terminators as live
     for block in cfg.blocks() {
-        visit_terminator_uses(&block.terminator, |value| {
+        visit_terminator_uses(cfg, &block.terminator, |value| {
             if live.insert(value.as_u32()) {
                 worklist.push(value);
             }
@@ -170,25 +170,31 @@ fn has_side_effects(cfg: &Cfg, value: CfgValue) -> bool {
 /// Calls the provided function for each value used by the terminator.
 /// This avoids allocating a Vec for each call.
 #[inline]
-fn visit_terminator_uses(term: &Terminator, mut f: impl FnMut(CfgValue)) {
+fn visit_terminator_uses(cfg: &Cfg, term: &Terminator, mut f: impl FnMut(CfgValue)) {
     match term {
-        Terminator::Goto { args, .. } => {
-            for arg in args {
-                f(*arg);
+        Terminator::Goto {
+            args_start,
+            args_len,
+            ..
+        } => {
+            for &arg in cfg.get_extra(*args_start, *args_len) {
+                f(arg);
             }
         }
         Terminator::Branch {
             cond,
-            then_args,
-            else_args,
+            then_args_start,
+            then_args_len,
+            else_args_start,
+            else_args_len,
             ..
         } => {
             f(*cond);
-            for arg in then_args {
-                f(*arg);
+            for &arg in cfg.get_extra(*then_args_start, *then_args_len) {
+                f(arg);
             }
-            for arg in else_args {
-                f(*arg);
+            for &arg in cfg.get_extra(*else_args_start, *else_args_len) {
+                f(arg);
             }
         }
         Terminator::Switch { scrutinee, .. } => f(*scrutinee),
@@ -377,8 +383,13 @@ fn compute_reachable_blocks(cfg: &Cfg) -> BitSet {
                 worklist.push(*then_block);
                 worklist.push(*else_block);
             }
-            Terminator::Switch { cases, default, .. } => {
-                for (_, target) in cases {
+            Terminator::Switch {
+                cases_start,
+                cases_len,
+                default,
+                ..
+            } => {
+                for (_, target) in cfg.get_switch_cases(*cases_start, *cases_len) {
                     worklist.push(*target);
                 }
                 worklist.push(*default);

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -549,7 +549,7 @@ impl<'a> CfgLower<'a> {
             let term_rationale = self.get_terminator_rationale(&block.terminator);
 
             block_info.terminator = Some(TerminatorLoweringDecision {
-                terminator_desc: format_terminator(&block.terminator),
+                terminator_desc: format_terminator(self.cfg, &block.terminator),
                 mir_insts: term_mir_insts,
                 rationale: term_rationale,
             });
@@ -631,8 +631,8 @@ impl<'a> CfgLower<'a> {
                     None
                 }
             }
-            Terminator::Switch { cases, .. } => {
-                Some(format!("Linear scan through {} cases", cases.len()))
+            Terminator::Switch { cases_len, .. } => {
+                Some(format!("Linear scan through {} cases", cases_len))
             }
             _ => None,
         }
@@ -3372,8 +3372,13 @@ impl<'a> CfgLower<'a> {
     /// Lower a block terminator.
     fn lower_terminator(&mut self, block: &BasicBlock) {
         match &block.terminator {
-            Terminator::Goto { target, args } => {
+            Terminator::Goto {
+                target,
+                args_start,
+                args_len,
+            } => {
                 // Copy args to target's block params
+                let args = self.cfg.get_extra(*args_start, *args_len);
                 for (i, &arg) in args.iter().enumerate() {
                     let arg_type = self.cfg.get_inst(arg).ty;
                     if matches!(arg_type, Type::Struct(_)) {
@@ -3402,9 +3407,11 @@ impl<'a> CfgLower<'a> {
             Terminator::Branch {
                 cond,
                 then_block,
-                then_args,
+                then_args_start,
+                then_args_len,
                 else_block,
-                else_args,
+                else_args_start,
+                else_args_len,
             } => {
                 let cond_vreg = self.get_vreg(*cond);
 
@@ -3418,6 +3425,7 @@ impl<'a> CfgLower<'a> {
                 });
 
                 // Copy then_args to then_block's params
+                let then_args = self.cfg.get_extra(*then_args_start, *then_args_len);
                 for (i, &arg) in then_args.iter().enumerate() {
                     let arg_type = self.cfg.get_inst(arg).ty;
                     if matches!(arg_type, Type::Struct(_)) {
@@ -3443,6 +3451,7 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(Aarch64Inst::Label {
                     id: else_setup_label,
                 });
+                let else_args = self.cfg.get_extra(*else_args_start, *else_args_len);
                 for (i, &arg) in else_args.iter().enumerate() {
                     let arg_type = self.cfg.get_inst(arg).ty;
                     if matches!(arg_type, Type::Struct(_)) {
@@ -3470,12 +3479,14 @@ impl<'a> CfgLower<'a> {
 
             Terminator::Switch {
                 scrutinee,
-                cases,
+                cases_start,
+                cases_len,
                 default,
             } => {
                 let scrutinee_vreg = self.get_vreg(*scrutinee);
 
                 // Generate comparison and jump for each case
+                let cases = self.cfg.get_switch_cases(*cases_start, *cases_len);
                 for (value, target) in cases {
                     // Compare scrutinee with case value (supports signed values for negative patterns)
                     let imm_vreg = self.mir.alloc_vreg();

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -220,11 +220,16 @@ pub fn format_cfg_inst_data(data: &rue_cfg::CfgInstData) -> String {
 }
 
 /// Format a CFG terminator as a human-readable string.
-pub fn format_terminator(terminator: &rue_cfg::Terminator) -> String {
+pub fn format_terminator(cfg: &rue_cfg::Cfg, terminator: &rue_cfg::Terminator) -> String {
     use rue_cfg::Terminator;
 
     match terminator {
-        Terminator::Goto { target, args } => {
+        Terminator::Goto {
+            target,
+            args_start,
+            args_len,
+        } => {
+            let args = cfg.get_extra(*args_start, *args_len);
             if args.is_empty() {
                 format!("goto {}", target)
             } else {
@@ -239,10 +244,13 @@ pub fn format_terminator(terminator: &rue_cfg::Terminator) -> String {
         Terminator::Branch {
             cond,
             then_block,
-            then_args,
+            then_args_start,
+            then_args_len,
             else_block,
-            else_args,
+            else_args_start,
+            else_args_len,
         } => {
+            let then_args = cfg.get_extra(*then_args_start, *then_args_len);
             let then_str = if then_args.is_empty() {
                 format!("{}", then_block)
             } else {
@@ -253,6 +261,7 @@ pub fn format_terminator(terminator: &rue_cfg::Terminator) -> String {
                     .join(", ");
                 format!("{}({})", then_block, args_str)
             };
+            let else_args = cfg.get_extra(*else_args_start, *else_args_len);
             let else_str = if else_args.is_empty() {
                 format!("{}", else_block)
             } else {
@@ -267,9 +276,11 @@ pub fn format_terminator(terminator: &rue_cfg::Terminator) -> String {
         }
         Terminator::Switch {
             scrutinee,
-            cases,
+            cases_start,
+            cases_len,
             default,
         } => {
+            let cases = cfg.get_switch_cases(*cases_start, *cases_len);
             let cases_str = cases
                 .iter()
                 .map(|(val, target)| format!("{} => {}", val, target))

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -572,7 +572,7 @@ impl<'a> CfgLower<'a> {
             let term_rationale = self.get_terminator_rationale(&block.terminator);
 
             block_info.terminator = Some(TerminatorLoweringDecision {
-                terminator_desc: format_terminator(&block.terminator),
+                terminator_desc: format_terminator(self.cfg, &block.terminator),
                 mir_insts: term_mir_insts,
                 rationale: term_rationale,
             });
@@ -670,8 +670,8 @@ impl<'a> CfgLower<'a> {
                     None
                 }
             }
-            Terminator::Switch { cases, .. } => {
-                Some(format!("Linear scan through {} cases", cases.len()))
+            Terminator::Switch { cases_len, .. } => {
+                Some(format!("Linear scan through {} cases", cases_len))
             }
             _ => None,
         }
@@ -3227,8 +3227,13 @@ impl<'a> CfgLower<'a> {
     /// Lower a block terminator.
     fn lower_terminator(&mut self, block: &BasicBlock) {
         match &block.terminator {
-            Terminator::Goto { target, args } => {
+            Terminator::Goto {
+                target,
+                args_start,
+                args_len,
+            } => {
                 // Copy args to target's block params
+                let args = self.cfg.get_extra(*args_start, *args_len);
                 for (i, &arg) in args.iter().enumerate() {
                     let arg_type = self.cfg.get_inst(arg).ty;
                     if matches!(arg_type, Type::Struct(_)) {
@@ -3257,9 +3262,11 @@ impl<'a> CfgLower<'a> {
             Terminator::Branch {
                 cond,
                 then_block,
-                then_args,
+                then_args_start,
+                then_args_len,
                 else_block,
-                else_args,
+                else_args_start,
+                else_args_len,
             } => {
                 let cond_vreg = self.get_vreg(*cond);
 
@@ -3278,6 +3285,7 @@ impl<'a> CfgLower<'a> {
                 });
 
                 // Copy then_args to then_block's params
+                let then_args = self.cfg.get_extra(*then_args_start, *then_args_len);
                 for (i, &arg) in then_args.iter().enumerate() {
                     let arg_type = self.cfg.get_inst(arg).ty;
                     if matches!(arg_type, Type::Struct(_)) {
@@ -3303,6 +3311,7 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(X86Inst::Label {
                     id: else_setup_label,
                 });
+                let else_args = self.cfg.get_extra(*else_args_start, *else_args_len);
                 for (i, &arg) in else_args.iter().enumerate() {
                     let arg_type = self.cfg.get_inst(arg).ty;
                     if matches!(arg_type, Type::Struct(_)) {
@@ -3330,12 +3339,14 @@ impl<'a> CfgLower<'a> {
 
             Terminator::Switch {
                 scrutinee,
-                cases,
+                cases_start,
+                cases_len,
                 default,
             } => {
                 let scrutinee_vreg = self.get_vreg(*scrutinee);
 
                 // Generate comparison and jump for each case
+                let cases = self.cfg.get_switch_cases(*cases_start, *cases_len);
                 for (value, target) in cases {
                     // Load case value into a register (supports signed values for negative patterns)
                     let case_vreg = self.mir.alloc_vreg();


### PR DESCRIPTION
Replace inline Vec<CfgValue> fields in Terminator enum with (start, len) indices into the CFG's extra array. This eliminates heap allocations for block arguments and makes Terminator Copy.

Changes:
- Terminator::Goto now uses args_start/args_len instead of args Vec
- Terminator::Branch uses then_args_start/len and else_args_start/len
- Terminator::Switch stores cases in new switch_cases array
- Added accessor methods: get_goto_args, get_branch_then_args, etc.
- Updated all call sites in build.rs, dce.rs, and both codegen backends

This follows the same pooling pattern already used for calls and struct-init.

Closes: rue-p957

🤖 Generated with [Claude Code](https://claude.com/claude-code)