### PR TITLE
Fix ICE when accessing field of array element (Fixes rue-oqm6)

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -156,6 +156,31 @@ impl<'a> CfgLower<'a> {
                     None
                 }
             }
+            CfgInstData::IndexGet {
+                base: array_base,
+                array_type_id,
+                index,
+            } => {
+                // Array of structs case: the field's base is an IndexGet
+                // Try to trace the array base to find the original Load/Param
+                if let Some((index_base, mut levels)) = self.trace_index_chain(*array_base) {
+                    let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                    levels.push(IndexLevel {
+                        index: *index,
+                        elem_slot_count,
+                        array_type_id: *array_type_id,
+                    });
+                    Some((
+                        FieldChainBase::IndexGet {
+                            index_base,
+                            index_levels: levels,
+                        },
+                        0, // No field offset yet - that will be added by the calling FieldGet
+                    ))
+                } else {
+                    None
+                }
+            }
             _ => None,
         }
     }
@@ -1993,6 +2018,151 @@ impl<'a> CfgLower<'a> {
                                     offset,
                                 });
                             }
+                        }
+                        FieldChainBase::IndexGet {
+                            index_base,
+                            index_levels,
+                        } => {
+                            // Array of structs case: arr[i].field
+                            // Calculate the array element offset, then add the field offset
+
+                            // Emit bounds check for the innermost index
+                            if let Some(innermost) = index_levels.last() {
+                                let innermost_index_vreg = self.get_vreg(innermost.index);
+                                let array_length = self.array_length(innermost.array_type_id);
+                                self.emit_bounds_check(innermost_index_vreg, array_length);
+                            }
+
+                            // Calculate total array offset by summing index * stride for each level
+                            let mut total_array_offset_vreg: Option<VReg> = None;
+
+                            for level in &index_levels {
+                                let level_index_vreg = self.get_vreg(level.index);
+                                let level_stride = level.elem_slot_count;
+
+                                // Scale this level's index by its stride
+                                let scaled = self.mir.alloc_vreg();
+                                if level_stride == 1 {
+                                    // Simple case: just shift by 3 (multiply by 8)
+                                    self.mir.push(Aarch64Inst::LslImm {
+                                        dst: Operand::Virtual(scaled),
+                                        src: Operand::Virtual(level_index_vreg),
+                                        imm: 3,
+                                    });
+                                } else {
+                                    // Multiply by stride * 8
+                                    let stride_vreg = self.mir.alloc_vreg();
+                                    self.mir.push(Aarch64Inst::MovImm {
+                                        dst: Operand::Virtual(stride_vreg),
+                                        imm: (level_stride * 8) as i64,
+                                    });
+                                    self.mir.push(Aarch64Inst::MulRR {
+                                        dst: Operand::Virtual(scaled),
+                                        src1: Operand::Virtual(level_index_vreg),
+                                        src2: Operand::Virtual(stride_vreg),
+                                    });
+                                }
+
+                                // Add to running total
+                                if let Some(prev_total) = total_array_offset_vreg {
+                                    let new_total = self.mir.alloc_vreg();
+                                    self.mir.push(Aarch64Inst::AddRR {
+                                        dst: Operand::Virtual(new_total),
+                                        src1: Operand::Virtual(prev_total),
+                                        src2: Operand::Virtual(scaled),
+                                    });
+                                    total_array_offset_vreg = Some(new_total);
+                                } else {
+                                    total_array_offset_vreg = Some(scaled);
+                                }
+                            }
+
+                            // Add the field offset (in bytes) to the array element offset
+                            // total_offset is the field offset within the struct element
+                            if total_offset > 0 {
+                                let field_offset_bytes = (total_offset * 8) as i64;
+                                if let Some(arr_offset) = total_array_offset_vreg {
+                                    let field_offset_vreg = self.mir.alloc_vreg();
+                                    self.mir.push(Aarch64Inst::MovImm {
+                                        dst: Operand::Virtual(field_offset_vreg),
+                                        imm: field_offset_bytes,
+                                    });
+                                    let new_total = self.mir.alloc_vreg();
+                                    self.mir.push(Aarch64Inst::AddRR {
+                                        dst: Operand::Virtual(new_total),
+                                        src1: Operand::Virtual(arr_offset),
+                                        src2: Operand::Virtual(field_offset_vreg),
+                                    });
+                                    total_array_offset_vreg = Some(new_total);
+                                }
+                            }
+
+                            // Compute base address
+                            let addr_vreg = self.mir.alloc_vreg();
+
+                            if let IndexChainBase::Param { index: param_index } = &index_base {
+                                if self.cfg.is_param_inout(*param_index) {
+                                    // For inout params, use the stored pointer
+                                    let ptr_vreg = self.ensure_inout_param_ptr(*param_index);
+                                    self.mir.push(Aarch64Inst::MovRR {
+                                        dst: Operand::Virtual(addr_vreg),
+                                        src: Operand::Virtual(ptr_vreg),
+                                    });
+
+                                    // Subtract total offset (array offset + field offset)
+                                    if let Some(total) = total_array_offset_vreg {
+                                        self.mir.push(Aarch64Inst::SubRR {
+                                            dst: Operand::Virtual(addr_vreg),
+                                            src1: Operand::Virtual(addr_vreg),
+                                            src2: Operand::Virtual(total),
+                                        });
+                                    }
+
+                                    // Load from computed address
+                                    self.mir.push(Aarch64Inst::LdrIndexed {
+                                        dst: Operand::Virtual(vreg),
+                                        base: addr_vreg,
+                                    });
+                                    return;
+                                }
+                            }
+
+                            // Normal case: compute from FP offset
+                            let base_offset = match &index_base {
+                                IndexChainBase::Load { slot } => self.local_offset(*slot),
+                                IndexChainBase::Param { index: param_index } => {
+                                    let base_slot = self.num_locals + *param_index as u32;
+                                    self.local_offset(base_slot)
+                                }
+                                IndexChainBase::FieldGet {
+                                    struct_base_slot,
+                                    field_slot_offset,
+                                } => {
+                                    let array_base_slot = struct_base_slot + field_slot_offset;
+                                    self.local_offset(array_base_slot)
+                                }
+                            };
+
+                            self.mir.push(Aarch64Inst::SubImm {
+                                dst: Operand::Virtual(addr_vreg),
+                                src: Operand::Physical(Reg::Fp),
+                                imm: -base_offset,
+                            });
+
+                            // Subtract total offset (array offset + field offset)
+                            if let Some(total) = total_array_offset_vreg {
+                                self.mir.push(Aarch64Inst::SubRR {
+                                    dst: Operand::Virtual(addr_vreg),
+                                    src1: Operand::Virtual(addr_vreg),
+                                    src2: Operand::Virtual(total),
+                                });
+                            }
+
+                            // Load from computed address
+                            self.mir.push(Aarch64Inst::LdrIndexed {
+                                dst: Operand::Virtual(vreg),
+                                base: addr_vreg,
+                            });
                         }
                     }
                 } else {

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -301,11 +301,18 @@ pub fn format_terminator(cfg: &rue_cfg::Cfg, terminator: &rue_cfg::Terminator) -
 }
 
 /// Result of tracing back through FieldGet chains to find the original source.
+#[derive(Clone)]
 pub enum FieldChainBase {
     /// Chain originates from a Load instruction with the given slot.
     Load { slot: u32 },
     /// Chain originates from a Param instruction with the given index.
     Param { index: u32 },
+    /// Chain originates from an IndexGet (struct element within an array).
+    /// Contains the index chain base and levels needed to compute the element address.
+    IndexGet {
+        index_base: IndexChainBase,
+        index_levels: Vec<IndexLevel>,
+    },
 }
 
 /// Result of tracing back through IndexGet chains to find the original source.

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -167,6 +167,31 @@ impl<'a> CfgLower<'a> {
                     None
                 }
             }
+            CfgInstData::IndexGet {
+                base: array_base,
+                array_type_id,
+                index,
+            } => {
+                // Array of structs case: the field's base is an IndexGet
+                // Try to trace the array base to find the original Load/Param
+                if let Some((index_base, mut levels)) = self.trace_index_chain(*array_base) {
+                    let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                    levels.push(IndexLevel {
+                        index: *index,
+                        elem_slot_count,
+                        array_type_id: *array_type_id,
+                    });
+                    Some((
+                        FieldChainBase::IndexGet {
+                            index_base,
+                            index_levels: levels,
+                        },
+                        0, // No field offset yet - that will be added by the calling FieldGet
+                    ))
+                } else {
+                    None
+                }
+            }
             _ => None,
         }
     }
@@ -2130,6 +2155,155 @@ impl<'a> CfgLower<'a> {
                                     offset,
                                 });
                             }
+                        }
+                        FieldChainBase::IndexGet {
+                            index_base,
+                            index_levels,
+                        } => {
+                            // Array of structs case: arr[i].field
+                            // Calculate the array element offset, then add the field offset
+
+                            // Emit bounds check for the innermost index
+                            if let Some(innermost) = index_levels.last() {
+                                let innermost_index_vreg = self.get_vreg(innermost.index);
+                                let array_length = self.array_length(innermost.array_type_id);
+                                self.emit_bounds_check(innermost_index_vreg, array_length);
+                            }
+
+                            // Calculate total array offset by summing index * stride for each level
+                            let mut total_array_offset_vreg: Option<VReg> = None;
+
+                            for level in &index_levels {
+                                let level_index_vreg = self.get_vreg(level.index);
+                                let level_stride = level.elem_slot_count;
+
+                                // Scale this level's index by its stride
+                                let scaled = self.mir.alloc_vreg();
+                                self.mir.push(X86Inst::MovRR {
+                                    dst: Operand::Virtual(scaled),
+                                    src: Operand::Virtual(level_index_vreg),
+                                });
+
+                                if level_stride == 1 {
+                                    // Simple case: just shift by 3 (multiply by 8)
+                                    let shift_count = self.mir.alloc_vreg();
+                                    self.mir.push(X86Inst::MovRI32 {
+                                        dst: Operand::Virtual(shift_count),
+                                        imm: 3,
+                                    });
+                                    self.mir.push(X86Inst::Shl {
+                                        dst: Operand::Virtual(scaled),
+                                        count: Operand::Virtual(shift_count),
+                                    });
+                                } else {
+                                    // Multiply by stride * 8
+                                    let stride_vreg = self.mir.alloc_vreg();
+                                    self.mir.push(X86Inst::MovRI64 {
+                                        dst: Operand::Virtual(stride_vreg),
+                                        imm: (level_stride * 8) as i64,
+                                    });
+                                    self.mir.push(X86Inst::ImulRR64 {
+                                        dst: Operand::Virtual(scaled),
+                                        src: Operand::Virtual(stride_vreg),
+                                    });
+                                }
+
+                                // Add to running total
+                                if let Some(prev_total) = total_array_offset_vreg {
+                                    self.mir.push(X86Inst::AddRR64 {
+                                        dst: Operand::Virtual(prev_total),
+                                        src: Operand::Virtual(scaled),
+                                    });
+                                } else {
+                                    total_array_offset_vreg = Some(scaled);
+                                }
+                            }
+
+                            // Add the field offset (in bytes) to the array element offset
+                            // total_offset is the field offset within the struct element
+                            if total_offset > 0 {
+                                let field_offset_bytes = (total_offset * 8) as i64;
+                                if let Some(arr_offset) = total_array_offset_vreg {
+                                    let field_offset_vreg = self.mir.alloc_vreg();
+                                    self.mir.push(X86Inst::MovRI64 {
+                                        dst: Operand::Virtual(field_offset_vreg),
+                                        imm: field_offset_bytes,
+                                    });
+                                    self.mir.push(X86Inst::AddRR64 {
+                                        dst: Operand::Virtual(arr_offset),
+                                        src: Operand::Virtual(field_offset_vreg),
+                                    });
+                                }
+                            }
+
+                            // Compute base address
+                            let addr_vreg = self.mir.alloc_vreg();
+
+                            if let IndexChainBase::Param { index: param_index } = &index_base {
+                                if self.cfg.is_param_inout(*param_index) {
+                                    // For inout params, use the stored pointer
+                                    let ptr_vreg = self.ensure_inout_param_ptr(*param_index);
+                                    self.mir.push(X86Inst::MovRR {
+                                        dst: Operand::Virtual(addr_vreg),
+                                        src: Operand::Virtual(ptr_vreg),
+                                    });
+
+                                    // Subtract total offset (array offset + field offset)
+                                    if let Some(total) = total_array_offset_vreg {
+                                        self.mir.push(X86Inst::SubRR64 {
+                                            dst: Operand::Virtual(addr_vreg),
+                                            src: Operand::Virtual(total),
+                                        });
+                                    }
+
+                                    // Load from computed address
+                                    self.mir.push(X86Inst::MovRMIndexed {
+                                        dst: Operand::Virtual(vreg),
+                                        base: addr_vreg,
+                                        offset: 0,
+                                    });
+                                    return;
+                                }
+                            }
+
+                            // Normal case: compute from RBP offset
+                            let base_offset = match &index_base {
+                                IndexChainBase::Load { slot } => self.local_offset(*slot),
+                                IndexChainBase::Param { index: param_index } => {
+                                    let base_slot = self.num_locals + *param_index as u32;
+                                    self.local_offset(base_slot)
+                                }
+                                IndexChainBase::FieldGet {
+                                    struct_base_slot,
+                                    field_slot_offset,
+                                } => {
+                                    let array_base_slot = struct_base_slot + field_slot_offset;
+                                    self.local_offset(array_base_slot)
+                                }
+                            };
+
+                            self.mir.push(X86Inst::Lea {
+                                dst: Operand::Virtual(addr_vreg),
+                                base: Reg::Rbp,
+                                index: None,
+                                scale: 1,
+                                disp: base_offset,
+                            });
+
+                            // Subtract total offset (array offset + field offset)
+                            if let Some(total) = total_array_offset_vreg {
+                                self.mir.push(X86Inst::SubRR64 {
+                                    dst: Operand::Virtual(addr_vreg),
+                                    src: Operand::Virtual(total),
+                                });
+                            }
+
+                            // Load from computed address
+                            self.mir.push(X86Inst::MovRMIndexed {
+                                dst: Operand::Virtual(vreg),
+                                base: addr_vreg,
+                                offset: 0,
+                            });
                         }
                     }
                 } else {

--- a/crates/rue-spec/cases/arrays/fixed.toml
+++ b/crates/rue-spec/cases/arrays/fixed.toml
@@ -661,22 +661,80 @@ fn main() -> i32 {
 """
 exit_code = 32
 
-# NOTE: Arrays of structs with indexing into struct fields (arr[i].field) currently
-# causes an ICE in codegen. This test is commented out pending that fix.
-# The underlying array projection semantics are correct; only codegen is affected.
-# [[case]]
-# name = "array_of_copy_struct_read"
-# spec = ["7.1:26"]
-# description = "Array of @copy struct allows multiple element reads"
-# source = """
-# @copy
-# struct Point { x: i32, y: i32 }
-#
-# fn main() -> i32 {
-#     let arr: [Point; 2] = [Point { x: 10, y: 20 }, Point { x: 5, y: 7 }];
-#     let p1 = arr[0];
-#     let p2 = arr[0];
-#     p1.x + p2.x + arr[1].x
-# }
-# """
-# exit_code = 25
+[[case]]
+name = "array_of_copy_struct_read"
+spec = ["7.1:26"]
+description = "Array of @copy struct allows multiple element reads"
+source = """
+@copy
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let arr: [Point; 2] = [Point { x: 10, y: 20 }, Point { x: 5, y: 7 }];
+    let p1 = arr[0];
+    let p2 = arr[0];
+    p1.x + p2.x + arr[1].x
+}
+"""
+exit_code = 25
+
+# =============================================================================
+# Structs in Arrays (array of structs, then field access)
+# =============================================================================
+
+[[case]]
+name = "array_of_structs_field_access"
+spec = ["7.1:6", "6.2:8"]
+source = """
+@copy
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let arr: [Point; 2] = [Point { x: 10, y: 20 }, Point { x: 5, y: 7 }];
+    arr[0].x
+}
+"""
+exit_code = 10
+
+[[case]]
+name = "array_of_structs_field_access_second_element"
+spec = ["7.1:6", "6.2:8"]
+source = """
+@copy
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let arr: [Point; 2] = [Point { x: 10, y: 20 }, Point { x: 5, y: 7 }];
+    arr[1].y
+}
+"""
+exit_code = 7
+
+[[case]]
+name = "array_of_structs_sum_fields"
+spec = ["7.1:6", "6.2:8"]
+source = """
+@copy
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let arr: [Point; 2] = [Point { x: 10, y: 20 }, Point { x: 5, y: 7 }];
+    arr[0].x + arr[0].y + arr[1].x + arr[1].y
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "array_of_structs_variable_index"
+spec = ["7.1:6", "7.1:10", "6.2:8"]
+source = """
+@copy
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let arr: [Point; 2] = [Point { x: 10, y: 20 }, Point { x: 5, y: 7 }];
+    let i = 1;
+    arr[i].x
+}
+"""
+exit_code = 5


### PR DESCRIPTION
When accessing a field of an array element (e.g., arr[0].x where arr is an array of structs), the codegen panicked with 'struct base should have slot vregs in cache'. This happened because trace_field_chain did not handle IndexGet as a valid base for FieldGet.

The fix:
- Add FieldChainBase::IndexGet variant to capture index chain info
- Extend trace_field_chain in both x86_64 and aarch64 backends to recognize IndexGet as a valid base for field access
- Emit proper address computation: array element offset + field offset

The inverse pattern (struct.array_field[i]) already worked correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)