### PR TITLE
Add spec rules for reserved and duplicate type names

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -1755,6 +1755,16 @@ impl<'a> Sema<'a> {
                         ));
                     }
 
+                    // Check for duplicate type definitions (struct or enum with same name)
+                    if self.enums.contains_key(name) || self.structs.contains_key(name) {
+                        return Err(CompileError::new(
+                            ErrorKind::DuplicateTypeDefinition {
+                                type_name: enum_name,
+                            },
+                            inst.span,
+                        ));
+                    }
+
                     let variants = self.rir.get_symbols(*variants_start, *variants_len);
 
                     // Check for duplicate variant names
@@ -1799,6 +1809,16 @@ impl<'a> Sema<'a> {
                     if is_reserved_type_name(&struct_name) {
                         return Err(CompileError::new(
                             ErrorKind::ReservedTypeName {
+                                type_name: struct_name,
+                            },
+                            inst.span,
+                        ));
+                    }
+
+                    // Check for duplicate type definitions (struct or enum with same name)
+                    if self.structs.contains_key(name) || self.enums.contains_key(name) {
+                        return Err(CompileError::new(
+                            ErrorKind::DuplicateTypeDefinition {
                                 type_name: struct_name,
                             },
                             inst.span,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -495,6 +495,9 @@ pub enum ErrorKind {
     /// User-defined type collides with a built-in type name
     #[error("cannot define type `{type_name}`: name is reserved for built-in type")]
     ReservedTypeName { type_name: String },
+    /// Duplicate type definition
+    #[error("duplicate type definition: `{type_name}` is already defined")]
+    DuplicateTypeDefinition { type_name: String },
     /// Linear value was not consumed before going out of scope
     #[error("linear value '{0}' must be consumed but was dropped")]
     LinearValueNotConsumed(String),

--- a/crates/rue-spec/cases/items/general.toml
+++ b/crates/rue-spec/cases/items/general.toml
@@ -1,0 +1,89 @@
+[section]
+id = "items.general"
+spec_chapter = "6.0"
+name = "Items General"
+description = "General rules for items, including type name uniqueness."
+
+# =============================================================================
+# Reserved Type Names
+# =============================================================================
+
+[[case]]
+name = "struct_reserved_string"
+spec = ["6.0:3"]
+description = "User-defined struct cannot use reserved name 'String'"
+source = """
+struct String { data: i32 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "cannot define type `String`: name is reserved for built-in type"
+
+[[case]]
+name = "enum_reserved_string"
+spec = ["6.0:3"]
+description = "User-defined enum cannot use reserved name 'String'"
+source = """
+enum String { Empty, Full }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "cannot define type `String`: name is reserved for built-in type"
+
+# =============================================================================
+# Type Name Uniqueness - Duplicate Definitions
+# =============================================================================
+
+[[case]]
+name = "duplicate_struct_definitions"
+spec = ["6.0:2"]
+description = "Two structs with the same name are not allowed"
+source = """
+struct Point { x: i32 }
+struct Point { y: i32 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "duplicate type"
+
+[[case]]
+name = "duplicate_enum_definitions"
+spec = ["6.0:2"]
+description = "Two enums with the same name are not allowed"
+source = """
+enum Color { Red, Green }
+enum Color { Blue, Yellow }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "duplicate type"
+
+[[case]]
+name = "struct_and_enum_same_name"
+spec = ["6.0:2"]
+description = "A struct and enum cannot have the same name"
+source = """
+struct Point { x: i32 }
+enum Point { Up, Down }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "duplicate type"
+
+# =============================================================================
+# Valid Type Names
+# =============================================================================
+
+[[case]]
+name = "custom_type_names_allowed"
+spec = ["6.0:2", "6.0:3"]
+description = "User-defined types with non-reserved names are allowed"
+source = """
+struct MyString { len: i32 }
+enum MyColor { Red, Blue }
+fn main() -> i32 {
+    let s = MyString { len: 42 };
+    s.len
+}
+"""
+exit_code = 42

--- a/docs/spec/src/06-items/_index.md
+++ b/docs/spec/src/06-items/_index.md
@@ -13,3 +13,20 @@ This chapter describes items in Rue.
 {{ rule(id="6.0:1") }}
 
 Items are top-level definitions in a program. Unlike statements, items are visible throughout the module.
+
+## Type Name Uniqueness
+
+{{ rule(id="6.0:2", cat="legality-rule") }}
+
+User-defined type names (structs and enums) **MUST** be unique within a program. Defining multiple types with the same name produces a compile-time error.
+
+{{ rule(id="6.0:3", cat="legality-rule") }}
+
+User-defined types **MUST NOT** use names reserved for built-in types. Currently, the only reserved type name is `String`.
+
+{{ rule(id="6.0:4", cat="example") }}
+
+```rue
+// Error: cannot define type with reserved name
+struct String { data: i32 }  // compile error
+```


### PR DESCRIPTION
Adds specification rules 6.0:2 and 6.0:3 documenting that:
- Type names must be unique within a program
- User-defined types cannot use reserved names like String

Implements DuplicateTypeDefinition error in the compiler to catch duplicate struct/enum definitions (previously silently overwritten).

Fixes rue-tdh9

🤖 Generated with [Claude Code](https://claude.com/claude-code)