### PR TITLE
feat(ci): add multi-platform benchmark support with website UI

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -10,19 +10,33 @@ on:
         default: '5'
         type: string
 
-# Only run one benchmark at a time to ensure consistent results
-concurrency:
-  group: benchmarks
-  cancel-in-progress: false
-
 permissions:
   contents: write  # Needed to push to perf branch
 
 jobs:
   benchmark:
-    # Run on a consistent runner for reproducible results
-    # macOS provides the most consistent performance on GitHub Actions
-    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: x86-64-linux
+            name: Linux x86-64
+          - runner: ubuntu-24.04-arm
+            platform: aarch64-linux
+            name: Linux ARM64
+          - runner: macos-latest
+            platform: aarch64-macos
+            name: macOS ARM64
+
+    # Allow parallel runs on different platforms, but serialize per-platform
+    concurrency:
+      group: benchmarks-${{ matrix.platform }}
+      cancel-in-progress: false
+
+    runs-on: ${{ matrix.runner }}
+    name: benchmark (${{ matrix.name }})
+
     steps:
       - name: Checkout trunk
         uses: actions/checkout@v4
@@ -40,9 +54,9 @@ jobs:
           path: |
             buck-out/v2/gen
             ~/.cache/buck2
-          key: buck2-macos-release-${{ hashFiles('**/BUCK', 'toolchains/rust/defs.bzl') }}
+          key: buck2-${{ matrix.platform }}-release-${{ hashFiles('**/BUCK', 'toolchains/rust/defs.bzl') }}
           restore-keys: |
-            buck2-macos-release-
+            buck2-${{ matrix.platform }}-release-
 
       - name: Get commit info
         id: commit
@@ -54,7 +68,7 @@ jobs:
         id: bench
         run: |
           iterations="${{ github.event.inputs.iterations || '5' }}"
-          echo "Running benchmarks with $iterations iterations..."
+          echo "Running benchmarks with $iterations iterations on ${{ matrix.platform }}..."
           ./bench.sh --iterations "$iterations" --output /tmp/results.json --no-history
 
           # Extract summary for PR comment
@@ -78,7 +92,6 @@ jobs:
             git init
             git checkout -b perf
             mkdir -p benchmarks
-            echo '{"version": 1, "runs": []}' > benchmarks/history.json
             echo "# Performance History" > README.md
             echo "" >> README.md
             echo "This branch stores benchmark history for the Rue compiler." >> README.md
@@ -87,7 +100,13 @@ jobs:
 
       - name: Append to history
         run: |
-          python3 scripts/append-benchmark.py /tmp/results.json perf-branch/benchmarks/history.json
+          # Create platform-specific history file if it doesn't exist
+          history_file="perf-branch/benchmarks/history-${{ matrix.platform }}.json"
+          if [ ! -f "$history_file" ]; then
+            mkdir -p perf-branch/benchmarks
+            echo '{"version": 1, "runs": []}' > "$history_file"
+          fi
+          python3 scripts/append-benchmark.py /tmp/results.json "$history_file"
 
       - name: Commit and push to perf branch
         run: |
@@ -95,23 +114,34 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
-          git add benchmarks/history.json
+          git add benchmarks/
 
           # Only commit if there are changes
           if git diff --staged --quiet; then
             echo "No changes to commit"
           else
-            git commit -m "Benchmark results for ${{ steps.commit.outputs.sha }}"
+            git commit -m "[${{ matrix.platform }}] Benchmark results for ${{ steps.commit.outputs.sha }}"
 
             # Push to perf branch (create if doesn't exist)
-            git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:perf
+            # Retry a few times in case of concurrent pushes from other platform jobs
+            for i in 1 2 3; do
+              if git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:perf; then
+                echo "Push succeeded"
+                break
+              else
+                echo "Push failed, attempt $i/3. Pulling and retrying..."
+                git pull --rebase https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git perf || true
+                sleep $((i * 2))
+              fi
+            done
           fi
 
       - name: Summary
         run: |
-          echo "## Benchmark Results" >> $GITHUB_STEP_SUMMARY
+          echo "## Benchmark Results (${{ matrix.name }})" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Commit: \`${{ steps.commit.outputs.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Platform:** ${{ matrix.platform }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** \`${{ steps.commit.outputs.sha }}\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "### Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -45,14 +45,25 @@ jobs:
         run: |
           # Try to fetch benchmark history from the perf branch
           # This may fail if the perf branch doesn't exist yet (new repos)
+          mkdir -p website/static/benchmarks
+
           if git fetch origin perf --depth=1 2>/dev/null; then
-            mkdir -p website/static/benchmarks
-            git show origin/perf:benchmarks/history.json > website/static/benchmarks/history.json 2>/dev/null || echo '{"version": 1, "runs": []}' > website/static/benchmarks/history.json
-            echo "Fetched benchmark history from perf branch"
+            echo "Fetched perf branch, extracting benchmark history..."
+
+            # Fetch per-platform history files
+            for platform in x86-64-linux aarch64-linux aarch64-macos; do
+              if git show origin/perf:benchmarks/history-${platform}.json > website/static/benchmarks/history-${platform}.json 2>/dev/null; then
+                echo "  Fetched history-${platform}.json"
+              else
+                echo "  No history for ${platform} yet"
+                rm -f website/static/benchmarks/history-${platform}.json
+              fi
+            done
+
+            # Also fetch legacy history.json for backwards compatibility
+            git show origin/perf:benchmarks/history.json > website/static/benchmarks/history.json 2>/dev/null || true
           else
             echo "Perf branch not found, using empty benchmark history"
-            mkdir -p website/static/benchmarks
-            echo '{"version": 1, "runs": []}' > website/static/benchmarks/history.json
           fi
 
       - name: Build website

--- a/scripts/generate-charts.py
+++ b/scripts/generate-charts.py
@@ -2,17 +2,31 @@
 """
 Generate SVG charts from benchmark history for the performance dashboard.
 
-This script reads benchmark history from JSON and generates two SVG charts:
+This script reads benchmark history from JSON and generates SVG charts:
 1. timeline.svg - Time-series chart showing total compilation time over commits
 2. breakdown.svg - Stacked bar chart showing time per compiler pass
+3. memory.svg - Memory usage over time
+4. binary_size.svg - Binary size over time
 
 Usage:
-    ./generate-charts.py <history.json> <output-dir>
+    # Generate charts for a single platform
+    ./generate-charts.py <history.json> <output-dir> [--platform <name>]
 
-Example:
+    # Generate comparison charts from multiple platform histories
+    ./generate-charts.py --comparison <output-dir> <history1.json> <history2.json> ...
+
+Examples:
+    # Single platform (legacy mode)
     ./generate-charts.py website/static/benchmarks/history.json website/static/benchmarks/
+
+    # Per-platform generation
+    ./generate-charts.py history-x86-64-linux.json platforms/x86-64-linux/ --platform x86-64-linux
+
+    # Cross-platform comparison
+    ./generate-charts.py --comparison comparison/ history-*.json
 """
 
+import argparse
 import json
 import sys
 from pathlib import Path
@@ -27,6 +41,8 @@ MEMORY_WIDTH = 800
 MEMORY_HEIGHT = 250
 BINARY_WIDTH = 800
 BINARY_HEIGHT = 250
+COMPARISON_WIDTH = 900
+COMPARISON_HEIGHT = 400
 
 # Colors for passes (consistent with website theme)
 PASS_COLORS = {
@@ -41,6 +57,13 @@ PASS_COLORS = {
 
 # Order of passes in the stack
 PASS_ORDER = ["lexer", "parser", "astgen", "sema", "cfg", "codegen", "linker"]
+
+# Platform display names and colors
+PLATFORM_INFO = {
+    "x86-64-linux": {"name": "Linux x86-64", "color": "#4f6ddb"},
+    "aarch64-linux": {"name": "Linux ARM64", "color": "#10b981"},
+    "aarch64-macos": {"name": "macOS ARM64", "color": "#f59e0b"},
+}
 
 
 def load_history(path: Path) -> dict:
@@ -151,7 +174,7 @@ def generate_empty_chart(width: int, height: int, message: str) -> str:
 </svg>'''
 
 
-def generate_timeline_chart(runs: list[dict]) -> str:
+def generate_timeline_chart(runs: list[dict], platform: Optional[str] = None) -> str:
     """Generate time-series SVG chart of total compilation time."""
     if not runs:
         return generate_empty_chart(TIMELINE_WIDTH, TIMELINE_HEIGHT, "No benchmark data available yet")
@@ -184,6 +207,12 @@ def generate_timeline_chart(runs: list[dict]) -> str:
     def scale_y(v: float) -> float:
         return margin["top"] + chart_height - (v / max_time) * chart_height
 
+    # Title with optional platform
+    title = "Compilation Time Over Recent Commits"
+    if platform:
+        platform_name = PLATFORM_INFO.get(platform, {}).get("name", platform)
+        title = f"{title} ({platform_name})"
+
     # Build SVG
     svg_parts = [
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {TIMELINE_WIDTH} {TIMELINE_HEIGHT}" class="benchmark-chart">',
@@ -204,7 +233,7 @@ def generate_timeline_chart(runs: list[dict]) -> str:
     }
   </style>''',
         f'  <rect class="chart-bg" width="{TIMELINE_WIDTH}" height="{TIMELINE_HEIGHT}" rx="8"/>',
-        f'  <text class="chart-title" x="{TIMELINE_WIDTH/2}" y="25" text-anchor="middle" font-size="16">Compilation Time Over Recent Commits</text>',
+        f'  <text class="chart-title" x="{TIMELINE_WIDTH/2}" y="25" text-anchor="middle" font-size="16">{escape_xml(title)}</text>',
     ]
 
     # Y-axis grid lines and labels
@@ -426,7 +455,7 @@ def get_pass_times_for_benchmark(run: dict, benchmark_name: str) -> dict[str, fl
     return {}
 
 
-def generate_breakdown_chart(runs: list[dict], benchmark_name: Optional[str] = None) -> str:
+def generate_breakdown_chart(runs: list[dict], benchmark_name: Optional[str] = None, platform: Optional[str] = None) -> str:
     """Generate stacked bar chart showing time per compiler pass.
 
     If benchmark_name is provided, shows data for that specific benchmark.
@@ -460,6 +489,15 @@ def generate_breakdown_chart(runs: list[dict], benchmark_name: Optional[str] = N
     if total == 0:
         total = 1
 
+    # Build title
+    title_parts = ["Compilation Time by Pass"]
+    if benchmark_name:
+        title_parts.append(f" - {benchmark_name}")
+    if platform:
+        platform_name = PLATFORM_INFO.get(platform, {}).get("name", platform)
+        title_parts.append(f" ({platform_name})")
+    title = "".join(title_parts)
+
     # Build SVG
     svg_parts = [
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {BREAKDOWN_WIDTH} {BREAKDOWN_HEIGHT}" class="benchmark-chart">',
@@ -478,7 +516,7 @@ def generate_breakdown_chart(runs: list[dict], benchmark_name: Optional[str] = N
     }
   </style>''',
         f'  <rect class="chart-bg" width="{BREAKDOWN_WIDTH}" height="{BREAKDOWN_HEIGHT}" rx="8"/>',
-        f'  <text class="chart-title" x="{BREAKDOWN_WIDTH/2}" y="25" text-anchor="middle" font-size="16">Compilation Time by Pass{" - " + escape_xml(benchmark_name) if benchmark_name else ""}</text>',
+        f'  <text class="chart-title" x="{BREAKDOWN_WIDTH/2}" y="25" text-anchor="middle" font-size="16">{escape_xml(title)}</text>',
         f'  <text class="chart-text" x="{BREAKDOWN_WIDTH/2}" y="42" text-anchor="middle" font-size="11">(commit: {escape_xml(commit)})</text>',
     ]
 
@@ -527,7 +565,7 @@ def generate_breakdown_chart(runs: list[dict], benchmark_name: Optional[str] = N
     return "\n".join(svg_parts)
 
 
-def generate_memory_chart(runs: list[dict]) -> str:
+def generate_memory_chart(runs: list[dict], platform: Optional[str] = None) -> str:
     """Generate time-series SVG chart of peak memory usage."""
     if not runs:
         return generate_empty_chart(MEMORY_WIDTH, MEMORY_HEIGHT, "No benchmark data available yet")
@@ -560,6 +598,12 @@ def generate_memory_chart(runs: list[dict]) -> str:
     def scale_y(v: float) -> float:
         return margin["top"] + chart_height - (v / max_memory) * chart_height
 
+    # Title with optional platform
+    title = "Peak Memory Usage Over Recent Commits"
+    if platform:
+        platform_name = PLATFORM_INFO.get(platform, {}).get("name", platform)
+        title = f"{title} ({platform_name})"
+
     # Build SVG
     svg_parts = [
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {MEMORY_WIDTH} {MEMORY_HEIGHT}" class="benchmark-chart">',
@@ -580,7 +624,7 @@ def generate_memory_chart(runs: list[dict]) -> str:
     }
   </style>''',
         f'  <rect class="chart-bg" width="{MEMORY_WIDTH}" height="{MEMORY_HEIGHT}" rx="8"/>',
-        f'  <text class="chart-title" x="{MEMORY_WIDTH/2}" y="25" text-anchor="middle" font-size="16">Peak Memory Usage Over Recent Commits</text>',
+        f'  <text class="chart-title" x="{MEMORY_WIDTH/2}" y="25" text-anchor="middle" font-size="16">{escape_xml(title)}</text>',
     ]
 
     # Y-axis grid lines and labels
@@ -629,7 +673,7 @@ def generate_memory_chart(runs: list[dict]) -> str:
     return "\n".join(svg_parts)
 
 
-def generate_binary_size_chart(runs: list[dict]) -> str:
+def generate_binary_size_chart(runs: list[dict], platform: Optional[str] = None) -> str:
     """Generate time-series SVG chart of binary size."""
     if not runs:
         return generate_empty_chart(BINARY_WIDTH, BINARY_HEIGHT, "No benchmark data available yet")
@@ -662,6 +706,12 @@ def generate_binary_size_chart(runs: list[dict]) -> str:
     def scale_y(v: float) -> float:
         return margin["top"] + chart_height - (v / max_size) * chart_height
 
+    # Title with optional platform
+    title = "Binary Size Over Recent Commits"
+    if platform:
+        platform_name = PLATFORM_INFO.get(platform, {}).get("name", platform)
+        title = f"{title} ({platform_name})"
+
     # Build SVG
     svg_parts = [
         f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {BINARY_WIDTH} {BINARY_HEIGHT}" class="benchmark-chart">',
@@ -682,7 +732,7 @@ def generate_binary_size_chart(runs: list[dict]) -> str:
     }
   </style>''',
         f'  <rect class="chart-bg" width="{BINARY_WIDTH}" height="{BINARY_HEIGHT}" rx="8"/>',
-        f'  <text class="chart-title" x="{BINARY_WIDTH/2}" y="25" text-anchor="middle" font-size="16">Binary Size Over Recent Commits</text>',
+        f'  <text class="chart-title" x="{BINARY_WIDTH/2}" y="25" text-anchor="middle" font-size="16">{escape_xml(title)}</text>',
     ]
 
     # Y-axis grid lines and labels
@@ -731,7 +781,136 @@ def generate_binary_size_chart(runs: list[dict]) -> str:
     return "\n".join(svg_parts)
 
 
-def generate_summary_data(runs: list[dict]) -> dict:
+def generate_comparison_timeline_chart(platform_data: dict[str, list[dict]]) -> str:
+    """Generate a comparison chart showing all platforms on the same timeline."""
+    if not platform_data or all(not runs for runs in platform_data.values()):
+        return generate_empty_chart(COMPARISON_WIDTH, COMPARISON_HEIGHT, "No benchmark data available")
+
+    # Build a unified commit timeline from all platforms
+    commit_to_times: dict[str, dict[str, float]] = {}
+
+    for platform, runs in platform_data.items():
+        for run in runs[-20:]:
+            commit = short_commit(run.get("commit", ""))
+            time = get_total_time(run)
+            if commit not in commit_to_times:
+                commit_to_times[commit] = {}
+            commit_to_times[commit][platform] = time
+
+    if not commit_to_times:
+        return generate_empty_chart(COMPARISON_WIDTH, COMPARISON_HEIGHT, "No timing data available")
+
+    # Sort commits (we'll use order of appearance in first platform that has data)
+    commits = list(commit_to_times.keys())[-20:]  # Last 20 unique commits
+    platforms = list(platform_data.keys())
+
+    # Find max time across all platforms
+    all_times = [t for times in commit_to_times.values() for t in times.values() if t > 0]
+    if not all_times:
+        return generate_empty_chart(COMPARISON_WIDTH, COMPARISON_HEIGHT, "No timing data available")
+    max_time = max(all_times) * 1.1
+
+    # Chart layout
+    margin = {"top": 50, "right": 150, "bottom": 70, "left": 70}
+    chart_width = COMPARISON_WIDTH - margin["left"] - margin["right"]
+    chart_height = COMPARISON_HEIGHT - margin["top"] - margin["bottom"] - 50  # Room for legend
+
+    def scale_x(i: int) -> float:
+        if len(commits) == 1:
+            return margin["left"] + chart_width / 2
+        return margin["left"] + (i / (len(commits) - 1)) * chart_width
+
+    def scale_y(v: float) -> float:
+        return margin["top"] + chart_height - (v / max_time) * chart_height
+
+    # Build SVG
+    svg_parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 {COMPARISON_WIDTH} {COMPARISON_HEIGHT}" class="benchmark-chart">',
+        '''  <style>
+    .chart-bg { fill: var(--chart-bg, #ffffff); }
+    .chart-text { fill: var(--chart-text, #6b7280); font-family: system-ui, sans-serif; }
+    .chart-title { fill: var(--chart-title, #1a1a1a); font-family: system-ui, sans-serif; font-weight: 600; }
+    .chart-grid { stroke: var(--chart-grid, #e5e7eb); stroke-width: 1; }
+    .chart-axis { stroke: var(--chart-axis, #9ca3af); stroke-width: 1; }
+    @media (prefers-color-scheme: dark) {
+      .chart-bg { fill: #1a1a1a; }
+      .chart-text { fill: #9ca3af; }
+      .chart-title { fill: #f0f0f0; }
+      .chart-grid { stroke: #2e2e2e; }
+      .chart-axis { stroke: #4b5563; }
+    }
+  </style>''',
+        f'  <rect class="chart-bg" width="{COMPARISON_WIDTH}" height="{COMPARISON_HEIGHT}" rx="8"/>',
+        f'  <text class="chart-title" x="{COMPARISON_WIDTH/2}" y="25" text-anchor="middle" font-size="16">Compilation Time - All Platforms</text>',
+    ]
+
+    # Y-axis grid lines and labels
+    num_grid_lines = 5
+    for i in range(num_grid_lines + 1):
+        y = margin["top"] + (i / num_grid_lines) * chart_height
+        value = max_time * (1 - i / num_grid_lines)
+        svg_parts.append(
+            f'  <line class="chart-grid" x1="{margin["left"]}" y1="{y}" x2="{COMPARISON_WIDTH - margin["right"]}" y2="{y}"/>'
+        )
+        svg_parts.append(
+            f'  <text class="chart-text" x="{margin["left"] - 10}" y="{y + 4}" text-anchor="end" font-size="11">{value:.1f}ms</text>'
+        )
+
+    # Axes
+    svg_parts.append(
+        f'  <line class="chart-axis" x1="{margin["left"]}" y1="{margin["top"]}" x2="{margin["left"]}" y2="{margin["top"] + chart_height}"/>'
+    )
+    svg_parts.append(
+        f'  <line class="chart-axis" x1="{margin["left"]}" y1="{margin["top"] + chart_height}" x2="{COMPARISON_WIDTH - margin["right"]}" y2="{margin["top"] + chart_height}"/>'
+    )
+
+    # Draw lines for each platform
+    for platform in platforms:
+        info = PLATFORM_INFO.get(platform, {"name": platform, "color": "#888888"})
+        color = info["color"]
+
+        # Collect points for this platform
+        line_points = []
+        for i, commit in enumerate(commits):
+            time = commit_to_times.get(commit, {}).get(platform, 0)
+            if time > 0:
+                line_points.append((i, time))
+
+        # Draw connecting line
+        if len(line_points) > 1:
+            path_d = "M " + " L ".join(
+                f"{scale_x(i)},{scale_y(t)}" for i, t in line_points
+            )
+            svg_parts.append(f'  <path d="{path_d}" fill="none" stroke="{color}" stroke-width="2"/>')
+
+        # Draw points
+        for i, t in line_points:
+            svg_parts.append(f'  <circle cx="{scale_x(i)}" cy="{scale_y(t)}" r="4" fill="{color}"/>')
+
+    # X-axis labels
+    for i, commit in enumerate(commits):
+        x = scale_x(i)
+        label_y = margin["top"] + chart_height + 15
+        svg_parts.append(
+            f'  <text class="chart-text" x="{x}" y="{label_y}" text-anchor="end" font-size="9" transform="rotate(-45 {x} {label_y})">{escape_xml(commit)}</text>'
+        )
+
+    # Legend
+    legend_y = COMPARISON_HEIGHT - 35
+    legend_x_start = margin["left"]
+    for idx, platform in enumerate(platforms):
+        info = PLATFORM_INFO.get(platform, {"name": platform, "color": "#888888"})
+        x = legend_x_start + idx * 200
+        svg_parts.append(f'  <rect x="{x}" y="{legend_y}" width="14" height="14" fill="{info["color"]}" rx="2"/>')
+        svg_parts.append(
+            f'  <text class="chart-text" x="{x + 20}" y="{legend_y + 11}" font-size="12">{escape_xml(info["name"])}</text>'
+        )
+
+    svg_parts.append("</svg>")
+    return "\n".join(svg_parts)
+
+
+def generate_summary_data(runs: list[dict], platform: Optional[str] = None) -> dict:
     """Generate summary statistics for the performance dashboard."""
     if not runs:
         return {}
@@ -763,7 +942,7 @@ def generate_summary_data(runs: list[dict]) -> dict:
     all_times = [get_total_time(r) for r in runs if get_total_time(r) > 0]
     best_time = min(all_times) if all_times else 0
 
-    return {
+    result = {
         "latest_commit": latest_commit,
         "latest_time_ms": round(latest_time, 2),
         "latest_memory_mb": round(latest_memory, 2),
@@ -780,20 +959,23 @@ def generate_summary_data(runs: list[dict]) -> dict:
         "run_count": len(runs),
     }
 
+    if platform:
+        result["platform"] = platform
+        info = PLATFORM_INFO.get(platform, {})
+        result["platform_name"] = info.get("name", platform)
 
-def main():
-    if len(sys.argv) != 3:
-        print(f"Usage: {sys.argv[0]} <history.json> <output-dir>", file=sys.stderr)
-        sys.exit(1)
+    return result
 
-    history_path = Path(sys.argv[1])
-    output_dir = Path(sys.argv[2])
 
+def generate_platform_charts(history_path: Path, output_dir: Path, platform: Optional[str] = None):
+    """Generate all charts for a single platform."""
     # Load history
     history = load_history(history_path)
     runs = history.get("runs", [])
 
     print(f"Loaded {len(runs)} benchmark runs from {history_path}")
+    if platform:
+        print(f"Generating charts for platform: {platform}")
 
     # Ensure output directory exists
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -803,7 +985,7 @@ def main():
     print(f"Found {len(benchmark_names)} benchmarks: {', '.join(benchmark_names)}")
 
     # Generate aggregate timeline chart
-    timeline_svg = generate_timeline_chart(runs)
+    timeline_svg = generate_timeline_chart(runs, platform)
     timeline_path = output_dir / "timeline.svg"
     with open(timeline_path, "w") as f:
         f.write(timeline_svg)
@@ -818,21 +1000,21 @@ def main():
         print(f"Generated {multi_timeline_path}")
 
     # Generate aggregate breakdown chart (for backwards compatibility)
-    breakdown_svg = generate_breakdown_chart(runs)
+    breakdown_svg = generate_breakdown_chart(runs, platform=platform)
     breakdown_path = output_dir / "breakdown.svg"
     with open(breakdown_path, "w") as f:
         f.write(breakdown_svg)
     print(f"Generated {breakdown_path}")
 
     # Generate memory usage chart
-    memory_svg = generate_memory_chart(runs)
+    memory_svg = generate_memory_chart(runs, platform)
     memory_path = output_dir / "memory.svg"
     with open(memory_path, "w") as f:
         f.write(memory_svg)
     print(f"Generated {memory_path}")
 
     # Generate binary size chart
-    binary_svg = generate_binary_size_chart(runs)
+    binary_svg = generate_binary_size_chart(runs, platform)
     binary_path = output_dir / "binary_size.svg"
     with open(binary_path, "w") as f:
         f.write(binary_svg)
@@ -840,7 +1022,7 @@ def main():
 
     # Generate per-benchmark breakdown charts
     for bench_name in benchmark_names:
-        bench_svg = generate_breakdown_chart(runs, bench_name)
+        bench_svg = generate_breakdown_chart(runs, bench_name, platform)
         # Use sanitized filename
         safe_name = bench_name.replace(" ", "_").replace("/", "_")
         bench_path = output_dir / f"breakdown_{safe_name}.svg"
@@ -849,7 +1031,7 @@ def main():
         print(f"Generated {bench_path}")
 
     # Generate summary statistics
-    summary = generate_summary_data(runs)
+    summary = generate_summary_data(runs, platform)
 
     # Include latest run's metrics for display
     latest_benchmarks = []
@@ -882,10 +1064,117 @@ def main():
         "summary": summary,
         "latest_benchmarks": latest_benchmarks,
     }
+    if platform:
+        metadata["platform"] = platform
+        info = PLATFORM_INFO.get(platform, {})
+        metadata["platform_name"] = info.get("name", platform)
+
     metadata_path = output_dir / "metadata.json"
     with open(metadata_path, "w") as f:
         json.dump(metadata, f, indent=2)
     print(f"Generated {metadata_path}")
+
+
+def generate_comparison_charts(history_files: list[Path], output_dir: Path):
+    """Generate comparison charts from multiple platform history files."""
+    print(f"Generating comparison charts from {len(history_files)} history files")
+
+    # Load all histories
+    platform_data: dict[str, list[dict]] = {}
+    platform_info_list = []
+
+    for path in history_files:
+        # Extract platform from filename (e.g., history-x86-64-linux.json -> x86-64-linux)
+        name = path.stem
+        if name.startswith("history-"):
+            platform = name[8:]  # Remove "history-" prefix
+        elif name == "history":
+            platform = "unknown"
+        else:
+            platform = name
+
+        history = load_history(path)
+        runs = history.get("runs", [])
+
+        if runs:
+            platform_data[platform] = runs
+            info = PLATFORM_INFO.get(platform, {"name": platform, "color": "#888888"})
+            platform_info_list.append({
+                "id": platform,
+                "name": info["name"],
+                "color": info["color"],
+                "run_count": len(runs),
+                "latest_commit": short_commit(runs[-1].get("commit", "")) if runs else None,
+                "has_data": True
+            })
+            print(f"  Loaded {len(runs)} runs for {platform}")
+        else:
+            print(f"  No data for {platform}")
+
+    if not platform_data:
+        print("No data available for comparison charts")
+        return
+
+    # Ensure output directory exists
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Generate comparison timeline
+    comparison_svg = generate_comparison_timeline_chart(platform_data)
+    comparison_path = output_dir / "timeline.svg"
+    with open(comparison_path, "w") as f:
+        f.write(comparison_svg)
+    print(f"Generated {comparison_path}")
+
+    # Generate comparison metadata
+    metadata = {
+        "platforms": platform_info_list,
+        "default_platform": platform_info_list[0]["id"] if platform_info_list else None
+    }
+    metadata_path = output_dir / "metadata.json"
+    with open(metadata_path, "w") as f:
+        json.dump(metadata, f, indent=2)
+    print(f"Generated {metadata_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate SVG charts from benchmark history for the performance dashboard."
+    )
+    parser.add_argument(
+        "--comparison",
+        action="store_true",
+        help="Generate comparison charts from multiple platform histories"
+    )
+    parser.add_argument(
+        "--platform",
+        type=str,
+        help="Platform identifier for chart titles (e.g., x86-64-linux)"
+    )
+    parser.add_argument(
+        "paths",
+        nargs="+",
+        help="History file(s) and output directory. For single platform: <history.json> <output-dir>. "
+             "For comparison: <output-dir> <history1.json> <history2.json> ..."
+    )
+
+    args = parser.parse_args()
+
+    if args.comparison:
+        # Comparison mode: first arg is output dir, rest are history files
+        if len(args.paths) < 2:
+            print("Error: Comparison mode requires output directory and at least one history file", file=sys.stderr)
+            sys.exit(1)
+        output_dir = Path(args.paths[0])
+        history_files = [Path(p) for p in args.paths[1:]]
+        generate_comparison_charts(history_files, output_dir)
+    else:
+        # Single platform mode
+        if len(args.paths) != 2:
+            print("Error: Single platform mode requires exactly <history.json> <output-dir>", file=sys.stderr)
+            sys.exit(1)
+        history_path = Path(args.paths[0])
+        output_dir = Path(args.paths[1])
+        generate_platform_charts(history_path, output_dir, args.platform)
 
 
 if __name__ == "__main__":

--- a/website/build.sh
+++ b/website/build.sh
@@ -7,6 +7,9 @@ set -euo pipefail
 cd "$(dirname "$0")/.."
 ROOT="$PWD"
 
+# Platforms to generate charts for
+PLATFORMS=("x86-64-linux" "aarch64-linux" "aarch64-macos")
+
 # Copy spec content into website/content/spec
 # We use a copy rather than a symlink for Windows compatibility (symlinks
 # require elevated privileges on Windows). The spec source lives in
@@ -24,11 +27,102 @@ else
     find website/content/spec -name "*.md" -exec sed -i 's|@/\([0-9]\)|@/spec/\1|g' {} \;
 fi
 
-# Generate benchmark charts
+# Generate benchmark charts for each platform
 echo "Generating benchmark charts..."
-python3 "$ROOT/scripts/generate-charts.py" \
-    "$ROOT/website/static/benchmarks/history.json" \
-    "$ROOT/website/static/benchmarks/"
+BENCHMARKS_DIR="$ROOT/website/static/benchmarks"
+mkdir -p "$BENCHMARKS_DIR/platforms"
+mkdir -p "$BENCHMARKS_DIR/comparison"
+
+# Track which platforms have data for the root metadata.json
+PLATFORMS_WITH_DATA=()
+
+for platform in "${PLATFORMS[@]}"; do
+    history_file="$BENCHMARKS_DIR/history-${platform}.json"
+    platform_dir="$BENCHMARKS_DIR/platforms/${platform}"
+
+    if [[ -f "$history_file" ]]; then
+        echo "  Generating charts for ${platform}..."
+        mkdir -p "$platform_dir"
+        python3 "$ROOT/scripts/generate-charts.py" \
+            "$history_file" \
+            "$platform_dir" \
+            --platform "$platform"
+        PLATFORMS_WITH_DATA+=("$platform")
+    else
+        echo "  No history file for ${platform} (skipping)"
+    fi
+done
+
+# Generate comparison charts if we have multiple platforms
+if [[ ${#PLATFORMS_WITH_DATA[@]} -gt 0 ]]; then
+    echo "  Generating comparison charts..."
+    history_files=()
+    for platform in "${PLATFORMS_WITH_DATA[@]}"; do
+        history_files+=("$BENCHMARKS_DIR/history-${platform}.json")
+    done
+    python3 "$ROOT/scripts/generate-charts.py" \
+        --comparison \
+        "$BENCHMARKS_DIR/comparison" \
+        "${history_files[@]}"
+fi
+
+# Generate root metadata.json listing all platforms
+echo "  Generating root metadata.json..."
+python3 -c "
+import json
+import os
+from pathlib import Path
+
+benchmarks_dir = Path('$BENCHMARKS_DIR')
+platforms = []
+
+for platform in ${PLATFORMS_WITH_DATA[@]+"${PLATFORMS_WITH_DATA[@]}"}:
+    platform = platform.strip()
+    if not platform:
+        continue
+    metadata_file = benchmarks_dir / 'platforms' / platform / 'metadata.json'
+    if metadata_file.exists():
+        with open(metadata_file) as f:
+            data = json.load(f)
+        platforms.append({
+            'id': platform,
+            'name': data.get('platform_name', platform),
+            'has_data': True,
+            'run_count': data.get('run_count', 0),
+            'latest_commit': data.get('latest_commit')
+        })
+
+# Add platforms without data
+all_platforms = ['x86-64-linux', 'aarch64-linux', 'aarch64-macos']
+platform_ids = [p['id'] for p in platforms]
+for platform in all_platforms:
+    if platform not in platform_ids:
+        platforms.append({
+            'id': platform,
+            'name': {'x86-64-linux': 'Linux x86-64', 'aarch64-linux': 'Linux ARM64', 'aarch64-macos': 'macOS ARM64'}.get(platform, platform),
+            'has_data': False
+        })
+
+# Sort by platform id for consistency
+platforms.sort(key=lambda p: p['id'])
+
+metadata = {
+    'platforms': platforms,
+    'default_platform': platforms[0]['id'] if platforms else None
+}
+
+with open(benchmarks_dir / 'metadata.json', 'w') as f:
+    json.dump(metadata, f, indent=2)
+" 2>/dev/null || echo "  (No platform data available)"
+
+# Backwards compatibility: Generate charts from legacy history.json if it exists
+# and no per-platform history exists yet
+if [[ -f "$BENCHMARKS_DIR/history.json" && ${#PLATFORMS_WITH_DATA[@]} -eq 0 ]]; then
+    echo "  Generating legacy charts from history.json..."
+    python3 "$ROOT/scripts/generate-charts.py" \
+        "$BENCHMARKS_DIR/history.json" \
+        "$BENCHMARKS_DIR/"
+fi
 
 # Build Tailwind CSS
 echo "Building Tailwind CSS..."

--- a/website/templates/performance.html
+++ b/website/templates/performance.html
@@ -10,6 +10,20 @@
             {{ page.content | safe }}
         </div>
 
+        <!-- Platform Selector -->
+        <section class="mb-8">
+            <div class="flex flex-wrap items-center gap-4">
+                <div class="flex items-center gap-2">
+                    <label for="platform-select" class="text-sm font-medium">Platform:</label>
+                    <select id="platform-select" class="bg-surface border border-themed rounded px-3 py-2 text-sm">
+                        <option value="comparison">All Platforms</option>
+                        <!-- Options populated by JavaScript from metadata.json -->
+                    </select>
+                </div>
+                <span id="platform-info" class="text-sm text-muted"></span>
+            </div>
+        </section>
+
         <!-- Summary Stats -->
         <section id="summary-stats" class="mb-12">
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
@@ -52,26 +66,24 @@
             <p class="text-muted mb-4">
                 Total compilation time across the last 20 commits. Lower is better.
             </p>
-            <div class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
-                {% set timeline = load_data(path="static/benchmarks/timeline.svg", format="plain") %}
-                {{ timeline | safe }}
+            <div id="timeline-chart-container" class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
+                <p class="text-muted text-center py-8">Loading chart...</p>
             </div>
         </section>
 
-        <!-- Timeline Chart (Per-Program) -->
-        <section class="mb-12">
+        <!-- Timeline Chart (Per-Program) - Only shown for single platform -->
+        <section id="timeline-by-program-section" class="mb-12">
             <h2 class="text-xl font-semibold mb-4">Compilation Time by Program</h2>
             <p class="text-muted mb-4">
                 Each benchmark program shown as a separate line to identify which programs regress.
             </p>
-            <div class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
-                {% set timeline_by_program = load_data(path="static/benchmarks/timeline_by_program.svg", format="plain") %}
-                {{ timeline_by_program | safe }}
+            <div id="timeline-by-program-container" class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
+                <p class="text-muted text-center py-8">Loading chart...</p>
             </div>
         </section>
 
         <!-- Breakdown Chart -->
-        <section class="mb-12">
+        <section id="breakdown-section" class="mb-12">
             <div class="flex items-center justify-between mb-4">
                 <h2 class="text-xl font-semibold">Time by Compiler Pass</h2>
                 <div class="flex items-center gap-2">
@@ -86,37 +98,34 @@
                 Breakdown of where compilation time is spent in the most recent benchmark run.
             </p>
             <div id="breakdown-chart-container" class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
-                {% set breakdown = load_data(path="static/benchmarks/breakdown.svg", format="plain") %}
-                {{ breakdown | safe }}
+                <p class="text-muted text-center py-8">Loading chart...</p>
             </div>
         </section>
 
         <!-- Memory Usage Chart -->
-        <section class="mb-12">
+        <section id="memory-section" class="mb-12">
             <h2 class="text-xl font-semibold mb-4">Peak Memory Usage</h2>
             <p class="text-muted mb-4">
                 Peak memory consumption during compilation. Lower is better.
             </p>
-            <div class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
-                {% set memory = load_data(path="static/benchmarks/memory.svg", format="plain") %}
-                {{ memory | safe }}
+            <div id="memory-chart-container" class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
+                <p class="text-muted text-center py-8">Loading chart...</p>
             </div>
         </section>
 
         <!-- Binary Size Chart -->
-        <section class="mb-12">
+        <section id="binary-section" class="mb-12">
             <h2 class="text-xl font-semibold mb-4">Output Binary Size</h2>
             <p class="text-muted mb-4">
                 Size of compiled binary. Smaller binaries are generally preferable.
             </p>
-            <div class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
-                {% set binary_size = load_data(path="static/benchmarks/binary_size.svg", format="plain") %}
-                {{ binary_size | safe }}
+            <div id="binary-chart-container" class="benchmark-chart-container bg-surface border border-themed rounded-lg p-4">
+                <p class="text-muted text-center py-8">Loading chart...</p>
             </div>
         </section>
 
         <!-- Metrics Table -->
-        <section class="mb-12">
+        <section id="metrics-section" class="mb-12">
             <h2 class="text-xl font-semibold mb-4">Detailed Metrics</h2>
             <p class="text-muted mb-4">
                 Source metrics, throughput, memory usage, and binary size for the latest benchmark run.
@@ -128,128 +137,285 @@
 
         <script>
         (function() {
-            const select = document.getElementById('benchmark-select');
+            const platformSelect = document.getElementById('platform-select');
+            const platformInfo = document.getElementById('platform-info');
+            const benchmarkSelect = document.getElementById('benchmark-select');
+            const timelineContainer = document.getElementById('timeline-chart-container');
+            const timelineByProgramSection = document.getElementById('timeline-by-program-section');
+            const timelineByProgramContainer = document.getElementById('timeline-by-program-container');
+            const breakdownSection = document.getElementById('breakdown-section');
             const breakdownContainer = document.getElementById('breakdown-chart-container');
+            const memorySection = document.getElementById('memory-section');
+            const memoryContainer = document.getElementById('memory-chart-container');
+            const binarySection = document.getElementById('binary-section');
+            const binaryContainer = document.getElementById('binary-chart-container');
+            const metricsSection = document.getElementById('metrics-section');
             const metricsContainer = document.getElementById('metrics-table-container');
 
-            // Load metadata to populate dropdown, summary stats, and metrics table
+            let currentPlatform = 'comparison';
+            let platformMetadata = null;
+
+            // Fetch an SVG and insert it into a container
+            function loadSvg(container, path) {
+                fetch(path)
+                    .then(r => {
+                        if (!r.ok) throw new Error('Not found');
+                        return r.text();
+                    })
+                    .then(svg => {
+                        container.innerHTML = svg;
+                    })
+                    .catch(() => {
+                        container.innerHTML = '<p class="text-muted text-center py-8">Chart not available</p>';
+                    });
+            }
+
+            // Update summary stats from metadata
+            function updateStats(summary) {
+                if (!summary) {
+                    document.getElementById('stat-time').textContent = '--';
+                    document.getElementById('stat-time-delta').textContent = '';
+                    document.getElementById('stat-time-avg').textContent = 'Avg: --';
+                    document.getElementById('stat-time-best').textContent = 'Best: --';
+                    document.getElementById('stat-memory').textContent = '--';
+                    document.getElementById('stat-memory-delta').textContent = '';
+                    document.getElementById('stat-memory-avg').textContent = 'Avg: --';
+                    document.getElementById('stat-binary').textContent = '--';
+                    document.getElementById('stat-binary-delta').textContent = '';
+                    document.getElementById('stat-commit').textContent = 'Commit: --';
+                    return;
+                }
+
+                const s = summary;
+
+                // Time stats
+                document.getElementById('stat-time').textContent =
+                    s.latest_time_ms ? `${s.latest_time_ms.toFixed(1)}ms` : '--';
+                document.getElementById('stat-time-avg').textContent =
+                    s.avg_time_ms ? `Avg: ${s.avg_time_ms.toFixed(1)}ms` : 'Avg: --';
+                document.getElementById('stat-time-best').textContent =
+                    s.best_time_ms ? `Best: ${s.best_time_ms.toFixed(1)}ms` : 'Best: --';
+
+                // Time delta with color
+                const timeDelta = document.getElementById('stat-time-delta');
+                if (s.time_delta_str) {
+                    timeDelta.textContent = s.time_delta_str;
+                    timeDelta.className = s.time_delta_pct > 0 ? 'text-sm text-red-500' : 'text-sm text-green-500';
+                } else {
+                    timeDelta.textContent = '';
+                }
+
+                // Memory stats
+                document.getElementById('stat-memory').textContent =
+                    s.latest_memory_mb ? `${s.latest_memory_mb.toFixed(1)}MB` : '--';
+                document.getElementById('stat-memory-avg').textContent =
+                    s.avg_memory_mb ? `Avg: ${s.avg_memory_mb.toFixed(1)}MB` : 'Avg: --';
+
+                // Memory delta with color
+                const memDelta = document.getElementById('stat-memory-delta');
+                if (s.memory_delta_str) {
+                    memDelta.textContent = s.memory_delta_str;
+                    memDelta.className = s.memory_delta_pct > 0 ? 'text-sm text-red-500' : 'text-sm text-green-500';
+                } else {
+                    memDelta.textContent = '';
+                }
+
+                // Binary stats
+                document.getElementById('stat-binary').textContent =
+                    s.latest_binary_kb ? `${s.latest_binary_kb.toFixed(1)}KB` : '--';
+
+                // Binary delta with color
+                const binDelta = document.getElementById('stat-binary-delta');
+                if (s.binary_delta_str) {
+                    binDelta.textContent = s.binary_delta_str;
+                    binDelta.className = s.binary_delta_pct > 0 ? 'text-sm text-red-500' : 'text-sm text-green-500';
+                } else {
+                    binDelta.textContent = '';
+                }
+
+                // Commit info
+                document.getElementById('stat-commit').textContent =
+                    s.latest_commit ? `Commit: ${s.latest_commit}` : 'Commit: --';
+            }
+
+            // Build metrics table
+            function updateMetricsTable(benchmarks) {
+                if (!benchmarks || benchmarks.length === 0) {
+                    metricsContainer.innerHTML = '<p class="text-muted text-center py-8">No detailed metrics available</p>';
+                    return;
+                }
+
+                let html = '<table class="w-full text-sm">';
+                html += '<thead class="bg-surface border-b border-themed">';
+                html += '<tr>';
+                html += '<th class="text-left p-2">Program</th>';
+                html += '<th class="text-right p-2">Time (ms)</th>';
+                html += '<th class="text-right p-2">Lines</th>';
+                html += '<th class="text-right p-2">Tokens</th>';
+                html += '<th class="text-right p-2">Lines/sec</th>';
+                html += '<th class="text-right p-2">Tokens/sec</th>';
+                html += '<th class="text-right p-2">Memory (MB)</th>';
+                html += '<th class="text-right p-2">Binary (KB)</th>';
+                html += '</tr></thead><tbody>';
+
+                benchmarks.forEach(b => {
+                    html += '<tr class="border-b border-themed">';
+                    html += `<td class="p-2 font-medium">${b.name}</td>`;
+                    html += `<td class="p-2 text-right">${b.mean_ms?.toFixed(2) || '-'}</td>`;
+                    html += `<td class="p-2 text-right">${b.source_metrics?.lines?.toLocaleString() || '-'}</td>`;
+                    html += `<td class="p-2 text-right">${b.source_metrics?.tokens?.toLocaleString() || '-'}</td>`;
+                    html += `<td class="p-2 text-right">${b.lines_per_sec?.toLocaleString() || '-'}</td>`;
+                    html += `<td class="p-2 text-right">${b.tokens_per_sec?.toLocaleString() || '-'}</td>`;
+                    html += `<td class="p-2 text-right">${b.peak_memory_mb?.toFixed(1) || '-'}</td>`;
+                    html += `<td class="p-2 text-right">${b.binary_size_kb?.toFixed(1) || '-'}</td>`;
+                    html += '</tr>';
+                });
+
+                html += '</tbody></table>';
+                metricsContainer.innerHTML = html;
+            }
+
+            // Load data for a specific platform
+            function loadPlatformData(platform) {
+                currentPlatform = platform;
+
+                if (platform === 'comparison') {
+                    // Comparison mode: show cross-platform timeline, hide per-program charts
+                    platformInfo.textContent = 'Showing all platforms';
+                    timelineByProgramSection.style.display = 'none';
+                    breakdownSection.style.display = 'none';
+                    memorySection.style.display = 'none';
+                    binarySection.style.display = 'none';
+                    metricsSection.style.display = 'none';
+
+                    loadSvg(timelineContainer, '/benchmarks/comparison/timeline.svg');
+                    updateStats(null);
+                } else {
+                    // Single platform mode: show all charts
+                    const platformName = platformMetadata?.platforms?.find(p => p.id === platform)?.name || platform;
+                    platformInfo.textContent = `${platformName}`;
+                    timelineByProgramSection.style.display = 'block';
+                    breakdownSection.style.display = 'block';
+                    memorySection.style.display = 'block';
+                    binarySection.style.display = 'block';
+                    metricsSection.style.display = 'block';
+
+                    const basePath = `/benchmarks/platforms/${platform}`;
+
+                    loadSvg(timelineContainer, `${basePath}/timeline.svg`);
+                    loadSvg(timelineByProgramContainer, `${basePath}/timeline_by_program.svg`);
+                    loadSvg(breakdownContainer, `${basePath}/breakdown.svg`);
+                    loadSvg(memoryContainer, `${basePath}/memory.svg`);
+                    loadSvg(binaryContainer, `${basePath}/binary_size.svg`);
+
+                    // Fetch platform metadata for stats and benchmarks
+                    fetch(`${basePath}/metadata.json`)
+                        .then(r => r.json())
+                        .then(data => {
+                            updateStats(data.summary);
+                            updateMetricsTable(data.latest_benchmarks);
+
+                            // Populate benchmark dropdown
+                            benchmarkSelect.innerHTML = '<option value="">All (aggregate)</option>';
+                            if (data.benchmarks && data.benchmarks.length > 0) {
+                                data.benchmarks.forEach(name => {
+                                    const option = document.createElement('option');
+                                    const safeName = name.replace(/ /g, '_').replace(/\//g, '_');
+                                    option.value = safeName;
+                                    option.textContent = name;
+                                    benchmarkSelect.appendChild(option);
+                                });
+                            }
+                        })
+                        .catch(() => {
+                            updateStats(null);
+                            updateMetricsTable(null);
+                        });
+                }
+            }
+
+            // Initialize: load root metadata to populate platform selector
             fetch('/benchmarks/metadata.json')
                 .then(r => r.json())
                 .then(data => {
-                    // Populate benchmark dropdown
-                    if (data.benchmarks && data.benchmarks.length > 0) {
-                        data.benchmarks.forEach(name => {
-                            const option = document.createElement('option');
-                            const safeName = name.replace(/ /g, '_').replace(/\//g, '_');
-                            option.value = safeName;
-                            option.textContent = name;
-                            select.appendChild(option);
+                    platformMetadata = data;
+
+                    // Populate platform dropdown
+                    if (data.platforms && data.platforms.length > 0) {
+                        data.platforms.forEach(p => {
+                            if (p.has_data) {
+                                const option = document.createElement('option');
+                                option.value = p.id;
+                                option.textContent = `${p.name} (${p.run_count} runs)`;
+                                platformSelect.appendChild(option);
+                            }
                         });
                     }
 
-                    // Populate summary stats
-                    if (data.summary) {
-                        const s = data.summary;
-
-                        // Time stats
-                        document.getElementById('stat-time').textContent =
-                            s.latest_time_ms ? `${s.latest_time_ms.toFixed(1)}ms` : '--';
-                        document.getElementById('stat-time-avg').textContent =
-                            s.avg_time_ms ? `Avg: ${s.avg_time_ms.toFixed(1)}ms` : 'Avg: --';
-                        document.getElementById('stat-time-best').textContent =
-                            s.best_time_ms ? `Best: ${s.best_time_ms.toFixed(1)}ms` : 'Best: --';
-
-                        // Time delta with color
-                        const timeDelta = document.getElementById('stat-time-delta');
-                        if (s.time_delta_str) {
-                            timeDelta.textContent = s.time_delta_str;
-                            timeDelta.className = s.time_delta_pct > 0 ? 'text-sm text-red-500' : 'text-sm text-green-500';
-                        }
-
-                        // Memory stats
-                        document.getElementById('stat-memory').textContent =
-                            s.latest_memory_mb ? `${s.latest_memory_mb.toFixed(1)}MB` : '--';
-                        document.getElementById('stat-memory-avg').textContent =
-                            s.avg_memory_mb ? `Avg: ${s.avg_memory_mb.toFixed(1)}MB` : 'Avg: --';
-
-                        // Memory delta with color
-                        const memDelta = document.getElementById('stat-memory-delta');
-                        if (s.memory_delta_str) {
-                            memDelta.textContent = s.memory_delta_str;
-                            memDelta.className = s.memory_delta_pct > 0 ? 'text-sm text-red-500' : 'text-sm text-green-500';
-                        }
-
-                        // Binary stats
-                        document.getElementById('stat-binary').textContent =
-                            s.latest_binary_kb ? `${s.latest_binary_kb.toFixed(1)}KB` : '--';
-
-                        // Binary delta with color
-                        const binDelta = document.getElementById('stat-binary-delta');
-                        if (s.binary_delta_str) {
-                            binDelta.textContent = s.binary_delta_str;
-                            binDelta.className = s.binary_delta_pct > 0 ? 'text-sm text-red-500' : 'text-sm text-green-500';
-                        }
-
-                        // Commit info
-                        document.getElementById('stat-commit').textContent =
-                            s.latest_commit ? `Commit: ${s.latest_commit}` : 'Commit: --';
-                    }
-
-                    // Build metrics table
-                    if (data.latest_benchmarks && data.latest_benchmarks.length > 0) {
-                        let html = '<table class="w-full text-sm">';
-                        html += '<thead class="bg-surface border-b border-themed">';
-                        html += '<tr>';
-                        html += '<th class="text-left p-2">Program</th>';
-                        html += '<th class="text-right p-2">Time (ms)</th>';
-                        html += '<th class="text-right p-2">Lines</th>';
-                        html += '<th class="text-right p-2">Tokens</th>';
-                        html += '<th class="text-right p-2">Lines/sec</th>';
-                        html += '<th class="text-right p-2">Tokens/sec</th>';
-                        html += '<th class="text-right p-2">Memory (MB)</th>';
-                        html += '<th class="text-right p-2">Binary (KB)</th>';
-                        html += '</tr></thead><tbody>';
-
-                        data.latest_benchmarks.forEach(b => {
-                            html += '<tr class="border-b border-themed">';
-                            html += `<td class="p-2 font-medium">${b.name}</td>`;
-                            html += `<td class="p-2 text-right">${b.mean_ms?.toFixed(2) || '-'}</td>`;
-                            html += `<td class="p-2 text-right">${b.source_metrics?.lines?.toLocaleString() || '-'}</td>`;
-                            html += `<td class="p-2 text-right">${b.source_metrics?.tokens?.toLocaleString() || '-'}</td>`;
-                            html += `<td class="p-2 text-right">${b.lines_per_sec?.toLocaleString() || '-'}</td>`;
-                            html += `<td class="p-2 text-right">${b.tokens_per_sec?.toLocaleString() || '-'}</td>`;
-                            html += `<td class="p-2 text-right">${b.peak_memory_mb?.toFixed(1) || '-'}</td>`;
-                            html += `<td class="p-2 text-right">${b.binary_size_kb?.toFixed(1) || '-'}</td>`;
-                            html += '</tr>';
-                        });
-
-                        html += '</tbody></table>';
-                        metricsContainer.innerHTML = html;
+                    // Load comparison view by default, or first platform with data
+                    const defaultPlatform = data.default_platform || 'comparison';
+                    if (data.platforms?.some(p => p.has_data)) {
+                        loadPlatformData('comparison');
                     } else {
-                        metricsContainer.innerHTML = '<p class="text-muted text-center py-8">No detailed metrics available</p>';
+                        platformInfo.textContent = 'No benchmark data available yet';
+                        timelineContainer.innerHTML = '<p class="text-muted text-center py-8">No benchmark data available</p>';
                     }
                 })
                 .catch(() => {
-                    // No metadata available, hide selector and show error
-                    select.parentElement.style.display = 'none';
-                    metricsContainer.innerHTML = '<p class="text-muted text-center py-8">Metrics data not available</p>';
+                    // Fallback to legacy mode (single history.json)
+                    platformSelect.parentElement.parentElement.style.display = 'none';
+                    timelineByProgramSection.style.display = 'block';
+                    breakdownSection.style.display = 'block';
+                    memorySection.style.display = 'block';
+                    binarySection.style.display = 'block';
+                    metricsSection.style.display = 'block';
+
+                    loadSvg(timelineContainer, '/benchmarks/timeline.svg');
+                    loadSvg(timelineByProgramContainer, '/benchmarks/timeline_by_program.svg');
+                    loadSvg(breakdownContainer, '/benchmarks/breakdown.svg');
+                    loadSvg(memoryContainer, '/benchmarks/memory.svg');
+                    loadSvg(binaryContainer, '/benchmarks/binary_size.svg');
+
+                    // Try to load legacy metadata
+                    fetch('/benchmarks/metadata.json')
+                        .then(r => r.json())
+                        .then(data => {
+                            updateStats(data.summary);
+                            updateMetricsTable(data.latest_benchmarks);
+
+                            // Populate benchmark dropdown
+                            if (data.benchmarks && data.benchmarks.length > 0) {
+                                data.benchmarks.forEach(name => {
+                                    const option = document.createElement('option');
+                                    const safeName = name.replace(/ /g, '_').replace(/\//g, '_');
+                                    option.value = safeName;
+                                    option.textContent = name;
+                                    benchmarkSelect.appendChild(option);
+                                });
+                            }
+                        })
+                        .catch(() => {
+                            updateStats(null);
+                            updateMetricsTable(null);
+                        });
                 });
 
-            // Handle selection changes for breakdown chart
-            select.addEventListener('change', function() {
-                const value = this.value;
-                const svgPath = value
-                    ? `/benchmarks/breakdown_${value}.svg`
-                    : '/benchmarks/breakdown.svg';
+            // Handle platform selection changes
+            platformSelect.addEventListener('change', function() {
+                loadPlatformData(this.value);
+            });
 
-                fetch(svgPath)
-                    .then(r => r.text())
-                    .then(svg => {
-                        breakdownContainer.innerHTML = svg;
-                    })
-                    .catch(() => {
-                        breakdownContainer.innerHTML = '<p class="text-muted text-center py-8">Failed to load chart</p>';
-                    });
+            // Handle benchmark selection changes for breakdown chart
+            benchmarkSelect.addEventListener('change', function() {
+                if (currentPlatform === 'comparison') return;
+
+                const value = this.value;
+                const basePath = `/benchmarks/platforms/${currentPlatform}`;
+                const svgPath = value
+                    ? `${basePath}/breakdown_${value}.svg`
+                    : `${basePath}/breakdown.svg`;
+
+                loadSvg(breakdownContainer, svgPath);
             });
         })();
         </script>
@@ -258,10 +424,20 @@
         <section class="prose">
             <h2>Methodology</h2>
             <p>
-                These benchmarks are run automatically on every commit to the main branch.
+                These benchmarks are run automatically on every commit to the main branch
+                across all supported platforms.
                 Each benchmark is executed multiple times to reduce noise, and both mean
                 and standard deviation are recorded.
             </p>
+            <h3>Platforms</h3>
+            <p>
+                Benchmarks run on the following platforms using GitHub Actions:
+            </p>
+            <ul>
+                <li><strong>Linux x86-64</strong> - Ubuntu runner (ubuntu-latest)</li>
+                <li><strong>Linux ARM64</strong> - Ubuntu ARM runner (ubuntu-24.04-arm)</li>
+                <li><strong>macOS ARM64</strong> - Apple Silicon runner (macos-latest)</li>
+            </ul>
             <h3>Benchmark Suite</h3>
             <p>
                 The benchmark corpus includes hand-crafted stress tests that exercise
@@ -277,7 +453,9 @@
             <h3>Environment</h3>
             <p>
                 Benchmarks run on GitHub Actions runners. While there is some variability
-                between runs, running multiple iterations helps smooth out noise.
+                between runs, running multiple iterations helps smooth out noise. Cross-platform
+                comparisons should focus on trends rather than absolute numbers, as different
+                architectures have different performance characteristics.
             </p>
         </section>
     </div>


### PR DESCRIPTION
Expand performance testing to run benchmarks on all three supported platforms (x86-64-linux, aarch64-linux, aarch64-macos) and add a platform selector to the website performance dashboard.

Changes:
- benchmarks.yml: Convert to matrix strategy for parallel multi-platform runs
- generate-charts.py: Add --platform and --comparison modes for per-platform and cross-platform chart generation
- build.sh: Generate charts for each available platform plus comparison charts
- deploy-website.yml: Fetch per-platform history files from perf branch
- performance.html: Add platform selector UI with dynamic chart loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)