### PR TITLE
Optimize Substitution with Vec and path compression (Fixes rue-piww)

### DIFF
--- a/crates/rue-air/src/inference/constraint.rs
+++ b/crates/rue-air/src/inference/constraint.rs
@@ -6,7 +6,7 @@
 
 use super::types::{InferType, TypeVarId};
 use rue_span::Span;
-use std::collections::HashMap;
+use std::cell::RefCell;
 
 /// A type constraint generated during analysis.
 ///
@@ -78,17 +78,40 @@ impl Constraint {
 /// The substitution is built incrementally during unification.
 /// It maps type variable IDs to `InferType`s, which may themselves
 /// be type variables (requiring transitive lookup via `apply`).
+///
+/// # Performance
+///
+/// Uses a `Vec<Option<InferType>>` instead of `HashMap<TypeVarId, InferType>` for O(1)
+/// lookups without hashing overhead. This works because `TypeVarId` is a sequential
+/// `u32` starting from 0.
+///
+/// Additionally implements path compression: when following a chain of variable
+/// references, intermediate links are updated to point directly to the final result,
+/// amortizing the cost of chain traversal.
 #[derive(Debug, Default)]
 pub struct Substitution {
-    /// Mapping from type variable ID to its resolved type.
-    mapping: HashMap<TypeVarId, InferType>,
+    /// Mapping from type variable index to its resolved type.
+    /// Uses `RefCell` to allow path compression during immutable lookups.
+    mapping: RefCell<Vec<Option<InferType>>>,
 }
 
 impl Substitution {
     /// Create an empty substitution.
     pub fn new() -> Self {
         Substitution {
-            mapping: HashMap::new(),
+            mapping: RefCell::new(Vec::new()),
+        }
+    }
+
+    /// Create a substitution with pre-allocated capacity.
+    ///
+    /// Use when you know approximately how many type variables will be created.
+    pub fn with_capacity(capacity: usize) -> Self {
+        let mut mapping = Vec::with_capacity(capacity);
+        // Pre-fill with None to allow direct indexing
+        mapping.resize(capacity, None);
+        Substitution {
+            mapping: RefCell::new(mapping),
         }
     }
 
@@ -96,12 +119,24 @@ impl Substitution {
     ///
     /// If the variable is already mapped, the old mapping is replaced.
     pub fn insert(&mut self, var: TypeVarId, ty: InferType) {
-        self.mapping.insert(var, ty);
+        let idx = var.index() as usize;
+        let mut mapping = self.mapping.borrow_mut();
+        // Grow the vector if necessary
+        if idx >= mapping.len() {
+            mapping.resize(idx + 1, None);
+        }
+        mapping[idx] = Some(ty);
     }
 
     /// Look up a type variable's immediate mapping (without following chains).
-    pub fn get(&self, var: TypeVarId) -> Option<&InferType> {
-        self.mapping.get(&var)
+    pub fn get(&self, var: TypeVarId) -> Option<InferType> {
+        let idx = var.index() as usize;
+        let mapping = self.mapping.borrow();
+        if idx < mapping.len() {
+            mapping[idx].clone()
+        } else {
+            None
+        }
     }
 
     /// Apply the substitution to a type, following type variable chains
@@ -112,16 +147,16 @@ impl Substitution {
     /// - `IntLiteral` → `IntLiteral` (unchanged, unless we add IntLiteral
     ///   to variable mappings)
     /// - `Array { element, length }` → recursively apply to element type
+    ///
+    /// # Path Compression
+    ///
+    /// When following a chain like `v0 -> v1 -> v2 -> i32`, this method
+    /// updates all intermediate links to point directly to the final result.
+    /// This amortizes the cost of repeated lookups.
     pub fn apply(&self, ty: &InferType) -> InferType {
         match ty {
             InferType::Concrete(_) => ty.clone(),
-            InferType::Var(id) => {
-                // Follow the chain of substitutions
-                match self.mapping.get(id) {
-                    Some(resolved) => self.apply(resolved),
-                    None => ty.clone(), // Unbound variable
-                }
-            }
+            InferType::Var(id) => self.apply_var(*id),
             InferType::IntLiteral => ty.clone(),
             InferType::Array { element, length } => {
                 let resolved_element = self.apply(element);
@@ -131,6 +166,38 @@ impl Substitution {
                 }
             }
         }
+    }
+
+    /// Apply substitution to a type variable with path compression.
+    fn apply_var(&self, id: TypeVarId) -> InferType {
+        let idx = id.index() as usize;
+
+        // First, get the resolved type without holding the borrow
+        let resolved = {
+            let mapping = self.mapping.borrow();
+            if idx >= mapping.len() {
+                return InferType::Var(id);
+            }
+            match &mapping[idx] {
+                None => return InferType::Var(id),
+                Some(ty) => ty.clone(),
+            }
+        };
+
+        // Recursively resolve
+        let final_type = self.apply(&resolved);
+
+        // Path compression: if we followed a chain to reach a different result,
+        // update this mapping to point directly to the final result.
+        // This avoids traversing the same chain repeatedly.
+        if final_type != resolved {
+            let mut mapping = self.mapping.borrow_mut();
+            if idx < mapping.len() {
+                mapping[idx] = Some(final_type.clone());
+            }
+        }
+
+        final_type
     }
 
     /// Check if a type variable occurs in a type (for occurs check).
@@ -145,8 +212,8 @@ impl Substitution {
                     return true;
                 }
                 // Check if the variable chain leads to our target
-                match self.mapping.get(id) {
-                    Some(resolved) => self.occurs_in(var, resolved),
+                match self.get(*id) {
+                    Some(resolved) => self.occurs_in(var, &resolved),
                     None => false,
                 }
             }
@@ -156,13 +223,16 @@ impl Substitution {
     }
 
     /// Get the number of mappings in the substitution.
+    ///
+    /// Note: This counts all slots that have values, requiring a full scan.
+    /// For performance-critical code, consider tracking this separately.
     pub fn len(&self) -> usize {
-        self.mapping.len()
+        self.mapping.borrow().iter().filter(|c| c.is_some()).count()
     }
 
     /// Check if the substitution is empty.
     pub fn is_empty(&self) -> bool {
-        self.mapping.is_empty()
+        self.mapping.borrow().iter().all(|c| c.is_none())
     }
 }
 
@@ -251,5 +321,61 @@ mod tests {
 
         assert_eq!(c1.span(), span);
         assert_eq!(c2.span(), span);
+    }
+
+    #[test]
+    fn test_substitution_with_capacity() {
+        let subst = Substitution::with_capacity(10);
+        // Pre-allocated substitution should be empty (no mappings yet)
+        assert!(subst.is_empty());
+        assert_eq!(subst.len(), 0);
+    }
+
+    #[test]
+    fn test_substitution_path_compression() {
+        // Create a long chain: v0 -> v1 -> v2 -> v3 -> v4 -> i32
+        let mut subst = Substitution::new();
+        let v0 = TypeVarId::new(0);
+        let v1 = TypeVarId::new(1);
+        let v2 = TypeVarId::new(2);
+        let v3 = TypeVarId::new(3);
+        let v4 = TypeVarId::new(4);
+
+        subst.insert(v0, InferType::Var(v1));
+        subst.insert(v1, InferType::Var(v2));
+        subst.insert(v2, InferType::Var(v3));
+        subst.insert(v3, InferType::Var(v4));
+        subst.insert(v4, InferType::Concrete(Type::I32));
+
+        // First lookup should resolve the chain
+        assert_eq!(
+            subst.apply(&InferType::Var(v0)),
+            InferType::Concrete(Type::I32)
+        );
+
+        // After path compression, all intermediate variables should point directly to i32
+        // Verify by checking that v0 now directly points to i32
+        let resolved = subst.get(v0);
+        assert_eq!(resolved, Some(InferType::Concrete(Type::I32)));
+
+        // v1, v2, v3 should also be compressed
+        assert_eq!(subst.get(v1), Some(InferType::Concrete(Type::I32)));
+        assert_eq!(subst.get(v2), Some(InferType::Concrete(Type::I32)));
+        assert_eq!(subst.get(v3), Some(InferType::Concrete(Type::I32)));
+    }
+
+    #[test]
+    fn test_substitution_len_and_is_empty() {
+        let mut subst = Substitution::new();
+        assert!(subst.is_empty());
+        assert_eq!(subst.len(), 0);
+
+        subst.insert(TypeVarId::new(0), InferType::Concrete(Type::I32));
+        assert!(!subst.is_empty());
+        assert_eq!(subst.len(), 1);
+
+        // Insert at a higher index - only counts actual mappings
+        subst.insert(TypeVarId::new(5), InferType::Concrete(Type::Bool));
+        assert_eq!(subst.len(), 2);
     }
 }

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -226,11 +226,24 @@ impl<'a> ConstraintGenerator<'a> {
         &self.expr_types
     }
 
-    /// Consume the constraint generator and return (constraints, int_literal_vars, expr_types).
+    /// Consume the constraint generator and return (constraints, int_literal_vars, expr_types, type_var_count).
     ///
     /// This is useful when you need ownership of the expression types map.
-    pub fn into_parts(self) -> (Vec<Constraint>, Vec<TypeVarId>, HashMap<InstRef, InferType>) {
-        (self.constraints, self.int_literal_vars, self.expr_types)
+    /// The `type_var_count` can be used to pre-size the unifier's substitution for better performance.
+    pub fn into_parts(
+        self,
+    ) -> (
+        Vec<Constraint>,
+        Vec<TypeVarId>,
+        HashMap<InstRef, InferType>,
+        u32,
+    ) {
+        (
+            self.constraints,
+            self.int_literal_vars,
+            self.expr_types,
+            self.type_vars.count(),
+        )
     }
 
     /// Generate constraints for an expression.

--- a/crates/rue-air/src/inference/unify.rs
+++ b/crates/rue-air/src/inference/unify.rs
@@ -118,6 +118,16 @@ impl Unifier {
         }
     }
 
+    /// Create a new unifier with a pre-sized substitution.
+    ///
+    /// Use this when you know how many type variables will be created
+    /// (e.g., from `TypeVarAllocator::count()`).
+    pub fn with_capacity(type_var_count: u32) -> Self {
+        Unifier {
+            substitution: Substitution::with_capacity(type_var_count as usize),
+        }
+    }
+
     /// Unify two types.
     ///
     /// This is the core of Algorithm W. It updates the substitution

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -2423,10 +2423,11 @@ impl<'a> Sema<'a> {
         ));
 
         // Consume the constraint generator to release borrows
-        let (constraints, int_literal_vars, expr_types) = cgen.into_parts();
+        let (constraints, int_literal_vars, expr_types, type_var_count) = cgen.into_parts();
 
         // Phase 2: Solve constraints via unification
-        let mut unifier = Unifier::new();
+        // Pre-size the substitution for better performance on large functions
+        let mut unifier = Unifier::with_capacity(type_var_count);
         let errors = unifier.solve_constraints(&constraints);
 
         // Convert unification errors to compile errors


### PR DESCRIPTION
Replace HashMap<TypeVarId, InferType> with Vec<Option<InferType>> for O(1)  lookups without hashing overhead. TypeVarId is a sequential u32 starting  from 0, making it ideal for direct array indexing.

Additionally implement path compression: when following a chain like  v0 -> v1 -> v2 -> i32, update intermediate links to point directly to  the final result. This amortizes the cost of repeated lookups.

Also expose type_var_count from ConstraintGenerator::into_parts() so  the Unifier can pre-size its substitution, avoiding reallocations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)