### PR TITLE
Fix linear struct field access to consume the value (Fixes rue-cjpe)

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -4125,6 +4125,7 @@ impl<'a> Sema<'a> {
                 };
 
                 let struct_def = &self.struct_defs[struct_id.0 as usize];
+                let is_linear = struct_def.is_linear;
                 let field_name_str = self.interner.resolve(&*field).to_string();
 
                 let (field_index, struct_field) =
@@ -4138,8 +4139,19 @@ impl<'a> Sema<'a> {
 
                 let field_type = struct_field.ty;
 
-                // Check if accessing a non-Copy field - track field-level moves
-                if !self.is_type_copy(field_type) {
+                // For linear types, field access consumes the entire struct.
+                // This is a destructuring move - the struct is no longer usable after.
+                if is_linear {
+                    if let Some(root_var) = self.extract_root_variable(inst_ref) {
+                        // Mark the entire struct as fully moved (empty path = full move)
+                        ctx.moved_vars
+                            .entry(root_var)
+                            .or_default()
+                            .mark_path_moved(&[], inst.span);
+                    }
+                }
+                // For non-linear types, check if accessing a non-Copy field - track field-level moves
+                else if !self.is_type_copy(field_type) {
                     // Extract the full field path (root variable + field names)
                     if let Some((root_var, mut field_path)) = self.extract_field_path(inst_ref) {
                         // Check if this field path is already moved

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -797,6 +797,7 @@ exit_code = 42
 name = "linear_field_access"
 spec = ["3.8:32", "3.8:33"]
 preview = "affine_mvs"
+preview_should_pass = true
 description = "Field access on linear struct counts as move (consuming)"
 source = """
 linear struct MustUse { value: i32 }

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -127,6 +127,7 @@ A linear type **MUST** be explicitly consumed. It is a compile-time error for a 
 A linear value is consumed when it is:
 - Passed as an argument to a function (the function is the consumer)
 - Returned from a function (the caller becomes responsible for consuming it)
+- Field access is performed on the value (the value is destructured)
 
 {{ rule(id="3.8:34", cat="example") }}
 


### PR DESCRIPTION
Field access on a linear struct now properly marks the struct as consumed, allowing patterns like `m.value` to satisfy the linear consumption requirement.

- Updated spec rule 3.8:33 to include field access as a consumption method
- Modified sema.rs to mark linear structs as fully moved on field access
- Enabled the linear_field_access test

🤖 Generated with [Claude Code](https://claude.com/claude-code)