### PR TITLE
Fix benchmark workflow race condition and website metadata.json gener…

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -17,6 +17,7 @@ jobs:
   benchmark:
     strategy:
       fail-fast: false
+      max-parallel: 1  # Run sequentially to avoid race conditions on perf branch
       matrix:
         include:
           - runner: ubuntu-latest
@@ -28,11 +29,6 @@ jobs:
           - runner: macos-latest
             platform: aarch64-macos
             name: macOS ARM64
-
-    # Allow parallel runs on different platforms, but serialize per-platform
-    concurrency:
-      group: benchmarks-${{ matrix.platform }}
-      cancel-in-progress: false
 
     runs-on: ${{ matrix.runner }}
     name: benchmark (${{ matrix.name }})
@@ -123,17 +119,8 @@ jobs:
             git commit -m "[${{ matrix.platform }}] Benchmark results for ${{ steps.commit.outputs.sha }}"
 
             # Push to perf branch (create if doesn't exist)
-            # Retry a few times in case of concurrent pushes from other platform jobs
-            for i in 1 2 3; do
-              if git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:perf; then
-                echo "Push succeeded"
-                break
-              else
-                echo "Push failed, attempt $i/3. Pulling and retrying..."
-                git pull --rebase https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git perf || true
-                sleep $((i * 2))
-              fi
-            done
+            # Jobs run sequentially (max-parallel: 1) so no race conditions
+            git push https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git HEAD:perf
           fi
 
       - name: Summary

--- a/website/build.sh
+++ b/website/build.sh
@@ -68,15 +68,29 @@ fi
 
 # Generate root metadata.json listing all platforms
 echo "  Generating root metadata.json..."
+# Build a JSON array of platform IDs to pass to Python
+PLATFORMS_JSON="["
+first=true
+for platform in "${PLATFORMS_WITH_DATA[@]+"${PLATFORMS_WITH_DATA[@]}"}"; do
+    if [ "$first" = true ]; then
+        first=false
+    else
+        PLATFORMS_JSON+=","
+    fi
+    PLATFORMS_JSON+="\"$platform\""
+done
+PLATFORMS_JSON+="]"
+
 python3 -c "
 import json
-import os
+import sys
 from pathlib import Path
 
 benchmarks_dir = Path('$BENCHMARKS_DIR')
+platforms_with_data = json.loads('$PLATFORMS_JSON')
 platforms = []
 
-for platform in ${PLATFORMS_WITH_DATA[@]+"${PLATFORMS_WITH_DATA[@]}"}:
+for platform in platforms_with_data:
     platform = platform.strip()
     if not platform:
         continue
@@ -113,7 +127,8 @@ metadata = {
 
 with open(benchmarks_dir / 'metadata.json', 'w') as f:
     json.dump(metadata, f, indent=2)
-" 2>/dev/null || echo "  (No platform data available)"
+print(f'  Generated {benchmarks_dir}/metadata.json with {len([p for p in platforms if p[\"has_data\"]])} platforms with data')
+"
 
 # Backwards compatibility: Generate charts from legacy history.json if it exists
 # and no per-platform history exists yet


### PR DESCRIPTION
…ation

- benchmarks.yml: Add max-parallel: 1 to run jobs sequentially, preventing race conditions when multiple platforms push to perf branch simultaneously
- website/build.sh: Fix Python syntax error where bash array was expanded directly into Python code. Now builds a proper JSON array to pass to Python.

These issues caused:
1. Linux ARM64 benchmark job failures due to concurrent perf branch updates
2. 404 errors on rue-lang.dev/performance/ for metadata.json and charts

🤖 Generated with [Claude Code](https://claude.com/claude-code)