### PR TITLE
Remove Type::String variant from Type enum (Fixes rue-bmje)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -261,9 +261,20 @@ impl<'a> ConstraintGenerator<'a> {
 
             InstData::BoolConst(_) => InferType::Concrete(Type::Bool),
 
-            // String constants use Type::String during migration.
-            // Once String is a struct, sema converts this to the struct type.
-            InstData::StringConst(_) => InferType::Concrete(Type::String),
+            // String constants use the builtin String struct type.
+            InstData::StringConst(_) => {
+                // Look up the String type from the structs map
+                if let Some(string_spur) = self.interner.get("String") {
+                    if let Some(&string_ty) = self.structs.get(&string_spur) {
+                        InferType::Concrete(string_ty)
+                    } else {
+                        // Fallback if String struct not found (shouldn't happen after builtin injection)
+                        InferType::Concrete(Type::Error)
+                    }
+                } else {
+                    InferType::Concrete(Type::Error)
+                }
+            }
 
             InstData::UnitConst => InferType::Concrete(Type::Unit),
 
@@ -988,9 +999,18 @@ impl<'a> ConstraintGenerator<'a> {
             "u64" => Type::U64,
             "bool" => Type::Bool,
             "()" => Type::Unit,
-            // Type::String migration path - sema converts to struct-based String
-            "String" => Type::String,
-            _ => return None, // Struct/enum types need to be looked up separately
+            _ => {
+                // Check for struct types (including builtin String)
+                if let Some(name_spur) = self.interner.get(name) {
+                    if let Some(&struct_ty) = self.structs.get(&name_spur) {
+                        return Some(InferType::Concrete(struct_ty));
+                    }
+                    if let Some(&enum_ty) = self.enums.get(&name_spur) {
+                        return Some(InferType::Concrete(enum_ty));
+                    }
+                }
+                return None;
+            }
         };
         Some(InferType::Concrete(ty))
     }

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -1554,7 +1554,7 @@ impl<'a> Sema<'a> {
             Type::Unit => "()".to_string(),
             Type::Never => "!".to_string(),
             Type::Error => "<error>".to_string(),
-            Type::String => "String".to_string(),
+            // Note: String is now handled via Type::Struct with builtin_string_id
             Type::Struct(struct_id) => self.struct_defs[struct_id.0 as usize].name.clone(),
             Type::Enum(enum_id) => self.enum_defs[enum_id.0 as usize].name.clone(),
             Type::Array(array_id) => {
@@ -1593,8 +1593,7 @@ impl<'a> Sema<'a> {
                 let struct_def = &self.struct_defs[struct_id.0 as usize];
                 struct_def.is_copy
             }
-            // String is a move type (owns heap data)
-            Type::String => false,
+            // Note: String is now handled via Type::Struct with is_builtin
             // Arrays are move types for now
             // TODO: Arrays of Copy types could be Copy
             Type::Array(_) => false,
@@ -1662,12 +1661,10 @@ impl<'a> Sema<'a> {
 
     /// Check if a type is the builtin String type.
     ///
-    /// This replaces direct `ty == Type::String` checks throughout sema.
     /// Uses the stored `builtin_string_id` for fast comparison.
     fn is_builtin_string(&self, ty: Type) -> bool {
         match ty {
             Type::Struct(struct_id) => Some(struct_id) == self.builtin_string_id,
-            Type::String => true, // Still support during migration
             _ => false,
         }
     }
@@ -1716,16 +1713,9 @@ impl<'a> Sema<'a> {
 
     /// Get the AIR output type for a builtin struct.
     ///
-    /// During migration, builtin types still use their Type enum variants
-    /// (e.g., Type::String) for AIR output so downstream code (codegen, drop_glue)
-    /// continues to work. This will be removed once all downstream code is migrated.
+    /// Builtin types like String are now represented as Type::Struct with is_builtin=true.
     fn builtin_air_type(&self, struct_id: StructId) -> Type {
-        // String is special - uses Type::String for AIR output
-        if Some(struct_id) == self.builtin_string_id {
-            Type::String
-        } else {
-            Type::Struct(struct_id)
-        }
+        Type::Struct(struct_id)
     }
 
     /// Check if a type is a linear type.
@@ -2806,10 +2796,8 @@ impl<'a> Sema<'a> {
             }
 
             InstData::StringConst(symbol) => {
-                // String literals - keep using Type::String for AIR output
-                // so downstream code (codegen, drop_glue) continues to work.
-                // The internal sema checks use struct-based queries.
-                let ty = Type::String;
+                // String literals use the builtin String struct type.
+                let ty = self.builtin_string_type();
                 // Add string to the string table
                 let string_content = self.interner.resolve(&*symbol).to_string();
                 let string_id = self.add_string(string_content);
@@ -5068,11 +5056,6 @@ impl<'a> Sema<'a> {
                 // Check that receiver is a struct type
                 let struct_id = match receiver_type {
                     Type::Struct(id) => id,
-                    Type::String => {
-                        // During migration, Type::String might still appear from inference
-                        // Fall back to builtin_string_id
-                        self.builtin_string_id.expect("builtin string not injected")
-                    }
                     _ => {
                         return Err(CompileError::new(
                             ErrorKind::MethodCallOnNonStruct {
@@ -5291,9 +5274,8 @@ impl<'a> Sema<'a> {
     fn resolve_type(&mut self, type_sym: Spur, span: Span) -> CompileResult<Type> {
         let type_name = self.interner.resolve(&type_sym);
 
-        // Check primitive and builtin types first.
-        // Note: String still uses Type::String for AIR compatibility with downstream code.
-        // Struct-based queries are used internally in sema.rs for method dispatch etc.
+        // Check primitive types first.
+        // Note: String is handled below via struct lookup (it's a builtin struct).
         match type_name {
             "i8" => return Ok(Type::I8),
             "i16" => return Ok(Type::I16),
@@ -5306,7 +5288,6 @@ impl<'a> Sema<'a> {
             "bool" => return Ok(Type::Bool),
             "()" => return Ok(Type::Unit),
             "!" => return Ok(Type::Never),
-            "String" => return Ok(Type::String),
             _ => {}
         }
 
@@ -5427,17 +5408,7 @@ impl<'a> Sema<'a> {
             Type::Unit | Type::Never => 0,
             // Enums are represented as their discriminant type (a scalar), so 1 slot
             Type::Enum(_) => 1,
-            // String during migration - use builtin struct's slot count
-            Type::String => {
-                // Fall through to synthetic struct handling
-                let string_id = self.builtin_string_id.expect("builtin string not injected");
-                let struct_def = &self.struct_defs[string_id.0 as usize];
-                struct_def
-                    .fields
-                    .iter()
-                    .map(|f| self.abi_slot_count(f.ty))
-                    .sum()
-            }
+            // Struct uses sum of all field slots (includes builtin String with 3 fields)
             Type::Struct(struct_id) => {
                 // Sum the slot counts of all fields (handles arrays, nested structs, and builtins)
                 // Empty structs naturally get 0 slots here

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -45,8 +45,6 @@ pub enum Type {
     Enum(EnumId),
     /// Fixed-size array type: [T; N]
     Array(ArrayTypeId),
-    /// String type (ptr + len + cap, 24 bytes)
-    String,
     /// An error type (used during type checking to continue after errors)
     Error,
     /// The never type - represents computations that don't return (e.g., break, continue).
@@ -175,7 +173,6 @@ impl Type {
             Type::Struct(_) => "<struct>",
             Type::Enum(_) => "<enum>",
             Type::Array(_) => "<array>",
-            Type::String => "String",
             Type::Error => "<error>",
             Type::Never => "!",
         }
@@ -245,11 +242,6 @@ impl Type {
         }
     }
 
-    /// Check if this is a string type.
-    pub fn is_string(&self) -> bool {
-        matches!(self, Type::String)
-    }
-
     /// Check if this is a signed integer type.
     pub fn is_signed(&self) -> bool {
         matches!(self, Type::I8 | Type::I16 | Type::I32 | Type::I64)
@@ -265,9 +257,11 @@ impl Type {
     /// - Never type and Error type (for convenience in error recovery)
     ///
     /// Non-Copy types (move types) are:
-    /// - Struct types
-    /// - String
+    /// - Struct types (unless marked @copy, checked via StructDef.is_copy)
     /// - Array types (until we implement Copy arrays with Copy elements)
+    ///
+    /// Note: This method can't check struct's is_copy attribute since it doesn't
+    /// have access to StructDefs. Use Sema.is_type_copy() for full checking.
     pub fn is_copy(&self) -> bool {
         match self {
             // Primitive Copy types
@@ -285,10 +279,8 @@ impl Type {
             Type::Enum(_) => true,
             // Never and Error are Copy for convenience
             Type::Never | Type::Error => true,
-            // Struct types are move types
+            // Struct types are move types by default (may be @copy, but need StructDef to check)
             Type::Struct(_) => false,
-            // String is a move type (owns heap data)
-            Type::String => false,
             // Arrays are move types for now
             // TODO: Arrays of Copy types could be Copy
             Type::Array(_) => false,
@@ -445,7 +437,6 @@ mod tests {
     fn test_type_name_other() {
         assert_eq!(Type::Bool.name(), "bool");
         assert_eq!(Type::Unit.name(), "()");
-        assert_eq!(Type::String.name(), "String");
         assert_eq!(Type::Error.name(), "<error>");
         assert_eq!(Type::Never.name(), "!");
     }
@@ -479,7 +470,6 @@ mod tests {
     fn test_is_integer_non_integers() {
         assert!(!Type::Bool.is_integer());
         assert!(!Type::Unit.is_integer());
-        assert!(!Type::String.is_integer());
         assert!(!Type::Struct(StructId(0)).is_integer());
         assert!(!Type::Enum(EnumId(0)).is_integer());
         assert!(!Type::Array(ArrayTypeId(0)).is_integer());
@@ -604,15 +594,6 @@ mod tests {
         assert_eq!(Type::Struct(StructId(0)).as_array(), None);
     }
 
-    // ========== Type::is_string() tests ==========
-
-    #[test]
-    fn test_is_string() {
-        assert!(Type::String.is_string());
-        assert!(!Type::I32.is_string());
-        assert!(!Type::Array(ArrayTypeId(0)).is_string());
-    }
-
     // ========== Type::is_copy() tests ==========
 
     #[test]
@@ -644,9 +625,8 @@ mod tests {
 
     #[test]
     fn test_is_copy_move_types() {
-        // Struct, String, and Array are move types
+        // Struct and Array are move types (String is a builtin struct now)
         assert!(!Type::Struct(StructId(0)).is_copy());
-        assert!(!Type::String.is_copy());
         assert!(!Type::Array(ArrayTypeId(0)).is_copy());
     }
 
@@ -656,14 +636,13 @@ mod tests {
     fn test_can_coerce_to_same_type() {
         assert!(Type::I32.can_coerce_to(&Type::I32));
         assert!(Type::Bool.can_coerce_to(&Type::Bool));
-        assert!(Type::String.can_coerce_to(&Type::String));
+        assert!(Type::Struct(StructId(0)).can_coerce_to(&Type::Struct(StructId(0))));
     }
 
     #[test]
     fn test_can_coerce_to_never_coerces_to_anything() {
         assert!(Type::Never.can_coerce_to(&Type::I32));
         assert!(Type::Never.can_coerce_to(&Type::Bool));
-        assert!(Type::Never.can_coerce_to(&Type::String));
         assert!(Type::Never.can_coerce_to(&Type::Struct(StructId(0))));
     }
 
@@ -671,7 +650,7 @@ mod tests {
     fn test_can_coerce_to_error_coerces_to_anything() {
         assert!(Type::Error.can_coerce_to(&Type::I32));
         assert!(Type::Error.can_coerce_to(&Type::Bool));
-        assert!(Type::Error.can_coerce_to(&Type::String));
+        assert!(Type::Error.can_coerce_to(&Type::Struct(StructId(0))));
     }
 
     #[test]
@@ -679,7 +658,7 @@ mod tests {
         assert!(!Type::I32.can_coerce_to(&Type::Bool));
         assert!(!Type::Bool.can_coerce_to(&Type::I32));
         assert!(!Type::I32.can_coerce_to(&Type::I64));
-        assert!(!Type::String.can_coerce_to(&Type::I32));
+        assert!(!Type::Struct(StructId(0)).can_coerce_to(&Type::I32));
     }
 
     // ========== Type::literal_fits() tests ==========
@@ -742,7 +721,7 @@ mod tests {
     #[test]
     fn test_literal_fits_non_integer() {
         assert!(!Type::Bool.literal_fits(0));
-        assert!(!Type::String.literal_fits(0));
+        assert!(!Type::Struct(StructId(0)).literal_fits(0));
         assert!(!Type::Unit.literal_fits(0));
     }
 
@@ -784,7 +763,7 @@ mod tests {
     #[test]
     fn test_negated_literal_fits_non_integer() {
         assert!(!Type::Bool.negated_literal_fits(1));
-        assert!(!Type::String.negated_literal_fits(1));
+        assert!(!Type::Struct(StructId(0)).negated_literal_fits(1));
     }
 
     // ========== Type Display tests ==========

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1730,9 +1730,7 @@ impl<'a> CfgBuilder<'a> {
                 struct_def.fields.iter().any(|f| self.type_needs_drop(f.ty))
             }
 
-            // Type::String still supported during migration - will be removed
-            // once all downstream code uses struct-based String
-            Type::String => true,
+            // Note: String is now Type::Struct with is_builtin=true, handled above
 
             // Array types need drop if element type needs drop
             Type::Array(array_id) => {

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -311,14 +311,12 @@ impl<'a> CfgLower<'a> {
     /// Check if a type is the builtin String struct.
     ///
     /// Returns true if the type is a struct that is marked as builtin with name "String".
-    /// This is used to identify String types during the transition away from Type::String.
     fn is_builtin_string(&self, ty: Type) -> bool {
         match ty {
             Type::Struct(struct_id) => {
                 let struct_def = &self.struct_defs[struct_id.0 as usize];
                 struct_def.is_builtin && struct_def.name == "String"
             }
-            Type::String => true, // Keep compatibility during transition
             _ => false,
         }
     }
@@ -1575,8 +1573,7 @@ impl<'a> CfgLower<'a> {
                         continue;
                     }
 
-                    // Handle builtin String specially - check before the match
-                    // since String can be either Type::String or Type::Struct(builtin_string_id)
+                    // Handle builtin String specially (String is a builtin struct type)
                     if self.is_builtin_string(arg_type) {
                         // String has 3 slots: ptr, len, cap
                         let arg_data = &self.cfg.get_inst(arg_value).data;
@@ -1772,27 +1769,8 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Handle struct and string returns (multi-slot types)
-                if let Type::Struct(struct_id) = ty {
-                    let slot_count = self.type_slot_count(Type::Struct(struct_id));
-                    let mut slot_vregs = Vec::new();
-                    for slot_idx in 0..slot_count {
-                        let slot_vreg = self.mir.alloc_vreg();
-                        if (slot_idx as usize) < RET_REGS.len() {
-                            self.mir.push(Aarch64Inst::MovRR {
-                                dst: Operand::Virtual(slot_vreg),
-                                src: Operand::Physical(RET_REGS[slot_idx as usize]),
-                            });
-                        }
-                        slot_vregs.push(slot_vreg);
-                    }
-                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
-                    if let Some(&first_vreg) = slot_vregs.first() {
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Virtual(result_vreg),
-                            src: Operand::Virtual(first_vreg),
-                        });
-                    }
-                } else if self.is_builtin_string(ty) {
+                // Check builtin String first - it uses sret convention
+                if self.is_builtin_string(ty) {
                     // String uses sret convention: result was written to [sp]
                     // Load ptr, len, cap from stack
                     let mut slot_vregs = Vec::new();
@@ -1817,6 +1795,27 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(result_vreg),
                         src: Operand::Virtual(slot_vregs[0]),
                     });
+                } else if let Type::Struct(struct_id) = ty {
+                    // Non-builtin structs return in registers
+                    let slot_count = self.type_slot_count(Type::Struct(struct_id));
+                    let mut slot_vregs = Vec::new();
+                    for slot_idx in 0..slot_count {
+                        let slot_vreg = self.mir.alloc_vreg();
+                        if (slot_idx as usize) < RET_REGS.len() {
+                            self.mir.push(Aarch64Inst::MovRR {
+                                dst: Operand::Virtual(slot_vreg),
+                                src: Operand::Physical(RET_REGS[slot_idx as usize]),
+                            });
+                        }
+                        slot_vregs.push(slot_vreg);
+                    }
+                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
+                    if let Some(&first_vreg) = slot_vregs.first() {
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Virtual(result_vreg),
+                            src: Operand::Virtual(first_vreg),
+                        });
+                    }
                 } else {
                     // Move result from X0
                     self.mir.push(Aarch64Inst::MovRR {

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -49,9 +49,7 @@ pub fn type_slot_count(struct_defs: &[StructDef], array_types: &[ArrayTypeDef], 
                 1
             }
         }
-        // Type::String still supported during migration (uses 3 slots: ptr, len, cap)
-        // Once String is a struct, the Type::Struct case handles it via field count
-        Type::String => 3,
+        // Scalars and other types use 1 slot
         _ => 1,
     }
 }
@@ -128,21 +126,13 @@ pub fn collect_array_scalar_vregs(
                         get_vreg,
                     ));
                 } else if matches!(elem_inst.ty, Type::Struct(_)) {
-                    // Recursively collect from struct element
+                    // Recursively collect from struct element (includes builtin String)
                     result.extend(collect_struct_scalar_vregs(
                         cfg,
                         struct_slot_vregs,
                         *elem,
                         get_vreg,
                     ));
-                } else if elem_inst.ty == Type::String {
-                    // Type::String migration path - has 3 slots (ptr, len, cap)
-                    // Once String is a struct, the Type::Struct case handles it
-                    if let Some(vregs) = struct_slot_vregs.get(elem).cloned() {
-                        result.extend(vregs);
-                    } else {
-                        result.push(get_vreg(*elem));
-                    }
                 } else {
                     // Scalar element - get its vreg
                     result.push(get_vreg(*elem));
@@ -193,9 +183,8 @@ fn type_name(ty: Type, struct_defs: &[StructDef], array_types: &[ArrayTypeDef]) 
         Type::Unit => "unit".to_string(),
         Type::Never => "never".to_string(),
         Type::Error => "error".to_string(),
-        // Type::String migration path - once String is a struct, uses struct_def.name
-        Type::String => "String".to_string(),
         Type::Enum(enum_id) => format!("enum{}", enum_id.0),
+        // Struct types include builtin types like String
         Type::Struct(struct_id) => struct_defs[struct_id.0 as usize].name.clone(),
         Type::Array(array_id) => {
             let array_def = &array_types[array_id.0 as usize];
@@ -242,22 +231,13 @@ pub fn collect_struct_scalar_vregs(
                         get_vreg,
                     ));
                 } else if matches!(field_inst.ty, Type::Struct(_)) {
-                    // Recursively collect from nested struct field
+                    // Recursively collect from nested struct field (includes builtin String)
                     result.extend(collect_struct_scalar_vregs(
                         cfg,
                         struct_slot_vregs,
                         *field,
                         get_vreg,
                     ));
-                } else if field_inst.ty == Type::String {
-                    // Type::String migration path - has 3 slots (ptr, len, cap)
-                    // Once String is a struct, the Type::Struct case handles it
-                    if let Some(vregs) = struct_slot_vregs.get(field).cloned() {
-                        result.extend(vregs);
-                    } else {
-                        // Fallback: just get the main vreg (should not happen for properly lowered String)
-                        result.push(get_vreg(*field));
-                    }
                 } else {
                     // Scalar field - get its vreg
                     result.push(get_vreg(*field));

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -139,15 +139,13 @@ impl<'a> CfgLower<'a> {
 
     /// Check if a type is the builtin String struct.
     ///
-    /// Returns true if the type is a struct that is marked as builtin with name "String",
-    /// or if it's the legacy Type::String variant (migration path).
+    /// Returns true if the type is a struct that is marked as builtin with name "String".
     fn is_builtin_string(&self, ty: Type) -> bool {
         match ty {
             Type::Struct(struct_id) => {
                 let struct_def = &self.struct_defs[struct_id.0 as usize];
                 struct_def.is_builtin && struct_def.name == "String"
             }
-            Type::String => true, // Migration path - will be removed
             _ => false,
         }
     }
@@ -166,8 +164,6 @@ impl<'a> CfgLower<'a> {
                     return None;
                 }
             }
-            // Type::String migration path
-            Type::String => get_builtin_type("String")?,
             _ => return None,
         };
         builtin
@@ -1843,56 +1839,7 @@ impl<'a> CfgLower<'a> {
                                 }
                             }
                         }
-                        Type::String => {
-                            // Type::String migration path - once String becomes a struct,
-                            // the Type::Struct case handles it (String has 3 slots: ptr, len, cap)
-                            let arg_data = &self.cfg.get_inst(arg_value).data;
-                            match arg_data {
-                                CfgInstData::Load { slot } => {
-                                    // Load all 3 String fields from stack
-                                    for field_idx in 0..3u32 {
-                                        let field_vreg = self.mir.alloc_vreg();
-                                        let field_slot = slot + field_idx;
-                                        let offset = self.local_offset(field_slot);
-                                        self.mir.push(X86Inst::MovRM {
-                                            dst: Operand::Virtual(field_vreg),
-                                            base: Reg::Rbp,
-                                            offset,
-                                        });
-                                        flattened_vregs.push(field_vreg);
-                                    }
-                                }
-                                CfgInstData::Param { index } => {
-                                    // Load all 3 String fields from param slots
-                                    for field_idx in 0..3u32 {
-                                        let field_vreg = self.mir.alloc_vreg();
-                                        let param_slot = self.num_locals + index + field_idx;
-                                        let offset = self.local_offset(param_slot);
-                                        self.mir.push(X86Inst::MovRM {
-                                            dst: Operand::Virtual(field_vreg),
-                                            base: Reg::Rbp,
-                                            offset,
-                                        });
-                                        flattened_vregs.push(field_vreg);
-                                    }
-                                }
-                                CfgInstData::StringConst(_) | CfgInstData::Call { .. } => {
-                                    // String from a call result or string const - use vregs
-                                    if let Some(field_vregs) =
-                                        self.struct_slot_vregs.get(&arg_value)
-                                    {
-                                        flattened_vregs.extend(field_vregs.iter().copied());
-                                    } else {
-                                        // Single vreg case (shouldn't happen for String)
-                                        flattened_vregs.push(self.get_vreg(arg_value));
-                                    }
-                                }
-                                _ => {
-                                    // Fallback - should be rare for String
-                                    flattened_vregs.push(self.get_vreg(arg_value));
-                                }
-                            }
-                        }
+                        // Note: String is now Type::Struct, handled above
                         _ => {
                             flattened_vregs.push(self.get_vreg(arg_value));
                         }
@@ -1945,27 +1892,8 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Handle struct and string returns (multi-slot types)
-                if let Type::Struct(struct_id) = ty {
-                    let slot_count = self.type_slot_count(Type::Struct(struct_id));
-                    let mut slot_vregs = Vec::new();
-                    for slot_idx in 0..slot_count {
-                        let slot_vreg = self.mir.alloc_vreg();
-                        if (slot_idx as usize) < RET_REGS.len() {
-                            self.mir.push(X86Inst::MovRR {
-                                dst: Operand::Virtual(slot_vreg),
-                                src: Operand::Physical(RET_REGS[slot_idx as usize]),
-                            });
-                        }
-                        slot_vregs.push(slot_vreg);
-                    }
-                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
-                    if let Some(&first_vreg) = slot_vregs.first() {
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Virtual(result_vreg),
-                            src: Operand::Virtual(first_vreg),
-                        });
-                    }
-                } else if self.is_builtin_string(ty) {
+                // Check builtin String first - it uses sret convention
+                if self.is_builtin_string(ty) {
                     // Builtin String uses sret convention: result was written to [rsp]
                     // Load ptr, len, cap from stack
                     let mut slot_vregs = Vec::new();
@@ -1989,6 +1917,27 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(result_vreg),
                         src: Operand::Virtual(slot_vregs[0]),
                     });
+                } else if let Type::Struct(struct_id) = ty {
+                    // Non-builtin structs return in registers
+                    let slot_count = self.type_slot_count(Type::Struct(struct_id));
+                    let mut slot_vregs = Vec::new();
+                    for slot_idx in 0..slot_count {
+                        let slot_vreg = self.mir.alloc_vreg();
+                        if (slot_idx as usize) < RET_REGS.len() {
+                            self.mir.push(X86Inst::MovRR {
+                                dst: Operand::Virtual(slot_vreg),
+                                src: Operand::Physical(RET_REGS[slot_idx as usize]),
+                            });
+                        }
+                        slot_vregs.push(slot_vreg);
+                    }
+                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
+                    if let Some(&first_vreg) = slot_vregs.first() {
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Virtual(result_vreg),
+                            src: Operand::Virtual(first_vreg),
+                        });
+                    }
                 } else {
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Virtual(result_vreg),

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -58,8 +58,7 @@ fn type_needs_drop(ty: Type, struct_defs: &[StructDef], array_types: &[ArrayType
                 .any(|f| type_needs_drop(f.ty, struct_defs, array_types))
         }
 
-        // Type::String still supported during migration
-        Type::String => true,
+        // Note: String is now Type::Struct with is_builtin=true, handled above
 
         // Array types need drop if element type needs drop
         Type::Array(array_id) => {
@@ -97,8 +96,7 @@ fn type_slot_count(ty: Type, struct_defs: &[StructDef], array_types: &[ArrayType
                 .sum()
         }
 
-        // Type::String still supported during migration (uses 3 slots: ptr, len, cap)
-        Type::String => 3,
+        // Note: String is now Type::Struct with is_builtin=true, handled above
 
         // Array uses element slots * length
         Type::Array(array_id) => {
@@ -188,31 +186,8 @@ fn create_struct_drop_glue_function(
 
         if type_needs_drop(field.ty, struct_defs, array_types) {
             // Emit Drop for this field.
-            // Note: Type::Struct handles both user-defined structs and builtin String
-            // (when String becomes a struct). Type::String is the migration path.
+            // Type::Struct handles both user-defined structs and builtin String.
             match field.ty {
-                Type::String => {
-                    // String has 3 params (ptr, len, cap)
-                    // We need to load all three and pass them to the Drop instruction
-                    // The Drop instruction in AIR operates on a value, and the CFG/codegen
-                    // will handle the flattening.
-
-                    // For simplicity, emit a Param to get the first slot, then drop it.
-                    // The codegen knows this is a String and will use all 3 slots.
-                    let param_ref = air.add_inst(AirInst {
-                        data: AirInstData::Param {
-                            index: current_param_slot,
-                        },
-                        ty: Type::String,
-                        span,
-                    });
-                    let drop_ref = air.add_inst(AirInst {
-                        data: AirInstData::Drop { value: param_ref },
-                        ty: Type::Unit,
-                        span,
-                    });
-                    drop_statements.push(drop_ref);
-                }
                 Type::Struct(nested_struct_id) => {
                     // Nested struct - load it and drop it
                     // The recursive drop glue will handle its fields
@@ -326,28 +301,12 @@ fn create_array_drop_glue_function(
     let mut drop_statements = Vec::new();
 
     // For each element, emit a Drop instruction.
-    // Note: Type::Struct handles both user-defined structs and builtin String
-    // (when String becomes a struct). Type::String is the migration path.
+    // Type::Struct handles both user-defined structs and builtin String.
     for elem_idx in 0..array_def.length {
         let current_param_slot = elem_idx as u32 * element_slot_count;
 
         // Emit Drop for this element
         match array_def.element_type {
-            Type::String => {
-                let param_ref = air.add_inst(AirInst {
-                    data: AirInstData::Param {
-                        index: current_param_slot,
-                    },
-                    ty: Type::String,
-                    span,
-                });
-                let drop_ref = air.add_inst(AirInst {
-                    data: AirInstData::Drop { value: param_ref },
-                    ty: Type::Unit,
-                    span,
-                });
-                drop_statements.push(drop_ref);
-            }
             Type::Struct(struct_id) => {
                 let param_ref = air.add_inst(AirInst {
                     data: AirInstData::Param {
@@ -458,8 +417,8 @@ fn type_name(ty: Type, struct_defs: &[StructDef], array_types: &[ArrayTypeDef]) 
         Type::Unit => "unit".to_string(),
         Type::Never => "never".to_string(),
         Type::Error => "error".to_string(),
-        Type::String => "String".to_string(),
         Type::Enum(enum_id) => format!("enum{}", enum_id.0),
+        // Struct types include builtin types like String
         Type::Struct(struct_id) => struct_defs[struct_id.0 as usize].name.clone(),
         Type::Array(array_id) => {
             let array_def = &array_types[array_id.0 as usize];


### PR DESCRIPTION
This is the final phase of ADR-0020, removing the Type::String variant completely. String is now represented purely as Type::Struct with is_builtin=true.

Changes:
- Remove Type::String variant from the Type enum
- Remove Type::is_string() method (use struct-based checks instead)
- Update type_name() in drop_glue.rs (String is now Type::Struct)
- Update type_needs_drop() in rue-cfg
- Update inference generator to look up String from structs map
- Fix sret calling convention handling in both x86_64 and aarch64 backends: Check is_builtin_string() BEFORE Type::Struct since String is now a struct

The key fix was in the Call instruction handling: after removing Type::String, the code matched Type::Struct first (reading return values from registers) instead of the sret path (reading from stack). This caused String returns to be corrupted. Fixed by checking is_builtin_string() before Type::Struct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)