### PR TITLE
Add ADR-0021 (stdin input) and ADR-0022 (integer parsing)

### DIFF
--- a/docs/designs/0021-stdin-input.md
+++ b/docs/designs/0021-stdin-input.md
@@ -1,0 +1,243 @@
+---
+id: 0021
+title: Standard Input
+status: proposal
+tags: [io, intrinsics, runtime]
+feature-flag: stdin-input
+created: 2025-12-31
+accepted:
+implemented:
+spec-sections: ["4.13"]
+superseded-by:
+---
+
+# ADR-0021: Standard Input
+
+## Status
+
+Proposal
+
+## Summary
+
+Add a `@read_line()` intrinsic that reads a line of text from standard input and returns it as a `String`. On EOF or I/O error, the intrinsic panics. This provides the simplest possible input mechanism for Rue programs.
+
+## Context
+
+### Current I/O Situation
+
+Rue currently has output via `@dbg`, but no input mechanism:
+
+```rue
+fn main() -> i32 {
+    @dbg("Hello, world!");  // Output works
+    // But how do we read user input?
+    0
+}
+```
+
+Without input, Rue programs cannot:
+- Interact with users
+- Process data from pipes
+- Read configuration at runtime
+
+### Design Philosophy: Start Simple
+
+Rue is building up capabilities incrementally. For input, the simplest useful primitive is reading a line of text. More sophisticated I/O (files, binary data, non-blocking I/O) can come later.
+
+Key constraints:
+- **No generics yet**: Can't have `Result<String, Error>`
+- **No error enums**: Can't return structured errors
+- **Mutable strings exist**: Can return an owned `String`
+
+Given these constraints, the simplest approach is: read a line, return a String, panic on failure.
+
+### Why Panic on Error?
+
+For a first implementation, panicking on error is acceptable because:
+
+1. **EOF is rare in interactive use**: Users typically provide input
+2. **Pipe failures are exceptional**: Usually indicate broken pipelines
+3. **Matches existing patterns**: `@intCast` panics on overflow, bounds checks panic
+4. **No error handling overhead**: Simple control flow
+
+Later, we can add `@try_read_line()` that returns a sentinel (empty string on EOF) or eventually a proper `Result` type when generics exist.
+
+### Dependencies
+
+This feature requires:
+- **ADR-0014 (Mutable Strings)**: To return a `String` ✓ (implemented)
+- **Runtime syscall layer**: Already exists for `write`, needs `read`
+
+## Decision
+
+### The `@read_line` Intrinsic
+
+```rue
+@read_line() -> String
+```
+
+Reads characters from standard input until a newline (`\n`) is encountered. Returns the line as a `String`, **excluding** the trailing newline.
+
+#### Behavior
+
+1. Read bytes from stdin (file descriptor 0) into an internal buffer
+2. Accumulate bytes until `\n` is found or EOF is reached
+3. If `\n` found: return the bytes before it as a String (newline is consumed but not included)
+4. If EOF with no bytes read: panic with "unexpected end of input"
+5. If EOF with some bytes: return those bytes as a String (partial line)
+6. If read error: panic with "input error"
+
+#### Examples
+
+```rue
+fn main() -> i32 {
+    @dbg("What is your name?");
+    let name = @read_line();
+    @dbg("Hello, ");
+    @dbg(name);
+    0
+}
+```
+
+Running interactively:
+```
+$ ./program
+What is your name?
+Alice
+Hello,
+Alice
+```
+
+#### Edge Cases
+
+| Input | Result |
+|-------|--------|
+| `"hello\n"` | `"hello"` |
+| `"hello\nworld\n"` | First call: `"hello"`, second call: `"world"` |
+| `"hello"` (no newline, EOF) | `"hello"` |
+| Empty (immediate EOF) | Panic: "unexpected end of input" |
+| `"\n"` (just newline) | `""` (empty string) |
+
+### Runtime Implementation
+
+Add to the platform-specific runtime (`x86_64_linux.rs`, `aarch64_linux.rs`, `aarch64_macos.rs`):
+
+```rust
+pub fn read(fd: u64, buf: *mut u8, len: usize) -> i64 {
+    // syscall read(fd, buf, len)
+    // Returns bytes read, 0 on EOF, negative on error
+}
+```
+
+Add to the shared runtime (`lib.rs`):
+
+```rust
+/// Read a line from stdin, return as String.
+/// Panics on EOF with no data or on I/O error.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rue_read_line() -> (*mut u8, u64, u64) {
+    // 1. Allocate initial buffer (e.g., 128 bytes)
+    // 2. Read in a loop until \n or EOF
+    // 3. Grow buffer as needed (using string allocation functions)
+    // 4. On EOF with no data: panic
+    // 5. On error: panic
+    // 6. Return (ptr, len, cap) for String
+}
+```
+
+The function returns the three components of a String (ptr, len, cap) which codegen assembles into the String value.
+
+### Buffering Consideration
+
+For simplicity, the initial implementation does **not** use stdio-style buffering. Each `@read_line()` call reads byte-by-byte until newline. This is inefficient for heavy I/O but fine for:
+- Interactive input (human typing speed)
+- Simple scripts reading a few lines
+
+A future optimization could add an internal buffer to reduce syscalls.
+
+### Codegen
+
+The `@read_line` intrinsic is lowered to:
+
+1. Call `__rue_read_line` (returns ptr, len, cap in registers/memory)
+2. Construct String value from the three components
+
+This follows the same pattern as `String::new()` and other String-returning functions.
+
+## Implementation Phases
+
+### Phase 1: Runtime Read Syscall
+
+- [ ] Add `SYS_READ` constant to platform modules
+- [ ] Add `read(fd, buf, len) -> i64` to platform modules
+- [ ] Add `STDIN` constant (0) to platform modules
+- [ ] Unit tests for read syscall
+
+### Phase 2: Line Reading Runtime Function
+
+- [ ] Add `__rue_read_line() -> (ptr, len, cap)` to runtime
+- [ ] Implement byte-by-byte reading until newline
+- [ ] Handle EOF (panic if no data, otherwise return partial)
+- [ ] Handle errors (panic with message)
+- [ ] Unit tests in Rust
+
+### Phase 3: Intrinsic in Compiler
+
+- [ ] Add `@read_line` to known intrinsics in sema
+- [ ] Type check: no arguments, returns `String`
+- [ ] Lower to `__rue_read_line` call in codegen
+- [ ] Handle String return value assembly
+
+### Phase 4: Spec and Tests
+
+- [ ] Add `@read_line` to spec section 4.13 (Intrinsics)
+- [ ] Add spec tests (may need special handling for stdin in test harness)
+- [ ] Document in language guide
+
+## Consequences
+
+### Positive
+
+- **Enables interactive programs**: Can now read user input
+- **Simple API**: One function, easy to understand
+- **Matches existing patterns**: Returns String like other constructors
+- **No new concepts**: Uses existing String type
+
+### Negative
+
+- **Panics on EOF**: Programs can't gracefully handle end of input
+- **Inefficient**: Byte-by-byte reading without buffering
+- **No binary input**: Only line-oriented text
+
+### Neutral
+
+- **Newline handling**: Newline is consumed but not returned (common convention)
+- **UTF-8**: Input is treated as bytes, conventionally UTF-8 (like all Rue strings)
+
+## Open Questions
+
+1. **Should empty input (just EOF) return empty string instead of panicking?**
+   - Current decision: Panic, because it likely indicates unexpected EOF
+   - Alternative: Return empty string, let caller check `.is_empty()`
+
+2. **Should we strip `\r\n` on Windows (future)?**
+   - Current: Not applicable (Linux/macOS only)
+   - Future: Probably yes, normalize to `\n`
+
+3. **Test harness support?**
+   - Need to figure out how spec tests can provide stdin input
+   - Options: heredoc in test file, separate input file, skip stdin tests
+
+## Future Work
+
+- **`@try_read_line() -> String`**: Return empty string on EOF instead of panicking
+- **`@read_bytes(n: u64) -> [u8; N]`**: Read exact number of bytes
+- **File I/O**: `@open`, `@read_file`, `@write_file`
+- **Buffered I/O**: Internal buffering for efficiency
+- **Result type**: Once generics exist, `@read_line() -> Result<String, IoError>`
+
+## References
+
+- [ADR-0014: Mutable Strings](0014-mutable-strings.md) - String type used for return value
+- [POSIX read(2)](https://pubs.opengroup.org/onlinepubs/9699919799/functions/read.html) - Underlying syscall
+- [Rust std::io::stdin](https://doc.rust-lang.org/std/io/fn.stdin.html) - Similar high-level API

--- a/docs/designs/0022-integer-parsing.md
+++ b/docs/designs/0022-integer-parsing.md
@@ -1,0 +1,269 @@
+---
+id: 0022
+title: Integer Parsing
+status: proposal
+tags: [intrinsics, runtime, strings]
+feature-flag: integer-parsing
+created: 2025-12-31
+accepted:
+implemented:
+spec-sections: ["4.13"]
+superseded-by:
+---
+
+# ADR-0022: Integer Parsing
+
+## Status
+
+Proposal
+
+## Summary
+
+Add intrinsics to parse strings into integer values: `@parse_i32`, `@parse_i64`, `@parse_u32`, `@parse_u64`. These intrinsics accept a `String` and return the corresponding integer type, panicking on invalid input or overflow. This enables programs to process numeric input from users or files.
+
+## Context
+
+### The Input→Process→Output Pattern
+
+With `@read_line()` (ADR-0021) providing input and `@dbg` providing output, we need a way to process numeric input:
+
+```rue
+fn main() -> i32 {
+    @dbg("Enter a number:");
+    let input = @read_line();
+
+    // How do we convert input to an integer?
+    let n = ???;  // Need this!
+
+    @dbg(n * 2);
+    0
+}
+```
+
+### Why Intrinsics Instead of Methods?
+
+Two design options exist:
+
+1. **Intrinsics**: `@parse_i32(s)`
+2. **Methods**: `s.parse_i32()` or `i32::parse(s)`
+
+We choose intrinsics because:
+- Consistent with other conversion operations (`@intCast`)
+- No need for associated functions on primitive types yet
+- Simpler implementation (no method dispatch)
+- Can migrate to methods later if desired
+
+### Error Handling: Panic
+
+Like `@intCast`, parsing panics on failure:
+- Invalid characters (e.g., "12abc")
+- Overflow (e.g., "999999999999" for i32)
+- Empty string
+
+This matches Rue's current pattern: runtime errors are panics. Once we have `Result<T, E>` (requires generics), we can add `@try_parse_i32` that returns a Result.
+
+### What About Other Bases?
+
+For simplicity, we only support base-10 (decimal) parsing. Hexadecimal (`0x`), binary (`0b`), and octal (`0o`) can be added later if needed.
+
+## Decision
+
+### Parsing Intrinsics
+
+```rue
+@parse_i32(s: String) -> i32
+@parse_i64(s: String) -> i64
+@parse_u32(s: String) -> u32
+@parse_u64(s: String) -> u64
+```
+
+Each intrinsic:
+1. Borrows the string (does not consume it)
+2. Parses ASCII decimal digits
+3. Returns the parsed integer
+4. Panics on invalid input or overflow
+
+### Syntax Accepted
+
+The parsed string must match this grammar:
+
+```ebnf
+integer_string = [ "-" ] digit { digit } ;
+digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+```
+
+Rules:
+- Optional leading `-` for signed types only
+- One or more ASCII digits
+- No leading/trailing whitespace allowed
+- No underscores, no `+` sign
+- No `0x`, `0b`, `0o` prefixes
+
+### Valid Examples
+
+| Input | `@parse_i32` | `@parse_u32` |
+|-------|--------------|--------------|
+| `"42"` | `42` | `42` |
+| `"0"` | `0` | `0` |
+| `"-17"` | `-17` | panic (negative) |
+| `"2147483647"` | `2147483647` | `2147483647` |
+| `"-2147483648"` | `-2147483648` | panic (negative) |
+
+### Invalid Examples (All Panic)
+
+| Input | Reason |
+|-------|--------|
+| `""` | Empty string |
+| `"  42"` | Leading whitespace |
+| `"42  "` | Trailing whitespace |
+| `"4 2"` | Internal whitespace |
+| `"12abc"` | Invalid characters |
+| `"abc"` | No digits |
+| `"+42"` | Plus sign not allowed |
+| `"1_000"` | Underscores not allowed |
+| `"0x10"` | Hex prefix not allowed |
+| `"99999999999"` | Overflow (for i32) |
+| `"-1"` | Negative (for unsigned) |
+
+### Panic Messages
+
+Clear, actionable error messages:
+
+| Condition | Message |
+|-----------|---------|
+| Empty string | `"parse error: empty string"` |
+| Invalid character | `"parse error: invalid character"` |
+| Overflow | `"parse error: integer overflow"` |
+| Negative for unsigned | `"parse error: negative value for unsigned type"` |
+
+### String Consumption
+
+The intrinsics **borrow** the string rather than consuming it:
+
+```rue
+fn main() -> i32 {
+    let s = "42";
+    let n = @parse_i32(s);  // Borrows s
+    @dbg(s);                // s is still valid
+    @dbg(n);
+    0
+}
+```
+
+This is analogous to how `s.len()` borrows rather than consumes.
+
+### Runtime Implementation
+
+Add to the shared runtime (`lib.rs`):
+
+```rust
+/// Parse string as i32. Panics on invalid input or overflow.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rue_parse_i32(ptr: *const u8, len: u64) -> i32 {
+    // 1. Check for empty string
+    // 2. Check for leading '-'
+    // 3. Parse digits, checking for overflow
+    // 4. Panic on any error
+}
+
+/// Parse string as i64. Panics on invalid input or overflow.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rue_parse_i64(ptr: *const u8, len: u64) -> i64 { ... }
+
+/// Parse string as u32. Panics on invalid input, overflow, or negative.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rue_parse_u32(ptr: *const u8, len: u64) -> u32 { ... }
+
+/// Parse string as u64. Panics on invalid input, overflow, or negative.
+#[unsafe(no_mangle)]
+pub extern "C" fn __rue_parse_u64(ptr: *const u8, len: u64) -> u64 { ... }
+```
+
+Each function receives the string's pointer and length (extracted from the String fat pointer by codegen).
+
+### Codegen
+
+For `@parse_i32(s)`:
+
+1. Extract `ptr` and `len` from String `s`
+2. Call `__rue_parse_i32(ptr, len)`
+3. Return result in register
+
+The String is borrowed, so no drop is inserted for it (the caller retains ownership).
+
+## Implementation Phases
+
+### Phase 1: Runtime Parsing Functions
+
+- [ ] Add `__rue_parse_i64` to runtime (signed, 64-bit as base case)
+- [ ] Add `__rue_parse_u64` to runtime (unsigned, 64-bit)
+- [ ] Add `__rue_parse_i32` to runtime (delegates to i64, checks range)
+- [ ] Add `__rue_parse_u32` to runtime (delegates to u64, checks range)
+- [ ] Unit tests in Rust for all parsing functions
+- [ ] Test edge cases: empty, whitespace, overflow, negative
+
+### Phase 2: Intrinsics in Compiler
+
+- [ ] Add `@parse_i32`, `@parse_i64`, `@parse_u32`, `@parse_u64` to known intrinsics
+- [ ] Type check: one String argument, returns appropriate integer type
+- [ ] Mark String argument as borrowed (not consumed)
+- [ ] Lower to appropriate `__rue_parse_*` call in codegen
+- [ ] Extract ptr/len from String for call
+
+### Phase 3: Spec and Tests
+
+- [ ] Add parsing intrinsics to spec section 4.13 (Intrinsics)
+- [ ] Add spec tests for valid parsing
+- [ ] Add spec tests for panic cases (compile_fail with error_contains)
+- [ ] Document in language guide
+
+## Consequences
+
+### Positive
+
+- **Enables numeric input**: Complete the input→process→output cycle
+- **Clear semantics**: Panic on invalid input, no ambiguity
+- **Type-specific**: Each type has its own intrinsic, clear about range
+- **Non-consuming**: String can be reused after parsing
+
+### Negative
+
+- **Panics on invalid input**: Can't recover from user typos
+- **No whitespace tolerance**: Must trim before parsing
+- **Decimal only**: No hex, binary, octal support
+- **Four intrinsics**: Verbose compared to a generic `parse<T>`
+
+### Neutral
+
+- **Borrow semantics**: String is borrowed, matches query methods
+
+## Open Questions
+
+1. **Should we allow leading/trailing whitespace?**
+   - Current decision: No, be strict
+   - Alternative: Trim automatically (more forgiving)
+   - Recommendation: Stay strict, add `s.trim()` method later
+
+2. **Should we have `@parse_i8`, `@parse_u8`, etc.?**
+   - Current decision: Only 32-bit and 64-bit
+   - Can use `@intCast(@parse_i32(s))` for smaller types
+   - Add if there's demand
+
+3. **Naming: `@parse_i32` vs `@parseInt32` vs `@str_to_i32`?**
+   - `@parse_i32` follows Rust naming (`parse::<i32>()`)
+   - Consistent lowercase with underscores
+
+## Future Work
+
+- **`@try_parse_i32(s) -> ???`**: Non-panicking version (needs Result type)
+- **Radix support**: `@parse_i32_radix(s, 16)` for hex
+- **String methods**: `s.parse_i32()` as method
+- **Format intrinsic**: `@format("{}", n)` to convert integer to String
+- **Trimming**: `s.trim()` method to remove whitespace before parsing
+
+## References
+
+- [ADR-0021: Standard Input](0021-stdin-input.md) - Provides the input strings
+- [ADR-0014: Mutable Strings](0014-mutable-strings.md) - String type
+- [Rust str::parse](https://doc.rust-lang.org/std/primitive.str.html#method.parse) - Similar API
+- [Go strconv.Atoi](https://pkg.go.dev/strconv#Atoi) - Similar simple parsing


### PR DESCRIPTION
Reserve ADR numbers for upcoming I/O features:
- ADR-0021: @read_line() intrinsic for reading from stdin
- ADR-0022: @parse_i32/i64/u32/u64 intrinsics for string-to-int

🤖 Generated with [Claude Code](https://claude.com/claude-code)