### PR TITLE
Document builtin types architecture (Fixes rue-n20l)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,6 +93,7 @@ graph LR
 | `rue-target` | Target platform configuration |
 | `rue-spec` | Specification test runner |
 | `rue-runtime` | Runtime support |
+| `rue-builtins` | Built-in type definitions (String, future Vec, etc.) |
 
 ### Key Design Decisions
 
@@ -100,6 +101,31 @@ graph LR
 - **Index-based references**: Instructions stored in vectors, referenced by u32 indices (cache-friendly, no lifetimes)
 - **Direct code emission**: No LLVM dependency; machine code emitted directly
 - **Minimal ELF**: Static executables with direct syscalls (Linux x86-64 only)
+- **Built-in types as synthetic structs**: Types like `String` are defined in `rue-builtins` and injected as synthetic structs, not as hardcoded `Type` enum variants (see [ADR-0020](docs/designs/0020-builtin-types-as-structs.md))
+
+### Built-in Types Architecture
+
+Built-in types (currently just `String`, future `Vec<T>`, etc.) are implemented as "synthetic structs" — the compiler injects them before processing user code. This architecture:
+
+- **Eliminates special-casing**: Built-in types flow through the same code paths as user-defined structs
+- **Centralizes metadata**: All type information (fields, methods, operators) lives in `rue-builtins`
+- **Scales to new types**: Adding `Vec<T>` or `HashMap<K,V>` becomes "add an entry to `BUILTIN_TYPES`"
+
+**Key components:**
+
+| Component | Location | Purpose |
+|-----------|----------|---------|
+| Type definitions | `rue-builtins/src/lib.rs` | `BuiltinTypeDef` constants describing fields, methods, operators |
+| Injection point | `rue-air/src/sema.rs` | `inject_builtin_types()` creates synthetic `StructDef` entries |
+| Runtime functions | `rue-runtime/src/lib.rs` | Actual implementations (e.g., `String__len`, `__rue_drop_String`) |
+
+**Adding a new built-in type:**
+
+1. Define a `BuiltinTypeDef` in `rue-builtins/src/lib.rs`
+2. Add it to the `BUILTIN_TYPES` slice
+3. Implement runtime functions in `rue-runtime`
+
+See the module documentation in `rue-builtins` for a detailed example with hypothetical `Vec` type.
 
 ## Testing
 

--- a/crates/rue-builtins/src/lib.rs
+++ b/crates/rue-builtins/src/lib.rs
@@ -11,14 +11,128 @@
 //! flow through the same code paths as user-defined types, eliminating scattered
 //! special-case handling throughout the compiler.
 //!
+//! The injection happens in `Sema::inject_builtin_types()` during the declaration
+//! gathering phase. After injection:
+//!
+//! - The type is accessible by name (e.g., `String`)
+//! - Methods are registered and callable (e.g., `s.len()`)
+//! - Associated functions work (e.g., `String::new()`)
+//! - Operators are supported (e.g., `s1 == s2`)
+//! - Drop glue is automatically generated if `drop_fn` is set
+//!
 //! # Adding a New Built-in Type
 //!
-//! 1. Define a `BuiltinTypeDef` constant describing the type's fields, methods,
-//!    operators, and runtime functions.
-//! 2. Add it to the `BUILTIN_TYPES` slice.
-//! 3. Implement the runtime functions in `rue-runtime`.
+//! To add a new built-in type (e.g., `Vec<T>` when generics are available):
 //!
-//! See `STRING_TYPE` for an example.
+//! ## Step 1: Define the Type
+//!
+//! Create a `BuiltinTypeDef` constant describing the type's structure:
+//!
+//! ```rust,ignore
+//! pub static VEC_TYPE: BuiltinTypeDef = BuiltinTypeDef {
+//!     name: "Vec",  // How users refer to it in source code
+//!     fields: &[
+//!         BuiltinField { name: "ptr", ty: BuiltinFieldType::U64 },
+//!         BuiltinField { name: "len", ty: BuiltinFieldType::U64 },
+//!         BuiltinField { name: "cap", ty: BuiltinFieldType::U64 },
+//!     ],
+//!     is_copy: false,  // Vec owns heap memory, so it's a move type
+//!     drop_fn: Some("__rue_drop_Vec"),  // Runtime destructor
+//!     operators: &[
+//!         // Vec might support equality if elements do
+//!     ],
+//!     associated_fns: &[
+//!         BuiltinAssociatedFn {
+//!             name: "new",
+//!             params: &[],
+//!             return_ty: BuiltinReturnType::SelfType,
+//!             runtime_fn: "Vec__new",
+//!         },
+//!         BuiltinAssociatedFn {
+//!             name: "with_capacity",
+//!             params: &[BuiltinParam { name: "capacity", ty: BuiltinParamType::U64 }],
+//!             return_ty: BuiltinReturnType::SelfType,
+//!             runtime_fn: "Vec__with_capacity",
+//!         },
+//!     ],
+//!     methods: &[
+//!         BuiltinMethod {
+//!             name: "len",
+//!             receiver_mode: ReceiverMode::ByRef,
+//!             params: &[],
+//!             return_ty: BuiltinReturnType::U64,
+//!             runtime_fn: "Vec__len",
+//!         },
+//!         BuiltinMethod {
+//!             name: "push",
+//!             receiver_mode: ReceiverMode::ByMutRef,
+//!             params: &[BuiltinParam { name: "value", ty: BuiltinParamType::U64 }],
+//!             return_ty: BuiltinReturnType::SelfType,
+//!             runtime_fn: "Vec__push",
+//!         },
+//!         // ... more methods
+//!     ],
+//! };
+//! ```
+//!
+//! ## Step 2: Register the Type
+//!
+//! Add it to the `BUILTIN_TYPES` slice:
+//!
+//! ```rust,ignore
+//! pub static BUILTIN_TYPES: &[&BuiltinTypeDef] = &[
+//!     &STRING_TYPE,
+//!     &VEC_TYPE,  // Add new types here
+//! ];
+//! ```
+//!
+//! ## Step 3: Implement Runtime Functions
+//!
+//! In `rue-runtime`, implement the functions referenced in the type definition:
+//!
+//! ```rust,ignore
+//! // In rue-runtime/src/lib.rs or a new module
+//!
+//! #[unsafe(no_mangle)]
+//! pub extern "C" fn Vec__new(out: *mut u64) {
+//!     // Initialize empty Vec at `out` pointer
+//!     unsafe {
+//!         *out = 0;           // ptr = null
+//!         *out.add(1) = 0;    // len = 0
+//!         *out.add(2) = 0;    // cap = 0
+//!     }
+//! }
+//!
+//! #[unsafe(no_mangle)]
+//! pub extern "C" fn __rue_drop_Vec(ptr: *mut u64) {
+//!     // Free the Vec's heap allocation if any
+//!     unsafe {
+//!         let data_ptr = *ptr as *mut u8;
+//!         let cap = *ptr.add(2);
+//!         if cap > 0 {
+//!             __rue_free(data_ptr, cap as usize);
+//!         }
+//!     }
+//! }
+//! ```
+//!
+//! ## Naming Conventions
+//!
+//! - **Associated functions**: `TypeName__function_name` (e.g., `String__new`)
+//! - **Methods**: `TypeName__method_name` (e.g., `String__len`)
+//! - **Drop functions**: `__rue_drop_TypeName` (e.g., `__rue_drop_String`)
+//! - **Operators**: `__rue_typename_op` (e.g., `__rue_str_eq`)
+//!
+//! ## Key Types
+//!
+//! - [`BuiltinTypeDef`]: Complete definition of a built-in type
+//! - [`BuiltinField`]: A field in the struct layout
+//! - [`BuiltinMethod`]: An instance method (takes `self`)
+//! - [`BuiltinAssociatedFn`]: A static function (e.g., `Type::new()`)
+//! - [`BuiltinOperator`]: Operator overload (e.g., `==`, `!=`)
+//! - [`ReceiverMode`]: How `self` is passed to methods
+//!
+//! See [`STRING_TYPE`] for a complete working example.
 
 /// Binary operators that can be overloaded for built-in types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/docs/designs/0020-builtin-types-as-structs.md
+++ b/docs/designs/0020-builtin-types-as-structs.md
@@ -1,12 +1,12 @@
 ---
 id: 0020
 title: Built-in Types as Synthetic Structs
-status: proposal
+status: implemented
 tags: [architecture, types, refactoring, strings]
 feature-flag:
 created: 2025-12-31
-accepted:
-implemented:
+accepted: 2025-12-31
+implemented: 2025-12-31
 spec-sections: []
 superseded-by:
 ---
@@ -15,7 +15,7 @@ superseded-by:
 
 ## Status
 
-Proposal
+Implemented
 
 ## Summary
 


### PR DESCRIPTION
Added comprehensive documentation for the rue-builtins crate:
- Expanded module docs with Vec type example showing full implementation
- Added naming conventions and key types reference
- Updated CLAUDE.md with Built-in Types Architecture section
- Updated ADR-0020 status to Implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)