### PR TITLE
Add @read_line intrinsic for stdin input (ADR-0021)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -528,6 +528,18 @@ impl<'a> ConstraintGenerator<'a> {
                     // Return type is inferred from context - create a fresh type variable
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
+                } else if intrinsic_name == "read_line" {
+                    // @read_line: returns String (same as string constants)
+                    if let Some(string_spur) = self.interner.get("String") {
+                        if let Some(&string_ty) = self.structs.get(&string_spur) {
+                            InferType::Concrete(string_ty)
+                        } else {
+                            // Fallback if String struct not found
+                            InferType::Concrete(Type::Error)
+                        }
+                    } else {
+                        InferType::Concrete(Type::Error)
+                    }
                 } else {
                     // Generate constraints for arguments (they need to be processed)
                     for arg_ref in args.iter() {

--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -4738,6 +4738,38 @@ impl<'a> Sema<'a> {
                         });
                         Ok(AnalysisResult::new(air_ref, Type::Unit))
                     }
+                    "read_line" => {
+                        // @read_line() - reads a line from stdin and returns it as a String.
+                        // Takes no arguments, returns String.
+                        // Panics on EOF with no data or on I/O error.
+
+                        // Takes no arguments
+                        if !args.is_empty() {
+                            return Err(CompileError::new(
+                                ErrorKind::IntrinsicWrongArgCount {
+                                    name: intrinsic_name_str.to_string(),
+                                    expected: 0,
+                                    found: args.len(),
+                                },
+                                inst.span,
+                            ));
+                        }
+
+                        // Get the String type
+                        let string_type = self.builtin_string_type();
+
+                        // Create the intrinsic instruction that returns String
+                        let air_ref = air.add_inst(AirInst {
+                            data: AirInstData::Intrinsic {
+                                name: *name,
+                                args_start: 0, // No args
+                                args_len: 0,
+                            },
+                            ty: string_type,
+                            span: inst.span,
+                        });
+                        Ok(AnalysisResult::new(air_ref, string_type))
+                    }
                     _ => Err(CompileError::new(
                         ErrorKind::UnknownIntrinsic(intrinsic_name_str.to_string()),
                         inst.span,

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1831,7 +1831,58 @@ impl<'a> CfgLower<'a> {
                 args_len,
             } => {
                 let name_str = self.interner.resolve(name);
-                if name_str == "dbg" {
+                if name_str == "read_line" {
+                    // @read_line() intrinsic - reads a line from stdin and returns String.
+                    // Uses sret convention: allocate space on stack for the result (ptr, len, cap).
+
+                    // Allocate 32 bytes on stack for sret (24 bytes for String + 8 for alignment)
+                    self.mir.push(Aarch64Inst::SubImm {
+                        dst: Operand::Physical(Reg::Sp),
+                        src: Operand::Physical(Reg::Sp),
+                        imm: 32,
+                    });
+
+                    // Move SP (pointer to sret space) to X0 as first argument
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Physical(Reg::X0),
+                        src: Operand::Physical(Reg::Sp),
+                    });
+
+                    // Call __rue_read_line
+                    let symbol_id = self.intern_symbol("__rue_read_line");
+                    self.mir.push(Aarch64Inst::Bl { symbol_id });
+
+                    // Load ptr, len, cap from stack into vregs
+                    let mut slot_vregs = Vec::new();
+                    for slot_idx in 0..3 {
+                        let slot_vreg = self.mir.alloc_vreg();
+                        let offset = (slot_idx * 8) as i32;
+                        self.mir.push(Aarch64Inst::Ldr {
+                            dst: Operand::Virtual(slot_vreg),
+                            base: Reg::Sp,
+                            offset,
+                        });
+                        slot_vregs.push(slot_vreg);
+                    }
+
+                    // Pop the sret space
+                    self.mir.push(Aarch64Inst::AddImm {
+                        dst: Operand::Physical(Reg::Sp),
+                        src: Operand::Physical(Reg::Sp),
+                        imm: 32,
+                    });
+
+                    // Store the slot vregs for the String value
+                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
+
+                    // Create a result vreg (for the primary value representation)
+                    let result_vreg = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(result_vreg),
+                        src: Operand::Virtual(slot_vregs[0]),
+                    });
+                    self.value_map.insert(value, result_vreg);
+                } else if name_str == "dbg" {
                     let args = self.cfg.get_extra(*args_start, *args_len);
                     let arg_val = args[0];
                     let arg_type = self.cfg.get_inst(arg_val).ty;

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1952,7 +1952,57 @@ impl<'a> CfgLower<'a> {
                 args_len,
             } => {
                 let name_str = self.interner.resolve(name);
-                if name_str == "dbg" {
+                if name_str == "read_line" {
+                    // @read_line() intrinsic - reads a line from stdin and returns String.
+                    // Uses sret convention: allocate space on stack for the result (ptr, len, cap).
+
+                    // Allocate 32 bytes on stack for sret (24 bytes for String + 8 for alignment)
+                    // Use AddRI with negative immediate (no SubRI in MIR)
+                    self.mir.push(X86Inst::AddRI {
+                        dst: Operand::Physical(Reg::Rsp),
+                        imm: -32,
+                    });
+
+                    // Move RSP (pointer to sret space) to RDI as first argument
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(Reg::Rdi),
+                        src: Operand::Physical(Reg::Rsp),
+                    });
+
+                    // Call __rue_read_line
+                    let symbol_id = self.intern_symbol("__rue_read_line");
+                    self.mir.push(X86Inst::CallRel { symbol_id });
+
+                    // Load ptr, len, cap from stack into vregs
+                    let mut slot_vregs = Vec::new();
+                    for slot_idx in 0..3 {
+                        let slot_vreg = self.mir.alloc_vreg();
+                        let offset = (slot_idx * 8) as i32;
+                        self.mir.push(X86Inst::MovRM {
+                            dst: Operand::Virtual(slot_vreg),
+                            base: Reg::Rsp,
+                            offset,
+                        });
+                        slot_vregs.push(slot_vreg);
+                    }
+
+                    // Pop the sret space
+                    self.mir.push(X86Inst::AddRI {
+                        dst: Operand::Physical(Reg::Rsp),
+                        imm: 32,
+                    });
+
+                    // Store the slot vregs for the String value
+                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
+
+                    // Create a result vreg (for the primary value representation)
+                    let result_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(result_vreg),
+                        src: Operand::Virtual(slot_vregs[0]),
+                    });
+                    self.value_map.insert(value, result_vreg);
+                } else if name_str == "dbg" {
                     let args = self.cfg.get_extra(*args_start, *args_len);
                     let arg_val = args[0];
                     let arg_type = self.cfg.get_inst(arg_val).ty;

--- a/crates/rue-runtime/src/aarch64_linux.rs
+++ b/crates/rue-runtime/src/aarch64_linux.rs
@@ -27,11 +27,14 @@ compile_error!("aarch64_linux module only supports aarch64 Linux");
 
 use core::arch::asm;
 
-/// Linux aarch64 syscall number for exit (from asm-generic/unistd.h).
-const SYS_EXIT: u64 = 93;
+/// Linux aarch64 syscall number for read (from asm-generic/unistd.h).
+const SYS_READ: u64 = 63;
 
 /// Linux aarch64 syscall number for write (from asm-generic/unistd.h).
 const SYS_WRITE: u64 = 64;
+
+/// Linux aarch64 syscall number for exit (from asm-generic/unistd.h).
+const SYS_EXIT: u64 = 93;
 
 /// Linux aarch64 syscall number for mmap (from asm-generic/unistd.h).
 const SYS_MMAP: u64 = 222;
@@ -39,11 +42,14 @@ const SYS_MMAP: u64 = 222;
 /// Linux aarch64 syscall number for munmap (from asm-generic/unistd.h).
 const SYS_MUNMAP: u64 = 215;
 
-/// Standard error file descriptor.
-const STDERR: u64 = 2;
+/// Standard input file descriptor.
+pub const STDIN: u64 = 0;
 
 /// Standard output file descriptor.
-const STDOUT: u64 = 1;
+pub const STDOUT: u64 = 1;
+
+/// Standard error file descriptor.
+pub const STDERR: u64 = 2;
 
 /// Write bytes to a file descriptor.
 ///
@@ -76,6 +82,45 @@ pub fn write(fd: u64, buf: *const u8, len: usize) -> i64 {
         asm!(
             "svc #0",
             in("x8") SYS_WRITE,
+            inlateout("x0") fd as i64 => result,
+            in("x1") buf,
+            in("x2") len,
+        );
+    }
+
+    result
+}
+
+/// Read bytes from a file descriptor.
+///
+/// This is a thin wrapper around the Linux `read(2)` syscall.
+///
+/// # Arguments
+///
+/// * `fd` - File descriptor to read from
+/// * `buf` - Pointer to the buffer to read data into
+/// * `len` - Maximum number of bytes to read
+///
+/// # Returns
+///
+/// On success, returns the number of bytes read (0 indicates end-of-file).
+///
+/// On error, returns a negative value representing `-errno`.
+///
+/// # Safety
+///
+/// The caller must ensure:
+/// - `buf` points to a valid, writable memory region of at least `len` bytes
+/// - The memory region remains valid for the duration of the syscall
+pub fn read(fd: u64, buf: *mut u8, len: usize) -> i64 {
+    let result: i64;
+
+    // SAFETY: We're making a syscall with the provided arguments.
+    // The caller is responsible for ensuring buf/len are valid.
+    unsafe {
+        asm!(
+            "svc #0",
+            in("x8") SYS_READ,
             inlateout("x0") fd as i64 => result,
             in("x1") buf,
             in("x2") len,
@@ -358,12 +403,33 @@ mod tests {
     #[test]
     fn test_syscall_constants() {
         // Verify our syscall numbers match Linux aarch64
-        assert_eq!(SYS_EXIT, 93);
+        assert_eq!(SYS_READ, 63);
         assert_eq!(SYS_WRITE, 64);
+        assert_eq!(SYS_EXIT, 93);
         assert_eq!(SYS_MMAP, 222);
         assert_eq!(SYS_MUNMAP, 215);
-        assert_eq!(STDERR, 2);
+        assert_eq!(STDIN, 0);
         assert_eq!(STDOUT, 1);
+        assert_eq!(STDERR, 2);
+    }
+
+    #[test]
+    fn test_read_invalid_fd() {
+        // Reading from an invalid fd should return an error
+        let mut buf = [0u8; 16];
+        let result = read(999, buf.as_mut_ptr(), buf.len());
+        // Should return -EBADF (9) for bad file descriptor
+        assert!(result < 0);
+        assert_eq!(-result, 9); // EBADF
+    }
+
+    #[test]
+    fn test_read_zero_bytes() {
+        // Reading zero bytes should succeed and return 0
+        let mut buf = [0u8; 16];
+        // Use stdin (fd 0) - reading 0 bytes should always succeed
+        let result = read(STDIN, buf.as_mut_ptr(), 0);
+        assert_eq!(result, 0);
     }
 
     #[test]

--- a/crates/rue-runtime/src/aarch64_macos.rs
+++ b/crates/rue-runtime/src/aarch64_macos.rs
@@ -31,6 +31,9 @@ use core::arch::asm;
 /// macOS syscall number for exit (SYS_exit).
 const SYS_EXIT: u64 = 1;
 
+/// macOS syscall number for read (SYS_read).
+const SYS_READ: u64 = 3;
+
 /// macOS syscall number for write (SYS_write).
 const SYS_WRITE: u64 = 4;
 
@@ -40,11 +43,14 @@ const SYS_MMAP: u64 = 197;
 /// macOS syscall number for munmap (SYS_munmap).
 const SYS_MUNMAP: u64 = 73;
 
-/// Standard error file descriptor.
-const STDERR: u64 = 2;
+/// Standard input file descriptor.
+pub const STDIN: u64 = 0;
 
 /// Standard output file descriptor.
-const STDOUT: u64 = 1;
+pub const STDOUT: u64 = 1;
+
+/// Standard error file descriptor.
+pub const STDERR: u64 = 2;
 
 /// Write bytes to a file descriptor.
 ///
@@ -80,6 +86,53 @@ pub fn write(fd: u64, buf: *const u8, len: usize) -> i64 {
             // Check carry flag for error
             "cset {err}, cs",
             inlateout("x16") SYS_WRITE => _,
+            in("x0") fd,
+            in("x1") buf,
+            in("x2") len,
+            lateout("x0") result,
+            err = out(reg) err_flag,
+            // x17 may be clobbered by the syscall
+            out("x17") _,
+        );
+    }
+
+    // If carry flag was set, result is errno (positive), negate it
+    if err_flag != 0 { -result } else { result }
+}
+
+/// Read bytes from a file descriptor.
+///
+/// This is a thin wrapper around the macOS `read(2)` syscall.
+///
+/// # Arguments
+///
+/// * `fd` - File descriptor to read from
+/// * `buf` - Pointer to the buffer to read data into
+/// * `len` - Maximum number of bytes to read
+///
+/// # Returns
+///
+/// On success, returns the number of bytes read (0 indicates end-of-file).
+///
+/// On error, returns a negative value representing `-errno`.
+///
+/// # Safety
+///
+/// The caller must ensure:
+/// - `buf` points to a valid, writable memory region of at least `len` bytes
+/// - The memory region remains valid for the duration of the syscall
+pub fn read(fd: u64, buf: *mut u8, len: usize) -> i64 {
+    let result: i64;
+    let err_flag: u64;
+
+    // SAFETY: We're making a syscall with the provided arguments.
+    // The caller is responsible for ensuring buf/len are valid.
+    unsafe {
+        asm!(
+            "svc #0x80",
+            // Check carry flag for error
+            "cset {err}, cs",
+            inlateout("x16") SYS_READ => _,
             in("x0") fd,
             in("x1") buf,
             in("x2") len,
@@ -383,11 +436,32 @@ mod tests {
     fn test_syscall_constants() {
         // Verify our syscall numbers match macOS
         assert_eq!(SYS_EXIT, 1);
+        assert_eq!(SYS_READ, 3);
         assert_eq!(SYS_WRITE, 4);
         assert_eq!(SYS_MMAP, 197);
         assert_eq!(SYS_MUNMAP, 73);
-        assert_eq!(STDERR, 2);
+        assert_eq!(STDIN, 0);
         assert_eq!(STDOUT, 1);
+        assert_eq!(STDERR, 2);
+    }
+
+    #[test]
+    fn test_read_invalid_fd() {
+        // Reading from an invalid fd should return an error
+        let mut buf = [0u8; 16];
+        let result = read(999, buf.as_mut_ptr(), buf.len());
+        // Should return -EBADF (9) for bad file descriptor
+        assert!(result < 0);
+        assert_eq!(-result, 9); // EBADF
+    }
+
+    #[test]
+    fn test_read_zero_bytes() {
+        // Reading zero bytes should succeed and return 0
+        let mut buf = [0u8; 16];
+        // Use stdin (fd 0) - reading 0 bytes should always succeed
+        let result = read(STDIN, buf.as_mut_ptr(), 0);
+        assert_eq!(result, 0);
     }
 
     #[test]

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -1622,6 +1622,142 @@ fn string_ensure_capacity(ptr: *mut u8, len: u64, cap: u64, additional: u64) -> 
     }
 }
 
+// =============================================================================
+// Input Functions
+// =============================================================================
+
+/// Initial buffer size for reading lines.
+/// This is a reasonable size for most interactive input.
+const READ_LINE_INITIAL_CAPACITY: u64 = 128;
+
+/// Read a line from standard input.
+///
+/// Reads bytes from stdin (file descriptor 0) until a newline character (`\n`)
+/// is encountered or EOF is reached. Returns the line as a String (excluding
+/// the trailing newline).
+///
+/// # Returns
+///
+/// Returns the string data via sret convention. Writes to `out`:
+/// - ptr: Pointer to the string data (heap-allocated)
+/// - len: Length of the string in bytes (excluding newline)
+/// - cap: Capacity of the allocated buffer
+///
+/// # Panics
+///
+/// - If EOF is reached with no data read: panics with "unexpected end of input"
+/// - If a read error occurs: panics with "input error"
+///
+/// # ABI (sret convention)
+///
+/// ```text
+/// extern "C" fn __rue_read_line(out: *mut StringResult)
+/// ```
+///
+/// Caller allocates space for the return value and passes pointer.
+#[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn __rue_read_line(out: *mut StringResult) {
+    read_line_impl(out);
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn __rue_read_line(out: *mut StringResult) {
+    read_line_impl(out);
+}
+
+#[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+#[unsafe(no_mangle)]
+#[allow(non_snake_case)]
+pub extern "C" fn __rue_read_line(out: *mut StringResult) {
+    read_line_impl(out);
+}
+
+/// Implementation of read_line shared across platforms.
+///
+/// This function reads from stdin byte-by-byte until:
+/// - A newline character is found (returns line without the newline)
+/// - EOF is reached with some data (returns partial line)
+/// - EOF is reached with no data (panics)
+/// - A read error occurs (panics)
+#[inline]
+fn read_line_impl(out: *mut StringResult) {
+    // Allocate initial buffer
+    let mut cap = READ_LINE_INITIAL_CAPACITY;
+    let mut ptr = heap::alloc(cap, 1);
+    if ptr.is_null() {
+        // Allocation failed - panic
+        platform::write_stderr(b"error: out of memory\n");
+        platform::exit(101);
+    }
+
+    let mut len: u64 = 0;
+    let mut byte_buf = [0u8; 1];
+
+    loop {
+        // Read one byte at a time
+        let result = platform::read(platform::STDIN, byte_buf.as_mut_ptr(), 1);
+
+        if result < 0 {
+            // Read error - free buffer and panic
+            heap::free(ptr, cap, 1);
+            platform::write_stderr(b"error: input error\n");
+            platform::exit(101);
+        }
+
+        if result == 0 {
+            // EOF reached
+            if len == 0 {
+                // EOF with no data - free buffer and panic
+                heap::free(ptr, cap, 1);
+                platform::write_stderr(b"error: unexpected end of input\n");
+                platform::exit(101);
+            }
+            // EOF with data - return partial line
+            break;
+        }
+
+        // Got a byte
+        let byte = byte_buf[0];
+
+        // Check for newline - line is complete (don't include the newline)
+        if byte == b'\n' {
+            break;
+        }
+
+        // Need to store this byte - ensure we have capacity
+        if len >= cap {
+            // Grow the buffer (2x strategy)
+            let new_cap = cap.saturating_mul(2).max(STRING_MIN_CAPACITY);
+            let new_ptr = heap::realloc(ptr, cap, new_cap, 1);
+            if new_ptr.is_null() {
+                // Realloc failed - free old buffer and panic
+                heap::free(ptr, cap, 1);
+                platform::write_stderr(b"error: out of memory\n");
+                platform::exit(101);
+            }
+            ptr = new_ptr;
+            cap = new_cap;
+        }
+
+        // Store the byte
+        unsafe {
+            *ptr.add(len as usize) = byte;
+        }
+        len += 1;
+    }
+
+    // Return the string
+    unsafe {
+        (*out).ptr = ptr;
+        (*out).len = len;
+        (*out).cap = cap;
+    }
+}
+
 // Re-export platform functions for tests
 #[cfg(all(test, target_arch = "x86_64", target_os = "linux"))]
 pub use x86_64_linux::{exit, write, write_all, write_stderr};

--- a/crates/rue-runtime/src/x86_64_linux.rs
+++ b/crates/rue-runtime/src/x86_64_linux.rs
@@ -27,6 +27,9 @@ compile_error!("rue-runtime only supports x86-64 Linux");
 
 use core::arch::asm;
 
+/// Linux syscall number for read (see `man 2 read`).
+const SYS_READ: i64 = 0;
+
 /// Linux syscall number for write (see `man 2 write`).
 const SYS_WRITE: i64 = 1;
 
@@ -39,11 +42,14 @@ const SYS_MUNMAP: i64 = 11;
 /// Linux syscall number for exit (see `man 2 exit`).
 const SYS_EXIT: i64 = 60;
 
-/// Standard error file descriptor.
-const STDERR: u64 = 2;
+/// Standard input file descriptor.
+pub const STDIN: u64 = 0;
 
 /// Standard output file descriptor.
-const STDOUT: u64 = 1;
+pub const STDOUT: u64 = 1;
+
+/// Standard error file descriptor.
+pub const STDERR: u64 = 2;
 
 /// Write bytes to a file descriptor.
 ///
@@ -81,6 +87,47 @@ pub fn write(fd: u64, buf: *const u8, len: usize) -> i64 {
         asm!(
             "syscall",
             in("rax") SYS_WRITE,
+            in("rdi") fd,
+            in("rsi") buf,
+            in("rdx") len,
+            lateout("rax") result,
+            // syscall clobbers rcx and r11 per x86-64 ABI
+            out("rcx") _,
+            out("r11") _,
+        );
+    }
+    result
+}
+
+/// Read bytes from a file descriptor.
+///
+/// This is a thin wrapper around the Linux `read(2)` syscall.
+///
+/// # Arguments
+///
+/// * `fd` - File descriptor to read from
+/// * `buf` - Pointer to the buffer to read data into
+/// * `len` - Maximum number of bytes to read
+///
+/// # Returns
+///
+/// On success, returns the number of bytes read (0 indicates end-of-file).
+///
+/// On error, returns a negative value representing `-errno`.
+///
+/// # Safety
+///
+/// The caller must ensure:
+/// - `buf` points to a valid, writable memory region of at least `len` bytes
+/// - The memory region remains valid for the duration of the syscall
+pub fn read(fd: u64, buf: *mut u8, len: usize) -> i64 {
+    let result: i64;
+    // SAFETY: We're making a syscall with the provided arguments.
+    // The caller is responsible for ensuring buf/len are valid.
+    unsafe {
+        asm!(
+            "syscall",
+            in("rax") SYS_READ,
             in("rdi") fd,
             in("rsi") buf,
             in("rdx") len,
@@ -444,11 +491,33 @@ mod tests {
     #[test]
     fn test_syscall_constants() {
         // Verify our syscall numbers match Linux x86-64 ABI
+        assert_eq!(SYS_READ, 0);
         assert_eq!(SYS_WRITE, 1);
         assert_eq!(SYS_MMAP, 9);
         assert_eq!(SYS_MUNMAP, 11);
         assert_eq!(SYS_EXIT, 60);
+        assert_eq!(STDIN, 0);
+        assert_eq!(STDOUT, 1);
         assert_eq!(STDERR, 2);
+    }
+
+    #[test]
+    fn test_read_invalid_fd() {
+        // Reading from an invalid fd should return an error
+        let mut buf = [0u8; 16];
+        let result = read(999, buf.as_mut_ptr(), buf.len());
+        // Should return -EBADF (9) for bad file descriptor
+        assert!(result < 0);
+        assert_eq!(-result, 9); // EBADF
+    }
+
+    #[test]
+    fn test_read_zero_bytes() {
+        // Reading zero bytes should succeed and return 0
+        let mut buf = [0u8; 16];
+        // Use stdin (fd 0) - reading 0 bytes should always succeed
+        let result = read(STDIN, buf.as_mut_ptr(), 0);
+        assert_eq!(result, 0);
     }
 
     #[test]

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -527,3 +527,153 @@ fn main() -> i32 {
 """
 exit_code = 101
 stderr_contains = "integer cast overflow"
+
+# =============================================================================
+# @read_line Intrinsic
+# =============================================================================
+
+[[case]]
+name = "read_line_returns_string"
+spec = ["4.13:33", "4.13:35"]
+source = """
+fn takes_string(s: String) -> i32 { 0 }
+fn main() -> i32 {
+    // Type checking: @read_line returns String
+    let line: String = @read_line();
+    takes_string(@read_line())
+}
+"""
+# This test will hang waiting for stdin input, so we use compile_only=true
+# to verify it compiles, but don't actually run it
+compile_only = true
+
+[[case]]
+name = "read_line_no_args"
+spec = ["4.13:34"]
+source = """
+fn main() -> i32 {
+    // Verify @read_line takes no arguments
+    let line: String = @read_line();
+    0
+}
+"""
+compile_only = true
+
+[[case]]
+name = "read_line_wrong_arg_count_one"
+spec = ["4.13:4", "4.13:34"]
+source = """
+fn main() -> i32 {
+    let line: String = @read_line(42);
+    0
+}
+"""
+compile_fail = true
+error_contains = "argument"
+
+[[case]]
+name = "read_line_wrong_arg_count_two"
+spec = ["4.13:4", "4.13:34"]
+source = """
+fn main() -> i32 {
+    let line: String = @read_line(1, 2);
+    0
+}
+"""
+compile_fail = true
+error_contains = "argument"
+
+# =============================================================================
+# @read_line Runtime Behavior
+# =============================================================================
+
+[[case]]
+name = "read_line_basic_input"
+spec = ["4.13:33", "4.13:36", "4.13:37"]
+source = """
+fn main() -> i32 {
+    let line = @read_line();
+    @dbg(line);
+    0
+}
+"""
+stdin = "Hello World\n"
+expected_stdout = "Hello World"
+exit_code = 0
+
+[[case]]
+name = "read_line_strips_newline"
+spec = ["4.13:37"]
+source = """
+fn main() -> i32 {
+    let line = @read_line();
+    @dbg(line);
+    0
+}
+"""
+stdin = "test\n"
+expected_stdout = "test"
+exit_code = 0
+
+[[case]]
+name = "read_line_multiple_lines"
+spec = ["4.13:36"]
+source = """
+fn main() -> i32 {
+    let line1 = @read_line();
+    let line2 = @read_line();
+    @dbg(line1);
+    @dbg(line2);
+    0
+}
+"""
+stdin = "first\nsecond\n"
+expected_stdout = """
+first
+second
+"""
+exit_code = 0
+
+[[case]]
+name = "read_line_partial_line_at_eof"
+spec = ["4.13:38"]
+source = """
+fn main() -> i32 {
+    let line = @read_line();
+    @dbg(line);
+    0
+}
+"""
+# No trailing newline - should still return the partial line
+stdin = "partial"
+expected_stdout = "partial"
+exit_code = 0
+
+[[case]]
+name = "read_line_empty_line"
+spec = ["4.13:36", "4.13:37"]
+source = """
+fn main() -> i32 {
+    let line = @read_line();
+    @dbg(line);
+    0
+}
+"""
+# Just a newline - should return empty string
+stdin = "\n"
+expected_stdout = ""
+exit_code = 0
+
+[[case]]
+name = "read_line_eof_no_data_panics"
+spec = ["4.13:39"]
+source = """
+fn main() -> i32 {
+    let line = @read_line();
+    0
+}
+"""
+# Empty stdin - should panic
+stdin = ""
+exit_code = 101
+stderr_contains = "unexpected end of input"

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -139,6 +139,16 @@ pub struct Case {
     /// If the test exceeds this timeout, it will be killed and marked as failed.
     #[serde(default)]
     pub timeout_ms: Option<u64>,
+    /// Input to provide to the program's stdin during execution.
+    /// This is useful for testing programs that read from stdin (e.g., @read_line).
+    /// The input is piped to the program before execution starts.
+    #[serde(default)]
+    pub stdin: Option<String>,
+    /// Expected stderr output (substring match).
+    /// For runtime errors, use `runtime_error` instead. This field is for
+    /// checking stderr content in successful runs (e.g., panic messages).
+    #[serde(default)]
+    pub stderr_contains: Option<String>,
     /// Parameter sets for generating multiple test instances from a template.
     /// When present, this case is expanded into multiple cases, one per param set.
     /// Template placeholders like `{type}` in `source` and `name` are substituted.
@@ -209,6 +219,14 @@ pub fn expand_case(case: Case) -> Vec<Case> {
                     .map(|s| substitute_placeholders(s, params)),
                 expected_stdout: case
                     .expected_stdout
+                    .as_ref()
+                    .map(|s| substitute_placeholders(s, params)),
+                stdin: case
+                    .stdin
+                    .as_ref()
+                    .map(|s| substitute_placeholders(s, params)),
+                stderr_contains: case
+                    .stderr_contains
                     .as_ref()
                     .map(|s| substitute_placeholders(s, params)),
 
@@ -495,24 +513,44 @@ fn read_all_bytes<R: IoRead>(mut reader: R) -> Vec<u8> {
     bytes
 }
 
-/// Run a command with a timeout.
+/// Run a command with a timeout and optional stdin input.
 ///
-/// This function spawns a child process and polls for completion,
-/// killing the process if it exceeds the specified timeout.
+/// This function spawns a child process, writes to its stdin if provided,
+/// and polls for completion, killing the process if it exceeds the specified timeout.
 ///
 /// # Arguments
 /// * `cmd` - The command to run (already configured with arguments)
 /// * `timeout` - Maximum duration to wait for the process to complete
+/// * `stdin_input` - Optional input to write to the process's stdin
 ///
 /// # Returns
 /// * `Ok(Output)` - The process output (stdout, stderr, exit status)
 /// * `Err(String)` - Error message if the process timed out or failed to start
-fn run_with_timeout(mut cmd: Command, timeout: Duration) -> Result<Output, String> {
+fn run_with_timeout(
+    mut cmd: Command,
+    timeout: Duration,
+    stdin_input: Option<&str>,
+) -> Result<Output, String> {
     let mut child = cmd
+        .stdin(if stdin_input.is_some() {
+            Stdio::piped()
+        } else {
+            Stdio::null()
+        })
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| format!("Failed to spawn process: {}", e))?;
+
+    // Write stdin input if provided
+    if let Some(input) = stdin_input {
+        if let Some(mut stdin) = child.stdin.take() {
+            stdin
+                .write_all(input.as_bytes())
+                .map_err(|e| format!("Failed to write stdin: {}", e))?;
+            // Closing stdin signals EOF to the child process
+        }
+    }
 
     let start = Instant::now();
 
@@ -715,9 +753,9 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         return Ok(());
     }
 
-    // Run the compiled binary with timeout
+    // Run the compiled binary with timeout and optional stdin
     let timeout = Duration::from_millis(case.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS));
-    let run_output = run_with_timeout(Command::new(&output_path), timeout)?;
+    let run_output = run_with_timeout(Command::new(&output_path), timeout, case.stdin.as_deref())?;
 
     let actual_exit_code = run_output.status.code().unwrap_or(-1);
     let stderr = String::from_utf8_lossy(&run_output.stderr);
@@ -754,6 +792,16 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
             return Err(format!(
                 "Stdout mismatch:\n--- expected ---\n{}\n--- actual ---\n{}\n  source: {}",
                 expected_normalized, actual_normalized, case.source
+            ));
+        }
+    }
+
+    // Check stderr contains expected substring (for non-error cases)
+    if let Some(ref expected) = case.stderr_contains {
+        if !stderr.contains(expected.as_str()) {
+            return Err(format!(
+                "Stderr mismatch:\n  expected to contain: {}\n  actual stderr: {}\n  source: {}",
+                expected, stderr, case.source
             ));
         }
     }
@@ -908,6 +956,8 @@ mod tests {
             target: None,
             opt_level: None,
             timeout_ms: None,
+            stdin: None,
+            stderr_contains: None,
             params: vec![],
         };
 
@@ -953,6 +1003,8 @@ mod tests {
             target: None,
             opt_level: None,
             timeout_ms: None,
+            stdin: None,
+            stderr_contains: None,
             params: vec![ParamSet { values: param1 }, ParamSet { values: param2 }],
         };
 
@@ -1006,6 +1058,8 @@ mod tests {
             target: None,
             opt_level: None,
             timeout_ms: None,
+            stdin: None,
+            stderr_contains: None,
             params: vec![ParamSet { values: params }],
         };
 
@@ -1051,6 +1105,8 @@ mod tests {
             target: None,
             opt_level: None,
             timeout_ms: None,
+            stdin: None,
+            stderr_contains: None,
             params: vec![ParamSet { values: params }],
         };
 
@@ -1258,7 +1314,7 @@ mod tests {
     fn test_run_with_timeout_completes_normally() {
         // A simple command that completes quickly
         let cmd = Command::new("echo");
-        let result = run_with_timeout(cmd, Duration::from_secs(5));
+        let result = run_with_timeout(cmd, Duration::from_secs(5), None);
         assert!(result.is_ok());
         let output = result.unwrap();
         assert!(output.status.success());
@@ -1268,7 +1324,7 @@ mod tests {
     fn test_run_with_timeout_captures_stdout() {
         let mut cmd = Command::new("echo");
         cmd.arg("hello");
-        let result = run_with_timeout(cmd, Duration::from_secs(5));
+        let result = run_with_timeout(cmd, Duration::from_secs(5), None);
         assert!(result.is_ok());
         let output = result.unwrap();
         let stdout = String::from_utf8_lossy(&output.stdout);
@@ -1280,7 +1336,7 @@ mod tests {
         // Sleep for 10 seconds but timeout after 100ms
         let mut cmd = Command::new("sleep");
         cmd.arg("10");
-        let result = run_with_timeout(cmd, Duration::from_millis(100));
+        let result = run_with_timeout(cmd, Duration::from_millis(100), None);
 
         assert!(result.is_err());
         let err = result.unwrap_err();
@@ -1296,9 +1352,31 @@ mod tests {
         // Use a command that exits with a non-zero status
         let mut cmd = Command::new("sh");
         cmd.arg("-c").arg("exit 42");
-        let result = run_with_timeout(cmd, Duration::from_secs(5));
+        let result = run_with_timeout(cmd, Duration::from_secs(5), None);
         assert!(result.is_ok());
         let output = result.unwrap();
         assert_eq!(output.status.code(), Some(42));
+    }
+
+    #[test]
+    fn test_run_with_timeout_pipes_stdin() {
+        // Use cat to echo back stdin
+        let cmd = Command::new("cat");
+        let result = run_with_timeout(cmd, Duration::from_secs(5), Some("hello from stdin"));
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(stdout, "hello from stdin");
+    }
+
+    #[test]
+    fn test_run_with_timeout_stdin_with_newlines() {
+        // Use cat to echo back stdin with newlines
+        let cmd = Command::new("cat");
+        let result = run_with_timeout(cmd, Duration::from_secs(5), Some("line1\nline2\n"));
+        assert!(result.is_ok());
+        let output = result.unwrap();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        assert_eq!(stdout, "line1\nline2\n");
     }
 }

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -215,3 +215,63 @@ fn main() -> i32 {
     0
 }
 ```
+
+## `@read_line`
+
+{{ rule(id="4.13:33", cat="normative") }}
+
+The `@read_line` intrinsic reads a line of text from standard input.
+
+{{ rule(id="4.13:34", cat="normative") }}
+
+`@read_line` accepts no arguments.
+
+{{ rule(id="4.13:35", cat="normative") }}
+
+The return type of `@read_line` is `String`.
+
+{{ rule(id="4.13:36", cat="dynamic-semantics") }}
+
+`@read_line` reads bytes from standard input until a newline character (`\n`) is encountered or end-of-file is reached.
+
+{{ rule(id="4.13:37", cat="dynamic-semantics") }}
+
+The returned `String` does **not** include the trailing newline character.
+
+{{ rule(id="4.13:38", cat="dynamic-semantics") }}
+
+If end-of-file is reached with some data read, the partial line is returned.
+
+{{ rule(id="4.13:39", cat="dynamic-semantics") }}
+
+If end-of-file is reached with no data read, a runtime panic occurs with the message "unexpected end of input".
+
+{{ rule(id="4.13:40", cat="informative") }}
+
+If a read error occurs, a runtime panic occurs with the message "input error". (This behavior is documented but not tested, as I/O errors cannot be reliably simulated in portable test environments.)
+
+{{ rule(id="4.13:41") }}
+
+```rue
+fn main() -> i32 {
+    @dbg("What is your name?");
+    let name = @read_line();
+    @dbg("Hello, ");
+    @dbg(name);
+    0
+}
+```
+
+{{ rule(id="4.13:42") }}
+
+Reading multiple lines:
+
+```rue
+fn main() -> i32 {
+    let line1 = @read_line();  // First line
+    let line2 = @read_line();  // Second line
+    @dbg(line1);
+    @dbg(line2);
+    0
+}
+```


### PR DESCRIPTION
Implements the @read_line intrinsic that reads a line from standard input and returns it as a String. This is the first input mechanism for Rue programs.

Changes:
- Add SYS_READ syscall to all platform modules (x86_64-linux, aarch64-linux, aarch64-macos)
- Implement __rue_read_line runtime function with sret calling convention
- Add @read_line intrinsic to sema with proper type checking (returns String)
- Add HM type inference support for @read_line intrinsic
- Lower @read_line to MIR for both x86_64 and aarch64 backends
- Add stdin piping support to spec test runner
- Add runtime tests covering spec paragraphs 4.13:33-39
- Update spec documentation for @read_line

Fixes rue-gmof

🤖 Generated with [Claude Code](https://claude.com/claude-code)