### PR TITLE
Reduce unnecessary allocations in hot paths

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -79,6 +79,17 @@ impl<'a> CfgLower<'a> {
     ) -> Self {
         let num_locals = cfg.num_locals();
         let num_params = cfg.num_params();
+
+        // Pre-calculate capacity hints to reduce HashMap reallocations
+        let num_values = cfg.value_count();
+        let num_blocks = cfg.blocks().len();
+        // Estimate ~4 block params per block on average
+        let estimated_block_params = num_blocks.saturating_mul(4);
+        // Estimate ~10% of values are struct inits
+        let estimated_struct_inits = num_values / 10;
+        // Estimate inout params are rare, start small
+        let estimated_inout_params = num_params.min(4) as usize;
+
         Self {
             cfg,
             struct_defs,
@@ -86,13 +97,13 @@ impl<'a> CfgLower<'a> {
             strings,
             interner,
             mir: Aarch64Mir::new(),
-            value_map: HashMap::new(),
-            block_param_vregs: HashMap::new(),
+            value_map: HashMap::with_capacity(num_values),
+            block_param_vregs: HashMap::with_capacity(estimated_block_params),
             num_locals,
             num_params,
             fn_name: cfg.fn_name(),
-            struct_slot_vregs: HashMap::new(),
-            inout_param_ptrs: HashMap::new(),
+            struct_slot_vregs: HashMap::with_capacity(estimated_struct_inits),
+            inout_param_ptrs: HashMap::with_capacity(estimated_inout_params),
         }
     }
 

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -201,6 +201,17 @@ impl LabelOffsets {
         Self::default()
     }
 
+    /// Create a new label offset map with pre-allocated capacity.
+    ///
+    /// - `inline_capacity`: Expected number of inline labels (overflow checks, etc.)
+    /// - `block_capacity`: Expected number of block labels (CFG blocks)
+    fn with_capacity(inline_capacity: usize, block_capacity: usize) -> Self {
+        Self {
+            inline: Vec::with_capacity(inline_capacity),
+            block: Vec::with_capacity(block_capacity),
+        }
+    }
+
     /// Insert a label offset.
     fn insert(&mut self, label: LabelId, offset: usize) {
         let id = label.index();
@@ -274,13 +285,24 @@ impl<'a> Emitter<'a> {
         callee_saved: &[Reg],
         strings: &'a [String],
     ) -> Self {
+        // Pre-calculate capacity hints to reduce Vec reallocations
+        let num_instructions = mir.instructions().len();
+        // AArch64 instructions are fixed at 4 bytes each
+        let estimated_code_size = num_instructions.saturating_mul(4);
+        // Estimate ~10% of instructions are branches that need fixups
+        let estimated_fixups = num_instructions / 10;
+        // Estimate inline labels: ~5% of instructions generate overflow/bounds check labels
+        let estimated_inline_labels = num_instructions / 20;
+        // Estimate block labels: ~10% of instructions are block boundaries
+        let estimated_block_labels = num_instructions / 10;
+
         Self {
             mir,
-            code: Vec::new(),
-            instructions: Vec::new(),
-            relocations: Vec::new(),
-            labels: LabelOffsets::new(),
-            fixups: Vec::new(),
+            code: Vec::with_capacity(estimated_code_size),
+            instructions: Vec::with_capacity(num_instructions),
+            relocations: Vec::new(), // Relocations are rare, don't pre-allocate
+            labels: LabelOffsets::with_capacity(estimated_inline_labels, estimated_block_labels),
+            fixups: Vec::with_capacity(estimated_fixups),
             num_locals,
             num_params,
             callee_saved: callee_saved.to_vec(),

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -90,6 +90,17 @@ impl<'a> CfgLower<'a> {
     ) -> Self {
         let num_locals = cfg.num_locals();
         let num_params = cfg.num_params();
+
+        // Pre-calculate capacity hints to reduce HashMap reallocations
+        let num_values = cfg.value_count();
+        let num_blocks = cfg.blocks().len();
+        // Estimate ~4 block params per block on average
+        let estimated_block_params = num_blocks.saturating_mul(4);
+        // Estimate ~10% of values are struct inits
+        let estimated_struct_inits = num_values / 10;
+        // Estimate inout params are rare, start small
+        let estimated_inout_params = num_params.min(4) as usize;
+
         Self {
             cfg,
             struct_defs,
@@ -97,14 +108,14 @@ impl<'a> CfgLower<'a> {
             strings,
             interner,
             mir: X86Mir::new(),
-            value_map: HashMap::new(),
-            block_param_vregs: HashMap::new(),
+            value_map: HashMap::with_capacity(num_values),
+            block_param_vregs: HashMap::with_capacity(estimated_block_params),
             next_label: 0,
             num_locals,
             num_params,
             fn_name: cfg.fn_name(),
-            struct_slot_vregs: HashMap::new(),
-            inout_param_ptrs: HashMap::new(),
+            struct_slot_vregs: HashMap::with_capacity(estimated_struct_inits),
+            inout_param_ptrs: HashMap::with_capacity(estimated_inout_params),
         }
     }
 

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -141,6 +141,17 @@ impl LabelOffsets {
         Self::default()
     }
 
+    /// Create a new label offset map with pre-allocated capacity.
+    ///
+    /// - `inline_capacity`: Expected number of inline labels (overflow checks, etc.)
+    /// - `block_capacity`: Expected number of block labels (CFG blocks)
+    fn with_capacity(inline_capacity: usize, block_capacity: usize) -> Self {
+        Self {
+            inline: Vec::with_capacity(inline_capacity),
+            block: Vec::with_capacity(block_capacity),
+        }
+    }
+
     /// Insert a label offset.
     fn insert(&mut self, label: LabelId, offset: usize) {
         let id = label.index();
@@ -223,13 +234,24 @@ impl<'a> Emitter<'a> {
         callee_saved: &[Reg],
         strings: &'a [String],
     ) -> Self {
+        // Pre-calculate capacity hints to reduce Vec reallocations
+        let num_instructions = mir.instructions().len();
+        // Estimate ~8 bytes per instruction on average (x86-64 instructions vary from 1-15 bytes)
+        let estimated_code_size = num_instructions.saturating_mul(8);
+        // Estimate ~10% of instructions are branches/jumps that need fixups
+        let estimated_fixups = num_instructions / 10;
+        // Estimate inline labels: ~5% of instructions generate overflow/bounds check labels
+        let estimated_inline_labels = num_instructions / 20;
+        // Estimate block labels: ~10% of instructions are block boundaries
+        let estimated_block_labels = num_instructions / 10;
+
         Self {
             mir,
-            code: Vec::new(),
-            instructions: Vec::new(),
-            relocations: Vec::new(),
-            labels: LabelOffsets::new(),
-            fixups: Vec::new(),
+            code: Vec::with_capacity(estimated_code_size),
+            instructions: Vec::with_capacity(num_instructions),
+            relocations: Vec::new(), // Relocations are rare, don't pre-allocate
+            labels: LabelOffsets::with_capacity(estimated_inline_labels, estimated_block_labels),
+            fixups: Vec::with_capacity(estimated_fixups),
             num_locals,
             num_locals_original,
             num_params,


### PR DESCRIPTION
Add capacity hints to HashMap and Vec constructors in the hot paths of the code generation pipeline:

- cfg_lower.rs (both x86_64 and aarch64): Pre-size value_map, block_param_vregs, struct_slot_vregs, and inout_param_ptrs based on CFG size estimates

- emit.rs (both x86_64 and aarch64): Pre-size code buffer, instructions vector, label offsets (with new LabelOffsets::with_capacity method), and fixups based on instruction count estimates

This reduces HashMap/Vec resizing during the lowering and emission phases, improving compile-time performance for larger programs.

Closes: rue-gi6q

🤖 Generated with [Claude Code](https://claude.com/claude-code)