### PR TITLE
Remove debug print statements from size assertion tests

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -960,8 +960,6 @@ mod tests {
         // If this test fails, update the const assertions at the top of this file.
         let air_inst_size = std::mem::size_of::<AirInst>();
         let air_inst_data_size = std::mem::size_of::<AirInstData>();
-        eprintln!("AirInst size: {} bytes", air_inst_size);
-        eprintln!("AirInstData size: {} bytes", air_inst_data_size);
 
         // These assertions document the current sizes.
         // If the layout changes, update both these values and the const assertions.

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -1065,8 +1065,6 @@ mod tests {
         // If this test fails, update the const assertions at the top of this file.
         let cfg_inst_size = std::mem::size_of::<CfgInst>();
         let cfg_inst_data_size = std::mem::size_of::<CfgInstData>();
-        eprintln!("CfgInst size: {} bytes", cfg_inst_size);
-        eprintln!("CfgInstData size: {} bytes", cfg_inst_data_size);
 
         // These assertions document the current sizes.
         // If the layout changes, update both these values and the const assertions.

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -1129,7 +1129,6 @@ mod tests {
         // Document actual sizes for future reference.
         // If this test fails, update the const assertions at the top of this file.
         let aarch64_inst_size = std::mem::size_of::<Aarch64Inst>();
-        eprintln!("Aarch64Inst size: {} bytes", aarch64_inst_size);
 
         // This assertion documents the current size.
         // If the layout changes, update both this value and the const assertion.

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -766,7 +766,6 @@ mod tests {
         // Document actual sizes for future reference.
         // If this test fails, update the const assertions at the top of this file.
         let x86_inst_size = std::mem::size_of::<X86Inst>();
-        eprintln!("X86Inst size: {} bytes", x86_inst_size);
 
         // This assertion documents the current size.
         // If the layout changes, update both this value and the const assertion.


### PR DESCRIPTION
These eprintln! statements in test code were producing unnecessary output during test runs. The size information is already captured in the assertion failure messages if the tests fail, making these prints redundant.

Files changed:
- crates/rue-air/src/inst.rs
- crates/rue-cfg/src/inst.rs
- crates/rue-codegen/src/x86_64/mir.rs
- crates/rue-codegen/src/aarch64/mir.rs

Closes: rue-eo5v

🤖 Generated with [Claude Code](https://claude.com/claude-code)