### PR TITLE
Implement Copy trait for arrays of Copy types

### DIFF
--- a/crates/rue-air/src/sema.rs
+++ b/crates/rue-air/src/sema.rs
@@ -1721,9 +1721,11 @@ impl<'a> Sema<'a> {
                 struct_def.is_copy
             }
             // Note: String is now handled via Type::Struct with is_builtin
-            // Arrays are move types for now
-            // TODO: Arrays of Copy types could be Copy
-            Type::Array(_) => false,
+            // Arrays are Copy if their element type is Copy
+            Type::Array(array_id) => {
+                let array_def = &self.array_type_defs[array_id.0 as usize];
+                self.is_type_copy(array_def.element_type)
+            }
         }
     }
 

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -258,10 +258,11 @@ impl Type {
     ///
     /// Non-Copy types (move types) are:
     /// - Struct types (unless marked @copy, checked via StructDef.is_copy)
-    /// - Array types (until we implement Copy arrays with Copy elements)
+    /// - Array types (unless element type is Copy, checked via Sema.is_type_copy)
     ///
-    /// Note: This method can't check struct's is_copy attribute since it doesn't
-    /// have access to StructDefs. Use Sema.is_type_copy() for full checking.
+    /// Note: This method can't check struct's is_copy attribute or array element
+    /// types since it doesn't have access to StructDefs or ArrayTypeDefs.
+    /// Use Sema.is_type_copy() for full checking.
     pub fn is_copy(&self) -> bool {
         match self {
             // Primitive Copy types
@@ -281,8 +282,7 @@ impl Type {
             Type::Never | Type::Error => true,
             // Struct types are move types by default (may be @copy, but need StructDef to check)
             Type::Struct(_) => false,
-            // Arrays are move types for now
-            // TODO: Arrays of Copy types could be Copy
+            // Arrays may be Copy if element type is Copy (need ArrayTypeDef to check)
             Type::Array(_) => false,
         }
     }

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1372,6 +1372,32 @@ impl<'a> CfgLower<'a> {
                     self.struct_slot_vregs
                         .insert(value, vec![ptr_vreg, len_vreg, cap_vreg]);
                     self.value_map.insert(value, ptr_vreg);
+                } else if let Type::Array(_) = load_type {
+                    // Array: load all element slots (recursively flattened)
+                    let slot_count = self.type_slot_count(load_type);
+                    let mut slot_vregs = Vec::with_capacity(slot_count as usize);
+
+                    for i in 0..slot_count {
+                        let elem_vreg = self.mir.alloc_vreg();
+                        let elem_offset = self.local_offset(slot + i);
+                        self.mir.push(Aarch64Inst::Ldr {
+                            dst: Operand::Virtual(elem_vreg),
+                            base: Reg::Fp,
+                            offset: elem_offset,
+                        });
+                        slot_vregs.push(elem_vreg);
+                    }
+
+                    // Register array element vregs
+                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
+
+                    // Use first element as the primary vreg
+                    if let Some(&first_vreg) = slot_vregs.first() {
+                        self.value_map.insert(value, first_vreg);
+                    } else {
+                        let vreg = self.mir.alloc_vreg();
+                        self.value_map.insert(value, vreg);
+                    }
                 } else if let Type::Struct(struct_id) = load_type {
                     // Struct: load all field slots (recursively flattened)
                     let slot_count = self.type_slot_count(Type::Struct(struct_id));

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1541,6 +1541,32 @@ impl<'a> CfgLower<'a> {
                     self.struct_slot_vregs
                         .insert(value, vec![ptr_vreg, len_vreg, cap_vreg]);
                     self.value_map.insert(value, ptr_vreg);
+                } else if let Type::Array(_) = load_type {
+                    // Array: load all element slots (recursively flattened)
+                    let slot_count = self.type_slot_count(load_type);
+                    let mut slot_vregs = Vec::with_capacity(slot_count as usize);
+
+                    for i in 0..slot_count {
+                        let elem_vreg = self.mir.alloc_vreg();
+                        let elem_offset = self.local_offset(slot + i);
+                        self.mir.push(X86Inst::MovRM {
+                            dst: Operand::Virtual(elem_vreg),
+                            base: Reg::Rbp,
+                            offset: elem_offset,
+                        });
+                        slot_vregs.push(elem_vreg);
+                    }
+
+                    // Register array element vregs
+                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
+
+                    // Use first element as the primary vreg
+                    if let Some(&first_vreg) = slot_vregs.first() {
+                        self.value_map.insert(value, first_vreg);
+                    } else {
+                        let vreg = self.mir.alloc_vreg();
+                        self.value_map.insert(value, vreg);
+                    }
                 } else if let Type::Struct(struct_id) = load_type {
                     // Struct: load all field slots (recursively flattened)
                     let slot_count = self.type_slot_count(Type::Struct(struct_id));

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -91,6 +91,127 @@ fn main() -> i32 {
 """
 exit_code = 1
 
+[[case]]
+name = "array_of_copy_is_copy"
+spec = ["3.8:2"]
+description = "Array of Copy type (i32) can be used multiple times"
+source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [1, 2, 3];
+    let arr2 = arr;
+    let arr3 = arr;
+    arr[0] + arr2[1] + arr3[2]
+}
+"""
+exit_code = 6
+
+[[case]]
+name = "array_of_copy_nested"
+spec = ["3.8:2"]
+description = "Nested arrays of Copy types are Copy"
+source = """
+fn main() -> i32 {
+    let matrix: [[i32; 2]; 2] = [[1, 2], [3, 4]];
+    let m2 = matrix;
+    let m3 = matrix;
+    matrix[0][0] + m2[1][1] + m3[0][1]
+}
+"""
+exit_code = 7
+
+[[case]]
+name = "array_of_bool_is_copy"
+spec = ["3.8:2"]
+description = "Array of bool is Copy"
+source = """
+fn main() -> i32 {
+    let flags: [bool; 2] = [true, false];
+    let f2 = flags;
+    if flags[0] && f2[0] { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "array_of_enum_is_copy"
+spec = ["3.8:2"]
+description = "Array of enum is Copy (enums are Copy)"
+source = """
+enum Status { On, Off }
+fn main() -> i32 {
+    let states: [Status; 2] = [Status::On, Status::Off];
+    let s2 = states;
+    match states[0] {
+        Status::On => match s2[1] {
+            Status::Off => 42,
+            Status::On => 0,
+        },
+        Status::Off => 0,
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "array_of_non_copy_is_not_copy"
+spec = ["3.8:2", "3.8:3"]
+description = "Array of non-Copy struct is not Copy"
+source = """
+struct Data { value: i32 }
+fn main() -> i32 {
+    let arr: [Data; 2] = [Data { value: 1 }, Data { value: 2 }];
+    let arr2 = arr;
+    arr[0].value
+}
+"""
+compile_fail = true
+error_contains = "use of moved value"
+
+[[case]]
+name = "array_of_copy_struct_is_copy"
+spec = ["3.8:2", "3.8:16"]
+description = "Array of @copy struct is Copy"
+source = """
+@copy
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let points: [Point; 2] = [Point { x: 1, y: 2 }, Point { x: 3, y: 4 }];
+    let p2 = points;
+    points[0].x + p2[1].x
+}
+"""
+exit_code = 4
+
+[[case]]
+name = "copy_struct_with_array_field"
+spec = ["3.8:2", "3.8:20"]
+description = "@copy struct can contain array of Copy type"
+source = """
+@copy
+struct Container { values: [i32; 3] }
+fn main() -> i32 {
+    let c = Container { values: [10, 20, 30] };
+    let c2 = c;
+    c.values[0] + c2.values[2]
+}
+"""
+exit_code = 40
+
+[[case]]
+name = "copy_struct_with_array_of_non_copy_error"
+spec = ["3.8:18", "3.8:20"]
+description = "@copy struct cannot contain array of non-Copy type"
+source = """
+struct Data { value: i32 }
+
+@copy
+struct Container { items: [Data; 2] }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "non-Copy type"
+
 # =============================================================================
 # Move Types (Structs)
 # =============================================================================

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -22,6 +22,7 @@ The following types are Copy types:
 - The boolean type (`bool`)
 - The unit type (`()`)
 - Enum types (all variants of an enum)
+- Array types `[T; N]` where `T` is a Copy type
 
 {{ rule(id="3.8:3", cat="normative") }}
 
@@ -85,7 +86,7 @@ struct Outer { inner: Inner }  // ERROR: field 'inner' has non-Copy type 'Inner'
 
 {{ rule(id="3.8:20", cat="normative") }}
 
-A `@copy` struct **MAY** contain fields of primitive Copy types (integers, booleans, unit), enum types, or other `@copy` struct types.
+A `@copy` struct **MAY** contain fields of primitive Copy types (integers, booleans, unit), enum types, arrays of Copy types, or other `@copy` struct types.
 
 {{ rule(id="3.8:21", cat="example") }}
 


### PR DESCRIPTION
Arrays of Copy types (e.g., [i32; 3]) are now themselves Copy types, allowing them to be used multiple times without moving. This includes:
- Nested arrays: [[i32; 2]; 3] is Copy
- Arrays of @copy structs
- @copy structs can now contain array fields

Implementation:
- Updated is_type_copy() in sema.rs to recursively check element types
- Fixed codegen Load instruction in both x86_64 and aarch64 backends to properly copy all array elements (was only copying first slot)
- Updated spec rules 3.8:2 and 3.8:20
- Added comprehensive spec tests

Fixes rue-gad5

🤖 Generated with [Claude Code](https://claude.com/claude-code)