### PR TITLE
Decouple string table from function analysis for parallel compilation

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -364,6 +364,22 @@ impl Air {
             .map(|&v| v as usize);
         (fields, source_order)
     }
+
+    /// Remap string constant IDs using the provided mapping function.
+    ///
+    /// This is used after parallel function analysis to convert local string IDs
+    /// (per-function) to global string IDs (across all functions). The mapping
+    /// function takes a local string ID and returns the global string ID.
+    pub fn remap_string_ids<F>(&mut self, map_fn: F)
+    where
+        F: Fn(u32) -> u32,
+    {
+        for inst in &mut self.instructions {
+            if let AirInstData::StringConst(ref mut id) = inst.data {
+                *id = map_fn(*id);
+            }
+        }
+    }
 }
 
 /// A single AIR instruction.

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -37,7 +37,10 @@ pub(crate) fn analyze_all_function_bodies(mut sema: Sema<'_>) -> MultiErrorResul
     // Build inference context once
     let infer_ctx = sema.build_inference_context();
 
-    let mut functions = Vec::new();
+    // Collect analyzed functions with their local strings.
+    // Each function collects strings independently (enabling future parallelization),
+    // then we merge and deduplicate globally, remapping string IDs in the AIR.
+    let mut functions_with_strings: Vec<(AnalyzedFunction, Vec<String>)> = Vec::new();
     let mut errors = CompileErrors::new();
     let mut all_warnings = Vec::new();
 
@@ -84,8 +87,8 @@ pub(crate) fn analyze_all_function_bodies(mut sema: Sema<'_>) -> MultiErrorResul
                 *body,
                 inst.span,
             ) {
-                Ok((analyzed, warnings)) => {
-                    functions.push(analyzed);
+                Ok((analyzed, warnings, local_strings)) => {
+                    functions_with_strings.push((analyzed, local_strings));
                     all_warnings.extend(warnings);
                 }
                 Err(e) => errors.push(e),
@@ -149,8 +152,8 @@ pub(crate) fn analyze_all_function_bodies(mut sema: Sema<'_>) -> MultiErrorResul
                         struct_type,
                         *has_self,
                     ) {
-                        Ok((analyzed, warnings)) => {
-                            functions.push(analyzed);
+                        Ok((analyzed, warnings, local_strings)) => {
+                            functions_with_strings.push((analyzed, local_strings));
                             all_warnings.extend(warnings);
                         }
                         Err(e) => errors.push(e),
@@ -187,13 +190,42 @@ pub(crate) fn analyze_all_function_bodies(mut sema: Sema<'_>) -> MultiErrorResul
                 inst.span,
                 struct_type,
             ) {
-                Ok((analyzed, warnings)) => {
-                    functions.push(analyzed);
+                Ok((analyzed, warnings, local_strings)) => {
+                    functions_with_strings.push((analyzed, local_strings));
                     all_warnings.extend(warnings);
                 }
                 Err(e) => errors.push(e),
             }
         }
+    }
+
+    // Merge strings from all functions into a global table with deduplication.
+    // Build a mapping from (local_strings_vec, local_id) -> global_id for remapping.
+    let mut global_string_table: HashMap<String, u32> = HashMap::new();
+    let mut global_strings: Vec<String> = Vec::new();
+
+    // For each function, build a mapping from local string ID to global string ID
+    let mut functions: Vec<AnalyzedFunction> = Vec::new();
+    for (mut analyzed, local_strings) in functions_with_strings {
+        if !local_strings.is_empty() {
+            // Build mapping from local IDs to global IDs
+            let local_to_global: Vec<u32> = local_strings
+                .into_iter()
+                .map(|s| {
+                    *global_string_table.entry(s.clone()).or_insert_with(|| {
+                        let id = global_strings.len() as u32;
+                        global_strings.push(s);
+                        id
+                    })
+                })
+                .collect();
+
+            // Remap string IDs in the AIR
+            analyzed
+                .air
+                .remap_string_ids(|local_id| local_to_global[local_id as usize]);
+        }
+        functions.push(analyzed);
     }
 
     all_warnings.sort_by_key(|w| w.span().map(|s| s.start));
@@ -203,7 +235,7 @@ pub(crate) fn analyze_all_function_bodies(mut sema: Sema<'_>) -> MultiErrorResul
         struct_defs: sema.struct_defs,
         enum_defs: sema.enum_defs,
         array_types: sema.array_type_defs,
-        strings: sema.strings,
+        strings: global_strings,
         warnings: all_warnings,
     })
 }
@@ -254,7 +286,7 @@ impl<'a> Sema<'a> {
         params: &[rue_rir::RirParam],
         body: InstRef,
         span: Span,
-    ) -> CompileResult<(AnalyzedFunction, Vec<CompileWarning>)> {
+    ) -> CompileResult<(AnalyzedFunction, Vec<CompileWarning>, Vec<String>)> {
         let ret_type = self.resolve_type(return_type, span)?;
 
         // Resolve parameter types and modes
@@ -266,7 +298,7 @@ impl<'a> Sema<'a> {
             })
             .collect::<CompileResult<Vec<_>>>()?;
 
-        let (air, num_locals, num_param_slots, param_modes, warnings) =
+        let (air, num_locals, num_param_slots, param_modes, warnings, local_strings) =
             self.analyze_function(infer_ctx, ret_type, &param_info, body)?;
 
         Ok((
@@ -278,6 +310,7 @@ impl<'a> Sema<'a> {
                 param_modes,
             },
             warnings,
+            local_strings,
         ))
     }
 
@@ -285,7 +318,7 @@ impl<'a> Sema<'a> {
     ///
     /// The `infer_ctx` provides pre-computed type information for constraint generation.
     ///
-    /// Returns the analyzed function and any warnings generated during analysis.
+    /// Returns the analyzed function, any warnings, and local strings collected during analysis.
     fn analyze_method_function(
         &mut self,
         infer_ctx: &InferenceContext,
@@ -296,7 +329,7 @@ impl<'a> Sema<'a> {
         span: Span,
         struct_type: Type,
         has_self: bool,
-    ) -> CompileResult<(AnalyzedFunction, Vec<CompileWarning>)> {
+    ) -> CompileResult<(AnalyzedFunction, Vec<CompileWarning>, Vec<String>)> {
         let ret_type = self.resolve_type(return_type, span)?;
 
         // Build parameter list, adding self as first parameter for methods
@@ -314,7 +347,7 @@ impl<'a> Sema<'a> {
             param_info.push((p.name, ty, p.mode));
         }
 
-        let (air, num_locals, num_param_slots, param_modes, warnings) =
+        let (air, num_locals, num_param_slots, param_modes, warnings, local_strings) =
             self.analyze_function(infer_ctx, ret_type, &param_info, body)?;
 
         Ok((
@@ -326,6 +359,7 @@ impl<'a> Sema<'a> {
                 param_modes,
             },
             warnings,
+            local_strings,
         ))
     }
 
@@ -333,7 +367,7 @@ impl<'a> Sema<'a> {
     ///
     /// The `infer_ctx` provides pre-computed type information for constraint generation.
     ///
-    /// Returns the analyzed function and any warnings generated during analysis.
+    /// Returns the analyzed function, any warnings, and local strings collected during analysis.
     fn analyze_destructor_function(
         &mut self,
         infer_ctx: &InferenceContext,
@@ -341,13 +375,13 @@ impl<'a> Sema<'a> {
         body: InstRef,
         _span: Span,
         struct_type: Type,
-    ) -> CompileResult<(AnalyzedFunction, Vec<CompileWarning>)> {
+    ) -> CompileResult<(AnalyzedFunction, Vec<CompileWarning>, Vec<String>)> {
         // Destructors take self parameter and return unit
         let self_sym = self.interner.get_or_intern("self");
         let param_info: Vec<(Spur, Type, RirParamMode)> =
             vec![(self_sym, struct_type, RirParamMode::Normal)];
 
-        let (air, num_locals, num_param_slots, param_modes, warnings) =
+        let (air, num_locals, num_param_slots, param_modes, warnings, local_strings) =
             self.analyze_function(infer_ctx, Type::Unit, &param_info, body)?;
 
         Ok((
@@ -359,6 +393,7 @@ impl<'a> Sema<'a> {
                 param_modes,
             },
             warnings,
+            local_strings,
         ))
     }
     /// Analyze a single function, producing AIR.
@@ -374,7 +409,7 @@ impl<'a> Sema<'a> {
         return_type: Type,
         params: &[(Spur, Type, RirParamMode)], // (name, type, mode)
         body: InstRef,
-    ) -> CompileResult<(Air, u32, u32, Vec<bool>, Vec<CompileWarning>)> {
+    ) -> CompileResult<(Air, u32, u32, Vec<bool>, Vec<CompileWarning>, Vec<String>)> {
         let mut air = Air::new(return_type);
         let mut param_map: HashMap<Spur, ParamInfo> = HashMap::new();
         let mut param_modes: Vec<bool> = Vec::new();
@@ -426,6 +461,8 @@ impl<'a> Sema<'a> {
             resolved_types: &resolved_types,
             moved_vars: HashMap::new(),
             warnings: Vec::new(),
+            local_string_table: HashMap::new(),
+            local_strings: Vec::new(),
         };
 
         // ======================================================================
@@ -449,6 +486,7 @@ impl<'a> Sema<'a> {
             num_param_slots,
             param_modes,
             ctx.warnings,
+            ctx.local_strings,
         ))
     }
 
@@ -853,12 +891,12 @@ impl<'a> Sema<'a> {
             InstData::StringConst(symbol) => {
                 // String literals use the builtin String struct type.
                 let ty = self.builtin_string_type();
-                // Add string to the string table
+                // Add string to the local string table (per-function for parallel analysis)
                 let string_content = self.interner.resolve(&*symbol).to_string();
-                let string_id = self.add_string(string_content);
+                let local_string_id = ctx.add_local_string(string_content);
 
                 let air_ref = air.add_inst(AirInst {
-                    data: AirInstData::StringConst(string_id),
+                    data: AirInstData::StringConst(local_string_id),
                     ty,
                     span: inst.span,
                 });
@@ -4164,19 +4202,6 @@ impl<'a> Sema<'a> {
         };
 
         Ok(AnalysisResult::new(store_ref, Type::Unit))
-    }
-
-    fn add_string(&mut self, content: String) -> u32 {
-        use std::collections::hash_map::Entry;
-        match self.string_table.entry(content) {
-            Entry::Occupied(e) => *e.get(),
-            Entry::Vacant(e) => {
-                let id = self.strings.len() as u32;
-                self.strings.push(e.key().clone());
-                e.insert(id);
-                id
-            }
-        }
     }
 
     /// Check if directives contain @allow for a specific warning name.

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -184,6 +184,12 @@ pub(crate) struct AnalysisContext<'a> {
     /// Warnings collected during function analysis.
     /// This is per-function to enable future parallel analysis.
     pub warnings: Vec<CompileWarning>,
+    /// Local string table: maps string content to local index (for deduplication within function).
+    /// This is per-function to enable parallel analysis - strings are merged globally after.
+    pub local_string_table: HashMap<String, u32>,
+    /// Local string data indexed by local string table index.
+    /// After analysis, these are merged into the global string table with ID remapping.
+    pub local_strings: Vec<String>,
 }
 
 // Import InstRef for use in resolved_types
@@ -300,6 +306,24 @@ impl AnalysisContext<'_> {
                 }
 
                 self.moved_vars = merged;
+            }
+        }
+    }
+
+    /// Add a string to the local string table, returning its local index.
+    ///
+    /// This deduplicates strings within a single function. After function analysis
+    /// completes, local strings are merged into the global string table with ID
+    /// remapping in the AIR instructions.
+    pub fn add_local_string(&mut self, content: String) -> u32 {
+        use std::collections::hash_map::Entry;
+        match self.local_string_table.entry(content) {
+            Entry::Occupied(e) => *e.get(),
+            Entry::Vacant(e) => {
+                let id = self.local_strings.len() as u32;
+                self.local_strings.push(e.key().clone());
+                e.insert(id);
+                id
             }
         }
     }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -113,8 +113,6 @@ impl<'a> GatherOutput<'a> {
             enum_defs: self.enum_defs,
             array_types: self.array_types,
             array_type_defs: self.array_type_defs,
-            string_table: HashMap::new(),
-            strings: Vec::new(),
             methods: self.methods,
             preview_features: self.preview_features,
             builtin_string_id: self.builtin_string_id,
@@ -239,10 +237,6 @@ pub struct Sema<'a> {
     pub(crate) array_types: HashMap<(Type, u64), ArrayTypeId>,
     /// Array type definitions indexed by ArrayTypeId
     pub(crate) array_type_defs: Vec<ArrayTypeDef>,
-    /// String table: maps string content to index (for deduplication)
-    pub(crate) string_table: HashMap<String, u32>,
-    /// String data indexed by string table index
-    pub(crate) strings: Vec<String>,
     /// Method table: maps (struct_name, method_name) to method info
     /// Used for resolving method calls (receiver.method()) and associated
     /// function calls (Type::function())
@@ -271,8 +265,6 @@ impl<'a> Sema<'a> {
             enum_defs: Vec::new(),
             array_types: HashMap::new(),
             array_type_defs: Vec::new(),
-            string_table: HashMap::new(),
-            strings: Vec::new(),
             methods: HashMap::new(),
             preview_features,
             builtin_string_id: None,


### PR DESCRIPTION
The string table (string_table HashMap and strings Vec) in Sema was the primary blocker for parallel function analysis because each function could mutate this shared state when encountering string literals.

Solution: Each function now collects strings into a local_strings Vec within its AnalysisContext. After all functions are analyzed, strings are merged globally with deduplication, and the string IDs in each function's AIR are remapped to the global IDs.

Changes:
- Add local_string_table and local_strings fields to AnalysisContext
- Add add_local_string() method to AnalysisContext
- Add remap_string_ids() method to Air for remapping after merge
- Update analyze_function to return local_strings
- Update analyze_all_function_bodies to merge and remap strings
- Remove unused string_table and strings fields from Sema struct

This change enables future parallelization of function body analysis with rayon, as each function can now be analyzed independently without shared mutable state for string collection.

Closes: rue-n4kd

🤖 Generated with [Claude Code](https://claude.com/claude-code)