### PR TITLE
Fix benchmark job cancellation with concurrency groups

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -13,6 +13,12 @@ on:
 permissions:
   contents: write  # Needed to push to perf branch
 
+# Only allow one benchmark run at a time to prevent race conditions
+# when pushing to the perf branch. New runs will queue and wait.
+concurrency:
+  group: benchmarks
+  cancel-in-progress: false
+
 jobs:
   benchmark:
     strategy:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -27,9 +27,12 @@ permissions:
   pages: write
   id-token: write
 
+# Use a fixed concurrency group for all website deployments to ensure
+# they run sequentially and don't cancel each other (especially important
+# when triggered by benchmark workflow completion)
 concurrency:
-  group: "pages-${{ github.ref }}"
-  cancel-in-progress: true
+  group: "pages"
+  cancel-in-progress: false
 
 jobs:
   build:


### PR DESCRIPTION
Add explicit concurrency configuration to prevent benchmark and website deployment jobs from being canceled or racing:

- benchmarks.yml: Add concurrency group with cancel-in-progress: false to ensure only one benchmark run happens at a time (queued, not canceled)
- deploy-website.yml: Change from cancel-in-progress: true to false and use fixed group name to prevent website deployments from canceling each other when triggered by benchmark completion

🤖 Generated with [Claude Code](https://claude.com/claude-code)