### PR TITLE
Clean up dead rel8 code and add large jump tests (rue-m80z)

### DIFF
--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -101,22 +101,24 @@ use super::mir::{LabelId, Reg, X86Inst, X86Mir};
 use crate::vreg::BLOCK_LABEL_BASE;
 use crate::{EmittedCode, EmittedInst, EmittedRelocation, end_inst, format_offset};
 
-/// Kind of jump fixup (rel8 or rel32).
+/// Kind of jump fixup.
+///
+/// We always use rel32 encoding to support jumps of any size within a function.
+/// While rel8 would save 3-5 bytes per jump for small functions, the simplicity
+/// of always using rel32 avoids needing a two-pass encoding or relaxation loop.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum FixupKind {
-    /// 1-byte relative offset (-128 to +127)
-    Rel8,
-    /// 4-byte relative offset
+    /// 4-byte relative offset (supports jumps up to ±2GB)
     Rel32,
 }
 
 /// A pending fixup for a forward jump.
 struct Fixup {
-    /// Offset of the rel8/rel32 displacement in the code.
+    /// Offset of the rel32 displacement in the code.
     offset: usize,
     /// Target label ID.
     label: LabelId,
-    /// Kind of fixup (rel8 or rel32).
+    /// Kind of fixup.
     kind: FixupKind,
 }
 
@@ -515,25 +517,6 @@ impl<'a> Emitter<'a> {
             })?;
 
             match fixup.kind {
-                FixupKind::Rel8 => {
-                    // Calculate relative offset from the end of the jump instruction
-                    // The fixup offset points to the rel8, which is the last byte of the instruction
-                    let jump_end = fixup.offset + 1; // rel8 is 1 byte
-                    let relative = target_offset as i64 - jump_end as i64;
-
-                    // rel8 encoding only supports -128 to +127 byte offsets
-                    if relative < -128 || relative > 127 {
-                        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
-                            format!(
-                                "jump offset {} exceeds rel8 range (-128..127) for label '{}'; \
-                                 consider implementing rel32 fallback",
-                                relative, fixup.label
-                            ),
-                        )));
-                    }
-
-                    self.code[fixup.offset] = relative as u8;
-                }
                 FixupKind::Rel32 => {
                     // Calculate relative offset from the end of the jump instruction
                     // The fixup offset points to the first byte of the 4-byte rel32

--- a/crates/rue-spec/cases/appendices/implementation-limits.toml
+++ b/crates/rue-spec/cases/appendices/implementation-limits.toml
@@ -235,3 +235,86 @@ fn main() -> i32 {
 }
 """
 exit_code = 14
+
+# =============================================================================
+# Code Generation Limits (C.8)
+# =============================================================================
+#
+# These tests verify that the compiler correctly handles jumps that exceed
+# the 127-byte limit of rel8 encoding. The x86-64 backend uses rel32 encoding
+# for all conditional jumps to support functions of any size.
+
+[[case]]
+name = "large_forward_jump_if"
+spec = ["C.8:1"]
+description = "Test forward jump over many instructions (exceeds rel8 range)"
+source = """
+fn main() -> i32 {
+    let x: i32 = 1;
+    // This if-else generates a forward jump. The else branch contains
+    // enough instructions to push the target well beyond 127 bytes.
+    if x == 1 {
+        // Branch taken - jumps over the large else block
+        42
+    } else {
+        // Generate enough code to exceed rel8 range (~200+ bytes)
+        let a: i32 = 1; let b: i32 = 2; let c: i32 = 3; let d: i32 = 4;
+        let e: i32 = 5; let f: i32 = 6; let g: i32 = 7; let h: i32 = 8;
+        let i: i32 = 9; let j: i32 = 10; let k: i32 = 11; let l: i32 = 12;
+        let m: i32 = 13; let n: i32 = 14; let o: i32 = 15; let p: i32 = 16;
+        let q: i32 = 17; let r: i32 = 18; let s: i32 = 19; let t: i32 = 20;
+        let u: i32 = 21; let v: i32 = 22; let w: i32 = 23; let y: i32 = 24;
+        // Sum them all to prevent dead code elimination
+        a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p + q + r + s + t + u + v + w + y
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "large_forward_jump_while"
+spec = ["C.8:1"]
+description = "Test loop with large body (conditional jump to loop exit)"
+source = """
+fn main() -> i32 {
+    let mut result: i32 = 0;
+    let mut count: i32 = 3;
+    // The while loop generates a conditional jump forward to the exit.
+    // The loop body is large enough to exceed rel8 range.
+    while count > 0 {
+        // Large loop body
+        let a: i32 = 1; let b: i32 = 2; let c: i32 = 3; let d: i32 = 4;
+        let e: i32 = 5; let f: i32 = 6; let g: i32 = 7; let h: i32 = 8;
+        let i: i32 = 9; let j: i32 = 10; let k: i32 = 11; let l: i32 = 12;
+        let m: i32 = 13; let n: i32 = 14; let o: i32 = 15; let p: i32 = 16;
+        result = result + a + b + c + d + e + f + g + h + i + j + k + l + m + n + o + p;
+        count = count - 1;
+    }
+    // Return something recognizable
+    result / 100  // 136 * 3 = 408, 408 / 100 = 4
+}
+"""
+exit_code = 4
+
+[[case]]
+name = "large_backward_jump_loop"
+spec = ["C.8:1"]
+description = "Test backward jump from loop end to start (over large body)"
+source = """
+fn main() -> i32 {
+    let mut sum: i32 = 0;
+    let mut i: i32 = 0;
+    // This loop has a large body. At the end of each iteration,
+    // there's a backward jump to the loop header that exceeds 127 bytes.
+    while i < 2 {
+        let a: i32 = 1; let b: i32 = 2; let c: i32 = 3; let d: i32 = 4;
+        let e: i32 = 5; let f: i32 = 6; let g: i32 = 7; let h: i32 = 8;
+        let j: i32 = 9; let k: i32 = 10; let l: i32 = 11; let m: i32 = 12;
+        let n: i32 = 13; let o: i32 = 14; let p: i32 = 15; let q: i32 = 16;
+        sum = sum + a + b + c + d + e + f + g + h + j + k + l + m + n + o + p + q;
+        i = i + 1;
+    }
+    sum / 100  // (136 * 2) / 100 = 272 / 100 = 2
+}
+"""
+exit_code = 2

--- a/docs/spec/src/appendices/C-implementation-limits.md
+++ b/docs/spec/src/appendices/C-implementation-limits.md
@@ -94,3 +94,16 @@ While the language specification does not impose limits on recursion depth or st
 {{ rule(id="C.7:2", cat="informative") }}
 
 Programs requiring deep recursion or large stack allocations **SHOULD** be designed with these platform constraints in mind.
+
+## Code Generation Limits
+
+{{ rule(id="C.8:1", cat="normative") }}
+
+Function size is limited by the target architecture's addressing modes:
+
+- On x86-64, functions **MUST** fit within the ±2 GiB range addressable by 32-bit relative offsets
+- Jump instructions within a function use 32-bit relative addressing to support functions of any reasonable size
+
+{{ rule(id="C.8:2", cat="informative") }}
+
+The compiler uses 32-bit relative (rel32) encoding for all conditional and unconditional jumps, avoiding the 127-byte limit of 8-bit relative (rel8) encoding. This ensures functions with large basic blocks compile correctly without requiring multi-pass relaxation.


### PR DESCRIPTION
The x86-64 emitter already uses rel32 encoding for all conditional jumps, supporting functions of any size. This change:

1. Removes the unused FixupKind::Rel8 variant and associated dead code
2. Adds spec section C.8 documenting code generation limits
3. Adds 3 test cases verifying large forward/backward jumps work

The issue described (rel8 overflow causing compile errors) was already fixed at some point - emit_jcc uses the rel32 0F 8x encoding form. This commit cleans up the dead code path that would never be reached.

🤖 Generated with [Claude Code](https://claude.com/claude-code)