### PR TITLE
Split Sema into SemaContext + FunctionAnalyzer for parallel analysis

### DIFF
--- a/crates/rue-air/src/function_analyzer.rs
+++ b/crates/rue-air/src/function_analyzer.rs
@@ -1,0 +1,482 @@
+//! Per-function analysis state and analyzer.
+//!
+//! This module contains `FunctionAnalyzer`, which holds the mutable state
+//! needed during function body analysis. Each function gets its own analyzer
+//! instance, enabling future parallel analysis.
+//!
+//! # Architecture
+//!
+//! `FunctionAnalyzer` is designed to work with a shared immutable `SemaContext`.
+//! The split enables:
+//! - Parallel function body analysis (each function has independent mutable state)
+//! - Better separation of concerns (immutable type info vs mutable analysis state)
+//! - Post-analysis merging of results (strings, array types, warnings)
+
+use std::collections::HashMap;
+
+use lasso::Spur;
+use rue_error::{CompileError, CompileResult, CompileWarning, ErrorKind, PreviewFeature};
+use rue_span::Span;
+
+use crate::inference::InferType;
+use crate::sema_context::SemaContext;
+use crate::types::{ArrayTypeDef, ArrayTypeId, Type};
+
+/// Per-function mutable state during semantic analysis.
+///
+/// This struct contains all mutable state that is modified during function
+/// body analysis. For parallel analysis, each function gets its own instance,
+/// and results are merged afterward.
+///
+/// # Separation from SemaContext
+///
+/// `FunctionAnalyzer` holds mutable state while `SemaContext` holds immutable
+/// type information. This separation enables:
+/// - Sharing `SemaContext` across parallel function analyses
+/// - Independent mutable state per function
+/// - Post-analysis merging of results
+#[derive(Debug)]
+pub struct FunctionAnalyzer<'a, 'ctx> {
+    /// Reference to the shared immutable context.
+    pub ctx: &'a SemaContext<'ctx>,
+    /// Array types created during this function's analysis.
+    /// These are local to the function and merged post-analysis.
+    array_types: HashMap<(Type, u64), ArrayTypeId>,
+    /// Array type definitions in order of creation.
+    array_type_defs: Vec<ArrayTypeDef>,
+    /// String table for deduplication.
+    string_table: HashMap<String, u32>,
+    /// String literals in order of creation.
+    strings: Vec<String>,
+    /// Warnings collected during analysis.
+    warnings: Vec<CompileWarning>,
+}
+
+/// Output from analyzing a single function.
+#[derive(Debug)]
+pub struct FunctionAnalyzerOutput {
+    /// Array types created during analysis.
+    pub array_types: HashMap<(Type, u64), ArrayTypeId>,
+    /// Array type definitions.
+    pub array_type_defs: Vec<ArrayTypeDef>,
+    /// String literals (deduplicated).
+    pub strings: Vec<String>,
+    /// Warnings collected during analysis.
+    pub warnings: Vec<CompileWarning>,
+}
+
+impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
+    /// Create a new function analyzer with a reference to the shared context.
+    pub fn new(ctx: &'a SemaContext<'ctx>) -> Self {
+        Self {
+            ctx,
+            array_types: HashMap::new(),
+            array_type_defs: Vec::new(),
+            string_table: HashMap::new(),
+            strings: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Create a new function analyzer initialized with pre-existing array types.
+    ///
+    /// This is used when we need to inherit array types from the context
+    /// (e.g., array types discovered during declaration gathering).
+    pub fn with_array_types(
+        ctx: &'a SemaContext<'ctx>,
+        array_types: HashMap<(Type, u64), ArrayTypeId>,
+        array_type_defs: Vec<ArrayTypeDef>,
+    ) -> Self {
+        Self {
+            ctx,
+            array_types,
+            array_type_defs,
+            string_table: HashMap::new(),
+            strings: Vec::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Consume the analyzer and return its output.
+    pub fn into_output(self) -> FunctionAnalyzerOutput {
+        FunctionAnalyzerOutput {
+            array_types: self.array_types,
+            array_type_defs: self.array_type_defs,
+            strings: self.strings,
+            warnings: self.warnings,
+        }
+    }
+
+    /// Add a string to the string table, returning its index.
+    /// Deduplicates identical strings.
+    pub fn add_string(&mut self, content: String) -> u32 {
+        use std::collections::hash_map::Entry;
+        match self.string_table.entry(content) {
+            Entry::Occupied(e) => *e.get(),
+            Entry::Vacant(e) => {
+                let id = self.strings.len() as u32;
+                self.strings.push(e.key().clone());
+                e.insert(id);
+                id
+            }
+        }
+    }
+
+    /// Add a warning.
+    pub fn add_warning(&mut self, warning: CompileWarning) {
+        self.warnings.push(warning);
+    }
+
+    /// Get or create an array type, returning its ID.
+    pub fn get_or_create_array_type(&mut self, element_type: Type, length: u64) -> ArrayTypeId {
+        let key = (element_type, length);
+
+        // First check if it exists in the shared context
+        if let Some(id) = self.ctx.get_array_type(element_type, length) {
+            return id;
+        }
+
+        // Then check local cache
+        if let Some(&id) = self.array_types.get(&key) {
+            return id;
+        }
+
+        // Create new array type locally
+        // Use an offset based on context's array types to avoid ID collisions
+        let base_id = self.ctx.array_type_defs.len() as u32;
+        let id = ArrayTypeId(base_id + self.array_type_defs.len() as u32);
+        self.array_type_defs.push(ArrayTypeDef {
+            element_type,
+            length,
+        });
+        self.array_types.insert(key, id);
+        id
+    }
+
+    /// Get an array type definition by ID.
+    ///
+    /// First checks the shared context, then the local definitions.
+    pub fn get_array_type_def(&self, id: ArrayTypeId) -> &ArrayTypeDef {
+        let base_id = self.ctx.array_type_defs.len() as u32;
+        if id.0 < base_id {
+            // From shared context
+            &self.ctx.array_type_defs[id.0 as usize]
+        } else {
+            // From local definitions
+            let local_idx = (id.0 - base_id) as usize;
+            &self.array_type_defs[local_idx]
+        }
+    }
+
+    /// Pre-create array types from a resolved InferType.
+    ///
+    /// This walks the InferType recursively and ensures all array types that will
+    /// be needed during `infer_type_to_type` conversion are created beforehand.
+    pub fn pre_create_array_types_from_infer_type(&mut self, ty: &InferType) {
+        match ty {
+            InferType::Array { element, length } => {
+                // First recursively process nested array types
+                self.pre_create_array_types_from_infer_type(element);
+
+                // Convert the element type to get the concrete Type
+                let elem_ty = self.infer_type_to_concrete_type_for_key(element);
+                if elem_ty != Type::Error {
+                    // Pre-create this array type
+                    self.get_or_create_array_type(elem_ty, *length);
+                }
+            }
+            InferType::Concrete(_) | InferType::Var(_) | InferType::IntLiteral => {
+                // Non-array types don't need pre-creation
+            }
+        }
+    }
+
+    /// Convert an InferType to a concrete Type for use as an array element key.
+    fn infer_type_to_concrete_type_for_key(&self, ty: &InferType) -> Type {
+        match ty {
+            InferType::Concrete(t) => *t,
+            InferType::Var(_) => Type::Error,
+            InferType::IntLiteral => Type::I32,
+            InferType::Array { element, length } => {
+                let elem_ty = self.infer_type_to_concrete_type_for_key(element);
+                if elem_ty == Type::Error {
+                    return Type::Error;
+                }
+                // Check shared context first
+                if let Some(id) = self.ctx.get_array_type(elem_ty, *length) {
+                    return Type::Array(id);
+                }
+                // Then check local cache
+                let key = (elem_ty, *length);
+                if let Some(&id) = self.array_types.get(&key) {
+                    Type::Array(id)
+                } else {
+                    Type::Error
+                }
+            }
+        }
+    }
+
+    /// Convert a fully-resolved InferType to a concrete Type.
+    pub fn infer_type_to_type(&self, ty: &InferType) -> Type {
+        match ty {
+            InferType::Concrete(t) => *t,
+            InferType::Var(_) => Type::Error,
+            InferType::IntLiteral => Type::I32,
+            InferType::Array { element, length } => {
+                let elem_ty = self.infer_type_to_type(element);
+                if elem_ty == Type::Error {
+                    return Type::Error;
+                }
+                // Check shared context first
+                if let Some(id) = self.ctx.get_array_type(elem_ty, *length) {
+                    return Type::Array(id);
+                }
+                // Then check local cache
+                let key = (elem_ty, *length);
+                if let Some(&id) = self.array_types.get(&key) {
+                    Type::Array(id)
+                } else {
+                    // Should have been pre-created
+                    debug_assert!(false, "Array type not found: ({:?}, {})", elem_ty, length);
+                    Type::Error
+                }
+            }
+        }
+    }
+
+    /// Check that a preview feature is enabled.
+    pub fn require_preview(
+        &self,
+        feature: PreviewFeature,
+        what: &str,
+        span: Span,
+    ) -> CompileResult<()> {
+        if self.ctx.preview_features.contains(&feature) {
+            Ok(())
+        } else {
+            Err(CompileError::new(
+                ErrorKind::PreviewFeatureRequired {
+                    feature,
+                    what: what.to_string(),
+                },
+                span,
+            )
+            .with_help(format!(
+                "use `--preview {}` to enable this feature ({})",
+                feature.name(),
+                feature.adr()
+            )))
+        }
+    }
+
+    /// Get a human-readable name for a type.
+    /// Delegates to context for most types but handles local array types.
+    pub fn format_type_name(&self, ty: Type) -> String {
+        match ty {
+            Type::Array(array_id) => {
+                let array_def = self.get_array_type_def(array_id);
+                format!(
+                    "[{}; {}]",
+                    self.format_type_name(array_def.element_type),
+                    array_def.length
+                )
+            }
+            _ => self.ctx.format_type_name(ty),
+        }
+    }
+
+    /// Check if a type is a Copy type.
+    /// Delegates to context for most types but handles local array types.
+    pub fn is_type_copy(&self, ty: Type) -> bool {
+        match ty {
+            Type::Array(array_id) => {
+                let array_def = self.get_array_type_def(array_id);
+                self.is_type_copy(array_def.element_type)
+            }
+            _ => self.ctx.is_type_copy(ty),
+        }
+    }
+
+    /// Get the number of ABI slots required for a type.
+    /// Delegates to context for most types but handles local array types.
+    pub fn abi_slot_count(&self, ty: Type) -> u32 {
+        match ty {
+            Type::Array(array_id) => {
+                let array_def = self.get_array_type_def(array_id);
+                let element_slots = self.abi_slot_count(array_def.element_type);
+                element_slots * array_def.length as u32
+            }
+            _ => self.ctx.abi_slot_count(ty),
+        }
+    }
+
+    /// Resolve a type symbol to a Type.
+    pub fn resolve_type(&mut self, type_sym: Spur, span: Span) -> CompileResult<Type> {
+        let type_name = self.ctx.interner.resolve(&type_sym);
+
+        // Check primitive types first
+        match type_name {
+            "i8" => return Ok(Type::I8),
+            "i16" => return Ok(Type::I16),
+            "i32" => return Ok(Type::I32),
+            "i64" => return Ok(Type::I64),
+            "u8" => return Ok(Type::U8),
+            "u16" => return Ok(Type::U16),
+            "u32" => return Ok(Type::U32),
+            "u64" => return Ok(Type::U64),
+            "bool" => return Ok(Type::Bool),
+            "()" => return Ok(Type::Unit),
+            "!" => return Ok(Type::Never),
+            _ => {}
+        }
+
+        if let Some(struct_id) = self.ctx.get_struct(type_sym) {
+            Ok(Type::Struct(struct_id))
+        } else if let Some(enum_id) = self.ctx.get_enum(type_sym) {
+            Ok(Type::Enum(enum_id))
+        } else {
+            // Check for array type syntax: [T; N]
+            if let Some((element_type, length)) = crate::types::parse_array_type_syntax(type_name) {
+                // Resolve the element type first
+                let element_sym = self.ctx.interner.get_or_intern(&element_type);
+                let element_ty = self.resolve_type(element_sym, span)?;
+                // Get or create the array type
+                let array_type_id = self.get_or_create_array_type(element_ty, length);
+                Ok(Type::Array(array_type_id))
+            } else {
+                Err(CompileError::new(
+                    ErrorKind::UnknownType(type_name.to_string()),
+                    span,
+                ))
+            }
+        }
+    }
+
+    /// Access the warnings collected during analysis.
+    pub fn warnings(&self) -> &[CompileWarning] {
+        &self.warnings
+    }
+
+    /// Access the strings collected during analysis.
+    pub fn strings(&self) -> &[String] {
+        &self.strings
+    }
+}
+
+/// Merge multiple function analyzer outputs into a single result.
+///
+/// This is used after parallel analysis to combine results from all functions.
+#[derive(Debug, Default)]
+pub struct MergedFunctionOutput {
+    /// All array type definitions (deduplicated).
+    pub array_type_defs: Vec<ArrayTypeDef>,
+    /// Mapping from original (element_type, length) to final ArrayTypeId.
+    pub array_type_map: HashMap<(Type, u64), ArrayTypeId>,
+    /// All string literals (deduplicated).
+    pub strings: Vec<String>,
+    /// Mapping from string content to final index.
+    pub string_map: HashMap<String, u32>,
+    /// All warnings from all functions.
+    pub warnings: Vec<CompileWarning>,
+}
+
+impl MergedFunctionOutput {
+    /// Create a new empty merged output.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Initialize with array types from the context.
+    pub fn with_context_arrays(ctx: &SemaContext) -> Self {
+        let array_type_map: HashMap<(Type, u64), ArrayTypeId> = ctx.array_types.clone();
+        let array_type_defs = ctx.array_type_defs.clone();
+        Self {
+            array_type_defs,
+            array_type_map,
+            strings: Vec::new(),
+            string_map: HashMap::new(),
+            warnings: Vec::new(),
+        }
+    }
+
+    /// Merge a function's output into this merged result.
+    ///
+    /// Returns a remapping for array type IDs and string indices so the
+    /// function's AIR can be updated with the final IDs.
+    pub fn merge_function_output(
+        &mut self,
+        output: FunctionAnalyzerOutput,
+    ) -> FunctionOutputRemapping {
+        let mut array_remap = HashMap::new();
+        let mut string_remap = HashMap::new();
+
+        // Merge array types (deduplicate by (element_type, length))
+        for (key, old_id) in output.array_types {
+            let new_id = if let Some(&id) = self.array_type_map.get(&key) {
+                id
+            } else {
+                let id = ArrayTypeId(self.array_type_defs.len() as u32);
+                self.array_type_defs.push(ArrayTypeDef {
+                    element_type: key.0,
+                    length: key.1,
+                });
+                self.array_type_map.insert(key, id);
+                id
+            };
+            if old_id != new_id {
+                array_remap.insert(old_id, new_id);
+            }
+        }
+
+        // Merge strings (deduplicate by content)
+        for (idx, content) in output.strings.into_iter().enumerate() {
+            let old_id = idx as u32;
+            let new_id = if let Some(&id) = self.string_map.get(&content) {
+                id
+            } else {
+                let id = self.strings.len() as u32;
+                self.strings.push(content.clone());
+                self.string_map.insert(content, id);
+                id
+            };
+            if old_id != new_id {
+                string_remap.insert(old_id, new_id);
+            }
+        }
+
+        // Merge warnings
+        self.warnings.extend(output.warnings);
+
+        FunctionOutputRemapping {
+            array_remap,
+            string_remap,
+        }
+    }
+}
+
+/// Remapping information for updating AIR after merging.
+#[derive(Debug, Default)]
+pub struct FunctionOutputRemapping {
+    /// Mapping from old ArrayTypeId to new ArrayTypeId.
+    pub array_remap: HashMap<ArrayTypeId, ArrayTypeId>,
+    /// Mapping from old string index to new string index.
+    pub string_remap: HashMap<u32, u32>,
+}
+
+impl FunctionOutputRemapping {
+    /// Check if any remapping is needed.
+    pub fn is_empty(&self) -> bool {
+        self.array_remap.is_empty() && self.string_remap.is_empty()
+    }
+
+    /// Remap an array type ID if needed.
+    pub fn remap_array_type(&self, id: ArrayTypeId) -> ArrayTypeId {
+        self.array_remap.get(&id).copied().unwrap_or(id)
+    }
+
+    /// Remap a string index if needed.
+    pub fn remap_string(&self, id: u32) -> u32 {
+        self.string_remap.get(&id).copied().unwrap_or(id)
+    }
+}

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -11,13 +11,18 @@
 //! Inspired by Zig's AIR (Analyzed Intermediate Representation).
 
 mod analysis_state;
+mod function_analyzer;
 mod inference;
 mod inst;
 mod sema;
+mod sema_context;
 mod type_context;
 mod types;
 
 pub use analysis_state::{AnalysisStateRemapping, FunctionAnalysisState, MergedAnalysisState};
+pub use function_analyzer::{
+    FunctionAnalyzer, FunctionAnalyzerOutput, FunctionOutputRemapping, MergedFunctionOutput,
+};
 pub use inference::{
     Constraint, ConstraintContext, ConstraintGenerator, ExprInfo, FunctionSig, InferType,
     LocalVarInfo, MethodSig, ParamVarInfo, Substitution, TypeVarAllocator, TypeVarId,
@@ -27,6 +32,10 @@ pub use inst::{
     Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirParamMode, AirPattern, AirRef,
 };
 pub use sema::{AnalyzedFunction, FunctionInfo, GatherOutput, MethodInfo, Sema, SemaOutput};
+pub use sema_context::{
+    FunctionInfo as SemaContextFunctionInfo, InferenceContext as SemaContextInferenceContext,
+    MethodInfo as SemaContextMethodInfo, SemaContext,
+};
 pub use type_context::{FunctionSignature, MethodSignature, TypeContext};
 pub use types::{
     ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructField, StructId, Type,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -32,6 +32,10 @@ use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileErrors, MultiErrorResult, PreviewFeatures};
 use rue_rir::Rir;
 
+use crate::sema_context::{
+    FunctionInfo as SemaContextFunctionInfo, InferenceContext as SemaContextInferenceContext,
+    MethodInfo as SemaContextMethodInfo, SemaContext,
+};
 use crate::types::{ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructId, Type};
 
 // Internal types are used via pub(crate) within submodules
@@ -391,6 +395,139 @@ impl<'a> Sema<'a> {
         };
 
         Ok((type_ctx, output))
+    }
+
+    /// Build a SemaContext from the current Sema state.
+    ///
+    /// This creates an immutable context that can be shared across threads
+    /// for parallel function body analysis. The SemaContext contains all
+    /// type definitions, function signatures, and method signatures.
+    ///
+    /// # Usage
+    ///
+    /// ```ignore
+    /// let mut sema = Sema::new(rir, interner, preview);
+    /// sema.inject_builtin_types();
+    /// sema.register_type_names()?;
+    /// sema.resolve_declarations()?;
+    /// let ctx = sema.build_sema_context();
+    /// // Now ctx can be shared across threads for parallel analysis
+    /// ```
+    pub fn build_sema_context(&self) -> SemaContext<'a> {
+        // Build the inference context
+        let inference_ctx = self.build_sema_context_inference();
+
+        SemaContext {
+            rir: self.rir,
+            interner: self.interner,
+            struct_defs: self.struct_defs.clone(),
+            enum_defs: self.enum_defs.clone(),
+            array_types: self.array_types.clone(),
+            array_type_defs: self.array_type_defs.clone(),
+            structs: self.structs.clone(),
+            enums: self.enums.clone(),
+            functions: self
+                .functions
+                .iter()
+                .map(|(name, info)| {
+                    (
+                        *name,
+                        SemaContextFunctionInfo {
+                            param_types: info.param_types.clone(),
+                            param_modes: info.param_modes.clone(),
+                            return_type: info.return_type,
+                        },
+                    )
+                })
+                .collect(),
+            methods: self
+                .methods
+                .iter()
+                .map(|((type_name, method_name), info)| {
+                    (
+                        (*type_name, *method_name),
+                        SemaContextMethodInfo {
+                            struct_type: info.struct_type,
+                            has_self: info.has_self,
+                            param_names: info.param_names.clone(),
+                            param_types: info.param_types.clone(),
+                            return_type: info.return_type,
+                            body: info.body,
+                            span: info.span,
+                        },
+                    )
+                })
+                .collect(),
+            preview_features: self.preview_features.clone(),
+            builtin_string_id: self.builtin_string_id,
+            inference_ctx,
+        }
+    }
+
+    /// Build the inference context portion of SemaContext.
+    fn build_sema_context_inference(&self) -> SemaContextInferenceContext {
+        use crate::inference::{FunctionSig, MethodSig};
+
+        // Build function signatures with InferType for constraint generation
+        let func_sigs: HashMap<Spur, FunctionSig> = self
+            .functions
+            .iter()
+            .map(|(name, info)| {
+                (
+                    *name,
+                    FunctionSig {
+                        param_types: info
+                            .param_types
+                            .iter()
+                            .map(|t| self.type_to_infer_type(*t))
+                            .collect(),
+                        return_type: self.type_to_infer_type(info.return_type),
+                    },
+                )
+            })
+            .collect();
+
+        // Build struct types map (name -> Type::Struct(id))
+        let struct_types: HashMap<Spur, Type> = self
+            .structs
+            .iter()
+            .map(|(name, id)| (*name, Type::Struct(*id)))
+            .collect();
+
+        // Build enum types map (name -> Type::Enum(id))
+        let enum_types: HashMap<Spur, Type> = self
+            .enums
+            .iter()
+            .map(|(name, id)| (*name, Type::Enum(*id)))
+            .collect();
+
+        // Build method signatures with InferType for constraint generation
+        let method_sigs: HashMap<(Spur, Spur), MethodSig> = self
+            .methods
+            .iter()
+            .map(|((type_name, method_name), info)| {
+                (
+                    (*type_name, *method_name),
+                    MethodSig {
+                        struct_type: info.struct_type,
+                        has_self: info.has_self,
+                        param_types: info
+                            .param_types
+                            .iter()
+                            .map(|t| self.type_to_infer_type(*t))
+                            .collect(),
+                        return_type: self.type_to_infer_type(info.return_type),
+                    },
+                )
+            })
+            .collect();
+
+        SemaContextInferenceContext {
+            func_sigs,
+            struct_types,
+            enum_types,
+            method_sigs,
+        }
     }
 }
 

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -1,0 +1,312 @@
+//! Immutable semantic analysis context.
+//!
+//! This module contains `SemaContext`, which holds all type information and
+//! declarations that are immutable after the declaration gathering phase.
+//! `SemaContext` is designed to be `Send + Sync` for future parallel function analysis.
+//!
+//! # Architecture
+//!
+//! The semantic analysis pipeline is split into two phases:
+//!
+//! 1. **Declaration gathering** (sequential): Builds the `SemaContext` with all
+//!    type definitions, function signatures, and method signatures.
+//!
+//! 2. **Function body analysis** (parallelizable): Each function is analyzed
+//!    using a `FunctionAnalyzer` that holds a reference to the shared `SemaContext`.
+//!
+//! This separation enables:
+//! - Parallel type checking (each function can be analyzed independently)
+//! - Better cache locality (immutable context can be shared)
+//! - Foundation for incremental compilation (can cache `SemaContext` across compilations)
+
+use std::collections::HashMap;
+
+use lasso::{Spur, ThreadedRodeo};
+use rue_error::PreviewFeatures;
+use rue_rir::{Rir, RirParamMode};
+
+use crate::inference::{FunctionSig, InferType, MethodSig};
+use crate::types::{ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructId, Type};
+
+/// Information about a function.
+#[derive(Debug, Clone)]
+pub struct FunctionInfo {
+    /// Parameter types (in order)
+    pub param_types: Vec<Type>,
+    /// Parameter modes (in order)
+    pub param_modes: Vec<RirParamMode>,
+    /// Return type
+    pub return_type: Type,
+}
+
+/// Information about a method in an impl block.
+#[derive(Debug, Clone)]
+pub struct MethodInfo {
+    /// The struct type this method belongs to
+    pub struct_type: Type,
+    /// Whether this is a method (has self) or associated function (no self)
+    pub has_self: bool,
+    /// Parameter names (excluding self if present)
+    pub param_names: Vec<Spur>,
+    /// Parameter types (excluding self if present)
+    pub param_types: Vec<Type>,
+    /// Return type
+    pub return_type: Type,
+    /// The RIR instruction ref for the method body
+    pub body: rue_rir::InstRef,
+    /// Span of the method declaration
+    pub span: rue_span::Span,
+}
+
+/// Pre-computed type information for constraint generation.
+///
+/// This struct holds the function, struct, enum, and method signature maps
+/// converted to `InferType` format for use in Hindley-Milner type inference.
+/// Building this once and reusing it for all function analyses avoids the
+/// O(n²) cost of rebuilding these maps for each function.
+#[derive(Debug)]
+pub struct InferenceContext {
+    /// Function signatures with InferType (for constraint generation).
+    pub func_sigs: HashMap<Spur, FunctionSig>,
+    /// Struct types: name -> Type::Struct(id).
+    pub struct_types: HashMap<Spur, Type>,
+    /// Enum types: name -> Type::Enum(id).
+    pub enum_types: HashMap<Spur, Type>,
+    /// Method signatures with InferType: (struct_name, method_name) -> MethodSig.
+    pub method_sigs: HashMap<(Spur, Spur), MethodSig>,
+}
+
+/// Immutable context for semantic analysis.
+///
+/// This struct contains all type information and declarations that are
+/// read-only after the declaration gathering phase. It is designed to be
+/// `Send + Sync` so it can be shared across threads during parallel function
+/// body analysis.
+///
+/// # Contents
+///
+/// - Struct and enum definitions
+/// - Function and method signatures
+/// - Array type registry
+/// - Pre-computed inference context
+/// - Built-in type IDs
+///
+/// # Thread Safety
+///
+/// `SemaContext` is `Send + Sync` because:
+/// - All contained data is immutable after construction
+/// - References to RIR and interner are shared immutably
+/// - No `Cell`, `RefCell`, or other interior mutability types are used
+#[derive(Debug)]
+pub struct SemaContext<'a> {
+    /// Reference to the RIR being analyzed.
+    pub rir: &'a Rir,
+    /// Reference to the string interner.
+    pub interner: &'a ThreadedRodeo,
+    /// Struct definitions indexed by StructId.
+    pub struct_defs: Vec<StructDef>,
+    /// Enum definitions indexed by EnumId.
+    pub enum_defs: Vec<EnumDef>,
+    /// Array type table: maps (element_type, length) to ArrayTypeId.
+    /// Pre-populated during declaration gathering for array types in signatures.
+    pub array_types: HashMap<(Type, u64), ArrayTypeId>,
+    /// Array type definitions indexed by ArrayTypeId.
+    pub array_type_defs: Vec<ArrayTypeDef>,
+    /// Struct lookup: maps struct name symbol to StructId.
+    pub structs: HashMap<Spur, StructId>,
+    /// Enum lookup: maps enum name symbol to EnumId.
+    pub enums: HashMap<Spur, EnumId>,
+    /// Function lookup: maps function name to info.
+    pub functions: HashMap<Spur, FunctionInfo>,
+    /// Method lookup: maps (struct_name, method_name) to info.
+    pub methods: HashMap<(Spur, Spur), MethodInfo>,
+    /// Enabled preview features.
+    pub preview_features: PreviewFeatures,
+    /// StructId of the synthetic String type.
+    pub builtin_string_id: Option<StructId>,
+    /// Pre-computed inference context for HM type inference.
+    pub inference_ctx: InferenceContext,
+}
+
+// SAFETY: SemaContext contains only immutable data after construction.
+// The references to RIR and ThreadedRodeo are shared immutably.
+// ThreadedRodeo is designed to be thread-safe.
+unsafe impl<'a> Send for SemaContext<'a> {}
+unsafe impl<'a> Sync for SemaContext<'a> {}
+
+impl<'a> SemaContext<'a> {
+    /// Get the builtin String type as a Type::Struct.
+    pub fn builtin_string_type(&self) -> Type {
+        self.builtin_string_id
+            .map(Type::Struct)
+            .expect("String type should be registered during builtin injection")
+    }
+
+    /// Look up a struct by name.
+    pub fn get_struct(&self, name: Spur) -> Option<StructId> {
+        self.structs.get(&name).copied()
+    }
+
+    /// Get a struct definition by ID.
+    pub fn get_struct_def(&self, id: StructId) -> &StructDef {
+        &self.struct_defs[id.0 as usize]
+    }
+
+    /// Look up an enum by name.
+    pub fn get_enum(&self, name: Spur) -> Option<EnumId> {
+        self.enums.get(&name).copied()
+    }
+
+    /// Get an enum definition by ID.
+    pub fn get_enum_def(&self, id: EnumId) -> &EnumDef {
+        &self.enum_defs[id.0 as usize]
+    }
+
+    /// Look up a function by name.
+    pub fn get_function(&self, name: Spur) -> Option<&FunctionInfo> {
+        self.functions.get(&name)
+    }
+
+    /// Look up a method by type and method name.
+    pub fn get_method(&self, type_name: Spur, method_name: Spur) -> Option<&MethodInfo> {
+        self.methods.get(&(type_name, method_name))
+    }
+
+    /// Get an array type definition by ID.
+    pub fn get_array_type_def(&self, id: ArrayTypeId) -> &ArrayTypeDef {
+        &self.array_type_defs[id.0 as usize]
+    }
+
+    /// Look up an array type by element type and length.
+    pub fn get_array_type(&self, element_type: Type, length: u64) -> Option<ArrayTypeId> {
+        self.array_types.get(&(element_type, length)).copied()
+    }
+
+    /// Get a human-readable name for a type.
+    pub fn format_type_name(&self, ty: Type) -> String {
+        match ty {
+            Type::I8 => "i8".to_string(),
+            Type::I16 => "i16".to_string(),
+            Type::I32 => "i32".to_string(),
+            Type::I64 => "i64".to_string(),
+            Type::U8 => "u8".to_string(),
+            Type::U16 => "u16".to_string(),
+            Type::U32 => "u32".to_string(),
+            Type::U64 => "u64".to_string(),
+            Type::Bool => "bool".to_string(),
+            Type::Unit => "()".to_string(),
+            Type::Never => "!".to_string(),
+            Type::Error => "<error>".to_string(),
+            Type::Struct(struct_id) => self.struct_defs[struct_id.0 as usize].name.clone(),
+            Type::Enum(enum_id) => self.enum_defs[enum_id.0 as usize].name.clone(),
+            Type::Array(array_id) => {
+                let array_def = &self.array_type_defs[array_id.0 as usize];
+                format!(
+                    "[{}; {}]",
+                    self.format_type_name(array_def.element_type),
+                    array_def.length
+                )
+            }
+        }
+    }
+
+    /// Check if a type is a Copy type.
+    pub fn is_type_copy(&self, ty: Type) -> bool {
+        match ty {
+            // Primitive Copy types
+            Type::I8
+            | Type::I16
+            | Type::I32
+            | Type::I64
+            | Type::U8
+            | Type::U16
+            | Type::U32
+            | Type::U64
+            | Type::Bool
+            | Type::Unit => true,
+            // Enum types are Copy (they're small discriminant values)
+            Type::Enum(_) => true,
+            // Never and Error are Copy for convenience
+            Type::Never | Type::Error => true,
+            // Struct types: check if marked with @copy
+            Type::Struct(struct_id) => {
+                let struct_def = &self.struct_defs[struct_id.0 as usize];
+                struct_def.is_copy
+            }
+            // Arrays are Copy if their element type is Copy
+            Type::Array(array_id) => {
+                let array_def = &self.array_type_defs[array_id.0 as usize];
+                self.is_type_copy(array_def.element_type)
+            }
+        }
+    }
+
+    /// Get the number of ABI slots required for a type.
+    pub fn abi_slot_count(&self, ty: Type) -> u32 {
+        match ty {
+            Type::I8
+            | Type::I16
+            | Type::I32
+            | Type::I64
+            | Type::U8
+            | Type::U16
+            | Type::U32
+            | Type::U64
+            | Type::Bool
+            | Type::Error => 1,
+            Type::Unit | Type::Never => 0,
+            Type::Enum(_) => 1,
+            Type::Struct(struct_id) => {
+                let struct_def = &self.struct_defs[struct_id.0 as usize];
+                struct_def
+                    .fields
+                    .iter()
+                    .map(|f| self.abi_slot_count(f.ty))
+                    .sum()
+            }
+            Type::Array(array_type_id) => {
+                let array_def = &self.array_type_defs[array_type_id.0 as usize];
+                let element_slots = self.abi_slot_count(array_def.element_type);
+                element_slots * array_def.length as u32
+            }
+        }
+    }
+
+    /// Get the slot offset of a field within a struct.
+    pub fn field_slot_offset(&self, struct_id: StructId, field_index: usize) -> u32 {
+        let struct_def = &self.struct_defs[struct_id.0 as usize];
+        struct_def.fields[..field_index]
+            .iter()
+            .map(|f| self.abi_slot_count(f.ty))
+            .sum()
+    }
+
+    /// Convert a concrete Type to InferType for use in constraint generation.
+    pub fn type_to_infer_type(&self, ty: Type) -> InferType {
+        match ty {
+            Type::Array(array_id) => {
+                let array_def = &self.array_type_defs[array_id.0 as usize];
+                let element_infer = self.type_to_infer_type(array_def.element_type);
+                InferType::Array {
+                    element: Box::new(element_infer),
+                    length: array_def.length,
+                }
+            }
+            _ => InferType::Concrete(ty),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Compile-time assertion that SemaContext is Send + Sync.
+    /// This is critical for parallel function body analysis.
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn test_sema_context_is_send_sync() {
+        assert_send_sync::<SemaContext<'_>>();
+    }
+}


### PR DESCRIPTION
Refactor semantic analysis to separate immutable shared state from per-function mutable state, enabling future parallel function body analysis:

- SemaContext: immutable type context (Send + Sync) containing struct/enum defs, function/method signatures, inference context, and builtin type IDs
- FunctionAnalyzer: per-function mutable state for strings, array types, warnings
- MergedFunctionOutput: post-analysis merging infrastructure for parallel results

Key changes:
- Add sema_context.rs with SemaContext and helper methods
- Add function_analyzer.rs with FunctionAnalyzer and merging infrastructure
- Add build_sema_context() method to Sema for creating shared context
- Export new types from lib.rs

Fixes rue-6ewz

🤖 Generated with [Claude Code](https://claude.com/claude-code)