### PR TITLE
Improve error recovery: add IsInteger constraint for arithmetic

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -999,6 +999,9 @@ impl<'a> ConstraintGenerator<'a> {
             rhs_info.span,
         ));
 
+        // Result must be an integer type (catches errors like `true + 1` early)
+        self.add_constraint(Constraint::is_integer(result_ty.clone(), lhs_info.span));
+
         result_ty
     }
 
@@ -1161,8 +1164,13 @@ mod tests {
 
         // Result should be a type variable
         assert!(info.ty.is_var());
-        // Should generate 2 constraints: lhs = result, rhs = result
-        assert_eq!(cgen.constraints().len(), 2);
+        // Should generate 3 constraints: lhs = result, rhs = result, IsInteger(result)
+        assert_eq!(cgen.constraints().len(), 3);
+        // Verify the third constraint is IsInteger
+        match &cgen.constraints()[2] {
+            Constraint::IsInteger(_, _) => {}
+            _ => panic!("Expected IsInteger constraint for arithmetic result"),
+        }
     }
 
     #[test]

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -182,4 +182,91 @@ mod tests {
             .any(|(_, inst)| matches!(inst.data, AirInstData::UnitConst));
         assert!(has_unit_const, "Empty block should produce UnitConst");
     }
+
+    // =========================================================================
+    // Error recovery tests
+    // =========================================================================
+    // These tests verify that one type error does not cause cascading errors.
+    // The issue rue-wqyw tracks the implementation of better error recovery.
+
+    #[test]
+    fn test_single_error_no_cascade_simple() {
+        // A simple case where adding an integer and boolean should report exactly one error
+        let result = compile_to_air("fn main() -> i32 { 1 + true }");
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert_eq!(
+            errors.len(),
+            1,
+            "Should have exactly 1 error, not cascading errors"
+        );
+
+        // Verify the error is about type mismatch (integer vs bool)
+        let error = errors.iter().next().unwrap();
+        assert!(
+            matches!(&error.kind, ErrorKind::TypeMismatch { expected, found }
+                if expected.contains("integer") && found.contains("bool")),
+            "Error should mention integer and bool, got: {:?}",
+            error.kind
+        );
+    }
+
+    #[test]
+    fn test_single_error_no_cascade_with_function_call() {
+        // The error-typed variable is used in a function call - should not cascade
+        let result = compile_to_air(
+            "fn foo(a: i32, b: i32) -> i32 { a + b }
+             fn main() -> i32 {
+                 let x = 1 + true;
+                 foo(x, 1)
+             }",
+        );
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert_eq!(
+            errors.len(),
+            1,
+            "Should have exactly 1 error for the original type mismatch"
+        );
+    }
+
+    #[test]
+    fn test_single_error_no_cascade_deep_chain() {
+        // Deep chain of operations using error-typed value - should not cascade
+        let result = compile_to_air(
+            "fn main() -> i32 {
+                 let x = 1 + true;
+                 let y = x + 1;
+                 let z = y * 2;
+                 let w = z - 3;
+                 let v = w / 4;
+                 v
+             }",
+        );
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert_eq!(
+            errors.len(),
+            1,
+            "Should have exactly 1 error, not 5 cascading errors"
+        );
+    }
+
+    #[test]
+    fn test_bool_plus_int_error() {
+        // Reversed order: bool + int should also give one error
+        let result = compile_to_air("fn main() -> i32 { true + 1 }");
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1);
+    }
+
+    #[test]
+    fn test_arithmetic_on_bool_type_error() {
+        // Using bool in any arithmetic should be an error
+        let result = compile_to_air("fn main() -> i32 { true * true }");
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1);
+    }
 }


### PR DESCRIPTION
Add an IsInteger constraint in generate_binary_arith to catch type errors at the correct location. Previously, errors like `1 + true` would be caught at downstream uses (e.g., `foo(x, 1)`) rather than at the arithmetic operation itself, causing confusing error messages.

Changes:
- Add IsInteger constraint for arithmetic operation results
- Update unit test to expect 3 constraints instead of 2
- Add 5 new unit tests verifying error recovery behavior:
  - Single error doesn't cascade
  - Error-typed variables in function calls
  - Deep chains of dependent operations
  - Both operand orderings (int+bool, bool+int)
  - Both operands being bool

The fix ensures that `1 + true` reports "expected integer type, found bool" at the correct source location, not a confusing cascading error elsewhere.

Fixes rue-wqyw

🤖 Generated with [Claude Code](https://claude.com/claude-code)