### PR TITLE
Add strength reduction: multiply by power of 2 -> shift

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -889,10 +889,110 @@ impl<'a> CfgLower<'a> {
                 self.value_map.insert(value, vreg);
 
                 let lhs_vreg = self.get_vreg(*lhs);
-                let rhs_vreg = self.get_vreg(*rhs);
 
-                // Overflow check for multiplication
-                self.emit_overflow_check_mul(ty, vreg, lhs_vreg, rhs_vreg);
+                // Strength reduction: multiply by power of 2 -> shift left
+                // This replaces expensive MUL with LSL (typically faster).
+                // Only apply to 32/64-bit types - sub-word types (i8, i16, u8, u16)
+                // have complex overflow checking that doesn't work well with shifts.
+                // Check rhs first (more common: x * constant), then lhs (constant * x)
+                //
+                // Future optimization: x * 2 could use `add x, x` instead of `lsl x, #1`
+                // (same latency but potentially better for some microarchitectures).
+                let is_word_or_larger = matches!(ty, Type::I32 | Type::I64 | Type::U32 | Type::U64);
+                let shift_amount = if is_word_or_larger {
+                    self.try_power_of_two_shift(*rhs)
+                        .or_else(|| self.try_power_of_two_shift(*lhs))
+                } else {
+                    None
+                };
+
+                if let Some(shift) = shift_amount {
+                    // Use the non-constant operand as the value to shift
+                    let src_vreg = if self.try_power_of_two_shift(*rhs).is_some() {
+                        lhs_vreg
+                    } else {
+                        self.get_vreg(*rhs)
+                    };
+
+                    // Emit shift left
+                    if ty.is_64_bit() {
+                        self.mir.push(Aarch64Inst::LslImm {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Virtual(src_vreg),
+                            imm: shift,
+                        });
+                    } else {
+                        self.mir.push(Aarch64Inst::Lsl32Imm {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Virtual(src_vreg),
+                            imm: shift,
+                        });
+                    }
+
+                    // Overflow check: shift back and compare with original
+                    // If they differ, bits were lost during the shift (overflow)
+                    let check_vreg = self.mir.alloc_vreg();
+
+                    // Use arithmetic shift (ASR) for signed, logical shift (LSR) for unsigned
+                    if ty.is_signed() {
+                        if ty.is_64_bit() {
+                            self.mir.push(Aarch64Inst::Asr64Imm {
+                                dst: Operand::Virtual(check_vreg),
+                                src: Operand::Virtual(vreg),
+                                imm: shift,
+                            });
+                        } else {
+                            self.mir.push(Aarch64Inst::Asr32Imm {
+                                dst: Operand::Virtual(check_vreg),
+                                src: Operand::Virtual(vreg),
+                                imm: shift,
+                            });
+                        }
+                    } else if ty.is_64_bit() {
+                        self.mir.push(Aarch64Inst::Lsr64Imm {
+                            dst: Operand::Virtual(check_vreg),
+                            src: Operand::Virtual(vreg),
+                            imm: shift,
+                        });
+                    } else {
+                        self.mir.push(Aarch64Inst::Lsr32Imm {
+                            dst: Operand::Virtual(check_vreg),
+                            src: Operand::Virtual(vreg),
+                            imm: shift,
+                        });
+                    }
+
+                    // Compare with original value
+                    let ok_label = self.mir.alloc_label();
+                    if ty.is_64_bit() {
+                        self.mir.push(Aarch64Inst::Cmp64RR {
+                            src1: Operand::Virtual(check_vreg),
+                            src2: Operand::Virtual(src_vreg),
+                        });
+                    } else {
+                        self.mir.push(Aarch64Inst::CmpRR {
+                            src1: Operand::Virtual(check_vreg),
+                            src2: Operand::Virtual(src_vreg),
+                        });
+                    }
+
+                    // Branch if equal (no overflow)
+                    self.mir.push(Aarch64Inst::BCond {
+                        cond: Cond::Eq,
+                        label: ok_label,
+                    });
+
+                    // Overflow - call panic handler
+                    let symbol_id = self.intern_symbol("__rue_overflow");
+                    self.mir.push(Aarch64Inst::Bl { symbol_id });
+                    self.mir.push(Aarch64Inst::Label { id: ok_label });
+                } else {
+                    // Fall back to regular multiply for non-power-of-2 constants
+                    let rhs_vreg = self.get_vreg(*rhs);
+
+                    // Overflow check for multiplication
+                    self.emit_overflow_check_mul(ty, vreg, lhs_vreg, rhs_vreg);
+                }
             }
 
             CfgInstData::Div(lhs, rhs) => {
@@ -2875,6 +2975,30 @@ impl<'a> CfgLower<'a> {
     /// Sema guarantees both operands have the same signedness, so we only need to check one.
     fn is_unsigned_comparison(&self, lhs: CfgValue) -> bool {
         self.cfg.get_inst(lhs).ty.is_unsigned()
+    }
+
+    /// Try to extract a power-of-two shift amount from a constant value.
+    ///
+    /// Returns `Some(shift_amount)` if the value is a constant that is a power of 2
+    /// greater than 1, otherwise returns `None`.
+    ///
+    /// Used for strength reduction: `x * 2^n` can be lowered to `x << n`.
+    fn try_power_of_two_shift(&self, value: CfgValue) -> Option<u8> {
+        let inst = self.cfg.get_inst(value);
+        match &inst.data {
+            CfgInstData::Const(n) => {
+                let n = *n;
+                // Check if n is a power of 2 and greater than 1
+                // n > 1 because x * 1 should be handled by identity optimization (not here)
+                // n must fit in u64 for is_power_of_two
+                if n > 1 && n.is_power_of_two() {
+                    Some(n.trailing_zeros() as u8)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
     }
 
     /// Emit overflow check for ADD based on the type.

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -968,30 +968,131 @@ impl<'a> CfgLower<'a> {
                 self.value_map.insert(value, vreg);
 
                 let lhs_vreg = self.get_vreg(*lhs);
-                let rhs_vreg = self.get_vreg(*rhs);
 
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(vreg),
-                    src: Operand::Virtual(lhs_vreg),
-                });
-
-                // Use 64-bit mul for 64-bit types to get correct overflow detection
-                if matches!(ty, Type::I64 | Type::U64) {
-                    self.mir.push(X86Inst::ImulRR64 {
-                        dst: Operand::Virtual(vreg),
-                        src: Operand::Virtual(rhs_vreg),
-                    });
+                // Strength reduction: multiply by power of 2 -> shift left
+                // This replaces expensive IMUL (3-4 cycles) with SHL (1 cycle).
+                // Only apply to 32/64-bit types - sub-word types (i8, i16, u8, u16)
+                // have complex overflow checking that doesn't work well with shifts.
+                // Check rhs first (more common: x * constant), then lhs (constant * x)
+                //
+                // Future optimization: x * 2 could use `add x, x` instead of `shl x, 1`
+                // (same latency but potentially better for some microarchitectures).
+                let is_word_or_larger = matches!(ty, Type::I32 | Type::I64 | Type::U32 | Type::U64);
+                let shift_amount = if is_word_or_larger {
+                    self.try_power_of_two_shift(*rhs)
+                        .or_else(|| self.try_power_of_two_shift(*lhs))
                 } else {
-                    self.mir.push(X86Inst::ImulRR {
-                        dst: Operand::Virtual(vreg),
-                        src: Operand::Virtual(rhs_vreg),
-                    });
-                }
+                    None
+                };
 
-                // Overflow check - use appropriate flag based on signedness
-                // Note: IMUL sets both OF and CF to the same value, so this works
-                // for both signed and unsigned multiplication
-                self.emit_overflow_check(ty, vreg);
+                if let Some(shift) = shift_amount {
+                    // Use the non-constant operand as the value to shift
+                    let src_vreg = if self.try_power_of_two_shift(*rhs).is_some() {
+                        lhs_vreg
+                    } else {
+                        self.get_vreg(*rhs)
+                    };
+
+                    // Copy source to result
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(src_vreg),
+                    });
+
+                    // Emit shift left
+                    if ty.is_64_bit() {
+                        self.mir.push(X86Inst::ShlRI {
+                            dst: Operand::Virtual(vreg),
+                            imm: shift,
+                        });
+                    } else {
+                        self.mir.push(X86Inst::Shl32RI {
+                            dst: Operand::Virtual(vreg),
+                            imm: shift,
+                        });
+                    }
+
+                    // Overflow check: shift back and compare with original
+                    // If they differ, bits were lost during the shift (overflow)
+                    let check_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(check_vreg),
+                        src: Operand::Virtual(vreg),
+                    });
+
+                    // Use arithmetic shift (SAR) for signed, logical shift (SHR) for unsigned
+                    if ty.is_signed() {
+                        if ty.is_64_bit() {
+                            self.mir.push(X86Inst::SarRI {
+                                dst: Operand::Virtual(check_vreg),
+                                imm: shift,
+                            });
+                        } else {
+                            self.mir.push(X86Inst::Sar32RI {
+                                dst: Operand::Virtual(check_vreg),
+                                imm: shift,
+                            });
+                        }
+                    } else if ty.is_64_bit() {
+                        self.mir.push(X86Inst::ShrRI {
+                            dst: Operand::Virtual(check_vreg),
+                            imm: shift,
+                        });
+                    } else {
+                        self.mir.push(X86Inst::Shr32RI {
+                            dst: Operand::Virtual(check_vreg),
+                            imm: shift,
+                        });
+                    }
+
+                    // Compare with original value
+                    if ty.is_64_bit() {
+                        self.mir.push(X86Inst::Cmp64RR {
+                            src1: Operand::Virtual(check_vreg),
+                            src2: Operand::Virtual(src_vreg),
+                        });
+                    } else {
+                        self.mir.push(X86Inst::CmpRR {
+                            src1: Operand::Virtual(check_vreg),
+                            src2: Operand::Virtual(src_vreg),
+                        });
+                    }
+
+                    // Jump if equal (no overflow)
+                    let ok_label = self.new_label();
+                    self.mir.push(X86Inst::Jz { label: ok_label });
+
+                    // Overflow - call panic handler
+                    let symbol_id = self.intern_symbol("__rue_overflow");
+                    self.mir.push(X86Inst::CallRel { symbol_id });
+                    self.mir.push(X86Inst::Label { id: ok_label });
+                } else {
+                    // Fall back to IMUL for non-power-of-2 constants
+                    let rhs_vreg = self.get_vreg(*rhs);
+
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(lhs_vreg),
+                    });
+
+                    // Use 64-bit mul for 64-bit types to get correct overflow detection
+                    if matches!(ty, Type::I64 | Type::U64) {
+                        self.mir.push(X86Inst::ImulRR64 {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Virtual(rhs_vreg),
+                        });
+                    } else {
+                        self.mir.push(X86Inst::ImulRR {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Virtual(rhs_vreg),
+                        });
+                    }
+
+                    // Overflow check - use appropriate flag based on signedness
+                    // Note: IMUL sets both OF and CF to the same value, so this works
+                    // for both signed and unsigned multiplication
+                    self.emit_overflow_check(ty, vreg);
+                }
             }
 
             CfgInstData::Div(lhs, rhs) => {
@@ -3054,6 +3155,30 @@ impl<'a> CfgLower<'a> {
     /// Sema guarantees both operands have the same signedness, so we only need to check one.
     fn is_unsigned_comparison(&self, lhs: CfgValue) -> bool {
         self.cfg.get_inst(lhs).ty.is_unsigned()
+    }
+
+    /// Try to extract a power-of-two shift amount from a constant value.
+    ///
+    /// Returns `Some(shift_amount)` if the value is a constant that is a power of 2
+    /// greater than 1, otherwise returns `None`.
+    ///
+    /// Used for strength reduction: `x * 2^n` can be lowered to `x << n`.
+    fn try_power_of_two_shift(&self, value: CfgValue) -> Option<u8> {
+        let inst = self.cfg.get_inst(value);
+        match &inst.data {
+            CfgInstData::Const(n) => {
+                let n = *n;
+                // Check if n is a power of 2 and greater than 1
+                // n > 1 because x * 1 should be handled by identity optimization (not here)
+                // n must fit in u64 for is_power_of_two
+                if n > 1 && n.is_power_of_two() {
+                    Some(n.trailing_zeros() as u8)
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
     }
 
     /// Emit overflow check based on the type.

--- a/crates/rue-spec/cases/golden/ir-dumps.toml
+++ b/crates/rue-spec/cases/golden/ir-dumps.toml
@@ -398,6 +398,9 @@ air (return_type: i32) {
 }
 """
 
+# Note: 3 * 4 uses shift (shl/lsl) instead of imul/smull because 4 is a power of 2.
+# The shift-back-and-compare pattern detects overflow.
+
 [[case]]
 name = "multiplication_mir"
 spec = ["4.2:1"]
@@ -408,8 +411,11 @@ function main:
     mov v0, 3
     mov v1, 4
     mov v2, v0
-    imul v2, v1
-    jno .L0
+    shll v2, 2
+    mov v3, v2
+    sarl v3, 2
+    cmp v3, v0
+    jz .L0
     call __rue_overflow
     .L0:
     mov rdi, v2
@@ -425,15 +431,59 @@ expected_mir = """
 function main:
     mov v0, #3
     mov v1, #4
-    smull v3, v0, v1
-    mov v2, v3
-    sxtw v4, v3
-    cmp v3, v4
+    lsl v2, v0, #2 // 32-bit
+    asr v3, v2, #2 // 32-bit
+    cmp v3, v0
     b.eq .L0
     bl __rue_overflow
     .L0:
     mov x0, v2
     bl __rue_exit
+"""
+
+# =============================================================================
+# Strength Reduction (multiply by power of 2 -> shift)
+# =============================================================================
+
+[[case]]
+name = "strength_reduction_multiply_by_8"
+spec = ["4.2:1"]
+source = "fn main() -> i32 { let x = 5; x * 8 }"
+target = "x86-64-linux"
+expected_mir = """
+function main:
+    mov v0, 5
+    mov [rbp-8], v0
+    mov v1, [rbp-8]
+    mov v2, 8
+    mov v3, v1
+    shll v3, 3
+    mov v4, v3
+    sarl v4, 3
+    cmp v4, v1
+    jz .L0
+    call __rue_overflow
+    .L0:
+    mov rdi, v3
+    call __rue_exit
+"""
+
+[[case]]
+name = "non_power_of_2_uses_imul"
+spec = ["4.2:1"]
+source = "fn main() -> i32 { 3 * 5 }"
+target = "x86-64-linux"
+expected_mir = """
+function main:
+    mov v0, 3
+    mov v1, 5
+    mov v2, v0
+    imul v2, v1
+    jno .L0
+    call __rue_overflow
+    .L0:
+    mov rdi, v2
+    call __rue_exit
 """
 
 [[case]]


### PR DESCRIPTION
Replace multiplication by powers of 2 (2, 4, 8, 16, etc.) with faster left shift instructions in both x86_64 and aarch64 backends.

- SHL/LSL is 1 cycle vs IMUL 3-4 cycles
- Includes proper overflow detection via shift-back-and-compare
- Limited to 32/64-bit types (sub-word types use IMUL for simpler overflow checks)
- Handles both 'x * constant' and 'constant * x' orderings

Fixes rue-1tbw

🤖 Generated with [Claude Code](https://claude.com/claude-code)