### PR TITLE
Eliminate unnecessary cloning in function call analysis

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1949,13 +1949,9 @@ impl<'a> Sema<'a> {
         // Check for exclusive access violation
         self.check_exclusive_access(&args, span)?;
 
-        // Clone the data we need before mutable borrow
-        let param_types = fn_info.param_types.clone();
-        let param_modes = fn_info.param_modes.clone();
-        let return_type = fn_info.return_type;
-
         // Check that call-site argument modes match function parameter modes
-        for (i, (arg, expected_mode)) in args.iter().zip(param_modes.iter()).enumerate() {
+        // Do this before the mutable borrow in analyze_call_args, accessing fn_info directly
+        for (i, (arg, expected_mode)) in args.iter().zip(fn_info.param_modes.iter()).enumerate() {
             match expected_mode {
                 RirParamMode::Inout => {
                     if arg.mode != RirArgMode::Inout {
@@ -1978,6 +1974,9 @@ impl<'a> Sema<'a> {
                 }
             }
         }
+
+        // Extract return_type before mutable borrow (Copy type, no allocation)
+        let return_type = fn_info.return_type;
 
         // Analyze arguments
         let air_args = self.analyze_call_args(air, &args, ctx)?;


### PR DESCRIPTION
Restructure the Call instruction handler to avoid allocating clones:

- Remove unused param_types.clone() (was dead code)
- Move mode-checking loop before extracting data, accessing fn_info.param_modes directly instead of cloning
- Only extract return_type (Copy type, no allocation)

This eliminates two Vec::clone() allocations per function call.

Fixes rue-hkme

🤖 Generated with [Claude Code](https://claude.com/claude-code)