### PR TITLE
Add comprehensive unit tests for sema module

### DIFF
--- a/crates/rue-air/src/inference/unify.rs
+++ b/crates/rue-air/src/inference/unify.rs
@@ -1078,4 +1078,250 @@ mod tests {
         assert_eq!(unifier.resolve(&InferType::Var(v1)), Some(Type::I64));
         assert_eq!(unifier.resolve(&InferType::Var(v2)), Some(Type::I64));
     }
+
+    // =========================================================================
+    // Additional edge case tests
+    // =========================================================================
+
+    #[test]
+    fn test_check_unsigned_with_unsigned_types() {
+        let unifier = Unifier::new();
+        assert!(
+            unifier
+                .check_unsigned(&InferType::Concrete(Type::U8))
+                .is_ok()
+        );
+        assert!(
+            unifier
+                .check_unsigned(&InferType::Concrete(Type::U16))
+                .is_ok()
+        );
+        assert!(
+            unifier
+                .check_unsigned(&InferType::Concrete(Type::U32))
+                .is_ok()
+        );
+        assert!(
+            unifier
+                .check_unsigned(&InferType::Concrete(Type::U64))
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn test_check_unsigned_with_signed_type() {
+        let unifier = Unifier::new();
+        let result = unifier.check_unsigned(&InferType::Concrete(Type::I32));
+        assert!(!result.is_ok());
+        assert!(matches!(result, UnifyResult::NotUnsigned { ty: Type::I32 }));
+    }
+
+    #[test]
+    fn test_check_unsigned_with_int_literal() {
+        let unifier = Unifier::new();
+        // IntLiteral is OK - it will become an unsigned type if constrained
+        assert!(unifier.check_unsigned(&InferType::IntLiteral).is_ok());
+    }
+
+    #[test]
+    fn test_check_unsigned_with_non_integer_type() {
+        let unifier = Unifier::new();
+        let result = unifier.check_unsigned(&InferType::Concrete(Type::Bool));
+        assert!(!result.is_ok());
+        assert!(matches!(
+            result,
+            UnifyResult::NotUnsigned { ty: Type::Bool }
+        ));
+    }
+
+    #[test]
+    fn test_solve_constraints_is_unsigned() {
+        let mut unifier = Unifier::new();
+        let constraints = vec![Constraint::is_unsigned(
+            InferType::Concrete(Type::U64),
+            Span::new(0, 5),
+        )];
+        let errors = unifier.solve_constraints(&constraints);
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn test_solve_constraints_is_unsigned_fails_for_signed() {
+        let mut unifier = Unifier::new();
+        let constraints = vec![Constraint::is_unsigned(
+            InferType::Concrete(Type::I32),
+            Span::new(0, 5),
+        )];
+        let errors = unifier.solve_constraints(&constraints);
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(
+            errors[0].kind,
+            UnifyResult::NotUnsigned { ty: Type::I32 }
+        ));
+    }
+
+    #[test]
+    fn test_unify_array_same_element_same_length() {
+        let mut unifier = Unifier::new();
+        let arr1 = InferType::Array {
+            element: Box::new(InferType::Concrete(Type::I32)),
+            length: 5,
+        };
+        let arr2 = InferType::Array {
+            element: Box::new(InferType::Concrete(Type::I32)),
+            length: 5,
+        };
+        let result = unifier.unify(&arr1, &arr2);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_unify_array_different_length() {
+        let mut unifier = Unifier::new();
+        let arr1 = InferType::Array {
+            element: Box::new(InferType::Concrete(Type::I32)),
+            length: 3,
+        };
+        let arr2 = InferType::Array {
+            element: Box::new(InferType::Concrete(Type::I32)),
+            length: 5,
+        };
+        let result = unifier.unify(&arr1, &arr2);
+        assert!(!result.is_ok());
+        assert!(matches!(result, UnifyResult::ArrayLengthMismatch { .. }));
+    }
+
+    #[test]
+    fn test_unify_array_different_element_type() {
+        let mut unifier = Unifier::new();
+        let arr1 = InferType::Array {
+            element: Box::new(InferType::Concrete(Type::I32)),
+            length: 3,
+        };
+        let arr2 = InferType::Array {
+            element: Box::new(InferType::Concrete(Type::Bool)),
+            length: 3,
+        };
+        let result = unifier.unify(&arr1, &arr2);
+        assert!(!result.is_ok());
+        assert!(matches!(result, UnifyResult::TypeMismatch { .. }));
+    }
+
+    #[test]
+    fn test_unify_array_with_variable_element() {
+        let mut unifier = Unifier::new();
+        let v0 = TypeVarId::new(0);
+        let arr1 = InferType::Array {
+            element: Box::new(InferType::Var(v0)),
+            length: 3,
+        };
+        let arr2 = InferType::Array {
+            element: Box::new(InferType::Concrete(Type::I64)),
+            length: 3,
+        };
+        let result = unifier.unify(&arr1, &arr2);
+        assert!(result.is_ok());
+
+        // Variable should now be bound to I64
+        assert_eq!(
+            unifier.substitution.apply(&InferType::Var(v0)),
+            InferType::Concrete(Type::I64)
+        );
+    }
+
+    #[test]
+    fn test_unify_array_with_int_literal_element() {
+        let mut unifier = Unifier::new();
+        let arr1 = InferType::Array {
+            element: Box::new(InferType::IntLiteral),
+            length: 3,
+        };
+        let arr2 = InferType::Array {
+            element: Box::new(InferType::Concrete(Type::I32)),
+            length: 3,
+        };
+        let result = unifier.unify(&arr1, &arr2);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_unify_array_with_concrete() {
+        let mut unifier = Unifier::new();
+        let arr = InferType::Array {
+            element: Box::new(InferType::Concrete(Type::I32)),
+            length: 3,
+        };
+        let concrete = InferType::Concrete(Type::I32);
+        let result = unifier.unify(&arr, &concrete);
+        assert!(!result.is_ok());
+        assert!(matches!(result, UnifyResult::TypeMismatch { .. }));
+    }
+
+    #[test]
+    fn test_resolve_array_type() {
+        let mut unifier = Unifier::new();
+        let v0 = TypeVarId::new(0);
+
+        // Bind v0 to array of I32
+        unifier.substitution.insert(
+            v0,
+            InferType::Array {
+                element: Box::new(InferType::Concrete(Type::I32)),
+                length: 10,
+            },
+        );
+
+        // resolve() returns None for arrays (they need special handling)
+        let resolved = unifier.resolve(&InferType::Var(v0));
+        assert!(resolved.is_none());
+
+        // resolve_infer_type() should properly resolve arrays
+        let resolved_infer = unifier.resolve_infer_type(&InferType::Var(v0));
+        match resolved_infer {
+            InferType::Array { element, length } => {
+                assert_eq!(*element, InferType::Concrete(Type::I32));
+                assert_eq!(length, 10);
+            }
+            _ => panic!("Expected InferType::Array, got {:?}", resolved_infer),
+        }
+    }
+
+    #[test]
+    fn test_unification_error_not_unsigned_message() {
+        let error =
+            UnificationError::new(UnifyResult::NotUnsigned { ty: Type::I32 }, Span::new(0, 5));
+        let msg = error.message();
+        assert!(msg.contains("unsigned"));
+        assert!(msg.contains("i32"));
+    }
+
+    #[test]
+    fn test_unification_error_array_length_mismatch_message() {
+        let error = UnificationError::new(
+            UnifyResult::ArrayLengthMismatch {
+                expected: 3,
+                found: 5,
+            },
+            Span::new(0, 10),
+        );
+        let msg = error.message();
+        assert!(msg.contains("3"));
+        assert!(msg.contains("5"));
+    }
+
+    #[test]
+    fn test_unification_error_occurs_check_message() {
+        let error = UnificationError::new(
+            UnifyResult::OccursCheck {
+                var: TypeVarId::new(0),
+                ty: InferType::Array {
+                    element: Box::new(InferType::Var(TypeVarId::new(0))),
+                    length: 3,
+                },
+            },
+            Span::new(0, 5),
+        );
+        let msg = error.message();
+        assert!(msg.contains("infinite") || msg.contains("occurs"));
+    }
 }

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -419,3 +419,336 @@ pub(crate) struct ReceiverInfo {
     /// Only set when the receiver is a mutable lvalue and the method mutates.
     pub storage: Option<StringReceiverStorage>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lasso::ThreadedRodeo;
+
+    // =========================================================================
+    // VariableMoveState tests
+    // =========================================================================
+
+    #[test]
+    fn variable_move_state_default_is_empty() {
+        let state = VariableMoveState::default();
+        assert!(state.full_move.is_none());
+        assert!(state.partial_moves.is_empty());
+        assert!(state.is_empty());
+    }
+
+    #[test]
+    fn variable_move_state_full_move() {
+        let mut state = VariableMoveState::default();
+        let span = Span::new(10, 20);
+        state.mark_path_moved(&[], span);
+
+        assert!(state.full_move.is_some());
+        assert_eq!(state.full_move.unwrap(), span);
+        assert!(state.partial_moves.is_empty()); // Full move clears partials
+    }
+
+    #[test]
+    fn variable_move_state_is_path_moved_after_full_move() {
+        let mut state = VariableMoveState::default();
+        let span = Span::new(10, 20);
+        state.mark_path_moved(&[], span);
+
+        // Any path should be considered moved after a full move
+        assert_eq!(state.is_path_moved(&[]), Some(span));
+
+        let interner = ThreadedRodeo::new();
+        let field_x = interner.get_or_intern("x");
+        assert_eq!(state.is_path_moved(&[field_x]), Some(span));
+    }
+
+    #[test]
+    fn variable_move_state_partial_move() {
+        let mut state = VariableMoveState::default();
+        let interner = ThreadedRodeo::new();
+        let field_x = interner.get_or_intern("x");
+        let span = Span::new(10, 20);
+
+        state.mark_path_moved(&[field_x], span);
+
+        assert!(state.full_move.is_none());
+        assert_eq!(state.partial_moves.len(), 1);
+        assert_eq!(state.is_path_moved(&[field_x]), Some(span));
+    }
+
+    #[test]
+    fn variable_move_state_partial_move_does_not_affect_root() {
+        let mut state = VariableMoveState::default();
+        let interner = ThreadedRodeo::new();
+        let field_x = interner.get_or_intern("x");
+        let span = Span::new(10, 20);
+
+        state.mark_path_moved(&[field_x], span);
+
+        // The root path should not be moved if only a field is moved
+        assert!(state.is_path_moved(&[]).is_none());
+    }
+
+    #[test]
+    fn variable_move_state_partial_move_affects_descendants() {
+        let mut state = VariableMoveState::default();
+        let interner = ThreadedRodeo::new();
+        let field_a = interner.get_or_intern("a");
+        let field_b = interner.get_or_intern("b");
+        let span = Span::new(10, 20);
+
+        // Move s.a
+        state.mark_path_moved(&[field_a], span);
+
+        // s.a.b should also be considered moved (parent is moved)
+        assert_eq!(state.is_path_moved(&[field_a, field_b]), Some(span));
+
+        // s.b should not be moved
+        assert!(state.is_path_moved(&[field_b]).is_none());
+    }
+
+    #[test]
+    fn variable_move_state_multiple_partial_moves() {
+        let mut state = VariableMoveState::default();
+        let interner = ThreadedRodeo::new();
+        let field_x = interner.get_or_intern("x");
+        let field_y = interner.get_or_intern("y");
+        let span1 = Span::new(10, 20);
+        let span2 = Span::new(30, 40);
+
+        state.mark_path_moved(&[field_x], span1);
+        state.mark_path_moved(&[field_y], span2);
+
+        assert!(state.full_move.is_none());
+        assert_eq!(state.partial_moves.len(), 2);
+        assert_eq!(state.is_path_moved(&[field_x]), Some(span1));
+        assert_eq!(state.is_path_moved(&[field_y]), Some(span2));
+    }
+
+    #[test]
+    fn variable_move_state_full_move_after_partial_clears_partials() {
+        let mut state = VariableMoveState::default();
+        let interner = ThreadedRodeo::new();
+        let field_x = interner.get_or_intern("x");
+        let span1 = Span::new(10, 20);
+        let span2 = Span::new(30, 40);
+
+        // First, partially move a field
+        state.mark_path_moved(&[field_x], span1);
+        assert_eq!(state.partial_moves.len(), 1);
+
+        // Then, fully move the variable
+        state.mark_path_moved(&[], span2);
+
+        // Full move should clear partial moves
+        assert!(state.full_move.is_some());
+        assert!(state.partial_moves.is_empty());
+    }
+
+    #[test]
+    fn variable_move_state_partial_after_full_is_ignored() {
+        let mut state = VariableMoveState::default();
+        let interner = ThreadedRodeo::new();
+        let field_x = interner.get_or_intern("x");
+        let span1 = Span::new(10, 20);
+        let span2 = Span::new(30, 40);
+
+        // First, fully move the variable
+        state.mark_path_moved(&[], span1);
+
+        // Then try to partially move a field
+        state.mark_path_moved(&[field_x], span2);
+
+        // Partial move should be ignored when already fully moved
+        assert_eq!(state.full_move, Some(span1));
+        assert!(state.partial_moves.is_empty());
+    }
+
+    #[test]
+    fn variable_move_state_is_partially_moved() {
+        let mut state = VariableMoveState::default();
+        let interner = ThreadedRodeo::new();
+        let field_x = interner.get_or_intern("x");
+        let span = Span::new(10, 20);
+
+        // Initially not partially moved
+        assert!(state.is_partially_moved().is_none());
+
+        // After partial move
+        state.mark_path_moved(&[field_x], span);
+        assert_eq!(state.is_partially_moved(), Some(span));
+
+        // After full move, is_partially_moved returns None
+        state.mark_path_moved(&[], Span::new(50, 60));
+        assert!(state.is_partially_moved().is_none());
+    }
+
+    #[test]
+    fn variable_move_state_is_any_part_moved() {
+        let mut state = VariableMoveState::default();
+        let interner = ThreadedRodeo::new();
+        let field_x = interner.get_or_intern("x");
+        let span1 = Span::new(10, 20);
+        let span2 = Span::new(30, 40);
+
+        // Initially nothing is moved
+        assert!(state.is_any_part_moved().is_none());
+
+        // After partial move
+        state.mark_path_moved(&[field_x], span1);
+        assert_eq!(state.is_any_part_moved(), Some(span1));
+
+        // After full move
+        let mut state2 = VariableMoveState::default();
+        state2.mark_path_moved(&[], span2);
+        assert_eq!(state2.is_any_part_moved(), Some(span2));
+    }
+
+    #[test]
+    fn variable_move_state_clear() {
+        let mut state = VariableMoveState::default();
+        let interner = ThreadedRodeo::new();
+        let field_x = interner.get_or_intern("x");
+        let span = Span::new(10, 20);
+
+        state.mark_path_moved(&[], span);
+        state.partial_moves.insert(vec![field_x], Span::new(30, 40));
+
+        state.clear();
+
+        assert!(state.full_move.is_none());
+        assert!(state.partial_moves.is_empty());
+        assert!(state.is_empty());
+    }
+
+    #[test]
+    fn variable_move_state_merge_union_both_empty() {
+        let state1 = VariableMoveState::default();
+        let state2 = VariableMoveState::default();
+
+        let merged = VariableMoveState::merge_union(&state1, &state2);
+
+        assert!(merged.is_empty());
+    }
+
+    #[test]
+    fn variable_move_state_merge_union_one_full_move() {
+        let mut state1 = VariableMoveState::default();
+        let state2 = VariableMoveState::default();
+        let span = Span::new(10, 20);
+
+        state1.mark_path_moved(&[], span);
+
+        let merged = VariableMoveState::merge_union(&state1, &state2);
+        assert_eq!(merged.full_move, Some(span));
+
+        // Test other order
+        let merged2 = VariableMoveState::merge_union(&state2, &state1);
+        assert_eq!(merged2.full_move, Some(span));
+    }
+
+    #[test]
+    fn variable_move_state_merge_union_both_full_moves_prefers_first() {
+        let mut state1 = VariableMoveState::default();
+        let mut state2 = VariableMoveState::default();
+        let span1 = Span::new(10, 20);
+        let span2 = Span::new(30, 40);
+
+        state1.mark_path_moved(&[], span1);
+        state2.mark_path_moved(&[], span2);
+
+        let merged = VariableMoveState::merge_union(&state1, &state2);
+        assert_eq!(merged.full_move, Some(span1)); // Prefers first
+    }
+
+    #[test]
+    fn variable_move_state_merge_union_partial_moves() {
+        let mut state1 = VariableMoveState::default();
+        let mut state2 = VariableMoveState::default();
+        let interner = ThreadedRodeo::new();
+        let field_x = interner.get_or_intern("x");
+        let field_y = interner.get_or_intern("y");
+        let span1 = Span::new(10, 20);
+        let span2 = Span::new(30, 40);
+
+        state1.mark_path_moved(&[field_x], span1);
+        state2.mark_path_moved(&[field_y], span2);
+
+        let merged = VariableMoveState::merge_union(&state1, &state2);
+
+        // Both partial moves should be present
+        assert_eq!(merged.partial_moves.len(), 2);
+        assert_eq!(merged.is_path_moved(&[field_x]), Some(span1));
+        assert_eq!(merged.is_path_moved(&[field_y]), Some(span2));
+    }
+
+    #[test]
+    fn variable_move_state_merge_union_same_partial_move_prefers_first() {
+        let mut state1 = VariableMoveState::default();
+        let mut state2 = VariableMoveState::default();
+        let interner = ThreadedRodeo::new();
+        let field_x = interner.get_or_intern("x");
+        let span1 = Span::new(10, 20);
+        let span2 = Span::new(30, 40);
+
+        state1.mark_path_moved(&[field_x], span1);
+        state2.mark_path_moved(&[field_x], span2);
+
+        let merged = VariableMoveState::merge_union(&state1, &state2);
+
+        // Should have the span from the first state
+        assert_eq!(merged.partial_moves.len(), 1);
+        assert_eq!(merged.is_path_moved(&[field_x]), Some(span1));
+    }
+
+    // =========================================================================
+    // ConstValue tests
+    // =========================================================================
+
+    #[test]
+    fn const_value_as_integer() {
+        let cv = ConstValue::Integer(42);
+        assert_eq!(cv.as_integer(), Some(42));
+        assert_eq!(cv.as_bool(), None);
+    }
+
+    #[test]
+    fn const_value_as_bool() {
+        let cv = ConstValue::Bool(true);
+        assert_eq!(cv.as_bool(), Some(true));
+        assert_eq!(cv.as_integer(), None);
+
+        let cv2 = ConstValue::Bool(false);
+        assert_eq!(cv2.as_bool(), Some(false));
+    }
+
+    #[test]
+    fn const_value_negative_integer() {
+        let cv = ConstValue::Integer(-100);
+        assert_eq!(cv.as_integer(), Some(-100));
+    }
+
+    #[test]
+    fn const_value_equality() {
+        assert_eq!(ConstValue::Integer(42), ConstValue::Integer(42));
+        assert_ne!(ConstValue::Integer(42), ConstValue::Integer(43));
+        assert_eq!(ConstValue::Bool(true), ConstValue::Bool(true));
+        assert_ne!(ConstValue::Bool(true), ConstValue::Bool(false));
+        assert_ne!(ConstValue::Integer(1), ConstValue::Bool(true));
+    }
+
+    // =========================================================================
+    // AnalysisResult tests
+    // =========================================================================
+
+    #[test]
+    fn analysis_result_new() {
+        let air_ref = AirRef::from_raw(5);
+        let ty = Type::I32;
+
+        let result = AnalysisResult::new(air_ref, ty);
+
+        assert_eq!(result.air_ref.as_u32(), 5);
+        assert_eq!(result.ty, Type::I32);
+    }
+}

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -269,4 +269,547 @@ mod tests {
         let errors = result.unwrap_err();
         assert_eq!(errors.len(), 1);
     }
+
+    // =========================================================================
+    // Scope management tests
+    // =========================================================================
+    // These tests verify that variable scoping works correctly, including
+    // shadowing, nested scopes, and proper cleanup when exiting scopes.
+
+    #[test]
+    fn test_variable_shadowing_same_type() {
+        // Variable shadowing with the same type should work
+        let output = compile_to_air(
+            "fn main() -> i32 {
+                let x = 10;
+                let x = 20;  // Shadow x with a new binding
+                x
+            }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions[0].num_locals, 2);
+    }
+
+    #[test]
+    fn test_variable_shadowing_different_type() {
+        // Variable shadowing with a different type should work
+        let output = compile_to_air(
+            "fn main() -> bool {
+                let x = 10;
+                let x = true;  // Shadow x with a different type
+                x
+            }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions[0].num_locals, 2);
+        assert_eq!(output.functions[0].air.return_type(), Type::Bool);
+    }
+
+    #[test]
+    fn test_nested_scope_variable_not_visible_outside() {
+        // Variable declared in inner scope should not be visible outside
+        let result = compile_to_air(
+            "fn main() -> i32 {
+                {
+                    let x = 10;
+                }
+                x  // Error: x is not in scope
+            }",
+        );
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert_eq!(errors.len(), 1);
+        assert!(matches!(
+            errors.iter().next().unwrap().kind,
+            ErrorKind::UndefinedVariable(_)
+        ));
+    }
+
+    #[test]
+    fn test_shadowed_variable_restored_after_scope() {
+        // After inner scope ends, the outer variable should be visible again
+        let output = compile_to_air(
+            "fn main() -> i32 {
+                let x = 10;
+                {
+                    let x = 20;  // Shadow x in inner scope
+                }
+                x  // Should be 10 (outer x)
+            }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions[0].num_locals, 2);
+    }
+
+    #[test]
+    fn test_deeply_nested_scopes() {
+        // Variables in deeply nested scopes should work correctly
+        let output = compile_to_air(
+            "fn main() -> i32 {
+                let a = 1;
+                {
+                    let b = 2;
+                    {
+                        let c = 3;
+                        {
+                            let d = 4;
+                            a + b + c + d
+                        }
+                    }
+                }
+            }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions[0].num_locals, 4);
+    }
+
+    #[test]
+    fn test_if_else_scope_isolation() {
+        // Variables in if/else branches should not leak
+        let result = compile_to_air(
+            "fn main() -> i32 {
+                if true {
+                    let x = 10;
+                    x
+                } else {
+                    y  // Error: y not defined in this branch
+                }
+            }",
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_loop_scope_isolation() {
+        // Variables in loop body should not leak outside
+        let result = compile_to_air(
+            "fn main() -> i32 {
+                let mut i = 0;
+                loop {
+                    let inner = 10;
+                    i = i + 1;
+                    if i > 5 {
+                        break inner;
+                    }
+                }
+            }",
+        );
+
+        // This should compile successfully
+        assert!(result.is_ok());
+    }
+
+    // =========================================================================
+    // Declaration gathering tests
+    // =========================================================================
+    // These tests verify that declarations are properly gathered and validated.
+
+    #[test]
+    fn test_duplicate_struct_names() {
+        // Two structs with the same name should error
+        let result = compile_to_air(
+            "struct Foo { x: i32 }
+             struct Foo { y: bool }
+             fn main() -> i32 { 0 }",
+        );
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(matches!(
+            errors.iter().next().unwrap().kind,
+            ErrorKind::DuplicateTypeDefinition { .. }
+        ));
+    }
+
+    #[test]
+    fn test_duplicate_enum_names() {
+        // Two enums with the same name should error
+        let result = compile_to_air(
+            "enum Color { Red, Green }
+             enum Color { Blue, Yellow }
+             fn main() -> i32 { 0 }",
+        );
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(matches!(
+            errors.iter().next().unwrap().kind,
+            ErrorKind::DuplicateTypeDefinition { .. }
+        ));
+    }
+
+    #[test]
+    fn test_struct_and_enum_name_collision() {
+        // A struct and enum with the same name should error
+        let result = compile_to_air(
+            "struct Foo { x: i32 }
+             enum Foo { A, B }
+             fn main() -> i32 { 0 }",
+        );
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(matches!(
+            errors.iter().next().unwrap().kind,
+            ErrorKind::DuplicateTypeDefinition { .. }
+        ));
+    }
+
+    #[test]
+    fn test_duplicate_struct_field() {
+        // Duplicate field names in a struct should error
+        let result = compile_to_air(
+            "struct Foo { x: i32, x: bool }
+             fn main() -> i32 { 0 }",
+        );
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(matches!(
+            errors.iter().next().unwrap().kind,
+            ErrorKind::DuplicateField { .. }
+        ));
+    }
+
+    #[test]
+    fn test_duplicate_enum_variant() {
+        // Duplicate variant names in an enum should error
+        let result = compile_to_air(
+            "enum Color { Red, Blue, Red }
+             fn main() -> i32 { 0 }",
+        );
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(matches!(
+            errors.iter().next().unwrap().kind,
+            ErrorKind::DuplicateVariant { .. }
+        ));
+    }
+
+    #[test]
+    fn test_struct_field_type_resolution() {
+        // Struct with field of another struct type should resolve correctly
+        let output = compile_to_air(
+            "@copy struct Inner { x: i32 }
+             @copy struct Outer { inner: Inner }
+             fn main() -> i32 {
+                let o = Outer { inner: Inner { x: 42 } };
+                o.inner.x
+             }",
+        )
+        .unwrap();
+
+        assert_eq!(output.struct_defs.len(), 3); // Inner, Outer, and String (builtin)
+    }
+
+    #[test]
+    fn test_copy_struct_with_copy_fields() {
+        // @copy struct with only Copy fields should compile
+        let output = compile_to_air(
+            "@copy struct Point { x: i32, y: i32 }
+             fn main() -> i32 {
+                let p = Point { x: 1, y: 2 };
+                let q = p;  // Copy, not move
+                p.x + q.x
+             }",
+        )
+        .unwrap();
+
+        assert!(
+            output
+                .struct_defs
+                .iter()
+                .any(|s| s.name == "Point" && s.is_copy)
+        );
+    }
+
+    #[test]
+    fn test_copy_struct_with_non_copy_field_rejected() {
+        // @copy struct with non-copy field should error
+        let result = compile_to_air(
+            "struct NonCopy { x: i32 }
+             @copy struct Wrapper { inner: NonCopy }
+             fn main() -> i32 { 0 }",
+        );
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(matches!(
+            errors.iter().next().unwrap().kind,
+            ErrorKind::CopyStructNonCopyField(_)
+        ));
+    }
+
+    #[test]
+    fn test_recursive_struct_via_array() {
+        // Self-referential struct through array is not allowed (no arrays of non-copy structs yet)
+        // But circular reference through other means should be detected
+        let result = compile_to_air(
+            "struct Node { value: i32 }
+             fn main() -> i32 { 0 }",
+        );
+
+        // Simple non-recursive struct should work
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_function_signature_resolution() {
+        // Function parameters and return types should resolve correctly
+        let output = compile_to_air(
+            "fn add(a: i32, b: i32) -> i32 { a + b }
+             fn main() -> i32 { add(1, 2) }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions.len(), 2);
+    }
+
+    // =========================================================================
+    // Builtin type tests
+    // =========================================================================
+    // These tests verify that builtin types (String, etc.) work correctly.
+
+    #[test]
+    fn test_string_type_injected() {
+        // String type should exist after builtin injection
+        let output = compile_to_air(
+            "fn main() -> i32 {
+                let s = \"hello\";
+                0
+            }",
+        )
+        .unwrap();
+
+        // String struct should exist in struct_defs
+        assert!(output.struct_defs.iter().any(|s| s.name == "String"));
+    }
+
+    #[test]
+    fn test_string_len_method() {
+        // String.len() should return u64
+        let output = compile_to_air(
+            "fn main() -> u64 {
+                let s = \"hello\";
+                s.len()
+            }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions[0].air.return_type(), Type::U64);
+    }
+
+    #[test]
+    fn test_string_is_empty_method() {
+        // String.is_empty() should return bool
+        let output = compile_to_air(
+            "fn main() -> bool {
+                let s = \"hello\";
+                s.is_empty()
+            }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions[0].air.return_type(), Type::Bool);
+    }
+
+    #[test]
+    fn test_string_literal_type_inference() {
+        // String literal should have type String
+        let output = compile_to_air(
+            "fn main() -> bool {
+                let s = \"hello\";
+                let t = \"world\";
+                s.is_empty()
+            }",
+        )
+        .unwrap();
+
+        // Should have local storage for two string variables
+        assert!(output.functions[0].num_locals >= 2);
+    }
+
+    // =========================================================================
+    // Move tracking integration tests
+    // =========================================================================
+    // These tests verify move semantics work correctly through the full pipeline.
+
+    #[test]
+    fn test_use_after_move_error() {
+        // Using a moved value should error
+        let result = compile_to_air(
+            "struct NonCopy { x: i32 }
+             fn consume(n: NonCopy) -> i32 { n.x }
+             fn main() -> i32 {
+                 let n = NonCopy { x: 42 };
+                 let x = consume(n);
+                 n.x  // Error: n was moved
+             }",
+        );
+
+        assert!(result.is_err());
+        let errors = result.unwrap_err();
+        assert!(matches!(
+            errors.iter().next().unwrap().kind,
+            ErrorKind::UseAfterMove { .. }
+        ));
+    }
+
+    #[test]
+    fn test_partial_move_sibling_still_valid() {
+        // After moving one field, sibling fields should still be usable
+        // Note: Inner is non-copy, Outer is also non-copy (can't be @copy with non-copy field)
+        let output = compile_to_air(
+            "struct Inner { x: i32 }
+             struct Outer { a: Inner, b: i32 }
+             fn consume(i: Inner) -> i32 { i.x }
+             fn main() -> i32 {
+                 let o = Outer { a: Inner { x: 1 }, b: 2 };
+                 let x = consume(o.a);  // Move o.a
+                 o.b  // OK: o.b is still valid (it's Copy)
+             }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions[0].air.return_type(), Type::I32);
+    }
+
+    #[test]
+    fn test_copy_type_not_moved() {
+        // Copy types should not be moved, allowing multiple uses
+        let output = compile_to_air(
+            "@copy struct Point { x: i32, y: i32 }
+             fn use_point(p: Point) -> i32 { p.x }
+             fn main() -> i32 {
+                 let p = Point { x: 1, y: 2 };
+                 let a = use_point(p);
+                 let b = use_point(p);  // OK: Point is Copy
+                 a + b
+             }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions.len(), 2);
+    }
+
+    // =========================================================================
+    // Type inference tests
+    // =========================================================================
+    // These tests verify type inference works correctly.
+
+    #[test]
+    fn test_integer_literal_infers_i32_by_default() {
+        // Unconstrained integer literal should default to i32
+        let output = compile_to_air(
+            "fn main() -> i32 {
+                let x = 42;
+                x
+            }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions[0].air.return_type(), Type::I32);
+    }
+
+    #[test]
+    fn test_integer_literal_infers_from_context() {
+        // Integer literal should infer type from context
+        let output = compile_to_air(
+            "fn main() -> i64 {
+                let x: i64 = 42;
+                x
+            }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions[0].air.return_type(), Type::I64);
+    }
+
+    #[test]
+    fn test_integer_literal_infers_from_return_type() {
+        // Integer literal should infer type from function return type
+        let output = compile_to_air("fn main() -> u8 { 42 }").unwrap();
+
+        assert_eq!(output.functions[0].air.return_type(), Type::U8);
+    }
+
+    #[test]
+    fn test_integer_literal_infers_from_binary_op() {
+        // Integer literal should infer type from binary operation context
+        let output = compile_to_air(
+            "fn main() -> i64 {
+                let x: i64 = 10;
+                x + 5  // 5 should infer to i64
+            }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions[0].air.return_type(), Type::I64);
+    }
+
+    // =========================================================================
+    // Array type tests
+    // =========================================================================
+
+    #[test]
+    fn test_array_type_inference() {
+        // Array element type should be inferred
+        let output = compile_to_air(
+            "fn main() -> i32 {
+                let arr: [i32; 3] = [1, 2, 3];
+                arr[0]
+            }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions[0].air.return_type(), Type::I32);
+    }
+
+    #[test]
+    fn test_array_index_type_must_be_unsigned() {
+        // Array index must be unsigned integer
+        let result = compile_to_air(
+            "fn main() -> i32 {
+                let arr: [i32; 3] = [1, 2, 3];
+                let i: i32 = 1;
+                arr[i]  // Error: i32 is signed
+            }",
+        );
+
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_array_index_literal_infers_u64() {
+        // Integer literal used as array index should infer to u64
+        let output = compile_to_air(
+            "fn main() -> i32 {
+                let arr: [i32; 3] = [1, 2, 3];
+                arr[1]  // 1 should infer to u64
+            }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions[0].air.return_type(), Type::I32);
+    }
+
+    #[test]
+    fn test_array_length_mismatch() {
+        // Array length in type annotation must match initializer
+        let result = compile_to_air(
+            "fn main() -> i32 {
+                let arr: [i32; 3] = [1, 2];  // Error: length mismatch
+                arr[0]
+            }",
+        );
+
+        assert!(result.is_err());
+    }
 }


### PR DESCRIPTION
Add 58 new unit tests across three files to improve test coverage of the semantic analysis module:

- context.rs: Tests for VariableMoveState (full/partial moves, merge semantics), ConstValue, and AnalysisResult
- tests.rs: Integration tests for scope management, declaration gathering, builtin types, move tracking, and type inference
- unify.rs: Tests for unsigned checks, array unification, and error messages

These unit tests provide faster feedback during development than end-to-end spec tests and help catch edge cases in internal implementation details.

Fixes rue-jb8v

🤖 Generated with [Claude Code](https://claude.com/claude-code)