### PR TITLE
Add structured diagnostics with annotate-snippets

### DIFF
--- a/crates/rue-compiler/BUCK
+++ b/crates/rue-compiler/BUCK
@@ -19,6 +19,7 @@ rust_library(
         "//crates/rue-target:rue-target",
         "//third-party:annotate-snippets",
         "//third-party:rayon",
+        "//third-party:serde_json",
         "//third-party:tracing",
     ],
     visibility = ["PUBLIC"],
@@ -44,6 +45,7 @@ rust_test(
         "//crates/rue-target:rue-target",
         "//third-party:annotate-snippets",
         "//third-party:rayon",
+        "//third-party:serde_json",
         "//third-party:tracing",
     ],
 )

--- a/crates/rue-compiler/src/diagnostic.rs
+++ b/crates/rue-compiler/src/diagnostic.rs
@@ -21,6 +21,7 @@
 //! ```
 
 use std::collections::HashMap;
+use std::io::IsTerminal;
 
 use annotate_snippets::{Level, Renderer, Snippet};
 
@@ -45,6 +46,18 @@ impl<'a> SourceInfo<'a> {
     }
 }
 
+/// Color choice for diagnostic output.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum ColorChoice {
+    /// Automatically detect whether to use colors based on terminal capabilities.
+    #[default]
+    Auto,
+    /// Always use colors.
+    Always,
+    /// Never use colors.
+    Never,
+}
+
 /// Formatter for compiler diagnostics.
 ///
 /// Provides methods to format compilation errors and warnings into
@@ -56,10 +69,27 @@ pub struct DiagnosticFormatter<'a> {
 
 impl<'a> DiagnosticFormatter<'a> {
     /// Create a new diagnostic formatter for the given source info.
+    ///
+    /// By default, uses automatic color detection based on whether stderr is a terminal.
     pub fn new(source_info: &'a SourceInfo<'a>) -> Self {
+        Self::with_color_choice(source_info, ColorChoice::Auto)
+    }
+
+    /// Create a new diagnostic formatter with explicit color choice.
+    pub fn with_color_choice(source_info: &'a SourceInfo<'a>, color_choice: ColorChoice) -> Self {
+        let use_color = match color_choice {
+            ColorChoice::Auto => std::io::stderr().is_terminal(),
+            ColorChoice::Always => true,
+            ColorChoice::Never => false,
+        };
+        let renderer = if use_color {
+            Renderer::styled()
+        } else {
+            Renderer::plain()
+        };
         Self {
             source_info,
-            renderer: Renderer::plain(),
+            renderer,
         }
     }
 
@@ -219,10 +249,357 @@ impl<'a> DiagnosticFormatter<'a> {
     }
 }
 
+// ============================================================================
+// JSON Diagnostic Output
+// ============================================================================
+
+use crate::{Applicability, Suggestion};
+
+/// A diagnostic formatted for JSON output.
+///
+/// This structure is designed to be compatible with common editor protocols
+/// (LSP, cargo's JSON format) while containing all information needed for
+/// rich diagnostic display.
+#[derive(Debug)]
+pub struct JsonDiagnostic {
+    /// Error or warning code (e.g., "E0206").
+    pub code: String,
+    /// The diagnostic message.
+    pub message: String,
+    /// Severity level: "error" or "warning".
+    pub severity: &'static str,
+    /// Primary and secondary spans with labels.
+    pub spans: Vec<JsonSpan>,
+    /// Suggested fixes that can be applied.
+    pub suggestions: Vec<JsonSuggestion>,
+    /// Additional notes providing context.
+    pub notes: Vec<String>,
+    /// Additional help messages.
+    pub helps: Vec<String>,
+}
+
+/// A span in JSON format with file location and labels.
+#[derive(Debug)]
+pub struct JsonSpan {
+    /// Source file path.
+    pub file: String,
+    /// Start byte offset (0-indexed).
+    pub start: u32,
+    /// End byte offset (exclusive).
+    pub end: u32,
+    /// Line number (1-indexed).
+    pub line: u32,
+    /// Column number (1-indexed).
+    pub column: u32,
+    /// Label text for this span.
+    pub label: Option<String>,
+    /// Whether this is the primary span.
+    pub primary: bool,
+}
+
+/// A suggested fix in JSON format.
+#[derive(Debug)]
+pub struct JsonSuggestion {
+    /// Human-readable description.
+    pub message: String,
+    /// File containing the span.
+    pub file: String,
+    /// Start byte offset.
+    pub start: u32,
+    /// End byte offset.
+    pub end: u32,
+    /// Replacement text.
+    pub replacement: String,
+    /// Applicability level.
+    pub applicability: String,
+}
+
+impl JsonDiagnostic {
+    /// Serialize this diagnostic to a JSON string.
+    pub fn to_json(&self) -> String {
+        let mut obj = serde_json::Map::new();
+        obj.insert(
+            "code".to_string(),
+            serde_json::Value::String(self.code.clone()),
+        );
+        obj.insert(
+            "message".to_string(),
+            serde_json::Value::String(self.message.clone()),
+        );
+        obj.insert(
+            "severity".to_string(),
+            serde_json::Value::String(self.severity.to_string()),
+        );
+
+        // Spans
+        let spans: Vec<serde_json::Value> = self
+            .spans
+            .iter()
+            .map(|s| {
+                let mut span = serde_json::Map::new();
+                span.insert(
+                    "file".to_string(),
+                    serde_json::Value::String(s.file.clone()),
+                );
+                span.insert(
+                    "start".to_string(),
+                    serde_json::Value::Number(s.start.into()),
+                );
+                span.insert("end".to_string(), serde_json::Value::Number(s.end.into()));
+                span.insert("line".to_string(), serde_json::Value::Number(s.line.into()));
+                span.insert(
+                    "column".to_string(),
+                    serde_json::Value::Number(s.column.into()),
+                );
+                if let Some(label) = &s.label {
+                    span.insert(
+                        "label".to_string(),
+                        serde_json::Value::String(label.clone()),
+                    );
+                } else {
+                    span.insert("label".to_string(), serde_json::Value::Null);
+                }
+                span.insert("primary".to_string(), serde_json::Value::Bool(s.primary));
+                serde_json::Value::Object(span)
+            })
+            .collect();
+        obj.insert("spans".to_string(), serde_json::Value::Array(spans));
+
+        // Suggestions
+        let suggestions: Vec<serde_json::Value> = self
+            .suggestions
+            .iter()
+            .map(|s| {
+                let mut sugg = serde_json::Map::new();
+                sugg.insert(
+                    "message".to_string(),
+                    serde_json::Value::String(s.message.clone()),
+                );
+                sugg.insert(
+                    "file".to_string(),
+                    serde_json::Value::String(s.file.clone()),
+                );
+                sugg.insert(
+                    "start".to_string(),
+                    serde_json::Value::Number(s.start.into()),
+                );
+                sugg.insert("end".to_string(), serde_json::Value::Number(s.end.into()));
+                sugg.insert(
+                    "replacement".to_string(),
+                    serde_json::Value::String(s.replacement.clone()),
+                );
+                sugg.insert(
+                    "applicability".to_string(),
+                    serde_json::Value::String(s.applicability.clone()),
+                );
+                serde_json::Value::Object(sugg)
+            })
+            .collect();
+        obj.insert(
+            "suggestions".to_string(),
+            serde_json::Value::Array(suggestions),
+        );
+
+        // Notes and helps
+        let notes: Vec<serde_json::Value> = self
+            .notes
+            .iter()
+            .map(|n| serde_json::Value::String(n.clone()))
+            .collect();
+        obj.insert("notes".to_string(), serde_json::Value::Array(notes));
+
+        let helps: Vec<serde_json::Value> = self
+            .helps
+            .iter()
+            .map(|h| serde_json::Value::String(h.clone()))
+            .collect();
+        obj.insert("helps".to_string(), serde_json::Value::Array(helps));
+
+        serde_json::to_string(&serde_json::Value::Object(obj)).unwrap_or_else(|_| "{}".to_string())
+    }
+}
+
+/// Formats diagnostics as JSON for machine consumption.
+///
+/// Use this formatter when outputting to tools like editors, CI systems,
+/// or any context requiring machine-readable output.
+pub struct JsonDiagnosticFormatter<'a> {
+    source_info: &'a SourceInfo<'a>,
+}
+
+impl<'a> JsonDiagnosticFormatter<'a> {
+    /// Create a new JSON diagnostic formatter.
+    pub fn new(source_info: &'a SourceInfo<'a>) -> Self {
+        Self { source_info }
+    }
+
+    /// Calculate line and column for a byte offset.
+    fn offset_to_line_col(&self, offset: u32) -> (u32, u32) {
+        let offset = offset as usize;
+        let source = self.source_info.source;
+        let mut line = 1u32;
+        let mut col = 1u32;
+        for (i, ch) in source.char_indices() {
+            if i >= offset {
+                break;
+            }
+            if ch == '\n' {
+                line += 1;
+                col = 1;
+            } else {
+                col += 1;
+            }
+        }
+        (line, col)
+    }
+
+    /// Format a compile error as JSON.
+    pub fn format_error(&self, error: &CompileError) -> JsonDiagnostic {
+        let diag = error.diagnostic();
+        let (line, col) = error
+            .span()
+            .map(|s| self.offset_to_line_col(s.start))
+            .unwrap_or((1, 1));
+
+        let primary_span = error.span().map(|span| JsonSpan {
+            file: self.source_info.path.to_string(),
+            start: span.start,
+            end: span.end,
+            line,
+            column: col,
+            label: None,
+            primary: true,
+        });
+
+        let secondary_spans: Vec<JsonSpan> = diag
+            .labels
+            .iter()
+            .map(|label| {
+                let (line, col) = self.offset_to_line_col(label.span.start);
+                JsonSpan {
+                    file: self.source_info.path.to_string(),
+                    start: label.span.start,
+                    end: label.span.end,
+                    line,
+                    column: col,
+                    label: Some(label.message.clone()),
+                    primary: false,
+                }
+            })
+            .collect();
+
+        let mut spans: Vec<JsonSpan> = primary_span.into_iter().collect();
+        spans.extend(secondary_spans);
+
+        let suggestions: Vec<JsonSuggestion> = diag
+            .suggestions
+            .iter()
+            .map(|s| JsonSuggestion {
+                message: s.message.clone(),
+                file: self.source_info.path.to_string(),
+                start: s.span.start,
+                end: s.span.end,
+                replacement: s.replacement.clone(),
+                applicability: s.applicability.to_string(),
+            })
+            .collect();
+
+        JsonDiagnostic {
+            code: format!("{}", error.kind.code()),
+            message: format!("{}", error.kind),
+            severity: "error",
+            spans,
+            suggestions,
+            notes: diag.notes.iter().map(|n| n.0.clone()).collect(),
+            helps: diag.helps.iter().map(|h| h.0.clone()).collect(),
+        }
+    }
+
+    /// Format a compile warning as JSON.
+    pub fn format_warning(&self, warning: &CompileWarning) -> JsonDiagnostic {
+        let diag = warning.diagnostic();
+        let (line, col) = warning
+            .span()
+            .map(|s| self.offset_to_line_col(s.start))
+            .unwrap_or((1, 1));
+
+        let primary_span = warning.span().map(|span| JsonSpan {
+            file: self.source_info.path.to_string(),
+            start: span.start,
+            end: span.end,
+            line,
+            column: col,
+            label: None,
+            primary: true,
+        });
+
+        let secondary_spans: Vec<JsonSpan> = diag
+            .labels
+            .iter()
+            .map(|label| {
+                let (line, col) = self.offset_to_line_col(label.span.start);
+                JsonSpan {
+                    file: self.source_info.path.to_string(),
+                    start: label.span.start,
+                    end: label.span.end,
+                    line,
+                    column: col,
+                    label: Some(label.message.clone()),
+                    primary: false,
+                }
+            })
+            .collect();
+
+        let mut spans: Vec<JsonSpan> = primary_span.into_iter().collect();
+        spans.extend(secondary_spans);
+
+        let suggestions: Vec<JsonSuggestion> = diag
+            .suggestions
+            .iter()
+            .map(|s| JsonSuggestion {
+                message: s.message.clone(),
+                file: self.source_info.path.to_string(),
+                start: s.span.start,
+                end: s.span.end,
+                replacement: s.replacement.clone(),
+                applicability: s.applicability.to_string(),
+            })
+            .collect();
+
+        JsonDiagnostic {
+            code: String::new(), // Warnings don't have codes yet
+            message: format!("{}", warning.kind),
+            severity: "warning",
+            spans,
+            suggestions,
+            notes: diag.notes.iter().map(|n| n.0.clone()).collect(),
+            helps: diag.helps.iter().map(|h| h.0.clone()).collect(),
+        }
+    }
+
+    /// Format multiple errors as a JSON array string.
+    pub fn format_errors(&self, errors: &CompileErrors) -> String {
+        let diagnostics: Vec<String> = errors
+            .iter()
+            .map(|e| self.format_error(e).to_json())
+            .collect();
+        format!("[{}]", diagnostics.join(","))
+    }
+
+    /// Format multiple warnings as a JSON array string.
+    pub fn format_warnings(&self, warnings: &[CompileWarning]) -> String {
+        let diagnostics: Vec<String> = warnings
+            .iter()
+            .map(|w| self.format_warning(w).to_json())
+            .collect();
+        format!("[{}]", diagnostics.join(","))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{ErrorKind, WarningKind};
+    use crate::{ErrorKind, Suggestion, WarningKind};
 
     #[test]
     fn test_format_error_with_span() {
@@ -405,5 +782,179 @@ mod tests {
         assert!(output.contains("expected bool, found i32"));
         // Should have summary line
         assert!(output.contains("aborting due to 2 previous errors"));
+    }
+
+    #[test]
+    fn test_color_choice_never() {
+        let source = "fn main() -> i32 { 1 + true }";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = DiagnosticFormatter::with_color_choice(&source_info, ColorChoice::Never);
+
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::new(23, 27),
+        );
+
+        let output = formatter.format_error(&error);
+        // Output should not contain ANSI escape codes
+        assert!(!output.contains("\x1b["));
+        assert!(output.contains("type mismatch"));
+    }
+
+    #[test]
+    fn test_color_choice_always() {
+        let source = "fn main() -> i32 { 1 + true }";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = DiagnosticFormatter::with_color_choice(&source_info, ColorChoice::Always);
+
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::new(23, 27),
+        );
+
+        let output = formatter.format_error(&error);
+        // Output should contain ANSI escape codes
+        assert!(output.contains("\x1b["));
+        assert!(output.contains("type mismatch"));
+    }
+
+    // ========================================================================
+    // JSON Formatting Tests
+    // ========================================================================
+
+    #[test]
+    fn test_json_format_error() {
+        let source = "fn main() -> i32 { 1 + true }";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = JsonDiagnosticFormatter::new(&source_info);
+
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::new(23, 27),
+        );
+
+        let json_diag = formatter.format_error(&error);
+        assert_eq!(json_diag.severity, "error");
+        assert_eq!(json_diag.code, "E0206");
+        assert!(json_diag.message.contains("type mismatch"));
+        assert_eq!(json_diag.spans.len(), 1);
+        assert_eq!(json_diag.spans[0].file, "test.rue");
+        assert_eq!(json_diag.spans[0].start, 23);
+        assert_eq!(json_diag.spans[0].end, 27);
+        assert!(json_diag.spans[0].primary);
+    }
+
+    #[test]
+    fn test_json_format_error_line_col() {
+        let source = "fn main() -> i32 {\n    1 + true\n}";
+        //                            ^--- line 2, col 9 (0-indexed: 23)
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = JsonDiagnosticFormatter::new(&source_info);
+
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::new(27, 31), // "true" on line 2
+        );
+
+        let json_diag = formatter.format_error(&error);
+        assert_eq!(json_diag.spans[0].line, 2);
+        assert!(json_diag.spans[0].column > 1); // Column should be > 1 (indented)
+    }
+
+    #[test]
+    fn test_json_format_error_with_suggestion() {
+        let source = "fn main() -> i32 { x = 1; 0 }";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = JsonDiagnosticFormatter::new(&source_info);
+
+        let error = CompileError::new(
+            ErrorKind::AssignToImmutable("x".to_string()),
+            Span::new(19, 20),
+        )
+        .with_suggestion(Suggestion::machine_applicable(
+            "add mut",
+            Span::new(4, 5),
+            "mut x",
+        ));
+
+        let json_diag = formatter.format_error(&error);
+        assert_eq!(json_diag.suggestions.len(), 1);
+        assert_eq!(json_diag.suggestions[0].message, "add mut");
+        assert_eq!(json_diag.suggestions[0].replacement, "mut x");
+        assert_eq!(json_diag.suggestions[0].applicability, "MachineApplicable");
+    }
+
+    #[test]
+    fn test_json_format_warning() {
+        let source = "fn main() -> i32 { let x = 42; 0 }";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = JsonDiagnosticFormatter::new(&source_info);
+
+        let warning = CompileWarning::new(
+            WarningKind::UnusedVariable("x".to_string()),
+            Span::new(23, 24),
+        );
+
+        let json_diag = formatter.format_warning(&warning);
+        assert_eq!(json_diag.severity, "warning");
+        assert!(json_diag.message.contains("unused variable"));
+    }
+
+    #[test]
+    fn test_json_to_string() {
+        let source = "fn main() -> i32 { 1 + true }";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = JsonDiagnosticFormatter::new(&source_info);
+
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::new(23, 27),
+        );
+
+        let json_diag = formatter.format_error(&error);
+        let json_str = json_diag.to_json();
+
+        // Should be valid JSON
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert_eq!(parsed["severity"], "error");
+        assert_eq!(parsed["code"], "E0206");
+        assert!(parsed["spans"].is_array());
+        assert_eq!(parsed["spans"][0]["primary"], true);
+    }
+
+    #[test]
+    fn test_json_format_errors_array() {
+        let source = "fn main() -> i32 {\n    1 + true\n}";
+        let source_info = SourceInfo::new(source, "test.rue");
+        let formatter = JsonDiagnosticFormatter::new(&source_info);
+
+        let mut errors = CompileErrors::new();
+        errors.push(CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::new(27, 31),
+        ));
+
+        let json_str = formatter.format_errors(&errors);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert!(parsed.is_array());
+        assert_eq!(parsed.as_array().unwrap().len(), 1);
     }
 }

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -31,7 +31,10 @@ mod drop_glue;
 use rayon::prelude::*;
 use tracing::{info, info_span};
 
-pub use diagnostic::{DiagnosticFormatter, SourceInfo};
+pub use diagnostic::{
+    ColorChoice, DiagnosticFormatter, JsonDiagnostic, JsonDiagnosticFormatter, JsonSpan,
+    JsonSuggestion, SourceInfo,
+};
 
 use std::io::Write;
 use std::path::PathBuf;
@@ -169,8 +172,9 @@ pub use rue_codegen::{
     aarch64::Aarch64Mir, generate_stack_frame_info,
 };
 pub use rue_error::{
-    CompileError, CompileErrors, CompileResult, CompileWarning, Diagnostic, ErrorCode, ErrorKind,
-    MultiErrorResult, PreviewFeature, PreviewFeatures, WarningKind,
+    Applicability, CompileError, CompileErrors, CompileResult, CompileWarning, Diagnostic,
+    ErrorCode, ErrorKind, MultiErrorResult, PreviewFeature, PreviewFeatures, Suggestion,
+    WarningKind,
 };
 pub use rue_lexer::{Lexer, Token, TokenKind};
 pub use rue_linker::{Archive, CodeRelocation, Linker, ObjectBuilder, ObjectFile, RelocationType};

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -380,6 +380,129 @@ impl std::fmt::Display for Help {
     }
 }
 
+/// How confident we are that a suggested fix is correct.
+///
+/// This follows rustc's conventions for suggestion applicability levels.
+/// IDEs and tools can use this to decide whether to auto-apply suggestions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Applicability {
+    /// The suggestion is definitely correct and can be safely auto-applied.
+    ///
+    /// Use this when the fix is guaranteed to compile and preserve semantics.
+    MachineApplicable,
+
+    /// The suggestion might be correct but should be reviewed by a human.
+    ///
+    /// Use this when the fix will likely work but may change behavior in
+    /// edge cases, or when there are multiple equally valid options.
+    MaybeIncorrect,
+
+    /// The suggestion contains placeholders that the user must fill in.
+    ///
+    /// Use this when the fix shows the general shape but needs specific
+    /// values like variable names or types.
+    HasPlaceholders,
+
+    /// The suggestion is just a hint and may not even compile.
+    ///
+    /// Use this for illustrative suggestions that show concepts rather
+    /// than working code.
+    Unspecified,
+}
+
+impl Default for Applicability {
+    fn default() -> Self {
+        Self::Unspecified
+    }
+}
+
+impl std::fmt::Display for Applicability {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Applicability::MachineApplicable => write!(f, "MachineApplicable"),
+            Applicability::MaybeIncorrect => write!(f, "MaybeIncorrect"),
+            Applicability::HasPlaceholders => write!(f, "HasPlaceholders"),
+            Applicability::Unspecified => write!(f, "Unspecified"),
+        }
+    }
+}
+
+/// A suggested code fix that can be applied to resolve a diagnostic.
+///
+/// Suggestions provide machine-readable fix information that IDEs and
+/// tools can use to offer quick-fix actions.
+#[derive(Debug, Clone)]
+pub struct Suggestion {
+    /// Human-readable description of what the suggestion does.
+    pub message: String,
+    /// The span of code to replace.
+    pub span: Span,
+    /// The replacement text.
+    pub replacement: String,
+    /// How confident we are that this fix is correct.
+    pub applicability: Applicability,
+}
+
+impl Suggestion {
+    /// Create a new suggestion with unspecified applicability.
+    pub fn new(message: impl Into<String>, span: Span, replacement: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            span,
+            replacement: replacement.into(),
+            applicability: Applicability::Unspecified,
+        }
+    }
+
+    /// Create a suggestion that is safe to auto-apply.
+    pub fn machine_applicable(
+        message: impl Into<String>,
+        span: Span,
+        replacement: impl Into<String>,
+    ) -> Self {
+        Self {
+            message: message.into(),
+            span,
+            replacement: replacement.into(),
+            applicability: Applicability::MachineApplicable,
+        }
+    }
+
+    /// Create a suggestion that may need human review.
+    pub fn maybe_incorrect(
+        message: impl Into<String>,
+        span: Span,
+        replacement: impl Into<String>,
+    ) -> Self {
+        Self {
+            message: message.into(),
+            span,
+            replacement: replacement.into(),
+            applicability: Applicability::MaybeIncorrect,
+        }
+    }
+
+    /// Create a suggestion with placeholders.
+    pub fn with_placeholders(
+        message: impl Into<String>,
+        span: Span,
+        replacement: impl Into<String>,
+    ) -> Self {
+        Self {
+            message: message.into(),
+            span,
+            replacement: replacement.into(),
+            applicability: Applicability::HasPlaceholders,
+        }
+    }
+
+    /// Set the applicability of this suggestion.
+    pub fn with_applicability(mut self, applicability: Applicability) -> Self {
+        self.applicability = applicability;
+        self
+    }
+}
+
 /// Rich diagnostic information for errors and warnings.
 ///
 /// This struct collects all supplementary information that can be
@@ -392,6 +515,8 @@ pub struct Diagnostic {
     pub notes: Vec<Note>,
     /// Actionable help suggestions.
     pub helps: Vec<Help>,
+    /// Code suggestions that can be applied to fix the issue.
+    pub suggestions: Vec<Suggestion>,
 }
 
 impl Diagnostic {
@@ -402,7 +527,10 @@ impl Diagnostic {
 
     /// Check if this diagnostic has any content.
     pub fn is_empty(&self) -> bool {
-        self.labels.is_empty() && self.notes.is_empty() && self.helps.is_empty()
+        self.labels.is_empty()
+            && self.notes.is_empty()
+            && self.helps.is_empty()
+            && self.suggestions.is_empty()
     }
 }
 
@@ -500,6 +628,15 @@ impl<K> DiagnosticWrapper<K> {
     #[inline]
     pub fn with_help(mut self, message: impl Into<String>) -> Self {
         self.diagnostic.helps.push(Help::new(message));
+        self
+    }
+
+    /// Add a code suggestion that can be applied to fix the issue.
+    ///
+    /// Suggestions provide machine-readable fix information for IDEs and tools.
+    #[inline]
+    pub fn with_suggestion(mut self, suggestion: Suggestion) -> Self {
+        self.diagnostic.suggestions.push(suggestion);
         self
     }
 }
@@ -1347,6 +1484,7 @@ mod tests {
         assert!(diag.labels.is_empty());
         assert!(diag.notes.is_empty());
         assert!(diag.helps.is_empty());
+        assert!(diag.suggestions.is_empty());
     }
 
     #[test]
@@ -1371,6 +1509,14 @@ mod tests {
     }
 
     #[test]
+    fn test_diagnostic_not_empty_with_suggestion() {
+        let mut diag = Diagnostic::new();
+        diag.suggestions
+            .push(Suggestion::new("try this", Span::new(0, 10), "replacement"));
+        assert!(!diag.is_empty());
+    }
+
+    #[test]
     fn test_label_creation() {
         let span = Span::new(10, 20);
         let label = Label::new("expected type here", span);
@@ -1388,6 +1534,82 @@ mod tests {
     fn test_help_display() {
         let help = Help::new("consider adding a type annotation");
         assert_eq!(help.to_string(), "consider adding a type annotation");
+    }
+
+    #[test]
+    fn test_suggestion_creation() {
+        let span = Span::new(10, 20);
+        let suggestion = Suggestion::new("try this fix", span, "new_code");
+        assert_eq!(suggestion.message, "try this fix");
+        assert_eq!(suggestion.span, span);
+        assert_eq!(suggestion.replacement, "new_code");
+        assert_eq!(suggestion.applicability, Applicability::Unspecified);
+    }
+
+    #[test]
+    fn test_suggestion_machine_applicable() {
+        let span = Span::new(0, 5);
+        let suggestion = Suggestion::machine_applicable("rename variable", span, "new_name");
+        assert_eq!(suggestion.applicability, Applicability::MachineApplicable);
+    }
+
+    #[test]
+    fn test_suggestion_maybe_incorrect() {
+        let span = Span::new(0, 5);
+        let suggestion = Suggestion::maybe_incorrect("try adding mut", span, "mut x");
+        assert_eq!(suggestion.applicability, Applicability::MaybeIncorrect);
+    }
+
+    #[test]
+    fn test_suggestion_with_placeholders() {
+        let span = Span::new(0, 5);
+        let suggestion = Suggestion::with_placeholders("add type annotation", span, ": <type>");
+        assert_eq!(suggestion.applicability, Applicability::HasPlaceholders);
+    }
+
+    #[test]
+    fn test_suggestion_with_applicability() {
+        let span = Span::new(0, 5);
+        let suggestion = Suggestion::new("fix", span, "new_code")
+            .with_applicability(Applicability::MachineApplicable);
+        assert_eq!(suggestion.applicability, Applicability::MachineApplicable);
+    }
+
+    #[test]
+    fn test_applicability_display() {
+        assert_eq!(
+            Applicability::MachineApplicable.to_string(),
+            "MachineApplicable"
+        );
+        assert_eq!(Applicability::MaybeIncorrect.to_string(), "MaybeIncorrect");
+        assert_eq!(
+            Applicability::HasPlaceholders.to_string(),
+            "HasPlaceholders"
+        );
+        assert_eq!(Applicability::Unspecified.to_string(), "Unspecified");
+    }
+
+    #[test]
+    fn test_applicability_default() {
+        assert_eq!(Applicability::default(), Applicability::Unspecified);
+    }
+
+    #[test]
+    fn test_error_with_suggestion() {
+        let span = Span::new(10, 20);
+        let error =
+            CompileError::new(ErrorKind::AssignToImmutable("x".to_string()), span).with_suggestion(
+                Suggestion::machine_applicable("add mut", Span::new(4, 5), "mut x"),
+            );
+
+        let diag = error.diagnostic();
+        assert_eq!(diag.suggestions.len(), 1);
+        assert_eq!(diag.suggestions[0].message, "add mut");
+        assert_eq!(diag.suggestions[0].replacement, "mut x");
+        assert_eq!(
+            diag.suggestions[0].applicability,
+            Applicability::MachineApplicable
+        );
     }
 
     #[test]


### PR DESCRIPTION
- Add ColorChoice enum for color output control (Auto/Always/Never)
- Add Applicability and Suggestion types for machine-readable fixes
- Add JsonDiagnosticFormatter for JSON output compatible with LSP
- Auto-detect terminal for colored output using Renderer::styled()

Closes rue-rizg

🤖 Generated with [Claude Code](https://claude.com/claude-code)