### PR TITLE
Make array type registry thread-safe for parallel function analysis

### DIFF
--- a/crates/rue-air/src/function_analyzer.rs
+++ b/crates/rue-air/src/function_analyzer.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains `FunctionAnalyzer`, which holds the mutable state
 //! needed during function body analysis. Each function gets its own analyzer
-//! instance, enabling future parallel analysis.
+//! instance, enabling parallel analysis.
 //!
 //! # Architecture
 //!
@@ -10,7 +10,10 @@
 //! The split enables:
 //! - Parallel function body analysis (each function has independent mutable state)
 //! - Better separation of concerns (immutable type info vs mutable analysis state)
-//! - Post-analysis merging of results (strings, array types, warnings)
+//! - Post-analysis merging of results (strings, warnings)
+//!
+//! Array types are managed by the thread-safe `ArrayTypeRegistry` in `SemaContext`,
+//! allowing parallel creation without local buffering or post-merge remapping.
 
 use std::collections::HashMap;
 
@@ -20,7 +23,7 @@ use rue_span::Span;
 
 use crate::inference::InferType;
 use crate::sema_context::SemaContext;
-use crate::types::{ArrayTypeDef, ArrayTypeId, Type};
+use crate::types::{ArrayTypeId, Type};
 
 /// Per-function mutable state during semantic analysis.
 ///
@@ -34,16 +37,14 @@ use crate::types::{ArrayTypeDef, ArrayTypeId, Type};
 /// type information. This separation enables:
 /// - Sharing `SemaContext` across parallel function analyses
 /// - Independent mutable state per function
-/// - Post-analysis merging of results
+/// - Post-analysis merging of results (strings, warnings)
+///
+/// Array types are created via the thread-safe `ArrayTypeRegistry` in `SemaContext`,
+/// so they don't require local buffering or post-merge remapping.
 #[derive(Debug)]
 pub struct FunctionAnalyzer<'a, 'ctx> {
     /// Reference to the shared immutable context.
     pub ctx: &'a SemaContext<'ctx>,
-    /// Array types created during this function's analysis.
-    /// These are local to the function and merged post-analysis.
-    array_types: HashMap<(Type, u64), ArrayTypeId>,
-    /// Array type definitions in order of creation.
-    array_type_defs: Vec<ArrayTypeDef>,
     /// String table for deduplication.
     string_table: HashMap<String, u32>,
     /// String literals in order of creation.
@@ -55,10 +56,6 @@ pub struct FunctionAnalyzer<'a, 'ctx> {
 /// Output from analyzing a single function.
 #[derive(Debug)]
 pub struct FunctionAnalyzerOutput {
-    /// Array types created during analysis.
-    pub array_types: HashMap<(Type, u64), ArrayTypeId>,
-    /// Array type definitions.
-    pub array_type_defs: Vec<ArrayTypeDef>,
     /// String literals (deduplicated).
     pub strings: Vec<String>,
     /// Warnings collected during analysis.
@@ -70,27 +67,6 @@ impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
     pub fn new(ctx: &'a SemaContext<'ctx>) -> Self {
         Self {
             ctx,
-            array_types: HashMap::new(),
-            array_type_defs: Vec::new(),
-            string_table: HashMap::new(),
-            strings: Vec::new(),
-            warnings: Vec::new(),
-        }
-    }
-
-    /// Create a new function analyzer initialized with pre-existing array types.
-    ///
-    /// This is used when we need to inherit array types from the context
-    /// (e.g., array types discovered during declaration gathering).
-    pub fn with_array_types(
-        ctx: &'a SemaContext<'ctx>,
-        array_types: HashMap<(Type, u64), ArrayTypeId>,
-        array_type_defs: Vec<ArrayTypeDef>,
-    ) -> Self {
-        Self {
-            ctx,
-            array_types,
-            array_type_defs,
             string_table: HashMap::new(),
             strings: Vec::new(),
             warnings: Vec::new(),
@@ -100,8 +76,6 @@ impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
     /// Consume the analyzer and return its output.
     pub fn into_output(self) -> FunctionAnalyzerOutput {
         FunctionAnalyzerOutput {
-            array_types: self.array_types,
-            array_type_defs: self.array_type_defs,
             strings: self.strings,
             warnings: self.warnings,
         }
@@ -128,58 +102,35 @@ impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
     }
 
     /// Get or create an array type, returning its ID.
-    pub fn get_or_create_array_type(&mut self, element_type: Type, length: u64) -> ArrayTypeId {
-        let key = (element_type, length);
-
-        // First check if it exists in the shared context
-        if let Some(id) = self.ctx.get_array_type(element_type, length) {
-            return id;
-        }
-
-        // Then check local cache
-        if let Some(&id) = self.array_types.get(&key) {
-            return id;
-        }
-
-        // Create new array type locally
-        // Use an offset based on context's array types to avoid ID collisions
-        let base_id = self.ctx.array_type_defs.len() as u32;
-        let id = ArrayTypeId(base_id + self.array_type_defs.len() as u32);
-        self.array_type_defs.push(ArrayTypeDef {
-            element_type,
-            length,
-        });
-        self.array_types.insert(key, id);
-        id
+    ///
+    /// Delegates to the thread-safe `ArrayTypeRegistry` in `SemaContext`.
+    pub fn get_or_create_array_type(&self, element_type: Type, length: u64) -> ArrayTypeId {
+        self.ctx.get_or_create_array_type(element_type, length)
     }
 
     /// Get an array type definition by ID.
     ///
-    /// First checks the shared context, then the local definitions.
-    pub fn get_array_type_def(&self, id: ArrayTypeId) -> &ArrayTypeDef {
-        let base_id = self.ctx.array_type_defs.len() as u32;
-        if id.0 < base_id {
-            // From shared context
-            &self.ctx.array_type_defs[id.0 as usize]
-        } else {
-            // From local definitions
-            let local_idx = (id.0 - base_id) as usize;
-            &self.array_type_defs[local_idx]
-        }
+    /// Delegates to the `ArrayTypeRegistry` in `SemaContext`.
+    pub fn get_array_type_def(&self, id: ArrayTypeId) -> crate::types::ArrayTypeDef {
+        self.ctx.get_array_type_def(id)
     }
 
     /// Pre-create array types from a resolved InferType.
     ///
     /// This walks the InferType recursively and ensures all array types that will
     /// be needed during `infer_type_to_type` conversion are created beforehand.
-    pub fn pre_create_array_types_from_infer_type(&mut self, ty: &InferType) {
+    ///
+    /// With the thread-safe `ArrayTypeRegistry`, this is no longer strictly necessary
+    /// since `infer_type_to_type` can create array types on-demand. However, it's
+    /// kept for explicit documentation of intent and potential future optimizations.
+    pub fn pre_create_array_types_from_infer_type(&self, ty: &InferType) {
         match ty {
             InferType::Array { element, length } => {
                 // First recursively process nested array types
                 self.pre_create_array_types_from_infer_type(element);
 
                 // Convert the element type to get the concrete Type
-                let elem_ty = self.infer_type_to_concrete_type_for_key(element);
+                let elem_ty = self.infer_type_to_type(element);
                 if elem_ty != Type::Error {
                     // Pre-create this array type
                     self.get_or_create_array_type(elem_ty, *length);
@@ -187,32 +138,6 @@ impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
             }
             InferType::Concrete(_) | InferType::Var(_) | InferType::IntLiteral => {
                 // Non-array types don't need pre-creation
-            }
-        }
-    }
-
-    /// Convert an InferType to a concrete Type for use as an array element key.
-    fn infer_type_to_concrete_type_for_key(&self, ty: &InferType) -> Type {
-        match ty {
-            InferType::Concrete(t) => *t,
-            InferType::Var(_) => Type::Error,
-            InferType::IntLiteral => Type::I32,
-            InferType::Array { element, length } => {
-                let elem_ty = self.infer_type_to_concrete_type_for_key(element);
-                if elem_ty == Type::Error {
-                    return Type::Error;
-                }
-                // Check shared context first
-                if let Some(id) = self.ctx.get_array_type(elem_ty, *length) {
-                    return Type::Array(id);
-                }
-                // Then check local cache
-                let key = (elem_ty, *length);
-                if let Some(&id) = self.array_types.get(&key) {
-                    Type::Array(id)
-                } else {
-                    Type::Error
-                }
             }
         }
     }
@@ -228,19 +153,9 @@ impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
                 if elem_ty == Type::Error {
                     return Type::Error;
                 }
-                // Check shared context first
-                if let Some(id) = self.ctx.get_array_type(elem_ty, *length) {
-                    return Type::Array(id);
-                }
-                // Then check local cache
-                let key = (elem_ty, *length);
-                if let Some(&id) = self.array_types.get(&key) {
-                    Type::Array(id)
-                } else {
-                    // Should have been pre-created
-                    debug_assert!(false, "Array type not found: ({:?}, {})", elem_ty, length);
-                    Type::Error
-                }
+                // Use the thread-safe registry to get or create the array type
+                let id = self.get_or_create_array_type(elem_ty, *length);
+                Type::Array(id)
             }
         }
     }
@@ -367,12 +282,10 @@ impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
 /// Merge multiple function analyzer outputs into a single result.
 ///
 /// This is used after parallel analysis to combine results from all functions.
+/// Array types are managed by the thread-safe `ArrayTypeRegistry` in `SemaContext`,
+/// so only strings and warnings need merging.
 #[derive(Debug, Default)]
 pub struct MergedFunctionOutput {
-    /// All array type definitions (deduplicated).
-    pub array_type_defs: Vec<ArrayTypeDef>,
-    /// Mapping from original (element_type, length) to final ArrayTypeId.
-    pub array_type_map: HashMap<(Type, u64), ArrayTypeId>,
     /// All string literals (deduplicated).
     pub strings: Vec<String>,
     /// Mapping from string content to final index.
@@ -387,47 +300,15 @@ impl MergedFunctionOutput {
         Self::default()
     }
 
-    /// Initialize with array types from the context.
-    pub fn with_context_arrays(ctx: &SemaContext) -> Self {
-        let array_type_map: HashMap<(Type, u64), ArrayTypeId> = ctx.array_types.clone();
-        let array_type_defs = ctx.array_type_defs.clone();
-        Self {
-            array_type_defs,
-            array_type_map,
-            strings: Vec::new(),
-            string_map: HashMap::new(),
-            warnings: Vec::new(),
-        }
-    }
-
     /// Merge a function's output into this merged result.
     ///
-    /// Returns a remapping for array type IDs and string indices so the
-    /// function's AIR can be updated with the final IDs.
+    /// Returns a remapping for string indices so the function's AIR
+    /// can be updated with the final IDs.
     pub fn merge_function_output(
         &mut self,
         output: FunctionAnalyzerOutput,
     ) -> FunctionOutputRemapping {
-        let mut array_remap = HashMap::new();
         let mut string_remap = HashMap::new();
-
-        // Merge array types (deduplicate by (element_type, length))
-        for (key, old_id) in output.array_types {
-            let new_id = if let Some(&id) = self.array_type_map.get(&key) {
-                id
-            } else {
-                let id = ArrayTypeId(self.array_type_defs.len() as u32);
-                self.array_type_defs.push(ArrayTypeDef {
-                    element_type: key.0,
-                    length: key.1,
-                });
-                self.array_type_map.insert(key, id);
-                id
-            };
-            if old_id != new_id {
-                array_remap.insert(old_id, new_id);
-            }
-        }
 
         // Merge strings (deduplicate by content)
         for (idx, content) in output.strings.into_iter().enumerate() {
@@ -448,18 +329,13 @@ impl MergedFunctionOutput {
         // Merge warnings
         self.warnings.extend(output.warnings);
 
-        FunctionOutputRemapping {
-            array_remap,
-            string_remap,
-        }
+        FunctionOutputRemapping { string_remap }
     }
 }
 
 /// Remapping information for updating AIR after merging.
 #[derive(Debug, Default)]
 pub struct FunctionOutputRemapping {
-    /// Mapping from old ArrayTypeId to new ArrayTypeId.
-    pub array_remap: HashMap<ArrayTypeId, ArrayTypeId>,
     /// Mapping from old string index to new string index.
     pub string_remap: HashMap<u32, u32>,
 }
@@ -467,12 +343,7 @@ pub struct FunctionOutputRemapping {
 impl FunctionOutputRemapping {
     /// Check if any remapping is needed.
     pub fn is_empty(&self) -> bool {
-        self.array_remap.is_empty() && self.string_remap.is_empty()
-    }
-
-    /// Remap an array type ID if needed.
-    pub fn remap_array_type(&self, id: ArrayTypeId) -> ArrayTypeId {
-        self.array_remap.get(&id).copied().unwrap_or(id)
+        self.string_remap.is_empty()
     }
 
     /// Remap a string index if needed.

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -308,25 +308,24 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
 /// `analyze_inst_with_context`.
 #[allow(dead_code)]
 fn analyze_all_function_bodies_parallel(sema: Sema<'_>) -> MultiErrorResult<SemaOutput> {
-    // Build immutable SemaContext for sharing across threads
+    // Build SemaContext with thread-safe array registry for sharing across threads
     let ctx = sema.build_sema_context();
 
     // Collect all function jobs
     let jobs = collect_function_jobs(&ctx);
 
     // Analyze functions in parallel
+    // Array types may be created during analysis via ctx.get_or_create_array_type()
     let results: Vec<FunctionResult> = jobs
         .into_par_iter()
         .map(|job| analyze_function_job(&ctx, job))
         .collect();
 
+    // Extract array types from the thread-safe registry
+    let array_type_defs = ctx.array_registry.into_defs();
+
     // Merge results
-    merge_function_results(
-        results,
-        sema.struct_defs,
-        sema.enum_defs,
-        sema.array_type_defs,
-    )
+    merge_function_results(results, sema.struct_defs, sema.enum_defs, array_type_defs)
 }
 
 /// Collect all functions to be analyzed from the RIR.
@@ -806,6 +805,9 @@ fn run_type_inference_with_context(
 }
 
 /// Convert an InferType to a concrete Type using the context.
+///
+/// This function is thread-safe and can be called from parallel function analysis.
+/// Array types are created on-demand via the thread-safe `ArrayTypeRegistry`.
 fn infer_type_to_type_standalone(ty: &InferType, ctx: &SemaContext<'_>) -> Type {
     match ty {
         InferType::Concrete(t) => *t,
@@ -816,11 +818,9 @@ fn infer_type_to_type_standalone(ty: &InferType, ctx: &SemaContext<'_>) -> Type 
             if elem_ty == Type::Error {
                 return Type::Error;
             }
-            if let Some(id) = ctx.get_array_type(elem_ty, *length) {
-                Type::Array(id)
-            } else {
-                Type::Error
-            }
+            // Use get_or_create to handle inferred array types from literals
+            let id = ctx.get_or_create_array_type(elem_ty, *length);
+            Type::Array(id)
         }
     }
 }

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -302,6 +302,14 @@ impl<'a> Sema<'a> {
     /// Now that all type names are registered, this resolves:
     /// - Struct field types (must be done first for @copy validation)
     /// - @copy struct validation, destructors, functions, and methods
+    ///
+    /// # Array Type Registration
+    ///
+    /// Array types from explicit type annotations (struct fields, function parameters,
+    /// return types, local variable annotations) are registered during this phase via
+    /// `resolve_type()` calls. Array types from literals (inferred during HM inference)
+    /// are created on-demand via the thread-safe `ArrayTypeRegistry` during function
+    /// body analysis.
     pub(crate) fn resolve_declarations(&mut self) -> CompileResult<()> {
         self.resolve_struct_fields()?;
         self.resolve_remaining_declarations()

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -34,8 +34,9 @@ use rue_error::{CompileErrors, MultiErrorResult, PreviewFeatures};
 use rue_rir::Rir;
 
 use crate::sema_context::{
-    FunctionInfo as SemaContextFunctionInfo, InferenceContext as SemaContextInferenceContext,
-    MethodInfo as SemaContextMethodInfo, SemaContext,
+    ArrayTypeRegistry, FunctionInfo as SemaContextFunctionInfo,
+    InferenceContext as SemaContextInferenceContext, MethodInfo as SemaContextMethodInfo,
+    SemaContext,
 };
 use crate::types::{ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructId, Type};
 
@@ -415,8 +416,10 @@ impl<'a> Sema<'a> {
             interner: self.interner,
             struct_defs: self.struct_defs.clone(),
             enum_defs: self.enum_defs.clone(),
-            array_types: self.array_types.clone(),
-            array_type_defs: self.array_type_defs.clone(),
+            array_registry: ArrayTypeRegistry::from_existing(
+                self.array_types.clone(),
+                self.array_type_defs.clone(),
+            ),
             structs: self.structs.clone(),
             enums: self.enums.clone(),
             functions: self

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -2,7 +2,7 @@
 //!
 //! This module contains `SemaContext`, which holds all type information and
 //! declarations that are immutable after the declaration gathering phase.
-//! `SemaContext` is designed to be `Send + Sync` for future parallel function analysis.
+//! `SemaContext` is designed to be `Send + Sync` for parallel function analysis.
 //!
 //! # Architecture
 //!
@@ -16,10 +16,20 @@
 //!
 //! This separation enables:
 //! - Parallel type checking (each function can be analyzed independently)
-//! - Better cache locality (immutable context can be shared)
+//! - Better cache locality (context can be shared across threads)
 //! - Foundation for incremental compilation (can cache `SemaContext` across compilations)
+//!
+//! # Array Type Registry
+//!
+//! The array type registry is thread-safe to support parallel function analysis.
+//! Array types can be created during function body analysis when type inference
+//! resolves array literals like `[1, 2, 3]` without explicit type annotations.
+//! The registry uses `RwLock` for concurrent access with the following pattern:
+//! - Read lock for lookups (most common case)
+//! - Write lock for insertions (rare, only for new array types)
 
 use std::collections::HashMap;
+use std::sync::RwLock;
 
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::PreviewFeatures;
@@ -27,6 +37,120 @@ use rue_rir::{Rir, RirParamMode};
 
 use crate::inference::{FunctionSig, InferType, MethodSig};
 use crate::types::{ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructId, Type};
+
+/// Thread-safe registry for array types.
+///
+/// This registry allows concurrent lookups and insertions of array types during
+/// parallel function analysis. It uses double-checked locking to minimize
+/// contention: most operations only need a read lock.
+#[derive(Debug)]
+pub struct ArrayTypeRegistry {
+    /// Maps (element_type, length) to ArrayTypeId.
+    types: RwLock<HashMap<(Type, u64), ArrayTypeId>>,
+    /// Array type definitions indexed by ArrayTypeId.
+    defs: RwLock<Vec<ArrayTypeDef>>,
+}
+
+impl ArrayTypeRegistry {
+    /// Create a new empty registry.
+    pub fn new() -> Self {
+        Self {
+            types: RwLock::new(HashMap::new()),
+            defs: RwLock::new(Vec::new()),
+        }
+    }
+
+    /// Create a registry pre-populated with existing types.
+    pub fn from_existing(
+        types: HashMap<(Type, u64), ArrayTypeId>,
+        defs: Vec<ArrayTypeDef>,
+    ) -> Self {
+        Self {
+            types: RwLock::new(types),
+            defs: RwLock::new(defs),
+        }
+    }
+
+    /// Look up an array type by element type and length.
+    pub fn get(&self, element_type: Type, length: u64) -> Option<ArrayTypeId> {
+        self.types
+            .read()
+            .expect("ArrayTypeRegistry lock poisoned")
+            .get(&(element_type, length))
+            .copied()
+    }
+
+    /// Get or create an array type. Thread-safe with double-checked locking.
+    pub fn get_or_create(&self, element_type: Type, length: u64) -> ArrayTypeId {
+        let key = (element_type, length);
+
+        // Fast path: check with read lock
+        {
+            let types = self.types.read().expect("ArrayTypeRegistry lock poisoned");
+            if let Some(&id) = types.get(&key) {
+                return id;
+            }
+        }
+
+        // Slow path: acquire write lock and double-check
+        let mut types = self.types.write().expect("ArrayTypeRegistry lock poisoned");
+
+        // Double-check after acquiring write lock (another thread may have inserted)
+        if let Some(&id) = types.get(&key) {
+            return id;
+        }
+
+        // Create new array type
+        let mut defs = self.defs.write().expect("ArrayTypeRegistry lock poisoned");
+        let id = ArrayTypeId(defs.len() as u32);
+        defs.push(ArrayTypeDef {
+            element_type,
+            length,
+        });
+        types.insert(key, id);
+        id
+    }
+
+    /// Get an array type definition by ID.
+    pub fn get_def(&self, id: ArrayTypeId) -> ArrayTypeDef {
+        self.defs.read().expect("ArrayTypeRegistry lock poisoned")[id.0 as usize]
+    }
+
+    /// Get the number of registered array types.
+    pub fn len(&self) -> usize {
+        self.defs
+            .read()
+            .expect("ArrayTypeRegistry lock poisoned")
+            .len()
+    }
+
+    /// Check if the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Extract the array type definitions (consumes the registry).
+    /// Used when building the final SemaOutput.
+    pub fn into_defs(self) -> Vec<ArrayTypeDef> {
+        self.defs
+            .into_inner()
+            .expect("ArrayTypeRegistry lock poisoned")
+    }
+
+    /// Get a snapshot of all array type definitions.
+    pub fn snapshot_defs(&self) -> Vec<ArrayTypeDef> {
+        self.defs
+            .read()
+            .expect("ArrayTypeRegistry lock poisoned")
+            .clone()
+    }
+}
+
+impl Default for ArrayTypeRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 /// Information about a function.
 #[derive(Debug, Clone)]
@@ -76,27 +200,27 @@ pub struct InferenceContext {
     pub method_sigs: HashMap<(Spur, Spur), MethodSig>,
 }
 
-/// Immutable context for semantic analysis.
+/// Context for semantic analysis, designed for parallel function analysis.
 ///
-/// This struct contains all type information and declarations that are
-/// read-only after the declaration gathering phase. It is designed to be
-/// `Send + Sync` so it can be shared across threads during parallel function
-/// body analysis.
+/// This struct contains all type information and declarations needed during
+/// function body analysis. It is designed to be `Send + Sync` so it can be
+/// shared across threads during parallel function analysis.
 ///
 /// # Contents
 ///
-/// - Struct and enum definitions
-/// - Function and method signatures
-/// - Array type registry
-/// - Pre-computed inference context
-/// - Built-in type IDs
+/// - Struct and enum definitions (immutable)
+/// - Function and method signatures (immutable)
+/// - Array type registry (thread-safe, allows concurrent insertions)
+/// - Pre-computed inference context (immutable)
+/// - Built-in type IDs (immutable)
 ///
 /// # Thread Safety
 ///
 /// `SemaContext` is `Send + Sync` because:
-/// - All contained data is immutable after construction
+/// - Most fields are immutable after construction
+/// - The array type registry uses `RwLock` for thread-safe mutations
 /// - References to RIR and interner are shared immutably
-/// - No `Cell`, `RefCell`, or other interior mutability types are used
+/// - ThreadedRodeo is designed to be thread-safe
 #[derive(Debug)]
 pub struct SemaContext<'a> {
     /// Reference to the RIR being analyzed.
@@ -107,11 +231,9 @@ pub struct SemaContext<'a> {
     pub struct_defs: Vec<StructDef>,
     /// Enum definitions indexed by EnumId.
     pub enum_defs: Vec<EnumDef>,
-    /// Array type table: maps (element_type, length) to ArrayTypeId.
-    /// Pre-populated during declaration gathering for array types in signatures.
-    pub array_types: HashMap<(Type, u64), ArrayTypeId>,
-    /// Array type definitions indexed by ArrayTypeId.
-    pub array_type_defs: Vec<ArrayTypeDef>,
+    /// Thread-safe array type registry.
+    /// Supports concurrent lookups and insertions during parallel analysis.
+    pub array_registry: ArrayTypeRegistry,
     /// Struct lookup: maps struct name symbol to StructId.
     pub structs: HashMap<Spur, StructId>,
     /// Enum lookup: maps enum name symbol to EnumId.
@@ -128,9 +250,11 @@ pub struct SemaContext<'a> {
     pub inference_ctx: InferenceContext,
 }
 
-// SAFETY: SemaContext contains only immutable data after construction.
-// The references to RIR and ThreadedRodeo are shared immutably.
-// ThreadedRodeo is designed to be thread-safe.
+// SAFETY: SemaContext is Send + Sync because:
+// - Immutable fields are trivially thread-safe
+// - ArrayTypeRegistry uses RwLock for interior mutability
+// - References to RIR and ThreadedRodeo are shared immutably
+// - ThreadedRodeo is designed to be thread-safe
 unsafe impl<'a> Send for SemaContext<'a> {}
 unsafe impl<'a> Sync for SemaContext<'a> {}
 
@@ -173,13 +297,18 @@ impl<'a> SemaContext<'a> {
     }
 
     /// Get an array type definition by ID.
-    pub fn get_array_type_def(&self, id: ArrayTypeId) -> &ArrayTypeDef {
-        &self.array_type_defs[id.0 as usize]
+    pub fn get_array_type_def(&self, id: ArrayTypeId) -> ArrayTypeDef {
+        self.array_registry.get_def(id)
     }
 
     /// Look up an array type by element type and length.
     pub fn get_array_type(&self, element_type: Type, length: u64) -> Option<ArrayTypeId> {
-        self.array_types.get(&(element_type, length)).copied()
+        self.array_registry.get(element_type, length)
+    }
+
+    /// Get or create an array type. Thread-safe.
+    pub fn get_or_create_array_type(&self, element_type: Type, length: u64) -> ArrayTypeId {
+        self.array_registry.get_or_create(element_type, length)
     }
 
     /// Get a human-readable name for a type.
@@ -200,7 +329,7 @@ impl<'a> SemaContext<'a> {
             Type::Struct(struct_id) => self.struct_defs[struct_id.0 as usize].name.clone(),
             Type::Enum(enum_id) => self.enum_defs[enum_id.0 as usize].name.clone(),
             Type::Array(array_id) => {
-                let array_def = &self.array_type_defs[array_id.0 as usize];
+                let array_def = self.array_registry.get_def(array_id);
                 format!(
                     "[{}; {}]",
                     self.format_type_name(array_def.element_type),
@@ -235,7 +364,7 @@ impl<'a> SemaContext<'a> {
             }
             // Arrays are Copy if their element type is Copy
             Type::Array(array_id) => {
-                let array_def = &self.array_type_defs[array_id.0 as usize];
+                let array_def = self.array_registry.get_def(array_id);
                 self.is_type_copy(array_def.element_type)
             }
         }
@@ -265,7 +394,7 @@ impl<'a> SemaContext<'a> {
                     .sum()
             }
             Type::Array(array_type_id) => {
-                let array_def = &self.array_type_defs[array_type_id.0 as usize];
+                let array_def = self.array_registry.get_def(array_type_id);
                 let element_slots = self.abi_slot_count(array_def.element_type);
                 element_slots * array_def.length as u32
             }
@@ -285,7 +414,7 @@ impl<'a> SemaContext<'a> {
     pub fn type_to_infer_type(&self, ty: Type) -> InferType {
         match ty {
             Type::Array(array_id) => {
-                let array_def = &self.array_type_defs[array_id.0 as usize];
+                let array_def = self.array_registry.get_def(array_id);
                 let element_infer = self.type_to_infer_type(array_def.element_type);
                 InferType::Array {
                     element: Box::new(element_infer),


### PR DESCRIPTION
Implements rue-wcg7: Thread-safe ArrayTypeRegistry with RwLock-based double-checked locking pattern.

Key changes:
- Add ArrayTypeRegistry struct in sema_context.rs with RwLock-wrapped HashMap and Vec for thread-safe get_or_create
- Update SemaContext to use array_registry instead of separate array_types/array_type_defs fields  
- Simplify FunctionAnalyzer to delegate array type operations to the shared registry (no local array type management needed)
- Update MergedFunctionOutput to only track strings/warnings since array types are now globally managed
- Update parallel analysis path in analysis.rs to extract array types from registry at the end

This enables parallel function body analysis by eliminating the &mut self requirement on get_or_create_array_type.

🤖 Generated with [Claude Code](https://claude.com/claude-code)