### PR TITLE
feat(rue-air): add pre-interned known symbols for fast intrinsic disp…

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -4179,179 +4179,177 @@ fn analyze_intrinsic_ctx(
             mode: RirArgMode::Normal,
         })
         .collect();
-    let intrinsic_name = ctx.interner.resolve(&name);
+    let known = &ctx.known;
 
-    match intrinsic_name {
-        "dbg" => {
-            if args.len() != 1 {
-                return Err(CompileError::new(
-                    ErrorKind::IntrinsicWrongArgCount {
-                        name: "dbg".to_string(),
-                        expected: 1,
-                        found: args.len(),
-                    },
-                    span,
-                ));
-            }
-
-            let arg_result = analyze_inst_with_context(ctx, air, args[0].value, analysis_ctx)?;
-            let arg_type = arg_result.ty;
-
-            // Validate type
-            if !arg_type.is_integer()
-                && arg_type != Type::Bool
-                && !arg_type.is_struct()
-                && !arg_type.is_enum()
-                && !arg_type.is_array()
-                && !arg_type.is_error()
-                && !arg_type.is_never()
-            {
-                return Err(CompileError::new(
-                    ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                        name: "dbg".to_string(),
-                        expected: "integer, bool, struct, enum, or array".to_string(),
-                        found: arg_type.name().to_string(),
-                    })),
-                    span,
-                ));
-            }
-
-            let air_args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
-            let air_ref = air.add_inst(AirInst {
-                data: AirInstData::Intrinsic {
-                    name: ctx.interner.get_or_intern("dbg"),
-                    args_start: air_args_start,
-                    args_len: 1,
+    // Use pre-interned symbol comparison instead of string comparison
+    if name == known.dbg {
+        if args.len() != 1 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "dbg".to_string(),
+                    expected: 1,
+                    found: args.len(),
                 },
-                ty: Type::Unit,
                 span,
-            });
-            Ok(AnalysisResult::new(air_ref, Type::Unit))
+            ));
         }
-        "cast" => {
-            if args.len() != 1 {
-                return Err(CompileError::new(
-                    ErrorKind::IntrinsicWrongArgCount {
-                        name: "cast".to_string(),
-                        expected: 1,
-                        found: args.len(),
-                    },
-                    span,
-                ));
-            }
 
-            // Get target type from HM inference
-            let target_type =
-                get_resolved_type_ctx(analysis_ctx, inst_ref, span, "@cast intrinsic")?;
+        let arg_result = analyze_inst_with_context(ctx, air, args[0].value, analysis_ctx)?;
+        let arg_type = arg_result.ty;
 
-            let arg_result = analyze_inst_with_context(ctx, air, args[0].value, analysis_ctx)?;
-            let source_type = arg_result.ty;
-
-            // Validate types
-            if !source_type.is_integer() && !source_type.is_error() && !source_type.is_never() {
-                return Err(CompileError::new(
-                    ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                        name: "cast".to_string(),
-                        expected: "integer type".to_string(),
-                        found: source_type.name().to_string(),
-                    })),
-                    span,
-                ));
-            }
-            if !target_type.is_integer() && !target_type.is_error() && !target_type.is_never() {
-                return Err(CompileError::new(
-                    ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                        name: "cast".to_string(),
-                        expected: "integer target type".to_string(),
-                        found: target_type.name().to_string(),
-                    })),
-                    span,
-                ));
-            }
-
-            // Skip cast if types are the same
-            if source_type == target_type || source_type.is_error() || source_type.is_never() {
-                return Ok(arg_result);
-            }
-
-            let air_ref = air.add_inst(AirInst {
-                data: AirInstData::IntCast {
-                    value: arg_result.air_ref,
-                    from_ty: source_type,
-                },
-                ty: target_type,
+        // Validate type
+        if !arg_type.is_integer()
+            && arg_type != Type::Bool
+            && !arg_type.is_struct()
+            && !arg_type.is_enum()
+            && !arg_type.is_array()
+            && !arg_type.is_error()
+            && !arg_type.is_never()
+        {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: "dbg".to_string(),
+                    expected: "integer, bool, struct, enum, or array".to_string(),
+                    found: arg_type.name().to_string(),
+                })),
                 span,
-            });
-            Ok(AnalysisResult::new(air_ref, target_type))
+            ));
         }
-        "panic" => {
-            // @panic takes an optional string message
-            if args.len() > 1 {
-                return Err(CompileError::new(
-                    ErrorKind::IntrinsicWrongArgCount {
-                        name: "panic".to_string(),
-                        expected: 1,
-                        found: args.len(),
-                    },
-                    span,
-                ));
-            }
 
-            if args.is_empty() {
-                // Panic with no message
-                let air_ref = air.add_inst(AirInst {
-                    data: AirInstData::UnitConst,
-                    ty: Type::Never,
-                    span,
-                });
-                return Ok(AnalysisResult::new(air_ref, Type::Never));
-            }
-
-            // Analyze the message argument
-            let arg_result = analyze_inst_with_context(ctx, air, args[0].value, analysis_ctx)?;
-
-            let air_args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
-            let air_ref = air.add_inst(AirInst {
-                data: AirInstData::Intrinsic {
-                    name: ctx.interner.get_or_intern("panic"),
-                    args_start: air_args_start,
-                    args_len: 1,
+        let air_args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name: known.dbg,
+                args_start: air_args_start,
+                args_len: 1,
+            },
+            ty: Type::Unit,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::Unit))
+    } else if name == known.cast {
+        if args.len() != 1 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "cast".to_string(),
+                    expected: 1,
+                    found: args.len(),
                 },
+                span,
+            ));
+        }
+
+        // Get target type from HM inference
+        let target_type = get_resolved_type_ctx(analysis_ctx, inst_ref, span, "@cast intrinsic")?;
+
+        let arg_result = analyze_inst_with_context(ctx, air, args[0].value, analysis_ctx)?;
+        let source_type = arg_result.ty;
+
+        // Validate types
+        if !source_type.is_integer() && !source_type.is_error() && !source_type.is_never() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: "cast".to_string(),
+                    expected: "integer type".to_string(),
+                    found: source_type.name().to_string(),
+                })),
+                span,
+            ));
+        }
+        if !target_type.is_integer() && !target_type.is_error() && !target_type.is_never() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: "cast".to_string(),
+                    expected: "integer target type".to_string(),
+                    found: target_type.name().to_string(),
+                })),
+                span,
+            ));
+        }
+
+        // Skip cast if types are the same
+        if source_type == target_type || source_type.is_error() || source_type.is_never() {
+            return Ok(arg_result);
+        }
+
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::IntCast {
+                value: arg_result.air_ref,
+                from_ty: source_type,
+            },
+            ty: target_type,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, target_type))
+    } else if name == known.panic {
+        // @panic takes an optional string message
+        if args.len() > 1 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "panic".to_string(),
+                    expected: 1,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        if args.is_empty() {
+            // Panic with no message
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::UnitConst,
                 ty: Type::Never,
                 span,
             });
-            Ok(AnalysisResult::new(air_ref, Type::Never))
+            return Ok(AnalysisResult::new(air_ref, Type::Never));
         }
-        "assert" => {
-            if args.len() != 1 {
-                return Err(CompileError::new(
-                    ErrorKind::IntrinsicWrongArgCount {
-                        name: "assert".to_string(),
-                        expected: 1,
-                        found: args.len(),
-                    },
-                    span,
-                ));
-            }
 
-            let arg_result = analyze_inst_with_context(ctx, air, args[0].value, analysis_ctx)?;
+        // Analyze the message argument
+        let arg_result = analyze_inst_with_context(ctx, air, args[0].value, analysis_ctx)?;
 
-            let air_args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
-            let air_ref = air.add_inst(AirInst {
-                data: AirInstData::Intrinsic {
-                    name: ctx.interner.get_or_intern("assert"),
-                    args_start: air_args_start,
-                    args_len: 1,
+        let air_args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name: known.panic,
+                args_start: air_args_start,
+                args_len: 1,
+            },
+            ty: Type::Never,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::Never))
+    } else if name == known.assert {
+        if args.len() != 1 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "assert".to_string(),
+                    expected: 1,
+                    found: args.len(),
                 },
-                ty: Type::Unit,
                 span,
-            });
-            Ok(AnalysisResult::new(air_ref, Type::Unit))
+            ));
         }
-        _ => Err(CompileError::new(
+
+        let arg_result = analyze_inst_with_context(ctx, air, args[0].value, analysis_ctx)?;
+
+        let air_args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name: known.assert,
+                args_start: air_args_start,
+                args_len: 1,
+            },
+            ty: Type::Unit,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::Unit))
+    } else {
+        // Unknown intrinsic - resolve name for error message
+        let intrinsic_name = ctx.interner.resolve(&name);
+        Err(CompileError::new(
             ErrorKind::UnknownIntrinsic(intrinsic_name.to_string()),
             span,
-        )),
+        ))
     }
 }
 
@@ -4363,27 +4361,24 @@ fn analyze_type_intrinsic_ctx(
     type_arg: Spur,
     span: Span,
 ) -> CompileResult<AnalysisResult> {
-    let intrinsic_name = ctx.interner.resolve(&name);
+    let known = &ctx.known;
     let ty = resolve_type_from_ctx(ctx, type_arg, span)?;
 
-    // Calculate the value based on which intrinsic
-    let value: u64 = match intrinsic_name {
-        "size_of" => {
-            // Calculate size in bytes (slot count * 8)
-            let slot_count = ctx.abi_slot_count(ty);
-            (slot_count * 8) as u64
-        }
-        "align_of" => {
-            // Zero-sized types have 1-byte alignment, others have 8-byte
-            let slot_count = ctx.abi_slot_count(ty);
-            if slot_count == 0 { 1u64 } else { 8u64 }
-        }
-        _ => {
-            return Err(CompileError::new(
-                ErrorKind::UnknownIntrinsic(intrinsic_name.to_string()),
-                span,
-            ));
-        }
+    // Calculate the value based on which intrinsic (using symbol comparison)
+    let value: u64 = if name == known.size_of {
+        // Calculate size in bytes (slot count * 8)
+        let slot_count = ctx.abi_slot_count(ty);
+        (slot_count * 8) as u64
+    } else if name == known.align_of {
+        // Zero-sized types have 1-byte alignment, others have 8-byte
+        let slot_count = ctx.abi_slot_count(ty);
+        if slot_count == 0 { 1u64 } else { 8u64 }
+    } else {
+        let intrinsic_name = ctx.interner.resolve(&name);
+        return Err(CompileError::new(
+            ErrorKind::UnknownIntrinsic(intrinsic_name.to_string()),
+            span,
+        ));
     };
 
     let air_ref = air.add_inst(AirInst {
@@ -5840,23 +5835,32 @@ impl<'a> Sema<'a> {
                 mode: RirArgMode::Normal,
             })
             .collect();
-        let intrinsic_name_str = self.interner.resolve(&name);
+        let known = &self.known;
 
-        match intrinsic_name_str {
-            "dbg" => self.analyze_dbg_intrinsic(air, inst_ref, &args, span, ctx),
-            "intCast" => self.analyze_intcast_intrinsic(air, inst_ref, &args, span, ctx),
-            "test_preview_gate" => self.analyze_test_preview_gate_intrinsic(air, &args, span),
-            "read_line" => self.analyze_read_line_intrinsic(air, name, &args, span),
-            "parse_i32" | "parse_i64" | "parse_u32" | "parse_u64" => {
-                self.analyze_parse_intrinsic(air, name, intrinsic_name_str, &args, span, ctx)
-            }
-            "cast" => self.analyze_cast_intrinsic(air, inst_ref, &args, span, ctx),
-            "panic" => self.analyze_panic_intrinsic(air, &args, span, ctx),
-            "assert" => self.analyze_assert_intrinsic(air, &args, span, ctx),
-            _ => Err(CompileError::new(
+        // Use pre-interned symbol comparison instead of string comparison
+        if name == known.dbg {
+            self.analyze_dbg_intrinsic(air, inst_ref, &args, span, ctx)
+        } else if name == known.int_cast {
+            self.analyze_intcast_intrinsic(air, inst_ref, &args, span, ctx)
+        } else if name == known.test_preview_gate {
+            self.analyze_test_preview_gate_intrinsic(air, &args, span)
+        } else if name == known.read_line {
+            self.analyze_read_line_intrinsic(air, name, &args, span)
+        } else if let Some(intrinsic_name_str) = known.get_parse_intrinsic_name(name) {
+            self.analyze_parse_intrinsic(air, name, intrinsic_name_str, &args, span, ctx)
+        } else if name == known.cast {
+            self.analyze_cast_intrinsic(air, inst_ref, &args, span, ctx)
+        } else if name == known.panic {
+            self.analyze_panic_intrinsic(air, &args, span, ctx)
+        } else if name == known.assert {
+            self.analyze_assert_intrinsic(air, &args, span, ctx)
+        } else {
+            // Unknown intrinsic - resolve name for error message
+            let intrinsic_name_str = self.interner.resolve(&name);
+            Err(CompileError::new(
                 ErrorKind::UnknownIntrinsic(intrinsic_name_str.to_string()),
                 span,
-            )),
+            ))
         }
     }
 
@@ -5906,7 +5910,7 @@ impl<'a> Sema<'a> {
         let args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
-                name: self.interner.get_or_intern("dbg"),
+                name: self.known.dbg,
                 args_start,
                 args_len: 1,
             },
@@ -6014,7 +6018,7 @@ impl<'a> Sema<'a> {
         let args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
-                name: self.interner.get_or_intern("panic"),
+                name: self.known.panic,
                 args_start,
                 args_len: 1,
             },
@@ -6056,7 +6060,7 @@ impl<'a> Sema<'a> {
         let args_start = air.add_extra(&extra_data);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
-                name: self.interner.get_or_intern("assert"),
+                name: self.known.assert,
                 args_start,
                 args_len,
             },

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -1,0 +1,197 @@
+//! Pre-interned known symbols for fast comparison.
+//!
+//! This module provides `KnownSymbols`, a struct that holds pre-interned `Spur`
+//! values for commonly compared strings like intrinsic names. By interning these
+//! strings once at initialization, we can compare symbols directly (integer
+//! comparison) instead of resolving to strings and doing string comparison.
+//!
+//! # Performance
+//!
+//! Each `interner.resolve()` call involves a hash table lookup. While individual
+//! lookups are fast, the cumulative cost across many intrinsic dispatches can be
+//! significant. Pre-interning known symbols reduces intrinsic dispatch from
+//! O(string_length) to O(1).
+//!
+//! # Usage
+//!
+//! ```ignore
+//! let known = KnownSymbols::new(interner);
+//!
+//! // Fast symbol comparison instead of string comparison
+//! if name == known.dbg {
+//!     // Handle @dbg intrinsic
+//! } else if name == known.cast {
+//!     // Handle @cast intrinsic
+//! }
+//! ```
+
+use lasso::{Spur, ThreadedRodeo};
+
+/// Pre-interned symbols for known strings.
+///
+/// This struct is created once during `SemaContext` construction and provides
+/// fast symbol comparison for intrinsic dispatch and other common lookups.
+#[derive(Debug, Clone, Copy)]
+pub struct KnownSymbols {
+    // Intrinsic names
+    /// The `dbg` intrinsic symbol.
+    pub dbg: Spur,
+    /// The `intCast` intrinsic symbol (deprecated, use `cast`).
+    pub int_cast: Spur,
+    /// The `cast` intrinsic symbol.
+    pub cast: Spur,
+    /// The `panic` intrinsic symbol.
+    pub panic: Spur,
+    /// The `assert` intrinsic symbol.
+    pub assert: Spur,
+    /// The `read_line` intrinsic symbol.
+    pub read_line: Spur,
+    /// The `parse_i32` intrinsic symbol.
+    pub parse_i32: Spur,
+    /// The `parse_i64` intrinsic symbol.
+    pub parse_i64: Spur,
+    /// The `parse_u32` intrinsic symbol.
+    pub parse_u32: Spur,
+    /// The `parse_u64` intrinsic symbol.
+    pub parse_u64: Spur,
+    /// The `test_preview_gate` intrinsic symbol.
+    pub test_preview_gate: Spur,
+
+    // Type intrinsics
+    /// The `size_of` type intrinsic symbol.
+    pub size_of: Spur,
+    /// The `align_of` type intrinsic symbol.
+    pub align_of: Spur,
+
+    // Builtin type names
+    /// The `String` type name symbol.
+    pub string_type: Spur,
+
+    // Special function names
+    /// The `main` function name symbol.
+    pub main_fn: Spur,
+}
+
+impl KnownSymbols {
+    /// Create a new `KnownSymbols` by interning all known strings.
+    ///
+    /// This should be called once during `SemaContext` construction.
+    pub fn new(interner: &ThreadedRodeo) -> Self {
+        Self {
+            // Intrinsic names
+            dbg: interner.get_or_intern_static("dbg"),
+            int_cast: interner.get_or_intern_static("intCast"),
+            cast: interner.get_or_intern_static("cast"),
+            panic: interner.get_or_intern_static("panic"),
+            assert: interner.get_or_intern_static("assert"),
+            read_line: interner.get_or_intern_static("read_line"),
+            parse_i32: interner.get_or_intern_static("parse_i32"),
+            parse_i64: interner.get_or_intern_static("parse_i64"),
+            parse_u32: interner.get_or_intern_static("parse_u32"),
+            parse_u64: interner.get_or_intern_static("parse_u64"),
+            test_preview_gate: interner.get_or_intern_static("test_preview_gate"),
+
+            // Type intrinsics
+            size_of: interner.get_or_intern_static("size_of"),
+            align_of: interner.get_or_intern_static("align_of"),
+
+            // Builtin type names
+            string_type: interner.get_or_intern_static("String"),
+
+            // Special function names
+            main_fn: interner.get_or_intern_static("main"),
+        }
+    }
+
+    /// Check if a symbol matches any of the parse intrinsics.
+    ///
+    /// Returns the parse intrinsic name as a string if it matches, or None.
+    pub fn get_parse_intrinsic_name(&self, sym: Spur) -> Option<&'static str> {
+        if sym == self.parse_i32 {
+            Some("parse_i32")
+        } else if sym == self.parse_i64 {
+            Some("parse_i64")
+        } else if sym == self.parse_u32 {
+            Some("parse_u32")
+        } else if sym == self.parse_u64 {
+            Some("parse_u64")
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_symbols_creation() {
+        let interner = ThreadedRodeo::new();
+        let known = KnownSymbols::new(&interner);
+
+        // Verify symbols can be resolved back to their expected strings
+        assert_eq!(interner.resolve(&known.dbg), "dbg");
+        assert_eq!(interner.resolve(&known.int_cast), "intCast");
+        assert_eq!(interner.resolve(&known.cast), "cast");
+        assert_eq!(interner.resolve(&known.panic), "panic");
+        assert_eq!(interner.resolve(&known.assert), "assert");
+        assert_eq!(interner.resolve(&known.read_line), "read_line");
+        assert_eq!(interner.resolve(&known.parse_i32), "parse_i32");
+        assert_eq!(interner.resolve(&known.parse_i64), "parse_i64");
+        assert_eq!(interner.resolve(&known.parse_u32), "parse_u32");
+        assert_eq!(interner.resolve(&known.parse_u64), "parse_u64");
+        assert_eq!(
+            interner.resolve(&known.test_preview_gate),
+            "test_preview_gate"
+        );
+        assert_eq!(interner.resolve(&known.size_of), "size_of");
+        assert_eq!(interner.resolve(&known.align_of), "align_of");
+        assert_eq!(interner.resolve(&known.string_type), "String");
+        assert_eq!(interner.resolve(&known.main_fn), "main");
+    }
+
+    #[test]
+    fn known_symbols_comparison() {
+        let interner = ThreadedRodeo::new();
+        let known = KnownSymbols::new(&interner);
+
+        // Interning the same string should return the same Spur
+        let dbg_sym = interner.get_or_intern("dbg");
+        assert_eq!(dbg_sym, known.dbg);
+
+        let main_sym = interner.get_or_intern("main");
+        assert_eq!(main_sym, known.main_fn);
+    }
+
+    #[test]
+    fn get_parse_intrinsic_name() {
+        let interner = ThreadedRodeo::new();
+        let known = KnownSymbols::new(&interner);
+
+        assert_eq!(
+            known.get_parse_intrinsic_name(known.parse_i32),
+            Some("parse_i32")
+        );
+        assert_eq!(
+            known.get_parse_intrinsic_name(known.parse_i64),
+            Some("parse_i64")
+        );
+        assert_eq!(
+            known.get_parse_intrinsic_name(known.parse_u32),
+            Some("parse_u32")
+        );
+        assert_eq!(
+            known.get_parse_intrinsic_name(known.parse_u64),
+            Some("parse_u64")
+        );
+        assert_eq!(known.get_parse_intrinsic_name(known.dbg), None);
+    }
+
+    #[test]
+    fn known_symbols_is_copy() {
+        // KnownSymbols should be Copy since it only contains Spur values
+        fn assert_copy<T: Copy>() {}
+        assert_copy::<KnownSymbols>();
+    }
+}

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -25,7 +25,10 @@ mod analyze_ops;
 mod builtins;
 mod context;
 mod declarations;
+mod known_symbols;
 mod typeck;
+
+pub use known_symbols::KnownSymbols;
 
 use std::collections::HashMap;
 
@@ -122,6 +125,7 @@ impl<'a> GatherOutput<'a> {
             methods: self.methods,
             preview_features: self.preview_features,
             builtin_string_id: self.builtin_string_id,
+            known: KnownSymbols::new(self.interner),
         }
     }
 
@@ -252,6 +256,8 @@ pub struct Sema<'a> {
     /// StructId of the synthetic String type.
     /// This is populated during `inject_builtin_types()` and used for quick lookups.
     pub(crate) builtin_string_id: Option<StructId>,
+    /// Pre-interned known symbols for fast comparison.
+    pub(crate) known: KnownSymbols,
 }
 
 impl<'a> Sema<'a> {
@@ -274,6 +280,7 @@ impl<'a> Sema<'a> {
             methods: HashMap::new(),
             preview_features,
             builtin_string_id: None,
+            known: KnownSymbols::new(interner),
         }
     }
 
@@ -457,6 +464,7 @@ impl<'a> Sema<'a> {
             preview_features: self.preview_features.clone(),
             builtin_string_id: self.builtin_string_id,
             inference_ctx,
+            known: KnownSymbols::new(self.interner),
         }
     }
 

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -36,6 +36,7 @@ use rue_error::PreviewFeatures;
 use rue_rir::{Rir, RirParamMode};
 
 use crate::inference::{FunctionSig, InferType, MethodSig};
+use crate::sema::KnownSymbols;
 use crate::types::{ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructId, Type};
 
 /// Thread-safe registry for array types.
@@ -248,6 +249,8 @@ pub struct SemaContext<'a> {
     pub builtin_string_id: Option<StructId>,
     /// Pre-computed inference context for HM type inference.
     pub inference_ctx: InferenceContext,
+    /// Pre-interned known symbols for fast comparison.
+    pub known: KnownSymbols,
 }
 
 // SAFETY: SemaContext is Send + Sync because:


### PR DESCRIPTION
…atch

Add KnownSymbols struct that pre-interns commonly compared strings like intrinsic names (dbg, cast, panic, assert, read_line, parse_*, etc.), type intrinsics (size_of, align_of), and builtin type names (String, main).

This allows intrinsic dispatch to use fast Spur comparison (integer comparison) instead of resolving to strings and doing string comparison on each intrinsic call. Each interner.resolve() involves a hash table lookup, so pre-interning known symbols reduces that to O(1).

Changes:
- Add known_symbols.rs with KnownSymbols struct
- Add known field to both Sema and SemaContext
- Update analyze_intrinsic_ctx to use symbol comparison
- Update Sema::analyze_intrinsic_impl to use symbol comparison
- Update intrinsic helper methods (dbg, panic, assert) to use known symbols

Closes: rue-nifs

🤖 Generated with [Claude Code](https://claude.com/claude-code)