### PR TITLE
Remove duplicate FunctionInfo/MethodInfo types from sema_context

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -33,10 +33,9 @@ pub use inst::{
     Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirParamMode, AirPattern, AirRef,
 };
 pub use sema::{AnalyzedFunction, FunctionInfo, GatherOutput, MethodInfo, Sema, SemaOutput};
-pub use sema_context::{
-    FunctionInfo as SemaContextFunctionInfo, InferenceContext as SemaContextInferenceContext,
-    MethodInfo as SemaContextMethodInfo, SemaContext,
-};
+// Note: FunctionInfo and MethodInfo are defined in sema and re-exported by sema_context.
+// We export InferenceContext and SemaContext from sema_context.
+pub use sema_context::{InferenceContext as SemaContextInferenceContext, SemaContext};
 pub use type_context::{FunctionSignature, MethodSignature, TypeContext};
 pub use types::{
     ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructField, StructId, Type,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -37,9 +37,7 @@ use rue_error::{CompileErrors, MultiErrorResult, PreviewFeatures};
 use rue_rir::Rir;
 
 use crate::sema_context::{
-    ArrayTypeRegistry, FunctionInfo as SemaContextFunctionInfo,
-    InferenceContext as SemaContextInferenceContext, MethodInfo as SemaContextMethodInfo,
-    SemaContext,
+    ArrayTypeRegistry, InferenceContext as SemaContextInferenceContext, SemaContext,
 };
 use crate::types::{ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructId, Type};
 
@@ -429,38 +427,8 @@ impl<'a> Sema<'a> {
             ),
             structs: self.structs.clone(),
             enums: self.enums.clone(),
-            functions: self
-                .functions
-                .iter()
-                .map(|(name, info)| {
-                    (
-                        *name,
-                        SemaContextFunctionInfo {
-                            param_types: info.param_types.clone(),
-                            param_modes: info.param_modes.clone(),
-                            return_type: info.return_type,
-                        },
-                    )
-                })
-                .collect(),
-            methods: self
-                .methods
-                .iter()
-                .map(|((type_name, method_name), info)| {
-                    (
-                        (*type_name, *method_name),
-                        SemaContextMethodInfo {
-                            struct_type: info.struct_type,
-                            has_self: info.has_self,
-                            param_names: info.param_names.clone(),
-                            param_types: info.param_types.clone(),
-                            return_type: info.return_type,
-                            body: info.body,
-                            span: info.span,
-                        },
-                    )
-                })
-                .collect(),
+            functions: self.functions.clone(),
+            methods: self.methods.clone(),
             preview_features: self.preview_features.clone(),
             builtin_string_id: self.builtin_string_id,
             inference_ctx,

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -33,10 +33,12 @@ use std::sync::RwLock;
 
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::PreviewFeatures;
-use rue_rir::{Rir, RirParamMode};
+use rue_rir::Rir;
 
 use crate::inference::{FunctionSig, InferType, MethodSig};
-use crate::sema::KnownSymbols;
+// Import FunctionInfo, MethodInfo, and KnownSymbols from sema module to avoid duplication.
+// FunctionInfo and MethodInfo are the canonical definitions; we re-export them for convenience.
+pub use crate::sema::{FunctionInfo, KnownSymbols, MethodInfo};
 use crate::types::{ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructId, Type};
 
 /// Thread-safe registry for array types.
@@ -151,36 +153,6 @@ impl Default for ArrayTypeRegistry {
     fn default() -> Self {
         Self::new()
     }
-}
-
-/// Information about a function.
-#[derive(Debug, Clone)]
-pub struct FunctionInfo {
-    /// Parameter types (in order)
-    pub param_types: Vec<Type>,
-    /// Parameter modes (in order)
-    pub param_modes: Vec<RirParamMode>,
-    /// Return type
-    pub return_type: Type,
-}
-
-/// Information about a method in an impl block.
-#[derive(Debug, Clone)]
-pub struct MethodInfo {
-    /// The struct type this method belongs to
-    pub struct_type: Type,
-    /// Whether this is a method (has self) or associated function (no self)
-    pub has_self: bool,
-    /// Parameter names (excluding self if present)
-    pub param_names: Vec<Spur>,
-    /// Parameter types (excluding self if present)
-    pub param_types: Vec<Type>,
-    /// Return type
-    pub return_type: Type,
-    /// The RIR instruction ref for the method body
-    pub body: rue_rir::InstRef,
-    /// Span of the method declaration
-    pub span: rue_span::Span,
 }
 
 /// Pre-computed type information for constraint generation.


### PR DESCRIPTION
Eliminates type duplication by having sema_context.rs import and re-export FunctionInfo and MethodInfo from sema/mod.rs instead of defining its own copies. Simplifies build_sema_context() to directly clone the HashMaps.

Fixes rue-mq61

🤖 Generated with [Claude Code](https://claude.com/claude-code)