### PR TITLE
feat(diagnostics): add MultiFileFormatter for multi-file diagnostics

### DIFF
--- a/crates/rue-compiler/src/diagnostic.rs
+++ b/crates/rue-compiler/src/diagnostic.rs
@@ -25,7 +25,7 @@ use std::io::IsTerminal;
 
 use annotate_snippets::{Level, Renderer, Snippet};
 
-use crate::{CompileError, CompileErrors, CompileWarning, Diagnostic, Span};
+use crate::{CompileError, CompileErrors, CompileWarning, Diagnostic, FileId, Span};
 
 /// Source code information for diagnostic rendering.
 ///
@@ -250,10 +250,283 @@ impl<'a> DiagnosticFormatter<'a> {
 }
 
 // ============================================================================
-// JSON Diagnostic Output
+// Multi-File Diagnostic Formatter
 // ============================================================================
 
-use crate::{Applicability, Suggestion};
+/// A diagnostic formatter that supports diagnostics spanning multiple source files.
+///
+/// While [`DiagnosticFormatter`] works with a single source file, this formatter
+/// can render errors that reference multiple files. This is useful for multi-file
+/// compilation where an error might reference a type defined in one file while
+/// being used in another.
+///
+/// # Example
+///
+/// ```ignore
+/// use rue_compiler::{MultiFileFormatter, SourceInfo, FileId};
+///
+/// // Create source infos for each file
+/// let sources = vec![
+///     (FileId::new(1), SourceInfo::new(&source1, "main.rue")),
+///     (FileId::new(2), SourceInfo::new(&source2, "utils.rue")),
+/// ];
+///
+/// let formatter = MultiFileFormatter::new(sources);
+/// let error_output = formatter.format_error(&error);
+/// eprintln!("{}", error_output);
+/// ```
+pub struct MultiFileFormatter<'a> {
+    /// Mapping from FileId to source information.
+    sources: HashMap<FileId, SourceInfo<'a>>,
+    /// The renderer for formatting diagnostics.
+    renderer: Renderer,
+}
+
+impl<'a> MultiFileFormatter<'a> {
+    /// Create a new multi-file formatter from an iterator of (FileId, SourceInfo) pairs.
+    ///
+    /// By default, uses automatic color detection based on whether stderr is a terminal.
+    pub fn new(sources: impl IntoIterator<Item = (FileId, SourceInfo<'a>)>) -> Self {
+        Self::with_color_choice(sources, ColorChoice::Auto)
+    }
+
+    /// Create a new multi-file formatter with explicit color choice.
+    pub fn with_color_choice(
+        sources: impl IntoIterator<Item = (FileId, SourceInfo<'a>)>,
+        color_choice: ColorChoice,
+    ) -> Self {
+        let use_color = match color_choice {
+            ColorChoice::Auto => std::io::stderr().is_terminal(),
+            ColorChoice::Always => true,
+            ColorChoice::Never => false,
+        };
+        let renderer = if use_color {
+            Renderer::styled()
+        } else {
+            Renderer::plain()
+        };
+        Self {
+            sources: sources.into_iter().collect(),
+            renderer,
+        }
+    }
+
+    /// Get the source info for a file ID, if it exists.
+    fn get_source(&self, file_id: FileId) -> Option<&SourceInfo<'a>> {
+        self.sources.get(&file_id)
+    }
+
+    /// Get a fallback source info (the first one in the map).
+    ///
+    /// This is used when a span has no file ID (FileId::DEFAULT) and we need
+    /// to show something. Returns None if no sources are registered.
+    fn fallback_source(&self) -> Option<&SourceInfo<'a>> {
+        // Try FileId::DEFAULT first, then any source
+        self.sources
+            .get(&FileId::DEFAULT)
+            .or_else(|| self.sources.values().next())
+    }
+
+    /// Format a compilation error into a string.
+    ///
+    /// The error is formatted with its error code, e.g.:
+    /// `error[E0206]: type mismatch: expected i32, found bool`
+    ///
+    /// If the error or its labels reference multiple files, each file's
+    /// snippet is shown separately.
+    pub fn format_error(&self, error: &CompileError) -> String {
+        let message_with_code = format!("[{}]: {}", error.kind.code(), error.kind);
+        self.format_diagnostic_impl(
+            Level::Error,
+            &message_with_code,
+            error.span(),
+            error.diagnostic(),
+        )
+    }
+
+    /// Format multiple compilation errors into a string.
+    ///
+    /// Each error is formatted on its own line(s). A summary line is added at
+    /// the end if there are multiple errors showing the total count.
+    pub fn format_errors(&self, errors: &CompileErrors) -> String {
+        if errors.is_empty() {
+            return String::new();
+        }
+
+        let mut output = String::new();
+        for error in errors.iter() {
+            if !output.is_empty() {
+                output.push('\n');
+            }
+            output.push_str(&self.format_error(error));
+        }
+
+        if errors.len() > 1 {
+            output.push_str(&format!(
+                "\nerror: aborting due to {} previous errors\n",
+                errors.len()
+            ));
+        }
+
+        output
+    }
+
+    /// Format all warnings, adding line numbers when multiple variables share the same name.
+    pub fn format_warnings(&self, warnings: &[CompileWarning]) -> String {
+        if warnings.is_empty() {
+            return String::new();
+        }
+
+        // Count occurrences of each unused variable name
+        let mut var_name_counts: HashMap<&str, usize> = HashMap::new();
+        for warning in warnings {
+            if let Some(name) = warning.kind.unused_variable_name() {
+                *var_name_counts.entry(name).or_insert(0) += 1;
+            }
+        }
+
+        // Format each warning
+        let mut output = String::new();
+        for warning in warnings {
+            let needs_line_number = warning
+                .kind
+                .unused_variable_name()
+                .is_some_and(|name| var_name_counts.get(name).copied().unwrap_or(0) > 1);
+
+            if !output.is_empty() {
+                output.push('\n');
+            }
+            output.push_str(&self.format_warning_internal(warning, needs_line_number));
+        }
+        output
+    }
+
+    /// Format a single warning into a string.
+    pub fn format_warning(&self, warning: &CompileWarning) -> String {
+        self.format_warning_internal(warning, false)
+    }
+
+    fn format_warning_internal(
+        &self,
+        warning: &CompileWarning,
+        include_line_number: bool,
+    ) -> String {
+        // Get the message, optionally with line number for disambiguation
+        let message = if include_line_number {
+            if let Some(span) = warning.span() {
+                if let Some(source_info) = self
+                    .get_source(span.file_id)
+                    .or_else(|| self.fallback_source())
+                {
+                    let line = span.line_number(source_info.source);
+                    warning.kind.format_with_line(Some(line))
+                } else {
+                    warning.to_string()
+                }
+            } else {
+                warning.to_string()
+            }
+        } else {
+            warning.to_string()
+        };
+
+        self.format_diagnostic_impl(
+            Level::Warning,
+            &message,
+            warning.span(),
+            warning.diagnostic(),
+        )
+    }
+
+    /// Internal implementation for formatting diagnostics with multi-file support.
+    fn format_diagnostic_impl(
+        &self,
+        level: Level,
+        message: &str,
+        span: Option<Span>,
+        diagnostic: &Diagnostic,
+    ) -> String {
+        // For diagnostics without a span, just format the message with any footers
+        let Some(primary_span) = span else {
+            let mut report = level.title(message);
+            for note in &diagnostic.notes {
+                report = report.footer(Level::Note.title(note.0.as_str()));
+            }
+            for help in &diagnostic.helps {
+                report = report.footer(Level::Help.title(help.0.as_str()));
+            }
+            return format!("{}", self.renderer.render(report));
+        };
+
+        // Collect all file IDs we need to show
+        let mut file_spans: HashMap<FileId, Vec<(Span, Option<&str>, Level)>> = HashMap::new();
+
+        // Add primary span
+        file_spans
+            .entry(primary_span.file_id)
+            .or_default()
+            .push((primary_span, None, level));
+
+        // Add secondary labels
+        for label in &diagnostic.labels {
+            file_spans.entry(label.span.file_id).or_default().push((
+                label.span,
+                Some(label.message.as_str()),
+                Level::Info,
+            ));
+        }
+
+        // Build report with snippets for each file
+        let mut report = level.title(message);
+
+        // Process files in a deterministic order (by FileId)
+        let mut file_ids: Vec<_> = file_spans.keys().copied().collect();
+        file_ids.sort_by_key(|id| id.0);
+
+        for file_id in file_ids {
+            let spans = &file_spans[&file_id];
+
+            // Get source info for this file
+            let source_info = self.get_source(file_id).or_else(|| self.fallback_source());
+
+            let Some(source_info) = source_info else {
+                // No source available for this file - skip it
+                continue;
+            };
+
+            // Build snippet with all annotations for this file
+            let mut snippet = Snippet::source(source_info.source)
+                .origin(source_info.path)
+                .fold(true);
+
+            for (span, label, span_level) in spans {
+                let annotation = span_level.span(span.start as usize..span.end as usize);
+                let annotation = if let Some(label_text) = label {
+                    annotation.label(label_text)
+                } else {
+                    annotation
+                };
+                snippet = snippet.annotation(annotation);
+            }
+
+            report = report.snippet(snippet);
+        }
+
+        // Add notes and helps as footers
+        for note in &diagnostic.notes {
+            report = report.footer(Level::Note.title(note.0.as_str()));
+        }
+        for help in &diagnostic.helps {
+            report = report.footer(Level::Help.title(help.0.as_str()));
+        }
+
+        format!("{}", self.renderer.render(report))
+    }
+}
+
+// ============================================================================
+// JSON Diagnostic Output
+// ============================================================================
 
 /// A diagnostic formatted for JSON output.
 ///
@@ -563,6 +836,234 @@ impl<'a> JsonDiagnosticFormatter<'a> {
                 end: s.span.end,
                 replacement: s.replacement.clone(),
                 applicability: s.applicability.to_string(),
+            })
+            .collect();
+
+        JsonDiagnostic {
+            code: String::new(), // Warnings don't have codes yet
+            message: format!("{}", warning.kind),
+            severity: "warning",
+            spans,
+            suggestions,
+            notes: diag.notes.iter().map(|n| n.0.clone()).collect(),
+            helps: diag.helps.iter().map(|h| h.0.clone()).collect(),
+        }
+    }
+
+    /// Format multiple errors as a JSON array string.
+    pub fn format_errors(&self, errors: &CompileErrors) -> String {
+        let diagnostics: Vec<String> = errors
+            .iter()
+            .map(|e| self.format_error(e).to_json())
+            .collect();
+        format!("[{}]", diagnostics.join(","))
+    }
+
+    /// Format multiple warnings as a JSON array string.
+    pub fn format_warnings(&self, warnings: &[CompileWarning]) -> String {
+        let diagnostics: Vec<String> = warnings
+            .iter()
+            .map(|w| self.format_warning(w).to_json())
+            .collect();
+        format!("[{}]", diagnostics.join(","))
+    }
+}
+
+// ============================================================================
+// Multi-File JSON Diagnostic Formatter
+// ============================================================================
+
+/// Formats diagnostics as JSON with support for multiple source files.
+///
+/// This formatter maps FileIds to their source information, enabling correct
+/// file path and line/column output for diagnostics spanning multiple files.
+///
+/// # Example
+///
+/// ```ignore
+/// use rue_compiler::{MultiFileJsonFormatter, SourceInfo, FileId};
+///
+/// let sources = vec![
+///     (FileId::new(1), SourceInfo::new(&source1, "main.rue")),
+///     (FileId::new(2), SourceInfo::new(&source2, "utils.rue")),
+/// ];
+///
+/// let formatter = MultiFileJsonFormatter::new(sources);
+/// let json = formatter.format_error(&error).to_json();
+/// ```
+pub struct MultiFileJsonFormatter<'a> {
+    /// Mapping from FileId to source information.
+    sources: HashMap<FileId, SourceInfo<'a>>,
+}
+
+impl<'a> MultiFileJsonFormatter<'a> {
+    /// Create a new multi-file JSON diagnostic formatter.
+    pub fn new(sources: impl IntoIterator<Item = (FileId, SourceInfo<'a>)>) -> Self {
+        Self {
+            sources: sources.into_iter().collect(),
+        }
+    }
+
+    /// Get the source info for a file ID, if it exists.
+    fn get_source(&self, file_id: FileId) -> Option<&SourceInfo<'a>> {
+        self.sources.get(&file_id)
+    }
+
+    /// Get a fallback source info (for FileId::DEFAULT or when no specific source is found).
+    fn fallback_source(&self) -> Option<&SourceInfo<'a>> {
+        self.sources
+            .get(&FileId::DEFAULT)
+            .or_else(|| self.sources.values().next())
+    }
+
+    /// Calculate line and column for a byte offset in a specific source.
+    fn offset_to_line_col(&self, source: &str, offset: u32) -> (u32, u32) {
+        let offset = offset as usize;
+        let mut line = 1u32;
+        let mut col = 1u32;
+        for (i, ch) in source.char_indices() {
+            if i >= offset {
+                break;
+            }
+            if ch == '\n' {
+                line += 1;
+                col = 1;
+            } else {
+                col += 1;
+            }
+        }
+        (line, col)
+    }
+
+    /// Get the path and source for a span, using the span's file ID.
+    fn source_for_span(&self, span: Span) -> Option<(&str, &str)> {
+        self.get_source(span.file_id)
+            .or_else(|| self.fallback_source())
+            .map(|info| (info.path, info.source))
+    }
+
+    /// Format a compile error as JSON.
+    pub fn format_error(&self, error: &CompileError) -> JsonDiagnostic {
+        let diag = error.diagnostic();
+
+        let primary_span = error.span().and_then(|span| {
+            self.source_for_span(span).map(|(path, source)| {
+                let (line, col) = self.offset_to_line_col(source, span.start);
+                JsonSpan {
+                    file: path.to_string(),
+                    start: span.start,
+                    end: span.end,
+                    line,
+                    column: col,
+                    label: None,
+                    primary: true,
+                }
+            })
+        });
+
+        let secondary_spans: Vec<JsonSpan> = diag
+            .labels
+            .iter()
+            .filter_map(|label| {
+                self.source_for_span(label.span).map(|(path, source)| {
+                    let (line, col) = self.offset_to_line_col(source, label.span.start);
+                    JsonSpan {
+                        file: path.to_string(),
+                        start: label.span.start,
+                        end: label.span.end,
+                        line,
+                        column: col,
+                        label: Some(label.message.clone()),
+                        primary: false,
+                    }
+                })
+            })
+            .collect();
+
+        let mut spans: Vec<JsonSpan> = primary_span.into_iter().collect();
+        spans.extend(secondary_spans);
+
+        let suggestions: Vec<JsonSuggestion> = diag
+            .suggestions
+            .iter()
+            .filter_map(|s| {
+                self.source_for_span(s.span)
+                    .map(|(path, _)| JsonSuggestion {
+                        message: s.message.clone(),
+                        file: path.to_string(),
+                        start: s.span.start,
+                        end: s.span.end,
+                        replacement: s.replacement.clone(),
+                        applicability: s.applicability.to_string(),
+                    })
+            })
+            .collect();
+
+        JsonDiagnostic {
+            code: format!("{}", error.kind.code()),
+            message: format!("{}", error.kind),
+            severity: "error",
+            spans,
+            suggestions,
+            notes: diag.notes.iter().map(|n| n.0.clone()).collect(),
+            helps: diag.helps.iter().map(|h| h.0.clone()).collect(),
+        }
+    }
+
+    /// Format a compile warning as JSON.
+    pub fn format_warning(&self, warning: &CompileWarning) -> JsonDiagnostic {
+        let diag = warning.diagnostic();
+
+        let primary_span = warning.span().and_then(|span| {
+            self.source_for_span(span).map(|(path, source)| {
+                let (line, col) = self.offset_to_line_col(source, span.start);
+                JsonSpan {
+                    file: path.to_string(),
+                    start: span.start,
+                    end: span.end,
+                    line,
+                    column: col,
+                    label: None,
+                    primary: true,
+                }
+            })
+        });
+
+        let secondary_spans: Vec<JsonSpan> = diag
+            .labels
+            .iter()
+            .filter_map(|label| {
+                self.source_for_span(label.span).map(|(path, source)| {
+                    let (line, col) = self.offset_to_line_col(source, label.span.start);
+                    JsonSpan {
+                        file: path.to_string(),
+                        start: label.span.start,
+                        end: label.span.end,
+                        line,
+                        column: col,
+                        label: Some(label.message.clone()),
+                        primary: false,
+                    }
+                })
+            })
+            .collect();
+
+        let mut spans: Vec<JsonSpan> = primary_span.into_iter().collect();
+        spans.extend(secondary_spans);
+
+        let suggestions: Vec<JsonSuggestion> = diag
+            .suggestions
+            .iter()
+            .filter_map(|s| {
+                self.source_for_span(s.span)
+                    .map(|(path, _)| JsonSuggestion {
+                        message: s.message.clone(),
+                        file: path.to_string(),
+                        start: s.span.start,
+                        end: s.span.end,
+                        replacement: s.replacement.clone(),
+                        applicability: s.applicability.to_string(),
+                    })
             })
             .collect();
 
@@ -956,5 +1457,233 @@ mod tests {
         let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
         assert!(parsed.is_array());
         assert_eq!(parsed.as_array().unwrap().len(), 1);
+    }
+
+    // ========================================================================
+    // MultiFileFormatter tests
+    // ========================================================================
+
+    #[test]
+    fn test_multi_file_formatter_single_file() {
+        let source = "fn main() -> i32 { 1 + true }";
+        let sources = vec![(FileId::new(1), SourceInfo::new(source, "test.rue"))];
+        let formatter = MultiFileFormatter::new(sources);
+
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::with_file(FileId::new(1), 23, 27),
+        );
+
+        let output = formatter.format_error(&error);
+        assert!(output.contains("[E0206]"));
+        assert!(output.contains("type mismatch"));
+        assert!(output.contains("test.rue"));
+    }
+
+    #[test]
+    fn test_multi_file_formatter_multiple_files() {
+        let source1 = "fn main() -> i32 { helper() }";
+        let source2 = "fn helper() -> bool { true }";
+        let sources = vec![
+            (FileId::new(1), SourceInfo::new(source1, "main.rue")),
+            (FileId::new(2), SourceInfo::new(source2, "helper.rue")),
+        ];
+        let formatter = MultiFileFormatter::new(sources);
+
+        // Error in file 1 with label pointing to file 2
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::with_file(FileId::new(1), 19, 27),
+        )
+        .with_label(
+            "function returns bool here",
+            Span::with_file(FileId::new(2), 15, 19),
+        );
+
+        let output = formatter.format_error(&error);
+        // Should contain both file names
+        assert!(output.contains("main.rue"));
+        assert!(output.contains("helper.rue"));
+        assert!(output.contains("function returns bool here"));
+    }
+
+    #[test]
+    fn test_multi_file_formatter_without_span() {
+        let source = "fn foo() -> i32 { 42 }";
+        let sources = vec![(FileId::new(1), SourceInfo::new(source, "test.rue"))];
+        let formatter = MultiFileFormatter::new(sources);
+
+        let error = CompileError::without_span(ErrorKind::NoMainFunction);
+
+        let output = formatter.format_error(&error);
+        assert!(output.contains("[E0200]"));
+        assert!(output.contains("no main function"));
+    }
+
+    #[test]
+    fn test_multi_file_formatter_format_errors() {
+        let source = "fn main() -> i32 { 1 + true }";
+        let sources = vec![(FileId::new(1), SourceInfo::new(source, "test.rue"))];
+        let formatter = MultiFileFormatter::new(sources);
+
+        let mut errors = CompileErrors::new();
+        errors.push(CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::with_file(FileId::new(1), 23, 27),
+        ));
+        errors.push(CompileError::without_span(ErrorKind::NoMainFunction));
+
+        let output = formatter.format_errors(&errors);
+        assert!(output.contains("type mismatch"));
+        assert!(output.contains("no main function"));
+        assert!(output.contains("aborting due to 2 previous errors"));
+    }
+
+    #[test]
+    fn test_multi_file_formatter_format_warnings() {
+        let source = "fn main() -> i32 { let x = 42; 0 }";
+        let sources = vec![(FileId::new(1), SourceInfo::new(source, "test.rue"))];
+        let formatter = MultiFileFormatter::new(sources);
+
+        let warnings = vec![CompileWarning::new(
+            WarningKind::UnusedVariable("x".to_string()),
+            Span::with_file(FileId::new(1), 23, 24),
+        )];
+
+        let output = formatter.format_warnings(&warnings);
+        assert!(output.contains("unused variable"));
+        assert!(output.contains("'x'"));
+    }
+
+    #[test]
+    fn test_multi_file_formatter_color_choice() {
+        let source = "fn main() -> i32 { 1 + true }";
+        let sources = vec![(FileId::new(1), SourceInfo::new(source, "test.rue"))];
+        let formatter = MultiFileFormatter::with_color_choice(sources, ColorChoice::Never);
+
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::with_file(FileId::new(1), 23, 27),
+        );
+
+        let output = formatter.format_error(&error);
+        // Output should not contain ANSI escape codes
+        assert!(!output.contains("\x1b["));
+    }
+
+    // ========================================================================
+    // MultiFileJsonFormatter tests
+    // ========================================================================
+
+    #[test]
+    fn test_multi_file_json_formatter_single_file() {
+        let source = "fn main() -> i32 { 1 + true }";
+        let sources = vec![(FileId::new(1), SourceInfo::new(source, "test.rue"))];
+        let formatter = MultiFileJsonFormatter::new(sources);
+
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::with_file(FileId::new(1), 23, 27),
+        );
+
+        let json_diag = formatter.format_error(&error);
+        assert_eq!(json_diag.severity, "error");
+        assert_eq!(json_diag.code, "E0206");
+        assert_eq!(json_diag.spans.len(), 1);
+        assert_eq!(json_diag.spans[0].file, "test.rue");
+        assert!(json_diag.spans[0].primary);
+    }
+
+    #[test]
+    fn test_multi_file_json_formatter_multiple_files() {
+        let source1 = "fn main() -> i32 { helper() }";
+        let source2 = "fn helper() -> bool { true }";
+        let sources = vec![
+            (FileId::new(1), SourceInfo::new(source1, "main.rue")),
+            (FileId::new(2), SourceInfo::new(source2, "helper.rue")),
+        ];
+        let formatter = MultiFileJsonFormatter::new(sources);
+
+        // Error in file 1 with label pointing to file 2
+        let error = CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::with_file(FileId::new(1), 19, 27),
+        )
+        .with_label(
+            "function returns bool here",
+            Span::with_file(FileId::new(2), 15, 19),
+        );
+
+        let json_diag = formatter.format_error(&error);
+        assert_eq!(json_diag.spans.len(), 2);
+
+        // Primary span should be from main.rue
+        let primary = json_diag.spans.iter().find(|s| s.primary).unwrap();
+        assert_eq!(primary.file, "main.rue");
+
+        // Secondary span should be from helper.rue
+        let secondary = json_diag.spans.iter().find(|s| !s.primary).unwrap();
+        assert_eq!(secondary.file, "helper.rue");
+        assert_eq!(
+            secondary.label,
+            Some("function returns bool here".to_string())
+        );
+    }
+
+    #[test]
+    fn test_multi_file_json_formatter_format_errors() {
+        let source = "fn main() -> i32 { 1 + true }";
+        let sources = vec![(FileId::new(1), SourceInfo::new(source, "test.rue"))];
+        let formatter = MultiFileJsonFormatter::new(sources);
+
+        let mut errors = CompileErrors::new();
+        errors.push(CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: "i32".to_string(),
+                found: "bool".to_string(),
+            },
+            Span::with_file(FileId::new(1), 23, 27),
+        ));
+
+        let json_str = formatter.format_errors(&errors);
+        let parsed: serde_json::Value = serde_json::from_str(&json_str).unwrap();
+        assert!(parsed.is_array());
+        assert_eq!(parsed.as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_multi_file_json_formatter_format_warning() {
+        let source = "fn main() -> i32 { let x = 42; 0 }";
+        let sources = vec![(FileId::new(1), SourceInfo::new(source, "test.rue"))];
+        let formatter = MultiFileJsonFormatter::new(sources);
+
+        let warning = CompileWarning::new(
+            WarningKind::UnusedVariable("x".to_string()),
+            Span::with_file(FileId::new(1), 23, 24),
+        );
+
+        let json_diag = formatter.format_warning(&warning);
+        assert_eq!(json_diag.severity, "warning");
+        assert!(json_diag.message.contains("unused variable"));
+        assert_eq!(json_diag.spans.len(), 1);
+        assert_eq!(json_diag.spans[0].file, "test.rue");
     }
 }

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -33,7 +33,7 @@ use tracing::{info, info_span};
 
 pub use diagnostic::{
     ColorChoice, DiagnosticFormatter, JsonDiagnostic, JsonDiagnosticFormatter, JsonSpan,
-    JsonSuggestion, SourceInfo,
+    JsonSuggestion, MultiFileFormatter, MultiFileJsonFormatter, SourceInfo,
 };
 
 use std::io::Write;

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -12,8 +12,8 @@ use tracing_subscriber::{EnvFilter, fmt};
 mod timing;
 
 use rue_compiler::{
-    CompileOptions, DiagnosticFormatter, FileId, Lexer, LinkerMode, OptLevel, ParsedProgram,
-    PreviewFeature, PreviewFeatures, SourceFile, SourceInfo,
+    CompileOptions, DiagnosticFormatter, FileId, Lexer, LinkerMode, MultiFileFormatter, OptLevel,
+    ParsedProgram, PreviewFeature, PreviewFeatures, SourceFile, SourceInfo,
     compile_frontend_from_ast_with_options, compile_multi_file_with_options, generate_emitted_asm,
     generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
     generate_stack_frame_info, merge_symbols, parse_all_files,
@@ -748,13 +748,21 @@ fn main() {
         })
         .collect();
 
-    // For diagnostic formatting, we use the first file as primary
-    // (multi-file diagnostics include file paths in error messages)
-    let (primary_path, primary_source) = &sources[0];
+    // Create multi-file formatter for diagnostics that may span multiple files
+    let source_infos: Vec<_> = sources
+        .iter()
+        .enumerate()
+        .map(|(i, (path, content))| {
+            (
+                FileId::new((i + 1) as u32),
+                SourceInfo::new(content.as_str(), path.as_str()),
+            )
+        })
+        .collect();
+    let formatter = MultiFileFormatter::new(source_infos);
 
-    // Create source info for diagnostic formatting
-    let source_info = SourceInfo::new(primary_source, primary_path);
-    let formatter = DiagnosticFormatter::new(&source_info);
+    // Also keep a single-file formatter for the primary file (for source metrics)
+    let (primary_path, primary_source) = &sources[0];
 
     // Compute source metrics if benchmark JSON is requested
     let source_metrics = if options.benchmark_json {
@@ -873,7 +881,7 @@ fn main() {
 fn handle_emit_multi_file(
     sources: &[SourceFile<'_>],
     options: &Options,
-    formatter: &DiagnosticFormatter,
+    formatter: &MultiFileFormatter,
 ) -> Result<(), ()> {
     // Determine which stages we need
     let needs_tokens = options.emit_stages.contains(&EmitStage::Tokens);


### PR DESCRIPTION
Add MultiFileFormatter and MultiFileJsonFormatter to support diagnostics that span multiple source files. When compiling multiple files, errors can now show snippets from different files when a diagnostic has labels pointing to different source files.

Changes:
- Add MultiFileFormatter with methods matching DiagnosticFormatter
- Add MultiFileJsonFormatter for machine-readable multi-file diagnostics
- Update main.rs to use MultiFileFormatter for all compilations
- Add comprehensive unit tests for both formatters

Closes: rue-212y

🤖 Generated with [Claude Code](https://claude.com/claude-code)