### PR TITLE
refactor(sema): use references for functions/methods in SemaContext

### DIFF
--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -402,6 +402,11 @@ impl<'a> Sema<'a> {
     /// for parallel function body analysis. The SemaContext contains all
     /// type definitions, function signatures, and method signatures.
     ///
+    /// The returned SemaContext borrows functions and methods from Sema,
+    /// so Sema must outlive the SemaContext. This is reflected in the
+    /// lifetime relationship: the returned context lives for `'s` (the
+    /// borrow of self), not `'a` (the lifetime of the RIR/interner).
+    ///
     /// # Usage
     ///
     /// ```ignore
@@ -411,8 +416,12 @@ impl<'a> Sema<'a> {
     /// sema.resolve_declarations()?;
     /// let ctx = sema.build_sema_context();
     /// // Now ctx can be shared across threads for parallel analysis
+    /// // (while sema is borrowed)
     /// ```
-    pub fn build_sema_context(&self) -> SemaContext<'a> {
+    pub fn build_sema_context<'s>(&'s self) -> SemaContext<'s>
+    where
+        'a: 's,
+    {
         // Build the inference context
         let inference_ctx = self.build_sema_context_inference();
 
@@ -427,8 +436,10 @@ impl<'a> Sema<'a> {
             ),
             structs: self.structs.clone(),
             enums: self.enums.clone(),
-            functions: self.functions.clone(),
-            methods: self.methods.clone(),
+            // Pass references to functions/methods instead of cloning.
+            // This is safe because after declaration gathering, these HashMaps are immutable.
+            functions: &self.functions,
+            methods: &self.methods,
             preview_features: self.preview_features.clone(),
             builtin_string_id: self.builtin_string_id,
             inference_ctx,

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -182,7 +182,7 @@ pub struct InferenceContext {
 /// # Contents
 ///
 /// - Struct and enum definitions (immutable)
-/// - Function and method signatures (immutable)
+/// - Function and method signatures (references to immutable data in Sema)
 /// - Array type registry (thread-safe, allows concurrent insertions)
 /// - Pre-computed inference context (immutable)
 /// - Built-in type IDs (immutable)
@@ -193,6 +193,7 @@ pub struct InferenceContext {
 /// - Most fields are immutable after construction
 /// - The array type registry uses `RwLock` for thread-safe mutations
 /// - References to RIR and interner are shared immutably
+/// - References to functions/methods HashMaps are immutable after declaration gathering
 /// - ThreadedRodeo is designed to be thread-safe
 #[derive(Debug)]
 pub struct SemaContext<'a> {
@@ -211,10 +212,10 @@ pub struct SemaContext<'a> {
     pub structs: HashMap<Spur, StructId>,
     /// Enum lookup: maps enum name symbol to EnumId.
     pub enums: HashMap<Spur, EnumId>,
-    /// Function lookup: maps function name to info.
-    pub functions: HashMap<Spur, FunctionInfo>,
-    /// Method lookup: maps (struct_name, method_name) to info.
-    pub methods: HashMap<(Spur, Spur), MethodInfo>,
+    /// Function lookup: reference to Sema's function map (immutable after declaration gathering).
+    pub functions: &'a HashMap<Spur, FunctionInfo>,
+    /// Method lookup: reference to Sema's method map (immutable after declaration gathering).
+    pub methods: &'a HashMap<(Spur, Spur), MethodInfo>,
     /// Enabled preview features.
     pub preview_features: PreviewFeatures,
     /// StructId of the synthetic String type.
@@ -226,10 +227,12 @@ pub struct SemaContext<'a> {
 }
 
 // SAFETY: SemaContext is Send + Sync because:
-// - Immutable fields are trivially thread-safe
+// - Immutable fields (struct_defs, enum_defs, structs, enums, etc.) are trivially thread-safe
 // - ArrayTypeRegistry uses RwLock for interior mutability
 // - References to RIR and ThreadedRodeo are shared immutably
+// - References to functions/methods HashMaps are shared immutably (read-only after declaration gathering)
 // - ThreadedRodeo is designed to be thread-safe
+// - &HashMap<K, V> is Send + Sync when the HashMap is (immutable references are always safe)
 unsafe impl<'a> Send for SemaContext<'a> {}
 unsafe impl<'a> Sync for SemaContext<'a> {}
 


### PR DESCRIPTION
Change SemaContext from owning cloned HashMaps to holding references to the original data in Sema. This eliminates unnecessary cloning during SemaContext construction.

Changes:
- SemaContext.functions and .methods are now &'a HashMap references
- build_sema_context() uses explicit lifetime to borrow from self
- Updated safety comments for Send/Sync impl

This is Phase 1.2 of the FunctionInfo/MethodInfo cloning elimination refactoring (rue-9sur).

Fixes rue-5wcd

🤖 Generated with [Claude Code](https://claude.com/claude-code)