### PR TITLE
Fix silent benchmark failures causing missing data points

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -100,6 +100,36 @@ jobs:
             echo "See [Performance Dashboard](https://rue-lang.dev/performance/) for visualization." >> README.md
           fi
 
+      - name: Validate benchmark results
+        run: |
+          echo "=== Benchmark Results ==="
+          cat /tmp/results.json
+          echo ""
+          echo "=== Validation ==="
+          python3 -c "
+          import json
+          import sys
+
+          with open('/tmp/results.json') as f:
+              data = json.load(f)
+
+          benchmarks = data.get('benchmarks', [])
+          print(f'Platform: ${{ matrix.platform }}')
+          print(f'Commit: {data.get(\"commit\", \"unknown\")}')
+          print(f'Benchmarks collected: {len(benchmarks)}')
+
+          if not benchmarks:
+              print('::error::No benchmark results collected! All benchmarks failed.')
+              sys.exit(1)
+
+          for b in benchmarks:
+              name = b.get('name', 'unknown')
+              mean = b.get('mean_ms', 0)
+              print(f'  - {name}: {mean:.2f}ms')
+
+          print('Validation passed!')
+          "
+
       - name: Append to history
         run: |
           # Create platform-specific history file if it doesn't exist
@@ -108,7 +138,13 @@ jobs:
             mkdir -p perf-branch/benchmarks
             echo '{"version": 1, "runs": []}' > "$history_file"
           fi
-          python3 scripts/append-benchmark.py /tmp/results.json "$history_file"
+
+          # Run append with explicit error checking
+          if ! python3 scripts/append-benchmark.py /tmp/results.json "$history_file"; then
+            echo "::error::Failed to append benchmark results for ${{ matrix.platform }}"
+            echo "See validation step above for details"
+            exit 1
+          fi
 
       - name: Commit and push to perf branch
         run: |

--- a/bench.sh
+++ b/bench.sh
@@ -342,6 +342,15 @@ print(json.dumps(result))
     all_results+=("{$(IFS=,; echo "${result_parts[*]}")}")
 done
 
+# Fail early if no benchmarks were collected
+if [[ ${#all_results[@]} -eq 0 ]]; then
+    log_error "No benchmark results collected! All benchmarks failed."
+    log_error "Check the benchmark programs and compiler output above for errors."
+    exit 1
+fi
+
+log_info "Successfully collected ${#all_results[@]} benchmark(s)"
+
 # Get metadata
 timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Get commit hash - try jj first (for local dev), fall back to git (for CI)

--- a/scripts/append-benchmark.py
+++ b/scripts/append-benchmark.py
@@ -66,16 +66,30 @@ def save_json(path: Path, data: dict) -> None:
 
 
 def validate_result(result: dict) -> bool:
-    """Validate that a result has the required fields."""
+    """Validate that a result has the required fields and non-empty data."""
     required_fields = ["timestamp", "benchmarks"]
     for field in required_fields:
         if field not in result:
-            print(f"Warning: Result missing required field: {field}", file=sys.stderr)
+            print(f"Error: Result missing required field: {field}", file=sys.stderr)
             return False
 
     if not isinstance(result["benchmarks"], list):
-        print("Warning: benchmarks field must be an array", file=sys.stderr)
+        print("Error: benchmarks field must be an array", file=sys.stderr)
         return False
+
+    if len(result["benchmarks"]) == 0:
+        print("Error: benchmarks array is empty - no data to record", file=sys.stderr)
+        print("This usually means all benchmark iterations failed.", file=sys.stderr)
+        return False
+
+    # Validate each benchmark has required fields
+    for i, bench in enumerate(result["benchmarks"]):
+        if "name" not in bench:
+            print(f"Error: benchmark[{i}] missing 'name' field", file=sys.stderr)
+            return False
+        if "mean_ms" not in bench:
+            print(f"Error: benchmark[{i}] ({bench.get('name', '?')}) missing 'mean_ms' field", file=sys.stderr)
+            return False
 
     return True
 


### PR DESCRIPTION
Add validation and error handling at multiple layers to catch benchmark failures that were previously being silently ignored:

1. benchmarks.yml: Add 'Validate benchmark results' step that:
   - Dumps full results JSON for debugging
   - Validates benchmarks were collected
   - Uses ::error:: annotations to surface failures in GitHub Actions UI

2. benchmarks.yml: Add explicit error handling to 'Append to history':
   - Check exit code of append-benchmark.py
   - Fail workflow with error annotation if append fails

3. bench.sh: Fail early if no benchmarks collected:
   - Exit with error if all_results array is empty
   - Provide helpful error message pointing to compiler output

4. append-benchmark.py: Stricter validation:
   - Reject empty benchmarks arrays
   - Validate each benchmark has required fields (name, mean_ms)
   - Change 'Warning' to 'Error' for clearer messaging

These changes ensure that when x86-64 benchmarks fail (or any platform), the failure is visible in GitHub Actions logs instead of silently producing missing data points on the performance dashboard chart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)