### PR TITLE
feat(rue-air): introduce TypeInternPool alongside existing type system

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -1,0 +1,1201 @@
+//! Type intern pool for efficient type representation.
+//!
+//! This module implements a unified type interning system inspired by Zig's `InternPool`.
+//! All types become 32-bit indices into a canonical pool, enabling:
+//!
+//! - O(1) type equality (u32 comparison)
+//! - Efficient memory usage
+//! - Clean parallel compilation (no per-function type merging)
+//! - Foundation for future generics
+//!
+//! # Architecture
+//!
+//! The `TypeInternPool` serves as a canonical repository for all composite types:
+//! - **Structs and enums** are nominal types (same name = same type)
+//! - **Arrays** are structural types (same element type + length = same type)
+//!
+//! Primitive types (i8-i64, u8-u64, bool, unit, never, error) are encoded directly
+//! in the `InternedType` index using reserved indices 0-15, requiring no pool lookup.
+//!
+//! # Migration Strategy (ADR-0024)
+//!
+//! This module is part of Phase 1 of the Type Intern Pool migration:
+//! - Phase 1: Introduce pool alongside existing system (this module)
+//! - Phase 2: Migrate array types to the pool
+//! - Phase 3: Migrate struct/enum IDs to pool indices
+//! - Phase 4: Unify Type representation to `InternedType(u32)`
+//!
+//! During Phase 1, the pool coexists with the existing `Type` enum, `StructId`,
+//! `EnumId`, and `ArrayTypeId`. The pool is populated during declaration collection
+//! but not yet used for type operations.
+//!
+//! # Thread Safety
+//!
+//! The pool uses `RwLock` for thread-safe access during parallel compilation:
+//! - Read lock for lookups (common case)
+//! - Write lock for insertions (rare, during declaration gathering)
+
+use std::collections::HashMap;
+use std::sync::RwLock;
+
+use lasso::Spur;
+
+use crate::types::{EnumDef, StructDef, Type};
+
+/// Interned type index - 32 bits, Copy, cheap comparison.
+///
+/// Reserved indices 0-15 are primitives (no lookup needed).
+/// Index 16+ are composite types stored in the pool.
+///
+/// # Primitive Encoding
+///
+/// The following indices are reserved for primitive types:
+/// - 0: i8
+/// - 1: i16
+/// - 2: i32
+/// - 3: i64
+/// - 4: u8
+/// - 5: u16
+/// - 6: u32
+/// - 7: u64
+/// - 8: bool
+/// - 9: unit
+/// - 10: never
+/// - 11: error
+/// - 12-15: reserved for future primitives
+#[derive(Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct InternedType(u32);
+
+impl InternedType {
+    // Reserved indices for primitives
+    pub const I8: InternedType = InternedType(0);
+    pub const I16: InternedType = InternedType(1);
+    pub const I32: InternedType = InternedType(2);
+    pub const I64: InternedType = InternedType(3);
+    pub const U8: InternedType = InternedType(4);
+    pub const U16: InternedType = InternedType(5);
+    pub const U32: InternedType = InternedType(6);
+    pub const U64: InternedType = InternedType(7);
+    pub const BOOL: InternedType = InternedType(8);
+    pub const UNIT: InternedType = InternedType(9);
+    pub const NEVER: InternedType = InternedType(10);
+    pub const ERROR: InternedType = InternedType(11);
+
+    const PRIMITIVE_COUNT: u32 = 16;
+
+    /// Check if this is a primitive type (no pool lookup needed).
+    #[inline]
+    pub fn is_primitive(self) -> bool {
+        self.0 < Self::PRIMITIVE_COUNT
+    }
+
+    /// Get the raw index value.
+    #[inline]
+    pub fn index(self) -> u32 {
+        self.0
+    }
+
+    /// Create an InternedType from a raw index.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure the index is valid (either a primitive index 0-15,
+    /// or a composite index that exists in the pool).
+    #[inline]
+    pub fn from_raw(index: u32) -> Self {
+        InternedType(index)
+    }
+
+    /// Create an InternedType for a composite type from its pool index.
+    ///
+    /// The pool index is offset by `PRIMITIVE_COUNT` to produce the final index.
+    #[inline]
+    fn from_pool_index(pool_index: u32) -> Self {
+        InternedType(pool_index + Self::PRIMITIVE_COUNT)
+    }
+
+    /// Get the pool index for a composite type.
+    ///
+    /// Returns `None` for primitive types.
+    #[inline]
+    pub fn pool_index(self) -> Option<u32> {
+        if self.is_primitive() {
+            None
+        } else {
+            Some(self.0 - Self::PRIMITIVE_COUNT)
+        }
+    }
+}
+
+impl std::fmt::Debug for InternedType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.is_primitive() {
+            let name = match self.0 {
+                0 => "i8",
+                1 => "i16",
+                2 => "i32",
+                3 => "i64",
+                4 => "u8",
+                5 => "u16",
+                6 => "u32",
+                7 => "u64",
+                8 => "bool",
+                9 => "()",
+                10 => "!",
+                11 => "<error>",
+                _ => "<reserved>",
+            };
+            write!(f, "InternedType({name})")
+        } else {
+            write!(f, "InternedType(pool:{})", self.0 - Self::PRIMITIVE_COUNT)
+        }
+    }
+}
+
+/// Type data stored in the intern pool.
+///
+/// This is NOT Copy - it lives in the pool. You work with `InternedType` indices.
+///
+/// # Type Categories
+///
+/// - **Struct** and **Enum** are nominal types: identity comes from the name
+/// - **Array** is a structural type: identity comes from element type + length
+#[derive(Debug, Clone)]
+pub enum TypeData {
+    /// User-defined struct (nominal type).
+    ///
+    /// Two structs with the same fields but different names are different types.
+    Struct(StructData),
+
+    /// User-defined enum (nominal type).
+    ///
+    /// Two enums with the same variants but different names are different types.
+    Enum(EnumData),
+
+    /// Fixed-size array (structural type).
+    ///
+    /// Arrays with the same element type and length are the same type,
+    /// regardless of where they were defined.
+    Array { element: InternedType, len: u64 },
+}
+
+/// Data for a struct type in the intern pool.
+///
+/// During Phase 1, this mirrors the existing `StructDef` to verify correctness.
+/// In later phases, `StructDef` will be replaced by this.
+#[derive(Debug, Clone)]
+pub struct StructData {
+    /// The name symbol (interned string).
+    pub name: Spur,
+    /// Reference to the full struct definition.
+    /// During Phase 1, we keep a clone of the StructDef for verification.
+    /// In later phases, the pool will be the canonical source.
+    pub def: StructDef,
+}
+
+/// Data for an enum type in the intern pool.
+///
+/// During Phase 1, this mirrors the existing `EnumDef` to verify correctness.
+/// In later phases, `EnumDef` will be replaced by this.
+#[derive(Debug, Clone)]
+pub struct EnumData {
+    /// The name symbol (interned string).
+    pub name: Spur,
+    /// Reference to the full enum definition.
+    /// During Phase 1, we keep a clone of the EnumDef for verification.
+    /// In later phases, the pool will be the canonical source.
+    pub def: EnumDef,
+}
+
+/// Thread-safe intern pool for all composite types.
+///
+/// The pool is designed to be built during declaration gathering (sequential)
+/// and then queried during function body analysis (potentially parallel).
+///
+/// # Thread Safety
+///
+/// Uses `RwLock` for interior mutability:
+/// - Read lock for lookups (most common)
+/// - Write lock for insertions (only during declaration gathering)
+///
+/// # Usage
+///
+/// ```ignore
+/// let pool = TypeInternPool::new();
+///
+/// // Register nominal types (structs/enums)
+/// let (struct_type, is_new) = pool.register_struct(name_spur, struct_def);
+///
+/// // Intern structural types (arrays)
+/// let array_type = pool.intern_array(element_type, 10);
+///
+/// // Look up type data
+/// if let Some(data) = pool.try_get(some_type) {
+///     match data {
+///         TypeData::Struct(s) => println!("struct {}", s.def.name),
+///         TypeData::Enum(e) => println!("enum {}", e.def.name),
+///         TypeData::Array { element, len } => println!("array of {:?}; {}", element, len),
+///     }
+/// }
+/// ```
+#[derive(Debug)]
+pub struct TypeInternPool {
+    inner: RwLock<TypeInternPoolInner>,
+}
+
+#[derive(Debug)]
+struct TypeInternPoolInner {
+    /// All composite type data, indexed by (InternedType.0 - PRIMITIVE_COUNT).
+    types: Vec<TypeData>,
+
+    /// Structural type deduplication: (element, len) -> InternedType for arrays.
+    array_map: HashMap<(InternedType, u64), InternedType>,
+
+    /// Nominal type lookup: name -> InternedType for structs.
+    struct_by_name: HashMap<Spur, InternedType>,
+
+    /// Nominal type lookup: name -> InternedType for enums.
+    enum_by_name: HashMap<Spur, InternedType>,
+}
+
+impl TypeInternPool {
+    /// Create a new empty pool.
+    pub fn new() -> Self {
+        Self {
+            inner: RwLock::new(TypeInternPoolInner {
+                types: Vec::new(),
+                array_map: HashMap::new(),
+                struct_by_name: HashMap::new(),
+                enum_by_name: HashMap::new(),
+            }),
+        }
+    }
+
+    /// Register a new struct (nominal - no deduplication).
+    ///
+    /// Returns the `InternedType` and whether it was newly inserted.
+    /// If a struct with this name already exists, returns the existing type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned.
+    pub fn register_struct(&self, name: Spur, def: StructDef) -> (InternedType, bool) {
+        // Fast path: check with read lock
+        {
+            let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+            if let Some(&existing) = inner.struct_by_name.get(&name) {
+                return (existing, false);
+            }
+        }
+
+        // Slow path: acquire write lock
+        let mut inner = self.inner.write().expect("TypeInternPool lock poisoned");
+
+        // Double-check after acquiring write lock
+        if let Some(&existing) = inner.struct_by_name.get(&name) {
+            return (existing, false);
+        }
+
+        // Create new struct type
+        let pool_index = inner.types.len() as u32;
+        let interned = InternedType::from_pool_index(pool_index);
+
+        inner.types.push(TypeData::Struct(StructData { name, def }));
+        inner.struct_by_name.insert(name, interned);
+
+        (interned, true)
+    }
+
+    /// Register a new enum (nominal - no deduplication).
+    ///
+    /// Returns the `InternedType` and whether it was newly inserted.
+    /// If an enum with this name already exists, returns the existing type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned.
+    pub fn register_enum(&self, name: Spur, def: EnumDef) -> (InternedType, bool) {
+        // Fast path: check with read lock
+        {
+            let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+            if let Some(&existing) = inner.enum_by_name.get(&name) {
+                return (existing, false);
+            }
+        }
+
+        // Slow path: acquire write lock
+        let mut inner = self.inner.write().expect("TypeInternPool lock poisoned");
+
+        // Double-check after acquiring write lock
+        if let Some(&existing) = inner.enum_by_name.get(&name) {
+            return (existing, false);
+        }
+
+        // Create new enum type
+        let pool_index = inner.types.len() as u32;
+        let interned = InternedType::from_pool_index(pool_index);
+
+        inner.types.push(TypeData::Enum(EnumData { name, def }));
+        inner.enum_by_name.insert(name, interned);
+
+        (interned, true)
+    }
+
+    /// Intern an array type (structural - deduplicates).
+    ///
+    /// Returns the canonical `InternedType` for arrays with this element type and length.
+    /// If an identical array type already exists, returns the existing type.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned.
+    pub fn intern_array(&self, element: InternedType, len: u64) -> InternedType {
+        let key = (element, len);
+
+        // Fast path: check with read lock
+        {
+            let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+            if let Some(&existing) = inner.array_map.get(&key) {
+                return existing;
+            }
+        }
+
+        // Slow path: acquire write lock
+        let mut inner = self.inner.write().expect("TypeInternPool lock poisoned");
+
+        // Double-check after acquiring write lock
+        if let Some(&existing) = inner.array_map.get(&key) {
+            return existing;
+        }
+
+        // Create new array type
+        let pool_index = inner.types.len() as u32;
+        let interned = InternedType::from_pool_index(pool_index);
+
+        inner.types.push(TypeData::Array { element, len });
+        inner.array_map.insert(key, interned);
+
+        interned
+    }
+
+    /// Look up a struct by name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned.
+    pub fn get_struct_by_name(&self, name: Spur) -> Option<InternedType> {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        inner.struct_by_name.get(&name).copied()
+    }
+
+    /// Look up an enum by name.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned.
+    pub fn get_enum_by_name(&self, name: Spur) -> Option<InternedType> {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        inner.enum_by_name.get(&name).copied()
+    }
+
+    /// Look up an array type by element and length.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned.
+    pub fn get_array(&self, element: InternedType, len: u64) -> Option<InternedType> {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        inner.array_map.get(&(element, len)).copied()
+    }
+
+    /// Get type data for a composite type.
+    ///
+    /// Returns `None` for primitive types (use `InternedType::is_primitive()` first).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the lock is poisoned or if the index is invalid.
+    pub fn get(&self, ty: InternedType) -> Option<TypeData> {
+        if ty.is_primitive() {
+            return None;
+        }
+
+        let pool_index = ty.pool_index().expect("non-primitive must have pool index");
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        Some(inner.types[pool_index as usize].clone())
+    }
+
+    /// Check if this is a struct type.
+    pub fn is_struct(&self, ty: InternedType) -> bool {
+        if ty.is_primitive() {
+            return false;
+        }
+        matches!(self.get(ty), Some(TypeData::Struct(_)))
+    }
+
+    /// Check if this is an enum type.
+    pub fn is_enum(&self, ty: InternedType) -> bool {
+        if ty.is_primitive() {
+            return false;
+        }
+        matches!(self.get(ty), Some(TypeData::Enum(_)))
+    }
+
+    /// Check if this is an array type.
+    pub fn is_array(&self, ty: InternedType) -> bool {
+        if ty.is_primitive() {
+            return false;
+        }
+        matches!(self.get(ty), Some(TypeData::Array { .. }))
+    }
+
+    /// Get the struct definition if this is a struct type.
+    pub fn get_struct_def(&self, ty: InternedType) -> Option<StructDef> {
+        match self.get(ty)? {
+            TypeData::Struct(data) => Some(data.def),
+            _ => None,
+        }
+    }
+
+    /// Get the enum definition if this is an enum type.
+    pub fn get_enum_def(&self, ty: InternedType) -> Option<EnumDef> {
+        match self.get(ty)? {
+            TypeData::Enum(data) => Some(data.def),
+            _ => None,
+        }
+    }
+
+    /// Get array info (element type, length) if this is an array type.
+    pub fn get_array_info(&self, ty: InternedType) -> Option<(InternedType, u64)> {
+        match self.get(ty)? {
+            TypeData::Array { element, len } => Some((element, len)),
+            _ => None,
+        }
+    }
+
+    /// Get the number of composite types in the pool.
+    pub fn len(&self) -> usize {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        inner.types.len()
+    }
+
+    /// Check if the pool is empty (no composite types).
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Get statistics about the pool contents.
+    pub fn stats(&self) -> TypeInternPoolStats {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        let mut struct_count = 0;
+        let mut enum_count = 0;
+        let mut array_count = 0;
+
+        for data in &inner.types {
+            match data {
+                TypeData::Struct(_) => struct_count += 1,
+                TypeData::Enum(_) => enum_count += 1,
+                TypeData::Array { .. } => array_count += 1,
+            }
+        }
+
+        TypeInternPoolStats {
+            struct_count,
+            enum_count,
+            array_count,
+            total: inner.types.len(),
+        }
+    }
+
+    // ========================================================================
+    // Conversion helpers for migration (Phase 1)
+    // ========================================================================
+
+    /// Convert an old-style `Type` to an `InternedType`.
+    ///
+    /// This is a temporary helper for Phase 1 migration. It converts the
+    /// existing `Type` enum to the new interned representation.
+    ///
+    /// # Note
+    ///
+    /// For struct/enum types, the corresponding type must already be registered
+    /// in the pool. For array types, this returns an error since array interning
+    /// requires the pool to already have the element type interned.
+    pub fn type_to_interned(&self, ty: Type) -> Option<InternedType> {
+        match ty {
+            Type::I8 => Some(InternedType::I8),
+            Type::I16 => Some(InternedType::I16),
+            Type::I32 => Some(InternedType::I32),
+            Type::I64 => Some(InternedType::I64),
+            Type::U8 => Some(InternedType::U8),
+            Type::U16 => Some(InternedType::U16),
+            Type::U32 => Some(InternedType::U32),
+            Type::U64 => Some(InternedType::U64),
+            Type::Bool => Some(InternedType::BOOL),
+            Type::Unit => Some(InternedType::UNIT),
+            Type::Never => Some(InternedType::NEVER),
+            Type::Error => Some(InternedType::ERROR),
+            // Struct and enum require pool lookup by ID - we need the name
+            // to find the interned type. This conversion is not straightforward
+            // without additional context. Return None to indicate we can't convert.
+            Type::Struct(_) | Type::Enum(_) | Type::Array(_) => None,
+        }
+    }
+
+    /// Convert an `InternedType` back to the old-style `Type`.
+    ///
+    /// This is a temporary helper for Phase 1 migration to verify correctness.
+    /// Returns `None` for composite types since we need the old IDs.
+    pub fn interned_to_type(&self, ty: InternedType) -> Option<Type> {
+        if !ty.is_primitive() {
+            return None;
+        }
+
+        Some(match ty.0 {
+            0 => Type::I8,
+            1 => Type::I16,
+            2 => Type::I32,
+            3 => Type::I64,
+            4 => Type::U8,
+            5 => Type::U16,
+            6 => Type::U32,
+            7 => Type::U64,
+            8 => Type::Bool,
+            9 => Type::Unit,
+            10 => Type::Never,
+            11 => Type::Error,
+            _ => return None,
+        })
+    }
+}
+
+impl Default for TypeInternPool {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Clone for TypeInternPool {
+    /// Clone the pool by copying all type data into a new pool.
+    ///
+    /// This is used when building `SemaContext` from `Sema`, as the context
+    /// needs its own copy of the pool for thread-safe sharing.
+    fn clone(&self) -> Self {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        Self {
+            inner: RwLock::new(TypeInternPoolInner {
+                types: inner.types.clone(),
+                array_map: inner.array_map.clone(),
+                struct_by_name: inner.struct_by_name.clone(),
+                enum_by_name: inner.enum_by_name.clone(),
+            }),
+        }
+    }
+}
+
+/// Statistics about the intern pool contents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct TypeInternPoolStats {
+    pub struct_count: usize,
+    pub enum_count: usize,
+    pub array_count: usize,
+    pub total: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use lasso::ThreadedRodeo;
+
+    // ========================================================================
+    // InternedType tests
+    // ========================================================================
+
+    #[test]
+    fn test_interned_type_primitives() {
+        assert!(InternedType::I8.is_primitive());
+        assert!(InternedType::I16.is_primitive());
+        assert!(InternedType::I32.is_primitive());
+        assert!(InternedType::I64.is_primitive());
+        assert!(InternedType::U8.is_primitive());
+        assert!(InternedType::U16.is_primitive());
+        assert!(InternedType::U32.is_primitive());
+        assert!(InternedType::U64.is_primitive());
+        assert!(InternedType::BOOL.is_primitive());
+        assert!(InternedType::UNIT.is_primitive());
+        assert!(InternedType::NEVER.is_primitive());
+        assert!(InternedType::ERROR.is_primitive());
+    }
+
+    #[test]
+    fn test_interned_type_indices() {
+        assert_eq!(InternedType::I8.index(), 0);
+        assert_eq!(InternedType::I16.index(), 1);
+        assert_eq!(InternedType::I32.index(), 2);
+        assert_eq!(InternedType::I64.index(), 3);
+        assert_eq!(InternedType::U8.index(), 4);
+        assert_eq!(InternedType::BOOL.index(), 8);
+        assert_eq!(InternedType::UNIT.index(), 9);
+    }
+
+    #[test]
+    fn test_interned_type_pool_index() {
+        // Primitives don't have pool indices
+        assert_eq!(InternedType::I32.pool_index(), None);
+        assert_eq!(InternedType::BOOL.pool_index(), None);
+
+        // Composite types have pool indices
+        let composite = InternedType::from_pool_index(0);
+        assert_eq!(composite.pool_index(), Some(0));
+        assert!(!composite.is_primitive());
+
+        let composite2 = InternedType::from_pool_index(42);
+        assert_eq!(composite2.pool_index(), Some(42));
+    }
+
+    #[test]
+    fn test_interned_type_equality() {
+        assert_eq!(InternedType::I32, InternedType::I32);
+        assert_ne!(InternedType::I32, InternedType::I64);
+        assert_ne!(InternedType::I32, InternedType::from_pool_index(0));
+    }
+
+    #[test]
+    fn test_interned_type_debug() {
+        let i32_str = format!("{:?}", InternedType::I32);
+        assert!(i32_str.contains("i32"));
+
+        let composite_str = format!("{:?}", InternedType::from_pool_index(5));
+        assert!(composite_str.contains("pool:5"));
+    }
+
+    // ========================================================================
+    // TypeInternPool tests
+    // ========================================================================
+
+    #[test]
+    fn test_pool_new() {
+        let pool = TypeInternPool::new();
+        assert!(pool.is_empty());
+        assert_eq!(pool.len(), 0);
+    }
+
+    #[test]
+    fn test_pool_register_struct() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let name = interner.get_or_intern("Point");
+
+        let def = StructDef {
+            name: "Point".to_string(),
+            fields: vec![],
+            is_copy: false,
+            is_handle: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+        };
+
+        let (ty, is_new) = pool.register_struct(name, def.clone());
+        assert!(is_new);
+        assert!(!ty.is_primitive());
+        assert_eq!(pool.len(), 1);
+
+        // Registering the same name returns the existing type
+        let (ty2, is_new2) = pool.register_struct(name, def);
+        assert!(!is_new2);
+        assert_eq!(ty, ty2);
+        assert_eq!(pool.len(), 1); // No new type added
+    }
+
+    #[test]
+    fn test_pool_register_enum() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let name = interner.get_or_intern("Color");
+
+        let def = EnumDef {
+            name: "Color".to_string(),
+            variants: vec!["Red".to_string(), "Green".to_string(), "Blue".to_string()],
+        };
+
+        let (ty, is_new) = pool.register_enum(name, def.clone());
+        assert!(is_new);
+        assert!(!ty.is_primitive());
+        assert_eq!(pool.len(), 1);
+
+        // Registering the same name returns the existing type
+        let (ty2, is_new2) = pool.register_enum(name, def);
+        assert!(!is_new2);
+        assert_eq!(ty, ty2);
+    }
+
+    #[test]
+    fn test_pool_intern_array() {
+        let pool = TypeInternPool::new();
+
+        // Intern [i32; 5]
+        let arr1 = pool.intern_array(InternedType::I32, 5);
+        assert!(!arr1.is_primitive());
+        assert_eq!(pool.len(), 1);
+
+        // Interning the same array returns the same type
+        let arr2 = pool.intern_array(InternedType::I32, 5);
+        assert_eq!(arr1, arr2);
+        assert_eq!(pool.len(), 1);
+
+        // Different length is a different type
+        let arr3 = pool.intern_array(InternedType::I32, 10);
+        assert_ne!(arr1, arr3);
+        assert_eq!(pool.len(), 2);
+
+        // Different element type is a different type
+        let arr4 = pool.intern_array(InternedType::I64, 5);
+        assert_ne!(arr1, arr4);
+        assert_eq!(pool.len(), 3);
+    }
+
+    #[test]
+    fn test_pool_get_struct_by_name() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let name = interner.get_or_intern("Point");
+
+        assert!(pool.get_struct_by_name(name).is_none());
+
+        let def = StructDef {
+            name: "Point".to_string(),
+            fields: vec![],
+            is_copy: false,
+            is_handle: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+        };
+
+        let (ty, _) = pool.register_struct(name, def);
+        assert_eq!(pool.get_struct_by_name(name), Some(ty));
+    }
+
+    #[test]
+    fn test_pool_get_enum_by_name() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+        let name = interner.get_or_intern("Status");
+
+        assert!(pool.get_enum_by_name(name).is_none());
+
+        let def = EnumDef {
+            name: "Status".to_string(),
+            variants: vec!["Active".to_string(), "Inactive".to_string()],
+        };
+
+        let (ty, _) = pool.register_enum(name, def);
+        assert_eq!(pool.get_enum_by_name(name), Some(ty));
+    }
+
+    #[test]
+    fn test_pool_get_array() {
+        let pool = TypeInternPool::new();
+
+        assert!(pool.get_array(InternedType::I32, 5).is_none());
+
+        let arr = pool.intern_array(InternedType::I32, 5);
+        assert_eq!(pool.get_array(InternedType::I32, 5), Some(arr));
+        assert!(pool.get_array(InternedType::I32, 10).is_none());
+    }
+
+    #[test]
+    fn test_pool_get_type_data() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+
+        // Primitive types return None
+        assert!(pool.get(InternedType::I32).is_none());
+
+        // Register a struct
+        let struct_name = interner.get_or_intern("Point");
+        let struct_def = StructDef {
+            name: "Point".to_string(),
+            fields: vec![],
+            is_copy: false,
+            is_handle: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+        };
+        let (struct_ty, _) = pool.register_struct(struct_name, struct_def);
+
+        // Get struct data
+        let data = pool.get(struct_ty).expect("should get struct data");
+        assert!(matches!(data, TypeData::Struct(_)));
+
+        // Intern an array
+        let arr_ty = pool.intern_array(InternedType::I32, 10);
+        let arr_data = pool.get(arr_ty).expect("should get array data");
+        match arr_data {
+            TypeData::Array { element, len } => {
+                assert_eq!(element, InternedType::I32);
+                assert_eq!(len, 10);
+            }
+            _ => panic!("expected array data"),
+        }
+    }
+
+    #[test]
+    fn test_pool_type_checks() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+
+        let struct_name = interner.get_or_intern("Point");
+        let struct_def = StructDef {
+            name: "Point".to_string(),
+            fields: vec![],
+            is_copy: false,
+            is_handle: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+        };
+        let (struct_ty, _) = pool.register_struct(struct_name, struct_def);
+
+        let enum_name = interner.get_or_intern("Color");
+        let enum_def = EnumDef {
+            name: "Color".to_string(),
+            variants: vec!["Red".to_string()],
+        };
+        let (enum_ty, _) = pool.register_enum(enum_name, enum_def);
+
+        let array_ty = pool.intern_array(InternedType::I32, 5);
+
+        // Check is_struct
+        assert!(pool.is_struct(struct_ty));
+        assert!(!pool.is_struct(enum_ty));
+        assert!(!pool.is_struct(array_ty));
+        assert!(!pool.is_struct(InternedType::I32));
+
+        // Check is_enum
+        assert!(!pool.is_enum(struct_ty));
+        assert!(pool.is_enum(enum_ty));
+        assert!(!pool.is_enum(array_ty));
+        assert!(!pool.is_enum(InternedType::I32));
+
+        // Check is_array
+        assert!(!pool.is_array(struct_ty));
+        assert!(!pool.is_array(enum_ty));
+        assert!(pool.is_array(array_ty));
+        assert!(!pool.is_array(InternedType::I32));
+    }
+
+    #[test]
+    fn test_pool_get_struct_def() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+
+        let name = interner.get_or_intern("Point");
+        let def = StructDef {
+            name: "Point".to_string(),
+            fields: vec![],
+            is_copy: true,
+            is_handle: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+        };
+        let (ty, _) = pool.register_struct(name, def.clone());
+
+        let retrieved = pool.get_struct_def(ty).expect("should get struct def");
+        assert_eq!(retrieved.name, def.name);
+        assert_eq!(retrieved.is_copy, def.is_copy);
+
+        // Non-struct returns None
+        let array_ty = pool.intern_array(InternedType::I32, 5);
+        assert!(pool.get_struct_def(array_ty).is_none());
+        assert!(pool.get_struct_def(InternedType::I32).is_none());
+    }
+
+    #[test]
+    fn test_pool_get_enum_def() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+
+        let name = interner.get_or_intern("Status");
+        let def = EnumDef {
+            name: "Status".to_string(),
+            variants: vec!["A".to_string(), "B".to_string()],
+        };
+        let (ty, _) = pool.register_enum(name, def.clone());
+
+        let retrieved = pool.get_enum_def(ty).expect("should get enum def");
+        assert_eq!(retrieved.name, def.name);
+        assert_eq!(retrieved.variants.len(), 2);
+
+        // Non-enum returns None
+        let array_ty = pool.intern_array(InternedType::I32, 5);
+        assert!(pool.get_enum_def(array_ty).is_none());
+        assert!(pool.get_enum_def(InternedType::I32).is_none());
+    }
+
+    #[test]
+    fn test_pool_get_array_info() {
+        let pool = TypeInternPool::new();
+
+        let array_ty = pool.intern_array(InternedType::I64, 100);
+        let (element, len) = pool
+            .get_array_info(array_ty)
+            .expect("should get array info");
+        assert_eq!(element, InternedType::I64);
+        assert_eq!(len, 100);
+
+        // Non-array returns None
+        let interner = ThreadedRodeo::default();
+        let name = interner.get_or_intern("X");
+        let def = StructDef {
+            name: "X".to_string(),
+            fields: vec![],
+            is_copy: false,
+            is_handle: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+        };
+        let (struct_ty, _) = pool.register_struct(name, def);
+        assert!(pool.get_array_info(struct_ty).is_none());
+        assert!(pool.get_array_info(InternedType::I32).is_none());
+    }
+
+    #[test]
+    fn test_pool_stats() {
+        let pool = TypeInternPool::new();
+        let interner = ThreadedRodeo::default();
+
+        let stats = pool.stats();
+        assert_eq!(stats.struct_count, 0);
+        assert_eq!(stats.enum_count, 0);
+        assert_eq!(stats.array_count, 0);
+        assert_eq!(stats.total, 0);
+
+        // Add some types
+        let s1 = interner.get_or_intern("S1");
+        let s2 = interner.get_or_intern("S2");
+        let e1 = interner.get_or_intern("E1");
+
+        let def = StructDef {
+            name: "S1".to_string(),
+            fields: vec![],
+            is_copy: false,
+            is_handle: false,
+            is_linear: false,
+            destructor: None,
+            is_builtin: false,
+        };
+        pool.register_struct(s1, def.clone());
+        pool.register_struct(
+            s2,
+            StructDef {
+                name: "S2".to_string(),
+                ..def
+            },
+        );
+
+        pool.register_enum(
+            e1,
+            EnumDef {
+                name: "E1".to_string(),
+                variants: vec![],
+            },
+        );
+
+        pool.intern_array(InternedType::I32, 5);
+        pool.intern_array(InternedType::I32, 10);
+        pool.intern_array(InternedType::BOOL, 3);
+
+        let stats = pool.stats();
+        assert_eq!(stats.struct_count, 2);
+        assert_eq!(stats.enum_count, 1);
+        assert_eq!(stats.array_count, 3);
+        assert_eq!(stats.total, 6);
+    }
+
+    #[test]
+    fn test_pool_nested_arrays() {
+        let pool = TypeInternPool::new();
+
+        // Create [i32; 3]
+        let inner = pool.intern_array(InternedType::I32, 3);
+
+        // Create [[i32; 3]; 4]
+        let outer = pool.intern_array(inner, 4);
+
+        // Verify structure
+        let (outer_elem, outer_len) = pool.get_array_info(outer).expect("outer array info");
+        assert_eq!(outer_elem, inner);
+        assert_eq!(outer_len, 4);
+
+        let (inner_elem, inner_len) = pool.get_array_info(inner).expect("inner array info");
+        assert_eq!(inner_elem, InternedType::I32);
+        assert_eq!(inner_len, 3);
+    }
+
+    #[test]
+    fn test_pool_type_to_interned() {
+        let pool = TypeInternPool::new();
+
+        // Primitive types convert correctly
+        assert_eq!(pool.type_to_interned(Type::I8), Some(InternedType::I8));
+        assert_eq!(pool.type_to_interned(Type::I16), Some(InternedType::I16));
+        assert_eq!(pool.type_to_interned(Type::I32), Some(InternedType::I32));
+        assert_eq!(pool.type_to_interned(Type::I64), Some(InternedType::I64));
+        assert_eq!(pool.type_to_interned(Type::U8), Some(InternedType::U8));
+        assert_eq!(pool.type_to_interned(Type::U16), Some(InternedType::U16));
+        assert_eq!(pool.type_to_interned(Type::U32), Some(InternedType::U32));
+        assert_eq!(pool.type_to_interned(Type::U64), Some(InternedType::U64));
+        assert_eq!(pool.type_to_interned(Type::Bool), Some(InternedType::BOOL));
+        assert_eq!(pool.type_to_interned(Type::Unit), Some(InternedType::UNIT));
+        assert_eq!(
+            pool.type_to_interned(Type::Never),
+            Some(InternedType::NEVER)
+        );
+        assert_eq!(
+            pool.type_to_interned(Type::Error),
+            Some(InternedType::ERROR)
+        );
+
+        // Composite types return None (need name lookup)
+        assert!(
+            pool.type_to_interned(Type::Struct(crate::types::StructId(0)))
+                .is_none()
+        );
+        assert!(
+            pool.type_to_interned(Type::Enum(crate::types::EnumId(0)))
+                .is_none()
+        );
+        assert!(
+            pool.type_to_interned(Type::Array(crate::types::ArrayTypeId(0)))
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn test_pool_interned_to_type() {
+        let pool = TypeInternPool::new();
+
+        // Primitive types convert back correctly
+        assert_eq!(pool.interned_to_type(InternedType::I8), Some(Type::I8));
+        assert_eq!(pool.interned_to_type(InternedType::I16), Some(Type::I16));
+        assert_eq!(pool.interned_to_type(InternedType::I32), Some(Type::I32));
+        assert_eq!(pool.interned_to_type(InternedType::I64), Some(Type::I64));
+        assert_eq!(pool.interned_to_type(InternedType::U8), Some(Type::U8));
+        assert_eq!(pool.interned_to_type(InternedType::U16), Some(Type::U16));
+        assert_eq!(pool.interned_to_type(InternedType::U32), Some(Type::U32));
+        assert_eq!(pool.interned_to_type(InternedType::U64), Some(Type::U64));
+        assert_eq!(pool.interned_to_type(InternedType::BOOL), Some(Type::Bool));
+        assert_eq!(pool.interned_to_type(InternedType::UNIT), Some(Type::Unit));
+        assert_eq!(
+            pool.interned_to_type(InternedType::NEVER),
+            Some(Type::Never)
+        );
+        assert_eq!(
+            pool.interned_to_type(InternedType::ERROR),
+            Some(Type::Error)
+        );
+
+        // Composite types return None
+        assert!(
+            pool.interned_to_type(InternedType::from_pool_index(0))
+                .is_none()
+        );
+    }
+
+    // ========================================================================
+    // Thread safety tests
+    // ========================================================================
+
+    #[test]
+    fn test_pool_concurrent_access() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let pool = Arc::new(TypeInternPool::new());
+        let interner = Arc::new(ThreadedRodeo::default());
+
+        // Pre-register names for thread safety
+        let names: Vec<Spur> = (0..100)
+            .map(|i| interner.get_or_intern(format!("Type{}", i)))
+            .collect();
+
+        let handles: Vec<_> = (0..10)
+            .map(|thread_id| {
+                let pool = Arc::clone(&pool);
+                let names = names.clone();
+                thread::spawn(move || {
+                    // Each thread registers 10 types
+                    for i in 0..10 {
+                        let idx = thread_id * 10 + i;
+                        let name = names[idx];
+                        let def = StructDef {
+                            name: format!("Type{}", idx),
+                            fields: vec![],
+                            is_copy: false,
+                            is_handle: false,
+                            is_linear: false,
+                            destructor: None,
+                            is_builtin: false,
+                        };
+                        pool.register_struct(name, def);
+                    }
+                })
+            })
+            .collect();
+
+        for handle in handles {
+            handle.join().expect("thread panicked");
+        }
+
+        // All 100 types should be registered
+        assert_eq!(pool.len(), 100);
+
+        // Each name should map to a valid type
+        for name in &names {
+            assert!(pool.get_struct_by_name(*name).is_some());
+        }
+    }
+
+    #[test]
+    fn test_pool_concurrent_array_interning() {
+        use std::sync::Arc;
+        use std::thread;
+
+        let pool = Arc::new(TypeInternPool::new());
+
+        // Multiple threads try to intern the same array type
+        let handles: Vec<_> = (0..10)
+            .map(|_| {
+                let pool = Arc::clone(&pool);
+                thread::spawn(move || pool.intern_array(InternedType::I32, 42))
+            })
+            .collect();
+
+        let results: Vec<_> = handles
+            .into_iter()
+            .map(|h| h.join().expect("thread panicked"))
+            .collect();
+
+        // All threads should get the same type
+        let first = results[0];
+        for result in &results {
+            assert_eq!(*result, first);
+        }
+
+        // Only one array type should be in the pool
+        assert_eq!(pool.stats().array_count, 1);
+    }
+
+    // Compile-time assertion that TypeInternPool is Send + Sync
+    fn assert_send_sync<T: Send + Sync>() {}
+
+    #[test]
+    fn test_pool_is_send_sync() {
+        assert_send_sync::<TypeInternPool>();
+    }
+}

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -14,6 +14,7 @@ mod analysis_state;
 mod function_analyzer;
 mod inference;
 mod inst;
+mod intern_pool;
 mod scope;
 mod sema;
 mod sema_context;
@@ -31,6 +32,9 @@ pub use inference::{
 };
 pub use inst::{
     Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirParamMode, AirPattern, AirRef,
+};
+pub use intern_pool::{
+    EnumData, InternedType, StructData, TypeData, TypeInternPool, TypeInternPoolStats,
 };
 pub use sema::{AnalyzedFunction, FunctionInfo, GatherOutput, MethodInfo, Sema, SemaOutput};
 // Note: FunctionInfo and MethodInfo are defined in sema and re-exported by sema_context.

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -299,6 +299,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
         array_types: std::mem::take(&mut sema.array_type_defs),
         strings: global_strings,
         warnings: all_warnings,
+        type_pool: sema.type_pool.clone(),
     })
 }
 
@@ -325,7 +326,13 @@ fn analyze_all_function_bodies_parallel(sema: Sema<'_>) -> MultiErrorResult<Sema
     let array_type_defs = ctx.array_registry.into_defs();
 
     // Merge results
-    merge_function_results(results, sema.struct_defs, sema.enum_defs, array_type_defs)
+    merge_function_results(
+        results,
+        sema.struct_defs,
+        sema.enum_defs,
+        array_type_defs,
+        sema.type_pool,
+    )
 }
 
 /// Collect all functions to be analyzed from the RIR.
@@ -1508,6 +1515,7 @@ fn merge_function_results(
     struct_defs: Vec<crate::types::StructDef>,
     enum_defs: Vec<crate::types::EnumDef>,
     array_type_defs: Vec<crate::types::ArrayTypeDef>,
+    type_pool: crate::intern_pool::TypeInternPool,
 ) -> MultiErrorResult<SemaOutput> {
     let mut errors = CompileErrors::new();
     let mut functions_with_strings: Vec<(AnalyzedFunction, Vec<String>)> = Vec::new();
@@ -1558,6 +1566,7 @@ fn merge_function_results(
         array_types: array_type_defs,
         strings: global_strings,
         warnings: all_warnings,
+        type_pool,
     })
 }
 

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -312,7 +312,38 @@ impl<'a> Sema<'a> {
     /// body analysis.
     pub(crate) fn resolve_declarations(&mut self) -> CompileResult<()> {
         self.resolve_struct_fields()?;
-        self.resolve_remaining_declarations()
+        self.resolve_remaining_declarations()?;
+
+        // Populate the type intern pool (ADR-0024 Phase 1).
+        // This runs after all type definitions are complete so we have
+        // full struct/enum definitions with resolved fields and variants.
+        self.populate_type_pool();
+
+        Ok(())
+    }
+
+    /// Populate the type intern pool with all registered types.
+    ///
+    /// This is part of ADR-0024 Phase 1: the pool coexists with the existing
+    /// type registries and is populated after declarations are complete.
+    /// The pool can be used for verification but is not yet the canonical
+    /// source for type information.
+    pub(crate) fn populate_type_pool(&mut self) {
+        // Register all structs in the pool
+        for (name_spur, &struct_id) in &self.structs {
+            let def = &self.struct_defs[struct_id.0 as usize];
+            self.type_pool.register_struct(*name_spur, def.clone());
+        }
+
+        // Register all enums in the pool
+        for (name_spur, &enum_id) in &self.enums {
+            let def = &self.enum_defs[enum_id.0 as usize];
+            self.type_pool.register_enum(*name_spur, def.clone());
+        }
+
+        // Note: Array types are not populated here during Phase 1.
+        // They are created on-demand during function body analysis via the
+        // ArrayTypeRegistry, and will be migrated to the pool in Phase 2.
     }
 
     /// Resolve struct field types. Must run before @copy validation.

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -36,6 +36,7 @@ use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileErrors, MultiErrorResult, PreviewFeatures};
 use rue_rir::Rir;
 
+use crate::intern_pool::TypeInternPool;
 use crate::sema_context::{
     ArrayTypeRegistry, InferenceContext as SemaContextInferenceContext, SemaContext,
 };
@@ -102,6 +103,8 @@ pub struct GatherOutput<'a> {
     pub preview_features: PreviewFeatures,
     /// StructId of the synthetic String type.
     pub builtin_string_id: Option<StructId>,
+    /// Type intern pool (ADR-0024 Phase 1).
+    pub type_pool: TypeInternPool,
 }
 
 impl<'a> GatherOutput<'a> {
@@ -124,6 +127,7 @@ impl<'a> GatherOutput<'a> {
             preview_features: self.preview_features,
             builtin_string_id: self.builtin_string_id,
             known: KnownSymbols::new(self.interner),
+            type_pool: self.type_pool,
         }
     }
 
@@ -171,6 +175,8 @@ pub struct SemaOutput {
     pub strings: Vec<String>,
     /// Warnings collected during analysis.
     pub warnings: Vec<rue_error::CompileWarning>,
+    /// Type intern pool (Phase 1: coexists with existing type system).
+    pub type_pool: TypeInternPool,
 }
 
 /// Pre-computed type information for constraint generation.
@@ -256,6 +262,12 @@ pub struct Sema<'a> {
     pub(crate) builtin_string_id: Option<StructId>,
     /// Pre-interned known symbols for fast comparison.
     pub(crate) known: KnownSymbols,
+    /// Type intern pool for unified type representation (ADR-0024 Phase 1).
+    ///
+    /// During Phase 1, the pool coexists with the existing type registries.
+    /// It is populated during declaration collection but not yet used for
+    /// type operations. Later phases will migrate to using the pool exclusively.
+    pub(crate) type_pool: TypeInternPool,
 }
 
 impl<'a> Sema<'a> {
@@ -279,6 +291,7 @@ impl<'a> Sema<'a> {
             preview_features,
             builtin_string_id: None,
             known: KnownSymbols::new(interner),
+            type_pool: TypeInternPool::new(),
         }
     }
 
@@ -391,6 +404,7 @@ impl<'a> Sema<'a> {
             methods: self.methods,
             preview_features: self.preview_features,
             builtin_string_id: self.builtin_string_id,
+            type_pool: self.type_pool,
         };
 
         Ok((type_ctx, output))
@@ -444,6 +458,7 @@ impl<'a> Sema<'a> {
             builtin_string_id: self.builtin_string_id,
             inference_ctx,
             known: KnownSymbols::new(self.interner),
+            type_pool: self.type_pool.clone(),
         }
     }
 

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -812,4 +812,229 @@ mod tests {
 
         assert!(result.is_err());
     }
+
+    // ========================================================================
+    // Type Intern Pool tests (ADR-0024 Phase 1)
+    //
+    // These tests verify that the TypeInternPool is correctly populated during
+    // declaration collection and that its contents match the existing type
+    // registries (struct_defs, enum_defs).
+    // ========================================================================
+
+    /// Helper to gather declarations and return the Sema state for testing.
+    fn gather_declarations_for_testing(source: &str) -> Sema<'static> {
+        // We need to leak the interner for the static lifetime
+        let lexer = Lexer::new(source);
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        let parser = Parser::new(tokens, interner);
+        let (ast, mut interner) = parser.parse().unwrap();
+
+        let astgen = AstGen::new(&ast, &mut interner);
+        let rir = astgen.generate();
+
+        // Leak both to get 'static lifetime for testing
+        let rir = Box::leak(Box::new(rir));
+        let interner = Box::leak(Box::new(interner));
+
+        let mut sema = Sema::new(rir, interner, PreviewFeatures::new());
+        sema.inject_builtin_types();
+        sema.register_type_names().unwrap();
+        sema.resolve_declarations().unwrap();
+        sema
+    }
+
+    #[test]
+    fn test_type_pool_populated_with_builtin_string() {
+        // The String type should be in the pool after builtin injection
+        let sema = gather_declarations_for_testing("fn main() -> i32 { 0 }");
+
+        let string_name = sema.interner.get("String").unwrap();
+        let pool_string = sema.type_pool.get_struct_by_name(string_name);
+
+        assert!(pool_string.is_some(), "String should be in the type pool");
+
+        // Verify the pool and existing registry agree
+        let registry_string = sema.structs.get(&string_name);
+        assert!(
+            registry_string.is_some(),
+            "String should be in struct registry"
+        );
+
+        // Check that the definitions match
+        let pool_def = sema.type_pool.get_struct_def(pool_string.unwrap()).unwrap();
+        let registry_def = &sema.struct_defs[registry_string.unwrap().0 as usize];
+
+        assert_eq!(pool_def.name, registry_def.name);
+        assert_eq!(pool_def.is_builtin, registry_def.is_builtin);
+        assert!(pool_def.is_builtin, "String should be marked as builtin");
+    }
+
+    #[test]
+    fn test_type_pool_populated_with_user_struct() {
+        let sema = gather_declarations_for_testing(
+            "struct Point { x: i32, y: i32 }
+             fn main() -> i32 { 0 }",
+        );
+
+        let point_name = sema.interner.get("Point").unwrap();
+
+        // Check the pool has the struct
+        let pool_point = sema.type_pool.get_struct_by_name(point_name);
+        assert!(pool_point.is_some(), "Point should be in the type pool");
+
+        // Verify pool and registry agree
+        let registry_point = sema.structs.get(&point_name);
+        assert!(
+            registry_point.is_some(),
+            "Point should be in struct registry"
+        );
+
+        // Check that definitions match
+        let pool_def = sema.type_pool.get_struct_def(pool_point.unwrap()).unwrap();
+        let registry_def = &sema.struct_defs[registry_point.unwrap().0 as usize];
+
+        assert_eq!(pool_def.name, registry_def.name);
+        assert_eq!(pool_def.fields.len(), registry_def.fields.len());
+        assert_eq!(pool_def.fields.len(), 2);
+        assert_eq!(pool_def.fields[0].name, "x");
+        assert_eq!(pool_def.fields[1].name, "y");
+        assert_eq!(pool_def.is_copy, registry_def.is_copy);
+        assert!(
+            !pool_def.is_builtin,
+            "Point should not be marked as builtin"
+        );
+    }
+
+    #[test]
+    fn test_type_pool_populated_with_enum() {
+        let sema = gather_declarations_for_testing(
+            "enum Color { Red, Green, Blue }
+             fn main() -> i32 { 0 }",
+        );
+
+        let color_name = sema.interner.get("Color").unwrap();
+
+        // Check the pool has the enum
+        let pool_color = sema.type_pool.get_enum_by_name(color_name);
+        assert!(pool_color.is_some(), "Color should be in the type pool");
+
+        // Verify pool and registry agree
+        let registry_color = sema.enums.get(&color_name);
+        assert!(registry_color.is_some(), "Color should be in enum registry");
+
+        // Check that definitions match
+        let pool_def = sema.type_pool.get_enum_def(pool_color.unwrap()).unwrap();
+        let registry_def = &sema.enum_defs[registry_color.unwrap().0 as usize];
+
+        assert_eq!(pool_def.name, registry_def.name);
+        assert_eq!(pool_def.variants.len(), registry_def.variants.len());
+        assert_eq!(pool_def.variants.len(), 3);
+        assert_eq!(pool_def.variants[0], "Red");
+        assert_eq!(pool_def.variants[1], "Green");
+        assert_eq!(pool_def.variants[2], "Blue");
+    }
+
+    #[test]
+    fn test_type_pool_copy_struct() {
+        let sema = gather_declarations_for_testing(
+            "@copy
+             struct Data { value: i32 }
+             fn main() -> i32 { 0 }",
+        );
+
+        let data_name = sema.interner.get("Data").unwrap();
+        let pool_data = sema.type_pool.get_struct_by_name(data_name).unwrap();
+        let pool_def = sema.type_pool.get_struct_def(pool_data).unwrap();
+
+        assert!(pool_def.is_copy, "Data should be marked as @copy");
+    }
+
+    #[test]
+    fn test_type_pool_stats() {
+        let sema = gather_declarations_for_testing(
+            "struct A {}
+             struct B {}
+             enum E { X }
+             fn main() -> i32 { 0 }",
+        );
+
+        let stats = sema.type_pool.stats();
+
+        // 3 structs: String (builtin) + A + B
+        assert_eq!(stats.struct_count, 3);
+        // 1 enum: E
+        assert_eq!(stats.enum_count, 1);
+        // No arrays in Phase 1
+        assert_eq!(stats.array_count, 0);
+        // Total: 4 composite types
+        assert_eq!(stats.total, 4);
+    }
+
+    #[test]
+    fn test_type_pool_all_registries_match() {
+        // Test with multiple types to verify complete consistency
+        let sema = gather_declarations_for_testing(
+            "struct Point { x: i32, y: i32 }
+             struct Empty {}
+             @copy struct Value { v: bool }
+             enum Status { Ok, Error }
+             enum Direction { Up, Down, Left, Right }
+             fn main() -> i32 { 0 }",
+        );
+
+        // Verify all structs in registry are in pool
+        for (name_spur, &struct_id) in &sema.structs {
+            let registry_def = &sema.struct_defs[struct_id.0 as usize];
+            let pool_type = sema.type_pool.get_struct_by_name(*name_spur);
+
+            assert!(
+                pool_type.is_some(),
+                "Struct '{}' should be in pool",
+                registry_def.name
+            );
+
+            let pool_def = sema.type_pool.get_struct_def(pool_type.unwrap()).unwrap();
+            assert_eq!(
+                pool_def.name, registry_def.name,
+                "Struct names should match"
+            );
+            assert_eq!(
+                pool_def.fields.len(),
+                registry_def.fields.len(),
+                "Field counts should match for {}",
+                registry_def.name
+            );
+            assert_eq!(
+                pool_def.is_copy, registry_def.is_copy,
+                "is_copy should match for {}",
+                registry_def.name
+            );
+        }
+
+        // Verify all enums in registry are in pool
+        for (name_spur, &enum_id) in &sema.enums {
+            let registry_def = &sema.enum_defs[enum_id.0 as usize];
+            let pool_type = sema.type_pool.get_enum_by_name(*name_spur);
+
+            assert!(
+                pool_type.is_some(),
+                "Enum '{}' should be in pool",
+                registry_def.name
+            );
+
+            let pool_def = sema.type_pool.get_enum_def(pool_type.unwrap()).unwrap();
+            assert_eq!(pool_def.name, registry_def.name, "Enum names should match");
+            assert_eq!(
+                pool_def.variants.len(),
+                registry_def.variants.len(),
+                "Variant counts should match for {}",
+                registry_def.name
+            );
+        }
+
+        // Verify counts match
+        let stats = sema.type_pool.stats();
+        assert_eq!(stats.struct_count, sema.struct_defs.len());
+        assert_eq!(stats.enum_count, sema.enum_defs.len());
+    }
 }

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -36,6 +36,7 @@ use rue_error::PreviewFeatures;
 use rue_rir::Rir;
 
 use crate::inference::{FunctionSig, InferType, MethodSig};
+use crate::intern_pool::TypeInternPool;
 // Import FunctionInfo, MethodInfo, and KnownSymbols from sema module to avoid duplication.
 // FunctionInfo and MethodInfo are the canonical definitions; we re-export them for convenience.
 pub use crate::sema::{FunctionInfo, KnownSymbols, MethodInfo};
@@ -224,11 +225,19 @@ pub struct SemaContext<'a> {
     pub inference_ctx: InferenceContext,
     /// Pre-interned known symbols for fast comparison.
     pub known: KnownSymbols,
+    /// Type intern pool for unified type representation (ADR-0024 Phase 1).
+    ///
+    /// During Phase 1, the pool coexists with the existing type registries.
+    /// It can be used for lookups but the canonical type representation
+    /// remains the old `Type` enum. Later phases will migrate to using
+    /// the pool exclusively.
+    pub type_pool: TypeInternPool,
 }
 
 // SAFETY: SemaContext is Send + Sync because:
 // - Immutable fields (struct_defs, enum_defs, structs, enums, etc.) are trivially thread-safe
 // - ArrayTypeRegistry uses RwLock for interior mutability
+// - TypeInternPool uses RwLock for interior mutability
 // - References to RIR and ThreadedRodeo are shared immutably
 // - References to functions/methods HashMaps are shared immutably (read-only after declaration gathering)
 // - ThreadedRodeo is designed to be thread-safe


### PR DESCRIPTION
Phase 1 of ADR-0024 Type Intern Pool migration. Creates the TypeInternPool infrastructure without removing the old system - both coexist temporarily.

Key additions:
- intern_pool.rs with TypeInternPool, InternedType, TypeData, StructData, EnumData
- Primitives encoded in indices 0-15 for O(1) equality without pool lookup
- Thread-safe RwLock-based pool with double-checked locking for arrays
- Pool populated during declaration collection via populate_type_pool()
- type_pool field added to Sema, SemaContext, GatherOutput, and SemaOutput

The pool is verified via 6 new tests ensuring pool-registry consistency. All 265 rue-air unit tests pass.

Fixes rue-3mjg

🤖 Generated with [Claude Code](https://claude.com/claude-code)