### PR TITLE
ADR-0024 Phase 2: Migrate array types to shared registry

### DIFF
--- a/crates/rue-air/src/analysis_state.rs
+++ b/crates/rue-air/src/analysis_state.rs
@@ -3,12 +3,17 @@
 //! This module contains state that is mutated during function analysis.
 //! Each function can have its own `FunctionAnalysisState`, which is then
 //! merged after parallel analysis completes.
+//!
+//! # Array Type Handling (Phase 2 - ADR-0024)
+//!
+//! Array types are now handled by the shared `ArrayTypeRegistry` in `SemaContext`,
+//! which is thread-safe and handles deduplication automatically. Per-function
+//! array tracking has been removed - array types created during function analysis
+//! go directly to the shared registry.
 
 use std::collections::HashMap;
 
 use rue_error::CompileWarning;
-
-use crate::types::{ArrayTypeDef, ArrayTypeId, Type};
 
 /// Per-function mutable state during semantic analysis.
 ///
@@ -18,23 +23,21 @@ use crate::types::{ArrayTypeDef, ArrayTypeId, Type};
 ///
 /// # Contents
 ///
-/// - Array types created during analysis
 /// - String literals encountered
 /// - Warnings generated
+///
+/// # Note on Array Types
+///
+/// Array types are handled by the shared `ArrayTypeRegistry` in `SemaContext`.
+/// They are no longer tracked per-function as of ADR-0024 Phase 2.
 ///
 /// # Merging
 ///
 /// After parallel analysis, use `merge_into` to combine results:
-/// - Array types are deduplicated
 /// - Strings are deduplicated
 /// - Warnings are concatenated
 #[derive(Debug, Default)]
 pub struct FunctionAnalysisState {
-    /// Array types created during this function's analysis.
-    /// Key is (element_type, length), value is the ArrayTypeId assigned.
-    pub array_types: HashMap<(Type, u64), ArrayTypeId>,
-    /// Array type definitions in order of creation.
-    pub array_type_defs: Vec<ArrayTypeDef>,
     /// String table for deduplication.
     pub string_table: HashMap<String, u32>,
     /// String literals in order of creation.
@@ -64,22 +67,6 @@ impl FunctionAnalysisState {
         }
     }
 
-    /// Get or create an array type, returning its ID.
-    pub fn get_or_create_array_type(&mut self, element_type: Type, length: u64) -> ArrayTypeId {
-        let key = (element_type, length);
-        if let Some(&id) = self.array_types.get(&key) {
-            return id;
-        }
-
-        let id = ArrayTypeId(self.array_type_defs.len() as u32);
-        self.array_type_defs.push(ArrayTypeDef {
-            element_type,
-            length,
-        });
-        self.array_types.insert(key, id);
-        id
-    }
-
     /// Add a warning.
     pub fn add_warning(&mut self, warning: CompileWarning) {
         self.warnings.push(warning);
@@ -90,12 +77,13 @@ impl FunctionAnalysisState {
 ///
 /// This is the result of merging all `FunctionAnalysisState` instances
 /// after parallel analysis completes.
+///
+/// # Note on Array Types
+///
+/// Array types are handled by the shared `ArrayTypeRegistry` in `SemaContext`.
+/// They are no longer merged here as of ADR-0024 Phase 2.
 #[derive(Debug, Default)]
 pub struct MergedAnalysisState {
-    /// All array type definitions (deduplicated).
-    pub array_type_defs: Vec<ArrayTypeDef>,
-    /// Mapping from original (element_type, length) to final ArrayTypeId.
-    pub array_type_map: HashMap<(Type, u64), ArrayTypeId>,
     /// All string literals (deduplicated).
     pub strings: Vec<String>,
     /// Mapping from string content to final index.
@@ -112,29 +100,15 @@ impl MergedAnalysisState {
 
     /// Merge a function's analysis state into this merged state.
     ///
-    /// Returns a remapping for array type IDs so the function's AIR
+    /// Returns a remapping for string indices so the function's AIR
     /// can be updated with the final IDs.
+    ///
+    /// # Note
+    ///
+    /// Array type merging is no longer needed (ADR-0024 Phase 2).
+    /// Array types go directly to the shared `ArrayTypeRegistry`.
     pub fn merge_function_state(&mut self, state: FunctionAnalysisState) -> AnalysisStateRemapping {
-        let mut array_remap = HashMap::new();
         let mut string_remap = HashMap::new();
-
-        // Merge array types (deduplicate by (element_type, length))
-        for (key, old_id) in state.array_types {
-            let new_id = if let Some(&id) = self.array_type_map.get(&key) {
-                id
-            } else {
-                let id = ArrayTypeId(self.array_type_defs.len() as u32);
-                self.array_type_defs.push(ArrayTypeDef {
-                    element_type: key.0,
-                    length: key.1,
-                });
-                self.array_type_map.insert(key, id);
-                id
-            };
-            if old_id != new_id {
-                array_remap.insert(old_id, new_id);
-            }
-        }
 
         // Merge strings (deduplicate by content)
         for (content, old_id) in state.string_table {
@@ -154,10 +128,7 @@ impl MergedAnalysisState {
         // Merge warnings (no deduplication needed)
         self.warnings.extend(state.warnings);
 
-        AnalysisStateRemapping {
-            array_remap,
-            string_remap,
-        }
+        AnalysisStateRemapping { string_remap }
     }
 }
 
@@ -165,11 +136,13 @@ impl MergedAnalysisState {
 ///
 /// When function analysis states are merged, IDs may change due to
 /// deduplication. This struct provides the mapping from old to new IDs.
+///
+/// # Note
+///
+/// Array type remapping is no longer needed (ADR-0024 Phase 2).
+/// Array types use the shared `ArrayTypeRegistry` which handles deduplication.
 #[derive(Debug, Default)]
 pub struct AnalysisStateRemapping {
-    /// Mapping from old ArrayTypeId to new ArrayTypeId.
-    /// Only contains entries where the ID changed.
-    pub array_remap: HashMap<ArrayTypeId, ArrayTypeId>,
     /// Mapping from old string index to new string index.
     /// Only contains entries where the index changed.
     pub string_remap: HashMap<u32, u32>,
@@ -178,12 +151,7 @@ pub struct AnalysisStateRemapping {
 impl AnalysisStateRemapping {
     /// Check if any remapping is needed.
     pub fn is_empty(&self) -> bool {
-        self.array_remap.is_empty() && self.string_remap.is_empty()
-    }
-
-    /// Remap an array type ID if needed.
-    pub fn remap_array_type(&self, id: ArrayTypeId) -> ArrayTypeId {
-        self.array_remap.get(&id).copied().unwrap_or(id)
+        self.string_remap.is_empty()
     }
 
     /// Remap a string index if needed.

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -14,7 +14,7 @@ use std::fmt;
 const _: () = assert!(std::mem::size_of::<AirInst>() <= 48);
 const _: () = assert!(std::mem::size_of::<AirInstData>() <= 32);
 
-use crate::types::{ArrayTypeId, StructId, Type};
+use crate::types::{StructId, Type};
 use lasso::{Key, Spur};
 use rue_span::Span;
 
@@ -611,44 +611,46 @@ pub enum AirInstData {
     },
 
     // Array operations
-    /// Create a new array with initialized elements
+    /// Create a new array with initialized elements.
+    /// The array type is stored in `AirInst.ty` as `Type::Array(...)`.
     ArrayInit {
-        /// The array type
-        array_type_id: ArrayTypeId,
         /// Start index into extra array for element refs
         elems_start: u32,
         /// Number of elements
         elems_len: u32,
     },
 
-    /// Load an element from an array
+    /// Load an element from an array.
+    /// The array type is stored in `AirInst.ty`.
     IndexGet {
         /// The array value
         base: AirRef,
-        /// The array type
-        array_type_id: ArrayTypeId,
+        /// The array type (for bounds checking and element size)
+        array_type: Type,
         /// Index expression
         index: AirRef,
     },
 
-    /// Store a value to an array element
+    /// Store a value to an array element.
+    /// The array type is stored in `AirInst.ty`.
     IndexSet {
         /// The array variable slot
         slot: u32,
-        /// The array type
-        array_type_id: ArrayTypeId,
+        /// The array type (for bounds checking and element size)
+        array_type: Type,
         /// Index expression
         index: AirRef,
         /// Value to store
         value: AirRef,
     },
 
-    /// Store a value to an array element of an inout parameter
+    /// Store a value to an array element of an inout parameter.
+    /// The array type is stored in `AirInst.ty`.
     ParamIndexSet {
         /// The parameter's ABI slot (relative to params, not locals)
         param_slot: u32,
-        /// The array type
-        array_type_id: ArrayTypeId,
+        /// The array type (for bounds checking and element size)
+        array_type: Type,
         /// Index expression
         index: AirRef,
         /// Value to store
@@ -893,11 +895,10 @@ impl fmt::Display for Air {
                     )?;
                 }
                 AirInstData::ArrayInit {
-                    array_type_id,
                     elems_start,
                     elems_len,
                 } => {
-                    write!(f, "array_init @{} [", array_type_id.0)?;
+                    write!(f, "array_init [")?;
                     for (i, elem) in self.get_air_refs(*elems_start, *elems_len).enumerate() {
                         if i > 0 {
                             write!(f, ", ")?;
@@ -908,33 +909,39 @@ impl fmt::Display for Air {
                 }
                 AirInstData::IndexGet {
                     base,
-                    array_type_id,
+                    array_type,
                     index,
                 } => {
-                    writeln!(f, "index_get {}(@{})[{}]", base, array_type_id.0, index)?;
+                    writeln!(f, "index_get {}({})[{}]", base, array_type.name(), index)?;
                 }
                 AirInstData::IndexSet {
                     slot,
-                    array_type_id,
+                    array_type,
                     index,
                     value,
                 } => {
                     writeln!(
                         f,
-                        "index_set ${}(@{})[{}] = {}",
-                        slot, array_type_id.0, index, value
+                        "index_set ${}({})[{}] = {}",
+                        slot,
+                        array_type.name(),
+                        index,
+                        value
                     )?;
                 }
                 AirInstData::ParamIndexSet {
                     param_slot,
-                    array_type_id,
+                    array_type,
                     index,
                     value,
                 } => {
                     writeln!(
                         f,
-                        "param_index_set param{}(@{})[{}] = {}",
-                        param_slot, array_type_id.0, index, value
+                        "param_index_set param{}({})[{}] = {}",
+                        param_slot,
+                        array_type.name(),
+                        index,
+                        value
                     )?;
                 }
                 AirInstData::EnumVariant {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -2832,7 +2832,7 @@ fn analyze_inst_for_projection_ctx(
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::IndexGet {
                     base: base_result.air_ref,
-                    array_type_id,
+                    array_type: base_type,
                     index: index_result.air_ref,
                 },
                 ty: elem_type,
@@ -3259,7 +3259,6 @@ fn analyze_array_init_ctx(
 
     let air_ref = air.add_inst(AirInst {
         data: AirInstData::ArrayInit {
-            array_type_id,
             elems_start,
             elems_len,
         },
@@ -3344,7 +3343,7 @@ fn analyze_index_get_ctx(
     let air_ref = air.add_inst(AirInst {
         data: AirInstData::IndexGet {
             base: base_result.air_ref,
-            array_type_id,
+            array_type: base_type,
             index: index_result.air_ref,
         },
         ty: elem_type,
@@ -3522,7 +3521,7 @@ fn analyze_index_set_ctx(
         air.add_inst(AirInst {
             data: AirInstData::ParamIndexSet {
                 param_slot: slot,
-                array_type_id,
+                array_type: base_type,
                 index: index_result.air_ref,
                 value: value_result.air_ref,
             },
@@ -3533,7 +3532,7 @@ fn analyze_index_set_ctx(
         air.add_inst(AirInst {
             data: AirInstData::IndexSet {
                 slot,
-                array_type_id,
+                array_type: base_type,
                 index: index_result.air_ref,
                 value: value_result.air_ref,
             },
@@ -4964,7 +4963,7 @@ impl<'a> Sema<'a> {
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::IndexGet {
                     base: base_result.air_ref,
-                    array_type_id,
+                    array_type: base_type,
                     index: index_result.air_ref,
                 },
                 ty: element_type,
@@ -5566,7 +5565,7 @@ impl<'a> Sema<'a> {
             air.add_inst(AirInst {
                 data: AirInstData::ParamIndexSet {
                     param_slot: slot,
-                    array_type_id,
+                    array_type: base_type,
                     index: index_result.air_ref,
                     value: value_result.air_ref,
                 },
@@ -5577,7 +5576,7 @@ impl<'a> Sema<'a> {
             air.add_inst(AirInst {
                 data: AirInstData::IndexSet {
                     slot,
-                    array_type_id,
+                    array_type: base_type,
                     index: index_result.air_ref,
                     value: value_result.air_ref,
                 },

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1693,7 +1693,6 @@ impl<'a> Sema<'a> {
 
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::ArrayInit {
-                array_type_id,
                 elems_start,
                 elems_len,
             },
@@ -1764,7 +1763,7 @@ impl<'a> Sema<'a> {
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::IndexGet {
                 base: base_result.air_ref,
-                array_type_id,
+                array_type: base_type,
                 index: index_result.air_ref,
             },
             ty: elem_type,

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1451,7 +1451,6 @@ impl<'a> CfgBuilder<'a> {
             }
 
             AirInstData::ArrayInit {
-                array_type_id,
                 elems_start,
                 elems_len,
             } => {
@@ -1466,7 +1465,6 @@ impl<'a> CfgBuilder<'a> {
                 let (elements_start, elements_len) = self.cfg.push_extra(element_vals);
                 let value = self.emit(
                     CfgInstData::ArrayInit {
-                        array_type_id: *array_type_id,
                         elements_start,
                         elements_len,
                     },
@@ -1482,7 +1480,7 @@ impl<'a> CfgBuilder<'a> {
 
             AirInstData::IndexGet {
                 base,
-                array_type_id,
+                array_type,
                 index,
             } => {
                 let Some(base_val) = self.lower_value(*base) else {
@@ -1494,7 +1492,7 @@ impl<'a> CfgBuilder<'a> {
                 let value = self.emit(
                     CfgInstData::IndexGet {
                         base: base_val,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                         index: index_val,
                     },
                     ty,
@@ -1509,7 +1507,7 @@ impl<'a> CfgBuilder<'a> {
 
             AirInstData::IndexSet {
                 slot,
-                array_type_id,
+                array_type,
                 index,
                 value,
             } => {
@@ -1522,7 +1520,7 @@ impl<'a> CfgBuilder<'a> {
                 self.emit(
                     CfgInstData::IndexSet {
                         slot: *slot,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                         index: index_val,
                         value: val,
                     },
@@ -1537,7 +1535,7 @@ impl<'a> CfgBuilder<'a> {
 
             AirInstData::ParamIndexSet {
                 param_slot,
-                array_type_id,
+                array_type,
                 index,
                 value,
             } => {
@@ -1550,7 +1548,7 @@ impl<'a> CfgBuilder<'a> {
                 self.emit(
                     CfgInstData::ParamIndexSet {
                         param_slot: *param_slot,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                         index: index_val,
                         value: val,
                     },

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -16,7 +16,7 @@ const _: () = assert!(std::mem::size_of::<CfgInst>() <= 48);
 const _: () = assert!(std::mem::size_of::<CfgInstData>() <= 32);
 
 use lasso::{Key, Spur};
-use rue_air::{ArrayTypeId, EnumId, StructId, Type};
+use rue_air::{EnumId, StructId, Type};
 use rue_span::Span;
 
 /// A basic block identifier.
@@ -245,21 +245,26 @@ pub enum CfgInstData {
     // Array operations
     /// Array initialization. Element values are stored in the Cfg's extra array.
     /// Use `Cfg::get_extra(elements_start, elements_len)` to retrieve them.
+    /// The array type is stored in `CfgInst.ty`.
     ArrayInit {
-        array_type_id: ArrayTypeId,
         /// Start index into Cfg's extra array
         elements_start: u32,
         /// Number of elements
         elements_len: u32,
     },
+    /// Load an element from an array.
+    /// The result type is the element type.
     IndexGet {
         base: CfgValue,
-        array_type_id: ArrayTypeId,
+        /// The array type (for bounds checking and element size)
+        array_type: Type,
         index: CfgValue,
     },
+    /// Store a value to an array element.
     IndexSet {
         slot: u32,
-        array_type_id: ArrayTypeId,
+        /// The array type (for bounds checking and element size)
+        array_type: Type,
         index: CfgValue,
         value: CfgValue,
     },
@@ -267,8 +272,8 @@ pub enum CfgInstData {
     ParamIndexSet {
         /// The parameter's ABI slot (relative to params, not locals)
         param_slot: u32,
-        /// The array type
-        array_type_id: ArrayTypeId,
+        /// The array type (for bounds checking and element size)
+        array_type: Type,
         /// Index expression
         index: CfgValue,
         /// Value to store
@@ -978,11 +983,10 @@ impl Cfg {
                 )
             }
             CfgInstData::ArrayInit {
-                array_type_id,
                 elements_start,
                 elements_len,
             } => {
-                write!(f, "array_init @{} [", array_type_id.0)?;
+                write!(f, "array_init [")?;
                 let elements = self.get_extra(*elements_start, *elements_len);
                 for (i, elem) in elements.iter().enumerate() {
                     if i > 0 {
@@ -994,33 +998,39 @@ impl Cfg {
             }
             CfgInstData::IndexGet {
                 base,
-                array_type_id,
+                array_type,
                 index,
             } => {
-                write!(f, "index_get {}(@{})[{}]", base, array_type_id.0, index)
+                write!(f, "index_get {}({})[{}]", base, array_type.name(), index)
             }
             CfgInstData::IndexSet {
                 slot,
-                array_type_id,
+                array_type,
                 index,
                 value,
             } => {
                 write!(
                     f,
-                    "index_set ${}(@{})[{}] = {}",
-                    slot, array_type_id.0, index, value
+                    "index_set ${}({})[{}] = {}",
+                    slot,
+                    array_type.name(),
+                    index,
+                    value
                 )
             }
             CfgInstData::ParamIndexSet {
                 param_slot,
-                array_type_id,
+                array_type,
                 index,
                 value,
             } => {
                 write!(
                     f,
-                    "param_index_set %{}(@{})[{}] = {}",
-                    param_slot, array_type_id.0, index, value
+                    "param_index_set %{}({})[{}] = {}",
+                    param_slot,
+                    array_type.name(),
+                    index,
+                    value
                 )
             }
             CfgInstData::EnumVariant {

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
-use rue_air::{ArrayTypeDef, ArrayTypeId};
+use rue_air::ArrayTypeDef;
 use rue_cfg::{
     BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, StructDef, StructId, Terminator, Type,
 };
@@ -115,21 +115,13 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Get the length of an array type.
-    fn array_length(&self, array_type_id: ArrayTypeId) -> u64 {
-        debug_assert!(
-            (array_type_id.0 as usize) < self.array_types.len(),
-            "invalid array type ID: {:?}",
-            array_type_id
-        );
-        self.array_types
-            .get(array_type_id.0 as usize)
-            .map(|def| def.length)
-            .unwrap_or(0)
+    fn array_length(&self, array_type: Type) -> u64 {
+        types::array_length_from_type(self.array_types, array_type)
     }
 
     /// Get the array type definition.
-    fn array_type_def(&self, array_type_id: ArrayTypeId) -> Option<&ArrayTypeDef> {
-        types::array_type_def(self.array_types, array_type_id)
+    fn array_type_def(&self, array_type: Type) -> Option<&ArrayTypeDef> {
+        types::array_type_def_from_type(self.array_types, array_type)
     }
 
     /// Calculate the total number of slots needed to store a type.
@@ -138,8 +130,8 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Calculate the slot count for a single element of an array type.
-    fn array_element_slot_count(&self, array_type_id: ArrayTypeId) -> u32 {
-        types::array_element_slot_count(self.struct_defs, self.array_types, array_type_id)
+    fn array_element_slot_count(&self, array_type: Type) -> u32 {
+        types::array_element_slot_count_from_type(self.struct_defs, self.array_types, array_type)
     }
 
     /// Calculate the slot offset for a field within a struct.
@@ -169,17 +161,17 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::IndexGet {
                 base: array_base,
-                array_type_id,
+                array_type,
                 index,
             } => {
                 // Array of structs case: the field's base is an IndexGet
                 // Try to trace the array base to find the original Load/Param
                 if let Some((index_base, mut levels)) = self.trace_index_chain(*array_base) {
-                    let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                    let elem_slot_count = self.array_element_slot_count(*array_type);
                     levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                     });
                     Some((
                         FieldChainBase::IndexGet {
@@ -228,16 +220,16 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::IndexGet {
                 base,
-                array_type_id,
+                array_type,
                 index,
             } => {
                 // Recursively trace the base
                 if let Some((base_kind, mut levels)) = self.trace_index_chain(*base) {
-                    let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                    let elem_slot_count = self.array_element_slot_count(*array_type);
                     levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                     });
                     Some((base_kind, levels))
                 } else {
@@ -1805,9 +1797,9 @@ impl<'a> CfgLower<'a> {
                                 }
                             }
                         }
-                        Type::Array(array_type_id) => {
+                        Type::Array(_) => {
                             let arg_data = &self.cfg.get_inst(arg_value).data;
-                            let array_len = self.array_length(array_type_id) as u32;
+                            let array_len = self.array_length(arg_type) as u32;
                             match arg_data {
                                 CfgInstData::Load { slot } => {
                                     for elem_idx in 0..array_len {
@@ -2279,7 +2271,7 @@ impl<'a> CfgLower<'a> {
                             // Emit bounds check for the innermost index
                             if let Some(innermost) = index_levels.last() {
                                 let innermost_index_vreg = self.get_vreg(innermost.index);
-                                let array_length = self.array_length(innermost.array_type_id);
+                                let array_length = self.array_length(innermost.array_type);
                                 self.emit_bounds_check(innermost_index_vreg, array_length);
                             }
 
@@ -2487,7 +2479,6 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::ArrayInit {
-                array_type_id: _,
                 elements_start,
                 elements_len,
             } => {
@@ -2509,14 +2500,14 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::IndexGet {
                 base,
-                array_type_id,
+                array_type,
                 index,
             } => {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
 
                 // Calculate the slot stride for this array's elements
-                let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                let elem_slot_count = self.array_element_slot_count(*array_type);
 
                 // First, check if base is an ArrayInit (constant index case)
                 let base_data = &self.cfg.get_inst(*base).data.clone();
@@ -2548,12 +2539,12 @@ impl<'a> CfgLower<'a> {
                     levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                     });
 
                     // Emit bounds check for the innermost index
                     let innermost_index_vreg = self.get_vreg(*index);
-                    let array_length = self.array_length(*array_type_id);
+                    let array_length = self.array_length(*array_type);
                     self.emit_bounds_check(innermost_index_vreg, array_length);
 
                     // Calculate total offset by summing index * stride for each level
@@ -2679,7 +2670,7 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::IndexSet {
                 slot,
-                array_type_id,
+                array_type,
                 index,
                 value: val,
             } => {
@@ -2687,7 +2678,7 @@ impl<'a> CfgLower<'a> {
                 let index_vreg = self.get_vreg(*index);
 
                 // Emit runtime bounds check
-                let array_length = self.array_length(*array_type_id);
+                let array_length = self.array_length(*array_type);
                 self.emit_bounds_check(index_vreg, array_length);
 
                 // Shift left by 3 (multiply by 8)
@@ -2724,7 +2715,7 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::ParamIndexSet {
                 param_slot,
-                array_type_id,
+                array_type,
                 index,
                 value: val,
             } => {
@@ -2732,7 +2723,7 @@ impl<'a> CfgLower<'a> {
                 let index_vreg = self.get_vreg(*index);
 
                 // Emit runtime bounds check
-                let array_length = self.array_length(*array_type_id);
+                let array_length = self.array_length(*array_type);
                 self.emit_bounds_check(index_vreg, array_length);
 
                 // Shift left by 3 (multiply by 8)

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -6,8 +6,7 @@
 use std::fmt;
 
 use lasso::Key;
-use rue_air::ArrayTypeId;
-use rue_cfg::{BlockId, CfgValue};
+use rue_cfg::{BlockId, CfgValue, Type};
 
 /// A single lowering decision: maps one CFG instruction to its MIR expansion.
 #[derive(Debug, Clone)]
@@ -177,32 +176,38 @@ pub fn format_cfg_inst_data(data: &rue_cfg::CfgInstData) -> String {
             "param_field_set %{}+{}.#{}.{} = {}",
             param_slot, inner_offset, struct_id.0, field_index, value
         ),
-        CfgInstData::ArrayInit { array_type_id, .. } => {
-            // Note: Can't show elements without Cfg access; just show array_type_id
-            format!("array_init @{} [...]", array_type_id.0)
+        CfgInstData::ArrayInit { .. } => {
+            // Note: Can't show elements without Cfg access
+            "array_init [...]".to_string()
         }
         CfgInstData::IndexGet {
             base,
-            array_type_id,
+            array_type,
             index,
-        } => format!("index_get {}[@{}][{}]", base, array_type_id.0, index),
+        } => format!("index_get {}[{}][{}]", base, array_type.name(), index),
         CfgInstData::IndexSet {
             slot,
-            array_type_id,
+            array_type,
             index,
             value,
         } => format!(
-            "index_set ${}[@{}][{}] = {}",
-            slot, array_type_id.0, index, value
+            "index_set ${}[{}][{}] = {}",
+            slot,
+            array_type.name(),
+            index,
+            value
         ),
         CfgInstData::ParamIndexSet {
             param_slot,
-            array_type_id,
+            array_type,
             index,
             value,
         } => format!(
-            "param_index_set %{}[@{}][{}] = {}",
-            param_slot, array_type_id.0, index, value
+            "param_index_set %{}[{}][{}] = {}",
+            param_slot,
+            array_type.name(),
+            index,
+            value
         ),
         CfgInstData::EnumVariant {
             enum_id,
@@ -334,5 +339,6 @@ pub enum IndexChainBase {
 pub struct IndexLevel {
     pub index: CfgValue,
     pub elem_slot_count: u32,
-    pub array_type_id: ArrayTypeId,
+    /// The array type (Type::Array(...)) for bounds checking.
+    pub array_type: Type,
 }

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -9,12 +9,55 @@ use std::collections::HashMap;
 
 use crate::vreg::VReg;
 
+/// Extract the ArrayTypeId from a Type::Array.
+/// Returns None if the type is not an array type.
+#[inline]
+pub fn extract_array_type_id(ty: Type) -> Option<ArrayTypeId> {
+    match ty {
+        Type::Array(id) => Some(id),
+        _ => None,
+    }
+}
+
 /// Get the array type definition for an array type ID.
 pub fn array_type_def<'a>(
     array_types: &'a [ArrayTypeDef],
     array_type_id: ArrayTypeId,
 ) -> Option<&'a ArrayTypeDef> {
     array_types.get(array_type_id.0 as usize)
+}
+
+/// Get the array type definition from a Type.
+/// Returns None if the type is not an array type or if the ID is out of bounds.
+#[inline]
+pub fn array_type_def_from_type<'a>(
+    array_types: &'a [ArrayTypeDef],
+    ty: Type,
+) -> Option<&'a ArrayTypeDef> {
+    extract_array_type_id(ty).and_then(|id| array_type_def(array_types, id))
+}
+
+/// Get the length of an array from its Type.
+/// Returns 0 if the type is not an array or the ID is invalid.
+#[inline]
+pub fn array_length_from_type(array_types: &[ArrayTypeDef], ty: Type) -> u64 {
+    array_type_def_from_type(array_types, ty)
+        .map(|def| def.length)
+        .unwrap_or(0)
+}
+
+/// Calculate the slot count for a single element of an array from its Type.
+#[inline]
+pub fn array_element_slot_count_from_type(
+    struct_defs: &[StructDef],
+    array_types: &[ArrayTypeDef],
+    ty: Type,
+) -> u32 {
+    if let Some(def) = array_type_def_from_type(array_types, ty) {
+        type_slot_count(struct_defs, array_types, def.element_type)
+    } else {
+        1
+    }
 }
 
 /// Calculate the total number of slots needed to store a type.

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -28,7 +28,7 @@
 use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
-use rue_air::{ArrayTypeDef, ArrayTypeId};
+use rue_air::ArrayTypeDef;
 use rue_builtins::{BinOp, get_builtin_type};
 use rue_cfg::{
     BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, StructDef, StructId, Terminator, Type,
@@ -127,21 +127,13 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Get the length of an array type.
-    fn array_length(&self, array_type_id: ArrayTypeId) -> u64 {
-        debug_assert!(
-            (array_type_id.0 as usize) < self.array_types.len(),
-            "invalid array type ID: {:?}",
-            array_type_id
-        );
-        self.array_types
-            .get(array_type_id.0 as usize)
-            .map(|def| def.length)
-            .unwrap_or(0)
+    fn array_length(&self, array_type: Type) -> u64 {
+        types::array_length_from_type(self.array_types, array_type)
     }
 
     /// Get the array type definition.
-    fn array_type_def(&self, array_type_id: ArrayTypeId) -> Option<&ArrayTypeDef> {
-        types::array_type_def(self.array_types, array_type_id)
+    fn array_type_def(&self, array_type: Type) -> Option<&ArrayTypeDef> {
+        types::array_type_def_from_type(self.array_types, array_type)
     }
 
     // ========================================================================
@@ -188,8 +180,8 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Calculate the slot count for a single element of an array type.
-    fn array_element_slot_count(&self, array_type_id: ArrayTypeId) -> u32 {
-        types::array_element_slot_count(self.struct_defs, self.array_types, array_type_id)
+    fn array_element_slot_count(&self, array_type: Type) -> u32 {
+        types::array_element_slot_count_from_type(self.struct_defs, self.array_types, array_type)
     }
 
     /// Calculate the slot offset for a field within a struct.
@@ -219,17 +211,17 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::IndexGet {
                 base: array_base,
-                array_type_id,
+                array_type,
                 index,
             } => {
                 // Array of structs case: the field's base is an IndexGet
                 // Try to trace the array base to find the original Load/Param
                 if let Some((index_base, mut levels)) = self.trace_index_chain(*array_base) {
-                    let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                    let elem_slot_count = self.array_element_slot_count(*array_type);
                     levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                     });
                     Some((
                         FieldChainBase::IndexGet {
@@ -278,16 +270,16 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::IndexGet {
                 base,
-                array_type_id,
+                array_type,
                 index,
             } => {
                 // Recursively trace the base
                 if let Some((base_kind, mut levels)) = self.trace_index_chain(*base) {
-                    let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                    let elem_slot_count = self.array_element_slot_count(*array_type);
                     levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                     });
                     Some((base_kind, levels))
                 } else {
@@ -1934,9 +1926,9 @@ impl<'a> CfgLower<'a> {
                                 }
                             }
                         }
-                        Type::Array(array_type_id) => {
+                        Type::Array(_) => {
                             let arg_data = &self.cfg.get_inst(arg_value).data;
-                            let array_len = self.array_length(array_type_id) as u32;
+                            let array_len = self.array_length(arg_type) as u32;
                             match arg_data {
                                 CfgInstData::Load { slot } => {
                                     for elem_idx in 0..array_len {
@@ -2426,7 +2418,7 @@ impl<'a> CfgLower<'a> {
                             // Emit bounds check for the innermost index
                             if let Some(innermost) = index_levels.last() {
                                 let innermost_index_vreg = self.get_vreg(innermost.index);
-                                let array_length = self.array_length(innermost.array_type_id);
+                                let array_length = self.array_length(innermost.array_type);
                                 self.emit_bounds_check(innermost_index_vreg, array_length);
                             }
 
@@ -2638,7 +2630,6 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::ArrayInit {
-                array_type_id: _,
                 elements_start,
                 elements_len,
             } => {
@@ -2662,14 +2653,14 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::IndexGet {
                 base,
-                array_type_id,
+                array_type,
                 index,
             } => {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
 
                 // Calculate the slot stride for this array's elements
-                let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                let elem_slot_count = self.array_element_slot_count(*array_type);
 
                 // First, check if base is an ArrayInit (constant index case)
                 let base_data = &self.cfg.get_inst(*base).data.clone();
@@ -2701,12 +2692,12 @@ impl<'a> CfgLower<'a> {
                     levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
-                        array_type_id: *array_type_id,
+                        array_type: *array_type,
                     });
 
                     // Emit bounds check for the innermost index
                     let innermost_index_vreg = self.get_vreg(*index);
-                    let array_length = self.array_length(*array_type_id);
+                    let array_length = self.array_length(*array_type);
                     self.emit_bounds_check(innermost_index_vreg, array_length);
 
                     // Calculate total offset by summing index * stride for each level
@@ -2882,7 +2873,7 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::IndexSet {
                 slot,
-                array_type_id,
+                array_type,
                 index,
                 value: val,
             } => {
@@ -2890,12 +2881,12 @@ impl<'a> CfgLower<'a> {
                 let index_vreg = self.get_vreg(*index);
 
                 // Emit runtime bounds check
-                let array_length = self.array_length(*array_type_id);
+                let array_length = self.array_length(*array_type);
                 self.emit_bounds_check(index_vreg, array_length);
 
                 // Optimization: use SIB addressing for single-element arrays
                 // This is always the case for IndexSet (it doesn't chain like IndexGet)
-                let elem_slot_count = self.array_element_slot_count(*array_type_id);
+                let elem_slot_count = self.array_element_slot_count(*array_type);
 
                 let base_offset = self.local_offset(*slot);
 
@@ -2971,7 +2962,7 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::ParamIndexSet {
                 param_slot,
-                array_type_id,
+                array_type,
                 index,
                 value: val,
             } => {
@@ -2979,7 +2970,7 @@ impl<'a> CfgLower<'a> {
                 let index_vreg = self.get_vreg(*index);
 
                 // Emit runtime bounds check
-                let array_length = self.array_length(*array_type_id);
+                let array_length = self.array_length(*array_type);
                 self.emit_bounds_check(index_vreg, array_length);
 
                 // Scale index by 8 (element size)


### PR DESCRIPTION
This implements Phase 2 of the Type Intern Pool design (ADR-0024).

Changes:
- AIR/CFG array instructions now use Type instead of ArrayTypeId
- ArrayInit no longer stores array_type_id (uses AirInst.ty)
- IndexGet, IndexSet, ParamIndexSet store array_type: Type
- Added helper functions in types.rs to extract array info from Type
- Removed per-function array tracking from FunctionAnalysisState
- Removed array merging from MergedAnalysisState
- Updated both x86_64 and aarch64 codegen backends

Array types are now handled by the shared thread-safe ArrayTypeRegistry in SemaContext, which deduplicates automatically.

Closes: rue-9e5t

🤖 Generated with [Claude Code](https://claude.com/claude-code)