### PR TITLE
Implement Phase 2: Comptime Value Parameters (ADR-0025)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -3880,6 +3880,46 @@ fn analyze_call_ctx(
         }
     }
 
+    // Check that comptime parameters receive compile-time constant values
+    let has_comptime_params = fn_info.param_comptime.iter().any(|&c| c);
+    if has_comptime_params {
+        // Gate behind comptime preview feature
+        if !ctx.preview_features.contains(&PreviewFeature::Comptime) {
+            return Err(CompileError::new(
+                ErrorKind::PreviewFeatureRequired {
+                    feature: PreviewFeature::Comptime,
+                    what: "comptime parameters".to_string(),
+                },
+                span,
+            )
+            .with_help(format!(
+                "use `--preview {}` to enable this feature ({})",
+                PreviewFeature::Comptime.name(),
+                PreviewFeature::Comptime.adr()
+            )));
+        }
+
+        // Validate each comptime parameter receives a compile-time constant
+        for (i, (&is_comptime, arg)) in fn_info.param_comptime.iter().zip(args.iter()).enumerate() {
+            if is_comptime {
+                // Try to evaluate the argument at compile time
+                if try_evaluate_const_in_rir(ctx.rir, arg.value).is_none() {
+                    let param_name = ctx.interner.resolve(&fn_info.param_names[i]).to_string();
+                    return Err(CompileError::new(
+                        ErrorKind::ComptimeArgNotConst {
+                            param_name: param_name.clone(),
+                        },
+                        ctx.rir.get(arg.value).span,
+                    )
+                    .with_help(format!(
+                        "parameter '{}' is declared as 'comptime' and requires a compile-time known value",
+                        param_name
+                    )));
+                }
+            }
+        }
+    }
+
     // Extract return_type before mutable borrow
     let return_type = fn_info.return_type;
 
@@ -6730,7 +6770,7 @@ impl<'a> Sema<'a> {
     ///
     /// This is the foundation for compile-time bounds checking and can be extended
     /// for future `comptime` features.
-    fn try_evaluate_const(&self, inst_ref: InstRef) -> Option<ConstValue> {
+    pub(crate) fn try_evaluate_const(&self, inst_ref: InstRef) -> Option<ConstValue> {
         let inst = self.rir.get(inst_ref);
         match &inst.data {
             // Integer literals
@@ -6887,6 +6927,9 @@ impl<'a> Sema<'a> {
                 let n = self.try_evaluate_const(*operand)?.as_integer()?;
                 Some(ConstValue::Integer(!n))
             }
+
+            // Comptime block: comptime { expr } is compile-time evaluable if its inner expr is
+            InstData::Comptime { expr } => self.try_evaluate_const(*expr),
 
             // Everything else requires runtime evaluation
             _ => None,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -25,7 +25,7 @@ use std::collections::{HashMap, HashSet};
 use lasso::Spur;
 use rue_error::{
     CompileError, CompileResult, CompileWarning, ErrorKind, MissingFieldsError, OptionExt,
-    WarningKind,
+    PreviewFeature, WarningKind,
 };
 use rue_rir::{InstData, InstRef, RirArgMode, RirParamMode, RirPattern};
 use rue_span::Span;
@@ -1971,6 +1971,35 @@ impl<'a> Sema<'a> {
                 }
                 RirParamMode::Normal => {
                     // Normal params accept any mode
+                }
+            }
+        }
+
+        // Check that comptime parameters receive compile-time constant values
+        let has_comptime_params = fn_info.param_comptime.iter().any(|&c| c);
+        if has_comptime_params {
+            // Gate behind comptime preview feature
+            self.require_preview(PreviewFeature::Comptime, "comptime parameters", span)?;
+
+            // Validate each comptime parameter receives a compile-time constant
+            for (i, (&is_comptime, arg)) in
+                fn_info.param_comptime.iter().zip(args.iter()).enumerate()
+            {
+                if is_comptime {
+                    // Try to evaluate the argument at compile time
+                    if self.try_evaluate_const(arg.value).is_none() {
+                        let param_name = self.interner.resolve(&fn_info.param_names[i]).to_string();
+                        return Err(CompileError::new(
+                            ErrorKind::ComptimeArgNotConst {
+                                param_name: param_name.clone(),
+                            },
+                            self.rir.get(arg.value).span,
+                        )
+                        .with_help(format!(
+                            "parameter '{}' is declared as 'comptime' and requires a compile-time known value",
+                            param_name
+                        )));
+                    }
                 }
             }
         }

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -667,17 +667,28 @@ impl<'a> Sema<'a> {
     ) -> CompileResult<()> {
         let ret_type = self.resolve_type(return_type, span)?;
         let params = self.rir.get_params(params_start, params_len);
+
+        // Check if any parameter is comptime and gate behind preview feature
+        let has_comptime_params = params.iter().any(|p| p.is_comptime);
+        if has_comptime_params {
+            self.require_preview(PreviewFeature::Comptime, "comptime parameters", span)?;
+        }
+
+        let param_names: Vec<_> = params.iter().map(|p| p.name).collect();
         let param_types: Vec<Type> = params
             .iter()
             .map(|p| self.resolve_type(p.ty, span))
             .collect::<CompileResult<Vec<_>>>()?;
         let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
+        let param_comptime: Vec<bool> = params.iter().map(|p| p.is_comptime).collect();
 
         self.functions.insert(
             name,
             FunctionInfo {
+                param_names,
                 param_types,
                 param_modes,
+                param_comptime,
                 return_type: ret_type,
             },
         );

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -206,10 +206,14 @@ pub struct InferenceContext {
 /// Information about a function.
 #[derive(Debug, Clone)]
 pub struct FunctionInfo {
+    /// Parameter names (in order)
+    pub param_names: Vec<lasso::Spur>,
     /// Parameter types (in order)
     pub param_types: Vec<Type>,
     /// Parameter modes (in order)
     pub param_modes: Vec<rue_rir::RirParamMode>,
+    /// Whether each parameter is comptime (in order)
+    pub param_comptime: Vec<bool>,
     /// Return type
     pub return_type: Type,
 }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -169,6 +169,7 @@ impl ErrorCode {
     // Comptime errors (E1200-E1299)
     // ========================================================================
     pub const COMPTIME_EVALUATION_FAILED: Self = Self(1200);
+    pub const COMPTIME_ARG_NOT_CONST: Self = Self(1201);
 
     // ========================================================================
     // Internal compiler errors (E9000-E9999)
@@ -980,6 +981,9 @@ pub enum ErrorKind {
     #[error("comptime evaluation failed: {reason}")]
     ComptimeEvaluationFailed { reason: String },
 
+    #[error("comptime parameter requires a compile-time known value")]
+    ComptimeArgNotConst { param_name: String },
+
     // Internal compiler errors (bugs in the compiler itself)
     #[error("internal compiler error: {0}")]
     InternalError(String),
@@ -1088,6 +1092,7 @@ impl ErrorKind {
 
             // Comptime errors (E1200-E1299)
             ErrorKind::ComptimeEvaluationFailed { .. } => ErrorCode::COMPTIME_EVALUATION_FAILED,
+            ErrorKind::ComptimeArgNotConst { .. } => ErrorCode::COMPTIME_ARG_NOT_CONST,
 
             // Internal compiler errors (E9000-E9999)
             ErrorKind::InternalError(_) => ErrorCode::INTERNAL_ERROR,

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -206,6 +206,8 @@ impl Default for ParamMode {
 /// A function parameter.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Param {
+    /// Whether this parameter is evaluated at compile time
+    pub is_comptime: bool,
     /// Parameter passing mode (normal or inout)
     pub mode: ParamMode,
     /// Parameter name

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -247,17 +247,19 @@ where
     ))
 }
 
-/// Parser for function parameters: [inout|borrow] name: type
+/// Parser for function parameters: [comptime] [inout|borrow] name: type
 fn param_parser<'src, I>() -> impl Parser<'src, I, Param, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    param_mode_parser()
+    just(TokenKind::Comptime)
         .or_not()
+        .then(param_mode_parser().or_not())
         .then(ident_parser())
         .then_ignore(just(TokenKind::Colon))
         .then(type_parser())
-        .map_with(|((mode, name), ty), e| Param {
+        .map_with(|(((is_comptime, mode), name), ty), e| Param {
+            is_comptime: is_comptime.is_some(),
             mode: mode.unwrap_or(ParamMode::Normal),
             name,
             ty,

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -190,6 +190,7 @@ impl<'a> AstGen<'a> {
                 name: p.name.name, // Already a Spur
                 ty: self.intern_type(&p.ty),
                 mode: self.convert_param_mode(p.mode),
+                is_comptime: p.is_comptime,
             })
             .collect();
         let (params_start, params_len) = self.rir.add_params(&params);
@@ -291,6 +292,7 @@ impl<'a> AstGen<'a> {
                 name: p.name.name, // Already a Spur
                 ty: self.intern_type(&p.ty),
                 mode: self.convert_param_mode(p.mode),
+                is_comptime: p.is_comptime,
             })
             .collect();
         let (params_start, params_len) = self.rir.add_params(&params);

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -60,6 +60,8 @@ pub struct RirParam {
     pub ty: Spur,
     /// Parameter passing mode
     pub mode: RirParamMode,
+    /// Whether this parameter is evaluated at compile time
+    pub is_comptime: bool,
 }
 
 /// Argument passing mode in RIR.
@@ -136,8 +138,8 @@ impl RirPattern {
 const CALL_ARG_SIZE: u32 = 2;
 
 /// Stored representation of RirParam in the extra array.
-/// Layout: [name: u32, ty: u32, mode: u32] = 3 u32s per param
-const PARAM_SIZE: u32 = 3;
+/// Layout: [name: u32, ty: u32, mode: u32, is_comptime: u32] = 4 u32s per param
+const PARAM_SIZE: u32 = 4;
 
 /// Stored representation of match arm in the extra array.
 /// Layout: pattern data + [body: u32]
@@ -421,13 +423,14 @@ impl Rir {
     }
 
     /// Store RirParams and return (start, len).
-    /// Layout: [name: u32, ty: u32, mode: u32] per param
+    /// Layout: [name: u32, ty: u32, mode: u32, is_comptime: u32] per param
     pub fn add_params(&mut self, params: &[RirParam]) -> (u32, u32) {
         let mut data = Vec::with_capacity(params.len() * PARAM_SIZE as usize);
         for param in params {
             data.push(param.name.into_usize() as u32);
             data.push(param.ty.into_usize() as u32);
             data.push(param.mode as u32);
+            data.push(param.is_comptime as u32);
         }
         let start = self.add_extra(&data);
         (start, params.len() as u32)
@@ -446,7 +449,13 @@ impl Rir {
                 2 => RirParamMode::Borrow,
                 _ => RirParamMode::Normal, // Fallback
             };
-            params.push(RirParam { name, ty, mode });
+            let is_comptime = chunk[3] != 0;
+            params.push(RirParam {
+                name,
+                ty,
+                mode,
+                is_comptime,
+            });
         }
         params
     }
@@ -2507,6 +2516,7 @@ mod tests {
             name: param_name,
             ty: param_type,
             mode: RirParamMode::Normal,
+            is_comptime: false,
         }]);
 
         rir.add_inst(Inst {
@@ -2584,16 +2594,19 @@ mod tests {
                 name: param1_name,
                 ty: param1_type,
                 mode: RirParamMode::Normal,
+                is_comptime: false,
             },
             RirParam {
                 name: param2_name,
                 ty: param2_type,
                 mode: RirParamMode::Inout,
+                is_comptime: false,
             },
             RirParam {
                 name: param3_name,
                 ty: param3_type,
                 mode: RirParamMode::Borrow,
+                is_comptime: false,
             },
         ]);
 

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -263,3 +263,122 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "cannot be known at compile time"
+
+# =============================================================================
+# Comptime Parameters (Phase 2 - ADR-0025)
+# =============================================================================
+
+[[case]]
+name = "comptime_param_requires_preview_flag"
+spec = ["4.13:5"]
+source = """
+fn repeat(comptime n: i32, value: i32) -> i32 { n + value }
+fn main() -> i32 {
+    repeat(3, 10)
+}
+"""
+compile_fail = true
+error_contains = "requires preview feature"
+
+[[case]]
+name = "comptime_param_basic"
+spec = ["4.13:5"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn multiply(comptime n: i32, value: i32) -> i32 {
+    n * value
+}
+fn main() -> i32 {
+    multiply(6, 7)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_with_literal"
+spec = ["4.13:5"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn add_constant(comptime c: i32, x: i32) -> i32 {
+    c + x
+}
+fn main() -> i32 {
+    add_constant(40, 2)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_multiple"
+spec = ["4.13:5"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn compute(comptime a: i32, comptime b: i32, x: i32) -> i32 {
+    a * b + x
+}
+fn main() -> i32 {
+    compute(5, 8, 2)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_runtime_arg_error"
+spec = ["4.13:6"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn double(comptime n: i32) -> i32 { n * 2 }
+fn main() -> i32 {
+    let x = 21;
+    double(x)
+}
+"""
+compile_fail = true
+error_contains = "comptime parameter requires a compile-time known value"
+
+[[case]]
+name = "comptime_param_function_call_arg_error"
+spec = ["4.13:6"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn get_value() -> i32 { 5 }
+fn scale(comptime factor: i32, value: i32) -> i32 { factor * value }
+fn main() -> i32 {
+    scale(get_value(), 10)
+}
+"""
+compile_fail = true
+error_contains = "comptime parameter requires a compile-time known value"
+
+[[case]]
+name = "comptime_param_comptime_expr_ok"
+spec = ["4.13:5"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn triple(comptime n: i32) -> i32 { n * 3 }
+fn main() -> i32 {
+    triple(comptime { 7 * 2 })
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_mixed_with_normal"
+spec = ["4.13:5"]
+preview = "comptime"
+preview_should_pass = true
+source = """
+fn offset(x: i32, comptime delta: i32, y: i32) -> i32 {
+    x + delta + y
+}
+fn main() -> i32 {
+    offset(10, 20, 12)
+}
+"""
+exit_code = 42


### PR DESCRIPTION
This implements Phase 2 of the comptime feature as designed in ADR-0025, adding support for comptime parameters that must receive compile-time known values at call sites.

Changes:
- Parser: Add support for 'comptime' modifier on function parameters
- RIR: Track is_comptime in RirParam struct, update serialization
- AIR/Sema: Track param_comptime in FunctionInfo, validate at call sites
- Error: Add E1201 ComptimeArgNotConst error for non-constant args
- Add try_evaluate_const support for Comptime blocks

The feature is gated behind --preview comptime and validates:
- Comptime params require compile-time evaluable arguments
- Literals, constant expressions, and comptime blocks are allowed
- Runtime variables and function calls are rejected

8 new spec tests verify the functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)