### PR TITLE
Add pub visibility modifier for functions, structs, and enums (Phase …

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -175,10 +175,20 @@ impl<'a> Sema<'a> {
         for (_, inst) in self.rir.iter() {
             match &inst.data {
                 InstData::EnumDecl {
+                    is_pub,
                     name,
                     variants_start,
                     variants_len,
                 } => {
+                    // pub visibility requires preview feature
+                    if *is_pub {
+                        self.require_preview(
+                            PreviewFeature::Modules,
+                            "pub visibility modifier",
+                            inst.span,
+                        )?;
+                    }
+
                     let enum_id = EnumId(self.enum_defs.len() as u32);
                     let enum_name = self.interner.resolve(&*name).to_string();
 
@@ -235,10 +245,20 @@ impl<'a> Sema<'a> {
                 InstData::StructDecl {
                     directives_start,
                     directives_len,
+                    is_pub,
                     is_linear,
                     name,
                     ..
                 } => {
+                    // pub visibility requires preview feature
+                    if *is_pub {
+                        self.require_preview(
+                            PreviewFeature::Modules,
+                            "pub visibility modifier",
+                            inst.span,
+                        )?;
+                    }
+
                     let struct_id = StructId(self.struct_defs.len() as u32);
                     let struct_name = self.interner.resolve(&*name).to_string();
 
@@ -424,12 +444,22 @@ impl<'a> Sema<'a> {
                 }
 
                 InstData::FnDecl {
+                    is_pub,
                     name,
                     params_start,
                     params_len,
                     return_type,
                     ..
                 } => {
+                    // pub visibility requires preview feature
+                    if *is_pub {
+                        self.require_preview(
+                            PreviewFeature::Modules,
+                            "pub visibility modifier",
+                            inst.span,
+                        )?;
+                    }
+
                     self.collect_function_signature(
                         *name,
                         *params_start,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -249,6 +249,9 @@ pub enum PreviewFeature {
     /// Compile-time execution (comptime).
     /// See ADR-0025 for the full design.
     Comptime,
+    /// Module system with @import and pub visibility.
+    /// See ADR-0026 for the full design.
+    Modules,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -271,6 +274,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::AffineMvs => "affine_mvs",
             PreviewFeature::Comptime => "comptime",
+            PreviewFeature::Modules => "modules",
         }
     }
 
@@ -281,6 +285,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::AffineMvs => "ADR-0008",
             PreviewFeature::Comptime => "ADR-0025",
+            PreviewFeature::Modules => "ADR-0026",
         }
     }
 
@@ -290,6 +295,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra,
             PreviewFeature::AffineMvs,
             PreviewFeature::Comptime,
+            PreviewFeature::Modules,
         ]
     }
 
@@ -315,6 +321,7 @@ impl std::str::FromStr for PreviewFeature {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "affine_mvs" => Ok(PreviewFeature::AffineMvs),
             "comptime" => Ok(PreviewFeature::Comptime),
+            "modules" => Ok(PreviewFeature::Modules),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -1786,7 +1793,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, affine_mvs, comptime");
+        assert_eq!(names, "test_infra, affine_mvs, comptime, modules");
     }
 
     // ========================================================================

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -41,6 +41,7 @@ pub enum TokenKind {
     Linear,    // linear struct modifier
     SelfValue, // self (value, not type)
     Comptime,  // comptime (compile-time evaluation)
+    Pub,       // pub visibility modifier (module system)
 
     // Type keywords
     I8,
@@ -132,6 +133,7 @@ impl TokenKind {
             TokenKind::Linear => "'linear'",
             TokenKind::SelfValue => "'self'",
             TokenKind::Comptime => "'comptime'",
+            TokenKind::Pub => "'pub'",
             TokenKind::I8 => "type 'i8'",
             TokenKind::I16 => "type 'i16'",
             TokenKind::I32 => "type 'i32'",
@@ -227,6 +229,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Linear => write!(f, "LINEAR"),
             TokenKind::SelfValue => write!(f, "SELF"),
             TokenKind::Comptime => write!(f, "COMPTIME"),
+            TokenKind::Pub => write!(f, "PUB"),
             TokenKind::I8 => write!(f, "TYPE(i8)"),
             TokenKind::I16 => write!(f, "TYPE(i16)"),
             TokenKind::I32 => write!(f, "TYPE(i32)"),

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -153,6 +153,8 @@ pub enum LogosTokenKind {
     SelfValue,
     #[token("comptime")]
     Comptime,
+    #[token("pub")]
+    Pub,
 
     // Type keywords
     #[token("i8")]
@@ -295,6 +297,7 @@ impl From<LogosTokenKind> for TokenKind {
             LogosTokenKind::Linear => TokenKind::Linear,
             LogosTokenKind::SelfValue => TokenKind::SelfValue,
             LogosTokenKind::Comptime => TokenKind::Comptime,
+            LogosTokenKind::Pub => TokenKind::Pub,
             LogosTokenKind::I8 => TokenKind::I8,
             LogosTokenKind::I16 => TokenKind::I16,
             LogosTokenKind::I32 => TokenKind::I32,

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -76,6 +76,8 @@ pub enum Item {
 pub struct StructDecl {
     /// Directives applied to this struct (e.g., @copy)
     pub directives: Directives,
+    /// Visibility of this struct
+    pub visibility: Visibility,
     /// Whether this struct is a linear type (must be consumed, cannot be dropped)
     pub is_linear: bool,
     /// Struct name
@@ -100,6 +102,8 @@ pub struct FieldDecl {
 /// An enum declaration.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnumDecl {
+    /// Visibility of this enum
+    pub visibility: Visibility,
     /// Enum name
     pub name: Ident,
     /// Enum variants
@@ -169,11 +173,23 @@ pub struct SelfParam {
     pub span: Span,
 }
 
+/// Visibility of an item (function, struct, enum, etc.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Visibility {
+    /// Private to the current file (default)
+    #[default]
+    Private,
+    /// Public - visible to importers
+    Public,
+}
+
 /// A function definition.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Function {
     /// Directives applied to this function
     pub directives: Directives,
+    /// Visibility of this function
+    pub visibility: Visibility,
     /// Function name
     pub name: Ident,
     /// Function parameters

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -11,7 +11,7 @@ use crate::ast::{
     IntrinsicCallExpr, Item, LetPattern, LetStatement, LoopExpr, MatchArm, MatchExpr, Method,
     MethodCallExpr, NegIntLit, Param, ParamMode, ParenExpr, PathExpr, PathPattern, Pattern,
     ReturnExpr, SelfExpr, SelfParam, Statement, StringLit, StructDecl, StructLitExpr, TypeExpr,
-    UnaryExpr, UnaryOp, UnitLit, WhileExpr,
+    UnaryExpr, UnaryOp, UnitLit, Visibility, WhileExpr,
 };
 use chumsky::input::{Input as ChumskyInput, MapExtra, Stream, ValueInput};
 use chumsky::pratt::{infix, left, prefix};
@@ -1513,14 +1513,25 @@ where
 {
     let expr = expr_parser();
 
+    // Parse optional visibility (pub keyword)
+    let visibility = just(TokenKind::Pub).or_not().map(|opt| {
+        if opt.is_some() {
+            Visibility::Public
+        } else {
+            Visibility::Private
+        }
+    });
+
     directives_parser()
+        .then(visibility)
         .then(just(TokenKind::Fn).ignore_then(ident_parser()))
         .then(params_parser().delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)))
         .then(just(TokenKind::Arrow).ignore_then(type_parser()).or_not())
         .then(block_parser(expr))
         .map_with(
-            |((((directives, name), params), return_type), body), e| Function {
+            |(((((directives, visibility), name), params), return_type), body), e| Function {
                 directives,
+                visibility,
                 name,
                 params,
                 return_type,
@@ -1530,22 +1541,35 @@ where
         )
 }
 
-/// Parser for struct definitions: [@directive]* [linear] struct Name { field: Type, ... }
+/// Parser for struct definitions: [@directive]* [pub] [linear] struct Name { field: Type, ... }
 fn struct_parser<'src, I>() -> impl Parser<'src, I, StructDecl, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
+    // Parse optional visibility (pub keyword)
+    let visibility = just(TokenKind::Pub).or_not().map(|opt| {
+        if opt.is_some() {
+            Visibility::Public
+        } else {
+            Visibility::Private
+        }
+    });
+
     directives_parser()
+        .then(visibility)
         .then(just(TokenKind::Linear).or_not())
         .then(just(TokenKind::Struct).ignore_then(ident_parser()))
         .then(field_decls_parser().delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace)))
-        .map_with(|(((directives, is_linear), name), fields), e| StructDecl {
-            directives,
-            is_linear: is_linear.is_some(),
-            name,
-            fields,
-            span: to_rue_span(e.span()),
-        })
+        .map_with(
+            |((((directives, visibility), is_linear), name), fields), e| StructDecl {
+                directives,
+                visibility,
+                is_linear: is_linear.is_some(),
+                name,
+                fields,
+                span: to_rue_span(e.span()),
+            },
+        )
 }
 
 /// Parser for enum variant: just an identifier
@@ -1571,15 +1595,25 @@ where
         .collect()
 }
 
-/// Parser for enum definitions: enum Name { Variant1, Variant2, ... }
+/// Parser for enum definitions: [pub] enum Name { Variant1, Variant2, ... }
 fn enum_parser<'src, I>() -> impl Parser<'src, I, EnumDecl, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    just(TokenKind::Enum)
-        .ignore_then(ident_parser())
+    // Parse optional visibility (pub keyword)
+    let visibility = just(TokenKind::Pub).or_not().map(|opt| {
+        if opt.is_some() {
+            Visibility::Public
+        } else {
+            Visibility::Private
+        }
+    });
+
+    visibility
+        .then(just(TokenKind::Enum).ignore_then(ident_parser()))
         .then(enum_variants_parser().delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace)))
-        .map_with(|(name, variants), e| EnumDecl {
+        .map_with(|((visibility, name), variants), e| EnumDecl {
+            visibility,
             name,
             variants,
             span: to_rue_span(e.span()),

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -12,7 +12,7 @@ use rue_parser::ast::DropFn;
 use rue_parser::{
     ArgMode, AssignTarget, Ast, BinaryOp, CallArg, Directive, DirectiveArg, EnumDecl, Expr,
     Function, ImplBlock, IntrinsicArg, Item, LetPattern, Method, ParamMode, Pattern, Statement,
-    StructDecl, TypeExpr, UnaryOp,
+    StructDecl, TypeExpr, UnaryOp, ast::Visibility,
 };
 
 use crate::inst::{
@@ -109,6 +109,7 @@ impl<'a> AstGen<'a> {
             data: InstData::StructDecl {
                 directives_start,
                 directives_len,
+                is_pub: struct_decl.visibility == Visibility::Public,
                 is_linear: struct_decl.is_linear,
                 name,
                 fields_start,
@@ -129,6 +130,7 @@ impl<'a> AstGen<'a> {
 
         self.rir.add_inst(Inst {
             data: InstData::EnumDecl {
+                is_pub: enum_decl.visibility == Visibility::Public,
                 name,
                 variants_start,
                 variants_len,
@@ -205,10 +207,12 @@ impl<'a> AstGen<'a> {
 
         // Emit methods as FnDecl instructions with has_self flag.
         // Sema uses has_self to add the implicit self parameter for methods.
+        // Methods don't have their own visibility - they're accessible if the type is accessible.
         let decl = self.rir.add_inst(Inst {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
+                is_pub: false,
                 name,
                 params_start,
                 params_len,
@@ -307,6 +311,7 @@ impl<'a> AstGen<'a> {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
+                is_pub: func.visibility == Visibility::Public,
                 name,
                 params_start,
                 params_len,

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -932,6 +932,7 @@ impl Rir {
             InstData::FnDecl {
                 directives_start,
                 directives_len,
+                is_pub,
                 name,
                 params_start,
                 params_len,
@@ -941,6 +942,7 @@ impl Rir {
             } => InstData::FnDecl {
                 directives_start: *directives_start + extra_offset,
                 directives_len: *directives_len,
+                is_pub: *is_pub,
                 name: *name,
                 params_start: *params_start + extra_offset,
                 params_len: *params_len,
@@ -975,6 +977,7 @@ impl Rir {
             InstData::StructDecl {
                 directives_start,
                 directives_len,
+                is_pub,
                 is_linear,
                 name,
                 fields_start,
@@ -982,6 +985,7 @@ impl Rir {
             } => InstData::StructDecl {
                 directives_start: *directives_start + extra_offset,
                 directives_len: *directives_len,
+                is_pub: *is_pub,
                 is_linear: *is_linear,
                 name: *name,
                 fields_start: *fields_start + extra_offset,
@@ -1008,10 +1012,12 @@ impl Rir {
 
             // Enum operations
             InstData::EnumDecl {
+                is_pub,
                 name,
                 variants_start,
                 variants_len,
             } => InstData::EnumDecl {
+                is_pub: *is_pub,
                 name: *name,
                 variants_start: *variants_start + extra_offset,
                 variants_len: *variants_len,
@@ -1368,6 +1374,8 @@ pub enum InstData {
         directives_start: u32,
         /// Number of directives
         directives_len: u32,
+        /// Whether this function is public (requires --preview modules)
+        is_pub: bool,
         name: Spur,
         /// Index into extra data where params start
         params_start: u32,
@@ -1472,6 +1480,8 @@ pub enum InstData {
         directives_start: u32,
         /// Number of directives
         directives_len: u32,
+        /// Whether this struct is public (requires --preview modules)
+        is_pub: bool,
         /// Whether this struct is a linear type (must be consumed)
         is_linear: bool,
         /// Struct name
@@ -1515,6 +1525,8 @@ pub enum InstData {
     /// Enum type declaration
     /// Variants are stored in the extra array using add_symbols/get_symbols.
     EnumDecl {
+        /// Whether this enum is public (requires --preview modules)
+        is_pub: bool,
         /// Enum name
         name: Spur,
         /// Index into extra data where variants start
@@ -1740,6 +1752,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 InstData::FnDecl {
                     directives_start: _,
                     directives_len: _,
+                    is_pub,
                     name,
                     params_start,
                     params_len,
@@ -1747,6 +1760,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     body,
                     has_self,
                 } => {
+                    let pub_str = if *is_pub { "pub " } else { "" };
                     let name_str = self.interner.resolve(&*name);
                     let ret_str = self.interner.resolve(&*return_type);
                     let self_str = if *has_self { "self, " } else { "" };
@@ -1769,7 +1783,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         .collect();
                     writeln!(
                         out,
-                        "fn {}({}{}) -> {} {{",
+                        "{}fn {}({}{}) -> {} {{",
+                        pub_str,
                         name_str,
                         self_str,
                         params_str.join(", "),
@@ -1846,11 +1861,13 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 InstData::StructDecl {
                     directives_start,
                     directives_len,
+                    is_pub,
                     is_linear,
                     name,
                     fields_start,
                     fields_len,
                 } => {
+                    let pub_str = if *is_pub { "pub " } else { "" };
                     let name_str = self.interner.resolve(&*name);
                     let fields = self.rir.get_field_decls(*fields_start, *fields_len);
                     let fields_str: Vec<String> = fields
@@ -1876,8 +1893,9 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     };
                     writeln!(
                         out,
-                        "{}{}struct {} {{ {} }}",
+                        "{}{}{}struct {} {{ {} }}",
                         directives_str,
+                        pub_str,
                         linear_str,
                         name_str,
                         fields_str.join(", ")
@@ -1921,17 +1939,26 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
 
                 // Enums
                 InstData::EnumDecl {
+                    is_pub,
                     name,
                     variants_start,
                     variants_len,
                 } => {
+                    let pub_str = if *is_pub { "pub " } else { "" };
                     let name_str = self.interner.resolve(&*name);
                     let variants = self.rir.get_symbols(*variants_start, *variants_len);
                     let variants_str: Vec<String> = variants
                         .iter()
                         .map(|v| self.interner.resolve(&*v).to_string())
                         .collect();
-                    writeln!(out, "enum {} {{ {} }}", name_str, variants_str.join(", ")).unwrap();
+                    writeln!(
+                        out,
+                        "{}enum {} {{ {} }}",
+                        pub_str,
+                        name_str,
+                        variants_str.join(", ")
+                    )
+                    .unwrap();
                 }
                 InstData::EnumVariant { type_name, variant } => {
                     writeln!(
@@ -2513,6 +2540,7 @@ mod tests {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
+                is_pub: false,
                 name,
                 params_start,
                 params_len,
@@ -2546,6 +2574,7 @@ mod tests {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
+                is_pub: false,
                 name,
                 params_start,
                 params_len,
@@ -2601,6 +2630,7 @@ mod tests {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
+                is_pub: false,
                 name,
                 params_start,
                 params_len,
@@ -2908,6 +2938,7 @@ mod tests {
             data: InstData::StructDecl {
                 directives_start,
                 directives_len,
+                is_pub: false,
                 is_linear: false,
                 name,
                 fields_start,
@@ -2940,6 +2971,7 @@ mod tests {
             data: InstData::StructDecl {
                 directives_start,
                 directives_len,
+                is_pub: false,
                 is_linear: false,
                 name,
                 fields_start,
@@ -3041,6 +3073,7 @@ mod tests {
 
         rir.add_inst(Inst {
             data: InstData::EnumDecl {
+                is_pub: false,
                 name,
                 variants_start,
                 variants_len,
@@ -3168,6 +3201,7 @@ mod tests {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
+                is_pub: false,
                 name: method_name,
                 params_start,
                 params_len,
@@ -3747,6 +3781,7 @@ mod tests {
             data: InstData::FnDecl {
                 directives_start: dirs_start,
                 directives_len: dirs_len,
+                is_pub: false,
                 name: main_name,
                 params_start,
                 params_len,
@@ -3771,6 +3806,7 @@ mod tests {
             data: InstData::FnDecl {
                 directives_start: dirs_start2,
                 directives_len: dirs_len2,
+                is_pub: false,
                 name: helper_name,
                 params_start: params_start2,
                 params_len: params_len2,

--- a/crates/rue-spec/cases/modules/visibility.toml
+++ b/crates/rue-spec/cases/modules/visibility.toml
@@ -1,0 +1,132 @@
+[section]
+id = "modules.visibility"
+name = "Visibility"
+description = "Pub visibility modifier for functions, structs, and enums (Phase 1 of module system). Spec chapter pending ADR-0026 finalization."
+
+# =============================================================================
+# Public Functions
+# =============================================================================
+
+[[case]]
+name = "pub_fn_basic"
+preview = "modules"
+preview_should_pass = true
+description = "Basic pub function declaration is allowed with preview flag"
+source = """
+pub fn helper() -> i32 { 42 }
+fn main() -> i32 { helper() }
+"""
+exit_code = 42
+
+[[case]]
+name = "pub_fn_with_params"
+preview = "modules"
+preview_should_pass = true
+description = "Pub function with parameters"
+source = """
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+fn main() -> i32 { add(20, 22) }
+"""
+exit_code = 42
+
+[[case]]
+name = "pub_fn_without_preview_error"
+description = "Pub function without preview flag gives helpful error"
+source = """
+pub fn helper() -> i32 { 42 }
+fn main() -> i32 { helper() }
+"""
+compile_fail = true
+error_contains = "preview"
+
+# =============================================================================
+# Public Structs
+# =============================================================================
+
+[[case]]
+name = "pub_struct_basic"
+preview = "modules"
+preview_should_pass = true
+description = "Basic pub struct declaration is allowed with preview flag"
+source = """
+pub struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { x: 10, y: 32 };
+    p.x + p.y
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "pub_struct_without_preview_error"
+description = "Pub struct without preview flag gives helpful error"
+source = """
+pub struct Point { x: i32, y: i32 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "preview"
+
+# =============================================================================
+# Public Enums
+# =============================================================================
+
+[[case]]
+name = "pub_enum_basic"
+preview = "modules"
+preview_should_pass = true
+description = "Basic pub enum declaration is allowed with preview flag"
+source = """
+pub enum Color { Red, Green, Blue }
+fn main() -> i32 {
+    let c = Color::Red;
+    match c {
+        Color::Red => 42,
+        Color::Green => 0,
+        Color::Blue => 0,
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "pub_enum_without_preview_error"
+description = "Pub enum without preview flag gives helpful error"
+source = """
+pub enum Status { Active, Inactive }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "preview"
+
+# =============================================================================
+# Mixed Visibility
+# =============================================================================
+
+[[case]]
+name = "mixed_pub_and_private"
+preview = "modules"
+preview_should_pass = true
+description = "Mix of public and private declarations"
+source = """
+pub fn public_fn() -> i32 { 10 }
+fn private_fn() -> i32 { 20 }
+
+pub struct PubPoint { x: i32 }
+struct PrivPoint { y: i32 }
+
+pub enum PubStatus { On, Off }
+enum PrivStatus { Active, Inactive }
+
+fn main() -> i32 {
+    let p1 = PubPoint { x: public_fn() };
+    let p2 = PrivPoint { y: private_fn() };
+    let s1 = PubStatus::On;
+    let s2 = PrivStatus::Active;
+    match s1 {
+        PubStatus::On => p1.x + p2.y + 12,
+        PubStatus::Off => 0,
+    }
+}
+"""
+exit_code = 42


### PR DESCRIPTION
…1 of Module System)

This implements Phase 1 of ADR-0026 (Module System), enabling the `pub` keyword for visibility modifiers on functions, structs, and enums. The feature is gated behind `--preview modules`.

Changes:
- Add Pub token to lexer (rue-lexer)
- Add Visibility enum with Private/Public variants (rue-parser)
- Parse optional pub before fn/struct/enum declarations
- Add is_pub field to FnDecl, StructDecl, EnumDecl in RIR
- Add preview gate in sema (requires --preview modules)
- Add spec tests for pub visibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)