### PR TITLE
Add spec tests for @import parsing (rue-r37o)

### DIFF
--- a/crates/rue-spec/cases/modules/import.toml
+++ b/crates/rue-spec/cases/modules/import.toml
@@ -1,0 +1,111 @@
+[section]
+id = "modules.import"
+name = "Import Expressions"
+description = "The @import builtin for importing modules (Phase 1 of module system). Spec chapter pending ADR-0026 finalization."
+
+# =============================================================================
+# @import Parsing (verified at parse stage, before semantic analysis)
+# =============================================================================
+
+# Note: These tests verify that @import parses correctly as an intrinsic call.
+# The actual module resolution and semantic behavior is covered by rue-u0li.
+# Until semantic analysis for @import is implemented, these tests use
+# compile_fail with "unknown intrinsic" since the parser correctly accepts
+# the syntax but sema doesn't know what to do with it yet.
+
+[[case]]
+name = "import_basic_syntax"
+preview = "modules"
+description = "@import with string argument parses as intrinsic call"
+source = """
+fn main() -> i32 {
+    let m = @import("foo.rue");
+    0
+}
+"""
+# Parser accepts this; sema rejects until module resolution is implemented
+compile_fail = true
+error_contains = "unknown intrinsic"
+
+[[case]]
+name = "import_used_in_const"
+preview = "modules"
+description = "@import can be used in a const binding (typical pattern)"
+source = """
+fn main() -> i32 {
+    let math = @import("math.rue");
+    0
+}
+"""
+# Parser accepts this; sema rejects until module resolution is implemented
+compile_fail = true
+error_contains = "unknown intrinsic"
+
+[[case]]
+name = "import_multiple_files"
+preview = "modules"
+description = "Multiple @import calls in same file"
+source = """
+fn main() -> i32 {
+    let a = @import("a.rue");
+    let b = @import("b.rue");
+    0
+}
+"""
+# Parser accepts this; sema rejects until module resolution is implemented
+compile_fail = true
+error_contains = "unknown intrinsic"
+
+[[case]]
+name = "import_nested_path"
+preview = "modules"
+description = "@import with nested path"
+source = """
+fn main() -> i32 {
+    let utils = @import("utils/strings.rue");
+    0
+}
+"""
+# Parser accepts this; sema rejects until module resolution is implemented
+compile_fail = true
+error_contains = "unknown intrinsic"
+
+# =============================================================================
+# @import Parse Errors (invalid syntax should fail at parse stage)
+# =============================================================================
+
+[[case]]
+name = "import_no_args_error"
+preview = "modules"
+description = "@import with no arguments is a parse/sema error"
+source = """
+fn main() -> i32 {
+    let m = @import();
+    0
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "import_integer_arg_error"
+preview = "modules"
+description = "@import with integer argument should fail type checking"
+source = """
+fn main() -> i32 {
+    let m = @import(42);
+    0
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "import_multiple_args_error"
+preview = "modules"
+description = "@import with multiple arguments should fail"
+source = """
+fn main() -> i32 {
+    let m = @import("a.rue", "b.rue");
+    0
+}
+"""
+compile_fail = true


### PR DESCRIPTION
Verified that the parser already correctly handles @import("path.rue") syntax through the generic intrinsic call mechanism (@name(args)).

Tests added in modules/import.toml verify:
- Basic @import syntax is parsed correctly
- Multiple imports work
- Nested paths work
- Error cases (no args, wrong type, multiple args)

Currently these tests expect compile_fail with "unknown intrinsic" since semantic analysis for @import is not yet implemented (tracked in rue-u0li).

Closes: rue-r37o