### PR TITLE
Fix visibility terminology inconsistencies in module system ADR

### DIFF
--- a/docs/designs/0026-module-system.md
+++ b/docs/designs/0026-module-system.md
@@ -158,9 +158,6 @@ utils.strings.format("hello")
 
 // Access re-exported function directly
 utils.helper()
-
-// Can also import submodules directly if needed
-const internal = @import("utils/internal.rue");
 ```
 
 **Why `_` prefix?**
@@ -178,12 +175,12 @@ Only two visibility levels:
 
 | Modifier | Meaning |
 |----------|---------|
-| `pub` | Visible to importers |
-| (none) | Private to this file |
+| `pub` | Visible to all importers |
+| (none) | Private to this module (directory) |
 
 **Rationale:** Rust's `pub(crate)`, `pub(super)`, `pub(in path)` are rarely used and add cognitive overhead. If we later need package-level visibility, we can add `pub(pkg)` without breaking existing code.
 
-**Intra-directory visibility:** Files within the same directory can access each other's non-pub items. This matches Hylo's model where `pub` only affects cross-module (cross-directory) visibility.
+**Intra-module visibility:** Files within the same directory can access each other's non-pub items. This matches Hylo's model where `pub` only affects cross-module (cross-directory) visibility.
 
 ```rue
 // utils/strings.rue


### PR DESCRIPTION
- Changed 'private to this file' to 'private to this module (directory)'
- Changed 'Intra-directory' to 'Intra-module' for consistency
- Removed example of directly importing submodules (bypasses encapsulation)

Thanks @dorianlistens for the bug report!

🤖 Generated with [Claude Code](https://claude.com/claude-code)