### PR TITLE
Phase 3: Implement generic function specialization (ADR-0025)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -45,6 +45,17 @@ pub struct FunctionSig {
     pub param_types: Vec<InferType>,
     /// Return type, as InferType for uniform handling.
     pub return_type: InferType,
+    /// Whether this is a generic function (has comptime type parameters).
+    /// Generic functions skip type checking during constraint generation -
+    /// they'll be checked during specialization.
+    pub is_generic: bool,
+    /// Parameter modes (Normal, Inout, Borrow, Comptime).
+    /// Used to identify which parameters are comptime type parameters.
+    pub param_modes: Vec<rue_rir::RirParamMode>,
+    /// Parameter names, needed for type substitution in generic returns.
+    pub param_names: Vec<lasso::Spur>,
+    /// The return type as a symbol (used for substitution lookup).
+    pub return_type_sym: lasso::Spur,
 }
 
 /// Information about a method during constraint generation.
@@ -467,10 +478,69 @@ impl<'a> ConstraintGenerator<'a> {
             } => {
                 let args = self.rir.get_call_args(*args_start, *args_len);
                 if let Some(func) = self.functions.get(name) {
-                    // Check argument count matches parameter count.
-                    // Semantic analysis will emit a proper error; we just need to avoid
-                    // panicking and process what we can.
-                    if args.len() != func.param_types.len() {
+                    // For generic functions, skip constraint generation for arguments.
+                    // The types will be checked during specialization when we know
+                    // the concrete type substitutions.
+                    if func.is_generic {
+                        // Process all arguments and build type substitution map
+                        let mut type_subst: std::collections::HashMap<lasso::Spur, Type> =
+                            std::collections::HashMap::new();
+
+                        for (i, arg) in args.iter().enumerate() {
+                            let arg_info = self.generate(arg.value, ctx);
+
+                            // If this is a comptime parameter, extract the type for substitution
+                            if i < func.param_modes.len()
+                                && func.param_modes[i] == rue_rir::RirParamMode::Comptime
+                            {
+                                // The argument should be a TypeConst - extract the concrete type
+                                if let InferType::Concrete(Type::ComptimeType) = &arg_info.ty {
+                                    // This is a type value - get the actual type from the RIR
+                                    let arg_inst = self.rir.get(arg.value);
+                                    if let rue_rir::InstData::TypeConst { type_name } =
+                                        &arg_inst.data
+                                    {
+                                        // Resolve type_name to a concrete Type
+                                        let type_name_str = self.interner.resolve(type_name);
+                                        let concrete_ty = match type_name_str {
+                                            "i8" => Type::I8,
+                                            "i16" => Type::I16,
+                                            "i32" => Type::I32,
+                                            "i64" => Type::I64,
+                                            "u8" => Type::U8,
+                                            "u16" => Type::U16,
+                                            "u32" => Type::U32,
+                                            "u64" => Type::U64,
+                                            "bool" => Type::Bool,
+                                            "()" => Type::Unit,
+                                            _ => Type::Error, // Unknown type
+                                        };
+                                        if i < func.param_names.len() {
+                                            type_subst.insert(func.param_names[i], concrete_ty);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+
+                        // Compute the actual return type by substituting type parameters
+                        let return_type =
+                            if func.return_type == InferType::Concrete(Type::ComptimeType) {
+                                // Return type is a type parameter - look it up in substitutions
+                                if let Some(&concrete_ty) = type_subst.get(&func.return_type_sym) {
+                                    InferType::Concrete(concrete_ty)
+                                } else {
+                                    func.return_type.clone()
+                                }
+                            } else {
+                                func.return_type.clone()
+                            };
+
+                        return_type
+                    } else if args.len() != func.param_types.len() {
+                        // Check argument count matches parameter count.
+                        // Semantic analysis will emit a proper error; we just need to avoid
+                        // panicking and process what we can.
                         // Still process all arguments to catch type errors within them
                         for arg in args.iter() {
                             self.generate(arg.value, ctx);
@@ -974,6 +1044,10 @@ impl<'a> ConstraintGenerator<'a> {
                 self.add_constraint(Constraint::equal(InferType::Var(var), inner_info.ty, span));
                 InferType::Var(var)
             }
+
+            // Type constant: a type used as a value (e.g., `i32` in `identity(i32, 42)`)
+            // This has the special ComptimeType type which indicates it's a type value.
+            InstData::TypeConst { .. } => InferType::Concrete(Type::ComptimeType),
         };
 
         // Record the type for this expression
@@ -1445,15 +1519,28 @@ mod tests {
         assert_eq!(info.span, Span::new(5, 10));
     }
 
+    /// Helper to create a non-generic FunctionSig for tests
+    fn make_test_func_sig(param_types: Vec<InferType>, return_type: InferType) -> FunctionSig {
+        let num_params = param_types.len();
+        FunctionSig {
+            param_types,
+            return_type,
+            is_generic: false,
+            param_modes: vec![rue_rir::RirParamMode::Normal; num_params],
+            param_names: vec![],
+            return_type_sym: lasso::Spur::default(),
+        }
+    }
+
     #[test]
     fn test_function_sig() {
-        let sig = FunctionSig {
-            param_types: vec![
+        let sig = make_test_func_sig(
+            vec![
                 InferType::Concrete(Type::I32),
                 InferType::Concrete(Type::Bool),
             ],
-            return_type: InferType::Concrete(Type::I64),
-        };
+            InferType::Concrete(Type::I64),
+        );
         assert_eq!(sig.param_types.len(), 2);
         assert_eq!(sig.return_type, InferType::Concrete(Type::I64));
     }
@@ -1672,13 +1759,13 @@ mod tests {
         let func_name = interner.get_or_intern("foo");
         functions.insert(
             func_name,
-            FunctionSig {
-                param_types: vec![
+            make_test_func_sig(
+                vec![
                     InferType::Concrete(Type::I32),
                     InferType::Concrete(Type::I32),
                 ],
-                return_type: InferType::Concrete(Type::Bool),
-            },
+                InferType::Concrete(Type::Bool),
+            ),
         );
 
         // Create a call with only 1 argument (mismatch)

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -380,6 +380,20 @@ impl Air {
             }
         }
     }
+
+    /// Get a reference to all instructions.
+    #[inline]
+    pub fn instructions(&self) -> &[AirInst] {
+        &self.instructions
+    }
+
+    /// Rewrite the data of an instruction at a given index.
+    ///
+    /// This is used by the specialization pass to rewrite `CallGeneric` to `Call`.
+    /// The type and span are preserved.
+    pub fn rewrite_inst_data(&mut self, index: usize, new_data: AirInstData) {
+        self.instructions[index].data = new_data;
+    }
 }
 
 /// A single AIR instruction.
@@ -404,6 +418,12 @@ pub enum AirInstData {
 
     /// Unit constant
     UnitConst,
+
+    /// Type constant - a compile-time type value.
+    /// This is used for comptime type parameters (e.g., passing `i32` to `fn foo(comptime T: type)`).
+    /// The contained Type is the type being passed as a value.
+    /// This instruction has type `Type::ComptimeType` and is erased during specialization.
+    TypeConst(crate::Type),
 
     // Binary arithmetic operations
     /// Addition
@@ -529,6 +549,27 @@ pub enum AirInstData {
         /// Start index into extra array for arguments
         args_start: u32,
         /// Number of arguments
+        args_len: u32,
+    },
+
+    /// Generic function call - requires specialization before codegen.
+    ///
+    /// This is emitted when calling a function with `comptime T: type` parameters.
+    /// During a post-analysis specialization pass, this is rewritten to a regular
+    /// `Call` to a specialized version of the function (e.g., `identity__i32`).
+    ///
+    /// The type_args are encoded in the extra array as raw Type discriminant values.
+    /// The runtime args (non-comptime) are also in the extra array, after type_args.
+    CallGeneric {
+        /// Base function name (interned symbol)
+        name: Spur,
+        /// Start index into extra array for type arguments (raw Type values)
+        type_args_start: u32,
+        /// Number of type arguments
+        type_args_len: u32,
+        /// Start index into extra array for runtime arguments
+        args_start: u32,
+        /// Number of runtime arguments
         args_len: u32,
     },
 
@@ -722,6 +763,7 @@ impl fmt::Display for Air {
                 AirInstData::BoolConst(v) => writeln!(f, "const {}", v)?,
                 AirInstData::StringConst(idx) => writeln!(f, "string_const @{}", idx)?,
                 AirInstData::UnitConst => writeln!(f, "const ()")?,
+                AirInstData::TypeConst(ty) => writeln!(f, "type_const {}", ty.name())?,
                 AirInstData::Add(lhs, rhs) => writeln!(f, "add {}, {}", lhs, rhs)?,
                 AirInstData::Sub(lhs, rhs) => writeln!(f, "sub {}, {}", lhs, rhs)?,
                 AirInstData::Mul(lhs, rhs) => writeln!(f, "mul {}, {}", lhs, rhs)?,
@@ -801,6 +843,32 @@ impl fmt::Display for Air {
                     args_len,
                 } => {
                     write!(f, "call @{}(", name.into_usize())?;
+                    for (i, arg) in self.get_call_args(*args_start, *args_len).enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", arg)?;
+                    }
+                    writeln!(f, ")")?;
+                }
+                AirInstData::CallGeneric {
+                    name,
+                    type_args_start,
+                    type_args_len,
+                    args_start,
+                    args_len,
+                } => {
+                    write!(f, "call_generic @{}<", name.into_usize())?;
+                    // Show type arguments
+                    for i in 0..*type_args_len {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        let type_val = self.extra[(*type_args_start + i) as usize];
+                        write!(f, "type#{}", type_val)?;
+                    }
+                    write!(f, ">(")?;
+                    // Show runtime arguments
                     for (i, arg) in self.get_call_args(*args_start, *args_len).enumerate() {
                         if i > 0 {
                             write!(f, ", ")?;

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -539,6 +539,8 @@ impl TypeInternPool {
             // to find the interned type. This conversion is not straightforward
             // without additional context. Return None to indicate we can't convert.
             Type::Struct(_) | Type::Enum(_) | Type::Array(_) => None,
+            // ComptimeType is a comptime-only type, cannot be interned for runtime
+            Type::ComptimeType => None,
         }
     }
 

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -18,6 +18,7 @@ mod intern_pool;
 mod scope;
 mod sema;
 mod sema_context;
+pub mod specialize;
 mod type_context;
 mod types;
 

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -64,7 +64,8 @@ fn try_evaluate_const_in_rir(rir: &rue_rir::Rir, inst_ref: InstRef) -> Option<Co
         InstData::Neg { operand } => {
             match try_evaluate_const_in_rir(rir, *operand)? {
                 ConstValue::Integer(n) => n.checked_neg().map(ConstValue::Integer),
-                ConstValue::Bool(_) => None, // Can't negate a boolean
+                // Can't negate a boolean, type, or unit
+                ConstValue::Bool(_) | ConstValue::Type(_) | ConstValue::Unit => None,
             }
         }
 
@@ -72,7 +73,8 @@ fn try_evaluate_const_in_rir(rir: &rue_rir::Rir, inst_ref: InstRef) -> Option<Co
         InstData::Not { operand } => {
             match try_evaluate_const_in_rir(rir, *operand)? {
                 ConstValue::Bool(b) => Some(ConstValue::Bool(!b)),
-                ConstValue::Integer(_) => None, // Can't logical-NOT an integer
+                // Can't logical-NOT an integer, type, or unit
+                ConstValue::Integer(_) | ConstValue::Type(_) | ConstValue::Unit => None,
             }
         }
 
@@ -293,7 +295,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
         }
     }
 
-    // Analyze regular functions
+    // Analyze regular functions (skip generic functions - they're analyzed during specialization)
     for (inst_ref, inst) in sema.rir.iter() {
         if let InstData::FnDecl {
             name,
@@ -307,6 +309,13 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
         {
             if method_refs.contains(&inst_ref) {
                 continue;
+            }
+
+            // Skip generic functions - they'll be analyzed during specialization
+            if let Some(fn_info) = sema.functions.get(name) {
+                if fn_info.is_generic {
+                    continue;
+                }
             }
 
             let fn_name = sema.interner.resolve(&*name).to_string();
@@ -459,7 +468,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
 
     all_warnings.sort_by_key(|w| w.span().map(|s| s.start));
 
-    errors.into_result_with(SemaOutput {
+    let mut output = SemaOutput {
         functions,
         struct_defs: std::mem::take(&mut sema.struct_defs),
         enum_defs: std::mem::take(&mut sema.enum_defs),
@@ -467,7 +476,15 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
         strings: global_strings,
         warnings: all_warnings,
         type_pool: sema.type_pool.clone(),
-    })
+    };
+
+    // Run specialization pass to rewrite CallGeneric instructions to Call
+    // and create specialized function bodies
+    if let Err(e) = crate::specialize::specialize(&mut output, sema, &infer_ctx, sema.interner) {
+        errors.push(e);
+    }
+
+    errors.into_result_with(output)
 }
 
 /// Parallel analysis path (work in progress).
@@ -522,7 +539,7 @@ fn collect_function_jobs(ctx: &SemaContext<'_>) -> Vec<FunctionJob> {
         }
     }
 
-    // Collect regular functions
+    // Collect regular functions (skip generic functions - they're analyzed during specialization)
     for (inst_ref, inst) in ctx.rir.iter() {
         if let InstData::FnDecl {
             name,
@@ -536,6 +553,13 @@ fn collect_function_jobs(ctx: &SemaContext<'_>) -> Vec<FunctionJob> {
         {
             if method_refs.contains(&inst_ref) {
                 continue;
+            }
+
+            // Skip generic functions - they'll be analyzed during specialization
+            if let Some(fn_info) = ctx.functions.get(name) {
+                if fn_info.is_generic {
+                    continue;
+                }
             }
 
             let fn_name = ctx.interner.resolve(&*name).to_string();
@@ -756,6 +780,8 @@ fn resolve_type_from_ctx(ctx: &SemaContext<'_>, type_sym: Spur, span: Span) -> C
         "bool" => return Ok(Type::Bool),
         "()" => return Ok(Type::Unit),
         "!" => return Ok(Type::Never),
+        // The type of types - used for comptime type parameters
+        "type" => return Ok(Type::ComptimeType),
         _ => {}
     }
 
@@ -1672,6 +1698,26 @@ fn analyze_inst_with_context(
                     });
                     Ok(AnalysisResult::new(air_ref, ty))
                 }
+                Some(ConstValue::Type(_type_val)) => {
+                    // Type values can only exist at comptime - they cannot be returned
+                    // from a comptime block since they can't exist at runtime.
+                    // This will be used for type parameter substitution in specialization.
+                    Err(CompileError::new(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason: "type values cannot exist at runtime".to_string(),
+                        },
+                        inst.span,
+                    ))
+                }
+                Some(ConstValue::Unit) => {
+                    let ty = Type::Unit;
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::UnitConst,
+                        ty,
+                        span: inst.span,
+                    });
+                    Ok(AnalysisResult::new(air_ref, ty))
+                }
                 None => {
                     // The expression couldn't be evaluated at compile time
                     Err(CompileError::new(
@@ -1684,6 +1730,17 @@ fn analyze_inst_with_context(
                     ))
                 }
             }
+        }
+
+        InstData::TypeConst { type_name } => {
+            // Resolve the type name to a concrete type
+            let ty = resolve_type_from_ctx(ctx, *type_name, inst.span)?;
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::TypeConst(ty),
+                ty: Type::ComptimeType,
+                span: inst.span,
+            });
+            Ok(AnalysisResult::new(air_ref, Type::ComptimeType))
         }
     }
 }
@@ -2033,7 +2090,7 @@ fn analyze_var_ref_ctx(
         // Handle move semantics based on parameter mode
         if !ctx.is_type_copy(ty) {
             match param_info.mode {
-                RirParamMode::Normal => {
+                RirParamMode::Normal | RirParamMode::Comptime => {
                     analysis_ctx
                         .moved_vars
                         .entry(name)
@@ -2244,7 +2301,7 @@ fn analyze_assign_ctx(
     if let Some(param_info) = analysis_ctx.params.get(&name) {
         // Check parameter mode - only inout can be assigned to
         match param_info.mode {
-            RirParamMode::Normal => {
+            RirParamMode::Normal | RirParamMode::Comptime => {
                 return Err(CompileError::new(
                     ErrorKind::AssignToImmutable(name_str.to_string()),
                     span,
@@ -3331,7 +3388,7 @@ fn analyze_field_set_ctx(
         }
         RootKind::Param { abi_slot, mode } => {
             match mode {
-                RirParamMode::Normal => {
+                RirParamMode::Normal | RirParamMode::Comptime => {
                     return Err(CompileError::new(
                         ErrorKind::AssignToImmutable(var_name.clone()),
                         span,
@@ -3700,7 +3757,7 @@ fn analyze_index_set_ctx(
         }
         IndexSetRootKind::Param { abi_slot, mode } => {
             let is_inout = match mode {
-                RirParamMode::Normal => false,
+                RirParamMode::Normal | RirParamMode::Comptime => false,
                 RirParamMode::Inout => true,
                 RirParamMode::Borrow => {
                     return Err(CompileError::new(
@@ -3874,8 +3931,8 @@ fn analyze_call_ctx(
                     ));
                 }
             }
-            RirParamMode::Normal => {
-                // Normal params accept any mode
+            RirParamMode::Normal | RirParamMode::Comptime => {
+                // Normal and comptime params accept any mode
             }
         }
     }
@@ -3920,31 +3977,108 @@ fn analyze_call_ctx(
         }
     }
 
-    // Extract return_type before mutable borrow
-    let return_type = fn_info.return_type;
+    // Extract info before mutable borrow
+    let is_generic = fn_info.is_generic;
+    let param_modes = fn_info.param_modes.clone();
+    let param_names = fn_info.param_names.clone();
+    let return_type_sym = fn_info.return_type_sym;
+    let base_return_type = fn_info.return_type;
 
-    // Analyze arguments
+    // Analyze all arguments
     let air_args = analyze_call_args_ctx(ctx, air, &args, analysis_ctx)?;
 
-    // Encode call args into extra array
-    let args_len = air_args.len() as u32;
-    let mut extra_data = Vec::with_capacity(air_args.len() * 2);
-    for arg in &air_args {
-        extra_data.push(arg.value.as_u32());
-        extra_data.push(arg.mode.as_u32());
-    }
-    let args_start = air.add_extra(&extra_data);
+    // Handle generic function calls differently
+    if is_generic {
+        // Separate type arguments from runtime arguments
+        let mut type_args: Vec<Type> = Vec::new();
+        let mut runtime_args: Vec<AirCallArg> = Vec::new();
+        let mut type_subst: HashMap<Spur, Type> = HashMap::new();
 
-    let air_ref = air.add_inst(AirInst {
-        data: AirInstData::Call {
-            name,
-            args_start,
-            args_len,
-        },
-        ty: return_type,
-        span,
-    });
-    Ok(AnalysisResult::new(air_ref, return_type))
+        for (i, (air_arg, param_mode)) in air_args.iter().zip(param_modes.iter()).enumerate() {
+            if *param_mode == RirParamMode::Comptime {
+                // This should be a TypeConst instruction - extract the type
+                let inst = air.get(air_arg.value);
+                if let AirInstData::TypeConst(ty) = &inst.data {
+                    type_args.push(*ty);
+                    // Record the substitution: param_name -> concrete_type
+                    type_subst.insert(param_names[i], *ty);
+                } else {
+                    // Not a type - this is an error
+                    return Err(CompileError::new(
+                        ErrorKind::ComptimeEvaluationFailed {
+                            reason: "comptime type parameter must be a type literal".to_string(),
+                        },
+                        span,
+                    ));
+                }
+            } else {
+                runtime_args.push(air_arg.clone());
+            }
+        }
+
+        // Determine the actual return type by substituting type parameters
+        let return_type = if base_return_type == Type::ComptimeType {
+            // Return type is a type parameter - look it up in substitutions
+            *type_subst
+                .get(&return_type_sym)
+                .unwrap_or(&base_return_type)
+        } else {
+            base_return_type
+        };
+
+        // Encode type arguments into extra array (as raw Type discriminants)
+        let mut type_extra = Vec::with_capacity(type_args.len());
+        for ty in &type_args {
+            type_extra.push(ty.as_u32());
+        }
+        let type_args_start = air.add_extra(&type_extra);
+        let type_args_len = type_args.len() as u32;
+
+        // Encode runtime args into extra array
+        let mut args_extra = Vec::with_capacity(runtime_args.len() * 2);
+        for arg in &runtime_args {
+            args_extra.push(arg.value.as_u32());
+            args_extra.push(arg.mode.as_u32());
+        }
+        let runtime_args_start = air.add_extra(&args_extra);
+        let runtime_args_len = runtime_args.len() as u32;
+
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::CallGeneric {
+                name,
+                type_args_start,
+                type_args_len,
+                args_start: runtime_args_start,
+                args_len: runtime_args_len,
+            },
+            ty: return_type,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, return_type))
+    } else {
+        // Regular non-generic call
+        let return_type = base_return_type;
+
+        // Encode call args into extra array
+        let args_len = air_args.len() as u32;
+        let mut extra_data = Vec::with_capacity(air_args.len() * 2);
+        for arg in &air_args {
+            extra_data.push(arg.value.as_u32());
+            extra_data.push(arg.mode.as_u32());
+        }
+        let args_start = air.add_extra(&extra_data);
+
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Call {
+                name,
+                args_start,
+                args_len,
+            },
+            ty: return_type,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, return_type))
+    }
 }
 
 /// Check for exclusive access violations in call arguments.
@@ -4267,7 +4401,7 @@ fn get_receiver_storage_ctx(
                             span,
                         ));
                     }
-                    RirParamMode::Normal => {
+                    RirParamMode::Normal | RirParamMode::Comptime => {
                         let name_str = ctx.interner.resolve(name);
                         return Err(CompileError::new(
                             ErrorKind::AssignToImmutable(name_str.to_string()),
@@ -4931,6 +5065,27 @@ impl<'a> Sema<'a> {
         ))
     }
 
+    /// Analyze a specialized function body.
+    ///
+    /// This is similar to `analyze_function` but for generic function specialization.
+    /// The `type_subst` map provides substitutions for type parameters to their
+    /// concrete types.
+    ///
+    /// For example, when specializing `fn identity<T>(x: T) -> T { x }` with `T = i32`,
+    /// the `params` will be `[(x, i32, Normal)]` and `return_type` will be `i32`.
+    pub fn analyze_specialized_function(
+        &mut self,
+        infer_ctx: &InferenceContext,
+        return_type: Type,
+        params: &[(Spur, Type, RirParamMode)],
+        body: InstRef,
+        _type_subst: &std::collections::HashMap<Spur, Type>,
+    ) -> CompileResult<(Air, u32, u32, Vec<bool>, Vec<CompileWarning>, Vec<String>)> {
+        // The type substitution has already been applied to params and return_type,
+        // so we can just call the regular analyze_function.
+        self.analyze_function(infer_ctx, return_type, params, body)
+    }
+
     /// Run Hindley-Milner type inference on a function body.
     ///
     /// This is Phases 1-2 of the HM algorithm:
@@ -5483,6 +5638,25 @@ impl<'a> Sema<'a> {
                         });
                         Ok(AnalysisResult::new(air_ref, ty))
                     }
+                    Some(ConstValue::Type(_type_val)) => {
+                        // Type values can only exist at comptime - they cannot be returned
+                        // from a comptime block since they can't exist at runtime.
+                        Err(CompileError::new(
+                            ErrorKind::ComptimeEvaluationFailed {
+                                reason: "type values cannot exist at runtime".to_string(),
+                            },
+                            inst.span,
+                        ))
+                    }
+                    Some(ConstValue::Unit) => {
+                        let ty = Type::Unit;
+                        let air_ref = air.add_inst(AirInst {
+                            data: AirInstData::UnitConst,
+                            ty,
+                            span: inst.span,
+                        });
+                        Ok(AnalysisResult::new(air_ref, ty))
+                    }
                     None => Err(CompileError::new(
                         ErrorKind::ComptimeEvaluationFailed {
                             reason:
@@ -5492,6 +5666,18 @@ impl<'a> Sema<'a> {
                         inst.span,
                     )),
                 }
+            }
+
+            // Type constant: a type used as a value (e.g., `i32` in `identity(i32, 42)`)
+            InstData::TypeConst { type_name } => {
+                // Resolve the type name to a concrete type
+                let ty = self.resolve_type(*type_name, inst.span)?;
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::TypeConst(ty),
+                    ty: Type::ComptimeType,
+                    span: inst.span,
+                });
+                Ok(AnalysisResult::new(air_ref, Type::ComptimeType))
             }
         }
     }
@@ -5624,7 +5810,7 @@ impl<'a> Sema<'a> {
             }
             RootKind::Param { abi_slot, mode } => {
                 match mode {
-                    RirParamMode::Normal => {
+                    RirParamMode::Normal | RirParamMode::Comptime => {
                         return Err(CompileError::new(
                             ErrorKind::AssignToImmutable(var_name.clone()),
                             span,
@@ -5848,7 +6034,7 @@ impl<'a> Sema<'a> {
             }
             IndexSetRootKind::Param { abi_slot, mode } => {
                 let is_inout = match mode {
-                    RirParamMode::Normal => false,
+                    RirParamMode::Normal | RirParamMode::Comptime => false,
                     RirParamMode::Inout => true,
                     RirParamMode::Borrow => {
                         return Err(CompileError::new(
@@ -6783,7 +6969,8 @@ impl<'a> Sema<'a> {
             InstData::Neg { operand } => {
                 match self.try_evaluate_const(*operand)? {
                     ConstValue::Integer(n) => n.checked_neg().map(ConstValue::Integer),
-                    ConstValue::Bool(_) => None, // Can't negate a boolean
+                    // Can't negate a boolean, type, or unit
+                    ConstValue::Bool(_) | ConstValue::Type(_) | ConstValue::Unit => None,
                 }
             }
 
@@ -6791,7 +6978,8 @@ impl<'a> Sema<'a> {
             InstData::Not { operand } => {
                 match self.try_evaluate_const(*operand)? {
                     ConstValue::Bool(b) => Some(ConstValue::Bool(!b)),
-                    ConstValue::Integer(_) => None, // Can't logical-NOT an integer
+                    // Can't logical-NOT an integer, type, or unit
+                    ConstValue::Integer(_) | ConstValue::Type(_) | ConstValue::Unit => None,
                 }
             }
 
@@ -7243,9 +7431,8 @@ impl<'a> Sema<'a> {
                                 span,
                             ));
                         }
-                        RirParamMode::Normal => {
-                            // Normal parameters can be mutated if declared as `var`
-                            // For now, we don't allow mutation of normal params
+                        RirParamMode::Normal | RirParamMode::Comptime => {
+                            // Normal and comptime parameters are immutable
                             let name_str = self.interner.resolve(&*name);
                             return Err(CompileError::new(
                                 ErrorKind::AssignToImmutable(name_str.to_string()),

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -32,7 +32,7 @@ use rue_span::Span;
 
 use super::Sema;
 use super::context::{AnalysisContext, AnalysisResult, LocalVar};
-use crate::inst::{Air, AirInst, AirInstData, AirPattern, AirRef};
+use crate::inst::{Air, AirCallArg, AirInst, AirInstData, AirPattern, AirRef};
 use crate::scope::ScopedContext;
 use crate::types::Type;
 
@@ -1121,7 +1121,9 @@ impl<'a> Sema<'a> {
             // Handle move semantics based on parameter mode
             if !self.is_type_copy(ty) {
                 match param_info.mode {
-                    RirParamMode::Normal => {
+                    // Normal and comptime parameters behave similarly for moves
+                    // (comptime params are substituted at compile time)
+                    RirParamMode::Normal | RirParamMode::Comptime => {
                         ctx.moved_vars
                             .entry(name)
                             .or_default()
@@ -1157,42 +1159,60 @@ impl<'a> Sema<'a> {
 
         // Look up the variable in locals
         let name_str = self.interner.resolve(&name);
-        let local = ctx
-            .locals
-            .get(&name)
-            .ok_or_compile_error(ErrorKind::UndefinedVariable(name_str.to_string()), span)?;
 
-        let ty = local.ty;
-        let slot = local.slot;
+        // Check if this is a local variable first
+        if let Some(local) = ctx.locals.get(&name) {
+            let ty = local.ty;
+            let slot = local.slot;
 
-        // Check if this variable has been moved
-        if let Some(move_state) = ctx.moved_vars.get(&name) {
-            if let Some(moved_span) = move_state.is_any_part_moved() {
-                return Err(
-                    CompileError::new(ErrorKind::UseAfterMove(name_str.to_string()), span)
-                        .with_label("value moved here", moved_span),
-                );
+            // Check if this variable has been moved
+            if let Some(move_state) = ctx.moved_vars.get(&name) {
+                if let Some(moved_span) = move_state.is_any_part_moved() {
+                    return Err(CompileError::new(
+                        ErrorKind::UseAfterMove(name_str.to_string()),
+                        span,
+                    )
+                    .with_label("value moved here", moved_span));
+                }
             }
+
+            // If type is not Copy, mark as moved
+            if !self.is_type_copy(ty) {
+                ctx.moved_vars
+                    .entry(name)
+                    .or_default()
+                    .mark_path_moved(&[], span);
+            }
+
+            // Mark variable as used
+            ctx.used_locals.insert(name);
+
+            // Load the variable
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::Load { slot },
+                ty,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, ty));
         }
 
-        // If type is not Copy, mark as moved
-        if !self.is_type_copy(ty) {
-            ctx.moved_vars
-                .entry(name)
-                .or_default()
-                .mark_path_moved(&[], span);
+        // Check if this is a type name (for comptime type parameters)
+        // Try to resolve it as a type - if successful, emit a TypeConst instruction
+        if let Ok(resolved_type) = self.resolve_type(name, span) {
+            // This is a type name being used as a value (e.g., `i32` passed to `comptime T: type`)
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::TypeConst(resolved_type),
+                ty: Type::ComptimeType,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
         }
 
-        // Mark variable as used
-        ctx.used_locals.insert(name);
-
-        // Load the variable
-        let air_ref = air.add_inst(AirInst {
-            data: AirInstData::Load { slot },
-            ty,
+        // Not a parameter, local, or type - undefined variable
+        Err(CompileError::new(
+            ErrorKind::UndefinedVariable(name_str.to_string()),
             span,
-        });
-        Ok(AnalysisResult::new(air_ref, ty))
+        ))
     }
 
     /// Analyze a parameter reference.
@@ -1236,7 +1256,8 @@ impl<'a> Sema<'a> {
         if let Some(param_info) = ctx.params.get(&name) {
             // Check parameter mode - only inout can be assigned to
             match param_info.mode {
-                RirParamMode::Normal => {
+                // Normal and comptime parameters are immutable
+                RirParamMode::Normal | RirParamMode::Comptime => {
                     return Err(CompileError::new(
                         ErrorKind::AssignToImmutable(name_str.to_string()),
                         span,
@@ -1969,7 +1990,9 @@ impl<'a> Sema<'a> {
                         ));
                     }
                 }
-                RirParamMode::Normal => {
+                // Normal and comptime params accept any mode
+                // (comptime params are substituted at compile time, not passed at runtime)
+                RirParamMode::Normal | RirParamMode::Comptime => {
                     // Normal params accept any mode
                 }
             }
@@ -2004,31 +2027,110 @@ impl<'a> Sema<'a> {
             }
         }
 
-        // Extract return_type before mutable borrow (Copy type, no allocation)
-        let return_type = fn_info.return_type;
+        // Extract info before mutable borrow
+        let is_generic = fn_info.is_generic;
+        let param_modes = fn_info.param_modes.clone();
+        let param_names = fn_info.param_names.clone();
+        let return_type_sym = fn_info.return_type_sym;
+        let base_return_type = fn_info.return_type;
 
-        // Analyze arguments
+        // Analyze all arguments
         let air_args = self.analyze_call_args(air, &args, ctx)?;
 
-        // Encode call args into extra array
-        let args_len = air_args.len() as u32;
-        let mut extra_data = Vec::with_capacity(air_args.len() * 2);
-        for arg in &air_args {
-            extra_data.push(arg.value.as_u32());
-            extra_data.push(arg.mode.as_u32());
-        }
-        let args_start = air.add_extra(&extra_data);
+        // Handle generic function calls differently
+        if is_generic {
+            // Separate type arguments from runtime arguments
+            let mut type_args: Vec<Type> = Vec::new();
+            let mut runtime_args: Vec<AirCallArg> = Vec::new();
+            let mut type_subst: std::collections::HashMap<Spur, Type> =
+                std::collections::HashMap::new();
 
-        let air_ref = air.add_inst(AirInst {
-            data: AirInstData::Call {
-                name,
-                args_start,
-                args_len,
-            },
-            ty: return_type,
-            span,
-        });
-        Ok(AnalysisResult::new(air_ref, return_type))
+            for (i, (air_arg, param_mode)) in air_args.iter().zip(param_modes.iter()).enumerate() {
+                if *param_mode == RirParamMode::Comptime {
+                    // This should be a TypeConst instruction - extract the type
+                    let inst = air.get(air_arg.value);
+                    if let AirInstData::TypeConst(ty) = &inst.data {
+                        type_args.push(*ty);
+                        // Record the substitution: param_name -> concrete_type
+                        type_subst.insert(param_names[i], *ty);
+                    } else {
+                        // Not a type - this is an error
+                        return Err(CompileError::new(
+                            ErrorKind::ComptimeEvaluationFailed {
+                                reason: "comptime type parameter must be a type literal"
+                                    .to_string(),
+                            },
+                            span,
+                        ));
+                    }
+                } else {
+                    runtime_args.push(air_arg.clone());
+                }
+            }
+
+            // Determine the actual return type by substituting type parameters
+            let return_type = if base_return_type == Type::ComptimeType {
+                // Return type is a type parameter - look it up in substitutions
+                *type_subst
+                    .get(&return_type_sym)
+                    .unwrap_or(&base_return_type)
+            } else {
+                base_return_type
+            };
+
+            // Encode type arguments into extra array (as raw Type discriminants)
+            let mut type_extra = Vec::with_capacity(type_args.len());
+            for ty in &type_args {
+                type_extra.push(ty.as_u32());
+            }
+            let type_args_start = air.add_extra(&type_extra);
+            let type_args_len = type_args.len() as u32;
+
+            // Encode runtime args into extra array
+            let mut args_extra = Vec::with_capacity(runtime_args.len() * 2);
+            for arg in &runtime_args {
+                args_extra.push(arg.value.as_u32());
+                args_extra.push(arg.mode.as_u32());
+            }
+            let runtime_args_start = air.add_extra(&args_extra);
+            let runtime_args_len = runtime_args.len() as u32;
+
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::CallGeneric {
+                    name,
+                    type_args_start,
+                    type_args_len,
+                    args_start: runtime_args_start,
+                    args_len: runtime_args_len,
+                },
+                ty: return_type,
+                span,
+            });
+            Ok(AnalysisResult::new(air_ref, return_type))
+        } else {
+            // Regular non-generic call
+            let return_type = base_return_type;
+
+            // Encode call args into extra array
+            let args_len = air_args.len() as u32;
+            let mut extra_data = Vec::with_capacity(air_args.len() * 2);
+            for arg in &air_args {
+                extra_data.push(arg.value.as_u32());
+                extra_data.push(arg.mode.as_u32());
+            }
+            let args_start = air.add_extra(&extra_data);
+
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::Call {
+                    name,
+                    args_start,
+                    args_len,
+                },
+                ty: return_type,
+                span,
+            });
+            Ok(AnalysisResult::new(air_ref, return_type))
+        }
     }
 
     /// Analyze a method call.

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -355,6 +355,12 @@ pub(crate) enum ConstValue {
     Integer(i64),
     /// Boolean value
     Bool(bool),
+    /// Type value - stores a concrete type for type parameters.
+    /// This is used when a `comptime T: type` parameter is instantiated
+    /// with a specific type like `i32` or `bool`.
+    Type(Type),
+    /// Unit value - the value of `()`.
+    Unit,
 }
 
 impl ConstValue {
@@ -362,7 +368,7 @@ impl ConstValue {
     pub fn as_integer(self) -> Option<i64> {
         match self {
             ConstValue::Integer(n) => Some(n),
-            ConstValue::Bool(_) => None,
+            _ => None,
         }
     }
 
@@ -370,7 +376,30 @@ impl ConstValue {
     pub fn as_bool(self) -> Option<bool> {
         match self {
             ConstValue::Bool(b) => Some(b),
-            ConstValue::Integer(_) => None,
+            _ => None,
+        }
+    }
+
+    /// Try to extract a type value.
+    pub fn as_type(self) -> Option<Type> {
+        match self {
+            ConstValue::Type(ty) => Some(ty),
+            _ => None,
+        }
+    }
+
+    /// Check if this is a unit value.
+    pub fn is_unit(self) -> bool {
+        matches!(self, ConstValue::Unit)
+    }
+
+    /// Get the type of this constant value.
+    pub fn get_type(&self) -> Type {
+        match self {
+            ConstValue::Integer(_) => Type::I64, // Default to i64 for comptime integers
+            ConstValue::Bool(_) => Type::Bool,
+            ConstValue::Type(_) => Type::ComptimeType,
+            ConstValue::Unit => Type::Unit,
         }
     }
 }
@@ -732,6 +761,41 @@ mod tests {
         assert_eq!(ConstValue::Bool(true), ConstValue::Bool(true));
         assert_ne!(ConstValue::Bool(true), ConstValue::Bool(false));
         assert_ne!(ConstValue::Integer(1), ConstValue::Bool(true));
+    }
+
+    #[test]
+    fn const_value_as_type() {
+        let cv = ConstValue::Type(Type::I32);
+        assert_eq!(cv.as_type(), Some(Type::I32));
+        assert_eq!(cv.as_integer(), None);
+        assert_eq!(cv.as_bool(), None);
+
+        let cv2 = ConstValue::Type(Type::Bool);
+        assert_eq!(cv2.as_type(), Some(Type::Bool));
+    }
+
+    #[test]
+    fn const_value_unit() {
+        let cv = ConstValue::Unit;
+        assert!(cv.is_unit());
+        assert_eq!(cv.as_integer(), None);
+        assert_eq!(cv.as_bool(), None);
+        assert_eq!(cv.as_type(), None);
+    }
+
+    #[test]
+    fn const_value_get_type() {
+        assert_eq!(ConstValue::Integer(42).get_type(), Type::I64);
+        assert_eq!(ConstValue::Bool(true).get_type(), Type::Bool);
+        assert_eq!(ConstValue::Type(Type::I32).get_type(), Type::ComptimeType);
+        assert_eq!(ConstValue::Unit.get_type(), Type::Unit);
+    }
+
+    #[test]
+    fn const_value_type_equality() {
+        assert_eq!(ConstValue::Type(Type::I32), ConstValue::Type(Type::I32));
+        assert_ne!(ConstValue::Type(Type::I32), ConstValue::Type(Type::I64));
+        assert_ne!(ConstValue::Type(Type::I32), ConstValue::Integer(32));
     }
 
     // =========================================================================

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -16,7 +16,7 @@ use rue_builtins::is_reserved_type_name;
 use rue_error::{
     CompileError, CompileResult, CopyStructNonCopyFieldError, ErrorKind, PreviewFeature,
 };
-use rue_rir::{InstData, RirDirective, RirParamMode};
+use rue_rir::{InstData, InstRef, RirDirective, RirParamMode};
 use rue_span::Span;
 
 use super::{FunctionInfo, InferenceContext, MethodInfo, Sema};
@@ -98,6 +98,10 @@ impl<'a> Sema<'a> {
                             .map(|t| self.type_to_infer_type(*t))
                             .collect(),
                         return_type: self.type_to_infer_type(info.return_type),
+                        is_generic: info.is_generic,
+                        param_modes: info.param_modes.clone(),
+                        param_names: info.param_names.clone(),
+                        return_type_sym: info.return_type_sym,
                     },
                 )
             })
@@ -449,6 +453,7 @@ impl<'a> Sema<'a> {
                     params_start,
                     params_len,
                     return_type,
+                    body,
                     ..
                 } => {
                     // pub visibility requires preview feature
@@ -465,6 +470,7 @@ impl<'a> Sema<'a> {
                         *params_start,
                         *params_len,
                         *return_type,
+                        *body,
                         inst.span,
                     )?;
                 }
@@ -692,10 +698,10 @@ impl<'a> Sema<'a> {
         name: Spur,
         params_start: u32,
         params_len: u32,
-        return_type: Spur,
+        return_type_sym: Spur,
+        body: InstRef,
         span: Span,
     ) -> CompileResult<()> {
-        let ret_type = self.resolve_type(return_type, span)?;
         let params = self.rir.get_params(params_start, params_len);
 
         // Check if any parameter is comptime and gate behind preview feature
@@ -704,13 +710,46 @@ impl<'a> Sema<'a> {
             self.require_preview(PreviewFeature::Comptime, "comptime parameters", span)?;
         }
 
-        let param_names: Vec<_> = params.iter().map(|p| p.name).collect();
+        let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
+        let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
+
+        // Check if this function has any comptime type parameters
+        let is_generic = params.iter().any(|p| p.mode == RirParamMode::Comptime);
+
+        // Collect type parameter names (comptime parameters whose type is `type`)
+        let type_param_names: Vec<Spur> = params
+            .iter()
+            .filter(|p| p.mode == RirParamMode::Comptime)
+            .map(|p| p.name)
+            .collect();
+
+        // For generic functions, we defer type resolution of type parameters until specialization.
+        // We use Type::ComptimeType as a placeholder for comptime T: type parameters.
         let param_types: Vec<Type> = params
             .iter()
-            .map(|p| self.resolve_type(p.ty, span))
+            .map(|p| {
+                if p.mode == RirParamMode::Comptime {
+                    // For comptime type parameters, the type is `type` (represented by ComptimeType)
+                    Ok(Type::ComptimeType)
+                } else if type_param_names.contains(&p.ty) {
+                    // This parameter's type is a type parameter (e.g., `x: T` where T is comptime)
+                    // Use ComptimeType as a placeholder - actual type determined at specialization
+                    Ok(Type::ComptimeType)
+                } else {
+                    self.resolve_type(p.ty, span)
+                }
+            })
             .collect::<CompileResult<Vec<_>>>()?;
-        let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
         let param_comptime: Vec<bool> = params.iter().map(|p| p.is_comptime).collect();
+
+        // For generic functions, we can't resolve the return type yet if it references
+        // a type parameter. For now, check if it matches any type parameter name.
+        let ret_type = if type_param_names.contains(&return_type_sym) {
+            // Return type is a type parameter - use placeholder
+            Type::ComptimeType
+        } else {
+            self.resolve_type(return_type_sym, span)?
+        };
 
         self.functions.insert(
             name,
@@ -720,6 +759,10 @@ impl<'a> Sema<'a> {
                 param_modes,
                 param_comptime,
                 return_type: ret_type,
+                return_type_sym,
+                body,
+                span,
+                is_generic,
             },
         );
         Ok(())

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -206,8 +206,8 @@ pub struct InferenceContext {
 /// Information about a function.
 #[derive(Debug, Clone)]
 pub struct FunctionInfo {
-    /// Parameter names (in order)
-    pub param_names: Vec<lasso::Spur>,
+    /// Parameter names (in order) - needed for generic function specialization
+    pub param_names: Vec<Spur>,
     /// Parameter types (in order)
     pub param_types: Vec<Type>,
     /// Parameter modes (in order)
@@ -216,6 +216,14 @@ pub struct FunctionInfo {
     pub param_comptime: Vec<bool>,
     /// Return type
     pub return_type: Type,
+    /// The return type symbol (before resolution) - needed for generic function specialization
+    pub return_type_sym: Spur,
+    /// The RIR instruction ref for the function body - needed for generic function specialization
+    pub body: rue_rir::InstRef,
+    /// Span of the function declaration
+    pub span: rue_span::Span,
+    /// Whether this function has any comptime type parameters
+    pub is_generic: bool,
 }
 
 /// Information about a method in an impl block.
@@ -484,6 +492,10 @@ impl<'a> Sema<'a> {
                             .map(|t| self.type_to_infer_type(*t))
                             .collect(),
                         return_type: self.type_to_infer_type(info.return_type),
+                        is_generic: info.is_generic,
+                        param_modes: info.param_modes.clone(),
+                        param_names: info.param_names.clone(),
+                        return_type_sym: info.return_type_sym,
                     },
                 )
             })

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -41,6 +41,7 @@ impl<'a> Sema<'a> {
                     array_def.length
                 )
             }
+            Type::ComptimeType => "type".to_string(),
         }
     }
 
@@ -75,6 +76,8 @@ impl<'a> Sema<'a> {
                 let array_def = &self.array_type_defs[array_id.0 as usize];
                 self.is_type_copy(array_def.element_type)
             }
+            // ComptimeType is Copy (only exists at comptime anyway)
+            Type::ComptimeType => true,
         }
     }
 
@@ -138,6 +141,8 @@ impl<'a> Sema<'a> {
             "bool" => return Ok(Type::Bool),
             "()" => return Ok(Type::Unit),
             "!" => return Ok(Type::Never),
+            // The type of types - used for comptime type parameters
+            "type" => return Ok(Type::ComptimeType),
             _ => {}
         }
 
@@ -259,7 +264,8 @@ impl<'a> Sema<'a> {
             | Type::Bool
             | Type::Error => 1,
             // Zero-sized types use 0 slots
-            Type::Unit | Type::Never => 0,
+            // ComptimeType is comptime-only and uses 0 runtime slots
+            Type::Unit | Type::Never | Type::ComptimeType => 0,
             // Enums are represented as their discriminant type (a scalar), so 1 slot
             Type::Enum(_) => 1,
             // Struct uses sum of all field slots (includes builtin String with 3 fields)

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -323,6 +323,7 @@ impl<'a> SemaContext<'a> {
                     array_def.length
                 )
             }
+            Type::ComptimeType => "type".to_string(),
         }
     }
 
@@ -342,8 +343,8 @@ impl<'a> SemaContext<'a> {
             | Type::Unit => true,
             // Enum types are Copy (they're small discriminant values)
             Type::Enum(_) => true,
-            // Never and Error are Copy for convenience
-            Type::Never | Type::Error => true,
+            // Never, Error, and ComptimeType are Copy for convenience
+            Type::Never | Type::Error | Type::ComptimeType => true,
             // Struct types: check if marked with @copy
             Type::Struct(struct_id) => {
                 let struct_def = &self.struct_defs[struct_id.0 as usize];
@@ -370,7 +371,8 @@ impl<'a> SemaContext<'a> {
             | Type::U64
             | Type::Bool
             | Type::Error => 1,
-            Type::Unit | Type::Never => 0,
+            // Zero-sized types (including comptime-only)
+            Type::Unit | Type::Never | Type::ComptimeType => 0,
             Type::Enum(_) => 1,
             Type::Struct(struct_id) => {
                 let struct_def = &self.struct_defs[struct_id.0 as usize];

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -1,0 +1,296 @@
+//! Generic function specialization pass.
+//!
+//! This module provides the specialization pass that transforms `CallGeneric`
+//! instructions into regular `Call` instructions by:
+//!
+//! 1. Collecting all `CallGeneric` instructions in the analyzed functions
+//! 2. For each unique (func_name, type_args) combination, creating a specialized function
+//! 3. Rewriting `CallGeneric` to `Call` with the specialized function name
+//!
+//! # Architecture
+//!
+//! The specialization pass runs after semantic analysis but before CFG building.
+//! It transforms the AIR in-place and adds new specialized functions to the output.
+
+use std::collections::HashMap;
+
+use lasso::{Spur, ThreadedRodeo};
+use rue_error::CompileResult;
+use rue_rir::RirParamMode;
+
+use crate::inst::{Air, AirInstData};
+use crate::sema::{AnalyzedFunction, FunctionInfo, InferenceContext, Sema, SemaOutput};
+use crate::types::Type;
+
+/// A key for a specialized function: (base_function_name, type_arguments).
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct SpecializationKey {
+    /// Base function name (e.g., "identity")
+    pub base_name: Spur,
+    /// Type arguments (e.g., [Type::I32])
+    pub type_args: Vec<Type>,
+}
+
+/// Perform the specialization pass on the sema output.
+///
+/// This collects all `CallGeneric` instructions, creates specialized functions,
+/// and rewrites calls to point to the specialized versions.
+pub fn specialize(
+    output: &mut SemaOutput,
+    sema: &mut Sema<'_>,
+    infer_ctx: &InferenceContext,
+    interner: &ThreadedRodeo,
+) -> CompileResult<()> {
+    // Phase 1: Collect all specialization requests
+    let mut specializations: HashMap<SpecializationKey, Spur> = HashMap::new();
+
+    for func in &output.functions {
+        collect_specializations(&func.air, interner, &mut specializations);
+    }
+
+    if specializations.is_empty() {
+        // No generic calls, nothing to do
+        return Ok(());
+    }
+
+    // Phase 2: Rewrite CallGeneric to Call in all functions
+    for func in &mut output.functions {
+        rewrite_call_generic(&mut func.air, &specializations);
+    }
+
+    // Phase 3: Create specialized function bodies by re-analyzing with type substitution
+    for (key, specialized_name) in &specializations {
+        let base_info = sema
+            .functions
+            .get(&key.base_name)
+            .expect("function must exist")
+            .clone();
+        let specialized_func = create_specialized_function(
+            sema,
+            infer_ctx,
+            key,
+            *specialized_name,
+            &base_info,
+            interner,
+        )?;
+        output.functions.push(specialized_func);
+    }
+
+    Ok(())
+}
+
+/// Collect all specializations needed from a function's AIR.
+fn collect_specializations(
+    air: &Air,
+    interner: &ThreadedRodeo,
+    specializations: &mut HashMap<SpecializationKey, Spur>,
+) {
+    for inst in air.instructions() {
+        if let AirInstData::CallGeneric {
+            name,
+            type_args_start,
+            type_args_len,
+            ..
+        } = &inst.data
+        {
+            // Extract type arguments using the public accessor
+            let type_args: Vec<Type> = air
+                .get_extra(*type_args_start, *type_args_len)
+                .iter()
+                .map(|&encoded| Type::from_u32(encoded))
+                .collect();
+
+            let key = SpecializationKey {
+                base_name: *name,
+                type_args: type_args.clone(),
+            };
+
+            if !specializations.contains_key(&key) {
+                // Generate a mangled name for the specialized function
+                let base_name = interner.resolve(name);
+                let mangled = mangle_specialized_name(base_name, &type_args);
+                let mangled_sym = interner.get_or_intern(&mangled);
+                specializations.insert(key, mangled_sym);
+            }
+        }
+    }
+}
+
+/// Rewrite CallGeneric instructions to Call instructions.
+fn rewrite_call_generic(air: &mut Air, specializations: &HashMap<SpecializationKey, Spur>) {
+    // We need to collect the rewrites first, then apply them.
+    // This avoids borrowing issues with the extra array.
+    let mut rewrites: Vec<(usize, AirInstData)> = Vec::new();
+
+    for (i, inst) in air.instructions().iter().enumerate() {
+        if let AirInstData::CallGeneric {
+            name,
+            type_args_start,
+            type_args_len,
+            args_start,
+            args_len,
+        } = &inst.data
+        {
+            // Extract type arguments to form the key
+            let type_args: Vec<Type> = air
+                .get_extra(*type_args_start, *type_args_len)
+                .iter()
+                .map(|&encoded| Type::from_u32(encoded))
+                .collect();
+
+            let key = SpecializationKey {
+                base_name: *name,
+                type_args,
+            };
+
+            if let Some(&specialized_name) = specializations.get(&key) {
+                // Rewrite to a regular Call
+                let new_data = AirInstData::Call {
+                    name: specialized_name,
+                    args_start: *args_start,
+                    args_len: *args_len,
+                };
+                rewrites.push((i, new_data));
+            }
+        }
+    }
+
+    // Apply all rewrites
+    for (index, new_data) in rewrites {
+        air.rewrite_inst_data(index, new_data);
+    }
+}
+
+/// Generate a mangled name for a specialized function.
+fn mangle_specialized_name(base_name: &str, type_args: &[Type]) -> String {
+    let mut mangled = base_name.to_string();
+    for ty in type_args {
+        mangled.push_str("__");
+        mangled.push_str(ty.name());
+    }
+    mangled
+}
+
+/// Create a specialized function by re-analyzing the body with type substitution.
+///
+/// This builds a type substitution map from the comptime parameters to their concrete
+/// type arguments, then re-analyzes the function body with these substitutions.
+fn create_specialized_function(
+    sema: &mut Sema<'_>,
+    infer_ctx: &InferenceContext,
+    key: &SpecializationKey,
+    specialized_name: Spur,
+    base_info: &FunctionInfo,
+    interner: &ThreadedRodeo,
+) -> CompileResult<AnalyzedFunction> {
+    let specialized_name_str = interner.resolve(&specialized_name).to_string();
+
+    // Build the type substitution map: comptime param name -> concrete Type
+    let mut type_subst: HashMap<Spur, Type> = HashMap::new();
+    let mut type_arg_idx = 0;
+    for (i, param_mode) in base_info.param_modes.iter().enumerate() {
+        if *param_mode == RirParamMode::Comptime {
+            if type_arg_idx < key.type_args.len() {
+                type_subst.insert(base_info.param_names[i], key.type_args[type_arg_idx]);
+                type_arg_idx += 1;
+            }
+        }
+    }
+
+    // Calculate the return type by substituting type parameters
+    let return_type = if base_info.return_type == Type::ComptimeType {
+        // The return type references a type parameter - substitute it
+        type_subst
+            .get(&base_info.return_type_sym)
+            .copied()
+            .unwrap_or(Type::Unit)
+    } else {
+        base_info.return_type
+    };
+
+    // Build the specialized parameter list by:
+    // 1. Filtering out comptime parameters (they're erased at runtime)
+    // 2. Substituting type parameters in non-comptime parameter types
+    let specialized_params: Vec<(Spur, Type, RirParamMode)> = base_info
+        .param_names
+        .iter()
+        .zip(base_info.param_types.iter())
+        .zip(base_info.param_modes.iter())
+        .filter(|((_, _), mode)| **mode != RirParamMode::Comptime)
+        .map(|((name, ty), mode)| {
+            // If the type is ComptimeType, look it up in the substitution map
+            // The param name's type symbol is stored in param_types as ComptimeType,
+            // but we need to find which type param it references.
+            // For now, we'll need to look at the original RIR to get the type name.
+            let concrete_ty = if *ty == Type::ComptimeType {
+                // This parameter's type is a type parameter. We need to find which one.
+                // The type name in RIR is stored in the param's ty field as a Spur.
+                // Unfortunately, we've lost that information by this point.
+                // We need to look at the original function in RIR.
+                substitute_param_type(sema, base_info, *name, &type_subst).unwrap_or(*ty)
+            } else {
+                *ty
+            };
+            (*name, concrete_ty, *mode)
+        })
+        .collect();
+
+    // Now analyze the function body with the specialized types
+    let (air, num_locals, num_param_slots, param_modes, _warnings, _local_strings) = sema
+        .analyze_specialized_function(
+            infer_ctx,
+            return_type,
+            &specialized_params,
+            base_info.body,
+            &type_subst,
+        )?;
+
+    Ok(AnalyzedFunction {
+        name: specialized_name_str,
+        air,
+        num_locals,
+        num_param_slots,
+        param_modes,
+    })
+}
+
+/// Substitute a parameter's type using the type substitution map.
+///
+/// This looks up the parameter's type symbol in the original RIR function
+/// and substitutes it with the concrete type if it's a type parameter.
+fn substitute_param_type(
+    sema: &Sema<'_>,
+    base_info: &FunctionInfo,
+    param_name: Spur,
+    type_subst: &HashMap<Spur, Type>,
+) -> Option<Type> {
+    // Get the original RIR function to find the type symbol for this param
+    let fn_inst = sema.rir.get(base_info.body);
+
+    // Walk up to find the FnDecl that contains this body
+    for (_, inst) in sema.rir.iter() {
+        if let rue_rir::InstData::FnDecl {
+            body,
+            params_start,
+            params_len,
+            ..
+        } = &inst.data
+        {
+            if *body == base_info.body {
+                // Found the function declaration
+                let params = sema.rir.get_params(*params_start, *params_len);
+                for param in params {
+                    if param.name == param_name {
+                        // Found the parameter - get its type symbol
+                        // If the type symbol is in our substitution map, use that
+                        if let Some(&concrete_ty) = type_subst.get(&param.ty) {
+                            return Some(concrete_ty);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    None
+}

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -50,6 +50,10 @@ pub enum Type {
     /// The never type - represents computations that don't return (e.g., break, continue).
     /// Can coerce to any other type.
     Never,
+    /// The comptime type - the type of types themselves.
+    /// Values of this type are types (e.g., `i32`, `bool`, `MyStruct`).
+    /// This is a comptime-only type; it cannot exist at runtime.
+    ComptimeType,
 }
 
 /// Definition of a struct type.
@@ -175,6 +179,7 @@ impl Type {
             Type::Array(_) => "<array>",
             Type::Error => "<error>",
             Type::Never => "!",
+            Type::ComptimeType => "type",
         }
     }
 
@@ -201,6 +206,11 @@ impl Type {
     /// Check if this is the never type.
     pub fn is_never(&self) -> bool {
         matches!(self, Type::Never)
+    }
+
+    /// Check if this is the comptime type (the type of types).
+    pub fn is_comptime_type(&self) -> bool {
+        matches!(self, Type::ComptimeType)
     }
 
     /// Check if this is a struct type.
@@ -278,8 +288,9 @@ impl Type {
             | Type::Unit => true,
             // Enum types are Copy (they're small discriminant values)
             Type::Enum(_) => true,
-            // Never and Error are Copy for convenience
-            Type::Never | Type::Error => true,
+            // Never, Error, and ComptimeType are Copy for convenience
+            // (ComptimeType only exists at comptime anyway)
+            Type::Never | Type::Error | Type::ComptimeType => true,
             // Struct types are move types by default (may be @copy, but need StructDef to check)
             Type::Struct(_) => false,
             // Arrays may be Copy if element type is Copy (need ArrayTypeDef to check)
@@ -342,6 +353,65 @@ impl Type {
             Type::I32 => value <= (i32::MIN as i64).unsigned_abs(),
             Type::I64 => value <= (i64::MIN).unsigned_abs(),
             _ => false,
+        }
+    }
+
+    /// Encode this type as a u32 for storage in extra arrays.
+    ///
+    /// This uses a tag-value encoding:
+    /// - Primitive types (I8..ComptimeType): tag = discriminant, no additional data
+    /// - Struct(id): tag = 100, followed by id
+    /// - Enum(id): tag = 101, followed by id
+    /// - Array(id): tag = 102, followed by id
+    ///
+    /// Note: For compound types, caller must encode additional data separately.
+    /// This method returns the tag only.
+    pub fn as_u32(&self) -> u32 {
+        match self {
+            Type::I8 => 0,
+            Type::I16 => 1,
+            Type::I32 => 2,
+            Type::I64 => 3,
+            Type::U8 => 4,
+            Type::U16 => 5,
+            Type::U32 => 6,
+            Type::U64 => 7,
+            Type::Bool => 8,
+            Type::Unit => 9,
+            Type::Error => 10,
+            Type::Never => 11,
+            Type::ComptimeType => 12,
+            // Compound types need special handling - store ID in high bits
+            Type::Struct(id) => 100 | ((id.0 as u32) << 8),
+            Type::Enum(id) => 101 | ((id.0 as u32) << 8),
+            Type::Array(id) => 102 | ((id.0 as u32) << 8),
+        }
+    }
+
+    /// Decode a type from a u32 value.
+    ///
+    /// This reverses the encoding done by `as_u32`.
+    pub fn from_u32(v: u32) -> Self {
+        let tag = v & 0xFF;
+        let id = (v >> 8) as u32;
+        match tag {
+            0 => Type::I8,
+            1 => Type::I16,
+            2 => Type::I32,
+            3 => Type::I64,
+            4 => Type::U8,
+            5 => Type::U16,
+            6 => Type::U32,
+            7 => Type::U64,
+            8 => Type::Bool,
+            9 => Type::Unit,
+            10 => Type::Error,
+            11 => Type::Never,
+            12 => Type::ComptimeType,
+            100 => Type::Struct(StructId(id)),
+            101 => Type::Enum(EnumId(id)),
+            102 => Type::Array(ArrayTypeId(id)),
+            _ => panic!("invalid Type encoding: {}", v),
         }
     }
 }
@@ -944,5 +1014,50 @@ mod tests {
             variants: (0..257).map(|i| format!("V{}", i)).collect(),
         };
         assert_eq!(medium.discriminant_type(), Type::U16);
+    }
+
+    // ========== Type::ComptimeType tests ==========
+
+    #[test]
+    fn test_comptime_type_name() {
+        assert_eq!(Type::ComptimeType.name(), "type");
+    }
+
+    #[test]
+    fn test_comptime_type_is_copy() {
+        assert!(Type::ComptimeType.is_copy());
+    }
+
+    #[test]
+    fn test_comptime_type_is_comptime_type() {
+        assert!(Type::ComptimeType.is_comptime_type());
+        assert!(!Type::I32.is_comptime_type());
+        assert!(!Type::Bool.is_comptime_type());
+    }
+
+    #[test]
+    fn test_comptime_type_not_integer() {
+        assert!(!Type::ComptimeType.is_integer());
+    }
+
+    #[test]
+    fn test_comptime_type_not_signed() {
+        assert!(!Type::ComptimeType.is_signed());
+    }
+
+    #[test]
+    fn test_comptime_type_not_64_bit() {
+        assert!(!Type::ComptimeType.is_64_bit());
+    }
+
+    #[test]
+    fn test_comptime_type_can_coerce_to_itself() {
+        assert!(Type::ComptimeType.can_coerce_to(&Type::ComptimeType));
+    }
+
+    #[test]
+    fn test_comptime_type_cannot_coerce_to_runtime_types() {
+        assert!(!Type::ComptimeType.can_coerce_to(&Type::I32));
+        assert!(!Type::ComptimeType.can_coerce_to(&Type::Bool));
     }
 }

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -185,6 +185,26 @@ impl<'a> CfgBuilder<'a> {
                 }
             }
 
+            AirInstData::TypeConst(_) => {
+                // TypeConst instructions are compile-time-only and should be erased
+                // during specialization. If we reach here, it means a TypeConst
+                // was not properly substituted - this is a compiler bug.
+                panic!(
+                    "TypeConst instruction reached CFG building - this is a compiler bug. \
+                     TypeConst should only appear as arguments to generic functions and \
+                     be erased during specialization."
+                );
+            }
+
+            AirInstData::CallGeneric { .. } => {
+                // CallGeneric instructions must be specialized (rewritten to Call)
+                // before CFG building. If we reach here, specialization didn't run.
+                panic!(
+                    "CallGeneric instruction reached CFG building - this is a compiler bug. \
+                     CallGeneric must be specialized to regular Call before codegen."
+                );
+            }
+
             AirInstData::Param { index } => {
                 let value = self.emit(CfgInstData::Param { index: *index }, ty, span);
                 self.cache(air_ref, value);
@@ -1700,6 +1720,7 @@ impl<'a> CfgBuilder<'a> {
     fn type_needs_drop(&self, ty: Type) -> bool {
         match ty {
             // Primitive types are trivially droppable
+            // ComptimeType is a comptime-only type and has no runtime representation
             Type::I8
             | Type::I16
             | Type::I32
@@ -1711,7 +1732,8 @@ impl<'a> CfgBuilder<'a> {
             | Type::Bool
             | Type::Unit
             | Type::Never
-            | Type::Error => false,
+            | Type::Error
+            | Type::ComptimeType => false,
 
             // Enum types are trivially droppable (just discriminant values)
             Type::Enum(_) => false,

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -226,6 +226,8 @@ fn type_name(ty: Type, struct_defs: &[StructDef], array_types: &[ArrayTypeDef]) 
         Type::Unit => "unit".to_string(),
         Type::Never => "never".to_string(),
         Type::Error => "error".to_string(),
+        // ComptimeType only exists at compile time, no runtime representation
+        Type::ComptimeType => "comptime_type".to_string(),
         Type::Enum(enum_id) => format!("enum{}", enum_id.0),
         // Struct types include builtin types like String
         Type::Struct(struct_id) => struct_defs[struct_id.0 as usize].name.clone(),

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -27,6 +27,7 @@ use rue_span::Span;
 fn type_needs_drop(ty: Type, struct_defs: &[StructDef], array_types: &[ArrayTypeDef]) -> bool {
     match ty {
         // Primitive types are trivially droppable
+        // ComptimeType is comptime-only, no runtime representation
         Type::I8
         | Type::I16
         | Type::I32
@@ -38,7 +39,8 @@ fn type_needs_drop(ty: Type, struct_defs: &[StructDef], array_types: &[ArrayType
         | Type::Bool
         | Type::Unit
         | Type::Never
-        | Type::Error => false,
+        | Type::Error
+        | Type::ComptimeType => false,
 
         // Enum types are trivially droppable (just discriminant values)
         Type::Enum(_) => false,
@@ -72,6 +74,7 @@ fn type_needs_drop(ty: Type, struct_defs: &[StructDef], array_types: &[ArrayType
 fn type_slot_count(ty: Type, struct_defs: &[StructDef], array_types: &[ArrayTypeDef]) -> u32 {
     match ty {
         // Primitives use 1 slot
+        // ComptimeType uses 0 slots (comptime-only, no runtime representation)
         Type::I8
         | Type::I16
         | Type::I32
@@ -85,6 +88,7 @@ fn type_slot_count(ty: Type, struct_defs: &[StructDef], array_types: &[ArrayType
         | Type::Never
         | Type::Error
         | Type::Enum(_) => 1,
+        Type::ComptimeType => 0,
 
         // Struct uses sum of all field slots (including builtin String with 3 fields)
         Type::Struct(struct_id) => {
@@ -417,6 +421,8 @@ fn type_name(ty: Type, struct_defs: &[StructDef], array_types: &[ArrayTypeDef]) 
         Type::Unit => "unit".to_string(),
         Type::Never => "never".to_string(),
         Type::Error => "error".to_string(),
+        // ComptimeType only exists at compile time
+        Type::ComptimeType => "comptime_type".to_string(),
         Type::Enum(enum_id) => format!("enum{}", enum_id.0),
         // Struct types include builtin types like String
         Type::Struct(struct_id) => struct_defs[struct_id.0 as usize].name.clone(),

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -211,6 +211,8 @@ pub enum ParamMode {
     Inout,
     /// Borrow parameter - immutable borrow without ownership transfer
     Borrow,
+    /// Comptime parameter - evaluated at compile time (used for type parameters)
+    Comptime,
 }
 
 impl Default for ParamMode {
@@ -346,6 +348,8 @@ pub enum Expr {
     SelfExpr(SelfExpr),
     /// Comptime block expression (e.g., `comptime { 1 + 2 }`)
     Comptime(ComptimeBlockExpr),
+    /// Type literal expression (e.g., `i32` used as a value in generic function calls)
+    TypeLit(TypeLitExpr),
 }
 
 /// An integer literal.
@@ -784,6 +788,16 @@ pub struct ComptimeBlockExpr {
     pub span: Span,
 }
 
+/// A type literal expression (e.g., `i32` used as a value).
+/// This represents a type used as a value in expression context, typically
+/// as an argument to a generic function with comptime parameters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeLitExpr {
+    /// The type being used as a value
+    pub type_expr: TypeExpr,
+    pub span: Span,
+}
+
 impl Expr {
     /// Get the span of this expression.
     pub fn span(&self) -> Span {
@@ -815,6 +829,7 @@ impl Expr {
             Expr::AssocFnCall(assoc_fn_call) => assoc_fn_call.span,
             Expr::SelfExpr(self_expr) => self_expr.span,
             Expr::Comptime(comptime_expr) => comptime_expr.span,
+            Expr::TypeLit(type_lit) => type_lit.span,
         }
     }
 }
@@ -923,6 +938,7 @@ fn fmt_param(f: &mut fmt::Formatter<'_>, param: &Param) -> fmt::Result {
     match param.mode {
         ParamMode::Inout => write!(f, "inout ")?,
         ParamMode::Borrow => write!(f, "borrow ")?,
+        ParamMode::Comptime => write!(f, "comptime ")?,
         ParamMode::Normal => {}
     }
     write!(f, "sym:{}: {}", param.name.name.into_usize(), param.ty)
@@ -1134,6 +1150,9 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
         Expr::Comptime(comptime) => {
             writeln!(f, "Comptime")?;
             fmt_expr(f, &comptime.expr, level + 1)
+        }
+        Expr::TypeLit(type_lit) => {
+            writeln!(f, "TypeLit({})", type_lit.type_expr)
         }
     }
 }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -11,7 +11,7 @@ use crate::ast::{
     IntrinsicCallExpr, Item, LetPattern, LetStatement, LoopExpr, MatchArm, MatchExpr, Method,
     MethodCallExpr, NegIntLit, Param, ParamMode, ParenExpr, PathExpr, PathPattern, Pattern,
     ReturnExpr, SelfExpr, SelfParam, Statement, StringLit, StructDecl, StructLitExpr, TypeExpr,
-    UnaryExpr, UnaryOp, UnitLit, Visibility, WhileExpr,
+    TypeLitExpr, UnaryExpr, UnaryOp, UnitLit, Visibility, WhileExpr,
 };
 use chumsky::input::{Input as ChumskyInput, MapExtra, Stream, ValueInput};
 use chumsky::pratt::{infix, left, prefix};
@@ -236,7 +236,7 @@ where
     })
 }
 
-/// Parser for parameter mode: inout or borrow
+/// Parser for parameter mode: inout, borrow, or comptime
 fn param_mode_parser<'src, I>() -> impl Parser<'src, I, ParamMode, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
@@ -244,6 +244,7 @@ where
     choice((
         just(TokenKind::Inout).to(ParamMode::Inout),
         just(TokenKind::Borrow).to(ParamMode::Borrow),
+        just(TokenKind::Comptime).to(ParamMode::Comptime),
     ))
 }
 
@@ -1090,17 +1091,28 @@ where
             })
         });
 
+    // Type literal expression: i32, bool, etc. used as values
+    // This enables generic function calls like identity(i32, 42)
+    let type_lit_expr = primitive_type_parser().map_with(|type_expr, e| {
+        Expr::TypeLit(TypeLitExpr {
+            type_expr,
+            span: to_rue_span(e.span()),
+        })
+    });
+
     // Primary expression (before field access and indexing)
     // Note: literal_parser() includes unit_lit which must come before paren_expr
     // so () is parsed as unit, not empty parens
     // Note: self_expr must come before call_and_access_parser since self is a keyword
     // Note: comptime_expr must come before block_expr since comptime starts with a keyword
+    // Note: type_lit_expr must come before call_and_access_parser since type names are keywords
     let primary = choice((
         literal_parser(),
         control_flow_parser(expr.clone()),
         self_expr,
         intrinsic_call,
         array_lit,
+        type_lit_expr,
         call_and_access_parser(expr.clone()),
         paren_expr,
         comptime_expr,

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -11,6 +11,6 @@ pub use ast::{
     FieldInit, Function, Ident, ImplBlock, IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr,
     Item, LetPattern, LetStatement, MatchArm, MatchExpr, Method, MethodCallExpr, Param, ParamMode,
     ParenExpr, PathExpr, PathPattern, Pattern, ReturnExpr, SelfParam, Statement, StructDecl,
-    StructLitExpr, TypeExpr, UnaryExpr, UnaryOp, WhileExpr,
+    StructLitExpr, TypeExpr, TypeLitExpr, UnaryExpr, UnaryOp, WhileExpr,
 };
 pub use chumsky_parser::ChumskyParser as Parser;

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -12,7 +12,7 @@ use rue_parser::ast::DropFn;
 use rue_parser::{
     ArgMode, AssignTarget, Ast, BinaryOp, CallArg, Directive, DirectiveArg, EnumDecl, Expr,
     Function, ImplBlock, IntrinsicArg, Item, LetPattern, Method, ParamMode, Pattern, Statement,
-    StructDecl, TypeExpr, UnaryOp, ast::Visibility,
+    StructDecl, TypeExpr, TypeLitExpr, UnaryOp, ast::Visibility,
 };
 
 use crate::inst::{
@@ -256,6 +256,7 @@ impl<'a> AstGen<'a> {
             ParamMode::Normal => RirParamMode::Normal,
             ParamMode::Inout => RirParamMode::Inout,
             ParamMode::Borrow => RirParamMode::Borrow,
+            ParamMode::Comptime => RirParamMode::Comptime,
         }
     }
 
@@ -647,6 +648,24 @@ impl<'a> AstGen<'a> {
                 self.rir.add_inst(Inst {
                     data: InstData::Comptime { expr: inner_expr },
                     span: comptime_block.span,
+                })
+            }
+            Expr::TypeLit(type_lit) => {
+                // Generate a type constant instruction for type-as-value expressions
+                // The type name is extracted from the TypeExpr
+                let type_name = match &type_lit.type_expr {
+                    TypeExpr::Named(ident) => ident.name,
+                    TypeExpr::Unit(_) => self.interner.get_or_intern_static("()"),
+                    TypeExpr::Never(_) => self.interner.get_or_intern_static("!"),
+                    TypeExpr::Array { .. } => {
+                        // Array types as values are not yet supported
+                        // For now, use a placeholder
+                        self.interner.get_or_intern_static("array")
+                    }
+                };
+                self.rir.add_inst(Inst {
+                    data: InstData::TypeConst { type_name },
+                    span: type_lit.span,
                 })
             }
         }

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -49,6 +49,8 @@ pub enum RirParamMode {
     Inout,
     /// Borrow parameter - immutable borrow without ownership transfer
     Borrow,
+    /// Comptime parameter - evaluated at compile time (used for type parameters)
+    Comptime,
 }
 
 /// A parameter in a function declaration.
@@ -447,6 +449,7 @@ impl Rir {
                 0 => RirParamMode::Normal,
                 1 => RirParamMode::Inout,
                 2 => RirParamMode::Borrow,
+                3 => RirParamMode::Comptime,
                 _ => RirParamMode::Normal, // Fallback
             };
             let is_comptime = chunk[3] != 0;
@@ -1089,6 +1092,9 @@ impl Rir {
             InstData::Comptime { expr } => InstData::Comptime {
                 expr: renumber(*expr),
             },
+            InstData::TypeConst { type_name } => InstData::TypeConst {
+                type_name: *type_name,
+            },
         };
 
         Inst {
@@ -1264,7 +1270,8 @@ impl Rir {
                 | InstData::IndexSet { .. }
                 | InstData::TypeIntrinsic { .. }
                 | InstData::DropFnDecl { .. }
-                | InstData::Comptime { .. } => {}
+                | InstData::Comptime { .. }
+                | InstData::TypeConst { .. } => {}
             }
         }
     }
@@ -1632,6 +1639,13 @@ pub enum InstData {
         /// The expression to evaluate at compile time
         expr: InstRef,
     },
+
+    /// Type constant: a type used as a value expression (e.g., `i32` in `identity(i32, 42)`)
+    /// The type_name is the symbol for the type (e.g., "i32", "bool").
+    TypeConst {
+        /// The type name symbol
+        type_name: Spur,
+    },
 }
 
 impl fmt::Display for InstRef {
@@ -1780,6 +1794,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                             let mode_prefix = match p.mode {
                                 RirParamMode::Inout => "inout ",
                                 RirParamMode::Borrow => "borrow ",
+                                RirParamMode::Comptime => "comptime ",
                                 RirParamMode::Normal => "",
                             };
                             format!(
@@ -2056,6 +2071,12 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 // Comptime block
                 InstData::Comptime { expr } => {
                     writeln!(out, "comptime {{ {} }}", expr).unwrap();
+                }
+
+                // Type constant
+                InstData::TypeConst { type_name } => {
+                    let name = self.interner.resolve(type_name);
+                    writeln!(out, "type {}", name).unwrap();
                 }
             }
         }

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -382,3 +382,139 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Phase 3: Type Parameters (ADR-0025)
+# =============================================================================
+# Tests for `type` as a type name and comptime type parameters.
+# These tests verify that:
+# 1. `type` can be used as a type annotation for comptime parameters
+# 2. Type parameters are substituted during specialization
+# 3. Generic functions work correctly with different concrete types
+
+[[case]]
+name = "type_as_type_name_can_be_resolved"
+spec = ["4.13:5"]
+preview = "comptime"
+description = "The keyword 'type' can be used as a type annotation"
+source = """
+// Simple test: `type` as a type name is parsed correctly
+// This will fail until comptime parameters are fully implemented
+fn identity(comptime T: type, x: T) -> T {
+    x
+}
+fn main() -> i32 {
+    identity(i32, 42)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "generic_function_with_i32"
+spec = ["4.13:5"]
+preview = "comptime"
+description = "Generic identity function specialized for i32"
+source = """
+fn identity(comptime T: type, x: T) -> T {
+    x
+}
+fn main() -> i32 {
+    identity(i32, 42)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "generic_function_with_bool"
+spec = ["4.13:5"]
+preview = "comptime"
+description = "Generic identity function specialized for bool"
+source = """
+fn identity(comptime T: type, x: T) -> T {
+    x
+}
+fn main() -> i32 {
+    if identity(bool, true) { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "generic_max_function"
+spec = ["4.13:5"]
+preview = "comptime"
+description = "The ADR example: generic max function"
+source = """
+fn max(comptime T: type, a: T, b: T) -> T {
+    if a > b { a } else { b }
+}
+fn main() -> i32 {
+    max(i32, 10, 20)
+}
+"""
+exit_code = 20
+
+[[case]]
+name = "generic_function_multiple_calls_same_type"
+spec = ["4.13:5"]
+preview = "comptime"
+description = "Multiple calls to generic function with same type reuse specialization"
+source = """
+fn identity(comptime T: type, x: T) -> T {
+    x
+}
+fn main() -> i32 {
+    let a = identity(i32, 10);
+    let b = identity(i32, 32);
+    a + b
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "generic_function_multiple_types"
+spec = ["4.13:5"]
+preview = "comptime"
+description = "Generic function called with different types creates separate specializations"
+source = """
+fn identity(comptime T: type, x: T) -> T {
+    x
+}
+fn main() -> i32 {
+    let i: i32 = identity(i32, 42);
+    let b: bool = identity(bool, true);
+    if b { i } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "type_parameter_in_arithmetic"
+spec = ["4.13:5"]
+preview = "comptime"
+description = "Type parameter used with arithmetic operators"
+source = """
+fn add_one(comptime T: type, x: T) -> T {
+    x + 1
+}
+fn main() -> i32 {
+    add_one(i32, 41)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "type_value_cannot_escape_comptime"
+spec = ["4.13:6"]
+preview = "comptime"
+# Not preview_should_pass yet - requires type-as-expression parsing which is Phase 4
+description = "Type values cannot exist at runtime"
+source = """
+fn main() -> i32 {
+    // This should fail because type values can't exist at runtime
+    let t = comptime { i32 };
+    0
+}
+"""
+compile_fail = true
+error_contains = "type values cannot exist at runtime"

--- a/examples/generics.rue
+++ b/examples/generics.rue
@@ -1,0 +1,79 @@
+// Generic functions using comptime type parameters
+//
+// This example demonstrates Rue's generic function support through
+// compile-time type parameters. The compiler creates specialized
+// versions for each concrete type used.
+//
+// NOTE: This is a preview feature. Compile with:
+//   rue --preview comptime generics.rue output
+
+// A generic identity function that works with any type.
+// The `comptime T: type` parameter is resolved at compile time,
+// and the function is specialized for each unique type argument.
+fn identity(comptime T: type, x: T) -> T {
+    x
+}
+
+// A generic max function that returns the larger of two values.
+// Works with any type that supports the > operator.
+fn max(comptime T: type, a: T, b: T) -> T {
+    if a > b { a } else { b }
+}
+
+// A generic min function that returns the smaller of two values.
+fn min(comptime T: type, a: T, b: T) -> T {
+    if a < b { a } else { b }
+}
+
+// A generic clamp function that constrains a value to a range.
+fn clamp(comptime T: type, value: T, lo: T, hi: T) -> T {
+    if value < lo {
+        lo
+    } else if value > hi {
+        hi
+    } else {
+        value
+    }
+}
+
+// A generic absolute difference function.
+fn abs_diff(comptime T: type, a: T, b: T) -> T {
+    if a > b { a - b } else { b - a }
+}
+
+fn main() -> i32 {
+    // Using identity with different types
+    let i: i32 = identity(i32, 42);
+    let _b: bool = identity(bool, true);
+
+    @dbg(i);  // 42
+
+    // The compiler creates separate specializations:
+    // - identity__i32
+    // - identity__bool
+
+    // Using max with i32
+    let bigger = max(i32, 10, 20);
+    @dbg(bigger);  // 20
+
+    // Using min with i32
+    let smaller = min(i32, 10, 20);
+    @dbg(smaller);  // 10
+
+    // Clamp a value to a range
+    let clamped = clamp(i32, 150, 0, 100);
+    @dbg(clamped);  // 100
+
+    // Absolute difference
+    let diff = abs_diff(i32, 7, 15);
+    @dbg(diff);  // 8
+
+    // Multiple calls with the same type reuse the same specialization
+    let a = max(i32, 5, 3);
+    let c = max(i32, 8, 12);
+    @dbg(a + c);  // 5 + 12 = 17
+
+    // Return the result of our generic functions
+    // 42 (identity) + 20 (max) + 10 (min) = 72
+    i + bigger + smaller
+}


### PR DESCRIPTION
This commit implements the core type parameter functionality for the comptime feature:

1. Generic function analysis:
   - Skip generic functions during normal analysis (they're analyzed during specialization)
   - Track type parameter names in function signatures
   - Use Type::ComptimeType as placeholder for type-parameterized types

2. Generic call handling:
   - Emit CallGeneric AIR instruction for calls to generic functions
   - Compute actual return type by building type substitution map
   - Store type arguments in AIR extra data

3. Specialization pass:
   - Collect all CallGeneric instructions across functions
   - Generate mangled names (e.g., identity__i32)
   - Rewrite CallGeneric to Call with specialized function name
   - Re-analyze generic function body with concrete types

4. Type parameter expression support:
   - TypeLit AST expression for type names as values
   - TypeConst RIR instruction for type constants
   - TypeConst AIR instruction for type-as-value

This enables writing generic functions like:
```rue
fn identity(comptime T: type, x: T) -> T { x }
fn main() -> i32 { identity(i32, 42) }
```

The compiler creates specialized versions (identity__i8, identity__i32, etc.) for each unique set of type arguments.

Fixes rue-fbwv

🤖 Generated with [Claude Code](https://claude.com/claude-code)