### PR TITLE
feat(modules): Implement Phase 1 module member access (rue-pxyn)

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -675,10 +675,10 @@ impl TypeInternPool {
             Type::Unit => Some(InternedType::UNIT),
             Type::Never => Some(InternedType::NEVER),
             Type::Error => Some(InternedType::ERROR),
-            // Struct and enum require pool lookup by ID - we need the name
+            // Struct, enum, array, and module require pool lookup by ID - we need the name
             // to find the interned type. This conversion is not straightforward
             // without additional context. Return None to indicate we can't convert.
-            Type::Struct(_) | Type::Enum(_) | Type::Array(_) => None,
+            Type::Struct(_) | Type::Enum(_) | Type::Array(_) | Type::Module(_) => None,
             // ComptimeType is a comptime-only type, cannot be interned for runtime
             Type::ComptimeType => None,
         }

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -40,11 +40,13 @@ pub use intern_pool::{
 pub use sema::{AnalyzedFunction, FunctionInfo, GatherOutput, MethodInfo, Sema, SemaOutput};
 // Note: FunctionInfo and MethodInfo are defined in sema and re-exported by sema_context.
 // We export InferenceContext and SemaContext from sema_context.
-pub use sema_context::{InferenceContext as SemaContextInferenceContext, SemaContext};
+pub use sema_context::{
+    InferenceContext as SemaContextInferenceContext, ModuleRegistry, SemaContext,
+};
 pub use type_context::{FunctionSignature, MethodSignature, TypeContext};
 pub use types::{
-    ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructField, StructId, Type,
-    parse_array_type_syntax,
+    ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, StructDef, StructField,
+    StructId, Type, parse_array_type_syntax,
 };
 
 /// Sentinel value used to encode parameter slots in AIR instructions.

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -4172,6 +4172,19 @@ fn analyze_method_call_ctx(
     let receiver_result = analyze_inst_with_context(ctx, air, receiver, analysis_ctx)?;
     let receiver_type = receiver_result.ty;
 
+    // Handle module member access: module.function() becomes a direct function call
+    if let Type::Module(_module_id) = receiver_type {
+        return analyze_module_member_call_ctx(
+            ctx,
+            air,
+            method,
+            args_start,
+            args_len,
+            span,
+            analysis_ctx,
+        );
+    }
+
     // Get the type name for method lookup
     let type_name = match receiver_type {
         Type::Struct(struct_id) => {
@@ -4251,6 +4264,99 @@ fn analyze_method_call_ctx(
             name: full_name_sym,
             args_start,
             args_len,
+        },
+        ty: return_type,
+        span,
+    });
+    Ok(AnalysisResult::new(air_ref, return_type))
+}
+
+/// Analyze a module member call: `module.function(args)` becomes a direct function call.
+///
+/// In Phase 1 of the module system, modules are virtual namespaces. When you import
+/// a module with `@import("foo.rue")`, all of foo.rue's functions are already in the
+/// global function table (via multi-file compilation). The module just provides a
+/// namespace at the source level.
+///
+/// This function looks up the function by name in the global function table and
+/// generates a direct call to it.
+fn analyze_module_member_call_ctx(
+    ctx: &SemaContext<'_>,
+    air: &mut Air,
+    function_name: Spur,
+    args_start: u32,
+    args_len: u32,
+    span: Span,
+    analysis_ctx: &mut AnalysisContext,
+) -> CompileResult<AnalysisResult> {
+    // Look up the function in the global function table
+    let fn_name_str = ctx.interner.resolve(&function_name).to_string();
+    let fn_info = ctx
+        .get_function(function_name)
+        .ok_or_compile_error(ErrorKind::UndefinedFunction(fn_name_str.clone()), span)?;
+
+    let args = ctx.rir.get_call_args(args_start, args_len);
+
+    // Check argument count
+    if args.len() != fn_info.param_types.len() {
+        let expected = fn_info.param_types.len();
+        let found = args.len();
+        return Err(CompileError::new(
+            ErrorKind::WrongArgumentCount { expected, found },
+            span,
+        ));
+    }
+
+    // Check for exclusive access violation
+    check_exclusive_access_ctx(ctx, &args, span)?;
+
+    // Check that call-site argument modes match function parameter modes
+    for (i, (arg, expected_mode)) in args.iter().zip(fn_info.param_modes.iter()).enumerate() {
+        match expected_mode {
+            RirParamMode::Inout => {
+                if arg.mode != RirArgMode::Inout {
+                    return Err(CompileError::new(
+                        ErrorKind::InoutKeywordMissing,
+                        ctx.rir.get(args[i].value).span,
+                    ));
+                }
+            }
+            RirParamMode::Borrow => {
+                if arg.mode != RirArgMode::Borrow {
+                    return Err(CompileError::new(
+                        ErrorKind::BorrowKeywordMissing,
+                        ctx.rir.get(args[i].value).span,
+                    ));
+                }
+            }
+            RirParamMode::Normal => {
+                // Normal params accept any mode
+            }
+            RirParamMode::Comptime => {
+                // Comptime params - handled elsewhere
+            }
+        }
+    }
+
+    // Analyze arguments
+    let air_args = analyze_call_args_ctx(ctx, air, &args, analysis_ctx)?;
+
+    let return_type = fn_info.return_type;
+
+    // Encode call args
+    let mut extra_data = Vec::with_capacity(air_args.len() * 2);
+    for arg in &air_args {
+        extra_data.push(arg.value.as_u32());
+        extra_data.push(arg.mode.as_u32());
+    }
+    let call_args_start = air.add_extra(&extra_data);
+    let call_args_len = air_args.len() as u32;
+
+    let air_ref = air.add_inst(AirInst {
+        data: AirInstData::Call {
+            name: function_name,
+            args_start: call_args_start,
+            args_len: call_args_len,
         },
         ty: return_type,
         span,
@@ -4810,24 +4916,47 @@ fn analyze_intrinsic_ctx(
             }
         };
 
-        // TODO: Actually resolve and load the imported module.
-        // For now, return a placeholder that allows us to gate the feature.
-        // The actual module loading will be implemented in a follow-up task.
-        //
-        // When implemented, this should:
-        // 1. Resolve import_path relative to the current file
-        // 2. Load and parse the target file
-        // 3. Create a synthetic struct type containing pub declarations
-        // 4. Return that struct type
-        let _ = import_path; // Silence unused warning for now
+        // Resolve the import path relative to the current source file
+        let resolved_path = if import_path.starts_with("./") || import_path.starts_with("../") {
+            // Relative path - resolve against current file's directory
+            match &ctx.source_file_path {
+                Some(source_path) => {
+                    let source_dir = std::path::Path::new(source_path)
+                        .parent()
+                        .unwrap_or(std::path::Path::new("."));
+                    source_dir.join(&import_path).to_string_lossy().to_string()
+                }
+                None => {
+                    // No source file path set - treat as relative to current directory
+                    import_path.clone()
+                }
+            }
+        } else {
+            // Assume it's a relative path from current directory or same directory
+            match &ctx.source_file_path {
+                Some(source_path) => {
+                    let source_dir = std::path::Path::new(source_path)
+                        .parent()
+                        .unwrap_or(std::path::Path::new("."));
+                    source_dir.join(&import_path).to_string_lossy().to_string()
+                }
+                None => import_path.clone(),
+            }
+        };
 
-        // Return Unit for now - this will change when module loading is implemented
+        // Get or create the module in the registry
+        // The module will be populated lazily when member access is performed
+        let (module_id, _is_new) = ctx.get_or_create_module(import_path.clone(), resolved_path);
+
+        // Return a module type
+        // AIR doesn't have a ModuleConst instruction, so we use UnitConst as a placeholder
+        // The type is what matters for subsequent member access resolution
         let air_ref = air.add_inst(AirInst {
-            data: AirInstData::UnitConst,
-            ty: Type::Unit,
+            data: AirInstData::UnitConst, // Placeholder - module values are compile-time only
+            ty: Type::Module(module_id),
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Unit))
+        Ok(AnalysisResult::new(air_ref, Type::Module(module_id)))
     } else {
         // Unknown intrinsic - resolve name for error message
         let intrinsic_name = ctx.interner.resolve(&name);
@@ -6237,6 +6366,12 @@ impl<'a> Sema<'a> {
         let receiver_result = self.analyze_inst(air, receiver, ctx)?;
         let receiver_type = receiver_result.ty;
 
+        // Handle module member access: module.function() becomes a direct function call
+        if let Type::Module(_module_id) = receiver_type {
+            return self
+                .analyze_module_member_call_impl(air, method, args_start, args_len, span, ctx);
+        }
+
         // Check that receiver is a struct type
         let struct_id = match receiver_type {
             Type::Struct(id) => id,
@@ -6337,6 +6472,95 @@ impl<'a> Sema<'a> {
                 name: call_name_sym,
                 args_start,
                 args_len,
+            },
+            ty: return_type,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, return_type))
+    }
+
+    /// Analyze a module member call: `module.function(args)` becomes a direct function call.
+    ///
+    /// In Phase 1 of the module system, modules are virtual namespaces. When you import
+    /// a module with `@import("foo.rue")`, all of foo.rue's functions are already in the
+    /// global function table (via multi-file compilation). The module just provides a
+    /// namespace at the source level.
+    fn analyze_module_member_call_impl(
+        &mut self,
+        air: &mut Air,
+        function_name: Spur,
+        args_start: u32,
+        args_len: u32,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        // Look up the function in the global function table
+        let fn_name_str = self.interner.resolve(&function_name).to_string();
+        let fn_info = self
+            .functions
+            .get(&function_name)
+            .ok_or_compile_error(ErrorKind::UndefinedFunction(fn_name_str.clone()), span)?
+            .clone();
+
+        let args = self.rir.get_call_args(args_start, args_len);
+
+        // Check argument count
+        if args.len() != fn_info.param_types.len() {
+            let expected = fn_info.param_types.len();
+            let found = args.len();
+            return Err(CompileError::new(
+                ErrorKind::WrongArgumentCount { expected, found },
+                span,
+            ));
+        }
+
+        // Check that call-site argument modes match function parameter modes
+        for (i, (arg, expected_mode)) in args.iter().zip(fn_info.param_modes.iter()).enumerate() {
+            match expected_mode {
+                RirParamMode::Inout => {
+                    if arg.mode != RirArgMode::Inout {
+                        return Err(CompileError::new(
+                            ErrorKind::InoutKeywordMissing,
+                            self.rir.get(args[i].value).span,
+                        ));
+                    }
+                }
+                RirParamMode::Borrow => {
+                    if arg.mode != RirArgMode::Borrow {
+                        return Err(CompileError::new(
+                            ErrorKind::BorrowKeywordMissing,
+                            self.rir.get(args[i].value).span,
+                        ));
+                    }
+                }
+                RirParamMode::Normal => {
+                    // Normal params accept any mode
+                }
+                RirParamMode::Comptime => {
+                    // Comptime params - handled elsewhere
+                }
+            }
+        }
+
+        // Analyze arguments
+        let air_args = self.analyze_call_args(air, &args, ctx)?;
+
+        let return_type = fn_info.return_type;
+
+        // Encode call args
+        let mut extra_data = Vec::with_capacity(air_args.len() * 2);
+        for arg in &air_args {
+            extra_data.push(arg.value.as_u32());
+            extra_data.push(arg.mode.as_u32());
+        }
+        let call_args_start = air.add_extra(&extra_data);
+        let call_args_len = air_args.len() as u32;
+
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Call {
+                name: function_name,
+                args_start: call_args_start,
+                args_len: call_args_len,
             },
             ty: return_type,
             span,
@@ -6963,18 +7187,25 @@ impl<'a> Sema<'a> {
             }
         };
 
-        // TODO: Actually resolve and load the imported module.
-        // For now, return a placeholder that allows us to gate the feature.
-        // The actual module loading will be implemented in a follow-up task.
-        let _ = import_path; // Silence unused warning for now
+        // Resolve the import path relative to the current source file
+        // For now, we just use the import_path as-is since module resolution is simple
+        let resolved_path = import_path.clone();
 
-        // Return Unit for now - this will change when module loading is implemented
+        // Get or create the module in the registry
+        // The module will be populated lazily when member access is performed
+        let (module_id, _is_new) = self
+            .module_registry
+            .get_or_create(import_path.clone(), resolved_path);
+
+        // Return a module type
+        // AIR doesn't have a ModuleConst instruction, so we use UnitConst as a placeholder
+        // The type is what matters for subsequent member access resolution
         let air_ref = air.add_inst(AirInst {
-            data: AirInstData::UnitConst,
-            ty: Type::Unit,
+            data: AirInstData::UnitConst, // Placeholder - module values are compile-time only
+            ty: Type::Module(module_id),
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Unit))
+        Ok(AnalysisResult::new(air_ref, Type::Module(module_id)))
     }
 
     // Note: The old analyze_inst body from here onwards is now handled by the

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -130,6 +130,7 @@ impl<'a> GatherOutput<'a> {
             builtin_string_id: self.builtin_string_id,
             known: KnownSymbols::new(self.interner),
             type_pool: self.type_pool,
+            module_registry: crate::sema_context::ModuleRegistry::new(),
         }
     }
 
@@ -282,6 +283,8 @@ pub struct Sema<'a> {
     /// It is populated during declaration collection but not yet used for
     /// type operations. Later phases will migrate to using the pool exclusively.
     pub(crate) type_pool: TypeInternPool,
+    /// Module registry for tracking imported modules (Phase 1 modules).
+    pub(crate) module_registry: crate::sema_context::ModuleRegistry,
 }
 
 impl<'a> Sema<'a> {
@@ -306,6 +309,7 @@ impl<'a> Sema<'a> {
             builtin_string_id: None,
             known: KnownSymbols::new(interner),
             type_pool: TypeInternPool::new(),
+            module_registry: crate::sema_context::ModuleRegistry::new(),
         }
     }
 
@@ -473,6 +477,8 @@ impl<'a> Sema<'a> {
             inference_ctx,
             known: KnownSymbols::new(self.interner),
             type_pool: self.type_pool.clone(),
+            module_registry: crate::sema_context::ModuleRegistry::new(),
+            source_file_path: None, // Will be set when analyzing specific files
         }
     }
 

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -41,6 +41,7 @@ impl<'a> Sema<'a> {
                     array_def.length
                 )
             }
+            Type::Module(_) => "<module>".to_string(),
             Type::ComptimeType => "type".to_string(),
         }
     }
@@ -76,6 +77,8 @@ impl<'a> Sema<'a> {
                 let array_def = &self.array_type_defs[array_id.0 as usize];
                 self.is_type_copy(array_def.element_type)
             }
+            // Module types are Copy (they're just compile-time namespace references)
+            Type::Module(_) => true,
             // ComptimeType is Copy (only exists at comptime anyway)
             Type::ComptimeType => true,
         }
@@ -285,6 +288,8 @@ impl<'a> Sema<'a> {
                 let element_slots = self.abi_slot_count(array_def.element_type);
                 element_slots * array_def.length as u32
             }
+            // Module types don't take ABI slots (they're compile-time only)
+            Type::Module(_) => 0,
         }
     }
 

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -40,7 +40,9 @@ use crate::intern_pool::TypeInternPool;
 // Import FunctionInfo, MethodInfo, and KnownSymbols from sema module to avoid duplication.
 // FunctionInfo and MethodInfo are the canonical definitions; we re-export them for convenience.
 pub use crate::sema::{FunctionInfo, KnownSymbols, MethodInfo};
-use crate::types::{ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructId, Type};
+use crate::types::{
+    ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, StructDef, StructId, Type,
+};
 
 /// Thread-safe registry for array types.
 ///
@@ -156,6 +158,105 @@ impl Default for ArrayTypeRegistry {
     }
 }
 
+/// Thread-safe registry for modules.
+///
+/// This registry allows concurrent lookups and insertions of imported modules during
+/// parallel function analysis. It uses double-checked locking to minimize contention.
+#[derive(Debug)]
+pub struct ModuleRegistry {
+    /// Maps import path (e.g., "math.rue") to ModuleId.
+    paths: RwLock<HashMap<String, ModuleId>>,
+    /// Module definitions indexed by ModuleId.
+    defs: RwLock<Vec<ModuleDef>>,
+}
+
+impl ModuleRegistry {
+    /// Create a new empty registry.
+    pub fn new() -> Self {
+        Self {
+            paths: RwLock::new(HashMap::new()),
+            defs: RwLock::new(Vec::new()),
+        }
+    }
+
+    /// Look up a module by import path.
+    pub fn get(&self, import_path: &str) -> Option<ModuleId> {
+        self.paths
+            .read()
+            .expect("ModuleRegistry lock poisoned")
+            .get(import_path)
+            .copied()
+    }
+
+    /// Get or create a module for the given import path and resolved file path.
+    ///
+    /// Returns the ModuleId and whether it was newly created.
+    pub fn get_or_create(&self, import_path: String, file_path: String) -> (ModuleId, bool) {
+        // Fast path: check if already exists
+        {
+            let paths = self.paths.read().expect("ModuleRegistry lock poisoned");
+            if let Some(id) = paths.get(&import_path) {
+                return (*id, false);
+            }
+        }
+
+        // Slow path: acquire write lock and insert
+        let mut paths = self.paths.write().expect("ModuleRegistry lock poisoned");
+        // Double-check after acquiring write lock
+        if let Some(id) = paths.get(&import_path) {
+            return (*id, false);
+        }
+
+        let mut defs = self.defs.write().expect("ModuleRegistry lock poisoned");
+        let id = ModuleId::new(defs.len() as u32);
+        defs.push(ModuleDef::new(import_path.clone(), file_path));
+        paths.insert(import_path, id);
+        (id, true)
+    }
+
+    /// Get a module definition by ID.
+    pub fn get_def(&self, id: ModuleId) -> ModuleDef {
+        self.defs
+            .read()
+            .expect("ModuleRegistry lock poisoned")
+            .get(id.index() as usize)
+            .cloned()
+            .expect("Invalid ModuleId")
+    }
+
+    /// Update a module definition.
+    pub fn update_def(&self, id: ModuleId, def: ModuleDef) {
+        let mut defs = self.defs.write().expect("ModuleRegistry lock poisoned");
+        defs[id.index() as usize] = def;
+    }
+
+    /// Get the number of modules in the registry.
+    pub fn len(&self) -> usize {
+        self.defs
+            .read()
+            .expect("ModuleRegistry lock poisoned")
+            .len()
+    }
+
+    /// Check if the registry is empty.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Extract the module definitions (consumes the registry).
+    pub fn into_defs(self) -> Vec<ModuleDef> {
+        self.defs
+            .into_inner()
+            .expect("ModuleRegistry lock poisoned")
+    }
+}
+
+impl Default for ModuleRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// Pre-computed type information for constraint generation.
 ///
 /// This struct holds the function, struct, enum, and method signature maps
@@ -232,11 +333,18 @@ pub struct SemaContext<'a> {
     /// remains the old `Type` enum. Later phases will migrate to using
     /// the pool exclusively.
     pub type_pool: TypeInternPool,
+    /// Thread-safe module registry.
+    /// Supports concurrent lookups and insertions during parallel analysis.
+    pub module_registry: ModuleRegistry,
+    /// Path to the current source file being compiled.
+    /// Used for resolving relative imports.
+    pub source_file_path: Option<String>,
 }
 
 // SAFETY: SemaContext is Send + Sync because:
 // - Immutable fields (struct_defs, enum_defs, structs, enums, etc.) are trivially thread-safe
 // - ArrayTypeRegistry uses RwLock for interior mutability
+// - ModuleRegistry uses RwLock for interior mutability
 // - TypeInternPool uses RwLock for interior mutability
 // - References to RIR and ThreadedRodeo are shared immutably
 // - References to functions/methods HashMaps are shared immutably (read-only after declaration gathering)
@@ -298,6 +406,28 @@ impl<'a> SemaContext<'a> {
         self.array_registry.get_or_create(element_type, length)
     }
 
+    /// Look up a module by import path.
+    pub fn get_module(&self, import_path: &str) -> Option<ModuleId> {
+        self.module_registry.get(import_path)
+    }
+
+    /// Get a module definition by ID.
+    pub fn get_module_def(&self, id: ModuleId) -> ModuleDef {
+        self.module_registry.get_def(id)
+    }
+
+    /// Get or create a module for the given import path and file path. Thread-safe.
+    ///
+    /// Returns the ModuleId and whether it was newly created.
+    pub fn get_or_create_module(&self, import_path: String, file_path: String) -> (ModuleId, bool) {
+        self.module_registry.get_or_create(import_path, file_path)
+    }
+
+    /// Update a module definition with populated declarations.
+    pub fn update_module_def(&self, id: ModuleId, def: ModuleDef) {
+        self.module_registry.update_def(id, def);
+    }
+
     /// Get a human-readable name for a type.
     pub fn format_type_name(&self, ty: Type) -> String {
         match ty {
@@ -323,6 +453,7 @@ impl<'a> SemaContext<'a> {
                     array_def.length
                 )
             }
+            Type::Module(_) => "<module>".to_string(),
             Type::ComptimeType => "type".to_string(),
         }
     }
@@ -355,6 +486,8 @@ impl<'a> SemaContext<'a> {
                 let array_def = self.array_registry.get_def(array_id);
                 self.is_type_copy(array_def.element_type)
             }
+            // Module types are Copy (they're just compile-time namespace references)
+            Type::Module(_) => true,
         }
     }
 
@@ -387,6 +520,8 @@ impl<'a> SemaContext<'a> {
                 let element_slots = self.abi_slot_count(array_def.element_type);
                 element_slots * array_def.length as u32
             }
+            // Module types don't take ABI slots (they're compile-time only)
+            Type::Module(_) => 0,
         }
     }
 

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -59,6 +59,27 @@ impl EnumId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ArrayTypeId(pub u32);
 
+/// A unique identifier for a module (imported file).
+///
+/// Modules are created by `@import("path.rue")` and represent the public
+/// declarations of an imported file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ModuleId(pub u32);
+
+impl ModuleId {
+    /// Create a ModuleId from an index.
+    #[inline]
+    pub fn new(index: u32) -> Self {
+        ModuleId(index)
+    }
+
+    /// Get the index for this module.
+    #[inline]
+    pub fn index(self) -> u32 {
+        self.0
+    }
+}
+
 /// A type in the Rue type system.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
 pub enum Type {
@@ -89,6 +110,11 @@ pub enum Type {
     Enum(EnumId),
     /// Fixed-size array type: [T; N]
     Array(ArrayTypeId),
+    /// A module type (from @import)
+    ///
+    /// Module types represent imported files. Accessing members on a module
+    /// type resolves to the module's public declarations.
+    Module(ModuleId),
     /// An error type (used during type checking to continue after errors)
     Error,
     /// The never type - represents computations that don't return (e.g., break, continue).
@@ -202,6 +228,45 @@ impl EnumDef {
     }
 }
 
+/// Definition of a module (imported file).
+///
+/// A module contains the public declarations from an imported file.
+/// When code accesses `math.add()`, the module definition is consulted
+/// to find the corresponding function.
+#[derive(Debug, Clone)]
+pub struct ModuleDef {
+    /// The path used in @import (e.g., "math.rue")
+    pub import_path: String,
+    /// The resolved absolute file path
+    pub file_path: String,
+    /// Public functions in this module: name -> mangled name
+    /// The mangled name includes the module path (e.g., "math::add")
+    pub functions: std::collections::HashMap<String, String>,
+    /// Public structs in this module
+    pub structs: Vec<String>,
+    /// Public enums in this module
+    pub enums: Vec<String>,
+}
+
+impl ModuleDef {
+    /// Create a new empty module definition.
+    pub fn new(import_path: String, file_path: String) -> Self {
+        Self {
+            import_path,
+            file_path,
+            functions: std::collections::HashMap::new(),
+            structs: Vec::new(),
+            enums: Vec::new(),
+        }
+    }
+
+    /// Find a function by name in this module.
+    /// Returns the mangled function name if found.
+    pub fn find_function(&self, name: &str) -> Option<&str> {
+        self.functions.get(name).map(|s| s.as_str())
+    }
+}
+
 impl Type {
     /// Get a human-readable name for this type.
     /// Note: For struct and array types, this returns a placeholder.
@@ -221,6 +286,7 @@ impl Type {
             Type::Struct(_) => "<struct>",
             Type::Enum(_) => "<enum>",
             Type::Array(_) => "<array>",
+            Type::Module(_) => "<module>",
             Type::Error => "<error>",
             Type::Never => "!",
             Type::ComptimeType => "type",
@@ -296,6 +362,19 @@ impl Type {
         }
     }
 
+    /// Check if this is a module type.
+    pub fn is_module(&self) -> bool {
+        matches!(self, Type::Module(_))
+    }
+
+    /// Get the module ID if this is a module type.
+    pub fn as_module(&self) -> Option<ModuleId> {
+        match self {
+            Type::Module(id) => Some(*id),
+            _ => None,
+        }
+    }
+
     /// Check if this is a signed integer type.
     pub fn is_signed(&self) -> bool {
         matches!(self, Type::I8 | Type::I16 | Type::I32 | Type::I64)
@@ -339,6 +418,8 @@ impl Type {
             Type::Struct(_) => false,
             // Arrays may be Copy if element type is Copy (need ArrayTypeDef to check)
             Type::Array(_) => false,
+            // Module types are Copy (they're just compile-time namespace references)
+            Type::Module(_) => true,
         }
     }
 
@@ -448,6 +529,7 @@ impl Type {
             Type::Struct(id) => 100 | ((id.0 as u32) << 8),
             Type::Enum(id) => 101 | ((id.0 as u32) << 8),
             Type::Array(id) => 102 | ((id.0 as u32) << 8),
+            Type::Module(id) => 103 | ((id.index() as u32) << 8),
         }
     }
 
@@ -474,6 +556,7 @@ impl Type {
             100 => Type::Struct(StructId(id)),
             101 => Type::Enum(EnumId(id)),
             102 => Type::Array(ArrayTypeId(id)),
+            103 => Type::Module(ModuleId::new(id)),
             _ => panic!("invalid Type encoding: {}", v),
         }
     }

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1759,6 +1759,9 @@ impl<'a> CfgBuilder<'a> {
                 let array_def = &self.array_types[array_id.0 as usize];
                 self.type_needs_drop(array_def.element_type)
             }
+
+            // Module types don't need drop (compile-time only)
+            Type::Module(_) => false,
         }
     }
 

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -233,6 +233,8 @@ fn type_name(ty: Type, type_pool: &TypeInternPool, array_types: &[ArrayTypeDef])
             let elem_name = type_name(array_def.element_type, type_pool, array_types);
             format!("array_{}_{}", elem_name, array_def.length)
         }
+        // Module types should never reach codegen (compile-time only)
+        Type::Module(_) => "module".to_string(),
     }
 }
 

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -69,6 +69,9 @@ fn type_needs_drop(ty: Type, type_pool: &TypeInternPool, array_types: &[ArrayTyp
             let array_def = &array_types[array_id.0 as usize];
             type_needs_drop(array_def.element_type, type_pool, array_types)
         }
+
+        // Module types don't need drop (compile-time only)
+        Type::Module(_) => false,
     }
 }
 
@@ -110,6 +113,9 @@ fn type_slot_count(ty: Type, type_pool: &TypeInternPool, array_types: &[ArrayTyp
             type_slot_count(array_def.element_type, type_pool, array_types)
                 * array_def.length as u32
         }
+
+        // Module types don't take ABI slots (compile-time only)
+        Type::Module(_) => 0,
     }
 }
 
@@ -432,5 +438,7 @@ fn type_name(ty: Type, type_pool: &TypeInternPool, array_types: &[ArrayTypeDef])
             let elem_name = type_name(array_def.element_type, type_pool, array_types);
             format!("array_{}_{}", elem_name, array_def.length)
         }
+        // Module types should never reach drop glue (compile-time only)
+        Type::Module(_) => "module".to_string(),
     }
 }

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -2592,6 +2592,104 @@ mod tests {
             result.err()
         );
     }
+
+    // ========================================================================
+    // Module Import Tests
+    // ========================================================================
+
+    #[test]
+    fn test_module_member_access() {
+        // Test that @import returns a module type and member access works
+        // Note: In Phase 1, all files are merged into the same namespace,
+        // so math.add() looks up "add" in the global function table.
+        let sources = vec![
+            SourceFile::new(
+                "main.rue",
+                r#"fn main() -> i32 {
+                    let math = @import("math.rue");
+                    math.add(1, 2)
+                }"#,
+                FileId::new(1),
+            ),
+            SourceFile::new(
+                "math.rue",
+                "fn add(a: i32, b: i32) -> i32 { a + b }",
+                FileId::new(2),
+            ),
+        ];
+        let mut options = CompileOptions::default();
+        options.preview_features.insert(PreviewFeature::Modules);
+        let result = compile_multi_file_with_options(&sources, &options);
+        assert!(
+            result.is_ok(),
+            "module member access should compile: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_module_member_access_multiple_functions() {
+        // Test accessing multiple functions from an imported module
+        let sources = vec![
+            SourceFile::new(
+                "main.rue",
+                r#"fn main() -> i32 {
+                    let math = @import("math.rue");
+                    let sum = math.add(10, 20);
+                    let diff = math.sub(sum, 5);
+                    diff
+                }"#,
+                FileId::new(1),
+            ),
+            SourceFile::new(
+                "math.rue",
+                r#"fn add(a: i32, b: i32) -> i32 { a + b }
+                fn sub(a: i32, b: i32) -> i32 { a - b }"#,
+                FileId::new(2),
+            ),
+        ];
+        let mut options = CompileOptions::default();
+        options.preview_features.insert(PreviewFeature::Modules);
+        let result = compile_multi_file_with_options(&sources, &options);
+        assert!(
+            result.is_ok(),
+            "module with multiple functions should compile: {:?}",
+            result.err()
+        );
+    }
+
+    #[test]
+    fn test_module_undefined_function_error() {
+        // Test that accessing an undefined function in a module produces an error
+        let sources = vec![
+            SourceFile::new(
+                "main.rue",
+                r#"fn main() -> i32 {
+                    let math = @import("math.rue");
+                    math.nonexistent(1, 2)
+                }"#,
+                FileId::new(1),
+            ),
+            SourceFile::new(
+                "math.rue",
+                "fn add(a: i32, b: i32) -> i32 { a + b }",
+                FileId::new(2),
+            ),
+        ];
+        let mut options = CompileOptions::default();
+        options.preview_features.insert(PreviewFeature::Modules);
+        let result = compile_multi_file_with_options(&sources, &options);
+        assert!(
+            result.is_err(),
+            "undefined module function should fail to compile"
+        );
+        let err = result.err().unwrap().to_string();
+        assert!(
+            err.contains("undefined function") || err.contains("nonexistent"),
+            "error should mention undefined function: {}",
+            err
+        );
+    }
 }
 
 // ============================================================================


### PR DESCRIPTION
This implements the core of ADR-0026 Phase 1: enabling 'math.add(1, 2)' style access on imported modules.

Changes:
- Add Type::Module variant and ModuleId struct to types.rs
- Add ModuleDef to hold module metadata (import_path, file_path, functions)
- Add ModuleRegistry for thread-safe module tracking in SemaContext and Sema
- Update @import intrinsic to return Type::Module instead of Type::Unit
- Add analyze_module_member_call_impl to Sema for handling module.function() calls
- Add analyze_module_member_call_ctx to SemaContext for parallel analysis path
- Update all exhaustive Type matches across the codebase
- Add unit tests for module member access in rue-compiler

In Phase 1, modules act as virtual namespaces over the existing multi-file compilation infrastructure. When you import 'math.rue', its functions are already in the global table from command-line compilation - the module provides namespacing at the source level.

Fixes rue-pxyn

🤖 Generated with [Claude Code](https://claude.com/claude-code)