### PR TITLE
Implement ADR-0024: Type intern pool with O(1) equality

### DIFF
--- a/crates/rue-air/src/function_analyzer.rs
+++ b/crates/rue-air/src/function_analyzer.rs
@@ -110,8 +110,8 @@ impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
 
     /// Get an array type definition by ID.
     ///
-    /// Delegates to the `ArrayTypeRegistry` in `SemaContext`.
-    pub fn get_array_type_def(&self, id: ArrayTypeId) -> crate::types::ArrayTypeDef {
+    /// Returns `(element_type, length)` for the array.
+    pub fn get_array_type_def(&self, id: ArrayTypeId) -> (Type, u64) {
         self.ctx.get_array_type_def(id)
     }
 
@@ -188,41 +188,34 @@ impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
     /// Get a human-readable name for a type.
     /// Delegates to context for most types but handles local array types.
     pub fn format_type_name(&self, ty: Type) -> String {
-        match ty {
-            Type::Array(array_id) => {
-                let array_def = self.get_array_type_def(array_id);
-                format!(
-                    "[{}; {}]",
-                    self.format_type_name(array_def.element_type),
-                    array_def.length
-                )
-            }
-            _ => self.ctx.format_type_name(ty),
+        if let Some(array_id) = ty.as_array() {
+            let (element_type, length) = self.get_array_type_def(array_id);
+            format!("[{}; {}]", self.format_type_name(element_type), length)
+        } else {
+            self.ctx.format_type_name(ty)
         }
     }
 
     /// Check if a type is a Copy type.
     /// Delegates to context for most types but handles local array types.
     pub fn is_type_copy(&self, ty: Type) -> bool {
-        match ty {
-            Type::Array(array_id) => {
-                let array_def = self.get_array_type_def(array_id);
-                self.is_type_copy(array_def.element_type)
-            }
-            _ => self.ctx.is_type_copy(ty),
+        if let Some(array_id) = ty.as_array() {
+            let (element_type, _length) = self.get_array_type_def(array_id);
+            self.is_type_copy(element_type)
+        } else {
+            self.ctx.is_type_copy(ty)
         }
     }
 
     /// Get the number of ABI slots required for a type.
     /// Delegates to context for most types but handles local array types.
     pub fn abi_slot_count(&self, ty: Type) -> u32 {
-        match ty {
-            Type::Array(array_id) => {
-                let array_def = self.get_array_type_def(array_id);
-                let element_slots = self.abi_slot_count(array_def.element_type);
-                element_slots * array_def.length as u32
-            }
-            _ => self.ctx.abi_slot_count(ty),
+        if let Some(array_id) = ty.as_array() {
+            let (element_type, length) = self.get_array_type_def(array_id);
+            let element_slots = self.abi_slot_count(element_type);
+            element_slots * length as u32
+        } else {
+            self.ctx.abi_slot_count(ty)
         }
     }
 

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -948,47 +948,54 @@ impl<'a> ConstraintGenerator<'a> {
                 // Get struct name from receiver type if it's a struct
                 // If we can't determine the struct type, we still generate constraints
                 // for the arguments and return a type variable (actual error is in sema)
-                let result_type = if let InferType::Concrete(Type::Struct(struct_id)) =
-                    &receiver_info.ty
-                {
-                    // Find the struct name symbol
-                    let struct_name = self
-                        .structs
-                        .iter()
-                        .find(|(_, ty)| **ty == Type::Struct(*struct_id))
-                        .map(|(name, _)| *name);
+                let result_type = if let InferType::Concrete(ty) = &receiver_info.ty {
+                    if let Some(struct_id) = ty.as_struct() {
+                        // Find the struct name symbol
+                        let struct_name = self
+                            .structs
+                            .iter()
+                            .find(|(_, t)| t.as_struct() == Some(struct_id))
+                            .map(|(name, _)| *name);
 
-                    if let Some(struct_name) = struct_name {
-                        let method_key = (struct_name, *method);
-                        if let Some(method_sig) = self.methods.get(&method_key) {
-                            // Generate constraints for arguments
-                            for (arg, param_type) in args.iter().zip(method_sig.param_types.iter())
-                            {
-                                let arg_info = self.generate(arg.value, ctx);
-                                self.add_constraint(Constraint::equal(
-                                    arg_info.ty,
-                                    param_type.clone(),
-                                    arg_info.span,
-                                ));
+                        if let Some(struct_name) = struct_name {
+                            let method_key = (struct_name, *method);
+                            if let Some(method_sig) = self.methods.get(&method_key) {
+                                // Generate constraints for arguments
+                                for (arg, param_type) in
+                                    args.iter().zip(method_sig.param_types.iter())
+                                {
+                                    let arg_info = self.generate(arg.value, ctx);
+                                    self.add_constraint(Constraint::equal(
+                                        arg_info.ty,
+                                        param_type.clone(),
+                                        arg_info.span,
+                                    ));
+                                }
+                                method_sig.return_type.clone()
+                            } else {
+                                // Method not found - sema will report the error
+                                // Still generate arg types to catch errors in arguments
+                                for arg in args.iter() {
+                                    self.generate(arg.value, ctx);
+                                }
+                                InferType::Concrete(Type::Error)
                             }
-                            method_sig.return_type.clone()
                         } else {
-                            // Method not found - sema will report the error
-                            // Still generate arg types to catch errors in arguments
+                            // Couldn't find struct name - shouldn't happen but handle gracefully
                             for arg in args.iter() {
                                 self.generate(arg.value, ctx);
                             }
                             InferType::Concrete(Type::Error)
                         }
                     } else {
-                        // Couldn't find struct name - shouldn't happen but handle gracefully
+                        // Non-struct receiver - sema will report the error
                         for arg in args.iter() {
                             self.generate(arg.value, ctx);
                         }
                         InferType::Concrete(Type::Error)
                     }
                 } else {
-                    // Non-struct receiver - sema will report the error
+                    // Non-concrete type - generate args and return error
                     for arg in args.iter() {
                         self.generate(arg.value, ctx);
                     }

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -40,7 +40,7 @@ use std::sync::RwLock;
 
 use lasso::Spur;
 
-use crate::types::{EnumDef, EnumId, StructDef, StructId, Type};
+use crate::types::{ArrayTypeId, EnumDef, EnumId, StructDef, StructId, Type, TypeKind};
 
 /// Interned type index - 32 bits, Copy, cheap comparison.
 ///
@@ -581,6 +581,131 @@ impl TypeInternPool {
         InternedType::from_pool_index(enum_id.0)
     }
 
+    /// Get an array type definition by ArrayTypeId.
+    ///
+    /// The ArrayTypeId contains a pool index. This method looks up the array
+    /// in the pool and returns its element type and length as a tuple.
+    ///
+    /// # Returns
+    ///
+    /// Returns `(element_type, length)` where `element_type` is the array's element type
+    /// and `length` is the array's fixed size.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the ArrayTypeId doesn't correspond to an array in the pool.
+    pub fn array_def(&self, array_id: ArrayTypeId) -> (Type, u64) {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        let pool_index = array_id.0 as usize;
+        match &inner.types[pool_index] {
+            TypeData::Array { element, len } => {
+                // Convert InternedType back to Type
+                let element_type = Self::interned_to_type_recursive(*element, &inner);
+                (element_type, *len)
+            }
+            other => panic!(
+                "Expected array at pool index {}, got {:?}",
+                pool_index, other
+            ),
+        }
+    }
+
+    /// Intern an array type from a Type element (for Phase 2B migration).
+    ///
+    /// This is a helper method that converts the Type to InternedType
+    /// and then interns the array. Used during migration from ArrayTypeRegistry.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the element type contains a struct/enum that isn't in the pool.
+    pub fn intern_array_from_type(&self, element_type: Type, len: u64) -> ArrayTypeId {
+        let element_interned = Self::type_to_interned_recursive(element_type);
+        let array_interned = self.intern_array(element_interned, len);
+        ArrayTypeId::from_pool_index(
+            array_interned
+                .pool_index()
+                .expect("array must have pool index"),
+        )
+    }
+
+    /// Look up an array type by Type element and length (for Phase 2B migration).
+    ///
+    /// Returns None if no such array exists in the pool.
+    pub fn get_array_by_type(&self, element_type: Type, len: u64) -> Option<ArrayTypeId> {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        let element_interned = Self::type_to_interned_recursive(element_type);
+        let array_interned = inner.array_map.get(&(element_interned, len))?;
+        Some(ArrayTypeId::from_pool_index(
+            array_interned
+                .pool_index()
+                .expect("array must have pool index"),
+        ))
+    }
+
+    /// Convert InternedType to Type recursively (handles composite types).
+    ///
+    /// This is used to convert array element types from InternedType back to Type.
+    fn interned_to_type_recursive(ty: InternedType, inner: &TypeInternPoolInner) -> Type {
+        if ty.is_primitive() {
+            return match ty.0 {
+                0 => Type::I8,
+                1 => Type::I16,
+                2 => Type::I32,
+                3 => Type::I64,
+                4 => Type::U8,
+                5 => Type::U16,
+                6 => Type::U32,
+                7 => Type::U64,
+                8 => Type::Bool,
+                9 => Type::Unit,
+                10 => Type::Never,
+                11 => Type::Error,
+                _ => panic!("Unknown primitive index: {}", ty.0),
+            };
+        }
+
+        let pool_index = ty.pool_index().expect("non-primitive must have pool index");
+        match &inner.types[pool_index as usize] {
+            TypeData::Struct(_) => Type::Struct(StructId::from_pool_index(pool_index)),
+            TypeData::Enum(_) => Type::Enum(EnumId::from_pool_index(pool_index)),
+            TypeData::Array { .. } => Type::Array(ArrayTypeId::from_pool_index(pool_index)),
+        }
+    }
+
+    /// Convert Type to InternedType recursively (handles composite types).
+    ///
+    /// This is used during Phase 2B migration to convert Type to InternedType
+    /// for array interning.
+    fn type_to_interned_recursive(ty: Type) -> InternedType {
+        match ty.kind() {
+            TypeKind::I8 => InternedType::I8,
+            TypeKind::I16 => InternedType::I16,
+            TypeKind::I32 => InternedType::I32,
+            TypeKind::I64 => InternedType::I64,
+            TypeKind::U8 => InternedType::U8,
+            TypeKind::U16 => InternedType::U16,
+            TypeKind::U32 => InternedType::U32,
+            TypeKind::U64 => InternedType::U64,
+            TypeKind::Bool => InternedType::BOOL,
+            TypeKind::Unit => InternedType::UNIT,
+            TypeKind::Never => InternedType::NEVER,
+            TypeKind::Error => InternedType::ERROR,
+            TypeKind::Struct(id) => InternedType::from_pool_index(id.pool_index()),
+            TypeKind::Enum(id) => InternedType::from_pool_index(id.pool_index()),
+            TypeKind::Array(id) => InternedType::from_pool_index(id.pool_index()),
+            TypeKind::Module(_) => panic!("Cannot intern module types"),
+            TypeKind::ComptimeType => panic!("Cannot intern comptime types"),
+        }
+    }
+
+    /// Convert an ArrayTypeId to an InternedType.
+    ///
+    /// Since ArrayTypeId now contains a pool index, we just add the primitive offset.
+    #[inline]
+    pub fn array_id_to_interned(&self, array_id: ArrayTypeId) -> InternedType {
+        InternedType::from_pool_index(array_id.0)
+    }
+
     /// Get all struct IDs registered in the pool.
     ///
     /// Returns a vector of all StructId values, useful for iterating over all
@@ -609,6 +734,23 @@ impl TypeInternPool {
             .map(|interned| {
                 let pool_index = interned.pool_index().expect("enum must have pool index");
                 EnumId::from_pool_index(pool_index)
+            })
+            .collect()
+    }
+
+    /// Get all array IDs registered in the pool.
+    ///
+    /// Returns a vector of all ArrayTypeId values, useful for iterating over all
+    /// arrays (e.g., for drop glue synthesis).
+    pub fn all_array_ids(&self) -> Vec<ArrayTypeId> {
+        let inner = self.inner.read().expect("TypeInternPool lock poisoned");
+        inner
+            .types
+            .iter()
+            .enumerate()
+            .filter_map(|(idx, data)| match data {
+                TypeData::Array { .. } => Some(ArrayTypeId(idx as u32)),
+                _ => None,
             })
             .collect()
     }
@@ -662,25 +804,27 @@ impl TypeInternPool {
     /// in the pool. For array types, this returns an error since array interning
     /// requires the pool to already have the element type interned.
     pub fn type_to_interned(&self, ty: Type) -> Option<InternedType> {
-        match ty {
-            Type::I8 => Some(InternedType::I8),
-            Type::I16 => Some(InternedType::I16),
-            Type::I32 => Some(InternedType::I32),
-            Type::I64 => Some(InternedType::I64),
-            Type::U8 => Some(InternedType::U8),
-            Type::U16 => Some(InternedType::U16),
-            Type::U32 => Some(InternedType::U32),
-            Type::U64 => Some(InternedType::U64),
-            Type::Bool => Some(InternedType::BOOL),
-            Type::Unit => Some(InternedType::UNIT),
-            Type::Never => Some(InternedType::NEVER),
-            Type::Error => Some(InternedType::ERROR),
+        match ty.kind() {
+            TypeKind::I8 => Some(InternedType::I8),
+            TypeKind::I16 => Some(InternedType::I16),
+            TypeKind::I32 => Some(InternedType::I32),
+            TypeKind::I64 => Some(InternedType::I64),
+            TypeKind::U8 => Some(InternedType::U8),
+            TypeKind::U16 => Some(InternedType::U16),
+            TypeKind::U32 => Some(InternedType::U32),
+            TypeKind::U64 => Some(InternedType::U64),
+            TypeKind::Bool => Some(InternedType::BOOL),
+            TypeKind::Unit => Some(InternedType::UNIT),
+            TypeKind::Never => Some(InternedType::NEVER),
+            TypeKind::Error => Some(InternedType::ERROR),
             // Struct, enum, array, and module require pool lookup by ID - we need the name
             // to find the interned type. This conversion is not straightforward
             // without additional context. Return None to indicate we can't convert.
-            Type::Struct(_) | Type::Enum(_) | Type::Array(_) | Type::Module(_) => None,
+            TypeKind::Struct(_) | TypeKind::Enum(_) | TypeKind::Array(_) | TypeKind::Module(_) => {
+                None
+            }
             // ComptimeType is a comptime-only type, cannot be interned for runtime
-            Type::ComptimeType => None,
+            TypeKind::ComptimeType => None,
         }
     }
 

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -45,8 +45,8 @@ pub use sema_context::{
 };
 pub use type_context::{FunctionSignature, MethodSignature, TypeContext};
 pub use types::{
-    ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, StructDef, StructField,
-    StructId, Type, parse_array_type_syntax,
+    ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, StructDef, StructField, StructId, Type,
+    TypeKind, parse_array_type_syntax,
 };
 
 /// Sentinel value used to encode parameter slots in AIR instructions.

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -41,7 +41,7 @@ use crate::inference::{
 use crate::inst::{Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirPattern, AirRef};
 use crate::scope::ScopedContext;
 use crate::sema_context::SemaContext;
-use crate::types::{EnumId, StructDef, StructField, StructId, Type};
+use crate::types::{EnumId, StructDef, StructField, StructId, Type, TypeKind};
 
 /// Try to evaluate an RIR expression as a compile-time constant.
 ///
@@ -470,9 +470,6 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
 
     let mut output = SemaOutput {
         functions,
-        struct_defs: std::mem::take(&mut sema.struct_defs),
-        enum_defs: std::mem::take(&mut sema.enum_defs),
-        array_types: std::mem::take(&mut sema.array_type_defs),
         strings: global_strings,
         warnings: all_warnings,
         type_pool: sema.type_pool.clone(),
@@ -506,17 +503,8 @@ fn analyze_all_function_bodies_parallel(sema: Sema<'_>) -> MultiErrorResult<Sema
         .map(|job| analyze_function_job(&ctx, job))
         .collect();
 
-    // Extract array types from the thread-safe registry
-    let array_type_defs = ctx.array_registry.into_defs();
-
-    // Merge results
-    merge_function_results(
-        results,
-        sema.struct_defs,
-        sema.enum_defs,
-        array_type_defs,
-        sema.type_pool,
-    )
+    // Merge results (array types are now in the type pool)
+    merge_function_results(results, sema.type_pool)
 }
 
 /// Collect all functions to be analyzed from the RIR.
@@ -1307,11 +1295,11 @@ fn analyze_inst_with_context(
                 // Check if this value, when negated, fits in the target signed type
                 if ty.negated_literal_fits(*value) && !ty.literal_fits(*value) {
                     // This is the MIN value case - store the MIN value directly.
-                    let neg_value = match ty {
-                        Type::I8 => (i8::MIN as i64) as u64,
-                        Type::I16 => (i16::MIN as i64) as u64,
-                        Type::I32 => (i32::MIN as i64) as u64,
-                        Type::I64 => i64::MIN as u64,
+                    let neg_value = match ty.kind() {
+                        TypeKind::I8 => (i8::MIN as i64) as u64,
+                        TypeKind::I16 => (i16::MIN as i64) as u64,
+                        TypeKind::I32 => (i32::MIN as i64) as u64,
+                        TypeKind::I64 => i64::MIN as u64,
                         _ => unreachable!(),
                     };
                     let air_ref = air.add_inst(AirInst {
@@ -1827,9 +1815,6 @@ where
 /// Merge results from parallel function analysis.
 fn merge_function_results(
     results: Vec<FunctionResult>,
-    struct_defs: Vec<crate::types::StructDef>,
-    enum_defs: Vec<crate::types::EnumDef>,
-    array_type_defs: Vec<crate::types::ArrayTypeDef>,
     type_pool: crate::intern_pool::TypeInternPool,
 ) -> MultiErrorResult<SemaOutput> {
     let mut errors = CompileErrors::new();
@@ -1876,9 +1861,6 @@ fn merge_function_results(
 
     errors.into_result_with(SemaOutput {
         functions,
-        struct_defs,
-        enum_defs,
-        array_types: array_type_defs,
         strings: global_strings,
         warnings: all_warnings,
         type_pool,
@@ -3084,8 +3066,8 @@ fn analyze_inst_for_projection_ctx(
             let base_result = analyze_inst_for_projection_ctx(ctx, air, *base, analysis_ctx)?;
             let base_type = base_result.ty;
 
-            let struct_id = match base_type {
-                Type::Struct(id) => id,
+            let struct_id = match base_type.kind() {
+                TypeKind::Struct(id) => id,
                 _ => {
                     return Err(CompileError::new(
                         ErrorKind::FieldAccessOnNonStruct {
@@ -3129,10 +3111,10 @@ fn analyze_inst_for_projection_ctx(
             let index_result = analyze_inst_with_context(ctx, air, *index, analysis_ctx)?;
 
             // Verify base is an array
-            let (array_type_id, elem_type, _array_len) = match base_type {
-                Type::Array(type_id) => {
-                    let array_def = ctx.get_array_type_def(type_id);
-                    (type_id, array_def.element_type, array_def.length)
+            let (array_type_id, elem_type, _array_len) = match base_type.kind() {
+                TypeKind::Array(type_id) => {
+                    let (element_type, length) = ctx.get_array_type_def(type_id);
+                    (type_id, element_type, length)
                 }
                 _ => {
                     return Err(CompileError::new(
@@ -3201,8 +3183,8 @@ fn analyze_field_get_ctx(
     let base_result = analyze_inst_for_projection_ctx(ctx, air, base, analysis_ctx)?;
     let base_type = base_result.ty;
 
-    let struct_id = match base_type {
-        Type::Struct(id) => id,
+    let struct_id = match base_type.kind() {
+        TypeKind::Struct(id) => id,
         _ => {
             return Err(CompileError::new(
                 ErrorKind::FieldAccessOnNonStruct {
@@ -3433,8 +3415,8 @@ fn analyze_field_set_ctx(
     let mut slot_offset: u32 = 0;
 
     for field_sym in field_symbols.iter().rev() {
-        let struct_id = match current_type {
-            Type::Struct(id) => id,
+        let struct_id = match current_type.kind() {
+            TypeKind::Struct(id) => id,
             _ => {
                 return Err(CompileError::new(
                     ErrorKind::FieldAccessOnNonStruct {
@@ -3462,8 +3444,8 @@ fn analyze_field_set_ctx(
     }
 
     // Now handle the final field being assigned
-    let struct_id = match current_type {
-        Type::Struct(id) => id,
+    let struct_id = match current_type.kind() {
+        TypeKind::Struct(id) => id,
         _ => {
             return Err(CompileError::new(
                 ErrorKind::FieldAccessOnNonStruct {
@@ -3533,10 +3515,10 @@ fn analyze_array_init_ctx(
     // Get the array type from HM inference
     let array_type = get_resolved_type_ctx(analysis_ctx, inst_ref, span, "array literal")?;
 
-    let (array_type_id, _elem_type, expected_len) = match array_type {
-        Type::Array(type_id) => {
-            let array_def = ctx.get_array_type_def(type_id);
-            (type_id, array_def.element_type, array_def.length)
+    let (array_type_id, _elem_type, expected_len) = match array_type.kind() {
+        TypeKind::Array(type_id) => {
+            let (element_type, length) = ctx.get_array_type_def(type_id);
+            (type_id, element_type, length)
         }
         _ => {
             return Err(CompileError::new(
@@ -3616,10 +3598,10 @@ fn analyze_index_get_ctx(
     let index_result = analyze_inst_with_context(ctx, air, index, analysis_ctx)?;
 
     // Verify base is an array
-    let (array_type_id, elem_type, array_len) = match base_type {
-        Type::Array(type_id) => {
-            let array_def = ctx.get_array_type_def(type_id);
-            (type_id, array_def.element_type, array_def.length)
+    let (array_type_id, elem_type, array_len) = match base_type.kind() {
+        TypeKind::Array(type_id) => {
+            let (element_type, length) = ctx.get_array_type_def(type_id);
+            (type_id, element_type, length)
         }
         _ => {
             return Err(CompileError::new(
@@ -3797,10 +3779,10 @@ fn analyze_index_set_ctx(
     };
 
     // Verify base is an array and get its element type
-    let (array_type_id, _elem_type, array_len) = match base_type {
-        Type::Array(type_id) => {
-            let array_def = ctx.get_array_type_def(type_id);
-            (type_id, array_def.element_type, array_def.length)
+    let (array_type_id, _elem_type, array_len) = match base_type.kind() {
+        TypeKind::Array(type_id) => {
+            let (element_type, length) = ctx.get_array_type_def(type_id);
+            (type_id, element_type, length)
         }
         _ => {
             return Err(CompileError::new(
@@ -4176,7 +4158,7 @@ fn analyze_method_call_ctx(
     let receiver_type = receiver_result.ty;
 
     // Handle module member access: module.function() becomes a direct function call
-    if let Type::Module(_module_id) = receiver_type {
+    if receiver_type.is_module() {
         return analyze_module_member_call_ctx(
             ctx,
             air,
@@ -4189,8 +4171,8 @@ fn analyze_method_call_ctx(
     }
 
     // Get the type name for method lookup
-    let type_name = match receiver_type {
-        Type::Struct(struct_id) => {
+    let type_name = match receiver_type.kind() {
+        TypeKind::Struct(struct_id) => {
             let struct_def = ctx.get_struct_def(struct_id);
             ctx.interner.get_or_intern(&struct_def.name)
         }
@@ -4207,7 +4189,7 @@ fn analyze_method_call_ctx(
     };
 
     // Check if this is a builtin type with builtin methods
-    if let Type::Struct(struct_id) = receiver_type {
+    if let Some(struct_id) = receiver_type.as_struct() {
         if let Some(builtin_def) = ctx.get_builtin_type_def(struct_id) {
             let method_name = ctx.interner.resolve(&method);
             if let Some(builtin_method) = builtin_def.find_method(method_name) {
@@ -4399,8 +4381,8 @@ fn analyze_builtin_method_ctx(
     let air_args = analyze_call_args_ctx(ctx, air, &args, analysis_ctx)?;
 
     // Get the struct ID for builtin type
-    let struct_id = match receiver_type {
-        Type::Struct(id) => id,
+    let struct_id = match receiver_type.kind() {
+        TypeKind::Struct(id) => id,
         _ => unreachable!("builtin method called on non-struct type"),
     };
 
@@ -5501,8 +5483,8 @@ impl<'a> Sema<'a> {
             let base_result = self.analyze_inst_for_projection(air, *base, ctx)?;
             let base_type = base_result.ty;
 
-            let struct_id = match base_type {
-                Type::Struct(id) => id,
+            let struct_id = match base_type.kind() {
+                TypeKind::Struct(id) => id,
                 _ => {
                     return Err(CompileError::new(
                         ErrorKind::FieldAccessOnNonStruct {
@@ -5547,8 +5529,8 @@ impl<'a> Sema<'a> {
             let base_result = self.analyze_inst_for_projection(air, *base, ctx)?;
             let base_type = base_result.ty;
 
-            let array_type_id = match base_type {
-                Type::Array(id) => id,
+            let array_type_id = match base_type.kind() {
+                TypeKind::Array(id) => id,
                 _ => {
                     return Err(CompileError::new(
                         ErrorKind::IndexOnNonArray {
@@ -5558,6 +5540,8 @@ impl<'a> Sema<'a> {
                     ));
                 }
             };
+
+            let (element_type, length) = self.type_pool.array_def(array_type_id);
 
             // Index must be an unsigned integer
             let index_result = self.analyze_inst(air, *index, ctx)?;
@@ -5571,9 +5555,7 @@ impl<'a> Sema<'a> {
                 ));
             }
 
-            let array_def = &self.array_type_defs[array_type_id.0 as usize];
-            let element_type = array_def.element_type;
-            let array_length = array_def.length;
+            let array_length = length;
 
             // Compile-time bounds check for constant indices
             if let Some(const_index) = self.try_get_const_index(*index) {
@@ -6068,8 +6050,8 @@ impl<'a> Sema<'a> {
         let mut slot_offset: u32 = 0;
 
         for field_sym in field_symbols.iter().rev() {
-            let struct_id = match current_type {
-                Type::Struct(id) => id,
+            let struct_id = match current_type.kind() {
+                TypeKind::Struct(id) => id,
                 _ => {
                     return Err(CompileError::new(
                         ErrorKind::FieldAccessOnNonStruct {
@@ -6097,8 +6079,8 @@ impl<'a> Sema<'a> {
         }
 
         // Now handle the final field being assigned
-        let struct_id = match current_type {
-            Type::Struct(id) => id,
+        let struct_id = match current_type.kind() {
+            TypeKind::Struct(id) => id,
             _ => {
                 return Err(CompileError::new(
                     ErrorKind::FieldAccessOnNonStruct {
@@ -6271,8 +6253,8 @@ impl<'a> Sema<'a> {
             }
         };
 
-        let array_type_id = match base_type {
-            Type::Array(id) => id,
+        let array_type_id = match base_type.kind() {
+            TypeKind::Array(id) => id,
             _ => {
                 return Err(CompileError::new(
                     ErrorKind::IndexOnNonArray {
@@ -6282,6 +6264,8 @@ impl<'a> Sema<'a> {
                 ));
             }
         };
+
+        let (element_type, length) = self.type_pool.array_def(array_type_id);
 
         // Index must be an unsigned integer
         let index_result = self.analyze_inst(air, index, ctx)?;
@@ -6295,9 +6279,7 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        let array_def = &self.array_type_defs[array_type_id.0 as usize];
-        let element_type = array_def.element_type;
-        let array_length = array_def.length;
+        let array_length = length;
 
         // Compile-time bounds check for constant indices
         if let Some(const_index) = self.try_get_const_index(index) {
@@ -6372,14 +6354,14 @@ impl<'a> Sema<'a> {
         let receiver_type = receiver_result.ty;
 
         // Handle module member access: module.function() becomes a direct function call
-        if let Type::Module(_module_id) = receiver_type {
+        if receiver_type.is_module() {
             return self
                 .analyze_module_member_call_impl(air, method, args_start, args_len, span, ctx);
         }
 
         // Check that receiver is a struct type
-        let struct_id = match receiver_type {
-            Type::Struct(id) => id,
+        let struct_id = match receiver_type.kind() {
+            TypeKind::Struct(id) => id,
             _ => {
                 return Err(CompileError::new(
                     ErrorKind::MethodCallOnNonStruct {

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -34,7 +34,7 @@ use super::Sema;
 use super::context::{AnalysisContext, AnalysisResult, LocalVar};
 use crate::inst::{Air, AirCallArg, AirInst, AirInstData, AirPattern, AirRef};
 use crate::scope::ScopedContext;
-use crate::types::Type;
+use crate::types::{Type, TypeKind};
 
 impl<'a> Sema<'a> {
     // ========================================================================
@@ -156,11 +156,11 @@ impl<'a> Sema<'a> {
                     // Check if this value, when negated, fits in the target signed type
                     if ty.negated_literal_fits(*value) && !ty.literal_fits(*value) {
                         // This is the MIN value case - store the MIN value directly.
-                        let neg_value = match ty {
-                            Type::I8 => (i8::MIN as i64) as u64,
-                            Type::I16 => (i16::MIN as i64) as u64,
-                            Type::I32 => (i32::MIN as i64) as u64,
-                            Type::I64 => i64::MIN as u64,
+                        let neg_value = match ty.kind() {
+                            TypeKind::I8 => (i8::MIN as i64) as u64,
+                            TypeKind::I16 => (i16::MIN as i64) as u64,
+                            TypeKind::I32 => (i32::MIN as i64) as u64,
+                            TypeKind::I64 => i64::MIN as u64,
                             _ => unreachable!(),
                         };
                         let air_ref = air.add_inst(AirInst {
@@ -1523,9 +1523,9 @@ impl<'a> Sema<'a> {
         let base_result = self.analyze_inst_for_projection(air, base, ctx)?;
         let base_type = base_result.ty;
 
-        let struct_id = match base_type {
-            Type::Struct(id) => id,
-            _ => {
+        let struct_id = match base_type.as_struct() {
+            Some(id) => id,
+            None => {
                 return Err(CompileError::new(
                     ErrorKind::FieldAccessOnNonStruct {
                         found: base_type.name().to_string(),
@@ -1673,12 +1673,12 @@ impl<'a> Sema<'a> {
         // Get the array type from HM inference
         let array_type = Self::get_resolved_type(ctx, inst_ref, span, "array literal")?;
 
-        let (array_type_id, _elem_type, expected_len) = match array_type {
-            Type::Array(type_id) => {
-                let array_def = &self.array_type_defs[type_id.0 as usize];
-                (type_id, array_def.element_type, array_def.length)
+        let (array_type_id, _elem_type, expected_len) = match array_type.as_array() {
+            Some(type_id) => {
+                let (element_type, length) = self.type_pool.array_def(type_id);
+                (type_id, element_type, length)
             }
-            _ => {
+            None => {
                 return Err(CompileError::new(
                     ErrorKind::InternalError(format!(
                         "Array literal inferred as non-array type: {}",
@@ -1739,12 +1739,12 @@ impl<'a> Sema<'a> {
         let index_result = self.analyze_inst(air, index, ctx)?;
 
         // Verify base is an array
-        let (array_type_id, elem_type, array_len) = match base_type {
-            Type::Array(type_id) => {
-                let array_def = &self.array_type_defs[type_id.0 as usize];
-                (type_id, array_def.element_type, array_def.length)
+        let (array_type_id, elem_type, array_len) = match base_type.as_array() {
+            Some(type_id) => {
+                let (element_type, length) = self.type_pool.array_def(type_id);
+                (type_id, element_type, length)
             }
-            _ => {
+            None => {
                 return Err(CompileError::new(
                     ErrorKind::IndexOnNonArray {
                         found: base_type.name().to_string(),

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -7,7 +7,7 @@
 use rue_builtins::{BUILTIN_TYPES, BuiltinFieldType, BuiltinTypeDef};
 
 use super::Sema;
-use crate::types::{StructDef, StructField, StructId, Type};
+use crate::types::{StructDef, StructField, StructId, Type, TypeKind};
 
 impl<'a> Sema<'a> {
     /// Phase 0: Inject built-in types as synthetic structs.
@@ -48,12 +48,7 @@ impl<'a> Sema<'a> {
 
             // Register in type pool and get pool-based StructId
             let name_spur = self.interner.get_or_intern(builtin.name);
-            let (struct_id, _) = self
-                .type_pool
-                .register_struct(name_spur, struct_def.clone());
-
-            // Keep in struct_defs for backwards compatibility during migration
-            self.struct_defs.push(struct_def);
+            let (struct_id, _) = self.type_pool.register_struct(name_spur, struct_def);
 
             // Register in struct lookup with pool-based StructId
             self.structs.insert(name_spur, struct_id);
@@ -77,8 +72,8 @@ impl<'a> Sema<'a> {
     ///
     /// Uses the stored `builtin_string_id` for fast comparison.
     pub(crate) fn is_builtin_string(&self, ty: Type) -> bool {
-        match ty {
-            Type::Struct(struct_id) => Some(struct_id) == self.builtin_string_id,
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => Some(struct_id) == self.builtin_string_id,
             _ => false,
         }
     }
@@ -138,8 +133,8 @@ impl<'a> Sema<'a> {
     /// Check if a type is a linear type.
     /// Only struct types can be linear - primitives and other types are not linear.
     pub(crate) fn is_type_linear(&self, ty: Type) -> bool {
-        match ty {
-            Type::Struct(struct_id) => {
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => {
                 let struct_def = self.type_pool.struct_def(struct_id);
                 struct_def.is_linear
             }

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -66,9 +66,8 @@ impl<'a> Sema<'a> {
             func_sigs,
             method_sigs,
             struct_by_name: self.structs.clone(),
-            struct_defs: self.struct_defs.clone(),
             enum_by_name: self.enums.clone(),
-            enum_defs: self.enum_defs.clone(),
+            type_pool: self.type_pool.clone(),
         }
     }
     /// Build an `InferenceContext` from the collected type information.
@@ -245,10 +244,7 @@ impl<'a> Sema<'a> {
                     };
 
                     // Register in type pool and get pool-based EnumId
-                    let (enum_id, _) = self.type_pool.register_enum(*name, enum_def.clone());
-
-                    // Keep in enum_defs for backwards compatibility during migration
-                    self.enum_defs.push(enum_def);
+                    let (enum_id, _) = self.type_pool.register_enum(*name, enum_def);
 
                     // Register in enum lookup with pool-based EnumId
                     self.enums.insert(*name, enum_id);
@@ -321,10 +317,7 @@ impl<'a> Sema<'a> {
                     };
 
                     // Register in type pool and get pool-based StructId
-                    let (struct_id, _) = self.type_pool.register_struct(*name, struct_def.clone());
-
-                    // Keep in struct_defs for backwards compatibility during migration
-                    self.struct_defs.push(struct_def);
+                    let (struct_id, _) = self.type_pool.register_struct(*name, struct_def);
 
                     // Register in struct lookup with pool-based StructId
                     self.structs.insert(*name, struct_id);
@@ -369,17 +362,8 @@ impl<'a> Sema<'a> {
     pub(crate) fn populate_type_pool(&mut self) {
         // Update all structs in the pool with resolved field definitions
         for (_, &struct_id) in &self.structs {
-            // Get the fully resolved struct_def from the vector
-            // Note: During this migration phase, struct_defs still uses vector indices
-            // We need to find the matching entry by iterating
-            let pool_def = self.type_pool.struct_def(struct_id);
-            // Find the struct_def in the vector by name (not by struct_id which is pool-based)
-            let vec_def = self
-                .struct_defs
-                .iter()
-                .find(|d| d.name == pool_def.name)
-                .expect("struct must exist in struct_defs");
-            self.type_pool.update_struct_def(struct_id, vec_def.clone());
+            // The struct is already in the pool from register_type_names
+            // No need to update it again - it's the source of truth
         }
 
         // Note: Enum definitions don't need updating as they are complete when registered.
@@ -410,21 +394,16 @@ impl<'a> Sema<'a> {
                     ));
                 }
 
-                // Find the vector index by searching for the matching name
-                // (struct_defs uses sequential indices, not pool indices)
-                let vec_index = self
-                    .struct_defs
-                    .iter()
-                    .position(|d| d.name == name_str)
-                    .ok_or_else(|| {
-                        CompileError::new(
-                            ErrorKind::InternalError(format!(
-                                "struct '{}' not found in struct_defs during field resolution",
-                                name_str
-                            )),
-                            inst.span,
-                        )
-                    })?;
+                // Get the struct ID from the lookup table
+                let struct_id = *self.structs.get(name).ok_or_else(|| {
+                    CompileError::new(
+                        ErrorKind::InternalError(format!(
+                            "struct '{}' not found in structs map during field resolution",
+                            name_str
+                        )),
+                        inst.span,
+                    )
+                })?;
 
                 let struct_name = name_str.clone();
                 let fields = self.rir.get_field_decls(*fields_start, *fields_len);
@@ -454,7 +433,10 @@ impl<'a> Sema<'a> {
                     });
                 }
 
-                self.struct_defs[vec_index].fields = resolved_fields;
+                // Update the struct definition in the pool with resolved fields
+                let mut struct_def = self.type_pool.struct_def(struct_id);
+                struct_def.fields = resolved_fields;
+                self.type_pool.update_struct_def(struct_id, struct_def);
             }
         }
         Ok(())
@@ -554,20 +536,19 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        // Find struct in vector by name (type_pool may not have updated fields yet)
-        let struct_def = self
-            .struct_defs
-            .iter()
-            .find(|d| d.name == struct_name)
-            .ok_or_else(|| {
-                CompileError::new(
-                    ErrorKind::InternalError(format!(
-                        "struct '{}' not found in struct_defs during @copy validation",
-                        struct_name
-                    )),
-                    span,
-                )
-            })?;
+        // Get the struct ID from the lookup table
+        let struct_id = *self.structs.get(&name).ok_or_else(|| {
+            CompileError::new(
+                ErrorKind::InternalError(format!(
+                    "struct '{}' not found in structs map during @copy validation",
+                    struct_name
+                )),
+                span,
+            )
+        })?;
+
+        // Get struct definition from the pool
+        let struct_def = self.type_pool.struct_def(struct_id);
 
         for field in &struct_def.fields {
             if !self.is_type_copy(field.ty) {
@@ -726,23 +707,18 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        // Find the vector index by searching for the matching name
-        // (struct_defs uses sequential indices, not pool indices)
-        let vec_index = self
-            .struct_defs
-            .iter()
-            .position(|d| d.name == type_name_str)
-            .ok_or_else(|| {
-                CompileError::new(
-                    ErrorKind::InternalError(format!(
-                        "struct '{}' not found in struct_defs during destructor collection",
-                        type_name_str
-                    )),
-                    span,
-                )
-            })?;
+        // Get the struct ID from the lookup table
+        let struct_id = *self.structs.get(&type_name).ok_or_else(|| {
+            CompileError::new(
+                ErrorKind::InternalError(format!(
+                    "struct '{}' not found in structs map during destructor collection",
+                    type_name_str
+                )),
+                span,
+            )
+        })?;
 
-        let struct_def = &self.struct_defs[vec_index];
+        let mut struct_def = self.type_pool.struct_def(struct_id);
         if struct_def.destructor.is_some() {
             return Err(CompileError::new(
                 ErrorKind::DuplicateDestructor {
@@ -753,7 +729,8 @@ impl<'a> Sema<'a> {
         }
 
         let destructor_name = format!("{}.__drop", type_name_str);
-        self.struct_defs[vec_index].destructor = Some(destructor_name);
+        struct_def.destructor = Some(destructor_name);
+        self.type_pool.update_struct_def(struct_id, struct_def);
         Ok(())
     }
 

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -37,12 +37,8 @@ use rue_error::{CompileErrors, MultiErrorResult, PreviewFeatures};
 use rue_rir::Rir;
 
 use crate::intern_pool::TypeInternPool;
-use crate::sema_context::{
-    ArrayTypeRegistry, InferenceContext as SemaContextInferenceContext, SemaContext,
-};
-use crate::types::{
-    ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, StructDef, StructField, StructId, Type,
-};
+use crate::sema_context::{InferenceContext as SemaContextInferenceContext, SemaContext};
+use crate::types::{ArrayTypeId, EnumDef, EnumId, StructDef, StructField, StructId, Type};
 
 // Internal types are used via pub(crate) within submodules
 // No re-exports needed for context types as they're internal
@@ -84,15 +80,6 @@ pub struct GatherOutput<'a> {
     pub rir: &'a Rir,
     /// Reference to the string interner.
     pub interner: &'a ThreadedRodeo,
-    /// Struct definitions indexed by StructId.
-    pub struct_defs: Vec<StructDef>,
-    /// Enum definitions indexed by EnumId.
-    pub enum_defs: Vec<EnumDef>,
-    /// Array type table: maps (element_type, length) to ArrayTypeId.
-    /// Pre-populated during declaration gathering for array types in signatures.
-    pub array_types: HashMap<(Type, u64), ArrayTypeId>,
-    /// Array type definitions indexed by ArrayTypeId.
-    pub array_type_defs: Vec<ArrayTypeDef>,
     /// Struct lookup: maps struct name symbol to StructId.
     pub structs: HashMap<Spur, StructId>,
     /// Enum lookup: maps enum name symbol to EnumId.
@@ -120,11 +107,7 @@ impl<'a> GatherOutput<'a> {
             interner: self.interner,
             functions: self.functions,
             structs: self.structs,
-            struct_defs: self.struct_defs,
             enums: self.enums,
-            enum_defs: self.enum_defs,
-            array_types: self.array_types,
-            array_type_defs: self.array_type_defs,
             methods: self.methods,
             preview_features: self.preview_features,
             builtin_string_id: self.builtin_string_id,
@@ -132,14 +115,6 @@ impl<'a> GatherOutput<'a> {
             type_pool: self.type_pool,
             module_registry: crate::sema_context::ModuleRegistry::new(),
         }
-    }
-
-    /// Consume the gather output and return ownership of struct and enum definitions.
-    ///
-    /// This is used after all function analysis is complete to build the final
-    /// `SemaOutput`.
-    pub fn into_type_defs(self) -> (Vec<StructDef>, Vec<EnumDef>) {
-        (self.struct_defs, self.enum_defs)
     }
 }
 
@@ -168,17 +143,11 @@ pub struct AnalyzedFunction {
 pub struct SemaOutput {
     /// Analyzed functions with typed IR.
     pub functions: Vec<AnalyzedFunction>,
-    /// Struct definitions.
-    pub struct_defs: Vec<StructDef>,
-    /// Enum definitions.
-    pub enum_defs: Vec<EnumDef>,
-    /// Array type definitions.
-    pub array_types: Vec<ArrayTypeDef>,
     /// String literals indexed by their AIR string_const index.
     pub strings: Vec<String>,
     /// Warnings collected during analysis.
     pub warnings: Vec<rue_error::CompileWarning>,
-    /// Type intern pool (Phase 1: coexists with existing type system).
+    /// Type intern pool (contains all types including arrays).
     pub type_pool: TypeInternPool,
 }
 
@@ -256,16 +225,8 @@ pub struct Sema<'a> {
     pub(crate) functions: HashMap<Spur, FunctionInfo>,
     /// Struct table: maps struct name symbols to their StructId
     pub(crate) structs: HashMap<Spur, StructId>,
-    /// Struct definitions indexed by StructId
-    pub(crate) struct_defs: Vec<StructDef>,
     /// Enum table: maps enum name symbols to their EnumId
     pub(crate) enums: HashMap<Spur, EnumId>,
-    /// Enum definitions indexed by EnumId
-    pub(crate) enum_defs: Vec<EnumDef>,
-    /// Array type table: maps (element_type, length) to ArrayTypeId
-    pub(crate) array_types: HashMap<(Type, u64), ArrayTypeId>,
-    /// Array type definitions indexed by ArrayTypeId
-    pub(crate) array_type_defs: Vec<ArrayTypeDef>,
     /// Method table: maps (struct_name, method_name) to method info
     /// Used for resolving method calls (receiver.method()) and associated
     /// function calls (Type::function())
@@ -299,11 +260,7 @@ impl<'a> Sema<'a> {
             interner,
             functions: HashMap::new(),
             structs: HashMap::new(),
-            struct_defs: Vec::new(),
             enums: HashMap::new(),
-            enum_defs: Vec::new(),
-            array_types: HashMap::new(),
-            array_type_defs: Vec::new(),
             methods: HashMap::new(),
             preview_features,
             builtin_string_id: None,
@@ -412,10 +369,6 @@ impl<'a> Sema<'a> {
         let output = GatherOutput {
             rir: self.rir,
             interner: self.interner,
-            struct_defs: self.struct_defs,
-            enum_defs: self.enum_defs,
-            array_types: self.array_types,
-            array_type_defs: self.array_type_defs,
             structs: self.structs,
             enums: self.enums,
             functions: self.functions,
@@ -460,12 +413,6 @@ impl<'a> Sema<'a> {
         SemaContext {
             rir: self.rir,
             interner: self.interner,
-            struct_defs: self.struct_defs.clone(),
-            enum_defs: self.enum_defs.clone(),
-            array_registry: ArrayTypeRegistry::from_existing(
-                self.array_types.clone(),
-                self.array_type_defs.clone(),
-            ),
             structs: self.structs.clone(),
             enums: self.enums.clone(),
             // Pass references to functions/methods instead of cloning.
@@ -559,7 +506,8 @@ impl<'a> Sema<'a> {
     pub(crate) fn find_or_create_anon_struct(&mut self, fields: &[StructField]) -> Type {
         // Check if an equivalent anonymous struct already exists
         // Anonymous structs have names starting with "__anon_struct_"
-        for (i, struct_def) in self.struct_defs.iter().enumerate() {
+        for struct_id in self.type_pool.all_struct_ids() {
+            let struct_def = self.type_pool.struct_def(struct_id);
             if struct_def.name.starts_with("__anon_struct_") {
                 if struct_def.fields.len() == fields.len() {
                     let mut all_match = true;
@@ -570,23 +518,21 @@ impl<'a> Sema<'a> {
                         }
                     }
                     if all_match {
-                        return Type::Struct(StructId(i as u32));
+                        return Type::Struct(struct_id);
                     }
                 }
             }
         }
 
         // No matching struct found - create a new one
-        let struct_id = StructId(self.struct_defs.len() as u32);
-        let anon_name = format!("__anon_struct_{}", struct_id.0);
+        let anon_name_temp = format!("__anon_struct_temp_{}", self.type_pool.len());
+        let name_spur = self.interner.get_or_intern(&anon_name_temp);
 
         // Determine if the struct is Copy (all fields are Copy)
-        let is_copy = fields
-            .iter()
-            .all(|f| f.ty.is_copy_in_sema(&self.struct_defs));
+        let is_copy = fields.iter().all(|f| f.ty.is_copy_in_pool(&self.type_pool));
 
         let struct_def = StructDef {
-            name: anon_name.clone(),
+            name: anon_name_temp.clone(),
             fields: fields.to_vec(),
             is_copy,
             is_handle: false,
@@ -595,11 +541,23 @@ impl<'a> Sema<'a> {
             is_builtin: false,
         };
 
-        self.struct_defs.push(struct_def);
+        let (struct_id, _) = self.type_pool.register_struct(name_spur, struct_def);
 
         // Register in struct lookup
-        let name_spur = self.interner.get_or_intern(&anon_name);
         self.structs.insert(name_spur, struct_id);
+
+        // Update the name now that we have the ID
+        let final_name = format!("__anon_struct_{}", struct_id.0);
+        let final_name_spur = self.interner.get_or_intern(&final_name);
+
+        // Update the struct definition with the correct name
+        let mut updated_def = self.type_pool.struct_def(struct_id);
+        updated_def.name = final_name.clone();
+        self.type_pool.update_struct_def(struct_id, updated_def);
+
+        // Update the struct lookup
+        self.structs.remove(&name_spur);
+        self.structs.insert(final_name_spur, struct_id);
 
         Type::Struct(struct_id)
     }

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -506,7 +506,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(output.struct_defs.len(), 3); // Inner, Outer, and String (builtin)
+        assert_eq!(output.type_pool.stats().struct_count, 3); // Inner, Outer, and String (builtin)
     }
 
     #[test]
@@ -524,8 +524,10 @@ mod tests {
 
         assert!(
             output
-                .struct_defs
+                .type_pool
+                .all_struct_ids()
                 .iter()
+                .map(|id| output.type_pool.struct_def(*id))
                 .any(|s| s.name == "Point" && s.is_copy)
         );
     }
@@ -588,8 +590,15 @@ mod tests {
         )
         .unwrap();
 
-        // String struct should exist in struct_defs
-        assert!(output.struct_defs.iter().any(|s| s.name == "String"));
+        // String struct should exist in the pool
+        assert!(
+            output
+                .type_pool
+                .all_struct_ids()
+                .iter()
+                .map(|id| output.type_pool.struct_def(*id))
+                .any(|s| s.name == "String")
+        );
     }
 
     #[test]
@@ -853,19 +862,17 @@ mod tests {
 
         assert!(pool_string.is_some(), "String should be in the type pool");
 
-        // Verify the pool and existing registry agree
+        // Verify the struct lookup has it
         let registry_string = sema.structs.get(&string_name);
         assert!(
             registry_string.is_some(),
             "String should be in struct registry"
         );
 
-        // Check that the definitions match
+        // Check the pool definition
         let pool_def = sema.type_pool.get_struct_def(pool_string.unwrap()).unwrap();
-        let registry_def = &sema.struct_defs[registry_string.unwrap().0 as usize];
 
-        assert_eq!(pool_def.name, registry_def.name);
-        assert_eq!(pool_def.is_builtin, registry_def.is_builtin);
+        assert_eq!(pool_def.name, "String");
         assert!(pool_def.is_builtin, "String should be marked as builtin");
     }
 
@@ -882,23 +889,20 @@ mod tests {
         let pool_point = sema.type_pool.get_struct_by_name(point_name);
         assert!(pool_point.is_some(), "Point should be in the type pool");
 
-        // Verify pool and registry agree
+        // Verify struct lookup has it
         let registry_point = sema.structs.get(&point_name);
         assert!(
             registry_point.is_some(),
             "Point should be in struct registry"
         );
 
-        // Check that definitions match
+        // Check the pool definition
         let pool_def = sema.type_pool.get_struct_def(pool_point.unwrap()).unwrap();
-        let registry_def = &sema.struct_defs[registry_point.unwrap().0 as usize];
 
-        assert_eq!(pool_def.name, registry_def.name);
-        assert_eq!(pool_def.fields.len(), registry_def.fields.len());
+        assert_eq!(pool_def.name, "Point");
         assert_eq!(pool_def.fields.len(), 2);
         assert_eq!(pool_def.fields[0].name, "x");
         assert_eq!(pool_def.fields[1].name, "y");
-        assert_eq!(pool_def.is_copy, registry_def.is_copy);
         assert!(
             !pool_def.is_builtin,
             "Point should not be marked as builtin"
@@ -1009,9 +1013,9 @@ mod tests {
             );
         }
 
-        // Verify counts match
+        // Verify stats are available
         let stats = sema.type_pool.stats();
-        assert_eq!(stats.struct_count, sema.struct_defs.len());
-        assert_eq!(stats.enum_count, sema.enum_defs.len());
+        assert!(stats.struct_count > 0); // At least String builtin
+        assert!(stats.enum_count > 0); // The enum we added
     }
 }

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -12,37 +12,33 @@ use rue_span::Span;
 
 use super::Sema;
 use crate::inference::InferType;
-use crate::types::{ArrayTypeDef, ArrayTypeId, StructId, Type, parse_array_type_syntax};
+use crate::types::{ArrayTypeId, StructId, Type, TypeKind, parse_array_type_syntax};
 
 impl<'a> Sema<'a> {
     /// Get a human-readable name for a type.
     pub(crate) fn format_type_name(&self, ty: Type) -> String {
-        match ty {
-            Type::I8 => "i8".to_string(),
-            Type::I16 => "i16".to_string(),
-            Type::I32 => "i32".to_string(),
-            Type::I64 => "i64".to_string(),
-            Type::U8 => "u8".to_string(),
-            Type::U16 => "u16".to_string(),
-            Type::U32 => "u32".to_string(),
-            Type::U64 => "u64".to_string(),
-            Type::Bool => "bool".to_string(),
-            Type::Unit => "()".to_string(),
-            Type::Never => "!".to_string(),
-            Type::Error => "<error>".to_string(),
-            // Note: String is now handled via Type::Struct with builtin_string_id
-            Type::Struct(struct_id) => self.type_pool.struct_def(struct_id).name.clone(),
-            Type::Enum(enum_id) => self.type_pool.enum_def(enum_id).name.clone(),
-            Type::Array(array_id) => {
-                let array_def = &self.array_type_defs[array_id.0 as usize];
-                format!(
-                    "[{}; {}]",
-                    self.format_type_name(array_def.element_type),
-                    array_def.length
-                )
+        match ty.kind() {
+            TypeKind::I8 => "i8".to_string(),
+            TypeKind::I16 => "i16".to_string(),
+            TypeKind::I32 => "i32".to_string(),
+            TypeKind::I64 => "i64".to_string(),
+            TypeKind::U8 => "u8".to_string(),
+            TypeKind::U16 => "u16".to_string(),
+            TypeKind::U32 => "u32".to_string(),
+            TypeKind::U64 => "u64".to_string(),
+            TypeKind::Bool => "bool".to_string(),
+            TypeKind::Unit => "()".to_string(),
+            TypeKind::Never => "!".to_string(),
+            TypeKind::Error => "<error>".to_string(),
+            // Note: String is now handled via TypeKind::Struct with builtin_string_id
+            TypeKind::Struct(struct_id) => self.type_pool.struct_def(struct_id).name.clone(),
+            TypeKind::Enum(enum_id) => self.type_pool.enum_def(enum_id).name.clone(),
+            TypeKind::Array(array_id) => {
+                let (element_type, length) = self.type_pool.array_def(array_id);
+                format!("[{}; {}]", self.format_type_name(element_type), length)
             }
-            Type::Module(_) => "<module>".to_string(),
-            Type::ComptimeType => "type".to_string(),
+            TypeKind::Module(_) => "<module>".to_string(),
+            TypeKind::ComptimeType => "type".to_string(),
         }
     }
 
@@ -50,37 +46,37 @@ impl<'a> Sema<'a> {
     /// This differs from Type::is_copy() because it can look up struct definitions
     /// to check if a struct is marked with @copy.
     pub(crate) fn is_type_copy(&self, ty: Type) -> bool {
-        match ty {
+        match ty.kind() {
             // Primitive Copy types
-            Type::I8
-            | Type::I16
-            | Type::I32
-            | Type::I64
-            | Type::U8
-            | Type::U16
-            | Type::U32
-            | Type::U64
-            | Type::Bool
-            | Type::Unit => true,
+            TypeKind::I8
+            | TypeKind::I16
+            | TypeKind::I32
+            | TypeKind::I64
+            | TypeKind::U8
+            | TypeKind::U16
+            | TypeKind::U32
+            | TypeKind::U64
+            | TypeKind::Bool
+            | TypeKind::Unit => true,
             // Enum types are Copy (they're small discriminant values)
-            Type::Enum(_) => true,
+            TypeKind::Enum(_) => true,
             // Never and Error are Copy for convenience
-            Type::Never | Type::Error => true,
+            TypeKind::Never | TypeKind::Error => true,
             // Struct types: check if marked with @copy
-            Type::Struct(struct_id) => {
+            TypeKind::Struct(struct_id) => {
                 let struct_def = self.type_pool.struct_def(struct_id);
                 struct_def.is_copy
             }
-            // Note: String is now handled via Type::Struct with is_builtin
+            // Note: String is now handled via TypeKind::Struct with is_builtin
             // Arrays are Copy if their element type is Copy
-            Type::Array(array_id) => {
-                let array_def = &self.array_type_defs[array_id.0 as usize];
-                self.is_type_copy(array_def.element_type)
+            TypeKind::Array(array_id) => {
+                let (element_type, _length) = self.type_pool.array_def(array_id);
+                self.is_type_copy(element_type)
             }
             // Module types are Copy (they're just compile-time namespace references)
-            Type::Module(_) => true,
+            TypeKind::Module(_) => true,
             // ComptimeType is Copy (only exists at comptime anyway)
-            Type::ComptimeType => true,
+            TypeKind::ComptimeType => true,
         }
     }
 
@@ -111,13 +107,13 @@ impl<'a> Sema<'a> {
     /// This handles the conversion of Type::Array(id) to InferType::Array
     /// by looking up the array definition to get element type and length.
     pub(crate) fn type_to_infer_type(&self, ty: Type) -> InferType {
-        match ty {
-            Type::Array(array_id) => {
-                let array_def = &self.array_type_defs[array_id.0 as usize];
-                let element_infer = self.type_to_infer_type(array_def.element_type);
+        match ty.kind() {
+            TypeKind::Array(array_id) => {
+                let (element_type, length) = self.type_pool.array_def(array_id);
+                let element_infer = self.type_to_infer_type(element_type);
                 InferType::Array {
                     element: Box::new(element_infer),
-                    length: array_def.length,
+                    length,
                 }
             }
             // All other types wrap directly
@@ -177,18 +173,7 @@ impl<'a> Sema<'a> {
         element_type: Type,
         length: u64,
     ) -> ArrayTypeId {
-        let key = (element_type, length);
-        if let Some(&id) = self.array_types.get(&key) {
-            return id;
-        }
-
-        let id = ArrayTypeId(self.array_type_defs.len() as u32);
-        self.array_type_defs.push(ArrayTypeDef {
-            element_type,
-            length,
-        });
-        self.array_types.insert(key, id);
-        id
+        self.type_pool.intern_array_from_type(element_type, length)
     }
 
     /// Pre-create array types from a resolved InferType.
@@ -228,24 +213,14 @@ impl<'a> Sema<'a> {
             InferType::Var(_) => Type::Error,   // Unbound variable
             InferType::IntLiteral => Type::I32, // Default
             InferType::Array { element, length } => {
-                // For nested arrays, look up the already-created array type
+                // For nested arrays, look up or create the array type
                 let elem_ty = self.infer_type_to_concrete_type_for_key(element);
                 if elem_ty == Type::Error {
                     return Type::Error;
                 }
-                // The array type should already exist from the recursive call
-                let key = (elem_ty, *length);
-                if let Some(&id) = self.array_types.get(&key) {
-                    Type::Array(id)
-                } else {
-                    // This shouldn't happen if we process depth-first, but handle gracefully
-                    debug_assert!(
-                        false,
-                        "Array type not found during pre-creation: ({:?}, {})",
-                        elem_ty, length
-                    );
-                    Type::Error
-                }
+                // Get or create the array type in the pool
+                let id = self.type_pool.intern_array_from_type(elem_ty, *length);
+                Type::Array(id)
             }
         }
     }
@@ -255,24 +230,24 @@ impl<'a> Sema<'a> {
     /// structs use 1 slot per field, arrays use 1 slot per element.
     /// Zero-sized types (unit, never, empty structs, zero-length arrays) use 0 slots.
     pub(crate) fn abi_slot_count(&self, ty: Type) -> u32 {
-        match ty {
-            Type::I8
-            | Type::I16
-            | Type::I32
-            | Type::I64
-            | Type::U8
-            | Type::U16
-            | Type::U32
-            | Type::U64
-            | Type::Bool
-            | Type::Error => 1,
+        match ty.kind() {
+            TypeKind::I8
+            | TypeKind::I16
+            | TypeKind::I32
+            | TypeKind::I64
+            | TypeKind::U8
+            | TypeKind::U16
+            | TypeKind::U32
+            | TypeKind::U64
+            | TypeKind::Bool
+            | TypeKind::Error => 1,
             // Zero-sized types use 0 slots
             // ComptimeType is comptime-only and uses 0 runtime slots
-            Type::Unit | Type::Never | Type::ComptimeType => 0,
+            TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType => 0,
             // Enums are represented as their discriminant type (a scalar), so 1 slot
-            Type::Enum(_) => 1,
+            TypeKind::Enum(_) => 1,
             // Struct uses sum of all field slots (includes builtin String with 3 fields)
-            Type::Struct(struct_id) => {
+            TypeKind::Struct(struct_id) => {
                 // Sum the slot counts of all fields (handles arrays, nested structs, and builtins)
                 // Empty structs naturally get 0 slots here
                 let struct_def = self.type_pool.struct_def(struct_id);
@@ -282,14 +257,14 @@ impl<'a> Sema<'a> {
                     .map(|f| self.abi_slot_count(f.ty))
                     .sum()
             }
-            Type::Array(array_type_id) => {
+            TypeKind::Array(array_type_id) => {
                 // Zero-length arrays naturally get 0 slots (0 * element_slots)
-                let array_def = &self.array_type_defs[array_type_id.0 as usize];
-                let element_slots = self.abi_slot_count(array_def.element_type);
-                element_slots * array_def.length as u32
+                let (element_type, length) = self.type_pool.array_def(array_type_id);
+                let element_slots = self.abi_slot_count(element_type);
+                element_slots * length as u32
             }
             // Module types don't take ABI slots (they're compile-time only)
-            Type::Module(_) => 0,
+            TypeKind::Module(_) => 0,
         }
     }
 

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -41,122 +41,8 @@ use crate::intern_pool::TypeInternPool;
 // FunctionInfo and MethodInfo are the canonical definitions; we re-export them for convenience.
 pub use crate::sema::{FunctionInfo, KnownSymbols, MethodInfo};
 use crate::types::{
-    ArrayTypeDef, ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, StructDef, StructId, Type,
+    ArrayTypeId, EnumDef, EnumId, ModuleDef, ModuleId, StructDef, StructId, Type, TypeKind,
 };
-
-/// Thread-safe registry for array types.
-///
-/// This registry allows concurrent lookups and insertions of array types during
-/// parallel function analysis. It uses double-checked locking to minimize
-/// contention: most operations only need a read lock.
-#[derive(Debug)]
-pub struct ArrayTypeRegistry {
-    /// Maps (element_type, length) to ArrayTypeId.
-    types: RwLock<HashMap<(Type, u64), ArrayTypeId>>,
-    /// Array type definitions indexed by ArrayTypeId.
-    defs: RwLock<Vec<ArrayTypeDef>>,
-}
-
-impl ArrayTypeRegistry {
-    /// Create a new empty registry.
-    pub fn new() -> Self {
-        Self {
-            types: RwLock::new(HashMap::new()),
-            defs: RwLock::new(Vec::new()),
-        }
-    }
-
-    /// Create a registry pre-populated with existing types.
-    pub fn from_existing(
-        types: HashMap<(Type, u64), ArrayTypeId>,
-        defs: Vec<ArrayTypeDef>,
-    ) -> Self {
-        Self {
-            types: RwLock::new(types),
-            defs: RwLock::new(defs),
-        }
-    }
-
-    /// Look up an array type by element type and length.
-    pub fn get(&self, element_type: Type, length: u64) -> Option<ArrayTypeId> {
-        self.types
-            .read()
-            .expect("ArrayTypeRegistry lock poisoned")
-            .get(&(element_type, length))
-            .copied()
-    }
-
-    /// Get or create an array type. Thread-safe with double-checked locking.
-    pub fn get_or_create(&self, element_type: Type, length: u64) -> ArrayTypeId {
-        let key = (element_type, length);
-
-        // Fast path: check with read lock
-        {
-            let types = self.types.read().expect("ArrayTypeRegistry lock poisoned");
-            if let Some(&id) = types.get(&key) {
-                return id;
-            }
-        }
-
-        // Slow path: acquire write lock and double-check
-        let mut types = self.types.write().expect("ArrayTypeRegistry lock poisoned");
-
-        // Double-check after acquiring write lock (another thread may have inserted)
-        if let Some(&id) = types.get(&key) {
-            return id;
-        }
-
-        // Create new array type
-        let mut defs = self.defs.write().expect("ArrayTypeRegistry lock poisoned");
-        let id = ArrayTypeId(defs.len() as u32);
-        defs.push(ArrayTypeDef {
-            element_type,
-            length,
-        });
-        types.insert(key, id);
-        id
-    }
-
-    /// Get an array type definition by ID.
-    pub fn get_def(&self, id: ArrayTypeId) -> ArrayTypeDef {
-        self.defs.read().expect("ArrayTypeRegistry lock poisoned")[id.0 as usize]
-    }
-
-    /// Get the number of registered array types.
-    pub fn len(&self) -> usize {
-        self.defs
-            .read()
-            .expect("ArrayTypeRegistry lock poisoned")
-            .len()
-    }
-
-    /// Check if the registry is empty.
-    pub fn is_empty(&self) -> bool {
-        self.len() == 0
-    }
-
-    /// Extract the array type definitions (consumes the registry).
-    /// Used when building the final SemaOutput.
-    pub fn into_defs(self) -> Vec<ArrayTypeDef> {
-        self.defs
-            .into_inner()
-            .expect("ArrayTypeRegistry lock poisoned")
-    }
-
-    /// Get a snapshot of all array type definitions.
-    pub fn snapshot_defs(&self) -> Vec<ArrayTypeDef> {
-        self.defs
-            .read()
-            .expect("ArrayTypeRegistry lock poisoned")
-            .clone()
-    }
-}
-
-impl Default for ArrayTypeRegistry {
-    fn default() -> Self {
-        Self::new()
-    }
-}
 
 /// Thread-safe registry for modules.
 ///
@@ -285,7 +171,7 @@ pub struct InferenceContext {
 ///
 /// - Struct and enum definitions (immutable)
 /// - Function and method signatures (references to immutable data in Sema)
-/// - Array type registry (thread-safe, allows concurrent insertions)
+/// - Type intern pool (thread-safe, allows concurrent array interning)
 /// - Pre-computed inference context (immutable)
 /// - Built-in type IDs (immutable)
 ///
@@ -293,7 +179,7 @@ pub struct InferenceContext {
 ///
 /// `SemaContext` is `Send + Sync` because:
 /// - Most fields are immutable after construction
-/// - The array type registry uses `RwLock` for thread-safe mutations
+/// - The type intern pool uses `RwLock` for thread-safe mutations
 /// - References to RIR and interner are shared immutably
 /// - References to functions/methods HashMaps are immutable after declaration gathering
 /// - ThreadedRodeo is designed to be thread-safe
@@ -303,13 +189,6 @@ pub struct SemaContext<'a> {
     pub rir: &'a Rir,
     /// Reference to the string interner.
     pub interner: &'a ThreadedRodeo,
-    /// Struct definitions indexed by StructId.
-    pub struct_defs: Vec<StructDef>,
-    /// Enum definitions indexed by EnumId.
-    pub enum_defs: Vec<EnumDef>,
-    /// Thread-safe array type registry.
-    /// Supports concurrent lookups and insertions during parallel analysis.
-    pub array_registry: ArrayTypeRegistry,
     /// Struct lookup: maps struct name symbol to StructId.
     pub structs: HashMap<Spur, StructId>,
     /// Enum lookup: maps enum name symbol to EnumId.
@@ -342,10 +221,9 @@ pub struct SemaContext<'a> {
 }
 
 // SAFETY: SemaContext is Send + Sync because:
-// - Immutable fields (struct_defs, enum_defs, structs, enums, etc.) are trivially thread-safe
-// - ArrayTypeRegistry uses RwLock for interior mutability
+// - Immutable fields (structs, enums, etc.) are trivially thread-safe
 // - ModuleRegistry uses RwLock for interior mutability
-// - TypeInternPool uses RwLock for interior mutability
+// - TypeInternPool uses RwLock for interior mutability (including array interning)
 // - References to RIR and ThreadedRodeo are shared immutably
 // - References to functions/methods HashMaps are shared immutably (read-only after declaration gathering)
 // - ThreadedRodeo is designed to be thread-safe
@@ -392,18 +270,20 @@ impl<'a> SemaContext<'a> {
     }
 
     /// Get an array type definition by ID.
-    pub fn get_array_type_def(&self, id: ArrayTypeId) -> ArrayTypeDef {
-        self.array_registry.get_def(id)
+    ///
+    /// Returns `(element_type, length)` for the array.
+    pub fn get_array_type_def(&self, id: ArrayTypeId) -> (Type, u64) {
+        self.type_pool.array_def(id)
     }
 
     /// Look up an array type by element type and length.
     pub fn get_array_type(&self, element_type: Type, length: u64) -> Option<ArrayTypeId> {
-        self.array_registry.get(element_type, length)
+        self.type_pool.get_array_by_type(element_type, length)
     }
 
     /// Get or create an array type. Thread-safe.
     pub fn get_or_create_array_type(&self, element_type: Type, length: u64) -> ArrayTypeId {
-        self.array_registry.get_or_create(element_type, length)
+        self.type_pool.intern_array_from_type(element_type, length)
     }
 
     /// Look up a module by import path.
@@ -430,84 +310,80 @@ impl<'a> SemaContext<'a> {
 
     /// Get a human-readable name for a type.
     pub fn format_type_name(&self, ty: Type) -> String {
-        match ty {
-            Type::I8 => "i8".to_string(),
-            Type::I16 => "i16".to_string(),
-            Type::I32 => "i32".to_string(),
-            Type::I64 => "i64".to_string(),
-            Type::U8 => "u8".to_string(),
-            Type::U16 => "u16".to_string(),
-            Type::U32 => "u32".to_string(),
-            Type::U64 => "u64".to_string(),
-            Type::Bool => "bool".to_string(),
-            Type::Unit => "()".to_string(),
-            Type::Never => "!".to_string(),
-            Type::Error => "<error>".to_string(),
-            Type::Struct(struct_id) => self.type_pool.struct_def(struct_id).name.clone(),
-            Type::Enum(enum_id) => self.type_pool.enum_def(enum_id).name.clone(),
-            Type::Array(array_id) => {
-                let array_def = self.array_registry.get_def(array_id);
-                format!(
-                    "[{}; {}]",
-                    self.format_type_name(array_def.element_type),
-                    array_def.length
-                )
+        match ty.kind() {
+            TypeKind::I8 => "i8".to_string(),
+            TypeKind::I16 => "i16".to_string(),
+            TypeKind::I32 => "i32".to_string(),
+            TypeKind::I64 => "i64".to_string(),
+            TypeKind::U8 => "u8".to_string(),
+            TypeKind::U16 => "u16".to_string(),
+            TypeKind::U32 => "u32".to_string(),
+            TypeKind::U64 => "u64".to_string(),
+            TypeKind::Bool => "bool".to_string(),
+            TypeKind::Unit => "()".to_string(),
+            TypeKind::Never => "!".to_string(),
+            TypeKind::Error => "<error>".to_string(),
+            TypeKind::Struct(struct_id) => self.type_pool.struct_def(struct_id).name.clone(),
+            TypeKind::Enum(enum_id) => self.type_pool.enum_def(enum_id).name.clone(),
+            TypeKind::Array(array_id) => {
+                let (element_type, length) = self.type_pool.array_def(array_id);
+                format!("[{}; {}]", self.format_type_name(element_type), length)
             }
-            Type::Module(_) => "<module>".to_string(),
-            Type::ComptimeType => "type".to_string(),
+            TypeKind::Module(_) => "<module>".to_string(),
+            TypeKind::ComptimeType => "type".to_string(),
         }
     }
 
     /// Check if a type is a Copy type.
     pub fn is_type_copy(&self, ty: Type) -> bool {
-        match ty {
+        match ty.kind() {
             // Primitive Copy types
-            Type::I8
-            | Type::I16
-            | Type::I32
-            | Type::I64
-            | Type::U8
-            | Type::U16
-            | Type::U32
-            | Type::U64
-            | Type::Bool
-            | Type::Unit => true,
+            TypeKind::I8
+            | TypeKind::I16
+            | TypeKind::I32
+            | TypeKind::I64
+            | TypeKind::U8
+            | TypeKind::U16
+            | TypeKind::U32
+            | TypeKind::U64
+            | TypeKind::Bool
+            | TypeKind::Unit => true,
             // Enum types are Copy (they're small discriminant values)
-            Type::Enum(_) => true,
+            TypeKind::Enum(_) => true,
             // Never, Error, and ComptimeType are Copy for convenience
-            Type::Never | Type::Error | Type::ComptimeType => true,
+            TypeKind::Never | TypeKind::Error | TypeKind::ComptimeType => true,
             // Struct types: check if marked with @copy
-            Type::Struct(struct_id) => {
+            TypeKind::Struct(struct_id) => {
                 let struct_def = self.type_pool.struct_def(struct_id);
                 struct_def.is_copy
             }
             // Arrays are Copy if their element type is Copy
-            Type::Array(array_id) => {
-                let array_def = self.array_registry.get_def(array_id);
-                self.is_type_copy(array_def.element_type)
+            TypeKind::Array(array_id) => {
+                let (element_type, _length) = self.type_pool.array_def(array_id);
+                self.is_type_copy(element_type)
             }
             // Module types are Copy (they're just compile-time namespace references)
-            Type::Module(_) => true,
+            TypeKind::Module(_) => true,
         }
     }
 
     /// Get the number of ABI slots required for a type.
     pub fn abi_slot_count(&self, ty: Type) -> u32 {
-        match ty {
-            Type::I8
-            | Type::I16
-            | Type::I32
-            | Type::I64
-            | Type::U8
-            | Type::U16
-            | Type::U32
-            | Type::U64
-            | Type::Bool
-            | Type::Error => 1,
+        match ty.kind() {
+            TypeKind::I8
+            | TypeKind::I16
+            | TypeKind::I32
+            | TypeKind::I64
+            | TypeKind::U8
+            | TypeKind::U16
+            | TypeKind::U32
+            | TypeKind::U64
+            | TypeKind::Bool
+            | TypeKind::Error => 1,
             // Zero-sized types (including comptime-only)
-            Type::Unit | Type::Never | Type::ComptimeType => 0,
-            Type::Enum(_) => 1,
-            Type::Struct(struct_id) => {
+            TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType => 0,
+            TypeKind::Enum(_) => 1,
+            TypeKind::Struct(struct_id) => {
                 let struct_def = self.type_pool.struct_def(struct_id);
                 struct_def
                     .fields
@@ -515,13 +391,13 @@ impl<'a> SemaContext<'a> {
                     .map(|f| self.abi_slot_count(f.ty))
                     .sum()
             }
-            Type::Array(array_type_id) => {
-                let array_def = self.array_registry.get_def(array_type_id);
-                let element_slots = self.abi_slot_count(array_def.element_type);
-                element_slots * array_def.length as u32
+            TypeKind::Array(array_type_id) => {
+                let (element_type, length) = self.type_pool.array_def(array_type_id);
+                let element_slots = self.abi_slot_count(element_type);
+                element_slots * length as u32
             }
             // Module types don't take ABI slots (they're compile-time only)
-            Type::Module(_) => 0,
+            TypeKind::Module(_) => 0,
         }
     }
 
@@ -536,13 +412,13 @@ impl<'a> SemaContext<'a> {
 
     /// Convert a concrete Type to InferType for use in constraint generation.
     pub fn type_to_infer_type(&self, ty: Type) -> InferType {
-        match ty {
-            Type::Array(array_id) => {
-                let array_def = self.array_registry.get_def(array_id);
-                let element_infer = self.type_to_infer_type(array_def.element_type);
+        match ty.kind() {
+            TypeKind::Array(array_id) => {
+                let (element_type, length) = self.type_pool.array_def(array_id);
+                let element_infer = self.type_to_infer_type(element_type);
                 InferType::Array {
                     element: Box::new(element_infer),
-                    length: array_def.length,
+                    length,
                 }
             }
             _ => InferType::Concrete(ty),
@@ -555,8 +431,8 @@ impl<'a> SemaContext<'a> {
 
     /// Check if a type is the builtin String type.
     pub fn is_builtin_string(&self, ty: Type) -> bool {
-        match ty {
-            Type::Struct(struct_id) => Some(struct_id) == self.builtin_string_id,
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => Some(struct_id) == self.builtin_string_id,
             _ => false,
         }
     }
@@ -595,8 +471,8 @@ impl<'a> SemaContext<'a> {
 
     /// Check if a type is a linear type.
     pub fn is_type_linear(&self, ty: Type) -> bool {
-        match ty {
-            Type::Struct(struct_id) => {
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => {
                 let struct_def = self.type_pool.struct_def(struct_id);
                 struct_def.is_linear
             }

--- a/crates/rue-air/src/type_context.rs
+++ b/crates/rue-air/src/type_context.rs
@@ -39,12 +39,10 @@ pub struct TypeContext {
     pub method_sigs: HashMap<(Spur, Spur), MethodSignature>,
     /// Struct lookup: maps struct name symbol to StructId.
     pub struct_by_name: HashMap<Spur, StructId>,
-    /// Struct definitions indexed by StructId.
-    pub struct_defs: Vec<StructDef>,
     /// Enum lookup: maps enum name symbol to EnumId.
     pub enum_by_name: HashMap<Spur, EnumId>,
-    /// Enum definitions indexed by EnumId.
-    pub enum_defs: Vec<EnumDef>,
+    /// Type intern pool for struct/enum definitions.
+    pub type_pool: crate::intern_pool::TypeInternPool,
 }
 
 /// Signature information for a function.
@@ -82,9 +80,8 @@ impl TypeContext {
             func_sigs: HashMap::new(),
             method_sigs: HashMap::new(),
             struct_by_name: HashMap::new(),
-            struct_defs: Vec::new(),
             enum_by_name: HashMap::new(),
-            enum_defs: Vec::new(),
+            type_pool: crate::intern_pool::TypeInternPool::new(),
         }
     }
 
@@ -94,8 +91,8 @@ impl TypeContext {
     }
 
     /// Get a struct definition by ID.
-    pub fn get_struct_def(&self, id: StructId) -> &StructDef {
-        &self.struct_defs[id.0 as usize]
+    pub fn get_struct_def(&self, id: StructId) -> StructDef {
+        self.type_pool.struct_def(id)
     }
 
     /// Look up an enum by name.
@@ -104,8 +101,8 @@ impl TypeContext {
     }
 
     /// Get an enum definition by ID.
-    pub fn get_enum_def(&self, id: EnumId) -> &EnumDef {
-        &self.enum_defs[id.0 as usize]
+    pub fn get_enum_def(&self, id: EnumId) -> EnumDef {
+        self.type_pool.enum_def(id)
     }
 
     /// Look up a function signature by name.

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -59,6 +59,25 @@ impl EnumId {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct ArrayTypeId(pub u32);
 
+impl ArrayTypeId {
+    /// Create an ArrayTypeId from a pool index.
+    ///
+    /// This is used during Phase 2B to create ArrayTypeIds from pool indices.
+    /// The pool index is the raw index into `TypeInternPool.types`.
+    #[inline]
+    pub fn from_pool_index(pool_index: u32) -> Self {
+        ArrayTypeId(pool_index)
+    }
+
+    /// Get the pool index for this array type.
+    ///
+    /// Returns the raw index into the TypeInternPool.
+    #[inline]
+    pub fn pool_index(self) -> u32 {
+        self.0
+    }
+}
+
 /// A unique identifier for a module (imported file).
 ///
 /// Modules are created by `@import("path.rue")` and represent the public
@@ -80,9 +99,17 @@ impl ModuleId {
     }
 }
 
-/// A type in the Rue type system.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
-pub enum Type {
+/// The kind of a type - used for pattern matching.
+///
+/// This enum mirrors the structure of the `Type` enum but is designed for
+/// pattern matching. During the migration to `Type(InternedType)`, code that
+/// pattern matches on types will use `ty.kind()` to get a `TypeKind`.
+///
+/// This separation allows incremental migration: all pattern matches can be
+/// updated to use `.kind()` while `Type` is still an enum, then `Type` can be
+/// replaced with `Type(InternedType)` without breaking existing code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TypeKind {
     /// 8-bit signed integer
     I8,
     /// 16-bit signed integer
@@ -102,7 +129,6 @@ pub enum Type {
     /// Boolean
     Bool,
     /// The unit type (for functions that don't return a value)
-    #[default]
     Unit,
     /// User-defined struct type
     Struct(StructId),
@@ -111,19 +137,137 @@ pub enum Type {
     /// Fixed-size array type: [T; N]
     Array(ArrayTypeId),
     /// A module type (from @import)
-    ///
-    /// Module types represent imported files. Accessing members on a module
-    /// type resolves to the module's public declarations.
     Module(ModuleId),
     /// An error type (used during type checking to continue after errors)
     Error,
-    /// The never type - represents computations that don't return (e.g., break, continue).
-    /// Can coerce to any other type.
+    /// The never type - represents computations that don't return
     Never,
-    /// The comptime type - the type of types themselves.
-    /// Values of this type are types (e.g., `i32`, `bool`, `MyStruct`).
-    /// This is a comptime-only type; it cannot exist at runtime.
+    /// The comptime type - the type of types themselves
     ComptimeType,
+}
+
+/// A type in the Rue type system.
+///
+/// After Phase 4.1 of ADR-0024, `Type` is a newtype wrapping a u32 index.
+/// This enables O(1) type equality via u32 comparison.
+///
+/// # Encoding
+///
+/// The u32 value uses a tag-based encoding:
+/// - Primitives (0-12): I8=0, I16=1, I32=2, I64=3, U8=4, U16=5, U32=6, U64=7,
+///   Bool=8, Unit=9, Error=10, Never=11, ComptimeType=12
+/// - Composites: low byte is tag (100=Struct, 101=Enum, 102=Array, 103=Module),
+///   high 24 bits are the ID
+///
+/// # Usage
+///
+/// Use the associated constants for primitive types:
+/// ```ignore
+/// let ty = Type::I32;
+/// ```
+///
+/// Use constructor methods for composite types:
+/// ```ignore
+/// let ty = Type::Struct(struct_id);
+/// ```
+///
+/// Use `kind()` for pattern matching:
+/// ```ignore
+/// match ty.kind() {
+///     TypeKind::I32 => { /* ... */ }
+///     TypeKind::Struct(id) => { /* ... */ }
+///     _ => { /* ... */ }
+/// }
+/// ```
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Type(u32);
+
+impl Default for Type {
+    fn default() -> Self {
+        Type::Unit
+    }
+}
+
+impl std::fmt::Debug for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // Provide a readable debug format
+        match self.kind() {
+            TypeKind::I8 => write!(f, "Type::I8"),
+            TypeKind::I16 => write!(f, "Type::I16"),
+            TypeKind::I32 => write!(f, "Type::I32"),
+            TypeKind::I64 => write!(f, "Type::I64"),
+            TypeKind::U8 => write!(f, "Type::U8"),
+            TypeKind::U16 => write!(f, "Type::U16"),
+            TypeKind::U32 => write!(f, "Type::U32"),
+            TypeKind::U64 => write!(f, "Type::U64"),
+            TypeKind::Bool => write!(f, "Type::Bool"),
+            TypeKind::Unit => write!(f, "Type::Unit"),
+            TypeKind::Error => write!(f, "Type::Error"),
+            TypeKind::Never => write!(f, "Type::Never"),
+            TypeKind::ComptimeType => write!(f, "Type::ComptimeType"),
+            TypeKind::Struct(id) => write!(f, "Type::Struct(StructId({}))", id.0),
+            TypeKind::Enum(id) => write!(f, "Type::Enum(EnumId({}))", id.0),
+            TypeKind::Array(id) => write!(f, "Type::Array(ArrayTypeId({}))", id.0),
+            TypeKind::Module(id) => write!(f, "Type::Module(ModuleId({}))", id.0),
+        }
+    }
+}
+
+// Primitive type constants
+impl Type {
+    /// 8-bit signed integer
+    pub const I8: Type = Type(0);
+    /// 16-bit signed integer
+    pub const I16: Type = Type(1);
+    /// 32-bit signed integer
+    pub const I32: Type = Type(2);
+    /// 64-bit signed integer
+    pub const I64: Type = Type(3);
+    /// 8-bit unsigned integer
+    pub const U8: Type = Type(4);
+    /// 16-bit unsigned integer
+    pub const U16: Type = Type(5);
+    /// 32-bit unsigned integer
+    pub const U32: Type = Type(6);
+    /// 64-bit unsigned integer
+    pub const U64: Type = Type(7);
+    /// Boolean
+    pub const Bool: Type = Type(8);
+    /// The unit type (for functions that don't return a value)
+    pub const Unit: Type = Type(9);
+    /// An error type (used during type checking to continue after errors)
+    pub const Error: Type = Type(10);
+    /// The never type - represents computations that don't return
+    pub const Never: Type = Type(11);
+    /// The comptime type - the type of types themselves
+    pub const ComptimeType: Type = Type(12);
+}
+
+// Composite type constructors
+impl Type {
+    /// Create a struct type from a StructId.
+    #[inline]
+    pub const fn Struct(id: StructId) -> Type {
+        Type(100 | ((id.0 as u32) << 8))
+    }
+
+    /// Create an enum type from an EnumId.
+    #[inline]
+    pub const fn Enum(id: EnumId) -> Type {
+        Type(101 | ((id.0 as u32) << 8))
+    }
+
+    /// Create an array type from an ArrayTypeId.
+    #[inline]
+    pub const fn Array(id: ArrayTypeId) -> Type {
+        Type(102 | ((id.0 as u32) << 8))
+    }
+
+    /// Create a module type from a ModuleId.
+    #[inline]
+    pub const fn Module(id: ModuleId) -> Type {
+        Type(103 | ((id.0 as u32) << 8))
+    }
 }
 
 /// Definition of a struct type.
@@ -166,27 +310,6 @@ impl StructDef {
     /// Get the number of fields in this struct.
     pub fn field_count(&self) -> usize {
         self.fields.len()
-    }
-}
-
-/// Definition of an array type.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub struct ArrayTypeDef {
-    /// Element type
-    pub element_type: Type,
-    /// Fixed array length
-    pub length: u64,
-}
-
-impl ArrayTypeDef {
-    /// Get the total number of elements in this array.
-    pub fn len(&self) -> u64 {
-        self.length
-    }
-
-    /// Check if this array has zero length.
-    pub fn is_empty(&self) -> bool {
-        self.length == 0
     }
 }
 
@@ -268,116 +391,164 @@ impl ModuleDef {
 }
 
 impl Type {
+    /// Get the kind of this type for pattern matching.
+    ///
+    /// This method decodes the u32 representation back to a `TypeKind` for pattern matching.
+    /// Primitive types (0-12) decode directly; composite types decode the tag and ID.
+    ///
+    /// # Example
+    ///
+    /// ```ignore
+    /// match ty.kind() {
+    ///     TypeKind::I32 | TypeKind::I64 => { /* handle integers */ }
+    ///     TypeKind::Struct(id) => { /* handle struct */ }
+    ///     _ => { /* other types */ }
+    /// }
+    /// ```
+    #[inline]
+    pub fn kind(&self) -> TypeKind {
+        let tag = self.0 & 0xFF;
+        match tag {
+            0 => TypeKind::I8,
+            1 => TypeKind::I16,
+            2 => TypeKind::I32,
+            3 => TypeKind::I64,
+            4 => TypeKind::U8,
+            5 => TypeKind::U16,
+            6 => TypeKind::U32,
+            7 => TypeKind::U64,
+            8 => TypeKind::Bool,
+            9 => TypeKind::Unit,
+            10 => TypeKind::Error,
+            11 => TypeKind::Never,
+            12 => TypeKind::ComptimeType,
+            100 => TypeKind::Struct(StructId(self.0 >> 8)),
+            101 => TypeKind::Enum(EnumId(self.0 >> 8)),
+            102 => TypeKind::Array(ArrayTypeId(self.0 >> 8)),
+            103 => TypeKind::Module(ModuleId(self.0 >> 8)),
+            _ => panic!("invalid Type encoding: {}", self.0),
+        }
+    }
+
     /// Get a human-readable name for this type.
     /// Note: For struct and array types, this returns a placeholder.
     /// Use `type_name_with_structs` for proper struct/array names.
     pub fn name(&self) -> &'static str {
-        match self {
-            Type::I8 => "i8",
-            Type::I16 => "i16",
-            Type::I32 => "i32",
-            Type::I64 => "i64",
-            Type::U8 => "u8",
-            Type::U16 => "u16",
-            Type::U32 => "u32",
-            Type::U64 => "u64",
-            Type::Bool => "bool",
-            Type::Unit => "()",
-            Type::Struct(_) => "<struct>",
-            Type::Enum(_) => "<enum>",
-            Type::Array(_) => "<array>",
-            Type::Module(_) => "<module>",
-            Type::Error => "<error>",
-            Type::Never => "!",
-            Type::ComptimeType => "type",
+        match self.kind() {
+            TypeKind::I8 => "i8",
+            TypeKind::I16 => "i16",
+            TypeKind::I32 => "i32",
+            TypeKind::I64 => "i64",
+            TypeKind::U8 => "u8",
+            TypeKind::U16 => "u16",
+            TypeKind::U32 => "u32",
+            TypeKind::U64 => "u64",
+            TypeKind::Bool => "bool",
+            TypeKind::Unit => "()",
+            TypeKind::Struct(_) => "<struct>",
+            TypeKind::Enum(_) => "<enum>",
+            TypeKind::Array(_) => "<array>",
+            TypeKind::Module(_) => "<module>",
+            TypeKind::Error => "<error>",
+            TypeKind::Never => "!",
+            TypeKind::ComptimeType => "type",
         }
     }
 
     /// Check if this type is an integer type.
+    /// Optimized: checks tag range directly (0-7 are integer types).
+    #[inline]
     pub fn is_integer(&self) -> bool {
-        matches!(
-            self,
-            Type::I8
-                | Type::I16
-                | Type::I32
-                | Type::I64
-                | Type::U8
-                | Type::U16
-                | Type::U32
-                | Type::U64
-        )
+        self.0 <= 7
     }
 
     /// Check if this is an error type.
+    #[inline]
     pub fn is_error(&self) -> bool {
-        matches!(self, Type::Error)
+        *self == Type::Error
     }
 
     /// Check if this is the never type.
+    #[inline]
     pub fn is_never(&self) -> bool {
-        matches!(self, Type::Never)
+        *self == Type::Never
     }
 
     /// Check if this is the comptime type (the type of types).
+    #[inline]
     pub fn is_comptime_type(&self) -> bool {
-        matches!(self, Type::ComptimeType)
+        *self == Type::ComptimeType
     }
 
     /// Check if this is a struct type.
+    #[inline]
     pub fn is_struct(&self) -> bool {
-        matches!(self, Type::Struct(_))
+        (self.0 & 0xFF) == 100
     }
 
     /// Get the struct ID if this is a struct type.
+    #[inline]
     pub fn as_struct(&self) -> Option<StructId> {
-        match self {
-            Type::Struct(id) => Some(*id),
-            _ => None,
+        if self.is_struct() {
+            Some(StructId(self.0 >> 8))
+        } else {
+            None
         }
     }
 
     /// Check if this is an array type.
+    #[inline]
     pub fn is_array(&self) -> bool {
-        matches!(self, Type::Array(_))
+        (self.0 & 0xFF) == 102
     }
 
     /// Get the array type ID if this is an array type.
+    #[inline]
     pub fn as_array(&self) -> Option<ArrayTypeId> {
-        match self {
-            Type::Array(id) => Some(*id),
-            _ => None,
+        if self.is_array() {
+            Some(ArrayTypeId(self.0 >> 8))
+        } else {
+            None
         }
     }
 
     /// Check if this is an enum type.
+    #[inline]
     pub fn is_enum(&self) -> bool {
-        matches!(self, Type::Enum(_))
+        (self.0 & 0xFF) == 101
     }
 
     /// Get the enum ID if this is an enum type.
+    #[inline]
     pub fn as_enum(&self) -> Option<EnumId> {
-        match self {
-            Type::Enum(id) => Some(*id),
-            _ => None,
+        if self.is_enum() {
+            Some(EnumId(self.0 >> 8))
+        } else {
+            None
         }
     }
 
     /// Check if this is a module type.
+    #[inline]
     pub fn is_module(&self) -> bool {
-        matches!(self, Type::Module(_))
+        (self.0 & 0xFF) == 103
     }
 
     /// Get the module ID if this is a module type.
+    #[inline]
     pub fn as_module(&self) -> Option<ModuleId> {
-        match self {
-            Type::Module(id) => Some(*id),
-            _ => None,
+        if self.is_module() {
+            Some(ModuleId(self.0 >> 8))
+        } else {
+            None
         }
     }
 
     /// Check if this is a signed integer type.
+    /// Optimized: checks tag range directly (0-3 are signed integers).
+    #[inline]
     pub fn is_signed(&self) -> bool {
-        matches!(self, Type::I8 | Type::I16 | Type::I32 | Type::I64)
+        self.0 <= 3
     }
 
     /// Check if this is a Copy type (can be implicitly duplicated).
@@ -394,32 +565,24 @@ impl Type {
     /// - Array types (unless element type is Copy, checked via Sema.is_type_copy)
     ///
     /// Note: This method can't check struct's is_copy attribute or array element
-    /// types since it doesn't have access to StructDefs or ArrayTypeDefs.
+    /// types since it doesn't have access to StructDefs or array type information.
     /// Use Sema.is_type_copy() for full checking.
     pub fn is_copy(&self) -> bool {
-        match self {
-            // Primitive Copy types
-            Type::I8
-            | Type::I16
-            | Type::I32
-            | Type::I64
-            | Type::U8
-            | Type::U16
-            | Type::U32
-            | Type::U64
-            | Type::Bool
-            | Type::Unit => true,
+        let tag = self.0 & 0xFF;
+        match tag {
+            // Primitive Copy types (I8..Unit = 0..9)
+            0..=9 => true,
+            // Error, Never, ComptimeType are Copy for convenience
+            10..=12 => true,
             // Enum types are Copy (they're small discriminant values)
-            Type::Enum(_) => true,
-            // Never, Error, and ComptimeType are Copy for convenience
-            // (ComptimeType only exists at comptime anyway)
-            Type::Never | Type::Error | Type::ComptimeType => true,
-            // Struct types are move types by default (may be @copy, but need StructDef to check)
-            Type::Struct(_) => false,
-            // Arrays may be Copy if element type is Copy (need ArrayTypeDef to check)
-            Type::Array(_) => false,
+            101 => true,
             // Module types are Copy (they're just compile-time namespace references)
-            Type::Module(_) => true,
+            103 => true,
+            // Struct types are move types by default
+            100 => false,
+            // Arrays may be Copy if element type is Copy (need ArrayTypeDef to check)
+            102 => false,
+            _ => false,
         }
     }
 
@@ -428,23 +591,35 @@ impl Type {
     /// This is used during anonymous struct creation to determine if the new struct
     /// should be Copy based on its field types.
     pub fn is_copy_in_sema(&self, struct_defs: &[StructDef]) -> bool {
-        match self {
-            Type::Struct(struct_id) => {
-                let idx = struct_id.0 as usize;
-                if idx < struct_defs.len() {
-                    struct_defs[idx].is_copy
-                } else {
-                    false
-                }
+        if let Some(struct_id) = self.as_struct() {
+            let idx = struct_id.0 as usize;
+            if idx < struct_defs.len() {
+                struct_defs[idx].is_copy
+            } else {
+                false
             }
-            // For non-struct types, delegate to is_copy()
-            _ => self.is_copy(),
+        } else {
+            self.is_copy()
+        }
+    }
+
+    /// Check if this type is Copy, with access to TypeInternPool for struct checking.
+    ///
+    /// This is used during anonymous struct creation to determine if the new struct
+    /// should be Copy based on its field types.
+    pub fn is_copy_in_pool(&self, type_pool: &crate::intern_pool::TypeInternPool) -> bool {
+        if let Some(struct_id) = self.as_struct() {
+            type_pool.struct_def(struct_id).is_copy
+        } else {
+            self.is_copy()
         }
     }
 
     /// Check if this is a 64-bit type (uses 64-bit operations).
+    /// Optimized: checks for I64 (3) or U64 (7).
+    #[inline]
     pub fn is_64_bit(&self) -> bool {
-        matches!(self, Type::I64 | Type::U64)
+        self.0 == 3 || self.0 == 7
     }
 
     /// Check if this type can coerce to the target type.
@@ -458,9 +633,11 @@ impl Type {
     }
 
     /// Check if this is an unsigned integer type.
+    /// Optimized: checks tag range directly (4-7 are unsigned integers).
+    #[inline]
     #[must_use]
     pub fn is_unsigned(&self) -> bool {
-        matches!(self, Type::U8 | Type::U16 | Type::U32 | Type::U64)
+        self.0 >= 4 && self.0 <= 7
     }
 
     /// Check if a u64 value fits within the range of this integer type.
@@ -472,15 +649,15 @@ impl Type {
     /// For non-integer types, returns `false`.
     #[must_use]
     pub fn literal_fits(&self, value: u64) -> bool {
-        match self {
-            Type::I8 => value <= i8::MAX as u64,
-            Type::I16 => value <= i16::MAX as u64,
-            Type::I32 => value <= i32::MAX as u64,
-            Type::I64 => value <= i64::MAX as u64,
-            Type::U8 => value <= u8::MAX as u64,
-            Type::U16 => value <= u16::MAX as u64,
-            Type::U32 => value <= u32::MAX as u64,
-            Type::U64 => true, // Any u64 value fits in u64
+        match self.0 {
+            0 => value <= i8::MAX as u64,  // I8
+            1 => value <= i16::MAX as u64, // I16
+            2 => value <= i32::MAX as u64, // I32
+            3 => value <= i64::MAX as u64, // I64
+            4 => value <= u8::MAX as u64,  // U8
+            5 => value <= u16::MAX as u64, // U16
+            6 => value <= u32::MAX as u64, // U32
+            7 => true,                     // U64 - Any u64 value fits
             _ => false,
         }
     }
@@ -491,74 +668,30 @@ impl Type {
     /// Returns `true` if the negated value fits, `false` otherwise.
     #[must_use]
     pub fn negated_literal_fits(&self, value: u64) -> bool {
-        match self {
-            Type::I8 => value <= (i8::MIN as i64).unsigned_abs(),
-            Type::I16 => value <= (i16::MIN as i64).unsigned_abs(),
-            Type::I32 => value <= (i32::MIN as i64).unsigned_abs(),
-            Type::I64 => value <= (i64::MIN).unsigned_abs(),
+        match self.0 {
+            0 => value <= (i8::MIN as i64).unsigned_abs(),  // I8
+            1 => value <= (i16::MIN as i64).unsigned_abs(), // I16
+            2 => value <= (i32::MIN as i64).unsigned_abs(), // I32
+            3 => value <= (i64::MIN).unsigned_abs(),        // I64
             _ => false,
         }
     }
 
     /// Encode this type as a u32 for storage in extra arrays.
     ///
-    /// This uses a tag-value encoding:
-    /// - Primitive types (I8..ComptimeType): tag = discriminant, no additional data
-    /// - Struct(id): tag = 100, followed by id
-    /// - Enum(id): tag = 101, followed by id
-    /// - Array(id): tag = 102, followed by id
-    ///
-    /// Note: For compound types, caller must encode additional data separately.
-    /// This method returns the tag only.
+    /// Since Type is now a u32 newtype, this simply returns the inner value.
+    #[inline]
     pub fn as_u32(&self) -> u32 {
-        match self {
-            Type::I8 => 0,
-            Type::I16 => 1,
-            Type::I32 => 2,
-            Type::I64 => 3,
-            Type::U8 => 4,
-            Type::U16 => 5,
-            Type::U32 => 6,
-            Type::U64 => 7,
-            Type::Bool => 8,
-            Type::Unit => 9,
-            Type::Error => 10,
-            Type::Never => 11,
-            Type::ComptimeType => 12,
-            // Compound types need special handling - store ID in high bits
-            Type::Struct(id) => 100 | ((id.0 as u32) << 8),
-            Type::Enum(id) => 101 | ((id.0 as u32) << 8),
-            Type::Array(id) => 102 | ((id.0 as u32) << 8),
-            Type::Module(id) => 103 | ((id.index() as u32) << 8),
-        }
+        self.0
     }
 
     /// Decode a type from a u32 value.
     ///
-    /// This reverses the encoding done by `as_u32`.
+    /// Since Type is now a u32 newtype, this simply wraps the value.
+    /// Note: This does not validate the encoding - use with values from `as_u32()`.
+    #[inline]
     pub fn from_u32(v: u32) -> Self {
-        let tag = v & 0xFF;
-        let id = (v >> 8) as u32;
-        match tag {
-            0 => Type::I8,
-            1 => Type::I16,
-            2 => Type::I32,
-            3 => Type::I64,
-            4 => Type::U8,
-            5 => Type::U16,
-            6 => Type::U32,
-            7 => Type::U64,
-            8 => Type::Bool,
-            9 => Type::Unit,
-            10 => Type::Error,
-            11 => Type::Never,
-            12 => Type::ComptimeType,
-            100 => Type::Struct(StructId(id)),
-            101 => Type::Enum(EnumId(id)),
-            102 => Type::Array(ArrayTypeId(id)),
-            103 => Type::Module(ModuleId::new(id)),
-            _ => panic!("invalid Type encoding: {}", v),
-        }
+        Type(v)
     }
 }
 
@@ -1069,32 +1202,6 @@ mod tests {
             is_builtin: false,
         };
         assert_eq!(with_fields.field_count(), 3);
-    }
-
-    // ========== ArrayTypeDef tests ==========
-
-    #[test]
-    fn test_array_type_def_len() {
-        let arr = ArrayTypeDef {
-            element_type: Type::I32,
-            length: 10,
-        };
-        assert_eq!(arr.len(), 10);
-    }
-
-    #[test]
-    fn test_array_type_def_is_empty() {
-        let empty = ArrayTypeDef {
-            element_type: Type::I32,
-            length: 0,
-        };
-        assert!(empty.is_empty());
-
-        let non_empty = ArrayTypeDef {
-            element_type: Type::I32,
-            length: 1,
-        };
-        assert!(!non_empty.is_empty());
     }
 
     // ========== EnumDef tests ==========

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -4,9 +4,7 @@
 //! into explicit basic blocks with terminators.
 
 use lasso::ThreadedRodeo;
-use rue_air::{
-    Air, AirArgMode, AirInstData, AirPattern, AirRef, ArrayTypeDef, Type, TypeInternPool,
-};
+use rue_air::{Air, AirArgMode, AirInstData, AirPattern, AirRef, Type, TypeInternPool, TypeKind};
 use rue_error::{CompileWarning, WarningKind};
 
 use crate::CfgOutput;
@@ -59,10 +57,8 @@ struct LiveSlot {
 pub struct CfgBuilder<'a> {
     air: &'a Air,
     cfg: Cfg,
-    /// Type intern pool for struct/enum lookups (Phase 3 ADR-0024)
+    /// Type intern pool for struct/enum/array lookups (Phase 2B ADR-0024)
     type_pool: &'a TypeInternPool,
-    /// Array type definitions for type queries
-    array_types: &'a [ArrayTypeDef],
     /// Interner for resolving symbols to strings
     interner: &'a ThreadedRodeo,
     /// Current block we're building
@@ -82,16 +78,14 @@ pub struct CfgBuilder<'a> {
 impl<'a> CfgBuilder<'a> {
     /// Build a CFG from AIR, returning the CFG and any warnings.
     ///
-    /// The `type_pool` provides struct/enum definitions needed for queries like
-    /// `type_needs_drop`. The `array_types` provides array type definitions.
-    /// The `interner` is used to resolve Symbol values to strings for the CFG.
+    /// The `type_pool` provides struct/enum/array definitions needed for queries like
+    /// `type_needs_drop`. The `interner` is used to resolve Symbol values to strings for the CFG.
     pub fn build(
         air: &'a Air,
         num_locals: u32,
         num_params: u32,
         fn_name: &str,
         type_pool: &'a TypeInternPool,
-        array_types: &'a [ArrayTypeDef],
         param_modes: Vec<bool>,
         interner: &'a ThreadedRodeo,
     ) -> CfgOutput {
@@ -105,7 +99,6 @@ impl<'a> CfgBuilder<'a> {
                 param_modes,
             ),
             type_pool,
-            array_types,
             interner,
             current_block: BlockId(0),
             loop_stack: Vec::new(),
@@ -1720,29 +1713,29 @@ impl<'a> CfgBuilder<'a> {
     /// - Struct: needs drop if any field needs drop
     /// - Array: needs drop if element type needs drop
     fn type_needs_drop(&self, ty: Type) -> bool {
-        match ty {
+        match ty.kind() {
             // Primitive types are trivially droppable
             // ComptimeType is a comptime-only type and has no runtime representation
-            Type::I8
-            | Type::I16
-            | Type::I32
-            | Type::I64
-            | Type::U8
-            | Type::U16
-            | Type::U32
-            | Type::U64
-            | Type::Bool
-            | Type::Unit
-            | Type::Never
-            | Type::Error
-            | Type::ComptimeType => false,
+            TypeKind::I8
+            | TypeKind::I16
+            | TypeKind::I32
+            | TypeKind::I64
+            | TypeKind::U8
+            | TypeKind::U16
+            | TypeKind::U32
+            | TypeKind::U64
+            | TypeKind::Bool
+            | TypeKind::Unit
+            | TypeKind::Never
+            | TypeKind::Error
+            | TypeKind::ComptimeType => false,
 
             // Enum types are trivially droppable (just discriminant values)
-            Type::Enum(_) => false,
+            TypeKind::Enum(_) => false,
 
             // Struct types need drop if they have a destructor (e.g., builtin String)
             // or if any field needs drop
-            Type::Struct(struct_id) => {
+            TypeKind::Struct(struct_id) => {
                 let struct_def = self.type_pool.struct_def(struct_id);
                 // Builtins with destructors (like String) need drop
                 if struct_def.destructor.is_some() {
@@ -1755,13 +1748,13 @@ impl<'a> CfgBuilder<'a> {
             // Note: String is now Type::Struct with is_builtin=true, handled above
 
             // Array types need drop if element type needs drop
-            Type::Array(array_id) => {
-                let array_def = &self.array_types[array_id.0 as usize];
-                self.type_needs_drop(array_def.element_type)
+            TypeKind::Array(array_id) => {
+                let (element_type, _length) = self.type_pool.array_def(array_id);
+                self.type_needs_drop(element_type)
             }
 
             // Module types don't need drop (compile-time only)
-            Type::Module(_) => false,
+            TypeKind::Module(_) => false,
         }
     }
 
@@ -1861,7 +1854,6 @@ mod tests {
             func.num_param_slots,
             &func.name,
             &output.type_pool,
-            &output.array_types,
             func.param_modes.clone(),
             &interner,
         )

--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -29,7 +29,7 @@ pub use inst::{
 pub use opt::OptLevel;
 
 // Re-export types from rue-air that we use
-pub use rue_air::{StructDef, StructId, Type};
+pub use rue_air::{StructDef, StructId, Type, TypeKind};
 
 /// Output from CFG construction.
 ///

--- a/crates/rue-cfg/src/opt/constfold.rs
+++ b/crates/rue-cfg/src/opt/constfold.rs
@@ -18,7 +18,7 @@
 //! This ensures the runtime panic behavior is preserved.
 
 use crate::{Cfg, CfgInstData, CfgValue};
-use rue_air::Type;
+use rue_air::{Type, TypeKind};
 
 /// Run constant folding on the CFG.
 ///
@@ -234,28 +234,31 @@ fn get_const_bool(cfg: &Cfg, value: CfgValue) -> Option<bool> {
 
 /// Check if a type is signed.
 fn is_signed(ty: Type) -> bool {
-    matches!(ty, Type::I8 | Type::I16 | Type::I32 | Type::I64)
+    matches!(
+        ty.kind(),
+        TypeKind::I8 | TypeKind::I16 | TypeKind::I32 | TypeKind::I64
+    )
 }
 
 /// Get the bit width of a type.
 fn type_bits(ty: Type) -> u32 {
-    match ty {
-        Type::I8 | Type::U8 => 8,
-        Type::I16 | Type::U16 => 16,
-        Type::I32 | Type::U32 => 32,
-        Type::I64 | Type::U64 => 64,
-        Type::Bool => 1,
+    match ty.kind() {
+        TypeKind::I8 | TypeKind::U8 => 8,
+        TypeKind::I16 | TypeKind::U16 => 16,
+        TypeKind::I32 | TypeKind::U32 => 32,
+        TypeKind::I64 | TypeKind::U64 => 64,
+        TypeKind::Bool => 1,
         _ => 64, // Default for other types
     }
 }
 
 /// Mask a value to the bit width of a type.
 fn mask_to_type(val: u64, ty: Type) -> u64 {
-    match ty {
-        Type::I8 | Type::U8 => val & 0xFF,
-        Type::I16 | Type::U16 => val & 0xFFFF,
-        Type::I32 | Type::U32 => val & 0xFFFF_FFFF,
-        Type::I64 | Type::U64 => val,
+    match ty.kind() {
+        TypeKind::I8 | TypeKind::U8 => val & 0xFF,
+        TypeKind::I16 | TypeKind::U16 => val & 0xFFFF,
+        TypeKind::I32 | TypeKind::U32 => val & 0xFFFF_FFFF,
+        TypeKind::I64 | TypeKind::U64 => val,
         _ => val,
     }
 }
@@ -361,11 +364,11 @@ fn checked_neg(a: u64, ty: Type) -> Option<u64> {
 
 /// Sign-extend a value based on its type.
 fn sign_extend(val: u64, ty: Type) -> u64 {
-    match ty {
-        Type::I8 => (val as i8) as i64 as u64,
-        Type::I16 => (val as i16) as i64 as u64,
-        Type::I32 => (val as i32) as i64 as u64,
-        Type::I64 => val,
+    match ty.kind() {
+        TypeKind::I8 => (val as i8) as i64 as u64,
+        TypeKind::I16 => (val as i16) as i64 as u64,
+        TypeKind::I32 => (val as i32) as i64 as u64,
+        TypeKind::I64 => val,
         _ => val,
     }
 }
@@ -377,22 +380,22 @@ fn sign_extend_operands(a: u64, b: u64, ty: Type) -> (u64, u64) {
 
 /// Check if a signed result fits in the target type.
 fn fits_in_signed_type(val: i64, ty: Type) -> bool {
-    match ty {
-        Type::I8 => val >= i8::MIN as i64 && val <= i8::MAX as i64,
-        Type::I16 => val >= i16::MIN as i64 && val <= i16::MAX as i64,
-        Type::I32 => val >= i32::MIN as i64 && val <= i32::MAX as i64,
-        Type::I64 => true, // i64 can hold any i64
+    match ty.kind() {
+        TypeKind::I8 => val >= i8::MIN as i64 && val <= i8::MAX as i64,
+        TypeKind::I16 => val >= i16::MIN as i64 && val <= i16::MAX as i64,
+        TypeKind::I32 => val >= i32::MIN as i64 && val <= i32::MAX as i64,
+        TypeKind::I64 => true, // i64 can hold any i64
         _ => true,
     }
 }
 
 /// Check if an unsigned result fits in the target type.
 fn fits_in_unsigned_type(val: u64, ty: Type) -> bool {
-    match ty {
-        Type::U8 => val <= u8::MAX as u64,
-        Type::U16 => val <= u16::MAX as u64,
-        Type::U32 => val <= u32::MAX as u64,
-        Type::U64 => true,
+    match ty.kind() {
+        TypeKind::U8 => val <= u8::MAX as u64,
+        TypeKind::U16 => val <= u16::MAX as u64,
+        TypeKind::U32 => val <= u32::MAX as u64,
+        TypeKind::U64 => true,
         _ => true,
     }
 }

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -6,8 +6,8 @@
 use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
-use rue_air::{ArrayTypeDef, StructId, TypeInternPool};
-use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Terminator, Type};
+use rue_air::{StructId, TypeInternPool};
+use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Terminator, Type, TypeKind};
 
 use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Operand, Reg, VReg};
 use crate::cfg_lower::{FieldChainBase, IndexChainBase, IndexLevel};
@@ -40,10 +40,8 @@ const RET_REGS: [Reg; 8] = [
 /// CFG to Aarch64Mir lowering.
 pub struct CfgLower<'a> {
     cfg: &'a Cfg,
-    /// Type intern pool for struct/enum lookups (Phase 3 ADR-0024).
+    /// Type intern pool for struct/enum/array lookups (Phase 2B ADR-0024).
     type_pool: &'a TypeInternPool,
-    /// Array type definitions for bounds checking.
-    array_types: &'a [ArrayTypeDef],
     /// String table from semantic analysis (indexed by StringId).
     strings: &'a [String],
     /// Interner for resolving Spur to string
@@ -72,7 +70,6 @@ impl<'a> CfgLower<'a> {
     pub fn new(
         cfg: &'a Cfg,
         type_pool: &'a TypeInternPool,
-        array_types: &'a [ArrayTypeDef],
         strings: &'a [String],
         interner: &'a ThreadedRodeo,
     ) -> Self {
@@ -92,7 +89,6 @@ impl<'a> CfgLower<'a> {
         Self {
             cfg,
             type_pool,
-            array_types,
             strings,
             interner,
             mir: Aarch64Mir::new(),
@@ -115,27 +111,29 @@ impl<'a> CfgLower<'a> {
 
     /// Get the length of an array type.
     fn array_length(&self, array_type: Type) -> u64 {
-        types::array_length_from_type(self.array_types, array_type)
+        types::array_length_from_type(self.type_pool, array_type)
     }
 
     /// Get the array type definition.
-    fn array_type_def(&self, array_type: Type) -> Option<&ArrayTypeDef> {
-        types::array_type_def_from_type(self.array_types, array_type)
+    ///
+    /// Returns `Some((element_type, length))` for array types, `None` otherwise.
+    fn array_type_def(&self, array_type: Type) -> Option<(Type, u64)> {
+        types::array_type_def_from_type(self.type_pool, array_type)
     }
 
     /// Calculate the total number of slots needed to store a type.
     fn type_slot_count(&self, ty: Type) -> u32 {
-        types::type_slot_count(self.type_pool, self.array_types, ty)
+        types::type_slot_count(self.type_pool, ty)
     }
 
     /// Calculate the slot count for a single element of an array type.
     fn array_element_slot_count(&self, array_type: Type) -> u32 {
-        types::array_element_slot_count_from_type(self.type_pool, self.array_types, array_type)
+        types::array_element_slot_count_from_type(self.type_pool, array_type)
     }
 
     /// Calculate the slot offset for a field within a struct.
     fn struct_field_slot_offset(&self, struct_id: StructId, field_index: u32) -> u32 {
-        types::struct_field_slot_offset(self.type_pool, self.array_types, struct_id, field_index)
+        types::struct_field_slot_offset(self.type_pool, struct_id, field_index)
     }
 
     /// Trace back through a chain of FieldGet instructions to find the original
@@ -314,8 +312,8 @@ impl<'a> CfgLower<'a> {
     ///
     /// Returns true if the type is a struct that is marked as builtin with name "String".
     fn is_builtin_string(&self, ty: Type) -> bool {
-        match ty {
-            Type::Struct(struct_id) => {
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => {
                 let struct_def = self.type_pool.struct_def(struct_id);
                 struct_def.is_builtin && struct_def.name == "String"
             }
@@ -378,9 +376,9 @@ impl<'a> CfgLower<'a> {
         }
 
         let inst = self.cfg.get_inst(value);
-        let struct_id = match inst.ty {
-            Type::Struct(id) => id,
-            _ => return None,
+        let struct_id = match inst.ty.as_struct() {
+            Some(id) => id,
+            None => return None,
         };
 
         match &inst.data.clone() {
@@ -472,8 +470,8 @@ impl<'a> CfgLower<'a> {
                 self.value_map.insert(*param_val, vreg);
 
                 // For struct types, also allocate vregs for each slot
-                if let Type::Struct(struct_id) = ty {
-                    let slot_count = self.type_slot_count(Type::Struct(*struct_id));
+                if let Some(struct_id) = ty.as_struct() {
+                    let slot_count = self.type_slot_count(Type::Struct(struct_id));
                     let mut slot_vregs = vec![vreg]; // First slot uses main vreg
                     for _ in 1..slot_count {
                         slot_vregs.push(self.mir.alloc_vreg());
@@ -515,8 +513,8 @@ impl<'a> CfgLower<'a> {
                     .insert((block.id, param_idx as u32), vreg);
                 self.value_map.insert(*param_val, vreg);
 
-                if let Type::Struct(struct_id) = ty {
-                    let slot_count = self.type_slot_count(Type::Struct(*struct_id));
+                if let Some(struct_id) = ty.as_struct() {
+                    let slot_count = self.type_slot_count(Type::Struct(struct_id));
                     let mut slot_vregs = vec![vreg];
                     for _ in 1..slot_count {
                         slot_vregs.push(self.mir.alloc_vreg());
@@ -1095,7 +1093,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         imm: 1,
                     });
-                } else if let Type::Struct(struct_id) = lhs_ty {
+                } else if let Some(struct_id) = lhs_ty.as_struct() {
                     // Struct equality: compare all fields
                     self.emit_struct_equality(value, *lhs, *rhs, struct_id, false);
                 } else {
@@ -1124,7 +1122,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         imm: 0,
                     });
-                } else if let Type::Struct(struct_id) = lhs_ty {
+                } else if let Some(struct_id) = lhs_ty.as_struct() {
                     // Struct inequality: compare all fields, invert result
                     self.emit_struct_equality(value, *lhs, *rhs, struct_id, true);
                 } else {
@@ -1351,7 +1349,7 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::Alloc { slot, init } => {
                 let init_type = self.cfg.get_inst(*init).ty;
-                if matches!(init_type, Type::Array(_)) {
+                if init_type.is_array() {
                     // Array: recursively flatten nested arrays and store scalar elements
                     let scalar_vregs = self.collect_array_scalar_vregs(*init);
                     for (i, scalar_vreg) in scalar_vregs.iter().enumerate() {
@@ -1363,7 +1361,7 @@ impl<'a> CfgLower<'a> {
                             offset,
                         });
                     }
-                } else if matches!(init_type, Type::Struct(_)) {
+                } else if init_type.is_struct() {
                     // Struct: recursively flatten struct fields (including array fields) to scalars
                     let scalar_vregs = self.collect_struct_scalar_vregs(*init);
                     for (i, scalar_vreg) in scalar_vregs.iter().enumerate() {
@@ -1463,7 +1461,7 @@ impl<'a> CfgLower<'a> {
                     self.struct_slot_vregs
                         .insert(value, vec![ptr_vreg, len_vreg, cap_vreg]);
                     self.value_map.insert(value, ptr_vreg);
-                } else if let Type::Array(_) = load_type {
+                } else if load_type.is_array() {
                     // Array: load all element slots (recursively flattened)
                     let slot_count = self.type_slot_count(load_type);
                     let mut slot_vregs = Vec::with_capacity(slot_count as usize);
@@ -1489,7 +1487,7 @@ impl<'a> CfgLower<'a> {
                         let vreg = self.mir.alloc_vreg();
                         self.value_map.insert(value, vreg);
                     }
-                } else if let Type::Struct(struct_id) = load_type {
+                } else if let Some(struct_id) = load_type.as_struct() {
                     // Struct: load all field slots (recursively flattened)
                     let slot_count = self.type_slot_count(Type::Struct(struct_id));
                     let mut slot_vregs = Vec::with_capacity(slot_count as usize);
@@ -1751,8 +1749,8 @@ impl<'a> CfgLower<'a> {
                         continue;
                     }
 
-                    match arg_type {
-                        Type::Struct(struct_id) => {
+                    match arg_type.kind() {
+                        TypeKind::Struct(struct_id) => {
                             let arg_data = &self.cfg.get_inst(arg_value).data;
                             let slot_count = self.type_slot_count(Type::Struct(struct_id));
                             match arg_data {
@@ -1796,7 +1794,7 @@ impl<'a> CfgLower<'a> {
                                 }
                             }
                         }
-                        Type::Array(_) => {
+                        TypeKind::Array(_) => {
                             let arg_data = &self.cfg.get_inst(arg_value).data;
                             let array_len = self.array_length(arg_type) as u32;
                             match arg_data {
@@ -1923,7 +1921,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(result_vreg),
                         src: Operand::Virtual(slot_vregs[0]),
                     });
-                } else if let Type::Struct(struct_id) = ty {
+                } else if let Some(struct_id) = ty.as_struct() {
                     // Non-builtin structs return in registers
                     let slot_count = self.type_slot_count(Type::Struct(struct_id));
                     let mut slot_vregs = Vec::new();
@@ -2045,16 +2043,20 @@ impl<'a> CfgLower<'a> {
                         // Handle scalar types (integers and bool)
                         let arg_vreg = self.get_vreg(arg_val);
 
-                        let runtime_fn = match arg_type {
-                            Type::Bool => "__rue_dbg_bool",
-                            Type::I8 | Type::I16 | Type::I32 | Type::I64 => "__rue_dbg_i64",
-                            Type::U8 | Type::U16 | Type::U32 | Type::U64 => "__rue_dbg_u64",
+                        let runtime_fn = match arg_type.kind() {
+                            TypeKind::Bool => "__rue_dbg_bool",
+                            TypeKind::I8 | TypeKind::I16 | TypeKind::I32 | TypeKind::I64 => {
+                                "__rue_dbg_i64"
+                            }
+                            TypeKind::U8 | TypeKind::U16 | TypeKind::U32 | TypeKind::U64 => {
+                                "__rue_dbg_u64"
+                            }
                             _ => unreachable!("@dbg only supports scalars and strings"),
                         };
 
                         // Handle type extensions
-                        match arg_type {
-                            Type::I8 => {
+                        match arg_type.kind() {
+                            TypeKind::I8 => {
                                 self.mir.push(Aarch64Inst::MovRR {
                                     dst: Operand::Physical(Reg::X0),
                                     src: Operand::Virtual(arg_vreg),
@@ -2064,7 +2066,7 @@ impl<'a> CfgLower<'a> {
                                     src: Operand::Physical(Reg::X0),
                                 });
                             }
-                            Type::I16 => {
+                            TypeKind::I16 => {
                                 self.mir.push(Aarch64Inst::MovRR {
                                     dst: Operand::Physical(Reg::X0),
                                     src: Operand::Virtual(arg_vreg),
@@ -2074,7 +2076,7 @@ impl<'a> CfgLower<'a> {
                                     src: Operand::Physical(Reg::X0),
                                 });
                             }
-                            Type::I32 => {
+                            TypeKind::I32 => {
                                 self.mir.push(Aarch64Inst::MovRR {
                                     dst: Operand::Physical(Reg::X0),
                                     src: Operand::Virtual(arg_vreg),
@@ -2084,7 +2086,7 @@ impl<'a> CfgLower<'a> {
                                     src: Operand::Physical(Reg::X0),
                                 });
                             }
-                            Type::U8 => {
+                            TypeKind::U8 => {
                                 self.mir.push(Aarch64Inst::MovRR {
                                     dst: Operand::Physical(Reg::X0),
                                     src: Operand::Virtual(arg_vreg),
@@ -2094,7 +2096,7 @@ impl<'a> CfgLower<'a> {
                                     src: Operand::Physical(Reg::X0),
                                 });
                             }
-                            Type::U16 => {
+                            TypeKind::U16 => {
                                 self.mir.push(Aarch64Inst::MovRR {
                                     dst: Operand::Physical(Reg::X0),
                                     src: Operand::Virtual(arg_vreg),
@@ -2104,7 +2106,7 @@ impl<'a> CfgLower<'a> {
                                     src: Operand::Physical(Reg::X0),
                                 });
                             }
-                            Type::U32 | Type::I64 | Type::U64 | Type::Bool => {
+                            TypeKind::U32 | TypeKind::I64 | TypeKind::U64 | TypeKind::Bool => {
                                 self.mir.push(Aarch64Inst::MovRR {
                                     dst: Operand::Physical(Reg::X0),
                                     src: Operand::Virtual(arg_vreg),
@@ -2184,7 +2186,7 @@ impl<'a> CfgLower<'a> {
                 let fields = self.cfg.get_extra(*fields_start, *fields_len).to_vec();
                 for field in &fields {
                     let field_inst = self.cfg.get_inst(*field);
-                    if let Type::Struct(_) = field_inst.ty {
+                    if field_inst.ty.is_struct() {
                         // Nested struct - get all its slot vregs
                         let nested_vregs = self
                             .struct_slot_vregs
@@ -2868,7 +2870,7 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Handle struct drops - need to pass all flattened field values
-                if let Type::Struct(struct_id) = dropped_ty {
+                if let Some(struct_id) = dropped_ty.as_struct() {
                     let struct_def = self.type_pool.struct_def(struct_id);
 
                     // Collect all scalar vregs for this struct (flattened)
@@ -2912,7 +2914,7 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Handle array drops - need to pass all element values
-                if let Type::Array(array_id) = dropped_ty {
+                if let Some(array_id) = dropped_ty.as_array() {
                     // Collect all scalar vregs for this array (flattened)
                     let element_vregs = self.collect_array_scalar_vregs(*dropped_value);
 
@@ -2932,8 +2934,7 @@ impl<'a> CfgLower<'a> {
                         });
                     }
 
-                    let drop_fn_name =
-                        types::array_drop_glue_name(array_id, self.array_types, self.type_pool);
+                    let drop_fn_name = types::array_drop_glue_name(array_id, self.type_pool);
                     let symbol_id = self.intern_symbol(&drop_fn_name);
                     self.mir.push(Aarch64Inst::Bl { symbol_id });
                     return;
@@ -3008,8 +3009,8 @@ impl<'a> CfgLower<'a> {
     ///
     /// Branches to `ok_label` if the value is in range (no overflow).
     fn emit_subword_range_check(&mut self, ty: Type, result_vreg: VReg, ok_label: LabelId) {
-        match ty {
-            Type::U8 => {
+        match ty.kind() {
+            TypeKind::U8 => {
                 // Result must be <= 255
                 self.mir.push(Aarch64Inst::CmpImm {
                     src: Operand::Virtual(result_vreg),
@@ -3021,7 +3022,7 @@ impl<'a> CfgLower<'a> {
                     label: ok_label,
                 });
             }
-            Type::U16 => {
+            TypeKind::U16 => {
                 // Result must be <= 65535
                 let max_vreg = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::MovImm {
@@ -3037,7 +3038,7 @@ impl<'a> CfgLower<'a> {
                     label: ok_label,
                 });
             }
-            Type::I8 => {
+            TypeKind::I8 => {
                 // Sign-extend to 64-bit and compare with original
                 let sext_vreg = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::Sxtb {
@@ -3054,7 +3055,7 @@ impl<'a> CfgLower<'a> {
                     label: ok_label,
                 });
             }
-            Type::I16 => {
+            TypeKind::I16 => {
                 // Sign-extend to 64-bit and compare with original
                 let sext_vreg = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::Sxth {
@@ -3080,21 +3081,21 @@ impl<'a> CfgLower<'a> {
     fn emit_overflow_check_add(&mut self, ty: Type, result_vreg: VReg) {
         let ok_label = self.mir.alloc_label();
 
-        match ty {
+        match ty.kind() {
             // 32-bit and 64-bit unsigned: C=1 means overflow (carry out)
             // Branch to ok if C=0 (no overflow)
-            Type::U32 | Type::U64 => {
+            TypeKind::U32 | TypeKind::U64 => {
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Lo, // Lo = C=0 (no carry)
                     label: ok_label,
                 });
             }
             // 32-bit and 64-bit signed: V flag indicates overflow
-            Type::I32 | Type::I64 => {
+            TypeKind::I32 | TypeKind::I64 => {
                 self.mir.push(Aarch64Inst::Bvc { label: ok_label });
             }
             // Sub-word types: check if result fits in type's range
-            Type::U8 | Type::U16 | Type::I8 | Type::I16 => {
+            TypeKind::U8 | TypeKind::U16 | TypeKind::I8 | TypeKind::I16 => {
                 self.emit_subword_range_check(ty, result_vreg, ok_label);
             }
             // Other types don't have arithmetic
@@ -3115,21 +3116,21 @@ impl<'a> CfgLower<'a> {
     fn emit_overflow_check_sub(&mut self, ty: Type, result_vreg: VReg) {
         let ok_label = self.mir.alloc_label();
 
-        match ty {
+        match ty.kind() {
             // 32-bit and 64-bit unsigned: C=0 means borrow (underflow)
             // Branch to ok if C=1 (no underflow)
-            Type::U32 | Type::U64 => {
+            TypeKind::U32 | TypeKind::U64 => {
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Hs, // Hs = C=1 (no borrow)
                     label: ok_label,
                 });
             }
             // 32-bit and 64-bit signed: V flag indicates overflow
-            Type::I32 | Type::I64 => {
+            TypeKind::I32 | TypeKind::I64 => {
                 self.mir.push(Aarch64Inst::Bvc { label: ok_label });
             }
             // Sub-word types: check if result fits in type's range
-            Type::U8 | Type::U16 | Type::I8 | Type::I16 => {
+            TypeKind::U8 | TypeKind::U16 | TypeKind::I8 | TypeKind::I16 => {
                 self.emit_subword_range_check(ty, result_vreg, ok_label);
             }
             // Other types don't have arithmetic
@@ -3155,9 +3156,9 @@ impl<'a> CfgLower<'a> {
     ) {
         let ok_label = self.mir.alloc_label();
 
-        match ty {
+        match ty.kind() {
             // 32-bit signed: SMULL gives 64-bit result
-            Type::I32 => {
+            TypeKind::I32 => {
                 let smull_vreg = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::SmullRR {
                     dst: Operand::Virtual(smull_vreg),
@@ -3186,7 +3187,7 @@ impl<'a> CfgLower<'a> {
                 });
             }
             // 32-bit unsigned: UMULL gives 64-bit result
-            Type::U32 => {
+            TypeKind::U32 => {
                 let umull_vreg = self.mir.alloc_vreg();
                 self.mir.push(Aarch64Inst::UmullRR {
                     dst: Operand::Virtual(umull_vreg),
@@ -3211,7 +3212,7 @@ impl<'a> CfgLower<'a> {
                 });
             }
             // 64-bit signed: Use SMULH for high bits
-            Type::I64 => {
+            TypeKind::I64 => {
                 // Do the multiply first
                 self.mir.push(Aarch64Inst::MulRR {
                     dst: Operand::Virtual(result_vreg),
@@ -3243,7 +3244,7 @@ impl<'a> CfgLower<'a> {
                 });
             }
             // 64-bit unsigned: Use UMULH for high bits
-            Type::U64 => {
+            TypeKind::U64 => {
                 // Do the multiply first
                 self.mir.push(Aarch64Inst::MulRR {
                     dst: Operand::Virtual(result_vreg),
@@ -3264,7 +3265,7 @@ impl<'a> CfgLower<'a> {
                 });
             }
             // Sub-word types: do the multiply, then check range
-            Type::I8 | Type::I16 | Type::U8 | Type::U16 => {
+            TypeKind::I8 | TypeKind::I16 | TypeKind::U8 | TypeKind::U16 => {
                 // For sub-word, just do the multiply and check range
                 self.mir.push(Aarch64Inst::MulRR {
                     dst: Operand::Virtual(result_vreg),
@@ -3289,21 +3290,21 @@ impl<'a> CfgLower<'a> {
     fn emit_overflow_check_neg(&mut self, ty: Type, result_vreg: VReg) {
         let ok_label = self.mir.alloc_label();
 
-        match ty {
+        match ty.kind() {
             // Unsigned: NEGS sets C=0 for non-zero operands (which is overflow)
             // Branch to ok if C=1 (meaning operand was 0, no overflow)
-            Type::U32 | Type::U64 => {
+            TypeKind::U32 | TypeKind::U64 => {
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Hs, // Hs = C=1
                     label: ok_label,
                 });
             }
             // Signed: V flag indicates overflow
-            Type::I32 | Type::I64 => {
+            TypeKind::I32 | TypeKind::I64 => {
                 self.mir.push(Aarch64Inst::Bvc { label: ok_label });
             }
             // Sub-word unsigned types: only 0 is valid (negating to 0)
-            Type::U8 | Type::U16 => {
+            TypeKind::U8 | TypeKind::U16 => {
                 // Result must be 0 for no overflow
                 self.mir.push(Aarch64Inst::Cbz {
                     src: Operand::Virtual(result_vreg),
@@ -3311,7 +3312,7 @@ impl<'a> CfgLower<'a> {
                 });
             }
             // Sub-word signed types: check if result fits in type's range
-            Type::I8 | Type::I16 => {
+            TypeKind::I8 | TypeKind::I16 => {
                 self.emit_subword_range_check(ty, result_vreg, ok_label);
             }
             _ => return,
@@ -3411,20 +3412,20 @@ impl<'a> CfgLower<'a> {
                 // make -1 appear as a large positive number in 64-bit compare.
                 let compare_vreg = if from_bits < 64 {
                     let sext_vreg = self.mir.alloc_vreg();
-                    match from_ty {
-                        Type::I8 => {
+                    match from_ty.kind() {
+                        TypeKind::I8 => {
                             self.mir.push(Aarch64Inst::Sxtb {
                                 dst: Operand::Virtual(sext_vreg),
                                 src: Operand::Virtual(src_vreg),
                             });
                         }
-                        Type::I16 => {
+                        TypeKind::I16 => {
                             self.mir.push(Aarch64Inst::Sxth {
                                 dst: Operand::Virtual(sext_vreg),
                                 src: Operand::Virtual(src_vreg),
                             });
                         }
-                        Type::I32 => {
+                        TypeKind::I32 => {
                             self.mir.push(Aarch64Inst::Sxtw {
                                 dst: Operand::Virtual(sext_vreg),
                                 src: Operand::Virtual(src_vreg),
@@ -3527,26 +3528,26 @@ impl<'a> CfgLower<'a> {
 
     /// Get the bit width of an integer type.
     fn type_bits(ty: Type) -> u32 {
-        match ty {
-            Type::I8 | Type::U8 => 8,
-            Type::I16 | Type::U16 => 16,
-            Type::I32 | Type::U32 => 32,
-            Type::I64 | Type::U64 => 64,
+        match ty.kind() {
+            TypeKind::I8 | TypeKind::U8 => 8,
+            TypeKind::I16 | TypeKind::U16 => 16,
+            TypeKind::I32 | TypeKind::U32 => 32,
+            TypeKind::I64 | TypeKind::U64 => 64,
             _ => panic!("type_bits called on non-integer type: {:?}", ty),
         }
     }
 
     /// Get the min and max values for an integer type.
     fn type_range(ty: Type) -> (i64, i64) {
-        match ty {
-            Type::I8 => (i8::MIN as i64, i8::MAX as i64),
-            Type::I16 => (i16::MIN as i64, i16::MAX as i64),
-            Type::I32 => (i32::MIN as i64, i32::MAX as i64),
-            Type::I64 => (i64::MIN, i64::MAX),
-            Type::U8 => (0, u8::MAX as i64),
-            Type::U16 => (0, u16::MAX as i64),
-            Type::U32 => (0, u32::MAX as i64),
-            Type::U64 => (0, i64::MAX), // Can't represent u64::MAX in i64, but we use unsigned compare
+        match ty.kind() {
+            TypeKind::I8 => (i8::MIN as i64, i8::MAX as i64),
+            TypeKind::I16 => (i16::MIN as i64, i16::MAX as i64),
+            TypeKind::I32 => (i32::MIN as i64, i32::MAX as i64),
+            TypeKind::I64 => (i64::MIN, i64::MAX),
+            TypeKind::U8 => (0, u8::MAX as i64),
+            TypeKind::U16 => (0, u16::MAX as i64),
+            TypeKind::U32 => (0, u32::MAX as i64),
+            TypeKind::U64 => (0, i64::MAX), // Can't represent u64::MAX in i64, but we use unsigned compare
             _ => panic!("type_range called on non-integer type: {:?}", ty),
         }
     }
@@ -3815,7 +3816,7 @@ impl<'a> CfgLower<'a> {
                 let args = self.cfg.get_extra(*args_start, *args_len);
                 for (i, &arg) in args.iter().enumerate() {
                     let arg_type = self.cfg.get_inst(arg).ty;
-                    if matches!(arg_type, Type::Struct(_)) {
+                    if arg_type.is_struct() {
                         // For struct args, copy all field vregs
                         self.copy_struct_to_block_param(arg, *target, i as u32);
                     } else {
@@ -3862,7 +3863,7 @@ impl<'a> CfgLower<'a> {
                 let then_args = self.cfg.get_extra(*then_args_start, *then_args_len);
                 for (i, &arg) in then_args.iter().enumerate() {
                     let arg_type = self.cfg.get_inst(arg).ty;
-                    if matches!(arg_type, Type::Struct(_)) {
+                    if arg_type.is_struct() {
                         // For struct args, copy all field vregs
                         self.copy_struct_to_block_param(arg, *then_block, i as u32);
                     } else {
@@ -3888,7 +3889,7 @@ impl<'a> CfgLower<'a> {
                 let else_args = self.cfg.get_extra(*else_args_start, *else_args_len);
                 for (i, &arg) in else_args.iter().enumerate() {
                     let arg_type = self.cfg.get_inst(arg).ty;
-                    if matches!(arg_type, Type::Struct(_)) {
+                    if arg_type.is_struct() {
                         // For struct args, copy all field vregs
                         self.copy_struct_to_block_param(arg, *else_block, i as u32);
                     } else {
@@ -3961,7 +3962,7 @@ impl<'a> CfgLower<'a> {
                     });
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(Aarch64Inst::Bl { symbol_id });
-                } else if let Type::Struct(struct_id) = return_type {
+                } else if let Some(struct_id) = return_type.as_struct() {
                     // Return struct in registers
                     let slot_count = self.type_slot_count(Type::Struct(struct_id));
                     let value_data = &self.cfg.get_inst(*value).data;
@@ -4054,7 +4055,7 @@ impl<'a> CfgLower<'a> {
 mod tests {
     use super::*;
     use lasso::ThreadedRodeo;
-    use rue_air::Sema;
+    use rue_air::{ArrayTypeId, Sema};
     use rue_cfg::CfgBuilder;
     use rue_error::PreviewFeatures;
     use rue_lexer::Lexer;
@@ -4075,7 +4076,6 @@ mod tests {
 
         let func = &output.functions[0];
         let type_pool = &output.type_pool;
-        let array_types = &output.array_types;
         let strings = &output.strings;
         let cfg_output = CfgBuilder::build(
             &func.air,
@@ -4083,12 +4083,11 @@ mod tests {
             func.num_param_slots,
             &func.name,
             type_pool,
-            array_types,
             func.param_modes.clone(),
             &interner,
         );
 
-        CfgLower::new(&cfg_output.cfg, type_pool, array_types, strings, &interner).lower()
+        CfgLower::new(&cfg_output.cfg, type_pool, strings, &interner).lower()
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -27,7 +27,7 @@ pub use mir::{Aarch64Inst, Aarch64Mir, Cond, Operand, Reg, VReg};
 pub use regalloc::RegAlloc;
 
 use lasso::ThreadedRodeo;
-use rue_air::{ArrayTypeDef, TypeInternPool};
+use rue_air::TypeInternPool;
 use rue_cfg::Cfg;
 use rue_error::CompileResult;
 
@@ -43,7 +43,6 @@ pub use super::{EmittedCode, EmittedRelocation};
 pub fn generate(
     cfg: &Cfg,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
 ) -> CompileResult<MachineCode> {
@@ -51,7 +50,7 @@ pub fn generate(
     let num_params = cfg.num_params();
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, array_types, strings, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
 
     // Allocate physical registers
     let existing_slots = num_locals + num_params;
@@ -87,7 +86,6 @@ pub fn generate(
 pub fn generate_with_asm(
     cfg: &Cfg,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
 ) -> CompileResult<(MachineCode, String)> {
@@ -95,7 +93,7 @@ pub fn generate_with_asm(
     let num_params = cfg.num_params();
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, array_types, strings, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
 
     // Allocate physical registers
     let existing_slots = num_locals + num_params;
@@ -134,7 +132,6 @@ pub fn generate_with_asm(
 pub fn generate_regalloc_info(
     cfg: &Cfg,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
 ) -> CompileResult<RegAllocDebugInfo<Reg>> {
@@ -142,7 +139,7 @@ pub fn generate_regalloc_info(
     let num_params = cfg.num_params();
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, array_types, strings, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
 
     // Allocate physical registers with debug info
     let existing_slots = num_locals + num_params;

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -356,10 +356,10 @@ mod tests {
         // Build CFG from AIR (no struct/array types in this simple test)
         let interner = ThreadedRodeo::new();
         let type_pool = rue_air::TypeInternPool::new();
-        let cfg_output = CfgBuilder::build(&air, 0, 0, "main", &type_pool, &[], vec![], &interner);
+        let cfg_output = CfgBuilder::build(&air, 0, 0, "main", &type_pool, vec![], &interner);
 
         // Test the generate function
-        let machine_code = generate(&cfg_output.cfg, &type_pool, &[], &[], &interner).unwrap();
+        let machine_code = generate(&cfg_output.cfg, &type_pool, &[], &interner).unwrap();
 
         // Should generate working code
         assert!(!machine_code.code.is_empty());

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -5,7 +5,7 @@
 //! calling convention bugs, and understanding how values are laid out on the stack.
 
 use lasso::ThreadedRodeo;
-use rue_air::{ArrayTypeDef, TypeInternPool};
+use rue_air::TypeInternPool;
 use rue_cfg::Cfg;
 use rue_error::CompileResult;
 use rue_target::{Arch, Target};
@@ -255,30 +255,17 @@ pub fn generate_stack_frame_info(
     cfg: &Cfg,
     function_name: &str,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<StackFrameInfo> {
     match target.arch() {
-        Arch::X86_64 => generate_x86_64_stack_frame(
-            cfg,
-            function_name,
-            type_pool,
-            array_types,
-            strings,
-            interner,
-            target,
-        ),
-        Arch::Aarch64 => generate_aarch64_stack_frame(
-            cfg,
-            function_name,
-            type_pool,
-            array_types,
-            strings,
-            interner,
-            target,
-        ),
+        Arch::X86_64 => {
+            generate_x86_64_stack_frame(cfg, function_name, type_pool, strings, interner, target)
+        }
+        Arch::Aarch64 => {
+            generate_aarch64_stack_frame(cfg, function_name, type_pool, strings, interner, target)
+        }
     }
 }
 
@@ -287,7 +274,6 @@ fn generate_x86_64_stack_frame(
     cfg: &Cfg,
     function_name: &str,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
     target: Target,
@@ -298,7 +284,7 @@ fn generate_x86_64_stack_frame(
     let num_params = cfg.num_params();
 
     // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, array_types, strings, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
 
     // Allocate physical registers (may add spill slots)
     let existing_slots = num_locals + num_params;
@@ -411,7 +397,6 @@ fn generate_aarch64_stack_frame(
     cfg: &Cfg,
     function_name: &str,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
     target: Target,
@@ -422,7 +407,7 @@ fn generate_aarch64_stack_frame(
     let num_params = cfg.num_params();
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, array_types, strings, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
 
     // Allocate physical registers (may add spill slots)
     let existing_slots = num_locals + num_params;
@@ -564,12 +549,7 @@ mod tests {
     use rue_cfg::CfgBuilder;
     use rue_span::Span;
 
-    fn create_simple_cfg() -> (
-        rue_cfg::Cfg,
-        TypeInternPool,
-        Vec<ArrayTypeDef>,
-        ThreadedRodeo,
-    ) {
+    fn create_simple_cfg() -> (rue_cfg::Cfg, TypeInternPool, ThreadedRodeo) {
         let mut air = Air::new(Type::I32);
 
         let const_ref = air.add_inst(AirInst {
@@ -586,25 +566,17 @@ mod tests {
 
         let interner = ThreadedRodeo::new();
         let type_pool = TypeInternPool::new();
-        let cfg_output = CfgBuilder::build(&air, 0, 0, "test", &type_pool, &[], vec![], &interner);
-        (cfg_output.cfg, type_pool, vec![], interner)
+        let cfg_output = CfgBuilder::build(&air, 0, 0, "test", &type_pool, vec![], &interner);
+        (cfg_output.cfg, type_pool, interner)
     }
 
     #[test]
     fn test_generate_stack_frame_info_x86_64() {
-        let (cfg, type_pool, array_types, interner) = create_simple_cfg();
+        let (cfg, type_pool, interner) = create_simple_cfg();
         let target = Target::X86_64Linux;
 
-        let info = generate_stack_frame_info(
-            &cfg,
-            "test",
-            &type_pool,
-            &array_types,
-            &[],
-            &interner,
-            target,
-        )
-        .unwrap();
+        let info =
+            generate_stack_frame_info(&cfg, "test", &type_pool, &[], &interner, target).unwrap();
 
         assert_eq!(info.function_name, "test");
         assert_eq!(info.alignment, 16);

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -6,7 +6,7 @@
 //! As of Phase 3 (ADR-0024), all struct/enum lookups go through `TypeInternPool`
 //! instead of separate `&[StructDef]` slices.
 
-use rue_air::{ArrayTypeDef, ArrayTypeId, StructId, TypeInternPool};
+use rue_air::{ArrayTypeId, StructId, TypeInternPool, TypeKind};
 use rue_cfg::{Cfg, CfgInstData, CfgValue, Type};
 use std::collections::HashMap;
 
@@ -16,48 +16,41 @@ use crate::vreg::VReg;
 /// Returns None if the type is not an array type.
 #[inline]
 pub fn extract_array_type_id(ty: Type) -> Option<ArrayTypeId> {
-    match ty {
-        Type::Array(id) => Some(id),
+    match ty.kind() {
+        TypeKind::Array(id) => Some(id),
         _ => None,
     }
 }
 
 /// Get the array type definition for an array type ID.
-pub fn array_type_def<'a>(
-    array_types: &'a [ArrayTypeDef],
-    array_type_id: ArrayTypeId,
-) -> Option<&'a ArrayTypeDef> {
-    array_types.get(array_type_id.0 as usize)
+///
+/// Returns `(element_type, length)`.
+pub fn array_type_def(type_pool: &TypeInternPool, array_type_id: ArrayTypeId) -> (Type, u64) {
+    type_pool.array_def(array_type_id)
 }
 
 /// Get the array type definition from a Type.
-/// Returns None if the type is not an array type or if the ID is out of bounds.
+///
+/// Returns `Some((element_type, length))` if the type is an array type, `None` otherwise.
 #[inline]
-pub fn array_type_def_from_type<'a>(
-    array_types: &'a [ArrayTypeDef],
-    ty: Type,
-) -> Option<&'a ArrayTypeDef> {
-    extract_array_type_id(ty).and_then(|id| array_type_def(array_types, id))
+pub fn array_type_def_from_type(type_pool: &TypeInternPool, ty: Type) -> Option<(Type, u64)> {
+    extract_array_type_id(ty).map(|id| array_type_def(type_pool, id))
 }
 
 /// Get the length of an array from its Type.
-/// Returns 0 if the type is not an array or the ID is invalid.
+/// Returns 0 if the type is not an array.
 #[inline]
-pub fn array_length_from_type(array_types: &[ArrayTypeDef], ty: Type) -> u64 {
-    array_type_def_from_type(array_types, ty)
-        .map(|def| def.length)
+pub fn array_length_from_type(type_pool: &TypeInternPool, ty: Type) -> u64 {
+    array_type_def_from_type(type_pool, ty)
+        .map(|(_element_type, length)| length)
         .unwrap_or(0)
 }
 
 /// Calculate the slot count for a single element of an array from its Type.
 #[inline]
-pub fn array_element_slot_count_from_type(
-    type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
-    ty: Type,
-) -> u32 {
-    if let Some(def) = array_type_def_from_type(array_types, ty) {
-        type_slot_count(type_pool, array_types, def.element_type)
+pub fn array_element_slot_count_from_type(type_pool: &TypeInternPool, ty: Type) -> u32 {
+    if let Some((element_type, _length)) = array_type_def_from_type(type_pool, ty) {
+        type_slot_count(type_pool, element_type)
     } else {
         1
     }
@@ -69,26 +62,23 @@ pub fn array_element_slot_count_from_type(
 /// For structs, this is the sum of slot counts for all fields.
 /// For nested types, this recursively calculates.
 /// Zero-sized types (unit, never, empty structs, zero-length arrays) return 0.
-pub fn type_slot_count(type_pool: &TypeInternPool, array_types: &[ArrayTypeDef], ty: Type) -> u32 {
-    match ty {
+pub fn type_slot_count(type_pool: &TypeInternPool, ty: Type) -> u32 {
+    match ty.kind() {
         // Zero-sized types
-        Type::Unit | Type::Never => 0,
-        Type::Array(array_type_id) => {
+        TypeKind::Unit | TypeKind::Never => 0,
+        TypeKind::Array(array_type_id) => {
             // Zero-length arrays naturally get 0 slots (0 * element_slots)
-            if let Some(def) = array_type_def(array_types, array_type_id) {
-                let elem_slots = type_slot_count(type_pool, array_types, def.element_type);
-                (def.length as u32) * elem_slots
-            } else {
-                1
-            }
+            let (element_type, length) = type_pool.array_def(array_type_id);
+            let elem_slots = type_slot_count(type_pool, element_type);
+            (length as u32) * elem_slots
         }
-        Type::Struct(struct_id) => {
+        TypeKind::Struct(struct_id) => {
             // Sum the slot counts of all fields
             // Empty structs naturally get 0 slots here
             let struct_def = type_pool.struct_def(struct_id);
             let mut total = 0u32;
             for field in &struct_def.fields {
-                total += type_slot_count(type_pool, array_types, field.ty);
+                total += type_slot_count(type_pool, field.ty);
             }
             total
         }
@@ -98,16 +88,9 @@ pub fn type_slot_count(type_pool: &TypeInternPool, array_types: &[ArrayTypeDef],
 }
 
 /// Calculate the slot count for a single element of an array type.
-pub fn array_element_slot_count(
-    type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
-    array_type_id: ArrayTypeId,
-) -> u32 {
-    if let Some(def) = array_type_def(array_types, array_type_id) {
-        type_slot_count(type_pool, array_types, def.element_type)
-    } else {
-        1
-    }
+pub fn array_element_slot_count(type_pool: &TypeInternPool, array_type_id: ArrayTypeId) -> u32 {
+    let (element_type, _length) = type_pool.array_def(array_type_id);
+    type_slot_count(type_pool, element_type)
 }
 
 /// Calculate the slot offset for a field within a struct.
@@ -115,7 +98,6 @@ pub fn array_element_slot_count(
 /// This accounts for the sizes of all preceding fields.
 pub fn struct_field_slot_offset(
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     struct_id: StructId,
     field_index: u32,
 ) -> u32 {
@@ -123,7 +105,7 @@ pub fn struct_field_slot_offset(
     let mut offset = 0u32;
     for i in 0..(field_index as usize) {
         if let Some(field) = struct_def.fields.get(i) {
-            offset += type_slot_count(type_pool, array_types, field.ty);
+            offset += type_slot_count(type_pool, field.ty);
         }
     }
     offset
@@ -157,7 +139,7 @@ pub fn collect_array_scalar_vregs(
             let mut result = Vec::new();
             for elem in elements {
                 let elem_inst = cfg.get_inst(*elem);
-                if matches!(elem_inst.ty, Type::Array(_)) {
+                if elem_inst.ty.is_array() {
                     // Recursively collect from nested array
                     result.extend(collect_array_scalar_vregs(
                         cfg,
@@ -165,7 +147,7 @@ pub fn collect_array_scalar_vregs(
                         *elem,
                         get_vreg,
                     ));
-                } else if matches!(elem_inst.ty, Type::Struct(_)) {
+                } else if elem_inst.ty.is_struct() {
                     // Recursively collect from struct element (includes builtin String)
                     result.extend(collect_struct_scalar_vregs(
                         cfg,
@@ -195,46 +177,39 @@ pub fn collect_array_scalar_vregs(
 ///
 /// The name encodes the element type and length, e.g., `__rue_drop_array_String_3`.
 /// This must match the name generated by `rue_compiler::drop_glue::array_drop_glue_name`.
-pub fn array_drop_glue_name(
-    array_id: ArrayTypeId,
-    array_types: &[ArrayTypeDef],
-    type_pool: &TypeInternPool,
-) -> String {
-    let array_def = &array_types[array_id.0 as usize];
-    let element_type_name = type_name(array_def.element_type, type_pool, array_types);
-    format!(
-        "__rue_drop_array_{}_{}",
-        element_type_name, array_def.length
-    )
+pub fn array_drop_glue_name(array_id: ArrayTypeId, type_pool: &TypeInternPool) -> String {
+    let (element_type, length) = type_pool.array_def(array_id);
+    let element_type_name = type_name(element_type, type_pool);
+    format!("__rue_drop_array_{}_{}", element_type_name, length)
 }
 
 /// Get a name for a type (used for generating drop glue function names).
-fn type_name(ty: Type, type_pool: &TypeInternPool, array_types: &[ArrayTypeDef]) -> String {
-    match ty {
-        Type::I8 => "i8".to_string(),
-        Type::I16 => "i16".to_string(),
-        Type::I32 => "i32".to_string(),
-        Type::I64 => "i64".to_string(),
-        Type::U8 => "u8".to_string(),
-        Type::U16 => "u16".to_string(),
-        Type::U32 => "u32".to_string(),
-        Type::U64 => "u64".to_string(),
-        Type::Bool => "bool".to_string(),
-        Type::Unit => "unit".to_string(),
-        Type::Never => "never".to_string(),
-        Type::Error => "error".to_string(),
+fn type_name(ty: Type, type_pool: &TypeInternPool) -> String {
+    match ty.kind() {
+        TypeKind::I8 => "i8".to_string(),
+        TypeKind::I16 => "i16".to_string(),
+        TypeKind::I32 => "i32".to_string(),
+        TypeKind::I64 => "i64".to_string(),
+        TypeKind::U8 => "u8".to_string(),
+        TypeKind::U16 => "u16".to_string(),
+        TypeKind::U32 => "u32".to_string(),
+        TypeKind::U64 => "u64".to_string(),
+        TypeKind::Bool => "bool".to_string(),
+        TypeKind::Unit => "unit".to_string(),
+        TypeKind::Never => "never".to_string(),
+        TypeKind::Error => "error".to_string(),
         // ComptimeType only exists at compile time, no runtime representation
-        Type::ComptimeType => "comptime_type".to_string(),
-        Type::Enum(enum_id) => format!("enum{}", enum_id.0),
+        TypeKind::ComptimeType => "comptime_type".to_string(),
+        TypeKind::Enum(enum_id) => format!("enum{}", enum_id.0),
         // Struct types include builtin types like String
-        Type::Struct(struct_id) => type_pool.struct_def(struct_id).name.clone(),
-        Type::Array(array_id) => {
-            let array_def = &array_types[array_id.0 as usize];
-            let elem_name = type_name(array_def.element_type, type_pool, array_types);
-            format!("array_{}_{}", elem_name, array_def.length)
+        TypeKind::Struct(struct_id) => type_pool.struct_def(struct_id).name.clone(),
+        TypeKind::Array(array_id) => {
+            let (element_type, length) = type_pool.array_def(array_id);
+            let elem_name = type_name(element_type, type_pool);
+            format!("array_{}_{}", elem_name, length)
         }
         // Module types should never reach codegen (compile-time only)
-        Type::Module(_) => "module".to_string(),
+        TypeKind::Module(_) => "module".to_string(),
     }
 }
 
@@ -266,7 +241,7 @@ pub fn collect_struct_scalar_vregs(
             let mut result = Vec::new();
             for field in fields {
                 let field_inst = cfg.get_inst(*field);
-                if matches!(field_inst.ty, Type::Array(_)) {
+                if field_inst.ty.is_array() {
                     // Recursively collect from array field
                     result.extend(collect_array_scalar_vregs(
                         cfg,
@@ -274,7 +249,7 @@ pub fn collect_struct_scalar_vregs(
                         *field,
                         get_vreg,
                     ));
-                } else if matches!(field_inst.ty, Type::Struct(_)) {
+                } else if field_inst.ty.is_struct() {
                     // Recursively collect from nested struct field (includes builtin String)
                     result.extend(collect_struct_scalar_vregs(
                         cfg,

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -28,7 +28,7 @@
 use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
-use rue_air::{ArrayTypeDef, StructId, TypeInternPool};
+use rue_air::{StructId, TypeInternPool, TypeKind};
 use rue_builtins::{BinOp, get_builtin_type};
 use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Terminator, Type};
 
@@ -46,10 +46,8 @@ const RET_REGS: [Reg; 6] = [Reg::Rax, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9, Reg:
 /// CFG to X86Mir lowering.
 pub struct CfgLower<'a> {
     cfg: &'a Cfg,
-    /// Type intern pool for struct/enum lookups (Phase 3 ADR-0024).
+    /// Type intern pool for struct/enum/array lookups (Phase 2B ADR-0024).
     type_pool: &'a TypeInternPool,
-    /// Array type definitions for bounds checking.
-    array_types: &'a [ArrayTypeDef],
     /// String table from semantic analysis (indexed by StringId).
     strings: &'a [String],
     /// Interner for resolving Spur to string
@@ -83,7 +81,6 @@ impl<'a> CfgLower<'a> {
     pub fn new(
         cfg: &'a Cfg,
         type_pool: &'a TypeInternPool,
-        array_types: &'a [ArrayTypeDef],
         strings: &'a [String],
         interner: &'a ThreadedRodeo,
     ) -> Self {
@@ -103,7 +100,6 @@ impl<'a> CfgLower<'a> {
         Self {
             cfg,
             type_pool,
-            array_types,
             strings,
             interner,
             mir: X86Mir::new(),
@@ -127,12 +123,14 @@ impl<'a> CfgLower<'a> {
 
     /// Get the length of an array type.
     fn array_length(&self, array_type: Type) -> u64 {
-        types::array_length_from_type(self.array_types, array_type)
+        types::array_length_from_type(self.type_pool, array_type)
     }
 
     /// Get the array type definition.
-    fn array_type_def(&self, array_type: Type) -> Option<&ArrayTypeDef> {
-        types::array_type_def_from_type(self.array_types, array_type)
+    ///
+    /// Returns `Some((element_type, length))` for array types, `None` otherwise.
+    fn array_type_def(&self, array_type: Type) -> Option<(Type, u64)> {
+        types::array_type_def_from_type(self.type_pool, array_type)
     }
 
     // ========================================================================
@@ -143,8 +141,8 @@ impl<'a> CfgLower<'a> {
     ///
     /// Returns true if the type is a struct that is marked as builtin with name "String".
     fn is_builtin_string(&self, ty: Type) -> bool {
-        match ty {
-            Type::Struct(struct_id) => {
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => {
                 let struct_def = self.type_pool.struct_def(struct_id);
                 struct_def.is_builtin && struct_def.name == "String"
             }
@@ -157,8 +155,8 @@ impl<'a> CfgLower<'a> {
     /// Returns `Some((runtime_fn, invert_result))` if the type has a builtin
     /// operator implementation, `None` otherwise.
     fn get_builtin_operator(&self, ty: Type, op: BinOp) -> Option<(&'static str, bool)> {
-        let builtin = match ty {
-            Type::Struct(struct_id) => {
+        let builtin = match ty.kind() {
+            TypeKind::Struct(struct_id) => {
                 let struct_def = self.type_pool.struct_def(struct_id);
                 if struct_def.is_builtin {
                     get_builtin_type(&struct_def.name)?
@@ -175,17 +173,17 @@ impl<'a> CfgLower<'a> {
 
     /// Calculate the total number of slots needed to store a type.
     fn type_slot_count(&self, ty: Type) -> u32 {
-        types::type_slot_count(self.type_pool, self.array_types, ty)
+        types::type_slot_count(self.type_pool, ty)
     }
 
     /// Calculate the slot count for a single element of an array type.
     fn array_element_slot_count(&self, array_type: Type) -> u32 {
-        types::array_element_slot_count_from_type(self.type_pool, self.array_types, array_type)
+        types::array_element_slot_count_from_type(self.type_pool, array_type)
     }
 
     /// Calculate the slot offset for a field within a struct.
     fn struct_field_slot_offset(&self, struct_id: StructId, field_index: u32) -> u32 {
-        types::struct_field_slot_offset(self.type_pool, self.array_types, struct_id, field_index)
+        types::struct_field_slot_offset(self.type_pool, struct_id, field_index)
     }
 
     /// Trace back through a chain of FieldGet instructions to find the original
@@ -427,8 +425,8 @@ impl<'a> CfgLower<'a> {
         }
 
         let inst = self.cfg.get_inst(value);
-        let struct_id = match inst.ty {
-            Type::Struct(id) => id,
+        let struct_id = match inst.ty.kind() {
+            TypeKind::Struct(id) => id,
             _ => return None,
         };
 
@@ -521,8 +519,8 @@ impl<'a> CfgLower<'a> {
                 self.value_map.insert(*param_val, vreg);
 
                 // For struct types, also allocate vregs for each slot
-                if let Type::Struct(struct_id) = ty {
-                    let slot_count = self.type_slot_count(Type::Struct(*struct_id));
+                if let TypeKind::Struct(struct_id) = ty.kind() {
+                    let slot_count = self.type_slot_count(Type::Struct(struct_id));
                     let mut slot_vregs = vec![vreg]; // First slot uses main vreg
                     for _ in 1..slot_count {
                         slot_vregs.push(self.mir.alloc_vreg());
@@ -564,8 +562,8 @@ impl<'a> CfgLower<'a> {
                     .insert((block.id, param_idx as u32), vreg);
                 self.value_map.insert(*param_val, vreg);
 
-                if let Type::Struct(struct_id) = ty {
-                    let slot_count = self.type_slot_count(Type::Struct(*struct_id));
+                if let TypeKind::Struct(struct_id) = ty.kind() {
+                    let slot_count = self.type_slot_count(Type::Struct(struct_id));
                     let mut slot_vregs = vec![vreg];
                     for _ in 1..slot_count {
                         slot_vregs.push(self.mir.alloc_vreg());
@@ -653,11 +651,16 @@ impl<'a> CfgLower<'a> {
     fn get_lowering_rationale(&self, data: &CfgInstData, ty: Type) -> Option<String> {
         match data {
             CfgInstData::Add(_, _) | CfgInstData::Sub(_, _) | CfgInstData::Mul(_, _) => {
-                if matches!(ty, Type::I64 | Type::U64) {
+                if matches!(ty.kind(), TypeKind::I64 | TypeKind::U64) {
                     Some("64-bit operation with 64-bit overflow check".to_string())
                 } else if matches!(
-                    ty,
-                    Type::I8 | Type::I16 | Type::I32 | Type::U8 | Type::U16 | Type::U32
+                    ty.kind(),
+                    TypeKind::I8
+                        | TypeKind::I16
+                        | TypeKind::I32
+                        | TypeKind::U8
+                        | TypeKind::U16
+                        | TypeKind::U32
                 ) {
                     Some("32-bit operation with overflow check".to_string())
                 } else {
@@ -665,14 +668,20 @@ impl<'a> CfgLower<'a> {
                 }
             }
             CfgInstData::Div(_, _) | CfgInstData::Mod(_, _) => {
-                if matches!(ty, Type::I8 | Type::I16 | Type::I32 | Type::I64) {
+                if matches!(
+                    ty.kind(),
+                    TypeKind::I8 | TypeKind::I16 | TypeKind::I32 | TypeKind::I64
+                ) {
                     Some("Signed division: uses CDQ/IDIV sequence".to_string())
                 } else {
                     Some("Unsigned division: uses XOR/DIV sequence".to_string())
                 }
             }
             CfgInstData::Shr(_, _) => {
-                if matches!(ty, Type::I8 | Type::I16 | Type::I32 | Type::I64) {
+                if matches!(
+                    ty.kind(),
+                    TypeKind::I8 | TypeKind::I16 | TypeKind::I32 | TypeKind::I64
+                ) {
                     Some("Signed shift right (SAR) preserves sign bit".to_string())
                 } else {
                     Some("Unsigned shift right (SHR) zero-extends".to_string())
@@ -909,7 +918,7 @@ impl<'a> CfgLower<'a> {
                 });
 
                 // Use 64-bit add for 64-bit types to get correct overflow detection
-                if matches!(ty, Type::I64 | Type::U64) {
+                if matches!(ty.kind(), TypeKind::I64 | TypeKind::U64) {
                     self.mir.push(X86Inst::AddRR64 {
                         dst: Operand::Virtual(vreg),
                         src: Operand::Virtual(rhs_vreg),
@@ -938,7 +947,7 @@ impl<'a> CfgLower<'a> {
                 });
 
                 // Use 64-bit sub for 64-bit types to get correct overflow detection
-                if matches!(ty, Type::I64 | Type::U64) {
+                if matches!(ty.kind(), TypeKind::I64 | TypeKind::U64) {
                     self.mir.push(X86Inst::SubRR64 {
                         dst: Operand::Virtual(vreg),
                         src: Operand::Virtual(rhs_vreg),
@@ -968,7 +977,10 @@ impl<'a> CfgLower<'a> {
                 //
                 // Future optimization: x * 2 could use `add x, x` instead of `shl x, 1`
                 // (same latency but potentially better for some microarchitectures).
-                let is_word_or_larger = matches!(ty, Type::I32 | Type::I64 | Type::U32 | Type::U64);
+                let is_word_or_larger = matches!(
+                    ty.kind(),
+                    TypeKind::I32 | TypeKind::I64 | TypeKind::U32 | TypeKind::U64
+                );
                 let shift_amount = if is_word_or_larger {
                     self.try_power_of_two_shift(*rhs)
                         .or_else(|| self.try_power_of_two_shift(*lhs))
@@ -1067,7 +1079,7 @@ impl<'a> CfgLower<'a> {
                     });
 
                     // Use 64-bit mul for 64-bit types to get correct overflow detection
-                    if matches!(ty, Type::I64 | Type::U64) {
+                    if matches!(ty.kind(), TypeKind::I64 | TypeKind::U64) {
                         self.mir.push(X86Inst::ImulRR64 {
                             dst: Operand::Virtual(vreg),
                             src: Operand::Virtual(rhs_vreg),
@@ -1161,7 +1173,7 @@ impl<'a> CfgLower<'a> {
                 });
 
                 // Use 64-bit neg for 64-bit types to get correct overflow detection
-                if matches!(ty, Type::I64 | Type::U64) {
+                if matches!(ty.kind(), TypeKind::I64 | TypeKind::U64) {
                     self.mir.push(X86Inst::Neg64 {
                         dst: Operand::Virtual(vreg),
                     });
@@ -1411,7 +1423,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         imm: 1,
                     });
-                } else if let Type::Struct(struct_id) = lhs_ty {
+                } else if let TypeKind::Struct(struct_id) = lhs_ty.kind() {
                     // Struct equality: compare all fields
                     self.emit_struct_equality(value, *lhs, *rhs, struct_id, false);
                 } else {
@@ -1445,7 +1457,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         imm: 0,
                     });
-                } else if let Type::Struct(struct_id) = lhs_ty {
+                } else if let TypeKind::Struct(struct_id) = lhs_ty.kind() {
                     // Struct inequality: compare all fields, invert result
                     self.emit_struct_equality(value, *lhs, *rhs, struct_id, true);
                 } else {
@@ -1519,7 +1531,7 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::Alloc { slot, init } => {
                 let init_type = self.cfg.get_inst(*init).ty;
-                if matches!(init_type, Type::Array(_)) {
+                if matches!(init_type.kind(), TypeKind::Array(_)) {
                     // Array: recursively flatten nested arrays and store scalar elements
                     let scalar_vregs = self.collect_array_scalar_vregs(*init);
                     for (i, scalar_vreg) in scalar_vregs.iter().enumerate() {
@@ -1572,7 +1584,7 @@ impl<'a> CfgLower<'a> {
                         offset: cap_offset,
                         src: Operand::Virtual(cap_vreg),
                     });
-                } else if matches!(init_type, Type::Struct(_)) {
+                } else if matches!(init_type.kind(), TypeKind::Struct(_)) {
                     // Struct: recursively flatten struct fields (including array fields) to scalars
                     let scalar_vregs = self.collect_struct_scalar_vregs(*init);
                     for (i, scalar_vreg) in scalar_vregs.iter().enumerate() {
@@ -1633,7 +1645,7 @@ impl<'a> CfgLower<'a> {
                     self.struct_slot_vregs
                         .insert(value, vec![ptr_vreg, len_vreg, cap_vreg]);
                     self.value_map.insert(value, ptr_vreg);
-                } else if let Type::Array(_) = load_type {
+                } else if let TypeKind::Array(_) = load_type.kind() {
                     // Array: load all element slots (recursively flattened)
                     let slot_count = self.type_slot_count(load_type);
                     let mut slot_vregs = Vec::with_capacity(slot_count as usize);
@@ -1659,7 +1671,7 @@ impl<'a> CfgLower<'a> {
                         let vreg = self.mir.alloc_vreg();
                         self.value_map.insert(value, vreg);
                     }
-                } else if let Type::Struct(struct_id) = load_type {
+                } else if let TypeKind::Struct(struct_id) = load_type.kind() {
                     // Struct: load all field slots (recursively flattened)
                     let slot_count = self.type_slot_count(Type::Struct(struct_id));
                     let mut slot_vregs = Vec::with_capacity(slot_count as usize);
@@ -1877,8 +1889,8 @@ impl<'a> CfgLower<'a> {
                         continue;
                     }
 
-                    match arg_type {
-                        Type::Struct(struct_id) => {
+                    match arg_type.kind() {
+                        TypeKind::Struct(struct_id) => {
                             let arg_data = &self.cfg.get_inst(arg_value).data;
                             let slot_count = self.type_slot_count(Type::Struct(struct_id));
                             match arg_data {
@@ -1925,7 +1937,7 @@ impl<'a> CfgLower<'a> {
                                 }
                             }
                         }
-                        Type::Array(_) => {
+                        TypeKind::Array(_) => {
                             let arg_data = &self.cfg.get_inst(arg_value).data;
                             let array_len = self.array_length(arg_type) as u32;
                             match arg_data {
@@ -2061,7 +2073,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(result_vreg),
                         src: Operand::Virtual(slot_vregs[0]),
                     });
-                } else if let Type::Struct(struct_id) = ty {
+                } else if let TypeKind::Struct(struct_id) = ty.kind() {
                     // Non-builtin structs return in registers
                     let slot_count = self.type_slot_count(Type::Struct(struct_id));
                     let mut slot_vregs = Vec::new();
@@ -2187,16 +2199,20 @@ impl<'a> CfgLower<'a> {
                         // Existing scalar handling
                         let arg_vreg = self.get_vreg(arg_val);
 
-                        let runtime_fn = match arg_type {
-                            Type::Bool => "__rue_dbg_bool",
-                            Type::I8 | Type::I16 | Type::I32 | Type::I64 => "__rue_dbg_i64",
-                            Type::U8 | Type::U16 | Type::U32 | Type::U64 => "__rue_dbg_u64",
+                        let runtime_fn = match arg_type.kind() {
+                            TypeKind::Bool => "__rue_dbg_bool",
+                            TypeKind::I8 | TypeKind::I16 | TypeKind::I32 | TypeKind::I64 => {
+                                "__rue_dbg_i64"
+                            }
+                            TypeKind::U8 | TypeKind::U16 | TypeKind::U32 | TypeKind::U64 => {
+                                "__rue_dbg_u64"
+                            }
                             _ => unreachable!("@dbg only supports scalars and strings"),
                         };
 
                         // Handle type extensions
-                        match arg_type {
-                            Type::I8 => {
+                        match arg_type.kind() {
+                            TypeKind::I8 => {
                                 self.mir.push(X86Inst::MovRR {
                                     dst: Operand::Physical(Reg::Rax),
                                     src: Operand::Virtual(arg_vreg),
@@ -2206,7 +2222,7 @@ impl<'a> CfgLower<'a> {
                                     src: Operand::Physical(Reg::Rax),
                                 });
                             }
-                            Type::I16 => {
+                            TypeKind::I16 => {
                                 self.mir.push(X86Inst::MovRR {
                                     dst: Operand::Physical(Reg::Rax),
                                     src: Operand::Virtual(arg_vreg),
@@ -2216,7 +2232,7 @@ impl<'a> CfgLower<'a> {
                                     src: Operand::Physical(Reg::Rax),
                                 });
                             }
-                            Type::I32 => {
+                            TypeKind::I32 => {
                                 self.mir.push(X86Inst::MovRR {
                                     dst: Operand::Physical(Reg::Rax),
                                     src: Operand::Virtual(arg_vreg),
@@ -2226,7 +2242,7 @@ impl<'a> CfgLower<'a> {
                                     src: Operand::Physical(Reg::Rax),
                                 });
                             }
-                            Type::U8 => {
+                            TypeKind::U8 => {
                                 self.mir.push(X86Inst::MovRR {
                                     dst: Operand::Physical(Reg::Rax),
                                     src: Operand::Virtual(arg_vreg),
@@ -2236,7 +2252,7 @@ impl<'a> CfgLower<'a> {
                                     src: Operand::Physical(Reg::Rax),
                                 });
                             }
-                            Type::U16 => {
+                            TypeKind::U16 => {
                                 self.mir.push(X86Inst::MovRR {
                                     dst: Operand::Physical(Reg::Rax),
                                     src: Operand::Virtual(arg_vreg),
@@ -2246,7 +2262,7 @@ impl<'a> CfgLower<'a> {
                                     src: Operand::Physical(Reg::Rax),
                                 });
                             }
-                            Type::U32 | Type::I64 | Type::U64 | Type::Bool => {
+                            TypeKind::U32 | TypeKind::I64 | TypeKind::U64 | TypeKind::Bool => {
                                 self.mir.push(X86Inst::MovRR {
                                     dst: Operand::Physical(Reg::Rdi),
                                     src: Operand::Virtual(arg_vreg),
@@ -2331,7 +2347,7 @@ impl<'a> CfgLower<'a> {
                 let fields = self.cfg.get_extra(*fields_start, *fields_len).to_vec();
                 for field in &fields {
                     let field_inst = self.cfg.get_inst(*field);
-                    if let Type::Struct(_) = field_inst.ty {
+                    if let TypeKind::Struct(_) = field_inst.ty.kind() {
                         // Nested struct - get all its slot vregs
                         let nested_vregs = self
                             .struct_slot_vregs
@@ -3127,7 +3143,7 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Handle struct drops - need to pass all flattened field values
-                if let Type::Struct(struct_id) = dropped_ty {
+                if let TypeKind::Struct(struct_id) = dropped_ty.kind() {
                     let struct_def = self.type_pool.struct_def(struct_id);
 
                     // Collect all scalar vregs for this struct (flattened)
@@ -3188,7 +3204,7 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Handle array drops - need to pass all element values
-                if let Type::Array(array_id) = dropped_ty {
+                if let TypeKind::Array(array_id) = dropped_ty.kind() {
                     // Collect all scalar vregs for this array (flattened)
                     let element_vregs = self.collect_array_scalar_vregs(*dropped_value);
 
@@ -3208,8 +3224,7 @@ impl<'a> CfgLower<'a> {
                         });
                     }
 
-                    let drop_fn_name =
-                        types::array_drop_glue_name(array_id, self.array_types, self.type_pool);
+                    let drop_fn_name = types::array_drop_glue_name(array_id, self.type_pool);
                     let symbol_id = self.intern_symbol(&drop_fn_name);
                     self.mir.push(X86Inst::CallRel { symbol_id });
                     return;
@@ -3278,17 +3293,17 @@ impl<'a> CfgLower<'a> {
     fn emit_overflow_check(&mut self, ty: Type, result_vreg: VReg) {
         let ok_label = self.new_label();
 
-        match ty {
+        match ty.kind() {
             // 32-bit and 64-bit unsigned: check carry flag
-            Type::U32 | Type::U64 => {
+            TypeKind::U32 | TypeKind::U64 => {
                 self.mir.push(X86Inst::Jae { label: ok_label });
             }
             // 32-bit and 64-bit signed: check overflow flag
-            Type::I32 | Type::I64 => {
+            TypeKind::I32 | TypeKind::I64 => {
                 self.mir.push(X86Inst::Jno { label: ok_label });
             }
             // Sub-word unsigned types: check if result fits in range [0, max]
-            Type::U8 => {
+            TypeKind::U8 => {
                 // Result must be <= 255
                 self.mir.push(X86Inst::CmpRI {
                     src: Operand::Virtual(result_vreg),
@@ -3297,7 +3312,7 @@ impl<'a> CfgLower<'a> {
                 // Jump if below or equal (unsigned)
                 self.mir.push(X86Inst::Jbe { label: ok_label });
             }
-            Type::U16 => {
+            TypeKind::U16 => {
                 // Result must be <= 65535
                 let max_vreg = self.mir.alloc_vreg();
                 self.mir.push(X86Inst::MovRI32 {
@@ -3312,7 +3327,7 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(X86Inst::Jbe { label: ok_label });
             }
             // Sub-word signed types: check if result fits in range [min, max]
-            Type::I8 => {
+            TypeKind::I8 => {
                 // For i8: result must be in [-128, 127]
                 // Sign-extend to 64-bit and compare with original
                 // If they differ, overflow occurred
@@ -3328,7 +3343,7 @@ impl<'a> CfgLower<'a> {
                 });
                 self.mir.push(X86Inst::Jz { label: ok_label });
             }
-            Type::I16 => {
+            TypeKind::I16 => {
                 // For i16: result must be in [-32768, 32767]
                 // Sign-extend to 64-bit and compare with original
                 let sext_vreg = self.mir.alloc_vreg();
@@ -3553,26 +3568,26 @@ impl<'a> CfgLower<'a> {
 
     /// Get the bit width of an integer type.
     fn type_bits(ty: Type) -> u32 {
-        match ty {
-            Type::I8 | Type::U8 => 8,
-            Type::I16 | Type::U16 => 16,
-            Type::I32 | Type::U32 => 32,
-            Type::I64 | Type::U64 => 64,
+        match ty.kind() {
+            TypeKind::I8 | TypeKind::U8 => 8,
+            TypeKind::I16 | TypeKind::U16 => 16,
+            TypeKind::I32 | TypeKind::U32 => 32,
+            TypeKind::I64 | TypeKind::U64 => 64,
             _ => panic!("type_bits called on non-integer type: {:?}", ty),
         }
     }
 
     /// Get the min and max values for an integer type.
     fn type_range(ty: Type) -> (i64, i64) {
-        match ty {
-            Type::I8 => (i8::MIN as i64, i8::MAX as i64),
-            Type::I16 => (i16::MIN as i64, i16::MAX as i64),
-            Type::I32 => (i32::MIN as i64, i32::MAX as i64),
-            Type::I64 => (i64::MIN, i64::MAX),
-            Type::U8 => (0, u8::MAX as i64),
-            Type::U16 => (0, u16::MAX as i64),
-            Type::U32 => (0, u32::MAX as i64),
-            Type::U64 => (0, i64::MAX), // Can't represent u64::MAX in i64, but we use unsigned compare
+        match ty.kind() {
+            TypeKind::I8 => (i8::MIN as i64, i8::MAX as i64),
+            TypeKind::I16 => (i16::MIN as i64, i16::MAX as i64),
+            TypeKind::I32 => (i32::MIN as i64, i32::MAX as i64),
+            TypeKind::I64 => (i64::MIN, i64::MAX),
+            TypeKind::U8 => (0, u8::MAX as i64),
+            TypeKind::U16 => (0, u16::MAX as i64),
+            TypeKind::U32 => (0, u32::MAX as i64),
+            TypeKind::U64 => (0, i64::MAX), // Can't represent u64::MAX in i64, but we use unsigned compare
             _ => panic!("type_range called on non-integer type: {:?}", ty),
         }
     }
@@ -3590,7 +3605,7 @@ impl<'a> CfgLower<'a> {
 
         // Use 64-bit compare for i64/u64 types
         let lhs_ty = self.cfg.get_inst(lhs).ty;
-        if matches!(lhs_ty, Type::I64 | Type::U64) {
+        if matches!(lhs_ty.kind(), TypeKind::I64 | TypeKind::U64) {
             self.mir.push(X86Inst::Cmp64RR {
                 src1: Operand::Virtual(lhs_vreg),
                 src2: Operand::Virtual(rhs_vreg),
@@ -3664,7 +3679,7 @@ impl<'a> CfgLower<'a> {
             let cmp_vreg = self.mir.alloc_vreg();
 
             // Use 64-bit compare for i64/u64 types
-            if matches!(field.ty, Type::I64 | Type::U64) {
+            if matches!(field.ty.kind(), TypeKind::I64 | TypeKind::U64) {
                 self.mir.push(X86Inst::Cmp64RR {
                     src1: Operand::Virtual(lhs_field_vreg),
                     src2: Operand::Virtual(rhs_field_vreg),
@@ -3779,7 +3794,7 @@ impl<'a> CfgLower<'a> {
                 let args = self.cfg.get_extra(*args_start, *args_len);
                 for (i, &arg) in args.iter().enumerate() {
                     let arg_type = self.cfg.get_inst(arg).ty;
-                    if matches!(arg_type, Type::Struct(_)) {
+                    if matches!(arg_type.kind(), TypeKind::Struct(_)) {
                         // For struct args, copy all field vregs
                         self.copy_struct_to_block_param(arg, *target, i as u32);
                     } else {
@@ -3831,7 +3846,7 @@ impl<'a> CfgLower<'a> {
                 let then_args = self.cfg.get_extra(*then_args_start, *then_args_len);
                 for (i, &arg) in then_args.iter().enumerate() {
                     let arg_type = self.cfg.get_inst(arg).ty;
-                    if matches!(arg_type, Type::Struct(_)) {
+                    if matches!(arg_type.kind(), TypeKind::Struct(_)) {
                         // For struct args, copy all field vregs
                         self.copy_struct_to_block_param(arg, *then_block, i as u32);
                     } else {
@@ -3857,7 +3872,7 @@ impl<'a> CfgLower<'a> {
                 let else_args = self.cfg.get_extra(*else_args_start, *else_args_len);
                 for (i, &arg) in else_args.iter().enumerate() {
                     let arg_type = self.cfg.get_inst(arg).ty;
-                    if matches!(arg_type, Type::Struct(_)) {
+                    if matches!(arg_type.kind(), TypeKind::Struct(_)) {
                         // For struct args, copy all field vregs
                         self.copy_struct_to_block_param(arg, *else_block, i as u32);
                     } else {
@@ -3933,7 +3948,7 @@ impl<'a> CfgLower<'a> {
                     // it 0 mod 16 at callee entry, violating SysV ABI).
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(X86Inst::CallRel { symbol_id });
-                } else if let Type::Struct(struct_id) = return_type {
+                } else if let Some(struct_id) = return_type.as_struct() {
                     // Return struct in registers
                     let slot_count = self.type_slot_count(Type::Struct(struct_id));
                     let value_data = &self.cfg.get_inst(*value).data;
@@ -4030,7 +4045,7 @@ impl<'a> CfgLower<'a> {
 mod tests {
     use super::*;
     use lasso::ThreadedRodeo;
-    use rue_air::Sema;
+    use rue_air::{ArrayTypeId, Sema};
     use rue_cfg::CfgBuilder;
     use rue_error::PreviewFeatures;
     use rue_lexer::Lexer;
@@ -4051,7 +4066,6 @@ mod tests {
 
         let func = &output.functions[0];
         let type_pool = &output.type_pool;
-        let array_types = &output.array_types;
         let strings = &output.strings;
         let cfg_output = CfgBuilder::build(
             &func.air,
@@ -4059,12 +4073,11 @@ mod tests {
             func.num_param_slots,
             &func.name,
             type_pool,
-            array_types,
             func.param_modes.clone(),
             &interner,
         );
 
-        CfgLower::new(&cfg_output.cfg, type_pool, array_types, strings, &interner).lower()
+        CfgLower::new(&cfg_output.cfg, type_pool, strings, &interner).lower()
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -29,7 +29,7 @@ pub use regalloc::RegAlloc;
 use crate::regalloc::RegAllocDebugInfo;
 
 use lasso::ThreadedRodeo;
-use rue_air::{ArrayTypeDef, TypeInternPool};
+use rue_air::TypeInternPool;
 use rue_cfg::Cfg;
 use rue_error::CompileResult;
 
@@ -43,7 +43,6 @@ pub use super::{EmittedCode, EmittedRelocation, MachineCode};
 pub fn generate(
     cfg: &Cfg,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
 ) -> CompileResult<MachineCode> {
@@ -51,7 +50,7 @@ pub fn generate(
     let num_params = cfg.num_params();
 
     // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, array_types, strings, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
 
     // Allocate physical registers (may add spill slots)
     // Spill slots go after both locals AND parameters to avoid conflicts
@@ -98,7 +97,6 @@ pub fn generate(
 pub fn generate_with_asm(
     cfg: &Cfg,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
 ) -> CompileResult<(MachineCode, String)> {
@@ -106,7 +104,7 @@ pub fn generate_with_asm(
     let num_params = cfg.num_params();
 
     // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, array_types, strings, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
 
     // Allocate physical registers (may add spill slots)
     let existing_slots = num_locals + num_params;
@@ -152,7 +150,6 @@ pub fn generate_with_asm(
 pub fn generate_regalloc_info(
     cfg: &Cfg,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
 ) -> CompileResult<RegAllocDebugInfo<Reg>> {
@@ -160,7 +157,7 @@ pub fn generate_regalloc_info(
     let num_params = cfg.num_params();
 
     // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, array_types, strings, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
 
     // Allocate physical registers with debug info
     let existing_slots = num_locals + num_params;

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -21,35 +21,35 @@
 //! 2. Drops each element in index order (element 0 first, then 1, etc.)
 
 use rue_air::{
-    Air, AirInst, AirInstData, AnalyzedFunction, ArrayTypeDef, StructDef, Type, TypeInternPool,
+    Air, AirInst, AirInstData, AnalyzedFunction, StructDef, Type, TypeInternPool, TypeKind,
 };
 use rue_span::Span;
 
 /// Check if a type needs drop.
-fn type_needs_drop(ty: Type, type_pool: &TypeInternPool, array_types: &[ArrayTypeDef]) -> bool {
-    match ty {
+fn type_needs_drop(ty: Type, type_pool: &TypeInternPool) -> bool {
+    match ty.kind() {
         // Primitive types are trivially droppable
         // ComptimeType is comptime-only, no runtime representation
-        Type::I8
-        | Type::I16
-        | Type::I32
-        | Type::I64
-        | Type::U8
-        | Type::U16
-        | Type::U32
-        | Type::U64
-        | Type::Bool
-        | Type::Unit
-        | Type::Never
-        | Type::Error
-        | Type::ComptimeType => false,
+        TypeKind::I8
+        | TypeKind::I16
+        | TypeKind::I32
+        | TypeKind::I64
+        | TypeKind::U8
+        | TypeKind::U16
+        | TypeKind::U32
+        | TypeKind::U64
+        | TypeKind::Bool
+        | TypeKind::Unit
+        | TypeKind::Never
+        | TypeKind::Error
+        | TypeKind::ComptimeType => false,
 
         // Enum types are trivially droppable (just discriminant values)
-        Type::Enum(_) => false,
+        TypeKind::Enum(_) => false,
 
         // Struct types need drop if they have a destructor (e.g., builtin String)
         // or if any field needs drop
-        Type::Struct(struct_id) => {
+        TypeKind::Struct(struct_id) => {
             let struct_def = type_pool.struct_def(struct_id);
             // Builtins with destructors (like String) need drop
             if struct_def.destructor.is_some() {
@@ -59,73 +59,69 @@ fn type_needs_drop(ty: Type, type_pool: &TypeInternPool, array_types: &[ArrayTyp
             struct_def
                 .fields
                 .iter()
-                .any(|f| type_needs_drop(f.ty, type_pool, array_types))
+                .any(|f| type_needs_drop(f.ty, type_pool))
         }
 
         // Note: String is now Type::Struct with is_builtin=true, handled above
 
         // Array types need drop if element type needs drop
-        Type::Array(array_id) => {
-            let array_def = &array_types[array_id.0 as usize];
-            type_needs_drop(array_def.element_type, type_pool, array_types)
+        TypeKind::Array(array_id) => {
+            let (element_type, _length) = type_pool.array_def(array_id);
+            type_needs_drop(element_type, type_pool)
         }
 
         // Module types don't need drop (compile-time only)
-        Type::Module(_) => false,
+        TypeKind::Module(_) => false,
     }
 }
 
 /// Count the number of ABI slots a type uses (flattened).
-fn type_slot_count(ty: Type, type_pool: &TypeInternPool, array_types: &[ArrayTypeDef]) -> u32 {
-    match ty {
+fn type_slot_count(ty: Type, type_pool: &TypeInternPool) -> u32 {
+    match ty.kind() {
         // Primitives use 1 slot
         // ComptimeType uses 0 slots (comptime-only, no runtime representation)
-        Type::I8
-        | Type::I16
-        | Type::I32
-        | Type::I64
-        | Type::U8
-        | Type::U16
-        | Type::U32
-        | Type::U64
-        | Type::Bool
-        | Type::Unit
-        | Type::Never
-        | Type::Error
-        | Type::Enum(_) => 1,
-        Type::ComptimeType => 0,
+        TypeKind::I8
+        | TypeKind::I16
+        | TypeKind::I32
+        | TypeKind::I64
+        | TypeKind::U8
+        | TypeKind::U16
+        | TypeKind::U32
+        | TypeKind::U64
+        | TypeKind::Bool
+        | TypeKind::Unit
+        | TypeKind::Never
+        | TypeKind::Error
+        | TypeKind::Enum(_) => 1,
+        TypeKind::ComptimeType => 0,
 
         // Struct uses sum of all field slots (including builtin String with 3 fields)
-        Type::Struct(struct_id) => {
+        TypeKind::Struct(struct_id) => {
             let struct_def = type_pool.struct_def(struct_id);
             struct_def
                 .fields
                 .iter()
-                .map(|f| type_slot_count(f.ty, type_pool, array_types))
+                .map(|f| type_slot_count(f.ty, type_pool))
                 .sum()
         }
 
         // Note: String is now Type::Struct with is_builtin=true, handled above
 
         // Array uses element slots * length
-        Type::Array(array_id) => {
-            let array_def = &array_types[array_id.0 as usize];
-            type_slot_count(array_def.element_type, type_pool, array_types)
-                * array_def.length as u32
+        TypeKind::Array(array_id) => {
+            let (element_type, length) = type_pool.array_def(array_id);
+            type_slot_count(element_type, type_pool) * length as u32
         }
 
         // Module types don't take ABI slots (compile-time only)
-        Type::Module(_) => 0,
+        TypeKind::Module(_) => 0,
     }
 }
 
 /// Synthesize drop glue functions for all structs and arrays that need them.
 ///
 /// Returns a list of synthesized functions that should be added to the compilation.
-pub fn synthesize_drop_glue(
-    type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
-) -> Vec<AnalyzedFunction> {
+pub fn synthesize_drop_glue(type_pool: &TypeInternPool) -> Vec<AnalyzedFunction> {
     let mut drop_glue_functions = Vec::new();
 
     // Create drop glue for structs
@@ -133,7 +129,7 @@ pub fn synthesize_drop_glue(
         let struct_def = type_pool.struct_def(struct_id);
         // Skip structs that don't need drop
         let struct_ty = Type::Struct(struct_id);
-        if !type_needs_drop(struct_ty, type_pool, array_types) {
+        if !type_needs_drop(struct_ty, type_pool) {
             continue;
         }
 
@@ -145,21 +141,20 @@ pub fn synthesize_drop_glue(
         }
 
         // Create drop glue function for struct
-        let func = create_struct_drop_glue_function(&struct_def, struct_id, type_pool, array_types);
+        let func = create_struct_drop_glue_function(&struct_def, struct_id, type_pool);
         drop_glue_functions.push(func);
     }
 
     // Create drop glue for arrays
-    for (array_idx, array_def) in array_types.iter().enumerate() {
+    for array_id in type_pool.all_array_ids() {
         // Skip arrays that don't need drop
-        let array_id = rue_air::ArrayTypeId(array_idx as u32);
         let array_ty = Type::Array(array_id);
-        if !type_needs_drop(array_ty, type_pool, array_types) {
+        if !type_needs_drop(array_ty, type_pool) {
             continue;
         }
 
         // Create drop glue function for array
-        let func = create_array_drop_glue_function(array_def, array_id, type_pool, array_types);
+        let func = create_array_drop_glue_function(array_id, type_pool);
         drop_glue_functions.push(func);
     }
 
@@ -171,7 +166,6 @@ fn create_struct_drop_glue_function(
     struct_def: &StructDef,
     _struct_id: rue_air::StructId,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
 ) -> AnalyzedFunction {
     let fn_name = format!("__rue_drop_{}", struct_def.name);
     let span = Span::new(0, 0); // Synthetic span
@@ -182,7 +176,7 @@ fn create_struct_drop_glue_function(
     // Calculate total parameter slots
     let mut num_param_slots = 0u32;
     for field in &struct_def.fields {
-        num_param_slots += type_slot_count(field.ty, type_pool, array_types);
+        num_param_slots += type_slot_count(field.ty, type_pool);
     }
 
     // Collect drop statements - these are side-effects that must be executed
@@ -193,13 +187,13 @@ fn create_struct_drop_glue_function(
     let mut current_param_slot = 0u32;
 
     for field in &struct_def.fields {
-        let field_slot_count = type_slot_count(field.ty, type_pool, array_types);
+        let field_slot_count = type_slot_count(field.ty, type_pool);
 
-        if type_needs_drop(field.ty, type_pool, array_types) {
+        if type_needs_drop(field.ty, type_pool) {
             // Emit Drop for this field.
             // Type::Struct handles both user-defined structs and builtin String.
-            match field.ty {
-                Type::Struct(nested_struct_id) => {
+            match field.ty.kind() {
+                TypeKind::Struct(nested_struct_id) => {
                     // Nested struct - load it and drop it
                     // The recursive drop glue will handle its fields
                     let param_ref = air.add_inst(AirInst {
@@ -216,7 +210,7 @@ fn create_struct_drop_glue_function(
                     });
                     drop_statements.push(drop_ref);
                 }
-                Type::Array(array_id) => {
+                TypeKind::Array(array_id) => {
                     // Array field - load it and drop it
                     // The array drop glue will handle dropping each element
                     let param_ref = air.add_inst(AirInst {
@@ -293,32 +287,33 @@ fn create_struct_drop_glue_function(
 /// The function receives all element slots as parameters (flattened) and drops
 /// each element in index order.
 fn create_array_drop_glue_function(
-    array_def: &ArrayTypeDef,
     array_id: rue_air::ArrayTypeId,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
 ) -> AnalyzedFunction {
-    let fn_name = array_drop_glue_name(array_id, array_types, type_pool);
+    let fn_name = array_drop_glue_name(array_id, type_pool);
     let span = Span::new(0, 0); // Synthetic span
+
+    // Get array element type and length
+    let (element_type, length) = type_pool.array_def(array_id);
 
     // Create AIR for the drop glue function
     let mut air = Air::new(Type::Unit);
 
     // Calculate total parameter slots (element slots * length)
-    let element_slot_count = type_slot_count(array_def.element_type, type_pool, array_types);
-    let num_param_slots = element_slot_count * array_def.length as u32;
+    let element_slot_count = type_slot_count(element_type, type_pool);
+    let num_param_slots = element_slot_count * length as u32;
 
     // Collect drop statements for each element
     let mut drop_statements = Vec::new();
 
     // For each element, emit a Drop instruction.
     // Type::Struct handles both user-defined structs and builtin String.
-    for elem_idx in 0..array_def.length {
+    for elem_idx in 0..length {
         let current_param_slot = elem_idx as u32 * element_slot_count;
 
         // Emit Drop for this element
-        match array_def.element_type {
-            Type::Struct(struct_id) => {
+        match element_type.kind() {
+            TypeKind::Struct(struct_id) => {
                 let param_ref = air.add_inst(AirInst {
                     data: AirInstData::Param {
                         index: current_param_slot,
@@ -333,7 +328,7 @@ fn create_array_drop_glue_function(
                 });
                 drop_statements.push(drop_ref);
             }
-            Type::Array(nested_array_id) => {
+            TypeKind::Array(nested_array_id) => {
                 let param_ref = air.add_inst(AirInst {
                     data: AirInstData::Param {
                         index: current_param_slot,
@@ -400,45 +395,38 @@ fn create_array_drop_glue_function(
 /// Generate the drop glue function name for an array type.
 ///
 /// The name encodes the element type and length, e.g., `__rue_drop_array_String_3`
-pub fn array_drop_glue_name(
-    array_id: rue_air::ArrayTypeId,
-    array_types: &[ArrayTypeDef],
-    type_pool: &TypeInternPool,
-) -> String {
-    let array_def = &array_types[array_id.0 as usize];
-    let element_type_name = type_name(array_def.element_type, type_pool, array_types);
-    format!(
-        "__rue_drop_array_{}_{}",
-        element_type_name, array_def.length
-    )
+pub fn array_drop_glue_name(array_id: rue_air::ArrayTypeId, type_pool: &TypeInternPool) -> String {
+    let (element_type, length) = type_pool.array_def(array_id);
+    let element_type_name = type_name(element_type, type_pool);
+    format!("__rue_drop_array_{}_{}", element_type_name, length)
 }
 
 /// Get a name for a type (used for generating drop glue function names).
-fn type_name(ty: Type, type_pool: &TypeInternPool, array_types: &[ArrayTypeDef]) -> String {
-    match ty {
-        Type::I8 => "i8".to_string(),
-        Type::I16 => "i16".to_string(),
-        Type::I32 => "i32".to_string(),
-        Type::I64 => "i64".to_string(),
-        Type::U8 => "u8".to_string(),
-        Type::U16 => "u16".to_string(),
-        Type::U32 => "u32".to_string(),
-        Type::U64 => "u64".to_string(),
-        Type::Bool => "bool".to_string(),
-        Type::Unit => "unit".to_string(),
-        Type::Never => "never".to_string(),
-        Type::Error => "error".to_string(),
+fn type_name(ty: Type, type_pool: &TypeInternPool) -> String {
+    match ty.kind() {
+        TypeKind::I8 => "i8".to_string(),
+        TypeKind::I16 => "i16".to_string(),
+        TypeKind::I32 => "i32".to_string(),
+        TypeKind::I64 => "i64".to_string(),
+        TypeKind::U8 => "u8".to_string(),
+        TypeKind::U16 => "u16".to_string(),
+        TypeKind::U32 => "u32".to_string(),
+        TypeKind::U64 => "u64".to_string(),
+        TypeKind::Bool => "bool".to_string(),
+        TypeKind::Unit => "unit".to_string(),
+        TypeKind::Never => "never".to_string(),
+        TypeKind::Error => "error".to_string(),
         // ComptimeType only exists at compile time
-        Type::ComptimeType => "comptime_type".to_string(),
-        Type::Enum(enum_id) => format!("enum{}", enum_id.0),
+        TypeKind::ComptimeType => "comptime_type".to_string(),
+        TypeKind::Enum(enum_id) => format!("enum{}", enum_id.0),
         // Struct types include builtin types like String
-        Type::Struct(struct_id) => type_pool.struct_def(struct_id).name.clone(),
-        Type::Array(array_id) => {
-            let array_def = &array_types[array_id.0 as usize];
-            let elem_name = type_name(array_def.element_type, type_pool, array_types);
-            format!("array_{}_{}", elem_name, array_def.length)
+        TypeKind::Struct(struct_id) => type_pool.struct_def(struct_id).name.clone(),
+        TypeKind::Array(array_id) => {
+            let (element_type, length) = type_pool.array_def(array_id);
+            let elem_name = type_name(element_type, type_pool);
+            format!("array_{}_{}", elem_name, length)
         }
         // Module types should never reach drop glue (compile-time only)
-        Type::Module(_) => "module".to_string(),
+        TypeKind::Module(_) => "module".to_string(),
     }
 }

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -165,9 +165,7 @@ pub fn validate_runtime() -> Result<(), String> {
 
 // Re-export commonly used types
 pub use lasso::{Spur, ThreadedRodeo};
-pub use rue_air::{
-    Air, AnalyzedFunction, ArrayTypeDef, Sema, SemaOutput, StructDef, Type, TypeInternPool,
-};
+pub use rue_air::{Air, AnalyzedFunction, Sema, SemaOutput, StructDef, Type, TypeInternPool};
 pub use rue_cfg::{Cfg, CfgBuilder, CfgOutput, OptLevel};
 pub use rue_codegen::{
     LoweringDebugInfo, RegAllocDebugInfo, RelocationKind, StackFrameInfo, X86Mir,
@@ -774,8 +772,6 @@ pub struct CompileState {
     pub functions: Vec<FunctionWithCfg>,
     /// Type intern pool containing all struct and enum definitions.
     pub type_pool: TypeInternPool,
-    /// Array type definitions (element type and length).
-    pub array_types: Vec<ArrayTypeDef>,
     /// String literals indexed by their string_const index.
     pub strings: Vec<String>,
     /// Warnings collected during compilation.
@@ -894,15 +890,14 @@ pub fn compile_frontend_from_ast_with_options(
         let output = sema.analyze_all()?;
         info!(
             function_count = output.functions.len(),
-            struct_count = output.struct_defs.len(),
+            struct_count = output.type_pool.stats().struct_count,
             "semantic analysis complete"
         );
         output
     };
 
     // Synthesize drop glue functions for structs that need them
-    let drop_glue_functions =
-        drop_glue::synthesize_drop_glue(&sema_output.type_pool, &sema_output.array_types);
+    let drop_glue_functions = drop_glue::synthesize_drop_glue(&sema_output.type_pool);
 
     // Combine user functions with synthesized drop glue functions
     // Filter out comptime-only functions (those returning `type`) as they don't generate runtime code
@@ -927,7 +922,6 @@ pub fn compile_frontend_from_ast_with_options(
                     func.num_param_slots,
                     &func.name,
                     &sema_output.type_pool,
-                    &sema_output.array_types,
                     func.param_modes.clone(),
                     &interner,
                 );
@@ -967,7 +961,6 @@ pub fn compile_frontend_from_ast_with_options(
         rir,
         functions,
         type_pool: sema_output.type_pool,
-        array_types: sema_output.array_types,
         strings: sema_output.strings,
         warnings,
     })
@@ -1002,15 +995,14 @@ pub fn compile_frontend_from_rir_with_options(
         let output = sema.analyze_all()?;
         info!(
             function_count = output.functions.len(),
-            struct_count = output.struct_defs.len(),
+            struct_count = output.type_pool.stats().struct_count,
             "semantic analysis complete"
         );
         output
     };
 
     // Synthesize drop glue functions for structs that need them
-    let drop_glue_functions =
-        drop_glue::synthesize_drop_glue(&sema_output.type_pool, &sema_output.array_types);
+    let drop_glue_functions = drop_glue::synthesize_drop_glue(&sema_output.type_pool);
 
     // Combine user functions with synthesized drop glue functions
     // Filter out comptime-only functions (those returning `type`) as they don't generate runtime code
@@ -1035,7 +1027,6 @@ pub fn compile_frontend_from_rir_with_options(
                     func.num_param_slots,
                     &func.name,
                     &sema_output.type_pool,
-                    &sema_output.array_types,
                     func.param_modes.clone(),
                     &interner,
                 );
@@ -1074,7 +1065,6 @@ pub fn compile_frontend_from_rir_with_options(
         rir,
         functions,
         type_pool: sema_output.type_pool,
-        array_types: sema_output.array_types,
         strings: sema_output.strings,
         warnings,
     })
@@ -1093,8 +1083,6 @@ pub struct CompileStateFromRir {
     pub functions: Vec<FunctionWithCfg>,
     /// Type intern pool containing all struct and enum definitions.
     pub type_pool: TypeInternPool,
-    /// Array type definitions (element type and length).
-    pub array_types: Vec<ArrayTypeDef>,
     /// String literals indexed by their string_const index.
     pub strings: Vec<String>,
     /// Warnings collected during compilation.
@@ -1233,7 +1221,6 @@ fn compile_x86_64(
                 let machine_code = rue_codegen::x86_64::generate(
                     &func.cfg,
                     &state.type_pool,
-                    &state.array_types,
                     &state.strings,
                     &state.interner,
                 )?;
@@ -1481,7 +1468,6 @@ fn compile_aarch64(
                 let machine_code = rue_codegen::aarch64::generate(
                     &func.cfg,
                     &state.type_pool,
-                    &state.array_types,
                     &state.strings,
                     &state.interner,
                 )?;
@@ -1563,7 +1549,6 @@ fn compile_x86_64_from_rir(
                 let machine_code = rue_codegen::x86_64::generate(
                     &func.cfg,
                     &state.type_pool,
-                    &state.array_types,
                     &state.strings,
                     &state.interner,
                 )?;
@@ -1646,7 +1631,6 @@ fn compile_aarch64_from_rir(
                 let machine_code = rue_codegen::aarch64::generate(
                     &func.cfg,
                     &state.type_pool,
-                    &state.array_types,
                     &state.strings,
                     &state.interner,
                 )?;
@@ -1782,22 +1766,18 @@ impl Mir {
 pub fn generate_mir(
     cfg: &Cfg,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
     target: Target,
 ) -> Mir {
     match target.arch() {
         Arch::X86_64 => {
-            let mir =
-                rue_codegen::x86_64::CfgLower::new(cfg, type_pool, array_types, strings, interner)
-                    .lower();
+            let mir = rue_codegen::x86_64::CfgLower::new(cfg, type_pool, strings, interner).lower();
             Mir::X86_64(mir)
         }
         Arch::Aarch64 => {
             let mir =
-                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, array_types, strings, interner)
-                    .lower();
+                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, strings, interner).lower();
             Mir::Aarch64(mir)
         }
     }
@@ -1810,7 +1790,6 @@ pub fn generate_mir(
 pub fn generate_allocated_mir(
     cfg: &Cfg,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
     target: Target,
@@ -1822,9 +1801,7 @@ pub fn generate_allocated_mir(
     match target.arch() {
         Arch::X86_64 => {
             // Lower CFG to X86Mir with virtual registers
-            let mir =
-                rue_codegen::x86_64::CfgLower::new(cfg, type_pool, array_types, strings, interner)
-                    .lower();
+            let mir = rue_codegen::x86_64::CfgLower::new(cfg, type_pool, strings, interner).lower();
 
             // Allocate physical registers
             let (mir, _num_spills, _used_callee_saved) =
@@ -1835,8 +1812,7 @@ pub fn generate_allocated_mir(
         Arch::Aarch64 => {
             // Lower CFG to Aarch64Mir with virtual registers
             let mir =
-                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, array_types, strings, interner)
-                    .lower();
+                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, strings, interner).lower();
 
             // Allocate physical registers
             let (mir, _num_spills, _used_callee_saved) =
@@ -1856,22 +1832,18 @@ pub fn generate_allocated_mir(
 pub fn generate_liveness_info(
     cfg: &Cfg,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
     target: Target,
 ) -> rue_codegen::LivenessDebugInfo {
     match target.arch() {
         Arch::X86_64 => {
-            let mir =
-                rue_codegen::x86_64::CfgLower::new(cfg, type_pool, array_types, strings, interner)
-                    .lower();
+            let mir = rue_codegen::x86_64::CfgLower::new(cfg, type_pool, strings, interner).lower();
             rue_codegen::x86_64::liveness::analyze_debug(&mir)
         }
         Arch::Aarch64 => {
             let mir =
-                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, array_types, strings, interner)
-                    .lower();
+                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, strings, interner).lower();
             rue_codegen::aarch64::liveness::analyze_debug(&mir)
         }
     }
@@ -1886,7 +1858,6 @@ pub fn generate_liveness_info(
 pub fn generate_lowering_info(
     cfg: &Cfg,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
     target: Target,
@@ -1894,13 +1865,13 @@ pub fn generate_lowering_info(
     match target.arch() {
         Arch::X86_64 => {
             let (_mir, debug_info) =
-                rue_codegen::x86_64::CfgLower::new(cfg, type_pool, array_types, strings, interner)
+                rue_codegen::x86_64::CfgLower::new(cfg, type_pool, strings, interner)
                     .lower_with_debug();
             debug_info
         }
         Arch::Aarch64 => {
             let (_mir, debug_info) =
-                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, array_types, strings, interner)
+                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, strings, interner)
                     .lower_with_debug();
             debug_info
         }
@@ -1918,30 +1889,19 @@ pub fn generate_lowering_info(
 pub fn generate_emitted_asm(
     cfg: &Cfg,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<String> {
     match target.arch() {
         Arch::X86_64 => {
-            let (_machine_code, asm) = rue_codegen::x86_64::generate_with_asm(
-                cfg,
-                type_pool,
-                array_types,
-                strings,
-                interner,
-            )?;
+            let (_machine_code, asm) =
+                rue_codegen::x86_64::generate_with_asm(cfg, type_pool, strings, interner)?;
             Ok(asm)
         }
         Arch::Aarch64 => {
-            let (_machine_code, asm) = rue_codegen::aarch64::generate_with_asm(
-                cfg,
-                type_pool,
-                array_types,
-                strings,
-                interner,
-            )?;
+            let (_machine_code, asm) =
+                rue_codegen::aarch64::generate_with_asm(cfg, type_pool, strings, interner)?;
             Ok(asm)
         }
     }
@@ -1955,30 +1915,19 @@ pub fn generate_emitted_asm(
 pub fn generate_regalloc_info(
     cfg: &Cfg,
     type_pool: &TypeInternPool,
-    array_types: &[ArrayTypeDef],
     strings: &[String],
     interner: &ThreadedRodeo,
     target: Target,
 ) -> CompileResult<String> {
     match target.arch() {
         Arch::X86_64 => {
-            let debug_info = rue_codegen::x86_64::generate_regalloc_info(
-                cfg,
-                type_pool,
-                array_types,
-                strings,
-                interner,
-            )?;
+            let debug_info =
+                rue_codegen::x86_64::generate_regalloc_info(cfg, type_pool, strings, interner)?;
             Ok(debug_info.to_string())
         }
         Arch::Aarch64 => {
-            let debug_info = rue_codegen::aarch64::generate_regalloc_info(
-                cfg,
-                type_pool,
-                array_types,
-                strings,
-                interner,
-            )?;
+            let debug_info =
+                rue_codegen::aarch64::generate_regalloc_info(cfg, type_pool, strings, interner)?;
             Ok(debug_info.to_string())
         }
     }
@@ -2004,8 +1953,6 @@ pub struct AirOutput {
     pub functions: Vec<AnalyzedFunction>,
     /// Type intern pool containing all struct and enum definitions.
     pub type_pool: TypeInternPool,
-    /// Array type definitions.
-    pub array_types: Vec<ArrayTypeDef>,
     /// String literals.
     pub strings: Vec<String>,
     /// Warnings collected during analysis.
@@ -2049,7 +1996,6 @@ pub fn compile_to_air(source: &str) -> MultiErrorResult<AirOutput> {
         rir,
         functions: sema_output.functions,
         type_pool: sema_output.type_pool,
-        array_types: sema_output.array_types,
         strings: sema_output.strings,
         warnings: sema_output.warnings,
     })

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1042,7 +1042,6 @@ fn handle_emit_multi_file(
                         let lowering_info = generate_lowering_info(
                             &func.cfg,
                             &state.type_pool,
-                            &state.array_types,
                             &state.strings,
                             &state.interner,
                             options.target,
@@ -1059,7 +1058,6 @@ fn handle_emit_multi_file(
                         let mir = generate_mir(
                             &func.cfg,
                             &state.type_pool,
-                            &state.array_types,
                             &state.strings,
                             &state.interner,
                             options.target,
@@ -1078,7 +1076,6 @@ fn handle_emit_multi_file(
                         let liveness_info = generate_liveness_info(
                             &func.cfg,
                             &state.type_pool,
-                            &state.array_types,
                             &state.strings,
                             &state.interner,
                             options.target,
@@ -1096,7 +1093,6 @@ fn handle_emit_multi_file(
                         let regalloc_info = match generate_regalloc_info(
                             &func.cfg,
                             &state.type_pool,
-                            &state.array_types,
                             &state.strings,
                             &state.interner,
                             options.target,
@@ -1121,7 +1117,6 @@ fn handle_emit_multi_file(
                         let asm = match generate_emitted_asm(
                             &func.cfg,
                             &state.type_pool,
-                            &state.array_types,
                             &state.strings,
                             &state.interner,
                             options.target,
@@ -1144,7 +1139,6 @@ fn handle_emit_multi_file(
                             &func.cfg,
                             &func.analyzed.name,
                             &state.type_pool,
-                            &state.array_types,
                             &state.strings,
                             &state.interner,
                             options.target,

--- a/docs/designs/0024-type-intern-pool-revised.md
+++ b/docs/designs/0024-type-intern-pool-revised.md
@@ -1,0 +1,455 @@
+---
+id: 0024-revised
+title: Type Intern Pool - Revised Approach
+status: implemented
+tags: [type-system, performance, parallelization]
+feature-flag: null
+created: 2026-01-02
+supersedes: 0024-type-intern-pool.md
+---
+
+# ADR-0024 Revised: Type Intern Pool - Simplified Migration
+
+## Status
+
+**Implemented** (2026-01-02) - Phases 1-4 complete. Type is now a u32 newtype with O(1) equality.
+
+## Executive Summary
+
+After multiple failed migration attempts, we discovered that **the pool is already the primary lookup mechanism** for struct/enum definitions. The `struct_defs` and `enum_defs` Vecs are legacy artifacts carried around for "backwards compatibility" but aren't used in the main codepath.
+
+This revised approach:
+1. **Removes the Vec duplication** (Phase 2A) - simple cleanup
+2. **Keeps the `Type` enum unchanged** - no pattern match migration needed
+3. **Migrates arrays to the pool** (Phase 2B) - the real value
+4. **Defers `Type` → `TypeId` rename** until generics needs it (Phase 4, optional)
+
+## Context: Why Previous Attempts Failed
+
+### Original ADR-0024 Phase 4
+The original plan required:
+- Renaming `InternedType` → `Type` globally (~675 usages)
+- Updating all pattern matches simultaneously
+- Massive compiler errors eating all context (600+ errors)
+
+### Incremental Migration Approach
+A previous incremental approach added a `Type::Interned(TypeId)` variant, but:
+- Created dual representations that both needed handling
+- Every pattern match needed `Type::Interned(_) => panic!(...)` or `.normalize()`
+- The migration stalled with 9+ locations needing manual updates
+
+## Key Discovery: Pool Already Primary
+
+Analysis revealed that `SemaContext.get_struct_def()` already uses the pool:
+
+```rust
+// sema_context.rs:370-372
+pub fn get_struct_def(&self, id: StructId) -> StructDef {
+    self.type_pool.struct_def(id)  // Uses pool, NOT Vec!
+}
+```
+
+The only code using the Vec directly:
+- `TypeContext.get_struct_def()` - legacy, limited use
+- Test assertions checking `output.struct_defs.len()`
+- Logging for struct_count
+
+This means **90%+ of struct/enum lookups already use the pool**.
+
+## Revised Approach
+
+### Guiding Principles
+
+1. **Keep `Type` enum unchanged** - pattern matching works, don't break it
+2. **Remove duplication first** - the Vecs are pure overhead
+3. **Pool is canonical** - all lookups go through pool
+4. **Defer rename to Phase 4** - only if generics specialization needs it
+
+### What Changes
+
+| Component | Current | After Phase 2A | After Phase 2B |
+|-----------|---------|----------------|----------------|
+| `Sema.struct_defs` | `Vec<StructDef>` | **Removed** | Removed |
+| `Sema.enum_defs` | `Vec<EnumDef>` | **Removed** | Removed |
+| `TypeContext.struct_defs` | `Vec<StructDef>` | **Removed** | Removed |
+| `SemaContext.struct_defs` | `Vec<StructDef>` (unused) | **Removed** | Removed |
+| `SemaOutput.struct_defs` | `Vec<StructDef>` | **Pool ref** | Pool ref |
+| `ArrayTypeRegistry` | Separate | Separate | **Pool** |
+| `Type` enum | 15 variants | **Unchanged** | Unchanged |
+| Pattern matches | ~215 locations | **Unchanged** | Unchanged |
+
+### What Stays the Same
+
+- `Type::I32`, `Type::Struct(StructId)` - unchanged
+- All pattern matches on `Type` - unchanged
+- `StructId`, `EnumId` newtypes - unchanged (they wrap pool indices)
+- `ArrayTypeId` - unchanged until Phase 2B
+
+## Implementation Phases
+
+### Phase 1: Infrastructure ✅ (Already Complete)
+
+The pool infrastructure exists and is populated:
+- `TypeInternPool` in `intern_pool.rs`
+- `type_pool.struct_def(id)` works
+- `SemaContext` uses pool for lookups
+
+### Phase 2A: Remove Vec Duplication (NEW - Easy)
+
+**Goal**: Single source of truth for struct/enum definitions.
+
+**Changes**:
+1. Remove `struct_defs: Vec<StructDef>` from `Sema`, `TypeContext`, `SemaContext`
+2. Remove `enum_defs: Vec<EnumDef>` from same
+3. Update `SemaOutput` to provide pool access instead of Vecs
+4. Update tests to use `type_pool.struct_count()` instead of `output.struct_defs.len()`
+5. Update logging to use pool stats
+
+**Files affected**: ~8-10 files, mostly deletions
+
+**Ship criterion**: All tests pass, no `struct_defs` or `enum_defs` Vecs anywhere.
+
+### Phase 2B: Migrate Arrays to Pool
+
+**Goal**: Array types interned in pool, enabling parallel creation without merging.
+
+**Changes**:
+1. Move `ArrayTypeRegistry` functionality into `TypeInternPool`
+2. Use `type_pool.intern_array(element, len)` instead of registry
+3. Remove `ArrayTypeRegistry` from `SemaContext`
+4. Arrays deduplicate automatically (same element+len = same type)
+
+**Files affected**: ~5-10 files
+
+**Ship criterion**: Arrays work, no separate array registry, parallel function analysis cleaner.
+
+### Phase 3: Struct/Enum Unified Indexing (Optional)
+
+**Goal**: `StructId` and `EnumId` are just `TypeId` under the hood.
+
+Currently `StructId(0)` and `EnumId(0)` could both exist (different types). After this phase, all composite types share one index space.
+
+**Changes**:
+1. Make `StructId` and `EnumId` aliases for a range of `TypeId`
+2. Update pattern matching on `Type::Struct(id)` to extract from TypeId
+
+**Complexity**: Medium. May not be needed if current design works.
+
+### Phase 4: Type Enum → TypeId (Deferred)
+
+**Goal**: Replace `Type` enum with `TypeId(u32)` for O(1) comparison in generics.
+
+**Only do this when**:
+- Generics specialization needs canonical type comparison
+- `SpecializationKey { type_args: Vec<Type> }` hash collisions become an issue
+- We're adding `Vec<T>` and need to intern generic instantiations
+
+**Changes**:
+1. Rename `Type` → `TypeKind` (the pattern-matchable form)
+2. Make `TypeId` the primary type representation
+3. Add `TypeId::kind(&self, pool) -> TypeKind` for pattern matching
+4. Migrate storage: `ty: Type` → `ty: TypeId`
+5. Migrate patterns: `match ty { Type::I32 => }` → `match ty.kind(pool) { TypeKind::I32 => }`
+
+**Complexity**: High. 200+ pattern matches need updating. Only do if benefits justify cost.
+
+## Benefits of This Approach
+
+### Immediate (Phase 2A)
+- **Simpler codebase**: Remove redundant Vec storage
+- **Single source of truth**: Pool is canonical
+- **No risk**: Just deletions, easy to verify
+
+### Medium-term (Phase 2B)
+- **Parallel array creation**: No per-function merging
+- **Array deduplication**: `[i32; 5]` same type everywhere
+- **Cleaner architecture**: One registry for all composite types
+
+### Long-term (Phase 4, if needed)
+- **O(1) type equality**: Critical for generic specialization caching
+- **Foundation for generics**: `Vec<i32>` as interned type
+- **Future type features**: Pointers, function types, etc.
+
+## Comparison to Original Plan
+
+| Aspect | Original | Revised |
+|--------|----------|---------|
+| Pattern matches changed | 215+ | **0** (until Phase 4) |
+| Files changed (Phase 2) | ~25 | **~10** |
+| Risk of breaking changes | High | **Low** |
+| Immediate benefit | Low (just infrastructure) | **High** (remove duplication) |
+| Type representation | Changes immediately | **Unchanged until needed** |
+| Generics support | Required before generics | **Only if needed** |
+
+## Migration Order
+
+```
+Phase 1 ✅ (done)
+    │
+    ▼
+Phase 2A: Remove Vec duplication (~1-2 hours)
+    │
+    ▼
+Phase 2B: Migrate arrays to pool (~2-4 hours)
+    │
+    ▼
+[STOP HERE unless generics needs it]
+    │
+    ▼
+Phase 3: Unified indexing (optional, ~2-4 hours)
+    │
+    ▼
+Phase 4: Type→TypeId rename (only if needed, ~8-16 hours)
+```
+
+## Files to Change
+
+### Phase 2A (Remove Vecs)
+
+**Delete fields**:
+- `crates/rue-air/src/sema/mod.rs`: `struct_defs`, `enum_defs` fields
+- `crates/rue-air/src/sema_context.rs`: `struct_defs`, `enum_defs` fields
+- `crates/rue-air/src/type_context.rs`: `struct_defs`, `enum_defs` fields
+
+**Update**:
+- `crates/rue-air/src/sema/declarations.rs`: Remove `.push()` calls
+- `crates/rue-air/src/sema/builtins.rs`: Remove `.push()` call
+- `crates/rue-air/src/sema/analysis.rs`: Remove `std::mem::take(&mut sema.struct_defs)`
+- `crates/rue-air/src/sema/mod.rs`: Remove Vec cloning in `build_type_context()`
+- `crates/rue-air/src/sema/tests.rs`: Use `type_pool.struct_count()` instead
+- `crates/rue-compiler/src/lib.rs`: Use `type_pool.struct_count()` for logging
+
+### Phase 2B (Arrays to Pool)
+
+- `crates/rue-air/src/intern_pool.rs`: Already has `intern_array()`
+- `crates/rue-air/src/sema_context.rs`: Replace `ArrayTypeRegistry` with pool
+- `crates/rue-air/src/sema/analysis.rs`: Use `type_pool.intern_array()`
+- `crates/rue-codegen/src/types.rs`: Update array lookups
+
+## Success Criteria
+
+### Phase 2A Complete ✅ (2026-01-02)
+- [x] No `struct_defs: Vec<StructDef>` anywhere in codebase
+- [x] No `enum_defs: Vec<EnumDef>` anywhere in codebase
+- [x] All struct/enum lookups go through `type_pool`
+- [x] All tests pass
+- [x] `./test.sh` green
+
+### Phase 2B Complete ✅ (2026-01-02)
+- [x] No `ArrayTypeRegistry`
+- [x] Arrays interned via `type_pool.intern_array()`
+- [x] Array deduplication works (same element+len = same ArrayTypeId)
+- [x] All tests pass
+
+## Phase 3 & 4: Type Enum → Type(u32) Migration
+
+**Status**: Implemented (2026-01-02)
+
+After completing Phase 2B, we proceeded with Phases 3 and 4 to achieve the full benefits described in the original ADR-0024:
+- O(1) type equality via u32 comparison
+- Foundation for generic type instantiation
+- Unified type representation
+
+### Migration Strategy: "Shadow Type" Approach
+
+The key challenge is migrating ~61 pattern match sites without creating 600+ simultaneous compilation errors. Our approach uses **incremental migration with TypeKind**:
+
+#### Phase 3.1: Introduce TypeKind enum
+
+Create a new `TypeKind` enum that mirrors the current `Type` enum structure:
+
+```rust
+// crates/rue-air/src/types.rs
+pub enum TypeKind {
+    I8, I16, I32, I64, U8, U16, U32, U64,
+    Bool, Unit,
+    Struct(StructId),
+    Enum(EnumId),
+    Array(ArrayTypeId),
+    Module(ModuleId),
+    Error,
+    Never,
+    ComptimeType,
+}
+```
+
+**Why**: TypeKind is the pattern-matchable representation of a Type. Separating these concerns allows incremental migration.
+
+#### Phase 3.2: Add Type::kind() method
+
+Add a method to convert Type to TypeKind:
+
+```rust
+impl Type {
+    pub fn kind(&self) -> TypeKind {
+        match self {
+            Type::I8 => TypeKind::I8,
+            Type::I16 => TypeKind::I16,
+            // ... etc for all variants
+        }
+    }
+}
+```
+
+**Why**: This allows pattern matches to gradually migrate from `match ty { Type::I32 => }` to `match ty.kind() { TypeKind::I32 => }` while keeping everything compiling.
+
+#### Phase 3.3: Migrate pattern matches incrementally
+
+Migrate one file at a time:
+
+```rust
+// Before:
+match ty {
+    Type::I32 | Type::I64 => emit_integer_op(),
+    Type::Struct(id) => {
+        let def = pool.struct_def(id);
+        emit_struct_op(&def);
+    }
+    _ => panic!("unexpected type"),
+}
+
+// After:
+match ty.kind() {
+    TypeKind::I32 | TypeKind::I64 => emit_integer_op(),
+    TypeKind::Struct(id) => {
+        let def = pool.struct_def(id);
+        emit_struct_op(&def);
+    }
+    _ => panic!("unexpected type"),
+}
+```
+
+**Benefits**:
+- Each file compiles and tests pass ✅
+- Can ship intermediate states ✅
+- Easy to back out if issues arise ✅
+- Clear progress tracking (~61 match sites)
+
+#### Phase 4.1: Replace Type enum with Type(InternedType)
+
+Once all pattern matches use `.kind()`, replace the Type enum:
+
+```rust
+// Remove the old enum:
+// pub enum Type { I8, I16, ... }
+
+// Replace with newtype:
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Type(InternedType);
+
+impl Type {
+    // Primitive constants
+    pub const I8: Type = Type(InternedType::I8);
+    pub const I16: Type = Type(InternedType::I16);
+    // ... etc
+
+    // Now kind() does a pool lookup:
+    pub fn kind(&self, pool: &TypeInternPool) -> TypeKind {
+        if self.0.is_primitive() {
+            // Fast path: decode primitive from index
+            match self.0.index() {
+                0 => TypeKind::I8,
+                1 => TypeKind::I16,
+                // ... etc
+            }
+        } else {
+            // Composite types: pool lookup
+            pool.get_kind(self.0)
+        }
+    }
+}
+```
+
+**Why**: Now Type is just a u32 index, giving us O(1) equality. All existing pattern matches continue to work via `.kind()`.
+
+#### Phase 4.2: Update method signatures
+
+Once Type is Type(InternedType), update methods that pattern match:
+
+```rust
+// Before (Phase 3):
+impl Type {
+    pub fn is_integer(&self) -> bool {
+        matches!(self.kind(), TypeKind::I8 | TypeKind::I16 | ...)
+    }
+}
+
+// After (Phase 4, optimized):
+impl Type {
+    pub fn is_integer(&self) -> bool {
+        // No pool lookup needed - just check the index
+        matches!(self.0.index(), 0..=7) // i8..u64
+    }
+}
+```
+
+### Success Criteria
+
+#### Phase 3 Complete ✅ (2026-01-02)
+- [x] TypeKind enum exists in crates/rue-air/src/types.rs
+- [x] Type::kind() method implemented
+- [x] All ~61 pattern match sites migrated to use .kind()
+- [x] All tests pass
+- [x] No direct pattern matches on Type enum remain
+
+#### Phase 4 Complete ✅ (2026-01-02)
+- [x] Type enum removed, replaced with Type(u32) newtype
+- [x] Type::kind() decodes u32 back to TypeKind for pattern matching
+- [x] Type constants (Type::I32, etc.) defined as const Type(n)
+- [x] Helper methods (is_integer, as_struct, etc.) optimized with u32 checks
+- [x] All tests pass (1230 spec, 275 unit, 38 UI)
+- [x] O(1) type equality via u32 comparison works
+
+### Files Affected (Estimated)
+
+**Phase 3.1-3.2** (~1-2 files):
+- `crates/rue-air/src/types.rs` - Add TypeKind, Type::kind()
+
+**Phase 3.3** (~20 files, 61 match sites):
+- `crates/rue-air/src/sema/analysis.rs` (~19 matches)
+- `crates/rue-air/src/sema/typeck.rs` (~9 matches)
+- `crates/rue-codegen/src/x86_64/cfg_lower.rs` (~7 matches)
+- `crates/rue-compiler/src/drop_glue.rs` (~8 matches)
+- `crates/rue-air/src/intern_pool.rs` (~15 matches)
+- ... (15 more files with 1-3 matches each)
+
+**Phase 4.1-4.2** (~3-5 files):
+- `crates/rue-air/src/types.rs` - Replace enum with newtype
+- `crates/rue-air/src/intern_pool.rs` - Add get_kind() method
+- `crates/rue-air/src/lib.rs` - Update exports
+
+### Comparison to Big-Bang Approach
+
+| Aspect | Big-Bang | Shadow Type (Our Approach) |
+|--------|----------|----------------------------|
+| Compilation errors | 600+ all at once | 0 (compiles at each step) |
+| Testability | Only at the end | After each file migration |
+| Risk | High | Low |
+| Context window | Fills with errors | Clean, focused changes |
+| Reversibility | Difficult | Easy (one file at a time) |
+| Progress tracking | Binary (done/not done) | Linear (~61 match sites) |
+
+### Why This Works
+
+1. **TypeKind is the same structure as Type**: Just a renamed copy, so semantics don't change
+2. **Type::kind() starts trivial**: Just returns the enum variant, no pool lookup
+3. **Incremental migration**: Each file can be done independently
+4. **Final flip is mechanical**: Once all matches use .kind(), replacing the enum is safe
+
+### Implementation Order (Completed)
+
+1. ✅ Add TypeKind enum to types.rs
+2. ✅ Add Type::kind() → TypeKind conversion
+3. ✅ Migrate pattern matches file by file, testing after each
+4. ✅ Replace Type enum with Type(u32) newtype
+5. ✅ Optimize Type::kind() and helper methods
+6. Kept TypeKind for pattern matching (provides better ergonomics than direct u32 decoding)
+
+## Appendix: Why We Proceeded with Phases 3 & 4
+
+The revised ADR originally recommended stopping after Phase 2B and only proceeding if generics needed it. However, we implemented Phases 3 & 4 because:
+
+1. **Clean foundation**: Better to complete the migration while the architecture is fresh
+2. **Original design intent**: The full InternPool design provides clear benefits
+3. **Incremental safety**: Our "Shadow Type" approach mitigates the risk that caused the original deferral
+4. **Future-proofing**: O(1) type comparison and generic type instantiation will be needed eventually


### PR DESCRIPTION
Complete implementation of Phases 2B through 4 of the type intern pool:

- Phase 2B: Migrate arrays to TypeInternPool
  - Remove separate ArrayTypeRegistry
  - Arrays now interned via type_pool.intern_array()
  - Array deduplication (same element+len = same ArrayTypeId)

- Phase 3: Introduce TypeKind for pattern matching
  - Add TypeKind enum mirroring Type structure
  - Add Type::kind() method for incremental migration
  - Migrate all ~61 pattern match sites to use .kind()

- Phase 4: Replace Type enum with Type(u32) newtype
  - Type is now a 32-bit tagged value with O(1) equality
  - Primitives encoded as 0-12, composites use tag byte + 24-bit ID
  - Helper methods (is_integer, as_struct, etc.) optimized

This enables efficient type comparison for future generics support and eliminates the need to carry around separate Vec<StructDef>, Vec<EnumDef>, and ArrayTypeRegistry structures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)