### PR TITLE
Fix comptime type vs value parameter distinction

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -50,8 +50,11 @@ pub struct FunctionSig {
     /// they'll be checked during specialization.
     pub is_generic: bool,
     /// Parameter modes (Normal, Inout, Borrow, Comptime).
-    /// Used to identify which parameters are comptime type parameters.
     pub param_modes: Vec<rue_rir::RirParamMode>,
+    /// Which parameters are comptime (declared with `comptime` keyword).
+    /// This is separate from param_modes because `comptime T: type` sets
+    /// is_comptime=true but mode=Normal.
+    pub param_comptime: Vec<bool>,
     /// Parameter names, needed for type substitution in generic returns.
     pub param_names: Vec<lasso::Spur>,
     /// The return type as a symbol (used for substitution lookup).
@@ -490,9 +493,7 @@ impl<'a> ConstraintGenerator<'a> {
                             let arg_info = self.generate(arg.value, ctx);
 
                             // If this is a comptime parameter, extract the type for substitution
-                            if i < func.param_modes.len()
-                                && func.param_modes[i] == rue_rir::RirParamMode::Comptime
-                            {
+                            if i < func.param_comptime.len() && func.param_comptime[i] {
                                 // The argument should be a TypeConst - extract the concrete type
                                 if let InferType::Concrete(Type::ComptimeType) = &arg_info.ty {
                                     // This is a type value - get the actual type from the RIR
@@ -1538,6 +1539,7 @@ mod tests {
             return_type,
             is_generic: false,
             param_modes: vec![rue_rir::RirParamMode::Normal; num_params],
+            param_comptime: vec![false; num_params],
             param_names: vec![],
             return_type_sym: lasso::Spur::default(),
         }

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -207,6 +207,18 @@ fn try_evaluate_const_in_rir(rir: &rue_rir::Rir, inst_ref: InstRef) -> Option<Co
         // Comptime blocks: evaluate the inner expression
         InstData::Comptime { expr } => try_evaluate_const_in_rir(rir, *expr),
 
+        // TypeConst: a type used as a value (e.g., `i32` in `identity(i32, 42)`)
+        // Note: This only handles primitive types. Struct/enum types need the
+        // full try_evaluate_const method which has access to the type maps.
+        InstData::TypeConst { type_name: _ } => {
+            // We can't resolve type_name here since we don't have an interner.
+            // Return a placeholder - the actual type resolution happens in
+            // the Sema::try_evaluate_const method which has full context.
+            // For primitive type checks, this is good enough since the
+            // argument is validated at the call site.
+            Some(ConstValue::Type(Type::ComptimeType))
+        }
+
         // Everything else requires runtime evaluation
         _ => None,
     }
@@ -7497,6 +7509,35 @@ impl<'a> Sema<'a> {
 
             // Comptime block: comptime { expr } is compile-time evaluable if its inner expr is
             InstData::Comptime { expr } => self.try_evaluate_const(*expr),
+
+            // TypeConst: a type used as a value (e.g., `i32` in `identity(i32, 42)`)
+            InstData::TypeConst { type_name } => {
+                let type_name_str = self.interner.resolve(type_name);
+                let ty = match type_name_str {
+                    "i8" => Type::I8,
+                    "i16" => Type::I16,
+                    "i32" => Type::I32,
+                    "i64" => Type::I64,
+                    "u8" => Type::U8,
+                    "u16" => Type::U16,
+                    "u32" => Type::U32,
+                    "u64" => Type::U64,
+                    "bool" => Type::Bool,
+                    "()" => Type::Unit,
+                    "!" => Type::Never,
+                    _ => {
+                        // Check for struct types
+                        if let Some(&struct_id) = self.structs.get(type_name) {
+                            Type::Struct(struct_id)
+                        } else if let Some(&enum_id) = self.enums.get(type_name) {
+                            Type::Enum(enum_id)
+                        } else {
+                            return None; // Unknown type
+                        }
+                    }
+                };
+                Some(ConstValue::Type(ty))
+            }
 
             // Everything else requires runtime evaluation
             _ => None,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2029,7 +2029,8 @@ impl<'a> Sema<'a> {
 
         // Extract info before mutable borrow
         let is_generic = fn_info.is_generic;
-        let param_modes = fn_info.param_modes.clone();
+        let param_types = fn_info.param_types.clone();
+        let param_comptime = fn_info.param_comptime.clone();
         let param_names = fn_info.param_names.clone();
         let return_type_sym = fn_info.return_type_sym;
         let base_return_type = fn_info.return_type;
@@ -2045,23 +2046,35 @@ impl<'a> Sema<'a> {
             let mut type_subst: std::collections::HashMap<Spur, Type> =
                 std::collections::HashMap::new();
 
-            for (i, (air_arg, param_mode)) in air_args.iter().zip(param_modes.iter()).enumerate() {
-                if *param_mode == RirParamMode::Comptime {
-                    // This should be a TypeConst instruction - extract the type
-                    let inst = air.get(air_arg.value);
-                    if let AirInstData::TypeConst(ty) = &inst.data {
-                        type_args.push(*ty);
-                        // Record the substitution: param_name -> concrete_type
-                        type_subst.insert(param_names[i], *ty);
+            for (i, (air_arg, is_comptime)) in
+                air_args.iter().zip(param_comptime.iter()).enumerate()
+            {
+                if *is_comptime {
+                    // Check if this is a type parameter (param type is ComptimeType)
+                    // vs a value parameter (param type is i32, bool, etc.)
+                    if param_types[i] == Type::ComptimeType {
+                        // This is a TYPE parameter - expect a TypeConst instruction
+                        let inst = air.get(air_arg.value);
+                        if let AirInstData::TypeConst(ty) = &inst.data {
+                            type_args.push(*ty);
+                            // Record the substitution: param_name -> concrete_type
+                            type_subst.insert(param_names[i], *ty);
+                        } else {
+                            // Not a type - this is an error for type parameters
+                            return Err(CompileError::new(
+                                ErrorKind::ComptimeEvaluationFailed {
+                                    reason: "comptime type parameter must be a type literal"
+                                        .to_string(),
+                                },
+                                span,
+                            ));
+                        }
                     } else {
-                        // Not a type - this is an error
-                        return Err(CompileError::new(
-                            ErrorKind::ComptimeEvaluationFailed {
-                                reason: "comptime type parameter must be a type literal"
-                                    .to_string(),
-                            },
-                            span,
-                        ));
+                        // This is a VALUE parameter (e.g., comptime n: i32)
+                        // It's still passed at runtime but must be a compile-time constant.
+                        // The constant-ness has already been validated above.
+                        // We don't erase value parameters - they're passed normally.
+                        runtime_args.push(air_arg.clone());
                     }
                 } else {
                     runtime_args.push(air_arg.clone());

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -99,6 +99,7 @@ impl<'a> Sema<'a> {
                         return_type: self.type_to_infer_type(info.return_type),
                         is_generic: info.is_generic,
                         param_modes: info.param_modes.clone(),
+                        param_comptime: info.param_comptime.clone(),
                         param_names: info.param_names.clone(),
                         return_type_sym: info.return_type_sym,
                     },
@@ -755,13 +756,17 @@ impl<'a> Sema<'a> {
         let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
         let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
 
-        // Check if this function has any comptime type parameters
-        let is_generic = params.iter().any(|p| p.mode == RirParamMode::Comptime);
+        // Check if this function has any comptime TYPE parameters (not value parameters).
+        // A type parameter is a comptime param where the type is `type`.
+        // - `comptime T: type` -> type parameter (is_generic = true)
+        // - `comptime n: i32` -> value parameter (is_generic = false)
+        let type_sym = self.interner.get_or_intern("type");
+        let is_generic = params.iter().any(|p| p.is_comptime && p.ty == type_sym);
 
         // Collect type parameter names (comptime parameters whose type is `type`)
         let type_param_names: Vec<Spur> = params
             .iter()
-            .filter(|p| p.mode == RirParamMode::Comptime)
+            .filter(|p| p.is_comptime && p.ty == type_sym)
             .map(|p| p.name)
             .collect();
 
@@ -770,14 +775,15 @@ impl<'a> Sema<'a> {
         let param_types: Vec<Type> = params
             .iter()
             .map(|p| {
-                if p.mode == RirParamMode::Comptime {
-                    // For comptime type parameters, the type is `type` (represented by ComptimeType)
+                if p.is_comptime && p.ty == type_sym {
+                    // For comptime TYPE parameters (comptime T: type), the type is `type`
                     Ok(Type::ComptimeType)
                 } else if type_param_names.contains(&p.ty) {
                     // This parameter's type is a type parameter (e.g., `x: T` where T is comptime)
                     // Use ComptimeType as a placeholder - actual type determined at specialization
                     Ok(Type::ComptimeType)
                 } else {
+                    // Regular params OR comptime VALUE params (comptime n: i32)
                     self.resolve_type(p.ty, span)
                 }
             })

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -449,6 +449,7 @@ impl<'a> Sema<'a> {
                         return_type: self.type_to_infer_type(info.return_type),
                         is_generic: info.is_generic,
                         param_modes: info.param_modes.clone(),
+                        param_comptime: info.param_comptime.clone(),
                         param_names: info.param_names.clone(),
                         return_type_sym: info.return_type_sym,
                     },

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -188,8 +188,8 @@ fn create_specialized_function(
     // Build the type substitution map: comptime param name -> concrete Type
     let mut type_subst: HashMap<Spur, Type> = HashMap::new();
     let mut type_arg_idx = 0;
-    for (i, param_mode) in base_info.param_modes.iter().enumerate() {
-        if *param_mode == RirParamMode::Comptime {
+    for (i, is_comptime) in base_info.param_comptime.iter().enumerate() {
+        if *is_comptime {
             if type_arg_idx < key.type_args.len() {
                 type_subst.insert(base_info.param_names[i], key.type_args[type_arg_idx]);
                 type_arg_idx += 1;
@@ -216,8 +216,9 @@ fn create_specialized_function(
         .iter()
         .zip(base_info.param_types.iter())
         .zip(base_info.param_modes.iter())
-        .filter(|((_, _), mode)| **mode != RirParamMode::Comptime)
-        .map(|((name, ty), mode)| {
+        .zip(base_info.param_comptime.iter())
+        .filter(|(((_, _), _), is_comptime)| !*is_comptime)
+        .map(|(((name, ty), mode), _)| {
             // If the type is ComptimeType, look it up in the substitution map
             // The param name's type symbol is stored in param_types as ComptimeType,
             // but we need to find which type param it references.


### PR DESCRIPTION
This fixes the comptime/generics implementation to correctly distinguish between:
- Type parameters:  - requires monomorphization
- Value parameters:  - compile-time constant value

Key changes:
- declarations.rs: is_generic only true for type parameters (where param type is 'type'), not all comptime params
- declarations.rs: param_types now correctly resolves value params while using ComptimeType placeholder only for type params
- analyze_ops.rs: type args extraction handles the distinction
- specialize.rs: uses param_comptime field consistently
- generate.rs: FunctionSig now includes param_comptime field
- analysis.rs: try_evaluate_const handles TypeConst instructions

All 36 comptime tests pass (10 Phase 4 anon struct tests remain ignored).

🤖 Generated with [Claude Code](https://claude.com/claude-code)