### PR TITLE
Fix ICE with if-statements in unit-returning functions

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1442,13 +1442,15 @@ impl<'a> CfgBuilder<'a> {
             AirInstData::Ret(value) => {
                 let val = match value {
                     Some(v) => {
-                        let Some(val) = self.lower_value(*v) else {
+                        let result = self.lower_inst(*v);
+                        if matches!(result.continuation, Continuation::Diverged) {
                             // The return value expression itself diverged (e.g., a block
                             // containing an earlier return). The terminator was already set
                             // by the inner diverging expression, so just propagate divergence.
                             return Self::diverged();
-                        };
-                        Some(val)
+                        }
+                        // result.value may be None for Unit-typed expressions - that's OK
+                        result.value
                     }
                     None => None,
                 };

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -278,6 +278,19 @@ params = [
   { variant = "with_statements", source = "fn main() {\n    let x = 42;\n}" },
 ]
 
+[[case]]
+name = "unit_return_with_if_{variant}"
+spec = ["6.1:6"]
+description = "Unit-returning functions with if statements (regression test for CFG terminator bug)"
+source = "{source}"
+exit_code = 0
+params = [
+  { variant = "simple", source = "fn unit_fn(x: i32) {\n    if x > 0 {\n        let y = 1;\n    }\n}\nfn main() -> i32 { unit_fn(5); 0 }" },
+  { variant = "with_else", source = "fn unit_fn(x: i32) {\n    if x > 0 {\n        let y = 1;\n    } else {\n        let y = 2;\n    }\n}\nfn main() -> i32 { unit_fn(5); 0 }" },
+  { variant = "nested", source = "fn unit_fn(x: i32) {\n    if x > 0 {\n        if x > 5 {\n            let y = 1;\n        }\n    }\n}\nfn main() -> i32 { unit_fn(7); 0 }" },
+  { variant = "with_intrinsic", source = "fn unit_fn(x: i32) {\n    if x > 0 {\n        @dbg(x);\n    }\n}\nfn main() -> i32 { unit_fn(5); 0 }" },
+]
+
 # =============================================================================
 # Struct parameters
 # =============================================================================

--- a/examples/quicksort.rue
+++ b/examples/quicksort.rue
@@ -1,0 +1,73 @@
+// Quicksort - an efficient O(n log n) average-case sorting algorithm
+//
+// This implementation uses the Lomuto partition scheme:
+// 1. Pick the last element as the pivot
+// 2. Partition the array so elements <= pivot are on the left
+// 3. Recursively sort the left and right partitions
+//
+// Demonstrates: recursion, inout parameters, array mutation, borrow parameters
+
+// Partition the array segment [low..high] around a pivot.
+// Returns the final index of the pivot element.
+fn partition(inout arr: [i32; 10], low: u64, high: u64) -> u64 {
+    let pivot = arr[high];
+    let mut i = low;  // Boundary for elements <= pivot
+
+    let mut j = low;
+    while j < high {
+        if arr[j] <= pivot {
+            // Swap arr[i] and arr[j]
+            let temp = arr[i];
+            arr[i] = arr[j];
+            arr[j] = temp;
+            i = i + 1;
+        }
+        j = j + 1;
+    }
+
+    // Move pivot to its correct position
+    let temp = arr[i];
+    arr[i] = arr[high];
+    arr[high] = temp;
+
+    i
+}
+
+// Sort the array segment [low..high] in place.
+fn quicksort_impl(inout arr: [i32; 10], low: u64, high: u64) {
+    if low < high {
+        let pivot_idx = partition(inout arr, low, high);
+
+        // Sort left partition (guard against underflow when pivot is at low)
+        if pivot_idx > low {
+            quicksort_impl(inout arr, low, pivot_idx - 1);
+        }
+
+        // Sort right partition
+        quicksort_impl(inout arr, pivot_idx + 1, high);
+    }
+}
+
+// Helper to print all elements of the array.
+fn print_array(borrow arr: [i32; 10]) {
+    let mut i: u64 = 0;
+    while i < 10 {
+        @dbg(arr[i]);
+        i = i + 1;
+    }
+}
+
+fn main() -> i32 {
+    let mut arr = [64, 34, 25, 12, 22, 11, 90, 42, 15, 77];
+
+    @dbg(0);  // Before sorting
+    print_array(borrow arr);
+
+    quicksort_impl(inout arr, 0, 9);
+
+    @dbg(1);  // After sorting
+    print_array(borrow arr);
+
+    // Return smallest element as exit code (should be 11)
+    arr[0]
+}


### PR DESCRIPTION
The CFG builder's Ret handler incorrectly treated Unit-typed return values as diverging expressions. When a unit-returning function contained an if-statement, lower_value() would return None (because Unit types have no runtime representation), and the Ret handler interpreted this as divergence, skipping the Return terminator.

The fix checks the continuation field explicitly rather than relying on the value being Some/None, allowing Unit-typed expressions that don't diverge to properly set the Return terminator.

Also adds:
- Regression tests for unit-returning functions with if-statements
- New quicksort example demonstrating recursion, inout, and borrow

🤖 Generated with [Claude Code](https://claude.com/claude-code)