### PR TITLE
Stabilize comptime feature (Phase 4 + stabilization)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1641,22 +1641,6 @@ fn analyze_inst_with_context(
         }
 
         InstData::Comptime { expr } => {
-            // Gate the comptime feature
-            if !ctx.preview_features.contains(&PreviewFeature::Comptime) {
-                return Err(CompileError::new(
-                    ErrorKind::PreviewFeatureRequired {
-                        feature: PreviewFeature::Comptime,
-                        what: "comptime blocks".to_string(),
-                    },
-                    inst.span,
-                )
-                .with_help(format!(
-                    "use `--preview {}` to enable this feature ({})",
-                    PreviewFeature::Comptime.name(),
-                    PreviewFeature::Comptime.adr()
-                )));
-            }
-
             // Try to evaluate the inner expression at compile time
             match try_evaluate_const_in_rir(ctx.rir, *expr) {
                 Some(ConstValue::Integer(value)) => {
@@ -2134,6 +2118,18 @@ fn analyze_var_ref_ctx(
             span,
         });
         return Ok(AnalysisResult::new(air_ref, ty));
+    }
+
+    // Check if it's a comptime type variable (e.g., `let P = Point();`)
+    // These are stored in comptime_type_vars, not in locals
+    if let Some(&ty) = analysis_ctx.comptime_type_vars.get(&name) {
+        // Comptime type vars produce TypeConst instructions
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::TypeConst(ty),
+            ty: Type::ComptimeType,
+            span,
+        });
+        return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
     }
 
     // Look up the variable in locals
@@ -4017,22 +4013,6 @@ fn analyze_call_ctx(
     // Check that comptime parameters receive compile-time constant values
     let has_comptime_params = fn_info.param_comptime.iter().any(|&c| c);
     if has_comptime_params {
-        // Gate behind comptime preview feature
-        if !ctx.preview_features.contains(&PreviewFeature::Comptime) {
-            return Err(CompileError::new(
-                ErrorKind::PreviewFeatureRequired {
-                    feature: PreviewFeature::Comptime,
-                    what: "comptime parameters".to_string(),
-                },
-                span,
-            )
-            .with_help(format!(
-                "use `--preview {}` to enable this feature ({})",
-                PreviewFeature::Comptime.name(),
-                PreviewFeature::Comptime.adr()
-            )));
-        }
-
         // Validate each comptime parameter receives a compile-time constant
         for (i, (&is_comptime, arg)) in fn_info.param_comptime.iter().zip(args.iter()).enumerate() {
             if is_comptime {
@@ -5239,6 +5219,22 @@ impl<'a> Sema<'a> {
         params: &[(Spur, Type, RirParamMode)], // (name, type, mode)
         body: InstRef,
     ) -> CompileResult<(Air, u32, u32, Vec<bool>, Vec<CompileWarning>, Vec<String>)> {
+        self.analyze_function_internal(infer_ctx, return_type, params, body, None)
+    }
+
+    /// Internal function analysis with optional type substitutions.
+    ///
+    /// When `type_subst` is provided (for specialized generic functions), it populates
+    /// `comptime_type_vars` so that type parameters can be resolved in struct initialization
+    /// (e.g., `P { x: 1, y: 2 }` where `P` is a type parameter).
+    fn analyze_function_internal(
+        &mut self,
+        infer_ctx: &InferenceContext,
+        return_type: Type,
+        params: &[(Spur, Type, RirParamMode)],
+        body: InstRef,
+        type_subst: Option<&std::collections::HashMap<Spur, Type>>,
+    ) -> CompileResult<(Air, u32, u32, Vec<bool>, Vec<CompileWarning>, Vec<String>)> {
         let mut air = Air::new(return_type);
         let mut param_map: HashMap<Spur, ParamInfo> = HashMap::new();
         let mut param_modes: Vec<bool> = Vec::new();
@@ -5281,6 +5277,9 @@ impl<'a> Sema<'a> {
         let resolved_types = self.run_type_inference(infer_ctx, return_type, params, body)?;
 
         // Create analysis context with resolved types
+        // If type_subst is provided, initialize comptime_type_vars with the substitutions
+        // so that type parameters can be resolved during struct initialization.
+        let comptime_type_vars = type_subst.map(|s| s.clone()).unwrap_or_else(HashMap::new);
         let mut ctx = AnalysisContext {
             locals: HashMap::new(),
             params: &param_map,
@@ -5294,7 +5293,7 @@ impl<'a> Sema<'a> {
             warnings: Vec::new(),
             local_string_table: HashMap::new(),
             local_strings: Vec::new(),
-            comptime_type_vars: HashMap::new(),
+            comptime_type_vars,
         };
 
         // ======================================================================
@@ -5336,11 +5335,12 @@ impl<'a> Sema<'a> {
         return_type: Type,
         params: &[(Spur, Type, RirParamMode)],
         body: InstRef,
-        _type_subst: &std::collections::HashMap<Spur, Type>,
+        type_subst: &std::collections::HashMap<Spur, Type>,
     ) -> CompileResult<(Air, u32, u32, Vec<bool>, Vec<CompileWarning>, Vec<String>)> {
-        // The type substitution has already been applied to params and return_type,
-        // so we can just call the regular analyze_function.
-        self.analyze_function(infer_ctx, return_type, params, body)
+        // For specialized functions, we need to populate comptime_type_vars with the
+        // type substitutions so that references to type parameters (like `P { ... }`)
+        // can be resolved in the function body.
+        self.analyze_function_internal(infer_ctx, return_type, params, body, Some(type_subst))
     }
 
     /// Run Hindley-Milner type inference on a function body.
@@ -5847,9 +5847,6 @@ impl<'a> Sema<'a> {
 
             // Comptime block expression
             InstData::Comptime { expr } => {
-                // Gate the comptime feature
-                self.require_preview(PreviewFeature::Comptime, "comptime blocks", inst.span)?;
-
                 // Try to evaluate the inner expression at compile time
                 match self.try_evaluate_const(*expr) {
                     Some(ConstValue::Integer(value)) => {
@@ -5945,6 +5942,11 @@ impl<'a> Sema<'a> {
             } => {
                 // Get the field declarations from the RIR
                 let field_decls = self.rir.get_field_decls(*fields_start, *fields_len);
+
+                // Empty structs are not allowed
+                if field_decls.is_empty() {
+                    return Err(CompileError::new(ErrorKind::EmptyStruct, inst.span));
+                }
 
                 // Resolve each field type and build the struct fields
                 let mut struct_fields = Vec::with_capacity(field_decls.len());
@@ -7694,12 +7696,363 @@ impl<'a> Sema<'a> {
         self.try_evaluate_const(inst_ref)?.as_integer()
     }
 
+    /// Try to evaluate an RIR instruction to a compile-time constant value with type substitution.
+    ///
+    /// This is used when evaluating generic functions that return `type`. For example,
+    /// when calling `fn Pair(comptime T: type) -> type { struct { first: T, second: T } }`
+    /// with `Pair(i32)`, we need to substitute `T -> i32` when evaluating the body.
+    ///
+    /// The `type_subst` map contains mappings from type parameter names to concrete types.
+    pub(crate) fn try_evaluate_const_with_subst(
+        &mut self,
+        inst_ref: InstRef,
+        type_subst: &std::collections::HashMap<Spur, Type>,
+    ) -> Option<ConstValue> {
+        let inst = self.rir.get(inst_ref);
+        match &inst.data {
+            // Integer literals
+            InstData::IntConst(value) => i64::try_from(*value).ok().map(ConstValue::Integer),
+
+            // Boolean literals
+            InstData::BoolConst(value) => Some(ConstValue::Bool(*value)),
+
+            // Unary negation: -expr
+            InstData::Neg { operand } => {
+                match self.try_evaluate_const_with_subst(*operand, type_subst)? {
+                    ConstValue::Integer(n) => n.checked_neg().map(ConstValue::Integer),
+                    ConstValue::Bool(_) | ConstValue::Type(_) | ConstValue::Unit => None,
+                }
+            }
+
+            // Logical NOT: !expr
+            InstData::Not { operand } => {
+                match self.try_evaluate_const_with_subst(*operand, type_subst)? {
+                    ConstValue::Bool(b) => Some(ConstValue::Bool(!b)),
+                    ConstValue::Integer(_) | ConstValue::Type(_) | ConstValue::Unit => None,
+                }
+            }
+
+            // Binary arithmetic operations
+            InstData::Add { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_integer()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_integer()?;
+                l.checked_add(r).map(ConstValue::Integer)
+            }
+            InstData::Sub { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_integer()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_integer()?;
+                l.checked_sub(r).map(ConstValue::Integer)
+            }
+            InstData::Mul { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_integer()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_integer()?;
+                l.checked_mul(r).map(ConstValue::Integer)
+            }
+            InstData::Div { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_integer()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_integer()?;
+                if r == 0 {
+                    None
+                } else {
+                    l.checked_div(r).map(ConstValue::Integer)
+                }
+            }
+            InstData::Mod { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_integer()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_integer()?;
+                if r == 0 {
+                    None
+                } else {
+                    l.checked_rem(r).map(ConstValue::Integer)
+                }
+            }
+
+            // Comparison operations
+            InstData::Eq { lhs, rhs } => {
+                let l = self.try_evaluate_const_with_subst(*lhs, type_subst)?;
+                let r = self.try_evaluate_const_with_subst(*rhs, type_subst)?;
+                match (l, r) {
+                    (ConstValue::Integer(a), ConstValue::Integer(b)) => {
+                        Some(ConstValue::Bool(a == b))
+                    }
+                    (ConstValue::Bool(a), ConstValue::Bool(b)) => Some(ConstValue::Bool(a == b)),
+                    _ => None,
+                }
+            }
+            InstData::Ne { lhs, rhs } => {
+                let l = self.try_evaluate_const_with_subst(*lhs, type_subst)?;
+                let r = self.try_evaluate_const_with_subst(*rhs, type_subst)?;
+                match (l, r) {
+                    (ConstValue::Integer(a), ConstValue::Integer(b)) => {
+                        Some(ConstValue::Bool(a != b))
+                    }
+                    (ConstValue::Bool(a), ConstValue::Bool(b)) => Some(ConstValue::Bool(a != b)),
+                    _ => None,
+                }
+            }
+            InstData::Lt { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_integer()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_integer()?;
+                Some(ConstValue::Bool(l < r))
+            }
+            InstData::Gt { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_integer()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_integer()?;
+                Some(ConstValue::Bool(l > r))
+            }
+            InstData::Le { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_integer()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_integer()?;
+                Some(ConstValue::Bool(l <= r))
+            }
+            InstData::Ge { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_integer()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_integer()?;
+                Some(ConstValue::Bool(l >= r))
+            }
+
+            // Logical operations
+            InstData::And { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_bool()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_bool()?;
+                Some(ConstValue::Bool(l && r))
+            }
+            InstData::Or { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_bool()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_bool()?;
+                Some(ConstValue::Bool(l || r))
+            }
+
+            // Bitwise operations
+            InstData::BitAnd { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_integer()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_integer()?;
+                Some(ConstValue::Integer(l & r))
+            }
+            InstData::BitOr { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_integer()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_integer()?;
+                Some(ConstValue::Integer(l | r))
+            }
+            InstData::BitXor { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_integer()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_integer()?;
+                Some(ConstValue::Integer(l ^ r))
+            }
+            InstData::Shl { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_integer()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_integer()?;
+                if r < 0 || r >= 8 {
+                    return None;
+                }
+                Some(ConstValue::Integer(l << r))
+            }
+            InstData::Shr { lhs, rhs } => {
+                let l = self
+                    .try_evaluate_const_with_subst(*lhs, type_subst)?
+                    .as_integer()?;
+                let r = self
+                    .try_evaluate_const_with_subst(*rhs, type_subst)?
+                    .as_integer()?;
+                if r < 0 || r >= 8 {
+                    return None;
+                }
+                Some(ConstValue::Integer(l >> r))
+            }
+            InstData::BitNot { operand } => {
+                let n = self
+                    .try_evaluate_const_with_subst(*operand, type_subst)?
+                    .as_integer()?;
+                Some(ConstValue::Integer(!n))
+            }
+
+            // Comptime block: comptime { expr } is compile-time evaluable if its inner expr is
+            InstData::Comptime { expr } => self.try_evaluate_const_with_subst(*expr, type_subst),
+
+            // Block: evaluate the result expression (last expression in the block)
+            InstData::Block { extra_start, len } => {
+                if *len == 1 {
+                    let inst_refs = self.rir.get_extra(*extra_start, *len);
+                    let result_ref = InstRef::from_raw(inst_refs[0]);
+                    self.try_evaluate_const_with_subst(result_ref, type_subst)
+                } else {
+                    None
+                }
+            }
+
+            // Anonymous struct type: evaluate to a comptime type value with substitution
+            InstData::AnonStructType {
+                fields_start,
+                fields_len,
+            } => {
+                let field_decls = self.rir.get_field_decls(*fields_start, *fields_len);
+
+                let mut struct_fields = Vec::with_capacity(field_decls.len());
+                for (name_sym, type_sym) in field_decls {
+                    let name_str = self.interner.resolve(&name_sym).to_string();
+                    // Use the substitution-aware type resolution
+                    let field_ty =
+                        self.resolve_type_for_comptime_with_subst(type_sym, type_subst)?;
+                    struct_fields.push(StructField {
+                        name: name_str,
+                        ty: field_ty,
+                    });
+                }
+
+                let struct_ty = self.find_or_create_anon_struct(&struct_fields);
+                Some(ConstValue::Type(struct_ty))
+            }
+
+            // TypeConst: a type used as a value
+            InstData::TypeConst { type_name } => {
+                // First check the substitution map
+                if let Some(&ty) = type_subst.get(type_name) {
+                    return Some(ConstValue::Type(ty));
+                }
+
+                let type_name_str = self.interner.resolve(type_name);
+                let ty = match type_name_str {
+                    "i8" => Type::I8,
+                    "i16" => Type::I16,
+                    "i32" => Type::I32,
+                    "i64" => Type::I64,
+                    "u8" => Type::U8,
+                    "u16" => Type::U16,
+                    "u32" => Type::U32,
+                    "u64" => Type::U64,
+                    "bool" => Type::Bool,
+                    "()" => Type::Unit,
+                    "!" => Type::Never,
+                    _ => {
+                        if let Some(&struct_id) = self.structs.get(type_name) {
+                            Type::Struct(struct_id)
+                        } else if let Some(&enum_id) = self.enums.get(type_name) {
+                            Type::Enum(enum_id)
+                        } else {
+                            return None;
+                        }
+                    }
+                };
+                Some(ConstValue::Type(ty))
+            }
+
+            // VarRef: check substitution map first, then try as a type name
+            InstData::VarRef { name } => {
+                // Check if this is a type parameter in the substitution map
+                if let Some(&ty) = type_subst.get(name) {
+                    return Some(ConstValue::Type(ty));
+                }
+
+                // Try to resolve as a type name
+                let name_str = self.interner.resolve(name);
+                let ty = match name_str {
+                    "i8" => Type::I8,
+                    "i16" => Type::I16,
+                    "i32" => Type::I32,
+                    "i64" => Type::I64,
+                    "u8" => Type::U8,
+                    "u16" => Type::U16,
+                    "u32" => Type::U32,
+                    "u64" => Type::U64,
+                    "bool" => Type::Bool,
+                    "()" => Type::Unit,
+                    "!" => Type::Never,
+                    _ => {
+                        if let Some(&struct_id) = self.structs.get(name) {
+                            Type::Struct(struct_id)
+                        } else if let Some(&enum_id) = self.enums.get(name) {
+                            Type::Enum(enum_id)
+                        } else {
+                            return None;
+                        }
+                    }
+                };
+                Some(ConstValue::Type(ty))
+            }
+
+            // Everything else requires runtime evaluation
+            _ => None,
+        }
+    }
+
     /// Check if an RIR instruction is an integer literal.
     ///
     /// This is used for bidirectional type inference to detect when the LHS
     /// of a binary operator is a literal that can adopt its type from the RHS.
     fn is_integer_literal(&self, inst_ref: InstRef) -> bool {
         matches!(self.rir.get(inst_ref).data, InstData::IntConst(_))
+    }
+
+    /// Check if an RIR instruction is a VarRef to a comptime type variable.
+    ///
+    /// This is used when validating comptime arguments to detect variables
+    /// that hold comptime type values (e.g., `let P = Point(); ... Line(P)`).
+    pub(crate) fn is_comptime_type_var(&self, inst_ref: InstRef, ctx: &AnalysisContext) -> bool {
+        if let InstData::VarRef { name } = &self.rir.get(inst_ref).data {
+            ctx.comptime_type_vars.contains_key(name)
+        } else {
+            false
+        }
     }
 
     /// Check if an RIR instruction is a comparison operation.

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1229,6 +1229,18 @@ impl<'a> Sema<'a> {
             return Ok(AnalysisResult::new(air_ref, ty));
         }
 
+        // Check if it's a comptime type variable (e.g., `let P = Point();`)
+        // These are stored in comptime_type_vars, not in locals
+        if let Some(&ty) = ctx.comptime_type_vars.get(&name) {
+            // Comptime type vars produce TypeConst instructions
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::TypeConst(ty),
+                ty: Type::ComptimeType,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
+        }
+
         // Check if this is a type name (for comptime type parameters)
         // Try to resolve it as a type - if successful, emit a TypeConst instruction
         if let Ok(resolved_type) = self.resolve_type(name, span) {
@@ -2113,14 +2125,13 @@ impl<'a> Sema<'a> {
         // Check that comptime parameters receive compile-time constant values
         let has_comptime_params = param_comptime.iter().any(|&c| c);
         if has_comptime_params {
-            // Gate behind comptime preview feature
-            self.require_preview(PreviewFeature::Comptime, "comptime parameters", span)?;
-
             // Validate each comptime parameter receives a compile-time constant
             for (i, (&is_comptime, arg)) in param_comptime.iter().zip(args.iter()).enumerate() {
                 if is_comptime {
                     // Try to evaluate the argument at compile time
-                    if self.try_evaluate_const(arg.value).is_none() {
+                    let is_comptime_known = self.try_evaluate_const(arg.value).is_some()
+                        || self.is_comptime_type_var(arg.value, ctx);
+                    if !is_comptime_known {
                         let param_name = self.interner.resolve(&param_names[i]).to_string();
                         return Err(CompileError::new(
                             ErrorKind::ComptimeArgNotConst {
@@ -2192,6 +2203,27 @@ impl<'a> Sema<'a> {
             } else {
                 base_return_type
             };
+
+            // Special case: functions that return `type` (not a type parameter) with no runtime args
+            // can be fully evaluated at compile time to produce a concrete anonymous struct type.
+            // This handles cases like: `fn Pair(comptime T: type) -> type { struct { first: T, second: T } }`
+            if return_type == Type::ComptimeType && runtime_args.is_empty() {
+                // The return type is literally `type`, not a type parameter that was substituted.
+                // Try to evaluate the function body at compile time with type substitutions.
+                if let Some(ConstValue::Type(ty)) =
+                    self.try_evaluate_const_with_subst(fn_body, &type_subst)
+                {
+                    // Success! Return a TypeConst instruction instead of a runtime call
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::TypeConst(ty),
+                        ty: Type::ComptimeType,
+                        span,
+                    });
+                    return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
+                }
+                // If we can't evaluate at compile time, fall through to the error below
+                // (we can't have a runtime call that returns `type`)
+            }
 
             // Encode type arguments into extra array (as raw Type discriminants)
             let mut type_extra = Vec::with_capacity(type_args.len());

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -747,12 +747,6 @@ impl<'a> Sema<'a> {
     ) -> CompileResult<()> {
         let params = self.rir.get_params(params_start, params_len);
 
-        // Check if any parameter is comptime and gate behind preview feature
-        let has_comptime_params = params.iter().any(|p| p.is_comptime);
-        if has_comptime_params {
-            self.require_preview(PreviewFeature::Comptime, "comptime parameters", span)?;
-        }
-
         let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
         let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
 

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -171,6 +171,25 @@ impl<'a> Sema<'a> {
     ///
     /// This is used in comptime evaluation where we can't produce a compile error.
     pub(crate) fn resolve_type_for_comptime(&mut self, type_sym: Spur) -> Option<Type> {
+        self.resolve_type_for_comptime_with_subst(type_sym, &std::collections::HashMap::new())
+    }
+
+    /// Resolve a type symbol to a Type with type parameter substitution.
+    ///
+    /// This is used in comptime evaluation of generic functions where type parameters
+    /// need to be substituted with their concrete types. For example, when evaluating
+    /// `fn Pair(comptime T: type) -> type { struct { first: T, second: T } }` with T=i32,
+    /// we need to resolve `T` to `i32`.
+    pub(crate) fn resolve_type_for_comptime_with_subst(
+        &mut self,
+        type_sym: Spur,
+        type_subst: &std::collections::HashMap<Spur, Type>,
+    ) -> Option<Type> {
+        // First check the substitution map for type parameters
+        if let Some(&ty) = type_subst.get(&type_sym) {
+            return Some(ty);
+        }
+
         let type_name = self.interner.resolve(&type_sym);
 
         // Check primitive types first
@@ -197,7 +216,7 @@ impl<'a> Sema<'a> {
         } else if let Some((element_type, length)) = parse_array_type_syntax(type_name) {
             // Resolve the element type first
             let element_sym = self.interner.get_or_intern(&element_type);
-            let element_ty = self.resolve_type_for_comptime(element_sym)?;
+            let element_ty = self.resolve_type_for_comptime_with_subst(element_sym, type_subst)?;
             // Get or create the array type
             let array_type_id = self.get_or_create_array_type(element_ty, length);
             Some(Type::Array(array_type_id))

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -117,6 +117,7 @@ impl ErrorCode {
     pub const BORROW_INOUT_CONFLICT: Self = Self(429);
     pub const INOUT_KEYWORD_MISSING: Self = Self(430);
     pub const BORROW_KEYWORD_MISSING: Self = Self(431);
+    pub const EMPTY_STRUCT: Self = Self(432);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -248,9 +249,6 @@ pub enum PreviewFeature {
     /// Affine types and mutable value semantics.
     /// See ADR-0008 for the full design.
     AffineMvs,
-    /// Compile-time execution (comptime).
-    /// See ADR-0025 for the full design.
-    Comptime,
     /// Module system with @import and pub visibility.
     /// See ADR-0026 for the full design.
     Modules,
@@ -275,7 +273,6 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::AffineMvs => "affine_mvs",
-            PreviewFeature::Comptime => "comptime",
             PreviewFeature::Modules => "modules",
         }
     }
@@ -286,7 +283,6 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::AffineMvs => "ADR-0008",
-            PreviewFeature::Comptime => "ADR-0025",
             PreviewFeature::Modules => "ADR-0026",
         }
     }
@@ -296,7 +292,6 @@ impl PreviewFeature {
         &[
             PreviewFeature::TestInfra,
             PreviewFeature::AffineMvs,
-            PreviewFeature::Comptime,
             PreviewFeature::Modules,
         ]
     }
@@ -322,7 +317,6 @@ impl std::str::FromStr for PreviewFeature {
         match s {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "affine_mvs" => Ok(PreviewFeature::AffineMvs),
-            "comptime" => Ok(PreviewFeature::Comptime),
             "modules" => Ok(PreviewFeature::Modules),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
@@ -805,6 +799,9 @@ pub enum ErrorKind {
         struct_name: String,
         field_name: String,
     },
+    /// Anonymous struct with no fields is not allowed
+    #[error("empty struct is not allowed")]
+    EmptyStruct,
     /// @copy struct contains a field with non-Copy type
     #[error("@copy struct '{struct_name}' has field '{field_name}' with non-Copy type '{field_type}'", struct_name = .0.struct_name, field_name = .0.field_name, field_type = .0.field_type)]
     CopyStructNonCopyField(Box<CopyStructNonCopyFieldError>),
@@ -1037,6 +1034,7 @@ impl ErrorKind {
             ErrorKind::MissingFields(_) => ErrorCode::MISSING_FIELDS,
             ErrorKind::UnknownField { .. } => ErrorCode::UNKNOWN_FIELD,
             ErrorKind::DuplicateField { .. } => ErrorCode::DUPLICATE_FIELD,
+            ErrorKind::EmptyStruct => ErrorCode::EMPTY_STRUCT,
             ErrorKind::CopyStructNonCopyField(_) => ErrorCode::COPY_STRUCT_NON_COPY_FIELD,
             ErrorKind::ReservedTypeName { .. } => ErrorCode::RESERVED_TYPE_NAME,
             ErrorKind::DuplicateTypeDefinition { .. } => ErrorCode::DUPLICATE_TYPE_DEFINITION,
@@ -1804,7 +1802,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, affine_mvs, comptime, modules");
+        assert_eq!(names, "test_infra, affine_mvs, modules");
     }
 
     // ========================================================================

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1,7 +1,6 @@
 # Compile-Time Execution (comptime) Tests
 #
-# Tests for the comptime block expression feature (ADR-0025, Phase 1).
-# This is a preview feature that must be enabled with --preview comptime.
+# Tests for the comptime block expression feature (ADR-0025).
 
 [section]
 id = "expressions.comptime"
@@ -10,40 +9,12 @@ name = "Compile-Time Execution"
 description = "Comptime blocks evaluate expressions at compile time."
 
 # =============================================================================
-# Preview Feature Gating
-# =============================================================================
-
-[[case]]
-name = "comptime_requires_preview_flag"
-spec = ["4.13:1"]
-source = """
-fn main() -> i32 {
-    comptime { 42 }
-}
-"""
-compile_fail = true
-error_contains = "requires preview feature"
-
-[[case]]
-name = "comptime_error_includes_help"
-spec = ["4.13:1"]
-source = """
-fn main() -> i32 {
-    comptime { 1 + 2 }
-}
-"""
-compile_fail = true
-error_contains = "--preview comptime"
-
-# =============================================================================
 # Basic Comptime Expressions
 # =============================================================================
 
 [[case]]
 name = "comptime_integer_literal"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     comptime { 42 }
@@ -54,8 +25,6 @@ exit_code = 42
 [[case]]
 name = "comptime_addition"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     comptime { 1 + 2 + 3 }
@@ -66,8 +35,6 @@ exit_code = 6
 [[case]]
 name = "comptime_complex_arithmetic"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     comptime { 1 + 2 * 3 }
@@ -78,8 +45,6 @@ exit_code = 7
 [[case]]
 name = "comptime_subtraction"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     comptime { 10 - 3 }
@@ -90,8 +55,6 @@ exit_code = 7
 [[case]]
 name = "comptime_multiplication"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     comptime { 6 * 7 }
@@ -102,8 +65,6 @@ exit_code = 42
 [[case]]
 name = "comptime_division"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     comptime { 84 / 2 }
@@ -114,8 +75,6 @@ exit_code = 42
 [[case]]
 name = "comptime_modulo"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     comptime { 47 % 5 }
@@ -126,8 +85,6 @@ exit_code = 2
 [[case]]
 name = "comptime_boolean_true"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     if comptime { true } { 42 } else { 0 }
@@ -138,8 +95,6 @@ exit_code = 42
 [[case]]
 name = "comptime_boolean_false"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     if comptime { false } { 0 } else { 42 }
@@ -150,8 +105,6 @@ exit_code = 42
 [[case]]
 name = "comptime_comparison"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     if comptime { 10 > 5 } { 42 } else { 0 }
@@ -162,8 +115,6 @@ exit_code = 42
 [[case]]
 name = "comptime_equality"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     if comptime { 5 == 5 } { 42 } else { 0 }
@@ -174,8 +125,6 @@ exit_code = 42
 [[case]]
 name = "comptime_logical_and"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     if comptime { true && true } { 42 } else { 0 }
@@ -186,8 +135,6 @@ exit_code = 42
 [[case]]
 name = "comptime_logical_or"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     if comptime { false || true } { 42 } else { 0 }
@@ -198,8 +145,6 @@ exit_code = 42
 [[case]]
 name = "comptime_bitwise_and"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     comptime { 255 & 15 }
@@ -210,8 +155,6 @@ exit_code = 15
 [[case]]
 name = "comptime_bitwise_or"
 spec = ["4.13:2"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     comptime { 240 | 15 }
@@ -222,8 +165,6 @@ exit_code = 255
 [[case]]
 name = "comptime_in_let_binding"
 spec = ["4.13:3"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let x: i32 = comptime { 21 * 2 };
@@ -239,8 +180,6 @@ exit_code = 42
 [[case]]
 name = "comptime_cannot_use_runtime_variable"
 spec = ["4.13:4"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let x = 10;
@@ -253,8 +192,6 @@ error_contains = "cannot be known at compile time"
 [[case]]
 name = "comptime_cannot_call_function"
 spec = ["4.13:4"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn add(a: i32, b: i32) -> i32 { a + b }
 fn main() -> i32 {
@@ -269,22 +206,8 @@ error_contains = "cannot be known at compile time"
 # =============================================================================
 
 [[case]]
-name = "comptime_param_requires_preview_flag"
-spec = ["4.13:5"]
-source = """
-fn repeat(comptime n: i32, value: i32) -> i32 { n + value }
-fn main() -> i32 {
-    repeat(3, 10)
-}
-"""
-compile_fail = true
-error_contains = "requires preview feature"
-
-[[case]]
 name = "comptime_param_basic"
 spec = ["4.13:5"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn multiply(comptime n: i32, value: i32) -> i32 {
     n * value
@@ -298,8 +221,6 @@ exit_code = 42
 [[case]]
 name = "comptime_param_with_literal"
 spec = ["4.13:5"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn add_constant(comptime c: i32, x: i32) -> i32 {
     c + x
@@ -313,8 +234,6 @@ exit_code = 42
 [[case]]
 name = "comptime_param_multiple"
 spec = ["4.13:5"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn compute(comptime a: i32, comptime b: i32, x: i32) -> i32 {
     a * b + x
@@ -328,8 +247,6 @@ exit_code = 42
 [[case]]
 name = "comptime_param_runtime_arg_error"
 spec = ["4.13:6"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn double(comptime n: i32) -> i32 { n * 2 }
 fn main() -> i32 {
@@ -343,8 +260,6 @@ error_contains = "comptime parameter requires a compile-time known value"
 [[case]]
 name = "comptime_param_function_call_arg_error"
 spec = ["4.13:6"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn get_value() -> i32 { 5 }
 fn scale(comptime factor: i32, value: i32) -> i32 { factor * value }
@@ -358,8 +273,6 @@ error_contains = "comptime parameter requires a compile-time known value"
 [[case]]
 name = "comptime_param_comptime_expr_ok"
 spec = ["4.13:5"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn triple(comptime n: i32) -> i32 { n * 3 }
 fn main() -> i32 {
@@ -371,8 +284,6 @@ exit_code = 42
 [[case]]
 name = "comptime_param_mixed_with_normal"
 spec = ["4.13:5"]
-preview = "comptime"
-preview_should_pass = true
 source = """
 fn offset(x: i32, comptime delta: i32, y: i32) -> i32 {
     x + delta + y
@@ -395,11 +306,9 @@ exit_code = 42
 [[case]]
 name = "type_as_type_name_can_be_resolved"
 spec = ["4.13:5"]
-preview = "comptime"
 description = "The keyword 'type' can be used as a type annotation"
 source = """
 // Simple test: `type` as a type name is parsed correctly
-// This will fail until comptime parameters are fully implemented
 fn identity(comptime T: type, x: T) -> T {
     x
 }
@@ -412,7 +321,6 @@ exit_code = 42
 [[case]]
 name = "generic_function_with_i32"
 spec = ["4.13:5"]
-preview = "comptime"
 description = "Generic identity function specialized for i32"
 source = """
 fn identity(comptime T: type, x: T) -> T {
@@ -427,7 +335,6 @@ exit_code = 42
 [[case]]
 name = "generic_function_with_bool"
 spec = ["4.13:5"]
-preview = "comptime"
 description = "Generic identity function specialized for bool"
 source = """
 fn identity(comptime T: type, x: T) -> T {
@@ -442,7 +349,6 @@ exit_code = 42
 [[case]]
 name = "generic_max_function"
 spec = ["4.13:5"]
-preview = "comptime"
 description = "The ADR example: generic max function"
 source = """
 fn max(comptime T: type, a: T, b: T) -> T {
@@ -457,7 +363,6 @@ exit_code = 20
 [[case]]
 name = "generic_function_multiple_calls_same_type"
 spec = ["4.13:5"]
-preview = "comptime"
 description = "Multiple calls to generic function with same type reuse specialization"
 source = """
 fn identity(comptime T: type, x: T) -> T {
@@ -474,7 +379,6 @@ exit_code = 42
 [[case]]
 name = "generic_function_multiple_types"
 spec = ["4.13:5"]
-preview = "comptime"
 description = "Generic function called with different types creates separate specializations"
 source = """
 fn identity(comptime T: type, x: T) -> T {
@@ -491,7 +395,6 @@ exit_code = 42
 [[case]]
 name = "type_parameter_in_arithmetic"
 spec = ["4.13:5"]
-preview = "comptime"
 description = "Type parameter used with arithmetic operators"
 source = """
 fn add_one(comptime T: type, x: T) -> T {
@@ -506,8 +409,6 @@ exit_code = 42
 [[case]]
 name = "type_value_cannot_escape_comptime"
 spec = ["4.13:6"]
-preview = "comptime"
-# Not preview_should_pass yet - requires type-as-expression parsing which is Phase 4
 description = "Type values cannot exist at runtime"
 source = """
 fn main() -> i32 {
@@ -528,14 +429,10 @@ error_contains = "type values cannot exist at runtime"
 # 2. Anonymous structs can be returned from functions returning `type`
 # 3. Structural type equality: two structs with same fields are the same type
 # 4. Anonymous structs can be instantiated and used
-#
-# NOTE: These tests depend on Phase 3 (type parameters with comptime T: type)
-# which is not yet complete. Tests are marked as preview without preview_should_pass.
 
 [[case]]
 name = "anon_struct_basic"
 spec = ["4.13:7"]
-preview = "comptime"
 description = "Basic anonymous struct type syntax"
 source = """
 fn make_point() -> type {
@@ -552,7 +449,6 @@ exit_code = 42
 [[case]]
 name = "anon_struct_single_field"
 spec = ["4.13:7"]
-preview = "comptime"
 description = "Anonymous struct with single field"
 source = """
 fn wrapper() -> type {
@@ -569,7 +465,6 @@ exit_code = 42
 [[case]]
 name = "anon_struct_generic_pair"
 spec = ["4.13:7"]
-preview = "comptime"
 description = "Generic Pair type constructor - ADR deliverable example"
 source = """
 fn Pair(comptime T: type) -> type {
@@ -586,7 +481,6 @@ exit_code = 42
 [[case]]
 name = "anon_struct_structural_equality"
 spec = ["4.13:8"]
-preview = "comptime"
 description = "Two anonymous structs with same fields are structurally equal"
 source = """
 fn make_point1() -> type {
@@ -609,7 +503,6 @@ exit_code = 30
 [[case]]
 name = "anon_struct_different_fields_different_types"
 spec = ["4.13:8"]
-preview = "comptime"
 description = "Anonymous structs with different fields are different types"
 source = """
 fn make_xy() -> type {
@@ -631,7 +524,6 @@ exit_code = 42
 [[case]]
 name = "anon_struct_different_field_types"
 spec = ["4.13:8"]
-preview = "comptime"
 description = "Anonymous structs with different field types are different types"
 source = """
 fn make_i32_pair() -> type {
@@ -653,7 +545,6 @@ exit_code = 42
 [[case]]
 name = "anon_struct_nested"
 spec = ["4.13:7"]
-preview = "comptime"
 description = "Anonymous struct containing another struct type"
 source = """
 fn Point() -> type {
@@ -676,7 +567,6 @@ exit_code = 42
 [[case]]
 name = "anon_struct_empty_error"
 spec = ["4.13:9"]
-preview = "comptime"
 description = "Empty anonymous struct is not allowed"
 source = """
 fn empty() -> type {
@@ -692,7 +582,6 @@ error_contains = "empty struct"
 [[case]]
 name = "anon_struct_specialization_caching"
 spec = ["4.13:7"]
-preview = "comptime"
 description = "Multiple calls with same type reuse the same anonymous struct"
 source = """
 fn Wrapper(comptime T: type) -> type {
@@ -712,7 +601,6 @@ exit_code = 42
 [[case]]
 name = "anon_struct_method_like_function"
 spec = ["4.13:7"]
-preview = "comptime"
 description = "Using anonymous struct with a function that takes it"
 source = """
 fn Point() -> type {


### PR DESCRIPTION
Complete the comptime epic (rue-33lf) by fixing remaining 5 anonymous struct tests and removing the preview gate:

Phase 4 fixes (anonymous struct types):
- Add type substitution support in comptime evaluation for generic functions
- Fix comptime type variable lookup in analyze_var_ref to allow using let-bound comptime types (e.g., let P = Point()) as arguments
- Add try_evaluate_const_with_subst for evaluating comptime with substitutions
- Add is_comptime_type_var helper to check if a VarRef is a comptime type
- Add empty struct error (E0432) for 'struct { }' syntax

Stabilization:
- Remove PreviewFeature::Comptime variant
- Remove all require_preview(Comptime) gates from Sema
- Remove preview/preview_should_pass from comptime spec tests
- Remove tests that only tested 'requires preview feature' error

All 43 comptime tests now pass without --preview flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)