### PR TITLE
Add comptime chapter to spec (fixes #749)

### DIFF
--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -4,7 +4,7 @@
 
 [section]
 id = "expressions.comptime"
-spec_chapter = "4.13"
+spec_chapter = "4.14"
 name = "Compile-Time Execution"
 description = "Comptime blocks evaluate expressions at compile time."
 
@@ -14,7 +14,7 @@ description = "Comptime blocks evaluate expressions at compile time."
 
 [[case]]
 name = "comptime_integer_literal"
-spec = ["4.13:2"]
+spec = ["4.14:1", "4.14:2"]
 source = """
 fn main() -> i32 {
     comptime { 42 }
@@ -24,7 +24,7 @@ exit_code = 42
 
 [[case]]
 name = "comptime_addition"
-spec = ["4.13:2"]
+spec = ["4.14:2"]
 source = """
 fn main() -> i32 {
     comptime { 1 + 2 + 3 }
@@ -34,7 +34,7 @@ exit_code = 6
 
 [[case]]
 name = "comptime_complex_arithmetic"
-spec = ["4.13:2"]
+spec = ["4.14:2"]
 source = """
 fn main() -> i32 {
     comptime { 1 + 2 * 3 }
@@ -44,7 +44,7 @@ exit_code = 7
 
 [[case]]
 name = "comptime_subtraction"
-spec = ["4.13:2"]
+spec = ["4.14:2"]
 source = """
 fn main() -> i32 {
     comptime { 10 - 3 }
@@ -54,7 +54,7 @@ exit_code = 7
 
 [[case]]
 name = "comptime_multiplication"
-spec = ["4.13:2"]
+spec = ["4.14:2"]
 source = """
 fn main() -> i32 {
     comptime { 6 * 7 }
@@ -64,7 +64,7 @@ exit_code = 42
 
 [[case]]
 name = "comptime_division"
-spec = ["4.13:2"]
+spec = ["4.14:2"]
 source = """
 fn main() -> i32 {
     comptime { 84 / 2 }
@@ -74,7 +74,7 @@ exit_code = 42
 
 [[case]]
 name = "comptime_modulo"
-spec = ["4.13:2"]
+spec = ["4.14:2"]
 source = """
 fn main() -> i32 {
     comptime { 47 % 5 }
@@ -84,7 +84,7 @@ exit_code = 2
 
 [[case]]
 name = "comptime_boolean_true"
-spec = ["4.13:2"]
+spec = ["4.14:2"]
 source = """
 fn main() -> i32 {
     if comptime { true } { 42 } else { 0 }
@@ -94,7 +94,7 @@ exit_code = 42
 
 [[case]]
 name = "comptime_boolean_false"
-spec = ["4.13:2"]
+spec = ["4.14:2"]
 source = """
 fn main() -> i32 {
     if comptime { false } { 0 } else { 42 }
@@ -104,7 +104,7 @@ exit_code = 42
 
 [[case]]
 name = "comptime_comparison"
-spec = ["4.13:2"]
+spec = ["4.14:2"]
 source = """
 fn main() -> i32 {
     if comptime { 10 > 5 } { 42 } else { 0 }
@@ -114,7 +114,7 @@ exit_code = 42
 
 [[case]]
 name = "comptime_equality"
-spec = ["4.13:2"]
+spec = ["4.14:2"]
 source = """
 fn main() -> i32 {
     if comptime { 5 == 5 } { 42 } else { 0 }
@@ -124,7 +124,7 @@ exit_code = 42
 
 [[case]]
 name = "comptime_logical_and"
-spec = ["4.13:2"]
+spec = ["4.14:2"]
 source = """
 fn main() -> i32 {
     if comptime { true && true } { 42 } else { 0 }
@@ -134,7 +134,7 @@ exit_code = 42
 
 [[case]]
 name = "comptime_logical_or"
-spec = ["4.13:2"]
+spec = ["4.14:2"]
 source = """
 fn main() -> i32 {
     if comptime { false || true } { 42 } else { 0 }
@@ -144,7 +144,7 @@ exit_code = 42
 
 [[case]]
 name = "comptime_bitwise_and"
-spec = ["4.13:2"]
+spec = ["4.14:2"]
 source = """
 fn main() -> i32 {
     comptime { 255 & 15 }
@@ -154,7 +154,7 @@ exit_code = 15
 
 [[case]]
 name = "comptime_bitwise_or"
-spec = ["4.13:2"]
+spec = ["4.14:2"]
 source = """
 fn main() -> i32 {
     comptime { 240 | 15 }
@@ -164,7 +164,7 @@ exit_code = 255
 
 [[case]]
 name = "comptime_in_let_binding"
-spec = ["4.13:3"]
+spec = ["4.14:3"]
 source = """
 fn main() -> i32 {
     let x: i32 = comptime { 21 * 2 };
@@ -179,7 +179,7 @@ exit_code = 42
 
 [[case]]
 name = "comptime_cannot_use_runtime_variable"
-spec = ["4.13:4"]
+spec = ["4.14:4"]
 source = """
 fn main() -> i32 {
     let x = 10;
@@ -191,7 +191,7 @@ error_contains = "cannot be known at compile time"
 
 [[case]]
 name = "comptime_cannot_call_function"
-spec = ["4.13:4"]
+spec = ["4.14:4"]
 source = """
 fn add(a: i32, b: i32) -> i32 { a + b }
 fn main() -> i32 {
@@ -207,7 +207,7 @@ error_contains = "cannot be known at compile time"
 
 [[case]]
 name = "comptime_param_basic"
-spec = ["4.13:5"]
+spec = ["4.14:5"]
 source = """
 fn multiply(comptime n: i32, value: i32) -> i32 {
     n * value
@@ -220,7 +220,7 @@ exit_code = 42
 
 [[case]]
 name = "comptime_param_with_literal"
-spec = ["4.13:5"]
+spec = ["4.14:5"]
 source = """
 fn add_constant(comptime c: i32, x: i32) -> i32 {
     c + x
@@ -233,7 +233,7 @@ exit_code = 42
 
 [[case]]
 name = "comptime_param_multiple"
-spec = ["4.13:5"]
+spec = ["4.14:5"]
 source = """
 fn compute(comptime a: i32, comptime b: i32, x: i32) -> i32 {
     a * b + x
@@ -246,7 +246,7 @@ exit_code = 42
 
 [[case]]
 name = "comptime_param_runtime_arg_error"
-spec = ["4.13:6"]
+spec = ["4.14:6"]
 source = """
 fn double(comptime n: i32) -> i32 { n * 2 }
 fn main() -> i32 {
@@ -259,7 +259,7 @@ error_contains = "comptime parameter requires a compile-time known value"
 
 [[case]]
 name = "comptime_param_function_call_arg_error"
-spec = ["4.13:6"]
+spec = ["4.14:6"]
 source = """
 fn get_value() -> i32 { 5 }
 fn scale(comptime factor: i32, value: i32) -> i32 { factor * value }
@@ -272,7 +272,7 @@ error_contains = "comptime parameter requires a compile-time known value"
 
 [[case]]
 name = "comptime_param_comptime_expr_ok"
-spec = ["4.13:5"]
+spec = ["4.14:5"]
 source = """
 fn triple(comptime n: i32) -> i32 { n * 3 }
 fn main() -> i32 {
@@ -283,7 +283,7 @@ exit_code = 42
 
 [[case]]
 name = "comptime_param_mixed_with_normal"
-spec = ["4.13:5"]
+spec = ["4.14:5"]
 source = """
 fn offset(x: i32, comptime delta: i32, y: i32) -> i32 {
     x + delta + y
@@ -305,7 +305,7 @@ exit_code = 42
 
 [[case]]
 name = "type_as_type_name_can_be_resolved"
-spec = ["4.13:5"]
+spec = ["4.14:5"]
 description = "The keyword 'type' can be used as a type annotation"
 source = """
 // Simple test: `type` as a type name is parsed correctly
@@ -320,7 +320,7 @@ exit_code = 42
 
 [[case]]
 name = "generic_function_with_i32"
-spec = ["4.13:5"]
+spec = ["4.14:5"]
 description = "Generic identity function specialized for i32"
 source = """
 fn identity(comptime T: type, x: T) -> T {
@@ -334,7 +334,7 @@ exit_code = 42
 
 [[case]]
 name = "generic_function_with_bool"
-spec = ["4.13:5"]
+spec = ["4.14:5"]
 description = "Generic identity function specialized for bool"
 source = """
 fn identity(comptime T: type, x: T) -> T {
@@ -348,7 +348,7 @@ exit_code = 42
 
 [[case]]
 name = "generic_max_function"
-spec = ["4.13:5"]
+spec = ["4.14:5"]
 description = "The ADR example: generic max function"
 source = """
 fn max(comptime T: type, a: T, b: T) -> T {
@@ -362,7 +362,7 @@ exit_code = 20
 
 [[case]]
 name = "generic_function_multiple_calls_same_type"
-spec = ["4.13:5"]
+spec = ["4.14:5"]
 description = "Multiple calls to generic function with same type reuse specialization"
 source = """
 fn identity(comptime T: type, x: T) -> T {
@@ -378,7 +378,7 @@ exit_code = 42
 
 [[case]]
 name = "generic_function_multiple_types"
-spec = ["4.13:5"]
+spec = ["4.14:5"]
 description = "Generic function called with different types creates separate specializations"
 source = """
 fn identity(comptime T: type, x: T) -> T {
@@ -394,7 +394,7 @@ exit_code = 42
 
 [[case]]
 name = "type_parameter_in_arithmetic"
-spec = ["4.13:5"]
+spec = ["4.14:5"]
 description = "Type parameter used with arithmetic operators"
 source = """
 fn add_one(comptime T: type, x: T) -> T {
@@ -408,7 +408,7 @@ exit_code = 42
 
 [[case]]
 name = "type_value_cannot_escape_comptime"
-spec = ["4.13:6"]
+spec = ["4.14:6"]
 description = "Type values cannot exist at runtime"
 source = """
 fn main() -> i32 {
@@ -432,7 +432,7 @@ error_contains = "type values cannot exist at runtime"
 
 [[case]]
 name = "anon_struct_basic"
-spec = ["4.13:7"]
+spec = ["4.14:7"]
 description = "Basic anonymous struct type syntax"
 source = """
 fn make_point() -> type {
@@ -448,7 +448,7 @@ exit_code = 42
 
 [[case]]
 name = "anon_struct_single_field"
-spec = ["4.13:7"]
+spec = ["4.14:7"]
 description = "Anonymous struct with single field"
 source = """
 fn wrapper() -> type {
@@ -464,7 +464,7 @@ exit_code = 42
 
 [[case]]
 name = "anon_struct_generic_pair"
-spec = ["4.13:7"]
+spec = ["4.14:7"]
 description = "Generic Pair type constructor - ADR deliverable example"
 source = """
 fn Pair(comptime T: type) -> type {
@@ -480,7 +480,7 @@ exit_code = 42
 
 [[case]]
 name = "anon_struct_structural_equality"
-spec = ["4.13:8"]
+spec = ["4.14:8"]
 description = "Two anonymous structs with same fields are structurally equal"
 source = """
 fn make_point1() -> type {
@@ -502,7 +502,7 @@ exit_code = 30
 
 [[case]]
 name = "anon_struct_different_fields_different_types"
-spec = ["4.13:8"]
+spec = ["4.14:8"]
 description = "Anonymous structs with different fields are different types"
 source = """
 fn make_xy() -> type {
@@ -523,7 +523,7 @@ exit_code = 42
 
 [[case]]
 name = "anon_struct_different_field_types"
-spec = ["4.13:8"]
+spec = ["4.14:8"]
 description = "Anonymous structs with different field types are different types"
 source = """
 fn make_i32_pair() -> type {
@@ -544,7 +544,7 @@ exit_code = 42
 
 [[case]]
 name = "anon_struct_nested"
-spec = ["4.13:7"]
+spec = ["4.14:7"]
 description = "Anonymous struct containing another struct type"
 source = """
 fn Point() -> type {
@@ -566,7 +566,7 @@ exit_code = 42
 
 [[case]]
 name = "anon_struct_empty_error"
-spec = ["4.13:9"]
+spec = ["4.14:9"]
 description = "Empty anonymous struct is not allowed"
 source = """
 fn empty() -> type {
@@ -581,7 +581,7 @@ error_contains = "empty struct"
 
 [[case]]
 name = "anon_struct_specialization_caching"
-spec = ["4.13:7"]
+spec = ["4.14:7"]
 description = "Multiple calls with same type reuse the same anonymous struct"
 source = """
 fn Wrapper(comptime T: type) -> type {
@@ -600,7 +600,7 @@ exit_code = 42
 
 [[case]]
 name = "anon_struct_method_like_function"
-spec = ["4.13:7"]
+spec = ["4.14:7"]
 description = "Using anonymous struct with a function that takes it"
 source = """
 fn Point() -> type {

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -1,0 +1,180 @@
++++
+title = "Compile-Time Expressions"
+weight = 14
+template = "spec/page.html"
++++
+
+# Compile-Time Expressions
+
+{{ rule(id="4.14:1", cat="normative") }}
+
+A compile-time expression is an expression marked with the `comptime` keyword that **MUST** be fully evaluated at compile time.
+
+{{ rule(id="4.14:2", cat="normative") }}
+
+```ebnf
+comptime_expr = "comptime" "{" expression "}" ;
+```
+
+The expression inside a comptime block is evaluated during compilation. The following operations are supported within comptime blocks:
+
+- Integer literals
+- Boolean literals (`true`, `false`)
+- Arithmetic operators (`+`, `-`, `*`, `/`, `%`)
+- Comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`)
+- Logical operators (`&&`, `||`, `!`)
+- Bitwise operators (`&`, `|`, `^`, `<<`, `>>`)
+
+{{ rule(id="4.14:3", cat="normative") }}
+
+A comptime expression can be used anywhere an expression is expected. The result of the comptime evaluation replaces the comptime block.
+
+```rue
+fn main() -> i32 {
+    let x: i32 = comptime { 21 * 2 };
+    x
+}
+```
+
+## Comptime Restrictions
+
+{{ rule(id="4.14:4", cat="legality-rule") }}
+
+It is a compile-time error if an expression inside a comptime block cannot be evaluated at compile time. This includes:
+
+- References to runtime variables
+- Function calls (except to comptime-evaluable functions in future versions)
+- Operations that would panic at runtime
+
+```rue
+fn main() -> i32 {
+    let x = 10;
+    comptime { x + 1 }  // ERROR: x cannot be known at compile time
+}
+```
+
+## Comptime Parameters
+
+{{ rule(id="4.14:5", cat="normative") }}
+
+Function parameters can be marked with `comptime`, requiring the caller to provide a compile-time known value. The parameter's value is available as a compile-time constant within the function body.
+
+```ebnf
+parameter = [ "comptime" ] IDENT ":" type ;
+```
+
+Comptime parameters can have any type, including the special `type` type (see below).
+
+```rue
+fn multiply(comptime n: i32, value: i32) -> i32 {
+    n * value
+}
+
+fn main() -> i32 {
+    multiply(6, 7)  // n is known at compile time
+}
+```
+
+Comptime parameters enable monomorphization: each unique combination of comptime arguments creates a specialized version of the function.
+
+The keyword `type` is a comptime-only type whose values are types themselves. A parameter of type `type` must be marked `comptime`.
+
+```rue
+fn identity(comptime T: type, x: T) -> T {
+    x
+}
+
+fn main() -> i32 {
+    identity(i32, 42)
+}
+```
+
+When a function has a `comptime T: type` parameter, occurrences of `T` in parameter types and return types are substituted with the concrete type at each call site.
+
+{{ rule(id="4.14:6", cat="legality-rule") }}
+
+It is a compile-time error to pass a runtime value to a comptime parameter.
+
+```rue
+fn double(comptime n: i32) -> i32 { n * 2 }
+
+fn main() -> i32 {
+    let x = 21;
+    double(x)  // ERROR: comptime parameter requires a compile-time known value
+}
+```
+
+Type values cannot exist at runtime. It is a compile-time error to attempt to store a type value in a runtime variable.
+
+```rue
+fn main() -> i32 {
+    let t = comptime { i32 };  // ERROR: type values cannot exist at runtime
+    0
+}
+```
+
+## Anonymous Struct Types
+
+{{ rule(id="4.14:7", cat="normative") }}
+
+A comptime function that returns `type` can construct an anonymous struct type using the following syntax:
+
+```ebnf
+anon_struct_type = "struct" "{" struct_field { "," struct_field } "}" ;
+struct_field = IDENT ":" type ;
+```
+
+```rue
+fn Point() -> type {
+    struct { x: i32, y: i32 }
+}
+
+fn main() -> i32 {
+    let P = Point();
+    let p: P = P { x: 10, y: 32 };
+    p.x + p.y
+}
+```
+
+Anonymous structs can be parameterized using comptime type parameters:
+
+```rue
+fn Pair(comptime T: type) -> type {
+    struct { first: T, second: T }
+}
+
+fn main() -> i32 {
+    let IntPair = Pair(i32);
+    let p: IntPair = IntPair { first: 20, second: 22 };
+    p.first + p.second
+}
+```
+
+{{ rule(id="4.14:8", cat="normative") }}
+
+Two anonymous struct types are structurally equal if and only if they have the same field names in the same order with the same types.
+
+```rue
+fn make_point1() -> type { struct { x: i32, y: i32 } }
+fn make_point2() -> type { struct { x: i32, y: i32 } }
+
+fn main() -> i32 {
+    let P1 = make_point1();
+    let P2 = make_point2();
+    let p1: P1 = P1 { x: 10, y: 20 };
+    let p2: P2 = p1;  // OK: P1 and P2 are structurally equal
+    p2.x + p2.y
+}
+```
+
+Anonymous structs with different field names or different field types are different types and are not assignable to each other.
+
+{{ rule(id="4.14:9", cat="legality-rule") }}
+
+It is a compile-time error to define an anonymous struct type with no fields.
+
+```rue
+fn empty() -> type {
+    struct { }  // ERROR: empty struct
+}
+```


### PR DESCRIPTION
The comptime spec tests referenced chapter 4.13, but that chapter was actually 'Intrinsic Expressions'. This adds the missing chapter 4.14 'Compile-Time Expressions' and updates all test references.

The new spec chapter covers:
- Comptime block syntax and supported operations
- Comptime restrictions (runtime variables, function calls)
- Comptime parameters (value and type parameters)
- The 'type' type
- Anonymous struct types and structural equality

🤖 Generated with [Claude Code](https://claude.com/claude-code)