### PR TITLE
Implement directory module resolution (Phase 2)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -7259,8 +7259,11 @@ impl<'a> Sema<'a> {
         };
 
         // Resolve the import path relative to the current source file
-        // For now, we just use the import_path as-is since module resolution is simple
-        let resolved_path = import_path.clone();
+        // Resolution order (per ADR-0026):
+        // 1. foo.rue (simple file module)
+        // 2. _foo.rue with foo/ directory (directory module)
+        // 3. (Future) Dependency from rue.toml
+        let resolved_path = self.resolve_import_path(&import_path, span)?;
 
         // Get or create the module in the registry
         // The module will be populated lazily when member access is performed
@@ -7277,6 +7280,92 @@ impl<'a> Sema<'a> {
             span,
         });
         Ok(AnalysisResult::new(air_ref, Type::Module(module_id)))
+    }
+
+    /// Resolve an import path to an absolute file path.
+    ///
+    /// Resolution order (per ADR-0026):
+    /// 1. `foo.rue` (simple file module) - if import path already ends in .rue
+    /// 2. `foo.rue` (simple file module) - try adding .rue extension
+    /// 3. `_foo.rue` with `foo/` directory (directory module)
+    /// 4. (Future) Dependency from rue.toml
+    fn resolve_import_path(&self, import_path: &str, span: Span) -> CompileResult<String> {
+        use std::path::Path;
+
+        // Phase 1: Check if the import path matches an already-loaded file
+        // This handles unit tests and multi-file compilation where all files are pre-loaded
+        for (_file_id, path) in &self.file_paths {
+            // Check for exact match
+            if path == import_path {
+                return Ok(path.clone());
+            }
+            // Check if the file path ends with the import path (handles relative imports)
+            if path.ends_with(import_path) {
+                return Ok(path.clone());
+            }
+            // For imports like "math" or "math.rue", check if the file is named accordingly
+            let import_base = import_path.strip_suffix(".rue").unwrap_or(import_path);
+            let file_name = Path::new(path).file_stem().and_then(|s| s.to_str());
+            if let Some(name) = file_name {
+                if name == import_base {
+                    return Ok(path.clone());
+                }
+            }
+        }
+
+        // Phase 2: Try to find the file on disk (for directory modules and actual file imports)
+        // Get the directory of the current source file
+        let source_path = self.get_source_path(span);
+        let source_dir = source_path
+            .and_then(|p| Path::new(p).parent())
+            .unwrap_or(Path::new("."));
+
+        let mut candidates = Vec::new();
+
+        // Strip .rue extension if present for base name calculation
+        let base_name = import_path.strip_suffix(".rue").unwrap_or(import_path);
+
+        // Resolution order:
+        // 1. Try foo.rue (simple file module)
+        let file_candidate = source_dir.join(format!("{}.rue", base_name));
+        candidates.push(file_candidate.display().to_string());
+        if file_candidate.exists() {
+            return Ok(file_candidate.to_string_lossy().to_string());
+        }
+
+        // 2. If the path already ends in .rue, also try it directly
+        if import_path.ends_with(".rue") {
+            let candidate = source_dir.join(import_path);
+            if !candidates.contains(&candidate.display().to_string()) {
+                candidates.push(candidate.display().to_string());
+            }
+            if candidate.exists() {
+                return Ok(candidate.to_string_lossy().to_string());
+            }
+        }
+
+        // 3. Try _foo.rue + foo/ directory (directory module)
+        let dir_module_root = source_dir.join(format!("_{}.rue", base_name));
+        let dir_path = source_dir.join(base_name);
+        candidates.push(format!("{} + {}/", dir_module_root.display(), base_name));
+        if dir_module_root.exists() && dir_path.is_dir() {
+            return Ok(dir_module_root.to_string_lossy().to_string());
+        }
+
+        // 3b. Also try just _foo.rue without requiring foo/ directory
+        // (This allows directory modules where all submodules are re-exported)
+        if dir_module_root.exists() {
+            return Ok(dir_module_root.to_string_lossy().to_string());
+        }
+
+        // Module not found - report error with candidates tried
+        Err(CompileError::new(
+            ErrorKind::ModuleNotFound {
+                path: import_path.to_string(),
+                candidates,
+            },
+            span,
+        ))
     }
 
     // Note: The old analyze_inst body from here onwards is now handled by the

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -35,6 +35,7 @@ use std::collections::HashMap;
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileErrors, MultiErrorResult, PreviewFeatures};
 use rue_rir::Rir;
+use rue_span::FileId;
 
 use crate::intern_pool::TypeInternPool;
 use crate::sema_context::{InferenceContext as SemaContextInferenceContext, SemaContext};
@@ -114,6 +115,7 @@ impl<'a> GatherOutput<'a> {
             known: KnownSymbols::new(self.interner),
             type_pool: self.type_pool,
             module_registry: crate::sema_context::ModuleRegistry::new(),
+            file_paths: HashMap::new(),
         }
     }
 }
@@ -246,6 +248,9 @@ pub struct Sema<'a> {
     pub(crate) type_pool: TypeInternPool,
     /// Module registry for tracking imported modules (Phase 1 modules).
     pub(crate) module_registry: crate::sema_context::ModuleRegistry,
+    /// Maps FileId to source file paths (for module resolution).
+    /// Used to resolve relative imports when compiling multiple files.
+    pub(crate) file_paths: HashMap<FileId, String>,
 }
 
 impl<'a> Sema<'a> {
@@ -267,7 +272,23 @@ impl<'a> Sema<'a> {
             known: KnownSymbols::new(interner),
             type_pool: TypeInternPool::new(),
             module_registry: crate::sema_context::ModuleRegistry::new(),
+            file_paths: HashMap::new(),
         }
+    }
+
+    /// Set file paths for module resolution in multi-file compilation.
+    ///
+    /// This maps FileIds to their corresponding source file paths,
+    /// enabling relative import resolution during @import.
+    pub fn set_file_paths(&mut self, file_paths: HashMap<FileId, String>) {
+        self.file_paths = file_paths;
+    }
+
+    /// Get the source file path for a span.
+    ///
+    /// Looks up the file path using the span's file_id.
+    pub(crate) fn get_source_path(&self, span: rue_span::Span) -> Option<&str> {
+        self.file_paths.get(&span.file_id).map(|s| s.as_str())
     }
 
     /// Perform semantic analysis on the RIR.
@@ -426,6 +447,7 @@ impl<'a> Sema<'a> {
             type_pool: self.type_pool.clone(),
             module_registry: crate::sema_context::ModuleRegistry::new(),
             source_file_path: None, // Will be set when analyzing specific files
+            file_paths: self.file_paths.clone(), // Copy file paths for module resolution
         }
     }
 

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -215,9 +215,12 @@ pub struct SemaContext<'a> {
     /// Thread-safe module registry.
     /// Supports concurrent lookups and insertions during parallel analysis.
     pub module_registry: ModuleRegistry,
-    /// Path to the current source file being compiled.
-    /// Used for resolving relative imports.
+    /// Path to the current source file being compiled (single-file mode).
+    /// Used for resolving relative imports when only one file is compiled.
     pub source_file_path: Option<String>,
+    /// Maps FileId to source file paths (multi-file mode).
+    /// Used for resolving relative imports when multiple files are compiled.
+    pub file_paths: HashMap<rue_span::FileId, String>,
 }
 
 // SAFETY: SemaContext is Send + Sync because:
@@ -306,6 +309,19 @@ impl<'a> SemaContext<'a> {
     /// Update a module definition with populated declarations.
     pub fn update_module_def(&self, id: ModuleId, def: ModuleDef) {
         self.module_registry.update_def(id, def);
+    }
+
+    /// Get the source file path for a span.
+    ///
+    /// Looks up the file path using the span's file_id. Falls back to
+    /// `source_file_path` for single-file compilation mode.
+    pub fn get_source_path(&self, span: rue_span::Span) -> Option<&str> {
+        // First, try the file_paths map (multi-file mode)
+        if let Some(path) = self.file_paths.get(&span.file_id) {
+            return Some(path.as_str());
+        }
+        // Fall back to source_file_path (single-file mode)
+        self.source_file_path.as_deref()
     }
 
     /// Get a human-readable name for a type.

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -325,6 +325,8 @@ pub struct ValidatedProgram {
     pub rir: Rir,
     /// Merged interner containing all symbols from all files.
     pub interner: ThreadedRodeo,
+    /// Maps FileId to source file path (for module resolution).
+    pub file_paths: std::collections::HashMap<FileId, String>,
 }
 
 /// Information about a symbol definition for duplicate detection.
@@ -542,6 +544,13 @@ pub fn validate_and_generate_rir_parallel(
     )
     .entered();
 
+    // Step 0: Build file_id -> path mapping for module resolution
+    let file_paths: HashMap<FileId, String> = program
+        .files
+        .iter()
+        .map(|f| (f.file_id, f.path.clone()))
+        .collect();
+
     // Step 1: Validate symbols for duplicates (same logic as merge_symbols)
     let mut functions: HashMap<String, SymbolDef> = HashMap::new();
     let mut structs: HashMap<String, SymbolDef> = HashMap::new();
@@ -684,7 +693,11 @@ pub fn validate_and_generate_rir_parallel(
 
     info!(instruction_count = rir.len(), "RIR generation complete");
 
-    Ok(ValidatedProgram { rir, interner })
+    Ok(ValidatedProgram {
+        rir,
+        interner,
+        file_paths,
+    })
 }
 
 /// Which linker to use for the final linking phase.
@@ -988,10 +1001,31 @@ pub fn compile_frontend_from_rir_with_options(
     opt_level: OptLevel,
     preview_features: &PreviewFeatures,
 ) -> MultiErrorResult<CompileStateFromRir> {
+    compile_frontend_from_rir_with_file_paths(
+        rir,
+        interner,
+        opt_level,
+        preview_features,
+        std::collections::HashMap::new(),
+    )
+}
+
+/// Compile frontend from RIR with file paths for module resolution.
+///
+/// This is the full version that accepts file_id -> path mapping for
+/// multi-file compilation with module imports.
+pub fn compile_frontend_from_rir_with_file_paths(
+    rir: Rir,
+    interner: ThreadedRodeo,
+    opt_level: OptLevel,
+    preview_features: &PreviewFeatures,
+    file_paths: std::collections::HashMap<FileId, String>,
+) -> MultiErrorResult<CompileStateFromRir> {
     // Semantic analysis (RIR to AIR)
     let sema_output = {
         let _span = info_span!("sema").entered();
-        let sema = Sema::new(&rir, &interner, preview_features.clone());
+        let mut sema = Sema::new(&rir, &interner, preview_features.clone());
+        sema.set_file_paths(file_paths);
         let output = sema.analyze_all()?;
         info!(
             function_count = output.functions.len(),
@@ -1180,12 +1214,13 @@ pub fn compile_multi_file_with_options(
     // This is faster than the sequential path for multi-file projects
     let validated = validate_and_generate_rir_parallel(parsed)?;
 
-    // Compile from the merged RIR
-    let state = compile_frontend_from_rir_with_options(
+    // Compile from the merged RIR (with file paths for module resolution)
+    let state = compile_frontend_from_rir_with_file_paths(
         validated.rir,
         validated.interner,
         options.opt_level,
         &options.preview_features,
+        validated.file_paths,
     )?;
 
     // Check for main function

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -139,6 +139,7 @@ impl ErrorCode {
     pub const INTRINSIC_WRONG_ARG_COUNT: Self = Self(701);
     pub const INTRINSIC_TYPE_MISMATCH: Self = Self(702);
     pub const IMPORT_REQUIRES_STRING_LITERAL: Self = Self(703);
+    pub const MODULE_NOT_FOUND: Self = Self(704);
 
     // ========================================================================
     // Literal/operator errors (E0800-E0899)
@@ -947,6 +948,12 @@ pub enum ErrorKind {
     // Module errors
     #[error("@import requires a string literal argument")]
     ImportRequiresStringLiteral,
+    #[error("cannot find module '{path}'")]
+    ModuleNotFound {
+        path: String,
+        /// Candidates that were tried (for error message)
+        candidates: Vec<String>,
+    },
 
     // Literal errors
     #[error("literal value {value} is out of range for type '{ty}'")]
@@ -1081,6 +1088,7 @@ impl ErrorKind {
             ErrorKind::IntrinsicWrongArgCount { .. } => ErrorCode::INTRINSIC_WRONG_ARG_COUNT,
             ErrorKind::IntrinsicTypeMismatch(_) => ErrorCode::INTRINSIC_TYPE_MISMATCH,
             ErrorKind::ImportRequiresStringLiteral => ErrorCode::IMPORT_REQUIRES_STRING_LITERAL,
+            ErrorKind::ModuleNotFound { .. } => ErrorCode::MODULE_NOT_FOUND,
 
             // Literal/operator errors (E0800-E0899)
             ErrorKind::LiteralOutOfRange { .. } => ErrorCode::LITERAL_OUT_OF_RANGE,

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -19,7 +19,7 @@ use chumsky::prelude::*;
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileError, CompileErrors, ErrorKind, MultiErrorResult};
 use rue_lexer::TokenKind;
-use rue_span::Span;
+use rue_span::{FileId, Span};
 use std::borrow::Cow;
 
 use chumsky::extra::SimpleState;
@@ -56,9 +56,29 @@ impl PrimitiveTypeSpurs {
     }
 }
 
-/// Type alias for parser extras that carries primitive type symbols as state.
+/// Parser state containing primitive type symbols and file ID.
+///
+/// This struct holds mutable state needed during parsing:
+/// - Pre-interned primitive type symbols for efficient lookup
+/// - The FileId for the current file being parsed (for multi-file compilation)
+#[derive(Clone, Copy)]
+pub struct ParserState {
+    /// Pre-interned primitive type symbols.
+    pub syms: PrimitiveTypeSpurs,
+    /// The file ID for spans in this file.
+    pub file_id: FileId,
+}
+
+impl ParserState {
+    /// Create a new parser state with the given symbols and file ID.
+    pub fn new(syms: PrimitiveTypeSpurs, file_id: FileId) -> Self {
+        Self { syms, file_id }
+    }
+}
+
+/// Type alias for parser extras that carries parser state.
 /// This replaces the previous thread-local approach with compile-time safe state passing.
-type ParserExtras<'src> = extra::Full<Rich<'src, TokenKind>, SimpleState<PrimitiveTypeSpurs>, ()>;
+type ParserExtras<'src> = extra::Full<Rich<'src, TokenKind>, SimpleState<ParserState>, ()>;
 
 /// Convert a `usize` offset to `u32`, asserting it fits in debug builds.
 ///
@@ -76,14 +96,31 @@ fn offset_to_u32(offset: usize) -> u32 {
     offset as u32
 }
 
-/// Convert chumsky SimpleSpan to rue_span::Span.
+/// Convert chumsky SimpleSpan to rue_span::Span with a specific file ID.
 ///
 /// # Panics
 ///
 /// In debug builds, panics if `span.start` or `span.end` exceeds `u32::MAX`.
 /// This would only happen for source files larger than 4GB.
+fn to_rue_span_with_file(span: SimpleSpan, file_id: FileId) -> Span {
+    Span::with_file(file_id, offset_to_u32(span.start), offset_to_u32(span.end))
+}
+
+/// Convert chumsky SimpleSpan to rue_span::Span using the default file ID.
+/// Only used for error conversion where we don't have access to the parser state.
 fn to_rue_span(span: SimpleSpan) -> Span {
     Span::new(offset_to_u32(span.start), offset_to_u32(span.end))
+}
+
+/// Extract a Span with file ID from the parser extra.
+/// This is the primary way to create spans during parsing.
+#[inline]
+fn span_from_extra<'src, I>(e: &mut MapExtra<'src, '_, I, ParserExtras<'src>>) -> Span
+where
+    I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
+{
+    let file_id = e.state().0.file_id;
+    to_rue_span_with_file(e.span(), file_id)
 }
 
 /// Parser that produces Ident from identifier tokens
@@ -94,7 +131,7 @@ where
     select! {
         TokenKind::Ident(name) = e => Ident {
             name,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         },
     }
 }
@@ -110,74 +147,74 @@ where
     // Type annotation on closure parameter is needed to help Rust infer the Extra type
     let i8_parser =
         just(TokenKind::I8).map_with(|_, e: &mut MapExtra<'src, '_, I, ParserExtras<'src>>| {
-            let syms = e.state().0;
+            let syms = e.state().0.syms;
             TypeExpr::Named(Ident {
                 name: syms.i8,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
     let i16_parser =
         just(TokenKind::I16).map_with(|_, e: &mut MapExtra<'src, '_, I, ParserExtras<'src>>| {
-            let syms = e.state().0;
+            let syms = e.state().0.syms;
             TypeExpr::Named(Ident {
                 name: syms.i16,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
     let i32_parser =
         just(TokenKind::I32).map_with(|_, e: &mut MapExtra<'src, '_, I, ParserExtras<'src>>| {
-            let syms = e.state().0;
+            let syms = e.state().0.syms;
             TypeExpr::Named(Ident {
                 name: syms.i32,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
     let i64_parser =
         just(TokenKind::I64).map_with(|_, e: &mut MapExtra<'src, '_, I, ParserExtras<'src>>| {
-            let syms = e.state().0;
+            let syms = e.state().0.syms;
             TypeExpr::Named(Ident {
                 name: syms.i64,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
     let u8_parser =
         just(TokenKind::U8).map_with(|_, e: &mut MapExtra<'src, '_, I, ParserExtras<'src>>| {
-            let syms = e.state().0;
+            let syms = e.state().0.syms;
             TypeExpr::Named(Ident {
                 name: syms.u8,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
     let u16_parser =
         just(TokenKind::U16).map_with(|_, e: &mut MapExtra<'src, '_, I, ParserExtras<'src>>| {
-            let syms = e.state().0;
+            let syms = e.state().0.syms;
             TypeExpr::Named(Ident {
                 name: syms.u16,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
     let u32_parser =
         just(TokenKind::U32).map_with(|_, e: &mut MapExtra<'src, '_, I, ParserExtras<'src>>| {
-            let syms = e.state().0;
+            let syms = e.state().0.syms;
             TypeExpr::Named(Ident {
                 name: syms.u32,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
     let u64_parser =
         just(TokenKind::U64).map_with(|_, e: &mut MapExtra<'src, '_, I, ParserExtras<'src>>| {
-            let syms = e.state().0;
+            let syms = e.state().0.syms;
             TypeExpr::Named(Ident {
                 name: syms.u64,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
     let bool_parser =
         just(TokenKind::Bool).map_with(|_, e: &mut MapExtra<'src, '_, I, ParserExtras<'src>>| {
-            let syms = e.state().0;
+            let syms = e.state().0.syms;
             TypeExpr::Named(Ident {
                 name: syms.bool,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
 
@@ -203,11 +240,10 @@ where
         // Unit type: ()
         let unit_type = just(TokenKind::LParen)
             .then(just(TokenKind::RParen))
-            .map_with(|_, e| TypeExpr::Unit(to_rue_span(e.span())));
+            .map_with(|_, e| TypeExpr::Unit(span_from_extra(e)));
 
         // Never type: !
-        let never_type =
-            just(TokenKind::Bang).map_with(|_, e| TypeExpr::Never(to_rue_span(e.span())));
+        let never_type = just(TokenKind::Bang).map_with(|_, e| TypeExpr::Never(span_from_extra(e)));
 
         // Array type: [T; N]
         let array_type = just(TokenKind::LBracket)
@@ -220,7 +256,7 @@ where
             .map_with(|(element, length), e| TypeExpr::Array {
                 element: Box::new(element),
                 length,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             });
 
         // Anonymous struct type: struct { field: Type, ... }
@@ -231,7 +267,7 @@ where
             .map_with(|(name, field_ty), e| AnonStructField {
                 name,
                 ty: field_ty,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             });
 
         let anon_struct_type = just(TokenKind::Struct)
@@ -245,7 +281,7 @@ where
             .then_ignore(just(TokenKind::RBrace))
             .map_with(|fields, e| TypeExpr::AnonymousStruct {
                 fields,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             });
 
         // Named type: user-defined types like MyStruct
@@ -290,7 +326,7 @@ where
             mode: mode.unwrap_or(ParamMode::Normal),
             name,
             ty,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         })
 }
 
@@ -305,7 +341,7 @@ where
         .map_with(|(name, ty), e| FieldDecl {
             name,
             ty,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         })
 }
 
@@ -349,7 +385,7 @@ where
         .map_with(|(name, args), e| Directive {
             name,
             args: args.unwrap_or_default(),
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         })
 }
 
@@ -391,7 +427,7 @@ where
         .map_with(|(mode, expr), e| CallArg {
             mode: mode.unwrap_or(ArgMode::Normal),
             expr,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         })
 }
 
@@ -430,7 +466,7 @@ where
         .map_with(|(name, value), e| FieldInit {
             name,
             value: Box::new(value),
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         })
 }
 
@@ -635,13 +671,13 @@ where
 {
     // Wildcard pattern: _
     let wildcard =
-        just(TokenKind::Underscore).map_with(|_, e| Pattern::Wildcard(to_rue_span(e.span())));
+        just(TokenKind::Underscore).map_with(|_, e| Pattern::Wildcard(span_from_extra(e)));
 
     // Integer literal pattern (positive or zero)
     let int_pat = select! {
         TokenKind::Int(n) = e => Pattern::Int(IntLit {
             value: n,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         }),
     };
 
@@ -651,7 +687,7 @@ where
         .map_with(|(_, n), e| {
             Pattern::NegInt(NegIntLit {
                 value: n,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
 
@@ -659,14 +695,14 @@ where
     let bool_true = select! {
         TokenKind::True = e => Pattern::Bool(BoolLit {
             value: true,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         }),
     };
 
     let bool_false = select! {
         TokenKind::False = e => Pattern::Bool(BoolLit {
             value: false,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         }),
     };
 
@@ -678,7 +714,7 @@ where
             Pattern::Path(PathPattern {
                 type_name,
                 variant,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
 
@@ -705,7 +741,7 @@ where
         .map_with(|(pattern, body), e| MatchArm {
             pattern,
             body: Box::new(body),
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         })
 }
 
@@ -718,7 +754,7 @@ where
     let int_lit = select! {
         TokenKind::Int(n) = e => Expr::Int(IntLit {
             value: n,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         }),
     };
 
@@ -726,7 +762,7 @@ where
     let string_lit = select! {
         TokenKind::String(s) = e => Expr::String(StringLit {
             value: s,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         }),
     };
 
@@ -734,14 +770,14 @@ where
     let bool_true = select! {
         TokenKind::True = e => Expr::Bool(BoolLit {
             value: true,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         }),
     };
 
     let bool_false = select! {
         TokenKind::False = e => Expr::Bool(BoolLit {
             value: false,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         }),
     };
 
@@ -750,7 +786,7 @@ where
         .then(just(TokenKind::RParen))
         .map_with(|_, e| {
             Expr::Unit(UnitLit {
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
 
@@ -766,12 +802,12 @@ where
 {
     // Break
     let break_expr = select! {
-        TokenKind::Break = e => Expr::Break(BreakExpr { span: to_rue_span(e.span()) }),
+        TokenKind::Break = e => Expr::Break(BreakExpr { span: span_from_extra(e) }),
     };
 
     // Continue
     let continue_expr = select! {
-        TokenKind::Continue = e => Expr::Continue(ContinueExpr { span: to_rue_span(e.span()) }),
+        TokenKind::Continue = e => Expr::Continue(ContinueExpr { span: span_from_extra(e) }),
     };
 
     // Return expression: return <expr>? (expression is optional for unit-returning functions)
@@ -780,7 +816,7 @@ where
         .map_with(|value, e| {
             Expr::Return(ReturnExpr {
                 value: value.map(Box::new),
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
 
@@ -794,7 +830,7 @@ where
                     .ignore_then(choice((
                         // else if: wrap the nested if in a synthetic block
                         if_expr_rec.map_with(|nested_if, e| {
-                            let span = to_rue_span(e.span());
+                            let span = span_from_extra(e);
                             BlockExpr {
                                 statements: Vec::new(),
                                 expr: Box::new(nested_if),
@@ -811,7 +847,7 @@ where
                     cond: Box::new(cond),
                     then_block,
                     else_block,
-                    span: to_rue_span(e.span()),
+                    span: span_from_extra(e),
                 })
             })
     })
@@ -825,7 +861,7 @@ where
             Expr::While(WhileExpr {
                 cond: Box::new(cond),
                 body,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         })
         .boxed();
@@ -836,7 +872,7 @@ where
         .map_with(|body, e| {
             Expr::Loop(LoopExpr {
                 body,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         })
         .boxed();
@@ -855,7 +891,7 @@ where
             Expr::Match(MatchExpr {
                 scrutinee: Box::new(scrutinee),
                 arms,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         })
         .boxed();
@@ -919,23 +955,23 @@ where
             IdentSuffix::Call(args) => Expr::Call(CallExpr {
                 name,
                 args,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             }),
             IdentSuffix::StructLit(fields) => Expr::StructLit(StructLitExpr {
                 name,
                 fields,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             }),
             IdentSuffix::PathCall(function, args) => Expr::AssocFnCall(AssocFnCallExpr {
                 type_name: name,
                 function,
                 args,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             }),
             IdentSuffix::Path(variant) => Expr::Path(PathExpr {
                 type_name: name,
                 variant,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             }),
             IdentSuffix::None => Expr::Ident(name),
         })
@@ -1024,7 +1060,7 @@ where
 {
     // Self expression (in method bodies)
     let self_expr = select! {
-        TokenKind::SelfValue = e => Expr::SelfExpr(SelfExpr { span: to_rue_span(e.span()) }),
+        TokenKind::SelfValue = e => Expr::SelfExpr(SelfExpr { span: span_from_extra(e) }),
     };
 
     // Parenthesized expression
@@ -1034,7 +1070,7 @@ where
         .map_with(|inner, e| {
             Expr::Paren(ParenExpr {
                 inner: Box::new(inner),
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
 
@@ -1047,7 +1083,7 @@ where
         .map_with(|inner_expr, e| {
             Expr::Comptime(ComptimeBlockExpr {
                 expr: Box::new(inner_expr),
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
 
@@ -1058,11 +1094,11 @@ where
         // Unit type: ()
         let unit_type = just(TokenKind::LParen)
             .then(just(TokenKind::RParen))
-            .map_with(|_, e| IntrinsicArg::Type(TypeExpr::Unit(to_rue_span(e.span()))));
+            .map_with(|_, e| IntrinsicArg::Type(TypeExpr::Unit(span_from_extra(e))));
 
         // Never type: !
         let never_type = just(TokenKind::Bang)
-            .map_with(|_, e| IntrinsicArg::Type(TypeExpr::Never(to_rue_span(e.span()))));
+            .map_with(|_, e| IntrinsicArg::Type(TypeExpr::Never(span_from_extra(e))));
 
         // Array type: [T; N]
         let array_type = just(TokenKind::LBracket)
@@ -1076,7 +1112,7 @@ where
                 IntrinsicArg::Type(TypeExpr::Array {
                     element: Box::new(element),
                     length,
-                    span: to_rue_span(e.span()),
+                    span: span_from_extra(e),
                 })
             });
 
@@ -1105,13 +1141,13 @@ where
             Expr::IntrinsicCall(IntrinsicCallExpr {
                 name,
                 args,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
 
     // @import(args) - lexer tokenizes @import as a single token with interned "import" Spur
     let import_call = select! {
-        TokenKind::AtImport(import_spur) = e => (import_spur, to_rue_span(e.span())),
+        TokenKind::AtImport(import_spur) = e => (import_spur, span_from_extra(e)),
     }
     .then(
         intrinsic_arg
@@ -1127,7 +1163,7 @@ where
                 span: import_span,
             },
             args,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         })
     });
 
@@ -1140,7 +1176,7 @@ where
         .map_with(|elements, e| {
             Expr::ArrayLit(ArrayLitExpr {
                 elements,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         });
 
@@ -1149,7 +1185,7 @@ where
     let type_lit_expr = primitive_type_parser().map_with(|type_expr, e| {
         Expr::TypeLit(TypeLitExpr {
             type_expr,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         })
     });
 
@@ -1162,7 +1198,7 @@ where
         .map_with(|(name, field_ty), e| AnonStructField {
             name,
             ty: field_ty,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         });
 
     let anon_struct_type_expr = just(TokenKind::Struct)
@@ -1175,7 +1211,7 @@ where
         )
         .then_ignore(just(TokenKind::RBrace))
         .map_with(|fields, e| {
-            let span = to_rue_span(e.span());
+            let span = span_from_extra(e);
             Expr::TypeLit(TypeLitExpr {
                 type_expr: TypeExpr::AnonymousStruct { fields, span },
                 span,
@@ -1233,7 +1269,7 @@ where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
     let wildcard =
-        just(TokenKind::Underscore).map_with(|_, e| LetPattern::Wildcard(to_rue_span(e.span())));
+        just(TokenKind::Underscore).map_with(|_, e| LetPattern::Wildcard(span_from_extra(e)));
     let ident = ident_parser().map(LetPattern::Ident);
     ident.or(wildcard)
 }
@@ -1259,7 +1295,7 @@ where
                 pattern,
                 ty,
                 init: Box::new(init),
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         })
 }
@@ -1367,7 +1403,7 @@ where
             Statement::Assign(AssignStatement {
                 target,
                 value: Box::new(value),
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             })
         })
 }
@@ -1572,7 +1608,7 @@ where
         .collect::<Vec<_>>()
         .delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace))
         .map_with(|items, e| {
-            let span = to_rue_span(e.span());
+            let span = span_from_extra(e);
             let (statements, final_expr) = process_block_items(items, span);
             BlockExpr {
                 statements,
@@ -1594,7 +1630,7 @@ where
         .collect::<Vec<_>>()
         .delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace))
         .map_with(|items, e| {
-            let span = to_rue_span(e.span());
+            let span = span_from_extra(e);
             let (statements, final_expr) = process_block_items(items, span);
             Expr::Block(BlockExpr {
                 statements,
@@ -1634,7 +1670,7 @@ where
                 params,
                 return_type,
                 body,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             },
         )
 }
@@ -1665,7 +1701,7 @@ where
                 is_linear: is_linear.is_some(),
                 name,
                 fields,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             },
         )
 }
@@ -1677,7 +1713,7 @@ where
 {
     ident_parser().map_with(|name, e| EnumVariant {
         name,
-        span: to_rue_span(e.span()),
+        span: span_from_extra(e),
     })
 }
 
@@ -1714,7 +1750,7 @@ where
             visibility,
             name,
             variants,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         })
 }
 
@@ -1728,7 +1764,7 @@ where
 
     // Parse optional self parameter
     let self_param = just(TokenKind::SelfValue).map_with(|_, e| SelfParam {
-        span: to_rue_span(e.span()),
+        span: span_from_extra(e),
     });
 
     // Parse self followed by optional regular params
@@ -1763,7 +1799,7 @@ where
                 params,
                 return_type,
                 body,
-                span: to_rue_span(e.span()),
+                span: span_from_extra(e),
             },
         )
 }
@@ -1784,7 +1820,7 @@ where
         .map_with(|(type_name, methods), e| ImplBlock {
             type_name,
             methods,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         })
 }
 
@@ -1797,7 +1833,7 @@ where
 
     // Parse self parameter
     let self_param = just(TokenKind::SelfValue).map_with(|_, e| SelfParam {
-        span: to_rue_span(e.span()),
+        span: span_from_extra(e),
     });
 
     just(TokenKind::Drop)
@@ -1809,7 +1845,7 @@ where
             type_name,
             self_param,
             body,
-            span: to_rue_span(e.span()),
+            span: span_from_extra(e),
         })
 }
 
@@ -1906,12 +1942,19 @@ pub struct ChumskyParser {
     tokens: Vec<(TokenKind, SimpleSpan)>,
     source_len: usize,
     interner: ThreadedRodeo,
+    /// File ID for spans in this file.
+    file_id: FileId,
 }
 
 impl ChumskyParser {
     /// Create a new parser from tokens and an interner produced by the lexer.
     pub fn new(tokens: Vec<rue_lexer::Token>, interner: ThreadedRodeo) -> Self {
         let source_len = tokens.last().map(|t| t.span.end as usize).unwrap_or(0);
+        // Extract file_id from the first token (all tokens in a file have the same file_id)
+        let file_id = tokens
+            .first()
+            .map(|t| t.span.file_id)
+            .unwrap_or(FileId::DEFAULT);
 
         let spanned_tokens: Vec<(TokenKind, SimpleSpan)> = tokens
             .into_iter()
@@ -1927,6 +1970,7 @@ impl ChumskyParser {
             tokens: spanned_tokens,
             source_len,
             interner,
+            file_id,
         }
     }
 
@@ -1934,9 +1978,10 @@ impl ChumskyParser {
     ///
     /// Returns all parse errors if parsing fails, not just the first one.
     pub fn parse(mut self) -> MultiErrorResult<(Ast, ThreadedRodeo)> {
-        // Pre-intern primitive type symbols for use as parser state
+        // Pre-intern primitive type symbols and create parser state with file ID
         let syms = PrimitiveTypeSpurs::new(&mut self.interner);
-        let mut state = SimpleState(syms);
+        let parser_state = ParserState::new(syms, self.file_id);
+        let mut state = SimpleState(parser_state);
 
         // Create a stream from the token iterator
         let token_iter = self.tokens.iter().cloned();

--- a/crates/rue-spec/cases/modules/directory.toml
+++ b/crates/rue-spec/cases/modules/directory.toml
@@ -1,0 +1,149 @@
+[section]
+id = "modules.directory"
+name = "Directory Module Resolution"
+description = "Directory module resolution using the _foo.rue + foo/ pattern (Phase 2 of module system). Per ADR-0026, @import('foo') resolves to _foo.rue when foo.rue doesn't exist."
+
+# =============================================================================
+# Simple File Module Resolution
+# =============================================================================
+# Note: Module resolution is implemented, but module member access is not yet.
+# These tests verify the path resolution logic by checking that the correct
+# file is found (no "module not found" error).
+
+[[case]]
+name = "import_simple_file_resolves"
+preview = "modules"
+preview_should_pass = true
+description = "@import('foo') resolves to foo.rue when it exists (verifies file is found)"
+source = """
+fn main() -> i32 {
+    let math = @import("math");
+    0
+}
+"""
+aux_files = { "math.rue" = """
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+""" }
+exit_code = 0
+
+[[case]]
+name = "import_simple_file_with_extension_resolves"
+preview = "modules"
+preview_should_pass = true
+description = "@import('foo.rue') resolves to foo.rue directly"
+source = """
+fn main() -> i32 {
+    let math = @import("math.rue");
+    0
+}
+"""
+aux_files = { "math.rue" = """
+fn multiply(a: i32, b: i32) -> i32 {
+    a * b
+}
+""" }
+exit_code = 0
+
+# =============================================================================
+# Directory Module Resolution (_foo.rue pattern)
+# =============================================================================
+
+[[case]]
+name = "import_directory_module_resolves"
+preview = "modules"
+preview_should_pass = true
+description = "@import('utils') resolves to _utils.rue when utils.rue doesn't exist"
+source = """
+fn main() -> i32 {
+    let utils = @import("utils");
+    0
+}
+"""
+aux_files = { "_utils.rue" = """
+fn helper() -> i32 {
+    42
+}
+""" }
+exit_code = 0
+
+[[case]]
+name = "import_directory_module_with_subdir_resolves"
+preview = "modules"
+preview_should_pass = true
+description = "@import('utils') finds _utils.rue even when utils/ directory exists"
+source = """
+fn main() -> i32 {
+    let utils = @import("utils");
+    0
+}
+"""
+aux_files = { "_utils.rue" = """
+fn helper() -> i32 {
+    99
+}
+""", "utils/inner.rue" = """
+fn inner_fn() -> i32 { 1 }
+""" }
+exit_code = 0
+
+# =============================================================================
+# Resolution Priority (foo.rue before _foo.rue)
+# =============================================================================
+
+[[case]]
+name = "import_prefers_simple_file_resolves"
+preview = "modules"
+preview_should_pass = true
+description = "foo.rue is preferred over _foo.rue if both exist (verifies resolution order)"
+source = """
+fn main() -> i32 {
+    let math = @import("math");
+    0
+}
+"""
+aux_files = { "math.rue" = """
+fn value() -> i32 { 10 }
+""", "_math.rue" = """
+fn value() -> i32 { 20 }
+""" }
+exit_code = 0
+
+# =============================================================================
+# Module Not Found Errors
+# =============================================================================
+
+[[case]]
+name = "import_module_not_found"
+preview = "modules"
+preview_should_pass = true
+description = "@import for non-existent module produces clear error"
+source = """
+fn main() -> i32 {
+    let missing = @import("nonexistent");
+    0
+}
+"""
+compile_fail = true
+error_contains = "cannot find module"
+
+# =============================================================================
+# Nested Directory Resolution
+# =============================================================================
+
+[[case]]
+name = "import_nested_path_resolves"
+preview = "modules"
+preview_should_pass = true
+description = "@import('foo/bar') resolves to foo/bar.rue"
+source = """
+fn main() -> i32 {
+    let nested = @import("sub/helper");
+    0
+}
+"""
+aux_files = { "sub/helper.rue" = """
+fn value() -> i32 { 123 }
+""" }
+exit_code = 0

--- a/crates/rue-spec/cases/modules/import.toml
+++ b/crates/rue-spec/cases/modules/import.toml
@@ -8,20 +8,20 @@ description = "The @import builtin for importing modules (Phase 1 of module syst
 # =============================================================================
 
 # These tests verify that @import is correctly gated behind the modules preview
-# feature and accepts valid syntax. Actual module resolution is not yet implemented,
-# so these tests only verify the placeholder behavior (returns Unit).
+# feature and accepts valid syntax. Module resolution is implemented per ADR-0026.
 
 [[case]]
 name = "import_basic_syntax"
 preview = "modules"
 preview_should_pass = true
-description = "@import with string argument is accepted (returns Unit placeholder)"
+description = "@import with string argument is accepted"
 source = """
 fn main() -> i32 {
-    let m = @import("foo.rue");
+    let m = @import("foo");
     0
 }
 """
+aux_files = { "foo.rue" = "fn f() -> i32 { 1 }" }
 exit_code = 0
 
 [[case]]
@@ -31,10 +31,11 @@ preview_should_pass = true
 description = "@import can be used in a const binding (typical pattern)"
 source = """
 fn main() -> i32 {
-    let math = @import("math.rue");
+    let math = @import("math");
     0
 }
 """
+aux_files = { "math.rue" = "fn add(a: i32, b: i32) -> i32 { a + b }" }
 exit_code = 0
 
 [[case]]
@@ -44,11 +45,12 @@ preview_should_pass = true
 description = "Multiple @import calls in same file"
 source = """
 fn main() -> i32 {
-    let a = @import("a.rue");
-    let b = @import("b.rue");
+    let a = @import("a");
+    let b = @import("b");
     0
 }
 """
+aux_files = { "a.rue" = "fn a_fn() -> i32 { 1 }", "b.rue" = "fn b_fn() -> i32 { 2 }" }
 exit_code = 0
 
 [[case]]
@@ -58,10 +60,11 @@ preview_should_pass = true
 description = "@import with nested path"
 source = """
 fn main() -> i32 {
-    let utils = @import("utils/strings.rue");
+    let utils = @import("utils/strings");
     0
 }
 """
+aux_files = { "utils/strings.rue" = "fn format(x: i32) -> i32 { x }" }
 exit_code = 0
 
 # =============================================================================

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -154,6 +154,11 @@ pub struct Case {
     /// Template placeholders like `{type}` in `source` and `name` are substituted.
     #[serde(default)]
     pub params: Vec<ParamSet>,
+    /// Auxiliary source files for multi-file tests (for module imports).
+    /// Each entry maps a relative filename to its source content.
+    /// Example: `{ "math.rue" = "pub fn add(a: i32, b: i32) -> i32 { a + b }" }`
+    #[serde(default)]
+    pub aux_files: HashMap<String, String>,
 }
 
 /// A test file containing a section and its cases.
@@ -251,6 +256,7 @@ pub fn expand_case(case: Case) -> Vec<Case> {
                 target: case.target.clone(),
                 opt_level: case.opt_level,
                 timeout_ms: case.timeout_ms,
+                aux_files: case.aux_files.clone(),
 
                 // Clear params on expanded case
                 params: vec![],
@@ -600,6 +606,20 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
     source_file
         .write_all(case.source.as_bytes())
         .map_err(|e| format!("Failed to write source: {}", e))?;
+
+    // Write auxiliary files for multi-file tests (module imports)
+    let mut aux_paths = Vec::new();
+    for (filename, content) in &case.aux_files {
+        // Create subdirectories if needed (e.g., "foo/bar.rue")
+        let aux_path = temp_dir.path().join(filename);
+        if let Some(parent) = aux_path.parent() {
+            fs::create_dir_all(parent)
+                .map_err(|e| format!("Failed to create dir for {}: {}", filename, e))?;
+        }
+        fs::write(&aux_path, content)
+            .map_err(|e| format!("Failed to write aux file {}: {}", filename, e))?;
+        aux_paths.push(aux_path);
+    }
 
     // Build base command with target, preview, and optimization flags if needed
     let build_command = |binary: &Path| -> Command {
@@ -959,6 +979,7 @@ mod tests {
             stdin: None,
             stderr_contains: None,
             params: vec![],
+            aux_files: HashMap::new(),
         };
 
         let expanded = expand_case(case);
@@ -1006,6 +1027,7 @@ mod tests {
             stdin: None,
             stderr_contains: None,
             params: vec![ParamSet { values: param1 }, ParamSet { values: param2 }],
+            aux_files: HashMap::new(),
         };
 
         let expanded = expand_case(case);
@@ -1061,6 +1083,7 @@ mod tests {
             stdin: None,
             stderr_contains: None,
             params: vec![ParamSet { values: params }],
+            aux_files: HashMap::new(),
         };
 
         let expanded = expand_case(case);
@@ -1108,6 +1131,7 @@ mod tests {
             stdin: None,
             stderr_contains: None,
             params: vec![ParamSet { values: params }],
+            aux_files: HashMap::new(),
         };
 
         let expanded = expand_case(case);


### PR DESCRIPTION
This implements the directory module resolution pattern from ADR-0026:
- @import("foo") first tries foo.rue, then _foo.rue + foo/ directory
- FileId is now preserved through the parser for multi-file compilation
- Test runner supports aux_files for multi-file spec tests
- Added 7 new spec tests for directory module resolution

Key changes:
- rue-parser: Added ParserState to track FileId through parsing
- rue-air: Added resolve_import_path with priority-based resolution
- rue-compiler: File paths now propagated to Sema for resolution
- rue-error: Added ModuleNotFound error kind (E0704)
- rue-test-runner: Added aux_files support for multi-file tests

Closes rue-w9mn

🤖 Generated with [Claude Code](https://claude.com/claude-code)