### PR TITLE
Add Phase 2: Parser and Sema for random intrinsics

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -6780,6 +6780,10 @@ impl<'a> Sema<'a> {
             self.analyze_assert_intrinsic(air, &args, span, ctx)
         } else if name == known.import {
             self.analyze_import_intrinsic(air, &args, span)
+        } else if name == known.random_u32 {
+            self.analyze_random_u32_intrinsic(air, name, &args, span)
+        } else if name == known.random_u64 {
+            self.analyze_random_u64_intrinsic(air, name, &args, span)
         } else {
             // Unknown intrinsic - resolve name for error message
             let intrinsic_name_str = self.interner.resolve(&name);
@@ -7201,6 +7205,78 @@ impl<'a> Sema<'a> {
             span,
         });
         Ok(AnalysisResult::new(air_ref, return_type))
+    }
+
+    /// Analyze @random_u32 intrinsic.
+    fn analyze_random_u32_intrinsic(
+        &mut self,
+        air: &mut Air,
+        name: Spur,
+        args: &[RirCallArg],
+        span: Span,
+    ) -> CompileResult<AnalysisResult> {
+        // Requires the random preview feature
+        self.require_preview(PreviewFeature::Random, "@random_u32() intrinsic", span)?;
+
+        // @random_u32() - takes no arguments, returns u32
+        if !args.is_empty() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "random_u32".to_string(),
+                    expected: 0,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        // Create the intrinsic instruction that returns u32
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name,
+                args_start: 0, // No args
+                args_len: 0,
+            },
+            ty: Type::U32,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::U32))
+    }
+
+    /// Analyze @random_u64 intrinsic.
+    fn analyze_random_u64_intrinsic(
+        &mut self,
+        air: &mut Air,
+        name: Spur,
+        args: &[RirCallArg],
+        span: Span,
+    ) -> CompileResult<AnalysisResult> {
+        // Requires the random preview feature
+        self.require_preview(PreviewFeature::Random, "@random_u64() intrinsic", span)?;
+
+        // @random_u64() - takes no arguments, returns u64
+        if !args.is_empty() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "random_u64".to_string(),
+                    expected: 0,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        // Create the intrinsic instruction that returns u64
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name,
+                args_start: 0, // No args
+                args_len: 0,
+            },
+            ty: Type::U64,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::U64))
     }
 
     /// Analyze @import intrinsic.

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -58,6 +58,10 @@ pub struct KnownSymbols {
     pub test_preview_gate: Spur,
     /// The `import` builtin symbol.
     pub import: Spur,
+    /// The `random_u32` intrinsic symbol.
+    pub random_u32: Spur,
+    /// The `random_u64` intrinsic symbol.
+    pub random_u64: Spur,
 
     // Type intrinsics
     /// The `size_of` type intrinsic symbol.
@@ -93,6 +97,8 @@ impl KnownSymbols {
             parse_u64: interner.get_or_intern_static("parse_u64"),
             test_preview_gate: interner.get_or_intern_static("test_preview_gate"),
             import: interner.get_or_intern_static("import"),
+            random_u32: interner.get_or_intern_static("random_u32"),
+            random_u64: interner.get_or_intern_static("random_u64"),
 
             // Type intrinsics
             size_of: interner.get_or_intern_static("size_of"),
@@ -149,6 +155,8 @@ mod tests {
             "test_preview_gate"
         );
         assert_eq!(interner.resolve(&known.import), "import");
+        assert_eq!(interner.resolve(&known.random_u32), "random_u32");
+        assert_eq!(interner.resolve(&known.random_u64), "random_u64");
         assert_eq!(interner.resolve(&known.size_of), "size_of");
         assert_eq!(interner.resolve(&known.align_of), "align_of");
         assert_eq!(interner.resolve(&known.string_type), "String");


### PR DESCRIPTION
Implemented @random_u32 and @random_u64 intrinsic support:

- Added random_u32 and random_u64 symbols to KnownSymbols
- Added analyze_random_u32_intrinsic and analyze_random_u64_intrinsic handlers
- Added dispatch logic in analyze_intrinsic_impl  
- Preview feature gate (PreviewFeature::Random) enforced in handlers
- Intrinsics lower to generic AirInstData::Intrinsic (returns u32/u64)
- CFG lowering works through generic Intrinsic handling

Phase 2 complete. Requires Phase 3 (runtime) and Phase 4 (codegen) for full e2e testing.

Part of rue-krhv (ADR-0027).

🤖 Generated with [Claude Code](https://claude.com/claude-code)