### PR TITLE
Add runtime implementation for random intrinsics

### DIFF
--- a/crates/rue-runtime/src/aarch64_linux.rs
+++ b/crates/rue-runtime/src/aarch64_linux.rs
@@ -42,6 +42,9 @@ const SYS_MMAP: u64 = 222;
 /// Linux aarch64 syscall number for munmap (from asm-generic/unistd.h).
 const SYS_MUNMAP: u64 = 215;
 
+/// Linux aarch64 syscall number for getrandom (from asm-generic/unistd.h).
+const SYS_GETRANDOM: u64 = 278;
+
 /// Standard input file descriptor.
 pub const STDIN: u64 = 0;
 
@@ -371,6 +374,54 @@ pub fn exit(status: i32) -> ! {
     }
 }
 
+/// Fill a buffer with random bytes from the kernel entropy pool.
+///
+/// This is a wrapper around the Linux `getrandom(2)` syscall.
+///
+/// # Arguments
+///
+/// * `buf` - Pointer to the buffer to fill with random bytes
+/// * `len` - Number of random bytes to generate
+///
+/// # Returns
+///
+/// On success, returns the number of random bytes written (should equal `len`).
+/// On error, returns a negative value representing `-errno`.
+///
+/// # Safety
+///
+/// The caller must ensure:
+/// - `buf` points to a valid, writable memory region of at least `len` bytes
+/// - The memory region remains valid for the duration of the syscall
+///
+/// # Flags
+///
+/// This function uses `flags = 0`, which means:
+/// - Block if the entropy pool is not initialized (early boot only)
+/// - Use the main entropy pool (suitable for all non-cryptographic uses)
+pub fn getrandom(buf: *mut u8, len: usize) -> i64 {
+    let result: i64;
+
+    // SAFETY: Making the getrandom(2) syscall is safe because:
+    // - The syscall interface is stable (available since Linux 3.17)
+    // - We pass arguments in the correct registers per AArch64 Linux ABI
+    // - The kernel validates buf and len; invalid values return errors
+    // - flags=0 is the safest mode (blocks until initialized)
+    // - Syscall number goes in x8, args in x0-x2, result in x0
+    // - The caller is responsible for ensuring buf points to writable memory
+    unsafe {
+        asm!(
+            "svc #0",
+            in("x8") SYS_GETRANDOM,
+            inlateout("x0") buf => result,
+            in("x1") len,
+            in("x2") 0u64,  // flags: 0 (block if not initialized)
+        );
+    }
+
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -516,5 +567,31 @@ mod tests {
         // Zero-size mmap should fail (returns EINVAL on Linux)
         let ptr = mmap(0);
         assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn test_getrandom_basic() {
+        // Get 4 random bytes
+        let mut buf = [0u8; 4];
+        let result = getrandom(buf.as_mut_ptr(), 4);
+        assert_eq!(result, 4);
+        // We can't test the actual values (they're random), but we can verify
+        // the syscall succeeded
+    }
+
+    #[test]
+    fn test_getrandom_larger() {
+        // Get 32 random bytes
+        let mut buf = [0u8; 32];
+        let result = getrandom(buf.as_mut_ptr(), 32);
+        assert_eq!(result, 32);
+    }
+
+    #[test]
+    fn test_getrandom_zero_size() {
+        // Zero-size request should succeed and return 0
+        let mut buf = [0u8; 4];
+        let result = getrandom(buf.as_mut_ptr(), 0);
+        assert_eq!(result, 0);
     }
 }

--- a/crates/rue-runtime/src/aarch64_macos.rs
+++ b/crates/rue-runtime/src/aarch64_macos.rs
@@ -407,6 +407,55 @@ pub fn exit(status: i32) -> ! {
     }
 }
 
+/// Fill a buffer with random bytes from the system entropy pool.
+///
+/// This uses the macOS `getentropy(2)` function from libSystem.
+///
+/// # Arguments
+///
+/// * `buf` - Pointer to the buffer to fill with random bytes
+/// * `len` - Number of random bytes to generate (maximum 256 bytes per call)
+///
+/// # Returns
+///
+/// On success, returns the number of bytes written (equal to `len`).
+/// On error, returns a negative value.
+///
+/// # Safety
+///
+/// The caller must ensure:
+/// - `buf` points to a valid, writable memory region of at least `len` bytes
+/// - `len` does not exceed 256 bytes (macOS limit for getentropy)
+/// - The memory region remains valid for the duration of the call
+///
+/// # Note
+///
+/// macOS's `getentropy` has a maximum buffer size of 256 bytes. Callers
+/// should ensure `len <= 256`. For larger amounts of randomness, call
+/// multiple times.
+pub fn getrandom(buf: *mut u8, len: usize) -> i64 {
+    // Link with libSystem's getentropy function
+    unsafe extern "C" {
+        fn getentropy(buf: *mut u8, buflen: usize) -> i32;
+    }
+
+    // SAFETY: Calling getentropy is safe because:
+    // - We pass valid arguments (caller guarantees buf and len)
+    // - getentropy is a standard macOS library function
+    // - The function validates parameters and returns errors on failure
+    // - The caller ensures buf is writable and len is <= 256
+    unsafe {
+        let result = getentropy(buf, len);
+        if result == 0 {
+            // Success: return the number of bytes written
+            len as i64
+        } else {
+            // Error: return negative to match Linux convention
+            -1
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -552,5 +601,31 @@ mod tests {
         // Zero-size mmap should fail (returns EINVAL on macOS)
         let ptr = mmap(0);
         assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn test_getrandom_basic() {
+        // Get 4 random bytes
+        let mut buf = [0u8; 4];
+        let result = getrandom(buf.as_mut_ptr(), 4);
+        assert_eq!(result, 4);
+        // We can't test the actual values (they're random), but we can verify
+        // the call succeeded
+    }
+
+    #[test]
+    fn test_getrandom_larger() {
+        // Get 32 random bytes
+        let mut buf = [0u8; 32];
+        let result = getrandom(buf.as_mut_ptr(), 32);
+        assert_eq!(result, 32);
+    }
+
+    #[test]
+    fn test_getrandom_zero_size() {
+        // Zero-size request should succeed and return 0
+        let mut buf = [0u8; 4];
+        let result = getrandom(buf.as_mut_ptr(), 0);
+        assert_eq!(result, 0);
     }
 }

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -2658,3 +2658,86 @@ mod parse_tests {
         assert_eq!(result, u32::MAX);
     }
 }
+
+// ============================================================================
+// Random Number Generation Intrinsics
+// ============================================================================
+//
+// These intrinsics provide cryptographically-secure random numbers using
+// platform-specific entropy sources:
+// - Linux (x86-64 and aarch64): getrandom(2) syscall
+// - macOS (aarch64): getentropy(2) via libSystem
+//
+// See ADR-0027 for design rationale.
+
+/// Generate a random unsigned 32-bit integer.
+///
+/// # ABI
+///
+/// ```text
+/// extern "C" fn __rue_random_u32() -> u32
+/// ```
+///
+/// No arguments. Returns a random u32 value.
+///
+/// # Behavior
+///
+/// Each call returns a non-deterministic value from the platform's
+/// cryptographically-secure entropy source. The returned values have
+/// uniform distribution across the full u32 range (0 to 4,294,967,295).
+///
+/// # Panics
+///
+/// Panics if the platform entropy source is unavailable or fails to
+/// generate random bytes. This should be extremely rare on modern systems.
+define_for_all_platforms! {
+    pub extern "C" fn __rue_random_u32() -> u32 {
+        let mut bytes = [0u8; 4];
+        let result = platform::getrandom(bytes.as_mut_ptr(), 4);
+        if result < 0 {
+            platform::write_stderr(b"error: random number generation failed\n");
+            platform::exit(101);
+        }
+        if result != 4 {
+            platform::write_stderr(b"error: incomplete random data\n");
+            platform::exit(101);
+        }
+        u32::from_ne_bytes(bytes)
+    }
+}
+
+/// Generate a random unsigned 64-bit integer.
+///
+/// # ABI
+///
+/// ```text
+/// extern "C" fn __rue_random_u64() -> u64
+/// ```
+///
+/// No arguments. Returns a random u64 value.
+///
+/// # Behavior
+///
+/// Each call returns a non-deterministic value from the platform's
+/// cryptographically-secure entropy source. The returned values have
+/// uniform distribution across the full u64 range (0 to 18,446,744,073,709,551,615).
+///
+/// # Panics
+///
+/// Panics if the platform entropy source is unavailable or fails to
+/// generate random bytes. This should be extremely rare on modern systems.
+define_for_all_platforms! {
+    pub extern "C" fn __rue_random_u64() -> u64 {
+        let mut bytes = [0u8; 8];
+        let result = platform::getrandom(bytes.as_mut_ptr(), 8);
+        if result < 0 {
+            platform::write_stderr(b"error: random number generation failed\n");
+            platform::exit(101);
+        }
+        if result != 8 {
+            platform::write_stderr(b"error: incomplete random data\n");
+            platform::exit(101);
+        }
+        u64::from_ne_bytes(bytes)
+    }
+}

--- a/crates/rue-runtime/src/x86_64_linux.rs
+++ b/crates/rue-runtime/src/x86_64_linux.rs
@@ -42,6 +42,9 @@ const SYS_MUNMAP: i64 = 11;
 /// Linux syscall number for exit (see `man 2 exit`).
 const SYS_EXIT: i64 = 60;
 
+/// Linux syscall number for getrandom (see `man 2 getrandom`).
+const SYS_GETRANDOM: i64 = 318;
+
 /// Standard input file descriptor.
 pub const STDIN: u64 = 0;
 
@@ -433,6 +436,56 @@ pub fn exit(status: i32) -> ! {
     }
 }
 
+/// Fill a buffer with random bytes from the kernel entropy pool.
+///
+/// This is a wrapper around the Linux `getrandom(2)` syscall.
+///
+/// # Arguments
+///
+/// * `buf` - Pointer to the buffer to fill with random bytes
+/// * `len` - Number of random bytes to generate
+///
+/// # Returns
+///
+/// On success, returns the number of random bytes written (should equal `len`).
+/// On error, returns a negative value representing `-errno`.
+///
+/// # Safety
+///
+/// The caller must ensure:
+/// - `buf` points to a valid, writable memory region of at least `len` bytes
+/// - The memory region remains valid for the duration of the syscall
+///
+/// # Flags
+///
+/// This function uses `flags = 0`, which means:
+/// - Block if the entropy pool is not initialized (early boot only)
+/// - Use the main entropy pool (suitable for all non-cryptographic uses)
+pub fn getrandom(buf: *mut u8, len: usize) -> i64 {
+    let result: i64;
+    // SAFETY: Making the getrandom(2) syscall is safe because:
+    // - The syscall interface is stable (available since Linux 3.17)
+    // - We pass arguments in the correct registers per x86-64 Linux ABI
+    // - The kernel validates buf and len; invalid values return errors
+    // - flags=0 is the safest mode (blocks until initialized)
+    // - We correctly mark rcx and r11 as clobbered (per syscall ABI)
+    // - The caller is responsible for ensuring buf points to writable memory
+    unsafe {
+        asm!(
+            "syscall",
+            in("rax") SYS_GETRANDOM,
+            in("rdi") buf,
+            in("rsi") len,
+            in("rdx") 0i64,  // flags: 0 (block if not initialized)
+            lateout("rax") result,
+            // syscall clobbers rcx and r11 per x86-64 ABI
+            out("rcx") _,
+            out("r11") _,
+        );
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -604,5 +657,31 @@ mod tests {
         // Zero-size mmap should fail (returns EINVAL on Linux)
         let ptr = mmap(0);
         assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn test_getrandom_basic() {
+        // Get 4 random bytes
+        let mut buf = [0u8; 4];
+        let result = getrandom(buf.as_mut_ptr(), 4);
+        assert_eq!(result, 4);
+        // We can't test the actual values (they're random), but we can verify
+        // the syscall succeeded
+    }
+
+    #[test]
+    fn test_getrandom_larger() {
+        // Get 32 random bytes
+        let mut buf = [0u8; 32];
+        let result = getrandom(buf.as_mut_ptr(), 32);
+        assert_eq!(result, 32);
+    }
+
+    #[test]
+    fn test_getrandom_zero_size() {
+        // Zero-size request should succeed and return 0
+        let mut buf = [0u8; 4];
+        let result = getrandom(buf.as_mut_ptr(), 0);
+        assert_eq!(result, 0);
     }
 }

--- a/docs/designs/0027-random-intrinsics.md
+++ b/docs/designs/0027-random-intrinsics.md
@@ -195,16 +195,16 @@ The return type of `@random_u64` is `u64`.
   - Add preview-gated spec tests (non-deterministic, so test compilation only)
   - Add `Random` to `PreviewFeature` enum
 
-- [ ] **Phase 2: Parser and Sema** - rue-ub3z
+- [x] **Phase 2: Parser and Sema** - rue-ub3z
   - Add `RandomU32` and `RandomU64` to intrinsic parsing
   - Add type checking (returns u32/u64, takes no args)
   - Add preview feature gate check
   - Add CFG lowering for random intrinsics
 
-- [ ] **Phase 3: Runtime implementation** - rue-5852
+- [x] **Phase 3: Runtime implementation** - rue-5852
   - Implement `__rue_random_u32` for x86-64 Linux
   - Implement `__rue_random_u64` for x86-64 Linux
-  - Implement for aarch64 macOS
+  - Implement for aarch64 macOS (using getentropy from libSystem)
   - Implement for aarch64 Linux
   - Handle error cases (no entropy source)
 


### PR DESCRIPTION
Implement __rue_random_u32 and __rue_random_u64 runtime functions for all platforms:
- x86-64 Linux: getrandom syscall #318
- aarch64 Linux: getrandom syscall #278  
- aarch64 macOS: getentropy from libSystem

Each platform provides a getrandom() wrapper that fills a buffer with cryptographically-secure random bytes from the kernel entropy pool. The runtime functions use these wrappers to generate u32 and u64 values, panicking with exit code 101 if randomness is unavailable.

Added unit tests for getrandom() on all platforms to verify:
- Basic 4-byte and 32-byte requests succeed
- Zero-size requests return 0

This completes Phase 3 of ADR-0027.

Closes rue-5852.

🤖 Generated with [Claude Code](https://claude.com/claude-code)