### PR TITLE
Add codegen for random intrinsics

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2168,6 +2168,28 @@ impl<'a> CfgLower<'a> {
                     } else {
                         unreachable!("String fat pointer not found in struct_slot_vregs");
                     }
+                } else if name_str == "random_u32" || name_str == "random_u64" {
+                    // @random_u32() and @random_u64() intrinsics - generate random numbers
+                    // These intrinsics take no arguments and return u32/u64 respectively
+                    // Call __rue_random_u32 or __rue_random_u64 from the runtime
+
+                    let runtime_fn = match name_str {
+                        "random_u32" => "__rue_random_u32",
+                        "random_u64" => "__rue_random_u64",
+                        _ => unreachable!(),
+                    };
+
+                    // Call the runtime function (no arguments)
+                    let symbol_id = self.intern_symbol(runtime_fn);
+                    self.mir.push(Aarch64Inst::Bl { symbol_id });
+
+                    // Result is in X0, move to a vreg
+                    let result_vreg = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(result_vreg),
+                        src: Operand::Physical(Reg::X0),
+                    });
+                    self.value_map.insert(value, result_vreg);
                 }
             }
 

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2329,6 +2329,28 @@ impl<'a> CfgLower<'a> {
                     } else {
                         unreachable!("string value should have field vregs for fat pointer");
                     }
+                } else if name_str == "random_u32" || name_str == "random_u64" {
+                    // @random_u32() and @random_u64() intrinsics - generate random numbers
+                    // These intrinsics take no arguments and return u32/u64 respectively
+                    // Call __rue_random_u32 or __rue_random_u64 from the runtime
+
+                    let runtime_fn = match name_str {
+                        "random_u32" => "__rue_random_u32",
+                        "random_u64" => "__rue_random_u64",
+                        _ => unreachable!(),
+                    };
+
+                    // Call the runtime function (no arguments)
+                    let symbol_id = self.intern_symbol(runtime_fn);
+                    self.mir.push(X86Inst::CallRel { symbol_id });
+
+                    // Result is in RAX, move to a vreg
+                    let result_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(result_vreg),
+                        src: Operand::Physical(Reg::Rax),
+                    });
+                    self.value_map.insert(value, result_vreg);
                 }
             }
 

--- a/docs/designs/0027-random-intrinsics.md
+++ b/docs/designs/0027-random-intrinsics.md
@@ -208,10 +208,10 @@ The return type of `@random_u64` is `u64`.
   - Implement for aarch64 Linux
   - Handle error cases (no entropy source)
 
-- [ ] **Phase 4: Codegen** - rue-2h42
+- [x] **Phase 4: Codegen** - rue-2h42
   - Add call generation for x86-64 backend
   - Add call generation for aarch64 backend
-  - Integration testing with example programs
+  - Integration testing with example programs (spec tests)
 
 ## Consequences
 


### PR DESCRIPTION
Implement code generation for @random_u32 and @random_u64 intrinsics in both x86-64 and aarch64 backends.

x86-64 backend (cfg_lower.rs):
- Generate CallRel to __rue_random_u32 or __rue_random_u64
- Move result from RAX to virtual register
- No arguments needed

aarch64 backend (cfg_lower.rs):
- Generate Bl (branch and link) to __rue_random_u32 or __rue_random_u64  
- Move result from X0 to virtual register
- No arguments needed

The intrinsics return u32/u64 values directly from the runtime functions via the standard calling convention (RAX on x86-64, X0 on aarch64).

Spec tests verify compilation and execution of both intrinsics with the preview feature flag.

This completes Phase 4 and ADR-0027 implementation.

Closes rue-2h42.

🤖 Generated with [Claude Code](https://claude.com/claude-code)