### PR TITLE
Implement `pub const` syntax for module re-exports (rue-bh3h)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -933,7 +933,8 @@ impl<'a> ConstraintGenerator<'a> {
             | InstData::StructDecl { .. }
             | InstData::EnumDecl { .. }
             | InstData::ImplDecl { .. }
-            | InstData::DropFnDecl { .. } => InferType::Concrete(Type::Unit),
+            | InstData::DropFnDecl { .. }
+            | InstData::ConstDecl { .. } => InferType::Concrete(Type::Unit),
 
             // Method call: receiver.method(args)
             InstData::MethodCall {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1620,7 +1620,7 @@ fn analyze_inst_with_context(
         }
 
         // Declaration no-ops (produce Unit in expression context)
-        InstData::ImplDecl { .. } | InstData::DropFnDecl { .. } => {
+        InstData::ImplDecl { .. } | InstData::DropFnDecl { .. } | InstData::ConstDecl { .. } => {
             // These are processed during collection phase, just return Unit
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::UnitConst,
@@ -5841,9 +5841,10 @@ impl<'a> Sema<'a> {
             }
 
             // Declaration no-ops (produce Unit in expression context)
-            InstData::ImplDecl { .. } | InstData::DropFnDecl { .. } | InstData::FnDecl { .. } => {
-                self.analyze_decl_noop(air, inst_ref, ctx)
-            }
+            InstData::ImplDecl { .. }
+            | InstData::DropFnDecl { .. }
+            | InstData::FnDecl { .. }
+            | InstData::ConstDecl { .. } => self.analyze_decl_noop(air, inst_ref, ctx),
 
             // Comptime block expression
             InstData::Comptime { expr } => {

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -19,7 +19,7 @@ use rue_error::{
 use rue_rir::{InstData, InstRef, RirDirective, RirParamMode};
 use rue_span::Span;
 
-use super::{FunctionInfo, InferenceContext, MethodInfo, Sema};
+use super::{ConstInfo, FunctionInfo, InferenceContext, MethodInfo, Sema};
 use crate::inference::{FunctionSig, MethodSig};
 use crate::type_context::{FunctionSignature, MethodSignature, TypeContext};
 use crate::types::{EnumDef, EnumId, StructDef, StructField, StructId, Type};
@@ -502,6 +502,21 @@ impl<'a> Sema<'a> {
                     self.collect_impl_methods(*type_name, *methods_start, *methods_len, inst.span)?;
                 }
 
+                InstData::ConstDecl {
+                    is_pub, name, init, ..
+                } => {
+                    // pub const requires preview feature
+                    if *is_pub {
+                        self.require_preview(
+                            PreviewFeature::Modules,
+                            "pub const declaration",
+                            inst.span,
+                        )?;
+                    }
+
+                    self.collect_const_declaration(*name, *is_pub, *init, inst.span)?;
+                }
+
                 _ => {}
             }
         }
@@ -878,6 +893,68 @@ impl<'a> Sema<'a> {
                 );
             }
         }
+        Ok(())
+    }
+
+    /// Collect a constant declaration.
+    ///
+    /// Constants are compile-time values. In the module system, they're primarily
+    /// used for re-exports:
+    /// ```rue
+    /// pub const strings = @import("utils/strings.rue");
+    /// ```
+    ///
+    /// For now, we store the constant info but don't fully evaluate it.
+    /// The type will be determined when the init expression is analyzed.
+    fn collect_const_declaration(
+        &mut self,
+        name: Spur,
+        is_pub: bool,
+        init: InstRef,
+        span: Span,
+    ) -> CompileResult<()> {
+        let name_str = self.interner.resolve(&name).to_string();
+
+        // Check for duplicate constant names
+        if self.constants.contains_key(&name) {
+            return Err(CompileError::new(
+                ErrorKind::DuplicateConstant {
+                    name: name_str,
+                    kind: "constant".to_string(),
+                },
+                span,
+            ));
+        }
+
+        // Check for collision with function names
+        if self.functions.contains_key(&name) {
+            return Err(CompileError::new(
+                ErrorKind::DuplicateConstant {
+                    name: name_str.clone(),
+                    kind: "constant (conflicts with function)".to_string(),
+                },
+                span,
+            ));
+        }
+
+        // For now, store with Type::Error as a placeholder - the actual type will be determined
+        // when the init expression is analyzed during module population phase.
+        // This is Phase 2 of the module system where we'll walk the init expression
+        // to determine if it's an @import (making it Type::Module).
+        //
+        // Note: Type::Error here is a placeholder indicating "not yet resolved".
+        // This is fine because const types are determined lazily when the module
+        // is populated with re-exports.
+        self.constants.insert(
+            name,
+            ConstInfo {
+                is_pub,
+                ty: Type::Error,
+                init,
+                span,
+            },
+        );
+
         Ok(())
     }
 }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -89,6 +89,8 @@ pub struct GatherOutput<'a> {
     pub functions: HashMap<Spur, FunctionInfo>,
     /// Method lookup: maps (struct_name, method_name) to info.
     pub methods: HashMap<(Spur, Spur), MethodInfo>,
+    /// Constant lookup: maps const name to info.
+    pub constants: HashMap<Spur, ConstInfo>,
     /// Enabled preview features.
     pub preview_features: PreviewFeatures,
     /// StructId of the synthetic String type.
@@ -110,6 +112,7 @@ impl<'a> GatherOutput<'a> {
             structs: self.structs,
             enums: self.enums,
             methods: self.methods,
+            constants: self.constants,
             preview_features: self.preview_features,
             builtin_string_id: self.builtin_string_id,
             known: KnownSymbols::new(self.interner),
@@ -219,6 +222,26 @@ pub struct MethodInfo {
     pub span: rue_span::Span,
 }
 
+/// Information about a constant declaration.
+///
+/// Constants are compile-time values. In the module system, they're primarily
+/// used for re-exports:
+/// ```rue
+/// pub const strings = @import("utils/strings.rue");
+/// pub const helper = @import("utils/internal.rue").helper;
+/// ```
+#[derive(Debug, Clone)]
+pub struct ConstInfo {
+    /// Whether this constant is public
+    pub is_pub: bool,
+    /// The type of the constant value (e.g., Type::Module for imports)
+    pub ty: Type,
+    /// The RIR instruction ref for the initializer
+    pub init: rue_rir::InstRef,
+    /// Span of the const declaration
+    pub span: rue_span::Span,
+}
+
 /// Semantic analyzer that converts RIR to AIR.
 pub struct Sema<'a> {
     pub(crate) rir: &'a Rir,
@@ -233,6 +256,9 @@ pub struct Sema<'a> {
     /// Used for resolving method calls (receiver.method()) and associated
     /// function calls (Type::function())
     pub(crate) methods: HashMap<(Spur, Spur), MethodInfo>,
+    /// Constant table: maps const name symbol to const info
+    /// Used for module re-exports: `pub const strings = @import("utils/strings");`
+    pub(crate) constants: HashMap<Spur, ConstInfo>,
     /// Enabled preview features
     pub(crate) preview_features: PreviewFeatures,
     /// StructId of the synthetic String type.
@@ -267,6 +293,7 @@ impl<'a> Sema<'a> {
             structs: HashMap::new(),
             enums: HashMap::new(),
             methods: HashMap::new(),
+            constants: HashMap::new(),
             preview_features,
             builtin_string_id: None,
             known: KnownSymbols::new(interner),
@@ -394,6 +421,7 @@ impl<'a> Sema<'a> {
             enums: self.enums,
             functions: self.functions,
             methods: self.methods,
+            constants: self.constants,
             preview_features: self.preview_features,
             builtin_string_id: self.builtin_string_id,
             type_pool: self.type_pool,

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -488,9 +488,10 @@ pub fn merge_symbols(program: ParsedProgram) -> MultiErrorResult<MergedProgram> 
                         );
                     }
                 }
-                Item::Impl(_) | Item::DropFn(_) => {
-                    // Impl blocks and drop fns are validated in Sema, not here.
+                Item::Impl(_) | Item::DropFn(_) | Item::Const(_) => {
+                    // Impl blocks, drop fns, and const declarations are validated in Sema, not here.
                     // They can have multiple impl blocks for the same type (with different methods).
+                    // Const declarations are checked for duplicates in the declarations phase.
                 }
             }
             all_items.push(item.clone());
@@ -652,7 +653,7 @@ pub fn validate_and_generate_rir_parallel(
                         );
                     }
                 }
-                Item::Impl(_) | Item::DropFn(_) => {
+                Item::Impl(_) | Item::DropFn(_) | Item::Const(_) => {
                     // Validated in Sema
                 }
             }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -103,21 +103,22 @@ impl ErrorCode {
     pub const ASSOC_FN_CALLED_AS_METHOD: Self = Self(415);
     pub const DUPLICATE_DESTRUCTOR: Self = Self(416);
     pub const DESTRUCTOR_UNKNOWN_TYPE: Self = Self(417);
-    pub const DUPLICATE_VARIANT: Self = Self(418);
-    pub const UNKNOWN_VARIANT: Self = Self(419);
-    pub const UNKNOWN_ENUM_TYPE: Self = Self(420);
-    pub const FIELD_WRONG_ORDER: Self = Self(421);
-    pub const FIELD_ACCESS_ON_NON_STRUCT: Self = Self(422);
-    pub const INVALID_ASSIGNMENT_TARGET: Self = Self(423);
-    pub const INOUT_NON_LVALUE: Self = Self(424);
-    pub const INOUT_EXCLUSIVE_ACCESS: Self = Self(425);
-    pub const BORROW_NON_LVALUE: Self = Self(426);
-    pub const MUTATE_BORROWED_VALUE: Self = Self(427);
-    pub const MOVE_OUT_OF_BORROW: Self = Self(428);
-    pub const BORROW_INOUT_CONFLICT: Self = Self(429);
-    pub const INOUT_KEYWORD_MISSING: Self = Self(430);
-    pub const BORROW_KEYWORD_MISSING: Self = Self(431);
-    pub const EMPTY_STRUCT: Self = Self(432);
+    pub const DUPLICATE_CONSTANT: Self = Self(418);
+    pub const DUPLICATE_VARIANT: Self = Self(419);
+    pub const UNKNOWN_VARIANT: Self = Self(420);
+    pub const UNKNOWN_ENUM_TYPE: Self = Self(421);
+    pub const FIELD_WRONG_ORDER: Self = Self(422);
+    pub const FIELD_ACCESS_ON_NON_STRUCT: Self = Self(423);
+    pub const INVALID_ASSIGNMENT_TARGET: Self = Self(424);
+    pub const INOUT_NON_LVALUE: Self = Self(425);
+    pub const INOUT_EXCLUSIVE_ACCESS: Self = Self(426);
+    pub const BORROW_NON_LVALUE: Self = Self(427);
+    pub const MUTATE_BORROWED_VALUE: Self = Self(428);
+    pub const MOVE_OUT_OF_BORROW: Self = Self(429);
+    pub const BORROW_INOUT_CONFLICT: Self = Self(430);
+    pub const INOUT_KEYWORD_MISSING: Self = Self(431);
+    pub const BORROW_KEYWORD_MISSING: Self = Self(432);
+    pub const EMPTY_STRUCT: Self = Self(433);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -882,6 +883,11 @@ pub enum ErrorKind {
     #[error("unknown type '{type_name}' in destructor")]
     DestructorUnknownType { type_name: String },
 
+    // Constant errors
+    /// Duplicate constant declaration
+    #[error("duplicate {kind} '{name}'")]
+    DuplicateConstant { name: String, kind: String },
+
     // Enum errors
     #[error("duplicate variant '{variant_name}' in enum '{enum_name}'")]
     DuplicateVariant {
@@ -1066,6 +1072,7 @@ impl ErrorKind {
             ErrorKind::AssocFnCalledAsMethod { .. } => ErrorCode::ASSOC_FN_CALLED_AS_METHOD,
             ErrorKind::DuplicateDestructor { .. } => ErrorCode::DUPLICATE_DESTRUCTOR,
             ErrorKind::DestructorUnknownType { .. } => ErrorCode::DESTRUCTOR_UNKNOWN_TYPE,
+            ErrorKind::DuplicateConstant { .. } => ErrorCode::DUPLICATE_CONSTANT,
             ErrorKind::DuplicateVariant { .. } => ErrorCode::DUPLICATE_VARIANT,
             ErrorKind::UnknownVariant { .. } => ErrorCode::UNKNOWN_VARIANT,
             ErrorKind::UnknownEnumType(_) => ErrorCode::UNKNOWN_ENUM_TYPE,

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -42,6 +42,7 @@ pub enum TokenKind {
     SelfValue, // self (value, not type)
     Comptime,  // comptime (compile-time evaluation)
     Pub,       // pub visibility modifier (module system)
+    Const,     // const declaration (module system re-exports)
 
     // Type keywords
     I8,
@@ -137,6 +138,7 @@ impl TokenKind {
             TokenKind::SelfValue => "'self'",
             TokenKind::Comptime => "'comptime'",
             TokenKind::Pub => "'pub'",
+            TokenKind::Const => "'const'",
             TokenKind::I8 => "type 'i8'",
             TokenKind::I16 => "type 'i16'",
             TokenKind::I32 => "type 'i32'",
@@ -234,6 +236,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::SelfValue => write!(f, "SELF"),
             TokenKind::Comptime => write!(f, "COMPTIME"),
             TokenKind::Pub => write!(f, "PUB"),
+            TokenKind::Const => write!(f, "CONST"),
             TokenKind::I8 => write!(f, "TYPE(i8)"),
             TokenKind::I16 => write!(f, "TYPE(i16)"),
             TokenKind::I32 => write!(f, "TYPE(i32)"),

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -155,6 +155,8 @@ pub enum LogosTokenKind {
     Comptime,
     #[token("pub")]
     Pub,
+    #[token("const")]
+    Const,
 
     // Type keywords
     #[token("i8")]
@@ -312,6 +314,7 @@ impl From<LogosTokenKind> for TokenKind {
             LogosTokenKind::SelfValue => TokenKind::SelfValue,
             LogosTokenKind::Comptime => TokenKind::Comptime,
             LogosTokenKind::Pub => TokenKind::Pub,
+            LogosTokenKind::Const => TokenKind::Const,
             LogosTokenKind::I8 => TokenKind::I8,
             LogosTokenKind::I16 => TokenKind::I16,
             LogosTokenKind::I32 => TokenKind::I32,

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -69,6 +69,33 @@ pub enum Item {
     Enum(EnumDecl),
     Impl(ImplBlock),
     DropFn(DropFn),
+    /// Constant declaration (e.g., `const math = @import("math");`)
+    Const(ConstDecl),
+}
+
+/// A constant declaration.
+///
+/// Constants are compile-time values. In the context of the module system,
+/// they're used for re-exports:
+/// ```rue
+/// // _utils.rue (directory module root)
+/// pub const strings = @import("utils/strings.rue");
+/// pub const helper = @import("utils/internal.rue").helper;
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConstDecl {
+    /// Directives applied to this const
+    pub directives: Directives,
+    /// Visibility of this constant
+    pub visibility: Visibility,
+    /// Constant name
+    pub name: Ident,
+    /// Optional type annotation (usually inferred)
+    pub ty: Option<TypeExpr>,
+    /// Initializer expression
+    pub init: Box<Expr>,
+    /// Span covering the entire const declaration
+    pub span: Span,
 }
 
 /// A struct declaration.
@@ -874,6 +901,7 @@ impl fmt::Display for Ast {
                 Item::Enum(e) => fmt_enum(f, e, 0)?,
                 Item::Impl(impl_block) => fmt_impl_block(f, impl_block, 0)?,
                 Item::DropFn(drop_fn) => fmt_drop_fn(f, drop_fn, 0)?,
+                Item::Const(c) => fmt_const(f, c, 0)?,
             }
         }
         Ok(())
@@ -915,6 +943,23 @@ fn fmt_enum(f: &mut fmt::Formatter<'_>, e: &EnumDecl, level: usize) -> fmt::Resu
         indent(f, level + 1)?;
         writeln!(f, "Variant sym:{}", variant.name.name.into_usize())?;
     }
+    Ok(())
+}
+
+fn fmt_const(f: &mut fmt::Formatter<'_>, c: &ConstDecl, level: usize) -> fmt::Result {
+    indent(f, level)?;
+    for directive in &c.directives {
+        write!(f, "@sym:{} ", directive.name.name.into_usize())?;
+    }
+    if c.visibility == Visibility::Public {
+        write!(f, "pub ")?;
+    }
+    write!(f, "Const sym:{}", c.name.name.into_usize())?;
+    if let Some(ref ty) = c.ty {
+        write!(f, ": {}", ty)?;
+    }
+    writeln!(f)?;
+    fmt_expr(f, &c.init, level + 1)?;
     Ok(())
 }
 

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -6,8 +6,8 @@
 use crate::ast::{
     AnonStructField, ArgMode, ArrayLitExpr, AssignStatement, AssignTarget, AssocFnCallExpr, Ast,
     BinaryExpr, BinaryOp, BlockExpr, BoolLit, BreakExpr, CallArg, CallExpr, ComptimeBlockExpr,
-    ContinueExpr, Directive, DirectiveArg, Directives, DropFn, EnumDecl, EnumVariant, Expr,
-    FieldDecl, FieldExpr, FieldInit, Function, Ident, IfExpr, ImplBlock, IndexExpr, IntLit,
+    ConstDecl, ContinueExpr, Directive, DirectiveArg, Directives, DropFn, EnumDecl, EnumVariant,
+    Expr, FieldDecl, FieldExpr, FieldInit, Function, Ident, IfExpr, ImplBlock, IndexExpr, IntLit,
     IntrinsicArg, IntrinsicCallExpr, Item, LetPattern, LetStatement, LoopExpr, MatchArm, MatchExpr,
     Method, MethodCallExpr, NegIntLit, Param, ParamMode, ParenExpr, PathExpr, PathPattern, Pattern,
     ReturnExpr, SelfExpr, SelfParam, Statement, StringLit, StructDecl, StructLitExpr, TypeExpr,
@@ -1849,7 +1849,50 @@ where
         })
 }
 
-/// Parser for top-level items (functions, structs, enums, impl blocks, and drop fns)
+/// Parser for const declarations: [pub] const name [: Type] = expr;
+///
+/// Used for module re-exports:
+/// ```rue
+/// pub const strings = @import("utils/strings.rue");
+/// pub const helper = @import("utils/internal.rue").helper;
+/// ```
+fn const_parser<'src, I>() -> impl Parser<'src, I, ConstDecl, ParserExtras<'src>> + Clone
+where
+    I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
+{
+    let expr = expr_parser();
+
+    // Parse optional visibility (pub keyword)
+    let visibility = just(TokenKind::Pub).or_not().map(|opt| {
+        if opt.is_some() {
+            Visibility::Public
+        } else {
+            Visibility::Private
+        }
+    });
+
+    // Optional type annotation
+    let type_annotation = just(TokenKind::Colon).ignore_then(type_parser()).or_not();
+
+    directives_parser()
+        .then(visibility)
+        .then(just(TokenKind::Const).ignore_then(ident_parser()))
+        .then(type_annotation)
+        .then(just(TokenKind::Eq).ignore_then(expr))
+        .then_ignore(just(TokenKind::Semi))
+        .map_with(
+            |((((directives, visibility), name), ty), init), e| ConstDecl {
+                directives,
+                visibility,
+                name,
+                ty,
+                init: Box::new(init),
+                span: span_from_extra(e),
+            },
+        )
+}
+
+/// Parser for top-level items (functions, structs, enums, impl blocks, drop fns, and consts)
 fn item_parser<'src, I>() -> impl Parser<'src, I, Item, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
@@ -1860,6 +1903,7 @@ where
         enum_parser().map(Item::Enum),
         impl_parser().map(Item::Impl),
         drop_fn_parser().map(Item::DropFn),
+        const_parser().map(Item::Const),
     ))
 }
 
@@ -2057,6 +2101,7 @@ mod tests {
             Item::Enum(_) => panic!("parse_expr helper should only be used with functions"),
             Item::Impl(_) => panic!("parse_expr helper should only be used with functions"),
             Item::DropFn(_) => panic!("parse_expr helper should only be used with functions"),
+            Item::Const(_) => panic!("parse_expr helper should only be used with functions"),
         };
         Ok(ExprResult { expr, interner })
     }
@@ -2085,6 +2130,7 @@ mod tests {
             Item::Enum(_) => panic!("expected Function"),
             Item::Impl(_) => panic!("expected Function"),
             Item::DropFn(_) => panic!("expected Function"),
+            Item::Const(_) => panic!("expected Function"),
         }
     }
 
@@ -2154,6 +2200,7 @@ mod tests {
             Item::Enum(_) => panic!("expected Function"),
             Item::Impl(_) => panic!("expected Function"),
             Item::DropFn(_) => panic!("expected Function"),
+            Item::Const(_) => panic!("expected Function"),
         }
     }
 

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -8,7 +8,7 @@ use lasso::{Spur, ThreadedRodeo};
 /// Known type intrinsics that take a type argument rather than an expression.
 /// These intrinsics operate on types at compile time (e.g., @size_of(i32)).
 const TYPE_INTRINSICS: &[&str] = &["size_of", "align_of"];
-use rue_parser::ast::DropFn;
+use rue_parser::ast::{ConstDecl, DropFn};
 use rue_parser::{
     ArgMode, AssignTarget, Ast, BinaryOp, CallArg, Directive, DirectiveArg, EnumDecl, Expr,
     Function, ImplBlock, IntrinsicArg, Item, LetPattern, Method, ParamMode, Pattern, Statement,
@@ -66,6 +66,9 @@ impl<'a> AstGen<'a> {
             }
             Item::DropFn(drop_fn) => {
                 self.gen_drop_fn(drop_fn);
+            }
+            Item::Const(const_decl) => {
+                self.gen_const(const_decl);
             }
         }
     }
@@ -153,6 +156,26 @@ impl<'a> AstGen<'a> {
                 variants_len,
             },
             span: enum_decl.span,
+        })
+    }
+
+    fn gen_const(&mut self, const_decl: &ConstDecl) -> InstRef {
+        let directives = self.convert_directives(&const_decl.directives);
+        let (directives_start, directives_len) = self.rir.add_directives(&directives);
+        let name = const_decl.name.name; // Already a Spur
+        let ty = const_decl.ty.as_ref().map(|t| self.intern_type(t));
+        let init = self.gen_expr(&const_decl.init);
+
+        self.rir.add_inst(Inst {
+            data: InstData::ConstDecl {
+                directives_start,
+                directives_len,
+                is_pub: const_decl.visibility == Visibility::Public,
+                name,
+                ty,
+                init,
+            },
+            span: const_decl.span,
         })
     }
 

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -963,6 +963,23 @@ impl Rir {
                 has_self: *has_self,
             },
 
+            // Constant declaration - init is an InstRef
+            InstData::ConstDecl {
+                directives_start,
+                directives_len,
+                is_pub,
+                name,
+                ty,
+                init,
+            } => InstData::ConstDecl {
+                directives_start: *directives_start + extra_offset,
+                directives_len: *directives_len,
+                is_pub: *is_pub,
+                name: *name,
+                ty: *ty,
+                init: renumber(*init),
+            },
+
             // Function call - args in extra
             InstData::Call {
                 name,
@@ -1268,6 +1285,7 @@ impl Rir {
                 | InstData::Alloc { .. }
                 | InstData::Assign { .. }
                 | InstData::FnDecl { .. }
+                | InstData::ConstDecl { .. }
                 | InstData::FieldGet { .. }
                 | InstData::FieldSet { .. }
                 | InstData::StructDecl { .. }
@@ -1411,6 +1429,25 @@ pub enum InstData {
         /// Only true for methods in impl blocks that have a self parameter.
         /// Used by sema to know to add the implicit self parameter.
         has_self: bool,
+    },
+
+    /// Constant declaration
+    /// Contains: name symbol, optional type, initializer expression ref
+    /// Directives are stored in the extra array.
+    /// Used for module re-exports: `pub const strings = @import("utils/strings.rue");`
+    ConstDecl {
+        /// Index into extra data where directives start
+        directives_start: u32,
+        /// Number of directives
+        directives_len: u32,
+        /// Whether this constant is public (requires --preview modules)
+        is_pub: bool,
+        /// Constant name
+        name: Spur,
+        /// Optional type annotation (interned string, None if inferred)
+        ty: Option<Spur>,
+        /// Initializer expression
+        init: InstRef,
     },
 
     /// Function call
@@ -1835,6 +1872,21 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     .unwrap();
                     writeln!(out, "    {}", body).unwrap();
                     writeln!(out, "}}").unwrap();
+                }
+                InstData::ConstDecl {
+                    directives_start: _,
+                    directives_len: _,
+                    is_pub,
+                    name,
+                    ty,
+                    init,
+                } => {
+                    let pub_str = if *is_pub { "pub " } else { "" };
+                    let name_str = self.interner.resolve(&*name);
+                    let ty_str = ty
+                        .map(|t| format!(": {}", self.interner.resolve(&t)))
+                        .unwrap_or_default();
+                    writeln!(out, "{}const {}{} = {}", pub_str, name_str, ty_str, init).unwrap();
                 }
                 InstData::Ret(inner) => {
                     if let Some(inner) = inner {

--- a/crates/rue-spec/cases/modules/constants.toml
+++ b/crates/rue-spec/cases/modules/constants.toml
@@ -1,0 +1,112 @@
+[section]
+id = "modules.constants"
+name = "Constants"
+description = "Constant declarations for module re-exports (Phase 2 of module system). Spec chapter pending ADR-0026 finalization."
+
+# =============================================================================
+# Basic Const Declarations
+# =============================================================================
+
+[[case]]
+name = "const_basic_integer"
+preview = "modules"
+preview_should_pass = true
+description = "Basic const declaration with integer value"
+source = """
+const VALUE: i32 = 42;
+fn main() -> i32 { 0 }
+"""
+exit_code = 0
+
+[[case]]
+name = "const_without_type"
+preview = "modules"
+preview_should_pass = true
+description = "Const declaration without explicit type annotation"
+source = """
+const VALUE = 42;
+fn main() -> i32 { 0 }
+"""
+exit_code = 0
+
+# =============================================================================
+# Public Const Declarations
+# =============================================================================
+
+[[case]]
+name = "pub_const_basic"
+preview = "modules"
+preview_should_pass = true
+description = "Public const declaration is allowed with preview flag"
+source = """
+pub const VALUE: i32 = 42;
+fn main() -> i32 { 0 }
+"""
+exit_code = 0
+
+[[case]]
+name = "pub_const_without_preview_error"
+description = "Pub const without preview flag gives helpful error"
+source = """
+pub const VALUE: i32 = 42;
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "preview"
+
+# =============================================================================
+# Const with Import (Module Re-exports)
+# =============================================================================
+
+# Note: These tests verify the syntax is accepted. Full re-export behavior
+# will be tested once module population is implemented.
+
+[[case]]
+name = "const_import_syntax"
+preview = "modules"
+description = "Const with @import syntax parses correctly"
+source = """
+const math = @import("nonexistent");
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "module 'nonexistent' not found"
+
+[[case]]
+name = "pub_const_import_syntax"
+preview = "modules"
+description = "Pub const with @import syntax parses correctly"
+source = """
+pub const math = @import("nonexistent");
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "module 'nonexistent' not found"
+
+# =============================================================================
+# Duplicate Detection
+# =============================================================================
+
+[[case]]
+name = "duplicate_const_error"
+preview = "modules"
+description = "Duplicate const declarations cause error"
+source = """
+const X: i32 = 1;
+const X: i32 = 2;
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "duplicate"
+
+[[case]]
+name = "const_function_conflict"
+preview = "modules"
+description = "Const with same name as function causes error"
+source = """
+fn foo() -> i32 { 42 }
+const foo: i32 = 1;
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "duplicate"


### PR DESCRIPTION
Add support for const declarations throughout the compiler pipeline:

- Lexer: Add 'const' keyword token
- Parser: Add const_parser() for `[pub] const name [: Type] = expr;` syntax
- RIR: Add InstData::ConstDecl variant for untyped const representation
- Sema: Add ConstInfo struct and constants collection in declarations phase
- Error: Add DuplicateConstant error kind for duplicate const detection

This enables the Zig-inspired module re-export pattern:
  pub const math = @import("math");

The actual module population (populating ModuleDef with re-exported items from const declarations) will be done as part of full module member resolution.

Spec tests added in crates/rue-spec/cases/modules/constants.toml.

🤖 Generated with [Claude Code](https://claude.com/claude-code)