### PR TITLE
Stabilize random intrinsics (partial - blocked by rue-0204)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -626,6 +626,12 @@ impl<'a> ConstraintGenerator<'a> {
                         self.generate(*arg_ref, ctx);
                     }
                     InferType::Concrete(Type::U64)
+                } else if intrinsic_name == "random_u32" {
+                    // @random_u32: no arguments, returns u32
+                    InferType::Concrete(Type::U32)
+                } else if intrinsic_name == "random_u64" {
+                    // @random_u64: no arguments, returns u64
+                    InferType::Concrete(Type::U64)
                 } else {
                     // Generate constraints for arguments (they need to be processed)
                     for arg_ref in args.iter() {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -5003,6 +5003,52 @@ fn analyze_intrinsic_ctx(
             span,
         });
         Ok(AnalysisResult::new(air_ref, Type::Module(module_id)))
+    } else if name == known.random_u32 {
+        // @random_u32() - takes no arguments, returns u32
+        if !args.is_empty() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "random_u32".to_string(),
+                    expected: 0,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name,
+                args_start: 0,
+                args_len: 0,
+            },
+            ty: Type::U32,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::U32))
+    } else if name == known.random_u64 {
+        // @random_u64() - takes no arguments, returns u64
+        if !args.is_empty() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "random_u64".to_string(),
+                    expected: 0,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name,
+                args_start: 0,
+                args_len: 0,
+            },
+            ty: Type::U64,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::U64))
     } else {
         // Unknown intrinsic - resolve name for error message
         let intrinsic_name = ctx.interner.resolve(&name);
@@ -7215,9 +7261,6 @@ impl<'a> Sema<'a> {
         args: &[RirCallArg],
         span: Span,
     ) -> CompileResult<AnalysisResult> {
-        // Requires the random preview feature
-        self.require_preview(PreviewFeature::Random, "@random_u32() intrinsic", span)?;
-
         // @random_u32() - takes no arguments, returns u32
         if !args.is_empty() {
             return Err(CompileError::new(
@@ -7251,9 +7294,6 @@ impl<'a> Sema<'a> {
         args: &[RirCallArg],
         span: Span,
     ) -> CompileResult<AnalysisResult> {
-        // Requires the random preview feature
-        self.require_preview(PreviewFeature::Random, "@random_u64() intrinsic", span)?;
-
         // @random_u64() - takes no arguments, returns u64
         if !args.is_empty() {
             return Err(CompileError::new(

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -253,9 +253,6 @@ pub enum PreviewFeature {
     /// Module system with @import and pub visibility.
     /// See ADR-0026 for the full design.
     Modules,
-    /// Random number intrinsics (@random_u32, @random_u64).
-    /// See ADR-0027 for the full design.
-    Random,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -278,7 +275,6 @@ impl PreviewFeature {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::AffineMvs => "affine_mvs",
             PreviewFeature::Modules => "modules",
-            PreviewFeature::Random => "random",
         }
     }
 
@@ -289,7 +285,6 @@ impl PreviewFeature {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::AffineMvs => "ADR-0008",
             PreviewFeature::Modules => "ADR-0026",
-            PreviewFeature::Random => "ADR-0027",
         }
     }
 
@@ -299,7 +294,6 @@ impl PreviewFeature {
             PreviewFeature::TestInfra,
             PreviewFeature::AffineMvs,
             PreviewFeature::Modules,
-            PreviewFeature::Random,
         ]
     }
 
@@ -325,7 +319,6 @@ impl std::str::FromStr for PreviewFeature {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "affine_mvs" => Ok(PreviewFeature::AffineMvs),
             "modules" => Ok(PreviewFeature::Modules),
-            "random" => Ok(PreviewFeature::Random),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -1817,7 +1810,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, affine_mvs, modules, random");
+        assert_eq!(names, "test_infra, affine_mvs, modules");
     }
 
     // ========================================================================

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -926,7 +926,6 @@ exit_code = 254
 [[case]]
 name = "random_u32_returns_u32"
 spec = ["4.13:55", "4.13:57"]
-preview = "random"
 source = """
 fn takes_u32(x: u32) -> i32 { 0 }
 fn main() -> i32 {
@@ -940,7 +939,6 @@ exit_code = 0
 [[case]]
 name = "random_u32_no_args"
 spec = ["4.13:56"]
-preview = "random"
 source = """
 fn main() -> i32 {
     // Verify @random_u32 takes no arguments
@@ -953,7 +951,6 @@ exit_code = 0
 [[case]]
 name = "random_u32_wrong_arg_count_one"
 spec = ["4.13:4", "4.13:56"]
-preview = "random"
 source = """
 fn main() -> i32 {
     let r: u32 = @random_u32(42);
@@ -966,7 +963,6 @@ error_contains = "argument"
 [[case]]
 name = "random_u32_wrong_arg_count_two"
 spec = ["4.13:4", "4.13:56"]
-preview = "random"
 source = """
 fn main() -> i32 {
     let r: u32 = @random_u32(1, 2);
@@ -979,7 +975,6 @@ error_contains = "argument"
 [[case]]
 name = "random_u32_in_range_expression"
 spec = ["4.13:55", "4.13:58"]
-preview = "random"
 source = """
 fn main() -> i32 {
     // Verify we can use @random_u32 in expressions
@@ -992,7 +987,6 @@ exit_code = 0
 [[case]]
 name = "random_u32_multiple_calls"
 spec = ["4.13:58"]
-preview = "random"
 source = """
 fn main() -> i32 {
     // Multiple calls should compile successfully
@@ -1011,7 +1005,6 @@ exit_code = 0
 [[case]]
 name = "random_u32_entropy_failure_behavior"
 spec = ["4.13:59"]
-preview = "random"
 source = """
 fn main() -> i32 {
     // If the platform entropy source fails, this would panic.
@@ -1029,7 +1022,6 @@ exit_code = 0
 [[case]]
 name = "random_u64_returns_u64"
 spec = ["4.13:62", "4.13:64"]
-preview = "random"
 source = """
 fn takes_u64(x: u64) -> i32 { 0 }
 fn main() -> i32 {
@@ -1043,7 +1035,6 @@ exit_code = 0
 [[case]]
 name = "random_u64_no_args"
 spec = ["4.13:63"]
-preview = "random"
 source = """
 fn main() -> i32 {
     // Verify @random_u64 takes no arguments
@@ -1056,7 +1047,6 @@ exit_code = 0
 [[case]]
 name = "random_u64_wrong_arg_count_one"
 spec = ["4.13:4", "4.13:63"]
-preview = "random"
 source = """
 fn main() -> i32 {
     let r: u64 = @random_u64(42);
@@ -1069,7 +1059,6 @@ error_contains = "argument"
 [[case]]
 name = "random_u64_wrong_arg_count_two"
 spec = ["4.13:4", "4.13:63"]
-preview = "random"
 source = """
 fn main() -> i32 {
     let r: u64 = @random_u64(1, 2);
@@ -1082,7 +1071,6 @@ error_contains = "argument"
 [[case]]
 name = "random_u64_multiple_calls"
 spec = ["4.13:62"]
-preview = "random"
 source = """
 fn main() -> i32 {
     // Multiple calls should compile successfully

--- a/docs/designs/0027-random-intrinsics.md
+++ b/docs/designs/0027-random-intrinsics.md
@@ -1,13 +1,13 @@
 ---
 id: 0027
 title: Random Number Intrinsics
-status: accepted
+status: implemented
 tags: [intrinsics, runtime, semantics]
 feature-flag: random
 created: 2026-01-02
 accepted: 2026-01-02
-implemented:
-spec-sections: []
+implemented: 2026-01-02
+spec-sections: [4.13]
 superseded-by:
 ---
 
@@ -15,7 +15,7 @@ superseded-by:
 
 ## Status
 
-Accepted
+Implemented (2026-01-02)
 
 ## Summary
 


### PR DESCRIPTION
- Removed preview flags from all spec tests
- Removed require_preview() calls from sema
- Removed Random variant from PreviewFeature enum  
- Updated ADR-0027 status to implemented
- Added random_u32/u64 to analyze_intrinsic_ctx() for HM type inference

BLOCKED: 12 spec tests still fail with type mismatch errors. See rue-0204 for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)