### PR TITLE
feat(modules): Implement intra-directory visibility rules

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -980,6 +980,8 @@ mod tests {
             is_linear: false,
             destructor: None,
             is_builtin: false,
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
 
         let (struct_id, is_new) = pool.register_struct(name, def.clone());
@@ -1003,6 +1005,8 @@ mod tests {
         let def = EnumDef {
             name: "Color".to_string(),
             variants: vec!["Red".to_string(), "Green".to_string(), "Blue".to_string()],
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
 
         let (enum_id, is_new) = pool.register_enum(name, def.clone());
@@ -1057,6 +1061,8 @@ mod tests {
             is_linear: false,
             destructor: None,
             is_builtin: false,
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
 
         let (struct_id, _) = pool.register_struct(name, def);
@@ -1076,6 +1082,8 @@ mod tests {
         let def = EnumDef {
             name: "Status".to_string(),
             variants: vec!["Active".to_string(), "Inactive".to_string()],
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
 
         let (enum_id, _) = pool.register_enum(name, def);
@@ -1113,6 +1121,8 @@ mod tests {
             is_linear: false,
             destructor: None,
             is_builtin: false,
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         let (struct_id, _) = pool.register_struct(struct_name, struct_def);
         let struct_ty = pool.struct_id_to_interned(struct_id);
@@ -1147,6 +1157,8 @@ mod tests {
             is_linear: false,
             destructor: None,
             is_builtin: false,
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         let (struct_id, _) = pool.register_struct(struct_name, struct_def);
         let struct_ty = pool.struct_id_to_interned(struct_id);
@@ -1155,6 +1167,8 @@ mod tests {
         let enum_def = EnumDef {
             name: "Color".to_string(),
             variants: vec!["Red".to_string()],
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         let (enum_id, _) = pool.register_enum(enum_name, enum_def);
         let enum_ty = pool.enum_id_to_interned(enum_id);
@@ -1194,6 +1208,8 @@ mod tests {
             is_linear: false,
             destructor: None,
             is_builtin: false,
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         let (struct_id, _) = pool.register_struct(name, def.clone());
 
@@ -1224,6 +1240,8 @@ mod tests {
         let def = EnumDef {
             name: "Status".to_string(),
             variants: vec!["A".to_string(), "B".to_string()],
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         let (enum_id, _) = pool.register_enum(name, def.clone());
 
@@ -1265,6 +1283,8 @@ mod tests {
             is_linear: false,
             destructor: None,
             is_builtin: false,
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         let (struct_id, _) = pool.register_struct(name, def);
         let struct_ty = pool.struct_id_to_interned(struct_id);
@@ -1296,6 +1316,8 @@ mod tests {
             is_linear: false,
             destructor: None,
             is_builtin: false,
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         pool.register_struct(s1, def.clone());
         pool.register_struct(
@@ -1311,6 +1333,8 @@ mod tests {
             EnumDef {
                 name: "E1".to_string(),
                 variants: vec![],
+                is_pub: false,
+                file_id: rue_span::FileId::DEFAULT,
             },
         );
 
@@ -1449,6 +1473,8 @@ mod tests {
                             is_linear: false,
                             destructor: None,
                             is_builtin: false,
+                            is_pub: false,
+                            file_id: rue_span::FileId::DEFAULT,
                         };
                         pool.register_struct(name, def);
                     }

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -4325,7 +4325,9 @@ fn analyze_method_call_ctx(
 /// namespace at the source level.
 ///
 /// This function looks up the function by name in the global function table and
-/// generates a direct call to it.
+/// generates a direct call to it. Visibility is checked based on directory:
+/// - `pub` functions are always accessible
+/// - Private functions are only accessible from the same directory
 fn analyze_module_member_call_ctx(
     ctx: &SemaContext<'_>,
     air: &mut Air,
@@ -4340,6 +4342,19 @@ fn analyze_module_member_call_ctx(
     let fn_info = ctx
         .get_function(function_name)
         .ok_or_compile_error(ErrorKind::UndefinedFunction(fn_name_str.clone()), span)?;
+
+    // Check visibility: private functions are only accessible from the same directory
+    let accessing_file_id = span.file_id;
+    let target_file_id = fn_info.file_id;
+    if !ctx.is_accessible(accessing_file_id, target_file_id, fn_info.is_pub) {
+        return Err(CompileError::new(
+            ErrorKind::PrivateMemberAccess {
+                item_kind: "function".to_string(),
+                name: fn_name_str,
+            },
+            span,
+        ));
+    }
 
     let args = ctx.rir.get_call_args(args_start, args_len);
 
@@ -6619,6 +6634,19 @@ impl<'a> Sema<'a> {
             .get(&function_name)
             .ok_or_compile_error(ErrorKind::UndefinedFunction(fn_name_str.clone()), span)?
             .clone();
+
+        // Check visibility: private functions are only accessible from the same directory
+        let accessing_file_id = span.file_id;
+        let target_file_id = fn_info.file_id;
+        if !self.is_accessible(accessing_file_id, target_file_id, fn_info.is_pub) {
+            return Err(CompileError::new(
+                ErrorKind::PrivateMemberAccess {
+                    item_kind: "function".to_string(),
+                    name: fn_name_str,
+                },
+                span,
+            ));
+        }
 
         let args = self.rir.get_call_args(args_start, args_len);
 

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -36,6 +36,7 @@ impl<'a> Sema<'a> {
                 .collect();
 
             // Create the synthetic struct definition
+            // Built-in types are always public and have no source file
             let struct_def = StructDef {
                 name: builtin.name.to_string(),
                 fields,
@@ -44,6 +45,8 @@ impl<'a> Sema<'a> {
                 is_linear: false, // Built-in types are not linear
                 destructor: builtin.drop_fn.map(|s| s.to_string()),
                 is_builtin: true,
+                is_pub: true,                      // Built-in types are always public
+                file_id: rue_span::FileId::new(0), // Synthetic, no source file
             };
 
             // Register in type pool and get pool-based StructId

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -196,6 +196,8 @@ impl<'a> Sema<'a> {
                     let enum_def = EnumDef {
                         name: enum_name,
                         variants: variant_names,
+                        is_pub: *is_pub,
+                        file_id: inst.span.file_id,
                     };
 
                     // Register in type pool and get pool-based EnumId
@@ -269,6 +271,8 @@ impl<'a> Sema<'a> {
                         is_linear: *is_linear,
                         destructor: None,  // Filled in during resolve_declarations
                         is_builtin: false, // User-defined struct
+                        is_pub: *is_pub,
+                        file_id: inst.span.file_id,
                     };
 
                     // Register in type pool and get pool-based StructId
@@ -445,6 +449,7 @@ impl<'a> Sema<'a> {
                         *return_type,
                         *body,
                         inst.span,
+                        *is_pub,
                     )?;
                 }
 
@@ -713,6 +718,7 @@ impl<'a> Sema<'a> {
         return_type_sym: Spur,
         body: InstRef,
         span: Span,
+        is_pub: bool,
     ) -> CompileResult<()> {
         let params = self.rir.get_params(params_start, params_len);
 
@@ -774,6 +780,8 @@ impl<'a> Sema<'a> {
                 body,
                 span,
                 is_generic,
+                is_pub,
+                file_id: span.file_id,
             },
         );
         Ok(())

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -198,6 +198,10 @@ pub struct FunctionInfo {
     pub span: rue_span::Span,
     /// Whether this function has any comptime type parameters
     pub is_generic: bool,
+    /// Whether this function is public (visible outside its directory)
+    pub is_pub: bool,
+    /// File ID this function was declared in (for visibility checking)
+    pub file_id: rue_span::FileId,
 }
 
 /// Information about a method in an impl block.
@@ -313,6 +317,47 @@ impl<'a> Sema<'a> {
     /// Looks up the file path using the span's file_id.
     pub(crate) fn get_source_path(&self, span: rue_span::Span) -> Option<&str> {
         self.file_paths.get(&span.file_id).map(|s| s.as_str())
+    }
+
+    /// Get the file path for a given FileId.
+    pub(crate) fn get_file_path(&self, file_id: FileId) -> Option<&str> {
+        self.file_paths.get(&file_id).map(|s| s.as_str())
+    }
+
+    /// Check if the accessing file can see a private item from the target file.
+    ///
+    /// Visibility rules (per ADR-0026):
+    /// - `pub` items are always accessible
+    /// - Private items are accessible if the files are in the same directory
+    ///
+    /// Returns true if the item is accessible.
+    pub(crate) fn is_accessible(
+        &self,
+        accessing_file_id: FileId,
+        target_file_id: FileId,
+        is_pub: bool,
+    ) -> bool {
+        // Public items are always accessible
+        if is_pub {
+            return true;
+        }
+
+        // Get paths for both files
+        let accessing_path = self.get_file_path(accessing_file_id);
+        let target_path = self.get_file_path(target_file_id);
+
+        // If we can't determine the paths, be permissive (for single-file mode or tests)
+        match (accessing_path, target_path) {
+            (Some(acc), Some(tgt)) => {
+                use std::path::Path;
+                let acc_dir = Path::new(acc).parent();
+                let tgt_dir = Path::new(tgt).parent();
+                // Same directory means accessible
+                acc_dir == tgt_dir
+            }
+            // If either path is unknown, allow access (e.g., synthetic types, single-file mode)
+            _ => true,
+        }
     }
 
     /// Perform semantic analysis on the RIR.
@@ -526,6 +571,8 @@ impl<'a> Sema<'a> {
             is_linear: false,
             destructor: None,
             is_builtin: false,
+            is_pub: false,                     // Anonymous structs are private
+            file_id: rue_span::FileId::new(0), // Anonymous, no source file
         };
 
         let (struct_id, _) = self.type_pool.register_struct(name_spur, struct_def);

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -324,6 +324,47 @@ impl<'a> SemaContext<'a> {
         self.source_file_path.as_deref()
     }
 
+    /// Get the file path for a given FileId.
+    pub fn get_file_path(&self, file_id: rue_span::FileId) -> Option<&str> {
+        self.file_paths.get(&file_id).map(|s| s.as_str())
+    }
+
+    /// Check if the accessing file can see a private item from the target file.
+    ///
+    /// Visibility rules (per ADR-0026):
+    /// - `pub` items are always accessible
+    /// - Private items are accessible if the files are in the same directory
+    ///
+    /// Returns true if the item is accessible.
+    pub fn is_accessible(
+        &self,
+        accessing_file_id: rue_span::FileId,
+        target_file_id: rue_span::FileId,
+        is_pub: bool,
+    ) -> bool {
+        // Public items are always accessible
+        if is_pub {
+            return true;
+        }
+
+        // Get paths for both files
+        let accessing_path = self.get_file_path(accessing_file_id);
+        let target_path = self.get_file_path(target_file_id);
+
+        // If we can't determine the paths, be permissive (for single-file mode or tests)
+        match (accessing_path, target_path) {
+            (Some(acc), Some(tgt)) => {
+                use std::path::Path;
+                let acc_dir = Path::new(acc).parent();
+                let tgt_dir = Path::new(tgt).parent();
+                // Same directory means accessible
+                acc_dir == tgt_dir
+            }
+            // If either path is unknown, allow access (e.g., synthetic types, single-file mode)
+            _ => true,
+        }
+    }
+
     /// Get a human-readable name for a type.
     pub fn format_type_name(&self, ty: Type) -> String {
         match ty.kind() {

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -290,6 +290,10 @@ pub struct StructDef {
     /// Built-in types behave like regular structs but have runtime implementations
     /// for their methods rather than generated code.
     pub is_builtin: bool,
+    /// Whether this struct is public (visible outside its directory)
+    pub is_pub: bool,
+    /// File ID this struct was declared in (for visibility checking)
+    pub file_id: rue_span::FileId,
 }
 
 /// A field in a struct definition.
@@ -320,6 +324,10 @@ pub struct EnumDef {
     pub name: String,
     /// Variant names in declaration order
     pub variants: Vec<String>,
+    /// Whether this enum is public (visible outside its directory)
+    pub is_pub: bool,
+    /// File ID this enum was declared in (for visibility checking)
+    pub file_id: rue_span::FileId,
 }
 
 impl EnumDef {
@@ -1152,6 +1160,8 @@ mod tests {
             is_linear: false,
             destructor: None,
             is_builtin: false,
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
 
         let (idx, field) = def.find_field("x").unwrap();
@@ -1176,6 +1186,8 @@ mod tests {
             is_linear: false,
             destructor: None,
             is_builtin: false,
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         assert_eq!(empty.field_count(), 0);
 
@@ -1200,6 +1212,8 @@ mod tests {
             is_linear: false,
             destructor: None,
             is_builtin: false,
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         assert_eq!(with_fields.field_count(), 3);
     }
@@ -1211,12 +1225,16 @@ mod tests {
         let empty = EnumDef {
             name: "Empty".to_string(),
             variants: vec![],
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         assert_eq!(empty.variant_count(), 0);
 
         let color = EnumDef {
             name: "Color".to_string(),
             variants: vec!["Red".to_string(), "Green".to_string(), "Blue".to_string()],
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         assert_eq!(color.variant_count(), 3);
     }
@@ -1226,6 +1244,8 @@ mod tests {
         let color = EnumDef {
             name: "Color".to_string(),
             variants: vec!["Red".to_string(), "Green".to_string(), "Blue".to_string()],
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
 
         assert_eq!(color.find_variant("Red"), Some(0));
@@ -1239,6 +1259,8 @@ mod tests {
         let empty = EnumDef {
             name: "Empty".to_string(),
             variants: vec![],
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         assert_eq!(empty.discriminant_type(), Type::Never);
     }
@@ -1249,12 +1271,16 @@ mod tests {
         let small = EnumDef {
             name: "Small".to_string(),
             variants: vec!["A".to_string()],
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         assert_eq!(small.discriminant_type(), Type::U8);
 
         let max_u8 = EnumDef {
             name: "MaxU8".to_string(),
             variants: (0..256).map(|i| format!("V{}", i)).collect(),
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         assert_eq!(max_u8.discriminant_type(), Type::U8);
     }
@@ -1265,6 +1291,8 @@ mod tests {
         let medium = EnumDef {
             name: "Medium".to_string(),
             variants: (0..257).map(|i| format!("V{}", i)).collect(),
+            is_pub: false,
+            file_id: rue_span::FileId::DEFAULT,
         };
         assert_eq!(medium.discriminant_type(), Type::U16);
     }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -141,6 +141,7 @@ impl ErrorCode {
     pub const INTRINSIC_TYPE_MISMATCH: Self = Self(702);
     pub const IMPORT_REQUIRES_STRING_LITERAL: Self = Self(703);
     pub const MODULE_NOT_FOUND: Self = Self(704);
+    pub const PRIVATE_MEMBER_ACCESS: Self = Self(705);
 
     // ========================================================================
     // Literal/operator errors (E0800-E0899)
@@ -960,6 +961,8 @@ pub enum ErrorKind {
         /// Candidates that were tried (for error message)
         candidates: Vec<String>,
     },
+    #[error("{item_kind} `{name}` is private")]
+    PrivateMemberAccess { item_kind: String, name: String },
 
     // Literal errors
     #[error("literal value {value} is out of range for type '{ty}'")]
@@ -1096,6 +1099,7 @@ impl ErrorKind {
             ErrorKind::IntrinsicTypeMismatch(_) => ErrorCode::INTRINSIC_TYPE_MISMATCH,
             ErrorKind::ImportRequiresStringLiteral => ErrorCode::IMPORT_REQUIRES_STRING_LITERAL,
             ErrorKind::ModuleNotFound { .. } => ErrorCode::MODULE_NOT_FOUND,
+            ErrorKind::PrivateMemberAccess { .. } => ErrorCode::PRIVATE_MEMBER_ACCESS,
 
             // Literal/operator errors (E0800-E0899)
             ErrorKind::LiteralOutOfRange { .. } => ErrorCode::LITERAL_OUT_OF_RANGE,

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -1023,7 +1023,8 @@ where
         choice((method_call_suffix, field_suffix, index_suffix)).repeated(),
         |base, suffix| match suffix {
             Suffix::Field(field) => {
-                let span = Span::new(base.span().start, field.span.end);
+                // Extend the base span to include the field, preserving file_id
+                let span = base.span().extend_to(field.span.end);
                 Expr::Field(FieldExpr {
                     base: Box::new(base),
                     field,
@@ -1031,7 +1032,8 @@ where
                 })
             }
             Suffix::MethodCall(method, args, end) => {
-                let span = Span::new(base.span().start, end);
+                // Extend the base span to the end of the call, preserving file_id
+                let span = base.span().extend_to(end);
                 Expr::MethodCall(MethodCallExpr {
                     receiver: Box::new(base),
                     method,
@@ -1040,7 +1042,8 @@ where
                 })
             }
             Suffix::Index(index, end) => {
-                let span = Span::new(base.span().start, end);
+                // Extend the base span to the end of the index, preserving file_id
+                let span = base.span().extend_to(end);
                 Expr::Index(IndexExpr {
                     base: Box::new(base),
                     index: Box::new(index),

--- a/crates/rue-span/src/lib.rs
+++ b/crates/rue-span/src/lib.rs
@@ -100,6 +100,18 @@ impl Span {
         }
     }
 
+    /// Extend this span to a new end position, preserving the file ID.
+    ///
+    /// Creates a span from `self.start` to `end` with the same file ID.
+    #[inline]
+    pub const fn extend_to(&self, end: u32) -> Self {
+        Self {
+            file_id: self.file_id,
+            start: self.start,
+            end,
+        }
+    }
+
     /// Get the start byte offset.
     #[inline]
     pub const fn start(&self) -> u32 {

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -1,0 +1,235 @@
+[section]
+id = "modules.intra_directory"
+name = "Intra-Directory Visibility"
+description = "Files within the same directory can access each other's non-pub items. Per ADR-0026, pub only affects cross-directory visibility."
+
+# =============================================================================
+# Intra-Directory Access (Same Directory)
+# =============================================================================
+# Files in the same directory can access private (non-pub) items from each other.
+
+[[case]]
+name = "same_dir_access_private_fn"
+preview = "modules"
+preview_should_pass = true
+description = "Files in same directory can access private functions"
+source = """
+fn main() -> i32 {
+    let utils = @import("utils");
+    utils.internal_helper()
+}
+"""
+aux_files = { "utils.rue" = """
+// Private function - no pub keyword
+fn internal_helper() -> i32 {
+    42
+}
+""" }
+pass_aux_files = true
+exit_code = 42
+
+[[case]]
+name = "same_dir_access_pub_fn"
+preview = "modules"
+preview_should_pass = true
+description = "Files in same directory can access public functions"
+source = """
+fn main() -> i32 {
+    let utils = @import("utils");
+    utils.public_helper()
+}
+"""
+aux_files = { "utils.rue" = """
+pub fn public_helper() -> i32 {
+    42
+}
+""" }
+pass_aux_files = true
+exit_code = 42
+
+[[case]]
+name = "same_dir_access_private_struct"
+preview = "modules"
+description = "Files in same directory can access private structs"
+source = """
+fn main() -> i32 {
+    let utils = @import("utils");
+    let p = utils.InternalPoint { x: 20, y: 22 };
+    p.x + p.y
+}
+"""
+aux_files = { "utils.rue" = """
+// Private struct - no pub keyword
+struct InternalPoint { x: i32, y: i32 }
+""" }
+pass_aux_files = true
+exit_code = 42
+
+[[case]]
+name = "same_dir_access_private_enum"
+preview = "modules"
+description = "Files in same directory can access private enums"
+source = """
+fn main() -> i32 {
+    let utils = @import("utils");
+    let s = utils.InternalStatus::Active;
+    match s {
+        utils.InternalStatus::Active => 42,
+        utils.InternalStatus::Inactive => 0,
+    }
+}
+"""
+aux_files = { "utils.rue" = """
+// Private enum - no pub keyword
+enum InternalStatus { Active, Inactive }
+""" }
+pass_aux_files = true
+exit_code = 42
+
+# =============================================================================
+# Cross-Directory Access (Different Directories)
+# =============================================================================
+# Files in different directories can only access pub items.
+
+[[case]]
+name = "cross_dir_access_pub_fn"
+preview = "modules"
+preview_should_pass = true
+description = "Files in different directories can access public functions"
+source = """
+fn main() -> i32 {
+    let utils = @import("subdir/utils");
+    utils.public_fn()
+}
+"""
+aux_files = { "subdir/utils.rue" = """
+pub fn public_fn() -> i32 {
+    42
+}
+""" }
+pass_aux_files = true
+exit_code = 42
+
+[[case]]
+name = "cross_dir_access_private_fn_error"
+preview = "modules"
+preview_should_pass = true
+description = "Files in different directories cannot access private functions"
+source = """
+fn main() -> i32 {
+    let utils = @import("subdir/utils");
+    utils.private_fn()
+}
+"""
+aux_files = { "subdir/utils.rue" = """
+fn private_fn() -> i32 {
+    42
+}
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "private"
+
+[[case]]
+name = "cross_dir_access_pub_struct"
+preview = "modules"
+description = "Files in different directories can access public structs"
+source = """
+fn main() -> i32 {
+    let utils = @import("subdir/utils");
+    let p = utils.PublicPoint { x: 10, y: 32 };
+    p.x + p.y
+}
+"""
+aux_files = { "subdir/utils.rue" = """
+pub struct PublicPoint { x: i32, y: i32 }
+""" }
+pass_aux_files = true
+exit_code = 42
+
+[[case]]
+name = "cross_dir_access_private_struct_error"
+preview = "modules"
+description = "Files in different directories cannot access private structs"
+source = """
+fn main() -> i32 {
+    let utils = @import("subdir/utils");
+    let p = utils.PrivatePoint { x: 10, y: 32 };
+    p.x + p.y
+}
+"""
+aux_files = { "subdir/utils.rue" = """
+struct PrivatePoint { x: i32, y: i32 }
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "private"
+
+[[case]]
+name = "cross_dir_access_pub_enum"
+preview = "modules"
+description = "Files in different directories can access public enums"
+source = """
+fn main() -> i32 {
+    let utils = @import("subdir/utils");
+    let s = utils.PublicStatus::On;
+    match s {
+        utils.PublicStatus::On => 42,
+        utils.PublicStatus::Off => 0,
+    }
+}
+"""
+aux_files = { "subdir/utils.rue" = """
+pub enum PublicStatus { On, Off }
+""" }
+pass_aux_files = true
+exit_code = 42
+
+[[case]]
+name = "cross_dir_access_private_enum_error"
+preview = "modules"
+description = "Files in different directories cannot access private enums"
+source = """
+fn main() -> i32 {
+    let utils = @import("subdir/utils");
+    let s = utils.PrivateStatus::On;
+    0
+}
+"""
+aux_files = { "subdir/utils.rue" = """
+enum PrivateStatus { On, Off }
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "private"
+
+# =============================================================================
+# Nested Submodule Access
+# =============================================================================
+# Tests for the _foo.rue + foo/ directory module pattern.
+
+[[case]]
+name = "directory_module_intra_access"
+preview = "modules"
+description = "Files within a directory module can access each other's private items"
+source = """
+fn main() -> i32 {
+    let utils = @import("utils");
+    utils.format()
+}
+"""
+aux_files = { "_utils.rue" = """
+// Re-export the strings module functions
+const strings = @import("utils/strings");
+
+pub fn format() -> i32 {
+    strings.internal_format()
+}
+""", "utils/strings.rue" = """
+// Private function - accessible from _utils.rue since same directory module
+fn internal_format() -> i32 {
+    42
+}
+""" }
+pass_aux_files = true
+exit_code = 42

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -159,6 +159,11 @@ pub struct Case {
     /// Example: `{ "math.rue" = "pub fn add(a: i32, b: i32) -> i32 { a + b }" }`
     #[serde(default)]
     pub aux_files: HashMap<String, String>,
+    /// If true, pass aux_files to the compiler on the command line (multi-file compilation).
+    /// If false (default), aux_files are just written to disk for @import to find.
+    /// Use this when tests need to call functions from imported modules.
+    #[serde(default)]
+    pub pass_aux_files: bool,
 }
 
 /// A test file containing a section and its cases.
@@ -257,6 +262,7 @@ pub fn expand_case(case: Case) -> Vec<Case> {
                 opt_level: case.opt_level,
                 timeout_ms: case.timeout_ms,
                 aux_files: case.aux_files.clone(),
+                pass_aux_files: case.pass_aux_files,
 
                 // Clear params on expanded case
                 params: vec![],
@@ -680,9 +686,18 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
     }
 
     // Compile with rue
-    let compile_output = build_command(rue_binary)
-        .arg(&source_path)
-        .arg(&output_path)
+    // By default, aux_files are just written to disk for @import to find.
+    // When pass_aux_files is true, they're passed on the command line for
+    // multi-file compilation (needed when tests call functions from imported modules).
+    let mut compile_cmd = build_command(rue_binary);
+    compile_cmd.arg(&source_path);
+    if case.pass_aux_files {
+        for aux_path in &aux_paths {
+            compile_cmd.arg(aux_path);
+        }
+    }
+    compile_cmd.arg("-o").arg(&output_path);
+    let compile_output = compile_cmd
         .output()
         .map_err(|e| format!("Failed to run rue compiler: {}", e))?;
 
@@ -980,6 +995,7 @@ mod tests {
             stderr_contains: None,
             params: vec![],
             aux_files: HashMap::new(),
+            pass_aux_files: false,
         };
 
         let expanded = expand_case(case);
@@ -1028,6 +1044,7 @@ mod tests {
             stderr_contains: None,
             params: vec![ParamSet { values: param1 }, ParamSet { values: param2 }],
             aux_files: HashMap::new(),
+            pass_aux_files: false,
         };
 
         let expanded = expand_case(case);
@@ -1084,6 +1101,7 @@ mod tests {
             stderr_contains: None,
             params: vec![ParamSet { values: params }],
             aux_files: HashMap::new(),
+            pass_aux_files: false,
         };
 
         let expanded = expand_case(case);
@@ -1132,6 +1150,7 @@ mod tests {
             stderr_contains: None,
             params: vec![ParamSet { values: params }],
             aux_files: HashMap::new(),
+            pass_aux_files: false,
         };
 
         let expanded = expand_case(case);


### PR DESCRIPTION
Per ADR-0026, pub only affects cross-directory visibility. Files within the same directory can access each other's private (non-pub) items:

- Added is_pub and file_id tracking to FunctionInfo, StructDef, and EnumDef
- Added is_accessible() helper to check directory relationships
- Visibility check in analyze_module_member_call_impl for function calls
- Added PrivateMemberAccess error kind for clear error messages
- Fixed parser span creation to preserve file_id with new extend_to() method
- Added test runner support for aux_files in multi-file test cases

Passing tests:
- same_dir_access_private_fn: Files in same dir can access private functions
- same_dir_access_pub_fn: Files in same dir can access public functions  
- cross_dir_access_pub_fn: Files in different dirs can access public functions
- cross_dir_access_private_fn_error: Files in different dirs cannot access private functions (produces 'function X is private' error)

Closes: rue-c0z8, rue-5r4d

🤖 Generated with [Claude Code](https://claude.com/claude-code)