### PR TITLE
feat(air): Migrate FunctionInfo to ParamArena

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -3971,10 +3971,16 @@ fn analyze_call_ctx(
         .get_function(name)
         .ok_or_compile_error(ErrorKind::UndefinedFunction(fn_name_str.clone()), span)?;
 
+    // Get parameter data from the arena
+    let param_types = ctx.param_arena.types(fn_info.params);
+    let param_modes = ctx.param_arena.modes(fn_info.params);
+    let param_comptime = ctx.param_arena.comptime(fn_info.params);
+    let param_names = ctx.param_arena.names(fn_info.params);
+
     let args = ctx.rir.get_call_args(args_start, args_len);
     // Check argument count
-    if args.len() != fn_info.param_types.len() {
-        let expected = fn_info.param_types.len();
+    if args.len() != param_types.len() {
+        let expected = param_types.len();
         let found = args.len();
         return Err(CompileError::new(
             ErrorKind::WrongArgumentCount { expected, found },
@@ -3986,7 +3992,7 @@ fn analyze_call_ctx(
     check_exclusive_access_ctx(ctx, &args, span)?;
 
     // Check that call-site argument modes match function parameter modes
-    for (i, (arg, expected_mode)) in args.iter().zip(fn_info.param_modes.iter()).enumerate() {
+    for (i, (arg, expected_mode)) in args.iter().zip(param_modes.iter()).enumerate() {
         match expected_mode {
             RirParamMode::Inout => {
                 if arg.mode != RirArgMode::Inout {
@@ -4011,14 +4017,14 @@ fn analyze_call_ctx(
     }
 
     // Check that comptime parameters receive compile-time constant values
-    let has_comptime_params = fn_info.param_comptime.iter().any(|&c| c);
+    let has_comptime_params = param_comptime.iter().any(|&c| c);
     if has_comptime_params {
         // Validate each comptime parameter receives a compile-time constant
-        for (i, (&is_comptime, arg)) in fn_info.param_comptime.iter().zip(args.iter()).enumerate() {
+        for (i, (&is_comptime, arg)) in param_comptime.iter().zip(args.iter()).enumerate() {
             if is_comptime {
                 // Try to evaluate the argument at compile time
                 if try_evaluate_const_in_rir(ctx.rir, arg.value).is_none() {
-                    let param_name = ctx.interner.resolve(&fn_info.param_names[i]).to_string();
+                    let param_name = ctx.interner.resolve(&param_names[i]).to_string();
                     return Err(CompileError::new(
                         ErrorKind::ComptimeArgNotConst {
                             param_name: param_name.clone(),
@@ -4036,8 +4042,8 @@ fn analyze_call_ctx(
 
     // Extract info before mutable borrow
     let is_generic = fn_info.is_generic;
-    let param_modes = fn_info.param_modes.clone();
-    let param_names = fn_info.param_names.clone();
+    let param_modes = param_modes.to_vec();
+    let param_names = param_names.to_vec();
     let return_type_sym = fn_info.return_type_sym;
     let base_return_type = fn_info.return_type;
 
@@ -4356,11 +4362,15 @@ fn analyze_module_member_call_ctx(
         ));
     }
 
+    // Get parameter data from the arena
+    let param_types = ctx.param_arena.types(fn_info.params);
+    let param_modes = ctx.param_arena.modes(fn_info.params);
+
     let args = ctx.rir.get_call_args(args_start, args_len);
 
     // Check argument count
-    if args.len() != fn_info.param_types.len() {
-        let expected = fn_info.param_types.len();
+    if args.len() != param_types.len() {
+        let expected = param_types.len();
         let found = args.len();
         return Err(CompileError::new(
             ErrorKind::WrongArgumentCount { expected, found },
@@ -4372,7 +4382,7 @@ fn analyze_module_member_call_ctx(
     check_exclusive_access_ctx(ctx, &args, span)?;
 
     // Check that call-site argument modes match function parameter modes
-    for (i, (arg, expected_mode)) in args.iter().zip(fn_info.param_modes.iter()).enumerate() {
+    for (i, (arg, expected_mode)) in args.iter().zip(param_modes.iter()).enumerate() {
         match expected_mode {
             RirParamMode::Inout => {
                 if arg.mode != RirArgMode::Inout {
@@ -6648,11 +6658,15 @@ impl<'a> Sema<'a> {
             ));
         }
 
+        // Get parameter data from the arena
+        let param_types = self.param_arena.types(fn_info.params);
+        let param_modes = self.param_arena.modes(fn_info.params);
+
         let args = self.rir.get_call_args(args_start, args_len);
 
         // Check argument count
-        if args.len() != fn_info.param_types.len() {
-            let expected = fn_info.param_types.len();
+        if args.len() != param_types.len() {
+            let expected = param_types.len();
             let found = args.len();
             return Err(CompileError::new(
                 ErrorKind::WrongArgumentCount { expected, found },
@@ -6661,7 +6675,7 @@ impl<'a> Sema<'a> {
         }
 
         // Check that call-site argument modes match function parameter modes
-        for (i, (arg, expected_mode)) in args.iter().zip(fn_info.param_modes.iter()).enumerate() {
+        for (i, (arg, expected_mode)) in args.iter().zip(param_modes.iter()).enumerate() {
             match expected_mode {
                 RirParamMode::Inout => {
                     if arg.mode != RirArgMode::Inout {

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2054,10 +2054,16 @@ impl<'a> Sema<'a> {
             .get(&name)
             .ok_or_compile_error(ErrorKind::UndefinedFunction(fn_name_str.clone()), span)?;
 
+        // Get parameter data from the arena
+        let param_types = self.param_arena.types(fn_info.params);
+        let param_modes = self.param_arena.modes(fn_info.params);
+        let param_comptime = self.param_arena.comptime(fn_info.params);
+        let param_names = self.param_arena.names(fn_info.params);
+
         let args = self.rir.get_call_args(args_start, args_len);
         // Check argument count
-        if args.len() != fn_info.param_types.len() {
-            let expected = fn_info.param_types.len();
+        if args.len() != param_types.len() {
+            let expected = param_types.len();
             let found = args.len();
             return Err(CompileError::new(
                 ErrorKind::WrongArgumentCount { expected, found },
@@ -2070,7 +2076,7 @@ impl<'a> Sema<'a> {
 
         // Check that call-site argument modes match function parameter modes
         // Do this before the mutable borrow in analyze_call_args, accessing fn_info directly
-        for (i, (arg, expected_mode)) in args.iter().zip(fn_info.param_modes.iter()).enumerate() {
+        for (i, (arg, expected_mode)) in args.iter().zip(param_modes.iter()).enumerate() {
             match expected_mode {
                 RirParamMode::Inout => {
                     if arg.mode != RirArgMode::Inout {
@@ -2098,9 +2104,9 @@ impl<'a> Sema<'a> {
 
         // Extract info before any mutable borrow
         let is_generic = fn_info.is_generic;
-        let param_types = fn_info.param_types.clone();
-        let param_comptime = fn_info.param_comptime.clone();
-        let param_names = fn_info.param_names.clone();
+        let param_types = param_types.to_vec();
+        let param_comptime = param_comptime.to_vec();
+        let param_names = param_names.to_vec();
         let return_type_sym = fn_info.return_type_sym;
         let base_return_type = fn_info.return_type;
         let fn_body = fn_info.body;

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -45,16 +45,17 @@ impl<'a> Sema<'a> {
                 (
                     *name,
                     FunctionSig {
-                        param_types: info
-                            .param_types
+                        param_types: self
+                            .param_arena
+                            .types(info.params)
                             .iter()
                             .map(|t| self.type_to_infer_type(*t))
                             .collect(),
                         return_type: self.type_to_infer_type(info.return_type),
                         is_generic: info.is_generic,
-                        param_modes: info.param_modes.clone(),
-                        param_comptime: info.param_comptime.clone(),
-                        param_names: info.param_names.clone(),
+                        param_modes: self.param_arena.modes(info.params).to_vec(),
+                        param_comptime: self.param_arena.comptime(info.params).to_vec(),
+                        param_names: self.param_arena.names(info.params).to_vec(),
                         return_type_sym: info.return_type_sym,
                     },
                 )
@@ -768,13 +769,18 @@ impl<'a> Sema<'a> {
             self.resolve_type(return_type_sym, span)?
         };
 
+        // Allocate parameter data in the arena
+        let params_range = self.param_arena.alloc(
+            param_names.into_iter(),
+            param_types.into_iter(),
+            param_modes.into_iter(),
+            param_comptime.into_iter(),
+        );
+
         self.functions.insert(
             name,
             FunctionInfo {
-                param_names,
-                param_types,
-                param_modes,
-                param_comptime,
+                params: params_range,
                 return_type: ret_type,
                 return_type_sym,
                 body,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -38,6 +38,7 @@ use rue_rir::Rir;
 use rue_span::FileId;
 
 use crate::intern_pool::TypeInternPool;
+use crate::param_arena::{ParamArena, ParamRange};
 use crate::sema_context::{InferenceContext as SemaContextInferenceContext, SemaContext};
 use crate::types::{ArrayTypeId, EnumDef, EnumId, StructDef, StructField, StructId, Type};
 
@@ -94,6 +95,8 @@ pub struct GatherOutput<'a> {
     pub builtin_string_id: Option<StructId>,
     /// Type intern pool (ADR-0024 Phase 1).
     pub type_pool: TypeInternPool,
+    /// Arena storage for function/method parameter data.
+    pub param_arena: ParamArena,
 }
 
 impl<'a> GatherOutput<'a> {
@@ -116,6 +119,7 @@ impl<'a> GatherOutput<'a> {
             type_pool: self.type_pool,
             module_registry: crate::sema_context::ModuleRegistry::new(),
             file_paths: HashMap::new(),
+            param_arena: self.param_arena,
         }
     }
 }
@@ -178,16 +182,11 @@ pub struct InferenceContext {
 }
 
 /// Information about a function.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct FunctionInfo {
-    /// Parameter names (in order) - needed for generic function specialization
-    pub param_names: Vec<Spur>,
-    /// Parameter types (in order)
-    pub param_types: Vec<Type>,
-    /// Parameter modes (in order)
-    pub param_modes: Vec<rue_rir::RirParamMode>,
-    /// Whether each parameter is comptime (in order)
-    pub param_comptime: Vec<bool>,
+    /// Parameter data (names, types, modes, comptime flags) stored in arena.
+    /// Access via `arena.names(params)`, `arena.types(params)`, etc.
+    pub params: ParamRange,
     /// Return type
     pub return_type: Type,
     /// The return type symbol (before resolution) - needed for generic function specialization
@@ -278,6 +277,9 @@ pub struct Sema<'a> {
     /// Maps FileId to source file paths (for module resolution).
     /// Used to resolve relative imports when compiling multiple files.
     pub(crate) file_paths: HashMap<FileId, String>,
+    /// Arena storage for function/method parameter data.
+    /// FunctionInfo and MethodInfo store ParamRange handles into this arena.
+    pub(crate) param_arena: ParamArena,
 }
 
 impl<'a> Sema<'a> {
@@ -301,6 +303,7 @@ impl<'a> Sema<'a> {
             type_pool: TypeInternPool::new(),
             module_registry: crate::sema_context::ModuleRegistry::new(),
             file_paths: HashMap::new(),
+            param_arena: ParamArena::new(),
         }
     }
 
@@ -457,6 +460,7 @@ impl<'a> Sema<'a> {
             module_registry: crate::sema_context::ModuleRegistry::new(),
             source_file_path: None, // Will be set when analyzing specific files
             file_paths: self.file_paths.clone(), // Copy file paths for module resolution
+            param_arena: &self.param_arena,
         }
     }
 
@@ -472,16 +476,17 @@ impl<'a> Sema<'a> {
                 (
                     *name,
                     FunctionSig {
-                        param_types: info
-                            .param_types
+                        param_types: self
+                            .param_arena
+                            .types(info.params)
                             .iter()
                             .map(|t| self.type_to_infer_type(*t))
                             .collect(),
                         return_type: self.type_to_infer_type(info.return_type),
                         is_generic: info.is_generic,
-                        param_modes: info.param_modes.clone(),
-                        param_comptime: info.param_comptime.clone(),
-                        param_names: info.param_names.clone(),
+                        param_modes: self.param_arena.modes(info.params).to_vec(),
+                        param_comptime: self.param_arena.comptime(info.params).to_vec(),
+                        param_names: self.param_arena.names(info.params).to_vec(),
                         return_type_sym: info.return_type_sym,
                     },
                 )

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -37,6 +37,7 @@ use rue_rir::Rir;
 
 use crate::inference::{FunctionSig, InferType, MethodSig};
 use crate::intern_pool::TypeInternPool;
+use crate::param_arena::ParamArena;
 // Import FunctionInfo, MethodInfo, and KnownSymbols from sema module to avoid duplication.
 // FunctionInfo and MethodInfo are the canonical definitions; we re-export them for convenience.
 pub use crate::sema::{FunctionInfo, KnownSymbols, MethodInfo};
@@ -174,6 +175,7 @@ pub struct InferenceContext {
 /// - Type intern pool (thread-safe, allows concurrent array interning)
 /// - Pre-computed inference context (immutable)
 /// - Built-in type IDs (immutable)
+/// - Parameter arena for function/method parameter data (immutable after declaration gathering)
 ///
 /// # Thread Safety
 ///
@@ -182,6 +184,7 @@ pub struct InferenceContext {
 /// - The type intern pool uses `RwLock` for thread-safe mutations
 /// - References to RIR and interner are shared immutably
 /// - References to functions/methods HashMaps are immutable after declaration gathering
+/// - Reference to param_arena is immutable after declaration gathering
 /// - ThreadedRodeo is designed to be thread-safe
 #[derive(Debug)]
 pub struct SemaContext<'a> {
@@ -221,6 +224,9 @@ pub struct SemaContext<'a> {
     /// Maps FileId to source file paths (multi-file mode).
     /// Used for resolving relative imports when multiple files are compiled.
     pub file_paths: HashMap<rue_span::FileId, String>,
+    /// Reference to the parameter arena for accessing function/method parameter data.
+    /// Use `param_arena.types(fn_info.params)` to get parameter types, etc.
+    pub param_arena: &'a ParamArena,
 }
 
 // SAFETY: SemaContext is Send + Sync because:

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -185,13 +185,19 @@ fn create_specialized_function(
 ) -> CompileResult<AnalyzedFunction> {
     let specialized_name_str = interner.resolve(&specialized_name).to_string();
 
+    // Get parameter data from the arena
+    let param_names = sema.param_arena.names(base_info.params);
+    let param_types = sema.param_arena.types(base_info.params);
+    let param_modes = sema.param_arena.modes(base_info.params);
+    let param_comptime = sema.param_arena.comptime(base_info.params);
+
     // Build the type substitution map: comptime param name -> concrete Type
     let mut type_subst: HashMap<Spur, Type> = HashMap::new();
     let mut type_arg_idx = 0;
-    for (i, is_comptime) in base_info.param_comptime.iter().enumerate() {
+    for (i, is_comptime) in param_comptime.iter().enumerate() {
         if *is_comptime {
             if type_arg_idx < key.type_args.len() {
-                type_subst.insert(base_info.param_names[i], key.type_args[type_arg_idx]);
+                type_subst.insert(param_names[i], key.type_args[type_arg_idx]);
                 type_arg_idx += 1;
             }
         }
@@ -211,12 +217,11 @@ fn create_specialized_function(
     // Build the specialized parameter list by:
     // 1. Filtering out comptime parameters (they're erased at runtime)
     // 2. Substituting type parameters in non-comptime parameter types
-    let specialized_params: Vec<(Spur, Type, RirParamMode)> = base_info
-        .param_names
+    let specialized_params: Vec<(Spur, Type, RirParamMode)> = param_names
         .iter()
-        .zip(base_info.param_types.iter())
-        .zip(base_info.param_modes.iter())
-        .zip(base_info.param_comptime.iter())
+        .zip(param_types.iter())
+        .zip(param_modes.iter())
+        .zip(param_comptime.iter())
         .filter(|(((_, _), _), is_comptime)| !*is_comptime)
         .map(|(((name, ty), mode), _)| {
             // If the type is ComptimeType, look it up in the substitution map


### PR DESCRIPTION
Phase 2.3 and 2.6 of ADR-0023 (Parameter Arena):

- Add ParamArena field to Sema struct  
- Add ParamArena reference to SemaContext
- Update FunctionInfo to use ParamRange instead of 4 Vec fields
  - params: ParamRange (8 bytes) replaces:
    - param_names: Vec<Spur> (24 bytes)
    - param_types: Vec<Type> (24 bytes)  
    - param_modes: Vec<RirParamMode> (24 bytes)
    - param_comptime: Vec<bool> (24 bytes)
- FunctionInfo is now Copy (was Clone)
- Update all access patterns to use arena methods:
  - param_arena.names(info.params)
  - param_arena.types(info.params)
  - param_arena.modes(info.params)
  - param_arena.comptime(info.params)

Benefits:
- FunctionInfo reduced from ~136 bytes to ~48 bytes
- Better cache locality for parameter data
- Eliminates per-function allocation overhead
- FunctionInfo can now be copied cheaply

Closes: rue-8xvf, rue-3so2

🤖 Generated with [Claude Code](https://claude.com/claude-code)