### PR TITLE
feat(air): Migrate FunctionInfo to ParamArena

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -6573,11 +6573,12 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        // Check argument count (method_info.param_types excludes self)
-        if args.len() != method_info.param_types.len() {
+        // Check argument count (method_info.params excludes self)
+        let method_param_types = self.param_arena.types(method_info.params);
+        if args.len() != method_param_types.len() {
             return Err(CompileError::new(
                 ErrorKind::WrongArgumentCount {
-                    expected: method_info.param_types.len(),
+                    expected: method_param_types.len(),
                     found: args.len(),
                 },
                 span,
@@ -6784,10 +6785,11 @@ impl<'a> Sema<'a> {
         }
 
         // Check argument count
-        if args.len() != method_info.param_types.len() {
+        let method_param_types = self.param_arena.types(method_info.params);
+        if args.len() != method_param_types.len() {
             return Err(CompileError::new(
                 ErrorKind::WrongArgumentCount {
-                    expected: method_info.param_types.len(),
+                    expected: method_param_types.len(),
                     found: args.len(),
                 },
                 span,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -86,8 +86,9 @@ impl<'a> Sema<'a> {
                     MethodSig {
                         struct_type: info.struct_type,
                         has_self: info.has_self,
-                        param_types: info
-                            .param_types
+                        param_types: self
+                            .param_arena
+                            .types(info.params)
                             .iter()
                             .map(|t| self.type_to_infer_type(*t))
                             .collect(),
@@ -598,10 +599,10 @@ impl<'a> Sema<'a> {
 
                 // Validate: must be a method (has self), not associated function
                 if !method_info.has_self {
+                    let param_types = self.param_arena.types(method_info.params);
                     let found_signature = format!(
                         "fn handle({}) -> {}",
-                        method_info
-                            .param_types
+                        param_types
                             .iter()
                             .map(|t| self.format_type_name(*t))
                             .collect::<Vec<_>>()
@@ -618,21 +619,17 @@ impl<'a> Sema<'a> {
                 }
 
                 // Validate: should take no extra parameters (just self)
-                if !method_info.param_types.is_empty() {
+                let param_types = self.param_arena.types(method_info.params);
+                if !param_types.is_empty() {
+                    let param_names = self.param_arena.names(method_info.params);
                     let params = std::iter::once(format!("self: {}", struct_name))
-                        .chain(
-                            method_info
-                                .param_types
-                                .iter()
-                                .zip(&method_info.param_names)
-                                .map(|(ty, name)| {
-                                    format!(
-                                        "{}: {}",
-                                        self.interner.resolve(name),
-                                        self.format_type_name(*ty)
-                                    )
-                                }),
-                        )
+                        .chain(param_types.iter().zip(param_names).map(|(ty, name)| {
+                            format!(
+                                "{}: {}",
+                                self.interner.resolve(name),
+                                self.format_type_name(*ty)
+                            )
+                        }))
                         .collect::<Vec<_>>()
                         .join(", ");
                     let found_signature = format!(
@@ -847,13 +844,17 @@ impl<'a> Sema<'a> {
                     .collect::<CompileResult<Vec<_>>>()?;
                 let ret_type = self.resolve_type(*return_type, method_inst.span)?;
 
+                // Allocate method parameters in the arena
+                let param_range = self
+                    .param_arena
+                    .alloc_method(param_names.into_iter(), param_types.into_iter());
+
                 self.methods.insert(
                     key,
                     MethodInfo {
                         struct_type,
                         has_self: *has_self,
-                        param_names,
-                        param_types,
+                        params: param_range,
                         return_type: ret_type,
                         body: *body,
                         span: method_inst.span,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -204,16 +204,16 @@ pub struct FunctionInfo {
 }
 
 /// Information about a method in an impl block.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub struct MethodInfo {
     /// The struct type this method belongs to
     pub struct_type: Type,
     /// Whether this is a method (has self) or associated function (no self)
     pub has_self: bool,
-    /// Parameter names (excluding self if present)
-    pub param_names: Vec<Spur>,
-    /// Parameter types (excluding self if present)
-    pub param_types: Vec<Type>,
+    /// Parameter data (names, types, modes, comptime flags) stored in arena.
+    /// Access via `arena.names(params)`, `arena.types(params)`, etc.
+    /// Note: This excludes `self` if present - only explicit parameters.
+    pub params: ParamRange,
     /// Return type
     pub return_type: Type,
     /// The RIR instruction ref for the method body
@@ -517,8 +517,9 @@ impl<'a> Sema<'a> {
                     MethodSig {
                         struct_type: info.struct_type,
                         has_self: info.has_self,
-                        param_types: info
-                            .param_types
+                        param_types: self
+                            .param_arena
+                            .types(info.params)
                             .iter()
                             .map(|t| self.type_to_infer_type(*t))
                             .collect(),


### PR DESCRIPTION
Update MethodInfo to store ParamRange instead of Vec<Spur> and Vec<Type>:

- Changed MethodInfo struct to use ParamRange (now Clone + Copy)
- Updated collect_impl_methods() to allocate params via arena
- Updated build_inference_context() to read method params from arena
- Updated validate_handle_structs() to use arena accessors
- Updated method call handling in analysis.rs to use arena

This continues the Phase 2 arena migration started with FunctionInfo. Memory savings: ~88 bytes per method definition.

Closes: rue-0o1y

🤖 Generated with [Claude Code](https://claude.com/claude-code)