### PR TITLE
docs(std): Add standard library documentation

### DIFF
--- a/website/content/std/01-math.md
+++ b/website/content/std/01-math.md
@@ -1,0 +1,162 @@
++++
+title = "math"
+weight = 1
++++
+
+# std.math
+
+The `math` module provides basic mathematical utilities for working with integers.
+
+## Import
+
+```rue
+const math = @import("std").math;
+```
+
+## Functions
+
+### abs
+
+```rue
+pub fn abs(x: i32) -> i32
+```
+
+Returns the absolute value of an integer.
+
+**Parameters:**
+- `x` - The input value
+
+**Returns:** The absolute value of `x`
+
+**Example:**
+
+```rue
+const math = @import("std").math;
+
+fn main() -> i32 {
+    let a = math.abs(-42);  // 42
+    let b = math.abs(10);   // 10
+    let c = math.abs(0);    // 0
+    a
+}
+```
+
+---
+
+### min
+
+```rue
+pub fn min(a: i32, b: i32) -> i32
+```
+
+Returns the smaller of two values.
+
+**Parameters:**
+- `a` - First value
+- `b` - Second value
+
+**Returns:** The smaller of `a` and `b`
+
+**Example:**
+
+```rue
+const math = @import("std").math;
+
+fn main() -> i32 {
+    let smaller = math.min(10, 20);  // 10
+    let same = math.min(5, 5);       // 5
+    smaller
+}
+```
+
+---
+
+### max
+
+```rue
+pub fn max(a: i32, b: i32) -> i32
+```
+
+Returns the larger of two values.
+
+**Parameters:**
+- `a` - First value
+- `b` - Second value
+
+**Returns:** The larger of `a` and `b`
+
+**Example:**
+
+```rue
+const math = @import("std").math;
+
+fn main() -> i32 {
+    let larger = math.max(10, 20);  // 20
+    let same = math.max(5, 5);      // 5
+    larger
+}
+```
+
+---
+
+### clamp
+
+```rue
+pub fn clamp(x: i32, lo: i32, hi: i32) -> i32
+```
+
+Clamps a value to be within the given range `[lo, hi]`.
+
+If `x` is less than `lo`, returns `lo`. If `x` is greater than `hi`, returns `hi`. Otherwise, returns `x`.
+
+**Parameters:**
+- `x` - The value to clamp
+- `lo` - The lower bound (inclusive)
+- `hi` - The upper bound (inclusive)
+
+**Returns:** The clamped value
+
+**Example:**
+
+```rue
+const math = @import("std").math;
+
+fn main() -> i32 {
+    let a = math.clamp(5, 0, 10);    // 5 (within range)
+    let b = math.clamp(-5, 0, 10);   // 0 (clamped to lower bound)
+    let c = math.clamp(15, 0, 10);   // 10 (clamped to upper bound)
+    a + b + c  // 15
+}
+```
+
+## Complete Example
+
+Here's a more complete example using multiple math functions:
+
+```rue
+const math = @import("std").math;
+
+fn distance(a: i32, b: i32) -> i32 {
+    math.abs(a - b)
+}
+
+fn main() -> i32 {
+    let x = 15;
+    let y = 7;
+
+    // Calculate distance between x and y
+    let dist = distance(x, y);  // 8
+
+    // Clamp the result to a valid range
+    let clamped = math.clamp(dist, 0, 5);  // 5
+
+    // Get the larger of the two original values
+    let larger = math.max(x, y);  // 15
+
+    clamped + larger  // 20
+}
+```
+
+## Implementation
+
+The math module is implemented in `std/math.rue`. All functions currently operate on `i32` values. Future versions may include overloads for other integer types.

--- a/website/content/std/_index.md
+++ b/website/content/std/_index.md
@@ -1,0 +1,74 @@
++++
+title = "Standard Library"
+sort_by = "weight"
+template = "std/section.html"
+page_template = "std/page.html"
++++
+
+The Rue standard library provides common utilities for Rue programs. It is organized into modules that can be imported using `@import("std")`.
+
+## Importing the Standard Library
+
+The standard library is **not** implicitly imported. You must explicitly import what you need:
+
+```rue
+const std = @import("std");
+const math = std.math;
+
+fn main() -> i32 {
+    math.abs(-42)
+}
+```
+
+Or import specific modules directly:
+
+```rue
+const math = @import("std").math;
+
+fn main() -> i32 {
+    math.max(10, 20)
+}
+```
+
+## Module Structure
+
+The standard library is organized as a module tree:
+
+```
+std/
+  _std.rue      # Module root - re-exports submodules
+  math.rue      # Mathematical utilities
+```
+
+When you write `@import("std")`, the compiler resolves this to the `_std.rue` file in the standard library directory. This file re-exports the submodules:
+
+```rue
+// std/_std.rue
+pub const math = @import("math.rue");
+```
+
+## Available Modules
+
+| Module | Description |
+|--------|-------------|
+| [`math`](math/) | Mathematical functions: `abs`, `min`, `max`, `clamp` |
+
+## Future Modules
+
+As Rue matures, the standard library will grow to include:
+
+- **io** - Input/output operations
+- **collections** - Data structures like `Vec`, `HashMap`
+- **strings** - String manipulation utilities
+- **mem** - Memory utilities
+
+## Design Philosophy
+
+The Rue standard library follows several design principles:
+
+1. **Explicit imports** - No implicit prelude; all dependencies are visible
+2. **Lazy analysis** - Only imported code is analyzed, enabling fast compilation
+3. **File = module** - Each `.rue` file is a module; the filesystem is the source of truth
+4. **Simple visibility** - Just `pub` (public) or nothing (private)
+
+For more details on the module system, see [ADR-0026: Module System](https://github.com/rue-language/rue/blob/main/docs/designs/0026-module-system.md).

--- a/website/templates/std/base.html
+++ b/website/templates/std/base.html
@@ -1,0 +1,61 @@
+{% extends "base.html" %}
+
+{% block title %}{{ page.title | default(value=section.title) }} - Standard Library{% endblock %}
+
+{% block content %}
+<div class="spec-layout">
+    {# Sidebar - reuses spec-sidebar styles #}
+    <aside class="spec-sidebar">
+        <div class="spec-sidebar-inner">
+            <div class="spec-sidebar-header">
+                <a href="{{ get_url(path='std') }}" class="spec-title">Standard Library</a>
+            </div>
+            <nav class="spec-nav">
+                {% set std_section = get_section(path="std/_index.md") %}
+                {% set current = page.permalink | default(value=section.permalink) | default(value="") %}
+                {{ self::render_nav(section=std_section, current_path=current) }}
+            </nav>
+        </div>
+    </aside>
+
+    {# Main content #}
+    <div class="spec-main">
+        <article class="spec-content std-content">
+            {% block std_content %}{% endblock %}
+        </article>
+
+        {# Prev/Next navigation #}
+        {% block prev_next %}
+        <nav class="spec-page-nav">
+            {% if page.lower %}
+            <a href="{{ page.lower.permalink }}" class="spec-nav-prev">
+                <span class="spec-nav-label">Previous</span>
+                <span class="spec-nav-title">{{ page.lower.title }}</span>
+            </a>
+            {% else %}
+            <span></span>
+            {% endif %}
+            {% if page.higher %}
+            <a href="{{ page.higher.permalink }}" class="spec-nav-next">
+                <span class="spec-nav-label">Next</span>
+                <span class="spec-nav-title">{{ page.higher.title }}</span>
+            </a>
+            {% endif %}
+        </nav>
+        {% endblock %}
+    </div>
+</div>
+{% endblock %}
+
+{# Recursive macro for navigation #}
+{% macro render_nav(section, current_path) %}
+<ul class="spec-nav-list">
+    {% for pg in section.pages %}
+    <li class="spec-nav-item">
+        <a href="{{ pg.permalink }}" class="spec-nav-link {% if pg.permalink == current_path %}active{% endif %}">
+            {{ pg.title }}
+        </a>
+    </li>
+    {% endfor %}
+</ul>
+{% endmacro %}

--- a/website/templates/std/page.html
+++ b/website/templates/std/page.html
@@ -1,0 +1,5 @@
+{% extends "std/base.html" %}
+
+{% block std_content %}
+{{ page.content | safe }}
+{% endblock %}

--- a/website/templates/std/section.html
+++ b/website/templates/std/section.html
@@ -1,0 +1,20 @@
+{% extends "std/base.html" %}
+
+{% block std_content %}
+<h1>{{ section.title }}</h1>
+
+{{ section.content | safe }}
+
+{% if section.pages %}
+<h2>Modules</h2>
+<ul class="spec-section-toc">
+    {% for page in section.pages %}
+    <li><a href="{{ page.path }}">{{ page.title }}</a></li>
+    {% endfor %}
+</ul>
+{% endif %}
+{% endblock %}
+
+{% block prev_next %}
+{# Section index doesn't have prev/next #}
+{% endblock %}


### PR DESCRIPTION
Add website documentation for the standard library, completing Phase 4 of the module system implementation:

- Module structure overview explaining @import("std") usage
- Complete API reference for std.math (abs, min, max, clamp)
- Usage examples demonstrating common patterns
- Website templates following existing tutorial/spec patterns

Fixes rue-7fbt

🤖 Generated with [Claude Code](https://claude.com/claude-code)