### PR TITLE
feat(parser): Add Phase 1 parser support for unchecked code and raw p…

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1058,6 +1058,14 @@ impl<'a> ConstraintGenerator<'a> {
                 InferType::Var(var)
             }
 
+            // Checked block: for type inference purposes, the type is the type of the inner expression
+            // The actual checking of unchecked operations happens in sema
+            InstData::Checked { expr } => {
+                // Generate constraints for the inner expression
+                let inner_info = self.generate(*expr, ctx);
+                inner_info.ty
+            }
+
             // Type constant: a type used as a value (e.g., `i32` in `identity(i32, 42)`)
             // This has the special ComptimeType type which indicates it's a type value.
             InstData::TypeConst { .. } => InferType::Concrete(Type::ComptimeType),

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -2048,6 +2048,10 @@ fn analyze_inst_with_context(
                 inst.span,
             ))
         }
+
+        // Checked block: evaluate the inner expression
+        // The actual checking of unchecked operations happens in Phase 2
+        InstData::Checked { expr } => analyze_inst_with_context(ctx, air, *expr, analysis_ctx),
     }
 }
 
@@ -6460,6 +6464,10 @@ impl<'a> Sema<'a> {
                 });
                 Ok(AnalysisResult::new(air_ref, Type::ComptimeType))
             }
+
+            // Checked block: evaluate the inner expression
+            // The actual checking of unchecked operations happens in Phase 2
+            InstData::Checked { expr } => self.analyze_inst(air, *expr, ctx),
         }
     }
 

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -410,6 +410,7 @@ impl<'a> Sema<'a> {
 
                 InstData::FnDecl {
                     is_pub,
+                    is_unchecked,
                     name,
                     params_start,
                     params_len,
@@ -417,6 +418,14 @@ impl<'a> Sema<'a> {
                     body,
                     ..
                 } => {
+                    // Unchecked functions require preview feature
+                    if *is_unchecked {
+                        self.require_preview(
+                            PreviewFeature::UncheckedCode,
+                            "unchecked functions",
+                            inst.span,
+                        )?;
+                    }
                     self.collect_function_signature(
                         *name,
                         *params_start,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -261,6 +261,9 @@ pub enum PreviewFeature {
     /// Allows method definitions inside anonymous struct type expressions.
     /// See ADR-0029 for the full design.
     AnonStructMethods,
+    /// Unchecked code and raw pointers.
+    /// See ADR-0028 for the full design.
+    UncheckedCode,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -284,6 +287,7 @@ impl PreviewFeature {
             PreviewFeature::AffineMvs => "affine_mvs",
             PreviewFeature::ModuleTypes => "module_types",
             PreviewFeature::AnonStructMethods => "anon_struct_methods",
+            PreviewFeature::UncheckedCode => "unchecked_code",
         }
     }
 
@@ -295,6 +299,7 @@ impl PreviewFeature {
             PreviewFeature::AffineMvs => "ADR-0008",
             PreviewFeature::ModuleTypes => "ADR-0026",
             PreviewFeature::AnonStructMethods => "ADR-0029",
+            PreviewFeature::UncheckedCode => "ADR-0028",
         }
     }
 
@@ -305,6 +310,7 @@ impl PreviewFeature {
             PreviewFeature::AffineMvs,
             PreviewFeature::ModuleTypes,
             PreviewFeature::AnonStructMethods,
+            PreviewFeature::UncheckedCode,
         ]
     }
 
@@ -331,6 +337,7 @@ impl std::str::FromStr for PreviewFeature {
             "affine_mvs" => Ok(PreviewFeature::AffineMvs),
             "module_types" => Ok(PreviewFeature::ModuleTypes),
             "anon_struct_methods" => Ok(PreviewFeature::AnonStructMethods),
+            "unchecked_code" => Ok(PreviewFeature::UncheckedCode),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -1842,7 +1849,7 @@ mod tests {
         let names = PreviewFeature::all_names();
         assert_eq!(
             names,
-            "test_infra, affine_mvs, module_types, anon_struct_methods"
+            "test_infra, affine_mvs, module_types, anon_struct_methods, unchecked_code"
         );
     }
 

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -44,6 +44,9 @@ pub enum TokenKind {
     Comptime,  // comptime (compile-time evaluation)
     Pub,       // pub visibility modifier (module system)
     Const,     // const declaration (module system re-exports)
+    Checked,   // checked { } block for unchecked operations
+    Unchecked, // unchecked fn modifier
+    Ptr,       // ptr const T / ptr mut T pointer types
 
     // Type keywords
     I8,
@@ -141,6 +144,9 @@ impl TokenKind {
             TokenKind::Comptime => "'comptime'",
             TokenKind::Pub => "'pub'",
             TokenKind::Const => "'const'",
+            TokenKind::Checked => "'checked'",
+            TokenKind::Unchecked => "'unchecked'",
+            TokenKind::Ptr => "'ptr'",
             TokenKind::I8 => "type 'i8'",
             TokenKind::I16 => "type 'i16'",
             TokenKind::I32 => "type 'i32'",
@@ -240,6 +246,9 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Comptime => write!(f, "COMPTIME"),
             TokenKind::Pub => write!(f, "PUB"),
             TokenKind::Const => write!(f, "CONST"),
+            TokenKind::Checked => write!(f, "CHECKED"),
+            TokenKind::Unchecked => write!(f, "UNCHECKED"),
+            TokenKind::Ptr => write!(f, "PTR"),
             TokenKind::I8 => write!(f, "TYPE(i8)"),
             TokenKind::I16 => write!(f, "TYPE(i16)"),
             TokenKind::I32 => write!(f, "TYPE(i32)"),

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -159,6 +159,12 @@ pub enum LogosTokenKind {
     Pub,
     #[token("const")]
     Const,
+    #[token("checked")]
+    Checked,
+    #[token("unchecked")]
+    Unchecked,
+    #[token("ptr")]
+    Ptr,
 
     // Type keywords
     #[token("i8")]
@@ -318,6 +324,9 @@ impl From<LogosTokenKind> for TokenKind {
             LogosTokenKind::Comptime => TokenKind::Comptime,
             LogosTokenKind::Pub => TokenKind::Pub,
             LogosTokenKind::Const => TokenKind::Const,
+            LogosTokenKind::Checked => TokenKind::Checked,
+            LogosTokenKind::Unchecked => TokenKind::Unchecked,
+            LogosTokenKind::Ptr => TokenKind::Ptr,
             LogosTokenKind::I8 => TokenKind::I8,
             LogosTokenKind::I16 => TokenKind::I16,
             LogosTokenKind::I32 => TokenKind::I32,

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -217,6 +217,8 @@ pub struct Function {
     pub directives: Directives,
     /// Visibility of this function
     pub visibility: Visibility,
+    /// Whether this function is marked `unchecked` (can only be called from checked blocks)
+    pub is_unchecked: bool,
     /// Function name
     pub name: Ident,
     /// Function parameters
@@ -295,6 +297,10 @@ pub enum TypeExpr {
         methods: Vec<Method>,
         span: Span,
     },
+    /// Raw pointer to immutable data: ptr const T
+    PointerConst { pointee: Box<TypeExpr>, span: Span },
+    /// Raw pointer to mutable data: ptr mut T
+    PointerMut { pointee: Box<TypeExpr>, span: Span },
 }
 
 /// A field in an anonymous struct type expression.
@@ -317,6 +323,8 @@ impl TypeExpr {
             TypeExpr::Never(span) => *span,
             TypeExpr::Array { span, .. } => *span,
             TypeExpr::AnonymousStruct { span, .. } => *span,
+            TypeExpr::PointerConst { span, .. } => *span,
+            TypeExpr::PointerMut { span, .. } => *span,
         }
     }
 }
@@ -348,6 +356,8 @@ impl fmt::Display for TypeExpr {
                 }
                 write!(f, " }}")
             }
+            TypeExpr::PointerConst { pointee, .. } => write!(f, "ptr const {}", pointee),
+            TypeExpr::PointerMut { pointee, .. } => write!(f, "ptr mut {}", pointee),
         }
     }
 }
@@ -415,6 +425,8 @@ pub enum Expr {
     SelfExpr(SelfExpr),
     /// Comptime block expression (e.g., `comptime { 1 + 2 }`)
     Comptime(ComptimeBlockExpr),
+    /// Checked block expression (e.g., `checked { @ptr_read(p) }`)
+    Checked(CheckedBlockExpr),
     /// Type literal expression (e.g., `i32` used as a value in generic function calls)
     TypeLit(TypeLitExpr),
 }
@@ -863,6 +875,16 @@ pub struct ComptimeBlockExpr {
     pub span: Span,
 }
 
+/// A checked block expression (e.g., `checked { @ptr_read(p) }`).
+/// Unchecked operations (raw pointer manipulation, calling unchecked functions)
+/// are only allowed inside checked blocks.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CheckedBlockExpr {
+    /// The expression inside the checked block
+    pub expr: Box<Expr>,
+    pub span: Span,
+}
+
 /// A type literal expression (e.g., `i32` used as a value).
 /// This represents a type used as a value in expression context, typically
 /// as an argument to a generic function with comptime parameters.
@@ -904,6 +926,7 @@ impl Expr {
             Expr::AssocFnCall(assoc_fn_call) => assoc_fn_call.span,
             Expr::SelfExpr(self_expr) => self_expr.span,
             Expr::Comptime(comptime_expr) => comptime_expr.span,
+            Expr::Checked(checked_expr) => checked_expr.span,
             Expr::TypeLit(type_lit) => type_lit.span,
         }
     }
@@ -1055,6 +1078,9 @@ fn fmt_call_arg(f: &mut fmt::Formatter<'_>, arg: &CallArg, level: usize) -> fmt:
 
 fn fmt_function(f: &mut fmt::Formatter<'_>, func: &Function, level: usize) -> fmt::Result {
     indent(f, level)?;
+    if func.is_unchecked {
+        write!(f, "unchecked ")?;
+    }
     write!(f, "Function sym:{}", func.name.name.into_usize())?;
     if !func.params.is_empty() {
         write!(f, "(")?;
@@ -1243,6 +1269,10 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
         Expr::Comptime(comptime) => {
             writeln!(f, "Comptime")?;
             fmt_expr(f, &comptime.expr, level + 1)
+        }
+        Expr::Checked(checked) => {
+            writeln!(f, "Checked")?;
+            fmt_expr(f, &checked.expr, level + 1)
         }
         Expr::TypeLit(type_lit) => {
             writeln!(f, "TypeLit({})", type_lit.type_expr)

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -5,13 +5,14 @@
 
 use crate::ast::{
     AnonStructField, ArgMode, ArrayLitExpr, AssignStatement, AssignTarget, AssocFnCallExpr, Ast,
-    BinaryExpr, BinaryOp, BlockExpr, BoolLit, BreakExpr, CallArg, CallExpr, ComptimeBlockExpr,
-    ConstDecl, ContinueExpr, Directive, DirectiveArg, Directives, DropFn, EnumDecl, EnumVariant,
-    Expr, FieldDecl, FieldExpr, FieldInit, Function, Ident, IfExpr, ImplBlock, IndexExpr, IntLit,
-    IntrinsicArg, IntrinsicCallExpr, Item, LetPattern, LetStatement, LoopExpr, MatchArm, MatchExpr,
-    Method, MethodCallExpr, NegIntLit, Param, ParamMode, ParenExpr, PathExpr, PathPattern, Pattern,
-    ReturnExpr, SelfExpr, SelfParam, Statement, StringLit, StructDecl, StructLitExpr, TypeExpr,
-    TypeLitExpr, UnaryExpr, UnaryOp, UnitLit, Visibility, WhileExpr,
+    BinaryExpr, BinaryOp, BlockExpr, BoolLit, BreakExpr, CallArg, CallExpr, CheckedBlockExpr,
+    ComptimeBlockExpr, ConstDecl, ContinueExpr, Directive, DirectiveArg, Directives, DropFn,
+    EnumDecl, EnumVariant, Expr, FieldDecl, FieldExpr, FieldInit, Function, Ident, IfExpr,
+    ImplBlock, IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr, Item, LetPattern, LetStatement,
+    LoopExpr, MatchArm, MatchExpr, Method, MethodCallExpr, NegIntLit, Param, ParamMode, ParenExpr,
+    PathExpr, PathPattern, Pattern, ReturnExpr, SelfExpr, SelfParam, Statement, StringLit,
+    StructDecl, StructLitExpr, TypeExpr, TypeLitExpr, UnaryExpr, UnaryOp, UnitLit, Visibility,
+    WhileExpr,
 };
 use chumsky::input::{Input as ChumskyInput, MapExtra, Stream, ValueInput};
 use chumsky::pratt::{infix, left, prefix};
@@ -288,6 +289,23 @@ where
                 span: span_from_extra(e),
             });
 
+        // Pointer type: ptr const T or ptr mut T
+        let ptr_const_type = just(TokenKind::Ptr)
+            .ignore_then(just(TokenKind::Const))
+            .ignore_then(ty.clone())
+            .map_with(|pointee, e| TypeExpr::PointerConst {
+                pointee: Box::new(pointee),
+                span: span_from_extra(e),
+            });
+
+        let ptr_mut_type = just(TokenKind::Ptr)
+            .ignore_then(just(TokenKind::Mut))
+            .ignore_then(ty.clone())
+            .map_with(|pointee, e| TypeExpr::PointerMut {
+                pointee: Box::new(pointee),
+                span: span_from_extra(e),
+            });
+
         // Named type: user-defined types like MyStruct
         let named_type = ident_parser().map(TypeExpr::Named);
 
@@ -305,6 +323,8 @@ where
             never_type,
             array_type,
             anon_struct_type,
+            ptr_const_type,
+            ptr_mut_type,
             primitive_type_parser(),
             self_type,
             named_type,
@@ -1282,6 +1302,17 @@ where
             })
         });
 
+    // Checked block expression: checked { expr }
+    // Unchecked operations are only allowed inside checked blocks
+    let checked_expr = just(TokenKind::Checked)
+        .ignore_then(block_parser(expr.clone()))
+        .map_with(|inner_expr, e| {
+            Expr::Checked(CheckedBlockExpr {
+                expr: Box::new(inner_expr),
+                span: span_from_extra(e),
+            })
+        });
+
     // Intrinsic argument: can be either a type or an expression
     // We parse as type only for unambiguous type syntax (primitives, (), !, [T;N])
     // Bare identifiers are parsed as expressions since they could be variables
@@ -1453,7 +1484,7 @@ where
     // so () is parsed as unit, not empty parens
     // Note: self_expr must come before call_and_access_parser since self is a keyword
     // Note: self_type_expr must come before call_and_access_parser since Self is a keyword
-    // Note: comptime_expr must come before block_expr since comptime starts with a keyword
+    // Note: comptime_expr and checked_expr must come before block_expr since they start with keywords
     // Note: type_lit_expr must come before call_and_access_parser since type names are keywords
     // Note: anon_struct_type_expr must come before call_and_access_parser since struct is a keyword
     let primary = choice((
@@ -1468,6 +1499,7 @@ where
         call_and_access_parser(expr.clone()),
         paren_expr,
         comptime_expr,
+        checked_expr,
         block_expr,
     ));
 
@@ -1872,7 +1904,7 @@ where
         })
 }
 
-/// Parser for function definitions: [@directive]* fn name(params) -> Type { body }
+/// Parser for function definitions: [@directive]* [pub] [unchecked] fn name(params) -> Type { body }
 fn function_parser<'src, I>() -> impl Parser<'src, I, Function, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
@@ -1890,14 +1922,17 @@ where
 
     directives_parser()
         .then(visibility)
+        .then(just(TokenKind::Unchecked).or_not())
         .then(just(TokenKind::Fn).ignore_then(ident_parser()))
         .then(params_parser().delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)))
         .then(just(TokenKind::Arrow).ignore_then(type_parser()).or_not())
         .then(block_parser(expr))
         .map_with(
-            |(((((directives, visibility), name), params), return_type), body), e| Function {
+            |((((((directives, visibility), is_unchecked), name), params), return_type), body),
+             e| Function {
                 directives,
                 visibility,
+                is_unchecked: is_unchecked.is_some(),
                 name,
                 params,
                 return_type,

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -107,6 +107,20 @@ impl<'a> AstGen<'a> {
                 s.push_str(" }");
                 self.interner.get_or_intern(&s)
             }
+            TypeExpr::PointerConst { pointee, .. } => {
+                // ptr const T
+                let pointee_sym = self.intern_type(pointee);
+                let pointee_name = self.interner.resolve(&pointee_sym);
+                let s = format!("ptr const {}", pointee_name);
+                self.interner.get_or_intern(&s)
+            }
+            TypeExpr::PointerMut { pointee, .. } => {
+                // ptr mut T
+                let pointee_sym = self.intern_type(pointee);
+                let pointee_name = self.interner.resolve(&pointee_sym);
+                let s = format!("ptr mut {}", pointee_name);
+                self.interner.get_or_intern(&s)
+            }
         }
     }
 
@@ -249,11 +263,13 @@ impl<'a> AstGen<'a> {
         // Emit methods as FnDecl instructions with has_self flag.
         // Sema uses has_self to add the implicit self parameter for methods.
         // Methods don't have their own visibility - they're accessible if the type is accessible.
+        // Methods cannot be marked unchecked (that's a function-level modifier).
         let decl = self.rir.add_inst(Inst {
             data: InstData::FnDecl {
                 directives_start,
                 directives_len,
                 is_pub: false,
+                is_unchecked: false,
                 name,
                 params_start,
                 params_len,
@@ -355,6 +371,7 @@ impl<'a> AstGen<'a> {
                 directives_start,
                 directives_len,
                 is_pub: func.visibility == Visibility::Public,
+                is_unchecked: func.is_unchecked,
                 name,
                 params_start,
                 params_len,
@@ -704,6 +721,15 @@ impl<'a> AstGen<'a> {
                     span: comptime_block.span,
                 })
             }
+            Expr::Checked(checked_block) => {
+                // Generate the inner expression, wrapped in a Checked instruction
+                // Unchecked operations are only allowed inside checked blocks
+                let inner_expr = self.gen_expr(&checked_block.expr);
+                self.rir.add_inst(Inst {
+                    data: InstData::Checked { expr: inner_expr },
+                    span: checked_block.span,
+                })
+            }
             Expr::TypeLit(type_lit) => {
                 // Generate a type constant instruction for type-as-value expressions
                 match &type_lit.type_expr {
@@ -727,7 +753,7 @@ impl<'a> AstGen<'a> {
                         })
                     }
                     _ => {
-                        // For named types, unit, never, and arrays, generate TypeConst
+                        // For named types, unit, never, arrays, and pointers, generate TypeConst
                         let type_name = match &type_lit.type_expr {
                             TypeExpr::Named(ident) => ident.name,
                             TypeExpr::Unit(_) => self.interner.get_or_intern_static("()"),
@@ -739,6 +765,10 @@ impl<'a> AstGen<'a> {
                             }
                             TypeExpr::AnonymousStruct { .. } => {
                                 unreachable!("handled above")
+                            }
+                            TypeExpr::PointerConst { .. } | TypeExpr::PointerMut { .. } => {
+                                // Pointer types as values - use intern_type to get representation
+                                self.intern_type(&type_lit.type_expr)
                             }
                         };
                         self.rir.add_inst(Inst {

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -964,6 +964,7 @@ impl Rir {
                 directives_start,
                 directives_len,
                 is_pub,
+                is_unchecked,
                 name,
                 params_start,
                 params_len,
@@ -974,6 +975,7 @@ impl Rir {
                 directives_start: *directives_start + extra_offset,
                 directives_len: *directives_len,
                 is_pub: *is_pub,
+                is_unchecked: *is_unchecked,
                 name: *name,
                 params_start: *params_start + extra_offset,
                 params_len: *params_len,
@@ -1128,6 +1130,9 @@ impl Rir {
                 body: renumber(*body),
             },
             InstData::Comptime { expr } => InstData::Comptime {
+                expr: renumber(*expr),
+            },
+            InstData::Checked { expr } => InstData::Checked {
                 expr: renumber(*expr),
             },
             InstData::TypeConst { type_name } => InstData::TypeConst {
@@ -1317,6 +1322,7 @@ impl Rir {
                 | InstData::TypeIntrinsic { .. }
                 | InstData::DropFnDecl { .. }
                 | InstData::Comptime { .. }
+                | InstData::Checked { .. }
                 | InstData::TypeConst { .. }
                 | InstData::AnonStructType { .. } => {}
             }
@@ -1439,6 +1445,8 @@ pub enum InstData {
         directives_len: u32,
         /// Whether this function is public (requires --preview modules)
         is_pub: bool,
+        /// Whether this function is marked `unchecked` (can only be called from checked blocks)
+        is_unchecked: bool,
         name: Spur,
         /// Index into extra data where params start
         params_start: u32,
@@ -1712,6 +1720,14 @@ pub enum InstData {
         expr: InstRef,
     },
 
+    /// Checked block expression: checked { expr }
+    /// Unchecked operations (raw pointer manipulation, calling unchecked functions)
+    /// are only allowed inside checked blocks.
+    Checked {
+        /// The expression inside the checked block
+        expr: InstRef,
+    },
+
     /// Type constant: a type used as a value expression (e.g., `i32` in `identity(i32, 42)`)
     /// The type_name is the symbol for the type (e.g., "i32", "bool").
     TypeConst {
@@ -1867,6 +1883,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     directives_start: _,
                     directives_len: _,
                     is_pub,
+                    is_unchecked,
                     name,
                     params_start,
                     params_len,
@@ -1875,6 +1892,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     has_self,
                 } => {
                     let pub_str = if *is_pub { "pub " } else { "" };
+                    let unchecked_str = if *is_unchecked { "unchecked " } else { "" };
                     let name_str = self.interner.resolve(&*name);
                     let ret_str = self.interner.resolve(&*return_type);
                     let self_str = if *has_self { "self, " } else { "" };
@@ -1898,8 +1916,9 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         .collect();
                     writeln!(
                         out,
-                        "{}fn {}({}{}) -> {} {{",
+                        "{}{}fn {}({}{}) -> {} {{",
                         pub_str,
+                        unchecked_str,
                         name_str,
                         self_str,
                         params_str.join(", "),
@@ -2186,6 +2205,11 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 // Comptime block
                 InstData::Comptime { expr } => {
                     writeln!(out, "comptime {{ {} }}", expr).unwrap();
+                }
+
+                // Checked block
+                InstData::Checked { expr } => {
+                    writeln!(out, "checked {{ {} }}", expr).unwrap();
                 }
 
                 // Type constant
@@ -2706,6 +2730,7 @@ mod tests {
                 directives_start,
                 directives_len,
                 is_pub: false,
+                is_unchecked: false,
                 name,
                 params_start,
                 params_len,
@@ -2740,6 +2765,7 @@ mod tests {
                 directives_start,
                 directives_len,
                 is_pub: false,
+                is_unchecked: false,
                 name,
                 params_start,
                 params_len,
@@ -2799,6 +2825,7 @@ mod tests {
                 directives_start,
                 directives_len,
                 is_pub: false,
+                is_unchecked: false,
                 name,
                 params_start,
                 params_len,
@@ -3375,6 +3402,7 @@ mod tests {
                 directives_start,
                 directives_len,
                 is_pub: false,
+                is_unchecked: false,
                 name: method_name,
                 params_start,
                 params_len,
@@ -3957,6 +3985,7 @@ mod tests {
                 directives_start: dirs_start,
                 directives_len: dirs_len,
                 is_pub: false,
+                is_unchecked: false,
                 name: main_name,
                 params_start,
                 params_len,
@@ -3982,6 +4011,7 @@ mod tests {
                 directives_start: dirs_start2,
                 directives_len: dirs_len2,
                 is_pub: false,
+                is_unchecked: false,
                 name: helper_name,
                 params_start: params_start2,
                 params_len: params_len2,

--- a/crates/rue-spec/cases/items/unchecked.toml
+++ b/crates/rue-spec/cases/items/unchecked.toml
@@ -1,0 +1,165 @@
+# Unchecked Code and Raw Pointers - Phase 1: Parser Support
+#
+# This tests the syntax support for:
+# - `unchecked fn` modifier
+# - `checked { }` block expressions
+# - `ptr const T` and `ptr mut T` type syntax
+#
+# Note: These tests use the unchecked_code preview feature and are expected
+# to pass for Phase 1 (parsing). Later phases will add semantic analysis.
+
+[section]
+id = "items.unchecked"
+spec_chapter = "9.1"
+name = "Unchecked Code"
+description = "Unchecked functions, checked blocks, and raw pointer types for low-level memory access."
+
+# =============================================================================
+# Unchecked function modifier
+# =============================================================================
+
+[[case]]
+name = "unchecked_fn_basic"
+spec = ["9.1:1", "9.1:3"]
+preview = "unchecked_code"
+source = """
+unchecked fn dangerous_op() -> i32 { 42 }
+fn main() -> i32 { 0 }
+"""
+exit_code = 0
+
+[[case]]
+name = "unchecked_fn_with_params"
+spec = ["9.1:1"]
+preview = "unchecked_code"
+source = """
+unchecked fn read_memory(addr: i32) -> i32 { addr }
+fn main() -> i32 { 0 }
+"""
+exit_code = 0
+
+[[case]]
+name = "pub_unchecked_fn"
+spec = ["9.1:1"]
+preview = "unchecked_code"
+source = """
+pub unchecked fn public_dangerous() -> i32 { 0 }
+fn main() -> i32 { 0 }
+"""
+exit_code = 0
+
+# =============================================================================
+# Unchecked function requires preview feature
+# =============================================================================
+
+[[case]]
+name = "unchecked_fn_requires_preview"
+spec = ["9.1:2"]
+source = """
+unchecked fn dangerous_op() -> i32 { 42 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "requires preview feature"
+
+# =============================================================================
+# Checked block expressions
+# =============================================================================
+
+[[case]]
+name = "checked_block_basic"
+spec = ["9.1:5", "9.1:6", "9.1:7"]
+preview = "unchecked_code"
+source = """
+fn main() -> i32 {
+    let x = checked { 42 };
+    x
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "checked_block_nested"
+spec = ["9.1:5"]
+preview = "unchecked_code"
+source = """
+fn main() -> i32 {
+    checked {
+        let x = 10;
+        let y = 32;
+        x + y
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "checked_block_with_statements"
+spec = ["9.1:5"]
+preview = "unchecked_code"
+source = """
+fn main() -> i32 {
+    let result = checked {
+        let a = 20;
+        let b = 22;
+        a + b
+    };
+    result
+}
+"""
+exit_code = 42
+
+# =============================================================================
+# Pointer type syntax - Phase 1 only parses, Phase 2 adds semantic analysis
+# =============================================================================
+
+# These tests verify the parser accepts pointer syntax.
+# In Phase 1, the semantic analyzer doesn't recognize ptr types yet.
+# This test is expected to fail until Phase 2 is implemented.
+
+[[case]]
+name = "ptr_const_type_in_param"
+spec = ["9.1:9", "9.1:10"]
+preview = "unchecked_code"
+source = """
+fn takes_ptr(p: ptr const i32) -> i32 { 0 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "unknown type"
+
+[[case]]
+name = "ptr_mut_type_in_param"
+spec = ["9.1:9"]
+preview = "unchecked_code"
+source = """
+fn takes_mut_ptr(p: ptr mut i32) -> i32 { 0 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "unknown type"
+
+[[case]]
+name = "ptr_const_return_type"
+spec = ["9.1:9"]
+preview = "unchecked_code"
+source = """
+unchecked fn get_ptr() -> ptr const i32 {
+    @panic()
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "unknown type"
+
+[[case]]
+name = "ptr_to_struct_type"
+spec = ["9.1:9"]
+preview = "unchecked_code"
+source = """
+struct Point { x: i32, y: i32 }
+fn takes_point_ptr(p: ptr const Point) -> i32 { 0 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "unknown type"

--- a/docs/spec/src/09-unchecked-code/01-syntax.md
+++ b/docs/spec/src/09-unchecked-code/01-syntax.md
@@ -1,0 +1,93 @@
++++
+title = "Unchecked Code Syntax"
+weight = 1
+template = "spec/page.html"
++++
+
+# Unchecked Code Syntax
+
+This section describes the syntax for unchecked code constructs.
+
+## Unchecked Functions
+
+{{ rule(id="9.1:1", cat="normative") }}
+
+A function **MAY** be marked with the `unchecked` modifier to indicate that calling it requires a `checked` block.
+
+{{ rule(id="9.1:2", cat="legality-rule") }}
+
+The `unchecked` modifier requires the `unchecked_code` preview feature. Using `unchecked` without enabling this feature is a compile-time error.
+
+{{ rule(id="9.1:3", cat="syntax") }}
+
+```ebnf
+function = [ "pub" ] [ "unchecked" ] "fn" IDENT "(" [ params ] ")" [ "->" type ] "{" block "}" ;
+```
+
+{{ rule(id="9.1:4", cat="example") }}
+
+```rue
+unchecked fn dangerous_operation() -> i32 {
+    42
+}
+
+pub unchecked fn public_dangerous() -> i32 {
+    0
+}
+```
+
+## Checked Blocks
+
+{{ rule(id="9.1:5", cat="normative") }}
+
+A `checked` block is an expression that enables unchecked operations within its body.
+
+{{ rule(id="9.1:6", cat="syntax") }}
+
+```ebnf
+checked_expr = "checked" "{" block "}" ;
+```
+
+{{ rule(id="9.1:7", cat="dynamic-semantics") }}
+
+A `checked` block evaluates its body and returns the value of the final expression. The type of a `checked` block is the type of its body expression.
+
+{{ rule(id="9.1:8", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    let x = checked {
+        let a = 10;
+        let b = 32;
+        a + b
+    };
+    x
+}
+```
+
+## Raw Pointer Types
+
+{{ rule(id="9.1:9", cat="normative") }}
+
+Rue provides two raw pointer types for low-level memory access:
+- `ptr const T` - a pointer to immutable data of type `T`
+- `ptr mut T` - a pointer to mutable data of type `T`
+
+{{ rule(id="9.1:10", cat="syntax") }}
+
+```ebnf
+ptr_type = "ptr" ( "const" | "mut" ) type ;
+```
+
+{{ rule(id="9.1:11", cat="informative") }}
+
+Raw pointer types are parsed in Phase 1 but semantic analysis (type checking, pointer operations) is implemented in later phases. Until Phase 2 is implemented, using pointer types results in an "unknown type" error.
+
+{{ rule(id="9.1:12", cat="example") }}
+
+```rue
+// These parse correctly but fail type checking until Phase 2
+fn takes_ptr(p: ptr const i32) -> i32 { 0 }
+fn takes_mut_ptr(p: ptr mut i32) -> i32 { 0 }
+unchecked fn get_ptr() -> ptr const i32 { @panic() }
+```

--- a/docs/spec/src/09-unchecked-code/_index.md
+++ b/docs/spec/src/09-unchecked-code/_index.md
@@ -1,0 +1,15 @@
++++
+title = "Unchecked Code"
+weight = 9
+sort_by = "weight"
+template = "spec/section.html"
+page_template = "spec/page.html"
++++
+
+# Unchecked Code
+
+This chapter describes Rue's mechanism for low-level operations that bypass normal safety checks.
+
+{{ rule(id="9.0:1") }}
+
+Rue provides `checked` blocks and `unchecked` functions to enable low-level memory operations while keeping such code visibly separate from normal safe code.


### PR DESCRIPTION
…ointers

Implements rue-7qxm from ADR-0028:
- Add 'checked', 'unchecked', and 'ptr' tokens to rue-lexer
- Add checked block expression parsing (`checked { ... }`)
- Add unchecked function modifier (`unchecked fn ...`)
- Add pointer type syntax (`ptr const T`, `ptr mut T`)
- Add PreviewFeature::UncheckedCode to gate the feature
- Add RIR representation for checked blocks and is_unchecked field
- Add spec chapter 9 for unchecked code syntax
- Add spec tests with preview = "unchecked_code" flag

Note: Pointer types currently result in 'unknown type' errors since Phase 2 (semantic analysis) is not yet implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)