### PR TITLE
feat(modules): Implement module type member access (rue-vw7u)

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1622,6 +1622,12 @@ impl<'a> Sema<'a> {
         let base_result = self.analyze_inst_for_projection(air, base, ctx)?;
         let base_type = base_result.ty;
 
+        // Handle module member access: module.StructName or module.EnumName
+        // This returns a comptime type that can be used to construct values
+        if let Some(module_id) = base_type.as_module() {
+            return self.analyze_module_type_member_access(air, module_id, field, span);
+        }
+
         let struct_id = match base_type.as_struct() {
             Some(id) => id,
             None => {
@@ -1716,6 +1722,129 @@ impl<'a> Sema<'a> {
         // This is one of the larger handlers that we'll keep in the main file
         // for now and refactor in a future pass
         self.analyze_field_set_impl(air, base, field, value, span, ctx)
+    }
+
+    /// Analyze module type member access: `module.StructName` or `module.EnumName`.
+    ///
+    /// When accessing a struct or enum through a module, we return a comptime type
+    /// that can be used to construct values. For example:
+    ///
+    /// ```rue
+    /// let utils = @import("utils");
+    /// let Point = utils.Point;        // Returns Type::Struct as a comptime type
+    /// let p = Point { x: 1, y: 2 };   // Uses the type to construct a value
+    /// ```
+    ///
+    /// This enables the pattern of importing types through modules and using them
+    /// for struct initialization or enum variant access.
+    fn analyze_module_type_member_access(
+        &mut self,
+        air: &mut Air,
+        module_id: crate::types::ModuleId,
+        member_name: Spur,
+        span: Span,
+    ) -> CompileResult<AnalysisResult> {
+        let member_name_str = self.interner.resolve(&member_name).to_string();
+
+        // Get the module definition to find its file path
+        let module_def = self.module_registry.get_def(module_id);
+        let module_file_path = module_def.file_path.clone();
+
+        // Get the accessing file's directory for visibility check
+        let accessing_file_path = self.get_source_path(span).map(|s| s.to_string());
+
+        // First, try to find a struct with this name that belongs to the module's file
+        if let Some(&struct_id) = self.structs.get(&member_name) {
+            let struct_def = self.type_pool.struct_def(struct_id);
+
+            // Check if this struct was defined in the module's file
+            if let Some(struct_file_path) = self.get_file_path(struct_def.file_id) {
+                if struct_file_path == module_file_path {
+                    // Check visibility: pub structs are visible to all, private only to same directory
+                    if !struct_def.is_pub {
+                        // Check if accessing from same directory
+                        let same_dir = match &accessing_file_path {
+                            Some(accessing) => {
+                                let accessing_dir = std::path::Path::new(accessing).parent();
+                                let module_dir = std::path::Path::new(&module_file_path).parent();
+                                accessing_dir == module_dir
+                            }
+                            None => true, // Be permissive if we can't determine the path
+                        };
+
+                        if !same_dir {
+                            return Err(CompileError::new(
+                                ErrorKind::PrivateMemberAccess {
+                                    item_kind: "struct".to_string(),
+                                    name: member_name_str,
+                                },
+                                span,
+                            ));
+                        }
+                    }
+
+                    // Return a TypeConst instruction with the struct type
+                    let struct_type = Type::Struct(struct_id);
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::TypeConst(struct_type),
+                        ty: Type::ComptimeType,
+                        span,
+                    });
+                    return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
+                }
+            }
+        }
+
+        // Next, try to find an enum with this name that belongs to the module's file
+        if let Some(&enum_id) = self.enums.get(&member_name) {
+            let enum_def = self.type_pool.enum_def(enum_id);
+
+            // Check if this enum was defined in the module's file
+            if let Some(enum_file_path) = self.get_file_path(enum_def.file_id) {
+                if enum_file_path == module_file_path {
+                    // Check visibility: pub enums are visible to all, private only to same directory
+                    if !enum_def.is_pub {
+                        // Check if accessing from same directory
+                        let same_dir = match &accessing_file_path {
+                            Some(accessing) => {
+                                let accessing_dir = std::path::Path::new(accessing).parent();
+                                let module_dir = std::path::Path::new(&module_file_path).parent();
+                                accessing_dir == module_dir
+                            }
+                            None => true, // Be permissive if we can't determine the path
+                        };
+
+                        if !same_dir {
+                            return Err(CompileError::new(
+                                ErrorKind::PrivateMemberAccess {
+                                    item_kind: "enum".to_string(),
+                                    name: member_name_str,
+                                },
+                                span,
+                            ));
+                        }
+                    }
+
+                    // Return a TypeConst instruction with the enum type
+                    let enum_type = Type::Enum(enum_id);
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::TypeConst(enum_type),
+                        ty: Type::ComptimeType,
+                        span,
+                    });
+                    return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
+                }
+            }
+        }
+
+        // Member not found in the module
+        Err(CompileError::new(
+            ErrorKind::UnknownModuleMember {
+                module_name: module_def.import_path.clone(),
+                member_name: member_name_str,
+            },
+            span,
+        ))
     }
 
     // ========================================================================

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -143,6 +143,7 @@ impl ErrorCode {
     pub const MODULE_NOT_FOUND: Self = Self(704);
     pub const STD_LIB_NOT_FOUND: Self = Self(705);
     pub const PRIVATE_MEMBER_ACCESS: Self = Self(706);
+    pub const UNKNOWN_MODULE_MEMBER: Self = Self(707);
 
     // ========================================================================
     // Literal/operator errors (E0800-E0899)
@@ -966,6 +967,11 @@ pub enum ErrorKind {
     StdLibNotFound,
     #[error("{item_kind} `{name}` is private")]
     PrivateMemberAccess { item_kind: String, name: String },
+    #[error("module `{module_name}` has no member `{member_name}`")]
+    UnknownModuleMember {
+        module_name: String,
+        member_name: String,
+    },
 
     // Literal errors
     #[error("literal value {value} is out of range for type '{ty}'")]
@@ -1104,6 +1110,7 @@ impl ErrorKind {
             ErrorKind::ModuleNotFound { .. } => ErrorCode::MODULE_NOT_FOUND,
             ErrorKind::StdLibNotFound => ErrorCode::STD_LIB_NOT_FOUND,
             ErrorKind::PrivateMemberAccess { .. } => ErrorCode::PRIVATE_MEMBER_ACCESS,
+            ErrorKind::UnknownModuleMember { .. } => ErrorCode::UNKNOWN_MODULE_MEMBER,
 
             // Literal/operator errors (E0800-E0899)
             ErrorKind::LiteralOutOfRange { .. } => ErrorCode::LITERAL_OUT_OF_RANGE,

--- a/crates/rue-spec/cases/modules/constants.toml
+++ b/crates/rue-spec/cases/modules/constants.toml
@@ -48,6 +48,7 @@ exit_code = 0
 [[case]]
 name = "const_import_syntax"
 description = "Const with @import syntax parses correctly"
+# TODO: Needs const x = @import(...) to be evaluated at compile time
 preview = "module_types"
 source = """
 const math = @import("nonexistent");
@@ -59,6 +60,7 @@ error_contains = "module 'nonexistent' not found"
 [[case]]
 name = "pub_const_import_syntax"
 description = "Pub const with @import syntax parses correctly"
+# TODO: Needs const x = @import(...) to be evaluated at compile time
 preview = "module_types"
 source = """
 pub const math = @import("nonexistent");

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -46,7 +46,6 @@ exit_code = 42
 [[case]]
 name = "same_dir_access_private_struct"
 description = "Files in same directory can access private structs"
-preview = "module_types"
 source = """
 fn main() -> i32 {
     let utils = @import("utils");
@@ -65,6 +64,7 @@ exit_code = 42
 [[case]]
 name = "same_dir_access_private_enum"
 description = "Files in same directory can access private enums"
+# TODO: Needs parser support for module.EnumName::Variant in match patterns
 preview = "module_types"
 source = """
 fn main() -> i32 {
@@ -126,7 +126,6 @@ error_contains = "private"
 [[case]]
 name = "cross_dir_access_pub_struct"
 description = "Files in different directories can access public structs"
-preview = "module_types"
 source = """
 fn main() -> i32 {
     let utils = @import("subdir/utils");
@@ -144,7 +143,6 @@ exit_code = 42
 [[case]]
 name = "cross_dir_access_private_struct_error"
 description = "Files in different directories cannot access private structs"
-preview = "module_types"
 source = """
 fn main() -> i32 {
     let utils = @import("subdir/utils");
@@ -163,6 +161,7 @@ error_contains = "private"
 [[case]]
 name = "cross_dir_access_pub_enum"
 description = "Files in different directories can access public enums"
+# TODO: Needs parser support for module.EnumName::Variant in match patterns
 preview = "module_types"
 source = """
 fn main() -> i32 {
@@ -183,6 +182,7 @@ exit_code = 42
 [[case]]
 name = "cross_dir_access_private_enum_error"
 description = "Files in different directories cannot access private enums"
+# TODO: Needs parser support for module.EnumName::Variant in expressions
 preview = "module_types"
 source = """
 fn main() -> i32 {
@@ -206,6 +206,7 @@ error_contains = "private"
 [[case]]
 name = "directory_module_intra_access"
 description = "Files within a directory module can access each other's private items"
+# TODO: Needs const x = @import(...) to work (compile-time evaluation)
 preview = "module_types"
 source = """
 fn main() -> i32 {


### PR DESCRIPTION
Adds support for accessing struct and enum types through modules:
- `utils.Point` returns the Point struct type
- `utils.Status` returns the Status enum type

When a field access is performed on a module type, Sema now looks up the member name in the module's file and returns a TypeConst instruction with the appropriate struct or enum type. Visibility is checked based on directory (same directory can access private items, different directories require pub).

This enables patterns like:
```rue
let utils = @import("utils");
let Point = utils.Point;
let p = Point { x: 1, y: 2 };
```

Remaining work (under preview = "module_types"):
- Parser support for module.EnumName::Variant in match patterns
- Compile-time evaluation of const = @import(...)

🤖 Generated with [Claude Code](https://claude.com/claude-code)