### PR TITLE
CI: Use macOS 15 to fix linker assertion failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             name: linux-x64
           - os: ubuntu-24.04-arm
             name: linux-arm64
-          - os: macos-latest
+          - os: macos-15
             name: macos
     runs-on: ${{ matrix.os }}
     name: test (${{ matrix.name }})


### PR DESCRIPTION
macOS 14 defaults to Xcode 15.4, which has a known linker bug that fails on long symbol names (ld: Assertion failed: name.size() <= maxLength). macOS 15 defaults to Xcode 16.0 which has this fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)