### PR TITLE
Fix module constant visibility and intra-directory access

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -2438,6 +2438,51 @@ fn analyze_var_ref_ctx(
         return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
     }
 
+    // Check if it's a constant (e.g., `const VALUE = 42` or `const math = @import("math")`)
+    if let Some(const_info) = ctx.get_constant(name) {
+        let ty = const_info.ty;
+        // For module constants, produce a TypeConst with the module type.
+        // This allows field access on the module (e.g., `math.add(1, 2)`)
+        if matches!(ty.kind(), TypeKind::Module(_)) {
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::TypeConst(ty),
+                ty,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, ty));
+        }
+        // For regular constants (e.g., `const VALUE = 42`), we need to inline the value.
+        // We read the RIR instruction directly since type inference hasn't run on const
+        // initializers in the declaration phase.
+        let init_inst = ctx.rir.get(const_info.init);
+        match &init_inst.data {
+            InstData::IntConst(value) => {
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::Const(*value),
+                    ty,
+                    span,
+                });
+                return Ok(AnalysisResult::new(air_ref, ty));
+            }
+            InstData::BoolConst(value) => {
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::BoolConst(*value),
+                    ty: Type::Bool,
+                    span,
+                });
+                return Ok(AnalysisResult::new(air_ref, Type::Bool));
+            }
+            _ => {
+                // For other expressions, we'd need to run full analysis on the init
+                // For now, this path shouldn't be reached for supported const types
+                return Err(CompileError::new(
+                    ErrorKind::InternalError("unsupported const expression type".to_string()),
+                    span,
+                ));
+            }
+        }
+    }
+
     // Look up the variable in locals
     let name_str = ctx.interner.resolve(&name);
     let local = analysis_ctx
@@ -7857,7 +7902,11 @@ impl<'a> Sema<'a> {
     /// 3. `foo.rue` (simple file module)
     /// 4. `_foo.rue` with `foo/` directory (directory module)
     /// 5. (Future) Dependency from rue.toml
-    fn resolve_import_path(&self, import_path: &str, span: Span) -> CompileResult<String> {
+    pub(crate) fn resolve_import_path(
+        &self,
+        import_path: &str,
+        span: Span,
+    ) -> CompileResult<String> {
         use std::path::Path;
 
         // Phase 0: Check for standard library import

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1259,6 +1259,48 @@ impl<'a> Sema<'a> {
             return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
         }
 
+        // Check if it's a constant (e.g., `const VALUE = 42` or `const math = @import("math")`)
+        if let Some(const_info) = self.constants.get(&name).cloned() {
+            let ty = const_info.ty;
+            // For module constants, produce a TypeConst with the module type.
+            // This allows field access on the module (e.g., `math.add(1, 2)`)
+            if matches!(ty.kind(), TypeKind::Module(_)) {
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::TypeConst(ty),
+                    ty,
+                    span,
+                });
+                return Ok(AnalysisResult::new(air_ref, ty));
+            }
+            // For regular constants (e.g., `const VALUE = 42`), we need to inline the value.
+            // We read the RIR instruction directly since type inference hasn't run on const
+            // initializers in the declaration phase.
+            let init_inst = self.rir.get(const_info.init);
+            match &init_inst.data {
+                rue_rir::InstData::IntConst(value) => {
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::Const(*value),
+                        ty,
+                        span,
+                    });
+                    return Ok(AnalysisResult::new(air_ref, ty));
+                }
+                rue_rir::InstData::BoolConst(value) => {
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::BoolConst(*value),
+                        ty: Type::Bool,
+                        span,
+                    });
+                    return Ok(AnalysisResult::new(air_ref, Type::Bool));
+                }
+                _ => {
+                    // For complex expressions, fall back to analyzing the init expression
+                    // This may fail for expressions that need type inference context
+                    return self.analyze_inst(air, const_info.init, ctx);
+                }
+            }
+        }
+
         // Check if this is a type name (for comptime type parameters)
         // Try to resolve it as a type - if successful, emit a TypeConst instruction
         if let Ok(resolved_type) = self.resolve_type(name, span) {

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -837,8 +837,9 @@ impl<'a> Sema<'a> {
     /// pub const strings = @import("utils/strings.rue");
     /// ```
     ///
-    /// For now, we store the constant info but don't fully evaluate it.
-    /// The type will be determined when the init expression is analyzed.
+    /// When the initializer is an `@import(...)`, we evaluate it at compile time
+    /// to resolve the module and register it in the module registry. This enables
+    /// subsequent member access via `const_name.function()` syntax.
     fn collect_const_declaration(
         &mut self,
         name: Spur,
@@ -870,24 +871,130 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        // For now, store with Type::Error as a placeholder - the actual type will be determined
-        // when the init expression is analyzed during module population phase.
-        // This is Phase 2 of the module system where we'll walk the init expression
-        // to determine if it's an @import (making it Type::Module).
-        //
-        // Note: Type::Error here is a placeholder indicating "not yet resolved".
-        // This is fine because const types are determined lazily when the module
-        // is populated with re-exports.
+        // Evaluate the initializer at compile time to determine the constant type.
+        // Currently we only handle @import(...) - other constant expressions will
+        // be supported as part of the broader comptime feature (ADR-0025).
+        let const_type = self.evaluate_const_init(init, span)?;
+
         self.constants.insert(
             name,
             ConstInfo {
                 is_pub,
-                ty: Type::Error,
+                ty: const_type,
                 init,
                 span,
             },
         );
 
         Ok(())
+    }
+
+    /// Evaluate a constant initializer at compile time.
+    ///
+    /// Currently handles:
+    /// - `@import("path")` - Returns Type::Module
+    /// - Integer literals - Returns the integer type
+    ///
+    /// Future extensions (ADR-0025 comptime) will support:
+    /// - Arithmetic on constants
+    /// - comptime blocks
+    /// - comptime function calls
+    fn evaluate_const_init(&mut self, init: InstRef, span: Span) -> CompileResult<Type> {
+        let init_inst = self.rir.get(init);
+
+        match &init_inst.data {
+            // @import("path") evaluates to Type::Module at compile time
+            InstData::Intrinsic {
+                name,
+                args_start,
+                args_len,
+            } => {
+                if *name == self.known.import {
+                    // Require module_types preview feature
+                    self.require_preview(
+                        PreviewFeature::ModuleTypes,
+                        "const = @import(...)",
+                        span,
+                    )?;
+
+                    // Validate exactly one argument
+                    if *args_len != 1 {
+                        return Err(CompileError::new(
+                            ErrorKind::IntrinsicWrongArgCount {
+                                name: "import".to_string(),
+                                expected: 1,
+                                found: *args_len as usize,
+                            },
+                            span,
+                        ));
+                    }
+
+                    // Get the string literal argument
+                    let arg_refs = self.rir.get_inst_refs(*args_start, *args_len);
+                    let arg_inst = self.rir.get(arg_refs[0]);
+                    let import_path = match &arg_inst.data {
+                        InstData::StringConst(path_spur) => {
+                            self.interner.resolve(path_spur).to_string()
+                        }
+                        _ => {
+                            return Err(CompileError::new(
+                                ErrorKind::ImportRequiresStringLiteral,
+                                arg_inst.span,
+                            ));
+                        }
+                    };
+
+                    // Resolve the import path to an absolute file path
+                    let resolved_path = self.resolve_import_path(&import_path, span)?;
+
+                    // Register the module in the registry
+                    let (module_id, _is_new) = self
+                        .module_registry
+                        .get_or_create(import_path, resolved_path);
+
+                    Ok(Type::Module(module_id))
+                } else {
+                    // For other intrinsics in const context, we don't support them yet
+                    let intrinsic_name = self.interner.resolve(name).to_string();
+                    Err(CompileError::new(
+                        ErrorKind::ConstExprNotSupported {
+                            expr_kind: format!("@{} intrinsic", intrinsic_name),
+                        },
+                        span,
+                    ))
+                }
+            }
+
+            // Integer literals evaluate to i32 (the default integer type)
+            // Note: RIR doesn't distinguish between integer types at this level;
+            // type inference happens later. For now, we treat all integer consts as i32.
+            InstData::IntConst(_) => Ok(Type::I32),
+
+            // Boolean literals
+            InstData::BoolConst(_) => Ok(Type::Bool),
+
+            // Unit literal
+            InstData::UnitConst => Ok(Type::Unit),
+
+            // String literals
+            InstData::StringConst(_) => {
+                // String constants would need the String type
+                // For now, we don't support them in const context
+                Err(CompileError::new(
+                    ErrorKind::ConstExprNotSupported {
+                        expr_kind: "string literals".to_string(),
+                    },
+                    span,
+                ))
+            }
+
+            // Other expressions are not yet supported in const context
+            _ => Err(CompileError::new(
+                ErrorKind::ConstExprNotSupported {
+                    expr_kind: "this expression".to_string(),
+                },
+                span,
+            )),
+        }
     }
 }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -340,7 +340,11 @@ impl<'a> Sema<'a> {
     ///
     /// Visibility rules (per ADR-0026):
     /// - `pub` items are always accessible
-    /// - Private items are accessible if the files are in the same directory
+    /// - Private items are accessible if the files are in the same directory module
+    ///
+    /// Directory module membership includes:
+    /// - Files directly in the directory (e.g., `utils/strings.rue` is in `utils`)
+    /// - Facade files for the directory (e.g., `_utils.rue` is in `utils` module)
     ///
     /// Returns true if the item is accessible.
     pub(crate) fn is_accessible(
@@ -362,13 +366,38 @@ impl<'a> Sema<'a> {
         match (accessing_path, target_path) {
             (Some(acc), Some(tgt)) => {
                 use std::path::Path;
-                let acc_dir = Path::new(acc).parent();
-                let tgt_dir = Path::new(tgt).parent();
-                // Same directory means accessible
-                acc_dir == tgt_dir
+
+                // Get the "module identity" for each file.
+                // For a regular file like `utils/strings.rue`, the module is `utils/`
+                // For a facade file like `_utils.rue`, the module is `utils/` (the directory it represents)
+                let acc_module = Self::get_module_identity(Path::new(acc));
+                let tgt_module = Self::get_module_identity(Path::new(tgt));
+
+                acc_module == tgt_module
             }
             // If either path is unknown, allow access (e.g., synthetic types, single-file mode)
             _ => true,
+        }
+    }
+
+    /// Get the module identity for a file path.
+    ///
+    /// - For regular files: returns the parent directory
+    /// - For facade files (`_foo.rue`): returns the corresponding directory (`foo/`)
+    ///
+    /// This allows facade files to be treated as part of their corresponding directory module.
+    fn get_module_identity(path: &std::path::Path) -> Option<std::path::PathBuf> {
+        let parent = path.parent()?;
+        let file_stem = path.file_stem()?.to_str()?;
+
+        // Check if this is a facade file (starts with underscore)
+        if file_stem.starts_with('_') {
+            // Facade file: _utils.rue -> parent/utils
+            let module_name = &file_stem[1..]; // Strip the leading underscore
+            Some(parent.join(module_name))
+        } else {
+            // Regular file: the module is just the parent directory
+            Some(parent.to_path_buf())
         }
     }
 
@@ -391,6 +420,11 @@ impl<'a> Sema<'a> {
         // These are critical and must succeed before we can analyze functions
         self.register_type_names().map_err(CompileErrors::from)?;
         self.resolve_declarations().map_err(CompileErrors::from)?;
+
+        // Phase 2.5: Evaluate const initializers (e.g., const x = @import(...))
+        // This determines the types of constants before function body analysis.
+        self.evaluate_const_initializers()
+            .map_err(CompileErrors::from)?;
 
         // Delegate to the analysis module for function body analysis
         analysis::analyze_all_function_bodies(self)
@@ -457,10 +491,11 @@ impl<'a> Sema<'a> {
             interner: self.interner,
             structs: self.structs.clone(),
             enums: self.enums.clone(),
-            // Pass references to functions/methods instead of cloning.
+            // Pass references to functions/methods/constants instead of cloning.
             // This is safe because after declaration gathering, these HashMaps are immutable.
             functions: &self.functions,
             methods: &self.methods,
+            constants: &self.constants,
             preview_features: self.preview_features.clone(),
             builtin_string_id: self.builtin_string_id,
             inference_ctx,
@@ -637,6 +672,170 @@ impl<'a> Sema<'a> {
                 span,
             )
         })
+    }
+
+    /// Evaluate const initializers to determine their types.
+    ///
+    /// This is Phase 2.5 of semantic analysis, called after declaration gathering
+    /// but before function body analysis. It handles:
+    ///
+    /// - `const x = @import("module")` - evaluates to Type::Module
+    /// - Other const initializers are left with placeholder types for now
+    ///
+    /// This enables module re-exports where a const holds an imported module
+    /// that can be accessed via dot notation.
+    pub fn evaluate_const_initializers(&mut self) -> rue_error::CompileResult<()> {
+        use rue_error::{CompileError, ErrorKind};
+
+        // Collect const names to iterate (avoid borrowing issues)
+        let const_names: Vec<lasso::Spur> = self.constants.keys().copied().collect();
+
+        for name in const_names {
+            let const_info = self.constants.get(&name).unwrap();
+            let init_ref = const_info.init;
+            let span = const_info.span;
+
+            // Check if the init expression is an @import intrinsic
+            let inst = self.rir.get(init_ref);
+            if let rue_rir::InstData::Intrinsic {
+                name: intrinsic_name,
+                args_start,
+                args_len,
+            } = &inst.data
+            {
+                let intrinsic_name_str = self.interner.resolve(intrinsic_name);
+                if intrinsic_name_str == "import" {
+                    // This is an @import - evaluate it at compile time
+                    let result = self.evaluate_import_intrinsic(*args_start, *args_len, span)?;
+
+                    // Update the const type to the module type
+                    if let Some(const_info_mut) = self.constants.get_mut(&name) {
+                        const_info_mut.ty = result;
+                    }
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Evaluate an @import intrinsic call at compile time.
+    ///
+    /// This is used during const initializer evaluation to resolve module imports.
+    fn evaluate_import_intrinsic(
+        &mut self,
+        args_start: u32,
+        args_len: u32,
+        span: rue_span::Span,
+    ) -> rue_error::CompileResult<Type> {
+        use rue_error::{CompileError, ErrorKind};
+
+        // @import takes exactly one argument
+        if args_len != 1 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "import".to_string(),
+                    expected: 1,
+                    found: args_len as usize,
+                },
+                span,
+            ));
+        }
+
+        // Get the argument from extra data (intrinsics use inst_refs, not call_args)
+        let arg_refs = self.rir.get_inst_refs(args_start, args_len);
+        let arg_inst = self.rir.get(arg_refs[0]);
+
+        // The argument must be a string literal
+        let import_path = match &arg_inst.data {
+            rue_rir::InstData::StringConst(path_spur) => {
+                self.interner.resolve(path_spur).to_string()
+            }
+            _ => {
+                return Err(CompileError::new(
+                    ErrorKind::ImportRequiresStringLiteral,
+                    arg_inst.span,
+                ));
+            }
+        };
+
+        // Resolve the import path
+        let resolved_path = self.resolve_import_path_for_const(&import_path, span)?;
+
+        // Register the module
+        let (module_id, _is_new) = self
+            .module_registry
+            .get_or_create(import_path, resolved_path);
+
+        Ok(Type::Module(module_id))
+    }
+
+    /// Resolve an import path for const evaluation.
+    ///
+    /// This is a simplified version of `resolve_import_path` that works
+    /// during the const evaluation phase before full analysis.
+    fn resolve_import_path_for_const(
+        &self,
+        import_path: &str,
+        span: rue_span::Span,
+    ) -> rue_error::CompileResult<String> {
+        use rue_error::{CompileError, ErrorKind};
+        use std::path::Path;
+
+        // Check for standard library import
+        if import_path == "std" {
+            // For now, std is not supported during const eval
+            return Err(CompileError::new(
+                ErrorKind::ModuleNotFound {
+                    path: import_path.to_string(),
+                    candidates: vec![],
+                },
+                span,
+            ));
+        }
+
+        // Check if the import path matches an already-loaded file
+        let import_base = import_path.strip_suffix(".rue").unwrap_or(import_path);
+        let import_with_rue = format!("{}.rue", import_base);
+
+        for (_file_id, file_path) in &self.file_paths {
+            // Check for exact match
+            if file_path == import_path {
+                return Ok(file_path.clone());
+            }
+
+            // Check if file path ends with import_path.rue (e.g., "utils/strings" matches ".../utils/strings.rue")
+            if file_path.ends_with(&import_with_rue) {
+                return Ok(file_path.clone());
+            }
+
+            // Check if the file path ends with the import path (e.g., "utils/strings.rue" matches)
+            if file_path.ends_with(import_path) {
+                return Ok(file_path.clone());
+            }
+
+            // For imports like "math" or "math.rue", check if the file is named accordingly
+            let file_name = Path::new(file_path).file_stem().and_then(|s| s.to_str());
+            if let Some(name) = file_name {
+                if name == import_base {
+                    return Ok(file_path.clone());
+                }
+                // Also check for _foo.rue (directory module entry point)
+                if name == format!("_{}", import_base) {
+                    return Ok(file_path.clone());
+                }
+            }
+        }
+
+        // Module not found - collect candidates for error message
+        let candidates: Vec<String> = self.file_paths.values().map(|p| p.clone()).collect();
+        Err(CompileError::new(
+            ErrorKind::ModuleNotFound {
+                path: import_path.to_string(),
+                candidates,
+            },
+            span,
+        ))
     }
 }
 

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -227,6 +227,9 @@ pub struct SemaContext<'a> {
     /// Reference to the parameter arena for accessing function/method parameter data.
     /// Use `param_arena.types(fn_info.params)` to get parameter types, etc.
     pub param_arena: &'a ParamArena,
+    /// Constant lookup: reference to Sema's constant map (immutable after declaration gathering).
+    /// Used for looking up const declarations like `const x = @import("...")`.
+    pub constants: &'a HashMap<Spur, crate::sema::ConstInfo>,
 }
 
 // SAFETY: SemaContext is Send + Sync because:
@@ -276,6 +279,11 @@ impl<'a> SemaContext<'a> {
     /// Look up a method by type and method name.
     pub fn get_method(&self, type_name: Spur, method_name: Spur) -> Option<&MethodInfo> {
         self.methods.get(&(type_name, method_name))
+    }
+
+    /// Look up a constant by name.
+    pub fn get_constant(&self, name: Spur) -> Option<&crate::sema::ConstInfo> {
+        self.constants.get(&name)
     }
 
     /// Get an array type definition by ID.
@@ -339,7 +347,11 @@ impl<'a> SemaContext<'a> {
     ///
     /// Visibility rules (per ADR-0026):
     /// - `pub` items are always accessible
-    /// - Private items are accessible if the files are in the same directory
+    /// - Private items are accessible if the files are in the same directory module
+    ///
+    /// Directory module membership includes:
+    /// - Files directly in the directory (e.g., `utils/strings.rue` is in `utils`)
+    /// - Facade files for the directory (e.g., `_utils.rue` is in `utils` module)
     ///
     /// Returns true if the item is accessible.
     pub fn is_accessible(
@@ -361,13 +373,38 @@ impl<'a> SemaContext<'a> {
         match (accessing_path, target_path) {
             (Some(acc), Some(tgt)) => {
                 use std::path::Path;
-                let acc_dir = Path::new(acc).parent();
-                let tgt_dir = Path::new(tgt).parent();
-                // Same directory means accessible
-                acc_dir == tgt_dir
+
+                // Get the "module identity" for each file.
+                // For a regular file like `utils/strings.rue`, the module is `utils/`
+                // For a facade file like `_utils.rue`, the module is `utils/` (the directory it represents)
+                let acc_module = Self::get_module_identity(Path::new(acc));
+                let tgt_module = Self::get_module_identity(Path::new(tgt));
+
+                acc_module == tgt_module
             }
             // If either path is unknown, allow access (e.g., synthetic types, single-file mode)
             _ => true,
+        }
+    }
+
+    /// Get the module identity for a file path.
+    ///
+    /// - For regular files: returns the parent directory
+    /// - For facade files (`_foo.rue`): returns the corresponding directory (`foo/`)
+    ///
+    /// This allows facade files to be treated as part of their corresponding directory module.
+    fn get_module_identity(path: &std::path::Path) -> Option<std::path::PathBuf> {
+        let parent = path.parent()?;
+        let file_stem = path.file_stem()?.to_str()?;
+
+        // Check if this is a facade file (starts with underscore)
+        if file_stem.starts_with('_') {
+            // Facade file: _utils.rue -> parent/utils
+            let module_name = &file_stem[1..]; // Strip the leading underscore
+            Some(parent.join(module_name))
+        } else {
+            // Regular file: the module is just the parent directory
+            Some(parent.to_path_buf())
         }
     }
 

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -104,6 +104,7 @@ impl ErrorCode {
     pub const DUPLICATE_DESTRUCTOR: Self = Self(416);
     pub const DESTRUCTOR_UNKNOWN_TYPE: Self = Self(417);
     pub const DUPLICATE_CONSTANT: Self = Self(418);
+    pub const CONST_EXPR_NOT_SUPPORTED: Self = Self(434);
     pub const DUPLICATE_VARIANT: Self = Self(419);
     pub const UNKNOWN_VARIANT: Self = Self(420);
     pub const UNKNOWN_ENUM_TYPE: Self = Self(421);
@@ -883,6 +884,9 @@ pub enum ErrorKind {
     /// Duplicate constant declaration
     #[error("duplicate {kind} '{name}'")]
     DuplicateConstant { name: String, kind: String },
+    /// Expression not supported in const context
+    #[error("{expr_kind} is not supported in const context")]
+    ConstExprNotSupported { expr_kind: String },
 
     // Enum errors
     #[error("duplicate variant '{variant_name}' in enum '{enum_name}'")]
@@ -1078,6 +1082,7 @@ impl ErrorKind {
             ErrorKind::DuplicateDestructor { .. } => ErrorCode::DUPLICATE_DESTRUCTOR,
             ErrorKind::DestructorUnknownType { .. } => ErrorCode::DESTRUCTOR_UNKNOWN_TYPE,
             ErrorKind::DuplicateConstant { .. } => ErrorCode::DUPLICATE_CONSTANT,
+            ErrorKind::ConstExprNotSupported { .. } => ErrorCode::CONST_EXPR_NOT_SUPPORTED,
             ErrorKind::DuplicateVariant { .. } => ErrorCode::DUPLICATE_VARIANT,
             ErrorKind::UnknownVariant { .. } => ErrorCode::UNKNOWN_VARIANT,
             ErrorKind::UnknownEnumType(_) => ErrorCode::UNKNOWN_ENUM_TYPE,

--- a/crates/rue-spec/cases/modules/constants.toml
+++ b/crates/rue-spec/cases/modules/constants.toml
@@ -47,27 +47,27 @@ exit_code = 0
 
 [[case]]
 name = "const_import_syntax"
-description = "Const with @import syntax parses correctly"
-# TODO: Needs const x = @import(...) to be evaluated at compile time
+description = "Const with @import syntax evaluated at compile time"
 preview = "module_types"
+preview_should_pass = true
 source = """
 const math = @import("nonexistent");
 fn main() -> i32 { 0 }
 """
 compile_fail = true
-error_contains = "module 'nonexistent' not found"
+error_contains = "cannot find module 'nonexistent'"
 
 [[case]]
 name = "pub_const_import_syntax"
-description = "Pub const with @import syntax parses correctly"
-# TODO: Needs const x = @import(...) to be evaluated at compile time
+description = "Pub const with @import syntax evaluated at compile time"
 preview = "module_types"
+preview_should_pass = true
 source = """
 pub const math = @import("nonexistent");
 fn main() -> i32 { 0 }
 """
 compile_fail = true
-error_contains = "module 'nonexistent' not found"
+error_contains = "cannot find module 'nonexistent'"
 
 # =============================================================================
 # Duplicate Detection

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -206,8 +206,8 @@ error_contains = "private"
 [[case]]
 name = "directory_module_intra_access"
 description = "Files within a directory module can access each other's private items"
-# TODO: Needs const x = @import(...) to work (compile-time evaluation)
 preview = "module_types"
+preview_should_pass = true
 source = """
 fn main() -> i32 {
     let utils = @import("utils");


### PR DESCRIPTION
This commit fixes two related issues with the module system:

1. **Constants visible in function bodies**: Module-level constants (like `const math = @import("math")`) are now correctly visible when referenced in function bodies. Added constant lookup to both `analyze_var_ref_ctx` and `analyze_var_ref` functions.

2. **Intra-directory visibility for facade files**: Files within the same directory module can now access each other's private items. The `_utils.rue` facade file is treated as part of the `utils/` directory module, allowing it to access private items in  `utils/strings.rue` and vice versa.

The key change is in `is_accessible()` which now computes "module identity" - for regular files it's the parent directory, but for facade files (starting with `_`) it's the corresponding subdirectory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)