### PR TITLE
Add methods_start/methods_len to AnonStructType in RIR

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -6475,10 +6475,12 @@ impl<'a> Sema<'a> {
             }
 
             // Anonymous struct type: a struct type constructed at comptime
-            // (e.g., `struct { first: T, second: T }` in a comptime function)
+            // (e.g., `struct { first: T, second: T, fn method(self) -> T { ... } }` in a comptime function)
             InstData::AnonStructType {
                 fields_start,
                 fields_len,
+                methods_start: _,
+                methods_len: _,
             } => {
                 // Get the field declarations from the RIR
                 let field_decls = self.rir.get_field_decls(*fields_start, *fields_len);
@@ -6500,7 +6502,10 @@ impl<'a> Sema<'a> {
                 }
 
                 // Check if an equivalent anonymous struct already exists (structural equality)
+                // TODO (Phase 3): Include method signatures in structural equality
                 let struct_ty = self.find_or_create_anon_struct(&struct_fields);
+
+                // TODO (Phase 3): Register methods for this anonymous struct using methods_start/methods_len
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::TypeConst(struct_ty),
@@ -8371,6 +8376,8 @@ impl<'a> Sema<'a> {
             InstData::AnonStructType {
                 fields_start,
                 fields_len,
+                methods_start: _,
+                methods_len: _,
             } => {
                 // Get the field declarations from the RIR
                 let field_decls = self.rir.get_field_decls(*fields_start, *fields_len);
@@ -8389,6 +8396,7 @@ impl<'a> Sema<'a> {
                 }
 
                 // Find or create the anonymous struct type
+                // TODO (Phase 3): Include method signatures in structural equality and register methods
                 let struct_ty = self.find_or_create_anon_struct(&struct_fields);
                 Some(ConstValue::Type(struct_ty))
             }
@@ -8713,6 +8721,8 @@ impl<'a> Sema<'a> {
             InstData::AnonStructType {
                 fields_start,
                 fields_len,
+                methods_start: _,
+                methods_len: _,
             } => {
                 let field_decls = self.rir.get_field_decls(*fields_start, *fields_len);
 
@@ -8728,6 +8738,7 @@ impl<'a> Sema<'a> {
                     });
                 }
 
+                // TODO (Phase 3): Include method signatures in structural equality and register methods with substitution
                 let struct_ty = self.find_or_create_anon_struct(&struct_fields);
                 Some(ConstValue::Type(struct_ty))
             }

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -733,8 +733,10 @@ impl<'a> AstGen<'a> {
             Expr::TypeLit(type_lit) => {
                 // Generate a type constant instruction for type-as-value expressions
                 match &type_lit.type_expr {
-                    TypeExpr::AnonymousStruct { fields, .. } => {
-                        // Generate an anonymous struct type instruction
+                    TypeExpr::AnonymousStruct {
+                        fields, methods, ..
+                    } => {
+                        // Generate an anonymous struct type instruction with methods
                         let field_decls: Vec<(Spur, Spur)> = fields
                             .iter()
                             .map(|f| {
@@ -744,10 +746,19 @@ impl<'a> AstGen<'a> {
                             })
                             .collect();
                         let (fields_start, fields_len) = self.rir.add_field_decls(&field_decls);
+
+                        // Generate each method inside the anonymous struct
+                        // (reusing gen_method, which generates FnDecl instructions)
+                        let method_refs: Vec<InstRef> =
+                            methods.iter().map(|m| self.gen_method(m)).collect();
+                        let (methods_start, methods_len) = self.rir.add_inst_refs(&method_refs);
+
                         self.rir.add_inst(Inst {
                             data: InstData::AnonStructType {
                                 fields_start,
                                 fields_len,
+                                methods_start,
+                                methods_len,
                             },
                             span: type_lit.span,
                         })
@@ -1919,5 +1930,135 @@ mod tests {
                 i
             );
         }
+    }
+
+    #[test]
+    fn test_anon_struct_with_methods() {
+        // Test that anonymous structs with methods generate AnonStructType with method references
+        let source = r#"
+            fn MakePoint(comptime T: type) -> type {
+                struct {
+                    x: T,
+                    y: T,
+
+                    fn get_x(self) -> T { self.x }
+                    fn origin() -> Self { Self { x: 0, y: 0 } }
+                }
+            }
+            fn main() -> i32 { 0 }
+        "#;
+        let (rir, interner) = gen_rir(source);
+
+        // Find the AnonStructType instruction
+        let anon_struct = rir
+            .iter()
+            .find(|(_, inst)| matches!(inst.data, InstData::AnonStructType { .. }));
+        assert!(
+            anon_struct.is_some(),
+            "Expected to find AnonStructType instruction"
+        );
+
+        let (_, inst) = anon_struct.unwrap();
+        match &inst.data {
+            InstData::AnonStructType {
+                fields_start,
+                fields_len,
+                methods_start,
+                methods_len,
+            } => {
+                // Should have 2 fields (x and y)
+                let fields = rir.get_field_decls(*fields_start, *fields_len);
+                assert_eq!(fields.len(), 2);
+                assert_eq!(interner.resolve(&fields[0].0), "x");
+                assert_eq!(interner.resolve(&fields[1].0), "y");
+
+                // Should have 2 methods (get_x and origin)
+                assert_eq!(*methods_len, 2);
+                let methods = rir.get_inst_refs(*methods_start, *methods_len);
+                assert_eq!(methods.len(), 2);
+
+                // Verify each method is a FnDecl
+                for method_ref in methods {
+                    let method_inst = rir.get(method_ref);
+                    match &method_inst.data {
+                        InstData::FnDecl { name, has_self, .. } => {
+                            let name_str = interner.resolve(name);
+                            // get_x has self, origin doesn't
+                            if name_str == "get_x" {
+                                assert!(*has_self, "get_x should have self parameter");
+                            } else if name_str == "origin" {
+                                assert!(!*has_self, "origin should not have self parameter");
+                            }
+                        }
+                        _ => panic!("Expected FnDecl for method"),
+                    }
+                }
+            }
+            _ => panic!("Expected AnonStructType"),
+        }
+    }
+
+    #[test]
+    fn test_anon_struct_without_methods() {
+        // Test that anonymous structs without methods have zero methods_len
+        let source = r#"
+            fn MakePair(comptime T: type) -> type {
+                struct { first: T, second: T }
+            }
+            fn main() -> i32 { 0 }
+        "#;
+        let (rir, _interner) = gen_rir(source);
+
+        // Find the AnonStructType instruction
+        let anon_struct = rir
+            .iter()
+            .find(|(_, inst)| matches!(inst.data, InstData::AnonStructType { .. }));
+        assert!(
+            anon_struct.is_some(),
+            "Expected to find AnonStructType instruction"
+        );
+
+        let (_, inst) = anon_struct.unwrap();
+        match &inst.data {
+            InstData::AnonStructType { methods_len, .. } => {
+                assert_eq!(*methods_len, 0, "Expected no methods");
+            }
+            _ => panic!("Expected AnonStructType"),
+        }
+    }
+
+    #[test]
+    fn test_anon_struct_method_function_spans() {
+        // Test that methods inside anonymous structs are tracked in function_spans
+        let source = r#"
+            fn Container(comptime T: type) -> type {
+                struct {
+                    value: T,
+                    fn get(self) -> T { self.value }
+                    fn set(self, v: T) -> Self { Self { value: v } }
+                }
+            }
+            fn main() -> i32 { 0 }
+        "#;
+        let (rir, interner) = gen_rir(source);
+
+        // Should have 4 functions: Container, get, set, main
+        assert_eq!(
+            rir.function_count(),
+            4,
+            "Expected 4 functions (Container, get, set, main)"
+        );
+
+        // Check that all methods are findable by name
+        let get_sym = interner.get_or_intern("get");
+        let set_sym = interner.get_or_intern("set");
+        assert!(
+            rir.find_function(get_sym).is_some(),
+            "Should find 'get' method"
+        );
+        assert!(
+            rir.find_function(set_sym).is_some(),
+            "Should find 'set' method"
+        );
     }
 }

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -1141,9 +1141,13 @@ impl Rir {
             InstData::AnonStructType {
                 fields_start,
                 fields_len,
+                methods_start,
+                methods_len,
             } => InstData::AnonStructType {
-                fields_start: *fields_start,
+                fields_start: *fields_start + extra_offset,
                 fields_len: *fields_len,
+                methods_start: *methods_start + extra_offset,
+                methods_len: *methods_len,
             },
         };
 
@@ -1204,6 +1208,18 @@ impl Rir {
 
                 // Impl decl - contains InstRef array for methods
                 InstData::ImplDecl {
+                    methods_start,
+                    methods_len,
+                    ..
+                } => {
+                    let start = (*methods_start + extra_offset) as usize;
+                    for i in 0..*methods_len as usize {
+                        extra[start + i] += inst_offset;
+                    }
+                }
+
+                // Anonymous struct type - contains InstRef array for methods
+                InstData::AnonStructType {
                     methods_start,
                     methods_len,
                     ..
@@ -1736,13 +1752,18 @@ pub enum InstData {
     },
 
     /// Anonymous struct type: a struct type used as a value expression
-    /// (e.g., `struct { first: T, second: T }` in comptime type construction)
+    /// (e.g., `struct { first: T, second: T, fn method(self) -> T { ... } }` in comptime type construction)
     /// Fields are stored in the extra array using add_field_decls/get_field_decls.
+    /// Methods are stored as InstRefs to FnDecl instructions in the extra array.
     AnonStructType {
         /// Index into extra data where fields start
         fields_start: u32,
         /// Number of fields
         fields_len: u32,
+        /// Index into extra data where method InstRefs start
+        methods_start: u32,
+        /// Number of methods (InstRefs to FnDecl instructions)
+        methods_len: u32,
     },
 }
 
@@ -2222,6 +2243,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 InstData::AnonStructType {
                     fields_start,
                     fields_len,
+                    methods_start,
+                    methods_len,
                 } => {
                     write!(out, "struct {{ ").unwrap();
                     let fields = self.rir.get_field_decls(*fields_start, *fields_len);
@@ -2232,6 +2255,17 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         let name_str = self.interner.resolve(name);
                         let ty_str = self.interner.resolve(ty);
                         write!(out, "{}: {}", name_str, ty_str).unwrap();
+                    }
+                    if *methods_len > 0 {
+                        let methods = self.rir.get_inst_refs(*methods_start, *methods_len);
+                        let mut need_sep = !fields.is_empty();
+                        for method in methods {
+                            if need_sep {
+                                write!(out, ", ").unwrap();
+                            }
+                            write!(out, "fn {}", method).unwrap();
+                            need_sep = true;
+                        }
                     }
                     writeln!(out, " }}").unwrap();
                 }

--- a/docs/designs/0029-anonymous-struct-methods.md
+++ b/docs/designs/0029-anonymous-struct-methods.md
@@ -213,12 +213,12 @@ Epic: rue-nj40
 
 **Deliverable**: Parser accepts `struct { x: i32, fn get(self) -> i32 { self.x } }` syntax.
 
-### Phase 2: RIR Generation (rue-nj40.2)
+### Phase 2: RIR Generation (rue-nj40.2) ✅
 
-- [ ] Extend `InstData::AnonStructType` to include method references
-- [ ] Store anonymous struct methods in RIR extra data
-- [ ] Generate RIR for methods inside anonymous structs
-- [ ] Handle `Self` type reference in RIR
+- [x] Extend `InstData::AnonStructType` to include method references
+- [x] Store anonymous struct methods in RIR extra data
+- [x] Generate RIR for methods inside anonymous structs
+- [x] Handle `Self` type reference in RIR
 
 **Deliverable**: RIR correctly represents anonymous structs with methods.
 


### PR DESCRIPTION
Phase 2 of rue-nj40: Extend RIR to represent methods in anonymous struct type expressions. This change:

- Adds methods_start and methods_len fields to InstData::AnonStructType
- Updates astgen to call gen_method for each method in anonymous structs
- Correctly renumbers method InstRefs during RIR merge operations
- Fixes RIR printer to properly separate multiple methods with commas
- Adds unit tests for method generation in anonymous structs
- Updates Sema to acknowledge new fields (deferred to Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)