### PR TITLE
fix(linker): Fix Mach-O string table to start with null byte

### DIFF
--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -617,8 +617,8 @@ impl ObjectBuilder {
         let macho_name = format!("_{}", self.name);
 
         // Build string table
-        // Format: starts with a space for empty string, then null-terminated strings
-        let mut strtab = vec![0x20, 0x00]; // Start with " \0" (space + null)
+        // Format: starts with null byte (index 0 = empty string), then null-terminated strings
+        let mut strtab = vec![0u8]; // Start with null byte (same as ELF)
 
         // The function symbol name (with underscore prefix for macOS)
         let func_name_offset = strtab.len();


### PR DESCRIPTION
The string table was starting with "\ \0" (space + null) instead of just a null byte. Per Mach-O conventions, index 0 should refer to an empty string (null byte), consistent with ELF's approach.

This was causing debugging tools (otool, nm, lldb) to potentially display strange results.

Closes: rue-52cc

🤖 Generated with [Claude Code](https://claude.com/claude-code)