### PR TITLE
Make macOS minimum version configurable via Target

### DIFF
--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -773,10 +773,10 @@ impl ObjectBuilder {
         macho.extend_from_slice(&LC_BUILD_VERSION.to_le_bytes()); // cmd
         macho.extend_from_slice(&(MACHO64_BUILD_VERSION_CMD_SIZE as u32).to_le_bytes()); // cmdsize
         macho.extend_from_slice(&PLATFORM_MACOS.to_le_bytes()); // platform
-        // minos: macOS 11.0.0 (Big Sur) - encoded as major.minor.patch in nibbles
-        // 11.0.0 = 0x000B0000
-        macho.extend_from_slice(&0x000B0000_u32.to_le_bytes()); // minos (11.0.0)
-        macho.extend_from_slice(&0x000B0000_u32.to_le_bytes()); // sdk (11.0.0)
+        // minos/sdk: macOS minimum version (encoded as 0x00XXYYPP for major.minor.patch)
+        let macos_version = self.target.macos_min_version().unwrap_or(0x000B0000);
+        macho.extend_from_slice(&macos_version.to_le_bytes()); // minos
+        macho.extend_from_slice(&macos_version.to_le_bytes()); // sdk
         macho.extend_from_slice(&0_u32.to_le_bytes()); // ntools
 
         // === LC_SYMTAB ===

--- a/crates/rue-target/src/lib.rs
+++ b/crates/rue-target/src/lib.rs
@@ -143,6 +143,22 @@ impl Target {
         matches!(self, Target::X86_64Linux | Target::Aarch64Linux)
     }
 
+    /// Returns the minimum macOS version for this target, encoded for Mach-O.
+    ///
+    /// The version is encoded as `0x00XXYYPP` where XX is major, YY is minor, PP is patch.
+    /// For example, macOS 11.0.0 (Big Sur) is encoded as `0x000B0000`.
+    ///
+    /// Returns `None` for non-macOS targets.
+    ///
+    /// Note: macOS 11.0 (Big Sur) was the first version to support Apple Silicon (ARM64),
+    /// which is why it's the minimum for `Aarch64Macos`.
+    pub fn macos_min_version(&self) -> Option<u32> {
+        match self {
+            Target::Aarch64Macos => Some(0x000B0000), // 11.0.0 (Big Sur)
+            Target::X86_64Linux | Target::Aarch64Linux => None,
+        }
+    }
+
     /// Returns all supported targets.
     pub fn all() -> &'static [Target] {
         &[
@@ -362,6 +378,15 @@ mod tests {
         assert_eq!(Target::X86_64Linux.page_size(), 0x1000);
         assert_eq!(Target::Aarch64Linux.page_size(), 0x1000);
         assert_eq!(Target::Aarch64Macos.page_size(), 0x4000);
+    }
+
+    #[test]
+    fn test_macos_min_version() {
+        // Linux targets return None
+        assert_eq!(Target::X86_64Linux.macos_min_version(), None);
+        assert_eq!(Target::Aarch64Linux.macos_min_version(), None);
+        // macOS returns the encoded version (11.0.0 = 0x000B0000 for Big Sur)
+        assert_eq!(Target::Aarch64Macos.macos_min_version(), Some(0x000B0000));
     }
 
     #[test]


### PR DESCRIPTION
Add Target::macos_min_version() method to centralize the macOS minimum version (11.0.0 Big Sur for ARM64). This replaces the hardcoded value in rue-linker/emit.rs and makes it easier to change in the future.

Fixes rue-eb2t

🤖 Generated with [Claude Code](https://claude.com/claude-code)