### PR TITLE
Implement @syscall intrinsic (Phase 1 of ADR-0028)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -7407,6 +7407,8 @@ impl<'a> Sema<'a> {
             self.analyze_addr_of_intrinsic(air, &args, span, ctx, false)
         } else if name == known.addr_of_mut {
             self.analyze_addr_of_intrinsic(air, &args, span, ctx, true)
+        } else if name == known.syscall {
+            self.analyze_syscall_intrinsic(air, name, &args, span, ctx)
         } else {
             // Unknown intrinsic - resolve name for error message
             let intrinsic_name_str = self.interner.resolve(&name);
@@ -9992,5 +9994,69 @@ impl<'a> Sema<'a> {
             span,
         });
         Ok(AnalysisResult::new(air_ref, result_type))
+    }
+
+    /// Analyze @syscall intrinsic: perform a raw OS syscall.
+    /// Signature: @syscall(syscall_num: u64, arg0?: u64, ..., arg5?: u64) -> i64
+    ///
+    /// Takes a syscall number and up to 6 arguments, all of which must be u64.
+    /// Returns i64 (the syscall return value, which may be negative for errors).
+    /// Requires a checked block.
+    fn analyze_syscall_intrinsic(
+        &mut self,
+        air: &mut Air,
+        name: Spur,
+        args: &[RirCallArg],
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        // Require unchecked context
+        self.require_preview(PreviewFeature::UncheckedCode, "@syscall intrinsic", span)?;
+
+        // Syscall takes 1-7 arguments: syscall number + up to 6 arguments
+        if args.is_empty() || args.len() > 7 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "syscall".to_string(),
+                    expected: 7, // Show max expected for "at least 1, at most 7"
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        // Analyze all arguments and verify they are u64
+        let mut arg_refs = Vec::with_capacity(args.len());
+        for (i, arg) in args.iter().enumerate() {
+            let arg_result = self.analyze_inst(air, arg.value, ctx)?;
+            let arg_type = arg_result.ty;
+
+            // All syscall arguments must be u64
+            if arg_type != Type::U64 && !arg_type.is_error() && !arg_type.is_never() {
+                return Err(CompileError::new(
+                    ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                        name: "syscall".to_string(),
+                        expected: format!("u64 for argument {}", i),
+                        found: self.format_type_name(arg_type),
+                    })),
+                    span,
+                ));
+            }
+
+            arg_refs.push(arg_result.air_ref.as_u32());
+        }
+
+        // Create the intrinsic call instruction
+        let args_start = air.add_extra(&arg_refs);
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name,
+                args_start,
+                args_len: args.len() as u32,
+            },
+            ty: Type::I64,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::I64))
     }
 }

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -84,6 +84,8 @@ pub struct KnownSymbols {
     pub addr_of: Spur,
     /// The `addr_of_mut` intrinsic symbol - takes mutable address of lvalue.
     pub addr_of_mut: Spur,
+    /// The `syscall` intrinsic symbol - direct OS syscall.
+    pub syscall: Spur,
 
     // Builtin type names
     /// The `String` type name symbol.
@@ -128,6 +130,7 @@ impl KnownSymbols {
             int_to_ptr: interner.get_or_intern_static("int_to_ptr"),
             addr_of: interner.get_or_intern_static("addr_of"),
             addr_of_mut: interner.get_or_intern_static("addr_of_mut"),
+            syscall: interner.get_or_intern_static("syscall"),
 
             // Builtin type names
             string_type: interner.get_or_intern_static("String"),
@@ -191,6 +194,7 @@ mod tests {
         assert_eq!(interner.resolve(&known.int_to_ptr), "int_to_ptr");
         assert_eq!(interner.resolve(&known.addr_of), "addr_of");
         assert_eq!(interner.resolve(&known.addr_of_mut), "addr_of_mut");
+        assert_eq!(interner.resolve(&known.syscall), "syscall");
         assert_eq!(interner.resolve(&known.string_type), "String");
         assert_eq!(interner.resolve(&known.main_fn), "main");
     }

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -8,6 +8,7 @@ use std::collections::HashMap;
 use lasso::ThreadedRodeo;
 use rue_air::{StructId, TypeInternPool};
 use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Terminator, Type, TypeKind};
+use rue_target::Target;
 
 use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Operand, Reg, VReg};
 use crate::cfg_lower::{FieldChainBase, IndexChainBase, IndexLevel};
@@ -46,6 +47,8 @@ pub struct CfgLower<'a> {
     strings: &'a [String],
     /// Interner for resolving Spur to string
     interner: &'a ThreadedRodeo,
+    /// Target platform (needed for syscall ABI differences between Linux/macOS).
+    target: Target,
     mir: Aarch64Mir,
     /// Maps CFG values to vregs
     value_map: HashMap<CfgValue, VReg>,
@@ -72,6 +75,7 @@ impl<'a> CfgLower<'a> {
         type_pool: &'a TypeInternPool,
         strings: &'a [String],
         interner: &'a ThreadedRodeo,
+        target: Target,
     ) -> Self {
         let num_locals = cfg.num_locals();
         let num_params = cfg.num_params();
@@ -91,6 +95,7 @@ impl<'a> CfgLower<'a> {
             type_pool,
             strings,
             interner,
+            target,
             mir: Aarch64Mir::new(),
             value_map: HashMap::with_capacity(num_values),
             block_param_vregs: HashMap::with_capacity(estimated_block_params),
@@ -2190,6 +2195,68 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Physical(Reg::X0),
                     });
                     self.value_map.insert(value, result_vreg);
+                } else if name_str == "syscall" {
+                    // @syscall intrinsic - perform a direct system call
+                    //
+                    // ABI differs between Linux and macOS:
+                    //
+                    // Linux aarch64:
+                    //   - X8: syscall number
+                    //   - X0-X5: arguments 1-6
+                    //   - Returns result in X0
+                    //   - Uses SVC #0
+                    //
+                    // macOS aarch64:
+                    //   - X16: syscall number
+                    //   - X0-X5: arguments 1-6
+                    //   - Returns result in X0
+                    //   - Uses SVC #0x80
+
+                    let args = self.cfg.get_extra(*args_start, *args_len);
+
+                    // First argument is syscall number
+                    // Linux uses X8, macOS uses X16
+                    let syscall_num_vreg = self.get_vreg(args[0]);
+                    let syscall_num_reg = if self.target.is_macho() {
+                        Reg::X16
+                    } else {
+                        Reg::X8
+                    };
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Physical(syscall_num_reg),
+                        src: Operand::Virtual(syscall_num_vreg),
+                    });
+
+                    // Remaining arguments go to X0-X5
+                    for (i, &arg) in args.iter().skip(1).enumerate() {
+                        let arg_vreg = self.get_vreg(arg);
+                        let target_reg = match i {
+                            0 => Reg::X0,
+                            1 => Reg::X1,
+                            2 => Reg::X2,
+                            3 => Reg::X3,
+                            4 => Reg::X4,
+                            5 => Reg::X5,
+                            _ => unreachable!("syscall can have at most 6 arguments"),
+                        };
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Physical(target_reg),
+                            src: Operand::Virtual(arg_vreg),
+                        });
+                    }
+
+                    // Execute the syscall
+                    // Linux uses SVC #0, macOS uses SVC #0x80
+                    let svc_imm = if self.target.is_macho() { 0x80 } else { 0 };
+                    self.mir.push(Aarch64Inst::Svc { imm: svc_imm });
+
+                    // Result is in X0, move to a vreg
+                    let result_vreg = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(result_vreg),
+                        src: Operand::Physical(Reg::X0),
+                    });
+                    self.value_map.insert(value, result_vreg);
                 }
             }
 
@@ -4109,7 +4176,15 @@ mod tests {
             &interner,
         );
 
-        CfgLower::new(&cfg_output.cfg, type_pool, strings, &interner).lower()
+        // Use host target for tests
+        CfgLower::new(
+            &cfg_output.cfg,
+            type_pool,
+            strings,
+            &interner,
+            Target::host(),
+        )
+        .lower()
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -1033,6 +1033,12 @@ impl<'a> Emitter<'a> {
                 end_inst!(self, "ret");
             }
 
+            Aarch64Inst::Svc { imm } => {
+                self.begin_inst();
+                self.emit_svc(*imm);
+                end_inst!(self, "svc #{:#x}", imm);
+            }
+
             Aarch64Inst::StpPre { src1, src2, offset } => {
                 let rt1 = src1.as_physical();
                 let rt2 = src2.as_physical();
@@ -1825,6 +1831,14 @@ impl<'a> Emitter<'a> {
     fn emit_ret(&mut self) {
         // RET (branch to LR)
         self.emit_u32(OPCODE_RET);
+    }
+
+    fn emit_svc(&mut self, imm: u16) {
+        // SVC #imm - Supervisor Call
+        // Encoding: 1101 0100 000 imm16 00001
+        // imm16 is 16 bits from bits 5-20
+        let encoding = 0xD400_0001 | ((imm as u32) << 5);
+        self.emit_u32(encoding);
     }
 
     fn emit_lsl_imm(&mut self, rd: Reg, rn: Reg, shift: u8) {

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -260,7 +260,8 @@ fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
         | Aarch64Inst::Bvc { .. }
         | Aarch64Inst::Label { .. }
         | Aarch64Inst::Bl { .. }
-        | Aarch64Inst::Ret => {
+        | Aarch64Inst::Ret
+        | Aarch64Inst::Svc { .. } => {
             // No vreg operands
         }
     }
@@ -380,7 +381,8 @@ fn defs(inst: &Aarch64Inst) -> Vec<VReg> {
         | Aarch64Inst::Bvc { .. }
         | Aarch64Inst::Label { .. }
         | Aarch64Inst::Bl { .. }
-        | Aarch64Inst::Ret => {
+        | Aarch64Inst::Ret
+        | Aarch64Inst::Svc { .. } => {
             // No vreg operands
         }
     }

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -715,6 +715,13 @@ pub enum Aarch64Inst {
     /// `ret` - Return (branch to LR).
     Ret,
 
+    /// `svc #imm` - Supervisor call (syscall instruction).
+    ///
+    /// On macOS, syscalls use `svc #0x80` with syscall number in X16.
+    /// On Linux, syscalls use `svc #0` with syscall number in X8.
+    /// This instruction takes an immediate that specifies the system call type.
+    Svc { imm: u16 },
+
     // === Stack operations ===
     /// `stp x1, x2, [sp, #offset]!` - Store pair with pre-index (push).
     StpPre {
@@ -770,6 +777,10 @@ impl Aarch64Inst {
                 Reg::X17,
                 Reg::Lr,
             ],
+            // Syscall clobbers X0 (return value) and preserves most registers.
+            // On macOS, X16 contains syscall number; on Linux, X8 does.
+            // We conservatively clobber both to handle either target.
+            Aarch64Inst::Svc { .. } => &[Reg::X0, Reg::X8, Reg::X16],
             // All other instructions don't clobber additional registers
             _ => &[],
         }
@@ -922,6 +933,7 @@ impl fmt::Display for Aarch64Inst {
             Aarch64Inst::Label { id } => write!(f, "{}:", id),
             Aarch64Inst::Bl { symbol_id } => write!(f, "bl sym{}", symbol_id),
             Aarch64Inst::Ret => write!(f, "ret"),
+            Aarch64Inst::Svc { imm } => write!(f, "svc #{:#x}", imm),
             Aarch64Inst::StpPre { src1, src2, offset } => {
                 write!(f, "stp {}, {}, [sp, #{}]!", src1, src2, offset)
             }

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -30,6 +30,7 @@ use lasso::ThreadedRodeo;
 use rue_air::TypeInternPool;
 use rue_cfg::Cfg;
 use rue_error::CompileResult;
+use rue_target::Target;
 
 use crate::MachineCode;
 use crate::regalloc::RegAllocDebugInfo;
@@ -45,12 +46,13 @@ pub fn generate(
     type_pool: &TypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
+    target: Target,
 ) -> CompileResult<MachineCode> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, strings, interner, target).lower();
 
     // Allocate physical registers
     let existing_slots = num_locals + num_params;
@@ -88,12 +90,13 @@ pub fn generate_with_asm(
     type_pool: &TypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
+    target: Target,
 ) -> CompileResult<(MachineCode, String)> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, strings, interner, target).lower();
 
     // Allocate physical registers
     let existing_slots = num_locals + num_params;
@@ -134,12 +137,13 @@ pub fn generate_regalloc_info(
     type_pool: &TypeInternPool,
     strings: &[String],
     interner: &ThreadedRodeo,
+    target: Target,
 ) -> CompileResult<RegAllocDebugInfo<Reg>> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, strings, interner, target).lower();
 
     // Allocate physical registers with debug info
     let existing_slots = num_locals + num_params;

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -907,6 +907,7 @@ impl RegAlloc {
             Aarch64Inst::Label { id } => mir.push(Aarch64Inst::Label { id }),
             Aarch64Inst::Bl { symbol_id } => mir.push(Aarch64Inst::Bl { symbol_id }),
             Aarch64Inst::Ret => mir.push(Aarch64Inst::Ret),
+            Aarch64Inst::Svc { imm } => mir.push(Aarch64Inst::Svc { imm }),
         }
         Ok(())
     }

--- a/crates/rue-codegen/src/aarch64/schedule.rs
+++ b/crates/rue-codegen/src/aarch64/schedule.rs
@@ -184,6 +184,9 @@ fn get_latency(inst: &Aarch64Inst) -> u32 {
         Aarch64Inst::StringConstPtr { .. }
         | Aarch64Inst::StringConstLen { .. }
         | Aarch64Inst::StringConstCap { .. } => 1,
+
+        // Syscall instruction
+        Aarch64Inst::Svc { .. } => 1,
     }
 }
 

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -407,7 +407,7 @@ fn generate_aarch64_stack_frame(
     let num_params = cfg.num_params();
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, strings, interner, target).lower();
 
     // Allocate physical registers (may add spill slots)
     let existing_slots = num_locals + num_params;

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2351,6 +2351,46 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Physical(Reg::Rax),
                     });
                     self.value_map.insert(value, result_vreg);
+                } else if name_str == "syscall" {
+                    // @syscall intrinsic - perform a direct system call
+                    // Linux x86-64 syscall ABI:
+                    //   - RAX: syscall number
+                    //   - RDI, RSI, RDX, R10, R8, R9: arguments 1-6
+                    //   - Returns result in RAX
+                    //   - Clobbers RCX and R11 (saved by hardware)
+
+                    let args = self.cfg.get_extra(*args_start, *args_len);
+
+                    // Syscall argument registers (different from regular function call ABI!)
+                    const SYSCALL_ARG_REGS: [Reg; 6] =
+                        [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::R10, Reg::R8, Reg::R9];
+
+                    // First argument is syscall number -> RAX
+                    let syscall_num_vreg = self.get_vreg(args[0]);
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(Reg::Rax),
+                        src: Operand::Virtual(syscall_num_vreg),
+                    });
+
+                    // Remaining arguments go to RDI, RSI, RDX, R10, R8, R9
+                    for (i, &arg) in args.iter().skip(1).enumerate() {
+                        let arg_vreg = self.get_vreg(arg);
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Physical(SYSCALL_ARG_REGS[i]),
+                            src: Operand::Virtual(arg_vreg),
+                        });
+                    }
+
+                    // Execute the syscall instruction
+                    self.mir.push(X86Inst::Syscall);
+
+                    // Result is in RAX, move to a vreg
+                    let result_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(result_vreg),
+                        src: Operand::Physical(Reg::Rax),
+                    });
+                    self.value_map.insert(value, result_vreg);
                 }
             }
 

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -1506,6 +1506,7 @@ fn compile_aarch64(
                     &state.type_pool,
                     &state.strings,
                     &state.interner,
+                    options.target,
                 )?;
 
                 let mut obj_builder = ObjectBuilder::new(options.target, &func.analyzed.name)
@@ -1669,6 +1670,7 @@ fn compile_aarch64_from_rir(
                     &state.type_pool,
                     &state.strings,
                     &state.interner,
+                    options.target,
                 )?;
 
                 let mut obj_builder = ObjectBuilder::new(options.target, &func.analyzed.name)
@@ -1813,7 +1815,8 @@ pub fn generate_mir(
         }
         Arch::Aarch64 => {
             let mir =
-                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, strings, interner).lower();
+                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, strings, interner, target)
+                    .lower();
             Mir::Aarch64(mir)
         }
     }
@@ -1848,7 +1851,8 @@ pub fn generate_allocated_mir(
         Arch::Aarch64 => {
             // Lower CFG to Aarch64Mir with virtual registers
             let mir =
-                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, strings, interner).lower();
+                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, strings, interner, target)
+                    .lower();
 
             // Allocate physical registers
             let (mir, _num_spills, _used_callee_saved) =
@@ -1879,7 +1883,8 @@ pub fn generate_liveness_info(
         }
         Arch::Aarch64 => {
             let mir =
-                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, strings, interner).lower();
+                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, strings, interner, target)
+                    .lower();
             rue_codegen::aarch64::liveness::analyze_debug(&mir)
         }
     }
@@ -1907,7 +1912,7 @@ pub fn generate_lowering_info(
         }
         Arch::Aarch64 => {
             let (_mir, debug_info) =
-                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, strings, interner)
+                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, strings, interner, target)
                     .lower_with_debug();
             debug_info
         }
@@ -1937,7 +1942,7 @@ pub fn generate_emitted_asm(
         }
         Arch::Aarch64 => {
             let (_machine_code, asm) =
-                rue_codegen::aarch64::generate_with_asm(cfg, type_pool, strings, interner)?;
+                rue_codegen::aarch64::generate_with_asm(cfg, type_pool, strings, interner, target)?;
             Ok(asm)
         }
     }
@@ -1962,8 +1967,9 @@ pub fn generate_regalloc_info(
             Ok(debug_info.to_string())
         }
         Arch::Aarch64 => {
-            let debug_info =
-                rue_codegen::aarch64::generate_regalloc_info(cfg, type_pool, strings, interner)?;
+            let debug_info = rue_codegen::aarch64::generate_regalloc_info(
+                cfg, type_pool, strings, interner, target,
+            )?;
             Ok(debug_info.to_string())
         }
     }

--- a/crates/rue-spec/cases/runtime/syscall.toml
+++ b/crates/rue-spec/cases/runtime/syscall.toml
@@ -1,0 +1,182 @@
+# Syscall Intrinsic Tests
+#
+# These tests verify the @syscall intrinsic, which performs direct OS syscalls.
+# The intrinsic requires the unchecked_code preview feature and a checked block.
+
+[section]
+id = "runtime.syscall"
+spec_chapter = "9.2"
+name = "Syscall Intrinsic"
+
+# Test that @syscall requires the unchecked_code preview feature
+[[case]]
+name = "syscall_requires_unchecked_preview"
+spec = ["9.2:2", "9.2:3"]
+source = """
+fn main() -> i32 {
+    let syscall_num: u64 = 60;
+    let arg: u64 = 0;
+    checked {
+        @syscall(syscall_num, arg);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "requires preview feature"
+
+# Test that @syscall works with the preview feature enabled (x86-64 Linux)
+# Note: only_on restricts this test to run only on matching host platforms
+[[case]]
+name = "syscall_basic_x86_64"
+spec = ["9.2:1", "9.2:5"]
+preview = "unchecked_code"
+preview_should_pass = true
+only_on = ["x86-64-linux"]
+source = """
+fn main() -> i32 {
+    // exit_group syscall (231 on Linux x86-64)
+    // This will immediately terminate the program with exit code 42
+    let syscall_num: u64 = 231;
+    let exit_code: u64 = 42;
+    checked {
+        @syscall(syscall_num, exit_code);
+    };
+    // Unreachable - the syscall terminates the process
+    0
+}
+"""
+exit_code = 42
+
+# Test that @syscall works with the preview feature enabled (aarch64 Linux)
+[[case]]
+name = "syscall_basic_aarch64"
+spec = ["9.2:1", "9.2:5"]
+preview = "unchecked_code"
+preview_should_pass = true
+only_on = ["aarch64-linux"]
+source = """
+fn main() -> i32 {
+    // exit_group syscall (94 on Linux aarch64)
+    // This will immediately terminate the program with exit code 42
+    let syscall_num: u64 = 94;
+    let exit_code: u64 = 42;
+    checked {
+        @syscall(syscall_num, exit_code);
+    };
+    // Unreachable - the syscall terminates the process
+    0
+}
+"""
+exit_code = 42
+
+# Test that @syscall requires at least one argument (the syscall number)
+[[case]]
+name = "syscall_requires_syscall_number"
+spec = ["9.2:4"]
+preview = "unchecked_code"
+source = """
+fn main() -> i32 {
+    checked {
+        @syscall();
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "wrong number of arguments"
+
+# Test that @syscall accepts up to 7 arguments
+# TODO: This test currently fails - the syscall doesn't terminate with max args.
+# Filed as rue-8qt6 for investigation.
+[[case]]
+name = "syscall_max_args"
+spec = ["9.2:4"]
+preview = "unchecked_code"
+source = """
+fn main() -> i32 {
+    // Test that we can pass 7 arguments (syscall number + 6 args)
+    // We use exit_group syscall which terminates the process with exit code 0
+    let syscall_num: u64 = 231;
+    let a0: u64 = 0;
+    let a1: u64 = 0;
+    let a2: u64 = 0;
+    let a3: u64 = 0;
+    let a4: u64 = 0;
+    let a5: u64 = 0;
+    checked {
+        @syscall(syscall_num, a0, a1, a2, a3, a4, a5);
+    };
+    // Unreachable - the syscall terminates the process with exit code 0
+    42
+}
+"""
+exit_code = 0
+
+# Test that @syscall rejects too many arguments
+[[case]]
+name = "syscall_too_many_args"
+spec = ["9.2:4"]
+preview = "unchecked_code"
+source = """
+fn main() -> i32 {
+    let n: u64 = 60;
+    let a0: u64 = 0;
+    let a1: u64 = 0;
+    let a2: u64 = 0;
+    let a3: u64 = 0;
+    let a4: u64 = 0;
+    let a5: u64 = 0;
+    let a6: u64 = 0;
+    checked {
+        @syscall(n, a0, a1, a2, a3, a4, a5, a6);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "wrong number of arguments"
+
+# Test that @syscall requires u64 arguments
+[[case]]
+name = "syscall_requires_u64_args"
+spec = ["9.2:4"]
+preview = "unchecked_code"
+source = """
+fn main() -> i32 {
+    let syscall_num: i32 = 60;  // i32 instead of u64
+    let arg: i32 = 0;           // i32 instead of u64
+    checked {
+        @syscall(syscall_num, arg);
+    };
+    0
+}
+"""
+compile_fail = true
+error_contains = "type mismatch"
+
+# Test that @syscall returns i64
+# TODO: This test currently fails due to checked block type inference issue.
+# Filed as rue-8qt6 for investigation.
+[[case]]
+name = "syscall_returns_i64"
+spec = ["9.2:5"]
+preview = "unchecked_code"
+source = """
+fn main() -> i32 {
+    // getpid syscall (39 on Linux x86-64) returns the process ID
+    let syscall_num: u64 = 39;
+    let result: i64 = 0;
+    checked {
+        result = @syscall(syscall_num);
+    };
+    // PID should be positive
+    let zero: i64 = 0;
+    if result > zero {
+        42
+    } else {
+        1
+    }
+}
+"""
+exit_code = 42

--- a/crates/rue-spec/src/main.rs
+++ b/crates/rue-spec/src/main.rs
@@ -35,7 +35,9 @@
 //! - `RUE_BINARY` - Path to the rue compiler binary
 
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
-use rue_test_runner::{Case, find_dir, find_rue_binary, load_test_files, run_test_case};
+use rue_test_runner::{
+    Case, find_dir, find_rue_binary, load_test_files, run_test_case, should_skip_for_platform,
+};
 use std::path::Path;
 
 mod traceability;
@@ -88,6 +90,9 @@ fn run_case_wrapper(
     if skip {
         return ctx.ignore_for("marked as skip");
     }
+    if let Some(reason) = should_skip_for_platform(&case.only_on) {
+        return ctx.ignore_for(reason);
+    }
     run_test_case(case, rue_binary).map_err(|e| RunError::fail(e.to_string()))
 }
 
@@ -100,6 +105,9 @@ fn run_preview_case_wrapper(
 ) -> Result<(), RunError> {
     if skip {
         return ctx.ignore_for("marked as skip");
+    }
+    if let Some(reason) = should_skip_for_platform(&case.only_on) {
+        return ctx.ignore_for(reason);
     }
     match run_test_case(case, rue_binary) {
         Ok(()) => Ok(()),

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -164,6 +164,12 @@ pub struct Case {
     /// Use this when tests need to call functions from imported modules.
     #[serde(default)]
     pub pass_aux_files: bool,
+    /// List of target triples on which this test should run.
+    /// If specified, the test is skipped on hosts that don't match any of the targets.
+    /// Example: `only_on = ["x86-64-linux", "aarch64-linux"]`
+    /// If not specified, the test runs on all platforms.
+    #[serde(default)]
+    pub only_on: Vec<String>,
 }
 
 /// A test file containing a section and its cases.
@@ -176,6 +182,56 @@ pub struct TestFile {
 
 /// Result of running a test.
 pub type TestResult = Result<(), String>;
+
+/// Get the current host target triple in Rue's format.
+///
+/// Returns strings like "x86-64-linux", "aarch64-linux", "aarch64-macos".
+pub fn get_host_target() -> &'static str {
+    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
+    {
+        "x86-64-linux"
+    }
+    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
+    {
+        "aarch64-linux"
+    }
+    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
+    {
+        "aarch64-macos"
+    }
+    #[cfg(all(target_arch = "x86_64", target_os = "macos"))]
+    {
+        "x86-64-macos"
+    }
+    #[cfg(not(any(
+        all(target_arch = "x86_64", target_os = "linux"),
+        all(target_arch = "aarch64", target_os = "linux"),
+        all(target_arch = "aarch64", target_os = "macos"),
+        all(target_arch = "x86_64", target_os = "macos"),
+    )))]
+    {
+        "unknown"
+    }
+}
+
+/// Check if a test should be skipped based on `only_on` restrictions.
+///
+/// Returns `Some(reason)` if the test should be skipped, `None` if it should run.
+pub fn should_skip_for_platform(only_on: &[String]) -> Option<String> {
+    if only_on.is_empty() {
+        return None;
+    }
+
+    let host = get_host_target();
+    if only_on.iter().any(|target| target == host) {
+        None
+    } else {
+        Some(format!(
+            "test only runs on {:?}, current host is {}",
+            only_on, host
+        ))
+    }
+}
 
 /// Convert a TOML value to a string for template substitution.
 fn toml_value_to_string(value: &toml::Value) -> String {
@@ -263,6 +319,7 @@ pub fn expand_case(case: Case) -> Vec<Case> {
                 timeout_ms: case.timeout_ms,
                 aux_files: case.aux_files.clone(),
                 pass_aux_files: case.pass_aux_files,
+                only_on: case.only_on.clone(),
 
                 // Clear params on expanded case
                 params: vec![],
@@ -996,6 +1053,7 @@ mod tests {
             params: vec![],
             aux_files: HashMap::new(),
             pass_aux_files: false,
+            only_on: vec![],
         };
 
         let expanded = expand_case(case);
@@ -1045,6 +1103,7 @@ mod tests {
             params: vec![ParamSet { values: param1 }, ParamSet { values: param2 }],
             aux_files: HashMap::new(),
             pass_aux_files: false,
+            only_on: vec![],
         };
 
         let expanded = expand_case(case);
@@ -1102,6 +1161,7 @@ mod tests {
             params: vec![ParamSet { values: params }],
             aux_files: HashMap::new(),
             pass_aux_files: false,
+            only_on: vec![],
         };
 
         let expanded = expand_case(case);
@@ -1151,6 +1211,7 @@ mod tests {
             params: vec![ParamSet { values: params }],
             aux_files: HashMap::new(),
             pass_aux_files: false,
+            only_on: vec![],
         };
 
         let expanded = expand_case(case);

--- a/crates/rue-ui-tests/src/main.rs
+++ b/crates/rue-ui-tests/src/main.rs
@@ -4,7 +4,9 @@
 //! such as warnings, diagnostics quality, and compiler flags.
 
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
-use rue_test_runner::{Case, find_dir, find_rue_binary, load_test_files, run_test_case};
+use rue_test_runner::{
+    Case, find_dir, find_rue_binary, load_test_files, run_test_case, should_skip_for_platform,
+};
 use std::path::Path;
 
 /// Possible paths for the cases directory.
@@ -23,6 +25,9 @@ fn run_case_wrapper(
 ) -> Result<(), RunError> {
     if skip {
         return ctx.ignore_for("marked as skip");
+    }
+    if let Some(reason) = should_skip_for_platform(&case.only_on) {
+        return ctx.ignore_for(reason);
     }
     run_test_case(case, rue_binary).map_err(|e| RunError::fail(e.to_string()))
 }

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -1,0 +1,54 @@
++++
+title = "Unchecked Intrinsics"
+weight = 2
+template = "spec/page.html"
++++
+
+# Unchecked Intrinsics
+
+This section describes intrinsics that require a checked block.
+
+## Syscall Intrinsic
+
+{{ rule(id="9.2:1", cat="normative") }}
+
+The `@syscall` intrinsic performs a direct system call to the operating system.
+
+{{ rule(id="9.2:2", cat="legality-rule") }}
+
+The `@syscall` intrinsic requires the `unchecked_code` preview feature. Using `@syscall` without enabling this feature is a compile-time error.
+
+{{ rule(id="9.2:3", cat="syntax") }}
+
+```ebnf
+syscall_intrinsic = "@syscall" "(" syscall_number { "," argument } ")" ;
+syscall_number = expression ;
+argument = expression ;
+```
+
+{{ rule(id="9.2:4", cat="legality-rule") }}
+
+The `@syscall` intrinsic takes at least one argument (the syscall number) and at most seven arguments (syscall number plus six syscall arguments). All arguments must be of type `u64`.
+
+{{ rule(id="9.2:5", cat="dynamic-semantics") }}
+
+The `@syscall` intrinsic returns an `i64` value representing the result of the syscall. On Linux x86-64, negative values typically indicate errors. The exact behavior depends on the syscall being invoked and the platform.
+
+{{ rule(id="9.2:6", cat="informative") }}
+
+Syscall numbers and conventions differ between operating systems. Linux x86-64 syscall numbers are different from macOS aarch64 syscall numbers. Users should consult platform-specific documentation.
+
+{{ rule(id="9.2:7", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    checked {
+        // Linux x86-64: write(fd=1, buf, len)
+        let result = @syscall(1_u64, 1_u64, msg_ptr, msg_len);
+
+        // Linux x86-64: exit_group(code)
+        @syscall(231_u64, 0_u64);
+    };
+    0
+}
+```


### PR DESCRIPTION
Adds the @syscall intrinsic for making direct OS syscalls from Rue code. This intrinsic requires the unchecked_code preview feature and a checked block.

Implementation:
- Added syscall to KnownSymbols
- Added analyze_syscall_intrinsic in sema.rs with type checking (all args must be u64)
- Added x86_64 codegen using the syscall instruction
- Added aarch64 codegen using SVC #0x80 instruction
- Added spec section 9.2 for syscall intrinsic documentation
- Added spec tests for basic functionality

Known issues filed as rue-8qt6:
- checked block type inference with intrinsic return values
- syscall with max arguments test

🤖 Generated with [Claude Code](https://claude.com/claude-code)