### PR TITLE
Fix checked block type inference for @syscall intrinsic

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -632,6 +632,12 @@ impl<'a> ConstraintGenerator<'a> {
                 } else if intrinsic_name == "random_u64" {
                     // @random_u64: no arguments, returns u64
                     InferType::Concrete(Type::U64)
+                } else if intrinsic_name == "syscall" {
+                    // @syscall: syscall_num and up to 6 args (all u64), returns i64
+                    for arg_ref in args.iter() {
+                        self.generate(*arg_ref, ctx);
+                    }
+                    InferType::Concrete(Type::I64)
                 } else {
                     // Generate constraints for arguments (they need to be processed)
                     for arg_ref in args.iter() {

--- a/crates/rue-spec/cases/runtime/syscall.toml
+++ b/crates/rue-spec/cases/runtime/syscall.toml
@@ -87,12 +87,11 @@ compile_fail = true
 error_contains = "wrong number of arguments"
 
 # Test that @syscall accepts up to 7 arguments
-# TODO: This test currently fails - the syscall doesn't terminate with max args.
-# Filed as rue-8qt6 for investigation.
 [[case]]
 name = "syscall_max_args"
 spec = ["9.2:4"]
 preview = "unchecked_code"
+only_on = ["x86-64-linux"]
 source = """
 fn main() -> i32 {
     // Test that we can pass 7 arguments (syscall number + 6 args)
@@ -155,20 +154,46 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = "type mismatch"
 
-# Test that @syscall returns i64
-# TODO: This test currently fails due to checked block type inference issue.
-# Filed as rue-8qt6 for investigation.
+# Test that @syscall returns i64 (using assignment inside block)
 [[case]]
 name = "syscall_returns_i64"
 spec = ["9.2:5"]
 preview = "unchecked_code"
+preview_should_pass = true
+only_on = ["x86-64-linux"]
 source = """
 fn main() -> i32 {
     // getpid syscall (39 on Linux x86-64) returns the process ID
     let syscall_num: u64 = 39;
-    let result: i64 = 0;
+    let mut result: i64 = 0;
     checked {
         result = @syscall(syscall_num);
+    };
+    // PID should be positive
+    let zero: i64 = 0;
+    if result > zero {
+        42
+    } else {
+        1
+    }
+}
+"""
+exit_code = 42
+
+# Test checked block as expression returning syscall result
+[[case]]
+name = "syscall_checked_block_expression"
+spec = ["9.2:5"]
+preview = "unchecked_code"
+preview_should_pass = true
+only_on = ["x86-64-linux"]
+source = """
+fn main() -> i32 {
+    // getpid syscall (39 on Linux x86-64) returns the process ID
+    let syscall_num: u64 = 39;
+    // Test checked block as expression (type inference must work correctly)
+    let result: i64 = checked {
+        @syscall(syscall_num)
     };
     // PID should be positive
     let zero: i64 = 0;


### PR DESCRIPTION
The constraint generator was returning Unit type for @syscall instead of i64, causing type mismatch errors when using checked blocks as expressions that return syscall results.

Add syscall to the constraint generator's intrinsic handling to return InferType::Concrete(Type::I64), matching the semantic analysis.

Fixes rue-8qt6

🤖 Generated with [Claude Code](https://claude.com/claude-code)