### PR TITLE
Stabilize affine_mvs preview feature (ADR-0008)

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -233,17 +233,12 @@ impl<'a> Sema<'a> {
                     let is_copy = self.has_copy_directive(&directives);
                     let is_handle = self.has_handle_directive(&directives);
 
-                    // Linear types require preview feature
-                    if *is_linear {
-                        self.require_preview(PreviewFeature::AffineMvs, "linear types", inst.span)?;
-
-                        // Linear types cannot be @copy
-                        if is_copy {
-                            return Err(CompileError::new(
-                                ErrorKind::LinearStructCopy(struct_name.clone()),
-                                inst.span,
-                            ));
-                        }
+                    // Linear types cannot be @copy
+                    if *is_linear && is_copy {
+                        return Err(CompileError::new(
+                            ErrorKind::LinearStructCopy(struct_name.clone()),
+                            inst.span,
+                        ));
                     }
 
                     // Create placeholder struct def (fields will be resolved in phase 2)

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -252,9 +252,6 @@ pub enum PreviewFeature {
     /// Testing infrastructure feature - permanently unstable.
     /// Used to verify the preview feature gating mechanism works.
     TestInfra,
-    /// Affine types and mutable value semantics.
-    /// See ADR-0008 for the full design.
-    AffineMvs,
     /// Module type access (e.g., `module.StructName`, `module.EnumName::Variant`).
     /// Part of the module system (ADR-0026) - accessing types through modules.
     ModuleTypes,
@@ -285,7 +282,6 @@ impl PreviewFeature {
     pub fn name(&self) -> &'static str {
         match *self {
             PreviewFeature::TestInfra => "test_infra",
-            PreviewFeature::AffineMvs => "affine_mvs",
             PreviewFeature::ModuleTypes => "module_types",
             PreviewFeature::AnonStructMethods => "anon_struct_methods",
             PreviewFeature::UncheckedCode => "unchecked_code",
@@ -297,7 +293,6 @@ impl PreviewFeature {
     pub fn adr(&self) -> &'static str {
         match *self {
             PreviewFeature::TestInfra => "ADR-0005",
-            PreviewFeature::AffineMvs => "ADR-0008",
             PreviewFeature::ModuleTypes => "ADR-0026",
             PreviewFeature::AnonStructMethods => "ADR-0029",
             PreviewFeature::UncheckedCode => "ADR-0028",
@@ -308,7 +303,6 @@ impl PreviewFeature {
     pub fn all() -> &'static [PreviewFeature] {
         &[
             PreviewFeature::TestInfra,
-            PreviewFeature::AffineMvs,
             PreviewFeature::ModuleTypes,
             PreviewFeature::AnonStructMethods,
             PreviewFeature::UncheckedCode,
@@ -335,7 +329,6 @@ impl std::str::FromStr for PreviewFeature {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "test_infra" => Ok(PreviewFeature::TestInfra),
-            "affine_mvs" => Ok(PreviewFeature::AffineMvs),
             "module_types" => Ok(PreviewFeature::ModuleTypes),
             "anon_struct_methods" => Ok(PreviewFeature::AnonStructMethods),
             "unchecked_code" => Ok(PreviewFeature::UncheckedCode),
@@ -1854,7 +1847,7 @@ mod tests {
         let names = PreviewFeature::all_names();
         assert_eq!(
             names,
-            "test_infra, affine_mvs, module_types, anon_struct_methods, unchecked_code"
+            "test_infra, module_types, anon_struct_methods, unchecked_code"
         );
     }
 

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -790,13 +790,12 @@ compile_fail = true
 error_contains = "use of moved value"
 
 # =============================================================================
-# Linear Types (Preview: affine_mvs)
+# Linear Types
 # =============================================================================
 
 [[case]]
 name = "linear_struct_consumed"
 spec = ["3.8:30", "3.8:31", "3.8:32", "3.8:33", "3.8:34"]
-preview = "affine_mvs"
 description = "Linear struct can be consumed by passing to a function"
 source = """
 linear struct MustUse { value: i32 }
@@ -813,7 +812,6 @@ exit_code = 42
 [[case]]
 name = "linear_struct_returned"
 spec = ["3.8:32", "3.8:33"]
-preview = "affine_mvs"
 description = "Linear struct returned from function transfers responsibility to caller"
 source = """
 linear struct MustUse { value: i32 }
@@ -831,7 +829,6 @@ exit_code = 10
 [[case]]
 name = "linear_struct_dropped_error"
 spec = ["3.8:32", "3.8:35", "3.8:36"]
-preview = "affine_mvs"
 description = "Linear value dropped without being consumed is an error"
 source = """
 linear struct MustUse { value: i32 }
@@ -847,7 +844,6 @@ error_contains = "linear value"
 [[case]]
 name = "linear_struct_copy_error"
 spec = ["3.8:37", "3.8:38"]
-preview = "affine_mvs"
 description = "Linear struct cannot be marked @copy"
 source = """
 @copy
@@ -861,7 +857,6 @@ error_contains = "cannot be marked @copy"
 [[case]]
 name = "linear_copy_reverse_order_error"
 spec = ["3.8:37"]
-preview = "affine_mvs"
 description = "Linear and @copy in reverse order is also an error"
 source = """
 linear struct Invalid { value: i32 }
@@ -874,7 +869,6 @@ exit_code = 0
 [[case]]
 name = "linear_struct_chain_consumed"
 spec = ["3.8:32", "3.8:33"]
-preview = "affine_mvs"
 description = "Linear value can be chained through functions"
 source = """
 linear struct MustUse { value: i32 }
@@ -895,8 +889,6 @@ exit_code = 42
 [[case]]
 name = "linear_in_branch_consumed"
 spec = ["3.8:32"]
-preview = "affine_mvs"
-preview_should_pass = true
 description = "Linear value must be consumed in all branches"
 source = """
 linear struct MustUse { value: i32 }
@@ -984,8 +976,6 @@ error_contains = "use of moved value"
 [[case]]
 name = "linear_field_access"
 spec = ["3.8:32", "3.8:33"]
-preview = "affine_mvs"
-preview_should_pass = true
 description = "Field access on linear struct counts as move (consuming)"
 source = """
 linear struct MustUse { value: i32 }
@@ -997,20 +987,8 @@ fn main() -> i32 {
 """
 exit_code = 42
 
-[[case]]
-name = "linear_requires_preview"
-spec = ["3.8:30"]
-description = "Linear keyword requires affine_mvs preview feature"
-source = """
-linear struct MustUse { value: i32 }
-
-fn main() -> i32 { 0 }
-"""
-compile_fail = true
-error_contains = "preview feature"
-
 # =============================================================================
-# @handle Directive (Stable)
+# @handle Directive
 # =============================================================================
 
 [[case]]
@@ -1130,7 +1108,6 @@ error_contains = "wrong signature"
 [[case]]
 name = "handle_with_linear"
 spec = ["3.8:49"]
-preview = "affine_mvs"
 description = "Linear struct can be marked @handle"
 source = """
 @handle

--- a/docs/designs/0008-affine-types-mvs.md
+++ b/docs/designs/0008-affine-types-mvs.md
@@ -1,12 +1,11 @@
 ---
 id: 0008
 title: Affine Types and Mutable Value Semantics
-status: accepted
+status: implemented
 tags: [types, semantics, ownership]
-feature-flag: affine-mvs
 created: 2025-12-24
 accepted: 2025-12-24
-implemented: 2025-12-31
+implemented: 2026-01-04
 spec-sections: ["3.8"]
 superseded-by:
 ---
@@ -15,7 +14,7 @@ superseded-by:
 
 ## Status
 
-Accepted
+Implemented
 
 ## Summary
 


### PR DESCRIPTION
Remove the affine_mvs preview gate, making linear types stable:
- Remove AffineMvs from PreviewFeature enum
- Remove require_preview() gate for linear struct declarations
- Remove preview flags from linear type spec tests
- Remove linear_requires_preview test (no longer applicable)
- Update ADR-0008 status to Implemented

All phases of ADR-0008 are now complete and stable:
- Phase 1: Affine structs ✓
- Phase 2: @copy directive ✓
- Phase 3: Inout parameters ✓
- Phase 4: Linear types ✓
- Phase 5: Projection semantics ✓
- Phase 6: @handle directive ✓

Fixes rue-270h

🤖 Generated with [Claude Code](https://claude.com/claude-code)