### PR TITLE
docs: Update ADR-0011 Runtime Heap status to Implemented

### DIFF
--- a/docs/designs/0011-runtime-heap.md
+++ b/docs/designs/0011-runtime-heap.md
@@ -1,12 +1,12 @@
 ---
 id: 0011
 title: Runtime Heap
-status: proposal
+status: implemented
 tags: [runtime, memory, allocator]
 feature-flag: runtime-heap
 created: 2025-12-25
-accepted:
-implemented:
+accepted: 2025-12-25
+implemented: 2026-01-04
 spec-sections: []
 superseded-by:
 ---
@@ -15,7 +15,7 @@ superseded-by:
 
 ## Status
 
-Proposal
+Implemented
 
 ## Summary
 


### PR DESCRIPTION
Mark ADR-0011 as implemented. The runtime heap is already fully complete:

- Phase 1: mmap/munmap syscall wrappers on all 3 platforms (x86_64_linux, aarch64_linux, aarch64_macos)
- Phase 2: Bump allocator core with arena management
- Phase 3: Realloc and large allocation support
- Phase 4: Compiler integration (__rue_alloc, __rue_realloc, __rue_free)

Epic rue-n50n was already closed. Closes rue-4s3x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)