### PR TITLE
feat: Include method signatures in anonymous struct structural equality

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -7106,6 +7106,15 @@ impl<'a> Sema<'a> {
                     return Err(CompileError::new(ErrorKind::EmptyStruct, inst.span));
                 }
 
+                // If methods are present, check the preview feature first
+                if *methods_len > 0 {
+                    self.require_preview(
+                        PreviewFeature::AnonStructMethods,
+                        "anonymous struct methods",
+                        inst.span,
+                    )?;
+                }
+
                 // Resolve each field type and build the struct fields
                 let mut struct_fields = Vec::with_capacity(field_decls.len());
                 for (name_sym, type_sym) in field_decls {
@@ -7117,17 +7126,18 @@ impl<'a> Sema<'a> {
                     });
                 }
 
-                // Check if an equivalent anonymous struct already exists (structural equality)
-                let struct_ty = self.find_or_create_anon_struct(&struct_fields);
+                // Extract method signatures for structural equality comparison
+                // (uses type symbols, not resolved Types, so Self matches Self)
+                let method_sigs = self.extract_anon_method_sigs(*methods_start, *methods_len);
 
-                // Register methods for this anonymous struct
-                if *methods_len > 0 {
-                    // Anonymous struct methods require preview feature
-                    self.require_preview(
-                        PreviewFeature::AnonStructMethods,
-                        "anonymous struct methods",
-                        inst.span,
-                    )?;
+                // Check if an equivalent anonymous struct already exists (structural equality)
+                // This now compares both fields AND method signatures
+                let (struct_ty, is_new) =
+                    self.find_or_create_anon_struct(&struct_fields, &method_sigs);
+
+                // Register methods only for newly created anonymous structs
+                // (existing ones already have their methods registered)
+                if is_new && *methods_len > 0 {
                     let struct_id = struct_ty
                         .as_struct()
                         .expect("anon struct should have StructId");
@@ -9041,11 +9051,16 @@ impl<'a> Sema<'a> {
                     });
                 }
 
+                // Extract method signatures for structural equality comparison
+                let method_sigs = self.extract_anon_method_sigs(*methods_start, *methods_len);
+
                 // Find or create the anonymous struct type
-                let struct_ty = self.find_or_create_anon_struct(&struct_fields);
+                let (struct_ty, is_new) =
+                    self.find_or_create_anon_struct(&struct_fields, &method_sigs);
 
                 // Register methods if present (requires preview feature)
-                if *methods_len > 0 {
+                // Only register for newly created structs to avoid duplicate registration
+                if is_new && *methods_len > 0 {
                     // Check preview feature is enabled
                     if !self
                         .preview_features
@@ -9054,29 +9069,15 @@ impl<'a> Sema<'a> {
                         return None; // Feature not enabled, can't evaluate
                     }
                     let struct_id = struct_ty.as_struct()?;
-                    // Only register methods if not already registered
-                    // (can happen if the same AnonStructType is evaluated multiple times)
-                    let method_refs = self.rir.get_inst_refs(*methods_start, *methods_len);
-                    let first_method_ref = method_refs.first()?;
-                    let first_method_inst = self.rir.get(*first_method_ref);
-                    if let InstData::FnDecl {
-                        name: method_name, ..
-                    } = &first_method_inst.data
-                    {
-                        let key = (struct_id, *method_name);
-                        if !self.methods.contains_key(&key) {
-                            // Use comptime-safe method registration
-                            self.register_anon_struct_methods_for_comptime(
-                                struct_id,
-                                struct_ty,
-                                *methods_start,
-                                *methods_len,
-                                inst.span,
-                            )?;
-                        }
-                    }
+                    // Use comptime-safe method registration
+                    self.register_anon_struct_methods_for_comptime(
+                        struct_id,
+                        struct_ty,
+                        *methods_start,
+                        *methods_len,
+                        inst.span,
+                    )?;
                 }
-
                 Some(ConstValue::Type(struct_ty))
             }
 
@@ -9400,7 +9401,8 @@ impl<'a> Sema<'a> {
             InstData::AnonStructType {
                 fields_start,
                 fields_len,
-                ..
+                methods_start,
+                methods_len,
             } => {
                 let field_decls = self.rir.get_field_decls(*fields_start, *fields_len);
 
@@ -9416,7 +9418,11 @@ impl<'a> Sema<'a> {
                     });
                 }
 
-                let struct_ty = self.find_or_create_anon_struct(&struct_fields);
+                // Extract method signatures for structural equality comparison
+                let method_sigs = self.extract_anon_method_sigs(*methods_start, *methods_len);
+
+                let (struct_ty, _is_new) =
+                    self.find_or_create_anon_struct(&struct_fields, &method_sigs);
                 Some(ConstValue::Type(struct_ty))
             }
 
@@ -10316,6 +10322,46 @@ impl<'a> Sema<'a> {
         } else {
             self.resolve_type(type_sym, span)
         }
+    }
+
+    /// Extract method signatures from RIR for structural equality comparison.
+    ///
+    /// This extracts method signatures as type symbols (Spur), not resolved Types.
+    /// This is intentional: for structural equality, we compare type symbols directly
+    /// so that `Self` matches `Self` even before we know the concrete StructId.
+    fn extract_anon_method_sigs(
+        &self,
+        methods_start: u32,
+        methods_len: u32,
+    ) -> Vec<super::AnonMethodSig> {
+        let method_refs = self.rir.get_inst_refs(methods_start, methods_len);
+        let mut sigs = Vec::with_capacity(method_refs.len());
+
+        for method_ref in method_refs {
+            let method_inst = self.rir.get(method_ref);
+            if let InstData::FnDecl {
+                name,
+                params_start,
+                params_len,
+                return_type,
+                has_self,
+                ..
+            } = &method_inst.data
+            {
+                // Extract parameter types as symbols (excluding self)
+                let params = self.rir.get_params(*params_start, *params_len);
+                let param_types: Vec<Spur> = params.iter().map(|p| p.ty).collect();
+
+                sigs.push(super::AnonMethodSig {
+                    name: *name,
+                    has_self: *has_self,
+                    param_types,
+                    return_type: *return_type,
+                });
+            }
+        }
+
+        sigs
     }
 
     // ========================================================================

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -120,6 +120,7 @@ impl<'a> GatherOutput<'a> {
             module_registry: crate::sema_context::ModuleRegistry::new(),
             file_paths: HashMap::new(),
             param_arena: self.param_arena,
+            anon_struct_method_sigs: HashMap::new(),
         }
     }
 }
@@ -222,6 +223,27 @@ pub struct MethodInfo {
     pub span: rue_span::Span,
 }
 
+/// Method signature for anonymous struct structural equality comparison.
+///
+/// This captures only the parts of a method that affect structural equality:
+/// method name, whether it has self, parameter types (as symbols), and return type.
+/// Method bodies do NOT affect structural equality - only signatures matter.
+///
+/// Type symbols are stored as Spur (interned strings) rather than resolved Types
+/// because at comparison time, `Self` hasn't been resolved to a concrete StructId yet.
+/// Two methods using `Self` in the same positions are considered structurally equal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AnonMethodSig {
+    /// Method name
+    pub name: Spur,
+    /// Whether this is a method (has self) or associated function (no self)
+    pub has_self: bool,
+    /// Parameter type symbols (excluding self parameter)
+    pub param_types: Vec<Spur>,
+    /// Return type symbol
+    pub return_type: Spur,
+}
+
 /// Information about a constant declaration.
 ///
 /// Constants are compile-time values. In the module system, they're primarily
@@ -282,6 +304,11 @@ pub struct Sema<'a> {
     /// Arena storage for function/method parameter data.
     /// FunctionInfo and MethodInfo store ParamRange handles into this arena.
     pub(crate) param_arena: ParamArena,
+    /// Method signatures for anonymous structs, used for structural equality comparison.
+    /// Maps StructId to the list of method signatures (as type symbols, not resolved Types).
+    /// This enables comparing anonymous structs by their method signatures before methods
+    /// are fully registered.
+    pub(crate) anon_struct_method_sigs: HashMap<StructId, Vec<AnonMethodSig>>,
 }
 
 impl<'a> Sema<'a> {
@@ -306,6 +333,7 @@ impl<'a> Sema<'a> {
             module_registry: crate::sema_context::ModuleRegistry::new(),
             file_paths: HashMap::new(),
             param_arena: ParamArena::new(),
+            anon_struct_method_sigs: HashMap::new(),
         }
     }
 
@@ -583,27 +611,59 @@ impl<'a> Sema<'a> {
         }
     }
 
-    /// Find an existing anonymous struct with the same fields, or create a new one.
+    /// Find an existing anonymous struct with the same fields and methods, or create a new one.
     ///
     /// This implements structural type equality for anonymous structs: two anonymous
-    /// structs with the same field names and types (in the same order) are the same type.
-    pub(crate) fn find_or_create_anon_struct(&mut self, fields: &[StructField]) -> Type {
+    /// structs with the same field names/types (in the same order) AND the same method
+    /// signatures are the same type. Method bodies do NOT affect structural equality.
+    ///
+    /// Returns a tuple of (Type, is_new) where is_new indicates whether the struct was
+    /// newly created (true) or an existing match was found (false). Callers should only
+    /// register methods for newly created structs.
+    pub(crate) fn find_or_create_anon_struct(
+        &mut self,
+        fields: &[StructField],
+        method_sigs: &[AnonMethodSig],
+    ) -> (Type, bool) {
         // Check if an equivalent anonymous struct already exists
         // Anonymous structs have names starting with "__anon_struct_"
         for struct_id in self.type_pool.all_struct_ids() {
             let struct_def = self.type_pool.struct_def(struct_id);
             if struct_def.name.starts_with("__anon_struct_") {
-                if struct_def.fields.len() == fields.len() {
-                    let mut all_match = true;
-                    for (def_field, new_field) in struct_def.fields.iter().zip(fields.iter()) {
-                        if def_field.name != new_field.name || def_field.ty != new_field.ty {
-                            all_match = false;
-                            break;
-                        }
+                // Check fields match
+                if struct_def.fields.len() != fields.len() {
+                    continue;
+                }
+                let mut fields_match = true;
+                for (def_field, new_field) in struct_def.fields.iter().zip(fields.iter()) {
+                    if def_field.name != new_field.name || def_field.ty != new_field.ty {
+                        fields_match = false;
+                        break;
                     }
-                    if all_match {
-                        return Type::Struct(struct_id);
+                }
+                if !fields_match {
+                    continue;
+                }
+
+                // Check method signatures match
+                let existing_sigs = self
+                    .anon_struct_method_sigs
+                    .get(&struct_id)
+                    .map(|v| v.as_slice())
+                    .unwrap_or(&[]);
+                if existing_sigs.len() != method_sigs.len() {
+                    continue;
+                }
+                let mut methods_match = true;
+                for (existing, new) in existing_sigs.iter().zip(method_sigs.iter()) {
+                    if existing != new {
+                        methods_match = false;
+                        break;
                     }
+                }
+                if methods_match {
+                    // Found a matching struct - return it with is_new=false
+                    return (Type::Struct(struct_id), false);
                 }
             }
         }
@@ -629,6 +689,12 @@ impl<'a> Sema<'a> {
 
         let (struct_id, _) = self.type_pool.register_struct(name_spur, struct_def);
 
+        // Store method signatures for future structural equality checks
+        if !method_sigs.is_empty() {
+            self.anon_struct_method_sigs
+                .insert(struct_id, method_sigs.to_vec());
+        }
+
         // Register in struct lookup
         self.structs.insert(name_spur, struct_id);
 
@@ -645,7 +711,8 @@ impl<'a> Sema<'a> {
         self.structs.remove(&name_spur);
         self.structs.insert(final_name_spur, struct_id);
 
-        Type::Struct(struct_id)
+        // Return with is_new=true
+        (Type::Struct(struct_id), true)
     }
 
     /// Resolve an enum type through a module reference.


### PR DESCRIPTION
Anonymous structs are now considered the same type only when they have:
- Same field names and types (in the same order)
- Same method signatures (name, has_self, parameter types, return type)

Method bodies do NOT affect structural equality - only signatures matter. This enables comptime-generated types with methods to be correctly unified.

Key changes:
- Added AnonMethodSig struct to represent method signatures for comparison
- Added anon_struct_method_sigs HashMap to Sema for storing signatures per StructId
- Updated find_or_create_anon_struct to compare method signatures
- Returns (Type, is_new) to avoid duplicate method registration for existing structs
- Added extract_anon_method_sigs helper to extract signatures from RIR

Closes: rue-jyjq

🤖 Generated with [Claude Code](https://claude.com/claude-code)