### PR TITLE
Stabilize module system (ADR-0026)

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -919,13 +919,6 @@ impl<'a> Sema<'a> {
                 args_len,
             } => {
                 if *name == self.known.import {
-                    // Require module_types preview feature
-                    self.require_preview(
-                        PreviewFeature::ModuleTypes,
-                        "const = @import(...)",
-                        span,
-                    )?;
-
                     // Validate exactly one argument
                     if *args_len != 1 {
                         return Err(CompileError::new(

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -252,9 +252,6 @@ pub enum PreviewFeature {
     /// Testing infrastructure feature - permanently unstable.
     /// Used to verify the preview feature gating mechanism works.
     TestInfra,
-    /// Module type access (e.g., `module.StructName`, `module.EnumName::Variant`).
-    /// Part of the module system (ADR-0026) - accessing types through modules.
-    ModuleTypes,
     /// Anonymous struct methods (Zig-style).
     /// Allows method definitions inside anonymous struct type expressions.
     /// See ADR-0029 for the full design.
@@ -282,7 +279,6 @@ impl PreviewFeature {
     pub fn name(&self) -> &'static str {
         match *self {
             PreviewFeature::TestInfra => "test_infra",
-            PreviewFeature::ModuleTypes => "module_types",
             PreviewFeature::AnonStructMethods => "anon_struct_methods",
             PreviewFeature::UncheckedCode => "unchecked_code",
         }
@@ -293,7 +289,6 @@ impl PreviewFeature {
     pub fn adr(&self) -> &'static str {
         match *self {
             PreviewFeature::TestInfra => "ADR-0005",
-            PreviewFeature::ModuleTypes => "ADR-0026",
             PreviewFeature::AnonStructMethods => "ADR-0029",
             PreviewFeature::UncheckedCode => "ADR-0028",
         }
@@ -303,7 +298,6 @@ impl PreviewFeature {
     pub fn all() -> &'static [PreviewFeature] {
         &[
             PreviewFeature::TestInfra,
-            PreviewFeature::ModuleTypes,
             PreviewFeature::AnonStructMethods,
             PreviewFeature::UncheckedCode,
         ]
@@ -329,7 +323,6 @@ impl std::str::FromStr for PreviewFeature {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "test_infra" => Ok(PreviewFeature::TestInfra),
-            "module_types" => Ok(PreviewFeature::ModuleTypes),
             "anon_struct_methods" => Ok(PreviewFeature::AnonStructMethods),
             "unchecked_code" => Ok(PreviewFeature::UncheckedCode),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
@@ -1845,10 +1838,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(
-            names,
-            "test_infra, module_types, anon_struct_methods, unchecked_code"
-        );
+        assert_eq!(names, "test_infra, anon_struct_methods, unchecked_code");
     }
 
     // ========================================================================

--- a/crates/rue-spec/cases/modules/constants.toml
+++ b/crates/rue-spec/cases/modules/constants.toml
@@ -48,8 +48,6 @@ exit_code = 0
 [[case]]
 name = "const_import_syntax"
 description = "Const with @import syntax evaluated at compile time"
-preview = "module_types"
-preview_should_pass = true
 source = """
 const math = @import("nonexistent");
 fn main() -> i32 { 0 }
@@ -60,8 +58,6 @@ error_contains = "cannot find module 'nonexistent'"
 [[case]]
 name = "pub_const_import_syntax"
 description = "Pub const with @import syntax evaluated at compile time"
-preview = "module_types"
-preview_should_pass = true
 source = """
 pub const math = @import("nonexistent");
 fn main() -> i32 { 0 }

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -64,8 +64,6 @@ exit_code = 42
 [[case]]
 name = "same_dir_access_private_enum"
 description = "Files in same directory can access private enums"
-# TODO: Needs parser support for module.EnumName::Variant in match patterns
-preview = "module_types"
 source = """
 fn main() -> i32 {
     let utils = @import("utils");
@@ -161,8 +159,6 @@ error_contains = "private"
 [[case]]
 name = "cross_dir_access_pub_enum"
 description = "Files in different directories can access public enums"
-preview = "module_types"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let utils = @import("subdir/utils");
@@ -182,8 +178,6 @@ exit_code = 42
 [[case]]
 name = "cross_dir_access_private_enum_error"
 description = "Files in different directories cannot access private enums"
-preview = "module_types"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let utils = @import("subdir/utils");
@@ -206,8 +200,6 @@ error_contains = "private"
 [[case]]
 name = "directory_module_intra_access"
 description = "Files within a directory module can access each other's private items"
-preview = "module_types"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let utils = @import("utils");

--- a/docs/designs/0026-module-system.md
+++ b/docs/designs/0026-module-system.md
@@ -1,12 +1,12 @@
 ---
 id: 0026
 title: Module System
-status: implemented
+status: stable
 tags: [architecture, compiler, modules, scalability]
-feature-flag: modules
 created: 2026-01-01
 accepted: 2026-01-04
 implemented: 2026-01-04
+stabilized: 2026-01-04
 spec-sections: []
 superseded-by:
 ---
@@ -15,7 +15,7 @@ superseded-by:
 
 ## Status
 
-Implemented
+Stable (no longer requires `--preview module_types`)
 
 ## Summary
 
@@ -322,7 +322,7 @@ All phases are complete. 40 spec tests pass.
 - [x] Resolve relative file paths from importing file
 - [x] Load and parse imported files on demand
 - [x] Create Module type for imported file
-- [x] PreviewFeature gate (`module_types`)
+- [x] Stabilized (preview gate removed)
 
 ### Phase 2: Module Member Access ✓
 
@@ -357,11 +357,6 @@ All phases are complete. 40 spec tests pass.
 - [x] `std/` directory with `_std.rue` root
 - [x] `@import("std")` resolution
 - [x] `std.math` submodule with abs, min, max, clamp
-
-### Remaining Work
-
-One test remains under `preview = "module_types"` without `preview_should_pass`:
-- `same_dir_access_private_enum`: Needs parser support for `module.EnumName::Variant` in match patterns
 
 ## Consequences
 


### PR DESCRIPTION
Remove the `--preview module_types` gate, making the module system available without preview flags. All 40 module tests pass.

Changes:
- Remove PreviewFeature::ModuleTypes variant
- Remove require_preview call in declarations.rs
- Remove preview markers from 6 spec tests
- Update ADR-0026 status to "stable"

🤖 Generated with [Claude Code](https://claude.com/claude-code)