### PR TITLE
Fix unsigned division bug in both aarch64 and x86_64 backends

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1006,11 +1006,20 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(Aarch64Inst::Bl { symbol_id });
                 self.mir.push(Aarch64Inst::Label { id: ok_label });
 
-                self.mir.push(Aarch64Inst::SdivRR {
-                    dst: Operand::Virtual(vreg),
-                    src1: Operand::Virtual(lhs_vreg),
-                    src2: Operand::Virtual(rhs_vreg),
-                });
+                // Use SDIV for signed types, UDIV for unsigned types
+                if ty.is_signed() {
+                    self.mir.push(Aarch64Inst::SdivRR {
+                        dst: Operand::Virtual(vreg),
+                        src1: Operand::Virtual(lhs_vreg),
+                        src2: Operand::Virtual(rhs_vreg),
+                    });
+                } else {
+                    self.mir.push(Aarch64Inst::UdivRR {
+                        dst: Operand::Virtual(vreg),
+                        src1: Operand::Virtual(lhs_vreg),
+                        src2: Operand::Virtual(rhs_vreg),
+                    });
+                }
             }
 
             CfgInstData::Mod(lhs, rhs) => {
@@ -1030,13 +1039,21 @@ impl<'a> CfgLower<'a> {
                 self.mir.push(Aarch64Inst::Bl { symbol_id });
                 self.mir.push(Aarch64Inst::Label { id: ok_label });
 
-                // Compute quotient first
+                // Compute quotient first using SDIV or UDIV based on signedness
                 let quot_vreg = self.mir.alloc_vreg();
-                self.mir.push(Aarch64Inst::SdivRR {
-                    dst: Operand::Virtual(quot_vreg),
-                    src1: Operand::Virtual(lhs_vreg),
-                    src2: Operand::Virtual(rhs_vreg),
-                });
+                if ty.is_signed() {
+                    self.mir.push(Aarch64Inst::SdivRR {
+                        dst: Operand::Virtual(quot_vreg),
+                        src1: Operand::Virtual(lhs_vreg),
+                        src2: Operand::Virtual(rhs_vreg),
+                    });
+                } else {
+                    self.mir.push(Aarch64Inst::UdivRR {
+                        dst: Operand::Virtual(quot_vreg),
+                        src1: Operand::Virtual(lhs_vreg),
+                        src2: Operand::Virtual(rhs_vreg),
+                    });
+                }
 
                 // rem = dividend - (quotient * divisor)
                 self.mir.push(Aarch64Inst::Msub {

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -129,6 +129,8 @@ const OPCODE_SUBS_W: u32 = 0x6B000000;
 const OPCODE_ADDS_X: u32 = 0xAB000000;
 /// SDIV Wd, Wn, Wm - Signed divide (32-bit)
 const OPCODE_SDIV_W: u32 = 0x1AC00C00;
+/// UDIV Wd, Wn, Wm - Unsigned divide (32-bit)
+const OPCODE_UDIV_W: u32 = 0x1AC00800;
 /// MSUB Wd, Wn, Wm, Wa - Multiply-subtract (32-bit)
 const OPCODE_MSUB_W: u32 = 0x1B008000;
 
@@ -743,6 +745,15 @@ impl<'a> Emitter<'a> {
                 self.begin_inst();
                 self.emit_sdiv(rd, rn, rm);
                 end_inst!(self, "sdiv {}, {}, {}", rd.as_w(), rn.as_w(), rm.as_w());
+            }
+
+            Aarch64Inst::UdivRR { dst, src1, src2 } => {
+                let rd = dst.as_physical();
+                let rn = src1.as_physical();
+                let rm = src2.as_physical();
+                self.begin_inst();
+                self.emit_udiv(rd, rn, rm);
+                end_inst!(self, "udiv {}, {}, {}", rd.as_w(), rn.as_w(), rm.as_w());
             }
 
             Aarch64Inst::Msub {
@@ -1599,6 +1610,15 @@ impl<'a> Emitter<'a> {
     fn emit_sdiv(&mut self, rd: Reg, rn: Reg, rm: Reg) {
         // SDIV Wd, Wn, Wm (32-bit for proper i32 signed division)
         let inst = OPCODE_SDIV_W
+            | (rm.encoding() as u32) << 16
+            | (rn.encoding() as u32) << 5
+            | rd.encoding() as u32;
+        self.emit_u32(inst);
+    }
+
+    fn emit_udiv(&mut self, rd: Reg, rn: Reg, rm: Reg) {
+        // UDIV Wd, Wn, Wm (32-bit for proper u32 unsigned division)
+        let inst = OPCODE_UDIV_W
             | (rm.encoding() as u32) << 16
             | (rn.encoding() as u32) << 5
             | rd.encoding() as u32;

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -163,6 +163,7 @@ fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
         | Aarch64Inst::SmulhRR { src1, src2, .. }
         | Aarch64Inst::UmulhRR { src1, src2, .. }
         | Aarch64Inst::SdivRR { src1, src2, .. }
+        | Aarch64Inst::UdivRR { src1, src2, .. }
         | Aarch64Inst::AndRR { src1, src2, .. }
         | Aarch64Inst::OrrRR { src1, src2, .. }
         | Aarch64Inst::EorRR { src1, src2, .. }
@@ -309,6 +310,7 @@ fn defs(inst: &Aarch64Inst) -> Vec<VReg> {
         | Aarch64Inst::Lsr64Imm { dst, .. }
         | Aarch64Inst::Asr64Imm { dst, .. }
         | Aarch64Inst::SdivRR { dst, .. }
+        | Aarch64Inst::UdivRR { dst, .. }
         | Aarch64Inst::Msub { dst, .. }
         | Aarch64Inst::Neg { dst, .. }
         | Aarch64Inst::Negs { dst, .. }

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -559,6 +559,13 @@ pub enum Aarch64Inst {
         src2: Operand,
     },
 
+    /// `udiv dst, src1, src2` - Unsigned divide.
+    UdivRR {
+        dst: Operand,
+        src1: Operand,
+        src2: Operand,
+    },
+
     /// `msub dst, src1, src2, src3` - Multiply-subtract: dst = src3 - (src1 * src2)
     /// Used for computing remainder: rem = dividend - (quotient * divisor)
     Msub {
@@ -875,6 +882,9 @@ impl fmt::Display for Aarch64Inst {
             }
             Aarch64Inst::SdivRR { dst, src1, src2 } => {
                 write!(f, "sdiv {}, {}, {}", dst, src1, src2)
+            }
+            Aarch64Inst::UdivRR { dst, src1, src2 } => {
+                write!(f, "udiv {}, {}, {}", dst, src1, src2)
             }
             Aarch64Inst::Msub {
                 dst,

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -415,6 +415,14 @@ impl RegAlloc {
                 })?;
             }
 
+            Aarch64Inst::UdivRR { dst, src1, src2 } => {
+                self.emit_ternop(mir, dst, src1, src2, |d, s1, s2| Aarch64Inst::UdivRR {
+                    dst: d,
+                    src1: s1,
+                    src2: s2,
+                })?;
+            }
+
             Aarch64Inst::Msub {
                 dst,
                 src1,

--- a/crates/rue-codegen/src/aarch64/schedule.rs
+++ b/crates/rue-codegen/src/aarch64/schedule.rs
@@ -126,7 +126,7 @@ fn get_latency(inst: &Aarch64Inst) -> u32 {
         | Aarch64Inst::Msub { .. } => 3,
 
         // Division: 12-20 cycles (highly variable)
-        Aarch64Inst::SdivRR { .. } => 12,
+        Aarch64Inst::SdivRR { .. } | Aarch64Inst::UdivRR { .. } => 12,
 
         // Logical operations: 1 cycle
         Aarch64Inst::AndRR { .. }
@@ -256,6 +256,7 @@ fn regs_read(inst: &Aarch64Inst) -> Vec<Reg> {
         | Aarch64Inst::SmulhRR { src1, src2, .. }
         | Aarch64Inst::UmulhRR { src1, src2, .. }
         | Aarch64Inst::SdivRR { src1, src2, .. }
+        | Aarch64Inst::UdivRR { src1, src2, .. }
         | Aarch64Inst::AndRR { src1, src2, .. }
         | Aarch64Inst::OrrRR { src1, src2, .. }
         | Aarch64Inst::EorRR { src1, src2, .. }
@@ -355,6 +356,7 @@ fn regs_written(inst: &Aarch64Inst) -> Vec<Reg> {
         | Aarch64Inst::SmulhRR { dst, .. }
         | Aarch64Inst::UmulhRR { dst, .. }
         | Aarch64Inst::SdivRR { dst, .. }
+        | Aarch64Inst::UdivRR { dst, .. }
         | Aarch64Inst::Msub { dst, .. }
         | Aarch64Inst::Neg { dst, .. }
         | Aarch64Inst::Negs { dst, .. }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1120,10 +1120,25 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Physical(Reg::Rax),
                     src: Operand::Virtual(lhs_vreg),
                 });
-                self.mir.push(X86Inst::Cdq);
-                self.mir.push(X86Inst::IdivR {
-                    src: Operand::Virtual(rhs_vreg),
-                });
+
+                // Use signed division (CDQ + IDIV) for signed types,
+                // unsigned division (XOR EDX,EDX + DIV) for unsigned types
+                if ty.is_signed() {
+                    self.mir.push(X86Inst::Cdq);
+                    self.mir.push(X86Inst::IdivR {
+                        src: Operand::Virtual(rhs_vreg),
+                    });
+                } else {
+                    // Zero-extend EAX into EDX:EAX by zeroing EDX
+                    self.mir.push(X86Inst::XorRR {
+                        dst: Operand::Physical(Reg::Rdx),
+                        src: Operand::Physical(Reg::Rdx),
+                    });
+                    self.mir.push(X86Inst::DivR {
+                        src: Operand::Virtual(rhs_vreg),
+                    });
+                }
+
                 self.mir.push(X86Inst::MovRR {
                     dst: Operand::Virtual(vreg),
                     src: Operand::Physical(Reg::Rax),
@@ -1151,10 +1166,25 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Physical(Reg::Rax),
                     src: Operand::Virtual(lhs_vreg),
                 });
-                self.mir.push(X86Inst::Cdq);
-                self.mir.push(X86Inst::IdivR {
-                    src: Operand::Virtual(rhs_vreg),
-                });
+
+                // Use signed division (CDQ + IDIV) for signed types,
+                // unsigned division (XOR EDX,EDX + DIV) for unsigned types
+                if ty.is_signed() {
+                    self.mir.push(X86Inst::Cdq);
+                    self.mir.push(X86Inst::IdivR {
+                        src: Operand::Virtual(rhs_vreg),
+                    });
+                } else {
+                    // Zero-extend EAX into EDX:EAX by zeroing EDX
+                    self.mir.push(X86Inst::XorRR {
+                        dst: Operand::Physical(Reg::Rdx),
+                        src: Operand::Physical(Reg::Rdx),
+                    });
+                    self.mir.push(X86Inst::DivR {
+                        src: Operand::Virtual(rhs_vreg),
+                    });
+                }
+
                 self.mir.push(X86Inst::MovRR {
                     dst: Operand::Virtual(vreg),
                     src: Operand::Physical(Reg::Rdx),

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -723,6 +723,11 @@ impl<'a> Emitter<'a> {
                 self.emit_idiv(src.as_physical());
                 end_inst!(self, "idiv {}", src.as_physical());
             }
+            X86Inst::DivR { src } => {
+                self.begin_inst();
+                self.emit_div(src.as_physical());
+                end_inst!(self, "div {}", src.as_physical());
+            }
             X86Inst::CmpRR { src1, src2 } => {
                 self.begin_inst();
                 self.emit_cmp_rr(src1.as_physical(), src2.as_physical());
@@ -2064,6 +2069,25 @@ impl<'a> Emitter<'a> {
 
         // ModR/M: mod=11, reg=7 (IDIV), r/m=src
         let modrm = 0xC0 | (7 << 3) | (src_enc & 7);
+        self.code.push(modrm);
+    }
+
+    /// Emit `div r32` - Unsigned divide EDX:EAX by r32.
+    ///
+    /// Encoding: [REX] F7 /6 (div r/m32)
+    fn emit_div(&mut self, src: Reg) {
+        let src_enc = src.encoding();
+
+        // REX prefix if needed
+        if src.needs_rex() {
+            self.code.push(0x41); // REX.B
+        }
+
+        // Opcode: F7 (group 3 operations)
+        self.code.push(0xF7);
+
+        // ModR/M: mod=11, reg=6 (DIV), r/m=src
+        let modrm = 0xC0 | (6 << 3) | (src_enc & 7);
         self.code.push(modrm);
     }
 

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -205,7 +205,7 @@ pub fn uses(inst: &X86Inst) -> Vec<VReg> {
             // dst is both read and written
             add_if_virtual(dst, &mut result);
         }
-        X86Inst::IdivR { src } => {
+        X86Inst::IdivR { src } | X86Inst::DivR { src } => {
             add_if_virtual(src, &mut result);
             // Also implicitly uses RAX and RDX (physical)
         }
@@ -360,7 +360,7 @@ pub fn defs(inst: &X86Inst) -> Vec<VReg> {
         | X86Inst::Sar32RI { dst, .. } => {
             add_if_virtual(dst, &mut result);
         }
-        X86Inst::IdivR { .. } => {
+        X86Inst::IdivR { .. } | X86Inst::DivR { .. } => {
             // Implicitly defines RAX (quotient) and RDX (remainder), but those are physical
         }
         X86Inst::TestRR { .. }

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -270,12 +270,16 @@ pub enum X86Inst {
     /// `sar dst, imm` - Arithmetic shift right 32-bit by immediate.
     Sar32RI { dst: Operand, imm: u8 },
 
-    /// `cdq` - Sign-extend EAX into EDX:EAX (for division).
+    /// `cdq` - Sign-extend EAX into EDX:EAX (for signed division).
     Cdq,
 
     /// `idiv src` - Signed divide EDX:EAX by src.
     /// Quotient in EAX, remainder in EDX.
     IdivR { src: Operand },
+
+    /// `div src` - Unsigned divide EDX:EAX by src.
+    /// Quotient in EAX, remainder in EDX.
+    DivR { src: Operand },
 
     // Comparison and control flow
     /// `cmp src1, src2` - Compare 32-bit (subtract and set flags, discard result).
@@ -466,7 +470,7 @@ impl X86Inst {
     pub fn clobbers(&self) -> &'static [Reg] {
         match self {
             // Division clobbers RAX (quotient) and RDX (remainder)
-            X86Inst::IdivR { .. } => &[Reg::Rax, Reg::Rdx],
+            X86Inst::IdivR { .. } | X86Inst::DivR { .. } => &[Reg::Rax, Reg::Rdx],
             // CDQ sign-extends EAX into EDX, clobbering RDX
             X86Inst::Cdq => &[Reg::Rdx],
             // Function calls clobber all caller-saved registers per System V AMD64 ABI
@@ -537,6 +541,7 @@ impl fmt::Display for X86Inst {
             X86Inst::Sar32RI { dst, imm } => write!(f, "sarl {}, {}", dst, imm),
             X86Inst::Cdq => write!(f, "cdq"),
             X86Inst::IdivR { src } => write!(f, "idiv {}", src),
+            X86Inst::DivR { src } => write!(f, "div {}", src),
             X86Inst::CmpRR { src1, src2 } => write!(f, "cmp {}, {}", src1, src2),
             X86Inst::Cmp64RR { src1, src2 } => write!(f, "cmpq {}, {}", src1, src2),
             X86Inst::CmpRI { src, imm } => write!(f, "cmp {}, {}", src, imm),

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -425,6 +425,11 @@ impl RegAlloc {
                 mir.push(X86Inst::IdivR { src: src_op });
             }
 
+            X86Inst::DivR { src } => {
+                let src_op = self.load_operand(mir, src, Reg::R10)?;
+                mir.push(X86Inst::DivR { src: src_op });
+            }
+
             X86Inst::TestRR { src1, src2 } => {
                 let src1_op = self.load_operand(mir, src1, Reg::Rax)?;
                 let src2_op = self.load_operand(mir, src2, Reg::R10)?;

--- a/crates/rue-codegen/src/x86_64/schedule.rs
+++ b/crates/rue-codegen/src/x86_64/schedule.rs
@@ -111,7 +111,7 @@ fn get_latency(inst: &X86Inst) -> u32 {
         X86Inst::ImulRR { .. } | X86Inst::ImulRR64 { .. } => 3,
 
         // Division: 20-80 cycles (highly variable)
-        X86Inst::IdivR { .. } => 20,
+        X86Inst::IdivR { .. } | X86Inst::DivR { .. } => 20,
         X86Inst::Cdq => 1,
 
         // Negation: 1 cycle
@@ -294,7 +294,7 @@ fn regs_read(inst: &X86Inst) -> Vec<Reg> {
         | X86Inst::Sar32RI { dst, .. } => {
             add_if_phys(dst, &mut result);
         }
-        X86Inst::IdivR { src } => {
+        X86Inst::IdivR { src } | X86Inst::DivR { src } => {
             add_if_phys(src, &mut result);
             result.push(Reg::Rax);
             result.push(Reg::Rdx);
@@ -412,7 +412,7 @@ fn regs_written(inst: &X86Inst) -> Vec<Reg> {
         | X86Inst::Sar32RI { dst, .. } => {
             add_if_phys(dst, &mut result);
         }
-        X86Inst::IdivR { .. } => {
+        X86Inst::IdivR { .. } | X86Inst::DivR { .. } => {
             result.push(Reg::Rax);
             result.push(Reg::Rdx);
         }
@@ -477,6 +477,7 @@ fn writes_flags(inst: &X86Inst) -> bool {
             | X86Inst::ImulRR { .. }
             | X86Inst::ImulRR64 { .. }
             | X86Inst::IdivR { .. }
+            | X86Inst::DivR { .. }
             | X86Inst::Neg { .. }
             | X86Inst::Neg64 { .. }
             // Logical (set SF, ZF, PF; clear OF, CF)

--- a/crates/rue-spec/cases/expressions/arithmetic.toml
+++ b/crates/rue-spec/cases/expressions/arithmetic.toml
@@ -271,3 +271,74 @@ params = [
   { op = "mul", expr = "2147483647 * 2" },
   { op = "neg", expr = "--2147483648" },
 ]
+
+# =============================================================================
+# Unsigned Division/Modulo
+# =============================================================================
+# These tests verify that unsigned division/modulo work correctly with values
+# that would be negative if treated as signed. This catches bugs where the
+# compiler incorrectly uses signed division for unsigned types.
+
+[[case]]
+name = "unsigned_division_large_value"
+spec = ["4.2:10"]
+source = """
+fn main() -> i32 {
+    // 0x80000000 = 2147483648 (would be -2147483648 if signed)
+    let x: u32 = 2147483648;
+    // Unsigned: 2147483648 / 100 = 21474836
+    // If incorrectly using signed: -2147483648 / 100 = -21474836
+    let result: u32 = x / 100;
+    // 21474836 % 256 = 20
+    let low_byte: u32 = result % 256;
+    @intCast(low_byte)
+}
+"""
+exit_code = 20
+
+[[case]]
+name = "unsigned_modulo_large_value"
+spec = ["4.2:10"]
+source = """
+fn main() -> i32 {
+    // 0x80000000 = 2147483648 (would be -2147483648 if signed)
+    let x: u32 = 2147483648;
+    // Unsigned: 2147483648 % 100 = 48
+    // If incorrectly using signed: -2147483648 % 100 = -48 (or something wrong)
+    let result: u32 = x % 100;
+    @intCast(result)
+}
+"""
+exit_code = 48
+
+[[case]]
+name = "unsigned_division_max_value"
+spec = ["4.2:10"]
+source = """
+fn main() -> i32 {
+    // 0xFFFFFFFF = 4294967295 (would be -1 if signed)
+    let x: u32 = 4294967295;
+    // Unsigned: 4294967295 / 1000 = 4294967
+    // If incorrectly using signed: -1 / 1000 = 0
+    let result: u32 = x / 1000;
+    // 4294967 % 256 = 55
+    let low_byte: u32 = result % 256;
+    @intCast(low_byte)
+}
+"""
+exit_code = 55
+
+[[case]]
+name = "unsigned_modulo_max_value"
+spec = ["4.2:10"]
+source = """
+fn main() -> i32 {
+    // 0xFFFFFFFF = 4294967295 (would be -1 if signed)
+    let x: u32 = 4294967295;
+    // Unsigned: 4294967295 % 100 = 95
+    // If incorrectly using signed: -1 % 100 = -1
+    let result: u32 = x % 100;
+    @intCast(result)
+}
+"""
+exit_code = 95


### PR DESCRIPTION
Both backends were using signed division instructions (SDIV/IDIV) for all integer types, including unsigned. When operating on values with the high bit set (>= 2^31 for u32), the value would be incorrectly treated as negative, producing wrong results.

For aarch64:
- Added UdivRR instruction to use UDIV for unsigned types
- SDIV continues to be used for signed types

For x86_64:
- Added DivR instruction to use DIV for unsigned types
- Uses XOR EDX,EDX to zero-extend instead of CDQ sign-extend
- IDIV continues to be used for signed types

This fixes flaky test failures where @random_u32() would intermittently produce wrong results when the random value had its high bit set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)