### PR TITLE
Support associated function calls on comptime type variables

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -7926,10 +7926,27 @@ impl<'a> Sema<'a> {
         let function_name_str = self.interner.resolve(&function).to_string();
 
         // Check that the type exists and is a struct
-        let struct_id = *self
-            .structs
-            .get(&type_name)
-            .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.clone()), span)?;
+        // First check if it's a comptime type variable (e.g., `let P = Point(); P::origin()`)
+        let struct_id = if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
+            // Extract struct ID from the comptime type
+            match ty.kind() {
+                TypeKind::Struct(id) => id,
+                _ => {
+                    return Err(CompileError::new(
+                        ErrorKind::TypeMismatch {
+                            expected: "struct type".to_string(),
+                            found: ty.name().to_string(),
+                        },
+                        span,
+                    ));
+                }
+            }
+        } else {
+            *self
+                .structs
+                .get(&type_name)
+                .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.clone()), span)?
+        };
 
         // Handle builtin type associated functions
         if let Some(builtin_def) = self.get_builtin_type_def(struct_id) {
@@ -7990,7 +8007,11 @@ impl<'a> Sema<'a> {
         let air_args = self.analyze_call_args(air, &args, ctx)?;
 
         // Generate a function call name: Type::function
-        let call_name = format!("{}::{}", type_name_str, function_name_str);
+        // Use the internal struct name (e.g., "__anon_struct_0") for anonymous structs,
+        // not the user-visible type variable name (e.g., "P")
+        let struct_def = self.type_pool.struct_def(struct_id);
+        let internal_type_name = &struct_def.name;
+        let call_name = format!("{}::{}", internal_type_name, function_name_str);
         let call_name_sym = self.interner.get_or_intern(&call_name);
 
         // Encode call args into extra array

--- a/docs/designs/0029-anonymous-struct-methods.md
+++ b/docs/designs/0029-anonymous-struct-methods.md
@@ -227,12 +227,13 @@ Epic: rue-nj40
 - [x] Change method lookup key from `(Spur, Spur)` to `(StructId, Spur)`
 - [x] Register methods when creating anonymous struct types
 - [x] Resolve `Self` to the anonymous struct's `StructId` (in signatures only)
+- [x] Handle `Type::function()` call syntax for comptime type variables (rue-ybbz)
 - [ ] Update structural equality to include method signatures
 - [ ] Handle comptime parameter capture in method bodies
 - [x] Analyze method bodies with `self` in scope
 - [ ] Resolve `Self` in method body expressions
 
-**Status**: Partial - method registration works, `self` in method bodies works, but `Self` type resolution is incomplete. See rue-h6zn for remaining work.
+**Status**: Partial - method registration works, `self` in method bodies works, associated function calls on comptime type variables work (e.g., `P::constant()`), but `Self` type resolution in method bodies is incomplete. See rue-h6zn for remaining work.
 
 **Deliverable**: `v.push(42)` compiles when `v` is an anonymous struct type with a `push` method.
 


### PR DESCRIPTION
Enable `P::function()` syntax where `P` is a comptime type variable holding an anonymous struct type (e.g., `let P = Point()`).

Changes:
- Modified `analyze_assoc_fn_call_impl` to check `comptime_type_vars` before falling back to `self.structs` for type resolution
- Fixed call name generation to use the internal struct name (e.g., `__anon_struct_0::constant`) instead of the user-visible type variable name (e.g., `P::constant`)

This enables the `anon_struct_empty_with_method_ok` test which uses associated functions that return primitive types (not `Self`).

Tests that use `Self` in associated function signatures/bodies remain blocked by rue-h6zn (Self type resolution in method bodies).

Related: rue-ybbz, ADR-0029 Phase 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)