### PR TITLE
Implement Self type resolution in anonymous struct method bodies

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -165,6 +165,9 @@ pub struct ConstraintGenerator<'a> {
     /// Type variables allocated for integer literals.
     /// These start as unbound and need to be defaulted to i32 if unconstrained.
     int_literal_vars: Vec<TypeVarId>,
+    /// Type substitutions for Self and type parameters (used in method bodies).
+    /// Maps type names (like "Self") to their concrete types.
+    type_subst: Option<&'a HashMap<Spur, Type>>,
 }
 
 impl<'a> ConstraintGenerator<'a> {
@@ -177,6 +180,24 @@ impl<'a> ConstraintGenerator<'a> {
         enums: &'a HashMap<Spur, Type>,
         methods: &'a HashMap<(StructId, Spur), MethodSig>,
     ) -> Self {
+        Self::with_type_subst(rir, interner, functions, structs, enums, methods, None)
+    }
+
+    /// Create a new constraint generator with type substitutions.
+    ///
+    /// The `type_subst` map provides type substitutions for names like "Self"
+    /// that should be resolved to concrete types during constraint generation.
+    /// This is used for method bodies where `Self { ... }` struct literals
+    /// need to know the concrete struct type.
+    pub fn with_type_subst(
+        rir: &'a Rir,
+        interner: &'a ThreadedRodeo,
+        functions: &'a HashMap<Spur, FunctionSig>,
+        structs: &'a HashMap<Spur, Type>,
+        enums: &'a HashMap<Spur, Type>,
+        methods: &'a HashMap<(StructId, Spur), MethodSig>,
+        type_subst: Option<&'a HashMap<Spur, Type>>,
+    ) -> Self {
         Self {
             rir,
             interner,
@@ -188,6 +209,7 @@ impl<'a> ConstraintGenerator<'a> {
             enums,
             methods,
             int_literal_vars: Vec::new(),
+            type_subst,
         }
     }
 
@@ -879,7 +901,13 @@ impl<'a> ConstraintGenerator<'a> {
                 fields_len,
                 ..
             } => {
-                if let Some(&struct_ty) = self.structs.get(type_name) {
+                // Check type_subst first (for Self and type parameters in method bodies)
+                let struct_ty = self
+                    .type_subst
+                    .and_then(|subst| subst.get(type_name).copied())
+                    .or_else(|| self.structs.get(type_name).copied());
+
+                if let Some(struct_ty) = struct_ty {
                     let fields = self.rir.get_field_inits(*fields_start, *fields_len);
                     // Generate constraints for each field
                     for (_, value_ref) in fields.iter() {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -6448,7 +6448,8 @@ impl<'a> Sema<'a> {
         // ======================================================================
         // Run constraint generation and unification to determine types
         // for all expressions BEFORE emitting AIR.
-        let resolved_types = self.run_type_inference(infer_ctx, return_type, params, body)?;
+        let resolved_types =
+            self.run_type_inference(infer_ctx, return_type, params, body, type_subst)?;
 
         // Create analysis context with resolved types
         // If type_subst is provided, initialize comptime_type_vars with the substitutions
@@ -6577,15 +6578,17 @@ impl<'a> Sema<'a> {
         return_type: Type,
         params: &[(Spur, Type, RirParamMode)],
         body: InstRef,
+        type_subst: Option<&HashMap<Spur, Type>>,
     ) -> CompileResult<HashMap<InstRef, Type>> {
         // Create constraint generator using pre-computed inference context
-        let mut cgen = ConstraintGenerator::new(
+        let mut cgen = ConstraintGenerator::with_type_subst(
             self.rir,
             self.interner,
             &infer_ctx.func_sigs,
             &infer_ctx.struct_types,
             &infer_ctx.enum_types,
             &infer_ctx.method_sigs,
+            type_subst,
         );
 
         // Build parameter map for constraint context.

--- a/docs/designs/0029-anonymous-struct-methods.md
+++ b/docs/designs/0029-anonymous-struct-methods.md
@@ -231,9 +231,9 @@ Epic: rue-nj40
 - [ ] Update structural equality to include method signatures
 - [ ] Handle comptime parameter capture in method bodies
 - [x] Analyze method bodies with `self` in scope
-- [ ] Resolve `Self` in method body expressions
+- [x] Resolve `Self` in method body expressions (rue-h6zn)
 
-**Status**: Partial - method registration works, `self` in method bodies works, associated function calls on comptime type variables work (e.g., `P::constant()`), but `Self` type resolution in method bodies is incomplete. See rue-h6zn for remaining work.
+**Status**: Most items complete. Method registration, `self` in method bodies, associated function calls on comptime type variables (`P::constant()`), and `Self` type resolution all work. Remaining: structural equality with methods, comptime parameter capture.
 
 **Deliverable**: `v.push(42)` compiles when `v` is an anonymous struct type with a `push` method.
 
@@ -243,8 +243,6 @@ Epic: rue-nj40
 - [x] Add comprehensive spec tests (17 tests, preview-gated)
 - [x] Add UI tests for error messages (2 tests)
 - [x] Traceability coverage for all spec paragraphs (100% normative)
-
-**Note**: Tests are in place but preview tests fail because Phase 3 is incomplete.
 
 **Deliverable**: Full test coverage and specification documentation.
 


### PR DESCRIPTION
Extended the constraint generator to accept type substitutions (Self -> struct type) during type inference. This allows Self { ... } struct literals inside method bodies to properly resolve to the anonymous struct's type.

Changes:
- Added type_subst field to ConstraintGenerator with new with_type_subst() constructor
- Modified StructInit handling to check type_subst before falling back to structs map
- Updated run_type_inference to pass type_subst through to the constraint generator

Closes: rue-h6zn

🤖 Generated with [Claude Code](https://claude.com/claude-code)