### PR TITLE
Add @target_arch and @target_os intrinsics for platform detection

### DIFF
--- a/crates/rue-air/BUCK
+++ b/crates/rue-air/BUCK
@@ -9,6 +9,7 @@ rust_library(
         "//crates/rue-parser:rue-parser",
         "//crates/rue-rir:rue-rir",
         "//crates/rue-span:rue-span",
+        "//crates/rue-target:rue-target",
         "//third-party:rayon",
     ],
     visibility = ["PUBLIC"],
@@ -25,6 +26,7 @@ rust_test(
         "//crates/rue-parser:rue-parser",
         "//crates/rue-rir:rue-rir",
         "//crates/rue-span:rue-span",
+        "//crates/rue-target:rue-target",
         "//third-party:rayon",
     ],
 )

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -719,6 +719,28 @@ impl<'a> ConstraintGenerator<'a> {
                         self.generate(*arg_ref, ctx);
                     }
                     InferType::Concrete(Type::Unit)
+                } else if intrinsic_name == "target_arch" {
+                    // @target_arch: returns Arch enum
+                    if let Some(arch_spur) = self.interner.get("Arch") {
+                        if let Some(&arch_ty) = self.enums.get(&arch_spur) {
+                            InferType::Concrete(arch_ty)
+                        } else {
+                            InferType::Concrete(Type::Error)
+                        }
+                    } else {
+                        InferType::Concrete(Type::Error)
+                    }
+                } else if intrinsic_name == "target_os" {
+                    // @target_os: returns Os enum
+                    if let Some(os_spur) = self.interner.get("Os") {
+                        if let Some(&os_ty) = self.enums.get(&os_spur) {
+                            InferType::Concrete(os_ty)
+                        } else {
+                            InferType::Concrete(Type::Error)
+                        }
+                    } else {
+                        InferType::Concrete(Type::Error)
+                    }
                 } else {
                     // Generate constraints for arguments (they need to be processed)
                     for arg_ref in args.iter() {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -25,6 +25,7 @@ use rue_error::{
 };
 use rue_rir::{InstData, InstRef, RirArgMode, RirCallArg, RirDirective, RirParamMode};
 use rue_span::Span;
+use rue_target::{Arch, Os};
 
 use super::context::{
     AnalysisContext, AnalysisResult, BuiltinMethodContext, ConstValue, FieldPath, ParamInfo,
@@ -6111,6 +6112,68 @@ fn analyze_intrinsic_ctx(
             span,
         });
         Ok(AnalysisResult::new(air_ref, Type::I64))
+    } else if name == known.target_arch {
+        // @target_arch() - Returns Arch enum value for target CPU architecture
+        if !args.is_empty() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "target_arch".to_string(),
+                    expected: 0,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        let arch_enum_id = ctx
+            .builtin_arch_id
+            .expect("Arch enum not injected - internal compiler error");
+        let variant_index = match ctx.target.arch() {
+            Arch::X86_64 => 0,
+            Arch::Aarch64 => 1,
+        };
+
+        let result_type = Type::Enum(arch_enum_id);
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::EnumVariant {
+                enum_id: arch_enum_id,
+                variant_index,
+            },
+            ty: result_type,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, result_type))
+    } else if name == known.target_os {
+        // @target_os() - Returns Os enum value for target operating system
+        if !args.is_empty() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "target_os".to_string(),
+                    expected: 0,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        let os_enum_id = ctx
+            .builtin_os_id
+            .expect("Os enum not injected - internal compiler error");
+        let variant_index = match ctx.target.os() {
+            Os::Linux => 0,
+            Os::Macos => 1,
+        };
+
+        let result_type = Type::Enum(os_enum_id);
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::EnumVariant {
+                enum_id: os_enum_id,
+                variant_index,
+            },
+            ty: result_type,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, result_type))
     } else {
         // Unknown intrinsic - resolve name for error message
         let intrinsic_name = ctx.interner.resolve(&name);
@@ -8099,6 +8162,10 @@ impl<'a> Sema<'a> {
             self.analyze_addr_of_intrinsic(air, &args, span, ctx, true)
         } else if name == known.syscall {
             self.analyze_syscall_intrinsic(air, name, &args, span, ctx)
+        } else if name == known.target_arch {
+            self.analyze_target_arch_intrinsic(air, &args, span)
+        } else if name == known.target_os {
+            self.analyze_target_os_intrinsic(air, &args, span)
         } else {
             // Unknown intrinsic - resolve name for error message
             let intrinsic_name_str = self.interner.resolve(&name);
@@ -11014,5 +11081,95 @@ impl<'a> Sema<'a> {
             span,
         });
         Ok(AnalysisResult::new(air_ref, Type::I64))
+    }
+
+    /// Analyze @target_arch() intrinsic - returns target CPU architecture enum.
+    ///
+    /// This intrinsic takes no arguments and returns an Arch enum value
+    /// representing the target CPU architecture (X86_64 or Aarch64).
+    fn analyze_target_arch_intrinsic(
+        &self,
+        air: &mut Air,
+        args: &[RirCallArg],
+        span: Span,
+    ) -> CompileResult<AnalysisResult> {
+        // Validate: no arguments
+        if !args.is_empty() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "target_arch".to_string(),
+                    expected: 0,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        let arch_enum_id = self
+            .builtin_arch_id
+            .expect("Arch enum not injected - internal compiler error");
+
+        // Determine variant index based on host architecture (compile-time evaluation)
+        // Currently we always compile for the host architecture
+        let variant_index = match rue_target::Target::host().arch() {
+            Arch::X86_64 => 0,
+            Arch::Aarch64 => 1,
+        };
+
+        let result_type = Type::Enum(arch_enum_id);
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::EnumVariant {
+                enum_id: arch_enum_id,
+                variant_index,
+            },
+            ty: result_type,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, result_type))
+    }
+
+    /// Analyze @target_os() intrinsic - returns target operating system enum.
+    ///
+    /// This intrinsic takes no arguments and returns an Os enum value
+    /// representing the target operating system (Linux or Macos).
+    fn analyze_target_os_intrinsic(
+        &self,
+        air: &mut Air,
+        args: &[RirCallArg],
+        span: Span,
+    ) -> CompileResult<AnalysisResult> {
+        // Validate: no arguments
+        if !args.is_empty() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "target_os".to_string(),
+                    expected: 0,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        let os_enum_id = self
+            .builtin_os_id
+            .expect("Os enum not injected - internal compiler error");
+
+        // Determine variant index based on host OS (compile-time evaluation)
+        // Currently we always compile for the host OS
+        let variant_index = match rue_target::Target::host().os() {
+            Os::Linux => 0,
+            Os::Macos => 1,
+        };
+
+        let result_type = Type::Enum(os_enum_id);
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::EnumVariant {
+                enum_id: os_enum_id,
+                variant_index,
+            },
+            ty: result_type,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, result_type))
     }
 }

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -1,25 +1,28 @@
 //! Built-in type injection for semantic analysis.
 //!
 //! This module handles injection of built-in types like String as synthetic
-//! structs. Built-in types are registered before user code is processed,
+//! structs, and built-in enums like Arch and Os as synthetic enums.
+//! Built-in types are registered before user code is processed,
 //! enabling collision detection and proper type resolution.
 
-use rue_builtins::{BUILTIN_TYPES, BuiltinFieldType, BuiltinTypeDef};
+use rue_builtins::{BUILTIN_ENUMS, BUILTIN_TYPES, BuiltinFieldType, BuiltinTypeDef};
 
 use super::Sema;
-use crate::types::{StructDef, StructField, StructId, Type, TypeKind};
+use crate::types::{EnumDef, EnumId, StructDef, StructField, StructId, Type, TypeKind};
 
 impl<'a> Sema<'a> {
-    /// Phase 0: Inject built-in types as synthetic structs.
+    /// Phase 0: Inject built-in types as synthetic structs and enums.
     ///
-    /// This creates `StructDef` entries for built-in types like `String` before
+    /// This creates `StructDef` entries for built-in types like `String` and
+    /// `EnumDef` entries for built-in enums like `Arch` and `Os` before
     /// processing user code. The built-in types are registered in the `structs`
-    /// HashMap so they can be looked up by name, and their StructIds are stored
-    /// in dedicated fields (e.g., `builtin_string_id`) for fast access.
+    /// and `enums` HashMaps so they can be looked up by name, and their IDs are
+    /// stored in dedicated fields for fast access.
     ///
     /// Built-in types are marked with `is_builtin: true` and have their fields,
     /// destructor, and copy status derived from the `rue-builtins` registry.
     pub(crate) fn inject_builtin_types(&mut self) {
+        // Inject built-in struct types (String, etc.)
         for builtin in BUILTIN_TYPES {
             // Convert builtin field types to our Type enum
             let fields: Vec<StructField> = builtin
@@ -64,6 +67,37 @@ impl<'a> Sema<'a> {
             // Note: Associated functions and methods are not registered here.
             // They are handled by looking up methods in the builtin registry
             // when analyzing method calls on builtin types.
+        }
+
+        // Inject built-in enum types (Arch, Os)
+        for builtin_enum in BUILTIN_ENUMS {
+            let variants: Vec<String> = builtin_enum
+                .variants
+                .iter()
+                .map(|v| v.to_string())
+                .collect();
+
+            // Create the synthetic enum definition
+            let enum_def = EnumDef {
+                name: builtin_enum.name.to_string(),
+                variants,
+                is_pub: true,                      // Built-in enums are always public
+                file_id: rue_span::FileId::new(0), // Synthetic, no source file
+            };
+
+            // Register in type pool and get pool-based EnumId
+            let name_spur = self.interner.get_or_intern(builtin_enum.name);
+            let (enum_id, _) = self.type_pool.register_enum(name_spur, enum_def);
+
+            // Register in enum lookup
+            self.enums.insert(name_spur, enum_id);
+
+            // Store special IDs for quick access
+            if builtin_enum.name == "Arch" {
+                self.builtin_arch_id = Some(enum_id);
+            } else if builtin_enum.name == "Os" {
+                self.builtin_os_id = Some(enum_id);
+            }
         }
     }
 

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -64,6 +64,10 @@ pub struct GatherOutput<'a> {
     pub preview_features: PreviewFeatures,
     /// StructId of the synthetic String type.
     pub builtin_string_id: Option<StructId>,
+    /// EnumId of the synthetic Arch enum (for @target_arch intrinsic).
+    pub builtin_arch_id: Option<EnumId>,
+    /// EnumId of the synthetic Os enum (for @target_os intrinsic).
+    pub builtin_os_id: Option<EnumId>,
     /// Type intern pool (ADR-0024 Phase 1).
     pub type_pool: TypeInternPool,
     /// Arena storage for function/method parameter data.
@@ -86,6 +90,8 @@ impl<'a> GatherOutput<'a> {
             constants: self.constants,
             preview_features: self.preview_features,
             builtin_string_id: self.builtin_string_id,
+            builtin_arch_id: self.builtin_arch_id,
+            builtin_os_id: self.builtin_os_id,
             known: KnownSymbols::new(self.interner),
             type_pool: self.type_pool,
             module_registry: crate::sema_context::ModuleRegistry::new(),

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -87,6 +87,12 @@ pub struct KnownSymbols {
     /// The `syscall` intrinsic symbol - direct OS syscall.
     pub syscall: Spur,
 
+    // Target platform intrinsics
+    /// The `target_arch` intrinsic symbol - returns target CPU architecture.
+    pub target_arch: Spur,
+    /// The `target_os` intrinsic symbol - returns target operating system.
+    pub target_os: Spur,
+
     // Builtin type names
     /// The `String` type name symbol.
     pub string_type: Spur,
@@ -131,6 +137,10 @@ impl KnownSymbols {
             addr_of: interner.get_or_intern_static("addr_of"),
             addr_of_mut: interner.get_or_intern_static("addr_of_mut"),
             syscall: interner.get_or_intern_static("syscall"),
+
+            // Target platform intrinsics
+            target_arch: interner.get_or_intern_static("target_arch"),
+            target_os: interner.get_or_intern_static("target_os"),
 
             // Builtin type names
             string_type: interner.get_or_intern_static("String"),
@@ -195,6 +205,8 @@ mod tests {
         assert_eq!(interner.resolve(&known.addr_of), "addr_of");
         assert_eq!(interner.resolve(&known.addr_of_mut), "addr_of_mut");
         assert_eq!(interner.resolve(&known.syscall), "syscall");
+        assert_eq!(interner.resolve(&known.target_arch), "target_arch");
+        assert_eq!(interner.resolve(&known.target_os), "target_os");
         assert_eq!(interner.resolve(&known.string_type), "String");
         assert_eq!(interner.resolve(&known.main_fn), "main");
     }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -82,6 +82,10 @@ pub struct Sema<'a> {
     pub(crate) preview_features: PreviewFeatures,
     /// StructId of the synthetic String type.
     pub(crate) builtin_string_id: Option<StructId>,
+    /// EnumId of the synthetic Arch enum (for @target_arch intrinsic).
+    pub(crate) builtin_arch_id: Option<EnumId>,
+    /// EnumId of the synthetic Os enum (for @target_os intrinsic).
+    pub(crate) builtin_os_id: Option<EnumId>,
     /// Pre-interned known symbols for fast comparison.
     pub(crate) known: KnownSymbols,
     /// Type intern pool for unified type representation (ADR-0024 Phase 1).
@@ -113,6 +117,8 @@ impl<'a> Sema<'a> {
             constants: HashMap::new(),
             preview_features,
             builtin_string_id: None,
+            builtin_arch_id: None,
+            builtin_os_id: None,
             known: KnownSymbols::new(interner),
             type_pool: TypeInternPool::new(),
             module_registry: crate::sema_context::ModuleRegistry::new(),

--- a/crates/rue-air/src/sema/sema_ctx_builder.rs
+++ b/crates/rue-air/src/sema/sema_ctx_builder.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 
 use lasso::Spur;
+use rue_target::Target;
 
 use crate::inference::{FunctionSig, MethodSig};
 use crate::sema_context::{InferenceContext as SemaContextInferenceContext, SemaContext};
@@ -55,6 +56,9 @@ impl<'a> Sema<'a> {
             constants: &self.constants,
             preview_features: self.preview_features.clone(),
             builtin_string_id: self.builtin_string_id,
+            builtin_arch_id: self.builtin_arch_id,
+            builtin_os_id: self.builtin_os_id,
+            target: Target::default(), // Will be overridden by caller if needed
             inference_ctx,
             known: KnownSymbols::new(self.interner),
             type_pool: self.type_pool.clone(),

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -965,12 +965,12 @@ mod tests {
 
         // 3 structs: String (builtin) + A + B
         assert_eq!(stats.struct_count, 3);
-        // 1 enum: E
-        assert_eq!(stats.enum_count, 1);
+        // 3 enums: Arch (builtin) + Os (builtin) + E
+        assert_eq!(stats.enum_count, 3);
         // No arrays in Phase 1
         assert_eq!(stats.array_count, 0);
-        // Total: 4 composite types
-        assert_eq!(stats.total, 4);
+        // Total: 6 composite types
+        assert_eq!(stats.total, 6);
     }
 
     #[test]

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -205,6 +205,12 @@ pub struct SemaContext<'a> {
     pub preview_features: PreviewFeatures,
     /// StructId of the synthetic String type.
     pub builtin_string_id: Option<StructId>,
+    /// EnumId of the synthetic Arch enum (for @target_arch intrinsic).
+    pub builtin_arch_id: Option<EnumId>,
+    /// EnumId of the synthetic Os enum (for @target_os intrinsic).
+    pub builtin_os_id: Option<EnumId>,
+    /// Compilation target (architecture + OS).
+    pub target: rue_target::Target,
     /// Pre-computed inference context for HM type inference.
     pub inference_ctx: InferenceContext,
     /// Pre-interned known symbols for fast comparison.

--- a/crates/rue-builtins/src/lib.rs
+++ b/crates/rue-builtins/src/lib.rs
@@ -427,6 +427,63 @@ pub static STRING_TYPE: BuiltinTypeDef = BuiltinTypeDef {
 /// processing user code.
 pub static BUILTIN_TYPES: &[&BuiltinTypeDef] = &[&STRING_TYPE];
 
+// ============================================================================
+// Built-in Enums (Target Platform)
+// ============================================================================
+
+/// Definition of a built-in enum type.
+///
+/// These are synthetic enums injected by the compiler before processing user code.
+/// They are used for compile-time platform detection via intrinsics like
+/// `@target_arch()` and `@target_os()`.
+#[derive(Debug, Clone)]
+pub struct BuiltinEnumDef {
+    /// Enum name as it appears in source code (e.g., "Arch")
+    pub name: &'static str,
+    /// Variant names in order (index matches variant_index in EnumVariant)
+    pub variants: &'static [&'static str],
+}
+
+/// The built-in Arch enum for CPU architecture detection.
+///
+/// Variants:
+/// - `X86_64` (index 0): x86-64 / AMD64
+/// - `Aarch64` (index 1): ARM64 / AArch64
+///
+/// Used with `@target_arch()` intrinsic for platform-specific code.
+pub static ARCH_ENUM: BuiltinEnumDef = BuiltinEnumDef {
+    name: "Arch",
+    variants: &["X86_64", "Aarch64"],
+};
+
+/// The built-in Os enum for operating system detection.
+///
+/// Variants:
+/// - `Linux` (index 0): Linux
+/// - `Macos` (index 1): macOS / Darwin
+///
+/// Used with `@target_os()` intrinsic for platform-specific code.
+pub static OS_ENUM: BuiltinEnumDef = BuiltinEnumDef {
+    name: "Os",
+    variants: &["Linux", "Macos"],
+};
+
+/// All built-in enums.
+///
+/// The compiler iterates over this to inject synthetic enums before
+/// processing user code.
+pub static BUILTIN_ENUMS: &[&BuiltinEnumDef] = &[&ARCH_ENUM, &OS_ENUM];
+
+/// Look up a built-in enum by name.
+pub fn get_builtin_enum(name: &str) -> Option<&'static BuiltinEnumDef> {
+    BUILTIN_ENUMS.iter().find(|e| e.name == name).copied()
+}
+
+/// Check if a name is reserved for a built-in enum.
+pub fn is_reserved_enum_name(name: &str) -> bool {
+    BUILTIN_ENUMS.iter().any(|e| e.name == name)
+}
+
 /// Look up a built-in type by name.
 pub fn get_builtin_type(name: &str) -> Option<&'static BuiltinTypeDef> {
     BUILTIN_TYPES.iter().find(|t| t.name == name).copied()
@@ -550,5 +607,44 @@ mod tests {
                 name
             );
         }
+    }
+
+    // ========================================================================
+    // Built-in Enum Tests
+    // ========================================================================
+
+    #[test]
+    fn test_arch_enum() {
+        assert_eq!(ARCH_ENUM.name, "Arch");
+        assert_eq!(ARCH_ENUM.variants.len(), 2);
+        assert_eq!(ARCH_ENUM.variants[0], "X86_64");
+        assert_eq!(ARCH_ENUM.variants[1], "Aarch64");
+    }
+
+    #[test]
+    fn test_os_enum() {
+        assert_eq!(OS_ENUM.name, "Os");
+        assert_eq!(OS_ENUM.variants.len(), 2);
+        assert_eq!(OS_ENUM.variants[0], "Linux");
+        assert_eq!(OS_ENUM.variants[1], "Macos");
+    }
+
+    #[test]
+    fn test_get_builtin_enum() {
+        assert!(get_builtin_enum("Arch").is_some());
+        assert!(get_builtin_enum("Os").is_some());
+        assert!(get_builtin_enum("Target").is_none());
+    }
+
+    #[test]
+    fn test_is_reserved_enum_name() {
+        assert!(is_reserved_enum_name("Arch"));
+        assert!(is_reserved_enum_name("Os"));
+        assert!(!is_reserved_enum_name("MyEnum"));
+    }
+
+    #[test]
+    fn test_builtin_enums_count() {
+        assert_eq!(BUILTIN_ENUMS.len(), 2);
     }
 }

--- a/crates/rue-cfg/src/opt/constfold.rs
+++ b/crates/rue-cfg/src/opt/constfold.rs
@@ -18,7 +18,7 @@
 //! This ensures the runtime panic behavior is preserved.
 
 use crate::{Cfg, CfgInstData, CfgValue};
-use rue_air::{Type, TypeKind};
+use rue_air::{EnumId, Type, TypeKind};
 
 /// Run constant folding on the CFG.
 ///
@@ -62,8 +62,16 @@ fn fold_instruction(cfg: &mut Cfg, value: CfgValue) {
         }
 
         // Comparisons (result is always bool)
-        CfgInstData::Eq(lhs, rhs) => fold_comparison(cfg, *lhs, *rhs, |a, b| a == b),
-        CfgInstData::Ne(lhs, rhs) => fold_comparison(cfg, *lhs, *rhs, |a, b| a != b),
+        CfgInstData::Eq(lhs, rhs) => {
+            // Try integer comparison first, then enum variant comparison
+            fold_comparison(cfg, *lhs, *rhs, |a, b| a == b)
+                .or_else(|| fold_enum_comparison(cfg, *lhs, *rhs, |v1, v2| v1 == v2))
+        }
+        CfgInstData::Ne(lhs, rhs) => {
+            // Try integer comparison first, then enum variant comparison
+            fold_comparison(cfg, *lhs, *rhs, |a, b| a != b)
+                .or_else(|| fold_enum_comparison(cfg, *lhs, *rhs, |v1, v2| v1 != v2))
+        }
         CfgInstData::Lt(lhs, rhs) => {
             let lhs_ty = cfg.get_inst(*lhs).ty;
             fold_comparison_signed(cfg, *lhs, *rhs, lhs_ty, |a, b| a < b, |a, b| a < b)
@@ -131,6 +139,30 @@ where
     let rhs_val = get_const_int(cfg, rhs)?;
     let result = op(lhs_val, rhs_val);
     Some(CfgInstData::BoolConst(result))
+}
+
+/// Try to fold an enum variant comparison on two constant operands.
+///
+/// This enables dead code elimination for platform-specific code like:
+/// ```ignore
+/// if @target_arch() == Arch::X86_64 { ... }
+/// ```
+fn fold_enum_comparison<F>(cfg: &Cfg, lhs: CfgValue, rhs: CfgValue, op: F) -> Option<CfgInstData>
+where
+    F: FnOnce(u32, u32) -> bool,
+{
+    let (lhs_enum_id, lhs_variant) = get_enum_variant(cfg, lhs)?;
+    let (rhs_enum_id, rhs_variant) = get_enum_variant(cfg, rhs)?;
+
+    // Only fold if both operands are from the same enum type
+    if lhs_enum_id == rhs_enum_id {
+        let result = op(lhs_variant, rhs_variant);
+        Some(CfgInstData::BoolConst(result))
+    } else {
+        // Different enum types - this would be a type error,
+        // but let it pass through unfold for error reporting
+        None
+    }
 }
 
 /// Try to fold a comparison that needs signed semantics for signed types.
@@ -228,6 +260,17 @@ fn get_const_int(cfg: &Cfg, value: CfgValue) -> Option<u64> {
 fn get_const_bool(cfg: &Cfg, value: CfgValue) -> Option<bool> {
     match &cfg.get_inst(value).data {
         CfgInstData::BoolConst(v) => Some(*v),
+        _ => None,
+    }
+}
+
+/// Get the enum variant info of an instruction, if it's an EnumVariant.
+fn get_enum_variant(cfg: &Cfg, value: CfgValue) -> Option<(EnumId, u32)> {
+    match &cfg.get_inst(value).data {
+        CfgInstData::EnumVariant {
+            enum_id,
+            variant_index,
+        } => Some((*enum_id, *variant_index)),
         _ => None,
     }
 }

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -1081,3 +1081,405 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
+
+# =============================================================================
+# @target_arch Intrinsic
+# =============================================================================
+
+[[case]]
+name = "target_arch_returns_enum_x86_64"
+spec = ["4.13:66", "4.13:68"]
+only_on = ["x86-64-linux", "x86-64-macos"]
+source = """
+fn main() -> i32 {
+    // @target_arch() returns an Arch enum value
+    let arch = @target_arch();
+    match arch {
+        Arch::X86_64 => 1,
+        Arch::Aarch64 => 2,
+    }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "target_arch_returns_enum_aarch64"
+spec = ["4.13:66", "4.13:68"]
+only_on = ["aarch64-linux", "aarch64-macos"]
+source = """
+fn main() -> i32 {
+    // @target_arch() returns an Arch enum value
+    let arch = @target_arch();
+    match arch {
+        Arch::X86_64 => 1,
+        Arch::Aarch64 => 2,
+    }
+}
+"""
+exit_code = 2
+
+[[case]]
+name = "target_arch_no_args"
+spec = ["4.13:67"]
+source = """
+fn main() -> i32 {
+    // Verify @target_arch takes no arguments
+    let arch = @target_arch();
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "target_arch_wrong_arg_count"
+spec = ["4.13:4", "4.13:67"]
+source = """
+fn main() -> i32 {
+    let arch = @target_arch(42);
+    0
+}
+"""
+compile_fail = true
+error_contains = "argument"
+
+[[case]]
+name = "target_arch_constant_folding_x86_64"
+spec = ["4.13:66", "4.13:70"]
+only_on = ["x86-64-linux", "x86-64-macos"]
+source = """
+// The branch is selected at compile time based on target arch
+fn main() -> i32 {
+    match @target_arch() {
+        Arch::X86_64 => 42,
+        Arch::Aarch64 => 43,
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "target_arch_constant_folding_aarch64"
+spec = ["4.13:66", "4.13:70"]
+only_on = ["aarch64-linux", "aarch64-macos"]
+source = """
+// The branch is selected at compile time based on target arch
+fn main() -> i32 {
+    match @target_arch() {
+        Arch::X86_64 => 42,
+        Arch::Aarch64 => 43,
+    }
+}
+"""
+exit_code = 43
+
+[[case]]
+name = "target_arch_match_x86_64"
+spec = ["4.13:66", "4.13:68"]
+only_on = ["x86-64-linux", "x86-64-macos"]
+source = """
+fn main() -> i32 {
+    match @target_arch() {
+        Arch::X86_64 => 100,
+        Arch::Aarch64 => 200,
+    }
+}
+"""
+exit_code = 100
+
+[[case]]
+name = "target_arch_match_aarch64"
+spec = ["4.13:66", "4.13:68"]
+only_on = ["aarch64-linux", "aarch64-macos"]
+source = """
+fn main() -> i32 {
+    match @target_arch() {
+        Arch::X86_64 => 100,
+        Arch::Aarch64 => 200,
+    }
+}
+"""
+exit_code = 200
+
+# =============================================================================
+# @target_os Intrinsic
+# =============================================================================
+
+[[case]]
+name = "target_os_returns_enum_linux"
+spec = ["4.13:72", "4.13:74"]
+only_on = ["x86-64-linux", "aarch64-linux"]
+source = """
+fn main() -> i32 {
+    // @target_os() returns an Os enum value
+    let os = @target_os();
+    match os {
+        Os::Linux => 1,
+        Os::Macos => 2,
+    }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "target_os_returns_enum_macos"
+spec = ["4.13:72", "4.13:74"]
+only_on = ["x86-64-macos", "aarch64-macos"]
+source = """
+fn main() -> i32 {
+    // @target_os() returns an Os enum value
+    let os = @target_os();
+    match os {
+        Os::Linux => 1,
+        Os::Macos => 2,
+    }
+}
+"""
+exit_code = 2
+
+[[case]]
+name = "target_os_no_args"
+spec = ["4.13:73"]
+source = """
+fn main() -> i32 {
+    // Verify @target_os takes no arguments
+    let os = @target_os();
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "target_os_wrong_arg_count"
+spec = ["4.13:4", "4.13:73"]
+source = """
+fn main() -> i32 {
+    let os = @target_os(42);
+    0
+}
+"""
+compile_fail = true
+error_contains = "argument"
+
+[[case]]
+name = "target_os_match_linux"
+spec = ["4.13:72", "4.13:74"]
+only_on = ["x86-64-linux", "aarch64-linux"]
+source = """
+fn main() -> i32 {
+    match @target_os() {
+        Os::Linux => 10,
+        Os::Macos => 20,
+    }
+}
+"""
+exit_code = 10
+
+[[case]]
+name = "target_os_match_macos"
+spec = ["4.13:72", "4.13:74"]
+only_on = ["x86-64-macos", "aarch64-macos"]
+source = """
+fn main() -> i32 {
+    match @target_os() {
+        Os::Linux => 10,
+        Os::Macos => 20,
+    }
+}
+"""
+exit_code = 20
+
+# =============================================================================
+# Combined Platform Detection
+# =============================================================================
+
+[[case]]
+name = "target_combined_detection_x86_64_linux"
+spec = ["4.13:66", "4.13:72"]
+only_on = ["x86-64-linux"]
+source = """
+fn main() -> i32 {
+    // Combined arch + os detection using nested match
+    match @target_arch() {
+        Arch::X86_64 => {
+            match @target_os() {
+                Os::Linux => 99,
+                Os::Macos => 88,
+            }
+        },
+        Arch::Aarch64 => {
+            match @target_os() {
+                Os::Linux => 77,
+                Os::Macos => 66,
+            }
+        },
+    }
+}
+"""
+exit_code = 99
+
+[[case]]
+name = "target_combined_detection_x86_64_macos"
+spec = ["4.13:66", "4.13:72"]
+only_on = ["x86-64-macos"]
+source = """
+fn main() -> i32 {
+    // Combined arch + os detection using nested match
+    match @target_arch() {
+        Arch::X86_64 => {
+            match @target_os() {
+                Os::Linux => 99,
+                Os::Macos => 88,
+            }
+        },
+        Arch::Aarch64 => {
+            match @target_os() {
+                Os::Linux => 77,
+                Os::Macos => 66,
+            }
+        },
+    }
+}
+"""
+exit_code = 88
+
+[[case]]
+name = "target_combined_detection_aarch64_linux"
+spec = ["4.13:66", "4.13:72"]
+only_on = ["aarch64-linux"]
+source = """
+fn main() -> i32 {
+    // Combined arch + os detection using nested match
+    match @target_arch() {
+        Arch::X86_64 => {
+            match @target_os() {
+                Os::Linux => 99,
+                Os::Macos => 88,
+            }
+        },
+        Arch::Aarch64 => {
+            match @target_os() {
+                Os::Linux => 77,
+                Os::Macos => 66,
+            }
+        },
+    }
+}
+"""
+exit_code = 77
+
+[[case]]
+name = "target_combined_detection_aarch64_macos"
+spec = ["4.13:66", "4.13:72"]
+only_on = ["aarch64-macos"]
+source = """
+fn main() -> i32 {
+    // Combined arch + os detection using nested match
+    match @target_arch() {
+        Arch::X86_64 => {
+            match @target_os() {
+                Os::Linux => 99,
+                Os::Macos => 88,
+            }
+        },
+        Arch::Aarch64 => {
+            match @target_os() {
+                Os::Linux => 77,
+                Os::Macos => 66,
+            }
+        },
+    }
+}
+"""
+exit_code = 66
+
+[[case]]
+name = "target_arch_enum_variants_x86_64"
+spec = ["4.13:69"]
+only_on = ["x86-64-linux", "x86-64-macos"]
+source = """
+fn main() -> i32 {
+    // Test that Arch enum has X86_64 and Aarch64 variants
+    match @target_arch() {
+        Arch::X86_64 => 1,
+        Arch::Aarch64 => 2,
+    }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "target_arch_enum_variants_aarch64"
+spec = ["4.13:69"]
+only_on = ["aarch64-linux", "aarch64-macos"]
+source = """
+fn main() -> i32 {
+    // Test that Arch enum has X86_64 and Aarch64 variants
+    match @target_arch() {
+        Arch::X86_64 => 1,
+        Arch::Aarch64 => 2,
+    }
+}
+"""
+exit_code = 2
+
+[[case]]
+name = "target_os_enum_variants_linux"
+spec = ["4.13:75"]
+only_on = ["x86-64-linux", "aarch64-linux"]
+source = """
+fn main() -> i32 {
+    // Test that Os enum has Linux and Macos variants
+    match @target_os() {
+        Os::Linux => 1,
+        Os::Macos => 2,
+    }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "target_os_enum_variants_macos"
+spec = ["4.13:75"]
+only_on = ["x86-64-macos", "aarch64-macos"]
+source = """
+fn main() -> i32 {
+    // Test that Os enum has Linux and Macos variants
+    match @target_os() {
+        Os::Linux => 1,
+        Os::Macos => 2,
+    }
+}
+"""
+exit_code = 2
+
+[[case]]
+name = "target_os_compile_time_linux"
+spec = ["4.13:76"]
+only_on = ["x86-64-linux", "aarch64-linux"]
+source = """
+fn main() -> i32 {
+    // The value is determined at compile time
+    let os = @target_os();
+    match os {
+        Os::Linux => 10,
+        Os::Macos => 20,
+    }
+}
+"""
+exit_code = 10
+
+[[case]]
+name = "target_os_compile_time_macos"
+spec = ["4.13:76"]
+only_on = ["x86-64-macos", "aarch64-macos"]
+source = """
+fn main() -> i32 {
+    // The value is determined at compile time
+    let os = @target_os();
+    match os {
+        Os::Linux => 10,
+        Os::Macos => 20,
+    }
+}
+"""
+exit_code = 20

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -457,3 +457,96 @@ fn main() -> i32 {
     0
 }
 ```
+
+## `@target_arch`
+
+{{ rule(id="4.13:66", cat="normative") }}
+
+The `@target_arch` intrinsic returns the target architecture as an `Arch` enum value.
+
+{{ rule(id="4.13:67", cat="normative") }}
+
+`@target_arch` accepts no arguments.
+
+{{ rule(id="4.13:68", cat="normative") }}
+
+The return type of `@target_arch` is `Arch`.
+
+{{ rule(id="4.13:69", cat="normative") }}
+
+The `Arch` enum is a built-in enum with the following variants:
+- `Arch::X86_64` - x86-64 architecture
+- `Arch::Aarch64` - ARM64/AArch64 architecture
+
+{{ rule(id="4.13:70", cat="normative") }}
+
+The value returned by `@target_arch` is determined at compile time based on the compilation target.
+
+{{ rule(id="4.13:71") }}
+
+```rue
+fn main() -> i32 {
+    match @target_arch() {
+        Arch::X86_64 => 1,
+        Arch::Aarch64 => 2,
+    }
+}
+```
+
+## `@target_os`
+
+{{ rule(id="4.13:72", cat="normative") }}
+
+The `@target_os` intrinsic returns the target operating system as an `Os` enum value.
+
+{{ rule(id="4.13:73", cat="normative") }}
+
+`@target_os` accepts no arguments.
+
+{{ rule(id="4.13:74", cat="normative") }}
+
+The return type of `@target_os` is `Os`.
+
+{{ rule(id="4.13:75", cat="normative") }}
+
+The `Os` enum is a built-in enum with the following variants:
+- `Os::Linux` - Linux operating system
+- `Os::Macos` - macOS operating system
+
+{{ rule(id="4.13:76", cat="normative") }}
+
+The value returned by `@target_os` is determined at compile time based on the compilation target.
+
+{{ rule(id="4.13:77") }}
+
+```rue
+fn main() -> i32 {
+    match @target_os() {
+        Os::Linux => 1,
+        Os::Macos => 2,
+    }
+}
+```
+
+{{ rule(id="4.13:78") }}
+
+Combining `@target_arch` and `@target_os` for platform-specific code:
+
+```rue
+fn main() -> i32 {
+    match @target_arch() {
+        Arch::X86_64 => {
+            match @target_os() {
+                Os::Linux => 99,
+                Os::Macos => 88,
+            }
+        },
+        Arch::Aarch64 => {
+            match @target_os() {
+                Os::Linux => 77,
+                Os::Macos => 66,
+            }
+        },
+    }
+}
+```


### PR DESCRIPTION
Implement cross-platform abstractions that enable platform-specific code using pattern matching. These intrinsics return Arch and Os enum values respectively, and their values are determined at compile time based on the compilation target.

Key changes:
- Add BuiltinEnumDef to rue-builtins for Arch and Os enums
- Inject built-in enums in Sema (similar to built-in String type)
- Add target_arch/target_os intrinsic handlers in semantic analysis
- Extend CFG constant folding to support enum variant comparison
- Add HM type inference cases for the new intrinsics
- Add spec paragraphs 4.13:66-78 documenting the intrinsics
- Add comprehensive spec tests with 100% normative coverage

Combined with existing constant folding and DCE, dead branches are eliminated at compile time when using these intrinsics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)