### PR TITLE
rue-ppre: Implement parser error recovery for multi-error reporting

### DIFF
--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -495,6 +495,9 @@ pub fn merge_symbols(program: ParsedProgram) -> MultiErrorResult<MergedProgram> 
                     // Drop fns and const declarations are validated in Sema, not here.
                     // Const declarations are checked for duplicates in the declarations phase.
                 }
+                Item::Error(_) => {
+                    // Error nodes from parser recovery are skipped - errors were already reported
+                }
             }
             all_items.push(item.clone());
         }
@@ -657,6 +660,9 @@ pub fn validate_and_generate_rir_parallel(
                 }
                 Item::DropFn(_) | Item::Const(_) => {
                     // Validated in Sema
+                }
+                Item::Error(_) => {
+                    // Error nodes from parser recovery are skipped
                 }
             }
         }

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -322,6 +322,9 @@ impl<'src> CompilationUnit<'src> {
                     Item::DropFn(_) | Item::Const(_) => {
                         // Validated in Sema
                     }
+                    Item::Error(_) => {
+                        // Error nodes from parser recovery are skipped
+                    }
                 }
                 all_items.push(item.clone());
             }

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -70,6 +70,9 @@ pub enum Item {
     DropFn(DropFn),
     /// Constant declaration (e.g., `const math = @import("math");`)
     Const(ConstDecl),
+    /// Error node for recovered parse errors at item level.
+    /// Used by error recovery to continue parsing after a syntax error.
+    Error(Span),
 }
 
 /// A constant declaration.
@@ -433,6 +436,9 @@ pub enum Expr {
     Checked(CheckedBlockExpr),
     /// Type literal expression (e.g., `i32` used as a value in generic function calls)
     TypeLit(TypeLitExpr),
+    /// Error node for recovered parse errors.
+    /// Used by error recovery to continue parsing after a syntax error.
+    Error(Span),
 }
 
 /// An integer literal.
@@ -932,6 +938,7 @@ impl Expr {
             Expr::Comptime(comptime_expr) => comptime_expr.span,
             Expr::Checked(checked_expr) => checked_expr.span,
             Expr::TypeLit(type_lit) => type_lit.span,
+            Expr::Error(span) => *span,
         }
     }
 }
@@ -947,6 +954,7 @@ impl fmt::Display for Ast {
                 Item::Enum(e) => fmt_enum(f, e, 0)?,
                 Item::DropFn(drop_fn) => fmt_drop_fn(f, drop_fn, 0)?,
                 Item::Const(c) => fmt_const(f, c, 0)?,
+                Item::Error(span) => writeln!(f, "Error({:?})", span)?,
             }
         }
         Ok(())
@@ -1273,6 +1281,9 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
         }
         Expr::TypeLit(type_lit) => {
             writeln!(f, "TypeLit({})", type_lit.type_expr)
+        }
+        Expr::Error(span) => {
+            writeln!(f, "Error({:?})", span)
         }
     }
 }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -16,6 +16,7 @@ use crate::ast::{
 use chumsky::input::{Input as ChumskyInput, MapExtra, Stream, ValueInput};
 use chumsky::pratt::{infix, left, prefix};
 use chumsky::prelude::*;
+use chumsky::recovery::via_parser;
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileError, CompileErrors, ErrorKind, MultiErrorResult};
 use rue_lexer::TokenKind;
@@ -2183,12 +2184,65 @@ where
     ))
 }
 
+/// Parser that matches tokens that can start an item (for recovery).
+/// This is a "lookahead" - it peeks but doesn't consume.
+fn item_start<'src, I>() -> impl Parser<'src, I, (), ParserExtras<'src>> + Clone
+where
+    I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
+{
+    choice((
+        just(TokenKind::Fn).ignored(),
+        just(TokenKind::Struct).ignored(),
+        just(TokenKind::Enum).ignored(),
+        just(TokenKind::Drop).ignored(),
+        just(TokenKind::Const).ignored(),
+        just(TokenKind::Pub).ignored(),
+        just(TokenKind::Linear).ignored(),
+        just(TokenKind::Unchecked).ignored(),
+        just(TokenKind::At).ignored(), // For @directives
+    ))
+    .rewind() // Peek without consuming
+}
+
+/// Recovery parser that skips tokens until finding an item start.
+/// Consumes at least one token to guarantee progress, then skips until
+/// we find a token that could start an item.
+fn error_recovery<'src, I>() -> impl Parser<'src, I, Item, ParserExtras<'src>> + Clone
+where
+    I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
+{
+    // Skip at least one token to make progress, capturing the span
+    any()
+        .map_with(|_, extra| extra.span())
+        // Then skip any more tokens that don't start an item
+        .then(
+            any()
+                .and_is(item_start().not())
+                .repeated()
+                .collect::<Vec<_>>(),
+        )
+        .map(|(start_span, _): (SimpleSpan, Vec<TokenKind>)| {
+            // Convert SimpleSpan to Span
+            Item::Error(to_rue_span(start_span))
+        })
+}
+
+/// Parser for top-level items with error recovery.
+/// When an item fails to parse, we skip tokens until we find the start of
+/// another item, emit an Error node, and continue parsing.
+fn item_with_recovery<'src, I>() -> impl Parser<'src, I, Item, ParserExtras<'src>> + Clone
+where
+    I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
+{
+    item_parser().recover_with(via_parser(error_recovery()))
+}
+
 /// Main parser that produces an AST
 fn ast_parser<'src, I>() -> impl Parser<'src, I, Ast, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    item_parser()
+    item_with_recovery()
         .repeated()
         .collect::<Vec<_>>()
         .then_ignore(end())
@@ -2377,6 +2431,7 @@ mod tests {
             Item::Enum(_) => panic!("parse_expr helper should only be used with functions"),
             Item::DropFn(_) => panic!("parse_expr helper should only be used with functions"),
             Item::Const(_) => panic!("parse_expr helper should only be used with functions"),
+            Item::Error(_) => panic!("parse_expr helper should only be used with functions"),
         };
         Ok(ExprResult { expr, interner })
     }
@@ -2405,6 +2460,7 @@ mod tests {
             Item::Enum(_) => panic!("expected Function"),
             Item::DropFn(_) => panic!("expected Function"),
             Item::Const(_) => panic!("expected Function"),
+            Item::Error(_) => panic!("expected Function"),
         }
     }
 
@@ -2474,6 +2530,7 @@ mod tests {
             Item::Enum(_) => panic!("expected Function"),
             Item::DropFn(_) => panic!("expected Function"),
             Item::Const(_) => panic!("expected Function"),
+            Item::Error(_) => panic!("expected Function"),
         }
     }
 

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -65,6 +65,8 @@ impl<'a> AstGen<'a> {
             Item::Const(const_decl) => {
                 self.gen_const(const_decl);
             }
+            // Error nodes from parser recovery are skipped - errors were already reported
+            Item::Error(_) => {}
         }
     }
 
@@ -773,6 +775,12 @@ impl<'a> AstGen<'a> {
                     }
                 }
             }
+            // Error nodes from parser recovery - generate a unit constant as a placeholder
+            // The error was already reported during parsing
+            Expr::Error(span) => self.rir.add_inst(Inst {
+                data: InstData::UnitConst,
+                span: *span,
+            }),
         }
     }
 

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -4,7 +4,7 @@
 //! including test case parsing, execution, and output comparison.
 
 use rue_error::PreviewFeature;
-use serde::Deserialize;
+use serde::{Deserialize, Deserializer};
 
 /// Default timeout for test execution in milliseconds (10 seconds).
 pub const DEFAULT_TIMEOUT_MS: u64 = 10_000;
@@ -51,6 +51,61 @@ pub struct ParamSet {
     pub values: HashMap<String, toml::Value>,
 }
 
+/// Wrapper type for `error_contains` that can be either a single string or an array.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct ErrorContains(pub Vec<String>);
+
+impl ErrorContains {
+    /// Returns true if there are no expected error substrings.
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    /// Returns an iterator over the expected error substrings.
+    pub fn iter(&self) -> impl Iterator<Item = &String> {
+        self.0.iter()
+    }
+}
+
+impl<'de> Deserialize<'de> for ErrorContains {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::{self, Visitor};
+
+        struct ErrorContainsVisitor;
+
+        impl<'de> Visitor<'de> for ErrorContainsVisitor {
+            type Value = ErrorContains;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str("a string or array of strings")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<ErrorContains, E>
+            where
+                E: de::Error,
+            {
+                Ok(ErrorContains(vec![value.to_string()]))
+            }
+
+            fn visit_seq<A>(self, mut seq: A) -> Result<ErrorContains, A::Error>
+            where
+                A: de::SeqAccess<'de>,
+            {
+                let mut values = Vec::new();
+                while let Some(value) = seq.next_element::<String>()? {
+                    values.push(value);
+                }
+                Ok(ErrorContains(values))
+            }
+        }
+
+        deserializer.deserialize_any(ErrorContainsVisitor)
+    }
+}
+
 /// A single test case.
 #[derive(Debug, Clone, Deserialize)]
 pub struct Case {
@@ -65,9 +120,10 @@ pub struct Case {
     /// If true, only compile (don't run) - useful for infinite loops
     #[serde(default)]
     pub compile_only: bool,
-    /// Optional substring that should appear in the error message
+    /// Substring(s) that should appear in the error message.
+    /// Can be a single string or an array of strings.
     #[serde(default)]
-    pub error_contains: Option<String>,
+    pub error_contains: ErrorContains,
     /// Expected exact error output (golden test)
     #[serde(default)]
     pub expected_error: Option<String>,
@@ -272,10 +328,12 @@ pub fn expand_case(case: Case) -> Vec<Case> {
                 // Substitute placeholders in string fields
                 name: substitute_placeholders(&case.name, params),
                 source: substitute_placeholders(&case.source, params),
-                error_contains: case
-                    .error_contains
-                    .as_ref()
-                    .map(|s| substitute_placeholders(s, params)),
+                error_contains: ErrorContains(
+                    case.error_contains
+                        .iter()
+                        .map(|s| substitute_placeholders(s, params))
+                        .collect(),
+                ),
                 expected_error: case
                     .expected_error
                     .as_ref()
@@ -861,8 +919,8 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
             }
         }
 
-        // Check error message contains substring
-        if let Some(ref expected_error) = case.error_contains {
+        // Check error message contains all expected substrings
+        for expected_error in case.error_contains.iter() {
             if !stderr.contains(expected_error) {
                 return Err(format!(
                     "Error message mismatch:\n  expected to contain: {}\n  actual stderr: {}\n  source: {}",
@@ -1106,7 +1164,7 @@ mod tests {
             exit_code: Some(0),
             compile_fail: false,
             compile_only: false,
-            error_contains: None,
+            error_contains: ErrorContains::default(),
             expected_error: None,
             expected_tokens: None,
             expected_ast: None,
@@ -1156,7 +1214,7 @@ mod tests {
             exit_code: None, // Will be overridden
             compile_fail: false,
             compile_only: false,
-            error_contains: None,
+            error_contains: ErrorContains::default(),
             expected_error: None,
             expected_tokens: None,
             expected_ast: None,
@@ -1214,7 +1272,7 @@ mod tests {
             exit_code: Some(0),
             compile_fail: false,
             compile_only: false,
-            error_contains: None,
+            error_contains: ErrorContains::default(),
             expected_error: None,
             expected_tokens: None,
             expected_ast: None,
@@ -1264,7 +1322,7 @@ mod tests {
             exit_code: None,
             compile_fail: false, // Will be overridden
             compile_only: false,
-            error_contains: Some("{error_msg}".to_string()),
+            error_contains: ErrorContains(vec!["{error_msg}".to_string()]),
             expected_error: None,
             expected_tokens: None,
             expected_ast: None,
@@ -1298,7 +1356,7 @@ mod tests {
         assert!(expanded[0].compile_fail);
         assert_eq!(
             expanded[0].error_contains,
-            Some("type mismatch".to_string())
+            ErrorContains(vec!["type mismatch".to_string()])
         );
     }
 
@@ -1572,7 +1630,7 @@ mod tests {
             exit_code: Some(0),
             compile_fail: false,
             compile_only: false,
-            error_contains: None,
+            error_contains: ErrorContains::default(),
             expected_error: None,
             expected_tokens: None,
             expected_ast: None,

--- a/crates/rue-ui-tests/cases/diagnostics/multi-error.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/multi-error.toml
@@ -1,0 +1,133 @@
+[section]
+id = "diagnostics.multi-error"
+name = "Multi-Error Reporting"
+description = "Tests that the parser reports multiple syntax errors in a single compilation."
+
+# =============================================================================
+# Multiple Syntax Errors at Item Level
+# =============================================================================
+
+# These tests verify that the parser can recover from one syntax error and
+# continue to find additional errors in subsequent items.
+
+[[case]]
+name = "multiple_function_errors"
+source = """
+fn foo( -> i32 { 0 }
+
+fn bar() -> i32 { 0 }
+
+fn baz( -> i32 { 0 }
+"""
+compile_fail = true
+# Both functions with missing params should be reported (lines 1 and 5)
+error_contains = ["1:9", "5:9"]
+
+[[case]]
+name = "missing_braces_multiple_functions"
+source = """
+fn foo() -> i32 0
+
+fn bar() -> i32 { 0 }
+
+fn baz() -> i32 0
+"""
+compile_fail = true
+# Both functions with missing braces should be reported
+error_contains = ["expected", "{"]
+
+[[case]]
+name = "multiple_struct_errors"
+source = """
+struct Foo x: i32 }
+
+struct Bar { y: i32 }
+
+struct Baz { z i32 }
+"""
+compile_fail = true
+error_contains = ["expected"]
+
+# =============================================================================
+# Multiple Errors Within a Function (Future: statement-level recovery)
+# =============================================================================
+
+# These tests verify that the parser can recover from errors within a function
+# body and continue to find additional errors. Note: statement-level recovery
+# is not yet implemented, so these tests are expected to report only the first error.
+
+[[case]]
+name = "multiple_statement_errors"
+source = """
+fn main() -> i32 {
+    let x 5;
+    let y = 10;
+    let z 15;
+    y
+}
+"""
+compile_fail = true
+# Currently only the first error is reported (no statement-level recovery yet)
+error_contains = ["expected"]
+
+[[case]]
+name = "missing_semicolons"
+source = """
+fn main() -> i32 {
+    let x = 5
+    let y = 10
+    y
+}
+"""
+compile_fail = true
+# The parser reports this as an unexpected 'let' token
+error_contains = ["expected"]
+
+# =============================================================================
+# Nested Delimiter Recovery (Future: delimiter recovery)
+# =============================================================================
+
+# These tests verify that the parser can recover from unbalanced delimiters.
+# Note: nested delimiter recovery is not yet implemented.
+
+[[case]]
+name = "unbalanced_parens"
+source = """
+fn main() -> i32 {
+    let x = (1 + 2;
+    let y = 3;
+    y
+}
+"""
+compile_fail = true
+# The parser reports an unexpected ';' token
+error_contains = ["expected"]
+
+[[case]]
+name = "unbalanced_braces"
+source = """
+fn main() -> i32 {
+    if true { 1
+    0
+}
+"""
+compile_fail = true
+# The parser reports expected semicolon
+error_contains = ["semicolon"]
+
+# =============================================================================
+# Error Count Verification
+# =============================================================================
+
+# These tests verify that we report multiple errors at item level.
+
+[[case]]
+name = "three_distinct_errors"
+source = """
+fn foo( -> i32 { 0 }
+fn bar( -> i32 { 0 }
+fn baz( -> i32 { 0 }
+"""
+compile_fail = true
+# All three function signatures are malformed - we should see errors on lines 1, 2, and 3
+error_contains = ["1:9", "2:9", "3:9"]


### PR DESCRIPTION
Add error recovery to the parser so that when a syntax error is encountered at the item level (function, struct, enum, etc.), the parser can skip tokens until finding the start of the next item and continue parsing.

Key changes:
- Add Item::Error and Expr::Error variants to AST for recovered error nodes
- Implement error_recovery() parser using Chumsky's via_parser() strategy
- Update all Item and Expr match exhaustiveness throughout the codebase
- Add ErrorContains type to test runner for checking multiple error substrings
- Add UI tests for multi-error reporting scenarios

Before this change, the compiler would stop at the first parse error. Now it can report multiple errors in a single compilation, helping users fix more issues per compile cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)