### PR TITLE
Refactor Type API and remove dead code to enable -Dwarnings

### DIFF
--- a/crates/rue-air/BUCK
+++ b/crates/rue-air/BUCK
@@ -1,6 +1,7 @@
 rust_library(
     name = "rue-air",
     srcs = glob(["src/**/*.rs"]),
+    rustc_flags = ["-Dwarnings"],
     deps = [
         "//crates/rue-builtins:rue-builtins",
         "//crates/rue-error:rue-error",
@@ -18,6 +19,7 @@ rust_library(
 rust_test(
     name = "rue-air-test",
     srcs = glob(["src/**/*.rs"]),
+    rustc_flags = ["-Dwarnings"],
     deps = [
         "//crates/rue-builtins:rue-builtins",
         "//crates/rue-error:rue-error",

--- a/crates/rue-air/src/function_analyzer.rs
+++ b/crates/rue-air/src/function_analyzer.rs
@@ -131,7 +131,7 @@ impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
 
                 // Convert the element type to get the concrete Type
                 let elem_ty = self.infer_type_to_type(element);
-                if elem_ty != Type::Error {
+                if elem_ty != Type::ERROR {
                     // Pre-create this array type
                     self.get_or_create_array_type(elem_ty, *length);
                 }
@@ -146,16 +146,16 @@ impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
     pub fn infer_type_to_type(&self, ty: &InferType) -> Type {
         match ty {
             InferType::Concrete(t) => *t,
-            InferType::Var(_) => Type::Error,
+            InferType::Var(_) => Type::ERROR,
             InferType::IntLiteral => Type::I32,
             InferType::Array { element, length } => {
                 let elem_ty = self.infer_type_to_type(element);
-                if elem_ty == Type::Error {
-                    return Type::Error;
+                if elem_ty == Type::ERROR {
+                    return Type::ERROR;
                 }
                 // Use the thread-safe registry to get or create the array type
                 let id = self.get_or_create_array_type(elem_ty, *length);
-                Type::Array(id)
+                Type::new_array(id)
             }
         }
     }
@@ -233,16 +233,16 @@ impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
             "u16" => return Ok(Type::U16),
             "u32" => return Ok(Type::U32),
             "u64" => return Ok(Type::U64),
-            "bool" => return Ok(Type::Bool),
-            "()" => return Ok(Type::Unit),
-            "!" => return Ok(Type::Never),
+            "bool" => return Ok(Type::BOOL),
+            "()" => return Ok(Type::UNIT),
+            "!" => return Ok(Type::NEVER),
             _ => {}
         }
 
         if let Some(struct_id) = self.ctx.get_struct(type_sym) {
-            Ok(Type::Struct(struct_id))
+            Ok(Type::new_struct(struct_id))
         } else if let Some(enum_id) = self.ctx.get_enum(type_sym) {
-            Ok(Type::Enum(enum_id))
+            Ok(Type::new_enum(enum_id))
         } else {
             // Check for array type syntax: [T; N]
             if let Some((element_type, length)) = crate::types::parse_array_type_syntax(type_name) {
@@ -251,7 +251,7 @@ impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
                 let element_ty = self.resolve_type(element_sym, span)?;
                 // Get or create the array type
                 let array_type_id = self.get_or_create_array_type(element_ty, length);
-                Ok(Type::Array(array_type_id))
+                Ok(Type::new_array(array_type_id))
             } else if let Some((pointee_type, mutability)) =
                 crate::types::parse_pointer_type_syntax(type_name)
             {
@@ -262,11 +262,11 @@ impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
                 match mutability {
                     crate::types::PtrMutability::Const => {
                         let ptr_id = self.ctx.get_or_create_ptr_const_type(pointee_ty);
-                        Ok(Type::PtrConst(ptr_id))
+                        Ok(Type::new_ptr_const(ptr_id))
                     }
                     crate::types::PtrMutability::Mut => {
                         let ptr_id = self.ctx.get_or_create_ptr_mut_type(pointee_ty);
-                        Ok(Type::PtrMut(ptr_id))
+                        Ok(Type::new_ptr_mut(ptr_id))
                     }
                 }
             } else {

--- a/crates/rue-air/src/inference/constraint.rs
+++ b/crates/rue-air/src/inference/constraint.rs
@@ -261,10 +261,10 @@ mod tests {
     fn test_substitution_apply_bound_var() {
         let mut subst = Substitution::new();
         let v0 = TypeVarId::new(0);
-        subst.insert(v0, InferType::Concrete(Type::Bool));
+        subst.insert(v0, InferType::Concrete(Type::BOOL));
 
         let ty = InferType::Var(v0);
-        assert_eq!(subst.apply(&ty), InferType::Concrete(Type::Bool));
+        assert_eq!(subst.apply(&ty), InferType::Concrete(Type::BOOL));
     }
 
     #[test]
@@ -375,7 +375,7 @@ mod tests {
         assert_eq!(subst.len(), 1);
 
         // Insert at a higher index - only counts actual mappings
-        subst.insert(TypeVarId::new(5), InferType::Concrete(Type::Bool));
+        subst.insert(TypeVarId::new(5), InferType::Concrete(Type::BOOL));
         assert_eq!(subst.len(), 2);
     }
 }

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -106,16 +106,8 @@ impl<'a> ConstraintContext<'a> {
 impl ScopedContext for ConstraintContext<'_> {
     type VarInfo = LocalVarInfo;
 
-    fn locals(&self) -> &HashMap<Spur, Self::VarInfo> {
-        &self.locals
-    }
-
     fn locals_mut(&mut self) -> &mut HashMap<Spur, Self::VarInfo> {
         &mut self.locals
-    }
-
-    fn scope_stack(&self) -> &[Vec<(Spur, Option<Self::VarInfo>)>] {
-        &self.scope_stack
     }
 
     fn scope_stack_mut(&mut self) -> &mut Vec<Vec<(Spur, Option<Self::VarInfo>)>> {
@@ -156,9 +148,9 @@ pub struct ConstraintGenerator<'a> {
     expr_types: HashMap<InstRef, InferType>,
     /// Function signatures (for call type checking).
     functions: &'a HashMap<Spur, FunctionSig>,
-    /// Struct types (name -> Type::Struct(id)).
+    /// Struct types (name -> Type::new_struct(id)).
     structs: &'a HashMap<Spur, Type>,
-    /// Enum types (name -> Type::Enum(id)).
+    /// Enum types (name -> Type::new_enum(id)).
     enums: &'a HashMap<Spur, Type>,
     /// Method signatures: (struct_id, method_name) -> MethodSig
     methods: &'a HashMap<(StructId, Spur), MethodSig>,
@@ -299,7 +291,7 @@ impl<'a> ConstraintGenerator<'a> {
                 InferType::Var(var)
             }
 
-            InstData::BoolConst(_) => InferType::Concrete(Type::Bool),
+            InstData::BoolConst(_) => InferType::Concrete(Type::BOOL),
 
             // String constants use the builtin String struct type.
             InstData::StringConst(_) => {
@@ -309,14 +301,14 @@ impl<'a> ConstraintGenerator<'a> {
                         InferType::Concrete(string_ty)
                     } else {
                         // Fallback if String struct not found (shouldn't happen after builtin injection)
-                        InferType::Concrete(Type::Error)
+                        InferType::Concrete(Type::ERROR)
                     }
                 } else {
-                    InferType::Concrete(Type::Error)
+                    InferType::Concrete(Type::ERROR)
                 }
             }
 
-            InstData::UnitConst => InferType::Concrete(Type::Unit),
+            InstData::UnitConst => InferType::Concrete(Type::UNIT),
 
             // Binary arithmetic: both operands must have the same type, result is that type
             InstData::Add { lhs, rhs }
@@ -343,7 +335,7 @@ impl<'a> ConstraintGenerator<'a> {
                 let rhs_info = self.generate(*rhs, ctx);
                 // Operands must have the same type
                 self.add_constraint(Constraint::equal(lhs_info.ty, rhs_info.ty, span));
-                InferType::Concrete(Type::Bool)
+                InferType::Concrete(Type::BOOL)
             }
 
             // Logical operators: operands must be bool, result is bool
@@ -352,15 +344,15 @@ impl<'a> ConstraintGenerator<'a> {
                 let rhs_info = self.generate(*rhs, ctx);
                 self.add_constraint(Constraint::equal(
                     lhs_info.ty,
-                    InferType::Concrete(Type::Bool),
+                    InferType::Concrete(Type::BOOL),
                     lhs_info.span,
                 ));
                 self.add_constraint(Constraint::equal(
                     rhs_info.ty,
-                    InferType::Concrete(Type::Bool),
+                    InferType::Concrete(Type::BOOL),
                     rhs_info.span,
                 ));
-                InferType::Concrete(Type::Bool)
+                InferType::Concrete(Type::BOOL)
             }
 
             // Unary negation: operand must be signed integer
@@ -378,10 +370,10 @@ impl<'a> ConstraintGenerator<'a> {
                 let operand_info = self.generate(*operand, ctx);
                 self.add_constraint(Constraint::equal(
                     operand_info.ty,
-                    InferType::Concrete(Type::Bool),
+                    InferType::Concrete(Type::BOOL),
                     operand_info.span,
                 ));
-                InferType::Concrete(Type::Bool)
+                InferType::Concrete(Type::BOOL)
             }
 
             // Bitwise NOT: operand must be integer
@@ -401,7 +393,7 @@ impl<'a> ConstraintGenerator<'a> {
                     param.ty.clone()
                 } else {
                     // Unknown variable - will be caught during semantic analysis
-                    InferType::Concrete(Type::Error)
+                    InferType::Concrete(Type::ERROR)
                 }
             }
 
@@ -410,7 +402,7 @@ impl<'a> ConstraintGenerator<'a> {
                 if let Some(param) = ctx.params.get(name) {
                     param.ty.clone()
                 } else {
-                    InferType::Concrete(Type::Error)
+                    InferType::Concrete(Type::ERROR)
                 }
             }
 
@@ -459,7 +451,7 @@ impl<'a> ConstraintGenerator<'a> {
                 }
 
                 // Alloc produces unit type
-                InferType::Concrete(Type::Unit)
+                InferType::Concrete(Type::UNIT)
             }
 
             // Assignment
@@ -470,7 +462,7 @@ impl<'a> ConstraintGenerator<'a> {
                     self.add_constraint(Constraint::equal(value_info.ty, local.ty.clone(), span));
                 }
                 // Assignment produces unit
-                InferType::Concrete(Type::Unit)
+                InferType::Concrete(Type::UNIT)
             }
 
             // Return statement
@@ -486,13 +478,13 @@ impl<'a> ConstraintGenerator<'a> {
                 } else {
                     // Return without value - function must return unit
                     self.add_constraint(Constraint::equal(
-                        InferType::Concrete(Type::Unit),
+                        InferType::Concrete(Type::UNIT),
                         InferType::Concrete(ctx.return_type),
                         span,
                     ));
                 }
                 // Return diverges
-                InferType::Concrete(Type::Never)
+                InferType::Concrete(Type::NEVER)
             }
 
             // Function call
@@ -517,7 +509,7 @@ impl<'a> ConstraintGenerator<'a> {
                             // If this is a comptime parameter, extract the type for substitution
                             if i < func.param_comptime.len() && func.param_comptime[i] {
                                 // The argument should be a TypeConst - extract the concrete type
-                                if let InferType::Concrete(Type::ComptimeType) = &arg_info.ty {
+                                if let InferType::Concrete(Type::COMPTIME_TYPE) = &arg_info.ty {
                                     // This is a type value - get the actual type from the RIR
                                     let arg_inst = self.rir.get(arg.value);
                                     if let rue_rir::InstData::TypeConst { type_name } =
@@ -534,9 +526,9 @@ impl<'a> ConstraintGenerator<'a> {
                                             "u16" => Type::U16,
                                             "u32" => Type::U32,
                                             "u64" => Type::U64,
-                                            "bool" => Type::Bool,
-                                            "()" => Type::Unit,
-                                            _ => Type::Error, // Unknown type
+                                            "bool" => Type::BOOL,
+                                            "()" => Type::UNIT,
+                                            _ => Type::ERROR, // Unknown type
                                         };
                                         if i < func.param_names.len() {
                                             type_subst.insert(func.param_names[i], concrete_ty);
@@ -548,7 +540,7 @@ impl<'a> ConstraintGenerator<'a> {
 
                         // Compute the actual return type by substituting type parameters
                         let return_type =
-                            if func.return_type == InferType::Concrete(Type::ComptimeType) {
+                            if func.return_type == InferType::Concrete(Type::COMPTIME_TYPE) {
                                 // Return type is a type parameter - look it up in substitutions
                                 if let Some(&concrete_ty) = type_subst.get(&func.return_type_sym) {
                                     InferType::Concrete(concrete_ty)
@@ -587,7 +579,7 @@ impl<'a> ConstraintGenerator<'a> {
                     for arg in args.iter() {
                         self.generate(arg.value, ctx);
                     }
-                    InferType::Concrete(Type::Error)
+                    InferType::Concrete(Type::ERROR)
                 }
             }
 
@@ -619,10 +611,10 @@ impl<'a> ConstraintGenerator<'a> {
                             InferType::Concrete(string_ty)
                         } else {
                             // Fallback if String struct not found
-                            InferType::Concrete(Type::Error)
+                            InferType::Concrete(Type::ERROR)
                         }
                     } else {
-                        InferType::Concrete(Type::Error)
+                        InferType::Concrete(Type::ERROR)
                     }
                 } else if intrinsic_name == "parse_i32" {
                     // @parse_i32: takes a String, returns i32
@@ -671,13 +663,13 @@ impl<'a> ConstraintGenerator<'a> {
                     for arg_ref in args.iter() {
                         self.generate(*arg_ref, ctx);
                     }
-                    InferType::Concrete(Type::Unit)
+                    InferType::Concrete(Type::UNIT)
                 } else if intrinsic_name == "is_null" {
                     // @is_null: takes a pointer, returns bool
                     for arg_ref in args.iter() {
                         self.generate(*arg_ref, ctx);
                     }
-                    InferType::Concrete(Type::Bool)
+                    InferType::Concrete(Type::BOOL)
                 } else if intrinsic_name == "ptr_read" {
                     // @ptr_read: takes ptr const T or ptr mut T, returns T
                     // The return type depends on the pointee type of the argument.
@@ -718,17 +710,17 @@ impl<'a> ConstraintGenerator<'a> {
                     for arg_ref in args.iter() {
                         self.generate(*arg_ref, ctx);
                     }
-                    InferType::Concrete(Type::Unit)
+                    InferType::Concrete(Type::UNIT)
                 } else if intrinsic_name == "target_arch" {
                     // @target_arch: returns Arch enum
                     if let Some(arch_spur) = self.interner.get("Arch") {
                         if let Some(&arch_ty) = self.enums.get(&arch_spur) {
                             InferType::Concrete(arch_ty)
                         } else {
-                            InferType::Concrete(Type::Error)
+                            InferType::Concrete(Type::ERROR)
                         }
                     } else {
-                        InferType::Concrete(Type::Error)
+                        InferType::Concrete(Type::ERROR)
                     }
                 } else if intrinsic_name == "target_os" {
                     // @target_os: returns Os enum
@@ -736,10 +728,10 @@ impl<'a> ConstraintGenerator<'a> {
                         if let Some(&os_ty) = self.enums.get(&os_spur) {
                             InferType::Concrete(os_ty)
                         } else {
-                            InferType::Concrete(Type::Error)
+                            InferType::Concrete(Type::ERROR)
                         }
                     } else {
-                        InferType::Concrete(Type::Error)
+                        InferType::Concrete(Type::ERROR)
                     }
                 } else {
                     // Generate constraints for arguments (they need to be processed)
@@ -747,7 +739,7 @@ impl<'a> ConstraintGenerator<'a> {
                         self.generate(*arg_ref, ctx);
                     }
                     // @dbg and other intrinsics return Unit
-                    InferType::Concrete(Type::Unit)
+                    InferType::Concrete(Type::UNIT)
                 }
             }
 
@@ -763,7 +755,7 @@ impl<'a> ConstraintGenerator<'a> {
             // Block
             InstData::Block { extra_start, len } => {
                 ctx.push_scope();
-                let mut last_ty = InferType::Concrete(Type::Unit);
+                let mut last_ty = InferType::Concrete(Type::UNIT);
                 let block_insts = self.rir.get_extra(*extra_start, *len);
                 for &inst_raw in block_insts {
                     let block_inst_ref = InstRef::from_raw(inst_raw);
@@ -783,7 +775,7 @@ impl<'a> ConstraintGenerator<'a> {
                 let cond_info = self.generate(*cond, ctx);
                 self.add_constraint(Constraint::equal(
                     cond_info.ty,
-                    InferType::Concrete(Type::Bool),
+                    InferType::Concrete(Type::BOOL),
                     cond_info.span,
                 ));
 
@@ -796,13 +788,13 @@ impl<'a> ConstraintGenerator<'a> {
                     // - If one branch is Never, the if-else takes the other branch's type
                     // - If both are Never, the result is Never
                     // - Otherwise, both must unify to the same type
-                    let then_is_never = matches!(&then_info.ty, InferType::Concrete(Type::Never));
-                    let else_is_never = matches!(&else_info.ty, InferType::Concrete(Type::Never));
+                    let then_is_never = matches!(&then_info.ty, InferType::Concrete(Type::NEVER));
+                    let else_is_never = matches!(&else_info.ty, InferType::Concrete(Type::NEVER));
 
                     match (then_is_never, else_is_never) {
                         (true, true) => {
                             // Both diverge - result is Never
-                            InferType::Concrete(Type::Never)
+                            InferType::Concrete(Type::NEVER)
                         }
                         (true, false) => {
                             // Then diverges - result is else type
@@ -832,7 +824,7 @@ impl<'a> ConstraintGenerator<'a> {
                 } else {
                     // No else branch - the if expression has unit type
                     // (or the then branch type if it's unit-compatible)
-                    InferType::Concrete(Type::Unit)
+                    InferType::Concrete(Type::UNIT)
                 }
             }
 
@@ -841,7 +833,7 @@ impl<'a> ConstraintGenerator<'a> {
                 let cond_info = self.generate(*cond, ctx);
                 self.add_constraint(Constraint::equal(
                     cond_info.ty,
-                    InferType::Concrete(Type::Bool),
+                    InferType::Concrete(Type::BOOL),
                     cond_info.span,
                 ));
 
@@ -850,7 +842,7 @@ impl<'a> ConstraintGenerator<'a> {
                 ctx.loop_depth -= 1;
 
                 // Loops produce unit
-                InferType::Concrete(Type::Unit)
+                InferType::Concrete(Type::UNIT)
             }
 
             // Infinite loop
@@ -860,11 +852,11 @@ impl<'a> ConstraintGenerator<'a> {
                 ctx.loop_depth -= 1;
 
                 // Infinite loop without break never returns
-                InferType::Concrete(Type::Never)
+                InferType::Concrete(Type::NEVER)
             }
 
             // Break/Continue
-            InstData::Break | InstData::Continue => InferType::Concrete(Type::Never),
+            InstData::Break | InstData::Continue => InferType::Concrete(Type::NEVER),
 
             // Match expression
             InstData::Match {
@@ -895,12 +887,12 @@ impl<'a> ConstraintGenerator<'a> {
                 // Filter out Never arms and use the remaining non-Never types
                 let non_never_arms: Vec<_> = arm_types
                     .iter()
-                    .filter(|info| !matches!(&info.ty, InferType::Concrete(Type::Never)))
+                    .filter(|info| !matches!(&info.ty, InferType::Concrete(Type::NEVER)))
                     .collect();
 
                 if non_never_arms.is_empty() {
                     // All arms diverge - result is Never
-                    InferType::Concrete(Type::Never)
+                    InferType::Concrete(Type::NEVER)
                 } else {
                     // Create constraints for non-Never arms to have the same type
                     let result_var = self.fresh_var();
@@ -937,7 +929,7 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                     InferType::Concrete(struct_ty)
                 } else {
-                    InferType::Concrete(Type::Error)
+                    InferType::Concrete(Type::ERROR)
                 }
             }
 
@@ -960,7 +952,7 @@ impl<'a> ConstraintGenerator<'a> {
             } => {
                 self.generate(*base, ctx);
                 self.generate(*value, ctx);
-                InferType::Concrete(Type::Unit)
+                InferType::Concrete(Type::UNIT)
             }
 
             // Enum variant
@@ -968,7 +960,7 @@ impl<'a> ConstraintGenerator<'a> {
                 if let Some(&enum_ty) = self.enums.get(type_name) {
                     InferType::Concrete(enum_ty)
                 } else {
-                    InferType::Concrete(Type::Error)
+                    InferType::Concrete(Type::ERROR)
                 }
             }
 
@@ -1044,7 +1036,7 @@ impl<'a> ConstraintGenerator<'a> {
                     ));
                 }
 
-                InferType::Concrete(Type::Unit)
+                InferType::Concrete(Type::UNIT)
             }
 
             // Type declarations don't produce values
@@ -1052,7 +1044,7 @@ impl<'a> ConstraintGenerator<'a> {
             | InstData::StructDecl { .. }
             | InstData::EnumDecl { .. }
             | InstData::DropFnDecl { .. }
-            | InstData::ConstDecl { .. } => InferType::Concrete(Type::Unit),
+            | InstData::ConstDecl { .. } => InferType::Concrete(Type::UNIT),
 
             // Method call: receiver.method(args)
             InstData::MethodCall {
@@ -1090,21 +1082,21 @@ impl<'a> ConstraintGenerator<'a> {
                             for arg in args.iter() {
                                 self.generate(arg.value, ctx);
                             }
-                            InferType::Concrete(Type::Error)
+                            InferType::Concrete(Type::ERROR)
                         }
                     } else {
                         // Non-struct receiver - sema will report the error
                         for arg in args.iter() {
                             self.generate(arg.value, ctx);
                         }
-                        InferType::Concrete(Type::Error)
+                        InferType::Concrete(Type::ERROR)
                     }
                 } else {
                     // Non-concrete type - generate args and return error
                     for arg in args.iter() {
                         self.generate(arg.value, ctx);
                     }
-                    InferType::Concrete(Type::Error)
+                    InferType::Concrete(Type::ERROR)
                 };
 
                 result_type
@@ -1139,14 +1131,14 @@ impl<'a> ConstraintGenerator<'a> {
                         for arg in args.iter() {
                             self.generate(arg.value, ctx);
                         }
-                        InferType::Concrete(Type::Error)
+                        InferType::Concrete(Type::ERROR)
                     }
                 } else {
                     // Type not found - sema will report the error
                     for arg in args.iter() {
                         self.generate(arg.value, ctx);
                     }
-                    InferType::Concrete(Type::Error)
+                    InferType::Concrete(Type::ERROR)
                 };
                 result_type
             }
@@ -1178,11 +1170,11 @@ impl<'a> ConstraintGenerator<'a> {
 
             // Type constant: a type used as a value (e.g., `i32` in `identity(i32, 42)`)
             // This has the special ComptimeType type which indicates it's a type value.
-            InstData::TypeConst { .. } => InferType::Concrete(Type::ComptimeType),
+            InstData::TypeConst { .. } => InferType::Concrete(Type::COMPTIME_TYPE),
 
             // Anonymous struct type: a struct type used as a comptime value
             // This also has the ComptimeType type.
-            InstData::AnonStructType { .. } => InferType::Concrete(Type::ComptimeType),
+            InstData::AnonStructType { .. } => InferType::Concrete(Type::COMPTIME_TYPE),
         };
 
         // Record the type for this expression
@@ -1231,12 +1223,12 @@ impl<'a> ConstraintGenerator<'a> {
                 InferType::Var(var)
             }
             rue_rir::RirPattern::Int(_, _) => InferType::IntLiteral,
-            rue_rir::RirPattern::Bool(_, _) => InferType::Concrete(Type::Bool),
+            rue_rir::RirPattern::Bool(_, _) => InferType::Concrete(Type::BOOL),
             rue_rir::RirPattern::Path { type_name, .. } => {
                 if let Some(&enum_ty) = self.enums.get(type_name) {
                     InferType::Concrete(enum_ty)
                 } else {
-                    InferType::Concrete(Type::Error)
+                    InferType::Concrete(Type::ERROR)
                 }
             }
         }
@@ -1266,8 +1258,8 @@ impl<'a> ConstraintGenerator<'a> {
             "u16" => Type::U16,
             "u32" => Type::U32,
             "u64" => Type::U64,
-            "bool" => Type::Bool,
-            "()" => Type::Unit,
+            "bool" => Type::BOOL,
+            "()" => Type::UNIT,
             _ => {
                 // Check for struct types (including builtin String)
                 if let Some(name_spur) = self.interner.get(name) {
@@ -1342,11 +1334,11 @@ mod tests {
         let mut cgen =
             ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
-        let mut ctx = ConstraintContext::new(&params, Type::Bool);
+        let mut ctx = ConstraintContext::new(&params, Type::BOOL);
 
         let info = cgen.generate(inst_ref, &mut ctx);
 
-        assert_eq!(info.ty, InferType::Concrete(Type::Bool));
+        assert_eq!(info.ty, InferType::Concrete(Type::BOOL));
         assert_eq!(cgen.constraints().len(), 0);
     }
 
@@ -1415,12 +1407,12 @@ mod tests {
         let mut cgen =
             ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
-        let mut ctx = ConstraintContext::new(&params, Type::Bool);
+        let mut ctx = ConstraintContext::new(&params, Type::BOOL);
 
         let info = cgen.generate(lt, &mut ctx);
 
         // Comparisons always return Bool
-        assert_eq!(info.ty, InferType::Concrete(Type::Bool));
+        assert_eq!(info.ty, InferType::Concrete(Type::BOOL));
         // Should generate 1 constraint: lhs type = rhs type
         assert_eq!(cgen.constraints().len(), 1);
     }
@@ -1450,12 +1442,12 @@ mod tests {
         let mut cgen =
             ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
-        let mut ctx = ConstraintContext::new(&params, Type::Bool);
+        let mut ctx = ConstraintContext::new(&params, Type::BOOL);
 
         let info = cgen.generate(and, &mut ctx);
 
         // Logical operators return Bool
-        assert_eq!(info.ty, InferType::Concrete(Type::Bool));
+        assert_eq!(info.ty, InferType::Concrete(Type::BOOL));
         // Should generate 2 constraints: lhs = bool, rhs = bool
         assert_eq!(cgen.constraints().len(), 2);
     }
@@ -1522,7 +1514,7 @@ mod tests {
         let info = cgen.generate(ret, &mut ctx);
 
         // Return is divergent (Never type)
-        assert_eq!(info.ty, InferType::Concrete(Type::Never));
+        assert_eq!(info.ty, InferType::Concrete(Type::NEVER));
         // Should generate 1 constraint: return value = return type
         assert_eq!(cgen.constraints().len(), 1);
     }
@@ -1595,12 +1587,12 @@ mod tests {
         let mut cgen =
             ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
-        let mut ctx = ConstraintContext::new(&params, Type::Unit);
+        let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
         let info = cgen.generate(loop_inst, &mut ctx);
 
         // While loops produce Unit
-        assert_eq!(info.ty, InferType::Concrete(Type::Unit));
+        assert_eq!(info.ty, InferType::Concrete(Type::UNIT));
         // Should generate 1 constraint: cond = bool
         assert_eq!(cgen.constraints().len(), 1);
     }
@@ -1673,7 +1665,7 @@ mod tests {
         let sig = make_test_func_sig(
             vec![
                 InferType::Concrete(Type::I32),
-                InferType::Concrete(Type::Bool),
+                InferType::Concrete(Type::BOOL),
             ],
             InferType::Concrete(Type::I64),
         );
@@ -1702,12 +1694,12 @@ mod tests {
         let mut cgen =
             ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
-        let mut ctx = ConstraintContext::new(&params, Type::Unit);
+        let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
         let info = cgen.generate(loop_inst, &mut ctx);
 
         // Infinite loop produces Never (diverges)
-        assert_eq!(info.ty, InferType::Concrete(Type::Never));
+        assert_eq!(info.ty, InferType::Concrete(Type::NEVER));
         // No constraints for infinite loop itself
         assert_eq!(cgen.constraints().len(), 0);
     }
@@ -1728,12 +1720,12 @@ mod tests {
         let mut cgen =
             ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
-        let mut ctx = ConstraintContext::new(&params, Type::Unit);
+        let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
         let info = cgen.generate(break_inst, &mut ctx);
 
         // Break diverges
-        assert_eq!(info.ty, InferType::Concrete(Type::Never));
+        assert_eq!(info.ty, InferType::Concrete(Type::NEVER));
         assert_eq!(cgen.constraints().len(), 0);
     }
 
@@ -1805,12 +1797,12 @@ mod tests {
         let mut cgen =
             ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
-        let mut ctx = ConstraintContext::new(&params, Type::Unit);
+        let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
         let info = cgen.generate(index_set, &mut ctx);
 
         // Index assignment produces Unit
-        assert_eq!(info.ty, InferType::Concrete(Type::Unit));
+        assert_eq!(info.ty, InferType::Concrete(Type::UNIT));
         // Should generate 1 constraint: index must be unsigned
         assert_eq!(cgen.constraints().len(), 1);
         match &cgen.constraints()[0] {
@@ -1839,12 +1831,12 @@ mod tests {
         let mut cgen =
             ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
-        let mut ctx = ConstraintContext::new(&params, Type::Unit);
+        let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
         let info = cgen.generate(block, &mut ctx);
 
         // Empty block produces Unit
-        assert_eq!(info.ty, InferType::Concrete(Type::Unit));
+        assert_eq!(info.ty, InferType::Concrete(Type::UNIT));
         assert_eq!(cgen.constraints().len(), 0);
     }
 
@@ -1900,7 +1892,7 @@ mod tests {
                     InferType::Concrete(Type::I32),
                     InferType::Concrete(Type::I32),
                 ],
-                InferType::Concrete(Type::Bool),
+                InferType::Concrete(Type::BOOL),
             ),
         );
 
@@ -1925,12 +1917,12 @@ mod tests {
         let mut cgen =
             ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
         let params = HashMap::new();
-        let mut ctx = ConstraintContext::new(&params, Type::Bool);
+        let mut ctx = ConstraintContext::new(&params, Type::BOOL);
 
         let info = cgen.generate(call, &mut ctx);
 
         // Should still return the declared return type
-        assert_eq!(info.ty, InferType::Concrete(Type::Bool));
+        assert_eq!(info.ty, InferType::Concrete(Type::BOOL));
         // No constraints generated when arg count mismatches (error will be in sema)
         assert_eq!(cgen.constraints().len(), 0);
     }
@@ -1970,7 +1962,7 @@ mod tests {
         let info = cgen.generate(call, &mut ctx);
 
         // Unknown function returns Error type
-        assert_eq!(info.ty, InferType::Concrete(Type::Error));
+        assert_eq!(info.ty, InferType::Concrete(Type::ERROR));
         // Arguments should still be processed (but no constraints generated for them)
         assert_eq!(cgen.constraints().len(), 0);
     }

--- a/crates/rue-air/src/inference/types.rs
+++ b/crates/rue-air/src/inference/types.rs
@@ -56,7 +56,7 @@ pub enum InferType {
 
     /// An array type during inference.
     ///
-    /// Unlike `Concrete(Type::Array(id))`, this stores the element type as an
+    /// Unlike `Concrete(Type::new_array(id))`, this stores the element type as an
     /// `InferType` so we can handle cases where the element type is still a
     /// type variable. After unification, these are converted to `Type::Array`.
     Array {

--- a/crates/rue-air/src/inference/unify.rs
+++ b/crates/rue-air/src/inference/unify.rs
@@ -302,7 +302,7 @@ impl Unifier {
             // Type variables and IntLiteral are OK - they will be resolved to integers
             InferType::Var(_) | InferType::IntLiteral => UnifyResult::Ok,
             // Arrays are not integers - return error
-            InferType::Array { .. } => UnifyResult::NotInteger { ty: Type::Error },
+            InferType::Array { .. } => UnifyResult::NotInteger { ty: Type::ERROR },
         }
     }
 
@@ -329,7 +329,7 @@ impl Unifier {
             // IntLiteral can be used as unsigned - it will be inferred to u64
             InferType::IntLiteral => UnifyResult::Ok,
             // Arrays are not unsigned integers
-            InferType::Array { .. } => UnifyResult::NotUnsigned { ty: Type::Error },
+            InferType::Array { .. } => UnifyResult::NotUnsigned { ty: Type::ERROR },
         }
     }
 
@@ -340,7 +340,7 @@ impl Unifier {
     ///
     /// On error, the unifier continues processing remaining constraints to catch
     /// as many errors as possible in one pass. Type variables involved in errors
-    /// are bound to `Type::Error` for recovery.
+    /// are bound to `Type::ERROR` for recovery.
     ///
     /// Returns a list of errors (empty if all constraints were satisfied).
     pub fn solve_constraints(&mut self, constraints: &[Constraint]) -> Vec<UnificationError> {
@@ -412,11 +412,11 @@ impl Unifier {
         // Bind any unbound type variables to Error for recovery
         if let InferType::Var(var) = lhs_applied {
             self.substitution
-                .insert(var, InferType::Concrete(Type::Error));
+                .insert(var, InferType::Concrete(Type::ERROR));
         }
         if let InferType::Var(var) = rhs_applied {
             self.substitution
-                .insert(var, InferType::Concrete(Type::Error));
+                .insert(var, InferType::Concrete(Type::ERROR));
         }
     }
 
@@ -481,14 +481,14 @@ impl Unifier {
 
     /// Resolve a type to its final concrete type, with error recovery.
     ///
-    /// Like `resolve`, but returns `Type::Error` instead of `None` for
+    /// Like `resolve`, but returns `Type::ERROR` instead of `None` for
     /// unbound type variables. This allows compilation to continue
     /// with error recovery.
     ///
-    /// Note: For arrays, this returns `Type::Error`. Use `resolve_infer_type`
+    /// Note: For arrays, this returns `Type::ERROR`. Use `resolve_infer_type`
     /// and handle `InferType::Array` explicitly to create proper ArrayTypeIds.
     pub fn resolve_or_error(&self, ty: &InferType) -> Type {
-        self.resolve(ty).unwrap_or(Type::Error)
+        self.resolve(ty).unwrap_or(Type::ERROR)
     }
 }
 
@@ -522,13 +522,13 @@ mod tests {
         let mut unifier = Unifier::new();
         let v0 = TypeVarId::new(0);
 
-        let result = unifier.unify(&InferType::Var(v0), &InferType::Concrete(Type::Bool));
+        let result = unifier.unify(&InferType::Var(v0), &InferType::Concrete(Type::BOOL));
         assert!(result.is_ok());
 
         // Variable should now be bound to Bool
         assert_eq!(
             unifier.substitution.apply(&InferType::Var(v0)),
-            InferType::Concrete(Type::Bool)
+            InferType::Concrete(Type::BOOL)
         );
     }
 
@@ -542,7 +542,7 @@ mod tests {
     #[test]
     fn test_unify_int_literal_with_non_integer() {
         let mut unifier = Unifier::new();
-        let result = unifier.unify(&InferType::IntLiteral, &InferType::Concrete(Type::Bool));
+        let result = unifier.unify(&InferType::IntLiteral, &InferType::Concrete(Type::BOOL));
         assert!(!result.is_ok());
         assert!(matches!(result, UnifyResult::IntLiteralNonInteger { .. }));
     }
@@ -558,7 +558,7 @@ mod tests {
     fn test_unify_never_coerces() {
         let mut unifier = Unifier::new();
         let result = unifier.unify(
-            &InferType::Concrete(Type::Never),
+            &InferType::Concrete(Type::NEVER),
             &InferType::Concrete(Type::I32),
         );
         assert!(result.is_ok());
@@ -568,8 +568,8 @@ mod tests {
     fn test_unify_error_coerces() {
         let mut unifier = Unifier::new();
         let result = unifier.unify(
-            &InferType::Concrete(Type::Error),
-            &InferType::Concrete(Type::Bool),
+            &InferType::Concrete(Type::ERROR),
+            &InferType::Concrete(Type::BOOL),
         );
         assert!(result.is_ok());
     }
@@ -611,8 +611,8 @@ mod tests {
     #[test]
     fn test_resolve_concrete() {
         let unifier = Unifier::new();
-        let ty = InferType::Concrete(Type::Bool);
-        assert_eq!(unifier.resolve(&ty), Some(Type::Bool));
+        let ty = InferType::Concrete(Type::BOOL);
+        assert_eq!(unifier.resolve(&ty), Some(Type::BOOL));
     }
 
     #[test]
@@ -722,9 +722,9 @@ mod tests {
     #[test]
     fn test_check_integer_with_non_integer_type() {
         let unifier = Unifier::new();
-        let result = unifier.check_integer(&InferType::Concrete(Type::Bool));
+        let result = unifier.check_integer(&InferType::Concrete(Type::BOOL));
         assert!(!result.is_ok());
-        assert!(matches!(result, UnifyResult::NotInteger { ty: Type::Bool }));
+        assert!(matches!(result, UnifyResult::NotInteger { ty: Type::BOOL }));
     }
 
     #[test]
@@ -751,7 +751,7 @@ mod tests {
         // Error type is OK - for error recovery
         assert!(
             unifier
-                .check_integer(&InferType::Concrete(Type::Error))
+                .check_integer(&InferType::Concrete(Type::ERROR))
                 .is_ok()
         );
     }
@@ -786,15 +786,15 @@ mod tests {
             Constraint::equal(InferType::Var(v0), InferType::Var(v1), Span::new(0, 5)),
             Constraint::equal(
                 InferType::Var(v1),
-                InferType::Concrete(Type::Bool),
+                InferType::Concrete(Type::BOOL),
                 Span::new(6, 10),
             ),
         ];
         let errors = unifier.solve_constraints(&constraints);
         assert!(errors.is_empty());
         // Both variables should resolve to Bool
-        assert_eq!(unifier.resolve(&InferType::Var(v0)), Some(Type::Bool));
-        assert_eq!(unifier.resolve(&InferType::Var(v1)), Some(Type::Bool));
+        assert_eq!(unifier.resolve(&InferType::Var(v0)), Some(Type::BOOL));
+        assert_eq!(unifier.resolve(&InferType::Var(v1)), Some(Type::BOOL));
     }
 
     #[test]
@@ -802,7 +802,7 @@ mod tests {
         let mut unifier = Unifier::new();
         let constraints = vec![Constraint::equal(
             InferType::Concrete(Type::I32),
-            InferType::Concrete(Type::Bool),
+            InferType::Concrete(Type::BOOL),
             Span::new(0, 5),
         )];
         let errors = unifier.solve_constraints(&constraints);
@@ -870,14 +870,14 @@ mod tests {
     fn test_solve_constraints_is_integer_fails_for_bool() {
         let mut unifier = Unifier::new();
         let constraints = vec![Constraint::is_integer(
-            InferType::Concrete(Type::Bool),
+            InferType::Concrete(Type::BOOL),
             Span::new(0, 5),
         )];
         let errors = unifier.solve_constraints(&constraints);
         assert_eq!(errors.len(), 1);
         assert!(matches!(
             errors[0].kind,
-            UnifyResult::NotInteger { ty: Type::Bool }
+            UnifyResult::NotInteger { ty: Type::BOOL }
         ));
     }
 
@@ -887,7 +887,7 @@ mod tests {
         let constraints = vec![
             Constraint::equal(
                 InferType::Concrete(Type::I32),
-                InferType::Concrete(Type::Bool),
+                InferType::Concrete(Type::BOOL),
                 Span::new(0, 5),
             ),
             Constraint::is_signed(InferType::Concrete(Type::U64), Span::new(10, 15)),
@@ -910,7 +910,7 @@ mod tests {
             ),
             Constraint::equal(
                 InferType::Var(v0),
-                InferType::Concrete(Type::Bool),
+                InferType::Concrete(Type::BOOL),
                 Span::new(6, 10),
             ),
         ];
@@ -932,7 +932,7 @@ mod tests {
         // v2 is bound to Bool
         unifier
             .substitution
-            .insert(v2, InferType::Concrete(Type::Bool));
+            .insert(v2, InferType::Concrete(Type::BOOL));
 
         // Track v0 and v1 as int literal vars
         let int_literal_vars = vec![v0, v1];
@@ -943,7 +943,7 @@ mod tests {
         assert_eq!(unifier.resolve(&InferType::Var(v0)), Some(Type::I32));
         assert_eq!(unifier.resolve(&InferType::Var(v1)), Some(Type::I32));
         // v2 should still be Bool
-        assert_eq!(unifier.resolve(&InferType::Var(v2)), Some(Type::Bool));
+        assert_eq!(unifier.resolve(&InferType::Var(v2)), Some(Type::BOOL));
     }
 
     #[test]
@@ -961,7 +961,7 @@ mod tests {
         let unifier = Unifier::new();
         let v0 = TypeVarId::new(0);
         // Unbound variable should return Error
-        assert_eq!(unifier.resolve_or_error(&InferType::Var(v0)), Type::Error);
+        assert_eq!(unifier.resolve_or_error(&InferType::Var(v0)), Type::ERROR);
     }
 
     #[test]
@@ -976,7 +976,7 @@ mod tests {
         let error = UnificationError::new(
             UnifyResult::TypeMismatch {
                 expected: InferType::Concrete(Type::I32),
-                found: InferType::Concrete(Type::Bool),
+                found: InferType::Concrete(Type::BOOL),
             },
             Span::new(10, 20),
         );
@@ -989,7 +989,7 @@ mod tests {
     #[test]
     fn test_unification_error_int_literal_non_integer_message() {
         let error = UnificationError::new(
-            UnifyResult::IntLiteralNonInteger { found: Type::Bool },
+            UnifyResult::IntLiteralNonInteger { found: Type::BOOL },
             Span::new(0, 5),
         );
         let msg = error.message();
@@ -1009,7 +1009,7 @@ mod tests {
     #[test]
     fn test_unification_error_not_integer_message() {
         let error =
-            UnificationError::new(UnifyResult::NotInteger { ty: Type::Bool }, Span::new(0, 5));
+            UnificationError::new(UnifyResult::NotInteger { ty: Type::BOOL }, Span::new(0, 5));
         let msg = error.message();
         assert!(msg.contains("expected integer"));
         assert!(msg.contains("bool"));
@@ -1020,14 +1020,14 @@ mod tests {
         let mut unifier = Unifier::new();
         let constraints = vec![Constraint::equal(
             InferType::IntLiteral,
-            InferType::Concrete(Type::Bool),
+            InferType::Concrete(Type::BOOL),
             Span::new(0, 5),
         )];
         let errors = unifier.solve_constraints(&constraints);
         assert_eq!(errors.len(), 1);
         assert!(matches!(
             errors[0].kind,
-            UnifyResult::IntLiteralNonInteger { found: Type::Bool }
+            UnifyResult::IntLiteralNonInteger { found: Type::BOOL }
         ));
     }
 
@@ -1126,11 +1126,11 @@ mod tests {
     #[test]
     fn test_check_unsigned_with_non_integer_type() {
         let unifier = Unifier::new();
-        let result = unifier.check_unsigned(&InferType::Concrete(Type::Bool));
+        let result = unifier.check_unsigned(&InferType::Concrete(Type::BOOL));
         assert!(!result.is_ok());
         assert!(matches!(
             result,
-            UnifyResult::NotUnsigned { ty: Type::Bool }
+            UnifyResult::NotUnsigned { ty: Type::BOOL }
         ));
     }
 
@@ -1199,7 +1199,7 @@ mod tests {
             length: 3,
         };
         let arr2 = InferType::Array {
-            element: Box::new(InferType::Concrete(Type::Bool)),
+            element: Box::new(InferType::Concrete(Type::BOOL)),
             length: 3,
         };
         let result = unifier.unify(&arr1, &arr2);

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -642,7 +642,7 @@ pub enum AirInstData {
     /// Type constant - a compile-time type value.
     /// This is used for comptime type parameters (e.g., passing `i32` to `fn foo(comptime T: type)`).
     /// The contained Type is the type being passed as a value.
-    /// This instruction has type `Type::ComptimeType` and is erased during specialization.
+    /// This instruction has type `Type::COMPTIME_TYPE` and is erased during specialization.
     TypeConst(crate::Type),
 
     // Binary arithmetic operations
@@ -873,7 +873,7 @@ pub enum AirInstData {
 
     // Array operations
     /// Create a new array with initialized elements.
-    /// The array type is stored in `AirInst.ty` as `Type::Array(...)`.
+    /// The array type is stored in `AirInst.ty` as `Type::new_array(...)`.
     ArrayInit {
         /// Start index into extra array for element refs
         elems_start: u32,

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -771,23 +771,23 @@ impl TypeInternPool {
                 5 => Type::U16,
                 6 => Type::U32,
                 7 => Type::U64,
-                8 => Type::Bool,
-                9 => Type::Unit,
-                10 => Type::Never,
-                11 => Type::Error,
+                8 => Type::BOOL,
+                9 => Type::UNIT,
+                10 => Type::NEVER,
+                11 => Type::ERROR,
                 _ => panic!("Unknown primitive index: {}", ty.0),
             };
         }
 
         let pool_index = ty.pool_index().expect("non-primitive must have pool index");
         match &inner.types[pool_index as usize] {
-            TypeData::Struct(_) => Type::Struct(StructId::from_pool_index(pool_index)),
-            TypeData::Enum(_) => Type::Enum(EnumId::from_pool_index(pool_index)),
-            TypeData::Array { .. } => Type::Array(ArrayTypeId::from_pool_index(pool_index)),
+            TypeData::Struct(_) => Type::new_struct(StructId::from_pool_index(pool_index)),
+            TypeData::Enum(_) => Type::new_enum(EnumId::from_pool_index(pool_index)),
+            TypeData::Array { .. } => Type::new_array(ArrayTypeId::from_pool_index(pool_index)),
             TypeData::PtrConst { .. } => {
-                Type::PtrConst(PtrConstTypeId::from_pool_index(pool_index))
+                Type::new_ptr_const(PtrConstTypeId::from_pool_index(pool_index))
             }
-            TypeData::PtrMut { .. } => Type::PtrMut(PtrMutTypeId::from_pool_index(pool_index)),
+            TypeData::PtrMut { .. } => Type::new_ptr_mut(PtrMutTypeId::from_pool_index(pool_index)),
         }
     }
 
@@ -973,10 +973,10 @@ impl TypeInternPool {
             5 => Type::U16,
             6 => Type::U32,
             7 => Type::U64,
-            8 => Type::Bool,
-            9 => Type::Unit,
-            10 => Type::Never,
-            11 => Type::Error,
+            8 => Type::BOOL,
+            9 => Type::UNIT,
+            10 => Type::NEVER,
+            11 => Type::ERROR,
             _ => return None,
         })
     }
@@ -1511,28 +1511,28 @@ mod tests {
         assert_eq!(pool.type_to_interned(Type::U16), Some(InternedType::U16));
         assert_eq!(pool.type_to_interned(Type::U32), Some(InternedType::U32));
         assert_eq!(pool.type_to_interned(Type::U64), Some(InternedType::U64));
-        assert_eq!(pool.type_to_interned(Type::Bool), Some(InternedType::BOOL));
-        assert_eq!(pool.type_to_interned(Type::Unit), Some(InternedType::UNIT));
+        assert_eq!(pool.type_to_interned(Type::BOOL), Some(InternedType::BOOL));
+        assert_eq!(pool.type_to_interned(Type::UNIT), Some(InternedType::UNIT));
         assert_eq!(
-            pool.type_to_interned(Type::Never),
+            pool.type_to_interned(Type::NEVER),
             Some(InternedType::NEVER)
         );
         assert_eq!(
-            pool.type_to_interned(Type::Error),
+            pool.type_to_interned(Type::ERROR),
             Some(InternedType::ERROR)
         );
 
         // Composite types return None (need name lookup)
         assert!(
-            pool.type_to_interned(Type::Struct(crate::types::StructId(0)))
+            pool.type_to_interned(Type::new_struct(crate::types::StructId(0)))
                 .is_none()
         );
         assert!(
-            pool.type_to_interned(Type::Enum(crate::types::EnumId(0)))
+            pool.type_to_interned(Type::new_enum(crate::types::EnumId(0)))
                 .is_none()
         );
         assert!(
-            pool.type_to_interned(Type::Array(crate::types::ArrayTypeId(0)))
+            pool.type_to_interned(Type::new_array(crate::types::ArrayTypeId(0)))
                 .is_none()
         );
     }
@@ -1550,15 +1550,15 @@ mod tests {
         assert_eq!(pool.interned_to_type(InternedType::U16), Some(Type::U16));
         assert_eq!(pool.interned_to_type(InternedType::U32), Some(Type::U32));
         assert_eq!(pool.interned_to_type(InternedType::U64), Some(Type::U64));
-        assert_eq!(pool.interned_to_type(InternedType::BOOL), Some(Type::Bool));
-        assert_eq!(pool.interned_to_type(InternedType::UNIT), Some(Type::Unit));
+        assert_eq!(pool.interned_to_type(InternedType::BOOL), Some(Type::BOOL));
+        assert_eq!(pool.interned_to_type(InternedType::UNIT), Some(Type::UNIT));
         assert_eq!(
             pool.interned_to_type(InternedType::NEVER),
-            Some(Type::Never)
+            Some(Type::NEVER)
         );
         assert_eq!(
             pool.interned_to_type(InternedType::ERROR),
-            Some(Type::Error)
+            Some(Type::ERROR)
         );
 
         // Composite types return None

--- a/crates/rue-air/src/param_arena.rs
+++ b/crates/rue-air/src/param_arena.rs
@@ -354,7 +354,7 @@ mod tests {
 
         let range = arena.alloc(
             [x, y, z],
-            [Type::I32, Type::Bool, Type::I64],
+            [Type::I32, Type::BOOL, Type::I64],
             [
                 RirParamMode::Normal,
                 RirParamMode::Inout,
@@ -364,7 +364,7 @@ mod tests {
         );
 
         assert_eq!(range.len(), 3);
-        assert_eq!(arena.types(range), &[Type::I32, Type::Bool, Type::I64]);
+        assert_eq!(arena.types(range), &[Type::I32, Type::BOOL, Type::I64]);
         assert_eq!(
             arena.modes(range),
             &[
@@ -393,7 +393,7 @@ mod tests {
 
         // Second function with 1 param
         let c = make_spur(&mut rodeo, "c");
-        let range2 = arena.alloc([c], [Type::Bool], [RirParamMode::Inout], [false]);
+        let range2 = arena.alloc([c], [Type::BOOL], [RirParamMode::Inout], [false]);
 
         // Verify they don't overlap
         assert_eq!(range1.len(), 2);
@@ -402,7 +402,7 @@ mod tests {
 
         // Verify data is correct for each range
         assert_eq!(arena.types(range1), &[Type::I32, Type::I32]);
-        assert_eq!(arena.types(range2), &[Type::Bool]);
+        assert_eq!(arena.types(range2), &[Type::BOOL]);
     }
 
     #[test]
@@ -413,11 +413,11 @@ mod tests {
         let x = make_spur(&mut rodeo, "x");
         let y = make_spur(&mut rodeo, "y");
 
-        let range = arena.alloc_method([x, y], [Type::I32, Type::Bool]);
+        let range = arena.alloc_method([x, y], [Type::I32, Type::BOOL]);
 
         assert_eq!(range.len(), 2);
         assert_eq!(arena.names(range), &[x, y]);
-        assert_eq!(arena.types(range), &[Type::I32, Type::Bool]);
+        assert_eq!(arena.types(range), &[Type::I32, Type::BOOL]);
         // Methods default to Normal mode and non-comptime
         assert_eq!(
             arena.modes(range),
@@ -436,7 +436,7 @@ mod tests {
 
         let range = arena.alloc(
             [x, y],
-            [Type::I32, Type::Bool],
+            [Type::I32, Type::BOOL],
             [RirParamMode::Normal, RirParamMode::Inout],
             [false, true],
         );
@@ -444,7 +444,7 @@ mod tests {
         let items: Vec<_> = arena.iter(range).collect();
         assert_eq!(items.len(), 2);
         assert_eq!(items[0], (&x, &Type::I32, &RirParamMode::Normal, &false));
-        assert_eq!(items[1], (&y, &Type::Bool, &RirParamMode::Inout, &true));
+        assert_eq!(items[1], (&y, &Type::BOOL, &RirParamMode::Inout, &true));
     }
 
     #[test]
@@ -457,13 +457,13 @@ mod tests {
 
         let range = arena.alloc(
             [x, y],
-            [Type::I32, Type::Bool],
+            [Type::I32, Type::BOOL],
             [RirParamMode::Normal, RirParamMode::Normal],
             [false, false],
         );
 
         let pairs: Vec<_> = arena.name_type_pairs(range).collect();
-        assert_eq!(pairs, vec![(&x, &Type::I32), (&y, &Type::Bool)]);
+        assert_eq!(pairs, vec![(&x, &Type::I32), (&y, &Type::BOOL)]);
     }
 
     #[test]
@@ -476,7 +476,7 @@ mod tests {
 
         let range = arena.alloc(
             [x, y],
-            [Type::I32, Type::Bool],
+            [Type::I32, Type::BOOL],
             [RirParamMode::Normal, RirParamMode::Inout],
             [false, false],
         );
@@ -486,7 +486,7 @@ mod tests {
             pairs,
             vec![
                 (&Type::I32, &RirParamMode::Normal),
-                (&Type::Bool, &RirParamMode::Inout)
+                (&Type::BOOL, &RirParamMode::Inout)
             ]
         );
     }

--- a/crates/rue-air/src/scope.rs
+++ b/crates/rue-air/src/scope.rs
@@ -45,14 +45,8 @@ pub trait ScopedContext {
     /// The type of variable information stored for each local.
     type VarInfo: Clone;
 
-    /// Get a reference to the locals map.
-    fn locals(&self) -> &HashMap<Spur, Self::VarInfo>;
-
     /// Get a mutable reference to the locals map.
     fn locals_mut(&mut self) -> &mut HashMap<Spur, Self::VarInfo>;
-
-    /// Get a reference to the scope stack.
-    fn scope_stack(&self) -> &[Vec<(Spur, Option<Self::VarInfo>)>];
 
     /// Get a mutable reference to the scope stack.
     fn scope_stack_mut(&mut self) -> &mut Vec<Vec<(Spur, Option<Self::VarInfo>)>>;
@@ -128,16 +122,8 @@ mod tests {
     impl ScopedContext for TestContext {
         type VarInfo = i32;
 
-        fn locals(&self) -> &HashMap<Spur, Self::VarInfo> {
-            &self.locals
-        }
-
         fn locals_mut(&mut self) -> &mut HashMap<Spur, Self::VarInfo> {
             &mut self.locals
-        }
-
-        fn scope_stack(&self) -> &[Vec<(Spur, Option<Self::VarInfo>)>] {
-            &self.scope_stack
         }
 
         fn scope_stack_mut(&mut self) -> &mut Vec<Vec<(Spur, Option<Self::VarInfo>)>> {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -45,7 +45,7 @@ use crate::inst::{
 };
 use crate::scope::ScopedContext;
 use crate::sema_context::SemaContext;
-use crate::types::{EnumId, StructDef, StructField, StructId, Type, TypeKind};
+use crate::types::{EnumId, StructField, StructId, Type, TypeKind};
 
 /// Try to evaluate an RIR expression as a compile-time constant.
 ///
@@ -220,7 +220,7 @@ fn try_evaluate_const_in_rir(rir: &rue_rir::Rir, inst_ref: InstRef) -> Option<Co
             // the Sema::try_evaluate_const method which has full context.
             // For primitive type checks, this is good enough since the
             // argument is validated at the call site.
-            Some(ConstValue::Type(Type::ComptimeType))
+            Some(ConstValue::Type(Type::COMPTIME_TYPE))
         }
 
         // Everything else requires runtime evaluation
@@ -411,7 +411,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                     continue;
                 }
             };
-            let struct_type = Type::Struct(struct_id);
+            let struct_type = Type::new_struct(struct_id);
 
             let methods = sema.rir.get_inst_refs(*methods_start, *methods_len);
             for method_ref in methods {
@@ -473,7 +473,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                     continue;
                 }
             };
-            let struct_type = Type::Struct(struct_id);
+            let struct_type = Type::new_struct(struct_id);
             let full_name = format!("{}.__drop", type_name_str);
 
             match sema.analyze_destructor_function(
@@ -930,7 +930,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                 Some(id) => *id,
                 None => continue,
             };
-            let struct_type = Type::Struct(struct_id);
+            let struct_type = Type::new_struct(struct_id);
             let full_name = format!("{}.__drop", type_name_str);
 
             match sema.analyze_destructor_function(
@@ -1097,7 +1097,7 @@ fn collect_function_jobs(ctx: &SemaContext<'_>) -> Vec<FunctionJob> {
                 Some(id) => *id,
                 None => continue, // Error will be caught elsewhere
             };
-            let struct_type = Type::Struct(struct_id);
+            let struct_type = Type::new_struct(struct_id);
 
             let methods = ctx.rir.get_inst_refs(*methods_start, *methods_len);
             for method_ref in methods {
@@ -1142,7 +1142,7 @@ fn collect_function_jobs(ctx: &SemaContext<'_>) -> Vec<FunctionJob> {
                 Some(id) => *id,
                 None => continue, // Error will be caught elsewhere
             };
-            let struct_type = Type::Struct(struct_id);
+            let struct_type = Type::new_struct(struct_id);
             let full_name = format!("{}.__drop", type_name_str);
 
             jobs.push(FunctionJob::Destructor {
@@ -1270,7 +1270,7 @@ fn analyze_destructor_function_parallel(
     let param_info: Vec<(Spur, Type, RirParamMode)> =
         vec![(self_sym, struct_type, RirParamMode::Normal)];
 
-    analyze_function_with_context(ctx, full_name, Type::Unit, &param_info, body)
+    analyze_function_with_context(ctx, full_name, Type::UNIT, &param_info, body)
 }
 
 /// Resolve a type symbol using the shared context.
@@ -1287,18 +1287,18 @@ fn resolve_type_from_ctx(ctx: &SemaContext<'_>, type_sym: Spur, span: Span) -> C
         "u16" => return Ok(Type::U16),
         "u32" => return Ok(Type::U32),
         "u64" => return Ok(Type::U64),
-        "bool" => return Ok(Type::Bool),
-        "()" => return Ok(Type::Unit),
-        "!" => return Ok(Type::Never),
+        "bool" => return Ok(Type::BOOL),
+        "()" => return Ok(Type::UNIT),
+        "!" => return Ok(Type::NEVER),
         // The type of types - used for comptime type parameters
-        "type" => return Ok(Type::ComptimeType),
+        "type" => return Ok(Type::COMPTIME_TYPE),
         _ => {}
     }
 
     if let Some(struct_id) = ctx.get_struct(type_sym) {
-        Ok(Type::Struct(struct_id))
+        Ok(Type::new_struct(struct_id))
     } else if let Some(enum_id) = ctx.get_enum(type_sym) {
-        Ok(Type::Enum(enum_id))
+        Ok(Type::new_enum(enum_id))
     } else {
         // Check for array type syntax: [T; N]
         if let Some((element_type, length)) = crate::types::parse_array_type_syntax(type_name) {
@@ -1307,7 +1307,7 @@ fn resolve_type_from_ctx(ctx: &SemaContext<'_>, type_sym: Spur, span: Span) -> C
             let element_ty = resolve_type_from_ctx(ctx, element_sym, span)?;
             // Get the array type (must exist from declaration gathering)
             if let Some(array_type_id) = ctx.get_array_type(element_ty, length) {
-                Ok(Type::Array(array_type_id))
+                Ok(Type::new_array(array_type_id))
             } else {
                 Err(CompileError::new(
                     ErrorKind::UnknownType(type_name.to_string()),
@@ -1319,13 +1319,13 @@ fn resolve_type_from_ctx(ctx: &SemaContext<'_>, type_sym: Spur, span: Span) -> C
             let pointee_sym = ctx.interner.get_or_intern(pointee_type_str);
             let pointee_ty = resolve_type_from_ctx(ctx, pointee_sym, span)?;
             let ptr_type_id = ctx.type_pool.intern_ptr_const_from_type(pointee_ty);
-            Ok(Type::PtrConst(ptr_type_id))
+            Ok(Type::new_ptr_const(ptr_type_id))
         } else if let Some(pointee_type_str) = type_name.strip_prefix("ptr mut ") {
             // Pointer type syntax: ptr mut T
             let pointee_sym = ctx.interner.get_or_intern(pointee_type_str);
             let pointee_ty = resolve_type_from_ctx(ctx, pointee_sym, span)?;
             let ptr_type_id = ctx.type_pool.intern_ptr_mut_from_type(pointee_ty);
-            Ok(Type::PtrMut(ptr_type_id))
+            Ok(Type::new_ptr_mut(ptr_type_id))
         } else {
             Err(CompileError::new(
                 ErrorKind::UnknownType(type_name.to_string()),
@@ -1403,7 +1403,7 @@ fn analyze_function_with_context(
     let body_result = analyze_inst_with_context(ctx, &mut air, body, &mut analysis_ctx)?;
 
     // Add implicit return only if body doesn't already diverge
-    if body_result.ty != Type::Never {
+    if body_result.ty != Type::NEVER {
         air.add_inst(AirInst {
             data: AirInstData::Ret(Some(body_result.air_ref)),
             ty: return_type,
@@ -1521,7 +1521,7 @@ fn run_type_inference_with_context(
     // Build the resolved types map, converting InferType to Type.
     // Note: Array types should already be created during declaration gathering.
     // If new array types appear in function bodies (e.g., array literals), they
-    // won't be found and will result in Type::Error.
+    // won't be found and will result in Type::ERROR.
     let mut resolved_types = HashMap::new();
     for (inst_ref, infer_ty) in &expr_types {
         let resolved = unifier.resolve_infer_type(infer_ty);
@@ -1539,16 +1539,16 @@ fn run_type_inference_with_context(
 fn infer_type_to_type_standalone(ty: &InferType, ctx: &SemaContext<'_>) -> Type {
     match ty {
         InferType::Concrete(t) => *t,
-        InferType::Var(_) => Type::Error,
+        InferType::Var(_) => Type::ERROR,
         InferType::IntLiteral => Type::I32,
         InferType::Array { element, length } => {
             let elem_ty = infer_type_to_type_standalone(element, ctx);
-            if elem_ty == Type::Error {
-                return Type::Error;
+            if elem_ty == Type::ERROR {
+                return Type::ERROR;
             }
             // Use get_or_create to handle inferred array types from literals
             let id = ctx.get_or_create_array_type(elem_ty, *length);
-            Type::Array(id)
+            Type::new_array(id)
         }
     }
 }
@@ -1590,7 +1590,7 @@ fn analyze_inst_with_context(
         }
 
         InstData::BoolConst(value) => {
-            let ty = Type::Bool;
+            let ty = Type::BOOL;
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::BoolConst(*value),
                 ty,
@@ -1613,7 +1613,7 @@ fn analyze_inst_with_context(
         }
 
         InstData::UnitConst => {
-            let ty = Type::Unit;
+            let ty = Type::UNIT;
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::UnitConst,
                 ty,
@@ -1744,10 +1744,10 @@ fn analyze_inst_with_context(
 
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::And(lhs_result.air_ref, rhs_result.air_ref),
-                ty: Type::Bool,
+                ty: Type::BOOL,
                 span: inst.span,
             });
-            Ok(AnalysisResult::new(air_ref, Type::Bool))
+            Ok(AnalysisResult::new(air_ref, Type::BOOL))
         }
 
         InstData::Or { lhs, rhs } => {
@@ -1756,10 +1756,10 @@ fn analyze_inst_with_context(
 
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::Or(lhs_result.air_ref, rhs_result.air_ref),
-                ty: Type::Bool,
+                ty: Type::BOOL,
                 span: inst.span,
             });
-            Ok(AnalysisResult::new(air_ref, Type::Bool))
+            Ok(AnalysisResult::new(air_ref, Type::BOOL))
         }
 
         InstData::BitAnd { lhs, rhs } => analyze_binary_arith_ctx(
@@ -1863,10 +1863,10 @@ fn analyze_inst_with_context(
 
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::Not(operand_result.air_ref),
-                ty: Type::Bool,
+                ty: Type::BOOL,
                 span: inst.span,
             });
-            Ok(AnalysisResult::new(air_ref, Type::Bool))
+            Ok(AnalysisResult::new(air_ref, Type::BOOL))
         }
 
         InstData::BitNot { operand } => {
@@ -1905,10 +1905,10 @@ fn analyze_inst_with_context(
             // Break has the never type - it diverges
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::Break,
-                ty: Type::Never,
+                ty: Type::NEVER,
                 span: inst.span,
             });
-            Ok(AnalysisResult::new(air_ref, Type::Never))
+            Ok(AnalysisResult::new(air_ref, Type::NEVER))
         }
 
         InstData::Continue => {
@@ -1920,10 +1920,10 @@ fn analyze_inst_with_context(
             // Continue has the never type - it diverges
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::Continue,
-                ty: Type::Never,
+                ty: Type::NEVER,
                 span: inst.span,
             });
-            Ok(AnalysisResult::new(air_ref, Type::Never))
+            Ok(AnalysisResult::new(air_ref, Type::NEVER))
         }
 
         // Return statement
@@ -2068,10 +2068,10 @@ fn analyze_inst_with_context(
             // Enum declarations are processed during collection phase
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::UnitConst,
-                ty: Type::Unit,
+                ty: Type::UNIT,
                 span: inst.span,
             });
-            Ok(AnalysisResult::new(air_ref, Type::Unit))
+            Ok(AnalysisResult::new(air_ref, Type::UNIT))
         }
 
         InstData::EnumVariant {
@@ -2152,10 +2152,10 @@ fn analyze_inst_with_context(
             // These are processed during collection phase, just return Unit
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::UnitConst,
-                ty: Type::Unit,
+                ty: Type::UNIT,
                 span: inst.span,
             });
-            Ok(AnalysisResult::new(air_ref, Type::Unit))
+            Ok(AnalysisResult::new(air_ref, Type::UNIT))
         }
 
         InstData::FnDecl { .. } => {
@@ -2207,7 +2207,7 @@ fn analyze_inst_with_context(
                     Ok(AnalysisResult::new(air_ref, ty))
                 }
                 Some(ConstValue::Bool(value)) => {
-                    let ty = Type::Bool;
+                    let ty = Type::BOOL;
                     let air_ref = air.add_inst(AirInst {
                         data: AirInstData::BoolConst(value),
                         ty,
@@ -2227,7 +2227,7 @@ fn analyze_inst_with_context(
                     ))
                 }
                 Some(ConstValue::Unit) => {
-                    let ty = Type::Unit;
+                    let ty = Type::UNIT;
                     let air_ref = air.add_inst(AirInst {
                         data: AirInstData::UnitConst,
                         ty,
@@ -2254,10 +2254,10 @@ fn analyze_inst_with_context(
             let ty = resolve_type_from_ctx(ctx, *type_name, inst.span)?;
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::TypeConst(ty),
-                ty: Type::ComptimeType,
+                ty: Type::COMPTIME_TYPE,
                 span: inst.span,
             });
-            Ok(AnalysisResult::new(air_ref, Type::ComptimeType))
+            Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE))
         }
 
         InstData::AnonStructType { .. } => {
@@ -2356,10 +2356,10 @@ where
 
     let air_ref = air.add_inst(AirInst {
         data: make_inst(lhs_result.air_ref, rhs_result.air_ref),
-        ty: Type::Bool,
+        ty: Type::BOOL,
         span,
     });
-    Ok(AnalysisResult::new(air_ref, Type::Bool))
+    Ok(AnalysisResult::new(air_ref, Type::BOOL))
 }
 
 /// Merge results from parallel function analysis.
@@ -2450,7 +2450,7 @@ fn analyze_return_ctx(
         Some(inner_result.air_ref)
     } else {
         // `return;` without expression - only valid for unit-returning functions
-        if analysis_ctx.return_type != Type::Unit && !analysis_ctx.return_type.is_error() {
+        if analysis_ctx.return_type != Type::UNIT && !analysis_ctx.return_type.is_error() {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: analysis_ctx.return_type.name().to_string(),
@@ -2464,10 +2464,10 @@ fn analyze_return_ctx(
 
     let air_ref = air.add_inst(AirInst {
         data: AirInstData::Ret(inner_air_ref),
-        ty: Type::Never, // Return expressions have Never type
+        ty: Type::NEVER, // Return expressions have Never type
         span,
     });
-    Ok(AnalysisResult::new(air_ref, Type::Never))
+    Ok(AnalysisResult::new(air_ref, Type::NEVER))
 }
 
 /// Analyze a block expression using the shared context.
@@ -2517,10 +2517,10 @@ fn analyze_block_ctx(
             // Empty block: create a UnitConst
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::UnitConst,
-                ty: Type::Unit,
+                ty: Type::UNIT,
                 span,
             });
-            AnalysisResult::new(air_ref, Type::Unit)
+            AnalysisResult::new(air_ref, Type::UNIT)
         }
     };
 
@@ -2678,10 +2678,10 @@ fn analyze_var_ref_ctx(
         // Comptime type vars produce TypeConst instructions
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::TypeConst(ty),
-            ty: Type::ComptimeType,
+            ty: Type::COMPTIME_TYPE,
             span,
         });
-        return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
+        return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
     }
 
     // Check if it's a constant (e.g., `const VALUE = 42` or `const math = @import("math")`)
@@ -2713,10 +2713,10 @@ fn analyze_var_ref_ctx(
             InstData::BoolConst(value) => {
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::BoolConst(*value),
-                    ty: Type::Bool,
+                    ty: Type::BOOL,
                     span,
                 });
-                return Ok(AnalysisResult::new(air_ref, Type::Bool));
+                return Ok(AnalysisResult::new(air_ref, Type::BOOL));
             }
             _ => {
                 // For other expressions, we'd need to run full analysis on the init
@@ -2870,14 +2870,14 @@ fn analyze_alloc_ctx(
 
     // If name is None, this is a wildcard pattern `_` that discards the value
     let Some(name) = name else {
-        return Ok(AnalysisResult::new(init_result.air_ref, Type::Unit));
+        return Ok(AnalysisResult::new(init_result.air_ref, Type::UNIT));
     };
 
     // Special case: comptime type variables
     // When a variable is assigned a comptime type value (e.g., `let P = make_type()`),
     // we store the type in comptime_type_vars instead of creating a runtime variable.
     // This allows the variable to be used as a type annotation later (e.g., `let p: P = ...`).
-    if var_type == Type::ComptimeType {
+    if var_type == Type::COMPTIME_TYPE {
         // Extract the type value from the TypeConst instruction
         let inst = air.get(init_result.air_ref);
         if let AirInstData::TypeConst(ty) = &inst.data {
@@ -2885,10 +2885,10 @@ fn analyze_alloc_ctx(
             // Return Unit - no runtime code is generated for comptime type bindings
             let nop_ref = air.add_inst(AirInst {
                 data: AirInstData::UnitConst,
-                ty: Type::Unit,
+                ty: Type::UNIT,
                 span,
             });
-            return Ok(AnalysisResult::new(nop_ref, Type::Unit));
+            return Ok(AnalysisResult::new(nop_ref, Type::UNIT));
         }
         // If it's not a TypeConst, fall through to error (can't store types at runtime)
         let name_str = ctx.interner.resolve(&name);
@@ -2938,7 +2938,7 @@ fn analyze_alloc_ctx(
             slot,
             init: init_result.air_ref,
         },
-        ty: Type::Unit,
+        ty: Type::UNIT,
         span,
     });
 
@@ -2950,10 +2950,10 @@ fn analyze_alloc_ctx(
             stmts_len: 1,
             value: alloc_ref,
         },
-        ty: Type::Unit,
+        ty: Type::UNIT,
         span,
     });
-    Ok(AnalysisResult::new(block_ref, Type::Unit))
+    Ok(AnalysisResult::new(block_ref, Type::UNIT))
 }
 
 /// Analyze an assignment using the shared context.
@@ -3009,10 +3009,10 @@ fn analyze_assign_ctx(
                 param_slot: abi_slot,
                 value: value_result.air_ref,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         });
-        return Ok(AnalysisResult::new(air_ref, Type::Unit));
+        return Ok(AnalysisResult::new(air_ref, Type::UNIT));
     }
 
     // Look up local variable
@@ -3047,10 +3047,10 @@ fn analyze_assign_ctx(
             slot,
             value: value_result.air_ref,
         },
-        ty: Type::Unit,
+        ty: Type::UNIT,
         span,
     });
-    Ok(AnalysisResult::new(air_ref, Type::Unit))
+    Ok(AnalysisResult::new(air_ref, Type::UNIT))
 }
 
 /// Analyze a branch (if-else) expression using the shared context.
@@ -3103,7 +3103,7 @@ fn analyze_branch_ctx(
 
         // Compute the unified result type using never type coercion
         let result_type = match (then_type.is_never(), else_type.is_never()) {
-            (true, true) => Type::Never,
+            (true, true) => Type::NEVER,
             (true, false) => else_type,
             (false, true) => then_type,
             (false, false) => {
@@ -3146,7 +3146,7 @@ fn analyze_branch_ctx(
 
         // Check that the then branch has unit type (or Never/Error)
         let then_type = then_result.ty;
-        if then_type != Type::Unit && !then_type.is_never() && !then_type.is_error() {
+        if then_type != Type::UNIT && !then_type.is_never() && !then_type.is_error() {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "()".to_string(),
@@ -3183,10 +3183,10 @@ fn analyze_branch_ctx(
                 then_value: then_result.air_ref,
                 else_value: None,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Unit))
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
     }
 }
 
@@ -3214,10 +3214,10 @@ fn analyze_while_loop_ctx(
             cond: cond_result.air_ref,
             body: body_result.air_ref,
         },
-        ty: Type::Unit,
+        ty: Type::UNIT,
         span,
     });
-    Ok(AnalysisResult::new(air_ref, Type::Unit))
+    Ok(AnalysisResult::new(air_ref, Type::UNIT))
 }
 
 /// Analyze an infinite loop using the shared context.
@@ -3240,10 +3240,10 @@ fn analyze_infinite_loop_ctx(
         data: AirInstData::InfiniteLoop {
             body: body_result.air_ref,
         },
-        ty: Type::Never,
+        ty: Type::NEVER,
         span,
     });
-    Ok(AnalysisResult::new(air_ref, Type::Never))
+    Ok(AnalysisResult::new(air_ref, Type::NEVER))
 }
 
 /// Analyze a match expression using the shared context.
@@ -3263,7 +3263,7 @@ fn analyze_match_ctx(
     let scrutinee_type = scrutinee_result.ty;
 
     // Validate that we can match on this type (integers, booleans, and enums)
-    if !scrutinee_type.is_integer() && scrutinee_type != Type::Bool && !scrutinee_type.is_enum() {
+    if !scrutinee_type.is_integer() && scrutinee_type != Type::BOOL && !scrutinee_type.is_enum() {
         return Err(CompileError::new(
             ErrorKind::InvalidMatchType(scrutinee_type.name().to_string()),
             span,
@@ -3353,7 +3353,7 @@ fn analyze_match_ctx(
                 }
             }
             RirPattern::Bool(b, _) => {
-                if scrutinee_type != Type::Bool {
+                if scrutinee_type != Type::BOOL {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: scrutinee_type.name().to_string(),
@@ -3403,7 +3403,7 @@ fn analyze_match_ctx(
                 let enum_def = ctx.get_enum_def(enum_id);
 
                 // Check that scrutinee type matches the pattern's enum type
-                if scrutinee_type != Type::Enum(enum_id) {
+                if scrutinee_type != Type::new_enum(enum_id) {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: scrutinee_type.name().to_string(),
@@ -3530,7 +3530,7 @@ fn analyze_match_ctx(
     let has_wildcard = wildcard_span.is_some();
     let bool_true_covered = bool_true_span.is_some();
     let bool_false_covered = bool_false_span.is_some();
-    let is_exhaustive = if scrutinee_type == Type::Bool {
+    let is_exhaustive = if scrutinee_type == Type::BOOL {
         has_wildcard || (bool_true_covered && bool_false_covered)
     } else if let Some(enum_id) = pattern_enum_id {
         let enum_def = ctx.get_enum_def(enum_id);
@@ -3544,7 +3544,7 @@ fn analyze_match_ctx(
         return Err(CompileError::new(ErrorKind::NonExhaustiveMatch, span));
     }
 
-    let final_type = result_type.unwrap_or(Type::Unit);
+    let final_type = result_type.unwrap_or(Type::UNIT);
 
     // Encode match arms into extra array
     let arms_len = air_arms.len() as u32;
@@ -3607,7 +3607,7 @@ fn analyze_struct_init_ctx(
     };
 
     let struct_def = ctx.get_struct_def(struct_id);
-    let struct_type = Type::Struct(struct_id);
+    let struct_type = Type::new_struct(struct_id);
 
     // Build a map from field name to struct field index
     let field_index_map: std::collections::HashMap<&str, usize> = struct_def
@@ -3820,7 +3820,7 @@ fn analyze_inst_for_projection_ctx(
             let index_result = analyze_inst_with_context(ctx, air, *index, analysis_ctx)?;
 
             // Verify base is an array
-            let (array_type_id, elem_type, _array_len) = match base_type.kind() {
+            let (_array_type_id, elem_type, _array_len) = match base_type.kind() {
                 TypeKind::Array(type_id) => {
                     let (element_type, length) = ctx.get_array_type_def(type_id);
                     (type_id, element_type, length)
@@ -4081,7 +4081,7 @@ fn analyze_field_set_ctx(
     };
 
     // Check mutability based on root kind
-    let root_slot = match root_kind {
+    let _root_slot = match root_kind {
         RootKind::Local { slot, is_mut } => {
             if !is_mut {
                 return Err(CompileError::new(
@@ -4190,7 +4190,7 @@ fn analyze_field_set_ctx(
                     field_index: field_index as u32,
                     value: value_result.air_ref,
                 },
-                ty: Type::Unit,
+                ty: Type::UNIT,
                 span,
             })
         }
@@ -4202,11 +4202,11 @@ fn analyze_field_set_ctx(
                 field_index: field_index as u32,
                 value: value_result.air_ref,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         }),
     };
-    Ok(AnalysisResult::new(air_ref, Type::Unit))
+    Ok(AnalysisResult::new(air_ref, Type::UNIT))
 }
 
 /// Analyze an array initialization using the shared context.
@@ -4224,7 +4224,7 @@ fn analyze_array_init_ctx(
     // Get the array type from HM inference
     let array_type = get_resolved_type_ctx(analysis_ctx, inst_ref, span, "array literal")?;
 
-    let (array_type_id, _elem_type, expected_len) = match array_type.kind() {
+    let (_array_type_id, _elem_type, expected_len) = match array_type.kind() {
         TypeKind::Array(type_id) => {
             let (element_type, length) = ctx.get_array_type_def(type_id);
             (type_id, element_type, length)
@@ -4307,7 +4307,7 @@ fn analyze_index_get_ctx(
     let index_result = analyze_inst_with_context(ctx, air, index, analysis_ctx)?;
 
     // Verify base is an array
-    let (array_type_id, elem_type, array_len) = match base_type.kind() {
+    let (_array_type_id, elem_type, array_len) = match base_type.kind() {
         TypeKind::Array(type_id) => {
             let (element_type, length) = ctx.get_array_type_def(type_id);
             (type_id, element_type, length)
@@ -4488,7 +4488,7 @@ fn analyze_index_set_ctx(
     };
 
     // Verify base is an array and get its element type
-    let (array_type_id, _elem_type, array_len) = match base_type.kind() {
+    let (_array_type_id, _elem_type, array_len) = match base_type.kind() {
         TypeKind::Array(type_id) => {
             let (element_type, length) = ctx.get_array_type_def(type_id);
             (type_id, element_type, length)
@@ -4531,7 +4531,7 @@ fn analyze_index_set_ctx(
                 index: index_result.air_ref,
                 value: value_result.air_ref,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         })
     } else {
@@ -4542,11 +4542,11 @@ fn analyze_index_set_ctx(
                 index: index_result.air_ref,
                 value: value_result.air_ref,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         })
     };
-    Ok(AnalysisResult::new(air_ref, Type::Unit))
+    Ok(AnalysisResult::new(air_ref, Type::UNIT))
 }
 
 /// Analyze an enum variant using the shared context.
@@ -4581,7 +4581,7 @@ fn analyze_enum_variant_ctx(
         span,
     )?;
 
-    let ty = Type::Enum(enum_id);
+    let ty = Type::new_enum(enum_id);
 
     let air_ref = air.add_inst(AirInst {
         data: AirInstData::EnumVariant {
@@ -4722,7 +4722,7 @@ fn analyze_call_ctx(
         }
 
         // Determine the actual return type by substituting type parameters
-        let return_type = if base_return_type == Type::ComptimeType {
+        let return_type = if base_return_type == Type::COMPTIME_TYPE {
             // Return type is a type parameter - look it up in substitutions
             *type_subst
                 .get(&return_type_sym)
@@ -5162,7 +5162,7 @@ fn analyze_builtin_method_ctx(
                     slot,
                     value: call_ref,
                 },
-                ty: Type::Unit,
+                ty: Type::UNIT,
                 span,
             }),
             StringReceiverStorage::Param { abi_slot } => air.add_inst(AirInst {
@@ -5170,7 +5170,7 @@ fn analyze_builtin_method_ctx(
                     param_slot: abi_slot,
                     value: call_ref,
                 },
-                ty: Type::Unit,
+                ty: Type::UNIT,
                 span,
             }),
         };
@@ -5179,7 +5179,7 @@ fn analyze_builtin_method_ctx(
         // Otherwise return the call result (e.g., for pop() which returns the popped char)
         if return_type == receiver_type {
             // Return unit since mutation methods that return Self are for chaining
-            Ok(AnalysisResult::new(store_ref, Type::Unit))
+            Ok(AnalysisResult::new(store_ref, Type::UNIT))
         } else {
             // Return the actual return value
             Ok(AnalysisResult::new(call_ref, return_type))
@@ -5289,10 +5289,10 @@ fn resolve_builtin_return_type_ctx(
     self_struct_id: StructId,
 ) -> Type {
     match return_type {
-        BuiltinReturnType::Unit => Type::Unit,
+        BuiltinReturnType::Unit => Type::UNIT,
         BuiltinReturnType::U64 => Type::U64,
         BuiltinReturnType::U8 => Type::U8,
-        BuiltinReturnType::Bool => Type::Bool,
+        BuiltinReturnType::Bool => Type::BOOL,
         BuiltinReturnType::SelfType => ctx.builtin_air_type(self_struct_id),
     }
 }
@@ -5467,7 +5467,7 @@ fn analyze_intrinsic_ctx(
 
         // Validate type
         if !arg_type.is_integer()
-            && arg_type != Type::Bool
+            && arg_type != Type::BOOL
             && !arg_type.is_struct()
             && !arg_type.is_enum()
             && !arg_type.is_array()
@@ -5491,10 +5491,10 @@ fn analyze_intrinsic_ctx(
                 args_start: air_args_start,
                 args_len: 1,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Unit))
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
     } else if name == known.cast {
         if args.len() != 1 {
             return Err(CompileError::new(
@@ -5566,10 +5566,10 @@ fn analyze_intrinsic_ctx(
             // Panic with no message
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::UnitConst,
-                ty: Type::Never,
+                ty: Type::NEVER,
                 span,
             });
-            return Ok(AnalysisResult::new(air_ref, Type::Never));
+            return Ok(AnalysisResult::new(air_ref, Type::NEVER));
         }
 
         // Analyze the message argument
@@ -5582,10 +5582,10 @@ fn analyze_intrinsic_ctx(
                 args_start: air_args_start,
                 args_len: 1,
             },
-            ty: Type::Never,
+            ty: Type::NEVER,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Never))
+        Ok(AnalysisResult::new(air_ref, Type::NEVER))
     } else if name == known.assert {
         if args.len() != 1 {
             return Err(CompileError::new(
@@ -5607,10 +5607,10 @@ fn analyze_intrinsic_ctx(
                 args_start: air_args_start,
                 args_len: 1,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Unit))
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
     } else if name == known.import {
         // @import takes exactly one string literal argument
         if args.len() != 1 {
@@ -5675,10 +5675,10 @@ fn analyze_intrinsic_ctx(
         // The type is what matters for subsequent member access resolution
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::UnitConst, // Placeholder - module values are compile-time only
-            ty: Type::Module(module_id),
+            ty: Type::new_module(module_id),
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Module(module_id)))
+        Ok(AnalysisResult::new(air_ref, Type::new_module(module_id)))
     } else if name == known.random_u32 {
         // @random_u32() - takes no arguments, returns u32
         if !args.is_empty() {
@@ -5844,10 +5844,10 @@ fn analyze_intrinsic_ctx(
                 args_start,
                 args_len: 2,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Unit))
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
     } else if name == known.ptr_offset {
         // @ptr_offset(ptr, offset) - Pointer arithmetic
         require_preview_ctx(
@@ -6046,10 +6046,10 @@ fn analyze_intrinsic_ctx(
         // Create the pointer type
         let result_type = if is_mut {
             let ptr_type_id = ctx.type_pool.intern_ptr_mut_from_type(pointee_type);
-            Type::PtrMut(ptr_type_id)
+            Type::new_ptr_mut(ptr_type_id)
         } else {
             let ptr_type_id = ctx.type_pool.intern_ptr_const_from_type(pointee_type);
-            Type::PtrConst(ptr_type_id)
+            Type::new_ptr_const(ptr_type_id)
         };
 
         let args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
@@ -6136,7 +6136,7 @@ fn analyze_intrinsic_ctx(
             Arch::Aarch64 => 1,
         };
 
-        let result_type = Type::Enum(arch_enum_id);
+        let result_type = Type::new_enum(arch_enum_id);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::EnumVariant {
                 enum_id: arch_enum_id,
@@ -6167,7 +6167,7 @@ fn analyze_intrinsic_ctx(
             Os::Macos => 1,
         };
 
-        let result_type = Type::Enum(os_enum_id);
+        let result_type = Type::new_enum(os_enum_id);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::EnumVariant {
                 enum_id: os_enum_id,
@@ -6411,7 +6411,7 @@ impl<'a> Sema<'a> {
             local_strings,
             ref_fns,
             ref_meths,
-        ) = self.analyze_function(infer_ctx, Type::Unit, &param_info, body)?;
+        ) = self.analyze_function(infer_ctx, Type::UNIT, &param_info, body)?;
 
         Ok((
             AnalyzedFunction {
@@ -6546,7 +6546,7 @@ impl<'a> Sema<'a> {
         let body_result = self.analyze_inst(&mut air, body, &mut ctx)?;
 
         // Add implicit return only if body doesn't already diverge (e.g., explicit return)
-        if body_result.ty != Type::Never {
+        if body_result.ty != Type::NEVER {
             air.add_inst(AirInst {
                 data: AirInstData::Ret(Some(body_result.air_ref)),
                 ty: return_type,
@@ -7170,7 +7170,7 @@ impl<'a> Sema<'a> {
                         Ok(AnalysisResult::new(air_ref, ty))
                     }
                     Some(ConstValue::Bool(value)) => {
-                        let ty = Type::Bool;
+                        let ty = Type::BOOL;
                         let air_ref = air.add_inst(AirInst {
                             data: AirInstData::BoolConst(value),
                             ty,
@@ -7189,7 +7189,7 @@ impl<'a> Sema<'a> {
                         ))
                     }
                     Some(ConstValue::Unit) => {
-                        let ty = Type::Unit;
+                        let ty = Type::UNIT;
                         let air_ref = air.add_inst(AirInst {
                             data: AirInstData::UnitConst,
                             ty,
@@ -7214,10 +7214,10 @@ impl<'a> Sema<'a> {
                 let ty = self.resolve_type(*type_name, inst.span)?;
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::TypeConst(ty),
-                    ty: Type::ComptimeType,
+                    ty: Type::COMPTIME_TYPE,
                     span: inst.span,
                 });
-                Ok(AnalysisResult::new(air_ref, Type::ComptimeType))
+                Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE))
             }
 
             // Anonymous struct type: a struct type constructed at comptime
@@ -7282,10 +7282,10 @@ impl<'a> Sema<'a> {
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::TypeConst(struct_ty),
-                    ty: Type::ComptimeType,
+                    ty: Type::COMPTIME_TYPE,
                     span: inst.span,
                 });
-                Ok(AnalysisResult::new(air_ref, Type::ComptimeType))
+                Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE))
             }
 
             // Checked block: evaluate the inner expression
@@ -7410,10 +7410,10 @@ impl<'a> Sema<'a> {
                     place: place_ref,
                     value: value_result.air_ref,
                 },
-                ty: Type::Unit,
+                ty: Type::UNIT,
                 span,
             });
-            return Ok(AnalysisResult::new(air_ref, Type::Unit));
+            return Ok(AnalysisResult::new(air_ref, Type::UNIT));
         }
 
         // Fallback: base is not a place (e.g., function call result)
@@ -7485,7 +7485,7 @@ impl<'a> Sema<'a> {
 
             // Get array type info from the trace
             let base_type = trace.result_type();
-            let (array_type_id, elem_type, array_len) = match base_type.as_array() {
+            let (_array_type_id, elem_type, array_len) = match base_type.as_array() {
                 Some(id) => {
                     let (elem, len) = self.type_pool.array_def(id);
                     (id, elem, len)
@@ -7545,10 +7545,10 @@ impl<'a> Sema<'a> {
                     place: place_ref,
                     value: value_result.air_ref,
                 },
-                ty: Type::Unit,
+                ty: Type::UNIT,
                 span,
             });
-            return Ok(AnalysisResult::new(air_ref, Type::Unit));
+            return Ok(AnalysisResult::new(air_ref, Type::UNIT));
         }
 
         // Fallback: base is not a place
@@ -8030,7 +8030,7 @@ impl<'a> Sema<'a> {
 
         // Validate type
         if !arg_type.is_integer()
-            && arg_type != Type::Bool
+            && arg_type != Type::BOOL
             && !arg_type.is_struct()
             && !arg_type.is_enum()
             && !arg_type.is_array()
@@ -8054,10 +8054,10 @@ impl<'a> Sema<'a> {
                 args_start,
                 args_len: 1,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Unit))
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
     }
 
     fn analyze_cast_intrinsic(
@@ -8146,10 +8146,10 @@ impl<'a> Sema<'a> {
             // Panic with no message
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::UnitConst,
-                ty: Type::Never,
+                ty: Type::NEVER,
                 span,
             });
-            return Ok(AnalysisResult::new(air_ref, Type::Never));
+            return Ok(AnalysisResult::new(air_ref, Type::NEVER));
         }
 
         // Analyze the message argument
@@ -8162,10 +8162,10 @@ impl<'a> Sema<'a> {
                 args_start,
                 args_len: 1,
             },
-            ty: Type::Never,
+            ty: Type::NEVER,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Never))
+        Ok(AnalysisResult::new(air_ref, Type::NEVER))
     }
 
     fn analyze_assert_intrinsic(
@@ -8204,10 +8204,10 @@ impl<'a> Sema<'a> {
                 args_start,
                 args_len,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Unit))
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
     }
 
     /// Analyze @intCast intrinsic.
@@ -8252,7 +8252,7 @@ impl<'a> Sema<'a> {
         // Get the target type from HM inference
         let target_ty = match ctx.resolved_types.get(&inst_ref).copied() {
             Some(ty) if ty.is_integer() => ty,
-            Some(Type::Error) => {
+            Some(Type::ERROR) => {
                 // Error already reported during type inference
                 return Err(CompileError::new(ErrorKind::TypeAnnotationRequired, span));
             }
@@ -8312,10 +8312,10 @@ impl<'a> Sema<'a> {
         // No-op: just return a unit constant
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::UnitConst,
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Unit))
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
     }
 
     /// Analyze @read_line intrinsic.
@@ -8537,10 +8537,10 @@ impl<'a> Sema<'a> {
         // The type is what matters for subsequent member access resolution
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::UnitConst, // Placeholder - module values are compile-time only
-            ty: Type::Module(module_id),
+            ty: Type::new_module(module_id),
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Module(module_id)))
+        Ok(AnalysisResult::new(air_ref, Type::new_module(module_id)))
     }
 
     /// Resolve an import path to an absolute file path.
@@ -8779,10 +8779,10 @@ impl<'a> Sema<'a> {
         if lhs_type.is_never() || lhs_type.is_error() {
             let air_ref = air.add_inst(AirInst {
                 data: make_data(lhs_result.air_ref, rhs_result.air_ref),
-                ty: Type::Bool,
+                ty: Type::BOOL,
                 span,
             });
-            return Ok(AnalysisResult::new(air_ref, Type::Bool));
+            return Ok(AnalysisResult::new(air_ref, Type::BOOL));
         }
 
         // Validate the type is appropriate for this comparison
@@ -8790,8 +8790,8 @@ impl<'a> Sema<'a> {
             // Equality operators (==, !=) work on integers, booleans, strings, unit, and structs
             // Note: String is now a struct, so is_struct() covers it
             if !lhs_type.is_integer()
-                && lhs_type != Type::Bool
-                && lhs_type != Type::Unit
+                && lhs_type != Type::BOOL
+                && lhs_type != Type::UNIT
                 && !lhs_type.is_struct()
                 && !self.is_builtin_string(lhs_type)
             {
@@ -8815,10 +8815,10 @@ impl<'a> Sema<'a> {
 
         let air_ref = air.add_inst(AirInst {
             data: make_data(lhs_result.air_ref, rhs_result.air_ref),
-            ty: Type::Bool,
+            ty: Type::BOOL,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Bool))
+        Ok(AnalysisResult::new(air_ref, Type::BOOL))
     }
 
     /// Try to evaluate an RIR expression as a compile-time constant.
@@ -9073,15 +9073,15 @@ impl<'a> Sema<'a> {
                     "u16" => Type::U16,
                     "u32" => Type::U32,
                     "u64" => Type::U64,
-                    "bool" => Type::Bool,
-                    "()" => Type::Unit,
-                    "!" => Type::Never,
+                    "bool" => Type::BOOL,
+                    "()" => Type::UNIT,
+                    "!" => Type::NEVER,
                     _ => {
                         // Check for struct types
                         if let Some(&struct_id) = self.structs.get(type_name) {
-                            Type::Struct(struct_id)
+                            Type::new_struct(struct_id)
                         } else if let Some(&enum_id) = self.enums.get(type_name) {
-                            Type::Enum(enum_id)
+                            Type::new_enum(enum_id)
                         } else {
                             return None; // Unknown type
                         }
@@ -9103,15 +9103,15 @@ impl<'a> Sema<'a> {
                     "u16" => Type::U16,
                     "u32" => Type::U32,
                     "u64" => Type::U64,
-                    "bool" => Type::Bool,
-                    "()" => Type::Unit,
-                    "!" => Type::Never,
+                    "bool" => Type::BOOL,
+                    "()" => Type::UNIT,
+                    "!" => Type::NEVER,
                     _ => {
                         // Check for struct types
                         if let Some(&struct_id) = self.structs.get(name) {
-                            Type::Struct(struct_id)
+                            Type::new_struct(struct_id)
                         } else if let Some(&enum_id) = self.enums.get(name) {
-                            Type::Enum(enum_id)
+                            Type::new_enum(enum_id)
                         } else {
                             return None; // Not a type name - can't evaluate at compile time
                         }
@@ -9444,14 +9444,14 @@ impl<'a> Sema<'a> {
                     "u16" => Type::U16,
                     "u32" => Type::U32,
                     "u64" => Type::U64,
-                    "bool" => Type::Bool,
-                    "()" => Type::Unit,
-                    "!" => Type::Never,
+                    "bool" => Type::BOOL,
+                    "()" => Type::UNIT,
+                    "!" => Type::NEVER,
                     _ => {
                         if let Some(&struct_id) = self.structs.get(type_name) {
-                            Type::Struct(struct_id)
+                            Type::new_struct(struct_id)
                         } else if let Some(&enum_id) = self.enums.get(type_name) {
-                            Type::Enum(enum_id)
+                            Type::new_enum(enum_id)
                         } else {
                             return None;
                         }
@@ -9478,14 +9478,14 @@ impl<'a> Sema<'a> {
                     "u16" => Type::U16,
                     "u32" => Type::U32,
                     "u64" => Type::U64,
-                    "bool" => Type::Bool,
-                    "()" => Type::Unit,
-                    "!" => Type::Never,
+                    "bool" => Type::BOOL,
+                    "()" => Type::UNIT,
+                    "!" => Type::NEVER,
                     _ => {
                         if let Some(&struct_id) = self.structs.get(name) {
-                            Type::Struct(struct_id)
+                            Type::new_struct(struct_id)
                         } else if let Some(&enum_id) = self.enums.get(name) {
-                            Type::Enum(enum_id)
+                            Type::new_enum(enum_id)
                         } else {
                             return None;
                         }
@@ -9497,14 +9497,6 @@ impl<'a> Sema<'a> {
             // Everything else requires runtime evaluation
             _ => None,
         }
-    }
-
-    /// Check if an RIR instruction is an integer literal.
-    ///
-    /// This is used for bidirectional type inference to detect when the LHS
-    /// of a binary operator is a literal that can adopt its type from the RHS.
-    fn is_integer_literal(&self, inst_ref: InstRef) -> bool {
-        matches!(self.rir.get(inst_ref).data, InstData::IntConst(_))
     }
 
     /// Check if an RIR instruction is a VarRef to a comptime type variable.
@@ -9583,8 +9575,8 @@ impl<'a> Sema<'a> {
             let expected_ty = match assoc_fn.params[i].ty {
                 BuiltinParamType::U64 => Type::U64,
                 BuiltinParamType::U8 => Type::U8,
-                BuiltinParamType::Bool => Type::Bool,
-                BuiltinParamType::SelfType => Type::Struct(struct_id),
+                BuiltinParamType::Bool => Type::BOOL,
+                BuiltinParamType::SelfType => Type::new_struct(struct_id),
             };
 
             // Type check
@@ -9604,10 +9596,10 @@ impl<'a> Sema<'a> {
         // Determine return type
         // Use builtin_air_type for SelfType to get correct AIR output type
         let return_ty = match assoc_fn.return_ty {
-            BuiltinReturnType::Unit => Type::Unit,
+            BuiltinReturnType::Unit => Type::UNIT,
             BuiltinReturnType::U64 => Type::U64,
             BuiltinReturnType::U8 => Type::U8,
-            BuiltinReturnType::Bool => Type::Bool,
+            BuiltinReturnType::Bool => Type::BOOL,
             BuiltinReturnType::SelfType => self.builtin_air_type(struct_id),
         };
 
@@ -9708,8 +9700,8 @@ impl<'a> Sema<'a> {
             let expected_ty = match method.params[i].ty {
                 BuiltinParamType::U64 => Type::U64,
                 BuiltinParamType::U8 => Type::U8,
-                BuiltinParamType::Bool => Type::Bool,
-                BuiltinParamType::SelfType => Type::Struct(method_ctx.struct_id),
+                BuiltinParamType::Bool => Type::BOOL,
+                BuiltinParamType::SelfType => Type::new_struct(method_ctx.struct_id),
             };
 
             // Type check
@@ -9733,10 +9725,10 @@ impl<'a> Sema<'a> {
         // Determine return type
         // Use builtin_air_type for SelfType to get correct AIR output type
         let return_ty = match method.return_ty {
-            BuiltinReturnType::Unit => Type::Unit,
+            BuiltinReturnType::Unit => Type::UNIT,
             BuiltinReturnType::U64 => Type::U64,
             BuiltinReturnType::U8 => Type::U8,
-            BuiltinReturnType::Bool => Type::Bool,
+            BuiltinReturnType::Bool => Type::BOOL,
             BuiltinReturnType::SelfType => self.builtin_air_type(method_ctx.struct_id),
         };
 
@@ -9863,7 +9855,7 @@ impl<'a> Sema<'a> {
                     slot,
                     value: call_ref,
                 },
-                ty: Type::Unit,
+                ty: Type::UNIT,
                 span,
             }),
             StringReceiverStorage::Param { abi_slot } => air.add_inst(AirInst {
@@ -9871,12 +9863,12 @@ impl<'a> Sema<'a> {
                     param_slot: abi_slot,
                     value: call_ref,
                 },
-                ty: Type::Unit,
+                ty: Type::UNIT,
                 span,
             }),
         };
 
-        Ok(AnalysisResult::new(store_ref, Type::Unit))
+        Ok(AnalysisResult::new(store_ref, Type::UNIT))
     }
 
     /// Check if directives contain @allow for a specific warning name.
@@ -10007,37 +9999,6 @@ impl<'a> Sema<'a> {
         }
     }
 
-    /// Extract the root variable symbol and field path from an expression.
-    ///
-    /// For expressions like `s.a.b`, returns (sym("s"), [sym("a"), sym("b")]).
-    /// For `s`, returns (sym("s"), []).
-    ///
-    /// Returns None for expressions that don't refer to a variable (literals, calls, etc.)
-    pub(crate) fn extract_field_path(&self, inst_ref: InstRef) -> Option<(Spur, FieldPath)> {
-        let mut path = Vec::new();
-        let root = self.extract_field_path_inner(inst_ref, &mut path)?;
-        // Path is built in reverse order, so reverse it
-        path.reverse();
-        Some((root, path))
-    }
-
-    /// Helper for extract_field_path that builds the path in reverse order.
-    fn extract_field_path_inner(&self, inst_ref: InstRef, path: &mut FieldPath) -> Option<Spur> {
-        let inst = self.rir.get(inst_ref);
-        match &inst.data {
-            InstData::VarRef { name } => Some(*name),
-            InstData::ParamRef { name, .. } => Some(*name),
-            InstData::FieldGet { base, field } => {
-                path.push(*field);
-                self.extract_field_path_inner(*base, path)
-            }
-            // For index expressions, we stop tracking the field path
-            // (index-based moves are more complex and not addressed here)
-            InstData::IndexGet { .. } => None,
-            _ => None,
-        }
-    }
-
     /// Check exclusivity rules for inout and borrow parameters in a call.
     ///
     /// This enforces two rules:
@@ -10157,7 +10118,7 @@ impl<'a> Sema<'a> {
         struct_type: Type,
         methods_start: u32,
         methods_len: u32,
-        span: Span,
+        _span: Span,
     ) -> CompileResult<()> {
         let method_refs = self.rir.get_inst_refs(methods_start, methods_len);
 
@@ -10589,10 +10550,10 @@ impl<'a> Sema<'a> {
                 args_start,
                 args_len: 2,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Unit))
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
     }
 
     /// Analyze @ptr_offset intrinsic: pointer arithmetic.
@@ -10822,10 +10783,10 @@ impl<'a> Sema<'a> {
         // Create the pointer type
         let result_type = if is_mut {
             let ptr_type_id = self.type_pool.intern_ptr_mut_from_type(pointee_type);
-            Type::PtrMut(ptr_type_id)
+            Type::new_ptr_mut(ptr_type_id)
         } else {
             let ptr_type_id = self.type_pool.intern_ptr_const_from_type(pointee_type);
-            Type::PtrConst(ptr_type_id)
+            Type::new_ptr_const(ptr_type_id)
         };
 
         // Create the intrinsic call instruction
@@ -10944,7 +10905,7 @@ impl<'a> Sema<'a> {
             Arch::Aarch64 => 1,
         };
 
-        let result_type = Type::Enum(arch_enum_id);
+        let result_type = Type::new_enum(arch_enum_id);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::EnumVariant {
                 enum_id: arch_enum_id,
@@ -10989,7 +10950,7 @@ impl<'a> Sema<'a> {
             Os::Macos => 1,
         };
 
-        let result_type = Type::Enum(os_enum_id);
+        let result_type = Type::new_enum(os_enum_id);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::EnumVariant {
                 enum_id: os_enum_id,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -25,7 +25,7 @@ use std::collections::{HashMap, HashSet};
 use lasso::Spur;
 use rue_error::{
     CompileError, CompileResult, CompileWarning, ErrorKind, MissingFieldsError, OptionExt,
-    PreviewFeature, WarningKind,
+    WarningKind,
 };
 use rue_rir::{InstData, InstRef, RirArgMode, RirParamMode, RirPattern};
 
@@ -33,13 +33,13 @@ use crate::sema::context::ConstValue;
 use rue_span::Span;
 
 use super::Sema;
-use super::context::{AnalysisContext, AnalysisResult, LocalVar, ParamInfo};
+use super::context::{AnalysisContext, AnalysisResult, LocalVar};
 use crate::inst::{
     Air, AirCallArg, AirInst, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef, AirProjection,
     AirRef,
 };
 use crate::scope::ScopedContext;
-use crate::types::{StructId, Type, TypeKind};
+use crate::types::{Type, TypeKind};
 
 // ============================================================================
 // Place Building (ADR-0030 Phase 8)
@@ -332,7 +332,7 @@ impl<'a> Sema<'a> {
             }
 
             InstData::BoolConst(value) => {
-                let ty = Type::Bool;
+                let ty = Type::BOOL;
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::BoolConst(*value),
                     ty,
@@ -357,7 +357,7 @@ impl<'a> Sema<'a> {
             }
 
             InstData::UnitConst => {
-                let ty = Type::Unit;
+                let ty = Type::UNIT;
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::UnitConst,
                     ty,
@@ -442,10 +442,10 @@ impl<'a> Sema<'a> {
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Not(operand_result.air_ref),
-                    ty: Type::Bool,
+                    ty: Type::BOOL,
                     span: inst.span,
                 });
-                Ok(AnalysisResult::new(air_ref, Type::Bool))
+                Ok(AnalysisResult::new(air_ref, Type::BOOL))
             }
 
             InstData::BitNot { operand } => {
@@ -505,10 +505,10 @@ impl<'a> Sema<'a> {
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::And(lhs_result.air_ref, rhs_result.air_ref),
-                    ty: Type::Bool,
+                    ty: Type::BOOL,
                     span: inst.span,
                 });
-                Ok(AnalysisResult::new(air_ref, Type::Bool))
+                Ok(AnalysisResult::new(air_ref, Type::BOOL))
             }
 
             InstData::Or { lhs, rhs } => {
@@ -517,10 +517,10 @@ impl<'a> Sema<'a> {
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Or(lhs_result.air_ref, rhs_result.air_ref),
-                    ty: Type::Bool,
+                    ty: Type::BOOL,
                     span: inst.span,
                 });
-                Ok(AnalysisResult::new(air_ref, Type::Bool))
+                Ok(AnalysisResult::new(air_ref, Type::BOOL))
             }
 
             _ => Err(CompileError::new(
@@ -578,10 +578,10 @@ impl<'a> Sema<'a> {
                 // Break has the never type - it diverges
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Break,
-                    ty: Type::Never,
+                    ty: Type::NEVER,
                     span: inst.span,
                 });
-                Ok(AnalysisResult::new(air_ref, Type::Never))
+                Ok(AnalysisResult::new(air_ref, Type::NEVER))
             }
 
             InstData::Continue => {
@@ -593,10 +593,10 @@ impl<'a> Sema<'a> {
                 // Continue has the never type - it diverges
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Continue,
-                    ty: Type::Never,
+                    ty: Type::NEVER,
                     span: inst.span,
                 });
-                Ok(AnalysisResult::new(air_ref, Type::Never))
+                Ok(AnalysisResult::new(air_ref, Type::NEVER))
             }
 
             InstData::Ret(inner) => {
@@ -667,7 +667,7 @@ impl<'a> Sema<'a> {
 
             // Compute the unified result type using never type coercion
             let result_type = match (then_type.is_never(), else_type.is_never()) {
-                (true, true) => Type::Never,
+                (true, true) => Type::NEVER,
                 (true, false) => else_type,
                 (false, true) => then_type,
                 (false, false) => {
@@ -710,7 +710,7 @@ impl<'a> Sema<'a> {
 
             // Check that the then branch has unit type (or Never/Error)
             let then_type = then_result.ty;
-            if then_type != Type::Unit && !then_type.is_never() && !then_type.is_error() {
+            if then_type != Type::UNIT && !then_type.is_never() && !then_type.is_error() {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "()".to_string(),
@@ -747,10 +747,10 @@ impl<'a> Sema<'a> {
                     then_value: then_result.air_ref,
                     else_value: None,
                 },
-                ty: Type::Unit,
+                ty: Type::UNIT,
                 span,
             });
-            Ok(AnalysisResult::new(air_ref, Type::Unit))
+            Ok(AnalysisResult::new(air_ref, Type::UNIT))
         }
     }
 
@@ -778,10 +778,10 @@ impl<'a> Sema<'a> {
                 cond: cond_result.air_ref,
                 body: body_result.air_ref,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Unit))
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
     }
 
     /// Analyze an infinite loop.
@@ -804,10 +804,10 @@ impl<'a> Sema<'a> {
             data: AirInstData::InfiniteLoop {
                 body: body_result.air_ref,
             },
-            ty: Type::Never,
+            ty: Type::NEVER,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Never))
+        Ok(AnalysisResult::new(air_ref, Type::NEVER))
     }
 
     /// Analyze a match expression.
@@ -825,7 +825,7 @@ impl<'a> Sema<'a> {
         let scrutinee_type = scrutinee_result.ty;
 
         // Validate that we can match on this type (integers, booleans, and enums)
-        if !scrutinee_type.is_integer() && scrutinee_type != Type::Bool && !scrutinee_type.is_enum()
+        if !scrutinee_type.is_integer() && scrutinee_type != Type::BOOL && !scrutinee_type.is_enum()
         {
             return Err(CompileError::new(
                 ErrorKind::InvalidMatchType(scrutinee_type.name().to_string()),
@@ -845,7 +845,6 @@ impl<'a> Sema<'a> {
         let mut bool_false_span: Option<Span> = None;
         let mut seen_ints: HashMap<i64, Span> = HashMap::new();
         let mut covered_variants: HashSet<u32> = HashSet::new();
-        let mut seen_variants: HashMap<u32, Span> = HashMap::new();
         let mut pattern_enum_id: Option<crate::types::EnumId> = None;
 
         // Analyze each arm (each arm gets its own scope)
@@ -919,7 +918,7 @@ impl<'a> Sema<'a> {
                     }
                 }
                 RirPattern::Bool(b, _) => {
-                    if scrutinee_type != Type::Bool {
+                    if scrutinee_type != Type::BOOL {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
                                 expected: scrutinee_type.name().to_string(),
@@ -973,7 +972,7 @@ impl<'a> Sema<'a> {
                     let enum_def = self.type_pool.enum_def(enum_id);
 
                     // Check that scrutinee type matches the pattern's enum type
-                    if scrutinee_type != Type::Enum(enum_id) {
+                    if scrutinee_type != Type::new_enum(enum_id) {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
                                 expected: scrutinee_type.name().to_string(),
@@ -1079,7 +1078,7 @@ impl<'a> Sema<'a> {
         let has_wildcard = wildcard_span.is_some();
         let bool_true_covered = bool_true_span.is_some();
         let bool_false_covered = bool_false_span.is_some();
-        let is_exhaustive = if scrutinee_type == Type::Bool {
+        let is_exhaustive = if scrutinee_type == Type::BOOL {
             has_wildcard || (bool_true_covered && bool_false_covered)
         } else if let Some(enum_id) = pattern_enum_id {
             let enum_def = self.type_pool.enum_def(enum_id);
@@ -1093,7 +1092,7 @@ impl<'a> Sema<'a> {
             return Err(CompileError::new(ErrorKind::NonExhaustiveMatch, span));
         }
 
-        let final_type = result_type.unwrap_or(Type::Unit);
+        let final_type = result_type.unwrap_or(Type::UNIT);
 
         // Encode match arms into extra array
         let arms_len = air_arms.len() as u32;
@@ -1144,7 +1143,7 @@ impl<'a> Sema<'a> {
             Some(inner_result.air_ref)
         } else {
             // `return;` without expression - only valid for unit-returning functions
-            if ctx.return_type != Type::Unit && !ctx.return_type.is_error() {
+            if ctx.return_type != Type::UNIT && !ctx.return_type.is_error() {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: ctx.return_type.name().to_string(),
@@ -1158,10 +1157,10 @@ impl<'a> Sema<'a> {
 
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Ret(inner_air_ref),
-            ty: Type::Never, // Return expressions have Never type
+            ty: Type::NEVER, // Return expressions have Never type
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Never))
+        Ok(AnalysisResult::new(air_ref, Type::NEVER))
     }
 
     /// Analyze a block expression.
@@ -1211,10 +1210,10 @@ impl<'a> Sema<'a> {
                 // Empty block: create a UnitConst
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::UnitConst,
-                    ty: Type::Unit,
+                    ty: Type::UNIT,
                     span,
                 });
-                AnalysisResult::new(air_ref, Type::Unit)
+                AnalysisResult::new(air_ref, Type::UNIT)
             }
         };
 
@@ -1312,14 +1311,14 @@ impl<'a> Sema<'a> {
 
         // If name is None, this is a wildcard pattern `_` that discards the value
         let Some(name) = name else {
-            return Ok(AnalysisResult::new(init_result.air_ref, Type::Unit));
+            return Ok(AnalysisResult::new(init_result.air_ref, Type::UNIT));
         };
 
         // Special case: comptime type variables
         // When a variable is assigned a comptime type value (e.g., `let P = make_type()`),
         // we store the type in comptime_type_vars instead of creating a runtime variable.
         // This allows the variable to be used as a type annotation later (e.g., `let p: P = ...`).
-        if var_type == Type::ComptimeType {
+        if var_type == Type::COMPTIME_TYPE {
             // Extract the type value from the TypeConst instruction
             let inst = air.get(init_result.air_ref);
             if let AirInstData::TypeConst(ty) = &inst.data {
@@ -1327,10 +1326,10 @@ impl<'a> Sema<'a> {
                 // Return Unit - no runtime code is generated for comptime type bindings
                 let nop_ref = air.add_inst(AirInst {
                     data: AirInstData::UnitConst,
-                    ty: Type::Unit,
+                    ty: Type::UNIT,
                     span,
                 });
-                return Ok(AnalysisResult::new(nop_ref, Type::Unit));
+                return Ok(AnalysisResult::new(nop_ref, Type::UNIT));
             }
             // If it's not a TypeConst, fall through to error (can't store types at runtime)
             let name_str = self.interner.resolve(&name);
@@ -1380,7 +1379,7 @@ impl<'a> Sema<'a> {
                 slot,
                 init: init_result.air_ref,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         });
 
@@ -1392,10 +1391,10 @@ impl<'a> Sema<'a> {
                 stmts_len: 1,
                 value: alloc_ref,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(block_ref, Type::Unit))
+        Ok(AnalysisResult::new(block_ref, Type::UNIT))
     }
 
     /// Analyze a variable reference.
@@ -1506,10 +1505,10 @@ impl<'a> Sema<'a> {
             // Comptime type vars produce TypeConst instructions
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::TypeConst(ty),
-                ty: Type::ComptimeType,
+                ty: Type::COMPTIME_TYPE,
                 span,
             });
-            return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
+            return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
         }
 
         // Check if it's a constant (e.g., `const VALUE = 42` or `const math = @import("math")`)
@@ -1541,10 +1540,10 @@ impl<'a> Sema<'a> {
                 rue_rir::InstData::BoolConst(value) => {
                     let air_ref = air.add_inst(AirInst {
                         data: AirInstData::BoolConst(*value),
-                        ty: Type::Bool,
+                        ty: Type::BOOL,
                         span,
                     });
-                    return Ok(AnalysisResult::new(air_ref, Type::Bool));
+                    return Ok(AnalysisResult::new(air_ref, Type::BOOL));
                 }
                 _ => {
                     // For complex expressions, fall back to analyzing the init expression
@@ -1560,10 +1559,10 @@ impl<'a> Sema<'a> {
             // This is a type name being used as a value (e.g., `i32` passed to `comptime T: type`)
             let air_ref = air.add_inst(AirInst {
                 data: AirInstData::TypeConst(resolved_type),
-                ty: Type::ComptimeType,
+                ty: Type::COMPTIME_TYPE,
                 span,
             });
-            return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
+            return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
         }
 
         // Check if this is a module-level constant (e.g., `const utils = @import("utils")`)
@@ -1663,10 +1662,10 @@ impl<'a> Sema<'a> {
                     param_slot: abi_slot,
                     value: value_result.air_ref,
                 },
-                ty: Type::Unit,
+                ty: Type::UNIT,
                 span,
             });
-            return Ok(AnalysisResult::new(air_ref, Type::Unit));
+            return Ok(AnalysisResult::new(air_ref, Type::UNIT));
         }
 
         // Look up local variable
@@ -1702,10 +1701,10 @@ impl<'a> Sema<'a> {
                 slot,
                 value: value_result.air_ref,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::Unit))
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
     }
 
     // ========================================================================
@@ -1803,7 +1802,7 @@ impl<'a> Sema<'a> {
 
         // Get struct def (returns owned copy from pool)
         let struct_def = self.type_pool.struct_def(struct_id);
-        let struct_type = Type::Struct(struct_id);
+        let struct_type = Type::new_struct(struct_id);
 
         // Build a map from field name to struct field index
         let field_index_map: std::collections::HashMap<&str, usize> = struct_def
@@ -2164,13 +2163,13 @@ impl<'a> Sema<'a> {
                     }
 
                     // Return a TypeConst instruction with the struct type
-                    let struct_type = Type::Struct(struct_id);
+                    let struct_type = Type::new_struct(struct_id);
                     let air_ref = air.add_inst(AirInst {
                         data: AirInstData::TypeConst(struct_type),
-                        ty: Type::ComptimeType,
+                        ty: Type::COMPTIME_TYPE,
                         span,
                     });
-                    return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
+                    return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
                 }
             }
         }
@@ -2206,13 +2205,13 @@ impl<'a> Sema<'a> {
                     }
 
                     // Return a TypeConst instruction with the enum type
-                    let enum_type = Type::Enum(enum_id);
+                    let enum_type = Type::new_enum(enum_id);
                     let air_ref = air.add_inst(AirInst {
                         data: AirInstData::TypeConst(enum_type),
-                        ty: Type::ComptimeType,
+                        ty: Type::COMPTIME_TYPE,
                         span,
                     });
-                    return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
+                    return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
                 }
             }
         }
@@ -2281,7 +2280,7 @@ impl<'a> Sema<'a> {
         // Get the array type from HM inference
         let array_type = Self::get_resolved_type(ctx, inst_ref, span, "array literal")?;
 
-        let (array_type_id, _elem_type, expected_len) = match array_type.as_array() {
+        let (_array_type_id, _elem_type, expected_len) = match array_type.as_array() {
             Some(type_id) => {
                 let (element_type, length) = self.type_pool.array_def(type_id);
                 (type_id, element_type, length)
@@ -2345,7 +2344,7 @@ impl<'a> Sema<'a> {
     ) -> CompileResult<AnalysisResult> {
         // Check for constant out-of-bounds index early (before tracing)
         // We need the array type for bounds checking, so peek at the base first
-        let base_inst = self.rir.get(base);
+        let _base_inst = self.rir.get(base);
 
         // Try to trace this expression to a place (lvalue)
         if let Some(trace) = self.try_trace_place(inst_ref, air, ctx)? {
@@ -2503,10 +2502,10 @@ impl<'a> Sema<'a> {
                 // Enum declarations are processed during collection phase
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::UnitConst,
-                    ty: Type::Unit,
+                    ty: Type::UNIT,
                     span: inst.span,
                 });
-                Ok(AnalysisResult::new(air_ref, Type::Unit))
+                Ok(AnalysisResult::new(air_ref, Type::UNIT))
             }
 
             InstData::EnumVariant {
@@ -2537,7 +2536,7 @@ impl<'a> Sema<'a> {
                     inst.span,
                 )?;
 
-                let ty = Type::Enum(enum_id);
+                let ty = Type::new_enum(enum_id);
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::EnumVariant {
@@ -2701,16 +2700,16 @@ impl<'a> Sema<'a> {
 
         // Special case: functions that return `type` with no parameters are implicitly comptime
         // and should be evaluated at compile time.
-        if base_return_type == Type::ComptimeType && args.is_empty() {
+        if base_return_type == Type::COMPTIME_TYPE && args.is_empty() {
             // Try to evaluate the function body at compile time
             if let Some(ConstValue::Type(ty)) = self.try_evaluate_const(fn_body) {
                 // Success! Return a TypeConst instruction instead of a runtime call
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::TypeConst(ty),
-                    ty: Type::ComptimeType,
+                    ty: Type::COMPTIME_TYPE,
                     span,
                 });
-                return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
+                return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
             }
             // If we can't evaluate at compile time, fall through to runtime call
             // (which will fail at link time, but gives a better error experience)
@@ -2759,7 +2758,7 @@ impl<'a> Sema<'a> {
                 if *is_comptime {
                     // Check if this is a type parameter (param type is ComptimeType)
                     // vs a value parameter (param type is i32, bool, etc.)
-                    if param_types[i] == Type::ComptimeType {
+                    if param_types[i] == Type::COMPTIME_TYPE {
                         // This is a TYPE parameter - expect a TypeConst instruction
                         let inst = air.get(air_arg.value);
                         if let AirInstData::TypeConst(ty) = &inst.data {
@@ -2789,7 +2788,7 @@ impl<'a> Sema<'a> {
             }
 
             // Determine the actual return type by substituting type parameters
-            let return_type = if base_return_type == Type::ComptimeType {
+            let return_type = if base_return_type == Type::COMPTIME_TYPE {
                 // Return type is a type parameter - look it up in substitutions
                 *type_subst
                     .get(&return_type_sym)
@@ -2801,7 +2800,7 @@ impl<'a> Sema<'a> {
             // Special case: functions that return `type` (not a type parameter) with no runtime args
             // can be fully evaluated at compile time to produce a concrete anonymous struct type.
             // This handles cases like: `fn Pair(comptime T: type) -> type { struct { first: T, second: T } }`
-            if return_type == Type::ComptimeType && runtime_args.is_empty() {
+            if return_type == Type::COMPTIME_TYPE && runtime_args.is_empty() {
                 // The return type is literally `type`, not a type parameter that was substituted.
                 // Try to evaluate the function body at compile time with type substitutions.
                 if let Some(ConstValue::Type(ty)) =
@@ -2810,10 +2809,10 @@ impl<'a> Sema<'a> {
                     // Success! Return a TypeConst instruction instead of a runtime call
                     let air_ref = air.add_inst(AirInst {
                         data: AirInstData::TypeConst(ty),
-                        ty: Type::ComptimeType,
+                        ty: Type::COMPTIME_TYPE,
                         span,
                     });
-                    return Ok(AnalysisResult::new(air_ref, Type::ComptimeType));
+                    return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
                 }
                 // If we can't evaluate at compile time, fall through to the error below
                 // (we can't have a runtime call that returns `type`)
@@ -3024,10 +3023,10 @@ impl<'a> Sema<'a> {
                 // These are processed during collection phase, just return Unit
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::UnitConst,
-                    ty: Type::Unit,
+                    ty: Type::UNIT,
                     span: inst.span,
                 });
-                Ok(AnalysisResult::new(air_ref, Type::Unit))
+                Ok(AnalysisResult::new(air_ref, Type::UNIT))
             }
 
             InstData::FnDecl { .. } => {

--- a/crates/rue-air/src/sema/anon_structs.rs
+++ b/crates/rue-air/src/sema/anon_structs.rs
@@ -62,7 +62,7 @@ impl Sema<'_> {
                 }
                 if methods_match {
                     // Found a matching struct - return it with is_new=false
-                    return (Type::Struct(struct_id), false);
+                    return (Type::new_struct(struct_id), false);
                 }
             }
         }
@@ -111,6 +111,6 @@ impl Sema<'_> {
         self.structs.insert(final_name_spur, struct_id);
 
         // Return with is_new=true
-        (Type::Struct(struct_id), true)
+        (Type::new_struct(struct_id), true)
     }
 }

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -8,7 +8,7 @@
 use rue_builtins::{BUILTIN_ENUMS, BUILTIN_TYPES, BuiltinFieldType, BuiltinTypeDef};
 
 use super::Sema;
-use crate::types::{EnumDef, EnumId, StructDef, StructField, StructId, Type, TypeKind};
+use crate::types::{EnumDef, StructDef, StructField, StructId, Type, TypeKind};
 
 impl<'a> Sema<'a> {
     /// Phase 0: Inject built-in types as synthetic structs and enums.
@@ -33,7 +33,7 @@ impl<'a> Sema<'a> {
                     ty: match f.ty {
                         BuiltinFieldType::U64 => Type::U64,
                         BuiltinFieldType::U8 => Type::U8,
-                        BuiltinFieldType::Bool => Type::Bool,
+                        BuiltinFieldType::Bool => Type::BOOL,
                     },
                 })
                 .collect();
@@ -136,7 +136,7 @@ impl<'a> Sema<'a> {
     /// Returns the Type::Struct for the builtin String type.
     /// Panics if called before builtin types are injected.
     pub(crate) fn builtin_string_type(&self) -> Type {
-        Type::Struct(
+        Type::new_struct(
             self.builtin_string_id
                 .expect("builtin types not injected yet"),
         )
@@ -164,7 +164,7 @@ impl<'a> Sema<'a> {
     ///
     /// Builtin types like String are now represented as Type::Struct with is_builtin=true.
     pub(crate) fn builtin_air_type(&self, struct_id: StructId) -> Type {
-        Type::Struct(struct_id)
+        Type::new_struct(struct_id)
     }
 
     /// Check if a type is a linear type.

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -34,13 +34,6 @@ pub(crate) struct LocalVar {
 /// For example, `s.a.b` is represented as [sym("a"), sym("b")] with root sym("s").
 pub(crate) type FieldPath = Vec<Spur>;
 
-/// Information about a variable that has been moved.
-#[derive(Debug, Clone)]
-pub(crate) struct MoveInfo {
-    /// Span where the move occurred
-    pub moved_at: Span,
-}
-
 /// Tracks move state for a variable, including partial (field-level) moves.
 #[derive(Debug, Clone, Default)]
 pub(crate) struct VariableMoveState {
@@ -91,15 +84,6 @@ impl VariableMoveState {
         None
     }
 
-    /// Check if the variable is partially moved (some field is moved but not the whole var).
-    /// Returns Some(span) of the first partial move found.
-    pub fn is_partially_moved(&self) -> Option<Span> {
-        if self.full_move.is_some() {
-            return None; // Fully moved, not partially moved
-        }
-        self.partial_moves.values().next().copied()
-    }
-
     /// Check if the entire variable (including all fields) is fully valid to use.
     /// Returns Some(span) if there's any move (full or partial) that would prevent use.
     pub fn is_any_part_moved(&self) -> Option<Span> {
@@ -107,12 +91,6 @@ impl VariableMoveState {
             return Some(span);
         }
         self.partial_moves.values().next().copied()
-    }
-
-    /// Clear all move state (used when variable is reassigned).
-    pub fn clear(&mut self) {
-        self.full_move = None;
-        self.partial_moves.clear();
     }
 
     /// Check if the variable has any move state.
@@ -212,16 +190,8 @@ use rue_rir::InstRef;
 impl ScopedContext for AnalysisContext<'_> {
     type VarInfo = LocalVar;
 
-    fn locals(&self) -> &HashMap<Spur, Self::VarInfo> {
-        &self.locals
-    }
-
     fn locals_mut(&mut self) -> &mut HashMap<Spur, Self::VarInfo> {
         &mut self.locals
-    }
-
-    fn scope_stack(&self) -> &[Vec<(Spur, Option<Self::VarInfo>)>] {
-        &self.scope_stack
     }
 
     fn scope_stack_mut(&mut self) -> &mut Vec<Vec<(Spur, Option<Self::VarInfo>)>> {
@@ -372,6 +342,8 @@ pub(crate) enum ConstValue {
     /// with a specific type like `i32` or `bool`.
     Type(Type),
     /// Unit value - the value of `()`.
+    // TODO(rue-c6gi): Remove #[allow] when Unit const evaluation is implemented
+    #[allow(dead_code)]
     Unit,
 }
 
@@ -393,6 +365,8 @@ impl ConstValue {
     }
 
     /// Try to extract a type value.
+    // TODO(rue-c6gi): Remove #[allow] when Unit const evaluation is implemented
+    #[allow(dead_code)]
     pub fn as_type(self) -> Option<Type> {
         match self {
             ConstValue::Type(ty) => Some(ty),
@@ -401,17 +375,21 @@ impl ConstValue {
     }
 
     /// Check if this is a unit value.
+    // TODO(rue-c6gi): Remove #[allow] when Unit const evaluation is implemented
+    #[allow(dead_code)]
     pub fn is_unit(self) -> bool {
         matches!(self, ConstValue::Unit)
     }
 
     /// Get the type of this constant value.
+    // TODO(rue-c6gi): Remove #[allow] when Unit const evaluation is implemented
+    #[allow(dead_code)]
     pub fn get_type(&self) -> Type {
         match self {
             ConstValue::Integer(_) => Type::I64, // Default to i64 for comptime integers
-            ConstValue::Bool(_) => Type::Bool,
-            ConstValue::Type(_) => Type::ComptimeType,
-            ConstValue::Unit => Type::Unit,
+            ConstValue::Bool(_) => Type::BOOL,
+            ConstValue::Type(_) => Type::COMPTIME_TYPE,
+            ConstValue::Unit => Type::UNIT,
         }
     }
 }
@@ -603,25 +581,6 @@ mod tests {
     }
 
     #[test]
-    fn variable_move_state_is_partially_moved() {
-        let mut state = VariableMoveState::default();
-        let interner = ThreadedRodeo::new();
-        let field_x = interner.get_or_intern("x");
-        let span = Span::new(10, 20);
-
-        // Initially not partially moved
-        assert!(state.is_partially_moved().is_none());
-
-        // After partial move
-        state.mark_path_moved(&[field_x], span);
-        assert_eq!(state.is_partially_moved(), Some(span));
-
-        // After full move, is_partially_moved returns None
-        state.mark_path_moved(&[], Span::new(50, 60));
-        assert!(state.is_partially_moved().is_none());
-    }
-
-    #[test]
     fn variable_move_state_is_any_part_moved() {
         let mut state = VariableMoveState::default();
         let interner = ThreadedRodeo::new();
@@ -640,23 +599,6 @@ mod tests {
         let mut state2 = VariableMoveState::default();
         state2.mark_path_moved(&[], span2);
         assert_eq!(state2.is_any_part_moved(), Some(span2));
-    }
-
-    #[test]
-    fn variable_move_state_clear() {
-        let mut state = VariableMoveState::default();
-        let interner = ThreadedRodeo::new();
-        let field_x = interner.get_or_intern("x");
-        let span = Span::new(10, 20);
-
-        state.mark_path_moved(&[], span);
-        state.partial_moves.insert(vec![field_x], Span::new(30, 40));
-
-        state.clear();
-
-        assert!(state.full_move.is_none());
-        assert!(state.partial_moves.is_empty());
-        assert!(state.is_empty());
     }
 
     #[test]
@@ -782,8 +724,8 @@ mod tests {
         assert_eq!(cv.as_integer(), None);
         assert_eq!(cv.as_bool(), None);
 
-        let cv2 = ConstValue::Type(Type::Bool);
-        assert_eq!(cv2.as_type(), Some(Type::Bool));
+        let cv2 = ConstValue::Type(Type::BOOL);
+        assert_eq!(cv2.as_type(), Some(Type::BOOL));
     }
 
     #[test]
@@ -798,9 +740,9 @@ mod tests {
     #[test]
     fn const_value_get_type() {
         assert_eq!(ConstValue::Integer(42).get_type(), Type::I64);
-        assert_eq!(ConstValue::Bool(true).get_type(), Type::Bool);
-        assert_eq!(ConstValue::Type(Type::I32).get_type(), Type::ComptimeType);
-        assert_eq!(ConstValue::Unit.get_type(), Type::Unit);
+        assert_eq!(ConstValue::Bool(true).get_type(), Type::BOOL);
+        assert_eq!(ConstValue::Type(Type::I32).get_type(), Type::COMPTIME_TYPE);
+        assert_eq!(ConstValue::Unit.get_type(), Type::UNIT);
     }
 
     #[test]

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -21,7 +21,7 @@ use rue_span::Span;
 
 use super::{ConstInfo, FunctionInfo, InferenceContext, MethodInfo, Sema};
 use crate::inference::{FunctionSig, MethodSig};
-use crate::types::{EnumDef, EnumId, StructDef, StructField, StructId, Type};
+use crate::types::{EnumDef, StructDef, StructField, StructId, Type};
 
 impl<'a> Sema<'a> {
     /// Build an `InferenceContext` from the collected type information.
@@ -62,18 +62,18 @@ impl<'a> Sema<'a> {
             })
             .collect();
 
-        // Build struct types map (name -> Type::Struct(id))
+        // Build struct types map (name -> Type::new_struct(id))
         let struct_types: HashMap<Spur, Type> = self
             .structs
             .iter()
-            .map(|(name, id)| (*name, Type::Struct(*id)))
+            .map(|(name, id)| (*name, Type::new_struct(*id)))
             .collect();
 
-        // Build enum types map (name -> Type::Enum(id))
+        // Build enum types map (name -> Type::new_enum(id))
         let enum_types: HashMap<Spur, Type> = self
             .enums
             .iter()
-            .map(|(name, id)| (*name, Type::Enum(*id)))
+            .map(|(name, id)| (*name, Type::new_enum(*id)))
             .collect();
 
         // Build method signatures with InferType for constraint generation
@@ -282,31 +282,7 @@ impl<'a> Sema<'a> {
     pub(crate) fn resolve_declarations(&mut self) -> CompileResult<()> {
         self.resolve_struct_fields()?;
         self.resolve_remaining_declarations()?;
-
-        // Populate the type intern pool (ADR-0024 Phase 1).
-        // This runs after all type definitions are complete so we have
-        // full struct/enum definitions with resolved fields and variants.
-        self.populate_type_pool();
-
         Ok(())
-    }
-
-    /// Update the type intern pool with resolved struct/enum definitions.
-    ///
-    /// This is part of ADR-0024 Phase 3: structs and enums are registered in the
-    /// pool during `register_type_names()` with placeholder empty fields, then
-    /// this method updates them with the fully resolved definitions after
-    /// `resolve_struct_fields()` completes.
-    pub(crate) fn populate_type_pool(&mut self) {
-        // Update all structs in the pool with resolved field definitions
-        for (_, &struct_id) in &self.structs {
-            // The struct is already in the pool from register_type_names
-            // No need to update it again - it's the source of truth
-        }
-
-        // Note: Enum definitions don't need updating as they are complete when registered.
-        // Note: Array types are created on-demand during function body analysis via
-        // the TypeInternPool, which handles deduplication automatically.
     }
 
     /// Resolve struct field types. Must run before @copy validation.
@@ -543,7 +519,7 @@ impl<'a> Sema<'a> {
                         inst.span,
                     )
                 })?;
-                let struct_type = Type::Struct(struct_id);
+                let struct_type = Type::new_struct(struct_id);
 
                 // Look for a .handle() method using StructId
                 let handle_sym = self.interner.get("handle");
@@ -709,17 +685,17 @@ impl<'a> Sema<'a> {
             .collect();
 
         // For generic functions, we defer type resolution of type parameters until specialization.
-        // We use Type::ComptimeType as a placeholder for comptime T: type parameters.
+        // We use Type::COMPTIME_TYPE as a placeholder for comptime T: type parameters.
         let param_types: Vec<Type> = params
             .iter()
             .map(|p| {
                 if p.is_comptime && p.ty == type_sym {
                     // For comptime TYPE parameters (comptime T: type), the type is `type`
-                    Ok(Type::ComptimeType)
+                    Ok(Type::COMPTIME_TYPE)
                 } else if type_param_names.contains(&p.ty) {
                     // This parameter's type is a type parameter (e.g., `x: T` where T is comptime)
                     // Use ComptimeType as a placeholder - actual type determined at specialization
-                    Ok(Type::ComptimeType)
+                    Ok(Type::COMPTIME_TYPE)
                 } else {
                     // Regular params OR comptime VALUE params (comptime n: i32)
                     self.resolve_type(p.ty, span)
@@ -732,7 +708,7 @@ impl<'a> Sema<'a> {
         // a type parameter. For now, check if it matches any type parameter name.
         let ret_type = if type_param_names.contains(&return_type_sym) {
             // Return type is a type parameter - use placeholder
-            Type::ComptimeType
+            Type::COMPTIME_TYPE
         } else {
             self.resolve_type(return_type_sym, span)?
         };
@@ -779,7 +755,7 @@ impl<'a> Sema<'a> {
                 ));
             }
         };
-        let struct_type = Type::Struct(struct_id);
+        let struct_type = Type::new_struct(struct_id);
 
         let methods = self.rir.get_inst_refs(methods_start, methods_len);
         for method_ref in methods {
@@ -953,7 +929,7 @@ impl<'a> Sema<'a> {
                         .module_registry
                         .get_or_create(import_path, resolved_path);
 
-                    Ok(Type::Module(module_id))
+                    Ok(Type::new_module(module_id))
                 } else {
                     // For other intrinsics in const context, we don't support them yet
                     let intrinsic_name = self.interner.resolve(name).to_string();
@@ -972,10 +948,10 @@ impl<'a> Sema<'a> {
             InstData::IntConst(_) => Ok(Type::I32),
 
             // Boolean literals
-            InstData::BoolConst(_) => Ok(Type::Bool),
+            InstData::BoolConst(_) => Ok(Type::BOOL),
 
             // Unit literal
-            InstData::UnitConst => Ok(Type::Unit),
+            InstData::UnitConst => Ok(Type::UNIT),
 
             // String literals
             InstData::StringConst(_) => {

--- a/crates/rue-air/src/sema/imports.rs
+++ b/crates/rue-air/src/sema/imports.rs
@@ -103,7 +103,7 @@ impl Sema<'_> {
             .module_registry
             .get_or_create(import_path, resolved_path);
 
-        Ok(Type::Module(module_id))
+        Ok(Type::new_module(module_id))
     }
 
     /// Resolve an import path for const evaluation.

--- a/crates/rue-air/src/sema/inference_ctx.rs
+++ b/crates/rue-air/src/sema/inference_ctx.rs
@@ -27,9 +27,9 @@ use crate::types::{StructId, Type};
 pub struct InferenceContext {
     /// Function signatures with InferType (for constraint generation).
     pub func_sigs: HashMap<Spur, FunctionSig>,
-    /// Struct types: name -> Type::Struct(id).
+    /// Struct types: name -> Type::new_struct(id).
     pub struct_types: HashMap<Spur, Type>,
-    /// Enum types: name -> Type::Enum(id).
+    /// Enum types: name -> Type::new_enum(id).
     pub enum_types: HashMap<Spur, Type>,
     /// Method signatures with InferType: (struct_id, method_name) -> MethodSig.
     pub method_sigs: HashMap<(StructId, Spur), MethodSig>,

--- a/crates/rue-air/src/sema/sema_ctx_builder.rs
+++ b/crates/rue-air/src/sema/sema_ctx_builder.rs
@@ -96,18 +96,18 @@ impl<'a> Sema<'a> {
             })
             .collect();
 
-        // Build struct types map (name -> Type::Struct(id))
+        // Build struct types map (name -> Type::new_struct(id))
         let struct_types: HashMap<Spur, Type> = self
             .structs
             .iter()
-            .map(|(name, id)| (*name, Type::Struct(*id)))
+            .map(|(name, id)| (*name, Type::new_struct(*id)))
             .collect();
 
-        // Build enum types map (name -> Type::Enum(id))
+        // Build enum types map (name -> Type::new_enum(id))
         let enum_types: HashMap<Spur, Type> = self
             .enums
             .iter()
-            .map(|(name, id)| (*name, Type::Enum(*id)))
+            .map(|(name, id)| (*name, Type::new_enum(*id)))
             .collect();
 
         // Build method signatures with InferType for constraint generation

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -304,7 +304,7 @@ mod tests {
         .unwrap();
 
         assert_eq!(output.functions[0].num_locals, 2);
-        assert_eq!(output.functions[0].air.return_type(), Type::Bool);
+        assert_eq!(output.functions[0].air.return_type(), Type::BOOL);
     }
 
     #[test]
@@ -626,7 +626,7 @@ mod tests {
         )
         .unwrap();
 
-        assert_eq!(output.functions[0].air.return_type(), Type::Bool);
+        assert_eq!(output.functions[0].air.return_type(), Type::BOOL);
     }
 
     #[test]

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -12,7 +12,7 @@ use rue_span::Span;
 
 use super::Sema;
 use crate::inference::InferType;
-use crate::types::{ArrayTypeId, StructId, Type, TypeKind, parse_array_type_syntax};
+use crate::types::{ArrayTypeId, Type, TypeKind, parse_array_type_syntax};
 
 impl<'a> Sema<'a> {
     /// Get a human-readable name for a type.
@@ -92,29 +92,29 @@ impl<'a> Sema<'a> {
 
     /// Convert a fully-resolved InferType to a concrete Type.
     ///
-    /// This handles the conversion of InferType::Array to Type::Array(id)
+    /// This handles the conversion of InferType::Array to Type::new_array(id)
     /// by using the array type registry.
     pub(crate) fn infer_type_to_type(&mut self, ty: &InferType) -> Type {
         match ty {
             InferType::Concrete(t) => *t,
-            InferType::Var(_) => Type::Error,   // Unbound variable
+            InferType::Var(_) => Type::ERROR,   // Unbound variable
             InferType::IntLiteral => Type::I32, // Default (shouldn't happen after resolution)
             InferType::Array { element, length } => {
                 // Recursively convert element type
                 let elem_ty = self.infer_type_to_type(element);
-                if elem_ty == Type::Error {
-                    return Type::Error;
+                if elem_ty == Type::ERROR {
+                    return Type::ERROR;
                 }
                 // Get or create the array type ID
                 let array_type_id = self.get_or_create_array_type(elem_ty, *length);
-                Type::Array(array_type_id)
+                Type::new_array(array_type_id)
             }
         }
     }
 
     /// Convert a concrete Type to InferType for use in constraint generation.
     ///
-    /// This handles the conversion of Type::Array(id) to InferType::Array
+    /// This handles the conversion of Type::new_array(id) to InferType::Array
     /// by looking up the array definition to get element type and length.
     pub(crate) fn type_to_infer_type(&self, ty: Type) -> InferType {
         match ty.kind() {
@@ -147,18 +147,18 @@ impl<'a> Sema<'a> {
             "u16" => return Ok(Type::U16),
             "u32" => return Ok(Type::U32),
             "u64" => return Ok(Type::U64),
-            "bool" => return Ok(Type::Bool),
-            "()" => return Ok(Type::Unit),
-            "!" => return Ok(Type::Never),
+            "bool" => return Ok(Type::BOOL),
+            "()" => return Ok(Type::UNIT),
+            "!" => return Ok(Type::NEVER),
             // The type of types - used for comptime type parameters
-            "type" => return Ok(Type::ComptimeType),
+            "type" => return Ok(Type::COMPTIME_TYPE),
             _ => {}
         }
 
         if let Some(&struct_id) = self.structs.get(&type_sym) {
-            Ok(Type::Struct(struct_id))
+            Ok(Type::new_struct(struct_id))
         } else if let Some(&enum_id) = self.enums.get(&type_sym) {
-            Ok(Type::Enum(enum_id))
+            Ok(Type::new_enum(enum_id))
         } else {
             // Check for array type syntax: [T; N]
             if let Some((element_type, length)) = parse_array_type_syntax(type_name) {
@@ -167,19 +167,19 @@ impl<'a> Sema<'a> {
                 let element_ty = self.resolve_type(element_sym, span)?;
                 // Get or create the array type
                 let array_type_id = self.get_or_create_array_type(element_ty, length);
-                Ok(Type::Array(array_type_id))
+                Ok(Type::new_array(array_type_id))
             } else if let Some(pointee_type_str) = type_name.strip_prefix("ptr const ") {
                 // Pointer type syntax: ptr const T
                 let pointee_sym = self.interner.get_or_intern(pointee_type_str);
                 let pointee_ty = self.resolve_type(pointee_sym, span)?;
                 let ptr_type_id = self.type_pool.intern_ptr_const_from_type(pointee_ty);
-                Ok(Type::PtrConst(ptr_type_id))
+                Ok(Type::new_ptr_const(ptr_type_id))
             } else if let Some(pointee_type_str) = type_name.strip_prefix("ptr mut ") {
                 // Pointer type syntax: ptr mut T
                 let pointee_sym = self.interner.get_or_intern(pointee_type_str);
                 let pointee_ty = self.resolve_type(pointee_sym, span)?;
                 let ptr_type_id = self.type_pool.intern_ptr_mut_from_type(pointee_ty);
-                Ok(Type::PtrMut(ptr_type_id))
+                Ok(Type::new_ptr_mut(ptr_type_id))
             } else {
                 Err(CompileError::new(
                     ErrorKind::UnknownType(type_name.to_string()),
@@ -224,36 +224,36 @@ impl<'a> Sema<'a> {
             "u16" => return Some(Type::U16),
             "u32" => return Some(Type::U32),
             "u64" => return Some(Type::U64),
-            "bool" => return Some(Type::Bool),
-            "()" => return Some(Type::Unit),
-            "!" => return Some(Type::Never),
-            "type" => return Some(Type::ComptimeType),
+            "bool" => return Some(Type::BOOL),
+            "()" => return Some(Type::UNIT),
+            "!" => return Some(Type::NEVER),
+            "type" => return Some(Type::COMPTIME_TYPE),
             _ => {}
         }
 
         if let Some(&struct_id) = self.structs.get(&type_sym) {
-            Some(Type::Struct(struct_id))
+            Some(Type::new_struct(struct_id))
         } else if let Some(&enum_id) = self.enums.get(&type_sym) {
-            Some(Type::Enum(enum_id))
+            Some(Type::new_enum(enum_id))
         } else if let Some((element_type, length)) = parse_array_type_syntax(type_name) {
             // Resolve the element type first
             let element_sym = self.interner.get_or_intern(&element_type);
             let element_ty = self.resolve_type_for_comptime_with_subst(element_sym, type_subst)?;
             // Get or create the array type
             let array_type_id = self.get_or_create_array_type(element_ty, length);
-            Some(Type::Array(array_type_id))
+            Some(Type::new_array(array_type_id))
         } else if let Some(pointee_type_str) = type_name.strip_prefix("ptr const ") {
             // Pointer type syntax: ptr const T
             let pointee_sym = self.interner.get_or_intern(pointee_type_str);
             let pointee_ty = self.resolve_type_for_comptime_with_subst(pointee_sym, type_subst)?;
             let ptr_type_id = self.type_pool.intern_ptr_const_from_type(pointee_ty);
-            Some(Type::PtrConst(ptr_type_id))
+            Some(Type::new_ptr_const(ptr_type_id))
         } else if let Some(pointee_type_str) = type_name.strip_prefix("ptr mut ") {
             // Pointer type syntax: ptr mut T
             let pointee_sym = self.interner.get_or_intern(pointee_type_str);
             let pointee_ty = self.resolve_type_for_comptime_with_subst(pointee_sym, type_subst)?;
             let ptr_type_id = self.type_pool.intern_ptr_mut_from_type(pointee_ty);
-            Some(Type::PtrMut(ptr_type_id))
+            Some(Type::new_ptr_mut(ptr_type_id))
         } else {
             None // Unknown type
         }
@@ -283,7 +283,7 @@ impl<'a> Sema<'a> {
                 // Convert the element type to get the concrete Type
                 // (This is safe because we processed nested arrays first)
                 let elem_ty = self.infer_type_to_concrete_type_for_key(element);
-                if elem_ty != Type::Error {
+                if elem_ty != Type::ERROR {
                     // Pre-create this array type
                     self.get_or_create_array_type(elem_ty, *length);
                 }
@@ -302,17 +302,17 @@ impl<'a> Sema<'a> {
     pub(crate) fn infer_type_to_concrete_type_for_key(&self, ty: &InferType) -> Type {
         match ty {
             InferType::Concrete(t) => *t,
-            InferType::Var(_) => Type::Error,   // Unbound variable
+            InferType::Var(_) => Type::ERROR,   // Unbound variable
             InferType::IntLiteral => Type::I32, // Default
             InferType::Array { element, length } => {
                 // For nested arrays, look up or create the array type
                 let elem_ty = self.infer_type_to_concrete_type_for_key(element);
-                if elem_ty == Type::Error {
-                    return Type::Error;
+                if elem_ty == Type::ERROR {
+                    return Type::ERROR;
                 }
                 // Get or create the array type in the pool
                 let id = self.type_pool.intern_array_from_type(elem_ty, *length);
-                Type::Array(id)
+                Type::new_array(id)
             }
         }
     }
@@ -360,15 +360,5 @@ impl<'a> Sema<'a> {
             // Pointer types take 1 slot (64-bit address)
             TypeKind::PtrConst(_) | TypeKind::PtrMut(_) => 1,
         }
-    }
-
-    /// Get the slot offset of a field within a struct.
-    /// Returns the number of slots before the field starts.
-    pub(crate) fn field_slot_offset(&self, struct_id: StructId, field_index: usize) -> u32 {
-        let struct_def = self.type_pool.struct_def(struct_id);
-        struct_def.fields[..field_index]
-            .iter()
-            .map(|f| self.abi_slot_count(f.ty))
-            .sum()
     }
 }

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -154,9 +154,9 @@ impl Default for ModuleRegistry {
 pub struct InferenceContext {
     /// Function signatures with InferType (for constraint generation).
     pub func_sigs: HashMap<Spur, FunctionSig>,
-    /// Struct types: name -> Type::Struct(id).
+    /// Struct types: name -> Type::new_struct(id).
     pub struct_types: HashMap<Spur, Type>,
-    /// Enum types: name -> Type::Enum(id).
+    /// Enum types: name -> Type::new_enum(id).
     pub enum_types: HashMap<Spur, Type>,
     /// Method signatures with InferType: (struct_id, method_name) -> MethodSig.
     pub method_sigs: HashMap<(StructId, Spur), MethodSig>,
@@ -254,7 +254,7 @@ impl<'a> SemaContext<'a> {
     /// Get the builtin String type as a Type::Struct.
     pub fn builtin_string_type(&self) -> Type {
         self.builtin_string_id
-            .map(Type::Struct)
+            .map(Type::new_struct)
             .expect("String type should be registered during builtin injection")
     }
 
@@ -595,7 +595,7 @@ impl<'a> SemaContext<'a> {
 
     /// Get the AIR output type for a builtin struct.
     pub fn builtin_air_type(&self, struct_id: StructId) -> Type {
-        Type::Struct(struct_id)
+        Type::new_struct(struct_id)
     }
 
     /// Check if a type is a linear type.

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -230,12 +230,12 @@ fn create_specialized_function(
     }
 
     // Calculate the return type by substituting type parameters
-    let return_type = if base_info.return_type == Type::ComptimeType {
+    let return_type = if base_info.return_type == Type::COMPTIME_TYPE {
         // The return type references a type parameter - substitute it
         type_subst
             .get(&base_info.return_type_sym)
             .copied()
-            .unwrap_or(Type::Unit)
+            .unwrap_or(Type::UNIT)
     } else {
         base_info.return_type
     };
@@ -254,7 +254,7 @@ fn create_specialized_function(
             // The param name's type symbol is stored in param_types as ComptimeType,
             // but we need to find which type param it references.
             // For now, we'll need to look at the original RIR to get the type name.
-            let concrete_ty = if *ty == Type::ComptimeType {
+            let concrete_ty = if *ty == Type::COMPTIME_TYPE {
                 // This parameter's type is a type parameter. We need to find which one.
                 // The type name in RIR is stored in the param's ty field as a Spur.
                 // Unfortunately, we've lost that information by this point.
@@ -304,9 +304,6 @@ fn substitute_param_type(
     param_name: Spur,
     type_subst: &HashMap<Spur, Type>,
 ) -> Option<Type> {
-    // Get the original RIR function to find the type symbol for this param
-    let fn_inst = sema.rir.get(base_info.body);
-
     // Walk up to find the FnDecl that contains this body
     for (_, inst) in sema.rir.iter() {
         if let rue_rir::InstData::FnDecl {

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -210,7 +210,7 @@ pub enum TypeKind {
 ///
 /// Use constructor methods for composite types:
 /// ```ignore
-/// let ty = Type::Struct(struct_id);
+/// let ty = Type::new_struct(struct_id);
 /// ```
 ///
 /// Use `kind()` for pattern matching:
@@ -226,7 +226,7 @@ pub struct Type(u32);
 
 impl Default for Type {
     fn default() -> Self {
-        Type::Unit
+        Type::UNIT
     }
 }
 
@@ -242,17 +242,17 @@ impl std::fmt::Debug for Type {
             TypeKind::U16 => write!(f, "Type::U16"),
             TypeKind::U32 => write!(f, "Type::U32"),
             TypeKind::U64 => write!(f, "Type::U64"),
-            TypeKind::Bool => write!(f, "Type::Bool"),
-            TypeKind::Unit => write!(f, "Type::Unit"),
-            TypeKind::Error => write!(f, "Type::Error"),
-            TypeKind::Never => write!(f, "Type::Never"),
-            TypeKind::ComptimeType => write!(f, "Type::ComptimeType"),
-            TypeKind::Struct(id) => write!(f, "Type::Struct(StructId({}))", id.0),
-            TypeKind::Enum(id) => write!(f, "Type::Enum(EnumId({}))", id.0),
-            TypeKind::Array(id) => write!(f, "Type::Array(ArrayTypeId({}))", id.0),
-            TypeKind::PtrConst(id) => write!(f, "Type::PtrConst(PtrConstTypeId({}))", id.0),
-            TypeKind::PtrMut(id) => write!(f, "Type::PtrMut(PtrMutTypeId({}))", id.0),
-            TypeKind::Module(id) => write!(f, "Type::Module(ModuleId({}))", id.0),
+            TypeKind::Bool => write!(f, "Type::BOOL"),
+            TypeKind::Unit => write!(f, "Type::UNIT"),
+            TypeKind::Error => write!(f, "Type::ERROR"),
+            TypeKind::Never => write!(f, "Type::NEVER"),
+            TypeKind::ComptimeType => write!(f, "Type::COMPTIME_TYPE"),
+            TypeKind::Struct(id) => write!(f, "Type::new_struct(StructId({}))", id.0),
+            TypeKind::Enum(id) => write!(f, "Type::new_enum(EnumId({}))", id.0),
+            TypeKind::Array(id) => write!(f, "Type::new_array(ArrayTypeId({}))", id.0),
+            TypeKind::PtrConst(id) => write!(f, "Type::new_ptr_const(PtrConstTypeId({}))", id.0),
+            TypeKind::PtrMut(id) => write!(f, "Type::new_ptr_mut(PtrMutTypeId({}))", id.0),
+            TypeKind::Module(id) => write!(f, "Type::new_module(ModuleId({}))", id.0),
         }
     }
 }
@@ -286,52 +286,52 @@ impl Type {
     /// 64-bit unsigned integer
     pub const U64: Type = Type(7);
     /// Boolean
-    pub const Bool: Type = Type(8);
+    pub const BOOL: Type = Type(8);
     /// The unit type (for functions that don't return a value)
-    pub const Unit: Type = Type(9);
+    pub const UNIT: Type = Type(9);
     /// An error type (used during type checking to continue after errors)
-    pub const Error: Type = Type(10);
+    pub const ERROR: Type = Type(10);
     /// The never type - represents computations that don't return
-    pub const Never: Type = Type(11);
+    pub const NEVER: Type = Type(11);
     /// The comptime type - the type of types themselves
-    pub const ComptimeType: Type = Type(12);
+    pub const COMPTIME_TYPE: Type = Type(12);
 }
 
 // Composite type constructors
 impl Type {
     /// Create a struct type from a StructId.
     #[inline]
-    pub const fn Struct(id: StructId) -> Type {
+    pub const fn new_struct(id: StructId) -> Type {
         Type(TAG_STRUCT | ((id.0 as u32) << 8))
     }
 
     /// Create an enum type from an EnumId.
     #[inline]
-    pub const fn Enum(id: EnumId) -> Type {
+    pub const fn new_enum(id: EnumId) -> Type {
         Type(TAG_ENUM | ((id.0 as u32) << 8))
     }
 
     /// Create an array type from an ArrayTypeId.
     #[inline]
-    pub const fn Array(id: ArrayTypeId) -> Type {
+    pub const fn new_array(id: ArrayTypeId) -> Type {
         Type(TAG_ARRAY | ((id.0 as u32) << 8))
     }
 
     /// Create a raw const pointer type from a PtrConstTypeId.
     #[inline]
-    pub const fn PtrConst(id: PtrConstTypeId) -> Type {
+    pub const fn new_ptr_const(id: PtrConstTypeId) -> Type {
         Type(TAG_PTR_CONST | ((id.0 as u32) << 8))
     }
 
     /// Create a raw mut pointer type from a PtrMutTypeId.
     #[inline]
-    pub const fn PtrMut(id: PtrMutTypeId) -> Type {
+    pub const fn new_ptr_mut(id: PtrMutTypeId) -> Type {
         Type(TAG_PTR_MUT | ((id.0 as u32) << 8))
     }
 
     /// Create a module type from a ModuleId.
     #[inline]
-    pub const fn Module(id: ModuleId) -> Type {
+    pub const fn new_module(id: ModuleId) -> Type {
         Type(TAG_MODULE | ((id.0 as u32) << 8))
     }
 }
@@ -412,7 +412,7 @@ impl EnumDef {
     pub fn discriminant_type(&self) -> Type {
         let count = self.variants.len();
         if count == 0 {
-            Type::Never // Zero-variant enum is uninhabited
+            Type::NEVER // Zero-variant enum is uninhabited
         } else if count <= 256 {
             Type::U8
         } else if count <= 65536 {
@@ -580,19 +580,19 @@ impl Type {
     /// Check if this is an error type.
     #[inline]
     pub fn is_error(&self) -> bool {
-        *self == Type::Error
+        *self == Type::ERROR
     }
 
     /// Check if this is the never type.
     #[inline]
     pub fn is_never(&self) -> bool {
-        *self == Type::Never
+        *self == Type::NEVER
     }
 
     /// Check if this is the comptime type (the type of types).
     #[inline]
     pub fn is_comptime_type(&self) -> bool {
-        *self == Type::ComptimeType
+        *self == Type::COMPTIME_TYPE
     }
 
     /// Check if this is a struct type.
@@ -997,17 +997,17 @@ mod tests {
 
     #[test]
     fn test_type_name_other() {
-        assert_eq!(Type::Bool.name(), "bool");
-        assert_eq!(Type::Unit.name(), "()");
-        assert_eq!(Type::Error.name(), "<error>");
-        assert_eq!(Type::Never.name(), "!");
+        assert_eq!(Type::BOOL.name(), "bool");
+        assert_eq!(Type::UNIT.name(), "()");
+        assert_eq!(Type::ERROR.name(), "<error>");
+        assert_eq!(Type::NEVER.name(), "!");
     }
 
     #[test]
     fn test_type_name_composite() {
-        assert_eq!(Type::Struct(StructId(0)).name(), "<struct>");
-        assert_eq!(Type::Enum(EnumId(0)).name(), "<enum>");
-        assert_eq!(Type::Array(ArrayTypeId(0)).name(), "<array>");
+        assert_eq!(Type::new_struct(StructId(0)).name(), "<struct>");
+        assert_eq!(Type::new_enum(EnumId(0)).name(), "<enum>");
+        assert_eq!(Type::new_array(ArrayTypeId(0)).name(), "<array>");
     }
 
     // ========== Type::is_integer() tests ==========
@@ -1030,13 +1030,13 @@ mod tests {
 
     #[test]
     fn test_is_integer_non_integers() {
-        assert!(!Type::Bool.is_integer());
-        assert!(!Type::Unit.is_integer());
-        assert!(!Type::Struct(StructId(0)).is_integer());
-        assert!(!Type::Enum(EnumId(0)).is_integer());
-        assert!(!Type::Array(ArrayTypeId(0)).is_integer());
-        assert!(!Type::Error.is_integer());
-        assert!(!Type::Never.is_integer());
+        assert!(!Type::BOOL.is_integer());
+        assert!(!Type::UNIT.is_integer());
+        assert!(!Type::new_struct(StructId(0)).is_integer());
+        assert!(!Type::new_enum(EnumId(0)).is_integer());
+        assert!(!Type::new_array(ArrayTypeId(0)).is_integer());
+        assert!(!Type::ERROR.is_integer());
+        assert!(!Type::NEVER.is_integer());
     }
 
     // ========== Type::is_signed() tests ==========
@@ -1052,7 +1052,7 @@ mod tests {
         assert!(!Type::U16.is_signed());
         assert!(!Type::U32.is_signed());
         assert!(!Type::U64.is_signed());
-        assert!(!Type::Bool.is_signed());
+        assert!(!Type::BOOL.is_signed());
     }
 
     // ========== Type::is_unsigned() tests ==========
@@ -1068,7 +1068,7 @@ mod tests {
         assert!(!Type::I16.is_unsigned());
         assert!(!Type::I32.is_unsigned());
         assert!(!Type::I64.is_unsigned());
-        assert!(!Type::Bool.is_unsigned());
+        assert!(!Type::BOOL.is_unsigned());
     }
 
     // ========== Type::is_64_bit() tests ==========
@@ -1084,76 +1084,79 @@ mod tests {
         assert!(!Type::U8.is_64_bit());
         assert!(!Type::U16.is_64_bit());
         assert!(!Type::U32.is_64_bit());
-        assert!(!Type::Bool.is_64_bit());
+        assert!(!Type::BOOL.is_64_bit());
     }
 
     // ========== Type::is_error() tests ==========
 
     #[test]
     fn test_is_error() {
-        assert!(Type::Error.is_error());
+        assert!(Type::ERROR.is_error());
         assert!(!Type::I32.is_error());
-        assert!(!Type::Never.is_error());
+        assert!(!Type::NEVER.is_error());
     }
 
     // ========== Type::is_never() tests ==========
 
     #[test]
     fn test_is_never() {
-        assert!(Type::Never.is_never());
+        assert!(Type::NEVER.is_never());
         assert!(!Type::I32.is_never());
-        assert!(!Type::Error.is_never());
+        assert!(!Type::ERROR.is_never());
     }
 
     // ========== Type::is_struct() and as_struct() tests ==========
 
     #[test]
     fn test_is_struct() {
-        assert!(Type::Struct(StructId(0)).is_struct());
-        assert!(Type::Struct(StructId(42)).is_struct());
+        assert!(Type::new_struct(StructId(0)).is_struct());
+        assert!(Type::new_struct(StructId(42)).is_struct());
         assert!(!Type::I32.is_struct());
-        assert!(!Type::Enum(EnumId(0)).is_struct());
+        assert!(!Type::new_enum(EnumId(0)).is_struct());
     }
 
     #[test]
     fn test_as_struct() {
-        assert_eq!(Type::Struct(StructId(5)).as_struct(), Some(StructId(5)));
+        assert_eq!(Type::new_struct(StructId(5)).as_struct(), Some(StructId(5)));
         assert_eq!(Type::I32.as_struct(), None);
-        assert_eq!(Type::Enum(EnumId(0)).as_struct(), None);
+        assert_eq!(Type::new_enum(EnumId(0)).as_struct(), None);
     }
 
     // ========== Type::is_enum() and as_enum() tests ==========
 
     #[test]
     fn test_is_enum() {
-        assert!(Type::Enum(EnumId(0)).is_enum());
-        assert!(Type::Enum(EnumId(42)).is_enum());
+        assert!(Type::new_enum(EnumId(0)).is_enum());
+        assert!(Type::new_enum(EnumId(42)).is_enum());
         assert!(!Type::I32.is_enum());
-        assert!(!Type::Struct(StructId(0)).is_enum());
+        assert!(!Type::new_struct(StructId(0)).is_enum());
     }
 
     #[test]
     fn test_as_enum() {
-        assert_eq!(Type::Enum(EnumId(5)).as_enum(), Some(EnumId(5)));
+        assert_eq!(Type::new_enum(EnumId(5)).as_enum(), Some(EnumId(5)));
         assert_eq!(Type::I32.as_enum(), None);
-        assert_eq!(Type::Struct(StructId(0)).as_enum(), None);
+        assert_eq!(Type::new_struct(StructId(0)).as_enum(), None);
     }
 
     // ========== Type::is_array() and as_array() tests ==========
 
     #[test]
     fn test_is_array() {
-        assert!(Type::Array(ArrayTypeId(0)).is_array());
-        assert!(Type::Array(ArrayTypeId(42)).is_array());
+        assert!(Type::new_array(ArrayTypeId(0)).is_array());
+        assert!(Type::new_array(ArrayTypeId(42)).is_array());
         assert!(!Type::I32.is_array());
-        assert!(!Type::Struct(StructId(0)).is_array());
+        assert!(!Type::new_struct(StructId(0)).is_array());
     }
 
     #[test]
     fn test_as_array() {
-        assert_eq!(Type::Array(ArrayTypeId(5)).as_array(), Some(ArrayTypeId(5)));
+        assert_eq!(
+            Type::new_array(ArrayTypeId(5)).as_array(),
+            Some(ArrayTypeId(5))
+        );
         assert_eq!(Type::I32.as_array(), None);
-        assert_eq!(Type::Struct(StructId(0)).as_array(), None);
+        assert_eq!(Type::new_struct(StructId(0)).as_array(), None);
     }
 
     // ========== Type::is_copy() tests ==========
@@ -1171,25 +1174,25 @@ mod tests {
         assert!(Type::U64.is_copy());
 
         // Bool and Unit are Copy
-        assert!(Type::Bool.is_copy());
-        assert!(Type::Unit.is_copy());
+        assert!(Type::BOOL.is_copy());
+        assert!(Type::UNIT.is_copy());
     }
 
     #[test]
     fn test_is_copy_special() {
         // Enum types are Copy
-        assert!(Type::Enum(EnumId(0)).is_copy());
+        assert!(Type::new_enum(EnumId(0)).is_copy());
 
         // Never and Error are Copy for convenience
-        assert!(Type::Never.is_copy());
-        assert!(Type::Error.is_copy());
+        assert!(Type::NEVER.is_copy());
+        assert!(Type::ERROR.is_copy());
     }
 
     #[test]
     fn test_is_copy_move_types() {
         // Struct and Array are move types (String is a builtin struct now)
-        assert!(!Type::Struct(StructId(0)).is_copy());
-        assert!(!Type::Array(ArrayTypeId(0)).is_copy());
+        assert!(!Type::new_struct(StructId(0)).is_copy());
+        assert!(!Type::new_array(ArrayTypeId(0)).is_copy());
     }
 
     // ========== Type::can_coerce_to() tests ==========
@@ -1197,30 +1200,30 @@ mod tests {
     #[test]
     fn test_can_coerce_to_same_type() {
         assert!(Type::I32.can_coerce_to(&Type::I32));
-        assert!(Type::Bool.can_coerce_to(&Type::Bool));
-        assert!(Type::Struct(StructId(0)).can_coerce_to(&Type::Struct(StructId(0))));
+        assert!(Type::BOOL.can_coerce_to(&Type::BOOL));
+        assert!(Type::new_struct(StructId(0)).can_coerce_to(&Type::new_struct(StructId(0))));
     }
 
     #[test]
     fn test_can_coerce_to_never_coerces_to_anything() {
-        assert!(Type::Never.can_coerce_to(&Type::I32));
-        assert!(Type::Never.can_coerce_to(&Type::Bool));
-        assert!(Type::Never.can_coerce_to(&Type::Struct(StructId(0))));
+        assert!(Type::NEVER.can_coerce_to(&Type::I32));
+        assert!(Type::NEVER.can_coerce_to(&Type::BOOL));
+        assert!(Type::NEVER.can_coerce_to(&Type::new_struct(StructId(0))));
     }
 
     #[test]
     fn test_can_coerce_to_error_coerces_to_anything() {
-        assert!(Type::Error.can_coerce_to(&Type::I32));
-        assert!(Type::Error.can_coerce_to(&Type::Bool));
-        assert!(Type::Error.can_coerce_to(&Type::Struct(StructId(0))));
+        assert!(Type::ERROR.can_coerce_to(&Type::I32));
+        assert!(Type::ERROR.can_coerce_to(&Type::BOOL));
+        assert!(Type::ERROR.can_coerce_to(&Type::new_struct(StructId(0))));
     }
 
     #[test]
     fn test_can_coerce_to_different_types_fail() {
-        assert!(!Type::I32.can_coerce_to(&Type::Bool));
-        assert!(!Type::Bool.can_coerce_to(&Type::I32));
+        assert!(!Type::I32.can_coerce_to(&Type::BOOL));
+        assert!(!Type::BOOL.can_coerce_to(&Type::I32));
         assert!(!Type::I32.can_coerce_to(&Type::I64));
-        assert!(!Type::Struct(StructId(0)).can_coerce_to(&Type::I32));
+        assert!(!Type::new_struct(StructId(0)).can_coerce_to(&Type::I32));
     }
 
     // ========== Type::literal_fits() tests ==========
@@ -1282,9 +1285,9 @@ mod tests {
 
     #[test]
     fn test_literal_fits_non_integer() {
-        assert!(!Type::Bool.literal_fits(0));
-        assert!(!Type::Struct(StructId(0)).literal_fits(0));
-        assert!(!Type::Unit.literal_fits(0));
+        assert!(!Type::BOOL.literal_fits(0));
+        assert!(!Type::new_struct(StructId(0)).literal_fits(0));
+        assert!(!Type::UNIT.literal_fits(0));
     }
 
     // ========== Type::negated_literal_fits() tests ==========
@@ -1324,8 +1327,8 @@ mod tests {
 
     #[test]
     fn test_negated_literal_fits_non_integer() {
-        assert!(!Type::Bool.negated_literal_fits(1));
-        assert!(!Type::Struct(StructId(0)).negated_literal_fits(1));
+        assert!(!Type::BOOL.negated_literal_fits(1));
+        assert!(!Type::new_struct(StructId(0)).negated_literal_fits(1));
     }
 
     // ========== Type Display tests ==========
@@ -1333,15 +1336,15 @@ mod tests {
     #[test]
     fn test_type_display() {
         assert_eq!(format!("{}", Type::I32), "i32");
-        assert_eq!(format!("{}", Type::Bool), "bool");
-        assert_eq!(format!("{}", Type::Never), "!");
+        assert_eq!(format!("{}", Type::BOOL), "bool");
+        assert_eq!(format!("{}", Type::NEVER), "!");
     }
 
     // ========== Type Default tests ==========
 
     #[test]
     fn test_type_default() {
-        assert_eq!(Type::default(), Type::Unit);
+        assert_eq!(Type::default(), Type::UNIT);
     }
 
     // ========== StructDef tests ==========
@@ -1405,7 +1408,7 @@ mod tests {
                 },
                 StructField {
                     name: "b".to_string(),
-                    ty: Type::Bool,
+                    ty: Type::BOOL,
                 },
                 StructField {
                     name: "c".to_string(),
@@ -1467,7 +1470,7 @@ mod tests {
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
         };
-        assert_eq!(empty.discriminant_type(), Type::Never);
+        assert_eq!(empty.discriminant_type(), Type::NEVER);
     }
 
     #[test]
@@ -1502,49 +1505,49 @@ mod tests {
         assert_eq!(medium.discriminant_type(), Type::U16);
     }
 
-    // ========== Type::ComptimeType tests ==========
+    // ========== Type::COMPTIME_TYPE tests ==========
 
     #[test]
     fn test_comptime_type_name() {
-        assert_eq!(Type::ComptimeType.name(), "type");
+        assert_eq!(Type::COMPTIME_TYPE.name(), "type");
     }
 
     #[test]
     fn test_comptime_type_is_copy() {
-        assert!(Type::ComptimeType.is_copy());
+        assert!(Type::COMPTIME_TYPE.is_copy());
     }
 
     #[test]
     fn test_comptime_type_is_comptime_type() {
-        assert!(Type::ComptimeType.is_comptime_type());
+        assert!(Type::COMPTIME_TYPE.is_comptime_type());
         assert!(!Type::I32.is_comptime_type());
-        assert!(!Type::Bool.is_comptime_type());
+        assert!(!Type::BOOL.is_comptime_type());
     }
 
     #[test]
     fn test_comptime_type_not_integer() {
-        assert!(!Type::ComptimeType.is_integer());
+        assert!(!Type::COMPTIME_TYPE.is_integer());
     }
 
     #[test]
     fn test_comptime_type_not_signed() {
-        assert!(!Type::ComptimeType.is_signed());
+        assert!(!Type::COMPTIME_TYPE.is_signed());
     }
 
     #[test]
     fn test_comptime_type_not_64_bit() {
-        assert!(!Type::ComptimeType.is_64_bit());
+        assert!(!Type::COMPTIME_TYPE.is_64_bit());
     }
 
     #[test]
     fn test_comptime_type_can_coerce_to_itself() {
-        assert!(Type::ComptimeType.can_coerce_to(&Type::ComptimeType));
+        assert!(Type::COMPTIME_TYPE.can_coerce_to(&Type::COMPTIME_TYPE));
     }
 
     #[test]
     fn test_comptime_type_cannot_coerce_to_runtime_types() {
-        assert!(!Type::ComptimeType.can_coerce_to(&Type::I32));
-        assert!(!Type::ComptimeType.can_coerce_to(&Type::Bool));
+        assert!(!Type::COMPTIME_TYPE.can_coerce_to(&Type::I32));
+        assert!(!Type::COMPTIME_TYPE.can_coerce_to(&Type::BOOL));
     }
 
     // ========== Type encoding validation tests ==========
@@ -1621,9 +1624,9 @@ mod tests {
     #[test]
     fn test_try_kind_valid() {
         assert_eq!(Type::I32.try_kind(), Some(TypeKind::I32));
-        assert_eq!(Type::Bool.try_kind(), Some(TypeKind::Bool));
+        assert_eq!(Type::BOOL.try_kind(), Some(TypeKind::Bool));
         assert_eq!(
-            Type::Struct(StructId(42)).try_kind(),
+            Type::new_struct(StructId(42)).try_kind(),
             Some(TypeKind::Struct(StructId(42)))
         );
     }
@@ -1641,7 +1644,7 @@ mod tests {
     #[test]
     fn test_is_valid_method() {
         assert!(Type::I32.is_valid());
-        assert!(Type::Struct(StructId(0)).is_valid());
+        assert!(Type::new_struct(StructId(0)).is_valid());
 
         // Invalid types
         let invalid = Type::from_u32(50);
@@ -1667,18 +1670,18 @@ mod tests {
             Type::U16,
             Type::U32,
             Type::U64,
-            Type::Bool,
-            Type::Unit,
-            Type::Error,
-            Type::Never,
-            Type::ComptimeType,
-            Type::Struct(StructId(0)),
-            Type::Struct(StructId(1000)),
-            Type::Enum(EnumId(5)),
-            Type::Array(ArrayTypeId(10)),
-            Type::PtrConst(PtrConstTypeId(20)),
-            Type::PtrMut(PtrMutTypeId(30)),
-            Type::Module(ModuleId(40)),
+            Type::BOOL,
+            Type::UNIT,
+            Type::ERROR,
+            Type::NEVER,
+            Type::COMPTIME_TYPE,
+            Type::new_struct(StructId(0)),
+            Type::new_struct(StructId(1000)),
+            Type::new_enum(EnumId(5)),
+            Type::new_array(ArrayTypeId(10)),
+            Type::new_ptr_const(PtrConstTypeId(20)),
+            Type::new_ptr_mut(PtrMutTypeId(30)),
+            Type::new_module(ModuleId(40)),
         ];
 
         for ty in types {

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -393,10 +393,10 @@ impl<'a> CfgBuilder<'a> {
                 let join_block = self.cfg.new_block();
 
                 // Add block parameter for the result
-                let result_param = self.cfg.add_block_param(join_block, Type::Bool);
+                let result_param = self.cfg.add_block_param(join_block, Type::BOOL);
 
                 // Branch: if lhs is false, go to join with false; else evaluate rhs
-                let false_val = self.emit(CfgInstData::BoolConst(false), Type::Bool, span);
+                let false_val = self.emit(CfgInstData::BoolConst(false), Type::BOOL, span);
                 let (then_args_start, then_args_len) = self.cfg.push_extra(std::iter::empty());
                 let (else_args_start, else_args_len) =
                     self.cfg.push_extra(std::iter::once(false_val));
@@ -447,10 +447,10 @@ impl<'a> CfgBuilder<'a> {
                 let join_block = self.cfg.new_block();
 
                 // Add block parameter for the result
-                let result_param = self.cfg.add_block_param(join_block, Type::Bool);
+                let result_param = self.cfg.add_block_param(join_block, Type::BOOL);
 
                 // Branch: if lhs is true, go to join with true; else evaluate rhs
-                let true_val = self.emit(CfgInstData::BoolConst(true), Type::Bool, span);
+                let true_val = self.emit(CfgInstData::BoolConst(true), Type::BOOL, span);
                 let (then_args_start, then_args_len) =
                     self.cfg.push_extra(std::iter::once(true_val));
                 let (else_args_start, else_args_len) = self.cfg.push_extra(std::iter::empty());
@@ -607,13 +607,13 @@ impl<'a> CfgBuilder<'a> {
                 // If init produces a value, use it; otherwise use a dummy Unit value
                 let init_val = init_result
                     .value
-                    .unwrap_or_else(|| self.emit(CfgInstData::Const(0), Type::Unit, span));
+                    .unwrap_or_else(|| self.emit(CfgInstData::Const(0), Type::UNIT, span));
                 self.emit(
                     CfgInstData::Alloc {
                         slot: *slot,
                         init: init_val,
                     },
-                    Type::Unit,
+                    Type::UNIT,
                     span,
                 );
                 ExprResult {
@@ -640,7 +640,7 @@ impl<'a> CfgBuilder<'a> {
                         slot: *slot,
                         value: val,
                     },
-                    Type::Unit,
+                    Type::UNIT,
                     span,
                 );
                 ExprResult {
@@ -658,7 +658,7 @@ impl<'a> CfgBuilder<'a> {
                         param_slot: *param_slot,
                         value: val,
                     },
-                    Type::Unit,
+                    Type::UNIT,
                     span,
                 );
                 ExprResult {
@@ -803,7 +803,7 @@ impl<'a> CfgBuilder<'a> {
                 // Emit StorageLive, Alloc to store the computed struct
                 self.emit(
                     CfgInstData::StorageLive { slot: temp_slot },
-                    Type::Unit,
+                    Type::UNIT,
                     span,
                 );
                 self.emit(
@@ -811,7 +811,7 @@ impl<'a> CfgBuilder<'a> {
                         slot: temp_slot,
                         init: base_val,
                     },
-                    Type::Unit,
+                    Type::UNIT,
                     span,
                 );
 
@@ -828,7 +828,7 @@ impl<'a> CfgBuilder<'a> {
                 // Emit StorageDead for the temp
                 self.emit(
                     CfgInstData::StorageDead { slot: temp_slot },
-                    Type::Unit,
+                    Type::UNIT,
                     span,
                 );
 
@@ -855,7 +855,7 @@ impl<'a> CfgBuilder<'a> {
                         field_index: *field_index,
                         value: val,
                     },
-                    Type::Unit,
+                    Type::UNIT,
                     span,
                 );
                 ExprResult {
@@ -882,7 +882,7 @@ impl<'a> CfgBuilder<'a> {
                         field_index: *field_index,
                         value: val,
                     },
-                    Type::Unit,
+                    Type::UNIT,
                     span,
                 );
                 ExprResult {
@@ -998,7 +998,7 @@ impl<'a> CfgBuilder<'a> {
                                     );
                                     self.emit(
                                         CfgInstData::Drop { value: slot_val },
-                                        Type::Unit,
+                                        Type::UNIT,
                                         live_slot.span,
                                     );
                                 }
@@ -1006,7 +1006,7 @@ impl<'a> CfgBuilder<'a> {
                                     CfgInstData::StorageDead {
                                         slot: live_slot.slot,
                                     },
-                                    Type::Unit,
+                                    Type::UNIT,
                                     live_slot.span,
                                 );
                             }
@@ -1062,7 +1062,7 @@ impl<'a> CfgBuilder<'a> {
                     self.lower_inst(*else_val)
                 } else {
                     // No else - emit unit
-                    let unit_val = self.emit(CfgInstData::Const(0), Type::Unit, span);
+                    let unit_val = self.emit(CfgInstData::Const(0), Type::UNIT, span);
                     ExprResult {
                         value: Some(unit_val),
                         continuation: Continuation::Continues,
@@ -1082,13 +1082,13 @@ impl<'a> CfgBuilder<'a> {
 
                 // Determine result type
                 let result_type = if then_type.is_never() {
-                    else_type.unwrap_or(Type::Unit)
+                    else_type.unwrap_or(Type::UNIT)
                 } else {
                     then_type
                 };
 
                 // Add block parameter for result (if we have a value type)
-                let result_param = if result_type != Type::Unit && result_type != Type::Never {
+                let result_param = if result_type != Type::UNIT && result_type != Type::NEVER {
                     Some(self.cfg.add_block_param(join_block, result_type))
                 } else {
                     None
@@ -1219,7 +1219,7 @@ impl<'a> CfgBuilder<'a> {
                 self.current_block = exit_block;
 
                 // Loops produce a unit value (for use in unit-returning functions)
-                let unit_val = self.emit(CfgInstData::Const(0), Type::Unit, span);
+                let unit_val = self.emit(CfgInstData::Const(0), Type::UNIT, span);
                 ExprResult {
                     value: Some(unit_val),
                     continuation: Continuation::Continues,
@@ -1289,7 +1289,7 @@ impl<'a> CfgBuilder<'a> {
 
                 // Infinite loops have Never type, but if we reach exit_block via break,
                 // we need a dummy unit value for the loop expression result.
-                let unit_val = self.emit(CfgInstData::Const(0), Type::Unit, span);
+                let unit_val = self.emit(CfgInstData::Const(0), Type::UNIT, span);
                 ExprResult {
                     value: Some(unit_val),
                     continuation: Continuation::Continues,
@@ -1319,7 +1319,7 @@ impl<'a> CfgBuilder<'a> {
                     .iter()
                     .map(|(_, body)| self.air.get(*body).ty)
                     .find(|ty| !ty.is_never())
-                    .unwrap_or(Type::Never);
+                    .unwrap_or(Type::NEVER);
 
                 // Create the switch terminator
                 // Build cases: for each arm, check pattern and jump to corresponding block
@@ -1398,7 +1398,7 @@ impl<'a> CfgBuilder<'a> {
                 }
 
                 // Add block parameter for result (if we have a value type)
-                let result_param = if result_type != Type::Unit && result_type != Type::Never {
+                let result_param = if result_type != Type::UNIT && result_type != Type::NEVER {
                     Some(self.cfg.add_block_param(join_block, result_type))
                 } else {
                     None
@@ -1574,7 +1574,7 @@ impl<'a> CfgBuilder<'a> {
                 // Emit StorageLive, Alloc to store the computed array
                 self.emit(
                     CfgInstData::StorageLive { slot: temp_slot },
-                    Type::Unit,
+                    Type::UNIT,
                     span,
                 );
                 self.emit(
@@ -1582,7 +1582,7 @@ impl<'a> CfgBuilder<'a> {
                         slot: temp_slot,
                         init: base_val,
                     },
-                    Type::Unit,
+                    Type::UNIT,
                     span,
                 );
 
@@ -1599,7 +1599,7 @@ impl<'a> CfgBuilder<'a> {
                 // Emit StorageDead for the temp
                 self.emit(
                     CfgInstData::StorageDead { slot: temp_slot },
-                    Type::Unit,
+                    Type::UNIT,
                     span,
                 );
 
@@ -1629,7 +1629,7 @@ impl<'a> CfgBuilder<'a> {
                         index: index_val,
                         value: val,
                     },
-                    Type::Unit,
+                    Type::UNIT,
                     span,
                 );
                 ExprResult {
@@ -1657,7 +1657,7 @@ impl<'a> CfgBuilder<'a> {
                         index: index_val,
                         value: val,
                     },
-                    Type::Unit,
+                    Type::UNIT,
                     span,
                 );
                 ExprResult {
@@ -1694,7 +1694,7 @@ impl<'a> CfgBuilder<'a> {
                         place: cfg_place,
                         value: val,
                     },
-                    Type::Unit,
+                    Type::UNIT,
                     span,
                 );
                 ExprResult {
@@ -1757,7 +1757,7 @@ impl<'a> CfgBuilder<'a> {
                 // We use self.type_needs_drop() which has access to struct/array
                 // definitions to recursively check if fields need drop.
                 if self.type_needs_drop(val_ty) {
-                    self.emit(CfgInstData::Drop { value: val }, Type::Unit, span);
+                    self.emit(CfgInstData::Drop { value: val }, Type::UNIT, span);
                 }
 
                 // Drop is a statement, produces no value
@@ -1769,7 +1769,7 @@ impl<'a> CfgBuilder<'a> {
 
             AirInstData::StorageLive { slot } => {
                 // Emit StorageLive to CFG
-                self.emit(CfgInstData::StorageLive { slot: *slot }, Type::Unit, span);
+                self.emit(CfgInstData::StorageLive { slot: *slot }, Type::UNIT, span);
 
                 // Record this slot as live in the current scope for drop elaboration
                 if let Some(scope) = self.scope_stack.last_mut() {
@@ -1789,7 +1789,7 @@ impl<'a> CfgBuilder<'a> {
             AirInstData::StorageDead { slot } => {
                 // StorageDead in AIR is a hint; CFG builder emits these at scope exit
                 // This case handles explicit StorageDead if any (currently unused)
-                self.emit(CfgInstData::StorageDead { slot: *slot }, Type::Unit, span);
+                self.emit(CfgInstData::StorageDead { slot: *slot }, Type::UNIT, span);
                 ExprResult {
                     value: None,
                     continuation: Continuation::Continues,
@@ -1946,13 +1946,13 @@ impl<'a> CfgBuilder<'a> {
                 live_slot.ty,
                 span,
             );
-            self.emit(CfgInstData::Drop { value: slot_val }, Type::Unit, span);
+            self.emit(CfgInstData::Drop { value: slot_val }, Type::UNIT, span);
         }
         self.emit(
             CfgInstData::StorageDead {
                 slot: live_slot.slot,
             },
-            Type::Unit,
+            Type::UNIT,
             span,
         );
     }

--- a/crates/rue-cfg/src/opt/constfold.rs
+++ b/crates/rue-cfg/src/opt/constfold.rs
@@ -474,7 +474,7 @@ mod tests {
             entry,
             CfgInst {
                 data: CfgInstData::BoolConst(val),
-                ty: Type::Bool,
+                ty: Type::BOOL,
                 span: Span::new(0, 0),
             },
         )
@@ -547,7 +547,7 @@ mod tests {
             entry,
             CfgInst {
                 data: CfgInstData::Lt(c1, c2),
-                ty: Type::Bool,
+                ty: Type::BOOL,
                 span: Span::new(0, 0),
             },
         );
@@ -573,7 +573,7 @@ mod tests {
             entry,
             CfgInst {
                 data: CfgInstData::Lt(c1, c2),
-                ty: Type::Bool,
+                ty: Type::BOOL,
                 span: Span::new(0, 0),
             },
         );

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -602,7 +602,7 @@ mod tests {
                     args_start,
                     args_len,
                 },
-                ty: Type::Unit,
+                ty: Type::UNIT,
                 span: Span::new(0, 0),
             },
         );

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -238,7 +238,7 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::Load { slot } => {
                 // Load slot values from consecutive stack slots
-                let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                 let mut vregs = Vec::with_capacity(slot_count as usize);
                 for i in 0..slot_count {
                     let vreg = self.mir.alloc_vreg();
@@ -254,7 +254,7 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::Param { index } => {
                 // Get slot values from parameter area
-                let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                 let mut vregs = Vec::with_capacity(slot_count as usize);
                 for i in 0..slot_count {
                     let vreg = self.mir.alloc_vreg();
@@ -317,7 +317,7 @@ impl<'a> CfgLower<'a> {
 
                 // For struct types, also allocate vregs for each slot
                 if let Some(struct_id) = ty.as_struct() {
-                    let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                     let mut slot_vregs = vec![vreg]; // First slot uses main vreg
                     for _ in 1..slot_count {
                         slot_vregs.push(self.mir.alloc_vreg());
@@ -360,7 +360,7 @@ impl<'a> CfgLower<'a> {
                 self.value_map.insert(*param_val, vreg);
 
                 if let Some(struct_id) = ty.as_struct() {
-                    let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                     let mut slot_vregs = vec![vreg];
                     for _ in 1..slot_count {
                         slot_vregs.push(self.mir.alloc_vreg());
@@ -948,7 +948,7 @@ impl<'a> CfgLower<'a> {
                     // String equality: call __rue_str_eq(ptr1, len1, ptr2, len2)
                     let vreg = self.emit_string_eq_call(*lhs, *rhs);
                     self.value_map.insert(value, vreg);
-                } else if lhs_ty == Type::Unit {
+                } else if lhs_ty == Type::UNIT {
                     // Unit equality: () == () is always true
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
@@ -977,7 +977,7 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(vreg),
                         imm: 1,
                     });
-                } else if lhs_ty == Type::Unit {
+                } else if lhs_ty == Type::UNIT {
                     // Unit inequality: () != () is always false
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
@@ -1352,7 +1352,7 @@ impl<'a> CfgLower<'a> {
                     }
                 } else if let Some(struct_id) = load_type.as_struct() {
                     // Struct: load all field slots (recursively flattened)
-                    let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                     let mut slot_vregs = Vec::with_capacity(slot_count as usize);
 
                     for i in 0..slot_count {
@@ -1615,7 +1615,7 @@ impl<'a> CfgLower<'a> {
                     match arg_type.kind() {
                         TypeKind::Struct(struct_id) => {
                             let arg_data = &self.ctx.cfg.get_inst(arg_value).data;
-                            let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                            let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                             match arg_data {
                                 CfgInstData::Load { slot } => {
                                     for slot_idx in 0..slot_count {
@@ -1786,7 +1786,7 @@ impl<'a> CfgLower<'a> {
                     });
                 } else if let Some(struct_id) = ty.as_struct() {
                     // Non-builtin structs return in registers
-                    let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                     let mut slot_vregs = Vec::new();
                     for slot_idx in 0..slot_count {
                         let slot_vreg = self.mir.alloc_vreg();
@@ -3687,7 +3687,7 @@ impl<'a> CfgLower<'a> {
                     self.mir.push(Aarch64Inst::Bl { symbol_id });
                 } else if let Some(struct_id) = return_type.as_struct() {
                     // Return struct in registers
-                    let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                     let value_data = &self.ctx.cfg.get_inst(*value).data;
 
                     match value_data {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -263,7 +263,7 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::Load { slot } => {
                 // Load slot values from consecutive stack slots
-                let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                 let mut vregs = Vec::with_capacity(slot_count as usize);
                 for i in 0..slot_count {
                     let vreg = self.mir.alloc_vreg();
@@ -279,7 +279,7 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::Param { index } => {
                 // Get slot values from parameter area
-                let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                 let mut vregs = Vec::with_capacity(slot_count as usize);
                 for i in 0..slot_count {
                     let vreg = self.mir.alloc_vreg();
@@ -342,7 +342,7 @@ impl<'a> CfgLower<'a> {
 
                 // For struct types, also allocate vregs for each slot
                 if let TypeKind::Struct(struct_id) = ty.kind() {
-                    let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                     let mut slot_vregs = vec![vreg]; // First slot uses main vreg
                     for _ in 1..slot_count {
                         slot_vregs.push(self.mir.alloc_vreg());
@@ -385,7 +385,7 @@ impl<'a> CfgLower<'a> {
                 self.value_map.insert(*param_val, vreg);
 
                 if let TypeKind::Struct(struct_id) = ty.kind() {
-                    let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                     let mut slot_vregs = vec![vreg];
                     for _ in 1..slot_count {
                         slot_vregs.push(self.mir.alloc_vreg());
@@ -1269,7 +1269,7 @@ impl<'a> CfgLower<'a> {
                             imm: 1,
                         });
                     }
-                } else if lhs_ty == Type::Unit {
+                } else if lhs_ty == Type::UNIT {
                     // Unit equality: () == () is always true
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
@@ -1304,7 +1304,7 @@ impl<'a> CfgLower<'a> {
                             imm: 1,
                         });
                     }
-                } else if lhs_ty == Type::Unit {
+                } else if lhs_ty == Type::UNIT {
                     // Unit inequality: () != () is always false
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
@@ -1528,7 +1528,7 @@ impl<'a> CfgLower<'a> {
                     }
                 } else if let TypeKind::Struct(struct_id) = load_type.kind() {
                     // Struct: load all field slots (recursively flattened)
-                    let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                     let mut slot_vregs = Vec::with_capacity(slot_count as usize);
 
                     for i in 0..slot_count {
@@ -1747,7 +1747,7 @@ impl<'a> CfgLower<'a> {
                     match arg_type.kind() {
                         TypeKind::Struct(struct_id) => {
                             let arg_data = &self.ctx.cfg.get_inst(arg_value).data;
-                            let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                            let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                             match arg_data {
                                 CfgInstData::Load { slot } => {
                                     for slot_idx in 0..slot_count {
@@ -1930,7 +1930,7 @@ impl<'a> CfgLower<'a> {
                     });
                 } else if let TypeKind::Struct(struct_id) = ty.kind() {
                     // Non-builtin structs return in registers
-                    let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                     let mut slot_vregs = Vec::new();
                     for slot_idx in 0..slot_count {
                         let slot_vreg = self.mir.alloc_vreg();
@@ -3595,7 +3595,7 @@ impl<'a> CfgLower<'a> {
                     self.mir.push(X86Inst::CallRel { symbol_id });
                 } else if let Some(struct_id) = return_type.as_struct() {
                     // Return struct in registers
-                    let slot_count = self.ctx.type_slot_count(Type::Struct(struct_id));
+                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
                     let value_data = &self.ctx.cfg.get_inst(*value).data;
 
                     match value_data {

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -134,7 +134,7 @@ pub fn synthesize_drop_glue(type_pool: &TypeInternPool) -> Vec<AnalyzedFunction>
     for struct_id in type_pool.all_struct_ids() {
         let struct_def = type_pool.struct_def(struct_id);
         // Skip structs that don't need drop
-        let struct_ty = Type::Struct(struct_id);
+        let struct_ty = Type::new_struct(struct_id);
         if !type_needs_drop(struct_ty, type_pool) {
             continue;
         }
@@ -154,7 +154,7 @@ pub fn synthesize_drop_glue(type_pool: &TypeInternPool) -> Vec<AnalyzedFunction>
     // Create drop glue for arrays
     for array_id in type_pool.all_array_ids() {
         // Skip arrays that don't need drop
-        let array_ty = Type::Array(array_id);
+        let array_ty = Type::new_array(array_id);
         if !type_needs_drop(array_ty, type_pool) {
             continue;
         }
@@ -177,7 +177,7 @@ fn create_struct_drop_glue_function(
     let span = Span::new(0, 0); // Synthetic span
 
     // Create AIR for the drop glue function
-    let mut air = Air::new(Type::Unit);
+    let mut air = Air::new(Type::UNIT);
 
     // Calculate total parameter slots
     let mut num_param_slots = 0u32;
@@ -206,12 +206,12 @@ fn create_struct_drop_glue_function(
                         data: AirInstData::Param {
                             index: current_param_slot,
                         },
-                        ty: Type::Struct(nested_struct_id),
+                        ty: Type::new_struct(nested_struct_id),
                         span,
                     });
                     let drop_ref = air.add_inst(AirInst {
                         data: AirInstData::Drop { value: param_ref },
-                        ty: Type::Unit,
+                        ty: Type::UNIT,
                         span,
                     });
                     drop_statements.push(drop_ref);
@@ -223,12 +223,12 @@ fn create_struct_drop_glue_function(
                         data: AirInstData::Param {
                             index: current_param_slot,
                         },
-                        ty: Type::Array(array_id),
+                        ty: Type::new_array(array_id),
                         span,
                     });
                     let drop_ref = air.add_inst(AirInst {
                         data: AirInstData::Drop { value: param_ref },
-                        ty: Type::Unit,
+                        ty: Type::UNIT,
                         span,
                     });
                     drop_statements.push(drop_ref);
@@ -244,7 +244,7 @@ fn create_struct_drop_glue_function(
     // Create the unit value for return
     let unit_const = air.add_inst(AirInst {
         data: AirInstData::UnitConst,
-        ty: Type::Unit,
+        ty: Type::UNIT,
         span,
     });
 
@@ -264,7 +264,7 @@ fn create_struct_drop_glue_function(
                 stmts_len,
                 value: unit_const,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         })
     };
@@ -272,7 +272,7 @@ fn create_struct_drop_glue_function(
     // Add return instruction
     air.add_inst(AirInst {
         data: AirInstData::Ret(Some(return_value)),
-        ty: Type::Unit,
+        ty: Type::UNIT,
         span,
     });
 
@@ -303,7 +303,7 @@ fn create_array_drop_glue_function(
     let (element_type, length) = type_pool.array_def(array_id);
 
     // Create AIR for the drop glue function
-    let mut air = Air::new(Type::Unit);
+    let mut air = Air::new(Type::UNIT);
 
     // Calculate total parameter slots (element slots * length)
     let element_slot_count = type_slot_count(element_type, type_pool);
@@ -324,12 +324,12 @@ fn create_array_drop_glue_function(
                     data: AirInstData::Param {
                         index: current_param_slot,
                     },
-                    ty: Type::Struct(struct_id),
+                    ty: Type::new_struct(struct_id),
                     span,
                 });
                 let drop_ref = air.add_inst(AirInst {
                     data: AirInstData::Drop { value: param_ref },
-                    ty: Type::Unit,
+                    ty: Type::UNIT,
                     span,
                 });
                 drop_statements.push(drop_ref);
@@ -339,12 +339,12 @@ fn create_array_drop_glue_function(
                     data: AirInstData::Param {
                         index: current_param_slot,
                     },
-                    ty: Type::Array(nested_array_id),
+                    ty: Type::new_array(nested_array_id),
                     span,
                 });
                 let drop_ref = air.add_inst(AirInst {
                     data: AirInstData::Drop { value: param_ref },
-                    ty: Type::Unit,
+                    ty: Type::UNIT,
                     span,
                 });
                 drop_statements.push(drop_ref);
@@ -357,7 +357,7 @@ fn create_array_drop_glue_function(
     // Create the unit value for return
     let unit_const = air.add_inst(AirInst {
         data: AirInstData::UnitConst,
-        ty: Type::Unit,
+        ty: Type::UNIT,
         span,
     });
 
@@ -374,7 +374,7 @@ fn create_array_drop_glue_function(
                 stmts_len,
                 value: unit_const,
             },
-            ty: Type::Unit,
+            ty: Type::UNIT,
             span,
         })
     };
@@ -382,7 +382,7 @@ fn create_array_drop_glue_function(
     // Add return instruction
     air.add_inst(AirInst {
         data: AirInstData::Ret(Some(return_value)),
-        ty: Type::Unit,
+        ty: Type::UNIT,
         span,
     });
 

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -927,7 +927,7 @@ pub fn compile_frontend_from_ast_with_options(
     let all_functions: Vec<_> = sema_output
         .functions
         .into_iter()
-        .filter(|f| f.air.return_type() != Type::ComptimeType)
+        .filter(|f| f.air.return_type() != Type::COMPTIME_TYPE)
         .chain(drop_glue_functions)
         .collect();
 
@@ -1053,7 +1053,7 @@ pub fn compile_frontend_from_rir_with_file_paths(
     let all_functions: Vec<_> = sema_output
         .functions
         .into_iter()
-        .filter(|f| f.air.return_type() != Type::ComptimeType)
+        .filter(|f| f.air.return_type() != Type::COMPTIME_TYPE)
         .chain(drop_glue_functions)
         .collect();
 

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -412,7 +412,7 @@ impl<'src> CompilationUnit<'src> {
         let all_functions: Vec<_> = sema_output
             .functions
             .into_iter()
-            .filter(|f| f.air.return_type() != Type::ComptimeType)
+            .filter(|f| f.air.return_type() != Type::COMPTIME_TYPE)
             .chain(drop_glue_functions)
             .collect();
 

--- a/crates/rue-fuzz/BUCK
+++ b/crates/rue-fuzz/BUCK
@@ -1,6 +1,7 @@
 rust_binary(
     name = "rue-fuzz",
     srcs = glob(["src/**/*.rs"]),
+    rustc_flags = ["-Dwarnings"],
     deps = [
         "//crates/rue-codegen:rue-codegen",
         "//crates/rue-compiler:rue-compiler",
@@ -16,6 +17,7 @@ rust_binary(
 rust_test(
     name = "rue-fuzz-test",
     srcs = glob(["src/**/*.rs"]),
+    rustc_flags = ["-Dwarnings"],
     deps = [
         "//crates/rue-codegen:rue-codegen",
         "//crates/rue-compiler:rue-compiler",

--- a/crates/rue-fuzz/src/mutate.rs
+++ b/crates/rue-fuzz/src/mutate.rs
@@ -33,10 +33,6 @@ impl SimpleRng {
         }
         (self.next_u64() as usize) % max
     }
-
-    pub fn coin_flip(&mut self) -> bool {
-        self.next_u64() & 1 == 0
-    }
 }
 
 /// Mutate input bytes in place.

--- a/crates/rue-runtime/BUCK
+++ b/crates/rue-runtime/BUCK
@@ -6,6 +6,7 @@ rust_library(
     preferred_linkage = "static",
     # Minimize output size and ensure no_std compatibility
     rustc_flags = [
+        "-Dwarnings",
         "-Cpanic=abort",
         "-Copt-level=z",
         "-Clto=true",

--- a/crates/rue-test-runner/BUCK
+++ b/crates/rue-test-runner/BUCK
@@ -1,6 +1,7 @@
 rust_library(
     name = "rue-test-runner",
     srcs = glob(["src/**/*.rs"]),
+    rustc_flags = ["-Dwarnings"],
     deps = [
         "//crates/rue-error:rue-error",
         "//third-party:serde",
@@ -13,6 +14,7 @@ rust_library(
 rust_test(
     name = "rue-test-runner-test",
     srcs = glob(["src/**/*.rs"]),
+    rustc_flags = ["-Dwarnings"],
     deps = [
         "//crates/rue-error:rue-error",
         "//third-party:serde",

--- a/crates/rue/BUCK
+++ b/crates/rue/BUCK
@@ -4,6 +4,7 @@ rust_binary(
         "src/main.rs",
         "src/timing.rs",
     ],
+    rustc_flags = ["-Dwarnings"],
     deps = [
         "//crates/rue-compiler:rue-compiler",
         "//crates/rue-rir:rue-rir",
@@ -23,6 +24,7 @@ rust_test(
         "src/main.rs",
         "src/timing.rs",
     ],
+    rustc_flags = ["-Dwarnings"],
     deps = [
         "//crates/rue-compiler:rue-compiler",
         "//crates/rue-rir:rue-rir",

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -12,8 +12,8 @@ use tracing_subscriber::{EnvFilter, fmt};
 mod timing;
 
 use rue_compiler::{
-    CompileOptions, DiagnosticFormatter, FileId, Lexer, LinkerMode, MultiFileFormatter, OptLevel,
-    ParsedProgram, PreviewFeature, PreviewFeatures, SourceFile, SourceInfo,
+    CompileOptions, FileId, Lexer, LinkerMode, MultiFileFormatter, OptLevel, ParsedProgram,
+    PreviewFeature, PreviewFeatures, SourceFile, SourceInfo,
     compile_frontend_from_ast_with_options, compile_multi_file_with_options, generate_emitted_asm,
     generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
     generate_stack_frame_info, merge_symbols, parse_all_files,
@@ -762,7 +762,7 @@ fn main() {
     let formatter = MultiFileFormatter::new(source_infos);
 
     // Also keep a single-file formatter for the primary file (for source metrics)
-    let (primary_path, primary_source) = &sources[0];
+    let (_primary_path, primary_source) = &sources[0];
 
     // Compute source metrics if benchmark JSON is requested
     let source_metrics = if options.benchmark_json {

--- a/crates/rue/src/timing.rs
+++ b/crates/rue/src/timing.rs
@@ -203,19 +203,6 @@ impl TimingData {
         output
     }
 
-    /// Generate structured timing data for JSON serialization.
-    ///
-    /// Returns a `BenchmarkTiming` struct that can be serialized to JSON
-    /// for machine-readable output. This is used by `--benchmark-json` for
-    /// the performance dashboard.
-    ///
-    /// # Arguments
-    /// * `target` - The target platform string (e.g., "x86_64-linux")
-    /// * `version` - The compiler version string
-    pub fn to_benchmark_timing(&self, target: &str, version: &str) -> BenchmarkTiming {
-        self.to_benchmark_timing_with_metrics(target, version, None, None)
-    }
-
     /// Generate structured timing data with optional source metrics and memory usage.
     ///
     /// # Arguments
@@ -270,34 +257,6 @@ impl TimingData {
         }
     }
 
-    /// Generate JSON output for benchmark timing.
-    ///
-    /// Returns a JSON string suitable for machine parsing. The format includes
-    /// metadata for historical analysis:
-    /// ```json
-    /// {
-    ///   "metadata": {
-    ///     "timestamp": "2025-12-27T21:30:00Z",
-    ///     "version": "0.1.0",
-    ///     "target": "aarch64-macos"
-    ///   },
-    ///   "passes": [
-    ///     {"name": "lexer", "duration_ms": 0.5, "percent": 10.0},
-    ///     {"name": "parser", "duration_ms": 2.3, "percent": 46.0},
-    ///     ...
-    ///   ],
-    ///   "total_ms": 5.0
-    /// }
-    /// ```
-    ///
-    /// # Arguments
-    /// * `target` - The target platform string (e.g., "x86_64-linux")
-    /// * `version` - The compiler version string
-    pub fn to_json(&self, target: &str, version: &str) -> String {
-        let timing = self.to_benchmark_timing(target, version);
-        serde_json::to_string(&timing).unwrap_or_else(|_| "{}".to_string())
-    }
-
     /// Generate JSON output with additional source metrics.
     ///
     /// # Arguments
@@ -319,14 +278,6 @@ impl TimingData {
             peak_memory_bytes,
         );
         serde_json::to_string(&timing).unwrap_or_else(|_| "{}".to_string())
-    }
-
-    /// Generate pretty-printed JSON output for benchmark timing.
-    ///
-    /// Same as `to_json()` but with indentation for human readability.
-    pub fn to_json_pretty(&self, target: &str, version: &str) -> String {
-        let timing = self.to_benchmark_timing(target, version);
-        serde_json::to_string_pretty(&timing).unwrap_or_else(|_| "{}".to_string())
     }
 }
 
@@ -557,7 +508,7 @@ mod tests {
     #[test]
     fn test_to_benchmark_timing_empty() {
         let data = TimingData::new();
-        let timing = data.to_benchmark_timing("x86_64-linux", "0.1.0");
+        let timing = data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None);
         assert!(timing.passes.is_empty());
         assert_eq!(timing.total_ms, 0.0);
     }
@@ -568,7 +519,7 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
         data.record("parser", Duration::from_millis(200));
 
-        let timing = data.to_benchmark_timing("x86_64-linux", "0.1.0");
+        let timing = data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None);
         assert_eq!(timing.passes.len(), 2);
         assert_eq!(timing.passes[0].name, "lexer");
         assert_eq!(timing.passes[1].name, "parser");
@@ -582,7 +533,7 @@ mod tests {
         data.record("lexer", Duration::from_millis(100));
         data.record("parser", Duration::from_millis(300));
 
-        let timing = data.to_benchmark_timing("x86_64-linux", "0.1.0");
+        let timing = data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None);
         // lexer should be 25%, parser should be 75%
         assert!((timing.passes[0].percent - 25.0).abs() < 0.1);
         assert!((timing.passes[1].percent - 75.0).abs() < 0.1);
@@ -593,7 +544,7 @@ mod tests {
         let data = TimingData::new();
         data.record("lexer", Duration::from_millis(100));
 
-        let timing = data.to_benchmark_timing("aarch64-macos", "0.2.0");
+        let timing = data.to_benchmark_timing_with_metrics("aarch64-macos", "0.2.0", None, None);
         assert_eq!(timing.metadata.target, "aarch64-macos");
         assert_eq!(timing.metadata.version, "0.2.0");
         // Timestamp should be an ISO 8601 format
@@ -606,7 +557,7 @@ mod tests {
         let data = TimingData::new();
         data.record("lexer", Duration::from_millis(100));
 
-        let json = data.to_json("x86_64-linux", "0.1.0");
+        let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None);
         assert!(json.contains("\"passes\""));
         assert!(json.contains("\"name\""));
         assert!(json.contains("\"lexer\""));
@@ -621,21 +572,9 @@ mod tests {
     }
 
     #[test]
-    fn test_to_json_pretty() {
-        let data = TimingData::new();
-        data.record("lexer", Duration::from_millis(100));
-
-        let json = data.to_json_pretty("x86_64-linux", "0.1.0");
-        // Pretty JSON should have newlines
-        assert!(json.contains('\n'));
-        // And should still contain the data
-        assert!(json.contains("lexer"));
-    }
-
-    #[test]
     fn test_to_json_empty() {
         let data = TimingData::new();
-        let json = data.to_json("x86_64-linux", "0.1.0");
+        let json = data.to_json_with_metrics("x86_64-linux", "0.1.0", None, None);
         // Should produce valid JSON even with empty data
         assert!(json.contains("\"passes\":[]"));
         assert!(json.contains("\"total_ms\":0"));
@@ -648,7 +587,7 @@ mod tests {
         data.record("zzz", Duration::from_millis(100));
         data.record("mmm", Duration::from_millis(100));
 
-        let timing = data.to_benchmark_timing("x86_64-linux", "0.1.0");
+        let timing = data.to_benchmark_timing_with_metrics("x86_64-linux", "0.1.0", None, None);
         assert_eq!(timing.passes[0].name, "aaa");
         assert_eq!(timing.passes[1].name, "zzz");
         assert_eq!(timing.passes[2].name, "mmm");

--- a/third-party/BUCK
+++ b/third-party/BUCK
@@ -839,6 +839,9 @@ cargo.rust_library(
     edition = "2018",
     features = ["std"],
     platform = {
+        "linux-x86_64": dict(
+            deps = [":libc-0.2.178"],
+        ),
         "macos-arm64": dict(
             deps = [":libc-0.2.178"],
         ),


### PR DESCRIPTION
- Rename Type constants to SCREAMING_SNAKE_CASE (Bool → BOOL, Unit → UNIT, etc.)
- Rename composite type constructors to snake_case (Struct() → new_struct(), etc.)
- Remove unused functions and methods across codebase:
  - timing.rs: to_benchmark_timing(), to_json(), to_json_pretty()
  - context.rs: MoveInfo, is_partially_moved(), clear()
  - scope.rs: ScopedContext::locals(), ScopedContext::scope_stack()
- Add -Dwarnings flag to BUCK files for rue, rue-air, rue-fuzz, rue-runtime, rue-test-runner
- Add #[allow(dead_code)] with TODOs for intentionally unused ConstValue variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)