### PR TITLE
ADR-0030: Place Expressions for Memory Locations

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -1,6 +1,15 @@
 //! AIR instruction definitions.
 //!
 //! Like RIR, instructions are stored densely and referenced by index.
+//!
+//! # Place Expressions (ADR-0030 Phase 8)
+//!
+//! Memory locations are represented using [`AirPlace`], which consists of:
+//! - A base ([`AirPlaceBase`]): either a local variable slot or parameter slot
+//! - A list of projections ([`AirProjection`]): field accesses and array indices
+//!
+//! This design follows Rust MIR's proven approach and eliminates redundant
+//! Load instructions for nested access patterns like `arr[i].field`.
 
 use std::fmt;
 
@@ -17,6 +26,142 @@ const _: () = assert!(std::mem::size_of::<AirInstData>() <= 32);
 use crate::types::{StructId, Type};
 use lasso::{Key, Spur};
 use rue_span::Span;
+
+// ============================================================================
+// Place Expressions (ADR-0030 Phase 8)
+// ============================================================================
+
+/// A reference to a place in AIR - stored as index into the places array.
+///
+/// This is a lightweight handle that can be copied and compared efficiently.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct AirPlaceRef(u32);
+
+impl AirPlaceRef {
+    /// Create a new place reference from a raw index.
+    #[inline]
+    pub const fn from_raw(index: u32) -> Self {
+        Self(index)
+    }
+
+    /// Get the raw index.
+    #[inline]
+    pub const fn as_u32(self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for AirPlaceRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "place#{}", self.0)
+    }
+}
+
+/// A memory location that can be read from or written to.
+///
+/// A place represents a path to a memory location, consisting of a base
+/// (local variable or parameter) and zero or more projections (field access,
+/// array indexing).
+///
+/// # Examples
+///
+/// - `x` → `AirPlace { base: Local(0), projections_start: 0, projections_len: 0 }`
+/// - `arr[i]` → `AirPlace { base: Local(0), ... }` with `Index` projection
+/// - `point.x` → `AirPlace { base: Local(0), ... }` with `Field` projection
+/// - `arr[i].x` → `AirPlace { base: Local(0), ... }` with `Index` then `Field`
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AirPlace {
+    /// The base of the place - either a local slot or parameter slot
+    pub base: AirPlaceBase,
+    /// Start index into Air's projections array
+    pub projections_start: u32,
+    /// Number of projections
+    pub projections_len: u32,
+}
+
+impl AirPlace {
+    /// Create a place for a local variable with no projections.
+    #[inline]
+    pub const fn local(slot: u32) -> Self {
+        Self {
+            base: AirPlaceBase::Local(slot),
+            projections_start: 0,
+            projections_len: 0,
+        }
+    }
+
+    /// Create a place for a parameter with no projections.
+    #[inline]
+    pub const fn param(slot: u32) -> Self {
+        Self {
+            base: AirPlaceBase::Param(slot),
+            projections_start: 0,
+            projections_len: 0,
+        }
+    }
+
+    /// Returns true if this place has no projections (is just a variable).
+    #[inline]
+    pub const fn is_simple(&self) -> bool {
+        self.projections_len == 0
+    }
+
+    /// Returns the local slot if this is a simple local place with no projections.
+    #[inline]
+    pub const fn as_local(&self) -> Option<u32> {
+        if self.projections_len == 0 {
+            match self.base {
+                AirPlaceBase::Local(slot) => Some(slot),
+                AirPlaceBase::Param(_) => None,
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Returns the param slot if this is a simple param place with no projections.
+    #[inline]
+    pub const fn as_param(&self) -> Option<u32> {
+        if self.projections_len == 0 {
+            match self.base {
+                AirPlaceBase::Param(slot) => Some(slot),
+                AirPlaceBase::Local(_) => None,
+            }
+        } else {
+            None
+        }
+    }
+}
+
+/// The base of a place - where the memory location starts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AirPlaceBase {
+    /// Local variable slot
+    Local(u32),
+    /// Parameter slot (for parameters, including inout)
+    Param(u32),
+}
+
+/// A projection applied to a place to reach a nested location.
+///
+/// Projections are stored in `Air::projections` and referenced by
+/// `AirPlace::projections_start` and `AirPlace::projections_len`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AirProjection {
+    /// Field access: `.field_name`
+    ///
+    /// The struct_id identifies the struct type, and field_index is the
+    /// 0-based index of the field in declaration order.
+    Field {
+        struct_id: StructId,
+        field_index: u32,
+    },
+    /// Array index: `[index]`
+    ///
+    /// The array_type is needed for bounds checking and element size calculation.
+    /// The index is an AirRef that will be evaluated at runtime.
+    Index { array_type: Type, index: AirRef },
+}
 
 /// Parameter passing mode in AIR.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
@@ -231,6 +376,12 @@ pub struct Air {
     extra: Vec<u32>,
     /// The return type of this function
     return_type: Type,
+    /// Storage for place projections (ADR-0030 Phase 8).
+    /// AirPlace instructions store (start, len) indices into this array.
+    projections: Vec<AirProjection>,
+    /// Storage for places (ADR-0030 Phase 8).
+    /// AirPlaceRef values are indices into this array.
+    places: Vec<AirPlace>,
 }
 
 impl Air {
@@ -240,6 +391,8 @@ impl Air {
             instructions: Vec::new(),
             extra: Vec::new(),
             return_type,
+            projections: Vec::new(),
+            places: Vec::new(),
         }
     }
 
@@ -393,6 +546,73 @@ impl Air {
     /// The type and span are preserved.
     pub fn rewrite_inst_data(&mut self, index: usize, new_data: AirInstData) {
         self.instructions[index].data = new_data;
+    }
+
+    // ========================================================================
+    // Place operations (ADR-0030 Phase 8)
+    // ========================================================================
+
+    /// Add projections to the projections array and return (start, len).
+    ///
+    /// Used for PlaceRead and PlaceWrite instructions.
+    pub fn push_projections(
+        &mut self,
+        projs: impl IntoIterator<Item = AirProjection>,
+    ) -> (u32, u32) {
+        let start = self.projections.len() as u32;
+        self.projections.extend(projs);
+        let len = self.projections.len() as u32 - start;
+        (start, len)
+    }
+
+    /// Get a slice from the projections array.
+    #[inline]
+    pub fn get_projections(&self, start: u32, len: u32) -> &[AirProjection] {
+        &self.projections[start as usize..(start + len) as usize]
+    }
+
+    /// Get projections for a place.
+    #[inline]
+    pub fn get_place_projections(&self, place: &AirPlace) -> &[AirProjection] {
+        self.get_projections(place.projections_start, place.projections_len)
+    }
+
+    /// Create a place with the given base and projections.
+    ///
+    /// This adds the projections to the projections array and returns a PlaceRef
+    /// that references the place.
+    pub fn make_place(
+        &mut self,
+        base: AirPlaceBase,
+        projs: impl IntoIterator<Item = AirProjection>,
+    ) -> AirPlaceRef {
+        let (projections_start, projections_len) = self.push_projections(projs);
+        let place = AirPlace {
+            base,
+            projections_start,
+            projections_len,
+        };
+        let index = self.places.len() as u32;
+        self.places.push(place);
+        AirPlaceRef::from_raw(index)
+    }
+
+    /// Get a place by reference.
+    #[inline]
+    pub fn get_place(&self, place_ref: AirPlaceRef) -> &AirPlace {
+        &self.places[place_ref.0 as usize]
+    }
+
+    /// Get all places.
+    #[inline]
+    pub fn places(&self) -> &[AirPlace] {
+        &self.places
+    }
+
+    /// Get all projections.
+    #[inline]
+    pub fn projections(&self) -> &[AirProjection] {
+        &self.projections
     }
 }
 
@@ -695,6 +915,29 @@ pub enum AirInstData {
         /// Index expression
         index: AirRef,
         /// Value to store
+        value: AirRef,
+    },
+
+    // Place operations (ADR-0030 Phase 8)
+    /// Read a value from a memory location.
+    ///
+    /// This unifies Load, IndexGet, and FieldGet into a single instruction
+    /// that can handle arbitrarily nested access patterns like `arr[i].field`.
+    /// Eventually, the separate FieldGet/IndexGet instructions will be removed.
+    PlaceRead {
+        /// Reference to the place to read from
+        place: AirPlaceRef,
+    },
+
+    /// Write a value to a memory location.
+    ///
+    /// This unifies Store, IndexSet, ParamIndexSet, FieldSet, and ParamFieldSet
+    /// into a single instruction that can handle nested writes.
+    /// Eventually, the separate *Set instructions will be removed.
+    PlaceWrite {
+        /// Reference to the place to write to
+        place: AirPlaceRef,
+        /// Value to write
         value: AirRef,
     },
 
@@ -1012,6 +1255,16 @@ impl fmt::Display for Air {
                         value
                     )?;
                 }
+                AirInstData::PlaceRead { place } => {
+                    write!(f, "place_read ")?;
+                    self.fmt_place(f, *place)?;
+                    writeln!(f)?;
+                }
+                AirInstData::PlaceWrite { place, value } => {
+                    write!(f, "place_write ")?;
+                    self.fmt_place(f, *place)?;
+                    writeln!(f, " = {}", value)?;
+                }
                 AirInstData::EnumVariant {
                     enum_id,
                     variant_index,
@@ -1033,6 +1286,37 @@ impl fmt::Display for Air {
             }
         }
         writeln!(f, "}}")
+    }
+}
+
+impl Air {
+    /// Format a place for display, showing the base and projections.
+    fn fmt_place(&self, f: &mut fmt::Formatter<'_>, place_ref: AirPlaceRef) -> fmt::Result {
+        let place = self.get_place(place_ref);
+
+        // Write the base
+        match place.base {
+            AirPlaceBase::Local(slot) => write!(f, "${}", slot)?,
+            AirPlaceBase::Param(slot) => write!(f, "param%{}", slot)?,
+        }
+
+        // Write the projections
+        let projections = self.get_place_projections(place);
+        for proj in projections {
+            match proj {
+                AirProjection::Field {
+                    struct_id,
+                    field_index,
+                } => {
+                    write!(f, ".#{}.{}", struct_id.0, field_index)?;
+                }
+                AirProjection::Index { array_type, index } => {
+                    write!(f, "({})[{}]", array_type.name(), index)?;
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -32,7 +32,8 @@ pub use inference::{
     UnificationError, Unifier, UnifyResult,
 };
 pub use inst::{
-    Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirParamMode, AirPattern, AirRef,
+    Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirParamMode, AirPattern, AirPlace,
+    AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
 };
 pub use intern_pool::{
     EnumData, InternedType, StructData, TypeData, TypeInternPool, TypeInternPoolStats,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -38,7 +38,10 @@ use crate::inference::{
     Constraint, ConstraintContext, ConstraintGenerator, InferType, ParamVarInfo, Unifier,
     UnifyResult,
 };
-use crate::inst::{Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirPattern, AirRef};
+use crate::inst::{
+    Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirPattern, AirPlaceBase, AirProjection,
+    AirRef,
+};
 use crate::scope::ScopedContext;
 use crate::sema_context::SemaContext;
 use crate::types::{EnumId, StructDef, StructField, StructId, Type, TypeKind};
@@ -7243,159 +7246,67 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // For field assignment, we need to walk up the chain of field accesses
-        // to find the root variable. We accumulate the slot offset as we go.
+        use crate::sema::analyze_ops::ProjectionInfo;
 
-        // Walk up to find the root variable, collecting field symbols
-        let mut current_base = base;
-        let mut field_symbols: Vec<Spur> = Vec::new();
-
-        // Result is either (Local, slot, type, is_mut, name) or (Param, abi_slot, type, mode, name)
-        enum RootKind {
-            Local { slot: u32, is_mut: bool },
-            Param { abi_slot: u32, mode: RirParamMode },
-        }
-
-        let (var_name, root_kind, root_type, root_symbol) = loop {
-            let current_inst = self.rir.get(current_base);
-            match &current_inst.data {
-                InstData::VarRef { name } => {
-                    let name_str = self.interner.resolve(&*name);
-
-                    // Check if this variable has been moved
-                    if let Some(move_state) = ctx.moved_vars.get(name) {
-                        if let Some(moved_span) = move_state.is_any_part_moved() {
-                            return Err(CompileError::new(
-                                ErrorKind::UseAfterMove(name_str.to_string()),
-                                span,
-                            )
-                            .with_label("value moved here", moved_span));
-                        }
-                    }
-
-                    // First check if it's a parameter
-                    if let Some(param_info) = ctx.params.get(name) {
-                        break (
-                            name_str.to_string(),
-                            RootKind::Param {
-                                abi_slot: param_info.abi_slot,
-                                mode: param_info.mode,
-                            },
-                            param_info.ty,
-                            *name,
-                        );
-                    }
-
-                    // Then check locals
-                    let local = ctx.locals.get(name).ok_or_compile_error(
-                        ErrorKind::UndefinedVariable(name_str.to_string()),
+        // Try to trace the base to a place
+        if let Some(mut trace) = self.try_trace_place(base, air, ctx)? {
+            // Check if the root variable was fully moved
+            if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
+                if let Some(moved_span) = state.full_move {
+                    let root_name = self.interner.resolve(&trace.root_var);
+                    return Err(CompileError::new(
+                        ErrorKind::UseAfterMove(root_name.to_string()),
                         span,
-                    )?;
-
-                    break (
-                        name_str.to_string(),
-                        RootKind::Local {
-                            slot: local.slot,
-                            is_mut: local.is_mut,
-                        },
-                        local.ty,
-                        *name,
-                    );
-                }
-                InstData::ParamRef { name, .. } => {
-                    let name_str = self.interner.resolve(&*name);
-                    let param_info = ctx.params.get(name).ok_or_compile_error(
-                        ErrorKind::UndefinedVariable(name_str.to_string()),
-                        span,
-                    )?;
-
-                    // Check if this parameter has been moved
-                    if let Some(move_state) = ctx.moved_vars.get(name) {
-                        if let Some(moved_span) = move_state.is_any_part_moved() {
-                            return Err(CompileError::new(
-                                ErrorKind::UseAfterMove(name_str.to_string()),
-                                span,
-                            )
-                            .with_label("value moved here", moved_span));
-                        }
-                    }
-
-                    break (
-                        name_str.to_string(),
-                        RootKind::Param {
-                            abi_slot: param_info.abi_slot,
-                            mode: param_info.mode,
-                        },
-                        param_info.ty,
-                        *name,
-                    );
-                }
-                InstData::FieldGet {
-                    base: inner_base,
-                    field: inner_field,
-                } => {
-                    field_symbols.push(*inner_field);
-                    current_base = *inner_base;
-                }
-                _ => {
-                    return Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span));
+                    )
+                    .with_label("value moved here", moved_span));
                 }
             }
-        };
 
-        // Check mutability based on root kind
-        let root_slot = match root_kind {
-            RootKind::Local { slot, is_mut } => {
-                if !is_mut {
+            // Check mutability
+            let root_name = self.interner.resolve(&trace.root_var).to_string();
+            if !trace.is_root_mutable {
+                // Check if this is a borrow parameter - special error message
+                if trace.is_borrow_param {
                     return Err(CompileError::new(
-                        ErrorKind::AssignToImmutable(var_name),
+                        ErrorKind::MutateBorrowedValue {
+                            variable: root_name,
+                        },
                         span,
                     ));
                 }
-                slot
-            }
-            RootKind::Param { abi_slot, mode } => {
-                match mode {
-                    RirParamMode::Normal | RirParamMode::Comptime => {
+
+                let root_type = trace.base_type;
+                // Provide more specific error based on whether it's a param or local
+                match trace.base {
+                    AirPlaceBase::Param(_) => {
                         return Err(CompileError::new(
-                            ErrorKind::AssignToImmutable(var_name.clone()),
+                            ErrorKind::AssignToImmutable(root_name.clone()),
                             span,
                         )
                         .with_help(format!(
                             "consider making parameter `{}` inout: `inout {}: {}`",
-                            var_name,
-                            var_name,
+                            root_name,
+                            root_name,
                             root_type.name()
                         )));
                     }
-                    RirParamMode::Inout => {
-                        // Inout parameters can be mutated
-                    }
-                    RirParamMode::Borrow => {
+                    AirPlaceBase::Local(_) => {
                         return Err(CompileError::new(
-                            ErrorKind::MutateBorrowedValue { variable: var_name },
+                            ErrorKind::AssignToImmutable(root_name),
                             span,
                         ));
                     }
                 }
-                abi_slot
             }
-        };
 
-        // Suppress unused variable warning
-        let _ = root_symbol;
-
-        // Walk through the field chain to compute the slot offset
-        let mut current_type = root_type;
-        let mut slot_offset: u32 = 0;
-
-        for field_sym in field_symbols.iter().rev() {
-            let struct_id = match current_type.kind() {
-                TypeKind::Struct(id) => id,
-                _ => {
+            // Add the final field projection
+            let base_type = trace.result_type();
+            let struct_id = match base_type.as_struct() {
+                Some(id) => id,
+                None => {
                     return Err(CompileError::new(
                         ErrorKind::FieldAccessOnNonStruct {
-                            found: current_type.name().to_string(),
+                            found: base_type.name().to_string(),
                         },
                         span,
                     ));
@@ -7403,7 +7314,7 @@ impl<'a> Sema<'a> {
             };
 
             let struct_def = self.type_pool.struct_def(struct_id);
-            let field_name_str = self.interner.resolve(&*field_sym).to_string();
+            let field_name_str = self.interner.resolve(&field).to_string();
 
             let (field_index, struct_field) =
                 struct_def.find_field(&field_name_str).ok_or_compile_error(
@@ -7414,66 +7325,37 @@ impl<'a> Sema<'a> {
                     span,
                 )?;
 
-            slot_offset += self.field_slot_offset(struct_id, field_index);
-            current_type = struct_field.ty;
-        }
+            let field_type = struct_field.ty;
 
-        // Now handle the final field being assigned
-        let struct_id = match current_type.kind() {
-            TypeKind::Struct(id) => id,
-            _ => {
-                return Err(CompileError::new(
-                    ErrorKind::FieldAccessOnNonStruct {
-                        found: current_type.name().to_string(),
-                    },
-                    span,
-                ));
-            }
-        };
-
-        let struct_def = self.type_pool.struct_def(struct_id);
-        let field_name_str = self.interner.resolve(&field).to_string();
-
-        let (field_index, _struct_field) =
-            struct_def.find_field(&field_name_str).ok_or_compile_error(
-                ErrorKind::UnknownField {
-                    struct_name: struct_def.name.clone(),
-                    field_name: field_name_str.clone(),
-                },
-                span,
-            )?;
-
-        // Analyze the value
-        let value_result = self.analyze_inst(air, value, ctx)?;
-
-        // Emit the appropriate instruction based on whether root is a local or param
-        let air_ref = match root_kind {
-            RootKind::Local { slot, .. } => {
-                let base_slot = slot + slot_offset;
-                air.add_inst(AirInst {
-                    data: AirInstData::FieldSet {
-                        slot: base_slot,
-                        struct_id,
-                        field_index: field_index as u32,
-                        value: value_result.air_ref,
-                    },
-                    ty: Type::Unit,
-                    span,
-                })
-            }
-            RootKind::Param { abi_slot, .. } => air.add_inst(AirInst {
-                data: AirInstData::ParamFieldSet {
-                    param_slot: abi_slot,
-                    inner_offset: slot_offset,
+            // Add the field projection to the trace
+            trace.projections.push(ProjectionInfo {
+                proj: AirProjection::Field {
                     struct_id,
                     field_index: field_index as u32,
+                },
+                result_type: field_type,
+                field_name: Some(field),
+            });
+
+            // Analyze the value
+            let value_result = self.analyze_inst(air, value, ctx)?;
+
+            // Emit PlaceWrite instruction
+            let place_ref = Self::build_place_ref(air, &trace);
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::PlaceWrite {
+                    place: place_ref,
                     value: value_result.air_ref,
                 },
                 ty: Type::Unit,
                 span,
-            }),
-        };
-        Ok(AnalysisResult::new(air_ref, Type::Unit))
+            });
+            return Ok(AnalysisResult::new(air_ref, Type::Unit));
+        }
+
+        // Fallback: base is not a place (e.g., function call result)
+        // This shouldn't normally happen for valid assignment targets
+        Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span))
     }
 
     /// Implementation for IndexSet - handles both local and parameter array index assignment.
@@ -7486,182 +7368,128 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        let base_inst = self.rir.get(base);
+        use crate::sema::analyze_ops::ProjectionInfo;
 
-        enum IndexSetRootKind {
-            Local { slot: u32, is_mut: bool },
-            Param { abi_slot: u32, mode: RirParamMode },
-        }
-
-        let (var_name, root_kind, base_type) = match &base_inst.data {
-            InstData::VarRef { name } => {
-                let name_str = self.interner.resolve(&*name);
-
-                // Check if this variable has been moved
-                if let Some(move_state) = ctx.moved_vars.get(name) {
-                    if let Some(moved_span) = move_state.is_any_part_moved() {
-                        return Err(CompileError::new(
-                            ErrorKind::UseAfterMove(name_str.to_string()),
-                            span,
-                        )
-                        .with_label("value moved here", moved_span));
-                    }
-                }
-
-                // First check if it's a parameter
-                if let Some(param_info) = ctx.params.get(name) {
-                    (
-                        name_str.to_string(),
-                        IndexSetRootKind::Param {
-                            abi_slot: param_info.abi_slot,
-                            mode: param_info.mode,
-                        },
-                        param_info.ty,
-                    )
-                } else {
-                    // Then check locals
-                    let local = ctx.locals.get(name).ok_or_compile_error(
-                        ErrorKind::UndefinedVariable(name_str.to_string()),
-                        span,
-                    )?;
-
-                    (
-                        name_str.to_string(),
-                        IndexSetRootKind::Local {
-                            slot: local.slot,
-                            is_mut: local.is_mut,
-                        },
-                        local.ty,
-                    )
-                }
-            }
-            InstData::ParamRef { name, .. } => {
-                let name_str = self.interner.resolve(&*name);
-                let param_info = ctx.params.get(name).ok_or_compile_error(
-                    ErrorKind::UndefinedVariable(name_str.to_string()),
-                    span,
-                )?;
-
-                // Check if this parameter has been moved
-                if let Some(move_state) = ctx.moved_vars.get(name) {
-                    if let Some(moved_span) = move_state.is_any_part_moved() {
-                        return Err(CompileError::new(
-                            ErrorKind::UseAfterMove(name_str.to_string()),
-                            span,
-                        )
-                        .with_label("value moved here", moved_span));
-                    }
-                }
-
-                (
-                    name_str.to_string(),
-                    IndexSetRootKind::Param {
-                        abi_slot: param_info.abi_slot,
-                        mode: param_info.mode,
-                    },
-                    param_info.ty,
-                )
-            }
-            _ => {
-                return Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span));
-            }
-        };
-
-        // Check mutability based on root kind
-        let (is_inout_param, slot) = match root_kind {
-            IndexSetRootKind::Local { slot, is_mut } => {
-                if !is_mut {
+        // Try to trace the base to a place
+        if let Some(mut trace) = self.try_trace_place(base, air, ctx)? {
+            // Check if the root variable was fully moved
+            if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
+                if let Some(moved_span) = state.full_move {
+                    let root_name = self.interner.resolve(&trace.root_var);
                     return Err(CompileError::new(
-                        ErrorKind::AssignToImmutable(var_name),
+                        ErrorKind::UseAfterMove(root_name.to_string()),
+                        span,
+                    )
+                    .with_label("value moved here", moved_span));
+                }
+            }
+
+            // Check mutability
+            let root_name = self.interner.resolve(&trace.root_var).to_string();
+            if !trace.is_root_mutable {
+                // Check if this is a borrow parameter - special error message
+                if trace.is_borrow_param {
+                    return Err(CompileError::new(
+                        ErrorKind::MutateBorrowedValue {
+                            variable: root_name,
+                        },
                         span,
                     ));
                 }
-                (false, slot)
-            }
-            IndexSetRootKind::Param { abi_slot, mode } => {
-                let is_inout = match mode {
-                    RirParamMode::Normal | RirParamMode::Comptime => false,
-                    RirParamMode::Inout => true,
-                    RirParamMode::Borrow => {
+
+                let root_type = trace.base_type;
+                match trace.base {
+                    AirPlaceBase::Param(_) => {
                         return Err(CompileError::new(
-                            ErrorKind::MutateBorrowedValue { variable: var_name },
+                            ErrorKind::AssignToImmutable(root_name.clone()),
+                            span,
+                        )
+                        .with_help(format!(
+                            "consider making parameter `{}` inout: `inout {}: {}`",
+                            root_name,
+                            root_name,
+                            root_type.name()
+                        )));
+                    }
+                    AirPlaceBase::Local(_) => {
+                        return Err(CompileError::new(
+                            ErrorKind::AssignToImmutable(root_name),
                             span,
                         ));
                     }
-                };
-                (is_inout, abi_slot)
+                }
             }
-        };
 
-        let array_type_id = match base_type.kind() {
-            TypeKind::Array(id) => id,
-            _ => {
+            // Get array type info from the trace
+            let base_type = trace.result_type();
+            let (array_type_id, elem_type, array_len) = match base_type.as_array() {
+                Some(id) => {
+                    let (elem, len) = self.type_pool.array_def(id);
+                    (id, elem, len)
+                }
+                None => {
+                    return Err(CompileError::new(
+                        ErrorKind::IndexOnNonArray {
+                            found: base_type.name().to_string(),
+                        },
+                        span,
+                    ));
+                }
+            };
+
+            // Analyze index
+            let index_result = self.analyze_inst(air, index, ctx)?;
+            if !index_result.ty.is_unsigned() && !index_result.ty.is_error() {
                 return Err(CompileError::new(
-                    ErrorKind::IndexOnNonArray {
-                        found: base_type.name().to_string(),
-                    },
-                    span,
-                ));
-            }
-        };
-
-        let (element_type, length) = self.type_pool.array_def(array_type_id);
-
-        // Index must be an unsigned integer
-        let index_result = self.analyze_inst(air, index, ctx)?;
-        if !index_result.ty.is_unsigned() && !index_result.ty.is_error() {
-            return Err(CompileError::new(
-                ErrorKind::TypeMismatch {
-                    expected: "unsigned integer type".to_string(),
-                    found: index_result.ty.name().to_string(),
-                },
-                self.rir.get(index).span,
-            ));
-        }
-
-        let array_length = length;
-
-        // Compile-time bounds check for constant indices
-        if let Some(const_index) = self.try_get_const_index(index) {
-            if const_index < 0 || const_index as u64 >= array_length {
-                return Err(CompileError::new(
-                    ErrorKind::IndexOutOfBounds {
-                        index: const_index,
-                        length: array_length,
+                    ErrorKind::TypeMismatch {
+                        expected: "unsigned integer type".to_string(),
+                        found: index_result.ty.name().to_string(),
                     },
                     self.rir.get(index).span,
                 ));
             }
+
+            // Compile-time bounds check for constant indices
+            if let Some(const_index) = self.try_get_const_index(index) {
+                if const_index < 0 || const_index as u64 >= array_len {
+                    return Err(CompileError::new(
+                        ErrorKind::IndexOutOfBounds {
+                            index: const_index,
+                            length: array_len,
+                        },
+                        self.rir.get(index).span,
+                    ));
+                }
+            }
+
+            // Add the index projection
+            trace.projections.push(ProjectionInfo {
+                proj: AirProjection::Index {
+                    array_type: base_type,
+                    index: index_result.air_ref,
+                },
+                result_type: elem_type,
+                field_name: None,
+            });
+
+            // Analyze the value
+            let value_result = self.analyze_inst(air, value, ctx)?;
+
+            // Emit PlaceWrite instruction
+            let place_ref = Self::build_place_ref(air, &trace);
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::PlaceWrite {
+                    place: place_ref,
+                    value: value_result.air_ref,
+                },
+                ty: Type::Unit,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, Type::Unit));
         }
 
-        // Analyze the value
-        let value_result = self.analyze_inst(air, value, ctx)?;
-
-        // Emit appropriate instruction
-        let air_ref = if is_inout_param {
-            air.add_inst(AirInst {
-                data: AirInstData::ParamIndexSet {
-                    param_slot: slot,
-                    array_type: base_type,
-                    index: index_result.air_ref,
-                    value: value_result.air_ref,
-                },
-                ty: Type::Unit,
-                span,
-            })
-        } else {
-            air.add_inst(AirInst {
-                data: AirInstData::IndexSet {
-                    slot,
-                    array_type: base_type,
-                    index: index_result.air_ref,
-                    value: value_result.air_ref,
-                },
-                ty: Type::Unit,
-                span,
-            })
-        };
-        Ok(AnalysisResult::new(air_ref, Type::Unit))
+        // Fallback: base is not a place
+        Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span))
     }
 
     /// Implementation for MethodCall.

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -33,12 +33,265 @@ use crate::sema::context::ConstValue;
 use rue_span::Span;
 
 use super::Sema;
-use super::context::{AnalysisContext, AnalysisResult, LocalVar};
-use crate::inst::{Air, AirCallArg, AirInst, AirInstData, AirPattern, AirRef};
+use super::context::{AnalysisContext, AnalysisResult, LocalVar, ParamInfo};
+use crate::inst::{
+    Air, AirCallArg, AirInst, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef, AirProjection,
+    AirRef,
+};
 use crate::scope::ScopedContext;
-use crate::types::{Type, TypeKind};
+use crate::types::{StructId, Type, TypeKind};
+
+// ============================================================================
+// Place Building (ADR-0030 Phase 8)
+// ============================================================================
+
+/// Projection info collected during place tracing.
+///
+/// This extends `AirProjection` with additional metadata needed for type checking
+/// and move analysis.
+#[derive(Debug)]
+pub(crate) struct ProjectionInfo {
+    /// The projection to emit
+    pub proj: AirProjection,
+    /// The type resulting from this projection
+    pub result_type: Type,
+    /// For field projections: the field name (for move checking)
+    /// For index projections: None
+    pub field_name: Option<Spur>,
+}
+
+/// Result of tracing a place expression in RIR.
+///
+/// This contains all the information needed to build an `AirPlace` and emit
+/// a `PlaceRead` or `PlaceWrite` instruction.
+#[derive(Debug)]
+pub(crate) struct PlaceTrace {
+    /// The base of the place (local slot or param slot)
+    pub base: AirPlaceBase,
+    /// The type of the base (before projections)
+    pub base_type: Type,
+    /// Projections collected during tracing (in order from base to leaf)
+    pub projections: Vec<ProjectionInfo>,
+    /// The root variable name (for move checking)
+    pub root_var: Spur,
+    /// Whether the root is mutable (for write validation)
+    pub is_root_mutable: bool,
+    /// Whether this is a borrow parameter (for error messages)
+    pub is_borrow_param: bool,
+}
+
+impl PlaceTrace {
+    /// Get the final type of the place (after all projections).
+    pub fn result_type(&self) -> Type {
+        self.projections
+            .last()
+            .map(|p| p.result_type)
+            .unwrap_or(self.base_type)
+    }
+
+    /// Build the field path for move checking (list of field name symbols).
+    ///
+    /// Returns the field names in the projection chain. Index projections
+    /// break the field path (you can't partially move out of arrays), so
+    /// this returns field names from the last index projection to the end.
+    pub fn field_path(&self) -> Vec<Spur> {
+        // Find the last index projection (if any)
+        let start_from = self
+            .projections
+            .iter()
+            .rposition(|p| matches!(p.proj, AirProjection::Index { .. }))
+            .map(|i| i + 1)
+            .unwrap_or(0);
+
+        // Collect field names from that point to the end
+        self.projections[start_from..]
+            .iter()
+            .filter_map(|p| p.field_name)
+            .collect()
+    }
+}
 
 impl<'a> Sema<'a> {
+    // ========================================================================
+    // Place Tracing (ADR-0030 Phase 8)
+    // ========================================================================
+
+    /// Try to trace an RIR expression to a place (lvalue).
+    ///
+    /// This walks the RIR instruction chain backward from a `FieldGet` or `IndexGet`
+    /// to find the root `VarRef` or `ParamRef`, collecting projections along the way.
+    ///
+    /// Returns `None` if the expression is not a place (e.g., a function call result).
+    ///
+    /// # Arguments
+    /// * `inst_ref` - The RIR instruction to trace
+    /// * `air` - The AIR being built (needed to analyze index expressions)
+    /// * `ctx` - Analysis context with local/param info
+    ///
+    /// # Returns
+    /// * `Some(PlaceTrace)` if the expression is a place
+    /// * `None` if it's not (e.g., `get_struct().field` where base is a call)
+    pub(crate) fn try_trace_place(
+        &mut self,
+        inst_ref: InstRef,
+        air: &mut Air,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<Option<PlaceTrace>> {
+        self.try_trace_place_inner(inst_ref, air, ctx)
+    }
+
+    /// Inner implementation that accumulates projections.
+    fn try_trace_place_inner(
+        &mut self,
+        inst_ref: InstRef,
+        air: &mut Air,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<Option<PlaceTrace>> {
+        let inst = self.rir.get(inst_ref);
+
+        match &inst.data {
+            // Base case: local variable reference
+            InstData::VarRef { name } => {
+                // First check if it's actually a parameter
+                if let Some(param_info) = ctx.params.get(name) {
+                    return Ok(Some(PlaceTrace {
+                        base: AirPlaceBase::Param(param_info.abi_slot),
+                        base_type: param_info.ty,
+                        projections: Vec::new(),
+                        root_var: *name,
+                        is_root_mutable: matches!(param_info.mode, RirParamMode::Inout),
+                        is_borrow_param: matches!(param_info.mode, RirParamMode::Borrow),
+                    }));
+                }
+
+                // Check if it's a local variable
+                if let Some(local) = ctx.locals.get(name) {
+                    return Ok(Some(PlaceTrace {
+                        base: AirPlaceBase::Local(local.slot),
+                        base_type: local.ty,
+                        projections: Vec::new(),
+                        root_var: *name,
+                        is_root_mutable: local.is_mut,
+                        is_borrow_param: false,
+                    }));
+                }
+
+                // Not a variable - might be a constant or type name
+                Ok(None)
+            }
+
+            // Base case: explicit parameter reference
+            InstData::ParamRef { name, .. } => {
+                if let Some(param_info) = ctx.params.get(name) {
+                    return Ok(Some(PlaceTrace {
+                        base: AirPlaceBase::Param(param_info.abi_slot),
+                        base_type: param_info.ty,
+                        projections: Vec::new(),
+                        root_var: *name,
+                        is_root_mutable: matches!(param_info.mode, RirParamMode::Inout),
+                        is_borrow_param: matches!(param_info.mode, RirParamMode::Borrow),
+                    }));
+                }
+                Ok(None)
+            }
+
+            // Recursive case: field access
+            InstData::FieldGet { base, field } => {
+                // First, recursively trace the base
+                let base_trace = self.try_trace_place_inner(*base, air, ctx)?;
+
+                match base_trace {
+                    Some(mut trace) => {
+                        // Get the struct type from the base
+                        let base_type = trace.result_type();
+                        let struct_id = match base_type.as_struct() {
+                            Some(id) => id,
+                            None => {
+                                // Module access or non-struct - not a place
+                                return Ok(None);
+                            }
+                        };
+
+                        // Look up field info
+                        let struct_def = self.type_pool.struct_def(struct_id);
+                        let field_name_str = self.interner.resolve(field);
+                        let (field_index, struct_field) =
+                            match struct_def.find_field(field_name_str) {
+                                Some(info) => info,
+                                None => return Ok(None), // Unknown field
+                            };
+
+                        let field_type = struct_field.ty;
+
+                        // Add this projection with field name for move checking
+                        trace.projections.push(ProjectionInfo {
+                            proj: AirProjection::Field {
+                                struct_id,
+                                field_index: field_index as u32,
+                            },
+                            result_type: field_type,
+                            field_name: Some(*field),
+                        });
+
+                        Ok(Some(trace))
+                    }
+                    None => {
+                        // Base is not a place (e.g., function call result)
+                        Ok(None)
+                    }
+                }
+            }
+
+            // Recursive case: array index
+            InstData::IndexGet { base, index } => {
+                // First, recursively trace the base
+                let base_trace = self.try_trace_place_inner(*base, air, ctx)?;
+
+                match base_trace {
+                    Some(mut trace) => {
+                        // Get the array type from the base
+                        let base_type = trace.result_type();
+                        let (_array_type_id, elem_type) = match base_type.as_array() {
+                            Some(id) => {
+                                let (elem, _len) = self.type_pool.array_def(id);
+                                (id, elem)
+                            }
+                            None => return Ok(None), // Not an array
+                        };
+
+                        // Analyze the index expression to get an AirRef
+                        let index_result = self.analyze_inst(air, *index, ctx)?;
+
+                        // Add this projection (no field name for indices)
+                        trace.projections.push(ProjectionInfo {
+                            proj: AirProjection::Index {
+                                array_type: base_type,
+                                index: index_result.air_ref,
+                            },
+                            result_type: elem_type,
+                            field_name: None,
+                        });
+
+                        Ok(Some(trace))
+                    }
+                    None => {
+                        // Base is not a place
+                        Ok(None)
+                    }
+                }
+            }
+
+            // Not a place expression
+            _ => Ok(None),
+        }
+    }
+
+    /// Build an AirPlaceRef from a PlaceTrace, adding projections to the Air.
+    pub(crate) fn build_place_ref(air: &mut Air, trace: &PlaceTrace) -> AirPlaceRef {
+        let projs = trace.projections.iter().map(|p| p.proj);
+        air.make_place(trace.base, projs)
+    }
+
     // ========================================================================
     // Literals: IntConst, BoolConst, StringConst, UnitConst
     // ========================================================================
@@ -1679,6 +1932,8 @@ impl<'a> Sema<'a> {
     }
 
     /// Analyze a field access.
+    ///
+    /// Uses place-based analysis (ADR-0030) when possible for efficient code generation.
     fn analyze_field_get(
         &mut self,
         air: &mut Air,
@@ -1688,12 +1943,103 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Field access is a projection
-        let base_result = self.analyze_inst_for_projection(air, base, ctx)?;
+        // First, check if the base is a module access (special case, not a place)
+        // We need to peek at the base type to detect module.Type access patterns.
+        let base_inst = self.rir.get(base);
+        if let InstData::VarRef { name } = &base_inst.data {
+            // Check if this VarRef refers to a module
+            if let Some(local) = ctx.locals.get(name) {
+                if local.ty.as_module().is_some() {
+                    // This is module.Member access - handle specially
+                    let module_id = local.ty.as_module().unwrap();
+                    return self.analyze_module_type_member_access(air, module_id, field, span);
+                }
+            }
+        }
+
+        // Try to trace this expression to a place (lvalue)
+        if let Some(trace) = self.try_trace_place(inst_ref, air, ctx)? {
+            let field_type = trace.result_type();
+
+            // Check if the root variable was fully moved (applies regardless of field type)
+            if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
+                if let Some(moved_span) = state.full_move {
+                    let root_name = self.interner.resolve(&trace.root_var);
+                    return Err(CompileError::new(
+                        ErrorKind::UseAfterMove(root_name.to_string()),
+                        span,
+                    )
+                    .with_label("value moved here", moved_span));
+                }
+            }
+
+            // Get struct info for move checking
+            // The trace's result type is the field type, but we need the parent struct type
+            // to check if it's linear. The parent is the type *before* the last projection.
+            let parent_type = if trace.projections.len() > 1 {
+                trace.projections[trace.projections.len() - 2].result_type
+            } else {
+                trace.base_type
+            };
+
+            let is_linear = parent_type
+                .as_struct()
+                .map(|id| self.type_pool.struct_def(id).is_linear)
+                .unwrap_or(false);
+
+            // Move checking using the trace
+            if is_linear {
+                // For linear types, field access consumes the entire struct
+                ctx.moved_vars
+                    .entry(trace.root_var)
+                    .or_default()
+                    .mark_path_moved(&[], span);
+            } else if !self.is_type_copy(field_type) {
+                // For non-linear types, check if accessing a non-Copy field
+                let field_path = trace.field_path();
+
+                // Check if this field path is already moved (partial moves)
+                if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
+                    if let Some(moved_span) = state.is_path_moved(&field_path) {
+                        let root_name = self.interner.resolve(&trace.root_var);
+                        let path_str = if field_path.is_empty() {
+                            root_name.to_string()
+                        } else {
+                            let field_names: Vec<_> = field_path
+                                .iter()
+                                .map(|s| self.interner.resolve(s).to_string())
+                                .collect();
+                            format!("{}.{}", root_name, field_names.join("."))
+                        };
+                        return Err(CompileError::new(ErrorKind::UseAfterMove(path_str), span)
+                            .with_label("value moved here", moved_span));
+                    }
+                }
+
+                // Mark this field path as moved
+                ctx.moved_vars
+                    .entry(trace.root_var)
+                    .or_default()
+                    .mark_path_moved(&field_path, span);
+            }
+
+            // Emit PlaceRead instruction
+            let place_ref = Self::build_place_ref(air, &trace);
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::PlaceRead { place: place_ref },
+                ty: field_type,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, field_type));
+        }
+
+        // Fallback: base is not a place (e.g., function call result)
+        // Analyze the base and emit the old-style FieldGet
+        // This case handles `get_struct().field` patterns
+        let base_result = self.analyze_inst(air, base, ctx)?;
         let base_type = base_result.ty;
 
-        // Handle module member access: module.StructName or module.EnumName
-        // This returns a comptime type that can be used to construct values
+        // Handle module member access that wasn't caught above
         if let Some(module_id) = base_type.as_module() {
             return self.analyze_module_type_member_access(air, module_id, field, span);
         }
@@ -1711,10 +2057,9 @@ impl<'a> Sema<'a> {
         };
 
         let struct_def = self.type_pool.struct_def(struct_id);
-        let is_linear = struct_def.is_linear;
         let field_name_str = self.interner.resolve(&field).to_string();
 
-        let (field_index, struct_field) =
+        let (_field_index, struct_field) =
             struct_def.find_field(&field_name_str).ok_or_compile_error(
                 ErrorKind::UnknownField {
                     struct_name: struct_def.name.clone(),
@@ -1725,49 +2070,14 @@ impl<'a> Sema<'a> {
 
         let field_type = struct_field.ty;
 
-        // For linear types, field access consumes the entire struct.
-        if is_linear {
-            if let Some(root_var) = self.extract_root_variable(inst_ref) {
-                ctx.moved_vars
-                    .entry(root_var)
-                    .or_default()
-                    .mark_path_moved(&[], span);
-            }
-        }
-        // For non-linear types, check if accessing a non-Copy field
-        else if !self.is_type_copy(field_type) {
-            if let Some((root_var, field_path)) = self.extract_field_path(inst_ref) {
-                // Check if this field path is already moved
-                if let Some(state) = ctx.moved_vars.get(&root_var) {
-                    if let Some(moved_span) = state.is_path_moved(&field_path) {
-                        let root_name = self.interner.resolve(&root_var);
-                        let path_str = if field_path.is_empty() {
-                            root_name.to_string()
-                        } else {
-                            let field_names: Vec<_> = field_path
-                                .iter()
-                                .map(|s| self.interner.resolve(s).to_string())
-                                .collect();
-                            format!("{}.{}", root_name, field_names.join("."))
-                        };
-                        return Err(CompileError::new(ErrorKind::UseAfterMove(path_str), span)
-                            .with_label("value moved here", moved_span));
-                    }
-                }
-
-                // Mark this field path as moved
-                ctx.moved_vars
-                    .entry(root_var)
-                    .or_default()
-                    .mark_path_moved(&field_path, span);
-            }
-        }
-
+        // For non-place expressions, we can't do partial move tracking.
+        // The value is temporary and will be dropped after use.
+        // Just emit a FieldGet for now - we'll need to spill to a temp if this becomes common.
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::FieldGet {
                 base: base_result.air_ref,
                 struct_id,
-                field_index: field_index as u32,
+                field_index: _field_index as u32,
             },
             ty: field_type,
             span,
@@ -1939,7 +2249,7 @@ impl<'a> Sema<'a> {
             } => self.analyze_array_init(air, inst_ref, *elems_start, *elems_len, inst.span, ctx),
 
             InstData::IndexGet { base, index } => {
-                self.analyze_index_get(air, *base, *index, inst.span, ctx)
+                self.analyze_index_get(air, inst_ref, *base, *index, inst.span, ctx)
             }
 
             InstData::IndexSet { base, index, value } => {
@@ -2022,22 +2332,90 @@ impl<'a> Sema<'a> {
     }
 
     /// Analyze an array index read.
+    ///
+    /// Uses place-based analysis (ADR-0030) when possible for efficient code generation.
     fn analyze_index_get(
         &mut self,
         air: &mut Air,
+        inst_ref: InstRef,
         base: InstRef,
         index: InstRef,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Analyze base and index
-        let base_result = self.analyze_inst_for_projection(air, base, ctx)?;
-        let base_type = base_result.ty;
+        // Check for constant out-of-bounds index early (before tracing)
+        // We need the array type for bounds checking, so peek at the base first
+        let base_inst = self.rir.get(base);
 
+        // Try to trace this expression to a place (lvalue)
+        if let Some(trace) = self.try_trace_place(inst_ref, air, ctx)? {
+            let elem_type = trace.result_type();
+
+            // Get array info from the parent type (before the last projection)
+            let parent_type = if trace.projections.len() > 1 {
+                trace.projections[trace.projections.len() - 2].result_type
+            } else {
+                trace.base_type
+            };
+
+            let array_len = match parent_type.as_array() {
+                Some(type_id) => {
+                    let (_elem, len) = self.type_pool.array_def(type_id);
+                    len
+                }
+                None => {
+                    // This shouldn't happen if try_trace_place worked correctly
+                    return Err(CompileError::new(
+                        ErrorKind::IndexOnNonArray {
+                            found: parent_type.name().to_string(),
+                        },
+                        span,
+                    ));
+                }
+            };
+
+            // Check for constant out-of-bounds index
+            if let Some(const_idx) = self.try_get_const_index(index) {
+                if const_idx < 0 || const_idx as u64 >= array_len {
+                    return Err(CompileError::new(
+                        ErrorKind::IndexOutOfBounds {
+                            index: const_idx,
+                            length: array_len,
+                        },
+                        self.rir.get(index).span,
+                    ));
+                }
+            }
+
+            // Prevent moving non-Copy elements out of arrays.
+            if !self.is_type_copy(elem_type) {
+                return Err(CompileError::new(
+                    ErrorKind::MoveOutOfIndex {
+                        element_type: elem_type.name().to_string(),
+                    },
+                    span,
+                )
+                .with_help("use explicit methods like swap() or take() to remove elements"));
+            }
+
+            // Emit PlaceRead instruction
+            let place_ref = Self::build_place_ref(air, &trace);
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::PlaceRead { place: place_ref },
+                ty: elem_type,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, elem_type));
+        }
+
+        // Fallback: base is not a place (e.g., function call result)
+        // Analyze the base and emit the old-style IndexGet
+        let base_result = self.analyze_inst(air, base, ctx)?;
+        let base_type = base_result.ty;
         let index_result = self.analyze_inst(air, index, ctx)?;
 
         // Verify base is an array
-        let (array_type_id, elem_type, array_len) = match base_type.as_array() {
+        let (_array_type_id, elem_type, array_len) = match base_type.as_array() {
             Some(type_id) => {
                 let (element_type, length) = self.type_pool.array_def(type_id);
                 (type_id, element_type, length)
@@ -2066,9 +2444,6 @@ impl<'a> Sema<'a> {
         }
 
         // Prevent moving non-Copy elements out of arrays.
-        // This check is only applied in consume context (analyze_inst), not in
-        // projection context (analyze_inst_for_projection), which allows
-        // patterns like `arr[i].field` where field is Copy.
         if !self.is_type_copy(elem_type) {
             return Err(CompileError::new(
                 ErrorKind::MoveOutOfIndex {

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -4,12 +4,16 @@
 //! into explicit basic blocks with terminators.
 
 use lasso::ThreadedRodeo;
-use rue_air::{Air, AirArgMode, AirInstData, AirPattern, AirRef, Type, TypeInternPool, TypeKind};
+use rue_air::{
+    Air, AirArgMode, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
+    Type, TypeInternPool, TypeKind,
+};
 use rue_error::{CompileWarning, WarningKind};
 
 use crate::CfgOutput;
 use crate::inst::{
-    BlockId, Cfg, CfgArgMode, CfgCallArg, CfgInst, CfgInstData, CfgValue, Terminator,
+    BlockId, Cfg, CfgArgMode, CfgCallArg, CfgInst, CfgInstData, CfgValue, Place, PlaceBase,
+    Projection, Terminator,
 };
 
 /// Result of lowering an expression.
@@ -777,18 +781,57 @@ impl<'a> CfgBuilder<'a> {
                 struct_id,
                 field_index,
             } => {
+                // ADR-0030 Phase 3: Try to use PlaceRead for field access
+                if let Some(value) = self.lower_place_read(air_ref, ty, span) {
+                    self.cache(air_ref, value);
+                    return ExprResult {
+                        value: Some(value),
+                        continuation: Continuation::Continues,
+                    };
+                }
+
+                // ADR-0030 Phase 6: Spill computed struct to temp, then use PlaceRead
+                // This handles cases like `get_struct().field` or `method().field`
+                // where the base is a computed value, not a local variable.
                 let Some(base_val) = self.lower_value(*base) else {
                     return Self::diverged();
                 };
-                let value = self.emit(
-                    CfgInstData::FieldGet {
-                        base: base_val,
-                        struct_id: *struct_id,
-                        field_index: *field_index,
-                    },
-                    ty,
+
+                // Allocate a temporary slot for the struct
+                let temp_slot = self.cfg.alloc_temp_local();
+
+                // Emit StorageLive, Alloc to store the computed struct
+                self.emit(
+                    CfgInstData::StorageLive { slot: temp_slot },
+                    Type::Unit,
                     span,
                 );
+                self.emit(
+                    CfgInstData::Alloc {
+                        slot: temp_slot,
+                        init: base_val,
+                    },
+                    Type::Unit,
+                    span,
+                );
+
+                // Create a PlaceRead from the temp slot with Field projection
+                let place = self.cfg.make_place(
+                    PlaceBase::Local(temp_slot),
+                    std::iter::once(Projection::Field {
+                        struct_id: *struct_id,
+                        field_index: *field_index,
+                    }),
+                );
+                let value = self.emit(CfgInstData::PlaceRead { place }, ty, span);
+
+                // Emit StorageDead for the temp
+                self.emit(
+                    CfgInstData::StorageDead { slot: temp_slot },
+                    Type::Unit,
+                    span,
+                );
+
                 self.cache(air_ref, value);
                 ExprResult {
                     value: Some(value),
@@ -1504,21 +1547,62 @@ impl<'a> CfgBuilder<'a> {
                 array_type,
                 index,
             } => {
+                // ADR-0030 Phase 3: Try to use PlaceRead for array indexing
+                if let Some(value) = self.lower_place_read(air_ref, ty, span) {
+                    self.cache(air_ref, value);
+                    return ExprResult {
+                        value: Some(value),
+                        continuation: Continuation::Continues,
+                    };
+                }
+
+                // ADR-0030 Phase 6: Spill computed array to temp, then use PlaceRead
+                // This handles cases like `get_array()[i]` where the base is a computed
+                // value, not a local variable.
+                // Note: Currently Rue can't return arrays (see issue rue-b79f), but this
+                // handles the case for when that's fixed.
                 let Some(base_val) = self.lower_value(*base) else {
                     return Self::diverged();
                 };
                 let Some(index_val) = self.lower_value(*index) else {
                     return Self::diverged();
                 };
-                let value = self.emit(
-                    CfgInstData::IndexGet {
-                        base: base_val,
-                        array_type: *array_type,
-                        index: index_val,
-                    },
-                    ty,
+
+                // Allocate a temporary slot for the array
+                let temp_slot = self.cfg.alloc_temp_local();
+
+                // Emit StorageLive, Alloc to store the computed array
+                self.emit(
+                    CfgInstData::StorageLive { slot: temp_slot },
+                    Type::Unit,
                     span,
                 );
+                self.emit(
+                    CfgInstData::Alloc {
+                        slot: temp_slot,
+                        init: base_val,
+                    },
+                    Type::Unit,
+                    span,
+                );
+
+                // Create a PlaceRead from the temp slot with Index projection
+                let place = self.cfg.make_place(
+                    PlaceBase::Local(temp_slot),
+                    std::iter::once(Projection::Index {
+                        array_type: *array_type,
+                        index: index_val,
+                    }),
+                );
+                let value = self.emit(CfgInstData::PlaceRead { place }, ty, span);
+
+                // Emit StorageDead for the temp
+                self.emit(
+                    CfgInstData::StorageDead { slot: temp_slot },
+                    Type::Unit,
+                    span,
+                );
+
                 self.cache(air_ref, value);
                 ExprResult {
                     value: Some(value),
@@ -1571,6 +1655,43 @@ impl<'a> CfgBuilder<'a> {
                         param_slot: *param_slot,
                         array_type: *array_type,
                         index: index_val,
+                        value: val,
+                    },
+                    Type::Unit,
+                    span,
+                );
+                ExprResult {
+                    value: None,
+                    continuation: Continuation::Continues,
+                }
+            }
+
+            // ADR-0030 Phase 8: Handle AIR place-based instructions
+            AirInstData::PlaceRead { place } => {
+                // Convert AIR place to CFG place
+                let Some(cfg_place) = self.lower_air_place(*place) else {
+                    return Self::diverged();
+                };
+                let value = self.emit(CfgInstData::PlaceRead { place: cfg_place }, ty, span);
+                self.cache(air_ref, value);
+                ExprResult {
+                    value: Some(value),
+                    continuation: Continuation::Continues,
+                }
+            }
+
+            AirInstData::PlaceWrite { place, value } => {
+                // Lower the value first
+                let Some(val) = self.lower_value(*value) else {
+                    return Self::diverged();
+                };
+                // Convert AIR place to CFG place
+                let Some(cfg_place) = self.lower_air_place(*place) else {
+                    return Self::diverged();
+                };
+                self.emit(
+                    CfgInstData::PlaceWrite {
+                        place: cfg_place,
                         value: val,
                     },
                     Type::Unit,
@@ -1834,6 +1955,155 @@ impl<'a> CfgBuilder<'a> {
             Type::Unit,
             span,
         );
+    }
+
+    // ============================================================================
+    // Place Expression Tracing (ADR-0030)
+    // ============================================================================
+
+    /// Try to trace an AIR expression back to a Place.
+    ///
+    /// Returns `Some((base, projections))` if the expression represents a place
+    /// (lvalue) that can be read from or written to. Returns `None` if the
+    /// expression is not a simple place (e.g., a function call result).
+    ///
+    /// This function traces chains like `arr[i][j].field` into a `PlaceBase` and
+    /// a list of `Projection`s. The projections are returned in order from the
+    /// base outward (e.g., for `arr[i].x`, the projections are `[Index(i), Field(x)]`).
+    ///
+    /// The returned CfgValue indices for Index projections are the already-lowered
+    /// index values, which must be computed before calling this function.
+    fn try_trace_place(
+        &mut self,
+        air_ref: AirRef,
+    ) -> Option<(PlaceBase, Vec<(Projection, Option<CfgValue>)>)> {
+        let inst = self.air.get(air_ref);
+
+        match &inst.data {
+            // Base case: Load from a local variable
+            AirInstData::Load { slot } => Some((PlaceBase::Local(*slot), Vec::new())),
+
+            // Base case: Parameter reference
+            AirInstData::Param { index } => Some((PlaceBase::Param(*index), Vec::new())),
+
+            // Recursive case: Array index
+            AirInstData::IndexGet {
+                base,
+                array_type,
+                index,
+            } => {
+                // Recursively trace the base
+                let (base_place, mut projections) = self.try_trace_place(*base)?;
+
+                // Lower the index expression to get the CfgValue
+                let index_val = self.lower_value(*index)?;
+
+                // Add the Index projection
+                projections.push((
+                    Projection::Index {
+                        array_type: *array_type,
+                        index: index_val,
+                    },
+                    Some(index_val),
+                ));
+
+                Some((base_place, projections))
+            }
+
+            // Recursive case: Field access
+            AirInstData::FieldGet {
+                base,
+                struct_id,
+                field_index,
+            } => {
+                // Recursively trace the base
+                let (base_place, mut projections) = self.try_trace_place(*base)?;
+
+                // Add the Field projection
+                projections.push((
+                    Projection::Field {
+                        struct_id: *struct_id,
+                        field_index: *field_index,
+                    },
+                    None,
+                ));
+
+                Some((base_place, projections))
+            }
+
+            // Not a simple place expression
+            _ => None,
+        }
+    }
+
+    /// Lower a place expression from AIR to a CFG PlaceRead instruction.
+    ///
+    /// This is called when we detect that an IndexGet or FieldGet chain can be
+    /// represented as a single PlaceRead, avoiding redundant Load instructions.
+    fn lower_place_read(
+        &mut self,
+        air_ref: AirRef,
+        ty: Type,
+        span: rue_span::Span,
+    ) -> Option<CfgValue> {
+        // Try to trace the expression to a place
+        let (base, projections) = self.try_trace_place(air_ref)?;
+
+        // Build the Place with all projections
+        let proj_iter = projections.into_iter().map(|(proj, _)| proj);
+        let place = self.cfg.make_place(base, proj_iter);
+
+        // Emit the PlaceRead instruction
+        let value = self.emit(CfgInstData::PlaceRead { place }, ty, span);
+
+        Some(value)
+    }
+
+    /// Lower an AIR place reference to a CFG Place.
+    ///
+    /// This converts AirPlaceRef -> AirPlace -> CFG Place, translating projections
+    /// and lowering any index expressions to CFG values.
+    ///
+    /// ADR-0030 Phase 8: This is the bridge between AIR's PlaceRead/PlaceWrite
+    /// and CFG's PlaceRead/PlaceWrite.
+    fn lower_air_place(&mut self, place_ref: AirPlaceRef) -> Option<Place> {
+        let air_place = self.air.get_place(place_ref);
+
+        // Convert the base
+        let base = match air_place.base {
+            AirPlaceBase::Local(slot) => PlaceBase::Local(slot),
+            AirPlaceBase::Param(slot) => PlaceBase::Param(slot),
+        };
+
+        // Convert projections, lowering any index expressions
+        let air_projections = self.air.get_place_projections(air_place);
+        let mut cfg_projections = Vec::with_capacity(air_projections.len());
+
+        for proj in air_projections {
+            let cfg_proj = match proj {
+                AirProjection::Field {
+                    struct_id,
+                    field_index,
+                } => Projection::Field {
+                    struct_id: *struct_id,
+                    field_index: *field_index,
+                },
+                AirProjection::Index { array_type, index } => {
+                    // Lower the index expression to a CFG value
+                    let index_val = self.lower_value(*index)?;
+                    Projection::Index {
+                        array_type: *array_type,
+                        index: index_val,
+                    }
+                }
+            };
+            cfg_projections.push(cfg_proj);
+        }
+
+        // Create the CFG place
+        let place = self.cfg.make_place(base, cfg_projections);
+
+        Some(place)
     }
 }
 

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -2,6 +2,15 @@
 //!
 //! Unlike AIR, the CFG has explicit basic blocks and terminators.
 //! Control flow only happens at block boundaries via terminators.
+//!
+//! # Place Expressions (ADR-0030)
+//!
+//! Memory locations are represented using [`Place`], which consists of:
+//! - A base ([`PlaceBase`]): either a local variable slot or parameter slot
+//! - A list of projections ([`Projection`]): field accesses and array indices
+//!
+//! This design follows Rust MIR's proven approach and eliminates redundant
+//! Load instructions for nested access patterns like `arr[i].field`.
 
 use std::fmt;
 
@@ -18,6 +27,134 @@ const _: () = assert!(std::mem::size_of::<CfgInstData>() <= 32);
 use lasso::{Key, Spur};
 use rue_air::{EnumId, StructId, Type};
 use rue_span::Span;
+
+// ============================================================================
+// Place Expressions (ADR-0030)
+// ============================================================================
+
+/// A memory location that can be read from or written to.
+///
+/// A place represents a path to a memory location, consisting of a base
+/// (local variable or parameter) and zero or more projections (field access,
+/// array indexing).
+///
+/// # Examples
+///
+/// - `x` → `Place { base: Local(0), proj_start: 0, proj_len: 0 }`
+/// - `arr[i]` → `Place { base: Local(0), proj_start: 0, proj_len: 1 }` with `Index` projection
+/// - `point.x` → `Place { base: Local(0), proj_start: 0, proj_len: 1 }` with `Field` projection
+/// - `arr[i].x` → `Place { base: Local(0), proj_start: 0, proj_len: 2 }` with `Index` then `Field`
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Place {
+    /// The base of the place - either a local slot or parameter slot
+    pub base: PlaceBase,
+    /// Start index into Cfg's projections array
+    pub proj_start: u32,
+    /// Number of projections
+    pub proj_len: u32,
+}
+
+impl Place {
+    /// Create a place for a local variable with no projections.
+    #[inline]
+    pub const fn local(slot: u32) -> Self {
+        Self {
+            base: PlaceBase::Local(slot),
+            proj_start: 0,
+            proj_len: 0,
+        }
+    }
+
+    /// Create a place for a parameter with no projections.
+    #[inline]
+    pub const fn param(slot: u32) -> Self {
+        Self {
+            base: PlaceBase::Param(slot),
+            proj_start: 0,
+            proj_len: 0,
+        }
+    }
+
+    /// Returns true if this place has no projections (is just a variable).
+    #[inline]
+    pub const fn is_simple(&self) -> bool {
+        self.proj_len == 0
+    }
+
+    /// Returns the local slot if this is a simple local place with no projections.
+    #[inline]
+    pub const fn as_local(&self) -> Option<u32> {
+        if self.proj_len == 0 {
+            match self.base {
+                PlaceBase::Local(slot) => Some(slot),
+                PlaceBase::Param(_) => None,
+            }
+        } else {
+            None
+        }
+    }
+
+    /// Returns the param slot if this is a simple param place with no projections.
+    #[inline]
+    pub const fn as_param(&self) -> Option<u32> {
+        if self.proj_len == 0 {
+            match self.base {
+                PlaceBase::Param(slot) => Some(slot),
+                PlaceBase::Local(_) => None,
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl fmt::Display for Place {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.base {
+            PlaceBase::Local(slot) => write!(f, "${}", slot)?,
+            PlaceBase::Param(slot) => write!(f, "%{}", slot)?,
+        }
+        if self.proj_len > 0 {
+            write!(
+                f,
+                "[{}..{}]",
+                self.proj_start,
+                self.proj_start + self.proj_len
+            )?;
+        }
+        Ok(())
+    }
+}
+
+/// The base of a place - where the memory location starts.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlaceBase {
+    /// Local variable slot
+    Local(u32),
+    /// Parameter slot (for parameters, including inout)
+    Param(u32),
+}
+
+/// A projection applied to a place to reach a nested location.
+///
+/// Projections are stored in `Cfg::projections` and referenced by
+/// `Place::proj_start` and `Place::proj_len`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Projection {
+    /// Field access: `.field_name`
+    ///
+    /// The struct_id identifies the struct type, and field_index is the
+    /// 0-based index of the field in declaration order.
+    Field {
+        struct_id: StructId,
+        field_index: u32,
+    },
+    /// Array index: `[index]`
+    ///
+    /// The array_type is needed for bounds checking and element size calculation.
+    /// The index is a CfgValue that will be evaluated at runtime.
+    Index { array_type: Type, index: CfgValue },
+}
 
 /// A basic block identifier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -187,6 +324,24 @@ pub enum CfgInstData {
         value: CfgValue,
     },
 
+    // Place operations (ADR-0030)
+    /// Read a value from a memory location.
+    ///
+    /// This unifies Load, IndexGet, and FieldGet into a single instruction
+    /// that can handle arbitrarily nested access patterns like `arr[i].field`.
+    PlaceRead {
+        place: Place,
+    },
+
+    /// Write a value to a memory location.
+    ///
+    /// This unifies Store, IndexSet, ParamIndexSet, FieldSet, and ParamFieldSet
+    /// into a single instruction that can handle nested writes.
+    PlaceWrite {
+        place: Place,
+        value: CfgValue,
+    },
+
     // Function calls
     /// Function call. Arguments are stored in the Cfg's call_args array.
     /// Use `Cfg::get_call_args(args_start, args_len)` to retrieve them.
@@ -220,11 +375,6 @@ pub enum CfgInstData {
         /// Number of fields
         fields_len: u32,
     },
-    FieldGet {
-        base: CfgValue,
-        struct_id: StructId,
-        field_index: u32,
-    },
     FieldSet {
         slot: u32,
         struct_id: StructId,
@@ -251,14 +401,6 @@ pub enum CfgInstData {
         elements_start: u32,
         /// Number of elements
         elements_len: u32,
-    },
-    /// Load an element from an array.
-    /// The result type is the element type.
-    IndexGet {
-        base: CfgValue,
-        /// The array type (for bounds checking and element size)
-        array_type: Type,
-        index: CfgValue,
     },
     /// Store a value to an array element.
     IndexSet {
@@ -428,6 +570,9 @@ pub struct Cfg {
     /// Extra storage for switch cases (value, target block pairs).
     /// Switch terminators store (start, len) indices into this array.
     switch_cases: Vec<(i64, BlockId)>,
+    /// Extra storage for place projections (ADR-0030).
+    /// Place instructions store (start, len) indices into this array.
+    projections: Vec<Projection>,
     /// Number of local variable slots
     num_locals: u32,
     /// Number of parameter slots
@@ -455,6 +600,7 @@ impl Cfg {
             extra: Vec::new(),
             call_args: Vec::new(),
             switch_cases: Vec::new(),
+            projections: Vec::new(),
             num_locals,
             num_params,
             fn_name,
@@ -472,6 +618,20 @@ impl Cfg {
     #[inline]
     pub fn num_locals(&self) -> u32 {
         self.num_locals
+    }
+
+    /// Allocate a new temporary local slot for spilling computed values.
+    ///
+    /// This is used during CFG construction when a computed value (e.g., method
+    /// call result) needs to be accessed via a place expression. The value is
+    /// spilled to this temporary slot.
+    ///
+    /// Returns the slot number for the new local.
+    #[inline]
+    pub fn alloc_temp_local(&mut self) -> u32 {
+        let slot = self.num_locals;
+        self.num_locals += 1;
+        slot
     }
 
     /// Get the number of parameter slots.
@@ -594,6 +754,45 @@ impl Cfg {
     #[inline]
     pub fn get_switch_cases(&self, start: u32, len: u32) -> &[(i64, BlockId)] {
         &self.switch_cases[start as usize..(start + len) as usize]
+    }
+
+    /// Add projections to the projections array and return (start, len).
+    ///
+    /// Used for PlaceRead and PlaceWrite instructions (ADR-0030).
+    pub fn push_projections(&mut self, projs: impl IntoIterator<Item = Projection>) -> (u32, u32) {
+        let start = self.projections.len() as u32;
+        self.projections.extend(projs);
+        let len = self.projections.len() as u32 - start;
+        (start, len)
+    }
+
+    /// Get a slice from the projections array.
+    #[inline]
+    pub fn get_projections(&self, start: u32, len: u32) -> &[Projection] {
+        &self.projections[start as usize..(start + len) as usize]
+    }
+
+    /// Get projections for a place.
+    #[inline]
+    pub fn get_place_projections(&self, place: &Place) -> &[Projection] {
+        self.get_projections(place.proj_start, place.proj_len)
+    }
+
+    /// Create a place with the given base and projections.
+    ///
+    /// This adds the projections to the projections array and returns a Place
+    /// that references them.
+    pub fn make_place(
+        &mut self,
+        base: PlaceBase,
+        projs: impl IntoIterator<Item = Projection>,
+    ) -> Place {
+        let (proj_start, proj_len) = self.push_projections(projs);
+        Place {
+            base,
+            proj_start,
+            proj_len,
+        }
     }
 
     /// Get the block arguments from a Goto terminator.
@@ -899,6 +1098,15 @@ impl Cfg {
             CfgInstData::ParamStore { param_slot, value } => {
                 write!(f, "param_store %{} = {}", param_slot, value)
             }
+            CfgInstData::PlaceRead { place } => {
+                write!(f, "place_read ")?;
+                self.fmt_place(f, place)
+            }
+            CfgInstData::PlaceWrite { place, value } => {
+                write!(f, "place_write ")?;
+                self.fmt_place(f, place)?;
+                write!(f, " = {}", value)
+            }
             CfgInstData::Call {
                 name,
                 args_start,
@@ -950,13 +1158,6 @@ impl Cfg {
                 }
                 write!(f, "}}")
             }
-            CfgInstData::FieldGet {
-                base,
-                struct_id,
-                field_index,
-            } => {
-                write!(f, "field_get {}.#{}.{}", base, struct_id.0, field_index)
-            }
             CfgInstData::FieldSet {
                 slot,
                 struct_id,
@@ -995,13 +1196,6 @@ impl Cfg {
                     write!(f, "{}", elem)?;
                 }
                 write!(f, "]")
-            }
-            CfgInstData::IndexGet {
-                base,
-                array_type,
-                index,
-            } => {
-                write!(f, "index_get {}({})[{}]", base, array_type.name(), index)
             }
             CfgInstData::IndexSet {
                 slot,
@@ -1052,6 +1246,33 @@ impl Cfg {
                 write!(f, "storage_dead ${}", slot)
             }
         }
+    }
+
+    /// Format a place for display, showing the base and projections.
+    fn fmt_place(&self, f: &mut fmt::Formatter<'_>, place: &Place) -> fmt::Result {
+        // Write the base
+        match place.base {
+            PlaceBase::Local(slot) => write!(f, "${}", slot)?,
+            PlaceBase::Param(slot) => write!(f, "param%{}", slot)?,
+        }
+
+        // Write the projections
+        let projections = self.get_place_projections(place);
+        for proj in projections {
+            match proj {
+                Projection::Field {
+                    struct_id,
+                    field_index,
+                } => {
+                    write!(f, ".#{}.{}", struct_id.0, field_index)?;
+                }
+                Projection::Index { array_type, index } => {
+                    write!(f, "({})[{}]", array_type.name(), index)?;
+                }
+            }
+        }
+
+        Ok(())
     }
 }
 

--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -24,7 +24,8 @@ use rue_error::CompileWarning;
 
 pub use build::CfgBuilder;
 pub use inst::{
-    BasicBlock, BlockId, Cfg, CfgArgMode, CfgCallArg, CfgInst, CfgInstData, CfgValue, Terminator,
+    BasicBlock, BlockId, Cfg, CfgArgMode, CfgCallArg, CfgInst, CfgInstData, CfgValue, Place,
+    PlaceBase, Projection, Terminator,
 };
 pub use opt::OptLevel;
 

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -22,7 +22,7 @@
 //! - Drop instructions (run destructors)
 //! - StorageLive, StorageDead (affect stack allocation)
 
-use crate::{BlockId, Cfg, CfgInstData, CfgValue, Terminator};
+use crate::{BlockId, Cfg, CfgInstData, CfgValue, Projection, Terminator};
 
 /// A simple bitset for tracking indices.
 ///
@@ -160,6 +160,12 @@ fn has_side_effects(cfg: &Cfg, value: CfgValue) -> bool {
         // IntCast can panic (range check), so it has side effects
         CfgInstData::IntCast { .. } => true,
 
+        // PlaceWrite is a memory write (side effect)
+        CfgInstData::PlaceWrite { .. } => true,
+
+        // PlaceRead is pure (no side effect unless indexing panics, but we treat that like other ops)
+        CfgInstData::PlaceRead { .. } => false,
+
         // Everything else is pure computation
         _ => false,
     }
@@ -281,7 +287,6 @@ fn visit_instruction_uses(cfg: &Cfg, value: CfgValue, mut f: impl FnMut(CfgValue
                 f(v);
             }
         }
-        CfgInstData::FieldGet { base, .. } => f(*base),
         CfgInstData::FieldSet { value, .. } => f(*value),
         CfgInstData::ParamFieldSet { value, .. } => f(*value),
 
@@ -294,10 +299,6 @@ fn visit_instruction_uses(cfg: &Cfg, value: CfgValue, mut f: impl FnMut(CfgValue
             for &v in cfg.get_extra(*elements_start, *elements_len) {
                 f(v);
             }
-        }
-        CfgInstData::IndexGet { base, index, .. } => {
-            f(*base);
-            f(*index);
         }
         CfgInstData::IndexSet { index, value, .. } => {
             f(*index);
@@ -319,6 +320,25 @@ fn visit_instruction_uses(cfg: &Cfg, value: CfgValue, mut f: impl FnMut(CfgValue
 
         // Storage liveness
         CfgInstData::StorageLive { .. } | CfgInstData::StorageDead { .. } => {}
+
+        // Place operations
+        CfgInstData::PlaceRead { place } => {
+            // Visit any index values used in projections
+            for proj in cfg.get_place_projections(place) {
+                if let Projection::Index { index, .. } = proj {
+                    f(*index);
+                }
+            }
+        }
+        CfgInstData::PlaceWrite { place, value } => {
+            f(*value);
+            // Visit any index values used in projections
+            for proj in cfg.get_place_projections(place) {
+                if let Projection::Index { index, .. } = proj {
+                    f(*index);
+                }
+            }
+        }
     }
 }
 

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -7,11 +7,13 @@ use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
 use rue_air::{StructId, TypeInternPool, TypeKind};
-use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Terminator, Type};
+use rue_cfg::{
+    BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator, Type,
+};
 use rue_target::Target;
 
 use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Operand, Reg, VReg};
-use crate::cfg_lower::{CfgLowerContext, FieldChainBase, IndexChainBase, IndexLevel};
+use crate::cfg_lower::{CfgLowerContext, IndexLevel};
 use crate::types;
 
 /// Argument passing registers per AAPCS64.
@@ -493,9 +495,9 @@ impl<'a> CfgLower<'a> {
                     Some("From stack (AAPCS64, args > 8)".to_string())
                 }
             }
-            CfgInstData::IndexGet { .. } | CfgInstData::IndexSet { .. } => {
-                Some("Includes bounds check".to_string())
-            }
+            CfgInstData::IndexSet { .. }
+            | CfgInstData::PlaceRead { .. }
+            | CfgInstData::PlaceWrite { .. } => Some("Includes bounds check".to_string()),
             _ => None,
         }
     }
@@ -2247,145 +2249,14 @@ impl<'a> CfgLower<'a> {
                             imm: offset,
                         });
                         self.value_map.insert(value, result_vreg);
-                    } else if let CfgInstData::IndexGet {
-                        base,
-                        array_type,
-                        index,
-                    } = &lvalue_inst.data.clone()
-                    {
-                        // Address of an array element: arr[i]
-                        // We need to compute the address, NOT load the value
-                        let array_type = *array_type;
-                        let index = *index;
-                        let base = *base;
-
-                        let elem_slot_count = self.ctx.array_element_slot_count(array_type);
-
-                        // Use trace_index_chain to handle arbitrary nesting depth
-                        if let Some((chain_base, mut levels)) = self.ctx.trace_index_chain(base) {
-                            // Add this level's index to the chain
-                            levels.push(IndexLevel {
-                                index,
-                                elem_slot_count,
-                                array_type,
-                            });
-
-                            // Calculate total offset by summing index * stride for each level
-                            let mut total_offset_vreg: Option<VReg> = None;
-
-                            for level in &levels {
-                                let level_index_vreg = self.get_vreg(level.index);
-                                let level_stride = level.elem_slot_count;
-
-                                // Scale this level's index by its stride
-                                let scaled = self.mir.alloc_vreg();
-                                self.mir.push(Aarch64Inst::MovRR {
-                                    dst: Operand::Virtual(scaled),
-                                    src: Operand::Virtual(level_index_vreg),
-                                });
-
-                                if level_stride == 1 {
-                                    // Simple case: just shift by 3 (multiply by 8)
-                                    self.mir.push(Aarch64Inst::LslImm {
-                                        dst: Operand::Virtual(scaled),
-                                        src: Operand::Virtual(scaled),
-                                        imm: 3,
-                                    });
-                                } else {
-                                    // Multiply by stride * 8
-                                    let stride_vreg = self.mir.alloc_vreg();
-                                    self.mir.push(Aarch64Inst::MovImm {
-                                        dst: Operand::Virtual(stride_vreg),
-                                        imm: (level_stride * 8) as i64,
-                                    });
-                                    self.mir.push(Aarch64Inst::MulRR {
-                                        dst: Operand::Virtual(scaled),
-                                        src1: Operand::Virtual(scaled),
-                                        src2: Operand::Virtual(stride_vreg),
-                                    });
-                                }
-
-                                // Add to running total
-                                if let Some(prev_total) = total_offset_vreg {
-                                    self.mir.push(Aarch64Inst::AddRR {
-                                        dst: Operand::Virtual(prev_total),
-                                        src1: Operand::Virtual(prev_total),
-                                        src2: Operand::Virtual(scaled),
-                                    });
-                                    // prev_total is modified in place, so keep using it
-                                } else {
-                                    total_offset_vreg = Some(scaled);
-                                }
-                            }
-
-                            // Compute base address - different for inout params vs locals/normal params
-                            let addr_vreg = self.mir.alloc_vreg();
-
-                            if let IndexChainBase::Param { index: param_index } = &chain_base {
-                                // Check if this is an inout parameter
-                                if self.ctx.cfg.is_param_inout(*param_index) {
-                                    // For inout params, use the stored pointer
-                                    let ptr_vreg = self.ensure_inout_param_ptr(*param_index);
-                                    self.mir.push(Aarch64Inst::MovRR {
-                                        dst: Operand::Virtual(addr_vreg),
-                                        src: Operand::Virtual(ptr_vreg),
-                                    });
-
-                                    // Subtract total offset (stack grows down)
-                                    if let Some(total) = total_offset_vreg {
-                                        self.mir.push(Aarch64Inst::SubRR {
-                                            dst: Operand::Virtual(addr_vreg),
-                                            src1: Operand::Virtual(addr_vreg),
-                                            src2: Operand::Virtual(total),
-                                        });
-                                    }
-
-                                    self.value_map.insert(value, addr_vreg);
-                                    return;
-                                }
-                            }
-
-                            // Normal case: compute from FP offset
-                            let base_offset = match &chain_base {
-                                IndexChainBase::Load { slot } => self.ctx.local_offset(*slot),
-                                IndexChainBase::Param { index: param_index } => {
-                                    let base_slot = self.ctx.num_locals + *param_index as u32;
-                                    self.ctx.local_offset(base_slot)
-                                }
-                                IndexChainBase::FieldGet {
-                                    struct_base_slot,
-                                    field_slot_offset,
-                                } => {
-                                    let array_base_slot = struct_base_slot + field_slot_offset;
-                                    self.ctx.local_offset(array_base_slot)
-                                }
-                            };
-
-                            // Compute the element address: base_addr - offset
-                            // (stack grows down, so we subtract)
-                            self.mir.push(Aarch64Inst::AddImm {
-                                dst: Operand::Virtual(addr_vreg),
-                                src: Operand::Physical(Reg::Fp),
-                                imm: base_offset,
-                            });
-
-                            // Subtract total offset for the element position
-                            if let Some(total) = total_offset_vreg {
-                                self.mir.push(Aarch64Inst::SubRR {
-                                    dst: Operand::Virtual(addr_vreg),
-                                    src1: Operand::Virtual(addr_vreg),
-                                    src2: Operand::Virtual(total),
-                                });
-                            }
-
-                            self.value_map.insert(value, addr_vreg);
-                        } else {
-                            // Fallback for unsupported patterns
-                            let vreg = self.get_vreg(lvalue_val);
-                            self.value_map.insert(value, vreg);
-                        }
+                    } else if let CfgInstData::PlaceRead { place } = &lvalue_inst.data {
+                        // Address of a place expression (array element, struct field, etc.)
+                        // We compute the address without loading the value.
+                        let result_vreg = self.mir.alloc_vreg();
+                        self.lower_place_addr(result_vreg, place);
+                        self.value_map.insert(value, result_vreg);
                     } else {
-                        // For other lvalue types (Param, FieldGet), fall back to vreg
+                        // For other lvalue types (Param, etc.), fall back to vreg
                         // This is a limitation that can be addressed later.
                         let vreg = self.get_vreg(lvalue_val);
                         self.value_map.insert(value, vreg);
@@ -2435,219 +2306,6 @@ impl<'a> CfgLower<'a> {
                 }
 
                 self.struct_slot_vregs.insert(value, slot_vregs);
-            }
-
-            CfgInstData::FieldGet {
-                base,
-                struct_id,
-                field_index,
-            } => {
-                let vreg = self.mir.alloc_vreg();
-                self.value_map.insert(value, vreg);
-
-                // Try to trace back through any chain of FieldGets to find
-                // the original Load or Param. This handles nested struct field access.
-                let this_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
-                if let Some((base_kind, accumulated_offset)) = self.ctx.trace_field_chain(*base) {
-                    let total_offset = accumulated_offset + this_offset;
-                    match base_kind {
-                        FieldChainBase::Load { slot } => {
-                            // Chain originates from a Load - compute offset from local slot
-                            let actual_slot = slot + total_offset;
-                            let offset = self.ctx.local_offset(actual_slot);
-                            self.mir.push(Aarch64Inst::Ldr {
-                                dst: Operand::Virtual(vreg),
-                                base: Reg::Fp,
-                                offset,
-                            });
-                        }
-                        FieldChainBase::Param { index } => {
-                            // Check if this is an inout parameter
-                            if self.ctx.cfg.is_param_inout(index) {
-                                // For inout params, use the pointer we stored earlier
-                                // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
-                                let ptr_vreg = self.ensure_inout_param_ptr(index);
-                                // Load from pointer - field offset (negative because stack grows down)
-                                self.mir.push(Aarch64Inst::LdrIndexedOffset {
-                                    dst: Operand::Virtual(vreg),
-                                    base: ptr_vreg,
-                                    offset: -((total_offset as i32) * 8),
-                                });
-                            } else {
-                                // Non-inout param: struct is copied to our stack
-                                let param_slot = self.ctx.num_locals + index + total_offset;
-                                let offset = self.ctx.local_offset(param_slot);
-                                self.mir.push(Aarch64Inst::Ldr {
-                                    dst: Operand::Virtual(vreg),
-                                    base: Reg::Fp,
-                                    offset,
-                                });
-                            }
-                        }
-                        FieldChainBase::IndexGet {
-                            index_base,
-                            index_levels,
-                        } => {
-                            // Array of structs case: arr[i].field
-                            // Calculate the array element offset, then add the field offset
-
-                            // Emit bounds check for the innermost index
-                            if let Some(innermost) = index_levels.last() {
-                                let innermost_index_vreg = self.get_vreg(innermost.index);
-                                let array_length = self.ctx.array_length(innermost.array_type);
-                                self.emit_bounds_check(innermost_index_vreg, array_length);
-                            }
-
-                            // Calculate total array offset by summing index * stride for each level
-                            let mut total_array_offset_vreg: Option<VReg> = None;
-
-                            for level in &index_levels {
-                                let level_index_vreg = self.get_vreg(level.index);
-                                let level_stride = level.elem_slot_count;
-
-                                // Scale this level's index by its stride
-                                let scaled = self.mir.alloc_vreg();
-                                if level_stride == 1 {
-                                    // Simple case: just shift by 3 (multiply by 8)
-                                    self.mir.push(Aarch64Inst::LslImm {
-                                        dst: Operand::Virtual(scaled),
-                                        src: Operand::Virtual(level_index_vreg),
-                                        imm: 3,
-                                    });
-                                } else {
-                                    // Multiply by stride * 8
-                                    let stride_vreg = self.mir.alloc_vreg();
-                                    self.mir.push(Aarch64Inst::MovImm {
-                                        dst: Operand::Virtual(stride_vreg),
-                                        imm: (level_stride * 8) as i64,
-                                    });
-                                    self.mir.push(Aarch64Inst::MulRR {
-                                        dst: Operand::Virtual(scaled),
-                                        src1: Operand::Virtual(level_index_vreg),
-                                        src2: Operand::Virtual(stride_vreg),
-                                    });
-                                }
-
-                                // Add to running total
-                                if let Some(prev_total) = total_array_offset_vreg {
-                                    let new_total = self.mir.alloc_vreg();
-                                    self.mir.push(Aarch64Inst::AddRR {
-                                        dst: Operand::Virtual(new_total),
-                                        src1: Operand::Virtual(prev_total),
-                                        src2: Operand::Virtual(scaled),
-                                    });
-                                    total_array_offset_vreg = Some(new_total);
-                                } else {
-                                    total_array_offset_vreg = Some(scaled);
-                                }
-                            }
-
-                            // Add the field offset (in bytes) to the array element offset
-                            // total_offset is the field offset within the struct element
-                            if total_offset > 0 {
-                                let field_offset_bytes = (total_offset * 8) as i64;
-                                if let Some(arr_offset) = total_array_offset_vreg {
-                                    let field_offset_vreg = self.mir.alloc_vreg();
-                                    self.mir.push(Aarch64Inst::MovImm {
-                                        dst: Operand::Virtual(field_offset_vreg),
-                                        imm: field_offset_bytes,
-                                    });
-                                    let new_total = self.mir.alloc_vreg();
-                                    self.mir.push(Aarch64Inst::AddRR {
-                                        dst: Operand::Virtual(new_total),
-                                        src1: Operand::Virtual(arr_offset),
-                                        src2: Operand::Virtual(field_offset_vreg),
-                                    });
-                                    total_array_offset_vreg = Some(new_total);
-                                }
-                            }
-
-                            // Compute base address
-                            let addr_vreg = self.mir.alloc_vreg();
-
-                            if let IndexChainBase::Param { index: param_index } = &index_base {
-                                if self.ctx.cfg.is_param_inout(*param_index) {
-                                    // For inout params, use the stored pointer
-                                    let ptr_vreg = self.ensure_inout_param_ptr(*param_index);
-                                    self.mir.push(Aarch64Inst::MovRR {
-                                        dst: Operand::Virtual(addr_vreg),
-                                        src: Operand::Virtual(ptr_vreg),
-                                    });
-
-                                    // Subtract total offset (array offset + field offset)
-                                    if let Some(total) = total_array_offset_vreg {
-                                        self.mir.push(Aarch64Inst::SubRR {
-                                            dst: Operand::Virtual(addr_vreg),
-                                            src1: Operand::Virtual(addr_vreg),
-                                            src2: Operand::Virtual(total),
-                                        });
-                                    }
-
-                                    // Load from computed address
-                                    self.mir.push(Aarch64Inst::LdrIndexed {
-                                        dst: Operand::Virtual(vreg),
-                                        base: addr_vreg,
-                                    });
-                                    return;
-                                }
-                            }
-
-                            // Normal case: compute from FP offset
-                            let base_offset = match &index_base {
-                                IndexChainBase::Load { slot } => self.ctx.local_offset(*slot),
-                                IndexChainBase::Param { index: param_index } => {
-                                    let base_slot = self.ctx.num_locals + *param_index as u32;
-                                    self.ctx.local_offset(base_slot)
-                                }
-                                IndexChainBase::FieldGet {
-                                    struct_base_slot,
-                                    field_slot_offset,
-                                } => {
-                                    let array_base_slot = struct_base_slot + field_slot_offset;
-                                    self.ctx.local_offset(array_base_slot)
-                                }
-                            };
-
-                            self.mir.push(Aarch64Inst::SubImm {
-                                dst: Operand::Virtual(addr_vreg),
-                                src: Operand::Physical(Reg::Fp),
-                                imm: -base_offset,
-                            });
-
-                            // Subtract total offset (array offset + field offset)
-                            if let Some(total) = total_array_offset_vreg {
-                                self.mir.push(Aarch64Inst::SubRR {
-                                    dst: Operand::Virtual(addr_vreg),
-                                    src1: Operand::Virtual(addr_vreg),
-                                    src2: Operand::Virtual(total),
-                                });
-                            }
-
-                            // Load from computed address
-                            self.mir.push(Aarch64Inst::LdrIndexed {
-                                dst: Operand::Virtual(vreg),
-                                base: addr_vreg,
-                            });
-                        }
-                    }
-                } else {
-                    // For other sources (BlockParam, StructInit, Call), use slot vregs.
-                    // IMPORTANT: struct_slot_vregs contains slot vregs (accounting for
-                    // nested struct sizes), so we need to use the slot offset, not field index.
-                    let slot_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
-                    let slot_vregs = self
-                        .struct_slot_vregs
-                        .get(base)
-                        .cloned()
-                        .expect("struct base should have slot vregs in cache");
-                    let slot_vreg = *slot_vregs
-                        .get(slot_offset as usize)
-                        .expect("slot_offset should be within slot_vregs bounds");
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Virtual(vreg),
-                        src: Operand::Virtual(slot_vreg),
-                    });
-                }
             }
 
             CfgInstData::FieldSet {
@@ -2709,7 +2367,7 @@ impl<'a> CfgLower<'a> {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
 
-                // Store element vregs for later IndexGet access
+                // Store element vregs for later access
                 let elements = self.ctx.cfg.get_extra(*elements_start, *elements_len);
                 let element_vregs: Vec<VReg> = elements.iter().map(|e| self.get_vreg(*e)).collect();
                 self.struct_slot_vregs.insert(value, element_vregs);
@@ -2719,176 +2377,6 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(vreg),
                     imm: 0,
                 });
-            }
-
-            CfgInstData::IndexGet {
-                base,
-                array_type,
-                index,
-            } => {
-                let vreg = self.mir.alloc_vreg();
-                self.value_map.insert(value, vreg);
-
-                // Calculate the slot stride for this array's elements
-                let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
-
-                // First, check if base is an ArrayInit (constant index case)
-                let base_data = &self.ctx.cfg.get_inst(*base).data.clone();
-                if let CfgInstData::ArrayInit { .. } = base_data {
-                    // For ArrayInit sources, use element vregs if index is constant
-                    let index_inst = &self.ctx.cfg.get_inst(*index).data;
-                    if let CfgInstData::Const(idx) = index_inst {
-                        if let Some(element_vregs) = self.struct_slot_vregs.get(base).cloned() {
-                            if let Some(&elem_vreg) = element_vregs.get(*idx as usize) {
-                                self.mir.push(Aarch64Inst::MovRR {
-                                    dst: Operand::Virtual(vreg),
-                                    src: Operand::Virtual(elem_vreg),
-                                });
-                                return;
-                            }
-                        }
-                    }
-                    // Fallback for non-constant index into ArrayInit
-                    self.mir.push(Aarch64Inst::MovImm {
-                        dst: Operand::Virtual(vreg),
-                        imm: 0,
-                    });
-                    return;
-                }
-
-                // Use trace_index_chain to handle arbitrary nesting depth
-                if let Some((chain_base, mut levels)) = self.ctx.trace_index_chain(*base) {
-                    // Add this level's index to the chain
-                    levels.push(IndexLevel {
-                        index: *index,
-                        elem_slot_count,
-                        array_type: *array_type,
-                    });
-
-                    // Emit bounds check for the innermost index
-                    let innermost_index_vreg = self.get_vreg(*index);
-                    let array_length = self.ctx.array_length(*array_type);
-                    self.emit_bounds_check(innermost_index_vreg, array_length);
-
-                    // Calculate total offset by summing index * stride for each level
-                    let mut total_offset_vreg: Option<VReg> = None;
-
-                    for level in &levels {
-                        let level_index_vreg = self.get_vreg(level.index);
-                        let level_stride = level.elem_slot_count;
-
-                        // Scale this level's index by its stride
-                        let scaled = self.mir.alloc_vreg();
-                        if level_stride == 1 {
-                            // Simple case: just shift by 3 (multiply by 8)
-                            self.mir.push(Aarch64Inst::LslImm {
-                                dst: Operand::Virtual(scaled),
-                                src: Operand::Virtual(level_index_vreg),
-                                imm: 3,
-                            });
-                        } else {
-                            // Multiply by stride * 8
-                            let stride_vreg = self.mir.alloc_vreg();
-                            self.mir.push(Aarch64Inst::MovImm {
-                                dst: Operand::Virtual(stride_vreg),
-                                imm: (level_stride * 8) as i64,
-                            });
-                            self.mir.push(Aarch64Inst::MulRR {
-                                dst: Operand::Virtual(scaled),
-                                src1: Operand::Virtual(level_index_vreg),
-                                src2: Operand::Virtual(stride_vreg),
-                            });
-                        }
-
-                        // Add to running total
-                        if let Some(prev_total) = total_offset_vreg {
-                            let new_total = self.mir.alloc_vreg();
-                            self.mir.push(Aarch64Inst::AddRR {
-                                dst: Operand::Virtual(new_total),
-                                src1: Operand::Virtual(prev_total),
-                                src2: Operand::Virtual(scaled),
-                            });
-                            total_offset_vreg = Some(new_total);
-                        } else {
-                            total_offset_vreg = Some(scaled);
-                        }
-                    }
-
-                    // Compute base address - different for inout params vs locals/normal params
-                    let addr_vreg = self.mir.alloc_vreg();
-
-                    if let IndexChainBase::Param { index: param_index } = &chain_base {
-                        // Check if this is an inout parameter
-                        if self.ctx.cfg.is_param_inout(*param_index) {
-                            // For inout params, use the stored pointer
-                            // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
-                            let ptr_vreg = self.ensure_inout_param_ptr(*param_index);
-                            self.mir.push(Aarch64Inst::MovRR {
-                                dst: Operand::Virtual(addr_vreg),
-                                src: Operand::Virtual(ptr_vreg),
-                            });
-
-                            // Subtract total offset
-                            if let Some(total) = total_offset_vreg {
-                                self.mir.push(Aarch64Inst::SubRR {
-                                    dst: Operand::Virtual(addr_vreg),
-                                    src1: Operand::Virtual(addr_vreg),
-                                    src2: Operand::Virtual(total),
-                                });
-                            }
-
-                            // Load from computed address
-                            self.mir.push(Aarch64Inst::LdrIndexed {
-                                dst: Operand::Virtual(vreg),
-                                base: addr_vreg,
-                            });
-                            return;
-                        }
-                    }
-
-                    // Normal case: compute from FP offset
-                    let base_offset = match &chain_base {
-                        IndexChainBase::Load { slot } => self.ctx.local_offset(*slot),
-                        IndexChainBase::Param { index: param_index } => {
-                            let base_slot = self.ctx.num_locals + *param_index as u32;
-                            self.ctx.local_offset(base_slot)
-                        }
-                        IndexChainBase::FieldGet {
-                            struct_base_slot,
-                            field_slot_offset,
-                        } => {
-                            let array_base_slot = struct_base_slot + field_slot_offset;
-                            self.ctx.local_offset(array_base_slot)
-                        }
-                    };
-
-                    self.mir.push(Aarch64Inst::SubImm {
-                        dst: Operand::Virtual(addr_vreg),
-                        src: Operand::Physical(Reg::Fp),
-                        imm: -base_offset,
-                    });
-
-                    // Subtract total offset
-                    if let Some(total) = total_offset_vreg {
-                        self.mir.push(Aarch64Inst::SubRR {
-                            dst: Operand::Virtual(addr_vreg),
-                            src1: Operand::Virtual(addr_vreg),
-                            src2: Operand::Virtual(total),
-                        });
-                    }
-
-                    // Load from computed address
-                    self.mir.push(Aarch64Inst::LdrIndexed {
-                        dst: Operand::Virtual(vreg),
-                        base: addr_vreg,
-                    });
-                } else {
-                    // Fallback for unsupported patterns
-                    self.mir.push(Aarch64Inst::MovImm {
-                        dst: Operand::Virtual(vreg),
-                        imm: 0,
-                    });
-                }
             }
 
             CfgInstData::IndexSet {
@@ -3179,6 +2667,19 @@ impl<'a> CfgLower<'a> {
                 // StorageDead marks a slot as no longer in use.
                 // Currently a no-op in codegen. In the future, this could be used
                 // for stack slot optimization (LLVM lifetime intrinsics).
+            }
+
+            // Place operations (ADR-0030)
+            // These provide a unified abstraction for memory access with projections.
+            CfgInstData::PlaceRead { place } => {
+                let vreg = self.mir.alloc_vreg();
+                self.value_map.insert(value, vreg);
+                self.lower_place_read(vreg, place, ty);
+            }
+
+            CfgInstData::PlaceWrite { place, value: val } => {
+                let val_vreg = self.get_vreg(*val);
+                self.lower_place_write(place, val_vreg);
             }
         }
     }
@@ -4253,6 +3754,549 @@ impl<'a> CfgLower<'a> {
 
             Terminator::None => {
                 panic!("block has no terminator");
+            }
+        }
+    }
+
+    // === Place operations (ADR-0030) ===
+
+    /// Lower a PlaceRead instruction.
+    ///
+    /// This loads a value from the memory location described by the place,
+    /// walking through any projections (field accesses, array indices).
+    fn lower_place_read(&mut self, dst: VReg, place: &Place, _ty: Type) {
+        let projections = self.ctx.cfg.get_place_projections(place);
+
+        // Simple case: no projections, just load from the base slot
+        if projections.is_empty() {
+            match place.base {
+                PlaceBase::Local(slot) => {
+                    let offset = self.ctx.local_offset(slot);
+                    self.mir.push(Aarch64Inst::Ldr {
+                        dst: Operand::Virtual(dst),
+                        base: Reg::Fp,
+                        offset,
+                    });
+                }
+                PlaceBase::Param(param_slot) => {
+                    // Check if this is an inout parameter
+                    if self.ctx.cfg.is_param_inout(param_slot) {
+                        // Inout param - load through the pointer
+                        let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
+                        self.mir.push(Aarch64Inst::LdrIndexed {
+                            dst: Operand::Virtual(dst),
+                            base: ptr_vreg,
+                        });
+                    } else {
+                        // Normal param - load from local slot
+                        let slot = self.ctx.num_locals + param_slot;
+                        let offset = self.ctx.local_offset(slot);
+                        self.mir.push(Aarch64Inst::Ldr {
+                            dst: Operand::Virtual(dst),
+                            base: Reg::Fp,
+                            offset,
+                        });
+                    }
+                }
+            }
+            return;
+        }
+
+        // Complex case: has projections - compute the address
+        self.lower_place_read_with_projections(dst, place, projections);
+    }
+
+    /// Lower a PlaceRead with projections (field accesses and/or array indices).
+    fn lower_place_read_with_projections(
+        &mut self,
+        dst: VReg,
+        place: &Place,
+        projections: &[Projection],
+    ) {
+        // Calculate the static field offset (sum of all Field projection offsets)
+        let mut static_slot_offset: u32 = 0;
+
+        // Collect index projections for dynamic offset calculation
+        let mut index_levels: Vec<IndexLevel> = Vec::new();
+
+        for proj in projections {
+            match proj {
+                Projection::Field {
+                    struct_id,
+                    field_index,
+                } => {
+                    let field_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
+                    static_slot_offset += field_offset;
+                }
+                Projection::Index { array_type, index } => {
+                    // Emit bounds check for this index
+                    let index_vreg = self.get_vreg(*index);
+                    let array_length = self.ctx.array_length(*array_type);
+                    self.emit_bounds_check(index_vreg, array_length);
+
+                    let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
+                    index_levels.push(IndexLevel {
+                        index: *index,
+                        elem_slot_count,
+                        array_type: *array_type,
+                    });
+                }
+            }
+        }
+
+        // Calculate dynamic offset from index projections
+        let dynamic_offset_vreg = if !index_levels.is_empty() {
+            Some(self.compute_index_offset(&index_levels))
+        } else {
+            None
+        };
+
+        // Compute final address based on base type
+        match place.base {
+            PlaceBase::Local(slot) => {
+                let base_slot = slot + static_slot_offset;
+                let base_offset = self.ctx.local_offset(base_slot);
+
+                if let Some(dyn_offset) = dynamic_offset_vreg {
+                    // Compute address: fp + base_offset - dynamic_offset
+                    let addr_vreg = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::AddImm {
+                        dst: Operand::Virtual(addr_vreg),
+                        src: Operand::Physical(Reg::Fp),
+                        imm: base_offset,
+                    });
+                    self.mir.push(Aarch64Inst::SubRR {
+                        dst: Operand::Virtual(addr_vreg),
+                        src1: Operand::Virtual(addr_vreg),
+                        src2: Operand::Virtual(dyn_offset),
+                    });
+                    self.mir.push(Aarch64Inst::LdrIndexed {
+                        dst: Operand::Virtual(dst),
+                        base: addr_vreg,
+                    });
+                } else {
+                    // Static offset only
+                    self.mir.push(Aarch64Inst::Ldr {
+                        dst: Operand::Virtual(dst),
+                        base: Reg::Fp,
+                        offset: base_offset,
+                    });
+                }
+            }
+            PlaceBase::Param(param_slot) => {
+                if self.ctx.cfg.is_param_inout(param_slot) {
+                    // Inout param - use pointer
+                    let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
+                    let static_byte_offset = (static_slot_offset as i32) * 8;
+
+                    if let Some(dyn_offset) = dynamic_offset_vreg {
+                        // Compute address: ptr - static_offset - dynamic_offset
+                        let addr_vreg = self.mir.alloc_vreg();
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Virtual(addr_vreg),
+                            src: Operand::Virtual(ptr_vreg),
+                        });
+                        if static_byte_offset != 0 {
+                            self.mir.push(Aarch64Inst::SubImm {
+                                dst: Operand::Virtual(addr_vreg),
+                                src: Operand::Virtual(addr_vreg),
+                                imm: static_byte_offset,
+                            });
+                        }
+                        self.mir.push(Aarch64Inst::SubRR {
+                            dst: Operand::Virtual(addr_vreg),
+                            src1: Operand::Virtual(addr_vreg),
+                            src2: Operand::Virtual(dyn_offset),
+                        });
+                        self.mir.push(Aarch64Inst::LdrIndexed {
+                            dst: Operand::Virtual(dst),
+                            base: addr_vreg,
+                        });
+                    } else {
+                        // Static offset only
+                        self.mir.push(Aarch64Inst::LdrIndexedOffset {
+                            dst: Operand::Virtual(dst),
+                            base: ptr_vreg,
+                            offset: -static_byte_offset,
+                        });
+                    }
+                } else {
+                    // Normal param - treat like local
+                    let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
+                    let base_offset = self.ctx.local_offset(base_slot);
+
+                    if let Some(dyn_offset) = dynamic_offset_vreg {
+                        let addr_vreg = self.mir.alloc_vreg();
+                        self.mir.push(Aarch64Inst::AddImm {
+                            dst: Operand::Virtual(addr_vreg),
+                            src: Operand::Physical(Reg::Fp),
+                            imm: base_offset,
+                        });
+                        self.mir.push(Aarch64Inst::SubRR {
+                            dst: Operand::Virtual(addr_vreg),
+                            src1: Operand::Virtual(addr_vreg),
+                            src2: Operand::Virtual(dyn_offset),
+                        });
+                        self.mir.push(Aarch64Inst::LdrIndexed {
+                            dst: Operand::Virtual(dst),
+                            base: addr_vreg,
+                        });
+                    } else {
+                        self.mir.push(Aarch64Inst::Ldr {
+                            dst: Operand::Virtual(dst),
+                            base: Reg::Fp,
+                            offset: base_offset,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    /// Lower a PlaceWrite instruction.
+    ///
+    /// This stores a value to the memory location described by the place.
+    fn lower_place_write(&mut self, place: &Place, val_vreg: VReg) {
+        let projections = self.ctx.cfg.get_place_projections(place);
+
+        // Simple case: no projections, just store to the base slot
+        if projections.is_empty() {
+            match place.base {
+                PlaceBase::Local(slot) => {
+                    let offset = self.ctx.local_offset(slot);
+                    self.mir.push(Aarch64Inst::Str {
+                        src: Operand::Virtual(val_vreg),
+                        base: Reg::Fp,
+                        offset,
+                    });
+                }
+                PlaceBase::Param(param_slot) => {
+                    if self.ctx.cfg.is_param_inout(param_slot) {
+                        // Inout param - store through the pointer
+                        let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
+                        self.mir.push(Aarch64Inst::StrIndexed {
+                            src: Operand::Virtual(val_vreg),
+                            base: ptr_vreg,
+                        });
+                    } else {
+                        // Normal param - store to local slot
+                        let slot = self.ctx.num_locals + param_slot;
+                        let offset = self.ctx.local_offset(slot);
+                        self.mir.push(Aarch64Inst::Str {
+                            src: Operand::Virtual(val_vreg),
+                            base: Reg::Fp,
+                            offset,
+                        });
+                    }
+                }
+            }
+            return;
+        }
+
+        // Complex case: has projections - compute the address
+        self.lower_place_write_with_projections(place, projections, val_vreg);
+    }
+
+    /// Lower a PlaceWrite with projections.
+    fn lower_place_write_with_projections(
+        &mut self,
+        place: &Place,
+        projections: &[Projection],
+        val_vreg: VReg,
+    ) {
+        // Calculate the static field offset
+        let mut static_slot_offset: u32 = 0;
+
+        // Collect index projections for dynamic offset calculation
+        let mut index_levels: Vec<IndexLevel> = Vec::new();
+
+        for proj in projections {
+            match proj {
+                Projection::Field {
+                    struct_id,
+                    field_index,
+                } => {
+                    let field_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
+                    static_slot_offset += field_offset;
+                }
+                Projection::Index { array_type, index } => {
+                    // Emit bounds check for this index
+                    let index_vreg = self.get_vreg(*index);
+                    let array_length = self.ctx.array_length(*array_type);
+                    self.emit_bounds_check(index_vreg, array_length);
+
+                    let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
+                    index_levels.push(IndexLevel {
+                        index: *index,
+                        elem_slot_count,
+                        array_type: *array_type,
+                    });
+                }
+            }
+        }
+
+        // Calculate dynamic offset from index projections
+        let dynamic_offset_vreg = if !index_levels.is_empty() {
+            Some(self.compute_index_offset(&index_levels))
+        } else {
+            None
+        };
+
+        // Compute final address based on base type
+        match place.base {
+            PlaceBase::Local(slot) => {
+                let base_slot = slot + static_slot_offset;
+                let base_offset = self.ctx.local_offset(base_slot);
+
+                if let Some(dyn_offset) = dynamic_offset_vreg {
+                    let addr_vreg = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::AddImm {
+                        dst: Operand::Virtual(addr_vreg),
+                        src: Operand::Physical(Reg::Fp),
+                        imm: base_offset,
+                    });
+                    self.mir.push(Aarch64Inst::SubRR {
+                        dst: Operand::Virtual(addr_vreg),
+                        src1: Operand::Virtual(addr_vreg),
+                        src2: Operand::Virtual(dyn_offset),
+                    });
+                    self.mir.push(Aarch64Inst::StrIndexed {
+                        src: Operand::Virtual(val_vreg),
+                        base: addr_vreg,
+                    });
+                } else {
+                    self.mir.push(Aarch64Inst::Str {
+                        src: Operand::Virtual(val_vreg),
+                        base: Reg::Fp,
+                        offset: base_offset,
+                    });
+                }
+            }
+            PlaceBase::Param(param_slot) => {
+                if self.ctx.cfg.is_param_inout(param_slot) {
+                    let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
+                    let static_byte_offset = (static_slot_offset as i32) * 8;
+
+                    if let Some(dyn_offset) = dynamic_offset_vreg {
+                        let addr_vreg = self.mir.alloc_vreg();
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Virtual(addr_vreg),
+                            src: Operand::Virtual(ptr_vreg),
+                        });
+                        if static_byte_offset != 0 {
+                            self.mir.push(Aarch64Inst::SubImm {
+                                dst: Operand::Virtual(addr_vreg),
+                                src: Operand::Virtual(addr_vreg),
+                                imm: static_byte_offset,
+                            });
+                        }
+                        self.mir.push(Aarch64Inst::SubRR {
+                            dst: Operand::Virtual(addr_vreg),
+                            src1: Operand::Virtual(addr_vreg),
+                            src2: Operand::Virtual(dyn_offset),
+                        });
+                        self.mir.push(Aarch64Inst::StrIndexed {
+                            src: Operand::Virtual(val_vreg),
+                            base: addr_vreg,
+                        });
+                    } else {
+                        self.mir.push(Aarch64Inst::StrIndexedOffset {
+                            src: Operand::Virtual(val_vreg),
+                            base: ptr_vreg,
+                            offset: -static_byte_offset,
+                        });
+                    }
+                } else {
+                    let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
+                    let base_offset = self.ctx.local_offset(base_slot);
+
+                    if let Some(dyn_offset) = dynamic_offset_vreg {
+                        let addr_vreg = self.mir.alloc_vreg();
+                        self.mir.push(Aarch64Inst::AddImm {
+                            dst: Operand::Virtual(addr_vreg),
+                            src: Operand::Physical(Reg::Fp),
+                            imm: base_offset,
+                        });
+                        self.mir.push(Aarch64Inst::SubRR {
+                            dst: Operand::Virtual(addr_vreg),
+                            src1: Operand::Virtual(addr_vreg),
+                            src2: Operand::Virtual(dyn_offset),
+                        });
+                        self.mir.push(Aarch64Inst::StrIndexed {
+                            src: Operand::Virtual(val_vreg),
+                            base: addr_vreg,
+                        });
+                    } else {
+                        self.mir.push(Aarch64Inst::Str {
+                            src: Operand::Virtual(val_vreg),
+                            base: Reg::Fp,
+                            offset: base_offset,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    /// Compute the byte offset for a series of index projections.
+    ///
+    /// Returns a vreg containing the total byte offset (index * stride for each level).
+    fn compute_index_offset(&mut self, levels: &[IndexLevel]) -> VReg {
+        let mut total_offset_vreg: Option<VReg> = None;
+
+        for level in levels {
+            let level_index_vreg = self.get_vreg(level.index);
+            let level_stride = level.elem_slot_count;
+
+            // Scale this level's index by its stride
+            let scaled = self.mir.alloc_vreg();
+            self.mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Virtual(scaled),
+                src: Operand::Virtual(level_index_vreg),
+            });
+
+            if level_stride == 1 {
+                // Simple case: just shift by 3 (multiply by 8)
+                self.mir.push(Aarch64Inst::LslImm {
+                    dst: Operand::Virtual(scaled),
+                    src: Operand::Virtual(scaled),
+                    imm: 3,
+                });
+            } else {
+                // Multiply by stride * 8
+                let stride_vreg = self.mir.alloc_vreg();
+                self.mir.push(Aarch64Inst::MovImm {
+                    dst: Operand::Virtual(stride_vreg),
+                    imm: (level_stride * 8) as i64,
+                });
+                self.mir.push(Aarch64Inst::MulRR {
+                    dst: Operand::Virtual(scaled),
+                    src1: Operand::Virtual(scaled),
+                    src2: Operand::Virtual(stride_vreg),
+                });
+            }
+
+            // Add to running total
+            if let Some(prev_total) = total_offset_vreg {
+                self.mir.push(Aarch64Inst::AddRR {
+                    dst: Operand::Virtual(prev_total),
+                    src1: Operand::Virtual(prev_total),
+                    src2: Operand::Virtual(scaled),
+                });
+                // prev_total is modified in place
+            } else {
+                total_offset_vreg = Some(scaled);
+            }
+        }
+
+        total_offset_vreg.expect("compute_index_offset called with empty levels")
+    }
+
+    /// Compute the address of a place (for @addr_of intrinsic).
+    ///
+    /// This is similar to lower_place_read but returns the address instead of loading.
+    fn lower_place_addr(&mut self, dst: VReg, place: &Place) {
+        let projections = self.ctx.cfg.get_place_projections(place);
+
+        // Calculate static slot offset from field projections
+        let mut static_slot_offset: u32 = 0;
+        let mut index_levels: Vec<IndexLevel> = Vec::new();
+
+        for proj in projections {
+            match proj {
+                Projection::Field {
+                    struct_id,
+                    field_index,
+                } => {
+                    let field_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
+                    static_slot_offset += field_offset;
+                }
+                Projection::Index { array_type, index } => {
+                    let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
+                    index_levels.push(IndexLevel {
+                        index: *index,
+                        elem_slot_count,
+                        array_type: *array_type,
+                    });
+                }
+            }
+        }
+
+        // Calculate dynamic offset from index projections
+        let dynamic_offset_vreg = if !index_levels.is_empty() {
+            Some(self.compute_index_offset(&index_levels))
+        } else {
+            None
+        };
+
+        // Compute address based on base type
+        match place.base {
+            PlaceBase::Local(slot) => {
+                let base_slot = slot + static_slot_offset;
+                let base_offset = self.ctx.local_offset(base_slot);
+
+                // Start with fp + base_offset
+                self.mir.push(Aarch64Inst::AddImm {
+                    dst: Operand::Virtual(dst),
+                    src: Operand::Physical(Reg::Fp),
+                    imm: base_offset,
+                });
+
+                // Subtract dynamic offset if any
+                if let Some(dyn_offset) = dynamic_offset_vreg {
+                    self.mir.push(Aarch64Inst::SubRR {
+                        dst: Operand::Virtual(dst),
+                        src1: Operand::Virtual(dst),
+                        src2: Operand::Virtual(dyn_offset),
+                    });
+                }
+            }
+            PlaceBase::Param(param_slot) => {
+                if self.ctx.cfg.is_param_inout(param_slot) {
+                    let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
+                    let static_byte_offset = (static_slot_offset as i32) * 8;
+
+                    // Start with the pointer value
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(dst),
+                        src: Operand::Virtual(ptr_vreg),
+                    });
+
+                    // Subtract static offset
+                    if static_byte_offset != 0 {
+                        self.mir.push(Aarch64Inst::SubImm {
+                            dst: Operand::Virtual(dst),
+                            src: Operand::Virtual(dst),
+                            imm: static_byte_offset,
+                        });
+                    }
+
+                    // Subtract dynamic offset
+                    if let Some(dyn_offset) = dynamic_offset_vreg {
+                        self.mir.push(Aarch64Inst::SubRR {
+                            dst: Operand::Virtual(dst),
+                            src1: Operand::Virtual(dst),
+                            src2: Operand::Virtual(dyn_offset),
+                        });
+                    }
+                } else {
+                    let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
+                    let base_offset = self.ctx.local_offset(base_slot);
+
+                    self.mir.push(Aarch64Inst::AddImm {
+                        dst: Operand::Virtual(dst),
+                        src: Operand::Physical(Reg::Fp),
+                        imm: base_offset,
+                    });
+
+                    if let Some(dyn_offset) = dynamic_offset_vreg {
+                        self.mir.push(Aarch64Inst::SubRR {
+                            dst: Operand::Virtual(dst),
+                            src1: Operand::Virtual(dst),
+                            src2: Operand::Virtual(dyn_offset),
+                        });
+                    }
+                }
             }
         }
     }

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -26,6 +26,16 @@ use rue_cfg::{BlockId, Cfg, CfgInstData, CfgValue, Type};
 
 use crate::types;
 
+/// Represents an index operation: the index value and the stride (slots per element).
+/// Used for lowering Place projections that include array indexing.
+#[derive(Clone)]
+pub struct IndexLevel {
+    pub index: CfgValue,
+    pub elem_slot_count: u32,
+    /// The array type (Type::Array(...)) for bounds checking.
+    pub array_type: Type,
+}
+
 /// A single lowering decision: maps one CFG instruction to its MIR expansion.
 #[derive(Debug, Clone)]
 pub struct LoweringDecision {
@@ -170,11 +180,6 @@ pub fn format_cfg_inst_data(data: &rue_cfg::CfgInstData) -> String {
             // Note: Can't show fields without Cfg access; just show struct_id
             format!("struct_init #{} {{...}}", struct_id.0)
         }
-        CfgInstData::FieldGet {
-            base,
-            struct_id,
-            field_index,
-        } => format!("field_get {}.#{}.{}", base, struct_id.0, field_index),
         CfgInstData::FieldSet {
             slot,
             struct_id,
@@ -198,11 +203,6 @@ pub fn format_cfg_inst_data(data: &rue_cfg::CfgInstData) -> String {
             // Note: Can't show elements without Cfg access
             "array_init [...]".to_string()
         }
-        CfgInstData::IndexGet {
-            base,
-            array_type,
-            index,
-        } => format!("index_get {}[{}][{}]", base, array_type.name(), index),
         CfgInstData::IndexSet {
             slot,
             array_type,
@@ -239,6 +239,13 @@ pub fn format_cfg_inst_data(data: &rue_cfg::CfgInstData) -> String {
         CfgInstData::Drop { value } => format!("drop {}", value),
         CfgInstData::StorageLive { slot } => format!("storage_live ${}", slot),
         CfgInstData::StorageDead { slot } => format!("storage_dead ${}", slot),
+        // Place operations (ADR-0030)
+        CfgInstData::PlaceRead { place } => {
+            format!("place_read {}", place)
+        }
+        CfgInstData::PlaceWrite { place, value } => {
+            format!("place_write {} = {}", place, value)
+        }
     }
 }
 
@@ -323,44 +330,6 @@ pub fn format_terminator(cfg: &rue_cfg::Cfg, terminator: &rue_cfg::Terminator) -
     }
 }
 
-/// Result of tracing back through FieldGet chains to find the original source.
-#[derive(Clone)]
-pub enum FieldChainBase {
-    /// Chain originates from a Load instruction with the given slot.
-    Load { slot: u32 },
-    /// Chain originates from a Param instruction with the given index.
-    Param { index: u32 },
-    /// Chain originates from an IndexGet (struct element within an array).
-    /// Contains the index chain base and levels needed to compute the element address.
-    IndexGet {
-        index_base: IndexChainBase,
-        index_levels: Vec<IndexLevel>,
-    },
-}
-
-/// Result of tracing back through IndexGet chains to find the original source.
-#[derive(Clone)]
-pub enum IndexChainBase {
-    /// Chain originates from a Load instruction with the given slot.
-    Load { slot: u32 },
-    /// Chain originates from a Param instruction with the given index.
-    Param { index: u32 },
-    /// Chain originates from a FieldGet (array within a struct).
-    FieldGet {
-        struct_base_slot: u32,
-        field_slot_offset: u32,
-    },
-}
-
-/// Represents an index operation in a chain: the index value and the stride (slots per element).
-#[derive(Clone)]
-pub struct IndexLevel {
-    pub index: CfgValue,
-    pub elem_slot_count: u32,
-    /// The array type (Type::Array(...)) for bounds checking.
-    pub array_type: Type,
-}
-
 // ============================================================================
 // Shared CFG Lowering Context
 // ============================================================================
@@ -371,8 +340,8 @@ pub struct IndexLevel {
 /// and provides architecture-independent helper methods for:
 ///
 /// - Type queries (slot counts, field offsets, array lengths)
-/// - Chain tracing (following FieldGet/IndexGet chains to find origins)
 /// - Builtin type detection and operator lookup
+/// - Slot offset calculations
 ///
 /// Each backend's `CfgLower` embeds this context and delegates to its methods.
 pub struct CfgLowerContext<'a> {
@@ -464,111 +433,6 @@ impl<'a> CfgLowerContext<'a> {
         builtin
             .find_operator(op)
             .map(|op_def| (op_def.runtime_fn, op_def.invert_result))
-    }
-
-    // ========================================================================
-    // Chain tracing
-    // ========================================================================
-
-    /// Trace back through a chain of FieldGet instructions to find the original
-    /// Load or Param source. Returns the base kind and accumulated slot offset.
-    pub fn trace_field_chain(&self, value: CfgValue) -> Option<(FieldChainBase, u32)> {
-        let inst = self.cfg.get_inst(value);
-        match &inst.data {
-            CfgInstData::Load { slot } => Some((FieldChainBase::Load { slot: *slot }, 0)),
-            CfgInstData::Param { index } => Some((FieldChainBase::Param { index: *index }, 0)),
-            CfgInstData::FieldGet {
-                base,
-                struct_id,
-                field_index,
-            } => {
-                // Recursively trace back through the base
-                if let Some((base_kind, accumulated_offset)) = self.trace_field_chain(*base) {
-                    let this_offset = self.struct_field_slot_offset(*struct_id, *field_index);
-                    Some((base_kind, accumulated_offset + this_offset))
-                } else {
-                    None
-                }
-            }
-            CfgInstData::IndexGet {
-                base: array_base,
-                array_type,
-                index,
-            } => {
-                // Array of structs case: the field's base is an IndexGet
-                // Try to trace the array base to find the original Load/Param
-                if let Some((index_base, mut levels)) = self.trace_index_chain(*array_base) {
-                    let elem_slot_count = self.array_element_slot_count(*array_type);
-                    levels.push(IndexLevel {
-                        index: *index,
-                        elem_slot_count,
-                        array_type: *array_type,
-                    });
-                    Some((
-                        FieldChainBase::IndexGet {
-                            index_base,
-                            index_levels: levels,
-                        },
-                        0, // No field offset yet - that will be added by the calling FieldGet
-                    ))
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        }
-    }
-
-    /// Trace back through a chain of IndexGet instructions to find the original
-    /// source (Load, Param, or FieldGet). Returns the base kind and the list of
-    /// index levels from outermost to innermost.
-    pub fn trace_index_chain(&self, value: CfgValue) -> Option<(IndexChainBase, Vec<IndexLevel>)> {
-        let inst = self.cfg.get_inst(value);
-        match &inst.data {
-            CfgInstData::Load { slot } => Some((IndexChainBase::Load { slot: *slot }, vec![])),
-            CfgInstData::Param { index } => Some((IndexChainBase::Param { index: *index }, vec![])),
-            CfgInstData::FieldGet {
-                base,
-                struct_id,
-                field_index,
-            } => {
-                // Array within a struct - find the struct's Load/Param
-                let struct_base_data = &self.cfg.get_inst(*base).data;
-                match struct_base_data {
-                    CfgInstData::Load { slot } => {
-                        let field_slot_offset =
-                            self.struct_field_slot_offset(*struct_id, *field_index);
-                        Some((
-                            IndexChainBase::FieldGet {
-                                struct_base_slot: *slot,
-                                field_slot_offset,
-                            },
-                            vec![],
-                        ))
-                    }
-                    _ => None, // Other struct sources not supported
-                }
-            }
-            CfgInstData::IndexGet {
-                base,
-                array_type,
-                index,
-            } => {
-                // Recursively trace the base
-                if let Some((base_kind, mut levels)) = self.trace_index_chain(*base) {
-                    let elem_slot_count = self.array_element_slot_count(*array_type);
-                    levels.push(IndexLevel {
-                        index: *index,
-                        elem_slot_count,
-                        array_type: *array_type,
-                    });
-                    Some((base_kind, levels))
-                } else {
-                    None
-                }
-            }
-            _ => None,
-        }
     }
 
     // ========================================================================

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -29,11 +29,13 @@ use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
 use rue_air::{StructId, TypeInternPool, TypeKind};
-use rue_builtins::BinOp;
-use rue_cfg::{BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Terminator, Type};
+use rue_builtins::{BinOp, get_builtin_type};
+use rue_cfg::{
+    BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator, Type,
+};
 
 use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
-use crate::cfg_lower::{CfgLowerContext, FieldChainBase, IndexChainBase, IndexLevel};
+use crate::cfg_lower::{CfgLowerContext, IndexLevel};
 use crate::types;
 use crate::vreg::BLOCK_LABEL_BASE;
 
@@ -545,8 +547,9 @@ impl<'a> CfgLower<'a> {
                     Some("64-bit immediate required".to_string())
                 }
             }
-            CfgInstData::IndexGet { .. } | CfgInstData::IndexSet { .. } => {
-                Some("Includes bounds check".to_string())
+            CfgInstData::IndexSet { .. } => Some("Includes bounds check".to_string()),
+            CfgInstData::PlaceRead { .. } | CfgInstData::PlaceWrite { .. } => {
+                Some("Place operation with bounds checks".to_string())
             }
             _ => None,
         }
@@ -2385,147 +2388,14 @@ impl<'a> CfgLower<'a> {
                             disp: offset,
                         });
                         self.value_map.insert(value, result_vreg);
-                    } else if let CfgInstData::IndexGet {
-                        base,
-                        array_type,
-                        index,
-                    } = &lvalue_inst.data.clone()
-                    {
-                        // Address of an array element: arr[i]
-                        // We need to compute the address, NOT load the value
-                        let array_type = *array_type;
-                        let index = *index;
-                        let base = *base;
-
-                        let elem_slot_count = self.ctx.array_element_slot_count(array_type);
-
-                        // Use trace_index_chain to handle arbitrary nesting depth
-                        if let Some((chain_base, mut levels)) = self.ctx.trace_index_chain(base) {
-                            // Add this level's index to the chain
-                            levels.push(IndexLevel {
-                                index,
-                                elem_slot_count,
-                                array_type,
-                            });
-
-                            // Calculate total offset by summing index * stride for each level
-                            let mut total_offset_vreg: Option<VReg> = None;
-
-                            for level in &levels {
-                                let level_index_vreg = self.get_vreg(level.index);
-                                let level_stride = level.elem_slot_count;
-
-                                // Scale this level's index by its stride
-                                let scaled = self.mir.alloc_vreg();
-                                self.mir.push(X86Inst::MovRR {
-                                    dst: Operand::Virtual(scaled),
-                                    src: Operand::Virtual(level_index_vreg),
-                                });
-
-                                if level_stride == 1 {
-                                    // Simple case: just shift by 3 (multiply by 8)
-                                    let shift_count = self.mir.alloc_vreg();
-                                    self.mir.push(X86Inst::MovRI32 {
-                                        dst: Operand::Virtual(shift_count),
-                                        imm: 3,
-                                    });
-                                    self.mir.push(X86Inst::Shl {
-                                        dst: Operand::Virtual(scaled),
-                                        count: Operand::Virtual(shift_count),
-                                    });
-                                } else {
-                                    // Multiply by stride * 8
-                                    let stride_vreg = self.mir.alloc_vreg();
-                                    self.mir.push(X86Inst::MovRI64 {
-                                        dst: Operand::Virtual(stride_vreg),
-                                        imm: (level_stride * 8) as i64,
-                                    });
-                                    self.mir.push(X86Inst::ImulRR64 {
-                                        dst: Operand::Virtual(scaled),
-                                        src: Operand::Virtual(stride_vreg),
-                                    });
-                                }
-
-                                // Add to running total
-                                if let Some(prev_total) = total_offset_vreg {
-                                    self.mir.push(X86Inst::AddRR64 {
-                                        dst: Operand::Virtual(prev_total),
-                                        src: Operand::Virtual(scaled),
-                                    });
-                                    // prev_total is modified in place, so keep using it
-                                } else {
-                                    total_offset_vreg = Some(scaled);
-                                }
-                            }
-
-                            // Compute base address - different for inout params vs locals/normal params
-                            let addr_vreg = self.mir.alloc_vreg();
-
-                            if let IndexChainBase::Param { index: param_index } = &chain_base {
-                                // Check if this is an inout parameter
-                                if self.ctx.cfg.is_param_inout(*param_index) {
-                                    // For inout params, use the stored pointer
-                                    let ptr_vreg = self.ensure_inout_param_ptr(*param_index);
-                                    self.mir.push(X86Inst::MovRR {
-                                        dst: Operand::Virtual(addr_vreg),
-                                        src: Operand::Virtual(ptr_vreg),
-                                    });
-
-                                    // Subtract total offset (stack grows down)
-                                    if let Some(total) = total_offset_vreg {
-                                        self.mir.push(X86Inst::SubRR64 {
-                                            dst: Operand::Virtual(addr_vreg),
-                                            src: Operand::Virtual(total),
-                                        });
-                                    }
-
-                                    self.value_map.insert(value, addr_vreg);
-                                    return;
-                                }
-                            }
-
-                            // Normal case: compute from RBP offset
-                            let base_offset = match &chain_base {
-                                IndexChainBase::Load { slot } => self.ctx.local_offset(*slot),
-                                IndexChainBase::Param { index: param_index } => {
-                                    let base_slot = self.ctx.num_locals + *param_index as u32;
-                                    self.ctx.local_offset(base_slot)
-                                }
-                                IndexChainBase::FieldGet {
-                                    struct_base_slot,
-                                    field_slot_offset,
-                                } => {
-                                    let array_base_slot = struct_base_slot + field_slot_offset;
-                                    self.ctx.local_offset(array_base_slot)
-                                }
-                            };
-
-                            // Compute the element address: base_addr - offset
-                            // (stack grows down, so we subtract)
-                            self.mir.push(X86Inst::Lea {
-                                dst: Operand::Virtual(addr_vreg),
-                                base: Reg::Rbp,
-                                index: None,
-                                scale: 1,
-                                disp: base_offset,
-                            });
-
-                            // Subtract total offset for the element position
-                            if let Some(total) = total_offset_vreg {
-                                self.mir.push(X86Inst::SubRR64 {
-                                    dst: Operand::Virtual(addr_vreg),
-                                    src: Operand::Virtual(total),
-                                });
-                            }
-
-                            self.value_map.insert(value, addr_vreg);
-                        } else {
-                            // Fallback for unsupported patterns
-                            let vreg = self.get_vreg(lvalue_val);
-                            self.value_map.insert(value, vreg);
-                        }
+                    } else if let CfgInstData::PlaceRead { place } = &lvalue_inst.data {
+                        // ADR-0030: Handle PlaceRead for @addr_of
+                        // Compute the address of the place instead of reading from it
+                        let result_vreg = self.mir.alloc_vreg();
+                        self.lower_place_addr(result_vreg, place);
+                        self.value_map.insert(value, result_vreg);
                     } else {
-                        // For other lvalue types (Param, FieldGet), fall back to vreg
+                        // For other lvalue types (Param, etc.), fall back to vreg
                         // This is a limitation that can be addressed later.
                         let vreg = self.get_vreg(lvalue_val);
                         self.value_map.insert(value, vreg);
@@ -2577,223 +2447,6 @@ impl<'a> CfgLower<'a> {
                 self.struct_slot_vregs.insert(value, slot_vregs);
             }
 
-            CfgInstData::FieldGet {
-                base,
-                struct_id,
-                field_index,
-            } => {
-                let vreg = self.mir.alloc_vreg();
-                self.value_map.insert(value, vreg);
-
-                // Try to trace back through any chain of FieldGets to find
-                // the original Load or Param. This handles nested struct field access.
-                let this_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
-                if let Some((base_kind, accumulated_offset)) = self.ctx.trace_field_chain(*base) {
-                    let total_offset = accumulated_offset + this_offset;
-                    match base_kind {
-                        FieldChainBase::Load { slot } => {
-                            // Chain originates from a Load - compute offset from local slot
-                            let actual_slot = slot + total_offset;
-                            let offset = self.ctx.local_offset(actual_slot);
-                            self.mir.push(X86Inst::MovRM {
-                                dst: Operand::Virtual(vreg),
-                                base: Reg::Rbp,
-                                offset,
-                            });
-                        }
-                        FieldChainBase::Param { index } => {
-                            // Check if this is an inout parameter
-                            if self.ctx.cfg.is_param_inout(index) {
-                                // For inout params, use the pointer we stored earlier
-                                // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
-                                let ptr_vreg = self.ensure_inout_param_ptr(index);
-                                // Load from pointer - field offset (negative because stack grows down)
-                                self.mir.push(X86Inst::MovRMIndexed {
-                                    dst: Operand::Virtual(vreg),
-                                    base: ptr_vreg,
-                                    offset: -((total_offset as i32) * 8),
-                                });
-                            } else {
-                                // Non-inout param: struct is copied to our stack
-                                let param_slot = self.ctx.num_locals + index + total_offset;
-                                let offset = self.ctx.local_offset(param_slot);
-                                self.mir.push(X86Inst::MovRM {
-                                    dst: Operand::Virtual(vreg),
-                                    base: Reg::Rbp,
-                                    offset,
-                                });
-                            }
-                        }
-                        FieldChainBase::IndexGet {
-                            index_base,
-                            index_levels,
-                        } => {
-                            // Array of structs case: arr[i].field
-                            // Calculate the array element offset, then add the field offset
-
-                            // Emit bounds check for the innermost index
-                            if let Some(innermost) = index_levels.last() {
-                                let innermost_index_vreg = self.get_vreg(innermost.index);
-                                let array_length = self.ctx.array_length(innermost.array_type);
-                                self.emit_bounds_check(innermost_index_vreg, array_length);
-                            }
-
-                            // Calculate total array offset by summing index * stride for each level
-                            let mut total_array_offset_vreg: Option<VReg> = None;
-
-                            for level in &index_levels {
-                                let level_index_vreg = self.get_vreg(level.index);
-                                let level_stride = level.elem_slot_count;
-
-                                // Scale this level's index by its stride
-                                let scaled = self.mir.alloc_vreg();
-                                self.mir.push(X86Inst::MovRR {
-                                    dst: Operand::Virtual(scaled),
-                                    src: Operand::Virtual(level_index_vreg),
-                                });
-
-                                if level_stride == 1 {
-                                    // Simple case: just shift by 3 (multiply by 8)
-                                    let shift_count = self.mir.alloc_vreg();
-                                    self.mir.push(X86Inst::MovRI32 {
-                                        dst: Operand::Virtual(shift_count),
-                                        imm: 3,
-                                    });
-                                    self.mir.push(X86Inst::Shl {
-                                        dst: Operand::Virtual(scaled),
-                                        count: Operand::Virtual(shift_count),
-                                    });
-                                } else {
-                                    // Multiply by stride * 8
-                                    let stride_vreg = self.mir.alloc_vreg();
-                                    self.mir.push(X86Inst::MovRI64 {
-                                        dst: Operand::Virtual(stride_vreg),
-                                        imm: (level_stride * 8) as i64,
-                                    });
-                                    self.mir.push(X86Inst::ImulRR64 {
-                                        dst: Operand::Virtual(scaled),
-                                        src: Operand::Virtual(stride_vreg),
-                                    });
-                                }
-
-                                // Add to running total
-                                if let Some(prev_total) = total_array_offset_vreg {
-                                    self.mir.push(X86Inst::AddRR64 {
-                                        dst: Operand::Virtual(prev_total),
-                                        src: Operand::Virtual(scaled),
-                                    });
-                                } else {
-                                    total_array_offset_vreg = Some(scaled);
-                                }
-                            }
-
-                            // Add the field offset (in bytes) to the array element offset
-                            // total_offset is the field offset within the struct element
-                            if total_offset > 0 {
-                                let field_offset_bytes = (total_offset * 8) as i64;
-                                if let Some(arr_offset) = total_array_offset_vreg {
-                                    let field_offset_vreg = self.mir.alloc_vreg();
-                                    self.mir.push(X86Inst::MovRI64 {
-                                        dst: Operand::Virtual(field_offset_vreg),
-                                        imm: field_offset_bytes,
-                                    });
-                                    self.mir.push(X86Inst::AddRR64 {
-                                        dst: Operand::Virtual(arr_offset),
-                                        src: Operand::Virtual(field_offset_vreg),
-                                    });
-                                }
-                            }
-
-                            // Compute base address
-                            let addr_vreg = self.mir.alloc_vreg();
-
-                            if let IndexChainBase::Param { index: param_index } = &index_base {
-                                if self.ctx.cfg.is_param_inout(*param_index) {
-                                    // For inout params, use the stored pointer
-                                    let ptr_vreg = self.ensure_inout_param_ptr(*param_index);
-                                    self.mir.push(X86Inst::MovRR {
-                                        dst: Operand::Virtual(addr_vreg),
-                                        src: Operand::Virtual(ptr_vreg),
-                                    });
-
-                                    // Subtract total offset (array offset + field offset)
-                                    if let Some(total) = total_array_offset_vreg {
-                                        self.mir.push(X86Inst::SubRR64 {
-                                            dst: Operand::Virtual(addr_vreg),
-                                            src: Operand::Virtual(total),
-                                        });
-                                    }
-
-                                    // Load from computed address
-                                    self.mir.push(X86Inst::MovRMIndexed {
-                                        dst: Operand::Virtual(vreg),
-                                        base: addr_vreg,
-                                        offset: 0,
-                                    });
-                                    return;
-                                }
-                            }
-
-                            // Normal case: compute from RBP offset
-                            let base_offset = match &index_base {
-                                IndexChainBase::Load { slot } => self.ctx.local_offset(*slot),
-                                IndexChainBase::Param { index: param_index } => {
-                                    let base_slot = self.ctx.num_locals + *param_index as u32;
-                                    self.ctx.local_offset(base_slot)
-                                }
-                                IndexChainBase::FieldGet {
-                                    struct_base_slot,
-                                    field_slot_offset,
-                                } => {
-                                    let array_base_slot = struct_base_slot + field_slot_offset;
-                                    self.ctx.local_offset(array_base_slot)
-                                }
-                            };
-
-                            self.mir.push(X86Inst::Lea {
-                                dst: Operand::Virtual(addr_vreg),
-                                base: Reg::Rbp,
-                                index: None,
-                                scale: 1,
-                                disp: base_offset,
-                            });
-
-                            // Subtract total offset (array offset + field offset)
-                            if let Some(total) = total_array_offset_vreg {
-                                self.mir.push(X86Inst::SubRR64 {
-                                    dst: Operand::Virtual(addr_vreg),
-                                    src: Operand::Virtual(total),
-                                });
-                            }
-
-                            // Load from computed address
-                            self.mir.push(X86Inst::MovRMIndexed {
-                                dst: Operand::Virtual(vreg),
-                                base: addr_vreg,
-                                offset: 0,
-                            });
-                        }
-                    }
-                } else {
-                    // For other sources (BlockParam, StructInit, Call), use slot vregs.
-                    // IMPORTANT: struct_slot_vregs contains slot vregs (accounting for
-                    // nested struct sizes), so we need to use the slot offset, not field index.
-                    let slot_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
-                    let slot_vregs = self
-                        .struct_slot_vregs
-                        .get(base)
-                        .cloned()
-                        .expect("struct base should have slot vregs in cache");
-                    let slot_vreg = *slot_vregs
-                        .get(slot_offset as usize)
-                        .expect("slot_offset should be within slot_vregs bounds");
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Virtual(vreg),
-                        src: Operand::Virtual(slot_vreg),
-                    });
-                }
-            }
-
             CfgInstData::FieldSet {
                 slot,
                 struct_id,
@@ -2825,7 +2478,6 @@ impl<'a> CfgLower<'a> {
                 // Check if this is an inout parameter
                 if self.ctx.cfg.is_param_inout(*param_slot) {
                     // For inout params, store through the pointer
-                    // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
                     let ptr_vreg = self.ensure_inout_param_ptr(*param_slot);
                     // Negative offset because stack grows down
                     self.mir.push(X86Inst::MovMRIndexed {
@@ -2851,11 +2503,10 @@ impl<'a> CfgLower<'a> {
             } => {
                 // Array is stored in local slots; we just create vregs for elements.
                 // The actual storage is handled by the Alloc that precedes this.
-                // For now, just create a dummy vreg - arrays are passed by loading from slots.
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
 
-                // Store element vregs for later IndexGet access
+                // Store element vregs for later PlaceRead access
                 let elements = self.ctx.cfg.get_extra(*elements_start, *elements_len);
                 let element_vregs: Vec<VReg> = elements.iter().map(|e| self.get_vreg(*e)).collect();
                 self.struct_slot_vregs.insert(value, element_vregs);
@@ -2865,226 +2516,6 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(vreg),
                     imm: 0,
                 });
-            }
-
-            CfgInstData::IndexGet {
-                base,
-                array_type,
-                index,
-            } => {
-                let vreg = self.mir.alloc_vreg();
-                self.value_map.insert(value, vreg);
-
-                // Calculate the slot stride for this array's elements
-                let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
-
-                // First, check if base is an ArrayInit (constant index case)
-                let base_data = &self.ctx.cfg.get_inst(*base).data.clone();
-                if let CfgInstData::ArrayInit { .. } = base_data {
-                    // For ArrayInit sources, use element vregs if index is constant
-                    let index_inst = &self.ctx.cfg.get_inst(*index).data;
-                    if let CfgInstData::Const(idx) = index_inst {
-                        if let Some(element_vregs) = self.struct_slot_vregs.get(base).cloned() {
-                            if let Some(&elem_vreg) = element_vregs.get(*idx as usize) {
-                                self.mir.push(X86Inst::MovRR {
-                                    dst: Operand::Virtual(vreg),
-                                    src: Operand::Virtual(elem_vreg),
-                                });
-                                return;
-                            }
-                        }
-                    }
-                    // Fallback for non-constant index into ArrayInit
-                    self.mir.push(X86Inst::MovRI32 {
-                        dst: Operand::Virtual(vreg),
-                        imm: 0,
-                    });
-                    return;
-                }
-
-                // Use trace_index_chain to handle arbitrary nesting depth
-                if let Some((chain_base, mut levels)) = self.ctx.trace_index_chain(*base) {
-                    // Add this level's index to the chain
-                    levels.push(IndexLevel {
-                        index: *index,
-                        elem_slot_count,
-                        array_type: *array_type,
-                    });
-
-                    // Emit bounds check for the innermost index
-                    let innermost_index_vreg = self.get_vreg(*index);
-                    let array_length = self.ctx.array_length(*array_type);
-                    self.emit_bounds_check(innermost_index_vreg, array_length);
-
-                    // Calculate total offset by summing index * stride for each level
-                    let mut total_offset_vreg: Option<VReg> = None;
-
-                    for level in &levels {
-                        let level_index_vreg = self.get_vreg(level.index);
-                        let level_stride = level.elem_slot_count;
-
-                        // Scale this level's index by its stride
-                        let scaled = self.mir.alloc_vreg();
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Virtual(scaled),
-                            src: Operand::Virtual(level_index_vreg),
-                        });
-
-                        if level_stride == 1 {
-                            // Simple case: just shift by 3 (multiply by 8)
-                            let shift_count = self.mir.alloc_vreg();
-                            self.mir.push(X86Inst::MovRI32 {
-                                dst: Operand::Virtual(shift_count),
-                                imm: 3,
-                            });
-                            self.mir.push(X86Inst::Shl {
-                                dst: Operand::Virtual(scaled),
-                                count: Operand::Virtual(shift_count),
-                            });
-                        } else {
-                            // Multiply by stride * 8
-                            let stride_vreg = self.mir.alloc_vreg();
-                            self.mir.push(X86Inst::MovRI64 {
-                                dst: Operand::Virtual(stride_vreg),
-                                imm: (level_stride * 8) as i64,
-                            });
-                            self.mir.push(X86Inst::ImulRR64 {
-                                dst: Operand::Virtual(scaled),
-                                src: Operand::Virtual(stride_vreg),
-                            });
-                        }
-
-                        // Add to running total
-                        if let Some(prev_total) = total_offset_vreg {
-                            self.mir.push(X86Inst::AddRR64 {
-                                dst: Operand::Virtual(prev_total),
-                                src: Operand::Virtual(scaled),
-                            });
-                            // prev_total is modified in place, so keep using it
-                        } else {
-                            total_offset_vreg = Some(scaled);
-                        }
-                    }
-
-                    // Compute base address - different for inout params vs locals/normal params
-                    let addr_vreg = self.mir.alloc_vreg();
-
-                    if let IndexChainBase::Param { index: param_index } = &chain_base {
-                        // Check if this is an inout parameter
-                        if self.ctx.cfg.is_param_inout(*param_index) {
-                            // For inout params, use the stored pointer
-                            // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
-                            let ptr_vreg = self.ensure_inout_param_ptr(*param_index);
-                            self.mir.push(X86Inst::MovRR {
-                                dst: Operand::Virtual(addr_vreg),
-                                src: Operand::Virtual(ptr_vreg),
-                            });
-
-                            // Subtract total offset
-                            if let Some(total) = total_offset_vreg {
-                                self.mir.push(X86Inst::SubRR64 {
-                                    dst: Operand::Virtual(addr_vreg),
-                                    src: Operand::Virtual(total),
-                                });
-                            }
-
-                            // Load from computed address
-                            self.mir.push(X86Inst::MovRMIndexed {
-                                dst: Operand::Virtual(vreg),
-                                base: addr_vreg,
-                                offset: 0,
-                            });
-                            return;
-                        }
-                    }
-
-                    // Normal case: compute from RBP offset
-                    let base_offset = match &chain_base {
-                        IndexChainBase::Load { slot } => self.ctx.local_offset(*slot),
-                        IndexChainBase::Param { index: param_index } => {
-                            let base_slot = self.ctx.num_locals + *param_index as u32;
-                            self.ctx.local_offset(base_slot)
-                        }
-                        IndexChainBase::FieldGet {
-                            struct_base_slot,
-                            field_slot_offset,
-                        } => {
-                            let array_base_slot = struct_base_slot + field_slot_offset;
-                            self.ctx.local_offset(array_base_slot)
-                        }
-                    };
-
-                    // Optimization: for single-level array access with element size 8,
-                    // use SIB addressing mode instead of explicit address calculation.
-                    // This reduces instruction count from ~5 to ~3.
-                    //
-                    // Stack arrays grow downward, so arr[i] is at base - i*8.
-                    // We use SIB with a negated index: [base + (-i)*8]
-                    if levels.len() == 1 && levels[0].elem_slot_count == 1 {
-                        // Single-level array with 8-byte elements - use SIB
-                        let index_vreg = self.get_vreg(levels[0].index);
-
-                        // Negate the index for downward-growing stack
-                        let neg_index = self.mir.alloc_vreg();
-                        self.mir.push(X86Inst::MovRI64 {
-                            dst: Operand::Virtual(neg_index),
-                            imm: 0,
-                        });
-                        self.mir.push(X86Inst::SubRR64 {
-                            dst: Operand::Virtual(neg_index),
-                            src: Operand::Virtual(index_vreg),
-                        });
-
-                        // Load base address into a register
-                        let base_vreg = self.mir.alloc_vreg();
-                        self.mir.push(X86Inst::Lea {
-                            dst: Operand::Virtual(base_vreg),
-                            base: Reg::Rbp,
-                            index: None,
-                            scale: 1,
-                            disp: base_offset,
-                        });
-
-                        // Use SIB addressing: mov dst, [base + neg_index*8]
-                        self.mir.push(X86Inst::MovRMSib {
-                            dst: Operand::Virtual(vreg),
-                            base: Operand::Virtual(base_vreg),
-                            index: Operand::Virtual(neg_index),
-                            scale: 8,
-                            disp: 0,
-                        });
-                    } else {
-                        // Multi-level or non-8-byte elements - use original code path
-                        self.mir.push(X86Inst::Lea {
-                            dst: Operand::Virtual(addr_vreg),
-                            base: Reg::Rbp,
-                            index: None,
-                            scale: 1,
-                            disp: base_offset,
-                        });
-
-                        // Subtract total offset
-                        if let Some(total) = total_offset_vreg {
-                            self.mir.push(X86Inst::SubRR64 {
-                                dst: Operand::Virtual(addr_vreg),
-                                src: Operand::Virtual(total),
-                            });
-                        }
-
-                        // Load from computed address
-                        self.mir.push(X86Inst::MovRMIndexed {
-                            dst: Operand::Virtual(vreg),
-                            base: addr_vreg,
-                            offset: 0,
-                        });
-                    }
-                } else {
-                    // Fallback for unsupported patterns
-                    self.mir.push(X86Inst::MovRI32 {
-                        dst: Operand::Virtual(vreg),
-                        imm: 0,
-                    });
-                }
             }
 
             CfgInstData::IndexSet {
@@ -3448,6 +2879,19 @@ impl<'a> CfgLower<'a> {
                 // StorageDead marks a slot as no longer in use.
                 // Currently a no-op in codegen. In the future, this could be used
                 // for stack slot optimization (LLVM lifetime intrinsics).
+            }
+
+            // Place operations (ADR-0030)
+            // These provide a unified abstraction for memory access with projections.
+            CfgInstData::PlaceRead { place } => {
+                let vreg = self.mir.alloc_vreg();
+                self.value_map.insert(value, vreg);
+                self.lower_place_read(vreg, place, ty);
+            }
+
+            CfgInstData::PlaceWrite { place, value: val } => {
+                let val_vreg = self.get_vreg(*val);
+                self.lower_place_write(place, val_vreg);
             }
         }
     }
@@ -4222,6 +3666,572 @@ impl<'a> CfgLower<'a> {
 
             Terminator::None => {
                 panic!("block has no terminator");
+            }
+        }
+    }
+
+    // ========================================================================
+    // Place operations (ADR-0030)
+    // ========================================================================
+
+    /// Lower a PlaceRead instruction.
+    ///
+    /// A place consists of a base (local slot or param slot) and zero or more
+    /// projections (field accesses and array indices). This function computes
+    /// the final memory address and loads from it.
+    fn lower_place_read(&mut self, dst: VReg, place: &Place, _ty: Type) {
+        let projections = self.ctx.cfg.get_place_projections(place);
+
+        // Simple case: no projections, just load from the base slot
+        if projections.is_empty() {
+            match place.base {
+                PlaceBase::Local(slot) => {
+                    let offset = self.ctx.local_offset(slot);
+                    self.mir.push(X86Inst::MovRM {
+                        dst: Operand::Virtual(dst),
+                        base: Reg::Rbp,
+                        offset,
+                    });
+                }
+                PlaceBase::Param(param_slot) => {
+                    // Check if this is an inout parameter
+                    if self.ctx.cfg.is_param_inout(param_slot) {
+                        // Inout param - load through the pointer
+                        let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
+                        self.mir.push(X86Inst::MovRMIndexed {
+                            dst: Operand::Virtual(dst),
+                            base: ptr_vreg,
+                            offset: 0,
+                        });
+                    } else {
+                        // Normal param - load from local slot
+                        let slot = self.ctx.num_locals + param_slot;
+                        let offset = self.ctx.local_offset(slot);
+                        self.mir.push(X86Inst::MovRM {
+                            dst: Operand::Virtual(dst),
+                            base: Reg::Rbp,
+                            offset,
+                        });
+                    }
+                }
+            }
+            return;
+        }
+
+        // Complex case: has projections - compute the address
+        self.lower_place_read_with_projections(dst, place, projections);
+    }
+
+    /// Lower a PlaceRead with projections (field accesses and/or array indices).
+    fn lower_place_read_with_projections(
+        &mut self,
+        dst: VReg,
+        place: &Place,
+        projections: &[Projection],
+    ) {
+        // Calculate the static field offset (sum of all Field projection offsets)
+        let mut static_slot_offset: u32 = 0;
+
+        // Collect index projections for dynamic offset calculation
+        let mut index_levels: Vec<IndexLevel> = Vec::new();
+
+        for proj in projections {
+            match proj {
+                Projection::Field {
+                    struct_id,
+                    field_index,
+                } => {
+                    let field_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
+                    static_slot_offset += field_offset;
+                }
+                Projection::Index { array_type, index } => {
+                    // Emit bounds check for this index
+                    let index_vreg = self.get_vreg(*index);
+                    let array_length = self.ctx.array_length(*array_type);
+                    self.emit_bounds_check(index_vreg, array_length);
+
+                    let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
+                    index_levels.push(IndexLevel {
+                        index: *index,
+                        elem_slot_count,
+                        array_type: *array_type,
+                    });
+                }
+            }
+        }
+
+        // Calculate dynamic offset from index projections
+        let dynamic_offset_vreg = if !index_levels.is_empty() {
+            Some(self.compute_index_offset(&index_levels))
+        } else {
+            None
+        };
+
+        // Compute final address based on base type
+        match place.base {
+            PlaceBase::Local(slot) => {
+                let base_slot = slot + static_slot_offset;
+                let base_offset = self.ctx.local_offset(base_slot);
+
+                if let Some(dyn_offset) = dynamic_offset_vreg {
+                    // Compute address: rbp + base_offset - dynamic_offset
+                    let addr_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::Lea {
+                        dst: Operand::Virtual(addr_vreg),
+                        base: Reg::Rbp,
+                        index: None,
+                        scale: 1,
+                        disp: base_offset,
+                    });
+                    self.mir.push(X86Inst::SubRR64 {
+                        dst: Operand::Virtual(addr_vreg),
+                        src: Operand::Virtual(dyn_offset),
+                    });
+                    self.mir.push(X86Inst::MovRMIndexed {
+                        dst: Operand::Virtual(dst),
+                        base: addr_vreg,
+                        offset: 0,
+                    });
+                } else {
+                    // Static offset only
+                    self.mir.push(X86Inst::MovRM {
+                        dst: Operand::Virtual(dst),
+                        base: Reg::Rbp,
+                        offset: base_offset,
+                    });
+                }
+            }
+            PlaceBase::Param(param_slot) => {
+                if self.ctx.cfg.is_param_inout(param_slot) {
+                    // Inout param - use pointer
+                    let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
+                    let static_byte_offset = (static_slot_offset as i32) * 8;
+
+                    if let Some(dyn_offset) = dynamic_offset_vreg {
+                        // Compute address: ptr - static_offset - dynamic_offset
+                        let addr_vreg = self.mir.alloc_vreg();
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Virtual(addr_vreg),
+                            src: Operand::Virtual(ptr_vreg),
+                        });
+                        if static_byte_offset != 0 {
+                            let offset_vreg = self.mir.alloc_vreg();
+                            self.mir.push(X86Inst::MovRI64 {
+                                dst: Operand::Virtual(offset_vreg),
+                                imm: static_byte_offset as i64,
+                            });
+                            self.mir.push(X86Inst::SubRR64 {
+                                dst: Operand::Virtual(addr_vreg),
+                                src: Operand::Virtual(offset_vreg),
+                            });
+                        }
+                        self.mir.push(X86Inst::SubRR64 {
+                            dst: Operand::Virtual(addr_vreg),
+                            src: Operand::Virtual(dyn_offset),
+                        });
+                        self.mir.push(X86Inst::MovRMIndexed {
+                            dst: Operand::Virtual(dst),
+                            base: addr_vreg,
+                            offset: 0,
+                        });
+                    } else {
+                        // Static offset only
+                        self.mir.push(X86Inst::MovRMIndexed {
+                            dst: Operand::Virtual(dst),
+                            base: ptr_vreg,
+                            offset: -static_byte_offset,
+                        });
+                    }
+                } else {
+                    // Normal param - treat like local
+                    let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
+                    let base_offset = self.ctx.local_offset(base_slot);
+
+                    if let Some(dyn_offset) = dynamic_offset_vreg {
+                        let addr_vreg = self.mir.alloc_vreg();
+                        self.mir.push(X86Inst::Lea {
+                            dst: Operand::Virtual(addr_vreg),
+                            base: Reg::Rbp,
+                            index: None,
+                            scale: 1,
+                            disp: base_offset,
+                        });
+                        self.mir.push(X86Inst::SubRR64 {
+                            dst: Operand::Virtual(addr_vreg),
+                            src: Operand::Virtual(dyn_offset),
+                        });
+                        self.mir.push(X86Inst::MovRMIndexed {
+                            dst: Operand::Virtual(dst),
+                            base: addr_vreg,
+                            offset: 0,
+                        });
+                    } else {
+                        self.mir.push(X86Inst::MovRM {
+                            dst: Operand::Virtual(dst),
+                            base: Reg::Rbp,
+                            offset: base_offset,
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    /// Lower a PlaceWrite instruction.
+    ///
+    /// This stores a value to the memory location described by the place.
+    fn lower_place_write(&mut self, place: &Place, val_vreg: VReg) {
+        let projections = self.ctx.cfg.get_place_projections(place);
+
+        // Simple case: no projections, just store to the base slot
+        if projections.is_empty() {
+            match place.base {
+                PlaceBase::Local(slot) => {
+                    let offset = self.ctx.local_offset(slot);
+                    self.mir.push(X86Inst::MovMR {
+                        base: Reg::Rbp,
+                        offset,
+                        src: Operand::Virtual(val_vreg),
+                    });
+                }
+                PlaceBase::Param(param_slot) => {
+                    if self.ctx.cfg.is_param_inout(param_slot) {
+                        // Inout param - store through the pointer
+                        let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
+                        self.mir.push(X86Inst::MovMRIndexed {
+                            base: ptr_vreg,
+                            offset: 0,
+                            src: Operand::Virtual(val_vreg),
+                        });
+                    } else {
+                        // Normal param - store to local slot
+                        let slot = self.ctx.num_locals + param_slot;
+                        let offset = self.ctx.local_offset(slot);
+                        self.mir.push(X86Inst::MovMR {
+                            base: Reg::Rbp,
+                            offset,
+                            src: Operand::Virtual(val_vreg),
+                        });
+                    }
+                }
+            }
+            return;
+        }
+
+        // Complex case: has projections - compute the address
+        self.lower_place_write_with_projections(place, projections, val_vreg);
+    }
+
+    /// Lower a PlaceWrite with projections.
+    fn lower_place_write_with_projections(
+        &mut self,
+        place: &Place,
+        projections: &[Projection],
+        val_vreg: VReg,
+    ) {
+        // Calculate the static field offset
+        let mut static_slot_offset: u32 = 0;
+
+        // Collect index projections for dynamic offset calculation
+        let mut index_levels: Vec<IndexLevel> = Vec::new();
+
+        for proj in projections {
+            match proj {
+                Projection::Field {
+                    struct_id,
+                    field_index,
+                } => {
+                    let field_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
+                    static_slot_offset += field_offset;
+                }
+                Projection::Index { array_type, index } => {
+                    // Emit bounds check for this index
+                    let index_vreg = self.get_vreg(*index);
+                    let array_length = self.ctx.array_length(*array_type);
+                    self.emit_bounds_check(index_vreg, array_length);
+
+                    let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
+                    index_levels.push(IndexLevel {
+                        index: *index,
+                        elem_slot_count,
+                        array_type: *array_type,
+                    });
+                }
+            }
+        }
+
+        // Calculate dynamic offset from index projections
+        let dynamic_offset_vreg = if !index_levels.is_empty() {
+            Some(self.compute_index_offset(&index_levels))
+        } else {
+            None
+        };
+
+        // Compute final address based on base type
+        match place.base {
+            PlaceBase::Local(slot) => {
+                let base_slot = slot + static_slot_offset;
+                let base_offset = self.ctx.local_offset(base_slot);
+
+                if let Some(dyn_offset) = dynamic_offset_vreg {
+                    let addr_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::Lea {
+                        dst: Operand::Virtual(addr_vreg),
+                        base: Reg::Rbp,
+                        index: None,
+                        scale: 1,
+                        disp: base_offset,
+                    });
+                    self.mir.push(X86Inst::SubRR64 {
+                        dst: Operand::Virtual(addr_vreg),
+                        src: Operand::Virtual(dyn_offset),
+                    });
+                    self.mir.push(X86Inst::MovMRIndexed {
+                        base: addr_vreg,
+                        offset: 0,
+                        src: Operand::Virtual(val_vreg),
+                    });
+                } else {
+                    self.mir.push(X86Inst::MovMR {
+                        base: Reg::Rbp,
+                        offset: base_offset,
+                        src: Operand::Virtual(val_vreg),
+                    });
+                }
+            }
+            PlaceBase::Param(param_slot) => {
+                if self.ctx.cfg.is_param_inout(param_slot) {
+                    let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
+                    let static_byte_offset = (static_slot_offset as i32) * 8;
+
+                    if let Some(dyn_offset) = dynamic_offset_vreg {
+                        let addr_vreg = self.mir.alloc_vreg();
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Virtual(addr_vreg),
+                            src: Operand::Virtual(ptr_vreg),
+                        });
+                        if static_byte_offset != 0 {
+                            let offset_vreg = self.mir.alloc_vreg();
+                            self.mir.push(X86Inst::MovRI64 {
+                                dst: Operand::Virtual(offset_vreg),
+                                imm: static_byte_offset as i64,
+                            });
+                            self.mir.push(X86Inst::SubRR64 {
+                                dst: Operand::Virtual(addr_vreg),
+                                src: Operand::Virtual(offset_vreg),
+                            });
+                        }
+                        self.mir.push(X86Inst::SubRR64 {
+                            dst: Operand::Virtual(addr_vreg),
+                            src: Operand::Virtual(dyn_offset),
+                        });
+                        self.mir.push(X86Inst::MovMRIndexed {
+                            base: addr_vreg,
+                            offset: 0,
+                            src: Operand::Virtual(val_vreg),
+                        });
+                    } else {
+                        self.mir.push(X86Inst::MovMRIndexed {
+                            base: ptr_vreg,
+                            offset: -static_byte_offset,
+                            src: Operand::Virtual(val_vreg),
+                        });
+                    }
+                } else {
+                    let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
+                    let base_offset = self.ctx.local_offset(base_slot);
+
+                    if let Some(dyn_offset) = dynamic_offset_vreg {
+                        let addr_vreg = self.mir.alloc_vreg();
+                        self.mir.push(X86Inst::Lea {
+                            dst: Operand::Virtual(addr_vreg),
+                            base: Reg::Rbp,
+                            index: None,
+                            scale: 1,
+                            disp: base_offset,
+                        });
+                        self.mir.push(X86Inst::SubRR64 {
+                            dst: Operand::Virtual(addr_vreg),
+                            src: Operand::Virtual(dyn_offset),
+                        });
+                        self.mir.push(X86Inst::MovMRIndexed {
+                            base: addr_vreg,
+                            offset: 0,
+                            src: Operand::Virtual(val_vreg),
+                        });
+                    } else {
+                        self.mir.push(X86Inst::MovMR {
+                            base: Reg::Rbp,
+                            offset: base_offset,
+                            src: Operand::Virtual(val_vreg),
+                        });
+                    }
+                }
+            }
+        }
+    }
+
+    /// Compute the byte offset for a series of index projections.
+    ///
+    /// Returns a vreg containing the total byte offset (index * stride for each level).
+    fn compute_index_offset(&mut self, levels: &[IndexLevel]) -> VReg {
+        let mut total_offset_vreg: Option<VReg> = None;
+
+        for level in levels {
+            let level_index_vreg = self.get_vreg(level.index);
+            let level_stride = level.elem_slot_count;
+
+            // Scale this level's index by its stride
+            let scaled = self.mir.alloc_vreg();
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Virtual(scaled),
+                src: Operand::Virtual(level_index_vreg),
+            });
+
+            if level_stride == 1 {
+                // Simple case: just shift by 3 (multiply by 8)
+                let shift_count = self.mir.alloc_vreg();
+                self.mir.push(X86Inst::MovRI32 {
+                    dst: Operand::Virtual(shift_count),
+                    imm: 3,
+                });
+                self.mir.push(X86Inst::Shl {
+                    dst: Operand::Virtual(scaled),
+                    count: Operand::Virtual(shift_count),
+                });
+            } else {
+                // Multiply by stride * 8
+                let stride_vreg = self.mir.alloc_vreg();
+                self.mir.push(X86Inst::MovRI64 {
+                    dst: Operand::Virtual(stride_vreg),
+                    imm: (level_stride * 8) as i64,
+                });
+                self.mir.push(X86Inst::ImulRR64 {
+                    dst: Operand::Virtual(scaled),
+                    src: Operand::Virtual(stride_vreg),
+                });
+            }
+
+            // Add to running total
+            if let Some(prev_total) = total_offset_vreg {
+                self.mir.push(X86Inst::AddRR64 {
+                    dst: Operand::Virtual(prev_total),
+                    src: Operand::Virtual(scaled),
+                });
+                // prev_total is modified in place
+            } else {
+                total_offset_vreg = Some(scaled);
+            }
+        }
+
+        total_offset_vreg.expect("compute_index_offset called with empty levels")
+    }
+
+    /// Compute the address of a place (for @addr_of intrinsic).
+    ///
+    /// This is similar to lower_place_read but returns the address instead of loading.
+    fn lower_place_addr(&mut self, dst: VReg, place: &Place) {
+        let projections = self.ctx.cfg.get_place_projections(place);
+
+        // Calculate static slot offset from field projections
+        let mut static_slot_offset: u32 = 0;
+        let mut index_levels: Vec<IndexLevel> = Vec::new();
+
+        for proj in projections {
+            match proj {
+                Projection::Field {
+                    struct_id,
+                    field_index,
+                } => {
+                    let field_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
+                    static_slot_offset += field_offset;
+                }
+                Projection::Index { array_type, index } => {
+                    let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
+                    index_levels.push(IndexLevel {
+                        index: *index,
+                        elem_slot_count,
+                        array_type: *array_type,
+                    });
+                }
+            }
+        }
+
+        // Calculate dynamic offset from index projections
+        let dynamic_offset_vreg = if !index_levels.is_empty() {
+            Some(self.compute_index_offset(&index_levels))
+        } else {
+            None
+        };
+
+        // Compute address based on base type
+        match place.base {
+            PlaceBase::Local(slot) => {
+                let base_slot = slot + static_slot_offset;
+                let base_offset = self.ctx.local_offset(base_slot);
+
+                self.mir.push(X86Inst::Lea {
+                    dst: Operand::Virtual(dst),
+                    base: Reg::Rbp,
+                    index: None,
+                    scale: 1,
+                    disp: base_offset,
+                });
+
+                if let Some(dyn_offset) = dynamic_offset_vreg {
+                    self.mir.push(X86Inst::SubRR64 {
+                        dst: Operand::Virtual(dst),
+                        src: Operand::Virtual(dyn_offset),
+                    });
+                }
+            }
+            PlaceBase::Param(param_slot) => {
+                if self.ctx.cfg.is_param_inout(param_slot) {
+                    let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
+                    let static_byte_offset = (static_slot_offset as i32) * 8;
+
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(dst),
+                        src: Operand::Virtual(ptr_vreg),
+                    });
+
+                    if static_byte_offset != 0 {
+                        let offset_vreg = self.mir.alloc_vreg();
+                        self.mir.push(X86Inst::MovRI64 {
+                            dst: Operand::Virtual(offset_vreg),
+                            imm: static_byte_offset as i64,
+                        });
+                        self.mir.push(X86Inst::SubRR64 {
+                            dst: Operand::Virtual(dst),
+                            src: Operand::Virtual(offset_vreg),
+                        });
+                    }
+
+                    if let Some(dyn_offset) = dynamic_offset_vreg {
+                        self.mir.push(X86Inst::SubRR64 {
+                            dst: Operand::Virtual(dst),
+                            src: Operand::Virtual(dyn_offset),
+                        });
+                    }
+                } else {
+                    let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
+                    let base_offset = self.ctx.local_offset(base_slot);
+
+                    self.mir.push(X86Inst::Lea {
+                        dst: Operand::Virtual(dst),
+                        base: Reg::Rbp,
+                        index: None,
+                        scale: 1,
+                        disp: base_offset,
+                    });
+
+                    if let Some(dyn_offset) = dynamic_offset_vreg {
+                        self.mir.push(X86Inst::SubRR64 {
+                            dst: Operand::Virtual(dst),
+                            src: Operand::Virtual(dyn_offset),
+                        });
+                    }
+                }
             }
         }
     }

--- a/docs/designs/0030-place-expressions.md
+++ b/docs/designs/0030-place-expressions.md
@@ -1,7 +1,7 @@
 ---
 id: 0030
 title: Place Expressions for Memory Locations
-status: proposal
+status: implemented
 tags: [ir, codegen, performance]
 created: 2026-01-04
 spec-sections: []
@@ -11,7 +11,7 @@ spec-sections: []
 
 ## Status
 
-Proposal
+Implemented
 
 ## Summary
 
@@ -233,14 +233,24 @@ pub enum AirProjection {
 
 ## Implementation Phases
 
-- [ ] **Phase 1: Add Place type to CFG** - Define `Place`, `PlaceBase`, `Projection` in `rue-cfg`
-- [ ] **Phase 2: Add PlaceRead/PlaceWrite instructions** - Add new CFG instruction variants alongside existing ones
-- [ ] **Phase 3: Update CFG builder** - Generate Place-based instructions for simple cases
-- [ ] **Phase 4: Update x86_64 codegen** - Emit efficient code for Place-based instructions
-- [ ] **Phase 5: Update aarch64 codegen** - Same for ARM64 backend
-- [ ] **Phase 6: Migrate remaining cases** - Handle all array/field operations via places
-- [ ] **Phase 7: Remove old instructions** - Delete IndexGet/FieldGet with base values
-- [ ] **Phase 8: Apply same changes to AIR** - Propagate place abstraction to AIR level
+- [x] **Phase 1: Add Place type to CFG** - Define `Place`, `PlaceBase`, `Projection` in `rue-cfg`
+- [x] **Phase 2: Add PlaceRead/PlaceWrite instructions** - Add new CFG instruction variants alongside existing ones
+- [x] **Phase 3: Update CFG builder** - Generate Place-based instructions for simple cases
+- [x] **Phase 4: Update x86_64 codegen** - Emit efficient code for Place-based instructions
+- [x] **Phase 5: Update aarch64 codegen** - Same for ARM64 backend
+- [x] **Phase 6: Migrate remaining cases** - Handle all array/field operations via places
+- [x] **Phase 7: Remove old instructions** - Delete IndexGet/FieldGet with base values
+- [x] **Phase 8: Apply same changes to AIR** - Propagate place abstraction to AIR level
+  - Added `AirPlace`, `AirPlaceBase`, `AirProjection`, `AirPlaceRef` types to `rue-air`
+  - Added `AirInstData::PlaceRead` and `AirInstData::PlaceWrite` instruction variants
+  - Added `Air::make_place`, `Air::get_place`, `Air::get_place_projections` helper methods
+  - Updated CFG builder to lower `AirInstData::PlaceRead` → `CfgInstData::PlaceRead`
+  - Updated CFG builder to lower `AirInstData::PlaceWrite` → `CfgInstData::PlaceWrite`
+  - Added `PlaceTrace` and `try_trace_place` to trace RIR expressions to places
+  - Updated `analyze_field_get` and `analyze_index_get` to emit `PlaceRead` for place expressions
+  - Updated `analyze_field_set_impl` and `analyze_index_set_impl` to emit `PlaceWrite`
+  - Old instructions (`FieldGet`, `IndexGet`, etc.) remain as fallback for computed bases
+    (e.g., `get_struct().field` where base is a function call result)
 
 ## Consequences
 


### PR DESCRIPTION
Implement Place abstraction in Rue's IR to represent memory locations (lvalues) as first-class values. This eliminates redundant Load instructions for array indexing and field access.

Key changes:
- Add Place, PlaceBase, Projection types to rue-cfg
- Add PlaceRead/PlaceWrite instructions replacing FieldGet/IndexGet
- Update x86_64 and aarch64 backends with place lowering methods
- Update AIR with AirPlace, AirPlaceRef, and place-based instructions
- Remove obsolete trace_field_chain/trace_index_chain methods

This unified instruction set (2 instructions instead of 6) provides:
- Smaller IR with fewer intermediate Load instructions
- Simpler codegen that walks projections directly
- Better optimization opportunities for aliasing analysis

Resolves merge conflict with CfgLowerContext refactoring from trunk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)