### PR TITLE
Add comptime and type keywords to spec documentation

### DIFF
--- a/docs/spec/src/02-lexical-structure/04-keywords.md
+++ b/docs/spec/src/02-lexical-structure/04-keywords.md
@@ -31,6 +31,7 @@ The following words are keywords and cannot be used as identifiers:
 | `match` | Pattern matching expression |
 | `return` | Return from function |
 | `break` | Exit loop |
+| `comptime` | Compile-time evaluation |
 | `continue` | Skip to next iteration |
 | `true` | Boolean literal |
 | `false` | Boolean literal |
@@ -57,3 +58,4 @@ The following are type names and are reserved:
 | `u32` | 32-bit unsigned integer |
 | `u64` | 64-bit unsigned integer |
 | `bool` | Boolean type |
+| `type` | Compile-time type of types |


### PR DESCRIPTION
Add the missing `comptime` keyword to the Keywords table and `type` to the Type Names table in the lexical structure spec. These were documented in the comptime chapter but missing from the keywords reference.

Part of #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)