### PR TITLE
Add @import intrinsic to spec documentation

### DIFF
--- a/crates/rue-spec/cases/modules/import.toml
+++ b/crates/rue-spec/cases/modules/import.toml
@@ -1,5 +1,6 @@
 [section]
 id = "modules.import"
+spec_chapter = "4.13"
 name = "Import Expressions"
 description = "The @import builtin for importing modules."
 
@@ -12,6 +13,7 @@ description = "The @import builtin for importing modules."
 
 [[case]]
 name = "import_basic_syntax"
+spec = ["4.13:79", "4.13:80", "4.13:82"]
 description = "@import with string argument is accepted"
 source = """
 fn main() -> i32 {
@@ -24,6 +26,7 @@ exit_code = 0
 
 [[case]]
 name = "import_used_in_const"
+spec = ["4.13:79", "4.13:80"]
 description = "@import can be used in a const binding (typical pattern)"
 source = """
 fn main() -> i32 {
@@ -36,6 +39,7 @@ exit_code = 0
 
 [[case]]
 name = "import_multiple_files"
+spec = ["4.13:79"]
 description = "Multiple @import calls in same file"
 source = """
 fn main() -> i32 {
@@ -49,6 +53,7 @@ exit_code = 0
 
 [[case]]
 name = "import_nested_path"
+spec = ["4.13:79", "4.13:82"]
 description = "@import with nested path"
 source = """
 fn main() -> i32 {
@@ -65,6 +70,7 @@ exit_code = 0
 
 [[case]]
 name = "import_no_args_error"
+spec = ["4.13:80"]
 description = "@import with no arguments is an error"
 source = """
 fn main() -> i32 {
@@ -77,6 +83,7 @@ error_contains = "expects 1 argument"
 
 [[case]]
 name = "import_integer_arg_error"
+spec = ["4.13:84"]
 description = "@import with integer argument should fail"
 source = """
 fn main() -> i32 {
@@ -89,6 +96,7 @@ error_contains = "requires a string literal"
 
 [[case]]
 name = "import_multiple_args_error"
+spec = ["4.13:80"]
 description = "@import with multiple arguments should fail"
 source = """
 fn main() -> i32 {
@@ -98,3 +106,16 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "expects 1 argument"
+
+[[case]]
+name = "import_module_not_found_error"
+spec = ["4.13:83"]
+description = "@import with nonexistent module produces error"
+source = """
+fn main() -> i32 {
+    let m = @import("nonexistent");
+    0
+}
+"""
+compile_fail = true
+error_contains = "cannot find module"

--- a/crates/rue-spec/cases/modules/stdlib.toml
+++ b/crates/rue-spec/cases/modules/stdlib.toml
@@ -1,5 +1,6 @@
 [section]
 id = "modules.stdlib"
+spec_chapter = "4.13"
 name = "Standard Library Imports"
 description = "Resolution and usage of @import(\"std\") for the standard library."
 
@@ -9,6 +10,7 @@ description = "Resolution and usage of @import(\"std\") for the standard library
 
 [[case]]
 name = "import_std_resolves"
+spec = ["4.13:82"]
 description = "@import(\"std\") resolves to the standard library root when std/ exists"
 source = """
 fn main() -> i32 {
@@ -24,6 +26,7 @@ exit_code = 0
 
 [[case]]
 name = "import_std_not_found_error"
+spec = ["4.13:83"]
 description = "@import(\"std\") produces a clear error when stdlib is not found"
 source = """
 fn main() -> i32 {
@@ -44,6 +47,7 @@ error_contains = "standard library not found"
 
 [[case]]
 name = "import_std_with_submodule"
+spec = ["4.13:81", "4.13:82"]
 description = "std library with submodules can be imported"
 source = """
 fn main() -> i32 {

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -550,3 +550,82 @@ fn main() -> i32 {
     }
 }
 ```
+
+## `@import`
+
+{{ rule(id="4.13:79", cat="normative") }}
+
+The `@import` intrinsic imports a module from another source file.
+
+{{ rule(id="4.13:80", cat="normative") }}
+
+`@import` accepts exactly one argument, which **MUST** be a string literal specifying the module path.
+
+{{ rule(id="4.13:81", cat="normative") }}
+
+The return type of `@import` is a module struct type containing all `pub` declarations from the imported file.
+
+{{ rule(id="4.13:82", cat="normative") }}
+
+Module path resolution follows this order:
+1. Standard library: `@import("std")` resolves to the bundled standard library
+2. A file `{path}.rue` relative to the importing file's directory
+3. A directory module `_{path}.rue` with subdirectory `{path}/`
+
+{{ rule(id="4.13:83", cat="legality-rule") }}
+
+It is a compile-time error if the module path does not resolve to an existing file.
+
+{{ rule(id="4.13:84", cat="legality-rule") }}
+
+It is a compile-time error to pass a non-string-literal argument to `@import`.
+
+{{ rule(id="4.13:85") }}
+
+```rue
+// math.rue
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+pub fn sub(a: i32, b: i32) -> i32 { a - b }
+fn helper() -> i32 { 42 }  // private, not exported
+
+// main.rue
+fn main() -> i32 {
+    let math = @import("math");
+    math.add(1, 2)  // returns 3
+}
+```
+
+{{ rule(id="4.13:86") }}
+
+Private declarations (those without `pub`) are not visible to importers:
+
+```rue
+// main.rue
+fn main() -> i32 {
+    let math = @import("math");
+    // math.helper()  // Error: `helper` is not visible
+    0
+}
+```
+
+{{ rule(id="4.13:87") }}
+
+The imported module can be bound to any name:
+
+```rue
+fn main() -> i32 {
+    let m = @import("math");
+    m.add(1, 2)
+}
+```
+
+{{ rule(id="4.13:88") }}
+
+Nested paths are supported for importing from subdirectories:
+
+```rue
+fn main() -> i32 {
+    let strings = @import("utils/strings");
+    0
+}
+```


### PR DESCRIPTION
Document the @import builtin in the intrinsics chapter, covering:
- Basic syntax and semantics (takes string literal, returns module struct)
- Module path resolution order (std, foo.rue, _foo.rue + foo/)
- Compile-time error conditions
- Examples for basic usage, visibility, aliasing, and nested paths

Also add spec paragraph references to existing module tests for traceability.

Part of #805

🤖 Generated with [Claude Code](https://claude.com/claude-code)