### PR TITLE
Add IceContext type for rich ICE diagnostics (rue-w1x3.1) 

### DIFF
--- a/crates/rue-error/src/ice.rs
+++ b/crates/rue-error/src/ice.rs
@@ -1,0 +1,235 @@
+//! Internal Compiler Error (ICE) handling.
+//!
+//! This module provides rich context capture for internal compiler errors to
+//! improve bug reports and developer debugging experience.
+
+use std::fmt;
+
+/// Context information for an Internal Compiler Error (ICE).
+///
+/// This struct captures detailed information about the compiler state when an
+/// ICE occurs, making it easier to diagnose and fix compiler bugs.
+///
+/// # Example
+/// ```ignore
+/// let ice = IceContext::new("unexpected type in codegen")
+///     .with_version("0.1.0")
+///     .with_target("x86_64-unknown-linux-gnu")
+///     .with_phase("codegen/emit");
+/// ```
+#[derive(Debug, Clone)]
+pub struct IceContext {
+    /// The error message describing what went wrong.
+    pub message: String,
+    /// Compiler version (from CARGO_PKG_VERSION).
+    pub version: Option<String>,
+    /// Target architecture (e.g., "x86_64-unknown-linux-gnu").
+    pub target: Option<String>,
+    /// Compilation phase (e.g., "codegen/emit", "sema", "cfg_builder").
+    pub phase: Option<String>,
+    /// Additional context-specific details.
+    ///
+    /// This can include things like:
+    /// - Current function being compiled
+    /// - Instruction that triggered the ICE
+    /// - Type information
+    /// - Any other relevant state
+    pub details: Vec<(String, String)>,
+}
+
+impl IceContext {
+    /// Create a new ICE context with the given error message.
+    pub fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            version: None,
+            target: None,
+            phase: None,
+            details: Vec::new(),
+        }
+    }
+
+    /// Set the compiler version.
+    pub fn with_version(mut self, version: impl Into<String>) -> Self {
+        self.version = Some(version.into());
+        self
+    }
+
+    /// Set the target architecture.
+    pub fn with_target(mut self, target: impl Into<String>) -> Self {
+        self.target = Some(target.into());
+        self
+    }
+
+    /// Set the compilation phase.
+    pub fn with_phase(mut self, phase: impl Into<String>) -> Self {
+        self.phase = Some(phase.into());
+        self
+    }
+
+    /// Add a detail key-value pair.
+    ///
+    /// Details provide context-specific information about the compiler state.
+    pub fn with_detail(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.details.push((key.into(), value.into()));
+        self
+    }
+
+    /// Format the ICE context for display.
+    ///
+    /// This produces a user-friendly representation suitable for error messages.
+    pub fn format_details(&self) -> String {
+        let mut output = String::new();
+
+        if let Some(version) = &self.version {
+            output.push_str(&format!("  rue version: {}\n", version));
+        }
+
+        if let Some(target) = &self.target {
+            output.push_str(&format!("  target: {}\n", target));
+        }
+
+        if let Some(phase) = &self.phase {
+            output.push_str(&format!("  phase: {}\n", phase));
+        }
+
+        if !self.details.is_empty() {
+            output.push_str("\n  relevant state:\n");
+            for (key, value) in &self.details {
+                output.push_str(&format!("    {}: {}\n", key, value));
+            }
+        }
+
+        output
+    }
+}
+
+impl fmt::Display for IceContext {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "internal compiler error: {}", self.message)?;
+
+        if self.version.is_some()
+            || self.target.is_some()
+            || self.phase.is_some()
+            || !self.details.is_empty()
+        {
+            write!(f, "\n\ndebug info:\n{}", self.format_details())?;
+        }
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ice_context_new() {
+        let ice = IceContext::new("test error");
+        assert_eq!(ice.message, "test error");
+        assert!(ice.version.is_none());
+        assert!(ice.target.is_none());
+        assert!(ice.phase.is_none());
+        assert!(ice.details.is_empty());
+    }
+
+    #[test]
+    fn test_ice_context_with_version() {
+        let ice = IceContext::new("test error").with_version("0.1.0");
+        assert_eq!(ice.version.as_deref(), Some("0.1.0"));
+    }
+
+    #[test]
+    fn test_ice_context_with_target() {
+        let ice = IceContext::new("test error").with_target("x86_64-unknown-linux-gnu");
+        assert_eq!(ice.target.as_deref(), Some("x86_64-unknown-linux-gnu"));
+    }
+
+    #[test]
+    fn test_ice_context_with_phase() {
+        let ice = IceContext::new("test error").with_phase("codegen/emit");
+        assert_eq!(ice.phase.as_deref(), Some("codegen/emit"));
+    }
+
+    #[test]
+    fn test_ice_context_with_detail() {
+        let ice = IceContext::new("test error")
+            .with_detail("current_function", "main")
+            .with_detail("instruction", "Call");
+        assert_eq!(ice.details.len(), 2);
+        assert_eq!(
+            ice.details[0],
+            ("current_function".to_string(), "main".to_string())
+        );
+        assert_eq!(
+            ice.details[1],
+            ("instruction".to_string(), "Call".to_string())
+        );
+    }
+
+    #[test]
+    fn test_ice_context_builder_chain() {
+        let ice = IceContext::new("unexpected type")
+            .with_version("0.1.0")
+            .with_target("x86_64-unknown-linux-gnu")
+            .with_phase("codegen/emit")
+            .with_detail("function", "main")
+            .with_detail("instruction", "Call");
+
+        assert_eq!(ice.message, "unexpected type");
+        assert_eq!(ice.version.as_deref(), Some("0.1.0"));
+        assert_eq!(ice.target.as_deref(), Some("x86_64-unknown-linux-gnu"));
+        assert_eq!(ice.phase.as_deref(), Some("codegen/emit"));
+        assert_eq!(ice.details.len(), 2);
+    }
+
+    #[test]
+    fn test_ice_context_format_details_minimal() {
+        let ice = IceContext::new("test error");
+        let formatted = ice.format_details();
+        assert_eq!(formatted, "");
+    }
+
+    #[test]
+    fn test_ice_context_format_details_with_version() {
+        let ice = IceContext::new("test error").with_version("0.1.0");
+        let formatted = ice.format_details();
+        assert!(formatted.contains("rue version: 0.1.0"));
+    }
+
+    #[test]
+    fn test_ice_context_format_details_full() {
+        let ice = IceContext::new("test error")
+            .with_version("0.1.0")
+            .with_target("x86_64-unknown-linux-gnu")
+            .with_phase("codegen")
+            .with_detail("function", "main");
+
+        let formatted = ice.format_details();
+        assert!(formatted.contains("rue version: 0.1.0"));
+        assert!(formatted.contains("target: x86_64-unknown-linux-gnu"));
+        assert!(formatted.contains("phase: codegen"));
+        assert!(formatted.contains("relevant state:"));
+        assert!(formatted.contains("function: main"));
+    }
+
+    #[test]
+    fn test_ice_context_display_minimal() {
+        let ice = IceContext::new("test error");
+        assert_eq!(ice.to_string(), "internal compiler error: test error");
+    }
+
+    #[test]
+    fn test_ice_context_display_with_details() {
+        let ice = IceContext::new("test error")
+            .with_version("0.1.0")
+            .with_phase("codegen");
+
+        let output = ice.to_string();
+        assert!(output.contains("internal compiler error: test error"));
+        assert!(output.contains("debug info:"));
+        assert!(output.contains("rue version: 0.1.0"));
+        assert!(output.contains("phase: codegen"));
+    }
+}

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -17,6 +17,8 @@
 //!     .with_help("consider using a type conversion")
 //! ```
 
+pub mod ice;
+
 use rue_span::Span;
 use std::borrow::Cow;
 use std::collections::HashSet;


### PR DESCRIPTION
Introduces a builder-pattern IceContext type that captures structured
information about internal compiler errors:
- Compiler version, target, and phase
- Context-specific details (function name, instruction, etc.)
- Human-readable formatting

This is the foundation for improved ICE reporting. Future work will:
- Add backtrace capture
- Create convenience macros
- Update diagnostic rendering
- Replace panic! calls with structured ICEs

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>