### PR TITLE
Fix array return type unification in type inference

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1462,9 +1462,10 @@ fn run_type_inference_with_context(
     let body_info = cgen.generate(body, &mut cgen_ctx);
 
     // The function body's type must match the return type.
+    // For arrays, we need to convert Type to InferType structurally.
     cgen.add_constraint(Constraint::equal(
         body_info.ty,
-        InferType::Concrete(return_type),
+        ctx.type_to_infer_type(return_type),
         body_info.span,
     ));
 
@@ -6679,9 +6680,10 @@ impl<'a> Sema<'a> {
 
         // The function body's type must match the return type.
         // This handles implicit returns like `fn foo() -> i8 { 42 }`.
+        // For arrays, we need to convert Type to InferType structurally.
         cgen.add_constraint(Constraint::equal(
             body_info.ty,
-            InferType::Concrete(return_type),
+            self.type_to_infer_type(return_type),
             body_info.span,
         ));
 


### PR DESCRIPTION
Arrays can now be returned from functions correctly. The issue was that when creating constraints for function body types, the return type was wrapped as InferType::Concrete(Type::Array(...)) instead of using type_to_infer_type() to convert it to InferType::Array with structural representation.

This caused a mismatch where the body expression had type InferType::Array { element: ..., length: ... } but the constraint expected InferType::Concrete(Type::Array(...)), which failed to unify.

Fixed in both run_type_inference() and run_type_inference_with_context().

Fixes: rue-b79f