### PR TITLE
Fix shell syntax error in benchmarks workflow

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -85,7 +85,7 @@ jobs:
           cat /tmp/results.json
           echo ""
           echo "=== Validation ==="
-          python3 -c "
+          python3 << 'EOF'
           import json
           import sys
 
@@ -94,7 +94,7 @@ jobs:
 
           benchmarks = data.get('benchmarks', [])
           print(f'Platform: ${{ matrix.platform }}')
-          print(f'Commit: {data.get(\"commit\", \"unknown\")}')
+          print(f'Commit: {data.get("commit", "unknown")}')
           print(f'Benchmarks collected: {len(benchmarks)}')
 
           if not benchmarks:
@@ -107,7 +107,7 @@ jobs:
               print(f'  - {name}: {mean:.2f}ms')
 
           print('Validation passed!')
-          "
+          EOF
 
       - name: Upload benchmark results as artifact
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
The Python validation script was using inline quotes with python3 -c, which caused shell parsing errors. Changed to use a heredoc (<<'EOF') for cleaner multiline Python code embedding.

Fixes CI failure at line 19 of generated shell script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)