### PR TITLE
Replace InternalError/InternalCodegenError with ice! macro

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -14,7 +14,7 @@ use std::collections::{HashMap, HashSet};
 use lasso::Spur;
 use rue_builtins::is_reserved_type_name;
 use rue_error::{
-    CompileError, CompileResult, CopyStructNonCopyFieldError, ErrorKind, PreviewFeature,
+    CompileError, CompileResult, CopyStructNonCopyFieldError, ErrorKind, PreviewFeature, ice,
 };
 use rue_rir::{InstData, InstRef, RirDirective, RirParamMode};
 use rue_span::Span;
@@ -299,10 +299,16 @@ impl<'a> Sema<'a> {
                 // Verify the struct exists in our lookup table
                 if !self.structs.contains_key(name) {
                     return Err(CompileError::new(
-                        ErrorKind::InternalError(format!(
-                            "struct '{}' not found in struct map during field resolution",
-                            name_str
-                        )),
+                        ErrorKind::InternalError(
+                            ice!(
+                                "struct not found in struct map",
+                                phase: "sema/declarations",
+                                details: {
+                                    "struct_name" => name_str.to_string()
+                                }
+                            )
+                            .to_string(),
+                        ),
                         inst.span,
                     ));
                 }
@@ -310,10 +316,16 @@ impl<'a> Sema<'a> {
                 // Get the struct ID from the lookup table
                 let struct_id = *self.structs.get(name).ok_or_else(|| {
                     CompileError::new(
-                        ErrorKind::InternalError(format!(
-                            "struct '{}' not found in structs map during field resolution",
-                            name_str
-                        )),
+                        ErrorKind::InternalError(
+                            ice!(
+                                "struct not found in structs map",
+                                phase: "sema/declarations",
+                                details: {
+                                    "struct_name" => name_str.to_string()
+                                }
+                            )
+                            .to_string(),
+                        ),
                         inst.span,
                     )
                 })?;
@@ -452,10 +464,16 @@ impl<'a> Sema<'a> {
         // Verify struct exists in our lookup
         if !self.structs.contains_key(&name) {
             return Err(CompileError::new(
-                ErrorKind::InternalError(format!(
-                    "struct '{}' not found in struct map during @copy validation",
-                    struct_name
-                )),
+                ErrorKind::InternalError(
+                    ice!(
+                        "struct not found during @copy validation",
+                        phase: "sema/declarations",
+                        details: {
+                            "struct_name" => struct_name.clone()
+                        }
+                    )
+                    .to_string(),
+                ),
                 span,
             ));
         }
@@ -463,10 +481,16 @@ impl<'a> Sema<'a> {
         // Get the struct ID from the lookup table
         let struct_id = *self.structs.get(&name).ok_or_else(|| {
             CompileError::new(
-                ErrorKind::InternalError(format!(
-                    "struct '{}' not found in structs map during @copy validation",
-                    struct_name
-                )),
+                ErrorKind::InternalError(
+                    ice!(
+                        "struct not found during @copy validation",
+                        phase: "sema/declarations",
+                        details: {
+                            "struct_name" => struct_name.clone()
+                        }
+                    )
+                    .to_string(),
+                ),
                 span,
             )
         })?;
@@ -512,10 +536,16 @@ impl<'a> Sema<'a> {
                 let struct_name = self.interner.resolve(&*name).to_string();
                 let struct_id = *self.structs.get(name).ok_or_else(|| {
                     CompileError::new(
-                        ErrorKind::InternalError(format!(
-                            "struct '{}' not found in struct map during @handle validation",
-                            struct_name
-                        )),
+                        ErrorKind::InternalError(
+                            ice!(
+                                "struct not found during @handle validation",
+                                phase: "sema/declarations",
+                                details: {
+                                    "struct_name" => struct_name.clone()
+                                }
+                            )
+                            .to_string(),
+                        ),
                         inst.span,
                     )
                 })?;
@@ -630,10 +660,16 @@ impl<'a> Sema<'a> {
         // Get the struct ID from the lookup table
         let struct_id = *self.structs.get(&type_name).ok_or_else(|| {
             CompileError::new(
-                ErrorKind::InternalError(format!(
-                    "struct '{}' not found in structs map during destructor collection",
-                    type_name_str
-                )),
+                ErrorKind::InternalError(
+                    ice!(
+                        "struct not found during destructor collection",
+                        phase: "sema/declarations",
+                        details: {
+                            "struct_name" => type_name_str.to_string()
+                        }
+                    )
+                    .to_string(),
+                ),
                 span,
             )
         })?;

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -8,7 +8,7 @@ use rue_air::{
     Air, AirArgMode, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
     Type, TypeInternPool, TypeKind,
 };
-use rue_error::{CompileWarning, WarningKind};
+use rue_error::{CompileWarning, WarningKind, ice_error};
 
 use crate::CfgOutput;
 use crate::inst::{
@@ -202,6 +202,10 @@ impl<'a> CfgBuilder<'a> {
             AirInstData::CallGeneric { .. } => {
                 // CallGeneric instructions must be specialized (rewritten to Call)
                 // before CFG building. If we reach here, specialization didn't run.
+                //
+                // TODO(ICE): This should be converted to:
+                //   return Err(ice_error!("CallGeneric not specialized", phase: "cfg_builder"));
+                // But that requires refactoring build() to return CompileResult.
                 panic!(
                     "CallGeneric instruction reached CFG building - this is a compiler bug. \
                      CallGeneric must be specialized to regular Call before codegen."

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -95,7 +95,7 @@
 //! - Caller-saved: RAX, RCX, RDX, RSI, RDI, R8-R11, XMM0-XMM15
 //! - Callee-saved: RBX, RBP, R12-R15
 
-use rue_error::{CompileError, CompileResult, ErrorKind};
+use rue_error::{CompileError, CompileResult, ErrorKind, ice_error};
 
 use super::mir::{LabelId, Reg, X86Inst, X86Mir};
 use crate::vreg::BLOCK_LABEL_BASE;
@@ -347,13 +347,15 @@ impl<'a> Emitter<'a> {
                 inst,
                 X86Inst::MovRMIndexed { .. } | X86Inst::MovMRIndexed { .. }
             ) {
-                return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
-                    format!(
-                        "post-regalloc verification failed: instruction {} is {:?}, \
-                         which should have been lowered by regalloc",
-                        i, inst
-                    ),
-                )));
+                return Err(ice_error!(
+                    "post-regalloc verification failed",
+                    phase: "codegen/emit",
+                    details: {
+                        "instruction_index" => i.to_string(),
+                        "instruction" => format!("{:?}", inst),
+                        "reason" => "should have been lowered by regalloc"
+                    }
+                ));
             }
         }
 
@@ -510,10 +512,13 @@ impl<'a> Emitter<'a> {
     fn apply_fixups(&mut self) -> CompileResult<()> {
         for fixup in &self.fixups {
             let target_offset = self.labels.get(&fixup.label).ok_or_else(|| {
-                CompileError::without_span(ErrorKind::InternalCodegenError(format!(
-                    "undefined label: {}",
-                    fixup.label
-                )))
+                ice_error!(
+                    "undefined label during fixup",
+                    phase: "codegen/emit",
+                    details: {
+                        "label" => fixup.label.to_string()
+                    }
+                )
             })?;
 
             match fixup.kind {
@@ -525,12 +530,15 @@ impl<'a> Emitter<'a> {
 
                     // rel32 encoding supports i32 range
                     if relative < i32::MIN as i64 || relative > i32::MAX as i64 {
-                        return Err(CompileError::without_span(ErrorKind::InternalCodegenError(
-                            format!(
-                                "jump offset {} exceeds rel32 range for label '{}'",
-                                relative, fixup.label
-                            ),
-                        )));
+                        return Err(ice_error!(
+                            "jump offset exceeds rel32 range",
+                            phase: "codegen/emit",
+                            details: {
+                                "offset" => relative.to_string(),
+                                "label" => fixup.label.to_string(),
+                                "range" => "i32::MIN..=i32::MAX"
+                            }
+                        ));
                     }
 
                     let bytes = (relative as i32).to_le_bytes();
@@ -1323,7 +1331,7 @@ impl<'a> Emitter<'a> {
             2 => 0b01,
             4 => 0b10,
             8 => 0b11,
-            _ => panic!("Invalid SIB scale: {}", scale),
+            _ => unreachable!("Invalid SIB scale (compiler bug): {}", scale),
         };
 
         // x86 quirk: index=RSP (100) means "no index" - we shouldn't emit this

--- a/crates/rue-codegen/src/x86_64/verify.rs
+++ b/crates/rue-codegen/src/x86_64/verify.rs
@@ -34,7 +34,7 @@
 use std::collections::HashMap;
 
 use super::mir::{LabelId, Operand, Reg, X86Inst, X86Mir};
-use rue_error::{CompileError, CompileResult, ErrorKind};
+use rue_error::{CompileError, CompileResult, ErrorKind, ice_error};
 
 /// Verifies that the stack is properly aligned throughout function execution.
 ///
@@ -185,10 +185,16 @@ impl StackVerifier {
     }
 
     fn alignment_error(&self, idx: usize, inst: &X86Inst, message: String) -> CompileError {
-        CompileError::without_span(ErrorKind::InternalCodegenError(format!(
-            "stack alignment verification failed at instruction {}: {} (depth: {} bytes) - {}",
-            idx, inst, self.current_depth, message
-        )))
+        ice_error!(
+            "stack alignment verification failed",
+            phase: "codegen/verify",
+            details: {
+                "instruction_index" => idx.to_string(),
+                "instruction" => inst.to_string(),
+                "stack_depth_bytes" => self.current_depth.to_string(),
+                "message" => message
+            }
+        )
     }
 }
 


### PR DESCRIPTION
This commit replaces 10 uses of raw InternalError and InternalCodegenError with the new ice! macro, providing rich context including phase information, custom details, and automatic backtrace capture.

Changes:
- rue-air/src/sema/declarations.rs: 6 struct lookup errors now use ice! with phase 'sema/declarations' and struct_name details
- rue-codegen/src/x86_64/emit.rs: 3 codegen errors now use ice_error! with phase 'codegen/emit' and contextual details
- rue-codegen/src/x86_64/verify.rs: 1 alignment error now uses ice_error! with phase 'codegen/verify' and instruction details
- rue-cfg/src/build.rs: Added TODO comment showing how CallGeneric panic should be converted (requires refactoring to return Result)

The ice! macro automatically captures backtraces and formats errors with structured context for better debugging. All tests pass.

Related: rue-w1x3.5, rue-w1x3

🤖 Generated with [Claude Code](https://claude.com/claude-code)