### PR TITLE
Fix syscall register allocation bug in both backends (rue-n3ol)

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2069,37 +2069,68 @@ impl<'a> CfgLower<'a> {
                     //   - X0-X5: arguments 1-6
                     //   - Returns result in X0
                     //   - Uses SVC #0x80
+                    //
+                    // IMPORTANT: We allocate temporary stack space to stage arguments
+                    // before loading them into physical registers. This prevents the register
+                    // allocator from reusing these registers between setup and the SVC instruction,
+                    // which would break the syscall (especially the syscall number register).
 
                     let args = self.ctx.cfg.get_extra(*args_start, *args_len);
 
-                    // First argument is syscall number
+                    // Allocate stack space for all arguments (8 bytes each, 16-byte aligned)
+                    let num_args = args.len();
+                    let stack_space = ((num_args * 8 + 15) & !15) as i32; // Round up to 16-byte alignment
+                    if stack_space > 0 {
+                        self.mir.push(Aarch64Inst::SubImm {
+                            dst: Operand::Physical(Reg::Sp),
+                            src: Operand::Physical(Reg::Sp),
+                            imm: stack_space,
+                        });
+                    }
+
+                    // Store all arguments to the stack
+                    for (i, &arg) in args.iter().enumerate() {
+                        let arg_vreg = self.get_vreg(arg);
+                        let offset = (i * 8) as i32;
+                        self.mir.push(Aarch64Inst::Str {
+                            src: Operand::Virtual(arg_vreg),
+                            base: Reg::Sp,
+                            offset,
+                        });
+                    }
+
+                    // Load syscall number from stack into syscall number register
                     // Linux uses X8, macOS uses X16
-                    let syscall_num_vreg = self.get_vreg(args[0]);
                     let syscall_num_reg = if self.target.is_macho() {
                         Reg::X16
                     } else {
                         Reg::X8
                     };
-                    self.mir.push(Aarch64Inst::MovRR {
+                    self.mir.push(Aarch64Inst::Ldr {
                         dst: Operand::Physical(syscall_num_reg),
-                        src: Operand::Virtual(syscall_num_vreg),
+                        base: Reg::Sp,
+                        offset: 0,
                     });
 
-                    // Remaining arguments go to X0-X5
-                    for (i, &arg) in args.iter().skip(1).enumerate() {
-                        let arg_vreg = self.get_vreg(arg);
-                        let target_reg = match i {
+                    // Load remaining arguments from stack into X0-X5
+                    for i in 1..num_args {
+                        if i > 6 {
+                            break; // Syscall can have at most 6 arguments (plus syscall number)
+                        }
+                        let target_reg = match i - 1 {
                             0 => Reg::X0,
                             1 => Reg::X1,
                             2 => Reg::X2,
                             3 => Reg::X3,
                             4 => Reg::X4,
                             5 => Reg::X5,
-                            _ => unreachable!("syscall can have at most 6 arguments"),
+                            _ => unreachable!(),
                         };
-                        self.mir.push(Aarch64Inst::MovRR {
+                        let offset = (i * 8) as i32;
+                        self.mir.push(Aarch64Inst::Ldr {
                             dst: Operand::Physical(target_reg),
-                            src: Operand::Virtual(arg_vreg),
+                            base: Reg::Sp,
+                            offset,
                         });
                     }
 
@@ -2107,6 +2138,15 @@ impl<'a> CfgLower<'a> {
                     // Linux uses SVC #0, macOS uses SVC #0x80
                     let svc_imm = if self.target.is_macho() { 0x80 } else { 0 };
                     self.mir.push(Aarch64Inst::Svc { imm: svc_imm });
+
+                    // Clean up stack space
+                    if stack_space > 0 {
+                        self.mir.push(Aarch64Inst::AddImm {
+                            dst: Operand::Physical(Reg::Sp),
+                            src: Operand::Physical(Reg::Sp),
+                            imm: stack_space,
+                        });
+                    }
 
                     // Result is in X0, move to a vreg
                     let result_vreg = self.mir.alloc_vreg();

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2213,6 +2213,11 @@ impl<'a> CfgLower<'a> {
                     //   - RDI, RSI, RDX, R10, R8, R9: arguments 1-6
                     //   - Returns result in RAX
                     //   - Clobbers RCX and R11 (saved by hardware)
+                    //
+                    // IMPORTANT: We use push/pop to load arguments into physical registers
+                    // immediately before the syscall instruction. This prevents the register
+                    // allocator from reusing these registers between the setup and the syscall,
+                    // which would break the syscall (especially RAX containing the syscall number).
 
                     let args = self.ctx.cfg.get_extra(*args_start, *args_len);
 
@@ -2220,20 +2225,32 @@ impl<'a> CfgLower<'a> {
                     const SYSCALL_ARG_REGS: [Reg; 6] =
                         [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::R10, Reg::R8, Reg::R9];
 
-                    // First argument is syscall number -> RAX
-                    let syscall_num_vreg = self.get_vreg(args[0]);
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Physical(Reg::Rax),
-                        src: Operand::Virtual(syscall_num_vreg),
-                    });
-
-                    // Remaining arguments go to RDI, RSI, RDX, R10, R8, R9
-                    for (i, &arg) in args.iter().skip(1).enumerate() {
+                    // Push all arguments onto the stack in reverse order (syscall num last)
+                    // This creates a safe staging area that the register allocator won't touch
+                    for &arg in args.iter().rev() {
                         let arg_vreg = self.get_vreg(arg);
                         self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Physical(SYSCALL_ARG_REGS[i]),
+                            dst: Operand::Physical(Reg::Rax),
                             src: Operand::Virtual(arg_vreg),
                         });
+                        self.mir.push(X86Inst::Push {
+                            src: Operand::Physical(Reg::Rax),
+                        });
+                    }
+
+                    // Pop syscall number into RAX
+                    self.mir.push(X86Inst::Pop {
+                        dst: Operand::Physical(Reg::Rax),
+                    });
+
+                    // Pop remaining arguments into their syscall ABI registers
+                    for (i, reg) in SYSCALL_ARG_REGS.iter().enumerate() {
+                        if i < args.len() - 1 {
+                            // -1 because first arg (syscall num) is already in RAX
+                            self.mir.push(X86Inst::Pop {
+                                dst: Operand::Physical(*reg),
+                            });
+                        }
                     }
 
                     // Execute the syscall instruction


### PR DESCRIPTION
The @syscall intrinsic was using direct MovRR instructions to load arguments into physical registers (RAX, RDI, etc. on x86-64; X8/X16, X0-X5 on aarch64). This caused a register allocation bug: after moving the syscall number to RAX, the register allocator would see the source vreg as dead and feel free to reuse RAX for other purposes before the syscall instruction executed.

Result: RAX would contain the wrong value at syscall time, causing the syscall to execute with incorrect arguments (or the wrong syscall number entirely).

This manifested as the syscall_max_args test returning exit code 42 instead of 0 because the exit_group(0) syscall was being executed with a corrupted syscall number and didn't terminate the process as expected.

Fix:

x86_64: Use push/pop sequence to stage arguments on the stack before loading into physical registers immediately before the syscall instruction. This prevents the register allocator from inserting any instructions between argument setup and the syscall.

aarch64: Allocate aligned stack space, store all arguments, then load them into their target registers immediately before the SVC instruction. Same principle as x86_64 but adapted to aarch64 instruction set.

The issue wasn't specific to WSL - it was a general codegen bug that could affect any syscall with multiple arguments on any platform.

🤖 Generated with [Claude Code](https://claude.com/claude-code)