### PR TITLE
Fix: Skip anonymous struct methods during declaration gathering

### DIFF
--- a/crates/rue-air/src/function_analyzer.rs
+++ b/crates/rue-air/src/function_analyzer.rs
@@ -237,7 +237,7 @@ impl<'a, 'ctx> FunctionAnalyzer<'a, 'ctx> {
     pub fn resolve_type(&mut self, type_sym: Spur, span: Span) -> CompileResult<Type> {
         let type_name = self.ctx.interner.resolve(&type_sym);
 
-        // Check primitive types first
+        // Check primitive types
         match type_name {
             "i8" => return Ok(Type::I8),
             "i16" => return Ok(Type::I16),

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -369,8 +369,27 @@ impl<'a> Sema<'a> {
 
     /// Resolve @copy validation, destructors, functions, and methods.
     pub(crate) fn resolve_remaining_declarations(&mut self) -> CompileResult<()> {
-        // First pass: collect all declarations and validate @copy structs
+        // Collect all method InstRefs from anonymous struct types
+        // These need to be skipped during function declaration collection because:
+        // - They may use `Self` type which requires struct context
+        // - They are registered later during comptime evaluation with proper Self resolution
+        let mut anon_struct_method_refs = std::collections::HashSet::new();
         for (_, inst) in self.rir.iter() {
+            if let InstData::AnonStructType {
+                methods_start,
+                methods_len,
+                ..
+            } = &inst.data
+            {
+                let method_refs = self.rir.get_inst_refs(*methods_start, *methods_len);
+                for method_ref in method_refs {
+                    anon_struct_method_refs.insert(method_ref);
+                }
+            }
+        }
+
+        // First pass: collect all declarations and validate @copy structs
+        for (inst_ref, inst) in self.rir.iter() {
             match &inst.data {
                 InstData::StructDecl {
                     directives_start,
@@ -407,8 +426,13 @@ impl<'a> Sema<'a> {
                 } => {
                     // Skip methods (has_self = true) - these are handled elsewhere:
                     // - Named struct methods are collected via ImplDecl
-                    // - Anonymous struct methods are registered during comptime evaluation
                     if *has_self {
+                        continue;
+                    }
+
+                    // Skip ALL methods from anonymous structs (including associated functions)
+                    // These are registered during comptime evaluation with proper Self type context
+                    if anon_struct_method_refs.contains(&inst_ref) {
                         continue;
                     }
 


### PR DESCRIPTION
Anonymous struct methods (both instance methods and associated functions) may use the `Self` type in their signatures. During declaration gathering, the struct type context isn't available yet, so `Self` cannot be resolved.

The fix: collect all method InstRefs from AnonStructType instructions and skip them entirely during FnDecl processing in resolve_remaining_declarations(). These methods are properly registered later during comptime evaluation when the anonymous struct is instantiated, at which point resolve_type_with_self() can correctly map Self to the concrete struct type.

Fixes rue-wvxf