### PR TITLE
Stabilize unchecked_code preview feature

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -2294,6 +2294,7 @@ fn get_resolved_type_ctx(
 }
 
 /// Check that the unchecked_code preview feature is enabled (parallel version).
+#[allow(dead_code)]
 fn require_preview_ctx(
     ctx: &SemaContext<'_>,
     feature: PreviewFeature,
@@ -5734,13 +5735,6 @@ fn analyze_intrinsic_ctx(
         Ok(AnalysisResult::new(air_ref, Type::U64))
     } else if name == known.ptr_read {
         // @ptr_read(ptr) - Read value through pointer
-        require_preview_ctx(
-            ctx,
-            PreviewFeature::UncheckedCode,
-            "pointer intrinsics",
-            span,
-        )?;
-
         if args.len() != 1 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
@@ -5784,13 +5778,6 @@ fn analyze_intrinsic_ctx(
         Ok(AnalysisResult::new(air_ref, pointee_type))
     } else if name == known.ptr_write {
         // @ptr_write(ptr, value) - Write value through pointer
-        require_preview_ctx(
-            ctx,
-            PreviewFeature::UncheckedCode,
-            "pointer intrinsics",
-            span,
-        )?;
-
         if args.len() != 2 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
@@ -5857,13 +5844,6 @@ fn analyze_intrinsic_ctx(
         Ok(AnalysisResult::new(air_ref, Type::UNIT))
     } else if name == known.ptr_offset {
         // @ptr_offset(ptr, offset) - Pointer arithmetic
-        require_preview_ctx(
-            ctx,
-            PreviewFeature::UncheckedCode,
-            "pointer intrinsics",
-            span,
-        )?;
-
         if args.len() != 2 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
@@ -5918,13 +5898,6 @@ fn analyze_intrinsic_ctx(
         Ok(AnalysisResult::new(air_ref, ptr_type))
     } else if name == known.ptr_to_int {
         // @ptr_to_int(ptr) - Convert pointer to u64
-        require_preview_ctx(
-            ctx,
-            PreviewFeature::UncheckedCode,
-            "pointer intrinsics",
-            span,
-        )?;
-
         if args.len() != 1 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
@@ -5964,13 +5937,6 @@ fn analyze_intrinsic_ctx(
         Ok(AnalysisResult::new(air_ref, Type::U64))
     } else if name == known.int_to_ptr {
         // @int_to_ptr(addr) - Convert u64 to pointer
-        require_preview_ctx(
-            ctx,
-            PreviewFeature::UncheckedCode,
-            "pointer intrinsics",
-            span,
-        )?;
-
         if args.len() != 1 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
@@ -6029,13 +5995,6 @@ fn analyze_intrinsic_ctx(
         let is_mut = name == known.addr_of_mut;
         let intrinsic_name = if is_mut { "addr_of_mut" } else { "addr_of" };
 
-        require_preview_ctx(
-            ctx,
-            PreviewFeature::UncheckedCode,
-            "pointer intrinsics",
-            span,
-        )?;
-
         if args.len() != 1 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
@@ -6072,13 +6031,6 @@ fn analyze_intrinsic_ctx(
         Ok(AnalysisResult::new(air_ref, result_type))
     } else if name == known.syscall {
         // @syscall(num, arg0?, ..., arg5?) - Direct OS syscall
-        require_preview_ctx(
-            ctx,
-            PreviewFeature::UncheckedCode,
-            "@syscall intrinsic",
-            span,
-        )?;
-
         // Syscall takes 1-7 arguments: syscall number + up to 6 arguments
         if args.is_empty() || args.len() > 7 {
             return Err(CompileError::new(
@@ -10465,9 +10417,6 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Require unchecked context
-        self.require_preview(PreviewFeature::UncheckedCode, "pointer intrinsics", span)?;
-
         if args.len() != 1 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
@@ -10522,9 +10471,6 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Require unchecked context
-        self.require_preview(PreviewFeature::UncheckedCode, "pointer intrinsics", span)?;
-
         if args.len() != 2 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
@@ -10602,9 +10548,6 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Require unchecked context
-        self.require_preview(PreviewFeature::UncheckedCode, "pointer intrinsics", span)?;
-
         if args.len() != 2 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
@@ -10670,9 +10613,6 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Require unchecked context
-        self.require_preview(PreviewFeature::UncheckedCode, "pointer intrinsics", span)?;
-
         if args.len() != 1 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
@@ -10725,9 +10665,6 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Require unchecked context
-        self.require_preview(PreviewFeature::UncheckedCode, "pointer intrinsics", span)?;
-
         if args.len() != 1 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
@@ -10796,9 +10733,6 @@ impl<'a> Sema<'a> {
     ) -> CompileResult<AnalysisResult> {
         let intrinsic_name = if is_mut { "addr_of_mut" } else { "addr_of" };
 
-        // Require unchecked context
-        self.require_preview(PreviewFeature::UncheckedCode, "pointer intrinsics", span)?;
-
         if args.len() != 1 {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
@@ -10858,9 +10792,6 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Require unchecked context
-        self.require_preview(PreviewFeature::UncheckedCode, "@syscall intrinsic", span)?;
-
         // Syscall takes 1-7 arguments: syscall number + up to 6 arguments
         if args.is_empty() || args.len() > 7 {
             return Err(CompileError::new(

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -13,9 +13,7 @@ use std::collections::{HashMap, HashSet};
 
 use lasso::Spur;
 use rue_builtins::is_reserved_type_name;
-use rue_error::{
-    CompileError, CompileResult, CopyStructNonCopyFieldError, ErrorKind, PreviewFeature, ice,
-};
+use rue_error::{CompileError, CompileResult, CopyStructNonCopyFieldError, ErrorKind, ice};
 use rue_rir::{InstData, InstRef, RirDirective, RirParamMode};
 use rue_span::Span;
 
@@ -415,7 +413,7 @@ impl<'a> Sema<'a> {
 
                 InstData::FnDecl {
                     is_pub,
-                    is_unchecked,
+                    is_unchecked: _,
                     name,
                     params_start,
                     params_len,
@@ -434,15 +432,6 @@ impl<'a> Sema<'a> {
                     // These are registered during comptime evaluation with proper Self type context
                     if anon_struct_method_refs.contains(&inst_ref) {
                         continue;
-                    }
-
-                    // Unchecked functions require preview feature
-                    if *is_unchecked {
-                        self.require_preview(
-                            PreviewFeature::UncheckedCode,
-                            "unchecked functions",
-                            inst.span,
-                        )?;
                     }
                     self.collect_function_signature(
                         *name,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -301,9 +301,6 @@ pub enum PreviewFeature {
     /// Allows method definitions inside anonymous struct type expressions.
     /// See ADR-0029 for the full design.
     AnonStructMethods,
-    /// Unchecked code and raw pointers.
-    /// See ADR-0028 for the full design.
-    UncheckedCode,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -325,7 +322,6 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::AnonStructMethods => "anon_struct_methods",
-            PreviewFeature::UncheckedCode => "unchecked_code",
         }
     }
 
@@ -335,17 +331,12 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::AnonStructMethods => "ADR-0029",
-            PreviewFeature::UncheckedCode => "ADR-0028",
         }
     }
 
     /// Get all available preview features.
     pub fn all() -> &'static [PreviewFeature] {
-        &[
-            PreviewFeature::TestInfra,
-            PreviewFeature::AnonStructMethods,
-            PreviewFeature::UncheckedCode,
-        ]
+        &[PreviewFeature::TestInfra, PreviewFeature::AnonStructMethods]
     }
 
     /// Get a comma-separated list of all feature names (for help text).
@@ -369,7 +360,6 @@ impl std::str::FromStr for PreviewFeature {
         match s {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "anon_struct_methods" => Ok(PreviewFeature::AnonStructMethods),
-            "unchecked_code" => Ok(PreviewFeature::UncheckedCode),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -1883,7 +1873,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, anon_struct_methods, unchecked_code");
+        assert_eq!(names, "test_infra, anon_struct_methods");
     }
 
     // ========================================================================

--- a/crates/rue-spec/cases/items/unchecked.toml
+++ b/crates/rue-spec/cases/items/unchecked.toml
@@ -20,8 +20,7 @@ description = "Unchecked functions, checked blocks, and raw pointer types for lo
 
 [[case]]
 name = "unchecked_fn_basic"
-spec = ["9.1:1", "9.1:3"]
-preview = "unchecked_code"
+spec = ["9.1:1", "9.1:2"]
 source = """
 unchecked fn dangerous_op() -> i32 { 42 }
 fn main() -> i32 { 0 }
@@ -31,7 +30,6 @@ exit_code = 0
 [[case]]
 name = "unchecked_fn_with_params"
 spec = ["9.1:1"]
-preview = "unchecked_code"
 source = """
 unchecked fn read_memory(addr: i32) -> i32 { addr }
 fn main() -> i32 { 0 }
@@ -41,7 +39,6 @@ exit_code = 0
 [[case]]
 name = "pub_unchecked_fn"
 spec = ["9.1:1"]
-preview = "unchecked_code"
 source = """
 pub unchecked fn public_dangerous() -> i32 { 0 }
 fn main() -> i32 { 0 }
@@ -49,27 +46,12 @@ fn main() -> i32 { 0 }
 exit_code = 0
 
 # =============================================================================
-# Unchecked function requires preview feature
-# =============================================================================
-
-[[case]]
-name = "unchecked_fn_requires_preview"
-spec = ["9.1:2"]
-source = """
-unchecked fn dangerous_op() -> i32 { 42 }
-fn main() -> i32 { 0 }
-"""
-compile_fail = true
-error_contains = "requires preview feature"
-
-# =============================================================================
 # Checked block expressions
 # =============================================================================
 
 [[case]]
 name = "checked_block_basic"
-spec = ["9.1:5", "9.1:6", "9.1:7"]
-preview = "unchecked_code"
+spec = ["9.1:4", "9.1:5", "9.1:6"]
 source = """
 fn main() -> i32 {
     let x = checked { 42 };
@@ -80,8 +62,7 @@ exit_code = 42
 
 [[case]]
 name = "checked_block_nested"
-spec = ["9.1:5"]
-preview = "unchecked_code"
+spec = ["9.1:4"]
 source = """
 fn main() -> i32 {
     checked {
@@ -95,8 +76,7 @@ exit_code = 42
 
 [[case]]
 name = "checked_block_with_statements"
-spec = ["9.1:5"]
-preview = "unchecked_code"
+spec = ["9.1:4"]
 source = """
 fn main() -> i32 {
     let result = checked {
@@ -118,9 +98,7 @@ exit_code = 42
 
 [[case]]
 name = "ptr_const_type_in_param"
-spec = ["9.1:9", "9.1:10"]
-preview = "unchecked_code"
-preview_should_pass = true
+spec = ["9.1:8", "9.1:9"]
 source = """
 fn takes_ptr(p: ptr const i32) -> i32 { 0 }
 fn main() -> i32 { 0 }
@@ -129,9 +107,7 @@ exit_code = 0
 
 [[case]]
 name = "ptr_mut_type_in_param"
-spec = ["9.1:9"]
-preview = "unchecked_code"
-preview_should_pass = true
+spec = ["9.1:8"]
 source = """
 fn takes_mut_ptr(p: ptr mut i32) -> i32 { 0 }
 fn main() -> i32 { 0 }
@@ -140,9 +116,7 @@ exit_code = 0
 
 [[case]]
 name = "ptr_const_return_type"
-spec = ["9.1:9"]
-preview = "unchecked_code"
-preview_should_pass = true
+spec = ["9.1:8"]
 source = """
 // Test that ptr const T can be used as a return type
 // Pass the pointer through to verify the return type is recognized
@@ -153,9 +127,7 @@ exit_code = 0
 
 [[case]]
 name = "ptr_to_struct_type"
-spec = ["9.1:9"]
-preview = "unchecked_code"
-preview_should_pass = true
+spec = ["9.1:8"]
 source = """
 struct Point { x: i32, y: i32 }
 fn takes_point_ptr(p: ptr const Point) -> i32 { 0 }

--- a/crates/rue-spec/cases/runtime/pointers.toml
+++ b/crates/rue-spec/cases/runtime/pointers.toml
@@ -16,8 +16,6 @@ description = "Tests for pointer intrinsics (@addr_of, @ptr_read, @ptr_write, et
 [[case]]
 name = "addr_of_simple_local"
 spec = ["9.2:1"]
-preview = "unchecked_code"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let x: i32 = 42;
@@ -35,8 +33,6 @@ exit_code = 42
 [[case]]
 name = "addr_of_array_element"
 spec = ["9.2:1"]
-preview = "unchecked_code"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let arr: [i32; 3] = [10, 20, 30];
@@ -52,8 +48,6 @@ exit_code = 10
 [[case]]
 name = "addr_of_array_second_element"
 spec = ["9.2:1"]
-preview = "unchecked_code"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let arr: [i32; 3] = [10, 20, 30];
@@ -69,8 +63,6 @@ exit_code = 20
 [[case]]
 name = "addr_of_array_last_element"
 spec = ["9.2:1"]
-preview = "unchecked_code"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let arr: [i32; 3] = [10, 20, 30];
@@ -90,8 +82,6 @@ exit_code = 30
 [[case]]
 name = "ptr_to_int_basic"
 spec = ["9.2:1"]
-preview = "unchecked_code"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let x: i32 = 42;
@@ -111,8 +101,6 @@ exit_code = 42
 [[case]]
 name = "ptr_write_and_read"
 spec = ["9.2:1"]
-preview = "unchecked_code"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let mut x: i32 = 10;
@@ -128,8 +116,6 @@ exit_code = 99
 [[case]]
 name = "ptr_write_array_element"
 spec = ["9.2:1"]
-preview = "unchecked_code"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let mut arr: [i32; 3] = [10, 20, 30];

--- a/crates/rue-spec/cases/runtime/syscall.toml
+++ b/crates/rue-spec/cases/runtime/syscall.toml
@@ -8,30 +8,11 @@ id = "runtime.syscall"
 spec_chapter = "9.2"
 name = "Syscall Intrinsic"
 
-# Test that @syscall requires the unchecked_code preview feature
-[[case]]
-name = "syscall_requires_unchecked_preview"
-spec = ["9.2:2", "9.2:3"]
-source = """
-fn main() -> i32 {
-    let syscall_num: u64 = 60;
-    let arg: u64 = 0;
-    checked {
-        @syscall(syscall_num, arg);
-    };
-    0
-}
-"""
-compile_fail = true
-error_contains = "requires preview feature"
-
-# Test that @syscall works with the preview feature enabled (x86-64 Linux)
+# Test that @syscall works (x86-64 Linux)
 # Note: only_on restricts this test to run only on matching host platforms
 [[case]]
 name = "syscall_basic_x86_64"
-spec = ["9.2:1", "9.2:5"]
-preview = "unchecked_code"
-preview_should_pass = true
+spec = ["9.2:1", "9.2:2", "9.2:4"]
 only_on = ["x86-64-linux"]
 source = """
 fn main() -> i32 {
@@ -51,9 +32,7 @@ exit_code = 42
 # Test that @syscall works with the preview feature enabled (aarch64 Linux)
 [[case]]
 name = "syscall_basic_aarch64"
-spec = ["9.2:1", "9.2:5"]
-preview = "unchecked_code"
-preview_should_pass = true
+spec = ["9.2:1", "9.2:4"]
 only_on = ["aarch64-linux"]
 source = """
 fn main() -> i32 {
@@ -73,8 +52,7 @@ exit_code = 42
 # Test that @syscall requires at least one argument (the syscall number)
 [[case]]
 name = "syscall_requires_syscall_number"
-spec = ["9.2:4"]
-preview = "unchecked_code"
+spec = ["9.2:3"]
 source = """
 fn main() -> i32 {
     checked {
@@ -84,13 +62,12 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "wrong number of arguments"
+error_contains = "expects 7 arguments"
 
 # Test that @syscall accepts up to 7 arguments
 [[case]]
 name = "syscall_max_args"
-spec = ["9.2:4"]
-preview = "unchecked_code"
+spec = ["9.2:3"]
 only_on = ["x86-64-linux"]
 source = """
 fn main() -> i32 {
@@ -115,8 +92,7 @@ exit_code = 0
 # Test that @syscall rejects too many arguments
 [[case]]
 name = "syscall_too_many_args"
-spec = ["9.2:4"]
-preview = "unchecked_code"
+spec = ["9.2:3"]
 source = """
 fn main() -> i32 {
     let n: u64 = 60;
@@ -134,13 +110,12 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "wrong number of arguments"
+error_contains = "expects 7 arguments"
 
 # Test that @syscall requires u64 arguments
 [[case]]
 name = "syscall_requires_u64_args"
-spec = ["9.2:4"]
-preview = "unchecked_code"
+spec = ["9.2:3"]
 source = """
 fn main() -> i32 {
     let syscall_num: i32 = 60;  // i32 instead of u64
@@ -152,14 +127,12 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "type mismatch"
+error_contains = "expects u64"
 
 # Test that @syscall returns i64 (using assignment inside block)
 [[case]]
 name = "syscall_returns_i64"
-spec = ["9.2:5"]
-preview = "unchecked_code"
-preview_should_pass = true
+spec = ["9.2:4"]
 only_on = ["x86-64-linux"]
 source = """
 fn main() -> i32 {
@@ -183,9 +156,7 @@ exit_code = 42
 # Test checked block as expression returning syscall result
 [[case]]
 name = "syscall_checked_block_expression"
-spec = ["9.2:5"]
-preview = "unchecked_code"
-preview_should_pass = true
+spec = ["9.2:4"]
 only_on = ["x86-64-linux"]
 source = """
 fn main() -> i32 {

--- a/docs/designs/0028-unsafe-and-raw-pointers.md
+++ b/docs/designs/0028-unsafe-and-raw-pointers.md
@@ -15,7 +15,7 @@ superseded-by:
 
 ## Status
 
-Implemented (under preview feature `unchecked_code`)
+Implemented and stabilized (2026-01-11)
 
 ## Summary
 

--- a/docs/spec/src/09-unchecked-code/01-syntax.md
+++ b/docs/spec/src/09-unchecked-code/01-syntax.md
@@ -14,17 +14,13 @@ This section describes the syntax for unchecked code constructs.
 
 A function **MAY** be marked with the `unchecked` modifier to indicate that calling it requires a `checked` block.
 
-{{ rule(id="9.1:2", cat="legality-rule") }}
-
-The `unchecked` modifier requires the `unchecked_code` preview feature. Using `unchecked` without enabling this feature is a compile-time error.
-
-{{ rule(id="9.1:3", cat="syntax") }}
+{{ rule(id="9.1:2", cat="syntax") }}
 
 ```ebnf
 function = [ "pub" ] [ "unchecked" ] "fn" IDENT "(" [ params ] ")" [ "->" type ] "{" block "}" ;
 ```
 
-{{ rule(id="9.1:4", cat="example") }}
+{{ rule(id="9.1:3", cat="example") }}
 
 ```rue
 unchecked fn dangerous_operation() -> i32 {
@@ -38,21 +34,21 @@ pub unchecked fn public_dangerous() -> i32 {
 
 ## Checked Blocks
 
-{{ rule(id="9.1:5", cat="normative") }}
+{{ rule(id="9.1:4", cat="normative") }}
 
 A `checked` block is an expression that enables unchecked operations within its body.
 
-{{ rule(id="9.1:6", cat="syntax") }}
+{{ rule(id="9.1:5", cat="syntax") }}
 
 ```ebnf
 checked_expr = "checked" "{" block "}" ;
 ```
 
-{{ rule(id="9.1:7", cat="dynamic-semantics") }}
+{{ rule(id="9.1:6", cat="dynamic-semantics") }}
 
 A `checked` block evaluates its body and returns the value of the final expression. The type of a `checked` block is the type of its body expression.
 
-{{ rule(id="9.1:8", cat="example") }}
+{{ rule(id="9.1:7", cat="example") }}
 
 ```rue
 fn main() -> i32 {
@@ -67,23 +63,23 @@ fn main() -> i32 {
 
 ## Raw Pointer Types
 
-{{ rule(id="9.1:9", cat="normative") }}
+{{ rule(id="9.1:8", cat="normative") }}
 
 Rue provides two raw pointer types for low-level memory access:
 - `ptr const T` - a pointer to immutable data of type `T`
 - `ptr mut T` - a pointer to mutable data of type `T`
 
-{{ rule(id="9.1:10", cat="syntax") }}
+{{ rule(id="9.1:9", cat="syntax") }}
 
 ```ebnf
 ptr_type = "ptr" ( "const" | "mut" ) type ;
 ```
 
-{{ rule(id="9.1:11", cat="informative") }}
+{{ rule(id="9.1:10", cat="informative") }}
 
 Raw pointer types are parsed in Phase 1 but semantic analysis (type checking, pointer operations) is implemented in later phases. Until Phase 2 is implemented, using pointer types results in an "unknown type" error.
 
-{{ rule(id="9.1:12", cat="example") }}
+{{ rule(id="9.1:11", cat="example") }}
 
 ```rue
 // These parse correctly but fail type checking until Phase 2

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -14,11 +14,7 @@ This section describes intrinsics that require a checked block.
 
 The `@syscall` intrinsic performs a direct system call to the operating system.
 
-{{ rule(id="9.2:2", cat="legality-rule") }}
-
-The `@syscall` intrinsic requires the `unchecked_code` preview feature. Using `@syscall` without enabling this feature is a compile-time error.
-
-{{ rule(id="9.2:3", cat="syntax") }}
+{{ rule(id="9.2:2", cat="syntax") }}
 
 ```ebnf
 syscall_intrinsic = "@syscall" "(" syscall_number { "," argument } ")" ;
@@ -26,19 +22,19 @@ syscall_number = expression ;
 argument = expression ;
 ```
 
-{{ rule(id="9.2:4", cat="legality-rule") }}
+{{ rule(id="9.2:3", cat="legality-rule") }}
 
 The `@syscall` intrinsic takes at least one argument (the syscall number) and at most seven arguments (syscall number plus six syscall arguments). All arguments must be of type `u64`.
 
-{{ rule(id="9.2:5", cat="dynamic-semantics") }}
+{{ rule(id="9.2:4", cat="dynamic-semantics") }}
 
 The `@syscall` intrinsic returns an `i64` value representing the result of the syscall. On Linux x86-64, negative values typically indicate errors. The exact behavior depends on the syscall being invoked and the platform.
 
-{{ rule(id="9.2:6", cat="informative") }}
+{{ rule(id="9.2:5", cat="informative") }}
 
 Syscall numbers and conventions differ between operating systems. Linux x86-64 syscall numbers are different from macOS aarch64 syscall numbers. Users should consult platform-specific documentation.
 
-{{ rule(id="9.2:7", cat="example") }}
+{{ rule(id="9.2:6", cat="example") }}
 
 ```rue
 fn main() -> i32 {


### PR DESCRIPTION
Remove preview gates and stabilize unchecked functions, checked blocks, and raw pointer types (ptr const T, ptr mut T).

Changes:
- Remove require_preview() gates from pointer intrinsics and @syscall
- Remove preview fields from 26 spec tests
- Remove UncheckedCode from PreviewFeature enum
- Update ADR-0028 status to "Implemented and stabilized"
- Fix error message expectations in syscall tests

All 1339 spec tests passing.