### PR TITLE
Rename pointer intrinsics from @addr_of/@addr_of_mut to @raw/@raw_mut

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -689,8 +689,8 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
-                } else if intrinsic_name == "addr_of" || intrinsic_name == "addr_of_mut" {
-                    // @addr_of / @addr_of_mut: takes a value, returns a pointer to it
+                } else if intrinsic_name == "raw" || intrinsic_name == "raw_mut" {
+                    // @raw / @raw_mut: takes a value, returns a pointer to it
                     // The return type is ptr const T or ptr mut T where T is the argument type.
                     // We create a fresh type variable for proper inference.
                     for arg_ref in args.iter() {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -6024,10 +6024,10 @@ fn analyze_intrinsic_ctx(
             span,
         });
         Ok(AnalysisResult::new(air_ref, result_type))
-    } else if name == known.addr_of || name == known.addr_of_mut {
-        // @addr_of(lvalue) / @addr_of_mut(lvalue) - Take address of lvalue
-        let is_mut = name == known.addr_of_mut;
-        let intrinsic_name = if is_mut { "addr_of_mut" } else { "addr_of" };
+    } else if name == known.raw || name == known.raw_mut {
+        // @raw(lvalue) / @raw_mut(lvalue) - Take address of lvalue
+        let is_mut = name == known.raw_mut;
+        let intrinsic_name = if is_mut { "raw_mut" } else { "raw" };
 
         require_preview_ctx(
             ctx,
@@ -8020,9 +8020,9 @@ impl<'a> Sema<'a> {
             self.analyze_ptr_to_int_intrinsic(air, name, &args, span, ctx)
         } else if name == known.int_to_ptr {
             self.analyze_int_to_ptr_intrinsic(air, name, inst_ref, &args, span, ctx)
-        } else if name == known.addr_of {
+        } else if name == known.raw {
             self.analyze_addr_of_intrinsic(air, &args, span, ctx, false)
-        } else if name == known.addr_of_mut {
+        } else if name == known.raw_mut {
             self.analyze_addr_of_intrinsic(air, &args, span, ctx, true)
         } else if name == known.syscall {
             self.analyze_syscall_intrinsic(air, name, &args, span, ctx)
@@ -10827,9 +10827,9 @@ impl<'a> Sema<'a> {
 
         // Create the intrinsic call instruction
         let name = if is_mut {
-            self.known.addr_of_mut
+            self.known.raw_mut
         } else {
-            self.known.addr_of
+            self.known.raw
         };
         let args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -80,10 +80,10 @@ pub struct KnownSymbols {
     pub ptr_to_int: Spur,
     /// The `int_to_ptr` intrinsic symbol - converts usize to pointer.
     pub int_to_ptr: Spur,
-    /// The `addr_of` intrinsic symbol - takes address of lvalue.
-    pub addr_of: Spur,
-    /// The `addr_of_mut` intrinsic symbol - takes mutable address of lvalue.
-    pub addr_of_mut: Spur,
+    /// The `raw` intrinsic symbol - takes address of lvalue.
+    pub raw: Spur,
+    /// The `raw_mut` intrinsic symbol - takes mutable address of lvalue.
+    pub raw_mut: Spur,
     /// The `syscall` intrinsic symbol - direct OS syscall.
     pub syscall: Spur,
 
@@ -134,8 +134,8 @@ impl KnownSymbols {
             ptr_offset: interner.get_or_intern_static("ptr_offset"),
             ptr_to_int: interner.get_or_intern_static("ptr_to_int"),
             int_to_ptr: interner.get_or_intern_static("int_to_ptr"),
-            addr_of: interner.get_or_intern_static("addr_of"),
-            addr_of_mut: interner.get_or_intern_static("addr_of_mut"),
+            raw: interner.get_or_intern_static("raw"),
+            raw_mut: interner.get_or_intern_static("raw_mut"),
             syscall: interner.get_or_intern_static("syscall"),
 
             // Target platform intrinsics
@@ -202,8 +202,8 @@ mod tests {
         assert_eq!(interner.resolve(&known.ptr_offset), "ptr_offset");
         assert_eq!(interner.resolve(&known.ptr_to_int), "ptr_to_int");
         assert_eq!(interner.resolve(&known.int_to_ptr), "int_to_ptr");
-        assert_eq!(interner.resolve(&known.addr_of), "addr_of");
-        assert_eq!(interner.resolve(&known.addr_of_mut), "addr_of_mut");
+        assert_eq!(interner.resolve(&known.raw), "raw");
+        assert_eq!(interner.resolve(&known.raw_mut), "raw_mut");
         assert_eq!(interner.resolve(&known.syscall), "syscall");
         assert_eq!(interner.resolve(&known.target_arch), "target_arch");
         assert_eq!(interner.resolve(&known.target_os), "target_os");

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2269,8 +2269,8 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(addr_vreg),
                     });
                     self.value_map.insert(value, result_vreg);
-                } else if name_str == "addr_of" || name_str == "addr_of_mut" {
-                    // @addr_of(lvalue) / @addr_of_mut(lvalue) - Take address of a value
+                } else if name_str == "raw" || name_str == "raw_mut" {
+                    // @raw(lvalue) / @raw_mut(lvalue) - Take address of a value
                     // The argument should be a local variable, and we compute its stack address.
                     let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                     let lvalue_val = args[0];
@@ -4232,7 +4232,7 @@ impl<'a> CfgLower<'a> {
         total_offset_vreg.expect("compute_index_offset called with empty levels")
     }
 
-    /// Compute the address of a place (for @addr_of intrinsic).
+    /// Compute the address of a place (for @raw intrinsic).
     ///
     /// This is similar to lower_place_read but returns the address instead of loading.
     fn lower_place_addr(&mut self, dst: VReg, place: &Place) {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2384,8 +2384,8 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(addr_vreg),
                     });
                     self.value_map.insert(value, result_vreg);
-                } else if name_str == "addr_of" || name_str == "addr_of_mut" {
-                    // @addr_of(lvalue) / @addr_of_mut(lvalue) - Take address of a value
+                } else if name_str == "raw" || name_str == "raw_mut" {
+                    // @raw(lvalue) / @raw_mut(lvalue) - Take address of a value
                     // The argument should be a local variable, and we compute its stack address.
                     let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                     let lvalue_val = args[0];
@@ -2406,7 +2406,7 @@ impl<'a> CfgLower<'a> {
                         });
                         self.value_map.insert(value, result_vreg);
                     } else if let CfgInstData::PlaceRead { place } = &lvalue_inst.data {
-                        // ADR-0030: Handle PlaceRead for @addr_of
+                        // ADR-0030: Handle PlaceRead for @raw
                         // Compute the address of the place instead of reading from it
                         let result_vreg = self.mir.alloc_vreg();
                         self.lower_place_addr(result_vreg, place);
@@ -4144,7 +4144,7 @@ impl<'a> CfgLower<'a> {
         total_offset_vreg.expect("compute_index_offset called with empty levels")
     }
 
-    /// Compute the address of a place (for @addr_of intrinsic).
+    /// Compute the address of a place (for @raw intrinsic).
     ///
     /// This is similar to lower_place_read but returns the address instead of loading.
     fn lower_place_addr(&mut self, dst: VReg, place: &Place) {

--- a/crates/rue-spec/cases/runtime/pointers.toml
+++ b/crates/rue-spec/cases/runtime/pointers.toml
@@ -7,21 +7,21 @@
 id = "runtime.pointers"
 spec_chapter = "9.2"
 name = "Pointer Intrinsics"
-description = "Tests for pointer intrinsics (@addr_of, @ptr_read, @ptr_write, etc.)"
+description = "Tests for pointer intrinsics (@raw, @ptr_read, @ptr_write, etc.)"
 
 # =============================================================================
-# @addr_of with simple local variable
+# @raw with simple local variable
 # =============================================================================
 
 [[case]]
-name = "addr_of_simple_local"
+name = "raw_simple_local"
 spec = ["9.2:1"]
 preview = "unchecked_code"
 preview_should_pass = true
 source = """
 fn main() -> i32 {
     let x: i32 = 42;
-    let p: ptr const i32 = checked { @addr_of(x) };
+    let p: ptr const i32 = checked { @raw(x) };
     let val: i32 = checked { @ptr_read(p) };
     val
 }
@@ -29,11 +29,11 @@ fn main() -> i32 {
 exit_code = 42
 
 # =============================================================================
-# @addr_of with array element (the bug fix this was added for)
+# @raw with array element (the bug fix this was added for)
 # =============================================================================
 
 [[case]]
-name = "addr_of_array_element"
+name = "raw_array_element"
 spec = ["9.2:1"]
 preview = "unchecked_code"
 preview_should_pass = true
@@ -41,7 +41,7 @@ source = """
 fn main() -> i32 {
     let arr: [i32; 3] = [10, 20, 30];
     let first: i32 = checked {
-        let p: ptr const i32 = @addr_of(arr[0]);
+        let p: ptr const i32 = @raw(arr[0]);
         @ptr_read(p)
     };
     first
@@ -50,7 +50,7 @@ fn main() -> i32 {
 exit_code = 10
 
 [[case]]
-name = "addr_of_array_second_element"
+name = "raw_array_second_element"
 spec = ["9.2:1"]
 preview = "unchecked_code"
 preview_should_pass = true
@@ -58,7 +58,7 @@ source = """
 fn main() -> i32 {
     let arr: [i32; 3] = [10, 20, 30];
     let second: i32 = checked {
-        let p: ptr const i32 = @addr_of(arr[1]);
+        let p: ptr const i32 = @raw(arr[1]);
         @ptr_read(p)
     };
     second
@@ -67,7 +67,7 @@ fn main() -> i32 {
 exit_code = 20
 
 [[case]]
-name = "addr_of_array_last_element"
+name = "raw_array_last_element"
 spec = ["9.2:1"]
 preview = "unchecked_code"
 preview_should_pass = true
@@ -75,7 +75,7 @@ source = """
 fn main() -> i32 {
     let arr: [i32; 3] = [10, 20, 30];
     let third: i32 = checked {
-        let p: ptr const i32 = @addr_of(arr[2]);
+        let p: ptr const i32 = @raw(arr[2]);
         @ptr_read(p)
     };
     third
@@ -95,7 +95,7 @@ preview_should_pass = true
 source = """
 fn main() -> i32 {
     let x: i32 = 42;
-    let p: ptr const i32 = checked { @addr_of(x) };
+    let p: ptr const i32 = checked { @raw(x) };
     let addr: u64 = checked { @ptr_to_int(p) };
     // Stack addresses are high values, should be > 1000
     let threshold: u64 = 1000;
@@ -117,7 +117,7 @@ source = """
 fn main() -> i32 {
     let mut x: i32 = 10;
     checked {
-        let p: ptr mut i32 = @addr_of_mut(x);
+        let p: ptr mut i32 = @raw_mut(x);
         @ptr_write(p, 99);
     };
     x
@@ -134,7 +134,7 @@ source = """
 fn main() -> i32 {
     let mut arr: [i32; 3] = [10, 20, 30];
     checked {
-        let p: ptr mut i32 = @addr_of_mut(arr[1]);
+        let p: ptr mut i32 = @raw_mut(arr[1]);
         @ptr_write(p, 77);
     };
     arr[1]


### PR DESCRIPTION
ADR-0028 documented the intrinsics as @raw and @raw_mut, but the implementation used @addr_of and @addr_of_mut. This mismatch caused confusion when trying to use the feature.

This commit renames the intrinsics throughout the codebase to match the ADR documentation:

- Updated known_symbols.rs to intern 'raw' and 'raw_mut'
- Updated semantic analysis to recognize the new names
- Updated both x86_64 and aarch64 codegen backends
- Updated all spec tests to use @raw/@raw_mut
- Updated test names for consistency

All tests pass, including unit tests, spec tests, and traceability checks. Fixes rue-ic9q.

🤖 Generated with [Claude Code](https://claude.com/claude-code)