### PR TITLE
Fix @int_to_ptr type inference with explicit pointer types (rue-d2ym)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -9,8 +9,9 @@
 use super::constraint::Constraint;
 use super::types::{InferType, TypeVarAllocator, TypeVarId};
 use crate::Type;
+use crate::intern_pool::TypeInternPool;
 use crate::scope::ScopedContext;
-use crate::types::{StructId, parse_array_type_syntax};
+use crate::types::{PtrMutability, StructId, parse_array_type_syntax, parse_pointer_type_syntax};
 use lasso::{Spur, ThreadedRodeo};
 use rue_rir::{InstData, InstRef, Rir};
 use rue_span::Span;
@@ -160,6 +161,8 @@ pub struct ConstraintGenerator<'a> {
     /// Type substitutions for Self and type parameters (used in method bodies).
     /// Maps type names (like "Self") to their concrete types.
     type_subst: Option<&'a HashMap<Spur, Type>>,
+    /// Type intern pool for creating pointer and array types during constraint generation.
+    type_pool: &'a TypeInternPool,
 }
 
 impl<'a> ConstraintGenerator<'a> {
@@ -171,8 +174,11 @@ impl<'a> ConstraintGenerator<'a> {
         structs: &'a HashMap<Spur, Type>,
         enums: &'a HashMap<Spur, Type>,
         methods: &'a HashMap<(StructId, Spur), MethodSig>,
+        type_pool: &'a TypeInternPool,
     ) -> Self {
-        Self::with_type_subst(rir, interner, functions, structs, enums, methods, None)
+        Self::with_type_subst(
+            rir, interner, functions, structs, enums, methods, type_pool, None,
+        )
     }
 
     /// Create a new constraint generator with type substitutions.
@@ -188,6 +194,7 @@ impl<'a> ConstraintGenerator<'a> {
         structs: &'a HashMap<Spur, Type>,
         enums: &'a HashMap<Spur, Type>,
         methods: &'a HashMap<(StructId, Spur), MethodSig>,
+        type_pool: &'a TypeInternPool,
         type_subst: Option<&'a HashMap<Spur, Type>>,
     ) -> Self {
         Self {
@@ -202,6 +209,7 @@ impl<'a> ConstraintGenerator<'a> {
             methods,
             int_literal_vars: Vec::new(),
             type_subst,
+            type_pool,
         }
     }
 
@@ -1236,7 +1244,8 @@ impl<'a> ConstraintGenerator<'a> {
 
     /// Resolve a type name to an InferType.
     ///
-    /// Handles primitive types, array syntax `[T; N]`, and struct/enum types.
+    /// Handles primitive types, array syntax `[T; N]`, pointer syntax `ptr mut T` / `ptr const T`,
+    /// and struct/enum types.
     fn resolve_type_name(&self, name: &str) -> Option<InferType> {
         // Check for array syntax first: [T; N]
         if let Some((element_type_str, length)) = parse_array_type_syntax(name) {
@@ -1246,6 +1255,32 @@ impl<'a> ConstraintGenerator<'a> {
                 element: Box::new(element_ty),
                 length,
             });
+        }
+
+        // Check for pointer syntax: ptr mut T / ptr const T
+        if let Some((pointee_type_str, mutability)) = parse_pointer_type_syntax(name) {
+            // Recursively resolve the pointee type
+            let pointee_infer_ty = self.resolve_type_name(&pointee_type_str)?;
+
+            // Convert InferType to Type so we can intern the pointer
+            let pointee_ty = match pointee_infer_ty {
+                InferType::Concrete(ty) => ty,
+                // Can't handle non-concrete types in pointer positions during constraint generation
+                _ => return None,
+            };
+
+            // Intern the pointer type
+            let ptr_ty = match mutability {
+                PtrMutability::Mut => {
+                    let ptr_id = self.type_pool.intern_ptr_mut_from_type(pointee_ty);
+                    Type::new_ptr_mut(ptr_id)
+                }
+                PtrMutability::Const => {
+                    let ptr_id = self.type_pool.intern_ptr_const_from_type(pointee_ty);
+                    Type::new_ptr_const(ptr_id)
+                }
+            };
+            return Some(InferType::Concrete(ptr_ty));
         }
 
         // Check primitives
@@ -1282,16 +1317,17 @@ mod tests {
     use super::*;
     use lasso::ThreadedRodeo;
 
-    /// Helper to create a minimal RIR for testing.
-    fn make_test_rir_and_interner() -> (Rir, ThreadedRodeo) {
+    /// Helper to create a minimal RIR, interner, and type pool for testing.
+    fn make_test_rir_interner_and_type_pool() -> (Rir, ThreadedRodeo, TypeInternPool) {
         let rir = Rir::new();
         let interner = ThreadedRodeo::new();
-        (rir, interner)
+        let type_pool = TypeInternPool::new();
+        (rir, interner, type_pool)
     }
 
     #[test]
     fn test_constraint_generator_int_literal() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1303,8 +1339,9 @@ mod tests {
             span: Span::new(0, 2),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -1320,7 +1357,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_bool_literal() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1331,8 +1368,9 @@ mod tests {
             span: Span::new(0, 4),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::BOOL);
 
@@ -1344,7 +1382,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_binary_add() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1364,8 +1402,9 @@ mod tests {
             span: Span::new(0, 5),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -1384,7 +1423,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_comparison() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1404,8 +1443,9 @@ mod tests {
             span: Span::new(0, 5),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::BOOL);
 
@@ -1419,7 +1459,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_logical_and() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1439,8 +1479,9 @@ mod tests {
             span: Span::new(0, 13),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::BOOL);
 
@@ -1454,7 +1495,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_negation() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1470,8 +1511,9 @@ mod tests {
             span: Span::new(0, 3),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -1490,7 +1532,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_return() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1506,8 +1548,9 @@ mod tests {
             span: Span::new(0, 9),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -1521,7 +1564,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_if_else() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1549,8 +1592,9 @@ mod tests {
             span: Span::new(0, 25),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -1564,7 +1608,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_while_loop() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1584,8 +1628,9 @@ mod tests {
             span: Span::new(0, 15),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
@@ -1675,7 +1720,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_infinite_loop() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1691,8 +1736,9 @@ mod tests {
             span: Span::new(0, 10),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
@@ -1706,7 +1752,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_break_continue() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1717,8 +1763,9 @@ mod tests {
             span: Span::new(0, 5),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
@@ -1731,7 +1778,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_index_get() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1751,8 +1798,9 @@ mod tests {
             span: Span::new(0, 6),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -1770,7 +1818,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_index_set() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1794,8 +1842,9 @@ mod tests {
             span: Span::new(0, 11),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
@@ -1813,7 +1862,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_empty_block() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1828,8 +1877,9 @@ mod tests {
             span: Span::new(0, 2),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::UNIT);
 
@@ -1842,7 +1892,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_bitwise_not() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1858,8 +1908,9 @@ mod tests {
             span: Span::new(0, 3),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -1877,7 +1928,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_function_call_arg_count_mismatch() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let mut functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1914,8 +1965,9 @@ mod tests {
             span: Span::new(0, 7),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::BOOL);
 
@@ -1929,7 +1981,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_unknown_function() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new(); // Empty - no functions registered
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -1954,8 +2006,9 @@ mod tests {
             span: Span::new(0, 11),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 
@@ -1969,7 +2022,7 @@ mod tests {
 
     #[test]
     fn test_constraint_generator_match_multiple_arms() {
-        let (mut rir, interner) = make_test_rir_and_interner();
+        let (mut rir, interner, type_pool) = make_test_rir_interner_and_type_pool();
         let functions = HashMap::new();
         let structs = HashMap::new();
         let enums = HashMap::new();
@@ -2013,8 +2066,9 @@ mod tests {
             span: Span::new(0, 40),
         });
 
-        let mut cgen =
-            ConstraintGenerator::new(&rir, &interner, &functions, &structs, &enums, &methods);
+        let mut cgen = ConstraintGenerator::new(
+            &rir, &interner, &functions, &structs, &enums, &methods, &type_pool,
+        );
         let params = HashMap::new();
         let mut ctx = ConstraintContext::new(&params, Type::I32);
 

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1437,6 +1437,7 @@ fn run_type_inference_with_context(
         &ctx.inference_ctx.struct_types,
         &ctx.inference_ctx.enum_types,
         &ctx.inference_ctx.method_sigs,
+        &ctx.type_pool,
     );
 
     // Build parameter map for constraint context.
@@ -6641,6 +6642,7 @@ impl<'a> Sema<'a> {
             &infer_ctx.struct_types,
             &infer_ctx.enum_types,
             &infer_ctx.method_sigs,
+            &self.type_pool,
             type_subst,
         );
 

--- a/crates/rue-spec/cases/items/unchecked.toml
+++ b/crates/rue-spec/cases/items/unchecked.toml
@@ -1,12 +1,11 @@
-# Unchecked Code and Raw Pointers - Phase 1: Parser Support
+# Unchecked Code and Raw Pointers
 #
 # This tests the syntax support for:
 # - `unchecked fn` modifier
 # - `checked { }` block expressions
 # - `ptr const T` and `ptr mut T` type syntax
 #
-# Note: These tests use the unchecked_code preview feature and are expected
-# to pass for Phase 1 (parsing). Later phases will add semantic analysis.
+# These features are now part of the language and do not require a preview feature.
 
 [section]
 id = "items.unchecked"

--- a/crates/rue-spec/cases/runtime/pointers.toml
+++ b/crates/rue-spec/cases/runtime/pointers.toml
@@ -1,7 +1,7 @@
 # Pointer Intrinsic Tests
 #
-# Tests for pointer intrinsics that require the unchecked_code preview feature.
-# These intrinsics operate on raw pointers for low-level memory access.
+# Tests for pointer intrinsics that operate on raw pointers for low-level memory access.
+# These intrinsics must be used within `checked` blocks.
 
 [section]
 id = "runtime.pointers"
@@ -127,3 +127,57 @@ fn main() -> i32 {
 }
 """
 exit_code = 77
+
+# =============================================================================
+# @int_to_ptr converts u64 address to pointer with explicit type annotation
+# =============================================================================
+
+[[case]]
+name = "int_to_ptr_with_type_annotation"
+spec = ["9.2:1"]
+source = """
+fn main() -> i32 {
+    let x: i32 = 42;
+    let p1: ptr const i32 = checked { @raw(x) };
+    let addr: u64 = checked { @ptr_to_int(p1) };
+    // Convert address back to pointer with explicit type annotation
+    let p2: ptr mut i32 = checked { @int_to_ptr(addr) };
+    let val: i32 = checked { @ptr_read(p2) };
+    val
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "int_to_ptr_mutable_pointer"
+spec = ["9.2:1"]
+source = """
+fn main() -> i32 {
+    let x: i32 = 99;
+    let p1: ptr const i32 = checked { @raw(x) };
+    let addr: u64 = checked { @ptr_to_int(p1) };
+    // Convert to ptr mut (even from a const pointer address)
+    // This is allowed because int_to_ptr assumes you know what you're doing
+    let p2: ptr mut i32 = checked { @int_to_ptr(addr) };
+    let val: i32 = checked { @ptr_read(p2) };
+    val
+}
+"""
+exit_code = 99
+
+[[case]]
+name = "int_to_ptr_u64_pointer"
+spec = ["9.2:1"]
+source = """
+fn main() -> i32 {
+    let x: u64 = 12345;
+    let p1: ptr const u64 = checked { @raw(x) };
+    let addr: u64 = checked { @ptr_to_int(p1) };
+    // Convert to ptr mut u64
+    let p2: ptr mut u64 = checked { @int_to_ptr(addr) };
+    let val: u64 = checked { @ptr_read(p2) };
+    // Return i32 conversion for exit code
+    @intCast(val)
+}
+"""
+exit_code = 57  # 12345 % 256 = 57

--- a/crates/rue-spec/cases/runtime/syscall.toml
+++ b/crates/rue-spec/cases/runtime/syscall.toml
@@ -1,7 +1,7 @@
 # Syscall Intrinsic Tests
 #
 # These tests verify the @syscall intrinsic, which performs direct OS syscalls.
-# The intrinsic requires the unchecked_code preview feature and a checked block.
+# The intrinsic must be used within a checked block.
 
 [section]
 id = "runtime.syscall"


### PR DESCRIPTION
The @int_to_ptr intrinsic was failing type inference when used with explicit type annotations like 'let p: ptr mut u64 = @int_to_ptr(addr)'. This blocked stdlib implementation which needs to cast addresses to typed pointers.

Root cause: ConstraintGenerator's resolve_type_name() could parse array syntax '[T; N]' but not pointer syntax 'ptr mut T' / 'ptr const T'. When a let binding had an explicit pointer type annotation, the constraint generator couldn't resolve it, leaving the intrinsic's return type unconstrained.

Fix:
- Add parse_pointer_type_syntax parsing to resolve_type_name()
- Pass TypeInternPool to ConstraintGenerator so it can intern pointer types
- Update all call sites to provide type pool reference

Tests:
- Added 3 spec tests in runtime/pointers.toml covering @int_to_ptr with type annotations for ptr mut i32, ptr mut u64 cases
- All existing tests pass

Closes rue-d2ym

🤖 Generated with [Claude Code](https://claude.com/claude-code)