### PR TITLE
Optimize VariableMoveState, update ADR-0029, add examples

### DIFF
--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -39,23 +39,23 @@ pub(crate) type FieldPath = Vec<Spur>;
 pub(crate) struct VariableMoveState {
     /// If Some, the entire variable has been fully moved at this span.
     pub full_move: Option<Span>,
-    /// Partial moves: maps field paths to the span where they were moved.
+    /// Partial moves: field paths paired with the span where they were moved.
     /// For example, if `s.a` was moved, this contains ([sym("a")], span).
-    pub partial_moves: HashMap<FieldPath, Span>,
+    /// Uses Vec instead of HashMap for 3-6x faster lookups on small collections
+    /// (typically 0-5 partial moves per variable). See ADR-0032.
+    pub partial_moves: Vec<(FieldPath, Span)>,
 }
 
 impl VariableMoveState {
     /// Mark a field path as moved.
     pub fn mark_path_moved(&mut self, path: &[Spur], span: Span) {
         if path.is_empty() {
-            // Moving the whole variable
             self.full_move = Some(span);
-            // Clear partial moves since the whole thing is moved
             self.partial_moves.clear();
-        } else {
-            // Partial move - only if not already fully moved
-            if self.full_move.is_none() {
-                self.partial_moves.insert(path.to_vec(), span);
+        } else if self.full_move.is_none() {
+            // Only add if not already present (preserve first move span)
+            if !self.partial_moves.iter().any(|(p, _)| p.as_slice() == path) {
+                self.partial_moves.push((path.to_vec(), span));
             }
         }
     }
@@ -63,20 +63,14 @@ impl VariableMoveState {
     /// Check if a field path is moved.
     /// Returns Some(span) if the path (or any ancestor) is moved.
     pub fn is_path_moved(&self, path: &[Spur]) -> Option<Span> {
-        // If fully moved, everything is moved
         if let Some(span) = self.full_move {
             return Some(span);
         }
 
-        // Check if this exact path is moved
-        if let Some(span) = self.partial_moves.get(path) {
-            return Some(*span);
-        }
-
-        // Check if any prefix (ancestor) of this path is moved
-        // e.g., if s.a is moved, then s.a.b is also considered moved
-        for len in 1..path.len() {
-            if let Some(span) = self.partial_moves.get(&path[..len]) {
+        let path_len = path.len();
+        for (stored_path, span) in &self.partial_moves {
+            let stored_len = stored_path.len();
+            if stored_len <= path_len && path[..stored_len] == stored_path[..] {
                 return Some(*span);
             }
         }
@@ -90,7 +84,7 @@ impl VariableMoveState {
         if let Some(span) = self.full_move {
             return Some(span);
         }
-        self.partial_moves.values().next().copied()
+        self.partial_moves.first().map(|(_, s)| *s)
     }
 
     /// Check if the variable has any move state.
@@ -102,20 +96,16 @@ impl VariableMoveState {
     /// A variable is considered moved after a branch if it was moved in EITHER branch.
     /// This prevents use-after-move when a value might have been moved.
     pub fn merge_union(branch1: &Self, branch2: &Self) -> Self {
-        // If either branch has a full move, the result is a full move
-        // (use the span from whichever branch has it, preferring branch1)
         let full_move = branch1.full_move.or(branch2.full_move);
 
-        // A partial move is kept if it appears in EITHER branch
         let mut partial_moves = branch1.partial_moves.clone();
         for (path, span) in &branch2.partial_moves {
-            partial_moves.entry(path.clone()).or_insert(*span);
+            if !partial_moves.iter().any(|(p, _)| p == path) {
+                partial_moves.push((path.clone(), *span));
+            }
         }
 
-        Self {
-            full_move,
-            partial_moves,
-        }
+        Self { full_move, partial_moves }
     }
 }
 

--- a/docs/designs/0029-anonymous-struct-methods.md
+++ b/docs/designs/0029-anonymous-struct-methods.md
@@ -1,13 +1,13 @@
 ---
 id: 0029
 title: Anonymous Struct Methods (Zig-Style)
-status: proposal
+status: implemented
 tags: [types, methods, comptime, generics]
 feature-flag: anon_struct_methods
 created: 2026-01-03
-accepted:
-implemented:
-spec-sections: []
+accepted: 2026-01-10
+implemented: 2026-01-17
+spec-sections: ["4.14:10", "4.14:11", "4.14:12", "4.14:13", "4.14:14", "4.14:15"]
 superseded-by:
 ---
 
@@ -15,7 +15,7 @@ superseded-by:
 
 ## Status
 
-Proposal
+Implemented (preview feature: `anon_struct_methods`)
 
 ## Summary
 
@@ -45,8 +45,8 @@ This severely limits the usefulness of comptime type construction for building g
 
 - **Named struct methods (ADR-0009)**: Fully implemented via `impl` blocks
 - **Comptime Phase 1-3 (ADR-0025)**: Implemented - type parameters and monomorphization work
-- **Comptime Phase 4**: Anonymous structs can be created and instantiated, but cannot have methods
-- **Method lookup**: Uses `(struct_name_symbol, method_name_symbol)` key, which doesn't work for anonymous structs with generated names like `__anon_struct_<id>`
+- **Comptime Phase 4**: Anonymous structs can be created and instantiated
+- **Anonymous struct methods**: Fully implemented (this ADR) - methods can be defined inline, `Self` resolves correctly, structural equality includes method signatures
 
 ### Alternatives Considered
 
@@ -222,18 +222,22 @@ Epic: rue-nj40
 
 **Deliverable**: RIR correctly represents anonymous structs with methods.
 
-### Phase 3: Semantic Analysis (rue-nj40.3) 🔶
+### Phase 3: Semantic Analysis (rue-nj40.3) ✅
 
 - [x] Change method lookup key from `(Spur, Spur)` to `(StructId, Spur)`
 - [x] Register methods when creating anonymous struct types
 - [x] Resolve `Self` to the anonymous struct's `StructId` (in signatures only)
 - [x] Handle `Type::function()` call syntax for comptime type variables (rue-ybbz)
-- [ ] Update structural equality to include method signatures
-- [ ] Handle comptime parameter capture in method bodies
+- [x] Update structural equality to include method signatures
+- [x] Handle comptime parameter capture in method bodies
 - [x] Analyze method bodies with `self` in scope
 - [x] Resolve `Self` in method body expressions (rue-h6zn)
 
-**Status**: Most items complete. Method registration, `self` in method bodies, associated function calls on comptime type variables (`P::constant()`), and `Self` type resolution all work. Remaining: structural equality with methods, comptime parameter capture.
+**Status**: Complete. All semantic analysis features implemented:
+- Method lookup via `(StructId, Spur)` key in `sema/mod.rs`
+- Structural equality includes method signatures in `sema/anon_structs.rs`
+- Comptime parameter capture tracked via `anon_struct_captured_values` HashMap
+- Tests verify structural equality with methods (spec 4.14:15)
 
 **Deliverable**: `v.push(42)` compiles when `v` is an anonymous struct type with a `push` method.
 

--- a/examples/prime_factors.rue
+++ b/examples/prime_factors.rue
@@ -1,0 +1,39 @@
+// Prime Factorization
+//
+// Finds all prime factors of a number using trial division.
+// Demonstrates loops, conditionals, and integer arithmetic.
+
+fn is_divisible(n: i32, d: i32) -> bool {
+    n % d == 0
+}
+
+fn factorize(n: i32) -> i32 {
+    let mut num = n;
+    let mut count = 0;
+    let mut divisor = 2;
+
+    @dbg(n);
+
+    while divisor * divisor <= num {
+        while is_divisible(num, divisor) {
+            @dbg(divisor);
+            num = num / divisor;
+            count = count + 1;
+        }
+        divisor = divisor + 1;
+    }
+
+    if num > 1 {
+        @dbg(num);
+        count = count + 1;
+    }
+
+    count
+}
+
+fn main() -> i32 {
+    let n = 360;
+    let count = factorize(n);
+    @dbg(count);
+    0
+}

--- a/examples/vector2d.rue
+++ b/examples/vector2d.rue
@@ -1,0 +1,60 @@
+// 2D Vector Math
+//
+// Demonstrates structs with inline methods and basic vector operations.
+// Uses @copy since Vec2 contains only primitive Copy types (i32).
+
+@copy
+struct Vec2 {
+    x: i32,
+    y: i32,
+
+    fn new(x: i32, y: i32) -> Self {
+        Vec2 { x: x, y: y }
+    }
+
+    fn add(self, other: Vec2) -> Vec2 {
+        Vec2::new(self.x + other.x, self.y + other.y)
+    }
+
+    fn sub(self, other: Vec2) -> Vec2 {
+        Vec2::new(self.x - other.x, self.y - other.y)
+    }
+
+    fn scale(self, factor: i32) -> Vec2 {
+        Vec2::new(self.x * factor, self.y * factor)
+    }
+
+    fn dot(self, other: Vec2) -> i32 {
+        self.x * other.x + self.y * other.y
+    }
+
+    fn magnitude_squared(self) -> i32 {
+        self.dot(self)
+    }
+}
+
+fn print_vec(name: i32, v: Vec2) {
+    @dbg(name);
+    @dbg(v.x);
+    @dbg(v.y);
+}
+
+fn main() -> i32 {
+    let a = Vec2::new(3, 4);
+    let b = Vec2::new(1, 2);
+
+    let sum = a.add(b);
+    print_vec(1, sum);
+
+    let diff = a.sub(b);
+    print_vec(2, diff);
+
+    let scaled = a.scale(2);
+    print_vec(3, scaled);
+
+    let dot_product = a.dot(b);
+    @dbg(dot_product);
+
+    let mag_sq = a.magnitude_squared();
+    mag_sq
+}


### PR DESCRIPTION
## Summary

- **Optimize**: Convert `VariableMoveState.partial_moves` from `HashMap` to `Vec` per ADR-0032
  - Single-pass prefix checking in `is_path_moved` (O(n) vs O(n×depth))
  - 3-6x faster lookups for typical workloads (0-5 partial moves)
- **Update ADR-0029**: Mark anonymous struct methods as implemented
- **Add examples**: `prime_factors.rue` and `vector2d.rue`

## Changes

| Commit | Description |
|--------|-------------|
| 1 | HashMap→Vec optimization with single-pass algorithm |
| 2 | ADR-0029 status: proposal → implemented |
| 3 | Two working example programs |

## Testing

- All 1341 spec tests pass
- All unit tests pass
- Examples compile and run correctly