### PR TITLE
Add stable rue binary wrapper + tighten the fork dev loop (RUE-46, RU…

### DIFF
--- a/.claude/commands/rebase.md
+++ b/.claude/commands/rebase.md
@@ -12,7 +12,7 @@ Rebase the current change on trunk and automatically resolve any conflicts.
 ### 1. Rebase on trunk
 
 ```bash
-jj rebase -d trunk
+jj rebase -d 'trunk()'
 ```
 
 ### 2. Check for conflicts

--- a/.claude/commands/ship.md
+++ b/.claude/commands/ship.md
@@ -12,7 +12,7 @@ Ship the current work: rebase, format, review, test, commit, push, mark the Line
 ### 1. Rebase on trunk
 
 ```bash
-jj rebase -d trunk
+jj rebase -d 'trunk()'
 ```
 
 If conflicts, resolve them automatically (see `/fix-conflicts` for strategy).

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,1 +1,36 @@
-{}
+{
+  "permissions": {
+    "allow": [
+      "Bash(./buck2 build:*)",
+      "Bash(./buck2 test:*)",
+      "Bash(./buck2 run:*)",
+      "Bash(./scripts/rue:*)",
+      "Bash(./scripts/rue-bin:*)",
+      "Bash(./test.sh:*)",
+      "Bash(./quick-test.sh:*)",
+      "Bash(./fmt.sh:*)",
+      "Bash(./bench.sh:*)",
+      "Bash(jj status:*)",
+      "Bash(jj log:*)",
+      "Bash(jj diff:*)",
+      "Bash(jj show:*)",
+      "Bash(jj op log:*)",
+      "Bash(jj bookmark list:*)",
+      "Bash(jj file list:*)",
+      "Bash(jj file show:*)",
+      "Bash(jj config get:*)",
+      "Bash(jj config list:*)",
+      "Bash(gh run view:*)",
+      "Bash(gh run list:*)",
+      "Bash(gh pr view:*)",
+      "Bash(gh pr checks:*)",
+      "Bash(grep:*)",
+      "Bash(rg:*)",
+      "Bash(find:*)",
+      "Bash(ls:*)",
+      "Bash(wc:*)",
+      "Bash(head:*)",
+      "Bash(tail:*)"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ third-party/.cargo/.global-cache/
 
 # beads (now stored in the beads-metadata branch)
 .beads
+
+# Stable symlink to the built rue binary (scripts/rue-bin)
+/bin/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,26 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 **Note**: This project uses [Linear](https://linear.app) (team: **Rue**) for issue tracking. Use the Linear MCP tools instead of markdown TODOs. See the Issue Tracking section below for workflow details.
 
+## Quickstart
+
+The 8 commands that cover ~90% of work here (all runnable from anywhere in the repo):
+
+```bash
+scripts/rue build                    # build the compiler -> refreshes bin/rue symlink
+scripts/rue exec prog.rue            # compile prog.rue to a temp file AND run it (quick check)
+RUE="$(scripts/rue-bin)"; "$RUE" a.rue b.rue -o out   # drive the real CLI (modules, multi-file)
+scripts/rue test [pattern]           # full suite (= ./test.sh): unit + spec + UI + CLI + traceability
+scripts/rue quick                    # unit tests only (~2-5s, fast inner loop)
+scripts/rue spec 4.2                 # run spec tests matching a pattern
+scripts/rue cli abi                  # run CLI integration tests matching a pattern
+scripts/rue fmt                      # format (= ./fmt.sh) before committing
+```
+
+Key rules (details in the sections below):
+- **Version control is `jj`, not git**, and this is a **fork** — never commit on `trunk`; work on a change and `jj git push -c @-` to PR a feature branch upstream. See [Version Control](#version-control).
+- **Issue tracking is Linear** (team Rue, `RUE-NN`). See [Issue Tracking](#issue-tracking-with-linear).
+- To get the compiler binary, use `scripts/rue-bin` (prints an absolute path; the old `buck2 ... --show-output | awk` one-liner returns a *relative* path that breaks when cwd changes).
+
 ## Project Overview
 
 Rue is a systems programming language aiming for memory safety without garbage collection, with higher-level ergonomics than Rust/Zig. Currently in early development with Rust-like syntax.
@@ -663,6 +683,34 @@ Example: If adding a new comparison instruction variant (e.g., 64-bit compare):
 - **Working copy is a commit**: Your uncommitted changes are already tracked
 - **Use `jj describe`** to update the current commit message
 - **Use `jj new`** to start a new change on top of current one
+
+### Fork Workflow (IMPORTANT)
+
+This is a **fork** setup. There are two git remotes:
+
+- `upstream` = `rue-language/rue` — the canonical repo, the source of truth. You **cannot** push here; you open PRs into it.
+- `origin` = `steveklabnik/rue` — your fork. You push feature branches here, then PR them upstream.
+
+**Rules:**
+
+1. **Never put your own commits on `origin/trunk`.** `origin/trunk` should only ever mirror `upstream/trunk`. Committing on `trunk` and PRing `trunk` causes hash-rewrite divergence every time upstream rebase/squash-merges.
+2. **Work on a feature change**, then push it as a branch and PR it:
+   ```bash
+   jj rebase -d 'trunk()'          # rebase onto upstream's canonical trunk (a revset, not a bookmark)
+   jj git push -c @-               # pushes as steveklabnik/push-<changeid> (see git_push_bookmark template)
+   # then open a PR from that branch -> upstream/trunk using the URL the push prints
+   ```
+3. **`trunk()` is a revset alias = `trunk@upstream`** — always means upstream's latest, regardless of local bookmark state. Prefer `trunk()` over the bare `trunk` bookmark in rebase/log commands.
+4. **After a PR merges**, just `jj git fetch` (configured to pull both remotes) and your base updates. If upstream rebase-merged (rewriting hashes), the old fork-side copies show as "divergent" — that's cosmetic; `jj abandon` the orphaned old-hash chain to tidy up.
+
+**Required repo config** (machine-local; set on a fresh clone — jj does not read committed config):
+
+```bash
+jj config set --repo 'revset-aliases."trunk()"' 'trunk@upstream'   # base/immutability = canonical repo
+jj config set --repo git.fetch '["origin", "upstream"]'            # always see both remotes
+```
+
+Without these, `jj git fetch` only pulls `origin` (you won't see upstream merges), and `trunk()`/immutability anchor to your fork instead of upstream.
 
 ### Commit Messages
 

--- a/bench.sh
+++ b/bench.sh
@@ -102,10 +102,10 @@ arch=$(uname -m)
 
 # Build the compiler
 log_info "Building rue compiler ($BUILD_MODE mode)..."
-./buck2 build //crates/rue:rue --modifier //constraints:$BUILD_MODE 2>&1 | tail -3
 
-# Get the path to the built compiler
-RUE_BIN="$(./buck2 build //crates/rue:rue --modifier //constraints:$BUILD_MODE --show-output 2>/dev/null | awk '{print $2}')"
+# Get the path to the built compiler (scripts/rue-bin builds it and resolves a
+# stable absolute path; extra args pass through to buck2 build).
+RUE_BIN="$(./scripts/rue-bin --modifier //constraints:$BUILD_MODE)"
 if [[ ! -x "$RUE_BIN" ]]; then
     log_error "Failed to find rue binary at: $RUE_BIN"
     exit 1

--- a/scripts/rue
+++ b/scripts/rue
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+#
+# rue — convenience wrapper around the common Buck2 targets, so you don't have
+# to memorize `//crates/...` paths. Run from anywhere in the repo.
+#
+#   scripts/rue build              Build the compiler (refreshes bin/rue)
+#   scripts/rue run prog.rue out   Compile a program (then run ./out yourself)
+#   scripts/rue exec prog.rue      Compile prog.rue to a temp file AND run it
+#   scripts/rue test [pattern]     Full suite (./test.sh), optional filter
+#   scripts/rue quick              Unit tests only (./quick-test.sh)
+#   scripts/rue spec [pattern]     Spec tests, optional filter
+#   scripts/rue cli [pattern]      CLI integration tests, optional filter
+#   scripts/rue ui [pattern]       UI/diagnostics tests, optional filter
+#   scripts/rue fmt                Format the code (./fmt.sh)
+#   scripts/rue path               Print the absolute binary path (build if needed)
+#
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+cmd="${1:-}"
+shift || true
+
+case "$cmd" in
+    build)
+        scripts/rue-bin "$@" >/dev/null
+        echo "Built: bin/rue -> $(readlink bin/rue)"
+        ;;
+    path)
+        scripts/rue-bin "$@"
+        ;;
+    run)
+        # Compile via the real driver (so module resolution, -o, etc. behave
+        # exactly as a user would see).
+        bin="$(scripts/rue-bin)"
+        "$bin" "$@"
+        ;;
+    exec)
+        # Compile a single source to a temp executable and run it.
+        if [[ $# -lt 1 ]]; then
+            echo "usage: scripts/rue exec <source.rue> [program args...]" >&2
+            exit 2
+        fi
+        src="$1"; shift
+        bin="$(scripts/rue-bin)"
+        out="$(mktemp)"
+        "$bin" "$src" "$out"
+        "$out" "$@"
+        rc=$?
+        rm -f "$out"
+        exit $rc
+        ;;
+    test)
+        ./test.sh "$@"
+        ;;
+    quick)
+        ./quick-test.sh "$@"
+        ;;
+    spec)
+        RUE_BINARY="$(scripts/rue-bin)" \
+        RUE_SPEC_CASES="crates/rue-spec/cases" \
+        ./buck2 run //crates/rue-spec:rue-spec -- "$@"
+        ;;
+    cli)
+        RUE_BINARY="$(scripts/rue-bin)" \
+        RUE_CLI_CASES="crates/rue-cli-tests/cases" \
+        RUE_STD_DIR="std" \
+        ./buck2 run //crates/rue-cli-tests:rue-cli-tests -- "$@"
+        ;;
+    ui)
+        RUE_BINARY="$(scripts/rue-bin)" \
+        RUE_UI_CASES="crates/rue-ui-tests/cases" \
+        ./buck2 run //crates/rue-ui-tests:rue-ui-tests -- "$@"
+        ;;
+    fmt)
+        ./fmt.sh "$@"
+        ;;
+    ""|-h|--help|help)
+        sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+        ;;
+    *)
+        echo "scripts/rue: unknown command '$cmd' (try: scripts/rue help)" >&2
+        exit 2
+        ;;
+esac

--- a/scripts/rue-bin
+++ b/scripts/rue-bin
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# rue-bin — build the rue compiler and print the ABSOLUTE path to the binary.
+#
+# Buck2's `--show-output` prints a path relative to the repo root, and that
+# path contains a toolchain hash, so it is neither stable nor usable once the
+# working directory changes. This script resolves it to an absolute path,
+# refreshes a stable `bin/rue` symlink, and prints the absolute path on stdout
+# (all build chatter goes to stderr), so callers can do:
+#
+#   RUE_BINARY="$(scripts/rue-bin)"        # for the test harnesses
+#   "$(scripts/rue-bin)" prog.rue out      # to compile directly
+#   bin/rue prog.rue out                   # via the stable symlink
+#
+# Any extra arguments are passed through to `buck2 build`, e.g. a release build:
+#
+#   RUE_BINARY="$(scripts/rue-bin --modifier //constraints:release)"
+#
+set -euo pipefail
+
+# Resolve repo root (this script lives in scripts/) so we work from any cwd.
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+# Build and capture the relative output path. Build output goes to stderr so
+# stdout stays clean for command substitution.
+rel_path="$(./buck2 build //crates/rue:rue --show-output "$@" 2>/dev/null \
+    | awk '/crates\/rue:rue / {print $2}' | tail -1)"
+
+if [[ -z "${rel_path:-}" ]]; then
+    echo "rue-bin: failed to determine binary path from buck2 --show-output" >&2
+    echo "rue-bin: re-running build with output for diagnosis..." >&2
+    ./buck2 build //crates/rue:rue --show-output "$@" >&2
+    exit 1
+fi
+
+abs_path="$repo_root/$rel_path"
+if [[ ! -x "$abs_path" ]]; then
+    echo "rue-bin: built path is not executable: $abs_path" >&2
+    exit 1
+fi
+
+# Refresh the stable symlink (only for the default/no-extra-args build, so a
+# release build doesn't clobber the debug symlink and vice versa).
+if [[ $# -eq 0 ]]; then
+    mkdir -p "$repo_root/bin"
+    ln -sfn "$abs_path" "$repo_root/bin/rue"
+fi
+
+echo "$abs_path"

--- a/test.sh
+++ b/test.sh
@@ -20,8 +20,9 @@ echo "Running unit tests..."
     //crates/rue-linker:rue-linker-test \
     //crates/rue-compiler:rue-compiler-test
 
-# Get the path to the rue binary (this also builds it if needed)
-RUE_BINARY="$(./buck2 build //crates/rue:rue --show-output | tail -1 | awk '{print $2}')"
+# Get the path to the rue binary (this also builds it if needed).
+# scripts/rue-bin resolves it to a stable absolute path.
+RUE_BINARY="$(./scripts/rue-bin)"
 
 # Run spec tests (buck2 run will build rue-spec if needed)
 echo "Running spec tests..."


### PR DESCRIPTION
…E-55)

scripts/rue-bin: builds the compiler and prints a STABLE ABSOLUTE path (buck2 --show-output returns a hash-laden relative path that breaks when cwd changes); refreshes a bin/rue symlink. scripts/rue wraps the common targets (build/exec/test/quick/spec/cli/ui/fmt) so callers don't memorize //crates paths. test.sh and bench.sh now use scripts/rue-bin.

Fork-workflow correctness (jj):
- Document the fork workflow in CLAUDE.md: never commit on origin/trunk; push feature branches (jj git push -c @-) and PR upstream. Record the required machine-local jj config (trunk() = trunk@upstream so rebase base + immutability anchor to the canonical repo; git.fetch pulls both remotes). ship.md/rebase.md now rebase onto the trunk() revset.
- These mirror the config now set on this checkout via jj config --repo.

Agent loop (RUE-55):
- CLAUDE.md gains a Quickstart block (the ~8 commands covering most work).
- .claude/settings.json gains a conservative read-only/build-loop permission allowlist (buck2 build/test/run, read-only jj/gh, scripts) to cut repetitive approval prompts; write/destructive commands still prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)