### PR TITLE
Fix DCE eliding mandatory runtime traps at -O1+ (RUE-57)

### DIFF
--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -163,8 +163,26 @@ fn has_side_effects(cfg: &Cfg, value: CfgValue) -> bool {
         // PlaceWrite is a memory write (side effect)
         CfgInstData::PlaceWrite { .. } => true,
 
-        // PlaceRead is pure (no side effect unless indexing panics, but we treat that like other ops)
-        CfgInstData::PlaceRead { .. } => false,
+        // A PlaceRead is pure for field projections, but an array index read
+        // performs a bounds check that panics when out of range. A read whose
+        // place contains an Index projection is therefore side-effecting and
+        // must not be eliminated even when its value is unused (RUE-57).
+        CfgInstData::PlaceRead { place } => cfg
+            .get_place_projections(place)
+            .iter()
+            .any(|p| matches!(p, Projection::Index { .. })),
+
+        // Overflow-checked arithmetic (Add/Sub/Mul/Neg) and Div/Mod (division
+        // by zero) panic at runtime. That trap is observable behavior the
+        // optimizer must preserve, so these are side-effecting even when the
+        // result is unused (RUE-57). Bitwise ops and shifts do not trap (shift
+        // counts are masked per spec), so they remain pure.
+        CfgInstData::Add(..)
+        | CfgInstData::Sub(..)
+        | CfgInstData::Mul(..)
+        | CfgInstData::Div(..)
+        | CfgInstData::Mod(..)
+        | CfgInstData::Neg(..) => true,
 
         // Everything else is pure computation
         _ => false,
@@ -475,16 +493,17 @@ mod tests {
         let mut cfg = make_cfg();
         let entry = cfg.entry;
 
-        // Create: c1 = 10, c2 = 20, add = c1 + c2, c3 = 42, return c3
-        // c1, c2, and add should be removed since they're unused
+        // Create: c1 = 10, c2 = 20 (unused), c3 = 42, return c3
+        // c1 and c2 are unused PURE constants and should be removed. (Note: an
+        // unused `c1 + c2` must NOT be removed — arithmetic can overflow-trap;
+        // see test_dce_preserves_unused_trapping_arithmetic.)
         let _c1 = add_const(&mut cfg, 10, Type::I32);
         let _c2 = add_const(&mut cfg, 20, Type::I32);
-        let _add = add_add(&mut cfg, _c1, _c2, Type::I32);
         let c3 = add_const(&mut cfg, 42, Type::I32);
         finalize_cfg(&mut cfg, c3);
 
-        // Before DCE: block has 4 instructions
-        assert_eq!(cfg.get_block(entry).insts.len(), 4);
+        // Before DCE: block has 3 instructions
+        assert_eq!(cfg.get_block(entry).insts.len(), 3);
 
         run(&mut cfg);
 
@@ -503,6 +522,31 @@ mod tests {
             CfgInstData::Const(42) => {}
             other => panic!("Expected Const(42), got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_dce_preserves_unused_trapping_arithmetic() {
+        // An arithmetic op whose result is unused must still be preserved,
+        // because it can panic on overflow/division-by-zero — eliminating it
+        // would drop a mandatory runtime trap (RUE-57).
+        let mut cfg = make_cfg();
+        let entry = cfg.entry;
+
+        let c1 = add_const(&mut cfg, 10, Type::I32);
+        let c2 = add_const(&mut cfg, 20, Type::I32);
+        let _add = add_add(&mut cfg, c1, c2, Type::I32); // unused
+        let c3 = add_const(&mut cfg, 42, Type::I32);
+        finalize_cfg(&mut cfg, c3);
+
+        run(&mut cfg);
+
+        // The add (and its operands) must survive even though the add's result
+        // is never used; only nothing is removed here.
+        let block = cfg.get_block(entry);
+        assert!(
+            block.insts.contains(&_add),
+            "unused trapping arithmetic must not be eliminated by DCE"
+        );
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/opt.toml
+++ b/crates/rue-cli-tests/cases/opt.toml
@@ -1,0 +1,69 @@
+# Optimization-correctness regression tests.
+#
+# These compile at -O2 and assert that mandatory runtime traps (overflow,
+# divide-by-zero, out-of-bounds) still fire even when the trapping op's result
+# is unused. DCE used to eliminate these (RUE-57), silently turning exit 101
+# into exit 0 at -O1+. See crates/rue-cfg/src/opt/dce.rs has_side_effects.
+
+[section]
+id = "cli.opt"
+name = "Optimization correctness"
+description = "Mandatory runtime traps must survive optimization passes."
+
+[[case]]
+name = "dce_keeps_overflow_panic_at_O2"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = 2147483647;
+    a + 1;
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 101
+runtime_error_contains = ["integer overflow"]
+
+[[case]]
+name = "dce_keeps_div_by_zero_panic_at_O2"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = 10;
+    let z: i32 = 0;
+    a / z;
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 101
+runtime_error_contains = ["division by zero"]
+
+[[case]]
+name = "dce_keeps_bounds_check_panic_at_O2"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [1, 2, 3];
+    let i: u64 = 5;
+    arr[i];
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 101
+runtime_error_contains = ["index out of bounds"]
+
+# A genuinely dead, non-trapping computation should still be optimized away,
+# and a normal program must produce the same result at -O2 as -O0.
+[[case]]
+name = "normal_program_unaffected_at_O2"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = 5;
+    let b: i32 = a & 3;
+    let mut s = 0;
+    let mut i = 0;
+    while i < 10 { s = s + i; i = i + 1; }
+    s
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 45


### PR DESCRIPTION
**RUE-57** — found by the autonomous hunt.

Dead-code elimination treated overflow-checked arithmetic (`Add/Sub/Mul/Neg`), `Div`/`Mod` (divide-by-zero), and bounds-checked array index reads as pure. When the result was unused, DCE deleted them **along with their trap** — so at `-O1+` a mandatory panic (exit 101) silently became exit 0. Overflow, divide-by-zero, and out-of-bounds were all affected.

```rue
fn main() -> i32 { let a: i32 = 2147483647; a + 1; 0 }
// -O0: error: integer overflow, exit 101
// -O1+ (before this fix): exit 0
```

Fix: mark these trapping ops as side-effecting in `has_side_effects` (`crates/rue-cfg/src/opt/dce.rs`). Bitwise ops and shifts stay pure (no trap). `PlaceRead` is side-effecting only when its place has an `Index` projection.

Tests: new `-O2` CLI regression cases for all three traps + a normal-program control; a new DCE unit test pinning that unused trapping arithmetic survives; updated the pre-existing unit test that had encoded the buggy removal. Full `./test.sh` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)