### PR TITLE
Compare 64-bit operands at full width in bounds check and match dispatch (RUE-87, RUE-27)

### DIFF
--- a/crates/rue-cli-tests/cases/width.toml
+++ b/crates/rue-cli-tests/cases/width.toml
@@ -1,0 +1,97 @@
+# 64-bit operand-width regression tests (epic RUE-105).
+#
+# The x86-64 backend used to emit 32-bit compares for 64-bit operands, so any
+# value whose high 32 bits mattered was compared on its low 32 bits only. These
+# cases pin the fixed behavior for the two compare sites: the array bounds check
+# (RUE-87, a memory-safety hole) and the match/switch dispatch (RUE-27).
+
+[section]
+id = "cli.width"
+name = "64-bit operand width"
+description = "64-bit values must be compared at full width, not truncated to 32 bits."
+
+# RUE-87: a usize index above 2^32 whose low 32 bits are in range used to bypass
+# the bounds check and segfault (exit 139). It must now trap as a normal
+# out-of-bounds panic (exit 101).
+[[case]]
+name = "bounds_check_large_index_traps_not_segfaults"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr: [i32; 4] = [10, 20, 30, 40];
+    let idx: usize = 4294967298;   // 2^32 + 2; low 32 bits == 2
+    arr[idx]
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["index out of bounds"]
+
+# Control: an ordinary out-of-bounds index still traps (and a small index path
+# is unaffected by the 64-bit compare).
+[[case]]
+name = "bounds_check_small_oob_still_traps"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr: [i32; 4] = [10, 20, 30, 40];
+    let idx: usize = 5;
+    arr[idx]
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["index out of bounds"]
+
+[[case]]
+name = "bounds_check_in_bounds_ok"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr: [i32; 4] = [10, 20, 30, 40];
+    let i: usize = 2;
+    arr[i]
+}
+""" }]
+exit_code = 30
+
+# RUE-27: match on a 64-bit scrutinee used to compare only the low 32 bits, so
+# 2^32 wrongly matched the `0` arm (exit 1). It must take the wildcard (42).
+[[case]]
+name = "match_i64_high_bits_not_truncated"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i64 = 4294967296;   // 2^32; low 32 bits == 0
+    match x {
+        0 => 1,
+        _ => 42,
+    }
+}
+""" }]
+exit_code = 42
+
+# RUE-27: the correct arm is selected by the full 64-bit value. 4294967297 has
+# low 32 bits == 1, which used to alias the `1 =>` arm (exit 7).
+[[case]]
+name = "match_i64_selects_correct_arm"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i64 = 4294967297;
+    match x {
+        1 => 7,
+        4294967297 => 42,
+        _ => 2,
+    }
+}
+""" }]
+exit_code = 42
+
+# Control: sub-64-bit match dispatch keeps the 32-bit compare and stays correct.
+[[case]]
+name = "match_i32_still_correct"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = 5;
+    match x {
+        4 => 10,
+        5 => 42,
+        _ => 0,
+    }
+}
+""" }]
+exit_code = 42

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -179,8 +179,12 @@ impl<'a> CfgLower<'a> {
             imm: length as i64,
         });
 
-        // Compare index (unsigned) against length
-        self.mir.push(Aarch64Inst::CmpRR {
+        // Compare index (unsigned) against length. The index is a usize
+        // (64-bit) and the length is materialized as a 64-bit immediate, so the
+        // comparison MUST be 64-bit — a 32-bit cmp would ignore the high half of
+        // the index and let an out-of-range index whose low 32 bits happen to be
+        // in range bypass the check, reading out of bounds (RUE-87).
+        self.mir.push(Aarch64Inst::Cmp64RR {
             src1: Operand::Virtual(index_vreg),
             src2: Operand::Virtual(length_vreg),
         });
@@ -3682,6 +3686,11 @@ impl<'a> CfgLower<'a> {
                 default,
             } => {
                 let scrutinee_vreg = self.get_vreg(*scrutinee);
+                // The case value is materialized as a full 64-bit immediate, so a
+                // 64-bit scrutinee must be compared at 64-bit width; a 32-bit cmp
+                // would match on only the low 32 bits (RUE-27). Sub-64-bit
+                // scrutinees keep the 32-bit compare (correct at their width).
+                let scrutinee_is_64 = self.ctx.cfg.get_inst(*scrutinee).ty.is_64_bit();
 
                 // Generate comparison and jump for each case
                 let cases = self.ctx.cfg.get_switch_cases(*cases_start, *cases_len);
@@ -3692,10 +3701,17 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(imm_vreg),
                         imm: *value,
                     });
-                    self.mir.push(Aarch64Inst::CmpRR {
-                        src1: Operand::Virtual(scrutinee_vreg),
-                        src2: Operand::Virtual(imm_vreg),
-                    });
+                    if scrutinee_is_64 {
+                        self.mir.push(Aarch64Inst::Cmp64RR {
+                            src1: Operand::Virtual(scrutinee_vreg),
+                            src2: Operand::Virtual(imm_vreg),
+                        });
+                    } else {
+                        self.mir.push(Aarch64Inst::CmpRR {
+                            src1: Operand::Virtual(scrutinee_vreg),
+                            src2: Operand::Virtual(imm_vreg),
+                        });
+                    }
                     self.mir.push(Aarch64Inst::BCond {
                         cond: Cond::Eq,
                         label: self.block_label(*target),

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -190,8 +190,12 @@ impl<'a> CfgLower<'a> {
             imm: length as i64,
         });
 
-        // Compare index (unsigned) against length
-        self.mir.push(X86Inst::CmpRR {
+        // Compare index (unsigned) against length. The index is a usize
+        // (64-bit) and the length is materialized as a 64-bit immediate, so the
+        // comparison MUST be 64-bit — a 32-bit cmp would ignore the high half of
+        // the index and let an out-of-range index whose low 32 bits happen to be
+        // in range bypass the check, reading out of bounds (RUE-87).
+        self.mir.push(X86Inst::Cmp64RR {
             src1: Operand::Virtual(index_vreg),
             src2: Operand::Virtual(length_vreg),
         });
@@ -3564,6 +3568,11 @@ impl<'a> CfgLower<'a> {
                 default,
             } => {
                 let scrutinee_vreg = self.get_vreg(*scrutinee);
+                // The case value is materialized as a full 64-bit immediate, so a
+                // 64-bit scrutinee must be compared at 64-bit width; a 32-bit cmp
+                // would match on only the low 32 bits (RUE-27). Sub-64-bit
+                // scrutinees keep the 32-bit compare (correct at their width).
+                let scrutinee_is_64 = self.ctx.cfg.get_inst(*scrutinee).ty.is_64_bit();
 
                 // Generate comparison and jump for each case
                 let cases = self.ctx.cfg.get_switch_cases(*cases_start, *cases_len);
@@ -3574,10 +3583,17 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(case_vreg),
                         imm: *value,
                     });
-                    self.mir.push(X86Inst::CmpRR {
-                        src1: Operand::Virtual(scrutinee_vreg),
-                        src2: Operand::Virtual(case_vreg),
-                    });
+                    if scrutinee_is_64 {
+                        self.mir.push(X86Inst::Cmp64RR {
+                            src1: Operand::Virtual(scrutinee_vreg),
+                            src2: Operand::Virtual(case_vreg),
+                        });
+                    } else {
+                        self.mir.push(X86Inst::CmpRR {
+                            src1: Operand::Virtual(scrutinee_vreg),
+                            src2: Operand::Virtual(case_vreg),
+                        });
+                    }
                     self.mir.push(X86Inst::Jz {
                         label: self.block_label(*target),
                     });


### PR DESCRIPTION
## Summary

Two codegen sites emitted a **32-bit compare for 64-bit operands**, so a 64-bit value was compared on only its low 32 bits. Fixed in both the x86-64 and aarch64 backends.

### RUE-87 — array bounds check (memory-safety hole)
`emit_bounds_check` compared the `usize` index against the length with a 32-bit `cmp`. An out-of-range index whose low 32 bits were in range bypassed the check, and the element address was then computed with the full 64-bit index → an out-of-bounds read that **segfaulted instead of trapping**.

```rue
let arr: [i32; 4] = [10, 20, 30, 40];
let idx: usize = 4294967298;  // 2^32 + 2; low 32 bits == 2
arr[idx]                      // before: SIGSEGV (exit 139); after: panic "index out of bounds" (exit 101)
```

The index is a `usize` and the length is materialized as a 64-bit immediate, so the compare is now unconditionally 64-bit.

### RUE-27 — match/switch dispatch
The case value is materialized as a full 64-bit immediate but compared with a 32-bit `cmp`, so a 64-bit scrutinee matched on its low 32 bits.

```rue
let x: i64 = 4294967296;  // 2^32; low 32 bits == 0
match x { 0 => 1, _ => 42 }   // before: 1; after: 42
```

The compare now selects 64-bit width when the scrutinee type is 64-bit, and keeps the 32-bit compare for sub-64-bit scrutinees (correct at their width).

## Approach

Both fixes use the **existing** `Cmp64RR` / `Aarch64Inst::Cmp64RR` variants — the comparison operators (`Eq`/`Lt`/`Gt`/…) already select width this way; these two sites just didn't. No new instructions. Per the multi-backend checklist, both backends are fixed; the aarch64 cross-compile now emits `cmp x,x` (verified via `--emit asm`) where it previously emitted `cmp w,w`.

These are two of the sub-issues of the operand-width epic **RUE-105**. The remaining ones (RUE-26 div/mod, RUE-58 bitwise, RUE-88 intCast) need *new* 64-bit MIR variants (`Cqo`, `And64`/`Or64`/`Xor64`, `movsxd`) and are left as follow-ups.

## Testing

- New `crates/rue-cli-tests/cases/width.toml` — 6 cases: the large-index bounds trap (exit 101, not segfault), match on a 64-bit scrutinee (correct arm + correct-arm-selection), and controls for small-OOB / in-bounds / sub-64-bit-match.
- `./test.sh` green: spec 1346/0 + traceability 100%, UI 47/0, CLI 32/0, codegen unit tests pass. No regressions.

Fixes RUE-87, RUE-27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)