### PR TITLE
Lower i64/u64 bitwise AND/OR/XOR at 64-bit width on x86-64 (RUE-58)

### DIFF
--- a/crates/rue-cli-tests/cases/width.toml
+++ b/crates/rue-cli-tests/cases/width.toml
@@ -95,3 +95,54 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 42
+
+# RUE-58: i64/u64 bitwise AND/OR/XOR were lowered as 32-bit ops, zeroing the
+# high 32 bits of the result. Now use REX.W forms when the operands are 64-bit.
+[[case]]
+name = "i64_bitor_high_bits_preserved"
+files = [{ path = "main.rue", source = """
+fn val() -> i64 { 1 }
+fn main() -> i32 {
+    let high: i64 = val() << 40;
+    let a: i64 = high | 1;          // (1<<40) | 1, high bits set
+    if a > 4294967296 { 1 } else { 2 }
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "i64_bitand_high_bits_preserved"
+files = [{ path = "main.rue", source = """
+fn val() -> i64 { 1 }
+fn main() -> i32 {
+    let high: i64 = val() << 40;    // 2^40
+    let mask: i64 = val() << 40;    // 2^40
+    let a: i64 = high & mask;       // 2^40
+    if a > 4294967296 { 1 } else { 2 }
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "i64_bitxor_high_bits_preserved"
+files = [{ path = "main.rue", source = """
+fn val() -> i64 { 1 }
+fn main() -> i32 {
+    let high: i64 = val() << 40;    // 2^40
+    let a: i64 = high ^ 1;          // 2^40 + 1, high bit retained
+    if a > 4294967296 { 1 } else { 2 }
+}
+""" }]
+exit_code = 1
+
+# Control: 32-bit bitwise ops are unaffected.
+[[case]]
+name = "i32_bitand_still_correct"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = 5;
+    let b: i32 = 3;
+    a & b          // 1
+}
+""" }]
+exit_code = 1

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1122,9 +1122,18 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(vreg),
                     src: Operand::Virtual(lhs_vreg),
                 });
-                self.mir.push(X86Inst::AndRR {
-                    dst: Operand::Virtual(vreg),
-                    src: Operand::Virtual(rhs_vreg),
+                // 64-bit operands need a REX.W `and`; a 32-bit `and` would zero
+                // the high 32 bits of the result (RUE-58).
+                self.mir.push(if ty.is_64_bit() {
+                    X86Inst::And64RR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(rhs_vreg),
+                    }
+                } else {
+                    X86Inst::AndRR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(rhs_vreg),
+                    }
                 });
             }
 
@@ -1139,9 +1148,16 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(vreg),
                     src: Operand::Virtual(lhs_vreg),
                 });
-                self.mir.push(X86Inst::OrRR {
-                    dst: Operand::Virtual(vreg),
-                    src: Operand::Virtual(rhs_vreg),
+                self.mir.push(if ty.is_64_bit() {
+                    X86Inst::Or64RR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(rhs_vreg),
+                    }
+                } else {
+                    X86Inst::OrRR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(rhs_vreg),
+                    }
                 });
             }
 
@@ -1156,9 +1172,16 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(vreg),
                     src: Operand::Virtual(lhs_vreg),
                 });
-                self.mir.push(X86Inst::XorRR {
-                    dst: Operand::Virtual(vreg),
-                    src: Operand::Virtual(rhs_vreg),
+                self.mir.push(if ty.is_64_bit() {
+                    X86Inst::Xor64RR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(rhs_vreg),
+                    }
+                } else {
+                    X86Inst::XorRR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(rhs_vreg),
+                    }
                 });
             }
 

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -656,6 +656,21 @@ impl<'a> Emitter<'a> {
                 self.emit_xor_rr(dst.as_physical(), src.as_physical());
                 end_inst!(self, "xor {}, {}", dst.as_physical(), src.as_physical());
             }
+            X86Inst::And64RR { dst, src } => {
+                self.begin_inst();
+                self.emit_and_rr64(dst.as_physical(), src.as_physical());
+                end_inst!(self, "and {}, {}", dst.as_physical(), src.as_physical());
+            }
+            X86Inst::Or64RR { dst, src } => {
+                self.begin_inst();
+                self.emit_or_rr64(dst.as_physical(), src.as_physical());
+                end_inst!(self, "or {}, {}", dst.as_physical(), src.as_physical());
+            }
+            X86Inst::Xor64RR { dst, src } => {
+                self.begin_inst();
+                self.emit_xor_rr64(dst.as_physical(), src.as_physical());
+                end_inst!(self, "xor {}, {}", dst.as_physical(), src.as_physical());
+            }
             X86Inst::NotR { dst } => {
                 self.begin_inst();
                 self.emit_not(dst.as_physical());
@@ -1883,6 +1898,51 @@ impl<'a> Emitter<'a> {
         self.code.push(modrm);
     }
 
+    /// Emit `and r64, r64`.
+    ///
+    /// Encoding: REX.W 21 /r (and r/m64, r64)
+    fn emit_and_rr64(&mut self, dst: Reg, src: Reg) {
+        let dst_enc = dst.encoding();
+        let src_enc = src.encoding();
+        let rex = 0x48
+            | if src.needs_rex() { 0x04 } else { 0x00 }  // REX.R
+            | if dst.needs_rex() { 0x01 } else { 0x00 }; // REX.B
+        self.code.push(rex);
+        self.code.push(0x21);
+        let modrm = 0xC0 | ((src_enc & 7) << 3) | (dst_enc & 7);
+        self.code.push(modrm);
+    }
+
+    /// Emit `or r64, r64`.
+    ///
+    /// Encoding: REX.W 09 /r (or r/m64, r64)
+    fn emit_or_rr64(&mut self, dst: Reg, src: Reg) {
+        let dst_enc = dst.encoding();
+        let src_enc = src.encoding();
+        let rex = 0x48
+            | if src.needs_rex() { 0x04 } else { 0x00 }  // REX.R
+            | if dst.needs_rex() { 0x01 } else { 0x00 }; // REX.B
+        self.code.push(rex);
+        self.code.push(0x09);
+        let modrm = 0xC0 | ((src_enc & 7) << 3) | (dst_enc & 7);
+        self.code.push(modrm);
+    }
+
+    /// Emit `xor r64, r64`.
+    ///
+    /// Encoding: REX.W 31 /r (xor r/m64, r64)
+    fn emit_xor_rr64(&mut self, dst: Reg, src: Reg) {
+        let dst_enc = dst.encoding();
+        let src_enc = src.encoding();
+        let rex = 0x48
+            | if src.needs_rex() { 0x04 } else { 0x00 }  // REX.R
+            | if dst.needs_rex() { 0x01 } else { 0x00 }; // REX.B
+        self.code.push(rex);
+        self.code.push(0x31);
+        let modrm = 0xC0 | ((src_enc & 7) << 3) | (dst_enc & 7);
+        self.code.push(modrm);
+    }
+
     /// Emit `not r32`.
     ///
     /// Encoding: [REX] F7 /2 (not r/m32)
@@ -3054,6 +3114,46 @@ mod tests {
         });
         // xor eax, ecx -> 31 C8 (31 /r)
         assert_eq!(code, vec![0x31, 0xC8]);
+    }
+
+    #[test]
+    fn test_and64_rax_rcx() {
+        let code = emit_single(X86Inst::And64RR {
+            dst: Operand::Physical(Reg::Rax),
+            src: Operand::Physical(Reg::Rcx),
+        });
+        // and rax, rcx -> 48 21 C8 (REX.W 21 /r)
+        assert_eq!(code, vec![0x48, 0x21, 0xC8]);
+    }
+
+    #[test]
+    fn test_and64_r10_r11() {
+        let code = emit_single(X86Inst::And64RR {
+            dst: Operand::Physical(Reg::R10),
+            src: Operand::Physical(Reg::R11),
+        });
+        // and r10, r11 -> 4D 21 DA (REX.WRB 21 /r)
+        assert_eq!(code, vec![0x4D, 0x21, 0xDA]);
+    }
+
+    #[test]
+    fn test_or64_rax_rcx() {
+        let code = emit_single(X86Inst::Or64RR {
+            dst: Operand::Physical(Reg::Rax),
+            src: Operand::Physical(Reg::Rcx),
+        });
+        // or rax, rcx -> 48 09 C8 (REX.W 09 /r)
+        assert_eq!(code, vec![0x48, 0x09, 0xC8]);
+    }
+
+    #[test]
+    fn test_xor64_rax_rcx() {
+        let code = emit_single(X86Inst::Xor64RR {
+            dst: Operand::Physical(Reg::Rax),
+            src: Operand::Physical(Reg::Rcx),
+        });
+        // xor rax, rcx -> 48 31 C8 (REX.W 31 /r)
+        assert_eq!(code, vec![0x48, 0x31, 0xC8]);
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -179,7 +179,12 @@ pub fn uses(inst: &X86Inst) -> Vec<VReg> {
             // dst is both read and written
             add_if_virtual(dst, &mut result);
         }
-        X86Inst::AndRR { dst, src } | X86Inst::OrRR { dst, src } | X86Inst::XorRR { dst, src } => {
+        X86Inst::AndRR { dst, src }
+        | X86Inst::OrRR { dst, src }
+        | X86Inst::XorRR { dst, src }
+        | X86Inst::And64RR { dst, src }
+        | X86Inst::Or64RR { dst, src }
+        | X86Inst::Xor64RR { dst, src } => {
             add_if_virtual(dst, &mut result);
             add_if_virtual(src, &mut result);
         }
@@ -349,6 +354,9 @@ pub fn defs(inst: &X86Inst) -> Vec<VReg> {
         X86Inst::AndRR { dst, .. }
         | X86Inst::OrRR { dst, .. }
         | X86Inst::XorRR { dst, .. }
+        | X86Inst::And64RR { dst, .. }
+        | X86Inst::Or64RR { dst, .. }
+        | X86Inst::Xor64RR { dst, .. }
         | X86Inst::NotR { dst }
         | X86Inst::ShlRCl { dst }
         | X86Inst::Shl32RCl { dst }

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -222,14 +222,23 @@ pub enum X86Inst {
     /// `xor dst, imm` - XOR with immediate (dst = dst ^ imm).
     XorRI { dst: Operand, imm: i32 },
 
-    /// `and dst, src` - Bitwise AND (dst = dst & src).
+    /// `and dst, src` - Bitwise AND, 32-bit (dst = dst & src).
     AndRR { dst: Operand, src: Operand },
 
-    /// `or dst, src` - Bitwise OR (dst = dst | src).
+    /// `or dst, src` - Bitwise OR, 32-bit (dst = dst | src).
     OrRR { dst: Operand, src: Operand },
 
-    /// `xor dst, src` - Bitwise XOR (dst = dst ^ src).
+    /// `xor dst, src` - Bitwise XOR, 32-bit (dst = dst ^ src).
     XorRR { dst: Operand, src: Operand },
+
+    /// `and dst, src` - Bitwise AND, 64-bit (dst = dst & src).
+    And64RR { dst: Operand, src: Operand },
+
+    /// `or dst, src` - Bitwise OR, 64-bit (dst = dst | src).
+    Or64RR { dst: Operand, src: Operand },
+
+    /// `xor dst, src` - Bitwise XOR, 64-bit (dst = dst ^ src).
+    Xor64RR { dst: Operand, src: Operand },
 
     /// `not dst` - Bitwise NOT (dst = ~dst).
     NotR { dst: Operand },
@@ -543,6 +552,9 @@ impl fmt::Display for X86Inst {
             X86Inst::AndRR { dst, src } => write!(f, "and {}, {}", dst, src),
             X86Inst::OrRR { dst, src } => write!(f, "or {}, {}", dst, src),
             X86Inst::XorRR { dst, src } => write!(f, "xor {}, {}", dst, src),
+            X86Inst::And64RR { dst, src } => write!(f, "andq {}, {}", dst, src),
+            X86Inst::Or64RR { dst, src } => write!(f, "orq {}, {}", dst, src),
+            X86Inst::Xor64RR { dst, src } => write!(f, "xorq {}, {}", dst, src),
             X86Inst::NotR { dst } => write!(f, "not {}", dst),
             X86Inst::ShlRCl { dst } => write!(f, "shlq {}, cl", dst),
             X86Inst::Shl32RCl { dst } => write!(f, "shll {}, cl", dst),

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -368,6 +368,18 @@ impl RegAlloc {
                 self.emit_binop(mir, dst, src, |d, s| X86Inst::XorRR { dst: d, src: s })?;
             }
 
+            X86Inst::And64RR { dst, src } => {
+                self.emit_binop(mir, dst, src, |d, s| X86Inst::And64RR { dst: d, src: s })?;
+            }
+
+            X86Inst::Or64RR { dst, src } => {
+                self.emit_binop(mir, dst, src, |d, s| X86Inst::Or64RR { dst: d, src: s })?;
+            }
+
+            X86Inst::Xor64RR { dst, src } => {
+                self.emit_binop(mir, dst, src, |d, s| X86Inst::Xor64RR { dst: d, src: s })?;
+            }
+
             X86Inst::NotR { dst } => {
                 self.emit_unop(mir, dst, |d| X86Inst::NotR { dst: d });
             }

--- a/crates/rue-codegen/src/x86_64/schedule.rs
+++ b/crates/rue-codegen/src/x86_64/schedule.rs
@@ -124,6 +124,9 @@ fn get_latency(inst: &X86Inst) -> u32 {
         X86Inst::AndRR { .. }
         | X86Inst::OrRR { .. }
         | X86Inst::XorRR { .. }
+        | X86Inst::And64RR { .. }
+        | X86Inst::Or64RR { .. }
+        | X86Inst::Xor64RR { .. }
         | X86Inst::XorRI { .. }
         | X86Inst::NotR { .. } => 1,
 
@@ -271,7 +274,10 @@ fn regs_read(inst: &X86Inst) -> Vec<Reg> {
         | X86Inst::ImulRR64 { dst, src }
         | X86Inst::AndRR { dst, src }
         | X86Inst::OrRR { dst, src }
-        | X86Inst::XorRR { dst, src } => {
+        | X86Inst::XorRR { dst, src }
+        | X86Inst::And64RR { dst, src }
+        | X86Inst::Or64RR { dst, src }
+        | X86Inst::Xor64RR { dst, src } => {
             add_if_phys(dst, &mut result);
             add_if_phys(src, &mut result);
         }
@@ -405,6 +411,9 @@ fn regs_written(inst: &X86Inst) -> Vec<Reg> {
         X86Inst::AndRR { dst, .. }
         | X86Inst::OrRR { dst, .. }
         | X86Inst::XorRR { dst, .. }
+        | X86Inst::And64RR { dst, .. }
+        | X86Inst::Or64RR { dst, .. }
+        | X86Inst::Xor64RR { dst, .. }
         | X86Inst::NotR { dst }
         | X86Inst::ShlRCl { dst }
         | X86Inst::Shl32RCl { dst }
@@ -497,6 +506,9 @@ fn writes_flags(inst: &X86Inst) -> bool {
             | X86Inst::AndRR { .. }
             | X86Inst::OrRR { .. }
             | X86Inst::XorRR { .. }
+            | X86Inst::And64RR { .. }
+            | X86Inst::Or64RR { .. }
+            | X86Inst::Xor64RR { .. }
             | X86Inst::XorRI { .. }
             // Shifts (set CF, and SF/ZF/PF for non-zero counts)
             | X86Inst::ShlRCl { .. }


### PR DESCRIPTION
## Summary

i64/u64 bitwise AND/OR/XOR were lowered with the 32-bit `AndRR`/`OrRR`/`XorRR` forms unconditionally, so a 64-bit result had its high 32 bits zeroed:

```rue
fn val() -> i64 { 1 }
fn main() -> i32 {
    let a: i64 = (val() << 40) | 1;   // (1<<40) | 1
    if a > 4294967296 { 1 } else { 2 }   // before: 2 (truncated to 1); after: 1
}
```

## Changes

- Add `And64RR`/`Or64RR`/`Xor64RR` (REX.W forms of `and`/`or`/`xor r/m64, r64`), wired through `mir`/`liveness`/`regalloc`/`schedule`/`emit`.
- Select them in the `BitAnd`/`BitOr`/`BitXor` lowering when operands are 64-bit. Sub-64-bit bitwise ops keep the 32-bit forms.

## Scope

x86-64 only. The aarch64 backend already emits 64-bit (X-register) `and`/`orr`/`eor` for these ops (verified via `--emit asm`: i64 → `orr x..`), and high bits are don't-care for sub-64-bit results, so aarch64 is unaffected.

Fourth sub-issue of the operand-width epic RUE-105 (after RUE-27/RUE-87 in #893, RUE-26 in #894). Remaining: RUE-88 (intCast sign-extend).

## Testing

- Bitwise cases added to `crates/rue-cli-tests/cases/width.toml` (i64 and/or/xor preserve the high 32 bits; i32 control) — run on both CI hosts.
- `emit.rs` encoder unit tests pin the REX.W bytes (`48 21/09/31 ..`).
- `./test.sh` green: spec 1346/0 + traceability 100%, UI 47/0, CLI 44/0, codegen unit tests pass.

Fixes RUE-58.

🤖 Generated with [Claude Code](https://claude.com/claude-code)