### PR TITLE
@intCast: sign-extend signed integers when widening (RUE-88)

### DIFF
--- a/crates/rue-cli-tests/cases/intcast.toml
+++ b/crates/rue-cli-tests/cases/intcast.toml
@@ -1,0 +1,107 @@
+# @intCast widening sign-extension regression tests (RUE-88, epic RUE-105).
+#
+# Widening a signed integer to a larger type must SIGN-extend the high bits.
+# Both backends used a plain 64-bit move after the range check, carrying the
+# source's zero-extended high bits, so e.g. i32 -5 widened to i64 became
+# 4294967291. Now a movsx (x86-64) / sxtb/sxth/sxtw (aarch64) is emitted.
+#
+# Negative i8/i16 values are produced by narrowing an i32 (`@intCast(0 - 5)`)
+# rather than i8/i16 arithmetic, to avoid the unrelated sub-word overflow-check
+# bug (RUE-28/RUE-60).
+
+[section]
+id = "cli.intcast"
+name = "@intCast widening sign-extension"
+description = "Widening a signed integer must sign-extend, not zero-extend."
+
+[[case]]
+name = "i32_to_i64_negative_sign_extends"
+files = [{ path = "main.rue", source = """
+fn neg(x: i32) -> i32 { 0 - x }
+fn main() -> i32 {
+    let a: i32 = neg(5);          // -5, produced at runtime
+    let b: i64 = @intCast(a);     // must be -5, not 4294967291
+    if b == 0 - 5 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "i8_to_i64_negative_sign_extends"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let n: i32 = 0 - 5;
+    let a: i8 = @intCast(n);      // -5 as i8
+    let b: i64 = @intCast(a);     // widen i8 -> i64, must be -5
+    if b == 0 - 5 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "i16_to_i64_negative_sign_extends"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let n: i32 = 0 - 5;
+    let a: i16 = @intCast(n);
+    let b: i64 = @intCast(a);
+    if b == 0 - 5 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "i16_to_i32_negative_sign_extends"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let n: i32 = 0 - 5;
+    let a: i16 = @intCast(n);
+    let b: i32 = @intCast(a);
+    if b == 0 - 5 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+# Control: positive signed widening is unchanged.
+[[case]]
+name = "i32_to_i64_positive_ok"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = 5;
+    let b: i64 = @intCast(a);
+    if b == 5 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+# Control: unsigned widening must zero-extend (still correct).
+[[case]]
+name = "u32_to_u64_zero_extends"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: u32 = 4000000000;
+    let b: u64 = @intCast(a);
+    if b == 4000000000 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+# Control: a narrowing cast that overflows still traps.
+#
+# xfail on aarch64: the narrowing range check there compares only the low 32
+# bits of the 64-bit source (RUE-31), so this out-of-range value (whose low 32
+# bits happen to land in i32 range) is silently truncated instead of trapping.
+# That is a separate bug from this PR's widening sign-extension; remove
+# `known_bug_on` when RUE-31 is fixed.
+[[case]]
+name = "i64_to_i32_overflow_traps"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i64 = 5000000000;
+    @intCast(a)
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["integer cast overflow"]
+known_bug = "RUE-31"
+known_bug_on = ["aarch64-linux", "aarch64-macos"]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2578,12 +2578,27 @@ impl<'a> CfgLower<'a> {
                 // Emit range check and panic if out of bounds
                 self.emit_int_cast_check(src_vreg, *from_ty, to_ty);
 
-                // Move the value to the result vreg (the bits are already correct
-                // after sign/zero extension from the range check or simple copy)
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Virtual(vreg),
-                    src: Operand::Virtual(src_vreg),
-                });
+                // Move the value to the result vreg. A signed source widened to a
+                // larger type must be SIGN-extended into the high bits — a plain
+                // 64-bit copy would carry the source's zero-extended high bits,
+                // turning e.g. i32 -5 into 4294967291 (RUE-88). Emit an explicit
+                // sxtb/sxth/sxtw for that case.
+                let from_bits = Self::type_bits(*from_ty);
+                let to_bits = Self::type_bits(to_ty);
+                if from_ty.is_signed() && to_bits > from_bits {
+                    let dst = Operand::Virtual(vreg);
+                    let src = Operand::Virtual(src_vreg);
+                    match from_bits {
+                        8 => self.mir.push(Aarch64Inst::Sxtb { dst, src }),
+                        16 => self.mir.push(Aarch64Inst::Sxth { dst, src }),
+                        _ => self.mir.push(Aarch64Inst::Sxtw { dst, src }),
+                    }
+                } else {
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(src_vreg),
+                    });
+                }
             }
 
             CfgInstData::Drop {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2736,12 +2736,29 @@ impl<'a> CfgLower<'a> {
                 // Emit range check and panic if out of bounds
                 self.emit_int_cast_check(src_vreg, *from_ty, to_ty);
 
-                // Move the value to the result vreg (the bits are already correct
-                // after sign/zero extension from the range check or simple copy)
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(vreg),
-                    src: Operand::Virtual(src_vreg),
-                });
+                // Move the value to the result vreg. A signed source widened to a
+                // larger type must be SIGN-extended into the high bits — a plain
+                // 64-bit copy would carry the source's zero-extended high bits,
+                // turning e.g. i32 -5 into 4294967291 (RUE-88). The value is held
+                // zero-extended in the register, so emit an explicit movsx.
+                let from_bits = Self::type_bits(*from_ty);
+                let to_bits = Self::type_bits(to_ty);
+                if from_ty.is_signed() && to_bits > from_bits {
+                    let dst = Operand::Virtual(vreg);
+                    let src = Operand::Virtual(src_vreg);
+                    match from_bits {
+                        8 => self.mir.push(X86Inst::Movsx8To64 { dst, src }),
+                        16 => self.mir.push(X86Inst::Movsx16To64 { dst, src }),
+                        _ => self.mir.push(X86Inst::Movsx32To64 { dst, src }),
+                    }
+                } else {
+                    // Unsigned widening, narrowing, and same-size reinterpretation
+                    // already hold the correct bits in the low half.
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(src_vreg),
+                    });
+                }
             }
 
             CfgInstData::Drop {


### PR DESCRIPTION
## Summary

Widening a signed integer with `@intCast` (i8/i16/i32 → a larger type) emitted a plain register move after the range check, carrying the source's zero-extended high bits — so `i32 -5` widened to `i64` became `4294967291` (and the result diverged between -O0 and -O2).

```rue
fn neg1(x: i32) -> i32 { 0 - x }
fn main() -> i32 {
    let a: i32 = neg1(5);       // -5 at runtime
    let b: i64 = @intCast(a);   // before: 4294967291; after: -5
    if b == 0 - 5 { 0 } else { 1 }
}
```

## Changes

In the IntCast lowering on **both** backends, when the source is signed and the target is wider, emit an explicit sign-extending move — `movsx8/16/32→64` (x86-64) / `sxtb`/`sxth`/`sxtw` (aarch64) — instead of a plain copy. Unsigned widening, narrowing, and same-size reinterpretation are unchanged (they already hold the correct bits in the low half).

Verified cross-compile asm: i32→i64 now emits `sxtw x, w` on aarch64 / `movsx` on x86-64.

## Testing

- `crates/rue-cli-tests/cases/intcast.toml` — i8/i16/i32 → i64 and i16 → i32 of a negative value sign-extend; positive-widening and unsigned-widening controls; narrowing-overflow still traps. Runs on both CI hosts. (Negative i8/i16 values are produced by narrowing an i32 to avoid the unrelated sub-word overflow-check bug RUE-28/RUE-60.)
- `./test.sh` green: spec 1346/0 + traceability 100%, UI 47/0, CLI 47/0.

Fifth sub-issue of the operand-width epic RUE-105. With #893 (RUE-27/87), #894 (RUE-26), #895 (RUE-58), this completes the epic.

Fixes RUE-88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)