### PR TITLE
Fix sub-word i8/i16 overflow check: compare at 32-bit width (RUE-28, RUE-60, RUE-98)

### DIFF
--- a/crates/rue-cli-tests/cases/subword.toml
+++ b/crates/rue-cli-tests/cases/subword.toml
@@ -1,0 +1,113 @@
+# Sub-word (i8/i16) signed arithmetic overflow-check regression tests
+# (RUE-28 add/sub/mul, RUE-60 neg, RUE-98 right-shift; epic RUE-107).
+#
+# The sub-word overflow check sign-extended the low byte/word to 64 bits and
+# compared it with a 64-bit compare against the result. But the arithmetic was
+# emitted as a 32-bit op that zero-extends bits 32-63, so any legitimately
+# negative in-range result (e.g. -3) mismatched the sign-extended value and
+# falsely trapped "integer overflow". The compare is now 32-bit. Genuine
+# overflow (a value outside the type's range) must still trap.
+
+[section]
+id = "cli.subword"
+name = "Sub-word integer overflow checks"
+description = "i8/i16 arithmetic with in-range negative results must not falsely trap."
+
+[[case]]
+name = "i8_sub_negative_in_range"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i8 = 2;
+    let b: i8 = 5;
+    let c: i8 = a - b;     // -3, in range; must not trap
+    if c == 0 - 3 { 1 } else { 0 }
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "i8_add_negative_in_range"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i8 = 0 - 1;
+    let b: i8 = 0 - 1;
+    let c: i8 = a + b;     // -2
+    if c == 0 - 2 { 1 } else { 0 }
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "i8_mul_negative_in_range"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i8 = 0 - 5;
+    let b: i8 = 3;
+    let c: i8 = a * b;     // -15
+    if c == 0 - 15 { 1 } else { 0 }
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "i8_neg_in_range"
+files = [{ path = "main.rue", source = """
+fn negate(x: i8) -> i8 { 0 - x }
+fn main() -> i32 {
+    let c: i8 = negate(5);   // -5
+    if c == 0 - 5 { 1 } else { 0 }
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "i16_sub_negative_in_range"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i16 = 5;
+    let b: i16 = 10;
+    let c: i16 = a - b;    // -5
+    if c == 0 - 5 { 1 } else { 0 }
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "i16_arith_right_shift_negative"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i16 = 0 - 16;
+    let r: i16 = a >> 2;   // -4 (arithmetic shift)
+    if r == 0 - 4 { 1 } else { 0 }
+}
+""" }]
+exit_code = 1
+
+# Control: genuine overflow must still trap.
+[[case]]
+name = "i8_genuine_add_overflow_traps"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i8 = 100;
+    let b: i8 = 50;
+    let c: i8 = a + b;     // 150 > 127, overflow at this op
+    @dbg(c);
+    0
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["integer overflow"]
+
+[[case]]
+name = "i8_genuine_mul_overflow_traps"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i8 = 100;
+    let b: i8 = 2;
+    let c: i8 = a * b;     // 200 > 127, overflow at this op
+    @dbg(c);
+    0
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["integer overflow"]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2858,8 +2858,12 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(sext_vreg),
                     src: Operand::Virtual(result_vreg),
                 });
-                // Use 64-bit compare since sext_vreg is a 64-bit value
-                self.mir.push(Aarch64Inst::Cmp64RR {
+                // Compare at 32-bit width. The sub-word arithmetic was emitted
+                // as a 32-bit (W-register) op that zeroes bits 32-63, so a 64-bit
+                // compare against the sign-extended byte/word would mismatch a
+                // legitimately-negative in-range result and falsely trap
+                // (RUE-28 sub, RUE-60 neg). The low 32 bits must match.
+                self.mir.push(Aarch64Inst::CmpRR {
                     src1: Operand::Virtual(result_vreg),
                     src2: Operand::Virtual(sext_vreg),
                 });
@@ -2875,8 +2879,12 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(sext_vreg),
                     src: Operand::Virtual(result_vreg),
                 });
-                // Use 64-bit compare since sext_vreg is a 64-bit value
-                self.mir.push(Aarch64Inst::Cmp64RR {
+                // Compare at 32-bit width. The sub-word arithmetic was emitted
+                // as a 32-bit (W-register) op that zeroes bits 32-63, so a 64-bit
+                // compare against the sign-extended byte/word would mismatch a
+                // legitimately-negative in-range result and falsely trap
+                // (RUE-28 sub, RUE-60 neg). The low 32 bits must match.
+                self.mir.push(Aarch64Inst::CmpRR {
                     src1: Operand::Virtual(result_vreg),
                     src2: Operand::Virtual(sext_vreg),
                 });

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3057,8 +3057,14 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(sext_vreg),
                     src: Operand::Virtual(result_vreg),
                 });
-                // Use 64-bit compare since sext_vreg is a 64-bit value
-                self.mir.push(X86Inst::Cmp64RR {
+                // Compare at 32-bit width. The sub-word arithmetic was emitted
+                // as a 32-bit op that zero-extends bits 32-63, so result_vreg's
+                // valid data is only in its low 32 bits. A 64-bit compare against
+                // the sign-extended byte/word (1s in bits 32-63 for a negative
+                // value) would mismatch a legitimately-negative in-range result
+                // and falsely trap (RUE-28 sub, RUE-60 neg). The low 32 bits —
+                // sign-extended byte/word vs the 32-bit result — must match.
+                self.mir.push(X86Inst::CmpRR {
                     src1: Operand::Virtual(result_vreg),
                     src2: Operand::Virtual(sext_vreg),
                 });
@@ -3072,8 +3078,14 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(sext_vreg),
                     src: Operand::Virtual(result_vreg),
                 });
-                // Use 64-bit compare since sext_vreg is a 64-bit value
-                self.mir.push(X86Inst::Cmp64RR {
+                // Compare at 32-bit width. The sub-word arithmetic was emitted
+                // as a 32-bit op that zero-extends bits 32-63, so result_vreg's
+                // valid data is only in its low 32 bits. A 64-bit compare against
+                // the sign-extended byte/word (1s in bits 32-63 for a negative
+                // value) would mismatch a legitimately-negative in-range result
+                // and falsely trap (RUE-28 sub, RUE-60 neg). The low 32 bits —
+                // sign-extended byte/word vs the 32-bit result — must match.
+                self.mir.push(X86Inst::CmpRR {
                     src1: Operand::Virtual(result_vreg),
                     src2: Operand::Virtual(sext_vreg),
                 });


### PR DESCRIPTION
## Summary

The i8/i16 signed overflow check sign-extended the result's low byte/word to 64 bits (`movsx`/`sxtb`/`sxth`) and compared it against the result with a **64-bit** compare. But the sub-word arithmetic (add/sub/mul/neg, and the value feeding an arithmetic right shift) was emitted as a 32-bit op that zero-extends bits 32-63, so the result register holds valid data only in its low 32 bits.

For any in-range **negative** result (e.g. i8 `2 - 5 = -3` = `0x…0000_FFFFFFFD`) the high half is `0` while the sign-extended byte/word has `1`s there, so the 64-bit compare reported a spurious mismatch and falsely trapped "integer overflow".

```rue
fn main() -> i32 {
    let a: i8 = 2;
    let b: i8 = 5;
    let c: i8 = a - b;     // -3, in range — before: panics; after: ok
    if c == 0 - 3 { 1 } else { 0 }
}
```

## Fix

Change the comparison from 64-bit (`Cmp64RR`) to 32-bit (`CmpRR`) in the i8/i16 arms of `emit_overflow_check` on **both** backends. The low 32 bits — sign-extended byte/word vs the 32-bit arithmetic result — are exactly what must match, so this both stops the false trap on in-range negatives and still traps genuine overflow (a value outside the type's range sign-extends to a different low-32 value).

This covers the whole false-overflow family: i8/i16 add/sub/mul, negation, and arithmetic right shift of a negative value (which fed the same check). RUE-29 (shift count masking / result truncation) is a *separate* bug, not addressed here.

## Testing

- `crates/rue-cli-tests/cases/subword.toml` — i8/i16 add/sub/mul/neg and `i16 >>` with in-range negatives no longer trap; genuine i8 add/mul overflow still traps (exit 101). Runs on both CI hosts (the aarch64 backend had the identical bug, now emits `cmp w`).
- `./test.sh` green: spec 1346/0 + traceability 100%, UI 47/0, CLI 52/0.

Three sub-issues of the sub-word epic RUE-107 (RUE-29 remains).

Fixes RUE-28
Fixes RUE-60
Fixes RUE-98

🤖 Generated with [Claude Code](https://claude.com/claude-code)