### PR TITLE
Fix sub-word i8/i16 shift semantics: mask count mod bit width + narrow result (RUE-29)

### DIFF
--- a/crates/rue-cli-tests/cases/shift.toml
+++ b/crates/rue-cli-tests/cases/shift.toml
@@ -1,0 +1,97 @@
+# Sub-word (i8/i16) shift semantics regression tests (RUE-29, epic RUE-107).
+#
+# Two defects: (1) the shift count was masked by 0x1F (mod 32) for every
+# sub-64-bit type instead of mod the operand's bit width, so `1i8 << 8` gave
+# `1 << 8 = 256` instead of the spec's `1 << (8 mod 8) = 1`; (2) the result was
+# not narrowed to the operand width, so `1i8 << 7` held +128 instead of -128
+# and `65535u16 << 1` held 131070 instead of wrapping to 65534. Now the count
+# is masked mod-bit-width and left-shift results are narrowed (sign/zero
+# extension) on both backends.
+
+[section]
+id = "cli.shift"
+name = "Sub-word shift semantics"
+description = "i8/i16 shifts mask the count mod bit width and narrow the result."
+
+[[case]]
+name = "i8_shl_into_sign_bit"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i8 = 1;
+    let s: i8 = 7;
+    let r: i8 = a << s;    // 0x80 as i8 = -128
+    if r < 0 { 1 } else { 0 }
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "i8_shl_count_mod_bitwidth"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i8 = 1;
+    let s: i8 = 8;
+    let r: i8 = a << s;    // 8 mod 8 == 0, so 1 << 0 == 1
+    if r == 1 { 1 } else { 0 }
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "u16_shl_wraps_to_width"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let v: u16 = 65535;
+    let r: u16 = v << 1;   // 131070 truncated to u16 == 65534
+    if r > 65535 { 1 } else { 0 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "u8_shl_value"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: u8 = 1;
+    let s: u8 = 7;
+    let r: u8 = a << s;    // 128
+    @intCast(r)
+}
+""" }]
+exit_code = 128
+
+# Right shift: count is masked mod bit width too.
+[[case]]
+name = "i16_ashr_negative"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i16 = 0 - 16;
+    let r: i16 = a >> 2;   // -4
+    if r == 0 - 4 { 1 } else { 0 }
+}
+""" }]
+exit_code = 1
+
+# Controls: 32/64-bit shifts unchanged.
+[[case]]
+name = "i32_shl_unchanged"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = 1;
+    let s: i32 = 4;
+    a << s             // 16
+}
+""" }]
+exit_code = 16
+
+[[case]]
+name = "i64_shl_high_bits"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i64 = 1;
+    let s: i64 = 40;
+    let r: i64 = a << s;   // 2^40
+    if r > 4294967296 { 1 } else { 0 }
+}
+""" }]
+exit_code = 1

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1139,49 +1139,45 @@ impl<'a> CfgLower<'a> {
 
                 let lhs_vreg = self.get_vreg(*lhs);
 
-                // Check if shift amount is a constant within valid range - use immediate form if so
-                // For 64-bit: 0-63, for 32-bit: 0-31
+                // Shift count taken modulo the operand bit width (spec 4.3a:10);
+                // sub-word counts need an explicit mask (RUE-29).
+                let count_mask = Self::shift_count_mask(ty);
                 let rhs_inst = &self.ctx.cfg.get_inst(*rhs).data;
-                let bit_width = if ty.is_64_bit() { 64 } else { 32 };
                 if let CfgInstData::Const(shift_amount) = rhs_inst {
-                    let shift = *shift_amount;
-                    if shift < bit_width {
-                        let imm = shift as u8;
-                        // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
-                        if ty.is_64_bit() {
-                            self.mir.push(Aarch64Inst::LslImm {
-                                dst: Operand::Virtual(vreg),
-                                src: Operand::Virtual(lhs_vreg),
-                                imm,
-                            });
-                        } else {
-                            self.mir.push(Aarch64Inst::Lsl32Imm {
-                                dst: Operand::Virtual(vreg),
-                                src: Operand::Virtual(lhs_vreg),
-                                imm,
-                            });
-                        }
-                        return;
+                    let imm = (*shift_amount & count_mask) as u8;
+                    if ty.is_64_bit() {
+                        self.mir.push(Aarch64Inst::LslImm {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Virtual(lhs_vreg),
+                            imm,
+                        });
+                    } else {
+                        self.mir.push(Aarch64Inst::Lsl32Imm {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Virtual(lhs_vreg),
+                            imm,
+                        });
+                    }
+                } else {
+                    // Variable shift amount - mask it (mod bit width).
+                    let count_vreg = self.emit_masked_shift_count(*rhs, ty);
+                    if ty.is_64_bit() {
+                        self.mir.push(Aarch64Inst::LslRR {
+                            dst: Operand::Virtual(vreg),
+                            src1: Operand::Virtual(lhs_vreg),
+                            src2: Operand::Virtual(count_vreg),
+                        });
+                    } else {
+                        self.mir.push(Aarch64Inst::Lsl32RR {
+                            dst: Operand::Virtual(vreg),
+                            src1: Operand::Virtual(lhs_vreg),
+                            src2: Operand::Virtual(count_vreg),
+                        });
                     }
                 }
-                // Variable shift amount or out-of-range constant - use register form
-                let rhs_vreg = self.get_vreg(*rhs);
-
-                // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
-                // 32-bit shift masks by 31, 64-bit shift masks by 63
-                if ty.is_64_bit() {
-                    self.mir.push(Aarch64Inst::LslRR {
-                        dst: Operand::Virtual(vreg),
-                        src1: Operand::Virtual(lhs_vreg),
-                        src2: Operand::Virtual(rhs_vreg),
-                    });
-                } else {
-                    self.mir.push(Aarch64Inst::Lsl32RR {
-                        dst: Operand::Virtual(vreg),
-                        src1: Operand::Virtual(lhs_vreg),
-                        src2: Operand::Virtual(rhs_vreg),
-                    });
-                }
+                // Left shift can set bits above the operand width; narrow the
+                // result back to the sub-word type (RUE-29).
+                self.emit_subword_narrow(vreg, ty);
             }
 
             CfgInstData::Shr(lhs, rhs) => {
@@ -1190,73 +1186,66 @@ impl<'a> CfgLower<'a> {
 
                 let lhs_vreg = self.get_vreg(*lhs);
 
-                // Check if shift amount is a constant within valid range - use immediate form if so
-                // For 64-bit: 0-63, for 32-bit: 0-31
+                // Shift count taken modulo the operand bit width (spec 4.3a:10);
+                // sub-word counts need an explicit mask (RUE-29).
+                let count_mask = Self::shift_count_mask(ty);
                 let rhs_inst = &self.ctx.cfg.get_inst(*rhs).data;
-                let bit_width = if ty.is_64_bit() { 64 } else { 32 };
                 if let CfgInstData::Const(shift_amount) = rhs_inst {
-                    let shift = *shift_amount;
-                    if shift < bit_width {
-                        let imm = shift as u8;
-                        // Use arithmetic shift (ASR) for signed types, logical shift (LSR) for unsigned
-                        // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
-                        if ty.is_64_bit() && ty.is_signed() {
-                            self.mir.push(Aarch64Inst::Asr64Imm {
-                                dst: Operand::Virtual(vreg),
-                                src: Operand::Virtual(lhs_vreg),
-                                imm,
-                            });
-                        } else if ty.is_64_bit() {
-                            self.mir.push(Aarch64Inst::Lsr64Imm {
-                                dst: Operand::Virtual(vreg),
-                                src: Operand::Virtual(lhs_vreg),
-                                imm,
-                            });
-                        } else if ty.is_signed() {
-                            self.mir.push(Aarch64Inst::Asr32Imm {
-                                dst: Operand::Virtual(vreg),
-                                src: Operand::Virtual(lhs_vreg),
-                                imm,
-                            });
-                        } else {
-                            self.mir.push(Aarch64Inst::Lsr32Imm {
-                                dst: Operand::Virtual(vreg),
-                                src: Operand::Virtual(lhs_vreg),
-                                imm,
-                            });
-                        }
-                        return;
+                    let imm = (*shift_amount & count_mask) as u8;
+                    // Use arithmetic shift (ASR) for signed types, logical shift (LSR) for unsigned
+                    if ty.is_64_bit() && ty.is_signed() {
+                        self.mir.push(Aarch64Inst::Asr64Imm {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Virtual(lhs_vreg),
+                            imm,
+                        });
+                    } else if ty.is_64_bit() {
+                        self.mir.push(Aarch64Inst::Lsr64Imm {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Virtual(lhs_vreg),
+                            imm,
+                        });
+                    } else if ty.is_signed() {
+                        self.mir.push(Aarch64Inst::Asr32Imm {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Virtual(lhs_vreg),
+                            imm,
+                        });
+                    } else {
+                        self.mir.push(Aarch64Inst::Lsr32Imm {
+                            dst: Operand::Virtual(vreg),
+                            src: Operand::Virtual(lhs_vreg),
+                            imm,
+                        });
                     }
-                }
-                // Variable shift amount or out-of-range constant - use register form
-                let rhs_vreg = self.get_vreg(*rhs);
-
-                // Use arithmetic shift (ASR) for signed types, logical shift (LSR) for unsigned
-                // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
-                if ty.is_64_bit() && ty.is_signed() {
-                    self.mir.push(Aarch64Inst::AsrRR {
-                        dst: Operand::Virtual(vreg),
-                        src1: Operand::Virtual(lhs_vreg),
-                        src2: Operand::Virtual(rhs_vreg),
-                    });
-                } else if ty.is_64_bit() {
-                    self.mir.push(Aarch64Inst::LsrRR {
-                        dst: Operand::Virtual(vreg),
-                        src1: Operand::Virtual(lhs_vreg),
-                        src2: Operand::Virtual(rhs_vreg),
-                    });
-                } else if ty.is_signed() {
-                    self.mir.push(Aarch64Inst::Asr32RR {
-                        dst: Operand::Virtual(vreg),
-                        src1: Operand::Virtual(lhs_vreg),
-                        src2: Operand::Virtual(rhs_vreg),
-                    });
                 } else {
-                    self.mir.push(Aarch64Inst::Lsr32RR {
-                        dst: Operand::Virtual(vreg),
-                        src1: Operand::Virtual(lhs_vreg),
-                        src2: Operand::Virtual(rhs_vreg),
-                    });
+                    // Variable shift amount - mask it (mod bit width).
+                    let count_vreg = self.emit_masked_shift_count(*rhs, ty);
+                    if ty.is_64_bit() && ty.is_signed() {
+                        self.mir.push(Aarch64Inst::AsrRR {
+                            dst: Operand::Virtual(vreg),
+                            src1: Operand::Virtual(lhs_vreg),
+                            src2: Operand::Virtual(count_vreg),
+                        });
+                    } else if ty.is_64_bit() {
+                        self.mir.push(Aarch64Inst::LsrRR {
+                            dst: Operand::Virtual(vreg),
+                            src1: Operand::Virtual(lhs_vreg),
+                            src2: Operand::Virtual(count_vreg),
+                        });
+                    } else if ty.is_signed() {
+                        self.mir.push(Aarch64Inst::Asr32RR {
+                            dst: Operand::Virtual(vreg),
+                            src1: Operand::Virtual(lhs_vreg),
+                            src2: Operand::Virtual(count_vreg),
+                        });
+                    } else {
+                        self.mir.push(Aarch64Inst::Lsr32RR {
+                            dst: Operand::Virtual(vreg),
+                            src1: Operand::Virtual(lhs_vreg),
+                            src2: Operand::Virtual(count_vreg),
+                        });
+                    }
                 }
             }
 
@@ -3374,6 +3363,55 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Get the min and max values for an integer type.
+    /// The AND mask (bit_width - 1) applied to a shift count, since the count
+    /// is taken modulo the operand's bit width (spec 4.3a:10).
+    fn shift_count_mask(ty: Type) -> u64 {
+        match Self::type_bits(ty) {
+            8 => 0x07,
+            16 => 0x0F,
+            64 => 0x3F,
+            _ => 0x1F, // 32-bit
+        }
+    }
+
+    /// Materialize the shift count masked to the operand's bit width into a
+    /// fresh vreg (so a sub-word variable count >= the width wraps per spec).
+    /// For 32/64-bit operands the hardware mask already matches.
+    fn emit_masked_shift_count(&mut self, rhs: CfgValue, ty: Type) -> VReg {
+        let rhs_vreg = self.get_vreg(rhs);
+        if Self::type_bits(ty) >= 32 {
+            return rhs_vreg;
+        }
+        let mask_vreg = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(mask_vreg),
+            imm: Self::shift_count_mask(ty) as i64,
+        });
+        let count_vreg = self.mir.alloc_vreg();
+        self.mir.push(Aarch64Inst::AndRR {
+            dst: Operand::Virtual(count_vreg),
+            src1: Operand::Virtual(rhs_vreg),
+            src2: Operand::Virtual(mask_vreg),
+        });
+        count_vreg
+    }
+
+    /// Narrow a value to a sub-word integer type by sign-/zero-extending its
+    /// low byte/halfword, so it holds the correct value after an op that may
+    /// have set bits above the operand width (e.g. a left shift). No-op for
+    /// 32/64-bit types.
+    fn emit_subword_narrow(&mut self, vreg: VReg, ty: Type) {
+        let dst = Operand::Virtual(vreg);
+        let src = Operand::Virtual(vreg);
+        match Self::type_bits(ty) {
+            8 if ty.is_signed() => self.mir.push(Aarch64Inst::Sxtb { dst, src }),
+            8 => self.mir.push(Aarch64Inst::Uxtb { dst, src }),
+            16 if ty.is_signed() => self.mir.push(Aarch64Inst::Sxth { dst, src }),
+            16 => self.mir.push(Aarch64Inst::Uxth { dst, src }),
+            _ => {}
+        }
+    }
+
     fn type_range(ty: Type) -> (i64, i64) {
         match ty.kind() {
             TypeKind::I8 => (i8::MIN as i64, i8::MAX as i64),

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -251,6 +251,59 @@ impl<'a> CfgLower<'a> {
         }
     }
 
+    /// The AND mask (bit_width - 1) applied to a shift count, since the count
+    /// is taken modulo the operand's bit width (spec 4.3a:10).
+    fn shift_count_mask(ty: Type) -> u64 {
+        match Self::type_bits(ty) {
+            8 => 0x07,
+            16 => 0x0F,
+            64 => 0x3F,
+            _ => 0x1F, // 32-bit
+        }
+    }
+
+    /// Materialize the shift count masked to the operand's bit width into a
+    /// fresh vreg, so a sub-word variable count >= the width wraps per spec
+    /// (the x86 CL shift only masks by 31/63). For 32/64-bit operands the
+    /// hardware mask already matches, so the count is returned unmasked.
+    fn emit_masked_shift_count(&mut self, rhs: CfgValue, ty: Type) -> VReg {
+        let rhs_vreg = self.get_vreg(rhs);
+        if Self::type_bits(ty) >= 32 {
+            return rhs_vreg;
+        }
+        let mask_vreg = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRI32 {
+            dst: Operand::Virtual(mask_vreg),
+            imm: Self::shift_count_mask(ty) as i32,
+        });
+        let count_vreg = self.mir.alloc_vreg();
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Virtual(count_vreg),
+            src: Operand::Virtual(rhs_vreg),
+        });
+        self.mir.push(X86Inst::AndRR {
+            dst: Operand::Virtual(count_vreg),
+            src: Operand::Virtual(mask_vreg),
+        });
+        count_vreg
+    }
+
+    /// Narrow a value to a sub-word integer type by sign-/zero-extending its
+    /// low byte/word over the register, so it holds the correct value for the
+    /// type after an op that may have set bits above the operand width (e.g. a
+    /// left shift). No-op for 32/64-bit types.
+    fn emit_subword_narrow(&mut self, vreg: VReg, ty: Type) {
+        let dst = Operand::Virtual(vreg);
+        let src = Operand::Virtual(vreg);
+        match Self::type_bits(ty) {
+            8 if ty.is_signed() => self.mir.push(X86Inst::Movsx8To64 { dst, src }),
+            8 => self.mir.push(X86Inst::Movzx8To64 { dst, src }),
+            16 if ty.is_signed() => self.mir.push(X86Inst::Movsx16To64 { dst, src }),
+            16 => self.mir.push(X86Inst::Movzx16To64 { dst, src }),
+            _ => {}
+        }
+    }
+
     /// Allocate a new inline label ID.
     ///
     /// These labels are used for control flow within instruction lowering
@@ -1197,14 +1250,15 @@ impl<'a> CfgLower<'a> {
                     src: Operand::Virtual(lhs_vreg),
                 });
 
-                // Check if shift amount is a constant - use immediate form if so
-                // Mask shift amount to match x86-64 hardware semantics:
-                // 63 (0x3F) for 64-bit shifts, 31 (0x1F) for 32-bit shifts
+                // The shift count is taken modulo the operand's bit width
+                // (spec 4.3a:10): mod 8 for i8/u8, 16 for i16/u16, 32 for
+                // i32/u32, 64 for i64/u64. The x86 hardware only masks by 31
+                // (32-bit shift) or 63 (64-bit), so sub-word counts need an
+                // explicit mask (RUE-29).
+                let count_mask = Self::shift_count_mask(ty);
                 let rhs_inst = &self.ctx.cfg.get_inst(*rhs).data;
                 if let CfgInstData::Const(shift_amount) = rhs_inst {
-                    let mask = if ty.is_64_bit() { 0x3F } else { 0x1F };
-                    let imm = (*shift_amount & mask) as u8;
-                    // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
+                    let imm = (*shift_amount & count_mask) as u8;
                     if ty.is_64_bit() {
                         self.mir.push(X86Inst::ShlRI {
                             dst: Operand::Virtual(vreg),
@@ -1217,17 +1271,12 @@ impl<'a> CfgLower<'a> {
                         });
                     }
                 } else {
-                    // Variable shift amount - use CL register
-                    let rhs_vreg = self.get_vreg(*rhs);
-
-                    // Move shift amount to RCX (CL is the low byte)
+                    // Variable shift amount - mask it (mod bit width) and use CL.
+                    let count_vreg = self.emit_masked_shift_count(*rhs, ty);
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Physical(Reg::Rcx),
-                        src: Operand::Virtual(rhs_vreg),
+                        src: Operand::Virtual(count_vreg),
                     });
-
-                    // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
-                    // 32-bit shift masks by 31, 64-bit shift masks by 63
                     if ty.is_64_bit() {
                         self.mir.push(X86Inst::ShlRCl {
                             dst: Operand::Virtual(vreg),
@@ -1238,6 +1287,10 @@ impl<'a> CfgLower<'a> {
                         });
                     }
                 }
+                // Left shift can set bits above the operand's width; narrow the
+                // result back to the sub-word type so it has the correct value
+                // (e.g. 1i8 << 7 == -128, not +128) (RUE-29).
+                self.emit_subword_narrow(vreg, ty);
             }
 
             CfgInstData::Shr(lhs, rhs) => {
@@ -1252,13 +1305,12 @@ impl<'a> CfgLower<'a> {
                     src: Operand::Virtual(lhs_vreg),
                 });
 
-                // Check if shift amount is a constant - use immediate form if so.
-                // Mask shift amount to match x86-64 hardware semantics:
-                // 63 (0x3F) for 64-bit shifts, 31 (0x1F) for 32-bit shifts
+                // Shift count taken modulo the operand bit width (spec 4.3a:10);
+                // sub-word counts need an explicit mask (RUE-29).
+                let count_mask = Self::shift_count_mask(ty);
                 let rhs_inst = &self.ctx.cfg.get_inst(*rhs).data;
                 if let CfgInstData::Const(shift_amount) = rhs_inst {
-                    let mask = if ty.is_64_bit() { 0x3F } else { 0x1F };
-                    let imm = (*shift_amount & mask) as u8;
+                    let imm = (*shift_amount & count_mask) as u8;
                     // Use arithmetic shift (SAR) for signed types, logical shift (SHR) for unsigned
                     // Use 64-bit shift for i64/u64, 32-bit shift for smaller types
                     if ty.is_64_bit() && ty.is_signed() {
@@ -1283,13 +1335,11 @@ impl<'a> CfgLower<'a> {
                         });
                     }
                 } else {
-                    // Variable shift amount - use CL register
-                    let rhs_vreg = self.get_vreg(*rhs);
-
-                    // Move shift amount to RCX (CL is the low byte)
+                    // Variable shift amount - mask it (mod bit width) and use CL.
+                    let count_vreg = self.emit_masked_shift_count(*rhs, ty);
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Physical(Reg::Rcx),
-                        src: Operand::Virtual(rhs_vreg),
+                        src: Operand::Virtual(count_vreg),
                     });
 
                     // Use arithmetic shift (SAR) for signed types, logical shift (SHR) for unsigned


### PR DESCRIPTION
## Summary

Two defects in i8/i16 shifts:

1. **Count mask.** The shift count was masked by `0x1F` (mod 32) for every sub-64-bit type instead of mod the operand's bit width, so `1i8 << 8` produced `1 << 8 = 256` instead of the spec's `1 << (8 mod 8) = 1` (spec 4.3a:10).
2. **Result width.** The result was never narrowed to the operand width, so `1i8 << 7` held `+128` instead of `-128`, and `65535u16 << 1` held `131070` instead of wrapping to `65534`.

## Fix

- Mask the shift count by `(bit_width - 1)` per operand type, for **constant and variable (register)** counts.
- Narrow left-shift results back to the sub-word type with a sign-/zero-extending move — `movsx`/`movzx` (x86-64), `sxtb`/`sxth`/`uxtb`/`uxth` (aarch64). Right shifts get the count mask but no narrow (they stay in range). 32/64-bit shifts unchanged.
- Adds `shift_count_mask` / `emit_masked_shift_count` / `emit_subword_narrow` helpers to both backends.

Verified cross-compile asm: aarch64 `1i8 << s` now emits `and` (mask) + `lsl` + `sxtb` (narrow); `u16 << 1` emits `lsl` + `uxth`.

## Testing

- `crates/rue-cli-tests/cases/shift.toml` — i8 `<<` into the sign bit (-128), i8 `<< 8` wrapping mod-8, u16 `<< 1` wrapping, u8 `<< 7 == 128`, i16 arithmetic `>>` of a negative, and i32/i64 controls. Runs on both CI hosts.
- `./test.sh` green: spec 1346/0 + traceability 100%, UI 47/0, CLI 66/0.

This completes the sub-word epic **RUE-107** (RUE-28/60/98 landed in #897).

Fixes RUE-29

🤖 Generated with [Claude Code](https://claude.com/claude-code)