### PR TITLE
Materialize all fat-pointer slots for String read from a place (RUE-63, RUE-94)

### DIFF
--- a/crates/rue-cli-tests/cases/string_field.toml
+++ b/crates/rue-cli-tests/cases/string_field.toml
@@ -1,0 +1,81 @@
+[section]
+id = "string_field"
+name = "String fat-pointer materialization from places (RUE-111)"
+description = """
+Regression tests for the struct-field / parameter String ICEs (RUE-63, RUE-94).
+A multi-slot aggregate (builtin String, or a struct containing one) obtained by
+reading a place — a struct field or a rebound parameter — must materialize all of
+its fat-pointer slots, not just the first. Previously these aborted the compiler
+with "string should have fat pointer fields" / "builtin type should have field
+vregs" panics in codegen (both x86-64 and aarch64 backends).
+"""
+
+# RUE-63: a String parameter rebound to a local. Lowering the Alloc of the local
+# previously panicked "string should have fat pointer fields in Alloc" because the
+# param-sourced String had no struct_slot_vregs entry. (No call needed to repro the
+# ICE — defining the function was enough.)
+[[case]]
+name = "string_param_rebound_to_local"
+files = [{ path = "main.rue", source = """
+fn consume(s: String) -> i32 {
+    let held = s;
+    0
+}
+fn main() -> i32 { consume(\"hi\") }
+""" }]
+exit_code = 0
+
+# RUE-94: comparing a String read from a struct field with ==. emit_builtin_eq_call
+# previously panicked "builtin type should have field vregs" because the field-read
+# String was not registered in struct_slot_vregs.
+[[case]]
+name = "string_struct_field_eq_true"
+files = [{ path = "main.rue", source = """
+struct Holder { s: String }
+fn main() -> i32 {
+    let h = Holder { s: \"hello\" };
+    if h.s == \"hello\" { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "string_struct_field_eq_false"
+files = [{ path = "main.rue", source = """
+struct Holder { s: String }
+fn main() -> i32 {
+    let h = Holder { s: \"hello\" };
+    if h.s == \"world\" { 0 } else { 7 }
+}
+""" }]
+exit_code = 7
+
+# RUE-63 (field flavor): a String read from a struct field, rebound to a new local,
+# then consumed. Exercises both the field-read materialization and the re-store
+# (Alloc) of the fat pointer.
+[[case]]
+name = "string_field_rebound_then_eq"
+files = [{ path = "main.rue", source = """
+struct Holder { s: String }
+fn main() -> i32 {
+    let h = Holder { s: \"hello\" };
+    let s2 = h.s;
+    if s2 == \"hello\" { 5 } else { 0 }
+}
+""" }]
+exit_code = 5
+
+# A struct that contains a String field, compared by value. The generic struct
+# equality path reads both operands' field vregs; with a String field this required
+# materializing the String sub-slots from the struct place-read.
+[[case]]
+name = "struct_with_string_field_eq"
+files = [{ path = "main.rue", source = """
+struct P { name: String, age: i32 }
+fn main() -> i32 {
+    let a = P { name: \"bob\", age: 3 };
+    let b = P { name: \"bob\", age: 3 };
+    if a == b { 7 } else { 0 }
+}
+""" }]
+exit_code = 7

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -273,6 +273,51 @@ impl<'a> CfgLower<'a> {
                 }
                 Some(vregs)
             }
+            CfgInstData::PlaceRead { place } => {
+                // A multi-slot aggregate (struct or builtin String) read from a
+                // place — e.g. `let s2 = h.s;`. The base place-read lowering only
+                // materializes the first slot into `dst`; here we materialize all
+                // `slot_count` slots so consumers (struct equality, Alloc/Store of
+                // a fat pointer, etc.) see the full value. Only static field
+                // projections are handled — dynamic array indexing and inout params
+                // fall through to None (preserving prior behavior). (RUE-22/63/94)
+                let projections = self.ctx.cfg.get_place_projections(place).to_vec();
+                let mut static_slot_offset: u32 = 0;
+                for proj in &projections {
+                    match proj {
+                        Projection::Field {
+                            struct_id,
+                            field_index,
+                        } => {
+                            static_slot_offset +=
+                                self.ctx.struct_field_slot_offset(*struct_id, *field_index);
+                        }
+                        Projection::Index { .. } => return None,
+                    }
+                }
+                let base_slot = match place.base {
+                    PlaceBase::Local(slot) => slot + static_slot_offset,
+                    PlaceBase::Param(param_slot) => {
+                        if self.ctx.cfg.is_param_inout(param_slot) {
+                            return None;
+                        }
+                        self.ctx.num_locals + param_slot + static_slot_offset
+                    }
+                };
+                let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                let mut vregs = Vec::with_capacity(slot_count as usize);
+                for i in 0..slot_count {
+                    let vreg = self.mir.alloc_vreg();
+                    let offset = self.ctx.local_offset(base_slot + i);
+                    self.mir.push(Aarch64Inst::Ldr {
+                        dst: Operand::Virtual(vreg),
+                        base: Reg::Fp,
+                        offset,
+                    });
+                    vregs.push(vreg);
+                }
+                Some(vregs)
+            }
             // BlockParam and Call should already have field vregs in cache
             _ => None,
         }
@@ -1263,8 +1308,12 @@ impl<'a> CfgLower<'a> {
                             offset,
                         });
                     }
-                } else if init_type.is_struct() {
-                    // Struct: recursively flatten struct fields (including array fields) to scalars
+                } else if init_type.is_struct() && !self.ctx.is_builtin_string(init_type) {
+                    // Struct: recursively flatten struct fields (including array fields) to scalars.
+                    // Builtin String is also a struct, but must take the dedicated fat-pointer
+                    // branch below (it materializes all 3 slots via get_or_compute_field_vregs);
+                    // collect_struct_scalar_vregs only sees the single lowered vreg for a String
+                    // read from a place, which would drop len/cap. (RUE-63/94)
                     let scalar_vregs = self.collect_struct_scalar_vregs(*init);
                     for (i, scalar_vreg) in scalar_vregs.iter().enumerate() {
                         let field_slot = slot + i as u32;
@@ -1278,9 +1327,7 @@ impl<'a> CfgLower<'a> {
                 } else if self.ctx.is_builtin_string(init_type) {
                     // String: store ptr, len, and cap to consecutive slots
                     let field_vregs = self
-                        .struct_slot_vregs
-                        .get(init)
-                        .cloned()
+                        .get_or_compute_field_vregs(*init)
                         .expect("string should have fat pointer fields in Alloc");
                     debug_assert_eq!(
                         field_vregs.len(),
@@ -3440,18 +3487,14 @@ impl<'a> CfgLower<'a> {
 
             // Get left string fat pointer
             let lhs_fields = self
-                .struct_slot_vregs
-                .get(&lhs)
-                .cloned()
+                .get_or_compute_field_vregs(lhs)
                 .expect("String should have fat pointer fields");
             let lhs_ptr = lhs_fields[0];
             let lhs_len = lhs_fields[1];
 
             // Get right string fat pointer
             let rhs_fields = self
-                .struct_slot_vregs
-                .get(&rhs)
-                .cloned()
+                .get_or_compute_field_vregs(rhs)
                 .expect("String should have fat pointer fields");
             let rhs_ptr = rhs_fields[0];
             let rhs_len = rhs_fields[1];
@@ -3534,14 +3577,10 @@ impl<'a> CfgLower<'a> {
 
         // Get the struct field vregs
         let lhs_fields = self
-            .struct_slot_vregs
-            .get(&lhs)
-            .cloned()
+            .get_or_compute_field_vregs(lhs)
             .expect("struct should have field vregs");
         let rhs_fields = self
-            .struct_slot_vregs
-            .get(&rhs)
-            .cloned()
+            .get_or_compute_field_vregs(rhs)
             .expect("struct should have field vregs");
 
         let struct_def = self.ctx.type_pool.struct_def(struct_id);
@@ -3618,14 +3657,10 @@ impl<'a> CfgLower<'a> {
         // Get string fields (ptr, len, cap) from struct_slot_vregs
         // For comparison, we only use ptr and len (cap is not compared)
         let lhs_fields = self
-            .struct_slot_vregs
-            .get(&lhs)
-            .cloned()
+            .get_or_compute_field_vregs(lhs)
             .expect("string should have fat pointer fields");
         let rhs_fields = self
-            .struct_slot_vregs
-            .get(&rhs)
-            .cloned()
+            .get_or_compute_field_vregs(rhs)
             .expect("string should have fat pointer fields");
 
         debug_assert_eq!(

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -390,6 +390,51 @@ impl<'a> CfgLower<'a> {
                 }
                 Some(vregs)
             }
+            CfgInstData::PlaceRead { place } => {
+                // A multi-slot aggregate (struct or builtin String) read from a
+                // place — e.g. `let s2 = h.s;`. The base place-read lowering only
+                // materializes the first slot into `dst`; here we materialize all
+                // `slot_count` slots so consumers (struct equality, Alloc/Store of
+                // a fat pointer, etc.) see the full value. Only static field
+                // projections are handled — dynamic array indexing and inout params
+                // fall through to None (preserving prior behavior). (RUE-22/63/94)
+                let projections = self.ctx.cfg.get_place_projections(place).to_vec();
+                let mut static_slot_offset: u32 = 0;
+                for proj in &projections {
+                    match proj {
+                        Projection::Field {
+                            struct_id,
+                            field_index,
+                        } => {
+                            static_slot_offset +=
+                                self.ctx.struct_field_slot_offset(*struct_id, *field_index);
+                        }
+                        Projection::Index { .. } => return None,
+                    }
+                }
+                let base_slot = match place.base {
+                    PlaceBase::Local(slot) => slot + static_slot_offset,
+                    PlaceBase::Param(param_slot) => {
+                        if self.ctx.cfg.is_param_inout(param_slot) {
+                            return None;
+                        }
+                        self.ctx.num_locals + param_slot + static_slot_offset
+                    }
+                };
+                let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                let mut vregs = Vec::with_capacity(slot_count as usize);
+                for i in 0..slot_count {
+                    let vreg = self.mir.alloc_vreg();
+                    let offset = self.ctx.local_offset(base_slot + i);
+                    self.mir.push(X86Inst::MovRM {
+                        dst: Operand::Virtual(vreg),
+                        base: Reg::Rbp,
+                        offset,
+                    });
+                    vregs.push(vreg);
+                }
+                Some(vregs)
+            }
             // BlockParam and Call should already have field vregs in cache
             _ => None,
         }
@@ -1511,9 +1556,7 @@ impl<'a> CfgLower<'a> {
                     // Builtin String: store ptr, len, and cap to consecutive slots
                     // Check this before generic Struct case so builtin String uses this path
                     let field_vregs = self
-                        .struct_slot_vregs
-                        .get(init)
-                        .cloned()
+                        .get_or_compute_field_vregs(*init)
                         .expect("string should have fat pointer fields in Alloc");
                     debug_assert_eq!(
                         field_vregs.len(),
@@ -3440,14 +3483,10 @@ impl<'a> CfgLower<'a> {
 
         // Get the struct field vregs
         let lhs_fields = self
-            .struct_slot_vregs
-            .get(&lhs)
-            .cloned()
+            .get_or_compute_field_vregs(lhs)
             .expect("struct should have field vregs");
         let rhs_fields = self
-            .struct_slot_vregs
-            .get(&rhs)
-            .cloned()
+            .get_or_compute_field_vregs(rhs)
             .expect("struct should have field vregs");
 
         let struct_def = self.ctx.type_pool.struct_def(struct_id);
@@ -3526,14 +3565,10 @@ impl<'a> CfgLower<'a> {
         // Get struct fields from struct_slot_vregs
         // For comparison, we use ptr and len (first two fields)
         let lhs_fields = self
-            .struct_slot_vregs
-            .get(&lhs)
-            .cloned()
+            .get_or_compute_field_vregs(lhs)
             .expect("builtin type should have field vregs");
         let rhs_fields = self
-            .struct_slot_vregs
-            .get(&rhs)
-            .cloned()
+            .get_or_compute_field_vregs(rhs)
             .expect("builtin type should have field vregs");
 
         debug_assert!(


### PR DESCRIPTION
## Summary

A multi-slot aggregate (builtin `String`, or a struct containing one) obtained by reading a **place** — a struct field (`h.s`) or a rebound parameter (`let held = s;`) — only had its first slot materialized into `struct_slot_vregs`. Consumers that need the full fat pointer (the `Alloc`/`Store` of the value, struct/String `==`) read `struct_slot_vregs` directly and `.expect()`-panicked when no entry existed, aborting the compiler:

- `string should have fat pointer fields in Alloc` (RUE-63 — String param rebound to a local)
- `builtin type should have field vregs` (RUE-94 — `h.s == "hello"`)

## Fix

Extend `get_or_compute_field_vregs` to handle a `PlaceRead` source: for a static field projection off a `Local` or non-inout `Param` base, load all `slot_count` slots from the computed stack offset. Dynamic array indexing and inout params fall through to `None`, preserving prior behavior. The `Alloc` and equality `.expect()` sites now route through the helper, so the slots are materialized on demand instead of panicking.

Applied to **both** the x86-64 and aarch64 backends (`get_or_compute_field_vregs`, the Alloc-for-String site, `emit_struct_equality`, and the String-eq paths).

## Testing

- New `crates/rue-cli-tests/cases/string_field.toml` (5 cases): String param rebound to a local, struct-field String `==` (true/false), field rebind then compare, and struct-by-value equality with a String field. All pass on x86-64; verified aarch64 lowers without ICE via `--emit asm`.
- Full `./test.sh` green (100% normative traceability, UI + CLI suites pass).

This is the place-read slot-materialization piece of the RUE-106/RUE-111 aggregate work; RUE-22 (general multi-slot place-read) shares the same root and is now partially addressed for the static-field case.

Fixes RUE-63
Fixes RUE-94

🤖 Generated with [Claude Code](https://claude.com/claude-code)