### PR TITLE
Register builtin method signatures for type inference (RUE-95)

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -75,7 +75,7 @@ impl<'a> Sema<'a> {
             .collect();
 
         // Build method signatures with InferType for constraint generation
-        let method_sigs: HashMap<(StructId, Spur), MethodSig> = self
+        let mut method_sigs: HashMap<(StructId, Spur), MethodSig> = self
             .methods
             .iter()
             .map(|((struct_id, method_name), info)| {
@@ -95,6 +95,12 @@ impl<'a> Sema<'a> {
                 )
             })
             .collect();
+
+        // Register builtin-type method signatures (String::len, etc.) so inference
+        // can resolve their return types. Without this, a builtin method-call result
+        // used in a binop (e.g. `s.len() == 2`) was left unconstrained and resolved
+        // to `<error>`, poisoning the other operand's literal-range check. (RUE-95)
+        self.register_builtin_method_sigs(&mut method_sigs);
 
         InferenceContext {
             func_sigs,

--- a/crates/rue-air/src/sema/sema_ctx_builder.rs
+++ b/crates/rue-air/src/sema/sema_ctx_builder.rs
@@ -111,7 +111,7 @@ impl<'a> Sema<'a> {
             .collect();
 
         // Build method signatures with InferType for constraint generation
-        let method_sigs: HashMap<(StructId, Spur), MethodSig> = self
+        let mut method_sigs: HashMap<(StructId, Spur), MethodSig> = self
             .methods
             .iter()
             .map(|((struct_id, method_name), info)| {
@@ -132,11 +132,79 @@ impl<'a> Sema<'a> {
             })
             .collect();
 
+        // Register builtin-type method signatures (String::len, etc.) so the
+        // inference pass can resolve their return types. Builtin methods are NOT
+        // in `self.methods` — they have no RIR body and are analyzed via a separate
+        // path in `analysis.rs` — so without this, a builtin method-call result
+        // used in a binop (e.g. `s.len() == 2`) was left unconstrained and resolved
+        // to `<error>`, poisoning the other operand's literal-range check. (RUE-95)
+        self.register_builtin_method_sigs(&mut method_sigs);
+
         SemaContextInferenceContext {
             func_sigs,
             struct_types,
             enum_types,
             method_sigs,
+        }
+    }
+
+    /// Register inference signatures for builtin-type methods (e.g. `String::len`).
+    ///
+    /// Builtin methods live in the `rue-builtins` registry, not in `self.methods`
+    /// (they have no RIR body), so the constraint generator can't find them by the
+    /// `(StructId, method_name)` key it uses for user methods. We add an equivalent
+    /// `MethodSig` for each builtin method whose name is interned (i.e. referenced
+    /// somewhere in the program — uncalled methods need no signature). Names are
+    /// looked up, never interned, so this stays compatible with `&self`. (RUE-95)
+    pub(crate) fn register_builtin_method_sigs(
+        &self,
+        method_sigs: &mut HashMap<(StructId, Spur), MethodSig>,
+    ) {
+        use rue_builtins::{BUILTIN_TYPES, BuiltinParamType, BuiltinReturnType};
+
+        for builtin in BUILTIN_TYPES {
+            let Some(name_spur) = self.interner.get(builtin.name) else {
+                continue;
+            };
+            let Some(&struct_id) = self.structs.get(&name_spur) else {
+                continue;
+            };
+            let struct_type = Type::new_struct(struct_id);
+
+            for method in builtin.methods {
+                let Some(method_spur) = self.interner.get(method.name) else {
+                    continue; // method never referenced in this program
+                };
+                let param_types = method
+                    .params
+                    .iter()
+                    .map(|p| {
+                        let ty = match p.ty {
+                            BuiltinParamType::U64 => Type::U64,
+                            BuiltinParamType::U8 => Type::U8,
+                            BuiltinParamType::Bool => Type::BOOL,
+                            BuiltinParamType::SelfType => struct_type,
+                        };
+                        self.type_to_infer_type(ty)
+                    })
+                    .collect();
+                let return_ty = match method.return_ty {
+                    BuiltinReturnType::Unit => Type::UNIT,
+                    BuiltinReturnType::U64 => Type::U64,
+                    BuiltinReturnType::U8 => Type::U8,
+                    BuiltinReturnType::Bool => Type::BOOL,
+                    BuiltinReturnType::SelfType => struct_type,
+                };
+                method_sigs.insert(
+                    (struct_id, method_spur),
+                    MethodSig {
+                        struct_type,
+                        has_self: true,
+                        param_types,
+                        return_type: self.type_to_infer_type(return_ty),
+                    },
+                );
+            }
         }
     }
 }

--- a/crates/rue-cli-tests/cases/builtin_method_infer.toml
+++ b/crates/rue-cli-tests/cases/builtin_method_infer.toml
@@ -1,0 +1,65 @@
+# Builtin method-call return types must anchor integer-literal inference (RUE-95).
+#
+# `String::len`/`capacity` return u64, but builtin methods were registered only for
+# sema/airgen — NOT for the HM inference `method_sigs` map — so a builtin method-call
+# result used in a binop with an untyped literal (`s.len() + 1`, `s.len() == 2`) left
+# the literal's type unconstrained, resolving to `<error>` and tripping the E0800
+# range check. These pin the fixed behavior.
+
+[section]
+id = "cli.builtin_method_infer"
+name = "Builtin method return-type inference"
+description = "A builtin method-call result must anchor the type of an integer literal it is combined with."
+
+[[case]]
+name = "len_plus_literal"
+files = [{ path = "main.rue", source = """
+fn main() -> u64 {
+    let s = "hello";
+    s.len() + 1
+}
+""" }]
+exit_code = 6
+
+[[case]]
+name = "len_eq_literal"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = "hi";
+    if s.len() == 2 { 9 } else { 0 }
+}
+""" }]
+exit_code = 9
+
+[[case]]
+name = "len_lt_literal"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = "hello";
+    if s.len() < 10 { 9 } else { 0 }
+}
+""" }]
+exit_code = 9
+
+[[case]]
+name = "len_mul_literal_bound_to_local"
+files = [{ path = "main.rue", source = """
+fn main() -> u64 {
+    let s = "abc";
+    let n = s.len() * 2;
+    n
+}
+""" }]
+exit_code = 6
+
+# capacity() also returns u64; a string literal has cap == 0, so `> 0` is false.
+# (The point is that this compiles at all — previously it was E0800 <error>.)
+[[case]]
+name = "capacity_compare_literal_compiles"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = "hi";
+    if s.capacity() > 0 { 1 } else { 0 }
+}
+""" }]
+exit_code = 0


### PR DESCRIPTION
## Summary

Builtin-type methods (`String::len`, `capacity`, …) live in the `rue-builtins` registry and are resolved by a **dedicated path** in sema analysis. They were **never inserted into the `(StructId, method_name) -> MethodSig` map the HM inference pass uses**. So a builtin method-call result combined with an untyped integer literal in a binop left the result's type variable unconstrained — it resolved to the *error type* and poisoned the literal's range check:

```rue
fn main() -> u64 { let s = "hello"; s.len() + 1 }   // E0800: literal 1 out of range for '<error>'
```

Same for `s.len() == 2`, `s.len() < 10`, `s.len() * 2`, etc. A `u64` **local** or a user **function** call anchored the literal fine — only builtin method-call results were affected.

## Fix

Add `register_builtin_method_sigs`, which inserts a `MethodSig` for each builtin method whose name is interned (i.e. actually referenced in the program — uncalled methods need no sig), and call it from the inference-context builder. Names are looked up, never interned, so it's compatible with the `&self` builder.

While here: there are **two near-identical inference-context builders** — `declarations.rs::build_inference_context` (the one actually on the compile path) and `sema_ctx_builder.rs::build_sema_context_inference`. Both now call the shared helper so they can't silently disagree on this again. (Consolidating the two is worth a follow-up.)

## Testing

- New `crates/rue-cli-tests/cases/builtin_method_infer.toml` (5 cases): `len()+1`, `len()==2`, `len()<10`, `len()*2` bound to a local, and `capacity()>0` compiling.
- Full `./test.sh` green (100% normative traceability; UI + CLI + spec suites pass). Verified the repro lowers on aarch64 via `--emit asm`.

Fixes RUE-95

🤖 Generated with [Claude Code](https://claude.com/claude-code)