### PR TITLE
Register builtin associated-function signatures for type inference (RUE-117)

### DIFF
--- a/crates/rue-air/src/sema/sema_ctx_builder.rs
+++ b/crates/rue-air/src/sema/sema_ctx_builder.rs
@@ -205,6 +205,47 @@ impl<'a> Sema<'a> {
                     },
                 );
             }
+
+            // Associated functions (e.g. `String::new`, `String::with_capacity`) are
+            // resolved by inference through the same `(StructId, name)` method map (see
+            // `InstData::AssocFnCall` in inference/generate.rs). Like methods, they live
+            // only in the rue-builtins registry, so without registering them an untyped
+            // literal arg (`String::with_capacity(8)`) isn't constrained to the param's
+            // `u64` and a result feeding a literal resolves to `<error>`. (RUE-95 sibling)
+            for assoc_fn in builtin.associated_fns {
+                let Some(fn_spur) = self.interner.get(assoc_fn.name) else {
+                    continue; // never referenced in this program
+                };
+                let param_types = assoc_fn
+                    .params
+                    .iter()
+                    .map(|p| {
+                        let ty = match p.ty {
+                            BuiltinParamType::U64 => Type::U64,
+                            BuiltinParamType::U8 => Type::U8,
+                            BuiltinParamType::Bool => Type::BOOL,
+                            BuiltinParamType::SelfType => struct_type,
+                        };
+                        self.type_to_infer_type(ty)
+                    })
+                    .collect();
+                let return_ty = match assoc_fn.return_ty {
+                    BuiltinReturnType::Unit => Type::UNIT,
+                    BuiltinReturnType::U64 => Type::U64,
+                    BuiltinReturnType::U8 => Type::U8,
+                    BuiltinReturnType::Bool => Type::BOOL,
+                    BuiltinReturnType::SelfType => struct_type,
+                };
+                method_sigs.insert(
+                    (struct_id, fn_spur),
+                    MethodSig {
+                        struct_type,
+                        has_self: false,
+                        param_types,
+                        return_type: self.type_to_infer_type(return_ty),
+                    },
+                );
+            }
         }
     }
 }

--- a/crates/rue-cli-tests/cases/builtin_assocfn_infer.toml
+++ b/crates/rue-cli-tests/cases/builtin_assocfn_infer.toml
@@ -1,0 +1,42 @@
+# Builtin associated-function signatures must reach type inference (RUE-117).
+#
+# Sibling of RUE-95 (methods): builtin associated fns (`String::new`,
+# `String::with_capacity`) live only in the rue-builtins registry and weren't
+# registered in the HM inference method map, so an untyped literal argument
+# wasn't constrained to the param type (`with_capacity(8)` -> E0206 expected u64
+# found i32) and a result feeding a literal resolved to `<error>`.
+
+[section]
+id = "cli.builtin_assocfn_infer"
+name = "Builtin associated-function inference"
+description = "Builtin associated functions must constrain literal args and anchor result-type inference."
+
+[[case]]
+name = "with_capacity_literal_arg_is_u64"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = String::with_capacity(8);
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "string_new_result_is_empty"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = String::new();
+    if s.is_empty() { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "string_new_len_eq_literal"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = String::new();
+    if s.len() == 0 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0


### PR DESCRIPTION
## Summary

Sibling of RUE-95. Builtin **associated functions** (`String::new`, `String::with_capacity`) live only in the `rue-builtins` registry and are resolved by a dedicated sema path. Like builtin *methods* before RUE-95, they were never inserted into the `(StructId, name) -> MethodSig` map the HM inference pass consults (`InstData::AssocFnCall` → `Type::ERROR` on the miss). So an untyped literal arg wasn't constrained to the parameter type, and an associated-fn result feeding a literal resolved to the error type:

```rue
fn main() -> i32 { let s = String::with_capacity(8); 0 }   // before: E0206 expected u64, found i32
```

## Fix

Extend `register_builtin_method_sigs` (added in RUE-95) to also register each builtin type's `associated_fns` into the inference `method_sigs` map (key `(struct_id, fn_name)`, `has_self: false`), mirroring the method registration.

## Testing

- New `crates/rue-cli-tests/cases/builtin_assocfn_infer.toml`: `with_capacity(8)` literal arg, `String::new()` result feeding `is_empty()` and `len() == 0`.
- Full `./test.sh` green; aarch64 lowers via `--emit asm`.

Found by a scoped component review of the sema↔inference boundary (the same review that confirmed RUE-95's fix and flagged the duplicate inference-context builders as a follow-up).

Fixes RUE-117

🤖 Generated with [Claude Code](https://claude.com/claude-code)