### PR TITLE
Route all multi-slot aggregate consumers through get_or_compute_field_vregs (RUE-118)

### DIFF
--- a/crates/rue-cli-tests/cases/abi.toml
+++ b/crates/rue-cli-tests/cases/abi.toml
@@ -1,19 +1,22 @@
-# By-value aggregate ABI stress tests.
+# By-value aggregate ABI stress tests (RUE-13).
 #
-# x86-64 has 6 integer argument registers; aggregates passed by value are
-# exploded into per-slot arguments. The matrix below probes sizes around
-# that boundary, in every combination of pass/return, for structs, bare
-# arrays, and methods.
+# Aggregates passed/returned by value are exploded into per-slot arguments
+# (x86-64: 6 integer arg registers, 2 return registers; aarch64/AAPCS: 8 arg
+# registers, and large aggregates passed indirectly). This matrix probes sizes
+# around those boundaries in every pass/return combination for structs, bare
+# arrays, and methods. The per-case `known_bug` / `known_bug_on` markers are
+# the source of truth for exactly what fails where.
 #
-# Current state (RUE-13): on x86-64, pass+return above 6 slots ICEs the
-# compiler; pass-only and return-only above 6 slots SILENTLY MISCOMPILE
-# (wrong values); and method self-update drops field writes at just 5
-# slots. Locals and borrow/inout are correct (those cases pass).
-#
-# aarch64 differs (CI evidence from PR #888): 7-slot cases and 9-slot
-# pass-only WORK there (AAPCS passes large aggregates indirectly), while
-# the return-path cases still fail - hence the platform-scoped
-# known_bug_on markers below.
+# State after RUE-118 (route every aggregate consumer through the slot
+# accessor): aarch64 now handles struct pass/return and bare-array pass-only at
+# all tested sizes (5/7/9 slots). The remaining failures are:
+#   - x86-64's spill of aggregate args/returns past its 6 int arg-registers /
+#     2 return-registers — the 9-slot struct cases, scoped
+#     known_bug_on = ["x86-64-linux"] (they still pass on aarch64). See RUE-91.
+#   - the value-method self-update idiom (method_self_update_5/9_slots) and the
+#     8-element array round-trip (bare_array_8_pass_and_return), which still
+#     drop slots on BOTH backends (known_bug, unscoped).
+# Locals and borrow/inout large aggregates are correct on both backends.
 
 [section]
 id = "cli.abi"
@@ -66,6 +69,7 @@ stdout = "8\n"
 [[case]]
 name = "struct_9_slots_return_only"
 known_bug = "RUE-13"
+known_bug_on = ["x86-64-linux"]
 files = [{ path = "main.rue", source = """
 struct S {
     items: [i32; 8],
@@ -86,8 +90,6 @@ stdout = "8\n"
 
 [[case]]
 name = "struct_7_slots_pass_and_return"
-known_bug = "RUE-13"
-known_bug_on = ["x86-64-linux"]
 files = [{ path = "main.rue", source = """
 struct S {
     items: [i32; 6],
@@ -110,6 +112,7 @@ stdout = "6\n"
 [[case]]
 name = "struct_9_slots_pass_and_return"
 known_bug = "RUE-13"
+known_bug_on = ["x86-64-linux"]
 files = [{ path = "main.rue", source = """
 struct S {
     items: [i32; 8],

--- a/crates/rue-cli-tests/cases/aggregate_slots.toml
+++ b/crates/rue-cli-tests/cases/aggregate_slots.toml
@@ -1,0 +1,120 @@
+# Multi-slot aggregate consumer sites (RUE-118).
+#
+# A multi-slot aggregate (struct, struct-with-array, or the 3-slot String fat
+# pointer) read from a *place* — a struct field `h.s`/`w.p` or a rebound local —
+# must materialize ALL its slots at every consumer site, not just slot 0. These
+# pin the fixed behavior after routing every consumer (call arg, return, Alloc,
+# Store, StructInit field, @dbg, drop) through `get_or_compute_field_vregs`.
+# Previously these silently miscompiled (wrong value, no diagnostic) or ICE'd.
+# Runs on both backends — the aarch64 runtime path is only exercised in CI.
+
+[section]
+id = "cli.aggregate_slots"
+name = "Multi-slot aggregate place-read consumers"
+description = "All slots of a place-read aggregate must reach every consumer site, both backends."
+
+# By-value struct arg sourced from a struct field — previously passed only slot 0
+# (silent miscompile: returned 10 instead of 30).
+[[case]]
+name = "struct_arg_from_field"
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+struct Wrap { p: Point, tag: i32 }
+fn sum(pt: Point) -> i32 { pt.x + pt.y }
+fn main() -> i32 {
+    let w = Wrap { p: Point { x: 10, y: 20 }, tag: 1 };
+    sum(w.p)
+}
+""" }]
+exit_code = 30
+
+# Struct returned by value sourced from a struct field — previously returned only
+# slot 0 (silent miscompile: returned 11 instead of 30).
+[[case]]
+name = "struct_return_from_field"
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+struct Wrap { p: Point, tag: i32 }
+fn get_p(w: Wrap) -> Point { w.p }
+fn main() -> i32 {
+    let w = Wrap { p: Point { x: 10, y: 20 }, tag: 1 };
+    let p = get_p(w);
+    p.x + p.y
+}
+""" }]
+exit_code = 30
+
+# Multi-slot struct read from a field, rebound to a local (Alloc) — previously
+# kept only slot 0.
+[[case]]
+name = "struct_field_rebound_to_local"
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+struct A { p: Point }
+fn main() -> i32 {
+    let a = A { p: Point { x: 10, y: 20 } };
+    let q = a.p;
+    q.x + q.y
+}
+""" }]
+exit_code = 30
+
+# StructInit with a nested-struct field sourced from a place-read — previously an
+# ICE ("nested struct field should have slot vregs in cache").
+[[case]]
+name = "struct_init_nested_field_from_place"
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+struct A { p: Point }
+struct B { p: Point, tag: i32 }
+fn main() -> i32 {
+    let a = A { p: Point { x: 10, y: 20 } };
+    let b = B { p: a.p, tag: 99 };
+    b.p.x + b.p.y
+}
+""" }]
+exit_code = 30
+
+# Store of a String sourced from a struct field — previously an ICE
+# ("string should have fat pointer fields in Store").
+[[case]]
+name = "store_string_from_field"
+files = [{ path = "main.rue", source = """
+struct Holder { s: String, n: i32 }
+fn main() -> i32 {
+    let h = Holder { s: "hello", n: 7 };
+    let mut s2 = "init";
+    s2 = h.s;
+    if s2 == "hello" { 5 } else { 0 }
+}
+""" }]
+exit_code = 5
+
+# @dbg of a String sourced from a struct field — previously an ICE
+# ("string value should have field vregs for fat pointer"). Prints the string.
+[[case]]
+name = "dbg_string_from_field"
+files = [{ path = "main.rue", source = """
+struct Holder { s: String, n: i32 }
+fn main() -> i32 {
+    let h = Holder { s: "hi", n: 1 };
+    @dbg(h.s);
+    0
+}
+""" }]
+exit_code = 0
+stdout = "hi\n"
+
+# Struct containing an array field, copied by value — regression guard that the
+# StructInit/Alloc slot lists stay fully flattened (array elements included).
+[[case]]
+name = "struct_with_array_field_copy"
+files = [{ path = "main.rue", source = """
+struct S { a: [i32; 3], n: i32 }
+fn main() -> i32 {
+    let s = S { a: [1, 2, 3], n: 9 };
+    let t = s;
+    t.a[2] + t.n
+}
+""" }]
+exit_code = 12

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1309,12 +1309,16 @@ impl<'a> CfgLower<'a> {
                         });
                     }
                 } else if init_type.is_struct() && !self.ctx.is_builtin_string(init_type) {
-                    // Struct: recursively flatten struct fields (including array fields) to scalars.
-                    // Builtin String is also a struct, but must take the dedicated fat-pointer
-                    // branch below (it materializes all 3 slots via get_or_compute_field_vregs);
-                    // collect_struct_scalar_vregs only sees the single lowered vreg for a String
-                    // read from a place, which would drop len/cap. (RUE-63/94)
-                    let scalar_vregs = self.collect_struct_scalar_vregs(*init);
+                    // Struct: store all slots via the single accessor. It materializes a
+                    // struct read from a place (`let q = a.p`) by loading its slot_count
+                    // consecutive slots, and cache-hits StructInit/Load/Param/Call/
+                    // BlockParam — all of which now carry fully-flattened slot lists
+                    // (nested arrays included). Fall back to the flattener for any source
+                    // the accessor doesn't model. (RUE-118 / RUE-22)
+                    // (Builtin String is excluded above — it takes the fat-pointer branch.)
+                    let scalar_vregs = self
+                        .get_or_compute_field_vregs(*init)
+                        .unwrap_or_else(|| self.collect_struct_scalar_vregs(*init));
                     for (i, scalar_vreg) in scalar_vregs.iter().enumerate() {
                         let field_slot = slot + i as u32;
                         let offset = self.ctx.local_offset(field_slot);
@@ -1480,9 +1484,7 @@ impl<'a> CfgLower<'a> {
                 if self.ctx.is_builtin_string(val_type) {
                     // String: store ptr, len, and cap to consecutive slots
                     let field_vregs = self
-                        .struct_slot_vregs
-                        .get(val)
-                        .cloned()
+                        .get_or_compute_field_vregs(*val)
                         .expect("string should have fat pointer fields in Store");
                     debug_assert_eq!(
                         field_vregs.len(),
@@ -1699,48 +1701,17 @@ impl<'a> CfgLower<'a> {
                     }
 
                     match arg_type.kind() {
-                        TypeKind::Struct(struct_id) => {
-                            let arg_data = &self.ctx.cfg.get_inst(arg_value).data;
-                            let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
-                            match arg_data {
-                                CfgInstData::Load { slot } => {
-                                    for slot_idx in 0..slot_count {
-                                        let slot_vreg = self.mir.alloc_vreg();
-                                        let actual_slot = slot + slot_idx;
-                                        let offset = self.ctx.local_offset(actual_slot);
-                                        self.mir.push(Aarch64Inst::Ldr {
-                                            dst: Operand::Virtual(slot_vreg),
-                                            base: Reg::Fp,
-                                            offset,
-                                        });
-                                        flattened_vregs.push(slot_vreg);
-                                    }
-                                }
-                                CfgInstData::Param { index } => {
-                                    for slot_idx in 0..slot_count {
-                                        let slot_vreg = self.mir.alloc_vreg();
-                                        let param_slot = self.ctx.num_locals + index + slot_idx;
-                                        let offset = self.ctx.local_offset(param_slot);
-                                        self.mir.push(Aarch64Inst::Ldr {
-                                            dst: Operand::Virtual(slot_vreg),
-                                            base: Reg::Fp,
-                                            offset,
-                                        });
-                                        flattened_vregs.push(slot_vreg);
-                                    }
-                                }
-                                CfgInstData::StructInit { .. } | CfgInstData::Call { .. } => {
-                                    if let Some(field_vregs) =
-                                        self.struct_slot_vregs.get(&arg_value)
-                                    {
-                                        flattened_vregs.extend(field_vregs.iter().copied());
-                                    } else {
-                                        flattened_vregs.push(self.get_vreg(arg_value));
-                                    }
-                                }
-                                _ => {
-                                    flattened_vregs.push(self.get_vreg(arg_value));
-                                }
+                        TypeKind::Struct(_) => {
+                            // Pass all slots of the (possibly multi-slot) struct/String arg,
+                            // regardless of how it was produced — StructInit, Load, Param, Call,
+                            // BlockParam, or a field place-read (`f(h.s)` / `f(w.p)`). The
+                            // accessor materializes lazily-sourced values (Load/Param/PlaceRead)
+                            // and cache-hits eager ones (StructInit/Call/BlockParam). Previously
+                            // the `_` arm here passed only slot 0 of a place-read aggregate. (RUE-118)
+                            if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_value) {
+                                flattened_vregs.extend(field_vregs);
+                            } else {
+                                flattened_vregs.push(self.get_vreg(arg_value));
                             }
                         }
                         TypeKind::Array(_) => {
@@ -1964,8 +1935,9 @@ impl<'a> CfgLower<'a> {
 
                     // Handle String arguments separately
                     if self.ctx.is_builtin_string(arg_type) {
-                        // String is a fat pointer stored as [ptr_vreg, len_vreg] in struct_slot_vregs
-                        if let Some(field_vregs) = self.struct_slot_vregs.get(&arg_val) {
+                        // String fat pointer (ptr, len, cap) — materialize a String read
+                        // from a place (`@dbg(h.s)`) as well as cached sources. (RUE-118)
+                        if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_val) {
                             let ptr_vreg = field_vregs[0];
                             let len_vreg = field_vregs[1];
 
@@ -2079,8 +2051,9 @@ impl<'a> CfgLower<'a> {
                     let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                     let arg_val = args[0];
 
-                    // Get the String fat pointer (ptr, len, cap) from struct_slot_vregs
-                    if let Some(field_vregs) = self.struct_slot_vregs.get(&arg_val) {
+                    // Get the String fat pointer (ptr, len, cap) — materialize a String
+                    // read from a place (`@parse_i32(h.s)`) as well as cached sources. (RUE-118)
+                    if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_val) {
                         let ptr_vreg = field_vregs[0];
                         let len_vreg = field_vregs[1];
 
@@ -2406,13 +2379,17 @@ impl<'a> CfgLower<'a> {
                 for field in &fields {
                     let field_inst = self.ctx.cfg.get_inst(*field);
                     if field_inst.ty.is_struct() {
-                        // Nested struct - get all its slot vregs
+                        // Nested struct/String field - all its slot vregs, incl. a
+                        // field read from another aggregate (`B { p: a.p }`). (RUE-118)
                         let nested_vregs = self
-                            .struct_slot_vregs
-                            .get(field)
-                            .cloned()
-                            .expect("nested struct field should have slot vregs in cache");
+                            .get_or_compute_field_vregs(*field)
+                            .expect("nested struct field should have slot vregs");
                         slot_vregs.extend(nested_vregs);
+                    } else if field_inst.ty.is_array() {
+                        // Nested array field - flatten to its element scalar slots so the
+                        // cached slot list is fully flattened (consumers and the Alloc-of-
+                        // this-StructInit rely on it). (RUE-118)
+                        slot_vregs.extend(self.collect_array_scalar_vregs(*field));
                     } else {
                         // Scalar field - single vreg
                         slot_vregs.push(self.get_vreg(*field));
@@ -2650,51 +2627,12 @@ impl<'a> CfgLower<'a> {
 
                 // Handle String specially - it's a fat pointer (ptr, len, cap)
                 if self.ctx.is_builtin_string(dropped_ty) {
-                    // String requires all 3 slots as arguments to __rue_drop_String
-                    // First, try to get the vregs from cache
-                    let field_vregs =
-                        if let Some(vregs) = self.struct_slot_vregs.get(dropped_value).cloned() {
-                            vregs
-                        } else {
-                            // Not in cache - check if it's a Param instruction
-                            let dropped_inst = &self.ctx.cfg.get_inst(*dropped_value).data;
-                            if let CfgInstData::Param { index } = dropped_inst {
-                                // Load all 3 String fields from param slots
-                                let mut vregs = Vec::with_capacity(3);
-                                for field_idx in 0..3u32 {
-                                    let field_vreg = self.mir.alloc_vreg();
-                                    let param_slot = self.ctx.num_locals + index + field_idx;
-                                    let offset = self.ctx.local_offset(param_slot);
-                                    self.mir.push(Aarch64Inst::Ldr {
-                                        dst: Operand::Virtual(field_vreg),
-                                        base: Reg::Fp,
-                                        offset,
-                                    });
-                                    vregs.push(field_vreg);
-                                }
-                                vregs
-                            } else if let CfgInstData::Load { slot } = dropped_inst {
-                                // Load from local variable slots
-                                let mut vregs = Vec::with_capacity(3);
-                                for field_idx in 0..3u32 {
-                                    let field_vreg = self.mir.alloc_vreg();
-                                    let field_slot = slot + field_idx;
-                                    let offset = self.ctx.local_offset(field_slot);
-                                    self.mir.push(Aarch64Inst::Ldr {
-                                        dst: Operand::Virtual(field_vreg),
-                                        base: Reg::Fp,
-                                        offset,
-                                    });
-                                    vregs.push(field_vreg);
-                                }
-                                vregs
-                            } else {
-                                unreachable!(
-                                    "String value should have field vregs or be a Param/Load: {:?}",
-                                    dropped_inst
-                                );
-                            }
-                        };
+                    // String requires all 3 slots as arguments to __rue_drop_String.
+                    // The accessor handles every source (cache for StructInit/Call/
+                    // BlockParam; materialize for Load/Param/PlaceRead). (RUE-118)
+                    let field_vregs = self
+                        .get_or_compute_field_vregs(*dropped_value)
+                        .expect("String value should have field vregs");
 
                     debug_assert_eq!(
                         field_vregs.len(),
@@ -3883,54 +3821,20 @@ impl<'a> CfgLower<'a> {
                     });
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(Aarch64Inst::Bl { symbol_id });
-                } else if let Some(struct_id) = return_type.as_struct() {
-                    // Return struct in registers
-                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
-                    let value_data = &self.ctx.cfg.get_inst(*value).data;
-
-                    match value_data {
-                        CfgInstData::StructInit { .. }
-                        | CfgInstData::Call { .. }
-                        | CfgInstData::BlockParam { .. } => {
-                            // Use slot vregs from cache (populated for BlockParam, StructInit, Call)
-                            if let Some(slot_vregs) = self.struct_slot_vregs.get(value).cloned() {
-                                for (i, slot_vreg) in slot_vregs.iter().enumerate() {
-                                    if i < RET_REGS.len() {
-                                        self.mir.push(Aarch64Inst::MovRR {
-                                            dst: Operand::Physical(RET_REGS[i]),
-                                            src: Operand::Virtual(*slot_vreg),
-                                        });
-                                    }
-                                }
-                            }
-                        }
-                        CfgInstData::Param { index } => {
-                            for slot_idx in 0..slot_count {
-                                let param_slot = self.ctx.num_locals + index + slot_idx;
-                                let offset = self.ctx.local_offset(param_slot);
-                                self.mir.push(Aarch64Inst::Ldr {
-                                    dst: Operand::Physical(RET_REGS[slot_idx as usize]),
-                                    base: Reg::Fp,
-                                    offset,
-                                });
-                            }
-                        }
-                        CfgInstData::Load { slot } => {
-                            for slot_idx in 0..slot_count {
-                                let actual_slot = slot + slot_idx;
-                                let offset = self.ctx.local_offset(actual_slot);
-                                self.mir.push(Aarch64Inst::Ldr {
-                                    dst: Operand::Physical(RET_REGS[slot_idx as usize]),
-                                    base: Reg::Fp,
-                                    offset,
-                                });
-                            }
-                        }
-                        _ => {
-                            let val_vreg = self.get_vreg(*value);
+                } else if return_type.as_struct().is_some() {
+                    // Return struct in registers. Gather all slots of the returned
+                    // aggregate through the single accessor, regardless of source
+                    // (StructInit/Call/BlockParam cache-hit; Load/Param/PlaceRead
+                    // materialize). Previously the `_` arm returned only slot 0 of a
+                    // place-read aggregate (`fn f(w: Wrap) -> Point { w.p }`). (RUE-118)
+                    let slot_vregs = self
+                        .get_or_compute_field_vregs(*value)
+                        .unwrap_or_else(|| vec![self.get_vreg(*value)]);
+                    for (i, slot_vreg) in slot_vregs.iter().enumerate() {
+                        if i < RET_REGS.len() {
                             self.mir.push(Aarch64Inst::MovRR {
-                                dst: Operand::Physical(Reg::X0),
-                                src: Operand::Virtual(val_vreg),
+                                dst: Operand::Physical(RET_REGS[i]),
+                                src: Operand::Virtual(*slot_vreg),
                             });
                         }
                     }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1592,8 +1592,15 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(cap_vreg),
                     });
                 } else if matches!(init_type.kind(), TypeKind::Struct(_)) {
-                    // Struct: recursively flatten struct fields (including array fields) to scalars
-                    let scalar_vregs = self.collect_struct_scalar_vregs(*init);
+                    // Struct: store all slots via the single accessor. It materializes a
+                    // struct read from a place (`let q = a.p`) by loading its slot_count
+                    // consecutive slots, and cache-hits StructInit/Load/Param/Call/
+                    // BlockParam — all of which now carry fully-flattened slot lists
+                    // (nested arrays included). Fall back to the flattener for any source
+                    // the accessor doesn't model. (RUE-118 / RUE-22)
+                    let scalar_vregs = self
+                        .get_or_compute_field_vregs(*init)
+                        .unwrap_or_else(|| self.collect_struct_scalar_vregs(*init));
                     for (i, scalar_vreg) in scalar_vregs.iter().enumerate() {
                         let field_slot = slot + i as u32;
                         let offset = self.ctx.local_offset(field_slot);
@@ -1722,9 +1729,7 @@ impl<'a> CfgLower<'a> {
                 if self.ctx.is_builtin_string(val_type) {
                     // Builtin String: store ptr, len, and cap to consecutive slots
                     let field_vregs = self
-                        .struct_slot_vregs
-                        .get(val)
-                        .cloned()
+                        .get_or_compute_field_vregs(*val)
                         .expect("string should have fat pointer fields in Store");
                     debug_assert_eq!(
                         field_vregs.len(),
@@ -1897,51 +1902,18 @@ impl<'a> CfgLower<'a> {
                     }
 
                     match arg_type.kind() {
-                        TypeKind::Struct(struct_id) => {
-                            let arg_data = &self.ctx.cfg.get_inst(arg_value).data;
-                            let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
-                            match arg_data {
-                                CfgInstData::Load { slot } => {
-                                    for slot_idx in 0..slot_count {
-                                        let slot_vreg = self.mir.alloc_vreg();
-                                        let actual_slot = slot + slot_idx;
-                                        let offset = self.ctx.local_offset(actual_slot);
-                                        self.mir.push(X86Inst::MovRM {
-                                            dst: Operand::Virtual(slot_vreg),
-                                            base: Reg::Rbp,
-                                            offset,
-                                        });
-                                        flattened_vregs.push(slot_vreg);
-                                    }
-                                }
-                                CfgInstData::Param { index } => {
-                                    for slot_idx in 0..slot_count {
-                                        let slot_vreg = self.mir.alloc_vreg();
-                                        let param_slot = self.ctx.num_locals + index + slot_idx;
-                                        let offset = self.ctx.local_offset(param_slot);
-                                        self.mir.push(X86Inst::MovRM {
-                                            dst: Operand::Virtual(slot_vreg),
-                                            base: Reg::Rbp,
-                                            offset,
-                                        });
-                                        flattened_vregs.push(slot_vreg);
-                                    }
-                                }
-                                // StringConst for builtin String (when String becomes a struct)
-                                CfgInstData::StructInit { .. }
-                                | CfgInstData::Call { .. }
-                                | CfgInstData::StringConst(_) => {
-                                    if let Some(field_vregs) =
-                                        self.struct_slot_vregs.get(&arg_value)
-                                    {
-                                        flattened_vregs.extend(field_vregs.iter().copied());
-                                    } else {
-                                        flattened_vregs.push(self.get_vreg(arg_value));
-                                    }
-                                }
-                                _ => {
-                                    flattened_vregs.push(self.get_vreg(arg_value));
-                                }
+                        TypeKind::Struct(_) => {
+                            // Pass all slots of the (possibly multi-slot) struct/String arg,
+                            // regardless of how it was produced — StructInit, Load, Param, Call,
+                            // BlockParam, or a field place-read (`f(h.s)` / `f(w.p)`). The
+                            // accessor materializes lazily-sourced values (Load/Param/PlaceRead)
+                            // and cache-hits eager ones (StructInit/Call/BlockParam). Previously
+                            // the `_` arm here passed only slot 0 of a place-read aggregate,
+                            // silently dropping the rest. (RUE-118)
+                            if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_value) {
+                                flattened_vregs.extend(field_vregs);
+                            } else {
+                                flattened_vregs.push(self.get_vreg(arg_value));
                             }
                         }
                         TypeKind::Array(_) => {
@@ -2172,8 +2144,9 @@ impl<'a> CfgLower<'a> {
 
                     // Handle builtin String type specially
                     if self.ctx.is_builtin_string(arg_type) {
-                        // Get the fat pointer (ptr, len, cap) from struct_slot_vregs
-                        if let Some(field_vregs) = self.struct_slot_vregs.get(&arg_val).cloned() {
+                        // Get the fat pointer (ptr, len, cap) — materializes a String read
+                        // from a place (`@dbg(h.s)`) as well as cached sources. (RUE-118)
+                        if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_val) {
                             debug_assert_eq!(
                                 field_vregs.len(),
                                 3,
@@ -2293,8 +2266,9 @@ impl<'a> CfgLower<'a> {
                     let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                     let arg_val = args[0];
 
-                    // Get the String fat pointer (ptr, len, cap) from struct_slot_vregs
-                    if let Some(field_vregs) = self.struct_slot_vregs.get(&arg_val).cloned() {
+                    // Get the String fat pointer (ptr, len, cap) — materializes a String
+                    // read from a place (`@parse_i32(h.s)`) as well as cached sources. (RUE-118)
+                    if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_val) {
                         debug_assert_eq!(
                             field_vregs.len(),
                             3,
@@ -2587,17 +2561,25 @@ impl<'a> CfgLower<'a> {
                 let fields = self.ctx.cfg.get_extra(*fields_start, *fields_len).to_vec();
                 for field in &fields {
                     let field_inst = self.ctx.cfg.get_inst(*field);
-                    if let TypeKind::Struct(_) = field_inst.ty.kind() {
-                        // Nested struct - get all its slot vregs
-                        let nested_vregs = self
-                            .struct_slot_vregs
-                            .get(field)
-                            .cloned()
-                            .expect("nested struct field should have slot vregs in cache");
-                        slot_vregs.extend(nested_vregs);
-                    } else {
-                        // Scalar field - single vreg
-                        slot_vregs.push(self.get_vreg(*field));
+                    match field_inst.ty.kind() {
+                        TypeKind::Struct(_) => {
+                            // Nested struct/String field - all its slot vregs, incl. a
+                            // field read from another aggregate (`B { p: a.p }`). (RUE-118)
+                            let nested_vregs = self
+                                .get_or_compute_field_vregs(*field)
+                                .expect("nested struct field should have slot vregs");
+                            slot_vregs.extend(nested_vregs);
+                        }
+                        TypeKind::Array(_) => {
+                            // Nested array field - flatten to its element scalar slots so
+                            // the cached slot list is fully flattened (consumers and the
+                            // Alloc-of-this-StructInit rely on it). (RUE-118)
+                            slot_vregs.extend(self.collect_array_scalar_vregs(*field));
+                        }
+                        _ => {
+                            // Scalar field - single vreg
+                            slot_vregs.push(self.get_vreg(*field));
+                        }
                     }
                 }
 
@@ -2890,51 +2872,12 @@ impl<'a> CfgLower<'a> {
 
                 // Handle builtin String specially - it's a fat pointer (ptr, len, cap)
                 if self.ctx.is_builtin_string(dropped_ty) {
-                    // String requires all 3 slots as arguments to __rue_drop_String
-                    // First, try to get the vregs from cache
-                    let field_vregs =
-                        if let Some(vregs) = self.struct_slot_vregs.get(dropped_value).cloned() {
-                            vregs
-                        } else {
-                            // Not in cache - check if it's a Param instruction
-                            let dropped_inst = &self.ctx.cfg.get_inst(*dropped_value).data;
-                            if let CfgInstData::Param { index } = dropped_inst {
-                                // Load all 3 String fields from param slots
-                                let mut vregs = Vec::with_capacity(3);
-                                for field_idx in 0..3u32 {
-                                    let field_vreg = self.mir.alloc_vreg();
-                                    let param_slot = self.ctx.num_locals + index + field_idx;
-                                    let offset = self.ctx.local_offset(param_slot);
-                                    self.mir.push(X86Inst::MovRM {
-                                        dst: Operand::Virtual(field_vreg),
-                                        base: Reg::Rbp,
-                                        offset,
-                                    });
-                                    vregs.push(field_vreg);
-                                }
-                                vregs
-                            } else if let CfgInstData::Load { slot } = dropped_inst {
-                                // Load from local variable slots
-                                let mut vregs = Vec::with_capacity(3);
-                                for field_idx in 0..3u32 {
-                                    let field_vreg = self.mir.alloc_vreg();
-                                    let field_slot = slot + field_idx;
-                                    let offset = self.ctx.local_offset(field_slot);
-                                    self.mir.push(X86Inst::MovRM {
-                                        dst: Operand::Virtual(field_vreg),
-                                        base: Reg::Rbp,
-                                        offset,
-                                    });
-                                    vregs.push(field_vreg);
-                                }
-                                vregs
-                            } else {
-                                unreachable!(
-                                    "String value should have field vregs or be a Param/Load: {:?}",
-                                    dropped_inst
-                                );
-                            }
-                        };
+                    // String requires all 3 slots as arguments to __rue_drop_String.
+                    // The accessor handles every source (cache for StructInit/Call/
+                    // BlockParam; materialize for Load/Param/PlaceRead). (RUE-118)
+                    let field_vregs = self
+                        .get_or_compute_field_vregs(*dropped_value)
+                        .expect("String value should have field vregs");
 
                     debug_assert_eq!(
                         field_vregs.len(),
@@ -3795,58 +3738,23 @@ impl<'a> CfgLower<'a> {
                     // it 0 mod 16 at callee entry, violating SysV ABI).
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(X86Inst::CallRel { symbol_id });
-                } else if let Some(struct_id) = return_type.as_struct() {
-                    // Return struct in registers
-                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
-                    let value_data = &self.ctx.cfg.get_inst(*value).data;
-
-                    match value_data {
-                        CfgInstData::StructInit { .. }
-                        | CfgInstData::Call { .. }
-                        | CfgInstData::BlockParam { .. } => {
-                            // Use slot vregs from cache (populated for BlockParam, StructInit, Call)
-                            if let Some(slot_vregs) = self.struct_slot_vregs.get(value).cloned() {
-                                // Move slot values to return registers in REVERSE order.
-                                // This is important because register allocation uses Rax as
-                                // scratch when loading spilled values. By moving to Rax last,
-                                // we avoid clobbering it with scratch loads for later slots.
-                                for (i, slot_vreg) in slot_vregs.iter().enumerate().rev() {
-                                    if i < RET_REGS.len() {
-                                        self.mir.push(X86Inst::MovRR {
-                                            dst: Operand::Physical(RET_REGS[i]),
-                                            src: Operand::Virtual(*slot_vreg),
-                                        });
-                                    }
-                                }
-                            }
-                        }
-                        CfgInstData::Param { index } => {
-                            for slot_idx in 0..slot_count {
-                                let param_slot = self.ctx.num_locals + index + slot_idx;
-                                let offset = self.ctx.local_offset(param_slot);
-                                self.mir.push(X86Inst::MovRM {
-                                    dst: Operand::Physical(RET_REGS[slot_idx as usize]),
-                                    base: Reg::Rbp,
-                                    offset,
-                                });
-                            }
-                        }
-                        CfgInstData::Load { slot } => {
-                            for slot_idx in 0..slot_count {
-                                let actual_slot = slot + slot_idx;
-                                let offset = self.ctx.local_offset(actual_slot);
-                                self.mir.push(X86Inst::MovRM {
-                                    dst: Operand::Physical(RET_REGS[slot_idx as usize]),
-                                    base: Reg::Rbp,
-                                    offset,
-                                });
-                            }
-                        }
-                        _ => {
-                            let val_vreg = self.get_vreg(*value);
+                } else if return_type.as_struct().is_some() {
+                    // Return struct in registers. Gather all slots of the returned
+                    // aggregate through the single accessor, regardless of source
+                    // (StructInit/Call/BlockParam cache-hit; Load/Param/PlaceRead
+                    // materialize). Previously the `_` arm returned only slot 0 of a
+                    // place-read aggregate (`fn f(w: Wrap) -> Point { w.p }`). (RUE-118)
+                    let slot_vregs = self
+                        .get_or_compute_field_vregs(*value)
+                        .unwrap_or_else(|| vec![self.get_vreg(*value)]);
+                    // Move slot values to return registers in REVERSE order: regalloc
+                    // uses Rax as scratch when loading spilled values, so moving to Rax
+                    // (RET_REGS[0]) last avoids clobbering it with later slots' loads.
+                    for (i, slot_vreg) in slot_vregs.iter().enumerate().rev() {
+                        if i < RET_REGS.len() {
                             self.mir.push(X86Inst::MovRR {
-                                dst: Operand::Physical(Reg::Rax),
-                                src: Operand::Virtual(val_vreg),
+                                dst: Operand::Physical(RET_REGS[i]),
+                                src: Operand::Virtual(*slot_vreg),
                             });
                         }
                     }


### PR DESCRIPTION
## Summary

This is the Tier-2 consolidation of the codegen aggregate-slot handling flagged by the component review. A multi-slot aggregate (struct, struct-with-array, or the 3-slot `String` fat pointer) read from a **place** — a struct field (`h.s` / `w.p`) or a rebound local — only had its **first slot** materialized at most consumer sites. Each consumer re-derived an aggregate's slots ad hoc (direct `struct_slot_vregs.get().expect()`, `unreachable!`, or a `_ => get_vreg(value)` catch-all), and they disagreed about place-read sources — causing both ICEs and silent miscompiles.

### Bugs fixed (all confirmed by running on x86-64; aarch64 via `--emit asm` + CI)
**Silent miscompiles (wrong answer, no diagnostic — affect plain structs, not just String):**
- by-value struct arg from a field: `sum(w.p)` returned **10** instead of 30
- struct return from a field: `fn f(w) -> Point { w.p }` returned **11** instead of 30

**ICEs:**
- `Store` of a place-read String (`s2 = h.s`)
- `StructInit` with a nested-struct field from a place-read (`B { p: a.p }`)
- `@dbg` / `@parse_*` of a place-read String
- `Drop` of a place-read String

## Fix

Make `get_or_compute_field_vregs` **the** accessor for an aggregate value's slots and route every consumer through it (call-arg, return, Alloc, Store, StructInit-field, `@dbg`/`@parse`, Drop). It materializes lazily-sourced values (Load/Param/PlaceRead → load `slot_count` consecutive slots) and cache-hits eager ones (StructInit/Call/BlockParam). To keep the cache a single source of truth, the `StructInit` lowering now also flattens nested **array** fields into its cached slot list, so the accessor returns fully-flattened slots for every source.

Applied identically to both backends. **Net ~200 fewer lines** as the redundant per-source ladders collapse into the one accessor. This does **not** touch the cross-backend duplication itself — that's tracked separately as the Tier-3 debt item.

## Testing

- New `crates/rue-cli-tests/cases/aggregate_slots.toml` (7 cases): arg/return/Alloc/Store/StructInit/@dbg from a place, plus a struct-with-array copy guard.
- Un-marks `struct_7_slots_pass_and_return` (was `known_bug = "RUE-13"` on x86-64) — this fix makes it pass, so it's now a normal regression test.
- Full `./test.sh` green (1346 unit, 100% normative traceability, 47 UI, 87 CLI). aarch64 structurally verified via `--emit asm` (e.g. `sum(w.p)` loads both slots into x0/x1).

Fixes RUE-118

🤖 Generated with [Claude Code](https://claude.com/claude-code)