### PR TITLE
Mark orphaned loop blocks Unreachable when a while-condition diverges (RUE-77)

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1181,6 +1181,14 @@ impl<'a> CfgBuilder<'a> {
                 // Lower condition in header
                 self.current_block = header_block;
                 let Some(cond_val) = self.lower_value(*cond) else {
+                    // The condition itself diverges (e.g. `while return 8 {}`), so the
+                    // loop body and everything after the loop are unreachable. The
+                    // body/exit blocks allocated above are now orphaned — mark them
+                    // Unreachable so codegen does not assert on a missing terminator —
+                    // and pop the loop context we pushed to keep loop_stack balanced.
+                    self.cfg.set_terminator(body_block, Terminator::Unreachable);
+                    self.cfg.set_terminator(exit_block, Terminator::Unreachable);
+                    self.loop_stack.pop();
                     return Self::diverged();
                 };
 

--- a/crates/rue-cli-tests/cases/programs.toml
+++ b/crates/rue-cli-tests/cases/programs.toml
@@ -205,3 +205,32 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "111\n"
+
+# RUE-77: a `while` whose condition diverges (never-typed) left the loop body and
+# exit blocks orphaned (no terminator) -> codegen aborted "block has no terminator".
+# The loop body and everything after the loop are unreachable; the condition's
+# divergence is the function's result.
+[[case]]
+name = "while_with_diverging_condition"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    while return 8 {}
+    5
+}
+""" }]
+exit_code = 8
+
+# Same diverging-condition while nested inside an outer loop — confirms the
+# loop_stack stays balanced and the enclosing loop's break target is intact.
+[[case]]
+name = "while_diverging_condition_inside_outer_loop"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    loop {
+        while return 7 {}
+        break;
+    }
+    5
+}
+""" }]
+exit_code = 7


### PR DESCRIPTION
## Summary

A `while` whose condition expression **diverges** (never-typed) ICE'd the compiler:

```rue
fn main() -> i32 { while return 8 {} 5 }   // SIGABRT: "block has no terminator"
```

CFG lowering allocates the loop's header/body/exit blocks, then lowers the condition. When the condition diverges, the old code early-returned — leaving the body and exit blocks with **no terminator** and a stale `loop_stack` entry. Codegen then asserted on the missing terminator. (The analogous `if`-divergence path allocates its blocks *after* the condition, so it was fine — this just makes `while` consistent.)

## Fix

When the condition diverges, mark the orphaned body and exit blocks `Terminator::Unreachable` and pop the loop context. The loop body and everything after the loop are correctly unreachable; the condition's divergence is the function's result (so `while return 8 {}` yields 8). Purely a `rue-cfg` change.

## Testing

- New `crates/rue-cli-tests/cases/programs.toml` cases: the bare diverging `while`, plus one nested inside an outer `loop` to confirm `loop_stack` stays balanced (the enclosing loop's `break` target is intact).
- Full `./test.sh` green; aarch64 lowers via `--emit asm`.

Found via the parallel investigate workflow (one of three independent, non-conflicting fixes drafted concurrently).

Fixes RUE-77

🤖 Generated with [Claude Code](https://claude.com/claude-code)