### PR TITLE
Warn on duplicate enum-variant match arms (RUE-75)

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -20,7 +20,7 @@
 //! - `analyze_comparison` - Eq, Ne, Lt, Gt, Le, Ge
 //! - Logical And/Or are simple enough to remain inline
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 use lasso::Spur;
 use rue_error::{
@@ -844,7 +844,11 @@ impl<'a> Sema<'a> {
         let mut bool_true_span: Option<Span> = None;
         let mut bool_false_span: Option<Span> = None;
         let mut seen_ints: HashMap<i64, Span> = HashMap::new();
-        let mut covered_variants: HashSet<u32> = HashSet::new();
+        // Maps each covered enum-variant index to the span of its first arm, so a
+        // second arm matching the same variant can be reported as unreachable
+        // (mirroring seen_ints / bool_*_span). The map's len() still drives the
+        // exhaustiveness check below, identically to the former HashSet.
+        let mut covered_variants: HashMap<u32, Span> = HashMap::new();
         let mut pattern_enum_id: Option<crate::types::EnumId> = None;
 
         // Analyze each arm (each arm gets its own scope)
@@ -992,8 +996,31 @@ impl<'a> Sema<'a> {
                         pattern_span,
                     )?;
 
-                    covered_variants.insert(variant_index as u32);
                     pattern_enum_id = Some(enum_id);
+
+                    // Check for duplicate enum-variant pattern (mirrors the integer
+                    // and boolean duplicate checks above).
+                    if let Some(first_span) = covered_variants.get(&(variant_index as u32)) {
+                        if wildcard_span.is_none() {
+                            let pat_str = format!(
+                                "{}::{}",
+                                self.interner.resolve(&*type_name),
+                                self.interner.resolve(&*variant)
+                            );
+                            ctx.warnings.push(
+                                CompileWarning::new(
+                                    WarningKind::UnreachablePattern(pat_str),
+                                    pattern_span,
+                                )
+                                .with_label("first occurrence of this pattern", *first_span)
+                                .with_note(
+                                    "this pattern will never be matched because an earlier arm already matches the same value",
+                                ),
+                            );
+                        }
+                    } else {
+                        covered_variants.insert(variant_index as u32, pattern_span);
+                    }
                 }
             }
 

--- a/crates/rue-ui-tests/cases/warnings/unreachable.toml
+++ b/crates/rue-ui-tests/cases/warnings/unreachable.toml
@@ -255,3 +255,37 @@ fn main() -> i32 {
 """
 exit_code = 10
 no_warnings = true
+
+# RUE-75: a duplicate enum-variant match arm must warn (it previously slipped
+# through silently, unlike duplicate integer/boolean patterns). The first arm
+# wins at runtime; the second is unreachable.
+[[case]]
+name = "duplicate_enum_variant_pattern"
+source = """
+enum Dir { N, S }
+fn main() -> i32 {
+    match Dir::N {
+        Dir::N => 1,
+        Dir::N => 2,
+        Dir::S => 3,
+    }
+}
+"""
+exit_code = 1
+warning_contains = ["unreachable pattern", "'Dir::N'"]
+expected_warning_count = 1
+
+# Negative control: distinct variants must NOT warn.
+[[case]]
+name = "distinct_enum_variant_patterns_no_warning"
+source = """
+enum Dir { N, S }
+fn main() -> i32 {
+    match Dir::S {
+        Dir::N => 1,
+        Dir::S => 3,
+    }
+}
+"""
+exit_code = 3
+no_warnings = true


### PR DESCRIPTION
## Summary

Match-arm analysis flagged duplicate **integer** and **boolean** patterns as unreachable, but the **enum-variant** path only recorded coverage in a `HashSet<u32>` (for exhaustiveness) and discarded the first-occurrence span — so a repeated arm was silently accepted:

```rue
enum Dir { N, S }
match Dir::N {
    Dir::N => 1,
    Dir::N => 2,   // previously: no warning
    Dir::S => 3,
}
```

## Fix

Make `covered_variants` a `HashMap<u32, Span>` and, before recording a variant, emit `WarningKind::UnreachablePattern` (with a "first occurrence" label) if the variant was already covered and no wildcard precedes it — mirroring the integer/boolean duplicate checks exactly. The map's `len()` still drives the exhaustiveness check unchanged. Duplicates following a wildcard are suppressed; module-qualified patterns resolve to the same variant index, so a qualified+unqualified duplicate is also caught.

Diagnostics-only (`rue-air` sema); no codegen change.

## Testing

- Two new `crates/rue-ui-tests/cases/warnings/unreachable.toml` cases: the duplicate warns exactly once (`unreachable pattern 'Dir::N'`); distinct variants stay warning-free.
- Full `./test.sh` green.

Found via the parallel investigate workflow (one of the independent, non-conflicting fixes).

Fixes RUE-75

🤖 Generated with [Claude Code](https://claude.com/claude-code)