### PR TITLE
Reserve runtime-helper names for user functions (RUE-84)

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -720,6 +720,20 @@ impl<'a> Sema<'a> {
         span: Span,
         is_pub: bool,
     ) -> CompileResult<()> {
+        // Reject user functions whose name collides with a runtime/codegen helper
+        // symbol (e.g. `String__len`, `__rue_alloc`, `_start`). Without this, such a
+        // definition either fails to link with a confusing duplicate-symbol error or
+        // silently binds calls to the runtime's definition instead of the user's.
+        let name_str = self.interner.resolve(&name);
+        if rue_builtins::is_reserved_function_name(name_str) {
+            return Err(CompileError::new(
+                ErrorKind::ReservedFunctionName {
+                    function_name: name_str.to_string(),
+                },
+                span,
+            ));
+        }
+
         let params = self.rir.get_params(params_start, params_len);
 
         let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();

--- a/crates/rue-builtins/src/lib.rs
+++ b/crates/rue-builtins/src/lib.rs
@@ -494,6 +494,35 @@ pub fn is_reserved_type_name(name: &str) -> bool {
     BUILTIN_TYPES.iter().any(|t| t.name == name)
 }
 
+/// Check if a name is reserved for a runtime/codegen helper function, and thus
+/// may not be used as a user-defined function name.
+///
+/// A user function with one of these names would collide with the symbol emitted
+/// by the runtime or codegen — a built-in type method (`String__len`), a
+/// `__rue_*` runtime helper (`__rue_alloc`, `__rue_exit`, drop glue, ...), or the
+/// program entry point (`_start`). Depending on link order that collision either
+/// fails to link or silently binds calls to the wrong definition, so these names
+/// are reserved and rejected at declaration time with a clear diagnostic.
+pub fn is_reserved_function_name(name: &str) -> bool {
+    // Runtime internal helpers: allocation, exit, debug, drop glue, parsing, ...
+    if name.starts_with("__rue_") {
+        return true;
+    }
+    // The program entry point emitted by the linker.
+    if name == "_start" {
+        return true;
+    }
+    // Built-in type methods and associated functions are emitted as
+    // `<TypeName>__<method>` (e.g. `String__len`, `Vec__push`). Reserve any name
+    // of that shape whose type component is a reserved built-in type name.
+    if let Some((type_part, _method)) = name.split_once("__") {
+        if !type_part.is_empty() && is_reserved_type_name(type_part) {
+            return true;
+        }
+    }
+    false
+}
+
 // ============================================================================
 // Helper methods
 // ============================================================================
@@ -592,6 +621,28 @@ mod tests {
     fn test_is_reserved_type_name() {
         assert!(is_reserved_type_name("String"));
         assert!(!is_reserved_type_name("MyStruct"));
+    }
+
+    #[test]
+    fn test_is_reserved_function_name() {
+        // Runtime helper prefix.
+        assert!(is_reserved_function_name("__rue_alloc"));
+        assert!(is_reserved_function_name("__rue_exit"));
+        assert!(is_reserved_function_name("__rue_drop_String"));
+        // Entry point.
+        assert!(is_reserved_function_name("_start"));
+        // Built-in type methods / associated functions (any String__* shape).
+        assert!(is_reserved_function_name("String__len"));
+        assert!(is_reserved_function_name("String__new"));
+        assert!(is_reserved_function_name("String__anything"));
+        // Not reserved: ordinary user names, including non-builtin `Type__` shapes
+        // and single-underscore names.
+        assert!(!is_reserved_function_name("main"));
+        assert!(!is_reserved_function_name("my_len"));
+        assert!(!is_reserved_function_name("foo__bar")); // foo is not a builtin type
+        assert!(!is_reserved_function_name("Vec__push")); // Vec is not a builtin type yet
+        assert!(!is_reserved_function_name("_start_engine"));
+        assert!(!is_reserved_function_name("rue_helper")); // no leading __
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/reserved_names.toml
+++ b/crates/rue-cli-tests/cases/reserved_names.toml
@@ -1,0 +1,50 @@
+# Runtime-helper names are reserved for user functions (RUE-84).
+#
+# Defining a function whose name collides with a runtime/codegen symbol
+# (String__len, __rue_*, _start) used to fail with a confusing duplicate-symbol
+# LINK error — or, worse, link "successfully" and silently bind calls to the
+# runtime's definition instead of the user's (a miscompile). These names are now
+# rejected at declaration time with a clear E0435 diagnostic. Legitimate names
+# that merely resemble the conventions still compile.
+
+[section]
+id = "cli.reserved_names"
+name = "Reserved runtime-helper function names"
+description = "User functions may not shadow runtime/codegen helper symbols; the error is reported at compile time."
+
+[[case]]
+name = "builtin_method_name_rejected"
+files = [{ path = "main.rue", source = """
+fn String__len() -> i32 { 12345 }
+fn main() -> i32 { String__len() }
+""" }]
+compile_fail = true
+error_contains = ["E0435", "String__len", "reserved"]
+
+[[case]]
+name = "rue_runtime_prefix_rejected"
+files = [{ path = "main.rue", source = """
+fn __rue_alloc() -> i32 { 7 }
+fn main() -> i32 { __rue_alloc() }
+""" }]
+compile_fail = true
+error_contains = ["E0435", "__rue_alloc", "reserved"]
+
+[[case]]
+name = "entry_point_name_rejected"
+files = [{ path = "main.rue", source = """
+fn _start() -> i32 { 1 }
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0435", "_start", "reserved"]
+
+# Control: an ordinary user function with a similar-looking name (double
+# underscore, but the prefix is not a built-in type) compiles and runs.
+[[case]]
+name = "lookalike_user_name_allowed"
+files = [{ path = "main.rue", source = """
+fn foo__bar() -> i32 { 9 }
+fn main() -> i32 { foo__bar() }
+""" }]
+exit_code = 9

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -122,6 +122,7 @@ impl ErrorCode {
     pub const INOUT_KEYWORD_MISSING: Self = Self(431);
     pub const BORROW_KEYWORD_MISSING: Self = Self(432);
     pub const EMPTY_STRUCT: Self = Self(433);
+    pub const RESERVED_FUNCTION_NAME: Self = Self(435);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -843,6 +844,9 @@ pub enum ErrorKind {
     /// User-defined type collides with a built-in type name
     #[error("cannot define type `{type_name}`: name is reserved for built-in type")]
     ReservedTypeName { type_name: String },
+    /// User-defined function collides with a runtime/codegen helper symbol
+    #[error("cannot define function `{function_name}`: name is reserved for a runtime helper")]
+    ReservedFunctionName { function_name: String },
     /// Duplicate type definition
     #[error("duplicate type definition: `{type_name}` is already defined")]
     DuplicateTypeDefinition { type_name: String },
@@ -1095,6 +1099,7 @@ impl ErrorKind {
             ErrorKind::EmptyStruct => ErrorCode::EMPTY_STRUCT,
             ErrorKind::CopyStructNonCopyField(_) => ErrorCode::COPY_STRUCT_NON_COPY_FIELD,
             ErrorKind::ReservedTypeName { .. } => ErrorCode::RESERVED_TYPE_NAME,
+            ErrorKind::ReservedFunctionName { .. } => ErrorCode::RESERVED_FUNCTION_NAME,
             ErrorKind::DuplicateTypeDefinition { .. } => ErrorCode::DUPLICATE_TYPE_DEFINITION,
             ErrorKind::LinearValueNotConsumed(_) => ErrorCode::LINEAR_VALUE_NOT_CONSUMED,
             ErrorKind::LinearStructCopy(_) => ErrorCode::LINEAR_STRUCT_COPY,

--- a/crates/rue-spec/cases/items/general.toml
+++ b/crates/rue-spec/cases/items/general.toml
@@ -87,3 +87,50 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Reserved Function Names (RUE-84)
+# =============================================================================
+
+[[case]]
+name = "fn_reserved_builtin_method"
+spec = ["6.0:5"]
+description = "User-defined function cannot use a built-in type method name"
+source = """
+fn String__len() -> i32 { 12345 }
+fn main() -> i32 { String__len() }
+"""
+compile_fail = true
+error_contains = "cannot define function `String__len`: name is reserved for a runtime helper"
+
+[[case]]
+name = "fn_reserved_rue_prefix"
+spec = ["6.0:5"]
+description = "User-defined function cannot use the __rue_ runtime-helper prefix"
+source = """
+fn __rue_alloc() -> i32 { 7 }
+fn main() -> i32 { __rue_alloc() }
+"""
+compile_fail = true
+error_contains = "cannot define function `__rue_alloc`: name is reserved for a runtime helper"
+
+[[case]]
+name = "fn_reserved_entry_point"
+spec = ["6.0:5"]
+description = "User-defined function cannot use the entry-point name _start"
+source = """
+fn _start() -> i32 { 1 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "cannot define function `_start`: name is reserved for a runtime helper"
+
+[[case]]
+name = "fn_lookalike_name_allowed"
+spec = ["6.0:5"]
+description = "A name resembling but not matching a reserved name is allowed"
+source = """
+fn foo__bar() -> i32 { 9 }
+fn main() -> i32 { foo__bar() }
+"""
+exit_code = 9

--- a/docs/spec/src/06-items/_index.md
+++ b/docs/spec/src/06-items/_index.md
@@ -30,3 +30,14 @@ User-defined types **MUST NOT** use names reserved for built-in types. Currently
 // Error: cannot define type with reserved name
 struct String { data: i32 }  // compile error
 ```
+
+{{ rule(id="6.0:5", cat="legality-rule") }}
+
+User-defined functions **MUST NOT** use names reserved for runtime and code-generation helpers. Reserved function names are: any name beginning with `__rue_`, the program entry point `_start`, and any name of the form `T__m` where `T` is a built-in type name (for example `String__len`). Defining a function with a reserved name produces a compile-time error.
+
+{{ rule(id="6.0:6", cat="example") }}
+
+```rue
+// Error: cannot define function with reserved name
+fn String__len() -> i32 { 0 }  // compile error
+```


### PR DESCRIPTION
## Summary

Defining a function whose name collides with a runtime/codegen symbol used to fail at link time with a confusing duplicate-symbol error that leaked an internal name:

```rue
fn String__len() -> i32 { 12345 }
fn main() -> i32 { String__len() }   // before: E1000 link error: duplicate symbol: String__len
```

It generalized to every runtime helper (`__rue_alloc`, `__rue_exit`, `_start`, ...) — even in programs that never touch String/IO — because the runtime object defining `_start`/`exit` drags in its sibling helpers, which then collide with the user's identically-named global. (A naïve linker-level dedup is *worse*: it links but silently binds the call to the runtime's definition — a miscompile.)

## Fix

Reserve these names at **declaration time** with a clear diagnostic. New `rue_builtins::is_reserved_function_name` covers the runtime namespace:
- the `__rue_` prefix (alloc, exit, dbg, drop glue, parse, ...),
- the `_start` entry point,
- `<BuiltinType>__<method>` names (e.g. `String__len`) — derived from the built-in type set, so it auto-covers future built-ins like `Vec`.

`collect_function_signature` rejects a reserved name as **E0435** `cannot define function \`NAME\`: name is reserved for a runtime helper`. Names that merely resemble the conventions still compile (`foo__bar`, `_start_engine`, and `Vec__push` while `Vec` isn't a built-in yet).

Spec updated (06-items **6.0:5** legality-rule + example) so it stays the source of truth — it previously stated only the *type* name `String` was reserved.

## Testing

- `rue-builtins` unit test for `is_reserved_function_name` (reserved classes + non-reserved lookalikes).
- Spec cases under `items.general` (6.0:5): each reserved class + a lookalike control. Traceability stays 100% (518/518).
- `crates/rue-cli-tests/cases/reserved_names.toml` exercises the real driver path (the original repro now yields the clean E0435, not a link error).

Sema-only change; no codegen. Supersedes the rejected linker-dedup approach (which I documented on the issue as converting the link error into a silent miscompile).

Fixes RUE-84

🤖 Generated with [Claude Code](https://claude.com/claude-code)