### PR TITLE
Extend the aggregate slot accessor to arrays and multi-slot PlaceWrite (RUE-118 part 2)

### DIFF
--- a/crates/rue-cli-tests/cases/abi.toml
+++ b/crates/rue-cli-tests/cases/abi.toml
@@ -170,7 +170,6 @@ stdout = "20\n"
 # top() underflows (runtime "integer overflow"). Part of RUE-13.
 [[case]]
 name = "method_self_update_5_slots"
-known_bug = "RUE-13"
 files = [{ path = "main.rue", source = """
 @copy
 struct Stack {
@@ -219,6 +218,7 @@ stdout = "8\n"
 [[case]]
 name = "bare_array_8_pass_and_return"
 known_bug = "RUE-13"
+known_bug_on = ["x86-64-linux"]
 files = [{ path = "main.rue", source = """
 fn through(a: [i32; 8]) -> [i32; 8] {
     a

--- a/crates/rue-cli-tests/cases/aggregate_slots.toml
+++ b/crates/rue-cli-tests/cases/aggregate_slots.toml
@@ -118,3 +118,105 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 12
+
+# ── RUE-118 part 2: arrays + PlaceWrite ──────────────────────────────────────
+# The struct-shaped fixes above left their array-shaped and write-side siblings
+# broken. These pin the second wave: array return/args (RUE-78/79), whole-
+# aggregate reassignment (RUE-80), and multi-slot PlaceWrite (RUE-23).
+
+# RUE-78: returning an array by value lost all elements (only the ArrayInit
+# placeholder vreg reached the return register).
+[[case]]
+name = "array_return_by_value"
+files = [{ path = "main.rue", source = """
+fn make() -> [i32; 3] { [10, 20, 30] }
+fn main() -> i32 { let arr = make(); arr[0] + arr[1] + arr[2] }
+""" }]
+exit_code = 60
+
+# RUE-78 (struct flavor): a struct containing an array field returned by value.
+[[case]]
+name = "struct_with_array_field_return"
+files = [{ path = "main.rue", source = """
+struct Grid { cells: [i32; 3], n: i32 }
+fn make() -> Grid { Grid { cells: [10, 20, 30], n: 7 } }
+fn main() -> i32 { let g = make(); g.cells[0] + g.cells[1] + g.cells[2] + g.n }
+""" }]
+exit_code = 67
+
+# RUE-79: multidimensional array passed by value dropped every row after the
+# first (the arg ladder iterated element count, not slot count).
+[[case]]
+name = "multidim_array_arg"
+files = [{ path = "main.rue", source = """
+fn sum(g: [[i32; 2]; 2]) -> i32 { g[0][0] + g[0][1] + g[1][0] + g[1][1] }
+fn main() -> i32 { let g = [[1, 2], [3, 4]]; sum(g) }
+""" }]
+exit_code = 10
+
+# Same shape but the nested array literal passed directly (exercises the
+# flattened ArrayInit slot cache rather than the Load path).
+[[case]]
+name = "multidim_array_literal_arg"
+files = [{ path = "main.rue", source = """
+fn sum(g: [[i32; 2]; 2]) -> i32 { g[0][0] + g[0][1] + g[1][0] + g[1][1] }
+fn main() -> i32 { sum([[1, 2], [3, 4]]) }
+""" }]
+exit_code = 10
+
+# RUE-80: whole-aggregate reassignment copied only the first slot.
+[[case]]
+name = "whole_array_reassign"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: [i32; 3] = [11, 22, 33];
+    let mut b: [i32; 3] = [0, 0, 0];
+    b = a;
+    b[0] + b[1] + b[2]
+}
+""" }]
+exit_code = 66
+
+# RUE-23: assigning a multi-slot struct to a struct field stored only slot 0.
+[[case]]
+name = "place_write_struct_field"
+files = [{ path = "main.rue", source = """
+struct Inner { a: i32, b: i32 }
+struct Outer { x: i32, inner: Inner }
+fn main() -> i32 {
+    let mut o = Outer { x: 1, inner: Inner { a: 0, b: 0 } };
+    let i = Inner { a: 20, b: 21 };
+    o.inner = i;
+    o.x + o.inner.a + o.inner.b
+}
+""" }]
+exit_code = 42
+
+# RUE-23 (array-element flavor): assigning a multi-slot struct into an indexed
+# element (dynamic-address store path).
+[[case]]
+name = "place_write_array_element"
+files = [{ path = "main.rue", source = """
+struct P { a: i32, b: i32 }
+fn main() -> i32 {
+    let mut arr: [P; 2] = [P { a: 0, b: 0 }, P { a: 0, b: 0 }];
+    let p = P { a: 20, b: 22 };
+    arr[0] = p;
+    arr[0].a + arr[0].b
+}
+""" }]
+exit_code = 42
+
+# RUE-25: a struct produced by an if/else block expression passed directly as a
+# call argument (BlockParam producer) — fixed in part 1, regression-pinned here.
+[[case]]
+name = "block_expr_struct_arg"
+files = [{ path = "main.rue", source = """
+struct P { a: i32, b: i32 }
+fn get_b(p: P) -> i32 { p.b }
+fn main() -> i32 {
+    let cond = true;
+    get_b(if cond { P { a: 10, b: 42 } } else { P { a: 1, b: 2 } })
+}
+""" }]
+exit_code = 42

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -212,7 +212,8 @@ impl<'a> CfgLower<'a> {
         Aarch64Mir::block_label(block_id.as_u32())
     }
 
-    /// Get or compute field vregs for a struct value.
+    /// Get or compute the slot vregs for a multi-slot aggregate value
+    /// (struct, builtin String, or fixed-size array).
     ///
     /// This handles different sources of struct values:
     /// - StructInit: use the field values directly
@@ -226,10 +227,10 @@ impl<'a> CfgLower<'a> {
         }
 
         let inst = self.ctx.cfg.get_inst(value);
-        let struct_id = match inst.ty.as_struct() {
-            Some(id) => id,
-            None => return None,
-        };
+        let ty = inst.ty;
+        if !(ty.is_struct() || ty.is_array()) {
+            return None;
+        }
 
         match &inst.data.clone() {
             CfgInstData::StructInit {
@@ -242,7 +243,7 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::Load { slot } => {
                 // Load slot values from consecutive stack slots
-                let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                let slot_count = self.ctx.type_slot_count(ty);
                 let mut vregs = Vec::with_capacity(slot_count as usize);
                 for i in 0..slot_count {
                     let vreg = self.mir.alloc_vreg();
@@ -258,7 +259,7 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::Param { index } => {
                 // Get slot values from parameter area
-                let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                let slot_count = self.ctx.type_slot_count(ty);
                 let mut vregs = Vec::with_capacity(slot_count as usize);
                 for i in 0..slot_count {
                     let vreg = self.mir.alloc_vreg();
@@ -274,7 +275,7 @@ impl<'a> CfgLower<'a> {
                 Some(vregs)
             }
             CfgInstData::PlaceRead { place } => {
-                // A multi-slot aggregate (struct or builtin String) read from a
+                // A multi-slot aggregate (struct, builtin String, or array) read from a
                 // place — e.g. `let s2 = h.s;`. The base place-read lowering only
                 // materializes the first slot into `dst`; here we materialize all
                 // `slot_count` slots so consumers (struct equality, Alloc/Store of
@@ -304,7 +305,7 @@ impl<'a> CfgLower<'a> {
                         self.ctx.num_locals + param_slot + static_slot_offset
                     }
                 };
-                let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                let slot_count = self.ctx.type_slot_count(ty);
                 let mut vregs = Vec::with_capacity(slot_count as usize);
                 for i in 0..slot_count {
                     let vreg = self.mir.alloc_vreg();
@@ -1481,44 +1482,41 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::Store { slot, value: val } => {
                 let val_type = self.ctx.cfg.get_inst(*val).ty;
-                if self.ctx.is_builtin_string(val_type) {
-                    // String: store ptr, len, and cap to consecutive slots
-                    let field_vregs = self
-                        .get_or_compute_field_vregs(*val)
-                        .expect("string should have fat pointer fields in Store");
-                    debug_assert_eq!(
-                        field_vregs.len(),
-                        3,
-                        "string should have 3 fields (ptr, len, cap)"
-                    );
+                // Multi-slot aggregate (struct, builtin String fat pointer, or array):
+                // store ALL slots, not just the first. The accessor materializes
+                // lazily-sourced values and cache-hits eager ones; if it can't model
+                // the source (e.g. a dynamically-indexed place-read) fall back to the
+                // old single-slot behavior rather than ICE. (RUE-118, RUE-80)
+                let aggregate_vregs = if val_type.is_struct() || val_type.is_array() {
+                    self.get_or_compute_field_vregs(*val)
+                } else {
+                    None
+                };
 
-                    let ptr_vreg = field_vregs[0];
-                    let len_vreg = field_vregs[1];
-                    let cap_vreg = field_vregs[2];
-
-                    // Store ptr to slot
-                    let ptr_offset = self.ctx.local_offset(*slot);
-                    self.mir.push(Aarch64Inst::Str {
-                        src: Operand::Virtual(ptr_vreg),
-                        base: Reg::Fp,
-                        offset: ptr_offset,
-                    });
-
-                    // Store len to slot + 1
-                    let len_offset = self.ctx.local_offset(slot + 1);
-                    self.mir.push(Aarch64Inst::Str {
-                        src: Operand::Virtual(len_vreg),
-                        base: Reg::Fp,
-                        offset: len_offset,
-                    });
-
-                    // Store cap to slot + 2
-                    let cap_offset = self.ctx.local_offset(slot + 2);
-                    self.mir.push(Aarch64Inst::Str {
-                        src: Operand::Virtual(cap_vreg),
-                        base: Reg::Fp,
-                        offset: cap_offset,
-                    });
+                if let Some(slot_vregs) = aggregate_vregs {
+                    // Check if this slot corresponds to an inout parameter
+                    if let Some(param_index) = self.slot_to_inout_param_index(*slot) {
+                        // Whole-aggregate store through the inout pointer. Caller
+                        // slots descend from the pointer (stack grows down), so
+                        // slot i lives at ptr - i*8 — matching the place-read path.
+                        let ptr_vreg = self.ensure_inout_param_ptr(param_index);
+                        for (i, slot_vreg) in slot_vregs.iter().enumerate() {
+                            self.mir.push(Aarch64Inst::StrIndexedOffset {
+                                src: Operand::Virtual(*slot_vreg),
+                                base: ptr_vreg,
+                                offset: -((i as i32) * 8),
+                            });
+                        }
+                    } else {
+                        for (i, slot_vreg) in slot_vregs.iter().enumerate() {
+                            let offset = self.ctx.local_offset(slot + i as u32);
+                            self.mir.push(Aarch64Inst::Str {
+                                src: Operand::Virtual(*slot_vreg),
+                                base: Reg::Fp,
+                                offset,
+                            });
+                        }
+                    }
                 } else {
                     let val_vreg = self.get_vreg(*val);
 
@@ -1701,60 +1699,19 @@ impl<'a> CfgLower<'a> {
                     }
 
                     match arg_type.kind() {
-                        TypeKind::Struct(_) => {
-                            // Pass all slots of the (possibly multi-slot) struct/String arg,
-                            // regardless of how it was produced — StructInit, Load, Param, Call,
-                            // BlockParam, or a field place-read (`f(h.s)` / `f(w.p)`). The
-                            // accessor materializes lazily-sourced values (Load/Param/PlaceRead)
-                            // and cache-hits eager ones (StructInit/Call/BlockParam). Previously
-                            // the `_` arm here passed only slot 0 of a place-read aggregate. (RUE-118)
+                        TypeKind::Struct(_) | TypeKind::Array(_) => {
+                            // Pass all slots of the (possibly multi-slot) aggregate arg —
+                            // struct, builtin String, or fixed-size array — regardless of
+                            // how it was produced. The accessor materializes lazily-sourced
+                            // values (Load/Param/PlaceRead) and cache-hits eager ones
+                            // (StructInit/ArrayInit/Call/BlockParam). The old per-source
+                            // array ladder iterated array_len (element count), not
+                            // slot_count, so a multidimensional array dropped every row
+                            // after the first. (RUE-118, RUE-79)
                             if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_value) {
                                 flattened_vregs.extend(field_vregs);
                             } else {
                                 flattened_vregs.push(self.get_vreg(arg_value));
-                            }
-                        }
-                        TypeKind::Array(_) => {
-                            let arg_data = &self.ctx.cfg.get_inst(arg_value).data;
-                            let array_len = self.ctx.array_length(arg_type) as u32;
-                            match arg_data {
-                                CfgInstData::Load { slot } => {
-                                    for elem_idx in 0..array_len {
-                                        let elem_vreg = self.mir.alloc_vreg();
-                                        let elem_slot = slot + elem_idx;
-                                        let offset = self.ctx.local_offset(elem_slot);
-                                        self.mir.push(Aarch64Inst::Ldr {
-                                            dst: Operand::Virtual(elem_vreg),
-                                            base: Reg::Fp,
-                                            offset,
-                                        });
-                                        flattened_vregs.push(elem_vreg);
-                                    }
-                                }
-                                CfgInstData::Param { index } => {
-                                    for elem_idx in 0..array_len {
-                                        let elem_vreg = self.mir.alloc_vreg();
-                                        let param_slot = self.ctx.num_locals + index + elem_idx;
-                                        let offset = self.ctx.local_offset(param_slot);
-                                        self.mir.push(Aarch64Inst::Ldr {
-                                            dst: Operand::Virtual(elem_vreg),
-                                            base: Reg::Fp,
-                                            offset,
-                                        });
-                                        flattened_vregs.push(elem_vreg);
-                                    }
-                                }
-                                CfgInstData::ArrayInit { .. } | CfgInstData::Call { .. } => {
-                                    if let Some(elem_vregs) = self.struct_slot_vregs.get(&arg_value)
-                                    {
-                                        flattened_vregs.extend(elem_vregs.iter().copied());
-                                    } else {
-                                        flattened_vregs.push(self.get_vreg(arg_value));
-                                    }
-                                }
-                                _ => {
-                                    flattened_vregs.push(self.get_vreg(arg_value));
-                                }
                             }
                         }
                         _ => {
@@ -1841,9 +1798,11 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(result_vreg),
                         src: Operand::Virtual(slot_vregs[0]),
                     });
-                } else if let Some(struct_id) = ty.as_struct() {
-                    // Non-builtin structs return in registers
-                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                } else if ty.is_struct() || ty.is_array() {
+                    // Non-builtin structs and arrays return in registers. Capture
+                    // every slot from RET_REGS, not just x0 — arrays previously fell
+                    // to the scalar path and lost all elements but the first. (RUE-78)
+                    let slot_count = self.ctx.type_slot_count(ty);
                     let mut slot_vregs = Vec::new();
                     for slot_idx in 0..slot_count {
                         let slot_vreg = self.mir.alloc_vreg();
@@ -2470,9 +2429,27 @@ impl<'a> CfgLower<'a> {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
 
-                // Store element vregs for later access
-                let elements = self.ctx.cfg.get_extra(*elements_start, *elements_len);
-                let element_vregs: Vec<VReg> = elements.iter().map(|e| self.get_vreg(*e)).collect();
+                // Store element vregs for later access. Nested aggregate elements
+                // (multidimensional arrays, arrays of structs) are flattened to their
+                // scalar slots so the cached list is the full slot set — their own
+                // value_map entry is just a placeholder vreg. (RUE-118)
+                let elements = self
+                    .ctx
+                    .cfg
+                    .get_extra(*elements_start, *elements_len)
+                    .to_vec();
+                let mut element_vregs: Vec<VReg> = Vec::new();
+                for e in &elements {
+                    let e_ty = self.ctx.cfg.get_inst(*e).ty;
+                    if e_ty.is_struct() || e_ty.is_array() {
+                        let nested = self
+                            .get_or_compute_field_vregs(*e)
+                            .expect("nested aggregate element should have slot vregs");
+                        element_vregs.extend(nested);
+                    } else {
+                        element_vregs.push(self.get_vreg(*e));
+                    }
+                }
                 self.struct_slot_vregs.insert(value, element_vregs);
 
                 // Move 0 into vreg as placeholder
@@ -2757,8 +2734,18 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::PlaceWrite { place, value: val } => {
-                let val_vreg = self.get_vreg(*val);
-                self.lower_place_write(place, val_vreg);
+                // A multi-slot aggregate value (struct, String, array) must write
+                // ALL its slots to the place, not just the first. The accessor
+                // materializes lazily-sourced values; if it can't model the source,
+                // fall back to the old single-slot behavior. (RUE-118, RUE-23)
+                let val_type = self.ctx.cfg.get_inst(*val).ty;
+                let vals = if val_type.is_struct() || val_type.is_array() {
+                    self.get_or_compute_field_vregs(*val)
+                        .unwrap_or_else(|| vec![self.get_vreg(*val)])
+                } else {
+                    vec![self.get_vreg(*val)]
+                };
+                self.lower_place_write(place, &vals);
             }
         }
     }
@@ -3821,12 +3808,13 @@ impl<'a> CfgLower<'a> {
                     });
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(Aarch64Inst::Bl { symbol_id });
-                } else if return_type.as_struct().is_some() {
-                    // Return struct in registers. Gather all slots of the returned
-                    // aggregate through the single accessor, regardless of source
-                    // (StructInit/Call/BlockParam cache-hit; Load/Param/PlaceRead
-                    // materialize). Previously the `_` arm returned only slot 0 of a
-                    // place-read aggregate (`fn f(w: Wrap) -> Point { w.p }`). (RUE-118)
+                } else if return_type.as_struct().is_some() || return_type.is_array() {
+                    // Return a multi-slot aggregate (struct or array) in registers.
+                    // Gather all slots through the single accessor, regardless of source
+                    // (StructInit/ArrayInit/Call/BlockParam cache-hit; Load/Param/
+                    // PlaceRead materialize). Previously the `_` arm returned only slot 0
+                    // of a place-read aggregate, and arrays had NO return path at all —
+                    // only the ArrayInit placeholder vreg reached x0. (RUE-118, RUE-78)
                     let slot_vregs = self
                         .get_or_compute_field_vregs(*value)
                         .unwrap_or_else(|| vec![self.get_vreg(*value)]);
@@ -4057,38 +4045,49 @@ impl<'a> CfgLower<'a> {
 
     /// Lower a PlaceWrite instruction.
     ///
-    /// This stores a value to the memory location described by the place.
-    fn lower_place_write(&mut self, place: &Place, val_vreg: VReg) {
+    /// This stores a value to the memory location described by the place. `vals`
+    /// holds one vreg per slot of the value (a single element for scalars); all
+    /// slots are stored to consecutive locations. Slot i of an fp-relative place
+    /// lives at `local_offset(slot + i)`; through a pointer it lives at
+    /// `ptr_offset - i*8` (caller slots descend, stack grows down). (RUE-118)
+    fn lower_place_write(&mut self, place: &Place, vals: &[VReg]) {
         let projections = self.ctx.cfg.get_place_projections(place);
 
         // Simple case: no projections, just store to the base slot
         if projections.is_empty() {
             match place.base {
                 PlaceBase::Local(slot) => {
-                    let offset = self.ctx.local_offset(slot);
-                    self.mir.push(Aarch64Inst::Str {
-                        src: Operand::Virtual(val_vreg),
-                        base: Reg::Fp,
-                        offset,
-                    });
+                    for (i, val_vreg) in vals.iter().enumerate() {
+                        let offset = self.ctx.local_offset(slot + i as u32);
+                        self.mir.push(Aarch64Inst::Str {
+                            src: Operand::Virtual(*val_vreg),
+                            base: Reg::Fp,
+                            offset,
+                        });
+                    }
                 }
                 PlaceBase::Param(param_slot) => {
                     if self.ctx.cfg.is_param_inout(param_slot) {
                         // Inout param - store through the pointer
                         let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
-                        self.mir.push(Aarch64Inst::StrIndexed {
-                            src: Operand::Virtual(val_vreg),
-                            base: ptr_vreg,
-                        });
+                        for (i, val_vreg) in vals.iter().enumerate() {
+                            self.mir.push(Aarch64Inst::StrIndexedOffset {
+                                src: Operand::Virtual(*val_vreg),
+                                base: ptr_vreg,
+                                offset: -((i as i32) * 8),
+                            });
+                        }
                     } else {
                         // Normal param - store to local slot
                         let slot = self.ctx.num_locals + param_slot;
-                        let offset = self.ctx.local_offset(slot);
-                        self.mir.push(Aarch64Inst::Str {
-                            src: Operand::Virtual(val_vreg),
-                            base: Reg::Fp,
-                            offset,
-                        });
+                        for (i, val_vreg) in vals.iter().enumerate() {
+                            let offset = self.ctx.local_offset(slot + i as u32);
+                            self.mir.push(Aarch64Inst::Str {
+                                src: Operand::Virtual(*val_vreg),
+                                base: Reg::Fp,
+                                offset,
+                            });
+                        }
                     }
                 }
             }
@@ -4096,7 +4095,7 @@ impl<'a> CfgLower<'a> {
         }
 
         // Complex case: has projections - compute the address
-        self.lower_place_write_with_projections(place, projections, val_vreg);
+        self.lower_place_write_with_projections(place, projections, vals);
     }
 
     /// Lower a PlaceWrite with projections.
@@ -4104,7 +4103,7 @@ impl<'a> CfgLower<'a> {
         &mut self,
         place: &Place,
         projections: &[Projection],
-        val_vreg: VReg,
+        vals: &[VReg],
     ) {
         // Calculate the static field offset
         let mut static_slot_offset: u32 = 0;
@@ -4162,16 +4161,22 @@ impl<'a> CfgLower<'a> {
                         src1: Operand::Virtual(addr_vreg),
                         src2: Operand::Virtual(dyn_offset),
                     });
-                    self.mir.push(Aarch64Inst::StrIndexed {
-                        src: Operand::Virtual(val_vreg),
-                        base: addr_vreg,
-                    });
+                    for (i, val_vreg) in vals.iter().enumerate() {
+                        self.mir.push(Aarch64Inst::StrIndexedOffset {
+                            src: Operand::Virtual(*val_vreg),
+                            base: addr_vreg,
+                            offset: -((i as i32) * 8),
+                        });
+                    }
                 } else {
-                    self.mir.push(Aarch64Inst::Str {
-                        src: Operand::Virtual(val_vreg),
-                        base: Reg::Fp,
-                        offset: base_offset,
-                    });
+                    for (i, val_vreg) in vals.iter().enumerate() {
+                        let offset = self.ctx.local_offset(base_slot + i as u32);
+                        self.mir.push(Aarch64Inst::Str {
+                            src: Operand::Virtual(*val_vreg),
+                            base: Reg::Fp,
+                            offset,
+                        });
+                    }
                 }
             }
             PlaceBase::Param(param_slot) => {
@@ -4197,16 +4202,21 @@ impl<'a> CfgLower<'a> {
                             src1: Operand::Virtual(addr_vreg),
                             src2: Operand::Virtual(dyn_offset),
                         });
-                        self.mir.push(Aarch64Inst::StrIndexed {
-                            src: Operand::Virtual(val_vreg),
-                            base: addr_vreg,
-                        });
+                        for (i, val_vreg) in vals.iter().enumerate() {
+                            self.mir.push(Aarch64Inst::StrIndexedOffset {
+                                src: Operand::Virtual(*val_vreg),
+                                base: addr_vreg,
+                                offset: -((i as i32) * 8),
+                            });
+                        }
                     } else {
-                        self.mir.push(Aarch64Inst::StrIndexedOffset {
-                            src: Operand::Virtual(val_vreg),
-                            base: ptr_vreg,
-                            offset: -static_byte_offset,
-                        });
+                        for (i, val_vreg) in vals.iter().enumerate() {
+                            self.mir.push(Aarch64Inst::StrIndexedOffset {
+                                src: Operand::Virtual(*val_vreg),
+                                base: ptr_vreg,
+                                offset: -static_byte_offset - (i as i32) * 8,
+                            });
+                        }
                     }
                 } else {
                     let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
@@ -4224,16 +4234,22 @@ impl<'a> CfgLower<'a> {
                             src1: Operand::Virtual(addr_vreg),
                             src2: Operand::Virtual(dyn_offset),
                         });
-                        self.mir.push(Aarch64Inst::StrIndexed {
-                            src: Operand::Virtual(val_vreg),
-                            base: addr_vreg,
-                        });
+                        for (i, val_vreg) in vals.iter().enumerate() {
+                            self.mir.push(Aarch64Inst::StrIndexedOffset {
+                                src: Operand::Virtual(*val_vreg),
+                                base: addr_vreg,
+                                offset: -((i as i32) * 8),
+                            });
+                        }
                     } else {
-                        self.mir.push(Aarch64Inst::Str {
-                            src: Operand::Virtual(val_vreg),
-                            base: Reg::Fp,
-                            offset: base_offset,
-                        });
+                        for (i, val_vreg) in vals.iter().enumerate() {
+                            let offset = self.ctx.local_offset(base_slot + i as u32);
+                            self.mir.push(Aarch64Inst::Str {
+                                src: Operand::Virtual(*val_vreg),
+                                base: Reg::Fp,
+                                offset,
+                            });
+                        }
                     }
                 }
             }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -329,13 +329,15 @@ impl<'a> CfgLower<'a> {
         LabelId::new(BLOCK_LABEL_BASE + block_id.as_u32())
     }
 
-    /// Get or compute field vregs for a struct value.
+    /// Get or compute the slot vregs for a multi-slot aggregate value
+    /// (struct, builtin String, or fixed-size array).
     ///
-    /// This handles different sources of struct values:
+    /// This handles different sources of aggregate values:
     /// - StructInit: use the field values directly
-    /// - Load: load field values from stack slots
+    /// - Load: load slot values from consecutive stack slots
     /// - Param: use parameter registers/slots
-    /// - BlockParam/Call: use cached struct_slot_vregs
+    /// - PlaceRead (static field projections): load from the field's slots
+    /// - BlockParam/Call/ArrayInit: use cached struct_slot_vregs
     fn get_or_compute_field_vregs(&mut self, value: CfgValue) -> Option<Vec<VReg>> {
         // Check cache first
         if let Some(vregs) = self.struct_slot_vregs.get(&value).cloned() {
@@ -343,10 +345,10 @@ impl<'a> CfgLower<'a> {
         }
 
         let inst = self.ctx.cfg.get_inst(value);
-        let struct_id = match inst.ty.kind() {
-            TypeKind::Struct(id) => id,
-            _ => return None,
-        };
+        let ty = inst.ty;
+        if !matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+            return None;
+        }
 
         match &inst.data.clone() {
             CfgInstData::StructInit {
@@ -359,7 +361,7 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::Load { slot } => {
                 // Load slot values from consecutive stack slots
-                let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                let slot_count = self.ctx.type_slot_count(ty);
                 let mut vregs = Vec::with_capacity(slot_count as usize);
                 for i in 0..slot_count {
                     let vreg = self.mir.alloc_vreg();
@@ -375,7 +377,7 @@ impl<'a> CfgLower<'a> {
             }
             CfgInstData::Param { index } => {
                 // Get slot values from parameter area
-                let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                let slot_count = self.ctx.type_slot_count(ty);
                 let mut vregs = Vec::with_capacity(slot_count as usize);
                 for i in 0..slot_count {
                     let vreg = self.mir.alloc_vreg();
@@ -391,8 +393,8 @@ impl<'a> CfgLower<'a> {
                 Some(vregs)
             }
             CfgInstData::PlaceRead { place } => {
-                // A multi-slot aggregate (struct or builtin String) read from a
-                // place — e.g. `let s2 = h.s;`. The base place-read lowering only
+                // A multi-slot aggregate (struct, builtin String, or array) read from
+                // a place — e.g. `let s2 = h.s;`. The base place-read lowering only
                 // materializes the first slot into `dst`; here we materialize all
                 // `slot_count` slots so consumers (struct equality, Alloc/Store of
                 // a fat pointer, etc.) see the full value. Only static field
@@ -421,7 +423,7 @@ impl<'a> CfgLower<'a> {
                         self.ctx.num_locals + param_slot + static_slot_offset
                     }
                 };
-                let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                let slot_count = self.ctx.type_slot_count(ty);
                 let mut vregs = Vec::with_capacity(slot_count as usize);
                 for i in 0..slot_count {
                     let vreg = self.mir.alloc_vreg();
@@ -1726,44 +1728,42 @@ impl<'a> CfgLower<'a> {
 
             CfgInstData::Store { slot, value: val } => {
                 let val_type = self.ctx.cfg.get_inst(*val).ty;
-                if self.ctx.is_builtin_string(val_type) {
-                    // Builtin String: store ptr, len, and cap to consecutive slots
-                    let field_vregs = self
-                        .get_or_compute_field_vregs(*val)
-                        .expect("string should have fat pointer fields in Store");
-                    debug_assert_eq!(
-                        field_vregs.len(),
-                        3,
-                        "string should have 3 fields (ptr, len, cap)"
-                    );
+                // Multi-slot aggregate (struct, builtin String fat pointer, or array):
+                // store ALL slots, not just the first. The accessor materializes
+                // lazily-sourced values and cache-hits eager ones; if it can't model
+                // the source (e.g. a dynamically-indexed place-read) fall back to the
+                // old single-slot behavior rather than ICE. (RUE-118, RUE-80)
+                let aggregate_vregs =
+                    if matches!(val_type.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                        self.get_or_compute_field_vregs(*val)
+                    } else {
+                        None
+                    };
 
-                    let ptr_vreg = field_vregs[0];
-                    let len_vreg = field_vregs[1];
-                    let cap_vreg = field_vregs[2];
-
-                    // Store ptr to slot
-                    let ptr_offset = self.ctx.local_offset(*slot);
-                    self.mir.push(X86Inst::MovMR {
-                        base: Reg::Rbp,
-                        offset: ptr_offset,
-                        src: Operand::Virtual(ptr_vreg),
-                    });
-
-                    // Store len to slot + 1
-                    let len_offset = self.ctx.local_offset(slot + 1);
-                    self.mir.push(X86Inst::MovMR {
-                        base: Reg::Rbp,
-                        offset: len_offset,
-                        src: Operand::Virtual(len_vreg),
-                    });
-
-                    // Store cap to slot + 2
-                    let cap_offset = self.ctx.local_offset(slot + 2);
-                    self.mir.push(X86Inst::MovMR {
-                        base: Reg::Rbp,
-                        offset: cap_offset,
-                        src: Operand::Virtual(cap_vreg),
-                    });
+                if let Some(slot_vregs) = aggregate_vregs {
+                    // Check if this slot corresponds to an inout parameter
+                    if let Some(param_index) = self.slot_to_inout_param_index(*slot) {
+                        // Whole-aggregate store through the inout pointer. Caller
+                        // slots descend from the pointer (stack grows down), so
+                        // slot i lives at ptr - i*8 — matching the place-read path.
+                        let ptr_vreg = self.ensure_inout_param_ptr(param_index);
+                        for (i, slot_vreg) in slot_vregs.iter().enumerate() {
+                            self.mir.push(X86Inst::MovMRIndexed {
+                                base: ptr_vreg,
+                                offset: -((i as i32) * 8),
+                                src: Operand::Virtual(*slot_vreg),
+                            });
+                        }
+                    } else {
+                        for (i, slot_vreg) in slot_vregs.iter().enumerate() {
+                            let offset = self.ctx.local_offset(slot + i as u32);
+                            self.mir.push(X86Inst::MovMR {
+                                base: Reg::Rbp,
+                                offset,
+                                src: Operand::Virtual(*slot_vreg),
+                            });
+                        }
+                    }
                 } else {
                     let val_vreg = self.get_vreg(*val);
 
@@ -1902,61 +1902,19 @@ impl<'a> CfgLower<'a> {
                     }
 
                     match arg_type.kind() {
-                        TypeKind::Struct(_) => {
-                            // Pass all slots of the (possibly multi-slot) struct/String arg,
-                            // regardless of how it was produced — StructInit, Load, Param, Call,
-                            // BlockParam, or a field place-read (`f(h.s)` / `f(w.p)`). The
-                            // accessor materializes lazily-sourced values (Load/Param/PlaceRead)
-                            // and cache-hits eager ones (StructInit/Call/BlockParam). Previously
-                            // the `_` arm here passed only slot 0 of a place-read aggregate,
-                            // silently dropping the rest. (RUE-118)
+                        TypeKind::Struct(_) | TypeKind::Array(_) => {
+                            // Pass all slots of the (possibly multi-slot) aggregate arg —
+                            // struct, builtin String, or fixed-size array — regardless of
+                            // how it was produced. The accessor materializes lazily-sourced
+                            // values (Load/Param/PlaceRead) and cache-hits eager ones
+                            // (StructInit/ArrayInit/Call/BlockParam). The old per-source
+                            // array ladder iterated array_len (element count), not
+                            // slot_count, so a multidimensional array dropped every row
+                            // after the first. (RUE-118, RUE-79)
                             if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_value) {
                                 flattened_vregs.extend(field_vregs);
                             } else {
                                 flattened_vregs.push(self.get_vreg(arg_value));
-                            }
-                        }
-                        TypeKind::Array(_) => {
-                            let arg_data = &self.ctx.cfg.get_inst(arg_value).data;
-                            let array_len = self.ctx.array_length(arg_type) as u32;
-                            match arg_data {
-                                CfgInstData::Load { slot } => {
-                                    for elem_idx in 0..array_len {
-                                        let elem_vreg = self.mir.alloc_vreg();
-                                        let elem_slot = slot + elem_idx;
-                                        let offset = self.ctx.local_offset(elem_slot);
-                                        self.mir.push(X86Inst::MovRM {
-                                            dst: Operand::Virtual(elem_vreg),
-                                            base: Reg::Rbp,
-                                            offset,
-                                        });
-                                        flattened_vregs.push(elem_vreg);
-                                    }
-                                }
-                                CfgInstData::Param { index } => {
-                                    for elem_idx in 0..array_len {
-                                        let elem_vreg = self.mir.alloc_vreg();
-                                        let param_slot = self.ctx.num_locals + index + elem_idx;
-                                        let offset = self.ctx.local_offset(param_slot);
-                                        self.mir.push(X86Inst::MovRM {
-                                            dst: Operand::Virtual(elem_vreg),
-                                            base: Reg::Rbp,
-                                            offset,
-                                        });
-                                        flattened_vregs.push(elem_vreg);
-                                    }
-                                }
-                                CfgInstData::ArrayInit { .. } | CfgInstData::Call { .. } => {
-                                    if let Some(elem_vregs) = self.struct_slot_vregs.get(&arg_value)
-                                    {
-                                        flattened_vregs.extend(elem_vregs.iter().copied());
-                                    } else {
-                                        flattened_vregs.push(self.get_vreg(arg_value));
-                                    }
-                                }
-                                _ => {
-                                    flattened_vregs.push(self.get_vreg(arg_value));
-                                }
                             }
                         }
                         // Note: String is now Type::Struct, handled above
@@ -2052,9 +2010,11 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(result_vreg),
                         src: Operand::Virtual(slot_vregs[0]),
                     });
-                } else if let TypeKind::Struct(struct_id) = ty.kind() {
-                    // Non-builtin structs return in registers
-                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                } else if matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                    // Non-builtin structs and arrays return in registers. Capture
+                    // every slot from RET_REGS, not just rax — arrays previously fell
+                    // to the scalar path and lost all elements but the first. (RUE-78)
+                    let slot_count = self.ctx.type_slot_count(ty);
                     let mut slot_vregs = Vec::new();
                     for slot_idx in 0..slot_count {
                         let slot_vreg = self.mir.alloc_vreg();
@@ -2657,9 +2617,27 @@ impl<'a> CfgLower<'a> {
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
 
-                // Store element vregs for later PlaceRead access
-                let elements = self.ctx.cfg.get_extra(*elements_start, *elements_len);
-                let element_vregs: Vec<VReg> = elements.iter().map(|e| self.get_vreg(*e)).collect();
+                // Store element vregs for later PlaceRead access. Nested aggregate
+                // elements (multidimensional arrays, arrays of structs) are flattened
+                // to their scalar slots so the cached list is the full slot set —
+                // their own value_map entry is just a placeholder vreg. (RUE-118)
+                let elements = self
+                    .ctx
+                    .cfg
+                    .get_extra(*elements_start, *elements_len)
+                    .to_vec();
+                let mut element_vregs: Vec<VReg> = Vec::new();
+                for e in &elements {
+                    let e_ty = self.ctx.cfg.get_inst(*e).ty;
+                    if matches!(e_ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                        let nested = self
+                            .get_or_compute_field_vregs(*e)
+                            .expect("nested aggregate element should have slot vregs");
+                        element_vregs.extend(nested);
+                    } else {
+                        element_vregs.push(self.get_vreg(*e));
+                    }
+                }
                 self.struct_slot_vregs.insert(value, element_vregs);
 
                 // Move 0 into vreg as placeholder (array base doesn't have a single value)
@@ -3019,8 +2997,18 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::PlaceWrite { place, value: val } => {
-                let val_vreg = self.get_vreg(*val);
-                self.lower_place_write(place, val_vreg);
+                // A multi-slot aggregate value (struct, String, array) must write
+                // ALL its slots to the place, not just the first. The accessor
+                // materializes lazily-sourced values; if it can't model the source,
+                // fall back to the old single-slot behavior. (RUE-118, RUE-23)
+                let val_type = self.ctx.cfg.get_inst(*val).ty;
+                let vals = if matches!(val_type.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                    self.get_or_compute_field_vregs(*val)
+                        .unwrap_or_else(|| vec![self.get_vreg(*val)])
+                } else {
+                    vec![self.get_vreg(*val)]
+                };
+                self.lower_place_write(place, &vals);
             }
         }
     }
@@ -3738,12 +3726,13 @@ impl<'a> CfgLower<'a> {
                     // it 0 mod 16 at callee entry, violating SysV ABI).
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(X86Inst::CallRel { symbol_id });
-                } else if return_type.as_struct().is_some() {
-                    // Return struct in registers. Gather all slots of the returned
-                    // aggregate through the single accessor, regardless of source
-                    // (StructInit/Call/BlockParam cache-hit; Load/Param/PlaceRead
-                    // materialize). Previously the `_` arm returned only slot 0 of a
-                    // place-read aggregate (`fn f(w: Wrap) -> Point { w.p }`). (RUE-118)
+                } else if return_type.as_struct().is_some() || return_type.is_array() {
+                    // Return a multi-slot aggregate (struct or array) in registers.
+                    // Gather all slots through the single accessor, regardless of source
+                    // (StructInit/ArrayInit/Call/BlockParam cache-hit; Load/Param/
+                    // PlaceRead materialize). Previously the `_` arm returned only slot 0
+                    // of a place-read aggregate, and arrays had NO return path at all —
+                    // only the ArrayInit placeholder vreg reached rax. (RUE-118, RUE-78)
                     let slot_vregs = self
                         .get_or_compute_field_vregs(*value)
                         .unwrap_or_else(|| vec![self.get_vreg(*value)]);
@@ -3989,39 +3978,49 @@ impl<'a> CfgLower<'a> {
 
     /// Lower a PlaceWrite instruction.
     ///
-    /// This stores a value to the memory location described by the place.
-    fn lower_place_write(&mut self, place: &Place, val_vreg: VReg) {
+    /// This stores a value to the memory location described by the place. `vals`
+    /// holds one vreg per slot of the value (a single element for scalars); all
+    /// slots are stored to consecutive locations. Slot i of an rbp-relative place
+    /// lives at `local_offset(slot + i)`; through a pointer it lives at
+    /// `ptr_offset - i*8` (caller slots descend, stack grows down). (RUE-118)
+    fn lower_place_write(&mut self, place: &Place, vals: &[VReg]) {
         let projections = self.ctx.cfg.get_place_projections(place);
 
-        // Simple case: no projections, just store to the base slot
+        // Simple case: no projections, just store to the base slot(s)
         if projections.is_empty() {
             match place.base {
                 PlaceBase::Local(slot) => {
-                    let offset = self.ctx.local_offset(slot);
-                    self.mir.push(X86Inst::MovMR {
-                        base: Reg::Rbp,
-                        offset,
-                        src: Operand::Virtual(val_vreg),
-                    });
+                    for (i, val_vreg) in vals.iter().enumerate() {
+                        let offset = self.ctx.local_offset(slot + i as u32);
+                        self.mir.push(X86Inst::MovMR {
+                            base: Reg::Rbp,
+                            offset,
+                            src: Operand::Virtual(*val_vreg),
+                        });
+                    }
                 }
                 PlaceBase::Param(param_slot) => {
                     if self.ctx.cfg.is_param_inout(param_slot) {
                         // Inout param - store through the pointer
                         let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
-                        self.mir.push(X86Inst::MovMRIndexed {
-                            base: ptr_vreg,
-                            offset: 0,
-                            src: Operand::Virtual(val_vreg),
-                        });
+                        for (i, val_vreg) in vals.iter().enumerate() {
+                            self.mir.push(X86Inst::MovMRIndexed {
+                                base: ptr_vreg,
+                                offset: -((i as i32) * 8),
+                                src: Operand::Virtual(*val_vreg),
+                            });
+                        }
                     } else {
                         // Normal param - store to local slot
                         let slot = self.ctx.num_locals + param_slot;
-                        let offset = self.ctx.local_offset(slot);
-                        self.mir.push(X86Inst::MovMR {
-                            base: Reg::Rbp,
-                            offset,
-                            src: Operand::Virtual(val_vreg),
-                        });
+                        for (i, val_vreg) in vals.iter().enumerate() {
+                            let offset = self.ctx.local_offset(slot + i as u32);
+                            self.mir.push(X86Inst::MovMR {
+                                base: Reg::Rbp,
+                                offset,
+                                src: Operand::Virtual(*val_vreg),
+                            });
+                        }
                     }
                 }
             }
@@ -4029,7 +4028,7 @@ impl<'a> CfgLower<'a> {
         }
 
         // Complex case: has projections - compute the address
-        self.lower_place_write_with_projections(place, projections, val_vreg);
+        self.lower_place_write_with_projections(place, projections, vals);
     }
 
     /// Lower a PlaceWrite with projections.
@@ -4037,7 +4036,7 @@ impl<'a> CfgLower<'a> {
         &mut self,
         place: &Place,
         projections: &[Projection],
-        val_vreg: VReg,
+        vals: &[VReg],
     ) {
         // Calculate the static field offset
         let mut static_slot_offset: u32 = 0;
@@ -4096,17 +4095,22 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(addr_vreg),
                         src: Operand::Virtual(dyn_offset),
                     });
-                    self.mir.push(X86Inst::MovMRIndexed {
-                        base: addr_vreg,
-                        offset: 0,
-                        src: Operand::Virtual(val_vreg),
-                    });
+                    for (i, val_vreg) in vals.iter().enumerate() {
+                        self.mir.push(X86Inst::MovMRIndexed {
+                            base: addr_vreg,
+                            offset: -((i as i32) * 8),
+                            src: Operand::Virtual(*val_vreg),
+                        });
+                    }
                 } else {
-                    self.mir.push(X86Inst::MovMR {
-                        base: Reg::Rbp,
-                        offset: base_offset,
-                        src: Operand::Virtual(val_vreg),
-                    });
+                    for (i, val_vreg) in vals.iter().enumerate() {
+                        let offset = self.ctx.local_offset(base_slot + i as u32);
+                        self.mir.push(X86Inst::MovMR {
+                            base: Reg::Rbp,
+                            offset,
+                            src: Operand::Virtual(*val_vreg),
+                        });
+                    }
                 }
             }
             PlaceBase::Param(param_slot) => {
@@ -4135,17 +4139,21 @@ impl<'a> CfgLower<'a> {
                             dst: Operand::Virtual(addr_vreg),
                             src: Operand::Virtual(dyn_offset),
                         });
-                        self.mir.push(X86Inst::MovMRIndexed {
-                            base: addr_vreg,
-                            offset: 0,
-                            src: Operand::Virtual(val_vreg),
-                        });
+                        for (i, val_vreg) in vals.iter().enumerate() {
+                            self.mir.push(X86Inst::MovMRIndexed {
+                                base: addr_vreg,
+                                offset: -((i as i32) * 8),
+                                src: Operand::Virtual(*val_vreg),
+                            });
+                        }
                     } else {
-                        self.mir.push(X86Inst::MovMRIndexed {
-                            base: ptr_vreg,
-                            offset: -static_byte_offset,
-                            src: Operand::Virtual(val_vreg),
-                        });
+                        for (i, val_vreg) in vals.iter().enumerate() {
+                            self.mir.push(X86Inst::MovMRIndexed {
+                                base: ptr_vreg,
+                                offset: -static_byte_offset - (i as i32) * 8,
+                                src: Operand::Virtual(*val_vreg),
+                            });
+                        }
                     }
                 } else {
                     let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
@@ -4164,17 +4172,22 @@ impl<'a> CfgLower<'a> {
                             dst: Operand::Virtual(addr_vreg),
                             src: Operand::Virtual(dyn_offset),
                         });
-                        self.mir.push(X86Inst::MovMRIndexed {
-                            base: addr_vreg,
-                            offset: 0,
-                            src: Operand::Virtual(val_vreg),
-                        });
+                        for (i, val_vreg) in vals.iter().enumerate() {
+                            self.mir.push(X86Inst::MovMRIndexed {
+                                base: addr_vreg,
+                                offset: -((i as i32) * 8),
+                                src: Operand::Virtual(*val_vreg),
+                            });
+                        }
                     } else {
-                        self.mir.push(X86Inst::MovMR {
-                            base: Reg::Rbp,
-                            offset: base_offset,
-                            src: Operand::Virtual(val_vreg),
-                        });
+                        for (i, val_vreg) in vals.iter().enumerate() {
+                            let offset = self.ctx.local_offset(base_slot + i as u32);
+                            self.mir.push(X86Inst::MovMR {
+                                base: Reg::Rbp,
+                                offset,
+                                src: Operand::Virtual(*val_vreg),
+                            });
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## Summary

#904 routed the **struct-shaped** aggregate consumers through `get_or_compute_field_vregs` but left the **array-shaped and write-side** siblings on their old single-slot paths. The stale-issue verification sweep confirmed exactly which repros remained broken; this completes the sweep on both backends.

### Bugs fixed (all verified by running before/after on x86-64; aarch64 structurally via `--emit asm`)
- **RUE-78**: returning an array by value lost all elements (`make()[10,20,30]` → caller read 0; only the ArrayInit *placeholder* vreg reached the return register). Bare arrays **and** struct-with-array-field returns now work (60 / 67).
- **RUE-79 (multidim case)**: passing `[[1,2],[3,4]]` by value dropped every row after the first — the arg ladder iterated `array_len` (2), not `slot_count` (4). Now 10. *(The >6-slot spill case stays open — that's the RUE-13/RUE-91 spill ABI.)*
- **RUE-80**: whole-aggregate reassignment `b = a` copied only slot 0 (exit 11 → 66).
- **RUE-23**: assigning a multi-slot struct to a field (`o.inner = i`) or array element (`arr[0] = p`) stored only the first slot (21 → 42, both shapes).

### Mechanics
- `get_or_compute_field_vregs` generalized to arrays (type guard + `type_slot_count(ty)`).
- Call-arg array ladder collapsed into the accessor; caller-side Call lowering captures all RET_REGS slots for array results; return path covers arrays.
- `ArrayInit` caches a fully-flattened slot list (nested elements were cached as placeholder vregs).
- `Store` handles any multi-slot aggregate (subsumes the String-only special case), including through inout pointers at descending offsets.
- `lower_place_write` / `lower_place_write_with_projections` take a slice of slot vregs and store every slot in all branches (static field, dynamic index, inout, param).

### Tests
- 8 new cases in `crates/rue-cli-tests/cases/aggregate_slots.toml` (array returns, multidim args via Load and direct literal, whole-array reassign, PlaceWrite to field/element, plus a regression pin for the already-fixed RUE-25 block-expr arg).
- Un-marks `method_self_update_5_slots` (known_bug RUE-13): the value-method idiom `s = s.push(10)` no longer drops the `len` write — now a normal regression test on both platforms.
- Full `./test.sh` green (1350 unit, 100% traceability, 49 UI, 102 CLI).

Fixes RUE-78
Fixes RUE-80
Fixes RUE-23

🤖 Generated with [Claude Code](https://claude.com/claude-code)