### PR TITLE
Harden the test infrastructure: ICEs can no longer pass, all unit tests run, case files validated

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -5540,19 +5540,20 @@ fn analyze_intrinsic_ctx(
         let arg_result = analyze_inst_with_context(ctx, air, args[0].value, analysis_ctx)?;
         let arg_type = arg_result.ty;
 
-        // Validate type
+        // Validate type: @dbg supports integers, bool, and String (spec 4.13:7).
+        // Structs, enums, and arrays must be rejected HERE — codegen has no
+        // lowering for them and would panic ("@dbg only supports scalars and
+        // strings"), which the spec mandates as a compile error instead.
         if !arg_type.is_integer()
             && arg_type != Type::BOOL
-            && !arg_type.is_struct()
-            && !arg_type.is_enum()
-            && !arg_type.is_array()
+            && !ctx.is_builtin_string(arg_type)
             && !arg_type.is_error()
             && !arg_type.is_never()
         {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "dbg".to_string(),
-                    expected: "integer, bool, struct, enum, or array".to_string(),
+                    expected: "integer, bool, or String".to_string(),
                     found: arg_type.name().to_string(),
                 })),
                 span,
@@ -8114,19 +8115,20 @@ impl<'a> Sema<'a> {
         let arg_result = self.analyze_inst(air, args[0].value, ctx)?;
         let arg_type = arg_result.ty;
 
-        // Validate type
+        // Validate type: @dbg supports integers, bool, and String (spec 4.13:7).
+        // Structs, enums, and arrays must be rejected HERE — codegen has no
+        // lowering for them and would panic ("@dbg only supports scalars and
+        // strings"), which the spec mandates as a compile error instead.
         if !arg_type.is_integer()
             && arg_type != Type::BOOL
-            && !arg_type.is_struct()
-            && !arg_type.is_enum()
-            && !arg_type.is_array()
+            && !self.is_builtin_string(arg_type)
             && !arg_type.is_error()
             && !arg_type.is_never()
         {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "dbg".to_string(),
-                    expected: "integer, bool, struct, enum, or array".to_string(),
+                    expected: "integer, bool, or String".to_string(),
                     found: arg_type.name().to_string(),
                 })),
                 span,

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -82,6 +82,7 @@ const CASES_DIR_PATHS: &[&str] = &[
 const STD_DIR_PATHS: &[&str] = &["std", "../std", "../../std"];
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct TestFile {
     section: Section,
     #[serde(default, rename = "case")]
@@ -89,6 +90,7 @@ struct TestFile {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct Section {
     id: String,
     #[allow(dead_code)]
@@ -99,12 +101,14 @@ struct Section {
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct SourceFile {
     path: String,
     source: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct Case {
     name: String,
     /// Files written to the temp directory before invoking the compiler.

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1452,6 +1452,35 @@ impl WarningKind {
 mod tests {
     use super::*;
 
+    /// Every ErrorCode constant must map to a distinct number: two diagnostics
+    /// sharing an E-code would be indistinguishable to users and tests.
+    /// Scans this file's source for the `pub const NAME: Self = Self(NNN);`
+    /// declarations so the check can't go stale as codes are added.
+    #[test]
+    fn test_error_codes_are_unique() {
+        let src = include_str!("lib.rs");
+        let mut seen: std::collections::HashMap<u32, String> = std::collections::HashMap::new();
+        for line in src.lines() {
+            let Some(rest) = line.trim().strip_prefix("pub const ") else {
+                continue;
+            };
+            let Some((name, tail)) = rest.split_once(": Self = Self(") else {
+                continue;
+            };
+            let Some(num) = tail.split(')').next().and_then(|n| n.parse::<u32>().ok()) else {
+                continue;
+            };
+            if let Some(prev) = seen.insert(num, name.to_string()) {
+                panic!("duplicate ErrorCode {num}: {prev} and {name}");
+            }
+        }
+        assert!(
+            seen.len() > 50,
+            "expected to find the ErrorCode constants (found {})",
+            seen.len()
+        );
+    }
+
     #[test]
     fn test_error_with_span() {
         let span = Span::new(10, 20);

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -159,7 +159,7 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
-stdout = "1\n2\n3\n"
+expected_stdout = "1\n2\n3\n"
 
 [[case]]
 name = "array_of_struct_with_destructor_dropped"
@@ -182,7 +182,7 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
-stdout = "10\n20\n"
+expected_stdout = "10\n20\n"
 
 # =============================================================================
 # Drop Placement
@@ -651,7 +651,7 @@ fn main() -> i32 {
 }  // Counter destructor runs, prints 99
 """
 exit_code = 0
-stdout = "99\n"
+expected_stdout = "99\n"
 
 [[case]]
 name = "duplicate_destructor_error"

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -390,7 +390,7 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
-stdout = "hello\n"
+expected_stdout = "hello\n"
 
 [[case]]
 name = "string_dbg_variable"
@@ -403,7 +403,7 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
-stdout = "world\n"
+expected_stdout = "world\n"
 
 [[case]]
 name = "string_dbg_empty"
@@ -415,7 +415,7 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
-stdout = "\n"
+expected_stdout = "\n"
 
 [[case]]
 name = "string_dbg_with_spaces"
@@ -428,7 +428,7 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
-stdout = "Hello, world!\n"
+expected_stdout = "Hello, world!\n"
 
 [[case]]
 name = "string_dbg_with_escaped_newline"
@@ -440,7 +440,7 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
-stdout = "line1\nline2\n"
+expected_stdout = "line1\nline2\n"
 
 [[case]]
 name = "string_dbg_with_escaped_tab"
@@ -452,7 +452,7 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
-stdout = "col1\tcol2\n"
+expected_stdout = "col1\tcol2\n"
 
 # =============================================================================
 # String in Complex Expressions

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -23,6 +23,7 @@ use std::time::{Duration, Instant};
 
 /// A section header in a test file.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Section {
     pub id: String,
     #[allow(dead_code)]
@@ -108,8 +109,14 @@ impl<'de> Deserialize<'de> for ErrorContains {
 
 /// A single test case.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct Case {
     pub name: String,
+    /// Human-readable explanation of what this case pins and why. Not used by
+    /// the runner; it exists so case files can document intent inline.
+    #[allow(dead_code)]
+    #[serde(default)]
+    pub description: Option<String>,
     pub source: String,
     /// Expected exit code (for successful compilation)
     #[serde(default)]
@@ -231,6 +238,7 @@ pub struct Case {
 
 /// A test file containing a section and its cases.
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct TestFile {
     pub section: Section,
     #[serde(default)]
@@ -327,6 +335,7 @@ pub fn expand_case(case: Case) -> Vec<Case> {
             let mut expanded = Case {
                 // Substitute placeholders in string fields
                 name: substitute_placeholders(&case.name, params),
+                description: case.description.clone(),
                 source: substitute_placeholders(&case.source, params),
                 error_contains: ErrorContains(
                     case.error_contains
@@ -560,11 +569,12 @@ pub fn load_test_files(cases_dir: &Path) -> Vec<(String, TestFile)> {
     let mut toml_files = Vec::new();
     collect_toml_files(cases_dir, &mut toml_files);
 
+    let mut load_errors: Vec<String> = Vec::new();
     for path in toml_files {
         let content = match fs::read_to_string(&path) {
             Ok(c) => c,
             Err(e) => {
-                eprintln!("Error reading {}: {}", path.display(), e);
+                load_errors.push(format!("{}: {}", path.display(), e));
                 continue;
             }
         };
@@ -589,9 +599,26 @@ pub fn load_test_files(cases_dir: &Path) -> Vec<(String, TestFile)> {
                 specs.push((identifier, spec));
             }
             Err(e) => {
-                eprintln!("Error parsing {}: {}", path.display(), e);
+                load_errors.push(format!("{}: {}", path.display(), e));
             }
         }
+    }
+
+    // A case file that fails to load must fail the suite: silently skipping it
+    // would silently remove every test it contains. (RUE-132)
+    if !load_errors.is_empty() {
+        eprintln!(
+            "
+Error: {} test file(s) failed to load:",
+            load_errors.len()
+        );
+        for error in &load_errors {
+            eprintln!("  - {}", error);
+        }
+        panic!(
+            "Test loading failed: {} file(s) unreadable or unparsable.              See errors above for details.",
+            load_errors.len()
+        );
     }
 
     // Report all preview feature errors and fail if any were found
@@ -793,6 +820,30 @@ fn run_with_timeout(
     }
 }
 
+/// Detect an internal compiler error in a compiler invocation's outcome.
+///
+/// Returns a failure message when the compiler panicked (a Rust `panicked at`
+/// backtrace or an `internal compiler error` diagnostic on stderr) or died by
+/// signal (e.g. SIGABRT — no exit code on unix). An ICE must never satisfy a
+/// `compile_fail` expectation: "the compiler rejected the program" and "the
+/// compiler crashed" are different outcomes, and conflating them lets crashes
+/// hide inside passing suites. Mirrors `ice_message` in rue-cli-tests.
+fn ice_message(status: &std::process::ExitStatus, stderr: &str) -> Option<String> {
+    if stderr.contains("panicked at") || stderr.contains("internal compiler error") {
+        return Some(format!(
+            "INTERNAL COMPILER ERROR: compiler panicked\n--- compiler stderr ---\n{}",
+            stderr
+        ));
+    }
+    if status.code().is_none() {
+        return Some(format!(
+            "INTERNAL COMPILER ERROR: compiler killed by signal ({:?})\n--- compiler stderr ---\n{}",
+            status, stderr
+        ));
+    }
+    None
+}
+
 /// Run a single test case.
 pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
     // Create a temporary directory for this test
@@ -891,12 +942,21 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         }
     }
     compile_cmd.arg("-o").arg(&output_path);
-    let compile_output = compile_cmd
-        .output()
+    // Run the compiler under the same timeout as the compiled program, so a
+    // compiler hang fails the case instead of wedging the whole suite.
+    let compile_timeout = Duration::from_millis(case.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS));
+    let compile_output = run_with_timeout(compile_cmd, compile_timeout, None)
         .map_err(|e| format!("Failed to run rue compiler: {}", e))?;
 
     let compile_succeeded = compile_output.status.success();
     let stderr = String::from_utf8_lossy(&compile_output.stderr);
+
+    // A compiler crash is NEVER a pass — not even for compile_fail cases, where a
+    // panic would otherwise be indistinguishable from the expected diagnostic
+    // failure. Report it as a distinct ICE failure class instead.
+    if let Some(ice) = ice_message(&compile_output.status, &stderr) {
+        return Err(format!("{}\n  source: {}", ice, case.source));
+    }
 
     if case.compile_fail {
         // Expected to fail compilation
@@ -1160,6 +1220,7 @@ mod tests {
     fn test_expand_case_no_params() {
         let case = Case {
             name: "test".to_string(),
+            description: None,
             source: "fn main() {}".to_string(),
             exit_code: Some(0),
             compile_fail: false,
@@ -1210,6 +1271,7 @@ mod tests {
 
         let case = Case {
             name: "{type}_return".to_string(),
+            description: None,
             source: "fn main() -> {type} { 0 }".to_string(),
             exit_code: None, // Will be overridden
             compile_fail: false,
@@ -1268,6 +1330,7 @@ mod tests {
 
         let case = Case {
             name: "{type}_test".to_string(),
+            description: None,
             source: "fn main() {}".to_string(),
             exit_code: Some(0),
             compile_fail: false,
@@ -1318,6 +1381,7 @@ mod tests {
 
         let case = Case {
             name: "{type}_error".to_string(),
+            description: None,
             source: "fn main() -> {type} { true }".to_string(),
             exit_code: None,
             compile_fail: false, // Will be overridden
@@ -1626,6 +1690,7 @@ mod tests {
     fn make_test_case(name: &str, preview: Option<&str>) -> Case {
         Case {
             name: name.to_string(),
+            description: None,
             source: "fn main() {}".to_string(),
             exit_code: Some(0),
             compile_fail: false,

--- a/quick-test.sh
+++ b/quick-test.sh
@@ -13,18 +13,9 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 echo "Running unit tests (quick mode)..."
-./buck2 test \
-    //crates/rue-span:rue-span-test \
-    //crates/rue-error:rue-error-test \
-    //crates/rue-target:rue-target-test \
-    //crates/rue-lexer:rue-lexer-test \
-    //crates/rue-parser:rue-parser-test \
-    //crates/rue-rir:rue-rir-test \
-    //crates/rue-cfg:rue-cfg-test \
-    //crates/rue-air:rue-air-test \
-    //crates/rue-codegen:rue-codegen-test \
-    //crates/rue-linker:rue-linker-test \
-    //crates/rue-compiler:rue-compiler-test
+# Run every crate's unit tests; //... avoids a hand-maintained list that
+# silently goes stale as crates are added. (RUE-132)
+./buck2 test //...
 
 echo ""
 echo "Unit tests passed! Run ./test.sh for full verification before committing."

--- a/test.sh
+++ b/test.sh
@@ -5,20 +5,12 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
-# Run unit tests for all crates
+# Run unit tests for ALL crates. Use //... rather than a hand-maintained target
+# list: the old list silently omitted ~300 tests across 7 crates (rue,
+# rue-runtime, rue-fuzz, rue-test-runner, rue-builtins, rue-spec, rue-cli-tests)
+# because nobody remembered to add new crates here. (RUE-132)
 echo "Running unit tests..."
-./buck2 test \
-    //crates/rue-span:rue-span-test \
-    //crates/rue-error:rue-error-test \
-    //crates/rue-target:rue-target-test \
-    //crates/rue-lexer:rue-lexer-test \
-    //crates/rue-parser:rue-parser-test \
-    //crates/rue-rir:rue-rir-test \
-    //crates/rue-cfg:rue-cfg-test \
-    //crates/rue-air:rue-air-test \
-    //crates/rue-codegen:rue-codegen-test \
-    //crates/rue-linker:rue-linker-test \
-    //crates/rue-compiler:rue-compiler-test
+./buck2 test //...
 
 # Get the path to the rue binary (this also builds it if needed).
 # scripts/rue-bin resolves it to a stable absolute path.


### PR DESCRIPTION
## Summary

Part of **RUE-132** (test-infrastructure trust). The component review found the suite could lie in several ways; each was verified live, then fixed — and the fixes immediately caught real, previously-invisible problems.

### 1. ICEs counted as passing `compile_fail` tests
The shared runner accepted *any* nonzero compiler exit as the expected failure, so a panic/SIGABRT satisfied `compile_fail`. `ice_message()` (ported from rue-cli-tests) now fails such cases as a distinct **INTERNAL COMPILER ERROR** class.

**Immediately caught:** `dbg_invalid_type_array`/`dbg_invalid_type_struct` had "passed" their whole life while the compiler **panicked** — spec 4.13:7 mandates a compile error for `@dbg` on aggregates, but sema's allowlist accepted struct/enum/array and codegen panicked. Both intrinsic analyzers now reject non-(integer|bool|String) operands with a proper E0702.

### 2. ~300 unit tests never ran
test.sh/quick-test.sh hand-listed 11 of 18 `rust_test` targets — omitting `rue` (113 tests), `rue-runtime` (76), `rue-fuzz` (45, *including the compiler-never-panics proptests*), `rue-test-runner` (44), `rue-builtins` (14), `rue-spec` (8). Both now run `buck2 test //...` so new crates can't fall out silently. (All 17 targets pass — no bit-rot, happily.)

### 3. Unknown TOML fields silently ignored
`deny_unknown_fields` on both harnesses' case structs. **Immediately caught NINE assertions that never executed**: cases wrote `stdout =` where the real field is `expected_stdout` — including three destructor cases *written to assert drop ordering* that only ever checked exit codes. Renamed; all nine resurrected assertions pass. `description` is now a real, allowed field on `[[case]]`.

### 4. Case-file load failures were soft
A file that failed to parse was eprintln'd and *skipped* — silently removing every test it contained (observed: suite shrank from 1367 to 656 cases and still reported `ok`). Load errors now fail the run.

Plus: the compiler invocation runs under the same timeout as the compiled program (a compiler hang no longer wedges the suite), and rue-error gains a self-maintaining duplicate-ErrorCode test.

## Validation
Full `./test.sh` green end-to-end under the stricter rules: 17/17 buck targets, 1350 spec, 49 UI, 93 CLI, 100% normative traceability.

Remaining RUE-132 items (buck `command_test` targets for the case suites, golden-IR exec-skip, assertions for the 98 bare compile_fail cases) stay on the epic.

Part of RUE-132 (intentionally not auto-closing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)