### PR TITLE
Scope the unit-test sweep to //crates/...

### DIFF
--- a/quick-test.sh
+++ b/quick-test.sh
@@ -14,8 +14,9 @@ cd "$(dirname "$0")"
 
 echo "Running unit tests (quick mode)..."
 # Run every crate's unit tests; //... avoids a hand-maintained list that
-# silently goes stale as crates are added. (RUE-132)
-./buck2 test //...
+# silently goes stale as crates are added; scoping to //crates/ keeps vendored
+# third-party targets out of the test set. (RUE-132)
+./buck2 test //crates/...
 
 echo ""
 echo "Unit tests passed! Run ./test.sh for full verification before committing."

--- a/test.sh
+++ b/test.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 
 cd "$(dirname "$0")"
 
-# Run unit tests for ALL crates. Use //... rather than a hand-maintained target
+# Run unit tests for ALL crates. Use //crates/... rather than a hand-maintained target
 # list: the old list silently omitted ~300 tests across 7 crates (rue,
 # rue-runtime, rue-fuzz, rue-test-runner, rue-builtins, rue-spec, rue-cli-tests)
 # because nobody remembered to add new crates here. (RUE-132)
 echo "Running unit tests..."
-./buck2 test //...
+./buck2 test //crates/...
 
 # Get the path to the rue binary (this also builds it if needed).
 # scripts/rue-bin resolves it to a stable absolute path.


### PR DESCRIPTION
Follow-up to #910 from Steve's review comment: `buck2 test //...` matches 234 targets outside `crates/` (vendored third-party deps, toolchains, constraints). None define test targets today so behavior is identical — but `//...` would silently adopt any test a vendored crate ever grows, and builds everything it matches. `//crates/...` states the actual intent: every test in *our* crates, no hand-maintained list. Verified: same 17 targets, all pass.

Part of the test-infrastructure trust epic (not closing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)