### PR TITLE
Allocate what we record: fix String growth under-allocation heap overflow

### DIFF
--- a/crates/rue-cli-tests/cases/string_growth.toml
+++ b/crates/rue-cli-tests/cases/string_growth.toml
@@ -1,0 +1,45 @@
+# String heap-growth correctness (RUE-34).
+#
+# string_ensure_capacity used to realloc only `required` bytes while RECORDING
+# the doubled capacity — the next append that fit the phantom capacity wrote
+# past the allocation into neighboring heap memory (cross-allocation
+# corruption). The capacity recorded must never exceed the bytes owned.
+
+[section]
+id = "cli.string_growth"
+name = "String growth"
+description = "Growing a String must allocate at least the capacity it records."
+
+[[case]]
+name = "growth_does_not_corrupt_neighbor"
+description = "Two interleaved strings: growing one then appending in-place must not clobber the other (the original RUE-34 repro)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let cap: u64 = 16;
+    let mut s = String::with_capacity(cap);
+    s.push_str("AAAAAAAAAAAAAAAAA");
+    let mut s2 = String::with_capacity(cap);
+    s2.push_str("ZZZZZZZZ");
+    s.push_str("XXXXXXXXXXXXXXX");
+    if s2 == "ZZZZZZZZ" { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "interleaved_repeated_growth_stress"
+description = "Two strings growing in lockstep through many cap*2 doublings stay independent and reach the right lengths."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut a = String::new();
+    let mut b = String::new();
+    let mut i = 0;
+    while i < 50 {
+        a.push_str("aaaaaaaaaa");
+        b.push_str("bbbbbbbbbb");
+        i = i + 1;
+    }
+    if a.len() == 500 { if b.len() == 500 { 0 } else { 2 } } else { 1 }
+}
+""" }]
+exit_code = 0

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -111,6 +111,11 @@ struct SourceFile {
 #[serde(deny_unknown_fields)]
 struct Case {
     name: String,
+    /// Human-readable explanation of what this case pins and why. Not used by
+    /// the harness; it exists so case files can document intent inline.
+    #[allow(dead_code)]
+    #[serde(default)]
+    description: Option<String>,
     /// Files written to the temp directory before invoking the compiler.
     files: Vec<SourceFile>,
     /// Compiler arguments, relative to the temp dir (default: first file + `-o prog`).

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -1054,15 +1054,18 @@ fn string_ensure_capacity(ptr: *mut u8, len: u64, cap: u64, additional: u64) -> 
         }
         (new_ptr, new_cap)
     } else if required > cap {
-        // Need to grow: use the realloc function which implements growth strategy
-        let new_ptr = heap::realloc(ptr, cap, required, 1);
+        // Need to grow. Compute the doubled capacity FIRST and allocate exactly
+        // that: the capacity we record must never exceed the bytes we actually
+        // own. (This previously realloc'd only `required` while recording the
+        // doubled value — the next append that fit the phantom capacity wrote
+        // past the allocation into neighboring heap memory. RUE-34)
+        let grown_cap = cap.saturating_mul(2);
+        let new_cap = required.max(grown_cap).max(STRING_MIN_CAPACITY);
+        let new_ptr = heap::realloc(ptr, cap, new_cap, 1);
         // Check for allocation failure
         if new_ptr.is_null() {
             return (core::ptr::null_mut(), 0);
         }
-        // Calculate actual new capacity (realloc uses 2x growth strategy)
-        let grown_cap = cap.saturating_mul(2);
-        let new_cap = required.max(grown_cap).max(STRING_MIN_CAPACITY);
         (new_ptr, new_cap)
     } else {
         // Capacity is sufficient


### PR DESCRIPTION
## Summary

`string_ensure_capacity`'s grow branch realloc'd only `required` bytes while **recording** the doubled capacity (`max(required, cap*2, 16)`) — its comment even claimed the realloc implemented the growth strategy; it didn't. Whenever `cap*2 > required`, the recorded capacity was phantom: the next append that fit it took the in-place path and **wrote past the real allocation into neighboring heap memory**. Cross-allocation corruption from ordinary `push_str` calls — the exact class of bug the language promises to prevent, in its own runtime.

```rue
let mut s = String::with_capacity(16);
s.push_str("AAAAAAAAAAAAAAAAA");   // 17 bytes: grow (allocated 17, recorded 32)
let mut s2 = String::with_capacity(16);
s2.push_str("ZZZZZZZZ");
s.push_str("XXXXXXXXXXXXXXX");     // "fits" 32 → in-place → clobbers s2
// before: s2 corrupted (exit 1). after: exit 0
```

## Fix

Compute the doubled capacity first and realloc to exactly that — the capacity recorded never exceeds the bytes owned. (The dead `__rue_string_realloc` next to it always had this right; consolidating dead-vs-live duplicates is tracked separately in the dead-code-purge epic.)

## Testing

- New `crates/rue-cli-tests/cases/string_growth.toml`: the original two-string corruption repro + an interleaved 50-iteration growth stress through multiple doublings. Both verified failing before / passing after.
- Full `./test.sh` green. Also gives the CLI harness's `Case` the same documented `description` field the shared runner gained (the hardened unknown-field validation from #910 caught its absence loudly — working as designed).

Found by the component review (runtime reviewer pinned the exact root); root cause analysis on the issue.

Fixes RUE-34

🤖 Generated with [Claude Code](https://claude.com/claude-code)