### PR TITLE
CFG: refuse to overwrite block terminators; propagate diverging let-initializers

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -608,6 +608,15 @@ impl<'a> CfgBuilder<'a> {
 
             AirInstData::Alloc { slot, init } => {
                 let init_result = self.lower_inst(*init);
+                // If the initializer diverges (e.g. `let x = { return 7; 2 };`),
+                // the binding never happens and everything after the `let` is
+                // unreachable. Propagate the divergence — previously this arm
+                // always reported Continues, so the builder kept lowering the
+                // rest of the block and silently OVERWROTE the initializer's
+                // Return terminator with the later code's. (RUE-128)
+                if matches!(init_result.continuation, Continuation::Diverged) {
+                    return Self::diverged();
+                }
                 // If init produces a value, use it; otherwise use a dummy Unit value
                 let init_val = init_result
                     .value

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -867,7 +867,23 @@ impl Cfg {
     }
 
     /// Set the terminator for a block.
+    ///
+    /// A block's terminator may only be set once (from `None`), or may replace
+    /// an `Unreachable` placeholder. Silently overwriting a real terminator is
+    /// how divergence bugs hide — e.g. a diverging let-initializer's `Return`
+    /// being clobbered by the code after the `let` (RUE-128) — so that is a
+    /// loud debug assertion instead.
     pub fn set_terminator(&mut self, block: BlockId, term: Terminator) {
+        debug_assert!(
+            matches!(
+                self.blocks[block.0 as usize].terminator,
+                Terminator::None | Terminator::Unreachable
+            ),
+            "block {} already has terminator {:?}; refusing to overwrite with {:?}",
+            block.0,
+            self.blocks[block.0 as usize].terminator,
+            term
+        );
         self.blocks[block.0 as usize].terminator = term;
     }
 

--- a/crates/rue-cli-tests/cases/programs.toml
+++ b/crates/rue-cli-tests/cases/programs.toml
@@ -234,3 +234,27 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 7
+
+# RUE-128: a let whose initializer diverges. The Alloc lowering used to discard
+# the initializer's continuation, so the builder kept lowering the rest of the
+# block and silently OVERWROTE the Return terminator — `let x = { return 7; 2 }; 3`
+# returned 3. Everything after such a let is unreachable.
+[[case]]
+name = "let_with_diverging_block_initializer"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x = { return 7; 2 };
+    3
+}
+""" }]
+exit_code = 7
+
+[[case]]
+name = "let_with_diverging_if_initializer"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = if true { return 9; } else { return 8; };
+    3
+}
+""" }]
+exit_code = 9


### PR DESCRIPTION
## Summary

Two changes from the CFG-divergence family the component review identified (epic RUE-128 — referencing, not closing):

1. **`Cfg::set_terminator` now debug-asserts the block's existing terminator is `None`/`Unreachable`.** Silently overwriting a real terminator is how divergence bugs hide; this single line turns the entire class — present and future — into loud ICEs at the moment of overwrite instead of wrong answers at runtime.

2. **The assert immediately flagged the known silent miscompile, now fixed:** the Alloc arm discarded a diverging initializer's continuation, so

   ```rue
   fn main() -> i32 { let x = { return 7; 2 }; 3 }   // returned 3 — the Return terminator was overwritten
   ```

   The builder kept lowering past the `let` and clobbered the `Return`. The binding never happens and everything after the `let` is unreachable; the arm now propagates the divergence. Repro returns **7**; the if/else-initializer variant returns **9**.

## Validation

Full `./test.sh` green **with the assert live** — no other construct overwrites a terminator today, so the assert is pure future-proofing beyond this fix. The sibling `&&`/`||`-diverging-rhs case still ICEs via a *different* shape (join block left unterminated — caught by codegen's existing no-terminator panic) and stays tracked on the divergence epic.

Two new regression cases in `crates/rue-cli-tests/cases/programs.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)