### PR TITLE
Refuse output paths that would destroy a source file

### DIFF
--- a/crates/rue-cli-tests/cases/basics.toml
+++ b/crates/rue-cli-tests/cases/basics.toml
@@ -103,11 +103,11 @@ args = ["main.rue", "utils.rue", "-o", "prog"]
 stdout = "42\n"
 
 # CLAUDE.md documents `rue a.rue b.rue` as an error, but the CLI currently
-# treats b.rue as the OUTPUT path and silently overwrites the source file
-# with an ELF executable (data loss). See RUE-20.
+# used to treat b.rue as the OUTPUT path and silently overwrite the source
+# file with an ELF executable (data loss). The driver now refuses .rue output
+# paths in legacy mode (fixed under RUE-20).
 [[case]]
 name = "multi_file_without_dash_o_is_an_error"
-known_bug = "RUE-20"
 files = [
     { path = "a.rue", source = "fn main() -> i32 { 0 }" },
     { path = "b.rue", source = "fn helper() -> i32 { 1 }" },

--- a/crates/rue-cli-tests/cases/output_guard.toml
+++ b/crates/rue-cli-tests/cases/output_guard.toml
@@ -1,0 +1,37 @@
+# Output-path safety (the legacy two-positional footgun).
+#
+# `rue a.rue b.rue` used to treat b.rue as the OUTPUT path and silently
+# overwrite the source file with the compiled binary (exit 0, file destroyed).
+# The driver now refuses a .rue output in legacy mode and refuses any output
+# path that equals an input, in every mode.
+
+[section]
+id = "cli.output_guard"
+name = "Output path safety"
+description = "The compiler must never write its output over a source file."
+
+[[case]]
+# RUE-130: two .rue positionals without -o must error, not clobber the second file.
+name = "legacy_two_rue_positionals_refused"
+files = [
+  { path = "a.rue", source = "fn main() -> i32 { 1 }\n" },
+  { path = "b.rue", source = "fn main() -> i32 { 2 }\n" },
+]
+args = ["a.rue", "b.rue"]
+compile_fail = true
+error_contains = ["refusing", "b.rue", "-o"]
+
+[[case]]
+# Explicit -o pointing at an input source must be refused.
+name = "output_equal_to_input_refused"
+files = [{ path = "a.rue", source = "fn main() -> i32 { 1 }\n" }]
+args = ["a.rue", "-o", "a.rue"]
+compile_fail = true
+error_contains = ["also an input source file"]
+
+[[case]]
+# The backwards-compatible `rue src out` form stays functional for non-.rue outputs.
+name = "legacy_non_rue_output_still_works"
+files = [{ path = "a.rue", source = "fn main() -> i32 { 5 }\n" }]
+args = ["a.rue", "prog"]
+exit_code = 5

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -457,7 +457,19 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         (positional, "a.out".to_string())
     } else if positional.len() == 2 {
         // Two positional args, no -o: backwards compatible mode
-        // First is source, second is output
+        // First is source, second is output — but NEVER treat a .rue file as
+        // the output. `rue a.rue b.rue` used to silently overwrite the b.rue
+        // SOURCE FILE with the compiled binary (RUE-130); the user almost
+        // certainly meant to compile both.
+        if positional[1].ends_with(".rue") {
+            eprintln!(
+                "Error: refusing to use '{}' as the output path: it looks like a source file",
+                positional[1]
+            );
+            eprintln!("To compile multiple source files, specify the output with -o:");
+            eprintln!("       rue {} {} -o <output>", positional[0], positional[1]);
+            return ParseResult::Error;
+        }
         let mut pos = positional;
         let out = pos.pop().unwrap();
         (pos, out)
@@ -467,6 +479,16 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         eprintln!("Usage: rue a.rue b.rue -o output");
         return ParseResult::Error;
     };
+
+    // In every mode: the output must not clobber an input. (Catches explicit
+    // footguns like `rue a.rue -o a.rue` too.)
+    if source_paths.contains(&final_output_path) {
+        eprintln!(
+            "Error: output path '{}' is also an input source file; refusing to overwrite it",
+            final_output_path
+        );
+        return ParseResult::Error;
+    }
 
     ParseResult::Options(Options {
         source_paths,


### PR DESCRIPTION
## Summary

The backwards-compatible two-positional mode treated the second argument as the output path unconditionally — so `rue a.rue b.rue` **silently overwrote the b.rue source file** with the compiled ELF and exited 0 (confirmed by running: file destroyed). CLAUDE.md even documents that invocation as an error. Worst severity-per-fix-cost finding of the component review; the original report is RUE-20.

## Fix

Two guards in argument parsing:
- **Legacy mode refuses a `.rue` output path** with a message pointing at `-o` ("To compile multiple source files, specify the output with -o: …").
- **Every mode refuses an output path equal to any input** (catches the explicit `rue a.rue -o a.rue` footgun too).

The legitimate legacy form (`rue src out`) keeps working for non-`.rue` outputs.

## Testing

- New `crates/rue-cli-tests/cases/output_guard.toml`: both refusals + the legacy-form control, all verified by running.
- Un-marks the pre-existing xfail `multi_file_without_dash_o_is_an_error` (basics.toml) — this fix makes it pass, so it's now a normal regression test.
- Full `./test.sh` green.

Fixes RUE-20

🤖 Generated with [Claude Code](https://claude.com/claude-code)