### PR TITLE
Report type mismatches in the right direction: expected is the context, found is the value

### DIFF
--- a/crates/rue-air/src/inference/unify.rs
+++ b/crates/rue-air/src/inference/unify.rs
@@ -154,9 +154,16 @@ impl Unifier {
                 if t1 == t2 || t1.can_coerce_to(t2) || t2.can_coerce_to(t1) {
                     UnifyResult::Ok
                 } else {
+                    // Every directional constraint site passes (actual, expected):
+                    // Ret is (value, return_type), Assign is (value, variable),
+                    // Alloc is (init, annotation), calls are (arg, param). So the
+                    // RHS is what the context expects and the LHS is what was
+                    // found. This used to report lhs as "expected", which printed
+                    // every mismatch backwards ("expected bool, found i32" for
+                    // `fn main() -> i32 { true }`). (RUE-133)
                     UnifyResult::TypeMismatch {
-                        expected: lhs_resolved,
-                        found: rhs_resolved,
+                        expected: rhs_resolved,
+                        found: lhs_resolved,
                     }
                 }
             }
@@ -200,9 +207,10 @@ impl Unifier {
                 },
             ) => {
                 if len1 != len2 {
+                    // Same (actual, expected) convention as TypeMismatch above.
                     UnifyResult::ArrayLengthMismatch {
-                        expected: *len1,
-                        found: *len2,
+                        expected: *len2,
+                        found: *len1,
                     }
                 } else {
                     // Recursively unify element types

--- a/crates/rue-ui-tests/cases/diagnostics/type_mismatch_direction.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/type_mismatch_direction.toml
@@ -1,0 +1,35 @@
+[section]
+id = "diagnostics.type_mismatch_direction"
+name = "Type mismatch direction"
+description = "E0206 must report the context's expected type as 'expected' and the actual value's type as 'found' — these were systematically swapped (RUE-133)."
+
+[[case]]
+name = "return_type_mismatch_direction"
+source = """
+fn main() -> i32 { true }
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["expected i32, found bool"]
+
+[[case]]
+name = "let_annotation_mismatch_direction"
+source = """
+fn main() -> i32 {
+    let x: i32 = true;
+    0
+}
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["expected i32, found bool"]
+
+[[case]]
+name = "call_arg_mismatch_direction"
+source = """
+fn f(n: i32) -> i32 { n }
+fn main() -> i32 { f(true) }
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["expected i32, found bool"]


### PR DESCRIPTION
Every directional E0206 printed backwards — `fn main() -> i32 { true }` said *expected bool, found i32*. All constraint sites uniformly pass `(actual, expected)` (Ret/Assign/Alloc/call-args), but unify reported the **lhs** as expected. One systematic flip in `unify`'s TypeMismatch (+ the ArrayLengthMismatch sibling), convention documented at the site.

Verified across tail-return / let-annotation / assignment / call-arg shapes; full suite unchanged (nothing had pinned the backwards text); 3 new UI cases pin the corrected direction.

Part of the diagnostics-quality epic (item 1; not closing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)