### PR TITLE
Resolve struct-field types during constraint generation; range-check the struct-init literal shortcut

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -11,7 +11,9 @@ use super::types::{InferType, TypeVarAllocator, TypeVarId};
 use crate::Type;
 use crate::intern_pool::TypeInternPool;
 use crate::scope::ScopedContext;
-use crate::types::{PtrMutability, StructId, parse_array_type_syntax, parse_pointer_type_syntax};
+use crate::types::{
+    PtrMutability, StructId, TypeKind, parse_array_type_syntax, parse_pointer_type_syntax,
+};
 use lasso::{Spur, ThreadedRodeo};
 use rue_rir::{InstData, InstRef, Rir};
 use rue_span::Span;
@@ -219,6 +221,46 @@ impl<'a> ConstraintGenerator<'a> {
     }
 
     /// Allocate a fresh type variable.
+    /// Resolve a struct field's declared type when the base expression's type
+    /// is already a concrete struct. Returns None for unresolved bases,
+    /// non-struct types, and unknown field names (sema diagnoses those).
+    fn known_field_type(&self, base_ty: &InferType, field: Spur) -> Option<Type> {
+        let InferType::Concrete(ty) = base_ty else {
+            return None;
+        };
+        self.field_type_of(*ty, field)
+    }
+
+    /// Convert a resolved `Type` into an `InferType`, representing arrays
+    /// structurally so they unify with array-literal expressions. Mirrors
+    /// `Sema::type_to_infer_type`.
+    fn type_to_infer(&self, ty: Type) -> InferType {
+        match ty.kind() {
+            TypeKind::Array(array_id) => {
+                let (element_type, length) = self.type_pool.array_def(array_id);
+                InferType::Array {
+                    element: Box::new(self.type_to_infer(element_type)),
+                    length,
+                }
+            }
+            _ => InferType::Concrete(ty),
+        }
+    }
+
+    /// Resolve a field's declared type on a concrete struct type.
+    fn field_type_of(&self, struct_ty: Type, field: Spur) -> Option<Type> {
+        let TypeKind::Struct(struct_id) = struct_ty.kind() else {
+            return None;
+        };
+        let field_name = self.interner.resolve(&field);
+        self.type_pool
+            .struct_def(struct_id)
+            .fields
+            .iter()
+            .find(|f| f.name == field_name)
+            .map(|f| f.ty)
+    }
+
     pub fn fresh_var(&mut self) -> TypeVarId {
         self.type_vars.fresh()
     }
@@ -931,9 +973,17 @@ impl<'a> ConstraintGenerator<'a> {
 
                 if let Some(struct_ty) = struct_ty {
                     let fields = self.rir.get_field_inits(*fields_start, *fields_len);
-                    // Generate constraints for each field
-                    for (_, value_ref) in fields.iter() {
-                        self.generate(*value_ref, ctx);
+                    // Constrain each initializer against its field's declared
+                    // type, so literal initializers are range-checked at the
+                    // field's width instead of silently wrapping
+                    // (`S { a: 300 }` with a: u8 used to truncate to 44).
+                    // (RUE-72)
+                    for (field_name, value_ref) in fields.iter() {
+                        let value_info = self.generate(*value_ref, ctx);
+                        if let Some(field_ty) = self.field_type_of(struct_ty, *field_name) {
+                            let expected = self.type_to_infer(field_ty);
+                            self.add_constraint(Constraint::equal(value_info.ty, expected, span));
+                        }
                     }
                     InferType::Concrete(struct_ty)
                 } else {
@@ -942,24 +992,35 @@ impl<'a> ConstraintGenerator<'a> {
             }
 
             // Field access
-            InstData::FieldGet { base, field: _ } => {
-                // Generate constraints for the base expression (needed for nested field access)
-                let _base_info = self.generate(*base, ctx);
-                // We need to look up the field type from the struct definition.
-                // For now, use a fresh type variable - full resolution happens during
-                // semantic analysis which has access to struct definitions.
-                let result_var = self.fresh_var();
-                InferType::Var(result_var)
+            InstData::FieldGet { base, field } => {
+                let base_info = self.generate(*base, ctx);
+                // When the base's struct type is already concrete, the field's
+                // declared type is known RIGHT NOW — yield it so downstream
+                // constraints see the real type instead of a free variable.
+                // Leaving it free mis-defaulted literals compared against i64
+                // fields to i32 (spurious E0800) and made method calls on a
+                // field receiver unresolvable (the MethodCall arm requires a
+                // Concrete receiver). When the base is still a variable, fall
+                // back to a fresh var; sema resolves and diagnoses later.
+                // (RUE-89, RUE-126)
+                match self.known_field_type(&base_info.ty, *field) {
+                    Some(field_ty) => self.type_to_infer(field_ty),
+                    None => InferType::Var(self.fresh_var()),
+                }
             }
 
             // Field assignment
-            InstData::FieldSet {
-                base,
-                field: _,
-                value,
-            } => {
-                self.generate(*base, ctx);
-                self.generate(*value, ctx);
+            InstData::FieldSet { base, field, value } => {
+                let base_info = self.generate(*base, ctx);
+                let value_info = self.generate(*value, ctx);
+                // Constrain the assigned value against the field's declared
+                // type, so a literal RHS is range-checked at the field's width
+                // instead of silently wrapping (`s.a = 300` with a: u8 used to
+                // truncate to 44). (RUE-104)
+                if let Some(field_ty) = self.known_field_type(&base_info.ty, *field) {
+                    let expected = self.type_to_infer(field_ty);
+                    self.add_constraint(Constraint::equal(value_info.ty, expected, span));
+                }
                 InferType::Concrete(Type::UNIT)
             }
 

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1981,7 +1981,19 @@ impl<'a> Sema<'a> {
             // (e.g., when the struct comes from a comptime type variable)
             let field_inst = self.rir.get(*field_value);
             let field_result = if let InstData::IntConst(value) = &field_inst.data {
-                // Integer literal - use the expected field type directly
+                // Integer literal - use the expected field type directly, but
+                // range-check it first: this shortcut bypasses analyze_literal,
+                // and previously skipped the E0800 check entirely, so
+                // `S { a: 300 }` with a: u8 silently truncated to 44. (RUE-72)
+                if !expected_field_type.literal_fits(*value) {
+                    return Err(CompileError::new(
+                        ErrorKind::LiteralOutOfRange {
+                            value: *value,
+                            ty: expected_field_type.name().to_string(),
+                        },
+                        field_inst.span,
+                    ));
+                }
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::Const(*value),
                     ty: expected_field_type,

--- a/crates/rue-cli-tests/cases/field_type_inference.toml
+++ b/crates/rue-cli-tests/cases/field_type_inference.toml
@@ -1,0 +1,90 @@
+# Struct-field types must reach the inference layer (RUE-72/89/104/126).
+#
+# A field access used to yield an unconstrained fresh type variable ("full
+# resolution happens during semantic analysis"), and FieldSet/StructInit added
+# no constraint at all. Consequences: literals compared against i64 fields
+# mis-defaulted to i32 (spurious E0800), method calls on a field receiver were
+# unresolvable, and out-of-range literal initializers/assignments silently
+# wrapped. Field types are now resolved at constraint-generation time when the
+# base struct type is concrete, and the struct-init literal shortcut in sema
+# range-checks before coercing.
+
+[section]
+id = "cli.field_type_inference"
+name = "Field type inference"
+description = "Field reads anchor downstream inference; field writes and initializers are range-checked."
+
+[[case]]
+name = "i64_field_vs_large_literal"
+description = "RUE-89: a literal compared against an i64 field infers as i64, not i32."
+files = [{ path = "main.rue", source = """
+struct S { a: i64 }
+fn main() -> i32 {
+    let s = S { a: 1099511627776 };
+    if s.a == 1099511627776 { 1 } else { 0 }
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "string_field_method_receiver_anchors_literal"
+description = "RUE-126: h.s.len() resolves (field receiver is concrete) and anchors the compared literal."
+files = [{ path = "main.rue", source = """
+struct Holder { s: String }
+fn main() -> i32 {
+    let h = Holder { s: "hello" };
+    if h.s.len() == 5 { 5 } else { 0 }
+}
+""" }]
+exit_code = 5
+
+[[case]]
+name = "struct_init_literal_out_of_range_rejected"
+description = "RUE-72: an out-of-range literal field initializer is E0800, not a silent wrap to 44."
+files = [{ path = "main.rue", source = """
+struct S { a: u8 }
+fn main() -> i32 {
+    let s = S { a: 300 };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0800", "300", "u8"]
+
+[[case]]
+name = "field_assign_literal_out_of_range_rejected"
+description = "RUE-104: an out-of-range literal field assignment is E0800, not a silent wrap."
+files = [{ path = "main.rue", source = """
+struct S { a: u8 }
+fn main() -> i32 {
+    let mut s = S { a: 1 };
+    s.a = 300;
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0800", "300", "u8"]
+
+[[case]]
+name = "in_range_field_literals_still_work"
+files = [{ path = "main.rue", source = """
+struct S { a: u8 }
+fn main() -> i32 {
+    let mut s = S { a: 7 };
+    s.a = 49;
+    if s.a == 49 { 49 } else { 0 }
+}
+""" }]
+exit_code = 49
+
+[[case]]
+name = "array_field_initializer_still_works"
+description = "Array-typed fields unify structurally with array literals (regression guard for the conversion)."
+files = [{ path = "main.rue", source = """
+struct H { data: [i32; 3] }
+fn main() -> i32 {
+    let h = H { data: [1, 2, 3] };
+    h.data[0] + h.data[1] + h.data[2]
+}
+""" }]
+exit_code = 6

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1553,56 +1553,6 @@ impl<'a> CfgLower<'a> {
                         continue;
                     }
 
-                    // Handle builtin String specially (String is a builtin struct type)
-                    if self.ctx.is_builtin_string(arg_type) {
-                        // String has 3 slots: ptr, len, cap
-                        let arg_data = &self.ctx.cfg.get_inst(arg_value).data;
-                        match arg_data {
-                            CfgInstData::Load { slot } => {
-                                // Load all 3 String fields from stack
-                                for field_idx in 0..3u32 {
-                                    let field_vreg = self.mir.alloc_vreg();
-                                    let field_slot = slot + field_idx;
-                                    let offset = self.ctx.local_offset(field_slot);
-                                    self.mir.push(Aarch64Inst::Ldr {
-                                        dst: Operand::Virtual(field_vreg),
-                                        base: Reg::Fp,
-                                        offset,
-                                    });
-                                    flattened_vregs.push(field_vreg);
-                                }
-                            }
-                            CfgInstData::Param { index } => {
-                                // Load all 3 String fields from param slots
-                                for field_idx in 0..3u32 {
-                                    let field_vreg = self.mir.alloc_vreg();
-                                    let param_slot = self.ctx.num_locals + index + field_idx;
-                                    let offset = self.ctx.local_offset(param_slot);
-                                    self.mir.push(Aarch64Inst::Ldr {
-                                        dst: Operand::Virtual(field_vreg),
-                                        base: Reg::Fp,
-                                        offset,
-                                    });
-                                    flattened_vregs.push(field_vreg);
-                                }
-                            }
-                            CfgInstData::StringConst(_) | CfgInstData::Call { .. } => {
-                                // String from a call result or string const - use vregs
-                                if let Some(field_vregs) = self.struct_slot_vregs.get(&arg_value) {
-                                    flattened_vregs.extend(field_vregs.iter().copied());
-                                } else {
-                                    // Single vreg case (shouldn't happen for String)
-                                    flattened_vregs.push(self.get_vreg(arg_value));
-                                }
-                            }
-                            _ => {
-                                // Fallback - should be rare for String
-                                flattened_vregs.push(self.get_vreg(arg_value));
-                            }
-                        }
-                        continue;
-                    }
-
                     match arg_type.kind() {
                         TypeKind::Struct(_) | TypeKind::Array(_) => {
                             // Pass all slots of the (possibly multi-slot) aggregate arg —


### PR DESCRIPTION
## Summary

A field access yielded an **unconstrained fresh type variable** in the inference layer, and `FieldSet`/`StructInit` constrained their values against nothing. Four user-visible bugs shared this one root:

| Bug | Before | After |
|-----|--------|-------|
| literal vs i64 field (`s.a == 2^40`) | mis-defaulted to i32, spurious E0800 | exits 1 ✓ |
| method on field receiver (`h.s.len() == 5`) | E0800 against `<error>` | exits 5 ✓ |
| field assignment (`s.a = 300`, a: u8) | silently wrapped to 44 | proper E0800 ✓ |
| field initializer (`S { a: 300 }`) | silently wrapped | proper E0800 ✓ |

## Fix

The constraint generator now resolves a field's declared type whenever the base struct type is concrete: `FieldGet` yields the field's type; `FieldSet`/`StructInit` constrain their values against it. Array-typed fields convert through a `type_to_infer` mirror so they unify *structurally* with array literals (the first version broke array-field initializers — caught by the spec suite and fixed with a pinned regression control).

The initializer case needed one more piece: sema's `analyze_struct_init` has a shortcut that coerces integer-literal fields directly, **bypassing `analyze_literal`** — it now performs the same `literal_fits` range check before coercing.

Unresolved bases keep the fresh-var fallback, so the comptime-generic-receiver case is unchanged (still tracked separately).

## aarch64: latent String-receiver miscompile (found by this PR's CI run)

Making `h.s.len()` compile exposed a latent aarch64 bug — the first CI run failed on arm64 with exit 0 instead of 5. The aarch64 call-arg lowering had a String-specific pre-ladder ahead of the shared aggregate accessor, and its fallback arm passed a place-read String receiver as **one** vreg: `String__len` got the ptr slot in x0 and garbage in x1/x2, so `len()` returned 0. x86 has no such ladder and was already correct via the accessor.

The pre-ladder is deleted (−50 lines); String args now flow through `get_or_compute_field_vregs` like every other aggregate, and the emitted asm loads all three fat-pointer slots into x0/x1/x2.

This also made a pre-existing diagnostics gap reachable: a variable whose only use is a method call on one of its fields is spuriously reported unused. Filed as RUE-135 (not addressed here).

## Testing

Six regression cases in `field_type_inference.toml` (each bug + in-range control + array-field structural control); `string_field_method_receiver_anchors_literal` exercises the aarch64 receiver path. Full `./test.sh` green. The StructInit field-type constraint also fixes RUE-82 (ICE on empty array literal `[]` in a struct field initializer — the element type now infers from the declared field type; verified exit 5 vs E9000 on trunk; regression case to follow in the next CLI-cases batch).

Fixes RUE-72
Fixes RUE-82
Fixes RUE-89
Fixes RUE-104
Fixes RUE-126

🤖 Generated with [Claude Code](https://claude.com/claude-code)
