### PR TITLE
CFG: short-circuit operators with a diverging rhs; scope balance on diverged statements

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -417,20 +417,24 @@ impl<'a> CfgBuilder<'a> {
                     },
                 );
 
-                // In rhs_block, evaluate rhs and go to join
+                // In rhs_block, evaluate rhs and go to join.
+                // If the rhs diverges (e.g. `true && return 5`), its block already
+                // ends in the diverging terminator and contributes no edge to the
+                // join — but the join is STILL reachable via the short-circuit
+                // (lhs-false) edge, so we must continue lowering there rather than
+                // propagate divergence (which would leave the join unterminated).
                 self.current_block = rhs_block;
-                let Some(rhs_val) = self.lower_value(*rhs) else {
-                    return Self::diverged();
-                };
-                let (args_start, args_len) = self.cfg.push_extra(std::iter::once(rhs_val));
-                self.cfg.set_terminator(
-                    self.current_block,
-                    Terminator::Goto {
-                        target: join_block,
-                        args_start,
-                        args_len,
-                    },
-                );
+                if let Some(rhs_val) = self.lower_value(*rhs) {
+                    let (args_start, args_len) = self.cfg.push_extra(std::iter::once(rhs_val));
+                    self.cfg.set_terminator(
+                        self.current_block,
+                        Terminator::Goto {
+                            target: join_block,
+                            args_start,
+                            args_len,
+                        },
+                    );
+                }
 
                 // Continue in join block
                 self.current_block = join_block;
@@ -471,20 +475,24 @@ impl<'a> CfgBuilder<'a> {
                     },
                 );
 
-                // In rhs_block, evaluate rhs and go to join
+                // In rhs_block, evaluate rhs and go to join.
+                // If the rhs diverges (e.g. `false || return 7`), its block already
+                // ends in the diverging terminator and contributes no edge to the
+                // join — but the join is STILL reachable via the short-circuit
+                // (lhs-true) edge, so we must continue lowering there rather than
+                // propagate divergence (which would leave the join unterminated).
                 self.current_block = rhs_block;
-                let Some(rhs_val) = self.lower_value(*rhs) else {
-                    return Self::diverged();
-                };
-                let (args_start, args_len) = self.cfg.push_extra(std::iter::once(rhs_val));
-                self.cfg.set_terminator(
-                    self.current_block,
-                    Terminator::Goto {
-                        target: join_block,
-                        args_start,
-                        args_len,
-                    },
-                );
+                if let Some(rhs_val) = self.lower_value(*rhs) {
+                    let (args_start, args_len) = self.cfg.push_extra(std::iter::once(rhs_val));
+                    self.cfg.set_terminator(
+                        self.current_block,
+                        Terminator::Goto {
+                            target: join_block,
+                            args_start,
+                            args_len,
+                        },
+                    );
+                }
 
                 // Continue in join block
                 self.current_block = join_block;
@@ -971,7 +979,15 @@ impl<'a> CfgBuilder<'a> {
                             }
                         }
                         // Note: drops were already emitted by the diverging statement
-                        // (break/continue/return handle their own drops)
+                        // (break/continue/return handle their own drops), so we pop
+                        // our scope WITHOUT emitting cleanup. Popping is still
+                        // required: a leaked entry unbalances the LIFO pairing, so a
+                        // still-reachable enclosing block (e.g. the loop-exit path
+                        // after a `break`) would later pop THIS scope instead of its
+                        // own and re-drop these slots on a live path.
+                        if !is_storage_live_wrapper {
+                            self.scope_stack.pop();
+                        }
                         return ExprResult {
                             value: None,
                             continuation: Continuation::Diverged,
@@ -2209,5 +2225,65 @@ mod tests {
 
         // The function should return from within the loop
         assert!(cfg.block_count() >= 2);
+    }
+
+    /// Assert that every block in the CFG has a terminator. A `Terminator::None`
+    /// left behind by the builder is the "block has no terminator" codegen ICE.
+    fn assert_all_blocks_terminated(cfg: &Cfg) {
+        for block in cfg.blocks() {
+            assert!(
+                !matches!(block.terminator, Terminator::None),
+                "block {} has no terminator",
+                block.id.0
+            );
+        }
+    }
+
+    #[test]
+    fn test_andand_diverging_rhs_join_terminated() {
+        // RUE-128: `true && return 5` — the rhs diverges, but the join block
+        // (where the short-circuit value materializes) is still reachable via
+        // the lhs-false edge and must be terminated.
+        let cfg = build_cfg("fn main() -> i32 { let c = true && return 5; 3 }");
+        assert_all_blocks_terminated(&cfg);
+    }
+
+    #[test]
+    fn test_oror_diverging_rhs_join_terminated() {
+        // RUE-128: `false || return 7` — same shape as the && case above.
+        let cfg = build_cfg("fn main() -> i32 { let c = false || return 7; 3 }");
+        assert_all_blocks_terminated(&cfg);
+    }
+
+    #[test]
+    fn test_diverged_statement_mid_block_keeps_scope_stack_balanced() {
+        // RUE-128: a statement diverging mid-block (here: `break` followed by
+        // another statement) used to leak its block's scope_stack entry. The
+        // enclosing block's pop then drained the LEAKED scope instead of its
+        // own, re-emitting Drop/StorageDead for the inner slot on the loop-exit
+        // path — a same-path double drop. With the leak fixed, each droppable
+        // local (s and t) is dropped exactly once.
+        let cfg = build_cfg(
+            "fn main() -> i32 {\n\
+                 let mut s = String::with_capacity(8);\n\
+                 loop {\n\
+                     let mut t = String::with_capacity(8);\n\
+                     break;\n\
+                     let unreachable_tail = 0;\n\
+                 }\n\
+                 0\n\
+             }",
+        );
+        let drop_count = cfg
+            .blocks()
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .filter(|v| matches!(cfg.get_inst(**v).data, CfgInstData::Drop { .. }))
+            .count();
+        assert_eq!(
+            drop_count, 2,
+            "expected exactly one Drop per droppable local (s, t)"
+        );
+        assert_all_blocks_terminated(&cfg);
     }
 }

--- a/crates/rue-cli-tests/cases/divergence.toml
+++ b/crates/rue-cli-tests/cases/divergence.toml
@@ -1,0 +1,207 @@
+# Divergence in short-circuit operators and mid-block statements (RUE-128).
+#
+# Two sibling bugs of the diverging-let-initializer miscompile, both in the
+# CFG builder (rue-cfg/src/build.rs):
+#
+# 1. `&&` / `||` with a diverging rhs (e.g. `true && return 5`) left the join
+#    block unterminated. The join is still reachable via the short-circuit
+#    edge from the lhs, so lowering must continue there instead of propagating
+#    divergence. Previously: codegen ICE "block has no terminator".
+#
+# 2. A statement diverging mid-block (e.g. `break;` followed by another
+#    statement) leaked its block's scope_stack entry. The enclosing block's
+#    scope pop then drained the LEAKED scope instead of its own, re-emitting
+#    Drop/StorageDead for the inner local on the loop-exit path — a same-path
+#    double drop. (Runtime-silent today because heap::free is a no-op bump
+#    allocator, but pinned by a CFG unit test in rue-cfg; the cases here guard
+#    the construct end-to-end so a future real allocator stays safe.)
+
+[section]
+id = "cli.divergence"
+name = "Short-circuit and mid-block divergence"
+description = "Diverging rhs of && / || and diverged statements mid-block (RUE-128)."
+
+# ── (a) && / || with a diverging rhs ─────────────────────────────────────────
+
+# lhs true: rhs evaluates and diverges — main returns 5.
+[[case]]
+name = "and_true_rhs_return"
+description = "true && return 5: rhs runs and diverges; exits with the return value."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let c = true && return 5;
+    3
+}
+""" }]
+exit_code = 5
+
+# lhs false: rhs never runs, c = false, execution continues past the let.
+[[case]]
+name = "and_false_rhs_never_runs"
+description = "false && return 5: short-circuit skips the diverging rhs; falls through."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let c = false && return 5;
+    3
+}
+""" }]
+exit_code = 3
+
+# lhs true: || short-circuits, rhs never runs, c = true, continues.
+[[case]]
+name = "or_true_rhs_never_runs"
+description = "true || return 7: short-circuit skips the diverging rhs; falls through."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let c = true || return 7;
+    3
+}
+""" }]
+exit_code = 3
+
+# lhs false: rhs evaluates and diverges — main returns 7.
+[[case]]
+name = "or_false_rhs_return"
+description = "false || return 7: rhs runs and diverges; exits with the return value."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let c = false || return 7;
+    3
+}
+""" }]
+exit_code = 7
+
+# The short-circuit value must actually materialize in the join block.
+[[case]]
+name = "and_short_circuit_value_usable"
+description = "The c produced by the skipped-rhs path is a usable false."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let c = false && return 5;
+    if c { 1 } else { 2 }
+}
+""" }]
+exit_code = 2
+
+[[case]]
+name = "or_short_circuit_value_usable"
+description = "The c produced by the skipped-rhs path is a usable true."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let c = true || return 7;
+    if c { 4 } else { 1 }
+}
+""" }]
+exit_code = 4
+
+# Nested: the inner || diverges, making the outer && rhs diverge.
+[[case]]
+name = "nested_or_in_and_rhs_diverges"
+description = "true && (false || return 9): inner divergence propagates through both joins."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let c = true && (false || return 9);
+    3
+}
+""" }]
+exit_code = 9
+
+[[case]]
+name = "nested_or_in_and_short_circuits"
+description = "false && (false || return 9): outer short-circuit skips everything."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let c = false && (false || return 9);
+    3
+}
+""" }]
+exit_code = 3
+
+# Diverging rhs directly in an if condition (no let binding).
+[[case]]
+name = "and_diverging_rhs_in_if_condition"
+description = "if true && return 4: the condition diverges before the branch."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    if true && return 4 { 1 } else { 2 }
+}
+""" }]
+exit_code = 4
+
+# rhs diverging via break instead of return.
+[[case]]
+name = "and_rhs_break_exits_loop"
+description = "true && break inside a loop: divergence via break, loop exits."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut i = 0;
+    loop {
+        let c = true && break;
+        i = 99;
+    }
+    6 + i
+}
+""" }]
+exit_code = 6
+
+[[case]]
+name = "or_rhs_break_exits_loop"
+description = "false || break inside a loop: divergence via break, loop exits."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    loop {
+        let c = false || break;
+    }
+    6
+}
+""" }]
+exit_code = 6
+
+# ── (b) diverged statement mid-block: scope_stack stays balanced ─────────────
+
+# The original leak shape: break followed by another statement, with droppable
+# (String) locals both inside and outside the loop. Before the fix the CFG
+# re-dropped `t` on the loop-exit path (after `break` had already dropped it).
+# The program must run to completion with both strings intact.
+[[case]]
+name = "break_mid_block_no_double_drop"
+description = "Diverged statement mid-block must not re-drop the inner local on the exit path."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut s = String::with_capacity(8);
+    s.push_str("outer");
+    loop {
+        let mut t = String::with_capacity(8);
+        t.push_str("inner");
+        break;
+        let unreachable_tail = 0;
+    }
+    let intact = s == "outer";
+    @dbg(s);
+    if intact { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+stdout = "outer\n"
+
+# Same shape via early return in an if-branch: the leaked scope used to make
+# the enclosing block drop the never-initialized inner local on the
+# fall-through path.
+[[case]]
+name = "return_mid_block_in_untaken_branch"
+description = "Mid-block return in an untaken branch: fall-through path must not touch the inner local."
+files = [{ path = "main.rue", source = """
+fn check(flag: bool) -> i32 {
+    if flag {
+        let mut t = String::with_capacity(8);
+        t.push_str("taken");
+        return 1;
+        let unreachable_tail = 0;
+    }
+    0
+}
+fn main() -> i32 {
+    check(false) + check(true)
+}
+""" }]
+exit_code = 1


### PR DESCRIPTION
Worker-implemented (isolated worktree, full suite verified there), integrator re-verified on trunk: all four `&&`/`||` divergence combinations run correctly (5/3/7/3), suite green. Completes RUE-128 items 2+3 (the epic's last items — but leaving the epic close decision to its tracker; referencing only). Details in the commit message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)