### PR TITLE
Move checker: values moved in a loop body are moved on the back edge

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -369,7 +369,9 @@ impl AirRef {
 }
 
 /// The complete AIR for a function.
-#[derive(Debug, Default)]
+// Clone exists for the loop back-edge move recheck in sema, which re-analyzes
+// a loop body against a scratch copy of the Air and then discards it.
+#[derive(Debug, Default, Clone)]
 pub struct Air {
     instructions: Vec<AirInst>,
     /// Extra data for variable-length instruction payloads (args, elements, etc.)

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1422,6 +1422,7 @@ fn analyze_function_with_context(
         comptime_value_vars: HashMap::new(),
         referenced_functions: HashSet::new(),
         referenced_methods: HashSet::new(),
+        in_loop_move_recheck: false,
     };
 
     // Analyze the body expression
@@ -3269,6 +3270,11 @@ fn analyze_while_loop_ctx(
     span: Span,
     analysis_ctx: &mut AnalysisContext,
 ) -> CompileResult<AnalysisResult> {
+    // Snapshot move state before the loop: the condition and body re-execute
+    // on every iteration, so a value moved in either is already moved when the
+    // back edge re-enters the loop (see the recheck below).
+    let moves_before_loop = analysis_ctx.moved_vars.clone();
+
     // While loop: condition must be bool, result is Unit
     let cond_result = analyze_inst_with_context(ctx, air, cond, analysis_ctx)?;
 
@@ -3278,6 +3284,25 @@ fn analyze_while_loop_ctx(
     let body_result = analyze_inst_with_context(ctx, air, body, analysis_ctx)?;
     analysis_ctx.loop_depth -= 1;
     analysis_ctx.pop_scope();
+
+    // Loop back-edge move check: if the loop changed any move state, re-run
+    // the analysis once with the post-body state as the starting state. Any
+    // use of a value moved by a previous iteration then errors. The scratch
+    // Air and context are discarded - this pass exists only for the checks.
+    if !analysis_ctx.in_loop_move_recheck && analysis_ctx.moved_vars != moves_before_loop {
+        let mut scratch_air = air.clone();
+        let mut scratch_ctx = analysis_ctx.fork_for_loop_recheck();
+        (|| -> CompileResult<()> {
+            analyze_inst_with_context(ctx, &mut scratch_air, cond, &mut scratch_ctx)?;
+            scratch_ctx.push_scope();
+            scratch_ctx.loop_depth += 1;
+            analyze_inst_with_context(ctx, &mut scratch_air, body, &mut scratch_ctx)?;
+            scratch_ctx.loop_depth -= 1;
+            scratch_ctx.pop_scope();
+            Ok(())
+        })()
+        .map_err(|e| e.with_note("value was moved in a previous iteration of the loop"))?;
+    }
 
     let air_ref = air.add_inst(AirInst {
         data: AirInstData::Loop {
@@ -3300,11 +3325,28 @@ fn analyze_infinite_loop_ctx(
 ) -> CompileResult<AnalysisResult> {
     // Infinite loop: `loop { body }` - always produces Never type
 
+    // Snapshot move state before the body for the back-edge recheck below.
+    let moves_before_loop = analysis_ctx.moved_vars.clone();
+
     analysis_ctx.push_scope();
     analysis_ctx.loop_depth += 1;
     let body_result = analyze_inst_with_context(ctx, air, body, analysis_ctx)?;
     analysis_ctx.loop_depth -= 1;
     analysis_ctx.pop_scope();
+
+    // Loop back-edge move check (see analyze_while_loop_ctx for details).
+    // Note: like Rust, this is conservative - a body that unconditionally
+    // breaks after the move still errors.
+    if !analysis_ctx.in_loop_move_recheck && analysis_ctx.moved_vars != moves_before_loop {
+        let mut scratch_air = air.clone();
+        let mut scratch_ctx = analysis_ctx.fork_for_loop_recheck();
+        scratch_ctx.push_scope();
+        scratch_ctx.loop_depth += 1;
+        analyze_inst_with_context(ctx, &mut scratch_air, body, &mut scratch_ctx)
+            .map_err(|e| e.with_note("value was moved in a previous iteration of the loop"))?;
+        scratch_ctx.loop_depth -= 1;
+        scratch_ctx.pop_scope();
+    }
 
     let air_ref = air.add_inst(AirInst {
         data: AirInstData::InfiniteLoop {
@@ -6601,6 +6643,7 @@ impl<'a> Sema<'a> {
             comptime_value_vars,
             referenced_functions: HashSet::new(),
             referenced_methods: HashSet::new(),
+            in_loop_move_recheck: false,
         };
 
         // ======================================================================

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -763,6 +763,11 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        // Snapshot move state before the loop: the condition and body
+        // re-execute on every iteration, so a value moved in either is already
+        // moved when the back edge re-enters the loop (see the recheck below).
+        let moves_before_loop = ctx.moved_vars.clone();
+
         // While loop: condition must be bool, result is Unit
         let cond_result = self.analyze_inst(air, cond, ctx)?;
 
@@ -772,6 +777,26 @@ impl<'a> Sema<'a> {
         let body_result = self.analyze_inst(air, body, ctx)?;
         ctx.loop_depth -= 1;
         ctx.pop_scope();
+
+        // Loop back-edge move check: if the loop changed any move state,
+        // re-run the analysis once with the post-body state as the starting
+        // state. Any use of a value moved by a previous iteration then errors.
+        // The scratch Air and context are discarded - this pass exists only
+        // for the checks.
+        if !ctx.in_loop_move_recheck && ctx.moved_vars != moves_before_loop {
+            let mut scratch_air = air.clone();
+            let mut scratch_ctx = ctx.fork_for_loop_recheck();
+            (|| -> CompileResult<()> {
+                self.analyze_inst(&mut scratch_air, cond, &mut scratch_ctx)?;
+                scratch_ctx.push_scope();
+                scratch_ctx.loop_depth += 1;
+                self.analyze_inst(&mut scratch_air, body, &mut scratch_ctx)?;
+                scratch_ctx.loop_depth -= 1;
+                scratch_ctx.pop_scope();
+                Ok(())
+            })()
+            .map_err(|e| e.with_note("value was moved in a previous iteration of the loop"))?;
+        }
 
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Loop {
@@ -794,11 +819,28 @@ impl<'a> Sema<'a> {
     ) -> CompileResult<AnalysisResult> {
         // Infinite loop: `loop { body }` - always produces Never type
 
+        // Snapshot move state before the body for the back-edge recheck below.
+        let moves_before_loop = ctx.moved_vars.clone();
+
         ctx.push_scope();
         ctx.loop_depth += 1;
         let body_result = self.analyze_inst(air, body, ctx)?;
         ctx.loop_depth -= 1;
         ctx.pop_scope();
+
+        // Loop back-edge move check (see analyze_while_loop for details).
+        // Note: like Rust, this is conservative - a body that unconditionally
+        // breaks after the move still errors.
+        if !ctx.in_loop_move_recheck && ctx.moved_vars != moves_before_loop {
+            let mut scratch_air = air.clone();
+            let mut scratch_ctx = ctx.fork_for_loop_recheck();
+            scratch_ctx.push_scope();
+            scratch_ctx.loop_depth += 1;
+            self.analyze_inst(&mut scratch_air, body, &mut scratch_ctx)
+                .map_err(|e| e.with_note("value was moved in a previous iteration of the loop"))?;
+            scratch_ctx.loop_depth -= 1;
+            scratch_ctx.pop_scope();
+        }
 
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::InfiniteLoop {

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -35,7 +35,9 @@ pub(crate) struct LocalVar {
 pub(crate) type FieldPath = Vec<Spur>;
 
 /// Tracks move state for a variable, including partial (field-level) moves.
-#[derive(Debug, Clone, Default)]
+// PartialEq is used by the loop back-edge move recheck to detect whether a
+// loop body changed any move state.
+#[derive(Debug, Clone, Default, PartialEq)]
 pub(crate) struct VariableMoveState {
     /// If Some, the entire variable has been fully moved at this span.
     pub full_move: Option<Span>,
@@ -189,6 +191,12 @@ pub(crate) struct AnalysisContext<'a> {
     /// Methods referenced during analysis of this function.
     /// Each entry is (struct_id, method_name) matching the key format in methods map.
     pub referenced_methods: HashSet<(StructId, Spur)>,
+    /// True while re-running a loop's condition/body to validate the loop's
+    /// back edge (see [`AnalysisContext::fork_for_loop_recheck`]). The recheck
+    /// pass starts from a move state that already includes every move the loop
+    /// performs, so nested loops analyzed within it don't need (and must not
+    /// trigger) their own recheck — that would make nested loops exponential.
+    pub in_loop_move_recheck: bool,
 }
 
 // Import InstRef for use in resolved_types
@@ -221,7 +229,43 @@ impl ScopedContext for AnalysisContext<'_> {
     }
 }
 
-impl AnalysisContext<'_> {
+impl<'a> AnalysisContext<'a> {
+    /// Create a scratch copy of this context for the loop back-edge move check.
+    ///
+    /// A value moved anywhere in a loop's condition or body is already moved
+    /// when the back edge re-enters the loop. After analyzing a loop once, the
+    /// loop is re-analyzed against a fork of the context (and a scratch `Air`)
+    /// whose starting move state is the *post-body* state; any use of a moved
+    /// value then surfaces as a `UseAfterMove` error pointing at the move from
+    /// the "previous iteration". One re-run reaches a fixpoint: analysis is
+    /// deterministic, so re-running from the post-body state marks exactly the
+    /// same moves again.
+    ///
+    /// Output accumulators (warnings, referenced functions/methods) start
+    /// empty so the discarded pass doesn't duplicate entries in the real
+    /// context.
+    pub fn fork_for_loop_recheck(&self) -> AnalysisContext<'a> {
+        AnalysisContext {
+            locals: self.locals.clone(),
+            params: self.params,
+            next_slot: self.next_slot,
+            loop_depth: self.loop_depth,
+            used_locals: self.used_locals.clone(),
+            return_type: self.return_type,
+            scope_stack: self.scope_stack.clone(),
+            resolved_types: self.resolved_types,
+            moved_vars: self.moved_vars.clone(),
+            warnings: Vec::new(),
+            local_string_table: self.local_string_table.clone(),
+            local_strings: self.local_strings.clone(),
+            comptime_type_vars: self.comptime_type_vars.clone(),
+            comptime_value_vars: self.comptime_value_vars.clone(),
+            referenced_functions: HashSet::new(),
+            referenced_methods: HashSet::new(),
+            in_loop_move_recheck: true,
+        }
+    }
+
     /// Merge move states from two branches.
     ///
     /// For if-else expressions, a variable is considered moved after the expression

--- a/crates/rue-cli-tests/cases/loop_moves.toml
+++ b/crates/rue-cli-tests/cases/loop_moves.toml
@@ -1,0 +1,171 @@
+# Move checker: loop back-edge soundness (RUE-32).
+#
+# A value moved anywhere in a loop's condition or body is already moved when
+# the back edge re-enters the loop, so iteration 2 would re-move (and
+# double-drop) it. These cases pin the E0205 error for that pattern and the
+# valid controls that must keep compiling (value defined inside the body,
+# reassignment before the next use, Copy types).
+#
+# Like Rust, the check is conservative: a `loop` body that unconditionally
+# breaks after the move still errors even though no second iteration runs.
+
+[section]
+id = "cli.loop_moves"
+name = "Loop back-edge move checking"
+description = "Use-of-moved-value across loop iterations (RUE-32)."
+
+[[case]]
+name = "move_into_call_in_while_loop"
+description = "Moving a non-Copy struct into a call inside a while body errors: iteration 2 re-moves it."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    let mut i = 0;
+    let mut total = 0;
+    while i < 2 { total = total + consume(d); i = i + 1; }
+    total
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "use of moved value", "previous iteration of the loop"]
+
+[[case]]
+name = "string_move_in_while_loop"
+description = "The String variant of the same bug double-freed at runtime before the fix."
+files = [{ path = "main.rue", source = """
+fn consume(s: String) -> i32 { 1 }
+fn main() -> i32 {
+    let s: String = "hi";
+    let mut i = 0;
+    while i < 2 { consume(s); i = i + 1; }
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "previous iteration of the loop"]
+
+[[case]]
+name = "move_in_while_condition"
+description = "The condition re-executes every iteration, so a move inside it also errors."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn check(d: Data) -> bool { d.x > 0 }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    while check(d) { }
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "previous iteration of the loop"]
+
+[[case]]
+name = "move_in_infinite_loop_with_break"
+description = "Conservative like Rust: an unconditional break after the move still errors."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    loop { consume(d); break; }
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "previous iteration of the loop"]
+
+[[case]]
+name = "conditional_move_in_loop"
+description = "A move under an if inside the loop body is still a potential re-move (union semantics)."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    let mut i = 0;
+    while i < 3 { if i == 1 { consume(d); } i = i + 1; }
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "previous iteration of the loop"]
+
+[[case]]
+name = "move_in_nested_loop"
+description = "A move in an inner loop body errors at the inner back edge."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let d = Data { x: 1 };
+    let mut i = 0;
+    while i < 2 { let mut j = 0; while j < 2 { consume(d); j = j + 1; } i = i + 1; }
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "previous iteration of the loop"]
+
+[[case]]
+name = "value_defined_inside_loop_ok"
+description = "Control: a value created and moved within the same iteration is fine."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let mut i = 0;
+    let mut total = 0;
+    while i < 2 { let t = Data { x: 1 }; total = total + consume(t); i = i + 1; }
+    total
+}
+""" }]
+exit_code = 2
+
+[[case]]
+name = "reassign_after_move_ok"
+description = "Control: reassigning before the next iteration's use makes the move per-iteration valid."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let mut d = Data { x: 1 };
+    let mut i = 0;
+    let mut total = 0;
+    while i < 2 { total = total + consume(d); d = Data { x: 2 }; i = i + 1; }
+    total
+}
+""" }]
+exit_code = 3
+
+[[case]]
+name = "reassign_before_move_ok"
+description = "Control: reassignment at the top of the body clears last iteration's move."
+files = [{ path = "main.rue", source = """
+struct Data { x: i32 }
+fn consume(d: Data) -> i32 { d.x }
+fn main() -> i32 {
+    let mut d = Data { x: 1 };
+    let mut i = 0;
+    let mut total = 0;
+    while i < 2 { d = Data { x: 5 }; total = total + consume(d); i = i + 1; }
+    total
+}
+""" }]
+exit_code = 10
+
+[[case]]
+name = "copy_type_in_loop_ok"
+description = "Control: Copy types are never moved, so repeated by-value calls are fine."
+files = [{ path = "main.rue", source = """
+fn double(x: i32) -> i32 { x * 2 }
+fn main() -> i32 {
+    let v = 3;
+    let mut i = 0;
+    let mut total = 0;
+    while i < 2 { total = total + double(v); i = i + 1; }
+    total
+}
+""" }]
+exit_code = 12


### PR DESCRIPTION
Worker-implemented (isolated worktree, full verification there), integrator re-verified on trunk. Closes the move-checker soundness hole: moving a non-Copy value into a call inside a loop body compiled cleanly and double-dropped at runtime (double-free with String).

Mechanism: snapshot move state before while/loop; if the body changed it, re-analyze once against a scratch Air clone + forked context starting from the post-body state → uses of previously-moved values surface as E0205 with *"value was moved in a previous iteration of the loop"*. Recheck flag prevents nested-loop compounding.

Reject-valid guards verified: defined-inside-body, reassign-before-next-use, and after-loop moves all still compile (10 regression cases). Known-conservative: unconditional-break-after-move is rejected (rustc accepts it; documented on the issue as a future refinement). One perf note for review: the recheck clones the Air per move-changing loop — fine at current program sizes, worth revisiting if compile times matter later.

Fixes RUE-32

🤖 Generated with [Claude Code](https://claude.com/claude-code)