### PR TITLE
Bitwise NOT at operand width: constfold masking + runtime lowering on both backends

### DIFF
--- a/crates/rue-cfg/src/opt/constfold.rs
+++ b/crates/rue-cfg/src/opt/constfold.rs
@@ -99,7 +99,12 @@ fn fold_instruction(cfg: &mut Cfg, value: CfgValue) {
         // Unary
         CfgInstData::Neg(operand) => fold_unary_arith(cfg, *operand, ty, |v| checked_neg(v, ty)),
         CfgInstData::Not(operand) => fold_not(cfg, *operand),
-        CfgInstData::BitNot(operand) => fold_unary_arith(cfg, *operand, ty, |v| Some(!v)),
+        // `!v` flips all 64 stored bits, but the operation is defined at the
+        // operand's width; truncate so the folded constant matches what the
+        // runtime computes (RUE-59).
+        CfgInstData::BitNot(operand) => {
+            fold_unary_arith(cfg, *operand, ty, |v| Some(truncate_to_type(!v, ty)))
+        }
 
         // Everything else is not foldable
         _ => None,
@@ -223,8 +228,8 @@ fn fold_shift(
         lhs_val >> rhs_val
     };
 
-    // Mask to the type's bit width
-    let result = mask_to_type(result, ty);
+    // Truncate to the type's bit width (canonical representation)
+    let result = truncate_to_type(result, ty);
     Some(CfgInstData::Const(result))
 }
 
@@ -292,6 +297,25 @@ fn type_bits(ty: Type) -> u32 {
         TypeKind::I64 | TypeKind::U64 => 64,
         TypeKind::Bool => 1,
         _ => 64, // Default for other types
+    }
+}
+
+/// Truncate a value to a type's width, producing the canonical 64-bit
+/// representation: zero-extended for unsigned types, sign-extended for
+/// signed types.
+///
+/// All folds must produce canonical constants. The checked arithmetic
+/// helpers already do (signed results come out of an `i64 as u64` cast,
+/// i.e. sign-extended), and Eq/Ne folding compares raw u64 representations,
+/// so a non-canonical constant — an unmasked `!v`, or a masked-but-not-
+/// extended negative shift result — yields wrong folds and -O0 vs -O1+
+/// divergence (RUE-59).
+fn truncate_to_type(val: u64, ty: Type) -> u64 {
+    let masked = mask_to_type(val, ty);
+    if is_signed(ty) {
+        sign_extend(masked, ty)
+    } else {
+        masked
     }
 }
 
@@ -613,10 +637,15 @@ mod tests {
 
         run(&mut cfg);
 
-        // -1 >> 1 should be -1 (0xFF in i8)
+        // -1 >> 1 should be -1, stored canonically (sign-extended to 64 bits)
         match &cfg.get_inst(shr).data {
             CfgInstData::Const(val) => {
-                assert_eq!(*val, 0xFF, "Expected 0xFF (-1 as i8), got 0x{:X}", val);
+                assert_eq!(
+                    *val,
+                    (-1i64) as u64,
+                    "Expected -1 (sign-extended), got 0x{:X}",
+                    val
+                );
             }
             other => panic!("Expected Const, got {:?}", other),
         }
@@ -634,10 +663,15 @@ mod tests {
 
         run(&mut cfg);
 
-        // -8 >> 2 should be -2 (0xFE in i8)
+        // -8 >> 2 should be -2, stored canonically (sign-extended to 64 bits)
         match &cfg.get_inst(shr).data {
             CfgInstData::Const(val) => {
-                assert_eq!(*val, 0xFE, "Expected 0xFE (-2 as i8), got 0x{:X}", val);
+                assert_eq!(
+                    *val,
+                    (-2i64) as u64,
+                    "Expected -2 (sign-extended), got 0x{:X}",
+                    val
+                );
             }
             other => panic!("Expected Const, got {:?}", other),
         }
@@ -654,10 +688,15 @@ mod tests {
 
         run(&mut cfg);
 
-        // -1 >> 4 should be -1 (0xFFFF in i16)
+        // -1 >> 4 should be -1, stored canonically (sign-extended to 64 bits)
         match &cfg.get_inst(shr).data {
             CfgInstData::Const(val) => {
-                assert_eq!(*val, 0xFFFF, "Expected 0xFFFF (-1 as i16), got 0x{:X}", val);
+                assert_eq!(
+                    *val,
+                    (-1i64) as u64,
+                    "Expected -1 (sign-extended), got 0x{:X}",
+                    val
+                );
             }
             other => panic!("Expected Const, got {:?}", other),
         }
@@ -674,12 +713,13 @@ mod tests {
 
         run(&mut cfg);
 
-        // -1 >> 8 should be -1 (0xFFFFFFFF in i32)
+        // -1 >> 8 should be -1, stored canonically (sign-extended to 64 bits)
         match &cfg.get_inst(shr).data {
             CfgInstData::Const(val) => {
                 assert_eq!(
-                    *val, 0xFFFF_FFFF,
-                    "Expected 0xFFFFFFFF (-1 as i32), got 0x{:X}",
+                    *val,
+                    (-1i64) as u64,
+                    "Expected -1 (sign-extended), got 0x{:X}",
                     val
                 );
             }
@@ -702,6 +742,95 @@ mod tests {
         match &cfg.get_inst(shr).data {
             CfgInstData::Const(val) => {
                 assert_eq!(*val, 0x7F, "Expected 0x7F, got 0x{:X}", val);
+            }
+            other => panic!("Expected Const, got {:?}", other),
+        }
+    }
+
+    fn add_bitnot(cfg: &mut Cfg, operand: CfgValue, ty: Type) -> CfgValue {
+        let entry = cfg.entry;
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::BitNot(operand),
+                ty,
+                span: Span::new(0, 0),
+            },
+        )
+    }
+
+    #[test]
+    fn test_fold_bitnot_u32_masked() {
+        // ~0u32 must fold to 0xFFFF_FFFF, not the unmasked 64-bit !0 (RUE-59).
+        let mut cfg = make_cfg();
+        let c = add_const(&mut cfg, 0, Type::U32);
+        let not = add_bitnot(&mut cfg, c, Type::U32);
+        finalize_cfg(&mut cfg, not);
+
+        run(&mut cfg);
+
+        match &cfg.get_inst(not).data {
+            CfgInstData::Const(val) => {
+                assert_eq!(*val, 0xFFFF_FFFF, "Expected 0xFFFFFFFF, got 0x{:X}", val);
+            }
+            other => panic!("Expected Const, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_fold_bitnot_u8_masked() {
+        // ~5u8 = 250, masked to 8 bits.
+        let mut cfg = make_cfg();
+        let c = add_const(&mut cfg, 5, Type::U8);
+        let not = add_bitnot(&mut cfg, c, Type::U8);
+        finalize_cfg(&mut cfg, not);
+
+        run(&mut cfg);
+
+        match &cfg.get_inst(not).data {
+            CfgInstData::Const(val) => {
+                assert_eq!(*val, 250, "Expected 250, got {}", val);
+            }
+            other => panic!("Expected Const, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_fold_bitnot_i32_sign_extended() {
+        // ~5i32 = -6, stored canonically (sign-extended to 64 bits).
+        let mut cfg = make_cfg();
+        let c = add_const(&mut cfg, 5, Type::I32);
+        let not = add_bitnot(&mut cfg, c, Type::I32);
+        finalize_cfg(&mut cfg, not);
+
+        run(&mut cfg);
+
+        match &cfg.get_inst(not).data {
+            CfgInstData::Const(val) => {
+                assert_eq!(
+                    *val,
+                    (-6i64) as u64,
+                    "Expected -6 (sign-extended), got 0x{:X}",
+                    val
+                );
+            }
+            other => panic!("Expected Const, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_fold_bitnot_u64_full_width() {
+        // ~0u64 = u64::MAX; no truncation at full width.
+        let mut cfg = make_cfg();
+        let c = add_const(&mut cfg, 0, Type::U64);
+        let not = add_bitnot(&mut cfg, c, Type::U64);
+        finalize_cfg(&mut cfg, not);
+
+        run(&mut cfg);
+
+        match &cfg.get_inst(not).data {
+            CfgInstData::Const(val) => {
+                assert_eq!(*val, u64::MAX, "Expected u64::MAX, got 0x{:X}", val);
             }
             other => panic!("Expected Const, got {:?}", other),
         }

--- a/crates/rue-cli-tests/cases/constfold.toml
+++ b/crates/rue-cli-tests/cases/constfold.toml
@@ -1,0 +1,196 @@
+# Constant-folding width regression tests (RUE-59).
+#
+# Constfold's BitNot used to compute `!v` on the u64 constant storage without
+# truncating to the operand type's width, so `~0u32` folded to the 64-bit !0
+# (printed as 18446744073709551615 instead of 4294967295) and -O0 vs -O1+
+# diverged. The same fix made all folds produce the canonical representation
+# (zero-extended for unsigned, sign-extended for signed): fold_shift used to
+# leave signed results masked-but-not-extended, which broke Eq folding against
+# sign-extended constants. Finally, the runtime BitNot lowering used the
+# 32-bit `not`/64-bit `mvn` on both backends, mangling i64/u64 (x86-64) and
+# u32 (aarch64) results for non-folded operands.
+#
+# Each scenario is pinned at -O0 and at -O2 so the two can never diverge again.
+
+[section]
+id = "cli.constfold"
+name = "Constant folding width correctness"
+description = "Folded constants must match runtime results at the operand's width at every opt level."
+
+# ~0 as u32 must be 4294967295, not the unmasked 64-bit !0 (the RUE-59 repro).
+[[case]]
+name = "bitnot_unsigned_widths_O2"
+description = "Folded ~ on u8/u16/u32/u64 is truncated to the operand width at -O2."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: u8 = ~0;
+    let b: u16 = ~0;
+    let c: u32 = ~0;
+    let d: u32 = ~5;
+    let e: u64 = ~0;
+    @dbg(a);
+    @dbg(b);
+    @dbg(c);
+    @dbg(d);
+    @dbg(e);
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 0
+stdout = """255
+65535
+4294967295
+4294967290
+18446744073709551615
+"""
+
+# Control: the same program at -O0 (runtime bitnot) must agree.
+[[case]]
+name = "bitnot_unsigned_widths_O0"
+description = "Runtime ~ on u8/u16/u32/u64 matches the folded results at -O0."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: u8 = ~0;
+    let b: u16 = ~0;
+    let c: u32 = ~0;
+    let d: u32 = ~5;
+    let e: u64 = ~0;
+    @dbg(a);
+    @dbg(b);
+    @dbg(c);
+    @dbg(d);
+    @dbg(e);
+    0
+}
+""" }]
+args = ["main.rue", "-O0", "-o", "prog"]
+exit_code = 0
+stdout = """255
+65535
+4294967295
+4294967290
+18446744073709551615
+"""
+
+[[case]]
+name = "bitnot_signed_widths_O2"
+description = "Folded ~ on i8/i16/i32/i64 produces the two's-complement value at the operand width."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i8 = ~0;
+    let b: i16 = ~5;
+    let c: i32 = ~0;
+    let d: i64 = ~5;
+    @dbg(a);
+    @dbg(b);
+    @dbg(c);
+    @dbg(d);
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 0
+stdout = """-1
+-6
+-1
+-6
+"""
+
+# ~5i64 used to print 4294967290 at -O0: the x86-64 runtime lowering emitted a
+# 32-bit `not`, zeroing the high bits of 64-bit results.
+[[case]]
+name = "bitnot_signed_widths_O0"
+description = "Runtime ~ on i8/i16/i32/i64 is computed at full operand width at -O0."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i8 = ~0;
+    let b: i16 = ~5;
+    let c: i32 = ~0;
+    let d: i64 = ~5;
+    @dbg(a);
+    @dbg(b);
+    @dbg(c);
+    @dbg(d);
+    0
+}
+""" }]
+args = ["main.rue", "-O0", "-o", "prog"]
+exit_code = 0
+stdout = """-1
+-6
+-1
+-6
+"""
+
+# Non-constant operands defeat constfold, so these exercise the runtime
+# BitNot lowering even at -O2 (x86-64: `not r64` for 64-bit; aarch64: w-form
+# `mvn` for sub-64-bit).
+[[case]]
+name = "bitnot_runtime_operands_O2"
+description = "Runtime (non-folded) ~ is width-correct for u32/u64/i64 at -O2."
+files = [{ path = "main.rue", source = """
+fn id_u32(x: u32) -> u32 { x }
+fn id_u64(x: u64) -> u64 { x }
+fn id_i64(x: i64) -> i64 { x }
+fn main() -> i32 {
+    let a: u32 = ~id_u32(5);
+    let b: u64 = ~id_u64(0);
+    let c: i64 = ~id_i64(5);
+    @dbg(a);
+    @dbg(b);
+    @dbg(c);
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 0
+stdout = """4294967290
+18446744073709551615
+-6
+"""
+
+# Folded signed shift results must be canonical (sign-extended), or Eq folding
+# (raw u64 comparison) disagrees with the runtime: ((0-8) >> 2) == (0-2) used
+# to fold to false at -O2 while -O0 correctly computed true.
+[[case]]
+name = "folded_signed_shift_eq_O2"
+description = "Eq fold of a folded negative shift result against a negative constant."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    if ((0 - 8) >> 2) == (0 - 2) { 1 } else { 0 }
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 1
+
+[[case]]
+name = "folded_signed_shift_eq_O0"
+description = "Control: the same comparison computed at runtime at -O0."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    if ((0 - 8) >> 2) == (0 - 2) { 1 } else { 0 }
+}
+""" }]
+args = ["main.rue", "-O0", "-o", "prog"]
+exit_code = 1
+
+# Adjacent constructs: double-not round-trips, and a folded ~ result composes
+# with folded arithmetic and comparisons.
+[[case]]
+name = "bitnot_composes_with_folds_O2"
+description = "~~x round-trips and folded ~ feeds arithmetic/comparison folds."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: u32 = ~~7;
+    let b: u32 = ~0 - 4294967290;
+    @dbg(a);
+    @dbg(b);
+    if ~5 == (0 - 6) { 1 } else { 0 }
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 1
+stdout = """7
+5
+"""

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1025,9 +1025,20 @@ impl<'a> CfgLower<'a> {
 
                 let operand_vreg = self.get_vreg(*operand);
 
-                self.mir.push(Aarch64Inst::MvnRR {
-                    dst: Operand::Virtual(vreg),
-                    src: Operand::Virtual(operand_vreg),
+                // Sub-64-bit operands need the 32-bit w-form so the result
+                // is zero-extended above the operand width; the 64-bit mvn
+                // would set the upper 32 bits (wrong for u32, whose consumers
+                // assume zero-extended registers) (RUE-59).
+                self.mir.push(if ty.is_64_bit() {
+                    Aarch64Inst::MvnRR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(operand_vreg),
+                    }
+                } else {
+                    Aarch64Inst::Mvn32RR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(operand_vreg),
+                    }
                 });
             }
 

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -153,6 +153,8 @@ const OPCODE_EOR_X: u32 = 0xCA000000;
 const OPCODE_EOR_IMM_X: u32 = 0xD2400000;
 /// MVN Xd, Xm - Bitwise NOT (alias for ORN Xd, XZR, Xm)
 const OPCODE_ORN_X: u32 = 0xAA200000;
+/// MVN Wd, Wm - Bitwise NOT (alias for ORN Wd, WZR, Wm) (32-bit)
+const OPCODE_ORN_W: u32 = 0x2A200000;
 /// LSLV Xd, Xn, Xm - Logical shift left variable (64-bit)
 const OPCODE_LSLV_X: u32 = 0x9AC02000;
 /// LSLV Wd, Wn, Wm - Logical shift left variable (32-bit)
@@ -897,6 +899,14 @@ impl<'a> Emitter<'a> {
                 self.begin_inst();
                 self.emit_mvn_rr(rd, rm);
                 end_inst!(self, "mvn {}, {}", rd, rm);
+            }
+
+            Aarch64Inst::Mvn32RR { dst, src } => {
+                let rd = dst.as_physical();
+                let rm = src.as_physical();
+                self.begin_inst();
+                self.emit_mvn32_rr(rd, rm);
+                end_inst!(self, "mvn(w) {}, {}", rd, rm);
             }
 
             Aarch64Inst::LslRR { dst, src1, src2 } => {
@@ -1849,6 +1859,16 @@ impl<'a> Emitter<'a> {
         self.emit_u32(inst);
     }
 
+    fn emit_mvn32_rr(&mut self, rd: Reg, rm: Reg) {
+        // MVN Wd, Wm (alias for ORN Wd, WZR, Wm); zero-extends into the
+        // upper 32 bits of Xd.
+        let inst = OPCODE_ORN_W
+            | (rm.encoding() as u32) << 16
+            | (Reg::Xzr.encoding() as u32) << 5
+            | rd.encoding() as u32;
+        self.emit_u32(inst);
+    }
+
     fn emit_lslv_rr(&mut self, rd: Reg, rn: Reg, rm: Reg) {
         // LSLV Xd, Xn, Xm - Logical shift left variable (64-bit)
         let inst = OPCODE_LSLV_X
@@ -2603,6 +2623,25 @@ mod tests {
         assert_eq!(inst & 0xFF200000, 0xAA200000, "Should be ORN pattern");
         // Rn (bits 5-9) should be XZR (31)
         assert_eq!((inst >> 5) & 0x1F, 31, "Rn should be XZR");
+    }
+
+    #[test]
+    fn test_mvn32_rr() {
+        let code = emit_single(Aarch64Inst::Mvn32RR {
+            dst: Operand::Physical(Reg::X0),
+            src: Operand::Physical(Reg::X1),
+        });
+        // mvn w0, w1 -> orn w0, wzr, w1 (sf=0)
+        let inst = u32::from_le_bytes(code[0..4].try_into().unwrap());
+        assert_eq!(
+            inst & 0xFF200000,
+            0x2A200000,
+            "Should be 32-bit ORN pattern"
+        );
+        // Rn (bits 5-9) should be WZR (31)
+        assert_eq!((inst >> 5) & 0x1F, 31, "Rn should be WZR");
+        // Rm (bits 16-20) should be W1
+        assert_eq!((inst >> 16) & 0x1F, 1, "Rm should be W1");
     }
 
     // --- Shift instructions ---

--- a/crates/rue-codegen/src/aarch64/liveness.rs
+++ b/crates/rue-codegen/src/aarch64/liveness.rs
@@ -178,7 +178,7 @@ fn uses(inst: &Aarch64Inst) -> Vec<VReg> {
             add_if_virtual(src1, &mut result);
             add_if_virtual(src2, &mut result);
         }
-        Aarch64Inst::MvnRR { src, .. } => {
+        Aarch64Inst::MvnRR { src, .. } | Aarch64Inst::Mvn32RR { src, .. } => {
             add_if_virtual(src, &mut result);
         }
         Aarch64Inst::AddImm { src, .. }
@@ -328,6 +328,7 @@ fn defs(inst: &Aarch64Inst) -> Vec<VReg> {
         | Aarch64Inst::EorRR { dst, .. }
         | Aarch64Inst::EorImm { dst, .. }
         | Aarch64Inst::MvnRR { dst, .. }
+        | Aarch64Inst::Mvn32RR { dst, .. }
         | Aarch64Inst::LslRR { dst, .. }
         | Aarch64Inst::Lsl32RR { dst, .. }
         | Aarch64Inst::LsrRR { dst, .. }

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -635,8 +635,15 @@ pub enum Aarch64Inst {
         imm: u64,
     },
 
-    /// `mvn dst, src` - Bitwise NOT.
+    /// `mvn dst, src` - Bitwise NOT, 64-bit.
     MvnRR { dst: Operand, src: Operand },
+
+    /// `mvn wd, wm` - Bitwise NOT, 32-bit.
+    ///
+    /// Used for sub-64-bit BitNot: the w-form zeroes the upper 32 bits,
+    /// matching the invariant (shared with the x86-64 backend) that
+    /// sub-64-bit results don't leak set bits above their width (RUE-59).
+    Mvn32RR { dst: Operand, src: Operand },
 
     /// `lsl dst, src1, src2` - Logical shift left 64-bit by register.
     LslRR {
@@ -940,6 +947,7 @@ impl fmt::Display for Aarch64Inst {
             }
             Aarch64Inst::EorImm { dst, src, imm } => write!(f, "eor {}, {}, #{}", dst, src, imm),
             Aarch64Inst::MvnRR { dst, src } => write!(f, "mvn {}, {}", dst, src),
+            Aarch64Inst::Mvn32RR { dst, src } => write!(f, "mvnl {}, {}", dst, src),
             Aarch64Inst::LslRR { dst, src1, src2 } => {
                 write!(f, "lslq {}, {}, {}", dst, src1, src2)
             }

--- a/crates/rue-codegen/src/aarch64/regalloc.rs
+++ b/crates/rue-codegen/src/aarch64/regalloc.rs
@@ -555,6 +555,13 @@ impl RegAlloc {
                 self.emit_binop(mir, dst, src, |d, s| Aarch64Inst::MvnRR { dst: d, src: s })?;
             }
 
+            Aarch64Inst::Mvn32RR { dst, src } => {
+                self.emit_binop(mir, dst, src, |d, s| Aarch64Inst::Mvn32RR {
+                    dst: d,
+                    src: s,
+                })?;
+            }
+
             Aarch64Inst::LslRR { dst, src1, src2 } => {
                 self.emit_ternop(mir, dst, src1, src2, |d, s1, s2| Aarch64Inst::LslRR {
                     dst: d,

--- a/crates/rue-codegen/src/aarch64/schedule.rs
+++ b/crates/rue-codegen/src/aarch64/schedule.rs
@@ -137,7 +137,8 @@ fn get_latency(inst: &Aarch64Inst) -> u32 {
         | Aarch64Inst::OrrRR { .. }
         | Aarch64Inst::EorRR { .. }
         | Aarch64Inst::EorImm { .. }
-        | Aarch64Inst::MvnRR { .. } => 1,
+        | Aarch64Inst::MvnRR { .. }
+        | Aarch64Inst::Mvn32RR { .. } => 1,
 
         // Shifts: 1 cycle
         Aarch64Inst::LslRR { .. }
@@ -306,6 +307,7 @@ fn regs_read(inst: &Aarch64Inst) -> Vec<Reg> {
         | Aarch64Inst::Negs { src, .. }
         | Aarch64Inst::Negs32 { src, .. }
         | Aarch64Inst::MvnRR { src, .. }
+        | Aarch64Inst::Mvn32RR { src, .. }
         | Aarch64Inst::Sxtb { src, .. }
         | Aarch64Inst::Sxth { src, .. }
         | Aarch64Inst::Sxtw { src, .. }
@@ -384,6 +386,7 @@ fn regs_written(inst: &Aarch64Inst) -> Vec<Reg> {
         | Aarch64Inst::EorRR { dst, .. }
         | Aarch64Inst::EorImm { dst, .. }
         | Aarch64Inst::MvnRR { dst, .. }
+        | Aarch64Inst::Mvn32RR { dst, .. }
         | Aarch64Inst::LslRR { dst, .. }
         | Aarch64Inst::Lsl32RR { dst, .. }
         | Aarch64Inst::LslImm { dst, .. }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1099,8 +1099,16 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(vreg),
                     src: Operand::Virtual(operand_vreg),
                 });
-                self.mir.push(X86Inst::NotR {
-                    dst: Operand::Virtual(vreg),
+                // 64-bit operands need a REX.W `not`; the 32-bit form would
+                // zero the high 32 bits of the result (RUE-59).
+                self.mir.push(if ty.is_64_bit() {
+                    X86Inst::Not64R {
+                        dst: Operand::Virtual(vreg),
+                    }
+                } else {
+                    X86Inst::NotR {
+                        dst: Operand::Virtual(vreg),
+                    }
                 });
             }
 

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -676,6 +676,11 @@ impl<'a> Emitter<'a> {
                 self.emit_not(dst.as_physical());
                 end_inst!(self, "not {}", dst.as_physical());
             }
+            X86Inst::Not64R { dst } => {
+                self.begin_inst();
+                self.emit_not64(dst.as_physical());
+                end_inst!(self, "notq {}", dst.as_physical());
+            }
             X86Inst::ShlRCl { dst } => {
                 self.begin_inst();
                 self.emit_shl_cl(dst.as_physical());
@@ -1962,6 +1967,24 @@ impl<'a> Emitter<'a> {
         self.code.push(modrm);
     }
 
+    /// Emit `not r64`.
+    ///
+    /// Encoding: REX.W F7 /2 (not r/m64)
+    fn emit_not64(&mut self, dst: Reg) {
+        let dst_enc = dst.encoding();
+
+        // REX.W prefix (plus REX.B for extended registers)
+        let rex = 0x48 | if dst.needs_rex() { 0x01 } else { 0x00 };
+        self.code.push(rex);
+
+        // Opcode: F7 (group 3 operations)
+        self.code.push(0xF7);
+
+        // ModR/M: mod=11, reg=2 (NOT), r/m=dst
+        let modrm = 0xC0 | (2 << 3) | (dst_enc & 7);
+        self.code.push(modrm);
+    }
+
     /// Emit `shl r64, imm8`.
     ///
     /// Encoding: REX.W C1 /4 imm8 (shl r/m64, imm8)
@@ -3192,6 +3215,24 @@ mod tests {
         });
         // not r10d -> 41 F7 D2 (REX.B F7 /2)
         assert_eq!(code, vec![0x41, 0xF7, 0xD2]);
+    }
+
+    #[test]
+    fn test_not64_rax() {
+        let code = emit_single(X86Inst::Not64R {
+            dst: Operand::Physical(Reg::Rax),
+        });
+        // not rax -> 48 F7 D0 (REX.W F7 /2)
+        assert_eq!(code, vec![0x48, 0xF7, 0xD0]);
+    }
+
+    #[test]
+    fn test_not64_r10() {
+        let code = emit_single(X86Inst::Not64R {
+            dst: Operand::Physical(Reg::R10),
+        });
+        // not r10 -> 49 F7 D2 (REX.W+B F7 /2)
+        assert_eq!(code, vec![0x49, 0xF7, 0xD2]);
     }
 
     // --- Shift instructions ---

--- a/crates/rue-codegen/src/x86_64/liveness.rs
+++ b/crates/rue-codegen/src/x86_64/liveness.rs
@@ -188,7 +188,7 @@ pub fn uses(inst: &X86Inst) -> Vec<VReg> {
             add_if_virtual(dst, &mut result);
             add_if_virtual(src, &mut result);
         }
-        X86Inst::NotR { dst } => {
+        X86Inst::NotR { dst } | X86Inst::Not64R { dst } => {
             // dst is both read and written
             add_if_virtual(dst, &mut result);
         }
@@ -358,6 +358,7 @@ pub fn defs(inst: &X86Inst) -> Vec<VReg> {
         | X86Inst::Or64RR { dst, .. }
         | X86Inst::Xor64RR { dst, .. }
         | X86Inst::NotR { dst }
+        | X86Inst::Not64R { dst }
         | X86Inst::ShlRCl { dst }
         | X86Inst::Shl32RCl { dst }
         | X86Inst::ShlRI { dst, .. }

--- a/crates/rue-codegen/src/x86_64/mir.rs
+++ b/crates/rue-codegen/src/x86_64/mir.rs
@@ -240,8 +240,14 @@ pub enum X86Inst {
     /// `xor dst, src` - Bitwise XOR, 64-bit (dst = dst ^ src).
     Xor64RR { dst: Operand, src: Operand },
 
-    /// `not dst` - Bitwise NOT (dst = ~dst).
+    /// `not dst` - Bitwise NOT, 32-bit (dst = ~dst).
     NotR { dst: Operand },
+
+    /// `not dst` (64-bit) - Bitwise NOT treating operand as 64-bit (dst = ~dst).
+    ///
+    /// Used for i64/u64 BitNot where the 32-bit form would zero the high
+    /// 32 bits of the result (RUE-59).
+    Not64R { dst: Operand },
 
     /// `shl dst, cl` - Shift left 64-bit by count in CL register (dst = dst << CL).
     ShlRCl { dst: Operand },
@@ -556,6 +562,7 @@ impl fmt::Display for X86Inst {
             X86Inst::Or64RR { dst, src } => write!(f, "orq {}, {}", dst, src),
             X86Inst::Xor64RR { dst, src } => write!(f, "xorq {}, {}", dst, src),
             X86Inst::NotR { dst } => write!(f, "not {}", dst),
+            X86Inst::Not64R { dst } => write!(f, "notq {}", dst),
             X86Inst::ShlRCl { dst } => write!(f, "shlq {}, cl", dst),
             X86Inst::Shl32RCl { dst } => write!(f, "shll {}, cl", dst),
             X86Inst::ShlRI { dst, imm } => write!(f, "shlq {}, {}", dst, imm),

--- a/crates/rue-codegen/src/x86_64/regalloc.rs
+++ b/crates/rue-codegen/src/x86_64/regalloc.rs
@@ -384,6 +384,10 @@ impl RegAlloc {
                 self.emit_unop(mir, dst, |d| X86Inst::NotR { dst: d });
             }
 
+            X86Inst::Not64R { dst } => {
+                self.emit_unop(mir, dst, |d| X86Inst::Not64R { dst: d });
+            }
+
             X86Inst::ShlRCl { dst } => {
                 self.emit_unop(mir, dst, |d| X86Inst::ShlRCl { dst: d });
             }

--- a/crates/rue-codegen/src/x86_64/schedule.rs
+++ b/crates/rue-codegen/src/x86_64/schedule.rs
@@ -128,7 +128,8 @@ fn get_latency(inst: &X86Inst) -> u32 {
         | X86Inst::Or64RR { .. }
         | X86Inst::Xor64RR { .. }
         | X86Inst::XorRI { .. }
-        | X86Inst::NotR { .. } => 1,
+        | X86Inst::NotR { .. }
+        | X86Inst::Not64R { .. } => 1,
 
         // Shifts: 1 cycle
         X86Inst::ShlRCl { .. }
@@ -284,7 +285,10 @@ fn regs_read(inst: &X86Inst) -> Vec<Reg> {
         X86Inst::AddRI { dst, .. } | X86Inst::XorRI { dst, .. } => {
             add_if_phys(dst, &mut result);
         }
-        X86Inst::Neg { dst } | X86Inst::Neg64 { dst } | X86Inst::NotR { dst } => {
+        X86Inst::Neg { dst }
+        | X86Inst::Neg64 { dst }
+        | X86Inst::NotR { dst }
+        | X86Inst::Not64R { dst } => {
             add_if_phys(dst, &mut result);
         }
         X86Inst::ShlRCl { dst }
@@ -415,6 +419,7 @@ fn regs_written(inst: &X86Inst) -> Vec<Reg> {
         | X86Inst::Or64RR { dst, .. }
         | X86Inst::Xor64RR { dst, .. }
         | X86Inst::NotR { dst }
+        | X86Inst::Not64R { dst }
         | X86Inst::ShlRCl { dst }
         | X86Inst::Shl32RCl { dst }
         | X86Inst::ShlRI { dst, .. }


### PR DESCRIPTION
Worker-implemented (isolated worktree), integrator re-verified on current trunk. The constfold fix's mandated audit found the scope was bigger than filed: **-O0 wasn't ground truth** — the x86-64 runtime `~` used a 32-bit `not` for 64-bit operands, and aarch64's 64-bit `mvn` leaked high bits into sub-64-bit results. So this fixes constfold masking (+ fold_shift) **and** the runtime lowering on both backends (new `Not64R`/`Mvn32RR`, wired through the full MIR checklist with encoder tests).

Verified: `~0`/`~5` probed at all eight widths at -O0 and -O2 — every width agrees across opt levels and matches two's-complement semantics. Regression matrix in `constfold.toml`. arm64 runtime proof is CI.

Fixes RUE-59

🤖 Generated with [Claude Code](https://claude.com/claude-code)