### PR TITLE
Unify StructInit/ArrayInit flattening into the shared aggregate-slot module (RUE-121 phase 2)

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2232,47 +2232,7 @@ impl<'a> CfgLower<'a> {
                 fields_start,
                 fields_len,
             } => {
-                let vreg = self.mir.alloc_vreg();
-                self.value_map.insert(value, vreg);
-
-                // Collect all slot vregs for the struct.
-                // For scalar fields, this is a single vreg.
-                // For nested struct fields, recursively collect all slot vregs.
-                let mut slot_vregs = Vec::new();
-                let fields = self.ctx.cfg.get_extra(*fields_start, *fields_len).to_vec();
-                for field in &fields {
-                    let field_inst = self.ctx.cfg.get_inst(*field);
-                    if field_inst.ty.is_struct() {
-                        // Nested struct/String field - all its slot vregs, incl. a
-                        // field read from another aggregate (`B { p: a.p }`). (RUE-118)
-                        let nested_vregs = self
-                            .get_or_compute_field_vregs(*field)
-                            .expect("nested struct field should have slot vregs");
-                        slot_vregs.extend(nested_vregs);
-                    } else if field_inst.ty.is_array() {
-                        // Nested array field - flatten to its element scalar slots so the
-                        // cached slot list is fully flattened (consumers and the Alloc-of-
-                        // this-StructInit rely on it). (RUE-118)
-                        slot_vregs.extend(self.collect_array_scalar_vregs(*field));
-                    } else {
-                        // Scalar field - single vreg
-                        slot_vregs.push(self.get_vreg(*field));
-                    }
-                }
-
-                if let Some(&first_vreg) = slot_vregs.first() {
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Virtual(vreg),
-                        src: Operand::Virtual(first_vreg),
-                    });
-                } else {
-                    self.mir.push(Aarch64Inst::MovImm {
-                        dst: Operand::Virtual(vreg),
-                        imm: 0,
-                    });
-                }
-
-                self.struct_slot_vregs.insert(value, slot_vregs);
+                crate::agg_slots::lower_struct_init(self, value, *fields_start, *fields_len);
             }
 
             CfgInstData::FieldSet {
@@ -2330,38 +2290,7 @@ impl<'a> CfgLower<'a> {
                 elements_start,
                 elements_len,
             } => {
-                // Array is stored in local slots; we just create vregs for elements.
-                let vreg = self.mir.alloc_vreg();
-                self.value_map.insert(value, vreg);
-
-                // Store element vregs for later access. Nested aggregate elements
-                // (multidimensional arrays, arrays of structs) are flattened to their
-                // scalar slots so the cached list is the full slot set — their own
-                // value_map entry is just a placeholder vreg. (RUE-118)
-                let elements = self
-                    .ctx
-                    .cfg
-                    .get_extra(*elements_start, *elements_len)
-                    .to_vec();
-                let mut element_vregs: Vec<VReg> = Vec::new();
-                for e in &elements {
-                    let e_ty = self.ctx.cfg.get_inst(*e).ty;
-                    if e_ty.is_struct() || e_ty.is_array() {
-                        let nested = self
-                            .get_or_compute_field_vregs(*e)
-                            .expect("nested aggregate element should have slot vregs");
-                        element_vregs.extend(nested);
-                    } else {
-                        element_vregs.push(self.get_vreg(*e));
-                    }
-                }
-                self.struct_slot_vregs.insert(value, element_vregs);
-
-                // Move 0 into vreg as placeholder
-                self.mir.push(Aarch64Inst::MovImm {
-                    dst: Operand::Virtual(vreg),
-                    imm: 0,
-                });
+                crate::agg_slots::lower_array_init(self, value, *elements_start, *elements_len);
             }
 
             CfgInstData::IndexSet {
@@ -4353,6 +4282,9 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn get_vreg(&mut self, value: CfgValue) -> VReg {
         CfgLower::get_vreg(self, value)
     }
+    fn map_value(&mut self, value: CfgValue, vreg: VReg) {
+        self.value_map.insert(value, vreg);
+    }
     fn emit_load_slot(&mut self, dst: VReg, slot: u32) {
         let offset = self.ctx.local_offset(slot);
         self.mir.push(Aarch64Inst::Ldr {
@@ -4360,6 +4292,21 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             base: Reg::Fp,
             offset,
         });
+    }
+    fn emit_reg_move(&mut self, dst: VReg, src: VReg) {
+        self.mir.push(Aarch64Inst::MovRR {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(src),
+        });
+    }
+    fn emit_load_zero(&mut self, dst: VReg) {
+        self.mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(dst),
+            imm: 0,
+        });
+    }
+    fn collect_array_scalars(&mut self, value: CfgValue) -> Vec<VReg> {
+        self.collect_array_scalar_vregs(value)
     }
 }
 

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -14,10 +14,12 @@
 //! [`SlotBackend`]: vreg allocation, value lookup, and the one genuinely
 //! per-architecture instruction (load a frame slot into a vreg).
 //!
-//! Phase 1 covers the slot accessor. The StructInit/ArrayInit flattening and
-//! the consumer-side store loops still live per-backend; they migrate here in
-//! later phases once their (currently subtly different) behaviors are
-//! reconciled deliberately rather than incidentally.
+//! Phase 1 covered the slot accessor. Phase 2 moved the StructInit/ArrayInit
+//! flattening (the eager population of the slot cache) here as
+//! [`lower_struct_init`]/[`lower_array_init`]. The consumer-side store loops
+//! still live per-backend; they migrate in later phases once their (currently
+//! subtly different) behaviors are reconciled deliberately rather than
+//! incidentally.
 
 use std::collections::HashMap;
 
@@ -45,8 +47,21 @@ pub trait SlotBackend {
     /// Get (or lazily create) the primary vreg for a CFG value.
     fn get_vreg(&mut self, value: CfgValue) -> VReg;
 
+    /// Record `vreg` as the primary vreg for `value` (the `value_map` entry).
+    fn map_value(&mut self, value: CfgValue, vreg: VReg);
+
     /// Emit a load of frame slot `slot` into `dst`.
     fn emit_load_slot(&mut self, dst: VReg, slot: u32);
+
+    /// Emit a register-to-register move.
+    fn emit_reg_move(&mut self, dst: VReg, src: VReg);
+
+    /// Emit a load of the constant zero into `dst`.
+    fn emit_load_zero(&mut self, dst: VReg);
+
+    /// Recursively collect the scalar slot vregs of an array value
+    /// (the backends' thin wrapper over `types::collect_array_scalar_vregs`).
+    fn collect_array_scalars(&mut self, value: CfgValue) -> Vec<VReg>;
 }
 
 /// Get or compute the slot vregs for a multi-slot aggregate value
@@ -129,6 +144,87 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
         // BlockParam and Call should already have slot vregs in the cache
         _ => None,
     }
+}
+
+/// Lower a `StructInit`: flatten the field values into one vreg per slot,
+/// cache the list, and bind the value's primary vreg (first slot, or zero for
+/// a fieldless struct).
+///
+/// Nested struct/String fields contribute all their slot vregs via the
+/// accessor — including a field read from another aggregate (`B { p: a.p }`).
+/// Nested array fields flatten to their element scalar slots so the cached
+/// slot list is fully flattened (consumers and the Alloc of this StructInit
+/// rely on it). (RUE-118)
+pub fn lower_struct_init<B: SlotBackend>(
+    b: &mut B,
+    value: CfgValue,
+    fields_start: u32,
+    fields_len: u32,
+) {
+    let vreg = b.alloc_vreg();
+    b.map_value(value, vreg);
+
+    let fields = b.ctx().cfg.get_extra(fields_start, fields_len).to_vec();
+    let mut slot_vregs = Vec::new();
+    for field in &fields {
+        let field_ty = b.ctx().cfg.get_inst(*field).ty;
+        match field_ty.kind() {
+            TypeKind::Struct(_) => {
+                let nested = get_or_compute_field_vregs(b, *field)
+                    .expect("nested struct field should have slot vregs");
+                slot_vregs.extend(nested);
+            }
+            TypeKind::Array(_) => {
+                slot_vregs.extend(b.collect_array_scalars(*field));
+            }
+            _ => {
+                // Scalar field - single vreg
+                slot_vregs.push(b.get_vreg(*field));
+            }
+        }
+    }
+
+    if let Some(&first_vreg) = slot_vregs.first() {
+        b.emit_reg_move(vreg, first_vreg);
+    } else {
+        b.emit_load_zero(vreg);
+    }
+
+    b.slot_cache().insert(value, slot_vregs);
+}
+
+/// Lower an `ArrayInit`: flatten the element values into one vreg per slot
+/// and cache the list. The value's primary vreg is a zero placeholder — an
+/// array base has no single value; the actual storage is handled by the
+/// `Alloc` that precedes this.
+///
+/// Nested aggregate elements (multidimensional arrays, arrays of structs) are
+/// flattened to their scalar slots so the cached list is the full slot set —
+/// their own primary vreg is just a placeholder. (RUE-118)
+pub fn lower_array_init<B: SlotBackend>(
+    b: &mut B,
+    value: CfgValue,
+    elements_start: u32,
+    elements_len: u32,
+) {
+    let vreg = b.alloc_vreg();
+    b.map_value(value, vreg);
+
+    let elements = b.ctx().cfg.get_extra(elements_start, elements_len).to_vec();
+    let mut element_vregs: Vec<VReg> = Vec::new();
+    for e in &elements {
+        let e_ty = b.ctx().cfg.get_inst(*e).ty;
+        if matches!(e_ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+            let nested = get_or_compute_field_vregs(b, *e)
+                .expect("nested aggregate element should have slot vregs");
+            element_vregs.extend(nested);
+        } else {
+            element_vregs.push(b.get_vreg(*e));
+        }
+    }
+    b.slot_cache().insert(value, element_vregs);
+
+    b.emit_load_zero(vreg);
 }
 
 /// Load `count` consecutive frame slots starting at `base_slot`, returning the

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2412,51 +2412,7 @@ impl<'a> CfgLower<'a> {
                 fields_start,
                 fields_len,
             } => {
-                let vreg = self.mir.alloc_vreg();
-                self.value_map.insert(value, vreg);
-
-                // Collect all slot vregs for the struct.
-                // For scalar fields, this is a single vreg.
-                // For nested struct fields, recursively collect all slot vregs.
-                let mut slot_vregs = Vec::new();
-                let fields = self.ctx.cfg.get_extra(*fields_start, *fields_len).to_vec();
-                for field in &fields {
-                    let field_inst = self.ctx.cfg.get_inst(*field);
-                    match field_inst.ty.kind() {
-                        TypeKind::Struct(_) => {
-                            // Nested struct/String field - all its slot vregs, incl. a
-                            // field read from another aggregate (`B { p: a.p }`). (RUE-118)
-                            let nested_vregs = self
-                                .get_or_compute_field_vregs(*field)
-                                .expect("nested struct field should have slot vregs");
-                            slot_vregs.extend(nested_vregs);
-                        }
-                        TypeKind::Array(_) => {
-                            // Nested array field - flatten to its element scalar slots so
-                            // the cached slot list is fully flattened (consumers and the
-                            // Alloc-of-this-StructInit rely on it). (RUE-118)
-                            slot_vregs.extend(self.collect_array_scalar_vregs(*field));
-                        }
-                        _ => {
-                            // Scalar field - single vreg
-                            slot_vregs.push(self.get_vreg(*field));
-                        }
-                    }
-                }
-
-                if let Some(&first_vreg) = slot_vregs.first() {
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Virtual(vreg),
-                        src: Operand::Virtual(first_vreg),
-                    });
-                } else {
-                    self.mir.push(X86Inst::MovRI32 {
-                        dst: Operand::Virtual(vreg),
-                        imm: 0,
-                    });
-                }
-
-                self.struct_slot_vregs.insert(value, slot_vregs);
+                crate::agg_slots::lower_struct_init(self, value, *fields_start, *fields_len);
             }
 
             CfgInstData::FieldSet {
@@ -2513,39 +2469,7 @@ impl<'a> CfgLower<'a> {
                 elements_start,
                 elements_len,
             } => {
-                // Array is stored in local slots; we just create vregs for elements.
-                // The actual storage is handled by the Alloc that precedes this.
-                let vreg = self.mir.alloc_vreg();
-                self.value_map.insert(value, vreg);
-
-                // Store element vregs for later PlaceRead access. Nested aggregate
-                // elements (multidimensional arrays, arrays of structs) are flattened
-                // to their scalar slots so the cached list is the full slot set —
-                // their own value_map entry is just a placeholder vreg. (RUE-118)
-                let elements = self
-                    .ctx
-                    .cfg
-                    .get_extra(*elements_start, *elements_len)
-                    .to_vec();
-                let mut element_vregs: Vec<VReg> = Vec::new();
-                for e in &elements {
-                    let e_ty = self.ctx.cfg.get_inst(*e).ty;
-                    if matches!(e_ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
-                        let nested = self
-                            .get_or_compute_field_vregs(*e)
-                            .expect("nested aggregate element should have slot vregs");
-                        element_vregs.extend(nested);
-                    } else {
-                        element_vregs.push(self.get_vreg(*e));
-                    }
-                }
-                self.struct_slot_vregs.insert(value, element_vregs);
-
-                // Move 0 into vreg as placeholder (array base doesn't have a single value)
-                self.mir.push(X86Inst::MovRI32 {
-                    dst: Operand::Virtual(vreg),
-                    imm: 0,
-                });
+                crate::agg_slots::lower_array_init(self, value, *elements_start, *elements_len);
             }
 
             CfgInstData::IndexSet {
@@ -4289,6 +4213,9 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     fn get_vreg(&mut self, value: CfgValue) -> VReg {
         CfgLower::get_vreg(self, value)
     }
+    fn map_value(&mut self, value: CfgValue, vreg: VReg) {
+        self.value_map.insert(value, vreg);
+    }
     fn emit_load_slot(&mut self, dst: VReg, slot: u32) {
         let offset = self.ctx.local_offset(slot);
         self.mir.push(X86Inst::MovRM {
@@ -4296,6 +4223,21 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             base: Reg::Rbp,
             offset,
         });
+    }
+    fn emit_reg_move(&mut self, dst: VReg, src: VReg) {
+        self.mir.push(X86Inst::MovRR {
+            dst: Operand::Virtual(dst),
+            src: Operand::Virtual(src),
+        });
+    }
+    fn emit_load_zero(&mut self, dst: VReg) {
+        self.mir.push(X86Inst::MovRI32 {
+            dst: Operand::Virtual(dst),
+            imm: 0,
+        });
+    }
+    fn collect_array_scalars(&mut self, value: CfgValue) -> Vec<VReg> {
+        self.collect_array_scalar_vregs(value)
     }
 }
 


### PR DESCRIPTION
## Summary

RUE-121 phase 2: the `StructInit` and `ArrayInit` lowering arms — the eager flattening that populates the `struct_slot_vregs` cache — were structurally identical hand-mirrored copies in the two `cfg_lower.rs` files (the x86 copy matched on `TypeKind`, the aarch64 copy on `is_struct()`/`is_array()`; same semantics, drifted spelling). They now live once in `agg_slots.rs` as `lower_struct_init`/`lower_array_init`.

`SlotBackend` grows four thin leaf methods: `map_value` (value_map insert), `emit_reg_move`, `emit_load_zero` (`MovRR`/`MovRI32` on x86, `MovRR`/`MovImm` on aarch64), and `collect_array_scalars` (the backends' existing wrapper over the already-shared `types::collect_array_scalar_vregs`).

Net: −155/+140 lines, and the next StructInit/ArrayInit bug only needs fixing once.

## Verification

Same method as phase 1 (#917): `--emit asm` output is **byte-identical before/after** on a 37-program corpus of aggregate-heavy shapes (nested structs, fieldless structs, String fields, multidimensional arrays, arrays of structs, struct-with-array fields, aggregate args/returns) on **both** x86-64 and aarch64 — vreg allocation order is preserved exactly. Full `./test.sh` green.

Remaining phases tracked in RUE-121: consumer-side store loops (phase 3), scheduler/liveness sharing (phase 4).

Part of RUE-121 (do not auto-close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
