### PR TITLE
Attribute parse errors to the file that contains them

### DIFF
--- a/crates/rue-cli-tests/cases/multifile_errors.toml
+++ b/crates/rue-cli-tests/cases/multifile_errors.toml
@@ -1,0 +1,78 @@
+# Multi-file error attribution (RUE-115).
+#
+# Parse errors produced by the chumsky error-conversion path used to drop the
+# FileId (defaulting to FileId::DEFAULT), so in a multi-file compile the
+# diagnostic renderer fell back to an ARBITRARY source file: the error could be
+# rendered with a caret on perfectly valid code in the wrong file. These cases
+# pin that a parse error in one file is attributed to THAT file regardless of
+# argument order, and that the other (valid) file is never named in stderr.
+
+[section]
+id = "cli.multifile_errors"
+name = "Multi-file error attribution"
+description = "Parse errors must name the file that actually contains them (RUE-115)."
+
+[[case]]
+name = "parse_error_in_second_file"
+description = """
+RUE-115: the E0100 (unexpected token) conversion path lost the FileId. The
+error lives in bad.rue, passed second; stderr must point at bad.rue:1:9 and
+must not mention good.rue at all.
+"""
+files = [
+    { path = "good.rue", source = """
+fn good() -> i32 { 1 }
+""" },
+    { path = "bad.rue", source = """
+fn bad( -> i32 { 2 }
+fn main() -> i32 { 0 }
+""" },
+]
+args = ["good.rue", "bad.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0100", "bad.rue:1:9"]
+compile_stderr_not_contains = ["good.rue"]
+
+[[case]]
+name = "parse_error_in_first_file"
+description = """
+RUE-115, swapped order: before the fix the rendered file depended on hash-map
+iteration order, so the same error could land on either file. With bad.rue
+passed first, stderr must still point at bad.rue and never at good.rue.
+"""
+files = [
+    { path = "good.rue", source = """
+fn good() -> i32 { 1 }
+""" },
+    { path = "bad.rue", source = """
+fn bad( -> i32 { 2 }
+fn main() -> i32 { 0 }
+""" },
+]
+args = ["bad.rue", "good.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0100", "bad.rue:1:9"]
+compile_stderr_not_contains = ["good.rue"]
+
+[[case]]
+name = "missing_semicolon_error_in_second_file"
+description = """
+Control for RUE-115: the E0102 (expected semicolon) path already threaded the
+FileId correctly via the parser state. Pin it so it stays correct.
+"""
+files = [
+    { path = "good.rue", source = """
+fn good() -> i32 { 1 }
+""" },
+    { path = "bad.rue", source = """
+fn other() -> i32 {
+    let s = 1;
+    s s
+}
+fn main() -> i32 { 0 }
+""" },
+]
+args = ["good.rue", "bad.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0102", "bad.rue:3:5"]
+compile_stderr_not_contains = ["good.rue"]

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -110,12 +110,6 @@ fn to_rue_span_with_file(span: SimpleSpan, file_id: FileId) -> Span {
     Span::with_file(file_id, offset_to_u32(span.start), offset_to_u32(span.end))
 }
 
-/// Convert chumsky SimpleSpan to rue_span::Span using the default file ID.
-/// Only used for error conversion where we don't have access to the parser state.
-fn to_rue_span(span: SimpleSpan) -> Span {
-    Span::new(offset_to_u32(span.start), offset_to_u32(span.end))
-}
-
 /// Extract a Span with file ID from the parser extra.
 /// This is the primary way to create spans during parsing.
 #[inline]
@@ -2221,9 +2215,10 @@ where
                 .repeated()
                 .collect::<Vec<_>>(),
         )
-        .map(|(start_span, _): (SimpleSpan, Vec<TokenKind>)| {
-            // Convert SimpleSpan to Span
-            Item::Error(to_rue_span(start_span))
+        .map_with(|(start_span, _): (SimpleSpan, Vec<TokenKind>), extra| {
+            // Convert SimpleSpan to Span, tagging it with this file's ID
+            let file_id = extra.state().0.file_id;
+            Item::Error(to_rue_span_with_file(start_span, file_id))
         })
 }
 
@@ -2263,8 +2258,12 @@ fn format_pattern(pattern: &chumsky::error::RichPattern<'_, TokenKind>) -> Strin
 }
 
 /// Convert chumsky Rich error to CompileError, preserving rich context.
-fn convert_error(err: Rich<'_, TokenKind>) -> CompileError {
-    let span = to_rue_span(*err.span());
+///
+/// The `file_id` is threaded in from the parser so that error spans point at
+/// the file being parsed; without it, spans would default to `FileId::DEFAULT`
+/// and multi-file compilations would attribute errors to the wrong file.
+fn convert_error(err: Rich<'_, TokenKind>, file_id: FileId) -> CompileError {
+    let span = to_rue_span_with_file(*err.span(), file_id);
 
     // Build the base error from the reason
     let mut error = match err.reason() {
@@ -2304,7 +2303,7 @@ fn convert_error(err: Rich<'_, TokenKind>) -> CompileError {
     // Add labelled contexts as secondary labels
     for (pattern, ctx_span) in err.contexts() {
         let label_msg = format!("while parsing {}", format_pattern(pattern));
-        let label_span = to_rue_span(*ctx_span);
+        let label_span = to_rue_span_with_file(*ctx_span, file_id);
         error = error.with_label(label_msg, label_span);
     }
 
@@ -2369,7 +2368,10 @@ impl ChumskyParser {
             .parse_with_state(mapped, &mut state)
             .into_result()
             .map_err(|errs| {
-                let errors: Vec<CompileError> = errs.into_iter().map(convert_error).collect();
+                let errors: Vec<CompileError> = errs
+                    .into_iter()
+                    .map(|err| convert_error(err, self.file_id))
+                    .collect();
                 CompileErrors::from(errors)
             });
 
@@ -3216,11 +3218,13 @@ mod tests {
 
     #[test]
     fn test_to_rue_span_normal() {
-        // Normal spans should convert without issue
+        // Normal spans should convert without issue and carry the file ID
         let simple = SimpleSpan::new(10, 20);
-        let rue = to_rue_span(simple);
+        let file = FileId::new(3);
+        let rue = to_rue_span_with_file(simple, file);
         assert_eq!(rue.start, 10);
         assert_eq!(rue.end, 20);
+        assert_eq!(rue.file_id, file);
     }
 
     #[test]


### PR DESCRIPTION
The chumsky error-conversion path built spans with a defaulting to_rue_span()
that dropped the FileId, so every parse error span carried FileId::DEFAULT.
In a multi-file compile the diagnostic renderer's fallback then picked an
arbitrary source file: an E0100 in b.rue could be rendered with a caret on
perfectly valid code in a.rue, with wrong line/col and a mismatched snippet.
(The E0102 path already threaded the id via parser state, which is why only
some errors misattributed.)

The defaulting helper is deleted outright so the footgun can't return.
convert_error() now takes the FileId (threaded from ChumskyParser::parse) for
both the primary span and the labelled-context spans, and the
error_recovery() Item::Error span tags the file id via map_with + parser
state.

Three CLI cases in crates/rue-cli-tests/cases/multifile_errors.toml pin the
attribution: parse error in the second file, in the first file (swapped
order), and an E0102 control — each asserting the correct bad.rue:line:col
appears and the valid file's name never does. Full test.sh green.

Fixes RUE-115



🤖 Generated with [Claude Code](https://claude.com/claude-code)
