### PR TITLE
aarch64 branch-fixup range checks; record clobbers as writes in both schedulers

### DIFF
--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -57,7 +57,7 @@
 //! For values that cannot be encoded as logical immediates, we materialize the constant
 //! in a scratch register (X9) using MOVZ/MOVK and then use the register-register form.
 
-use rue_error::{CompileError, CompileResult, ErrorKind};
+use rue_error::{CompileError, CompileResult, ErrorKind, ice_error};
 
 use super::mir::{Aarch64Inst, Aarch64Mir, BLOCK_LABEL_BASE, Cond, LabelId, Reg};
 use crate::{EmittedCode, EmittedInst, EmittedRelocation, end_inst};
@@ -1299,10 +1299,28 @@ impl<'a> Emitter<'a> {
                     fixup.label
                 )))
             })?;
+            debug_assert_eq!(
+                (target as i64 - fixup.offset as i64) % 4,
+                0,
+                "branch target/site must be 4-byte aligned"
+            );
             let offset = (target as i64 - fixup.offset as i64) / 4;
             match fixup.kind {
                 FixupKind::Branch => {
-                    // B instruction: imm26
+                    // B instruction: imm26 is a SIGNED instruction count. Masking an
+                    // out-of-range offset would silently branch somewhere else, so
+                    // ICE instead (mirrors the x86 emitter's rel32 range check).
+                    if !(-(1 << 25)..(1 << 25)).contains(&offset) {
+                        return Err(ice_error!(
+                            "branch offset exceeds imm26 range",
+                            phase: "codegen/emit",
+                            details: {
+                                "offset_insts" => offset.to_string(),
+                                "label" => fixup.label.to_string(),
+                                "range" => "-2^25..2^25 instructions"
+                            }
+                        ));
+                    }
                     let inst = u32::from_le_bytes(
                         self.code[fixup.offset..fixup.offset + 4]
                             .try_into()
@@ -1314,7 +1332,18 @@ impl<'a> Emitter<'a> {
                         .copy_from_slice(&new_inst.to_le_bytes());
                 }
                 FixupKind::CondBranch => {
-                    // Conditional branch: imm19
+                    // Conditional branch (B.cond/CBZ/CBNZ): imm19, also signed.
+                    if !(-(1 << 18)..(1 << 18)).contains(&offset) {
+                        return Err(ice_error!(
+                            "conditional branch offset exceeds imm19 range",
+                            phase: "codegen/emit",
+                            details: {
+                                "offset_insts" => offset.to_string(),
+                                "label" => fixup.label.to_string(),
+                                "range" => "-2^18..2^18 instructions"
+                            }
+                        ));
+                    }
                     let inst = u32::from_le_bytes(
                         self.code[fixup.offset..fixup.offset + 4]
                             .try_into()

--- a/crates/rue-codegen/src/aarch64/schedule.rs
+++ b/crates/rue-codegen/src/aarch64/schedule.rs
@@ -591,7 +591,13 @@ fn build_dep_graph(instructions: &[Aarch64Inst], start: usize, end: usize) -> Ve
             }
         }
 
-        // Update tracking
+        // Update tracking. Clobbers count as writes here: a later instruction
+        // that writes (WAW) or reads (RAW) a clobbered register must not be
+        // scheduled above the clobberer, or the clobber destroys its value.
+        for &clobbered in inst.clobbers() {
+            last_writer.insert(clobbered, i);
+            last_readers.remove(&clobbered);
+        }
         for reg in writes {
             last_writer.insert(reg, i);
             last_readers.remove(&reg);
@@ -759,6 +765,37 @@ pub fn schedule(mir: &mut Aarch64Mir) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_clobber_orders_later_write_and_read() {
+        // Clobbers must be recorded as writes in the dep graph: a later write
+        // to (WAW) or read of (RAW) a clobbered register must depend on the
+        // clobberer. Today every aarch64 clobberer (Bl, Svc) is also a
+        // scheduling barrier, so this is defense-in-depth at the dep-graph
+        // level — build_dep_graph itself must stay correct for any future
+        // non-barrier clobberer (and for the x86 backend, where CQO/IDIV
+        // clobber without being barriers).
+        let insts = vec![
+            Aarch64Inst::Svc { imm: 0 }, // clobbers X0, X8, X16
+            Aarch64Inst::MovImm {
+                dst: Operand::Physical(Reg::X0),
+                imm: 7,
+            },
+            Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X1),
+                src: Operand::Physical(Reg::X8),
+            },
+        ];
+        let nodes = build_dep_graph(&insts, 0, insts.len());
+        assert!(
+            nodes[1].deps.contains(&0),
+            "write to clobbered X0 must depend on the clobbering SVC"
+        );
+        assert!(
+            nodes[2].deps.contains(&0),
+            "read of clobbered X8 must depend on the clobbering SVC"
+        );
+    }
 
     #[test]
     fn test_latency_values() {

--- a/crates/rue-codegen/src/x86_64/schedule.rs
+++ b/crates/rue-codegen/src/x86_64/schedule.rs
@@ -685,7 +685,13 @@ fn build_dep_graph(instructions: &[X86Inst], start: usize, end: usize) -> Vec<Sc
             }
         }
 
-        // Update tracking
+        // Update tracking. Clobbers count as writes here: a later instruction
+        // that writes (WAW) or reads (RAW) a clobbered register must not be
+        // scheduled above the clobberer, or the clobber destroys its value.
+        for &clobbered in inst.clobbers() {
+            last_writer.insert(clobbered, i);
+            last_readers.remove(&clobbered);
+        }
         for reg in writes {
             last_writer.insert(reg, i);
             last_readers.remove(&reg);
@@ -906,6 +912,44 @@ mod tests {
             dst: Operand::Physical(Reg::Rax),
             src: Operand::Physical(Reg::Rbx),
         }));
+    }
+
+    #[test]
+    fn test_clobber_orders_later_write() {
+        // A later write to a clobbered register must depend on the clobberer
+        // (WAW through the clobber set): if `mov rdx, 7` were hoisted above
+        // CQO, the sign-extension would destroy the 7.
+        let insts = vec![
+            X86Inst::Cqo, // clobbers RDX
+            X86Inst::MovRI32 {
+                dst: Operand::Physical(Reg::Rdx),
+                imm: 7,
+            },
+        ];
+        let nodes = build_dep_graph(&insts, 0, insts.len());
+        assert!(
+            nodes[1].deps.contains(&0),
+            "write to clobbered RDX must depend on the clobbering CQO"
+        );
+    }
+
+    #[test]
+    fn test_clobber_orders_later_read() {
+        // A later read of a clobbered register must depend on the clobberer
+        // (RAW through the clobber set): reading RDX after CQO must observe
+        // the sign-extension result, not the pre-CQO value.
+        let insts = vec![
+            X86Inst::Cqo, // clobbers RDX
+            X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rbx),
+                src: Operand::Physical(Reg::Rdx),
+            },
+        ];
+        let nodes = build_dep_graph(&insts, 0, insts.len());
+        assert!(
+            nodes[1].deps.contains(&0),
+            "read of clobbered RDX must depend on the clobbering CQO"
+        );
     }
 
     #[test]

--- a/crates/rue-spec/cases/runtime/syscall.toml
+++ b/crates/rue-spec/cases/runtime/syscall.toml
@@ -176,3 +176,53 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# aarch64 mirror of syscall_returns_i64. The two result-READING tests above
+# were x86-only, which is exactly how the aarch64 scheduler bug that hoisted
+# the x0 result capture above `svc #0` shipped undetected (RUE-129 item 4):
+# every used @syscall result on aarch64 read garbage, and no test noticed.
+[[case]]
+name = "syscall_returns_i64_aarch64"
+spec = ["9.2:4"]
+only_on = ["aarch64-linux"]
+source = """
+fn main() -> i32 {
+    // getpid syscall (172 on Linux aarch64) returns the process ID
+    let syscall_num: u64 = 172;
+    let mut result: i64 = 0;
+    checked {
+        result = @syscall(syscall_num);
+    };
+    // PID should be positive
+    let zero: i64 = 0;
+    if result > zero {
+        42
+    } else {
+        1
+    }
+}
+"""
+exit_code = 42
+
+# aarch64 mirror of syscall_checked_block_expression (see note above).
+[[case]]
+name = "syscall_checked_block_expression_aarch64"
+spec = ["9.2:4"]
+only_on = ["aarch64-linux"]
+source = """
+fn main() -> i32 {
+    // getpid syscall (172 on Linux aarch64) returns the process ID
+    let syscall_num: u64 = 172;
+    let result: i64 = checked {
+        @syscall(syscall_num)
+    };
+    // PID should be positive
+    let zero: i64 = 0;
+    if result > zero {
+        42
+    } else {
+        1
+    }
+}
+"""
+exit_code = 42


### PR DESCRIPTION
Remaining items of the aarch64-emitter correctness epic (items 5 and the rest
of 4/6).

Branch fixups (item 5): apply_fixups masked branch offsets to the encoding
field width with no range check — a B beyond +-2^25 instructions or a
B.cond/CBZ beyond +-2^18 would silently branch somewhere else entirely. Both
fixup kinds now ICE on out-of-range offsets, mirroring the x86 emitter's
rel32 check, plus a debug_assert that branch sites/targets are 4-byte
aligned.

Scheduler clobbers (item 4, second half): build_dep_graph created edges INTO
a clobbering instruction (clobberer after prior readers/writers) but never
recorded the clobbered registers as written by it. A later instruction
writing or reading a clobbered register therefore had no edge back to the
clobberer and could be hoisted above it — e.g. on x86 a `mov rdx, imm`
scheduled above the CQO/IDIV that clobbers rdx. Clobbers now update
last_writer/last_readers exactly like writes, on both backends. On aarch64
every current clobberer (Bl, Svc) is also a scheduling barrier, so this is
defense-in-depth there; on x86 CQO/CDQ/IDIV clobber without being barriers.
Verified behavior-preserving on the 37-program asm corpus (byte-identical on
both targets at the same base) — the new edges only forbid reorderings that
would have been wrong.

Test gaps (item 6, partial): three scheduler unit tests pin the clobber
ordering (x86 WAW + RAW vs CQO; aarch64 WAW + RAW vs SVC at the dep-graph
level), and the two @syscall result-READING spec cases — previously
x86-only, which is exactly how the Svc result-hoist bug shipped undetected —
now have aarch64-linux mirrors (getpid = 172) that CI's native arm64 job
executes.

Remaining in the epic after this: TestEmitter drift and aarch64 emitter
fuzz coverage.

Part of RUE-129.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
