### PR TITLE
Type loop-with-break as (), reject break-with-value

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -89,6 +89,10 @@ pub struct ConstraintContext<'a> {
     pub return_type: Type,
     /// How many loops we're nested inside (for break/continue validation).
     pub loop_depth: u32,
+    /// One entry per enclosing loop (innermost last); set to `true` when a
+    /// `break` targeting that loop is seen. An infinite loop containing a
+    /// break has type `()`; without one it has type `!` (see spec 4.8).
+    pub loop_break_stack: Vec<bool>,
     /// Scope stack for efficient scope management.
     scope_stack: Vec<Vec<(Spur, Option<LocalVarInfo>)>>,
 }
@@ -101,6 +105,7 @@ impl<'a> ConstraintContext<'a> {
             params,
             return_type,
             loop_depth: 0,
+            loop_break_stack: Vec::new(),
             scope_stack: Vec::new(),
         }
     }
@@ -888,7 +893,9 @@ impl<'a> ConstraintGenerator<'a> {
                 ));
 
                 ctx.loop_depth += 1;
+                ctx.loop_break_stack.push(false);
                 self.generate(*body, ctx);
+                ctx.loop_break_stack.pop();
                 ctx.loop_depth -= 1;
 
                 // Loops produce unit
@@ -898,15 +905,42 @@ impl<'a> ConstraintGenerator<'a> {
             // Infinite loop
             InstData::InfiniteLoop { body } => {
                 ctx.loop_depth += 1;
+                ctx.loop_break_stack.push(false);
                 self.generate(*body, ctx);
+                let has_break = ctx.loop_break_stack.pop().unwrap_or(false);
                 ctx.loop_depth -= 1;
 
-                // Infinite loop without break never returns
-                InferType::Concrete(Type::NEVER)
+                // An infinite loop with a break targeting it exits with unit;
+                // without one it never returns (see spec 4.8:17 / 4.8:21).
+                if has_break {
+                    InferType::Concrete(Type::UNIT)
+                } else {
+                    InferType::Concrete(Type::NEVER)
+                }
             }
 
             // Break/Continue
-            InstData::Break | InstData::Continue => InferType::Concrete(Type::NEVER),
+            InstData::Break { value } => {
+                match value {
+                    None => {
+                        // Record the break against the innermost enclosing loop.
+                        if let Some(broke) = ctx.loop_break_stack.last_mut() {
+                            *broke = true;
+                        }
+                    }
+                    Some(v) => {
+                        // A value operand is always rejected by sema (spec
+                        // 4.8:21). Don't count it as a loop exit here: keeping
+                        // the loop `!`-typed lets sema report the dedicated
+                        // break-with-value error instead of inference masking
+                        // it with a type mismatch. Still generate constraints
+                        // for the operand so inference stays total.
+                        self.generate(*v, ctx);
+                    }
+                }
+                InferType::Concrete(Type::NEVER)
+            }
+            InstData::Continue => InferType::Concrete(Type::NEVER),
 
             // Match expression
             InstData::Match {
@@ -1820,7 +1854,7 @@ mod tests {
         let methods: HashMap<(StructId, Spur), MethodSig> = HashMap::new();
 
         let break_inst = rir.add_inst(rue_rir::Inst {
-            data: InstData::Break,
+            data: InstData::Break { value: None },
             span: Span::new(0, 5),
         });
 

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1410,6 +1410,7 @@ fn analyze_function_with_context(
         params: &param_vec,
         next_slot: 0,
         loop_depth: 0,
+        loop_break_stack: Vec::new(),
         used_locals: HashSet::new(),
         return_type,
         scope_stack: Vec::new(),
@@ -1926,10 +1927,21 @@ fn analyze_inst_with_context(
         }
 
         // Control flow: Break and Continue
-        InstData::Break => {
+        InstData::Break { value } => {
             // Validate that we're inside a loop
             if analysis_ctx.loop_depth == 0 {
                 return Err(CompileError::new(ErrorKind::BreakOutsideLoop, inst.span));
+            }
+
+            // Break does not carry a value (spec 4.8:21)
+            if value.is_some() {
+                return Err(CompileError::new(ErrorKind::BreakWithValue, inst.span));
+            }
+
+            // Record the break against the innermost enclosing loop, so the
+            // loop can be typed `()` instead of `!` (spec 4.8:17).
+            if let Some(broke) = analysis_ctx.loop_break_stack.last_mut() {
+                *broke = true;
             }
 
             // Break has the never type - it diverges
@@ -3278,10 +3290,14 @@ fn analyze_while_loop_ctx(
     // While loop: condition must be bool, result is Unit
     let cond_result = analyze_inst_with_context(ctx, air, cond, analysis_ctx)?;
 
-    // Analyze body with its own scope
+    // Analyze body with its own scope. The loop_break_stack entry makes
+    // breaks inside the body target this while loop, not an outer loop; the
+    // flag itself is unused because a while loop is always `()`.
     analysis_ctx.push_scope();
     analysis_ctx.loop_depth += 1;
+    analysis_ctx.loop_break_stack.push(false);
     let body_result = analyze_inst_with_context(ctx, air, body, analysis_ctx)?;
+    analysis_ctx.loop_break_stack.pop();
     analysis_ctx.loop_depth -= 1;
     analysis_ctx.pop_scope();
 
@@ -3296,7 +3312,9 @@ fn analyze_while_loop_ctx(
             analyze_inst_with_context(ctx, &mut scratch_air, cond, &mut scratch_ctx)?;
             scratch_ctx.push_scope();
             scratch_ctx.loop_depth += 1;
+            scratch_ctx.loop_break_stack.push(false);
             analyze_inst_with_context(ctx, &mut scratch_air, body, &mut scratch_ctx)?;
+            scratch_ctx.loop_break_stack.pop();
             scratch_ctx.loop_depth -= 1;
             scratch_ctx.pop_scope();
             Ok(())
@@ -3323,14 +3341,18 @@ fn analyze_infinite_loop_ctx(
     span: Span,
     analysis_ctx: &mut AnalysisContext,
 ) -> CompileResult<AnalysisResult> {
-    // Infinite loop: `loop { body }` - always produces Never type
+    // Infinite loop: `loop { body }` - type `()` if the body contains a break
+    // targeting this loop (the loop can exit), `!` otherwise
+    // (spec 4.8:17 / 4.8:21).
 
     // Snapshot move state before the body for the back-edge recheck below.
     let moves_before_loop = analysis_ctx.moved_vars.clone();
 
     analysis_ctx.push_scope();
     analysis_ctx.loop_depth += 1;
+    analysis_ctx.loop_break_stack.push(false);
     let body_result = analyze_inst_with_context(ctx, air, body, analysis_ctx)?;
+    let has_break = analysis_ctx.loop_break_stack.pop().unwrap_or(false);
     analysis_ctx.loop_depth -= 1;
     analysis_ctx.pop_scope();
 
@@ -3342,20 +3364,23 @@ fn analyze_infinite_loop_ctx(
         let mut scratch_ctx = analysis_ctx.fork_for_loop_recheck();
         scratch_ctx.push_scope();
         scratch_ctx.loop_depth += 1;
+        scratch_ctx.loop_break_stack.push(false);
         analyze_inst_with_context(ctx, &mut scratch_air, body, &mut scratch_ctx)
             .map_err(|e| e.with_note("value was moved in a previous iteration of the loop"))?;
+        scratch_ctx.loop_break_stack.pop();
         scratch_ctx.loop_depth -= 1;
         scratch_ctx.pop_scope();
     }
 
+    let loop_ty = if has_break { Type::UNIT } else { Type::NEVER };
     let air_ref = air.add_inst(AirInst {
         data: AirInstData::InfiniteLoop {
             body: body_result.air_ref,
         },
-        ty: Type::NEVER,
+        ty: loop_ty,
         span,
     });
-    Ok(AnalysisResult::new(air_ref, Type::NEVER))
+    Ok(AnalysisResult::new(air_ref, loop_ty))
 }
 
 /// Analyze a match expression using the shared context.
@@ -6631,6 +6656,7 @@ impl<'a> Sema<'a> {
             params: &param_vec,
             next_slot: 0,
             loop_depth: 0,
+            loop_break_stack: Vec::new(),
             used_locals: HashSet::new(),
             return_type,
             scope_stack: Vec::new(),
@@ -7226,7 +7252,7 @@ impl<'a> Sema<'a> {
             | InstData::Loop { .. }
             | InstData::InfiniteLoop { .. }
             | InstData::Match { .. }
-            | InstData::Break
+            | InstData::Break { .. }
             | InstData::Continue
             | InstData::Ret(_)
             | InstData::Block { .. } => self.analyze_control_flow(air, inst_ref, ctx),

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -569,10 +569,21 @@ impl<'a> Sema<'a> {
                 arms_len,
             } => self.analyze_match(air, *scrutinee, *arms_start, *arms_len, inst.span, ctx),
 
-            InstData::Break => {
+            InstData::Break { value } => {
                 // Validate that we're inside a loop
                 if ctx.loop_depth == 0 {
                     return Err(CompileError::new(ErrorKind::BreakOutsideLoop, inst.span));
+                }
+
+                // Break does not carry a value (spec 4.8:21)
+                if value.is_some() {
+                    return Err(CompileError::new(ErrorKind::BreakWithValue, inst.span));
+                }
+
+                // Record the break against the innermost enclosing loop, so
+                // the loop can be typed `()` instead of `!` (spec 4.8:17).
+                if let Some(broke) = ctx.loop_break_stack.last_mut() {
+                    *broke = true;
                 }
 
                 // Break has the never type - it diverges
@@ -771,10 +782,14 @@ impl<'a> Sema<'a> {
         // While loop: condition must be bool, result is Unit
         let cond_result = self.analyze_inst(air, cond, ctx)?;
 
-        // Analyze body with its own scope
+        // Analyze body with its own scope. The loop_break_stack entry makes
+        // breaks inside the body target this while loop, not an outer loop;
+        // the flag itself is unused because a while loop is always `()`.
         ctx.push_scope();
         ctx.loop_depth += 1;
+        ctx.loop_break_stack.push(false);
         let body_result = self.analyze_inst(air, body, ctx)?;
+        ctx.loop_break_stack.pop();
         ctx.loop_depth -= 1;
         ctx.pop_scope();
 
@@ -790,7 +805,9 @@ impl<'a> Sema<'a> {
                 self.analyze_inst(&mut scratch_air, cond, &mut scratch_ctx)?;
                 scratch_ctx.push_scope();
                 scratch_ctx.loop_depth += 1;
+                scratch_ctx.loop_break_stack.push(false);
                 self.analyze_inst(&mut scratch_air, body, &mut scratch_ctx)?;
+                scratch_ctx.loop_break_stack.pop();
                 scratch_ctx.loop_depth -= 1;
                 scratch_ctx.pop_scope();
                 Ok(())
@@ -817,14 +834,18 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Infinite loop: `loop { body }` - always produces Never type
+        // Infinite loop: `loop { body }` - type `()` if the body contains a
+        // break targeting this loop (the loop can exit), `!` otherwise
+        // (spec 4.8:17 / 4.8:21).
 
         // Snapshot move state before the body for the back-edge recheck below.
         let moves_before_loop = ctx.moved_vars.clone();
 
         ctx.push_scope();
         ctx.loop_depth += 1;
+        ctx.loop_break_stack.push(false);
         let body_result = self.analyze_inst(air, body, ctx)?;
+        let has_break = ctx.loop_break_stack.pop().unwrap_or(false);
         ctx.loop_depth -= 1;
         ctx.pop_scope();
 
@@ -836,20 +857,23 @@ impl<'a> Sema<'a> {
             let mut scratch_ctx = ctx.fork_for_loop_recheck();
             scratch_ctx.push_scope();
             scratch_ctx.loop_depth += 1;
+            scratch_ctx.loop_break_stack.push(false);
             self.analyze_inst(&mut scratch_air, body, &mut scratch_ctx)
                 .map_err(|e| e.with_note("value was moved in a previous iteration of the loop"))?;
+            scratch_ctx.loop_break_stack.pop();
             scratch_ctx.loop_depth -= 1;
             scratch_ctx.pop_scope();
         }
 
+        let loop_ty = if has_break { Type::UNIT } else { Type::NEVER };
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::InfiniteLoop {
                 body: body_result.air_ref,
             },
-            ty: Type::NEVER,
+            ty: loop_ty,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, Type::NEVER))
+        Ok(AnalysisResult::new(air_ref, loop_ty))
     }
 
     /// Analyze a match expression.

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -149,6 +149,10 @@ pub(crate) struct AnalysisContext<'a> {
     pub next_slot: u32,
     /// How many loops we're nested inside (for break/continue validation)
     pub loop_depth: u32,
+    /// One entry per enclosing loop (innermost last); set to `true` when a
+    /// `break` targeting that loop is analyzed. An infinite loop containing a
+    /// break has type `()`; without one it has type `!` (see spec 4.8).
+    pub loop_break_stack: Vec<bool>,
     /// Local variables that have been read (for unused variable detection)
     pub used_locals: HashSet<Spur>,
     /// Return type of the current function (for explicit return validation)
@@ -250,6 +254,7 @@ impl<'a> AnalysisContext<'a> {
             params: self.params,
             next_slot: self.next_slot,
             loop_depth: self.loop_depth,
+            loop_break_stack: self.loop_break_stack.clone(),
             used_locals: self.used_locals.clone(),
             return_type: self.return_type,
             scope_stack: self.scope_stack.clone(),

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -392,17 +392,34 @@ mod tests {
             "fn main() -> i32 {
                 let mut i = 0;
                 loop {
-                    let inner = 10;
-                    i = i + 1;
+                    let inner = 1;
+                    i = i + inner;
                     if i > 5 {
-                        break inner;
+                        break;
                     }
                 }
+                i
             }",
         );
 
         // This should compile successfully
         assert!(result.is_ok());
+
+        // Using the loop-local variable after the loop is an error
+        let result = compile_to_air(
+            "fn main() -> i32 {
+                let mut i = 0;
+                loop {
+                    let inner = 1;
+                    i = i + inner;
+                    if i > 5 {
+                        break;
+                    }
+                }
+                inner
+            }",
+        );
+        assert!(result.is_err());
     }
 
     // =========================================================================

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1324,8 +1324,10 @@ impl<'a> CfgBuilder<'a> {
                 self.cfg
                     .set_terminator(self.current_block, Terminator::Unreachable);
 
-                // Infinite loops have Never type, but if we reach exit_block via break,
-                // we need a dummy unit value for the loop expression result.
+                // A loop containing a break has type () (a loop without one is
+                // !, and its exit block is unreachable). Either way, emit a
+                // unit value as the loop expression's result for the
+                // reached-via-break path.
                 let unit_val = self.emit(CfgInstData::Const(0), Type::UNIT, span);
                 ExprResult {
                     value: Some(unit_val),

--- a/crates/rue-cli-tests/cases/loop_break.toml
+++ b/crates/rue-cli-tests/cases/loop_break.toml
@@ -1,0 +1,113 @@
+# Loop/break never-type soundness (RUE-76, RUE-56).
+#
+# A `loop` expression used to be typed `!` unconditionally, even when its body
+# contained a `break`. Consuming that "never" value (let initializer or
+# function tail) compiled cleanly and then segfaulted at runtime: the break
+# exit path produced no value and no `ret` (the binary fell off the end of the
+# function or loaded an uninitialized slot).
+#
+# Fixed in sema/inference: a `loop` containing a `break` targeting it now has
+# type `()` (spec 4.8:21), so consuming it as an i32 is a type error. A loop
+# with no break keeps type `!` (spec 4.8:17).
+#
+# Separately, `break 42` (a value operand on break) used to parse as `break`
+# followed by an unreachable expression statement and segfault the same way.
+# It is now parsed as a break-with-value and rejected by sema with E0502
+# (spec 4.8:22).
+
+[section]
+id = "cli.loop_break"
+name = "Loop/break never-type soundness"
+description = "loop-with-break is (), break-with-value is rejected (RUE-76, RUE-56)."
+
+# ── RUE-76: loop-with-break is no longer a usable `!` value ─────────────────
+
+[[case]]
+name = "loop_break_as_let_init_is_type_error"
+description = "let x: i32 = loop { break; } used to segfault (uninit load); now a type error."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = loop { break; };
+    x
+}
+""" }]
+compile_fail = true
+error_contains = ["type mismatch"]
+
+[[case]]
+name = "loop_break_as_fn_tail_is_type_error"
+description = "fn -> i32 with a loop { break; } tail used to fall off the function; now a type error."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    loop { break; }
+}
+""" }]
+compile_fail = true
+error_contains = ["type mismatch"]
+
+# Control: a loop with a break used as a statement is still fine.
+[[case]]
+name = "loop_break_as_statement_still_runs"
+description = "loop { break } as a statement has type () and compiles and runs."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut x = 0;
+    loop {
+        x = x + 1;
+        if x == 5 { break; }
+    }
+    x
+}
+""" }]
+exit_code = 5
+
+# Control: a loop with NO break keeps type ! and still coerces.
+[[case]]
+name = "loop_without_break_keeps_never_type"
+description = "loop {} still types as ! (a diverging tail needs no value)."
+files = [{ path = "main.rue", source = """
+fn never_returns() -> ! {
+    loop {}
+}
+
+fn main() -> i32 {
+    let mut x = 0;
+    loop {
+        x = x + 2;
+        if x > 5 { break; }
+    }
+    x
+}
+""" }]
+exit_code = 6
+
+# ── RUE-56: break with a value is rejected ──────────────────────────────────
+
+[[case]]
+name = "break_with_value_is_rejected"
+description = "break 42 used to compile (warning only) and segfault; now rejected with E0502."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    loop {
+        break 42;
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0502", "'break' with a value is not supported"]
+
+[[case]]
+name = "break_with_value_in_while_is_rejected"
+description = "break with a value inside while is rejected too."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut i = 0;
+    while i < 3 {
+        i = i + 1;
+        break i;
+    }
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0502", "'break' with a value is not supported"]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -129,6 +129,7 @@ impl ErrorCode {
     // ========================================================================
     pub const BREAK_OUTSIDE_LOOP: Self = Self(500);
     pub const CONTINUE_OUTSIDE_LOOP: Self = Self(501);
+    pub const BREAK_WITH_VALUE: Self = Self(502);
 
     // ========================================================================
     // Match errors (E0600-E0699)
@@ -970,6 +971,9 @@ pub enum ErrorKind {
     BreakOutsideLoop,
     #[error("'continue' outside of loop")]
     ContinueOutsideLoop,
+    /// `break` with a value operand (e.g. `break 42`); break does not carry a value
+    #[error("'break' with a value is not supported")]
+    BreakWithValue,
 
     // Match errors
     #[error("match is not exhaustive")]
@@ -1135,6 +1139,7 @@ impl ErrorKind {
             // Control flow errors (E0500-E0599)
             ErrorKind::BreakOutsideLoop => ErrorCode::BREAK_OUTSIDE_LOOP,
             ErrorKind::ContinueOutsideLoop => ErrorCode::CONTINUE_OUTSIDE_LOOP,
+            ErrorKind::BreakWithValue => ErrorCode::BREAK_WITH_VALUE,
 
             // Match errors (E0600-E0699)
             ErrorKind::NonExhaustiveMatch => ErrorCode::NON_EXHAUSTIVE_MATCH,
@@ -2178,6 +2183,10 @@ mod tests {
         assert_eq!(
             ErrorKind::ContinueOutsideLoop.code(),
             ErrorCode::CONTINUE_OUTSIDE_LOOP
+        );
+        assert_eq!(
+            ErrorKind::BreakWithValue.code(),
+            ErrorCode::BREAK_WITH_VALUE
         );
     }
 

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -853,6 +853,9 @@ pub struct LoopExpr {
 /// A break expression (exits the innermost loop).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct BreakExpr {
+    /// A value operand (e.g. `break 42`). Parsed for diagnostics, but always
+    /// rejected by semantic analysis: break does not carry a value.
+    pub value: Option<Box<Expr>>,
     pub span: Span,
 }
 
@@ -1193,7 +1196,14 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
             }
             Ok(())
         }
-        Expr::Break(_) => writeln!(f, "Break"),
+        Expr::Break(brk) => {
+            if let Some(ref value) = brk.value {
+                writeln!(f, "Break")?;
+                fmt_expr(f, value, level + 1)
+            } else {
+                writeln!(f, "Break")
+            }
+        }
         Expr::Continue(_) => writeln!(f, "Continue"),
         Expr::Return(ret) => {
             if let Some(ref value) = ret.value {

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -885,10 +885,17 @@ fn control_flow_parser<'src, I>(
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    // Break
-    let break_expr = select! {
-        TokenKind::Break = e => Expr::Break(BreakExpr { span: span_from_extra(e) }),
-    };
+    // Break: break <expr>? (a value operand parses, but sema always rejects
+    // it - break does not carry a value; parsing it gives a better diagnostic
+    // than treating the operand as a separate, unreachable statement)
+    let break_expr = just(TokenKind::Break)
+        .ignore_then(expr.clone().or_not())
+        .map_with(|value, e| {
+            Expr::Break(BreakExpr {
+                value: value.map(Box::new),
+                span: span_from_extra(e),
+            })
+        });
 
     // Continue
     let continue_expr = select! {
@@ -1698,6 +1705,10 @@ fn is_control_flow_expr(e: &Expr) -> bool {
 /// Returns true if the expression diverges (has the Never type).
 /// These expressions can be promoted to the final expression of a block
 /// since Never coerces to any type.
+///
+/// `loop` is included even though a loop containing a `break` has type `()`
+/// rather than `!`: promotion is still transparent, because the block's value
+/// becomes exactly the loop expression's value either way.
 fn is_diverging_expr(e: &Expr) -> bool {
     matches!(
         e,

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -510,10 +510,13 @@ impl<'a> AstGen<'a> {
                     span: call.span,
                 })
             }
-            Expr::Break(break_expr) => self.rir.add_inst(Inst {
-                data: InstData::Break,
-                span: break_expr.span,
-            }),
+            Expr::Break(break_expr) => {
+                let value = break_expr.value.as_ref().map(|v| self.gen_expr(v));
+                self.rir.add_inst(Inst {
+                    data: InstData::Break { value },
+                    span: break_expr.span,
+                })
+            }
             Expr::Continue(continue_expr) => self.rir.add_inst(Inst {
                 data: InstData::Continue,
                 span: continue_expr.span,

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -796,7 +796,6 @@ impl Rir {
             InstData::BoolConst(v) => InstData::BoolConst(*v),
             InstData::StringConst(s) => InstData::StringConst(*s),
             InstData::UnitConst => InstData::UnitConst,
-            InstData::Break => InstData::Break,
             InstData::Continue => InstData::Continue,
             InstData::VarRef { name } => InstData::VarRef { name: *name },
             InstData::ParamRef { index, name } => InstData::ParamRef {
@@ -920,6 +919,9 @@ impl Rir {
                 body: renumber(*body),
             },
             InstData::Ret(value) => InstData::Ret(renumber_opt(*value)),
+            InstData::Break { value } => InstData::Break {
+                value: renumber_opt(*value),
+            },
 
             // Match - InstRefs in extra are handled separately
             InstData::Match {
@@ -1314,7 +1316,7 @@ impl Rir {
                 | InstData::Branch { .. }
                 | InstData::Loop { .. }
                 | InstData::InfiniteLoop { .. }
-                | InstData::Break
+                | InstData::Break { .. }
                 | InstData::Continue
                 | InstData::Ret(_)
                 | InstData::VarRef { .. }
@@ -1439,8 +1441,11 @@ pub enum InstData {
         arms_len: u32,
     },
 
-    /// Break: exits the innermost loop
-    Break,
+    /// Break: exits the innermost loop.
+    /// `value` is a value operand (e.g. `break 42`); it is carried through
+    /// for diagnostics but always rejected by sema - break does not carry a
+    /// value (see spec 4.8).
+    Break { value: Option<InstRef> },
 
     /// Continue: jumps to the next iteration of the innermost loop
     Continue,
@@ -1883,7 +1888,10 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         .collect();
                     writeln!(out, "match {} {{ {} }}", scrutinee, arms_str.join(", ")).unwrap();
                 }
-                InstData::Break => writeln!(out, "break").unwrap(),
+                InstData::Break { value } => match value {
+                    Some(v) => writeln!(out, "break {}", v).unwrap(),
+                    None => writeln!(out, "break").unwrap(),
+                },
                 InstData::Continue => writeln!(out, "continue").unwrap(),
 
                 // Functions
@@ -2685,7 +2693,7 @@ mod tests {
     fn test_printer_break_continue() {
         let (mut rir, interner) = create_printer_test_rir();
         rir.add_inst(Inst {
-            data: InstData::Break,
+            data: InstData::Break { value: None },
             span: Span::new(0, 5),
         });
         rir.add_inst(Inst {

--- a/crates/rue-spec/cases/expressions/while.toml
+++ b/crates/rue-spec/cases/expressions/while.toml
@@ -258,9 +258,9 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
-name = "loop_has_never_type_even_with_break"
-spec = ["4.8:17", "4.8:21"]
-description = "loop expression type remains ! even when break is present; break does not carry a value"
+name = "loop_with_break_has_unit_type"
+spec = ["4.8:21"]
+description = "a loop containing a break has type (), so it is fine as a statement"
 source = """
 fn main() -> i32 {
     let mut x = 0;
@@ -272,6 +272,59 @@ fn main() -> i32 {
 }
 """
 exit_code = 5
+
+[[case]]
+name = "loop_with_break_not_usable_as_i32_value"
+spec = ["4.8:21"]
+description = "a loop containing a break has type (), so binding it to an i32 is a type error (RUE-76)"
+source = """
+fn main() -> i32 {
+    let x: i32 = loop { break; };
+    x
+}
+"""
+compile_fail = true
+error_contains = "type mismatch"
+
+[[case]]
+name = "loop_with_break_not_usable_as_i32_tail"
+spec = ["4.8:21"]
+description = "a loop containing a break has type (), so it cannot be the tail of an i32 function (RUE-76)"
+source = """
+fn main() -> i32 {
+    loop { break; }
+}
+"""
+compile_fail = true
+error_contains = "type mismatch"
+
+[[case]]
+name = "break_with_value_is_error"
+spec = ["4.8:22"]
+description = "break does not carry a value; a value operand is a compile-time error (RUE-56)"
+source = """
+fn main() -> i32 {
+    loop {
+        break 42;
+    }
+}
+"""
+compile_fail = true
+error_contains = "'break' with a value is not supported"
+
+[[case]]
+name = "break_with_value_in_while_is_error"
+spec = ["4.8:22"]
+source = """
+fn main() -> i32 {
+    while true {
+        break 1;
+    }
+    0
+}
+"""
+compile_fail = true
+error_contains = "'break' with a value is not supported"
 
 [[case]]
 name = "loop_nested_break"

--- a/docs/spec/src/04-expressions/08-loop-expressions.md
+++ b/docs/spec/src/04-expressions/08-loop-expressions.md
@@ -58,7 +58,7 @@ loop_expr = "loop" "{" block "}" ;
 
 {{ rule(id="4.8:17", cat="normative") }}
 
-A loop expression has type `!` (never), because it never produces a value. Even when `break` is present, the loop expression itself does not yield a result.
+A loop expression that contains no `break` targeting it has type `!` (never), because it never produces a value.
 
 {{ rule(id="4.8:18", cat="normative") }}
 
@@ -115,7 +115,11 @@ Both `break` and `continue` have the never type `!`.
 
 {{ rule(id="4.8:21", cat="normative") }}
 
-Currently, `break` does not carry a value. A `loop` expression has type `!` regardless of whether `break` is reachable, because the loop itself does not produce a value.
+A `loop` expression that contains a `break` targeting it has type `()`: executing the `break` exits the loop, which then evaluates to `()`. This holds even if the `break` is unreachable.
+
+{{ rule(id="4.8:22", cat="legality-rule") }}
+
+Currently, `break` does not carry a value. A `break` expression **MUST NOT** have a value operand; `break expr` is a compile-time error.
 
 {{ rule(id="4.8:11") }}
 


### PR DESCRIPTION
Two repro-confirmed miscompiles from the never-type/loop interaction, both
producing memory-unsafe binaries from innocuous source:

- `let x: i32 = loop { break; }; x` compiled cleanly and segfaulted: the
  loop expression was typed `!` unconditionally, so binding it passed type
  checking, but the break-exit path never produced a value — the binding
  read an uninitialized slot. As a function tail expression the break-exit
  block had no ret and control fell off the end of the function. (RUE-76)
- `loop { break 42; }` parsed as `break` plus an unreachable expression
  statement, compiled with only a warning, and segfaulted the same way —
  the spec forbids a value operand on break. (RUE-56)

Sema (both implementations) and HM inference now track a per-loop break
flag (loop_break_stack): a loop containing a break that targets it is typed
`()` — Rust semantics — so both RUE-76 repros become honest E0206 type
errors; a loop with no reachable break keeps type `!` (still usable in
never position). The parser now parses an optional value operand on break
(carried through RIR) and sema rejects it with new diagnostic E0502
"'break' with a value is not supported"; inference deliberately does not
count a valued break as a loop exit so E0502 surfaces rather than a
confusing type mismatch.

Spec: 4.8:17 rewritten (no-break loop is !), 4.8:21 rewritten (loop with
break is ()), new legality rule 4.8:22 (break must not carry a value).
Traceability stays 100%.

Tests: CLI cases in crates/rue-cli-tests/cases/loop_break.toml (both
repros as compile_fail, break-as-statement and no-break controls,
break-with-value in loop and while); spec cases for 4.8:21/4.8:22.
Full test.sh green.

Fixes RUE-76
Fixes RUE-56



🤖 Generated with [Claude Code](https://claude.com/claude-code)
