### PR TITLE
Mark place-traced variables as used in the unused-variable lint

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -137,7 +137,19 @@ impl<'a> Sema<'a> {
         air: &mut Air,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<Option<PlaceTrace>> {
-        self.try_trace_place_inner(inst_ref, air, ctx)
+        let trace = self.try_trace_place_inner(inst_ref, air, ctx)?;
+        if let Some(trace) = &trace {
+            // Any place access through a projection (field read `s.a`, array
+            // index `a[i]`, method receiver `h.s.len()`, field/index write
+            // `s.a = ...`) uses its root variable. Mark it here, at the single
+            // shared tracing point, so the unused-variable lint doesn't fire
+            // on variables that are only accessed through projections
+            // (RUE-135). Direct assignment to the variable itself (`x = 5`)
+            // does not go through place tracing and intentionally still
+            // counts as unused.
+            ctx.used_locals.insert(trace.root_var);
+        }
+        Ok(trace)
     }
 
     /// Inner implementation that accumulates projections.

--- a/crates/rue-ui-tests/cases/warnings/unused.toml
+++ b/crates/rue-ui-tests/cases/warnings/unused.toml
@@ -197,6 +197,126 @@ warning_contains = ["unused variable 'x' (line", "line 2)", "line 4)"]
 expected_warning_count = 2
 
 # =============================================================================
+# Place reads mark the base variable as used (RUE-135)
+# =============================================================================
+
+[[case]]
+name = "field_read_in_tail_position_no_warning"
+description = "A tail-position field read uses the base variable (RUE-135)"
+source = """
+struct S { a: i32 }
+
+fn main() -> i32 {
+    let s = S { a: 5 };
+    s.a
+}
+"""
+exit_code = 5
+no_warnings = true
+
+[[case]]
+name = "method_call_on_field_receiver_no_warning"
+description = "A method call on a field receiver uses the base variable (RUE-135)"
+source = """
+struct H { s: String }
+
+fn main() -> i32 {
+    let h = H { s: "hello" };
+    let n = h.s.len();
+    if n == 5 { 5 } else { 0 }
+}
+"""
+exit_code = 5
+no_warnings = true
+
+[[case]]
+name = "field_read_as_call_argument_no_warning"
+description = "Passing a field read as a call argument uses the base variable (RUE-135)"
+source = """
+struct S { a: i32 }
+
+fn g(x: i32) -> i32 { x }
+
+fn main() -> i32 {
+    let s = S { a: 5 };
+    g(s.a)
+}
+"""
+exit_code = 5
+no_warnings = true
+
+[[case]]
+name = "array_index_read_no_warning"
+description = "Indexing an array uses the base variable (RUE-135)"
+source = """
+fn main() -> i32 {
+    let a = [7, 2, 3];
+    a[0]
+}
+"""
+exit_code = 7
+no_warnings = true
+
+[[case]]
+name = "dbg_field_operand_no_warning"
+description = "A field read as a @dbg operand uses the base variable (RUE-135)"
+source = """
+struct S { a: i32 }
+
+fn main() -> i32 {
+    let s = S { a: 5 };
+    @dbg(s.a);
+    0
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "field_write_counts_as_use"
+description = "Writing through a projection (s.a = ...) uses the base variable"
+source = """
+struct S { a: i32 }
+
+fn main() -> i32 {
+    let mut s = S { a: 5 };
+    s.a = 7;
+    0
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "unused_struct_variable_still_warns"
+description = "A struct variable that is never read or projected still warns"
+source = """
+struct S { a: i32 }
+
+fn main() -> i32 {
+    let s = S { a: 5 };
+    0
+}
+"""
+exit_code = 0
+warning_contains = ["unused variable", "'s'"]
+expected_warning_count = 1
+
+[[case]]
+name = "direct_assignment_only_still_warns"
+description = "Assigning directly to a variable (not through a projection) does not count as a use"
+source = """
+fn main() -> i32 {
+    let mut x = 5;
+    x = 6;
+    0
+}
+"""
+exit_code = 0
+warning_contains = ["unused variable", "'x'"]
+expected_warning_count = 1
+
+# =============================================================================
 # Unused Functions
 # =============================================================================
 


### PR DESCRIPTION
Sema's place-tracing path (Sema::try_trace_place) emitted PlaceRead and
PlaceWrite for projections — field reads, array indexing, method receivers,
call arguments, @dbg operands — without ever inserting the root variable
into used_locals. Only the comparison path and bare VarRef loads marked
usage, so a variable accessed solely through a projection warned as unused:
a tail-position `s.a`, `let x = s.a`, `g(s.a)`, `a[0]`, `@dbg(s.a)`, and a
method call on a field receiver (`h.s.len()`) all fired the lint on a
clearly-used variable. (`s.a == 5` happened to be fine because comparisons
take a different path — which is why the gap survived.)

One marking point fixes the family: the try_trace_place wrapper now inserts
the trace's root variable into used_locals on every successful trace. This
also makes projection writes (`s.a = 7`) count as a use, matching Rust's
lint; direct assignment to the variable itself (`x = 6`) does not go
through place tracing and intentionally still warns.

Eight new UI cases in crates/rue-ui-tests/cases/warnings/unused.toml: both
RUE-135 repros plus call-argument / array-index / @dbg / field-write
no-warning cases, and two still-warns controls (genuinely unused struct
variable; direct-assignment-only variable). Full test.sh green.

Fixes RUE-135



🤖 Generated with [Claude Code](https://claude.com/claude-code)
