### PR TITLE
Unify consumer-side aggregate store loops into agg_slots (RUE-121 phase 3)

### DIFF
--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1205,15 +1205,7 @@ impl<'a> CfgLower<'a> {
                 if init_type.is_array() {
                     // Array: recursively flatten nested arrays and store scalar elements
                     let scalar_vregs = self.collect_array_scalar_vregs(*init);
-                    for (i, scalar_vreg) in scalar_vregs.iter().enumerate() {
-                        let elem_slot = slot + i as u32;
-                        let offset = self.ctx.local_offset(elem_slot);
-                        self.mir.push(Aarch64Inst::Str {
-                            src: Operand::Virtual(*scalar_vreg),
-                            base: Reg::Fp,
-                            offset,
-                        });
-                    }
+                    crate::agg_slots::store_slots(self, &scalar_vregs, *slot);
                 } else if init_type.is_struct() && !self.ctx.is_builtin_string(init_type) {
                     // Struct: store all slots via the single accessor. It materializes a
                     // struct read from a place (`let q = a.p`) by loading its slot_count
@@ -1225,15 +1217,7 @@ impl<'a> CfgLower<'a> {
                     let scalar_vregs = self
                         .get_or_compute_field_vregs(*init)
                         .unwrap_or_else(|| self.collect_struct_scalar_vregs(*init));
-                    for (i, scalar_vreg) in scalar_vregs.iter().enumerate() {
-                        let field_slot = slot + i as u32;
-                        let offset = self.ctx.local_offset(field_slot);
-                        self.mir.push(Aarch64Inst::Str {
-                            src: Operand::Virtual(*scalar_vreg),
-                            base: Reg::Fp,
-                            offset,
-                        });
-                    }
+                    crate::agg_slots::store_slots(self, &scalar_vregs, *slot);
                 } else if self.ctx.is_builtin_string(init_type) {
                     // String: store ptr, len, and cap to consecutive slots
                     let field_vregs = self
@@ -1244,34 +1228,7 @@ impl<'a> CfgLower<'a> {
                         3,
                         "string should have 3 fields (ptr, len, cap)"
                     );
-
-                    let ptr_vreg = field_vregs[0];
-                    let len_vreg = field_vregs[1];
-                    let cap_vreg = field_vregs[2];
-
-                    // Store ptr to slot
-                    let ptr_offset = self.ctx.local_offset(*slot);
-                    self.mir.push(Aarch64Inst::Str {
-                        src: Operand::Virtual(ptr_vreg),
-                        base: Reg::Fp,
-                        offset: ptr_offset,
-                    });
-
-                    // Store len to slot + 1
-                    let len_offset = self.ctx.local_offset(slot + 1);
-                    self.mir.push(Aarch64Inst::Str {
-                        src: Operand::Virtual(len_vreg),
-                        base: Reg::Fp,
-                        offset: len_offset,
-                    });
-
-                    // Store cap to slot + 2
-                    let cap_offset = self.ctx.local_offset(slot + 2);
-                    self.mir.push(Aarch64Inst::Str {
-                        src: Operand::Virtual(cap_vreg),
-                        base: Reg::Fp,
-                        offset: cap_offset,
-                    });
+                    crate::agg_slots::store_slots(self, &field_vregs, *slot);
                 } else {
                     let init_vreg = self.get_vreg(*init);
                     let offset = self.ctx.local_offset(*slot);
@@ -1405,22 +1362,9 @@ impl<'a> CfgLower<'a> {
                         // slots descend from the pointer (stack grows down), so
                         // slot i lives at ptr - i*8 — matching the place-read path.
                         let ptr_vreg = self.ensure_inout_param_ptr(param_index);
-                        for (i, slot_vreg) in slot_vregs.iter().enumerate() {
-                            self.mir.push(Aarch64Inst::StrIndexedOffset {
-                                src: Operand::Virtual(*slot_vreg),
-                                base: ptr_vreg,
-                                offset: -((i as i32) * 8),
-                            });
-                        }
+                        crate::agg_slots::store_slots_through_ptr(self, &slot_vregs, ptr_vreg, 0);
                     } else {
-                        for (i, slot_vreg) in slot_vregs.iter().enumerate() {
-                            let offset = self.ctx.local_offset(slot + i as u32);
-                            self.mir.push(Aarch64Inst::Str {
-                                src: Operand::Virtual(*slot_vreg),
-                                base: Reg::Fp,
-                                offset,
-                            });
-                        }
+                        crate::agg_slots::store_slots(self, &slot_vregs, *slot);
                     }
                 } else {
                     let val_vreg = self.get_vreg(*val);
@@ -3841,37 +3785,17 @@ impl<'a> CfgLower<'a> {
         if projections.is_empty() {
             match place.base {
                 PlaceBase::Local(slot) => {
-                    for (i, val_vreg) in vals.iter().enumerate() {
-                        let offset = self.ctx.local_offset(slot + i as u32);
-                        self.mir.push(Aarch64Inst::Str {
-                            src: Operand::Virtual(*val_vreg),
-                            base: Reg::Fp,
-                            offset,
-                        });
-                    }
+                    crate::agg_slots::store_slots(self, vals, slot);
                 }
                 PlaceBase::Param(param_slot) => {
                     if self.ctx.cfg.is_param_inout(param_slot) {
                         // Inout param - store through the pointer
                         let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
-                        for (i, val_vreg) in vals.iter().enumerate() {
-                            self.mir.push(Aarch64Inst::StrIndexedOffset {
-                                src: Operand::Virtual(*val_vreg),
-                                base: ptr_vreg,
-                                offset: -((i as i32) * 8),
-                            });
-                        }
+                        crate::agg_slots::store_slots_through_ptr(self, vals, ptr_vreg, 0);
                     } else {
                         // Normal param - store to local slot
                         let slot = self.ctx.num_locals + param_slot;
-                        for (i, val_vreg) in vals.iter().enumerate() {
-                            let offset = self.ctx.local_offset(slot + i as u32);
-                            self.mir.push(Aarch64Inst::Str {
-                                src: Operand::Virtual(*val_vreg),
-                                base: Reg::Fp,
-                                offset,
-                            });
-                        }
+                        crate::agg_slots::store_slots(self, vals, slot);
                     }
                 }
             }
@@ -3945,22 +3869,9 @@ impl<'a> CfgLower<'a> {
                         src1: Operand::Virtual(addr_vreg),
                         src2: Operand::Virtual(dyn_offset),
                     });
-                    for (i, val_vreg) in vals.iter().enumerate() {
-                        self.mir.push(Aarch64Inst::StrIndexedOffset {
-                            src: Operand::Virtual(*val_vreg),
-                            base: addr_vreg,
-                            offset: -((i as i32) * 8),
-                        });
-                    }
+                    crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
                 } else {
-                    for (i, val_vreg) in vals.iter().enumerate() {
-                        let offset = self.ctx.local_offset(base_slot + i as u32);
-                        self.mir.push(Aarch64Inst::Str {
-                            src: Operand::Virtual(*val_vreg),
-                            base: Reg::Fp,
-                            offset,
-                        });
-                    }
+                    crate::agg_slots::store_slots(self, vals, base_slot);
                 }
             }
             PlaceBase::Param(param_slot) => {
@@ -3986,21 +3897,14 @@ impl<'a> CfgLower<'a> {
                             src1: Operand::Virtual(addr_vreg),
                             src2: Operand::Virtual(dyn_offset),
                         });
-                        for (i, val_vreg) in vals.iter().enumerate() {
-                            self.mir.push(Aarch64Inst::StrIndexedOffset {
-                                src: Operand::Virtual(*val_vreg),
-                                base: addr_vreg,
-                                offset: -((i as i32) * 8),
-                            });
-                        }
+                        crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
                     } else {
-                        for (i, val_vreg) in vals.iter().enumerate() {
-                            self.mir.push(Aarch64Inst::StrIndexedOffset {
-                                src: Operand::Virtual(*val_vreg),
-                                base: ptr_vreg,
-                                offset: -static_byte_offset - (i as i32) * 8,
-                            });
-                        }
+                        crate::agg_slots::store_slots_through_ptr(
+                            self,
+                            vals,
+                            ptr_vreg,
+                            static_byte_offset,
+                        );
                     }
                 } else {
                     let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
@@ -4018,22 +3922,9 @@ impl<'a> CfgLower<'a> {
                             src1: Operand::Virtual(addr_vreg),
                             src2: Operand::Virtual(dyn_offset),
                         });
-                        for (i, val_vreg) in vals.iter().enumerate() {
-                            self.mir.push(Aarch64Inst::StrIndexedOffset {
-                                src: Operand::Virtual(*val_vreg),
-                                base: addr_vreg,
-                                offset: -((i as i32) * 8),
-                            });
-                        }
+                        crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
                     } else {
-                        for (i, val_vreg) in vals.iter().enumerate() {
-                            let offset = self.ctx.local_offset(base_slot + i as u32);
-                            self.mir.push(Aarch64Inst::Str {
-                                src: Operand::Virtual(*val_vreg),
-                                base: Reg::Fp,
-                                offset,
-                            });
-                        }
+                        crate::agg_slots::store_slots(self, vals, base_slot);
                     }
                 }
             }
@@ -4257,6 +4148,21 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     }
     fn collect_array_scalars(&mut self, value: CfgValue) -> Vec<VReg> {
         self.collect_array_scalar_vregs(value)
+    }
+    fn emit_store_slot(&mut self, src: VReg, slot: u32) {
+        let offset = self.ctx.local_offset(slot);
+        self.mir.push(Aarch64Inst::Str {
+            src: Operand::Virtual(src),
+            base: Reg::Fp,
+            offset,
+        });
+    }
+    fn emit_store_through_ptr(&mut self, src: VReg, ptr: VReg, byte_offset: i32) {
+        self.mir.push(Aarch64Inst::StrIndexedOffset {
+            src: Operand::Virtual(src),
+            base: ptr,
+            offset: byte_offset,
+        });
     }
 }
 

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -16,10 +16,11 @@
 //!
 //! Phase 1 covered the slot accessor. Phase 2 moved the StructInit/ArrayInit
 //! flattening (the eager population of the slot cache) here as
-//! [`lower_struct_init`]/[`lower_array_init`]. The consumer-side store loops
-//! still live per-backend; they migrate in later phases once their (currently
-//! subtly different) behaviors are reconciled deliberately rather than
-//! incidentally.
+//! [`lower_struct_init`]/[`lower_array_init`]. Phase 3 moved the consumer-side
+//! store loops here as [`store_slots`]/[`store_slots_through_ptr`] — every
+//! site that writes an aggregate's slots (Alloc, Store, PlaceWrite, inout
+//! writeback) iterates via these two primitives. Remaining per-backend:
+//! call-arg/return marshalling and the scheduler/liveness tables.
 
 use std::collections::HashMap;
 
@@ -62,6 +63,12 @@ pub trait SlotBackend {
     /// Recursively collect the scalar slot vregs of an array value
     /// (the backends' thin wrapper over `types::collect_array_scalar_vregs`).
     fn collect_array_scalars(&mut self, value: CfgValue) -> Vec<VReg>;
+
+    /// Emit a store of `src` to frame slot `slot`.
+    fn emit_store_slot(&mut self, src: VReg, slot: u32);
+
+    /// Emit a store of `src` through pointer `ptr` at `byte_offset` from it.
+    fn emit_store_through_ptr(&mut self, src: VReg, ptr: VReg, byte_offset: i32);
 }
 
 /// Get or compute the slot vregs for a multi-slot aggregate value
@@ -225,6 +232,28 @@ pub fn lower_array_init<B: SlotBackend>(
     b.slot_cache().insert(value, element_vregs);
 
     b.emit_load_zero(vreg);
+}
+
+/// Store `vals` to consecutive frame slots starting at `base_slot`
+/// (slot `base_slot + i` gets `vals[i]`).
+pub fn store_slots<B: SlotBackend>(b: &mut B, vals: &[VReg], base_slot: u32) {
+    for (i, val) in vals.iter().enumerate() {
+        b.emit_store_slot(*val, base_slot + i as u32);
+    }
+}
+
+/// Store `vals` through `ptr` at descending byte offsets: `vals[i]` goes to
+/// `ptr - static_byte_offset - i*8`. Caller-frame slots descend from an inout
+/// pointer (the stack grows down), matching the place-read path.
+pub fn store_slots_through_ptr<B: SlotBackend>(
+    b: &mut B,
+    vals: &[VReg],
+    ptr: VReg,
+    static_byte_offset: i32,
+) {
+    for (i, val) in vals.iter().enumerate() {
+        b.emit_store_through_ptr(*val, ptr, -static_byte_offset - (i as i32) * 8);
+    }
 }
 
 /// Load `count` consecutive frame slots starting at `base_slot`, returning the

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1446,15 +1446,7 @@ impl<'a> CfgLower<'a> {
                 if matches!(init_type.kind(), TypeKind::Array(_)) {
                     // Array: recursively flatten nested arrays and store scalar elements
                     let scalar_vregs = self.collect_array_scalar_vregs(*init);
-                    for (i, scalar_vreg) in scalar_vregs.iter().enumerate() {
-                        let elem_slot = slot + i as u32;
-                        let offset = self.ctx.local_offset(elem_slot);
-                        self.mir.push(X86Inst::MovMR {
-                            base: Reg::Rbp,
-                            offset,
-                            src: Operand::Virtual(*scalar_vreg),
-                        });
-                    }
+                    crate::agg_slots::store_slots(self, &scalar_vregs, *slot);
                 } else if self.ctx.is_builtin_string(init_type) {
                     // Builtin String: store ptr, len, and cap to consecutive slots
                     // Check this before generic Struct case so builtin String uses this path
@@ -1466,34 +1458,7 @@ impl<'a> CfgLower<'a> {
                         3,
                         "string should have 3 fields (ptr, len, cap)"
                     );
-
-                    let ptr_vreg = field_vregs[0];
-                    let len_vreg = field_vregs[1];
-                    let cap_vreg = field_vregs[2];
-
-                    // Store ptr to slot
-                    let ptr_offset = self.ctx.local_offset(*slot);
-                    self.mir.push(X86Inst::MovMR {
-                        base: Reg::Rbp,
-                        offset: ptr_offset,
-                        src: Operand::Virtual(ptr_vreg),
-                    });
-
-                    // Store len to slot + 1
-                    let len_offset = self.ctx.local_offset(slot + 1);
-                    self.mir.push(X86Inst::MovMR {
-                        base: Reg::Rbp,
-                        offset: len_offset,
-                        src: Operand::Virtual(len_vreg),
-                    });
-
-                    // Store cap to slot + 2
-                    let cap_offset = self.ctx.local_offset(slot + 2);
-                    self.mir.push(X86Inst::MovMR {
-                        base: Reg::Rbp,
-                        offset: cap_offset,
-                        src: Operand::Virtual(cap_vreg),
-                    });
+                    crate::agg_slots::store_slots(self, &field_vregs, *slot);
                 } else if matches!(init_type.kind(), TypeKind::Struct(_)) {
                     // Struct: store all slots via the single accessor. It materializes a
                     // struct read from a place (`let q = a.p`) by loading its slot_count
@@ -1504,15 +1469,7 @@ impl<'a> CfgLower<'a> {
                     let scalar_vregs = self
                         .get_or_compute_field_vregs(*init)
                         .unwrap_or_else(|| self.collect_struct_scalar_vregs(*init));
-                    for (i, scalar_vreg) in scalar_vregs.iter().enumerate() {
-                        let field_slot = slot + i as u32;
-                        let offset = self.ctx.local_offset(field_slot);
-                        self.mir.push(X86Inst::MovMR {
-                            base: Reg::Rbp,
-                            offset,
-                            src: Operand::Virtual(*scalar_vreg),
-                        });
-                    }
+                    crate::agg_slots::store_slots(self, &scalar_vregs, *slot);
                 } else {
                     let init_vreg = self.get_vreg(*init);
                     let offset = self.ctx.local_offset(*slot);
@@ -1648,22 +1605,9 @@ impl<'a> CfgLower<'a> {
                         // slots descend from the pointer (stack grows down), so
                         // slot i lives at ptr - i*8 — matching the place-read path.
                         let ptr_vreg = self.ensure_inout_param_ptr(param_index);
-                        for (i, slot_vreg) in slot_vregs.iter().enumerate() {
-                            self.mir.push(X86Inst::MovMRIndexed {
-                                base: ptr_vreg,
-                                offset: -((i as i32) * 8),
-                                src: Operand::Virtual(*slot_vreg),
-                            });
-                        }
+                        crate::agg_slots::store_slots_through_ptr(self, &slot_vregs, ptr_vreg, 0);
                     } else {
-                        for (i, slot_vreg) in slot_vregs.iter().enumerate() {
-                            let offset = self.ctx.local_offset(slot + i as u32);
-                            self.mir.push(X86Inst::MovMR {
-                                base: Reg::Rbp,
-                                offset,
-                                src: Operand::Virtual(*slot_vreg),
-                            });
-                        }
+                        crate::agg_slots::store_slots(self, &slot_vregs, *slot);
                     }
                 } else {
                     let val_vreg = self.get_vreg(*val);
@@ -3815,37 +3759,17 @@ impl<'a> CfgLower<'a> {
         if projections.is_empty() {
             match place.base {
                 PlaceBase::Local(slot) => {
-                    for (i, val_vreg) in vals.iter().enumerate() {
-                        let offset = self.ctx.local_offset(slot + i as u32);
-                        self.mir.push(X86Inst::MovMR {
-                            base: Reg::Rbp,
-                            offset,
-                            src: Operand::Virtual(*val_vreg),
-                        });
-                    }
+                    crate::agg_slots::store_slots(self, vals, slot);
                 }
                 PlaceBase::Param(param_slot) => {
                     if self.ctx.cfg.is_param_inout(param_slot) {
                         // Inout param - store through the pointer
                         let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
-                        for (i, val_vreg) in vals.iter().enumerate() {
-                            self.mir.push(X86Inst::MovMRIndexed {
-                                base: ptr_vreg,
-                                offset: -((i as i32) * 8),
-                                src: Operand::Virtual(*val_vreg),
-                            });
-                        }
+                        crate::agg_slots::store_slots_through_ptr(self, vals, ptr_vreg, 0);
                     } else {
                         // Normal param - store to local slot
                         let slot = self.ctx.num_locals + param_slot;
-                        for (i, val_vreg) in vals.iter().enumerate() {
-                            let offset = self.ctx.local_offset(slot + i as u32);
-                            self.mir.push(X86Inst::MovMR {
-                                base: Reg::Rbp,
-                                offset,
-                                src: Operand::Virtual(*val_vreg),
-                            });
-                        }
+                        crate::agg_slots::store_slots(self, vals, slot);
                     }
                 }
             }
@@ -3920,22 +3844,9 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(addr_vreg),
                         src: Operand::Virtual(dyn_offset),
                     });
-                    for (i, val_vreg) in vals.iter().enumerate() {
-                        self.mir.push(X86Inst::MovMRIndexed {
-                            base: addr_vreg,
-                            offset: -((i as i32) * 8),
-                            src: Operand::Virtual(*val_vreg),
-                        });
-                    }
+                    crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
                 } else {
-                    for (i, val_vreg) in vals.iter().enumerate() {
-                        let offset = self.ctx.local_offset(base_slot + i as u32);
-                        self.mir.push(X86Inst::MovMR {
-                            base: Reg::Rbp,
-                            offset,
-                            src: Operand::Virtual(*val_vreg),
-                        });
-                    }
+                    crate::agg_slots::store_slots(self, vals, base_slot);
                 }
             }
             PlaceBase::Param(param_slot) => {
@@ -3964,21 +3875,14 @@ impl<'a> CfgLower<'a> {
                             dst: Operand::Virtual(addr_vreg),
                             src: Operand::Virtual(dyn_offset),
                         });
-                        for (i, val_vreg) in vals.iter().enumerate() {
-                            self.mir.push(X86Inst::MovMRIndexed {
-                                base: addr_vreg,
-                                offset: -((i as i32) * 8),
-                                src: Operand::Virtual(*val_vreg),
-                            });
-                        }
+                        crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
                     } else {
-                        for (i, val_vreg) in vals.iter().enumerate() {
-                            self.mir.push(X86Inst::MovMRIndexed {
-                                base: ptr_vreg,
-                                offset: -static_byte_offset - (i as i32) * 8,
-                                src: Operand::Virtual(*val_vreg),
-                            });
-                        }
+                        crate::agg_slots::store_slots_through_ptr(
+                            self,
+                            vals,
+                            ptr_vreg,
+                            static_byte_offset,
+                        );
                     }
                 } else {
                     let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
@@ -3997,22 +3901,9 @@ impl<'a> CfgLower<'a> {
                             dst: Operand::Virtual(addr_vreg),
                             src: Operand::Virtual(dyn_offset),
                         });
-                        for (i, val_vreg) in vals.iter().enumerate() {
-                            self.mir.push(X86Inst::MovMRIndexed {
-                                base: addr_vreg,
-                                offset: -((i as i32) * 8),
-                                src: Operand::Virtual(*val_vreg),
-                            });
-                        }
+                        crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
                     } else {
-                        for (i, val_vreg) in vals.iter().enumerate() {
-                            let offset = self.ctx.local_offset(base_slot + i as u32);
-                            self.mir.push(X86Inst::MovMR {
-                                base: Reg::Rbp,
-                                offset,
-                                src: Operand::Virtual(*val_vreg),
-                            });
-                        }
+                        crate::agg_slots::store_slots(self, vals, base_slot);
                     }
                 }
             }
@@ -4238,6 +4129,21 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
     }
     fn collect_array_scalars(&mut self, value: CfgValue) -> Vec<VReg> {
         self.collect_array_scalar_vregs(value)
+    }
+    fn emit_store_slot(&mut self, src: VReg, slot: u32) {
+        let offset = self.ctx.local_offset(slot);
+        self.mir.push(X86Inst::MovMR {
+            base: Reg::Rbp,
+            offset,
+            src: Operand::Virtual(src),
+        });
+    }
+    fn emit_store_through_ptr(&mut self, src: VReg, ptr: VReg, byte_offset: i32) {
+        self.mir.push(X86Inst::MovMRIndexed {
+            base: ptr,
+            offset: byte_offset,
+            src: Operand::Virtual(src),
+        });
     }
 }
 


### PR DESCRIPTION
Phase 3 of the backend dedup: every site that writes an aggregate's slots —
the Alloc arm (array/struct/String branches), the Store arm's whole-aggregate
paths, and all nine store loops in lower_place_write /
lower_place_write_with_projections (frame-slot stores, inout-pointer stores,
and dynamically-addressed stores) — was a hand-mirrored loop pair across the
two cfg_lower.rs files. They now iterate via two shared primitives in
agg_slots.rs:

  store_slots(vals, base_slot)                    one frame store per slot
  store_slots_through_ptr(vals, ptr, static_off)  descending ptr - off - i*8

SlotBackend grows the two corresponding leaf methods (emit_store_slot =
MovMR/Str; emit_store_through_ptr = MovMRIndexed/StrIndexedOffset). The
Alloc String branch's three unrolled stores collapse into the same
store_slots call (the 3-slot shape is already pinned by the debug_assert on
the accessor result). Address computation for dynamic indices stays
per-backend (Lea/SubRR64 vs AddImm/SubRR — genuinely different instruction
selection).

Verified behavior-preserving the same way as phases 1-2: --emit asm is
byte-identical before/after on the 37-program aggregate corpus on BOTH
x86-64 and aarch64 at the same base. Full test.sh green.

Remaining in RUE-121: call-arg/return marshalling (phase 4), then the
scheduler/liveness tables.

Part of RUE-121.



🤖 Generated with [Claude Code](https://claude.com/claude-code)
