### PR TITLE
RIR/driver: stop dropping stray intrinsic type-args; renumber merged Path patterns; dedup symbol detection

### DIFF
--- a/crates/rue-cli-tests/cases/intrinsic_args.toml
+++ b/crates/rue-cli-tests/cases/intrinsic_args.toml
@@ -1,0 +1,44 @@
+# Intrinsic argument lowering through the real driver.
+#
+# AstGen used to silently DROP a stray type argument to an expression
+# intrinsic: `@syscall(a, (), b)` lowered to `@syscall(a, b)`, shifting `b`
+# into the wrong syscall register and compiling cleanly — a silent
+# miscompile (RUE-130 item 8). The type argument is now lowered to a
+# placeholder so Sema reports a proper type error instead.
+
+[section]
+id = "cli.intrinsic_args"
+name = "Intrinsic argument handling"
+description = "Type arguments to expression intrinsics must error, not be dropped."
+
+# A `()` (unit type) argument in the middle of @syscall must be a compile
+# error, not silently deleted.
+[[case]]
+name = "syscall_stray_unit_type_arg_is_error"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let a: u64 = 60;
+    let b: u64 = 7;
+    let r = @syscall(a, (), b);
+    0
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0702", "argument 1", "found type"]
+
+# Same for a named type used as an expression-intrinsic argument.
+[[case]]
+name = "syscall_stray_named_type_arg_is_error"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let a: u64 = 60;
+    let r = @syscall(a, i32);
+    0
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0702", "argument 1", "found type"]

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -164,3 +164,38 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["E0704", "does_not_exist"]
+
+# Multi-file compile where a NON-FIRST file matches on a module-qualified
+# enum path (`m.Color::Green`). The Path match-arm pattern embeds a module
+# InstRef that Rir::merge must renumber along with everything else; it used
+# to be left pointing into the first file's instruction space (RUE-130
+# item 9 — latent today because Sema resolves the enum globally, but this
+# pins the user-visible behavior).
+[[case]]
+name = "qualified_enum_pattern_in_second_file"
+files = [
+    { path = "color.rue", source = """
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+
+pub fn pick() -> Color {
+    Color::Green
+}
+""" },
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let m = @import("color.rue");
+    let c = m.pick();
+    match c {
+        m.Color::Red => 1,
+        m.Color::Green => 2,
+        m.Color::Blue => 3,
+    }
+}
+""" },
+]
+args = ["color.rue", "main.rue", "-o", "prog"]
+exit_code = 2

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -335,12 +335,161 @@ pub struct ValidatedProgram {
 /// Information about a symbol definition for duplicate detection.
 #[derive(Debug, Clone)]
 struct SymbolDef {
-    /// Name of the symbol (function, struct, or enum name).
-    name: String,
     /// Span of the first definition.
     span: Span,
     /// File path where the first definition was found.
     file_path: String,
+}
+
+/// Outcome of scanning parsed files for duplicate symbol definitions.
+///
+/// Produced by [`detect_duplicate_symbols`]; carries the errors (one per
+/// duplicate) plus the unique-symbol counts used for logging.
+pub(crate) struct DuplicateSymbolCheck {
+    /// One error per duplicate definition found.
+    pub(crate) errors: Vec<CompileError>,
+    /// Number of unique functions seen.
+    pub(crate) function_count: usize,
+    /// Number of unique structs seen.
+    pub(crate) struct_count: usize,
+    /// Number of unique enums seen.
+    pub(crate) enum_count: usize,
+}
+
+/// Detect duplicate symbol definitions across parsed files.
+///
+/// All functions, structs, and enums share a single flat global namespace
+/// (no modules yet), so each name may be defined only once across all files;
+/// structs and enums also conflict with each other. Every duplicate produces
+/// one error pointing at the redefinition, with a label at the first
+/// definition.
+///
+/// This is the single source of truth for duplicate-symbol detection — it is
+/// shared by [`merge_symbols`], [`validate_and_generate_rir_parallel`], and
+/// `CompilationUnit::parse`.
+pub(crate) fn detect_duplicate_symbols<'a>(
+    files: impl IntoIterator<Item = (&'a str, &'a Ast)>,
+    interner: &ThreadedRodeo,
+) -> DuplicateSymbolCheck {
+    use std::collections::HashMap;
+
+    let mut functions: HashMap<String, SymbolDef> = HashMap::new();
+    let mut structs: HashMap<String, SymbolDef> = HashMap::new();
+    let mut enums: HashMap<String, SymbolDef> = HashMap::new();
+    let mut errors: Vec<CompileError> = Vec::new();
+
+    for (file_path, ast) in files {
+        for item in &ast.items {
+            match item {
+                Item::Function(func) => {
+                    let name = interner.resolve(&func.name.name).to_string();
+                    if let Some(first) = functions.get(&name) {
+                        // Duplicate function definition
+                        let err = CompileError::new(
+                            ErrorKind::DuplicateFunctionDefinition {
+                                function_name: name,
+                            },
+                            func.span,
+                        )
+                        .with_label(format!("first defined in {}", first.file_path), first.span);
+                        errors.push(err);
+                    } else {
+                        functions.insert(
+                            name,
+                            SymbolDef {
+                                span: func.span,
+                                file_path: file_path.to_string(),
+                            },
+                        );
+                    }
+                }
+                Item::Struct(s) => {
+                    let name = interner.resolve(&s.name.name).to_string();
+                    if let Some(first) = structs.get(&name) {
+                        // Duplicate struct definition
+                        let err = CompileError::new(
+                            ErrorKind::DuplicateTypeDefinition {
+                                type_name: format!("struct `{}`", name),
+                            },
+                            s.span,
+                        )
+                        .with_label(format!("first defined in {}", first.file_path), first.span);
+                        errors.push(err);
+                    } else if let Some(first) = enums.get(&name) {
+                        // Struct name conflicts with enum
+                        let err = CompileError::new(
+                            ErrorKind::DuplicateTypeDefinition {
+                                type_name: format!("struct `{}` (conflicts with enum)", name),
+                            },
+                            s.span,
+                        )
+                        .with_label(
+                            format!("enum first defined in {}", first.file_path),
+                            first.span,
+                        );
+                        errors.push(err);
+                    } else {
+                        structs.insert(
+                            name,
+                            SymbolDef {
+                                span: s.span,
+                                file_path: file_path.to_string(),
+                            },
+                        );
+                    }
+                }
+                Item::Enum(e) => {
+                    let name = interner.resolve(&e.name.name).to_string();
+                    if let Some(first) = enums.get(&name) {
+                        // Duplicate enum definition
+                        let err = CompileError::new(
+                            ErrorKind::DuplicateTypeDefinition {
+                                type_name: format!("enum `{}`", name),
+                            },
+                            e.span,
+                        )
+                        .with_label(format!("first defined in {}", first.file_path), first.span);
+                        errors.push(err);
+                    } else if let Some(first) = structs.get(&name) {
+                        // Enum name conflicts with struct
+                        let err = CompileError::new(
+                            ErrorKind::DuplicateTypeDefinition {
+                                type_name: format!("enum `{}` (conflicts with struct)", name),
+                            },
+                            e.span,
+                        )
+                        .with_label(
+                            format!("struct first defined in {}", first.file_path),
+                            first.span,
+                        );
+                        errors.push(err);
+                    } else {
+                        enums.insert(
+                            name,
+                            SymbolDef {
+                                span: e.span,
+                                file_path: file_path.to_string(),
+                            },
+                        );
+                    }
+                }
+                Item::DropFn(_) | Item::Const(_) => {
+                    // Drop fns and const declarations are validated in Sema, not here.
+                    // Const declarations are checked for duplicates in the declarations phase.
+                }
+                Item::Error(_) => {
+                    // Error nodes from parser recovery are skipped - errors were already reported
+                }
+            }
+        }
+    }
+
+    DuplicateSymbolCheck {
+        errors,
+        function_count: functions.len(),
+        struct_count: structs.len(),
+        enum_count: enums.len(),
+    }
 }
 
 /// Merge symbols from all parsed files into a unified program.
@@ -373,145 +522,28 @@ struct SymbolDef {
 /// // merged.ast now contains both functions
 /// ```
 pub fn merge_symbols(program: ParsedProgram) -> MultiErrorResult<MergedProgram> {
-    use std::collections::HashMap;
-
     let _span = info_span!("merge_symbols", file_count = program.files.len()).entered();
 
-    // Track seen symbols for duplicate detection.
-    // Key: symbol name (resolved string), Value: first definition info
-    let mut functions: HashMap<String, SymbolDef> = HashMap::new();
-    let mut structs: HashMap<String, SymbolDef> = HashMap::new();
-    let mut enums: HashMap<String, SymbolDef> = HashMap::new();
-
-    // Collect all items and detect duplicates
-    let mut all_items = Vec::new();
-    let mut errors: Vec<CompileError> = Vec::new();
-
-    // Use the shared interner for resolving all symbol names
-    let interner = &program.interner;
-
-    for file in &program.files {
-        for item in &file.ast.items {
-            match item {
-                Item::Function(func) => {
-                    // Use shared interner for consistent Spur resolution
-                    let name = interner.resolve(&func.name.name).to_string();
-                    if let Some(first) = functions.get(&name) {
-                        // Duplicate function definition
-                        let err = CompileError::new(
-                            ErrorKind::DuplicateTypeDefinition {
-                                type_name: format!("function `{}`", name),
-                            },
-                            func.span,
-                        )
-                        .with_label(format!("first defined in {}", first.file_path), first.span);
-                        errors.push(err);
-                    } else {
-                        functions.insert(
-                            name.clone(),
-                            SymbolDef {
-                                name,
-                                span: func.span,
-                                file_path: file.path.clone(),
-                            },
-                        );
-                    }
-                }
-                Item::Struct(s) => {
-                    // Use shared interner for consistent Spur resolution
-                    let name = interner.resolve(&s.name.name).to_string();
-                    if let Some(first) = structs.get(&name) {
-                        // Duplicate struct definition
-                        let err = CompileError::new(
-                            ErrorKind::DuplicateTypeDefinition {
-                                type_name: format!("struct `{}`", name),
-                            },
-                            s.span,
-                        )
-                        .with_label(format!("first defined in {}", first.file_path), first.span);
-                        errors.push(err);
-                    } else if let Some(first) = enums.get(&name) {
-                        // Struct name conflicts with enum
-                        let err = CompileError::new(
-                            ErrorKind::DuplicateTypeDefinition {
-                                type_name: format!("struct `{}` (conflicts with enum)", name),
-                            },
-                            s.span,
-                        )
-                        .with_label(
-                            format!("enum first defined in {}", first.file_path),
-                            first.span,
-                        );
-                        errors.push(err);
-                    } else {
-                        structs.insert(
-                            name.clone(),
-                            SymbolDef {
-                                name,
-                                span: s.span,
-                                file_path: file.path.clone(),
-                            },
-                        );
-                    }
-                }
-                Item::Enum(e) => {
-                    // Use shared interner for consistent Spur resolution
-                    let name = interner.resolve(&e.name.name).to_string();
-                    if let Some(first) = enums.get(&name) {
-                        // Duplicate enum definition
-                        let err = CompileError::new(
-                            ErrorKind::DuplicateTypeDefinition {
-                                type_name: format!("enum `{}`", name),
-                            },
-                            e.span,
-                        )
-                        .with_label(format!("first defined in {}", first.file_path), first.span);
-                        errors.push(err);
-                    } else if let Some(first) = structs.get(&name) {
-                        // Enum name conflicts with struct
-                        let err = CompileError::new(
-                            ErrorKind::DuplicateTypeDefinition {
-                                type_name: format!("enum `{}` (conflicts with struct)", name),
-                            },
-                            e.span,
-                        )
-                        .with_label(
-                            format!("struct first defined in {}", first.file_path),
-                            first.span,
-                        );
-                        errors.push(err);
-                    } else {
-                        enums.insert(
-                            name.clone(),
-                            SymbolDef {
-                                name,
-                                span: e.span,
-                                file_path: file.path.clone(),
-                            },
-                        );
-                    }
-                }
-                Item::DropFn(_) | Item::Const(_) => {
-                    // Drop fns and const declarations are validated in Sema, not here.
-                    // Const declarations are checked for duplicates in the declarations phase.
-                }
-                Item::Error(_) => {
-                    // Error nodes from parser recovery are skipped - errors were already reported
-                }
-            }
-            all_items.push(item.clone());
-        }
-    }
+    let check = detect_duplicate_symbols(
+        program.files.iter().map(|f| (f.path.as_str(), &f.ast)),
+        &program.interner,
+    );
 
     // If there are any duplicate definitions, return all errors
-    if !errors.is_empty() {
-        return Err(CompileErrors::from(errors));
+    if !check.errors.is_empty() {
+        return Err(CompileErrors::from(check.errors));
     }
 
+    let all_items: Vec<Item> = program
+        .files
+        .iter()
+        .flat_map(|file| file.ast.items.iter().cloned())
+        .collect();
+
     info!(
-        function_count = functions.len(),
-        struct_count = structs.len(),
-        enum_count = enums.len(),
+        function_count = check.function_count,
+        struct_count = check.struct_count,
+        enum_count = check.enum_count,
         "symbol merging complete"
     );
 
@@ -558,124 +590,19 @@ pub fn validate_and_generate_rir_parallel(
         .collect();
 
     // Step 1: Validate symbols for duplicates (same logic as merge_symbols)
-    let mut functions: HashMap<String, SymbolDef> = HashMap::new();
-    let mut structs: HashMap<String, SymbolDef> = HashMap::new();
-    let mut enums: HashMap<String, SymbolDef> = HashMap::new();
-    let mut errors: Vec<CompileError> = Vec::new();
+    let check = detect_duplicate_symbols(
+        program.files.iter().map(|f| (f.path.as_str(), &f.ast)),
+        &program.interner,
+    );
 
-    let interner = &program.interner;
-
-    for file in &program.files {
-        for item in &file.ast.items {
-            match item {
-                Item::Function(func) => {
-                    let name = interner.resolve(&func.name.name).to_string();
-                    if let Some(first) = functions.get(&name) {
-                        let err = CompileError::new(
-                            ErrorKind::DuplicateTypeDefinition {
-                                type_name: format!("function `{}`", name),
-                            },
-                            func.span,
-                        )
-                        .with_label(format!("first defined in {}", first.file_path), first.span);
-                        errors.push(err);
-                    } else {
-                        functions.insert(
-                            name.clone(),
-                            SymbolDef {
-                                name,
-                                span: func.span,
-                                file_path: file.path.clone(),
-                            },
-                        );
-                    }
-                }
-                Item::Struct(s) => {
-                    let name = interner.resolve(&s.name.name).to_string();
-                    if let Some(first) = structs.get(&name) {
-                        let err = CompileError::new(
-                            ErrorKind::DuplicateTypeDefinition {
-                                type_name: format!("struct `{}`", name),
-                            },
-                            s.span,
-                        )
-                        .with_label(format!("first defined in {}", first.file_path), first.span);
-                        errors.push(err);
-                    } else if let Some(first) = enums.get(&name) {
-                        let err = CompileError::new(
-                            ErrorKind::DuplicateTypeDefinition {
-                                type_name: format!("struct `{}` (conflicts with enum)", name),
-                            },
-                            s.span,
-                        )
-                        .with_label(
-                            format!("enum first defined in {}", first.file_path),
-                            first.span,
-                        );
-                        errors.push(err);
-                    } else {
-                        structs.insert(
-                            name.clone(),
-                            SymbolDef {
-                                name,
-                                span: s.span,
-                                file_path: file.path.clone(),
-                            },
-                        );
-                    }
-                }
-                Item::Enum(e) => {
-                    let name = interner.resolve(&e.name.name).to_string();
-                    if let Some(first) = enums.get(&name) {
-                        let err = CompileError::new(
-                            ErrorKind::DuplicateTypeDefinition {
-                                type_name: format!("enum `{}`", name),
-                            },
-                            e.span,
-                        )
-                        .with_label(format!("first defined in {}", first.file_path), first.span);
-                        errors.push(err);
-                    } else if let Some(first) = structs.get(&name) {
-                        let err = CompileError::new(
-                            ErrorKind::DuplicateTypeDefinition {
-                                type_name: format!("enum `{}` (conflicts with struct)", name),
-                            },
-                            e.span,
-                        )
-                        .with_label(
-                            format!("struct first defined in {}", first.file_path),
-                            first.span,
-                        );
-                        errors.push(err);
-                    } else {
-                        enums.insert(
-                            name.clone(),
-                            SymbolDef {
-                                name,
-                                span: e.span,
-                                file_path: file.path.clone(),
-                            },
-                        );
-                    }
-                }
-                Item::DropFn(_) | Item::Const(_) => {
-                    // Validated in Sema
-                }
-                Item::Error(_) => {
-                    // Error nodes from parser recovery are skipped
-                }
-            }
-        }
-    }
-
-    if !errors.is_empty() {
-        return Err(CompileErrors::from(errors));
+    if !check.errors.is_empty() {
+        return Err(CompileErrors::from(check.errors));
     }
 
     info!(
-        function_count = functions.len(),
-        struct_count = structs.len(),
-        enum_count = enums.len(),
+        function_count = check.function_count,
+        struct_count = check.struct_count,
+        enum_count = check.enum_count,
         "symbol validation complete"
     );
 
@@ -2025,8 +1952,9 @@ mod tests {
         assert_eq!(errors.len(), 1, "should have 1 error");
         let err_msg = errors.first().unwrap().to_string();
         assert!(
-            err_msg.contains("function `foo`"),
-            "error should mention the function name"
+            err_msg.contains("duplicate function definition") && err_msg.contains("`foo`"),
+            "error should mention the duplicate function name: {}",
+            err_msg
         );
     }
 

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -193,151 +193,26 @@ impl<'src> CompilationUnit<'src> {
         files: &[ParsedFileData],
         interner: &ThreadedRodeo,
     ) -> MultiErrorResult<Ast> {
-        use crate::{Item, Span};
-
-        /// Information about a symbol definition for duplicate detection.
-        struct SymbolDef {
-            span: Span,
-            file_path: String,
-        }
-
         let _span = info_span!("merge_symbols", file_count = files.len()).entered();
 
-        let mut functions: HashMap<String, SymbolDef> = HashMap::new();
-        let mut structs: HashMap<String, SymbolDef> = HashMap::new();
-        let mut enums: HashMap<String, SymbolDef> = HashMap::new();
-        let mut all_items = Vec::new();
-        let mut errors = Vec::new();
+        let check = crate::detect_duplicate_symbols(
+            files.iter().map(|f| (f.path.as_str(), &f.ast)),
+            interner,
+        );
 
-        for file in files {
-            for item in &file.ast.items {
-                match item {
-                    Item::Function(func) => {
-                        let name = interner.resolve(&func.name.name).to_string();
-                        if let Some(first) = functions.get(&name) {
-                            errors.push(
-                                CompileError::new(
-                                    ErrorKind::DuplicateTypeDefinition {
-                                        type_name: format!("function `{}`", name),
-                                    },
-                                    func.span,
-                                )
-                                .with_label(
-                                    format!("first defined in {}", first.file_path),
-                                    first.span,
-                                ),
-                            );
-                        } else {
-                            functions.insert(
-                                name,
-                                SymbolDef {
-                                    span: func.span,
-                                    file_path: file.path.clone(),
-                                },
-                            );
-                        }
-                    }
-                    Item::Struct(s) => {
-                        let name = interner.resolve(&s.name.name).to_string();
-                        if let Some(first) = structs.get(&name) {
-                            errors.push(
-                                CompileError::new(
-                                    ErrorKind::DuplicateTypeDefinition {
-                                        type_name: format!("struct `{}`", name),
-                                    },
-                                    s.span,
-                                )
-                                .with_label(
-                                    format!("first defined in {}", first.file_path),
-                                    first.span,
-                                ),
-                            );
-                        } else if let Some(first) = enums.get(&name) {
-                            errors.push(
-                                CompileError::new(
-                                    ErrorKind::DuplicateTypeDefinition {
-                                        type_name: format!(
-                                            "struct `{}` (conflicts with enum)",
-                                            name
-                                        ),
-                                    },
-                                    s.span,
-                                )
-                                .with_label(
-                                    format!("enum first defined in {}", first.file_path),
-                                    first.span,
-                                ),
-                            );
-                        } else {
-                            structs.insert(
-                                name,
-                                SymbolDef {
-                                    span: s.span,
-                                    file_path: file.path.clone(),
-                                },
-                            );
-                        }
-                    }
-                    Item::Enum(e) => {
-                        let name = interner.resolve(&e.name.name).to_string();
-                        if let Some(first) = enums.get(&name) {
-                            errors.push(
-                                CompileError::new(
-                                    ErrorKind::DuplicateTypeDefinition {
-                                        type_name: format!("enum `{}`", name),
-                                    },
-                                    e.span,
-                                )
-                                .with_label(
-                                    format!("first defined in {}", first.file_path),
-                                    first.span,
-                                ),
-                            );
-                        } else if let Some(first) = structs.get(&name) {
-                            errors.push(
-                                CompileError::new(
-                                    ErrorKind::DuplicateTypeDefinition {
-                                        type_name: format!(
-                                            "enum `{}` (conflicts with struct)",
-                                            name
-                                        ),
-                                    },
-                                    e.span,
-                                )
-                                .with_label(
-                                    format!("struct first defined in {}", first.file_path),
-                                    first.span,
-                                ),
-                            );
-                        } else {
-                            enums.insert(
-                                name,
-                                SymbolDef {
-                                    span: e.span,
-                                    file_path: file.path.clone(),
-                                },
-                            );
-                        }
-                    }
-                    Item::DropFn(_) | Item::Const(_) => {
-                        // Validated in Sema
-                    }
-                    Item::Error(_) => {
-                        // Error nodes from parser recovery are skipped
-                    }
-                }
-                all_items.push(item.clone());
-            }
+        if !check.errors.is_empty() {
+            return Err(CompileErrors::from(check.errors));
         }
 
-        if !errors.is_empty() {
-            return Err(CompileErrors::from(errors));
-        }
+        let all_items: Vec<_> = files
+            .iter()
+            .flat_map(|file| file.ast.items.iter().cloned())
+            .collect();
 
         info!(
-            function_count = functions.len(),
-            struct_count = structs.len(),
-            enum_count = enums.len(),
+            function_count = check.function_count,
+            struct_count = check.struct_count,
+            enum_count = check.enum_count,
             "symbol merging complete"
         );
 

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -123,8 +123,9 @@ impl ErrorCode {
     pub const BORROW_KEYWORD_MISSING: Self = Self(432);
     pub const EMPTY_STRUCT: Self = Self(433);
     pub const RESERVED_FUNCTION_NAME: Self = Self(435);
-    pub const BY_REF_ARG_NOT_PLAIN_VARIABLE: Self = Self(438);
+    pub const DUPLICATE_FUNCTION_DEFINITION: Self = Self(436);
     pub const MOVE_OUT_OF_INOUT: Self = Self(437);
+    pub const BY_REF_ARG_NOT_PLAIN_VARIABLE: Self = Self(438);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -853,6 +854,9 @@ pub enum ErrorKind {
     /// Duplicate type definition
     #[error("duplicate type definition: `{type_name}` is already defined")]
     DuplicateTypeDefinition { type_name: String },
+    /// Duplicate function definition
+    #[error("duplicate function definition: `{function_name}` is already defined")]
+    DuplicateFunctionDefinition { function_name: String },
     /// Linear value was not consumed before going out of scope
     #[error("linear value '{0}' must be consumed but was dropped")]
     LinearValueNotConsumed(String),
@@ -1115,6 +1119,9 @@ impl ErrorKind {
             ErrorKind::ReservedTypeName { .. } => ErrorCode::RESERVED_TYPE_NAME,
             ErrorKind::ReservedFunctionName { .. } => ErrorCode::RESERVED_FUNCTION_NAME,
             ErrorKind::DuplicateTypeDefinition { .. } => ErrorCode::DUPLICATE_TYPE_DEFINITION,
+            ErrorKind::DuplicateFunctionDefinition { .. } => {
+                ErrorCode::DUPLICATE_FUNCTION_DEFINITION
+            }
             ErrorKind::LinearValueNotConsumed(_) => ErrorCode::LINEAR_VALUE_NOT_CONSUMED,
             ErrorKind::LinearStructCopy(_) => ErrorCode::LINEAR_STRUCT_COPY,
             ErrorKind::HandleStructMissingMethod { .. } => ErrorCode::HANDLE_STRUCT_MISSING_METHOD,

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -599,9 +599,21 @@ impl<'a> AstGen<'a> {
                 let args: Vec<_> = intrinsic
                     .args
                     .iter()
-                    .filter_map(|a| match a {
-                        IntrinsicArg::Expr(expr) => Some(self.gen_expr(expr)),
-                        IntrinsicArg::Type(_) => None, // This shouldn't happen for expr intrinsics
+                    .map(|a| match a {
+                        IntrinsicArg::Expr(expr) => self.gen_expr(expr),
+                        // A type argument to an expression intrinsic (e.g. the
+                        // `()` in `@syscall(a, (), b)`) is invalid, but it must
+                        // NOT be dropped: that would shift the later arguments
+                        // into earlier slots and silently miscompile. Lower it
+                        // to a TypeConst placeholder so the argument count is
+                        // preserved and Sema reports a proper type error.
+                        IntrinsicArg::Type(ty) => {
+                            let type_name = self.intern_type(ty);
+                            self.rir.add_inst(Inst {
+                                data: InstData::TypeConst { type_name },
+                                span: ty.span(),
+                            })
+                        }
                     })
                     .collect();
                 let (args_start, args_len) = self.rir.add_inst_refs(&args);

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -1164,6 +1164,7 @@ impl Rir {
     /// - Call args (value field of each arg)
     /// - Field inits (value field of each init)
     /// - Match arm bodies (last field of each arm)
+    /// - Match arm Path pattern module refs (u32::MAX = None sentinel is kept)
     fn renumber_extra_inst_refs(
         extra: &mut [u32],
         instructions: &[Inst],
@@ -1281,6 +1282,13 @@ impl Rir {
                             k if k == PatternKind::Path as u32 => PATTERN_PATH_SIZE as usize,
                             _ => panic!("Unknown pattern kind during merge: {}", kind),
                         };
+                        // Path patterns also embed a module InstRef at offset 3
+                        // (u32::MAX encodes None); it must be renumbered like
+                        // every other InstRef or it would point into the wrong
+                        // file's instruction space after merging.
+                        if kind == PatternKind::Path as u32 && extra[pos + 3] != u32::MAX {
+                            extra[pos + 3] += inst_offset;
+                        }
                         // The body InstRef is always the last element of each pattern
                         extra[pos + pattern_size - 1] += inst_offset;
                         pos += pattern_size;
@@ -4119,6 +4127,152 @@ mod tests {
             merged.get(InstRef::from_raw(2)).data,
             InstData::IntConst(3)
         ));
+    }
+
+    #[test]
+    fn test_merge_renumbers_path_pattern_module_ref() {
+        // Regression test (RUE-130): the module InstRef embedded in a Path
+        // match-arm pattern must be renumbered by Rir::merge, just like the
+        // arm's body InstRef. Before the fix it was left untouched, so for any
+        // file after the first it pointed into the wrong file's instructions.
+        let interner = ThreadedRodeo::new();
+        let type_name = interner.get_or_intern("Color");
+        let variant = interner.get_or_intern("Red");
+        let module_name = interner.get_or_intern("m");
+
+        // RIR 1: a single instruction, so RIR 2 gets inst_offset = 1
+        let mut rir1 = Rir::new();
+        rir1.add_inst(Inst {
+            data: InstData::IntConst(0),
+            span: Span::new(0, 1),
+        });
+
+        // RIR 2: match with a module-qualified Path pattern and a wildcard
+        let mut rir2 = Rir::new();
+        let module = rir2.add_inst(Inst {
+            data: InstData::VarRef { name: module_name },
+            span: Span::new(10, 11),
+        });
+        let scrutinee = rir2.add_inst(Inst {
+            data: InstData::IntConst(1),
+            span: Span::new(12, 13),
+        });
+        let body1 = rir2.add_inst(Inst {
+            data: InstData::IntConst(2),
+            span: Span::new(14, 15),
+        });
+        let body2 = rir2.add_inst(Inst {
+            data: InstData::IntConst(3),
+            span: Span::new(16, 17),
+        });
+        let (arms_start, arms_len) = rir2.add_match_arms(&[
+            (
+                RirPattern::Path {
+                    module: Some(module),
+                    type_name,
+                    variant,
+                    span: Span::new(10, 13),
+                },
+                body1,
+            ),
+            (RirPattern::Wildcard(Span::new(18, 19)), body2),
+        ]);
+        rir2.add_inst(Inst {
+            data: InstData::Match {
+                scrutinee,
+                arms_start,
+                arms_len,
+            },
+            span: Span::new(10, 20),
+        });
+
+        let merged = Rir::merge(&[rir1, rir2]);
+        assert_eq!(merged.len(), 6);
+
+        // The match from rir2 is now at %5
+        let InstData::Match {
+            scrutinee,
+            arms_start,
+            arms_len,
+        } = &merged.get(InstRef::from_raw(5)).data
+        else {
+            panic!("Expected Match instruction at index 5");
+        };
+        assert_eq!(scrutinee.as_u32(), 2); // Was %1, now %1 + 1
+
+        let arms = merged.get_match_arms(*arms_start, *arms_len);
+        assert_eq!(arms.len(), 2);
+
+        let (pattern, body) = &arms[0];
+        let RirPattern::Path { module, .. } = pattern else {
+            panic!("Expected Path pattern in first arm");
+        };
+        // The module ref was %0 in rir2; after merging it must be %1
+        assert_eq!(module.map(|r| r.as_u32()), Some(1));
+        assert_eq!(body.as_u32(), 3); // Was %2, now %2 + 1
+
+        // The wildcard arm has no module ref; its body is still renumbered
+        let (pattern, body) = &arms[1];
+        assert!(matches!(pattern, RirPattern::Wildcard(_)));
+        assert_eq!(body.as_u32(), 4); // Was %3, now %3 + 1
+    }
+
+    #[test]
+    fn test_merge_renumbers_path_pattern_keeps_none_module() {
+        // The u32::MAX sentinel for "no module" must NOT be renumbered.
+        let interner = ThreadedRodeo::new();
+        let type_name = interner.get_or_intern("Color");
+        let variant = interner.get_or_intern("Red");
+
+        let mut rir1 = Rir::new();
+        rir1.add_inst(Inst {
+            data: InstData::IntConst(0),
+            span: Span::new(0, 1),
+        });
+
+        let mut rir2 = Rir::new();
+        let scrutinee = rir2.add_inst(Inst {
+            data: InstData::IntConst(1),
+            span: Span::new(10, 11),
+        });
+        let body = rir2.add_inst(Inst {
+            data: InstData::IntConst(2),
+            span: Span::new(12, 13),
+        });
+        let (arms_start, arms_len) = rir2.add_match_arms(&[(
+            RirPattern::Path {
+                module: None,
+                type_name,
+                variant,
+                span: Span::new(10, 13),
+            },
+            body,
+        )]);
+        rir2.add_inst(Inst {
+            data: InstData::Match {
+                scrutinee,
+                arms_start,
+                arms_len,
+            },
+            span: Span::new(10, 14),
+        });
+
+        let merged = Rir::merge(&[rir1, rir2]);
+
+        let InstData::Match {
+            arms_start,
+            arms_len,
+            ..
+        } = &merged.get(InstRef::from_raw(3)).data
+        else {
+            panic!("Expected Match instruction at index 3");
+        };
+        let arms = merged.get_match_arms(*arms_start, *arms_len);
+        let RirPattern::Path { module, .. } = &arms[0].0 else {
+            panic!("Expected Path pattern");
+        };
+        assert_eq!(*module, None);
+        assert_eq!(arms[0].1.as_u32(), 2); // Body was %1, now %1 + 1
     }
 
     #[test]


### PR DESCRIPTION
Three driver-layer fixes from the CLI-hardening epic:

Stray intrinsic type arguments (item 8, silent miscompile): AstGen dropped
IntrinsicArg::Type when lowering args for expression intrinsics, so
@syscall(a, (), b) silently deleted the middle argument and shifted b into
the wrong syscall register. The stray arg now lowers to a TypeConst
placeholder and sema reports E0702 (intrinsic argument type mismatch)
instead of miscompiling. CLI cases in intrinsic_args.toml.

Rir::merge Path patterns (item 9): merge renumbered every InstRef except
the module ref inside Path match-arm patterns, leaving refs from the second
file onward pointing into the wrong file's instruction space. Now
renumbered like everything else (preserving the u32::MAX None sentinel),
with unit tests for both. The corruption is latent today — sema's enum
resolution ignores the module ref — so a pinning multi-file CLI case
documents current behavior rather than a user-visible repro.

Duplicate-symbol detection (item 6): the same check was hand-written three
times (merge_symbols, the parallel RIR path, and CompilationUnit::parse)
and reported duplicate FUNCTIONS with DuplicateTypeDefinition. One
detect_duplicate_symbols helper now serves all three sites, and functions
get their own DuplicateFunctionDefinition error kind.

Full test.sh green.

Part of RUE-130 (items 6, 8, 9; remaining: 2-5, 7).



🤖 Generated with [Claude Code](https://claude.com/claude-code)
