### PR TITLE
Move checker: reject projected by-ref args and moves out of inout params

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -23,7 +23,7 @@ use rue_error::{
     CompileError, CompileErrors, CompileResult, CompileWarning, ErrorKind,
     IntrinsicTypeMismatchError, MultiErrorResult, OptionExt, PreviewFeature, WarningKind,
 };
-use rue_rir::{InstData, InstRef, RirArgMode, RirCallArg, RirDirective, RirParamMode};
+use rue_rir::{InstData, InstRef, Rir, RirArgMode, RirCallArg, RirDirective, RirParamMode};
 use rue_span::Span;
 use rue_target::{Arch, Os};
 
@@ -1423,6 +1423,7 @@ fn analyze_function_with_context(
         comptime_value_vars: HashMap::new(),
         referenced_functions: HashSet::new(),
         referenced_methods: HashSet::new(),
+        byref_arg_root: None,
         in_loop_move_recheck: false,
     };
 
@@ -2676,24 +2677,36 @@ fn analyze_var_ref_ctx(
             }
         }
 
-        // Handle move semantics based on parameter mode
+        // Handle move semantics based on parameter mode.
+        // A use as a by-ref call argument is a borrow, not a move
+        // (`analyze_call_args_ctx` sets `byref_arg_root`), so it neither marks
+        // the parameter moved nor counts as moving out of it. This is what
+        // permits forwarding an inout parameter: `f(inout v)` inside
+        // `fn g(inout v: T)`.
+        let is_byref_arg_use = analysis_ctx.byref_arg_root == Some(name);
         if !ctx.is_type_copy(ty) {
             match param_info.mode {
                 RirParamMode::Normal | RirParamMode::Comptime => {
-                    analysis_ctx
-                        .moved_vars
-                        .entry(name)
-                        .or_default()
-                        .mark_path_moved(&[], span);
+                    if !is_byref_arg_use {
+                        analysis_ctx
+                            .moved_vars
+                            .entry(name)
+                            .or_default()
+                            .mark_path_moved(&[], span);
+                    }
                 }
                 RirParamMode::Inout => {
-                    analysis_ctx
-                        .moved_vars
-                        .entry(name)
-                        .or_default()
-                        .mark_path_moved(&[], span);
+                    // Moving out of an inout parameter would leave the CALLER's
+                    // variable moved-from after the call returns, so it is
+                    // rejected outright (RUE-127).
+                    if !is_byref_arg_use {
+                        return Err(move_out_of_inout_error(name_str, span));
+                    }
                 }
                 RirParamMode::Borrow => {
+                    // Note: this also rejects by-ref forwarding of a borrow
+                    // parameter (`f(borrow v)` inside `fn g(borrow v: T)`),
+                    // a pre-existing limitation kept as-is for now.
                     let name_str = ctx.interner.resolve(&name);
                     return Err(CompileError::new(
                         ErrorKind::MoveOutOfBorrow {
@@ -2831,8 +2844,9 @@ fn analyze_var_ref_ctx(
         }
     }
 
-    // If type is not Copy, mark as moved
-    if !ctx.is_type_copy(ty) {
+    // If type is not Copy, mark as moved — unless this use is a by-ref call
+    // argument, which borrows the variable rather than moving it.
+    if !ctx.is_type_copy(ty) && analysis_ctx.byref_arg_root != Some(name) {
         analysis_ctx
             .moved_vars
             .entry(name)
@@ -4000,6 +4014,40 @@ fn extract_root_variable_ctx(ctx: &SemaContext<'_>, inst_ref: InstRef) -> Option
     }
 }
 
+/// Reject a move (full or partial) whose root is a by-ref parameter.
+///
+/// Moving a non-Copy value out of an `inout` or `borrow` parameter would leave
+/// the CALLER's variable (partially) moved-from after the call returns, so
+/// both are rejected outright (RUE-127); reinitialization before exit is not
+/// tracked yet. Counterpart of [`Sema::reject_move_out_of_byref_param`].
+fn reject_move_out_of_byref_param_ctx(
+    ctx: &SemaContext<'_>,
+    analysis_ctx: &AnalysisContext,
+    root_var: Spur,
+    span: Span,
+) -> CompileResult<()> {
+    if let Some(param_info) = analysis_ctx.params.iter().find(|p| p.name == root_var) {
+        match param_info.mode {
+            RirParamMode::Inout => {
+                return Err(move_out_of_inout_error(
+                    ctx.interner.resolve(&root_var),
+                    span,
+                ));
+            }
+            RirParamMode::Borrow => {
+                return Err(CompileError::new(
+                    ErrorKind::MoveOutOfBorrow {
+                        variable: ctx.interner.resolve(&root_var).to_string(),
+                    },
+                    span,
+                ));
+            }
+            RirParamMode::Normal | RirParamMode::Comptime => {}
+        }
+    }
+    Ok(())
+}
+
 /// Extract field path from a field access chain.
 fn extract_field_path_ctx(ctx: &SemaContext<'_>, inst_ref: InstRef) -> Option<(Spur, FieldPath)> {
     let inst = ctx.rir.get(inst_ref);
@@ -4058,6 +4106,7 @@ fn analyze_field_get_ctx(
     // For linear types, field access consumes the entire struct.
     if is_linear {
         if let Some(root_var) = extract_root_variable_ctx(ctx, inst_ref) {
+            reject_move_out_of_byref_param_ctx(ctx, analysis_ctx, root_var, span)?;
             analysis_ctx
                 .moved_vars
                 .entry(root_var)
@@ -4068,6 +4117,7 @@ fn analyze_field_get_ctx(
     // For non-linear types, check if accessing a non-Copy field
     else if !ctx.is_type_copy(field_type) {
         if let Some((root_var, field_path)) = extract_field_path_ctx(ctx, inst_ref) {
+            reject_move_out_of_byref_param_ctx(ctx, analysis_ctx, root_var, span)?;
             // Check if this field path is already moved
             if let Some(state) = analysis_ctx.moved_vars.get(&root_var) {
                 if let Some(moved_span) = state.is_path_moved(&field_path) {
@@ -4968,7 +5018,59 @@ fn extract_arg_var_name_ctx(ctx: &SemaContext<'_>, inst_ref: InstRef) -> Option<
     }
 }
 
+/// Build the diagnostic for a move out of an `inout` parameter.
+///
+/// Rule (RUE-127): moving out of an inout parameter is always rejected, even if
+/// the parameter is reassigned afterwards — reinitialization-before-exit is not
+/// tracked yet. Without this rule, the call would leave the caller's variable
+/// moved-from while the caller still considers it live.
+pub(crate) fn move_out_of_inout_error(name: &str, span: Span) -> CompileError {
+    CompileError::new(
+        ErrorKind::MoveOutOfInout {
+            variable: name.to_string(),
+        },
+        span,
+    )
+    .with_note(
+        "an `inout` parameter is a mutable borrow of the caller's variable; \
+         moving its value out would leave the caller's variable uninitialized",
+    )
+    .with_help(
+        "moves out of `inout` parameters are rejected even if the parameter is \
+         reassigned before returning (reinitialization is not tracked yet)",
+    )
+}
+
+/// Validate that a by-ref (`inout`/`borrow`) call argument is a plain variable
+/// and return its symbol.
+///
+/// Codegen passes a by-ref argument by taking the address of the variable's
+/// slot, so fields and array elements cannot be passed by reference yet
+/// (RUE-127); reject them here rather than panicking during lowering.
+fn require_plain_byref_arg(rir: &Rir, arg: &RirCallArg) -> CompileResult<Spur> {
+    let inst = rir.get(arg.value);
+    match &inst.data {
+        InstData::VarRef { name } | InstData::ParamRef { name, .. } => Ok(*name),
+        InstData::FieldGet { .. } | InstData::IndexGet { .. } => Err(CompileError::new(
+            ErrorKind::ByRefArgNotPlainVariable,
+            inst.span,
+        )
+        .with_help("bind the value to a local variable first and pass that variable by reference")),
+        _ => Err(CompileError::new(
+            if arg.is_inout() {
+                ErrorKind::InoutNonLvalue
+            } else {
+                ErrorKind::BorrowNonLvalue
+            },
+            inst.span,
+        )),
+    }
+}
+
 /// Analyze call arguments using the shared context.
+///
+/// See [`Sema::analyze_call_args`] for the by-ref argument rules enforced here
+/// (plain-variable shape, and borrow-not-move handling via `byref_arg_root`).
 fn analyze_call_args_ctx(
     ctx: &SemaContext<'_>,
     air: &mut Air,
@@ -4978,7 +5080,19 @@ fn analyze_call_args_ctx(
     let mut air_args = Vec::with_capacity(args.len());
 
     for arg in args {
-        let arg_result = analyze_inst_with_context(ctx, air, arg.value, analysis_ctx)?;
+        let byref_root = if arg.is_inout() || arg.is_borrow() {
+            Some(require_plain_byref_arg(ctx.rir, arg)?)
+        } else {
+            None
+        };
+
+        // Set while analyzing the argument so the use is treated as a borrow,
+        // not a move; restored afterwards.
+        let prev_byref_root = std::mem::replace(&mut analysis_ctx.byref_arg_root, byref_root);
+        let arg_result = analyze_inst_with_context(ctx, air, arg.value, analysis_ctx);
+        analysis_ctx.byref_arg_root = prev_byref_root;
+        let arg_result = arg_result?;
+
         let air_mode = match arg.mode {
             RirArgMode::Normal => AirArgMode::Normal,
             RirArgMode::Inout => AirArgMode::Inout,
@@ -6669,6 +6783,7 @@ impl<'a> Sema<'a> {
             comptime_value_vars,
             referenced_functions: HashSet::new(),
             referenced_methods: HashSet::new(),
+            byref_arg_root: None,
             in_loop_move_recheck: false,
         };
 
@@ -10240,10 +10355,14 @@ impl<'a> Sema<'a> {
         Ok(())
     }
 
-    /// Analyze a list of call arguments, handling inout unmove logic.
+    /// Analyze a list of call arguments, enforcing by-ref argument rules.
     ///
-    /// For inout arguments, the variable is "unmoving" after analysis - this is because
-    /// inout is a mutable borrow, not a move. The value stays valid after the call.
+    /// Inout/borrow arguments are borrows, not moves: `ctx.byref_arg_root` is
+    /// set while the argument value is analyzed so the variable-reference
+    /// analysis skips move tracking (and permits forwarding an inout parameter
+    /// to another function's by-ref parameter). By-ref arguments must also be
+    /// plain variables: codegen takes the address of the variable's slot
+    /// directly, and field/element projections are not supported yet (RUE-127).
     pub(crate) fn analyze_call_args(
         &mut self,
         air: &mut Air,
@@ -10252,21 +10371,18 @@ impl<'a> Sema<'a> {
     ) -> CompileResult<Vec<AirCallArg>> {
         let mut air_args = Vec::new();
         for arg in args.iter() {
-            // For inout/borrow arguments, extract the variable name before analysis
-            // so we can "unmove" it after - these are borrows, not moves
-            let borrowed_var = if arg.is_inout() || arg.is_borrow() {
-                self.extract_root_variable(arg.value)
+            let byref_root = if arg.is_inout() || arg.is_borrow() {
+                Some(require_plain_byref_arg(self.rir, arg)?)
             } else {
                 None
             };
 
-            let arg_result = self.analyze_inst(air, arg.value, ctx)?;
-
-            // If this was an inout/borrow argument, the variable shouldn't be marked as moved
-            // because these are borrows - the value stays valid after the call
-            if let Some(var_symbol) = borrowed_var {
-                ctx.moved_vars.remove(&var_symbol);
-            }
+            // Set while analyzing the argument so the use is treated as a
+            // borrow, not a move; restored afterwards.
+            let prev_byref_root = std::mem::replace(&mut ctx.byref_arg_root, byref_root);
+            let arg_result = self.analyze_inst(air, arg.value, ctx);
+            ctx.byref_arg_root = prev_byref_root;
+            let arg_result = arg_result?;
 
             air_args.push(AirCallArg {
                 value: arg_result.air_ref,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -33,6 +33,7 @@ use crate::sema::context::ConstValue;
 use rue_span::Span;
 
 use super::Sema;
+use super::analysis::move_out_of_inout_error;
 use super::context::{AnalysisContext, AnalysisResult, LocalVar};
 use crate::inst::{
     Air, AirCallArg, AirInst, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef, AirProjection,
@@ -1526,24 +1527,37 @@ impl<'a> Sema<'a> {
                 }
             }
 
-            // Handle move semantics based on parameter mode
+            // Handle move semantics based on parameter mode.
+            // A use as a by-ref call argument is a borrow, not a move
+            // (`analyze_call_args` sets `byref_arg_root`), so it neither marks
+            // the parameter moved nor counts as moving out of it. This is what
+            // permits forwarding an inout parameter: `f(inout v)` inside
+            // `fn g(inout v: T)`.
+            let is_byref_arg_use = ctx.byref_arg_root == Some(name);
             if !self.is_type_copy(ty) {
                 match param_info.mode {
                     // Normal and comptime parameters behave similarly for moves
                     // (comptime params are substituted at compile time)
                     RirParamMode::Normal | RirParamMode::Comptime => {
-                        ctx.moved_vars
-                            .entry(name)
-                            .or_default()
-                            .mark_path_moved(&[], span);
+                        if !is_byref_arg_use {
+                            ctx.moved_vars
+                                .entry(name)
+                                .or_default()
+                                .mark_path_moved(&[], span);
+                        }
                     }
                     RirParamMode::Inout => {
-                        ctx.moved_vars
-                            .entry(name)
-                            .or_default()
-                            .mark_path_moved(&[], span);
+                        // Moving out of an inout parameter would leave the
+                        // CALLER's variable moved-from after the call returns,
+                        // so it is rejected outright (RUE-127).
+                        if !is_byref_arg_use {
+                            return Err(move_out_of_inout_error(name_str, span));
+                        }
                     }
                     RirParamMode::Borrow => {
+                        // Note: this also rejects by-ref forwarding of a borrow
+                        // parameter (`f(borrow v)` inside `fn g(borrow v: T)`),
+                        // a pre-existing limitation kept as-is for now.
                         let name_str = self.interner.resolve(&name);
                         return Err(CompileError::new(
                             ErrorKind::MoveOutOfBorrow {
@@ -1584,8 +1598,9 @@ impl<'a> Sema<'a> {
                 }
             }
 
-            // If type is not Copy, mark as moved
-            if !self.is_type_copy(ty) {
+            // If type is not Copy, mark as moved — unless this use is a by-ref
+            // call argument, which borrows the variable rather than moving it.
+            if !self.is_type_copy(ty) && ctx.byref_arg_root != Some(name) {
                 ctx.moved_vars
                     .entry(name)
                     .or_default()
@@ -2090,6 +2105,40 @@ impl<'a> Sema<'a> {
         Ok(AnalysisResult::new(air_ref, struct_type))
     }
 
+    /// Reject a move (full or partial) whose root is a by-ref parameter.
+    ///
+    /// Moving a non-Copy value out of an `inout` or `borrow` parameter would
+    /// leave the CALLER's variable (partially) moved-from after the call
+    /// returns, so both are rejected outright (RUE-127); reinitialization
+    /// before exit is not tracked yet.
+    fn reject_move_out_of_byref_param(
+        &self,
+        root_var: Spur,
+        ctx: &AnalysisContext,
+        span: Span,
+    ) -> CompileResult<()> {
+        if let Some(param_info) = ctx.params.iter().find(|p| p.name == root_var) {
+            match param_info.mode {
+                RirParamMode::Inout => {
+                    return Err(move_out_of_inout_error(
+                        self.interner.resolve(&root_var),
+                        span,
+                    ));
+                }
+                RirParamMode::Borrow => {
+                    return Err(CompileError::new(
+                        ErrorKind::MoveOutOfBorrow {
+                            variable: self.interner.resolve(&root_var).to_string(),
+                        },
+                        span,
+                    ));
+                }
+                RirParamMode::Normal | RirParamMode::Comptime => {}
+            }
+        }
+        Ok(())
+    }
+
     /// Analyze a field access.
     ///
     /// Uses place-based analysis (ADR-0030) when possible for efficient code generation.
@@ -2149,12 +2198,14 @@ impl<'a> Sema<'a> {
             // Move checking using the trace
             if is_linear {
                 // For linear types, field access consumes the entire struct
+                self.reject_move_out_of_byref_param(trace.root_var, ctx, span)?;
                 ctx.moved_vars
                     .entry(trace.root_var)
                     .or_default()
                     .mark_path_moved(&[], span);
             } else if !self.is_type_copy(field_type) {
                 // For non-linear types, check if accessing a non-Copy field
+                self.reject_move_out_of_byref_param(trace.root_var, ctx, span)?;
                 let field_path = trace.field_path();
 
                 // Check if this field path is already moved (partial moves)

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -195,6 +195,12 @@ pub(crate) struct AnalysisContext<'a> {
     /// Methods referenced during analysis of this function.
     /// Each entry is (struct_id, method_name) matching the key format in methods map.
     pub referenced_methods: HashSet<(StructId, Spur)>,
+    /// While analyzing the value of an `inout`/`borrow` call argument, the root
+    /// variable being passed by reference (set by `analyze_call_args`). A by-ref
+    /// argument is a borrow, not a move, so the variable-reference analysis must
+    /// not mark the variable as moved — and must not reject forwarding an inout
+    /// parameter to another function's inout/borrow parameter.
+    pub byref_arg_root: Option<Spur>,
     /// True while re-running a loop's condition/body to validate the loop's
     /// back edge (see [`AnalysisContext::fork_for_loop_recheck`]). The recheck
     /// pass starts from a move state that already includes every move the loop
@@ -267,6 +273,10 @@ impl<'a> AnalysisContext<'a> {
             comptime_value_vars: self.comptime_value_vars.clone(),
             referenced_functions: HashSet::new(),
             referenced_methods: HashSet::new(),
+            // A by-ref argument's value is always a plain variable (enforced in
+            // analyze_call_args), so a loop can never be analyzed while this is
+            // set; the fork starts between whole-expression analyses.
+            byref_arg_root: None,
             in_loop_move_recheck: true,
         }
     }

--- a/crates/rue-cli-tests/cases/byref_params.toml
+++ b/crates/rue-cli-tests/cases/byref_params.toml
@@ -1,0 +1,254 @@
+# By-ref (inout/borrow) parameter soundness (RUE-127 items 3 and 4).
+#
+# Item 3: passing a struct field or array element as an `inout`/`borrow`
+# argument used to panic codegen ("by-ref argument must be a variable" ICE in
+# cfg_lower). Codegen takes the address of a variable's slot directly and
+# cannot address a projection yet, so sema now rejects these with E0438.
+#
+# Item 4: moving a non-Copy value out of an `inout` parameter (whole variable
+# or a field) compiled but left the CALLER's variable moved-from after the
+# call — a use-after-move the caller's own move checker could not see. Sema
+# now rejects any move out of an inout parameter with E0437. The rule is
+# deliberately conservative (reject-valid): reinitialization before exit is
+# not tracked, so moving out and reassigning before returning still errors.
+# Field-level moves out of `borrow` parameters are likewise rejected (E0429),
+# matching the existing whole-variable rule.
+#
+# Forwarding an inout parameter to another function's by-ref parameter
+# (`g(inout v)` inside `fn f(inout v: T)`) is a re-borrow, not a move, and
+# must keep working.
+
+[section]
+id = "cli.byref_params"
+name = "By-ref parameter soundness"
+description = "Field/element by-ref arguments and moves out of inout parameters (RUE-127)."
+
+# ---------------------------------------------------------------------------
+# Item 3: by-ref arguments must be plain variables
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "borrow_field_arg_rejected"
+description = "Passing a struct field as a borrow argument errors (E0438) instead of the former cfg_lower ICE."
+files = [{ path = "main.rue", source = """
+struct Inner { x: i32 }
+struct Outer { f: Inner }
+fn peek(borrow v: Inner) -> i32 { v.x }
+fn main() -> i32 { let o = Outer { f: Inner { x: 7 } }; peek(borrow o.f) }
+""" }]
+compile_fail = true
+error_contains = ["E0438", "by-ref argument must be a plain variable"]
+
+[[case]]
+name = "inout_field_arg_rejected"
+description = "The inout variant of the same shape is rejected too."
+files = [{ path = "main.rue", source = """
+struct Inner { x: i32 }
+struct Outer { f: Inner }
+fn bump(inout v: Inner) { v.x = v.x + 1; }
+fn main() -> i32 {
+    let mut o = Outer { f: Inner { x: 7 } };
+    bump(inout o.f);
+    o.f.x
+}
+""" }]
+compile_fail = true
+error_contains = ["E0438", "by-ref argument must be a plain variable"]
+
+[[case]]
+name = "borrow_array_element_arg_rejected"
+description = "Array elements cannot be passed by reference either (same codegen limitation)."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+fn peek(borrow v: D) -> i32 { v.x }
+fn main() -> i32 {
+    let a = [D { x: 3 }, D { x: 4 }];
+    peek(borrow a[0])
+}
+""" }]
+compile_fail = true
+error_contains = ["E0438", "by-ref argument must be a plain variable"]
+
+[[case]]
+name = "borrow_whole_variable_still_works"
+description = "Control: borrowing a whole local variable compiles and the value stays usable after the call."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+fn peek(borrow v: D) -> i32 { v.x }
+fn main() -> i32 {
+    let d = D { x: 7 };
+    let a = peek(borrow d);
+    let b = peek(borrow d);
+    a + b
+}
+""" }]
+exit_code = 14
+
+[[case]]
+name = "inout_whole_variable_still_works"
+description = "Control: passing a whole local as inout mutates it in place."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+fn bump(inout v: D) { v.x = v.x + 1; }
+fn main() -> i32 {
+    let mut d = D { x: 41 };
+    bump(inout d);
+    d.x
+}
+""" }]
+exit_code = 42
+
+# ---------------------------------------------------------------------------
+# Item 4: moves out of inout parameters are rejected
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "move_out_of_inout_rejected"
+description = "Moving an inout parameter into a by-value call left the caller's variable moved-from (returned garbage before the fix)."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+fn consume(d: D) -> i32 { d.x }
+fn steal(inout o: D) -> i32 { consume(o) }
+fn main() -> i32 {
+    let mut d = D { x: 7 };
+    let a = steal(inout d);
+    let b = consume(d);
+    a + b
+}
+""" }]
+compile_fail = true
+error_contains = ["E0437", "cannot move out of inout parameter"]
+
+[[case]]
+name = "move_out_of_inout_via_let_rejected"
+description = "A let-binding move out of an inout parameter is rejected the same way."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+fn steal(inout o: D) -> i32 {
+    let taken = o;
+    taken.x
+}
+fn main() -> i32 { let mut d = D { x: 7 }; steal(inout d) }
+""" }]
+compile_fail = true
+error_contains = ["E0437", "cannot move out of inout parameter"]
+
+[[case]]
+name = "move_out_of_inout_field_rejected"
+description = "Moving a non-Copy FIELD out of an inout parameter would leave the caller's variable partially moved-from."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+struct P { f: D }
+fn consume(d: D) -> i32 { d.x }
+fn steal(inout p: P) -> i32 { consume(p.f) }
+fn main() -> i32 { let mut p = P { f: D { x: 7 } }; steal(inout p) }
+""" }]
+compile_fail = true
+error_contains = ["E0437", "cannot move out of inout parameter"]
+
+[[case]]
+name = "move_out_of_borrow_field_rejected"
+description = "Moving a non-Copy field out of a borrow parameter is rejected (E0429), matching the whole-variable rule."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+struct P { f: D }
+fn consume(d: D) -> i32 { d.x }
+fn peek(borrow p: P) -> i32 { consume(p.f) }
+fn main() -> i32 { let p = P { f: D { x: 7 } }; peek(borrow p) }
+""" }]
+compile_fail = true
+error_contains = ["E0429", "cannot move out of borrowed value"]
+
+[[case]]
+name = "move_out_of_inout_in_loop_rejected"
+description = "The rejection also fires for moves inside a loop body (composes with the loop back-edge recheck)."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+fn consume(d: D) -> i32 { d.x }
+fn steal(inout o: D) -> i32 {
+    let mut i = 0;
+    let mut acc = 0;
+    while i < 2 {
+        acc = acc + consume(o);
+        i = i + 1;
+    }
+    acc
+}
+fn main() -> i32 { let mut d = D { x: 7 }; steal(inout d) }
+""" }]
+compile_fail = true
+error_contains = ["E0437", "cannot move out of inout parameter"]
+
+[[case]]
+name = "move_out_of_inout_with_reinit_still_rejected"
+description = "Reject-valid by design: reinitialization before exit is not tracked yet, so move-then-reassign still errors (see the E0437 help text)."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+fn consume(d: D) -> i32 { d.x }
+fn steal_and_reinit(inout o: D) -> i32 {
+    let v = consume(o);
+    o = D { x: 0 };
+    v
+}
+fn main() -> i32 { let mut d = D { x: 7 }; steal_and_reinit(inout d) }
+""" }]
+compile_fail = true
+error_contains = ["E0437", "cannot move out of inout parameter"]
+
+[[case]]
+name = "inout_forwarding_still_works"
+description = "Control: forwarding an inout parameter to another inout parameter is a re-borrow, not a move."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+fn g(inout v: D) -> i32 { v.x = v.x + 1; v.x }
+fn f(inout v: D) -> i32 { g(inout v) }
+fn main() -> i32 { let mut d = D { x: 7 }; f(inout d) }
+""" }]
+exit_code = 8
+
+[[case]]
+name = "inout_reassign_without_move_still_works"
+description = "Control: reassigning an inout parameter (without moving out of it) is the normal supported use."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+fn replace(inout o: D) {
+    o = D { x: 42 };
+}
+fn main() -> i32 {
+    let mut d = D { x: 7 };
+    replace(inout d);
+    d.x
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "inout_copy_field_read_still_works"
+description = "Control: reading a Copy field through an inout parameter is not a move."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+fn get(inout v: D) -> i32 { v.x }
+fn main() -> i32 { let mut d = D { x: 7 }; get(inout d) }
+""" }]
+exit_code = 7
+
+[[case]]
+name = "move_out_of_inout_rejected_in_imported_module"
+description = "The lazy (import-driven) analysis path enforces the same rule as the single-file path."
+args = ["main.rue", "lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+fn main() -> i32 {
+    let mut d = lib.D { x: 7 };
+    lib.steal(inout d)
+}
+""" },
+    { path = "lib.rue", source = """
+struct D { x: i32 }
+fn consume(d: D) -> i32 { d.x }
+fn steal(inout o: D) -> i32 { consume(o) }
+""" },
+]
+compile_fail = true
+error_contains = ["E0437", "cannot move out of inout parameter"]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -123,6 +123,8 @@ impl ErrorCode {
     pub const BORROW_KEYWORD_MISSING: Self = Self(432);
     pub const EMPTY_STRUCT: Self = Self(433);
     pub const RESERVED_FUNCTION_NAME: Self = Self(435);
+    pub const BY_REF_ARG_NOT_PLAIN_VARIABLE: Self = Self(438);
+    pub const MOVE_OUT_OF_INOUT: Self = Self(437);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -965,6 +967,14 @@ pub enum ErrorKind {
     /// Argument to borrow parameter is missing `borrow` keyword at call site
     #[error("argument to borrow parameter must use 'borrow' keyword")]
     BorrowKeywordMissing,
+    /// By-ref (inout/borrow) argument is a field or element projection, which
+    /// codegen cannot take the address of yet (RUE-127)
+    #[error("a by-ref argument must be a plain variable; passing a field is not yet supported")]
+    ByRefArgNotPlainVariable,
+    /// Cannot move a value out of an inout parameter (would leave the caller's
+    /// variable moved-from)
+    #[error("cannot move out of inout parameter '{variable}'")]
+    MoveOutOfInout { variable: String },
 
     // Control flow errors
     #[error("'break' outside of loop")]
@@ -1135,6 +1145,8 @@ impl ErrorKind {
             ErrorKind::BorrowInoutConflict { .. } => ErrorCode::BORROW_INOUT_CONFLICT,
             ErrorKind::InoutKeywordMissing => ErrorCode::INOUT_KEYWORD_MISSING,
             ErrorKind::BorrowKeywordMissing => ErrorCode::BORROW_KEYWORD_MISSING,
+            ErrorKind::ByRefArgNotPlainVariable => ErrorCode::BY_REF_ARG_NOT_PLAIN_VARIABLE,
+            ErrorKind::MoveOutOfInout { .. } => ErrorCode::MOVE_OUT_OF_INOUT,
 
             // Control flow errors (E0500-E0599)
             ErrorKind::BreakOutsideLoop => ErrorCode::BREAK_OUTSIDE_LOOP,


### PR DESCRIPTION
Two move-checking holes from the soundness epic, both verified by repro
before and after:

Projected by-ref arguments (item 3): passing a struct field as a borrow or
inout argument (peek(borrow o.f)) sailed through sema and panicked codegen
("by-ref argument must be a variable", cfg_lower.rs:1798). By-ref arguments
must now be plain variables — new E0438 with a "passing a field is not yet
supported" note. Covers function calls, method calls, and array elements,
on both sema implementations. Place-address lowering is the long-term fix
and stays in the epic.

Moves out of inout parameters (item 4): a callee could move out of an
inout param (fn steal(inout o: D) -> i32 { consume(o) }) with no
reinitialize-before-exit requirement, leaving the CALLER's variable
moved-from — a use-after-free shape that returned garbage today (observed
exit 127 for a 7+7 program). Any move out of an inout param is now
rejected flatly with E0437; the diagnostic documents the deliberately
conservative rule (reinitialization tracking may relax it later).
Field-level moves out of borrow params now also get the whole-var E0429
treatment. Inout forwarding (g(inout v) inside f(inout v)) keeps working
via an explicit byref-arg flag that replaces the old mark-then-unmove
hack — and composes with the loop re-move machinery (move-out in a loop
body errors; inout args in loops still compile).

Item 6 of the epic (Copy reads through a moved ancestor) was re-verified
still broken and remains tracked — the fix needs ancestor-moved checks on
Copy reads plus FieldSet auditing, too invasive to bundle here.

Fifteen CLI cases in byref_params.toml: the E0438/E0437/E0429 rejections
(including in-loop and reinit-then-return variants and a multi-file @import
case pinning the lazy path), plus controls for whole-var borrow/inout,
forwarding, reassign-only inout, and Copy field reads. Note E0438 was
renumbered from the worker's E0436 at integration: PR #930 takes E0436 for
DuplicateFunctionDefinition. Full test.sh green.

Part of RUE-127 (items 3, 4; remaining: 5, 6).



🤖 Generated with [Claude Code](https://claude.com/claude-code)
