### PR TITLE
Test trust: golden cases run execution assertions; ErrorCode injectivity; drop-ordering pinned

### DIFF
--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1486,6 +1486,91 @@ mod tests {
         );
     }
 
+    /// `ErrorKind::code()` must be injective: no two ErrorKind variants may
+    /// map to the same ErrorCode constant, and every constant must be used by
+    /// exactly one variant (a constant nobody maps to is dead, and usually a
+    /// sign that a variant was repointed at someone else's code).
+    ///
+    /// `test_error_codes_are_unique` (above) guards constant *values*; this
+    /// test guards the variant -> constant *mapping*. It scans the body of
+    /// `fn code()` in this file's source, so it can't go stale as variants
+    /// are added. It deliberately pins uniqueness, not specific code values.
+    #[test]
+    fn test_error_kind_to_code_mapping_is_injective() {
+        let src = include_str!("lib.rs");
+
+        // Collect all declared ErrorCode constant names.
+        let mut declared: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for line in src.lines() {
+            let Some(rest) = line.trim().strip_prefix("pub const ") else {
+                continue;
+            };
+            if let Some((name, _)) = rest.split_once(": Self = Self(") {
+                declared.insert(name);
+            }
+        }
+        assert!(
+            declared.len() > 50,
+            "expected to find the ErrorCode constants (found {})",
+            declared.len()
+        );
+
+        // Extract the body of `fn code()` by brace matching.
+        let start = src
+            .find("pub fn code(&self) -> ErrorCode {")
+            .expect("fn code() not found in lib.rs");
+        let open = start + src[start..].find('{').unwrap();
+        let mut depth = 0usize;
+        let mut end = open;
+        for (i, ch) in src[open..].char_indices() {
+            match ch {
+                '{' => depth += 1,
+                '}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        end = open + i;
+                        break;
+                    }
+                }
+                _ => {}
+            }
+        }
+        let body = &src[open..=end];
+
+        // Count every `ErrorCode::CONST` reference in the match arms.
+        let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+        let mut rest = body;
+        while let Some(pos) = rest.find("ErrorCode::") {
+            rest = &rest[pos + "ErrorCode::".len()..];
+            let name_len = rest
+                .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_'))
+                .unwrap_or(rest.len());
+            let name = &rest[..name_len];
+            *counts.entry(name).or_insert(0) += 1;
+        }
+
+        let duplicates: Vec<_> = counts.iter().filter(|&(_, &c)| c > 1).collect();
+        assert!(
+            duplicates.is_empty(),
+            "ErrorCode constants mapped by more than one ErrorKind variant in code(): {:?}",
+            duplicates
+        );
+
+        let referenced: std::collections::HashSet<&str> = counts.keys().copied().collect();
+        let orphans: Vec<_> = declared.difference(&referenced).collect();
+        assert!(
+            orphans.is_empty(),
+            "ErrorCode constants declared but never mapped by any ErrorKind variant: {:?}",
+            orphans
+        );
+        let undeclared: Vec<_> = referenced.difference(&declared).collect();
+        assert!(
+            undeclared.is_empty(),
+            "code() references ErrorCode constants that are not declared: {:?}",
+            undeclared
+        );
+    }
+
     #[test]
     fn test_error_with_span() {
         let span = Span::new(10, 20);

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -45,9 +45,13 @@ exit_code = 42
 [[case]]
 name = "drop_order_reverse_declaration"
 spec = ["3.9:4", "3.9:5", "3.9:6"]
-description = "Multiple values dropped in reverse declaration order (LIFO)"
+description = "Multiple values dropped in reverse declaration order (LIFO); expected_stdout pins the ORDER, not just that drops happen"
 source = """
 struct Data { value: i32 }
+
+drop fn Data(self) {
+    @dbg(self.value);
+}
 
 fn main() -> i32 {
     let a = Data { value: 1 };  // declared first
@@ -56,6 +60,7 @@ fn main() -> i32 {
 }  // b dropped first, then a dropped
 """
 exit_code = 3
+expected_stdout = "2\n1\n"
 
 # =============================================================================
 # Trivially Droppable Types
@@ -208,9 +213,13 @@ exit_code = 42
 [[case]]
 name = "drop_before_early_return"
 spec = ["3.9:18", "3.9:20"]
-description = "Values are dropped before early return"
+description = "Values are dropped before early return; expected_stdout pins that the destructor actually runs on the early-return path"
 source = """
 struct Data { value: i32 }
+
+drop fn Data(self) {
+    @dbg(self.value);
+}
 
 fn example(condition: bool) -> i32 {
     let a = Data { value: 1 };
@@ -225,13 +234,18 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+expected_stdout = "1\n"
 
 [[case]]
 name = "drop_in_each_branch"
 spec = ["3.9:19", "3.9:20"]
-description = "Each branch independently drops its bindings"
+description = "Each branch independently drops its bindings; expected_stdout pins LIFO order (b before a) on the taken branch"
 source = """
 struct Data { value: i32 }
+
+drop fn Data(self) {
+    @dbg(self.value);
+}
 
 fn example(condition: bool) -> i32 {
     let a = Data { value: 1 };
@@ -248,6 +262,7 @@ fn main() -> i32 {
 }
 """
 exit_code = 3
+expected_stdout = "2\n1\n"
 
 # =============================================================================
 # Types with Destructors (String)
@@ -319,7 +334,31 @@ exit_code = 42
 [[case]]
 name = "field_drop_order"
 spec = ["3.9:13"]
-description = "Fields dropped in declaration order"
+description = "Fields dropped in declaration order; the field destructors' @dbg output pins the ORDER (first, then second), so inverted field-drop order fails"
+source = """
+struct Member { id: i32 }
+
+drop fn Member(self) {
+    @dbg(self.id);
+}
+
+struct Pair {
+    first: Member,
+    second: Member,
+}
+
+fn main() -> i32 {
+    let p = Pair { first: Member { id: 1 }, second: Member { id: 2 } };
+    p.first.id - 1
+}  // Pair dropped: first field dropped (prints 1), then second field (prints 2)
+"""
+exit_code = 0
+expected_stdout = "1\n2\n"
+
+[[case]]
+name = "struct_with_string_fields_dropped"
+spec = ["3.9:13"]
+description = "Struct whose String fields require cleanup drops each field (heap buffers freed)"
 source = """
 struct TwoStrings {
     first: String,
@@ -368,7 +407,9 @@ cfg main (return_type: i32) {
 
 [[case]]
 name = "cfg_multiple_variables_drop_order"
-description = "CFG shows StorageDead in reverse declaration order (LIFO)"
+# This case combines a golden assertion with exit_code on purpose: the runner
+# must verify BOTH (regression test for the silent execution-skip, RUE-132).
+description = "CFG shows StorageDead in reverse declaration order (LIFO), and the program runs with the expected result"
 source = """
 fn main() -> i32 {
     let a = 1;
@@ -376,6 +417,7 @@ fn main() -> i32 {
     a + b
 }
 """
+exit_code = 3
 expected_cfg = """
 cfg main (return_type: i32) {
   bb0:

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -857,14 +857,14 @@ error_contains = "cannot be marked @copy"
 [[case]]
 name = "linear_copy_reverse_order_error"
 spec = ["3.8:37"]
-description = "Linear and @copy in reverse order is also an error"
+description = "Writing @copy after linear is also rejected: directives must precede the linear keyword, so the reverse order is a syntax error"
 source = """
-linear struct Invalid { value: i32 }
+linear @copy struct Invalid { value: i32 }
 
 fn main() -> i32 { 0 }
 """
-compile_fail = false
-exit_code = 0
+compile_fail = true
+error_contains = "expected 'struct', found '@'"
 
 [[case]]
 name = "linear_struct_chain_consumed"

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -108,6 +108,21 @@ impl<'de> Deserialize<'de> for ErrorContains {
 }
 
 /// A single test case.
+///
+/// # Golden-IR assertions vs execution assertions
+///
+/// Golden-IR assertions (`expected_tokens`, `expected_ast`, `expected_rir`,
+/// `expected_air`, `expected_cfg`, `expected_mir`) are checked by running
+/// `rue --emit <stage>` and comparing the dump. Execution assertions
+/// (`exit_code`, `expected_stdout`, `runtime_error`, warning checks, ...)
+/// are checked by compiling and running the program.
+///
+/// A case may combine both: ALL of its assertions are verified — the golden
+/// comparisons run first, then the program is compiled and executed for the
+/// execution assertions. (Previously the execution assertions were silently
+/// skipped when a golden assertion was present; see RUE-132.)
+/// `compile_fail` cannot be combined with golden-IR assertions, since a
+/// program that fails to compile has no IR to dump.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Case {
@@ -234,6 +249,38 @@ pub struct Case {
     /// If not specified, the test runs on all platforms.
     #[serde(default)]
     pub only_on: Vec<String>,
+}
+
+impl Case {
+    /// Whether this case carries any golden-IR assertions (checked against
+    /// `rue --emit <stage>` output).
+    pub fn has_golden_ir_assertions(&self) -> bool {
+        self.expected_tokens.is_some()
+            || self.expected_ast.is_some()
+            || self.expected_rir.is_some()
+            || self.expected_air.is_some()
+            || self.expected_cfg.is_some()
+            || self.expected_mir.is_some()
+    }
+
+    /// Whether this case carries assertions that require actually compiling
+    /// the program to a binary (and, unless `compile_only`, running it).
+    ///
+    /// Used so a case combining golden-IR assertions with execution
+    /// assertions verifies BOTH, instead of silently skipping the execution
+    /// half (RUE-132).
+    pub fn has_execution_assertions(&self) -> bool {
+        self.exit_code.is_some()
+            || self.expected_stdout.is_some()
+            || self.runtime_error.is_some()
+            || self.runtime_exit_code.is_some()
+            || self.stdin.is_some()
+            || self.stderr_contains.is_some()
+            || self.compile_only
+            || self.no_warnings
+            || self.expected_warning_count.is_some()
+            || self.warning_contains.is_some()
+    }
 }
 
 /// A test file containing a section and its cases.
@@ -693,6 +740,9 @@ pub fn check_golden(actual: &str, expected: &str, label: &str) -> TestResult {
 
 /// Map emit stage flag to the header name used in the compiler output.
 /// For example, "rir" -> "RIR", "tokens" -> "Tokens"
+///
+/// Only stages with a corresponding `expected_*` field on [`Case`] are
+/// listed; if an `expected_asm` field is ever added, extend this mapping.
 fn stage_to_header_name(stage: &str) -> &'static str {
     match stage {
         "tokens" => "Tokens",
@@ -701,7 +751,6 @@ fn stage_to_header_name(stage: &str) -> &'static str {
         "air" => "AIR",
         "cfg" => "CFG",
         "mir" => "MIR",
-        "asm" => "ASM",
         _ => panic!("Unknown stage: {}", stage),
     }
 }
@@ -888,13 +937,16 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
     };
 
     // Check for golden IR tests (tokens, AST, RIR, AIR, CFG, MIR)
-    if case.expected_tokens.is_some()
-        || case.expected_ast.is_some()
-        || case.expected_rir.is_some()
-        || case.expected_air.is_some()
-        || case.expected_cfg.is_some()
-        || case.expected_mir.is_some()
-    {
+    if case.has_golden_ir_assertions() {
+        // A program that fails to compile has no IR to dump, so this
+        // combination can never be satisfied — reject it loudly rather than
+        // letting one half of the case go unchecked.
+        if case.compile_fail {
+            return Err("golden IR assertions cannot be combined with compile_fail \
+                 (use expected_error / error_contains for diagnostics instead)"
+                .to_string());
+        }
+
         // Run dump commands and check golden output
         if let Some(ref expected) = case.expected_tokens {
             run_golden_ir_test(rue_binary, &source_path, "tokens", expected, &build_command)?;
@@ -927,7 +979,13 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
             run_golden_ir_test(rue_binary, &source_path, "mir", expected, &build_command)?;
         }
 
-        return Ok(());
+        // A case may combine golden-IR assertions with execution assertions
+        // (exit_code, expected_stdout, ...). When it does, fall through and
+        // verify those too — returning here would silently skip them
+        // (RUE-132). A pure golden case is done at this point.
+        if !case.has_execution_assertions() {
+            return Ok(());
+        }
     }
 
     // Compile with rue
@@ -1811,6 +1869,45 @@ mod tests {
         assert_eq!(errors.len(), 2);
         assert_eq!(errors[0].feature_name, "unknown1");
         assert_eq!(errors[1].feature_name, "unknown2");
+    }
+
+    // Tests for golden-IR / execution assertion classification (RUE-132)
+
+    #[test]
+    fn test_has_golden_ir_assertions() {
+        let mut case = make_test_case("golden", None);
+        case.exit_code = None;
+        assert!(!case.has_golden_ir_assertions());
+        case.expected_cfg = Some("cfg main {}".to_string());
+        assert!(case.has_golden_ir_assertions());
+    }
+
+    #[test]
+    fn test_has_execution_assertions_exit_code() {
+        // make_test_case sets exit_code = Some(0)
+        let case = make_test_case("exec", None);
+        assert!(case.has_execution_assertions());
+    }
+
+    #[test]
+    fn test_has_execution_assertions_stdout_only() {
+        let mut case = make_test_case("exec", None);
+        case.exit_code = None;
+        assert!(!case.has_execution_assertions());
+        case.expected_stdout = Some("1\n2\n".to_string());
+        assert!(
+            case.has_execution_assertions(),
+            "expected_stdout must force the program to actually run"
+        );
+    }
+
+    #[test]
+    fn test_pure_golden_case_has_no_execution_assertions() {
+        let mut case = make_test_case("golden", None);
+        case.exit_code = None;
+        case.expected_air = Some("air".to_string());
+        assert!(case.has_golden_ir_assertions());
+        assert!(!case.has_execution_assertions());
     }
 
     #[test]


### PR DESCRIPTION
Three more items from the test-infrastructure-trust epic:

Golden cases (item 6): a spec case combining golden-IR output with
execution assertions ran only the golden comparison — its exit_code /
expected_stdout were silently dead (reproduced: a case with correct
expected_air, WRONG exit_code, and bogus expected_stdout passed). The
harness now runs both: golden --emit comparisons first, then compile+run
when execution assertions are present; compile_fail + golden-IR is
rejected loudly as unsatisfiable. The dead "asm" header mapping is gone.
One in-suite case (cfg_multiple_variables_drop_order) now exercises the
combination live.

ErrorCode injectivity (item 7): nothing guarded against two ErrorKind
variants mapping to the same E-code. A new test parses the code() mapping
and asserts every ErrorCode constant is claimed by exactly one variant —
no duplicates, no orphans, no undeclared refs. This is timely: the two
worker branches in this very cycle independently claimed E0436, which this
test would have caught at queue-merge (renumbered to E0438 in #931).

Drop-ordering (item 8): the drop-semantics spec cases asserted only exit
codes, so they passed under fully INVERTED destruction order. They now pin
order with @dbg destructor output: reverse declaration order ("2\n1\n"),
per-branch drops, early-return drops, and declaration-order field drops
(all verified against the real compiler). linear_copy_reverse_order_error
tested nothing its name claims (no @copy in its source, compile_fail
false); it now actually asserts the grammar rejects "linear @copy" in
reverse order.

Full test.sh green.

Part of RUE-132 (items 6, 7, 8; remaining: bare compile_fail assertions,
buck command_test targets, harness timeouts).



🤖 Generated with [Claude Code](https://claude.com/claude-code)
