### PR TITLE
Load @import-ed modules from disk: transitive import discovery in the driver

### DIFF
--- a/crates/rue-air/src/sema/module_path.rs
+++ b/crates/rue-air/src/sema/module_path.rs
@@ -91,8 +91,11 @@ impl ModulePath {
     {
         match self {
             ModulePath::Std => {
-                // Standard library not supported yet
-                None
+                // The standard library's entry point is std/_std.rue. The
+                // driver loads it from $RUE_STD_PATH or an adjacent std/
+                // directory (see discover_and_load_imports in the rue crate);
+                // here we just match it among the loaded files.
+                self.resolve_explicit("_std.rue", loaded_paths)
             }
             ModulePath::ExplicitRue { path } => self.resolve_explicit(path, loaded_paths),
             ModulePath::Simple { path } => self.resolve_simple(path, loaded_paths),

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -27,11 +27,10 @@ pub fn triple(x: i32) -> i32 {
 ]
 exit_code = 0
 
-# ...but actually CALLING into the imported module fails: the resolved file
-# is never loaded/compiled. "undefined function 'triple'" (RUE-14).
+# Calling into the imported module: the driver discovers @import references
+# and loads the resolved files from disk transitively (RUE-14).
 [[case]]
 name = "import_call_through_local_let"
-known_bug = "RUE-14"
 files = [
     { path = "main.rue", source = """
 fn main() -> i32 {
@@ -49,10 +48,9 @@ pub fn triple(x: i32) -> i32 {
 stdout = "42\n"
 
 # Top-level `const utils = @import("utils")` — the idiomatic form from
-# ADR-0026 — fails outright with "cannot find module" (RUE-14).
+# ADR-0026.
 [[case]]
 name = "import_call_through_top_level_const"
-known_bug = "RUE-14"
 files = [
     { path = "main.rue", source = """
 const utils = @import("utils");
@@ -91,7 +89,6 @@ exit_code = 0
 # Directory module: _utils.rue alongside a utils/ directory (ADR-0026).
 [[case]]
 name = "import_directory_module_call"
-known_bug = "RUE-14"
 files = [
     { path = "main.rue", source = """
 const utils = @import("utils");
@@ -117,7 +114,7 @@ stdout = "42\n"
 # The standard library via a std/ directory adjacent to the source.
 [[case]]
 name = "import_std_adjacent_dir"
-known_bug = "RUE-14"
+known_bug = "RUE-136"
 files = [
     { path = "main.rue", source = """
 const std = @import("std");
@@ -141,7 +138,7 @@ stdout = "5\n"
 # The standard library via RUE_STD_PATH pointing at the repo's real std/.
 [[case]]
 name = "import_std_via_env_var"
-known_bug = "RUE-14"
+known_bug = "RUE-136"
 files = [{ path = "main.rue", source = """
 const std = @import("std");
 
@@ -199,3 +196,52 @@ fn main() -> i32 {
 ]
 args = ["color.rue", "main.rue", "-o", "prog"]
 exit_code = 2
+
+# Transitive discovery: main imports a, a imports b — only main.rue is on
+# the command line; the driver's import scan must load both (RUE-14).
+[[case]]
+name = "import_transitive_chain"
+files = [
+    { path = "main.rue", source = """
+const a = @import("a");
+
+fn main() -> i32 {
+    @dbg(a.double(21));
+    0
+}
+""" },
+    { path = "a.rue", source = """
+const b = @import("b");
+
+pub fn double(x: i32) -> i32 {
+    b.add(x, x)
+}
+""" },
+    { path = "b.rue", source = """
+pub fn add(x: i32, y: i32) -> i32 {
+    x + y
+}
+""" },
+]
+stdout = "42\n"
+
+# Direct member access on a loaded std (no const re-export chain): proves
+# std loading itself works; the re-export chain is RUE-136.
+[[case]]
+name = "import_std_direct_member"
+files = [
+    { path = "main.rue", source = """
+const std = @import("std");
+
+fn main() -> i32 {
+    @dbg(std.abs(0 - 5));
+    0
+}
+""" },
+    { path = "std/_std.rue", source = """
+pub fn abs(x: i32) -> i32 {
+    if x < 0 { 0 - x } else { x }
+}
+""" },
+]
+stdout = "5\n"

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -15,7 +15,7 @@ mod timing;
 
 use rue_compiler::{
     CompileOptions, FileId, Lexer, LinkerMode, MultiFileFormatter, OptLevel, ParsedProgram,
-    PreviewFeature, PreviewFeatures, SourceFile, SourceInfo,
+    PreviewFeature, PreviewFeatures, SourceFile, SourceInfo, TokenKind,
     compile_frontend_from_ast_with_options, compile_multi_file_with_options, generate_emitted_asm,
     generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
     generate_stack_frame_info, merge_symbols, parse_all_files,
@@ -735,6 +735,115 @@ fn get_peak_memory_bytes() -> Option<u64> {
     }
 }
 
+/// Discover `@import("...")` references in the given sources and load the
+/// referenced module files from disk, transitively, appending them to
+/// `sources` as if the user had listed them on the command line.
+///
+/// Sema resolves import paths only against loaded files (see
+/// `resolve_import_path_for_const`), so this is the step that makes
+/// `@import` work without hand-listing every module (RUE-14).
+///
+/// Imports are found by scanning the token stream (so comments and string
+/// contents are handled correctly) for the `@import ( "<path>" )` shape.
+/// Resolution mirrors sema's `ModulePath` order, probing the filesystem:
+///
+/// - `"std"`: `$RUE_STD_PATH/_std.rue`, then `std/_std.rue` relative to the
+///   importing file, then relative to the first (root) source file
+/// - `"foo.rue"`: exact path relative to the importing file, then the root
+/// - `"foo"` / `"a/b"`: `{path}.rue` then the `_{basename}.rue` facade,
+///   relative to the importing file, then the root
+///
+/// Unresolvable imports are left for sema to report (E0704 with candidate
+/// context); this function only loads what it can find.
+fn discover_and_load_imports(sources: &mut Vec<(String, String)>) {
+    use std::collections::HashSet;
+    use std::path::PathBuf;
+
+    let root_dir = Path::new(&sources[0].0)
+        .parent()
+        .map(PathBuf::from)
+        .unwrap_or_default();
+
+    // Canonical paths of everything already loaded (for dedupe and cycles).
+    let mut loaded: HashSet<PathBuf> = sources
+        .iter()
+        .filter_map(|(p, _)| fs::canonicalize(p).ok())
+        .collect();
+
+    let mut i = 0;
+    while i < sources.len() {
+        let (importer_path, content) = (sources[i].0.clone(), sources[i].1.clone());
+        i += 1;
+
+        let lexer = Lexer::new(&content);
+        let Ok((tokens, interner)) = lexer.tokenize() else {
+            // Lex errors will be reported properly during compilation.
+            continue;
+        };
+
+        for w in tokens.windows(4) {
+            let (
+                TokenKind::AtImport(_),
+                TokenKind::LParen,
+                TokenKind::String(s),
+                TokenKind::RParen,
+            ) = (&w[0].kind, &w[1].kind, &w[2].kind, &w[3].kind)
+            else {
+                continue;
+            };
+            let import_str = interner.resolve(s);
+
+            let importer_dir = Path::new(&importer_path)
+                .parent()
+                .map(PathBuf::from)
+                .unwrap_or_default();
+
+            let mut candidates: Vec<PathBuf> = Vec::new();
+            if import_str == "std" {
+                if let Ok(std_path) = env::var("RUE_STD_PATH") {
+                    candidates.push(Path::new(&std_path).join("_std.rue"));
+                }
+                candidates.push(importer_dir.join("std/_std.rue"));
+                candidates.push(root_dir.join("std/_std.rue"));
+            } else if import_str.ends_with(".rue") {
+                candidates.push(importer_dir.join(import_str));
+                candidates.push(root_dir.join(import_str));
+            } else {
+                let rel = Path::new(import_str);
+                let facade = match rel.parent() {
+                    Some(parent) if parent != Path::new("") => parent.join(format!(
+                        "_{}.rue",
+                        rel.file_name().unwrap_or_default().to_string_lossy()
+                    )),
+                    _ => PathBuf::from(format!("_{}.rue", import_str)),
+                };
+                candidates.push(importer_dir.join(format!("{import_str}.rue")));
+                candidates.push(importer_dir.join(&facade));
+                candidates.push(root_dir.join(format!("{import_str}.rue")));
+                candidates.push(root_dir.join(&facade));
+            }
+
+            for candidate in candidates {
+                let Ok(canonical) = fs::canonicalize(&candidate) else {
+                    continue;
+                };
+                if !canonical.is_file() {
+                    continue;
+                }
+                if loaded.contains(&canonical) {
+                    break; // already loaded (or a cycle) — nothing to do
+                }
+                let Ok(module_content) = fs::read_to_string(&candidate) else {
+                    continue;
+                };
+                loaded.insert(canonical);
+                sources.push((candidate.to_string_lossy().into_owned(), module_content));
+                break; // first match wins, matching ModulePath's order
+            }
+        }
+    }
+}
+
 fn main() {
     let options = match parse_args() {
         Some(opts) => opts,
@@ -751,7 +860,7 @@ fn main() {
     );
 
     // Read all source files into memory
-    let sources: Vec<(String, String)> = options
+    let mut sources: Vec<(String, String)> = options
         .source_paths
         .iter()
         .map(|path| {
@@ -762,6 +871,13 @@ fn main() {
             (path.clone(), content)
         })
         .collect();
+
+    // Discover and load @import-ed modules from disk, transitively. Sema
+    // resolves imports only against already-loaded files, so without this
+    // step `const utils = @import("utils")` fails with E0704 unless the
+    // user hand-lists every module on the command line (RUE-14).
+    discover_and_load_imports(&mut sources);
+    let sources = sources;
 
     // Build SourceFile structs for multi-file compilation
     let source_files: Vec<SourceFile<'_>> = sources


### PR DESCRIPTION
The module system resolved imports only against files already passed on the
command line — nothing in the pipeline ever read a resolved module file
from disk. So `const utils = @import("utils")` failed with E0704 unless the
user hand-listed every module, and the let-bound form resolved the path but
called into a function table that never contained the module's functions
("undefined function"). The stdlib was unusable, full stop.

The driver now runs a transitive discovery pass before compilation: each
source's token stream is scanned for the `@import("...")` shape (token
level, so comments and string contents can't confuse it), the path is
resolved against the filesystem mirroring sema's ModulePath order —
$RUE_STD_PATH/_std.rue then an adjacent std/ dir for "std"; exact path for
"foo.rue"; {path}.rue then the _{basename}.rue facade for simple paths —
relative to the importing file's directory and then the root source's, and
each newly found file is loaded as if listed on the command line.
Discovered files are scanned too (worklist), with canonicalized-path dedupe
handling diamonds and cycles. Unresolvable imports are left for sema's
existing E0704 with candidate context.

Sema's ModulePath::Std arm was a hardcoded None ("not supported yet"); it
now matches a loaded _std.rue facade, so `const std = @import("std")`
resolves end-to-end and direct members work: std.abs(-5) returns 5 via
either an adjacent std/ directory or RUE_STD_PATH.

CLI cases: known_bug markers removed from the three module shapes this
fixes (let-bound call, top-level-const call, directory facade — all now
green), plus new cases for a transitive a->b import chain and direct std
member access. The remaining gap is member access through a const module
RE-EXPORT (pub const math = @import(...) — the std.math.abs chain, E0707):
filed as RUE-136 with the two std-chain cases re-pointed at it.

Full test.sh green.

Fixes RUE-14



🤖 Generated with [Claude Code](https://claude.com/claude-code)
