### PR TITLE
Driver: --emit parity with normal builds; panic-hook ICE banner; full benchmark metrics

### DIFF
--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -1,0 +1,45 @@
+# The --emit pipeline must behave like a normal build (RUE-130 items 3-4):
+# same module resolution, same warnings. It used to skip sema's file paths
+# (module programs failed E0704 only under --emit) and silently drop all
+# warnings.
+
+[section]
+id = "cli.emit_pipeline"
+name = "--emit pipeline parity"
+description = "--emit modes resolve modules and report warnings like a normal build."
+
+[[case]]
+name = "emit_air_warnings_not_dropped"
+description = "Warnings were silently dropped in all --emit modes (RUE-130 item 3)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let unused = 1;
+    0
+}
+""" }]
+args = ["--emit", "air", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== AIR ==="]
+compile_stderr_contains = ["unused variable", "'unused'"]
+
+[[case]]
+name = "emit_air_resolves_modules"
+description = "--emit skipped sema.set_file_paths, so module programs failed E0704 only under --emit (RUE-130 item 4)."
+files = [
+    { path = "main.rue", source = """
+const utils = @import("utils");
+
+fn main() -> i32 {
+    utils.triple(2)
+}
+""" },
+    { path = "utils.rue", source = """
+pub fn triple(x: i32) -> i32 {
+    x * 3
+}
+""" },
+]
+args = ["--emit", "air", "main.rue", "utils.rue"]
+compile_only = true
+compile_stdout_contains = ["=== AIR ==="]
+compile_stderr_not_contains = ["E0704"]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -142,6 +142,11 @@ struct Case {
     /// Substrings expected in the compiler's stdout (e.g. `--emit` output).
     #[serde(default)]
     compile_stdout_contains: Vec<String>,
+    /// Substrings that MUST appear in the compiler's stderr, regardless of
+    /// whether compilation succeeds or fails. Use for warnings that must
+    /// survive a successful compile (e.g. under `--emit`).
+    #[serde(default)]
+    compile_stderr_contains: Vec<String>,
     /// Substrings that must NOT appear in the compiler's stderr, regardless of
     /// whether compilation succeeds or fails. Use to guard against debug spew
     /// or leaked internal diagnostics (e.g. raw `DEBUG:` eprintln lines).
@@ -243,6 +248,15 @@ fn run_case(case: &Case, rue_binary: &Path, real_std: &Path) -> TestResult {
     }
 
     // Debug-spew / leaked-diagnostics guard runs regardless of compile outcome.
+    for expected in &case.compile_stderr_contains {
+        if !compile_stderr.contains(expected) {
+            return Err(format!(
+                "compiler stderr missing expected substring: {}\n--- actual stderr ---\n{}",
+                expected, compile_stderr
+            ));
+        }
+    }
+
     for forbidden in &case.compile_stderr_not_contains {
         if compile_stderr.contains(forbidden) {
             return Err(format!(

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -824,6 +824,26 @@ pub fn compile_frontend_from_ast_with_options(
     opt_level: OptLevel,
     preview_features: &PreviewFeatures,
 ) -> MultiErrorResult<CompileState> {
+    compile_frontend_from_ast_with_file_paths(
+        ast,
+        interner,
+        opt_level,
+        preview_features,
+        std::collections::HashMap::new(),
+    )
+}
+
+/// Like [`compile_frontend_from_ast_with_options`], but with the
+/// file_id -> path mapping sema needs for `@import` resolution. The `--emit`
+/// pipeline used to skip this, so module programs that built normally failed
+/// with E0704 under `--emit` (RUE-130).
+pub fn compile_frontend_from_ast_with_file_paths(
+    ast: Ast,
+    interner: ThreadedRodeo,
+    opt_level: OptLevel,
+    preview_features: &PreviewFeatures,
+    file_paths: std::collections::HashMap<FileId, String>,
+) -> MultiErrorResult<CompileState> {
     // AST to RIR (untyped IR)
     let (rir, interner) = {
         let _span = info_span!("astgen").entered();
@@ -836,7 +856,8 @@ pub fn compile_frontend_from_ast_with_options(
     // Semantic analysis (RIR to AIR) - this now collects multiple errors
     let sema_output = {
         let _span = info_span!("sema").entered();
-        let sema = Sema::new(&rir, &interner, preview_features.clone());
+        let mut sema = Sema::new(&rir, &interner, preview_features.clone());
+        sema.set_file_paths(file_paths);
         let output = sema.analyze_all()?;
         info!(
             function_count = output.functions.len(),

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -16,9 +16,9 @@ mod timing;
 use rue_compiler::{
     CompileOptions, FileId, Lexer, LinkerMode, MultiFileFormatter, OptLevel, ParsedProgram,
     PreviewFeature, PreviewFeatures, SourceFile, SourceInfo, TokenKind,
-    compile_frontend_from_ast_with_options, compile_multi_file_with_options, generate_emitted_asm,
-    generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
-    generate_stack_frame_info, merge_symbols, parse_all_files,
+    compile_multi_file_with_options, generate_emitted_asm, generate_liveness_info,
+    generate_lowering_info, generate_mir, generate_regalloc_info, generate_stack_frame_info,
+    merge_symbols, parse_all_files,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
@@ -452,6 +452,12 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     let (source_paths, final_output_path) = if let Some(out) = output_path {
         // -o was specified: all positional args are source files
         (positional, out)
+    } else if !emit_stages.is_empty() {
+        // --emit produces no executable, so there is no output positional:
+        // every positional arg is a source file. Without this, the legacy
+        // two-positional mode claimed the second FILE as the output path and
+        // `--emit air a.rue b.rue` was impossible (RUE-130).
+        (positional, "a.out".to_string())
     } else if positional.len() == 1 {
         // Single source file, no -o: default output to a.out
         (positional, "a.out".to_string())
@@ -845,6 +851,19 @@ fn discover_and_load_imports(sources: &mut Vec<(String, String)>) {
 }
 
 fn main() {
+    // Present compiler panics as internal compiler errors with a report
+    // banner instead of a raw Rust backtrace pointer (RUE-130). The default
+    // hook still runs first so RUST_BACKTRACE=1 output is preserved.
+    let default_panic_hook = std::panic::take_hook();
+    std::panic::set_hook(Box::new(move |info| {
+        default_panic_hook(info);
+        eprintln!();
+        eprintln!("error: internal compiler error: the compiler panicked; this is a bug in rue");
+        eprintln!("note: rue version {}", VERSION);
+        eprintln!("note: please report this at https://github.com/rue-language/rue/issues");
+        eprintln!("note: re-run with RUST_BACKTRACE=1 for a backtrace");
+    }));
+
     let options = match parse_args() {
         Some(opts) => opts,
         None => std::process::exit(1),
@@ -901,21 +920,26 @@ fn main() {
         .collect();
     let formatter = MultiFileFormatter::new(source_infos);
 
-    // Also keep a single-file formatter for the primary file (for source metrics)
-    let (_primary_path, primary_source) = &sources[0];
-
     // Compute source metrics if benchmark JSON is requested
     let source_metrics = if options.benchmark_json {
-        // We need token count, so do a quick lex
-        let lexer = Lexer::new(primary_source);
-        let token_count = match lexer.tokenize() {
-            Ok((tokens, _interner)) => tokens.len(),
-            Err(_) => 0, // If lexing fails, we'll get the error during compilation anyway
-        };
+        // Sum metrics across ALL files — measuring only the first file made
+        // multi-file benchmark numbers meaningless (RUE-130).
+        let mut bytes = 0usize;
+        let mut lines = 0usize;
+        let mut tokens = 0usize;
+        for (_, content) in &sources {
+            bytes += content.len();
+            lines += content.lines().count();
+            let lexer = Lexer::new(content);
+            if let Ok((toks, _interner)) = lexer.tokenize() {
+                tokens += toks.len();
+            }
+            // If lexing fails, we'll get the error during compilation anyway
+        }
         Some(timing::SourceMetrics {
-            bytes: primary_source.len(),
-            lines: primary_source.lines().count(),
-            tokens: token_count,
+            bytes,
+            lines,
+            tokens,
         })
     } else {
         None
@@ -1127,11 +1151,18 @@ fn handle_emit_multi_file(
             }
         };
 
-        let state = match compile_frontend_from_ast_with_options(
+        // Thread file paths through so @import resolution works under --emit
+        // exactly as in a normal build (RUE-130).
+        let file_paths: std::collections::HashMap<FileId, String> = sources
+            .iter()
+            .map(|s| (s.file_id, s.path.to_string()))
+            .collect();
+        let state = match rue_compiler::compile_frontend_from_ast_with_file_paths(
             merged.ast,
             merged.interner,
             options.opt_level,
             &options.preview_features,
+            file_paths,
         ) {
             Ok(state) => state,
             Err(errors) => {
@@ -1139,6 +1170,11 @@ fn handle_emit_multi_file(
                 return Err(());
             }
         };
+
+        // Warnings used to be silently dropped in all --emit modes (RUE-130).
+        if !state.warnings.is_empty() {
+            eprintln!("{}", formatter.format_warnings(&state.warnings));
+        }
 
         Some(state)
     } else {
@@ -1742,6 +1778,10 @@ mod tests {
 
     #[test]
     fn parse_all_options_combined() {
+        // Under --emit no executable is produced, so there is no output
+        // positional: every positional is a source file (RUE-130). The old
+        // behavior claimed the second positional as a (dead) output path,
+        // which made multi-file --emit impossible.
         let opts = unwrap_options(parse_args_from(&[
             "--target",
             "x86_64-linux",
@@ -1751,10 +1791,9 @@ mod tests {
             "--emit",
             "air",
             "source.rue",
-            "output",
+            "other.rue",
         ]));
-        assert_eq!(opts.source_paths, vec!["source.rue"]);
-        assert_eq!(opts.output_path, "output");
+        assert_eq!(opts.source_paths, vec!["source.rue", "other.rue"]);
         assert_eq!(opts.target, Target::X86_64Linux);
         assert_eq!(opts.linker, LinkerMode::System("clang".to_string()));
         assert_eq!(opts.opt_level, OptLevel::O2);


### PR DESCRIPTION
The --emit pipeline diverged from normal builds in four user-visible ways
(driver-hardening epic, items 2-5 and 7):

- Module programs failed E0704 only under --emit: the emit path called the
  frontend without sema's file_id->path mapping. A new
  compile_frontend_from_ast_with_file_paths threads it through (the old
  entry point delegates with an empty map), so @import programs emit IR
  exactly like they build.
- Warnings were silently dropped in every --emit mode: the frontend state's
  warnings were computed and discarded. They now print to stderr via the
  multi-file formatter, same as a normal build.
- Multi-file --emit was impossible: with no -o, the legacy two-positional
  parse claimed the second FILE as the output path ("refusing to use
  'b.rue' as the output path") — but --emit produces no executable. Under
  --emit every positional is now a source file. One parse_args unit test
  pinned the old dead-output behavior and is updated.
- --benchmark-json source metrics measured only the first file; bytes,
  lines, and tokens now sum across all files.

Also installs a panic hook (item 5): a compiler panic now prints an
"internal compiler error: this is a bug in rue" banner with the version and
the issue-tracker URL after the standard panic output, instead of ending on
a bare backtrace pointer.

Item 2's reported lex-error misattribution under --emit tokens no longer
reproduces (file ids ride the tokens since the FileId threading fixes);
covered by the multifile_errors cases.

CLI: new emit_pipeline.toml cases pin warnings-under-emit and
modules-under-emit; the harness gains compile_stderr_contains (positive
mirror of the existing not_contains) to assert warnings on a successful
compile. Full test.sh green.

Part of RUE-130 (items 2-5, 7; remaining: item 6 landed in #930).



🤖 Generated with [Claude Code](https://claude.com/claude-code)
