### PR TITLE
Aggregate ABI: stack-spill args past the register budget; sret returns for String and large aggregates

### DIFF
--- a/crates/rue-cli-tests/cases/abi.toml
+++ b/crates/rue-cli-tests/cases/abi.toml
@@ -1,22 +1,18 @@
 # By-value aggregate ABI stress tests (RUE-13).
 #
-# Aggregates passed/returned by value are exploded into per-slot arguments
-# (x86-64: 6 integer arg registers, 2 return registers; aarch64/AAPCS: 8 arg
-# registers, and large aggregates passed indirectly). This matrix probes sizes
-# around those boundaries in every pass/return combination for structs, bare
-# arrays, and methods. The per-case `known_bug` / `known_bug_on` markers are
-# the source of truth for exactly what fails where.
+# Aggregates passed/returned by value are exploded into per-slot arguments.
+# This matrix probes sizes around the register boundaries in every pass/return
+# combination for structs, bare arrays, and methods.
 #
-# State after RUE-118 (route every aggregate consumer through the slot
-# accessor): aarch64 now handles struct pass/return and bare-array pass-only at
-# all tested sizes (5/7/9 slots). The remaining failures are:
-#   - x86-64's spill of aggregate args/returns past its 6 int arg-registers /
-#     2 return-registers — the 9-slot struct cases, scoped
-#     known_bug_on = ["x86-64-linux"] (they still pass on aarch64). See RUE-91.
-#   - the value-method self-update idiom (method_self_update_5/9_slots) and the
-#     8-element array round-trip (bare_array_8_pass_and_return), which still
-#     drop slots on BOTH backends (known_bug, unscoped).
-# Locals and borrow/inout large aggregates are correct on both backends.
+# The convention (RUE-106, see crate::cfg_lower::type_uses_sret_return in
+# rue-codegen):
+#   - Args: one 8-byte ABI slot per aggregate slot; slots past the arg
+#     registers (x86-64: 6, aarch64: 8) go on the caller's stack, and the
+#     callee prologue copies them into its frame param area.
+#   - Returns: aggregates that fit the return registers (x86-64: 6, aarch64:
+#     8) use them; larger aggregates — and String always — return via a
+#     caller-allocated sret buffer whose address is a hidden first argument.
+# All sizes here (5/7/9 slots) pass and return correctly on both backends.
 
 [section]
 id = "cli.abi"
@@ -46,8 +42,6 @@ stdout = "4\n"
 
 [[case]]
 name = "struct_9_slots_pass_only"
-known_bug = "RUE-13"
-known_bug_on = ["x86-64-linux"]
 files = [{ path = "main.rue", source = """
 struct S {
     items: [i32; 8],
@@ -68,8 +62,6 @@ stdout = "8\n"
 
 [[case]]
 name = "struct_9_slots_return_only"
-known_bug = "RUE-13"
-known_bug_on = ["x86-64-linux"]
 files = [{ path = "main.rue", source = """
 struct S {
     items: [i32; 8],
@@ -111,8 +103,6 @@ stdout = "6\n"
 
 [[case]]
 name = "struct_9_slots_pass_and_return"
-known_bug = "RUE-13"
-known_bug_on = ["x86-64-linux"]
 files = [{ path = "main.rue", source = """
 struct S {
     items: [i32; 8],
@@ -133,10 +123,9 @@ fn main() -> i32 {
 stdout = "8\n"
 
 # The value-oriented method idiom (self in, Self out) on a >6-slot struct —
-# the way this bug actually bites users writing ordinary code.
+# the way RUE-13 actually bit users writing ordinary code.
 [[case]]
 name = "method_self_update_9_slots"
-known_bug = "RUE-13"
 files = [{ path = "main.rue", source = """
 @copy
 struct Stack {
@@ -165,9 +154,8 @@ fn main() -> i32 {
 """ }]
 stdout = "20\n"
 
-# The same stack at 5 slots compiles and runs but MISCOMPILES: the len
-# field write is lost through the by-value return, so len stays 0 and
-# top() underflows (runtime "integer overflow"). Part of RUE-13.
+# The same stack at 5 slots (fits the return registers on both backends,
+# so it takes the register-return path rather than sret).
 [[case]]
 name = "method_self_update_5_slots"
 files = [{ path = "main.rue", source = """
@@ -200,8 +188,6 @@ stdout = "20\n"
 
 [[case]]
 name = "bare_array_7_pass_only"
-known_bug = "RUE-13"
-known_bug_on = ["x86-64-linux"]
 files = [{ path = "main.rue", source = """
 fn sum_ends(a: [i32; 7]) -> i32 {
     a[0] + a[6]
@@ -217,8 +203,6 @@ stdout = "8\n"
 
 [[case]]
 name = "bare_array_8_pass_and_return"
-known_bug = "RUE-13"
-known_bug_on = ["x86-64-linux"]
 files = [{ path = "main.rue", source = """
 fn through(a: [i32; 8]) -> [i32; 8] {
     a
@@ -232,6 +216,80 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "8\n"
+
+# RUE-92: a user function returning String by value. The caller has always
+# used the sret convention (buffer pointer as hidden first argument) for
+# String-returning calls, but the callee used to return the three slots in
+# registers and never write the buffer — len/cap arrived as garbage.
+[[case]]
+name = "string_return_by_value"
+files = [{ path = "main.rue", source = """
+fn make() -> String {
+    "hello"
+}
+
+fn main() -> i32 {
+    let s = make();
+    @dbg(s.len());
+    @dbg(s);
+    0
+}
+""" }]
+stdout = """
+5
+hello
+"""
+
+# sret + user args: the hidden sret pointer shifts every user argument by one
+# ABI slot; callee and caller must agree on the shift.
+[[case]]
+name = "string_return_with_args"
+files = [{ path = "main.rue", source = """
+fn pick(a: String, b: String, n: i32) -> String {
+    if n > 0 { a } else { b }
+}
+
+fn main() -> i32 {
+    let s = pick("first", "second", 1);
+    @dbg(s.len());
+    @dbg(s);
+    0
+}
+""" }]
+stdout = """
+5
+first
+"""
+
+# sret + stack-passed args together: a 9-slot struct argument (slots past the
+# arg registers spill to the caller's stack, shifted by the hidden sret
+# pointer) to a function that also returns a 9-slot struct via sret.
+[[case]]
+name = "struct_9_slots_sret_with_stack_args"
+files = [{ path = "main.rue", source = """
+struct S {
+    items: [i32; 8],
+    len: u32,
+}
+
+fn bump_last(s: S, by: i32) -> S {
+    let mut t = s;
+    t.items[7] = t.items[7] + by;
+    t
+}
+
+fn main() -> i32 {
+    let s = S { items: [1, 2, 3, 4, 5, 6, 7, 8], len: 8 };
+    let t = bump_last(s, 100);
+    @dbg(t.items[7]);
+    @dbg(t.len);
+    0
+}
+""" }]
+stdout = """
+108
+8
+"""
 
 # Borrow/inout large aggregates should always work (by reference).
 [[case]]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -16,8 +16,11 @@ use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Operand, Reg, VReg};
 use crate::cfg_lower::{CfgLowerContext, IndexLevel};
 use crate::types;
 
-/// Argument passing registers per AAPCS64.
-const ARG_REGS: [Reg; 8] = [
+/// Argument passing registers per AAPCS64. ABI arg slots beyond these are
+/// passed on the caller's stack (slot `k >= 8` at `[fp+16+(k-8)*8]` in the
+/// callee); the callee prologue copies them into its frame param area so the
+/// body addresses every param slot uniformly (see `emit_prologue`).
+pub(super) const ARG_REGS: [Reg; 8] = [
     Reg::X0,
     Reg::X1,
     Reg::X2,
@@ -28,8 +31,12 @@ const ARG_REGS: [Reg; 8] = [
     Reg::X7,
 ];
 
-/// Return value registers per AAPCS64.
-const RET_REGS: [Reg; 8] = [
+/// Return value registers for the internal Rue convention (AAPCS64 only
+/// defines x0/x1; we extend with the remaining arg registers for multi-slot
+/// aggregate returns). Aggregates with more slots than this — and builtin
+/// String always — return via sret instead; see
+/// `crate::cfg_lower::type_uses_sret_return`. (RUE-106)
+pub(super) const RET_REGS: [Reg; 8] = [
     Reg::X0,
     Reg::X1,
     Reg::X2,
@@ -141,26 +148,17 @@ impl<'a> CfgLower<'a> {
             return ptr_vreg;
         }
 
-        // Load the pointer from the param slot
+        // Load the pointer from the param slot. The prologue copies every ABI
+        // arg slot — register- and stack-passed alike — into the contiguous
+        // frame param area, so this is uniform regardless of param count.
         let ptr_vreg = self.mir.alloc_vreg();
-
-        if (param_slot as usize) < ARG_REGS.len() {
-            let slot = self.ctx.num_locals + param_slot;
-            let offset = self.ctx.local_offset(slot);
-            self.mir.push(Aarch64Inst::Ldr {
-                dst: Operand::Virtual(ptr_vreg),
-                base: Reg::Fp,
-                offset,
-            });
-        } else {
-            // Stack arguments are above the frame pointer
-            let stack_offset = 16 + ((param_slot as i32) - 8) * 8;
-            self.mir.push(Aarch64Inst::Ldr {
-                dst: Operand::Virtual(ptr_vreg),
-                base: Reg::Fp,
-                offset: stack_offset,
-            });
-        }
+        let slot = self.ctx.num_locals + param_slot;
+        let offset = self.ctx.local_offset(slot);
+        self.mir.push(Aarch64Inst::Ldr {
+            dst: Operand::Virtual(ptr_vreg),
+            base: Reg::Fp,
+            offset,
+        });
 
         // Cache it for future use
         self.inout_param_ptrs.insert(param_slot, ptr_vreg);
@@ -546,6 +544,13 @@ impl<'a> CfgLower<'a> {
                 // Check if this is an inout parameter
                 let is_inout = self.ctx.cfg.is_param_inout(*index);
 
+                // The prologue copies every ABI arg slot — register- and
+                // stack-passed alike — into the contiguous frame param area
+                // (slots num_locals..num_locals+num_params), so all param
+                // reads are uniform frame-slot loads. Previously slots past
+                // the 8 arg registers were read from [fp+16+...], which the
+                // frame-slot-based aggregate and write paths didn't mirror,
+                // dropping slots of >8-slot aggregate args. (RUE-13/79/91)
                 if is_inout {
                     // For inout params, the slot contains a POINTER to the caller's memory.
                     // Load the pointer, then dereference to get the value.
@@ -553,23 +558,13 @@ impl<'a> CfgLower<'a> {
                     let val_vreg = self.mir.alloc_vreg();
 
                     // Load the pointer from the param slot
-                    if (*index as usize) < ARG_REGS.len() {
-                        let slot = self.ctx.num_locals + *index;
-                        let offset = self.ctx.local_offset(slot);
-                        self.mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Virtual(ptr_vreg),
-                            base: Reg::Fp,
-                            offset,
-                        });
-                    } else {
-                        // Stack arguments are above the frame pointer
-                        let stack_offset = 16 + ((*index as i32) - 8) * 8;
-                        self.mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Virtual(ptr_vreg),
-                            base: Reg::Fp,
-                            offset: stack_offset,
-                        });
-                    }
+                    let slot = self.ctx.num_locals + *index;
+                    let offset = self.ctx.local_offset(slot);
+                    self.mir.push(Aarch64Inst::Ldr {
+                        dst: Operand::Virtual(ptr_vreg),
+                        base: Reg::Fp,
+                        offset,
+                    });
 
                     // Store the pointer vreg for later use by Store
                     self.inout_param_ptrs.insert(*index, ptr_vreg);
@@ -586,23 +581,13 @@ impl<'a> CfgLower<'a> {
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
 
-                    if (*index as usize) < ARG_REGS.len() {
-                        let slot = self.ctx.num_locals + *index;
-                        let offset = self.ctx.local_offset(slot);
-                        self.mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Virtual(vreg),
-                            base: Reg::Fp,
-                            offset,
-                        });
-                    } else {
-                        // Stack arguments are above the frame pointer
-                        let stack_offset = 16 + ((*index as i32) - 8) * 8;
-                        self.mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Virtual(vreg),
-                            base: Reg::Fp,
-                            offset: stack_offset,
-                        });
-                    }
+                    let slot = self.ctx.num_locals + *index;
+                    let offset = self.ctx.local_offset(slot);
+                    self.mir.push(Aarch64Inst::Ldr {
+                        dst: Operand::Virtual(vreg),
+                        base: Reg::Fp,
+                        offset,
+                    });
                 }
             }
 
@@ -1420,16 +1405,28 @@ impl<'a> CfgLower<'a> {
                 let result_vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, result_vreg);
 
-                // Check if this call returns a String (uses sret convention)
-                let is_sret_call = self.ctx.is_builtin_string(ty);
+                // Does this call return via the sret convention? Builtin
+                // String always does (runtime fns take an out-pointer first
+                // param); other aggregates do when their slots exceed the
+                // return registers. See crate::cfg_lower::type_uses_sret_return.
+                let is_sret_call = self.ctx.type_uses_sret(ty, RET_REGS.len() as u32);
+                let ret_slot_count =
+                    if matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                        self.ctx.type_slot_count(ty)
+                    } else {
+                        1
+                    };
+                // Caller-allocated return buffer: one 8-byte slot per
+                // aggregate slot, padded to keep sp 16-byte aligned.
+                let sret_bytes = ((ret_slot_count as i32 * 8) + 15) / 16 * 16;
 
-                // For sret calls, allocate 32 bytes on stack for the return value (24 bytes + padding for 16-byte alignment)
-                // We'll pass a pointer to this space as the first argument
+                // For sret calls, allocate the return buffer on the stack;
+                // we'll pass a pointer to this space as the first argument.
                 if is_sret_call {
                     self.mir.push(Aarch64Inst::SubImm {
                         dst: Operand::Physical(Reg::Sp),
                         src: Operand::Physical(Reg::Sp),
-                        imm: 32,
+                        imm: sret_bytes,
                     });
                 }
 
@@ -1571,12 +1568,12 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Handle struct and string returns (multi-slot types)
-                // Check builtin String first - it uses sret convention
-                if self.ctx.is_builtin_string(ty) {
-                    // String uses sret convention: result was written to [sp]
-                    // Load ptr, len, cap from stack
+                // sret calls first: the callee wrote the slots to the buffer
+                // at [sp]. (String always; big aggregates per RUE-106.)
+                if is_sret_call {
+                    // Load every slot from the return buffer
                     let mut slot_vregs = Vec::new();
-                    for slot_idx in 0..3 {
+                    for slot_idx in 0..ret_slot_count {
                         let slot_vreg = self.mir.alloc_vreg();
                         let offset = (slot_idx * 8) as i32;
                         self.mir.push(Aarch64Inst::Ldr {
@@ -1586,11 +1583,11 @@ impl<'a> CfgLower<'a> {
                         });
                         slot_vregs.push(slot_vreg);
                     }
-                    // Pop the sret space (32 bytes including alignment padding)
+                    // Pop the sret space (including alignment padding)
                     self.mir.push(Aarch64Inst::AddImm {
                         dst: Operand::Physical(Reg::Sp),
                         src: Operand::Physical(Reg::Sp),
-                        imm: 32,
+                        imm: sret_bytes,
                     });
                     self.struct_slot_vregs.insert(value, slot_vregs.clone());
                     self.mir.push(Aarch64Inst::MovRR {
@@ -1598,10 +1595,10 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(slot_vregs[0]),
                     });
                 } else if ty.is_struct() || ty.is_array() {
-                    // Non-builtin structs and arrays return in registers. Capture
+                    // Aggregates that fit return in registers. Capture
                     // every slot from RET_REGS, not just x0 — arrays previously fell
                     // to the scalar path and lost all elements but the first. (RUE-78)
-                    let slot_count = self.ctx.type_slot_count(ty);
+                    let slot_count = ret_slot_count;
                     let mut slot_vregs = Vec::new();
                     for slot_idx in 0..slot_count {
                         let slot_vreg = self.mir.alloc_vreg();
@@ -3537,7 +3534,7 @@ impl<'a> CfgLower<'a> {
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(Aarch64Inst::Bl { symbol_id });
                 } else if return_type.as_struct().is_some() || return_type.is_array() {
-                    // Return a multi-slot aggregate (struct or array) in registers.
+                    // Return a multi-slot aggregate (struct or array).
                     // Gather all slots through the single accessor, regardless of source
                     // (StructInit/ArrayInit/Call/BlockParam cache-hit; Load/Param/
                     // PlaceRead materialize). Previously the `_` arm returned only slot 0
@@ -3546,12 +3543,24 @@ impl<'a> CfgLower<'a> {
                     let slot_vregs = self
                         .get_or_compute_field_vregs(*value)
                         .unwrap_or_else(|| vec![self.get_vreg(*value)]);
-                    for (i, slot_vreg) in slot_vregs.iter().enumerate() {
-                        if i < RET_REGS.len() {
-                            self.mir.push(Aarch64Inst::MovRR {
-                                dst: Operand::Physical(RET_REGS[i]),
-                                src: Operand::Virtual(*slot_vreg),
-                            });
+                    if self.ctx.uses_sret_return(RET_REGS.len() as u32) {
+                        // sret return (String always; aggregates that don't fit
+                        // the return registers): the caller passed a buffer
+                        // pointer as a hidden first argument, which the
+                        // prologue saved at the dedicated frame slot one past
+                        // the param area. Store every slot through it.
+                        // Previously String returns took the register path
+                        // here while the caller read the (never-written) sret
+                        // buffer — len/cap arrived as garbage. (RUE-92)
+                        crate::agg_slots::store_slots_to_sret(self, &slot_vregs);
+                    } else {
+                        for (i, slot_vreg) in slot_vregs.iter().enumerate() {
+                            if i < RET_REGS.len() {
+                                self.mir.push(Aarch64Inst::MovRR {
+                                    dst: Operand::Physical(RET_REGS[i]),
+                                    src: Operand::Virtual(*slot_vreg),
+                                });
+                            }
                         }
                     }
 

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -335,6 +335,11 @@ pub struct Emitter<'a> {
     num_locals_original: u32,
     /// Number of function parameters.
     num_params: u32,
+    /// Whether the function returns via sret: a hidden buffer pointer arrives
+    /// as the first ABI argument (shifting user params by one register) and is
+    /// saved to the frame slot one past the param area. See
+    /// `crate::cfg_lower::type_uses_sret_return`. (RUE-106)
+    has_sret: bool,
     /// Callee-saved registers that need to be preserved.
     callee_saved: Vec<Reg>,
     /// Whether a stack frame was emitted (prologue was executed).
@@ -378,12 +383,21 @@ impl<'a> Emitter<'a> {
             num_locals,
             num_locals_original,
             num_params,
+            has_sret: false,
             callee_saved: callee_saved.to_vec(),
             has_frame: false,
             strings,
             inst_start: 0,
             emit_asm: false,
         }
+    }
+
+    /// Mark the function as returning via sret (hidden buffer pointer as the
+    /// first ABI argument). Affects the prologue's frame size, the param spill
+    /// register assignment, and reserves the sret pointer frame slot.
+    pub fn with_sret(mut self, has_sret: bool) -> Self {
+        self.has_sret = has_sret;
+        self
     }
 
     // ==================== Instruction recording helpers ====================
@@ -482,7 +496,11 @@ impl<'a> Emitter<'a> {
             }
         }
 
-        if self.num_locals > 0 || self.num_params > 0 || !self.callee_saved.is_empty() {
+        if self.num_locals > 0
+            || self.num_params > 0
+            || self.has_sret
+            || !self.callee_saved.is_empty()
+        {
             self.has_frame = true;
             self.emit_prologue();
         }
@@ -532,8 +550,11 @@ impl<'a> Emitter<'a> {
             end_inst!(self, "str {}, [sp, #-16]!", callee_saved[i]);
         }
 
-        // Allocate space for locals and spilled params
-        let total_slots = self.num_locals + self.num_params.min(8);
+        // Allocate space for locals (including regalloc spills), ALL params
+        // (stack-passed args are copied into the frame param area below so
+        // the body can address every param slot uniformly), and the incoming
+        // sret pointer slot, if any.
+        let total_slots = self.num_locals + self.num_params + self.has_sret as u32;
         if total_slots > 0 {
             let stack_size = ((total_slots as i32 * 8 + 15) / 16) * 16;
             if stack_size > 0 {
@@ -543,7 +564,12 @@ impl<'a> Emitter<'a> {
             }
         }
 
-        // Save incoming parameters from registers to the stack.
+        // Save ALL incoming ABI arguments into the contiguous frame param
+        // area: register args are stored directly, stack-passed args (ABI
+        // slot >= 8) are copied down from [fp+16+...] via x9 (a caller-saved
+        // temporary, dead at entry). After this the body addresses every
+        // param slot as a frame slot. (RUE-13/79/91)
+        //
         // Parameters are stored after locals AND after callee-saved registers:
         //   [fp-16] = first callee-saved pair (or single reg)
         //   [fp-16-callee_saved_size-8] = local 0
@@ -551,7 +577,9 @@ impl<'a> Emitter<'a> {
         //   ...
         //   [fp-16-callee_saved_size-(num_locals+1)*8] = param 0
         //
-        // AAPCS64: first 8 args in x0-x7
+        // AAPCS64: first 8 args in x0-x7. When the function returns via sret,
+        // the hidden buffer pointer is the first ABI argument, shifting every
+        // user param by one slot.
         let param_regs = [
             Reg::X0,
             Reg::X1,
@@ -563,16 +591,41 @@ impl<'a> Emitter<'a> {
             Reg::X7,
         ];
         let callee_saved_size = self.callee_saved_stack_size();
-        for i in 0..self.num_params.min(8) as usize {
+        let abi_shift = self.has_sret as u32;
+        for i in 0..self.num_params {
             // Use num_locals_original (not num_locals, which includes spill
             // slots): CfgLower generated the body's param reads against the
             // pre-spill count. (RUE-129)
-            let slot = self.num_locals_original + i as u32;
+            let slot = self.num_locals_original + i;
             // Skip past callee-saved registers in the offset calculation
             let offset = -callee_saved_size - ((slot as i32 + 1) * 8);
+            let abi_index = (i + abi_shift) as usize;
+
+            if abi_index < param_regs.len() {
+                self.begin_inst();
+                self.emit_str(param_regs[abi_index], Reg::Fp, offset);
+                end_inst!(self, "str {}, [x29, #{}]", param_regs[abi_index], offset);
+            } else {
+                // Stack-passed arg: copy from above the frame into the param area
+                let src_offset = 16 + (abi_index as i32 - param_regs.len() as i32) * 8;
+                self.begin_inst();
+                self.emit_ldr(Reg::X9, Reg::Fp, src_offset);
+                end_inst!(self, "ldr x9, [x29, #{}]", src_offset);
+                self.begin_inst();
+                self.emit_str(Reg::X9, Reg::Fp, offset);
+                end_inst!(self, "str x9, [x29, #{}]", offset);
+            }
+        }
+
+        // Save the incoming sret pointer (hidden first argument, x0) to its
+        // dedicated frame slot, one past the param area. The return path
+        // loads it back to store the result through.
+        if self.has_sret {
+            let slot = self.num_locals_original + self.num_params;
+            let offset = -callee_saved_size - ((slot as i32 + 1) * 8);
             self.begin_inst();
-            self.emit_str(param_regs[i], Reg::Fp, offset);
-            end_inst!(self, "str {}, [x29, #{}]", param_regs[i], offset);
+            self.emit_str(param_regs[0], Reg::Fp, offset);
+            end_inst!(self, "str {}, [x29, #{}] ; sret ptr", param_regs[0], offset);
         }
     }
 
@@ -1248,8 +1301,10 @@ impl<'a> Emitter<'a> {
 
         // Add to SP to deallocate locals (restore SP to FP - callee_saved_size)
         // which is where SP was right after pushing all callee-saved registers
-        if self.num_locals > 0 || self.num_params > 0 {
-            let total_slots = self.num_locals + self.num_params.min(8);
+        if self.num_locals > 0 || self.num_params > 0 || self.has_sret {
+            // Must mirror the prologue's allocation exactly: locals + ALL
+            // params + the sret pointer slot.
+            let total_slots = self.num_locals + self.num_params + self.has_sret as u32;
             let stack_size = ((total_slots as i32 * 8 + 15) / 16) * 16;
             if stack_size > 0 {
                 self.begin_inst();

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -50,12 +50,17 @@ pub fn generate(
 ) -> CompileResult<MachineCode> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
+    // sret returns reserve one extra frame slot (one past the param area)
+    // for the incoming buffer pointer; see crate::cfg_lower::type_uses_sret_return.
+    let has_sret =
+        crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
 
     // Lower CFG to Aarch64Mir with virtual registers
     let mir = CfgLower::new(cfg, type_pool, strings, interner, target).lower();
 
     // Allocate physical registers
-    let existing_slots = num_locals + num_params;
+    // Spill slots go after locals, parameters AND the sret pointer slot to avoid conflicts
+    let existing_slots = num_locals + num_params + has_sret as u32;
     let (mut mir, num_spills, used_callee_saved) =
         RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
 
@@ -79,6 +84,7 @@ pub fn generate(
         &used_callee_saved,
         strings,
     )
+    .with_sret(has_sret)
     .emit()?;
 
     Ok(MachineCode {
@@ -101,12 +107,14 @@ pub fn generate_with_asm(
 ) -> CompileResult<(MachineCode, String)> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
+    let has_sret =
+        crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
 
     // Lower CFG to Aarch64Mir with virtual registers
     let mir = CfgLower::new(cfg, type_pool, strings, interner, target).lower();
 
     // Allocate physical registers
-    let existing_slots = num_locals + num_params;
+    let existing_slots = num_locals + num_params + has_sret as u32;
     let (mut mir, num_spills, used_callee_saved) =
         RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
 
@@ -130,6 +138,7 @@ pub fn generate_with_asm(
         &used_callee_saved,
         strings,
     )
+    .with_sret(has_sret)
     .emit_all()?;
 
     let asm = emitted.to_asm();
@@ -155,12 +164,14 @@ pub fn generate_regalloc_info(
 ) -> CompileResult<RegAllocDebugInfo<Reg>> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
+    let has_sret =
+        crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
 
     // Lower CFG to Aarch64Mir with virtual registers
     let mir = CfgLower::new(cfg, type_pool, strings, interner, target).lower();
 
     // Allocate physical registers with debug info
-    let existing_slots = num_locals + num_params;
+    let existing_slots = num_locals + num_params + has_sret as u32;
     let (_mir, _num_spills, _used_callee_saved, debug_info) =
         RegAlloc::new(mir, existing_slots).allocate_with_debug()?;
 

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -19,8 +19,12 @@
 //! [`lower_struct_init`]/[`lower_array_init`]. Phase 3 moved the consumer-side
 //! store loops here as [`store_slots`]/[`store_slots_through_ptr`] — every
 //! site that writes an aggregate's slots (Alloc, Store, PlaceWrite, inout
-//! writeback) iterates via these two primitives. Remaining per-backend:
-//! call-arg/return marshalling and the scheduler/liveness tables.
+//! writeback) iterates via these two primitives. Phase 4 (RUE-106) added the
+//! callee side of the sret return as [`store_slots_to_sret`]; the convention
+//! *decision* (which returns use sret) is shared in
+//! `crate::cfg_lower::type_uses_sret_return`. Remaining per-backend: the
+//! physical-register/stack marshalling of call args and sret readback (truly
+//! arch-specific: push vs str, rsp vs sp) and the scheduler/liveness tables.
 
 use std::collections::HashMap;
 
@@ -253,6 +257,22 @@ pub fn store_slots_through_ptr<B: SlotBackend>(
 ) {
     for (i, val) in vals.iter().enumerate() {
         b.emit_store_through_ptr(*val, ptr, -static_byte_offset - (i as i32) * 8);
+    }
+}
+
+/// Callee side of the sret return convention (RUE-106): load the sret buffer
+/// pointer the prologue saved at the frame slot one past the param area, then
+/// store every slot of the return value through it at ascending byte offsets
+/// (`vals[i]` to `ptr + i*8` — the buffer is caller-allocated and addressed
+/// upward, unlike the descending inout frame-slot writes).
+///
+/// See `crate::cfg_lower::type_uses_sret_return` for when returns use sret.
+pub fn store_slots_to_sret<B: SlotBackend>(b: &mut B, vals: &[VReg]) {
+    let ptr = b.alloc_vreg();
+    let sret_slot = b.ctx().sret_ptr_slot();
+    b.emit_load_slot(ptr, sret_slot);
+    for (i, val) in vals.iter().enumerate() {
+        b.emit_store_through_ptr(*val, ptr, (i as i32) * 8);
     }
 }
 

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -331,6 +331,51 @@ pub fn format_terminator(cfg: &rue_cfg::Cfg, terminator: &rue_cfg::Terminator) -
 }
 
 // ============================================================================
+// Internal calling convention helpers
+// ============================================================================
+
+/// Does a by-value return of `ty` use the sret convention (caller-allocated
+/// return buffer, pointer passed as a hidden first argument) instead of
+/// return registers?
+///
+/// The internal Rue calling convention for aggregate returns (RUE-106):
+///
+/// - Aggregates whose flattened slot count fits in the backend's return
+///   registers (`ret_reg_budget`: 6 on x86-64, 8 on aarch64) are returned
+///   with one slot per return register.
+/// - Builtin `String` *always* returns via sret, regardless of fitting in
+///   registers: the runtime implementations (`String__clone`,
+///   `__rue_read_line`, ...) are `extern "C"` functions taking an
+///   `out: *mut StringResult` first parameter, so the convention is fixed
+///   by the runtime ABI. (RUE-92)
+/// - Any other aggregate with more slots than `ret_reg_budget` also returns
+///   via sret: the caller allocates `slot_count * 8` bytes (16-aligned) on
+///   its stack and passes the buffer address as a hidden first argument
+///   (shifting all user arguments by one ABI slot); the callee stores every
+///   slot through that pointer before returning. (RUE-13/78/91)
+///
+/// Scalars and unit never use sret.
+pub fn type_uses_sret_return(type_pool: &TypeInternPool, ty: Type, ret_reg_budget: u32) -> bool {
+    match ty.kind() {
+        TypeKind::Struct(struct_id) => {
+            let struct_def = type_pool.struct_def(struct_id);
+            if struct_def.is_builtin && struct_def.name == "String" {
+                return true;
+            }
+            types::type_slot_count(type_pool, ty) > ret_reg_budget
+        }
+        TypeKind::Array(_) => types::type_slot_count(type_pool, ty) > ret_reg_budget,
+        _ => false,
+    }
+}
+
+/// Does this function return its value via the sret convention?
+/// See [`type_uses_sret_return`] for the convention.
+pub fn fn_uses_sret_return(cfg: &Cfg, type_pool: &TypeInternPool, ret_reg_budget: u32) -> bool {
+    type_uses_sret_return(type_pool, cfg.return_type(), ret_reg_budget)
+}
+
+// ============================================================================
 // Shared CFG Lowering Context
 // ============================================================================
 
@@ -433,6 +478,26 @@ impl<'a> CfgLowerContext<'a> {
         builtin
             .find_operator(op)
             .map(|op_def| (op_def.runtime_fn, op_def.invert_result))
+    }
+
+    /// Does a by-value return of `ty` use the sret convention for the
+    /// backend's return-register budget? See [`type_uses_sret_return`].
+    pub fn type_uses_sret(&self, ty: Type, ret_reg_budget: u32) -> bool {
+        type_uses_sret_return(self.type_pool, ty, ret_reg_budget)
+    }
+
+    /// Does the function being lowered return via the sret convention?
+    pub fn uses_sret_return(&self, ret_reg_budget: u32) -> bool {
+        self.type_uses_sret(self.cfg.return_type(), ret_reg_budget)
+    }
+
+    /// The frame slot holding the incoming sret pointer, one past the param
+    /// area (only meaningful when [`Self::uses_sret_return`] is true). The
+    /// prologue stores the hidden first argument here; the return path loads
+    /// it back to write the result through. Register-allocator spill slots
+    /// start after this slot.
+    pub fn sret_ptr_slot(&self) -> u32 {
+        self.num_locals + self.num_params
     }
 
     // ========================================================================

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -282,18 +282,23 @@ fn generate_x86_64_stack_frame(
 
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
+    // sret returns reserve one extra frame slot for the incoming buffer
+    // pointer and shift user args by one ABI slot (RUE-106).
+    let has_sret = crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, 6);
+    let sret_slots = has_sret as u32;
 
     // Lower CFG to X86Mir with virtual registers
     let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
 
     // Allocate physical registers (may add spill slots)
-    let existing_slots = num_locals + num_params;
+    let existing_slots = num_locals + num_params + sret_slots;
     let (_mir, num_spills, used_callee_saved) =
         RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
 
-    // Calculate stack layout
+    // Calculate stack layout (ALL params get frame slots: the prologue copies
+    // stack-passed args into the frame param area)
     let callee_saved_size = used_callee_saved.len() * 8;
-    let total_slots = num_locals + num_spills + num_params.min(6);
+    let total_slots = num_locals + num_spills + num_params + sret_slots;
     let needed_bytes = total_slots as i32 * 8;
     let current_offset = callee_saved_size as i32;
     let total_needed = current_offset + needed_bytes;
@@ -327,10 +332,11 @@ fn generate_x86_64_stack_frame(
         });
     }
 
-    // Add parameter spill slots (for first 6 register params)
+    // Add parameter spill slots (ALL params: stack-passed args are copied
+    // into the frame param area by the prologue)
     #[allow(unused_variables)]
     let arg_regs = ["rdi", "rsi", "rdx", "rcx", "r8", "r9"];
-    for i in 0..num_params.min(6) {
+    for i in 0..num_params {
         let slot = num_locals + i;
         let slot_offset = -callee_saved_size_i32 - ((slot as i32 + 1) * 8);
         slots.push(StackSlot {
@@ -342,9 +348,22 @@ fn generate_x86_64_stack_frame(
         });
     }
 
+    // Add the sret pointer slot (one past the param area)
+    if has_sret {
+        let slot = num_locals + num_params;
+        let slot_offset = -callee_saved_size_i32 - ((slot as i32 + 1) * 8);
+        slots.push(StackSlot {
+            name: Some("sret ptr".to_string()),
+            offset: slot_offset,
+            size: 8,
+            ty: "ptr".to_string(),
+            kind: StackSlotKind::Parameter,
+        });
+    }
+
     // Add spill slots
     for i in 0..num_spills {
-        let slot = num_locals + num_params.min(6) + i;
+        let slot = num_locals + num_params + sret_slots + i;
         let slot_offset = -callee_saved_size_i32 - ((slot as i32 + 1) * 8);
         slots.push(StackSlot {
             name: None,
@@ -355,15 +374,17 @@ fn generate_x86_64_stack_frame(
         });
     }
 
-    // Build argument locations
+    // Build argument locations (the hidden sret pointer occupies the first
+    // ABI slot when present, shifting user args by one)
     let mut arguments = Vec::new();
     for i in 0..num_params as usize {
-        let location = if i < 6 {
-            ArgPassingLocation::Register(arg_regs[i].to_string())
+        let abi_index = i + has_sret as usize;
+        let location = if abi_index < 6 {
+            ArgPassingLocation::Register(arg_regs[abi_index].to_string())
         } else {
             // Stack arguments are at positive offsets from rbp
-            // arg7 at [rbp+16], arg8 at [rbp+24], etc.
-            let offset = 16 + ((i - 6) as i32) * 8;
+            // ABI slot 6 at [rbp+16], slot 7 at [rbp+24], etc.
+            let offset = 16 + ((abi_index - 6) as i32) * 8;
             ArgPassingLocation::Stack { offset }
         };
         arguments.push(ArgumentLocation {
@@ -374,11 +395,16 @@ fn generate_x86_64_stack_frame(
         });
     }
 
-    // Return location
+    // Return location (sret returns go through the caller-allocated buffer
+    // whose address arrived in rdi)
     let return_ty = format!("{:?}", cfg.return_type());
     let return_location = ReturnLocation {
         ty: return_ty,
-        registers: vec!["rax".to_string()],
+        registers: if has_sret {
+            vec!["sret buffer (via rdi)".to_string()]
+        } else {
+            vec!["rax".to_string()]
+        },
     };
 
     Ok(StackFrameInfo {
@@ -405,12 +431,16 @@ fn generate_aarch64_stack_frame(
 
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
+    // sret returns reserve one extra frame slot for the incoming buffer
+    // pointer and shift user args by one ABI slot (RUE-106).
+    let has_sret = crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, 8);
+    let sret_slots = has_sret as u32;
 
     // Lower CFG to Aarch64Mir with virtual registers
     let mir = CfgLower::new(cfg, type_pool, strings, interner, target).lower();
 
     // Allocate physical registers (may add spill slots)
-    let existing_slots = num_locals + num_params;
+    let existing_slots = num_locals + num_params + sret_slots;
     let (_mir, num_spills, used_callee_saved) =
         RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
 
@@ -423,7 +453,9 @@ fn generate_aarch64_stack_frame(
     // FP and LR are saved separately (16 bytes)
     let fp_lr_size = 16;
 
-    let total_slots = num_locals + num_spills + num_params.min(8);
+    // ALL params get frame slots: the prologue copies stack-passed args into
+    // the frame param area
+    let total_slots = num_locals + num_spills + num_params + sret_slots;
     let locals_size = ((total_slots as i32 * 8 + 15) / 16) * 16;
 
     let frame_size = fp_lr_size + callee_saved_size + locals_size as usize;
@@ -478,8 +510,9 @@ fn generate_aarch64_stack_frame(
         });
     }
 
-    // Add parameter spill slots (for first 8 register params on AArch64)
-    for i in 0..num_params.min(8) {
+    // Add parameter spill slots (ALL params: stack-passed args are copied
+    // into the frame param area by the prologue)
+    for i in 0..num_params {
         let slot = num_locals + i;
         let slot_offset = locals_base_offset - ((slot as i32 + 1) * 8);
         slots.push(StackSlot {
@@ -491,9 +524,22 @@ fn generate_aarch64_stack_frame(
         });
     }
 
+    // Add the sret pointer slot (one past the param area)
+    if has_sret {
+        let slot = num_locals + num_params;
+        let slot_offset = locals_base_offset - ((slot as i32 + 1) * 8);
+        slots.push(StackSlot {
+            name: Some("sret ptr".to_string()),
+            offset: slot_offset,
+            size: 8,
+            ty: "ptr".to_string(),
+            kind: StackSlotKind::Parameter,
+        });
+    }
+
     // Add spill slots
     for i in 0..num_spills {
-        let slot = num_locals + num_params.min(8) + i;
+        let slot = num_locals + num_params + sret_slots + i;
         let slot_offset = locals_base_offset - ((slot as i32 + 1) * 8);
         slots.push(StackSlot {
             name: None,
@@ -504,15 +550,17 @@ fn generate_aarch64_stack_frame(
         });
     }
 
-    // Build argument locations (x0-x7 for first 8 args on AArch64)
+    // Build argument locations (x0-x7 for first 8 ABI slots on AArch64; the
+    // hidden sret pointer occupies the first slot when present)
     let arg_regs = ["x0", "x1", "x2", "x3", "x4", "x5", "x6", "x7"];
     let mut arguments = Vec::new();
     for i in 0..num_params as usize {
-        let location = if i < 8 {
-            ArgPassingLocation::Register(arg_regs[i].to_string())
+        let abi_index = i + has_sret as usize;
+        let location = if abi_index < 8 {
+            ArgPassingLocation::Register(arg_regs[abi_index].to_string())
         } else {
             // Stack arguments on AArch64
-            let offset = ((i - 8) as i32) * 8;
+            let offset = ((abi_index - 8) as i32) * 8;
             ArgPassingLocation::Stack { offset }
         };
         arguments.push(ArgumentLocation {
@@ -523,11 +571,16 @@ fn generate_aarch64_stack_frame(
         });
     }
 
-    // Return location
+    // Return location (sret returns go through the caller-allocated buffer
+    // whose address arrived in x0)
     let return_ty = format!("{:?}", cfg.return_type());
     let return_location = ReturnLocation {
         ty: return_ty,
-        registers: vec!["x0".to_string()],
+        registers: if has_sret {
+            vec!["sret buffer (via x0)".to_string()]
+        } else {
+            vec!["x0".to_string()]
+        },
     };
 
     Ok(StackFrameInfo {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -39,11 +39,18 @@ use crate::cfg_lower::{CfgLowerContext, IndexLevel};
 use crate::types;
 use crate::vreg::BLOCK_LABEL_BASE;
 
-/// Argument passing registers per System V AMD64 ABI.
-const ARG_REGS: [Reg; 6] = [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9];
+/// Argument passing registers per System V AMD64 ABI. ABI arg slots beyond
+/// these are passed on the caller's stack (slot `k >= 6` at `[rbp+16+(k-6)*8]`
+/// in the callee); the callee prologue copies them into its frame param area
+/// so the body addresses every param slot uniformly (see `emit_prologue`).
+pub(super) const ARG_REGS: [Reg; 6] = [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9];
 
-/// Return value registers per System V AMD64 ABI.
-const RET_REGS: [Reg; 6] = [Reg::Rax, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9, Reg::R10];
+/// Return value registers for the internal Rue convention (SysV only defines
+/// rax/rdx; the rest are caller-saved scratch regs we extend the convention
+/// with for multi-slot aggregate returns). Aggregates with more slots than
+/// this — and builtin String always — return via sret instead; see
+/// `crate::cfg_lower::type_uses_sret_return`. (RUE-106)
+pub(super) const RET_REGS: [Reg; 6] = [Reg::Rax, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9, Reg::R10];
 
 /// CFG to X86Mir lowering.
 pub struct CfgLower<'a> {
@@ -153,25 +160,17 @@ impl<'a> CfgLower<'a> {
             return ptr_vreg;
         }
 
-        // Load the pointer from the param slot
+        // Load the pointer from the param slot. The prologue copies every ABI
+        // arg slot — register- and stack-passed alike — into the contiguous
+        // frame param area, so this is uniform regardless of param count.
         let ptr_vreg = self.mir.alloc_vreg();
-
-        if (param_slot as usize) < ARG_REGS.len() {
-            let slot = self.ctx.num_locals + param_slot;
-            let offset = self.ctx.local_offset(slot);
-            self.mir.push(X86Inst::MovRM {
-                dst: Operand::Virtual(ptr_vreg),
-                base: Reg::Rbp,
-                offset,
-            });
-        } else {
-            let stack_offset = 16 + ((param_slot as i32) - 6) * 8;
-            self.mir.push(X86Inst::MovRM {
-                dst: Operand::Virtual(ptr_vreg),
-                base: Reg::Rbp,
-                offset: stack_offset,
-            });
-        }
+        let slot = self.ctx.num_locals + param_slot;
+        let offset = self.ctx.local_offset(slot);
+        self.mir.push(X86Inst::MovRM {
+            dst: Operand::Virtual(ptr_vreg),
+            base: Reg::Rbp,
+            offset,
+        });
 
         // Cache it for future use
         self.inout_param_ptrs.insert(param_slot, ptr_vreg);
@@ -567,13 +566,22 @@ impl<'a> CfgLower<'a> {
             CfgInstData::Param { index } => {
                 if self.ctx.cfg.is_param_inout(*index) {
                     Some("Inout param: load pointer then dereference".to_string())
-                } else if (*index as usize) < ARG_REGS.len() {
-                    Some(format!(
-                        "From register {} (SysV ABI)",
-                        ARG_REGS[*index as usize]
-                    ))
                 } else {
-                    Some("From stack (SysV ABI, args > 6)".to_string())
+                    // ABI slot: shifted by one when a hidden sret pointer
+                    // occupies the first arg register.
+                    let abi_index =
+                        *index as usize + self.ctx.uses_sret_return(RET_REGS.len() as u32) as usize;
+                    if abi_index < ARG_REGS.len() {
+                        Some(format!(
+                            "From frame param slot (arrived in {}, spilled by prologue)",
+                            ARG_REGS[abi_index]
+                        ))
+                    } else {
+                        Some(
+                            "From frame param slot (stack-passed arg, copied by prologue)"
+                                .to_string(),
+                        )
+                    }
                 }
             }
             CfgInstData::Const(v) => {
@@ -701,6 +709,13 @@ impl<'a> CfgLower<'a> {
                 // Check if this is an inout parameter
                 let is_inout = self.ctx.cfg.is_param_inout(*index);
 
+                // The prologue copies every ABI arg slot — register- and
+                // stack-passed alike — into the contiguous frame param area
+                // (slots num_locals..num_locals+num_params), so all param
+                // reads are uniform frame-slot loads. Previously slots past
+                // the 6 arg registers were read from [rbp+16+...], which the
+                // frame-slot-based aggregate and write paths didn't mirror,
+                // dropping slots of >6-slot aggregate args. (RUE-13/79/91)
                 if is_inout {
                     // For inout params, the slot contains a POINTER to the caller's memory.
                     // Load the pointer, then dereference to get the value.
@@ -708,22 +723,13 @@ impl<'a> CfgLower<'a> {
                     let val_vreg = self.mir.alloc_vreg();
 
                     // Load the pointer from the param slot
-                    if (*index as usize) < ARG_REGS.len() {
-                        let slot = self.ctx.num_locals + *index;
-                        let offset = self.ctx.local_offset(slot);
-                        self.mir.push(X86Inst::MovRM {
-                            dst: Operand::Virtual(ptr_vreg),
-                            base: Reg::Rbp,
-                            offset,
-                        });
-                    } else {
-                        let stack_offset = 16 + ((*index as i32) - 6) * 8;
-                        self.mir.push(X86Inst::MovRM {
-                            dst: Operand::Virtual(ptr_vreg),
-                            base: Reg::Rbp,
-                            offset: stack_offset,
-                        });
-                    }
+                    let slot = self.ctx.num_locals + *index;
+                    let offset = self.ctx.local_offset(slot);
+                    self.mir.push(X86Inst::MovRM {
+                        dst: Operand::Virtual(ptr_vreg),
+                        base: Reg::Rbp,
+                        offset,
+                    });
 
                     // Store the pointer vreg for later use by Store
                     self.inout_param_ptrs.insert(*index, ptr_vreg);
@@ -741,22 +747,13 @@ impl<'a> CfgLower<'a> {
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
 
-                    if (*index as usize) < ARG_REGS.len() {
-                        let slot = self.ctx.num_locals + *index;
-                        let offset = self.ctx.local_offset(slot);
-                        self.mir.push(X86Inst::MovRM {
-                            dst: Operand::Virtual(vreg),
-                            base: Reg::Rbp,
-                            offset,
-                        });
-                    } else {
-                        let stack_offset = 16 + ((*index as i32) - 6) * 8;
-                        self.mir.push(X86Inst::MovRM {
-                            dst: Operand::Virtual(vreg),
-                            base: Reg::Rbp,
-                            offset: stack_offset,
-                        });
-                    }
+                    let slot = self.ctx.num_locals + *index;
+                    let offset = self.ctx.local_offset(slot);
+                    self.mir.push(X86Inst::MovRM {
+                        dst: Operand::Virtual(vreg),
+                        base: Reg::Rbp,
+                        offset,
+                    });
                 }
             }
 
@@ -1666,16 +1663,28 @@ impl<'a> CfgLower<'a> {
                 let result_vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, result_vreg);
 
-                // Check if this call returns a builtin String (uses sret convention)
-                let is_sret_call = self.ctx.is_builtin_string(ty);
+                // Does this call return via the sret convention? Builtin
+                // String always does (runtime fns take an out-pointer first
+                // param); other aggregates do when their slots exceed the
+                // return registers. See crate::cfg_lower::type_uses_sret_return.
+                let is_sret_call = self.ctx.type_uses_sret(ty, RET_REGS.len() as u32);
+                let ret_slot_count =
+                    if matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                        self.ctx.type_slot_count(ty)
+                    } else {
+                        1
+                    };
+                // Caller-allocated return buffer: one 8-byte slot per
+                // aggregate slot, padded to keep rsp 16-byte aligned.
+                let sret_bytes = ((ret_slot_count as i32 * 8) + 15) / 16 * 16;
 
-                // For sret calls, allocate 32 bytes on stack for the return value (24 bytes + padding for 16-byte alignment)
-                // We'll pass a pointer to this space as the first argument
+                // For sret calls, allocate the return buffer on the stack;
+                // we'll pass a pointer to this space as the first argument.
                 // Use add with negative offset (no SubRI in MIR)
                 if is_sret_call {
                     self.mir.push(X86Inst::AddRI {
                         dst: Operand::Physical(Reg::Rsp),
-                        imm: -32,
+                        imm: -sret_bytes,
                     });
                 }
 
@@ -1830,12 +1839,12 @@ impl<'a> CfgLower<'a> {
                 }
 
                 // Handle struct and string returns (multi-slot types)
-                // Check builtin String first - it uses sret convention
-                if self.ctx.is_builtin_string(ty) {
-                    // Builtin String uses sret convention: result was written to [rsp]
-                    // Load ptr, len, cap from stack
+                // sret calls first: the callee wrote the slots to the buffer
+                // at [rsp]. (String always; big aggregates per RUE-106.)
+                if is_sret_call {
+                    // Load every slot from the return buffer
                     let mut slot_vregs = Vec::new();
-                    for slot_idx in 0..3 {
+                    for slot_idx in 0..ret_slot_count {
                         let slot_vreg = self.mir.alloc_vreg();
                         let offset = (slot_idx * 8) as i32;
                         self.mir.push(X86Inst::MovRM {
@@ -1845,10 +1854,10 @@ impl<'a> CfgLower<'a> {
                         });
                         slot_vregs.push(slot_vreg);
                     }
-                    // Pop the sret space (32 bytes including alignment padding)
+                    // Pop the sret space (including alignment padding)
                     self.mir.push(X86Inst::AddRI {
                         dst: Operand::Physical(Reg::Rsp),
-                        imm: 32,
+                        imm: sret_bytes,
                     });
                     self.struct_slot_vregs.insert(value, slot_vregs.clone());
                     self.mir.push(X86Inst::MovRR {
@@ -1856,10 +1865,10 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(slot_vregs[0]),
                     });
                 } else if matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
-                    // Non-builtin structs and arrays return in registers. Capture
+                    // Aggregates that fit return in registers. Capture
                     // every slot from RET_REGS, not just rax — arrays previously fell
                     // to the scalar path and lost all elements but the first. (RUE-78)
-                    let slot_count = self.ctx.type_slot_count(ty);
+                    let slot_count = ret_slot_count;
                     let mut slot_vregs = Vec::new();
                     for slot_idx in 0..slot_count {
                         let slot_vreg = self.mir.alloc_vreg();
@@ -3496,7 +3505,7 @@ impl<'a> CfgLower<'a> {
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(X86Inst::CallRel { symbol_id });
                 } else if return_type.as_struct().is_some() || return_type.is_array() {
-                    // Return a multi-slot aggregate (struct or array) in registers.
+                    // Return a multi-slot aggregate (struct or array).
                     // Gather all slots through the single accessor, regardless of source
                     // (StructInit/ArrayInit/Call/BlockParam cache-hit; Load/Param/
                     // PlaceRead materialize). Previously the `_` arm returned only slot 0
@@ -3505,15 +3514,27 @@ impl<'a> CfgLower<'a> {
                     let slot_vregs = self
                         .get_or_compute_field_vregs(*value)
                         .unwrap_or_else(|| vec![self.get_vreg(*value)]);
-                    // Move slot values to return registers in REVERSE order: regalloc
-                    // uses Rax as scratch when loading spilled values, so moving to Rax
-                    // (RET_REGS[0]) last avoids clobbering it with later slots' loads.
-                    for (i, slot_vreg) in slot_vregs.iter().enumerate().rev() {
-                        if i < RET_REGS.len() {
-                            self.mir.push(X86Inst::MovRR {
-                                dst: Operand::Physical(RET_REGS[i]),
-                                src: Operand::Virtual(*slot_vreg),
-                            });
+                    if self.ctx.uses_sret_return(RET_REGS.len() as u32) {
+                        // sret return (String always; aggregates that don't fit
+                        // the return registers): the caller passed a buffer
+                        // pointer as a hidden first argument, which the
+                        // prologue saved at the dedicated frame slot one past
+                        // the param area. Store every slot through it.
+                        // Previously String returns took the register path
+                        // here while the caller read the (never-written) sret
+                        // buffer — len/cap arrived as garbage. (RUE-92)
+                        crate::agg_slots::store_slots_to_sret(self, &slot_vregs);
+                    } else {
+                        // Move slot values to return registers in REVERSE order: regalloc
+                        // uses Rax as scratch when loading spilled values, so moving to Rax
+                        // (RET_REGS[0]) last avoids clobbering it with later slots' loads.
+                        for (i, slot_vreg) in slot_vregs.iter().enumerate().rev() {
+                            if i < RET_REGS.len() {
+                                self.mir.push(X86Inst::MovRR {
+                                    dst: Operand::Physical(RET_REGS[i]),
+                                    src: Operand::Virtual(*slot_vreg),
+                                });
+                            }
                         }
                     }
 

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -30,8 +30,13 @@
 //! ├────────────────────────┤
 //! │ param 0 spill slot     │ [rbp - callee_saved_size - (num_locals+1)*8]
 //! │ param 1 spill slot     │ [rbp - callee_saved_size - (num_locals+2)*8]
-//! │ ...                    │
-//! │ param 5 spill slot     │ [rbp - callee_saved_size - (num_locals+6)*8]
+//! │ ...                    │ (ALL params: stack-passed args are copied
+//! │ param P-1 spill slot   │  down here by the prologue too)
+//! ├────────────────────────┤
+//! │ sret pointer slot      │ [rbp - callee_saved_size - (num_locals+P+1)*8]
+//! │ (only for sret fns)    │
+//! ├────────────────────────┤
+//! │ regalloc spill slots   │ (after locals, params, and sret slot)
 //! ├────────────────────────┤
 //! │ (alignment padding)    │   ← Ensures RSP is 16-byte aligned
 //! └────────────────────────┘
@@ -48,10 +53,12 @@
 //! push r12                 ; Save callee-saved registers (if used)
 //! push r13
 //! ...
-//! sub rsp, N               ; Allocate space for locals + params (16-aligned)
-//! mov [rbp-X], rdi         ; Spill register params to stack (first 6 args)
+//! sub rsp, N               ; Allocate space for locals + ALL params (+ sret slot)
+//! mov [rbp-X], rdi         ; Spill register params to the frame param area
 //! mov [rbp-X], rsi
 //! ...
+//! mov rax, [rbp+16]        ; Copy stack-passed args (ABI slot >= 6) down
+//! mov [rbp-X], rax         ;   into the same param area
 //! ```
 //!
 //! ## Epilogue Sequence
@@ -68,9 +75,11 @@
 //!
 //! ## Key Invariants
 //!
-//! 1. **RBP-relative stack arguments**: Stack arguments (7th argument and beyond)
-//!    are accessed at fixed positive offsets from RBP (`[rbp + 16]`, `[rbp + 24]`, etc.).
-//!    These offsets are stable regardless of callee-saved register usage.
+//! 1. **RBP-relative stack arguments**: Stack arguments (7th ABI slot and beyond)
+//!    sit at fixed positive offsets from RBP (`[rbp + 16]`, `[rbp + 24]`, etc.).
+//!    These offsets are stable regardless of callee-saved register usage. The
+//!    prologue copies them into the frame param area; the body only reads the
+//!    frame copies.
 //!
 //! 2. **Offset adjustment for locals**: CfgLower generates local variable offsets
 //!    assuming `[rbp - 8]` is slot 0. The emit phase adjusts all negative RBP-relative
@@ -87,11 +96,16 @@
 //!    (variable number), then allocates remaining space via `sub rsp, N`. This allows
 //!    calculating the exact alignment padding needed.
 //!
-//! ## Calling Convention (System V AMD64 ABI)
+//! ## Calling Convention (System V AMD64 ABI, extended internally)
 //!
-//! - Arguments 1-6: RDI, RSI, RDX, RCX, R8, R9
+//! - Arguments 1-6: RDI, RSI, RDX, RCX, R8, R9 (aggregates are flattened to
+//!   one 8-byte ABI slot per aggregate slot)
 //! - Arguments 7+: Pushed right-to-left onto stack (arg7 at [rbp+16])
-//! - Return value: RAX (second value in RDX for 128-bit returns)
+//! - Return value: RAX; multi-slot aggregates that fit use the internal
+//!   RET_REGS extension (rax, rdx, rcx, r8, r9, r10)
+//! - sret returns (String always; aggregates over the RET_REGS budget): the
+//!   caller allocates a buffer and passes its address as a hidden first
+//!   argument in RDI; the callee writes all slots through it (RUE-106)
 //! - Caller-saved: RAX, RCX, RDX, RSI, RDI, R8-R11, XMM0-XMM15
 //! - Callee-saved: RBX, RBP, R12-R15
 
@@ -209,6 +223,11 @@ pub struct Emitter<'a> {
     num_locals_original: u32,
     /// Number of function parameters.
     num_params: u32,
+    /// Whether the function returns via sret: a hidden buffer pointer arrives
+    /// as the first ABI argument (shifting user params by one register) and is
+    /// saved to the frame slot one past the param area. See
+    /// `crate::cfg_lower::type_uses_sret_return`. (RUE-106)
+    has_sret: bool,
     /// Callee-saved registers that need to be preserved.
     callee_saved: Vec<Reg>,
     /// String table (indexed by string_id in StringConstPtr/StringConstLen).
@@ -257,12 +276,21 @@ impl<'a> Emitter<'a> {
             num_locals,
             num_locals_original,
             num_params,
+            has_sret: false,
             callee_saved: callee_saved.to_vec(),
             strings,
             has_frame: false,
             inst_start: 0,
             emit_asm: false,
         }
+    }
+
+    /// Mark the function as returning via sret (hidden buffer pointer as the
+    /// first ABI argument). Affects the prologue's frame size, the param spill
+    /// register assignment, and reserves the sret pointer frame slot.
+    pub fn with_sret(mut self, has_sret: bool) -> Self {
+        self.has_sret = has_sret;
+        self
     }
 
     // ==================== Instruction recording helpers ====================
@@ -359,8 +387,13 @@ impl<'a> Emitter<'a> {
             }
         }
 
-        // Emit function prologue if we have local variables, parameters, or callee-saved regs
-        if self.num_locals > 0 || self.num_params > 0 || !self.callee_saved.is_empty() {
+        // Emit function prologue if we have local variables, parameters,
+        // an sret pointer to save, or callee-saved regs
+        if self.num_locals > 0
+            || self.num_params > 0
+            || self.has_sret
+            || !self.callee_saved.is_empty()
+        {
             self.has_frame = true;
             self.emit_prologue();
         }
@@ -374,12 +407,12 @@ impl<'a> Emitter<'a> {
     /// Emit function prologue to set up the stack frame.
     ///
     /// This sets up RBP-based stack frame, then saves callee-saved registers AFTER
-    /// setting up RBP. This ensures that stack arguments (beyond the first 6) can
-    /// be accessed at fixed offsets from RBP:
+    /// setting up RBP. This ensures that stack arguments (ABI slots beyond the
+    /// first 6) can be accessed at fixed offsets from RBP:
     /// - [rbp+0]  = saved rbp
     /// - [rbp+8]  = return address
-    /// - [rbp+16] = arg7 (first stack argument, if present)
-    /// - [rbp+24] = arg8, etc.
+    /// - [rbp+16] = first stack-passed ABI slot (if present)
+    /// - [rbp+24] = second, etc.
     ///
     /// ```asm
     /// push rbp
@@ -387,10 +420,12 @@ impl<'a> Emitter<'a> {
     /// push r12             ; save callee-saved registers AFTER rbp setup
     /// push r13
     /// ...
-    /// sub rsp, N           ; N = (num_locals + num_params) * 8, aligned to 16
-    /// mov [rbp-X], rdi     ; save param 0
+    /// sub rsp, N           ; N = (num_locals + num_params [+ sret]) * 8, 16-aligned
+    /// mov [rbp-X], rdi     ; save param 0 (or the sret ptr shifts params by one)
     /// mov [rbp-X], rsi     ; save param 1
     /// ...
+    /// mov rax, [rbp+16]    ; copy stack-passed args into the param area
+    /// mov [rbp-X], rax
     /// ```
     ///
     /// The corresponding epilogue (generated by lower.rs, augmented by emitter) is:
@@ -424,10 +459,13 @@ impl<'a> Emitter<'a> {
         }
 
         // Calculate stack space needed:
-        // - num_locals slots for local variables
-        // - num_params slots for saved parameters (for the first 6 params only)
+        // - num_locals slots for local variables (including regalloc spills)
+        // - num_params slots for saved parameters (ALL of them: stack-passed
+        //   args are copied into the frame param area below so the body can
+        //   address every param slot uniformly)
+        // - one slot for the incoming sret pointer, if any
         // Each slot is 8 bytes, total aligned to 16
-        let total_slots = self.num_locals + self.num_params.min(6);
+        let total_slots = self.num_locals + self.num_params + self.has_sret as u32;
         let needed_bytes = total_slots as i32 * 8;
         // Account for callee-saved pushes for alignment calculation
         let pushes_so_far = callee_saved.len() as i32;
@@ -448,29 +486,60 @@ impl<'a> Emitter<'a> {
             end_inst!(self, "sub rsp, {}", stack_size);
         }
 
-        // Save incoming parameters from registers to the stack.
+        // Save ALL incoming ABI arguments into the contiguous frame param
+        // area: register args are spilled directly, stack-passed args (ABI
+        // slot >= 6) are copied down from [rbp+16+...] via rax (dead at
+        // entry). After this the body addresses every param slot as a frame
+        // slot — there is no separate ">6 params" read path. (RUE-13/79/91)
+        //
         // cfg_lower generates offsets assuming [rbp-8] is the first slot, but
         // callee-saved registers are pushed after rbp, shifting everything down.
         // The emit phase adjusts all rbp-relative negative offsets to account
         // for this (see MovRM and MovMR handlers).
         //
-        // System V AMD64 ABI: first 6 args in rdi, rsi, rdx, rcx, r8, r9
+        // System V AMD64 ABI: first 6 args in rdi, rsi, rdx, rcx, r8, r9.
+        // When the function returns via sret, the hidden buffer pointer is
+        // the first ABI argument, shifting every user param by one slot.
         const ARG_REGS: [Reg; 6] = [Reg::Rdi, Reg::Rsi, Reg::Rdx, Reg::Rcx, Reg::R8, Reg::R9];
 
         let callee_saved_size = self.callee_saved_size();
+        let abi_shift = self.has_sret as u32;
 
-        for i in 0..self.num_params.min(6) {
+        for i in 0..self.num_params {
             // Use num_locals_original (not num_locals which includes spills)
             // because CfgLower generates param offsets based on the original count
             let slot = self.num_locals_original + i;
             // Skip past callee-saved registers in the offset calculation
             let offset = -callee_saved_size - ((slot as i32 + 1) * 8);
-            let reg = ARG_REGS[i as usize];
+            let abi_index = i + abi_shift;
 
-            // Emit: mov [rbp + offset], reg
+            if (abi_index as usize) < ARG_REGS.len() {
+                let reg = ARG_REGS[abi_index as usize];
+                // Emit: mov [rbp + offset], reg
+                self.begin_inst();
+                self.emit_mov_mr(Reg::Rbp, offset, reg);
+                end_inst!(self, "mov [rbp{}], {}", offset, reg);
+            } else {
+                // Stack-passed arg: copy from above the frame into the param area
+                let src_offset = 16 + (abi_index as i32 - ARG_REGS.len() as i32) * 8;
+                self.begin_inst();
+                self.emit_mov_rm(Reg::Rax, Reg::Rbp, src_offset);
+                end_inst!(self, "mov rax, [rbp+{}]", src_offset);
+                self.begin_inst();
+                self.emit_mov_mr(Reg::Rbp, offset, Reg::Rax);
+                end_inst!(self, "mov [rbp{}], rax", offset);
+            }
+        }
+
+        // Save the incoming sret pointer (hidden first argument) to its
+        // dedicated frame slot, one past the param area. The return path
+        // loads it back to store the result through.
+        if self.has_sret {
+            let slot = self.num_locals_original + self.num_params;
+            let offset = -callee_saved_size - ((slot as i32 + 1) * 8);
             self.begin_inst();
-            self.emit_mov_mr(Reg::Rbp, offset, reg);
-            end_inst!(self, "mov [rbp{}], {}", offset, reg);
+            self.emit_mov_mr(Reg::Rbp, offset, ARG_REGS[0]);
+            end_inst!(self, "mov [rbp{}], {} ; sret ptr", offset, ARG_REGS[0]);
         }
     }
 
@@ -488,7 +557,11 @@ impl<'a> Emitter<'a> {
 
         // Point RSP at the callee-saved area (skip locals and alignment padding)
         let size = self.callee_saved_size();
-        if !self.callee_saved.is_empty() || self.num_locals > 0 || self.num_params > 0 {
+        if !self.callee_saved.is_empty()
+            || self.num_locals > 0
+            || self.num_params > 0
+            || self.has_sret
+        {
             self.begin_inst();
             self.emit_lea_rsp_rbp_offset(-size);
             end_inst!(self, "lea rsp, [rbp{}]", format_offset(-size));

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -48,13 +48,17 @@ pub fn generate(
 ) -> CompileResult<MachineCode> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
+    // sret returns reserve one extra frame slot (one past the param area)
+    // for the incoming buffer pointer; see crate::cfg_lower::type_uses_sret_return.
+    let has_sret =
+        crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
 
     // Lower CFG to X86Mir with virtual registers
     let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
 
     // Allocate physical registers (may add spill slots)
-    // Spill slots go after both locals AND parameters to avoid conflicts
-    let existing_slots = num_locals + num_params;
+    // Spill slots go after locals, parameters AND the sret pointer slot to avoid conflicts
+    let existing_slots = num_locals + num_params + has_sret as u32;
     let (mut mir, num_spills, used_callee_saved) =
         RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
 
@@ -81,6 +85,7 @@ pub fn generate(
         &used_callee_saved,
         strings,
     )
+    .with_sret(has_sret)
     .emit()?;
 
     Ok(MachineCode {
@@ -102,12 +107,14 @@ pub fn generate_with_asm(
 ) -> CompileResult<(MachineCode, String)> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
+    let has_sret =
+        crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
 
     // Lower CFG to X86Mir with virtual registers
     let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
 
     // Allocate physical registers (may add spill slots)
-    let existing_slots = num_locals + num_params;
+    let existing_slots = num_locals + num_params + has_sret as u32;
     let (mut mir, num_spills, used_callee_saved) =
         RegAlloc::new(mir, existing_slots).allocate_with_spills()?;
 
@@ -131,6 +138,7 @@ pub fn generate_with_asm(
         &used_callee_saved,
         strings,
     )
+    .with_sret(has_sret)
     .emit_all()?;
 
     let asm = emitted.to_asm();
@@ -155,12 +163,14 @@ pub fn generate_regalloc_info(
 ) -> CompileResult<RegAllocDebugInfo<Reg>> {
     let num_locals = cfg.num_locals();
     let num_params = cfg.num_params();
+    let has_sret =
+        crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
 
     // Lower CFG to X86Mir with virtual registers
     let mir = CfgLower::new(cfg, type_pool, strings, interner).lower();
 
     // Allocate physical registers with debug info
-    let existing_slots = num_locals + num_params;
+    let existing_slots = num_locals + num_params + has_sret as u32;
     let (_mir, _num_spills, _used_callee_saved, debug_info) =
         RegAlloc::new(mir, existing_slots).allocate_with_debug()?;
 


### PR DESCRIPTION
The by-value aggregate calling convention disagreed with itself in three
ways, each a silent miscompile (the RUE-106 epic's remaining children):

- String returns: callers reserved an sret buffer but user-defined callees
  returned in registers and never wrote it — the caller read len=0 from its
  own untouched stack. Every String-returning function was broken (RUE-92).
- Args past the register budget (6 integer slots on x86-64, 8 on aarch64):
  the caller pushed them on the stack, but the callee read every param from
  its frame param area, which the prologue populated only for
  register-passed slots — slots past the budget read zeros or ICEd
  (RUE-13, RUE-91), including multidimensional arrays and [T; 8]+ (RUE-79).
- Aggregate returns wider than the return registers silently dropped slots
  (RUE-78's struct shapes).

The convention is now explicit and documented at type_uses_sret_return and
the ARG_REGS/RET_REGS definitions:

- Arguments: flattened slots fill the register budget; the rest go on the
  caller's stack. The callee prologue allocates frame slots for ALL params
  and copies stack-passed slots down, so every body access is a uniform
  frame-slot load — the divergent over-budget branches in both cfg_lower
  files are deleted. This also fixes a latent spill-slot-below-rsp bug when
  param count exceeded the budget.
- Returns: values fitting RET_REGS are unchanged; String (always) and
  over-budget aggregates use a caller-allocated sret buffer whose pointer
  rides as a hidden first argument. The callee pins it to a frame slot and
  stores all slots through it via the shared agg_slots::store_slots_to_sret.

Both backends change together; aarch64 verified by asm inspection locally
(CI's native arm64 job executes it). All six known_bug = "RUE-13" xfails in
abi.toml now pass and are un-marked (regression tests), plus new cases for
String returns (with and without args) and a 9-slot struct with stack args.
Stress-verified: >6 scalar args, inout past the budget, 16-slot
multidimensional pass+return, chained 11-slot sret calls. Full test.sh
green.

Fixes RUE-92
Fixes RUE-13
Fixes RUE-91
Fixes RUE-79
Fixes RUE-78



🤖 Generated with [Claude Code](https://claude.com/claude-code)
