### PR TITLE
Drop elaboration: suppress drops of moved-out values

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -384,6 +384,12 @@ pub struct Air {
     /// Storage for places (ADR-0030 Phase 8).
     /// AirPlaceRef values are indices into this array.
     places: Vec<AirPlace>,
+    /// Owned (pass-by-value) parameters of this function: (ABI slot, type).
+    /// Ownership of a by-value argument transfers to the callee, so the CFG
+    /// builder drops these at function exit unless they were moved out
+    /// (see [`AirInstData::MarkMoved`]). Empty for destructors (a destructor
+    /// must not re-drop `self`) and for synthesized drop-glue functions.
+    param_drops: Vec<(u32, Type)>,
 }
 
 impl Air {
@@ -395,6 +401,7 @@ impl Air {
             return_type,
             projections: Vec::new(),
             places: Vec::new(),
+            param_drops: Vec::new(),
         }
     }
 
@@ -409,6 +416,41 @@ impl Air {
     #[inline]
     pub fn get(&self, inst_ref: AirRef) -> &AirInst {
         &self.instructions[inst_ref.0 as usize]
+    }
+
+    /// Set the owned-parameter drop list: (ABI slot, type) for each
+    /// pass-by-value parameter that the callee owns (and must drop at exit
+    /// unless moved out).
+    pub fn set_param_drops(&mut self, param_drops: Vec<(u32, Type)>) {
+        self.param_drops = param_drops;
+    }
+
+    /// Clear the owned-parameter drop list. Used for destructors: the
+    /// destructor consumes `self`, and the drop glue (not the destructor
+    /// itself) is responsible for dropping the fields afterwards, so the
+    /// destructor must not re-drop its own parameter.
+    pub fn clear_param_drops(&mut self) {
+        self.param_drops.clear();
+    }
+
+    /// Owned (pass-by-value) parameters dropped by the callee at function
+    /// exit: (ABI slot, type).
+    #[inline]
+    pub fn param_drops(&self) -> &[(u32, Type)] {
+        &self.param_drops
+    }
+
+    /// Cancel a [`AirInstData::MarkMoved`] marker, turning it back into a
+    /// plain use of the value. Used when a use that was initially treated as
+    /// a move turns out to be a borrow (e.g. the receiver of a builtin query
+    /// method like `String.len`). The marker instruction is rewritten in
+    /// place to a copy of the wrapped instruction, preserving the value it
+    /// produces. No-op when `inst_ref` is not a `MarkMoved`.
+    pub fn cancel_move_marker(&mut self, inst_ref: AirRef) {
+        if let AirInstData::MarkMoved { value, .. } = self.instructions[inst_ref.0 as usize].data {
+            self.instructions[inst_ref.0 as usize].data =
+                self.instructions[value.0 as usize].data.clone();
+        }
     }
 
     /// The return type of this function.
@@ -990,6 +1032,23 @@ pub enum AirInstData {
         /// The slot that becomes dead
         slot: u32,
     },
+
+    /// Marks that the value produced by `value` was moved out of its home
+    /// slot on this control-flow path (passed by value to a call, bound to
+    /// another variable, returned, ...). A pure passthrough at runtime: it
+    /// produces the same value as `value`. Drop elaboration in the CFG
+    /// builder uses these markers to suppress the scope-exit drop of slots
+    /// whose contents were moved out (the new owner is responsible for the
+    /// drop). Emitted by sema wherever the move checker marks a whole
+    /// variable as moved.
+    MarkMoved {
+        /// The use of the variable that constitutes the move
+        value: AirRef,
+        /// The local slot (or parameter ABI slot when `is_param`) moved from
+        slot: u32,
+        /// True when `slot` refers to a parameter ABI slot
+        is_param: bool,
+    },
 }
 
 impl fmt::Display for AirRef {
@@ -1284,6 +1343,14 @@ impl fmt::Display for Air {
                 }
                 AirInstData::StorageDead { slot } => {
                     writeln!(f, "storage_dead ${}", slot)?;
+                }
+                AirInstData::MarkMoved {
+                    value,
+                    slot,
+                    is_param,
+                } => {
+                    let prefix = if *is_param { "param%" } else { "$" };
+                    writeln!(f, "mark_moved {} (from {}{})", value, prefix, slot)?;
                 }
             }
         }

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1296,7 +1296,12 @@ fn analyze_destructor_function_parallel(
     let param_info: Vec<(Spur, Type, RirParamMode)> =
         vec![(self_sym, struct_type, RirParamMode::Normal)];
 
-    analyze_function_with_context(ctx, full_name, Type::UNIT, &param_info, body)
+    let mut result = analyze_function_with_context(ctx, full_name, Type::UNIT, &param_info, body)?;
+    // The destructor consumes `self`; the drop glue (not the destructor
+    // itself) drops the fields afterwards, so the destructor must not
+    // re-drop its own parameter — that would recurse forever.
+    result.0.air.clear_param_drops();
+    Ok(result)
 }
 
 /// Resolve a type symbol using the shared context.
@@ -1400,6 +1405,18 @@ fn analyze_function_with_context(
         next_abi_slot += slot_count;
     }
     let num_param_slots = next_abi_slot;
+
+    // The callee owns its pass-by-value (Normal) parameters and must drop
+    // them at exit unless they are moved out (RUE-61). Inout/borrow params
+    // stay owned by the caller; comptime params are substituted away.
+    // Destructors clear this list after analysis (see the destructor path).
+    air.set_param_drops(
+        param_vec
+            .iter()
+            .filter(|p| p.mode == RirParamMode::Normal)
+            .map(|p| (p.abi_slot, p.ty))
+            .collect(),
+    );
 
     // Run Hindley-Milner type inference
     let resolved_types = run_type_inference_with_context(ctx, return_type, params, body)?;
@@ -2684,6 +2701,7 @@ fn analyze_var_ref_ctx(
         // permits forwarding an inout parameter: `f(inout v)` inside
         // `fn g(inout v: T)`.
         let is_byref_arg_use = analysis_ctx.byref_arg_root == Some(name);
+        let mut moves_out = false;
         if !ctx.is_type_copy(ty) {
             match param_info.mode {
                 RirParamMode::Normal | RirParamMode::Comptime => {
@@ -2693,6 +2711,9 @@ fn analyze_var_ref_ctx(
                             .entry(name)
                             .or_default()
                             .mark_path_moved(&[], span);
+                        // Only Normal params occupy a real ABI slot that
+                        // drop elaboration would otherwise drop at exit.
+                        moves_out = param_info.mode == RirParamMode::Normal;
                     }
                 }
                 RirParamMode::Inout => {
@@ -2718,13 +2739,27 @@ fn analyze_var_ref_ctx(
             }
         }
 
-        let air_ref = air.add_inst(AirInst {
+        let mut air_ref = air.add_inst(AirInst {
             data: AirInstData::Param {
                 index: param_info.abi_slot,
             },
             ty,
             span,
         });
+        if moves_out {
+            // Export the move to drop elaboration: the callee-side drop of
+            // this parameter is suppressed on paths where its value moved
+            // out (RUE-61).
+            air_ref = air.add_inst(AirInst {
+                data: AirInstData::MarkMoved {
+                    value: air_ref,
+                    slot: param_info.abi_slot,
+                    is_param: true,
+                },
+                ty,
+                span,
+            });
+        }
         return Ok(AnalysisResult::new(air_ref, ty));
     }
 
@@ -2846,7 +2881,8 @@ fn analyze_var_ref_ctx(
 
     // If type is not Copy, mark as moved — unless this use is a by-ref call
     // argument, which borrows the variable rather than moving it.
-    if !ctx.is_type_copy(ty) && analysis_ctx.byref_arg_root != Some(name) {
+    let moves_out = !ctx.is_type_copy(ty) && analysis_ctx.byref_arg_root != Some(name);
+    if moves_out {
         analysis_ctx
             .moved_vars
             .entry(name)
@@ -2858,11 +2894,25 @@ fn analyze_var_ref_ctx(
     analysis_ctx.used_locals.insert(name);
 
     // Load the variable
-    let air_ref = air.add_inst(AirInst {
+    let mut air_ref = air.add_inst(AirInst {
         data: AirInstData::Load { slot },
         ty,
         span,
     });
+    if moves_out {
+        // Export the move to drop elaboration so the scope-exit drop of
+        // this slot is suppressed on paths where its value moved out
+        // (RUE-61).
+        air_ref = air.add_inst(AirInst {
+            data: AirInstData::MarkMoved {
+                value: air_ref,
+                slot,
+                is_param: false,
+            },
+            ty,
+            span,
+        });
+    }
     Ok(AnalysisResult::new(air_ref, ty))
 }
 
@@ -4104,6 +4154,9 @@ fn analyze_field_get_ctx(
     let field_type = struct_field.ty;
 
     // For linear types, field access consumes the entire struct.
+    // Remember the consumed root so the FieldGet below can be wrapped in a
+    // MarkMoved marker for drop elaboration.
+    let mut linear_move_root: Option<(u32, bool)> = None;
     if is_linear {
         if let Some(root_var) = extract_root_variable_ctx(ctx, inst_ref) {
             reject_move_out_of_byref_param_ctx(ctx, analysis_ctx, root_var, span)?;
@@ -4112,6 +4165,11 @@ fn analyze_field_get_ctx(
                 .entry(root_var)
                 .or_default()
                 .mark_path_moved(&[], span);
+            if let Some(local) = analysis_ctx.locals.get(&root_var) {
+                linear_move_root = Some((local.slot, false));
+            } else if let Some(param) = analysis_ctx.params.iter().find(|p| p.name == root_var) {
+                linear_move_root = Some((param.abi_slot, true));
+            }
         }
     }
     // For non-linear types, check if accessing a non-Copy field
@@ -4145,7 +4203,7 @@ fn analyze_field_get_ctx(
         }
     }
 
-    let air_ref = air.add_inst(AirInst {
+    let mut air_ref = air.add_inst(AirInst {
         data: AirInstData::FieldGet {
             base: base_result.air_ref,
             struct_id,
@@ -4154,6 +4212,18 @@ fn analyze_field_get_ctx(
         ty: field_type,
         span,
     });
+    if let Some((slot, is_param)) = linear_move_root {
+        // Export the linear-type full move to drop elaboration.
+        air_ref = air.add_inst(AirInst {
+            data: AirInstData::MarkMoved {
+                value: air_ref,
+                slot,
+                is_param,
+            },
+            ty: field_type,
+            span,
+        });
+    }
     Ok(AnalysisResult::new(air_ref, field_type))
 }
 
@@ -5380,6 +5450,14 @@ fn analyze_builtin_method_ctx(
 
     // Resolve return type
     let return_type = resolve_builtin_return_type_ctx(ctx, builtin_method.return_ty, struct_id);
+
+    // Borrow (ByRef) / mutation (ByMutRef) receivers are not consumed:
+    // cancel the move marker the receiver analysis may have emitted so drop
+    // elaboration doesn't treat this borrow as a move. (The serial path also
+    // un-moves the variable in `moved_vars`.)
+    if builtin_method.receiver_mode != ReceiverMode::ByValue {
+        air.cancel_move_marker(receiver_air_ref);
+    }
 
     // For mutation methods, we need to handle the storage update
     if builtin_method.receiver_mode == ReceiverMode::ByMutRef {
@@ -6641,7 +6719,7 @@ impl<'a> Sema<'a> {
             vec![(self_sym, struct_type, RirParamMode::Normal)];
 
         let (
-            air,
+            mut air,
             num_locals,
             num_param_slots,
             param_modes,
@@ -6650,6 +6728,11 @@ impl<'a> Sema<'a> {
             ref_fns,
             ref_meths,
         ) = self.analyze_function(infer_ctx, Type::UNIT, &param_info, body)?;
+
+        // The destructor consumes `self`; the drop glue (not the destructor
+        // itself) drops the fields afterwards, so the destructor must not
+        // re-drop its own parameter — that would recurse forever.
+        air.clear_param_drops();
 
         Ok((
             AnalyzedFunction {
@@ -6745,6 +6828,18 @@ impl<'a> Sema<'a> {
             next_abi_slot += slot_count;
         }
         let num_param_slots = next_abi_slot;
+
+        // The callee owns its pass-by-value (Normal) parameters and must drop
+        // them at exit unless they are moved out (RUE-61). Inout/borrow params
+        // stay owned by the caller; comptime params are substituted away.
+        // Destructors clear this list after analysis (see the destructor path).
+        air.set_param_drops(
+            param_vec
+                .iter()
+                .filter(|p| p.mode == RirParamMode::Normal)
+                .map(|p| (p.abi_slot, p.ty))
+                .collect(),
+        );
 
         // ======================================================================
         // Phase 1-2: Hindley-Milner Type Inference
@@ -9946,17 +10041,15 @@ impl<'a> Sema<'a> {
 
         // Handle receiver mode (borrow vs mutation vs consume)
         match method.receiver_mode {
-            ReceiverMode::ByRef => {
-                // Borrow semantics - "unmove" the variable since it's not consumed
+            ReceiverMode::ByRef | ReceiverMode::ByMutRef => {
+                // Borrow (ByRef) / mutation (ByMutRef) semantics - "unmove"
+                // the variable since it's not consumed, and cancel the move
+                // marker the receiver analysis emitted so drop elaboration
+                // doesn't treat this borrow as a move.
                 if let Some(var_symbol) = receiver.var {
                     ctx.moved_vars.remove(&var_symbol);
                 }
-            }
-            ReceiverMode::ByMutRef => {
-                // Mutation semantics - variable remains valid after
-                if let Some(var_symbol) = receiver.var {
-                    ctx.moved_vars.remove(&var_symbol);
-                }
+                air.cancel_move_marker(receiver.result.air_ref);
             }
             ReceiverMode::ByValue => {
                 // Consume semantics - variable is moved (already handled by analyze_inst)

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1534,6 +1534,7 @@ impl<'a> Sema<'a> {
             // permits forwarding an inout parameter: `f(inout v)` inside
             // `fn g(inout v: T)`.
             let is_byref_arg_use = ctx.byref_arg_root == Some(name);
+            let mut moves_out = false;
             if !self.is_type_copy(ty) {
                 match param_info.mode {
                     // Normal and comptime parameters behave similarly for moves
@@ -1544,6 +1545,9 @@ impl<'a> Sema<'a> {
                                 .entry(name)
                                 .or_default()
                                 .mark_path_moved(&[], span);
+                            // Only Normal params occupy a real ABI slot that
+                            // drop elaboration would otherwise drop at exit.
+                            moves_out = param_info.mode == RirParamMode::Normal;
                         }
                     }
                     RirParamMode::Inout => {
@@ -1569,13 +1573,27 @@ impl<'a> Sema<'a> {
                 }
             }
 
-            let air_ref = air.add_inst(AirInst {
+            let mut air_ref = air.add_inst(AirInst {
                 data: AirInstData::Param {
                     index: param_info.abi_slot,
                 },
                 ty,
                 span,
             });
+            if moves_out {
+                // Export the move to drop elaboration: the callee-side drop
+                // of this parameter is suppressed on paths where its value
+                // moved out (RUE-61).
+                air_ref = air.add_inst(AirInst {
+                    data: AirInstData::MarkMoved {
+                        value: air_ref,
+                        slot: param_info.abi_slot,
+                        is_param: true,
+                    },
+                    ty,
+                    span,
+                });
+            }
             return Ok(AnalysisResult::new(air_ref, ty));
         }
 
@@ -1600,7 +1618,8 @@ impl<'a> Sema<'a> {
 
             // If type is not Copy, mark as moved — unless this use is a by-ref
             // call argument, which borrows the variable rather than moving it.
-            if !self.is_type_copy(ty) && ctx.byref_arg_root != Some(name) {
+            let moves_out = !self.is_type_copy(ty) && ctx.byref_arg_root != Some(name);
+            if moves_out {
                 ctx.moved_vars
                     .entry(name)
                     .or_default()
@@ -1611,11 +1630,25 @@ impl<'a> Sema<'a> {
             ctx.used_locals.insert(name);
 
             // Load the variable
-            let air_ref = air.add_inst(AirInst {
+            let mut air_ref = air.add_inst(AirInst {
                 data: AirInstData::Load { slot },
                 ty,
                 span,
             });
+            if moves_out {
+                // Export the move to drop elaboration so the scope-exit drop
+                // of this slot is suppressed on paths where its value moved
+                // out (RUE-61).
+                air_ref = air.add_inst(AirInst {
+                    data: AirInstData::MarkMoved {
+                        value: air_ref,
+                        slot,
+                        is_param: false,
+                    },
+                    ty,
+                    span,
+                });
+            }
             return Ok(AnalysisResult::new(air_ref, ty));
         }
 
@@ -2235,11 +2268,28 @@ impl<'a> Sema<'a> {
 
             // Emit PlaceRead instruction
             let place_ref = Self::build_place_ref(air, &trace);
-            let air_ref = air.add_inst(AirInst {
+            let mut air_ref = air.add_inst(AirInst {
                 data: AirInstData::PlaceRead { place: place_ref },
                 ty: field_type,
                 span,
             });
+            if is_linear {
+                // Field access on a linear type consumes the whole struct
+                // (marked above): export the full move to drop elaboration.
+                let (slot, is_param) = match trace.base {
+                    AirPlaceBase::Local(slot) => (slot, false),
+                    AirPlaceBase::Param(slot) => (slot, true),
+                };
+                air_ref = air.add_inst(AirInst {
+                    data: AirInstData::MarkMoved {
+                        value: air_ref,
+                        slot,
+                        is_param,
+                    },
+                    ty: field_type,
+                    span,
+                });
+            }
             return Ok(AnalysisResult::new(air_ref, field_type));
         }
 

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -57,6 +57,16 @@ struct LiveSlot {
     span: rue_span::Span,
 }
 
+/// A storage location whose contents may have been moved out.
+/// Used by drop elaboration to suppress drops of moved-out values.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum MovedSlot {
+    /// A local variable slot
+    Local(u32),
+    /// A parameter ABI slot
+    Param(u32),
+}
+
 /// Builder that converts AIR to CFG.
 pub struct CfgBuilder<'a> {
     air: &'a Air,
@@ -77,6 +87,18 @@ pub struct CfgBuilder<'a> {
     /// Each scope contains the slots that became live in that scope.
     /// Used to emit StorageDead (and Drop if needed) at scope exit.
     scope_stack: Vec<Vec<LiveSlot>>,
+    /// Slots whose contents have definitely been moved out on every path
+    /// reaching the current lowering position. Drop elaboration skips these
+    /// (the new owner of the value is responsible for dropping it).
+    ///
+    /// Maintained path-sensitively: each branch of an if/match is lowered
+    /// starting from the pre-branch state, and the post-construct state is
+    /// the intersection of the branch exit states ("moved on ALL paths").
+    /// A value moved on only SOME paths therefore stays in the drop schedule
+    /// — that conservatively keeps today's double-drop for branch-divergent
+    /// moves (proper fix needs runtime drop flags), but never leaks a value
+    /// that was not moved.
+    moved_slots: std::collections::HashSet<MovedSlot>,
 }
 
 impl<'a> CfgBuilder<'a> {
@@ -109,6 +131,7 @@ impl<'a> CfgBuilder<'a> {
             value_cache: vec![None; air.len()],
             warnings: Vec::new(),
             scope_stack: vec![Vec::new()], // Start with one scope for the function body
+            moved_slots: std::collections::HashSet::new(),
         };
 
         // Create entry block
@@ -423,6 +446,10 @@ impl<'a> CfgBuilder<'a> {
                 // join — but the join is STILL reachable via the short-circuit
                 // (lhs-false) edge, so we must continue lowering there rather than
                 // propagate divergence (which would leave the join unterminated).
+                // The rhs only runs on one of the two paths into the join, so
+                // moves inside it are not "moved on all paths": restore the
+                // pre-rhs move state afterwards.
+                let moved_before_rhs = self.moved_slots.clone();
                 self.current_block = rhs_block;
                 if let Some(rhs_val) = self.lower_value(*rhs) {
                     let (args_start, args_len) = self.cfg.push_extra(std::iter::once(rhs_val));
@@ -437,6 +464,7 @@ impl<'a> CfgBuilder<'a> {
                 }
 
                 // Continue in join block
+                self.moved_slots = moved_before_rhs;
                 self.current_block = join_block;
                 self.cache(air_ref, result_param);
                 ExprResult {
@@ -481,6 +509,9 @@ impl<'a> CfgBuilder<'a> {
                 // join — but the join is STILL reachable via the short-circuit
                 // (lhs-true) edge, so we must continue lowering there rather than
                 // propagate divergence (which would leave the join unterminated).
+                // The rhs only runs on one of the two paths into the join:
+                // restore the pre-rhs move state afterwards (see And above).
+                let moved_before_rhs = self.moved_slots.clone();
                 self.current_block = rhs_block;
                 if let Some(rhs_val) = self.lower_value(*rhs) {
                     let (args_start, args_len) = self.cfg.push_extra(std::iter::once(rhs_val));
@@ -495,6 +526,7 @@ impl<'a> CfgBuilder<'a> {
                 }
 
                 // Continue in join block
+                self.moved_slots = moved_before_rhs;
                 self.current_block = join_block;
                 self.cache(air_ref, result_param);
                 ExprResult {
@@ -637,6 +669,9 @@ impl<'a> CfgBuilder<'a> {
                     Type::UNIT,
                     span,
                 );
+                // Initialization fills the slot with a fresh value: any
+                // moved-out state from a previous occupant is stale.
+                self.moved_slots.remove(&MovedSlot::Local(*slot));
                 ExprResult {
                     value: None,
                     continuation: Continuation::Continues,
@@ -664,6 +699,10 @@ impl<'a> CfgBuilder<'a> {
                     Type::UNIT,
                     span,
                 );
+                // Assigning to the slot re-initializes it: a previously
+                // moved-out value has been replaced, so it must be dropped
+                // again at scope exit.
+                self.moved_slots.remove(&MovedSlot::Local(*slot));
                 ExprResult {
                     value: None,
                     continuation: Continuation::Continues,
@@ -682,6 +721,8 @@ impl<'a> CfgBuilder<'a> {
                     Type::UNIT,
                     span,
                 );
+                // Re-initialization: see the Store arm above.
+                self.moved_slots.remove(&MovedSlot::Param(*param_slot));
                 ExprResult {
                     value: None,
                     continuation: Continuation::Continues,
@@ -1016,28 +1057,8 @@ impl<'a> CfgBuilder<'a> {
                         // Only emit scope cleanup if the value didn't diverge
                         if !matches!(result.continuation, Continuation::Diverged) {
                             for live_slot in scope_slots.into_iter().rev() {
-                                // Emit Drop for types that need cleanup (e.g., heap-allocated String)
-                                if self.type_needs_drop(live_slot.ty) {
-                                    let slot_val = self.emit(
-                                        CfgInstData::Load {
-                                            slot: live_slot.slot,
-                                        },
-                                        live_slot.ty,
-                                        live_slot.span,
-                                    );
-                                    self.emit(
-                                        CfgInstData::Drop { value: slot_val },
-                                        Type::UNIT,
-                                        live_slot.span,
-                                    );
-                                }
-                                self.emit(
-                                    CfgInstData::StorageDead {
-                                        slot: live_slot.slot,
-                                    },
-                                    Type::UNIT,
-                                    live_slot.span,
-                                );
+                                let slot_span = live_slot.span;
+                                self.emit_drop_for_slot(&live_slot, slot_span);
                             }
                         }
                     }
@@ -1079,11 +1100,15 @@ impl<'a> CfgBuilder<'a> {
                     },
                 );
 
+                // Each branch starts move tracking from the pre-branch state.
+                let moved_before = self.moved_slots.clone();
+
                 // Lower then branch
                 self.current_block = then_block;
                 let then_result = self.lower_inst(*then_value);
                 let then_exit_block = self.current_block;
                 let then_diverged = matches!(then_result.continuation, Continuation::Diverged);
+                let moved_then = std::mem::replace(&mut self.moved_slots, moved_before);
 
                 // Lower else branch
                 self.current_block = else_block;
@@ -1099,6 +1124,24 @@ impl<'a> CfgBuilder<'a> {
                 };
                 let else_exit_block = self.current_block;
                 let else_diverged = matches!(else_result.continuation, Continuation::Diverged);
+
+                // Merge move state at the join: a slot counts as moved after
+                // the if only when it is moved on every path reaching the
+                // join. A diverged branch contributes no path to the join,
+                // so only the other branch's state matters.
+                // (self.moved_slots currently holds the else-branch state.)
+                match (then_diverged, else_diverged) {
+                    (true, true) => {}  // join unreachable; state is irrelevant
+                    (true, false) => {} // keep else state
+                    (false, true) => self.moved_slots = moved_then,
+                    (false, false) => {
+                        self.moved_slots = self
+                            .moved_slots
+                            .intersection(&moved_then)
+                            .copied()
+                            .collect();
+                    }
+                }
 
                 // If both branches diverge, mark join block as unreachable and diverge
                 if then_diverged && else_diverged {
@@ -1183,6 +1226,14 @@ impl<'a> CfgBuilder<'a> {
                 let body_block = self.cfg.new_block();
                 let exit_block = self.cfg.new_block();
 
+                // The body may execute zero times, so moves inside the
+                // condition/body are not "moved on all paths" at the loop
+                // exit: restore the pre-loop move state after lowering.
+                // (Sema's back-edge move recheck already rejects moving an
+                // outer variable inside a loop, so this conservatism cannot
+                // actually reintroduce a double-drop in accepted programs.)
+                let moved_before_loop = self.moved_slots.clone();
+
                 // Jump to header
                 let (args_start, args_len) = self.cfg.push_extra(std::iter::empty());
                 self.cfg.set_terminator(
@@ -1251,6 +1302,7 @@ impl<'a> CfgBuilder<'a> {
                 }
 
                 self.loop_stack.pop();
+                self.moved_slots = moved_before_loop;
 
                 // Continue after loop
                 self.current_block = exit_block;
@@ -1275,6 +1327,11 @@ impl<'a> CfgBuilder<'a> {
                 // entry point and the continue target.
                 let body_block = self.cfg.new_block();
                 let exit_block = self.cfg.new_block();
+
+                // The exit is only reached via break, and different breaks
+                // may have different move states; conservatively restore the
+                // pre-loop state after lowering (see the Loop arm above).
+                let moved_before_loop = self.moved_slots.clone();
 
                 // Jump to body
                 let (args_start, args_len) = self.cfg.push_extra(std::iter::empty());
@@ -1314,6 +1371,7 @@ impl<'a> CfgBuilder<'a> {
                 }
 
                 self.loop_stack.pop();
+                self.moved_slots = moved_before_loop;
 
                 // Continue after loop (only reachable via break).
                 // Set Unreachable as the initial terminator. If there's code after the loop
@@ -1410,22 +1468,35 @@ impl<'a> CfgBuilder<'a> {
                     },
                 );
 
-                // Lower each arm and wire to join block
+                // Lower each arm and wire to join block.
+                // Each arm starts move tracking from the pre-match state; the
+                // state after the match is the intersection of the exit
+                // states of the arms that reach the join ("moved on ALL
+                // paths" — see the moved_slots field docs).
                 let mut all_diverged = true;
                 let mut arm_results = Vec::new();
+                let moved_before = self.moved_slots.clone();
+                let mut moved_join: Option<std::collections::HashSet<MovedSlot>> = None;
 
                 for (i, (_, body)) in arms.iter().enumerate() {
                     self.current_block = arm_blocks[i];
+                    self.moved_slots = moved_before.clone();
                     let body_result = self.lower_inst(*body);
                     let exit_block = self.current_block;
                     let diverged = matches!(body_result.continuation, Continuation::Diverged);
 
                     if !diverged {
                         all_diverged = false;
+                        moved_join = Some(match moved_join.take() {
+                            None => self.moved_slots.clone(),
+                            Some(acc) => acc.intersection(&self.moved_slots).copied().collect(),
+                        });
                     }
 
                     arm_results.push((exit_block, body_result, diverged));
                 }
+
+                self.moved_slots = moved_join.unwrap_or(moved_before);
 
                 // If all arms diverge, mark join block unreachable
                 if all_diverged {
@@ -1736,6 +1807,16 @@ impl<'a> CfgBuilder<'a> {
                     Type::UNIT,
                     span,
                 );
+                // A whole-variable write (no projections) re-initializes the
+                // slot, so a previously moved-out value must be dropped again
+                // at scope exit. Projected writes (one field/element) don't
+                // restore a fully moved-out variable.
+                let air_place = self.air.get_place(*place);
+                if let Some(slot) = air_place.as_local() {
+                    self.moved_slots.remove(&MovedSlot::Local(slot));
+                } else if let Some(slot) = air_place.as_param() {
+                    self.moved_slots.remove(&MovedSlot::Param(slot));
+                }
                 ExprResult {
                     value: None,
                     continuation: Continuation::Continues,
@@ -1810,6 +1891,11 @@ impl<'a> CfgBuilder<'a> {
                 // Emit StorageLive to CFG
                 self.emit(CfgInstData::StorageLive { slot: *slot }, Type::UNIT, span);
 
+                // Fresh storage holds a fresh (not-moved-out) value.
+                // Slots are not currently reused, so this is a no-op today,
+                // but it keeps the moved-slot state correct if reuse lands.
+                self.moved_slots.remove(&MovedSlot::Local(*slot));
+
                 // Record this slot as live in the current scope for drop elaboration
                 if let Some(scope) = self.scope_stack.last_mut() {
                     scope.push(LiveSlot {
@@ -1833,6 +1919,29 @@ impl<'a> CfgBuilder<'a> {
                     value: None,
                     continuation: Continuation::Continues,
                 }
+            }
+
+            AirInstData::MarkMoved {
+                value,
+                slot,
+                is_param,
+            } => {
+                // Pure passthrough at runtime: lower the wrapped use and
+                // record that the slot's contents were moved out on this
+                // path, so drop elaboration skips the slot at scope exit.
+                let result = self.lower_inst(*value);
+                if !matches!(result.continuation, Continuation::Diverged) {
+                    let place = if *is_param {
+                        MovedSlot::Param(*slot)
+                    } else {
+                        MovedSlot::Local(*slot)
+                    };
+                    self.moved_slots.insert(place);
+                }
+                if let Some(val) = result.value {
+                    self.cache(air_ref, val);
+                }
+                result
             }
         }
     }
@@ -1941,6 +2050,8 @@ impl<'a> CfgBuilder<'a> {
 
     /// Emit drops for all live slots in all scopes (for return).
     /// Drops are emitted in reverse order (LIFO) across all scopes.
+    /// Owned (pass-by-value) parameters are dropped after all locals, in
+    /// reverse declaration order — the callee owns its by-value arguments.
     fn emit_drops_for_all_scopes(&mut self, span: rue_span::Span) {
         // Collect all live slots in reverse order across all scopes
         let all_slots: Vec<LiveSlot> = self
@@ -1952,6 +2063,19 @@ impl<'a> CfgBuilder<'a> {
 
         for live_slot in all_slots {
             self.emit_drop_for_slot(&live_slot, span);
+        }
+
+        // Drop owned parameters (unless their value was moved out on every
+        // path reaching this exit). The list is empty for destructors and
+        // drop-glue functions, which must not re-drop their own parameter.
+        for &(abi_slot, ty) in self.air.param_drops().to_vec().iter().rev() {
+            if self.moved_slots.contains(&MovedSlot::Param(abi_slot)) {
+                continue;
+            }
+            if self.type_needs_drop(ty) {
+                let param_val = self.emit(CfgInstData::Param { index: abi_slot }, ty, span);
+                self.emit(CfgInstData::Drop { value: param_val }, Type::UNIT, span);
+            }
         }
     }
 
@@ -1975,9 +2099,14 @@ impl<'a> CfgBuilder<'a> {
     }
 
     /// Emit Drop and StorageDead for a single slot.
+    /// The Drop is suppressed when the slot's value was moved out on every
+    /// path reaching this point (the new owner drops it); the StorageDead
+    /// is still emitted to end the slot's storage lifetime.
     fn emit_drop_for_slot(&mut self, live_slot: &LiveSlot, span: rue_span::Span) {
-        // Emit Drop if the type needs it
-        if self.type_needs_drop(live_slot.ty) {
+        // Emit Drop if the type needs it and the value wasn't moved out
+        if !self.moved_slots.contains(&MovedSlot::Local(live_slot.slot))
+            && self.type_needs_drop(live_slot.ty)
+        {
             let slot_val = self.emit(
                 CfgInstData::Load {
                     slot: live_slot.slot,
@@ -2157,6 +2286,12 @@ mod tests {
     use rue_rir::AstGen;
 
     fn build_cfg(source: &str) -> Cfg {
+        build_cfg_for(source, 0)
+    }
+
+    /// Build the CFG for the `index`-th analyzed function in `source`
+    /// (functions are analyzed in declaration order).
+    fn build_cfg_for(source: &str, index: usize) -> Cfg {
         let lexer = Lexer::new(source);
         let (tokens, interner) = lexer.tokenize().unwrap();
         let parser = Parser::new(tokens, interner);
@@ -2168,7 +2303,7 @@ mod tests {
         let mut sema = Sema::new(&rir, &mut interner, PreviewFeatures::new());
         let output = sema.analyze_all().unwrap();
 
-        let func = &output.functions[0];
+        let func = &output.functions[index];
         CfgBuilder::build(
             &func.air,
             func.num_locals,
@@ -2179,6 +2314,15 @@ mod tests {
             &interner,
         )
         .cfg
+    }
+
+    /// Count the Drop instructions in a CFG.
+    fn count_drops(cfg: &Cfg) -> usize {
+        cfg.blocks()
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .filter(|v| matches!(cfg.get_inst(**v).data, CfgInstData::Drop { .. }))
+            .count()
     }
 
     #[test]
@@ -2285,16 +2429,101 @@ mod tests {
                  0\n\
              }",
         );
-        let drop_count = cfg
-            .blocks()
-            .iter()
-            .flat_map(|b| b.insts.iter())
-            .filter(|v| matches!(cfg.get_inst(**v).data, CfgInstData::Drop { .. }))
-            .count();
+        let drop_count = count_drops(&cfg);
         assert_eq!(
             drop_count, 2,
             "expected exactly one Drop per droppable local (s, t)"
         );
         assert_all_blocks_terminated(&cfg);
+    }
+
+    #[test]
+    fn test_moved_local_not_dropped_at_source() {
+        // RUE-61: `let t = s;` moves s into t — only t's slot is dropped at
+        // scope exit; s's drop is suppressed by the MarkMoved marker.
+        let cfg = build_cfg(
+            "fn main() -> i32 {\n\
+                 let s = String::with_capacity(8);\n\
+                 let t = s;\n\
+                 0\n\
+             }",
+        );
+        assert_eq!(count_drops(&cfg), 1, "moved-out s must not be dropped");
+    }
+
+    #[test]
+    fn test_owned_param_dropped_at_exit() {
+        // The callee owns its pass-by-value parameters and drops them at
+        // function exit (unless moved out).
+        let cfg = build_cfg_for(
+            "fn f(s: String) -> i32 { 0 }\n\
+             fn main() -> i32 { 0 }",
+            0,
+        );
+        assert_eq!(count_drops(&cfg), 1, "owned String param must be dropped");
+    }
+
+    #[test]
+    fn test_moved_param_not_dropped_at_exit() {
+        // A param moved into a local is dropped via the local, not again as
+        // a param at exit.
+        let cfg = build_cfg_for(
+            "fn f(s: String) -> i32 { let t = s; 0 }\n\
+             fn main() -> i32 { 0 }",
+            0,
+        );
+        assert_eq!(count_drops(&cfg), 1, "moved param must drop only via t");
+    }
+
+    #[test]
+    fn test_branch_divergent_move_keeps_drop() {
+        // A value moved on only ONE path is NOT "moved on all paths": the
+        // scope-exit drop is conservatively kept (documented residual — the
+        // moving path double-drops until drop flags exist; the non-moving
+        // path must not leak).
+        let cfg = build_cfg(
+            "fn main() -> i32 {\n\
+                 let s = String::with_capacity(8);\n\
+                 let c = true;\n\
+                 if c {\n\
+                     let t = s;\n\
+                 }\n\
+                 0\n\
+             }",
+        );
+        // One drop for t inside the branch, one (conservative) for s at exit.
+        assert_eq!(
+            count_drops(&cfg),
+            2,
+            "branch-divergent move keeps the exit drop"
+        );
+    }
+
+    #[test]
+    fn test_move_on_both_branches_suppresses_drop() {
+        // Moved in BOTH branches => moved on all paths => exit drop suppressed.
+        let source = "fn consume(s: String) -> i32 { 0 }\n\
+             fn main() -> i32 {\n\
+                 let s = String::with_capacity(8);\n\
+                 let c = true;\n\
+                 if c {\n\
+                     consume(s);\n\
+                 } else {\n\
+                     consume(s);\n\
+                 }\n\
+                 0\n\
+             }";
+        let consume_cfg = build_cfg_for(source, 0);
+        let main_cfg = build_cfg_for(source, 1);
+        assert_eq!(
+            count_drops(&consume_cfg),
+            1,
+            "consume drops its owned param once"
+        );
+        assert_eq!(
+            count_drops(&main_cfg),
+            0,
+            "s is moved on every path; main must not drop it"
+        );
     }
 }

--- a/crates/rue-cli-tests/cases/drop_moves.toml
+++ b/crates/rue-cli-tests/cases/drop_moves.toml
@@ -1,0 +1,285 @@
+# Drop elaboration vs move semantics (RUE-61 / RUE-62, fixed by RUE-108).
+#
+# Spec 3.9:2: a value is dropped exactly once — moved values are dropped at
+# their final destination, not at their original binding. Before the fix,
+# sema's move analysis was discarded before AIR, so drop elaboration dropped
+# every live slot at scope exit: a value moved into a callee / another local /
+# out via return ran its destructor TWICE, and a callee never dropped its
+# owned pass-by-value parameters at all (the caller's spurious drop masked
+# that leak).
+#
+# These cases pin EXACT destructor output via @dbg markers so both the count
+# and the order of drops are regression-tested.
+#
+# Known residuals (conservative "moved on ALL paths" analysis):
+# - A value moved in only one branch of an if/match is still dropped at scope
+#   exit (double-drop on the moving path). A full fix needs runtime drop
+#   flags, like Rust.
+# - Partial (per-field) moves don't suppress the field's drop inside the
+#   whole-struct drop at scope exit — see the RUE-62 known_bug case below.
+
+[section]
+id = "cli.drop_moves"
+name = "Drop suppression for moved-out values"
+description = "Moved values are dropped exactly once, at their destination (RUE-61/RUE-62)."
+
+[[case]]
+name = "control_unmoved_value_drops_exactly_once"
+description = "Control: a value that is never moved drops exactly once, at scope exit."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+
+drop fn D(self) {
+    @dbg(self.v);
+}
+
+fn main() -> i32 {
+    let d = D { v: 7 };
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "100\n7\n"
+exit_code = 0
+
+[[case]]
+name = "control_destructor_then_field_drop_order"
+description = "Control: dropping a struct runs its destructor, then drops its droppable fields."
+files = [{ path = "main.rue", source = """
+struct A { x: i32 }
+struct O { a: A, b: i32 }
+
+drop fn A(self) {
+    @dbg(self.x);
+}
+
+drop fn O(self) {
+    @dbg(800);
+}
+
+fn main() -> i32 {
+    let o = O { a: A { x: 1 }, b: 2 };
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "100\n800\n1\n"
+exit_code = 0
+
+[[case]]
+name = "move_into_call_drops_once_in_callee"
+description = "RUE-61: a value moved into a call is dropped by the callee (param drop at callee exit), not again by the caller."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+
+drop fn D(self) {
+    @dbg(self.v);
+}
+
+fn take(d: D) -> i32 {
+    d.v
+}
+
+fn main() -> i32 {
+    let d = D { v: 7 };
+    let x = take(d);
+    @dbg(100);
+    x - 7
+}
+""" }]
+stdout = "7\n100\n"
+exit_code = 0
+
+[[case]]
+name = "move_param_to_local_drops_once"
+description = "RUE-61 original repro: callee re-binds its param to a local; destructor runs once (in the callee), not again in main."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+
+drop fn D(self) {
+    @dbg(self.v);
+}
+
+fn consume(d: D) -> i32 {
+    let held = d;
+    held.v
+}
+
+fn main() -> i32 {
+    let d = D { v: 7 };
+    consume(d);
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "7\n100\n"
+exit_code = 0
+
+[[case]]
+name = "move_to_local_drops_once_lifo"
+description = "Chained let-moves: only the final binding drops the value; LIFO order unaffected for other slots."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+
+drop fn D(self) {
+    @dbg(self.v);
+}
+
+fn main() -> i32 {
+    let a = D { v: 7 };
+    let other = D { v: 50 };
+    let b = a;
+    let c = b;
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "100\n7\n50\n"
+exit_code = 0
+
+[[case]]
+name = "move_out_via_return_not_dropped_in_returning_fn"
+description = "RUE-61 return path: a returned value is not dropped in the returning function; the caller's binding drops it."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+
+drop fn D(self) {
+    @dbg(self.v);
+}
+
+fn make() -> D {
+    let d = D { v: 5 };
+    d
+}
+
+fn main() -> i32 {
+    let m = make();
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "100\n5\n"
+exit_code = 0
+
+[[case]]
+name = "method_consumes_receiver_drops_once"
+description = "A by-value self receiver is moved into the method, which drops it at method exit."
+files = [{ path = "main.rue", source = """
+struct D {
+    v: i32,
+
+    fn get(self) -> i32 {
+        self.v
+    }
+}
+
+drop fn D(self) {
+    @dbg(self.v);
+}
+
+fn main() -> i32 {
+    let d = D { v: 9 };
+    let x = d.get();
+    @dbg(100);
+    x - 9
+}
+""" }]
+stdout = "9\n100\n"
+exit_code = 0
+
+[[case]]
+name = "reassignment_after_move_drops_new_value"
+description = "Assigning to a moved-from variable re-initializes it: the new value drops at scope exit, the old one only at its destination."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+
+drop fn D(self) {
+    @dbg(self.v);
+}
+
+fn consume(d: D) -> i32 { d.v }
+
+fn main() -> i32 {
+    let mut d = D { v: 1 };
+    consume(d);
+    d = D { v: 2 };
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "1\n100\n2\n"
+exit_code = 0
+
+[[case]]
+name = "moved_array_drops_once"
+description = "Moving an array of droppable elements suppresses the source binding's drops."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+
+drop fn D(self) {
+    @dbg(self.v);
+}
+
+fn main() -> i32 {
+    let arr: [D; 2] = [D { v: 1 }, D { v: 2 }];
+    let arr2 = arr;
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "100\n1\n2\n"
+exit_code = 0
+
+[[case]]
+name = "borrow_arg_caller_still_drops"
+description = "A borrow argument is not a move: the caller keeps ownership and drops at its own scope exit, the callee does not."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+
+drop fn D(self) {
+    @dbg(self.v);
+}
+
+fn peek(borrow d: D) -> i32 {
+    d.v
+}
+
+fn main() -> i32 {
+    let d = D { v: 7 };
+    let x = peek(borrow d);
+    @dbg(100);
+    x - 7
+}
+""" }]
+stdout = "100\n7\n"
+exit_code = 0
+
+[[case]]
+name = "partial_field_move_suppresses_field_drop"
+description = "RUE-62: moving o.a into a call must suppress field a's drop inside o's scope-exit drop (o's own destructor still runs). Currently the whole-struct drop glue re-drops the moved field."
+known_bug = "RUE-62"
+files = [{ path = "main.rue", source = """
+struct A { x: i32 }
+struct O { a: A, b: i32 }
+
+drop fn A(self) {
+    @dbg(self.x);
+}
+
+drop fn O(self) {
+    @dbg(800);
+}
+
+fn eat(a: A) -> i32 {
+    a.x
+}
+
+fn main() -> i32 {
+    let o = O { a: A { x: 1 }, b: 2 };
+    eat(o.a);
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "1\n100\n800\n"
+exit_code = 0

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -38,6 +38,75 @@ fn main() -> i32 {
 """
 exit_code = 42
 
+[[case]]
+name = "moved_value_dropped_exactly_once_in_callee"
+spec = ["3.9:1", "3.9:2", "3.9:3"]
+description = "A value moved into a call is dropped exactly once, by the callee (RUE-61)"
+source = """
+struct Data { value: i32 }
+
+drop fn Data(self) {
+    @dbg(self.value);
+}
+
+fn consume(d: Data) -> i32 { d.value }
+
+fn main() -> i32 {
+    let d = Data { value: 7 };
+    consume(d);   // destructor runs in consume, at its exit
+    @dbg(100);    // ...so 7 prints before 100, and never again
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "7\n100\n"
+
+[[case]]
+name = "moved_to_local_dropped_exactly_once"
+spec = ["3.9:1", "3.9:2"]
+description = "A value moved into another binding is dropped exactly once, at its destination (RUE-61)"
+source = """
+struct Data { value: i32 }
+
+drop fn Data(self) {
+    @dbg(self.value);
+}
+
+fn main() -> i32 {
+    let a = Data { value: 7 };
+    let b = a;    // a's slot must not be dropped again
+    @dbg(100);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "100\n7\n"
+
+[[case]]
+name = "returned_value_not_dropped_in_returning_function"
+spec = ["3.9:1", "3.9:2"]
+description = "A returned value moves to the caller and is not dropped by the returning function (RUE-61)"
+source = """
+struct Data { value: i32 }
+
+drop fn Data(self) {
+    @dbg(self.value);
+}
+
+fn make() -> Data {
+    let d = Data { value: 5 };
+    d
+}
+
+fn main() -> i32 {
+    let m = make();
+    @dbg(100);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "100\n5\n"
+
 # =============================================================================
 # Drop Order
 # =============================================================================


### PR DESCRIPTION
Sema computed move facts and discarded them before AIR; drop elaboration
dropped every slot at scope exit regardless, so a value moved into a
callee, into another local, or out via return had its destructor run TWICE
— a double-free with heap types, masked today only by the no-op allocator
(the RUE-108 epic, led by RUE-61).

Move facts now flow into AIR as a passthrough MarkMoved instruction emitted
at every whole-variable move site in both sema pipelines (builtin by-ref
receivers cancel their marker; by-ref args emit nothing). CfgBuilder tracks
moved slots path-sensitively — insert on MarkMoved; clear on
reinitialization; if/match joins intersect the non-diverged branch states;
loop and short-circuit edges restore conservatively — and skips the Drop
(never the StorageDead) for moved slots.

Callees now drop their owned by-value params at exit (new Air.param_drops,
cleared for destructors to prevent self-recursion): the caller's spurious
drop had been masking a callee-side leak, so suppression alone would have
produced zero drops.

Entirely AIR/CFG-level — zero per-backend codegen changes; both backends
verified via asm (params reload from uniform frame slots).

Verified by exact destructor output across: move-into-call, param-to-local,
local chains, move-out-via-return, by-value method receivers, reassignment
after move, array moves, borrow controls, early-return-in-branch, plus
drop-exactly-once and LIFO-order controls. Eleven CLI cases in
drop_moves.toml with exact @dbg stdout; three spec cases strengthened with
expected_stdout (spec already mandates drop-exactly-once; no text changes).

Honest residuals, pinned rather than papered over: partial FIELD moves
(RUE-62) still re-drop the moved field via whole-struct glue — pinned with
a known_bug case encoding the desired output; branch-divergent moves
(moved in one arm only) conservatively keep the exit drop until runtime
drop flags exist — pinned by unit test. Full test.sh green.

Fixes RUE-61



🤖 Generated with [Claude Code](https://claude.com/claude-code)
