### PR TITLE
Comptime generics: type-check arguments, mangle by type identity, iterate specialization to fixpoint

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -49,8 +49,9 @@ pub struct FunctionSig {
     /// Return type, as InferType for uniform handling.
     pub return_type: InferType,
     /// Whether this is a generic function (has comptime type parameters).
-    /// Generic functions skip type checking during constraint generation -
-    /// they'll be checked during specialization.
+    /// Generic calls substitute the comptime type arguments into the parameter
+    /// types before constraining arguments; type parameters that can't be
+    /// resolved during constraint generation are checked in sema instead.
     pub is_generic: bool,
     /// Parameter modes (Normal, Inout, Borrow, Comptime).
     pub param_modes: Vec<rue_rir::RirParamMode>,
@@ -60,6 +61,10 @@ pub struct FunctionSig {
     pub param_comptime: Vec<bool>,
     /// Parameter names, needed for type substitution in generic returns.
     pub param_names: Vec<lasso::Spur>,
+    /// Each parameter's declared type, as the source-level type name symbol
+    /// (e.g. the symbol for "T" in `x: T`). Used to look up which comptime
+    /// type parameter a generic parameter refers to.
+    pub param_type_syms: Vec<lasso::Spur>,
     /// The return type as a symbol (used for substitution lookup).
     pub return_type_sym: lasso::Spur,
 }
@@ -550,47 +555,71 @@ impl<'a> ConstraintGenerator<'a> {
             } => {
                 let args = self.rir.get_call_args(*args_start, *args_len);
                 if let Some(func) = self.functions.get(name) {
-                    // For generic functions, skip constraint generation for arguments.
-                    // The types will be checked during specialization when we know
-                    // the concrete type substitutions.
+                    // For generic functions, build the type substitution map from the
+                    // comptime type arguments, then constrain each runtime argument
+                    // against its (substituted) parameter type. When a type parameter
+                    // can't be resolved here (e.g. it's a local variable holding a
+                    // type value), the constraint is skipped and the check happens in
+                    // semantic analysis instead (RUE-73, RUE-99).
                     if func.is_generic {
-                        // Process all arguments and build type substitution map
+                        // Process all arguments once, collecting their inferred types
+                        let arg_infos: Vec<ExprInfo> = args
+                            .iter()
+                            .map(|arg| self.generate(arg.value, ctx))
+                            .collect();
+
+                        // Build the type substitution map from comptime type arguments
                         let mut type_subst: std::collections::HashMap<lasso::Spur, Type> =
                             std::collections::HashMap::new();
-
                         for (i, arg) in args.iter().enumerate() {
-                            let arg_info = self.generate(arg.value, ctx);
-
-                            // If this is a comptime parameter, extract the type for substitution
-                            if i < func.param_comptime.len() && func.param_comptime[i] {
-                                // The argument should be a TypeConst - extract the concrete type
-                                if let InferType::Concrete(Type::COMPTIME_TYPE) = &arg_info.ty {
-                                    // This is a type value - get the actual type from the RIR
-                                    let arg_inst = self.rir.get(arg.value);
-                                    if let rue_rir::InstData::TypeConst { type_name } =
-                                        &arg_inst.data
-                                    {
-                                        // Resolve type_name to a concrete Type
-                                        let type_name_str = self.interner.resolve(type_name);
-                                        let concrete_ty = match type_name_str {
-                                            "i8" => Type::I8,
-                                            "i16" => Type::I16,
-                                            "i32" => Type::I32,
-                                            "i64" => Type::I64,
-                                            "u8" => Type::U8,
-                                            "u16" => Type::U16,
-                                            "u32" => Type::U32,
-                                            "u64" => Type::U64,
-                                            "bool" => Type::BOOL,
-                                            "()" => Type::UNIT,
-                                            _ => Type::ERROR, // Unknown type
-                                        };
-                                        if i < func.param_names.len() {
-                                            type_subst.insert(func.param_names[i], concrete_ty);
-                                        }
-                                    }
+                            if i < func.param_comptime.len()
+                                && func.param_comptime[i]
+                                && func.param_types.get(i)
+                                    == Some(&InferType::Concrete(Type::COMPTIME_TYPE))
+                                && i < func.param_names.len()
+                            {
+                                if let Some(concrete_ty) =
+                                    self.extract_type_argument(arg.value, ctx)
+                                {
+                                    type_subst.insert(func.param_names[i], concrete_ty);
                                 }
                             }
+                        }
+
+                        // Constrain each runtime argument to its parameter type, with
+                        // type parameters substituted. Comptime type parameters (the
+                        // `T: type` arguments themselves) are validated in sema.
+                        for (i, arg_info) in arg_infos.iter().enumerate() {
+                            if i >= func.param_types.len() || i >= func.param_comptime.len() {
+                                break;
+                            }
+                            let declared = &func.param_types[i];
+                            if func.param_comptime[i]
+                                && *declared == InferType::Concrete(Type::COMPTIME_TYPE)
+                            {
+                                // Comptime TYPE parameter - the argument is a type value
+                                continue;
+                            }
+                            let expected = if *declared == InferType::Concrete(Type::COMPTIME_TYPE)
+                            {
+                                // Generic parameter like `x: T` - substitute T
+                                match func
+                                    .param_type_syms
+                                    .get(i)
+                                    .and_then(|sym| type_subst.get(sym))
+                                {
+                                    Some(&ty) => InferType::Concrete(ty),
+                                    // Unknown type parameter - checked in sema
+                                    None => continue,
+                                }
+                            } else {
+                                declared.clone()
+                            };
+                            self.add_constraint(Constraint::equal(
+                                arg_info.ty.clone(),
+                                expected,
+                                arg_info.span,
+                            ));
                         }
 
                         // Compute the actual return type by substituting type parameters
@@ -1341,6 +1370,59 @@ impl<'a> ConstraintGenerator<'a> {
     ///
     /// Handles primitive types, array syntax `[T; N]`, pointer syntax `ptr mut T` / `ptr const T`,
     /// and struct/enum types.
+    /// Resolve a call argument used as a comptime type value (e.g. the `i32` in
+    /// `identity(i32, 42)`) to a concrete type, if it can be determined during
+    /// constraint generation.
+    ///
+    /// Handles type literals (`i32`, `bool`, ...), named struct/enum types, and
+    /// forwarded type parameters (a reference to `T` inside a specialized generic
+    /// body, resolved via `self.type_subst`). Returns `None` for type values that
+    /// are only known to semantic analysis (e.g. a local variable bound to an
+    /// anonymous struct type) - those are type-checked in sema instead.
+    fn extract_type_argument(&self, arg: InstRef, ctx: &ConstraintContext) -> Option<Type> {
+        let resolve_sym = |sym: &Spur| -> Option<Type> {
+            if let Some(subst) = self.type_subst {
+                if let Some(&ty) = subst.get(sym) {
+                    return Some(ty);
+                }
+            }
+            if let Some(&ty) = self.structs.get(sym) {
+                return Some(ty);
+            }
+            if let Some(&ty) = self.enums.get(sym) {
+                return Some(ty);
+            }
+            None
+        };
+
+        match &self.rir.get(arg).data {
+            InstData::TypeConst { type_name } => {
+                if let Some(ty) = resolve_sym(type_name) {
+                    return Some(ty);
+                }
+                match self.resolve_type_name(self.interner.resolve(type_name)) {
+                    Some(InferType::Concrete(ty)) => Some(ty),
+                    _ => None,
+                }
+            }
+            // A struct/enum name or forwarded type parameter used as a value
+            // parses as a variable reference, not a type literal.
+            InstData::VarRef { name } | InstData::ParamRef { name, .. } => {
+                // A local or parameter shadows any same-named struct/enum. A local
+                // bound to a type value (e.g. `let P = Pair(i32)`) only has a
+                // concrete type during sema's comptime evaluation, so don't
+                // resolve it here. Forwarded type parameters (`T` inside a
+                // specialized generic body) are not in scope as runtime
+                // params/locals and resolve via `self.type_subst` above.
+                if ctx.locals.contains_key(name) || ctx.params.contains_key(name) {
+                    return None;
+                }
+                resolve_sym(name)
+            }
+            _ => None,
+        }
+    }
+
     fn resolve_type_name(&self, name: &str) -> Option<InferType> {
         // Check for array syntax first: [T; N]
         if let Some((element_type_str, length)) = parse_array_type_syntax(name) {
@@ -1796,6 +1878,7 @@ mod tests {
             param_modes: vec![rue_rir::RirParamMode::Normal; num_params],
             param_comptime: vec![false; num_params],
             param_names: vec![],
+            param_type_syms: vec![],
             return_type_sym: lasso::Spur::default(),
         }
     }

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2986,6 +2986,8 @@ impl<'a> Sema<'a> {
         let return_type_sym = fn_info.return_type_sym;
         let base_return_type = fn_info.return_type;
         let fn_body = fn_info.body;
+        let rir_params_start = fn_info.rir_params_start;
+        let rir_params_len = fn_info.rir_params_len;
 
         // Special case: functions that return `type` with no parameters or only comptime parameters
         // are implicitly comptime and should be evaluated at compile time.
@@ -3092,6 +3094,55 @@ impl<'a> Sema<'a> {
                     }
                 } else {
                     runtime_args.push(air_arg.clone());
+                }
+            }
+
+            // Type-check the runtime arguments against their (substituted)
+            // parameter types. Generic calls bypass the inference-based argument
+            // checking when the type parameter isn't resolvable during constraint
+            // generation, so this is the check that rejects e.g. passing a `B`
+            // where `T == A` - without it the callee would read B-shaped fields
+            // out of an A-sized allocation (RUE-99, RUE-73).
+            let rir_param_type_syms: Vec<Spur> = self
+                .rir
+                .get_params(rir_params_start, rir_params_len)
+                .iter()
+                .map(|p| p.ty)
+                .collect();
+            for (i, (air_arg, &is_comptime)) in
+                air_args.iter().zip(param_comptime.iter()).enumerate()
+            {
+                let declared = param_types[i];
+                if is_comptime && declared == Type::COMPTIME_TYPE {
+                    // The comptime type argument itself - already validated above.
+                    continue;
+                }
+                let expected = if declared == Type::COMPTIME_TYPE {
+                    // Generic parameter like `x: T` - substitute T. If the type
+                    // parameter wasn't resolved, an error was already reported.
+                    match rir_param_type_syms
+                        .get(i)
+                        .and_then(|sym| type_subst.get(sym))
+                    {
+                        Some(&ty) => ty,
+                        None => continue,
+                    }
+                } else {
+                    declared
+                };
+                let found = air.get(air_arg.value).ty;
+                if found != expected
+                    && !found.is_error()
+                    && !found.is_never()
+                    && !expected.is_error()
+                {
+                    return Err(CompileError::new(
+                        ErrorKind::TypeMismatch {
+                            expected: expected.safe_name_with_pool(Some(&self.type_pool)),
+                            found: found.safe_name_with_pool(Some(&self.type_pool)),
+                        },
+                        self.rir.get(args[i].value).span,
+                    ));
                 }
             }
 

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -54,6 +54,12 @@ impl<'a> Sema<'a> {
                         param_modes: self.param_arena.modes(info.params).to_vec(),
                         param_comptime: self.param_arena.comptime(info.params).to_vec(),
                         param_names: self.param_arena.names(info.params).to_vec(),
+                        param_type_syms: self
+                            .rir
+                            .get_params(info.rir_params_start, info.rir_params_len)
+                            .iter()
+                            .map(|p| p.ty)
+                            .collect(),
                         return_type_sym: info.return_type_sym,
                     },
                 )

--- a/crates/rue-air/src/sema/sema_ctx_builder.rs
+++ b/crates/rue-air/src/sema/sema_ctx_builder.rs
@@ -90,6 +90,12 @@ impl<'a> Sema<'a> {
                         param_modes: self.param_arena.modes(info.params).to_vec(),
                         param_comptime: self.param_arena.comptime(info.params).to_vec(),
                         param_names: self.param_arena.names(info.params).to_vec(),
+                        param_type_syms: self
+                            .rir
+                            .get_params(info.rir_params_start, info.rir_params_len)
+                            .iter()
+                            .map(|p| p.ty)
+                            .collect(),
                         return_type_sym: info.return_type_sym,
                     },
                 )

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -7,6 +7,10 @@
 //! 2. For each unique (func_name, type_args) combination, creating a specialized function
 //! 3. Rewriting `CallGeneric` to `Call` with the specialized function name
 //!
+//! Specialized bodies can contain further `CallGeneric` instructions (a generic
+//! function forwarding its type parameter to another generic), so these steps
+//! repeat until no new specializations are discovered.
+//!
 //! # Architecture
 //!
 //! The specialization pass runs after semantic analysis but before CFG building.
@@ -41,63 +45,101 @@ struct SpecializationInfo {
     call_site_span: Span,
 }
 
+/// Maximum number of specialization rounds before giving up.
+///
+/// Each round creates the bodies for the specializations discovered in the
+/// previous round, so this bounds the nesting depth of generic-to-generic
+/// calls. Unbounded growth is possible when a generic function instantiates
+/// itself with an ever-growing type (e.g. `f(Pair(T), ...)` inside `f`).
+const MAX_SPECIALIZATION_ROUNDS: usize = 64;
+
 /// Perform the specialization pass on the sema output.
 ///
 /// This collects all `CallGeneric` instructions, creates specialized functions,
 /// and rewrites calls to point to the specialized versions.
+///
+/// Specialized function bodies can themselves contain `CallGeneric` instructions
+/// (a generic function forwarding its type parameter to another generic call),
+/// so the pass iterates to a fixpoint: each round scans the functions created in
+/// the previous round for new specialization requests (RUE-102).
 pub fn specialize(
     output: &mut SemaOutput,
     sema: &mut Sema<'_>,
     infer_ctx: &InferenceContext,
     interner: &ThreadedRodeo,
 ) -> CompileResult<()> {
-    // Phase 1: Collect all specialization requests
+    // All specializations ever requested, used to deduplicate across rounds.
     let mut specializations: HashMap<SpecializationKey, SpecializationInfo> = HashMap::new();
+    // Index of the first function not yet scanned for CallGeneric instructions.
+    let mut next_unscanned = 0;
+    let mut rounds = 0;
 
-    for func in &output.functions {
-        collect_specializations(&func.air, interner, &mut specializations);
+    loop {
+        // Phase 1: Collect specialization requests from not-yet-scanned functions
+        let mut pending: Vec<SpecializationKey> = Vec::new();
+        for func in &output.functions[next_unscanned..] {
+            collect_specializations(&func.air, interner, &mut specializations, &mut pending);
+        }
+
+        // Phase 2: Rewrite CallGeneric to Call in the newly scanned functions
+        // (previously scanned functions have no CallGeneric left)
+        for func in &mut output.functions[next_unscanned..] {
+            rewrite_call_generic(&mut func.air, &specializations);
+        }
+        next_unscanned = output.functions.len();
+
+        if pending.is_empty() {
+            return Ok(());
+        }
+
+        rounds += 1;
+        if rounds > MAX_SPECIALIZATION_ROUNDS {
+            let key = &pending[0];
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: format!(
+                        "generic specialization of '{}' exceeded the maximum nesting depth ({}); \
+                         is a generic function recursively instantiating itself with new types?",
+                        interner.resolve(&key.base_name),
+                        MAX_SPECIALIZATION_ROUNDS
+                    ),
+                },
+                specializations[key].call_site_span,
+            ));
+        }
+
+        // Phase 3: Create specialized function bodies by re-analyzing with type
+        // substitution. These new functions are scanned in the next round.
+        for key in &pending {
+            let info = &specializations[key];
+            let base_info = match sema.functions.get(&key.base_name) {
+                Some(info) => info.clone(),
+                None => {
+                    let func_name = interner.resolve(&key.base_name);
+                    return Err(CompileError::new(
+                        ErrorKind::UndefinedFunction(func_name.to_string()),
+                        info.call_site_span,
+                    ));
+                }
+            };
+            let specialized_func = create_specialized_function(
+                sema,
+                infer_ctx,
+                key,
+                info.mangled_name,
+                &base_info,
+                interner,
+            )?;
+            output.functions.push(specialized_func);
+        }
     }
-
-    if specializations.is_empty() {
-        // No generic calls, nothing to do
-        return Ok(());
-    }
-
-    // Phase 2: Rewrite CallGeneric to Call in all functions
-    for func in &mut output.functions {
-        rewrite_call_generic(&mut func.air, &specializations);
-    }
-
-    // Phase 3: Create specialized function bodies by re-analyzing with type substitution
-    for (key, info) in &specializations {
-        let base_info = match sema.functions.get(&key.base_name) {
-            Some(info) => info.clone(),
-            None => {
-                let func_name = interner.resolve(&key.base_name);
-                return Err(CompileError::new(
-                    ErrorKind::UndefinedFunction(func_name.to_string()),
-                    info.call_site_span,
-                ));
-            }
-        };
-        let specialized_func = create_specialized_function(
-            sema,
-            infer_ctx,
-            key,
-            info.mangled_name,
-            &base_info,
-            interner,
-        )?;
-        output.functions.push(specialized_func);
-    }
-
-    Ok(())
 }
 
 fn collect_specializations(
     air: &Air,
     interner: &ThreadedRodeo,
     specializations: &mut HashMap<SpecializationKey, SpecializationInfo>,
+    pending: &mut Vec<SpecializationKey>,
 ) {
     for inst in air.instructions() {
         if let AirInstData::CallGeneric {
@@ -122,6 +164,7 @@ fn collect_specializations(
                 let base_name = interner.resolve(name);
                 let mangled = mangle_specialized_name(base_name, &entry.key().type_args);
                 let mangled_sym = interner.get_or_intern(&mangled);
+                pending.push(entry.key().clone());
                 entry.insert(SpecializationInfo {
                     mangled_name: mangled_sym,
                     call_site_span: inst.span,
@@ -180,9 +223,28 @@ fn mangle_specialized_name(base_name: &str, type_args: &[Type]) -> String {
     let mut mangled = base_name.to_string();
     for ty in type_args {
         mangled.push_str("__");
-        mangled.push_str(ty.name());
+        mangled.push_str(&mangle_type(*ty));
     }
     mangled
+}
+
+/// Mangle a single type argument into a unique string.
+///
+/// Scalar types use their source-level name. Aggregate types must encode their
+/// identity (the struct/enum/array/pointer ID): `Type::name()` returns a generic
+/// placeholder like `"<struct>"` for them, which made every struct instantiation
+/// of a generic function collide on a single specialized symbol (RUE-100).
+fn mangle_type(ty: Type) -> String {
+    use crate::types::TypeKind;
+    match ty.kind() {
+        TypeKind::Struct(id) => format!("struct{}", id.0),
+        TypeKind::Enum(id) => format!("enum{}", id.0),
+        TypeKind::Array(id) => format!("array{}", id.0),
+        TypeKind::PtrConst(id) => format!("ptr_const{}", id.0),
+        TypeKind::PtrMut(id) => format!("ptr_mut{}", id.0),
+        TypeKind::Module(id) => format!("module{}", id.0),
+        _ => ty.name().to_string(),
+    }
 }
 
 /// Create a specialized function by re-analyzing the body with type substitution.

--- a/crates/rue-cli-tests/cases/generics.toml
+++ b/crates/rue-cli-tests/cases/generics.toml
@@ -1,0 +1,192 @@
+# Comptime generic function calls: argument type checking, specialization
+# symbol mangling, and type-parameter forwarding (RUE-109 epic).
+#
+# Generic calls used to bypass argument type checking entirely (RUE-73,
+# RUE-101): an i64 silently truncated into T=i32, a struct A was accepted
+# where T=B and the callee read B-shaped fields out of an A-sized allocation
+# (RUE-99, an out-of-bounds read). All struct/enum type arguments also mangled
+# to the same specialized symbol (RUE-100), and forwarding a comptime type
+# parameter to a nested generic call ICEd in the CFG builder (RUE-102).
+
+[section]
+id = "cli.generics"
+name = "Comptime generic calls"
+description = "Argument type checking, symbol mangling, and forwarding for comptime generics."
+
+# =============================================================================
+# Argument type checking (RUE-73, RUE-101)
+# =============================================================================
+
+[[case]]
+name = "generic_arg_i64_into_i32_rejected"
+description = "Passing an i64 where T = i32 is a type error, not a silent truncation (RUE-73)."
+files = [{ path = "main.rue", source = """
+fn identity(comptime T: type, x: T) -> T {
+    x
+}
+fn main() -> i32 {
+    let big: i64 = 4294967296;
+    let t = identity(i32, big);
+    if t == 0 { 1 } else { 2 }
+}
+""" }]
+compile_fail = true
+error_contains = ["type mismatch"]
+
+[[case]]
+name = "generic_arg_bool_into_i32_rejected"
+description = "Passing a bool where T = i32 is a type error (RUE-101)."
+files = [{ path = "main.rue", source = """
+fn identity(comptime T: type, x: T) -> T {
+    x
+}
+fn main() -> i32 {
+    identity(i32, true)
+}
+""" }]
+compile_fail = true
+error_contains = ["type mismatch"]
+
+[[case]]
+name = "generic_arg_negative_into_u32_rejected"
+description = "A negative literal where T = u32 is rejected instead of wrapping (RUE-101)."
+files = [{ path = "main.rue", source = """
+fn identity(comptime T: type, x: T) -> T {
+    x
+}
+fn main() -> i32 {
+    let r = identity(u32, -1);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["cannot apply unary operator"]
+
+[[case]]
+name = "generic_arg_literal_ranged_against_t"
+description = "Integer literal arguments are range-checked against T, not against i32 (RUE-101)."
+files = [{ path = "main.rue", source = """
+fn identity(comptime T: type, x: T) -> T {
+    x
+}
+fn main() -> i32 {
+    let big = identity(i64, 4294967296);
+    if big == 4294967296 { 42 } else { 1 }
+}
+""" }]
+exit_code = 42
+
+# =============================================================================
+# Aggregate argument type checking (RUE-99: was an out-of-bounds read)
+# =============================================================================
+
+[[case]]
+name = "generic_arg_wrong_struct_rejected"
+description = "Passing struct A where T = B is a type error; previously the callee read B-sized fields from an A-sized allocation (RUE-99)."
+files = [{ path = "main.rue", source = """
+struct A { x: i32 }
+struct B { x: i32, y: i32, z: i32 }
+
+fn get_z(comptime T: type, v: T) -> i32 {
+    v.z
+}
+
+fn main() -> i32 {
+    let a = A { x: 7 };
+    get_z(B, a)
+}
+""" }]
+compile_fail = true
+error_contains = ["type mismatch"]
+
+# =============================================================================
+# Specialization symbol mangling (RUE-100)
+# =============================================================================
+
+[[case]]
+name = "generic_two_struct_instantiations_link"
+description = "Two struct instantiations of one generic produce distinct symbols; this used to fail to link with 'duplicate symbol' (RUE-100)."
+files = [{ path = "main.rue", source = """
+struct A { x: i32 }
+struct B { y: i32 }
+
+fn one(comptime T: type, v: T) -> i32 {
+    1
+}
+
+fn main() -> i32 {
+    let a = A { x: 7 };
+    let b = B { y: 9 };
+    one(A, a) + one(B, b)
+}
+""" }]
+exit_code = 2
+
+[[case]]
+name = "generic_two_struct_instantiations_distinct_bodies"
+description = "Each struct instantiation gets its own specialized body reading its own layout (RUE-100: they silently shared one body when the link happened to succeed)."
+files = [{ path = "main.rue", source = """
+struct Pair { x: i32, y: i32 }
+struct Triple { x: i32, y: i32, z: i32 }
+
+fn pick(comptime T: type, v: T, second: bool) -> i32 {
+    if second { v.y } else { v.x }
+}
+
+fn main() -> i32 {
+    let p = Pair { x: 2, y: 4 };
+    let t = Triple { x: 10, y: 30, z: 50 };
+    pick(Pair, p, false) + pick(Triple, t, true)
+}
+""" }]
+exit_code = 32
+
+# =============================================================================
+# Type parameter forwarding to nested generic calls (RUE-102)
+# =============================================================================
+
+[[case]]
+name = "generic_forwarding_t_return"
+description = "Forwarding T to a nested generic call whose return type is T; used to fail with a spurious type mismatch (RUE-102)."
+files = [{ path = "main.rue", source = """
+fn inner(comptime T: type, x: T) -> T { x }
+fn outer(comptime T: type, x: T) -> T {
+    inner(T, x)
+}
+fn main() -> i32 {
+    outer(i32, 42)
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "generic_forwarding_concrete_return"
+description = "Forwarding T to a nested generic call with a concrete return type; used to ICE in the CFG builder because specialization did not iterate (RUE-102)."
+files = [{ path = "main.rue", source = """
+fn inner(comptime T: type, x: T) -> i32 { 1 }
+fn outer(comptime T: type, x: T) -> i32 {
+    inner(T, x)
+}
+fn main() -> i32 {
+    if outer(i32, 41) == 1 { 42 } else { 0 }
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "generic_forwarding_multiple_types"
+description = "Forwarding T through a relay for two different instantiations, with values exercising the full 64-bit width (RUE-102)."
+files = [{ path = "main.rue", source = """
+fn pick(comptime T: type, a: T, b: T, first: bool) -> T {
+    if first { a } else { b }
+}
+fn relay(comptime T: type, a: T, b: T) -> T {
+    pick(T, a, b, false)
+}
+fn main() -> i32 {
+    let x = relay(i32, 1, 40);
+    let y: i64 = relay(i64, 2, 9000000000);
+    if y == 9000000000 { x + 2 } else { 0 }
+}
+""" }]
+exit_code = 42


### PR DESCRIPTION
The comptime-generics epic's three roots, all repro-verified before/after:

Argument type-check (the soundness hole): the inference generator's
is_generic branch never added the equality constraint between argument and
substituted parameter type that the non-generic branch adds. Scalars
silently truncated (i64 passed where T=i32), bools coerced to ints,
literals range-checked against i32 instead of T — and the aggregate case
was memory-unsafe: passing struct A where T=B compiled and the callee read
B-sized fields from an A-sized allocation (out-of-bounds read). A new
extract_type_argument builds the substitution map (type literals, named
struct/enum refs, forwarded type params; refuses shadowing locals) and the
constraint is now added; a second check in sema's generic-call path
compares each runtime argument's AIR type against the substituted
parameter type, catching shapes inference can't see (type values held in
locals). Both report the existing E0206.

Symbol mangling: specialized names encoded Type::name(), which renders
every struct as "<struct>" — ALL struct/enum instantiations of a generic
collided on one symbol (duplicate-symbol link errors, or silently sharing
one body). Mangling now encodes type identity; two instantiations link and
get distinct bodies, verified by a layout-sensitive two-struct test.

Forwarding: passing a comptime type param to a nested generic call ICEd at
the CallGeneric arm (bare panic in the CFG builder). Specialization now
iterates to fixpoint — each round scans newly created specializations for
CallGeneric, rewrites, and queues — with dedupe via the existing map and a
64-round cap that reports a clean comptime-evaluation error instead of
looping. The CFG panic remains as a now-unreachable guard.

Frontend-only (rue-air); no backend mirroring needed. Ten CLI cases in
generics.toml cover every fixed shape. Known cosmetic residual
(pre-existing, tracked in the diagnostics epic): struct mismatches print
"expected <struct>, found <struct>" — the unifier's wording for all struct
mismatches repo-wide. Full test.sh green.

Fixes RUE-99
Fixes RUE-100
Fixes RUE-102
Fixes RUE-73
Fixes RUE-101



🤖 Generated with [Claude Code](https://claude.com/claude-code)
