### PR TITLE
Modules: ratify the in-directory facade (foo/_foo.rue); ambiguous module forms are an error

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -8837,24 +8837,24 @@ impl<'a> Sema<'a> {
         }
 
         // Phase 1: Check if the import path matches an already-loaded file
-        // This handles unit tests and multi-file compilation where all files are pre-loaded
-        for (_file_id, path) in &self.file_paths {
-            // Check for exact match
-            if path == import_path {
-                return Ok(path.clone());
-            }
-            // Check if the file path ends with the import path (handles relative imports)
-            if path.ends_with(import_path) {
-                return Ok(path.clone());
-            }
-            // For imports like "math" or "math.rue", check if the file is named accordingly
-            let import_base = import_path.strip_suffix(".rue").unwrap_or(import_path);
-            let file_name = Path::new(path).file_stem().and_then(|s| s.to_str());
-            if let Some(name) = file_name {
-                if name == import_base {
-                    return Ok(path.clone());
-                }
-            }
+        // (unit tests, multi-file compilation, and files the driver's import
+        // discovery loaded). Delegates to the structured ModulePath resolver
+        // so loaded-path matching has exactly one implementation.
+        let module_path = super::module_path::ModulePath::parse(import_path);
+        if let Some((file_module, dir_module)) =
+            module_path.find_ambiguity(self.file_paths.values())
+        {
+            return Err(CompileError::new(
+                ErrorKind::AmbiguousModule(Box::new(rue_error::AmbiguousModuleData {
+                    path: import_path.to_string(),
+                    file_module,
+                    dir_module,
+                })),
+                span,
+            ));
+        }
+        if let Some(resolved) = module_path.resolve(self.file_paths.values()) {
+            return Ok(resolved);
         }
 
         // Phase 2: Try to find the file on disk (for directory modules and actual file imports)
@@ -8869,9 +8869,25 @@ impl<'a> Sema<'a> {
         // Strip .rue extension if present for base name calculation
         let base_name = import_path.strip_suffix(".rue").unwrap_or(import_path);
 
+        // Both module forms existing at once is ambiguous, not a precedence
+        // question — mirror Rust's E0761 and refuse (RUE-137).
+        let file_candidate = source_dir.join(format!("{}.rue", base_name));
+        let facade_candidate = source_dir
+            .join(base_name)
+            .join(format!("_{}.rue", base_name));
+        if !import_path.ends_with(".rue") && file_candidate.exists() && facade_candidate.exists() {
+            return Err(CompileError::new(
+                ErrorKind::AmbiguousModule(Box::new(rue_error::AmbiguousModuleData {
+                    path: import_path.to_string(),
+                    file_module: file_candidate.to_string_lossy().to_string(),
+                    dir_module: facade_candidate.to_string_lossy().to_string(),
+                })),
+                span,
+            ));
+        }
+
         // Resolution order:
         // 1. Try foo.rue (simple file module)
-        let file_candidate = source_dir.join(format!("{}.rue", base_name));
         candidates.push(file_candidate.display().to_string());
         if file_candidate.exists() {
             return Ok(file_candidate.to_string_lossy().to_string());
@@ -8888,18 +8904,11 @@ impl<'a> Sema<'a> {
             }
         }
 
-        // 3. Try _foo.rue + foo/ directory (directory module)
-        let dir_module_root = source_dir.join(format!("_{}.rue", base_name));
-        let dir_path = source_dir.join(base_name);
-        candidates.push(format!("{} + {}/", dir_module_root.display(), base_name));
-        if dir_module_root.exists() && dir_path.is_dir() {
-            return Ok(dir_module_root.to_string_lossy().to_string());
-        }
-
-        // 3b. Also try just _foo.rue without requiring foo/ directory
-        // (This allows directory modules where all submodules are re-exported)
-        if dir_module_root.exists() {
-            return Ok(dir_module_root.to_string_lossy().to_string());
+        // 3. Try the directory module: foo/ containing the facade foo/_foo.rue
+        // (the facade lives INSIDE the directory, like std/_std.rue — RUE-137).
+        candidates.push(facade_candidate.display().to_string());
+        if facade_candidate.exists() {
+            return Ok(facade_candidate.to_string_lossy().to_string());
         }
 
         // Module not found - report error with candidates tried

--- a/crates/rue-air/src/sema/imports.rs
+++ b/crates/rue-air/src/sema/imports.rs
@@ -116,7 +116,7 @@ impl Sema<'_> {
     ///
     /// # Resolution Order
     ///
-    /// 1. Standard library (`"std"`) - currently not supported
+    /// 1. Standard library (`"std"`) - the `_std.rue` facade
     /// 2. For explicit `.rue` paths - exact match, then suffix match
     /// 3. For simple paths - `{path}.rue`, then suffix match, then basename match
     /// 4. Facade files (`_foo.rue`) for directory modules

--- a/crates/rue-air/src/sema/module_path.rs
+++ b/crates/rue-air/src/sema/module_path.rs
@@ -11,9 +11,10 @@
 //! 1. **Standard library** - if the path is exactly "std"
 //! 2. **Exact path with extension** - if path includes ".rue" extension
 //! 3. **Simple file match** - look for `foo.rue` or path ending with `foo.rue`
-//! 4. **Facade module** - look for `_foo.rue` (directory module entry point)
+//! 4. **Facade module** - look for `foo/_foo.rue` (the directory module's entry point, inside the directory — RUE-137)
 //!
-//! The first match wins, so `foo.rue` takes precedence over `_foo.rue`.
+//! Both module forms existing at once (`foo.rue` AND `foo/_foo.rue`) is an
+//! ambiguity error (E0708), mirroring Rust's E0761 — see [`ModulePath::find_ambiguity`].
 
 use std::path::Path;
 
@@ -25,7 +26,8 @@ use std::path::Path;
 pub enum ModulePath {
     /// Standard library import: `@import("std")`
     ///
-    /// This is a special case that is currently not supported during const eval.
+    /// Resolves to the stdlib facade `_std.rue`, loaded by the driver from
+    /// `$RUE_STD_PATH` or an adjacent `std/` directory.
     Std,
 
     /// Import with explicit `.rue` extension: `@import("foo.rue")`
@@ -37,7 +39,7 @@ pub enum ModulePath {
     ///
     /// Resolution tries:
     /// 1. `{path}.rue` - standard file
-    /// 2. `_{basename}.rue` - facade file for directory modules
+    /// 2. `{path}/_{basename}.rue` - in-directory facade for directory modules
     ///
     /// For nested paths like `utils/strings`, we look for `utils/strings.rue`.
     Simple { path: String },
@@ -84,7 +86,7 @@ impl ModulePath {
     /// 1. Exact match (for ExplicitRue)
     /// 2. Standard file match (`{path}.rue`)
     /// 3. Path suffix match (for nested paths)
-    /// 4. Facade file match (`_{basename}.rue`)
+    /// 4. In-directory facade match (`{basename}/_{basename}.rue`)
     pub fn resolve<'a, I>(&self, loaded_paths: I) -> Option<String>
     where
         I: Iterator<Item = &'a String>,
@@ -100,6 +102,44 @@ impl ModulePath {
             ModulePath::ExplicitRue { path } => self.resolve_explicit(path, loaded_paths),
             ModulePath::Simple { path } => self.resolve_simple(path, loaded_paths),
         }
+    }
+
+    /// Detect the dual-entity ambiguity for a simple import: BOTH a file
+    /// module `{path}.rue` and a directory module `{path}/_{basename}.rue`
+    /// exist among the loaded files. Mirrors Rust's E0761 (module file found
+    /// at both locations): silently preferring one is a footgun, so callers
+    /// turn this into a hard error. Returns (file_module, dir_module).
+    pub fn find_ambiguity<'a, I>(&self, loaded_paths: I) -> Option<(String, String)>
+    where
+        I: Iterator<Item = &'a String>,
+    {
+        let ModulePath::Simple { path } = self else {
+            return None;
+        };
+        let import_with_rue = format!("{}.rue", path);
+        let basename = Path::new(path)
+            .file_name()
+            .and_then(|s| s.to_str())
+            .unwrap_or(path);
+        let facade_suffix = format!("{}/_{}.rue", basename, basename);
+
+        let boundary_match = |candidate: &str, suffix: &str| -> bool {
+            candidate.ends_with(suffix) && {
+                let prefix_len = candidate.len() - suffix.len();
+                prefix_len == 0 || candidate.as_bytes()[prefix_len - 1] == b'/'
+            }
+        };
+
+        let mut file_module = None;
+        let mut dir_module = None;
+        for p in loaded_paths {
+            if file_module.is_none() && boundary_match(p, &import_with_rue) {
+                file_module = Some(p.clone());
+            } else if dir_module.is_none() && boundary_match(p, &facade_suffix) {
+                dir_module = Some(p.clone());
+            }
+        }
+        file_module.zip(dir_module)
     }
 
     /// Resolve an explicit `.rue` path.
@@ -139,12 +179,16 @@ impl ModulePath {
         let import_with_rue = format!("{}.rue", import_path);
         let collected: Vec<_> = loaded_paths.collect();
 
-        // Extract the basename for facade file matching
+        // The directory-module facade lives INSIDE the directory:
+        // `@import("utils")` -> `utils/_utils.rue`, like the stdlib's
+        // `std/_std.rue` (placement ratified in RUE-137). Matching the bare
+        // basename would let a stray sibling `_utils.rue` masquerade as a
+        // directory module.
         let basename = Path::new(import_path)
             .file_name()
             .and_then(|s| s.to_str())
             .unwrap_or(import_path);
-        let facade_name = format!("_{}.rue", basename);
+        let facade_suffix = format!("{}/_{}.rue", basename, basename);
 
         // Priority 1: Look for exact {path}.rue
         for file_path in &collected {
@@ -177,13 +221,12 @@ impl ModulePath {
             }
         }
 
-        // Priority 4: Look for facade file (_foo.rue)
+        // Priority 4: Look for the in-directory facade ({foo}/_{foo}.rue)
         for file_path in &collected {
-            if let Some(file_name) = Path::new(file_path.as_str())
-                .file_name()
-                .and_then(|s| s.to_str())
-            {
-                if file_name == facade_name {
+            if file_path.ends_with(&facade_suffix) {
+                // Verify it's a proper path boundary
+                let prefix_len = file_path.len() - facade_suffix.len();
+                if prefix_len == 0 || file_path.as_bytes()[prefix_len - 1] == b'/' {
                     return Some((*file_path).clone());
                 }
             }
@@ -348,21 +391,48 @@ mod tests {
 
     #[test]
     fn test_resolve_simple_facade_file() {
+        // The facade lives INSIDE the directory (RUE-137): utils/_utils.rue.
+        let paths = vec!["utils/_utils.rue".to_string()];
+        let module = ModulePath::Simple {
+            path: "utils".to_string(),
+        };
+        assert_eq!(
+            module.resolve(paths.iter()),
+            Some("utils/_utils.rue".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_simple_sibling_facade_rejected() {
+        // The pre-RUE-137 sibling layout is NOT a directory module.
         let paths = vec!["_utils.rue".to_string()];
         let module = ModulePath::Simple {
             path: "utils".to_string(),
         };
-        assert_eq!(module.resolve(paths.iter()), Some("_utils.rue".to_string()));
+        assert_eq!(module.resolve(paths.iter()), None);
     }
 
     #[test]
-    fn test_resolve_simple_prefers_regular_over_facade() {
-        // When both "foo.rue" and "_foo.rue" exist, prefer "foo.rue"
-        let paths = vec!["_foo.rue".to_string(), "foo.rue".to_string()];
+    fn test_find_ambiguity_both_forms() {
+        // Both "foo.rue" and "foo/_foo.rue" loaded: ambiguous, not a
+        // precedence question (callers raise E0708).
+        let paths = vec!["foo/_foo.rue".to_string(), "foo.rue".to_string()];
         let module = ModulePath::Simple {
             path: "foo".to_string(),
         };
-        assert_eq!(module.resolve(paths.iter()), Some("foo.rue".to_string()));
+        assert_eq!(
+            module.find_ambiguity(paths.iter()),
+            Some(("foo.rue".to_string(), "foo/_foo.rue".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_find_ambiguity_single_form_is_none() {
+        let paths = vec!["foo.rue".to_string()];
+        let module = ModulePath::Simple {
+            path: "foo".to_string(),
+        };
+        assert_eq!(module.find_ambiguity(paths.iter()), None);
     }
 
     #[test]

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -20,9 +20,9 @@ impl Sema<'_> {
     /// - `pub` items are always accessible
     /// - Private items are accessible if the files are in the same directory module
     ///
-    /// Directory module membership includes:
-    /// - Files directly in the directory (e.g., `utils/strings.rue` is in `utils`)
-    /// - Facade files for the directory (e.g., `_utils.rue` is in `utils` module)
+    /// Directory module membership is simply "files in the same directory" —
+    /// including the facade, which lives inside its directory
+    /// (`utils/_utils.rue` is in the `utils` module, RUE-137).
     ///
     /// Returns true if the item is accessible.
     pub(crate) fn is_accessible(
@@ -43,9 +43,8 @@ impl Sema<'_> {
         // If we can't determine the paths, be permissive (for single-file mode or tests)
         match (accessing_path, target_path) {
             (Some(acc), Some(tgt)) => {
-                // Get the "module identity" for each file.
-                // For a regular file like `utils/strings.rue`, the module is `utils/`
-                // For a facade file like `_utils.rue`, the module is `utils/` (the directory it represents)
+                // Get the "module identity" for each file: its parent
+                // directory (the facade included — it lives in-directory).
                 let acc_module = get_module_identity(Path::new(acc));
                 let tgt_module = get_module_identity(Path::new(tgt));
 
@@ -92,23 +91,12 @@ impl Sema<'_> {
     }
 }
 
-/// Get the module identity for a file path.
+/// Get the module identity for a file path: its parent directory.
 ///
-/// - For regular files: returns the parent directory
-/// - For facade files (`_foo.rue`): returns the corresponding directory (`foo/`)
-///
-/// This allows facade files to be treated as part of their corresponding directory module.
+/// Since RUE-137 the directory-module facade lives INSIDE its directory
+/// (`utils/_utils.rue`), so the facade's module is simply its parent — the
+/// same rule as every other file. (The old sibling layout needed a special
+/// case mapping `_utils.rue` to `utils/`; that layout no longer exists.)
 pub(crate) fn get_module_identity(path: &Path) -> Option<PathBuf> {
-    let parent = path.parent()?;
-    let file_stem = path.file_stem()?.to_str()?;
-
-    // Check if this is a facade file (starts with underscore)
-    if file_stem.starts_with('_') {
-        // Facade file: _utils.rue -> parent/utils
-        let module_name = &file_stem[1..]; // Strip the leading underscore
-        Some(parent.join(module_name))
-    } else {
-        // Regular file: the module is just the parent directory
-        Some(parent.to_path_buf())
-    }
+    path.parent().map(Path::to_path_buf)
 }

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -87,8 +87,37 @@ pub fn triple(x: i32) -> i32 {
 exit_code = 0
 
 # Directory module: _utils.rue alongside a utils/ directory (ADR-0026).
+# The facade lives INSIDE the directory (utils/_utils.rue), like the
+# stdlib's std/_std.rue — ratified in RUE-137 after re-reading the cited
+# matklad article (an earlier ADR revision wrongly placed it as a sibling).
 [[case]]
 name = "import_directory_module_call"
+files = [
+    { path = "main.rue", source = """
+const utils = @import("utils");
+
+fn main() -> i32 {
+    @dbg(utils.triple(14));
+    0
+}
+""" },
+    { path = "utils/_utils.rue", source = """
+pub fn triple(x: i32) -> i32 {
+    x * 3
+}
+""" },
+    { path = "utils/helpers.rue", source = """
+pub fn unused() -> i32 {
+    0
+}
+""" },
+]
+stdout = "42\n"
+
+# A sibling _utils.rue (the rejected pre-RUE-137 layout) is NOT a module
+# facade: the import must fail cleanly, not silently half-work.
+[[case]]
+name = "sibling_facade_is_not_a_directory_module"
 files = [
     { path = "main.rue", source = """
 const utils = @import("utils");
@@ -109,7 +138,8 @@ pub fn unused() -> i32 {
 }
 """ },
 ]
-stdout = "42\n"
+compile_fail = true
+error_contains = ["E0704"]
 
 # The standard library via a std/ directory adjacent to the source.
 [[case]]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -152,6 +152,7 @@ impl ErrorCode {
     pub const STD_LIB_NOT_FOUND: Self = Self(705);
     pub const PRIVATE_MEMBER_ACCESS: Self = Self(706);
     pub const UNKNOWN_MODULE_MEMBER: Self = Self(707);
+    pub const AMBIGUOUS_MODULE: Self = Self(708);
 
     // ========================================================================
     // Literal/operator errors (E0800-E0899)
@@ -780,6 +781,15 @@ fn format_array_length_mismatch(expected: u64, found: u64) -> String {
     }
 }
 
+/// Payload for [`ErrorKind::AmbiguousModule`], boxed to keep `ErrorKind`
+/// within its 64-byte size budget (three inline `String`s exceed it).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AmbiguousModuleData {
+    pub path: String,
+    pub file_module: String,
+    pub dir_module: String,
+}
+
 /// The kind of compilation error.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ErrorKind {
@@ -1018,6 +1028,8 @@ pub enum ErrorKind {
         /// Candidates that were tried (for error message)
         candidates: Vec<String>,
     },
+    #[error("ambiguous module '{}': both '{}' and '{}' exist", .0.path, .0.file_module, .0.dir_module)]
+    AmbiguousModule(Box<AmbiguousModuleData>),
     #[error("standard library not found")]
     StdLibNotFound,
     #[error("{item_kind} `{name}` is private")]
@@ -1171,6 +1183,7 @@ impl ErrorKind {
             ErrorKind::IntrinsicTypeMismatch(_) => ErrorCode::INTRINSIC_TYPE_MISMATCH,
             ErrorKind::ImportRequiresStringLiteral => ErrorCode::IMPORT_REQUIRES_STRING_LITERAL,
             ErrorKind::ModuleNotFound { .. } => ErrorCode::MODULE_NOT_FOUND,
+            ErrorKind::AmbiguousModule { .. } => ErrorCode::AMBIGUOUS_MODULE,
             ErrorKind::StdLibNotFound => ErrorCode::STD_LIB_NOT_FOUND,
             ErrorKind::PrivateMemberAccess { .. } => ErrorCode::PRIVATE_MEMBER_ACCESS,
             ErrorKind::UnknownModuleMember { .. } => ErrorCode::UNKNOWN_MODULE_MEMBER,

--- a/crates/rue-spec/cases/modules/directory.toml
+++ b/crates/rue-spec/cases/modules/directory.toml
@@ -48,14 +48,14 @@ exit_code = 0
 
 [[case]]
 name = "import_directory_module_resolves"
-description = "@import('utils') resolves to _utils.rue when utils.rue doesn't exist"
+description = "@import('utils') resolves to the in-directory facade utils/_utils.rue (RUE-137)"
 source = """
 fn main() -> i32 {
     let utils = @import("utils");
     0
 }
 """
-aux_files = { "_utils.rue" = """
+aux_files = { "utils/_utils.rue" = """
 fn helper() -> i32 {
     42
 }
@@ -64,14 +64,14 @@ exit_code = 0
 
 [[case]]
 name = "import_directory_module_with_subdir_resolves"
-description = "@import('utils') finds _utils.rue even when utils/ directory exists"
+description = "@import('utils') finds utils/_utils.rue alongside other files in the directory"
 source = """
 fn main() -> i32 {
     let utils = @import("utils");
     0
 }
 """
-aux_files = { "_utils.rue" = """
+aux_files = { "utils/_utils.rue" = """
 fn helper() -> i32 {
     99
 }
@@ -81,12 +81,12 @@ fn inner_fn() -> i32 { 1 }
 exit_code = 0
 
 # =============================================================================
-# Resolution Priority (foo.rue before _foo.rue)
+# Ambiguity (foo.rue and foo/_foo.rue may not coexist — RUE-137)
 # =============================================================================
 
 [[case]]
-name = "import_prefers_simple_file_resolves"
-description = "foo.rue is preferred over _foo.rue if both exist (verifies resolution order)"
+name = "import_simple_file_with_stray_sibling_underscore_file"
+description = "A sibling _math.rue is just a file, not a facade: math.rue resolves cleanly (the pre-RUE-137 sibling layout has no special meaning)"
 source = """
 fn main() -> i32 {
     let math = @import("math");
@@ -96,7 +96,7 @@ fn main() -> i32 {
 aux_files = { "math.rue" = """
 fn value() -> i32 { 10 }
 """, "_math.rue" = """
-fn value() -> i32 { 20 }
+fn value2() -> i32 { 20 }
 """ }
 exit_code = 0
 

--- a/crates/rue-spec/cases/modules/import.toml
+++ b/crates/rue-spec/cases/modules/import.toml
@@ -119,3 +119,21 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "cannot find module"
+
+# =============================================================================
+# Ambiguous module forms (RUE-137)
+# =============================================================================
+
+[[case]]
+name = "ambiguous_module_both_forms_error"
+spec = ["4.13:89"]
+description = "Both foo.rue and foo/_foo.rue existing is a compile error, not a precedence question"
+source = """
+fn main() -> i32 {
+    let m = @import("foo");
+    0
+}
+"""
+aux_files = { "foo.rue" = "pub fn a() -> i32 { 1 }", "foo/_foo.rue" = "pub fn b() -> i32 { 2 }" }
+compile_fail = true
+error_contains = "ambiguous module"

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -195,7 +195,7 @@ error_contains = "private"
 # =============================================================================
 # Nested Submodule Access
 # =============================================================================
-# Tests for the _foo.rue + foo/ directory module pattern.
+# Tests for the foo/_foo.rue directory module pattern (facade inside, RUE-137).
 
 [[case]]
 name = "directory_module_intra_access"
@@ -206,7 +206,7 @@ fn main() -> i32 {
     utils.format()
 }
 """
-aux_files = { "_utils.rue" = """
+aux_files = { "utils/_utils.rue" = """
 // Re-export the strings module functions
 const strings = @import("utils/strings");
 

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -750,8 +750,10 @@ fn get_peak_memory_bytes() -> Option<u64> {
 /// - `"std"`: `$RUE_STD_PATH/_std.rue`, then `std/_std.rue` relative to the
 ///   importing file, then relative to the first (root) source file
 /// - `"foo.rue"`: exact path relative to the importing file, then the root
-/// - `"foo"` / `"a/b"`: `{path}.rue` then the `_{basename}.rue` facade,
-///   relative to the importing file, then the root
+/// - `"foo"` / `"a/b"`: `{path}.rue` then the directory-module facade
+///   `{path}/_{basename}.rue` (the facade lives INSIDE the directory, like
+///   `std/_std.rue` — ratified in RUE-137), relative to the importing file,
+///   then the root
 ///
 /// Unresolvable imports are left for sema to report (E0704 with candidate
 /// context); this function only loads what it can find.
@@ -798,47 +800,62 @@ fn discover_and_load_imports(sources: &mut Vec<(String, String)>) {
                 .map(PathBuf::from)
                 .unwrap_or_default();
 
-            let mut candidates: Vec<PathBuf> = Vec::new();
-            if import_str == "std" {
-                if let Ok(std_path) = env::var("RUE_STD_PATH") {
-                    candidates.push(Path::new(&std_path).join("_std.rue"));
-                }
-                candidates.push(importer_dir.join("std/_std.rue"));
-                candidates.push(root_dir.join("std/_std.rue"));
-            } else if import_str.ends_with(".rue") {
-                candidates.push(importer_dir.join(import_str));
-                candidates.push(root_dir.join(import_str));
+            // Candidate GROUPS, nearest base directory first. Within a
+            // group, EVERY existing candidate is loaded — if both `foo.rue`
+            // and `foo/_foo.rue` exist, loading both lets sema report the
+            // dual-entity ambiguity (E0708) instead of the driver silently
+            // picking one. Later groups are only probed when the nearer
+            // group had nothing.
+            let mut groups: Vec<Vec<PathBuf>> = Vec::new();
+            // "std" is the general directory-module rule (std/_std.rue) plus
+            // one extra candidate group: an installed stdlib via $RUE_STD_PATH.
+            if import_str == "std"
+                && let Ok(std_path) = env::var("RUE_STD_PATH")
+            {
+                groups.push(vec![Path::new(&std_path).join("_std.rue")]);
+            }
+            if import_str.ends_with(".rue") {
+                groups.push(vec![importer_dir.join(import_str)]);
+                groups.push(vec![root_dir.join(import_str)]);
             } else {
+                // Directory-module facade: foo/_foo.rue (inside the
+                // directory, mirroring std/_std.rue — RUE-137).
                 let rel = Path::new(import_str);
-                let facade = match rel.parent() {
-                    Some(parent) if parent != Path::new("") => parent.join(format!(
-                        "_{}.rue",
-                        rel.file_name().unwrap_or_default().to_string_lossy()
-                    )),
-                    _ => PathBuf::from(format!("_{}.rue", import_str)),
-                };
-                candidates.push(importer_dir.join(format!("{import_str}.rue")));
-                candidates.push(importer_dir.join(&facade));
-                candidates.push(root_dir.join(format!("{import_str}.rue")));
-                candidates.push(root_dir.join(&facade));
+                let basename = rel.file_name().unwrap_or_default().to_string_lossy();
+                let facade = rel.join(format!("_{basename}.rue"));
+                groups.push(vec![
+                    importer_dir.join(format!("{import_str}.rue")),
+                    importer_dir.join(&facade),
+                ]);
+                groups.push(vec![
+                    root_dir.join(format!("{import_str}.rue")),
+                    root_dir.join(&facade),
+                ]);
             }
 
-            for candidate in candidates {
-                let Ok(canonical) = fs::canonicalize(&candidate) else {
-                    continue;
-                };
-                if !canonical.is_file() {
-                    continue;
+            'groups: for group in groups {
+                let mut group_hit = false;
+                for candidate in group {
+                    let Ok(canonical) = fs::canonicalize(&candidate) else {
+                        continue;
+                    };
+                    if !canonical.is_file() {
+                        continue;
+                    }
+                    if loaded.contains(&canonical) {
+                        group_hit = true; // already loaded (or a cycle)
+                        continue;
+                    }
+                    let Ok(module_content) = fs::read_to_string(&candidate) else {
+                        continue;
+                    };
+                    loaded.insert(canonical);
+                    sources.push((candidate.to_string_lossy().into_owned(), module_content));
+                    group_hit = true;
                 }
-                if loaded.contains(&canonical) {
-                    break; // already loaded (or a cycle) — nothing to do
+                if group_hit {
+                    break 'groups;
                 }
-                let Ok(module_content) = fs::read_to_string(&candidate) else {
-                    continue;
-                };
-                loaded.insert(canonical);
-                sources.push((candidate.to_string_lossy().into_owned(), module_content));
-                break; // first match wins, matching ModulePath's order
             }
         }
     }

--- a/docs/designs/0026-module-system.md
+++ b/docs/designs/0026-module-system.md
@@ -115,27 +115,39 @@ fn helper() -> i32 { 42 }  // private
 
 **Resolution order for `@import("foo")`:**
 1. Local file `foo.rue` (simple file module)
-2. Local file `_foo.rue` with directory `foo/` (directory module)
+2. Directory `foo/` containing the facade file `foo/_foo.rue` (directory module)
 3. (Future) Dependency named `foo` in `rue.toml`
+
+Having BOTH `foo.rue` and `foo/_foo.rue` is a compile error (E0708, ambiguous
+module) — mirroring Rust's E0761 rather than silently preferring one form.
 
 ### Directory Modules
 
-A directory becomes a module when it contains a `_` prefixed file with the same name:
+A directory becomes a module when it contains a `_` prefixed facade file with
+the same name as the directory — the facade lives **inside** the directory,
+exactly where Rust's `mod.rs` would (this is matklad's actual proposal: the
+underscore file is the `mod.rs` replacement, renamed so it sorts first and is
+fuzzy-findable):
 
 ```
 src/
   main.rue
   math.rue           # const math = @import("math.rue");
-  _utils.rue         # const utils = @import("utils"); — module root for utils/
   utils/
+    _utils.rue       # facade — the module root for utils/
     strings.rue      # Submodule
     internal.rue     # Submodule
 ```
 
-The `_utils.rue` file controls what the directory exports using Zig's `pub const` pattern for re-exports:
+> Decision history: an earlier revision of this ADR placed `_utils.rue` as a
+> sibling of `utils/`, misreading the cited article (and contradicting the
+> shipped `std/_std.rue`). RUE-137 ratified the in-directory placement.
+
+The `utils/_utils.rue` file controls what the directory exports using Zig's
+`pub const` pattern for re-exports:
 
 ```rue
-// _utils.rue — the module root for utils/
+// utils/_utils.rue — the module root for utils/
 
 // Re-export the entire strings module
 pub const strings = @import("utils/strings.rue");
@@ -161,9 +173,9 @@ utils.helper()
 ```
 
 **Why `_` prefix?**
-1. **Sorts first** — In file listings, `_utils.rue` appears before `utils/`, making the module entry point immediately visible
-2. **Unambiguous** — `_foo.rue` is always a directory module root; `foo.rue` is always a standalone file module
-3. **No dual-file confusion** — Rust's `foo.rs` + `foo/` pattern requires remembering that both exist; here the `_` makes it explicit
+1. **Sorts first** — Within the directory's listing, `_utils.rue` appears above the submodule files, making the module entry point the first thing you see when you open the directory
+2. **Unambiguous** — `foo.rue` is always a standalone file module; a directory `foo/` containing `_foo.rue` is always a directory module
+3. **Self-contained modules** — unlike Rust 2018's `foo.rs` + `foo/` split, everything about the module lives in one directory: moving, vendoring, or deleting a module is a single filesystem operation
 
 This follows matklad's suggestion from "Notes on Module System" for improving discoverability.
 
@@ -305,7 +317,7 @@ json = { path = "../json-lib" }
 
 The resolution order becomes:
 1. Local file `foo.rue` (simple file module)
-2. Local file `_foo.rue` with `foo/` directory (directory module)
+2. Directory `foo/` containing the facade `foo/_foo.rue` (directory module)
 3. Dependency `foo` from `rue.toml`
 
 The import syntax (`@import("foo")`) remains unchanged—the package manager just adds another resolution step.
@@ -335,9 +347,9 @@ All phases are complete. 40 spec tests pass.
 
 ### Phase 3: Directory Modules ✓
 
-**Goal:** `@import("foo")` can import `_foo.rue` which has submodules in `foo/`.
+**Goal:** `@import("foo")` can import the facade `foo/_foo.rue`, which re-exports submodules from `foo/`.
 
-- [x] Directory module resolution (`_foo.rue` + `foo/` pattern)
+- [x] Directory module resolution (`foo/_foo.rue` facade pattern)
 - [x] Re-exports via `pub const`
 - [x] Intra-directory visibility rules
 

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -593,7 +593,7 @@ The return type of `@import` is a module struct type containing all `pub` declar
 Module path resolution follows this order:
 1. Standard library: `@import("std")` resolves to the bundled standard library
 2. A file `{path}.rue` relative to the importing file's directory
-3. A directory module `_{path}.rue` with subdirectory `{path}/`
+3. A directory module: a directory `{path}/` containing the facade file `_{basename}.rue`, which is the module's root
 
 {{ rule(id="4.13:83", cat="legality-rule") }}
 
@@ -652,3 +652,9 @@ fn main() -> i32 {
     0
 }
 ```
+
+{{ rule(id="4.13:89", cat="legality-rule") }}
+
+It is a compile-time error if a module path resolves to both a file module
+`{path}.rue` and a directory module `{path}/_{basename}.rue` — the import is
+ambiguous, and neither form takes precedence.


### PR DESCRIPTION
Ratifies RUE-137: the directory-module facade lives INSIDE its directory
(utils/_utils.rue), matching the cited matklad article (his underscore file
is the mod.rs replacement — an earlier ADR revision misread "sorts first"
as parent-listing order) and the stdlib's existing std/_std.rue. Every
artifact that encoded the sibling layout is updated together:

- ADR-0026: design tree, rationale wording (sorts first WITHIN the
  directory; self-contained modules instead of the self-contradicting
  dual-file argument), a decision-history note, and resolution-order text.
- Driver discovery: simple imports probe {path}/_{basename}.rue.
- Sema: the in-directory facade is matched with a path-boundary check (a
  stray sibling _utils.rue no longer masquerades as a directory module),
  and get_module_identity loses its facade special case entirely — with
  the facade in-directory, "module = parent directory" is the whole rule,
  which also makes facade<->submodule private access work (it didn't,
  exposed by the intra-directory spec case).
- Spec 4.13:82 reworded; CLI and spec cases moved to the new layout, plus
  a negative case pinning that the sibling layout is not a module.

Along the way the dual resolver problem bit again: the LIVE import
resolver (analysis.rs) hand-rolled loaded-path matching and probed the
disk with its own (sibling) facade rule, separate from the structured
ModulePath the const path uses. Phase 1 now delegates to ModulePath — one
implementation — and the disk probe uses the ratified layout.

Also per review: when BOTH foo.rue and foo/_foo.rue exist, resolution no
longer silently prefers the file — it is a compile error, new E0708
"ambiguous module" (mirroring Rust's E0761), detected both among loaded
files and on disk; the driver loads both candidates so sema can report it.
The old "foo.rue takes precedence" spec case is replaced by new normative
rule 4.13:89 with a covering compile-fail test, and the stray-underscore
shape gets its own non-facade case. ErrorKind::AmbiguousModule is boxed to
respect the 64-byte ErrorKind budget.

Full test.sh green (traceability 100% including the new rule).

Fixes RUE-137



🤖 Generated with [Claude Code](https://claude.com/claude-code)
