### PR TITLE
Modules: const re-exports resolve as members — the std.math.abs chain works

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2569,6 +2569,58 @@ impl<'a> Sema<'a> {
             }
         }
 
+        // Next, try a const defined in the module's file. The headline case is
+        // ADR-0026's re-export idiom — `pub const math = @import("...")` in a
+        // facade — where the const's type is itself a module: accessing it
+        // yields that module, so chains like `std.math.abs(...)` resolve
+        // member-by-member (RUE-136). Const lookup is by name in the flat
+        // constants table, filtered to the module's file via the declaration
+        // span (consts carry no file_id of their own).
+        if let Some(const_info) = self.constants.get(&member_name) {
+            let const_file_path = self
+                .get_file_path(const_info.span.file_id)
+                .map(|s| s.to_string());
+            if const_file_path.as_deref() == Some(module_file_path.as_str()) {
+                if !const_info.is_pub {
+                    let same_dir = match &accessing_file_path {
+                        Some(accessing) => {
+                            let accessing_dir = std::path::Path::new(accessing).parent();
+                            let module_dir = std::path::Path::new(&module_file_path).parent();
+                            accessing_dir == module_dir
+                        }
+                        None => true, // Be permissive if we can't determine the path
+                    };
+                    if !same_dir {
+                        return Err(CompileError::new(
+                            ErrorKind::PrivateMemberAccess {
+                                item_kind: "const".to_string(),
+                                name: member_name_str,
+                            },
+                            span,
+                        ));
+                    }
+                }
+
+                if const_info.ty.is_module() {
+                    // AIR doesn't have a ModuleConst instruction, so we use
+                    // UnitConst as a placeholder — the type is what matters
+                    // (mirrors how @import itself is lowered).
+                    let module_ty = const_info.ty;
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::UnitConst,
+                        ty: module_ty,
+                        span,
+                    });
+                    return Ok(AnalysisResult::new(air_ref, module_ty));
+                }
+                // A value const (e.g. `pub const PI = ...`) accessed as a
+                // module member needs const evaluation through the member
+                // path — not supported yet; fall through to the unknown-
+                // member error below so the user gets a module-scoped
+                // message rather than a confusing type error.
+            }
+        }
+
         // Member not found in the module
         Err(CompileError::new(
             ErrorKind::UnknownModuleMember {

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -144,7 +144,6 @@ error_contains = ["E0704"]
 # The standard library via a std/ directory adjacent to the source.
 [[case]]
 name = "import_std_adjacent_dir"
-known_bug = "RUE-136"
 files = [
     { path = "main.rue", source = """
 const std = @import("std");
@@ -168,7 +167,6 @@ stdout = "5\n"
 # The standard library via RUE_STD_PATH pointing at the repo's real std/.
 [[case]]
 name = "import_std_via_env_var"
-known_bug = "RUE-136"
 files = [{ path = "main.rue", source = """
 const std = @import("std");
 

--- a/crates/rue-spec/cases/modules/import.toml
+++ b/crates/rue-spec/cases/modules/import.toml
@@ -137,3 +137,38 @@ fn main() -> i32 {
 aux_files = { "foo.rue" = "pub fn a() -> i32 { 1 }", "foo/_foo.rue" = "pub fn b() -> i32 { 2 }" }
 compile_fail = true
 error_contains = "ambiguous module"
+
+[[case]]
+name = "const_module_reexport_member_chain"
+spec = ["4.13:81"]
+description = "A pub const holding a module (ADR-0026 re-export idiom) is accessible as a member; chained access reaches the inner module's functions (RUE-136)"
+source = """
+fn main() -> i32 {
+    let outer = @import("outer");
+    outer.inner.value()
+}
+"""
+aux_files = { "outer/_outer.rue" = """
+pub const inner = @import("outer/inner.rue");
+""", "outer/inner.rue" = """
+pub fn value() -> i32 { 42 }
+""" }
+exit_code = 42
+
+[[case]]
+name = "private_const_reexport_not_visible"
+spec = ["4.13:86"]
+description = "A non-pub const module re-export is not accessible from outside the directory"
+source = """
+fn main() -> i32 {
+    let outer = @import("outer");
+    outer.inner.value()
+}
+"""
+aux_files = { "outer/_outer.rue" = """
+const inner = @import("outer/inner.rue");
+""", "outer/inner.rue" = """
+pub fn value() -> i32 { 42 }
+""" }
+compile_fail = true
+error_contains = "private"


### PR DESCRIPTION
The ADR-0026 re-export idiom — pub const math = @import(...) in a facade —
was invisible to module member lookup: member access consulted functions,
structs, and enums in the module's file, but never consts, so
std.math.abs(-5) failed with E0707 "module 'std' has no member 'math'"
while std.abs worked (RUE-136, the last gap from the RUE-14 split).

Member access on a module type now also consults consts declared in the
module's file (matched via the declaration span; visibility enforced like
other members): a module-typed const yields its module, so chains resolve
member-by-member. Value consts (pub const PI = ...) still fall through to
the unknown-member error — const evaluation through the member path is a
separate feature.

Architecturally this is one edit in one place: member ACCESS is the
single-copy path shared by both sema pipelines, and once the access types
the receiver as a module, both member-CALL paths handle the chain
unchanged. (The call pair is still duplicated — that dedup lands
separately, after the in-flight worker branches that touch it.)

The two known_bug = "RUE-136" CLI cases (std via adjacent dir and via
RUE_STD_PATH, both using the std.math.abs chain) now pass and are
un-marked; two new spec cases pin the re-export chain and that a non-pub
re-export stays private. Full test.sh green.

Fixes RUE-136



🤖 Generated with [Claude Code](https://claude.com/claude-code)
