### PR TITLE
Diagnostics: real type names, correct mismatch direction, arm-precise spans, E0600 missing variants

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -275,6 +275,22 @@ impl<'a> ConstraintGenerator<'a> {
         self.type_vars.fresh()
     }
 
+    /// Check whether an instruction is a comparison operator.
+    ///
+    /// Mirrors `Sema::is_comparison`; used to recognize chained comparisons
+    /// (`a < b < c`) during constraint generation.
+    fn is_comparison(&self, inst_ref: InstRef) -> bool {
+        matches!(
+            self.rir.get(inst_ref).data,
+            InstData::Lt { .. }
+                | InstData::Gt { .. }
+                | InstData::Le { .. }
+                | InstData::Ge { .. }
+                | InstData::Eq { .. }
+                | InstData::Ne { .. }
+        )
+    }
+
     /// Add a constraint.
     pub fn add_constraint(&mut self, constraint: Constraint) {
         self.constraints.push(constraint);
@@ -335,17 +351,17 @@ impl<'a> ConstraintGenerator<'a> {
 
         let ty = match &inst.data {
             InstData::IntConst(_) => {
-                // Integer literals get a fresh type variable that we immediately
-                // bind to IntLiteral. This allows unification to track when the
-                // literal is constrained to a specific integer type.
+                // Integer literals get a fresh type variable, recorded in
+                // `int_literal_vars`. The unifier is told about these variables
+                // (via `mark_int_literal_vars`) so that binding one to a
+                // non-integer type is rejected at the offending constraint, and
+                // any that remain unbound after solving default to i32 (via
+                // `default_int_literal_vars`).
                 //
                 // Example: `let x: i64 = 42` generates:
                 //   - type_var(?0) for the literal 42
-                //   - substitution: ?0 -> IntLiteral
                 //   - constraint: Equal(Var(?0), Concrete(i64))
-                //
-                // During unification, Equal(IntLiteral, Concrete(i64)) succeeds
-                // and rebinds ?0 -> Concrete(i64) via rebind_int_literal_to_concrete.
+                // which binds ?0 -> Concrete(i64) during unification.
                 let var = self.fresh_var();
                 self.int_literal_vars.push(var);
                 InferType::Var(var)
@@ -393,8 +409,15 @@ impl<'a> ConstraintGenerator<'a> {
             | InstData::Ge { lhs, rhs } => {
                 let lhs_info = self.generate(*lhs, ctx);
                 let rhs_info = self.generate(*rhs, ctx);
-                // Operands must have the same type
-                self.add_constraint(Constraint::equal(lhs_info.ty, rhs_info.ty, span));
+                // A chained comparison (`a < b < c`, left-associative, so the
+                // LHS is itself a comparison) is always rejected by sema with a
+                // dedicated error. Skip the operand-equality constraint in that
+                // case so inference doesn't mask it with a generic type
+                // mismatch (e.g. bool vs integer literal).
+                if !self.is_comparison(*lhs) {
+                    // Operands must have the same type
+                    self.add_constraint(Constraint::equal(lhs_info.ty, rhs_info.ty, span));
+                }
                 InferType::Concrete(Type::BOOL)
             }
 
@@ -1278,7 +1301,10 @@ impl<'a> ConstraintGenerator<'a> {
             // Comptime block: the type depends on whether evaluation succeeds at compile time.
             // For type inference, we use a fresh type variable that can unify with
             // whatever type is expected from the context (e.g., a let binding's type annotation).
-            // Similar to integer literals, comptime blocks can adapt to their context.
+            // Note: the variable is NOT registered in `int_literal_vars` — a comptime
+            // block can have any type (bool, type, ...). If the inner expression is an
+            // integer literal, the Equal constraint chains this variable to the
+            // literal's variable, so i32-defaulting still applies transitively.
             InstData::Comptime { expr } => {
                 // Generate constraints for the inner expression
                 let inner_info = self.generate(*expr, ctx);
@@ -1286,7 +1312,6 @@ impl<'a> ConstraintGenerator<'a> {
                 // Use a fresh variable so comptime can unify with expected type from context.
                 // The actual evaluation happens in sema where we know the final type.
                 let var = self.fresh_var();
-                self.int_literal_vars.push(var);
                 // Add constraint that this var equals the inner expression's type
                 self.add_constraint(Constraint::equal(InferType::Var(var), inner_info.ty, span));
                 InferType::Var(var)

--- a/crates/rue-air/src/inference/types.rs
+++ b/crates/rue-air/src/inference/types.rs
@@ -114,6 +114,24 @@ impl InferType {
             _ => None,
         }
     }
+
+    /// Render this type for an error message, resolving struct/enum names
+    /// through the type pool.
+    ///
+    /// The plain `Display` impl falls back to `Type`'s pool-less placeholders
+    /// (`<struct>`, `<enum>`), which makes diagnostics like
+    /// "expected <enum>, found <enum>" useless. Use this in any user-facing
+    /// message (RUE-133).
+    pub fn name_with_pool(&self, pool: &crate::intern_pool::TypeInternPool) -> String {
+        match self {
+            InferType::Concrete(ty) => ty.safe_name_with_pool(Some(pool)),
+            InferType::Var(id) => id.to_string(),
+            InferType::IntLiteral => "{integer}".to_string(),
+            InferType::Array { element, length } => {
+                format!("[{}; {}]", element.name_with_pool(pool), length)
+            }
+        }
+    }
 }
 
 impl std::fmt::Display for InferType {

--- a/crates/rue-air/src/inference/unify.rs
+++ b/crates/rue-air/src/inference/unify.rs
@@ -102,6 +102,13 @@ impl UnificationError {
 pub struct Unifier {
     /// The current substitution being built.
     pub substitution: Substitution,
+    /// Type variables that stand for integer literals (plus any variables they
+    /// were bound to during unification). Binding one of these to a concrete
+    /// non-integer type is rejected eagerly in [`Unifier::bind`], so the error
+    /// points at the constraint that introduced the conflict (e.g. the
+    /// offending match arm) instead of surfacing later at an unrelated, wider
+    /// span like the whole function body (RUE-133).
+    int_literal_vars: std::collections::HashSet<TypeVarId>,
 }
 
 impl Default for Unifier {
@@ -115,6 +122,7 @@ impl Unifier {
     pub fn new() -> Self {
         Unifier {
             substitution: Substitution::new(),
+            int_literal_vars: std::collections::HashSet::new(),
         }
     }
 
@@ -125,7 +133,18 @@ impl Unifier {
     pub fn with_capacity(type_var_count: u32) -> Self {
         Unifier {
             substitution: Substitution::with_capacity(type_var_count as usize),
+            int_literal_vars: std::collections::HashSet::new(),
         }
+    }
+
+    /// Register the type variables that stand for integer literals.
+    ///
+    /// Call this before [`Unifier::solve_constraints`] so that binding one of
+    /// these variables (or a variable it gets chained to) to a non-integer
+    /// type is reported at the constraint that caused it. See the
+    /// `int_literal_vars` field documentation.
+    pub fn mark_int_literal_vars(&mut self, vars: &[TypeVarId]) {
+        self.int_literal_vars.extend(vars.iter().copied());
     }
 
     /// Unify two types.
@@ -221,12 +240,29 @@ impl Unifier {
             // Array with non-array: type mismatch
             // Note: This also handles Array with IntLiteral since the IntLiteral
             // cases with Concrete and IntLiteral are already handled above.
+            // Same (actual, expected) convention as TypeMismatch above: the RHS
+            // is what the context expects, the LHS is what was found (RUE-133).
             (InferType::Array { .. }, _) | (_, InferType::Array { .. }) => {
                 UnifyResult::TypeMismatch {
-                    expected: lhs_resolved,
-                    found: rhs_resolved,
+                    expected: self.render_for_error(&rhs_resolved),
+                    found: self.render_for_error(&lhs_resolved),
                 }
             }
+        }
+    }
+
+    /// Prepare a type for inclusion in an error message: variables that stand
+    /// for integer literals render as `{integer}` rather than a bare `?N`
+    /// (e.g. "expected i32, found [{integer}; 3]"). Recurses into array
+    /// element types. Display only — the substitution is not modified.
+    fn render_for_error(&self, ty: &InferType) -> InferType {
+        match ty {
+            InferType::Var(v) if self.int_literal_vars.contains(v) => InferType::IntLiteral,
+            InferType::Array { element, length } => InferType::Array {
+                element: Box::new(self.render_for_error(element)),
+                length: *length,
+            },
+            _ => ty.clone(),
         }
     }
 
@@ -261,6 +297,29 @@ impl Unifier {
                 var,
                 ty: ty.clone(),
             };
+        }
+
+        // Integer-literal tracking: an integer literal can only become an
+        // integer type. Rejecting the bind here (instead of letting the
+        // literal's variable silently absorb a non-integer type) reports the
+        // error at the constraint that introduced the conflict, with its
+        // narrow span (RUE-133).
+        if self.int_literal_vars.contains(&var) {
+            match ty {
+                // Chaining to another variable: that variable now also stands
+                // for an integer literal, so propagate the marker.
+                InferType::Var(other) => {
+                    self.int_literal_vars.insert(*other);
+                }
+                InferType::Concrete(t) => {
+                    if !t.is_integer() && !t.is_error() && !t.is_never() {
+                        return UnifyResult::IntLiteralNonInteger { found: *t };
+                    }
+                }
+                // IntLiteral keeps the variable a literal; arrays are reported
+                // by the Array-vs-non-array case in `unify`.
+                InferType::IntLiteral | InferType::Array { .. } => {}
+            }
         }
 
         self.substitution.insert(var, ty.clone());

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1520,6 +1520,7 @@ fn run_type_inference_with_context(
 
     // Phase 2: Solve constraints via unification
     let mut unifier = Unifier::with_capacity(type_var_count);
+    unifier.mark_int_literal_vars(&int_literal_vars);
     let errors = unifier.solve_constraints(&constraints);
 
     // Convert unification errors to compile errors
@@ -1527,8 +1528,8 @@ fn run_type_inference_with_context(
         let error_kind = match &err.kind {
             UnifyResult::Ok => unreachable!("UnificationError should never contain Ok"),
             UnifyResult::TypeMismatch { expected, found } => ErrorKind::TypeMismatch {
-                expected: expected.to_string(),
-                found: found.to_string(),
+                expected: expected.name_with_pool(&ctx.type_pool),
+                found: found.name_with_pool(&ctx.type_pool),
             },
             UnifyResult::IntLiteralNonInteger { found } => ErrorKind::TypeMismatch {
                 expected: "integer type".to_string(),
@@ -1624,7 +1625,7 @@ fn analyze_inst_with_context(
                 return Err(CompileError::new(
                     ErrorKind::LiteralOutOfRange {
                         value: *value,
-                        ty: ty.name().to_string(),
+                        ty: ty.safe_name_with_pool(Some(&ctx.type_pool)),
                     },
                     inst.span,
                 ));
@@ -1869,7 +1870,7 @@ fn analyze_inst_with_context(
             // Check if trying to negate an unsigned type.
             if ty.is_unsigned() {
                 return Err(CompileError::new(
-                    ErrorKind::CannotNegateUnsigned(ty.name().to_string()),
+                    ErrorKind::CannotNegateUnsigned(ty.safe_name_with_pool(Some(&ctx.type_pool))),
                     inst.span,
                 )
                 .with_note("unsigned values cannot be negated"));
@@ -1928,7 +1929,7 @@ fn analyze_inst_with_context(
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "integer type".to_string(),
-                        found: ty.name().to_string(),
+                        found: ty.safe_name_with_pool(Some(&ctx.type_pool)),
                     },
                     inst.span,
                 ));
@@ -2253,7 +2254,7 @@ fn analyze_inst_with_context(
                         return Err(CompileError::new(
                             ErrorKind::LiteralOutOfRange {
                                 value: unsigned_value,
-                                ty: ty.name().to_string(),
+                                ty: ty.safe_name_with_pool(Some(&ctx.type_pool)),
                             },
                             inst.span,
                         ));
@@ -2502,8 +2503,10 @@ fn analyze_return_ctx(
         {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
-                    expected: analysis_ctx.return_type.name().to_string(),
-                    found: inner_ty.name().to_string(),
+                    expected: analysis_ctx
+                        .return_type
+                        .safe_name_with_pool(Some(&ctx.type_pool)),
+                    found: inner_ty.safe_name_with_pool(Some(&ctx.type_pool)),
                 },
                 span,
             ));
@@ -2514,7 +2517,9 @@ fn analyze_return_ctx(
         if analysis_ctx.return_type != Type::UNIT && !analysis_ctx.return_type.is_error() {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
-                    expected: analysis_ctx.return_type.name().to_string(),
+                    expected: analysis_ctx
+                        .return_type
+                        .safe_name_with_pool(Some(&ctx.type_pool)),
                     found: "()".to_string(),
                 },
                 span,
@@ -3000,13 +3005,17 @@ fn analyze_alloc_ctx(
                 .unwrap_or_else(|| "unknown".to_string());
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
-                    expected: ty.name().to_string(),
-                    found: init_result.ty.name().to_string(),
+                    expected: ty.safe_name_with_pool(Some(&ctx.type_pool)),
+                    found: init_result.ty.safe_name_with_pool(Some(&ctx.type_pool)),
                 },
                 span,
             )
             .with_label(
-                format!("type annotation '{}' resolved to {}", type_name, ty.name()),
+                format!(
+                    "type annotation '{}' resolved to {}",
+                    type_name,
+                    ty.safe_name_with_pool(Some(&ctx.type_pool))
+                ),
                 span,
             ));
         }
@@ -3127,7 +3136,7 @@ fn analyze_assign_ctx(
                     "consider making parameter `{}` inout: `inout {}: {}`",
                     name_str,
                     name_str,
-                    param_info.ty.name()
+                    param_info.ty.safe_name_with_pool(Some(&ctx.type_pool))
                 )));
             }
             RirParamMode::Inout => {
@@ -3258,12 +3267,18 @@ fn analyze_branch_ctx(
                 if then_type != else_type && !then_type.is_error() && !else_type.is_error() {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
-                            expected: then_type.name().to_string(),
-                            found: else_type.name().to_string(),
+                            expected: then_type.safe_name_with_pool(Some(&ctx.type_pool)),
+                            found: else_type.safe_name_with_pool(Some(&ctx.type_pool)),
                         },
                         else_span,
                     )
-                    .with_label(format!("this is of type `{}`", then_type.name()), then_span)
+                    .with_label(
+                        format!(
+                            "this is of type `{}`",
+                            then_type.safe_name_with_pool(Some(&ctx.type_pool))
+                        ),
+                        then_span,
+                    )
                     .with_note("if and else branches must have compatible types"));
                 }
                 then_type
@@ -3297,7 +3312,7 @@ fn analyze_branch_ctx(
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "()".to_string(),
-                    found: then_type.name().to_string(),
+                    found: then_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 },
                 ctx.rir.get(then_block).span,
             )
@@ -3466,7 +3481,7 @@ fn analyze_match_ctx(
     // Validate that we can match on this type (integers, booleans, and enums)
     if !scrutinee_type.is_integer() && scrutinee_type != Type::BOOL && !scrutinee_type.is_enum() {
         return Err(CompileError::new(
-            ErrorKind::InvalidMatchType(scrutinee_type.name().to_string()),
+            ErrorKind::InvalidMatchType(scrutinee_type.safe_name_with_pool(Some(&ctx.type_pool))),
             span,
         ));
     }
@@ -3529,7 +3544,7 @@ fn analyze_match_ctx(
                 if !scrutinee_type.is_integer() {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
-                            expected: scrutinee_type.name().to_string(),
+                            expected: scrutinee_type.safe_name_with_pool(Some(&ctx.type_pool)),
                             found: "integer".to_string(),
                         },
                         pattern_span,
@@ -3557,7 +3572,7 @@ fn analyze_match_ctx(
                 if scrutinee_type != Type::BOOL {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
-                            expected: scrutinee_type.name().to_string(),
+                            expected: scrutinee_type.safe_name_with_pool(Some(&ctx.type_pool)),
                             found: "bool".to_string(),
                         },
                         pattern_span,
@@ -3607,7 +3622,7 @@ fn analyze_match_ctx(
                 if scrutinee_type != Type::new_enum(enum_id) {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
-                            expected: scrutinee_type.name().to_string(),
+                            expected: scrutinee_type.safe_name_with_pool(Some(&ctx.type_pool)),
                             found: enum_def.name.clone(),
                         },
                         pattern_span,
@@ -3670,8 +3685,8 @@ fn analyze_match_ctx(
                 } else if prev != body_type && !prev.is_error() && !body_type.is_error() {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
-                            expected: prev.name().to_string(),
-                            found: body_type.name().to_string(),
+                            expected: prev.safe_name_with_pool(Some(&ctx.type_pool)),
+                            found: body_type.safe_name_with_pool(Some(&ctx.type_pool)),
                         },
                         ctx.rir.get(*body).span,
                     ));
@@ -3742,7 +3757,22 @@ fn analyze_match_ctx(
     };
 
     if !is_exhaustive {
-        return Err(CompileError::new(ErrorKind::NonExhaustiveMatch, span));
+        // Name what's missing: the enum definition is in scope here, so list
+        // the uncovered variants instead of just "not exhaustive" (RUE-133).
+        let enum_def = pattern_enum_id
+            .or_else(|| match scrutinee_type.try_kind() {
+                Some(crate::types::TypeKind::Enum(id)) => Some(id),
+                _ => None,
+            })
+            .map(|id| ctx.get_enum_def(id));
+        return Err(non_exhaustive_match_error(
+            span,
+            scrutinee_type,
+            enum_def.as_ref(),
+            |i| covered_variants.contains(&i),
+            bool_true_covered,
+            bool_false_covered,
+        ));
     }
 
     let final_type = result_type.unwrap_or(Type::UNIT);
@@ -3795,7 +3825,7 @@ fn analyze_struct_init_ctx(
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "struct type".to_string(),
-                        found: ty.name().to_string(),
+                        found: ty.safe_name_with_pool(Some(&ctx.type_pool)),
                     },
                     span,
                 ));
@@ -3981,7 +4011,7 @@ fn analyze_inst_for_projection_ctx(
                 _ => {
                     return Err(CompileError::new(
                         ErrorKind::FieldAccessOnNonStruct {
-                            found: base_type.name().to_string(),
+                            found: base_type.safe_name_with_pool(Some(&ctx.type_pool)),
                         },
                         inst.span,
                     ));
@@ -4029,7 +4059,7 @@ fn analyze_inst_for_projection_ctx(
                 _ => {
                     return Err(CompileError::new(
                         ErrorKind::IndexOnNonArray {
-                            found: base_type.name().to_string(),
+                            found: base_type.safe_name_with_pool(Some(&ctx.type_pool)),
                         },
                         inst.span,
                     ));
@@ -4132,7 +4162,7 @@ fn analyze_field_get_ctx(
         _ => {
             return Err(CompileError::new(
                 ErrorKind::FieldAccessOnNonStruct {
-                    found: base_type.name().to_string(),
+                    found: base_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 },
                 span,
             ));
@@ -4363,7 +4393,7 @@ fn analyze_field_set_ctx(
                         "consider making parameter `{}` inout: `inout {}: {}`",
                         var_name,
                         var_name,
-                        root_type.name()
+                        root_type.safe_name_with_pool(Some(&ctx.type_pool))
                     )));
                 }
                 RirParamMode::Inout => {
@@ -4390,7 +4420,7 @@ fn analyze_field_set_ctx(
             _ => {
                 return Err(CompileError::new(
                     ErrorKind::FieldAccessOnNonStruct {
-                        found: current_type.name().to_string(),
+                        found: current_type.safe_name_with_pool(Some(&ctx.type_pool)),
                     },
                     span,
                 ));
@@ -4419,7 +4449,7 @@ fn analyze_field_set_ctx(
         _ => {
             return Err(CompileError::new(
                 ErrorKind::FieldAccessOnNonStruct {
-                    found: current_type.name().to_string(),
+                    found: current_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 },
                 span,
             ));
@@ -4494,7 +4524,7 @@ fn analyze_array_init_ctx(
             return Err(CompileError::new(
                 ErrorKind::InternalError(format!(
                     "Array literal inferred as non-array type: {}",
-                    array_type.name()
+                    array_type.safe_name_with_pool(Some(&ctx.type_pool))
                 )),
                 span,
             ));
@@ -4576,7 +4606,7 @@ fn analyze_index_get_ctx(
         _ => {
             return Err(CompileError::new(
                 ErrorKind::IndexOnNonArray {
-                    found: base_type.name().to_string(),
+                    found: base_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 },
                 span,
             ));
@@ -4600,7 +4630,7 @@ fn analyze_index_get_ctx(
     if !ctx.is_type_copy(elem_type) {
         return Err(CompileError::new(
             ErrorKind::MoveOutOfIndex {
-                element_type: elem_type.name().to_string(),
+                element_type: elem_type.safe_name_with_pool(Some(&ctx.type_pool)),
             },
             span,
         )
@@ -4742,7 +4772,7 @@ fn analyze_index_set_ctx(
                     "consider making parameter `{}` inout: `inout {}: {}`",
                     var_name,
                     var_name,
-                    base_type.name()
+                    base_type.safe_name_with_pool(Some(&ctx.type_pool))
                 )));
             }
             (true, abi_slot)
@@ -4758,7 +4788,7 @@ fn analyze_index_set_ctx(
         _ => {
             return Err(CompileError::new(
                 ErrorKind::IndexOnNonArray {
-                    found: base_type.name().to_string(),
+                    found: base_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 },
                 span,
             ));
@@ -5111,6 +5141,48 @@ pub(crate) fn move_out_of_inout_error(name: &str, span: Span) -> CompileError {
     )
 }
 
+/// Build the diagnostic for a non-exhaustive `match` (E0600), naming exactly
+/// what is missing (RUE-133).
+///
+/// - enum scrutinee: lists the uncovered variants ("missing variants: Blue, Green")
+/// - bool scrutinee: names the uncovered literal pattern(s)
+/// - integer scrutinee: suggests the required wildcard arm
+pub(crate) fn non_exhaustive_match_error(
+    span: Span,
+    scrutinee_type: Type,
+    enum_def: Option<&crate::types::EnumDef>,
+    variant_covered: impl Fn(u32) -> bool,
+    bool_true_covered: bool,
+    bool_false_covered: bool,
+) -> CompileError {
+    let err = CompileError::new(ErrorKind::NonExhaustiveMatch, span);
+    if scrutinee_type == Type::BOOL {
+        let missing = match (bool_true_covered, bool_false_covered) {
+            (false, false) => "patterns `true` and `false` are",
+            (false, true) => "pattern `true` is",
+            (true, false) => "pattern `false` is",
+            // Both covered means the match was exhaustive; we only get here
+            // because callers check exhaustiveness first.
+            (true, true) => return err,
+        };
+        err.with_help(format!("{missing} not covered"))
+    } else if let Some(def) = enum_def {
+        let missing: Vec<&str> = def
+            .variants
+            .iter()
+            .enumerate()
+            .filter(|(i, _)| !variant_covered(*i as u32))
+            .map(|(_, v)| v.as_str())
+            .collect();
+        if missing.is_empty() {
+            return err;
+        }
+        err.with_help(format!("missing variants: {}", missing.join(", ")))
+    } else {
+        err.with_help("integer matches must include a wildcard arm: `_ => ...`")
+    }
+}
+
 /// Validate that a by-ref (`inout`/`borrow`) call argument is a plain variable
 /// and return its symbol.
 ///
@@ -5213,7 +5285,7 @@ fn analyze_method_call_ctx(
             return Err(CompileError::new(
                 ErrorKind::MethodCallOnNonStruct {
                     method_name: method_name.to_string(),
-                    found: receiver_type.name().to_string(),
+                    found: receiver_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 },
                 span,
             ));
@@ -5813,7 +5885,7 @@ fn analyze_intrinsic_ctx(
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "dbg".to_string(),
                     expected: "integer, bool, or String".to_string(),
-                    found: arg_type.name().to_string(),
+                    found: arg_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 })),
                 span,
             ));
@@ -5854,7 +5926,7 @@ fn analyze_intrinsic_ctx(
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "cast".to_string(),
                     expected: "integer type".to_string(),
-                    found: source_type.name().to_string(),
+                    found: source_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 })),
                 span,
             ));
@@ -5864,7 +5936,7 @@ fn analyze_intrinsic_ctx(
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "cast".to_string(),
                     expected: "integer target type".to_string(),
-                    found: target_type.name().to_string(),
+                    found: target_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 })),
                 span,
             ));
@@ -6085,7 +6157,7 @@ fn analyze_intrinsic_ctx(
                     ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                         name: "ptr_read".to_string(),
                         expected: "ptr const T or ptr mut T".to_string(),
-                        found: ptr_type.name().to_string(),
+                        found: ptr_type.safe_name_with_pool(Some(&ctx.type_pool)),
                     })),
                     span,
                 ));
@@ -6129,7 +6201,7 @@ fn analyze_intrinsic_ctx(
                     ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                         name: "ptr_write".to_string(),
                         expected: "ptr mut T (cannot write through ptr const)".to_string(),
-                        found: ptr_type.name().to_string(),
+                        found: ptr_type.safe_name_with_pool(Some(&ctx.type_pool)),
                     })),
                     span,
                 ));
@@ -6139,7 +6211,7 @@ fn analyze_intrinsic_ctx(
                     ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                         name: "ptr_write".to_string(),
                         expected: "ptr mut T".to_string(),
-                        found: ptr_type.name().to_string(),
+                        found: ptr_type.safe_name_with_pool(Some(&ctx.type_pool)),
                     })),
                     span,
                 ));
@@ -6150,8 +6222,8 @@ fn analyze_intrinsic_ctx(
         if value_type != pointee_type && !value_type.is_error() && !value_type.is_never() {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
-                    expected: pointee_type.name().to_string(),
-                    found: value_type.name().to_string(),
+                    expected: pointee_type.safe_name_with_pool(Some(&ctx.type_pool)),
+                    found: value_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 },
                 span,
             ));
@@ -6193,7 +6265,7 @@ fn analyze_intrinsic_ctx(
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "ptr_offset".to_string(),
                     expected: "ptr const T or ptr mut T".to_string(),
-                    found: ptr_type.name().to_string(),
+                    found: ptr_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 })),
                 span,
             ));
@@ -6205,7 +6277,7 @@ fn analyze_intrinsic_ctx(
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "ptr_offset".to_string(),
                     expected: "integer offset".to_string(),
-                    found: offset_type.name().to_string(),
+                    found: offset_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 })),
                 span,
             ));
@@ -6245,7 +6317,7 @@ fn analyze_intrinsic_ctx(
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "ptr_to_int".to_string(),
                     expected: "ptr const T or ptr mut T".to_string(),
-                    found: ptr_type.name().to_string(),
+                    found: ptr_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 })),
                 span,
             ));
@@ -6284,7 +6356,7 @@ fn analyze_intrinsic_ctx(
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "int_to_ptr".to_string(),
                     expected: "u64".to_string(),
-                    found: addr_type.name().to_string(),
+                    found: addr_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 })),
                 span,
             ));
@@ -6300,7 +6372,7 @@ fn analyze_intrinsic_ctx(
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "int_to_ptr".to_string(),
                     expected: "ptr mut T".to_string(),
-                    found: result_type.name().to_string(),
+                    found: result_type.safe_name_with_pool(Some(&ctx.type_pool)),
                 })),
                 span,
             ));
@@ -6381,7 +6453,7 @@ fn analyze_intrinsic_ctx(
                     ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                         name: "syscall".to_string(),
                         expected: format!("u64 for argument {}", i),
-                        found: arg_type.name().to_string(),
+                        found: arg_type.safe_name_with_pool(Some(&ctx.type_pool)),
                     })),
                     span,
                 ));
@@ -6561,7 +6633,6 @@ impl<'a> Sema<'a> {
     /// # Returns
     /// A CompileError with properly formatted type names
     #[inline]
-    #[allow(dead_code)] // TODO: Use this helper throughout the codebase
     pub(crate) fn type_mismatch_error(
         &self,
         expected: Type,
@@ -7064,6 +7135,7 @@ impl<'a> Sema<'a> {
         // Phase 2: Solve constraints via unification
         // Pre-size the substitution for better performance on large functions
         let mut unifier = Unifier::with_capacity(type_var_count);
+        unifier.mark_int_literal_vars(&int_literal_vars);
         let errors = unifier.solve_constraints(&constraints);
 
         // Convert unification errors to compile errors
@@ -7074,27 +7146,27 @@ impl<'a> Sema<'a> {
             let error_kind = match &err.kind {
                 UnifyResult::Ok => unreachable!("UnificationError should never contain Ok"),
                 UnifyResult::TypeMismatch { expected, found } => ErrorKind::TypeMismatch {
-                    expected: expected.to_string(),
-                    found: found.to_string(),
+                    expected: expected.name_with_pool(&self.type_pool),
+                    found: found.name_with_pool(&self.type_pool),
                 },
                 UnifyResult::IntLiteralNonInteger { found } => ErrorKind::TypeMismatch {
                     expected: "integer type".to_string(),
-                    found: found.name().to_string(),
+                    found: found.safe_name_with_pool(Some(&self.type_pool)),
                 },
                 UnifyResult::OccursCheck { var, ty } => ErrorKind::TypeMismatch {
                     expected: "non-recursive type".to_string(),
                     found: format!("{var} = {ty} (infinite type)"),
                 },
                 UnifyResult::NotSigned { ty } => {
-                    ErrorKind::CannotNegateUnsigned(ty.name().to_string())
+                    ErrorKind::CannotNegateUnsigned(ty.safe_name_with_pool(Some(&self.type_pool)))
                 }
                 UnifyResult::NotInteger { ty } => ErrorKind::TypeMismatch {
                     expected: "integer type".to_string(),
-                    found: ty.name().to_string(),
+                    found: ty.safe_name_with_pool(Some(&self.type_pool)),
                 },
                 UnifyResult::NotUnsigned { ty } => ErrorKind::TypeMismatch {
                     expected: "unsigned integer type".to_string(),
-                    found: ty.name().to_string(),
+                    found: ty.safe_name_with_pool(Some(&self.type_pool)),
                 },
                 UnifyResult::ArrayLengthMismatch { expected, found } => {
                     ErrorKind::ArrayLengthMismatch {
@@ -7229,7 +7301,7 @@ impl<'a> Sema<'a> {
                 _ => {
                     return Err(CompileError::new(
                         ErrorKind::FieldAccessOnNonStruct {
-                            found: base_type.name().to_string(),
+                            found: base_type.safe_name_with_pool(Some(&self.type_pool)),
                         },
                         inst.span,
                     ));
@@ -7275,7 +7347,7 @@ impl<'a> Sema<'a> {
                 _ => {
                     return Err(CompileError::new(
                         ErrorKind::IndexOnNonArray {
-                            found: base_type.name().to_string(),
+                            found: base_type.safe_name_with_pool(Some(&self.type_pool)),
                         },
                         inst.span,
                     ));
@@ -7290,7 +7362,7 @@ impl<'a> Sema<'a> {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "unsigned integer type".to_string(),
-                        found: index_result.ty.name().to_string(),
+                        found: index_result.ty.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     self.rir.get(*index).span,
                 ));
@@ -7529,7 +7601,7 @@ impl<'a> Sema<'a> {
                             return Err(CompileError::new(
                                 ErrorKind::LiteralOutOfRange {
                                     value: unsigned_value,
-                                    ty: ty.name().to_string(),
+                                    ty: ty.safe_name_with_pool(Some(&self.type_pool)),
                                 },
                                 inst.span,
                             ));
@@ -7716,7 +7788,7 @@ impl<'a> Sema<'a> {
                             "consider making parameter `{}` inout: `inout {}: {}`",
                             root_name,
                             root_name,
-                            root_type.name()
+                            root_type.safe_name_with_pool(Some(&self.type_pool))
                         )));
                     }
                     AirPlaceBase::Local(_) => {
@@ -7735,7 +7807,7 @@ impl<'a> Sema<'a> {
                 None => {
                     return Err(CompileError::new(
                         ErrorKind::FieldAccessOnNonStruct {
-                            found: base_type.name().to_string(),
+                            found: base_type.safe_name_with_pool(Some(&self.type_pool)),
                         },
                         span,
                     ));
@@ -7837,7 +7909,7 @@ impl<'a> Sema<'a> {
                             "consider making parameter `{}` inout: `inout {}: {}`",
                             root_name,
                             root_name,
-                            root_type.name()
+                            root_type.safe_name_with_pool(Some(&self.type_pool))
                         )));
                     }
                     AirPlaceBase::Local(_) => {
@@ -7859,7 +7931,7 @@ impl<'a> Sema<'a> {
                 None => {
                     return Err(CompileError::new(
                         ErrorKind::IndexOnNonArray {
-                            found: base_type.name().to_string(),
+                            found: base_type.safe_name_with_pool(Some(&self.type_pool)),
                         },
                         span,
                     ));
@@ -7872,7 +7944,7 @@ impl<'a> Sema<'a> {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "unsigned integer type".to_string(),
-                        found: index_result.ty.name().to_string(),
+                        found: index_result.ty.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     self.rir.get(index).span,
                 ));
@@ -7962,7 +8034,7 @@ impl<'a> Sema<'a> {
             _ => {
                 return Err(CompileError::new(
                     ErrorKind::MethodCallOnNonStruct {
-                        found: receiver_type.name().to_string(),
+                        found: receiver_type.safe_name_with_pool(Some(&self.type_pool)),
                         method_name: method_name_str,
                     },
                     span,
@@ -8195,7 +8267,7 @@ impl<'a> Sema<'a> {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: "struct type".to_string(),
-                            found: ty.name().to_string(),
+                            found: ty.safe_name_with_pool(Some(&self.type_pool)),
                         },
                         span,
                     ));
@@ -8408,7 +8480,7 @@ impl<'a> Sema<'a> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "dbg".to_string(),
                     expected: "integer, bool, or String".to_string(),
-                    found: arg_type.name().to_string(),
+                    found: arg_type.safe_name_with_pool(Some(&self.type_pool)),
                 })),
                 span,
             ));
@@ -8458,7 +8530,7 @@ impl<'a> Sema<'a> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "cast".to_string(),
                     expected: "integer type".to_string(),
-                    found: source_type.name().to_string(),
+                    found: source_type.safe_name_with_pool(Some(&self.type_pool)),
                 })),
                 span,
             ));
@@ -8468,7 +8540,7 @@ impl<'a> Sema<'a> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "cast".to_string(),
                     expected: "integer target type".to_string(),
-                    found: target_type.name().to_string(),
+                    found: target_type.safe_name_with_pool(Some(&self.type_pool)),
                 })),
                 span,
             ));
@@ -8610,7 +8682,7 @@ impl<'a> Sema<'a> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: intrinsic_name.to_string(),
                     expected: "integer".to_string(),
-                    found: from_ty.name().to_string(),
+                    found: from_ty.safe_name_with_pool(Some(&self.type_pool)),
                 })),
                 span,
             ));
@@ -8628,7 +8700,7 @@ impl<'a> Sema<'a> {
                     ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                         name: intrinsic_name.to_string(),
                         expected: "integer".to_string(),
-                        found: ty.name().to_string(),
+                        found: ty.safe_name_with_pool(Some(&self.type_pool)),
                     })),
                     span,
                 ));
@@ -8755,7 +8827,7 @@ impl<'a> Sema<'a> {
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: format!("@{}", intrinsic_name_str),
                     expected: "String".to_string(),
-                    found: arg_type.name().to_string(),
+                    found: arg_type.safe_name_with_pool(Some(&self.type_pool)),
                 })),
                 span,
             ));
@@ -9104,7 +9176,7 @@ impl<'a> Sema<'a> {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "integer type".to_string(),
-                    found: lhs_result.ty.name().to_string(),
+                    found: lhs_result.ty.safe_name_with_pool(Some(&self.type_pool)),
                 },
                 span,
             ));
@@ -9174,7 +9246,7 @@ impl<'a> Sema<'a> {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "integer, bool, string, unit, or struct".to_string(),
-                        found: lhs_type.name().to_string(),
+                        found: lhs_type.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     self.rir.get(lhs).span,
                 ));
@@ -9183,7 +9255,7 @@ impl<'a> Sema<'a> {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
                     expected: "integer".to_string(),
-                    found: lhs_type.name().to_string(),
+                    found: lhs_type.safe_name_with_pool(Some(&self.type_pool)),
                 },
                 self.rir.get(lhs).span,
             ));
@@ -9975,8 +10047,8 @@ impl<'a> Sema<'a> {
             if arg_result.ty != expected_ty && !arg_result.ty.is_error() {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
-                        expected: expected_ty.name().to_string(),
-                        found: arg_result.ty.name().to_string(),
+                        expected: expected_ty.safe_name_with_pool(Some(&self.type_pool)),
+                        found: arg_result.ty.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     span,
                 ));
@@ -10102,8 +10174,8 @@ impl<'a> Sema<'a> {
             {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
-                        expected: expected_ty.name().to_string(),
-                        found: arg_result.ty.name().to_string(),
+                        expected: expected_ty.safe_name_with_pool(Some(&self.type_pool)),
+                        found: arg_result.ty.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     method_ctx.span,
                 ));

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -330,7 +330,7 @@ impl<'a> Sema<'a> {
                     return Err(CompileError::new(
                         ErrorKind::LiteralOutOfRange {
                             value: *value,
-                            ty: ty.name().to_string(),
+                            ty: ty.safe_name_with_pool(Some(&self.type_pool)),
                         },
                         inst.span,
                     ));
@@ -412,7 +412,9 @@ impl<'a> Sema<'a> {
                 // Check if trying to negate an unsigned type.
                 if ty.is_unsigned() {
                     return Err(CompileError::new(
-                        ErrorKind::CannotNegateUnsigned(ty.name().to_string()),
+                        ErrorKind::CannotNegateUnsigned(
+                            ty.safe_name_with_pool(Some(&self.type_pool)),
+                        ),
                         inst.span,
                     )
                     .with_note("unsigned values cannot be negated"));
@@ -470,7 +472,7 @@ impl<'a> Sema<'a> {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: "integer type".to_string(),
-                            found: ty.name().to_string(),
+                            found: ty.safe_name_with_pool(Some(&self.type_pool)),
                         },
                         inst.span,
                     ));
@@ -699,12 +701,18 @@ impl<'a> Sema<'a> {
                     if then_type != else_type && !then_type.is_error() && !else_type.is_error() {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
-                                expected: then_type.name().to_string(),
-                                found: else_type.name().to_string(),
+                                expected: then_type.safe_name_with_pool(Some(&self.type_pool)),
+                                found: else_type.safe_name_with_pool(Some(&self.type_pool)),
                             },
                             else_span,
                         )
-                        .with_label(format!("this is of type `{}`", then_type.name()), then_span)
+                        .with_label(
+                            format!(
+                                "this is of type `{}`",
+                                then_type.safe_name_with_pool(Some(&self.type_pool))
+                            ),
+                            then_span,
+                        )
                         .with_note("if and else branches must have compatible types"));
                     }
                     then_type
@@ -738,7 +746,7 @@ impl<'a> Sema<'a> {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
                         expected: "()".to_string(),
-                        found: then_type.name().to_string(),
+                        found: then_type.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     self.rir.get(then_block).span,
                 )
@@ -907,7 +915,9 @@ impl<'a> Sema<'a> {
         if !scrutinee_type.is_integer() && scrutinee_type != Type::BOOL && !scrutinee_type.is_enum()
         {
             return Err(CompileError::new(
-                ErrorKind::InvalidMatchType(scrutinee_type.name().to_string()),
+                ErrorKind::InvalidMatchType(
+                    scrutinee_type.safe_name_with_pool(Some(&self.type_pool)),
+                ),
                 span,
             ));
         }
@@ -976,7 +986,7 @@ impl<'a> Sema<'a> {
                     if !scrutinee_type.is_integer() {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
-                                expected: scrutinee_type.name().to_string(),
+                                expected: scrutinee_type.safe_name_with_pool(Some(&self.type_pool)),
                                 found: "integer".to_string(),
                             },
                             pattern_span,
@@ -1004,7 +1014,7 @@ impl<'a> Sema<'a> {
                     if scrutinee_type != Type::BOOL {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
-                                expected: scrutinee_type.name().to_string(),
+                                expected: scrutinee_type.safe_name_with_pool(Some(&self.type_pool)),
                                 found: "bool".to_string(),
                             },
                             pattern_span,
@@ -1058,7 +1068,7 @@ impl<'a> Sema<'a> {
                     if scrutinee_type != Type::new_enum(enum_id) {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
-                                expected: scrutinee_type.name().to_string(),
+                                expected: scrutinee_type.safe_name_with_pool(Some(&self.type_pool)),
                                 found: enum_def.name.clone(),
                             },
                             pattern_span,
@@ -1121,11 +1131,10 @@ impl<'a> Sema<'a> {
                     } else if body_type.is_never() {
                         prev
                     } else if prev != body_type && !prev.is_error() && !body_type.is_error() {
-                        return Err(CompileError::new(
-                            ErrorKind::TypeMismatch {
-                                expected: prev.name().to_string(),
-                                found: body_type.name().to_string(),
-                            },
+                        // Point at the offending arm's body, not the whole match.
+                        return Err(self.type_mismatch_error(
+                            prev,
+                            body_type,
                             self.rir.get(*body).span,
                         ));
                     } else {
@@ -1195,7 +1204,22 @@ impl<'a> Sema<'a> {
         };
 
         if !is_exhaustive {
-            return Err(CompileError::new(ErrorKind::NonExhaustiveMatch, span));
+            // Name what's missing: the enum definition is in scope here, so list
+            // the uncovered variants instead of just "not exhaustive" (RUE-133).
+            let enum_def = pattern_enum_id
+                .or_else(|| match scrutinee_type.try_kind() {
+                    Some(TypeKind::Enum(id)) => Some(id),
+                    _ => None,
+                })
+                .map(|id| self.type_pool.enum_def(id));
+            return Err(super::analysis::non_exhaustive_match_error(
+                span,
+                scrutinee_type,
+                enum_def.as_ref(),
+                |i| covered_variants.contains_key(&i),
+                bool_true_covered,
+                bool_false_covered,
+            ));
         }
 
         let final_type = result_type.unwrap_or(Type::UNIT);
@@ -1240,8 +1264,8 @@ impl<'a> Sema<'a> {
             {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
-                        expected: ctx.return_type.name().to_string(),
-                        found: inner_ty.name().to_string(),
+                        expected: ctx.return_type.safe_name_with_pool(Some(&self.type_pool)),
+                        found: inner_ty.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     span,
                 ));
@@ -1252,7 +1276,7 @@ impl<'a> Sema<'a> {
             if ctx.return_type != Type::UNIT && !ctx.return_type.is_error() {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
-                        expected: ctx.return_type.name().to_string(),
+                        expected: ctx.return_type.safe_name_with_pool(Some(&self.type_pool)),
                         found: "()".to_string(),
                     },
                     span,
@@ -1829,7 +1853,7 @@ impl<'a> Sema<'a> {
                         "consider making parameter `{}` inout: `inout {}: {}`",
                         name_str,
                         name_str,
-                        param_info.ty.name()
+                        param_info.ty.safe_name_with_pool(Some(&self.type_pool))
                     )));
                 }
                 RirParamMode::Inout => {
@@ -1983,7 +2007,7 @@ impl<'a> Sema<'a> {
                     return Err(CompileError::new(
                         ErrorKind::TypeMismatch {
                             expected: "struct type".to_string(),
-                            found: ty.name().to_string(),
+                            found: ty.safe_name_with_pool(Some(&self.type_pool)),
                         },
                         span,
                     ));
@@ -2073,7 +2097,7 @@ impl<'a> Sema<'a> {
                     return Err(CompileError::new(
                         ErrorKind::LiteralOutOfRange {
                             value: *value,
-                            ty: expected_field_type.name().to_string(),
+                            ty: expected_field_type.safe_name_with_pool(Some(&self.type_pool)),
                         },
                         field_inst.span,
                     ));
@@ -2093,8 +2117,8 @@ impl<'a> Sema<'a> {
             if field_result.ty != expected_field_type {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
-                        expected: expected_field_type.name().to_string(),
-                        found: field_result.ty.name().to_string(),
+                        expected: expected_field_type.safe_name_with_pool(Some(&self.type_pool)),
+                        found: field_result.ty.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     span,
                 )
@@ -2102,7 +2126,7 @@ impl<'a> Sema<'a> {
                     format!(
                         "field '{}' expects type {}",
                         init_name,
-                        expected_field_type.name()
+                        expected_field_type.safe_name_with_pool(Some(&self.type_pool))
                     ),
                     span,
                 ));
@@ -2309,7 +2333,7 @@ impl<'a> Sema<'a> {
             None => {
                 return Err(CompileError::new(
                     ErrorKind::FieldAccessOnNonStruct {
-                        found: base_type.name().to_string(),
+                        found: base_type.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     span,
                 ));
@@ -2588,7 +2612,7 @@ impl<'a> Sema<'a> {
                 return Err(CompileError::new(
                     ErrorKind::InternalError(format!(
                         "Array literal inferred as non-array type: {}",
-                        array_type.name()
+                        array_type.safe_name_with_pool(Some(&self.type_pool))
                     )),
                     span,
                 ));
@@ -2665,7 +2689,7 @@ impl<'a> Sema<'a> {
                     // This shouldn't happen if try_trace_place worked correctly
                     return Err(CompileError::new(
                         ErrorKind::IndexOnNonArray {
-                            found: parent_type.name().to_string(),
+                            found: parent_type.safe_name_with_pool(Some(&self.type_pool)),
                         },
                         span,
                     ));
@@ -2689,7 +2713,7 @@ impl<'a> Sema<'a> {
             if !self.is_type_copy(elem_type) {
                 return Err(CompileError::new(
                     ErrorKind::MoveOutOfIndex {
-                        element_type: elem_type.name().to_string(),
+                        element_type: elem_type.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     span,
                 )
@@ -2722,7 +2746,7 @@ impl<'a> Sema<'a> {
             None => {
                 return Err(CompileError::new(
                     ErrorKind::IndexOnNonArray {
-                        found: base_type.name().to_string(),
+                        found: base_type.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     span,
                 ));
@@ -2746,7 +2770,7 @@ impl<'a> Sema<'a> {
         if !self.is_type_copy(elem_type) {
             return Err(CompileError::new(
                 ErrorKind::MoveOutOfIndex {
-                    element_type: elem_type.name().to_string(),
+                    element_type: elem_type.safe_name_with_pool(Some(&self.type_pool)),
                 },
                 span,
             )

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -573,7 +573,8 @@ impl Type {
     /// Get a human-readable type name, safely handling anonymous structs and missing definitions.
     ///
     /// Unlike `name()`, this method can access the type pool to get actual struct/enum names
-    /// instead of returning generic placeholders like `"<struct>"`.
+    /// and array shapes (`[i32; 3]`) instead of returning generic placeholders like
+    /// `"<struct>"` or `"<array>"`.
     ///
     /// This is primarily used for error messages where we want to show meaningful type names
     /// even if the type pool lookup fails (returns safe fallback in that case).
@@ -597,6 +598,13 @@ impl Type {
                     return def.name.clone();
                 }
                 format!("<enum#{}>", enum_id.0)
+            }
+            Some(TypeKind::Array(array_id)) => {
+                if let Some(pool) = pool {
+                    let (element, len) = pool.array_def(array_id);
+                    return format!("[{}; {}]", element.safe_name_with_pool(Some(pool)), len);
+                }
+                format!("<array#{}>", array_id.0)
             }
             Some(_kind) => self.name().to_string(),
             None => format!("<invalid type encoding: {:#x}>", self.0),

--- a/crates/rue-ui-tests/cases/diagnostics/error-spans.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/error-spans.toml
@@ -21,9 +21,10 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-# With HM inference, the error now points to the scrutinee literal that
-# can't be the type inferred from the pattern
-error_contains = "2:11"
+# Points at the offending `true` pattern: the integer-literal scrutinee can
+# never have type bool, and the error should blame the pattern that demanded
+# it, not the scrutinee (RUE-133).
+error_contains = ["3:9", "expected integer type, found bool"]
 
 [[case]]
 name = "pattern_type_mismatch_bool_vs_int"

--- a/crates/rue-ui-tests/cases/diagnostics/match_diagnostics.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/match_diagnostics.toml
@@ -1,0 +1,109 @@
+[section]
+id = "diagnostics.match"
+name = "Match diagnostics quality"
+description = """
+Match-related errors must point at the offending arm (not the whole
+function) and non-exhaustive matches must name what is missing (RUE-133).
+"""
+
+[[case]]
+name = "arm_result_conflict_points_at_arm"
+description = """
+The arm result-type conflict between the integer arm and the bool arm used to
+surface at the body-to-return-type constraint, whose span is the WHOLE
+function body. It must point at the offending arm. The source-snippet line in
+stderr proves the span: the arm's line is quoted, the `fn main` line is not
+quoted as the primary span (a multi-line span starting at the fn body renders
+'fn main() -> i32 {' with an underline marker).
+"""
+source = """
+enum Color { Red, Blue }
+fn main() -> i32 {
+    let c = Color::Red;
+    match c {
+        Color::Red => 1,
+        Color::Blue => true,
+    }
+}
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["expected integer type, found bool", "6:24", "Color::Blue => true"]
+
+[[case]]
+name = "arm_result_conflict_concrete_arms_points_at_arm"
+source = """
+enum Color { Red, Blue }
+fn main() -> i32 {
+    let c = Color::Red;
+    let n: i32 = 5;
+    let r = match c {
+        Color::Red => n,
+        Color::Blue => true,
+    };
+    0
+}
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["expected i32, found bool", "7:24"]
+
+[[case]]
+name = "non_exhaustive_enum_lists_missing_variants"
+description = "E0600 must name the uncovered variants, which are known at the error site."
+source = """
+enum Color { Red, Blue, Green }
+fn main() -> i32 {
+    let c = Color::Red;
+    match c {
+        Color::Red => 1,
+    }
+}
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["match is not exhaustive", "missing variants: Blue, Green"]
+
+[[case]]
+name = "non_exhaustive_bool_names_missing_pattern"
+source = """
+fn main() -> i32 {
+    let b = true;
+    match b {
+        true => 1,
+    }
+}
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["match is not exhaustive", "pattern `false` is not covered"]
+
+[[case]]
+name = "non_exhaustive_integer_suggests_wildcard"
+source = """
+fn main() -> i32 {
+    let n: i32 = 1;
+    match n {
+        1 => 1,
+        2 => 2,
+    }
+}
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["match is not exhaustive", "wildcard arm"]
+
+[[case]]
+name = "exhaustive_enum_match_still_compiles"
+source = """
+enum Color { Red, Blue }
+fn main() -> i32 {
+    let c = Color::Blue;
+    match c {
+        Color::Red => 1,
+        Color::Blue => 42,
+    }
+}
+"""
+exit_code = 42
+no_warnings = true

--- a/crates/rue-ui-tests/cases/diagnostics/type_mismatch_direction.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/type_mismatch_direction.toml
@@ -33,3 +33,25 @@ fn main() -> i32 { f(true) }
 exit_code = 1
 compile_fail = true
 error_contains = ["expected i32, found bool"]
+
+# The array-vs-non-array unification path kept the swapped order after the
+# general fix landed: `fn main() -> i32 { [1, 2, 3] }` printed
+# "expected [?0; 3], found i32" (RUE-133).
+[[case]]
+name = "array_return_mismatch_direction"
+source = """
+fn main() -> i32 { [1, 2, 3] }
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["expected i32, found [{integer}; 3]"]
+
+[[case]]
+name = "scalar_for_array_return_mismatch_direction"
+source = """
+fn f() -> [i32; 3] { true }
+fn main() -> i32 { 0 }
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["expected [i32; 3], found bool"]

--- a/crates/rue-ui-tests/cases/diagnostics/type_names.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/type_names.toml
@@ -1,0 +1,80 @@
+[section]
+id = "diagnostics.type_names"
+name = "Real type names in diagnostics"
+description = """
+Type errors must render the user's struct/enum names, not internal
+placeholders like '<struct>' and '<enum>' (RUE-133). The names are resolved
+through the type pool at every diagnostic site.
+"""
+
+[[case]]
+name = "enum_return_mismatch_names_both_enums"
+description = "Used to print 'expected <enum>, found <enum>'."
+source = """
+enum Color { Red, Blue }
+enum Shape { Circle, Square }
+fn f() -> Color { Shape::Circle }
+fn main() -> i32 { 0 }
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["expected Color, found Shape"]
+
+[[case]]
+name = "struct_return_mismatch_names_struct"
+description = "Used to print 'expected i32, found <struct>'."
+source = """
+struct Point { x: i32, y: i32 }
+fn f() -> i32 { Point { x: 1, y: 2 } }
+fn main() -> i32 { 0 }
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["expected i32, found Point"]
+
+[[case]]
+name = "generic_arg_mismatch_names_both_structs"
+description = """
+Wrong struct passed for a generic type argument used to print
+'expected <struct>, found <struct>'.
+"""
+source = """
+struct A { x: i32 }
+struct B { y: i32 }
+fn id(comptime T: type, v: T) -> T { v }
+fn main() -> i32 {
+    let b = B { y: 1 };
+    let a = id(A, b);
+    0
+}
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["expected A, found B"]
+
+[[case]]
+name = "match_on_struct_names_struct"
+description = "E0602 used to print \"cannot match on type '<struct>'\"."
+source = """
+struct P { x: i32 }
+fn main() -> i32 {
+    let p = P { x: 1 };
+    match p {
+        _ => 0,
+    }
+}
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["cannot match on type 'P'"]
+
+[[case]]
+name = "array_literal_for_scalar_names_array_shape"
+description = "Used to print the '<array>' placeholder."
+source = """
+fn f() -> [i32; 3] { 5 }
+fn main() -> i32 { 0 }
+"""
+exit_code = 1
+compile_fail = true
+error_contains = ["[i32; 3]"]


### PR DESCRIPTION
Four citizen-quality items from the diagnostics epic, now more visible
since generics started type-checking aggregates:

- Type names (item 2): unify-error conversion and the sema error paths now
  render named types via the type pool — "expected B, found A" instead of
  "expected <struct>, found <struct>", "cannot match on type 'P'" instead
  of '<struct>', with array types rendered structurally and integer-
  literal inference vars as "{integer}". The dead-but-correct
  type_mismatch_error helper is finally wired (the dead-code theme again).
- Direction (item 1): the general expected/found swap was fixed earlier;
  the one remaining reversed arm was Array-vs-non-array in the unifier —
  fn main() -> i32 { [1,2,3] } now reports "expected i32, found
  [{integer}; 3]" instead of the reverse.
- Arm spans (item 3): a match arm whose result conflicts with the other
  arms was reported against the WHOLE FUNCTION because an integer-literal
  arm's unbound type var silently absorbed the conflicting arm; the
  unifier now tracks int-literal vars through var chains and rejects
  non-integer binds at the offending constraint — the error points at the
  arm. One existing UI case had pinned the old whole-scrutinee span as a
  documented regression; it now asserts the section's stated intent.
- E0600 (item 4): non-exhaustive match errors name what's missing via one
  shared helper used by BOTH match analyzers ("missing variants: Green,
  Blue"; "pattern `false` is not covered"; wildcard suggestion for
  integers).

Thirteen new UI cases across type_names, type_mismatch_direction, and
match_diagnostics; full-string assertions where stable. Known limitation
recorded in the epic: fn f() -> [i32; 3] { 5 } still reports E0800 rather
than a mismatch (though it now names the array type). Full test.sh green.

Part of RUE-133 (items 1-4; remaining: 8-10 and the pre-existing silent
unknown-directive acceptance).



🤖 Generated with [Claude Code](https://claude.com/claude-code)
