### PR TITLE
Mach-O linker: grow __TEXT with code size; fix bss symbol addresses; reject malformed relocations

### DIFF
--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -143,6 +143,10 @@ pub struct ObjectFile {
     pub symbols: Vec<Symbol>,
     /// Section name to index mapping.
     pub section_map: HashMap<String, usize>,
+    /// The machine architecture this object was compiled for. The linker
+    /// validates this against the link target — without it, an "aarch64"
+    /// binary could silently embed x86 code (RUE-131 item 10, RUE-36).
+    pub machine: ElfMachine,
 }
 
 /// A section from an object file.
@@ -732,6 +736,8 @@ impl ObjectFile {
             sections,
             symbols,
             section_map,
+            // The Mach-O parser only accepts CPU_TYPE_ARM64 objects.
+            machine: ElfMachine::Aarch64,
         })
     }
 
@@ -1102,6 +1108,7 @@ impl ObjectFile {
             sections,
             symbols,
             section_map,
+            machine,
         })
     }
 

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -697,7 +697,16 @@ impl ObjectFile {
                 } else {
                     // Local/section relocation: r_symbolnum is 1-indexed section number
                     // Find the function symbol for this section (should be at offset 0)
-                    let target_section = (r_symbolnum - 1) as usize;
+                    // r_symbolnum == 0 is invalid for a non-extern relocation;
+                    // the subtraction used to wrap to usize::MAX and index OOB
+                    // (a panic on malformed input). (RUE-131 item 6)
+                    let Some(section_number) = r_symbolnum.checked_sub(1) else {
+                        return Err(ParseError::InvalidSymbol(format!(
+                            "non-extern relocation at 0x{:x} has r_symbolnum 0",
+                            r_address
+                        )));
+                    };
+                    let target_section = section_number as usize;
                     let idx = symbols
                         .iter()
                         .position(|s| {

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -616,8 +616,12 @@ impl Linker {
 
         // Calculate offsets within data segment (data, then bss)
         let data_offset_in_data = 0u64;
+        // bss begins right after the (8-aligned) initialized data within the
+        // __DATA segment. The old formula also added bss_offset_in_data —
+        // which IS merged_data.len() — double-counting the data length, so
+        // every bss symbol pointed past its real storage. (RUE-131 item 4)
         let bss_vaddr = if bss_size > 0 {
-            data_vaddr + align_up(merged_data.len() as u64, 8) + bss_offset_in_data
+            data_vaddr + align_up(merged_data.len() as u64, 8)
         } else {
             0
         };

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -104,6 +104,11 @@ pub enum LinkError {
     UndefinedSymbol(String),
     /// Duplicate symbol definition.
     DuplicateSymbol(String),
+    /// Object architecture doesn't match the link target.
+    ArchMismatch {
+        object_machine: String,
+        target: String,
+    },
     /// Unsupported relocation type.
     UnsupportedRelocation(String),
     /// Relocation overflow (value doesn't fit).
@@ -135,6 +140,14 @@ impl std::fmt::Display for LinkError {
         match self {
             LinkError::UndefinedSymbol(s) => write!(f, "undefined symbol: {}", s),
             LinkError::DuplicateSymbol(s) => write!(f, "duplicate symbol: {}", s),
+            LinkError::ArchMismatch {
+                object_machine,
+                target,
+            } => write!(
+                f,
+                "object architecture mismatch: object is {}, link target is {}",
+                object_machine, target
+            ),
             LinkError::UnsupportedRelocation(s) => write!(f, "unsupported relocation: {}", s),
             LinkError::RelocationOverflow { symbol, rel_type } => {
                 write!(f, "relocation overflow for {} ({})", symbol, rel_type)
@@ -224,6 +237,21 @@ impl Linker {
 
     /// Add an object file to be linked.
     pub fn add_object(&mut self, obj: ObjectFile) -> Result<(), LinkError> {
+        // Refuse objects compiled for a different architecture — without this
+        // check an "aarch64" binary could silently embed x86 machine code
+        // (confirmed during the linker review: 22 x86 syscalls linked into an
+        // aarch64 output without complaint). (RUE-131 item 10, RUE-36)
+        let expected = match self.target {
+            Target::X86_64Linux => crate::elf::ElfMachine::X86_64,
+            Target::Aarch64Linux | Target::Aarch64Macos => crate::elf::ElfMachine::Aarch64,
+        };
+        if obj.machine != expected {
+            return Err(LinkError::ArchMismatch {
+                object_machine: format!("{:?}", obj.machine),
+                target: format!("{:?}", self.target),
+            });
+        }
+
         let obj_index = self.objects.len();
 
         // Collect global symbols
@@ -233,13 +261,17 @@ impl Linker {
                 && !sym.name.is_empty()
             {
                 if let Some((_, existing)) = self.global_symbols.get(&sym.name) {
-                    // Allow weak symbols to be overridden
+                    // Two strong definitions collide; weak symbols defer.
                     if existing.binding != SymbolBinding::Weak && sym.binding != SymbolBinding::Weak
                     {
                         return Err(LinkError::DuplicateSymbol(sym.name.clone()));
                     }
-                    // Keep the non-weak one
-                    if existing.binding == SymbolBinding::Weak {
+                    // A strong definition overrides a weak one. Among weak
+                    // definitions the FIRST wins (standard linker semantics;
+                    // this used to keep the last). (RUE-131 item 9)
+                    if existing.binding == SymbolBinding::Weak
+                        && sym.binding == SymbolBinding::Global
+                    {
                         self.global_symbols
                             .insert(sym.name.clone(), (obj_index, sym.clone()));
                     }
@@ -1152,6 +1184,14 @@ impl Linker {
                         sym_name, sec_idx
                     )));
                 }
+            } else if self.objects[obj_idx]
+                .find_symbol(&sym_name)
+                .is_some_and(|s| s.binding == SymbolBinding::Weak)
+            {
+                // An undefined WEAK symbol resolves to address 0 rather than
+                // erroring — standard ELF semantics, lets code do null checks
+                // against optional symbols. (RUE-131 item 9)
+                0
             } else {
                 return Err(LinkError::UndefinedSymbol(format!(
                     "{} (no section, rel_type={:?})",
@@ -1888,6 +1928,7 @@ mod tests {
             sections: vec![text, extra],
             symbols,
             section_map,
+            machine: crate::elf::ElfMachine::X86_64,
         }
     }
 
@@ -1958,6 +1999,149 @@ mod tests {
             slot, main_vaddr,
             "Abs64 relocation in .data must be applied (was silently dropped)"
         );
+    }
+
+    /// RUE-131 item 9: among multiple WEAK definitions, the first wins; a
+    /// strong definition overrides a weak one in either order.
+    #[test]
+    fn test_weak_symbol_first_wins_strong_overrides() {
+        use crate::elf::{Relocation, Section, SymbolType};
+        let make_obj = |name: &str, code: Vec<u8>, binding: SymbolBinding| ObjectFile {
+            sections: vec![Section {
+                name: ".text".into(),
+                data: code,
+                size: 1,
+                flags: SectionFlags::ALLOC | SectionFlags::EXEC,
+                relocations: vec![],
+                align: 16,
+            }],
+            symbols: vec![Symbol {
+                name: name.into(),
+                section_index: Some(0),
+                value: 0,
+                size: 1,
+                binding,
+                sym_type: SymbolType::Func,
+            }],
+            section_map: HashMap::from([(".text".into(), 0)]),
+            machine: crate::elf::ElfMachine::X86_64,
+        };
+        let _ = Relocation {
+            offset: 0,
+            symbol_index: 0,
+            rel_type: RelocationType::Abs64,
+            addend: 0,
+        };
+
+        // weak then weak: first wins
+        let mut linker = Linker::new(ELF_TARGET);
+        linker
+            .add_object(make_obj("f", vec![0xC3], SymbolBinding::Weak))
+            .unwrap();
+        linker
+            .add_object(make_obj("f", vec![0x90], SymbolBinding::Weak))
+            .unwrap();
+        let (obj_idx, _) = linker.global_symbols.get("f").unwrap();
+        assert_eq!(*obj_idx, 0, "first weak definition must win");
+
+        // weak then strong: strong overrides
+        let mut linker = Linker::new(ELF_TARGET);
+        linker
+            .add_object(make_obj("f", vec![0xC3], SymbolBinding::Weak))
+            .unwrap();
+        linker
+            .add_object(make_obj("f", vec![0x90], SymbolBinding::Global))
+            .unwrap();
+        let (obj_idx, sym) = linker.global_symbols.get("f").unwrap();
+        assert_eq!(*obj_idx, 1, "strong definition must override weak");
+        assert_eq!(sym.binding, SymbolBinding::Global);
+
+        // strong then weak: strong kept
+        let mut linker = Linker::new(ELF_TARGET);
+        linker
+            .add_object(make_obj("f", vec![0xC3], SymbolBinding::Global))
+            .unwrap();
+        linker
+            .add_object(make_obj("f", vec![0x90], SymbolBinding::Weak))
+            .unwrap();
+        let (obj_idx, _) = linker.global_symbols.get("f").unwrap();
+        assert_eq!(
+            *obj_idx, 0,
+            "strong definition must be kept over later weak"
+        );
+    }
+
+    /// RUE-131 item 9: a relocation against an UNDEFINED weak symbol resolves
+    /// to address 0 instead of an undefined-symbol error.
+    #[test]
+    fn test_undefined_weak_resolves_to_zero() {
+        use crate::elf::{Relocation, Section, SymbolType};
+        let obj = ObjectFile {
+            sections: vec![Section {
+                name: ".text".into(),
+                // mov rax, imm64 (placeholder patched by Abs64); ret
+                data: vec![0x48, 0xB8, 0, 0, 0, 0, 0, 0, 0, 0, 0xC3],
+                size: 11,
+                flags: SectionFlags::ALLOC | SectionFlags::EXEC,
+                relocations: vec![Relocation {
+                    offset: 2,
+                    symbol_index: 1,
+                    rel_type: RelocationType::Abs64,
+                    addend: 0,
+                }],
+                align: 16,
+            }],
+            symbols: vec![
+                Symbol {
+                    name: "main".into(),
+                    section_index: Some(0),
+                    value: 0,
+                    size: 11,
+                    binding: SymbolBinding::Global,
+                    sym_type: SymbolType::Func,
+                },
+                Symbol {
+                    name: "optional_hook".into(),
+                    section_index: None, // undefined
+                    value: 0,
+                    size: 0,
+                    binding: SymbolBinding::Weak,
+                    sym_type: SymbolType::None,
+                },
+            ],
+            section_map: HashMap::from([(".text".into(), 0)]),
+            machine: crate::elf::ElfMachine::X86_64,
+        };
+
+        let mut linker = Linker::new(ELF_TARGET);
+        linker.add_object(obj).unwrap();
+        let elf = linker.link("main").unwrap();
+
+        // The link must not error, and the mov's imm64 (the bytes following
+        // the 0x48 0xB8 opcode in the output) must be 0 — the weak resolution.
+        let opcode_pos = elf
+            .windows(2)
+            .position(|w| w == [0x48, 0xB8])
+            .expect("mov rax, imm64 opcode present in linked output");
+        let imm = u64::from_le_bytes(elf[opcode_pos + 2..opcode_pos + 10].try_into().unwrap());
+        assert_eq!(imm, 0, "undefined weak symbol must resolve to address 0");
+    }
+
+    /// RUE-131 item 10: an object compiled for a different architecture must
+    /// be refused — before this check, an "aarch64" output could silently
+    /// embed x86 machine code.
+    #[test]
+    fn test_arch_mismatch_rejected() {
+        let obj_bytes = ObjectBuilder::new(ELF_TARGET, "main")
+            .code(vec![0xC3])
+            .build();
+        let mut obj = ObjectFile::parse(&obj_bytes).unwrap();
+        // Simulate an object built for the other architecture.
+        obj.machine = crate::elf::ElfMachine::Aarch64;
+
+        let mut linker = Linker::new(ELF_TARGET);
+        let result = linker.add_object(obj);
+        assert!(matches!(result, Err(LinkError::ArchMismatch { .. })));
     }
 
     #[test]
@@ -2288,6 +2472,7 @@ mod tests {
             sections: vec![text_section],
             symbols: vec![null_symbol, bad_symbol, main_symbol],
             section_map: HashMap::from([(".text".into(), 0)]),
+            machine: crate::elf::ElfMachine::X86_64,
         };
 
         let mut linker = Linker::new(ELF_TARGET);
@@ -2360,6 +2545,7 @@ mod tests {
             sections: vec![text_section],
             symbols: vec![null_symbol, main_symbol], // Only 2 symbols, but relocation references index 999
             section_map: HashMap::from([(".text".into(), 0)]),
+            machine: crate::elf::ElfMachine::X86_64,
         };
 
         let mut linker = Linker::new(ELF_TARGET);
@@ -3267,6 +3453,7 @@ mod tests {
             sections: vec![text_section],
             symbols: vec![main_symbol],
             section_map: [("__text".to_string(), 0)].into_iter().collect(),
+            machine: crate::elf::ElfMachine::Aarch64,
         };
 
         let mut linker = Linker::new(Target::Aarch64Macos);
@@ -3325,6 +3512,7 @@ mod tests {
             sections: vec![text_section],
             symbols: vec![main_symbol],
             section_map: [("__text".to_string(), 0)].into_iter().collect(),
+            machine: crate::elf::ElfMachine::Aarch64,
         };
 
         let mut linker = Linker::new(Target::Aarch64Macos);
@@ -3363,6 +3551,7 @@ mod tests {
             sections: vec![text_section],
             symbols: vec![other_symbol],
             section_map: [("__text".to_string(), 0)].into_iter().collect(),
+            machine: crate::elf::ElfMachine::Aarch64,
         };
 
         let mut linker = Linker::new(Target::Aarch64Macos);

--- a/crates/rue-linker/src/macho.rs
+++ b/crates/rue-linker/src/macho.rs
@@ -30,6 +30,21 @@ pub const PAGE_SIZE: u64 = 0x4000;
 /// Default VM base address for executables.
 pub const VM_BASE: u64 = 0x100000000;
 
+/// Computed file/VM layout for a dynamic executable — produced only by
+/// `compute_dynamic_layout` so relocation pre-pass and the actual build can
+/// never disagree.
+struct DynamicLayout {
+    text_file_offset: usize,
+    text_segment_file_size: usize,
+    has_data: bool,
+    data_file_offset: usize,
+    data_vm_addr: u64,
+    data_file_size: usize,
+    data_vm_size: u64,
+    linkedit_file_offset: usize,
+    linkedit_vm_addr: u64,
+}
+
 // =============================================================================
 // Load Command Trait
 // =============================================================================
@@ -728,21 +743,29 @@ impl MachOBuilder {
         buf
     }
 
-    /// Calculate the text file offset for a dynamic executable without building it.
+    /// The complete dynamic-executable layout, computed in ONE place.
     ///
-    /// This is needed to apply relocations before calling build_dynamic().
-    /// The calculation matches what build_dynamic() will produce.
-    pub fn calculate_text_file_offset_for_dynamic(&self) -> u64 {
+    /// `calculate_text_file_offset_for_dynamic` and `build_dynamic` used to
+    /// compute this independently and had drifted: the precompute counted ONE
+    /// data section where the builder counts up to three (__const, __data,
+    /// __bss), so with more than one data section every relocation was
+    /// patched against a text offset the binary didn't actually use.
+    /// (RUE-131; the drift is the same dual-implementation disease tracked
+    /// across the codebase.)
+    fn compute_dynamic_layout(&self) -> DynamicLayout {
         let has_data = !self.rodata.is_empty() || !self.data.is_empty() || self.bss_size > 0;
 
-        // Calculate initial load commands size (existing segments + dyld commands)
+        // Segment header + up to 3 sections (__const, __data, __bss)
         let data_segment_cmd_size = if has_data {
-            MACHO64_SEGMENT_CMD_SIZE + MACHO64_SECTION_SIZE
+            let num_sections = (!self.rodata.is_empty() as usize)
+                + (!self.data.is_empty() as usize)
+                + ((self.bss_size > 0) as usize);
+            MACHO64_SEGMENT_CMD_SIZE + MACHO64_SECTION_SIZE * num_sections
         } else {
             0
         };
 
-        let initial_cmd_size: usize = self
+        let existing_cmd_size: usize = self
             .segments
             .iter()
             .map(|s| s.cmdsize() as usize)
@@ -751,26 +774,91 @@ impl MachOBuilder {
                 .commands
                 .iter()
                 .map(|c: &Box<dyn LoadCommand>| c.cmdsize() as usize)
-                .sum::<usize>()
-            + data_segment_cmd_size;
+                .sum::<usize>();
 
-        // We'll add symtab, dysymtab, entry point, dylinker, and dylib
-        // LC_LOAD_DYLINKER for "/usr/lib/dyld" is 32 bytes
-        // LC_LOAD_DYLIB for "/usr/lib/libSystem.B.dylib" is 56 bytes
-        let dylinker_size = LoadDylinker::new().cmdsize() as usize;
-        let dylib_size = LoadDylib::libsystem().cmdsize() as usize;
-        let remaining_cmd_size = MACHO64_SYMTAB_CMD_SIZE
+        // build_dynamic adds a __LINKEDIT segment when one isn't present, so
+        // its header must be counted whether or not the caller pre-added it
+        // (the relocation pre-pass does, build_dynamic's own builder doesn't —
+        // counting it conditionally keeps the two layouts identical).
+        let linkedit_cmd_size = if self
+            .segments
+            .iter()
+            .any(|s| &s.segname[..10] == b"__LINKEDIT")
+        {
+            0
+        } else {
+            MACHO64_SEGMENT_CMD_SIZE
+        };
+
+        // Commands added during build: dylinker, dylib, symtab, dysymtab, entry
+        let added_cmd_size = LoadDylinker::new().cmdsize() as usize
+            + LoadDylib::libsystem().cmdsize() as usize
+            + MACHO64_SYMTAB_CMD_SIZE
             + MACHO64_DYSYMTAB_CMD_SIZE
-            + MACHO64_ENTRY_POINT_CMD_SIZE
-            + dylinker_size
-            + dylib_size;
+            + MACHO64_ENTRY_POINT_CMD_SIZE;
 
-        let load_commands_size = initial_cmd_size + remaining_cmd_size;
-        let header_size = MACHO64_HEADER_SIZE + load_commands_size;
+        let header_size = MACHO64_HEADER_SIZE
+            + existing_cmd_size
+            + linkedit_cmd_size
+            + added_cmd_size
+            + data_segment_cmd_size;
 
         // Leave extra padding for codesign to add LC_CODE_SIGNATURE
         let codesign_padding = 256;
-        align_up((header_size + codesign_padding) as u64, 16)
+        let text_file_offset = align_up((header_size + codesign_padding) as u64, 16) as usize;
+
+        // __TEXT spans file offset 0 through the first page boundary AFTER the
+        // code ends. It was hardcoded to exactly one page, so any program
+        // whose headers+code exceeded 16KB had its code spill past the
+        // declared segment — the data segment then overlapped it in the file
+        // and dyld mapped garbage. (RUE-131 item 3)
+        let text_segment_file_size =
+            align_up((text_file_offset + self.code.len()) as u64, PAGE_SIZE) as usize;
+
+        let (data_file_offset, data_vm_addr, data_file_size, data_vm_size) = if has_data {
+            // Data segment starts at the next page after __TEXT
+            let offset = text_segment_file_size;
+            let vm_addr = VM_BASE + offset as u64;
+            // File size: rodata + data (not bss)
+            let file_size =
+                align_up(self.rodata.len() as u64, 8) + align_up(self.data.len() as u64, 8);
+            // VM size includes bss
+            let vm_size = align_up(file_size + self.bss_size, PAGE_SIZE);
+            (offset, vm_addr, file_size as usize, vm_size)
+        } else {
+            (0, 0, 0, 0)
+        };
+
+        let linkedit_file_offset = if has_data {
+            align_up((data_file_offset + data_file_size) as u64, PAGE_SIZE) as usize
+        } else {
+            text_segment_file_size
+        };
+        let linkedit_vm_addr = if has_data {
+            data_vm_addr + data_vm_size
+        } else {
+            VM_BASE + text_segment_file_size as u64
+        };
+
+        DynamicLayout {
+            text_file_offset,
+            text_segment_file_size,
+            has_data,
+            data_file_offset,
+            data_vm_addr,
+            data_file_size,
+            data_vm_size,
+            linkedit_file_offset,
+            linkedit_vm_addr,
+        }
+    }
+
+    /// Calculate the text file offset for a dynamic executable without building it.
+    ///
+    /// This is needed to apply relocations before calling build_dynamic().
+    /// Delegates to the single shared layout computation.
+    pub fn calculate_text_file_offset_for_dynamic(&self) -> u64 {
+        self.compute_dynamic_layout().text_file_offset as u64
     }
 
     /// Build a dynamic executable (using LC_MAIN + dyld).
@@ -795,7 +883,19 @@ impl MachOBuilder {
         // - __DATA: after __TEXT, contains rodata/data/bss (if any)
         // - __LINKEDIT: after __DATA (or __TEXT), contains symbol tables
 
-        let has_data = !self.rodata.is_empty() || !self.data.is_empty() || self.bss_size > 0;
+        // Single source of truth for the layout — the same computation the
+        // relocation pre-pass used (see compute_dynamic_layout).
+        let DynamicLayout {
+            text_file_offset,
+            text_segment_file_size,
+            has_data,
+            data_file_offset,
+            data_vm_addr,
+            data_file_size,
+            data_vm_size,
+            linkedit_file_offset,
+            linkedit_vm_addr,
+        } = self.compute_dynamic_layout();
 
         // Add __LINKEDIT segment if not present
         let has_linkedit = self
@@ -807,78 +907,10 @@ impl MachOBuilder {
             self.segments.push(linkedit);
         }
 
-        // Add dyld and libSystem
+        // Add dyld and libSystem (their sizes are already accounted for in
+        // the layout's added-command size)
         self.add_command(LoadDylinker::new());
         self.add_command(LoadDylib::libsystem());
-
-        // We need to calculate load commands size accounting for __DATA segment
-        // that we'll add if there's data
-        let data_segment_cmd_size = if has_data {
-            // Segment header + up to 3 sections (const, data, bss)
-            let num_sections = (!self.rodata.is_empty() as usize)
-                + (!self.data.is_empty() as usize)
-                + ((self.bss_size > 0) as usize);
-            MACHO64_SEGMENT_CMD_SIZE + MACHO64_SECTION_SIZE * num_sections
-        } else {
-            0
-        };
-
-        // Calculate load commands size (before adding remaining commands)
-        let initial_cmd_size: usize = self
-            .segments
-            .iter()
-            .map(|s| s.cmdsize() as usize)
-            .sum::<usize>()
-            + self
-                .commands
-                .iter()
-                .map(|c| c.cmdsize() as usize)
-                .sum::<usize>()
-            + data_segment_cmd_size;
-
-        // We'll add symtab, dysymtab, and entry point
-        let remaining_cmd_size =
-            MACHO64_SYMTAB_CMD_SIZE + MACHO64_DYSYMTAB_CMD_SIZE + MACHO64_ENTRY_POINT_CMD_SIZE;
-
-        let load_commands_size = initial_cmd_size + remaining_cmd_size;
-        let header_size = MACHO64_HEADER_SIZE + load_commands_size;
-
-        // Leave extra padding for codesign to add LC_CODE_SIGNATURE
-        let codesign_padding = 256;
-        let text_file_offset = align_up((header_size + codesign_padding) as u64, 16) as usize;
-
-        // __TEXT segment spans from file offset 0 to the first page boundary after code
-        let text_segment_file_size = PAGE_SIZE as usize;
-
-        // Calculate data segment layout (if needed)
-        let (data_file_offset, data_vm_addr, data_file_size, data_vm_size) = if has_data {
-            // Data segment starts at the next page after __TEXT
-            let offset = text_segment_file_size;
-            let vm_addr = VM_BASE + offset as u64;
-
-            // Calculate file size (rodata + data, but not bss)
-            let file_size =
-                align_up(self.rodata.len() as u64, 8) + align_up(self.data.len() as u64, 8);
-            // VM size includes bss
-            let vm_size = align_up(file_size + self.bss_size, PAGE_SIZE);
-
-            (offset, vm_addr, file_size as usize, vm_size)
-        } else {
-            (0, 0, 0, 0)
-        };
-
-        // __LINKEDIT comes after __DATA (or __TEXT if no data)
-        let linkedit_file_offset = if has_data {
-            align_up((data_file_offset + data_file_size) as u64, PAGE_SIZE) as usize
-        } else {
-            text_segment_file_size
-        };
-        // LINKEDIT's VM address must come after DATA's VM region (including bss)
-        let linkedit_vm_addr = if has_data {
-            data_vm_addr + data_vm_size
-        } else {
-            VM_BASE + text_segment_file_size as u64
-        };
         // Minimal LINKEDIT content: just a string table with null byte
         let linkedit_file_size = 16usize;
         let linkedit_vm_size = PAGE_SIZE;
@@ -1107,6 +1139,87 @@ fn align_up(value: u64, align: u64) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Mirrors link_macho's real usage: the relocation pre-pass builder has
+    /// __LINKEDIT manually added, the build builder doesn't (build_dynamic
+    /// adds it itself). The pre-computed text offset must equal the offset
+    /// the built binary actually uses — the macOS CI failure on the first
+    /// version of this refactor was exactly this asymmetry (strings printed
+    /// garbage because every relocation was patched for a different offset
+    /// than the binary's layout).
+    #[test]
+    fn test_precompute_matches_build_without_manual_linkedit() {
+        let make = |code: Vec<u8>| {
+            let mut b = MachOBuilder::new()
+                .with_code(code, 0)
+                .with_data(vec![7; 24])
+                .with_bss(16);
+            b.add_segment(Segment64::pagezero());
+            let mut text = Segment64::new("__TEXT").with_protection(VM_PROT_READ | VM_PROT_EXECUTE);
+            text.add_section(Section64::new("__text", "__TEXT").with_code_flags());
+            b.add_segment(text);
+            b
+        };
+
+        // Pre-pass shape: empty code, manual __LINKEDIT (as link_macho does)
+        let mut prepass = make(vec![]);
+        prepass.add_segment(Segment64::new("__LINKEDIT").with_protection(VM_PROT_READ));
+        let precomputed = prepass.calculate_text_file_offset_for_dynamic();
+
+        // Build shape: real code, NO manual __LINKEDIT
+        let build = make(vec![0xC3; 32]);
+        let (_bytes, built_offset, _data_vm) = build.build_dynamic();
+
+        assert_eq!(
+            precomputed, built_offset,
+            "relocation pre-pass and build_dynamic must agree on the text offset"
+        );
+    }
+
+    /// RUE-131 item 3: __TEXT was hardcoded to exactly one page; code larger
+    /// than (one page - headers) spilled past the declared segment and the
+    /// data segment overlapped it in the file.
+    #[test]
+    fn test_text_segment_grows_with_code() {
+        let big_code = vec![0x90u8; (PAGE_SIZE as usize) * 2]; // 2 pages of NOPs
+        let builder = MachOBuilder::new()
+            .with_code(big_code.clone(), 0)
+            .with_data(vec![1, 2, 3, 4, 5, 6, 7, 8]);
+        let layout = builder.compute_dynamic_layout();
+
+        assert!(
+            layout.text_segment_file_size >= layout.text_file_offset + big_code.len(),
+            "__TEXT ({} bytes) must contain headers ({}) + code ({})",
+            layout.text_segment_file_size,
+            layout.text_file_offset,
+            big_code.len()
+        );
+        assert_eq!(
+            layout.text_segment_file_size % PAGE_SIZE as usize,
+            0,
+            "__TEXT file size must be page-aligned"
+        );
+        assert_eq!(
+            layout.data_file_offset, layout.text_segment_file_size,
+            "__DATA must start where __TEXT ends — no overlap"
+        );
+    }
+
+    /// RUE-131: the relocation pre-pass and the builder used to compute the
+    /// text offset independently and drifted (the pre-pass counted one data
+    /// section; the builder counts up to three). With rodata + data + bss all
+    /// present, the two must agree exactly.
+    #[test]
+    fn test_precompute_matches_layout_with_all_data_sections() {
+        let builder = MachOBuilder::new()
+            .with_code(vec![0xC3], 0)
+            .with_rodata(vec![1; 16])
+            .with_data(vec![2; 16])
+            .with_bss(32);
+        let precomputed = builder.calculate_text_file_offset_for_dynamic();
+        let layout = builder.compute_dynamic_layout();
+        assert_eq!(precomputed, layout.text_file_offset as u64);
+    }
 
     #[test]
     fn test_load_dylinker_size() {


### PR DESCRIPTION
Three Mach-O items from the linker epic, plus a fourth bug found while
fixing them:

__TEXT sizing (item 3): the segment's file size was hardcoded to exactly
one 16KB page. Any program whose headers + code exceeded that had its code
spill past the declared segment — the data segment then overlapped it in
the file and dyld mapped garbage. The segment now grows to the page
boundary after the code ends, and __DATA starts where __TEXT actually
ends.

Layout drift (found during item 3): the relocation pre-pass
(calculate_text_file_offset_for_dynamic) and build_dynamic computed the
layout INDEPENDENTLY and had drifted — the pre-pass counted one data
section where the builder counts up to three (__const/__data/__bss), so
with more than one data section every relocation was patched against a
text offset the binary didn't use. Both now consume one
compute_dynamic_layout, and a test pins their equality with all three
sections present. (The dual-implementation disease, linker edition.)

bss addresses (item 4): link_macho computed bss symbol vaddrs as
data_vaddr + aligned data length + bss_offset_in_data — but
bss_offset_in_data IS the data length, so every bss symbol pointed one
data-length past its storage. The double-count is removed.

Malformed relocations (item 6): a non-extern relocation with
r_symbolnum == 0 underflowed (r_symbolnum - 1) and indexed out of bounds —
a parser panic on malformed input. Now a clean ParseError.

The first push of this change FAILED macOS CI with garbage string
output — its own medicine: the unified computation ran before
build_dynamic pushed __LINKEDIT, while the pre-pass builder had it
pre-added, so the two disagreed by one segment header and every
relocation was patched for an offset the binary didn't use. The shared
computation now counts __LINKEDIT conditionally (present-or-added), and a
regression test mirrors the linker's exact asymmetric usage: pre-pass
builder with manual __LINKEDIT versus build builder without, asserting
the offsets agree.

Three new layout tests (the >1-page growth invariant, the
precompute/build equality with all data sections, and the asymmetric
pre-pass/build agreement) plus the suite. Mach-O execution is validated
by CI's macos job; layout invariants are pinned at the unit level here.

Part of RUE-131 (items 3, 4, 6 + the layout drift; remaining: 2, 5, 7, 8
Mach-O-side, 11).



🤖 Generated with [Claude Code](https://claude.com/claude-code)
Note: stacked on #944; the diff collapses to the Mach-O changes once it merges.
