### PR TITLE
Spec: a dedicated modules chapter — 18 normative rules for the implemented system

### DIFF
--- a/crates/rue-spec/cases/modules/bindings.toml
+++ b/crates/rue-spec/cases/modules/bindings.toml
@@ -1,0 +1,112 @@
+[section]
+id = "modules.bindings"
+spec_chapter = "10.4"
+name = "Module Bindings and Re-exports"
+description = "Binding forms for @import, const re-exports, and modules not being runtime values (spec chapter 10.4)."
+
+# =============================================================================
+# Binding forms (10.4:1): top-level const and local let are equivalent
+# =============================================================================
+
+[[case]]
+name = "const_and_let_bindings_equivalent"
+spec = ["10.4:1"]
+description = "A module bound by top-level const and by local let supports the same member access"
+source = """
+const math = @import("math");
+
+fn main() -> i32 {
+    let m = @import("math");
+    math.add(40, m.add(1, 1))
+}
+"""
+aux_files = { "math.rue" = "pub fn add(a: i32, b: i32) -> i32 { a + b }" }
+exit_code = 42
+
+# =============================================================================
+# Re-exports (10.4:3, 10.4:4)
+# =============================================================================
+
+[[case]]
+name = "reexport_chain_two_levels"
+spec = ["10.4:3"]
+description = "Member access chains through two levels of pub const re-export (directory facades)"
+source = """
+fn main() -> i32 {
+    let a = @import("a");
+    a.b.value()
+}
+"""
+aux_files = { "a/_a.rue" = """
+pub const b = @import("a/b");
+""", "a/b/_b.rue" = """
+pub fn value() -> i32 { 42 }
+""" }
+exit_code = 42
+
+[[case]]
+name = "private_reexport_visible_within_directory"
+spec = ["10.4:4"]
+description = "A non-pub const re-export is accessible from a file in the same directory as its definer"
+source = """
+fn main() -> i32 {
+    let m = @import("mod");
+    m.helper.h()
+}
+"""
+aux_files = { "mod.rue" = """
+const helper = @import("sub/helper");
+""", "sub/helper.rue" = """
+pub fn h() -> i32 { 42 }
+""" }
+exit_code = 42
+
+# =============================================================================
+# Modules are not runtime values (10.4:6)
+# =============================================================================
+
+[[case]]
+name = "module_as_function_argument_error"
+spec = ["10.4:6"]
+description = "Passing a module binding as a function argument is a compile error"
+source = """
+fn takes(m: i32) -> i32 { m }
+fn main() -> i32 {
+    let math = @import("math");
+    takes(math)
+}
+"""
+aux_files = { "math.rue" = "pub fn add(a: i32, b: i32) -> i32 { a + b }" }
+compile_fail = true
+error_contains = "type mismatch"
+
+[[case]]
+name = "module_as_struct_field_error"
+spec = ["10.4:6"]
+description = "Using a module binding as a struct field value is a compile error"
+source = """
+struct Holder { m: i32 }
+fn main() -> i32 {
+    let math = @import("math");
+    let h = Holder { m: math };
+    0
+}
+"""
+aux_files = { "math.rue" = "pub fn add(a: i32, b: i32) -> i32 { a + b }" }
+compile_fail = true
+error_contains = "type mismatch"
+
+[[case]]
+name = "module_comparison_error"
+spec = ["10.4:6"]
+description = "Comparing module bindings with == is a compile error"
+source = """
+fn main() -> i32 {
+    let a = @import("math");
+    let b = @import("math");
+    if a == b { 1 } else { 0 }
+}
+"""
+aux_files = { "math.rue" = "pub fn add(a: i32, b: i32) -> i32 { a + b }" }
+compile_fail = true
+error_contains = "type mismatch"

--- a/crates/rue-spec/cases/modules/composition.toml
+++ b/crates/rue-spec/cases/modules/composition.toml
@@ -1,0 +1,43 @@
+[section]
+id = "modules.composition"
+spec_chapter = "10.5"
+name = "Program Composition"
+description = "Cross-file name collisions in the (transitional) flat namespace (spec chapter 10.5)."
+
+[[case]]
+name = "duplicate_symbol_across_imported_files_error"
+spec = ["10.5:1"]
+description = "Two loaded files defining the same top-level function name collide, even though each is only accessed through its own module"
+source = """
+fn main() -> i32 {
+    let a = @import("a");
+    let _b = @import("b");
+    a.shared()
+}
+"""
+aux_files = { "a.rue" = "pub fn shared() -> i32 { 1 }", "b.rue" = "pub fn shared() -> i32 { 2 }" }
+compile_fail = true
+error_contains = "duplicate"
+
+[[case]]
+name = "duplicate_const_across_imported_files_error"
+spec = ["10.5:1"]
+description = "Top-level const bindings (including module re-exports) also collide across files"
+source = """
+fn main() -> i32 {
+    let left = @import("left");
+    let _right = @import("right");
+    left.go()
+}
+"""
+aux_files = { "left.rue" = """
+const shared = @import("shared");
+pub fn go() -> i32 { shared.value() }
+""", "right.rue" = """
+const shared = @import("shared");
+pub fn go2() -> i32 { shared.value() }
+""", "shared.rue" = """
+pub fn value() -> i32 { 42 }
+""" }
+compile_fail = true
+error_contains = "duplicate"

--- a/crates/rue-spec/cases/modules/directory.toml
+++ b/crates/rue-spec/cases/modules/directory.toml
@@ -1,17 +1,16 @@
 [section]
 id = "modules.directory"
+spec_chapter = "10.1"
 name = "Directory Module Resolution"
-description = "Directory module resolution using the _foo.rue + foo/ pattern. Per ADR-0026, @import('foo') resolves to _foo.rue when foo.rue doesn't exist."
+description = "Module forms (spec chapter 10.1): file modules, directory modules with an in-directory _foo.rue facade, and resolution between them."
 
 # =============================================================================
 # Simple File Module Resolution
 # =============================================================================
-# Note: Module resolution is implemented, but module member access is not yet.
-# These tests verify the path resolution logic by checking that the correct
-# file is found (no "module not found" error).
 
 [[case]]
 name = "import_simple_file_resolves"
+spec = ["10.1:2"]
 description = "@import('foo') resolves to foo.rue when it exists (verifies file is found)"
 source = """
 fn main() -> i32 {
@@ -28,6 +27,7 @@ exit_code = 0
 
 [[case]]
 name = "import_simple_file_with_extension_resolves"
+spec = ["10.2:1"]
 description = "@import('foo.rue') resolves to foo.rue directly"
 source = """
 fn main() -> i32 {
@@ -48,6 +48,7 @@ exit_code = 0
 
 [[case]]
 name = "import_directory_module_resolves"
+spec = ["10.1:3"]
 description = "@import('utils') resolves to the in-directory facade utils/_utils.rue (RUE-137)"
 source = """
 fn main() -> i32 {
@@ -64,6 +65,7 @@ exit_code = 0
 
 [[case]]
 name = "import_directory_module_with_subdir_resolves"
+spec = ["10.1:3"]
 description = "@import('utils') finds utils/_utils.rue alongside other files in the directory"
 source = """
 fn main() -> i32 {
@@ -86,6 +88,7 @@ exit_code = 0
 
 [[case]]
 name = "import_simple_file_with_stray_sibling_underscore_file"
+spec = ["10.1:4"]
 description = "A sibling _math.rue is just a file, not a facade: math.rue resolves cleanly (the pre-RUE-137 sibling layout has no special meaning)"
 source = """
 fn main() -> i32 {
@@ -122,6 +125,7 @@ error_contains = "cannot find module"
 
 [[case]]
 name = "import_nested_path_resolves"
+spec = ["10.2:1"]
 description = "@import('foo/bar') resolves to foo/bar.rue"
 source = """
 fn main() -> i32 {
@@ -133,3 +137,53 @@ aux_files = { "sub/helper.rue" = """
 fn value() -> i32 { 123 }
 """ }
 exit_code = 0
+
+# =============================================================================
+# Module Forms (spec 10.1): membership and facade calls
+# =============================================================================
+
+[[case]]
+name = "module_members_are_top_level_items"
+spec = ["10.1:1", "10.1:2"]
+description = "A file's top-level items are the imported module's members"
+source = """
+fn main() -> i32 {
+    let math = @import("math");
+    math.add(40, 2)
+}
+"""
+aux_files = { "math.rue" = """
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+""" }
+exit_code = 42
+
+[[case]]
+name = "directory_module_call_through_facade"
+spec = ["10.1:3"]
+description = "Importing a directory yields the module defined by its in-directory facade"
+source = """
+fn main() -> i32 {
+    let utils = @import("utils");
+    utils.answer()
+}
+"""
+aux_files = { "utils/_utils.rue" = """
+pub fn answer() -> i32 { 42 }
+""" }
+exit_code = 42
+
+[[case]]
+name = "sibling_underscore_file_not_importable_as_module"
+spec = ["10.1:4"]
+description = "A lone sibling _foo.rue does not make 'foo' importable: it is not a facade outside a foo/ directory"
+source = """
+fn main() -> i32 {
+    let m = @import("foo");
+    0
+}
+"""
+aux_files = { "_foo.rue" = """
+pub fn f() -> i32 { 1 }
+""" }
+compile_fail = true
+error_contains = "cannot find module"

--- a/crates/rue-spec/cases/modules/import.toml
+++ b/crates/rue-spec/cases/modules/import.toml
@@ -13,7 +13,7 @@ description = "The @import builtin for importing modules."
 
 [[case]]
 name = "import_basic_syntax"
-spec = ["4.13:79", "4.13:80", "4.13:82"]
+spec = ["4.13:79", "4.13:80", "4.13:82", "10.2:1"]
 description = "@import with string argument is accepted"
 source = """
 fn main() -> i32 {
@@ -140,7 +140,7 @@ error_contains = "ambiguous module"
 
 [[case]]
 name = "const_module_reexport_member_chain"
-spec = ["4.13:81"]
+spec = ["4.13:81", "10.4:3"]
 description = "A pub const holding a module (ADR-0026 re-export idiom) is accessible as a member; chained access reaches the inner module's functions (RUE-136)"
 source = """
 fn main() -> i32 {
@@ -157,7 +157,7 @@ exit_code = 42
 
 [[case]]
 name = "private_const_reexport_not_visible"
-spec = ["4.13:86"]
+spec = ["4.13:86", "10.4:4"]
 description = "A non-pub const module re-export is not accessible from outside the directory"
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -10,6 +10,7 @@ description = "Files within the same directory can access each other's non-pub i
 
 [[case]]
 name = "same_dir_access_private_fn"
+spec = ["10.3:2"]
 description = "Files in same directory can access private functions"
 source = """
 fn main() -> i32 {
@@ -28,6 +29,7 @@ exit_code = 42
 
 [[case]]
 name = "same_dir_access_pub_fn"
+spec = ["10.3:4"]
 description = "Files in same directory can access public functions"
 source = """
 fn main() -> i32 {
@@ -45,6 +47,7 @@ exit_code = 42
 
 [[case]]
 name = "same_dir_access_private_struct"
+spec = ["10.3:2"]
 description = "Files in same directory can access private structs"
 source = """
 fn main() -> i32 {
@@ -63,6 +66,7 @@ exit_code = 42
 
 [[case]]
 name = "same_dir_access_private_enum"
+spec = ["10.3:2"]
 description = "Files in same directory can access private enums"
 source = """
 fn main() -> i32 {
@@ -88,6 +92,7 @@ exit_code = 42
 
 [[case]]
 name = "cross_dir_access_pub_fn"
+spec = ["10.3:4"]
 description = "Files in different directories can access public functions"
 source = """
 fn main() -> i32 {
@@ -105,6 +110,7 @@ exit_code = 42
 
 [[case]]
 name = "cross_dir_access_private_fn_error"
+spec = ["10.3:3"]
 description = "Files in different directories cannot access private functions"
 source = """
 fn main() -> i32 {
@@ -123,6 +129,7 @@ error_contains = "private"
 
 [[case]]
 name = "cross_dir_access_pub_struct"
+spec = ["10.3:4"]
 description = "Files in different directories can access public structs"
 source = """
 fn main() -> i32 {
@@ -140,6 +147,7 @@ exit_code = 42
 
 [[case]]
 name = "cross_dir_access_private_struct_error"
+spec = ["10.3:3"]
 description = "Files in different directories cannot access private structs"
 source = """
 fn main() -> i32 {
@@ -158,6 +166,7 @@ error_contains = "private"
 
 [[case]]
 name = "cross_dir_access_pub_enum"
+spec = ["10.3:4"]
 description = "Files in different directories can access public enums"
 source = """
 fn main() -> i32 {
@@ -177,6 +186,7 @@ exit_code = 42
 
 [[case]]
 name = "cross_dir_access_private_enum_error"
+spec = ["10.3:3"]
 description = "Files in different directories cannot access private enums"
 source = """
 fn main() -> i32 {
@@ -199,6 +209,7 @@ error_contains = "private"
 
 [[case]]
 name = "directory_module_intra_access"
+spec = ["10.3:5"]
 description = "Files within a directory module can access each other's private items"
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/modules/resolution.toml
+++ b/crates/rue-spec/cases/modules/resolution.toml
@@ -1,0 +1,116 @@
+[section]
+id = "modules.resolution"
+spec_chapter = "10.2"
+name = "Import Resolution Order"
+description = "Base-directory search order, transitive loading, and cycle behavior (spec chapter 10.2)."
+
+# =============================================================================
+# Base directory order (10.2:2): importing file's directory first, then the
+# root file's directory; nearer wins.
+# =============================================================================
+
+[[case]]
+name = "importer_relative_beats_root_relative"
+spec = ["10.2:2"]
+description = "A module found relative to the importing file shadows one at the same relative path next to the root file"
+source = """
+fn main() -> i32 {
+    let m = @import("sub/mod");
+    m.go()
+}
+"""
+aux_files = { "sub/mod.rue" = """
+const helper = @import("helper");
+pub fn go() -> i32 { helper.h() }
+""", "sub/helper.rue" = """
+pub fn h() -> i32 { 42 }
+""", "helper.rue" = """
+pub fn h() -> i32 { 7 }
+""" }
+exit_code = 42
+
+[[case]]
+name = "root_relative_fallback"
+spec = ["10.2:2"]
+description = "When the importing file's directory has no match, resolution falls back to the root file's directory"
+source = """
+fn main() -> i32 {
+    let m = @import("sub/mod");
+    m.go()
+}
+"""
+aux_files = { "sub/mod.rue" = """
+const helper = @import("helper");
+pub fn go() -> i32 { helper.h() }
+""", "helper.rue" = """
+pub fn h() -> i32 { 42 }
+""" }
+exit_code = 42
+
+# =============================================================================
+# Transitive loading (10.2:3)
+# =============================================================================
+
+[[case]]
+name = "transitive_import_loads_indirect_module"
+spec = ["10.2:3"]
+description = "Importing a module loads that module's own imports without the user listing them"
+source = """
+fn main() -> i32 {
+    let outer = @import("outer");
+    outer.go()
+}
+"""
+aux_files = { "outer.rue" = """
+const inner = @import("inner");
+pub fn go() -> i32 { inner.value() }
+""", "inner.rue" = """
+pub fn value() -> i32 { 42 }
+""" }
+exit_code = 42
+
+# =============================================================================
+# Dedupe and cycles (10.2:4)
+# =============================================================================
+
+[[case]]
+name = "import_cycle_is_legal"
+spec = ["10.2:4"]
+description = "Two modules importing each other compile and run; each file is loaded once"
+source = """
+fn main() -> i32 {
+    let a = @import("a");
+    a.a_uses_b()
+}
+"""
+aux_files = { "a.rue" = """
+const b = @import("b");
+pub fn from_a() -> i32 { 1 }
+pub fn a_uses_b() -> i32 { b.from_b() }
+""", "b.rue" = """
+const a = @import("a");
+pub fn from_b() -> i32 { 42 }
+""" }
+exit_code = 42
+
+[[case]]
+name = "diamond_import_loads_once"
+spec = ["10.2:4"]
+description = "Two importers of the same module refer to the same single loaded file (no duplicate-definition error from loading it twice)"
+source = """
+fn main() -> i32 {
+    let left = @import("left");
+    let _right = @import("right");
+    left.go()
+}
+"""
+aux_files = { "left.rue" = """
+const shared = @import("shared");
+pub fn go() -> i32 { shared.value() }
+""", "right.rue" = """
+const shared2 = @import("shared");
+pub fn go2() -> i32 { shared2.value() }
+""", "shared.rue" = """
+pub fn value() -> i32 { 42 }
+""" }
+exit_code = 42

--- a/crates/rue-spec/cases/modules/stdlib.toml
+++ b/crates/rue-spec/cases/modules/stdlib.toml
@@ -7,10 +7,15 @@ description = "Resolution and usage of @import(\"std\") for the standard library
 # =============================================================================
 # @import("std") Resolution
 # =============================================================================
+# Spec 10.2:6 has two halves: the adjacent std/_std.rue directory-module form
+# (covered here) and the $RUE_STD_PATH form with its precedence. The spec
+# harness cannot set per-case environment variables, so the env-var half is
+# exercised by the CLI integration test `import_std_via_env_var`
+# (crates/rue-cli-tests/cases/modules.toml).
 
 [[case]]
 name = "import_std_resolves"
-spec = ["4.13:82"]
+spec = ["4.13:82", "10.2:6"]
 description = "@import(\"std\") resolves to the standard library root when std/ exists"
 source = """
 fn main() -> i32 {
@@ -47,7 +52,7 @@ error_contains = "standard library not found"
 
 [[case]]
 name = "import_std_with_submodule"
-spec = ["4.13:81", "4.13:82"]
+spec = ["4.13:81", "4.13:82", "10.2:6"]
 description = "std library with submodules can be imported"
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/modules/visibility.toml
+++ b/crates/rue-spec/cases/modules/visibility.toml
@@ -9,6 +9,7 @@ description = "Pub visibility modifier for functions, structs, and enums."
 
 [[case]]
 name = "pub_fn_basic"
+spec = ["10.3:1"]
 description = "Basic pub function declaration"
 source = """
 pub fn helper() -> i32 { 42 }
@@ -31,6 +32,7 @@ exit_code = 42
 
 [[case]]
 name = "pub_struct_basic"
+spec = ["10.3:1"]
 description = "Basic pub struct declaration"
 source = """
 pub struct Point { x: i32, y: i32 }
@@ -47,6 +49,7 @@ exit_code = 42
 
 [[case]]
 name = "pub_enum_basic"
+spec = ["10.3:1"]
 description = "Basic pub enum declaration"
 source = """
 pub enum Color { Red, Green, Blue }
@@ -67,6 +70,7 @@ exit_code = 42
 
 [[case]]
 name = "mixed_pub_and_private"
+spec = ["10.3:1"]
 description = "Mix of public and private declarations"
 source = """
 pub fn public_fn() -> i32 { 10 }

--- a/docs/spec/src/10-modules/01-module-forms.md
+++ b/docs/spec/src/10-modules/01-module-forms.md
@@ -1,0 +1,56 @@
++++
+title = "Module Forms"
+weight = 1
+template = "spec/page.html"
++++
+
+# Module Forms
+
+This section describes what a module is and the two on-disk forms a module
+can take: a file module and a directory module.
+
+{{ rule(id="10.1:1", cat="normative") }}
+
+A module is a Rue source file. The top-level items of the file — functions,
+structs, enums, and constants — are the members of the module.
+
+{{ rule(id="10.1:2", cat="normative") }}
+
+A *file module* is a source file `{name}.rue`. An import of `{name}` that
+resolves to this file yields the module defined by it.
+
+{{ rule(id="10.1:3", cat="normative") }}
+
+A *directory module* is a directory `{name}/` that contains a facade file
+`_{name}.rue` directly inside it. The facade file is the directory module's
+root: an import of `{name}` that resolves to the directory module yields the
+module defined by the facade file. Other files inside the directory are not
+automatically part of the imported module; the facade reaches them via its
+own imports.
+
+{{ rule(id="10.1:4", cat="normative") }}
+
+A file `_{name}.rue` is a facade only when its enclosing directory is named
+`{name}`. Anywhere else — in particular, as a *sibling* of a directory or a
+file named `{name}` — it is an ordinary source file with no special meaning,
+and it does not make `{name}` importable.
+
+{{ rule(id="10.1:5") }}
+
+If both module forms exist for the same import path — a file module
+`{path}.rue` and a directory module `{path}/_{basename}.rue` — the import is
+ambiguous and rejected at compile time; neither form takes precedence. This
+is specified as rule
+[4.13:89](@/04-expressions/13-intrinsics.md) (error E0708).
+
+{{ rule(id="10.1:6", cat="example") }}
+
+A project mixing both forms:
+
+```text
+main.rue            # root file
+math.rue            # file module: @import("math")
+utils/              # directory module: @import("utils")
+├── _utils.rue      #   facade — the module root for "utils"
+└── strings.rue     #   helper file, reached via the facade's imports
+```

--- a/docs/spec/src/10-modules/02-import-resolution.md
+++ b/docs/spec/src/10-modules/02-import-resolution.md
@@ -1,0 +1,86 @@
++++
+title = "Import Resolution"
+weight = 2
+template = "spec/page.html"
++++
+
+# Import Resolution
+
+This section specifies how an import path given to `@import` is resolved to
+a source file on disk, and how the set of loaded files is computed. The
+`@import` intrinsic's argument form and its error conditions are rules
+4.13:79–4.13:89 in the
+[intrinsics section](@/04-expressions/13-intrinsics.md).
+
+## Resolution Order
+
+{{ rule(id="10.2:1", cat="normative") }}
+
+An import path `P` is resolved by trying the following interpretations in
+order; the first that matches is used:
+
+1. If `P` is exactly `"std"`, the import resolves to the standard library
+   (see 10.2:6).
+2. If `P` ends with the `.rue` extension, the import resolves to the file at
+   exactly that relative path.
+3. Otherwise, the import resolves to the file module `{P}.rue`, or, when no
+   such file exists, to the directory-module facade `{P}/_{basename}.rue`
+   (where `basename` is the final path component of `P`). If *both* exist,
+   the import is ambiguous and rejected (rule
+   [4.13:89](@/04-expressions/13-intrinsics.md)).
+
+{{ rule(id="10.2:2", cat="normative") }}
+
+Relative candidate paths are searched against base directories in order:
+first the directory containing the *importing* file, then the directory
+containing the *root* file (the first source file given to the compiler). A
+module found relative to the importing file takes precedence over a module
+at the same relative path found relative to the root file.
+
+## Transitive Loading
+
+{{ rule(id="10.2:3", cat="normative") }}
+
+Importing a module loads it *transitively*: imports appearing in an imported
+file are themselves resolved and loaded, and so on, as if every reachable
+module had been listed on the command line. The importer of a transitively
+loaded file — not the root file — is the base for that file's own relative
+imports (per 10.2:2).
+
+{{ rule(id="10.2:4", cat="normative") }}
+
+Each source file is loaded at most once per compilation. An import that
+resolves to an already-loaded file refers to that same module. Import cycles
+are therefore legal: two modules may import each other, and a chain of
+imports may return to its starting file.
+
+{{ rule(id="10.2:5", cat="example") }}
+
+Mutually importing modules:
+
+```rue
+// a.rue
+const b = @import("b");
+pub fn from_a() -> i32 { 1 }
+pub fn a_uses_b() -> i32 { b.from_b() }
+
+// b.rue
+const a = @import("a");
+pub fn from_b() -> i32 { 42 }
+
+// main.rue
+fn main() -> i32 {
+    let a = @import("a");
+    a.a_uses_b()  // 42
+}
+```
+
+## Standard Library Resolution
+
+{{ rule(id="10.2:6", cat="normative") }}
+
+`@import("std")` resolves to the standard library facade `_std.rue`. It is
+searched for at `$RUE_STD_PATH/_std.rue` when the `RUE_STD_PATH` environment
+variable is set, and otherwise as an ordinary directory module `std/_std.rue`
+per 10.2:2. When both exist, `$RUE_STD_PATH` takes precedence. If no
+standard library is found, the import is a compile-time error (E0705).

--- a/docs/spec/src/10-modules/03-visibility.md
+++ b/docs/spec/src/10-modules/03-visibility.md
@@ -1,0 +1,58 @@
++++
+title = "Visibility"
+weight = 3
+template = "spec/page.html"
++++
+
+# Visibility
+
+This section specifies the `pub` visibility modifier and the
+intra-directory visibility rule: visibility boundaries in Rue are
+*directories*, not files.
+
+{{ rule(id="10.3:1", cat="normative") }}
+
+A top-level function, struct, enum, or constant **MAY** be marked with the
+`pub` modifier. An item without `pub` is *private*.
+
+{{ rule(id="10.3:2", cat="normative") }}
+
+A private item is visible throughout the directory that contains its
+defining file: code in any source file in the *same directory* may access
+it, including through a module import.
+
+{{ rule(id="10.3:3", cat="legality-rule") }}
+
+It is a compile-time error to access a private item through a module from a
+source file in a *different directory* than the item's defining file
+(error E0706).
+
+{{ rule(id="10.3:4", cat="normative") }}
+
+A `pub` item is accessible through a module import from any directory.
+
+{{ rule(id="10.3:5", cat="normative") }}
+
+A directory module's facade file lives inside the directory it fronts
+(10.1:3); the facade therefore has intra-directory access to the private
+items of the other files in that directory, while external importers of the
+directory module see only the facade's `pub` members.
+
+{{ rule(id="10.3:6", cat="example") }}
+
+```rue
+// utils/_utils.rue — the facade
+const strings = @import("strings");
+pub fn format() -> i32 { strings.internal_format() }  // OK: same directory
+
+// utils/strings.rue
+fn internal_format() -> i32 { 42 }  // private
+
+// main.rue — a different directory
+fn main() -> i32 {
+    let utils = @import("utils");
+    utils.format()              // OK: `format` is pub
+    // utils.internal_format()  // would be an error even if imported:
+    //                          // private to the utils/ directory
+}
+```

--- a/docs/spec/src/10-modules/04-module-bindings.md
+++ b/docs/spec/src/10-modules/04-module-bindings.md
@@ -1,0 +1,79 @@
++++
+title = "Module Bindings and Re-exports"
+weight = 4
+template = "spec/page.html"
++++
+
+# Module Bindings and Re-exports
+
+This section specifies how the result of `@import` is bound to a name, the
+re-export idiom (`pub const m = @import(...)`), and the (non-)status of
+modules as runtime values. The imported module may be bound to any name
+(rule [4.13:87](@/04-expressions/13-intrinsics.md)).
+
+## Binding Forms
+
+{{ rule(id="10.4:1", cat="normative") }}
+
+The result of `@import` **MAY** be bound at the top level of a file with a
+`const` item, or locally inside a function body with a `let` statement.
+Member access through either binding form has the same semantics.
+
+{{ rule(id="10.4:2", cat="example") }}
+
+```rue
+const math = @import("math");      // top-level const binding
+
+fn main() -> i32 {
+    let m = @import("math");       // local let binding
+    math.add(1, m.add(2, 3))       // equivalent access through either
+}
+```
+
+## Re-exports
+
+{{ rule(id="10.4:3", cat="normative") }}
+
+A top-level `const` whose initializer is an `@import` expression makes the
+bound name a member of the enclosing module — a *re-export*. Accessing that
+member through an import of the enclosing module yields the inner imported
+module, and such access chains through multiple levels of re-export.
+
+{{ rule(id="10.4:4", cat="normative") }}
+
+A `const` re-export follows the same visibility rules as any other item
+(10.3): a `pub const` re-export is accessible from any directory, while a
+non-`pub` re-export is private to the directory of its defining file.
+
+{{ rule(id="10.4:5", cat="example") }}
+
+```rue
+// outer/_outer.rue
+pub const inner = @import("inner");   // pub re-export
+const hidden = @import("inner");      // private outside outer/
+
+// outer/inner.rue
+pub fn value() -> i32 { 42 }
+
+// main.rue
+fn main() -> i32 {
+    let outer = @import("outer");
+    outer.inner.value()       // 42, chained through the re-export
+    // outer.hidden.value()   // error: `hidden` is private (E0706)
+}
+```
+
+## Modules Are Not Runtime Values
+
+{{ rule(id="10.4:6", cat="legality-rule") }}
+
+A module is not a runtime value. It is a compile-time error to use a module
+binding as a function argument, as a struct field value, or as an operand of
+an operator such as `==`.
+
+{{ rule(id="10.4:7") }}
+
+In a few value positions (for example, the tail expression of a block whose
+type is `()`) a module expression is currently accepted and treated as the
+unit value. Programs must not rely on this; it is an artifact of the current
+implementation, not a guarantee.

--- a/docs/spec/src/10-modules/05-program-composition.md
+++ b/docs/spec/src/10-modules/05-program-composition.md
@@ -1,0 +1,55 @@
++++
+title = "Program Composition"
+weight = 5
+template = "spec/page.html"
++++
+
+# Program Composition
+
+This section specifies how the set of loaded source files composes into one
+program: the (transitional) shared namespace and the extent of semantic
+analysis.
+
+## Name Collisions
+
+{{ rule(id="10.5:1", cat="legality-rule") }}
+
+It is a compile-time error for two loaded source files to define a top-level
+item with the same name (duplicate definition, E0436). This holds regardless
+of the items' visibility and regardless of whether the files are in the same
+directory.
+
+{{ rule(id="10.5:2") }}
+
+Rule 10.5:1 is *transitional*: loaded files currently share one flat global
+namespace, so symbols collide program-wide even when each is only ever
+accessed through its own module. A future revision of the module system is
+expected to scope top-level names per module, relaxing this rule; programs
+should not be designed to rely on cross-file collisions being errors.
+
+{{ rule(id="10.5:3", cat="example") }}
+
+```rue
+// a.rue
+pub fn shared() -> i32 { 1 }
+
+// b.rue
+pub fn shared() -> i32 { 2 }   // error: duplicate definition of `shared`
+
+// main.rue
+fn main() -> i32 {
+    let a = @import("a");
+    let b = @import("b");      // loading both files collides
+    a.shared()
+}
+```
+
+## Extent of Analysis
+
+{{ rule(id="10.5:4") }}
+
+Every loaded source file is fully analyzed: a compile-time error anywhere in
+an imported module is reported even if the offending item is never
+referenced by the importing program. (ADR-0026 envisions lazy, on-demand
+analysis of imported modules; that is not implemented, and this paragraph is
+informative so that the eager behavior is not a guarantee either.)

--- a/docs/spec/src/10-modules/_index.md
+++ b/docs/spec/src/10-modules/_index.md
@@ -1,0 +1,23 @@
++++
+title = "Modules"
+weight = 10
+sort_by = "weight"
+template = "spec/section.html"
+page_template = "spec/page.html"
++++
+
+# Modules
+
+This chapter describes Rue's module system: how source files form modules,
+how import paths are resolved, item visibility, module bindings and
+re-exports, and how loaded files compose into a program.
+
+{{ rule(id="10.0:1") }}
+
+A Rue program is composed of modules. Each module corresponds to a source
+file. Modules are brought into scope with the `@import` intrinsic; the
+intrinsic itself (argument form, result type, and the associated
+compile-time errors) is specified in the
+[intrinsics section](@/04-expressions/13-intrinsics.md) as rules
+4.13:79 through 4.13:89. This chapter specifies the module system around
+that intrinsic.


### PR DESCRIPTION
The entire module system's normative spec was ten paragraphs inside the
@import intrinsic's section. This adds chapter 10 (docs/spec/src/10-modules/,
five sections plus index) covering what is implemented and verified today —
every rule and example was run against the compiler before being pinned:

- Module forms: file modules and directory modules with the in-directory
  facade (foo/_foo.rue, per the RUE-137 ratification), the sibling form's
  non-meaning, and the E0708 dual-form ambiguity (referencing 4.13:89).
- Import resolution: full candidate order including std via $RUE_STD_PATH
  then adjacent std/, importer-relative before root-relative, transitive
  disk loading, and load-once cycle dedupe (cycles are legal).
- Visibility: pub is cross-directory; non-pub items are visible within
  their directory, facade included; re-export chains through pub const,
  and non-pub re-exports staying private.
- Module bindings: const (top-level) and let (local) binding forms and
  their equivalence; modules are not runtime values (argument, field, and
  comparison positions error).
- Program composition: the flat-namespace duplicate-symbol rule, pinned
  with an informative note marking it transitional.

The existing 4.13:79-90 intrinsic rules are referenced, not moved —
consolidation is a separate change. Sixteen new spec cases across three
new case files plus annotations on ~20 existing module cases; normative
traceability stays 100% (539/539, up from 513). Two incoherent behaviors
were deliberately left unpinned and documented in the issue: member-call
results in arithmetic positions, and module expressions in unit positions.

Fixes RUE-138



🤖 Generated with [Claude Code](https://claude.com/claude-code)
