### PR TITLE
Linker: per-object local symbols; correct Mach-O relocation semantics; epic test gaps closed

### DIFF
--- a/crates/rue-linker/src/constants.rs
+++ b/crates/rue-linker/src/constants.rs
@@ -302,6 +302,9 @@ pub const ARM64_RELOC_BRANCH26: u32 = 2;
 pub const ARM64_RELOC_PAGE21: u32 = 3;
 /// ARM64_RELOC_PAGEOFF12: Page offset
 pub const ARM64_RELOC_PAGEOFF12: u32 = 4;
+/// ARM64_RELOC_ADDEND: carries the addend for the *following* relocation
+/// entry (Mach-O ARM64 relocation_info has no addend field of its own)
+pub const ARM64_RELOC_ADDEND: u32 = 10;
 
 // Mach-O structure sizes
 

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -12,6 +12,7 @@ use std::collections::HashMap;
 
 use crate::constants::{
     // Mach-O constants
+    ARM64_RELOC_ADDEND,
     ARM64_RELOC_BRANCH26,
     ARM64_RELOC_PAGE21,
     ARM64_RELOC_PAGEOFF12,
@@ -445,6 +446,12 @@ impl ObjectFile {
         // Track section info for relocations (offset, nreloc, reloff)
         let mut section_reloc_info: Vec<(usize, usize, usize)> = Vec::new();
 
+        // Each section's address within the object's VM layout. Mach-O symbol
+        // n_value fields and non-extern UNSIGNED patch-site contents are
+        // addresses in this layout, NOT section-relative offsets — we need the
+        // section addr to convert them.
+        let mut section_addrs: Vec<u64> = Vec::new();
+
         let mut cmd_offset = MACHO64_HEADER_SIZE;
         for _ in 0..ncmds {
             if cmd_offset + 8 > data.len() {
@@ -481,6 +488,7 @@ impl ObjectFile {
                         let full_name = format!("{},{}", segname, sectname);
 
                         // addr: u64 at offset 32
+                        let addr = read_u64(data, sect_offset + 32);
                         // size: u64 at offset 40
                         let size = read_u64(data, sect_offset + 40);
                         // offset: u32 at offset 48
@@ -518,6 +526,7 @@ impl ObjectFile {
 
                         let section_index = sections.len();
                         section_reloc_info.push((section_index, nreloc, reloff));
+                        section_addrs.push(addr);
                         section_map.insert(full_name.clone(), section_index);
 
                         sections.push(Section {
@@ -641,10 +650,26 @@ impl ObjectFile {
                     SymbolType::None
                 };
 
+                // Mach-O n_value for defined symbols is an address within the
+                // object's VM layout, not a section-relative offset (unlike
+                // ELF st_value in ET_REL files). Convert to section-relative
+                // by subtracting the owning section's addr, since the linker
+                // computes final addresses as merged-section-base + value.
+                // (Sections emitted at addr 0 — like our own __text — are
+                // unaffected.) Fall back to the raw value for malformed
+                // objects whose n_value is below the section start.
+                let value = match section_index {
+                    Some(idx) => {
+                        let sect_addr = section_addrs.get(idx).copied().unwrap_or(0);
+                        n_value.checked_sub(sect_addr).unwrap_or(n_value)
+                    }
+                    None => n_value,
+                };
+
                 symbols.push(Symbol {
                     name,
                     section_index,
-                    value: n_value,
+                    value,
                     size: 0, // Mach-O doesn't store symbol size
                     binding,
                     sym_type,
@@ -663,6 +688,15 @@ impl ObjectFile {
                 return Err(ParseError::RelocationOutOfBounds);
             }
 
+            // Mach-O ARM64 relocation_info has no addend field. Addends come
+            // from two places, both of which used to be ignored (the parser
+            // hardcoded addend 0, RUE-131 item 5b):
+            // - an ARM64_RELOC_ADDEND entry immediately PRECEDING the
+            //   relocation it modifies (used for BRANCH26/PAGE21/PAGEOFF12),
+            // - the bytes at the patch site for ARM64_RELOC_UNSIGNED
+            //   ("implicit" / embedded addend).
+            let mut pending_addend: i64 = 0;
+
             for i in 0..nreloc {
                 let rel_offset = reloff + i * MACHO64_RELOC_SIZE;
 
@@ -680,9 +714,17 @@ impl ObjectFile {
 
                 let r_symbolnum = r_info & 0x00FFFFFF;
                 let _r_pcrel = (r_info >> 24) & 1;
-                let _r_length = (r_info >> 25) & 3;
+                let r_length = (r_info >> 25) & 3;
                 let r_extern = (r_info >> 27) & 1;
                 let r_type = (r_info >> 28) & 0xF;
+
+                // ARM64_RELOC_ADDEND is not a relocation itself: its
+                // r_symbolnum field is a signed 24-bit addend that applies to
+                // the NEXT relocation entry.
+                if r_type == ARM64_RELOC_ADDEND {
+                    pending_addend = (((r_symbolnum << 8) as i32) >> 8) as i64;
+                    continue;
+                }
 
                 let symbol_index = if r_extern == 1 {
                     // External relocation: r_symbolnum is a symbol index
@@ -695,8 +737,10 @@ impl ObjectFile {
                     }
                     idx
                 } else {
-                    // Local/section relocation: r_symbolnum is 1-indexed section number
-                    // Find the function symbol for this section (should be at offset 0)
+                    // Non-extern relocation: r_symbolnum is a 1-indexed
+                    // section number; the target is an address inside that
+                    // section. We resolve it to a symbol at the section start
+                    // (offset folded into the addend below).
                     // r_symbolnum == 0 is invalid for a non-extern relocation;
                     // the subtraction used to wrap to usize::MAX and index OOB
                     // (a panic on malformed input). (RUE-131 item 6)
@@ -707,20 +751,36 @@ impl ObjectFile {
                         )));
                     };
                     let target_section = section_number as usize;
-                    let idx = symbols
+                    if target_section >= sections.len() {
+                        return Err(ParseError::InvalidSymbol(format!(
+                            "non-extern relocation at 0x{:x} references invalid section {}",
+                            r_address, target_section
+                        )));
+                    }
+                    // Reuse any named symbol at offset 0 of the section;
+                    // otherwise synthesize a local section anchor. (This used
+                    // to require a GLOBAL symbol at offset 0 and error out
+                    // otherwise — real objects routinely have only local
+                    // symbols, or none at all, at a section start.
+                    // RUE-131 item 5c)
+                    symbols
                         .iter()
                         .position(|s| {
                             s.section_index == Some(target_section)
                                 && s.value == 0
-                                && s.binding == SymbolBinding::Global
+                                && !s.name.is_empty()
                         })
-                        .ok_or_else(|| {
-                            ParseError::InvalidSymbol(format!(
-                                "no function symbol found for section {} (reloc at 0x{:x})",
-                                target_section, r_address
-                            ))
-                        })?;
-                    idx
+                        .unwrap_or_else(|| {
+                            symbols.push(Symbol {
+                                name: sections[target_section].name.clone(),
+                                section_index: Some(target_section),
+                                value: 0,
+                                size: 0,
+                                binding: SymbolBinding::Local,
+                                sym_type: SymbolType::Section,
+                            });
+                            symbols.len() - 1
+                        })
                 };
 
                 // Convert Mach-O relocation type to our type
@@ -732,11 +792,50 @@ impl ObjectFile {
                     _ => RelocationType::Unknown(r_type),
                 };
 
+                // ARM64_RELOC_UNSIGNED carries its addend embedded in the
+                // bytes at the patch site (4 or 8 bytes per r_length). For a
+                // non-extern UNSIGNED the stored value is the target's address
+                // in the object's VM layout; convert it to an offset from the
+                // section-start symbol we resolved to above.
+                let mut addend = pending_addend;
+                pending_addend = 0;
+                if r_type == ARM64_RELOC_UNSIGNED {
+                    let site = r_address as usize;
+                    let sec_data = &sections[section_index].data;
+                    let embedded = match r_length {
+                        2 => {
+                            if site + 4 > sec_data.len() {
+                                return Err(ParseError::RelocationOutOfBounds);
+                            }
+                            read_u32(sec_data, site) as i32 as i64
+                        }
+                        3 => {
+                            if site + 8 > sec_data.len() {
+                                return Err(ParseError::RelocationOutOfBounds);
+                            }
+                            read_i64(sec_data, site)
+                        }
+                        _ => {
+                            return Err(ParseError::InvalidSymbol(format!(
+                                "UNSIGNED relocation at 0x{:x} has unsupported length {}",
+                                r_address, r_length
+                            )));
+                        }
+                    };
+                    addend += embedded;
+                    if r_extern == 0 {
+                        // Stored value is target address in object VM layout;
+                        // re-base it onto the section anchor.
+                        let target_section = (r_symbolnum - 1) as usize;
+                        addend -= section_addrs.get(target_section).copied().unwrap_or(0) as i64;
+                    }
+                }
+
                 sections[section_index].relocations.push(Relocation {
                     offset: r_address,
                     symbol_index,
                     rel_type,
-                    addend: 0, // Mach-O ARM64 uses implicit addends (in instruction)
+                    addend,
                 });
             }
         }
@@ -1255,6 +1354,327 @@ mod tests {
         // The function should be defined in a section
         let sym = func_sym.unwrap();
         assert!(sym.section_index.is_some());
+    }
+
+    // ---------------------------------------------------------------------
+    // Hand-built Mach-O objects for parser tests (RUE-131 items 5b/5c).
+    // ObjectBuilder only emits extern relocations with zero addends, so these
+    // tests construct the raw bytes for the cases real (rustc/clang) objects
+    // produce: embedded addends, ARM64_RELOC_ADDEND pairs, and non-extern
+    // (section-based) relocations.
+    // ---------------------------------------------------------------------
+
+    struct TestMachoSection {
+        sectname: &'static str,
+        segname: &'static str,
+        addr: u64,
+        data: Vec<u8>,
+        /// Raw (r_address, r_info) relocation entries.
+        relocs: Vec<(u32, u32)>,
+    }
+
+    struct TestMachoSymbol {
+        name: &'static str,
+        n_type: u8,
+        /// 1-indexed section number (0 = NO_SECT).
+        n_sect: u8,
+        n_value: u64,
+    }
+
+    /// Pack a Mach-O relocation_info r_info word.
+    fn macho_r_info(symbolnum: u32, pcrel: bool, length: u32, ext: bool, rtype: u32) -> u32 {
+        (symbolnum & 0x00FF_FFFF)
+            | ((pcrel as u32) << 24)
+            | ((length & 0x3) << 25)
+            | ((ext as u32) << 27)
+            | ((rtype & 0xF) << 28)
+    }
+
+    /// Build a minimal Mach-O object: one LC_SEGMENT_64 holding `sections`,
+    /// plus an LC_SYMTAB with `symbols`.
+    fn build_test_macho(sections: &[TestMachoSection], symbols: &[TestMachoSymbol]) -> Vec<u8> {
+        let nsects = sections.len();
+        let seg_cmd_size = MACHO64_SEGMENT_CMD_SIZE + MACHO64_SECTION_SIZE * nsects;
+        let cmds_size = seg_cmd_size + crate::constants::MACHO64_SYMTAB_CMD_SIZE;
+        let header_end = MACHO64_HEADER_SIZE + cmds_size;
+
+        // Lay out: section data, then relocation entries, then symtab, then strtab
+        let align8 = |v: usize| (v + 7) & !7;
+        let mut cursor = header_end;
+        let mut data_offsets = Vec::new();
+        for s in sections {
+            cursor = align8(cursor);
+            data_offsets.push(cursor);
+            cursor += s.data.len();
+        }
+        let mut reloc_offsets = Vec::new();
+        for s in sections {
+            cursor = align8(cursor);
+            reloc_offsets.push(cursor);
+            cursor += s.relocs.len() * MACHO64_RELOC_SIZE;
+        }
+        let symtab_off = align8(cursor);
+        let strtab_off = symtab_off + symbols.len() * MACHO64_NLIST_SIZE;
+
+        let mut strtab = vec![0u8];
+        let mut name_offsets = Vec::new();
+        for sym in symbols {
+            name_offsets.push(strtab.len());
+            strtab.extend_from_slice(sym.name.as_bytes());
+            strtab.push(0);
+        }
+
+        let mut buf = Vec::new();
+        // Header
+        buf.extend_from_slice(&MH_MAGIC_64.to_le_bytes());
+        buf.extend_from_slice(&0x0100000C_u32.to_le_bytes()); // CPU_TYPE_ARM64
+        buf.extend_from_slice(&0_u32.to_le_bytes()); // cpusubtype
+        buf.extend_from_slice(&MH_OBJECT.to_le_bytes());
+        buf.extend_from_slice(&2_u32.to_le_bytes()); // ncmds
+        buf.extend_from_slice(&(cmds_size as u32).to_le_bytes());
+        buf.extend_from_slice(&0_u32.to_le_bytes()); // flags
+        buf.extend_from_slice(&0_u32.to_le_bytes()); // reserved
+
+        // LC_SEGMENT_64
+        buf.extend_from_slice(&LC_SEGMENT_64.to_le_bytes());
+        buf.extend_from_slice(&(seg_cmd_size as u32).to_le_bytes());
+        buf.extend_from_slice(&[0u8; 16]); // segname (empty for objects)
+        buf.extend_from_slice(&0_u64.to_le_bytes()); // vmaddr
+        buf.extend_from_slice(&0_u64.to_le_bytes()); // vmsize
+        buf.extend_from_slice(&0_u64.to_le_bytes()); // fileoff
+        buf.extend_from_slice(&0_u64.to_le_bytes()); // filesize
+        buf.extend_from_slice(&7_u32.to_le_bytes()); // maxprot
+        buf.extend_from_slice(&5_u32.to_le_bytes()); // initprot
+        buf.extend_from_slice(&(nsects as u32).to_le_bytes());
+        buf.extend_from_slice(&0_u32.to_le_bytes()); // flags
+
+        for (i, s) in sections.iter().enumerate() {
+            let mut sect = [0u8; 16];
+            sect[..s.sectname.len()].copy_from_slice(s.sectname.as_bytes());
+            let mut seg = [0u8; 16];
+            seg[..s.segname.len()].copy_from_slice(s.segname.as_bytes());
+            buf.extend_from_slice(&sect);
+            buf.extend_from_slice(&seg);
+            buf.extend_from_slice(&s.addr.to_le_bytes());
+            buf.extend_from_slice(&(s.data.len() as u64).to_le_bytes());
+            buf.extend_from_slice(&(data_offsets[i] as u32).to_le_bytes());
+            buf.extend_from_slice(&3_u32.to_le_bytes()); // align 2^3
+            buf.extend_from_slice(&(reloc_offsets[i] as u32).to_le_bytes());
+            buf.extend_from_slice(&(s.relocs.len() as u32).to_le_bytes());
+            let flags: u32 = if s.sectname == "__text" {
+                0x80000000 // S_ATTR_PURE_INSTRUCTIONS
+            } else {
+                0
+            };
+            buf.extend_from_slice(&flags.to_le_bytes());
+            buf.extend_from_slice(&0_u32.to_le_bytes()); // reserved1
+            buf.extend_from_slice(&0_u32.to_le_bytes()); // reserved2
+            buf.extend_from_slice(&0_u32.to_le_bytes()); // reserved3
+        }
+
+        // LC_SYMTAB
+        buf.extend_from_slice(&LC_SYMTAB.to_le_bytes());
+        buf.extend_from_slice(&(crate::constants::MACHO64_SYMTAB_CMD_SIZE as u32).to_le_bytes());
+        buf.extend_from_slice(&(symtab_off as u32).to_le_bytes());
+        buf.extend_from_slice(&(symbols.len() as u32).to_le_bytes());
+        buf.extend_from_slice(&(strtab_off as u32).to_le_bytes());
+        buf.extend_from_slice(&(strtab.len() as u32).to_le_bytes());
+
+        // Section data
+        for (i, s) in sections.iter().enumerate() {
+            buf.resize(data_offsets[i], 0);
+            buf.extend_from_slice(&s.data);
+        }
+        // Relocations
+        for (i, s) in sections.iter().enumerate() {
+            buf.resize(reloc_offsets[i], 0);
+            for (r_address, r_info) in &s.relocs {
+                buf.extend_from_slice(&r_address.to_le_bytes());
+                buf.extend_from_slice(&r_info.to_le_bytes());
+            }
+        }
+        // Symbols
+        buf.resize(symtab_off, 0);
+        for (i, sym) in symbols.iter().enumerate() {
+            buf.extend_from_slice(&(name_offsets[i] as u32).to_le_bytes());
+            buf.push(sym.n_type);
+            buf.push(sym.n_sect);
+            buf.extend_from_slice(&0_u16.to_le_bytes());
+            buf.extend_from_slice(&sym.n_value.to_le_bytes());
+        }
+        // String table
+        buf.extend_from_slice(&strtab);
+        buf
+    }
+
+    /// RUE-131 item 5b: ARM64_RELOC_UNSIGNED carries its addend in the bytes
+    /// at the patch site; the parser used to hardcode addend 0.
+    #[test]
+    fn test_macho_unsigned_reads_embedded_addend() {
+        let mut slot = vec![0u8; 8];
+        slot[0] = 0x10; // embedded addend = 0x10
+        let obj_bytes = build_test_macho(
+            &[TestMachoSection {
+                sectname: "__const",
+                segname: "__TEXT",
+                addr: 0,
+                data: slot,
+                // extern UNSIGNED, 8 bytes, against symbol 0
+                relocs: vec![(0, macho_r_info(0, false, 3, true, ARM64_RELOC_UNSIGNED))],
+            }],
+            &[TestMachoSymbol {
+                name: "_foo",
+                n_type: N_EXT | N_UNDF,
+                n_sect: 0,
+                n_value: 0,
+            }],
+        );
+
+        let obj = ObjectFile::parse(&obj_bytes).expect("parse");
+        let relocs = &obj.sections[0].relocations;
+        assert_eq!(relocs.len(), 1);
+        assert_eq!(relocs[0].rel_type, RelocationType::Aarch64Abs64);
+        assert_eq!(
+            relocs[0].addend, 0x10,
+            "embedded addend must be read from the patch site"
+        );
+    }
+
+    /// RUE-131 item 5b: an ARM64_RELOC_ADDEND entry supplies the addend for
+    /// the relocation that follows it; it is not itself a relocation.
+    #[test]
+    fn test_macho_addend_reloc_pairs_with_next() {
+        let obj_bytes = build_test_macho(
+            &[TestMachoSection {
+                sectname: "__text",
+                segname: "__TEXT",
+                addr: 0,
+                data: vec![0u8; 8],
+                relocs: vec![
+                    // ADDEND +0x14 followed by BRANCH26 against symbol 0
+                    (0, macho_r_info(0x14, false, 2, false, ARM64_RELOC_ADDEND)),
+                    (0, macho_r_info(0, true, 2, true, ARM64_RELOC_BRANCH26)),
+                    // ADDEND -8 (sign-extended 24-bit) + PAGE21
+                    (
+                        4,
+                        macho_r_info(0x00FF_FFF8, false, 2, false, ARM64_RELOC_ADDEND),
+                    ),
+                    (4, macho_r_info(0, true, 2, true, ARM64_RELOC_PAGE21)),
+                ],
+            }],
+            &[TestMachoSymbol {
+                name: "_foo",
+                n_type: N_EXT | N_UNDF,
+                n_sect: 0,
+                n_value: 0,
+            }],
+        );
+
+        let obj = ObjectFile::parse(&obj_bytes).expect("parse");
+        let relocs = &obj.sections[0].relocations;
+        assert_eq!(relocs.len(), 2, "ADDEND entries are not relocations");
+        assert_eq!(relocs[0].rel_type, RelocationType::Call26);
+        assert_eq!(relocs[0].addend, 0x14);
+        assert_eq!(relocs[1].rel_type, RelocationType::AdrpPage21);
+        assert_eq!(relocs[1].addend, -8, "24-bit addend must be sign-extended");
+    }
+
+    /// RUE-131 item 5c: a non-extern relocation against a section with no
+    /// symbol at offset 0 used to fail with "no function symbol found". The
+    /// parser now synthesizes a local section anchor, and (item 5b) re-bases
+    /// the embedded target address onto it.
+    #[test]
+    fn test_macho_non_extern_unsigned_synthesizes_anchor() {
+        // __cstring lives at addr 0x10 in the object's VM layout; the pointer
+        // slot holds the address of byte 3 within it (0x13).
+        let mut slot = vec![0u8; 8];
+        slot[0] = 0x13;
+        let obj_bytes = build_test_macho(
+            &[
+                TestMachoSection {
+                    sectname: "__const",
+                    segname: "__TEXT",
+                    addr: 0,
+                    data: slot,
+                    // non-extern UNSIGNED against section 2 (__cstring)
+                    relocs: vec![(0, macho_r_info(2, false, 3, false, ARM64_RELOC_UNSIGNED))],
+                },
+                TestMachoSection {
+                    sectname: "__cstring",
+                    segname: "__TEXT",
+                    addr: 0x10,
+                    data: b"hi there".to_vec(),
+                    relocs: vec![],
+                },
+            ],
+            // No symbol at offset 0 of __cstring at all
+            &[TestMachoSymbol {
+                name: "_main",
+                n_type: N_EXT | N_SECT,
+                n_sect: 1,
+                n_value: 0,
+            }],
+        );
+
+        let obj = ObjectFile::parse(&obj_bytes).expect("parse must not require a Global at 0");
+        let relocs = &obj.sections[0].relocations;
+        assert_eq!(relocs.len(), 1);
+        let anchor = &obj.symbols[relocs[0].symbol_index];
+        assert_eq!(anchor.section_index, Some(1), "anchor must be in __cstring");
+        assert_eq!(anchor.value, 0);
+        assert_eq!(anchor.binding, SymbolBinding::Local);
+        assert_eq!(
+            relocs[0].addend, 3,
+            "embedded target address must be re-based onto the section anchor"
+        );
+    }
+
+    /// Mach-O n_value is an address in the object's VM layout, not a
+    /// section-relative offset; the parser must subtract the section's addr.
+    #[test]
+    fn test_macho_symbol_value_normalized_to_section_offset() {
+        let obj_bytes = build_test_macho(
+            &[
+                TestMachoSection {
+                    sectname: "__text",
+                    segname: "__TEXT",
+                    addr: 0,
+                    data: vec![0u8; 16],
+                    relocs: vec![],
+                },
+                TestMachoSection {
+                    sectname: "__cstring",
+                    segname: "__TEXT",
+                    addr: 0x10,
+                    data: vec![0u8; 8],
+                    relocs: vec![],
+                },
+            ],
+            &[
+                TestMachoSymbol {
+                    name: "_main",
+                    n_type: N_EXT | N_SECT,
+                    n_sect: 1,
+                    n_value: 4, // 4 into __text (addr 0)
+                },
+                TestMachoSymbol {
+                    name: "_str",
+                    n_type: N_SECT, // local
+                    n_sect: 2,
+                    n_value: 0x10 + 5, // 5 into __cstring (addr 0x10)
+                },
+            ],
+        );
+
+        let obj = ObjectFile::parse(&obj_bytes).expect("parse");
+        let main = obj.find_symbol("main").expect("main");
+        assert_eq!(main.value, 4);
+        let s = obj.find_symbol("str").expect("str");
+        assert_eq!(
+            s.value, 5,
+            "n_value must be converted to a section-relative offset"
+        );
+        assert_eq!(s.binding, SymbolBinding::Local);
     }
 
     #[test]

--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -7,18 +7,18 @@ use std::collections::HashMap;
 use rue_target::Target;
 
 use crate::constants::{
-    ARM64_RELOC_BRANCH26, ARM64_RELOC_PAGE21, ARM64_RELOC_PAGEOFF12, ARM64_RELOC_UNSIGNED,
-    CPU_SUBTYPE_ARM64_ALL, CPU_TYPE_ARM64, ELF_MAGIC, ELF64_EHDR_SIZE, ELF64_SHDR_SIZE,
-    ELF64_SYM_SIZE, ELFCLASS64, ELFDATA2LSB, ET_REL, EV_CURRENT, LC_BUILD_VERSION, LC_DYSYMTAB,
-    LC_SEGMENT_64, LC_SYMTAB, MACHO64_BUILD_VERSION_CMD_SIZE, MACHO64_DYSYMTAB_CMD_SIZE,
-    MACHO64_HEADER_SIZE, MACHO64_NLIST_SIZE, MACHO64_RELOC_SIZE, MACHO64_SECTION_SIZE,
-    MACHO64_SEGMENT_CMD_SIZE, MACHO64_SYMTAB_CMD_SIZE, MH_MAGIC_64, MH_OBJECT, N_EXT, N_PEXT,
-    N_SECT, N_UNDF, PLATFORM_MACOS, R_AARCH64_ABS64, R_AARCH64_ADD_ABS_LO12_NC,
-    R_AARCH64_ADR_PREL_PG_HI21, R_AARCH64_CALL26, R_AARCH64_JUMP26, R_X86_64_32, R_X86_64_32S,
-    R_X86_64_64, R_X86_64_GOTPCREL, R_X86_64_GOTPCRELX, R_X86_64_PC32, R_X86_64_PLT32,
-    R_X86_64_REX_GOTPCRELX, S_ATTR_PURE_INSTRUCTIONS, S_ATTR_SOME_INSTRUCTIONS, SHF_ALLOC,
-    SHF_EXECINSTR, SHF_INFO_LINK, SHT_PROGBITS, SHT_RELA, SHT_STRTAB, SHT_SYMTAB, STB_GLOBAL,
-    STB_LOCAL, STT_FUNC, STT_NOTYPE, STT_SECTION, elf_st_info,
+    ARM64_RELOC_ADDEND, ARM64_RELOC_BRANCH26, ARM64_RELOC_PAGE21, ARM64_RELOC_PAGEOFF12,
+    ARM64_RELOC_UNSIGNED, CPU_SUBTYPE_ARM64_ALL, CPU_TYPE_ARM64, ELF_MAGIC, ELF64_EHDR_SIZE,
+    ELF64_SHDR_SIZE, ELF64_SYM_SIZE, ELFCLASS64, ELFDATA2LSB, ET_REL, EV_CURRENT, LC_BUILD_VERSION,
+    LC_DYSYMTAB, LC_SEGMENT_64, LC_SYMTAB, MACHO64_BUILD_VERSION_CMD_SIZE,
+    MACHO64_DYSYMTAB_CMD_SIZE, MACHO64_HEADER_SIZE, MACHO64_NLIST_SIZE, MACHO64_RELOC_SIZE,
+    MACHO64_SECTION_SIZE, MACHO64_SEGMENT_CMD_SIZE, MACHO64_SYMTAB_CMD_SIZE, MH_MAGIC_64,
+    MH_OBJECT, N_EXT, N_PEXT, N_SECT, N_UNDF, PLATFORM_MACOS, R_AARCH64_ABS64,
+    R_AARCH64_ADD_ABS_LO12_NC, R_AARCH64_ADR_PREL_PG_HI21, R_AARCH64_CALL26, R_AARCH64_JUMP26,
+    R_X86_64_32, R_X86_64_32S, R_X86_64_64, R_X86_64_GOTPCREL, R_X86_64_GOTPCRELX, R_X86_64_PC32,
+    R_X86_64_PLT32, R_X86_64_REX_GOTPCRELX, S_ATTR_PURE_INSTRUCTIONS, S_ATTR_SOME_INSTRUCTIONS,
+    SHF_ALLOC, SHF_EXECINSTR, SHF_INFO_LINK, SHT_PROGBITS, SHT_RELA, SHT_STRTAB, SHT_SYMTAB,
+    STB_GLOBAL, STB_LOCAL, STT_FUNC, STT_NOTYPE, STT_SECTION, elf_st_info,
 };
 
 /// ELF section layout with explicit indices.
@@ -577,6 +577,10 @@ impl ObjectBuilder {
             0
         };
         let rodata_size = rodata.len();
+        // Address of __rodata within the object's VM layout (__text is at
+        // addr 0). Symbol n_value fields are addresses in this layout per the
+        // Mach-O spec, so rodata symbols are written as rodata_addr + offset.
+        let rodata_addr = align_up(text_size, 8);
 
         // Text relocations follow text and rodata sections
         let text_reloc_offset = if has_rodata {
@@ -612,7 +616,12 @@ impl ObjectBuilder {
                 }
             })
             .collect();
-        let num_text_relocs = text_relocs.len();
+        // Mach-O ARM64 relocation entries have no addend field: a non-zero
+        // addend is carried by an extra ARM64_RELOC_ADDEND entry immediately
+        // preceding the relocation it modifies. (Addends used to be silently
+        // dropped here; the parser side ignored them too — RUE-131 item 5b.)
+        let num_addend_entries = text_relocs.iter().filter(|r| r.addend != 0).count();
+        let num_text_relocs = text_relocs.len() + num_addend_entries;
 
         // On macOS, all external C symbols get a leading underscore prefix.
         // This applies to ALL symbols, regardless of their original name.
@@ -759,7 +768,7 @@ impl ObjectBuilder {
             segname[..6].copy_from_slice(b"__TEXT");
             macho.extend_from_slice(&segname);
 
-            macho.extend_from_slice(&(text_size as u64).to_le_bytes()); // addr (follows text)
+            macho.extend_from_slice(&(rodata_addr as u64).to_le_bytes()); // addr (follows text, 8-aligned)
             macho.extend_from_slice(&(rodata_size as u64).to_le_bytes()); // size
             macho.extend_from_slice(&(rodata_offset as u32).to_le_bytes()); // offset
             macho.extend_from_slice(&3_u32.to_le_bytes()); // align (2^3 = 8 byte alignment)
@@ -878,6 +887,22 @@ impl ObjectBuilder {
                 }
             };
 
+            // A non-zero addend is emitted as an ARM64_RELOC_ADDEND entry
+            // immediately preceding the relocation it modifies (Mach-O ARM64
+            // relocation entries have no addend field of their own).
+            if reloc.addend != 0 {
+                assert!(
+                    (-(1 << 23)..(1 << 23)).contains(&reloc.addend),
+                    "ARM64_RELOC_ADDEND only encodes signed 24-bit addends, got {}",
+                    reloc.addend
+                );
+                macho.extend_from_slice(&(reloc.offset as u32).to_le_bytes());
+                let addend_info: u32 = ((reloc.addend as u32) & 0x00FFFFFF)  // r_symbolnum = addend
+                    | (2 << 25)  // r_length (unused for ADDEND, match the reloc)
+                    | (ARM64_RELOC_ADDEND << 28);
+                macho.extend_from_slice(&addend_info.to_le_bytes());
+            }
+
             // r_address (4 bytes)
             macho.extend_from_slice(&(reloc.offset as u32).to_le_bytes());
 
@@ -924,7 +949,7 @@ impl ObjectBuilder {
         macho.push(N_EXT | N_SECT); // n_type: external, defined in section
         macho.push(1); // n_sect: section 1 (__text)
         macho.extend_from_slice(&0_u16.to_le_bytes()); // n_desc
-        macho.extend_from_slice(&0_u64.to_le_bytes()); // n_value (offset in section)
+        macho.extend_from_slice(&0_u64.to_le_bytes()); // n_value (function start; __text is at addr 0)
 
         // Symbols 1..N: String constant symbols (private external, defined in rodata section)
         // Note: We mark these as N_PEXT | N_EXT because ARM64_RELOC_PAGE21/PAGEOFF12
@@ -946,10 +971,13 @@ impl ObjectBuilder {
                 macho.push(0); // Should not happen, but defensive
             }
             macho.extend_from_slice(&0_u16.to_le_bytes()); // n_desc
-            // n_value is the offset within the section (not a VM address!)
-            // For relocatable object files, n_value is relative to the section start
-            let section_offset = string_offsets[i] as u64;
-            macho.extend_from_slice(&section_offset.to_le_bytes());
+            // n_value is an address within the object's VM layout (section
+            // addr + offset), per the Mach-O spec — the same convention
+            // rustc/clang objects use, and what our parser normalizes away.
+            // (This used to write the bare section offset, which only worked
+            // because the parser made the matching mistake.)
+            let value = (rodata_addr + string_offsets[i]) as u64;
+            macho.extend_from_slice(&value.to_le_bytes());
             sym_name_idx += 1;
         }
 
@@ -1401,6 +1429,55 @@ mod tests {
 
         // Check Mach-O magic
         assert_eq!(&obj[0..4], &0xFEEDFACF_u32.to_le_bytes());
+    }
+
+    /// RUE-131 item 5b: non-zero addends must round-trip through the Mach-O
+    /// object format (emitted as ARM64_RELOC_ADDEND entries, re-attached by
+    /// the parser). They used to be silently dropped on emit AND hardcoded to
+    /// zero on parse.
+    #[test]
+    fn test_macho_addend_roundtrip() {
+        let obj_bytes = ObjectBuilder::new(Target::Aarch64Macos, "main")
+            .code(vec![
+                0x00, 0x00, 0x00, 0x90, // adrp x0, <page>
+                0x00, 0x00, 0x00, 0x91, // add x0, x0, <offset>
+                0x00, 0x00, 0x00, 0x94, // bl other
+                0xC0, 0x03, 0x5F, 0xD6, // ret
+            ])
+            .relocation(CodeRelocation {
+                offset: 0,
+                symbol: "data".into(),
+                rel_type: RelocationType::AdrpPage21,
+                addend: 16,
+            })
+            .relocation(CodeRelocation {
+                offset: 4,
+                symbol: "data".into(),
+                rel_type: RelocationType::AddLo12,
+                addend: 16,
+            })
+            .relocation(CodeRelocation {
+                offset: 8,
+                symbol: "other".into(),
+                rel_type: RelocationType::Call26,
+                addend: 0, // no ADDEND entry for this one
+            })
+            .build();
+
+        let obj = ObjectFile::parse(&obj_bytes).expect("parse emitted Mach-O");
+        let text_idx = obj.section_map["__TEXT,__text"];
+        let relocs = &obj.sections[text_idx].relocations;
+        assert_eq!(
+            relocs.len(),
+            3,
+            "ADDEND entries must not surface as relocations"
+        );
+        assert_eq!(relocs[0].rel_type, RelocationType::AdrpPage21);
+        assert_eq!(relocs[0].addend, 16);
+        assert_eq!(relocs[1].rel_type, RelocationType::AddLo12);
+        assert_eq!(relocs[1].addend, 16);
+        assert_eq!(relocs[2].rel_type, RelocationType::Call26);
+        assert_eq!(relocs[2].addend, 0);
     }
 
     /// Test recursive self-calls (function calling itself).

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -29,18 +29,53 @@ enum PatchHome {
     Data,
 }
 
-/// A relocation waiting to be applied once all section addresses are known:
-/// (patch offset within its home buffer, symbol name, symbol's section,
-/// object index, relocation type, addend, patch home).
-type PendingRelocation = (
-    u64,
-    String,
-    Option<usize>,
-    usize,
-    RelocationType,
-    i64,
-    PatchHome,
-);
+/// Is this a code section? Accepts both ELF (`.text*`) and Mach-O
+/// (`__TEXT,__text` / `__text*`) names.
+fn is_text_section(name: &str) -> bool {
+    name.starts_with(".text") || name == "__TEXT,__text" || name.starts_with("__text")
+}
+
+/// Is this a read-only data section? Accepts both ELF and Mach-O names.
+fn is_rodata_section(name: &str) -> bool {
+    name.starts_with(".rodata")
+        || name == "__DATA,__const"
+        || name == "__TEXT,__const"
+        || name == "__TEXT,__cstring"
+        || name == "__TEXT,__rodata"
+        || name.starts_with("__const")
+        || name.starts_with(".cstring")
+}
+
+/// Is this a writable data section? Accepts both ELF and Mach-O names.
+fn is_data_section(name: &str) -> bool {
+    name.starts_with(".data") || name == "__DATA,__data" || name.starts_with("__data")
+}
+
+/// Is this a zero-initialized (bss) section? Accepts both ELF and Mach-O names.
+fn is_bss_section(name: &str) -> bool {
+    name.starts_with(".bss") || name == "__DATA,__bss" || name.starts_with("__bss")
+}
+
+/// A relocation waiting to be applied once all section addresses are known.
+struct PendingRelocation {
+    /// Patch offset within the home buffer.
+    offset: u64,
+    /// Name of the referenced symbol.
+    sym_name: String,
+    /// Section the referenced symbol is defined in (None if undefined).
+    sym_section: Option<usize>,
+    /// Binding of the referenced symbol. LOCAL symbols must resolve within
+    /// their own object — resolving them by name across all objects lets
+    /// same-named locals in different objects shadow each other.
+    /// (RUE-131 item 2)
+    sym_binding: SymbolBinding,
+    /// Index of the object the relocation (and any local symbol) lives in.
+    obj_idx: usize,
+    rel_type: RelocationType,
+    addend: i64,
+    /// Which merged buffer the patch site lives in.
+    home: PatchHome,
+}
 
 /// Collect a merged section's relocations into `pending`, validating symbol
 /// indices and skipping null-symbol relocations and relocations against
@@ -69,32 +104,59 @@ fn collect_section_relocations(
             continue;
         }
 
-        // We link .text, .rodata, .data, and .bss; skip relocations whose
+        // We link text, rodata, data, and bss; skip relocations whose
         // TARGET symbol lives in a section we don't link (e.g. debug).
         if let Some(sec_idx) = sym.section_index {
             if sec_idx < obj.sections.len() {
                 let target_sec = &obj.sections[sec_idx];
-                if !target_sec.name.starts_with(".text")
-                    && !target_sec.name.starts_with(".rodata")
-                    && !target_sec.name.starts_with(".data")
-                    && !target_sec.name.starts_with(".bss")
+                if !is_text_section(&target_sec.name)
+                    && !is_rodata_section(&target_sec.name)
+                    && !is_data_section(&target_sec.name)
+                    && !is_bss_section(&target_sec.name)
                 {
                     continue;
                 }
             }
         }
 
-        pending.push((
-            merged_offset + reloc.offset,
-            sym.name.clone(),
-            sym.section_index,
+        pending.push(PendingRelocation {
+            offset: merged_offset + reloc.offset,
+            sym_name: sym.name.clone(),
+            sym_section: sym.section_index,
+            sym_binding: sym.binding,
             obj_idx,
-            reloc.rel_type,
-            reloc.addend,
+            rel_type: reloc.rel_type,
+            addend: reloc.addend,
             home,
-        ));
+        });
     }
     Ok(())
+}
+
+/// Final symbol addresses, split by binding scope.
+///
+/// Global (and weak) symbols are visible across all objects and keyed by
+/// name. LOCAL symbols (including section symbols and compiler-generated
+/// constants like `l_anon.*` / `.rodata.str*`) are only visible within their
+/// defining object, so they are keyed by `(object index, name)` — a single
+/// name-keyed map let same-named locals from different objects shadow each
+/// other, binding every reference to whichever object happened to win.
+/// (RUE-131 item 2)
+#[derive(Default)]
+struct SymbolAddresses {
+    globals: HashMap<String, u64>,
+    locals: HashMap<(usize, String), u64>,
+}
+
+impl SymbolAddresses {
+    /// Resolve a relocation's symbol reference: locals within the referencing
+    /// object only, globals/weaks by name.
+    fn resolve(&self, obj_idx: usize, name: &str, binding: SymbolBinding) -> Option<u64> {
+        match binding {
+            SymbolBinding::Local => self.locals.get(&(obj_idx, name.to_string())).copied(),
+            SymbolBinding::Global | SymbolBinding::Weak => self.globals.get(name).copied(),
+        }
+    }
 }
 
 /// Linker errors.
@@ -423,34 +485,7 @@ impl Linker {
     /// after ad-hoc code signing with `codesign -s - <binary>`.
     fn link_macho(self, entry_point: &str) -> Result<Vec<u8>, LinkError> {
         use crate::constants::{VM_PROT_EXECUTE, VM_PROT_READ};
-        use crate::elf::RelocationType;
-        use crate::macho::{MachOBuilder, PAGE_SIZE, Section64, Segment64, VM_BASE};
-
-        // Helper to check if a section is a text section
-        fn is_text_section(name: &str) -> bool {
-            name.starts_with(".text") || name == "__TEXT,__text" || name.starts_with("__text")
-        }
-
-        // Helper to check if a section is a rodata section
-        fn is_rodata_section(name: &str) -> bool {
-            name.starts_with(".rodata")
-                || name == "__DATA,__const"
-                || name == "__TEXT,__const"
-                || name == "__TEXT,__cstring"
-                || name == "__TEXT,__rodata"
-                || name.starts_with("__const")
-                || name.starts_with(".cstring")
-        }
-
-        // Helper to check if a section is a data section
-        fn is_data_section(name: &str) -> bool {
-            name.starts_with(".data") || name == "__DATA,__data" || name.starts_with("__data")
-        }
-
-        // Helper to check if a section is a bss section
-        fn is_bss_section(name: &str) -> bool {
-            name.starts_with(".bss") || name == "__DATA,__bss" || name.starts_with("__bss")
-        }
+        use crate::macho::{MachOBuilder, Section64, Segment64, VM_BASE};
 
         // Merge sections and collect relocations
         // For Mach-O, we put code AND rodata in the __TEXT segment (same as clang/ld64).
@@ -459,10 +494,9 @@ impl Linker {
         let mut merged_data = Vec::new(); // Writable data (goes in __DATA)
         let mut bss_size: u64 = 0;
         let mut section_offsets: HashMap<(usize, usize), u64> = HashMap::new();
-        let mut pending_relocations: Vec<(u64, String, Option<usize>, usize, RelocationType, i64)> =
-            Vec::new();
+        let mut pending_relocations: Vec<PendingRelocation> = Vec::new();
 
-        // Merge code sections (.text*)
+        // Merge code sections (.text* / __text)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for (sec_idx, section) in obj.sections.iter().enumerate() {
                 if !is_text_section(&section.name) || section.data.is_empty() {
@@ -487,64 +521,30 @@ impl Linker {
                 section_offsets.insert((obj_idx, sec_idx), offset);
                 merged_text.extend_from_slice(&section.data);
 
-                // Collect relocations for this section
-                for reloc in &section.relocations {
-                    // Validate symbol index
-                    if reloc.symbol_index >= obj.symbols.len() {
-                        return Err(LinkError::InvalidSymbolIndex {
-                            symbol_index: reloc.symbol_index,
-                            symbol_count: obj.symbols.len(),
-                        });
-                    }
-                    let sym = &obj.symbols[reloc.symbol_index];
-
-                    // Skip relocations that reference the null symbol (empty name)
-                    // Note: In Mach-O, symbol 0 is the function symbol, not null!
-                    if sym.name.is_empty() {
-                        continue;
-                    }
-
-                    // Skip relocations to debug/unwinding sections
-                    if let Some(sec_idx) = sym.section_index {
-                        if sec_idx < obj.sections.len() {
-                            let target_sec = &obj.sections[sec_idx];
-                            if !is_text_section(&target_sec.name)
-                                && !is_rodata_section(&target_sec.name)
-                                && !is_data_section(&target_sec.name)
-                                && !is_bss_section(&target_sec.name)
-                            {
-                                // Symbol is in a section we don't link
-                                continue;
-                            }
-                        }
-                    }
-
-                    pending_relocations.push((
-                        offset + reloc.offset,
-                        sym.name.clone(),
-                        sym.section_index,
-                        obj_idx,
-                        reloc.rel_type,
-                        reloc.addend,
-                    ));
-                }
+                collect_section_relocations(
+                    obj,
+                    section,
+                    offset,
+                    obj_idx,
+                    PatchHome::Text,
+                    &mut pending_relocations,
+                )?;
             }
         }
 
-        // Merge rodata sections directly into __TEXT (after code)
-        // This keeps rodata addresses close to code for PC-relative addressing
+        // Merge rodata sections directly into __TEXT (after code).
+        // This keeps rodata addresses close to code for PC-relative addressing.
+        // Patch sites in rodata live in the merged text buffer, so their home
+        // is Text. Rodata relocations used to not be collected at all on the
+        // Mach-O path, leaving e.g. pointer tables in rodata null.
+        // (RUE-131 items 8 and 11)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for (sec_idx, section) in obj.sections.iter().enumerate() {
-                tracing::trace!(section = %section.name, "checking section for rodata");
                 if !is_rodata_section(&section.name) {
                     continue;
                 }
-                tracing::trace!(
-                    section = %section.name,
-                    size = section.data.len(),
-                    merged_text_before = merged_text.len(),
-                    "merging rodata section"
-                );
+                // Note: empty sections are kept because they may still have
+                // symbols at offset 0 (e.g., empty strings) that need addresses.
 
                 // Align rodata (8-byte alignment is common for data)
                 let align = section.align.max(8);
@@ -554,14 +554,21 @@ impl Linker {
                 let offset = merged_text.len() as u64;
                 section_offsets.insert((obj_idx, sec_idx), offset);
                 merged_text.extend_from_slice(&section.data);
-                tracing::trace!(
-                    merged_text_after = merged_text.len(),
-                    "merged rodata section"
-                );
+
+                collect_section_relocations(
+                    obj,
+                    section,
+                    offset,
+                    obj_idx,
+                    PatchHome::Text,
+                    &mut pending_relocations,
+                )?;
             }
         }
 
-        // Merge data sections
+        // Merge data sections (their patch sites live in the merged data
+        // buffer — patching them against merged_text bounds/contents was
+        // RUE-131 item 8; the ELF side got the same fix via PatchHome in #928)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for (sec_idx, section) in obj.sections.iter().enumerate() {
                 if !is_data_section(&section.name) || section.data.is_empty() {
@@ -575,11 +582,19 @@ impl Linker {
                 let offset = merged_data.len() as u64;
                 section_offsets.insert((obj_idx, sec_idx), offset);
                 merged_data.extend_from_slice(&section.data);
+
+                collect_section_relocations(
+                    obj,
+                    section,
+                    offset,
+                    obj_idx,
+                    PatchHome::Data,
+                    &mut pending_relocations,
+                )?;
             }
         }
 
         // Handle bss sections
-        let bss_offset_in_data = merged_data.len() as u64;
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for (sec_idx, section) in obj.sections.iter().enumerate() {
                 if !is_bss_section(&section.name) {
@@ -596,26 +611,32 @@ impl Linker {
             }
         }
 
-        // Calculate virtual addresses
-        // The MachOBuilder will place:
-        // - __TEXT at VM_BASE, code+rodata starts at text_file_offset within it
-        // - __DATA at VM_BASE + PAGE_SIZE (if writable data exists)
-        //
-        // Since rodata is now part of __TEXT (merged_text), all text/rodata symbols
-        // get addresses as offsets within merged_text.
+        // Compute the final file/VM layout BEFORE placing symbols, using the
+        // same single-source-of-truth computation build_dynamic() uses. The
+        // data segment address used to be hardcoded to VM_BASE + PAGE_SIZE
+        // here, which went stale the moment __TEXT outgrew one page —
+        // the unified layout places __DATA wherever __TEXT actually ends.
+        // (RUE-131 items 3 and 8)
+        let mut layout_builder = MachOBuilder::new()
+            .with_code(merged_text.clone(), 0) // only the length matters for layout
+            .with_data(merged_data.clone())
+            .with_bss(bss_size);
+        layout_builder.add_segment(Segment64::pagezero());
+        let mut text_segment =
+            Segment64::new("__TEXT").with_protection(VM_PROT_READ | VM_PROT_EXECUTE);
+        text_segment.add_section(Section64::new("__text", "__TEXT").with_code_flags());
+        layout_builder.add_segment(text_segment);
+        // build_dynamic adds __LINKEDIT itself; adding it here keeps this
+        // builder's command sizes identical (compute_dynamic_layout counts it
+        // either way).
+        layout_builder.add_segment(Segment64::new("__LINKEDIT").with_protection(VM_PROT_READ));
+        let layout = layout_builder.dynamic_layout();
 
-        // Only writable data goes in __DATA
-        let has_writable_data = !merged_data.is_empty() || bss_size > 0;
-
-        // Calculate data segment virtual address (if present)
-        let data_vaddr = if has_writable_data {
-            VM_BASE + PAGE_SIZE // __DATA starts at second page
-        } else {
-            0
-        };
-
-        // Calculate offsets within data segment (data, then bss)
-        let data_offset_in_data = 0u64;
+        let text_file_offset = layout.text_file_offset as u64;
+        // Code+rodata are mapped at this virtual address
+        let text_vaddr = VM_BASE + text_file_offset;
+        // __DATA segment virtual address (0 if there is no writable data)
+        let data_vaddr = layout.data_vm_addr;
         // bss begins right after the (8-aligned) initialized data within the
         // __DATA segment. The old formula also added bss_offset_in_data —
         // which IS merged_data.len() — double-counting the data length, so
@@ -625,11 +646,16 @@ impl Linker {
         } else {
             0
         };
+        tracing::trace!(
+            text_file_offset = format_args!("0x{text_file_offset:x}"),
+            data_vaddr = format_args!("0x{data_vaddr:x}"),
+            "calculated Mach-O layout"
+        );
 
-        // Build symbol table mapping: name -> address
-        // For text/rodata symbols (in merged_text): store offset within merged_text
-        // For data/bss symbols (in __DATA): store absolute virtual address
-        let mut symbol_addresses: HashMap<String, u64> = HashMap::new();
+        // Build symbol table mapping: name -> final virtual address.
+        // Globals by name; locals by (object, name) so same-named locals in
+        // different objects can't shadow each other (RUE-131 item 2).
+        let mut symbol_addresses = SymbolAddresses::default();
 
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for sym in &obj.symbols {
@@ -646,136 +672,154 @@ impl Linker {
                         let addr =
                             if is_text_section(&section.name) || is_rodata_section(&section.name) {
                                 // Text and rodata are both in merged_text
-                                // Store offset (will be converted to vaddr during relocation)
-                                section_offset + sym.value
+                                text_vaddr + section_offset + sym.value
                             } else if is_data_section(&section.name) {
                                 // Writable data in __DATA segment
-                                data_vaddr + data_offset_in_data + section_offset + sym.value
+                                data_vaddr + section_offset + sym.value
                             } else if is_bss_section(&section.name) {
                                 bss_vaddr + section_offset + sym.value
                             } else {
                                 continue;
                             };
 
-                        // Prefer global symbols over local ones
-                        if sym.binding == SymbolBinding::Global
-                            || sym.binding == SymbolBinding::Weak
-                            || !symbol_addresses.contains_key(&sym.name)
-                        {
-                            // Debug: log function symbols
-                            if !sym.name.starts_with("l_anon")
-                                && !sym.name.starts_with(".rodata")
-                                && !sym.name.starts_with("__rue")
-                            {
-                                tracing::trace!(
-                                    symbol = %sym.name,
-                                    binding = ?sym.binding,
-                                    addr = format_args!("0x{addr:x}"),
-                                    "adding symbol"
-                                );
+                        match sym.binding {
+                            SymbolBinding::Local => {
+                                symbol_addresses
+                                    .locals
+                                    .insert((obj_idx, sym.name.clone()), addr);
                             }
-                            symbol_addresses.insert(sym.name.clone(), addr);
+                            SymbolBinding::Global | SymbolBinding::Weak => {
+                                // Honor the winner chosen in add_object for
+                                // duplicate weak definitions.
+                                let winner = self
+                                    .global_symbols
+                                    .get(&sym.name)
+                                    .map(|(winning_obj, _)| *winning_obj);
+                                if winner.is_none() || winner == Some(obj_idx) {
+                                    symbol_addresses.globals.insert(sym.name.clone(), addr);
+                                }
+                            }
                         }
                     }
                 }
             }
         }
 
-        // We need to calculate text_file_offset before applying relocations.
-        // Build the MachOBuilder structure (without building the binary yet) to calculate
-        // the offset where code will start in the final binary.
-        let mut builder = MachOBuilder::new()
-            .with_code(vec![], 0) // Temporary, will be replaced with relocated code
-            .with_data(merged_data.clone())
-            .with_bss(bss_size);
-
-        // Add __PAGEZERO segment (catches null pointer dereferences)
-        builder.add_segment(Segment64::pagezero());
-
-        // Add __TEXT segment with __text section
-        let mut text_segment =
-            Segment64::new("__TEXT").with_protection(VM_PROT_READ | VM_PROT_EXECUTE);
-        let text_section = Section64::new("__text", "__TEXT").with_code_flags();
-        text_segment.add_section(text_section);
-        builder.add_segment(text_segment);
-
-        // Add __LINKEDIT segment (build_dynamic adds this, so we need it for accurate calculation)
-        builder.add_segment(Segment64::new("__LINKEDIT").with_protection(VM_PROT_READ));
-
-        // Calculate text_file_offset using the builder
-        let text_file_offset = builder.calculate_text_file_offset_for_dynamic();
-        tracing::trace!(
-            text_file_offset = format_args!("0x{text_file_offset:x}"),
-            "calculated text file offset"
-        );
+        // Find entry point (always a global symbol).
+        // On macOS, symbols have underscore prefix, so try both with and without.
+        let entry_vaddr = symbol_addresses
+            .globals
+            .get(entry_point)
+            .or_else(|| symbol_addresses.globals.get(&format!("_{}", entry_point)))
+            .copied()
+            .ok_or_else(|| LinkError::UndefinedSymbol(entry_point.to_string()))?;
+        let entry_offset = entry_vaddr - text_vaddr;
 
         // Apply relocations
-        for (patch_offset, sym_name, sym_section, _obj_idx, rel_type, addend) in pending_relocations
+        for PendingRelocation {
+            offset: patch_offset,
+            sym_name,
+            sym_section,
+            sym_binding,
+            obj_idx,
+            rel_type,
+            addend,
+            home,
+        } in pending_relocations
         {
-            // Debug: log function call relocations
-            if matches!(rel_type, RelocationType::Call26)
-                && !sym_name.starts_with("__rue")
-                && !sym_name.starts_with("l_anon")
-            {
-                tracing::trace!(symbol = %sym_name, "processing Call26 relocation");
-            }
+            // Pick the buffer the patch site lives in and its base vaddr.
+            // (PatchHome::Rodata is unused here: Mach-O merges rodata into
+            // the text buffer.)
+            let (buf, base_vaddr): (&mut Vec<u8>, u64) = match home {
+                PatchHome::Text => (&mut merged_text, text_vaddr),
+                PatchHome::Rodata => unreachable!("Mach-O rodata is merged into the text buffer"),
+                PatchHome::Data => (&mut merged_data, data_vaddr),
+            };
 
-            // Look up symbol address
-            // For dynamic executables, undefined symbols (external symbols from libSystem, etc.)
-            // will be resolved by dyld at runtime. Skip relocations for external symbols.
-            let sym_addr = match symbol_addresses.get(&sym_name).copied() {
-                Some(addr) => addr,
-                None => {
-                    // External symbol - skip relocation, dyld will handle it at runtime
-                    // Note: This works for dynamic executables linked with libSystem
-                    if matches!(rel_type, RelocationType::Call26)
-                        && !sym_name.starts_with("__rue")
-                        && !sym_name.starts_with("l_anon")
-                    {
-                        tracing::trace!(
-                            symbol = %sym_name,
-                            "symbol not found in symbol_addresses, skipping relocation"
-                        );
+            // Resolve the symbol (locals only within their own object), with
+            // the same fallbacks as the ELF path: the symbol's own section,
+            // then 0 for undefined weaks. An unresolved symbol is an ERROR —
+            // it used to be silently skipped on the theory that dyld would
+            // bind it at runtime, but we emit no binding info (nsyms = 0), so
+            // the unpatched instruction was just garbage at runtime.
+            // (RUE-131 item 7)
+            let target_vaddr =
+                if let Some(addr) = symbol_addresses.resolve(obj_idx, &sym_name, sym_binding) {
+                    addr
+                } else if let Some(sec_idx) = sym_section {
+                    // Section-relative symbol - resolve via the section's address
+                    let obj = &self.objects[obj_idx];
+                    if sec_idx >= obj.sections.len() {
+                        return Err(LinkError::InvalidSectionIndex {
+                            symbol: sym_name.clone(),
+                            section_index: sec_idx,
+                            section_count: obj.sections.len(),
+                        });
                     }
-                    continue;
+                    let section = &obj.sections[sec_idx];
+                    if let Some(&sec_offset) = section_offsets.get(&(obj_idx, sec_idx)) {
+                        if is_text_section(&section.name) || is_rodata_section(&section.name) {
+                            text_vaddr + sec_offset
+                        } else if is_data_section(&section.name) {
+                            data_vaddr + sec_offset
+                        } else if is_bss_section(&section.name) {
+                            bss_vaddr + sec_offset
+                        } else {
+                            return Err(LinkError::UndefinedSymbol(format!(
+                                "{} (in section '{}')",
+                                sym_name, section.name
+                            )));
+                        }
+                    } else {
+                        return Err(LinkError::UndefinedSymbol(format!(
+                            "{} (section {} not in section_offsets)",
+                            sym_name, sec_idx
+                        )));
+                    }
+                } else if sym_binding == SymbolBinding::Weak {
+                    // An undefined WEAK symbol resolves to address 0 (RUE-131 item 9)
+                    0
+                } else {
+                    return Err(LinkError::UndefinedSymbol(format!(
+                        "{} (no section, rel_type={:?})",
+                        sym_name, rel_type
+                    )));
+                };
+
+            let patch_vaddr = base_vaddr + patch_offset;
+            let patch_idx = patch_offset as usize;
+
+            tracing::trace!(
+                symbol = %sym_name,
+                patch_offset = format_args!("0x{patch_offset:x}"),
+                rel_type = ?rel_type,
+                target_vaddr = format_args!("0x{target_vaddr:x}"),
+                patch_vaddr = format_args!("0x{patch_vaddr:x}"),
+                addend,
+                "relocating symbol"
+            );
+
+            // Bounds-check the patch site against ITS OWN buffer — the old
+            // code indexed merged_text unconditionally. (RUE-131 item 8)
+            let check_bounds = |size: usize| -> Result<(), LinkError> {
+                if patch_idx + size > buf.len() {
+                    return Err(LinkError::RelocationPatchOutOfBounds {
+                        patch_offset: patch_idx,
+                        patch_size: size,
+                        section_size: buf.len(),
+                        rel_type: format!("{:?}", rel_type),
+                    });
                 }
+                Ok(())
             };
-
-            // Calculate virtual addresses
-            let patch_vaddr = VM_BASE + text_file_offset + patch_offset;
-            // Text symbols are stored as offsets (< VM_BASE), data symbols as virtual addresses (>= VM_BASE)
-            let target_vaddr = if sym_addr < VM_BASE {
-                // Text symbol - convert offset to vaddr
-                VM_BASE + text_file_offset + sym_addr
-            } else {
-                // Data symbol - already a vaddr
-                sym_addr
-            };
-
-            if sym_name.contains("div_by_zero")
-                || sym_name.contains("l_anon")
-                || sym_name == "rec"
-                || sym_name == "other"
-                || sym_name == "main"
-            {
-                tracing::trace!(
-                    symbol = %sym_name,
-                    patch_offset = format_args!("0x{patch_offset:x}"),
-                    rel_type = ?rel_type,
-                    sym_addr = format_args!("0x{sym_addr:x}"),
-                    target_vaddr = format_args!("0x{target_vaddr:x}"),
-                    patch_vaddr = format_args!("0x{patch_vaddr:x}"),
-                    addend,
-                    "relocating symbol"
-                );
-            }
 
             // Apply the relocation based on type
             match rel_type {
                 RelocationType::Call26 | RelocationType::Jump26 => {
                     // ARM64 branch instruction: imm26 * 4 gives PC-relative offset
-                    let offset_bytes = (target_vaddr as i64 - patch_vaddr as i64 + addend) as i32;
-                    let offset_words = offset_bytes / 4;
+                    check_bounds(4)?;
+                    let offset_bytes = target_vaddr as i64 - patch_vaddr as i64 + addend;
+                    let offset_words = offset_bytes >> 2;
 
                     // Check range: 26-bit signed field gives ±128MB range
                     if offset_words < -(1 << 25) || offset_words >= (1 << 25) {
@@ -786,27 +830,14 @@ impl Linker {
                     }
 
                     // Read existing instruction and patch imm26 field
-                    let patch_idx = patch_offset as usize;
-                    let mut insn = u32::from_le_bytes([
-                        merged_text[patch_idx],
-                        merged_text[patch_idx + 1],
-                        merged_text[patch_idx + 2],
-                        merged_text[patch_idx + 3],
-                    ]);
+                    let mut insn =
+                        u32::from_le_bytes(buf[patch_idx..patch_idx + 4].try_into().unwrap());
                     insn = (insn & 0xFC000000) | ((offset_words as u32) & 0x03FFFFFF);
-                    merged_text[patch_idx..patch_idx + 4].copy_from_slice(&insn.to_le_bytes());
-
-                    if sym_name == "rec" || sym_name == "other" || sym_name == "main" {
-                        tracing::trace!(
-                            offset_bytes,
-                            offset_words,
-                            final_insn = format_args!("0x{insn:08x}"),
-                            "patched branch instruction"
-                        );
-                    }
+                    buf[patch_idx..patch_idx + 4].copy_from_slice(&insn.to_le_bytes());
                 }
                 RelocationType::AdrpPage21 => {
                     // ADRP: load page address (bits 12-32 of PC-relative offset)
+                    check_bounds(4)?;
                     let target_page = (target_vaddr as i64 + addend) & !0xFFF;
                     let patch_page = patch_vaddr as i64 & !0xFFF;
                     let page_offset = (target_page - patch_page) >> 12;
@@ -820,33 +851,64 @@ impl Linker {
                     }
 
                     // Encode into ADRP instruction
-                    let patch_idx = patch_offset as usize;
-                    let mut insn = u32::from_le_bytes([
-                        merged_text[patch_idx],
-                        merged_text[patch_idx + 1],
-                        merged_text[patch_idx + 2],
-                        merged_text[patch_idx + 3],
-                    ]);
+                    let mut insn =
+                        u32::from_le_bytes(buf[patch_idx..patch_idx + 4].try_into().unwrap());
                     let imm = page_offset as u32 & 0x1FFFFF;
                     let immlo = imm & 0x3;
                     let immhi = (imm >> 2) & 0x7FFFF;
                     insn = (insn & 0x9F00001F) | (immlo << 29) | (immhi << 5);
-                    merged_text[patch_idx..patch_idx + 4].copy_from_slice(&insn.to_le_bytes());
+                    buf[patch_idx..patch_idx + 4].copy_from_slice(&insn.to_le_bytes());
                 }
                 RelocationType::AddLo12 => {
-                    // ADD/LDR: page offset (bits 0-11)
-                    let page_offset = ((target_vaddr as i64 + addend) & 0xFFF) as u32;
+                    // ARM64_RELOC_PAGEOFF12: low 12 bits of the target address,
+                    // encoded in the imm12 field (bits 10-21).
+                    check_bounds(4)?;
+                    let lo12 = ((target_vaddr as i64 + addend) & 0xFFF) as u32;
 
-                    // Encode into ADD instruction (imm12 at bits 10-21)
-                    let patch_idx = patch_offset as usize;
-                    let mut insn = u32::from_le_bytes([
-                        merged_text[patch_idx],
-                        merged_text[patch_idx + 1],
-                        merged_text[patch_idx + 2],
-                        merged_text[patch_idx + 3],
-                    ]);
-                    insn = (insn & 0xFFC003FF) | (page_offset << 10);
-                    merged_text[patch_idx..patch_idx + 4].copy_from_slice(&insn.to_le_bytes());
+                    let mut insn =
+                        u32::from_le_bytes(buf[patch_idx..patch_idx + 4].try_into().unwrap());
+
+                    // PAGEOFF12 applies to both ADD and load/store
+                    // instructions. For loads/stores the imm12 field is
+                    // SCALED by the access size encoded in the instruction —
+                    // writing the raw byte offset multiplies the effective
+                    // displacement by the access size at runtime.
+                    // (RUE-131 item 5a)
+                    let imm = if insn & 0x3B00_0000 == 0x3900_0000 {
+                        // Load/store register, unsigned immediate class:
+                        // scale = size bits [31:30]; 128-bit vector ops
+                        // (size == 0b00, V == 1, opc<1> == 1) scale by 16.
+                        let mut scale = insn >> 30;
+                        if scale == 0 && insn & 0x0480_0000 == 0x0480_0000 {
+                            scale = 4;
+                        }
+                        if lo12 & ((1u32 << scale) - 1) != 0 {
+                            return Err(LinkError::RelocationOverflow {
+                                symbol: sym_name,
+                                rel_type: format!(
+                                    "ARM64_RELOC_PAGEOFF12 (offset 0x{lo12:x} misaligned \
+                                     for {}-byte access)",
+                                    1u32 << scale
+                                ),
+                            });
+                        }
+                        lo12 >> scale
+                    } else {
+                        // ADD immediate: unscaled
+                        lo12
+                    };
+
+                    insn = (insn & 0xFFC003FF) | (imm << 10);
+                    buf[patch_idx..patch_idx + 4].copy_from_slice(&insn.to_le_bytes());
+                }
+                RelocationType::Aarch64Abs64 | RelocationType::Abs64 => {
+                    // ARM64_RELOC_UNSIGNED: 64-bit absolute address (pointer
+                    // slots in rodata/data). Previously unsupported on the
+                    // Mach-O path because rodata/data relocations were never
+                    // collected at all. (RUE-131 item 11)
+                    check_bounds(8)?;
+                    let value = (target_vaddr as i64 + addend) as u64;
+                    buf[patch_idx..patch_idx + 8].copy_from_slice(&value.to_le_bytes());
                 }
                 _ => {
                     return Err(LinkError::UnsupportedRelocation(format!("{:?}", rel_type)));
@@ -854,20 +916,12 @@ impl Linker {
             }
         }
 
-        // Find entry point
-        // On macOS, symbols have underscore prefix, so try both with and without
-        let entry_offset = symbol_addresses
-            .get(entry_point)
-            .or_else(|| symbol_addresses.get(&format!("_{}", entry_point)))
-            .copied()
-            .ok_or_else(|| LinkError::UndefinedSymbol(entry_point.to_string()))?;
-
-        // Now rebuild the MachOBuilder with the relocated code
-        // Note: rodata is already included in merged_text (code + rodata in __TEXT)
-        // Only pass writable data to __DATA segment
+        // Now build the binary with the relocated code.
+        // Note: rodata is already included in merged_text (code + rodata in __TEXT);
+        // only writable data goes to the __DATA segment.
         tracing::trace!(
             merged_text_size = format_args!("0x{:x}", merged_text.len()),
-            "rebuilding MachOBuilder with relocated code"
+            "building Mach-O with relocated code"
         );
         let mut builder = MachOBuilder::new()
             .with_code(merged_text, entry_offset)
@@ -1070,8 +1124,9 @@ impl Linker {
         // BSS follows data in memory
         let bss_vaddr = data_vaddr + bss_offset_in_data;
 
-        // Build final symbol addresses
-        let mut symbol_addresses: HashMap<String, u64> = HashMap::new();
+        // Build final symbol addresses: globals by name, locals by
+        // (object, name) so same-named locals can't shadow each other.
+        let mut symbol_addresses = SymbolAddresses::default();
 
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for sym in &obj.symbols {
@@ -1101,12 +1156,25 @@ impl Linker {
 
                         let addr = base + section_offset + sym.value;
 
-                        // Only add global symbols, or section symbols for relocation
-                        if sym.binding == SymbolBinding::Global
-                            || sym.binding == SymbolBinding::Weak
-                            || !symbol_addresses.contains_key(&sym.name)
-                        {
-                            symbol_addresses.insert(sym.name.clone(), addr);
+                        match sym.binding {
+                            SymbolBinding::Local => {
+                                symbol_addresses
+                                    .locals
+                                    .insert((obj_idx, sym.name.clone()), addr);
+                            }
+                            SymbolBinding::Global | SymbolBinding::Weak => {
+                                // For duplicate weak definitions the winner was
+                                // already chosen in add_object (first weak wins,
+                                // strong overrides); honor that choice here
+                                // instead of letting the last definition win.
+                                let winner = self
+                                    .global_symbols
+                                    .get(&sym.name)
+                                    .map(|(winning_obj, _)| *winning_obj);
+                                if winner.is_none() || winner == Some(obj_idx) {
+                                    symbol_addresses.globals.insert(sym.name.clone(), addr);
+                                }
+                            }
                         }
                     }
                 }
@@ -1115,7 +1183,8 @@ impl Linker {
 
         // Also add section symbols for text, rodata, data, and bss relocation
         // This is needed for internal calls within object files that reference section names
-        // (e.g., .text._ZN11rue_runtime4heap5alloc... for Rust runtime internal calls)
+        // (e.g., .text._ZN11rue_runtime4heap5alloc... for Rust runtime internal calls).
+        // Section symbols are local to their object, so key them per object.
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for (sec_idx, section) in obj.sections.iter().enumerate() {
                 if let Some(&offset) = section_offsets.get(&(obj_idx, sec_idx)) {
@@ -1131,18 +1200,31 @@ impl Linker {
                         continue;
                     };
                     // Use section name as fallback
-                    symbol_addresses.entry(section.name.clone()).or_insert(addr);
+                    symbol_addresses
+                        .locals
+                        .entry((obj_idx, section.name.clone()))
+                        .or_insert(addr);
                 }
             }
         }
 
-        // Find entry point
+        // Find entry point (always a global symbol)
         let entry_addr = *symbol_addresses
+            .globals
             .get(entry_point)
             .ok_or_else(|| LinkError::UndefinedSymbol(entry_point.to_string()))?;
 
         // Apply relocations
-        for (offset, sym_name, sym_section, obj_idx, rel_type, addend, home) in pending_relocations
+        for PendingRelocation {
+            offset,
+            sym_name,
+            sym_section,
+            sym_binding,
+            obj_idx,
+            rel_type,
+            addend,
+            home,
+        } in pending_relocations
         {
             // Pick the buffer the patch site lives in and its base vaddr.
             // PC-relative relocations in rodata/data measure from their own
@@ -1152,61 +1234,59 @@ impl Linker {
                 PatchHome::Rodata => (&mut merged_rodata, rodata_vaddr),
                 PatchHome::Data => (&mut merged_data, data_vaddr),
             };
-            // Try to resolve the symbol
-            let target_addr = if let Some(&addr) = symbol_addresses.get(&sym_name) {
-                addr
-            } else if let Some(sec_idx) = sym_section {
-                // Section-relative symbol - look up the section's address
-                let obj = &self.objects[obj_idx];
-                if sec_idx >= obj.sections.len() {
-                    return Err(LinkError::InvalidSectionIndex {
-                        symbol: sym_name.clone(),
-                        section_index: sec_idx,
-                        section_count: obj.sections.len(),
-                    });
-                }
-                let section = &obj.sections[sec_idx];
-                if let Some(&sec_offset) = section_offsets.get(&(obj_idx, sec_idx)) {
-                    let base = if section.name.starts_with(".text") {
-                        code_vaddr
-                    } else if section.name.starts_with(".rodata") {
-                        rodata_vaddr
-                    } else if section.name.starts_with(".data") {
-                        data_vaddr
-                    } else if section.name.starts_with(".bss") {
-                        bss_vaddr
+            // Try to resolve the symbol (locals only within their own object)
+            let target_addr =
+                if let Some(addr) = symbol_addresses.resolve(obj_idx, &sym_name, sym_binding) {
+                    addr
+                } else if let Some(sec_idx) = sym_section {
+                    // Section-relative symbol - look up the section's address
+                    let obj = &self.objects[obj_idx];
+                    if sec_idx >= obj.sections.len() {
+                        return Err(LinkError::InvalidSectionIndex {
+                            symbol: sym_name.clone(),
+                            section_index: sec_idx,
+                            section_count: obj.sections.len(),
+                        });
+                    }
+                    let section = &obj.sections[sec_idx];
+                    if let Some(&sec_offset) = section_offsets.get(&(obj_idx, sec_idx)) {
+                        let base = if section.name.starts_with(".text") {
+                            code_vaddr
+                        } else if section.name.starts_with(".rodata") {
+                            rodata_vaddr
+                        } else if section.name.starts_with(".data") {
+                            data_vaddr
+                        } else if section.name.starts_with(".bss") {
+                            bss_vaddr
+                        } else {
+                            return Err(LinkError::UndefinedSymbol(format!(
+                                "{} (in section '{}')",
+                                sym_name, section.name
+                            )));
+                        };
+                        base + sec_offset
                     } else {
                         return Err(LinkError::UndefinedSymbol(format!(
-                            "{} (in section '{}')",
-                            sym_name, section.name
+                            "{} (section {} not in section_offsets)",
+                            sym_name, sec_idx
                         )));
-                    };
-                    base + sec_offset
+                    }
+                } else if sym_binding == SymbolBinding::Weak {
+                    // An undefined WEAK symbol resolves to address 0 rather than
+                    // erroring — standard ELF semantics, lets code do null checks
+                    // against optional symbols. (RUE-131 item 9)
+                    0
                 } else {
                     return Err(LinkError::UndefinedSymbol(format!(
-                        "{} (section {} not in section_offsets)",
-                        sym_name, sec_idx
+                        "{} (no section, rel_type={:?})",
+                        if sym_name.is_empty() {
+                            "<empty>"
+                        } else {
+                            &sym_name
+                        },
+                        rel_type
                     )));
-                }
-            } else if self.objects[obj_idx]
-                .find_symbol(&sym_name)
-                .is_some_and(|s| s.binding == SymbolBinding::Weak)
-            {
-                // An undefined WEAK symbol resolves to address 0 rather than
-                // erroring — standard ELF semantics, lets code do null checks
-                // against optional symbols. (RUE-131 item 9)
-                0
-            } else {
-                return Err(LinkError::UndefinedSymbol(format!(
-                    "{} (no section, rel_type={:?})",
-                    if sym_name.is_empty() {
-                        "<empty>"
-                    } else {
-                        &sym_name
-                    },
-                    rel_type
-                )));
-            };
+                };
 
             let pc = base_vaddr + offset;
             let patch_offset = offset as usize;
@@ -3566,6 +3646,637 @@ mod tests {
         assert!(
             matches!(result, Err(LinkError::UndefinedSymbol(_))),
             "Should return UndefinedSymbol error"
+        );
+    }
+
+    // =========================================================================
+    // RUE-131 items 2, 5, 7, 8, 11: symbol scoping and Mach-O reloc semantics
+    // =========================================================================
+
+    use crate::elf::{Relocation, SymbolType};
+
+    /// Hand-build an ObjectFile with one section, symbols, and relocations.
+    fn make_obj(
+        machine: crate::elf::ElfMachine,
+        sections: Vec<Section>,
+        symbols: Vec<Symbol>,
+    ) -> ObjectFile {
+        let section_map = sections
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (s.name.clone(), i))
+            .collect();
+        ObjectFile {
+            sections,
+            symbols,
+            section_map,
+            machine,
+        }
+    }
+
+    fn text_section(name: &str, data: Vec<u8>, relocations: Vec<Relocation>) -> Section {
+        Section {
+            name: name.into(),
+            size: data.len() as u64,
+            data,
+            flags: SectionFlags::ALLOC | SectionFlags::EXEC,
+            relocations,
+            align: 16,
+        }
+    }
+
+    fn sym(name: &str, section: Option<usize>, value: u64, binding: SymbolBinding) -> Symbol {
+        Symbol {
+            name: name.into(),
+            section_index: section,
+            value,
+            size: 0,
+            binding,
+            sym_type: SymbolType::Func,
+        }
+    }
+
+    /// Walk a linked Mach-O's load commands, returning each LC_SEGMENT_64 as
+    /// (name, vmaddr, fileoff, filesize).
+    fn macho_segments(macho: &[u8]) -> Vec<(String, u64, u64, u64)> {
+        use crate::constants::LC_SEGMENT_64;
+        let ncmds = u32::from_le_bytes(macho[16..20].try_into().unwrap()) as usize;
+        let mut segments = Vec::new();
+        let mut off = crate::constants::MACHO64_HEADER_SIZE;
+        for _ in 0..ncmds {
+            let cmd = u32::from_le_bytes(macho[off..off + 4].try_into().unwrap());
+            let cmdsize = u32::from_le_bytes(macho[off + 4..off + 8].try_into().unwrap()) as usize;
+            if cmd == LC_SEGMENT_64 {
+                let name_bytes = &macho[off + 8..off + 24];
+                let end = name_bytes.iter().position(|&b| b == 0).unwrap_or(16);
+                let name = String::from_utf8_lossy(&name_bytes[..end]).to_string();
+                let vmaddr = u64::from_le_bytes(macho[off + 24..off + 32].try_into().unwrap());
+                let fileoff = u64::from_le_bytes(macho[off + 40..off + 48].try_into().unwrap());
+                let filesize = u64::from_le_bytes(macho[off + 48..off + 56].try_into().unwrap());
+                segments.push((name, vmaddr, fileoff, filesize));
+            }
+            off += cmdsize;
+        }
+        segments
+    }
+
+    /// Read the LC_MAIN entryoff from a linked Mach-O (== the file offset of
+    /// merged code when the entry function is at code offset 0).
+    fn macho_entryoff(macho: &[u8]) -> u64 {
+        use crate::constants::LC_MAIN;
+        let ncmds = u32::from_le_bytes(macho[16..20].try_into().unwrap()) as usize;
+        let mut off = crate::constants::MACHO64_HEADER_SIZE;
+        for _ in 0..ncmds {
+            let cmd = u32::from_le_bytes(macho[off..off + 4].try_into().unwrap());
+            let cmdsize = u32::from_le_bytes(macho[off + 4..off + 8].try_into().unwrap()) as usize;
+            if cmd == LC_MAIN {
+                return u64::from_le_bytes(macho[off + 8..off + 16].try_into().unwrap());
+            }
+            off += cmdsize;
+        }
+        panic!("no LC_MAIN in linked output");
+    }
+
+    fn read_u64_at(bytes: &[u8], off: usize) -> u64 {
+        u64::from_le_bytes(bytes[off..off + 8].try_into().unwrap())
+    }
+
+    fn read_u32_at(bytes: &[u8], off: usize) -> u32 {
+        u32::from_le_bytes(bytes[off..off + 4].try_into().unwrap())
+    }
+
+    /// RUE-131 item 2 (ELF): LOCAL symbols with the same name in different
+    /// objects must each resolve within their own object. A single name-keyed
+    /// symbol map let one object's "helper" shadow the other's.
+    #[test]
+    fn test_local_symbols_resolve_within_object_elf() {
+        let abs64_at_8 = |symbol_index| {
+            vec![Relocation {
+                offset: 8,
+                symbol_index,
+                rel_type: RelocationType::Abs64,
+                addend: 0,
+            }]
+        };
+        // Both objects define a LOCAL "helper" — at offset 16 in obj0, at
+        // offset 4 in obj1 — and each takes its own helper's address.
+        let obj0 = make_obj(
+            crate::elf::ElfMachine::X86_64,
+            vec![text_section(".text", vec![0u8; 24], abs64_at_8(1))],
+            vec![
+                sym("main", Some(0), 0, SymbolBinding::Global),
+                sym("helper", Some(0), 16, SymbolBinding::Local),
+            ],
+        );
+        let obj1 = make_obj(
+            crate::elf::ElfMachine::X86_64,
+            vec![text_section(".text", vec![0u8; 24], abs64_at_8(1))],
+            vec![
+                sym("second", Some(0), 0, SymbolBinding::Global),
+                sym("helper", Some(0), 4, SymbolBinding::Local),
+            ],
+        );
+
+        let mut linker = Linker::new(ELF_TARGET);
+        linker.add_object(obj0).unwrap();
+        linker.add_object(obj1).unwrap();
+        let elf = linker.link("main").unwrap();
+
+        // Code is written right after the (single, text-only) program header
+        // in the FILE, but virtual addresses are always computed assuming the
+        // maximum 3 program headers.
+        let code_off = TEST_EHDR_SIZE + TEST_PHDR_SIZE;
+        let code_vaddr = 0x400000 + (TEST_EHDR_SIZE + 3 * TEST_PHDR_SIZE) as u64;
+        // obj0 .text at merged offset 0; obj1 .text at 32 (24 aligned to 16).
+        assert_eq!(
+            read_u64_at(&elf, code_off + 8),
+            code_vaddr + 16,
+            "obj0's relocation must bind to obj0's local helper"
+        );
+        assert_eq!(
+            read_u64_at(&elf, code_off + 32 + 8),
+            code_vaddr + 32 + 4,
+            "obj1's relocation must bind to obj1's local helper, not obj0's"
+        );
+    }
+
+    /// RUE-131 item 2 (Mach-O): same-named locals (e.g. each object's
+    /// `l_anon` constants) must not shadow each other.
+    #[test]
+    fn test_local_symbols_resolve_within_object_macho() {
+        use crate::macho::VM_BASE;
+        let abs64_at_8 = |symbol_index| {
+            vec![Relocation {
+                offset: 8,
+                symbol_index,
+                rel_type: RelocationType::Aarch64Abs64,
+                addend: 0,
+            }]
+        };
+        let mut t0 = text_section("__text", vec![0u8; 24], abs64_at_8(1));
+        t0.align = 4;
+        let mut t1 = text_section("__text", vec![0u8; 24], abs64_at_8(1));
+        t1.align = 4;
+        let obj0 = make_obj(
+            crate::elf::ElfMachine::Aarch64,
+            vec![t0],
+            vec![
+                sym("main", Some(0), 0, SymbolBinding::Global),
+                sym("helper", Some(0), 16, SymbolBinding::Local),
+            ],
+        );
+        let obj1 = make_obj(
+            crate::elf::ElfMachine::Aarch64,
+            vec![t1],
+            vec![
+                sym("other", Some(0), 0, SymbolBinding::Global),
+                sym("helper", Some(0), 4, SymbolBinding::Local),
+            ],
+        );
+
+        let mut linker = Linker::new(Target::Aarch64Macos);
+        linker.add_object(obj0).unwrap();
+        linker.add_object(obj1).unwrap();
+        let macho = linker.link("main").unwrap();
+
+        // main is at code offset 0, so LC_MAIN's entryoff == the code's file
+        // offset; code is mapped at VM_BASE + entryoff.
+        let code_off = macho_entryoff(&macho) as usize;
+        let code_vaddr = VM_BASE + code_off as u64;
+        // obj0 __text at merged offset 0; obj1 __text at 24 (already 4-aligned).
+        assert_eq!(
+            read_u64_at(&macho, code_off + 8),
+            code_vaddr + 16,
+            "obj0's relocation must bind to obj0's local helper"
+        );
+        assert_eq!(
+            read_u64_at(&macho, code_off + 24 + 8),
+            code_vaddr + 24 + 4,
+            "obj1's relocation must bind to obj1's local helper, not obj0's"
+        );
+    }
+
+    /// RUE-131 item 11: a relocation in a rodata section must be applied on
+    /// the Mach-O path (rodata relocations used to not be collected at all,
+    /// and ARM64_RELOC_UNSIGNED wasn't handled).
+    #[test]
+    fn test_macho_rodata_relocation_applied() {
+        use crate::macho::VM_BASE;
+        let text = {
+            let mut s = text_section("__text", vec![0xC0, 0x03, 0x5F, 0xD6], vec![]);
+            s.align = 4;
+            s
+        };
+        let rodata = Section {
+            name: "__TEXT,__const".into(),
+            data: vec![0u8; 8], // unrelocated pointer slot
+            size: 8,
+            flags: SectionFlags::ALLOC,
+            relocations: vec![Relocation {
+                offset: 0,
+                symbol_index: 0, // -> main
+                rel_type: RelocationType::Aarch64Abs64,
+                addend: 0,
+            }],
+            align: 8,
+        };
+        let obj = make_obj(
+            crate::elf::ElfMachine::Aarch64,
+            vec![text, rodata],
+            vec![sym("main", Some(0), 0, SymbolBinding::Global)],
+        );
+
+        let mut linker = Linker::new(Target::Aarch64Macos);
+        linker.add_object(obj).unwrap();
+        let macho = linker.link("main").unwrap();
+
+        let code_off = macho_entryoff(&macho) as usize;
+        // rodata is merged into the text buffer after the 4-byte code,
+        // aligned to 8.
+        let slot = read_u64_at(&macho, code_off + 8);
+        assert_eq!(
+            slot,
+            VM_BASE + code_off as u64,
+            "Abs64 slot in rodata must hold main's address (was silently dropped)"
+        );
+    }
+
+    /// RUE-131 items 3 & 8 through link_macho itself: with __TEXT larger than
+    /// one page, data symbols must be placed where __DATA actually lands (not
+    /// the old hardcoded VM_BASE + one page), and patch sites in __DATA must
+    /// be patched in the data buffer (not bounds-checked/patched against
+    /// merged_text).
+    #[test]
+    fn test_macho_multipage_text_and_data_relocs() {
+        use crate::macho::{PAGE_SIZE, VM_BASE};
+
+        // > one page of code so __TEXT spans two pages.
+        let code_len = PAGE_SIZE as usize + 0x100;
+        let mut code = vec![0u8; code_len];
+        // ret at the start (content is irrelevant; never executed)
+        code[..4].copy_from_slice(&[0xC0, 0x03, 0x5F, 0xD6]);
+        let text = {
+            let mut s = text_section(
+                "__text",
+                code,
+                vec![Relocation {
+                    offset: 16, // pointer slot in text -> gvar (in __DATA)
+                    symbol_index: 1,
+                    rel_type: RelocationType::Aarch64Abs64,
+                    addend: 0,
+                }],
+            );
+            s.align = 4;
+            s
+        };
+        let data = Section {
+            name: "__DATA,__data".into(),
+            data: vec![0u8; 16],
+            size: 16,
+            flags: SectionFlags::ALLOC | SectionFlags::WRITE,
+            relocations: vec![Relocation {
+                offset: 0, // pointer slot in data -> main (in __TEXT)
+                symbol_index: 0,
+                rel_type: RelocationType::Aarch64Abs64,
+                addend: 0,
+            }],
+            align: 8,
+        };
+        let obj = make_obj(
+            crate::elf::ElfMachine::Aarch64,
+            vec![text, data],
+            vec![
+                sym("main", Some(0), 0, SymbolBinding::Global),
+                sym("gvar", Some(1), 8, SymbolBinding::Global),
+            ],
+        );
+
+        let mut linker = Linker::new(Target::Aarch64Macos);
+        linker.add_object(obj).unwrap();
+        let macho = linker.link("main").unwrap();
+
+        let code_off = macho_entryoff(&macho) as usize;
+        let segments = macho_segments(&macho);
+        let (_, text_vmaddr, _, text_filesize) = segments
+            .iter()
+            .find(|(n, ..)| n == "__TEXT")
+            .cloned()
+            .expect("__TEXT segment");
+        let (_, data_vmaddr, data_fileoff, _) = segments
+            .iter()
+            .find(|(n, ..)| n == "__DATA")
+            .cloned()
+            .expect("__DATA segment");
+
+        assert_eq!(text_vmaddr, VM_BASE);
+        assert!(
+            text_filesize >= (code_off + code_len) as u64,
+            "__TEXT must contain headers + all the code"
+        );
+        assert!(
+            data_vmaddr >= VM_BASE + 2 * PAGE_SIZE,
+            "__DATA must start after the (multi-page) __TEXT, not at the \
+             hardcoded second page (got {data_vmaddr:#x})"
+        );
+
+        // Text-side slot points at gvar inside __DATA.
+        assert_eq!(
+            read_u64_at(&macho, code_off + 16),
+            data_vmaddr + 8,
+            "text slot must hold gvar's real address in __DATA"
+        );
+        // Data-side slot points back at main.
+        assert_eq!(
+            read_u64_at(&macho, data_fileoff as usize),
+            VM_BASE + code_off as u64,
+            "data slot must be patched in the DATA buffer"
+        );
+    }
+
+    /// RUE-131 item 7: a relocation against an unresolved symbol must be a
+    /// link error on the Mach-O path (it was silently skipped, leaving a
+    /// garbage instruction for runtime).
+    #[test]
+    fn test_macho_unresolved_symbol_errors() {
+        let text = {
+            let mut s = text_section(
+                "__text",
+                vec![
+                    0x00, 0x00, 0x00, 0x94, // bl <nope>
+                    0xC0, 0x03, 0x5F, 0xD6, // ret
+                ],
+                vec![Relocation {
+                    offset: 0,
+                    symbol_index: 1,
+                    rel_type: RelocationType::Call26,
+                    addend: 0,
+                }],
+            );
+            s.align = 4;
+            s
+        };
+        let obj = make_obj(
+            crate::elf::ElfMachine::Aarch64,
+            vec![text],
+            vec![
+                sym("main", Some(0), 0, SymbolBinding::Global),
+                sym("nope", None, 0, SymbolBinding::Global), // undefined
+            ],
+        );
+
+        let mut linker = Linker::new(Target::Aarch64Macos);
+        linker.add_object(obj).unwrap();
+        let result = linker.link("main");
+        assert!(
+            matches!(result, Err(LinkError::UndefinedSymbol(ref s)) if s.contains("nope")),
+            "unresolved symbol must error (was silently skipped), got: {:?}",
+            result
+        );
+    }
+
+    /// RUE-131 item 9 parity: an undefined WEAK symbol resolves to 0 on the
+    /// Mach-O path too, instead of erroring.
+    #[test]
+    fn test_macho_undefined_weak_resolves_to_zero() {
+        let text = {
+            let mut s = text_section(
+                "__text",
+                vec![0u8; 16],
+                vec![Relocation {
+                    offset: 8,
+                    symbol_index: 1,
+                    rel_type: RelocationType::Aarch64Abs64,
+                    addend: 0,
+                }],
+            );
+            s.align = 4;
+            s
+        };
+        let obj = make_obj(
+            crate::elf::ElfMachine::Aarch64,
+            vec![text],
+            vec![
+                sym("main", Some(0), 0, SymbolBinding::Global),
+                sym("optional_hook", None, 0, SymbolBinding::Weak),
+            ],
+        );
+
+        let mut linker = Linker::new(Target::Aarch64Macos);
+        linker.add_object(obj).unwrap();
+        let macho = linker.link("main").unwrap();
+        let code_off = macho_entryoff(&macho) as usize;
+        assert_eq!(
+            read_u64_at(&macho, code_off + 8),
+            0,
+            "undefined weak symbol must resolve to address 0"
+        );
+    }
+
+    /// RUE-131 item 5a: ARM64_RELOC_PAGEOFF12 on a load/store must scale the
+    /// page offset by the access size; on an ADD it stays unscaled. Writing
+    /// the raw byte offset into an LDR multiplies the displacement by the
+    /// access size at runtime.
+    #[test]
+    fn test_macho_pageoff12_scaled_for_loads() {
+        use crate::macho::{PAGE_SIZE, VM_BASE};
+
+        // ldr x0, [x8, #imm]  (64-bit load, imm12 scaled by 8)
+        // add x0, x0, #imm    (unscaled)
+        // ret
+        let text = {
+            let mut s = text_section(
+                "__text",
+                vec![
+                    0x00, 0x01, 0x40, 0xF9, // ldr x0, [x8]
+                    0x00, 0x00, 0x00, 0x91, // add x0, x0, #0
+                    0xC0, 0x03, 0x5F, 0xD6, // ret
+                ],
+                vec![
+                    Relocation {
+                        offset: 0,
+                        symbol_index: 1,
+                        rel_type: RelocationType::AddLo12,
+                        addend: 0,
+                    },
+                    Relocation {
+                        offset: 4,
+                        symbol_index: 1,
+                        rel_type: RelocationType::AddLo12,
+                        addend: 0,
+                    },
+                ],
+            );
+            s.align = 4;
+            s
+        };
+        let data = Section {
+            name: "__DATA,__data".into(),
+            data: vec![0u8; 16],
+            size: 16,
+            flags: SectionFlags::ALLOC | SectionFlags::WRITE,
+            relocations: vec![],
+            align: 8,
+        };
+        let obj = make_obj(
+            crate::elf::ElfMachine::Aarch64,
+            vec![text, data],
+            vec![
+                sym("main", Some(0), 0, SymbolBinding::Global),
+                sym("gvar", Some(1), 8, SymbolBinding::Global),
+            ],
+        );
+
+        let mut linker = Linker::new(Target::Aarch64Macos);
+        linker.add_object(obj).unwrap();
+        let macho = linker.link("main").unwrap();
+
+        let code_off = macho_entryoff(&macho) as usize;
+        let segments = macho_segments(&macho);
+        let (_, data_vmaddr, ..) = segments
+            .iter()
+            .find(|(n, ..)| n == "__DATA")
+            .cloned()
+            .expect("__DATA segment");
+        // __DATA lands on a page boundary, so gvar's low 12 bits are its
+        // section offset.
+        assert_eq!(data_vmaddr % PAGE_SIZE, 0);
+        assert!(data_vmaddr > VM_BASE);
+        let lo12 = ((data_vmaddr + 8) & 0xFFF) as u32;
+        assert_eq!(lo12, 8);
+
+        let ldr = read_u32_at(&macho, code_off);
+        assert_eq!(
+            ldr,
+            0xF9400100 | ((lo12 >> 3) << 10),
+            "LDR imm12 must be the byte offset scaled by the 8-byte access size"
+        );
+        let add = read_u32_at(&macho, code_off + 4);
+        assert_eq!(
+            add,
+            0x91000000 | (lo12 << 10),
+            "ADD imm12 must be the unscaled byte offset"
+        );
+    }
+
+    /// RUE-131 item 2, end-to-end through emit → parse → link_macho: every
+    /// object emits its own LOCAL `.rodata.str0` symbol, so with name-keyed
+    /// resolution the second object's string references bound to the FIRST
+    /// object's string. Each ADD's imm12 must address its own object's string.
+    #[test]
+    fn test_macho_full_cycle_same_named_string_locals() {
+        use crate::macho::VM_BASE;
+        let make = |name: &str, s: &str| {
+            ObjectBuilder::new(Target::Aarch64Macos, name)
+                .code(vec![
+                    0x00, 0x00, 0x00, 0x90, // adrp x0, str@PAGE
+                    0x00, 0x00, 0x00, 0x91, // add x0, x0, str@PAGEOFF
+                    0xC0, 0x03, 0x5F, 0xD6, // ret
+                ])
+                .strings(vec![s.to_string()])
+                .relocation(CodeRelocation {
+                    offset: 0,
+                    symbol: ".rodata.str0".into(),
+                    rel_type: RelocationType::AdrpPage21,
+                    addend: 0,
+                })
+                .relocation(CodeRelocation {
+                    offset: 4,
+                    symbol: ".rodata.str0".into(),
+                    rel_type: RelocationType::AddLo12,
+                    addend: 0,
+                })
+                .build()
+        };
+
+        let obj0 = ObjectFile::parse(&make("main", "AAAA")).unwrap();
+        let obj1 = ObjectFile::parse(&make("other", "BBBB")).unwrap();
+
+        let mut linker = Linker::new(Target::Aarch64Macos);
+        linker.add_object(obj0).unwrap();
+        linker.add_object(obj1).unwrap();
+        let macho = linker.link("main").unwrap();
+
+        let code_off = macho_entryoff(&macho) as usize;
+        // Merged layout: 12 bytes code per object (24 total), then obj0's
+        // rodata at 24 (4 bytes "AAAA"), then obj1's rodata at 32 (8-aligned).
+        assert_eq!(&macho[code_off + 24..code_off + 28], b"AAAA");
+        assert_eq!(&macho[code_off + 32..code_off + 36], b"BBBB");
+
+        // VM_BASE is page-aligned, so each string's low 12 address bits are
+        // (code file offset + rodata offset) & 0xFFF.
+        assert_eq!(VM_BASE & 0xFFF, 0);
+        let lo12_of = |rodata_off: usize| ((code_off + rodata_off) & 0xFFF) as u32;
+        let imm12_of = |insn: u32| (insn >> 10) & 0xFFF;
+
+        let add0 = read_u32_at(&macho, code_off + 4);
+        assert_eq!(
+            imm12_of(add0),
+            lo12_of(24),
+            "obj0's ADD must address obj0's string"
+        );
+        let add1 = read_u32_at(&macho, code_off + 12 + 4);
+        assert_eq!(
+            imm12_of(add1),
+            lo12_of(32),
+            "obj1's ADD must address obj1's string, not obj0's"
+        );
+    }
+
+    /// RUE-131 item 11: archive linking where resolving one member's
+    /// undefined symbols pulls in a second member.
+    #[test]
+    fn test_archive_selects_multiple_members() {
+        // main calls f (archive member 1), f calls g (archive member 2)
+        let main_bytes = ObjectBuilder::new(ELF_TARGET, "main")
+            .code(vec![0xE8, 0x00, 0x00, 0x00, 0x00, 0xC3])
+            .relocation(CodeRelocation {
+                offset: 1,
+                symbol: "f".into(),
+                rel_type: RelocationType::Pc32,
+                addend: -4,
+            })
+            .build();
+        let f_bytes = ObjectBuilder::new(ELF_TARGET, "f")
+            .code(vec![
+                0xB8, 0x11, 0x00, 0x00, 0x00, // mov eax, 0x11 (marker)
+                0xE8, 0x00, 0x00, 0x00, 0x00, // call g
+                0xC3,
+            ])
+            .relocation(CodeRelocation {
+                offset: 6,
+                symbol: "g".into(),
+                rel_type: RelocationType::Pc32,
+                addend: -4,
+            })
+            .build();
+        let g_bytes = ObjectBuilder::new(ELF_TARGET, "g")
+            .code(vec![
+                0xB8, 0x22, 0x00, 0x00, 0x00, // mov eax, 0x22 (marker)
+                0xC3,
+            ])
+            .build();
+
+        let archive = Archive {
+            objects: vec![
+                ObjectFile::parse(&f_bytes).unwrap(),
+                ObjectFile::parse(&g_bytes).unwrap(),
+            ],
+        };
+
+        let mut linker = Linker::new(ELF_TARGET);
+        linker
+            .add_object(ObjectFile::parse(&main_bytes).unwrap())
+            .unwrap();
+        linker.add_archive(archive).unwrap();
+        let elf = linker.link("main").expect("both members must be selected");
+
+        // Both members' marker instructions must be present in the output.
+        let has_f = elf.windows(5).any(|w| w == [0xB8, 0x11, 0x00, 0x00, 0x00]);
+        let has_g = elf.windows(5).any(|w| w == [0xB8, 0x22, 0x00, 0x00, 0x00]);
+        assert!(has_f, "archive member defining f must be linked");
+        assert!(
+            has_g,
+            "archive member defining g must be linked (pulled in by f)"
         );
     }
 }

--- a/crates/rue-linker/src/macho.rs
+++ b/crates/rue-linker/src/macho.rs
@@ -32,17 +32,20 @@ pub const VM_BASE: u64 = 0x100000000;
 
 /// Computed file/VM layout for a dynamic executable — produced only by
 /// `compute_dynamic_layout` so relocation pre-pass and the actual build can
-/// never disagree.
-struct DynamicLayout {
-    text_file_offset: usize,
-    text_segment_file_size: usize,
-    has_data: bool,
-    data_file_offset: usize,
-    data_vm_addr: u64,
-    data_file_size: usize,
-    data_vm_size: u64,
-    linkedit_file_offset: usize,
-    linkedit_vm_addr: u64,
+/// never disagree. The linker consumes this (via [`MachOBuilder::dynamic_layout`])
+/// to place symbols *before* the binary is built; previously it hardcoded
+/// `VM_BASE + PAGE_SIZE` for the data segment, which broke as soon as
+/// __TEXT outgrew one page. (RUE-131)
+pub(crate) struct DynamicLayout {
+    pub(crate) text_file_offset: usize,
+    pub(crate) text_segment_file_size: usize,
+    pub(crate) has_data: bool,
+    pub(crate) data_file_offset: usize,
+    pub(crate) data_vm_addr: u64,
+    pub(crate) data_file_size: usize,
+    pub(crate) data_vm_size: u64,
+    pub(crate) linkedit_file_offset: usize,
+    pub(crate) linkedit_vm_addr: u64,
 }
 
 // =============================================================================
@@ -859,6 +862,15 @@ impl MachOBuilder {
     /// Delegates to the single shared layout computation.
     pub fn calculate_text_file_offset_for_dynamic(&self) -> u64 {
         self.compute_dynamic_layout().text_file_offset as u64
+    }
+
+    /// The full pre-build layout (text offset, data segment address, …).
+    ///
+    /// The linker needs the data segment's virtual address before building so
+    /// data/bss symbols can be placed and relocations applied against the
+    /// addresses the binary will actually use.
+    pub(crate) fn dynamic_layout(&self) -> DynamicLayout {
+        self.compute_dynamic_layout()
     }
 
     /// Build a dynamic executable (using LC_MAIN + dyld).


### PR DESCRIPTION

The remaining linker-epic items, every claim reproduced before fixing
(six of eight grafted regression tests failed on the base):

Local symbol shadowing (item 2): symbol resolution was one flat name-keyed
map across all objects, so same-named LOCAL symbols (helpers, l_anon
constants, section names) in different objects shadowed each other — fires
the moment two archive members share a local name. Resolution is now split:
globals stay name-keyed, locals key on (object, name), with the binding
carried through pending relocations; ELF section-name fallbacks are
per-object too. Bonus fix: the address map now honors first-weak-wins
(add_object picked the right winner; the address map then overwrote it
with the last).

Mach-O relocation semantics (items 5, 7, 8):
- PAGEOFF12 now scales the imm12 by the instruction's access size for
  load/store-class instructions (misalignment is a loud error); ADD stays
  unscaled, matching ARM64 rules.
- Implicit addends are finally read: ARM64_RELOC_ADDEND pairs (signed
  24-bit) and embedded UNSIGNED addends; n_value is normalized to
  section-relative (Mach-O symbols carry object-VM-absolute values — this
  also fixes rustc-produced archive members). The emitter is made
  spec-compliant to match, byte-identical for current codegen.
- Non-extern relocations accept any named symbol at the section start, or
  synthesize a local anchor — no more Global-at-0 requirement.
- Unresolved symbols now ERROR like the ELF path instead of being silently
  skipped (if macOS runtime members reference truly-unlinked symbols, CI
  will say so loudly — that would be a real pre-existing bug surfacing).
  The hardcoded-name trace filters are deleted.
- rodata/data relocation sites get the PatchHome treatment (own buffer,
  own bounds), and link_macho consumes the builder's unified
  dynamic_layout instead of a stale VM_BASE+PAGE_SIZE hardcode.

Tests (item 11): fourteen new — including rodata-with-relocs and >1-page
__TEXT end-to-end through link_macho, a full emit→parse→link round trip of
two objects with the same local name, and multi-member archive selection
pinned as a regression test. Mach-O behavior is byte-validated here and
executed by CI's macos job. One out-of-scope quirk documented in the epic:
link_elf's text p_offset assumes three program headers while writing fewer
when rodata/data are absent.

Full test.sh green.

Fixes RUE-131



🤖 Generated with [Claude Code](https://claude.com/claude-code)
