### PR TITLE
Parser: reject duplicate modifiers and unknown directives; targeted errors for as-casts and hex literals

### DIFF
--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -64,6 +64,7 @@ impl ErrorCode {
     pub const INVALID_INTEGER: Self = Self(2);
     pub const INVALID_STRING_ESCAPE: Self = Self(3);
     pub const UNTERMINATED_STRING: Self = Self(4);
+    pub const UNSUPPORTED_INTEGER_BASE: Self = Self(5);
 
     // ========================================================================
     // Parser errors (E0100-E0199)
@@ -805,6 +806,18 @@ pub enum ErrorKind {
     InvalidStringEscape(char),
     #[error("unterminated string literal")]
     UnterminatedString,
+    /// A non-decimal integer literal prefix (`0x`/`0b`/`0o`). Rue integer
+    /// literals are decimal only (spec 2.1), so these are rejected with a
+    /// targeted diagnostic instead of splitting into `0` + identifier and
+    /// dying with a generic parse error. (RUE-133)
+    ///
+    /// `hint` is either empty or a pre-rendered ", write `N` instead"
+    /// suggestion containing the decimal value of the literal.
+    #[error("{base} integer literals are not supported; integer literals are decimal only{hint}")]
+    UnsupportedIntegerBase {
+        base: &'static str,
+        hint: Cow<'static, str>,
+    },
 
     // Parser errors
     #[error("expected {expected}, found {found}")]
@@ -1121,6 +1134,7 @@ impl ErrorKind {
             ErrorKind::InvalidInteger => ErrorCode::INVALID_INTEGER,
             ErrorKind::InvalidStringEscape(_) => ErrorCode::INVALID_STRING_ESCAPE,
             ErrorKind::UnterminatedString => ErrorCode::UNTERMINATED_STRING,
+            ErrorKind::UnsupportedIntegerBase { .. } => ErrorCode::UNSUPPORTED_INTEGER_BASE,
 
             // Parser errors (E0100-E0199)
             ErrorKind::UnexpectedToken { .. } => ErrorCode::UNEXPECTED_TOKEN,

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -25,6 +25,15 @@ pub enum LexError {
         escape: char,
     },
     UnterminatedString,
+    /// A non-decimal integer literal prefix: `0x`/`0X` (hex), `0b`/`0B`
+    /// (binary), or `0o`/`0O` (octal). Rue integer literals are decimal only
+    /// (spec 2.1). Without this rule, `0xFF` lexes as `0` + identifier `xFF`
+    /// and dies later with a generic parse error; lexing the whole literal as
+    /// one error token lets the diagnostic name the base and suggest the
+    /// decimal value. Carries the base prefix character, lowercased. (RUE-133)
+    UnsupportedIntegerBase {
+        prefix: char,
+    },
 }
 
 /// Process a string literal starting from an opening quote.
@@ -116,6 +125,20 @@ fn process_string_from_quote(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Resu
     Ok(spur)
 }
 
+/// Callback for the hex/binary/octal literal rule on [`LogosTokenKind::Int`]:
+/// always rejects, carrying the (lowercased) base prefix character so the
+/// diagnostic can name the base. See the comment on the rule. (RUE-133)
+fn reject_non_decimal_base(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Result<u64, LexError> {
+    let prefix = lex
+        .slice()
+        .chars()
+        .nth(1)
+        .expect("regex guarantees a prefix char");
+    Err(LexError::UnsupportedIntegerBase {
+        prefix: prefix.to_ascii_lowercase(),
+    })
+}
+
 /// Token kinds in the Rue language, using logos derive macro.
 #[derive(Logos, Debug, Clone, PartialEq, Eq)]
 #[logos(error = LexError)]
@@ -204,7 +227,16 @@ pub enum LogosTokenKind {
     Underscore,
 
     // Integer literals
+    //
+    // The second rule rejects hex/binary/octal prefixes (`0xFF`, `0b101`,
+    // `0o7`) as a unit: Rue integer literals are decimal only (spec 2.1),
+    // and without it the input would lex as `0` + identifier and surface as
+    // a confusing generic parse error. Matching the whole literal here lets
+    // the diagnostic name the base and suggest the decimal value. This can
+    // never reject a valid program: no grammar production allows an integer
+    // literal directly abutting an identifier character. (RUE-133)
     #[regex(r"[0-9]+", |lex| lex.slice().parse::<u64>().map_err(|_| LexError::InvalidInteger))]
+    #[regex(r"0[xXbBoO][0-9a-zA-Z_]*", reject_non_decimal_base)]
     Int(u64),
 
     // String literals - match opening quote and process content manually
@@ -544,6 +576,31 @@ impl<'a> LogosLexer<'a> {
                                         span.end as u32,
                                     ),
                                 ),
+                                LexError::UnsupportedIntegerBase { prefix } => {
+                                    let (base, radix) = match prefix {
+                                        'x' => ("hexadecimal", 16),
+                                        'b' => ("binary", 2),
+                                        _ => ("octal", 8),
+                                    };
+                                    // Suggest the decimal spelling when the
+                                    // digits actually parse in the named base
+                                    // (they may not, e.g. `0b2` or `0x`).
+                                    let digits = &slice[2..];
+                                    let hint = match u64::from_str_radix(digits, radix) {
+                                        Ok(value) if !digits.is_empty() => {
+                                            format!("; write `{}` instead", value).into()
+                                        }
+                                        _ => std::borrow::Cow::Borrowed(""),
+                                    };
+                                    (
+                                        ErrorKind::UnsupportedIntegerBase { base, hint },
+                                        Span::with_file(
+                                            self.file_id,
+                                            span.start as u32,
+                                            span.end as u32,
+                                        ),
+                                    )
+                                }
                             };
                             return Err(CompileError::new(kind, rue_span));
                         }
@@ -905,6 +962,51 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err.kind, ErrorKind::InvalidInteger));
+    }
+
+    #[test]
+    fn test_logos_non_decimal_bases_rejected() {
+        // RUE-133: 0x/0b/0o literals are not Rue syntax (integer literals are
+        // decimal only). They must be rejected as a unit with a targeted
+        // diagnostic, not split into `0` + identifier.
+        for (src, base, hint) in [
+            ("0xFF", "hexadecimal", "; write `255` instead"),
+            ("0X1f", "hexadecimal", "; write `31` instead"),
+            ("0b101", "binary", "; write `5` instead"),
+            ("0o17", "octal", "; write `15` instead"),
+        ] {
+            let err = LogosLexer::new(src).tokenize().unwrap_err();
+            match &err.kind {
+                ErrorKind::UnsupportedIntegerBase { base: b, hint: h } => {
+                    assert_eq!(*b, base, "base for {src}");
+                    assert_eq!(h.as_ref(), hint, "hint for {src}");
+                }
+                other => panic!("expected UnsupportedIntegerBase for {src}, got {other:?}"),
+            }
+            // The error span must cover the whole literal.
+            let span = err.span().expect("lexer errors carry a span");
+            assert_eq!(span.start, 0, "span start for {src}");
+            assert_eq!(span.end as usize, src.len(), "span end for {src}");
+        }
+
+        // Digits that don't parse in the named base get no decimal hint.
+        let err = LogosLexer::new("0b2").tokenize().unwrap_err();
+        match &err.kind {
+            ErrorKind::UnsupportedIntegerBase { base, hint } => {
+                assert_eq!(*base, "binary");
+                assert_eq!(hint.as_ref(), "");
+            }
+            other => panic!("expected UnsupportedIntegerBase, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_logos_decimal_zero_unaffected() {
+        // Plain `0` and decimal literals still lex normally.
+        let (tokens, _) = LogosLexer::new("0 10 0123").tokenize().unwrap();
+        assert!(matches!(tokens[0].kind, TokenKind::Int(0)));
+        assert!(matches!(tokens[1].kind, TokenKind::Int(10)));
+        assert!(matches!(tokens[2].kind, TokenKind::Int(123)));
     }
 
     #[test]

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -239,6 +239,12 @@ pub struct Function {
 }
 
 /// Parameter passing mode.
+///
+/// A parameter takes at most ONE mode keyword; the parser rejects repeated
+/// or conflicting modifiers (e.g. `comptime comptime T` or `comptime inout
+/// x`) with a targeted error. `ParamMode` is the single AST representation
+/// of the `comptime` modifier — there is deliberately no separate
+/// `is_comptime` flag (RUE-133 removed that dead duality).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ParamMode {
     /// Normal pass-by-value parameter
@@ -247,7 +253,8 @@ pub enum ParamMode {
     Inout,
     /// Borrow parameter - immutable borrow without ownership transfer
     Borrow,
-    /// Comptime parameter - evaluated at compile time (used for type parameters)
+    /// Comptime parameter - evaluated at compile time (used for type
+    /// parameters like `comptime T: type`)
     Comptime,
 }
 
@@ -257,12 +264,22 @@ impl Default for ParamMode {
     }
 }
 
+impl ParamMode {
+    /// The source keyword for this mode (empty for `Normal`).
+    pub fn keyword(self) -> &'static str {
+        match self {
+            ParamMode::Normal => "",
+            ParamMode::Inout => "inout",
+            ParamMode::Borrow => "borrow",
+            ParamMode::Comptime => "comptime",
+        }
+    }
+}
+
 /// A function parameter.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Param {
-    /// Whether this parameter is evaluated at compile time
-    pub is_comptime: bool,
-    /// Parameter passing mode (normal or inout)
+    /// Parameter passing mode (normal, inout, borrow, or comptime)
     pub mode: ParamMode,
     /// Parameter name
     pub name: Ident,

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -40,6 +40,10 @@ pub struct PrimitiveTypeSpurs {
     pub bool: Spur,
     /// Self type keyword - used in methods to refer to the containing struct type
     pub self_type: Spur,
+    /// The identifier `as` — not a Rue keyword, but recognized after an
+    /// expression to give Rust users a targeted "no 'as' operator" error
+    /// instead of a generic parse error. (RUE-133)
+    pub as_kw: Spur,
 }
 
 impl PrimitiveTypeSpurs {
@@ -56,6 +60,7 @@ impl PrimitiveTypeSpurs {
             u64: interner.get_or_intern("u64"),
             bool: interner.get_or_intern("bool"),
             self_type: interner.get_or_intern("Self"),
+            as_kw: interner.get_or_intern("as"),
         }
     }
 }
@@ -326,32 +331,53 @@ where
     })
 }
 
-/// Parser for parameter mode: inout, borrow, or comptime
+/// Parser for parameter mode: comptime, inout, or borrow
 fn param_mode_parser<'src, I>() -> impl Parser<'src, I, ParamMode, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
     choice((
+        just(TokenKind::Comptime).to(ParamMode::Comptime),
         just(TokenKind::Inout).to(ParamMode::Inout),
         just(TokenKind::Borrow).to(ParamMode::Borrow),
-        just(TokenKind::Comptime).to(ParamMode::Comptime),
     ))
 }
 
-/// Parser for function parameters: [comptime] [inout|borrow] name: type
+/// Parser for function parameters: [comptime|inout|borrow] name: type
+///
+/// A parameter takes at most one mode keyword. Repeated (`comptime comptime
+/// T`) or conflicting (`comptime inout x`) modifiers used to be silently
+/// accepted — the duplicate landed in a vestigial `is_comptime` flag next to
+/// `ParamMode` — and are now rejected with a targeted error. (RUE-133)
 fn param_parser<'src, I>() -> impl Parser<'src, I, Param, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    just(TokenKind::Comptime)
-        .or_not()
-        .then(param_mode_parser().or_not())
+    param_mode_parser()
+        .map_with(|mode, e| (mode, e.span()))
+        .repeated()
+        .collect::<Vec<_>>()
+        .try_map(|modes, _span| match modes.as_slice() {
+            [] => Ok(ParamMode::Normal),
+            [(mode, _)] => Ok(*mode),
+            [(first, _), (second, second_span), ..] => {
+                let msg = if first == second {
+                    format!("duplicate parameter modifier '{}'", first.keyword())
+                } else {
+                    format!(
+                        "conflicting parameter modifiers '{}' and '{}'; a parameter takes at most one of 'comptime', 'inout', or 'borrow'",
+                        first.keyword(),
+                        second.keyword()
+                    )
+                };
+                Err(Rich::custom(*second_span, msg))
+            }
+        })
         .then(ident_parser())
         .then_ignore(just(TokenKind::Colon))
         .then(type_parser())
-        .map_with(|(((is_comptime, mode), name), ty), e| Param {
-            is_comptime: is_comptime.is_some(),
-            mode: mode.unwrap_or(ParamMode::Normal),
+        .map_with(|((mode, name), ty), e| Param {
+            mode,
             name,
             ty,
             span: span_from_extra(e),
@@ -571,8 +597,20 @@ where
         // Atom parser - primary expressions
         let atom = atom_parser(expr.clone());
 
+        // Rust-refugee diagnostic: `expr as T` is not Rue syntax (`as` is an
+        // ordinary identifier, so `5 as i64` used to die with a generic
+        // "expected semicolon" error). An expression directly followed by the
+        // identifier `as` is never valid Rue, so consume it and report a
+        // targeted error pointing at the `as`. (RUE-133)
+        let as_misuse = select! { TokenKind::Ident(name) => name }
+            .map_with(|name, e: &mut MapExtra<'src, '_, I, ParserExtras<'src>>| {
+                (name, e.state().syms.as_kw, e.span())
+            })
+            .filter(|(name, as_kw, _)| name == as_kw)
+            .map(|(_, _, span)| span);
+
         // Build Pratt parser with precedence levels (see `precedence` module)
-        atom.pratt((
+        let pratt = atom.pratt((
             // Prefix operators
             prefix(
                 precedence::UNARY,
@@ -688,7 +726,18 @@ where
                 just(TokenKind::PipePipe),
                 |l, _, r, _| make_binary(l, BinaryOp::Or, r),
             ),
-        ))
+        ));
+
+        pratt
+            .then(as_misuse.or_not())
+            .try_map(|(parsed, as_span), _span| match as_span {
+                None => Ok(parsed),
+                Some(span) => Err(Rich::custom(
+                    span,
+                    "Rue has no 'as' cast operator; use '@intCast(T, value)' or give the target \
+                     type on the binding: 'let x: i64 = value'",
+                )),
+            })
     })
 }
 
@@ -2379,7 +2428,17 @@ impl ChumskyParser {
                 CompileErrors::from(errors)
             });
 
-        result.map(|ast| (ast, self.interner))
+        let ast = result?;
+
+        // Post-parse validation that needs the interner (e.g. resolving
+        // directive names so the diagnostic can say which directive is
+        // unknown). See the `validate` module.
+        let validation_errors = crate::validate::check_directives(&ast, &self.interner);
+        if !validation_errors.is_empty() {
+            return Err(CompileErrors::from(validation_errors));
+        }
+
+        Ok((ast, self.interner))
     }
 }
 
@@ -2661,15 +2720,82 @@ mod tests {
 
     #[test]
     fn test_struct_method_with_directive() {
-        let result = parse("struct Foo { @inline fn bar(self) -> i32 { 42 } }").unwrap();
+        // Must use a KNOWN directive: unknown ones are rejected post-parse
+        // by `validate::check_directives` (RUE-133).
+        let result = parse("struct Foo { @allow(something) fn bar(self) -> i32 { 42 } }").unwrap();
         match &result.ast.items[0] {
             Item::Struct(struct_decl) => {
                 let method = &struct_decl.methods[0];
                 assert_eq!(method.directives.len(), 1);
-                assert_eq!(result.get(method.directives[0].name.name), "inline");
+                assert_eq!(result.get(method.directives[0].name.name), "allow");
             }
             _ => panic!("expected Struct"),
         }
+    }
+
+    #[test]
+    fn test_unknown_directive_rejected() {
+        // RUE-133: unknown @-directives in item position used to be silently
+        // accepted and ignored (e.g. `@typo_allow` compiling as a no-op).
+        let err = parse("@important\nfn main() -> i32 { 42 }").unwrap_err();
+        let msg = format!("{}", err.first().expect("expected at least one error"));
+        assert!(
+            msg.contains("unknown directive '@important'"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_unknown_directive_on_nested_let_rejected() {
+        let err = parse(
+            "fn main() -> i32 { if true { @alllow(unused_variable) let x = 1; x } else { 0 } }",
+        )
+        .unwrap_err();
+        let msg = format!("{}", err.first().expect("expected at least one error"));
+        assert!(
+            msg.contains("unknown directive '@alllow'"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_duplicate_comptime_modifier_rejected() {
+        // RUE-133: `comptime comptime T: type` used to parse, with the second
+        // `comptime` landing in the (now removed) ParamMode::Comptime duality.
+        let err = parse("fn id(comptime comptime T: type, x: T) -> T { x }").unwrap_err();
+        let msg = format!("{}", err.first().expect("expected at least one error"));
+        assert!(
+            msg.contains("duplicate parameter modifier 'comptime'"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_conflicting_param_modifiers_rejected() {
+        let err = parse("fn f(comptime inout x: i32) -> i32 { x }").unwrap_err();
+        let msg = format!("{}", err.first().expect("expected at least one error"));
+        assert!(
+            msg.contains("conflicting parameter modifiers 'comptime' and 'inout'"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_as_cast_targeted_error() {
+        // RUE-133: `5 as i64` used to die with a generic "expected semicolon".
+        let err = parse("fn main() -> i32 { let x = 5 as i64; 0 }").unwrap_err();
+        let msg = format!("{}", err.first().expect("expected at least one error"));
+        assert!(
+            msg.contains("Rue has no 'as' cast operator"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_as_still_usable_as_identifier() {
+        // `as` is not a keyword; only `expr as ...` is special-cased.
+        let result = parse("fn main() -> i32 { let as = 3; as + 2 }");
+        assert!(result.is_ok(), "{:?}", result.err());
     }
 
     // ==================== Method Call Parsing Tests ====================

--- a/crates/rue-parser/src/lib.rs
+++ b/crates/rue-parser/src/lib.rs
@@ -4,6 +4,9 @@
 
 pub mod ast;
 mod chumsky_parser;
+mod validate;
+
+pub use validate::KNOWN_DIRECTIVES;
 
 pub use ast::{
     ArgMode,

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -1,0 +1,235 @@
+//! Post-parse AST validation.
+//!
+//! Checks that need the interner (resolving names to strings for the
+//! diagnostic) and therefore can't easily run inside the chumsky
+//! combinators, which only carry pre-interned symbols in their state.
+//!
+//! Currently this validates @-directive names: an unknown directive such as
+//! `@important fn main() ...` used to be silently accepted and ignored,
+//! turning typos like `@alllow(...)` into no-ops. Unknown directives are now
+//! a compile error naming the directive. (RUE-133)
+//!
+//! Note this covers *directive* position only (before items and `let`
+//! statements). Expression-position `@name(...)` intrinsics (`@dbg`,
+//! `@syscall`, `@intCast`, ...) are validated by sema, which already rejects
+//! unknown intrinsics.
+
+use crate::ast::{Ast, Directive, Expr, IntrinsicArg, Item, Method, Statement, TypeExpr};
+use lasso::ThreadedRodeo;
+use rue_error::{CompileError, ErrorKind};
+
+/// Directive names the compiler understands.
+///
+/// This is the single source of truth for *directive* (item/statement
+/// position) names; keep it in sync with the consumers in sema:
+/// - `allow`  — suppresses lints, e.g. `@allow(unused_variable)` on `let`
+///   (see `has_allow_directive` in rue-air)
+/// - `copy`   — marks a struct as a copy type (see `has_copy_directive`)
+/// - `handle` — marks a struct as a handle type (see `has_handle_directive`)
+pub const KNOWN_DIRECTIVES: &[&str] = &["allow", "copy", "handle"];
+
+/// Walk the AST and report every directive whose name is not in
+/// [`KNOWN_DIRECTIVES`].
+pub fn check_directives(ast: &Ast, interner: &ThreadedRodeo) -> Vec<CompileError> {
+    let mut v = Validator {
+        interner,
+        errors: Vec::new(),
+    };
+    for item in &ast.items {
+        v.check_item(item);
+    }
+    v.errors
+}
+
+struct Validator<'a> {
+    interner: &'a ThreadedRodeo,
+    errors: Vec<CompileError>,
+}
+
+impl Validator<'_> {
+    fn check_directives(&mut self, directives: &[Directive]) {
+        for directive in directives {
+            let name = self.interner.resolve(&directive.name.name);
+            if !KNOWN_DIRECTIVES.contains(&name) {
+                self.errors.push(CompileError::new(
+                    ErrorKind::ParseError(format!(
+                        "unknown directive '@{}'; known directives are @allow, @copy and @handle",
+                        name
+                    )),
+                    directive.span,
+                ));
+            }
+        }
+    }
+
+    fn check_item(&mut self, item: &Item) {
+        match item {
+            Item::Function(f) => {
+                self.check_directives(&f.directives);
+                self.check_expr(&f.body);
+            }
+            Item::Struct(s) => {
+                self.check_directives(&s.directives);
+                for method in &s.methods {
+                    self.check_method(method);
+                }
+            }
+            Item::Enum(_) => {}
+            Item::DropFn(d) => self.check_expr(&d.body),
+            Item::Const(c) => {
+                self.check_directives(&c.directives);
+                self.check_expr(&c.init);
+            }
+            Item::Error(_) => {}
+        }
+    }
+
+    fn check_method(&mut self, method: &Method) {
+        self.check_directives(&method.directives);
+        self.check_expr(&method.body);
+    }
+
+    fn check_statement(&mut self, statement: &Statement) {
+        match statement {
+            Statement::Let(l) => {
+                self.check_directives(&l.directives);
+                self.check_expr(&l.init);
+            }
+            Statement::Assign(a) => self.check_expr(&a.value),
+            Statement::Expr(e) => self.check_expr(e),
+        }
+    }
+
+    /// Recurse into every sub-expression that can contain a block (and thus
+    /// `let` statements carrying directives) or an anonymous struct type
+    /// (whose methods carry directives).
+    fn check_expr(&mut self, expr: &Expr) {
+        match expr {
+            Expr::Int(_)
+            | Expr::String(_)
+            | Expr::Bool(_)
+            | Expr::Unit(_)
+            | Expr::Ident(_)
+            | Expr::Continue(_)
+            | Expr::SelfExpr(_)
+            | Expr::Error(_) => {}
+            Expr::Binary(b) => {
+                self.check_expr(&b.left);
+                self.check_expr(&b.right);
+            }
+            Expr::Unary(u) => self.check_expr(&u.operand),
+            Expr::Paren(p) => self.check_expr(&p.inner),
+            Expr::Block(b) => {
+                for statement in &b.statements {
+                    self.check_statement(statement);
+                }
+                self.check_expr(&b.expr);
+            }
+            Expr::If(i) => {
+                self.check_expr(&i.cond);
+                self.check_expr_block(&i.then_block);
+                if let Some(else_block) = &i.else_block {
+                    self.check_expr_block(else_block);
+                }
+            }
+            Expr::Match(m) => {
+                self.check_expr(&m.scrutinee);
+                for arm in &m.arms {
+                    self.check_expr(&arm.body);
+                }
+            }
+            Expr::While(w) => {
+                self.check_expr(&w.cond);
+                self.check_expr_block(&w.body);
+            }
+            Expr::Loop(l) => self.check_expr_block(&l.body),
+            Expr::Call(c) => {
+                for arg in &c.args {
+                    self.check_expr(&arg.expr);
+                }
+            }
+            Expr::Break(b) => {
+                if let Some(value) = &b.value {
+                    self.check_expr(value);
+                }
+            }
+            Expr::Return(r) => {
+                if let Some(value) = &r.value {
+                    self.check_expr(value);
+                }
+            }
+            Expr::StructLit(s) => {
+                if let Some(base) = &s.base {
+                    self.check_expr(base);
+                }
+                for field in &s.fields {
+                    self.check_expr(&field.value);
+                }
+            }
+            Expr::Field(f) => self.check_expr(&f.base),
+            Expr::MethodCall(m) => {
+                self.check_expr(&m.receiver);
+                for arg in &m.args {
+                    self.check_expr(&arg.expr);
+                }
+            }
+            Expr::IntrinsicCall(i) => {
+                for arg in &i.args {
+                    match arg {
+                        IntrinsicArg::Expr(e) => self.check_expr(e),
+                        IntrinsicArg::Type(ty) => self.check_type_expr(ty),
+                    }
+                }
+            }
+            Expr::ArrayLit(a) => {
+                for element in &a.elements {
+                    self.check_expr(element);
+                }
+            }
+            Expr::Index(i) => {
+                self.check_expr(&i.base);
+                self.check_expr(&i.index);
+            }
+            Expr::Path(p) => {
+                if let Some(base) = &p.base {
+                    self.check_expr(base);
+                }
+            }
+            Expr::AssocFnCall(a) => {
+                if let Some(base) = &a.base {
+                    self.check_expr(base);
+                }
+                for arg in &a.args {
+                    self.check_expr(&arg.expr);
+                }
+            }
+            Expr::Comptime(c) => self.check_expr(&c.expr),
+            Expr::Checked(c) => self.check_expr(&c.expr),
+            Expr::TypeLit(t) => self.check_type_expr(&t.type_expr),
+        }
+    }
+
+    fn check_expr_block(&mut self, block: &crate::ast::BlockExpr) {
+        for statement in &block.statements {
+            self.check_statement(statement);
+        }
+        self.check_expr(&block.expr);
+    }
+
+    /// Anonymous struct types (comptime type construction) contain methods,
+    /// which carry directives and bodies of their own.
+    fn check_type_expr(&mut self, ty: &TypeExpr) {
+        match ty {
+            TypeExpr::Named(_) | TypeExpr::Unit(_) | TypeExpr::Never(_) => {}
+            TypeExpr::Array { element, .. } => self.check_type_expr(element),
+            TypeExpr::AnonymousStruct { methods, .. } => {
+                for method in methods {
+                    self.check_method(method);
+                }
+            }
+            TypeExpr::PointerConst { pointee, .. } | TypeExpr::PointerMut { pointee, .. } => {
+                self.check_type_expr(pointee)
+            }
+        }
+    }
+}

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -232,7 +232,7 @@ impl<'a> AstGen<'a> {
                 name: p.name.name, // Already a Spur
                 ty: self.intern_type(&p.ty),
                 mode: self.convert_param_mode(p.mode),
-                is_comptime: p.is_comptime,
+                is_comptime: p.mode == ParamMode::Comptime,
             })
             .collect();
         let (params_start, params_len) = self.rir.add_params(&params);
@@ -284,13 +284,19 @@ impl<'a> AstGen<'a> {
             .collect()
     }
 
-    /// Convert AST ParamMode to RIR RirParamMode
+    /// Convert AST ParamMode to RIR RirParamMode.
+    ///
+    /// The AST has a single `ParamMode` (RUE-133 collapsed the old
+    /// `is_comptime` flag into it), but the RIR keeps `mode` and
+    /// `is_comptime` as separate fields. A comptime parameter lowers to
+    /// `mode: Normal, is_comptime: true` — exactly the RIR shape sema has
+    /// always consumed — so `RirParamMode::Comptime` is never constructed
+    /// here.
     fn convert_param_mode(&self, mode: ParamMode) -> RirParamMode {
         match mode {
-            ParamMode::Normal => RirParamMode::Normal,
+            ParamMode::Normal | ParamMode::Comptime => RirParamMode::Normal,
             ParamMode::Inout => RirParamMode::Inout,
             ParamMode::Borrow => RirParamMode::Borrow,
-            ParamMode::Comptime => RirParamMode::Comptime,
         }
     }
 
@@ -331,7 +337,7 @@ impl<'a> AstGen<'a> {
                 name: p.name.name, // Already a Spur
                 ty: self.intern_type(&p.ty),
                 mode: self.convert_param_mode(p.mode),
-                is_comptime: p.is_comptime,
+                is_comptime: p.mode == ParamMode::Comptime,
             })
             .collect();
         let (params_start, params_len) = self.rir.add_params(&params);

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -49,7 +49,12 @@ pub enum RirParamMode {
     Inout,
     /// Borrow parameter - immutable borrow without ownership transfer
     Borrow,
-    /// Comptime parameter - evaluated at compile time (used for type parameters)
+    /// Comptime parameter - evaluated at compile time (used for type parameters).
+    ///
+    /// NOTE: astgen never constructs this variant — a `comptime` parameter
+    /// lowers to `mode: Normal, is_comptime: true` on [`RirParam`] (that is
+    /// the shape sema consumes). The variant is kept for the stability of
+    /// the packed encode/decode in `add_params`/`get_params`.
     Comptime,
 }
 
@@ -62,7 +67,9 @@ pub struct RirParam {
     pub ty: Spur,
     /// Parameter passing mode
     pub mode: RirParamMode,
-    /// Whether this parameter is evaluated at compile time
+    /// Whether this parameter is evaluated at compile time (declared with
+    /// the `comptime` modifier; carried separately from `mode`, which stays
+    /// `Normal` for comptime parameters)
     pub is_comptime: bool,
 }
 

--- a/crates/rue-ui-tests/cases/diagnostics/directives.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/directives.toml
@@ -1,0 +1,168 @@
+# Directive validation (RUE-133).
+#
+# Unknown @-directives in item/statement position used to be silently
+# accepted and ignored, so a typo like `@alllow(...)` was a no-op. They are
+# now a compile error naming the directive. The known set lives in
+# rue-parser's `validate::KNOWN_DIRECTIVES` (allow, copy, handle); the cases
+# below pin both the rejection and that every known directive still works.
+# (Expression-position intrinsics like @dbg/@intCast and the fused @import
+# token are separate mechanisms and unaffected.)
+#
+# This file also covers parameter-modifier validation: `comptime comptime T`
+# used to be silently accepted via a vestigial is_comptime/ParamMode duality.
+
+[section]
+id = "diagnostics.directives"
+name = "Directive and parameter-modifier validation"
+description = "Unknown directives and repeated parameter modifiers are rejected; known ones still work."
+
+[[case]]
+name = "unknown_directive_on_function"
+source = """
+@important
+fn main() -> i32 { 42 }
+"""
+compile_fail = true
+error_contains = ["unknown directive '@important'", "@allow, @copy and @handle"]
+
+[[case]]
+name = "unknown_directive_typo_of_allow"
+description = "The motivating case: a typo'd @allow must not silently disable nothing."
+source = """
+fn main() -> i32 {
+    @alllow(unused_variable)
+    let x = 1;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["unknown directive '@alllow'"]
+
+[[case]]
+name = "unknown_directive_on_struct"
+source = """
+@frozen
+struct P { x: i32 }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["unknown directive '@frozen'"]
+
+[[case]]
+name = "unknown_directive_on_nested_let"
+description = "Directives on let statements nested inside control flow are validated too."
+source = """
+fn main() -> i32 {
+    if true {
+        @nope
+        let x = 1;
+        x
+    } else {
+        0
+    }
+}
+"""
+compile_fail = true
+error_contains = ["unknown directive '@nope'"]
+
+[[case]]
+name = "known_directive_allow_still_works"
+source = """
+fn main() -> i32 {
+    @allow(unused_variable)
+    let unused = 1;
+    0
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "known_directive_copy_still_works"
+source = """
+@copy
+struct P { x: i32 }
+
+fn main() -> i32 {
+    let p = P { x: 21 };
+    let q = p;
+    p.x + q.x
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "known_directive_handle_still_works"
+source = """
+@handle
+struct Counter {
+    count: i32,
+
+    fn handle(self) -> Counter {
+        Counter { count: self.count }
+    }
+}
+
+fn main() -> i32 {
+    let a = Counter { count: 42 };
+    let b = a.handle();
+    b.count
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "intrinsics_unaffected_by_directive_validation"
+description = "@dbg/@size_of are expression-position intrinsics, not directives."
+source = """
+fn main() -> i32 {
+    @dbg(1);
+    @size_of(i32)
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "duplicate_comptime_modifier_rejected"
+description = """
+RUE-133 item 8: `comptime comptime T: type` was silently accepted (the second
+`comptime` landed in a vestigial ParamMode::Comptime next to the is_comptime
+flag; the duality is now collapsed and duplicates are parse errors).
+"""
+source = """
+fn id(comptime comptime T: type, x: T) -> T { x }
+
+fn main() -> i32 { id(i32, 42) }
+"""
+compile_fail = true
+error_contains = ["duplicate parameter modifier 'comptime'"]
+
+[[case]]
+name = "repeated_inout_modifier_rejected"
+source = """
+fn f(inout inout x: i32) { x = x + 1; }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["duplicate parameter modifier 'inout'"]
+
+[[case]]
+name = "conflicting_param_modifiers_rejected"
+source = """
+fn f(comptime inout x: i32) -> i32 { x }
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["conflicting parameter modifiers 'comptime' and 'inout'", "at most one"]
+
+[[case]]
+name = "single_comptime_param_still_works"
+source = """
+fn id(comptime T: type, x: T) -> T { x }
+
+fn main() -> i32 { id(i32, 42) }
+"""
+exit_code = 42

--- a/crates/rue-ui-tests/cases/diagnostics/lexer_precision.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/lexer_precision.toml
@@ -28,11 +28,14 @@ description = """
 RUE-133: a directive whose name merely starts with "import" used to die in
 the LEXER with "unexpected character: @" because the fused @import token
 matched and failed its word-boundary check without backtracking. It must lex
-as an ordinary @-directive (At + Ident) — currently unknown directives are
-accepted silently, so this compiles, matching @other-style directives.
+as an ordinary @-directive (At + Ident). Unknown directives are now rejected
+post-parse (see diagnostics/directives.toml), so the proof that lexing
+succeeded is that the error NAMES the directive instead of being the lexer's
+"unexpected character: @".
 """
 source = """
 @important
 fn main() -> i32 { 5 }
 """
-exit_code = 5
+compile_fail = true
+error_contains = ["unknown directive '@important'"]

--- a/crates/rue-ui-tests/cases/diagnostics/rust_refugees.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/rust_refugees.toml
@@ -1,0 +1,110 @@
+# Targeted diagnostics for common Rust-isms (RUE-133 item 9).
+#
+# `5 as i64` and `0xFF` are both valid Rust but not valid Rue; they used to
+# die with generic parse errors ("expected semicolon after expression" /
+# "expected '.' or '[' or '*', found identifier"). They now get targeted
+# diagnostics that say what Rue offers instead.
+
+[section]
+id = "diagnostics.rust_refugees"
+name = "Rust-refugee diagnostics"
+description = "Targeted errors for `as` casts and 0x/0b/0o integer literals."
+
+[[case]]
+name = "as_cast_targeted_error"
+description = """
+RUE-133: `as` is an ordinary identifier in Rue, so `5 as i64` used to be a
+generic "expected semicolon after expression" error pointing at the `5`. It
+must name the missing operator and suggest the Rue alternatives.
+"""
+source = """
+fn main() -> i32 {
+    let x = 5 as i64;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["Rue has no 'as' cast operator", "@intCast", "let x: i64 = value"]
+
+[[case]]
+name = "as_cast_in_expression_statement"
+source = """
+fn main() -> i32 {
+    5 as i64;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["Rue has no 'as' cast operator"]
+
+[[case]]
+name = "as_still_valid_as_identifier"
+description = "`as` is NOT reserved; only `expr as ...` is special-cased."
+source = """
+fn main() -> i32 {
+    let as = 40;
+    as + 2
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "hex_literal_targeted_error"
+description = """
+RUE-133: `0xFF` used to lex as `0` + identifier `xFF` and die with
+"expected '.' or '[' or '*', found identifier". The lexer now rejects the
+whole literal, names the base, and suggests the decimal value.
+"""
+source = """
+fn main() -> i32 {
+    let x = 0xFF;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["hexadecimal integer literals are not supported", "decimal only", "write `255` instead"]
+
+[[case]]
+name = "binary_literal_targeted_error"
+source = """
+fn main() -> i32 {
+    let x = 0b101;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["binary integer literals are not supported", "write `5` instead"]
+
+[[case]]
+name = "octal_literal_targeted_error"
+source = """
+fn main() -> i32 {
+    let x = 0o17;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["octal integer literals are not supported", "write `15` instead"]
+
+[[case]]
+name = "hex_literal_bad_digits_no_hint"
+description = "A prefix whose digits don't parse in that base still errors, just without the decimal suggestion."
+source = """
+fn main() -> i32 {
+    let x = 0b234;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["binary integer literals are not supported"]
+
+[[case]]
+name = "decimal_literals_unaffected"
+source = """
+fn main() -> i32 {
+    let x = 0;
+    let y = 42;
+    x + y
+}
+"""
+exit_code = 42


### PR DESCRIPTION

Three citizen-quality holes, each reproduced first:

Duplicate comptime (RUE-133 item 8): 'comptime comptime T: type' parsed
silently. Now a targeted parse error for duplicate or conflicting
modifiers — and the underlying duality is collapsed: the AST's separate
is_comptime flag is gone, ParamMode is the single representation, with
astgen producing byte-identical RIR. One deliberate behavior change:
'comptime inout x' (previously parsed, semantically meaningless, used
nowhere) is now a parse error. Side fix: --emit ast prints comptime on
comptime params (it was silently dropped).

Rust-refugee diagnostics (item 9): '5 as i64' now explains that Rue has
no 'as' operator and points at @intCast or a typed binding ('as' remains
a valid identifier, pinned by tests). '0xFF' gets a lexer-category E0005
naming the decimal-only rule and the decimal value to write instead. The
spec mandates decimal-only literals, so hex was NOT implemented — whether
it should be is a language question for Steve, argued in the issue.

Unknown directives: '@important' before an item compiled as a silent
no-op (found during the RUE-137 work and parked). The known set is
enumerated from sema's actual consumers — @allow, @copy, @handle — and a
post-parse validation pass walks every directive position (including
nested lets and anonymous-struct methods) rejecting anything else by
name. The UI case that had pinned the silent acceptance now asserts the
error.

Twenty UI cases, six parser unit tests, two lexer unit tests; no spec
changes (traceability stays 100%). Full test.sh green.

Part of RUE-133 (items 8, 9 + the directive gap; remaining: items 10
grammar appendix — now unblocked by the RUE-83 decision).



🤖 Generated with [Claude Code](https://claude.com/claude-code)
