### PR TITLE
Inference: module member calls and file-level consts reach type inference; generic-receiver fallback

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -173,6 +173,12 @@ pub struct ConstraintGenerator<'a> {
     /// Type substitutions for Self and type parameters (used in method bodies).
     /// Maps type names (like "Self") to their concrete types.
     type_subst: Option<&'a HashMap<Spur, Type>>,
+    /// File-level constant types (name -> declared type), resolved during
+    /// declaration gathering. Consulted by `VarRef` after locals and params so
+    /// a const reference infers to its declared type instead of `<error>`
+    /// (RUE-142). `None` only in unit tests; production passes the map via
+    /// [`Self::with_const_types`].
+    const_types: Option<&'a HashMap<Spur, Type>>,
     /// Type intern pool for creating pointer and array types during constraint generation.
     type_pool: &'a TypeInternPool,
 }
@@ -221,8 +227,16 @@ impl<'a> ConstraintGenerator<'a> {
             methods,
             int_literal_vars: Vec::new(),
             type_subst,
+            const_types: None,
             type_pool,
         }
+    }
+
+    /// Provide file-level constant types (name -> declared type) for `VarRef`
+    /// resolution. See the `const_types` field for details (RUE-142).
+    pub fn with_const_types(mut self, const_types: &'a HashMap<Spur, Type>) -> Self {
+        self.const_types = Some(const_types);
+        self
     }
 
     /// Get the type variables allocated for integer literals.
@@ -474,6 +488,14 @@ impl<'a> ConstraintGenerator<'a> {
                     local.ty.clone()
                 } else if let Some(param) = ctx.params.get(name) {
                     param.ty.clone()
+                } else if let Some(const_ty) = self.const_types.and_then(|consts| consts.get(name))
+                {
+                    // File-level constant: its type was resolved during
+                    // declaration gathering (i32/bool/unit literals, module
+                    // types for `const m = @import(...)`). Yielding it here
+                    // anchors expressions like `N + 1` and `m.go() + 1` that
+                    // previously decayed to `<error>` (RUE-142).
+                    self.type_to_infer(*const_ty)
                 } else {
                     // Unknown variable - will be caught during semantic analysis
                     InferType::Concrete(Type::ERROR)
@@ -840,6 +862,19 @@ impl<'a> ConstraintGenerator<'a> {
                     } else {
                         InferType::Concrete(Type::ERROR)
                     }
+                } else if intrinsic_name == "import" {
+                    // @import("path"): a module value. Resolving the path to a
+                    // real ModuleId needs the registry, which inference doesn't
+                    // have, so use the documented sentinel id — inference only
+                    // needs module-ness (member-call lookup is global by name,
+                    // RUE-140) and sema assigns the real id during analysis.
+                    // Returning Unit here (the old catch-all) made a member
+                    // call on the binding unresolvable (RUE-142) and let a
+                    // bare module expression coerce to `()` silently.
+                    for arg_ref in args.iter() {
+                        self.generate(*arg_ref, ctx);
+                    }
+                    InferType::Concrete(Type::new_module(crate::types::ModuleId::UNRESOLVED))
                 } else {
                     // Generate constraints for arguments (they need to be processed)
                     for arg_ref in args.iter() {
@@ -1212,46 +1247,110 @@ impl<'a> ConstraintGenerator<'a> {
                 let receiver_info = self.generate(*receiver, ctx);
                 let args = self.rir.get_call_args(*args_start, *args_len);
 
-                // Get struct name from receiver type if it's a struct
-                // If we can't determine the struct type, we still generate constraints
-                // for the arguments and return a type variable (actual error is in sema)
-                let result_type = if let InferType::Concrete(ty) = &receiver_info.ty {
-                    if let Some(struct_id) = ty.as_struct() {
-                        // Use StructId directly for method lookup
-                        let method_key = (struct_id, *method);
-                        if let Some(method_sig) = self.methods.get(&method_key) {
-                            // Generate constraints for arguments
-                            for (arg, param_type) in args.iter().zip(method_sig.param_types.iter())
-                            {
-                                let arg_info = self.generate(arg.value, ctx);
-                                self.add_constraint(Constraint::equal(
-                                    arg_info.ty,
-                                    param_type.clone(),
-                                    arg_info.span,
-                                ));
+                // Resolve the call's result type from the receiver's type.
+                // When the receiver can't be resolved RIGHT NOW but sema will
+                // resolve it later, yield a fresh variable rather than ERROR:
+                // a Concrete(ERROR) here flowed into sibling constraints and
+                // produced bogus "literal out of range for '<error>'" failures
+                // that masked (or preempted) sema's real analysis (RUE-126
+                // treats FieldGet the same way).
+                let result_type = match &receiver_info.ty {
+                    // Module receiver: `m.go(...)` is a module member call.
+                    // Mirror sema's `check_module_member_call`: the lookup is
+                    // global by name, never verifying the function belongs to
+                    // the receiver module's file (known looseness, RUE-140 —
+                    // when that is ratified, narrow this lookup too). Yielding
+                    // the callee's return type anchors uses like `m.go() + 1`
+                    // that previously decayed to `<error>` (RUE-142).
+                    InferType::Concrete(ty) if ty.is_module() => {
+                        if let Some(func) = self.functions.get(method) {
+                            if !func.is_generic && args.len() == func.param_types.len() {
+                                // Constrain each argument against its declared
+                                // parameter type (same as a direct Call).
+                                for (arg, param_ty) in args.iter().zip(func.param_types.iter()) {
+                                    let arg_info = self.generate(arg.value, ctx);
+                                    self.add_constraint(Constraint::equal(
+                                        arg_info.ty,
+                                        param_ty.clone(),
+                                        arg_info.span,
+                                    ));
+                                }
+                            } else {
+                                // Generic callee or arity mismatch: just
+                                // process the arguments; sema checks the rest.
+                                for arg in args.iter() {
+                                    self.generate(arg.value, ctx);
+                                }
                             }
-                            method_sig.return_type.clone()
+                            if func.return_type == InferType::Concrete(Type::COMPTIME_TYPE) {
+                                // Generic return type that can't be resolved
+                                // here; sema specialization determines it.
+                                InferType::Var(self.fresh_var())
+                            } else {
+                                func.return_type.clone()
+                            }
                         } else {
-                            // Method not found - sema will report the error
-                            // Still generate arg types to catch errors in arguments
+                            // Unknown member - sema reports UndefinedFunction
                             for arg in args.iter() {
                                 self.generate(arg.value, ctx);
                             }
                             InferType::Concrete(Type::ERROR)
                         }
-                    } else {
-                        // Non-struct receiver - sema will report the error
+                    }
+                    // Receiver of an unresolved comptime-generic type: e.g.
+                    // `pick(t, x).get()` where `t` is a local holding a type
+                    // value, so the generic Call arm couldn't substitute the
+                    // return type. Sema's comptime evaluation resolves the
+                    // receiver and types the call during analysis; an ERROR
+                    // here poisoned inference first (RUE-119 family).
+                    InferType::Concrete(ty) if *ty == Type::COMPTIME_TYPE => {
                         for arg in args.iter() {
                             self.generate(arg.value, ctx);
                         }
-                        InferType::Concrete(Type::ERROR)
+                        InferType::Var(self.fresh_var())
                     }
-                } else {
-                    // Non-concrete type - generate args and return error
-                    for arg in args.iter() {
-                        self.generate(arg.value, ctx);
+                    InferType::Concrete(ty) => {
+                        if let Some(struct_id) = ty.as_struct() {
+                            // Use StructId directly for method lookup
+                            let method_key = (struct_id, *method);
+                            if let Some(method_sig) = self.methods.get(&method_key) {
+                                // Generate constraints for arguments
+                                for (arg, param_type) in
+                                    args.iter().zip(method_sig.param_types.iter())
+                                {
+                                    let arg_info = self.generate(arg.value, ctx);
+                                    self.add_constraint(Constraint::equal(
+                                        arg_info.ty,
+                                        param_type.clone(),
+                                        arg_info.span,
+                                    ));
+                                }
+                                method_sig.return_type.clone()
+                            } else {
+                                // Method not found - sema will report the error
+                                // Still generate arg types to catch errors in arguments
+                                for arg in args.iter() {
+                                    self.generate(arg.value, ctx);
+                                }
+                                InferType::Concrete(Type::ERROR)
+                            }
+                        } else {
+                            // Non-struct receiver - sema will report the error
+                            for arg in args.iter() {
+                                self.generate(arg.value, ctx);
+                            }
+                            InferType::Concrete(Type::ERROR)
+                        }
                     }
-                    InferType::Concrete(Type::ERROR)
+                    // Receiver still a type variable: sema resolves the
+                    // receiver and diagnoses later (mirrors FieldGet's
+                    // fallback, RUE-126/RUE-119).
+                    _ => {
+                        for arg in args.iter() {
+                            self.generate(arg.value, ctx);
+                        }
+                        InferType::Var(self.fresh_var())
+                    }
                 };
 
                 result_type

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1524,7 +1524,8 @@ fn run_type_inference_with_context(
         &ctx.inference_ctx.enum_types,
         &ctx.inference_ctx.method_sigs,
         &ctx.type_pool,
-    );
+    )
+    .with_const_types(&ctx.inference_ctx.const_types);
 
     // Build parameter map for constraint context.
     // Convert Type to InferType so arrays are represented structurally.
@@ -7373,7 +7374,8 @@ impl<'a> Sema<'a> {
             &infer_ctx.method_sigs,
             &self.type_pool,
             type_subst,
-        );
+        )
+        .with_const_types(&infer_ctx.const_types);
 
         // Build parameter map for constraint context.
         // Convert Type to InferType so arrays are represented structurally.

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -108,11 +108,21 @@ impl<'a> Sema<'a> {
         // to `<error>`, poisoning the other operand's literal-range check. (RUE-95)
         self.register_builtin_method_sigs(&mut method_sigs);
 
+        // Constant types (resolved during declaration gathering) so a const
+        // reference in a function body infers to its declared type instead of
+        // `<error>` (RUE-142).
+        let const_types: HashMap<Spur, Type> = self
+            .constants
+            .iter()
+            .map(|(name, info)| (*name, info.ty))
+            .collect();
+
         InferenceContext {
             func_sigs,
             struct_types,
             enum_types,
             method_sigs,
+            const_types,
         }
     }
     /// Check if a directive list contains the @copy directive

--- a/crates/rue-air/src/sema/inference_ctx.rs
+++ b/crates/rue-air/src/sema/inference_ctx.rs
@@ -33,4 +33,11 @@ pub struct InferenceContext {
     pub enum_types: HashMap<Spur, Type>,
     /// Method signatures with InferType: (struct_id, method_name) -> MethodSig.
     pub method_sigs: HashMap<(StructId, Spur), MethodSig>,
+    /// File-level constant types: name -> declared type (e.g. `Type::I32` for
+    /// `const N = 41`, a module type for `const m = @import(...)`). Constant
+    /// types are fully resolved during declaration gathering, before any
+    /// function body is inferred, so they can be consulted like params here.
+    /// Without this map a const reference inferred to `<error>` and poisoned
+    /// every expression it touched (RUE-142).
+    pub const_types: HashMap<Spur, Type>,
 }

--- a/crates/rue-air/src/sema/sema_ctx_builder.rs
+++ b/crates/rue-air/src/sema/sema_ctx_builder.rs
@@ -146,11 +146,21 @@ impl<'a> Sema<'a> {
         // to `<error>`, poisoning the other operand's literal-range check. (RUE-95)
         self.register_builtin_method_sigs(&mut method_sigs);
 
+        // Constant types (resolved during declaration gathering) so a const
+        // reference in a function body infers to its declared type instead of
+        // `<error>` (RUE-142).
+        let const_types: HashMap<Spur, Type> = self
+            .constants
+            .iter()
+            .map(|(name, info)| (*name, info.ty))
+            .collect();
+
         SemaContextInferenceContext {
             func_sigs,
             struct_types,
             enum_types,
             method_sigs,
+            const_types,
         }
     }
 

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -160,6 +160,13 @@ pub struct InferenceContext {
     pub enum_types: HashMap<Spur, Type>,
     /// Method signatures with InferType: (struct_id, method_name) -> MethodSig.
     pub method_sigs: HashMap<(StructId, Spur), MethodSig>,
+    /// File-level constant types: name -> declared type (e.g. `Type::I32` for
+    /// `const N = 41`, a module type for `const m = @import(...)`). Constant
+    /// types are fully resolved during declaration gathering, before any
+    /// function body is inferred, so they can be consulted like params here.
+    /// Without this map a const reference inferred to `<error>` and poisoned
+    /// every expression it touched (RUE-142).
+    pub const_types: HashMap<Spur, Type>,
 }
 
 /// Context for semantic analysis, designed for parallel function analysis.

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -135,6 +135,19 @@ impl ModuleId {
     pub fn index(self) -> u32 {
         self.0
     }
+
+    /// Sentinel meaning "a module whose identity is not resolved yet".
+    ///
+    /// Type inference uses this for `@import(...)` in expression position:
+    /// resolving an import to a real `ModuleId` needs the module registry and
+    /// file-path resolution, which the constraint generator doesn't have.
+    /// Inference only needs module-NESS — module member-call lookup is global
+    /// by name (see RUE-140 in `check_module_member_call`) — and sema assigns
+    /// the real id when it analyzes the expression, so the sentinel id itself
+    /// is never consulted. The value is the maximum id representable in
+    /// `Type`'s 24-bit id field, which the registry's sequential allocation
+    /// never reaches in practice.
+    pub const UNRESOLVED: ModuleId = ModuleId(0xFF_FFFF);
 }
 
 /// The kind of a type - used for pattern matching.

--- a/crates/rue-cli-tests/cases/generic_receiver_infer.toml
+++ b/crates/rue-cli-tests/cases/generic_receiver_infer.toml
@@ -1,0 +1,117 @@
+# Method calls on comptime-generic receivers must not poison inference (RUE-119).
+#
+# The MethodCall inference arm can only RESOLVE a method when the receiver type
+# is a concrete struct. When the receiver's type is a comptime-generic `T`:
+#  - if `T` is substitutable at the call site (a type literal argument, #937's
+#    fix), the receiver is already concrete and resolution works;
+#  - if it genuinely can't be known pre-specialization (e.g. the type argument
+#    is a LOCAL holding a type value), the arm used to return Concrete(ERROR),
+#    which decayed every sibling expression to '<error>' (bogus E0800) before
+#    sema's comptime evaluation could type the call. It now yields a fresh
+#    inference variable instead — the same treatment FieldGet got in RUE-126 —
+#    and sema's specialization types the call correctly.
+#
+# Note: RUE-119's literal repro (`pick(Wrap, ...)` then `w.get() == 5`) was
+# already fixed on trunk by the generics call-site substitution (#937); the
+# cases below pin both that shape and the still-live local-type-value shape.
+
+[section]
+id = "cli.generic_receiver_infer"
+name = "Method calls on comptime-generic receivers"
+description = "Method-call results on generic receivers must anchor (or at least not poison) inference."
+
+[[case]]
+name = "method_on_generic_return_comparison"
+description = "RUE-119's original repro: receiver typed by a generic call's substituted return."
+files = [{ path = "main.rue", source = """
+struct Wrap { n: u64, fn get(self) -> u64 { self.n } }
+fn pick(comptime T: type, x: T) -> T { x }
+fn main() -> i32 {
+    let w = pick(Wrap, Wrap { n: 5 });
+    if w.get() == 5 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "method_in_generic_body_arithmetic"
+description = "Method call on a T-typed parameter inside the generic body, result in arithmetic."
+files = [{ path = "main.rue", source = """
+struct Wrap { n: i32, fn get(self) -> i32 { self.n } }
+fn bump(comptime T: type, x: T) -> i32 {
+    x.get() + 1
+}
+fn main() -> i32 {
+    bump(Wrap, Wrap { n: 41 })
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "method_in_two_layer_generic_body"
+description = "T flows through two generic layers before the method call."
+files = [{ path = "main.rue", source = """
+struct Wrap { n: u64, fn get(self) -> u64 { self.n } }
+fn inner(comptime T: type, x: T) -> u64 { x.get() }
+fn outer(comptime T: type, x: T) -> u64 { inner(T, x) }
+fn main() -> i32 {
+    if outer(Wrap, Wrap { n: 5 }) == 5 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "method_on_receiver_typed_via_local_type_value"
+description = "The type argument is a local holding a type value — unsubstitutable during inference; sema's comptime evaluation must type the call (the previously-failing shape)."
+files = [{ path = "main.rue", source = """
+struct Wrap { n: u64, fn get(self) -> u64 { self.n } }
+fn pick(comptime T: type, x: T) -> T { x }
+fn main() -> i32 {
+    let t = Wrap;
+    let w = pick(t, Wrap { n: 5 });
+    if w.get() == 5 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "let_bound_method_result_via_local_type_value"
+description = "Same shape, with the method result let-bound before the comparison."
+files = [{ path = "main.rue", source = """
+struct Wrap { n: u64, fn get(self) -> u64 { self.n } }
+fn pick(comptime T: type, x: T) -> T { x }
+fn main() -> i32 {
+    let t = Wrap;
+    let w = pick(t, Wrap { n: 5 });
+    let v = w.get();
+    if v == 5 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "field_access_via_local_type_value_control"
+description = "Control: field access on the same receiver already worked (RUE-126 fresh-var fallback)."
+files = [{ path = "main.rue", source = """
+struct Wrap { n: u64, fn get(self) -> u64 { self.n } }
+fn pick(comptime T: type, x: T) -> T { x }
+fn main() -> i32 {
+    let t = Wrap;
+    let w = pick(t, Wrap { n: 5 });
+    if w.n == 5 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "unknown_method_on_concrete_struct_still_errors"
+description = "The fresh-var fallback must not swallow real method-resolution errors."
+files = [{ path = "main.rue", source = """
+struct Wrap { n: u64, fn get(self) -> u64 { self.n } }
+fn main() -> i32 {
+    let w = Wrap { n: 5 };
+    if w.missing() == 5 { 0 } else { 1 }
+}
+""" }]
+compile_fail = true
+error_contains = ["no method named 'missing'"]

--- a/crates/rue-cli-tests/cases/module_member_infer.toml
+++ b/crates/rue-cli-tests/cases/module_member_infer.toml
@@ -1,0 +1,268 @@
+# Module member-call results must anchor type inference (RUE-142), and module
+# values must not silently coerce to `()` (modules are compile-time namespaces,
+# not runtime values).
+#
+# Before the fix, the inference generator typed `@import(...)` as `()` (the
+# intrinsic catch-all) and had no module arm in MethodCall, so `m.go()` decayed
+# to `<error>`: `m.go() + 1` failed E0800 ("literal out of range for '<error>'")
+# even though the same call worked as a statement, let-initializer, or tail
+# expression. File-level consts (`const m = @import(...)`, `const N = 41`) were
+# invisible to inference entirely — same decay. The `()` typing also let a bare
+# module expression pass where `()` was required, silently.
+
+[section]
+id = "cli.module_member_infer"
+name = "Module member-call return-type inference"
+description = "A module member-call result must anchor inference in operand positions; module values must not coerce to ()."
+
+# ---------------------------------------------------------------------------
+# RUE-142: member-call result in operand positions (local `let` binding)
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "member_call_arithmetic_operand_let"
+description = "m.go() + 1 with a let-bound module (the originally failing shape)."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let m = @import("m");
+    m.go() + 1
+}
+""" },
+    { path = "m.rue", source = """
+pub fn go() -> i32 { 41 }
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "member_call_arithmetic_operand_const"
+description = "m.go() + 1 with a file-level const module (RUE-142's exact repro)."
+files = [
+    { path = "main.rue", source = """
+const m = @import("m");
+fn main() -> i32 { m.go() + 1 }
+""" },
+    { path = "m.rue", source = """
+pub fn go() -> i32 { 41 }
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "member_call_comparison_operand"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let m = @import("m");
+    if m.go() == 41 { 7 } else { 1 }
+}
+""" },
+    { path = "m.rue", source = """
+pub fn go() -> i32 { 41 }
+""" },
+]
+exit_code = 7
+
+[[case]]
+name = "member_call_in_call_argument"
+files = [
+    { path = "main.rue", source = """
+fn twice(x: i32) -> i32 { x * 2 }
+fn main() -> i32 {
+    let m = @import("m");
+    twice(m.go()) - 40
+}
+""" },
+    { path = "m.rue", source = """
+pub fn go() -> i32 { 41 }
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "member_call_u64_result_anchors_literal"
+description = "The member's u64 return must anchor the literal it is compared with."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let m = @import("m");
+    if m.big() == 5 { 3 } else { 1 }
+}
+""" },
+    { path = "m.rue", source = """
+pub fn big() -> u64 { 5 }
+""" },
+]
+exit_code = 3
+
+[[case]]
+name = "member_call_literal_args_anchored_to_params"
+description = "Untyped literal arguments are constrained against the member's parameter types."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let m = @import("m");
+    m.add(40, 2)
+}
+""" },
+    { path = "m.rue", source = """
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+""" },
+]
+exit_code = 42
+
+# Controls: positions that already worked must keep working.
+[[case]]
+name = "member_call_tail_position_control"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let m = @import("m");
+    m.go()
+}
+""" },
+    { path = "m.rue", source = """
+pub fn go() -> i32 { 41 }
+""" },
+]
+exit_code = 41
+
+[[case]]
+name = "member_call_statement_and_let_init_control"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let m = @import("m");
+    m.go();
+    let x = m.go();
+    x + 1
+}
+""" },
+    { path = "m.rue", source = """
+pub fn go() -> i32 { 41 }
+""" },
+]
+exit_code = 42
+
+# Error paths must stay intact (the module arm's lookup is global by name,
+# RUE-140; unknown members are still sema's UndefinedFunction).
+[[case]]
+name = "member_call_arg_type_mismatch_still_errors"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let m = @import("m");
+    m.add(true, 2)
+}
+""" },
+    { path = "m.rue", source = """
+pub fn add(a: i32, b: i32) -> i32 { a + b }
+""" },
+]
+compile_fail = true
+error_contains = ["type mismatch"]
+
+[[case]]
+name = "unknown_member_still_errors"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let m = @import("m");
+    m.nope()
+}
+""" },
+    { path = "m.rue", source = """
+pub fn go() -> i32 { 41 }
+""" },
+]
+compile_fail = true
+error_contains = ["E0707", "no member `nope`"]
+
+# ---------------------------------------------------------------------------
+# Const references must reach inference too (RUE-142 sibling: any file-level
+# const used as an operand decayed to '<error>', not just module consts).
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "const_int_arithmetic_operand"
+files = [{ path = "main.rue", source = """
+const N = 41;
+fn main() -> i32 { N + 1 }
+""" }]
+exit_code = 42
+
+# ---------------------------------------------------------------------------
+# Modules are not runtime values: a bare module expression must not silently
+# coerce to `()`. (Statement position stays legal — a discarded value.)
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "module_expr_does_not_coerce_to_unit_tail"
+description = "A module as the tail of a ()-returning function was silently accepted."
+files = [
+    { path = "main.rue", source = """
+fn side() -> () {
+    let m = @import("m");
+    m
+}
+fn main() -> i32 { side(); 0 }
+""" },
+    { path = "m.rue", source = """
+pub fn go() -> i32 { 41 }
+""" },
+]
+compile_fail = true
+error_contains = ["expected (), found <module>"]
+
+[[case]]
+name = "module_expr_does_not_coerce_to_unit_let"
+description = "let u: () = m was silently accepted."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let m = @import("m");
+    let _u: () = m;
+    0
+}
+""" },
+    { path = "m.rue", source = """
+pub fn go() -> i32 { 41 }
+""" },
+]
+compile_fail = true
+error_contains = ["expected (), found <module>"]
+
+[[case]]
+name = "module_expr_in_i32_position_names_module_type"
+description = "The mismatch must name '<module>', not misreport the found type as '()'."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let m = @import("m");
+    m
+}
+""" },
+    { path = "m.rue", source = """
+pub fn go() -> i32 { 41 }
+""" },
+]
+compile_fail = true
+error_contains = ["expected i32, found <module>"]
+
+[[case]]
+name = "module_expr_statement_position_stays_legal"
+description = "A bare `m;` statement is a discarded value — still a no-op, still legal."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let m = @import("m");
+    m;
+    5
+}
+""" },
+    { path = "m.rue", source = """
+pub fn go() -> i32 { 41 }
+""" },
+]
+exit_code = 5


### PR DESCRIPTION

Three inference gaps, with one claim honestly refuted:

RUE-142 (verified): m.go() + 1 failed E0800 against '<error>'. Two roots,
both fixed in the constraint generator: @import was typed () by the
intrinsic catch-all (now yields a module type via a documented
ModuleId::UNRESOLVED sentinel), and the MethodCall arm had no module case
(now resolves the callee globally — explicitly mirroring sema's RUE-140
membership rule — constrains arguments, and returns the callee's return
type). The investigation found something broader: FILE-LEVEL CONSTS were
entirely invisible to inference — plain 'const N = 41; N + 1' failed the
same way, no modules involved. VarRef now falls back to a const-types map
threaded into the inference context. Both shapes pinned.

RUE-119 (partially refuted): the issue's exact repro already passes on
trunk — the generics fixpoint work fixed it. The residual live shape is a
type argument held in a LOCAL (let t = Wrap; pick(t, x).get()), where the
receiver is an unresolved comptime value and the MethodCall arm returned
ERROR, poisoning inference. It now yields a fresh var (the same fallback
RUE-126 established for field receivers); the shape runs end-to-end and
unknown-method-on-concrete-struct still errors.

Module values in unit positions: fell out of the @import typing — a
module bound or returned as () now errors "expected (), found <module>"
instead of silently coercing, and wrong-type positions name <module>
instead of "()". Bare 'm;' statements stay legal. No spec rules added
(value-position behavior is deliberately unpinned in chapter 10).

Twenty-two CLI cases in two new files. One expectation updated at
integration: unknown members now report the module-scoped E0707 from the
membership work rather than a generic undefined-function. Full test.sh
green.

Fixes RUE-142
Fixes RUE-119



🤖 Generated with [Claude Code](https://claude.com/claude-code)
