### PR TITLE
Parser: align comparison-vs-bitwise precedence with Rust; fix spec 4.3a:13

### DIFF
--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -565,19 +565,25 @@ fn make_unary(op: UnaryOp, operand: Expr, op_span: SimpleSpan) -> Expr {
 ///
 /// Example: `1 + 2 * 3` parses as `1 + (2 * 3)` because
 /// MULTIPLICATIVE (9) > ADDITIVE (8).
+///
+/// This ladder deliberately matches Rust's operator precedence
+/// (spec rule 4.3a:13): shifts bind looser than `+`/`-` but tighter
+/// than `&`, and the bitwise operators all bind tighter than
+/// comparisons. So `a << b + c` is `a << (b + c)` and `a & b == c`
+/// is `(a & b) == c`.
 mod precedence {
     /// Logical OR: `||`
     pub const LOGICAL_OR: u16 = 1;
     /// Logical AND: `&&`
     pub const LOGICAL_AND: u16 = 2;
-    /// Bitwise OR: `|`
-    pub const BITWISE_OR: u16 = 3;
-    /// Bitwise XOR: `^`
-    pub const BITWISE_XOR: u16 = 4;
-    /// Bitwise AND: `&`
-    pub const BITWISE_AND: u16 = 5;
     /// Comparison: `==`, `!=`, `<`, `>`, `<=`, `>=`
-    pub const COMPARISON: u16 = 6;
+    pub const COMPARISON: u16 = 3;
+    /// Bitwise OR: `|`
+    pub const BITWISE_OR: u16 = 4;
+    /// Bitwise XOR: `^`
+    pub const BITWISE_XOR: u16 = 5;
+    /// Bitwise AND: `&`
+    pub const BITWISE_AND: u16 = 6;
     /// Shift: `<<`, `>>`
     pub const SHIFT: u16 = 7;
     /// Additive: `+`, `-`

--- a/crates/rue-spec/cases/expressions/bitwise.toml
+++ b/crates/rue-spec/cases/expressions/bitwise.toml
@@ -139,6 +139,37 @@ fn main() -> i32 {
 """
 exit_code = 4
 
+# Pin the full Rust-style ladder (4.3a:13) via runtime results:
+# arithmetic binds tighter than shifts, shifts tighter than &, bitwise
+# tighter than comparisons.
+[[case]]
+name = "precedence_ladder_{variant}"
+spec = ["4.3a:13"]
+source = "fn main() -> i32 { {expr} }"
+params = [
+  { variant = "shift_vs_add", expr = "1 << 2 + 1", exit_code = 8 },       # 1 << (2 + 1)
+  { variant = "add_vs_shift", expr = "1 + 2 << 1", exit_code = 6 },       # (1 + 2) << 1
+  { variant = "shift_vs_mul", expr = "2 * 3 << 1", exit_code = 12 },      # (2 * 3) << 1
+  { variant = "shift_vs_mod", expr = "1 << 4 % 3", exit_code = 2 },       # 1 << (4 % 3)
+  { variant = "shr_vs_add", expr = "16 >> 1 + 1", exit_code = 4 },        # 16 >> (1 + 1)
+]
+
+[[case]]
+name = "precedence_ladder_cmp_{variant}"
+spec = ["4.3a:13"]
+source = """
+fn main() -> i32 {
+    if {expr} { 1 } else { 0 }
+}
+"""
+exit_code = 1
+params = [
+  { variant = "shift_vs_lt", expr = "1 << 2 < 10" },    # (1 << 2) < 10
+  { variant = "and_vs_eq", expr = "6 & 2 == 2" },       # (6 & 2) == 2
+  { variant = "xor_vs_eq", expr = "5 ^ 1 == 4" },       # (5 ^ 1) == 4
+  { variant = "or_vs_eq", expr = "4 | 2 == 6" },        # (4 | 2) == 6
+]
+
 [[case]]
 name = "precedence_parentheses"
 spec = ["4.3a:14"]

--- a/crates/rue-spec/cases/expressions/comparison.toml
+++ b/crates/rue-spec/cases/expressions/comparison.toml
@@ -95,6 +95,9 @@ exit_code = 1
 params = [
   { variant = "after_add", expr = "2 + 3 == 5" },
   { variant = "both_sides", expr = "2 + 3 < 10 - 3" },
+  { variant = "after_bitand", expr = "6 & 3 == 2" },   # (6 & 3) == 2
+  { variant = "after_bitor", expr = "1 | 2 == 3" },    # (1 | 2) == 3
+  { variant = "after_shift", expr = "1 << 3 == 8" },   # (1 << 3) == 8
 ]
 
 # =============================================================================

--- a/docs/spec/src/04-expressions/03-comparison-operators.md
+++ b/docs/spec/src/04-expressions/03-comparison-operators.md
@@ -90,7 +90,7 @@ fn main() -> i32 {
 
 {{ rule(id="4.3:8", cat="normative") }}
 
-Comparison operators have lower precedence than arithmetic operators.
+Comparison operators have lower precedence than arithmetic, shift, and bitwise operators, and higher precedence than the logical operators `&&` and `||`. (The complete precedence ladder, which matches Rust's, is given in rule 4.3a:13.)
 
 {{ rule(id="4.3:9") }}
 

--- a/docs/spec/src/04-expressions/03a-bitwise-operators.md
+++ b/docs/spec/src/04-expressions/03a-bitwise-operators.md
@@ -106,7 +106,19 @@ Bitwise operator precedence (highest to lowest within this group):
 
 {{ rule(id="4.3a:13", cat="normative") }}
 
-Shift operators have higher precedence than arithmetic operators. Bitwise AND, XOR, and OR have lower precedence than comparison operators.
+Rue uses the same operator precedence as Rust. Shift operators have lower precedence than the arithmetic operators, and the bitwise AND, XOR, and OR operators have higher precedence than the comparison operators. The complete binary operator precedence, from highest (binds tightest) to lowest:
+1. Unary `-`, `!`, `~`
+2. `*`, `/`, `%`
+3. `+`, `-`
+4. `<<`, `>>`
+5. `&`
+6. `^`
+7. `|`
+8. `==`, `!=`, `<`, `>`, `<=`, `>=`
+9. `&&`
+10. `||`
+
+For example, `a << b + c` parses as `a << (b + c)`, `a << b * c` parses as `a << (b * c)`, and `a & b == c` parses as `(a & b) == c`.
 
 {{ rule(id="4.3a:14", cat="normative") }}
 


### PR DESCRIPTION
Implements the RUE-83 decision: copy Rust's operator precedence.

Investigation found the parser's shift-vs-arithmetic placement was **already Rust-correct** (`1 << 2 + 1` → 8, `2 * 3 << 1` → 12 before this change; shifts below `%` is Rust's ladder). The real divergences were:

1. **Spec prose 4.3a:13** wrongly claimed shifts bind tighter than arithmetic and bitwise ops bind looser than comparisons. Rewritten with the explicit full ladder: unary > `* / %` > `+ -` > `<< >>` > `&` > `^` > `|` > comparisons > `&&` > `||`. (The grammar appendix already encoded the correct ladder and needed no change.)
2. **The parser's comparison-vs-bitwise ordering**: `a & b == 2` parsed as `a & (b == 2)` instead of Rust's `(a & b) == 2`. Fixed by renumbering the precedence ladder in `chumsky_parser.rs`.

Tests: 9 new runtime-pinning spec cases under 4.3a:13 (the `cmp` ones were type errors under the old precedence, so they are true regression pins) + 3 new variants under 4.3:8. No existing spec/UI/CLI cases pinned the old precedence. Full suite green, traceability 100%.

Fixes RUE-83

🤖 Generated with [Claude Code](https://claude.com/claude-code)