### PR TITLE
By-ref arguments accept place projections: inout/borrow of fields and indexed elements

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -883,30 +883,27 @@ pub(crate) fn non_exhaustive_match_error(
     }
 }
 
-/// Validate that a by-ref (`inout`/`borrow`) call argument is a plain variable
-/// and return its symbol.
+/// Validate that a by-ref (`inout`/`borrow`) call argument is a place — a
+/// variable, or a field/index projection chain rooted at one — and return
+/// the root variable symbol (RUE-143).
 ///
-/// Codegen passes a by-ref argument by taking the address of the variable's
-/// slot, so fields and array elements cannot be passed by reference yet
-/// (RUE-127); reject them here rather than panicking during lowering.
-fn require_plain_byref_arg(rir: &Rir, arg: &RirCallArg) -> CompileResult<Spur> {
-    let inst = rir.get(arg.value);
-    match &inst.data {
-        InstData::VarRef { name } | InstData::ParamRef { name, .. } => Ok(*name),
-        InstData::FieldGet { .. } | InstData::IndexGet { .. } => Err(CompileError::new(
-            ErrorKind::ByRefArgNotPlainVariable,
-            inst.span,
-        )
-        .with_help("bind the value to a local variable first and pass that variable by reference")),
-        _ => Err(CompileError::new(
+/// Codegen passes a by-ref argument by address: place-address formation
+/// (frame slot + static field offsets + dynamic index offsets, or a received
+/// by-ref pointer minus descending offsets) lives in `rue-codegen`'s shared
+/// `byref_args` module. Anything that is not a place (a call result, literal,
+/// struct-init expression, arithmetic, ...) has no caller-visible storage to
+/// point at and is rejected as a non-lvalue.
+fn require_byref_place_arg(rir: &Rir, arg: &RirCallArg) -> CompileResult<Spur> {
+    root_variable_of(rir, arg.value).ok_or_else(|| {
+        CompileError::new(
             if arg.is_inout() {
                 ErrorKind::InoutNonLvalue
             } else {
                 ErrorKind::BorrowNonLvalue
             },
-            inst.span,
-        )),
-    }
+            rir.get(arg.value).span,
+        )
+    })
 }
 
 /// Build the use-after-move error for a field access whose path (or one of
@@ -979,9 +976,12 @@ fn root_variable_of(rir: &Rir, inst_ref: InstRef) -> Option<Spur> {
 ///
 /// This is the shared implementation behind [`Sema::check_exclusive_access`].
 /// It enforces three rules:
-/// 1. Inout/borrow arguments must be lvalues (refer to a variable)
-/// 2. Same variable cannot be passed to multiple inout parameters (prevents aliasing)
-/// 3. Same variable cannot be passed to both inout and borrow (law of exclusivity)
+/// 1. Inout/borrow arguments must be lvalues (a variable, or a field/index
+///    projection chain rooted at one — RUE-143)
+/// 2. Same ROOT variable cannot be passed to multiple inout parameters
+///    (prevents aliasing; conservatively, even disjoint fields conflict)
+/// 3. Same root variable cannot be passed to both inout and borrow (law of
+///    exclusivity)
 ///
 /// The law of exclusivity: either one mutable (inout) access OR any number of
 /// immutable (borrow) accesses, never both simultaneously.
@@ -5038,11 +5038,15 @@ impl<'a> Sema<'a> {
     /// Analyze a list of call arguments, enforcing by-ref argument rules.
     ///
     /// Inout/borrow arguments are borrows, not moves: `ctx.byref_arg_root` is
-    /// set while the argument value is analyzed so the variable-reference
-    /// analysis skips move tracking (and permits forwarding an inout parameter
-    /// to another function's by-ref parameter). By-ref arguments must also be
-    /// plain variables: codegen takes the address of the variable's slot
-    /// directly, and field/element projections are not supported yet (RUE-127).
+    /// set to the argument's ROOT variable while the argument value is
+    /// analyzed, so the variable-reference and place analyses skip move
+    /// tracking for it (and permit forwarding an inout parameter to another
+    /// function's by-ref parameter). A by-ref argument must be a place — a
+    /// variable, or a field/index projection chain rooted at one (`borrow
+    /// o.f`, `inout a[i]`, RUE-143); codegen forms the place's address.
+    ///
+    /// An `inout` argument rooted at a `borrow` parameter is rejected here:
+    /// it would hand the callee a mutable view of read-only memory.
     pub(crate) fn analyze_call_args(
         &mut self,
         air: &mut Air,
@@ -5052,7 +5056,21 @@ impl<'a> Sema<'a> {
         let mut air_args = Vec::new();
         for arg in args.iter() {
             let byref_root = if arg.is_inout() || arg.is_borrow() {
-                Some(require_plain_byref_arg(self.rir, arg)?)
+                let root = require_byref_place_arg(self.rir, arg)?;
+                if arg.is_inout()
+                    && ctx
+                        .params
+                        .iter()
+                        .any(|p| p.name == root && p.mode == RirParamMode::Borrow)
+                {
+                    return Err(CompileError::new(
+                        ErrorKind::MutateBorrowedValue {
+                            variable: self.interner.resolve(&root).to_string(),
+                        },
+                        self.rir.get(arg.value).span,
+                    ));
+                }
+                Some(root)
             } else {
                 None
             };

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -272,8 +272,16 @@ impl<'a> Sema<'a> {
                             None => return Ok(None), // Not an array
                         };
 
-                        // Analyze the index expression to get an AirRef
-                        let index_result = self.analyze_inst(air, *index, ctx)?;
+                        // Analyze the index expression to get an AirRef. The
+                        // index is an rvalue of its own, not part of the
+                        // place: a surrounding by-ref argument's borrow
+                        // (`byref_arg_root`, RUE-143) must not leak into it
+                        // (in `f(inout a[take(x)])` the call `take(x)` moves
+                        // x normally, even if x happens to be the root).
+                        let saved_byref_root = ctx.byref_arg_root.take();
+                        let index_result = self.analyze_inst(air, *index, ctx);
+                        ctx.byref_arg_root = saved_byref_root;
+                        let index_result = index_result?;
 
                         // Add this projection (no field name for indices)
                         trace.projections.push(ProjectionInfo {
@@ -1598,16 +1606,22 @@ impl<'a> Sema<'a> {
                         }
                     }
                     RirParamMode::Borrow => {
-                        // Note: this also rejects by-ref forwarding of a borrow
-                        // parameter (`f(borrow v)` inside `fn g(borrow v: T)`),
-                        // a pre-existing limitation kept as-is for now.
-                        let name_str = self.interner.resolve(&name);
-                        return Err(CompileError::new(
-                            ErrorKind::MoveOutOfBorrow {
-                                variable: name_str.to_string(),
-                            },
-                            span,
-                        ));
+                        // A by-ref argument use re-borrows the parameter:
+                        // `f(borrow v)` inside `fn g(borrow v: T)` is a sound
+                        // read-only re-borrow and is allowed (RUE-143).
+                        // `f(inout v)` — a mutable view of read-only memory —
+                        // was already rejected in `analyze_call_args` (E0428),
+                        // so a by-ref use reaching here is borrow-mode.
+                        // Anything else moves out of the borrow: rejected.
+                        if !is_byref_arg_use {
+                            let name_str = self.interner.resolve(&name);
+                            return Err(CompileError::new(
+                                ErrorKind::MoveOutOfBorrow {
+                                    variable: name_str.to_string(),
+                                },
+                                span,
+                            ));
+                        }
                     }
                 }
             }
@@ -2272,9 +2286,29 @@ impl<'a> Sema<'a> {
             // Move checking using the trace. `move_field` is the MarkMoved
             // marker's field component: None for a whole-struct (linear)
             // move, Some(index) for a single top-level field move (RUE-62).
+            //
+            // A use as a by-ref call argument (`f(borrow o.f)`, `f(inout
+            // o.f)`) borrows the place rather than moving out of it
+            // (RUE-143): no move is recorded and the by-ref-param move
+            // rejections don't apply — but reading through an already-moved
+            // path is still a use-after-move.
+            let is_byref_arg_use = ctx.byref_arg_root == Some(trace.root_var);
             let mut emit_move_marker = false;
             let mut move_field: Option<u32> = None;
-            if is_linear {
+            if is_byref_arg_use {
+                let field_path = trace.field_path();
+                if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
+                    if let Some(moved_span) = state.is_path_moved(&field_path) {
+                        return Err(super::analysis::use_after_move_path_error(
+                            self.interner,
+                            trace.root_var,
+                            &field_path,
+                            span,
+                            moved_span,
+                        ));
+                    }
+                }
+            } else if is_linear {
                 // For linear types, field access consumes the entire struct
                 self.reject_move_out_of_byref_param(trace.root_var, ctx, span)?;
                 ctx.moved_vars
@@ -2820,8 +2854,28 @@ impl<'a> Sema<'a> {
                 }
             }
 
-            // Prevent moving non-Copy elements out of arrays.
-            if !self.is_type_copy(elem_type) {
+            // A use as a by-ref call argument (`f(borrow a[i])`, `f(inout
+            // a[i])`) borrows the element in place rather than moving it out
+            // of the array (RUE-143), so the non-Copy rejection below does
+            // not apply — but indexing an already-moved array is still a
+            // use-after-move (`field_path()` of an index-terminated trace is
+            // empty, so this checks the root's full move).
+            let is_byref_arg_use = ctx.byref_arg_root == Some(trace.root_var);
+            if is_byref_arg_use {
+                let field_path = trace.field_path();
+                if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
+                    if let Some(moved_span) = state.is_path_moved(&field_path) {
+                        return Err(super::analysis::use_after_move_path_error(
+                            self.interner,
+                            trace.root_var,
+                            &field_path,
+                            span,
+                            moved_span,
+                        ));
+                    }
+                }
+            } else if !self.is_type_copy(elem_type) {
+                // Prevent moving non-Copy elements out of arrays.
                 return Err(CompileError::new(
                     ErrorKind::MoveOutOfIndex {
                         element_type: elem_type.safe_name_with_pool(Some(&self.type_pool)),

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -251,11 +251,13 @@ pub(crate) struct AnalysisContext<'a> {
     /// Methods referenced during analysis of this function.
     /// Each entry is (struct_id, method_name) matching the key format in methods map.
     pub referenced_methods: HashSet<(StructId, Spur)>,
-    /// While analyzing the value of an `inout`/`borrow` call argument, the root
-    /// variable being passed by reference (set by `analyze_call_args`). A by-ref
-    /// argument is a borrow, not a move, so the variable-reference analysis must
-    /// not mark the variable as moved — and must not reject forwarding an inout
-    /// parameter to another function's inout/borrow parameter.
+    /// While analyzing the value of an `inout`/`borrow` call argument, the ROOT
+    /// variable of the place being passed by reference (set by
+    /// `analyze_call_args`; for `f(borrow o.f)` this is `o`). A by-ref argument
+    /// is a borrow, not a move, so the variable-reference and place analyses
+    /// must not mark the root (or the projected path) as moved — and must not
+    /// reject forwarding a by-ref parameter to another function's by-ref
+    /// parameter (RUE-143).
     pub byref_arg_root: Option<Spur>,
     /// True while re-running a loop's condition/body to validate the loop's
     /// back edge (see [`AnalysisContext::fork_for_loop_recheck`]). The recheck
@@ -329,9 +331,12 @@ impl<'a> AnalysisContext<'a> {
             comptime_value_vars: self.comptime_value_vars.clone(),
             referenced_functions: HashSet::new(),
             referenced_methods: HashSet::new(),
-            // A by-ref argument's value is always a plain variable (enforced in
-            // analyze_call_args), so a loop can never be analyzed while this is
-            // set; the fork starts between whole-expression analyses.
+            // A by-ref argument's value is a place — a variable or a
+            // field/index projection chain (enforced in analyze_call_args) —
+            // and index subexpressions are analyzed with the root cleared
+            // (see try_trace_place_inner), so a loop can never be analyzed
+            // while this is set; the fork starts between whole-expression
+            // analyses.
             byref_arg_root: None,
             in_loop_move_recheck: true,
         }

--- a/crates/rue-cli-tests/cases/byref_params.toml
+++ b/crates/rue-cli-tests/cases/byref_params.toml
@@ -1,9 +1,20 @@
-# By-ref (inout/borrow) parameter soundness (RUE-127 items 3 and 4).
+# By-ref (inout/borrow) parameter soundness and projection arguments
+# (RUE-127 items 3 and 4; RUE-143).
 #
-# Item 3: passing a struct field or array element as an `inout`/`borrow`
-# argument used to panic codegen ("by-ref argument must be a variable" ICE in
-# cfg_lower). Codegen takes the address of a variable's slot directly and
-# cannot address a projection yet, so sema now rejects these with E0438.
+# Item 3 (superseded by RUE-143): passing a struct field or array element as
+# an `inout`/`borrow` argument used to panic codegen ("by-ref argument must
+# be a variable" ICE in cfg_lower), then was rejected in sema with E0438.
+# RUE-143 implemented place-address formation for by-ref arguments (shared
+# logic in rue-codegen's `byref_args` module), so field and index projections
+# are now accepted: the callee reads/writes the projected place in the
+# caller's frame through its address. E0438 is retired. What remains
+# rejected:
+#   - non-lvalue arguments (call results, literals, ...) — E0425/E0427
+#   - `inout` arguments rooted at a `borrow` parameter (a mutable view of
+#     read-only memory) — E0428
+#   - two by-ref arguments sharing a ROOT variable where at least one is
+#     inout (exclusive access is per root, conservatively: even disjoint
+#     fields conflict) — E0426/E0430
 #
 # Item 4: moving a non-Copy value out of an `inout` parameter (whole variable
 # or a field) compiled but left the CALLER's variable moved-from after the
@@ -14,60 +25,206 @@
 # Field-level moves out of `borrow` parameters are likewise rejected (E0429),
 # matching the existing whole-variable rule.
 #
-# Forwarding an inout parameter to another function's by-ref parameter
-# (`g(inout v)` inside `fn f(inout v: T)`) is a re-borrow, not a move, and
+# Forwarding a by-ref parameter to another function's by-ref parameter
+# (`g(inout v)` inside `fn f(inout v: T)`, and since RUE-143 also
+# `g(borrow v)` inside `fn f(borrow v: T)`) is a re-borrow, not a move, and
 # must keep working.
 
 [section]
 id = "cli.byref_params"
 name = "By-ref parameter soundness"
-description = "Field/element by-ref arguments and moves out of inout parameters (RUE-127)."
+description = "Field/element by-ref arguments and moves out of inout parameters (RUE-127, RUE-143)."
 
 # ---------------------------------------------------------------------------
-# Item 3: by-ref arguments must be plain variables
+# By-ref arguments accept place projections (RUE-143): the callee must see
+# the projected place AND inout writes must land in the caller's variable.
 # ---------------------------------------------------------------------------
 
 [[case]]
-name = "borrow_field_arg_rejected"
-description = "Passing a struct field as a borrow argument errors (E0438) instead of the former cfg_lower ICE."
+name = "borrow_field_arg_reads_place"
+description = "Passing a struct field as a borrow argument reads the field in place (formerly E0438, before that a cfg_lower ICE); the owner stays usable."
 files = [{ path = "main.rue", source = """
 struct Inner { x: i32 }
 struct Outer { f: Inner }
 fn peek(borrow v: Inner) -> i32 { v.x }
-fn main() -> i32 { let o = Outer { f: Inner { x: 7 } }; peek(borrow o.f) }
+fn main() -> i32 {
+    let o = Outer { f: Inner { x: 7 } };
+    let a = peek(borrow o.f);
+    a + peek(borrow o.f) + o.f.x
+}
 """ }]
-compile_fail = true
-error_contains = ["E0438", "by-ref argument must be a plain variable"]
+exit_code = 21
 
 [[case]]
-name = "inout_field_arg_rejected"
-description = "The inout variant of the same shape is rejected too."
+name = "inout_field_arg_writes_back"
+description = "The inout variant: the callee's writes through the field's address are visible in the caller's struct."
 files = [{ path = "main.rue", source = """
 struct Inner { x: i32 }
 struct Outer { f: Inner }
 fn bump(inout v: Inner) { v.x = v.x + 1; }
 fn main() -> i32 {
-    let mut o = Outer { f: Inner { x: 7 } };
+    let mut o = Outer { f: Inner { x: 40 } };
+    bump(inout o.f);
     bump(inout o.f);
     o.f.x
 }
 """ }]
-compile_fail = true
-error_contains = ["E0438", "by-ref argument must be a plain variable"]
+exit_code = 42
 
 [[case]]
-name = "borrow_array_element_arg_rejected"
-description = "Array elements cannot be passed by reference either (same codegen limitation)."
+name = "borrow_array_element_arg_reads_place"
+description = "A non-Copy array element can be borrowed in place (no move out of the array)."
 files = [{ path = "main.rue", source = """
 struct D { x: i32 }
 fn peek(borrow v: D) -> i32 { v.x }
 fn main() -> i32 {
     let a = [D { x: 3 }, D { x: 4 }];
-    peek(borrow a[0])
+    peek(borrow a[0]) + peek(borrow a[1])
+}
+""" }]
+exit_code = 7
+
+[[case]]
+name = "inout_array_element_arg_in_loop"
+description = "Dynamic-index inout element arguments: each loop iteration's bounds check and address point at the right element."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+fn bump(inout v: D) { v.x = v.x + 1; }
+fn main() -> i32 {
+    let mut a = [D { x: 0 }, D { x: 0 }, D { x: 0 }];
+    let mut i = 0;
+    while i < 3 {
+        bump(inout a[i]);
+        bump(inout a[i]);
+        i = i + 1;
+    }
+    a[0].x * 100 + a[1].x * 10 + a[2].x
+}
+""" }]
+exit_code = 222
+
+[[case]]
+name = "inout_array_element_out_of_bounds_traps"
+description = "The address of an out-of-bounds element is never formed: the call site bounds-checks and panics first."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+fn bump(inout v: D) { v.x = v.x + 1; }
+fn main() -> i32 {
+    let mut a = [D { x: 1 }, D { x: 2 }];
+    let i = 5;
+    bump(inout a[i]);
+    a[0].x
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["index out of bounds"]
+
+[[case]]
+name = "inout_field_through_inout_param"
+description = "A field of an inout parameter can be re-passed inout: the address is computed from the received pointer (descending slot offsets); the write surfaces in main's variable."
+files = [{ path = "main.rue", source = """
+struct Inner { x: i32, y: i32 }
+struct Outer { a: i32, f: Inner }
+fn bump(inout v: Inner) { v.x = v.x + 1; v.y = v.y + 2; }
+fn through(inout o: Outer) { bump(inout o.f); }
+fn main() -> i32 {
+    let mut o = Outer { a: 9, f: Inner { x: 10, y: 20 } };
+    through(inout o);
+    o.f.x + o.f.y + o.a
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "borrow_forward_of_borrow_param"
+description = "Re-borrowing a borrow parameter (whole or a field of it) is a sound read-only re-borrow and now compiles (RUE-143)."
+files = [{ path = "main.rue", source = """
+struct Inner { x: i32 }
+struct Outer { f: Inner }
+fn peek(borrow v: Inner) -> i32 { v.x }
+fn whole(borrow v: Inner) -> i32 { peek(borrow v) }
+fn through(borrow o: Outer) -> i32 { peek(borrow o.f) }
+fn main() -> i32 {
+    let o = Outer { f: Inner { x: 21 } };
+    whole(borrow o.f) + through(borrow o)
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "inout_arg_rooted_at_borrow_param_rejected"
+description = "An inout argument rooted at a borrow parameter would hand the callee a mutable view of read-only memory (E0428)."
+files = [{ path = "main.rue", source = """
+struct Inner { x: i32 }
+struct Outer { f: Inner }
+fn bump(inout v: Inner) { v.x = v.x + 1; }
+fn evil(borrow o: Outer) { bump(inout o.f); }
+fn main() -> i32 {
+    let o = Outer { f: Inner { x: 1 } };
+    evil(borrow o);
+    o.f.x
 }
 """ }]
 compile_fail = true
-error_contains = ["E0438", "by-ref argument must be a plain variable"]
+error_contains = ["E0428", "cannot mutate borrowed value"]
+
+[[case]]
+name = "byref_arg_non_lvalue_still_rejected"
+description = "A call result still cannot be passed by reference: there is no caller-visible place to point at (E0427)."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+fn mk() -> D { D { x: 1 } }
+fn peek(borrow v: D) -> i32 { v.x }
+fn main() -> i32 { peek(borrow mk()) }
+""" }]
+compile_fail = true
+error_contains = ["E0427", "borrow argument must be a variable"]
+
+[[case]]
+name = "inout_projections_same_root_rejected"
+description = "Exclusive access is per ROOT variable: two inout arguments projecting different fields of the same struct are rejected (E0426)."
+files = [{ path = "main.rue", source = """
+struct O { a: i32, b: i32 }
+fn swap(inout x: i32, inout y: i32) { let t = x; x = y; y = t; }
+fn main() -> i32 {
+    let mut o = O { a: 1, b: 2 };
+    swap(inout o.a, inout o.b);
+    o.a
+}
+""" }]
+compile_fail = true
+error_contains = ["E0426", "same variable 'o' to multiple inout parameters"]
+
+[[case]]
+name = "borrow_inout_projections_same_root_rejected"
+description = "Law of exclusivity by root: borrowing one field while inout-passing another field of the same struct is rejected (E0430)."
+files = [{ path = "main.rue", source = """
+struct O { a: i32, b: i32 }
+fn obs(borrow x: i32, inout y: i32) -> i32 { x + y }
+fn main() -> i32 {
+    let mut o = O { a: 1, b: 2 };
+    obs(borrow o.a, inout o.b)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0430", "cannot borrow 'o' while it is mutably borrowed"]
+
+[[case]]
+name = "borrow_of_moved_field_rejected"
+description = "Borrowing a field whose value was already moved out is a use-after-move (E0205)."
+files = [{ path = "main.rue", source = """
+struct D { x: i32 }
+struct O { f: D }
+fn consume(d: D) -> i32 { d.x }
+fn peek(borrow v: D) -> i32 { v.x }
+fn main() -> i32 {
+    let o = O { f: D { x: 1 } };
+    let a = consume(o.f);
+    a + peek(borrow o.f)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "use of moved value 'o.f'"]
 
 [[case]]
 name = "borrow_whole_variable_still_works"

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1443,49 +1443,12 @@ impl<'a> CfgLower<'a> {
                     let arg_value = arg.value;
                     let arg_type = self.ctx.cfg.get_inst(arg_value).ty;
 
-                    // For by-ref args (inout or borrow), pass address instead of value
+                    // For by-ref args (inout or borrow), pass the address of
+                    // the argument place — a variable, field, or array
+                    // element (RUE-143). Single shared implementation — see
+                    // crate::byref_args.
                     if arg.is_by_ref() {
-                        let arg_data = &self.ctx.cfg.get_inst(arg_value).data;
-                        let addr_vreg = self.mir.alloc_vreg();
-
-                        match arg_data {
-                            CfgInstData::Load { slot } => {
-                                // Emit add to calculate the address of the local variable
-                                // add addr_vreg, fp, #offset
-                                let offset = self.ctx.local_offset(*slot);
-                                self.mir.push(Aarch64Inst::AddImm {
-                                    dst: Operand::Virtual(addr_vreg),
-                                    src: Operand::Physical(Reg::Fp),
-                                    imm: offset,
-                                });
-                            }
-                            CfgInstData::Param { index } => {
-                                // Check if this param is itself a by-ref param (forwarding case)
-                                if self.ctx.cfg.is_param_inout(*index) {
-                                    // For by-ref param, just pass the pointer we received
-                                    // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
-                                    let ptr_vreg = self.ensure_inout_param_ptr(*index);
-                                    self.mir.push(Aarch64Inst::MovRR {
-                                        dst: Operand::Virtual(addr_vreg),
-                                        src: Operand::Virtual(ptr_vreg),
-                                    });
-                                } else {
-                                    // Normal param: emit add to get its address
-                                    let param_slot = self.ctx.num_locals + *index;
-                                    let offset = self.ctx.local_offset(param_slot);
-                                    self.mir.push(Aarch64Inst::AddImm {
-                                        dst: Operand::Virtual(addr_vreg),
-                                        src: Operand::Physical(Reg::Fp),
-                                        imm: offset,
-                                    });
-                                }
-                            }
-                            _ => {
-                                // For other sources (StructInit, Call result, etc.),
-                                // we can't take an address - this should have been caught earlier
-                                panic!("by-ref argument must be a variable, not {:?}", arg_data);
-                            }
-                        }
+                        let addr_vreg = crate::byref_args::lower_byref_arg_addr(self, arg_value);
                         flattened_vregs.push(addr_vreg);
                         continue;
                     }
@@ -3990,9 +3953,13 @@ impl<'a> CfgLower<'a> {
         total_offset_vreg.expect("compute_index_offset called with empty levels")
     }
 
-    /// Compute the address of a place (for @raw intrinsic).
+    /// Compute the address of a place (for the @raw intrinsic and for by-ref
+    /// call arguments via `crate::byref_args`, RUE-143).
     ///
-    /// This is similar to lower_place_read but returns the address instead of loading.
+    /// This is similar to lower_place_read but returns the address instead of
+    /// loading. Index projections are NOT bounds-checked here (@raw is
+    /// deliberately unchecked); by-ref arguments bounds-check first in
+    /// `byref_args::lower_byref_arg_addr`.
     fn lower_place_addr(&mut self, dst: VReg, place: &Place) {
         let projections = self.ctx.cfg.get_place_projections(place);
 
@@ -4168,6 +4135,26 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             base: ptr,
             offset: byte_offset,
         });
+    }
+}
+
+impl crate::byref_args::ByrefAddrBackend for CfgLower<'_> {
+    fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg {
+        CfgLower::ensure_inout_param_ptr(self, param_slot)
+    }
+    fn emit_frame_addr(&mut self, dst: VReg, slot: u32) {
+        let offset = self.ctx.local_offset(slot);
+        self.mir.push(Aarch64Inst::AddImm {
+            dst: Operand::Virtual(dst),
+            src: Operand::Physical(Reg::Fp),
+            imm: offset,
+        });
+    }
+    fn emit_bounds_check(&mut self, index_vreg: VReg, length: u64) {
+        CfgLower::emit_bounds_check(self, index_vreg, length)
+    }
+    fn emit_place_addr(&mut self, dst: VReg, place: &Place) {
+        CfgLower::lower_place_addr(self, dst, place)
     }
 }
 

--- a/crates/rue-codegen/src/byref_args.rs
+++ b/crates/rue-codegen/src/byref_args.rs
@@ -1,0 +1,107 @@
+//! Shared by-ref (inout/borrow) call-argument address formation (RUE-143).
+//!
+//! A by-ref argument is passed as the ADDRESS of a place: a plain variable
+//! (`f(inout x)`), a field projection (`f(borrow o.f)`), an array element
+//! (`f(inout a[i])`), or a projection through a by-ref parameter the caller
+//! itself received (`f(inout p.f)` inside `fn g(inout p: T)`). Historically
+//! each backend handled only the plain-variable shapes and panicked on
+//! projections ("by-ref argument must be a variable"); sema mirrored the
+//! limitation by rejecting projections with the now-retired E0438.
+//!
+//! Like [`crate::agg_slots`], the decision logic here is target-independent —
+//! which argument shapes are addressable, that every index projection is
+//! bounds-checked before the address is formed — so backends only provide
+//! the leaf operations via [`ByrefAddrBackend`]: take a frame slot's address,
+//! fetch a received by-ref pointer, emit a bounds check, and form a projected
+//! place's address (the same math the backend's `PlaceRead`/`PlaceWrite`
+//! lowering uses: frame base + static field-slot offsets, minus dynamic index
+//! offsets; through a by-ref pointer the offsets descend per the ABI
+//! convention — caller slots grow downward).
+
+use rue_cfg::{CfgInstData, CfgValue, Place, Projection};
+
+use crate::agg_slots::SlotBackend;
+use crate::vreg::VReg;
+
+/// The per-backend leaf operations by-ref address formation needs, on top of
+/// the [`SlotBackend`] basics (`ctx`, `alloc_vreg`, `get_vreg`,
+/// `emit_reg_move`).
+pub trait ByrefAddrBackend: SlotBackend {
+    /// Get (or lazily materialize) the pointer vreg of a by-ref (inout or
+    /// borrow) parameter of the CURRENT function.
+    fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg;
+
+    /// Emit `dst = address of frame slot` (`lea dst, [rbp+off]` /
+    /// `add dst, fp, #off`).
+    fn emit_frame_addr(&mut self, dst: VReg, slot: u32);
+
+    /// Emit a bounds check trapping when `index_vreg >= length`.
+    fn emit_bounds_check(&mut self, index_vreg: VReg, length: u64);
+
+    /// Emit `dst = address of the (possibly projected) place`. Does NOT
+    /// bounds-check index projections; the shared logic does that first.
+    fn emit_place_addr(&mut self, dst: VReg, place: &Place);
+}
+
+/// Lower a by-ref (inout/borrow) call argument to the vreg holding its
+/// address.
+///
+/// Sema guarantees the argument is a place: a variable (`Load`/`Param`) or a
+/// field/index projection chain rooted at one (`PlaceRead`). Anything else is
+/// a compiler bug, hence the panic.
+pub fn lower_byref_arg_addr<B: ByrefAddrBackend + ?Sized>(b: &mut B, arg_value: CfgValue) -> VReg {
+    // Extract the small Copy payload first so the CFG borrow ends before we
+    // emit (emission needs `&mut B`).
+    enum ArgShape {
+        Local(u32),
+        Param(u32),
+        Place(Place),
+    }
+    let shape = match &b.ctx().cfg.get_inst(arg_value).data {
+        CfgInstData::Load { slot } => ArgShape::Local(*slot),
+        CfgInstData::Param { index } => ArgShape::Param(*index),
+        CfgInstData::PlaceRead { place } => ArgShape::Place(*place),
+        other => panic!("by-ref argument must be a place, not {:?}", other),
+    };
+
+    match shape {
+        ArgShape::Local(slot) => {
+            let addr_vreg = b.alloc_vreg();
+            b.emit_frame_addr(addr_vreg, slot);
+            addr_vreg
+        }
+        ArgShape::Param(index) => {
+            let addr_vreg = b.alloc_vreg();
+            if b.ctx().cfg.is_param_inout(index) {
+                // Forwarding a by-ref param: pass along the pointer we
+                // received. ensure_inout_param_ptr covers params never
+                // accessed via a Param instruction.
+                let ptr_vreg = b.ensure_inout_param_ptr(index);
+                b.emit_reg_move(addr_vreg, ptr_vreg);
+            } else {
+                // Normal param: it lives in a frame slot after the locals.
+                let slot = b.ctx().num_locals + index;
+                b.emit_frame_addr(addr_vreg, slot);
+            }
+            addr_vreg
+        }
+        ArgShape::Place(place) => {
+            // Bounds-check every index projection BEFORE forming the address:
+            // the callee accesses memory through this pointer, so an
+            // out-of-bounds index must trap at the call site (the projected
+            // PlaceRead the arg expression also lowers to is a dead value —
+            // its own bounds check does not protect the address).
+            let projections: Vec<Projection> = b.ctx().cfg.get_place_projections(&place).to_vec();
+            for proj in &projections {
+                if let Projection::Index { array_type, index } = proj {
+                    let length = b.ctx().array_length(*array_type);
+                    let index_vreg = b.get_vreg(*index);
+                    b.emit_bounds_check(index_vreg, length);
+                }
+            }
+            let addr_vreg = b.alloc_vreg();
+            b.emit_place_addr(addr_vreg, &place);
+            addr_vreg
+        }
+    }
+}

--- a/crates/rue-codegen/src/lib.rs
+++ b/crates/rue-codegen/src/lib.rs
@@ -45,6 +45,7 @@ mod stack_frame;
 
 pub mod aarch64;
 pub mod agg_slots;
+pub mod byref_args;
 pub mod cfg_lower;
 pub mod index_map;
 pub mod liveness;

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1697,48 +1697,12 @@ impl<'a> CfgLower<'a> {
                     let arg_value = arg.value;
                     let arg_type = self.ctx.cfg.get_inst(arg_value).ty;
 
-                    // For by-ref args (inout or borrow), pass address instead of value
+                    // For by-ref args (inout or borrow), pass the address of
+                    // the argument place — a variable, field, or array
+                    // element (RUE-143). Single shared implementation — see
+                    // crate::byref_args.
                     if arg.is_by_ref() {
-                        let arg_data = &self.ctx.cfg.get_inst(arg_value).data;
-                        let addr_vreg = self.mir.alloc_vreg();
-
-                        match arg_data {
-                            CfgInstData::Load { slot } => {
-                                // Emit lea to get the address of the local variable
-                                let offset = self.ctx.local_offset(*slot);
-                                self.mir.push(X86Inst::Lea {
-                                    dst: Operand::Virtual(addr_vreg),
-                                    base: Reg::Rbp,
-                                    disp: offset,
-                                });
-                            }
-                            CfgInstData::Param { index } => {
-                                // Check if this param is itself a by-ref param (forwarding case)
-                                if self.ctx.cfg.is_param_inout(*index) {
-                                    // For by-ref param, just pass the pointer we received
-                                    // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
-                                    let ptr_vreg = self.ensure_inout_param_ptr(*index);
-                                    self.mir.push(X86Inst::MovRR {
-                                        dst: Operand::Virtual(addr_vreg),
-                                        src: Operand::Virtual(ptr_vreg),
-                                    });
-                                } else {
-                                    // Normal param: emit lea to get its address
-                                    let param_slot = self.ctx.num_locals + *index;
-                                    let offset = self.ctx.local_offset(param_slot);
-                                    self.mir.push(X86Inst::Lea {
-                                        dst: Operand::Virtual(addr_vreg),
-                                        base: Reg::Rbp,
-                                        disp: offset,
-                                    });
-                                }
-                            }
-                            _ => {
-                                // For other sources (StructInit, Call result, etc.),
-                                // we can't take an address - this should have been caught earlier
-                                panic!("by-ref argument must be a variable, not {:?}", arg_data);
-                            }
-                        }
+                        let addr_vreg = crate::byref_args::lower_byref_arg_addr(self, arg_value);
                         flattened_vregs.push(addr_vreg);
                         continue;
                     }
@@ -3961,9 +3925,13 @@ impl<'a> CfgLower<'a> {
         total_offset_vreg.expect("compute_index_offset called with empty levels")
     }
 
-    /// Compute the address of a place (for @raw intrinsic).
+    /// Compute the address of a place (for the @raw intrinsic and for by-ref
+    /// call arguments via `crate::byref_args`, RUE-143).
     ///
-    /// This is similar to lower_place_read but returns the address instead of loading.
+    /// This is similar to lower_place_read but returns the address instead of
+    /// loading. Index projections are NOT bounds-checked here (@raw is
+    /// deliberately unchecked); by-ref arguments bounds-check first in
+    /// `byref_args::lower_byref_arg_addr`.
     fn lower_place_addr(&mut self, dst: VReg, place: &Place) {
         let projections = self.ctx.cfg.get_place_projections(place);
 
@@ -4135,6 +4103,26 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
             offset: byte_offset,
             src: Operand::Virtual(src),
         });
+    }
+}
+
+impl crate::byref_args::ByrefAddrBackend for CfgLower<'_> {
+    fn ensure_inout_param_ptr(&mut self, param_slot: u32) -> VReg {
+        CfgLower::ensure_inout_param_ptr(self, param_slot)
+    }
+    fn emit_frame_addr(&mut self, dst: VReg, slot: u32) {
+        let offset = self.ctx.local_offset(slot);
+        self.mir.push(X86Inst::Lea {
+            dst: Operand::Virtual(dst),
+            base: Reg::Rbp,
+            disp: offset,
+        });
+    }
+    fn emit_bounds_check(&mut self, index_vreg: VReg, length: u64) {
+        CfgLower::emit_bounds_check(self, index_vreg, length)
+    }
+    fn emit_place_addr(&mut self, dst: VReg, place: &Place) {
+        CfgLower::lower_place_addr(self, dst, place)
     }
 }
 

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -126,7 +126,8 @@ impl ErrorCode {
     pub const RESERVED_FUNCTION_NAME: Self = Self(435);
     pub const DUPLICATE_FUNCTION_DEFINITION: Self = Self(436);
     pub const MOVE_OUT_OF_INOUT: Self = Self(437);
-    pub const BY_REF_ARG_NOT_PLAIN_VARIABLE: Self = Self(438);
+    // 438 (BY_REF_ARG_NOT_PLAIN_VARIABLE) is retired: by-ref arguments may
+    // now be field/index projections (RUE-143). Do not reuse the number.
     // 439-441 are reserved by in-flight work; next free code is 444.
     pub const MOVE_SELF_OUT_OF_DESTRUCTOR: Self = Self(442);
     pub const LINEAR_VALUE_NOT_CONSUMED_ON_ALL_PATHS: Self = Self(443);
@@ -1000,10 +1001,6 @@ pub enum ErrorKind {
     /// Argument to borrow parameter is missing `borrow` keyword at call site
     #[error("argument to borrow parameter must use 'borrow' keyword")]
     BorrowKeywordMissing,
-    /// By-ref (inout/borrow) argument is a field or element projection, which
-    /// codegen cannot take the address of yet (RUE-127)
-    #[error("a by-ref argument must be a plain variable; passing a field is not yet supported")]
-    ByRefArgNotPlainVariable,
     /// Cannot move a value out of an inout parameter (would leave the caller's
     /// variable moved-from)
     #[error("cannot move out of inout parameter '{variable}'")]
@@ -1196,7 +1193,6 @@ impl ErrorKind {
             ErrorKind::BorrowInoutConflict { .. } => ErrorCode::BORROW_INOUT_CONFLICT,
             ErrorKind::InoutKeywordMissing => ErrorCode::INOUT_KEYWORD_MISSING,
             ErrorKind::BorrowKeywordMissing => ErrorCode::BORROW_KEYWORD_MISSING,
-            ErrorKind::ByRefArgNotPlainVariable => ErrorCode::BY_REF_ARG_NOT_PLAIN_VARIABLE,
             ErrorKind::MoveOutOfInout { .. } => ErrorCode::MOVE_OUT_OF_INOUT,
             ErrorKind::MoveSelfOutOfDestructor { .. } => ErrorCode::MOVE_SELF_OUT_OF_DESTRUCTOR,
 

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -547,6 +547,88 @@ params = [
 ]
 
 # =============================================================================
+# By-ref arguments that are field / array-element projections (RUE-143)
+# =============================================================================
+
+[[case]]
+name = "inout_field_arg_mutates_in_place"
+spec = ["6.1:17", "6.1:18"]
+description = "A struct field passed inout is mutated in place; the change is visible through the caller's variable"
+source = """
+struct Inner { x: i32 }
+struct Outer { f: Inner }
+fn bump(inout v: Inner) {
+    v.x = v.x + 1;
+}
+fn main() -> i32 {
+    let mut o = Outer { f: Inner { x: 41 } };
+    bump(inout o.f);
+    o.f.x
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_array_element_arg_dynamic_index"
+spec = ["6.1:17", "6.1:18"]
+description = "An array element selected by a runtime index can be passed inout; the write lands in the right element"
+source = """
+struct D { x: i32 }
+fn bump(inout v: D) {
+    v.x = v.x + 1;
+}
+fn main() -> i32 {
+    let mut a = [D { x: 10 }, D { x: 20 }];
+    let i = 1;
+    bump(inout a[i]);
+    a[0].x + a[1].x * 2
+}
+"""
+exit_code = 52
+
+[[case]]
+name = "inout_field_through_inout_param"
+spec = ["6.1:17", "6.1:18"]
+description = "A field of an inout parameter can itself be passed inout (address computed from the received pointer)"
+source = """
+struct Inner { x: i32, y: i32 }
+struct Outer { a: i32, f: Inner }
+fn bump(inout v: Inner) {
+    v.x = v.x + 1;
+    v.y = v.y + 2;
+}
+fn through(inout o: Outer) {
+    bump(inout o.f);
+}
+fn main() -> i32 {
+    let mut o = Outer { a: 9, f: Inner { x: 10, y: 20 } };
+    through(inout o);
+    o.f.x + o.f.y + o.a
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_exclusive_access_same_root_fields"
+spec = ["6.1:20"]
+description = "Two inout arguments projecting different fields of the same variable share a root and are rejected"
+source = """
+struct O { a: i32, b: i32 }
+fn swap(inout x: i32, inout y: i32) {
+    let t = x;
+    x = y;
+    y = t;
+}
+fn main() -> i32 {
+    let mut o = O { a: 1, b: 2 };
+    swap(inout o.a, inout o.b);
+    o.a
+}
+"""
+compile_fail = true
+error_contains = "same variable"
+
+# =============================================================================
 # Borrow parameters
 # =============================================================================
 
@@ -601,6 +683,64 @@ compile_fail = true
 error_contains = "cannot move out of borrowed"
 
 [[case]]
+name = "borrow_field_arg_reads_in_place"
+spec = ["6.1:26"]
+description = "A struct field passed borrow is read through its address; the owner is not moved and stays usable"
+source = """
+struct D { x: i32 }
+struct O { f: D }
+fn peek(borrow v: D) -> i32 {
+    v.x
+}
+fn main() -> i32 {
+    let o = O { f: D { x: 14 } };
+    let a = peek(borrow o.f);
+    let b = peek(borrow o.f);
+    a + b + o.f.x
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "borrow_array_element_arg"
+spec = ["6.1:26"]
+description = "An array element of non-Copy type can be borrowed in place (no move out of the array)"
+source = """
+struct D { x: i32 }
+fn peek(borrow v: D) -> i32 {
+    v.x
+}
+fn main() -> i32 {
+    let a = [D { x: 40 }, D { x: 2 }];
+    let i = 0;
+    peek(borrow a[i]) + peek(borrow a[1])
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "borrow_param_field_inout_arg_rejected"
+spec = ["6.1:24"]
+description = "Passing a field of a borrow parameter as an inout argument is a mutation of the borrow and is rejected"
+source = """
+struct Inner { x: i32 }
+struct Outer { f: Inner }
+fn bump(inout v: Inner) {
+    v.x = v.x + 1;
+}
+fn evil(borrow o: Outer) {
+    bump(inout o.f);
+}
+fn main() -> i32 {
+    let o = Outer { f: Inner { x: 1 } };
+    evil(borrow o);
+    o.f.x
+}
+"""
+compile_fail = true
+error_contains = "cannot mutate borrowed"
+
+[[case]]
 name = "borrow_inout_conflict"
 spec = ["6.1:30"]
 description = "Cannot borrow and inout the same variable in one call"
@@ -612,6 +752,24 @@ fn main() -> i32 {
     let mut x = 41;
     conflict(borrow x, inout x);
     x
+}
+"""
+compile_fail = true
+error_contains = "borrow"
+
+[[case]]
+name = "borrow_inout_conflict_same_root_fields"
+spec = ["6.1:30"]
+description = "Borrowing one field while passing another field of the same variable inout shares a root and is rejected"
+source = """
+struct O { a: i32, b: i32 }
+fn conflict(borrow x: i32, inout y: i32) {
+    y = x + 1;
+}
+fn main() -> i32 {
+    let mut o = O { a: 1, b: 2 };
+    conflict(borrow o.a, inout o.b);
+    o.b
 }
 """
 compile_fail = true

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -68,9 +68,9 @@ An argument to an `inout` parameter **MUST** be an lvalue (a variable, field acc
 {{ rule(id="6.1:18", cat="dynamic-semantics") }}
 
 When a function is called with an `inout` argument:
-1. The address of the argument is passed to the callee
+1. The address of the argument place is passed to the callee. For a field access or array index argument, this is the address of that field or element (an out-of-bounds index causes a runtime panic before the call); for a place rooted at a by-ref parameter of the caller, it is computed from the pointer the caller received
 2. The callee reads and writes to the argument through this address
-3. After the call returns, the original variable holds the updated value
+3. After the call returns, the original place holds the updated value, visible to the caller
 
 {{ rule(id="6.1:19", cat="example") }}
 
@@ -88,7 +88,7 @@ fn main() -> i32 {
 
 {{ rule(id="6.1:20", cat="legality-rule") }}
 
-A single function call **MUST NOT** pass the same variable to multiple `inout` parameters. This prevents aliasing of mutable references within a single call.
+A single function call **MUST NOT** pass the same variable to multiple `inout` parameters. This prevents aliasing of mutable references within a single call. The rule applies to the argument's root variable: two arguments that project different fields or elements of the same variable (such as `o.a` and `o.b`) are likewise rejected.
 
 {{ rule(id="6.1:21", cat="example") }}
 
@@ -122,6 +122,7 @@ The body of a function **MUST NOT** mutate a `borrow` parameter. This includes:
 - Assignment to the parameter itself
 - Assignment to fields of the parameter
 - Assignment to array elements of the parameter
+- Passing the parameter, or any field or element of it, as an `inout` argument
 
 {{ rule(id="6.1:25", cat="legality-rule") }}
 
@@ -130,9 +131,9 @@ The body of a function **MUST NOT** move out of a `borrow` parameter. A borrowed
 {{ rule(id="6.1:26", cat="dynamic-semantics") }}
 
 When a function is called with a `borrow` argument:
-1. The address of the argument is passed to the callee
+1. The address of the argument place is passed to the callee. For a field access or array index argument, this is the address of that field or element (an out-of-bounds index causes a runtime panic before the call); for a place rooted at a by-ref parameter of the caller, it is computed from the pointer the caller received
 2. The callee reads from the argument through this address
-3. After the call returns, the original variable is unchanged and still valid
+3. After the call returns, the original variable is unchanged and still valid; a borrowed place is not moved out of its owner
 
 {{ rule(id="6.1:27", cat="example") }}
 
@@ -169,7 +170,7 @@ fn main() -> i32 {
 
 {{ rule(id="6.1:30", cat="legality-rule") }}
 
-A single function call **MUST NOT** pass the same variable to both a `borrow` parameter and an `inout` parameter. This enforces the law of exclusivity: either one `inout` or any number of `borrow` accesses, but never both simultaneously.
+A single function call **MUST NOT** pass the same variable to both a `borrow` parameter and an `inout` parameter. This enforces the law of exclusivity: either one `inout` or any number of `borrow` accesses, but never both simultaneously. As with rule 6.1:20, the rule applies to the argument's root variable: a `borrow` of one field and an `inout` of another field of the same variable are likewise rejected.
 
 {{ rule(id="6.1:31", cat="example") }}
 


### PR DESCRIPTION
Implements RUE-143 (place-address lowering, approved): `inout p.y`, `borrow p.x`, and `inout a[i]` now work end-to-end instead of being rejected with E0438.

**Sema.** `require_byref_place_arg` accepts field/index projection chains rooted at a variable; E0438 is retired from rue-error. Field/index analyses treat byref-arg uses as borrows (no move marking — use-after-move remains E0205); index subexpressions are analyzed with the byref root suspended. New **E0428** rejects inout args rooted at borrow params, which also closes a pre-existing Copy-type unsoundness (mutating through a borrow). Borrow re-borrow of borrow params is now allowed. Exclusive-access rules still conflict by root variable.

**Codegen.** New shared `crates/rue-codegen/src/byref_args.rs` — a `ByrefAddrBackend` trait + `lower_byref_arg_addr` that emits call-site bounds checks for index projections and then delegates to the backend's place-address lowering. Both backends' previously-panicking by-ref match arms are replaced with one shared call + thin 4-method trait impls (aarch64 verified via `--emit asm`).

**Spec.** 6.1:18/20/24/26/30 amended: address-of-place semantics, root-variable exclusivity, inout-of-borrow-projection counts as mutation.

**Tests.** 3 E0438 CLI cases flipped to positive run cases (callee reads + caller-visible inout writes); 10 new CLI cases (in-loop dynamic index, OOB trap at the call site, inout-param projection, borrow forwarding, E0426/E0427/E0428/E0430/E0205); 8 new spec cases. Full ./test.sh green, traceability 100%.

Verified end-to-end post-integration: field inout, dynamic-index inout, borrow-of-field (exit 43 composite), and OOB index at the call site traps with `index out of bounds` exit 101.

Fixes RUE-143

🤖 Generated with [Claude Code](https://claude.com/claude-code)