### PR TITLE
x86-64 peephole: rewrite Cmp64RI{0} to Test64RR, not 32-bit TestRR

### DIFF
--- a/crates/rue-cli-tests/cases/intcast.toml
+++ b/crates/rue-cli-tests/cases/intcast.toml
@@ -105,3 +105,35 @@ exit_code = 101
 runtime_error_contains = ["integer cast overflow"]
 known_bug = "RUE-31"
 known_bug_on = ["aarch64-linux", "aarch64-macos"]
+
+# RUE-146: the x86-64 peephole rewrote the signed->unsigned negativity check
+# (`cmp64 r, 0`) into the 32-bit `test r, r`, so SF came from the low 32 bits
+# of the 64-bit source. Both directions broke: a negative i64 whose low 32
+# bits are non-negative skipped the mandatory trap, and a positive i64 whose
+# low 32 bits are negative trapped falsely. Values are produced via a function
+# call so constant folding cannot elide the runtime check.
+
+[[case]]
+name = "i64_negative_high_bits_to_u64_traps"
+files = [{ path = "main.rue", source = """
+fn g() -> i64 { 0 - 4294967296 }    // low 32 bits are all zero
+fn main() -> i32 {
+    let x: i64 = g();
+    let y: u64 = @intCast(x);       // negative -> must trap
+    if y == 0 { 1 } else { 2 }
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["integer cast overflow"]
+
+[[case]]
+name = "i64_positive_low_sign_bit_to_u64_ok"
+files = [{ path = "main.rue", source = """
+fn g() -> i64 { 2147483648 }        // bit 31 set, but positive as i64
+fn main() -> i32 {
+    let x: i64 = g();
+    let y: u64 = @intCast(x);       // in range -> must NOT trap
+    if y == 2147483648 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0

--- a/crates/rue-codegen/src/x86_64/peephole.rs
+++ b/crates/rue-codegen/src/x86_64/peephole.rs
@@ -65,8 +65,10 @@ fn transform_single(inst: &X86Inst) -> Option<X86Inst> {
             src2: *src,
         }),
 
-        // cmp64 r, 0 → test r, r (64-bit version)
-        X86Inst::Cmp64RI { src, imm: 0 } => Some(X86Inst::TestRR {
+        // cmp64 r, 0 → test64 r, r (64-bit version)
+        // Must stay 64-bit: the 32-bit `test` only sets SF/ZF from the low
+        // 32 bits, which broke @intCast i64->u64 range checks (RUE-146).
+        X86Inst::Cmp64RI { src, imm: 0 } => Some(X86Inst::Test64RR {
             src1: *src,
             src2: *src,
         }),
@@ -410,12 +412,14 @@ mod tests {
 
         assert_eq!(changes, 1);
         assert_eq!(instructions.len(), 2);
+        // Must be the 64-bit test: a 32-bit `test` would only set SF/ZF from
+        // the low 32 bits (RUE-146).
         match &instructions[0] {
-            X86Inst::TestRR { src1, src2 } => {
+            X86Inst::Test64RR { src1, src2 } => {
                 assert!(operands_equal(src1, src2));
                 assert!(matches!(src1, Operand::Physical(Reg::Rbx)));
             }
-            other => panic!("Expected TestRR, got {:?}", other),
+            other => panic!("Expected Test64RR, got {:?}", other),
         }
     }
 


### PR DESCRIPTION
The x86-64 peephole rewrote `Cmp64RI { imm: 0 }` into the **32-bit** `TestRR` (opcode 85, no REX.W), so the flags came from the low 32 bits only. The lone producer of that pattern is @intCast's signed→unsigned negativity check, which was broken in both directions:

- `-4294967296i64` (low-32 bits zero) silently cast to u64 — **missed mandatory panic** (spec 4.13:28)
- `2147483648i64` (bit 31 set) **spuriously panicked** on a perfectly valid cast

Now rewrites to the already-existing `Test64RR` (REX.W). Audit results: `Cmp64RI` was the only width-dropping rewrite in peephole.rs (CmpRI→TestRR, MovRI32{0}→XorRR, add-chain combining, and identity removals are all width-safe). aarch64's parallel `CmpImm{0}→TstRR` is already full-width (`ANDS` with sf=1) — verified via `--emit asm` (`tst x19, x19; b.ge`), no change needed.

Tests: 2 new CLI cases pinning both cast directions (routed through a function so constfold can't hide the runtime check); the peephole unit test pins the Test64RR rewrite; the Test64RR REX.W byte encoding (`48 85 C0`) was already pinned in emit.rs. Full ./test.sh green.

Worker audit also surfaced two latent (not currently reachable) flags hazards worth tracking separately: `mov r,0 → xor` writes flags MOV doesn't, and aarch64's `cmp #0 → tst` flips C for unsigned conditions — filing as a follow-up issue.

Fixes RUE-146

🤖 Generated with [Claude Code](https://claude.com/claude-code)