### PR TITLE
Inference: bind int-literal defaults to the chain representative; parser: leading ! in intrinsic args is logical not

### DIFF
--- a/crates/rue-air/src/inference/unify.rs
+++ b/crates/rue-air/src/inference/unify.rs
@@ -501,10 +501,15 @@ impl Unifier {
         for &var in int_literal_vars {
             // Check if this variable is already bound to a concrete type
             let resolved = self.substitution.apply(&InferType::Var(var));
-            if let InferType::Var(_) = resolved {
-                // Still unbound - default to i32
+            if let InferType::Var(rep) = resolved {
+                // Still unbound - default to i32. Bind the *representative*
+                // (the end of the substitution chain), not the literal's own
+                // variable: unification may have chained the literal to
+                // another variable (e.g. a binop result var for `-(3 + 4)`),
+                // and binding only the literal var would overwrite that chain
+                // and leave the result var unresolved as `<error>` (RUE-149).
                 self.substitution
-                    .insert(var, InferType::Concrete(Type::I32));
+                    .insert(rep, InferType::Concrete(Type::I32));
             }
             // If it resolved to Concrete, it was already constrained - no action needed
         }
@@ -1011,6 +1016,25 @@ mod tests {
         assert_eq!(unifier.resolve(&InferType::Var(v1)), Some(Type::I32));
         // v2 should still be Bool
         assert_eq!(unifier.resolve(&InferType::Var(v2)), Some(Type::BOOL));
+    }
+
+    #[test]
+    fn test_default_int_literal_vars_chained() {
+        // A literal var chained to another var (e.g. the result var of a
+        // binop, as in `-(3 + 4)`) must default the *representative*, so the
+        // chained var resolves to i32 too instead of staying unbound and
+        // decaying to `<error>` (RUE-149).
+        let mut unifier = Unifier::new();
+        let v0 = TypeVarId::new(0);
+        let v2 = TypeVarId::new(2);
+
+        // v0 (the literal) was unified with v2 (the binop result var).
+        unifier.substitution.insert(v0, InferType::Var(v2));
+
+        unifier.default_int_literal_vars(&[v0]);
+
+        assert_eq!(unifier.resolve(&InferType::Var(v0)), Some(Type::I32));
+        assert_eq!(unifier.resolve(&InferType::Var(v2)), Some(Type::I32));
     }
 
     #[test]

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -3037,6 +3037,19 @@ impl<'a> Sema<'a> {
         let arg_result = self.analyze_inst(air, args[0].value, ctx)?;
         let arg_type = arg_result.ty;
 
+        // An `<error>`-typed argument reaching here via `Ok` means no
+        // diagnostic was emitted for it (sema errors propagate as `Err`), so
+        // type inference failed silently. Report a proper internal error
+        // instead of letting codegen hit its `unreachable!` (RUE-149).
+        if arg_type.is_error() {
+            return Err(CompileError::new(
+                ErrorKind::InternalError(
+                    "@dbg argument type failed to resolve during inference".to_string(),
+                ),
+                span,
+            ));
+        }
+
         // Validate type: @dbg supports integers, bool, and String (spec 4.13:7).
         // Structs, enums, and arrays must be rejected HERE — codegen has no
         // lowering for them and would panic ("@dbg only supports scalars and
@@ -3044,7 +3057,6 @@ impl<'a> Sema<'a> {
         if !arg_type.is_integer()
             && arg_type != Type::BOOL
             && !self.is_builtin_string(arg_type)
-            && !arg_type.is_error()
             && !arg_type.is_never()
         {
             return Err(CompileError::new(

--- a/crates/rue-cli-tests/cases/intrinsic_args.toml
+++ b/crates/rue-cli-tests/cases/intrinsic_args.toml
@@ -42,3 +42,66 @@ fn main() -> i32 {
 ]
 compile_fail = true
 error_contains = ["E0702", "argument 1", "found type"]
+
+# Negation of a parenthesized binary expression in intrinsic-arg position
+# (RUE-149). Integer-literal defaulting used to bind only the literal's own
+# type variable, leaving the binop/neg result variable unresolved as
+# `<error>` with no diagnostic — and codegen then SIGABRTed on the
+# `unreachable!("@dbg only supports scalars and strings")` arm.
+[[case]]
+name = "dbg_neg_of_parenthesized_binop"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    @dbg(-(3 + 4));
+    0
+}
+""" },
+]
+stdout = "-7\n"
+exit_code = 0
+
+# Leading `!` in an intrinsic argument must parse as logical not, not as the
+# never type (RUE-150). The parser used to commit to the never-type parse of
+# the bare `!` and then reject the rest of the argument with E0100.
+[[case]]
+name = "dbg_logical_not_literal"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    @dbg(!true);
+    0
+}
+""" },
+]
+stdout = "false\n"
+exit_code = 0
+
+[[case]]
+name = "dbg_logical_not_variable"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let b = false;
+    @dbg(!b);
+    0
+}
+""" },
+]
+stdout = "true\n"
+exit_code = 0
+
+# Control for RUE-150: a bare `!` as the whole argument is still the never
+# type in type-argument position (@size_of(!) == 0).
+[[case]]
+name = "size_of_never_type_arg_still_parses"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    @dbg(@size_of(!));
+    0
+}
+""" },
+]
+stdout = "0\n"
+exit_code = 0

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -1378,8 +1378,14 @@ where
             .then(just(TokenKind::RParen))
             .map_with(|_, e| IntrinsicArg::Type(TypeExpr::Unit(span_from_extra(e))));
 
-        // Never type: !
+        // Never type: ! — but only when the `!` is the entire argument (the
+        // next token is `,` or `)`). A `!` followed by anything else is the
+        // logical-not operator (e.g. `@dbg(!flag)`), which must fall through
+        // to the expression branch; committing to the never-type parse here
+        // used to reject those arguments (RUE-150). The lookahead is
+        // non-consuming (`rewind`) so the delimiter is still parsed normally.
         let never_type = just(TokenKind::Bang)
+            .then_ignore(one_of([TokenKind::Comma, TokenKind::RParen]).rewind())
             .map_with(|_, e| IntrinsicArg::Type(TypeExpr::Never(span_from_extra(e))));
 
         // Array type: [T; N]


### PR DESCRIPTION
Two frontend fixes from the opt-correctness hunt.

**RUE-149 — ICE on `@dbg(-(3 + 4))`.** `default_int_literal_vars` bound the literal's *own* inference var to i32, overwriting its union-find chain link to the binop result var, which then decayed silently to `<error>` — no diagnostic, then SIGABRT at codegen's `unreachable!()`. The fix binds the chain representative instead (`crates/rue-air/src/inference/unify.rs`). `@dbg(-(3 + 4))` now prints -7. Defense in depth: an `<error>`-typed @dbg argument that arrives via `Ok` (meaning no diagnostic was ever emitted) now reports a proper internal-error diagnostic in sema rather than reaching codegen — guarding both backends with no new error code.

**RUE-150 — `@dbg(!true)` rejected.** The intrinsic-arg parser's never-type branch committed to the one-token `!` parse, so any `!expr` argument died with E0100. The branch now uses non-consuming lookahead: `!` parses as the never type only when followed by `,` or `)`. `@dbg(!true)` / `@dbg(!b)` work; `@size_of(!)` still parses (verified pre/post-fix).

Tests: 4 new CLI cases (`intrinsic_args.toml`) + 1 unit test. Full ./test.sh green. (The worker's patch also covered the parallel `_ctx` @dbg arm; that arm was deleted by #952, so this PR ports the guard to the single live arm only.)

Worth a follow-up issue (filing separately): a general "no `<error>` type in AIR without a diagnostic" consistency check — the silent unbound-Var→ERROR decay could bite other intrinsic/codegen paths the same way.

Fixes RUE-149
Fixes RUE-150

🤖 Generated with [Claude Code](https://claude.com/claude-code)