### PR TITLE
Attribute multi-file --emit tokens lex errors to the right file

### DIFF
--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -43,3 +43,23 @@ args = ["--emit", "air", "main.rue", "utils.rue"]
 compile_only = true
 compile_stdout_contains = ["=== AIR ==="]
 compile_stderr_not_contains = ["E0704"]
+
+# A lex error in the SECOND file used to be reported with the first file's
+# path and source snippet, because the --emit tokens path lexed every file
+# with FileId::DEFAULT (RUE-38).
+[[case]]
+name = "emit_tokens_lex_error_attributed_to_correct_file"
+description = "Lex errors under multi-file --emit tokens name the file that actually contains the error."
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 { 0 }
+""" },
+    { path = "bad.rue", source = """
+fn ok() -> i32 { 1 }
+let # = 3;
+""" },
+]
+args = ["--emit", "tokens", "main.rue", "bad.rue"]
+compile_fail = true
+compile_stderr_contains = ["bad.rue:", "let # = 3;"]
+compile_stderr_not_contains = ["main.rue:"]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1111,7 +1111,9 @@ fn handle_emit_multi_file(
     let per_file_tokens: Option<Vec<(String, Vec<rue_compiler::Token>)>> = if needs_tokens {
         let mut file_tokens = Vec::with_capacity(sources.len());
         for source in sources {
-            let lexer = Lexer::new(source.source);
+            // Lex with the file's real FileId so a lex error in the Nth file
+            // is attributed to that file, not to the first one (RUE-38).
+            let lexer = Lexer::with_file_id(source.source, source.file_id);
             match lexer.tokenize() {
                 Ok((tokens, _interner)) => {
                     file_tokens.push((source.path.to_string(), tokens));


### PR DESCRIPTION
The `--emit tokens` path lexed every file with `Lexer::new`, so error spans carried `FileId::DEFAULT` and a lex error in the Nth file was rendered with the **first** file's path and source snippet (wrong file, wrong line, mismatched caret).

One-line fix: lex with each file's real FileId (`Lexer::with_file_id`), matching the normal pipeline. CLI regression case pins the attribution (error must name `bad.rue` and show its line; must not name `main.rue`).

The issue's primary symptom (E0704 under `--emit air` for @import programs) was already fixed by the module-resolution rework and is pinned by `emit_air_resolves_modules`; this closes the remaining misattribution half. Verified before/after on a two-file repro.

Fixes RUE-38

🤖 Generated with [Claude Code](https://claude.com/claude-code)