### PR TITLE
Inout whole-value aggregate reassignment writes all slots through the pointer

### DIFF
--- a/crates/rue-cli-tests/cases/byref_params.toml
+++ b/crates/rue-cli-tests/cases/byref_params.toml
@@ -507,3 +507,119 @@ pub fn swap(inout a: i32, inout b: i32) {
 """ },
 ]
 exit_code = 41
+
+# ---------------------------------------------------------------------------
+# Whole-value reassignment of a multi-slot aggregate through an inout
+# parameter (RUE-145): `v = T { ... }` inside `fn f(inout v: T)` used to
+# lower ParamStore as a single-slot store through the pointer, writing only
+# slot 0 and leaving the caller's remaining slots stale. Field-wise writes
+# were unaffected. The fix writes every slot through the pointer, matching
+# the aggregate branch of Store.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "inout_whole_struct_reassign"
+description = "Whole-value reassignment of a 2-slot struct through inout writes back both slots (RUE-145; used to exit 9: 7 + stale 2)."
+files = [{ path = "main.rue", source = """
+struct Inner { x: i32, y: i32 }
+fn replace(inout v: Inner) { v = Inner { x: 7, y: 35 }; }
+fn main() -> i32 {
+    let mut f = Inner { x: 1, y: 2 };
+    replace(inout f);
+    f.x + f.y
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "inout_whole_struct_reassign_three_slots"
+description = "Same for a 3-slot struct: every slot must be written through the inout pointer, not just the first."
+files = [{ path = "main.rue", source = """
+struct Triple { a: i32, b: i32, c: i32 }
+fn replace(inout v: Triple) { v = Triple { a: 10, b: 12, c: 20 }; }
+fn main() -> i32 {
+    let mut t = Triple { a: 1, b: 2, c: 3 };
+    replace(inout t);
+    t.a + t.b + t.c
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "inout_whole_struct_reassign_nested"
+description = "Nested aggregate: reassigning a struct containing a struct through inout writes back all flattened slots."
+files = [{ path = "main.rue", source = """
+struct Inner { x: i32, y: i32 }
+struct Outer { a: i32, inner: Inner }
+fn replace(inout v: Outer) { v = Outer { a: 5, inner: Inner { x: 14, y: 23 } }; }
+fn main() -> i32 {
+    let mut o = Outer { a: 1, inner: Inner { x: 2, y: 3 } };
+    replace(inout o);
+    o.a + o.inner.x + o.inner.y
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "inout_whole_array_reassign"
+description = "Whole-value reassignment of an array through inout writes back every element slot."
+files = [{ path = "main.rue", source = """
+fn replace(inout v: [i32; 3]) { v = [10, 12, 20]; }
+fn main() -> i32 {
+    let mut a = [1, 2, 3];
+    replace(inout a);
+    a[0] + a[1] + a[2]
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "inout_whole_struct_reassign_i64_field"
+description = "Slot sizes: a struct with an i64 field reassigned through inout still writes back all slots."
+files = [{ path = "main.rue", source = """
+struct Mixed { a: i64, b: i32 }
+fn replace(inout v: Mixed) { v = Mixed { a: 40, b: 2 }; }
+fn main() -> i32 {
+    let mut m = Mixed { a: 1, b: 2 };
+    replace(inout m);
+    if m.a == 40 { m.b + 40 } else { m.b }
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "inout_whole_string_reassign"
+description = "Whole-value reassignment of a String (3-slot fat pointer) through inout writes back ptr, len, and cap."
+files = [{ path = "main.rue", source = """
+fn replace(inout v: String) {
+    v = "hello rue!";
+}
+fn main() -> i32 {
+    let mut s: String = "xx";
+    replace(inout s);
+    @dbg(s.len());
+    @dbg(s);
+    0
+}
+""" }]
+stdout = """
+10
+hello rue!
+"""
+
+[[case]]
+name = "inout_fieldwise_writes_control"
+description = "Control: field-wise writes through inout (which always worked) keep working alongside the whole-value fix."
+files = [{ path = "main.rue", source = """
+struct Inner { x: i32, y: i32 }
+fn replace(inout v: Inner) {
+    v.x = 7;
+    v.y = 35;
+}
+fn main() -> i32 {
+    let mut f = Inner { x: 1, y: 2 };
+    replace(inout f);
+    f.x + f.y
+}
+""" }]
+exit_code = 42

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1388,21 +1388,38 @@ impl<'a> CfgLower<'a> {
                 param_slot,
                 value: val,
             } => {
-                // ParamStore is used for inout params - store through the pointer
-                let val_vreg = self.get_vreg(*val);
-
+                // ParamStore is used for inout params - store through the pointer.
+                //
                 // For inout params, param_slot is the first ABI slot for that param.
                 // For scalar params, param_slot = param_index.
                 // For struct params, param_slot is the first slot (same as param_index for first param).
-                if self.ctx.cfg.is_param_inout(*param_slot) {
-                    // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
-                    let ptr_vreg = self.ensure_inout_param_ptr(*param_slot);
+                if !self.ctx.cfg.is_param_inout(*param_slot) {
+                    panic!("ParamStore used on non-inout param slot {}", param_slot);
+                }
+
+                // Whole-value reassignment of a multi-slot aggregate (struct,
+                // builtin String, or array) through inout must write ALL slots
+                // through the pointer, not just the first — same shape as the
+                // aggregate branch of Store above. Caller slots descend from
+                // the pointer (stack grows down), so slot i lives at ptr - i*8.
+                // Unmodeled sources fall back to single-slot. (RUE-145)
+                let val_type = self.ctx.cfg.get_inst(*val).ty;
+                let aggregate_vregs = if val_type.is_struct() || val_type.is_array() {
+                    self.get_or_compute_field_vregs(*val)
+                } else {
+                    None
+                };
+
+                // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
+                let ptr_vreg = self.ensure_inout_param_ptr(*param_slot);
+                if let Some(slot_vregs) = aggregate_vregs {
+                    crate::agg_slots::store_slots_through_ptr(self, &slot_vregs, ptr_vreg, 0);
+                } else {
+                    let val_vreg = self.get_vreg(*val);
                     self.mir.push(Aarch64Inst::StrIndexed {
                         src: Operand::Virtual(val_vreg),
                         base: ptr_vreg,
                     });
-                } else {
-                    panic!("ParamStore used on non-inout param slot {}", param_slot);
                 }
             }
 

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1725,23 +1725,41 @@ impl<'a> CfgLower<'a> {
                 param_slot,
                 value: val,
             } => {
-                // ParamStore is used for inout params - store through the pointer
-                let val_vreg = self.get_vreg(*val);
-
+                // ParamStore is used for inout params - store through the pointer.
+                //
                 // For inout params, param_slot is the first ABI slot for that param.
                 // For scalar params, param_slot = param_index.
                 // For struct params, param_slot is the first slot (same as param_index for first param).
                 // We use is_param_inout(param_slot) to check if this slot is inout.
-                if self.ctx.cfg.is_param_inout(*param_slot) {
-                    // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
-                    let ptr_vreg = self.ensure_inout_param_ptr(*param_slot);
+                if !self.ctx.cfg.is_param_inout(*param_slot) {
+                    panic!("ParamStore used on non-inout param slot {}", param_slot);
+                }
+
+                // Whole-value reassignment of a multi-slot aggregate (struct,
+                // builtin String, or array) through inout must write ALL slots
+                // through the pointer, not just the first — same shape as the
+                // aggregate branch of Store above. Caller slots descend from
+                // the pointer (stack grows down), so slot i lives at ptr - i*8.
+                // Unmodeled sources fall back to single-slot. (RUE-145)
+                let val_type = self.ctx.cfg.get_inst(*val).ty;
+                let aggregate_vregs =
+                    if matches!(val_type.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                        self.get_or_compute_field_vregs(*val)
+                    } else {
+                        None
+                    };
+
+                // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
+                let ptr_vreg = self.ensure_inout_param_ptr(*param_slot);
+                if let Some(slot_vregs) = aggregate_vregs {
+                    crate::agg_slots::store_slots_through_ptr(self, &slot_vregs, ptr_vreg, 0);
+                } else {
+                    let val_vreg = self.get_vreg(*val);
                     self.mir.push(X86Inst::MovMRIndexed {
                         base: ptr_vreg,
                         offset: 0,
                         src: Operand::Virtual(val_vreg),
                     });
-                } else {
-                    panic!("ParamStore used on non-inout param slot {}", param_slot);
                 }
             }
 


### PR DESCRIPTION
`fn replace(inout v: Inner) { v = Inner { x: 7, y: 35 }; }` wrote only slot 0 through the inout pointer — the caller saw `{ 7, <stale> }` (the repro exits 9 instead of 42).

Root cause: **ParamStore's** whole-value arm emitted a single store through the param pointer in **both backends**, while the sibling **Store** arm already had correct multi-slot aggregate handling. The fix mirrors the Store aggregate branch: materialize all slot vregs and store them through the pointer at descending offsets; the scalar/unmodeled fallback is unchanged.

Verified by execution on x86-64: the 2-slot repro (9→42), a 3-slot struct, a nested struct, `[i32; 3]`, an i64-field struct, a String through inout (3-slot fat pointer), and a field-wise-writes control. aarch64 verified via `--emit asm` (all three slots stored at #0/#-8/#-16). 7 new CLI cases in `byref_params.toml`. Full ./test.sh green.

Fixes RUE-145

🤖 Generated with [Claude Code](https://claude.com/claude-code)