### PR TITLE
usize/isize resolve in every type position; grammar appendix resync; RUE-67 pinned as fixed

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1594,6 +1594,9 @@ impl<'a> ConstraintGenerator<'a> {
             "u16" => Type::U16,
             "u32" => Type::U32,
             "u64" => Type::U64,
+            // Pointer-width integers (64-bit on all supported targets, RUE-151).
+            "usize" => Type::U64,
+            "isize" => Type::I64,
             "bool" => Type::BOOL,
             "()" => Type::UNIT,
             _ => {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -4100,6 +4100,9 @@ impl<'a> Sema<'a> {
                     "u16" => Type::U16,
                     "u32" => Type::U32,
                     "u64" => Type::U64,
+                    // Pointer-width integers (64-bit on all supported targets, RUE-151).
+                    "usize" => Type::U64,
+                    "isize" => Type::I64,
                     "bool" => Type::BOOL,
                     "()" => Type::UNIT,
                     "!" => Type::NEVER,
@@ -4130,6 +4133,9 @@ impl<'a> Sema<'a> {
                     "u16" => Type::U16,
                     "u32" => Type::U32,
                     "u64" => Type::U64,
+                    // Pointer-width integers (64-bit on all supported targets, RUE-151).
+                    "usize" => Type::U64,
+                    "isize" => Type::I64,
                     "bool" => Type::BOOL,
                     "()" => Type::UNIT,
                     "!" => Type::NEVER,
@@ -4486,6 +4492,9 @@ impl<'a> Sema<'a> {
                     "u16" => Type::U16,
                     "u32" => Type::U32,
                     "u64" => Type::U64,
+                    // Pointer-width integers (64-bit on all supported targets, RUE-151).
+                    "usize" => Type::U64,
+                    "isize" => Type::I64,
                     "bool" => Type::BOOL,
                     "()" => Type::UNIT,
                     "!" => Type::NEVER,
@@ -4525,6 +4534,9 @@ impl<'a> Sema<'a> {
                     "u16" => Type::U16,
                     "u32" => Type::U32,
                     "u64" => Type::U64,
+                    // Pointer-width integers (64-bit on all supported targets, RUE-151).
+                    "usize" => Type::U64,
+                    "isize" => Type::I64,
                     "bool" => Type::BOOL,
                     "()" => Type::UNIT,
                     "!" => Type::NEVER,

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -147,6 +147,10 @@ impl<'a> Sema<'a> {
             "u16" => return Ok(Type::U16),
             "u32" => return Ok(Type::U32),
             "u64" => return Ok(Type::U64),
+            // Pointer-width integers. All supported targets are 64-bit, so
+            // these resolve to the 64-bit types (RUE-151).
+            "usize" => return Ok(Type::U64),
+            "isize" => return Ok(Type::I64),
             "bool" => return Ok(Type::BOOL),
             "()" => return Ok(Type::UNIT),
             "!" => return Ok(Type::NEVER),
@@ -224,6 +228,9 @@ impl<'a> Sema<'a> {
             "u16" => return Some(Type::U16),
             "u32" => return Some(Type::U32),
             "u64" => return Some(Type::U64),
+            // Pointer-width integers (64-bit on all supported targets, RUE-151).
+            "usize" => return Some(Type::U64),
+            "isize" => return Some(Type::I64),
             "bool" => return Some(Type::BOOL),
             "()" => return Some(Type::UNIT),
             "!" => return Some(Type::NEVER),

--- a/crates/rue-cli-tests/cases/drop_flags.toml
+++ b/crates/rue-cli-tests/cases/drop_flags.toml
@@ -117,3 +117,31 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "4\n888\n5\n"
+
+# RUE-67 regression: match arms are SIBLING paths for the move checker. A move
+# in one arm must not leak into the others — using `a` in the `_` arm after
+# arm 0 consumed it is valid (exactly one arm runs). At runtime the drop flag
+# makes each path drop exactly once: in the consuming arm the flag is cleared
+# (drop runs inside `consume`), in the non-consuming arm it stays armed and
+# the drop runs at scope exit.
+[[case]]
+name = "match_sibling_arm_use_after_move_accepted"
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+fn consume(d: D) -> i32 { d.v }
+fn pick(n: i32) -> i32 {
+    let a = D { v: n };
+    match n {
+        0 => consume(a),
+        _ => a.v,
+    }
+}
+fn main() -> i32 {
+    let x = pick(0);
+    let y = pick(9);
+    x + y
+}
+""" }]
+stdout = "0\n9\n"
+exit_code = 9

--- a/crates/rue-cli-tests/cases/pointer_width_names.toml
+++ b/crates/rue-cli-tests/cases/pointer_width_names.toml
@@ -1,0 +1,63 @@
+# Pointer-width type names in signature positions (RUE-151).
+#
+# `usize` was accepted in let-binding type position but rejected with E0204
+# "unknown type" in fn param and return positions: the signature path resolves
+# through `resolve_type` (sema/typeck.rs) while the let path goes through the
+# inference table (inference/generate.rs), and only neither table knew the
+# name — the let "acceptance" was the annotation being silently ignored.
+# Both tables (and the comptime type-as-value tables) now resolve usize/isize
+# as the pointer-width integers (u64/i64 on all supported 64-bit targets).
+
+[section]
+id = "cli.pointer_width_names"
+name = "usize/isize type names"
+description = "usize and isize resolve uniformly in every type position (RUE-151)."
+
+[[case]]
+name = "usize_in_param_and_return_positions"
+description = "The original RUE-151 repro: usize in fn return and param positions."
+files = [{ path = "main.rue", source = """
+fn idx() -> usize { 5 }
+fn get(a: [i32; 3], i: usize) -> i32 { a[i] }
+fn main() -> i32 {
+    let arr: [i32; 3] = [4, 5, 6];
+    if idx() == 5 { get(arr, 2) } else { 0 }
+}
+""" }]
+exit_code = 6
+
+[[case]]
+name = "usize_is_pointer_width_across_fn_boundary"
+description = "A usize above 2^32 survives a fn call round-trip (really 64-bit, not i32)."
+files = [{ path = "main.rue", source = """
+fn through(x: usize) -> usize { x }
+fn main() -> i32 {
+    let big: usize = 4294967298;
+    if through(big) > 4294967296 { 1 } else { 0 }
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "isize_in_signature_positions"
+description = "isize works in param/return positions and is 64-bit signed."
+files = [{ path = "main.rue", source = """
+fn neg(d: isize) -> isize { d }
+fn main() -> i32 {
+    let s: isize = -4294967298;
+    if neg(s) < -4294967296 { 1 } else { 0 }
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "usize_isize_struct_fields"
+description = "Pointer-width names also resolve in struct field type position."
+files = [{ path = "main.rue", source = """
+struct S { n: usize, d: isize }
+fn main() -> i32 {
+    let s = S { n: 4294967298, d: -2 };
+    if s.n > 4294967296 { if s.d == -2 { 1 } else { 0 } } else { 0 }
+}
+""" }]
+exit_code = 1

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -1132,7 +1132,8 @@ enum Suffix {
     /// Index expression with the inner expression and closing bracket position
     Index(Expr, u32),
     /// Qualified struct literal: .StructName { fields }
-    /// NOTE: Not yet wired up due to grammar ambiguity with field access + block
+    /// (Disambiguated from field access + block by the `{ }` / `{ ident :`
+    /// lookahead in `with_suffix_parser`.)
     QualifiedStructLit(Ident, Vec<FieldInit>, u32),
     /// Qualified path (enum variant): .EnumName::Variant
     QualifiedPath(Ident, Ident, u32),

--- a/crates/rue-spec/cases/types/integers.toml
+++ b/crates/rue-spec/cases/types/integers.toml
@@ -600,3 +600,48 @@ params = [
   { type = "u16", max_value = "65535" },
   { type = "u32", max_value = "4294967295" },
 ]
+
+# =============================================================================
+# Pointer-Width Integer Types (usize / isize, RUE-151)
+# =============================================================================
+
+[[case]]
+name = "usize_isize_named_in_all_type_positions"
+spec = ["3.1:21", "3.1:22"]
+description = "usize/isize resolve uniformly in let, param, and return positions"
+source = """
+fn idx() -> usize { 5 }
+fn off(d: isize) -> isize { d }
+fn main() -> i32 {
+    let i: usize = idx();
+    let s: isize = off(-3);
+    if i == 5 { if s == -3 { 1 } else { 0 } } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "usize_is_64_bit"
+spec = ["3.1:22"]
+description = "usize holds values above 2^32 (same range as u64 on 64-bit targets)"
+source = """
+fn big() -> usize { 4294967298 }
+fn main() -> i32 {
+    let x: usize = big();
+    if x > 4294967296 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "isize_is_64_bit"
+spec = ["3.1:22"]
+description = "isize holds values below -2^32 (same range as i64 on 64-bit targets)"
+source = """
+fn big_neg() -> isize { -4294967298 }
+fn main() -> i32 {
+    let x: isize = big_neg();
+    if x < -4294967296 { 1 } else { 0 }
+}
+"""
+exit_code = 1

--- a/docs/spec/src/03-types/01-integer-types.md
+++ b/docs/spec/src/03-types/01-integer-types.md
@@ -70,6 +70,29 @@ The type `u64` represents unsigned integers in the range [0, 1844674407370955161
 
 Unsigned integer arithmetic that overflows **MUST** cause a runtime panic.
 
+## Pointer-Width Integer Types
+
+{{ rule(id="3.1:21", cat="normative") }}
+
+A pointer-width integer type is one of: `usize` (unsigned) or `isize` (signed). These types have the width of a machine address on the target platform.
+
+{{ rule(id="3.1:22", cat="normative") }}
+
+All supported targets are 64-bit, so `usize` has the same representation, range, and overflow behavior as `u64`, and `isize` has the same representation, range, and overflow behavior as `i64`. The names resolve to the same types and may be used interchangeably wherever a type is named (let bindings, function parameters, return types, struct fields).
+
+{{ rule(id="3.1:23") }}
+
+```rue
+fn get(a: [i32; 3], i: usize) -> i32 { a[i] }
+
+fn main() -> i32 {
+    let arr: [i32; 3] = [4, 5, 6];
+    let i: usize = 2;
+    let d: isize = -1;
+    if d == -1 { get(arr, i) } else { 0 }
+}
+```
+
 ## Integer Literal Type Inference
 
 {{ rule(id="3.1:14", cat="normative") }}

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -6,60 +6,80 @@ template = "spec/page.html"
 
 # Appendix A: Grammar
 
-This appendix contains the complete EBNF grammar for Rue.
+This appendix contains the complete EBNF grammar for Rue. It is maintained by
+hand against the parser in `crates/rue-parser/src/chumsky_parser.rs`; when the
+parser changes, this appendix must be updated in the same change.
 
 ```ebnf
 (* Program structure *)
 program        = { item } ;
-item           = [ directive ] ( function | struct_def | enum_def | impl_block | drop_fn ) ;
+item           = function | struct_def | enum_def | drop_fn | const_decl ;
 
-(* Builtins *)
-directive      = "@" IDENT "(" [ directive_args ] ")" ;
-directive_args = directive_arg { "," directive_arg } ;
-directive_arg  = IDENT ;
+(* Directives and intrinsics *)
+directives     = { directive } ;
+directive      = "@" IDENT [ "(" [ directive_args ] ")" ] ;
+directive_args = IDENT { "," IDENT } [ "," ] ;
 intrinsic      = "@" IDENT "(" [ intrinsic_args ] ")" ;
-intrinsic_args = intrinsic_arg { "," intrinsic_arg } ;
-intrinsic_arg  = expression | type ;
+intrinsic_args = intrinsic_arg { "," intrinsic_arg } [ "," ] ;
+intrinsic_arg  = type | expression ;
 
 (* Functions *)
-function       = "fn" IDENT "(" [ params ] ")" [ "->" type ] "{" block "}" ;
+function       = directives [ "pub" ] [ "unchecked" ]
+                 "fn" IDENT "(" [ params ] ")" [ "->" type ] "{" block "}" ;
 params         = param { "," param } ;
 param          = [ param_mode ] IDENT ":" type ;
-param_mode     = "inout" | "borrow" ;
+param_mode     = "comptime" | "inout" | "borrow" ;
 block          = { statement } [ expression ] ;
 
-(* Structs *)
-struct_def     = "struct" IDENT "{" [ struct_fields ] "}" ;
+(* Structs: fields first (comma-separated), then inline methods *)
+struct_def     = directives [ "pub" ] [ "linear" ]
+                 "struct" IDENT "{" [ struct_fields ] { method } "}" ;
 struct_fields  = struct_field { "," struct_field } [ "," ] ;
 struct_field   = IDENT ":" type ;
+method         = directives "fn" IDENT
+                 "(" [ "self" [ "," params ] | params ] ")"
+                 [ "->" type ] "{" block "}" ;
 
 (* Enums *)
-enum_def       = "enum" IDENT "{" [ enum_variants ] "}" ;
+enum_def       = [ "pub" ] "enum" IDENT "{" [ enum_variants ] "}" ;
 enum_variants  = IDENT { "," IDENT } [ "," ] ;
-
-(* Impl blocks *)
-impl_block     = "impl" IDENT "{" { method } "}" ;
-method         = "fn" IDENT "(" [ "self" [ "," params ] | params ] ")" [ "->" type ] "{" block "}" ;
 
 (* Destructors *)
 drop_fn        = "drop" "fn" IDENT "(" "self" ")" "{" block "}" ;
 
+(* Constants (also used for module re-exports) *)
+const_decl     = directives [ "pub" ] "const" IDENT [ ":" type ] "=" expression ";" ;
+
 (* Statements *)
-statement      = [ directive ] ( let_stmt | assign_stmt | expr_stmt ) ;
-let_stmt       = "let" [ "mut" ] IDENT [ ":" type ] "=" expression ";" ;
-assign_stmt    = IDENT "=" expression ";"
-               | IDENT "[" expression "]" "=" expression ";"
-               | expression "." IDENT "=" expression ";" ;
-expr_stmt      = expression ";" ;
+statement      = let_stmt | assign_stmt | expr_stmt ;
+let_stmt       = directives "let" [ "mut" ] let_pattern [ ":" type ] "=" expression ";" ;
+let_pattern    = IDENT | "_" ;
+assign_stmt    = place_expr "=" expression ";" ;
+expr_stmt      = expression ";"
+               | control_flow_expr ;   (* if/match/while/loop/break/continue/return
+                                          and bare blocks need no semicolon *)
+
+(* Place expressions: a variable with zero or more field/index projections.
+   Used as assignment targets and as inout/borrow call arguments. *)
+place_expr     = IDENT { "." IDENT | "[" expression "]" } ;
 
 (* Types *)
 type           = "i8" | "i16" | "i32" | "i64"
                | "u8" | "u16" | "u32" | "u64"
-               | "bool" | "()"
+               | "usize" | "isize"
+               | "bool" | "()" | "!"
                | "[" type ";" INTEGER "]"
+               | "ptr" "const" type
+               | "ptr" "mut" type
+               | anon_struct_type
+               | "Self"
                | IDENT ;
+anon_struct_type = "struct" "{" [ anon_struct_fields ] { method } "}" ;
+anon_struct_fields = struct_field { "," struct_field } [ "," ] ;
 
-(* Expressions *)
+(* Expressions: the precedence ladder, loosest first. This matches Rust's
+   operator precedence: unary > * / % > + - > << >> > & > ^ > | >
+   comparisons > && > ||. All binary operators are left-associative. *)
 expression     = or_expr ;
 or_expr        = and_expr { "||" and_expr } ;
 and_expr       = comparison { "&&" comparison } ;
@@ -70,43 +90,81 @@ bitand_expr    = shift_expr { "&" shift_expr } ;
 shift_expr     = additive { ( "<<" | ">>" ) additive } ;
 additive       = multiplicative { ( "+" | "-" ) multiplicative } ;
 multiplicative = unary { ( "*" | "/" | "%" ) unary } ;
-unary          = "-" unary | "!" unary | "~" unary | postfix ;
-postfix        = primary { "[" expression "]" | "(" [ args ] ")" | "." IDENT } ;
-args           = arg { "," arg } ;
-arg            = [ param_mode ] expression ;
-primary        = INTEGER | BOOL | IDENT | enum_variant_expr
-               | "(" expression ")"
-               | block_expr
-               | if_expr
-               | match_expr
-               | while_expr
-               | loop_expr
-               | "break" | "continue"
-               | return_expr
+unary          = ( "-" | "!" | "~" ) unary | postfix ;
+
+(* Postfix suffixes: field access, method calls, indexing, and
+   module-qualified struct literals / enum paths / associated calls. *)
+postfix        = primary { suffix } ;
+suffix         = "." IDENT                                     (* field access *)
+               | "." IDENT "(" [ call_args ] ")"               (* method call *)
+               | "[" expression "]"                            (* indexing *)
+               | "." IDENT "{" [ field_inits ] "}"             (* qualified struct literal *)
+               | "." IDENT "::" IDENT                          (* qualified enum variant *)
+               | "." IDENT "::" IDENT "(" [ call_args ] ")" ;  (* qualified assoc fn call *)
+
+(* Call arguments: inout/borrow arguments must be place expressions
+   (a variable, optionally with field/index projections); plain
+   arguments are arbitrary expressions. *)
+call_args      = call_arg { "," call_arg } ;
+call_arg       = ( "inout" | "borrow" ) place_expr
+               | expression ;
+
+primary        = INTEGER | STRING | BOOL | "()"
+               | "self"
+               | ident_expr
+               | self_struct_literal
+               | intrinsic
                | array_literal
-               | struct_literal
-               | intrinsic ;
-enum_variant_expr = IDENT "::" IDENT ;
+               | anon_struct_type        (* type used as a value, e.g. comptime *)
+               | primitive_type_literal  (* e.g. `i32` as a comptime value *)
+               | "(" expression ")"
+               | comptime_expr
+               | checked_expr
+               | block_expr
+               | control_flow_expr ;
+
+(* An identifier optionally followed by call arguments, a struct literal
+   body, or a path. *)
+ident_expr     = IDENT "(" [ call_args ] ")"           (* function call *)
+               | IDENT "{" [ field_inits ] "}"         (* struct literal *)
+               | IDENT "::" IDENT "(" [ call_args ] ")" (* associated fn call *)
+               | IDENT "::" IDENT                      (* enum variant *)
+               | IDENT ;
+self_struct_literal = "Self" "{" [ field_inits ] "}" ;
+primitive_type_literal = "i8" | "i16" | "i32" | "i64"
+                       | "u8" | "u16" | "u32" | "u64" | "bool" ;
 
 (* Compound expressions *)
 block_expr     = "{" block "}" ;
+comptime_expr  = "comptime" "{" block "}" ;
+checked_expr   = "checked" "{" block "}" ;
+control_flow_expr = if_expr | match_expr | while_expr | loop_expr
+                  | break_expr | "continue" | return_expr ;
 if_expr        = "if" expression "{" block "}" [ else_clause ] ;
 else_clause    = "else" ( "{" block "}" | if_expr ) ;
-match_expr     = "match" expression "{" { match_arm "," } [ match_arm ] "}" ;
+match_expr     = "match" expression "{" [ match_arms ] "}" ;
+match_arms     = match_arm { "," match_arm } [ "," ] ;
 match_arm      = pattern "=>" expression ;
-pattern        = "_" | INTEGER | BOOL | enum_variant_pattern ;
-enum_variant_pattern = IDENT "::" IDENT ;
+pattern        = "_"
+               | [ "-" ] INTEGER
+               | BOOL
+               | IDENT "::" IDENT                      (* Enum::Variant *)
+               | IDENT { "." IDENT } "::" IDENT ;      (* module.Enum::Variant *)
 while_expr     = "while" expression "{" block "}" ;
 loop_expr      = "loop" "{" block "}" ;
-return_expr    = "return" expression ;
+break_expr     = "break" [ expression ] ;   (* an operand parses but is always
+                                               rejected in semantic analysis *)
+return_expr    = "return" [ expression ] ;
 array_literal  = "[" [ expression { "," expression } ] "]" ;
-struct_literal = IDENT "{" [ field_inits ] "}" ;
 field_inits    = field_init { "," field_init } [ "," ] ;
 field_init     = IDENT ":" expression ;
 
 (* Lexical elements *)
 IDENT          = ( letter | "_" ) { letter | digit | "_" } ;
-INTEGER        = digit { digit } ;
+INTEGER        = digit { digit } ;   (* decimal only; 0x/0b/0o prefixes are
+                                        rejected with a dedicated diagnostic *)
+STRING         = '"' { string_char | escape } '"' ;
+escape         = "\\" ( "\\" | '"' | "n" | "t" | "r" | "0" ) ;
 BOOL           = "true" | "false" ;
 letter         = "a" | ... | "z" | "A" | ... | "Z" ;
 digit          = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
@@ -115,3 +173,29 @@ digit          = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 whitespace     = " " | "\t" | "\n" | "\r" ;
 line_comment   = "//" { any_char_except_newline } newline ;
 ```
+
+Notes:
+
+- **Operator precedence** is Rust's ladder (see spec rule 4.3a:13 and the
+  `precedence` module in the parser): unary operators bind tightest, then
+  `* / %`, `+ -`, `<< >>`, `&`, `^`, `|`, comparisons, `&&`, and `||`
+  loosest. So `a << b + c` is `a << (b + c)` and `a & b == c` is
+  `(a & b) == c`.
+- **`usize` and `isize`** lex as ordinary identifiers (they are not keyword
+  tokens) but always denote the pointer-width integer types (see spec rules
+  3.1:21–3.1:22); the other primitive type names are keywords.
+- **Intrinsic arguments** may be types or expressions. Syntax that is
+  unambiguously a type (`()`, `[T; N]`, a primitive type keyword, or a `!`
+  that is the entire argument) parses as a type; anything else — including
+  `!expr`, which is logical not — parses as an expression.
+- **`inout`/`borrow` call arguments** must be place expressions: a variable
+  optionally followed by field and index projections (e.g. `inout s.arr[i]`),
+  not arbitrary expressions.
+- **A parameter takes at most one mode** (`comptime`, `inout`, or `borrow`);
+  duplicate or conflicting modes are a parse error.
+- **Statement termination**: `let`, assignment, and ordinary expression
+  statements require `;`. Control-flow expressions (`if`, `match`, `while`,
+  `loop`, `break`, `continue`, `return`) and bare blocks may appear as
+  statements without a trailing semicolon.
+- There are no `impl` blocks: methods are declared inline inside the
+  `struct` body, after the fields.


### PR DESCRIPTION
Three frontend items from cycle 10.

**RUE-151 — `usize` rejected in fn signatures.** Root cause: **seven duplicated primitive-name tables** had drifted. The signature resolver (`sema/typeck.rs::resolve_type`) rejected `usize`/`isize`, while the let path only *appeared* to accept them — the inference table silently falls back to the init type for unknown annotation names. `usize`→u64 / `isize`→i64 added to all seven tables; new spec rules 3.1:21–23 (pointer-width integers) with 3 spec cases + a new CLI file `pointer_width_names.toml` (4 cases, incl. 64-bitness across a fn boundary). Verified end-to-end in param and return positions.

**RUE-67 — refuted as a current bug.** The exact issue repro compiles and runs correctly on trunk: `analyze_match` already forks each arm from the pre-match move state and joins via `merge_arm_moves` (the drop-flags work landed this). Verified at runtime: the consuming arm drops in the callee, the non-consuming arm at scope exit, exactly once each. Pinned with a regression case in `drop_flags.toml` so it stays fixed.

**RUE-133 item 10 — grammar appendix resync.** The precedence ladder already matched the parser exactly (no drift there, contrary to the item's assumption). The *rest* of Appendix A had drifted badly and is rewritten: dropped nonexistent `impl` blocks; added const items, `pub`/`linear`/`unchecked`, `comptime` mode, `!`/ptr/anon-struct/Self/usize/isize types, string escapes, place-expression byref args (RUE-143), intrinsic-arg `!` lookahead (RUE-150), qualified module suffixes, patterns, and statement-semicolon rules.

Full ./test.sh green (traceability 100% incl. the new rules).

Discovered while fixing (filing separately): `let x: zzz_bogus = 5;` compiles — unknown let-annotation names are silently ignored.

Fixes RUE-151
Fixes RUE-67
Part of RUE-133 (item 10 — the epic's last open item; verify remaining items before closing the epic).

🤖 Generated with [Claude Code](https://claude.com/claude-code)