### PR TITLE
Buck2: spec/UI/CLI suites as sh_test targets; fix inert CI cache; scripts/rue gc; fast fmt.sh

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -137,16 +137,20 @@ jobs:
       - name: Install dotslash
         uses: facebook/install-dotslash@latest
 
-      # Cache Buck2 outputs including downloaded Rust toolchain
-      - name: Cache Buck2 outputs
+      # Cache the dotslash-downloaded buck2 binary (~/.cache/dotslash on
+      # Linux, ~/Library/Caches/dotslash on macOS). The previous cache of
+      # buck-out/v2/gen + ~/.cache/buck2 was inert — OSS buck2 has no
+      # persistent action cache across daemon restarts, and ~/.cache/buck2
+      # is not a path buck2 uses. (RUE-144)
+      - name: Cache dotslash artifacts
         uses: actions/cache@v4
         with:
           path: |
-            buck-out/v2/gen
-            ~/.cache/buck2
-          key: buck2-${{ matrix.platform }}-release-${{ hashFiles('**/BUCK', 'toolchains/rust/defs.bzl') }}
+            ~/.cache/dotslash
+            ~/Library/Caches/dotslash
+          key: dotslash-${{ matrix.platform }}-${{ hashFiles('buck2') }}
           restore-keys: |
-            buck2-${{ matrix.platform }}-release-
+            dotslash-${{ matrix.platform }}-
 
       - name: Get commit info
         id: commit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,16 +48,21 @@ jobs:
       - name: Install dotslash
         uses: facebook/install-dotslash@latest
 
-      # Cache Buck2 outputs including downloaded Rust toolchain
-      - name: Cache Buck2 outputs
+      # Cache the dotslash-downloaded buck2 binary (~/.cache/dotslash on
+      # Linux, ~/Library/Caches/dotslash on macOS; actions/cache skips paths
+      # that don't exist). The previous cache of buck-out/v2/gen +
+      # ~/.cache/buck2 was inert: OSS buck2 has no persistent action cache
+      # across daemon restarts, and ~/.cache/buck2 is not a path buck2 uses —
+      # multi-GB saved/restored for zero hits. (RUE-144)
+      - name: Cache dotslash artifacts
         uses: actions/cache@v4
         with:
           path: |
-            buck-out/v2/gen
-            ~/.cache/buck2
-          key: buck2-${{ matrix.name }}-${{ hashFiles('**/BUCK', 'toolchains/rust/defs.bzl') }}
+            ~/.cache/dotslash
+            ~/Library/Caches/dotslash
+          key: dotslash-${{ matrix.name }}-${{ hashFiles('buck2') }}
           restore-keys: |
-            buck2-${{ matrix.name }}-
+            dotslash-${{ matrix.name }}-
 
       # Uses hermetic Rust toolchain downloaded by Buck2
       # First verify everything builds (catches issues tests might miss)

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -14,15 +14,17 @@ jobs:
       - name: Install dotslash
         uses: facebook/install-dotslash@latest
 
-      - name: Cache Buck2 outputs
+      # Cache the dotslash-downloaded buck2 binary. The previous cache of
+      # buck-out/v2/gen + ~/.cache/buck2 was inert — OSS buck2 has no
+      # persistent action cache across daemon restarts, and ~/.cache/buck2
+      # is not a path buck2 uses. (RUE-144)
+      - name: Cache dotslash artifacts
         uses: actions/cache@v4
         with:
-          path: |
-            buck-out/v2/gen
-            ~/.cache/buck2
-          key: buck2-fuzz-${{ hashFiles('**/BUCK', 'toolchains/rust/defs.bzl') }}
+          path: ~/.cache/dotslash
+          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
           restore-keys: |
-            buck2-fuzz-
+            dotslash-linux-x64-
 
       - name: Create seed corpus
         run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --init-corpus crates/rue-fuzz/corpus

--- a/BUCK
+++ b/BUCK
@@ -1,0 +1,61 @@
+# Repo-root test-suite targets (RUE-144 / RUE-132).
+#
+# Each sh_test ties a test-harness binary to the rue compiler and the on-disk
+# inputs the suite actually reads (cases/, std/), so Buck owns the binary
+# handoff and caches each suite against its real inputs:
+#
+#   buck2 test //...        # runs unit tests + spec + UI + CLI suites
+#
+# An edit under crates/rue-spec/cases/ re-runs only the spec suite; an edit
+# under std/ re-runs the CLI suite (std/ MUST be a declared input here or the
+# CLI suite would get false cache hits on std library changes).
+#
+# Mechanics: the harness binaries already locate everything via env vars
+# (rue-test-runner's find_rue_binary / find_dir), `$(exe_target ...)` /
+# `$(location ...)` expand to absolute paths, and sh_test runs from the
+# project root — so the harness binary itself can be the `test` command and
+# no wrapper script is needed. A filegroup's output directory is named after
+# the rule and contains its srcs at package-relative paths, hence the
+# `$(location ...)/cases` shape.
+#
+# These suites live at the repo root rather than in the harness crates' BUCK
+# files so that `buck2 test //crates/...` (quick-test.sh, test.sh's filtered
+# path) still means "unit tests only".
+
+# The std library sources are runtime inputs to the CLI integration tests
+# (compiled programs `@import` them via ${REAL_STD} / RUE_STD_DIR).
+filegroup(
+    name = "std",
+    srcs = glob(["std/**"]),
+)
+
+sh_test(
+    name = "spec-tests",
+    test = "//crates/rue-spec:rue-spec",
+    args = ["--quiet"],
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
+    },
+)
+
+sh_test(
+    name = "ui-tests",
+    test = "//crates/rue-ui-tests:rue-ui-tests",
+    args = ["--quiet"],
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_UI_CASES": "$(location //crates/rue-ui-tests:cases)/cases",
+    },
+)
+
+sh_test(
+    name = "cli-tests",
+    test = "//crates/rue-cli-tests:rue-cli-tests",
+    args = ["--quiet"],
+    env = {
+        "RUE_BINARY": "$(exe_target //crates/rue:rue)",
+        "RUE_CLI_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
+        "RUE_STD_DIR": "$(location :std)/std",
+    },
+)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Quickstart
 
-The 8 commands that cover ~90% of work here (all runnable from anywhere in the repo):
+The 9 commands that cover ~90% of work here (all runnable from anywhere in the repo):
 
 ```bash
 scripts/rue build                    # build the compiler -> refreshes bin/rue symlink
@@ -17,6 +17,7 @@ scripts/rue quick                    # unit tests only (~2-5s, fast inner loop)
 scripts/rue spec 4.2                 # run spec tests matching a pattern
 scripts/rue cli abi                  # run CLI integration tests matching a pattern
 scripts/rue fmt                      # format (= ./fmt.sh) before committing
+scripts/rue gc                       # reclaim disk (= buck2 clean --stale 1w)
 ```
 
 Key rules (details in the sections below):

--- a/crates/rue-cli-tests/BUCK
+++ b/crates/rue-cli-tests/BUCK
@@ -13,3 +13,11 @@ rue_binary(
         "//third-party:toml",
     ],
 )
+
+# The CLI integration test cases, as an input of the //:cli-tests suite (so a
+# cases/ edit re-runs exactly that suite under `buck2 test //...`).
+filegroup(
+    name = "cases",
+    srcs = glob(["cases/**"]),
+    visibility = ["PUBLIC"],
+)

--- a/crates/rue-spec/BUCK
+++ b/crates/rue-spec/BUCK
@@ -9,3 +9,11 @@ rue_binary(
         "//third-party:toml",
     ],
 )
+
+# The spec test cases, as an input of the //:spec-tests suite (so a cases/
+# edit re-runs exactly that suite under `buck2 test //...`).
+filegroup(
+    name = "cases",
+    srcs = glob(["cases/**"]),
+    visibility = ["PUBLIC"],
+)

--- a/crates/rue-ui-tests/BUCK
+++ b/crates/rue-ui-tests/BUCK
@@ -10,3 +10,11 @@ rue_binary(
         "//third-party:libtest2-mimic",
     ],
 )
+
+# The UI test cases, as an input of the //:ui-tests suite (so a cases/ edit
+# re-runs exactly that suite under `buck2 test //...`).
+filegroup(
+    name = "cases",
+    srcs = glob(["cases/**"]),
+    visibility = ["PUBLIC"],
+)

--- a/fmt.sh
+++ b/fmt.sh
@@ -6,10 +6,37 @@ set -euo pipefail
 # Usage:
 #   ./fmt.sh        # Format all Rust files
 #   ./fmt.sh check  # Check formatting (for CI)
+#
+# BUCK/.bzl files are NOT formatted: no Starlark formatter is vendored in
+# this repo (`buck2 starlark` offers only lint/typecheck, and buildifier is
+# not a dependency), so this script covers Rust sources only.
+
+cd "$(dirname "$0")"
 
 MODE="${1:-format}"
 
-# Get absolute paths to all Rust files (buck2 run changes working directory)
+# Resolve the hermetic rustfmt binary once and invoke it directly. The old
+# `xargs ./buck2 run toolchains//rust:rustfmt` form paid a buck2 CLI
+# round-trip per xargs chunk; one `--show-output` resolve avoids that.
+# --show-output prints a repo-root-relative path, so make it absolute.
+RUSTFMT="$(./buck2 build toolchains//rust:rustfmt --show-output 2>/dev/null \
+    | awk '/rust:rustfmt /{print $2}' | tail -1)"
+if [ -z "$RUSTFMT" ]; then
+    echo "fmt.sh: failed to resolve rustfmt via buck2 --show-output; re-running for diagnosis..." >&2
+    ./buck2 build toolchains//rust:rustfmt --show-output >&2
+    exit 1
+fi
+RUSTFMT="$(pwd)/$RUSTFMT"
+
+# rustfmt needs librustc_driver from the distribution's rustc/lib directory
+# (the toolchains//rust rustfmt rule's RunInfo wrapper does the same; see
+# _rustfmt_impl in toolchains/rust/defs.bzl). The binary lives at
+# <dist>/rustfmt-preview/bin/rustfmt, the libs at <dist>/rustc/lib.
+DIST_ROOT="${RUSTFMT%/rustfmt-preview/bin/rustfmt}"
+export LD_LIBRARY_PATH="$DIST_ROOT/rustc/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+export DYLD_LIBRARY_PATH="$DIST_ROOT/rustc/lib${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
+
+# Absolute paths to all Rust files (no filenames with spaces in this repo).
 RUST_FILES=$(find "$(pwd)/crates" -name "*.rs" -type f)
 
 if [ -z "$RUST_FILES" ]; then
@@ -19,10 +46,10 @@ fi
 
 if [ "$MODE" = "check" ]; then
     echo "Checking Rust formatting..."
-    echo "$RUST_FILES" | xargs ./buck2 run toolchains//rust:rustfmt -- --edition 2024 --check
+    echo "$RUST_FILES" | xargs "$RUSTFMT" --edition 2024 --check
     echo "All files formatted correctly!"
 else
     echo "Formatting Rust files..."
-    echo "$RUST_FILES" | xargs ./buck2 run toolchains//rust:rustfmt -- --edition 2024
+    echo "$RUST_FILES" | xargs "$RUSTFMT" --edition 2024
     echo "Done!"
 fi

--- a/scripts/rue
+++ b/scripts/rue
@@ -12,6 +12,7 @@
 #   scripts/rue cli [pattern]      CLI integration tests, optional filter
 #   scripts/rue ui [pattern]       UI/diagnostics tests, optional filter
 #   scripts/rue fmt                Format the code (./fmt.sh)
+#   scripts/rue gc                 Reclaim disk: drop buck-out artifacts unused for 1+ week
 #   scripts/rue path               Print the absolute binary path (build if needed)
 #
 set -euo pipefail
@@ -76,8 +77,15 @@ case "$cmd" in
     fmt)
         ./fmt.sh "$@"
         ;;
+    gc)
+        # buck-out grows without bound; drop artifacts not used in the last
+        # week. An optional argument overrides the window: scripts/rue gc 1d
+        ./buck2 clean --stale "${1:-1w}"
+        ;;
     ""|-h|--help|help)
-        sed -n '2,20p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+        # Print the header comment block (everything between the shebang and
+        # the first non-comment line), so new subcommands show up automatically.
+        awk 'NR > 1 { if (!/^#/) exit; sub(/^# ?/, ""); print }' "${BASH_SOURCE[0]}"
         ;;
     *)
         echo "scripts/rue: unknown command '$cmd' (try: scripts/rue help)" >&2

--- a/test.sh
+++ b/test.sh
@@ -1,43 +1,52 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Run all tests for the rue compiler
+# Run all tests for the rue compiler.
+#
+# Every suite is a Buck test target, so one `buck2 test //...` runs the unit
+# tests for ALL crates plus the spec/UI/CLI harness suites (the root BUCK
+# file's sh_tests, which declare the rue binary, cases/, and std/ as inputs —
+# Buck owns the binary handoff instead of a shell pipeline). Using //...
+# rather than a hand-maintained target list also keeps new crates from being
+# silently omitted. (RUE-132, RUE-144)
+#
+# With a pattern argument, the spec/UI/CLI suites are instead run directly
+# with the filter (unit tests still run in full, as before).
 
 cd "$(dirname "$0")"
 
-# Run unit tests for ALL crates. Use //crates/... rather than a hand-maintained target
-# list: the old list silently omitted ~300 tests across 7 crates (rue,
-# rue-runtime, rue-fuzz, rue-test-runner, rue-builtins, rue-spec, rue-cli-tests)
-# because nobody remembered to add new crates here. (RUE-132)
-echo "Running unit tests..."
-./buck2 test //crates/...
+if [[ $# -eq 0 ]]; then
+    echo "Running unit tests and spec/UI/CLI suites..."
+    ./buck2 test //...
+else
+    # Unit tests live under //crates/...; the suite sh_tests are at the repo
+    # root, so this scope keeps them out of the unfiltered step below.
+    echo "Running unit tests..."
+    ./buck2 test //crates/...
 
-# Get the path to the rue binary (this also builds it if needed).
-# scripts/rue-bin resolves it to a stable absolute path.
-RUE_BINARY="$(./scripts/rue-bin)"
+    # Get the path to the rue binary (this also builds it if needed).
+    # scripts/rue-bin resolves it to a stable absolute path.
+    RUE_BINARY="$(./scripts/rue-bin)"
 
-# Run spec tests (buck2 run will build rue-spec if needed)
-echo "Running spec tests..."
-RUE_BINARY="$RUE_BINARY" \
-RUE_SPEC_CASES="crates/rue-spec/cases" \
-./buck2 run //crates/rue-spec:rue-spec -- --quiet "$@"
+    echo "Running spec tests..."
+    RUE_BINARY="$RUE_BINARY" \
+    RUE_SPEC_CASES="crates/rue-spec/cases" \
+    ./buck2 run //crates/rue-spec:rue-spec -- --quiet "$@"
+
+    echo "Running UI tests..."
+    RUE_BINARY="$RUE_BINARY" \
+    RUE_UI_CASES="crates/rue-ui-tests/cases" \
+    ./buck2 run //crates/rue-ui-tests:rue-ui-tests -- --quiet "$@"
+
+    echo "Running CLI integration tests..."
+    RUE_BINARY="$RUE_BINARY" \
+    RUE_CLI_CASES="crates/rue-cli-tests/cases" \
+    RUE_STD_DIR="std" \
+    ./buck2 run //crates/rue-cli-tests:rue-cli-tests -- --quiet "$@"
+fi
 
 # Run traceability check (fails if coverage < 100% or orphan references exist)
 echo "Running spec traceability check..."
 RUE_SPEC_DIR="docs/spec/src" \
 RUE_SPEC_CASES="crates/rue-spec/cases" \
 ./buck2 run //crates/rue-spec:rue-spec -- --traceability
-
-# Run UI tests (compiler-specific tests like warnings)
-echo "Running UI tests..."
-RUE_BINARY="$RUE_BINARY" \
-RUE_UI_CASES="crates/rue-ui-tests/cases" \
-./buck2 run //crates/rue-ui-tests:rue-ui-tests -- --quiet "$@"
-
-# Run CLI integration tests (end-to-end through the real driver: files on
-# disk, relative paths, stdin, exit codes; catches ICEs and driver-only bugs)
-echo "Running CLI integration tests..."
-RUE_BINARY="$RUE_BINARY" \
-RUE_CLI_CASES="crates/rue-cli-tests/cases" \
-RUE_STD_DIR="std" \
-./buck2 run //crates/rue-cli-tests:rue-cli-tests -- --quiet "$@"


### PR DESCRIPTION
RUE-144 items 4-6 + 8, including the sh_test promotion that is also RUE-132 item 4.

**sh_test promotion (item 5).** Root `BUCK` adds `//:spec-tests`, `//:ui-tests`, `//:cli-tests` — the harness binaries are the test commands directly (no wrappers needed; `$(exe_target)`/`$(location)` env macros expand to absolute paths with cwd = project root). `cases/` filegroups in each harness crate plus a `std/` filegroup are declared inputs, so std-library edits invalidate CLI tests. `buck2 test //...` now runs everything (Pass 20), closing the "buck2 test looks green while test.sh fails" trap; test.sh delegates to it while preserving the pattern path and the traceability step.

**CI cache (item 4).** The workflows cached `buck-out/v2/gen` (inert — OSS buck2 has no persistent action cache across daemon restarts) and `~/.cache/buck2` (does not exist). Now they cache `~/.cache/dotslash` (+ the macOS path) keyed on `hashFiles('buck2')`, dropping the multi-GB inert save/restore.

**buck-out GC (item 6).** `scripts/rue gc` = `buck2 clean --stale 1w` (optional window arg) + one CLAUDE.md quickstart line; also fixes `scripts/rue help`'s hardcoded sed range.

**fmt.sh (item 8).** Resolves rustfmt once via `--show-output` and invokes it directly (needs `LD_LIBRARY_PATH` to the dist's rustc lib for librustc_driver — verified); ~1.2s warm vs the per-chunk daemon round-trips. No Starlark formatter is vendored, so BUCK/.bzl are skipped (noted in the script).

Refutation worth knowing: OSS buck2 does **not** cache test results locally — unchanged re-runs re-execute all suites — so per-suite incremental caching only materializes with a future remote/action cache; the declared inputs are correct either way.

Verified end-to-end: `buck2 test //...` Pass 20; `./test.sh` exit 0 (traceability 100%); `fmt.sh` and `scripts/rue gc` run clean. CI on this PR validates the workflow changes.

Part of RUE-144 (items 4-6, 8; item 7 remains — cross-target modeling, gated on RUE-36)
Part of RUE-132 (item 4 — the epic's last open item)

🤖 Generated with [Claude Code](https://claude.com/claude-code)