### PR TITLE
Per-field, path-keyed drop flags: conditional and nested field moves drop exactly once

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -1040,8 +1040,8 @@ pub enum AirInstData {
     /// builder uses these markers to suppress the scope-exit drop of slots
     /// whose contents were moved out (the new owner is responsible for the
     /// drop). Emitted by sema wherever the move checker marks a whole
-    /// variable as moved, and — with `field` set — wherever it marks a
-    /// single top-level struct field as moved (a partial move, RUE-62).
+    /// variable as moved, and — with `place` set — wherever it marks a
+    /// struct field path as moved (a partial move, RUE-62/RUE-157).
     MarkMoved {
         /// The use of the variable (or field) that constitutes the move
         value: AirRef,
@@ -1049,13 +1049,15 @@ pub enum AirInstData {
         slot: u32,
         /// True when `slot` refers to a parameter ABI slot
         is_param: bool,
-        /// `None`: the slot's whole value moved out. `Some(i)`: only the
-        /// top-level struct field with declaration index `i` moved out;
-        /// drop elaboration then drops the rest of the struct field by
-        /// field, skipping this one. Moves of deeper paths (`o.a.b`) are
-        /// NOT exported (no marker), conservatively keeping the whole-slot
-        /// drop (a double drop of the moved part, never a leak).
-        field: Option<u32>,
+        /// `None`: the slot's whole value moved out. `Some(place)`: only
+        /// the field path named by the place's projections moved out — a
+        /// pure `Field` projection chain of any depth (`o.a`, `o.a.b`);
+        /// drop elaboration then drops the struct field-granularly,
+        /// skipping the moved path. Paths through an array index
+        /// (`arr[i].a`) are NOT exported (no marker), keeping the
+        /// whole-slot drop — which re-drops the moved element (a known
+        /// gap: array-element moves aren't tracked by drop elaboration).
+        place: Option<AirPlaceRef>,
     },
 }
 
@@ -1356,15 +1358,23 @@ impl fmt::Display for Air {
                     value,
                     slot,
                     is_param,
-                    field,
+                    place,
                 } => {
                     let prefix = if *is_param { "param%" } else { "$" };
-                    match field {
-                        Some(idx) => writeln!(
-                            f,
-                            "mark_moved {} (from {}{} field {})",
-                            value, prefix, slot, idx
-                        )?,
+                    match place {
+                        Some(place_ref) => {
+                            write!(f, "mark_moved {} (from {}{} fields", value, prefix, slot)?;
+                            let p = self.get_place(*place_ref);
+                            for proj in self.get_place_projections(p) {
+                                match proj {
+                                    AirProjection::Field { field_index, .. } => {
+                                        write!(f, " .{}", field_index)?
+                                    }
+                                    AirProjection::Index { .. } => write!(f, " [_]")?,
+                                }
+                            }
+                            writeln!(f, ")")?;
+                        }
                         None => writeln!(f, "mark_moved {} (from {}{})", value, prefix, slot)?,
                     }
                 }

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -793,7 +793,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
 /// be borrows are cancelled in place and leave no marker). A destructor's
 /// only parameter is `self` at ABI slot 0, so any whole-value param marker
 /// in the analyzed AIR is a move of `self`. Partial field moves
-/// (`field: Some(_)`) are not rejected here: they don't re-enter the
+/// (`place: Some(_)`) are not rejected here: they don't re-enter the
 /// destructor (the drop-glue double drop of such a field is a separate,
 /// pre-existing issue).
 fn reject_self_move_in_destructor(air: &Air, full_name: &str) -> CompileResult<()> {
@@ -801,7 +801,7 @@ fn reject_self_move_in_destructor(air: &Air, full_name: &str) -> CompileResult<(
         if let AirInstData::MarkMoved {
             slot: 0,
             is_param: true,
-            field: None,
+            place: None,
             ..
         } = inst.data
         {

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1642,7 +1642,7 @@ impl<'a> Sema<'a> {
                         value: air_ref,
                         slot: param_info.abi_slot,
                         is_param: true,
-                        field: None,
+                        place: None,
                     },
                     ty,
                     span,
@@ -1698,7 +1698,7 @@ impl<'a> Sema<'a> {
                         value: air_ref,
                         slot,
                         is_param: false,
-                        field: None,
+                        place: None,
                     },
                     ty,
                     span,
@@ -2283,9 +2283,10 @@ impl<'a> Sema<'a> {
                 .map(|id| self.type_pool.struct_def(id).is_linear)
                 .unwrap_or(false);
 
-            // Move checking using the trace. `move_field` is the MarkMoved
-            // marker's field component: None for a whole-struct (linear)
-            // move, Some(index) for a single top-level field move (RUE-62).
+            // Move checking using the trace. `move_is_partial` selects the
+            // MarkMoved marker's place component: absent for a whole-struct
+            // (linear) move, the accessed place for a field-path move
+            // (RUE-62, RUE-157).
             //
             // A use as a by-ref call argument (`f(borrow o.f)`, `f(inout
             // o.f)`) borrows the place rather than moving out of it
@@ -2294,7 +2295,7 @@ impl<'a> Sema<'a> {
             // path is still a use-after-move.
             let is_byref_arg_use = ctx.byref_arg_root == Some(trace.root_var);
             let mut emit_move_marker = false;
-            let mut move_field: Option<u32> = None;
+            let mut move_is_partial = false;
             if is_byref_arg_use {
                 let field_path = trace.field_path();
                 if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
@@ -2340,25 +2341,29 @@ impl<'a> Sema<'a> {
                     .or_default()
                     .mark_path_moved(&field_path, span);
 
-                // Export single-level field moves (`o.a`, not `o.a.b` or
-                // `arr[i].a`) to drop elaboration so the field's drop inside
-                // the struct's scope-exit drop is suppressed (RUE-62).
-                // Deeper paths get no marker: drop elaboration keeps the
-                // whole-slot drop (conservative double drop of the moved
-                // part, never a leak). Only Normal params occupy a real ABI
-                // slot that drop elaboration would drop.
-                if trace.projections.len() == 1 {
-                    if let AirProjection::Field { field_index, .. } = trace.projections[0].proj {
-                        let is_droppable_param_base = match trace.base {
-                            AirPlaceBase::Local(_) => true,
-                            AirPlaceBase::Param(_) => ctx.params.iter().any(|p| {
-                                p.name == trace.root_var && p.mode == RirParamMode::Normal
-                            }),
-                        };
-                        if is_droppable_param_base {
-                            emit_move_marker = true;
-                            move_field = Some(field_index);
-                        }
+                // Export pure-field-path moves of any depth (`o.a`, `o.a.b`)
+                // to drop elaboration so the moved path's drop inside the
+                // struct's scope-exit drop is suppressed (RUE-62, RUE-157).
+                // Paths through an array index (`arr[i].a`) get no marker:
+                // drop elaboration keeps the whole-slot drop, which re-drops
+                // the moved element (a known gap — array-element moves
+                // aren't tracked by drop elaboration). Only Normal params
+                // occupy a real ABI slot that drop elaboration would drop.
+                let pure_field_path = trace
+                    .projections
+                    .iter()
+                    .all(|p| matches!(p.proj, AirProjection::Field { .. }));
+                if pure_field_path {
+                    let is_droppable_param_base = match trace.base {
+                        AirPlaceBase::Local(_) => true,
+                        AirPlaceBase::Param(_) => ctx
+                            .params
+                            .iter()
+                            .any(|p| p.name == trace.root_var && p.mode == RirParamMode::Normal),
+                    };
+                    if is_droppable_param_base {
+                        emit_move_marker = true;
+                        move_is_partial = true;
                     }
                 }
             } else {
@@ -2390,8 +2395,8 @@ impl<'a> Sema<'a> {
                 span,
             });
             if emit_move_marker {
-                // Export the move (whole struct for linear types, one
-                // top-level field for partial moves) to drop elaboration.
+                // Export the move (whole struct for linear types, the
+                // accessed field path for partial moves) to drop elaboration.
                 let (slot, is_param) = match trace.base {
                     AirPlaceBase::Local(slot) => (slot, false),
                     AirPlaceBase::Param(slot) => (slot, true),
@@ -2401,7 +2406,7 @@ impl<'a> Sema<'a> {
                         value: air_ref,
                         slot,
                         is_param,
-                        field: move_field,
+                        place: move_is_partial.then_some(place_ref),
                     },
                     ty: field_type,
                     span,

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -6,7 +6,7 @@
 use lasso::ThreadedRodeo;
 use rue_air::{
     Air, AirArgMode, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
-    Type, TypeInternPool, TypeKind,
+    StructId, Type, TypeInternPool, TypeKind,
 };
 use rue_error::{CompileWarning, WarningKind};
 
@@ -67,32 +67,48 @@ enum MovedSlot {
     Param(u32),
 }
 
-/// Move-out state for drop elaboration: whole slots and individual
-/// top-level struct fields whose contents were moved out.
+/// A struct field path inside a slot, as declaration indices from the
+/// outermost struct inward: `o.a` → `[0]`, `o.a.b` → `[0, 1]` (for `a` and
+/// `b` at declaration index 0 and 1 of their respective structs).
+type FieldPath = Vec<u32>;
+
+/// Move-out state for drop elaboration: whole slots and struct field paths
+/// whose contents were moved out.
 ///
 /// `slots` tracks whole-value moves (`let t = s;`). `fields` tracks partial
-/// moves of a single top-level struct field (`eat(o.a)`, RUE-62) — the slot
-/// itself stays live, but its scope-exit drop must skip the moved field.
+/// moves of a struct field path of any depth (`eat(o.a)`, `eat(o.a.b)`,
+/// RUE-62/RUE-157) — the slot itself stays live, but its scope-exit drop
+/// must skip the moved path. `maybe_fields` additionally remembers paths
+/// moved on only SOME tracked path: those drops stay in the schedule but
+/// run behind a per-path runtime drop flag (RUE-156).
 #[derive(Debug, Clone, Default)]
 struct MoveState {
     /// Slots whose ENTIRE contents were moved out.
     slots: std::collections::HashSet<MovedSlot>,
-    /// `(slot, field_index)` pairs for top-level struct fields moved out of
-    /// a slot that is itself still live.
-    fields: std::collections::HashSet<(MovedSlot, u32)>,
+    /// `(slot, path)` pairs for field paths moved out (on EVERY tracked
+    /// path) of a slot that is itself still live. Join: intersection.
+    fields: std::collections::HashSet<(MovedSlot, FieldPath)>,
+    /// `(slot, path)` pairs for field paths moved out on SOME tracked path.
+    /// Always a superset of `fields`. Join: union. A path here but not in
+    /// `fields` is path-dependent: its scope-exit drop is emitted behind
+    /// that path's runtime drop flag.
+    maybe_fields: std::collections::HashSet<(MovedSlot, FieldPath)>,
 }
 
 impl MoveState {
     /// Record that the slot's whole value moved out.
     fn mark_slot(&mut self, slot: MovedSlot) {
         self.slots.insert(slot);
-        // Whole-value move subsumes any per-field moves.
+        // Whole-value move subsumes any per-field moves (and the slot's
+        // whole-value drop flag takes over at runtime).
         self.fields.retain(|(s, _)| *s != slot);
+        self.maybe_fields.retain(|(s, _)| *s != slot);
     }
 
-    /// Record that one top-level struct field of the slot moved out.
-    fn mark_field(&mut self, slot: MovedSlot, field: u32) {
-        self.fields.insert((slot, field));
+    /// Record that one struct field path of the slot moved out.
+    fn mark_path(&mut self, slot: MovedSlot, path: FieldPath) {
+        self.fields.insert((slot, path.clone()));
+        self.maybe_fields.insert((slot, path));
     }
 
     /// The slot was (re)initialized with a fresh value: clear all move-out
@@ -101,12 +117,17 @@ impl MoveState {
     fn clear_slot(&mut self, slot: MovedSlot) {
         self.slots.remove(&slot);
         self.fields.retain(|(s, _)| *s != slot);
+        self.maybe_fields.retain(|(s, _)| *s != slot);
     }
 
-    /// One top-level field of the slot was reassigned: that field holds a
-    /// fresh value again and must be dropped at scope exit.
+    /// One top-level field of the slot was reassigned: that field (and
+    /// everything nested inside it) holds a fresh value again and must be
+    /// dropped at scope exit.
     fn clear_field(&mut self, slot: MovedSlot, field: u32) {
-        self.fields.remove(&(slot, field));
+        self.fields
+            .retain(|(s, p)| *s != slot || p.first() != Some(&field));
+        self.maybe_fields
+            .retain(|(s, p)| *s != slot || p.first() != Some(&field));
     }
 
     /// Was the slot's whole value moved out (on every tracked path)?
@@ -114,21 +135,38 @@ impl MoveState {
         self.slots.contains(&slot)
     }
 
-    /// Declaration indices of the top-level fields moved out of `slot`.
-    fn moved_fields_of(&self, slot: MovedSlot) -> std::collections::HashSet<u32> {
+    /// Field paths moved out of `slot` on EVERY tracked path.
+    fn moved_paths_of(&self, slot: MovedSlot) -> std::collections::HashSet<FieldPath> {
         self.fields
             .iter()
             .filter(|(s, _)| *s == slot)
-            .map(|(_, f)| *f)
+            .map(|(_, p)| p.clone())
             .collect()
     }
 
-    /// Join two path states: state is kept only if present in BOTH
-    /// ("moved on ALL paths" — see the `moved` field docs).
+    /// Field paths moved out of `slot` on SOME tracked path (superset of
+    /// `moved_paths_of`).
+    fn maybe_moved_paths_of(&self, slot: MovedSlot) -> std::collections::HashSet<FieldPath> {
+        self.maybe_fields
+            .iter()
+            .filter(|(s, _)| *s == slot)
+            .map(|(_, p)| p.clone())
+            .collect()
+    }
+
+    /// Join two path states: definite state (`slots`, `fields`) is kept
+    /// only if present in BOTH ("moved on ALL paths" — see the `moved`
+    /// field docs); possible state (`maybe_fields`) is kept if present in
+    /// EITHER ("moved on SOME path").
     fn intersect(&self, other: &MoveState) -> MoveState {
         MoveState {
             slots: self.slots.intersection(&other.slots).copied().collect(),
-            fields: self.fields.intersection(&other.fields).copied().collect(),
+            fields: self.fields.intersection(&other.fields).cloned().collect(),
+            maybe_fields: self
+                .maybe_fields
+                .union(&other.maybe_fields)
+                .cloned()
+                .collect(),
         }
     }
 }
@@ -161,21 +199,33 @@ pub struct CfgBuilder<'a> {
     /// joins, and short-circuit edges drop-exactly-once at RUNTIME even
     /// where the static all-paths analysis must stay conservative.
     drop_flags: std::collections::HashMap<MovedSlot, u32>,
+    /// Per-field-path runtime drop flags (RUE-156): like `drop_flags`, but
+    /// one flag per `(slot, field path)` with a field-level MarkMoved
+    /// anywhere in the function. Armed when the slot is (re)initialized,
+    /// cleared at the path's move site; `emit_partial_struct_drop` guards
+    /// each possibly-moved field's drop with its flag.
+    field_drop_flags: std::collections::HashMap<(MovedSlot, FieldPath), u32>,
     /// Slots with a whole-value MarkMoved anywhere in the AIR (pre-scanned),
     /// i.e. candidates for a drop flag.
     ever_moved: std::collections::HashSet<MovedSlot>,
-    /// Slots (and individual top-level struct fields, RUE-62) whose contents
-    /// have definitely been moved out on every path reaching the current
-    /// lowering position. Drop elaboration skips these (the new owner of the
-    /// value is responsible for dropping it).
+    /// `(slot, field path)` pairs with a field-level MarkMoved anywhere in
+    /// the AIR whose moved type needs drop (pre-scanned), i.e. candidates
+    /// for a per-field drop flag.
+    ever_field_moved: std::collections::HashSet<(MovedSlot, FieldPath)>,
+    /// Slots (and struct field paths of any depth, RUE-62/RUE-157) whose
+    /// contents have definitely been moved out on every path reaching the
+    /// current lowering position. Drop elaboration skips these (the new
+    /// owner of the value is responsible for dropping it).
     ///
     /// Maintained path-sensitively: each branch of an if/match is lowered
     /// starting from the pre-branch state, and the post-construct state is
     /// the intersection of the branch exit states ("moved on ALL paths").
     /// A value moved on only SOME paths stays in the drop schedule, but its
     /// scope-exit drop is emitted behind a runtime drop-flag guard (see
-    /// `drop_flags`), so the moving path skips it at runtime — drop exactly
-    /// once on every path, and never a leak.
+    /// `drop_flags` for whole slots, `field_drop_flags` plus the
+    /// union-joined `MoveState::maybe_fields` for field paths), so the
+    /// moving path skips it at runtime — drop exactly once on every path,
+    /// and never a leak.
     moved: MoveState,
 }
 
@@ -210,7 +260,9 @@ impl<'a> CfgBuilder<'a> {
             warnings: Vec::new(),
             scope_stack: vec![Vec::new()], // Start with one scope for the function body
             drop_flags: std::collections::HashMap::new(),
+            field_drop_flags: std::collections::HashMap::new(),
             ever_moved: std::collections::HashSet::new(),
+            ever_field_moved: std::collections::HashSet::new(),
             moved: MoveState::default(),
         };
 
@@ -218,21 +270,36 @@ impl<'a> CfgBuilder<'a> {
         builder.current_block = builder.cfg.new_block();
         builder.cfg.entry = builder.current_block;
 
-        // Pre-scan for whole-value moves so drop flags can be initialized at
-        // the value's init site, before the move is reached (RUE-108).
+        // Pre-scan for moves so drop flags can be initialized at the
+        // value's init site, before the move is reached (RUE-108).
+        // Whole-value MarkMoveds nominate the slot for a whole-slot flag;
+        // field-level MarkMoveds nominate their (slot, field path) for a
+        // per-field flag (RUE-156) when the moved type needs dropping.
         for i in 0..air.len() {
+            let inst = air.get(AirRef::from_raw(i as u32));
             if let AirInstData::MarkMoved {
                 slot,
                 is_param,
-                field: None,
+                place,
                 ..
-            } = &air.get(AirRef::from_raw(i as u32)).data
+            } = &inst.data
             {
-                builder.ever_moved.insert(if *is_param {
+                let key = if *is_param {
                     MovedSlot::Param(*slot)
                 } else {
                     MovedSlot::Local(*slot)
-                });
+                };
+                match place {
+                    None => {
+                        builder.ever_moved.insert(key);
+                    }
+                    Some(place_ref) => {
+                        if builder.type_needs_drop(inst.ty) {
+                            let path = builder.moved_field_path(*place_ref);
+                            builder.ever_field_moved.insert((key, path));
+                        }
+                    }
+                }
             }
         }
 
@@ -243,6 +310,7 @@ impl<'a> CfgBuilder<'a> {
             if builder.ever_moved.contains(&key) && builder.type_needs_drop(ty) {
                 builder.set_drop_flag(key, true, rue_span::Span::default());
             }
+            builder.arm_field_drop_flags(key, rue_span::Span::default());
         }
 
         // Find the root (should be Ret as last instruction)
@@ -2044,28 +2112,36 @@ impl<'a> CfgBuilder<'a> {
                 value,
                 slot,
                 is_param,
-                field,
+                place,
             } => {
                 // Pure passthrough at runtime: lower the wrapped use and
-                // record that the slot's contents (or one top-level field of
-                // them, RUE-62) were moved out on this path, so drop
-                // elaboration skips the slot (or just that field) at scope
-                // exit.
+                // record that the slot's contents (or one field path of
+                // them, RUE-62/RUE-157) were moved out on this path, so
+                // drop elaboration skips the slot (or just that path) at
+                // scope exit.
                 let result = self.lower_inst(*value);
                 if !matches!(result.continuation, Continuation::Diverged) {
-                    let place = if *is_param {
+                    let key = if *is_param {
                         MovedSlot::Param(*slot)
                     } else {
                         MovedSlot::Local(*slot)
                     };
-                    match field {
-                        Some(field_index) => self.moved.mark_field(place, *field_index),
+                    match place {
+                        Some(place_ref) => {
+                            let path = self.moved_field_path(*place_ref);
+                            // Clear the path's runtime drop flag on this
+                            // path (RUE-156); if another path doesn't move
+                            // the field, its flag stays 1 and the guarded
+                            // per-field exit drop still runs.
+                            self.update_field_drop_flag(key, &path, false, span);
+                            self.moved.mark_path(key, path);
+                        }
                         None => {
-                            self.moved.mark_slot(place);
+                            self.moved.mark_slot(key);
                             // Clear the runtime drop flag on this path; if
                             // another path doesn't move the value, its flag
                             // stays 1 and the guarded exit drop still runs.
-                            self.update_drop_flag(place, false, span);
+                            self.update_drop_flag(key, false, span);
                         }
                     }
                 }
@@ -2210,19 +2286,109 @@ impl<'a> CfgBuilder<'a> {
     }
 
     /// Update an EXISTING drop flag; no-op when the slot has none (its type
-    /// needs no drop, or it is never moved).
+    /// needs no drop, or it is never moved). Arming (`live = true`) marks a
+    /// whole-slot (re)initialization, which re-initializes every field too,
+    /// so the slot's per-field drop flags (RUE-156) are re-armed as well.
+    /// Clearing (`live = false`) marks a whole-slot move-out and leaves the
+    /// per-field flags alone: the per-field exit drops only run inside the
+    /// whole-slot flag's guard, which the cleared flag already skips.
     fn update_drop_flag(&mut self, key: MovedSlot, live: bool, span: rue_span::Span) {
         if self.drop_flags.contains_key(&key) {
             self.set_drop_flag(key, live, span);
         }
+        if live {
+            self.arm_field_drop_flags(key, span);
+        }
     }
 
     /// Arm the drop flag at a value's (re)initialization site, when the slot
-    /// is moved somewhere in this function and its type needs dropping.
+    /// is moved somewhere in this function and its type needs dropping. The
+    /// slot's per-field drop flags (RUE-156) are armed too: a fresh whole
+    /// value owns all of its fields.
     fn arm_drop_flag_if_needed(&mut self, key: MovedSlot, ty: Type, span: rue_span::Span) {
         if self.ever_moved.contains(&key) && self.type_needs_drop(ty) {
             self.set_drop_flag(key, true, span);
         }
+        self.arm_field_drop_flags(key, span);
+    }
+
+    /// Arm (allocating on first use) the per-field drop flags for every
+    /// field path of `key` that is moved somewhere in this function
+    /// (RUE-156). Called at the slot's (re)initialization sites.
+    fn arm_field_drop_flags(&mut self, key: MovedSlot, span: rue_span::Span) {
+        let paths: Vec<FieldPath> = self
+            .ever_field_moved
+            .iter()
+            .filter(|(s, _)| *s == key)
+            .map(|(_, p)| p.clone())
+            .collect();
+        for path in paths {
+            self.set_field_drop_flag(key, path, true, span);
+        }
+    }
+
+    /// Set a field path's runtime drop flag (RUE-156), allocating the hidden
+    /// flag slot on first use. The per-field analogue of `set_drop_flag`.
+    fn set_field_drop_flag(
+        &mut self,
+        key: MovedSlot,
+        path: FieldPath,
+        live: bool,
+        span: rue_span::Span,
+    ) {
+        let flag_slot = match self.field_drop_flags.get(&(key, path.clone())) {
+            Some(&f) => f,
+            None => {
+                let f = self.cfg.alloc_temp_local();
+                self.field_drop_flags.insert((key, path), f);
+                f
+            }
+        };
+        let val = self.emit(
+            CfgInstData::Const(if live { 1 } else { 0 }),
+            Type::I32,
+            span,
+        );
+        self.emit(
+            CfgInstData::Store {
+                slot: flag_slot,
+                value: val,
+            },
+            Type::UNIT,
+            span,
+        );
+    }
+
+    /// Update an EXISTING per-field drop flag; no-op when the path has none
+    /// (its type needs no drop). The flag is allocated and armed at the
+    /// slot's initialization site, which always precedes the move.
+    fn update_field_drop_flag(
+        &mut self,
+        key: MovedSlot,
+        path: &[u32],
+        live: bool,
+        span: rue_span::Span,
+    ) {
+        if self.field_drop_flags.contains_key(&(key, path.to_vec())) {
+            self.set_field_drop_flag(key, path.to_vec(), live, span);
+        }
+    }
+
+    /// The field path (declaration indices, outermost first) named by a
+    /// field-level MarkMoved's place. Sema only exports markers for pure
+    /// `Field` projection chains.
+    fn moved_field_path(&self, place_ref: AirPlaceRef) -> FieldPath {
+        let place = self.air.get_place(place_ref);
+        self.air
+            .get_place_projections(place)
+            .iter()
+            .map(|proj| match proj {
+                AirProjection::Field { field_index, .. } => *field_index,
+                AirProjection::Index { .. } => {
+                    unreachable!("MarkMoved place contains a non-field projection")
+                }
+            })
+            .collect()
     }
 
     fn emit_drops_for_all_scopes(&mut self, span: rue_span::Span) {
@@ -2293,6 +2459,15 @@ impl<'a> CfgBuilder<'a> {
         // Statically moved-on-all-paths is filtered by the callers; reaching
         // here with a flag means the move is path-dependent (or downstream of
         // a conservative join), so test the flag at runtime.
+        let cont_block = self.begin_flag_guard(flag_slot, span);
+        emit_body(self);
+        self.end_flag_guard(cont_block);
+    }
+
+    /// Open an `if flag != 0` diamond: emits the flag test and branch,
+    /// leaves the current block positioned at the guarded body block, and
+    /// returns the continuation block to pass to [`Self::end_flag_guard`].
+    fn begin_flag_guard(&mut self, flag_slot: u32, span: rue_span::Span) -> BlockId {
         let flag_val = self.emit(CfgInstData::Load { slot: flag_slot }, Type::I32, span);
         let zero = self.emit(CfgInstData::Const(0), Type::I32, span);
         let cond = self.emit(CfgInstData::Ne(flag_val, zero), Type::BOOL, span);
@@ -2313,9 +2488,14 @@ impl<'a> CfgBuilder<'a> {
                 else_args_len,
             },
         );
-
         self.current_block = drop_block;
-        emit_body(self);
+        cont_block
+    }
+
+    /// Close a diamond opened by [`Self::begin_flag_guard`]: terminate the
+    /// guarded body block with a jump to the continuation block and continue
+    /// building there.
+    fn end_flag_guard(&mut self, cont_block: BlockId) {
         let (args_start, args_len) = self.cfg.push_extra(std::iter::empty());
         self.cfg.set_terminator(
             self.current_block,
@@ -2355,11 +2535,14 @@ impl<'a> CfgBuilder<'a> {
         );
     }
 
-    /// Field-granular drop of a partially-moved struct (RUE-62).
+    /// Field-granular drop of a partially-moved struct (RUE-62, RUE-156,
+    /// RUE-157).
     ///
-    /// When one or more top-level fields of a struct slot were moved out
-    /// (`eat(o.a)`), the whole-value `Drop` (destructor + drop glue over ALL
-    /// fields) would re-drop the moved field. Instead this emits:
+    /// When one or more field paths of a struct slot were (or may have
+    /// been) moved out (`eat(o.a)`, `eat(o.a.b)`, `if c { eat(o.a) }`), the
+    /// whole-value `Drop` (destructor + drop glue over ALL fields) would
+    /// re-drop the moved part. Instead this emits, recursively per struct
+    /// level:
     ///
     /// 1. a plain call to the struct's own destructor (if any) — the
     ///    destructor is an ordinary `{Type}.__drop` function taking `self`
@@ -2367,18 +2550,25 @@ impl<'a> CfgBuilder<'a> {
     ///    arguments flattened, so no dedicated codegen op is needed; the
     ///    drop GLUE (which would re-walk every field) is deliberately NOT
     ///    called;
-    /// 2. a `Drop` of each still-owned droppable field, read individually
-    ///    via `PlaceRead`, in declaration order (matching glue order),
-    ///    skipping moved-out fields.
+    /// 2. per droppable field, in declaration order (matching glue order):
+    ///    - moved out on EVERY path: nothing (the new owner drops it);
+    ///    - moved out on SOME path (RUE-156): its drop behind the field
+    ///      path's runtime drop-flag guard;
+    ///    - holding a deeper moved path (RUE-157): a recursive
+    ///      field-granular drop of the field instead of a whole `Drop`;
+    ///    - untouched: a plain `Drop` of the field read via `PlaceRead`.
     ///
     /// Returns `false` (caller emits the normal whole-value drop) when the
-    /// slot has no moved-out fields or is not a struct. Note the destructor
-    /// still receives the WHOLE struct, including the moved-out field's
-    /// stale slots — reading a moved field in a destructor is a
-    /// use-after-move just like any other.
+    /// slot has no (possibly-)moved-out field paths or is not a struct.
+    /// Note each destructor still receives the WHOLE struct, including the
+    /// moved-out part's stale slots — reading a moved field in a destructor
+    /// is a use-after-move just like any other.
     fn emit_partial_struct_drop(&mut self, key: MovedSlot, ty: Type, span: rue_span::Span) -> bool {
-        let moved_fields = self.moved.moved_fields_of(key);
-        if moved_fields.is_empty() {
+        // `maybe` ⊇ `definite`: paths possibly vs. definitely moved out on
+        // the paths reaching this exit.
+        let definite = self.moved.moved_paths_of(key);
+        let maybe = self.moved.maybe_moved_paths_of(key);
+        if maybe.is_empty() && definite.is_empty() {
             return false;
         }
         let TypeKind::Struct(struct_id) = ty.kind() else {
@@ -2386,13 +2576,50 @@ impl<'a> CfgBuilder<'a> {
             // this is unreachable today; fall back to the whole-value drop.
             return false;
         };
-        let struct_def = self.type_pool.struct_def(struct_id);
+        self.emit_partial_struct_drop_level(
+            key,
+            struct_id,
+            ty,
+            &mut Vec::new(),
+            &mut Vec::new(),
+            &definite,
+            &maybe,
+            span,
+        );
+        true
+    }
 
-        // 1. Run the struct's own destructor (without the field glue).
+    /// One struct level of [`Self::emit_partial_struct_drop`]: destructor
+    /// (without glue) plus per-field drops for the struct at field path
+    /// `path` (projections `projs`) inside slot `key`.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_partial_struct_drop_level(
+        &mut self,
+        key: MovedSlot,
+        struct_id: StructId,
+        ty: Type,
+        path: &mut FieldPath,
+        projs: &mut Vec<Projection>,
+        definite: &std::collections::HashSet<FieldPath>,
+        maybe: &std::collections::HashSet<FieldPath>,
+        span: rue_span::Span,
+    ) {
+        let struct_def = self.type_pool.struct_def(struct_id);
+        let base = match key {
+            MovedSlot::Local(slot) => PlaceBase::Local(slot),
+            MovedSlot::Param(slot) => PlaceBase::Param(slot),
+        };
+
+        // 1. Run this struct's own destructor (without the field glue).
         if let Some(ref destructor_name) = struct_def.destructor {
-            let whole_val = match key {
-                MovedSlot::Local(slot) => self.emit(CfgInstData::Load { slot }, ty, span),
-                MovedSlot::Param(index) => self.emit(CfgInstData::Param { index }, ty, span),
+            let whole_val = if projs.is_empty() {
+                match key {
+                    MovedSlot::Local(slot) => self.emit(CfgInstData::Load { slot }, ty, span),
+                    MovedSlot::Param(index) => self.emit(CfgInstData::Param { index }, ty, span),
+                }
+            } else {
+                let place = self.cfg.make_place(base, projs.iter().copied());
+                self.emit(CfgInstData::PlaceRead { place }, ty, span)
             };
             let name = self.interner.get_or_intern(destructor_name);
             let (args_start, args_len) = self.cfg.push_call_args(std::iter::once(CfgCallArg {
@@ -2410,27 +2637,74 @@ impl<'a> CfgBuilder<'a> {
             );
         }
 
-        // 2. Drop the still-owned droppable fields in declaration order.
-        let base = match key {
-            MovedSlot::Local(slot) => PlaceBase::Local(slot),
-            MovedSlot::Param(slot) => PlaceBase::Param(slot),
-        };
+        // 2. Handle the droppable fields in declaration order.
         for (field_index, field) in struct_def.fields.iter().enumerate() {
             let field_index = field_index as u32;
-            if moved_fields.contains(&field_index) || !self.type_needs_drop(field.ty) {
+            if !self.type_needs_drop(field.ty) {
                 continue;
             }
-            let place = self.cfg.make_place(
-                base,
-                std::iter::once(Projection::Field {
-                    struct_id,
-                    field_index,
-                }),
-            );
-            let field_val = self.emit(CfgInstData::PlaceRead { place }, field.ty, span);
-            self.emit(CfgInstData::Drop { value: field_val }, Type::UNIT, span);
+            path.push(field_index);
+            projs.push(Projection::Field {
+                struct_id,
+                field_index,
+            });
+
+            if definite.contains(path) {
+                // Moved out on every path: the new owner drops it.
+                path.pop();
+                projs.pop();
+                continue;
+            }
+            // A strictly deeper (possibly-)moved path means this field
+            // can't take a whole `Drop`; recurse instead.
+            let has_deeper_move = maybe
+                .iter()
+                .any(|p| p.len() > path.len() && p.starts_with(path));
+            // Possibly (but not definitely) moved: guard the drop with the
+            // field path's runtime drop flag (RUE-156). The flag exists
+            // whenever a droppable path has a move site (armed at the
+            // slot's init); a missing flag falls through to an unguarded
+            // drop as a defensive default.
+            let guard_flag = if maybe.contains(path) {
+                self.field_drop_flags.get(&(key, path.clone())).copied()
+            } else {
+                None
+            };
+
+            let cont_block = guard_flag.map(|flag| self.begin_flag_guard(flag, span));
+            let recursed = if has_deeper_move {
+                if let TypeKind::Struct(field_struct_id) = field.ty.kind() {
+                    self.emit_partial_struct_drop_level(
+                        key,
+                        field_struct_id,
+                        field.ty,
+                        path,
+                        projs,
+                        definite,
+                        maybe,
+                        span,
+                    );
+                    true
+                } else {
+                    // Deeper paths only exist through struct fields; keep a
+                    // whole drop as a defensive fallback.
+                    false
+                }
+            } else {
+                false
+            };
+            if !recursed {
+                let place = self.cfg.make_place(base, projs.iter().copied());
+                let field_val = self.emit(CfgInstData::PlaceRead { place }, field.ty, span);
+                self.emit(CfgInstData::Drop { value: field_val }, Type::UNIT, span);
+            }
+            if let Some(cont_block) = cont_block {
+                self.end_flag_guard(cont_block);
+            }
+
+            path.pop();
+            projs.pop();
         }
-        true
     }
 
     // ============================================================================
@@ -2953,5 +3227,65 @@ mod tests {
             ),
             "the drop covers the whole re-initialized struct, not one field"
         );
+    }
+
+    #[test]
+    fn test_deep_field_move_skips_only_moved_leaf() {
+        // RUE-157: a depth-2 field path move (`eat(t.mid.leaf)`) is exported
+        // to drop elaboration. The exit drop recurses field-granularly: the
+        // moved leaf is skipped and only the sibling leaf gets a Drop.
+        let source = "struct Leaf { v: i32 }\n\
+             struct Mid { leaf: Leaf, other: Leaf }\n\
+             struct Top { mid: Mid }\n\
+             drop fn Leaf(self) { }\n\
+             fn eat(l: Leaf) -> i32 { 0 }\n\
+             fn main() -> i32 {\n\
+                 let t = Top { mid: Mid { leaf: Leaf { v: 5 }, other: Leaf { v: 6 } } };\n\
+                 eat(t.mid.leaf);\n\
+                 0\n\
+             }";
+        let main_cfg = build_cfg_named(source, "main");
+        assert_eq!(
+            count_drops(&main_cfg),
+            1,
+            "moved t.mid.leaf is skipped; only t.mid.other drops at exit"
+        );
+        assert_all_blocks_terminated(&main_cfg);
+    }
+
+    #[test]
+    fn test_branch_divergent_field_move_emits_guarded_field_drop() {
+        // RUE-156: a field moved in only ONE branch keeps its scope-exit
+        // drop, but behind a per-field-path runtime drop flag. Statically
+        // the CFG contains the guarded drop of field a plus the plain drop
+        // of field b, and a distinctive Ne flag test.
+        let source = "struct Inner { v: i32 }\n\
+             struct Outer { a: Inner, b: Inner }\n\
+             drop fn Inner(self) { }\n\
+             fn eat(i: Inner) -> i32 { 0 }\n\
+             fn main() -> i32 {\n\
+                 let o = Outer { a: Inner { v: 1 }, b: Inner { v: 2 } };\n\
+                 let c = true;\n\
+                 if c {\n\
+                     eat(o.a);\n\
+                 }\n\
+                 0\n\
+             }";
+        let main_cfg = build_cfg_named(source, "main");
+        assert_eq!(
+            count_drops(&main_cfg),
+            2,
+            "guarded drop of conditionally moved a, plain drop of b"
+        );
+        let has_flag_compare = main_cfg
+            .blocks()
+            .iter()
+            .flat_map(|b| b.insts.iter())
+            .any(|i| matches!(main_cfg.get_inst(*i).data, CfgInstData::Ne(..)));
+        assert!(
+            has_flag_compare,
+            "field a's exit drop must be guarded by a flag test"
+        );
+        assert_all_blocks_terminated(&main_cfg);
     }
 }

--- a/crates/rue-cli-tests/cases/drop_moves.toml
+++ b/crates/rue-cli-tests/cases/drop_moves.toml
@@ -16,10 +16,15 @@
 # scope exit — the struct's own destructor still runs, and the remaining
 # droppable fields are dropped individually in declaration order.
 #
-# Known residual (conservative "moved on ALL paths" analysis): a value moved
-# in only one branch of an if/match is still dropped at scope exit
-# (double-drop on the moving path). A full fix needs runtime drop flags, like
-# Rust.
+# Branch-divergent moves are handled with runtime drop flags (RUE-108 for
+# whole slots, RUE-156 for individual field paths): a value moved in only
+# one branch drops exactly once on every path. Field moves are tracked as
+# full paths of any depth (`eat(o.a.b)`, RUE-157), with each affected
+# field's scope-exit drop guarded by its own flag.
+#
+# Known residual: assigning over a still-owned struct FIELD does not drop
+# the old field value (pre-existing drop-on-overwrite gap, tracked
+# separately); these cases avoid pinning that behavior.
 
 [section]
 id = "cli.drop_moves"
@@ -395,8 +400,31 @@ stdout = "777\n"
 exit_code = 0
 
 [[case]]
-name = "branch_divergent_field_move_no_leak"
-description = "Known residual pinned: a field moved in only ONE branch is conservatively still dropped at scope exit (double-drop of 1 on the moving path), and nothing is leaked."
+name = "branch_divergent_string_field_move_no_double_free"
+description = "RUE-156 with a heap type: a String field moved in only ONE branch must not be freed again by the struct's scope-exit drop on the moving path."
+files = [{ path = "main.rue", source = """
+struct Holder { name: String, tag: String }
+
+fn eat(s: String) -> i32 {
+    0
+}
+
+fn main() -> i32 {
+    let h = Holder { name: String::with_capacity(8), tag: String::with_capacity(8) };
+    let c = true;
+    if c {
+        eat(h.name);
+    }
+    @dbg(777);
+    0
+}
+""" }]
+stdout = "777\n"
+exit_code = 0
+
+[[case]]
+name = "branch_divergent_field_move_drops_once_taken"
+description = "RUE-156: a field moved in only ONE branch drops exactly once when the branch IS taken — in the callee, with the field's guarded scope-exit drop skipped at runtime."
 files = [{ path = "main.rue", source = """
 struct Inner { v: i32 }
 
@@ -420,5 +448,241 @@ fn main() -> i32 {
     0
 }
 """ }]
-stdout = "1\n777\n1\n2\n"
+stdout = "1\n777\n2\n"
+exit_code = 0
+
+[[case]]
+name = "branch_divergent_field_move_drops_once_not_taken"
+description = "RUE-156: when the moving branch is NOT taken, the field's guarded scope-exit drop still runs — both fields drop at exit, nothing leaks."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Outer { a: Inner, b: Inner }
+
+fn eat(i: Inner) -> i32 {
+    0
+}
+
+fn main() -> i32 {
+    let o = Outer { a: Inner { v: 1 }, b: Inner { v: 2 } };
+    let c = false;
+    if c {
+        eat(o.a);
+    }
+    @dbg(777);
+    0
+}
+""" }]
+stdout = "777\n1\n2\n"
+exit_code = 0
+
+[[case]]
+name = "different_field_moved_per_branch_drops_once"
+description = "RUE-156: each branch moves a DIFFERENT field; per-field flags keep exactly the not-moved field's exit drop on each path."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Outer { a: Inner, b: Inner }
+
+fn eat(i: Inner) -> i32 {
+    0
+}
+
+fn main() -> i32 {
+    let o = Outer { a: Inner { v: 1 }, b: Inner { v: 2 } };
+    let c = true;
+    if c {
+        eat(o.a);
+    } else {
+        eat(o.b);
+    }
+    @dbg(777);
+    0
+}
+""" }]
+stdout = "1\n777\n2\n"
+exit_code = 0
+
+[[case]]
+name = "branch_divergent_field_move_then_reinit_drops_new_value"
+description = "RUE-156: a conditionally moved field that is reassigned afterwards is statically owned again — the fresh value drops at exit (no guard, no double drop of the moved one)."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Outer { a: Inner, b: Inner }
+
+fn eat(i: Inner) -> i32 {
+    0
+}
+
+fn main() -> i32 {
+    let mut o = Outer { a: Inner { v: 1 }, b: Inner { v: 2 } };
+    let c = true;
+    if c {
+        eat(o.a);
+    }
+    o.a = Inner { v: 9 };
+    @dbg(777);
+    0
+}
+""" }]
+stdout = "1\n777\n9\n2\n"
+exit_code = 0
+
+[[case]]
+name = "deep_field_move_drops_once"
+description = "RUE-157: moving a depth-2 field path (`t.mid.leaf`) exports a path marker — the leaf drops only in the callee, and the exit drop walks the structs field-granularly."
+files = [{ path = "main.rue", source = """
+struct Leaf { v: i32 }
+struct Mid { leaf: Leaf, other: Leaf }
+struct Top { mid: Mid }
+
+drop fn Leaf(self) {
+    @dbg(self.v);
+}
+
+fn eat(l: Leaf) -> i32 {
+    0
+}
+
+fn main() -> i32 {
+    let t = Top { mid: Mid { leaf: Leaf { v: 5 }, other: Leaf { v: 6 } } };
+    eat(t.mid.leaf);
+    @dbg(777);
+    0
+}
+""" }]
+stdout = "5\n777\n6\n"
+exit_code = 0
+
+[[case]]
+name = "deep_field_move_out_of_byvalue_param_drops_once"
+description = "RUE-157: a depth-2 path moved out of a by-value PARAM suppresses just that path in the callee's param exit drop."
+files = [{ path = "main.rue", source = """
+struct Leaf { v: i32 }
+struct Mid { leaf: Leaf, other: Leaf }
+struct Top { mid: Mid }
+
+drop fn Leaf(self) {
+    @dbg(self.v);
+}
+
+fn eat(l: Leaf) -> i32 {
+    0
+}
+
+fn consume(t: Top) -> i32 {
+    eat(t.mid.leaf)
+}
+
+fn main() -> i32 {
+    let t = Top { mid: Mid { leaf: Leaf { v: 5 }, other: Leaf { v: 6 } } };
+    consume(t);
+    @dbg(777);
+    0
+}
+""" }]
+stdout = "5\n6\n777\n"
+exit_code = 0
+
+[[case]]
+name = "branch_divergent_deep_field_move_taken"
+description = "RUE-156 + RUE-157 combined: a conditionally moved depth-2 path drops once when the branch is taken (callee drop only; guarded exit drop skipped)."
+files = [{ path = "main.rue", source = """
+struct Leaf { v: i32 }
+struct Mid { leaf: Leaf, other: Leaf }
+struct Top { mid: Mid }
+
+drop fn Leaf(self) {
+    @dbg(self.v);
+}
+
+fn eat(l: Leaf) -> i32 {
+    0
+}
+
+fn main() -> i32 {
+    let t = Top { mid: Mid { leaf: Leaf { v: 5 }, other: Leaf { v: 6 } } };
+    let c = true;
+    if c {
+        eat(t.mid.leaf);
+    }
+    @dbg(777);
+    0
+}
+""" }]
+stdout = "5\n777\n6\n"
+exit_code = 0
+
+[[case]]
+name = "branch_divergent_deep_field_move_not_taken"
+description = "RUE-156 + RUE-157 combined: when the moving branch is NOT taken, the depth-2 path's guarded exit drop runs — everything drops exactly once."
+files = [{ path = "main.rue", source = """
+struct Leaf { v: i32 }
+struct Mid { leaf: Leaf, other: Leaf }
+struct Top { mid: Mid }
+
+drop fn Leaf(self) {
+    @dbg(self.v);
+}
+
+fn eat(l: Leaf) -> i32 {
+    0
+}
+
+fn main() -> i32 {
+    let t = Top { mid: Mid { leaf: Leaf { v: 5 }, other: Leaf { v: 6 } } };
+    let c = false;
+    if c {
+        eat(t.mid.leaf);
+    }
+    @dbg(777);
+    0
+}
+""" }]
+stdout = "777\n5\n6\n"
+exit_code = 0
+
+[[case]]
+name = "nested_destructor_runs_for_partially_moved_inner_struct"
+description = "RUE-157: an inner struct with its own destructor that lost a field still runs its destructor (without glue) during the field-granular exit walk, then its remaining field drops."
+files = [{ path = "main.rue", source = """
+struct Leaf { v: i32 }
+struct Mid { leaf: Leaf, other: Leaf }
+
+drop fn Leaf(self) {
+    @dbg(self.v);
+}
+
+drop fn Mid(self) {
+    @dbg(100);
+}
+
+fn eat(l: Leaf) -> i32 {
+    0
+}
+
+fn main() -> i32 {
+    let m = Mid { leaf: Leaf { v: 5 }, other: Leaf { v: 6 } };
+    let c = true;
+    if c {
+        eat(m.leaf);
+    }
+    @dbg(777);
+    0
+}
+""" }]
+stdout = "5\n777\n100\n6\n"
 exit_code = 0


### PR DESCRIPTION
Two Urgent double-free holes from the drops-destructors hunt, fixed with one path-keyed design.

**RUE-157 — depth≥2 nested field moves emitted no move marker at all.** `take(t.mid.leaf)` dropped the leaf twice (callee + root's scope exit): sema exported MarkMoved only for single-level projections, with a comment calling the deeper case "conservative" — but the conservative direction for *drops* is the opposite of the one for move *checking*, so it was a double-drop, not an over-approximation. `AirInstData::MarkMoved` now carries `place: Option<AirPlaceRef>` (arbitrary-depth pure-Field path reusing interned places) and sema exports markers at any depth. The comment now states the honest consequence.

**RUE-156 — conditionally-moved fields were re-dropped at scope exit.** `if c { take(s.a); }` printed `1,1,2`: the field-level MarkMoved arm never touched drop flags, and the if-join intersected away the some-paths move. Now: per-(slot, field-path) runtime drop flags — armed at init and whole-slot reinit, cleared at the field move; `MoveState` gains a union-joined `maybe_fields` set; `emit_partial_struct_drop` is recursive (destructor-without-glue per level), skips definitely-moved paths, and guards possibly-moved paths via new `begin/end_flag_guard` primitives. The whole-slot machinery is unchanged.

Backend-neutral (rue-air/rue-cfg only; aarch64 sanity-checked via `--emit asm`). Verified post-integration: the conditional repro prints `1,2` and the nested repro prints `5` exactly once. 10 exact-stdout CLI cases in `drop_moves.toml` — including the case that previously **pinned the buggy output**, converted to a regression test — plus 2 CFG unit tests. Full ./test.sh green.

Known residuals (tracked, other PRs in flight this cycle): drop-on-overwrite for fields (RUE-64 family) and loop-body field moves stay conservative.

Fixes RUE-156
Fixes RUE-157

🤖 Generated with [Claude Code](https://claude.com/claude-code)