### PR TITLE
Drop the overwritten value at every store path; drop discarded temporaries

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -865,6 +865,10 @@ impl<'a> CfgBuilder<'a> {
                 let Some(val) = self.lower_value(*value) else {
                     return Self::diverged();
                 };
+                // The old value, if still owned, is dropped before being
+                // overwritten (RUE-64): evaluate RHS, drop old, store new.
+                let val_ty = self.air.get(*value).ty;
+                self.emit_overwrite_drop(MovedSlot::Local(*slot), val_ty, span);
                 self.emit(
                     CfgInstData::Store {
                         slot: *slot,
@@ -888,6 +892,10 @@ impl<'a> CfgBuilder<'a> {
                 let Some(val) = self.lower_value(*value) else {
                     return Self::diverged();
                 };
+                // Drop the overwritten old value first (RUE-64); for an
+                // `inout` param this is the caller's value being replaced.
+                let val_ty = self.air.get(*value).ty;
+                self.emit_overwrite_drop(MovedSlot::Param(*param_slot), val_ty, span);
                 self.emit(
                     CfgInstData::ParamStore {
                         param_slot: *param_slot,
@@ -1218,6 +1226,22 @@ impl<'a> CfgBuilder<'a> {
                             value: None,
                             continuation: Continuation::Diverged,
                         };
+                    }
+
+                    // A statement's discarded result is a temporary the
+                    // statement owns (`D { v: 7 };`, `make();`, `let _ = …`,
+                    // a discarded if/match result): drop it at the end of
+                    // the statement (RUE-65, RUE-66). Values forwarded into
+                    // calls are NOT affected — the callee owns and drops
+                    // those; only the statement's own result is dropped
+                    // here. Moves out of locals (`d;`) were already marked
+                    // by MarkMoved, so this drop is the move's destination.
+                    if let Some(temp_val) = result.value {
+                        let stmt_ty = self.air.get(*stmt).ty;
+                        if self.type_needs_drop(stmt_ty) {
+                            let stmt_span = self.air.get(*stmt).span;
+                            self.emit(CfgInstData::Drop { value: temp_val }, Type::UNIT, stmt_span);
+                        }
                     }
                 }
 
@@ -1904,6 +1928,25 @@ impl<'a> CfgBuilder<'a> {
                 let Some(val) = self.lower_value(*value) else {
                     return Self::diverged();
                 };
+                // The overwritten element, if still owned, is dropped before
+                // the store (RUE-64). (Element assignment currently reaches
+                // CFG as PlaceWrite; kept correct here too.)
+                let elem_ty = self.air.get(*value).ty;
+                let elem_place = self.cfg.make_place(
+                    PlaceBase::Local(*slot),
+                    std::iter::once(Projection::Index {
+                        array_type: *array_type,
+                        index: index_val,
+                    }),
+                );
+                self.emit_projected_overwrite_drop(
+                    MovedSlot::Local(*slot),
+                    elem_place,
+                    elem_ty,
+                    false,
+                    None,
+                    span,
+                );
                 self.emit(
                     CfgInstData::IndexSet {
                         slot: *slot,
@@ -1932,6 +1975,24 @@ impl<'a> CfgBuilder<'a> {
                 let Some(val) = self.lower_value(*value) else {
                     return Self::diverged();
                 };
+                // See the IndexSet arm: drop the overwritten element first
+                // (RUE-64).
+                let elem_ty = self.air.get(*value).ty;
+                let elem_place = self.cfg.make_place(
+                    PlaceBase::Param(*param_slot),
+                    std::iter::once(Projection::Index {
+                        array_type: *array_type,
+                        index: index_val,
+                    }),
+                );
+                self.emit_projected_overwrite_drop(
+                    MovedSlot::Param(*param_slot),
+                    elem_place,
+                    elem_ty,
+                    false,
+                    None,
+                    span,
+                );
                 self.emit(
                     CfgInstData::ParamIndexSet {
                         param_slot: *param_slot,
@@ -1971,6 +2032,54 @@ impl<'a> CfgBuilder<'a> {
                 let Some(cfg_place) = self.lower_air_place(*place) else {
                     return Self::diverged();
                 };
+                // The destination's old value, if still owned, is dropped
+                // before being overwritten (RUE-64): evaluate RHS, drop old,
+                // store new. A whole-variable write reuses the slot-overwrite
+                // drop (partial-move aware); a projected write (one field or
+                // array element) reads the old value through the place. A
+                // top-level field whose contents were statically moved out
+                // (RUE-62) holds nothing to drop.
+                let air_place = self.air.get_place(*place);
+                let val_ty = self.air.get(*value).ty;
+                let base_key = match air_place.base {
+                    AirPlaceBase::Local(slot) => MovedSlot::Local(slot),
+                    AirPlaceBase::Param(slot) => MovedSlot::Param(slot),
+                };
+                if air_place.projections_len == 0 {
+                    self.emit_overwrite_drop(base_key, val_ty, span);
+                } else {
+                    // A single top-level field write: skip the old-value
+                    // drop when the field was definitely moved out, and guard
+                    // it with the field's runtime drop flag when the move was
+                    // path-dependent (RUE-156 x RUE-64 interaction).
+                    let mut field_flag: Option<u32> = None;
+                    let field_moved = match self
+                        .air
+                        .get_projections(air_place.projections_start, air_place.projections_len)
+                    {
+                        [AirProjection::Field { field_index, .. }] => {
+                            let path = vec![*field_index];
+                            if self.moved.moved_paths_of(base_key).contains(&path) {
+                                true
+                            } else {
+                                if self.moved.maybe_moved_paths_of(base_key).contains(&path) {
+                                    field_flag =
+                                        self.field_drop_flags.get(&(base_key, path)).copied();
+                                }
+                                false
+                            }
+                        }
+                        _ => false,
+                    };
+                    self.emit_projected_overwrite_drop(
+                        base_key,
+                        cfg_place,
+                        val_ty,
+                        field_moved,
+                        field_flag,
+                        span,
+                    );
+                }
                 self.emit(
                     CfgInstData::PlaceWrite {
                         place: cfg_place,
@@ -1985,7 +2094,6 @@ impl<'a> CfgBuilder<'a> {
                 // restore a fully moved-out variable — but a write to exactly
                 // one top-level field (`o.a = ...`) does re-initialize that
                 // field, so its per-field moved state is cleared (RUE-62).
-                let air_place = self.air.get_place(*place);
                 if let Some(slot) = air_place.as_local() {
                     self.moved.clear_slot(MovedSlot::Local(slot));
                     self.update_drop_flag(MovedSlot::Local(slot), true, span);
@@ -1993,15 +2101,15 @@ impl<'a> CfgBuilder<'a> {
                     self.moved.clear_slot(MovedSlot::Param(slot));
                     self.update_drop_flag(MovedSlot::Param(slot), true, span);
                 } else if air_place.projections_len == 1 {
-                    let base = match air_place.base {
-                        AirPlaceBase::Local(slot) => MovedSlot::Local(slot),
-                        AirPlaceBase::Param(slot) => MovedSlot::Param(slot),
-                    };
                     if let [AirProjection::Field { field_index, .. }] = self
                         .air
                         .get_projections(air_place.projections_start, air_place.projections_len)
                     {
-                        self.moved.clear_field(base, *field_index);
+                        self.moved.clear_field(base_key, *field_index);
+                        // The field is re-initialized: re-arm its runtime
+                        // drop flag so scope-exit (and later overwrite)
+                        // drops fire again (RUE-156).
+                        self.update_field_drop_flag(base_key, &[*field_index], true, span);
                     }
                 }
                 ExprResult {
@@ -2533,6 +2641,65 @@ impl<'a> CfgBuilder<'a> {
             Type::UNIT,
             span,
         );
+    }
+
+    /// Drop the live value about to be overwritten by a whole-slot
+    /// assignment (RUE-64). Assignment semantics follow Rust: the RHS is
+    /// fully evaluated first, then the destination's old value is dropped,
+    /// then the new value is stored — so callers invoke this after lowering
+    /// the RHS and before emitting the store.
+    ///
+    /// The drop is skipped when the old value was moved out on every path
+    /// (`d = f(d)` — the RHS itself consumed it); path-dependent moves are
+    /// handled at runtime by the drop-flag guard. A slot with moved-out
+    /// FIELDS is dropped field-granularly (RUE-62), like at scope exit.
+    fn emit_overwrite_drop(&mut self, key: MovedSlot, ty: Type, span: rue_span::Span) {
+        if self.moved.is_slot_moved(key) || !self.type_needs_drop(ty) {
+            return;
+        }
+        self.emit_guarded(key, span, |b| {
+            if !b.emit_partial_struct_drop(key, ty, span) {
+                let old_val = match key {
+                    MovedSlot::Local(slot) => b.emit(CfgInstData::Load { slot }, ty, span),
+                    MovedSlot::Param(index) => b.emit(CfgInstData::Param { index }, ty, span),
+                };
+                b.emit(CfgInstData::Drop { value: old_val }, Type::UNIT, span);
+            }
+        });
+    }
+
+    /// Drop the live value about to be overwritten through a PROJECTED place
+    /// (field or array-element assignment, RUE-64). Same ordering contract
+    /// as [`emit_overwrite_drop`]. `base_key` is the place's base slot: a
+    /// statically moved-out base means the old projected value is gone, and
+    /// a path-dependent whole-base move is guarded by the base's drop flag.
+    /// `field_moved` lets the caller suppress the drop when this exact
+    /// top-level field was statically moved out (RUE-62).
+    fn emit_projected_overwrite_drop(
+        &mut self,
+        base_key: MovedSlot,
+        place: Place,
+        ty: Type,
+        field_moved: bool,
+        field_flag: Option<u32>,
+        span: rue_span::Span,
+    ) {
+        if self.moved.is_slot_moved(base_key) || field_moved || !self.type_needs_drop(ty) {
+            return;
+        }
+        self.emit_guarded(base_key, span, |b| {
+            if let Some(flag) = field_flag {
+                // The exact field was moved on some paths only: its per-path
+                // runtime flag (RUE-156) says whether the old value is live.
+                let cont = b.begin_flag_guard(flag, span);
+                let old_val = b.emit(CfgInstData::PlaceRead { place }, ty, span);
+                b.emit(CfgInstData::Drop { value: old_val }, Type::UNIT, span);
+                b.end_flag_guard(cont);
+            } else {
+                let old_val = b.emit(CfgInstData::PlaceRead { place }, ty, span);
+                b.emit(CfgInstData::Drop { value: old_val }, Type::UNIT, span);
+            }
+        });
     }
 
     /// Field-granular drop of a partially-moved struct (RUE-62, RUE-156,

--- a/crates/rue-cli-tests/cases/overwrite_drops.toml
+++ b/crates/rue-cli-tests/cases/overwrite_drops.toml
@@ -1,0 +1,337 @@
+# Assignment-overwrite drops (RUE-64) and statement-temporary drops
+# (RUE-65, RUE-66).
+#
+# Every assignment used to re-arm the destination's drop flag but never drop
+# the value being overwritten — `d = D{2}` leaked the old `D{1}` — and
+# discarded expression-statement results (`D{77};`, `make();`, `let _ = …`)
+# were never dropped at all. Assignment now follows Rust order: evaluate the
+# RHS, drop the destination's old value, store the new one; discarded
+# statement results drop at the end of their statement. All cases pin the
+# EXACT drop order via stdout.
+
+[section]
+id = "cli.overwrite_drops"
+name = "Overwrite and temporary drops"
+description = "Old values drop at assignment; discarded temporaries drop at statement end."
+
+# =============================================================================
+# RUE-64: the overwrite matrix
+# =============================================================================
+
+[[case]]
+name = "var_reassignment_drops_old_value"
+description = "d = D{2} drops the old D{1} after the RHS is built, before the store."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+fn main() -> i32 {
+    let mut d = D { v: 1 };
+    d = D { v: 2 };
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "1\n100\n2\n"
+
+[[case]]
+name = "field_assignment_drops_old_value"
+description = "b.f = D{2} drops the old field value."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+struct B { f: D }
+fn main() -> i32 {
+    let mut b = B { f: D { v: 1 } };
+    b.f = D { v: 2 };
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "1\n100\n2\n"
+
+[[case]]
+name = "element_assignment_drops_old_value"
+description = "arr[0] = D{10} drops the overwritten element; scope exit drops the rest."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+fn main() -> i32 {
+    let mut arr = [D { v: 1 }, D { v: 2 }];
+    arr[0] = D { v: 10 };
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "1\n100\n10\n2\n"
+
+[[case]]
+name = "inout_param_reassignment_drops_old_value"
+description = "Reassigning an inout param inside the callee drops the caller's old value."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+fn replace(inout d: D) {
+    d = D { v: 99 };
+}
+fn main() -> i32 {
+    let mut d = D { v: 1 };
+    replace(inout d);
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "1\n100\n99\n"
+
+[[case]]
+name = "reassignment_in_loop_drops_each_old_value"
+description = "Every loop-iteration store drops the previous occupant exactly once."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+fn main() -> i32 {
+    let mut d = D { v: 1 };
+    let mut i = 0;
+    while i < 2 {
+        d = D { v: 10 + i };
+        i = i + 1;
+    }
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "1\n10\n100\n11\n"
+
+# =============================================================================
+# RUE-64: no double drops where the RHS or a branch already consumed the value
+# =============================================================================
+
+[[case]]
+name = "self_move_assignment_no_double_drop"
+description = "d = bump(d): the RHS moves d out, so the assignment drops nothing (only bump's by-value param drop runs)."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+fn bump(d: D) -> D { D { v: d.v + 10 } }
+fn main() -> i32 {
+    let mut d = D { v: 1 };
+    d = bump(d);
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "1\n100\n11\n"
+
+[[case]]
+name = "assignment_after_full_move_drops_nothing"
+description = "After consume(d), the slot is empty: reassignment drops only at the next owner."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+fn consume(d: D) -> i32 { d.v }
+fn main() -> i32 {
+    let mut d = D { v: 1 };
+    consume(d);
+    d = D { v: 2 };
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "1\n100\n2\n"
+
+[[case]]
+name = "branch_divergent_move_then_assignment_guarded"
+description = "Conditionally moved value: the overwrite drop is guarded by the runtime drop flag — exactly one old-value drop on each path."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+fn consume(d: D) -> i32 { d.v }
+fn run(c: i32) -> i32 {
+    let mut d = D { v: 1 };
+    if c == 1 { consume(d); }
+    d = D { v: 2 };
+    @dbg(100);
+    0
+}
+fn main() -> i32 {
+    run(1);
+    @dbg(500);
+    run(0);
+    0
+}
+""" }]
+stdout = "1\n100\n2\n500\n1\n100\n2\n"
+
+[[case]]
+name = "partially_moved_struct_overwrite_drops_remaining_fields"
+description = "Whole-struct overwrite after a field move drops only the still-owned fields of the old value (RUE-62 interaction)."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+struct B { f: D, g: D }
+fn eat(d: D) -> i32 { d.v }
+fn main() -> i32 {
+    let mut b = B { f: D { v: 1 }, g: D { v: 2 } };
+    eat(b.f);
+    b = B { f: D { v: 3 }, g: D { v: 4 } };
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "1\n2\n100\n3\n4\n"
+
+# =============================================================================
+# RUE-65/RUE-66: discarded temporaries
+# =============================================================================
+
+[[case]]
+name = "bare_struct_literal_statement_drops"
+description = "An unbound droppable literal drops at the end of its statement."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+fn main() -> i32 {
+    D { v: 77 };
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "77\n100\n"
+
+[[case]]
+name = "temporary_forwarded_into_call_drops_in_callee"
+description = "consume(D{77}) is NOT a statement temporary: the callee owns and drops its by-value argument exactly once."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+fn consume(d: D) -> i32 { d.v }
+fn main() -> i32 {
+    consume(D { v: 77 });
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "77\n100\n"
+
+[[case]]
+name = "discarded_call_result_drops"
+description = "A droppable call result used as a statement drops at statement end."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+fn make() -> D { D { v: 44 } }
+fn main() -> i32 {
+    make();
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "44\n100\n"
+
+[[case]]
+name = "discarded_if_result_drops"
+description = "A discarded if/else result drops at statement end."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+fn pick(c: bool) -> i32 {
+    if c { D { v: 5 } } else { D { v: 6 } };
+    @dbg(100);
+    0
+}
+fn main() -> i32 {
+    pick(true);
+    pick(false);
+    0
+}
+""" }]
+stdout = "5\n100\n6\n100\n"
+
+[[case]]
+name = "let_underscore_drops_immediately"
+description = "let _ = value binds nothing and drops the value at the end of the statement."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+fn main() -> i32 {
+    let _ = D { v: 88 };
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "88\n100\n"
+
+[[case]]
+name = "bare_variable_statement_moves_and_drops"
+description = "`d;` moves d into a statement temporary, which drops there; no second drop at scope exit."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+fn main() -> i32 {
+    let d = D { v: 9 };
+    d;
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "9\n100\n"
+
+[[case]]
+name = "bare_field_statement_moves_field_and_drops"
+description = "`b.f;` partially moves the field into a dropped temporary; scope exit drops only the remaining field."
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+struct B { f: D, g: D }
+fn main() -> i32 {
+    let b = B { f: D { v: 1 }, g: D { v: 2 } };
+    b.f;
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "1\n100\n2\n"
+
+# Interaction of per-field drop flags (RUE-156) with overwrite drops
+# (RUE-64): a field moved on only SOME paths must not be re-dropped by the
+# reassignment on the paths where it was moved, and must be dropped on the
+# paths where it wasn't. The reassignment re-arms the field's flag either
+# way, so the new value drops at scope exit exactly once.
+[[case]]
+name = "conditional_field_move_then_reassign_taken"
+files = [{ path = "main.rue", source = """
+struct Inner { x: i32 }
+struct S { a: Inner, b: Inner }
+drop fn Inner(self) { @dbg(self.x); }
+fn take(i: Inner) -> i32 { i.x }
+fn main() -> i32 {
+    let mut s = S { a: Inner { x: 1 }, b: Inner { x: 2 } };
+    let c = true;
+    if c {
+        take(s.a);
+    }
+    s.a = Inner { x: 9 };
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "1\n100\n9\n2\n"
+
+[[case]]
+name = "conditional_field_move_then_reassign_not_taken"
+files = [{ path = "main.rue", source = """
+struct Inner { x: i32 }
+struct S { a: Inner, b: Inner }
+drop fn Inner(self) { @dbg(self.x); }
+fn take(i: Inner) -> i32 { i.x }
+fn main() -> i32 {
+    let mut s = S { a: Inner { x: 1 }, b: Inner { x: 2 } };
+    let c = false;
+    if c {
+        take(s.a);
+    }
+    s.a = Inner { x: 9 };
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "1\n100\n9\n2\n"

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -820,3 +820,133 @@ fn main() -> i32 { 0 }
 compile_fail = true
 error_contains = "unknown type"
 
+
+[[case]]
+name = "assignment_drops_overwritten_value"
+spec = ["3.9:18"]
+description = "Assignment drops the destination's old value after the RHS is evaluated, before the store (RUE-64)"
+source = """
+struct Data { value: i32 }
+
+drop fn Data(self) {
+    @dbg(self.value);
+}
+
+fn main() -> i32 {
+    let mut d = Data { value: 1 };
+    d = Data { value: 2 };  // old value (1) dropped here
+    @dbg(100);
+    0
+}  // new value (2) dropped here
+"""
+exit_code = 0
+expected_stdout = "1\n100\n2\n"
+
+[[case]]
+name = "field_assignment_drops_overwritten_value"
+spec = ["3.9:18"]
+description = "Field assignment drops the field's old value before storing the new one (RUE-64)"
+source = """
+struct Data { value: i32 }
+
+drop fn Data(self) {
+    @dbg(self.value);
+}
+
+struct Holder { d: Data }
+
+fn main() -> i32 {
+    let mut h = Holder { d: Data { value: 1 } };
+    h.d = Data { value: 2 };  // old field value (1) dropped here
+    @dbg(100);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "1\n100\n2\n"
+
+[[case]]
+name = "element_assignment_drops_overwritten_value"
+spec = ["3.9:18"]
+description = "Array element assignment drops the overwritten element before storing the new one (RUE-64)"
+source = """
+struct Data { value: i32 }
+
+drop fn Data(self) {
+    @dbg(self.value);
+}
+
+fn main() -> i32 {
+    let mut arr = [Data { value: 1 }, Data { value: 2 }];
+    arr[0] = Data { value: 10 };  // old element (1) dropped here
+    @dbg(100);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "1\n100\n10\n2\n"
+
+[[case]]
+name = "assignment_after_move_does_not_drop"
+spec = ["3.9:18", "3.9:2"]
+description = "Assignment to a moved-out variable drops nothing: the RHS consumed the old value (no double drop)"
+source = """
+struct Data { value: i32 }
+
+drop fn Data(self) {
+    @dbg(self.value);
+}
+
+fn bump(d: Data) -> Data {
+    Data { value: d.value + 10 }
+}
+
+fn main() -> i32 {
+    let mut d = Data { value: 1 };
+    d = bump(d);  // RHS moves d out; only bump's parameter drop (1) runs
+    @dbg(100);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "1\n100\n11\n"
+
+[[case]]
+name = "discarded_temporary_dropped_at_statement_end"
+spec = ["3.9:18"]
+description = "A discarded expression-statement result is dropped at the end of the statement (RUE-65)"
+source = """
+struct Data { value: i32 }
+
+drop fn Data(self) {
+    @dbg(self.value);
+}
+
+fn main() -> i32 {
+    Data { value: 77 };  // temporary dropped here
+    @dbg(100);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "77\n100\n"
+
+[[case]]
+name = "let_underscore_drops_value"
+spec = ["3.9:18"]
+description = "`let _ = value` drops the value at the end of the statement (RUE-66)"
+source = """
+struct Data { value: i32 }
+
+drop fn Data(self) {
+    @dbg(self.value);
+}
+
+fn main() -> i32 {
+    let _ = Data { value: 88 };  // dropped here
+    @dbg(100);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "88\n100\n"

--- a/docs/spec/src/03-types/09-destructors.md
+++ b/docs/spec/src/03-types/09-destructors.md
@@ -125,6 +125,8 @@ Drops are inserted at the following points:
 - At the end of a block scope, for all live bindings declared in that scope
 - Before a `return` statement, for all live bindings in all enclosing scopes
 - Before a `break` statement, for all live bindings declared inside the loop
+- At an assignment, for the destination's previous value: when an assignment overwrites a place (a variable, struct field, array element, or `inout` parameter) whose current value is live (not moved out), the overwritten value is dropped after the right-hand side has been fully evaluated and before the new value is stored
+- At the end of an expression statement whose result is discarded (including a `let _ = ...` statement), for the discarded result value
 
 {{ rule(id="3.9:19", cat="dynamic-semantics") }}
 


### PR DESCRIPTION
Closes the destructor-leak family from the drops-destructors hunt.

**RUE-64 — assignment over a live value leaked it.** All four store paths re-armed drop flags but never dropped the previous occupant: plain reassignment (`Store`), field/element assignment (`PlaceWrite`, plus the dormant `IndexSet`/`ParamIndexSet` arms), and reassignment through an `inout` param (`ParamStore` — which leaked the **caller's** value). Each now drops the old value in Rust order (evaluate RHS → drop old → store), **statically suppressed** when the RHS moved the destination out (`d = bump(d)` — verified no double-drop), **drop-flag-guarded** for branch-divergent moves, and **field-granular** for partially-moved structs.

**RUE-65/RUE-66 — discarded temporaries never dropped.** Discarded expression-statement results and `let _ =` (identical AIR, verified) now drop at end of statement via the Block stmt loop. `consume(D{77})` was verified NOT to be a leak (the callee drops its by-value param) and is pinned by a control case.

Spec 3.9:18 gains the assignment-overwrite and discarded-result drop points (the placement list omitted both). 6 new spec cases + 16 exact-stdout CLI cases (`overwrite_drops.toml`) asserting drop **order**, not just exit codes.

Verified post-integration by execution: reassignment prints `1,100,2`; inout reassignment prints `40,500,99` (caller's old value drops inside the callee); `d = bump(d)` prints `10,700,11` with no double-drop; `let _` prints `88,1`. Full ./test.sh green.

Note: this PR and #967 (per-field drop flags) edit disjoint regions of `rue-cfg/src/build.rs`; whichever lands second may need a trivial rebase.

Fixes RUE-64
Fixes RUE-65
Fixes RUE-66

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Rebase note (post-#967):** the predicted build.rs conflict landed here; resolution keeps both PRs' semantics. The rebase also wired the two mechanisms together — the single-field overwrite drop is now guarded by the field's RUE-156 runtime drop flag when the field was moved on only some paths (previously it double-dropped: `1,1,100,9,2`), and reassignment re-arms the field's flag. Two new exact-stdout CLI cases pin the taken and not-taken variants (both `1,100,9,2`). Full ./test.sh re-run green on the rebased stack.