### PR TITLE
Destructor legality: reject field moves out of dtor-having values (E0456) and @copy+drop (E0457)

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2227,6 +2227,70 @@ impl<'a> Sema<'a> {
         Ok(())
     }
 
+    /// Reject moving a field out of a value whose struct type has a
+    /// destructor (RUE-158, the spirit of Rust's E0509).
+    ///
+    /// The destructor always runs on the *whole* value when it is dropped:
+    /// it would observe the moved-out field (a use-after-free for heap
+    /// fields), and the automatic field cleanup after the destructor would
+    /// drop the field a second time. Inside `drop fn T(self)` this same rule
+    /// rejects `self.field` moves — `self` has type `T`, which has the very
+    /// destructor being defined (whole-`self` moves are E0442).
+    ///
+    /// Every container along the projection chain is checked (`o.a.b` moves
+    /// out of both `o` and `o.a`), mirroring Rust: a deep move leaves every
+    /// enclosing value partially moved. Whole-value moves and `borrow`/
+    /// `inout` access of fields (RUE-143) stay legal and never reach here.
+    fn reject_field_move_out_of_destructor_type(
+        &self,
+        trace: &PlaceTrace,
+        span: Span,
+    ) -> CompileResult<()> {
+        for (i, proj_info) in trace.projections.iter().enumerate() {
+            let container = if i == 0 {
+                trace.base_type
+            } else {
+                trace.projections[i - 1].result_type
+            };
+            let Some(struct_id) = container.as_struct() else {
+                continue;
+            };
+            let struct_def = self.type_pool.struct_def(struct_id);
+            if struct_def.destructor.is_none() {
+                continue;
+            }
+            let field_name = proj_info
+                .field_name
+                .map(|s| self.interner.resolve(&s).to_string())
+                .unwrap_or_default();
+            let mut err = CompileError::new(
+                ErrorKind::MoveFieldOutOfDestructorType {
+                    struct_name: struct_def.name.clone(),
+                    field_name: field_name.clone(),
+                },
+                span,
+            )
+            .with_label(format!("field `{field_name}` is moved out here"), span)
+            .with_note(format!(
+                "the destructor for '{}' runs on the whole value when it is dropped: it \
+                 would observe the moved-out field, and the automatic field cleanup after \
+                 the destructor would drop `{field_name}` a second time",
+                struct_def.name
+            ))
+            .with_help(format!(
+                "borrow the field instead (`borrow value.{field_name}`), or move the whole value"
+            ));
+            if let Some(drop_span) = self.destructor_spans.get(&struct_id) {
+                err = err.with_label(
+                    format!("destructor for '{}' is defined here", struct_def.name),
+                    *drop_span,
+                );
+            }
+            return Err(err);
+        }
+        Ok(())
+    }
+
     /// Analyze a field access.
     ///
     /// Uses place-based analysis (ADR-0030) when possible for efficient code generation.
@@ -2320,6 +2384,7 @@ impl<'a> Sema<'a> {
             } else if !self.is_type_copy(field_type) {
                 // For non-linear types, check if accessing a non-Copy field
                 self.reject_move_out_of_byref_param(trace.root_var, ctx, span)?;
+                self.reject_field_move_out_of_destructor_type(&trace, span)?;
                 let field_path = trace.field_path();
 
                 // Check if this field path is already moved (partial moves)

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -719,10 +719,60 @@ impl<'a> Sema<'a> {
             ));
         }
 
+        // A @copy struct cannot have a destructor (RUE-159, the spirit of
+        // Rust's E0184): copies are implicit and untracked, so every copy
+        // would run the destructor again — double cleanup of the same
+        // logical resource. `is_copy` is already set here: struct directives
+        // are processed in phase 1 (register_type_names), before this pass.
+        if struct_def.is_copy {
+            let mut err = CompileError::new(
+                ErrorKind::CopyStructWithDestructor {
+                    type_name: type_name_str,
+                },
+                span,
+            )
+            .with_label("destructor defined here", span)
+            .with_note(
+                "`@copy` values are duplicated implicitly, so the destructor would run \
+                 once per copy — cleaning up the same resource multiple times",
+            )
+            .with_help("remove the `@copy` attribute or remove the `drop fn`");
+            if let Some(copy_span) = self.find_copy_directive_span(type_name) {
+                err = err.with_label("type declared `@copy` here", copy_span);
+            }
+            return Err(err);
+        }
+
         let destructor_name = format!("{}.__drop", type_name_str);
         struct_def.destructor = Some(destructor_name);
         self.type_pool.update_struct_def(struct_id, struct_def);
+        self.destructor_spans.insert(struct_id, span);
         Ok(())
+    }
+
+    /// Find the span of the `@copy` directive on the struct declaration
+    /// named `type_name`, for diagnostics that point at the attribute.
+    fn find_copy_directive_span(&self, type_name: Spur) -> Option<Span> {
+        let copy_sym = self.interner.get("copy")?;
+        for (_, inst) in self.rir.iter() {
+            if let InstData::StructDecl {
+                name,
+                directives_start,
+                directives_len,
+                ..
+            } = &inst.data
+            {
+                if *name != type_name {
+                    continue;
+                }
+                let directives = self.rir.get_directives(*directives_start, *directives_len);
+                return directives
+                    .iter()
+                    .find(|d| d.name == copy_sym)
+                    .map(|d| d.span);
+            }
+        }
+        None
     }
 
     /// Collect a function signature for forward reference.

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -99,6 +99,7 @@ impl<'a> GatherOutput<'a> {
             param_arena: self.param_arena,
             anon_struct_method_sigs: HashMap::new(),
             anon_struct_captured_values: HashMap::new(),
+            destructor_spans: HashMap::new(),
         }
     }
 }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -59,7 +59,7 @@ use std::collections::HashMap;
 use lasso::{Spur, ThreadedRodeo};
 use rue_error::{CompileErrors, MultiErrorResult, PreviewFeatures};
 use rue_rir::Rir;
-use rue_span::FileId;
+use rue_span::{FileId, Span};
 
 use crate::intern_pool::TypeInternPool;
 use crate::param_arena::ParamArena;
@@ -105,6 +105,11 @@ pub struct Sema<'a> {
     /// stored here, keyed by StructId. These values become part of type identity:
     /// FixedBuffer(42) and FixedBuffer(100) are different types.
     pub(crate) anon_struct_captured_values: HashMap<StructId, HashMap<Spur, ConstValue>>,
+    /// Span of each user-defined `drop fn` declaration, keyed by the struct
+    /// it destructs. Used by diagnostics that point at the destructor
+    /// (E0456 field-move-out-of-destructor-type, E0457 @copy-with-destructor).
+    /// Builtin destructors (e.g. String's) have no entry.
+    pub(crate) destructor_spans: HashMap<StructId, Span>,
 }
 
 impl<'a> Sema<'a> {
@@ -133,6 +138,7 @@ impl<'a> Sema<'a> {
             param_arena: ParamArena::new(),
             anon_struct_method_sigs: HashMap::new(),
             anon_struct_captured_values: HashMap::new(),
+            destructor_spans: HashMap::new(),
         }
     }
 

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -3092,15 +3092,6 @@ mod tests {
             .count()
     }
 
-    /// Count the Call instructions in a CFG.
-    fn count_calls(cfg: &Cfg) -> usize {
-        cfg.blocks()
-            .iter()
-            .flat_map(|b| b.insts.iter())
-            .filter(|v| matches!(cfg.get_inst(**v).data, CfgInstData::Call { .. }))
-            .count()
-    }
-
     #[test]
     fn test_simple_return() {
         let cfg = build_cfg("fn main() -> i32 { 42 }");
@@ -3335,12 +3326,13 @@ mod tests {
     }
 
     #[test]
-    fn test_partial_field_move_still_calls_struct_destructor() {
-        // RUE-62: the struct's OWN destructor still runs for a partially
-        // moved struct — emitted as a plain call (without the field glue).
-        // main contains exactly two calls: eat(o.a) and O.__drop(o); and
-        // zero Drops (field a moved out, field b is a trivially-droppable
-        // i32, and field-granular dropping replaces the whole-struct Drop).
+    fn test_partial_field_move_out_of_destructor_type_rejected_in_sema() {
+        // RUE-158 supersedes the RUE-62 scenario this test used to pin
+        // (destructor-only call O.__drop(o) for a partially moved struct
+        // with its own `drop fn`): sema now rejects moving a field out of
+        // a value whose type has a user-defined destructor (E0456), so
+        // that elaboration shape is unreachable from legal source. This
+        // pins the rejection so the CFG-level assumption stays valid.
         let source = "struct A { x: i32 }\n\
              struct O { a: A, b: i32 }\n\
              drop fn A(self) { }\n\
@@ -3351,14 +3343,20 @@ mod tests {
                  eat(o.a);\n\
                  0\n\
              }";
-        let main_cfg = build_cfg_named(source, "main");
-        assert_eq!(count_drops(&main_cfg), 0, "no whole-struct or field Drop");
-        assert_eq!(
-            count_calls(&main_cfg),
-            2,
-            "eat(o.a) plus the destructor-only call O.__drop(o)"
+        let lexer = Lexer::new(source);
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        let parser = Parser::new(tokens, interner);
+        let (ast, mut interner) = parser.parse().unwrap();
+        let astgen = AstGen::new(&ast, &mut interner);
+        let rir = astgen.generate();
+        let sema = Sema::new(&rir, &mut interner, PreviewFeatures::new());
+        let err = sema
+            .analyze_all()
+            .expect_err("field move out of a destructor-having struct must be rejected");
+        assert!(
+            format!("{err}").contains("cannot move field"),
+            "unexpected error: {err}"
         );
-        assert_all_blocks_terminated(&main_cfg);
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/copy_destructor.toml
+++ b/crates/rue-cli-tests/cases/copy_destructor.toml
@@ -1,0 +1,74 @@
+# A `@copy` type cannot have a user-defined destructor (RUE-159, the spirit
+# of Rust's E0184).
+#
+# Copies of a `@copy` value are implicit and untracked, so each copy would
+# run the destructor again — double cleanup of the same logical resource.
+# Before the fix, `@copy struct P` + `drop fn P` compiled and ran the
+# destructor once per copy (the repro printed the field twice).
+#
+# The linear+@copy conflict is already rejected (E0407); this mirrors it for
+# destructors. The diagnostic points at both the `@copy` attribute and the
+# `drop fn`.
+
+[section]
+id = "cli.copy_destructor"
+name = "@copy types cannot have destructors"
+description = "Declaring a `drop fn` for a `@copy` struct is rejected at compile time (RUE-159)."
+
+[[case]]
+name = "copy_struct_with_destructor_rejected"
+description = "RUE-159 original repro: `@copy struct P` + `drop fn P` used to compile and run the destructor once per copy (printed 5 twice)."
+files = [{ path = "main.rue", source = """
+@copy
+struct P { x: i32 }
+
+drop fn P(self) {
+    @dbg(self.x);
+}
+
+fn main() -> i32 {
+    let p = P { x: 5 };
+    let _q = p;
+    @dbg(100);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0457", "cannot define a destructor for 'P'", "@copy"]
+
+[[case]]
+name = "drop_fn_before_copy_struct_decl_rejected"
+description = "Declaration order does not matter: a `drop fn` appearing before the `@copy` struct declaration is rejected the same way."
+files = [{ path = "main.rue", source = """
+drop fn P(self) {
+    @dbg(self.x);
+}
+
+@copy
+struct P { x: i32 }
+
+fn main() -> i32 {
+    let _p = P { x: 5 };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0457", "cannot define a destructor for 'P'"]
+
+[[case]]
+name = "copy_struct_without_destructor_copies_freely"
+description = "Control: a `@copy` struct without a destructor is duplicated implicitly with no drops at all."
+files = [{ path = "main.rue", source = """
+@copy
+struct P { x: i32 }
+
+fn main() -> i32 {
+    let p = P { x: 5 };
+    let q = p;
+    @dbg(p.x);
+    @dbg(q.x);
+    0
+}
+""" }]
+stdout = "5\n5\n"
+exit_code = 0

--- a/crates/rue-cli-tests/cases/destructor_field_move.toml
+++ b/crates/rue-cli-tests/cases/destructor_field_move.toml
@@ -1,0 +1,176 @@
+# Moving a field out of a value whose type has a user-defined destructor is
+# a compile error (RUE-158, the spirit of Rust's E0509).
+#
+# The destructor always runs on the WHOLE value when it is dropped: it would
+# observe the moved-out field (a use-after-free for heap fields), and the
+# automatic field cleanup after the destructor would drop the field a second
+# time. Before the fix, `drop fn Outer(self) { take(self.f) }` printed the
+# field's destructor output twice (the field glue re-dropped the moved
+# field), and moving a field out of a dtor-having local let the destructor
+# read the moved-out field at scope exit.
+#
+# Whole-value moves and `borrow`/`inout` access of fields (RUE-143) remain
+# legal, as do field moves out of structs WITHOUT their own destructor even
+# when the field's type has one (the RUE-62 shape, see drop_moves.toml).
+
+[section]
+id = "cli.destructor_field_move"
+name = "Cannot move a field out of a value with a destructor"
+description = "Field moves out of destructor-having values are rejected at compile time (RUE-158)."
+
+[[case]]
+name = "destructor_moves_own_field_rejected"
+description = "RUE-158 facet 1: a destructor that moves a field out of `self` is rejected (the automatic field glue would re-drop the moved field; this printed 7, 7, 7 before the fix)."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Outer { f: Inner }
+
+fn take(i: Inner) -> i32 {
+    i.v
+}
+
+drop fn Outer(self) {
+    @dbg(take(self.f));
+}
+
+fn main() -> i32 {
+    let _o = Outer { f: Inner { v: 7 } };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0456", "cannot move field `f` out of a value of type 'Outer'"]
+
+[[case]]
+name = "field_move_out_of_destructor_type_rejected"
+description = "RUE-158 facet 2: moving a field out of any value whose type has a `drop fn` is rejected (the destructor would observe the moved-out field at scope exit; this printed 800, 7, 100, 7 before the fix)."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Outer { f: Inner }
+
+drop fn Outer(self) {
+    @dbg(self.f.v);
+}
+
+fn eat(i: Inner) -> i32 {
+    @dbg(800);
+    0
+}
+
+fn main() -> i32 {
+    let o = Outer { f: Inner { v: 7 } };
+    eat(o.f);
+    @dbg(100);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0456", "cannot move field `f` out of a value of type 'Outer'", "destructor"]
+
+[[case]]
+name = "deep_field_move_through_destructor_type_rejected"
+description = "A deep move (`t.a.b`) is rejected when ANY enclosing value's type has a destructor — here the intermediate Mid, even though the root Top has none."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Mid { b: Inner }
+
+drop fn Mid(self) {
+    @dbg(800);
+}
+
+struct Top { a: Mid }
+
+fn eat(i: Inner) -> i32 {
+    i.v
+}
+
+fn main() -> i32 {
+    let t = Top { a: Mid { b: Inner { v: 7 } } };
+    eat(t.a.b);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0456", "cannot move field `b` out of a value of type 'Mid'"]
+
+[[case]]
+name = "borrow_and_inout_field_of_destructor_type_stay_legal"
+description = "Control: borrow/inout access to a field of a destructor-having value is not a move and stays legal; the whole value still drops exactly once, in order."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Outer { f: Inner }
+
+drop fn Outer(self) {
+    @dbg(800);
+}
+
+fn peek(borrow i: Inner) -> i32 {
+    i.v
+}
+
+fn bump(inout i: Inner) -> i32 {
+    i.v = i.v + 1;
+    0
+}
+
+fn main() -> i32 {
+    let mut o = Outer { f: Inner { v: 7 } };
+    @dbg(peek(borrow o.f));
+    bump(inout o.f);
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "7\n100\n800\n8\n"
+exit_code = 0
+
+[[case]]
+name = "whole_value_move_of_destructor_type_stays_legal"
+description = "Control: moving the WHOLE value (not a field) of a destructor-having type stays legal; the destructor runs once, at the destination."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Outer { f: Inner }
+
+drop fn Outer(self) {
+    @dbg(800);
+}
+
+fn eat(o: Outer) -> i32 {
+    @dbg(900);
+    0
+}
+
+fn main() -> i32 {
+    let o = Outer { f: Inner { v: 7 } };
+    eat(o);
+    @dbg(100);
+    0
+}
+""" }]
+stdout = "900\n800\n7\n100\n"
+exit_code = 0

--- a/crates/rue-cli-tests/cases/drop_moves.toml
+++ b/crates/rue-cli-tests/cases/drop_moves.toml
@@ -13,8 +13,11 @@
 #
 # Partial (per-field) moves are field-granular (RUE-62): moving one field out
 # of a struct (`eat(o.a)`) suppresses ONLY that field's drop at the struct's
-# scope exit — the struct's own destructor still runs, and the remaining
-# droppable fields are dropped individually in declaration order.
+# scope exit, and the remaining droppable fields are dropped individually in
+# declaration order. This only applies to structs WITHOUT their own `drop fn`:
+# moving a field out of a value whose type has a user-defined destructor is a
+# compile error (E0456, RUE-158) — the destructor would observe the moved-out
+# field and the field glue would drop it a second time.
 #
 # Branch-divergent moves are handled with runtime drop flags (RUE-108 for
 # whole slots, RUE-156 for individual field paths): a value moved in only
@@ -263,8 +266,8 @@ stdout = "100\n7\n"
 exit_code = 0
 
 [[case]]
-name = "partial_field_move_suppresses_field_drop"
-description = "RUE-62: moving o.a into a call suppresses field a's drop inside o's scope-exit drop (o's own destructor still runs)."
+name = "partial_field_move_out_of_destructor_type_rejected"
+description = "RUE-158: moving o.a out of O is rejected because O has its own `drop fn` (which would observe the moved-out field). Before the fix this compiled and printed 1, 100, 800."
 files = [{ path = "main.rue", source = """
 struct A { x: i32 }
 struct O { a: A, b: i32 }
@@ -288,8 +291,8 @@ fn main() -> i32 {
     0
 }
 """ }]
-stdout = "1\n100\n800\n"
-exit_code = 0
+compile_fail = true
+error_contains = ["E0456", "cannot move field `a` out of a value of type 'O'"]
 
 [[case]]
 name = "partial_field_move_remaining_field_still_drops"
@@ -655,9 +658,14 @@ fn main() -> i32 {
 stdout = "777\n5\n6\n"
 exit_code = 0
 
+# This program exercised the field-granular exit walk for a dtor-having
+# intermediate struct (RUE-157) — a shape that E0456 (RUE-158, Rust's E0509
+# rule) now forbids outright: you cannot move a field out of a value whose
+# type has a destructor. The case is kept as a compile-fail pin of that rule
+# at depth >= 2.
 [[case]]
 name = "nested_destructor_runs_for_partially_moved_inner_struct"
-description = "RUE-157: an inner struct with its own destructor that lost a field still runs its destructor (without glue) during the field-granular exit walk, then its remaining field drops."
+description = "Moving a field out of a dtor-having intermediate struct is rejected with E0456 (formerly a runtime drop-order case, RUE-157 x RUE-158)."
 files = [{ path = "main.rue", source = """
 struct Leaf { v: i32 }
 struct Mid { leaf: Leaf, other: Leaf }
@@ -684,5 +692,5 @@ fn main() -> i32 {
     0
 }
 """ }]
-stdout = "5\n777\n100\n6\n"
-exit_code = 0
+compile_fail = true
+error_contains = ["E0456", "cannot move field `leaf` out of a value of type 'Mid'"]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -131,6 +131,9 @@ impl ErrorCode {
     // 439-441 are reserved by in-flight work; next free code is 444.
     pub const MOVE_SELF_OUT_OF_DESTRUCTOR: Self = Self(442);
     pub const LINEAR_VALUE_NOT_CONSUMED_ON_ALL_PATHS: Self = Self(443);
+    // 444-455 are reserved by in-flight work; next free code is 458.
+    pub const MOVE_FIELD_OUT_OF_DESTRUCTOR_TYPE: Self = Self(456);
+    pub const COPY_STRUCT_WITH_DESTRUCTOR: Self = Self(457);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -1014,6 +1017,25 @@ pub enum ErrorKind {
         "cannot move `self` out of the destructor for '{type_name}': the new owner would drop it again, re-entering this destructor"
     )]
     MoveSelfOutOfDestructor { type_name: String },
+    /// Cannot move a field out of a value whose struct type has a
+    /// user-defined destructor (RUE-158, the spirit of Rust's E0509).
+    /// The destructor always runs on the whole value when it is dropped:
+    /// it would observe the moved-out field (use-after-free for heap
+    /// fields), and the automatic field cleanup after the destructor would
+    /// drop the field a second time.
+    #[error(
+        "cannot move field `{field_name}` out of a value of type '{struct_name}', which has a destructor"
+    )]
+    MoveFieldOutOfDestructorType {
+        struct_name: String,
+        field_name: String,
+    },
+    /// A `@copy` struct cannot have a user-defined destructor (RUE-159, the
+    /// spirit of Rust's E0184). Copies are implicit and untracked, so each
+    /// copy would run the destructor again — double cleanup of the same
+    /// logical resource.
+    #[error("cannot define a destructor for '{type_name}': `@copy` types cannot have destructors")]
+    CopyStructWithDestructor { type_name: String },
 
     // Control flow errors
     #[error("'break' outside of loop")]
@@ -1195,6 +1217,10 @@ impl ErrorKind {
             ErrorKind::BorrowKeywordMissing => ErrorCode::BORROW_KEYWORD_MISSING,
             ErrorKind::MoveOutOfInout { .. } => ErrorCode::MOVE_OUT_OF_INOUT,
             ErrorKind::MoveSelfOutOfDestructor { .. } => ErrorCode::MOVE_SELF_OUT_OF_DESTRUCTOR,
+            ErrorKind::MoveFieldOutOfDestructorType { .. } => {
+                ErrorCode::MOVE_FIELD_OUT_OF_DESTRUCTOR_TYPE
+            }
+            ErrorKind::CopyStructWithDestructor { .. } => ErrorCode::COPY_STRUCT_WITH_DESTRUCTOR,
 
             // Control flow errors (E0500-E0599)
             ErrorKind::BreakOutsideLoop => ErrorCode::BREAK_OUTSIDE_LOOP,

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -950,3 +950,135 @@ fn main() -> i32 {
 """
 exit_code = 0
 expected_stdout = "88\n100\n"
+
+# =============================================================================
+# Destructor Legality Rules (RUE-158 / RUE-159)
+# =============================================================================
+
+[[case]]
+name = "copy_struct_with_destructor_rejected"
+spec = ["3.9:31"]
+description = "A @copy type cannot have a user-defined destructor (E0457): implicit copies would each run the destructor again"
+source = """
+@copy
+struct P { x: i32 }
+
+drop fn P(self) {
+    @dbg(self.x);
+}
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "`@copy` types cannot have destructors"
+
+[[case]]
+name = "destructor_moves_self_rejected"
+spec = ["3.9:33"]
+description = "Moving `self` out of a destructor body is rejected (E0442): the new owner's drop would re-enter the destructor"
+source = """
+struct D { v: i32 }
+
+fn consume(d: D) -> i32 {
+    d.v
+}
+
+drop fn D(self) {
+    consume(self);
+}
+
+fn main() -> i32 {
+    let _d = D { v: 7 };
+    0
+}
+"""
+compile_fail = true
+error_contains = "cannot move `self` out of the destructor"
+
+[[case]]
+name = "field_move_out_of_destructor_type_rejected"
+spec = ["3.9:34"]
+description = "Moving a field out of a value whose type has a user-defined destructor is rejected (E0456): the destructor would observe the moved-out field"
+source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Outer { f: Inner }
+
+drop fn Outer(self) {
+    @dbg(self.f.v);
+}
+
+fn eat(i: Inner) -> i32 {
+    i.v
+}
+
+fn main() -> i32 {
+    let o = Outer { f: Inner { v: 7 } };
+    eat(o.f)
+}
+"""
+compile_fail = true
+error_contains = "cannot move field `f` out of a value of type 'Outer'"
+
+[[case]]
+name = "destructor_moves_own_field_rejected"
+spec = ["3.9:34"]
+description = "The same rule applies to `self` inside the type's own destructor: a destructor cannot move a field out of `self`"
+source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Outer { f: Inner }
+
+fn take(i: Inner) -> i32 {
+    i.v
+}
+
+drop fn Outer(self) {
+    @dbg(take(self.f));
+}
+
+fn main() -> i32 {
+    let _o = Outer { f: Inner { v: 7 } };
+    0
+}
+"""
+compile_fail = true
+error_contains = "cannot move field `f` out of a value of type 'Outer'"
+
+[[case]]
+name = "borrow_field_of_destructor_type_stays_legal"
+spec = ["3.9:34"]
+description = "Borrowing a field of a destructor-having value is not a move and stays legal; the value still drops exactly once"
+source = """
+struct Inner { v: i32 }
+
+drop fn Inner(self) {
+    @dbg(self.v);
+}
+
+struct Outer { f: Inner }
+
+drop fn Outer(self) {
+    @dbg(800);
+}
+
+fn peek(borrow i: Inner) -> i32 {
+    i.v
+}
+
+fn main() -> i32 {
+    let o = Outer { f: Inner { v: 7 } };
+    @dbg(peek(borrow o.f));
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "7\n800\n7\n"

--- a/docs/spec/src/03-types/09-destructors.md
+++ b/docs/spec/src/03-types/09-destructors.md
@@ -204,3 +204,42 @@ drop fn FileHandle(self) {
 {{ rule(id="3.9:30", cat="informative") }}
 
 The `drop fn` syntax was chosen because it clearly indicates the purpose of the function while being distinct from regular functions and methods. The destructor is not part of any impl block because it has special calling semantics: it is invoked automatically by the compiler when values go out of scope.
+
+{{ rule(id="3.9:31", cat="legality-rule") }}
+
+A type declared `@copy` **MUST NOT** have a user-defined destructor. A compile-time error is raised if a `drop fn` is declared for a `@copy` type.
+
+{{ rule(id="3.9:32", cat="informative") }}
+
+Copies of a `@copy` value are implicit and untracked, so each copy would run the destructor again — cleaning up the same logical resource multiple times. This mirrors Rust, where a type cannot implement both `Copy` and `Drop`.
+
+{{ rule(id="3.9:33", cat="legality-rule") }}
+
+Within a user-defined destructor, `self` **MUST NOT** be moved out (to a call argument, a new binding, a by-value method receiver, or any other new owner). A compile-time error is raised if the destructor body moves `self`. The new owner would drop the value again at its own scope exit, re-entering the destructor.
+
+{{ rule(id="3.9:34", cat="legality-rule") }}
+
+A field **MUST NOT** be moved out of a value whose type has a user-defined destructor. This applies to every enclosing value along a field path (moving `t.a.b` moves out of both `t` and `t.a`), and includes `self` within the type's own destructor. A compile-time error is raised for such a move. Borrowing such a field (`borrow` or `inout`) is permitted, as is moving the whole value.
+
+{{ rule(id="3.9:35", cat="informative") }}
+
+The destructor always runs on the whole value when it is dropped: it would observe the moved-out field, and the automatic field cleanup that follows the destructor would drop the moved field a second time. Moving a field out of a struct *without* a user-defined destructor remains legal even when the field's own type has one — the field's drop at the struct's scope exit is simply suppressed.
+
+{{ rule(id="3.9:36", cat="example") }}
+
+```rue
+struct Inner { v: i32 }
+
+drop fn Inner(self) { @dbg(self.v); }
+
+struct Outer { f: Inner }
+
+drop fn Outer(self) { @dbg(self.f.v); }
+
+fn eat(i: Inner) -> i32 { i.v }
+
+fn main() -> i32 {
+    let o = Outer { f: Inner { v: 7 } };
+    eat(o.f)  // ERROR: cannot move field `f` out of a value of type 'Outer'
+}
+```


### PR DESCRIPTION
Two compile-time legality rules closing destructor soundness holes from the drops-destructors hunt.

**RUE-158 — adopt Rust's E0509 rule (new E0456).** Moving a non-Copy field out of a value is rejected iff **any enclosing container along the projection chain** has a user-defined destructor. Previously: the automatic field glue re-dropped a field moved out inside the dtor body (`drop fn Outer(self) { take(self.f) }` printed `7,7,7` — double-free with heap fields), and a destructor observing a moved-out field was reachable in safe code. Borrow/inout of fields (RUE-143), whole-value moves, and the RUE-62 shape — dtor on the *field's* type, not the container — remain legal (verified: all RUE-62 cases pass unchanged, and the shape executes correctly post-change). Self-in-dtor field moves report the same E0456; E0442 stays for whole-`self` moves. The diagnostic names the struct and field and labels the `drop fn` (new `destructor_spans` map).

**RUE-159 — @copy types cannot define destructors (new E0457, Rust's E0184 analog).** Previously each implicit copy ran its own destructor — N+1 releases of one logical value. Order-independent check in `collect_destructor`; the diagnostic labels both the `@copy` attribute and the `drop fn`.

Spec rules 3.9:31–36 added (including the previously-unwritten E0442 rule) with spec-test coverage; new CLI suites `destructor_field_move.toml` + `copy_destructor.toml` with exact-stdout controls. One pre-existing `drop_moves.toml` case front-ended the exact program E0456 now forbids — converted to a compile-fail pin.

Verified post-integration: E0456 and E0457 fire with the right wording; the dtor-on-field-type-only program still compiles and drops `1,2`. Full ./test.sh green.

Fixes RUE-158
Fixes RUE-159

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Rebase note (post-#967/#968):** append-append conflict in `destructors.toml` resolved keeping both case sets. One #967 case (`nested_destructor_runs_for_partially_moved_inner_struct`) front-ended a program E0456 now forbids — moving a field out of a dtor-having intermediate struct at depth 2 — and is converted to a compile-fail pin of the rule. Full ./test.sh re-run green on the rebased stack.