### PR TITLE
Module privacy: unqualified calls to private functions of imported modules are rejected (E0460)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,7 +134,7 @@ graph LR
 Rue supports compiling multiple source files into a single executable:
 
 ```bash
-# All files share a flat global namespace (no modules yet)
+# Explicitly listed files share a flat global namespace (transitional, spec 10.5:2)
 rue main.rue utils.rue lib.rue -o program
 ```
 
@@ -144,11 +144,17 @@ rue main.rue utils.rue lib.rue -o program
 - `main()` must exist in exactly one file
 - Files are parsed in parallel, then merged for semantic analysis
 
-**Current limitations (will be addressed by the module system):**
-- No visibility control (`pub`/private)
-- No namespacing - all symbols share global scope
-- No `mod` or `use` syntax
-- Must list all files explicitly on command line
+**Module interaction:** files loaded via `@import` (the module system, spec
+chapter 10) get directory-based privacy enforcement — private items of an
+imported file are rejected from other directories whether accessed through
+the module object (E0706) or unqualified (E0460). Files that are only
+listed explicitly and never imported keep the flat namespace above.
+
+**Current limitations (transitional, see spec 10.5:2):**
+- Top-level names are not yet module-scoped — all symbols share one global
+  scope, so names collide program-wide and `pub` items remain callable
+  unqualified across files
+- No `mod` or `use` syntax (`@import` + `pub const` re-exports instead)
 
 ### Key Design Decisions
 

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3236,6 +3236,17 @@ impl<'a> Sema<'a> {
             .get(&name)
             .ok_or_compile_error(ErrorKind::UndefinedFunction(fn_name_str.clone()), span)?;
 
+        // Visibility: an unqualified call must not reach a private function
+        // in a module's file from outside that module's directory (E0460,
+        // RUE-37) — otherwise dropping the `module.` qualifier would bypass
+        // the E0706 privacy check on `module.f()`.
+        self.check_unqualified_call_visibility(
+            &fn_name_str,
+            fn_info.file_id,
+            fn_info.is_pub,
+            span,
+        )?;
+
         // Track this function as referenced (for lazy analysis)
         ctx.referenced_functions.insert(name);
 

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -55,6 +55,59 @@ impl Sema<'_> {
         }
     }
 
+    /// Check that an *unqualified* call may reach the callee (RUE-37).
+    ///
+    /// All loaded files share one flat global function namespace (spec
+    /// 10.5:2, transitional), so a plain `secret()` call would otherwise
+    /// resolve a private function from any file — bypassing the E0706 check
+    /// that qualified `module.secret()` access gets. The rule (spec 10.3:7):
+    ///
+    /// - If the callee is accessible per [`Sema::is_accessible`] (it is
+    ///   `pub`, or the caller is in the callee's directory), the call is fine.
+    /// - Otherwise, if the callee's file was loaded *as a module* (it is the
+    ///   target of a resolved `@import` in the program), the call is an error
+    ///   (E0460): module privacy must not be escapable by dropping the
+    ///   qualifier.
+    /// - Files that are never imported (only listed explicitly on the
+    ///   command line) keep the flat namespace: no error.
+    ///
+    /// Module-ness is read from the module registry, which is populated for
+    /// top-level `const m = @import(...)` bindings during Phase 2.5, before
+    /// any function body is analyzed. (A file imported *only* by a
+    /// function-local `let m = @import(...)` is registered when that body is
+    /// analyzed, so calls analyzed earlier may not yet see it as a module —
+    /// an accepted gap of the transitional flat namespace.)
+    pub(crate) fn check_unqualified_call_visibility(
+        &self,
+        fn_name: &str,
+        callee_file_id: FileId,
+        is_pub: bool,
+        span: rue_span::Span,
+    ) -> CompileResult<()> {
+        if self.is_accessible(span.file_id, callee_file_id, is_pub) {
+            return Ok(());
+        }
+
+        // Inaccessible — but only enforce if the callee's file is a module.
+        let Some(callee_path) = self.get_file_path(callee_file_id) else {
+            return Ok(());
+        };
+        let Some(import_path) = self.module_registry.import_path_for_file(callee_path) else {
+            return Ok(());
+        };
+
+        Err(CompileError::new(
+            ErrorKind::PrivateUnqualifiedAccess {
+                name: fn_name.to_string(),
+                module_path: import_path,
+            },
+            span,
+        )
+        .with_help(format!(
+            "`{fn_name}` is not marked `pub`; private items are only visible within their own directory"
+        )))
+    }
+
     /// Resolve an enum type through a module reference.
     ///
     /// Used for qualified enum paths like `module.EnumName::Variant` in match patterns.

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -70,6 +70,23 @@ impl ModuleRegistry {
         (id, true)
     }
 
+    /// Find the import path of a module whose resolved file path equals
+    /// `file_path`, if any.
+    ///
+    /// Used to decide whether a source file is "loaded as a module" (the
+    /// target of a resolved `@import`) — such files get directory-privacy
+    /// enforcement even for unqualified references (RUE-37), while files that
+    /// are only listed explicitly on the command line keep the transitional
+    /// flat namespace (spec 10.5:2).
+    pub fn import_path_for_file(&self, file_path: &str) -> Option<String> {
+        self.defs
+            .read()
+            .unwrap_or_else(PoisonError::into_inner)
+            .iter()
+            .find(|def| def.file_path == file_path)
+            .map(|def| def.import_path.clone())
+    }
+
     /// Get a module definition by ID.
     pub fn get_def(&self, id: ModuleId) -> ModuleDef {
         self.defs

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -375,3 +375,130 @@ pub fn abs(x: i32) -> i32 {
 ]
 compile_fail = true
 error_contains = ["E0707", "has no member `abs`"]
+
+# ---------------------------------------------------------------------------
+# Module privacy (RUE-114 + RUE-37).
+#
+# Visibility boundaries are DIRECTORIES (ADR-0026, spec 10.3): a private item
+# is reachable from files in the same directory — including through a module
+# object — and rejected from any other directory, whether the call is
+# qualified (E0706) or unqualified (E0460). Files that are never imported
+# keep the transitional flat namespace (spec 10.3:8 / 10.5:2).
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "private_fn_cross_dir_qualified_rejected"
+description = "Qualified access to a private function of a module in another directory is E0706 (RUE-114)."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    lib.secret()
+}
+""" },
+    { path = "sub/lib.rue", source = """
+fn secret() -> i32 {
+    99
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0706", "function `secret` is private"]
+
+[[case]]
+name = "private_fn_cross_dir_unqualified_rejected"
+description = "Dropping the module qualifier must not bypass privacy: unqualified call to the same private function is E0460 (RUE-37)."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    secret()
+}
+""" },
+    { path = "sub/lib.rue", source = """
+fn secret() -> i32 {
+    99
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "private to module `sub/lib.rue`"]
+
+[[case]]
+name = "private_fn_cross_dir_unqualified_rejected_when_also_listed"
+description = "Privacy is keyed on being imported, not on how the file was loaded: a file both listed on the CLI and imported is still a module (E0460)."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    secret()
+}
+""" },
+    { path = "sub/lib.rue", source = """
+fn secret() -> i32 {
+    99
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "private to module `sub/lib.rue`"]
+
+[[case]]
+name = "private_fn_same_dir_module_access_allowed"
+description = "Control: a private function IS reachable through a module from the same directory (intra-directory visibility, ADR-0026 / spec 10.3:2)."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("lib.rue");
+
+fn main() -> i32 {
+    lib.secret()
+}
+""" },
+    { path = "lib.rue", source = """
+fn secret() -> i32 {
+    99
+}
+""" },
+]
+exit_code = 99
+
+[[case]]
+name = "pub_fn_cross_dir_both_forms_allowed"
+description = "Control: a pub function in another directory is callable qualified and (transitionally) unqualified."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    lib.open() + open()
+}
+""" },
+    { path = "sub/lib.rue", source = """
+pub fn open() -> i32 {
+    7
+}
+""" },
+]
+exit_code = 14
+
+[[case]]
+name = "flat_multifile_private_fn_cross_dir_allowed"
+description = "A never-imported file listed explicitly keeps the flat namespace: cross-directory unqualified private call still works (spec 10.3:8)."
+args = ["main.rue", "sub/util.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    secret()
+}
+""" },
+    { path = "sub/util.rue", source = """
+fn secret() -> i32 {
+    42
+}
+""" },
+]
+exit_code = 42

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -134,6 +134,8 @@ impl ErrorCode {
     // 444-455 are reserved by in-flight work; next free code is 458.
     pub const MOVE_FIELD_OUT_OF_DESTRUCTOR_TYPE: Self = Self(456);
     pub const COPY_STRUCT_WITH_DESTRUCTOR: Self = Self(457);
+    // 458-459 are reserved by in-flight work.
+    pub const PRIVATE_UNQUALIFIED_ACCESS: Self = Self(460);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -1081,6 +1083,8 @@ pub enum ErrorKind {
     StdLibNotFound,
     #[error("{item_kind} `{name}` is private")]
     PrivateMemberAccess { item_kind: String, name: String },
+    #[error("function `{name}` is private to module `{module_path}`")]
+    PrivateUnqualifiedAccess { name: String, module_path: String },
     #[error("module `{module_name}` has no member `{member_name}`")]
     UnknownModuleMember {
         module_name: String,
@@ -1241,6 +1245,7 @@ impl ErrorKind {
             ErrorKind::AmbiguousModule { .. } => ErrorCode::AMBIGUOUS_MODULE,
             ErrorKind::StdLibNotFound => ErrorCode::STD_LIB_NOT_FOUND,
             ErrorKind::PrivateMemberAccess { .. } => ErrorCode::PRIVATE_MEMBER_ACCESS,
+            ErrorKind::PrivateUnqualifiedAccess { .. } => ErrorCode::PRIVATE_UNQUALIFIED_ACCESS,
             ErrorKind::UnknownModuleMember { .. } => ErrorCode::UNKNOWN_MODULE_MEMBER,
 
             // Literal/operator errors (E0800-E0899)

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -232,3 +232,83 @@ fn internal_format() -> i32 {
 """ }
 pass_aux_files = true
 exit_code = 42
+
+# =============================================================================
+# Unqualified Access to Module-Loaded Files (RUE-37)
+# =============================================================================
+# The flat global namespace (10.5:2) must not bypass module privacy: a
+# private function in an imported file in another directory is rejected even
+# when called WITHOUT the module qualifier (E0460). Files that are only
+# listed explicitly and never imported keep the flat namespace (10.3:8).
+
+[[case]]
+name = "cross_dir_unqualified_private_fn_error"
+spec = ["10.3:7"]
+description = "Unqualified call to a private function of an imported module in another directory is rejected"
+source = """
+const utils = @import("subdir/utils");
+
+fn main() -> i32 {
+    internal_fn()
+}
+"""
+aux_files = { "subdir/utils.rue" = """
+fn internal_fn() -> i32 {
+    42
+}
+""" }
+compile_fail = true
+error_contains = "private to module"
+
+[[case]]
+name = "cross_dir_unqualified_pub_fn_allowed"
+spec = ["10.3:7", "10.5:2"]
+description = "Unqualified call to a pub function of an imported module still resolves (transitional flat namespace)"
+source = """
+const utils = @import("subdir/utils");
+
+fn main() -> i32 {
+    public_fn()
+}
+"""
+aux_files = { "subdir/utils.rue" = """
+pub fn public_fn() -> i32 {
+    42
+}
+""" }
+exit_code = 42
+
+[[case]]
+name = "same_dir_unqualified_private_fn_allowed"
+spec = ["10.3:2", "10.3:7"]
+description = "Unqualified call to a private function of an imported file in the SAME directory is allowed (intra-directory visibility)"
+source = """
+const utils = @import("utils");
+
+fn main() -> i32 {
+    internal_fn()
+}
+"""
+aux_files = { "utils.rue" = """
+fn internal_fn() -> i32 {
+    42
+}
+""" }
+exit_code = 42
+
+[[case]]
+name = "flat_multifile_unqualified_private_fn_allowed"
+spec = ["10.3:8"]
+description = "A never-imported file listed explicitly keeps the flat namespace: cross-directory unqualified private call is allowed"
+source = """
+fn main() -> i32 {
+    internal_fn()
+}
+"""
+aux_files = { "subdir/utils.rue" = """
+fn internal_fn() -> i32 {
+    42
+}
+""" }
+pass_aux_files = true
+exit_code = 42

--- a/docs/spec/src/10-modules/03-visibility.md
+++ b/docs/spec/src/10-modules/03-visibility.md
@@ -56,3 +56,36 @@ fn main() -> i32 {
     //                          // private to the utils/ directory
 }
 ```
+
+{{ rule(id="10.3:7", cat="legality-rule") }}
+
+Privacy cannot be escaped by dropping the module qualifier. It is a
+compile-time error to call a private function of a *module-loaded* source
+file — a file that is the target of a resolved `@import` anywhere in the
+program — by its unqualified name from a source file in a different
+directory (error E0460).
+
+{{ rule(id="10.3:8") }}
+
+Source files that are only listed explicitly in the compilation and are
+never imported retain the transitional flat namespace (10.5:2): unqualified
+references to their items are permitted regardless of visibility. This
+exemption is expected to be removed together with rule 10.5:2 when
+top-level names become module-scoped.
+
+{{ rule(id="10.3:9", cat="example") }}
+
+```rue
+// sub/lib.rue
+fn secret() -> i32 { 99 }   // private to sub/
+pub fn open() -> i32 { 7 }
+
+// main.rue — a different directory
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    // lib.secret()          // error E0706: private member access
+    // secret()              // error E0460: same privacy, unqualified
+    open()                   // OK (transitional flat namespace, 10.5:2)
+}
+```


### PR DESCRIPTION
Closes the RUE-37 privacy bypass: privacy was enforced only at `module.member()` call sites (E0706), while a plain **unqualified** call to the same private function compiled and ran — the flat global namespace made `pub` decorative for cross-module calls.

**New rule** (the spec was silent; decision recorded as spec 10.3:7–9): privacy is enforced when the callee's file is the target of a resolved `@import` (module-ness detected via `ModuleRegistry::import_path_for_file`); explicit multi-file compilation with no imports keeps the documented flat namespace. Same-directory siblings of a facade remain mutually visible per ADR-0026. The check lives in a new `sema/visibility.rs` (`check_unqualified_call_visibility`), hooked at the single unqualified-call resolution site.

**Refutations pinned rather than fixed:** RUE-114's cross-directory repro was already fixed by the RUE-116 rework (pinned); its same-directory variant is intended ADR-0026 behavior, not a bug — recommending closure with a comment. RUE-37 part 2 (module objects resolving any global function) was fixed by RUE-140 (pinned).

4 new spec cases + 6 new CLI cases (E0460 both directions, E0706 pin, same-dir-allowed pin, flat-mode-unchanged pin). Verified post-integration: the unqualified private call errors `E0460: function \`secret\` is private to module \`libdir/util\``. Full ./test.sh green, traceability 100%.

Fixes RUE-37
Part of RUE-114 (pins; recommend closing — see PR discussion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)