### PR TITLE
Declared types are real: const annotations respected, let annotations validated, consts resolve in projection position

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1609,35 +1609,21 @@ impl<'a> ConstraintGenerator<'a> {
             return Some(InferType::Concrete(ptr_ty));
         }
 
-        // Check primitives
-        let ty = match name {
-            "i8" => Type::I8,
-            "i16" => Type::I16,
-            "i32" => Type::I32,
-            "i64" => Type::I64,
-            "u8" => Type::U8,
-            "u16" => Type::U16,
-            "u32" => Type::U32,
-            "u64" => Type::U64,
-            // Pointer-width integers (64-bit on all supported targets, RUE-151).
-            "usize" => Type::U64,
-            "isize" => Type::I64,
-            "bool" => Type::BOOL,
-            "()" => Type::UNIT,
-            _ => {
-                // Check for struct types (including builtin String)
-                if let Some(name_spur) = self.interner.get(name) {
-                    if let Some(&struct_ty) = self.structs.get(&name_spur) {
-                        return Some(InferType::Concrete(struct_ty));
-                    }
-                    if let Some(&enum_ty) = self.enums.get(&name_spur) {
-                        return Some(InferType::Concrete(enum_ty));
-                    }
-                }
-                return None;
+        // Check primitives (single shared table, RUE-155)
+        if let Some(ty) = Type::from_primitive_name(name) {
+            return Some(InferType::Concrete(ty));
+        }
+
+        // Check for struct types (including builtin String)
+        if let Some(name_spur) = self.interner.get(name) {
+            if let Some(&struct_ty) = self.structs.get(&name_spur) {
+                return Some(InferType::Concrete(struct_ty));
             }
-        };
-        Some(InferType::Concrete(ty))
+            if let Some(&enum_ty) = self.enums.get(&name_spur) {
+                return Some(InferType::Concrete(enum_ty));
+            }
+        }
+        None
     }
 }
 

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1869,10 +1869,15 @@ impl<'a> Sema<'a> {
 
             // Look up the variable in locals
             let name_str = self.interner.resolve(&*name);
-            let local = ctx.locals.get(name).ok_or_compile_error(
-                ErrorKind::UndefinedVariable(name_str.to_string()),
-                inst.span,
-            )?;
+            let Some(local) = ctx.locals.get(name) else {
+                // Not a param or local: fall back to the main VarRef path so
+                // file-level constants (and comptime vars/type names) resolve
+                // in projection positions too — e.g. `N == 1` routes its
+                // operands through here (RUE-165). Constants inline a fresh
+                // value, so there is no move state to preserve, and unknown
+                // names still get E0201 from the fallback.
+                return self.analyze_var_ref(air, *name, inst.span, ctx);
+            };
 
             let ty = local.ty;
             let slot = local.slot;

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1413,7 +1413,7 @@ impl<'a> Sema<'a> {
                 directives_len,
                 name,
                 is_mut,
-                ty: _,
+                ty,
                 init,
             } => self.analyze_alloc(
                 air,
@@ -1421,6 +1421,7 @@ impl<'a> Sema<'a> {
                 *directives_len,
                 *name,
                 *is_mut,
+                *ty,
                 *init,
                 inst.span,
                 ctx,
@@ -1454,10 +1455,25 @@ impl<'a> Sema<'a> {
         directives_len: u32,
         name: Option<Spur>,
         is_mut: bool,
+        ty: Option<Spur>,
         init: InstRef,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        // Validate the type annotation, if any. Inference treats an
+        // unresolvable annotation name as "no constraint" and silently falls
+        // back to the initializer's type, so `let x: zzz_bogus = 5;` used to
+        // compile (RUE-155). Resolve the name here so unknown annotations get
+        // the same E0204 as signature positions. Comptime type variables
+        // (e.g. `let P = Pair(i32); let p: P = ...`) and substituted type
+        // parameters live in ctx, not in the type tables, so accept those
+        // first.
+        if let Some(ty_sym) = ty {
+            if !ctx.comptime_type_vars.contains_key(&ty_sym) {
+                self.resolve_type(ty_sym, span)?;
+            }
+        }
+
         // Analyze the initializer
         let init_result = self.analyze_inst(air, init, ctx)?;
         let var_type = init_result.ty;
@@ -1551,7 +1567,7 @@ impl<'a> Sema<'a> {
     }
 
     /// Analyze a variable reference.
-    fn analyze_var_ref(
+    pub(crate) fn analyze_var_ref(
         &mut self,
         air: &mut Air,
         name: Spur,

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -269,22 +269,11 @@ impl Sema<'_> {
     /// Resolve a name to a type value (primitive type names, structs, enums).
     fn resolve_named_type_value(&self, name: &Spur) -> Option<Type> {
         let name_str = self.interner.resolve(name);
-        let ty = match name_str {
-            "i8" => Type::I8,
-            "i16" => Type::I16,
-            "i32" => Type::I32,
-            "i64" => Type::I64,
-            "u8" => Type::U8,
-            "u16" => Type::U16,
-            "u32" => Type::U32,
-            "u64" => Type::U64,
-            // Pointer-width integers (64-bit on all supported targets, RUE-151).
-            "usize" => Type::U64,
-            "isize" => Type::I64,
-            "bool" => Type::BOOL,
-            "()" => Type::UNIT,
-            "!" => Type::NEVER,
-            _ => {
+        // Primitive names come from the single shared table (RUE-155) so the
+        // evaluator can never drift from the resolver.
+        let ty = match Type::from_primitive_name(name_str) {
+            Some(t) => t,
+            None => {
                 if let Some(&struct_id) = self.structs.get(name) {
                     Type::new_struct(struct_id)
                 } else if let Some(&enum_id) = self.enums.get(name) {

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -477,9 +477,13 @@ impl<'a> Sema<'a> {
                 }
 
                 InstData::ConstDecl {
-                    is_pub, name, init, ..
+                    is_pub,
+                    name,
+                    ty,
+                    init,
+                    ..
                 } => {
-                    self.collect_const_declaration(*name, *is_pub, *init, inst.span)?;
+                    self.collect_const_declaration(*name, *is_pub, *ty, *init, inst.span)?;
                 }
 
                 _ => {}
@@ -983,6 +987,7 @@ impl<'a> Sema<'a> {
         &mut self,
         name: Spur,
         is_pub: bool,
+        ty: Option<Spur>,
         init: InstRef,
         span: Span,
     ) -> CompileResult<()> {
@@ -1029,10 +1034,26 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        // Evaluate the initializer at compile time to determine the constant type.
-        // Currently we only handle @import(...) - other constant expressions will
-        // be supported as part of the broader comptime feature (ADR-0025).
-        let const_type = self.evaluate_const_init(init, span)?;
+        // Evaluate the initializer at compile time to determine the constant's
+        // natural type (this also performs @import resolution side effects).
+        // Currently we only handle @import(...) and literals - other constant
+        // expressions will be supported as part of the broader comptime
+        // feature (ADR-0025).
+        let inferred_type = self.evaluate_const_init(init, span)?;
+
+        // An explicit annotation overrides the literal's default type:
+        // `const BIG: i64 = 5000000000;` must store an i64, not a silently
+        // truncated i32 (RUE-161). The annotation resolves like any signature
+        // type (unknown names are E0204) and the initializer is validated
+        // against it.
+        let const_type = match ty {
+            Some(ty_sym) => {
+                let declared = self.resolve_type(ty_sym, span)?;
+                self.check_const_init_matches_annotation(declared, inferred_type, init, span)?;
+                declared
+            }
+            None => inferred_type,
+        };
 
         let info = ConstInfo {
             is_pub,
@@ -1118,9 +1139,10 @@ impl<'a> Sema<'a> {
                 }
             }
 
-            // Integer literals evaluate to i32 (the default integer type)
-            // Note: RIR doesn't distinguish between integer types at this level;
-            // type inference happens later. For now, we treat all integer consts as i32.
+            // Integer literals evaluate to i32 (the default integer type).
+            // Note: RIR doesn't distinguish between integer types at this level.
+            // An explicit annotation (`const BIG: i64 = ...`) overrides this
+            // default in collect_const_declaration (RUE-161).
             InstData::IntConst(_) => Ok(Type::I32),
 
             // Boolean literals
@@ -1149,5 +1171,48 @@ impl<'a> Sema<'a> {
                 span,
             )),
         }
+    }
+
+    /// Validate a constant initializer against the declared (annotated) type.
+    ///
+    /// Integer literals are range-checked against the declared integer type
+    /// (E0800), mirroring how annotated `let` literals are checked. Any other
+    /// initializer must match the annotation exactly (E0206).
+    fn check_const_init_matches_annotation(
+        &self,
+        declared: Type,
+        inferred: Type,
+        init: InstRef,
+        span: Span,
+    ) -> CompileResult<()> {
+        let init_inst = self.rir.get(init);
+
+        // An integer literal adopts any integer annotation it fits in.
+        if let InstData::IntConst(value) = &init_inst.data {
+            if declared.is_integer() {
+                if !declared.literal_fits(*value) {
+                    return Err(CompileError::new(
+                        ErrorKind::LiteralOutOfRange {
+                            value: *value,
+                            ty: declared.safe_name_with_pool(Some(&self.type_pool)),
+                        },
+                        init_inst.span,
+                    ));
+                }
+                return Ok(());
+            }
+        }
+
+        if declared == inferred {
+            return Ok(());
+        }
+
+        Err(CompileError::new(
+            ErrorKind::TypeMismatch {
+                expected: declared.safe_name_with_pool(Some(&self.type_pool)),
+                found: inferred.safe_name_with_pool(Some(&self.type_pool)),
+            },
+            span,
+        ))
     }
 }

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -136,27 +136,10 @@ impl<'a> Sema<'a> {
     pub(crate) fn resolve_type(&mut self, type_sym: Spur, span: Span) -> CompileResult<Type> {
         let type_name = self.interner.resolve(&type_sym);
 
-        // Check primitive types first.
+        // Check primitive types first (single shared table, RUE-155).
         // Note: String is handled below via struct lookup (it's a builtin struct).
-        match type_name {
-            "i8" => return Ok(Type::I8),
-            "i16" => return Ok(Type::I16),
-            "i32" => return Ok(Type::I32),
-            "i64" => return Ok(Type::I64),
-            "u8" => return Ok(Type::U8),
-            "u16" => return Ok(Type::U16),
-            "u32" => return Ok(Type::U32),
-            "u64" => return Ok(Type::U64),
-            // Pointer-width integers. All supported targets are 64-bit, so
-            // these resolve to the 64-bit types (RUE-151).
-            "usize" => return Ok(Type::U64),
-            "isize" => return Ok(Type::I64),
-            "bool" => return Ok(Type::BOOL),
-            "()" => return Ok(Type::UNIT),
-            "!" => return Ok(Type::NEVER),
-            // The type of types - used for comptime type parameters
-            "type" => return Ok(Type::COMPTIME_TYPE),
-            _ => {}
+        if let Some(ty) = Type::from_primitive_name(type_name) {
+            return Ok(ty);
         }
 
         if let Some(&struct_id) = self.structs.get(&type_sym) {
@@ -218,24 +201,9 @@ impl<'a> Sema<'a> {
 
         let type_name = self.interner.resolve(&type_sym);
 
-        // Check primitive types first
-        match type_name {
-            "i8" => return Some(Type::I8),
-            "i16" => return Some(Type::I16),
-            "i32" => return Some(Type::I32),
-            "i64" => return Some(Type::I64),
-            "u8" => return Some(Type::U8),
-            "u16" => return Some(Type::U16),
-            "u32" => return Some(Type::U32),
-            "u64" => return Some(Type::U64),
-            // Pointer-width integers (64-bit on all supported targets, RUE-151).
-            "usize" => return Some(Type::U64),
-            "isize" => return Some(Type::I64),
-            "bool" => return Some(Type::BOOL),
-            "()" => return Some(Type::UNIT),
-            "!" => return Some(Type::NEVER),
-            "type" => return Some(Type::COMPTIME_TYPE),
-            _ => {}
+        // Check primitive types first (single shared table, RUE-155)
+        if let Some(ty) = Type::from_primitive_name(type_name) {
+            return Some(ty);
         }
 
         if let Some(&struct_id) = self.structs.get(&type_sym) {

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -624,6 +624,41 @@ impl Type {
         }
     }
 
+    /// Resolve a primitive type name to its `Type`.
+    ///
+    /// This is the **single source of truth** for the primitive-name table.
+    /// Every type-name resolution path (signature resolution, let-annotation
+    /// validation, HM inference, comptime/const evaluation) must consult this
+    /// function instead of keeping its own `match` — there used to be seven
+    /// duplicated copies, which is how `usize`/`isize` ended up accepted in
+    /// some positions and rejected in others (RUE-151, RUE-155).
+    ///
+    /// Returns `None` for non-primitive names (struct/enum names, array and
+    /// pointer syntax), which callers resolve against their own tables.
+    #[must_use]
+    pub fn from_primitive_name(name: &str) -> Option<Type> {
+        Some(match name {
+            "i8" => Type::I8,
+            "i16" => Type::I16,
+            "i32" => Type::I32,
+            "i64" => Type::I64,
+            "u8" => Type::U8,
+            "u16" => Type::U16,
+            "u32" => Type::U32,
+            "u64" => Type::U64,
+            // Pointer-width integers. All supported targets are 64-bit, so
+            // these resolve to the 64-bit types (RUE-151).
+            "usize" => Type::U64,
+            "isize" => Type::I64,
+            "bool" => Type::BOOL,
+            "()" => Type::UNIT,
+            "!" => Type::NEVER,
+            // The type of types - used for comptime type parameters
+            "type" => Type::COMPTIME_TYPE,
+            _ => return None,
+        })
+    }
+
     /// Check if this type is an integer type.
     /// Optimized: checks tag range directly (0-7 are integer types).
     #[inline]
@@ -1287,6 +1322,37 @@ mod tests {
         // Struct and Array are move types (String is a builtin struct now)
         assert!(!Type::new_struct(StructId(0)).is_copy());
         assert!(!Type::new_array(ArrayTypeId(0)).is_copy());
+    }
+
+    // ========== Type::from_primitive_name() tests ==========
+
+    #[test]
+    fn test_from_primitive_name_all_primitives() {
+        assert_eq!(Type::from_primitive_name("i8"), Some(Type::I8));
+        assert_eq!(Type::from_primitive_name("i16"), Some(Type::I16));
+        assert_eq!(Type::from_primitive_name("i32"), Some(Type::I32));
+        assert_eq!(Type::from_primitive_name("i64"), Some(Type::I64));
+        assert_eq!(Type::from_primitive_name("u8"), Some(Type::U8));
+        assert_eq!(Type::from_primitive_name("u16"), Some(Type::U16));
+        assert_eq!(Type::from_primitive_name("u32"), Some(Type::U32));
+        assert_eq!(Type::from_primitive_name("u64"), Some(Type::U64));
+        // Pointer-width names alias the 64-bit types (RUE-151).
+        assert_eq!(Type::from_primitive_name("usize"), Some(Type::U64));
+        assert_eq!(Type::from_primitive_name("isize"), Some(Type::I64));
+        assert_eq!(Type::from_primitive_name("bool"), Some(Type::BOOL));
+        assert_eq!(Type::from_primitive_name("()"), Some(Type::UNIT));
+        assert_eq!(Type::from_primitive_name("!"), Some(Type::NEVER));
+        assert_eq!(Type::from_primitive_name("type"), Some(Type::COMPTIME_TYPE));
+    }
+
+    #[test]
+    fn test_from_primitive_name_non_primitives() {
+        // Struct/enum names, array and pointer syntax are resolved by callers.
+        assert_eq!(Type::from_primitive_name("String"), None);
+        assert_eq!(Type::from_primitive_name("zzz_bogus"), None);
+        assert_eq!(Type::from_primitive_name("[i32; 3]"), None);
+        assert_eq!(Type::from_primitive_name("ptr const i32"), None);
+        assert_eq!(Type::from_primitive_name(""), None);
     }
 
     // ========== Type::can_coerce_to() tests ==========

--- a/crates/rue-cli-tests/cases/decl_annotations.toml
+++ b/crates/rue-cli-tests/cases/decl_annotations.toml
@@ -1,0 +1,251 @@
+# Declaration/annotation typing regression tests (RUE-161, RUE-155, RUE-165).
+#
+# RUE-161: a `const` item's type annotation used to be parsed but ignored —
+# every integer const was stored as i32, so `const BIG: i64 = 5000000000;`
+# silently truncated to 705032704 at runtime (a miscompile). The annotation
+# now types the stored const and the initializer is validated against it.
+#
+# RUE-155: unknown type names in let-annotation position were silently
+# ignored (inference fell back to the initializer's type), so
+# `let x: zzz_bogus = 5;` compiled. Annotations are now resolved against the
+# single shared type table and unknown names are E0204 like signature
+# positions.
+#
+# RUE-165: the projection-analysis VarRef path (used for comparison operands)
+# lacked the file-level-constant fallback, so `if N == 1` was a bogus E0201
+# even though `N` resolved fine in return/arithmetic position.
+
+[section]
+id = "cli.decl_annotations"
+name = "Declaration annotation typing"
+description = "const/let type annotations are respected and validated; consts resolve in every operand position."
+
+# ============================================================================
+# RUE-161: const annotations are respected
+# ============================================================================
+
+# The original repro's computation: BIG must be a real i64 5000000000, so
+# dividing by 1e9 yields 5 — not 0 from the silent i32 truncation.
+[[case]]
+name = "const_i64_annotation_not_truncated"
+description = "const BIG: i64 holds the full 64-bit value at runtime (RUE-161 repro)."
+files = [{ path = "main.rue", source = """
+const BIG: i64 = 5000000000;
+fn main() -> i32 {
+    @dbg(BIG);
+    @dbg(BIG / 1000000000);
+    if BIG / 1000000000 == 5 { 5 } else { 1 }
+}
+""" }]
+stdout = """5000000000
+5
+"""
+exit_code = 5
+
+# The exact RUE-161 repro program is now a compile error (i64 cannot flow to
+# main's i32 return), identical to its let-annotated equivalent — never a
+# silently truncated exit 0.
+[[case]]
+name = "const_i64_annotation_blocks_narrowing"
+description = "Returning an i64-typed const computation from main() -> i32 is E0206, not truncation."
+files = [{ path = "main.rue", source = """
+const BIG: i64 = 5000000000;
+fn main() -> i32 {
+    let x = BIG;
+    let y = x / 1000000000;
+    y
+}
+""" }]
+compile_fail = true
+error_contains = ["type mismatch: expected i32, found i64"]
+
+[[case]]
+name = "const_i64_across_fn_boundary"
+description = "An i64-annotated const is usable at its declared type as a call argument."
+files = [{ path = "main.rue", source = """
+const M: i64 = 1;
+fn f(x: i64) -> i64 { x + 1 }
+fn main() -> i32 {
+    @dbg(f(M));
+    if f(M) == 2 { 2 } else { 1 }
+}
+""" }]
+stdout = "2\n"
+exit_code = 2
+
+[[case]]
+name = "const_u64_annotation_full_range"
+description = "const X: u64 holds u64::MAX exactly."
+files = [{ path = "main.rue", source = """
+const HUGE: u64 = 18446744073709551615;
+fn main() -> i32 {
+    @dbg(HUGE);
+    if HUGE > 18446744073709551614 { 3 } else { 1 }
+}
+""" }]
+stdout = "18446744073709551615\n"
+exit_code = 3
+
+[[case]]
+name = "const_u8_annotation_across_fn_boundary"
+description = "const X: u8 is passed at its declared narrow type."
+files = [{ path = "main.rue", source = """
+const SMALL: u8 = 7;
+fn f(x: u8) -> u8 { x }
+fn main() -> i32 {
+    @dbg(f(SMALL));
+    if f(SMALL) == 7 { 7 } else { 1 }
+}
+""" }]
+stdout = "7\n"
+exit_code = 7
+
+[[case]]
+name = "const_annotation_out_of_range"
+description = "An initializer that doesn't fit the annotated type is E0800."
+files = [{ path = "main.rue", source = """
+const X: u8 = 300;
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["literal value 300 is out of range for type 'u8'"]
+
+[[case]]
+name = "const_annotation_type_mismatch"
+description = "A non-integer annotation must match the initializer's type exactly."
+files = [{ path = "main.rue", source = """
+const X: bool = 5;
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["type mismatch: expected bool, found i32"]
+
+[[case]]
+name = "const_unannotated_defaults_to_i32"
+description = "Unannotated integer consts still infer i32 from the literal."
+files = [{ path = "main.rue", source = """
+const N = 41;
+fn main() -> i32 { N + 1 }
+""" }]
+exit_code = 42
+
+# ============================================================================
+# RUE-155: let annotations are validated against the shared type table
+# ============================================================================
+
+[[case]]
+name = "let_unknown_annotation_rejected"
+description = "Unknown type names in let position are E0204, not silently ignored."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: zzz_bogus = 5;
+    x
+}
+""" }]
+compile_fail = true
+error_contains = ["unknown type 'zzz_bogus'"]
+
+[[case]]
+name = "let_never_annotation_rejected"
+description = "`!` in let position is a real type now: an integer initializer can't fit it."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: ! = 5;
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["out of range for type '!'"]
+
+[[case]]
+name = "let_type_annotation_value_mismatch"
+description = "`type` in let position constrains the initializer (5 is not a type value)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: type = 5;
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["type mismatch"]
+
+[[case]]
+name = "const_unknown_annotation_rejected"
+description = "Unknown type names on const items are E0204 too."
+files = [{ path = "main.rue", source = """
+const X: zzz_bogus = 5;
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["unknown type 'zzz_bogus'"]
+
+[[case]]
+name = "let_known_annotations_still_accepted"
+description = "Control: every primitive let annotation still resolves (shared table)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i8 = 1;
+    let b: i16 = 2;
+    let c: i32 = 3;
+    let d: i64 = 4;
+    let e: u8 = 5;
+    let f: u16 = 6;
+    let g: u32 = 7;
+    let h: u64 = 8;
+    let i: usize = 9;
+    let j: isize = 10;
+    let k: bool = true;
+    if k { c } else { 0 }
+}
+""" }]
+exit_code = 3
+
+# ============================================================================
+# RUE-165: consts resolve in projection/comparison operand positions
+# ============================================================================
+
+[[case]]
+name = "const_as_comparison_operand"
+description = "A file-level const is a valid comparison operand (was bogus E0201)."
+files = [{ path = "main.rue", source = """
+const N: i32 = 7;
+fn main() -> i32 {
+    if N == 1 { 1 } else { 2 }
+}
+""" }]
+exit_code = 2
+
+[[case]]
+name = "const_comparison_into_let"
+description = "Comparison of a const bound through a let works too."
+files = [{ path = "main.rue", source = """
+const N: i32 = 7;
+fn main() -> i32 {
+    let b = N == 7;
+    if b { 6 } else { 1 }
+}
+""" }]
+exit_code = 6
+
+[[case]]
+name = "const_comparison_both_sides"
+description = "Consts resolve on both sides of a comparison."
+files = [{ path = "main.rue", source = """
+const A: i32 = 7;
+const B: i32 = 7;
+fn main() -> i32 {
+    if A == B { 4 } else { 1 }
+}
+""" }]
+exit_code = 4
+
+[[case]]
+name = "unknown_name_in_comparison_still_e0201"
+description = "Control: a genuinely undefined name in comparison position is still E0201."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    if nope == 1 { 1 } else { 2 }
+}
+""" }]
+compile_fail = true
+error_contains = ["undefined variable 'nope'"]

--- a/crates/rue-spec/cases/modules/constants.toml
+++ b/crates/rue-spec/cases/modules/constants.toml
@@ -26,6 +26,51 @@ fn main() -> i32 { 0 }
 exit_code = 0
 
 # =============================================================================
+# Typed Const Declarations (RUE-161)
+# =============================================================================
+
+[[case]]
+name = "const_i64_annotation_respected"
+description = "An i64 annotation types the const's value; no truncation to i32"
+source = """
+const BIG: i64 = 5000000000;
+fn main() -> i32 {
+    if BIG / 1000000000 == 5 { 5 } else { 1 }
+}
+"""
+exit_code = 5
+
+[[case]]
+name = "const_annotation_value_out_of_range"
+description = "A const initializer must fit the annotated integer type"
+source = """
+const X: u8 = 300;
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "out of range"
+
+[[case]]
+name = "const_annotation_kind_mismatch"
+description = "A non-integer const annotation must match the initializer's type"
+source = """
+const X: bool = 5;
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "type mismatch"
+
+[[case]]
+name = "const_annotation_unknown_type"
+description = "Unknown type names on const items are rejected"
+source = """
+const X: zzz_bogus = 5;
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "unknown type"
+
+# =============================================================================
 # Public Const Declarations
 # =============================================================================
 


### PR DESCRIPTION
Three annotation/declaration bugs from the comptime-consteval hunt, one cluster.

**RUE-161 — const annotations were ignored (Urgent miscompile).** `const BIG: i64 = 5000000000` was typed i32 and silently truncated (the repro divided down to 0 instead of 5). `collect_const_declaration` now resolves the annotation, range-checks integer initializers (E0800), rejects kind mismatches (E0206), and stores the declared type — the const is a real i64 at every use site. Verified post-integration: the comparison form exits 5.

**RUE-155 — unknown let-annotation names were silently ignored.** `let x: zzz_bogus = 5;` compiled because the inference table falls back to the init type for unknown names. The root enabler — **seven duplicated primitive-name tables** (2× typeck.rs, generate.rs, 4× analysis.rs const-eval arms) — is consolidated into one `Type::from_primitive_name`, and `analyze_alloc` now validates let annotations: unknown names are E0204, and `!`/`type` constrain instead of being ignored. Verified: `zzz_bogus` errors E0204.

**RUE-165 — file-level consts as comparison operands.** `if N == 1` died with a bogus E0201 because the projection-analysis VarRef arm lacked the constants fallback. It now falls back to `analyze_var_ref` for non-param/non-locals; all 12 VarRef arms audited (list in the commit). Verified: exits 2.

18 exact-assertion CLI cases (`decl_annotations.toml`) + 4 spec cases + unit tests for the shared table. Full ./test.sh green, traceability 100%. Frontend-only — no codegen changes.

Fixes RUE-161
Fixes RUE-155
Fixes RUE-165

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Rebase note (post-#974):** the predicted collision landed here. #974 deleted the analysis.rs const-eval arms this PR had table-swapped — resolution keeps the deletion, and the new `comptime_eval.rs` (which had grown its own, eighth primitive-name table) is swapped onto this PR's shared `Type::from_primitive_name`. Cross-mechanism check verified by execution: `const N: i64 = 5000000000; comptime { N / 1000000000 }` == 5 — a W1-typed const flows correctly through the W2 evaluator. Full ./test.sh re-run green.