### PR TITLE
Typed comptime evaluator: one i128-backed, width-checked engine

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -298,18 +298,29 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
             let param_names = sema.param_arena.names(method_info.params);
             let param_types = sema.param_arena.types(method_info.params);
             let param_modes = sema.param_arena.modes(method_info.params);
+            let param_comptime = sema.param_arena.comptime(method_info.params);
 
-            let mut param_info: Vec<(Spur, Type, RirParamMode)> = Vec::new();
+            let mut param_info: Vec<(Spur, Type, RirParamMode, bool)> = Vec::new();
 
             if method_info.has_self {
                 // Add self parameter (Normal mode - passed by value)
                 let self_sym = sema.interner.get_or_intern("self");
-                param_info.push((self_sym, method_info.struct_type, RirParamMode::Normal));
+                param_info.push((
+                    self_sym,
+                    method_info.struct_type,
+                    RirParamMode::Normal,
+                    false,
+                ));
             }
 
             // Add regular parameters (convert from arena slices)
             for i in 0..param_names.len() {
-                param_info.push((param_names[i], param_types[i], param_modes[i]));
+                param_info.push((
+                    param_names[i],
+                    param_types[i],
+                    param_modes[i],
+                    param_comptime[i],
+                ));
             }
 
             // Retrieve captured comptime values from struct-level storage
@@ -562,18 +573,29 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                 let param_names = sema.param_arena.names(method_info.params);
                 let param_types = sema.param_arena.types(method_info.params);
                 let param_modes = sema.param_arena.modes(method_info.params);
+                let param_comptime = sema.param_arena.comptime(method_info.params);
 
-                let mut param_info: Vec<(Spur, Type, RirParamMode)> = Vec::new();
+                let mut param_info: Vec<(Spur, Type, RirParamMode, bool)> = Vec::new();
 
                 if method_info.has_self {
                     // Add self parameter (Normal mode - passed by value)
                     let self_sym = sema.interner.get_or_intern("self");
-                    param_info.push((self_sym, method_info.struct_type, RirParamMode::Normal));
+                    param_info.push((
+                        self_sym,
+                        method_info.struct_type,
+                        RirParamMode::Normal,
+                        false,
+                    ));
                 }
 
                 // Add regular parameters (convert from arena slices)
                 for i in 0..param_names.len() {
-                    param_info.push((param_names[i], param_types[i], param_modes[i]));
+                    param_info.push((
+                        param_names[i],
+                        param_types[i],
+                        param_modes[i],
+                        param_comptime[i],
+                    ));
                 }
 
                 // Retrieve captured comptime values from struct-level storage
@@ -1251,11 +1273,11 @@ impl<'a> Sema<'a> {
         let ret_type = self.resolve_type(return_type, span)?;
 
         // Resolve parameter types and modes
-        let param_info: Vec<(Spur, Type, RirParamMode)> = params
+        let param_info: Vec<(Spur, Type, RirParamMode, bool)> = params
             .iter()
             .map(|p| {
                 let ty = self.resolve_type(p.ty, span)?;
-                Ok((p.name, ty, p.mode))
+                Ok((p.name, ty, p.mode, p.is_comptime))
             })
             .collect::<CompileResult<Vec<_>>>()?;
 
@@ -1310,18 +1332,18 @@ impl<'a> Sema<'a> {
         let ret_type = self.resolve_type(return_type, span)?;
 
         // Build parameter list, adding self as first parameter for methods
-        let mut param_info: Vec<(Spur, Type, RirParamMode)> = Vec::new();
+        let mut param_info: Vec<(Spur, Type, RirParamMode, bool)> = Vec::new();
 
         if has_self {
             // Add self parameter (Normal mode - passed by value)
             let self_sym = self.interner.get_or_intern("self");
-            param_info.push((self_sym, struct_type, RirParamMode::Normal));
+            param_info.push((self_sym, struct_type, RirParamMode::Normal, false));
         }
 
         // Add regular parameters with their modes
         for p in params.iter() {
             let ty = self.resolve_type(p.ty, span)?;
-            param_info.push((p.name, ty, p.mode));
+            param_info.push((p.name, ty, p.mode, p.is_comptime));
         }
 
         let (
@@ -1371,8 +1393,8 @@ impl<'a> Sema<'a> {
     )> {
         // Destructors take self parameter and return unit
         let self_sym = self.interner.get_or_intern("self");
-        let param_info: Vec<(Spur, Type, RirParamMode)> =
-            vec![(self_sym, struct_type, RirParamMode::Normal)];
+        let param_info: Vec<(Spur, Type, RirParamMode, bool)> =
+            vec![(self_sym, struct_type, RirParamMode::Normal, false)];
 
         let (
             mut air,
@@ -1417,7 +1439,7 @@ impl<'a> Sema<'a> {
         &mut self,
         infer_ctx: &InferenceContext,
         return_type: Type,
-        params: &[(Spur, Type, RirParamMode)], // (name, type, mode)
+        params: &[(Spur, Type, RirParamMode, bool)], // (name, type, mode, is_comptime)
         body: InstRef,
     ) -> CompileResult<(
         Air,
@@ -1441,7 +1463,7 @@ impl<'a> Sema<'a> {
         &mut self,
         infer_ctx: &InferenceContext,
         return_type: Type,
-        params: &[(Spur, Type, RirParamMode)],
+        params: &[(Spur, Type, RirParamMode, bool)],
         body: InstRef,
         type_subst: Option<&std::collections::HashMap<Spur, Type>>,
         value_subst: Option<&std::collections::HashMap<Spur, ConstValue>>,
@@ -1463,12 +1485,13 @@ impl<'a> Sema<'a> {
         // Each parameter starts at the next available ABI slot.
         // For struct parameters, the slot count is the number of fields.
         let mut next_abi_slot: u32 = 0;
-        for (pname, ptype, mode) in params.iter() {
+        for (pname, ptype, mode, is_comptime) in params.iter() {
             param_vec.push(ParamInfo {
                 name: *pname,
                 abi_slot: next_abi_slot,
                 ty: *ptype,
                 mode: *mode,
+                is_comptime: *is_comptime,
             });
             // Inout and Borrow parameters are passed by reference.
             // Comptime parameters are VALUE params (like `comptime n: i32`), passed by value.
@@ -1579,7 +1602,7 @@ impl<'a> Sema<'a> {
         &mut self,
         infer_ctx: &InferenceContext,
         return_type: Type,
-        params: &[(Spur, Type, RirParamMode)],
+        params: &[(Spur, Type, RirParamMode, bool)],
         body: InstRef,
         type_subst: &std::collections::HashMap<Spur, Type>,
     ) -> CompileResult<(
@@ -1607,7 +1630,7 @@ impl<'a> Sema<'a> {
         &mut self,
         infer_ctx: &InferenceContext,
         return_type: Type,
-        params: &[(Spur, Type, RirParamMode)],
+        params: &[(Spur, Type, RirParamMode, bool)],
         body: InstRef,
         self_type: Type,
         captured_comptime_values: &std::collections::HashMap<Spur, ConstValue>,
@@ -1651,7 +1674,7 @@ impl<'a> Sema<'a> {
         &mut self,
         infer_ctx: &InferenceContext,
         return_type: Type,
-        params: &[(Spur, Type, RirParamMode)],
+        params: &[(Spur, Type, RirParamMode, bool)],
         body: InstRef,
         type_subst: Option<&HashMap<Spur, Type>>,
         value_subst: Option<&HashMap<Spur, ConstValue>>,
@@ -1674,7 +1697,7 @@ impl<'a> Sema<'a> {
         // Convert Type to InferType so arrays are represented structurally.
         let mut param_vars: HashMap<Spur, ParamVarInfo> = params
             .iter()
-            .map(|(name, ty, _mode)| {
+            .map(|(name, ty, _mode, _is_comptime)| {
                 (
                     *name,
                     ParamVarInfo {
@@ -2167,37 +2190,54 @@ impl<'a> Sema<'a> {
 
             // Comptime block expression
             InstData::Comptime { expr } => {
-                // Try to evaluate the inner expression at compile time
-                match self.try_evaluate_const(*expr) {
+                // Evaluate the inner expression at compile time. The
+                // environment carries the comptime parameters in scope and
+                // the HM-resolved types, so arithmetic is checked at the
+                // operand type (spec 8.1 / 4.14:4) and comptime parameters
+                // are usable as constants (spec 4.14:5). A would-panic
+                // operation (overflow, division by zero) propagates as a
+                // compile error here.
+                let result = {
+                    let mut env = super::comptime_eval::ComptimeEnv::for_analysis(ctx);
+                    self.eval_const_expr(*expr, &mut env)?
+                };
+                match result {
                     Some(ConstValue::Integer(value)) => {
                         // Get the expected type from resolved types
                         let ty =
                             Self::get_resolved_type(ctx, inst_ref, inst.span, "comptime block")?;
 
-                        // Check if the value fits in the target type
-                        if value < 0 {
-                            return Err(CompileError::new(
-                                ErrorKind::ComptimeEvaluationFailed {
-                                    reason: "negative values not yet supported in comptime"
-                                        .to_string(),
-                                },
-                                inst.span,
-                            ));
+                        // Backstop range check: negative results are legal
+                        // for signed targets (RUE-71); the value just has to
+                        // be representable in the target type.
+                        if !super::comptime_eval::const_int_fits(value, ty) {
+                            return if value >= 0 {
+                                Err(CompileError::new(
+                                    ErrorKind::LiteralOutOfRange {
+                                        value: value as u64,
+                                        ty: ty.safe_name_with_pool(Some(&self.type_pool)),
+                                    },
+                                    inst.span,
+                                ))
+                            } else {
+                                Err(CompileError::new(
+                                    ErrorKind::ComptimeEvaluationFailed {
+                                        reason: format!(
+                                            "value {} is out of range for type {}",
+                                            value,
+                                            ty.safe_name_with_pool(Some(&self.type_pool))
+                                        ),
+                                    },
+                                    inst.span,
+                                ))
+                            };
                         }
 
-                        let unsigned_value = value as u64;
-                        if !ty.literal_fits(unsigned_value) {
-                            return Err(CompileError::new(
-                                ErrorKind::LiteralOutOfRange {
-                                    value: unsigned_value,
-                                    ty: ty.safe_name_with_pool(Some(&self.type_pool)),
-                                },
-                                inst.span,
-                            ));
-                        }
-
+                        // Two's-complement encoding: negative values are
+                        // sign-extended into the u64 payload, matching how
+                        // negative literals are emitted elsewhere.
                         let air_ref = air.add_inst(AirInst {
-                            data: AirInstData::Const(unsigned_value),
+                            data: AirInstData::Const(value as u64),
                             ty,
                             span: inst.span,
                         });
@@ -2291,7 +2331,7 @@ impl<'a> Sema<'a> {
                     self.find_or_create_anon_struct(&struct_fields, &method_sigs, &HashMap::new());
 
                 // DON'T register methods here - they should be registered during const evaluation
-                // (either try_evaluate_const for non-comptime, or try_evaluate_const_with_subst for comptime).
+                // (the comptime evaluator's AnonStructType arm in sema::comptime_eval).
                 // If we register here, we create a struct without captured comptime values, which is incorrect.
                 //
                 // if is_new && *methods_len > 0 {
@@ -3853,712 +3893,6 @@ impl<'a> Sema<'a> {
         Ok(AnalysisResult::new(air_ref, Type::BOOL))
     }
 
-    /// Try to evaluate an RIR expression as a compile-time constant.
-    ///
-    /// Returns `Some(value)` if the expression can be fully evaluated at compile time,
-    /// or `None` if evaluation requires runtime information (e.g., variable values,
-    /// function calls) or would cause overflow/panic.
-    ///
-    /// This is the foundation for compile-time bounds checking and can be extended
-    /// for future `comptime` features.
-    pub(crate) fn try_evaluate_const(&mut self, inst_ref: InstRef) -> Option<ConstValue> {
-        let inst = self.rir.get(inst_ref);
-        match &inst.data {
-            // Integer literals
-            InstData::IntConst(value) => i64::try_from(*value).ok().map(ConstValue::Integer),
-
-            // Boolean literals
-            InstData::BoolConst(value) => Some(ConstValue::Bool(*value)),
-
-            // Unary negation: -expr
-            InstData::Neg { operand } => {
-                match self.try_evaluate_const(*operand)? {
-                    ConstValue::Integer(n) => n.checked_neg().map(ConstValue::Integer),
-                    // Can't negate a boolean, type, or unit
-                    ConstValue::Bool(_) | ConstValue::Type(_) | ConstValue::Unit => None,
-                }
-            }
-
-            // Logical NOT: !expr
-            InstData::Not { operand } => {
-                match self.try_evaluate_const(*operand)? {
-                    ConstValue::Bool(b) => Some(ConstValue::Bool(!b)),
-                    // Can't logical-NOT an integer, type, or unit
-                    ConstValue::Integer(_) | ConstValue::Type(_) | ConstValue::Unit => None,
-                }
-            }
-
-            // Binary arithmetic operations
-            InstData::Add { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_integer()?;
-                let r = self.try_evaluate_const(*rhs)?.as_integer()?;
-                l.checked_add(r).map(ConstValue::Integer)
-            }
-            InstData::Sub { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_integer()?;
-                let r = self.try_evaluate_const(*rhs)?.as_integer()?;
-                l.checked_sub(r).map(ConstValue::Integer)
-            }
-            InstData::Mul { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_integer()?;
-                let r = self.try_evaluate_const(*rhs)?.as_integer()?;
-                l.checked_mul(r).map(ConstValue::Integer)
-            }
-            InstData::Div { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_integer()?;
-                let r = self.try_evaluate_const(*rhs)?.as_integer()?;
-                if r == 0 {
-                    None // Division by zero - defer to runtime
-                } else {
-                    l.checked_div(r).map(ConstValue::Integer)
-                }
-            }
-            InstData::Mod { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_integer()?;
-                let r = self.try_evaluate_const(*rhs)?.as_integer()?;
-                if r == 0 {
-                    None // Modulo by zero - defer to runtime
-                } else {
-                    l.checked_rem(r).map(ConstValue::Integer)
-                }
-            }
-
-            // Comparison operations
-            InstData::Eq { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?;
-                let r = self.try_evaluate_const(*rhs)?;
-                match (l, r) {
-                    (ConstValue::Integer(a), ConstValue::Integer(b)) => {
-                        Some(ConstValue::Bool(a == b))
-                    }
-                    (ConstValue::Bool(a), ConstValue::Bool(b)) => Some(ConstValue::Bool(a == b)),
-                    _ => None, // Mixed types
-                }
-            }
-            InstData::Ne { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?;
-                let r = self.try_evaluate_const(*rhs)?;
-                match (l, r) {
-                    (ConstValue::Integer(a), ConstValue::Integer(b)) => {
-                        Some(ConstValue::Bool(a != b))
-                    }
-                    (ConstValue::Bool(a), ConstValue::Bool(b)) => Some(ConstValue::Bool(a != b)),
-                    _ => None,
-                }
-            }
-            InstData::Lt { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_integer()?;
-                let r = self.try_evaluate_const(*rhs)?.as_integer()?;
-                Some(ConstValue::Bool(l < r))
-            }
-            InstData::Gt { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_integer()?;
-                let r = self.try_evaluate_const(*rhs)?.as_integer()?;
-                Some(ConstValue::Bool(l > r))
-            }
-            InstData::Le { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_integer()?;
-                let r = self.try_evaluate_const(*rhs)?.as_integer()?;
-                Some(ConstValue::Bool(l <= r))
-            }
-            InstData::Ge { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_integer()?;
-                let r = self.try_evaluate_const(*rhs)?.as_integer()?;
-                Some(ConstValue::Bool(l >= r))
-            }
-
-            // Logical operations
-            InstData::And { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_bool()?;
-                let r = self.try_evaluate_const(*rhs)?.as_bool()?;
-                Some(ConstValue::Bool(l && r))
-            }
-            InstData::Or { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_bool()?;
-                let r = self.try_evaluate_const(*rhs)?.as_bool()?;
-                Some(ConstValue::Bool(l || r))
-            }
-
-            // Bitwise operations
-            InstData::BitAnd { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_integer()?;
-                let r = self.try_evaluate_const(*rhs)?.as_integer()?;
-                Some(ConstValue::Integer(l & r))
-            }
-            InstData::BitOr { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_integer()?;
-                let r = self.try_evaluate_const(*rhs)?.as_integer()?;
-                Some(ConstValue::Integer(l | r))
-            }
-            InstData::BitXor { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_integer()?;
-                let r = self.try_evaluate_const(*rhs)?.as_integer()?;
-                Some(ConstValue::Integer(l ^ r))
-            }
-            InstData::Shl { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_integer()?;
-                let r = self.try_evaluate_const(*rhs)?.as_integer()?;
-                // Only constant-fold small shift amounts to avoid type-width issues.
-                // For shifts >= 8, defer to runtime where hardware handles masking correctly.
-                // This is conservative but safe - we don't know the operand type here.
-                if r < 0 || r >= 8 {
-                    return None;
-                }
-                Some(ConstValue::Integer(l << r))
-            }
-            InstData::Shr { lhs, rhs } => {
-                let l = self.try_evaluate_const(*lhs)?.as_integer()?;
-                let r = self.try_evaluate_const(*rhs)?.as_integer()?;
-                // Only constant-fold small shift amounts to avoid type-width issues.
-                // For shifts >= 8, defer to runtime where hardware handles masking correctly.
-                if r < 0 || r >= 8 {
-                    return None;
-                }
-                Some(ConstValue::Integer(l >> r))
-            }
-            InstData::BitNot { operand } => {
-                let n = self.try_evaluate_const(*operand)?.as_integer()?;
-                Some(ConstValue::Integer(!n))
-            }
-
-            // Comptime block: comptime { expr } is compile-time evaluable if its inner expr is
-            InstData::Comptime { expr } => self.try_evaluate_const(*expr),
-
-            // Block: evaluate the result expression (last expression in the block)
-            InstData::Block { extra_start, len } => {
-                // A block is comptime-evaluable if it has a single instruction
-                // (which is the result expression) OR if all statements are
-                // side-effect-free and the result is comptime-evaluable.
-                // For now, only handle the single-instruction case (common for
-                // simple type-returning functions like `fn make_type() -> type { i32 }`).
-                if *len == 1 {
-                    let inst_refs = self.rir.get_extra(*extra_start, *len);
-                    let result_ref = InstRef::from_raw(inst_refs[0]);
-                    self.try_evaluate_const(result_ref)
-                } else {
-                    None // Blocks with multiple instructions need full interpreter support
-                }
-            }
-
-            // Anonymous struct type: evaluate to a comptime type value
-            InstData::AnonStructType {
-                fields_start,
-                fields_len,
-                methods_start,
-                methods_len,
-            } => {
-                // Get the field declarations from the RIR
-                let field_decls = self.rir.get_field_decls(*fields_start, *fields_len);
-
-                // Resolve each field type and build the struct fields
-                let mut struct_fields = Vec::with_capacity(field_decls.len());
-                for (name_sym, type_sym) in field_decls {
-                    let name_str = self.interner.resolve(&name_sym).to_string();
-                    // Try to resolve the type - for anonymous structs in comptime context,
-                    // we need to be able to resolve the field types
-                    let field_ty = self.resolve_type_for_comptime(type_sym)?;
-                    struct_fields.push(StructField {
-                        name: name_str,
-                        ty: field_ty,
-                    });
-                }
-
-                // Extract method signatures for structural equality comparison
-                let method_sigs = self.extract_anon_method_sigs(*methods_start, *methods_len);
-
-                // Find or create the anonymous struct type
-                let (struct_ty, is_new) =
-                    self.find_or_create_anon_struct(&struct_fields, &method_sigs, &HashMap::new());
-
-                // Register methods if present and struct is new
-                // This handles non-comptime functions like `fn Counter() -> type { struct { fn get() {} } }`
-                // For comptime functions with captured values, use try_evaluate_const_with_subst instead
-                if is_new && *methods_len > 0 {
-                    let struct_id = struct_ty.as_struct()?;
-                    // Use comptime-safe method registration (no type subst, no value subst for non-comptime)
-                    self.register_anon_struct_methods_for_comptime_with_subst(
-                        struct_id,
-                        struct_ty,
-                        *methods_start,
-                        *methods_len,
-                        inst.span,
-                        &HashMap::new(), // Empty type substitution
-                        &HashMap::new(), // Empty value substitution (non-comptime)
-                    )?;
-                }
-                Some(ConstValue::Type(struct_ty))
-            }
-
-            // TypeConst: a type used as a value (e.g., `i32` in `identity(i32, 42)`)
-            InstData::TypeConst { type_name } => {
-                let type_name_str = self.interner.resolve(type_name);
-                let ty = match type_name_str {
-                    "i8" => Type::I8,
-                    "i16" => Type::I16,
-                    "i32" => Type::I32,
-                    "i64" => Type::I64,
-                    "u8" => Type::U8,
-                    "u16" => Type::U16,
-                    "u32" => Type::U32,
-                    "u64" => Type::U64,
-                    // Pointer-width integers (64-bit on all supported targets, RUE-151).
-                    "usize" => Type::U64,
-                    "isize" => Type::I64,
-                    "bool" => Type::BOOL,
-                    "()" => Type::UNIT,
-                    "!" => Type::NEVER,
-                    _ => {
-                        // Check for struct types
-                        if let Some(&struct_id) = self.structs.get(type_name) {
-                            Type::new_struct(struct_id)
-                        } else if let Some(&enum_id) = self.enums.get(type_name) {
-                            Type::new_enum(enum_id)
-                        } else {
-                            return None; // Unknown type
-                        }
-                    }
-                };
-                Some(ConstValue::Type(ty))
-            }
-
-            // VarRef: when a variable reference is actually a type name (e.g., `Point` in `fn make_type() -> type { Point }`)
-            InstData::VarRef { name } => {
-                // Try to resolve as a type - if it's a type name, return the type
-                let name_str = self.interner.resolve(name);
-                let ty = match name_str {
-                    "i8" => Type::I8,
-                    "i16" => Type::I16,
-                    "i32" => Type::I32,
-                    "i64" => Type::I64,
-                    "u8" => Type::U8,
-                    "u16" => Type::U16,
-                    "u32" => Type::U32,
-                    "u64" => Type::U64,
-                    // Pointer-width integers (64-bit on all supported targets, RUE-151).
-                    "usize" => Type::U64,
-                    "isize" => Type::I64,
-                    "bool" => Type::BOOL,
-                    "()" => Type::UNIT,
-                    "!" => Type::NEVER,
-                    _ => {
-                        // Check for struct types
-                        if let Some(&struct_id) = self.structs.get(name) {
-                            Type::new_struct(struct_id)
-                        } else if let Some(&enum_id) = self.enums.get(name) {
-                            Type::new_enum(enum_id)
-                        } else {
-                            return None; // Not a type name - can't evaluate at compile time
-                        }
-                    }
-                };
-                Some(ConstValue::Type(ty))
-            }
-
-            // Everything else requires runtime evaluation
-            _ => None,
-        }
-    }
-
-    /// Try to extract a constant integer value from an RIR index expression.
-    ///
-    /// This is used for compile-time bounds checking. Returns `Some(value)` if
-    /// the index can be evaluated to an integer constant at compile time.
-    pub(crate) fn try_get_const_index(&mut self, inst_ref: InstRef) -> Option<i64> {
-        self.try_evaluate_const(inst_ref)?.as_integer()
-    }
-
-    /// Try to evaluate an RIR instruction to a compile-time constant value with type substitution.
-    ///
-    /// This is used when evaluating generic functions that return `type`. For example,
-    /// when calling `fn Pair(comptime T: type) -> type { struct { first: T, second: T } }`
-    /// with `Pair(i32)`, we need to substitute `T -> i32` when evaluating the body.
-    ///
-    /// The `type_subst` map contains mappings from type parameter names to concrete types.
-    pub(crate) fn try_evaluate_const_with_subst(
-        &mut self,
-        inst_ref: InstRef,
-        type_subst: &std::collections::HashMap<Spur, Type>,
-        value_subst: &std::collections::HashMap<Spur, ConstValue>,
-    ) -> Option<ConstValue> {
-        let inst = self.rir.get(inst_ref);
-        match &inst.data {
-            // Integer literals
-            InstData::IntConst(value) => i64::try_from(*value).ok().map(ConstValue::Integer),
-
-            // Boolean literals
-            InstData::BoolConst(value) => Some(ConstValue::Bool(*value)),
-
-            // Unary negation: -expr
-            InstData::Neg { operand } => {
-                match self.try_evaluate_const_with_subst(*operand, type_subst, value_subst)? {
-                    ConstValue::Integer(n) => n.checked_neg().map(ConstValue::Integer),
-                    ConstValue::Bool(_) | ConstValue::Type(_) | ConstValue::Unit => None,
-                }
-            }
-
-            // Logical NOT: !expr
-            InstData::Not { operand } => {
-                match self.try_evaluate_const_with_subst(*operand, type_subst, value_subst)? {
-                    ConstValue::Bool(b) => Some(ConstValue::Bool(!b)),
-                    ConstValue::Integer(_) | ConstValue::Type(_) | ConstValue::Unit => None,
-                }
-            }
-
-            // Binary arithmetic operations
-            InstData::Add { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_integer()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_integer()?;
-                l.checked_add(r).map(ConstValue::Integer)
-            }
-            InstData::Sub { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_integer()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_integer()?;
-                l.checked_sub(r).map(ConstValue::Integer)
-            }
-            InstData::Mul { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_integer()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_integer()?;
-                l.checked_mul(r).map(ConstValue::Integer)
-            }
-            InstData::Div { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_integer()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_integer()?;
-                if r == 0 {
-                    None
-                } else {
-                    l.checked_div(r).map(ConstValue::Integer)
-                }
-            }
-            InstData::Mod { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_integer()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_integer()?;
-                if r == 0 {
-                    None
-                } else {
-                    l.checked_rem(r).map(ConstValue::Integer)
-                }
-            }
-
-            // Comparison operations
-            InstData::Eq { lhs, rhs } => {
-                let l = self.try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?;
-                let r = self.try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?;
-                match (l, r) {
-                    (ConstValue::Integer(a), ConstValue::Integer(b)) => {
-                        Some(ConstValue::Bool(a == b))
-                    }
-                    (ConstValue::Bool(a), ConstValue::Bool(b)) => Some(ConstValue::Bool(a == b)),
-                    _ => None,
-                }
-            }
-            InstData::Ne { lhs, rhs } => {
-                let l = self.try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?;
-                let r = self.try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?;
-                match (l, r) {
-                    (ConstValue::Integer(a), ConstValue::Integer(b)) => {
-                        Some(ConstValue::Bool(a != b))
-                    }
-                    (ConstValue::Bool(a), ConstValue::Bool(b)) => Some(ConstValue::Bool(a != b)),
-                    _ => None,
-                }
-            }
-            InstData::Lt { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_integer()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_integer()?;
-                Some(ConstValue::Bool(l < r))
-            }
-            InstData::Gt { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_integer()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_integer()?;
-                Some(ConstValue::Bool(l > r))
-            }
-            InstData::Le { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_integer()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_integer()?;
-                Some(ConstValue::Bool(l <= r))
-            }
-            InstData::Ge { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_integer()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_integer()?;
-                Some(ConstValue::Bool(l >= r))
-            }
-
-            // Logical operations
-            InstData::And { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_bool()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_bool()?;
-                Some(ConstValue::Bool(l && r))
-            }
-            InstData::Or { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_bool()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_bool()?;
-                Some(ConstValue::Bool(l || r))
-            }
-
-            // Bitwise operations
-            InstData::BitAnd { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_integer()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_integer()?;
-                Some(ConstValue::Integer(l & r))
-            }
-            InstData::BitOr { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_integer()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_integer()?;
-                Some(ConstValue::Integer(l | r))
-            }
-            InstData::BitXor { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_integer()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_integer()?;
-                Some(ConstValue::Integer(l ^ r))
-            }
-            InstData::Shl { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_integer()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_integer()?;
-                if r < 0 || r >= 8 {
-                    return None;
-                }
-                Some(ConstValue::Integer(l << r))
-            }
-            InstData::Shr { lhs, rhs } => {
-                let l = self
-                    .try_evaluate_const_with_subst(*lhs, type_subst, value_subst)?
-                    .as_integer()?;
-                let r = self
-                    .try_evaluate_const_with_subst(*rhs, type_subst, value_subst)?
-                    .as_integer()?;
-                if r < 0 || r >= 8 {
-                    return None;
-                }
-                Some(ConstValue::Integer(l >> r))
-            }
-            InstData::BitNot { operand } => {
-                let n = self
-                    .try_evaluate_const_with_subst(*operand, type_subst, value_subst)?
-                    .as_integer()?;
-                Some(ConstValue::Integer(!n))
-            }
-
-            // Comptime block: comptime { expr } is compile-time evaluable if its inner expr is
-            InstData::Comptime { expr } => {
-                self.try_evaluate_const_with_subst(*expr, type_subst, value_subst)
-            }
-
-            // Block: evaluate the result expression (last expression in the block)
-            InstData::Block { extra_start, len } => {
-                if *len == 1 {
-                    let inst_refs = self.rir.get_extra(*extra_start, *len);
-                    let result_ref = InstRef::from_raw(inst_refs[0]);
-                    self.try_evaluate_const_with_subst(result_ref, type_subst, value_subst)
-                } else {
-                    None
-                }
-            }
-
-            // Anonymous struct type: evaluate to a comptime type value with substitution
-            InstData::AnonStructType {
-                fields_start,
-                fields_len,
-                methods_start,
-                methods_len,
-            } => {
-                let field_decls = self.rir.get_field_decls(*fields_start, *fields_len);
-
-                let mut struct_fields = Vec::with_capacity(field_decls.len());
-                for (name_sym, type_sym) in field_decls {
-                    let name_str = self.interner.resolve(&name_sym).to_string();
-                    // Use the substitution-aware type resolution
-                    let field_ty =
-                        self.resolve_type_for_comptime_with_subst(type_sym, type_subst)?;
-                    struct_fields.push(StructField {
-                        name: name_str,
-                        ty: field_ty,
-                    });
-                }
-
-                // Extract method signatures for structural equality comparison
-                let method_sigs = self.extract_anon_method_sigs(*methods_start, *methods_len);
-
-                let (struct_ty, _is_new) =
-                    self.find_or_create_anon_struct(&struct_fields, &method_sigs, value_subst);
-
-                // Register methods if present.
-                // Register if either:
-                // 1. This is a newly created struct (is_new=true), OR
-                // 2. The struct exists but has no methods registered yet
-                if *methods_len > 0 {
-                    let struct_id = struct_ty.as_struct()?;
-
-                    // Check if methods are already registered for this struct
-                    let method_refs = self.rir.get_inst_refs(*methods_start, *methods_len);
-                    let first_method_ref = method_refs[0];
-                    let first_method_inst = self.rir.get(first_method_ref);
-                    if let InstData::FnDecl {
-                        name: method_name, ..
-                    } = &first_method_inst.data
-                    {
-                        let needs_registration =
-                            !self.methods.contains_key(&(struct_id, *method_name));
-
-                        if needs_registration {
-                            // Use comptime-safe method registration with type substitution
-                            self.register_anon_struct_methods_for_comptime_with_subst(
-                                struct_id,
-                                struct_ty,
-                                *methods_start,
-                                *methods_len,
-                                inst.span,
-                                type_subst,
-                                value_subst,
-                            )?;
-                        }
-                    }
-                }
-                Some(ConstValue::Type(struct_ty))
-            }
-
-            // TypeConst: a type used as a value
-            InstData::TypeConst { type_name } => {
-                // First check the substitution map
-                if let Some(&ty) = type_subst.get(type_name) {
-                    return Some(ConstValue::Type(ty));
-                }
-
-                let type_name_str = self.interner.resolve(type_name);
-                let ty = match type_name_str {
-                    "i8" => Type::I8,
-                    "i16" => Type::I16,
-                    "i32" => Type::I32,
-                    "i64" => Type::I64,
-                    "u8" => Type::U8,
-                    "u16" => Type::U16,
-                    "u32" => Type::U32,
-                    "u64" => Type::U64,
-                    // Pointer-width integers (64-bit on all supported targets, RUE-151).
-                    "usize" => Type::U64,
-                    "isize" => Type::I64,
-                    "bool" => Type::BOOL,
-                    "()" => Type::UNIT,
-                    "!" => Type::NEVER,
-                    _ => {
-                        if let Some(&struct_id) = self.structs.get(type_name) {
-                            Type::new_struct(struct_id)
-                        } else if let Some(&enum_id) = self.enums.get(type_name) {
-                            Type::new_enum(enum_id)
-                        } else {
-                            return None;
-                        }
-                    }
-                };
-                Some(ConstValue::Type(ty))
-            }
-
-            // VarRef: check substitution maps first, then try as a type name
-            InstData::VarRef { name } => {
-                // Check if this is a type parameter in the type substitution map
-                if let Some(&ty) = type_subst.get(name) {
-                    return Some(ConstValue::Type(ty));
-                }
-
-                // Check if this is a comptime value variable in the value substitution map
-                if let Some(value) = value_subst.get(name) {
-                    return Some(value.clone());
-                }
-
-                // Try to resolve as a type name
-                let name_str = self.interner.resolve(name);
-                let ty = match name_str {
-                    "i8" => Type::I8,
-                    "i16" => Type::I16,
-                    "i32" => Type::I32,
-                    "i64" => Type::I64,
-                    "u8" => Type::U8,
-                    "u16" => Type::U16,
-                    "u32" => Type::U32,
-                    "u64" => Type::U64,
-                    // Pointer-width integers (64-bit on all supported targets, RUE-151).
-                    "usize" => Type::U64,
-                    "isize" => Type::I64,
-                    "bool" => Type::BOOL,
-                    "()" => Type::UNIT,
-                    "!" => Type::NEVER,
-                    _ => {
-                        if let Some(&struct_id) = self.structs.get(name) {
-                            Type::new_struct(struct_id)
-                        } else if let Some(&enum_id) = self.enums.get(name) {
-                            Type::new_enum(enum_id)
-                        } else {
-                            return None;
-                        }
-                    }
-                };
-                Some(ConstValue::Type(ty))
-            }
-
-            // Everything else requires runtime evaluation
-            _ => None,
-        }
-    }
-
     /// Check if an RIR instruction is a VarRef to a comptime type variable.
     ///
     /// This is used when validating comptime arguments to detect variables
@@ -5296,7 +4630,7 @@ impl<'a> Sema<'a> {
     /// ```
     /// When `Wrapper(i32)` is called, the type_subst map will contain `T -> i32`, so the
     /// method's return type `T` is resolved to `i32`.
-    fn register_anon_struct_methods_for_comptime_with_subst(
+    pub(crate) fn register_anon_struct_methods_for_comptime_with_subst(
         &mut self,
         struct_id: StructId,
         struct_type: Type,
@@ -5404,7 +4738,7 @@ impl<'a> Sema<'a> {
     /// This extracts method signatures as type symbols (Spur), not resolved Types.
     /// This is intentional: for structural equality, we compare type symbols directly
     /// so that `Self` matches `Self` even before we know the concrete StructId.
-    fn extract_anon_method_sigs(
+    pub(crate) fn extract_anon_method_sigs(
         &self,
         methods_start: u32,
         methods_len: u32,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3330,7 +3330,9 @@ impl<'a> Sema<'a> {
             for (i, is_comptime) in param_comptime.iter().enumerate() {
                 if *is_comptime && param_types[i] != Type::COMPTIME_TYPE {
                     // This is a comptime VALUE parameter - extract its const value
-                    if let Some(const_val) = self.try_evaluate_const(args[i].value) {
+                    // (evaluated in the calling function's context so comptime
+                    // parameters in scope and resolved types are visible)
+                    if let Some(const_val) = self.try_evaluate_const_in_fn(args[i].value, ctx) {
                         value_subst.insert(param_names[i], const_val);
                     }
                 }
@@ -3359,9 +3361,13 @@ impl<'a> Sema<'a> {
             // Validate each comptime parameter receives a compile-time constant
             for (i, (&is_comptime, arg)) in param_comptime.iter().zip(args.iter()).enumerate() {
                 if is_comptime {
-                    // Try to evaluate the argument at compile time
-                    let is_comptime_known = self.try_evaluate_const(arg.value).is_some()
-                        || self.is_comptime_type_var(arg.value, ctx);
+                    // Try to evaluate the argument at compile time. A direct
+                    // reference to a comptime parameter of the *current*
+                    // function also counts: its value is compile-time known
+                    // at every call site, so it may be forwarded (spec 4.14:5).
+                    let is_comptime_known = self.try_evaluate_const_in_fn(arg.value, ctx).is_some()
+                        || self.is_comptime_type_var(arg.value, ctx)
+                        || self.is_comptime_param_forward(arg.value, ctx);
                     if !is_comptime_known {
                         let param_name = self.interner.resolve(&param_names[i]).to_string();
                         return Err(CompileError::new(
@@ -3499,7 +3505,8 @@ impl<'a> Sema<'a> {
                 for (i, is_comptime) in param_comptime.iter().enumerate() {
                     if *is_comptime && param_types[i] != Type::COMPTIME_TYPE {
                         // This is a comptime VALUE parameter - extract its const value
-                        if let Some(const_val) = self.try_evaluate_const(args[i].value) {
+                        // (evaluated in the calling function's context)
+                        if let Some(const_val) = self.try_evaluate_const_in_fn(args[i].value, ctx) {
                             value_subst.insert(param_names[i], const_val);
                         }
                     }

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1,0 +1,770 @@
+//! Compile-time expression evaluation (the comptime const evaluator).
+//!
+//! This module hosts the single evaluation engine behind:
+//!
+//! - `comptime { ... }` block expressions (spec 4.14)
+//! - comptime argument validation and value capture for `comptime` parameters
+//! - opportunistic constant evaluation (array bounds checks, comptime type
+//!   construction for functions returning `type`)
+//!
+//! # Typed evaluation
+//!
+//! Values are carried as [`ConstValue::Integer`] backed by `i128`, which
+//! covers the full range of every Rue integer type (including u64 values
+//! above `i64::MAX`, RUE-70, and negative signed results, RUE-71).
+//!
+//! When the evaluator runs inside a function being analyzed, it has access to
+//! the Hindley-Milner `resolved_types` map and performs arithmetic *at the
+//! operand type*, exactly mirroring runtime semantics (spec 8.1):
+//!
+//! - Add/Sub/Mul/Neg/Div/Mod results that overflow the operand type are a
+//!   hard error (`Err`), because the same operation would panic at runtime
+//!   (RUE-68). Division/remainder by zero likewise.
+//! - Shifts mask the shift amount modulo the bit width and truncate the
+//!   result to the operand width (spec 4.3a:10, matching the RUE-29 runtime
+//!   semantics), so any constant shift folds (RUE-69).
+//! - `~` (BitNot) truncates to the operand width (`~0` as u8 is 255).
+//!
+//! When no resolved types are available (evaluating a comptime function body
+//! before specialization, or a file-level const initializer), arithmetic
+//! falls back to checked `i64` semantics: results outside the `i64` range
+//! make the expression non-evaluable (`Ok(None)`) rather than an error.
+//!
+//! # Outcome encoding
+//!
+//! [`Sema::eval_const_expr`] returns `CompileResult<Option<ConstValue>>`:
+//!
+//! - `Ok(Some(v))` — fully evaluated.
+//! - `Ok(None)` — not compile-time evaluable (runtime variables, calls, ...).
+//!   The `comptime` block handler reports this as E1200.
+//! - `Err(e)` — the expression *is* constant but would panic at runtime
+//!   (overflow at the operand type, division by zero). Inside a `comptime`
+//!   block this is a compile error (spec 4.14:4); opportunistic callers
+//!   ([`Sema::try_evaluate_const`] and friends) convert it to `None` and
+//!   defer to the runtime check.
+
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use lasso::Spur;
+use rue_error::{CompileError, CompileResult, ErrorKind};
+use rue_rir::{InstData, InstRef};
+use rue_span::Span;
+
+use super::Sema;
+use super::context::{AnalysisContext, ConstValue};
+use crate::types::{StructField, Type};
+
+/// Empty type substitution map for evaluation contexts without one.
+static EMPTY_TYPE_SUBST: LazyLock<HashMap<Spur, Type>> = LazyLock::new(HashMap::new);
+/// Empty value substitution map for evaluation contexts without one.
+static EMPTY_VALUE_SUBST: LazyLock<HashMap<Spur, ConstValue>> = LazyLock::new(HashMap::new);
+
+/// The environment a compile-time expression is evaluated in.
+pub(crate) struct ComptimeEnv<'a> {
+    /// Comptime type parameters in scope (e.g. `T` -> `i32`).
+    type_subst: &'a HashMap<Spur, Type>,
+    /// Comptime value parameters in scope (e.g. `N` -> `42`).
+    value_subst: &'a HashMap<Spur, ConstValue>,
+    /// Resolved types from HM inference for the function being analyzed.
+    /// `None` when evaluating expressions outside a typed function context
+    /// (comptime function bodies before specialization, const initializers).
+    resolved_types: Option<&'a HashMap<InstRef, Type>>,
+    /// `let` bindings introduced by blocks inside the comptime expression.
+    locals: HashMap<Spur, ConstValue>,
+}
+
+impl<'a> ComptimeEnv<'a> {
+    /// An environment with no substitutions and no type information.
+    pub(crate) fn new() -> Self {
+        Self {
+            type_subst: &EMPTY_TYPE_SUBST,
+            value_subst: &EMPTY_VALUE_SUBST,
+            resolved_types: None,
+            locals: HashMap::new(),
+        }
+    }
+
+    /// An environment with comptime parameter substitutions but no resolved
+    /// types (used when evaluating a comptime function body at a call site).
+    pub(crate) fn with_subst(
+        type_subst: &'a HashMap<Spur, Type>,
+        value_subst: &'a HashMap<Spur, ConstValue>,
+    ) -> Self {
+        Self {
+            type_subst,
+            value_subst,
+            resolved_types: None,
+            locals: HashMap::new(),
+        }
+    }
+
+    /// The environment for expressions inside the function currently being
+    /// analyzed: comptime parameters in scope plus HM-resolved types.
+    pub(crate) fn for_analysis(ctx: &'a AnalysisContext) -> Self {
+        Self {
+            type_subst: &ctx.comptime_type_vars,
+            value_subst: &ctx.comptime_value_vars,
+            resolved_types: Some(ctx.resolved_types),
+            locals: HashMap::new(),
+        }
+    }
+}
+
+/// Check whether `value` is representable in integer type `ty`.
+pub(crate) fn const_int_fits(value: i128, ty: Type) -> bool {
+    match (ty.int_min(), ty.int_max()) {
+        (Some(min), Some(max)) => value >= min && value <= max,
+        _ => false,
+    }
+}
+
+/// Truncate `value` to the width of integer type `ty` (two's complement
+/// wrapping, sign-extended for signed types). Mirrors what the hardware does
+/// for operations defined to truncate (shifts, bitwise NOT on unsigned).
+fn truncate_to_type(value: i128, ty: Type) -> i128 {
+    let width = ty
+        .int_bit_width()
+        .expect("truncate_to_type called with non-integer type");
+    let mask = (1i128 << width) - 1;
+    let mut r = value & mask;
+    if ty.is_signed() && (r & (1i128 << (width - 1))) != 0 {
+        r -= 1i128 << width;
+    }
+    r
+}
+
+/// Build the E1200 error for a constant operation that would panic at runtime.
+fn comptime_panic_err(reason: String, span: Span) -> CompileError {
+    CompileError::new(ErrorKind::ComptimeEvaluationFailed { reason }, span)
+}
+
+impl Sema<'_> {
+    /// Try to evaluate an RIR expression as a compile-time constant, with no
+    /// substitutions or type context.
+    ///
+    /// Returns `Some(value)` if the expression can be fully evaluated at
+    /// compile time, or `None` if evaluation requires runtime information
+    /// (e.g. variable values, function calls) or would cause overflow/panic
+    /// (callers using this entry point defer such cases to the runtime check).
+    pub(crate) fn try_evaluate_const(&mut self, inst_ref: InstRef) -> Option<ConstValue> {
+        let mut env = ComptimeEnv::new();
+        self.eval_const_expr(inst_ref, &mut env).ok().flatten()
+    }
+
+    /// Like [`try_evaluate_const`], but evaluated inside the function being
+    /// analyzed: comptime parameters in scope (`ctx.comptime_*_vars`) resolve
+    /// to their values, and arithmetic is checked at HM-resolved types.
+    ///
+    /// [`try_evaluate_const`]: Sema::try_evaluate_const
+    pub(crate) fn try_evaluate_const_in_fn(
+        &mut self,
+        inst_ref: InstRef,
+        ctx: &AnalysisContext,
+    ) -> Option<ConstValue> {
+        let mut env = ComptimeEnv::for_analysis(ctx);
+        self.eval_const_expr(inst_ref, &mut env).ok().flatten()
+    }
+
+    /// Try to evaluate an RIR instruction to a compile-time constant value
+    /// with type/value substitution.
+    ///
+    /// This is used when evaluating generic functions that return `type`. For
+    /// example, when calling `fn Pair(comptime T: type) -> type { struct {
+    /// first: T, second: T } }` with `Pair(i32)`, we need to substitute
+    /// `T -> i32` when evaluating the body.
+    pub(crate) fn try_evaluate_const_with_subst(
+        &mut self,
+        inst_ref: InstRef,
+        type_subst: &HashMap<Spur, Type>,
+        value_subst: &HashMap<Spur, ConstValue>,
+    ) -> Option<ConstValue> {
+        let mut env = ComptimeEnv::with_subst(type_subst, value_subst);
+        self.eval_const_expr(inst_ref, &mut env).ok().flatten()
+    }
+
+    /// Try to extract a constant integer value from an RIR index expression.
+    ///
+    /// This is used for compile-time bounds checking. Returns `Some(value)` if
+    /// the index can be evaluated to an integer constant at compile time.
+    pub(crate) fn try_get_const_index(&mut self, inst_ref: InstRef) -> Option<i64> {
+        self.try_evaluate_const(inst_ref)?.as_integer()
+    }
+
+    /// Check if an RIR instruction is a direct reference to a `comptime`
+    /// parameter of the function currently being analyzed.
+    ///
+    /// Such a reference is compile-time known *to every caller* even though
+    /// its value is unknown while the body is analyzed, so it may be
+    /// forwarded to another function's comptime parameter (spec 4.14:5):
+    ///
+    /// ```rue
+    /// fn g(comptime m: i32) -> i32 { m * 2 }
+    /// fn f(comptime n: i32) -> i32 { g(n) }  // forwarding
+    /// ```
+    pub(crate) fn is_comptime_param_forward(
+        &self,
+        inst_ref: InstRef,
+        ctx: &AnalysisContext,
+    ) -> bool {
+        if let InstData::VarRef { name } = &self.rir.get(inst_ref).data {
+            // A runtime local of the same name shadows the parameter.
+            !ctx.locals.contains_key(name)
+                && ctx.params.iter().any(|p| p.name == *name && p.is_comptime)
+        } else {
+            false
+        }
+    }
+
+    /// The resolved integer type of an expression, when known.
+    fn const_expr_type(&self, env: &ComptimeEnv, inst_ref: InstRef) -> Option<Type> {
+        env.resolved_types?
+            .get(&inst_ref)
+            .copied()
+            .filter(Type::is_integer)
+    }
+
+    /// Finish an arithmetic operation: range-check `value` against the
+    /// expression's type.
+    ///
+    /// - Typed: out-of-range results are a hard error (the operation would
+    ///   panic at runtime, spec 8.1 / 4.14:4).
+    /// - Untyped fallback: results outside the `i64` range make the
+    ///   expression non-evaluable (legacy checked-i64 semantics).
+    fn finish_arith(
+        &self,
+        value: Option<i128>,
+        ty: Option<Type>,
+        op: &str,
+        span: Span,
+    ) -> CompileResult<Option<ConstValue>> {
+        match ty {
+            Some(ty) => match value {
+                Some(v) if const_int_fits(v, ty) => Ok(Some(ConstValue::Integer(v))),
+                _ => {
+                    let ty_name = ty.safe_name_with_pool(Some(&self.type_pool));
+                    let detail = match value {
+                        Some(v) => format!("the result {} does not fit in {}", v, ty_name),
+                        None => format!("the result does not fit in {}", ty_name),
+                    };
+                    Err(comptime_panic_err(
+                        format!(
+                            "integer overflow evaluating `{}` at type {}: {} \
+                             (this operation would panic at runtime)",
+                            op, ty_name, detail
+                        ),
+                        span,
+                    ))
+                }
+            },
+            None => match value {
+                Some(v) if v >= i128::from(i64::MIN) && v <= i128::from(i64::MAX) => {
+                    Ok(Some(ConstValue::Integer(v)))
+                }
+                _ => Ok(None),
+            },
+        }
+    }
+
+    /// Resolve a name to a type value (primitive type names, structs, enums).
+    fn resolve_named_type_value(&self, name: &Spur) -> Option<Type> {
+        let name_str = self.interner.resolve(name);
+        let ty = match name_str {
+            "i8" => Type::I8,
+            "i16" => Type::I16,
+            "i32" => Type::I32,
+            "i64" => Type::I64,
+            "u8" => Type::U8,
+            "u16" => Type::U16,
+            "u32" => Type::U32,
+            "u64" => Type::U64,
+            // Pointer-width integers (64-bit on all supported targets, RUE-151).
+            "usize" => Type::U64,
+            "isize" => Type::I64,
+            "bool" => Type::BOOL,
+            "()" => Type::UNIT,
+            "!" => Type::NEVER,
+            _ => {
+                if let Some(&struct_id) = self.structs.get(name) {
+                    Type::new_struct(struct_id)
+                } else if let Some(&enum_id) = self.enums.get(name) {
+                    Type::new_enum(enum_id)
+                } else {
+                    return None;
+                }
+            }
+        };
+        Some(ty)
+    }
+
+    /// Evaluate both operands of a binary operation as integers.
+    ///
+    /// Returns `Ok(None)` if either operand is not a compile-time integer.
+    fn eval_int_operands(
+        &mut self,
+        lhs: InstRef,
+        rhs: InstRef,
+        env: &mut ComptimeEnv,
+    ) -> CompileResult<Option<(i128, i128)>> {
+        let Some(l) = self
+            .eval_const_expr(lhs, env)?
+            .and_then(ConstValue::as_int_value)
+        else {
+            return Ok(None);
+        };
+        let Some(r) = self
+            .eval_const_expr(rhs, env)?
+            .and_then(ConstValue::as_int_value)
+        else {
+            return Ok(None);
+        };
+        Ok(Some((l, r)))
+    }
+
+    /// The single compile-time evaluation engine. See the module docs for the
+    /// outcome encoding (`Ok(Some)` / `Ok(None)` / `Err`).
+    pub(crate) fn eval_const_expr(
+        &mut self,
+        inst_ref: InstRef,
+        env: &mut ComptimeEnv,
+    ) -> CompileResult<Option<ConstValue>> {
+        let inst = self.rir.get(inst_ref);
+        let span = inst.span;
+        match &inst.data {
+            // Integer literals. The literal itself must fit its resolved type
+            // (the inner expression of a comptime block never goes through
+            // `analyze_literal`, so this is where `300` at type u8 is caught).
+            InstData::IntConst(value) => {
+                let v = *value as i128;
+                if let Some(ty) = self.const_expr_type(env, inst_ref) {
+                    if !const_int_fits(v, ty) {
+                        return Err(CompileError::new(
+                            ErrorKind::LiteralOutOfRange {
+                                value: *value,
+                                ty: ty.safe_name_with_pool(Some(&self.type_pool)),
+                            },
+                            span,
+                        ));
+                    }
+                }
+                Ok(Some(ConstValue::Integer(v)))
+            }
+
+            // Boolean literals
+            InstData::BoolConst(value) => Ok(Some(ConstValue::Bool(*value))),
+
+            // Unit literal
+            InstData::UnitConst => Ok(Some(ConstValue::Unit)),
+
+            // Unary negation: -expr
+            InstData::Neg { operand } => {
+                let ty = self.const_expr_type(env, inst_ref);
+                if let Some(ty) = ty {
+                    if ty.is_unsigned() {
+                        return Err(CompileError::new(
+                            ErrorKind::CannotNegateUnsigned(
+                                ty.safe_name_with_pool(Some(&self.type_pool)),
+                            ),
+                            span,
+                        ));
+                    }
+                }
+                // Negated literals bypass the literal range check so that
+                // `-128` works for i8 (the magnitude alone exceeds i8::MAX).
+                let operand_value = if let InstData::IntConst(mag) = &self.rir.get(*operand).data {
+                    Some(ConstValue::Integer(*mag as i128))
+                } else {
+                    self.eval_const_expr(*operand, env)?
+                };
+                match operand_value {
+                    Some(ConstValue::Integer(n)) => self.finish_arith(Some(-n), ty, "-", span),
+                    // Can't negate a boolean, type, or unit
+                    _ => Ok(None),
+                }
+            }
+
+            // Logical NOT: !expr
+            InstData::Not { operand } => {
+                match self.eval_const_expr(*operand, env)? {
+                    Some(ConstValue::Bool(b)) => Ok(Some(ConstValue::Bool(!b))),
+                    // Can't logical-NOT an integer, type, or unit
+                    _ => Ok(None),
+                }
+            }
+
+            // Binary arithmetic operations, checked at the operand type
+            InstData::Add { lhs, rhs } => {
+                let Some((l, r)) = self.eval_int_operands(*lhs, *rhs, env)? else {
+                    return Ok(None);
+                };
+                let ty = self.const_expr_type(env, inst_ref);
+                self.finish_arith(l.checked_add(r), ty, "+", span)
+            }
+            InstData::Sub { lhs, rhs } => {
+                let Some((l, r)) = self.eval_int_operands(*lhs, *rhs, env)? else {
+                    return Ok(None);
+                };
+                let ty = self.const_expr_type(env, inst_ref);
+                self.finish_arith(l.checked_sub(r), ty, "-", span)
+            }
+            InstData::Mul { lhs, rhs } => {
+                let Some((l, r)) = self.eval_int_operands(*lhs, *rhs, env)? else {
+                    return Ok(None);
+                };
+                let ty = self.const_expr_type(env, inst_ref);
+                self.finish_arith(l.checked_mul(r), ty, "*", span)
+            }
+            InstData::Div { lhs, rhs } | InstData::Mod { lhs, rhs } => {
+                let is_div = matches!(&inst.data, InstData::Div { .. });
+                let op = if is_div { "/" } else { "%" };
+                let Some((l, r)) = self.eval_int_operands(*lhs, *rhs, env)? else {
+                    return Ok(None);
+                };
+                let ty = self.const_expr_type(env, inst_ref);
+                if r == 0 {
+                    let what = if is_div { "division" } else { "remainder" };
+                    return match ty {
+                        Some(_) => Err(comptime_panic_err(
+                            format!("{} by zero (this operation would panic at runtime)", what),
+                            span,
+                        )),
+                        // Untyped fallback: defer to the runtime check.
+                        None => Ok(None),
+                    };
+                }
+                // Signed MIN / -1 (and MIN % -1) overflow at runtime, spec 8.1:3.
+                if r == -1 {
+                    match ty {
+                        Some(t) if t.is_signed() && Some(l) == t.int_min() => {
+                            return self.finish_arith(None, ty, op, span);
+                        }
+                        None if l == i128::from(i64::MIN) => return Ok(None),
+                        _ => {}
+                    }
+                }
+                self.finish_arith(Some(if is_div { l / r } else { l % r }), ty, op, span)
+            }
+
+            // Comparison operations
+            InstData::Eq { lhs, rhs } => {
+                let l = self.eval_const_expr(*lhs, env)?;
+                let r = self.eval_const_expr(*rhs, env)?;
+                match (l, r) {
+                    (Some(ConstValue::Integer(a)), Some(ConstValue::Integer(b))) => {
+                        Ok(Some(ConstValue::Bool(a == b)))
+                    }
+                    (Some(ConstValue::Bool(a)), Some(ConstValue::Bool(b))) => {
+                        Ok(Some(ConstValue::Bool(a == b)))
+                    }
+                    _ => Ok(None), // Mixed or non-constant operands
+                }
+            }
+            InstData::Ne { lhs, rhs } => {
+                let l = self.eval_const_expr(*lhs, env)?;
+                let r = self.eval_const_expr(*rhs, env)?;
+                match (l, r) {
+                    (Some(ConstValue::Integer(a)), Some(ConstValue::Integer(b))) => {
+                        Ok(Some(ConstValue::Bool(a != b)))
+                    }
+                    (Some(ConstValue::Bool(a)), Some(ConstValue::Bool(b))) => {
+                        Ok(Some(ConstValue::Bool(a != b)))
+                    }
+                    _ => Ok(None),
+                }
+            }
+            InstData::Lt { lhs, rhs } => {
+                let Some((l, r)) = self.eval_int_operands(*lhs, *rhs, env)? else {
+                    return Ok(None);
+                };
+                Ok(Some(ConstValue::Bool(l < r)))
+            }
+            InstData::Gt { lhs, rhs } => {
+                let Some((l, r)) = self.eval_int_operands(*lhs, *rhs, env)? else {
+                    return Ok(None);
+                };
+                Ok(Some(ConstValue::Bool(l > r)))
+            }
+            InstData::Le { lhs, rhs } => {
+                let Some((l, r)) = self.eval_int_operands(*lhs, *rhs, env)? else {
+                    return Ok(None);
+                };
+                Ok(Some(ConstValue::Bool(l <= r)))
+            }
+            InstData::Ge { lhs, rhs } => {
+                let Some((l, r)) = self.eval_int_operands(*lhs, *rhs, env)? else {
+                    return Ok(None);
+                };
+                Ok(Some(ConstValue::Bool(l >= r)))
+            }
+
+            // Logical operations: short-circuit like the runtime, so a
+            // non-constant (or would-panic) RHS is irrelevant when the LHS
+            // already decides the result.
+            InstData::And { lhs, rhs } => match self.eval_const_expr(*lhs, env)? {
+                Some(ConstValue::Bool(false)) => Ok(Some(ConstValue::Bool(false))),
+                Some(ConstValue::Bool(true)) => match self.eval_const_expr(*rhs, env)? {
+                    Some(ConstValue::Bool(b)) => Ok(Some(ConstValue::Bool(b))),
+                    _ => Ok(None),
+                },
+                _ => Ok(None),
+            },
+            InstData::Or { lhs, rhs } => match self.eval_const_expr(*lhs, env)? {
+                Some(ConstValue::Bool(true)) => Ok(Some(ConstValue::Bool(true))),
+                Some(ConstValue::Bool(false)) => match self.eval_const_expr(*rhs, env)? {
+                    Some(ConstValue::Bool(b)) => Ok(Some(ConstValue::Bool(b))),
+                    _ => Ok(None),
+                },
+                _ => Ok(None),
+            },
+
+            // Bitwise operations. For values in range of their type these are
+            // closed (no overflow possible), so no range check is needed.
+            InstData::BitAnd { lhs, rhs } => {
+                let Some((l, r)) = self.eval_int_operands(*lhs, *rhs, env)? else {
+                    return Ok(None);
+                };
+                Ok(Some(ConstValue::Integer(l & r)))
+            }
+            InstData::BitOr { lhs, rhs } => {
+                let Some((l, r)) = self.eval_int_operands(*lhs, *rhs, env)? else {
+                    return Ok(None);
+                };
+                Ok(Some(ConstValue::Integer(l | r)))
+            }
+            InstData::BitXor { lhs, rhs } => {
+                let Some((l, r)) = self.eval_int_operands(*lhs, *rhs, env)? else {
+                    return Ok(None);
+                };
+                Ok(Some(ConstValue::Integer(l ^ r)))
+            }
+
+            // Shifts: the amount is masked modulo the bit width and the
+            // result truncated to the operand width (spec 4.3a:10), exactly
+            // matching the runtime semantics (RUE-29).
+            InstData::Shl { lhs, rhs } | InstData::Shr { lhs, rhs } => {
+                let is_shl = matches!(&inst.data, InstData::Shl { .. });
+                let Some((l, r)) = self.eval_int_operands(*lhs, *rhs, env)? else {
+                    return Ok(None);
+                };
+                match self.const_expr_type(env, inst_ref) {
+                    Some(ty) => {
+                        let width = ty
+                            .int_bit_width()
+                            .expect("const_expr_type returned non-integer");
+                        // Two's-complement AND masks negative amounts the same
+                        // way the hardware masks the count register.
+                        let amt = (r & i128::from(width - 1)) as u32;
+                        let v = if is_shl {
+                            // Wrapping shift + truncation: the low `width`
+                            // bits are exact, which is all that survives.
+                            truncate_to_type(l.wrapping_shl(amt), ty)
+                        } else {
+                            // Value semantics make this arithmetic for signed
+                            // (negative l) and logical for unsigned (l >= 0).
+                            l >> amt
+                        };
+                        Ok(Some(ConstValue::Integer(v)))
+                    }
+                    None => {
+                        // Without the operand type the width is unknown, so
+                        // only fold amounts < 8 (safe for every width) and
+                        // defer the rest to runtime.
+                        if !(0..8).contains(&r) {
+                            return Ok(None);
+                        }
+                        Ok(Some(ConstValue::Integer(if is_shl {
+                            l << r
+                        } else {
+                            l >> r
+                        })))
+                    }
+                }
+            }
+
+            // Bitwise NOT: truncated to the operand width (`~0` as u8 = 255).
+            InstData::BitNot { operand } => {
+                let Some(n) = self
+                    .eval_const_expr(*operand, env)?
+                    .and_then(ConstValue::as_int_value)
+                else {
+                    return Ok(None);
+                };
+                let v = match self.const_expr_type(env, inst_ref) {
+                    Some(ty) => truncate_to_type(!n, ty),
+                    None => !n,
+                };
+                Ok(Some(ConstValue::Integer(v)))
+            }
+
+            // Comptime block: comptime { expr } is compile-time evaluable if its inner expr is
+            InstData::Comptime { expr } => self.eval_const_expr(*expr, env),
+
+            // Block: evaluate `let` statements into the environment, then the
+            // tail expression. Loops, assignments and calls are not supported
+            // and make the block non-evaluable.
+            InstData::Block { extra_start, len } => {
+                if *len == 0 {
+                    return Ok(Some(ConstValue::Unit));
+                }
+                let stmt_refs: Vec<InstRef> = self
+                    .rir
+                    .get_extra(*extra_start, *len)
+                    .iter()
+                    .map(|&raw| InstRef::from_raw(raw))
+                    .collect();
+                // Bindings are scoped to the block.
+                let saved_locals = env.locals.clone();
+                let mut result = Some(ConstValue::Unit);
+                for (i, &stmt_ref) in stmt_refs.iter().enumerate() {
+                    let is_tail = i + 1 == stmt_refs.len();
+                    let value =
+                        if let InstData::Alloc { name, init, .. } = &self.rir.get(stmt_ref).data {
+                            let (name, init) = (*name, *init);
+                            let Some(v) = self.eval_const_expr(init, env)? else {
+                                env.locals = saved_locals;
+                                return Ok(None);
+                            };
+                            if let Some(name) = name {
+                                env.locals.insert(name, v);
+                            }
+                            // A `let` statement itself evaluates to unit.
+                            ConstValue::Unit
+                        } else {
+                            let Some(v) = self.eval_const_expr(stmt_ref, env)? else {
+                                env.locals = saved_locals;
+                                return Ok(None);
+                            };
+                            v
+                        };
+                    if is_tail {
+                        result = Some(value);
+                    }
+                }
+                env.locals = saved_locals;
+                Ok(result)
+            }
+
+            // Anonymous struct type: evaluate to a comptime type value,
+            // resolving field types through the type substitution.
+            InstData::AnonStructType {
+                fields_start,
+                fields_len,
+                methods_start,
+                methods_len,
+            } => {
+                let field_decls = self.rir.get_field_decls(*fields_start, *fields_len);
+
+                let mut struct_fields = Vec::with_capacity(field_decls.len());
+                for (name_sym, type_sym) in field_decls {
+                    let name_str = self.interner.resolve(&name_sym).to_string();
+                    let Some(field_ty) =
+                        self.resolve_type_for_comptime_with_subst(type_sym, env.type_subst)
+                    else {
+                        return Ok(None);
+                    };
+                    struct_fields.push(StructField {
+                        name: name_str,
+                        ty: field_ty,
+                    });
+                }
+
+                // Extract method signatures for structural equality comparison
+                let method_sigs = self.extract_anon_method_sigs(*methods_start, *methods_len);
+
+                let (struct_ty, _is_new) =
+                    self.find_or_create_anon_struct(&struct_fields, &method_sigs, env.value_subst);
+
+                // Register methods if present and not yet registered for this
+                // struct (it may have been created earlier without methods).
+                if *methods_len > 0 {
+                    let Some(struct_id) = struct_ty.as_struct() else {
+                        return Ok(None);
+                    };
+
+                    let method_refs = self.rir.get_inst_refs(*methods_start, *methods_len);
+                    let first_method_ref = method_refs[0];
+                    let first_method_inst = self.rir.get(first_method_ref);
+                    if let InstData::FnDecl {
+                        name: method_name, ..
+                    } = &first_method_inst.data
+                    {
+                        let needs_registration =
+                            !self.methods.contains_key(&(struct_id, *method_name));
+
+                        if needs_registration
+                            && self
+                                .register_anon_struct_methods_for_comptime_with_subst(
+                                    struct_id,
+                                    struct_ty,
+                                    *methods_start,
+                                    *methods_len,
+                                    span,
+                                    env.type_subst,
+                                    env.value_subst,
+                                )
+                                .is_none()
+                        {
+                            // Registration failure (e.g. duplicate method
+                            // names) makes the type non-evaluable; the
+                            // caller reports the comptime failure.
+                            return Ok(None);
+                        }
+                    }
+                }
+                Ok(Some(ConstValue::Type(struct_ty)))
+            }
+
+            // TypeConst: a type used as a value (e.g., `i32` in `identity(i32, 42)`)
+            InstData::TypeConst { type_name } => {
+                // Type parameters in scope substitute first.
+                if let Some(&ty) = env.type_subst.get(type_name) {
+                    return Ok(Some(ConstValue::Type(ty)));
+                }
+                Ok(self
+                    .resolve_named_type_value(type_name)
+                    .map(ConstValue::Type))
+            }
+
+            // VarRef: comptime let-bindings, comptime parameters, file-level
+            // constants, then type names.
+            InstData::VarRef { name } => {
+                // 1. `let` bindings inside the comptime expression
+                if let Some(&v) = env.locals.get(name) {
+                    return Ok(Some(v));
+                }
+                // 2. Comptime type parameters in scope
+                if let Some(&ty) = env.type_subst.get(name) {
+                    return Ok(Some(ConstValue::Type(ty)));
+                }
+                // 3. Comptime value parameters in scope
+                if let Some(&v) = env.value_subst.get(name) {
+                    return Ok(Some(v));
+                }
+                // 4. File-level constants: evaluate the initializer in a
+                //    fresh file-scope environment.
+                if let Some(info) = self.constants.get(name).cloned() {
+                    if info.ty.is_module() {
+                        // Module constants are namespaces, not values.
+                        return Ok(None);
+                    }
+                    let mut const_env = ComptimeEnv::new();
+                    let value = self.eval_const_expr(info.init, &mut const_env)?;
+                    // Backstop: an integer constant must fit its declared
+                    // type (declaration checking owns the diagnostic).
+                    if let (Some(ConstValue::Integer(v)), Some(_)) = (value, info.ty.int_min()) {
+                        if !const_int_fits(v, info.ty) {
+                            return Ok(None);
+                        }
+                    }
+                    return Ok(value);
+                }
+                // 5. Type names used as values (e.g. `Point` in
+                //    `fn make_type() -> type { Point }`)
+                Ok(self.resolve_named_type_value(name).map(ConstValue::Type))
+            }
+
+            // Everything else requires runtime evaluation
+            _ => Ok(None),
+        }
+    }
+}

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -190,6 +190,11 @@ pub(crate) struct ParamInfo {
     pub ty: Type,
     /// Parameter passing mode
     pub mode: RirParamMode,
+    /// Whether the parameter is declared `comptime` (carried separately from
+    /// `mode`, which stays `Normal` for comptime parameters — see
+    /// `RirParam::is_comptime`). Used to allow forwarding a comptime
+    /// parameter to another function's comptime parameter (spec 4.14:5).
+    pub is_comptime: bool,
 }
 
 /// Context for analyzing instructions within a function.
@@ -473,8 +478,11 @@ impl AnalysisResult {
 /// the value of `N` is stored as a `ConstValue::Integer`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConstValue {
-    /// Integer value (signed to handle arithmetic correctly)
-    Integer(i64),
+    /// Integer value. Backed by `i128` so the full range of every Rue integer
+    /// type is representable (u64 values above `i64::MAX` as well as negative
+    /// signed values). Range checks against the expression's Rue type happen
+    /// in the comptime evaluator (see `sema::comptime_eval`).
+    Integer(i128),
     /// Boolean value
     Bool(bool),
     /// Type value - stores a concrete type for type parameters.
@@ -488,8 +496,22 @@ pub enum ConstValue {
 }
 
 impl ConstValue {
-    /// Try to extract an integer value.
+    /// Try to extract an integer value that fits in an `i64`.
+    ///
+    /// Returns `None` for non-integer values and for integers outside the
+    /// `i64` range (e.g. u64 values above `i64::MAX`). Use [`as_int_value`]
+    /// when the full `i128` backing value is needed.
+    ///
+    /// [`as_int_value`]: ConstValue::as_int_value
     pub fn as_integer(self) -> Option<i64> {
+        match self {
+            ConstValue::Integer(n) => i64::try_from(n).ok(),
+            _ => None,
+        }
+    }
+
+    /// Try to extract the full backing integer value.
+    pub fn as_int_value(self) -> Option<i128> {
         match self {
             ConstValue::Integer(n) => Some(n),
             _ => None,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -31,6 +31,7 @@ mod analysis;
 mod analyze_ops;
 mod anon_structs;
 mod builtins;
+mod comptime_eval;
 mod context;
 mod declarations;
 mod file_paths;

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -279,11 +279,13 @@ fn create_specialized_function(
         base_info.return_type
     };
 
-    let specialized_params: Vec<(Spur, Type, RirParamMode)> = sema
+    let specialized_params: Vec<(Spur, Type, RirParamMode, bool)> = sema
         .param_arena
         .iter(base_info.params)
         .filter(|(_, _, _, is_comptime)| !**is_comptime)
         .map(|(name, ty, mode, _)| {
+            // Comptime parameters were filtered out above, so every
+            // surviving parameter carries is_comptime = false.
             let concrete_ty = if *ty == Type::COMPTIME_TYPE {
                 substitute_param_type(sema, base_info, *name, &type_subst).unwrap_or_else(|| {
                     debug_assert!(false, "type substitution failed for param");
@@ -292,7 +294,7 @@ fn create_specialized_function(
             } else {
                 *ty
             };
-            (*name, concrete_ty, *mode)
+            (*name, concrete_ty, *mode, false)
         })
         .collect();
 

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -853,6 +853,46 @@ impl Type {
         }
     }
 
+    /// Get the bit width of this integer type (8, 16, 32, or 64).
+    ///
+    /// Returns `None` for non-integer types.
+    #[must_use]
+    pub fn int_bit_width(&self) -> Option<u32> {
+        if self.is_integer() {
+            // Tags 0..=3 are i8..i64, 4..=7 are u8..u64; the low two bits
+            // select the width in both groups.
+            Some(8 << (self.0 & 3))
+        } else {
+            None
+        }
+    }
+
+    /// Get the minimum representable value of this integer type.
+    ///
+    /// Returns `None` for non-integer types.
+    #[must_use]
+    pub fn int_min(&self) -> Option<i128> {
+        let width = self.int_bit_width()?;
+        if self.is_signed() {
+            Some(-(1i128 << (width - 1)))
+        } else {
+            Some(0)
+        }
+    }
+
+    /// Get the maximum representable value of this integer type.
+    ///
+    /// Returns `None` for non-integer types.
+    #[must_use]
+    pub fn int_max(&self) -> Option<i128> {
+        let width = self.int_bit_width()?;
+        if self.is_signed() {
+            Some((1i128 << (width - 1)) - 1)
+        } else {
+            Some((1i128 << width) - 1)
+        }
+    }
+
     /// Check if a u64 value can be negated to fit within the range of this signed integer type.
     ///
     /// This is used to allow literals like `2147483648` when negated to `-2147483648` (i32::MIN).
@@ -1748,5 +1788,25 @@ mod tests {
                 ty
             );
         }
+    }
+
+    #[test]
+    fn int_bit_width_min_max() {
+        assert_eq!(Type::I8.int_bit_width(), Some(8));
+        assert_eq!(Type::U16.int_bit_width(), Some(16));
+        assert_eq!(Type::I32.int_bit_width(), Some(32));
+        assert_eq!(Type::U64.int_bit_width(), Some(64));
+        assert_eq!(Type::BOOL.int_bit_width(), None);
+
+        assert_eq!(Type::I8.int_min(), Some(-128));
+        assert_eq!(Type::I8.int_max(), Some(127));
+        assert_eq!(Type::U8.int_min(), Some(0));
+        assert_eq!(Type::U8.int_max(), Some(255));
+        assert_eq!(Type::I64.int_min(), Some(i64::MIN as i128));
+        assert_eq!(Type::I64.int_max(), Some(i64::MAX as i128));
+        assert_eq!(Type::U64.int_min(), Some(0));
+        assert_eq!(Type::U64.int_max(), Some(u64::MAX as i128));
+        assert_eq!(Type::UNIT.int_min(), None);
+        assert_eq!(Type::UNIT.int_max(), None);
     }
 }

--- a/crates/rue-cli-tests/cases/comptime_eval.toml
+++ b/crates/rue-cli-tests/cases/comptime_eval.toml
@@ -1,0 +1,63 @@
+# Typed comptime evaluation (RUE-68/69/70/71, RUE-163).
+#
+# The comptime const evaluator mirrors runtime semantics exactly: arithmetic
+# is checked at the operand type, shifts mask the amount modulo the bit width
+# and truncate the result to the operand width (matching RUE-29's runtime
+# semantics), and the full range of every integer type is representable
+# (negative results, u64 above i64::MAX). These cases pin the *emitted
+# values* end-to-end through the driver, codegen, and the runtime printer.
+
+[section]
+id = "cli.comptime_eval"
+name = "Typed comptime evaluation"
+description = "Comptime results agree with runtime values at every width."
+
+[[case]]
+name = "comptime_values_match_runtime"
+description = "Comptime-evaluated constants print identically to their runtime-computed twins."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    // RUE-71: negative results
+    let a: i32 = comptime { 0 - 1 };
+    // RUE-70: full u64 range
+    let b: u64 = comptime { 18446744073709551615 };
+    let c: u64 = comptime { 4611686018427387904 * 2 };
+    // RUE-69: large shift amounts fold; masking modulo bit width
+    let d: i32 = comptime { 1 << 10 };
+    let e: i32 = comptime { 1 << 33 };
+    // shift result truncates to the operand width
+    let f: u8 = comptime { 3 << 7 };
+    // width-aware bitwise NOT
+    let g: u8 = comptime { ~0 };
+    @dbg(a);
+    @dbg(b);
+    @dbg(c);
+    @dbg(d);
+    @dbg(e);
+    @dbg(f);
+    @dbg(g);
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+stdout = """-1
+18446744073709551615
+9223372036854775808
+1024
+2
+128
+255
+"""
+
+[[case]]
+name = "comptime_intermediate_overflow_rejected"
+description = "An intermediate overflow at the operand type inside comptime is a compile error (RUE-68); the runtime equivalent panics."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    comptime { 100000 * 100000 / 100000 }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E1200", "integer overflow", "i32"]

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -989,3 +989,256 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Typed Comptime Evaluation (RUE-68/69/70/71, RUE-163)
+# =============================================================================
+# The comptime evaluator mirrors runtime semantics exactly: arithmetic is
+# checked at the operands' type, shifts mask/truncate per 4.3a:10, the full
+# range of every integer type is representable, and would-panic operations
+# are compile-time errors (4.14:4).
+
+[[case]]
+name = "comptime_intermediate_overflow_i32_error"
+spec = ["4.14:4"]
+description = "Intermediate i32 overflow inside comptime is a compile error (runtime would panic) - RUE-68"
+source = """
+fn main() -> i32 {
+    comptime { 100000 * 100000 / 100000 }
+}
+"""
+compile_fail = true
+error_contains = "integer overflow"
+
+[[case]]
+name = "comptime_intermediate_overflow_u8_error"
+spec = ["4.14:4"]
+description = "Intermediate u8 overflow inside comptime is a compile error even when the final result fits - RUE-68"
+source = """
+fn main() -> i32 {
+    let x: u8 = comptime { 200 + 100 - 100 };
+    0
+}
+"""
+compile_fail = true
+error_contains = "integer overflow"
+
+[[case]]
+name = "comptime_overflow_i64_boundary_error"
+spec = ["4.14:4"]
+description = "i64 overflow inside comptime is still rejected"
+source = """
+fn main() -> i32 {
+    let x: i64 = comptime { 9223372036854775807 + 1 };
+    0
+}
+"""
+compile_fail = true
+error_contains = "integer overflow"
+
+[[case]]
+name = "comptime_division_by_zero_error"
+spec = ["4.14:4"]
+description = "Constant division by zero inside comptime is a compile error (runtime would panic)"
+source = """
+fn main() -> i32 {
+    comptime { 1 / 0 }
+}
+"""
+compile_fail = true
+error_contains = "division by zero"
+
+[[case]]
+name = "comptime_remainder_by_zero_error"
+spec = ["4.14:4"]
+description = "Constant remainder by zero inside comptime is a compile error (runtime would panic)"
+source = """
+fn main() -> i32 {
+    comptime { 5 % 0 }
+}
+"""
+compile_fail = true
+error_contains = "remainder by zero"
+
+[[case]]
+name = "comptime_signed_min_div_neg_one_error"
+spec = ["4.14:4"]
+description = "MIN / -1 overflows at runtime (8.1:3), so it is a comptime error"
+source = """
+fn main() -> i32 {
+    let x: i64 = comptime { (0 - 9223372036854775807 - 1) / (0 - 1) };
+    0
+}
+"""
+compile_fail = true
+error_contains = "integer overflow"
+
+[[case]]
+name = "comptime_negative_result"
+spec = ["4.14:2"]
+description = "Comptime expressions may evaluate to negative values - RUE-71"
+source = """
+fn main() -> i32 {
+    let x: i32 = comptime { 0 - 1 };
+    x + 43
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_unary_negation"
+spec = ["4.14:2"]
+description = "Unary negation is supported in comptime blocks"
+source = """
+fn main() -> i32 {
+    let x: i32 = comptime { -(2 + 3) };
+    x + 47
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_negative_i8_min"
+spec = ["4.14:2"]
+description = "The most negative i8 value is representable in comptime"
+source = """
+fn main() -> i32 {
+    let x: i8 = comptime { -128 };
+    if x < 0 { 42 } else { 1 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_bitnot_width_aware"
+spec = ["4.14:2"]
+description = "Bitwise NOT truncates to the operand width: ~0 as u8 is 255"
+source = """
+fn main() -> i32 {
+    let x: u8 = comptime { ~0 };
+    if x == 255 { 42 } else { 1 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_shift_large_amount"
+spec = ["4.14:2"]
+description = "Constant shifts with amount >= 8 fold at comptime - RUE-69"
+source = """
+fn main() -> i32 {
+    if comptime { 1 << 10 } == 1024 { 42 } else { 1 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_shift_amount_masked"
+spec = ["4.14:2"]
+description = "Shift amounts mask modulo the bit width (4.3a:10): i32 << 33 == i32 << 1"
+source = """
+fn main() -> i32 {
+    comptime { 1 << 33 }
+}
+"""
+exit_code = 2
+
+[[case]]
+name = "comptime_shift_truncates_to_width"
+spec = ["4.14:2"]
+description = "Shift results truncate to the operand width, matching runtime: 3 << 7 as u8 is 128"
+source = """
+fn main() -> i32 {
+    let x: u8 = comptime { 3 << 7 };
+    if x == 128 { 42 } else { 1 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_u64_max_literal"
+spec = ["4.14:2"]
+description = "The full u64 range is representable in comptime - RUE-70"
+source = """
+fn main() -> i32 {
+    let x: u64 = comptime { 18446744073709551615 };
+    if x == 18446744073709551615 { 42 } else { 1 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_u64_above_i64_max_arith"
+spec = ["4.14:2"]
+description = "u64 arithmetic above i64::MAX evaluates at comptime - RUE-70"
+source = """
+fn main() -> i32 {
+    let x: u64 = comptime { 4611686018427387904 * 2 };
+    if x == 9223372036854775808 { 42 } else { 1 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_let_bindings_in_block"
+spec = ["4.14:2"]
+description = "Comptime blocks support let statements followed by a tail expression"
+source = """
+fn main() -> i32 {
+    comptime { let a = 2; let b = a + 1; a * b * 7 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_file_level_const"
+spec = ["4.14:2"]
+description = "File-level constants are usable inside comptime blocks"
+source = """
+const N = 7;
+fn main() -> i32 {
+    comptime { N * 6 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_logical_short_circuit"
+spec = ["4.14:2"]
+description = "&& short-circuits at comptime, mirroring runtime (the would-panic RHS is never evaluated)"
+source = """
+fn main() -> i32 {
+    if comptime { false && 1 / 0 == 1 } { 1 } else { 42 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_forwarding"
+spec = ["4.14:5"]
+description = "A comptime parameter may be forwarded to another function's comptime parameter"
+source = """
+fn g(comptime m: i32) -> i32 { m * 2 }
+fn f(comptime n: i32) -> i32 { g(n) }
+fn main() -> i32 {
+    f(21)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_forward_shadowed_rejected"
+spec = ["4.14:6"]
+description = "A runtime local shadowing a comptime parameter is not comptime-known"
+source = """
+fn g(comptime m: i32) -> i32 { m * 2 }
+fn f(comptime n: i32, x: i32) -> i32 {
+    let n = x;
+    g(n)
+}
+fn main() -> i32 {
+    f(5, 1)
+}
+"""
+compile_fail = true
+error_contains = "comptime parameter requires a compile-time known value"

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -13,17 +13,22 @@ A compile-time expression is an expression marked with the `comptime` keyword th
 {{ rule(id="4.14:2", cat="normative") }}
 
 ```ebnf
-comptime_expr = "comptime" "{" expression "}" ;
+comptime_expr = "comptime" "{" block "}" ;
+block         = { statement } [ expression ] ;
 ```
 
-The expression inside a comptime block is evaluated during compilation. The following operations are supported within comptime blocks:
+The block inside a comptime expression is evaluated during compilation. It may contain `let` statements followed by a tail expression; the comptime expression evaluates to the value of the tail expression. The following operations are supported within comptime blocks:
 
 - Integer literals
 - Boolean literals (`true`, `false`)
-- Arithmetic operators (`+`, `-`, `*`, `/`, `%`)
+- Arithmetic operators (`+`, `-`, `*`, `/`, `%`) and unary negation (`-`)
 - Comparison operators (`==`, `!=`, `<`, `<=`, `>`, `>=`)
 - Logical operators (`&&`, `||`, `!`)
-- Bitwise operators (`&`, `|`, `^`, `<<`, `>>`)
+- Bitwise operators (`&`, `|`, `^`, `<<`, `>>`, `~`)
+- `let` bindings of comptime values
+- References to file-level constants and to `comptime` parameters in scope
+
+Evaluation follows runtime semantics exactly: arithmetic is checked at the operands' type (Chapter 8.1), the full value range of every integer type is supported (including negative results and `u64` values above `i64::MAX`), shift amounts are masked modulo the bit width and shift results truncate to the operand width (4.3a:10), and `&&`/`||` short-circuit.
 
 {{ rule(id="4.14:3", cat="normative") }}
 
@@ -44,7 +49,7 @@ It is a compile-time error if an expression inside a comptime block cannot be ev
 
 - References to runtime variables
 - Function calls (except to comptime-evaluable functions in future versions)
-- Operations that would panic at runtime
+- Operations that would panic at runtime: integer overflow at the operands' type (including in intermediate results), division by zero, and remainder by zero
 
 ```rue
 fn main() -> i32 {


### PR DESCRIPTION
Executes the core of the RUE-163 epic: `try_evaluate_const` was an **untyped i64 expression walker** duplicated in two places, with ad-hoc gates bolted onto the Comptime handler (any negative result rejected, shifts ≥ 8 bailed, u64 unrepresentable, and intermediate overflow invisible). One typed evaluator (`rue-air/src/sema/comptime_eval.rs`) replaces both copies (−767 lines); `ConstValue::Integer` is i128-backed and every operation is checked at the HM-resolved operand type.

- **RUE-68** — intermediate overflow / div-by-zero / MIN÷-1 inside comptime are now compile errors (E1200 naming the op and type), matching what the runtime panics on. `comptime { 200 + 100 - 100 }` as u8 is rejected.
- **RUE-69** — all constant shifts fold: amount masked modulo bit width, result truncated to operand width (exactly the RUE-29 runtime semantics). `comptime { 1 << 10 }` == 1024.
- **RUE-70** — full u64 range. `comptime { 18446744073709551615 }` works.
- **RUE-71** — negative results legal; width-aware `~` (`comptime { ~0 }` as u8 == 255).
- **Also**: file-level consts visible inside comptime blocks; multi-statement `let` blocks (spec 4.14:2 updated to the block grammar the parser and appendix already agreed on); short-circuit `&&`/`||`; comptime-param forwarding `g(n)`. Opportunistic const-fold callers still defer would-panic constants to runtime (the trap fires there, per RUE-57/147 precedent).

**Residual** (filed as RUE-166 under the epic): comptime value params aren't monomorphized per value, so `comptime { n + 1 }` directly in the body and comptime recursion still E1200.

20 new spec cases + a `comptime_eval.toml` CLI suite with exact stdout; traceability 100%. Target-independent — codegen untouched. Verified post-integration: the five-facet matrix above by execution.

Note: #973 (annotation typing) touches the analysis.rs const-eval arms this PR deletes — whichever lands second needs a rebase; the resolution is to keep this PR's deletion and verify the new evaluator parses type names through #973's shared `Type::from_primitive_name`.

Fixes RUE-68
Fixes RUE-69
Fixes RUE-70
Fixes RUE-71
Part of RUE-163

🤖 Generated with [Claude Code](https://claude.com/claude-code)