### PR TITLE
Sub-word BitNot narrowing, flags-aware peephole, constprop for let-bound constants

### DIFF
--- a/crates/rue-cfg/src/opt/constfold.rs
+++ b/crates/rue-cfg/src/opt/constfold.rs
@@ -23,20 +23,25 @@ use rue_air::{EnumId, Type, TypeKind};
 /// Run constant folding on the CFG.
 ///
 /// This iterates over all instructions and replaces operations on
-/// constants with constant results.
-pub fn run(cfg: &mut Cfg) {
+/// constants with constant results. Returns `true` if anything was folded
+/// (the optimize driver interleaves this with constprop until neither
+/// changes anything).
+pub fn run(cfg: &mut Cfg) -> bool {
     // We iterate by index since we need to look up other instructions
     // while potentially modifying the current one.
     let value_count = cfg.value_count();
 
+    let mut changed = false;
     for i in 0..value_count {
         let value = CfgValue::from_raw(i as u32);
-        fold_instruction(cfg, value);
+        changed |= fold_instruction(cfg, value);
     }
+    changed
 }
 
 /// Try to fold a single instruction if it operates on constants.
-fn fold_instruction(cfg: &mut Cfg, value: CfgValue) {
+/// Returns `true` if the instruction was replaced by a constant.
+fn fold_instruction(cfg: &mut Cfg, value: CfgValue) -> bool {
     // Get the instruction data and type
     let inst = cfg.get_inst(value);
     let ty = inst.ty;
@@ -115,6 +120,9 @@ fn fold_instruction(cfg: &mut Cfg, value: CfgValue) {
         let inst = cfg.get_inst_mut(value);
         inst.data = new_data;
         inst.span = span; // Preserve original span
+        true
+    } else {
+        false
     }
 }
 

--- a/crates/rue-cfg/src/opt/constprop.rs
+++ b/crates/rue-cfg/src/opt/constprop.rs
@@ -1,0 +1,322 @@
+//! Store-to-load constant propagation for local slots.
+//!
+//! CfgBuilder materializes every `let` as a stack slot: the initializer
+//! becomes an `Alloc` and each later use a `Load`. Constant folding only
+//! sees literal `Const` operands, so without this pass
+//! `let a = -2147483648; let q = a / -1;` never folds even though `a` is a
+//! compile-time constant (RUE-154).
+//!
+//! ## What it does
+//!
+//! For each local slot with exactly ONE whole-slot write (its `Alloc`, or a
+//! single `Store`) whose value is a `Const`/`BoolConst`, and that is never
+//! written through any other channel, every `Load` of the slot is replaced
+//! by that constant. Interleaved with constfold (see [`super::optimize`]),
+//! this lets constants flow through chains of single-assignment lets.
+//!
+//! ## Safety argument
+//!
+//! - Slots written more than once (mutated variables) are skipped.
+//! - Partial or aliased writes disqualify the slot: `FieldSet`/`IndexSet`/
+//!   `PlaceWrite`, and by-ref (`inout`/`borrow`) call arguments — those pass
+//!   the slot's ADDRESS to the callee, which may write through it, and the
+//!   by-ref lowering requires the argument to stay a place (`Load`) anyway.
+//! - Dominance: with a single write site, sema's definite-initialization
+//!   guarantee means every `Load` executes after (an execution of) the
+//!   write, and the write always stores the same constant.
+
+use crate::{Cfg, CfgInstData, PlaceBase};
+
+/// State of a local slot while scanning for writes.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SlotState {
+    /// No write seen yet.
+    NoWrite,
+    /// Exactly one whole-slot write of this constant payload.
+    OneConstWrite(ConstPayload),
+    /// Multiple writes, a non-constant write, a partial write, or the
+    /// slot's address escapes (by-ref call argument).
+    Disqualified,
+}
+
+/// The constant payloads we propagate.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ConstPayload {
+    Int(u64),
+    Bool(bool),
+}
+
+/// Run store-to-load constant propagation on the CFG.
+///
+/// Returns `true` if any `Load` was replaced (callers re-run constfold to
+/// fold the newly exposed constant operands).
+pub fn run(cfg: &mut Cfg) -> bool {
+    let mut slots = vec![SlotState::NoWrite; cfg.num_locals() as usize];
+
+    let record_write = |slots: &mut Vec<SlotState>, slot: u32, payload: Option<ConstPayload>| {
+        let state = &mut slots[slot as usize];
+        *state = match (*state, payload) {
+            (SlotState::NoWrite, Some(c)) => SlotState::OneConstWrite(c),
+            _ => SlotState::Disqualified,
+        };
+    };
+
+    // Pass 1: classify every local slot by the writes it receives. Only
+    // instructions still attached to a block matter; values orphaned by
+    // earlier passes never execute.
+    for block_idx in 0..cfg.block_count() {
+        let block_id = crate::BlockId::from_raw(block_idx as u32);
+        for i in 0..cfg.get_block(block_id).insts.len() {
+            let value = cfg.get_block(block_id).insts[i];
+            match &cfg.get_inst(value).data {
+                CfgInstData::Alloc { slot, init } | CfgInstData::Store { slot, value: init } => {
+                    let payload = match &cfg.get_inst(*init).data {
+                        CfgInstData::Const(v) => Some(ConstPayload::Int(*v)),
+                        CfgInstData::BoolConst(b) => Some(ConstPayload::Bool(*b)),
+                        _ => None,
+                    };
+                    record_write(&mut slots, *slot, payload);
+                }
+                // Partial writes: the slot's contents change through a
+                // projection, so its Loads are not the stored constant.
+                CfgInstData::FieldSet { slot, .. } | CfgInstData::IndexSet { slot, .. } => {
+                    record_write(&mut slots, *slot, None);
+                }
+                CfgInstData::PlaceWrite { place, .. } => {
+                    if let PlaceBase::Local(slot) = place.base {
+                        record_write(&mut slots, slot, None);
+                    }
+                }
+                // By-ref call arguments pass the ADDRESS of the argument
+                // place: the callee may write through it (inout), and the
+                // by-ref lowering needs the arg to remain a Load/PlaceRead.
+                // Disqualify any local the argument is rooted at.
+                CfgInstData::Call {
+                    args_start,
+                    args_len,
+                    ..
+                } => {
+                    let byref_args: Vec<_> = cfg
+                        .get_call_args(*args_start, *args_len)
+                        .iter()
+                        .filter(|a| a.is_by_ref())
+                        .map(|a| a.value)
+                        .collect();
+                    for arg_value in byref_args {
+                        match &cfg.get_inst(arg_value).data {
+                            CfgInstData::Load { slot } => {
+                                record_write(&mut slots, *slot, None);
+                            }
+                            CfgInstData::PlaceRead { place } => {
+                                if let PlaceBase::Local(slot) = place.base {
+                                    record_write(&mut slots, slot, None);
+                                }
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    // Pass 2: rewrite Loads of single-constant slots.
+    let mut changed = false;
+    for value_idx in 0..cfg.value_count() {
+        let value = crate::CfgValue::from_raw(value_idx as u32);
+        let slot = match &cfg.get_inst(value).data {
+            CfgInstData::Load { slot } => *slot,
+            _ => continue,
+        };
+        if let SlotState::OneConstWrite(payload) = slots[slot as usize] {
+            cfg.get_inst_mut(value).data = match payload {
+                ConstPayload::Int(v) => CfgInstData::Const(v),
+                ConstPayload::Bool(b) => CfgInstData::BoolConst(b),
+            };
+            changed = true;
+        }
+    }
+
+    changed
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{CfgArgMode, CfgCallArg, CfgInst, CfgValue, Terminator, Type};
+    use lasso::{Key, Spur};
+    use rue_span::Span;
+
+    fn make_cfg(num_locals: u32) -> Cfg {
+        let mut cfg = Cfg::new(Type::I32, num_locals, 0, "test".to_string(), vec![]);
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg
+    }
+
+    fn push(cfg: &mut Cfg, data: CfgInstData, ty: Type) -> CfgValue {
+        let entry = cfg.entry;
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data,
+                ty,
+                span: Span::new(0, 0),
+            },
+        )
+    }
+
+    #[test]
+    fn test_propagates_single_const_alloc() {
+        let mut cfg = make_cfg(1);
+        let c = push(&mut cfg, CfgInstData::Const(7), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: c },
+            Type::UNIT,
+        );
+        let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(load) });
+
+        assert!(run(&mut cfg));
+        match &cfg.get_inst(load).data {
+            CfgInstData::Const(7) => {}
+            other => panic!("Expected Const(7), got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_propagates_bool_const() {
+        let mut cfg = make_cfg(1);
+        let c = push(&mut cfg, CfgInstData::BoolConst(true), Type::BOOL);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: c },
+            Type::UNIT,
+        );
+        let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::BOOL);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(load) });
+
+        assert!(run(&mut cfg));
+        assert!(matches!(
+            cfg.get_inst(load).data,
+            CfgInstData::BoolConst(true)
+        ));
+    }
+
+    #[test]
+    fn test_mutated_slot_not_propagated() {
+        // let a = 1; a = 2; a -> two writes, must not propagate either.
+        let mut cfg = make_cfg(1);
+        let c1 = push(&mut cfg, CfgInstData::Const(1), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: c1 },
+            Type::UNIT,
+        );
+        let c2 = push(&mut cfg, CfgInstData::Const(2), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Store { slot: 0, value: c2 },
+            Type::UNIT,
+        );
+        let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(load) });
+
+        assert!(!run(&mut cfg));
+        assert!(matches!(
+            cfg.get_inst(load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
+    }
+
+    #[test]
+    fn test_non_const_init_not_propagated() {
+        let mut cfg = make_cfg(2);
+        let c = push(&mut cfg, CfgInstData::Const(3), Type::I32);
+        let sum = push(&mut cfg, CfgInstData::Add(c, c), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: sum },
+            Type::UNIT,
+        );
+        let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(load) });
+
+        assert!(!run(&mut cfg));
+        assert!(matches!(
+            cfg.get_inst(load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
+    }
+
+    #[test]
+    fn test_byref_call_arg_disqualifies_slot() {
+        // f(inout a): the callee may rewrite a, and the by-ref lowering
+        // needs the Load to remain a place. Nothing may be propagated.
+        let mut cfg = make_cfg(1);
+        let c = push(&mut cfg, CfgInstData::Const(5), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: c },
+            Type::UNIT,
+        );
+        let arg_load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        let (args_start, args_len) = cfg.push_call_args([CfgCallArg {
+            value: arg_load,
+            mode: CfgArgMode::Inout,
+        }]);
+        push(
+            &mut cfg,
+            CfgInstData::Call {
+                name: Spur::try_from_usize(0).unwrap(),
+                args_start,
+                args_len,
+            },
+            Type::UNIT,
+        );
+        let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: Some(load) });
+
+        assert!(!run(&mut cfg));
+        assert!(matches!(
+            cfg.get_inst(arg_load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
+        assert!(matches!(
+            cfg.get_inst(load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
+    }
+
+    #[test]
+    fn test_normal_call_arg_still_propagates() {
+        // f(a) by value: the slot is only read; propagation is fine.
+        let mut cfg = make_cfg(1);
+        let c = push(&mut cfg, CfgInstData::Const(5), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: c },
+            Type::UNIT,
+        );
+        let arg_load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::I32);
+        let (args_start, args_len) = cfg.push_call_args([CfgCallArg {
+            value: arg_load,
+            mode: CfgArgMode::Normal,
+        }]);
+        push(
+            &mut cfg,
+            CfgInstData::Call {
+                name: Spur::try_from_usize(0).unwrap(),
+                args_start,
+                args_len,
+            },
+            Type::UNIT,
+        );
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: None });
+
+        assert!(run(&mut cfg));
+        assert!(matches!(cfg.get_inst(arg_load).data, CfgInstData::Const(5)));
+    }
+}

--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -21,6 +21,7 @@
 //! ```
 
 mod constfold;
+mod constprop;
 mod dce;
 
 use crate::Cfg;
@@ -134,8 +135,19 @@ pub fn optimize(cfg: &mut Cfg, level: OptLevel) {
             // No optimization
         }
         OptLevel::O1 | OptLevel::O2 | OptLevel::O3 => {
-            // Constant folding: fold operations on compile-time constants
-            constfold::run(cfg);
+            // Interleave constant folding with store-to-load constant
+            // propagation until a fixpoint: folding a let's initializer can
+            // expose a constant store, and propagating it into Loads can
+            // expose new foldable operations (chains of single-assignment
+            // lets, RUE-154). Terminates because every change replaces a
+            // non-constant instruction with a constant.
+            loop {
+                let folded = constfold::run(cfg);
+                let propagated = constprop::run(cfg);
+                if !folded && !propagated {
+                    break;
+                }
+            }
 
             // Dead code elimination: remove unused values and unreachable blocks
             dce::run(cfg);

--- a/crates/rue-cli-tests/cases/bitnot_subword.toml
+++ b/crates/rue-cli-tests/cases/bitnot_subword.toml
@@ -1,0 +1,99 @@
+# Runtime sub-word bitwise-NOT regression tests (RUE-162).
+#
+# The runtime BitNot lowering on both backends flipped all 32 register bits
+# (`not r32` / `mvn w`) and never narrowed the result back to a sub-word
+# (8/16-bit) operand's width, so `~0u8` left 0xFFFFFFFF in the register —
+# 32-bit comparisons against the canonical 255 then failed. The constant-
+# folded form was already correct (RUE-59), masking the bug at -O1+ for
+# literal operands; routing the operand through a function call exposes the
+# runtime path at every opt level. Fixed by narrowing the NOT result with
+# the same sign-/zero-extension used for left shifts (RUE-29).
+
+[section]
+id = "cli.bitnot_subword"
+name = "Sub-word runtime bitwise NOT"
+description = "Runtime ~ on u8/u16/i8/i16 must be truncated to the operand's width."
+
+[[case]]
+name = "u8_runtime_bitnot"
+description = "~0u8 through a call operand is 255, not 0xFFFFFFFF (the RUE-162 repro)."
+files = [{ path = "main.rue", source = """
+fn id(v: u8) -> u8 { v }
+fn main() -> i32 {
+    let x: u8 = ~id(0);
+    if x == 255 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "u16_runtime_bitnot"
+files = [{ path = "main.rue", source = """
+fn id(v: u16) -> u16 { v }
+fn main() -> i32 {
+    let x: u16 = ~id(0);
+    if x == 65535 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "i8_runtime_bitnot"
+description = "~0i8 is -1 (sign-extended), and ~5i8 is -6."
+files = [{ path = "main.rue", source = """
+fn id(v: i8) -> i8 { v }
+fn main() -> i32 {
+    let x: i8 = ~id(0);
+    if x != 0 - 1 { return 1; }
+    let y: i8 = ~id(5);
+    if y != 0 - 6 { return 2; }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "i16_runtime_bitnot"
+files = [{ path = "main.rue", source = """
+fn id(v: i16) -> i16 { v }
+fn main() -> i32 {
+    let x: i16 = ~id(0);
+    if x != 0 - 1 { return 1; }
+    let y: i16 = ~id(5);
+    if y != 0 - 6 { return 2; }
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "u8_bitnot_roundtrip_O2"
+description = "~~v restores v for sub-word operands at -O2 (runtime path through calls)."
+files = [{ path = "main.rue", source = """
+fn id(v: u8) -> u8 { v }
+fn main() -> i32 {
+    let x: u8 = ~id(255);
+    if x != 0 { return 1; }
+    let y: u8 = ~x;
+    if y != 255 { return 2; }
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 0
+
+# Control: the constant form folds at -O1 (constfold was already
+# width-correct per RUE-59); the folded and runtime paths must agree.
+[[case]]
+name = "constant_form_control_O1"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: u8 = ~0;
+    if a != 255 { return 1; }
+    let b: i16 = ~5;
+    if b != 0 - 6 { return 2; }
+    0
+}
+""" }]
+args = ["main.rue", "-O1", "-o", "prog"]
+exit_code = 0

--- a/crates/rue-cli-tests/cases/constprop.toml
+++ b/crates/rue-cli-tests/cases/constprop.toml
@@ -1,0 +1,157 @@
+# Store-to-load constant propagation tests (RUE-154).
+#
+# CfgBuilder materializes every `let` as a stack slot, so constfold (which
+# only sees literal Const operands) never folded `let a = -2147483648;
+# a / -1` — only the direct-literal form. Constprop now forwards
+# single-assignment let-bound constants into their Loads, interleaved with
+# constfold to a fixpoint.
+#
+# The MIN/-1 cases pin the interaction with RUE-30/RUE-147: constfold
+# REFUSES to fold MIN/-1 (the quotient is unrepresentable), so even with
+# propagation the division stays a runtime op and the mandatory overflow
+# trap must fire at every opt level.
+
+[section]
+id = "cli.constprop"
+name = "Let-bound constant propagation"
+description = "Single-assignment let-bound constants reach div/mod; the MIN/-1 trap survives at every opt level."
+
+[[case]]
+name = "letbound_min_div_neg1_traps_O0"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = -2147483648;
+    let q = a / -1;
+    q
+}
+""" }]
+args = ["main.rue", "-O0", "-o", "prog"]
+runtime_error_contains = ["integer overflow"]
+exit_code = 101
+
+[[case]]
+name = "letbound_min_div_neg1_traps_O1"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = -2147483648;
+    let q = a / -1;
+    q
+}
+""" }]
+args = ["main.rue", "-O1", "-o", "prog"]
+runtime_error_contains = ["integer overflow"]
+exit_code = 101
+
+[[case]]
+name = "letbound_min_div_neg1_traps_O2"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = -2147483648;
+    let q = a / -1;
+    q
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+runtime_error_contains = ["integer overflow"]
+exit_code = 101
+
+[[case]]
+name = "letbound_min_mod_neg1_traps_O2"
+description = "MIN % -1 overflows like MIN / -1; the trap survives propagation."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i64 = -9223372036854775808;
+    let r = a % -1;
+    @intCast(r)
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+runtime_error_contains = ["integer overflow"]
+exit_code = 101
+
+[[case]]
+name = "letbound_div_mod_value_O1"
+description = "Let-bound constants propagate into div/mod and fold to the right values."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = 84;
+    let b: i32 = 2;
+    let q = a / b;     // 42
+    let r = a % 5;     // 4
+    q + r
+}
+""" }]
+args = ["main.rue", "-O1", "-o", "prog"]
+exit_code = 46
+
+[[case]]
+name = "letbound_div_mod_value_O0"
+description = "Control: the unoptimized runtime path computes the same values."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = 84;
+    let b: i32 = 2;
+    let q = a / b;     // 42
+    let r = a % 5;     // 4
+    q + r
+}
+""" }]
+args = ["main.rue", "-O0", "-o", "prog"]
+exit_code = 46
+
+[[case]]
+name = "letbound_chain_folds_O1"
+description = "Constants flow through chains of single-assignment lets (fold/prop fixpoint)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = 5;
+    let b: i32 = a + 2;    // 7
+    let c: i32 = b * 6;    // 42
+    c / a                  // 8
+}
+""" }]
+args = ["main.rue", "-O1", "-o", "prog"]
+exit_code = 8
+
+[[case]]
+name = "mutated_let_not_mispropagated_O1"
+description = "A reassigned variable has two stores; its loads must NOT be replaced by the initializer."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut a: i32 = 10;
+    a = 20;
+    a / 2
+}
+""" }]
+args = ["main.rue", "-O1", "-o", "prog"]
+exit_code = 10
+
+[[case]]
+name = "inout_arg_not_mispropagated_O1"
+description = "A let whose address is passed inout may be rewritten by the callee; do not propagate."
+files = [{ path = "main.rue", source = """
+fn bump(inout v: i32) {
+    v = v + 1;
+}
+fn main() -> i32 {
+    let a: i32 = 41;
+    bump(inout a);
+    a
+}
+""" }]
+args = ["main.rue", "-O1", "-o", "prog"]
+exit_code = 42
+
+[[case]]
+name = "letbound_div_by_zero_traps_O2"
+description = "Propagation must not fold away the division-by-zero trap (constfold refuses b == 0)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = 7;
+    let b: i32 = 0;
+    a / b
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+runtime_error_contains = ["division by zero"]
+exit_code = 101

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1034,6 +1034,10 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(operand_vreg),
                     }
                 });
+                // MVN flips all 32 w-register bits, setting bits above a
+                // sub-word operand's width (e.g. ~0u8 leaves 0xFFFFFFFF, not
+                // 0xFF); narrow back to the operand's type (RUE-162).
+                self.emit_subword_narrow(vreg, ty);
             }
 
             CfgInstData::BitAnd(lhs, rhs) => {

--- a/crates/rue-codegen/src/aarch64/peephole.rs
+++ b/crates/rue-codegen/src/aarch64/peephole.rs
@@ -17,8 +17,25 @@
 //! - `add r, r, #a` + `add r, r, #b` → `add r, r, #(a+b)` (when sum fits in i32)
 //!
 //! The pass operates in-place on the instruction vector for efficiency.
+//!
+//! ## NZCV invariant (RUE-152)
+//!
+//! A rewrite may not change the flag values a later reader observes.
+//! `cmp r, #0` and `tst r, r` produce the same N, Z and V (V=0 for both)
+//! but OPPOSITE C: `cmp` with 0 never borrows (C=1) while `tst` clears C.
+//! The rewrite is therefore only applied when every reader of the resulting
+//! flags — every `b.cond`/`cset` before the next flags writer — uses a
+//! C-free condition (eq/ne and the signed lt/gt/le/ge, which read N, Z and
+//! V only). If the flags escape this straight-line window (a label or an
+//! unconditional branch is reached first), the rewrite is skipped. See
+//! [`cmp_zero_to_tst_safe`].
+//!
+//! The removals and the add/sub combining here only touch non-flag-setting
+//! instructions (`add`/`sub`/`mov`/shifts/`eor` without the S suffix), so
+//! they need no flags gate.
 
-use super::mir::{Aarch64Inst, Operand, Reg};
+use super::mir::{Aarch64Inst, Cond, Operand, Reg};
+use super::schedule::writes_flags;
 
 /// Apply peephole optimizations to the instruction stream.
 ///
@@ -28,9 +45,9 @@ pub fn optimize(instructions: &mut Vec<Aarch64Inst>) -> usize {
     let mut changes = 0;
 
     // Pass 1: Single-instruction transforms (mov 0 -> mov xzr, cmp 0 -> tst)
-    for inst in instructions.iter_mut() {
-        if let Some(new_inst) = transform_single(inst) {
-            *inst = new_inst;
+    for i in 0..instructions.len() {
+        if let Some(new_inst) = transform_single(instructions, i) {
+            instructions[i] = new_inst;
             changes += 1;
         }
     }
@@ -46,24 +63,64 @@ pub fn optimize(instructions: &mut Vec<Aarch64Inst>) -> usize {
     changes
 }
 
-/// Transform a single instruction to a more efficient form.
+/// Check whether `cmp r, #0` at `idx` may be rewritten to `tst r, r`.
 ///
-/// Returns `Some(new_inst)` if a transformation was applied, `None` otherwise.
-fn transform_single(inst: &Aarch64Inst) -> Option<Aarch64Inst> {
-    match inst {
+/// The two differ only in C (cmp sets it, tst clears it), so the rewrite is
+/// safe iff no reader of these flags consumes C. Scans forward from
+/// `idx + 1`:
+/// - `b.cond` / `cset` with a C-reading condition (hs/lo/hi/ls) → unsafe
+/// - `b.cond` / `cset` with a C-free condition, or `b.vs`/`b.vc` (V is 0
+///   after both forms) → fine; keep scanning for more readers
+/// - a flags writer → safe (flags overwritten before any further read)
+/// - call/svc/ret → safe (NZCV is not live across these per the AAPCS)
+/// - label or unconditional branch → conservatively unsafe (flags escape)
+/// - end of stream → safe
+fn cmp_zero_to_tst_safe(instructions: &[Aarch64Inst], idx: usize) -> bool {
+    for inst in &instructions[idx + 1..] {
+        match inst {
+            Aarch64Inst::BCond { cond, .. } | Aarch64Inst::Cset { cond, .. } => {
+                if cond_reads_carry(*cond) {
+                    return false;
+                }
+            }
+            // V is 0 after both cmp r, #0 and tst r, r.
+            Aarch64Inst::Bvs { .. } | Aarch64Inst::Bvc { .. } => {}
+            Aarch64Inst::B { .. } | Aarch64Inst::Label { .. } => return false,
+            Aarch64Inst::Bl { .. } | Aarch64Inst::Svc { .. } | Aarch64Inst::Ret => return true,
+            inst if writes_flags(inst) => return true,
+            _ => {}
+        }
+    }
+    true
+}
+
+/// Conditions that read the carry flag — exactly the unsigned comparisons.
+fn cond_reads_carry(cond: Cond) -> bool {
+    matches!(cond, Cond::Hs | Cond::Lo | Cond::Hi | Cond::Ls)
+}
+
+/// Transform the instruction at `idx` to a more efficient form.
+///
+/// Returns `Some(new_inst)` if a transformation applies, `None` otherwise.
+fn transform_single(instructions: &[Aarch64Inst], idx: usize) -> Option<Aarch64Inst> {
+    match &instructions[idx] {
         // mov r, #0 → mov r, xzr (use zero register)
         // On AArch64, using the zero register is often more efficient.
+        // Neither form touches NZCV, so no flags gate is needed.
         Aarch64Inst::MovImm { dst, imm: 0 } => Some(Aarch64Inst::MovRR {
             dst: *dst,
             src: Operand::Physical(Reg::Xzr),
         }),
 
-        // cmp r, #0 → tst r, r (same flags, sometimes faster)
-        // tst sets ZF=1 if r==0, same as cmp r, 0
-        Aarch64Inst::CmpImm { src, imm: 0 } => Some(Aarch64Inst::TstRR {
-            src1: *src,
-            src2: *src,
-        }),
+        // cmp r, #0 → tst r, r (same N/Z/V, sometimes faster)
+        // C FLIPS (cmp sets it, tst clears it), so only legal when no
+        // consumer reads C — see cmp_zero_to_tst_safe (RUE-152).
+        Aarch64Inst::CmpImm { src, imm: 0 } if cmp_zero_to_tst_safe(instructions, idx) => {
+            Some(Aarch64Inst::TstRR {
+                src1: *src,
+                src2: *src,
+            })
+        }
 
         _ => None,
     }
@@ -744,6 +801,153 @@ mod tests {
         ));
         assert!(matches!(instructions[2], Aarch64Inst::TstRR { .. }));
         assert!(matches!(instructions[3], Aarch64Inst::Ret));
+    }
+
+    // ==================== NZCV Hazard Tests (RUE-152) ====================
+
+    use crate::aarch64::mir::{Cond, LabelId};
+
+    #[test]
+    fn test_cmp_zero_to_tst_fires_with_carry_free_consumer() {
+        // b.eq reads only Z, identical under tst: the rewrite STILL fires.
+        let mut instructions = vec![
+            Aarch64Inst::CmpImm {
+                src: Operand::Physical(Reg::X0),
+                imm: 0,
+            },
+            Aarch64Inst::BCond {
+                cond: Cond::Eq,
+                label: LabelId::new(0),
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        let changes = optimize(&mut instructions);
+
+        assert_eq!(changes, 1);
+        assert!(matches!(instructions[0], Aarch64Inst::TstRR { .. }));
+    }
+
+    #[test]
+    fn test_cmp_zero_to_tst_fires_with_signed_consumer() {
+        // Signed conditions read N/Z/V, all identical under tst (V=0 both).
+        let mut instructions = vec![
+            Aarch64Inst::CmpImm {
+                src: Operand::Physical(Reg::X0),
+                imm: 0,
+            },
+            Aarch64Inst::Cset {
+                dst: Operand::Physical(Reg::X1),
+                cond: Cond::Lt,
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        let changes = optimize(&mut instructions);
+
+        assert_eq!(changes, 1);
+        assert!(matches!(instructions[0], Aarch64Inst::TstRR { .. }));
+    }
+
+    #[test]
+    fn test_cmp_zero_to_tst_blocked_by_unsigned_branch() {
+        // b.hs reads C, which cmp #0 sets (no borrow) but tst clears: the
+        // rewrite would flip the branch. It must NOT fire.
+        let mut instructions = vec![
+            Aarch64Inst::CmpImm {
+                src: Operand::Physical(Reg::X0),
+                imm: 0,
+            },
+            Aarch64Inst::BCond {
+                cond: Cond::Hs,
+                label: LabelId::new(0),
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        let changes = optimize(&mut instructions);
+
+        assert_eq!(changes, 0);
+        assert!(matches!(
+            instructions[0],
+            Aarch64Inst::CmpImm { imm: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn test_cmp_zero_to_tst_blocked_by_unsigned_cset() {
+        let mut instructions = vec![
+            Aarch64Inst::CmpImm {
+                src: Operand::Physical(Reg::X0),
+                imm: 0,
+            },
+            Aarch64Inst::Cset {
+                dst: Operand::Physical(Reg::X1),
+                cond: Cond::Lo,
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        let changes = optimize(&mut instructions);
+
+        assert_eq!(changes, 0);
+        assert!(matches!(
+            instructions[0],
+            Aarch64Inst::CmpImm { imm: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn test_cmp_zero_to_tst_blocked_by_label() {
+        // Flags escape into a join point; conservatively keep the cmp.
+        let mut instructions = vec![
+            Aarch64Inst::CmpImm {
+                src: Operand::Physical(Reg::X0),
+                imm: 0,
+            },
+            Aarch64Inst::Label {
+                id: LabelId::new(0),
+            },
+            Aarch64Inst::BCond {
+                cond: Cond::Eq,
+                label: LabelId::new(1),
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        let changes = optimize(&mut instructions);
+
+        assert_eq!(changes, 0);
+        assert!(matches!(
+            instructions[0],
+            Aarch64Inst::CmpImm { imm: 0, .. }
+        ));
+    }
+
+    #[test]
+    fn test_cmp_zero_to_tst_unsigned_consumer_after_writer_ok() {
+        // The unsigned consumer reads flags from the LATER cmp, not ours:
+        // the rewrite fires.
+        let mut instructions = vec![
+            Aarch64Inst::CmpImm {
+                src: Operand::Physical(Reg::X0),
+                imm: 0,
+            },
+            Aarch64Inst::CmpRR {
+                src1: Operand::Physical(Reg::X1),
+                src2: Operand::Physical(Reg::X2),
+            },
+            Aarch64Inst::BCond {
+                cond: Cond::Hs,
+                label: LabelId::new(0),
+            },
+            Aarch64Inst::Ret,
+        ];
+
+        let changes = optimize(&mut instructions);
+
+        assert_eq!(changes, 1);
+        assert!(matches!(instructions[0], Aarch64Inst::TstRR { .. }));
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/schedule.rs
+++ b/crates/rue-codegen/src/aarch64/schedule.rs
@@ -438,7 +438,10 @@ fn regs_written(inst: &Aarch64Inst) -> Vec<Reg> {
 }
 
 /// Check if an instruction writes to NZCV flags.
-fn writes_flags(inst: &Aarch64Inst) -> bool {
+///
+/// Shared with the peephole pass, which must not change flags that a later
+/// reader observes (RUE-152).
+pub(super) fn writes_flags(inst: &Aarch64Inst) -> bool {
     matches!(
         inst,
         // Flag-setting arithmetic

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -1197,6 +1197,10 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                     }
                 });
+                // NOT flips all 32 register bits, setting bits above a
+                // sub-word operand's width (e.g. ~0u8 leaves 0xFFFFFFFF, not
+                // 0xFF); narrow back to the operand's type (RUE-162).
+                self.emit_subword_narrow(vreg, ty);
             }
 
             CfgInstData::BitAnd(lhs, rhs) => {

--- a/crates/rue-codegen/src/x86_64/peephole.rs
+++ b/crates/rue-codegen/src/x86_64/peephole.rs
@@ -17,8 +17,25 @@
 //! - `add r, a` + `add r, b` → `add r, a+b` (when sum fits in i32)
 //!
 //! The pass operates in-place on the instruction vector for efficiency.
+//!
+//! ## FLAGS invariant (RUE-152)
+//!
+//! A rewrite that changes what an instruction does to FLAGS — adding a
+//! flags write (`mov r, 0` → `xor r, r`), dropping one (removing
+//! `add r, 0` / `xor r, 0`), or changing the flag values an instruction
+//! produces (combining add chains alters CF/OF) — is only applied when the
+//! FLAGS state at that point is provably dead: scanning forward, the next
+//! flags READER must be preceded by another flags WRITER (or a call/ret,
+//! which clobbers FLAGS per the ABI). If the scan reaches a label or an
+//! unconditional jump first, the flags state escapes this straight-line
+//! window and the rewrite is skipped. See [`flags_dead_after`].
+//!
+//! `cmp r, 0` → `test r, r` needs no gate on x86: both set CF=0, OF=0 and
+//! identical ZF/SF/PF from the same value (only undefined AF differs, and
+//! no consumer reads AF).
 
 use super::mir::{Operand, X86Inst};
+use super::schedule::{reads_flags, writes_flags};
 
 /// Apply peephole optimizations to the instruction stream.
 ///
@@ -28,9 +45,9 @@ pub fn optimize(instructions: &mut Vec<X86Inst>) -> usize {
     let mut changes = 0;
 
     // Pass 1: Single-instruction transforms (mov 0 -> xor, cmp 0 -> test)
-    for inst in instructions.iter_mut() {
-        if let Some(new_inst) = transform_single(inst) {
-            *inst = new_inst;
+    for i in 0..instructions.len() {
+        if let Some(new_inst) = transform_single(instructions, i) {
+            instructions[i] = new_inst;
             changes += 1;
         }
     }
@@ -39,27 +56,100 @@ pub fn optimize(instructions: &mut Vec<X86Inst>) -> usize {
     changes += combine_adjacent(instructions);
 
     // Pass 3: Remove identity instructions
-    let before = instructions.len();
-    instructions.retain(|inst| !is_redundant(inst));
-    changes += before - instructions.len();
+    let mut i = 0;
+    while i < instructions.len() {
+        if is_redundant(&instructions[i]) && removal_preserves_flags(instructions, i) {
+            instructions.remove(i);
+            changes += 1;
+        } else {
+            i += 1;
+        }
+    }
 
     changes
 }
 
-/// Transform a single instruction to a more efficient form.
+/// Check whether the FLAGS state produced at position `idx` is dead: no
+/// instruction can observe it before it is overwritten.
 ///
-/// Returns `Some(new_inst)` if a transformation was applied, `None` otherwise.
-fn transform_single(inst: &X86Inst) -> Option<X86Inst> {
-    match inst {
+/// Scans forward from `idx + 1`:
+/// - a flags reader first → live (return false)
+/// - a flags writer first → dead (overwritten before any read)
+/// - call/syscall/ret → dead (FLAGS are clobbered/never live across these
+///   per the ABI; our codegen never branches on flags set before a call)
+/// - label or unconditional jump → conservatively live (the flags state
+///   merges with or flows into code outside this straight-line window)
+/// - end of stream → dead
+///
+/// Shift-by-zero immediates leave FLAGS untouched, so they are skipped even
+/// though [`writes_flags`] reports the non-zero forms as writers.
+fn flags_dead_after(instructions: &[X86Inst], idx: usize) -> bool {
+    for inst in &instructions[idx + 1..] {
+        if is_shift_by_zero(inst) {
+            continue;
+        }
+        if reads_flags(inst) {
+            return false;
+        }
+        if writes_flags(inst) {
+            return true;
+        }
+        match inst {
+            X86Inst::CallRel { .. } | X86Inst::Syscall | X86Inst::Ret => return true,
+            X86Inst::Jmp { .. } | X86Inst::Label { .. } => return false,
+            _ => {}
+        }
+    }
+    true
+}
+
+/// Shift-immediate-by-zero forms: architecturally, a shift count of 0
+/// leaves FLAGS unmodified, so these are neither flag writers (despite
+/// [`writes_flags`] reporting the non-zero forms) nor unsafe to remove.
+fn is_shift_by_zero(inst: &X86Inst) -> bool {
+    matches!(
+        inst,
+        X86Inst::ShlRI { imm: 0, .. }
+            | X86Inst::Shl32RI { imm: 0, .. }
+            | X86Inst::ShrRI { imm: 0, .. }
+            | X86Inst::Shr32RI { imm: 0, .. }
+            | X86Inst::SarRI { imm: 0, .. }
+            | X86Inst::Sar32RI { imm: 0, .. }
+    )
+}
+
+/// Check that removing the (redundant) instruction at `idx` does not drop a
+/// FLAGS write that a later reader observes (RUE-152).
+///
+/// `add r, 0` and `xor r, 0` are register no-ops but still set FLAGS;
+/// shift-by-zero and `mov r, r` touch no flags at all.
+fn removal_preserves_flags(instructions: &[X86Inst], idx: usize) -> bool {
+    let inst = &instructions[idx];
+    if !writes_flags(inst) || is_shift_by_zero(inst) {
+        return true;
+    }
+    flags_dead_after(instructions, idx)
+}
+
+/// Transform the instruction at `idx` to a more efficient form.
+///
+/// Returns `Some(new_inst)` if a transformation applies, `None` otherwise.
+fn transform_single(instructions: &[X86Inst], idx: usize) -> Option<X86Inst> {
+    match &instructions[idx] {
         // mov r, 0 → xor r, r (smaller encoding: 5 bytes → 2 bytes)
         // Also breaks false dependencies on modern CPUs.
-        X86Inst::MovRI32 { dst, imm: 0 } => Some(X86Inst::XorRR {
-            dst: *dst,
-            src: *dst,
-        }),
+        // XOR writes FLAGS where MOV does not, so this is only legal where
+        // the flags state at this point is dead (RUE-152).
+        X86Inst::MovRI32 { dst, imm: 0 } if flags_dead_after(instructions, idx) => {
+            Some(X86Inst::XorRR {
+                dst: *dst,
+                src: *dst,
+            })
+        }
 
         // cmp r, 0 → test r, r (same flags, often faster)
-        // test sets ZF=1 if r==0, same as cmp r, 0
+        // Flag-equivalent for every consumed flag: both set CF=0, OF=0 and
+        // ZF/SF/PF from the operand value itself (see module docs).
         X86Inst::CmpRI { src, imm: 0 } => Some(X86Inst::TestRR {
             src1: *src,
             src2: *src,
@@ -81,6 +171,10 @@ fn transform_single(inst: &X86Inst) -> Option<X86Inst> {
 ///
 /// Currently handles:
 /// - `add r, a` followed by `add r, b` → `add r, a+b`
+///
+/// The combined add produces the same final register value but can set
+/// CF/OF differently than the second original add, so combining is gated on
+/// the flags at that point being dead (RUE-152).
 ///
 /// Returns the number of combinations made.
 fn combine_adjacent(instructions: &mut Vec<X86Inst>) -> usize {
@@ -104,7 +198,7 @@ fn combine_adjacent(instructions: &mut Vec<X86Inst>) -> usize {
             },
         ) = (&instructions[i], &instructions[i + 1])
         {
-            if operands_equal(dst1, dst2) {
+            if operands_equal(dst1, dst2) && flags_dead_after(instructions, i + 1) {
                 // Check for overflow when combining immediates
                 if let Some(combined) = imm1.checked_add(*imm2) {
                     // Replace first instruction with combined add
@@ -648,6 +742,200 @@ mod tests {
         assert!(matches!(instructions[1], X86Inst::AddRI { imm: 30, .. }));
         assert!(matches!(instructions[2], X86Inst::TestRR { .. }));
         assert!(matches!(instructions[3], X86Inst::Ret));
+    }
+
+    // ==================== FLAGS Hazard Tests (RUE-152) ====================
+
+    use crate::x86_64::mir::LabelId;
+
+    #[test]
+    fn test_mov_zero_to_xor_blocked_by_live_flags() {
+        // cmp sets flags; jz reads them. The mov in between must NOT become
+        // xor (which would clobber the flags jz consumes).
+        let mut instructions = vec![
+            X86Inst::CmpRI {
+                src: Operand::Physical(Reg::Rbx),
+                imm: 42,
+            },
+            X86Inst::MovRI32 {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 0,
+            },
+            X86Inst::Jz {
+                label: LabelId::new(0),
+            },
+            X86Inst::Ret,
+        ];
+
+        optimize(&mut instructions);
+
+        assert!(
+            matches!(instructions[1], X86Inst::MovRI32 { imm: 0, .. }),
+            "mov r, 0 must not become xor while flags are live, got {:?}",
+            instructions[1]
+        );
+    }
+
+    #[test]
+    fn test_mov_zero_to_xor_fires_when_flags_rewritten_first() {
+        // A flags writer (test) sits between the mov and the reader, so the
+        // xor's flags are dead and the rewrite STILL fires.
+        let mut instructions = vec![
+            X86Inst::MovRI32 {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 0,
+            },
+            X86Inst::TestRR {
+                src1: Operand::Physical(Reg::Rbx),
+                src2: Operand::Physical(Reg::Rbx),
+            },
+            X86Inst::Jz {
+                label: LabelId::new(0),
+            },
+            X86Inst::Ret,
+        ];
+
+        optimize(&mut instructions);
+
+        assert!(
+            matches!(instructions[0], X86Inst::XorRR { .. }),
+            "mov r, 0 should become xor when a writer precedes the reader, got {:?}",
+            instructions[0]
+        );
+    }
+
+    #[test]
+    fn test_mov_zero_to_xor_blocked_by_label() {
+        // Flags state escapes into a join point; conservatively keep the mov.
+        let mut instructions = vec![
+            X86Inst::MovRI32 {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 0,
+            },
+            X86Inst::Label {
+                id: LabelId::new(0),
+            },
+            X86Inst::Jz {
+                label: LabelId::new(1),
+            },
+            X86Inst::Ret,
+        ];
+
+        optimize(&mut instructions);
+
+        assert!(
+            matches!(instructions[0], X86Inst::MovRI32 { imm: 0, .. }),
+            "mov r, 0 must not become xor across a label, got {:?}",
+            instructions[0]
+        );
+    }
+
+    #[test]
+    fn test_add_zero_kept_when_flags_consumed() {
+        // add r, 0 is a register no-op but writes FLAGS; a following jz
+        // consumes them, so the add must stay.
+        let mut instructions = vec![
+            X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 0,
+            },
+            X86Inst::Jz {
+                label: LabelId::new(0),
+            },
+            X86Inst::Ret,
+        ];
+
+        let changes = optimize(&mut instructions);
+
+        assert_eq!(changes, 0);
+        assert!(matches!(instructions[0], X86Inst::AddRI { imm: 0, .. }));
+    }
+
+    #[test]
+    fn test_xor_zero_kept_when_flags_consumed() {
+        let mut instructions = vec![
+            X86Inst::XorRI {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 0,
+            },
+            X86Inst::Jae {
+                label: LabelId::new(0),
+            },
+            X86Inst::Ret,
+        ];
+
+        let changes = optimize(&mut instructions);
+
+        assert_eq!(changes, 0);
+        assert!(matches!(instructions[0], X86Inst::XorRI { imm: 0, .. }));
+    }
+
+    #[test]
+    fn test_combine_adds_blocked_by_flags_reader() {
+        // Combining changes CF/OF; jae reads CF, so the adds must not merge.
+        let mut instructions = vec![
+            X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 10,
+            },
+            X86Inst::AddRI {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 20,
+            },
+            X86Inst::Jae {
+                label: LabelId::new(0),
+            },
+            X86Inst::Ret,
+        ];
+
+        let changes = optimize(&mut instructions);
+
+        assert_eq!(changes, 0);
+        assert_eq!(instructions.len(), 4);
+        assert!(matches!(instructions[0], X86Inst::AddRI { imm: 10, .. }));
+        assert!(matches!(instructions[1], X86Inst::AddRI { imm: 20, .. }));
+    }
+
+    #[test]
+    fn test_cmp_zero_to_test_fires_with_flags_reader() {
+        // cmp -> test is flag-equivalent on x86 and must still fire even
+        // with a consumer right after.
+        let mut instructions = vec![
+            X86Inst::CmpRI {
+                src: Operand::Physical(Reg::Rax),
+                imm: 0,
+            },
+            X86Inst::Jz {
+                label: LabelId::new(0),
+            },
+            X86Inst::Ret,
+        ];
+
+        let changes = optimize(&mut instructions);
+
+        assert_eq!(changes, 1);
+        assert!(matches!(instructions[0], X86Inst::TestRR { .. }));
+    }
+
+    #[test]
+    fn test_flags_dead_after_call() {
+        // FLAGS never live across a call: the xor rewrite fires even though
+        // a reader follows the call (it must consume flags set after it).
+        let mut instructions = vec![
+            X86Inst::MovRI32 {
+                dst: Operand::Physical(Reg::Rax),
+                imm: 0,
+            },
+            X86Inst::CallRel { symbol_id: 0 },
+            X86Inst::Jz {
+                label: LabelId::new(0),
+            },
+            X86Inst::Ret,
+        ];
+
+        optimize(&mut instructions);
+
+        assert!(matches!(instructions[0], X86Inst::XorRR { .. }));
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/schedule.rs
+++ b/crates/rue-codegen/src/x86_64/schedule.rs
@@ -495,7 +495,10 @@ fn regs_written(inst: &X86Inst) -> Vec<Reg> {
 }
 
 /// Check if an instruction writes to FLAGS.
-fn writes_flags(inst: &X86Inst) -> bool {
+///
+/// Shared with the peephole pass, which must not change or drop a flags
+/// write that a later reader observes (RUE-152).
+pub(super) fn writes_flags(inst: &X86Inst) -> bool {
     matches!(
         inst,
         // Arithmetic (set OF, SF, ZF, CF, PF, AF)
@@ -547,7 +550,9 @@ fn writes_flags(inst: &X86Inst) -> bool {
 }
 
 /// Check if an instruction reads FLAGS.
-fn reads_flags(inst: &X86Inst) -> bool {
+///
+/// Shared with the peephole pass (see [`writes_flags`]).
+pub(super) fn reads_flags(inst: &X86Inst) -> bool {
     matches!(
         inst,
         // Conditional set


### PR DESCRIPTION
Codegen cluster from the comptime-consteval hunt.

**RUE-162 — runtime `~` on u8/u16 unmasked (miscompile).** BitNot lowering in **both backends** now narrows sub-word results via `emit_subword_narrow` (the RUE-29 pattern); `~id(0)` as u8 is 255 at every opt level instead of an unmasked full-register `not` (aarch64 verified: `mvn`+`uxtb`). New `bitnot_subword` CLI suite (u8/u16/i8/i16, -O2 roundtrip, -O1 constant control). Audit of the other ops found BitNot was the only narrowing gap (and/or/xor width-safe by construction; shl narrows; sar/shr canonical on extended operands; neg/add/sub/mul trap via emit_overflow_check).

**RUE-152 — peephole flags hazards made safe by construction.** Flag-affecting rewrites are gated by a forward flags-liveness scan: `flags_dead_after` on x86 (mov→xor, add/xor-0 removal, add combining) and `cmp_zero_to_tst_safe` on aarch64 (blocks C-reading hs/lo/hi/ls consumers). x86 cmp→test stays unconditional — flag-equivalent, documented. The schedulers' `writes_flags`/`reads_flags` tables are shared via pub(super). 14 unit tests pin both directions (still fires in the safe case; blocked in a constructed hazard); the invariant is documented atop both peephole files.

**RUE-154 — constprop gap.** Diagnosis: every `let` is a slot and constfold never sees `Load`s. New `rue-cfg/src/opt/constprop.rs` forwards single-write constant slots into Loads (disqualifying mutated, partially-written, and by-ref-escaping slots), interleaved with constfold to a fixpoint. The opt-level matrix CLI case proves the MIN/-1 trap still fires at -O0/-O1/-O2 (constfold refuses the fold per RUE-147, the RUE-30 runtime guard catches it) and the div-by-zero trap survives -O2.

Verified post-integration by execution: BitNot 255 at -O0/-O1/-O2; MIN/-1 exits 101 at all three levels. Full ./test.sh green.

Fixes RUE-162
Fixes RUE-152
Fixes RUE-154

🤖 Generated with [Claude Code](https://claude.com/claude-code)