### PR TITLE
Array block params carry all slots across branch joins

### DIFF
--- a/crates/rue-cli-tests/cases/join_aggregates.toml
+++ b/crates/rue-cli-tests/cases/join_aggregates.toml
@@ -1,0 +1,191 @@
+# Aggregate values through branch joins (RUE-167).
+#
+# An aggregate produced in the arms of an `if`/`else` or `match` flows to the
+# join block as a block parameter. Block-param lowering only flattened STRUCT
+# params into per-slot vregs; array-typed params got a single vreg — and an
+# array's primary vreg is just a zero placeholder — so every element was
+# dropped at the join (silent miscompile: a[i] read 0 at every opt level, both
+# backends). Structs and String (a synthetic struct) already crossed joins
+# intact; these cases pin them as regressions alongside the array fixes.
+#
+# Conditions go through a function call so constant folding can't delete the
+# join. Runs on both backends — the aarch64 runtime path is exercised in CI.
+
+[section]
+id = "cli.join_aggregates"
+name = "Aggregate values through branch joins"
+description = "Every slot of an aggregate must survive an if/match join, both backends."
+
+# Array selected by a match — previously printed 0 0 0.
+[[case]]
+name = "array_through_match_join"
+files = [{ path = "main.rue", source = """
+fn pick(n: i32) -> i32 { n }
+fn main() -> i32 {
+    let a = match pick(1) { 1 => [10, 20, 30], _ => [40, 50, 60] };
+    @dbg(a[0]);
+    @dbg(a[1]);
+    @dbg(a[2]);
+    0
+}
+""" }]
+stdout = "10\n20\n30\n"
+exit_code = 0
+
+# Array selected by if/else with a runtime condition — previously 0 0 0.
+[[case]]
+name = "array_through_if_join"
+files = [{ path = "main.rue", source = """
+fn cond(n: i32) -> bool { n > 0 }
+fn main() -> i32 {
+    let a = if cond(1) { [10, 20, 30] } else { [40, 50, 60] };
+    @dbg(a[0]);
+    @dbg(a[1]);
+    @dbg(a[2]);
+    0
+}
+""" }]
+stdout = "10\n20\n30\n"
+exit_code = 0
+
+# Else arm taken: the join must carry the else slots, not the then slots.
+[[case]]
+name = "array_through_if_join_else_arm"
+files = [{ path = "main.rue", source = """
+fn cond(n: i32) -> bool { n > 0 }
+fn main() -> i32 {
+    let a = if cond(0) { [10, 20, 30] } else { [40, 50, 60] };
+    @dbg(a[0]);
+    @dbg(a[1]);
+    @dbg(a[2]);
+    0
+}
+""" }]
+stdout = "40\n50\n60\n"
+exit_code = 0
+
+# Same join under -O2: optimization passes must not re-lose the slots.
+[[case]]
+name = "array_through_match_join_o2"
+files = [{ path = "main.rue", source = """
+fn pick(n: i32) -> i32 { n }
+fn main() -> i32 {
+    let a = match pick(1) { 1 => [10, 20, 30], _ => [40, 50, 60] };
+    @dbg(a[0]);
+    @dbg(a[1]);
+    @dbg(a[2]);
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+stdout = "10\n20\n30\n"
+exit_code = 0
+
+# Nested (2D) array through a join: all four scalar slots must arrive.
+[[case]]
+name = "nested_array_through_join"
+files = [{ path = "main.rue", source = """
+fn cond(n: i32) -> bool { n > 0 }
+fn main() -> i32 {
+    let m = if cond(1) { [[1, 2], [3, 4]] } else { [[5, 6], [7, 8]] };
+    @dbg(m[0][0]);
+    @dbg(m[0][1]);
+    @dbg(m[1][0]);
+    @dbg(m[1][1]);
+    0
+}
+""" }]
+stdout = "1\n2\n3\n4\n"
+exit_code = 0
+
+# Array of structs through a join (else arm taken).
+[[case]]
+name = "array_of_structs_through_join"
+files = [{ path = "main.rue", source = """
+struct P { x: i32, y: i32 }
+fn cond(n: i32) -> bool { n > 0 }
+fn main() -> i32 {
+    let a = if cond(0) { [P { x: 1, y: 2 }, P { x: 3, y: 4 }] }
+            else { [P { x: 5, y: 6 }, P { x: 7, y: 8 }] };
+    @dbg(a[0].x);
+    @dbg(a[0].y);
+    @dbg(a[1].x);
+    @dbg(a[1].y);
+    0
+}
+""" }]
+stdout = "5\n6\n7\n8\n"
+exit_code = 0
+
+# Struct containing an array field through a join: the array slots ride
+# inside the struct's flattened slot list.
+[[case]]
+name = "struct_with_array_field_through_join"
+files = [{ path = "main.rue", source = """
+struct Q { v: [i32; 3], tag: i32 }
+fn cond(n: i32) -> bool { n > 0 }
+fn main() -> i32 {
+    let q = if cond(1) { Q { v: [9, 8, 7], tag: 1 } } else { Q { v: [6, 5, 4], tag: 2 } };
+    @dbg(q.v[0]);
+    @dbg(q.v[1]);
+    @dbg(q.v[2]);
+    @dbg(q.tag);
+    0
+}
+""" }]
+stdout = "9\n8\n7\n1\n"
+exit_code = 0
+
+# Match arms mixing array literals with an array-typed variable: the
+# variable arm's slots come from a Load, not an ArrayInit cache hit.
+[[case]]
+name = "match_arms_mix_literal_and_variable_arrays"
+files = [{ path = "main.rue", source = """
+fn pick(n: i32) -> i32 { n }
+fn main() -> i32 {
+    let pre = [70, 80, 90];
+    let a = match pick(2) { 1 => [10, 20, 30], 2 => pre, _ => [40, 50, 60] };
+    @dbg(a[0]);
+    @dbg(a[1]);
+    @dbg(a[2]);
+    let b = if pick(0) > 0 { [1, 2, 3] } else { pre };
+    @dbg(b[0]);
+    @dbg(b[1]);
+    @dbg(b[2]);
+    0
+}
+""" }]
+stdout = "70\n80\n90\n70\n80\n90\n"
+exit_code = 0
+
+# Plain struct through a join — worked before RUE-167; pinned as a regression
+# guard for the shared block-param machinery.
+[[case]]
+name = "struct_through_if_join"
+files = [{ path = "main.rue", source = """
+struct P { x: i32, y: i32 }
+fn cond(n: i32) -> bool { n > 0 }
+fn main() -> i32 {
+    let s = if cond(5) { P { x: 1, y: 2 } } else { P { x: 3, y: 4 } };
+    @dbg(s.x);
+    @dbg(s.y);
+    s.x + s.y
+}
+""" }]
+stdout = "1\n2\n"
+exit_code = 3
+
+# String (3-slot fat pointer) through a join — also pinned as a regression
+# guard; String is a synthetic struct so it used the working struct path.
+[[case]]
+name = "string_through_if_join"
+files = [{ path = "main.rue", source = """
+fn cond(n: i32) -> bool { n > 0 }
+fn main() -> i32 {
+    let s = if cond(0) { "hello" } else { "worldly" };
+    @dbg(s);
+    0
+}
+""" }]
+stdout = "worldly\n"
+exit_code = 0

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -212,34 +212,44 @@ impl<'a> CfgLower<'a> {
         crate::agg_slots::get_or_compute_field_vregs(self, value)
     }
 
-    /// Copy a struct value's field vregs to a block parameter's field vregs.
-    fn copy_struct_to_block_param(&mut self, arg: CfgValue, target_block: BlockId, param_idx: u32) {
+    /// Copy an aggregate value's slot vregs to a block parameter's slot vregs.
+    /// Covers structs, builtin String, and fixed-size arrays — every slot must
+    /// cross the join edge, not just the primary vreg (RUE-167).
+    fn copy_aggregate_to_block_param(
+        &mut self,
+        arg: CfgValue,
+        target_block: BlockId,
+        param_idx: u32,
+    ) {
         let target_param = self.ctx.cfg.get_block(target_block).params[param_idx as usize].0;
 
-        let src_fields = self.get_or_compute_field_vregs(arg);
-        let dst_fields = self.struct_slot_vregs.get(&target_param).cloned();
-
-        debug_assert!(
-            src_fields.is_some(),
-            "struct arg should have field vregs available"
-        );
-        debug_assert!(
-            dst_fields.is_some(),
-            "struct block param should have field vregs pre-allocated"
-        );
-
-        if let (Some(src), Some(dst)) = (src_fields, dst_fields) {
-            debug_assert_eq!(
-                src.len(),
-                dst.len(),
-                "source and destination struct field counts must match"
-            );
-            for (dst_vreg, src_vreg) in dst.iter().zip(src.iter()) {
-                self.mir.push(Aarch64Inst::MovRR {
-                    dst: Operand::Virtual(*dst_vreg),
-                    src: Operand::Virtual(*src_vreg),
-                });
+        // The accessor covers StructInit/ArrayInit/Call/BlockParam (cache
+        // hits) and Load/Param/static PlaceRead; fall back to the recursive
+        // flatteners for anything it doesn't model (mirrors Alloc lowering).
+        let src_slots = self.get_or_compute_field_vregs(arg).unwrap_or_else(|| {
+            let arg_ty = self.ctx.cfg.get_inst(arg).ty;
+            if arg_ty.is_array() {
+                self.collect_array_scalar_vregs(arg)
+            } else {
+                self.collect_struct_scalar_vregs(arg)
             }
+        });
+        let dst_slots = self
+            .struct_slot_vregs
+            .get(&target_param)
+            .cloned()
+            .expect("aggregate block param should have slot vregs pre-allocated");
+
+        debug_assert_eq!(
+            src_slots.len(),
+            dst_slots.len(),
+            "source and destination aggregate slot counts must match"
+        );
+        for (dst_vreg, src_vreg) in dst_slots.iter().zip(src_slots.iter()) {
+            self.mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Virtual(*dst_vreg),
+                src: Operand::Virtual(*src_vreg),
+            });
         }
     }
 
@@ -253,9 +263,12 @@ impl<'a> CfgLower<'a> {
                     .insert((block.id, param_idx as u32), vreg);
                 self.value_map.insert(*param_val, vreg);
 
-                // For struct types, also allocate vregs for each slot
-                if let Some(struct_id) = ty.as_struct() {
-                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                // For aggregate types (structs, builtin String, fixed-size
+                // arrays), also allocate vregs for each slot. Arrays included:
+                // their primary vreg is just a placeholder, so without slot
+                // vregs every element would be dropped at the join (RUE-167).
+                if ty.is_struct() || ty.is_array() {
+                    let slot_count = self.ctx.type_slot_count(*ty);
                     let mut slot_vregs = vec![vreg]; // First slot uses main vreg
                     for _ in 1..slot_count {
                         slot_vregs.push(self.mir.alloc_vreg());
@@ -297,8 +310,8 @@ impl<'a> CfgLower<'a> {
                     .insert((block.id, param_idx as u32), vreg);
                 self.value_map.insert(*param_val, vreg);
 
-                if let Some(struct_id) = ty.as_struct() {
-                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                if ty.is_struct() || ty.is_array() {
+                    let slot_count = self.ctx.type_slot_count(*ty);
                     let mut slot_vregs = vec![vreg];
                     for _ in 1..slot_count {
                         slot_vregs.push(self.mir.alloc_vreg());
@@ -3432,9 +3445,9 @@ impl<'a> CfgLower<'a> {
                 let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                 for (i, &arg) in args.iter().enumerate() {
                     let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if arg_type.is_struct() {
-                        // For struct args, copy all field vregs
-                        self.copy_struct_to_block_param(arg, *target, i as u32);
+                    if arg_type.is_struct() || arg_type.is_array() {
+                        // For aggregate args (structs, String, arrays), copy all slot vregs
+                        self.copy_aggregate_to_block_param(arg, *target, i as u32);
                     } else {
                         // For scalar args, just copy the single vreg
                         let arg_vreg = self.get_vreg(arg);
@@ -3479,9 +3492,9 @@ impl<'a> CfgLower<'a> {
                 let then_args = self.ctx.cfg.get_extra(*then_args_start, *then_args_len);
                 for (i, &arg) in then_args.iter().enumerate() {
                     let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if arg_type.is_struct() {
-                        // For struct args, copy all field vregs
-                        self.copy_struct_to_block_param(arg, *then_block, i as u32);
+                    if arg_type.is_struct() || arg_type.is_array() {
+                        // For aggregate args (structs, String, arrays), copy all slot vregs
+                        self.copy_aggregate_to_block_param(arg, *then_block, i as u32);
                     } else {
                         // For scalar args, just copy the single vreg
                         let arg_vreg = self.get_vreg(arg);
@@ -3505,9 +3518,9 @@ impl<'a> CfgLower<'a> {
                 let else_args = self.ctx.cfg.get_extra(*else_args_start, *else_args_len);
                 for (i, &arg) in else_args.iter().enumerate() {
                     let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if arg_type.is_struct() {
-                        // For struct args, copy all field vregs
-                        self.copy_struct_to_block_param(arg, *else_block, i as u32);
+                    if arg_type.is_struct() || arg_type.is_array() {
+                        // For aggregate args (structs, String, arrays), copy all slot vregs
+                        self.copy_aggregate_to_block_param(arg, *else_block, i as u32);
                     } else {
                         // For scalar args, just copy the single vreg
                         let arg_vreg = self.get_vreg(arg);

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -378,34 +378,44 @@ impl<'a> CfgLower<'a> {
         crate::agg_slots::get_or_compute_field_vregs(self, value)
     }
 
-    /// Copy a struct value's field vregs to a block parameter's field vregs.
-    fn copy_struct_to_block_param(&mut self, arg: CfgValue, target_block: BlockId, param_idx: u32) {
+    /// Copy an aggregate value's slot vregs to a block parameter's slot vregs.
+    /// Covers structs, builtin String, and fixed-size arrays — every slot must
+    /// cross the join edge, not just the primary vreg (RUE-167).
+    fn copy_aggregate_to_block_param(
+        &mut self,
+        arg: CfgValue,
+        target_block: BlockId,
+        param_idx: u32,
+    ) {
         let target_param = self.ctx.cfg.get_block(target_block).params[param_idx as usize].0;
 
-        let src_fields = self.get_or_compute_field_vregs(arg);
-        let dst_fields = self.struct_slot_vregs.get(&target_param).cloned();
-
-        debug_assert!(
-            src_fields.is_some(),
-            "struct arg should have field vregs available"
-        );
-        debug_assert!(
-            dst_fields.is_some(),
-            "struct block param should have field vregs pre-allocated"
-        );
-
-        if let (Some(src), Some(dst)) = (src_fields, dst_fields) {
-            debug_assert_eq!(
-                src.len(),
-                dst.len(),
-                "source and destination struct field counts must match"
-            );
-            for (dst_vreg, src_vreg) in dst.iter().zip(src.iter()) {
-                self.mir.push(X86Inst::MovRR {
-                    dst: Operand::Virtual(*dst_vreg),
-                    src: Operand::Virtual(*src_vreg),
-                });
+        // The accessor covers StructInit/ArrayInit/Call/BlockParam (cache
+        // hits) and Load/Param/static PlaceRead; fall back to the recursive
+        // flatteners for anything it doesn't model (mirrors Alloc lowering).
+        let src_slots = self.get_or_compute_field_vregs(arg).unwrap_or_else(|| {
+            let arg_ty = self.ctx.cfg.get_inst(arg).ty;
+            if arg_ty.is_array() {
+                self.collect_array_scalar_vregs(arg)
+            } else {
+                self.collect_struct_scalar_vregs(arg)
             }
+        });
+        let dst_slots = self
+            .struct_slot_vregs
+            .get(&target_param)
+            .cloned()
+            .expect("aggregate block param should have slot vregs pre-allocated");
+
+        debug_assert_eq!(
+            src_slots.len(),
+            dst_slots.len(),
+            "source and destination aggregate slot counts must match"
+        );
+        for (dst_vreg, src_vreg) in dst_slots.iter().zip(src_slots.iter()) {
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Virtual(*dst_vreg),
+                src: Operand::Virtual(*src_vreg),
+            });
         }
     }
 
@@ -419,9 +429,12 @@ impl<'a> CfgLower<'a> {
                     .insert((block.id, param_idx as u32), vreg);
                 self.value_map.insert(*param_val, vreg);
 
-                // For struct types, also allocate vregs for each slot
-                if let TypeKind::Struct(struct_id) = ty.kind() {
-                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                // For aggregate types (structs, builtin String, fixed-size
+                // arrays), also allocate vregs for each slot. Arrays included:
+                // their primary vreg is just a placeholder, so without slot
+                // vregs every element would be dropped at the join (RUE-167).
+                if matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                    let slot_count = self.ctx.type_slot_count(*ty);
                     let mut slot_vregs = vec![vreg]; // First slot uses main vreg
                     for _ in 1..slot_count {
                         slot_vregs.push(self.mir.alloc_vreg());
@@ -463,8 +476,8 @@ impl<'a> CfgLower<'a> {
                     .insert((block.id, param_idx as u32), vreg);
                 self.value_map.insert(*param_val, vreg);
 
-                if let TypeKind::Struct(struct_id) = ty.kind() {
-                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                if matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                    let slot_count = self.ctx.type_slot_count(*ty);
                     let mut slot_vregs = vec![vreg];
                     for _ in 1..slot_count {
                         slot_vregs.push(self.mir.alloc_vreg());
@@ -3408,9 +3421,9 @@ impl<'a> CfgLower<'a> {
                 let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                 for (i, &arg) in args.iter().enumerate() {
                     let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if matches!(arg_type.kind(), TypeKind::Struct(_)) {
-                        // For struct args, copy all field vregs
-                        self.copy_struct_to_block_param(arg, *target, i as u32);
+                    if matches!(arg_type.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                        // For aggregate args (structs, String, arrays), copy all slot vregs
+                        self.copy_aggregate_to_block_param(arg, *target, i as u32);
                     } else {
                         // For scalar args, just copy the single vreg
                         let arg_vreg = self.get_vreg(arg);
@@ -3460,9 +3473,9 @@ impl<'a> CfgLower<'a> {
                 let then_args = self.ctx.cfg.get_extra(*then_args_start, *then_args_len);
                 for (i, &arg) in then_args.iter().enumerate() {
                     let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if matches!(arg_type.kind(), TypeKind::Struct(_)) {
-                        // For struct args, copy all field vregs
-                        self.copy_struct_to_block_param(arg, *then_block, i as u32);
+                    if matches!(arg_type.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                        // For aggregate args (structs, String, arrays), copy all slot vregs
+                        self.copy_aggregate_to_block_param(arg, *then_block, i as u32);
                     } else {
                         // For scalar args, just copy the single vreg
                         let arg_vreg = self.get_vreg(arg);
@@ -3486,9 +3499,9 @@ impl<'a> CfgLower<'a> {
                 let else_args = self.ctx.cfg.get_extra(*else_args_start, *else_args_len);
                 for (i, &arg) in else_args.iter().enumerate() {
                     let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if matches!(arg_type.kind(), TypeKind::Struct(_)) {
-                        // For struct args, copy all field vregs
-                        self.copy_struct_to_block_param(arg, *else_block, i as u32);
+                    if matches!(arg_type.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                        // For aggregate args (structs, String, arrays), copy all slot vregs
+                        self.copy_aggregate_to_block_param(arg, *else_block, i as u32);
                     } else {
                         // For scalar args, just copy the single vreg
                         let arg_vreg = self.get_vreg(arg);


### PR DESCRIPTION
`let a = match 1 { 1 => [10,20,30], _ => [40,50,60] };` read as `0,0,0` — at every opt level, for match and if/else alike.

**Root cause:** block-param pre-allocation in both backends flattened only **struct**-typed params to per-slot vregs; array params got a single vreg — and an array's primary vreg is a zero placeholder — so predecessors passed only the placeholder and the join stored it as the entire array. Structs and String already crossed joins intact (verified pre-fix); arrays were the only gap, which is why this survived the RUE-106 epic.

**Fix (both backends):** seed the slot cache for array-typed block params and copy all slots across every Goto/Branch edge (`copy_struct_to_block_param` generalized to `copy_aggregate_to_block_param`, with a flattener fallback mirroring Alloc lowering). Slot-flattening over predecessor materialization because the slot cache is the currency every consumer already consults — no new MIR or convention.

Probes at -O0/-O1/-O2: match/if joins (both arms), 2D arrays, arrays-of-structs, struct-with-array-field, mixed literal/variable arms, struct + String regression controls. aarch64 MIR shows per-slot edge movs. 10 exact-stdout CLI cases (`join_aggregates.toml`). Verified post-integration: the repro prints `10,20,30`. Full ./test.sh green.

Fixes RUE-167

🤖 Generated with [Claude Code](https://claude.com/claude-code)