### PR TITLE
Match pattern literals are range/signedness-checked; unreachable-_ warning; uninhabited-enum match

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1503,7 +1503,7 @@ impl<'a> ConstraintGenerator<'a> {
                 let var = self.fresh_var();
                 InferType::Var(var)
             }
-            rue_rir::RirPattern::Int(_, _) => InferType::IntLiteral,
+            rue_rir::RirPattern::Int { .. } => InferType::IntLiteral,
             rue_rir::RirPattern::Bool(_, _) => InferType::Concrete(Type::BOOL),
             rue_rir::RirPattern::Path { type_name, .. } => {
                 if let Some(&enum_ty) = self.enums.get(type_name) {
@@ -2355,14 +2355,22 @@ mod tests {
             data: InstData::IntConst(10),
             span: Span::new(15, 17),
         });
-        let pattern1 = rue_rir::RirPattern::Int(1, Span::new(10, 11));
+        let pattern1 = rue_rir::RirPattern::Int {
+            value: 1,
+            negative: false,
+            span: Span::new(10, 11),
+        };
 
         // Arm 2: 2 => 20
         let body2 = rir.add_inst(rue_rir::Inst {
             data: InstData::IntConst(20),
             span: Span::new(25, 27),
         });
-        let pattern2 = rue_rir::RirPattern::Int(2, Span::new(20, 21));
+        let pattern2 = rue_rir::RirPattern::Int {
+            value: 2,
+            negative: false,
+            span: Span::new(20, 21),
+        };
 
         // Arm 3: _ => 30
         let body3 = rir.add_inst(rue_rir::Inst {

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -905,6 +905,50 @@ impl<'a> Sema<'a> {
         Ok(AnalysisResult::new(air_ref, loop_ty))
     }
 
+    /// Validate an integer pattern literal against the scrutinee type and
+    /// return the value it compares as at runtime (the scrutinee-typed value,
+    /// held as an i64 bit pattern).
+    ///
+    /// Mirrors the `let`-binding literal checks (RUE-74): out-of-range
+    /// literals are E0800 (`LiteralOutOfRange`) and negative literals on
+    /// unsigned scrutinees are E0801 (`CannotNegateUnsigned`) instead of
+    /// silently wrapping into a different (or unmatchable) value.
+    fn check_pattern_int(
+        &self,
+        value: u64,
+        negative: bool,
+        scrutinee_type: Type,
+        span: Span,
+    ) -> CompileResult<i64> {
+        let ty_name = scrutinee_type.safe_name_with_pool(Some(&self.type_pool));
+        if negative {
+            if scrutinee_type.is_unsigned() {
+                return Err(
+                    CompileError::new(ErrorKind::CannotNegateUnsigned(ty_name), span).with_note(
+                        "unsigned values are never negative, so this pattern could never match",
+                    ),
+                );
+            }
+            if !scrutinee_type.negated_literal_fits(value) {
+                return Err(CompileError::new(
+                    ErrorKind::LiteralOutOfRange { value, ty: ty_name },
+                    span,
+                )
+                .with_note(format!("the pattern value is -{}", value)));
+            }
+            // wrapping_neg handles the i64::MIN magnitude (9223372036854775808).
+            Ok((value as i64).wrapping_neg())
+        } else {
+            if !scrutinee_type.literal_fits(value) {
+                return Err(CompileError::new(
+                    ErrorKind::LiteralOutOfRange { value, ty: ty_name },
+                    span,
+                ));
+            }
+            Ok(value as i64)
+        }
+    }
+
     /// Analyze a match expression.
     fn analyze_match(
         &mut self,
@@ -931,9 +975,29 @@ impl<'a> Sema<'a> {
         }
 
         let arms = self.rir.get_match_arms(arms_start, arms_len);
-        // Check for empty match
+        // An empty match is only legal on a zero-variant (uninhabited) enum,
+        // where zero arms vacuously satisfy exhaustiveness because the type
+        // has no values (spec 4.7:26, RUE-169). The match can never be
+        // reached with a value, so its type is `!` (spec 4.7:27).
         if arms.is_empty() {
-            return Err(CompileError::new(ErrorKind::EmptyMatch, span));
+            let is_uninhabited_enum = match scrutinee_type.try_kind() {
+                Some(TypeKind::Enum(id)) => self.type_pool.enum_def(id).variant_count() == 0,
+                _ => false,
+            };
+            if !is_uninhabited_enum {
+                return Err(CompileError::new(ErrorKind::EmptyMatch, span));
+            }
+            let arms_start = air.add_extra(&[]);
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::Match {
+                    scrutinee: scrutinee_result.air_ref,
+                    arms_start,
+                    arms_len: 0,
+                },
+                ty: Type::NEVER,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, Type::NEVER));
         }
 
         // Track patterns for exhaustiveness checking and duplicate detection
@@ -966,7 +1030,15 @@ impl<'a> Sema<'a> {
             if let Some(first_wildcard_span) = wildcard_span {
                 let pat_str = match pattern {
                     RirPattern::Wildcard(_) => "_".to_string(),
-                    RirPattern::Int(n, _) => n.to_string(),
+                    RirPattern::Int {
+                        value, negative, ..
+                    } => {
+                        if *negative {
+                            format!("-{}", value)
+                        } else {
+                            value.to_string()
+                        }
+                    }
                     RirPattern::Bool(b, _) => b.to_string(),
                     RirPattern::Path {
                         type_name, variant, ..
@@ -993,11 +1065,35 @@ impl<'a> Sema<'a> {
             // Validate pattern against scrutinee type and check for duplicates
             match pattern {
                 RirPattern::Wildcard(_) => {
+                    // A `_` arm after the preceding arms already cover every
+                    // value (both bools, or every enum variant) is unreachable
+                    // (spec 4.7:17 / 4.7:20, RUE-168).
                     if wildcard_span.is_none() {
+                        let fully_covered = if scrutinee_type == Type::BOOL {
+                            bool_true_span.is_some() && bool_false_span.is_some()
+                        } else if let Some(enum_id) = pattern_enum_id {
+                            covered_variants.len()
+                                == self.type_pool.enum_def(enum_id).variant_count()
+                        } else {
+                            false
+                        };
+                        if fully_covered {
+                            ctx.warnings.push(
+                                CompileWarning::new(
+                                    WarningKind::UnreachablePattern("_".to_string()),
+                                    pattern_span,
+                                )
+                                .with_note(
+                                    "this pattern will never be matched because the arms above already cover every possible value",
+                                ),
+                            );
+                        }
                         wildcard_span = Some(pattern_span);
                     }
                 }
-                RirPattern::Int(n, _) => {
+                RirPattern::Int {
+                    value, negative, ..
+                } => {
                     if !scrutinee_type.is_integer() {
                         return Err(CompileError::new(
                             ErrorKind::TypeMismatch {
@@ -1007,12 +1103,24 @@ impl<'a> Sema<'a> {
                             pattern_span,
                         ));
                     }
+                    // Range-check the literal against the scrutinee type
+                    // (E0800/E0801, like `let` bindings) and get the value it
+                    // compares as at runtime. Previously the literal wrapped to
+                    // i64 untyped, so e.g. `4294967296` on a u32 scrutinee
+                    // truncated and matched 0 (RUE-74).
+                    let n =
+                        self.check_pattern_int(*value, *negative, scrutinee_type, pattern_span)?;
                     // Check for duplicate integer pattern
-                    if let Some(first_span) = seen_ints.get(n) {
+                    if let Some(first_span) = seen_ints.get(&n) {
                         if wildcard_span.is_none() {
+                            let pat_str = if *negative {
+                                format!("-{}", value)
+                            } else {
+                                value.to_string()
+                            };
                             ctx.warnings.push(
                                 CompileWarning::new(
-                                    WarningKind::UnreachablePattern(n.to_string()),
+                                    WarningKind::UnreachablePattern(pat_str),
                                     pattern_span,
                                 )
                                 .with_label("first occurrence of this pattern", *first_span)
@@ -1022,7 +1130,7 @@ impl<'a> Sema<'a> {
                             );
                         }
                     } else {
-                        seen_ints.insert(*n, pattern_span);
+                        seen_ints.insert(n, pattern_span);
                     }
                 }
                 RirPattern::Bool(b, _) => {
@@ -1164,7 +1272,18 @@ impl<'a> Sema<'a> {
             // Convert pattern to AIR pattern
             let air_pattern = match pattern {
                 RirPattern::Wildcard(_) => AirPattern::Wildcard,
-                RirPattern::Int(n, _) => AirPattern::Int(*n),
+                RirPattern::Int {
+                    value, negative, ..
+                } => {
+                    // Already range-checked above; wrapping_neg handles the
+                    // i64::MIN magnitude (9223372036854775808).
+                    let n = if *negative {
+                        (*value as i64).wrapping_neg()
+                    } else {
+                        *value as i64
+                    };
+                    AirPattern::Int(n)
+                }
                 RirPattern::Bool(b, _) => AirPattern::Bool(*b),
                 RirPattern::Path {
                     module,

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -419,8 +419,8 @@ impl<'a> AnalysisContext<'a> {
             .map(|(moves, _)| moves);
 
         let Some(first) = live.next() else {
-            // Every arm diverges (or there are no arms, which is rejected
-            // earlier as an empty match).
+            // Every arm diverges. (A zero-arm match on a zero-variant enum
+            // returns early in analyze_match and never reaches this merge.)
             if let Some((moves, _)) = arm_moves.into_iter().next() {
                 self.moved_vars = moves;
             }

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1603,6 +1603,16 @@ impl<'a> CfgBuilder<'a> {
                 let arms: Vec<(AirPattern, AirRef)> =
                     self.air.get_match_arms(*arms_start, *arms_len).collect();
 
+                // `match v {}` on a zero-variant enum (RUE-169): the scrutinee
+                // type is uninhabited, so this point can never be reached with
+                // a value. Sema verified exhaustiveness (vacuously); no switch
+                // is needed and control diverges.
+                if arms.is_empty() {
+                    self.cfg
+                        .set_terminator(self.current_block, Terminator::Unreachable);
+                    return Self::diverged();
+                }
+
                 // Create blocks for each arm and a join block
                 let arm_blocks: Vec<_> = arms.iter().map(|_| self.cfg.new_block()).collect();
                 let join_block = self.cfg.new_block();

--- a/crates/rue-cli-tests/cases/match_patterns.toml
+++ b/crates/rue-cli-tests/cases/match_patterns.toml
@@ -1,0 +1,176 @@
+# Match pattern literal range checks and empty matches (RUE-74, RUE-169).
+#
+# Pattern literals used to be converted to i64 with a raw `as` cast before any
+# range check against the scrutinee type, so out-of-range patterns silently
+# wrapped/truncated and then MATCHED the wrapped value at runtime
+# (miscompile-grade): `9223372036854775808` matched i64::MIN, `-1` matched
+# u64::MAX, `4294967296` matched u32 0. Patterns are now range-checked like
+# `let` bindings (E0800) and negative patterns on unsigned scrutinees are
+# rejected (E0801), per spec 4.7:23/4.7:24.
+#
+# `match v {}` on a zero-variant enum is legal (spec 4.7:26) and the braces
+# are the empty arm list, not a struct literal `v {}` (spec 4.7:28).
+
+[section]
+id = "cli.match_patterns"
+name = "Match pattern range checks and empty matches"
+description = "Out-of-range pattern literals are compile errors, not wrap-and-match; empty match works on uninhabited enums."
+
+[[case]]
+name = "pattern_2_to_63_does_not_wrap_match_i64_min"
+description = "Pattern 2^63 used to wrap to i64::MIN and match it at runtime (RUE-74)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i64 = -9223372036854775808;
+    match x {
+        9223372036854775808 => 1,
+        _ => 0,
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0800", "out of range", "i64"]
+
+[[case]]
+name = "negative_pattern_does_not_match_u64_max"
+description = "Pattern -1 used to wrap to the u64::MAX bit pattern and match it (RUE-74)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: u64 = 18446744073709551615;
+    match x {
+        -1 => 1,
+        _ => 0,
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0801"]
+
+[[case]]
+name = "negative_pattern_on_u8_is_not_a_silent_dead_arm"
+description = "Pattern -1 on a u8 scrutinee used to compile to an arm that could never match (RUE-74)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: u8 = 255;
+    match x {
+        -1 => 1,
+        _ => 0,
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0801"]
+
+[[case]]
+name = "pattern_2_to_32_does_not_truncate_match_u32_zero"
+description = "Pattern 4294967296 used to truncate (compounded by a 32-bit compare) and match u32 0 (RUE-74)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: u32 = 0;
+    match x {
+        4294967296 => 1,
+        _ => 0,
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0800", "u32"]
+
+[[case]]
+name = "pattern_out_of_range_i8_does_not_truncate"
+description = "Pattern 4294967340 used to truncate to i8 44 and match it (RUE-74)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i8 = 44;
+    match x {
+        4294967340 => 1,
+        _ => 0,
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0800", "i8"]
+
+[[case]]
+name = "below_i64_min_pattern_does_not_wrap_to_i64_max"
+description = "Pattern -9223372036854775809 used to wrap to i64::MAX and match it (RUE-74)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i64 = 9223372036854775807;
+    match x {
+        -9223372036854775809 => 1,
+        _ => 0,
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0800"]
+
+[[case]]
+name = "i64_min_pattern_still_legal_and_matches"
+description = "The i64::MIN literal edge: -9223372036854775808 must remain a valid pattern."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i64 = -9223372036854775808;
+    match x {
+        -9223372036854775808 => 42,
+        _ => 0,
+    }
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "u64_max_pattern_still_legal_and_matches"
+description = "u64 patterns above i64::MAX are in range for the scrutinee and must keep matching."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: u64 = 18446744073709551615;
+    match x {
+        18446744073709551615 => 42,
+        _ => 0,
+    }
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "u32_max_pattern_matches_at_32_bit_width"
+description = "In-range u32 boundary value compares correctly at 32-bit width."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: u32 = 4294967295;
+    match x {
+        4294967295 => 42,
+        _ => 0,
+    }
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "empty_match_on_zero_variant_enum_unparenthesized"
+description = "`match v {}` parses the braces as the arm list, not a struct literal `v {}` (RUE-169)."
+files = [{ path = "main.rue", source = """
+enum Never {}
+
+fn absurd(n: Never) -> i32 {
+    match n {}
+}
+
+fn main() -> i32 {
+    7
+}
+""" }]
+exit_code = 7
+
+[[case]]
+name = "empty_match_on_integer_still_rejected"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = 0;
+    match x {}
+}
+""" }]
+compile_fail = true
+error_contains = ["E0601"]

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -1019,6 +1019,14 @@ where
         .boxed();
 
     // Match expression: match scrutinee { pattern => expr, ... }
+    //
+    // The arm block is `.or_not()` because of a brace ambiguity: in
+    // `match v {}` the expression parser greedily parses `v {}` as a
+    // zero-field struct literal, swallowing the braces that were meant to be
+    // the (empty) arm list. Per spec 4.7:28 a struct literal may not appear
+    // unparenthesized as the scrutinee, so the `try_map_with` below
+    // reinterprets that case as an empty arm list and rejects any other bare
+    // struct-literal scrutinee with a targeted diagnostic (RUE-169).
     let match_expr = just(TokenKind::Match)
         .ignore_then(expr.clone())
         .then(
@@ -1026,14 +1034,39 @@ where
                 .separated_by(just(TokenKind::Comma))
                 .allow_trailing()
                 .collect::<Vec<_>>()
-                .delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace)),
+                .delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace))
+                .or_not(),
         )
-        .map_with(|(scrutinee, arms), e| {
-            Expr::Match(MatchExpr {
-                scrutinee: Box::new(scrutinee),
-                arms,
-                span: span_from_extra(e),
-            })
+        .try_map_with(|(scrutinee, arms), e| {
+            let span = {
+                let file_id = e.state().0.file_id;
+                to_rue_span_with_file(e.span(), file_id)
+            };
+            match (scrutinee, arms) {
+                // `match v {}`: reclaim the struct literal's braces as the
+                // match's empty arm list; the scrutinee is the bare identifier.
+                (Expr::StructLit(lit), None) if lit.base.is_none() && lit.fields.is_empty() => {
+                    Ok(Expr::Match(MatchExpr {
+                        scrutinee: Box::new(Expr::Ident(lit.name)),
+                        arms: Vec::new(),
+                        span,
+                    }))
+                }
+                (Expr::StructLit(_), _) => Err(Rich::custom(
+                    e.span(),
+                    "struct literals are not allowed as a bare match scrutinee; \
+                     wrap the scrutinee in parentheses",
+                )),
+                (scrutinee, Some(arms)) => Ok(Expr::Match(MatchExpr {
+                    scrutinee: Box::new(scrutinee),
+                    arms,
+                    span,
+                })),
+                (_, None) => Err(Rich::custom(
+                    e.span(),
+                    "expected '{' and match arms after the match scrutinee",
+                )),
+            }
         })
         .boxed();
 

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -793,9 +793,20 @@ impl<'a> AstGen<'a> {
     fn gen_pattern(&mut self, pattern: &Pattern) -> RirPattern {
         match pattern {
             Pattern::Wildcard(span) => RirPattern::Wildcard(*span),
-            Pattern::Int(lit) => RirPattern::Int(lit.value as i64, lit.span),
-            // Use wrapping_neg to handle i64::MIN correctly (where value is 9223372036854775808)
-            Pattern::NegInt(lit) => RirPattern::Int((lit.value as i64).wrapping_neg(), lit.span),
+            // Keep the raw u64 magnitude and sign: Sema range-checks the
+            // literal against the scrutinee type (E0800/E0801) before
+            // converting it to a comparison value, so out-of-range patterns
+            // are rejected instead of silently wrapping (RUE-74).
+            Pattern::Int(lit) => RirPattern::Int {
+                value: lit.value,
+                negative: false,
+                span: lit.span,
+            },
+            Pattern::NegInt(lit) => RirPattern::Int {
+                value: lit.value,
+                negative: true,
+                span: lit.span,
+            },
             Pattern::Bool(lit) => RirPattern::Bool(lit.value, lit.span),
             Pattern::Path(path) => {
                 // If there's a base expression (module reference), generate it first
@@ -1438,8 +1449,22 @@ mod tests {
             } => {
                 let arms = rir.get_match_arms(*arms_start, *arms_len);
                 assert_eq!(arms.len(), 3);
-                assert!(matches!(arms[0].0, RirPattern::Int(1, _)));
-                assert!(matches!(arms[1].0, RirPattern::Int(2, _)));
+                assert!(matches!(
+                    arms[0].0,
+                    RirPattern::Int {
+                        value: 1,
+                        negative: false,
+                        ..
+                    }
+                ));
+                assert!(matches!(
+                    arms[1].0,
+                    RirPattern::Int {
+                        value: 2,
+                        negative: false,
+                        ..
+                    }
+                ));
                 assert!(matches!(arms[2].0, RirPattern::Wildcard(_)));
             }
             _ => panic!("expected Match"),
@@ -1474,8 +1499,22 @@ mod tests {
             } => {
                 let arms = rir.get_match_arms(*arms_start, *arms_len);
                 assert_eq!(arms.len(), 3);
-                assert!(matches!(arms[0].0, RirPattern::Int(-5, _)));
-                assert!(matches!(arms[1].0, RirPattern::Int(-10, _)));
+                assert!(matches!(
+                    arms[0].0,
+                    RirPattern::Int {
+                        value: 5,
+                        negative: true,
+                        ..
+                    }
+                ));
+                assert!(matches!(
+                    arms[1].0,
+                    RirPattern::Int {
+                        value: 10,
+                        negative: true,
+                        ..
+                    }
+                ));
                 assert!(matches!(arms[2].0, RirPattern::Wildcard(_)));
             }
             _ => panic!("expected Match"),

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -112,8 +112,18 @@ impl RirCallArg {
 pub enum RirPattern {
     /// Wildcard pattern `_` - matches anything
     Wildcard(Span),
-    /// Integer literal pattern (can be positive or negative)
-    Int(i64, Span),
+    /// Integer literal pattern. The magnitude and sign are kept separate so
+    /// Sema can range-check the literal against the scrutinee type exactly
+    /// like `let` bindings (E0800/E0801) instead of silently wrapping
+    /// (RUE-74). `negative` means the source had a leading `-`.
+    Int {
+        /// Magnitude of the literal as written (e.g. 128 for `-128`).
+        value: u64,
+        /// True if the pattern was written with a leading minus sign.
+        negative: bool,
+        /// Span of the pattern (including the minus sign, if any).
+        span: Span,
+    },
     /// Boolean literal pattern
     Bool(bool, Span),
     /// Path pattern for enum variants (e.g., `Color::Red` or `module.Color::Red`)
@@ -134,7 +144,7 @@ impl RirPattern {
     pub fn span(&self) -> Span {
         match self {
             RirPattern::Wildcard(span) => *span,
-            RirPattern::Int(_, span) => *span,
+            RirPattern::Int { span, .. } => *span,
             RirPattern::Bool(_, span) => *span,
             RirPattern::Path { span, .. } => *span,
         }
@@ -173,7 +183,7 @@ pub enum PatternKind {
 
 /// Size of each pattern kind in the extra array (including body InstRef)
 const PATTERN_WILDCARD_SIZE: u32 = 4; // kind, span_start, span_len, body
-const PATTERN_INT_SIZE: u32 = 6; // kind, span_start, span_len, value_lo, value_hi, body
+const PATTERN_INT_SIZE: u32 = 7; // kind, span_start, span_len, value_lo, value_hi, negative, body
 const PATTERN_BOOL_SIZE: u32 = 5; // kind, span_start, span_len, value, body
 const PATTERN_PATH_SIZE: u32 = 7; // kind, span_start, span_len, module, type_name, variant, body
 
@@ -390,13 +400,18 @@ impl Rir {
                     self.extra.push(span.len());
                     self.extra.push(body.as_u32());
                 }
-                RirPattern::Int(value, span) => {
+                RirPattern::Int {
+                    value,
+                    negative,
+                    span,
+                } => {
                     self.extra.push(PatternKind::Int as u32);
                     self.extra.push(span.start());
                     self.extra.push(span.len());
-                    // Store i64 as two u32s (little-endian)
+                    // Store u64 magnitude as two u32s (little-endian) plus sign flag
                     self.extra.push(*value as u32);
                     self.extra.push((*value >> 32) as u32);
+                    self.extra.push(u32::from(*negative));
                     self.extra.push(body.as_u32());
                 }
                 RirPattern::Bool(value, span) => {
@@ -446,11 +461,19 @@ impl Rir {
                     let span_start = self.extra[pos + 1];
                     let span_len = self.extra[pos + 2];
                     let span = Span::new(span_start, span_start + span_len);
-                    let value_lo = self.extra[pos + 3] as i64;
-                    let value_hi = self.extra[pos + 4] as i64;
+                    let value_lo = self.extra[pos + 3] as u64;
+                    let value_hi = self.extra[pos + 4] as u64;
                     let value = value_lo | (value_hi << 32);
-                    let body = InstRef::from_raw(self.extra[pos + 5]);
-                    arms.push((RirPattern::Int(value, span), body));
+                    let negative = self.extra[pos + 5] != 0;
+                    let body = InstRef::from_raw(self.extra[pos + 6]);
+                    arms.push((
+                        RirPattern::Int {
+                            value,
+                            negative,
+                            span,
+                        },
+                        body,
+                    ));
                     pos += PATTERN_INT_SIZE as usize;
                 }
                 k if k == PatternKind::Bool as u32 => {
@@ -1670,7 +1693,15 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
     fn format_pattern(&self, pat: &RirPattern) -> String {
         match pat {
             RirPattern::Wildcard(_) => "_".to_string(),
-            RirPattern::Int(n, _) => n.to_string(),
+            RirPattern::Int {
+                value, negative, ..
+            } => {
+                if *negative {
+                    format!("-{}", value)
+                } else {
+                    value.to_string()
+                }
+            }
             RirPattern::Bool(b, _) => b.to_string(),
             RirPattern::Path {
                 module,
@@ -2228,11 +2259,19 @@ mod tests {
     #[test]
     fn test_rir_pattern_int_span() {
         let span = Span::new(20, 22);
-        let pattern = RirPattern::Int(42, span);
+        let pattern = RirPattern::Int {
+            value: 42,
+            negative: false,
+            span,
+        };
         assert_eq!(pattern.span(), span);
 
         // Test negative int
-        let pattern_neg = RirPattern::Int(-100, span);
+        let pattern_neg = RirPattern::Int {
+            value: 100,
+            negative: true,
+            span,
+        };
         assert_eq!(pattern_neg.span(), span);
     }
 
@@ -3536,8 +3575,22 @@ mod tests {
         });
 
         let (arms_start, arms_len) = rir.add_match_arms(&[
-            (RirPattern::Int(1, Span::new(0, 1)), body1),
-            (RirPattern::Int(-5, Span::new(0, 2)), body2),
+            (
+                RirPattern::Int {
+                    value: 1,
+                    negative: false,
+                    span: Span::new(0, 1),
+                },
+                body1,
+            ),
+            (
+                RirPattern::Int {
+                    value: 5,
+                    negative: true,
+                    span: Span::new(0, 2),
+                },
+                body2,
+            ),
             (RirPattern::Wildcard(Span::new(0, 1)), body_default),
         ]);
 

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -727,3 +727,204 @@ fn main() -> i32 {
 }
 """
 exit_code = 10
+# =============================================================================
+# Pattern Range Requirements (4.7:23, 4.7:24)
+# =============================================================================
+
+[[case]]
+name = "pattern_out_of_range_u32"
+spec = ["4.7:23"]
+source = """
+fn main() -> i32 {
+    let x: u32 = 0;
+    match x {
+        4294967296 => 1,
+        _ => 0,
+    }
+}
+"""
+compile_fail = true
+error_contains = "out of range"
+
+[[case]]
+name = "pattern_out_of_range_i64_positive"
+spec = ["4.7:23"]
+source = """
+fn main() -> i32 {
+    let x: i64 = -9223372036854775808;
+    match x {
+        9223372036854775808 => 1,
+        _ => 0,
+    }
+}
+"""
+compile_fail = true
+error_contains = "out of range"
+
+[[case]]
+name = "pattern_out_of_range_i8_negative"
+spec = ["4.7:23"]
+source = """
+fn main() -> i32 {
+    let x: i8 = 0;
+    match x {
+        -129 => 1,
+        _ => 0,
+    }
+}
+"""
+compile_fail = true
+error_contains = "out of range"
+
+[[case]]
+name = "pattern_i64_min_negated_literal_is_legal"
+spec = ["4.7:23"]
+source = """
+fn main() -> i32 {
+    let x: i64 = -9223372036854775808;
+    match x {
+        -9223372036854775808 => 42,
+        _ => 0,
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "pattern_i8_min_negated_literal_is_legal"
+spec = ["4.7:23"]
+source = """
+fn main() -> i32 {
+    let x: i8 = -128;
+    match x {
+        -128 => 42,
+        _ => 0,
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "pattern_u64_max_is_legal"
+spec = ["4.7:23"]
+source = """
+fn main() -> i32 {
+    let x: u64 = 18446744073709551615;
+    match x {
+        18446744073709551615 => 42,
+        _ => 0,
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "negative_pattern_on_unsigned_scrutinee"
+spec = ["4.7:24"]
+source = """
+fn main() -> i32 {
+    let x: u64 = 18446744073709551615;
+    match x {
+        -1 => 1,
+        _ => 0,
+    }
+}
+"""
+compile_fail = true
+error_contains = "unary operator"
+
+[[case]]
+name = "negative_pattern_on_u8_scrutinee"
+spec = ["4.7:24"]
+source = """
+fn main() -> i32 {
+    let x: u8 = 0;
+    match x {
+        -1 => 1,
+        _ => 0,
+    }
+}
+"""
+compile_fail = true
+
+# =============================================================================
+# Empty Match Expressions (4.7:26, 4.7:27, 4.7:28)
+# =============================================================================
+
+[[case]]
+name = "empty_match_on_zero_variant_enum"
+spec = ["4.7:26", "4.7:28"]
+source = """
+enum Never {}
+
+fn absurd(n: Never) -> i32 {
+    match n {}
+}
+
+fn main() -> i32 {
+    7
+}
+"""
+exit_code = 7
+
+[[case]]
+name = "empty_match_has_never_type"
+spec = ["4.7:26", "4.7:27"]
+source = """
+enum Never {}
+
+fn pick(n: Never) -> bool {
+    match (n) {}
+}
+
+fn main() -> i32 {
+    3
+}
+"""
+exit_code = 3
+
+[[case]]
+name = "empty_match_on_integer_is_error"
+spec = ["4.7:26"]
+source = """
+fn main() -> i32 {
+    let x: i32 = 0;
+    match x {}
+}
+"""
+compile_fail = true
+error_contains = "no arms"
+
+[[case]]
+name = "empty_match_on_inhabited_enum_is_error"
+spec = ["4.7:26"]
+source = """
+enum Color {
+    Red,
+    Green,
+}
+
+fn main() -> i32 {
+    let c = Color::Red;
+    match c {}
+}
+"""
+compile_fail = true
+error_contains = "no arms"
+
+[[case]]
+name = "struct_literal_scrutinee_requires_parens"
+spec = ["4.7:28"]
+source = """
+struct Point {
+    x: i32,
+}
+
+fn main() -> i32 {
+    match Point { x: 1 } {
+        _ => 0,
+    }
+}
+"""
+compile_fail = true
+error_contains = "parentheses"

--- a/crates/rue-ui-tests/cases/warnings/unreachable.toml
+++ b/crates/rue-ui-tests/cases/warnings/unreachable.toml
@@ -289,3 +289,70 @@ fn main() -> i32 {
 """
 exit_code = 3
 no_warnings = true
+
+# RUE-168: a `_` arm is unreachable when the preceding arms already cover
+# every possible value (both bools, or every enum variant). Spec 4.7:17 and
+# 4.7:20 mandate the warning; it previously only fired after an earlier `_`.
+[[case]]
+name = "wildcard_after_full_enum_coverage"
+source = """
+enum Color { Red, Green }
+fn main() -> i32 {
+    match Color::Red {
+        Color::Red => 1,
+        Color::Green => 2,
+        _ => 3,
+    }
+}
+"""
+exit_code = 1
+warning_contains = ["unreachable pattern", "'_'", "already cover every possible value"]
+expected_warning_count = 1
+
+[[case]]
+name = "wildcard_after_full_bool_coverage"
+source = """
+fn main() -> i32 {
+    match false {
+        true => 1,
+        false => 2,
+        _ => 3,
+    }
+}
+"""
+exit_code = 2
+warning_contains = ["unreachable pattern", "'_'", "already cover every possible value"]
+expected_warning_count = 1
+
+# Negative control: a `_` arm with enum variants still missing is load-bearing
+# and must NOT warn.
+[[case]]
+name = "wildcard_covering_missing_enum_variant_no_warning"
+source = """
+enum Color { Red, Green, Blue }
+fn main() -> i32 {
+    match Color::Blue {
+        Color::Red => 1,
+        Color::Green => 2,
+        _ => 3,
+    }
+}
+"""
+exit_code = 3
+no_warnings = true
+
+# Negative control: integers are never exhausted by literal arms, so the
+# wildcard is always reachable there.
+[[case]]
+name = "wildcard_after_int_literals_no_warning"
+source = """
+fn main() -> i32 {
+    match 7 {
+        1 => 1,
+        2 => 2,
+        _ => 3,
+    }
+}
+"""
+exit_code = 3
+no_warnings = true

--- a/docs/spec/src/04-expressions/07-match-expressions.md
+++ b/docs/spec/src/04-expressions/07-match-expressions.md
@@ -15,7 +15,7 @@ A match expression provides multi-way branching based on pattern matching.
 ```ebnf
 match_expr = "match" expression "{" { match_arm "," } [ match_arm ] "}" ;
 match_arm = pattern "=>" expression ;
-pattern = "_" | INTEGER | BOOL | enum_variant_pattern ;
+pattern = "_" | [ "-" ] INTEGER | BOOL | enum_variant_pattern ;
 enum_variant_pattern = IDENT "::" IDENT ;
 ```
 
@@ -157,5 +157,66 @@ fn main() -> i32 {
         1 => 20,  // warning: unreachable pattern '1'
         _ => 0,
     }
+}
+```
+
+## Pattern Range Requirements
+
+{{ rule(id="4.7:23", cat="legality-rule") }}
+
+An integer literal pattern **MUST** denote a value representable in the
+scrutinee's type. A pattern whose value is out of range for the scrutinee type
+is rejected with a compile-time error, exactly as an out-of-range integer
+literal in any other position (3.1:17). A negated literal that denotes the
+minimum value of a signed scrutinee type remains valid (3.1:18).
+
+{{ rule(id="4.7:24", cat="legality-rule") }}
+
+A negative integer literal pattern **MUST NOT** be used with a scrutinee of
+unsigned type. Such a pattern is rejected with a compile-time error; unsigned
+values are never negative, so the arm could never match.
+
+{{ rule(id="4.7:25", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    let x: u32 = 0;
+    match x {
+        4294967296 => 1,  // error: out of range for u32
+        -1 => 2,          // error: negative pattern on unsigned scrutinee
+        _ => 0,
+    }
+}
+```
+
+## Empty Match Expressions
+
+{{ rule(id="4.7:26", cat="normative") }}
+
+A match expression with zero arms is legal if and only if the scrutinee's type
+is an enum with zero variants. Such a type has no values, so the empty pattern
+set vacuously satisfies exhaustiveness (4.7:8). A match expression with zero
+arms on any other type is rejected with a compile-time error.
+
+{{ rule(id="4.7:27", cat="normative") }}
+
+The type of a match expression with zero arms is `!` (the never type): the
+expression can never be reached with a scrutinee value, so it never produces
+a value.
+
+{{ rule(id="4.7:28", cat="normative") }}
+
+A struct literal **MUST NOT** appear as the outermost expression of a match
+scrutinee; a program that requires one parenthesizes the scrutinee.
+Consequently, in `match v {}` the braces denote the match expression's empty
+arm list, not a struct literal `v {}`.
+
+{{ rule(id="4.7:29", cat="example") }}
+
+```rue
+enum Never {}
+
+fn absurd(n: Never) -> i32 {
+    match n {}  // legal: zero arms cover the zero values of `Never`
 }
 ```


### PR DESCRIPTION
Pattern-matching cluster from the hunt; the headline item was miscompile-grade.

**RUE-74 — out-of-range patterns wrapped and matched wrong values.** Pattern `9223372036854775808` (2^63) wrapped to i64::MIN and **matched** it; `-1` against a u64 scrutinee **matched u64::MAX**; `4294967296` against u32 truncated and matched 0. `RirPattern::Int` now carries the raw u64 magnitude + sign, and sema range-checks every pattern literal against the scrutinee type (`check_pattern_int`): E0800 for out-of-range, E0801 for negative-on-unsigned — the same rules let-bindings already enforce (spec 4.7:13). The `i64::MIN` pattern stays legal (verified exit 7); u64::MAX patterns still match.

**RUE-168** — a `_` arm subsumed by full bool/enum coverage now warns unreachable per spec 4.7:17/20. (RUE-75's duplicate-arm warning was already fixed in-tree — verified, not claimed.)

**RUE-169** — `match v {}` on a zero-variant enum: the parser reclaims the braces from the greedy struct-literal parse (Rust's no-bare-struct-literal-scrutinee rule, with a targeted "wrap the scrutinee in parentheses" diagnostic), sema accepts zero arms on uninhabited enums with type `!`, and the CFG lowers it as `Terminator::Unreachable` (backend-agnostic; aarch64 verified via `--emit asm`).

Spec 4.7:23–29 + the 4.7:2 grammar note; 13 spec cases, 11 CLI cases (`match_patterns.toml`), 4 UI cases; traceability 100%. Verified post-integration: E0800/E0801 fire on the wrap repros, i64::MIN matches. Full ./test.sh green.

Fixes RUE-74
Fixes RUE-168
Fixes RUE-169

🤖 Generated with [Claude Code](https://claude.com/claude-code)