### PR TITLE
Cross-compilation: refuse to link foreign targets with the host runtime; ADR-0034 for the real fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -673,7 +673,7 @@ Adding a variant (e.g. a 64-bit `Cqo`, `And64RR`, or aarch64 `Sdiv64RR`) touches
 
 Tip: `grep -n <SiblingVariant> crates/rue-codegen/src/<arch>/*.rs` lists every site you need to mirror.
 
-**Testing across backends**: x86-64 is verifiable locally (build + run). aarch64 is **not runnable locally** — you can only `--emit asm` and read it (cross-compiled binaries also embed the host runtime, RUE-36). But CI's `test (linux-arm64)` and `test (macos)` jobs build `rue` *natively* on arm64 and run the binaries, so an aarch64-only bug **will fail CI**. Therefore: **apply the parallel aarch64 change in the SAME PR** — never ship an x86-only fix expecting to follow up, or CI will bounce it. Use `known_bug` / `known_bug_on` in CLI tests only when a *separate, tracked* bug makes a case fail on one platform.
+**Testing across backends**: x86-64 is verifiable locally (build + run). aarch64 is **not runnable locally** — you can only `--emit asm` and read it (cross-target *links* are refused outright because only the host runtime is embedded; RUE-36 / ADR-0034). But CI's `test (linux-arm64)` and `test (macos)` jobs build `rue` *natively* on arm64 and run the binaries, so an aarch64-only bug **will fail CI**. Therefore: **apply the parallel aarch64 change in the SAME PR** — never ship an x86-only fix expecting to follow up, or CI will bounce it. Use `known_bug` / `known_bug_on` in CLI tests only when a *separate, tracked* bug makes a case fail on one platform.
 
 ## Version Control
 

--- a/crates/rue-cli-tests/cases/linker.toml
+++ b/crates/rue-cli-tests/cases/linker.toml
@@ -17,10 +17,13 @@ description = "Cross-compile and link-path behavior, including diagnostic cleanl
 # case and xfailed on the linux hosts:
 #   - macOS: aarch64-macos is the NATIVE target — it compiles & links cleanly,
 #     so this runs as a real regression test (DEBUG guard + successful compile).
-#   - linux (x86-64 / aarch64): aarch64-macos can't cross-link yet (RUE-85), so
-#     the compile fails. Marked known_bug RUE-85 on those platforms (xfail).
-#     When RUE-85 is fixed, drop `known_bug_on` and it becomes a real test on
-#     linux too.
+#   - linux (x86-64 / aarch64): aarch64-macos can't cross-link. Since the
+#     RUE-36 stopgap, the compile fails *by design* with the clear
+#     cross-target-runtime error (before that it failed deep in the Mach-O
+#     link path, RUE-85). Marked known_bug RUE-85 on those platforms (xfail).
+#     When cross-target runtimes land (RUE-36 / ADR-0034) and Mach-O
+#     cross-linking works (RUE-85), drop `known_bug_on` and this becomes a
+#     real test on linux too.
 [[case]]
 name = "aarch64_macos_link_no_debug_spew"
 files = [{ path = "main.rue", source = """
@@ -31,3 +34,100 @@ compile_only = true
 compile_stderr_not_contains = ["DEBUG"]
 known_bug = "RUE-85"
 known_bug_on = ["x86-64-linux", "aarch64-linux"]
+
+# ---------------------------------------------------------------------------
+# RUE-36 / ADR-0034: cross-target links are refused with a clear error.
+#
+# The compiler embeds exactly one rue-runtime staticlib, built for the HOST.
+# Before the stopgap, `--target <foreign>` happily linked host x86-64 machine
+# code into an "AArch64" ELF (objdump-verified) and reported success. Now the
+# driver refuses at link time with an error that names both targets, cites
+# RUE-36, and points the user at `--emit asm` (which still works for every
+# target on every host).
+#
+# Whether a given `--target` is foreign depends on the host, so each refusal
+# case is scoped with `only_on` to the hosts where the target is a true
+# cross-compile. When per-target runtimes land (ADR-0034), these flip into
+# "cross-compile succeeds and the ELF machine field is correct" cases.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "cross_link_to_aarch64_linux_refused"
+description = "On non-aarch64-linux hosts, --target aarch64-linux must fail clearly instead of emitting an ELF with host machine code (RUE-36)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--target", "aarch64-linux", "-o", "prog"]
+compile_fail = true
+error_contains = [
+    "cannot link an executable for aarch64-linux",
+    "only embeds",
+    "runtime library",
+    "RUE-36",
+    "--emit asm",
+]
+only_on = ["x86-64-linux", "aarch64-macos"]
+
+[[case]]
+name = "cross_link_to_x86_64_linux_refused"
+description = "On aarch64 hosts, --target x86-64-linux must fail clearly instead of emitting an ELF with host machine code (RUE-36)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--target", "x86-64-linux", "-o", "prog"]
+compile_fail = true
+error_contains = [
+    "cannot link an executable for x86-64-linux",
+    "only embeds",
+    "runtime library",
+    "RUE-36",
+    "--emit asm",
+]
+only_on = ["aarch64-linux", "aarch64-macos"]
+
+[[case]]
+name = "cross_link_to_aarch64_macos_refused"
+description = "On linux hosts, --target aarch64-macos must fail with the RUE-36 cross-target-runtime error (not a deep Mach-O link failure)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { 0 }
+""" }]
+args = ["main.rue", "--target", "aarch64-macos", "-o", "prog"]
+compile_fail = true
+error_contains = [
+    "cannot link an executable for aarch64-macos",
+    "only embeds",
+    "runtime library",
+    "RUE-36",
+    "--emit asm",
+]
+only_on = ["x86-64-linux", "aarch64-linux"]
+
+# Cross-target CODEGEN must keep working everywhere: --emit asm doesn't link,
+# so it must not be affected by the RUE-36 refusal. These run on every host
+# (on the matching host they're a native emit, which must also work).
+[[case]]
+name = "emit_asm_for_aarch64_linux_works_everywhere"
+description = "--emit asm --target aarch64-linux prints aarch64 assembly on any host (no link, no RUE-36 refusal)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { 42 }
+""" }]
+args = ["--emit", "asm", "--target", "aarch64-linux", "main.rue"]
+compile_only = true
+compile_stdout_contains = [
+    "=== Assembly (aarch64-linux) ===",
+    "stp x29, x30",
+    "bl __rue_exit",
+]
+
+[[case]]
+name = "emit_asm_for_x86_64_linux_works_everywhere"
+description = "--emit asm --target x86-64-linux prints x86-64 assembly on any host (no link, no RUE-36 refusal)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { 42 }
+""" }]
+args = ["--emit", "asm", "--target", "x86-64-linux", "main.rue"]
+compile_only = true
+compile_stdout_contains = [
+    "=== Assembly (x86-64-linux) ===",
+    "call __rue_exit",
+]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -49,6 +49,9 @@
 //! - `known_bug = "RUE-NN"`: expected failure (xfail). The case runs; if it
 //!   fails, it is reported as ignored with the bug reference. If it PASSES,
 //!   the suite fails loudly so the marker gets removed when the bug is fixed.
+//! - `only_on = ["x86-64-linux", ...]`: run the case only on these hosts
+//!   (ignored elsewhere). For behavior that depends on the host platform,
+//!   e.g. whether `--target X` is a cross-compile or a native compile.
 //!
 //! # ICE detection
 //!
@@ -172,6 +175,12 @@ struct Case {
     /// test. Useful for ABI bugs that manifest differently per target.
     #[serde(default)]
     known_bug_on: Vec<String>,
+    /// Platforms this case runs on (e.g. ["x86-64-linux"]); elsewhere it is
+    /// reported as ignored. Empty means all platforms. Use when the expected
+    /// behavior itself depends on the host (e.g. `--target X` is a
+    /// cross-compile on some hosts and a native compile on others).
+    #[serde(default)]
+    only_on: Vec<String>,
     /// Skip this case entirely.
     #[serde(default)]
     skip: bool,
@@ -388,6 +397,19 @@ fn run_case_wrapper(
 ) -> Result<(), RunError> {
     if case.skip {
         return ctx.ignore_for("marked as skip");
+    }
+
+    // Host-dependent cases: only run on the listed platforms.
+    if !case.only_on.is_empty()
+        && !case
+            .only_on
+            .iter()
+            .any(|p| p == rue_test_runner::get_host_target())
+    {
+        return ctx.ignore_for(format!(
+            "not applicable on this host (only_on = {:?})",
+            case.only_on
+        ));
     }
 
     let result = run_case(case, rue_binary, real_std);

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -154,7 +154,36 @@ impl Drop for TempLinkDir {
 
 /// The rue-runtime staticlib archive bytes, embedded at compile time.
 /// This is linked into every Rue executable.
+///
+/// NOTE: there is exactly one embedded archive and it is built for the
+/// *host* this compiler binary was built on. Linking an executable for any
+/// other target is therefore refused (see [`runtime_for_target`] and
+/// RUE-36 / ADR-0034) until per-target runtime archives are embedded.
 static RUNTIME_BYTES: &[u8] = include_bytes!("librue_runtime.a");
+
+/// Return the embedded rue-runtime archive for `target`, or a clear error
+/// if this compiler build doesn't carry a runtime for that target.
+///
+/// The build system embeds only the host-configuration staticlib, so any
+/// cross-target link would silently pull host machine code into the foreign
+/// binary (the original RUE-36 failure mode: an "AArch64" ELF whose entry
+/// point was x86-64 code). Refusing here turns that into an honest,
+/// actionable error while leaving cross-target code generation (`--emit
+/// asm`, `--emit mir`, ...) fully usable. ADR-0034 describes the full fix
+/// (per-target runtime archives selected at link time).
+fn runtime_for_target(target: Target) -> CompileResult<&'static [u8]> {
+    let host = Target::host();
+    if target == host {
+        Ok(RUNTIME_BYTES)
+    } else {
+        Err(CompileError::without_span(ErrorKind::LinkError(format!(
+            "cannot link an executable for {target}: this rue compiler was built for {host} \
+             and only embeds the {host} runtime library, so the result would not run on \
+             {target} (RUE-36). Cross-target code generation still works: use \
+             `--emit asm` to inspect {target} assembly.",
+        ))))
+    }
+}
 
 /// Validate that the embedded runtime archive is well-formed.
 ///
@@ -1178,6 +1207,10 @@ fn link_internal_with_warnings(
 ) -> MultiErrorResult<CompileOutput> {
     let _span = info_span!("linker", mode = "internal").entered();
 
+    // Refuse cross-target links up front: only the host runtime is embedded
+    // (RUE-36), and linking without a matching runtime is impossible.
+    let runtime_bytes = runtime_for_target(options.target).map_err(CompileErrors::from)?;
+
     let mut linker = Linker::new(options.target);
 
     // Add all object files to the linker
@@ -1206,7 +1239,7 @@ fn link_internal_with_warnings(
     linker.require_symbol(entry_point);
 
     // Add the runtime library
-    let runtime = Archive::parse(RUNTIME_BYTES)
+    let runtime = Archive::parse(runtime_bytes)
         .map_err(link_error)
         .map_err(CompileErrors::from)?;
     linker
@@ -1240,13 +1273,18 @@ fn link_system_with_warnings(
 ) -> MultiErrorResult<CompileOutput> {
     let _span = info_span!("linker", mode = "system", command = linker_cmd).entered();
 
+    // Refuse cross-target links up front: only the host runtime is embedded
+    // (RUE-36); a system linker would happily mix architectures (or fail
+    // with an opaque message), so catch it here with a clear error.
+    let runtime_bytes = runtime_for_target(options.target).map_err(CompileErrors::from)?;
+
     // Set up temporary directory with object files and runtime
     let mut temp_dir = TempLinkDir::new().map_err(CompileErrors::from)?;
     temp_dir
         .write_object_files(object_files)
         .map_err(CompileErrors::from)?;
     temp_dir
-        .write_runtime(RUNTIME_BYTES)
+        .write_runtime(runtime_bytes)
         .map_err(CompileErrors::from)?;
 
     // Build the linker command
@@ -1799,6 +1837,30 @@ mod tests {
     #[test]
     fn test_embedded_runtime_is_valid() {
         validate_runtime().expect("embedded runtime should be valid");
+    }
+
+    /// The embedded runtime is host-only (RUE-36 / ADR-0034): linking for
+    /// the host target must succeed; any other target must be refused with
+    /// an error that names both targets and points at `--emit asm`.
+    #[test]
+    fn test_runtime_only_available_for_host_target() {
+        assert!(runtime_for_target(Target::host()).is_ok());
+
+        for &target in Target::all() {
+            if target == Target::host() {
+                continue;
+            }
+            let err =
+                runtime_for_target(target).expect_err("cross-target link must be refused (RUE-36)");
+            let msg = err.to_string();
+            assert!(msg.contains(&target.to_string()), "names target: {msg}");
+            assert!(
+                msg.contains(&Target::host().to_string()),
+                "names host: {msg}"
+            );
+            assert!(msg.contains("RUE-36"), "references RUE-36: {msg}");
+            assert!(msg.contains("--emit asm"), "suggests --emit asm: {msg}");
+        }
     }
 
     #[test]

--- a/docs/designs/0034-cross-target-runtime.md
+++ b/docs/designs/0034-cross-target-runtime.md
@@ -1,0 +1,159 @@
+# ADR-0034: Per-Target Runtime Archives for Cross-Compilation
+
+**Status:** Proposed (stopgap implemented: cross-target links are refused with a clear error)
+**Tracking:** RUE-36 (cross-compilation embeds the host runtime), RUE-144 item 7 (build-graph root cause), RUE-85 (Mach-O cross-linking)
+
+## Problem
+
+`rue --target aarch64-linux main.rue -o out` on an x86-64 host used to
+report SUCCESS and emit an ELF whose header said AArch64 but whose entry
+point contained **x86-64 machine code** (objdump-verified; the entry was
+not even 4-byte aligned). The same held for `--target aarch64-macos`. The
+binary was silently unrunnable on real hardware.
+
+The aarch64 *codegen* is fine — CI builds `rue` natively on arm64 and
+runs the produced binaries. Only the cross-compile **driver** path was
+broken, and the root cause is in the build graph, not in the compiler
+source:
+
+- `crates/rue-compiler/BUCK` maps `//crates/rue-runtime:rue-runtime[staticlib]`
+  into `src/librue_runtime.a`, which `lib.rs` embeds via `include_bytes!`.
+- Buck2 builds that staticlib in the **host configuration**. There is
+  exactly one embedded archive, and it is always the host's.
+- Every link (internal ELF/Mach-O linker or `--linker <system>`) pulled
+  that host archive into the output regardless of `--target`. The
+  runtime contains the entry point (`_start`/`__main`), the syscall
+  layer, panic handlers, and all `String`/IO support — i.e. real
+  executable code of the wrong architecture.
+
+Two partial defenses landed independently of this ADR:
+
+1. The linker now validates each object's machine field against the link
+   target and fails with `ArchMismatch` (commit `cccb160c`, RUE-131
+   item 10). This stopped the *silent* part, but the message
+   ("object architecture mismatch: object is X86_64, link target is
+   Aarch64Linux") is misleading — the user's own objects are fine; it is
+   the invisible embedded runtime that is foreign — and it names neither
+   the cause nor a workaround.
+2. This ADR's stopgap (option C below, implemented): the driver refuses
+   the link up front with an error that explains exactly what is
+   missing.
+
+## Goals
+
+- A `--target` link either produces a **correct-architecture, runnable**
+  executable or fails with an error that names the limitation.
+- Cross-target code generation (`--emit asm/mir/...`) keeps working on
+  every host for every target.
+- Hermeticity: the runtime used for target X must be bit-identical no
+  matter which host compiled it (same rustc version, same flags).
+
+## Options Considered
+
+### A. Per-target staticlibs via Buck2 target platforms / transitions
+
+Declare Buck2 `platform()`s for the three Rue targets, apply a
+configuration transition (or `configured_alias`) to build
+`rue-runtime[staticlib]` once per target, map all three archives into
+`rue-compiler`, and have the driver select by `Target`.
+
+- Pros: idiomatic Buck2; the runtime build stays a normal `rust_library`
+  so flags/deps are declared once.
+- Cons: the heaviest option. The vendored hermetic toolchain
+  (`toolchains/rust/defs.bzl`) is **host-only**: each Rust dist tarball
+  ships `rust-std` for its own triple only (verified in `buck-out`: the
+  x86-64 Linux dist contains only `rust-std-x86_64-unknown-linux-gnu`).
+  Cross-configuration `rust_library` builds additionally require
+  per-platform toolchain registration, exec-platform plumbing, and
+  prelude cooperation. High risk of fighting the prelude for what is, in
+  the end, one no-std crate.
+
+### B. Per-target staticlib build rules using the hermetic rustc directly
+
+`rue-runtime` is `#![no_std]`, has **zero dependencies**, and needs only
+`core`/`compiler_builtins`. Compiling it for a foreign target needs just:
+
+1. The already-vendored host `rustc` invoked with `--target <triple>`.
+2. The target's std component: pin three extra
+   `rust-std-1.92.0-{triple}.tar.xz` archives (same `http_archive` +
+   sha256 pattern as `RUST_RELEASES`) and extend the merged sysroot —
+   or pass `-L` to the component's `lib/rustlib/{triple}/lib`.
+3. No platform linker at all: `--crate-type staticlib` only archives
+   objects (rustc's internal ar), so a Linux host can build the
+   aarch64-macos runtime archive and vice versa.
+
+Concretely: a small `cross_runtime` rule (or genrule) per target that
+runs `rustc --target {triple} --crate-type staticlib` with the existing
+runtime flags, three `mapped_srcs` entries in `crates/rue-compiler/BUCK`
+(`src/librue_runtime-{target}.a`), three `include_bytes!` statics, and
+`runtime_for_target()` becomes a total match instead of a host check.
+
+Details to handle:
+
+- The runtime's `rustc_flags` need a per-target split:
+  `-Ctarget-feature=-lse,-lse2,-outline-atomics` is aarch64-only;
+  `-Crelocation-model=static`, `-Cpanic=abort`, `-Copt-level=z`, LTO
+  apply everywhere.
+- CI implication: every platform's build downloads the three (two
+  foreign) `rust-std` components, ~40 MB compressed each, cached by
+  Buck2 like the existing toolchain archives. `validate_runtime()`
+  extends to all three archives, and the existing CLI cases flip from
+  "refused" to "succeeds + correct ELF machine field" (each scoped
+  `only_on` the hosts where the target is foreign).
+- aarch64-macos output remains gated on RUE-85 (Mach-O cross-linking
+  has its own issues beyond the runtime archive); the runtime archive
+  part is still worth shipping so RUE-85 is the only remainder.
+
+- Pros: smallest hermetic full fix; no platform/transition machinery;
+  reuses the `http_archive` pinning pattern; trivially testable
+  (`readelf -h` machine field per archive member).
+- Cons: bypasses the prelude's `rust_library` for the cross builds, so
+  the flag list is duplicated between the `rust_library` (host, used by
+  `rue-runtime-test`) and the cross rule — must be kept in sync.
+
+### C. Hard error: refuse to link for a target whose runtime we don't have
+
+At link time (both internal and system linker paths), if
+`options.target != Target::host()`, fail with:
+
+```
+error: [E1000]: link error: cannot link an executable for aarch64-linux:
+this rue compiler was built for x86-64-linux and only embeds the
+x86-64-linux runtime library, so the result would not run on
+aarch64-linux (RUE-36). Cross-target code generation still works: use
+`--emit asm` to inspect aarch64-linux assembly.
+```
+
+`--emit` paths never reach the linker, so cross-target codegen
+inspection is untouched.
+
+- Pros: tiny, honest, immediately ships; converts a silent (later:
+  cryptic) failure into an actionable one.
+- Cons: not a fix — cross-compilation simply doesn't exist until A or B
+  lands.
+
+## Decision
+
+- **Now (this change): option C.** The check lives in
+  `runtime_for_target()` in `crates/rue-compiler/src/lib.rs`, called by
+  both `link_internal_with_warnings` and `link_system_with_warnings`,
+  so every link path is covered and every `--emit` path is not.
+- **Full fix (proposed): option B.** Pin the three `rust-std`
+  components, add per-target staticlib rules invoking the hermetic
+  rustc, embed all three archives, and make `runtime_for_target()` a
+  total match. Option A is rejected as disproportionate machinery for
+  one dependency-free no-std crate; revisit if Rue ever grows more
+  per-target Rust components.
+
+## Consequences
+
+- Cross-target `-o` builds fail fast with a self-explanatory error
+  instead of producing broken binaries (pre-`cccb160c`) or a misleading
+  `ArchMismatch` (post-`cccb160c`).
+- CLI suite gained a host-conditional `only_on` case scope, since
+  whether `--target X` is a cross-compile depends on the host.
+- When option B lands: flip the three `cross_link_to_*_refused` CLI
+  cases to success cases asserting the ELF `e_machine` field (and keep
+  aarch64-macos xfailed under RUE-85 until Mach-O cross-linking works),
+  delete the refusal branch from `runtime_for_target()`, and mark this
+  ADR Implemented.


### PR DESCRIPTION
Stops the RUE-36 lie honestly while the real fix gets designed.

**Reproduction nuance:** the original *silent* miscompile no longer reproduces verbatim — the RUE-131-era linker arch validation already fails the cross link — but with a misleading `ArchMismatch` blaming the user's (correct) objects rather than the embedded **host** runtime, which is the actual culprit.

**Shipped:** `runtime_for_target()` in rue-compiler refuses `--target != host` on **both** link paths (internal + system linker) with a clear error naming both targets, citing RUE-36, and pointing at `--emit asm` — which is verified to keep working for all targets. Native compile/run is unaffected (smoke-tested). Verified post-integration: the refusal fires with the right message; aarch64 asm still emits.

**ADR-0034 (Proposed)** weighs (a) buck2 platform transitions, (b) hermetic-rustc cross staticlib rules, (c) the hard error — and recommends per-target staticlib rules plus pinning the 3 needed `rust-std` components (the vendored toolchain ships host-only rust-std, which is what puts the full fix beyond one cycle).

Tests: new `only_on` host-scoping support in the CLI harness; 3 cross-link refusal cases + 2 emit-asm cases in `linker.toml`; a unit test pins the message. Full ./test.sh green.

Part of RUE-36 (foreign binaries are now refused, not produced — the Fixes comes with ADR-0034's implementation)
Part of RUE-144 (item 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)