### PR TITLE
Anon-struct type aliases are visible to inference: ICE, field typing, annotations, method results

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -185,6 +185,23 @@ pub struct ConstraintGenerator<'a> {
     /// `None` only in unit tests; production passes the map via
     /// [`Self::with_module_binding_types`].
     module_binding_types: Option<&'a HashMap<(FileId, Spur), Type>>,
+    /// Compile-time type aliases bound by `let` in the current function body
+    /// (`let P = F();` where `F` returns `type`), pre-resolved by sema before
+    /// constraint generation. Consulted after `type_subst` when resolving
+    /// struct-literal type names and `let` annotations, so anonymous-struct
+    /// aliases route through the same concrete paths as named structs
+    /// (RUE-170). Like sema's `comptime_type_vars`, the map is flat (not
+    /// scope-aware). `None` only in unit tests; production passes the map via
+    /// [`Self::with_comptime_local_types`].
+    comptime_local_types: Option<&'a HashMap<Spur, Type>>,
+    /// Method signatures registered after the shared `InferenceContext` was
+    /// built: anonymous-struct methods are registered lazily during comptime
+    /// evaluation, so they're absent from `methods`. Consulted when a method
+    /// key misses `methods`, so a call on an anonymous-struct receiver yields
+    /// its declared return type instead of `<error>` (RUE-164). `None` only
+    /// in unit tests; production passes the map via
+    /// [`Self::with_extra_method_sigs`].
+    extra_method_sigs: Option<&'a HashMap<(StructId, Spur), MethodSig>>,
     /// Type intern pool for creating pointer and array types during constraint generation.
     type_pool: &'a TypeInternPool,
 }
@@ -235,6 +252,8 @@ impl<'a> ConstraintGenerator<'a> {
             type_subst,
             const_types: None,
             module_binding_types: None,
+            comptime_local_types: None,
+            extra_method_sigs: None,
             type_pool,
         }
     }
@@ -253,6 +272,28 @@ impl<'a> ConstraintGenerator<'a> {
         module_binding_types: &'a HashMap<(FileId, Spur), Type>,
     ) -> Self {
         self.module_binding_types = Some(module_binding_types);
+        self
+    }
+
+    /// Provide pre-resolved comptime type aliases (local name -> concrete
+    /// type) for struct-literal and `let`-annotation resolution. See the
+    /// `comptime_local_types` field (RUE-170).
+    pub fn with_comptime_local_types(
+        mut self,
+        comptime_local_types: &'a HashMap<Spur, Type>,
+    ) -> Self {
+        self.comptime_local_types = Some(comptime_local_types);
+        self
+    }
+
+    /// Provide late-registered method signatures (anonymous-struct methods)
+    /// for method-call resolution. See the `extra_method_sigs` field
+    /// (RUE-164).
+    pub fn with_extra_method_sigs(
+        mut self,
+        extra_method_sigs: &'a HashMap<(StructId, Spur), MethodSig>,
+    ) -> Self {
+        self.extra_method_sigs = Some(extra_method_sigs);
         self
     }
 
@@ -286,6 +327,14 @@ impl<'a> ConstraintGenerator<'a> {
             }
             _ => InferType::Concrete(ty),
         }
+    }
+
+    /// Look up a method signature, falling back to the late-registered
+    /// (anonymous-struct) signatures when the shared map misses (RUE-164).
+    fn method_sig(&self, key: &(StructId, Spur)) -> Option<&'a MethodSig> {
+        self.methods
+            .get(key)
+            .or_else(|| self.extra_method_sigs.and_then(|sigs| sigs.get(key)))
     }
 
     /// Resolve a field's declared type on a concrete struct type.
@@ -548,9 +597,18 @@ impl<'a> ConstraintGenerator<'a> {
                 let init_info = self.generate(*init, ctx);
 
                 let var_ty = if let Some(ty_sym) = type_annotation {
-                    // Explicit type annotation - use it and constrain init to match
-                    let ty_name = self.interner.resolve(ty_sym);
-                    if let Some(annotated_ty) = self.resolve_type_name(ty_name) {
+                    // Explicit type annotation - use it and constrain init to
+                    // match. Comptime type aliases (`let P = F(); let p: P =
+                    // ...`) resolve first, mirroring sema's annotation
+                    // validation order (`comptime_type_vars` before the type
+                    // tables); without this the annotation was unenforced and
+                    // any value typechecked against it (RUE-170).
+                    let annotated = self
+                        .comptime_local_types
+                        .and_then(|aliases| aliases.get(ty_sym).copied())
+                        .map(|ty| self.type_to_infer(ty))
+                        .or_else(|| self.resolve_type_name(self.interner.resolve(ty_sym)));
+                    if let Some(annotated_ty) = annotated {
                         self.add_constraint(Constraint::equal(
                             init_info.ty,
                             annotated_ty.clone(),
@@ -1111,14 +1169,22 @@ impl<'a> ConstraintGenerator<'a> {
                 fields_len,
                 ..
             } => {
-                // Check type_subst first (for Self and type parameters in method bodies)
+                // Check type_subst first (for Self and type parameters in
+                // method bodies), then comptime type aliases (`let P = F();
+                // P { ... }`, RUE-170) — mirroring sema, which consults
+                // `comptime_type_vars` before the struct table — then named
+                // structs.
                 let struct_ty = self
                     .type_subst
                     .and_then(|subst| subst.get(type_name).copied())
+                    .or_else(|| {
+                        self.comptime_local_types
+                            .and_then(|aliases| aliases.get(type_name).copied())
+                    })
                     .or_else(|| self.structs.get(type_name).copied());
 
+                let fields = self.rir.get_field_inits(*fields_start, *fields_len);
                 if let Some(struct_ty) = struct_ty {
-                    let fields = self.rir.get_field_inits(*fields_start, *fields_len);
                     // Constrain each initializer against its field's declared
                     // type, so literal initializers are range-checked at the
                     // field's width instead of silently wrapping
@@ -1133,6 +1199,14 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                     InferType::Concrete(struct_ty)
                 } else {
+                    // Unknown type name — sema reports the error. Still visit
+                    // the initializers so every sub-expression gets a type;
+                    // skipping them left compound initializers (`-1`, `1+2`)
+                    // with unresolved variables, which sema then reported as
+                    // an internal compiler error (RUE-170).
+                    for (_, value_ref) in fields.iter() {
+                        self.generate(*value_ref, ctx);
+                    }
                     InferType::Concrete(Type::ERROR)
                 }
             }
@@ -1336,9 +1410,11 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                     InferType::Concrete(ty) => {
                         if let Some(struct_id) = ty.as_struct() {
-                            // Use StructId directly for method lookup
+                            // Use StructId directly for method lookup (falls
+                            // back to late-registered anonymous-struct
+                            // signatures, RUE-164)
                             let method_key = (struct_id, *method);
-                            if let Some(method_sig) = self.methods.get(&method_key) {
+                            if let Some(method_sig) = self.method_sig(&method_key) {
                                 // Generate constraints for arguments
                                 for (arg, param_type) in
                                     args.iter().zip(method_sig.param_types.iter())

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1679,6 +1679,44 @@ impl<'a> Sema<'a> {
         type_subst: Option<&HashMap<Spur, Type>>,
         value_subst: Option<&HashMap<Spur, ConstValue>>,
     ) -> CompileResult<HashMap<InstRef, Type>> {
+        // Pre-resolve `let`-bound comptime type aliases (`let P = F();` where
+        // `F` returns `type`) so inference can see the concrete anonymous
+        // struct types behind them. Without this, `P { ... }`, `let p: P`,
+        // and methods on `P`-typed receivers all fell through to `<error>`
+        // or unconstrained variables (RUE-170, RUE-164). This may create the
+        // anonymous structs (idempotently — analysis re-evaluates the same
+        // initializers later and structural equality dedups them).
+        let comptime_local_types =
+            self.precompute_comptime_type_locals(body, type_subst, value_subst);
+
+        // Anonymous-struct methods are registered lazily (during comptime
+        // evaluation, including the pre-pass above), after the shared
+        // `InferenceContext` was built — so collect the signatures it doesn't
+        // know about. Without these, a method call on an anonymous-struct
+        // receiver inferred to `<error>` and poisoned sibling constraints
+        // (RUE-164).
+        let extra_method_sigs: HashMap<(StructId, Spur), crate::inference::MethodSig> = self
+            .methods
+            .iter()
+            .filter(|(key, _)| !infer_ctx.method_sigs.contains_key(*key))
+            .map(|(key, info)| {
+                (
+                    *key,
+                    crate::inference::MethodSig {
+                        struct_type: info.struct_type,
+                        has_self: info.has_self,
+                        param_types: self
+                            .param_arena
+                            .types(info.params)
+                            .iter()
+                            .map(|t| self.type_to_infer_type(*t))
+                            .collect(),
+                        return_type: self.type_to_infer_type(info.return_type),
+                    },
+                )
+            })
+            .collect();
+
         // Create constraint generator using pre-computed inference context
         let mut cgen = ConstraintGenerator::with_type_subst(
             self.rir,
@@ -1691,7 +1729,9 @@ impl<'a> Sema<'a> {
             type_subst,
         )
         .with_const_types(&infer_ctx.const_types)
-        .with_module_binding_types(&infer_ctx.module_binding_types);
+        .with_module_binding_types(&infer_ctx.module_binding_types)
+        .with_comptime_local_types(&comptime_local_types)
+        .with_extra_method_sigs(&extra_method_sigs);
 
         // Build parameter map for constraint context.
         // Convert Type to InferType so arrays are represented structurally.
@@ -4650,6 +4690,14 @@ impl<'a> Sema<'a> {
         // Track method names in this registration batch to detect duplicates
         let mut seen_methods: std::collections::HashSet<Spur> = std::collections::HashSet::new();
 
+        // Stage registrations and commit only if the whole batch validates.
+        // Inserting one-by-one left earlier methods registered when a later
+        // one failed (e.g. a duplicate name), so re-evaluating the same
+        // AnonStructType — which happens since the RUE-170 inference pre-pass
+        // evaluates type aliases before analysis does — saw the methods as
+        // "already registered", skipped this check, and silently succeeded.
+        let mut staged: Vec<((StructId, Spur), MethodInfo)> = Vec::new();
+
         for method_ref in method_refs {
             let method_inst = self.rir.get(method_ref);
             if let InstData::FnDecl {
@@ -4704,7 +4752,7 @@ impl<'a> Sema<'a> {
                     .param_arena
                     .alloc_method(param_names.into_iter(), param_types.into_iter());
 
-                self.methods.insert(
+                staged.push((
                     key,
                     MethodInfo {
                         struct_type,
@@ -4714,9 +4762,10 @@ impl<'a> Sema<'a> {
                         body: *body,
                         span: method_inst.span,
                     },
-                );
+                ));
             }
         }
+        self.methods.extend(staged);
         Some(())
     }
 

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -756,4 +756,160 @@ impl Sema<'_> {
             _ => Ok(None),
         }
     }
+
+    /// Pre-resolve `let`-bound compile-time type aliases in a function body,
+    /// before HM inference runs (RUE-170, RUE-164).
+    ///
+    /// A binding like `let P = F();` (where `F` returns `type`) only gets a
+    /// concrete type during sema's analysis pass — but inference runs first,
+    /// so every use of `P` as a type name (`P { ... }`, `let p: P = ...`,
+    /// methods on a `P`-typed receiver) used to fall through to `<error>` or
+    /// an unconstrained variable. This walk finds such bindings and evaluates
+    /// their initializers eagerly so the constraint generator can route them
+    /// through the same paths as named structs.
+    ///
+    /// The walk is opportunistic: initializers that can't be evaluated at
+    /// compile time are simply skipped (sema diagnoses them later). Like
+    /// `AnalysisContext::comptime_type_vars`, the resulting map is flat
+    /// (not scope-aware); a shadowed alias resolves to the type value, which
+    /// matches the analysis pass's behavior.
+    ///
+    /// `type_subst` / `value_subst` carry the enclosing comptime parameter
+    /// substitutions (specialized generic bodies), so aliases like
+    /// `let P = Pair(T)` resolve. Discovered aliases also feed back into the
+    /// evaluation environment, so chains (`let Q = Wrap(P)`) resolve too.
+    pub(crate) fn precompute_comptime_type_locals(
+        &mut self,
+        body: InstRef,
+        type_subst: Option<&HashMap<Spur, Type>>,
+        value_subst: Option<&HashMap<Spur, ConstValue>>,
+    ) -> HashMap<Spur, Type> {
+        let mut discovered: HashMap<Spur, Type> = HashMap::new();
+        let mut eval_types: HashMap<Spur, Type> = type_subst.cloned().unwrap_or_default();
+        let eval_values: HashMap<Spur, ConstValue> = value_subst.cloned().unwrap_or_default();
+        self.walk_comptime_type_locals(body, &mut discovered, &mut eval_types, &eval_values);
+        discovered
+    }
+
+    /// In-order walk over statement positions for
+    /// [`precompute_comptime_type_locals`]. Only containers that can hold
+    /// `let` statements are entered; everything else is left alone.
+    fn walk_comptime_type_locals(
+        &mut self,
+        inst_ref: InstRef,
+        discovered: &mut HashMap<Spur, Type>,
+        eval_types: &mut HashMap<Spur, Type>,
+        eval_values: &HashMap<Spur, ConstValue>,
+    ) {
+        match &self.rir.get(inst_ref).data {
+            InstData::Block { extra_start, len } => {
+                let stmts: Vec<InstRef> = self
+                    .rir
+                    .get_extra(*extra_start, *len)
+                    .iter()
+                    .map(|&raw| InstRef::from_raw(raw))
+                    .collect();
+                for stmt in stmts {
+                    self.walk_comptime_type_locals(stmt, discovered, eval_types, eval_values);
+                }
+            }
+            InstData::Alloc { name, init, .. } => {
+                let (name, init) = (*name, *init);
+                if let Some(name) = name {
+                    if let Some(ty) = self.try_eval_type_alias_init(init, eval_types, eval_values) {
+                        discovered.insert(name, ty);
+                        eval_types.insert(name, ty);
+                    }
+                }
+            }
+            InstData::Branch {
+                then_block,
+                else_block,
+                ..
+            } => {
+                let (then_block, else_block) = (*then_block, *else_block);
+                self.walk_comptime_type_locals(then_block, discovered, eval_types, eval_values);
+                if let Some(else_block) = else_block {
+                    self.walk_comptime_type_locals(else_block, discovered, eval_types, eval_values);
+                }
+            }
+            InstData::Loop { body, .. } | InstData::InfiniteLoop { body } => {
+                let body = *body;
+                self.walk_comptime_type_locals(body, discovered, eval_types, eval_values);
+            }
+            InstData::Match {
+                arms_start,
+                arms_len,
+                ..
+            } => {
+                let bodies: Vec<InstRef> = self
+                    .rir
+                    .get_match_arms(*arms_start, *arms_len)
+                    .iter()
+                    .map(|(_, body)| *body)
+                    .collect();
+                for body in bodies {
+                    self.walk_comptime_type_locals(body, discovered, eval_types, eval_values);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    /// Evaluate a `let` initializer as a compile-time type value, if it is
+    /// one. Handles calls to type-returning functions (`F()`, `Pair(i32)`,
+    /// `FixedBuffer(8)` — mirroring `analyze_call`'s implicit-comptime gate)
+    /// and direct type expressions (`let P = Q;`, `let P = struct { .. };`).
+    /// Returns `None` for anything else.
+    fn try_eval_type_alias_init(
+        &mut self,
+        init: InstRef,
+        eval_types: &HashMap<Spur, Type>,
+        eval_values: &HashMap<Spur, ConstValue>,
+    ) -> Option<Type> {
+        if let InstData::Call {
+            name,
+            args_start,
+            args_len,
+        } = &self.rir.get(init).data
+        {
+            let fn_info = self.functions.get(name)?;
+            if fn_info.return_type != Type::COMPTIME_TYPE {
+                return None;
+            }
+            let fn_body = fn_info.body;
+            let params = fn_info.params;
+            let param_names = self.param_arena.names(params).to_vec();
+            let param_comptime = self.param_arena.comptime(params).to_vec();
+            let args = self.rir.get_call_args(*args_start, *args_len).to_vec();
+            // Same gate as `analyze_call`: only no-arg or all-comptime-param
+            // type constructors are implicitly comptime-evaluated.
+            if args.len() != param_names.len()
+                || !(args.is_empty() || param_comptime.iter().all(|&c| c))
+            {
+                return None;
+            }
+            let mut callee_types: HashMap<Spur, Type> = HashMap::new();
+            let mut callee_values: HashMap<Spur, ConstValue> = HashMap::new();
+            for (i, arg) in args.iter().enumerate() {
+                match self.try_evaluate_const_with_subst(arg.value, eval_types, eval_values)? {
+                    ConstValue::Type(t) => {
+                        callee_types.insert(param_names[i], t);
+                    }
+                    value => {
+                        callee_values.insert(param_names[i], value);
+                    }
+                }
+            }
+            match self.try_evaluate_const_with_subst(fn_body, &callee_types, &callee_values) {
+                Some(ConstValue::Type(t)) => Some(t),
+                _ => None,
+            }
+        } else {
+            match self.try_evaluate_const_with_subst(init, eval_types, eval_values) {
+                Some(ConstValue::Type(t)) => Some(t),
+                _ => None,
+            }
+        }
+    }
 }

--- a/crates/rue-cli-tests/cases/comptime_alias_infer.toml
+++ b/crates/rue-cli-tests/cases/comptime_alias_infer.toml
@@ -1,0 +1,188 @@
+# Comptime type aliases must be visible to inference (RUE-170, RUE-164).
+#
+# A `let P = F();` binding (where `F` returns `type`) only got a concrete type
+# during sema's analysis pass, but HM inference runs first. Every use of `P`
+# as a type name therefore fell through inference's named-struct paths:
+#
+#  - `P { a: -1 }` returned Concrete(ERROR) without visiting the field
+#    initializers, so compound initializers kept unresolved inference
+#    variables and sema reported an internal compiler error (E9000);
+#  - `p.x` yielded a fresh variable instead of the declared field type, so a
+#    comparison literal defaulted to i32 (bogus E0800 against i64 fields);
+#  - `let x: P = ...` annotations were unenforced — any value typechecked;
+#  - `b.get()` on a `P`-typed receiver resolved to `<error>` and poisoned
+#    sibling constraints (`b.get() + 7` -> bogus E0800, RUE-164).
+#
+# Sema now pre-resolves such aliases before inference (and feeds the lazily
+# registered anonymous-struct method signatures in), so all four shapes route
+# through the same concrete paths as named structs. Named-struct controls are
+# included to pin that the two stay in sync.
+
+[section]
+id = "cli.comptime_alias_infer"
+name = "Comptime type aliases in inference"
+description = "let-bound type aliases must behave like named structs during inference."
+
+[[case]]
+name = "alias_struct_init_compound_field_initializer"
+description = "RUE-170 facet 1: compound initializers in an alias struct literal used to ICE (E9000)."
+files = [{ path = "main.rue", source = """
+fn F() -> type { struct { a: i32, b: i32 } }
+fn main() -> i32 {
+    let P = F();
+    let p: P = P { a: -1, b: 1 + 2 };
+    p.a + p.b + 40
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "alias_field_type_anchors_comparison_literal"
+description = "RUE-170 facet 2: p.x must yield the declared i64 field type, not an i32-defaulted variable."
+files = [{ path = "main.rue", source = """
+fn F() -> type { struct { x: i64 } }
+fn main() -> i32 {
+    let P = F();
+    let p: P = P { x: 5000000000 };
+    if p.x == 5000000000 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "alias_let_annotation_enforced"
+description = "RUE-170 facet 3: a let annotation naming a comptime type alias must reject mismatched values."
+files = [{ path = "main.rue", source = """
+fn F() -> type { struct { a: i32 } }
+fn main() -> i32 {
+    let P = F();
+    let x: P = true;
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["type mismatch", "found bool"]
+
+[[case]]
+name = "alias_method_result_in_arithmetic"
+description = "RUE-164: a method-call result on an alias-typed receiver must anchor sibling constraints."
+files = [{ path = "main.rue", source = """
+fn F() -> type {
+    struct {
+        v: i64,
+        fn get(self) -> i64 { self.v }
+    }
+}
+fn main() -> i32 {
+    let B = F();
+    let b: B = B { v: 35 };
+    let r = b.get() + 7;
+    if r == 42 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "alias_of_generic_type_constructor"
+description = "Alias of a generic type constructor: field types come from the substituted parameter."
+files = [{ path = "main.rue", source = """
+fn Pair(comptime T: type) -> type { struct { a: T, b: T } }
+fn main() -> i32 {
+    let P = Pair(i64);
+    let p: P = P { a: 5000000000, b: 1 };
+    if p.a == 5000000000 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "alias_with_captured_comptime_value_method"
+description = "Captured comptime values flow through alias method calls used in arithmetic."
+files = [{ path = "main.rue", source = """
+fn FixedBuffer(comptime N: i32) -> type {
+    struct {
+        v: i32,
+        fn capacity(self) -> i32 { N }
+    }
+}
+fn main() -> i32 {
+    let B = FixedBuffer(40);
+    let b: B = B { v: 0 };
+    b.capacity() + 2
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "alias_of_alias_chain"
+description = "An alias of an alias (`let Q = P;`) resolves through the chain."
+files = [{ path = "main.rue", source = """
+fn F() -> type { struct { a: i32 } }
+fn main() -> i32 {
+    let P = F();
+    let Q = P;
+    let q: Q = Q { a: 1 + 2 };
+    q.a + 39
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "alias_duplicate_method_still_rejected"
+description = "The pre-pass must not swallow lazy duplicate-method errors (registration is atomic now)."
+files = [{ path = "main.rue", source = """
+fn Bad() -> type {
+    struct {
+        x: i32,
+        fn get(self) -> i32 { self.x }
+        fn get(self) -> i32 { 0 }
+    }
+}
+fn main() -> i32 {
+    let B = Bad();
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["comptime evaluation failed"]
+
+[[case]]
+name = "named_struct_control_compound_initializer"
+description = "Named-struct control for facet 1: compound field initializers."
+files = [{ path = "main.rue", source = """
+struct P { a: i32, b: i32 }
+fn main() -> i32 {
+    let p: P = P { a: -1, b: 1 + 2 };
+    p.a + p.b + 40
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "named_struct_control_annotation_enforced"
+description = "Named-struct control for facet 3: annotations reject mismatched values."
+files = [{ path = "main.rue", source = """
+struct P { a: i32 }
+fn main() -> i32 {
+    let x: P = true;
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["type mismatch: expected P, found bool"]
+
+[[case]]
+name = "named_struct_control_method_arithmetic"
+description = "Named-struct control for RUE-164: method result anchors arithmetic."
+files = [{ path = "main.rue", source = """
+struct B {
+    v: i64,
+    fn get(self) -> i64 { self.v }
+}
+fn main() -> i32 {
+    let b: B = B { v: 35 };
+    let r = b.get() + 7;
+    if r == 42 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0


### PR DESCRIPTION
Closes the anon-struct inference blind spot from the type-inference hunt: `generate.rs` handled anon-struct types only when the base resolved to a Concrete struct during constraint generation, so the alias case (`let P = F();` used as a type) fell through — four ways.

**Fix:** sema pre-resolves let-bound comptime type aliases before HM inference runs (`precompute_comptime_type_locals`, using the same evaluation gate as `analyze_call`'s implicit-comptime path) and feeds the alias map + lazily-registered anon-struct method signatures into `ConstraintGenerator`. Aliases now route through the existing concrete paths, fixing:

1. **E9000 ICE** on compound field initializers (`P { a: -1 }`, `P { a: 1 + 2 }`)
2. **i32-defaulted FieldGet** (`p.x == 5000000000` vs an i64 field — spurious E0800)
3. **Unenforced let-annotations** naming comptime-type vars (any value type-checked)
4. **RUE-164**: method-call results decaying to `<error>` (`b.get() + 7`)

Two supporting fixes the pre-pass exposed: anon-struct method registration is now atomic (partial inserts previously swallowed the duplicate-method error on re-evaluation — caught by an existing spec test), and StructInit's unknown-type fallback visits field initializers so even failed alias resolution degrades to an ordinary sema error, never an ICE.

Designed against the reverted capture-stabilization history (checked the ADR + revert before building); the anon-struct spec suite (25 cases) passes, plus 11 new CLI cases covering all facets, generic/captured-value/chained-alias shapes, and named-struct controls. Verified post-integration by execution: all four facets. Residual noted in the commit: `P::f()` assoc-fn calls on alias-named types (pre-existing, separate path). Full ./test.sh green. Frontend-only.

Fixes RUE-170
Fixes RUE-164

🤖 Generated with [Claude Code](https://claude.com/claude-code)