### PR TITLE
Infectious linearity; comptime T in composite signature types

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -730,13 +730,13 @@ impl<'a> ConstraintGenerator<'a> {
                             }
                             let expected = if *declared == InferType::Concrete(Type::COMPTIME_TYPE)
                             {
-                                // Generic parameter like `x: T` - substitute T
-                                match func
-                                    .param_type_syms
-                                    .get(i)
-                                    .and_then(|sym| type_subst.get(sym))
-                                {
-                                    Some(&ty) => InferType::Concrete(ty),
+                                // Generic parameter like `x: T`, or a composite
+                                // mentioning a type parameter like `a: [T; 3]`
+                                // (RUE-172) - substitute T
+                                match func.param_type_syms.get(i).and_then(|sym| {
+                                    self.resolve_type_sym_with_subst(*sym, &type_subst)
+                                }) {
+                                    Some(ty) => ty,
                                     // Unknown type parameter - checked in sema
                                     None => continue,
                                 }
@@ -750,15 +750,13 @@ impl<'a> ConstraintGenerator<'a> {
                             ));
                         }
 
-                        // Compute the actual return type by substituting type parameters
+                        // Compute the actual return type by substituting type
+                        // parameters - bare (`-> T`) or inside a composite
+                        // (`-> [T; 3]`, RUE-172).
                         let return_type =
                             if func.return_type == InferType::Concrete(Type::COMPTIME_TYPE) {
-                                // Return type is a type parameter - look it up in substitutions
-                                if let Some(&concrete_ty) = type_subst.get(&func.return_type_sym) {
-                                    InferType::Concrete(concrete_ty)
-                                } else {
-                                    func.return_type.clone()
-                                }
+                                self.resolve_type_sym_with_subst(func.return_type_sym, &type_subst)
+                                    .unwrap_or_else(|| func.return_type.clone())
                             } else {
                                 func.return_type.clone()
                             };
@@ -1664,6 +1662,67 @@ impl<'a> ConstraintGenerator<'a> {
             }
             _ => None,
         }
+    }
+
+    /// Resolve a signature type symbol with type-parameter substitution,
+    /// looking through composite syntax (RUE-172).
+    ///
+    /// Like [`Self::resolve_type_name`], but substitutes comptime type
+    /// parameters (e.g. `T` with `T=i32` resolves `[T; 3]` to `[i32; 3]`).
+    /// Returns `None` when a mentioned type parameter isn't in `subst` (the
+    /// check then happens in sema / after specialization).
+    fn resolve_type_sym_with_subst(
+        &self,
+        sym: Spur,
+        subst: &HashMap<Spur, Type>,
+    ) -> Option<InferType> {
+        if let Some(&ty) = subst.get(&sym) {
+            return Some(InferType::Concrete(ty));
+        }
+        self.resolve_type_name_with_subst(self.interner.resolve(&sym), subst)
+    }
+
+    fn resolve_type_name_with_subst(
+        &self,
+        name: &str,
+        subst: &HashMap<Spur, Type>,
+    ) -> Option<InferType> {
+        if let Some(name_spur) = self.interner.get(name) {
+            if let Some(&ty) = subst.get(&name_spur) {
+                return Some(InferType::Concrete(ty));
+            }
+        }
+
+        // Array syntax: [T; N] - recurse so substituted element types work.
+        if let Some((element_type_str, length)) = parse_array_type_syntax(name) {
+            let element_ty = self.resolve_type_name_with_subst(&element_type_str, subst)?;
+            return Some(InferType::Array {
+                element: Box::new(element_ty),
+                length,
+            });
+        }
+
+        // Pointer syntax: ptr mut T / ptr const T - recurse on the pointee.
+        if let Some((pointee_type_str, mutability)) = parse_pointer_type_syntax(name) {
+            let pointee_infer_ty = self.resolve_type_name_with_subst(&pointee_type_str, subst)?;
+            // Only concrete pointees can be interned during constraint generation
+            // (same limitation as resolve_type_name).
+            let pointee_ty = match pointee_infer_ty {
+                InferType::Concrete(ty) => ty,
+                _ => return None,
+            };
+            let ptr_ty = match mutability {
+                PtrMutability::Mut => {
+                    Type::new_ptr_mut(self.type_pool.intern_ptr_mut_from_type(pointee_ty))
+                }
+                PtrMutability::Const => {
+                    Type::new_ptr_const(self.type_pool.intern_ptr_const_from_type(pointee_ty))
+                }
+            };
+            return Some(InferType::Concrete(ptr_ty));
+        }
+
+        self.resolve_type_name(name)
     }
 
     fn resolve_type_name(&self, name: &str) -> Option<InferType> {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -4402,15 +4402,34 @@ impl<'a> Sema<'a> {
             let state = ctx.moved_vars.get(symbol);
             if !state.is_some_and(|s| s.full_move_on_all_paths) {
                 let name = self.interner.resolve(&*symbol);
-                return Err(linear_not_consumed_error(
-                    name,
-                    local.span,
-                    state.and_then(|s| s.full_move),
-                ));
+                let err =
+                    linear_not_consumed_error(name, local.span, state.and_then(|s| s.full_move));
+                return Err(self.attach_infectious_linear_note(err, local.ty));
             }
         }
 
         Ok(())
+    }
+
+    /// If `ty` is a struct that is linear only because a field made it so
+    /// (infectious linearity, RUE-40), attach a note explaining the cause.
+    pub(crate) fn attach_infectious_linear_note(
+        &self,
+        err: rue_error::CompileError,
+        ty: Type,
+    ) -> rue_error::CompileError {
+        let Some(struct_id) = ty.as_struct() else {
+            return err;
+        };
+        match self.infectious_linear.get(&struct_id) {
+            Some((field_name, field_type)) => err.with_note(format!(
+                "'{}' is linear because field '{}' of type '{}' carries a linear value",
+                self.type_pool.struct_def(struct_id).name,
+                field_name,
+                field_type
+            )),
+            None => err,
+        }
     }
 
     /// Extract the root variable symbol from an expression, if it refers to a variable.

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2351,6 +2351,56 @@ impl<'a> Sema<'a> {
         Ok(())
     }
 
+    /// Reject a field access that consumes (destructures) a linear struct
+    /// when the destructure would implicitly drop a *different* field that
+    /// itself carries a linear value (E0474, spec 3.8:58, RUE-40).
+    ///
+    /// Destructuring consumption (spec 3.8:33) extracts the accessed leaf
+    /// field and drops everything else in the value. That implicit drop must
+    /// not lose a linear value. Every struct level along the projection
+    /// chain is checked: at each level, all fields other than the projected
+    /// one are dropped.
+    fn reject_linear_destructure_dropping_linear_field(
+        &self,
+        trace: &PlaceTrace,
+        span: Span,
+    ) -> CompileResult<()> {
+        let mut current_ty = trace.base_type;
+        for proj in &trace.projections {
+            if let AirProjection::Field {
+                struct_id,
+                field_index,
+            } = proj.proj
+            {
+                let def = self.type_pool.struct_def(struct_id);
+                for (i, field) in def.fields.iter().enumerate() {
+                    if i as u32 != field_index && self.type_carries_linear(field.ty) {
+                        let accessed = def.fields[field_index as usize].name.clone();
+                        let err = CompileError::new(
+                            ErrorKind::LinearFieldDroppedByDestructure(Box::new(
+                                rue_error::LinearFieldDroppedByDestructureError {
+                                    struct_name: def.name.clone(),
+                                    accessed,
+                                    dropped: field.name.clone(),
+                                },
+                            )),
+                            span,
+                        )
+                        .with_help(
+                            "destructuring consumption extracts one field and drops \
+                             the rest; access the linear field instead and consume \
+                             its value, or consume the whole value by passing it to \
+                             a function",
+                        );
+                        return Err(self.attach_infectious_linear_note(err, current_ty));
+                    }
+                }
+            }
+            current_ty = proj.result_type;
+        }
+        Ok(())
+    }
+
     /// Reject moving a field out of a value whose struct type has a
     /// destructor (RUE-158, the spirit of Rust's E0509).
     ///
@@ -2501,6 +2551,7 @@ impl<'a> Sema<'a> {
                 }
             } else if is_linear {
                 // For linear types, field access consumes the entire struct
+                self.reject_linear_destructure_dropping_linear_field(&trace, span)?;
                 self.reject_move_out_of_byref_param(trace.root_var, ctx, span)?;
                 ctx.moved_vars
                     .entry(trace.root_var)
@@ -3575,13 +3626,16 @@ impl<'a> Sema<'a> {
                     continue;
                 }
                 let expected = if declared == Type::COMPTIME_TYPE {
-                    // Generic parameter like `x: T` - substitute T. If the type
-                    // parameter wasn't resolved, an error was already reported.
-                    match rir_param_type_syms
-                        .get(i)
-                        .and_then(|sym| type_subst.get(sym))
+                    // Generic parameter like `x: T` or a composite mentioning a
+                    // type parameter like `a: [T; 3]` (RUE-172) - substitute T.
+                    // If the type parameter wasn't resolved (e.g. it's a local
+                    // bound to a type value), the check happens after
+                    // specialization instead.
+                    let sym = rir_param_type_syms.get(i).copied();
+                    match sym
+                        .and_then(|sym| self.resolve_type_for_comptime_with_subst(sym, &type_subst))
                     {
-                        Some(&ty) => ty,
+                        Some(ty) => ty,
                         None => continue,
                     }
                 } else {
@@ -3603,12 +3657,13 @@ impl<'a> Sema<'a> {
                 }
             }
 
-            // Determine the actual return type by substituting type parameters
+            // Determine the actual return type by substituting type parameters.
+            // Handles bare type parameters (`-> T`), composites mentioning one
+            // (`-> [T; 3]`, RUE-172), and the literal `type` return (which
+            // resolves back to COMPTIME_TYPE and is comptime-evaluated below).
             let return_type = if base_return_type == Type::COMPTIME_TYPE {
-                // Return type is a type parameter - look it up in substitutions
-                *type_subst
-                    .get(&return_type_sym)
-                    .unwrap_or(&base_return_type)
+                self.resolve_type_for_comptime_with_subst(return_type_sym, &type_subst)
+                    .unwrap_or(base_return_type)
             } else {
                 base_return_type
             };

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -179,4 +179,21 @@ impl<'a> Sema<'a> {
             _ => false,
         }
     }
+
+    /// Check if a type carries a linear value when stored by value: a linear
+    /// struct itself, or an array whose element type carries one.
+    ///
+    /// Used by infectious linearity (RUE-40): a struct with such a field must
+    /// itself be linear, and destructuring a linear struct must not implicitly
+    /// drop such a field. Pointers don't own their pointee and don't carry.
+    pub(crate) fn type_carries_linear(&self, ty: Type) -> bool {
+        match ty.kind() {
+            TypeKind::Struct(_) => self.is_type_linear(ty),
+            TypeKind::Array(array_id) => {
+                let (element_type, _length) = self.type_pool.array_def(array_id);
+                self.type_carries_linear(element_type)
+            }
+            _ => false,
+        }
+    }
 }

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -311,8 +311,47 @@ impl<'a> Sema<'a> {
     /// body analysis.
     pub(crate) fn resolve_declarations(&mut self) -> CompileResult<()> {
         self.resolve_struct_fields()?;
+        self.propagate_field_linearity();
         self.resolve_remaining_declarations()?;
         Ok(())
+    }
+
+    /// Propagate linearity from fields to containing structs (infectious
+    /// linearity, spec 3.8:57 / RUE-40).
+    ///
+    /// A struct with a field whose type carries a linear value (directly,
+    /// through an array, or through a nested struct) must itself be linear:
+    /// if the container could be implicitly dropped, the linear field would
+    /// be silently dropped with it. Runs to a fixpoint so linearity flows
+    /// through arbitrarily deep nestings. The causing field is recorded in
+    /// [`Sema::infectious_linear`] for diagnostics.
+    pub(crate) fn propagate_field_linearity(&mut self) {
+        let struct_ids: Vec<StructId> = self.structs.values().copied().collect();
+        loop {
+            let mut changed = false;
+            for &struct_id in &struct_ids {
+                let def = self.type_pool.struct_def(struct_id);
+                if def.is_linear {
+                    continue;
+                }
+                let Some(cause) = def
+                    .fields
+                    .iter()
+                    .find(|field| self.type_carries_linear(field.ty))
+                else {
+                    continue;
+                };
+                let cause = (cause.name.clone(), self.format_type_name(cause.ty));
+                let mut def = def;
+                def.is_linear = true;
+                self.type_pool.update_struct_def(struct_id, def);
+                self.infectious_linear.insert(struct_id, cause);
+                changed = true;
+            }
+            if !changed {
+                break;
+            }
+        }
     }
 
     /// Resolve struct field types. Must run before @copy validation.
@@ -843,9 +882,11 @@ impl<'a> Sema<'a> {
                 if p.is_comptime && p.ty == type_sym {
                     // For comptime TYPE parameters (comptime T: type), the type is `type`
                     Ok(Type::COMPTIME_TYPE)
-                } else if type_param_names.contains(&p.ty) {
-                    // This parameter's type is a type parameter (e.g., `x: T` where T is comptime)
-                    // Use ComptimeType as a placeholder - actual type determined at specialization
+                } else if self.type_mentions_type_param(p.ty, &type_param_names) {
+                    // This parameter's type is a type parameter (`x: T`) or a
+                    // composite mentioning one (`a: [T; 3]`, `p: ptr const T`;
+                    // RUE-172). Use ComptimeType as a placeholder - the actual
+                    // type is determined at specialization.
                     Ok(Type::COMPTIME_TYPE)
                 } else {
                     // Regular params OR comptime VALUE params (comptime n: i32)
@@ -856,9 +897,10 @@ impl<'a> Sema<'a> {
         let param_comptime: Vec<bool> = params.iter().map(|p| p.is_comptime).collect();
 
         // For generic functions, we can't resolve the return type yet if it references
-        // a type parameter. For now, check if it matches any type parameter name.
-        let ret_type = if type_param_names.contains(&return_type_sym) {
-            // Return type is a type parameter - use placeholder
+        // a type parameter - either directly (`-> T`) or inside a composite
+        // (`-> [T; 3]`, RUE-172).
+        let ret_type = if self.type_mentions_type_param(return_type_sym, &type_param_names) {
+            // Return type references a type parameter - use placeholder
             Type::COMPTIME_TYPE
         } else {
             self.resolve_type(return_type_sym, span)?

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -104,6 +104,7 @@ impl<'a> GatherOutput<'a> {
             anon_struct_method_sigs: HashMap::new(),
             anon_struct_captured_values: HashMap::new(),
             destructor_spans: HashMap::new(),
+            infectious_linear: HashMap::new(),
         }
     }
 }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -117,6 +117,11 @@ pub struct Sema<'a> {
     /// (E0456 field-move-out-of-destructor-type, E0457 @copy-with-destructor).
     /// Builtin destructors (e.g. String's) have no entry.
     pub(crate) destructor_spans: HashMap<StructId, Span>,
+    /// Structs that became linear via infectious linearity (RUE-40): not
+    /// declared `linear`, but containing a field that carries a linear value.
+    /// Maps the struct to the (field name, field type name) that caused it,
+    /// for diagnostics explaining why the container is linear.
+    pub(crate) infectious_linear: HashMap<StructId, (String, String)>,
 }
 
 impl<'a> Sema<'a> {
@@ -147,6 +152,7 @@ impl<'a> Sema<'a> {
             anon_struct_method_sigs: HashMap::new(),
             anon_struct_captured_values: HashMap::new(),
             destructor_spans: HashMap::new(),
+            infectious_linear: HashMap::new(),
         }
     }
 

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -234,6 +234,38 @@ impl<'a> Sema<'a> {
         }
     }
 
+    /// Check whether a signature type symbol mentions any of the given comptime
+    /// type parameters, looking through composite syntax: `[T; N]`,
+    /// `ptr const T`, `ptr mut T`, and nestings thereof (RUE-172).
+    ///
+    /// Used when collecting a generic function's signature to decide whether a
+    /// parameter/return type must be deferred (as `Type::COMPTIME_TYPE`) until
+    /// specialization instead of resolved eagerly.
+    pub(crate) fn type_mentions_type_param(&self, type_sym: Spur, type_params: &[Spur]) -> bool {
+        if type_params.contains(&type_sym) {
+            return true;
+        }
+        self.type_name_mentions_type_param(self.interner.resolve(&type_sym), type_params)
+    }
+
+    fn type_name_mentions_type_param(&self, type_name: &str, type_params: &[Spur]) -> bool {
+        if let Some((element_type, _length)) = parse_array_type_syntax(type_name) {
+            return self.type_name_mentions_type_param(&element_type, type_params);
+        }
+        if let Some(pointee) = type_name
+            .strip_prefix("ptr const ")
+            .or_else(|| type_name.strip_prefix("ptr mut "))
+        {
+            return self.type_name_mentions_type_param(pointee, type_params);
+        }
+        // Leaf name: only a match against an already-interned symbol counts
+        // (type parameter names are interned by the parser).
+        match self.interner.get(type_name) {
+            Some(sym) => type_params.contains(&sym),
+            None => false,
+        }
+    }
+
     /// Get or create an array type for the given element type and length.
     pub(crate) fn get_or_create_array_type(
         &mut self,

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -270,33 +270,40 @@ fn create_specialized_function(
         }
     }
 
+    // Resolve the return type, substituting type parameters - bare (`-> T`)
+    // or inside a composite (`-> [T; 3]`, RUE-172).
     let return_type = if base_info.return_type == Type::COMPTIME_TYPE {
-        type_subst
-            .get(&base_info.return_type_sym)
-            .copied()
+        sema.resolve_type_for_comptime_with_subst(base_info.return_type_sym, &type_subst)
             .unwrap_or(Type::UNIT)
     } else {
         base_info.return_type
     };
 
-    let specialized_params: Vec<(Spur, Type, RirParamMode, bool)> = sema
+    // Copy out the param data first: substitution needs `&mut Sema` (composite
+    // types like `[T; 3]` may intern new array types), which can't overlap a
+    // borrow of the param arena.
+    let base_params: Vec<(Spur, Type, RirParamMode, bool)> = sema
         .param_arena
         .iter(base_info.params)
-        .filter(|(_, _, _, is_comptime)| !**is_comptime)
-        .map(|(name, ty, mode, _)| {
-            // Comptime parameters were filtered out above, so every
-            // surviving parameter carries is_comptime = false.
-            let concrete_ty = if *ty == Type::COMPTIME_TYPE {
-                substitute_param_type(sema, base_info, *name, &type_subst).unwrap_or_else(|| {
-                    debug_assert!(false, "type substitution failed for param");
-                    *ty
-                })
-            } else {
-                *ty
-            };
-            (*name, concrete_ty, *mode, false)
-        })
+        .map(|(name, ty, mode, is_comptime)| (*name, *ty, *mode, *is_comptime))
         .collect();
+    let mut specialized_params: Vec<(Spur, Type, RirParamMode, bool)> =
+        Vec::with_capacity(base_params.len());
+    for (name, ty, mode, is_comptime) in base_params {
+        if is_comptime {
+            // Comptime parameters are erased from the specialized signature.
+            continue;
+        }
+        let concrete_ty = if ty == Type::COMPTIME_TYPE {
+            substitute_param_type(sema, base_info, name, &type_subst).unwrap_or_else(|| {
+                debug_assert!(false, "type substitution failed for param");
+                ty
+            })
+        } else {
+            ty
+        };
+        specialized_params.push((name, concrete_ty, mode, false));
+    }
 
     let (
         air,
@@ -324,20 +331,20 @@ fn create_specialized_function(
     })
 }
 
-/// Look up a parameter's concrete type from the type substitution map.
+/// Resolve a parameter's concrete type by substituting type parameters into
+/// its declared type symbol - bare (`x: T`) or inside a composite
+/// (`a: [T; 3]`, `p: ptr const T`; RUE-172).
 fn substitute_param_type(
-    sema: &Sema<'_>,
+    sema: &mut Sema<'_>,
     base_info: &FunctionInfo,
     param_name: Spur,
     type_subst: &HashMap<Spur, Type>,
 ) -> Option<Type> {
-    let params = sema
+    let type_sym = sema
         .rir
-        .get_params(base_info.rir_params_start, base_info.rir_params_len);
-    for param in params {
-        if param.name == param_name {
-            return type_subst.get(&param.ty).copied();
-        }
-    }
-    None
+        .get_params(base_info.rir_params_start, base_info.rir_params_len)
+        .iter()
+        .find(|param| param.name == param_name)
+        .map(|param| param.ty)?;
+    sema.resolve_type_for_comptime_with_subst(type_sym, type_subst)
 }

--- a/crates/rue-cli-tests/cases/generic_composite_sigs.toml
+++ b/crates/rue-cli-tests/cases/generic_composite_sigs.toml
@@ -1,0 +1,69 @@
+# Comptime type parameters inside composite signature types (RUE-172).
+#
+# `comptime T: type` used to work only as a *bare* signature type; `[T; N]`
+# or `ptr const T` in param/return position was rejected with E0204 unknown
+# type 'T'. The signature collector now defers any type mentioning a type
+# parameter to specialization, and the call-site/specialization resolvers
+# substitute recursively through composites.
+
+[section]
+id = "cli.generic_composite_sigs"
+name = "Generic composite signatures"
+description = "comptime T: type inside [T; N] / ptr T signature types (RUE-172)."
+
+[[case]]
+name = "array_of_t_param_and_return"
+description = "[T; N] works in parameter position and [T; 2] in return position; runs end-to-end."
+files = [{ path = "main.rue", source = """
+fn first(comptime T: type, a: [T; 2]) -> T { a[0] }
+fn pair(comptime T: type, x: T) -> [T; 2] { [x, x] }
+fn main() -> i32 {
+    let xs = [11, 22];
+    let p = pair(i32, 30);
+    let b = first(bool, [true, false]);
+    let mut r = first(i32, xs) + p[0];
+    if b { r = r + 1; }
+    r
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "array_of_t_two_specializations"
+description = "The same composite-signature generic specializes for two different type arguments in one program."
+files = [{ path = "main.rue", source = """
+fn last(comptime T: type, a: [T; 3]) -> T { a[2] }
+fn main() -> i32 {
+    let ns = [1, 2, 40];
+    let bs = [false, false, true];
+    let n = last(i32, ns);
+    if last(bool, bs) { n + 2 } else { 0 }
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "array_of_t_forwarded_type_param"
+description = "A forwarded type parameter reaches a nested generic with a composite signature."
+files = [{ path = "main.rue", source = """
+fn first(comptime T: type, a: [T; 2]) -> T { a[0] }
+fn outer(comptime T: type, a: [T; 2]) -> T { first(T, a) }
+fn main() -> i32 {
+    let xs = [7, 8];
+    outer(i32, xs)
+}
+""" }]
+exit_code = 7
+
+[[case]]
+name = "array_of_t_element_mismatch_rejected"
+description = "Passing [bool; 3] where [T; 3] with T=i32 is expected is a type error, not accepted or an ICE."
+files = [{ path = "main.rue", source = """
+fn first(comptime T: type, a: [T; 3]) -> T { a[0] }
+fn main() -> i32 {
+    let bs = [true, false, true];
+    first(i32, bs)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "type mismatch"]

--- a/crates/rue-cli-tests/cases/infectious_linear.toml
+++ b/crates/rue-cli-tests/cases/infectious_linear.toml
@@ -1,0 +1,110 @@
+# Infectious linearity (RUE-40, spec 3.8:57-3.8:61).
+#
+# A struct that is not declared `linear` but contains a field that carries a
+# linear value (a linear struct, an array of them, or a nested container) is
+# itself linear: dropping it implicitly would silently drop the linear field.
+# Destructuring consumption (field access) must not implicitly drop a
+# *different* linear-carrying field (E0474).
+
+[section]
+id = "cli.infectious_linear"
+name = "Infectious linearity"
+description = "Containers of linear fields are themselves linear (RUE-40)."
+
+[[case]]
+name = "wrap_with_linear_field_dropped_rejected"
+description = "Dropping a non-declared-linear container with a linear field is E0406, with a note explaining the inherited linearity."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+struct Wrap { m: MustUse }
+fn main() -> i32 {
+    let w = Wrap { m: MustUse { value: 1 } };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = [
+    "E0406",
+    "linear value 'w' must be consumed",
+    "'Wrap' is linear because field 'm'",
+]
+
+[[case]]
+name = "nested_container_dropped_rejected"
+description = "Infectious linearity propagates through nested containers."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+struct A { m: MustUse }
+struct B { a: A, tag: i32 }
+fn main() -> i32 {
+    let b = B { a: A { m: MustUse { value: 1 } }, tag: 7 };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0406", "linear value 'b' must be consumed"]
+
+[[case]]
+name = "array_of_linear_field_dropped_rejected"
+description = "An array-of-linear field carries a linear value into the container."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+struct Holder { arr: [MustUse; 2], tag: i32 }
+fn main() -> i32 {
+    let h = Holder { arr: [MustUse { value: 1 }, MustUse { value: 2 }], tag: 0 };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0406", "linear value 'h' must be consumed"]
+
+[[case]]
+name = "destructure_dropping_linear_field_rejected"
+description = "Accessing a non-linear field destructures the container and would drop the linear field (E0474)."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+struct Container { inner: MustUse, tag: i32 }
+fn main() -> i32 {
+    let c = Container { inner: MustUse { value: 1 }, tag: 2 };
+    c.tag
+}
+""" }]
+compile_fail = true
+error_contains = [
+    "E0474",
+    "would implicitly drop linear field 'inner'",
+]
+
+[[case]]
+name = "extract_and_consume_linear_field_ok"
+description = "Extracting the linear field and consuming it satisfies the container's linearity; the binary runs."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+struct Container { inner: MustUse, tag: i32 }
+fn sink(m: MustUse) -> i32 { m.value }
+fn main() -> i32 {
+    let c = Container { inner: MustUse { value: 42 }, tag: 1 };
+    sink(c.inner)
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "container_one_branch_consumption_rejected"
+description = "Must-consume-on-all-paths (E0443) applies to infectiously linear containers."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+struct Wrap { m: MustUse }
+fn sink(w: Wrap) -> i32 { w.m.value }
+fn main() -> i32 {
+    let w = Wrap { m: MustUse { value: 1 } };
+    let c = true;
+    if c {
+        sink(w)
+    } else {
+        0
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0443", "not consumed on all paths"]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -137,6 +137,8 @@ impl ErrorCode {
     // 458-459 are reserved by in-flight work.
     pub const PRIVATE_UNQUALIFIED_ACCESS: Self = Self(460);
     pub const CONST_INITIALIZER_CYCLE: Self = Self(461);
+    // 462-473 are reserved by in-flight work.
+    pub const LINEAR_FIELD_DROPPED_BY_DESTRUCTURE: Self = Self(474);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -275,6 +277,14 @@ pub struct CopyStructNonCopyFieldError {
     pub struct_name: String,
     pub field_name: String,
     pub field_type: String,
+}
+
+/// Payload for `ErrorKind::LinearFieldDroppedByDestructure`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LinearFieldDroppedByDestructureError {
+    pub struct_name: String,
+    pub accessed: String,
+    pub dropped: String,
 }
 
 /// Payload for `ErrorKind::IntrinsicTypeMismatch`.
@@ -899,6 +909,15 @@ pub enum ErrorKind {
     /// Linear struct cannot be marked @copy
     #[error("linear struct '{0}' cannot be marked @copy")]
     LinearStructCopy(String),
+    /// Field access destructures a linear struct, implicitly dropping another
+    /// field that carries a linear value
+    #[error(
+        "accessing field '{accessed}' of linear struct '{struct_name}' would implicitly drop linear field '{dropped}'",
+        struct_name = .0.struct_name,
+        accessed = .0.accessed,
+        dropped = .0.dropped
+    )]
+    LinearFieldDroppedByDestructure(Box<LinearFieldDroppedByDestructureError>),
     /// @handle struct missing required .handle() method
     #[error("struct '{struct_name}' is marked @handle but has no `handle` method")]
     HandleStructMissingMethod { struct_name: String },
@@ -1196,6 +1215,9 @@ impl ErrorKind {
                 ErrorCode::LINEAR_VALUE_NOT_CONSUMED_ON_ALL_PATHS
             }
             ErrorKind::LinearStructCopy(_) => ErrorCode::LINEAR_STRUCT_COPY,
+            ErrorKind::LinearFieldDroppedByDestructure(_) => {
+                ErrorCode::LINEAR_FIELD_DROPPED_BY_DESTRUCTURE
+            }
             ErrorKind::HandleStructMissingMethod { .. } => ErrorCode::HANDLE_STRUCT_MISSING_METHOD,
             ErrorKind::HandleMethodWrongSignature { .. } => {
                 ErrorCode::HANDLE_METHOD_WRONG_SIGNATURE

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1242,3 +1242,108 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "comptime parameter requires a compile-time known value"
+
+# =============================================================================
+# Type Parameters in Composite Signature Types (RUE-172)
+# =============================================================================
+
+[[case]]
+name = "type_param_in_array_param"
+spec = ["4.14:16"]
+description = "A comptime type parameter may be the element type of an array parameter"
+source = """
+fn first(comptime T: type, a: [T; 3]) -> T {
+    a[0]
+}
+fn main() -> i32 {
+    let xs = [10, 20, 30];
+    first(i32, xs)
+}
+"""
+exit_code = 10
+
+[[case]]
+name = "type_param_in_array_return"
+spec = ["4.14:16"]
+description = "A comptime type parameter may be the element type of an array return type"
+source = """
+fn pair(comptime T: type, x: T) -> [T; 2] {
+    [x, x]
+}
+fn main() -> i32 {
+    let p = pair(i32, 21);
+    p[0] + p[1]
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "type_param_in_nested_array"
+spec = ["4.14:16"]
+description = "A comptime type parameter substitutes through nested array composites"
+source = """
+fn corner(comptime T: type, grid: [[T; 2]; 2]) -> T {
+    grid[1][1]
+}
+fn main() -> i32 {
+    let g = [[1, 2], [3, 40]];
+    corner(i32, g)
+}
+"""
+exit_code = 40
+
+[[case]]
+name = "type_param_in_ptr_param_and_return"
+spec = ["4.14:16"]
+description = "A comptime type parameter may be a pointer pointee in param and return position"
+source = """
+fn id_ptr(comptime T: type, p: ptr const T) -> ptr const T { p }
+fn main() -> i32 { 0 }
+"""
+exit_code = 0
+
+[[case]]
+name = "type_param_array_two_specializations"
+spec = ["4.14:16"]
+description = "Composite signatures specialize independently per type argument"
+source = """
+fn first(comptime T: type, a: [T; 2]) -> T {
+    a[0]
+}
+fn main() -> i32 {
+    let xs = [11, 22];
+    let bs = [true, false];
+    let n = first(i32, xs);
+    let b = first(bool, bs);
+    if b { n } else { 0 }
+}
+"""
+exit_code = 11
+
+[[case]]
+name = "type_param_array_forwarded_to_nested_generic"
+spec = ["4.14:16"]
+description = "A composite signature works when the type parameter is forwarded from an outer generic"
+source = """
+fn first(comptime T: type, a: [T; 2]) -> T { a[0] }
+fn outer(comptime T: type, a: [T; 2]) -> T { first(T, a) }
+fn main() -> i32 {
+    let xs = [7, 8];
+    outer(i32, xs)
+}
+"""
+exit_code = 7
+
+[[case]]
+name = "type_param_array_element_mismatch_rejected"
+spec = ["4.14:16"]
+description = "Passing an array with the wrong element type for [T; N] is rejected"
+source = """
+fn first(comptime T: type, a: [T; 3]) -> T { a[0] }
+fn main() -> i32 {
+    let bs = [true, false, true];
+    first(i32, bs)
+}
+"""
+compile_fail = true
+error_contains = "type mismatch"

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -1401,3 +1401,117 @@ fn main() -> i32 {
 }
 """
 exit_code = 3
+# =============================================================================
+# Infectious Linearity (RUE-40)
+# =============================================================================
+
+[[case]]
+name = "linear_field_makes_container_linear"
+spec = ["3.8:57", "3.8:58"]
+description = "A non-linear struct containing a linear field is itself linear: dropping it is an error"
+source = """
+linear struct MustUse { value: i32 }
+
+struct Wrap { m: MustUse }
+
+fn main() -> i32 {
+    let w = Wrap { m: MustUse { value: 1 } };
+    0
+}
+"""
+compile_fail = true
+error_contains = "linear value 'w' must be consumed"
+
+[[case]]
+name = "linear_field_nested_container_linear"
+spec = ["3.8:57", "3.8:58"]
+description = "Infectious linearity propagates through nested containers"
+source = """
+linear struct MustUse { value: i32 }
+
+struct A { m: MustUse }
+struct B { a: A, tag: i32 }
+
+fn main() -> i32 {
+    let b = B { a: A { m: MustUse { value: 1 } }, tag: 7 };
+    0
+}
+"""
+compile_fail = true
+error_contains = "linear value 'b' must be consumed"
+
+[[case]]
+name = "linear_array_field_makes_container_linear"
+spec = ["3.8:57", "3.8:58"]
+description = "An array-of-linear field carries a linear value and makes the container linear"
+source = """
+linear struct MustUse { value: i32 }
+
+struct Holder { arr: [MustUse; 2], tag: i32 }
+
+fn main() -> i32 {
+    let h = Holder { arr: [MustUse { value: 1 }, MustUse { value: 2 }], tag: 0 };
+    0
+}
+"""
+compile_fail = true
+error_contains = "linear value 'h' must be consumed"
+
+[[case]]
+name = "linear_container_extract_and_consume"
+spec = ["3.8:58", "3.8:60"]
+description = "Extracting the linear field and consuming it satisfies the container's linearity"
+source = """
+linear struct MustUse { value: i32 }
+
+struct Container { inner: MustUse, tag: i32 }
+
+fn sink(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let c = Container { inner: MustUse { value: 42 }, tag: 1 };
+    sink(c.inner)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "linear_destructure_dropping_linear_field_error"
+spec = ["3.8:60"]
+description = "Field access that would implicitly drop a different linear field is rejected"
+source = """
+linear struct MustUse { value: i32 }
+
+struct Container { inner: MustUse, tag: i32 }
+
+fn main() -> i32 {
+    let c = Container { inner: MustUse { value: 1 }, tag: 2 };
+    c.tag
+}
+"""
+compile_fail = true
+error_contains = "would implicitly drop linear field 'inner'"
+
+[[case]]
+name = "linear_container_consumed_one_branch_error"
+spec = ["3.8:50", "3.8:58"]
+description = "Must-consume-on-all-paths applies to infectiously linear containers too"
+source = """
+linear struct MustUse { value: i32 }
+
+struct Wrap { m: MustUse }
+
+fn sink(w: Wrap) -> i32 { w.m.value }
+
+fn main() -> i32 {
+    let w = Wrap { m: MustUse { value: 1 } };
+    let c = true;
+    if c {
+        sink(w)
+    } else {
+        0
+    }
+}
+"""
+compile_fail = true
+error_contains = "not consumed on all paths"

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -194,6 +194,51 @@ fn main() -> i32 {
 }
 ```
 
+{{ rule(id="3.8:57", cat="normative") }}
+
+A type *carries a linear value* if it is a linear struct type, an array type whose element type carries a linear value, or a struct type with a field whose type carries a linear value. Pointer types do not carry a linear value (a pointer does not own its pointee).
+
+{{ rule(id="3.8:58", cat="normative") }}
+
+Linearity is infectious: a struct type that is not declared `linear` but has a field whose type carries a linear value is itself a linear type. If the containing struct could be implicitly dropped, the linear field would be silently dropped with it.
+
+{{ rule(id="3.8:59", cat="example") }}
+
+```rue
+linear struct MustUse { value: i32 }
+
+struct Wrap { m: MustUse }   // not declared linear, but linear by 3.8:58
+
+fn main() -> i32 {
+    let w = Wrap { m: MustUse { value: 1 } };  // ERROR: linear value 'w' dropped
+    0
+}
+```
+
+{{ rule(id="3.8:60", cat="legality-rule") }}
+
+It is a compile-time error for a field access that consumes a linear value (destructuring, 3.8:33) to implicitly drop a *different* field that carries a linear value. Every struct level along the access path is checked: at each level, all fields other than the accessed one are dropped by the destructure.
+
+{{ rule(id="3.8:61", cat="example") }}
+
+```rue
+linear struct MustUse { value: i32 }
+
+struct Container { inner: MustUse, tag: i32 }
+
+fn sink(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let c = Container { inner: MustUse { value: 1 }, tag: 2 };
+    c.tag            // ERROR: would implicitly drop linear field 'inner'
+}
+
+fn ok() -> i32 {
+    let c = Container { inner: MustUse { value: 1 }, tag: 2 };
+    sink(c.inner)    // OK: extracts the linear field; 'tag' (non-linear) is dropped
+}
+```
+
 {{ rule(id="3.8:39", cat="informative") }}
 
 Linear types are useful for:

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -96,6 +96,25 @@ fn main() -> i32 {
 
 When a function has a `comptime T: type` parameter, occurrences of `T` in parameter types and return types are substituted with the concrete type at each call site.
 
+{{ rule(id="4.14:16", cat="normative") }}
+
+A type parameter may appear anywhere within a composite parameter or return type — as an array element type (`[T; N]`), a pointer pointee (`ptr const T`, `ptr mut T`), or a nesting of these (`[[T; 2]; 3]`) — and is substituted recursively at each call site, in both parameter and return position.
+
+```rue
+fn first(comptime T: type, a: [T; 3]) -> T {
+    a[0]
+}
+
+fn pair(comptime T: type, x: T) -> [T; 2] {
+    [x, x]
+}
+
+fn main() -> i32 {
+    let xs = [10, 20, 30];
+    first(i32, xs) + pair(i32, 6)[0]  // 16
+}
+```
+
 {{ rule(id="4.14:6", cat="legality-rule") }}
 
 It is a compile-time error to pass a runtime value to a comptime parameter.


### PR DESCRIPTION
**RUE-40 facet 1 — refuted as still-open.** One-branch linear consumption (`if c { consume(m) } else { 0 }`) is already rejected with E0443 — the RUE-127 drop/move overhaul's intersection-at-joins fixed it. Pinned with spec + CLI coverage so it stays fixed.

**RUE-40 facet 2 — infectious linearity.** The spec was silent on linear fields inside non-linear containers (they were silently droppable, defeating linearity). New rules 3.8:57–61: a struct carrying a linear field (direct, array-of, or nested) is itself linear. Fixpoint propagation in declaration collection; E0406/E0443 diagnostics carry a "`Wrap` is linear because field `m` of type `L` carries a linear value" note; new **E0474** rejects destructuring field access that would implicitly drop a *different* linear-carrying field, checked at every struct level of the path.

**RUE-172 — `comptime T: type` in composite signature types.** `fn f(comptime T: type, a: [T; 3]) -> T` works (param and return; `[T; N]`, `ptr const/mut T`, nested). Signature collection defers any type mentioning a type param; the sema call-site check, HM inference (a new subst-aware `InferType` resolver), and `specialize.rs` substitute recursively. Two-T specialization, forwarding, and `[bool;3]`-vs-`[i32;3]` mismatch rejection all verified.

6+1 new spec cases under 3.8, 7 under 4.14:16; `infectious_linear.toml` (6) + `generic_composite_sigs.toml` (4) CLI suites with exact E-codes; traceability 100%. Verified post-integration by execution: E0443 on the one-branch repro, the infectious-linearity note, and the `[T; 3]` call (exit 7). Full ./test.sh green.

Remaining adjacent gaps (pre-existing, listed in the worker meta for follow-up filing): linear params unconsumed in the callee, linear temporaries, bare array-of-linear locals.

Fixes RUE-40
Fixes RUE-172

🤖 Generated with [Claude Code](https://claude.com/claude-code)