### PR TITLE
CI: upgrade all GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -38,7 +38,7 @@ jobs:
     steps:
       - name: Check workflow queue depth
         id: queue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             // Get all workflow runs for this workflow in queued or in_progress state
@@ -129,7 +129,7 @@ jobs:
 
     steps:
       - name: Checkout trunk
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: trunk
           fetch-depth: 0  # Full history for commit info
@@ -143,7 +143,7 @@ jobs:
       # persistent action cache across daemon restarts, and ~/.cache/buck2
       # is not a path buck2 uses. (RUE-144)
       - name: Cache dotslash artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/dotslash
@@ -201,7 +201,7 @@ jobs:
           EOF
 
       - name: Upload benchmark results as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: benchmark-results-${{ steps.commit.outputs.full_sha }}-${{ matrix.platform }}
           path: /tmp/results.json
@@ -230,7 +230,7 @@ jobs:
 
     steps:
       - name: Checkout trunk for scripts
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: trunk
           path: trunk
@@ -257,7 +257,7 @@ jobs:
           echo "Commit range: $commit_count commits in last 24h"
 
       - name: Download all benchmark artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
           pattern: benchmark-results-${{ steps.commit.outputs.full_sha }}-*
@@ -278,7 +278,7 @@ jobs:
           done
 
       - name: Checkout perf branch
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: perf
           path: perf-branch

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
   fmt:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dotslash
         uses: facebook/install-dotslash@latest
@@ -39,7 +39,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     name: test (${{ matrix.name }})
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Select Xcode 16.2
         if: runner.os == 'macOS'
@@ -55,7 +55,7 @@ jobs:
       # across daemon restarts, and ~/.cache/buck2 is not a path buck2 uses —
       # multi-GB saved/restored for zero hits. (RUE-144)
       - name: Cache dotslash artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cache/dotslash

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup dotslash
         uses: facebook/install-dotslash@latest
@@ -78,7 +78,7 @@ jobs:
 
       - name: Upload artifact
         if: github.ref == 'refs/heads/trunk'
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: website/public
 
@@ -92,4 +92,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -9,7 +9,7 @@ jobs:
   fuzz:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dotslash
         uses: facebook/install-dotslash@latest
@@ -19,7 +19,7 @@ jobs:
       # persistent action cache across daemon restarts, and ~/.cache/buck2
       # is not a path buck2 uses. (RUE-144)
       - name: Cache dotslash artifacts
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/dotslash
           key: dotslash-linux-x64-${{ hashFiles('buck2') }}
@@ -49,7 +49,7 @@ jobs:
 
       - name: Upload crash artifacts
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: fuzz-crashes
           path: crates/rue-fuzz/crashes/
@@ -57,7 +57,7 @@ jobs:
 
       - name: Create issue on failure
         if: failure()
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const title = `Fuzz testing found a crash (${new Date().toISOString().split('T')[0]})`;


### PR DESCRIPTION
GitHub forces Node 24 for JavaScript actions on **June 16, 2026** (five days from now; Node 20 is removed from runners September 16). The website build job was already warning about `actions/checkout@v4` and `actions/upload-artifact@v4` — and a survey found the same deprecated majors across all four workflows (ci, fuzz, benchmarks, deploy-website).

All actions bumped to their current Node-24 majors:

| Action | Old → New |
|---|---|
| actions/checkout | v4 → v6 (×7) |
| actions/upload-artifact | v4 → v6 (×2) |
| actions/cache | v4 → v5 (×3) |
| actions/download-artifact | v4 → v8 |
| actions/github-script | v7 → v9 (×2) |
| actions/deploy-pages | v4 → v5 |
| actions/upload-pages-artifact | v3 → v5 |

Every changed line is a `uses:` bump (verified by diff normalization — nothing else touched). All seven tags verified to exist upstream via the GitHub API. No usage adaptations were needed: our checkout `ref:`/`path:` params, cache keys, artifact upload/download patterns, github-script calls, and pages deployment are compatible per each action's release notes. This PR's own CI run exercises the upgraded ci.yml.

(Survey + edits delegated to a Haiku subagent; versions independently verified before shipping.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)