### PR TITLE
ADR-0034: Proposed → Accepted (option B ratified)

### DIFF
--- a/docs/designs/0034-cross-target-runtime.md
+++ b/docs/designs/0034-cross-target-runtime.md
@@ -1,6 +1,6 @@
 # ADR-0034: Per-Target Runtime Archives for Cross-Compilation
 
-**Status:** Proposed (stopgap implemented: cross-target links are refused with a clear error)
+**Status:** Accepted (ratified by Steve 2026-06-11: option B now, option A acknowledged as the probable eventual destination; stopgap C shipped in #978)
 **Tracking:** RUE-36 (cross-compilation embeds the host runtime), RUE-144 item 7 (build-graph root cause), RUE-85 (Mach-O cross-linking)
 
 ## Problem


### PR DESCRIPTION
Records the ratification from this morning's decision review: option B (per-target staticlib rules driving the hermetic rustc directly, plus three pinned rust-std components) is the accepted design, with option A (real Buck2 platforms/transitions) acknowledged as the probable eventual destination. The C stopgap shipped in #978; implementation is tracked in RUE-36.

One-line status change, no other edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)