### PR TITLE
Consts require type annotations

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1925,7 +1925,7 @@ impl<'a> Sema<'a> {
             return Ok(AnalysisResult::new(air_ref, ty));
         }
 
-        // Check if it's a value constant (e.g., `const VALUE = -42;`).
+        // Check if it's a value constant (e.g., `const VALUE: i32 = -42;`).
         // Module-typed constants never appear here: module bindings AND
         // aliases (`const m2 = std.math;`) live in `module_bindings`,
         // checked above. The value was evaluated once during declaration

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1124,7 +1124,7 @@ impl<'a> Sema<'a> {
                         p.span,
                     ));
                 }
-                let ty = self.const_type_for_value(value, p.ty_sym, p.init, p.span)?;
+                let ty = self.const_type_for_value(value, p.ty_sym, p.init, p.span, &name_str)?;
                 self.constants.insert(
                     name,
                     ConstInfo {
@@ -1294,7 +1294,7 @@ impl<'a> Sema<'a> {
 
             // Member access: `base.member` where `base` is a module —
             // `const math = std.math;` (alias of a re-export, RUE-160) or
-            // `const X = m.ANSWER;` (a member value constant).
+            // `const X: i32 = m.ANSWER;` (a member value constant).
             InstData::FieldGet { base, field } => {
                 let (base, field) = (*base, *field);
                 match self.eval_const_initializer(base, file_id, st)? {
@@ -1334,7 +1334,8 @@ impl<'a> Sema<'a> {
     /// The engine runs without HM type information here (a file-level const
     /// has no enclosing function), so arithmetic uses the checked-`i64`
     /// fallback semantics; the result is range-checked against the declared
-    /// or inferred type in [`Self::const_type_for_value`].
+    /// type in [`Self::const_type_for_value`] (which also rejects a missing
+    /// annotation, E0475).
     fn eval_const_value_expr(
         &mut self,
         init: InstRef,
@@ -1570,19 +1571,22 @@ impl<'a> Sema<'a> {
     }
 
     /// Determine a value constant's type from its evaluated value and
-    /// optional annotation.
+    /// annotation.
     ///
-    /// Unannotated integer constants infer the smallest fitting type out of
-    /// `i32` -> `i64` -> `u64` (spec 6.5:4), so `const BIG = 5000000000;` is
-    /// an `i64`, not a truncated `i32`. An annotated integer constant adopts
-    /// any integer annotation its value fits in (RUE-161); a value out of
-    /// range of the annotation is rejected at the declaration (E0800).
+    /// A value constant **requires** a type annotation (spec 6.5:4, RUE-179);
+    /// an unannotated one is E0475, with a help suggesting the annotation
+    /// that would have been inferred (smallest of `i32`/`i64`/`u64` for
+    /// integers, `bool`/`()` otherwise). Only module bindings — which never
+    /// take this path — are exempt. An annotated integer constant adopts any
+    /// integer annotation its value fits in (RUE-161); a value out of range
+    /// of the annotation is rejected at the declaration (E0800).
     fn const_type_for_value(
         &mut self,
         value: ConstValue,
         ty_sym: Option<Spur>,
         init: InstRef,
         span: Span,
+        name: &str,
     ) -> CompileResult<Type> {
         use super::comptime_eval::const_int_fits;
 
@@ -1605,7 +1609,23 @@ impl<'a> Sema<'a> {
         };
 
         let Some(ty_sym) = ty_sym else {
-            return Ok(inferred);
+            // Type values are not annotatable (no syntax names them), so a
+            // hypothetical unannotated type-valued constant is not an
+            // annotation error; today they are rejected upstream anyway.
+            if matches!(value, ConstValue::Type(_)) {
+                return Ok(inferred);
+            }
+            return Err(CompileError::new(
+                ErrorKind::ConstMissingTypeAnnotation {
+                    name: name.to_string(),
+                },
+                span,
+            )
+            .with_help(format!(
+                "add a type annotation: `const {}: {} = ...;`",
+                name,
+                inferred.safe_name_with_pool(Some(&self.type_pool))
+            )));
         };
         // The annotation resolves like any signature type (unknown names are
         // E0204) and the value is validated against it.

--- a/crates/rue-air/src/sema/inference_ctx.rs
+++ b/crates/rue-air/src/sema/inference_ctx.rs
@@ -35,7 +35,7 @@ pub struct InferenceContext {
     /// Method signatures with InferType: (struct_id, method_name) -> MethodSig.
     pub method_sigs: HashMap<(StructId, Spur), MethodSig>,
     /// File-level constant types: name -> declared type (e.g. `Type::I32` for
-    /// `const N = 41`, a module type for `const m = @import(...)`). Constant
+    /// `const N: i32 = 41`, a module type for `const m = @import(...)`). Constant
     /// types are fully resolved during declaration gathering, before any
     /// function body is inferred, so they can be consulted like params here.
     /// Without this map a const reference inferred to `<error>` and poisoned

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -77,7 +77,7 @@ pub struct Sema<'a> {
     /// Method table: maps (struct_id, method_name) to method info
     pub(crate) methods: HashMap<(StructId, Spur), MethodInfo>,
     /// Constant table: maps const name symbol to const info.
-    /// Holds value constants only (e.g. `const MAX = 10`); module bindings
+    /// Holds value constants only (e.g. `const MAX: i32 = 10`); module bindings
     /// live in [`Self::module_bindings`].
     pub(crate) constants: HashMap<Spur, ConstInfo>,
     /// Module-binding constants (`const utils = @import("...")`), keyed by

--- a/crates/rue-cli-tests/cases/const_init.toml
+++ b/crates/rue-cli-tests/cases/const_init.toml
@@ -1,16 +1,18 @@
-# Constant initializer evaluation (RUE-171).
+# Constant initializer evaluation (RUE-171) and required annotations (RUE-179).
 #
 # Const initializers go through the comptime engine: negated literals,
 # arithmetic, comptime blocks, and references to other constants are legal.
-# Unannotated integer constants infer the smallest fitting type out of
-# i32 -> i64 -> u64 (spec 6.5:4); annotated values are range-checked at the
-# declaration (E0800). Initializers are evaluated in dependency order across
-# files; cycles are E0461.
+# Value constants REQUIRE a type annotation (spec 6.5:4): an unannotated one
+# is E0475 (the value-based i32 -> i64 -> u64 inference that #980 shipped was
+# removed by RUE-179). Module bindings (`const m = @import(...)` and aliases)
+# are exempt. Annotated values are range-checked at the declaration (E0800).
+# Initializers are evaluated in dependency order across files; cycles are
+# E0461.
 
 [section]
 id = "cli.const_init"
 name = "Constant initializer evaluation"
-description = "Comptime-evaluated const initializers, inferred integer types, dependency ordering, cycle detection (RUE-171)."
+description = "Comptime-evaluated const initializers, required type annotations (E0475), dependency ordering, cycle detection (RUE-171, RUE-179)."
 
 # A negated literal — the headline RUE-171 repro (used to be E0434).
 [[case]]
@@ -40,9 +42,9 @@ exit_code = 7
 [[case]]
 name = "arithmetic_and_const_refs"
 files = [{ path = "main.rue", source = """
-const AREA = 6 * 7;
-const DOUBLE = AREA + AREA;
-const FLAG = !false;
+const AREA: i32 = 6 * 7;
+const DOUBLE: i32 = AREA + AREA;
+const FLAG: bool = !false;
 
 fn main() -> i32 {
     if FLAG { DOUBLE - AREA } else { 0 }
@@ -54,7 +56,7 @@ exit_code = 42
 [[case]]
 name = "comptime_block_initializer"
 files = [{ path = "main.rue", source = """
-const X = comptime { 6 * 7 };
+const X: i32 = comptime { 6 * 7 };
 
 fn main() -> i32 {
     X
@@ -62,12 +64,48 @@ fn main() -> i32 {
 """ }]
 exit_code = 42
 
-# Unannotated const whose literal does not fit i32 infers i64 (spec 6.5:4) —
-# previously it silently defaulted to i32 and errored at the USE site.
+# An unannotated value constant is E0475, with a help suggesting the
+# annotation the removed inference would have chosen (RUE-179).
 [[case]]
-name = "unannotated_big_literal_infers_i64"
+name = "unannotated_const_rejected_with_help"
+files = [{ path = "main.rue", source = """
+const X = 5;
+
+fn main() -> i32 {
+    X
+}
+""" }]
+compile_fail = true
+error_contains = ["E0475", "missing type annotation on constant 'X'", "add a type annotation: `const X: i32 = ...;`"]
+
+# The E0475 help suggests i64 for a literal that does not fit i32 (this
+# pinned inference under #980; the chain now only feeds the suggestion).
+[[case]]
+name = "unannotated_big_literal_rejected_suggests_i64"
 files = [{ path = "main.rue", source = """
 const BIG = 5000000000;
+
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0475", "missing type annotation on constant 'BIG'", "`const BIG: i64 = ...;`"]
+
+# ... and u64 beyond i64::MAX.
+[[case]]
+name = "unannotated_huge_literal_rejected_suggests_u64"
+files = [{ path = "main.rue", source = """
+const HUGE = 18446744073709551615;
+
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0475", "missing type annotation on constant 'HUGE'", "`const HUGE: u64 = ...;`"]
+
+# The annotated equivalents of the old inference chain keep working.
+[[case]]
+name = "annotated_big_literal_i64"
+files = [{ path = "main.rue", source = """
+const BIG: i64 = 5000000000;
 
 fn main() -> i32 {
     if BIG / 1000000000 == 5 { 5 } else { 1 }
@@ -75,17 +113,50 @@ fn main() -> i32 {
 """ }]
 exit_code = 5
 
-# Unannotated const beyond i64::MAX infers u64.
 [[case]]
-name = "unannotated_huge_literal_infers_u64"
+name = "annotated_huge_literal_u64"
 files = [{ path = "main.rue", source = """
-const HUGE = 18446744073709551615;
+const HUGE: u64 = 18446744073709551615;
 
 fn main() -> i32 {
     if HUGE > 18446744073709551614 { 3 } else { 1 }
 }
 """ }]
 exit_code = 3
+
+# Module bindings are NOT value constants: no annotation required (RUE-179
+# carve-out), and member access through one still works annotated.
+[[case]]
+name = "module_binding_exempt_from_annotation"
+files = [
+    { path = "main.rue", source = """
+const cfg = @import("cfg");
+const X: i32 = cfg.ANSWER;
+
+fn main() -> i32 {
+    X
+}
+""" },
+    { path = "cfg.rue", source = """
+pub const ANSWER: i32 = 42;
+""" },
+]
+exit_code = 42
+
+# A type-valued initializer is still E0434 (not E0475): type aliases are not
+# value constants, and fn-call initializers are not const-evaluable today
+# (fn-valued constants are RUE-173). If type aliases become legal they stay
+# exempt from the annotation requirement.
+[[case]]
+name = "type_alias_initializer_still_e0434"
+files = [{ path = "main.rue", source = """
+fn MakeT() -> type { i32 }
+const T = MakeT();
+
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0434", "not supported in const context"]
 
 # Annotated out-of-range value is rejected AT THE DECLARATION (E0800).
 [[case]]
@@ -113,9 +184,9 @@ error_contains = ["value -5 is out of range for type u8"]
 [[case]]
 name = "forward_reference_same_file"
 files = [{ path = "main.rue", source = """
-const A = B + 1;
-const B = C * 2;
-const C = 10;
+const A: i32 = B + 1;
+const B: i32 = C * 2;
+const C: i32 = 10;
 
 fn main() -> i32 {
     A
@@ -130,14 +201,14 @@ name = "cross_file_chain_definer_second"
 args = ["main.rue", "config.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
-const FROM_CONFIG = LIMIT + 1;
+const FROM_CONFIG: i32 = LIMIT + 1;
 
 fn main() -> i32 {
     FROM_CONFIG
 }
 """ },
     { path = "config.rue", source = """
-pub const LIMIT = 41;
+pub const LIMIT: i32 = 41;
 """ },
 ]
 exit_code = 42
@@ -148,10 +219,10 @@ name = "cross_file_chain_definer_first"
 args = ["config.rue", "main.rue", "-o", "prog"]
 files = [
     { path = "config.rue", source = """
-pub const LIMIT = 41;
+pub const LIMIT: i32 = 41;
 """ },
     { path = "main.rue", source = """
-const FROM_CONFIG = LIMIT + 1;
+const FROM_CONFIG: i32 = LIMIT + 1;
 
 fn main() -> i32 {
     FROM_CONFIG
@@ -164,8 +235,8 @@ exit_code = 42
 [[case]]
 name = "cycle_is_error_not_hang"
 files = [{ path = "main.rue", source = """
-const A = B;
-const B = A;
+const A: i32 = B;
+const B: i32 = A;
 
 fn main() -> i32 { 0 }
 """ }]
@@ -176,7 +247,7 @@ error_contains = ["E0461", "cycle detected in constant initializers", "A -> B ->
 [[case]]
 name = "self_cycle_is_error"
 files = [{ path = "main.rue", source = """
-const SELF = SELF;
+const SELF: i32 = SELF;
 
 fn main() -> i32 { 0 }
 """ }]
@@ -189,7 +260,7 @@ error_contains = ["E0461", "SELF -> SELF"]
 name = "runtime_call_initializer_still_rejected"
 files = [{ path = "main.rue", source = """
 fn get() -> i32 { 42 }
-const X = get();
+const X: i32 = get();
 
 fn main() -> i32 { 0 }
 """ }]

--- a/crates/rue-cli-tests/cases/decl_annotations.toml
+++ b/crates/rue-cli-tests/cases/decl_annotations.toml
@@ -121,13 +121,14 @@ compile_fail = true
 error_contains = ["type mismatch: expected bool, found i32"]
 
 [[case]]
-name = "const_unannotated_defaults_to_i32"
-description = "Unannotated integer consts still infer i32 from the literal."
+name = "const_unannotated_rejected"
+description = "Value consts require a type annotation (E0475, RUE-179)."
 files = [{ path = "main.rue", source = """
 const N = 41;
 fn main() -> i32 { N + 1 }
 """ }]
-exit_code = 42
+compile_fail = true
+error_contains = ["E0475", "missing type annotation on constant 'N'"]
 
 # ============================================================================
 # RUE-155: let annotations are validated against the shared type table

--- a/crates/rue-cli-tests/cases/module_consts.toml
+++ b/crates/rue-cli-tests/cases/module_consts.toml
@@ -35,7 +35,7 @@ name = "member_const_in_const_initializer"
 files = [
     { path = "main.rue", source = """
 const math = @import("math");
-const COPY = math.ANSWER;
+const COPY: i32 = math.ANSWER;
 
 fn main() -> i32 {
     COPY + math.ANSWER
@@ -60,7 +60,7 @@ fn main() -> i32 {
 }
 """ },
     { path = "cfg.rue", source = """
-pub const BIG = 5000000000;
+pub const BIG: i64 = 5000000000;
 """ },
 ]
 exit_code = 9
@@ -145,7 +145,7 @@ name = "private_member_const_rejected_in_const_context"
 files = [
     { path = "main.rue", source = """
 const lib = @import("sub/lib");
-const S = lib.SECRET;
+const S: i32 = lib.SECRET;
 
 fn main() -> i32 { S }
 """ },
@@ -201,7 +201,7 @@ name = "unknown_member_still_e0707"
 files = [
     { path = "main.rue", source = """
 const math = @import("math");
-const X = math.NOPE;
+const X: i32 = math.NOPE;
 
 fn main() -> i32 { 0 }
 """ },

--- a/crates/rue-cli-tests/cases/module_member_infer.toml
+++ b/crates/rue-cli-tests/cases/module_member_infer.toml
@@ -187,7 +187,7 @@ error_contains = ["E0707", "no member `nope`"]
 [[case]]
 name = "const_int_arithmetic_operand"
 files = [{ path = "main.rue", source = """
-const N = 41;
+const N: i32 = 41;
 fn main() -> i32 { N + 1 }
 """ }]
 exit_code = 42

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -139,6 +139,7 @@ impl ErrorCode {
     pub const CONST_INITIALIZER_CYCLE: Self = Self(461);
     // 462-473 are reserved by in-flight work.
     pub const LINEAR_FIELD_DROPPED_BY_DESTRUCTURE: Self = Self(474);
+    pub const CONST_MISSING_TYPE_ANNOTATION: Self = Self(475);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -986,6 +987,11 @@ pub enum ErrorKind {
     /// being defined, so no evaluation order exists.
     #[error("cycle detected in constant initializers: {cycle}")]
     ConstInitializerCycle { cycle: String },
+    /// A value constant declared without a type annotation. Annotations are
+    /// required on value constants (spec 6.5:4, RUE-179); only module
+    /// bindings (`const m = @import(...)` and aliases) are exempt.
+    #[error("missing type annotation on constant '{name}'")]
+    ConstMissingTypeAnnotation { name: String },
 
     // Enum errors
     #[error("duplicate variant '{variant_name}' in enum '{enum_name}'")]
@@ -1233,6 +1239,9 @@ impl ErrorKind {
             ErrorKind::DuplicateConstant { .. } => ErrorCode::DUPLICATE_CONSTANT,
             ErrorKind::ConstExprNotSupported { .. } => ErrorCode::CONST_EXPR_NOT_SUPPORTED,
             ErrorKind::ConstInitializerCycle { .. } => ErrorCode::CONST_INITIALIZER_CYCLE,
+            ErrorKind::ConstMissingTypeAnnotation { .. } => {
+                ErrorCode::CONST_MISSING_TYPE_ANNOTATION
+            }
             ErrorKind::DuplicateVariant { .. } => ErrorCode::DUPLICATE_VARIANT,
             ErrorKind::UnknownVariant { .. } => ErrorCode::UNKNOWN_VARIANT,
             ErrorKind::UnknownEnumType(_) => ErrorCode::UNKNOWN_ENUM_TYPE,

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1195,7 +1195,7 @@ name = "comptime_file_level_const"
 spec = ["4.14:2"]
 description = "File-level constants are usable inside comptime blocks"
 source = """
-const N = 7;
+const N: i32 = 7;
 fn main() -> i32 {
     comptime { N * 6 }
 }

--- a/crates/rue-spec/cases/items/constants.toml
+++ b/crates/rue-spec/cases/items/constants.toml
@@ -2,7 +2,7 @@
 id = "items.constants"
 spec_chapter = "6.5"
 name = "Constant Items"
-description = "Constant declarations: comptime-evaluated initializers, inferred and annotated types, dependency-ordered evaluation (spec chapter 6.5)."
+description = "Constant declarations: comptime-evaluated initializers, required type annotations, dependency-ordered evaluation (spec chapter 6.5)."
 
 # =============================================================================
 # Declaration form (6.5:1)
@@ -11,10 +11,10 @@ description = "Constant declarations: comptime-evaluated initializers, inferred 
 [[case]]
 name = "const_declaration_forms"
 spec = ["6.5:1"]
-description = "pub/non-pub, annotated/unannotated const items all declare usable constants"
+description = "pub and non-pub annotated const items declare usable constants"
 source = """
 pub const A: i32 = 30;
-const B = 12;
+const B: i32 = 12;
 
 fn main() -> i32 { A + B }
 """
@@ -40,9 +40,9 @@ name = "operator_and_const_ref_initializers"
 spec = ["6.5:2", "6.5:3"]
 description = "Arithmetic, boolean operators, and references to other constants"
 source = """
-const AREA = 6 * 7;
-const DOUBLE = AREA + AREA;
-const FLAG = !false;
+const AREA: i32 = 6 * 7;
+const DOUBLE: i32 = AREA + AREA;
+const FLAG: bool = !false;
 
 fn main() -> i32 {
     if FLAG { DOUBLE - AREA } else { 0 }
@@ -55,7 +55,7 @@ name = "comptime_block_initializer"
 spec = ["6.5:2"]
 description = "A comptime block is a legal const initializer"
 source = """
-const X = comptime { 40 + 2 };
+const X: i32 = comptime { 40 + 2 };
 
 fn main() -> i32 { X }
 """
@@ -67,7 +67,7 @@ spec = ["6.5:2"]
 description = "A runtime function call is not compile-time evaluable (E0434)"
 source = """
 fn get() -> i32 { 42 }
-const X = get();
+const X: i32 = get();
 
 fn main() -> i32 { 0 }
 """
@@ -75,58 +75,56 @@ compile_fail = true
 error_contains = "not supported in const context"
 
 # =============================================================================
-# Inferred types (6.5:4)
+# Required type annotations (6.5:4)
 # =============================================================================
 
 [[case]]
-name = "unannotated_small_literal_is_i32"
-spec = ["6.5:4"]
-description = "A fitting literal infers i32 (usable where i32 is expected)"
+name = "unannotated_integer_const_rejected"
+spec = ["6.5:4", "6.5:11"]
+description = "A value constant without a type annotation is E0475"
 source = """
 const N = 42;
 
-fn takes_i32(x: i32) -> i32 { x }
-
-fn main() -> i32 { takes_i32(N) }
+fn main() -> i32 { 0 }
 """
-exit_code = 42
+compile_fail = true
+error_contains = ["E0475", "missing type annotation on constant 'N'"]
 
 [[case]]
-name = "unannotated_big_literal_is_i64"
+name = "unannotated_bool_const_rejected"
 spec = ["6.5:4"]
-description = "A literal that does not fit i32 infers i64; no truncation, no use-site error"
-source = """
-const BIG = 5000000000;
-
-fn main() -> i32 {
-    if BIG / 1000000000 == 5 { 5 } else { 1 }
-}
-"""
-exit_code = 5
-
-[[case]]
-name = "unannotated_huge_literal_is_u64"
-spec = ["6.5:4"]
-description = "A literal beyond i64::MAX infers u64"
-source = """
-const HUGE = 18446744073709551615;
-
-fn main() -> i32 {
-    if HUGE > 18446744073709551614 { 3 } else { 1 }
-}
-"""
-exit_code = 3
-
-[[case]]
-name = "unannotated_bool_const"
-spec = ["6.5:4"]
-description = "Boolean constants have type bool"
+description = "Boolean value constants require an annotation too"
 source = """
 const FLAG = true;
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0475", "missing type annotation on constant 'FLAG'"]
+
+[[case]]
+name = "annotated_bool_const"
+spec = ["6.5:4"]
+description = "An annotated boolean constant has type bool"
+source = """
+const FLAG: bool = true;
 
 fn main() -> i32 { if FLAG { 7 } else { 1 } }
 """
 exit_code = 7
+
+[[case]]
+name = "module_binding_needs_no_annotation"
+spec = ["6.5:4"]
+description = "Module bindings are not value constants: no annotation required"
+source = """
+const cfg = @import("cfg");
+const X: i32 = cfg.LIMIT;
+
+fn main() -> i32 { X }
+"""
+aux_files = { "cfg.rue" = "pub const LIMIT: i32 = 42;" }
+exit_code = 42
 
 # =============================================================================
 # Annotated types (6.5:5)
@@ -144,6 +142,32 @@ fn takes_u8(x: u8) -> i32 { 1 }
 fn main() -> i32 { takes_u8(SMALL) }
 """
 exit_code = 1
+
+[[case]]
+name = "big_literal_with_i64_annotation"
+spec = ["6.5:5", "6.5:6"]
+description = "A literal that does not fit i32 works with an i64 annotation"
+source = """
+const BIG: i64 = 5000000000;
+
+fn main() -> i32 {
+    if BIG / 1000000000 == 5 { 5 } else { 1 }
+}
+"""
+exit_code = 5
+
+[[case]]
+name = "huge_literal_with_u64_annotation"
+spec = ["6.5:5", "6.5:6"]
+description = "A literal beyond i64::MAX works with a u64 annotation"
+source = """
+const HUGE: u64 = 18446744073709551615;
+
+fn main() -> i32 {
+    if HUGE > 18446744073709551614 { 3 } else { 1 }
+}
+"""
+exit_code = 3
 
 [[case]]
 name = "annotation_out_of_range_rejected_at_declaration"
@@ -190,9 +214,9 @@ name = "forward_reference_same_file"
 spec = ["6.5:7", "6.5:9"]
 description = "A const may reference a const declared later in the file"
 source = """
-const A = B + 1;
-const B = C * 2;
-const C = 10;
+const A: i32 = B + 1;
+const B: i32 = C * 2;
+const C: i32 = 10;
 
 fn main() -> i32 { A }
 """
@@ -200,16 +224,16 @@ exit_code = 21
 
 [[case]]
 name = "forward_reference_across_files"
-spec = ["6.5:7"]
+spec = ["6.5:7", "6.5:10"]
 description = "A const may reference a const declared in another (imported) file"
 source = """
 const cfg = @import("cfg");
-const BASE = cfg.LIMIT;
-const DERIVED = BASE + 1;
+const BASE: i32 = cfg.LIMIT;
+const DERIVED: i32 = BASE + 1;
 
 fn main() -> i32 { DERIVED }
 """
-aux_files = { "cfg.rue" = "pub const LIMIT = 41;" }
+aux_files = { "cfg.rue" = "pub const LIMIT: i32 = 41;" }
 exit_code = 42
 
 [[case]]
@@ -217,8 +241,8 @@ name = "initializer_cycle_is_error"
 spec = ["6.5:8", "6.5:9"]
 description = "A reference cycle between const initializers is a compile error, not a hang"
 source = """
-const A = B;
-const B = A;
+const A: i32 = B;
+const B: i32 = A;
 
 fn main() -> i32 { 0 }
 """
@@ -230,7 +254,7 @@ name = "self_referential_const_is_error"
 spec = ["6.5:8"]
 description = "A self-referential const is the smallest cycle"
 source = """
-const SELF = SELF;
+const SELF: i32 = SELF;
 
 fn main() -> i32 { 0 }
 """

--- a/crates/rue-spec/cases/modules/bindings.toml
+++ b/crates/rue-spec/cases/modules/bindings.toml
@@ -250,7 +250,7 @@ fn main() -> i32 {
     if cfg.BIG / 1000000000 == 5 { 9 } else { 1 }
 }
 """
-aux_files = { "cfg.rue" = "pub const BIG = 5000000000;" }
+aux_files = { "cfg.rue" = "pub const BIG: i64 = 5000000000;" }
 exit_code = 9
 
 [[case]]
@@ -259,7 +259,7 @@ spec = ["10.4:12", "10.4:14"]
 description = "Member access to a value const is itself compile-time evaluable"
 source = """
 const math = @import("math");
-const COPY = math.ANSWER;
+const COPY: i32 = math.ANSWER;
 
 fn main() -> i32 {
     math.ANSWER + COPY

--- a/crates/rue-spec/cases/modules/composition.toml
+++ b/crates/rue-spec/cases/modules/composition.toml
@@ -31,10 +31,10 @@ fn main() -> i32 {
 }
 """
 aux_files = { "left.rue" = """
-pub const LIMIT = 1;
+pub const LIMIT: i32 = 1;
 pub fn go() -> i32 { LIMIT }
 """, "right.rue" = """
-pub const LIMIT = 2;
+pub const LIMIT: i32 = 2;
 pub fn go2() -> i32 { LIMIT }
 """ }
 compile_fail = true

--- a/crates/rue-spec/cases/modules/constants.toml
+++ b/crates/rue-spec/cases/modules/constants.toml
@@ -17,13 +17,14 @@ fn main() -> i32 { 0 }
 exit_code = 0
 
 [[case]]
-name = "const_without_type"
-description = "Const declaration without explicit type annotation"
+name = "const_without_type_rejected"
+description = "A value const without a type annotation is E0475 (RUE-179)"
 source = """
 const VALUE = 42;
 fn main() -> i32 { 0 }
 """
-exit_code = 0
+compile_fail = true
+error_contains = ["E0475", "missing type annotation on constant 'VALUE'"]
 
 # =============================================================================
 # Typed Const Declarations (RUE-161)

--- a/docs/spec/src/06-items/05-constants.md
+++ b/docs/spec/src/06-items/05-constants.md
@@ -27,41 +27,53 @@ compile-time error (E0434).
 
 ```rue
 const NEG: i32 = -5;             // negated literal
-const AREA = 6 * 7;              // constant arithmetic
-const DOUBLE = AREA + AREA;      // references another constant
-const FLAG = !false;             // boolean operators
+const AREA: i32 = 6 * 7;         // constant arithmetic
+const DOUBLE: i32 = AREA + AREA; // references another constant
+const FLAG: bool = !false;       // boolean operators
 ```
 
 {{ rule(id="6.5:10", cat="informative") }}
 
 In the current implementation, a module member access (`m.CONST`, 10.4:12)
 is compile-time evaluable only as a whole initializer, not as the operand of
-an operator: write `const BASE = m.LIMIT; const N = BASE + 1;` rather than
-`const N = m.LIMIT + 1;`. This restriction is an implementation artifact,
-not a language guarantee.
+an operator: write `const BASE: i32 = m.LIMIT; const N: i32 = BASE + 1;`
+rather than `const N: i32 = m.LIMIT + 1;`. This restriction is an
+implementation artifact, not a language guarantee.
 
 ## Types of Constants
 
-{{ rule(id="6.5:4", cat="normative") }}
+{{ rule(id="6.5:4", cat="legality-rule") }}
 
-An integer constant without a type annotation has the smallest of the types
-`i32`, `i64`, `u64` that can represent its value. A boolean constant has
-type `bool`; a unit constant has type `()`.
+A *value constant* — a constant whose initializer evaluates to a value
+rather than a module — **MUST** have a type annotation. A value constant
+declared without one is a compile-time error (E0475). Module bindings
+(`const m = @import(...)`, aliases of module bindings, and re-exports —
+chapter 10) are not value constants: they take no annotation (no type
+annotation can name a module type) and require none.
+
+{{ rule(id="6.5:11", cat="informative") }}
+
+Earlier drafts inferred an unannotated integer constant's type from its
+value (the smallest of `i32`, `i64`, `u64` that could represent it). That
+inference was removed in favor of explicit annotations; some form of
+inference for constants may be revisited in a future revision. The E0475
+diagnostic suggests the annotation the removed inference would have chosen.
 
 {{ rule(id="6.5:5", cat="legality-rule") }}
 
-An integer constant with a type annotation has the annotated type; its value
-**MUST** be representable in that type, and a value out of range is a
-compile-time error reported at the declaration. A non-integer annotation
-**MUST** match the type of the initializer's value exactly.
+An integer constant's value **MUST** be representable in its annotated
+type; a value out of range is a compile-time error reported at the
+declaration. A non-integer annotation **MUST** match the type of the
+initializer's value exactly.
 
 {{ rule(id="6.5:6", cat="example") }}
 
 ```rue
-const BIG = 5000000000;          // i64: does not fit i32
-const HUGE = 18446744073709551615; // u64: does not fit i64
+const BIG: i64 = 5000000000;     // i64: annotation required and adopted
+const HUGE: u64 = 18446744073709551615; // u64: largest u64 value
 const SMALL: u8 = 200;           // u8: annotation adopted, value fits
 // const BAD: u8 = 300;          // error: out of range for u8 (E0800)
+// const NONE = 5;               // error: missing type annotation (E0475)
 ```
 
 ## Evaluation Order
@@ -81,7 +93,7 @@ including a constant that references itself — is a compile-time error
 {{ rule(id="6.5:9", cat="example") }}
 
 ```rue
-const A = B + 1;                 // forward reference: fine
-const B = 2;
-// const X = Y; const Y = X;     // error: cycle X -> Y -> X (E0461)
+const A: i32 = B + 1;            // forward reference: fine
+const B: i32 = 2;
+// const X: i32 = Y; const Y: i32 = X; // error: cycle X -> Y -> X (E0461)
 ```

--- a/docs/spec/src/10-modules/04-module-bindings.md
+++ b/docs/spec/src/10-modules/04-module-bindings.md
@@ -129,11 +129,11 @@ constant is private to the directory of its defining file (E0706).
 ```rue
 // math.rue
 pub const ANSWER: i32 = 42;
-const SECRET = 99;               // private outside math.rue's directory
+const SECRET: i32 = 99;          // private outside math.rue's directory
 
 // main.rue (same directory)
 const math = @import("math");
-const COPY = math.ANSWER;        // const-evaluable member access
+const COPY: i32 = math.ANSWER;   // const-evaluable member access
 
 fn main() -> i32 { math.ANSWER + COPY }   // 84
 ```


### PR DESCRIPTION
Implements Steve's morning ruling on the 6.5:4 review: the value-based i32→i64→u64 inference for unannotated consts (shipped in #980) was too magic — `const X = 5;` is now **E0475** missing-type-annotation, with help text suggesting the type the removed inference would have picked. Annotated consts keep the full #973/#980 behavior (comptime-engine initializers, dependency ordering, E0461 cycles, module member access — all re-verified by execution post-integration).

Module bindings (`const m = @import(...)`) structurally never reach the check and stay annotation-free. One premise refuted: file-level comptime type aliases (`const T = MakeT()`) turn out to be **already illegal** today (E0434), so that carve-out is pinned as still-E0434 rather than allowed.

Spec 6.5:4 rewritten as the annotations-required legality rule + informative 6.5:11 noting inference may be revisited; all inference pins flipped to E0475 pins with annotated equivalents; every unannotated value const across the suites and docs annotated. Full ./test.sh green, traceability 100%.

Fixes RUE-179

🤖 Generated with [Claude Code](https://claude.com/claude-code)