### PR TITLE
Privacy everywhere: cross-file calls require pub in all multi-file compilations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,16 +94,13 @@ rue main.rue utils.rue lib.rue -o program
 ```
 
 **Key semantics:**
-- All functions, structs, and enums are globally visible across files
+- All top-level names resolve across files without imports (flat namespace),
+  but privacy is uniform (spec 10.3:7): a function is callable outside its
+  defining directory only if `pub`, whether its file is imported or just
+  listed (E0460 otherwise; through a module object it's E0706)
 - Duplicate definitions (same name in multiple files) cause a compile error
 - `main()` must exist in exactly one file
 - Files are parsed in parallel, then merged for semantic analysis
-
-**Module interaction:** files loaded via `@import` (the module system, spec
-chapter 10) get directory-based privacy enforcement — private items of an
-imported file are rejected from other directories whether accessed through
-the module object (E0706) or unqualified (E0460). Files that are only
-listed explicitly and never imported keep the flat namespace above.
 
 **Current limitations (transitional, see spec 10.5:2):**
 - Top-level names are not yet module-scoped — all symbols share one global

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3418,10 +3418,11 @@ impl<'a> Sema<'a> {
             .get(&name)
             .ok_or_compile_error(ErrorKind::UndefinedFunction(fn_name_str.clone()), span)?;
 
-        // Visibility: an unqualified call must not reach a private function
-        // in a module's file from outside that module's directory (E0460,
-        // RUE-37) — otherwise dropping the `module.` qualifier would bypass
-        // the E0706 privacy check on `module.f()`.
+        // Visibility (E0460, RUE-37/RUE-180): an unqualified call must not
+        // reach a private function defined in another directory — privacy is
+        // uniform in every multi-file compilation, imports or not (spec
+        // 10.3:7), so the flat namespace resolves the name but the callee
+        // must be `pub` (or in the caller's directory).
         self.check_unqualified_call_visibility(
             &fn_name_str,
             fn_info.file_id,

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -55,28 +55,19 @@ impl Sema<'_> {
         }
     }
 
-    /// Check that an *unqualified* call may reach the callee (RUE-37).
+    /// Check that an *unqualified* call may reach the callee (RUE-37,
+    /// RUE-180).
     ///
-    /// All loaded files share one flat global function namespace (spec
-    /// 10.5:2, transitional), so a plain `secret()` call would otherwise
-    /// resolve a private function from any file — bypassing the E0706 check
-    /// that qualified `module.secret()` access gets. The rule (spec 10.3:7):
+    /// All loaded files share one flat global function namespace for *name
+    /// resolution* (spec 10.5:2, transitional), but privacy is uniform in
+    /// every multi-file compilation, imports or not (spec 10.3:7):
     ///
     /// - If the callee is accessible per [`Sema::is_accessible`] (it is
-    ///   `pub`, or the caller is in the callee's directory), the call is fine.
-    /// - Otherwise, if the callee's file was loaded *as a module* (it is the
-    ///   target of a resolved `@import` in the program), the call is an error
-    ///   (E0460): module privacy must not be escapable by dropping the
-    ///   qualifier.
-    /// - Files that are never imported (only listed explicitly on the
-    ///   command line) keep the flat namespace: no error.
-    ///
-    /// Module-ness is read from the module registry, which is populated for
-    /// top-level `const m = @import(...)` bindings during Phase 2.5, before
-    /// any function body is analyzed. (A file imported *only* by a
-    /// function-local `let m = @import(...)` is registered when that body is
-    /// analyzed, so calls analyzed earlier may not yet see it as a module —
-    /// an accepted gap of the transitional flat namespace.)
+    ///   `pub`, or the caller is in the callee's directory — ADR-0026
+    ///   intra-directory visibility), the call is fine.
+    /// - Otherwise the call is an error (E0460), naming the callee's
+    ///   defining file. Whether that file was loaded via `@import` or merely
+    ///   listed on the command line makes no difference.
     pub(crate) fn check_unqualified_call_visibility(
         &self,
         fn_name: &str,
@@ -88,23 +79,23 @@ impl Sema<'_> {
             return Ok(());
         }
 
-        // Inaccessible — but only enforce if the callee's file is a module.
-        let Some(callee_path) = self.get_file_path(callee_file_id) else {
-            return Ok(());
-        };
-        let Some(import_path) = self.module_registry.import_path_for_file(callee_path) else {
-            return Ok(());
-        };
+        // `is_accessible` is permissive when either file path is unknown
+        // (single-file mode, synthetic items), so the callee's path is
+        // always known here.
+        let defining_file = self
+            .get_file_path(callee_file_id)
+            .unwrap_or("<unknown>")
+            .to_string();
 
         Err(CompileError::new(
             ErrorKind::PrivateUnqualifiedAccess {
                 name: fn_name.to_string(),
-                module_path: import_path,
+                defining_file,
             },
             span,
         )
         .with_help(format!(
-            "`{fn_name}` is not marked `pub`; private items are only visible within their own directory"
+            "`{fn_name}` is not marked `pub`; private items are only visible within their defining directory"
         )))
     }
 

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -70,23 +70,6 @@ impl ModuleRegistry {
         (id, true)
     }
 
-    /// Find the import path of a module whose resolved file path equals
-    /// `file_path`, if any.
-    ///
-    /// Used to decide whether a source file is "loaded as a module" (the
-    /// target of a resolved `@import`) — such files get directory-privacy
-    /// enforcement even for unqualified references (RUE-37), while files that
-    /// are only listed explicitly on the command line keep the transitional
-    /// flat namespace (spec 10.5:2).
-    pub fn import_path_for_file(&self, file_path: &str) -> Option<String> {
-        self.defs
-            .read()
-            .unwrap_or_else(PoisonError::into_inner)
-            .iter()
-            .find(|def| def.file_path == file_path)
-            .map(|def| def.import_path.clone())
-    }
-
     /// Get a module definition by ID.
     pub fn get_def(&self, id: ModuleId) -> ModuleDef {
         self.defs

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -549,13 +549,14 @@ compile_fail = true
 error_contains = ["E0704", "til.rue"]
 
 # ---------------------------------------------------------------------------
-# Module privacy (RUE-114 + RUE-37).
+# Module privacy (RUE-114 + RUE-37 + RUE-180).
 #
 # Visibility boundaries are DIRECTORIES (ADR-0026, spec 10.3): a private item
 # is reachable from files in the same directory — including through a module
 # object — and rejected from any other directory, whether the call is
-# qualified (E0706) or unqualified (E0460). Files that are never imported
-# keep the transitional flat namespace (spec 10.3:8 / 10.5:2).
+# qualified (E0706) or unqualified (E0460). Privacy is uniform (RUE-180,
+# spec 10.3:7): it applies whether the defining file is imported or only
+# listed explicitly; the flat namespace (10.5:2) only resolves names.
 # ---------------------------------------------------------------------------
 
 [[case]]
@@ -596,11 +597,11 @@ fn secret() -> i32 {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "private to module `sub/lib.rue`"]
+error_contains = ["E0460", "function `secret` is private (defined in `sub/lib.rue`)"]
 
 [[case]]
 name = "private_fn_cross_dir_unqualified_rejected_when_also_listed"
-description = "Privacy is keyed on being imported, not on how the file was loaded: a file both listed on the CLI and imported is still a module (E0460)."
+description = "Privacy does not depend on how the file was loaded: a file both listed on the CLI and imported is still private cross-directory (E0460)."
 args = ["main.rue", "sub/lib.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -617,7 +618,7 @@ fn secret() -> i32 {
 """ },
 ]
 compile_fail = true
-error_contains = ["E0460", "private to module `sub/lib.rue`"]
+error_contains = ["E0460", "function `secret` is private (defined in `sub/lib.rue`)"]
 
 [[case]]
 name = "private_fn_same_dir_module_access_allowed"
@@ -658,8 +659,8 @@ pub fn open() -> i32 {
 exit_code = 14
 
 [[case]]
-name = "flat_multifile_private_fn_cross_dir_allowed"
-description = "A never-imported file listed explicitly keeps the flat namespace: cross-directory unqualified private call still works (spec 10.3:8)."
+name = "flat_multifile_private_fn_cross_dir_rejected"
+description = "Uniform privacy (RUE-180): a never-imported file listed explicitly is still private cross-directory — E0460, and the diagnostic names the defining file (no import exists, so no module relationship is claimed)."
 args = ["main.rue", "sub/util.rue", "-o", "prog"]
 files = [
     { path = "main.rue", source = """
@@ -668,6 +669,43 @@ fn main() -> i32 {
 }
 """ },
     { path = "sub/util.rue", source = """
+fn secret() -> i32 {
+    42
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "function `secret` is private (defined in `sub/util.rue`)"]
+
+[[case]]
+name = "flat_multifile_pub_fn_cross_dir_allowed"
+description = "Positive control for uniform privacy (RUE-180): a pub function in another never-imported file is callable unqualified with no import — the flat namespace still resolves names (spec 10.3:8)."
+args = ["main.rue", "sub/util.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    open()
+}
+""" },
+    { path = "sub/util.rue", source = """
+pub fn open() -> i32 {
+    42
+}
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "flat_multifile_private_fn_same_dir_allowed"
+description = "Control: intra-directory visibility (ADR-0026) is unchanged by RUE-180 — a private function in another listed file in the SAME directory is still callable."
+args = ["main.rue", "util.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    secret()
+}
+""" },
+    { path = "util.rue", source = """
 fn secret() -> i32 {
     42
 }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -1107,8 +1107,8 @@ pub enum ErrorKind {
     StdLibNotFound,
     #[error("{item_kind} `{name}` is private")]
     PrivateMemberAccess { item_kind: String, name: String },
-    #[error("function `{name}` is private to module `{module_path}`")]
-    PrivateUnqualifiedAccess { name: String, module_path: String },
+    #[error("function `{name}` is private (defined in `{defining_file}`)")]
+    PrivateUnqualifiedAccess { name: String, defining_file: String },
     #[error("module `{module_name}` has no member `{member_name}`")]
     UnknownModuleMember {
         module_name: String,

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -234,12 +234,12 @@ pass_aux_files = true
 exit_code = 42
 
 # =============================================================================
-# Unqualified Access to Module-Loaded Files (RUE-37)
+# Unqualified Cross-Directory Access (RUE-37, RUE-180)
 # =============================================================================
-# The flat global namespace (10.5:2) must not bypass module privacy: a
-# private function in an imported file in another directory is rejected even
-# when called WITHOUT the module qualifier (E0460). Files that are only
-# listed explicitly and never imported keep the flat namespace (10.3:8).
+# Privacy is uniform (10.3:7): a private function in a file in another
+# directory is rejected when called unqualified (E0460), whether that file
+# was imported or only listed explicitly. The flat namespace (10.5:2) only
+# resolves names — pub items remain callable without imports (10.3:8).
 
 [[case]]
 name = "cross_dir_unqualified_private_fn_error"
@@ -258,7 +258,7 @@ fn internal_fn() -> i32 {
 }
 """ }
 compile_fail = true
-error_contains = "private to module"
+error_contains = "is private (defined in"
 
 [[case]]
 name = "cross_dir_unqualified_pub_fn_allowed"
@@ -297,15 +297,50 @@ fn internal_fn() -> i32 {
 exit_code = 42
 
 [[case]]
-name = "flat_multifile_unqualified_private_fn_allowed"
-spec = ["10.3:8"]
-description = "A never-imported file listed explicitly keeps the flat namespace: cross-directory unqualified private call is allowed"
+name = "flat_multifile_unqualified_private_fn_error"
+spec = ["10.3:7", "10.3:8"]
+description = "Uniform privacy (RUE-180): a never-imported file listed explicitly is still private — cross-directory unqualified private call is E0460"
 source = """
 fn main() -> i32 {
     internal_fn()
 }
 """
 aux_files = { "subdir/utils.rue" = """
+fn internal_fn() -> i32 {
+    42
+}
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "is private (defined in"
+
+[[case]]
+name = "flat_multifile_unqualified_pub_fn_allowed"
+spec = ["10.3:8", "10.5:2"]
+description = "The flat namespace still resolves names without imports: a pub function in another never-imported directory is callable unqualified"
+source = """
+fn main() -> i32 {
+    public_fn()
+}
+"""
+aux_files = { "subdir/utils.rue" = """
+pub fn public_fn() -> i32 {
+    42
+}
+""" }
+pass_aux_files = true
+exit_code = 42
+
+[[case]]
+name = "flat_multifile_same_dir_private_fn_allowed"
+spec = ["10.3:2", "10.3:8"]
+description = "Intra-directory visibility (ADR-0026) is unchanged: a private function in another listed file in the same directory is callable unqualified"
+source = """
+fn main() -> i32 {
+    internal_fn()
+}
+"""
+aux_files = { "utils.rue" = """
 fn internal_fn() -> i32 {
     42
 }

--- a/docs/spec/src/10-modules/03-visibility.md
+++ b/docs/spec/src/10-modules/03-visibility.md
@@ -59,19 +59,21 @@ fn main() -> i32 {
 
 {{ rule(id="10.3:7", cat="legality-rule") }}
 
-Privacy cannot be escaped by dropping the module qualifier. It is a
-compile-time error to call a private function of a *module-loaded* source
-file — a file that is the target of a resolved `@import` anywhere in the
-program — by its unqualified name from a source file in a different
-directory (error E0460).
+Visibility is uniform across every multi-file compilation: an item is
+visible outside its defining directory if and only if it is `pub`,
+whether its defining file was loaded via `@import` or only listed
+explicitly in the compilation. It is a compile-time error to call a
+private function by its unqualified name from a source file in a
+different directory than the function's defining file (error E0460).
 
-{{ rule(id="10.3:8") }}
+{{ rule(id="10.3:8", cat="normative") }}
 
-Source files that are only listed explicitly in the compilation and are
-never imported retain the transitional flat namespace (10.5:2): unqualified
-references to their items are permitted regardless of visibility. This
-exemption is expected to be removed together with rule 10.5:2 when
-top-level names become module-scoped.
+The transitional flat namespace (10.5:2) affects only *name resolution*:
+an unqualified reference may resolve to an item in any file of the
+compilation without an import, but the visibility rules of this section
+apply regardless of how the item's file was loaded. A `pub` function in
+another directory is therefore callable unqualified without any import;
+a private one is not.
 
 {{ rule(id="10.3:9", cat="example") }}
 
@@ -80,12 +82,9 @@ top-level names become module-scoped.
 fn secret() -> i32 { 99 }   // private to sub/
 pub fn open() -> i32 { 7 }
 
-// main.rue — a different directory
-const lib = @import("sub/lib.rue");
-
+// main.rue — a different directory; no import needed (10.5:2)
 fn main() -> i32 {
-    // lib.secret()          // error E0706: private member access
-    // secret()              // error E0460: same privacy, unqualified
-    open()                   // OK (transitional flat namespace, 10.5:2)
+    // secret()              // error E0460: private to sub/lib.rue
+    open()                   // OK: `open` is pub
 }
 ```


### PR DESCRIPTION
Implements Steve's morning ruling on the 10.3:7–9 review: the import-gated privacy rule (#970) created two privacy regimes in one compilation and an action-at-a-distance hazard — adding an `@import` of a file anywhere flipped that file's regime, breaking unrelated bare calls elsewhere. Now uniform: **an item is visible outside its defining file iff `pub`**, in every multi-file compilation, imports or not.

`check_unqualified_call_visibility` drops the module-ness gate (the now-dead `import_path_for_file` is deleted); E0460's wording names the defining file rather than claiming a module relationship. Preserved and re-verified by execution post-integration: ADR-0026 same-directory visibility (the intra-directory repro deliberately does NOT invert), single-file mode, and pub flat-namespace resolution without imports (`pub fn helper` cross-dir call runs, exit 7; non-pub errors E0460).

Spec 10.3:7–9 rewritten (10.3:8 promoted to normative); CLAUDE.md's multi-file limitations list updated; the #970 flat-mode pin inverted to a compile-fail pin + 4 positive pins across CLI/spec suites. Full ./test.sh green (spec 1511, CLI 485, traceability 570/570).

Discovered while implementing (will file): E0460 guards **fn calls** only — private structs/consts remain usable cross-directory; same uniform rule should extend to them.

Fixes RUE-180

🤖 Generated with [Claude Code](https://claude.com/claude-code)