### PR TITLE
Integer literal forms: hex, octal, binary, underscore separators

### DIFF
--- a/crates/rue-cli-tests/cases/int_literals.toml
+++ b/crates/rue-cli-tests/cases/int_literals.toml
@@ -1,0 +1,65 @@
+# Based integer literals end-to-end (RUE-177).
+#
+# 0x/0o/0b literals and `_` separators are valid Rue syntax (spec 2.1),
+# semantically identical to their decimal spellings. This case pins a
+# bit-twiddling program (masks + shifts at several widths, u64 extremes,
+# comptime/const/match contexts) through the real driver, codegen, and the
+# runtime printer.
+
+[section]
+id = "cli.int_literals"
+name = "Based integer literals"
+description = "Hex/octal/binary literals with underscore separators, end-to-end."
+
+[[case]]
+name = "bit_twiddling_masks_and_shifts"
+files = [{ path = "main.rue", source = """
+const NIBBLE_MASK: u8 = 0x0F;
+const HIGH_BIT: u8 = 0b1000_0000;
+
+fn extract_byte(word: u32, index: u32) -> u32 {
+    (word >> (index * 8)) & 0xFF
+}
+
+fn main() -> i32 {
+    // Masks + shifts: pull each byte out of a hex word.
+    let word: u32 = 0xDEAD_BEEF;
+    @dbg(extract_byte(word, 0));        // 0xEF = 239
+    @dbg(extract_byte(word, 1));        // 0xBE = 190
+    @dbg(extract_byte(word, 2));        // 0xAD = 173
+    @dbg(extract_byte(word, 3));        // 0xDE = 222
+
+    // const initializers in every base.
+    let v: u8 = 0o252;                  // 0b1010_1010
+    @dbg(v & NIBBLE_MASK);              // 0b1010 = 10
+    @dbg(v | HIGH_BIT);                 // already set: 170
+
+    // comptime evaluation of based literals.
+    let c: i32 = comptime { (0xFF << 4) | 0b1111 };
+    @dbg(c);                            // 0xFFF = 4095
+
+    // u64 extremes: all-ones in hex, and binary/hex agreement.
+    let max: u64 = 0xFFFF_FFFF_FFFF_FFFF;
+    @dbg(max);                          // 18446744073709551615
+    let bin: u64 = 0b1111111111111111111111111111111111111111111111111111111111111111;
+    if max == bin { @dbg(1); } else { @dbg(0); }
+
+    // Based literals as match patterns.
+    match word >> 28 {
+        0xD => 0,
+        _ => 1,
+    }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+stdout = """239
+190
+173
+222
+10
+170
+4095
+18446744073709551615
+1
+"""

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -64,7 +64,11 @@ impl ErrorCode {
     pub const INVALID_INTEGER: Self = Self(2);
     pub const INVALID_STRING_ESCAPE: Self = Self(3);
     pub const UNTERMINATED_STRING: Self = Self(4);
-    pub const UNSUPPORTED_INTEGER_BASE: Self = Self(5);
+    // E0005 (UNSUPPORTED_INTEGER_BASE) is retired: 0x/0o/0b literals are now
+    // valid Rue syntax (RUE-177). Do not reuse the code.
+    pub const UPPERCASE_BASE_PREFIX: Self = Self(6);
+    pub const EMPTY_BASED_LITERAL: Self = Self(7);
+    pub const INVALID_DIGIT_FOR_BASE: Self = Self(8);
 
     // ========================================================================
     // Parser errors (E0100-E0199)
@@ -823,18 +827,20 @@ pub enum ErrorKind {
     InvalidStringEscape(char),
     #[error("unterminated string literal")]
     UnterminatedString,
-    /// A non-decimal integer literal prefix (`0x`/`0b`/`0o`). Rue integer
-    /// literals are decimal only (spec 2.1), so these are rejected with a
-    /// targeted diagnostic instead of splitting into `0` + identifier and
-    /// dying with a generic parse error. (RUE-133)
-    ///
-    /// `hint` is either empty or a pre-rendered ", write `N` instead"
-    /// suggestion containing the decimal value of the literal.
-    #[error("{base} integer literals are not supported; integer literals are decimal only{hint}")]
-    UnsupportedIntegerBase {
-        base: &'static str,
-        hint: Cow<'static, str>,
-    },
+    /// An uppercase integer-literal base prefix (`0X`/`0B`/`0O`). Base
+    /// prefixes are lowercase (spec 2.1); a targeted error is friendlier
+    /// than splitting into `0` + identifier and dying with a generic parse
+    /// error. (RUE-177)
+    #[error("invalid base prefix `0{0}`: base prefixes are lowercase (`0x`, `0o`, `0b`)")]
+    UppercaseBasePrefix(char),
+    /// A based integer literal with no digits after the prefix (`0x`,
+    /// `0b_`). (RUE-177)
+    #[error("missing digits after base prefix in {base} integer literal")]
+    EmptyBasedLiteral { base: &'static str },
+    /// A digit that is not valid for the literal's base (`0b2`, `0o9`,
+    /// `0xG`). (RUE-177)
+    #[error("invalid digit `{digit}` in {base} integer literal")]
+    InvalidDigitForBase { digit: char, base: &'static str },
 
     // Parser errors
     #[error("expected {expected}, found {found}")]
@@ -1181,7 +1187,9 @@ impl ErrorKind {
             ErrorKind::InvalidInteger => ErrorCode::INVALID_INTEGER,
             ErrorKind::InvalidStringEscape(_) => ErrorCode::INVALID_STRING_ESCAPE,
             ErrorKind::UnterminatedString => ErrorCode::UNTERMINATED_STRING,
-            ErrorKind::UnsupportedIntegerBase { .. } => ErrorCode::UNSUPPORTED_INTEGER_BASE,
+            ErrorKind::UppercaseBasePrefix(_) => ErrorCode::UPPERCASE_BASE_PREFIX,
+            ErrorKind::EmptyBasedLiteral { .. } => ErrorCode::EMPTY_BASED_LITERAL,
+            ErrorKind::InvalidDigitForBase { .. } => ErrorCode::INVALID_DIGIT_FOR_BASE,
 
             // Parser errors (E0100-E0199)
             ErrorKind::UnexpectedToken { .. } => ErrorCode::UNEXPECTED_TOKEN,

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -25,14 +25,27 @@ pub enum LexError {
         escape: char,
     },
     UnterminatedString,
-    /// A non-decimal integer literal prefix: `0x`/`0X` (hex), `0b`/`0B`
-    /// (binary), or `0o`/`0O` (octal). Rue integer literals are decimal only
-    /// (spec 2.1). Without this rule, `0xFF` lexes as `0` + identifier `xFF`
-    /// and dies later with a generic parse error; lexing the whole literal as
-    /// one error token lets the diagnostic name the base and suggest the
-    /// decimal value. Carries the base prefix character, lowercased. (RUE-133)
-    UnsupportedIntegerBase {
+    /// An uppercase base prefix (`0X`/`0B`/`0O`). Base prefixes are lowercase
+    /// (`0x`/`0b`/`0o`, spec 2.1); rejecting the whole literal with a targeted
+    /// error is friendlier than Rust's behavior of lexing `0XFF` as `0` plus
+    /// an identifier. Carries the offending (uppercase) prefix character.
+    /// (RUE-177)
+    UppercaseBasePrefix {
         prefix: char,
+    },
+    /// A based integer literal with no digits after the prefix (`0x`, `0b_`).
+    /// Carries the base name ("hexadecimal"/"octal"/"binary"). (RUE-177)
+    EmptyBasedLiteral {
+        base: &'static str,
+    },
+    /// A digit that is not valid in the literal's base (`0b2`, `0o9`, `0xG`).
+    /// Carries the offending character, the base name, and the character's
+    /// byte offset within the token so the diagnostic can point at it.
+    /// (RUE-177)
+    InvalidDigitForBase {
+        digit: char,
+        base: &'static str,
+        offset: u32,
     },
 }
 
@@ -125,18 +138,81 @@ fn process_string_from_quote(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Resu
     Ok(spur)
 }
 
-/// Callback for the hex/binary/octal literal rule on [`LogosTokenKind::Int`]:
-/// always rejects, carrying the (lowercased) base prefix character so the
-/// diagnostic can name the base. See the comment on the rule. (RUE-133)
-fn reject_non_decimal_base(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Result<u64, LexError> {
-    let prefix = lex
-        .slice()
+/// Callback for the decimal integer literal rule on [`LogosTokenKind::Int`]:
+/// computes the value, skipping `_` separators (`1_000_000`, trailing `1_`).
+/// The regex guarantees the literal starts with a digit (`_1` is an
+/// identifier), so every non-underscore character is a decimal digit; the
+/// only failure mode is overflow past `u64::MAX`. (RUE-177)
+fn parse_decimal_literal(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Result<u64, LexError> {
+    let mut value: u64 = 0;
+    for c in lex.slice().chars() {
+        if c == '_' {
+            continue;
+        }
+        let digit = c.to_digit(10).expect("regex guarantees decimal digits");
+        value = value
+            .checked_mul(10)
+            .and_then(|v| v.checked_add(u64::from(digit)))
+            .ok_or(LexError::InvalidInteger)?;
+    }
+    Ok(value)
+}
+
+/// Callback for the based integer literal rule on [`LogosTokenKind::Int`]:
+/// `0x` (hexadecimal), `0o` (octal), and `0b` (binary) literals, copying
+/// Rust's rules (RUE-177):
+///
+/// - prefixes are lowercase; an uppercase prefix (`0XFF`) is a targeted
+///   error rather than Rust's lex-as-`0`-plus-identifier
+/// - hex digits are case-insensitive (`0xff` == `0xFF`)
+/// - `_` separators are legal anywhere among the digits, including
+///   immediately after the prefix (`0x_FF`) and trailing (`0xFF_`)
+/// - a prefix with no digits (`0x`, `0b_`) is an error
+/// - a digit outside the base (`0b2`, `0o9`, `0xG`) is an error
+///
+/// The rule's regex deliberately swallows every alphanumeric/underscore
+/// character after the prefix so malformed forms error as one unit instead
+/// of splitting into literal + identifier and dying with a generic parse
+/// error downstream.
+fn parse_based_literal(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Result<u64, LexError> {
+    let slice = lex.slice();
+    let prefix = slice
         .chars()
         .nth(1)
         .expect("regex guarantees a prefix char");
-    Err(LexError::UnsupportedIntegerBase {
-        prefix: prefix.to_ascii_lowercase(),
-    })
+    let (base, radix) = match prefix.to_ascii_lowercase() {
+        'x' => ("hexadecimal", 16u32),
+        'o' => ("octal", 8),
+        'b' => ("binary", 2),
+        _ => unreachable!("regex only matches 0x/0o/0b prefixes"),
+    };
+    if prefix.is_ascii_uppercase() {
+        return Err(LexError::UppercaseBasePrefix { prefix });
+    }
+
+    let mut value: u64 = 0;
+    let mut seen_digit = false;
+    // The regex is ASCII-only, so byte offsets == char offsets here; +2
+    // skips the `0x` prefix.
+    for (i, c) in slice[2..].char_indices() {
+        if c == '_' {
+            continue;
+        }
+        let digit = c.to_digit(radix).ok_or(LexError::InvalidDigitForBase {
+            digit: c,
+            base,
+            offset: (2 + i) as u32,
+        })?;
+        value = value
+            .checked_mul(u64::from(radix))
+            .and_then(|v| v.checked_add(u64::from(digit)))
+            .ok_or(LexError::InvalidInteger)?;
+        seen_digit = true;
+    }
+    if !seen_digit {
+        return Err(LexError::EmptyBasedLiteral { base });
+    }
+    Ok(value)
 }
 
 /// Token kinds in the Rue language, using logos derive macro.
@@ -226,17 +302,19 @@ pub enum LogosTokenKind {
     #[token("_")]
     Underscore,
 
-    // Integer literals
+    // Integer literals (spec 2.1): decimal (`42`, `1_000`), hexadecimal
+    // (`0xFF`), octal (`0o17`), and binary (`0b101`), with `_` separators
+    // legal anywhere among the digits. (RUE-177)
     //
-    // The second rule rejects hex/binary/octal prefixes (`0xFF`, `0b101`,
-    // `0o7`) as a unit: Rue integer literals are decimal only (spec 2.1),
-    // and without it the input would lex as `0` + identifier and surface as
-    // a confusing generic parse error. Matching the whole literal here lets
-    // the diagnostic name the base and suggest the decimal value. This can
-    // never reject a valid program: no grammar production allows an integer
-    // literal directly abutting an identifier character. (RUE-133)
-    #[regex(r"[0-9]+", |lex| lex.slice().parse::<u64>().map_err(|_| LexError::InvalidInteger))]
-    #[regex(r"0[xXbBoO][0-9a-zA-Z_]*", reject_non_decimal_base)]
+    // The second rule matches based literals as a unit, deliberately
+    // swallowing any alphanumeric/underscore tail (`0xG`, `0b2`) so
+    // malformed forms get a targeted diagnostic instead of splitting into
+    // `0` + identifier and surfacing as a confusing generic parse error.
+    // This can never reject a valid program: no grammar production allows
+    // an integer literal directly abutting an identifier character.
+    // (RUE-133, RUE-177)
+    #[regex(r"[0-9][0-9_]*", parse_decimal_literal)]
+    #[regex(r"0[xXbBoO][0-9a-zA-Z_]*", parse_based_literal)]
     Int(u64),
 
     // String literals - match opening quote and process content manually
@@ -576,28 +654,36 @@ impl<'a> LogosLexer<'a> {
                                         span.end as u32,
                                     ),
                                 ),
-                                LexError::UnsupportedIntegerBase { prefix } => {
-                                    let (base, radix) = match prefix {
-                                        'x' => ("hexadecimal", 16),
-                                        'b' => ("binary", 2),
-                                        _ => ("octal", 8),
-                                    };
-                                    // Suggest the decimal spelling when the
-                                    // digits actually parse in the named base
-                                    // (they may not, e.g. `0b2` or `0x`).
-                                    let digits = &slice[2..];
-                                    let hint = match u64::from_str_radix(digits, radix) {
-                                        Ok(value) if !digits.is_empty() => {
-                                            format!("; write `{}` instead", value).into()
-                                        }
-                                        _ => std::borrow::Cow::Borrowed(""),
-                                    };
+                                LexError::UppercaseBasePrefix { prefix } => (
+                                    ErrorKind::UppercaseBasePrefix(prefix),
+                                    Span::with_file(
+                                        self.file_id,
+                                        span.start as u32,
+                                        span.end as u32,
+                                    ),
+                                ),
+                                LexError::EmptyBasedLiteral { base } => (
+                                    ErrorKind::EmptyBasedLiteral { base },
+                                    Span::with_file(
+                                        self.file_id,
+                                        span.start as u32,
+                                        span.end as u32,
+                                    ),
+                                ),
+                                LexError::InvalidDigitForBase {
+                                    digit,
+                                    base,
+                                    offset,
+                                } => {
+                                    // Point at the offending digit itself
+                                    // (`0b2`'s `2`), not the whole literal.
+                                    let digit_start = span.start as u32 + offset;
                                     (
-                                        ErrorKind::UnsupportedIntegerBase { base, hint },
+                                        ErrorKind::InvalidDigitForBase { digit, base },
                                         Span::with_file(
                                             self.file_id,
-                                            span.start as u32,
-                                            span.end as u32,
+                                            digit_start,
+                                            digit_start + digit.len_utf8() as u32,
                                         ),
                                     )
                                 }
@@ -964,40 +1050,144 @@ mod tests {
         assert!(matches!(err.kind, ErrorKind::InvalidInteger));
     }
 
-    #[test]
-    fn test_logos_non_decimal_bases_rejected() {
-        // RUE-133: 0x/0b/0o literals are not Rue syntax (integer literals are
-        // decimal only). They must be rejected as a unit with a targeted
-        // diagnostic, not split into `0` + identifier.
-        for (src, base, hint) in [
-            ("0xFF", "hexadecimal", "; write `255` instead"),
-            ("0X1f", "hexadecimal", "; write `31` instead"),
-            ("0b101", "binary", "; write `5` instead"),
-            ("0o17", "octal", "; write `15` instead"),
-        ] {
-            let err = LogosLexer::new(src).tokenize().unwrap_err();
-            match &err.kind {
-                ErrorKind::UnsupportedIntegerBase { base: b, hint: h } => {
-                    assert_eq!(*b, base, "base for {src}");
-                    assert_eq!(h.as_ref(), hint, "hint for {src}");
-                }
-                other => panic!("expected UnsupportedIntegerBase for {src}, got {other:?}"),
+    /// Helper: lex a single integer literal and return its value.
+    fn lex_int(src: &str) -> u64 {
+        let (tokens, _) = LogosLexer::new(src).tokenize().unwrap();
+        match tokens[0].kind {
+            TokenKind::Int(n) => {
+                // The literal must lex as ONE token (no `0` + ident split).
+                assert!(
+                    matches!(tokens[1].kind, TokenKind::Eof),
+                    "{src} split into multiple tokens"
+                );
+                assert_eq!(tokens[0].span, Span::new(0, src.len() as u32));
+                n
             }
-            // The error span must cover the whole literal.
+            ref other => panic!("expected Int for {src}, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_logos_based_literal_values() {
+        // RUE-177: hex/octal/binary literals, copying Rust's syntax.
+        assert_eq!(lex_int("0xFF"), 255);
+        assert_eq!(lex_int("0xff"), 255); // hex digits case-insensitive
+        assert_eq!(lex_int("0xDeadBeef"), 0xDEAD_BEEF);
+        assert_eq!(lex_int("0x0"), 0);
+        assert_eq!(lex_int("0o17"), 15);
+        assert_eq!(lex_int("0o0"), 0);
+        assert_eq!(lex_int("0b101"), 5);
+        assert_eq!(lex_int("0b0"), 0);
+        // u64 extremes
+        assert_eq!(lex_int("0xFFFF_FFFF_FFFF_FFFF"), u64::MAX);
+        assert_eq!(lex_int("0o1777777777777777777777"), u64::MAX);
+        assert_eq!(
+            lex_int("0b11111111_11111111_11111111_11111111_11111111_11111111_11111111_11111111"),
+            u64::MAX
+        );
+    }
+
+    #[test]
+    fn test_logos_underscore_separators() {
+        // RUE-177: underscores are legal anywhere among the digits,
+        // including immediately after the prefix and trailing.
+        assert_eq!(lex_int("1_000_000"), 1_000_000);
+        assert_eq!(lex_int("1_"), 1);
+        assert_eq!(lex_int("1__2"), 12);
+        assert_eq!(lex_int("0_"), 0);
+        assert_eq!(lex_int("0xFF_FF"), 0xFFFF);
+        assert_eq!(lex_int("0x_FF"), 255);
+        assert_eq!(lex_int("0xFF_"), 255);
+        assert_eq!(lex_int("0b1010_1010"), 0xAA);
+        assert_eq!(lex_int("0o_7_7_"), 0o77);
+    }
+
+    #[test]
+    fn test_logos_leading_underscore_is_identifier() {
+        // `_1` is an identifier, not an integer literal (RUE-177).
+        let (tokens, interner) = LogosLexer::new("_1").tokenize().unwrap();
+        assert_eq!(get_ident_str(&tokens[0].kind, &interner), Some("_1"));
+    }
+
+    #[test]
+    fn test_logos_uppercase_base_prefix_rejected() {
+        // RUE-177: uppercase prefixes get a targeted error (friendlier than
+        // Rust's lex-as-`0`-plus-identifier).
+        for (src, prefix) in [("0XFF", 'X'), ("0B101", 'B'), ("0O17", 'O')] {
+            let err = LogosLexer::new(src).tokenize().unwrap_err();
+            match err.kind {
+                ErrorKind::UppercaseBasePrefix(p) => assert_eq!(p, prefix, "prefix for {src}"),
+                other => panic!("expected UppercaseBasePrefix for {src}, got {other:?}"),
+            }
+            // Span covers the whole literal.
             let span = err.span().expect("lexer errors carry a span");
             assert_eq!(span.start, 0, "span start for {src}");
             assert_eq!(span.end as usize, src.len(), "span end for {src}");
         }
+    }
 
-        // Digits that don't parse in the named base get no decimal hint.
-        let err = LogosLexer::new("0b2").tokenize().unwrap_err();
-        match &err.kind {
-            ErrorKind::UnsupportedIntegerBase { base, hint } => {
-                assert_eq!(*base, "binary");
-                assert_eq!(hint.as_ref(), "");
+    #[test]
+    fn test_logos_empty_based_literal_rejected() {
+        // A bare prefix with no digits is an error, even with underscores.
+        for (src, base) in [
+            ("0x", "hexadecimal"),
+            ("0b", "binary"),
+            ("0o", "octal"),
+            ("0b_", "binary"),
+            ("0x__", "hexadecimal"),
+        ] {
+            let err = LogosLexer::new(src).tokenize().unwrap_err();
+            match err.kind {
+                ErrorKind::EmptyBasedLiteral { base: b } => assert_eq!(b, base, "base for {src}"),
+                other => panic!("expected EmptyBasedLiteral for {src}, got {other:?}"),
             }
-            other => panic!("expected UnsupportedIntegerBase, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn test_logos_invalid_digit_for_base_rejected() {
+        // Digits must match the base; the span points at the bad digit.
+        for (src, digit, base, offset) in [
+            ("0b2", '2', "binary", 2u32),
+            ("0b012", '2', "binary", 4),
+            ("0o9", '9', "octal", 2),
+            ("0o787", '8', "octal", 3),
+            ("0xG", 'G', "hexadecimal", 2),
+            ("0x12fg", 'g', "hexadecimal", 5),
+            ("0b1_2", '2', "binary", 4),
+        ] {
+            let err = LogosLexer::new(src).tokenize().unwrap_err();
+            match err.kind {
+                ErrorKind::InvalidDigitForBase { digit: d, base: b } => {
+                    assert_eq!(d, digit, "digit for {src}");
+                    assert_eq!(b, base, "base for {src}");
+                }
+                other => panic!("expected InvalidDigitForBase for {src}, got {other:?}"),
+            }
+            let span = err.span().expect("lexer errors carry a span");
+            assert_eq!(span.start, offset, "span start for {src}");
+            assert_eq!(span.end, offset + 1, "span end for {src}");
+        }
+    }
+
+    #[test]
+    fn test_logos_based_literal_overflow() {
+        // One past u64::MAX in each base is InvalidInteger.
+        for src in [
+            "0x1_0000_0000_0000_0000",
+            "0o2000000000000000000000",
+            "0b1_00000000_00000000_00000000_00000000_00000000_00000000_00000000_00000000",
+            "18_446_744_073_709_551_616",
+        ] {
+            let err = LogosLexer::new(src).tokenize().unwrap_err();
+            assert!(
+                matches!(err.kind, ErrorKind::InvalidInteger),
+                "expected InvalidInteger for {src}, got {:?}",
+                err.kind
+            );
+        }
+        // ... while u64::MAX itself is fine.
+        assert_eq!(lex_int("18_446_744_073_709_551_615"), u64::MAX);
     }
 
     #[test]

--- a/crates/rue-spec/cases/lexical/tokens.toml
+++ b/crates/rue-spec/cases/lexical/tokens.toml
@@ -44,6 +44,130 @@ fn main() -> i32 {
 exit_code = 42
 
 # =============================================================================
+# Based Integer Literals and Underscore Separators (RUE-177)
+# =============================================================================
+
+[[case]]
+name = "integer_literal_hex"
+spec = ["2.1:3"]
+source = "fn main() -> i32 { 0x2A }"
+exit_code = 42
+
+[[case]]
+name = "integer_literal_hex_case_insensitive_digits"
+spec = ["2.1:3"]
+source = """
+fn main() -> i32 {
+    let lower = 0xff;
+    let upper = 0xFF;
+    let mixed = 0xfF;
+    if lower == upper && upper == mixed { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "integer_literal_octal"
+spec = ["2.1:3"]
+source = "fn main() -> i32 { 0o52 }"
+exit_code = 42
+
+[[case]]
+name = "integer_literal_binary"
+spec = ["2.1:3"]
+source = "fn main() -> i32 { 0b101010 }"
+exit_code = 42
+
+[[case]]
+name = "integer_literal_underscore_separators"
+spec = ["2.1:19"]
+source = """
+fn main() -> i32 {
+    let million = 1_000_000;
+    if million == 1000000 { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "integer_literal_underscores_anywhere"
+spec = ["2.1:19"]
+source = """
+fn main() -> i32 {
+    let trailing = 4_2_;
+    let after_prefix = 0x_2A;
+    let trailing_hex = 0x2A_;
+    let doubled = 4__2;
+    if trailing == 42 && after_prefix == 42 && trailing_hex == 42 && doubled == 42 {
+        42
+    } else {
+        0
+    }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "integer_literal_leading_underscore_is_identifier"
+spec = ["2.1:19"]
+source = """
+fn main() -> i32 {
+    let _1 = 42;
+    _1
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "integer_literal_empty_base_prefix_error"
+spec = ["2.1:20"]
+source = "fn main() -> i32 { 0x }"
+compile_fail = true
+error_contains = "missing digits after base prefix"
+
+[[case]]
+name = "integer_literal_underscores_only_base_prefix_error"
+spec = ["2.1:20"]
+source = "fn main() -> i32 { 0b_ }"
+compile_fail = true
+error_contains = "missing digits after base prefix"
+
+[[case]]
+name = "integer_literal_invalid_binary_digit_error"
+spec = ["2.1:21"]
+source = "fn main() -> i32 { 0b2 }"
+compile_fail = true
+error_contains = "invalid digit `2` in binary integer literal"
+
+[[case]]
+name = "integer_literal_invalid_octal_digit_error"
+spec = ["2.1:21"]
+source = "fn main() -> i32 { 0o9 }"
+compile_fail = true
+error_contains = "invalid digit `9` in octal integer literal"
+
+[[case]]
+name = "integer_literal_invalid_hex_digit_error"
+spec = ["2.1:21"]
+source = "fn main() -> i32 { 0xG }"
+compile_fail = true
+error_contains = "invalid digit `G` in hexadecimal integer literal"
+
+[[case]]
+name = "integer_literal_uppercase_prefix_error"
+spec = ["2.1:22"]
+source = "fn main() -> i32 { 0XFF }"
+compile_fail = true
+error_contains = "base prefixes are lowercase"
+
+[[case]]
+name = "integer_literal_uppercase_binary_prefix_error"
+spec = ["2.1:22"]
+source = "fn main() -> i32 { 0B101 }"
+compile_fail = true
+error_contains = "base prefixes are lowercase"
+
+# =============================================================================
 # String Literals (syntax and legality)
 # =============================================================================
 

--- a/crates/rue-spec/cases/types/integers.toml
+++ b/crates/rue-spec/cases/types/integers.toml
@@ -645,3 +645,125 @@ fn main() -> i32 {
 }
 """
 exit_code = 1
+
+# =============================================================================
+# Literal Base Independence (RUE-177)
+# =============================================================================
+
+[[case]]
+name = "based_literal_value_matches_decimal"
+spec = ["3.1:24"]
+description = "Hex/octal/binary literals denote the same values as their decimal spellings"
+source = """
+fn main() -> i32 {
+    if 0xFF == 255 && 0o17 == 15 && 0b101 == 5 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "based_literal_type_inference"
+spec = ["3.1:24"]
+description = "A based literal is an untyped integer: context-inferred, i32 by default"
+source = """
+fn main() -> i32 {
+    let a = 0x10;          // defaults to i32
+    let b: u8 = 0xFF;      // inferred as u8
+    let c: u64 = 0x10;     // inferred as u64
+    if a == 16 { if b == 255 { if c == 16 { 1 } else { 0 } } else { 0 } } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "hex_literal_u64_max"
+spec = ["3.1:24", "3.1:12"]
+description = "0xFFFF_FFFF_FFFF_FFFF is u64::MAX"
+source = """
+fn main() -> i32 {
+    let x: u64 = 0xFFFF_FFFF_FFFF_FFFF;
+    if x == 18446744073709551615 { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "hex_literal_out_of_range"
+spec = ["3.1:24", "3.1:17"]
+description = "Range validation applies to based literals identically"
+source = """
+fn main() -> i32 {
+    let x: i32 = 0xFFFF_FFFF_FFFF_FFFF;
+    0
+}
+"""
+compile_fail = true
+error_contains = "out of range"
+
+[[case]]
+name = "binary_literal_out_of_range_u8"
+spec = ["3.1:24", "3.1:17"]
+description = "0b1_0000_0000 (256) exceeds u8 range"
+source = """
+fn main() -> i32 {
+    let x: u8 = 0b1_0000_0000;
+    0
+}
+"""
+compile_fail = true
+error_contains = "out of range"
+
+[[case]]
+name = "hex_literal_in_comptime"
+spec = ["3.1:24"]
+description = "Based literals evaluate in comptime blocks like decimal ones"
+source = """
+fn main() -> i32 {
+    comptime { 0xFF & 0x0F }
+}
+"""
+exit_code = 15
+
+[[case]]
+name = "hex_literal_const_initializer"
+spec = ["3.1:24"]
+description = "Based literals in annotated const initializers"
+source = """
+const MASK: u8 = 0xF0;
+const BITS: i32 = 0b110;
+fn main() -> i32 {
+    if MASK == 240 { BITS } else { 0 }
+}
+"""
+exit_code = 6
+
+[[case]]
+name = "hex_literal_match_pattern"
+spec = ["3.1:24"]
+description = "Based literals work as match patterns"
+source = """
+fn main() -> i32 {
+    let x: u8 = 0xAB;
+    match x & 0xF0 {
+        0xA0 => 1,
+        _ => 0,
+    }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "hex_literal_match_pattern_out_of_range"
+spec = ["3.1:24", "3.1:17"]
+description = "Range checks fire on out-of-range based literals in match patterns"
+source = """
+fn main() -> i32 {
+    let x: u8 = 1;
+    match x {
+        0x1FF => 1,
+        _ => 0,
+    }
+}
+"""
+compile_fail = true
+error_contains = "out of range"

--- a/crates/rue-ui-tests/cases/diagnostics/int_literals.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/int_literals.toml
@@ -1,0 +1,111 @@
+# Diagnostics for malformed integer literals (RUE-177).
+#
+# 0x/0o/0b literals and `_` separators are valid Rue syntax (spec 2.1,
+# copying Rust). Malformed forms keep targeted lexer errors instead of
+# splitting into `0` + identifier and dying with a generic parse error:
+#
+# - E0006: uppercase base prefix (`0XFF`) — friendlier than Rust, which
+#   lexes `0XFF` as `0` followed by the identifier `XFF`
+# - E0007: a base prefix with no digits (`0x`, `0b_`)
+# - E0008: a digit invalid in the base (`0b2`, `0o9`, `0xG`)
+#
+# These cases pin the *wording* of the diagnostics; the legality rules
+# themselves are spec-tested (2.1:20-2.1:22).
+
+[section]
+id = "diagnostics.int_literals"
+name = "Malformed integer literal diagnostics"
+description = "Targeted errors for malformed 0x/0o/0b literals."
+
+[[case]]
+name = "uppercase_hex_prefix_targeted_error"
+source = """
+fn main() -> i32 {
+    let x = 0XFF;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0006", "invalid base prefix `0X`", "base prefixes are lowercase", "`0x`"]
+
+[[case]]
+name = "uppercase_octal_prefix_targeted_error"
+source = """
+fn main() -> i32 {
+    let x = 0O17;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0006", "invalid base prefix `0O`"]
+
+[[case]]
+name = "empty_hex_literal_targeted_error"
+source = """
+fn main() -> i32 {
+    let x = 0x;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0007", "missing digits after base prefix", "hexadecimal"]
+
+[[case]]
+name = "underscores_only_binary_literal_targeted_error"
+description = "Underscores alone don't satisfy the at-least-one-digit rule."
+source = """
+fn main() -> i32 {
+    let x = 0b__;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0007", "missing digits after base prefix", "binary"]
+
+[[case]]
+name = "invalid_binary_digit_targeted_error"
+description = "The error names the offending digit; the bad-digit span is exercised in lexer unit tests."
+source = """
+fn main() -> i32 {
+    let x = 0b234;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0008", "invalid digit `2` in binary integer literal"]
+
+[[case]]
+name = "invalid_hex_digit_targeted_error"
+description = "A based literal swallows its alphanumeric tail, so `0x12g4` errors on `g` as one unit."
+source = """
+fn main() -> i32 {
+    let x = 0x12g4;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0008", "invalid digit `g` in hexadecimal integer literal"]
+
+[[case]]
+name = "based_literal_overflow_invalid_integer"
+description = "One past u64::MAX overflows the literal's magnitude (E0002, same as decimal)."
+source = """
+fn main() -> i32 {
+    let x: u64 = 0x1_0000_0000_0000_0000;
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0002", "invalid integer literal"]
+
+[[case]]
+name = "valid_literals_unaffected"
+source = """
+fn main() -> i32 {
+    let x = 0;
+    let y = 4_2;
+    let z = 0x0;
+    x + y + z
+}
+"""
+exit_code = 42

--- a/crates/rue-ui-tests/cases/diagnostics/rust_refugees.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/rust_refugees.toml
@@ -1,14 +1,17 @@
 # Targeted diagnostics for common Rust-isms (RUE-133 item 9).
 #
-# `5 as i64` and `0xFF` are both valid Rust but not valid Rue; they used to
-# die with generic parse errors ("expected semicolon after expression" /
-# "expected '.' or '[' or '*', found identifier"). They now get targeted
-# diagnostics that say what Rue offers instead.
+# `5 as i64` is valid Rust but not valid Rue; it used to die with a generic
+# parse error ("expected semicolon after expression"). It now gets a targeted
+# diagnostic that says what Rue offers instead.
+#
+# (0x/0b/0o integer literals used to live here as Rust-isms too; they are
+# valid Rue syntax since RUE-177. Diagnostics for MALFORMED integer literals
+# are in diagnostics/int_literals.toml.)
 
 [section]
 id = "diagnostics.rust_refugees"
 name = "Rust-refugee diagnostics"
-description = "Targeted errors for `as` casts and 0x/0b/0o integer literals."
+description = "Targeted errors for `as` casts."
 
 [[case]]
 name = "as_cast_targeted_error"
@@ -44,67 +47,6 @@ source = """
 fn main() -> i32 {
     let as = 40;
     as + 2
-}
-"""
-exit_code = 42
-
-[[case]]
-name = "hex_literal_targeted_error"
-description = """
-RUE-133: `0xFF` used to lex as `0` + identifier `xFF` and die with
-"expected '.' or '[' or '*', found identifier". The lexer now rejects the
-whole literal, names the base, and suggests the decimal value.
-"""
-source = """
-fn main() -> i32 {
-    let x = 0xFF;
-    0
-}
-"""
-compile_fail = true
-error_contains = ["hexadecimal integer literals are not supported", "decimal only", "write `255` instead"]
-
-[[case]]
-name = "binary_literal_targeted_error"
-source = """
-fn main() -> i32 {
-    let x = 0b101;
-    0
-}
-"""
-compile_fail = true
-error_contains = ["binary integer literals are not supported", "write `5` instead"]
-
-[[case]]
-name = "octal_literal_targeted_error"
-source = """
-fn main() -> i32 {
-    let x = 0o17;
-    0
-}
-"""
-compile_fail = true
-error_contains = ["octal integer literals are not supported", "write `15` instead"]
-
-[[case]]
-name = "hex_literal_bad_digits_no_hint"
-description = "A prefix whose digits don't parse in that base still errors, just without the decimal suggestion."
-source = """
-fn main() -> i32 {
-    let x = 0b234;
-    0
-}
-"""
-compile_fail = true
-error_contains = ["binary integer literals are not supported"]
-
-[[case]]
-name = "decimal_literals_unaffected"
-source = """
-fn main() -> i32 {
-    let x = 0;
-    let y = 42;
-    x + y
 }
 """
 exit_code = 42

--- a/docs/spec/src/02-lexical-structure/01-tokens.md
+++ b/docs/spec/src/02-lexical-structure/01-tokens.md
@@ -20,7 +20,7 @@ Rue tokens fall into the following categories:
 |----------|----------|
 | Keywords | `fn`, `let`, `mut`, `if`, `else`, `while`, `match`, `return`, `break`, `continue`, `true`, `false` |
 | Identifiers | `main`, `x`, `my_var`, `_unused` |
-| Integer literals | `0`, `42`, `255`, `2147483647` |
+| Integer literals | `0`, `42`, `1_000_000`, `0xFF`, `0o17`, `0b1010` |
 | String literals | `"hello"`, `"world"`, `"with \"escapes\""` |
 | Operators | `+`, `-`, `*`, `/`, `%`, `==`, `!=`, `<`, `>`, `<=`, `>=`, `&&`, `\|\|`, `!`, `&`, `\|`, `^`, `~`, `<<`, `>>` |
 | Delimiters | `(`, `)`, `{`, `}`, `[`, `]`, `,`, `;`, `:`, `->`, `=>` |
@@ -29,24 +29,52 @@ Rue tokens fall into the following categories:
 
 {{ rule(id="2.1:3", cat="normative") }}
 
-An integer literal is a sequence of decimal digits.
+An integer literal is a decimal literal, a hexadecimal literal (prefix `0x`), an octal literal (prefix `0o`), or a binary literal (prefix `0b`). A decimal literal begins with a decimal digit; a based literal begins with its lowercase base prefix and contains at least one digit of that base. Hexadecimal digits are case-insensitive: `0xff`, `0xFF`, and `0xfF` denote the same value.
 
 ```ebnf
-integer_literal = digit { digit } ;
-digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+integer_literal = dec_literal | hex_literal | oct_literal | bin_literal ;
+dec_literal = dec_digit { dec_digit | "_" } ;
+hex_literal = "0x" { hex_digit | "_" } ;   (* at least one hex_digit *)
+oct_literal = "0o" { oct_digit | "_" } ;   (* at least one oct_digit *)
+bin_literal = "0b" { bin_digit | "_" } ;   (* at least one bin_digit *)
+dec_digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
+oct_digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" ;
+bin_digit = "0" | "1" ;
+hex_digit = dec_digit | "a" | ... | "f" | "A" | ... | "F" ;
 ```
 
 {{ rule(id="2.1:4", cat="normative") }}
 
 Integer literals **MUST** be representable in their target type. An unadorned integer literal defaults to type `i32`.
 
+{{ rule(id="2.1:19", cat="normative") }}
+
+Underscores (`_`) may appear as digit separators anywhere among the digits of an integer literal — including immediately after a base prefix and trailing — and have no effect on the literal's value. An integer literal cannot *begin* with an underscore: a token such as `_1` is an identifier, not a literal.
+
+{{ rule(id="2.1:20", cat="legality-rule") }}
+
+A base prefix with no digits after it (e.g. `0x`, `0b_`) is a compile-time error.
+
+{{ rule(id="2.1:21", cat="legality-rule") }}
+
+A digit that is not valid in the literal's base (e.g. `0b2`, `0o9`, `0xG`) is a compile-time error.
+
+{{ rule(id="2.1:22", cat="legality-rule") }}
+
+Base prefixes are lowercase. An uppercase base prefix (`0X`, `0O`, `0B`) is a compile-time error.
+
 {{ rule(id="2.1:5") }}
 
 ```rue
 fn main() -> i32 {
-    0        // zero
-    42       // decimal integer
-    255      // maximum u8 value
+    0            // zero
+    42           // decimal integer
+    255          // maximum u8 value
+    1_000_000    // underscore separators
+    0xFF         // hexadecimal, value 255
+    0x_FF_       // underscores legal after the prefix and trailing
+    0o17         // octal, value 15
+    0b1010       // binary, value 10
 }
 ```
 

--- a/docs/spec/src/03-types/01-integer-types.md
+++ b/docs/spec/src/03-types/01-integer-types.md
@@ -145,3 +145,21 @@ fn main() -> i32 {
     0
 }
 ```
+
+## Literal Base Independence
+
+{{ rule(id="3.1:24", cat="normative") }}
+
+The written base of an integer literal (decimal, hexadecimal, octal, or binary; see 2.1) does not affect its semantics: the literal denotes the same value as its decimal spelling, and type inference (3.1:14, 3.1:15) and range validation (3.1:17) apply identically regardless of base.
+
+{{ rule(id="3.1:25") }}
+
+```rue
+fn main() -> i32 {
+    let a: u64 = 0xFFFF_FFFF_FFFF_FFFF;  // valid: u64 maximum value
+    let b: u8 = 0xFF;                    // valid: 255 fits in u8
+    let c = 0x10;                        // c has type i32 (default), value 16
+    let d: i32 = 0xFFFF_FFFF_FFFF_FFFF;  // error: out of range for i32
+    0
+}
+```

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -161,8 +161,14 @@ field_init     = IDENT ":" expression ;
 
 (* Lexical elements *)
 IDENT          = ( letter | "_" ) { letter | digit | "_" } ;
-INTEGER        = digit { digit } ;   (* decimal only; 0x/0b/0o prefixes are
-                                        rejected with a dedicated diagnostic *)
+INTEGER        = dec_literal | hex_literal | oct_literal | bin_literal ;
+dec_literal    = digit { digit | "_" } ;
+hex_literal    = "0x" { hex_digit | "_" } ;   (* at least one hex_digit *)
+oct_literal    = "0o" { oct_digit | "_" } ;   (* at least one oct_digit *)
+bin_literal    = "0b" { bin_digit | "_" } ;   (* at least one bin_digit *)
+hex_digit      = digit | "a" | ... | "f" | "A" | ... | "F" ;
+oct_digit      = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" ;
+bin_digit      = "0" | "1" ;
 STRING         = '"' { string_char | escape } '"' ;
 escape         = "\\" ( "\\" | '"' | "n" | "t" | "r" | "0" ) ;
 BOOL           = "true" | "false" ;


### PR DESCRIPTION
Implements the morning's hex-literals ruling: copy Rust's integer-literal syntax wholesale. `0xFF` / `0o77` / `0b1010` (hex digits case-insensitive) plus `_` separators anywhere among the digits (`0x_FF`, trailing `1_`), parsed into the existing u64-magnitude token path — so downstream everything is identical to decimal: context inference, E0800 range checks (verified: `0xFFFF_FFFF_FFFF_FFFF` works as u64, errors as i32; out-of-range hex match patterns hit the #977 checks), comptime evaluation (`comptime { 0xFF }`), and const initializers.

The #955 "hex literals are not supported" diagnostic (E0005) retires with honor, replaced by the feature. Targeted errors remain for malformed forms only: **E0006** uppercase prefix (`0XFF` — friendlier than Rust's silent lex-as-identifier), **E0007** bare prefix (`0x`, `0b_`), **E0008** wrong-base digit (`0b2`, `0o9`, span on the offending digit), E0002 overflow.

Spec: 2.1:3 grammar rewritten, new rules 2.1:19–22 and 3.1:24–25, grammar-appendix INTEGER production updated; traceability 100% (574/574). Tests: 8 lexer unit tests, 23 spec cases, 8 UI cases (new `diagnostics/int_literals.toml`), 1 end-to-end bit-twiddling CLI case. Verified post-integration by execution: all four forms in one program compute correctly. Lexer-only — no preview gate per the ruling (ships complete; ADR-0005 targets multi-phase features).

Fixes RUE-177

🤖 Generated with [Claude Code](https://claude.com/claude-code)