### PR TITLE
Performance page: per-platform stat rows in All Platforms view

### DIFF
--- a/website/templates/performance.html
+++ b/website/templates/performance.html
@@ -24,38 +24,21 @@
             </div>
         </section>
 
-        <!-- Summary Stats -->
+        <!-- Summary Stats: single-platform mode shows latest/avg/best + delta;
+             comparison mode shows one row per platform (populated by JS) -->
         <section id="summary-stats" class="mb-12">
             <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
                 <div class="bg-surface border border-themed rounded-lg p-4">
                     <div class="text-sm text-muted mb-1">Compilation Time</div>
-                    <div class="flex items-baseline gap-2">
-                        <span id="stat-time" class="text-2xl font-semibold">--</span>
-                        <span id="stat-time-delta" class="text-sm"></span>
-                    </div>
-                    <div class="text-xs text-muted mt-1">
-                        <span id="stat-time-avg">Avg: --</span> | <span id="stat-time-best">Best: --</span>
-                    </div>
+                    <div id="stat-time-body"><span class="text-2xl font-semibold">--</span></div>
                 </div>
                 <div class="bg-surface border border-themed rounded-lg p-4">
                     <div class="text-sm text-muted mb-1">Peak Memory</div>
-                    <div class="flex items-baseline gap-2">
-                        <span id="stat-memory" class="text-2xl font-semibold">--</span>
-                        <span id="stat-memory-delta" class="text-sm"></span>
-                    </div>
-                    <div class="text-xs text-muted mt-1">
-                        <span id="stat-memory-avg">Avg: --</span>
-                    </div>
+                    <div id="stat-memory-body"><span class="text-2xl font-semibold">--</span></div>
                 </div>
                 <div class="bg-surface border border-themed rounded-lg p-4">
                     <div class="text-sm text-muted mb-1">Binary Size</div>
-                    <div class="flex items-baseline gap-2">
-                        <span id="stat-binary" class="text-2xl font-semibold">--</span>
-                        <span id="stat-binary-delta" class="text-sm"></span>
-                    </div>
-                    <div class="text-xs text-muted mt-1">
-                        <span id="stat-commit">Commit: --</span>
-                    </div>
+                    <div id="stat-binary-body"><span class="text-2xl font-semibold">--</span></div>
                 </div>
             </div>
         </section>
@@ -170,72 +153,56 @@
                     });
             }
 
-            // Update summary stats from metadata
+            const statBodies = {
+                time: document.getElementById('stat-time-body'),
+                memory: document.getElementById('stat-memory-body'),
+                binary: document.getElementById('stat-binary-body'),
+            };
+            const WORSE = '#a14e24';  // sienna: regressions
+            const BETTER = 'var(--color-good)';
+
+            function fmtDelta(str, pct) {
+                if (!str) return '';
+                return ` <span class="text-sm" style="color: ${pct > 0 ? WORSE : BETTER}">${str}</span>`;
+            }
+
+            // Single-platform mode: big latest value + delta + sub-line
             function updateStats(summary) {
                 if (!summary) {
-                    document.getElementById('stat-time').textContent = '--';
-                    document.getElementById('stat-time-delta').textContent = '';
-                    document.getElementById('stat-time-avg').textContent = 'Avg: --';
-                    document.getElementById('stat-time-best').textContent = 'Best: --';
-                    document.getElementById('stat-memory').textContent = '--';
-                    document.getElementById('stat-memory-delta').textContent = '';
-                    document.getElementById('stat-memory-avg').textContent = 'Avg: --';
-                    document.getElementById('stat-binary').textContent = '--';
-                    document.getElementById('stat-binary-delta').textContent = '';
-                    document.getElementById('stat-commit').textContent = 'Commit: --';
+                    statBodies.time.innerHTML = '<span class="text-2xl font-semibold">--</span>';
+                    statBodies.memory.innerHTML = '<span class="text-2xl font-semibold">--</span>';
+                    statBodies.binary.innerHTML = '<span class="text-2xl font-semibold">--</span>';
                     return;
                 }
 
                 const s = summary;
+                statBodies.time.innerHTML =
+                    `<div class="flex items-baseline gap-2"><span class="text-2xl font-semibold">${s.latest_time_ms ? s.latest_time_ms.toFixed(1) + 'ms' : '--'}</span>${fmtDelta(s.time_delta_str, s.time_delta_pct)}</div>` +
+                    `<div class="text-xs text-muted mt-1">Avg: ${s.avg_time_ms ? s.avg_time_ms.toFixed(1) + 'ms' : '--'} | Best: ${s.best_time_ms ? s.best_time_ms.toFixed(1) + 'ms' : '--'}</div>`;
+                statBodies.memory.innerHTML =
+                    `<div class="flex items-baseline gap-2"><span class="text-2xl font-semibold">${s.latest_memory_mb ? s.latest_memory_mb.toFixed(1) + 'MB' : '--'}</span>${fmtDelta(s.memory_delta_str, s.memory_delta_pct)}</div>` +
+                    `<div class="text-xs text-muted mt-1">Avg: ${s.avg_memory_mb ? s.avg_memory_mb.toFixed(1) + 'MB' : '--'}</div>`;
+                statBodies.binary.innerHTML =
+                    `<div class="flex items-baseline gap-2"><span class="text-2xl font-semibold">${s.latest_binary_kb ? s.latest_binary_kb.toFixed(1) + 'KB' : '--'}</span>${fmtDelta(s.binary_delta_str, s.binary_delta_pct)}</div>` +
+                    `<div class="text-xs text-muted mt-1">Commit: ${s.latest_commit || '--'}</div>`;
+            }
 
-                // Time stats
-                document.getElementById('stat-time').textContent =
-                    s.latest_time_ms ? `${s.latest_time_ms.toFixed(1)}ms` : '--';
-                document.getElementById('stat-time-avg').textContent =
-                    s.avg_time_ms ? `Avg: ${s.avg_time_ms.toFixed(1)}ms` : 'Avg: --';
-                document.getElementById('stat-time-best').textContent =
-                    s.best_time_ms ? `Best: ${s.best_time_ms.toFixed(1)}ms` : 'Best: --';
-
-                // Time delta with color
-                const timeDelta = document.getElementById('stat-time-delta');
-                if (s.time_delta_str) {
-                    timeDelta.textContent = s.time_delta_str;
-                    timeDelta.className = s.time_delta_pct > 0 ? 'text-sm text-red-500' : 'text-sm text-green-500';
-                } else {
-                    timeDelta.textContent = '';
+            // Comparison mode: one compact row per platform in each card
+            function updateStatsComparison(metas) {
+                if (!metas || metas.length === 0) {
+                    updateStats(null);
+                    return;
                 }
-
-                // Memory stats
-                document.getElementById('stat-memory').textContent =
-                    s.latest_memory_mb ? `${s.latest_memory_mb.toFixed(1)}MB` : '--';
-                document.getElementById('stat-memory-avg').textContent =
-                    s.avg_memory_mb ? `Avg: ${s.avg_memory_mb.toFixed(1)}MB` : 'Avg: --';
-
-                // Memory delta with color
-                const memDelta = document.getElementById('stat-memory-delta');
-                if (s.memory_delta_str) {
-                    memDelta.textContent = s.memory_delta_str;
-                    memDelta.className = s.memory_delta_pct > 0 ? 'text-sm text-red-500' : 'text-sm text-green-500';
-                } else {
-                    memDelta.textContent = '';
-                }
-
-                // Binary stats
-                document.getElementById('stat-binary').textContent =
-                    s.latest_binary_kb ? `${s.latest_binary_kb.toFixed(1)}KB` : '--';
-
-                // Binary delta with color
-                const binDelta = document.getElementById('stat-binary-delta');
-                if (s.binary_delta_str) {
-                    binDelta.textContent = s.binary_delta_str;
-                    binDelta.className = s.binary_delta_pct > 0 ? 'text-sm text-red-500' : 'text-sm text-green-500';
-                } else {
-                    binDelta.textContent = '';
-                }
-
-                // Commit info
-                document.getElementById('stat-commit').textContent =
-                    s.latest_commit ? `Commit: ${s.latest_commit}` : 'Commit: --';
+                const row = (name, val) =>
+                    `<div class="flex justify-between items-baseline py-0.5 text-sm">` +
+                    `<span class="text-muted">${name}</span>` +
+                    `<span style="font-family: var(--font-mono); font-size: 0.82rem; font-variant-numeric: tabular-nums;">${val}</span></div>`;
+                statBodies.time.innerHTML = metas.map(m =>
+                    row(m.name, m.summary?.latest_time_ms ? m.summary.latest_time_ms.toFixed(1) + 'ms' : '--')).join('');
+                statBodies.memory.innerHTML = metas.map(m =>
+                    row(m.name, m.summary?.latest_memory_mb ? m.summary.latest_memory_mb.toFixed(1) + 'MB' : '--')).join('');
+                statBodies.binary.innerHTML = metas.map(m =>
+                    row(m.name, m.summary?.latest_binary_kb ? m.summary.latest_binary_kb.toFixed(1) + 'KB' : '--')).join('');
             }
 
             // Build metrics table
@@ -289,7 +256,15 @@
                     metricsSection.style.display = 'none';
 
                     loadSvg(timelineContainer, '/benchmarks/comparison/timeline.svg');
-                    updateStats(null);
+
+                    // Populate the stat cards with one row per platform
+                    const withData = (platformMetadata?.platforms || []).filter(p => p.has_data);
+                    Promise.all(withData.map(p =>
+                        fetch(`/benchmarks/platforms/${p.id}/metadata.json`)
+                            .then(r => r.json())
+                            .then(d => ({ name: p.name, summary: d.summary }))
+                            .catch(() => ({ name: p.name, summary: null }))
+                    )).then(updateStatsComparison);
                 } else {
                     // Single platform mode: show all charts
                     const platformName = platformMetadata?.platforms?.find(p => p.id === platform)?.name || platform;


### PR DESCRIPTION
Steve reported the live dashboard opens on three blank stat cards: comparison mode deliberately blanked the summary (`updateStats(null)`) since the summary was designed per-platform — a quirk the redesign promoted to the default view.

The cards are now useful in both modes: **All Platforms** fetches each platform's `metadata.json` and renders one row per platform in each card (compilation time / peak memory / binary size at latest commit); single-platform mode keeps the big latest value + delta + avg/best sub-line. Rebuilt on a single swappable card body — also replaces the tailwind `text-red-500`/`text-green-500` delta colors with theme colors (sienna/olive).

Verified by building and screenshotting the comparison view (rows render; graceful `--` for platforms without data).

🤖 Generated with [Claude Code](https://claude.com/claude-code)