### PR TITLE
aarch64 @intCast range checks compare full 64-bit sources; width-honest asm dumps

### DIFF
--- a/crates/rue-cli-tests/cases/intcast.toml
+++ b/crates/rue-cli-tests/cases/intcast.toml
@@ -88,11 +88,10 @@ exit_code = 0
 
 # Control: a narrowing cast that overflows still traps.
 #
-# xfail on aarch64: the narrowing range check there compares only the low 32
-# bits of the 64-bit source (RUE-31), so this out-of-range value (whose low 32
-# bits happen to land in i32 range) is silently truncated instead of trapping.
-# That is a separate bug from this PR's widening sign-extension; remove
-# `known_bug_on` when RUE-31 is fixed.
+# Also a regression test for RUE-31: the aarch64 range checks used the 32-bit
+# CmpRR for 64-bit sources, so this out-of-range value (whose low 32 bits
+# happen to land in i32 range) was silently truncated instead of trapping.
+# All 64-bit-source range checks now select the 64-bit Cmp64RR.
 [[case]]
 name = "i64_to_i32_overflow_traps"
 files = [{ path = "main.rue", source = """
@@ -103,8 +102,67 @@ fn main() -> i32 {
 """ }]
 exit_code = 101
 runtime_error_contains = ["integer cast overflow"]
-known_bug = "RUE-31"
-known_bug_on = ["aarch64-linux", "aarch64-macos"]
+
+# RUE-31: 2^32 exactly — the buggy 32-bit compare saw only the low 32 bits
+# (zero, comfortably in i32 range) and let the cast through. The value is
+# produced by a function call so constant folding cannot elide the check.
+[[case]]
+name = "i64_pow32_to_i32_overflow_traps"
+files = [{ path = "main.rue", source = """
+fn g() -> i64 { 4294967296 }        // 2^32: low 32 bits are all zero
+fn main() -> i32 {
+    let x: i64 = g();
+    let y: i32 = @intCast(x);       // out of i32 range -> must trap
+    if y == 0 { 1 } else { 2 }
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["integer cast overflow"]
+
+# RUE-31: the low-32-bits blindness affected every 64-bit-source range check,
+# not just signed->signed. u64 -> u32 narrowing must still trap.
+[[case]]
+name = "u64_to_u32_overflow_traps"
+files = [{ path = "main.rue", source = """
+fn g() -> u64 { 4294967296 }        // 2^32: low 32 bits are all zero
+fn main() -> i32 {
+    let x: u64 = g();
+    let y: u32 = @intCast(x);       // out of u32 range -> must trap
+    if y == 0 { 1 } else { 2 }
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["integer cast overflow"]
+
+# RUE-31: u64 -> i64 is a same-size cast that still needs its upper-bound
+# check; comparing only the low 32 bits made that check a no-op.
+[[case]]
+name = "u64_above_i64_max_traps"
+files = [{ path = "main.rue", source = """
+fn g() -> u64 { let a: u64 = 9223372036854775807; a + 1 }   // 2^63 > i64::MAX
+fn main() -> i32 {
+    let x: u64 = g();
+    let y: i64 = @intCast(x);       // out of i64 range -> must trap
+    if y == 0 { 1 } else { 2 }
+}
+""" }]
+exit_code = 101
+runtime_error_contains = ["integer cast overflow"]
+
+# Control: in-range 64-bit-source casts must not trap (the widened compare
+# from the RUE-31 fix must not introduce false positives).
+[[case]]
+name = "i64_in_range_to_i32_ok"
+files = [{ path = "main.rue", source = """
+fn g() -> i64 { 0 - 2147483647 - 1 }    // i32::MIN, exactly in range
+fn main() -> i32 {
+    let x: i64 = g();
+    let y: i32 = @intCast(x);           // boundary value -> must NOT trap
+    let z: i64 = @intCast(y);           // widen back to compare in i64
+    if z == g() { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
 
 # RUE-146: the x86-64 peephole rewrote the signed->unsigned negativity check
 # (`cmp64 r, 0`) into the 32-bit `test r, r`, so SF came from the low 32 bits

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2915,6 +2915,24 @@ impl<'a> CfgLower<'a> {
         self.mir.push(Aarch64Inst::Label { id: ok_label });
     }
 
+    /// Push a register-register compare at the width of the compared value:
+    /// `Cmp64RR` (x-registers) for 64-bit values, `CmpRR` (w-registers)
+    /// otherwise. Range checks on 64-bit sources must not use the 32-bit
+    /// form, which compares only the low half (RUE-31).
+    fn push_cmp_rr(&mut self, src1: VReg, src2: VReg, bits: u32) {
+        if bits > 32 {
+            self.mir.push(Aarch64Inst::Cmp64RR {
+                src1: Operand::Virtual(src1),
+                src2: Operand::Virtual(src2),
+            });
+        } else {
+            self.mir.push(Aarch64Inst::CmpRR {
+                src1: Operand::Virtual(src1),
+                src2: Operand::Virtual(src2),
+            });
+        }
+    }
+
     /// Emit integer cast range check.
     ///
     /// Checks if the source value can be represented in the target type.
@@ -2958,10 +2976,10 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(min_vreg),
                         imm: min_val,
                     });
-                    self.mir.push(Aarch64Inst::CmpRR {
-                        src1: Operand::Virtual(src_vreg),
-                        src2: Operand::Virtual(min_vreg),
-                    });
+                    // A 64-bit source needs a 64-bit compare: the 32-bit CmpRR
+                    // only sees the low half, so e.g. 2^32 would pass an i32
+                    // range check and silently truncate (RUE-31).
+                    self.push_cmp_rr(src_vreg, min_vreg, from_bits);
                     // For signed comparison, branch if greater or equal
                     self.mir.push(Aarch64Inst::BCond {
                         cond: Cond::Ge,
@@ -2980,10 +2998,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(max_vreg),
                         imm: max_val,
                     });
-                    self.mir.push(Aarch64Inst::CmpRR {
-                        src1: Operand::Virtual(src_vreg),
-                        src2: Operand::Virtual(max_vreg),
-                    });
+                    self.push_cmp_rr(src_vreg, max_vreg, from_bits);
                     // For signed comparison, branch if less or equal
                     self.mir.push(Aarch64Inst::BCond {
                         cond: Cond::Le,
@@ -3052,10 +3067,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(max_vreg),
                         imm: max_val,
                     });
-                    self.mir.push(Aarch64Inst::CmpRR {
-                        src1: Operand::Virtual(src_vreg),
-                        src2: Operand::Virtual(max_vreg),
-                    });
+                    self.push_cmp_rr(src_vreg, max_vreg, from_bits);
                     // Unsigned comparison for upper bound check
                     self.mir.push(Aarch64Inst::BCond {
                         cond: Cond::Ls, // Ls = unsigned less or same
@@ -3078,10 +3090,7 @@ impl<'a> CfgLower<'a> {
                     dst: Operand::Virtual(max_vreg),
                     imm: max_val,
                 });
-                self.mir.push(Aarch64Inst::CmpRR {
-                    src1: Operand::Virtual(src_vreg),
-                    src2: Operand::Virtual(max_vreg),
-                });
+                self.push_cmp_rr(src_vreg, max_vreg, from_bits);
                 // Unsigned comparison (Ls = below or same)
                 self.mir.push(Aarch64Inst::BCond {
                     cond: Cond::Ls,
@@ -3100,10 +3109,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(max_vreg),
                         imm: max_val,
                     });
-                    self.mir.push(Aarch64Inst::CmpRR {
-                        src1: Operand::Virtual(src_vreg),
-                        src2: Operand::Virtual(max_vreg),
-                    });
+                    self.push_cmp_rr(src_vreg, max_vreg, from_bits);
                     self.mir.push(Aarch64Inst::BCond {
                         cond: Cond::Ls,
                         label: ok_label,

--- a/crates/rue-codegen/src/aarch64/mir.rs
+++ b/crates/rue-codegen/src/aarch64/mir.rs
@@ -967,7 +967,11 @@ impl fmt::Display for Aarch64Inst {
                 write!(f, "asrl {}, {}, {}", dst, src1, src2)
             }
             Aarch64Inst::CmpRR { src1, src2 } => write!(f, "cmp {}, {}", src1, src2),
-            Aarch64Inst::Cmp64RR { src1, src2 } => write!(f, "cmp {}, {}", src1, src2),
+            Aarch64Inst::Cmp64RR { src1, src2 } => {
+                // Width-marked like Adds64RR/Subs64RR so the MIR dump can
+                // distinguish the 64-bit compare from the 32-bit CmpRR.
+                write!(f, "cmp {}, {} // 64-bit", src1, src2)
+            }
             Aarch64Inst::CmpImm { src, imm } => write!(f, "cmp {}, #{}", src, imm),
             Aarch64Inst::Cbz { src, label } => write!(f, "cbz {}, {}", src, label),
             Aarch64Inst::Cbnz { src, label } => write!(f, "cbnz {}, {}", src, label),

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -852,7 +852,16 @@ impl<'a> Emitter<'a> {
             X86Inst::CmpRR { src1, src2 } => {
                 self.begin_inst();
                 self.emit_cmp_rr(src1.as_physical(), src2.as_physical());
-                end_inst!(self, "cmp {}, {}", src1.as_physical(), src2.as_physical());
+                // Width-honest dump: this is a 32-bit compare, so print the
+                // 32-bit register names (RUE-90). Printing r12/r13 here made
+                // the dump indistinguishable from Cmp64RR and masked
+                // comparison-width miscompiles.
+                end_inst!(
+                    self,
+                    "cmp {}, {}",
+                    src1.as_physical().name32(),
+                    src2.as_physical().name32()
+                );
             }
             X86Inst::Cmp64RR { src1, src2 } => {
                 self.begin_inst();
@@ -862,7 +871,7 @@ impl<'a> Emitter<'a> {
             X86Inst::CmpRI { src, imm } => {
                 self.begin_inst();
                 self.emit_cmp_ri(src.as_physical(), *imm);
-                end_inst!(self, "cmp {}, {}", src.as_physical(), imm);
+                end_inst!(self, "cmp {}, {}", src.as_physical().name32(), imm);
             }
             X86Inst::Cmp64RI { src, imm } => {
                 self.begin_inst();


### PR DESCRIPTION
Cycle-17 worker integration (verified by hand at integration time on current trunk).

**RUE-31 (miscompile):** aarch64 `emit_int_cast_check` emitted width-less `CmpRR` (32-bit `cmp wN, wM`) for every range check, so an i64 source like `2^32` passed the i64→i32 check on its low 32 bits and silently truncated — while x86-64 correctly trapped. All four compare sites now select `Cmp64RR` for 64-bit sources. The `known_bug = "RUE-31"` xfail in `intcast.toml` is un-marked (now a regression test that CI's native arm64 jobs execute) and joined by four new boundary cases.

**RUE-90 (dump honesty):** the x86-64 asm dump printed `cmp r12, r13` for a 32-bit encoding (`45 39 ec`), masking exactly this bug class. The dishonesty was in `emit.rs`'s `end_inst!`, not the MIR Display; dumps now print `r12d`-style names for 32-bit ops, byte-verified against objdump.

Integration verification: aarch64-linux and aarch64-macos `--emit asm` show `cmp x19, x20` for the i64→i32 check; x86-64 execution still traps (exit 101); golden asm corpus needed no regeneration; full `./test.sh` green on this checkout.

Fixes RUE-31
Fixes RUE-90

🤖 Generated with [Claude Code](https://claude.com/claude-code)