### PR TITLE
Parser: merged spans carry their file_id; formatters refuse to guess files

### DIFF
--- a/crates/rue-cli-tests/cases/multifile_errors.toml
+++ b/crates/rue-cli-tests/cases/multifile_errors.toml
@@ -1,4 +1,4 @@
-# Multi-file error attribution (RUE-115).
+# Multi-file error attribution (RUE-115, RUE-175).
 #
 # Parse errors produced by the chumsky error-conversion path used to drop the
 # FileId (defaulting to FileId::DEFAULT), so in a multi-file compile the
@@ -6,11 +6,18 @@
 # rendered with a caret on perfectly valid code in the wrong file. These cases
 # pin that a parse error in one file is attributed to THAT file regardless of
 # argument order, and that the other (valid) file is never named in stderr.
+#
+# RUE-175 was the same bug class one layer down: the parser built MERGED spans
+# (binary exprs, unary exprs, assign-target field/index chains, implicit unit
+# block results) with `Span::new`, which resets the FileId to DEFAULT. Any sema
+# diagnostic whose primary span was such a merged span then landed on a
+# hash-map-order-dependent file. The `*_span_*` cases below pin each expression
+# shape to its actual file.
 
 [section]
 id = "cli.multifile_errors"
 name = "Multi-file error attribution"
-description = "Parse errors must name the file that actually contains them (RUE-115)."
+description = "Diagnostics must name the file that actually contains them (RUE-115, RUE-175)."
 
 [[case]]
 name = "parse_error_in_second_file"
@@ -76,3 +83,136 @@ args = ["good.rue", "bad.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E0102", "bad.rue:3:5"]
 compile_stderr_not_contains = ["good.rue"]
+
+[[case]]
+name = "binary_expr_span_in_second_file"
+description = """
+RUE-175: make_binary built the merged span with Span::new, dropping the
+FileId. The E0206 on the `if 1 + 2` condition in main.rue (passed second)
+alternated between main.rue:2:8 and a misaligned caret in lib.rue depending on
+hash-map iteration order. It must always point at main.rue:2:8.
+"""
+files = [
+    { path = "lib.rue", source = """
+pub fn helper() -> i64 {
+    return 1;
+}
+""" },
+    { path = "main.rue", source = """
+fn main() -> i64 {
+    if 1 + 2 {
+        return 1;
+    }
+    return 0;
+}
+""" },
+]
+args = ["lib.rue", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0206", "main.rue:2:8"]
+compile_stderr_not_contains = ["lib.rue"]
+
+[[case]]
+name = "binary_expr_span_swapped_order"
+description = """
+RUE-175, swapped argument order: attribution must not depend on which file
+comes first on the command line.
+"""
+files = [
+    { path = "lib.rue", source = """
+pub fn helper() -> i64 {
+    return 1;
+}
+""" },
+    { path = "main.rue", source = """
+fn main() -> i64 {
+    if 1 + 2 {
+        return 1;
+    }
+    return 0;
+}
+""" },
+]
+args = ["main.rue", "lib.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0206", "main.rue:2:8"]
+compile_stderr_not_contains = ["lib.rue"]
+
+[[case]]
+name = "unary_expr_span_in_second_file"
+description = """
+RUE-175: make_unary also built its merged span (operator start .. operand end)
+with Span::new. The E0206 on the `if -1` condition must point at main.rue:2:8,
+never at lib.rue.
+"""
+files = [
+    { path = "lib.rue", source = """
+pub fn helper() -> i64 {
+    return 1;
+}
+""" },
+    { path = "main.rue", source = """
+fn main() -> i64 {
+    if -1 {
+        return 1;
+    }
+    return 0;
+}
+""" },
+]
+args = ["lib.rue", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0206", "main.rue:2:8"]
+compile_stderr_not_contains = ["lib.rue"]
+
+[[case]]
+name = "field_assign_span_in_second_file"
+description = """
+RUE-175: field-assignment shape. The E0206 for assigning a bool to an i64
+field must be attributed to main.rue:4:5, never to lib.rue.
+"""
+files = [
+    { path = "lib.rue", source = """
+pub fn helper() -> i64 {
+    return 1;
+}
+""" },
+    { path = "main.rue", source = """
+struct P { x: i64 }
+fn main() -> i64 {
+    let mut p = P { x: 1 };
+    p.x = true;
+    return p.x;
+}
+""" },
+]
+args = ["lib.rue", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0206", "main.rue:4:5"]
+compile_stderr_not_contains = ["lib.rue"]
+
+[[case]]
+name = "index_expr_span_in_second_file"
+description = """
+RUE-175: index-expression shape. The E0206 whose primary span is the postfix
+index expression `a[0]` (used where a bool is required) must be attributed to
+main.rue:3:13, never to lib.rue.
+"""
+files = [
+    { path = "lib.rue", source = """
+pub fn helper() -> i64 {
+    return 1;
+}
+""" },
+    { path = "main.rue", source = """
+fn main() -> i64 {
+    let mut a = [1, 2, 3];
+    let i = a[0] && true;
+    return 0;
+}
+""" },
+]
+args = ["lib.rue", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0206", "main.rue:3:13"]
+compile_stderr_not_contains = ["lib.rue"]

--- a/crates/rue-compiler/src/diagnostic.rs
+++ b/crates/rue-compiler/src/diagnostic.rs
@@ -343,15 +343,22 @@ impl<'a> MultiFileFormatter<'a> {
         self.sources.get(&file_id)
     }
 
-    /// Get a fallback source info (the first one in the map).
+    /// Get a fallback source info for a span whose file ID has no entry.
     ///
-    /// This is used when a span has no file ID (FileId::DEFAULT) and we need
-    /// to show something. Returns None if no sources are registered.
+    /// Tries `FileId::DEFAULT` first (single-file paths register their source
+    /// there or under a real ID). If that is absent, the only safe guess is
+    /// when exactly one source is registered; with multiple sources, picking
+    /// an arbitrary one would attribute the diagnostic to the wrong file
+    /// nondeterministically (hash-map iteration order — RUE-175), so this
+    /// returns None and the caller renders the message without a snippet.
     fn fallback_source(&self) -> Option<&SourceInfo<'a>> {
-        // Try FileId::DEFAULT first, then any source
-        self.sources
-            .get(&FileId::DEFAULT)
-            .or_else(|| self.sources.values().next())
+        self.sources.get(&FileId::DEFAULT).or_else(|| {
+            if self.sources.len() == 1 {
+                self.sources.values().next()
+            } else {
+                None
+            }
+        })
     }
 
     /// Format a compilation error into a string.
@@ -537,7 +544,13 @@ impl<'a> MultiFileFormatter<'a> {
             let source_info = self.get_source(file_id).or_else(|| self.fallback_source());
 
             let Some(source_info) = source_info else {
-                // No source available for this file - skip it
+                // No source available for this file. Refuse to guess a file
+                // (see fallback_source); surface the problem instead of
+                // silently misattributing the span (RUE-175).
+                report = report.footer(Level::Note.title(
+                    "source snippet unavailable: span has an unknown file id \
+                     (this is a bug in the Rue compiler)",
+                ));
                 continue;
             };
 
@@ -962,10 +975,19 @@ impl<'a> MultiFileJsonFormatter<'a> {
     }
 
     /// Get a fallback source info (for FileId::DEFAULT or when no specific source is found).
+    ///
+    /// Like [`MultiFileFormatter::fallback_source`], this only guesses when
+    /// the choice is unambiguous: `FileId::DEFAULT` if registered, else the
+    /// sole registered source. With multiple sources an unknown file ID must
+    /// not be attributed to an arbitrary file (RUE-175).
     fn fallback_source(&self) -> Option<&SourceInfo<'a>> {
-        self.sources
-            .get(&FileId::DEFAULT)
-            .or_else(|| self.sources.values().next())
+        self.sources.get(&FileId::DEFAULT).or_else(|| {
+            if self.sources.len() == 1 {
+                self.sources.values().next()
+            } else {
+                None
+            }
+        })
     }
 
     /// Calculate line and column for a byte offset in a specific source.

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -539,7 +539,7 @@ where
 
 /// Helper to create binary expression
 fn make_binary(left: Expr, op: BinaryOp, right: Expr) -> Expr {
-    let span = Span::new(left.span().start, right.span().end);
+    let span = Span::with_file(left.span().file_id, left.span().start, right.span().end);
     Expr::Binary(BinaryExpr {
         left: Box::new(left),
         op,
@@ -550,7 +550,11 @@ fn make_binary(left: Expr, op: BinaryOp, right: Expr) -> Expr {
 
 /// Helper to create unary expression
 fn make_unary(op: UnaryOp, operand: Expr, op_span: SimpleSpan) -> Expr {
-    let span = Span::new(offset_to_u32(op_span.start), operand.span().end);
+    let span = Span::with_file(
+        operand.span().file_id,
+        offset_to_u32(op_span.start),
+        operand.span().end,
+    );
     Expr::Unary(UnaryExpr {
         op,
         operand: Box::new(operand),
@@ -1704,7 +1708,7 @@ where
                         // The last suffix determines the target type
                         return match suffix {
                             AssignSuffix::Field(field) => {
-                                let span = Span::new(base_expr.span().start, field.span.end);
+                                let span = base_expr.span().extend_to(field.span.end);
                                 AssignTarget::Field(FieldExpr {
                                     base: Box::new(base_expr),
                                     field,
@@ -1712,7 +1716,7 @@ where
                                 })
                             }
                             AssignSuffix::Index(index) => {
-                                let span = Span::new(base_expr.span().start, index.span().end);
+                                let span = base_expr.span().extend_to(index.span().end);
                                 AssignTarget::Index(IndexExpr {
                                     base: Box::new(base_expr),
                                     index: Box::new(index),
@@ -1724,7 +1728,7 @@ where
                     // Build intermediate expressions
                     match suffix {
                         AssignSuffix::Field(field) => {
-                            let span = Span::new(base_expr.span().start, field.span.end);
+                            let span = base_expr.span().extend_to(field.span.end);
                             base_expr = Expr::Field(FieldExpr {
                                 base: Box::new(base_expr),
                                 field,
@@ -1732,7 +1736,7 @@ where
                             });
                         }
                         AssignSuffix::Index(index) => {
-                            let span = Span::new(base_expr.span().start, index.span().end);
+                            let span = base_expr.span().extend_to(index.span().end);
                             base_expr = Expr::Index(IndexExpr {
                                 base: Box::new(base_expr),
                                 index: Box::new(index),
@@ -1953,7 +1957,7 @@ fn process_block_items(items: Vec<BlockItem>, block_span: Span) -> (Vec<Statemen
         }
         // Fallback: use a unit expression (block produces unit type)
         Expr::Unit(UnitLit {
-            span: Span::new(block_span.end, block_span.end),
+            span: Span::point_in_file(block_span.file_id, block_span.end),
         })
     });
 


### PR DESCRIPTION
Cycle-17 worker integration (verified by hand at integration time).

**RUE-175:** seven span-merge sites in `chumsky_parser.rs` built spans without a `file_id`, so multi-file diagnostics resolved against whichever file's line table hash-order served first — the same build alternated between `main.rue:2:8` (correct) and `lib.rue:2:2` (wrong file, misaligned caret) across runs. All seven sites now carry their constituents' file_id; an audit found no others. As defense in depth, `MultiFileFormatter`/`MultiFileJsonFormatter` (which live in rue-compiler, not rue-error as the issue guessed) now render an explicit "unknown file id" note instead of guessing a source.

Integration verification: repro executed 12× on this checkout — 12/12 deterministic at the correct location (trunk baseline: 5/8 wrong). Five new CLI regression cases; full `./test.sh` green.

Fixes RUE-175

🤖 Generated with [Claude Code](https://claude.com/claude-code)