### PR TITLE
Privacy everywhere, for every item kind: structs and consts join fns under E0460

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,9 +95,10 @@ rue main.rue utils.rue lib.rue -o program
 
 **Key semantics:**
 - All top-level names resolve across files without imports (flat namespace),
-  but privacy is uniform (spec 10.3:7): a function is callable outside its
-  defining directory only if `pub`, whether its file is imported or just
-  listed (E0460 otherwise; through a module object it's E0706)
+  but privacy is uniform (spec 10.3:7): an item — function, struct, or
+  constant — is usable outside its defining directory only if `pub`, whether
+  its file is imported or just listed (E0460 otherwise; through a module
+  object it's E0706)
 - Duplicate definitions (same name in multiple files) cause a compile error
 - `main()` must exist in exactly one file
 - Files are parsed in parallel, then merged for semantic analysis

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1932,6 +1932,18 @@ impl<'a> Sema<'a> {
         // gathering (RUE-171); materialize it directly — the initializer is
         // never re-analyzed at use sites.
         if let Some(const_info) = self.constants.get(&name) {
+            // Privacy (E0460, RUE-183): the constants table is global, so an
+            // unqualified reference can resolve to a private constant defined
+            // in another directory — reject it, privacy is uniform across
+            // item kinds (spec 10.3:1, 10.3:7). The declaration span's file
+            // is the constant's defining file.
+            self.check_unqualified_visibility(
+                "constant",
+                name_str,
+                const_info.span.file_id,
+                const_info.is_pub,
+                span,
+            )?;
             let (data, ty) = Self::materialize_const_value(const_info.value, const_info.ty);
             let air_ref = air.add_inst(AirInst { data, ty, span });
             return Ok(AnalysisResult::new(air_ref, ty));
@@ -1939,14 +1951,25 @@ impl<'a> Sema<'a> {
 
         // Check if this is a type name (for comptime type parameters)
         // Try to resolve it as a type - if successful, emit a TypeConst instruction
-        if let Ok(resolved_type) = self.resolve_type(name, span) {
-            // This is a type name being used as a value (e.g., `i32` passed to `comptime T: type`)
-            let air_ref = air.add_inst(AirInst {
-                data: AirInstData::TypeConst(resolved_type),
-                ty: Type::COMPTIME_TYPE,
-                span,
-            });
-            return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
+        match self.resolve_type(name, span) {
+            Ok(resolved_type) => {
+                // This is a type name being used as a value (e.g., `i32` passed to `comptime T: type`)
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::TypeConst(resolved_type),
+                    ty: Type::COMPTIME_TYPE,
+                    span,
+                });
+                return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
+            }
+            // The name IS a known type, but a private one from another
+            // directory (RUE-183): report the privacy error rather than
+            // falling through to a misleading "undefined variable".
+            Err(e) if matches!(e.kind, ErrorKind::PrivateUnqualifiedAccess(_)) => {
+                return Err(e);
+            }
+            // Any other resolution failure: not a type name, keep falling
+            // through to the undefined-variable error below.
+            Err(_) => {}
         }
 
         // Not a parameter, local, type, or constant - undefined variable
@@ -2169,10 +2192,25 @@ impl<'a> Sema<'a> {
                 }
             }
         } else {
-            *self
+            let struct_id = *self
                 .structs
                 .get(&type_name)
-                .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.to_string()), span)?
+                .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.to_string()), span)?;
+            // Privacy (E0460, RUE-183): a struct literal names the type
+            // unqualified, so a private struct from another directory is not
+            // constructible here — privacy is uniform across item kinds
+            // (spec 10.3:1, 10.3:7). The comptime-type-variable branch above
+            // is exempt: the type value arrived through a binding (e.g. a
+            // `pub` comptime function's return), not by naming the struct.
+            let def = self.type_pool.struct_def(struct_id);
+            self.check_unqualified_visibility(
+                "struct",
+                type_name_str,
+                def.file_id,
+                def.is_pub,
+                span,
+            )?;
+            struct_id
         };
 
         // Get struct def (returns owned copy from pool)
@@ -3423,7 +3461,8 @@ impl<'a> Sema<'a> {
         // uniform in every multi-file compilation, imports or not (spec
         // 10.3:7), so the flat namespace resolves the name but the callee
         // must be `pub` (or in the caller's directory).
-        self.check_unqualified_call_visibility(
+        self.check_unqualified_visibility(
+            "function",
             &fn_name_str,
             fn_info.file_id,
             fn_info.is_pub,

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -737,7 +737,20 @@ impl Sema<'_> {
                 //    access, RUE-160) and was exponential for const chains.
                 //    Module-typed constants never appear in this table
                 //    (module bindings live in `Sema::module_bindings`).
+                //    Privacy applies here too (E0460, RUE-183): the table is
+                //    global, so a const initializer in one directory could
+                //    otherwise read a private constant from another. The
+                //    VarRef's own span locates the referencing file;
+                //    speculative callers (`try_evaluate_const*`) swallow the
+                //    error and defer to runtime analysis, which re-checks.
                 if let Some(info) = self.constants.get(name) {
+                    self.check_unqualified_visibility(
+                        "constant",
+                        self.interner.resolve(name),
+                        info.span.file_id,
+                        info.is_pub,
+                        span,
+                    )?;
                     return Ok(Some(info.value));
                 }
                 // 5. Type names used as values (e.g. `Point` in

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1285,6 +1285,17 @@ impl<'a> Sema<'a> {
                     return Ok(ConstInit::Module(binding.ty));
                 }
                 if let Some(info) = self.constants.get(&name) {
+                    // Privacy (E0460, RUE-183): the value-constant table is
+                    // global, so this alias could otherwise read a private
+                    // constant from another directory. The initializer's own
+                    // span locates the referencing file.
+                    self.check_unqualified_visibility(
+                        "constant",
+                        self.interner.resolve(&name),
+                        info.span.file_id,
+                        info.is_pub,
+                        span,
+                    )?;
                     return Ok(ConstInit::Value(info.value));
                 }
                 // Not a constant: let the comptime engine decide (it rejects

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -143,6 +143,20 @@ impl<'a> Sema<'a> {
         }
 
         if let Some(&struct_id) = self.structs.get(&type_sym) {
+            // Privacy (E0460, RUE-183): an unqualified type reference must
+            // not reach a private struct defined in another directory —
+            // privacy is uniform across item kinds (spec 10.3:1, 10.3:7).
+            // Spans here are always the reference site (annotation,
+            // signature, struct literal), so `span.file_id` is the
+            // referencing file.
+            let struct_def = self.type_pool.struct_def(struct_id);
+            self.check_unqualified_visibility(
+                "struct",
+                type_name,
+                struct_def.file_id,
+                struct_def.is_pub,
+                span,
+            )?;
             Ok(Type::new_struct(struct_id))
         } else if let Some(&enum_id) = self.enums.get(&type_sym) {
             Ok(Type::new_enum(enum_id))

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -55,47 +55,56 @@ impl Sema<'_> {
         }
     }
 
-    /// Check that an *unqualified* call may reach the callee (RUE-37,
-    /// RUE-180).
+    /// Check that an *unqualified* reference may reach the item (RUE-37,
+    /// RUE-180, RUE-183).
     ///
-    /// All loaded files share one flat global function namespace for *name
+    /// All loaded files share one flat global namespace for *name
     /// resolution* (spec 10.5:2, transitional), but privacy is uniform in
-    /// every multi-file compilation, imports or not (spec 10.3:7):
+    /// every multi-file compilation, imports or not (spec 10.3:7), and it
+    /// covers every item kind — functions, structs, and constants alike
+    /// (spec 10.3:1):
     ///
-    /// - If the callee is accessible per [`Sema::is_accessible`] (it is
-    ///   `pub`, or the caller is in the callee's directory — ADR-0026
-    ///   intra-directory visibility), the call is fine.
-    /// - Otherwise the call is an error (E0460), naming the callee's
+    /// - If the item is accessible per [`Sema::is_accessible`] (it is
+    ///   `pub`, or the reference is in the item's directory — ADR-0026
+    ///   intra-directory visibility), the reference is fine.
+    /// - Otherwise the reference is an error (E0460), naming the item's
     ///   defining file. Whether that file was loaded via `@import` or merely
     ///   listed on the command line makes no difference.
-    pub(crate) fn check_unqualified_call_visibility(
+    ///
+    /// `item_kind` names the kind in the diagnostic ("function", "struct",
+    /// "constant").
+    pub(crate) fn check_unqualified_visibility(
         &self,
-        fn_name: &str,
-        callee_file_id: FileId,
+        item_kind: &str,
+        name: &str,
+        defining_file_id: FileId,
         is_pub: bool,
         span: rue_span::Span,
     ) -> CompileResult<()> {
-        if self.is_accessible(span.file_id, callee_file_id, is_pub) {
+        if self.is_accessible(span.file_id, defining_file_id, is_pub) {
             return Ok(());
         }
 
         // `is_accessible` is permissive when either file path is unknown
-        // (single-file mode, synthetic items), so the callee's path is
+        // (single-file mode, synthetic items), so the item's path is
         // always known here.
         let defining_file = self
-            .get_file_path(callee_file_id)
+            .get_file_path(defining_file_id)
             .unwrap_or("<unknown>")
             .to_string();
 
         Err(CompileError::new(
-            ErrorKind::PrivateUnqualifiedAccess {
-                name: fn_name.to_string(),
-                defining_file,
-            },
+            ErrorKind::PrivateUnqualifiedAccess(Box::new(
+                rue_error::PrivateUnqualifiedAccessData {
+                    item_kind: item_kind.to_string(),
+                    name: name.to_string(),
+                    defining_file,
+                },
+            )),
             span,
         )
         .with_help(format!(
-            "`{fn_name}` is not marked `pub`; private items are only visible within their defining directory"
+            "`{name}` is not marked `pub`; private items are only visible within their defining directory"
         )))
     }
 

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -713,6 +713,149 @@ fn secret() -> i32 {
 ]
 exit_code = 42
 
+# Structs and constants obey the same uniform rule (RUE-183): naming a
+# private struct (annotation or literal) or reading a private constant from
+# another directory is E0460, whether the file was imported or only listed.
+
+[[case]]
+name = "private_struct_cross_dir_unqualified_rejected"
+description = "Unqualified struct literal/annotation naming a private struct in another directory is E0460 (RUE-183) — fn-only privacy is not enough."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let p: Point = Point { x: 40, y: 2 };
+    p.x + p.y
+}
+""" },
+    { path = "sub/lib.rue", source = """
+struct Point {
+    x: i32,
+    y: i32,
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "struct `Point` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "private_const_cross_dir_unqualified_rejected"
+description = "Unqualified read of a private constant in another directory is E0460 (RUE-183)."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    LIMIT
+}
+""" },
+    { path = "sub/lib.rue", source = """
+const LIMIT: i32 = 99;
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "constant `LIMIT` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "flat_multifile_private_struct_cross_dir_rejected"
+description = "Uniform privacy for structs (RUE-183): a private struct in a never-imported listed file is not nameable cross-directory."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let p: Point = Point { x: 40, y: 2 };
+    p.x + p.y
+}
+""" },
+    { path = "sub/lib.rue", source = """
+struct Point {
+    x: i32,
+    y: i32,
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "struct `Point` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "flat_multifile_private_const_cross_dir_rejected"
+description = "Uniform privacy for constants (RUE-183): a private constant in a never-imported listed file is not readable cross-directory."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    LIMIT
+}
+""" },
+    { path = "sub/lib.rue", source = """
+const LIMIT: i32 = 99;
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "constant `LIMIT` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "flat_multifile_private_const_in_const_init_rejected"
+description = "A constant initializer is a reference site too (RUE-183): `const X = LIMIT;` reading a private cross-directory constant is E0460."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+const X: i32 = LIMIT;
+
+fn main() -> i32 {
+    X
+}
+""" },
+    { path = "sub/lib.rue", source = """
+const LIMIT: i32 = 99;
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "constant `LIMIT` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "flat_multifile_pub_struct_and_const_cross_dir_allowed"
+description = "Positive control (RUE-183): pub structs and constants in another never-imported directory remain usable unqualified (spec 10.3:8)."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let p: Point = Point { x: 30, y: 2 };
+    p.x + p.y + BONUS
+}
+""" },
+    { path = "sub/lib.rue", source = """
+pub struct Point {
+    x: i32,
+    y: i32,
+}
+pub const BONUS: i32 = 10;
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "flat_multifile_private_struct_and_const_same_dir_allowed"
+description = "Control (RUE-183): intra-directory visibility is unchanged — private structs and constants in another listed file in the SAME directory are usable."
+args = ["main.rue", "lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let p: Point = Point { x: 30, y: 2 };
+    p.x + p.y + BONUS
+}
+""" },
+    { path = "lib.rue", source = """
+struct Point {
+    x: i32,
+    y: i32,
+}
+const BONUS: i32 = 10;
+""" },
+]
+exit_code = 42
+
 # ---------------------------------------------------------------------------
 # Nested module member access (RUE-122 regression coverage).
 #

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -816,6 +816,19 @@ pub struct AmbiguousModuleData {
     pub dir_module: String,
 }
 
+/// Payload for [`ErrorKind::PrivateUnqualifiedAccess`], boxed to keep
+/// `ErrorKind` within its 64-byte size budget (three inline `String`s
+/// exceed it).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrivateUnqualifiedAccessData {
+    /// The kind of item ("function", "struct", "constant").
+    pub item_kind: String,
+    /// The item's name as written at the reference site.
+    pub name: String,
+    /// The path of the file that defines the private item.
+    pub defining_file: String,
+}
+
 /// The kind of compilation error.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ErrorKind {
@@ -1119,8 +1132,8 @@ pub enum ErrorKind {
     StdLibNotFound,
     #[error("{item_kind} `{name}` is private")]
     PrivateMemberAccess { item_kind: String, name: String },
-    #[error("function `{name}` is private (defined in `{defining_file}`)")]
-    PrivateUnqualifiedAccess { name: String, defining_file: String },
+    #[error("{} `{}` is private (defined in `{}`)", .0.item_kind, .0.name, .0.defining_file)]
+    PrivateUnqualifiedAccess(Box<PrivateUnqualifiedAccessData>),
     #[error("module `{module_name}` has no member `{member_name}`")]
     UnknownModuleMember {
         module_name: String,
@@ -1290,7 +1303,7 @@ impl ErrorKind {
             ErrorKind::AmbiguousModule { .. } => ErrorCode::AMBIGUOUS_MODULE,
             ErrorKind::StdLibNotFound => ErrorCode::STD_LIB_NOT_FOUND,
             ErrorKind::PrivateMemberAccess { .. } => ErrorCode::PRIVATE_MEMBER_ACCESS,
-            ErrorKind::PrivateUnqualifiedAccess { .. } => ErrorCode::PRIVATE_UNQUALIFIED_ACCESS,
+            ErrorKind::PrivateUnqualifiedAccess(_) => ErrorCode::PRIVATE_UNQUALIFIED_ACCESS,
             ErrorKind::UnknownModuleMember { .. } => ErrorCode::UNKNOWN_MODULE_MEMBER,
 
             // Literal/operator errors (E0800-E0899)

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -347,3 +347,142 @@ fn internal_fn() -> i32 {
 """ }
 pass_aux_files = true
 exit_code = 42
+
+# =============================================================================
+# Unqualified Cross-Directory Access: Structs and Constants (RUE-183)
+# =============================================================================
+# The uniform privacy rule (10.3:7) covers every item kind, not just
+# functions: naming a private struct (annotation or literal) or reading a
+# private constant from another directory is E0460, imported or flat-listed.
+
+[[case]]
+name = "cross_dir_unqualified_private_struct_error"
+spec = ["10.3:7"]
+description = "Unqualified struct literal + annotation naming a private struct of an imported module in another directory is rejected"
+source = """
+const defs = @import("subdir/defs");
+
+fn main() -> i32 {
+    let p: Point = Point { x: 40, y: 2 };
+    p.x + p.y
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+struct Point {
+    x: i32,
+    y: i32,
+}
+""" }
+compile_fail = true
+error_contains = "struct `Point` is private (defined in"
+
+[[case]]
+name = "cross_dir_unqualified_private_const_error"
+spec = ["10.3:7"]
+description = "Unqualified read of a private constant of an imported module in another directory is rejected"
+source = """
+const defs = @import("subdir/defs");
+
+fn main() -> i32 {
+    LIMIT
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+const LIMIT: i32 = 42;
+""" }
+compile_fail = true
+error_contains = "constant `LIMIT` is private (defined in"
+
+[[case]]
+name = "flat_multifile_unqualified_private_struct_error"
+spec = ["10.3:7", "10.3:8"]
+description = "Uniform privacy: a private struct in a never-imported, explicitly listed file in another directory is not nameable unqualified"
+source = """
+fn main() -> i32 {
+    let p: Point = Point { x: 40, y: 2 };
+    p.x + p.y
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+struct Point {
+    x: i32,
+    y: i32,
+}
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "struct `Point` is private (defined in"
+
+[[case]]
+name = "flat_multifile_unqualified_private_const_error"
+spec = ["10.3:7", "10.3:8"]
+description = "Uniform privacy: a private constant in a never-imported, explicitly listed file in another directory is not readable unqualified"
+source = """
+fn main() -> i32 {
+    LIMIT
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+const LIMIT: i32 = 42;
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "constant `LIMIT` is private (defined in"
+
+[[case]]
+name = "cross_dir_const_initializer_private_const_error"
+spec = ["10.3:7"]
+description = "A constant initializer reading a private constant from another directory is rejected too"
+source = """
+const X: i32 = LIMIT;
+
+fn main() -> i32 {
+    X
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+const LIMIT: i32 = 42;
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "constant `LIMIT` is private (defined in"
+
+[[case]]
+name = "flat_multifile_unqualified_pub_struct_and_const_allowed"
+spec = ["10.3:8", "10.5:2"]
+description = "The flat namespace still resolves pub structs and constants across directories without imports"
+source = """
+fn main() -> i32 {
+    let p: Point = Point { x: 30, y: 2 };
+    p.x + p.y + BONUS
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+pub struct Point {
+    x: i32,
+    y: i32,
+}
+pub const BONUS: i32 = 10;
+""" }
+pass_aux_files = true
+exit_code = 42
+
+[[case]]
+name = "flat_multifile_same_dir_private_struct_and_const_allowed"
+spec = ["10.3:2", "10.3:8"]
+description = "Intra-directory visibility (ADR-0026) is unchanged: private structs and constants in another listed file in the same directory are usable unqualified"
+source = """
+fn main() -> i32 {
+    let p: Point = Point { x: 30, y: 2 };
+    p.x + p.y + BONUS
+}
+"""
+aux_files = { "defs.rue" = """
+struct Point {
+    x: i32,
+    y: i32,
+}
+const BONUS: i32 = 10;
+""" }
+pass_aux_files = true
+exit_code = 42

--- a/docs/spec/src/10-modules/03-visibility.md
+++ b/docs/spec/src/10-modules/03-visibility.md
@@ -62,29 +62,40 @@ fn main() -> i32 {
 Visibility is uniform across every multi-file compilation: an item is
 visible outside its defining directory if and only if it is `pub`,
 whether its defining file was loaded via `@import` or only listed
-explicitly in the compilation. It is a compile-time error to call a
-private function by its unqualified name from a source file in a
-different directory than the function's defining file (error E0460).
+explicitly in the compilation. It is a compile-time error to reference a
+private item by its unqualified name from a source file in a different
+directory than the item's defining file (error E0460). This covers every
+form of unqualified reference: calling a private function, naming a
+private struct (in a type annotation, a signature, or a struct literal),
+and reading a private constant — including from another constant's
+initializer.
 
 {{ rule(id="10.3:8", cat="normative") }}
 
 The transitional flat namespace (10.5:2) affects only *name resolution*:
 an unqualified reference may resolve to an item in any file of the
 compilation without an import, but the visibility rules of this section
-apply regardless of how the item's file was loaded. A `pub` function in
-another directory is therefore callable unqualified without any import;
+apply regardless of how the item's file was loaded. A `pub` item in
+another directory is therefore usable unqualified without any import;
 a private one is not.
 
 {{ rule(id="10.3:9", cat="example") }}
 
 ```rue
 // sub/lib.rue
-fn secret() -> i32 { 99 }   // private to sub/
+fn secret() -> i32 { 99 }       // private to sub/
 pub fn open() -> i32 { 7 }
+struct Hidden { n: i32, }       // private to sub/
+pub struct Shared { n: i32, }
+const LIMIT: i32 = 8;           // private to sub/
+pub const MAX: i32 = 16;
 
 // main.rue — a different directory; no import needed (10.5:2)
 fn main() -> i32 {
-    // secret()              // error E0460: private to sub/lib.rue
-    open()                   // OK: `open` is pub
+    // secret()                  // error E0460: private to sub/lib.rue
+    // let h = Hidden { n: 1 };  // error E0460: private to sub/lib.rue
+    // let l = LIMIT;            // error E0460: private to sub/lib.rue
+    let s = Shared { n: MAX };   // OK: `Shared` and `MAX` are pub
+    open() + s.n
 }
 ```


### PR DESCRIPTION
Cycle-17 worker integration (verified by hand at integration time).

**RUE-183:** the uniform-privacy rule (#989) was enforced only at function-call sites, so non-pub **structs** and **consts** remained fully usable cross-directory — literals, type annotations, const reads, flat-listed or `@import`ed. Every unqualified reference form is now guarded: type resolution, struct literals, the VarRef const fallback, and two const-initializer paths (including `eval_const_initializer`'s direct-alias arm, `const X = LIMIT;`, which short-circuits before the comptime engine — found only by testing that exact shape). E0460 messages now name the item kind; no new error codes.

Integration verification by execution: struct / const / const-alias each E0460 with correct file attribution; pub controls compile and run; `m.LIMIT` and `m.secret()` still E0706; same-file private use unaffected. Spec 10.3:7–9 extended, +7 spec cases, +7 CLI cases, traceability 575/575, full `./test.sh` green.

Worker discovery to be filed as its own issue: **enums have the identical hole**.

Fixes RUE-183

🤖 Generated with [Claude Code](https://claude.com/claude-code)