### PR TITLE
Move/linear enforcement: path-precise builtin receivers; linear values can't leak through params, temporaries, or arrays

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,9 +95,10 @@ rue main.rue utils.rue lib.rue -o program
 
 **Key semantics:**
 - All top-level names resolve across files without imports (flat namespace),
-  but privacy is uniform (spec 10.3:7): a function is callable outside its
-  defining directory only if `pub`, whether its file is imported or just
-  listed (E0460 otherwise; through a module object it's E0706)
+  but privacy is uniform (spec 10.3:7): an item — function, struct, or
+  constant — is usable outside its defining directory only if `pub`, whether
+  its file is imported or just listed (E0460 otherwise; through a module
+  object it's E0706)
 - Duplicate definitions (same name in multiple files) cause a compile error
 - `main()` must exist in exactly one file
 - Files are parsed in parallel, then merged for semantic analysis

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1405,7 +1405,15 @@ impl<'a> Sema<'a> {
             local_strings,
             ref_fns,
             ref_meths,
-        ) = self.analyze_function(infer_ctx, Type::UNIT, &param_info, body)?;
+        ) = self.analyze_function_internal(
+            infer_ctx,
+            Type::UNIT,
+            &param_info,
+            body,
+            None,
+            None,
+            /* is_destructor */ true,
+        )?;
 
         reject_self_move_in_destructor(&air, full_name)?;
 
@@ -1451,7 +1459,7 @@ impl<'a> Sema<'a> {
         HashSet<Spur>,
         HashSet<(StructId, Spur)>,
     )> {
-        self.analyze_function_internal(infer_ctx, return_type, params, body, None, None)
+        self.analyze_function_internal(infer_ctx, return_type, params, body, None, None, false)
     }
 
     /// Internal function analysis with optional type substitutions.
@@ -1459,6 +1467,13 @@ impl<'a> Sema<'a> {
     /// When `type_subst` is provided (for specialized generic functions), it populates
     /// `comptime_type_vars` so that type parameters can be resolved in struct initialization
     /// (e.g., `P { x: 1, y: 2 }` where `P` is a type parameter).
+    ///
+    /// `is_destructor` exempts the function from the linear-parameter
+    /// must-consume check: a destructor's `self` is disposed of by the drop
+    /// glue after the body runs, and moving it out is rejected anyway
+    /// (RUE-139), so requiring consumption would make destructors on linear
+    /// types impossible to write.
+    #[allow(clippy::too_many_arguments)]
     fn analyze_function_internal(
         &mut self,
         infer_ctx: &InferenceContext,
@@ -1467,6 +1482,7 @@ impl<'a> Sema<'a> {
         body: InstRef,
         type_subst: Option<&std::collections::HashMap<Spur, Type>>,
         value_subst: Option<&std::collections::HashMap<Spur, ConstValue>>,
+        is_destructor: bool,
     ) -> CompileResult<(
         Air,
         u32,
@@ -1569,6 +1585,37 @@ impl<'a> Sema<'a> {
         // Analyze the body expression, emitting AIR with resolved types
         let body_result = self.analyze_inst(&mut air, body, &mut ctx)?;
 
+        // Linear parameters: the callee owns its pass-by-value parameters and
+        // drops them at exit unless moved out (RUE-61), so a by-value
+        // parameter carrying a linear value must be consumed by the body on
+        // every path — exactly like a linear local (RUE-176). Inout/borrow
+        // parameters stay owned by the caller and comptime parameters are
+        // substituted away; destructors are exempt (see the doc comment).
+        if !is_destructor {
+            for p in &param_vec {
+                if p.mode != RirParamMode::Normal || p.is_comptime {
+                    continue;
+                }
+                if !self.type_carries_linear(p.ty) {
+                    continue;
+                }
+                let state = ctx.moved_vars.get(&p.name);
+                if !state.is_some_and(|s| s.full_move_on_all_paths) {
+                    let name = self.interner.resolve(&p.name);
+                    let err = linear_not_consumed_error(
+                        name,
+                        self.rir.get(body).span,
+                        state.and_then(|s| s.full_move),
+                    )
+                    .with_note(format!(
+                        "parameter '{name}' is passed by value, so this function owns it \
+                         and must consume it (pass it on, return it, or destructure it)"
+                    ));
+                    return Err(self.attach_infectious_linear_note(err, p.ty));
+                }
+            }
+        }
+
         // Add implicit return only if body doesn't already diverge (e.g., explicit return)
         if body_result.ty != Type::NEVER {
             air.add_inst(AirInst {
@@ -1618,7 +1665,15 @@ impl<'a> Sema<'a> {
         // For specialized functions, we need to populate comptime_type_vars with the
         // type substitutions so that references to type parameters (like `P { ... }`)
         // can be resolved in the function body.
-        self.analyze_function_internal(infer_ctx, return_type, params, body, Some(type_subst), None)
+        self.analyze_function_internal(
+            infer_ctx,
+            return_type,
+            params,
+            body,
+            Some(type_subst),
+            None,
+            false,
+        )
     }
 
     /// Analyze a method body with `Self` type resolution.
@@ -1656,6 +1711,7 @@ impl<'a> Sema<'a> {
             body,
             Some(&type_subst),
             Some(captured_comptime_values),
+            false,
         )
     }
 
@@ -2713,6 +2769,11 @@ impl<'a> Sema<'a> {
             None
         };
 
+        // Snapshot the receiver root's move state before analyzing the
+        // receiver expression: builtin ByRef/ByMutRef methods restore it to
+        // undo the move the receiver analysis records (see ReceiverInfo).
+        let receiver_move_state_before = receiver_var.and_then(|v| ctx.moved_vars.get(&v).cloned());
+
         // Analyze the receiver expression
         let receiver_result = self.analyze_inst(air, receiver, ctx)?;
         let receiver_type = receiver_result.ty;
@@ -2749,6 +2810,7 @@ impl<'a> Sema<'a> {
             let receiver_info = ReceiverInfo {
                 result: receiver_result,
                 var: receiver_var,
+                move_state_before: receiver_move_state_before,
                 storage: receiver_storage,
             };
             return self.analyze_builtin_method(air, ctx, &method_ctx, receiver_info, &args);
@@ -4099,11 +4161,23 @@ impl<'a> Sema<'a> {
         match method.receiver_mode {
             ReceiverMode::ByRef | ReceiverMode::ByMutRef => {
                 // Borrow (ByRef) / mutation (ByMutRef) semantics - "unmove"
-                // the variable since it's not consumed, and cancel the move
+                // the receiver since it's not consumed, and cancel the move
                 // marker the receiver analysis emitted so drop elaboration
                 // doesn't treat this borrow as a move.
+                //
+                // Restore the pre-receiver snapshot instead of removing the
+                // whole entry: earlier moves of sibling paths (`consume(w.s);
+                // w.t.len()`) must stay recorded, or a later use of the moved
+                // sibling compiles and double-frees (RUE-33).
                 if let Some(var_symbol) = receiver.var {
-                    ctx.moved_vars.remove(&var_symbol);
+                    match receiver.move_state_before.clone() {
+                        Some(state) => {
+                            ctx.moved_vars.insert(var_symbol, state);
+                        }
+                        None => {
+                            ctx.moved_vars.remove(&var_symbol);
+                        }
+                    }
                 }
                 air.cancel_move_marker(receiver.result.air_ref);
             }
@@ -4390,8 +4464,11 @@ impl<'a> Sema<'a> {
                 continue;
             };
 
-            // Only check linear types
-            if !self.is_type_linear(local.ty) {
+            // Only check types that carry a linear value: linear structs
+            // themselves, and arrays whose elements carry one (an array of
+            // linear values must be consumed as a whole; dropping it would
+            // silently drop every element).
+            if !self.type_carries_linear(local.ty) {
                 continue;
             }
 
@@ -4411,13 +4488,44 @@ impl<'a> Sema<'a> {
         Ok(())
     }
 
+    /// Reject a discarded expression value that carries a linear value
+    /// (RUE-176): an expression statement (`make_linear();`) or a loop body
+    /// result is dropped without being consumed, which linearity forbids.
+    ///
+    /// `inst_ref` is the RIR instruction whose span the error points at.
+    pub(crate) fn reject_discarded_linear_value(
+        &self,
+        ty: Type,
+        inst_ref: InstRef,
+    ) -> CompileResult<()> {
+        if !self.type_carries_linear(ty) {
+            return Ok(());
+        }
+        let err = CompileError::new(
+            ErrorKind::LinearValueDiscarded {
+                type_name: ty.safe_name_with_pool(Some(&self.type_pool)),
+            },
+            self.rir.get(inst_ref).span,
+        )
+        .with_help("bind the value with `let` and consume it, or pass it to a consumer");
+        Err(self.attach_infectious_linear_note(err, ty))
+    }
+
     /// If `ty` is a struct that is linear only because a field made it so
     /// (infectious linearity, RUE-40), attach a note explaining the cause.
+    /// For an array carrying linear elements, note that the array must be
+    /// consumed as a whole.
     pub(crate) fn attach_infectious_linear_note(
         &self,
         err: rue_error::CompileError,
         ty: Type,
     ) -> rue_error::CompileError {
+        if let TypeKind::Array(_) = ty.kind() {
+            return err.with_note(
+                "this is an array whose elements carry linear values; \
+                 the array must be consumed as a whole",
+            );
+        }
         let Some(struct_id) = ty.as_struct() else {
             return err;
         };

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1932,6 +1932,18 @@ impl<'a> Sema<'a> {
         // gathering (RUE-171); materialize it directly — the initializer is
         // never re-analyzed at use sites.
         if let Some(const_info) = self.constants.get(&name) {
+            // Privacy (E0460, RUE-183): the constants table is global, so an
+            // unqualified reference can resolve to a private constant defined
+            // in another directory — reject it, privacy is uniform across
+            // item kinds (spec 10.3:1, 10.3:7). The declaration span's file
+            // is the constant's defining file.
+            self.check_unqualified_visibility(
+                "constant",
+                name_str,
+                const_info.span.file_id,
+                const_info.is_pub,
+                span,
+            )?;
             let (data, ty) = Self::materialize_const_value(const_info.value, const_info.ty);
             let air_ref = air.add_inst(AirInst { data, ty, span });
             return Ok(AnalysisResult::new(air_ref, ty));
@@ -1939,14 +1951,25 @@ impl<'a> Sema<'a> {
 
         // Check if this is a type name (for comptime type parameters)
         // Try to resolve it as a type - if successful, emit a TypeConst instruction
-        if let Ok(resolved_type) = self.resolve_type(name, span) {
-            // This is a type name being used as a value (e.g., `i32` passed to `comptime T: type`)
-            let air_ref = air.add_inst(AirInst {
-                data: AirInstData::TypeConst(resolved_type),
-                ty: Type::COMPTIME_TYPE,
-                span,
-            });
-            return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
+        match self.resolve_type(name, span) {
+            Ok(resolved_type) => {
+                // This is a type name being used as a value (e.g., `i32` passed to `comptime T: type`)
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::TypeConst(resolved_type),
+                    ty: Type::COMPTIME_TYPE,
+                    span,
+                });
+                return Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE));
+            }
+            // The name IS a known type, but a private one from another
+            // directory (RUE-183): report the privacy error rather than
+            // falling through to a misleading "undefined variable".
+            Err(e) if matches!(e.kind, ErrorKind::PrivateUnqualifiedAccess(_)) => {
+                return Err(e);
+            }
+            // Any other resolution failure: not a type name, keep falling
+            // through to the undefined-variable error below.
+            Err(_) => {}
         }
 
         // Not a parameter, local, type, or constant - undefined variable
@@ -2169,10 +2192,25 @@ impl<'a> Sema<'a> {
                 }
             }
         } else {
-            *self
+            let struct_id = *self
                 .structs
                 .get(&type_name)
-                .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.to_string()), span)?
+                .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.to_string()), span)?;
+            // Privacy (E0460, RUE-183): a struct literal names the type
+            // unqualified, so a private struct from another directory is not
+            // constructible here — privacy is uniform across item kinds
+            // (spec 10.3:1, 10.3:7). The comptime-type-variable branch above
+            // is exempt: the type value arrived through a binding (e.g. a
+            // `pub` comptime function's return), not by naming the struct.
+            let def = self.type_pool.struct_def(struct_id);
+            self.check_unqualified_visibility(
+                "struct",
+                type_name_str,
+                def.file_id,
+                def.is_pub,
+                span,
+            )?;
+            struct_id
         };
 
         // Get struct def (returns owned copy from pool)
@@ -3423,7 +3461,8 @@ impl<'a> Sema<'a> {
         // uniform in every multi-file compilation, imports or not (spec
         // 10.3:7), so the flat namespace resolves the name but the callee
         // must be `pub` (or in the caller's directory).
-        self.check_unqualified_call_visibility(
+        self.check_unqualified_visibility(
+            "function",
             &fn_name_str,
             fn_info.file_id,
             fn_info.is_pub,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -822,6 +822,11 @@ impl<'a> Sema<'a> {
         ctx.loop_depth -= 1;
         ctx.pop_scope();
 
+        // A while loop discards its body's result value on every iteration;
+        // discarding a value that carries a linear value would implicitly
+        // drop it (RUE-176).
+        self.reject_discarded_linear_value(body_result.ty, body)?;
+
         // Loop back-edge move check: if the loop changed any move state,
         // re-run the analysis once with the post-body state as the starting
         // state. Any use of a value moved by a previous iteration then errors.
@@ -877,6 +882,11 @@ impl<'a> Sema<'a> {
         let has_break = ctx.loop_break_stack.pop().unwrap_or(false);
         ctx.loop_depth -= 1;
         ctx.pop_scope();
+
+        // The loop discards its body's result value on every iteration;
+        // discarding a value that carries a linear value would implicitly
+        // drop it (RUE-176).
+        self.reject_discarded_linear_value(body_result.ty, body)?;
 
         // Loop back-edge move check (see analyze_while_loop for details).
         // Note: like Rust, this is conservative - a body that unconditionally
@@ -1462,6 +1472,10 @@ impl<'a> Sema<'a> {
             if is_last {
                 last_result = Some(result);
             } else {
+                // A non-final statement's value is discarded. Discarding a
+                // value that carries a linear value would implicitly drop it
+                // (`make_linear();` — RUE-176), which linearity forbids.
+                self.reject_discarded_linear_value(result.ty, inst_ref)?;
                 statements.push(result.air_ref);
             }
         }

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -737,7 +737,20 @@ impl Sema<'_> {
                 //    access, RUE-160) and was exponential for const chains.
                 //    Module-typed constants never appear in this table
                 //    (module bindings live in `Sema::module_bindings`).
+                //    Privacy applies here too (E0460, RUE-183): the table is
+                //    global, so a const initializer in one directory could
+                //    otherwise read a private constant from another. The
+                //    VarRef's own span locates the referencing file;
+                //    speculative callers (`try_evaluate_const*`) swallow the
+                //    error and defer to runtime analysis, which re-checks.
                 if let Some(info) = self.constants.get(name) {
+                    self.check_unqualified_visibility(
+                        "constant",
+                        self.interner.resolve(name),
+                        info.span.file_id,
+                        info.is_pub,
+                        span,
+                    )?;
                     return Ok(Some(info.value));
                 }
                 // 5. Type names used as values (e.g. `Point` in

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -593,6 +593,13 @@ pub(crate) struct ReceiverInfo {
     /// The root variable symbol if the receiver is a variable reference.
     /// Used to track moves and "unmove" for borrow semantics.
     pub var: Option<Spur>,
+    /// The move state of `var` captured BEFORE the receiver expression was
+    /// analyzed (`None` = the variable had no move state). ByRef/ByMutRef
+    /// methods restore this snapshot to undo exactly the move the receiver
+    /// analysis recorded — a whole-map `remove` would also erase earlier,
+    /// unrelated moves of sibling fields (`consume(w.s); w.t.len()` must not
+    /// forget that `w.s` is moved — RUE-33).
+    pub move_state_before: Option<VariableMoveState>,
     /// Storage location for mutation methods that need to write back.
     /// Only set when the receiver is a mutable lvalue and the method mutates.
     pub storage: Option<StringReceiverStorage>,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1285,6 +1285,17 @@ impl<'a> Sema<'a> {
                     return Ok(ConstInit::Module(binding.ty));
                 }
                 if let Some(info) = self.constants.get(&name) {
+                    // Privacy (E0460, RUE-183): the value-constant table is
+                    // global, so this alias could otherwise read a private
+                    // constant from another directory. The initializer's own
+                    // span locates the referencing file.
+                    self.check_unqualified_visibility(
+                        "constant",
+                        self.interner.resolve(&name),
+                        info.span.file_id,
+                        info.is_pub,
+                        span,
+                    )?;
                     return Ok(ConstInit::Value(info.value));
                 }
                 // Not a constant: let the comptime engine decide (it rejects

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -143,6 +143,20 @@ impl<'a> Sema<'a> {
         }
 
         if let Some(&struct_id) = self.structs.get(&type_sym) {
+            // Privacy (E0460, RUE-183): an unqualified type reference must
+            // not reach a private struct defined in another directory —
+            // privacy is uniform across item kinds (spec 10.3:1, 10.3:7).
+            // Spans here are always the reference site (annotation,
+            // signature, struct literal), so `span.file_id` is the
+            // referencing file.
+            let struct_def = self.type_pool.struct_def(struct_id);
+            self.check_unqualified_visibility(
+                "struct",
+                type_name,
+                struct_def.file_id,
+                struct_def.is_pub,
+                span,
+            )?;
             Ok(Type::new_struct(struct_id))
         } else if let Some(&enum_id) = self.enums.get(&type_sym) {
             Ok(Type::new_enum(enum_id))

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -55,47 +55,56 @@ impl Sema<'_> {
         }
     }
 
-    /// Check that an *unqualified* call may reach the callee (RUE-37,
-    /// RUE-180).
+    /// Check that an *unqualified* reference may reach the item (RUE-37,
+    /// RUE-180, RUE-183).
     ///
-    /// All loaded files share one flat global function namespace for *name
+    /// All loaded files share one flat global namespace for *name
     /// resolution* (spec 10.5:2, transitional), but privacy is uniform in
-    /// every multi-file compilation, imports or not (spec 10.3:7):
+    /// every multi-file compilation, imports or not (spec 10.3:7), and it
+    /// covers every item kind — functions, structs, and constants alike
+    /// (spec 10.3:1):
     ///
-    /// - If the callee is accessible per [`Sema::is_accessible`] (it is
-    ///   `pub`, or the caller is in the callee's directory — ADR-0026
-    ///   intra-directory visibility), the call is fine.
-    /// - Otherwise the call is an error (E0460), naming the callee's
+    /// - If the item is accessible per [`Sema::is_accessible`] (it is
+    ///   `pub`, or the reference is in the item's directory — ADR-0026
+    ///   intra-directory visibility), the reference is fine.
+    /// - Otherwise the reference is an error (E0460), naming the item's
     ///   defining file. Whether that file was loaded via `@import` or merely
     ///   listed on the command line makes no difference.
-    pub(crate) fn check_unqualified_call_visibility(
+    ///
+    /// `item_kind` names the kind in the diagnostic ("function", "struct",
+    /// "constant").
+    pub(crate) fn check_unqualified_visibility(
         &self,
-        fn_name: &str,
-        callee_file_id: FileId,
+        item_kind: &str,
+        name: &str,
+        defining_file_id: FileId,
         is_pub: bool,
         span: rue_span::Span,
     ) -> CompileResult<()> {
-        if self.is_accessible(span.file_id, callee_file_id, is_pub) {
+        if self.is_accessible(span.file_id, defining_file_id, is_pub) {
             return Ok(());
         }
 
         // `is_accessible` is permissive when either file path is unknown
-        // (single-file mode, synthetic items), so the callee's path is
+        // (single-file mode, synthetic items), so the item's path is
         // always known here.
         let defining_file = self
-            .get_file_path(callee_file_id)
+            .get_file_path(defining_file_id)
             .unwrap_or("<unknown>")
             .to_string();
 
         Err(CompileError::new(
-            ErrorKind::PrivateUnqualifiedAccess {
-                name: fn_name.to_string(),
-                defining_file,
-            },
+            ErrorKind::PrivateUnqualifiedAccess(Box::new(
+                rue_error::PrivateUnqualifiedAccessData {
+                    item_kind: item_kind.to_string(),
+                    name: name.to_string(),
+                    defining_file,
+                },
+            )),
             span,
         )
         .with_help(format!(
-            "`{fn_name}` is not marked `pub`; private items are only visible within their defining directory"
+            "`{name}` is not marked `pub`; private items are only visible within their defining directory"
         )))
     }
 

--- a/crates/rue-cli-tests/cases/borrow_sibling_moves.toml
+++ b/crates/rue-cli-tests/cases/borrow_sibling_moves.toml
@@ -1,0 +1,68 @@
+# Borrows must not erase sibling move records (RUE-33).
+#
+# A builtin ByRef method call (`w.t.len()`) used to "unmove" its receiver by
+# removing the root variable's ENTIRE move-state entry, forgetting that a
+# SIBLING field (`w.s`) had already been moved out. The later re-use of the
+# moved sibling then compiled and double-freed at runtime. The fix restores
+# the pre-receiver snapshot of the root's move state instead, undoing exactly
+# the move the receiver analysis recorded.
+#
+# Site 2 (a sibling field passed as a `borrow` call argument) was fixed
+# earlier and is pinned here too.
+
+[section]
+id = "cli.borrow_sibling_moves"
+name = "Borrows preserve sibling move records"
+description = "By-ref receivers and borrow arguments must not erase earlier sibling-field moves (RUE-33)."
+
+[[case]]
+name = "byref_method_on_sibling_keeps_move_record"
+description = "w.t.len() between two consume(w.s) calls must not resurrect w.s (double free)."
+files = [{ path = "main.rue", source = """
+struct Wrap { s: String, t: String }
+fn consume(s: String) -> i32 { 1 }
+fn main() -> i32 {
+    let w = Wrap { s: "hello", t: "world" };
+    let _a = consume(w.s);
+    let _n = w.t.len();
+    let _b = consume(w.s);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "use of moved value 'w.s'"]
+
+[[case]]
+name = "borrow_call_arg_on_sibling_keeps_move_record"
+description = "Site 2 regression pin: peek(borrow w.t) must not resurrect the moved w.s."
+files = [{ path = "main.rue", source = """
+struct Wrap { s: String, t: String }
+fn consume(s: String) -> i32 { 1 }
+fn peek(borrow s: String) -> i32 { 2 }
+fn main() -> i32 {
+    let w = Wrap { s: "hello", t: "world" };
+    let _a = consume(w.s);
+    let _n = peek(borrow w.t);
+    let _b = consume(w.s);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "use of moved value 'w.s'"]
+
+[[case]]
+name = "byref_method_receiver_stays_usable_control"
+description = "Control: a by-ref method does not move its receiver; sibling move alone still errors without the len() call."
+files = [{ path = "main.rue", source = """
+struct Wrap { s: String, t: String }
+fn consume(s: String) -> i32 { 20 }
+fn main() -> i32 {
+    let w = Wrap { s: "hello", t: "world" };
+    let a = consume(w.s);
+    let n = w.t.len();
+    let m = w.t.len();
+    let b = consume(w.t);
+    if n == 5 { if m == 5 { a + b + 2 } else { 1 } } else { 0 }
+}
+""" }]
+exit_code = 42

--- a/crates/rue-cli-tests/cases/linear_must_consume.toml
+++ b/crates/rue-cli-tests/cases/linear_must_consume.toml
@@ -142,3 +142,74 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 23
+
+# ---------------------------------------------------------------------------
+# RUE-176: enforcement holes - linear params, discarded temporaries, arrays
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "linear_param_unconsumed_in_callee_rejected"
+description = "A pass-by-value linear parameter silently dropped by the callee is rejected (RUE-176)."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn f(m: MustUse) -> i32 { 0 }
+fn main() -> i32 {
+    let m = MustUse { value: 1 };
+    f(m)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0406", "linear value 'm' must be consumed"]
+
+[[case]]
+name = "linear_param_destructure_consumes_control"
+description = "Control: the canonical consumer destructures its parameter, which counts as consumption."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn consume(m: MustUse) -> i32 { m.value }
+fn main() -> i32 {
+    consume(MustUse { value: 42 })
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "linear_temporary_discarded_rejected"
+description = "A linear value produced and discarded by an expression statement is rejected (RUE-176)."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn make_linear() -> MustUse { MustUse { value: 1 } }
+fn main() -> i32 {
+    make_linear();
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0478", "carries a linear value and must be consumed"]
+
+[[case]]
+name = "linear_array_dropped_rejected"
+description = "An array of linear values that is never consumed is rejected, not just warned (RUE-176)."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn make_linear() -> MustUse { MustUse { value: 1 } }
+fn main() -> i32 {
+    let a = [make_linear(), make_linear()];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0406", "linear value 'a' must be consumed"]
+
+[[case]]
+name = "linear_plain_local_dropped_control"
+description = "Control (E0406 baseline): a plain unconsumed linear local was already rejected before RUE-176."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn main() -> i32 {
+    let m = MustUse { value: 1 };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0406", "linear value 'm' must be consumed"]

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -713,6 +713,149 @@ fn secret() -> i32 {
 ]
 exit_code = 42
 
+# Structs and constants obey the same uniform rule (RUE-183): naming a
+# private struct (annotation or literal) or reading a private constant from
+# another directory is E0460, whether the file was imported or only listed.
+
+[[case]]
+name = "private_struct_cross_dir_unqualified_rejected"
+description = "Unqualified struct literal/annotation naming a private struct in another directory is E0460 (RUE-183) — fn-only privacy is not enough."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let p: Point = Point { x: 40, y: 2 };
+    p.x + p.y
+}
+""" },
+    { path = "sub/lib.rue", source = """
+struct Point {
+    x: i32,
+    y: i32,
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "struct `Point` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "private_const_cross_dir_unqualified_rejected"
+description = "Unqualified read of a private constant in another directory is E0460 (RUE-183)."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    LIMIT
+}
+""" },
+    { path = "sub/lib.rue", source = """
+const LIMIT: i32 = 99;
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "constant `LIMIT` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "flat_multifile_private_struct_cross_dir_rejected"
+description = "Uniform privacy for structs (RUE-183): a private struct in a never-imported listed file is not nameable cross-directory."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let p: Point = Point { x: 40, y: 2 };
+    p.x + p.y
+}
+""" },
+    { path = "sub/lib.rue", source = """
+struct Point {
+    x: i32,
+    y: i32,
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "struct `Point` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "flat_multifile_private_const_cross_dir_rejected"
+description = "Uniform privacy for constants (RUE-183): a private constant in a never-imported listed file is not readable cross-directory."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    LIMIT
+}
+""" },
+    { path = "sub/lib.rue", source = """
+const LIMIT: i32 = 99;
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "constant `LIMIT` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "flat_multifile_private_const_in_const_init_rejected"
+description = "A constant initializer is a reference site too (RUE-183): `const X = LIMIT;` reading a private cross-directory constant is E0460."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+const X: i32 = LIMIT;
+
+fn main() -> i32 {
+    X
+}
+""" },
+    { path = "sub/lib.rue", source = """
+const LIMIT: i32 = 99;
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "constant `LIMIT` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "flat_multifile_pub_struct_and_const_cross_dir_allowed"
+description = "Positive control (RUE-183): pub structs and constants in another never-imported directory remain usable unqualified (spec 10.3:8)."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let p: Point = Point { x: 30, y: 2 };
+    p.x + p.y + BONUS
+}
+""" },
+    { path = "sub/lib.rue", source = """
+pub struct Point {
+    x: i32,
+    y: i32,
+}
+pub const BONUS: i32 = 10;
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "flat_multifile_private_struct_and_const_same_dir_allowed"
+description = "Control (RUE-183): intra-directory visibility is unchanged — private structs and constants in another listed file in the SAME directory are usable."
+args = ["main.rue", "lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let p: Point = Point { x: 30, y: 2 };
+    p.x + p.y + BONUS
+}
+""" },
+    { path = "lib.rue", source = """
+struct Point {
+    x: i32,
+    y: i32,
+}
+const BONUS: i32 = 10;
+""" },
+]
+exit_code = 42
+
 # ---------------------------------------------------------------------------
 # Nested module member access (RUE-122 regression coverage).
 #

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -144,6 +144,8 @@ impl ErrorCode {
     // 462-473 are reserved by in-flight work.
     pub const LINEAR_FIELD_DROPPED_BY_DESTRUCTURE: Self = Self(474);
     pub const CONST_MISSING_TYPE_ANNOTATION: Self = Self(475);
+    // 476-477 are reserved by in-flight work.
+    pub const LINEAR_VALUE_DISCARDED: Self = Self(478);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -926,6 +928,10 @@ pub enum ErrorKind {
     /// Linear value was consumed on some control-flow paths but not all of them
     #[error("linear value '{0}' is not consumed on all paths")]
     LinearValueNotConsumedOnAllPaths(String),
+    /// A discarded expression value (e.g. an expression statement or a loop
+    /// body result) carries a linear value, which would be implicitly dropped
+    #[error("discarded value of type '{type_name}' carries a linear value and must be consumed")]
+    LinearValueDiscarded { type_name: String },
     /// Linear struct cannot be marked @copy
     #[error("linear struct '{0}' cannot be marked @copy")]
     LinearStructCopy(String),
@@ -1241,6 +1247,7 @@ impl ErrorKind {
             ErrorKind::LinearValueNotConsumedOnAllPaths(_) => {
                 ErrorCode::LINEAR_VALUE_NOT_CONSUMED_ON_ALL_PATHS
             }
+            ErrorKind::LinearValueDiscarded { .. } => ErrorCode::LINEAR_VALUE_DISCARDED,
             ErrorKind::LinearStructCopy(_) => ErrorCode::LINEAR_STRUCT_COPY,
             ErrorKind::LinearFieldDroppedByDestructure(_) => {
                 ErrorCode::LINEAR_FIELD_DROPPED_BY_DESTRUCTURE

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -816,6 +816,19 @@ pub struct AmbiguousModuleData {
     pub dir_module: String,
 }
 
+/// Payload for [`ErrorKind::PrivateUnqualifiedAccess`], boxed to keep
+/// `ErrorKind` within its 64-byte size budget (three inline `String`s
+/// exceed it).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PrivateUnqualifiedAccessData {
+    /// The kind of item ("function", "struct", "constant").
+    pub item_kind: String,
+    /// The item's name as written at the reference site.
+    pub name: String,
+    /// The path of the file that defines the private item.
+    pub defining_file: String,
+}
+
 /// The kind of compilation error.
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ErrorKind {
@@ -1119,8 +1132,8 @@ pub enum ErrorKind {
     StdLibNotFound,
     #[error("{item_kind} `{name}` is private")]
     PrivateMemberAccess { item_kind: String, name: String },
-    #[error("function `{name}` is private (defined in `{defining_file}`)")]
-    PrivateUnqualifiedAccess { name: String, defining_file: String },
+    #[error("{} `{}` is private (defined in `{}`)", .0.item_kind, .0.name, .0.defining_file)]
+    PrivateUnqualifiedAccess(Box<PrivateUnqualifiedAccessData>),
     #[error("module `{module_name}` has no member `{member_name}`")]
     UnknownModuleMember {
         module_name: String,
@@ -1290,7 +1303,7 @@ impl ErrorKind {
             ErrorKind::AmbiguousModule { .. } => ErrorCode::AMBIGUOUS_MODULE,
             ErrorKind::StdLibNotFound => ErrorCode::STD_LIB_NOT_FOUND,
             ErrorKind::PrivateMemberAccess { .. } => ErrorCode::PRIVATE_MEMBER_ACCESS,
-            ErrorKind::PrivateUnqualifiedAccess { .. } => ErrorCode::PRIVATE_UNQUALIFIED_ACCESS,
+            ErrorKind::PrivateUnqualifiedAccess(_) => ErrorCode::PRIVATE_UNQUALIFIED_ACCESS,
             ErrorKind::UnknownModuleMember { .. } => ErrorCode::UNKNOWN_MODULE_MEMBER,
 
             // Literal/operator errors (E0800-E0899)

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -347,3 +347,142 @@ fn internal_fn() -> i32 {
 """ }
 pass_aux_files = true
 exit_code = 42
+
+# =============================================================================
+# Unqualified Cross-Directory Access: Structs and Constants (RUE-183)
+# =============================================================================
+# The uniform privacy rule (10.3:7) covers every item kind, not just
+# functions: naming a private struct (annotation or literal) or reading a
+# private constant from another directory is E0460, imported or flat-listed.
+
+[[case]]
+name = "cross_dir_unqualified_private_struct_error"
+spec = ["10.3:7"]
+description = "Unqualified struct literal + annotation naming a private struct of an imported module in another directory is rejected"
+source = """
+const defs = @import("subdir/defs");
+
+fn main() -> i32 {
+    let p: Point = Point { x: 40, y: 2 };
+    p.x + p.y
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+struct Point {
+    x: i32,
+    y: i32,
+}
+""" }
+compile_fail = true
+error_contains = "struct `Point` is private (defined in"
+
+[[case]]
+name = "cross_dir_unqualified_private_const_error"
+spec = ["10.3:7"]
+description = "Unqualified read of a private constant of an imported module in another directory is rejected"
+source = """
+const defs = @import("subdir/defs");
+
+fn main() -> i32 {
+    LIMIT
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+const LIMIT: i32 = 42;
+""" }
+compile_fail = true
+error_contains = "constant `LIMIT` is private (defined in"
+
+[[case]]
+name = "flat_multifile_unqualified_private_struct_error"
+spec = ["10.3:7", "10.3:8"]
+description = "Uniform privacy: a private struct in a never-imported, explicitly listed file in another directory is not nameable unqualified"
+source = """
+fn main() -> i32 {
+    let p: Point = Point { x: 40, y: 2 };
+    p.x + p.y
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+struct Point {
+    x: i32,
+    y: i32,
+}
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "struct `Point` is private (defined in"
+
+[[case]]
+name = "flat_multifile_unqualified_private_const_error"
+spec = ["10.3:7", "10.3:8"]
+description = "Uniform privacy: a private constant in a never-imported, explicitly listed file in another directory is not readable unqualified"
+source = """
+fn main() -> i32 {
+    LIMIT
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+const LIMIT: i32 = 42;
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "constant `LIMIT` is private (defined in"
+
+[[case]]
+name = "cross_dir_const_initializer_private_const_error"
+spec = ["10.3:7"]
+description = "A constant initializer reading a private constant from another directory is rejected too"
+source = """
+const X: i32 = LIMIT;
+
+fn main() -> i32 {
+    X
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+const LIMIT: i32 = 42;
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "constant `LIMIT` is private (defined in"
+
+[[case]]
+name = "flat_multifile_unqualified_pub_struct_and_const_allowed"
+spec = ["10.3:8", "10.5:2"]
+description = "The flat namespace still resolves pub structs and constants across directories without imports"
+source = """
+fn main() -> i32 {
+    let p: Point = Point { x: 30, y: 2 };
+    p.x + p.y + BONUS
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+pub struct Point {
+    x: i32,
+    y: i32,
+}
+pub const BONUS: i32 = 10;
+""" }
+pass_aux_files = true
+exit_code = 42
+
+[[case]]
+name = "flat_multifile_same_dir_private_struct_and_const_allowed"
+spec = ["10.3:2", "10.3:8"]
+description = "Intra-directory visibility (ADR-0026) is unchanged: private structs and constants in another listed file in the same directory are usable unqualified"
+source = """
+fn main() -> i32 {
+    let p: Point = Point { x: 30, y: 2 };
+    p.x + p.y + BONUS
+}
+"""
+aux_files = { "defs.rue" = """
+struct Point {
+    x: i32,
+    y: i32,
+}
+const BONUS: i32 = 10;
+""" }
+pass_aux_files = true
+exit_code = 42

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -1515,3 +1515,239 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "not consumed on all paths"
+
+[[case]]
+name = "linear_param_unconsumed_in_callee_error"
+spec = ["3.8:62", "3.8:63"]
+description = "A pass-by-value linear parameter dropped by the callee body is an error (RUE-176)"
+source = """
+linear struct MustUse { value: i32 }
+
+fn f(m: MustUse) -> i32 { 0 }
+
+fn main() -> i32 {
+    let m = MustUse { value: 1 };
+    f(m)
+}
+"""
+compile_fail = true
+error_contains = "linear value 'm' must be consumed"
+
+[[case]]
+name = "linear_param_consumed_on_one_path_only_error"
+spec = ["3.8:62"]
+description = "A linear parameter consumed on only one branch of the callee body is an error"
+source = """
+linear struct MustUse { value: i32 }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn f(m: MustUse, c: bool) -> i32 {
+    if c { consume(m) } else { 0 }
+}
+
+fn main() -> i32 {
+    f(MustUse { value: 1 }, true)
+}
+"""
+compile_fail = true
+error_contains = "not consumed on all paths"
+
+[[case]]
+name = "linear_param_returned_ok"
+spec = ["3.8:62"]
+description = "Returning a linear parameter consumes it (responsibility moves to the caller)"
+source = """
+linear struct MustUse { value: i32 }
+
+fn id(m: MustUse) -> MustUse { m }
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    consume(id(MustUse { value: 42 }))
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "linear_param_borrow_exempt"
+spec = ["3.8:62"]
+description = "A borrow parameter of linear type is exempt: the caller retains ownership"
+source = """
+linear struct MustUse { value: i32 }
+
+fn peek(borrow m: MustUse) -> i32 { 5 }
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let m = MustUse { value: 44 };
+    let v = peek(borrow m);
+    consume(m) - v + 3
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "linear_param_destructor_self_exempt"
+spec = ["3.8:62"]
+description = "A destructor's self parameter is exempt from the linear must-consume rule"
+source = """
+linear struct MustUse { value: i32 }
+
+drop fn MustUse(self) { let _x = 1; }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let m = MustUse { value: 42 };
+    consume(m)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "linear_temporary_discarded_error"
+spec = ["3.8:64", "3.8:65"]
+description = "A linear value produced and discarded by an expression statement is an error (RUE-176)"
+source = """
+linear struct MustUse { value: i32 }
+
+fn make_linear() -> MustUse { MustUse { value: 1 } }
+
+fn main() -> i32 {
+    make_linear();
+    0
+}
+"""
+compile_fail = true
+error_contains = "carries a linear value and must be consumed"
+
+[[case]]
+name = "linear_loop_body_discarded_error"
+spec = ["3.8:64"]
+description = "A loop body whose result value is linear discards it on every iteration - error"
+source = """
+linear struct MustUse { value: i32 }
+
+fn make_linear() -> MustUse { MustUse { value: 1 } }
+
+fn main() -> i32 {
+    let mut i = 0;
+    while i < 2 { make_linear() }
+    0
+}
+"""
+compile_fail = true
+error_contains = "carries a linear value and must be consumed"
+
+[[case]]
+name = "linear_moved_binding_statement_discard_error"
+spec = ["3.8:64"]
+description = "A bare variable statement moving a linear binding discards (drops) the value - error"
+source = """
+linear struct MustUse { value: i32 }
+
+fn main() -> i32 {
+    let m = MustUse { value: 1 };
+    m;
+    0
+}
+"""
+compile_fail = true
+error_contains = "carries a linear value and must be consumed"
+
+[[case]]
+name = "linear_array_dropped_error"
+spec = ["3.8:66", "3.8:67"]
+description = "An array of linear values dropped without being consumed is an error (RUE-176)"
+source = """
+linear struct MustUse { value: i32 }
+
+fn make_linear() -> MustUse { MustUse { value: 1 } }
+
+fn main() -> i32 {
+    let a = [make_linear(), make_linear()];
+    0
+}
+"""
+compile_fail = true
+error_contains = "linear value 'a' must be consumed"
+
+[[case]]
+name = "linear_array_consumed_whole_ok"
+spec = ["3.8:66"]
+description = "An array of linear values consumed as a whole satisfies the requirement"
+source = """
+linear struct MustUse { value: i32 }
+
+fn make_linear() -> MustUse { MustUse { value: 21 } }
+
+fn eat(a: [MustUse; 2]) -> i32 { a[0].value * 2 }
+
+fn main() -> i32 {
+    let a = [make_linear(), make_linear()];
+    eat(a)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "borrow_method_preserves_sibling_field_move"
+spec = ["3.8:24"]
+description = "A builtin by-ref method call on a sibling field must not erase earlier move records (RUE-33)"
+source = """
+struct Wrap { s: String, t: String }
+
+fn consume(s: String) -> i32 { 1 }
+
+fn main() -> i32 {
+    let w = Wrap { s: "hello", t: "world" };
+    let _a = consume(w.s);
+    let _n = w.t.len();
+    let _b = consume(w.s);
+    0
+}
+"""
+compile_fail = true
+error_contains = "use of moved value 'w.s'"
+
+[[case]]
+name = "borrow_call_arg_preserves_sibling_field_move"
+spec = ["3.8:24"]
+description = "Passing a sibling field as a borrow argument must not erase earlier move records (RUE-33 site 2 regression pin)"
+source = """
+struct Wrap { s: String, t: String }
+
+fn consume(s: String) -> i32 { 1 }
+fn peek(borrow s: String) -> i32 { 2 }
+
+fn main() -> i32 {
+    let w = Wrap { s: "hello", t: "world" };
+    let _a = consume(w.s);
+    let _n = peek(borrow w.t);
+    let _b = consume(w.s);
+    0
+}
+"""
+compile_fail = true
+error_contains = "use of moved value 'w.s'"
+
+[[case]]
+name = "borrow_method_receiver_still_usable_after"
+spec = ["3.8:24"]
+description = "A by-ref builtin method call does not itself move its receiver: sibling and receiver stay usable"
+source = """
+struct Wrap { s: String, t: String }
+
+fn consume(s: String) -> i32 { 21 }
+
+fn main() -> i32 {
+    let w = Wrap { s: "hello", t: "world" };
+    let _a = consume(w.s);
+    let n = w.t.len();
+    let m = w.t.len();
+    let _b = consume(w.t);
+    if n == 5 { if m == 5 { 42 } else { 1 } } else { 0 }
+}
+"""
+exit_code = 42

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -239,6 +239,54 @@ fn ok() -> i32 {
 }
 ```
 
+{{ rule(id="3.8:62", cat="legality-rule") }}
+
+A function owns its pass-by-value parameters and drops them when it returns unless they are moved out. Therefore a pass-by-value parameter whose type carries a linear value **MUST** be consumed by the function body on every non-diverging control-flow path, exactly as for a linear local binding (3.8:32, 3.8:50). `borrow` and `inout` parameters are exempt: the caller retains ownership. A destructor's `self` parameter is also exempt: it is disposed of by the drop glue after the destructor body runs (see 3.9), and moving it out is rejected.
+
+{{ rule(id="3.8:63", cat="example") }}
+
+```rue
+linear struct MustUse { value: i32 }
+
+fn bad(m: MustUse) -> i32 { 0 }          // ERROR: 'm' is dropped, not consumed
+
+fn good(m: MustUse) -> i32 { m.value }   // OK: destructuring consumes 'm'
+```
+
+{{ rule(id="3.8:64", cat="legality-rule") }}
+
+It is a compile-time error to discard an expression value whose type carries a linear value. A value is discarded when it is the value of a non-final expression statement in a block, or the result value of a loop body (which is discarded on every iteration).
+
+{{ rule(id="3.8:65", cat="example") }}
+
+```rue
+linear struct MustUse { value: i32 }
+
+fn make_linear() -> MustUse { MustUse { value: 1 } }
+
+fn main() -> i32 {
+    make_linear();   // ERROR: discarded linear value
+    0
+}
+```
+
+{{ rule(id="3.8:66", cat="legality-rule") }}
+
+The consumption requirement (3.8:32) applies to every binding whose type carries a linear value (3.8:57), not only to bindings of linear struct type. In particular, an array whose element type carries a linear value **MUST** be consumed as a whole (for example, by passing the array to a function by value); dropping the array would silently drop every element.
+
+{{ rule(id="3.8:67", cat="example") }}
+
+```rue
+linear struct MustUse { value: i32 }
+
+fn make_linear() -> MustUse { MustUse { value: 1 } }
+
+fn main() -> i32 {
+    let a = [make_linear(), make_linear()];  // ERROR: 'a' is dropped, not consumed
+    0
+}
+```
+
 {{ rule(id="3.8:39", cat="informative") }}
 
 Linear types are useful for:

--- a/docs/spec/src/10-modules/03-visibility.md
+++ b/docs/spec/src/10-modules/03-visibility.md
@@ -62,29 +62,40 @@ fn main() -> i32 {
 Visibility is uniform across every multi-file compilation: an item is
 visible outside its defining directory if and only if it is `pub`,
 whether its defining file was loaded via `@import` or only listed
-explicitly in the compilation. It is a compile-time error to call a
-private function by its unqualified name from a source file in a
-different directory than the function's defining file (error E0460).
+explicitly in the compilation. It is a compile-time error to reference a
+private item by its unqualified name from a source file in a different
+directory than the item's defining file (error E0460). This covers every
+form of unqualified reference: calling a private function, naming a
+private struct (in a type annotation, a signature, or a struct literal),
+and reading a private constant — including from another constant's
+initializer.
 
 {{ rule(id="10.3:8", cat="normative") }}
 
 The transitional flat namespace (10.5:2) affects only *name resolution*:
 an unqualified reference may resolve to an item in any file of the
 compilation without an import, but the visibility rules of this section
-apply regardless of how the item's file was loaded. A `pub` function in
-another directory is therefore callable unqualified without any import;
+apply regardless of how the item's file was loaded. A `pub` item in
+another directory is therefore usable unqualified without any import;
 a private one is not.
 
 {{ rule(id="10.3:9", cat="example") }}
 
 ```rue
 // sub/lib.rue
-fn secret() -> i32 { 99 }   // private to sub/
+fn secret() -> i32 { 99 }       // private to sub/
 pub fn open() -> i32 { 7 }
+struct Hidden { n: i32, }       // private to sub/
+pub struct Shared { n: i32, }
+const LIMIT: i32 = 8;           // private to sub/
+pub const MAX: i32 = 16;
 
 // main.rue — a different directory; no import needed (10.5:2)
 fn main() -> i32 {
-    // secret()              // error E0460: private to sub/lib.rue
-    open()                   // OK: `open` is pub
+    // secret()                  // error E0460: private to sub/lib.rue
+    // let h = Hidden { n: 1 };  // error E0460: private to sub/lib.rue
+    // let l = LIMIT;            // error E0460: private to sub/lib.rue
+    let s = Shared { n: MAX };   // OK: `Shared` and `MAX` are pub
+    open() + s.n
 }
 ```


### PR DESCRIPTION
Cycle-17 worker integration, **stacked on #1001** (both touch `rue-error` ErrorKind; the diff shown here shrinks to just this work once #1001 merges).

**RUE-33 (remaining site):** a builtin by-ref method call on a *sibling field* erased the whole root's move records — `consume(w.s); w.t.len(); consume(w.s)` compiled and double-freed. `ReceiverInfo` now snapshots move state pre-analysis and the ByRef/ByMutRef arm restores it instead of removing the root's entry. Site 2 (borrow call args) was already fixed; pinned.

**RUE-176, all three facets:** (1) by-value linear params must be consumed by the **callee** (E0406; borrow/inout/comptime/destructor-self exempt); (2) discarded linear values — statement position, loop bodies, bare `m;` — rejected with new **E0478**; (3) array-of-linear locals enter the must-consume check instead of earning only an unused-variable warning.

**Cross-mechanism check at integration** (this PR × #1001): naming a private linear type cross-file → E0460; consuming one through pub fns without naming it → the linear checker takes over (E0406). Composes cleanly.

Integration verification by execution: double-free repro now E0205; callee-drop E0406; discarded temp E0478; bare array E0406. Spec 3.8:62–67 added; 13 spec + 8 CLI cases incl. site-2 and E0406-control pins; traceability 575/575; full `./test.sh` green on the stack.

Worker discoveries (filing as issues): index destructure marks the whole array moved; no intentional-destroy escape hatch for linear values (design ruling).

Fixes RUE-33
Fixes RUE-176

🤖 Generated with [Claude Code](https://claude.com/claude-code)