### PR TITLE
Settings: allow rm under /tmp (unattended worker runs)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -36,7 +36,10 @@
       "Bash(ls:*)",
       "Bash(wc:*)",
       "Bash(head:*)",
-      "Bash(tail:*)"
+      "Bash(tail:*)",
+      "Bash(rm /tmp/*)",
+      "Bash(rm -f /tmp/*)",
+      "Bash(rm -rf /tmp/claude-1000/*)"
     ]
   },
   "hooks": {


### PR DESCRIPTION
Companion to #1003: permission allow rules for `rm` under /tmp and the session scratch root, so auto mode doesn't stall unattended worker fleets on scratch-file cleanup. Authored by Steve; PR'd so the rules live on trunk (settings.json is read from the working directory — an unmerged local commit would silently revert whenever a workspace parks on fresh trunk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)