### PR TITLE
Enum privacy joins the uniform rule; RIR match-arm spans keep their file_id

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ rue main.rue utils.rue lib.rue -o program
 
 **Key semantics:**
 - All top-level names resolve across files without imports (flat namespace),
-  but privacy is uniform (spec 10.3:7): an item — function, struct, or
+  but privacy is uniform (spec 10.3:7): an item — function, struct, enum, or
   constant — is usable outside its defining directory only if `pub`, whether
   its file is imported or just listed (E0460 otherwise; through a module
   object it's E0706)

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1188,12 +1188,29 @@ impl<'a> Sema<'a> {
                         self.resolve_enum_through_module(*module_ref, *type_name, pattern_span)?
                     } else {
                         // Unqualified access: EnumName::Variant
-                        *self.enums.get(type_name).ok_or_compile_error(
+                        let enum_id = *self.enums.get(type_name).ok_or_compile_error(
                             ErrorKind::UnknownEnumType(
                                 self.interner.resolve(&*type_name).to_string(),
                             ),
                             pattern_span,
-                        )?
+                        )?;
+                        // Privacy (E0460, RUE-185): a match pattern names the
+                        // enum unqualified, so a private enum from another
+                        // directory cannot be matched on — privacy is uniform
+                        // across item kinds (spec 10.3:1, 10.3:7). The
+                        // module-qualified branch above does its own check
+                        // (E0706). The pattern-to-AIR conversion later in
+                        // this loop re-resolves the same name but runs only
+                        // after this check has passed.
+                        let def = self.type_pool.enum_def(enum_id);
+                        self.check_unqualified_visibility(
+                            "enum",
+                            self.interner.resolve(&*type_name),
+                            def.file_id,
+                            def.is_pub,
+                            pattern_span,
+                        )?;
+                        enum_id
                     };
                     let enum_def = self.type_pool.enum_def(enum_id);
 
@@ -3351,10 +3368,25 @@ impl<'a> Sema<'a> {
                     self.resolve_enum_through_module(*module_ref, *type_name, inst.span)?
                 } else {
                     // Unqualified access: EnumName::Variant
-                    *self.enums.get(type_name).ok_or_compile_error(
+                    let enum_id = *self.enums.get(type_name).ok_or_compile_error(
                         ErrorKind::UnknownEnumType(self.interner.resolve(&*type_name).to_string()),
                         inst.span,
-                    )?
+                    )?;
+                    // Privacy (E0460, RUE-185): constructing a variant names
+                    // the enum unqualified, so a private enum from another
+                    // directory is not constructible here — privacy is
+                    // uniform across item kinds (spec 10.3:1, 10.3:7). The
+                    // module-qualified branch above does its own check
+                    // (E0706, `resolve_enum_through_module`).
+                    let def = self.type_pool.enum_def(enum_id);
+                    self.check_unqualified_visibility(
+                        "enum",
+                        self.interner.resolve(&*type_name),
+                        def.file_id,
+                        def.is_pub,
+                        inst.span,
+                    )?;
+                    enum_id
                 };
                 let enum_def = self.type_pool.enum_def(enum_id);
 

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -159,6 +159,17 @@ impl<'a> Sema<'a> {
             )?;
             Ok(Type::new_struct(struct_id))
         } else if let Some(&enum_id) = self.enums.get(&type_sym) {
+            // Privacy (E0460, RUE-185): same rule for enums — an unqualified
+            // type reference must not reach a private enum defined in another
+            // directory.
+            let enum_def = self.type_pool.enum_def(enum_id);
+            self.check_unqualified_visibility(
+                "enum",
+                type_name,
+                enum_def.file_id,
+                enum_def.is_pub,
+                span,
+            )?;
             Ok(Type::new_enum(enum_id))
         } else {
             // Check for array type syntax: [T; N]

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -56,13 +56,13 @@ impl Sema<'_> {
     }
 
     /// Check that an *unqualified* reference may reach the item (RUE-37,
-    /// RUE-180, RUE-183).
+    /// RUE-180, RUE-183, RUE-185).
     ///
     /// All loaded files share one flat global namespace for *name
     /// resolution* (spec 10.5:2, transitional), but privacy is uniform in
     /// every multi-file compilation, imports or not (spec 10.3:7), and it
-    /// covers every item kind — functions, structs, and constants alike
-    /// (spec 10.3:1):
+    /// covers every item kind — functions, structs, enums, and constants
+    /// alike (spec 10.3:1):
     ///
     /// - If the item is accessible per [`Sema::is_accessible`] (it is
     ///   `pub`, or the reference is in the item's directory — ADR-0026
@@ -72,7 +72,7 @@ impl Sema<'_> {
     ///   listed on the command line makes no difference.
     ///
     /// `item_kind` names the kind in the diagnostic ("function", "struct",
-    /// "constant").
+    /// "enum", "constant").
     pub(crate) fn check_unqualified_visibility(
         &self,
         item_kind: &str,

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -856,6 +856,188 @@ const BONUS: i32 = 10;
 ]
 exit_code = 42
 
+# Enums obey the same uniform rule (RUE-185): naming a private enum from
+# another directory — annotation, variant construction, or match pattern —
+# is E0460, whether the file was imported or merely listed.
+[[case]]
+name = "private_enum_cross_dir_unqualified_rejected"
+description = "Unqualified annotation/construction naming a private enum in another directory is E0460 (RUE-185), imported or not."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let c: Color = Color::Blue;
+    0
+}
+""" },
+    { path = "sub/lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "enum `Color` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "flat_multifile_private_enum_construction_rejected"
+description = "Uniform privacy for enums (RUE-185): a variant of a private enum in a never-imported listed file is not constructible cross-directory."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let c = Color::Blue;
+    0
+}
+""" },
+    { path = "sub/lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "enum `Color` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "flat_multifile_private_enum_match_pattern_rejected"
+description = "A match pattern is a reference site too (RUE-185): matching on a private cross-directory enum is E0460 with the pattern's own file-attributed span, even when the scrutinee arrives via a pub fn."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    match make() {
+        Color::Red => 1,
+        Color::Green => 2,
+        Color::Blue => 3,
+    }
+}
+""" },
+    { path = "sub/lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+pub fn make() -> Color {
+    Color::Green
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "enum `Color` is private (defined in `sub/lib.rue`)", "main.rue"]
+
+[[case]]
+name = "private_enum_module_qualified_pattern_rejected"
+description = "Through a module object the private enum stays E0706 (non-regression, RUE-185): `lib.Color::Red` in a match pattern."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    match lib.make() {
+        lib.Color::Red => 1,
+        _ => 0,
+    }
+}
+""" },
+    { path = "sub/lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+pub fn make() -> Color {
+    Color::Green
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0706", "enum `Color` is private"]
+
+[[case]]
+name = "flat_multifile_pub_enum_cross_dir_allowed"
+description = "Positive control (RUE-185): a pub enum in another never-imported directory remains usable unqualified — annotation, construction, and match (spec 10.3:8)."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let c: Color = Color::Blue;
+    match c {
+        Color::Red => 10,
+        Color::Green => 20,
+        Color::Blue => 42,
+    }
+}
+""" },
+    { path = "sub/lib.rue", source = """
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "pub_enum_module_qualified_pattern_allowed"
+description = "Positive control (RUE-185): a pub enum through a module object works in match patterns, verified by execution."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    match lib.make() {
+        lib.Color::Red => 1,
+        lib.Color::Green => 42,
+        lib.Color::Blue => 3,
+    }
+}
+""" },
+    { path = "sub/lib.rue", source = """
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+pub fn make() -> Color {
+    Color::Green
+}
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "flat_multifile_private_enum_same_dir_allowed"
+description = "Control (RUE-185): intra-directory visibility is unchanged — a private enum in another listed file in the SAME directory is usable."
+args = ["main.rue", "lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let c: Color = Color::Green;
+    match c {
+        Color::Red => 1,
+        Color::Green => 42,
+        Color::Blue => 3,
+    }
+}
+""" },
+    { path = "lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" },
+]
+exit_code = 42
+
 # ---------------------------------------------------------------------------
 # Nested module member access (RUE-122 regression coverage).
 #

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -823,7 +823,7 @@ pub struct AmbiguousModuleData {
 /// exceed it).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrivateUnqualifiedAccessData {
-    /// The kind of item ("function", "struct", "constant").
+    /// The kind of item ("function", "struct", "enum", "constant").
     pub item_kind: String,
     /// The item's name as written at the reference site.
     pub name: String,

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -181,11 +181,16 @@ pub enum PatternKind {
     Path = 3,
 }
 
-/// Size of each pattern kind in the extra array (including body InstRef)
-const PATTERN_WILDCARD_SIZE: u32 = 4; // kind, span_start, span_len, body
-const PATTERN_INT_SIZE: u32 = 7; // kind, span_start, span_len, value_lo, value_hi, negative, body
-const PATTERN_BOOL_SIZE: u32 = 5; // kind, span_start, span_len, value, body
-const PATTERN_PATH_SIZE: u32 = 7; // kind, span_start, span_len, module, type_name, variant, body
+/// Size of each pattern kind in the extra array (including body InstRef).
+///
+/// The span is stored as three words — start, len, AND file id — so pattern
+/// diagnostics in multi-file compilations attribute to the right file
+/// (dropping the file id here was why pattern-anchored errors reported
+/// "span has an unknown file id", RUE-185).
+const PATTERN_WILDCARD_SIZE: u32 = 5; // kind, span_start, span_len, span_file, body
+const PATTERN_INT_SIZE: u32 = 8; // kind, span_start, span_len, span_file, value_lo, value_hi, negative, body
+const PATTERN_BOOL_SIZE: u32 = 6; // kind, span_start, span_len, span_file, value, body
+const PATTERN_PATH_SIZE: u32 = 8; // kind, span_start, span_len, span_file, module, type_name, variant, body
 
 /// Stored representation of struct field initializer.
 /// Layout: [field_name: u32, value: u32] = 2 u32s per field
@@ -398,6 +403,7 @@ impl Rir {
                     self.extra.push(PatternKind::Wildcard as u32);
                     self.extra.push(span.start());
                     self.extra.push(span.len());
+                    self.extra.push(span.file_id.index());
                     self.extra.push(body.as_u32());
                 }
                 RirPattern::Int {
@@ -408,6 +414,7 @@ impl Rir {
                     self.extra.push(PatternKind::Int as u32);
                     self.extra.push(span.start());
                     self.extra.push(span.len());
+                    self.extra.push(span.file_id.index());
                     // Store u64 magnitude as two u32s (little-endian) plus sign flag
                     self.extra.push(*value as u32);
                     self.extra.push((*value >> 32) as u32);
@@ -418,6 +425,7 @@ impl Rir {
                     self.extra.push(PatternKind::Bool as u32);
                     self.extra.push(span.start());
                     self.extra.push(span.len());
+                    self.extra.push(span.file_id.index());
                     self.extra.push(if *value { 1 } else { 0 });
                     self.extra.push(body.as_u32());
                 }
@@ -430,6 +438,7 @@ impl Rir {
                     self.extra.push(PatternKind::Path as u32);
                     self.extra.push(span.start());
                     self.extra.push(span.len());
+                    self.extra.push(span.file_id.index());
                     // Store module as u32::MAX for None, otherwise the InstRef
                     self.extra.push(module.map_or(u32::MAX, |r| r.as_u32()));
                     self.extra.push(type_name.into_usize() as u32);
@@ -441,6 +450,16 @@ impl Rir {
         (start, arms.len() as u32)
     }
 
+    /// Decode a pattern's span from the extra array. Every pattern kind
+    /// stores its span as [start, len, file_id] at offsets 1..=3 after the
+    /// kind word (see the `PATTERN_*_SIZE` layout comments).
+    fn decode_pattern_span(extra: &[u32], pos: usize) -> Span {
+        let span_start = extra[pos + 1];
+        let span_len = extra[pos + 2];
+        let file_id = rue_span::FileId::new(extra[pos + 3]);
+        Span::with_file(file_id, span_start, span_start + span_len)
+    }
+
     /// Retrieve match arms from the extra array.
     pub fn get_match_arms(&self, start: u32, arm_count: u32) -> Vec<(RirPattern, InstRef)> {
         let mut arms = Vec::with_capacity(arm_count as usize);
@@ -450,22 +469,18 @@ impl Rir {
             let kind = self.extra[pos];
             match kind {
                 k if k == PatternKind::Wildcard as u32 => {
-                    let span_start = self.extra[pos + 1];
-                    let span_len = self.extra[pos + 2];
-                    let span = Span::new(span_start, span_start + span_len);
-                    let body = InstRef::from_raw(self.extra[pos + 3]);
+                    let span = Self::decode_pattern_span(&self.extra, pos);
+                    let body = InstRef::from_raw(self.extra[pos + 4]);
                     arms.push((RirPattern::Wildcard(span), body));
                     pos += PATTERN_WILDCARD_SIZE as usize;
                 }
                 k if k == PatternKind::Int as u32 => {
-                    let span_start = self.extra[pos + 1];
-                    let span_len = self.extra[pos + 2];
-                    let span = Span::new(span_start, span_start + span_len);
-                    let value_lo = self.extra[pos + 3] as u64;
-                    let value_hi = self.extra[pos + 4] as u64;
+                    let span = Self::decode_pattern_span(&self.extra, pos);
+                    let value_lo = self.extra[pos + 4] as u64;
+                    let value_hi = self.extra[pos + 5] as u64;
                     let value = value_lo | (value_hi << 32);
-                    let negative = self.extra[pos + 5] != 0;
-                    let body = InstRef::from_raw(self.extra[pos + 6]);
+                    let negative = self.extra[pos + 6] != 0;
+                    let body = InstRef::from_raw(self.extra[pos + 7]);
                     arms.push((
                         RirPattern::Int {
                             value,
@@ -477,28 +492,24 @@ impl Rir {
                     pos += PATTERN_INT_SIZE as usize;
                 }
                 k if k == PatternKind::Bool as u32 => {
-                    let span_start = self.extra[pos + 1];
-                    let span_len = self.extra[pos + 2];
-                    let span = Span::new(span_start, span_start + span_len);
-                    let value = self.extra[pos + 3] != 0;
-                    let body = InstRef::from_raw(self.extra[pos + 4]);
+                    let span = Self::decode_pattern_span(&self.extra, pos);
+                    let value = self.extra[pos + 4] != 0;
+                    let body = InstRef::from_raw(self.extra[pos + 5]);
                     arms.push((RirPattern::Bool(value, span), body));
                     pos += PATTERN_BOOL_SIZE as usize;
                 }
                 k if k == PatternKind::Path as u32 => {
-                    let span_start = self.extra[pos + 1];
-                    let span_len = self.extra[pos + 2];
-                    let span = Span::new(span_start, span_start + span_len);
+                    let span = Self::decode_pattern_span(&self.extra, pos);
                     // Decode module: u32::MAX means None
-                    let module_raw = self.extra[pos + 3];
+                    let module_raw = self.extra[pos + 4];
                     let module = if module_raw == u32::MAX {
                         None
                     } else {
                         Some(InstRef::from_raw(module_raw))
                     };
-                    let type_name = Spur::try_from_usize(self.extra[pos + 4] as usize).unwrap();
-                    let variant = Spur::try_from_usize(self.extra[pos + 5] as usize).unwrap();
-                    let body = InstRef::from_raw(self.extra[pos + 6]);
+                    let type_name = Spur::try_from_usize(self.extra[pos + 5] as usize).unwrap();
+                    let variant = Spur::try_from_usize(self.extra[pos + 6] as usize).unwrap();
+                    let body = InstRef::from_raw(self.extra[pos + 7]);
                     arms.push((
                         RirPattern::Path {
                             module,
@@ -1164,12 +1175,13 @@ impl Rir {
                             k if k == PatternKind::Path as u32 => PATTERN_PATH_SIZE as usize,
                             _ => panic!("Unknown pattern kind during merge: {}", kind),
                         };
-                        // Path patterns also embed a module InstRef at offset 3
-                        // (u32::MAX encodes None); it must be renumbered like
-                        // every other InstRef or it would point into the wrong
-                        // file's instruction space after merging.
-                        if kind == PatternKind::Path as u32 && extra[pos + 3] != u32::MAX {
-                            extra[pos + 3] += inst_offset;
+                        // Path patterns also embed a module InstRef at offset 4
+                        // (after kind + the 3-word span; u32::MAX encodes
+                        // None); it must be renumbered like every other
+                        // InstRef or it would point into the wrong file's
+                        // instruction space after merging.
+                        if kind == PatternKind::Path as u32 && extra[pos + 4] != u32::MAX {
+                            extra[pos + 4] += inst_offset;
                         }
                         // The body InstRef is always the last element of each pattern
                         extra[pos + pattern_size - 1] += inst_offset;

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -486,3 +486,128 @@ const BONUS: i32 = 10;
 """ }
 pass_aux_files = true
 exit_code = 42
+
+# =============================================================================
+# Unqualified Cross-Directory Access: Enums (RUE-185)
+# =============================================================================
+# The uniform privacy rule (10.3:7) covers enums too: naming a private enum
+# from another directory — in a type annotation, a variant construction, or a
+# match pattern — is E0460, imported or flat-listed.
+
+[[case]]
+name = "cross_dir_unqualified_private_enum_error"
+spec = ["10.3:7"]
+description = "Unqualified annotation + variant construction naming a private enum of an imported module in another directory is rejected"
+source = """
+const defs = @import("subdir/defs");
+
+fn main() -> i32 {
+    let c: Color = Color::Blue;
+    0
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" }
+compile_fail = true
+error_contains = "enum `Color` is private (defined in"
+
+[[case]]
+name = "flat_multifile_unqualified_private_enum_construction_error"
+spec = ["10.3:7", "10.3:8"]
+description = "Uniform privacy: constructing a variant of a private enum in a never-imported, explicitly listed file in another directory is rejected"
+source = """
+fn main() -> i32 {
+    let c = Color::Blue;
+    0
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "enum `Color` is private (defined in"
+
+[[case]]
+name = "flat_multifile_private_enum_match_pattern_error"
+spec = ["10.3:7", "10.3:8"]
+description = "A match pattern names the enum unqualified too: matching on a private cross-directory enum is rejected even when the scrutinee arrives through a pub function"
+source = """
+fn main() -> i32 {
+    match make() {
+        Color::Red => 1,
+        Color::Green => 2,
+        Color::Blue => 3,
+    }
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+pub fn make() -> Color {
+    Color::Green
+}
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "enum `Color` is private (defined in"
+
+[[case]]
+name = "flat_multifile_unqualified_pub_enum_allowed"
+spec = ["10.3:8", "10.5:2"]
+description = "The flat namespace still resolves pub enums across directories without imports: annotation, construction, and match all work"
+source = """
+fn main() -> i32 {
+    let c: Color = Color::Blue;
+    match c {
+        Color::Red => 10,
+        Color::Green => 20,
+        Color::Blue => 42,
+    }
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" }
+pass_aux_files = true
+exit_code = 42
+
+[[case]]
+name = "flat_multifile_same_dir_private_enum_allowed"
+spec = ["10.3:2", "10.3:8"]
+description = "Intra-directory visibility (ADR-0026) is unchanged: a private enum in another listed file in the same directory is usable unqualified"
+source = """
+fn main() -> i32 {
+    let c: Color = Color::Green;
+    match c {
+        Color::Red => 1,
+        Color::Green => 42,
+        Color::Blue => 3,
+    }
+}
+"""
+aux_files = { "defs.rue" = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" }
+pass_aux_files = true
+exit_code = 42

--- a/docs/spec/src/10-modules/03-visibility.md
+++ b/docs/spec/src/10-modules/03-visibility.md
@@ -67,8 +67,9 @@ private item by its unqualified name from a source file in a different
 directory than the item's defining file (error E0460). This covers every
 form of unqualified reference: calling a private function, naming a
 private struct (in a type annotation, a signature, or a struct literal),
-and reading a private constant — including from another constant's
-initializer.
+naming a private enum (in a type annotation, a signature, a variant
+construction, or a match pattern), and reading a private constant —
+including from another constant's initializer.
 
 {{ rule(id="10.3:8", cat="normative") }}
 
@@ -87,6 +88,8 @@ fn secret() -> i32 { 99 }       // private to sub/
 pub fn open() -> i32 { 7 }
 struct Hidden { n: i32, }       // private to sub/
 pub struct Shared { n: i32, }
+enum Mode { Fast, Slow, }       // private to sub/
+pub enum Level { Low, High, }
 const LIMIT: i32 = 8;           // private to sub/
 pub const MAX: i32 = 16;
 
@@ -94,8 +97,12 @@ pub const MAX: i32 = 16;
 fn main() -> i32 {
     // secret()                  // error E0460: private to sub/lib.rue
     // let h = Hidden { n: 1 };  // error E0460: private to sub/lib.rue
+    // let m = Mode::Fast;       // error E0460: private to sub/lib.rue
     // let l = LIMIT;            // error E0460: private to sub/lib.rue
     let s = Shared { n: MAX };   // OK: `Shared` and `MAX` are pub
-    open() + s.n
+    match Level::High {          // OK: `Level` is pub
+        Level::Low => 0,
+        Level::High => open() + s.n,
+    }
 }
 ```


### PR DESCRIPTION
Cycle-18 worker integration (verified by hand at integration time).

**RUE-185:** non-pub enums were fully usable cross-directory — annotations, variant construction, and match patterns all bypassed the guard #1001 extended to structs/consts. All three forms now E0460 with the enum kind named. Side doors hunted per the RUE-183 lesson (enum consts already E0434; comptime type args and `@size_of` route through the guarded resolver).

**Bonus fix:** the RIR match-arm encoding dropped pattern spans' file_id — after #1000's honest fallback, every pattern diagnostic in multi-file builds rendered "unknown file id", and pattern-site privacy checks were silently permissive. Spans now round-trip file_id through the arm encoding. (The same encoding shape exists for directive spans — filing as follow-up.)

Integration verification by execution: private enum cross-dir → E0460; pub enum control runs exit 42; E0706 and same-dir access unchanged. +5 spec / +7 CLI cases, traceability 575/575, full `./test.sh` green.

Fixes RUE-185

🤖 Generated with [Claude Code](https://claude.com/claude-code)