### PR TITLE
Comptime value parameters are monomorphized per value

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ rue main.rue utils.rue lib.rue -o program
 
 **Key semantics:**
 - All top-level names resolve across files without imports (flat namespace),
-  but privacy is uniform (spec 10.3:7): an item — function, struct, or
+  but privacy is uniform (spec 10.3:7): an item — function, struct, enum, or
   constant — is usable outside its defining directory only if `pub`, whether
   its file is imported or just listed (E0460 otherwise; through a module
   object it's E0706)

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -48,10 +48,14 @@ pub struct FunctionSig {
     pub param_types: Vec<InferType>,
     /// Return type, as InferType for uniform handling.
     pub return_type: InferType,
-    /// Whether this is a generic function (has comptime type parameters).
+    /// Whether this function requires specialization (has any comptime
+    /// parameters — type parameters like `comptime T: type` or value
+    /// parameters like `comptime n: i32`, RUE-166).
     /// Generic calls substitute the comptime type arguments into the parameter
     /// types before constraining arguments; type parameters that can't be
     /// resolved during constraint generation are checked in sema instead.
+    /// Comptime value parameters have concrete declared types, so their
+    /// arguments are constrained normally.
     pub is_generic: bool,
     /// Parameter modes (Normal, Inout, Borrow, Comptime).
     pub param_modes: Vec<rue_rir::RirParamMode>,

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -818,12 +818,18 @@ pub enum AirInstData {
 
     /// Generic function call - requires specialization before codegen.
     ///
-    /// This is emitted when calling a function with `comptime T: type` parameters.
-    /// During a post-analysis specialization pass, this is rewritten to a regular
-    /// `Call` to a specialized version of the function (e.g., `identity__i32`).
+    /// This is emitted when calling a function with `comptime` parameters
+    /// (type parameters like `comptime T: type` or value parameters like
+    /// `comptime n: i32`, RUE-166). During a post-analysis specialization
+    /// pass, this is rewritten to a regular `Call` to a specialized version
+    /// of the function (e.g., `identity__i32`, `fact__v5`).
     ///
-    /// The type_args are encoded in the extra array as raw Type discriminant values.
-    /// The runtime args (non-comptime) are also in the extra array, after type_args.
+    /// The type_args are encoded in the extra array as raw Type discriminant
+    /// values. The comptime value arguments are encoded in the extra array as
+    /// a tagged word stream (see `specialize::encode_const_values`). The
+    /// runtime args are also in the extra array; comptime value arguments
+    /// remain part of the runtime argument list (they are still passed at
+    /// runtime), while type arguments are erased.
     CallGeneric {
         /// Base function name (interned symbol)
         name: Spur,
@@ -831,6 +837,10 @@ pub enum AirInstData {
         type_args_start: u32,
         /// Number of type arguments
         type_args_len: u32,
+        /// Start index into extra array for encoded comptime value arguments
+        value_args_start: u32,
+        /// Number of words (not values) in the encoded value-argument stream
+        value_args_len: u32,
         /// Start index into extra array for runtime arguments
         args_start: u32,
         /// Number of runtime arguments
@@ -1169,6 +1179,8 @@ impl fmt::Display for Air {
                     name,
                     type_args_start,
                     type_args_len,
+                    value_args_start,
+                    value_args_len,
                     args_start,
                     args_len,
                 } => {
@@ -1180,6 +1192,19 @@ impl fmt::Display for Air {
                         }
                         let type_val = self.extra[(*type_args_start + i) as usize];
                         write!(f, "type#{}", type_val)?;
+                    }
+                    // Show comptime value arguments (decoded from the tagged
+                    // word stream, see specialize::encode_const_values)
+                    for (i, value) in crate::specialize::decode_const_values(
+                        self.get_extra(*value_args_start, *value_args_len),
+                    )
+                    .iter()
+                    .enumerate()
+                    {
+                        if i > 0 || *type_args_len > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "value {:?}", value)?;
                     }
                     write!(f, ">(")?;
                     // Show runtime arguments

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -123,7 +123,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                 continue;
             }
 
-            // Skip generic functions - they'll be analyzed during specialization
+            // Skip functions with comptime parameters - they are analyzed per specialization
             if let Some(fn_info) = sema.functions.get(name) {
                 if fn_info.is_generic {
                     continue;
@@ -476,7 +476,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                 None => continue, // Should not happen, but be defensive
             };
 
-            // Skip generic functions - they're analyzed during specialization
+            // Skip functions with comptime parameters - they are analyzed per specialization
             if fn_info.is_generic {
                 continue;
             }
@@ -1641,7 +1641,8 @@ impl<'a> Sema<'a> {
     ///
     /// This is similar to `analyze_function` but for generic function specialization.
     /// The `type_subst` map provides substitutions for type parameters to their
-    /// concrete types.
+    /// concrete types; the `value_subst` map provides the concrete values of the
+    /// comptime value parameters (RUE-166).
     ///
     /// For example, when specializing `fn identity<T>(x: T) -> T { x }` with `T = i32`,
     /// the `params` will be `[(x, i32, Normal)]` and `return_type` will be `i32`.
@@ -1652,6 +1653,7 @@ impl<'a> Sema<'a> {
         params: &[(Spur, Type, RirParamMode, bool)],
         body: InstRef,
         type_subst: &std::collections::HashMap<Spur, Type>,
+        value_subst: &std::collections::HashMap<Spur, ConstValue>,
     ) -> CompileResult<(
         Air,
         u32,
@@ -1664,14 +1666,17 @@ impl<'a> Sema<'a> {
     )> {
         // For specialized functions, we need to populate comptime_type_vars with the
         // type substitutions so that references to type parameters (like `P { ... }`)
-        // can be resolved in the function body.
+        // can be resolved in the function body, and comptime_value_vars with the
+        // value substitutions so comptime contexts (comptime blocks, arguments to
+        // further comptime parameters, comptime-known branch conditions) see the
+        // concrete values.
         self.analyze_function_internal(
             infer_ctx,
             return_type,
             params,
             body,
             Some(type_subst),
-            None,
+            Some(value_subst),
             false,
         )
     }
@@ -1805,6 +1810,12 @@ impl<'a> Sema<'a> {
 
         // Add comptime value variables as if they were parameters
         // This allows constraint generation to see captured comptime values
+        // (anonymous-struct methods capturing `comptime N` from the enclosing
+        // function). Real parameters keep their declared type: in a
+        // value-specialized body (RUE-166) the comptime value parameter is
+        // also a runtime parameter with a precise type (e.g. `comptime n:
+        // i64`), which the fallback below (i32 for any integer) must not
+        // clobber.
         if let Some(values) = value_subst {
             for (name, const_val) in values {
                 let ty = match const_val {
@@ -1813,12 +1824,9 @@ impl<'a> Sema<'a> {
                     ConstValue::Type(t) => *t,
                     ConstValue::Unit => Type::UNIT,
                 };
-                param_vars.insert(
-                    *name,
-                    ParamVarInfo {
-                        ty: self.type_to_infer_type(ty),
-                    },
-                );
+                param_vars.entry(*name).or_insert(ParamVarInfo {
+                    ty: self.type_to_infer_type(ty),
+                });
             }
         }
 
@@ -2944,6 +2952,15 @@ impl<'a> Sema<'a> {
             accessible,
             span,
         )?;
+
+        // Functions with comptime parameters need specialization: a plain
+        // Call to the base name would reference a body that is never
+        // analyzed (generic bodies are only materialized per specialization,
+        // RUE-166). Delegate to the unqualified call path, which emits
+        // CallGeneric; module membership and accessibility were checked above.
+        if fn_info.is_generic {
+            return self.analyze_call(air, function_name, args_start, args_len, span, ctx);
+        }
 
         // Check for exclusive access violation. (The old, pre-deduplication
         // copy of this function skipped this check entirely.)

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1188,12 +1188,29 @@ impl<'a> Sema<'a> {
                         self.resolve_enum_through_module(*module_ref, *type_name, pattern_span)?
                     } else {
                         // Unqualified access: EnumName::Variant
-                        *self.enums.get(type_name).ok_or_compile_error(
+                        let enum_id = *self.enums.get(type_name).ok_or_compile_error(
                             ErrorKind::UnknownEnumType(
                                 self.interner.resolve(&*type_name).to_string(),
                             ),
                             pattern_span,
-                        )?
+                        )?;
+                        // Privacy (E0460, RUE-185): a match pattern names the
+                        // enum unqualified, so a private enum from another
+                        // directory cannot be matched on — privacy is uniform
+                        // across item kinds (spec 10.3:1, 10.3:7). The
+                        // module-qualified branch above does its own check
+                        // (E0706). The pattern-to-AIR conversion later in
+                        // this loop re-resolves the same name but runs only
+                        // after this check has passed.
+                        let def = self.type_pool.enum_def(enum_id);
+                        self.check_unqualified_visibility(
+                            "enum",
+                            self.interner.resolve(&*type_name),
+                            def.file_id,
+                            def.is_pub,
+                            pattern_span,
+                        )?;
+                        enum_id
                     };
                     let enum_def = self.type_pool.enum_def(enum_id);
 
@@ -3351,10 +3368,25 @@ impl<'a> Sema<'a> {
                     self.resolve_enum_through_module(*module_ref, *type_name, inst.span)?
                 } else {
                     // Unqualified access: EnumName::Variant
-                    *self.enums.get(type_name).ok_or_compile_error(
+                    let enum_id = *self.enums.get(type_name).ok_or_compile_error(
                         ErrorKind::UnknownEnumType(self.interner.resolve(&*type_name).to_string()),
                         inst.span,
-                    )?
+                    )?;
+                    // Privacy (E0460, RUE-185): constructing a variant names
+                    // the enum unqualified, so a private enum from another
+                    // directory is not constructible here — privacy is
+                    // uniform across item kinds (spec 10.3:1, 10.3:7). The
+                    // module-qualified branch above does its own check
+                    // (E0706, `resolve_enum_through_module`).
+                    let def = self.type_pool.enum_def(enum_id);
+                    self.check_unqualified_visibility(
+                        "enum",
+                        self.interner.resolve(&*type_name),
+                        def.file_id,
+                        def.is_pub,
+                        inst.span,
+                    )?;
+                    enum_id
                 };
                 let enum_def = self.type_pool.enum_def(enum_id);
 

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -661,6 +661,58 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        // Comptime-known branch selection (RUE-166, spec 4.14:17): inside a
+        // body with comptime value parameters in scope (a value-specialized
+        // function or an anonymous-struct method capturing comptime values),
+        // an `if` whose condition is compile-time evaluable selects its
+        // branch during analysis — only the taken branch is analyzed and
+        // emitted. This is what lets comptime recursion terminate: in
+        // `fact(comptime n: i32)`, the body specialized for n == 1 must not
+        // analyze the `fact(n - 1)` call in the dead else-branch, or
+        // specialization would recurse until the depth cap.
+        if !ctx.comptime_value_vars.is_empty() {
+            if let Some(ConstValue::Bool(taken)) = self.try_evaluate_const_in_fn(cond, ctx) {
+                let taken_block = if taken { Some(then_block) } else { else_block };
+                return match taken_block {
+                    Some(block) => {
+                        ctx.push_scope();
+                        let result = self.analyze_inst(air, block, ctx)?;
+                        ctx.pop_scope();
+                        // An `if` without `else` is unit-typed, so its (taken)
+                        // then-branch must still be unit (spec 4.6:5).
+                        if else_block.is_none()
+                            && result.ty != Type::UNIT
+                            && !result.ty.is_never()
+                            && !result.ty.is_error()
+                        {
+                            return Err(CompileError::new(
+                                ErrorKind::TypeMismatch {
+                                    expected: "()".to_string(),
+                                    found: result.ty.safe_name_with_pool(Some(&self.type_pool)),
+                                },
+                                self.rir.get(block).span,
+                            )
+                            .with_help(
+                                "if expressions without else must have unit type; \
+                                 consider adding an else branch or making the body return ()",
+                            ));
+                        }
+                        Ok(result)
+                    }
+                    // `if false { ... }` with no else: nothing runs; the
+                    // expression is unit.
+                    None => {
+                        let air_ref = air.add_inst(AirInst {
+                            data: AirInstData::UnitConst,
+                            ty: Type::UNIT,
+                            span,
+                        });
+                        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+                    }
+                };
+            }
+        }
+
         // Condition must be bool
         let cond_result = self.analyze_inst(air, cond, ctx)?;
 
@@ -3486,7 +3538,10 @@ impl<'a> Sema<'a> {
     }
 
     /// Analyze a function call.
-    fn analyze_call(
+    ///
+    /// Also used by the module-member-call path for callees with comptime
+    /// parameters, which must go through generic specialization (RUE-166).
+    pub(crate) fn analyze_call(
         &mut self,
         air: &mut Air,
         name: Spur,
@@ -3650,8 +3705,10 @@ impl<'a> Sema<'a> {
 
         // Handle generic function calls differently
         if is_generic {
-            // Separate type arguments from runtime arguments
+            // Separate type arguments and comptime value arguments from
+            // runtime arguments
             let mut type_args: Vec<Type> = Vec::new();
+            let mut value_args: Vec<ConstValue> = Vec::new();
             let mut runtime_args: Vec<AirCallArg> = Vec::new();
             let mut type_subst: std::collections::HashMap<Spur, Type> =
                 std::collections::HashMap::new();
@@ -3680,10 +3737,29 @@ impl<'a> Sema<'a> {
                             ));
                         }
                     } else {
-                        // This is a VALUE parameter (e.g., comptime n: i32)
-                        // It's still passed at runtime but must be a compile-time constant.
-                        // The constant-ness has already been validated above.
-                        // We don't erase value parameters - they're passed normally.
+                        // This is a VALUE parameter (e.g., comptime n: i32).
+                        // Capture its concrete value: the callee is
+                        // specialized per value so its body sees the value as
+                        // a compile-time constant (RUE-166). The argument is
+                        // still also passed at runtime (value parameters are
+                        // not erased from the signature).
+                        match self.try_evaluate_const_in_fn(args[i].value, ctx) {
+                            Some(const_val) => value_args.push(const_val),
+                            None => {
+                                let param_name = self.interner.resolve(&param_names[i]).to_string();
+                                return Err(CompileError::new(
+                                    ErrorKind::ComptimeArgNotConst {
+                                        param_name: param_name.clone(),
+                                    },
+                                    self.rir.get(args[i].value).span,
+                                )
+                                .with_help(format!(
+                                    "parameter '{}' is declared as 'comptime' and requires \
+                                     a compile-time known value",
+                                    param_name
+                                )));
+                            }
+                        }
                         runtime_args.push(air_arg.clone());
                     }
                 } else {
@@ -3798,6 +3874,12 @@ impl<'a> Sema<'a> {
             let type_args_start = air.add_extra(&type_extra);
             let type_args_len = type_args.len() as u32;
 
+            // Encode comptime value arguments into extra array (as a tagged
+            // word stream; the length is in words, not values)
+            let value_words = crate::specialize::encode_const_values(&value_args);
+            let value_args_start = air.add_extra(&value_words);
+            let value_args_len = value_words.len() as u32;
+
             // Encode runtime args into extra array
             let mut args_extra = Vec::with_capacity(runtime_args.len() * 2);
             for arg in &runtime_args {
@@ -3812,6 +3894,8 @@ impl<'a> Sema<'a> {
                     name,
                     type_args_start,
                     type_args_len,
+                    value_args_start,
+                    value_args_len,
                     args_start: runtime_args_start,
                     args_len: runtime_args_len,
                 },

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -52,7 +52,7 @@ use rue_rir::{InstData, InstRef};
 use rue_span::Span;
 
 use super::Sema;
-use super::context::{AnalysisContext, ConstValue};
+use super::context::{AnalysisContext, ConstValue, LocalVar};
 use crate::types::{StructField, Type};
 
 /// Empty type substitution map for evaluation contexts without one.
@@ -70,6 +70,12 @@ pub(crate) struct ComptimeEnv<'a> {
     /// `None` when evaluating expressions outside a typed function context
     /// (comptime function bodies before specialization, const initializers).
     resolved_types: Option<&'a HashMap<InstRef, Type>>,
+    /// Runtime locals in scope at the point being evaluated. A runtime local
+    /// shadows same-named comptime parameters and file-level constants, so a
+    /// reference to it makes the expression non-evaluable — without this,
+    /// `let n = x; g(n)` inside a body with `comptime n` in scope would
+    /// wrongly evaluate `n` to the parameter's value (spec 4.14:6).
+    runtime_locals: Option<&'a HashMap<Spur, LocalVar>>,
     /// `let` bindings introduced by blocks inside the comptime expression.
     locals: HashMap<Spur, ConstValue>,
 }
@@ -81,6 +87,7 @@ impl<'a> ComptimeEnv<'a> {
             type_subst: &EMPTY_TYPE_SUBST,
             value_subst: &EMPTY_VALUE_SUBST,
             resolved_types: None,
+            runtime_locals: None,
             locals: HashMap::new(),
         }
     }
@@ -95,6 +102,7 @@ impl<'a> ComptimeEnv<'a> {
             type_subst,
             value_subst,
             resolved_types: None,
+            runtime_locals: None,
             locals: HashMap::new(),
         }
     }
@@ -106,6 +114,7 @@ impl<'a> ComptimeEnv<'a> {
             type_subst: &ctx.comptime_type_vars,
             value_subst: &ctx.comptime_value_vars,
             resolved_types: Some(ctx.resolved_types),
+            runtime_locals: Some(&ctx.locals),
             locals: HashMap::new(),
         }
     }
@@ -194,14 +203,18 @@ impl Sema<'_> {
     /// Check if an RIR instruction is a direct reference to a `comptime`
     /// parameter of the function currently being analyzed.
     ///
-    /// Such a reference is compile-time known *to every caller* even though
-    /// its value is unknown while the body is analyzed, so it may be
+    /// Such a reference is compile-time known to every caller, so it may be
     /// forwarded to another function's comptime parameter (spec 4.14:5):
     ///
     /// ```rue
     /// fn g(comptime m: i32) -> i32 { m * 2 }
     /// fn f(comptime n: i32) -> i32 { g(n) }  // forwarding
     /// ```
+    ///
+    /// Since per-value specialization (RUE-166), bodies with comptime value
+    /// parameters are only analyzed with the concrete values in
+    /// `ctx.comptime_value_vars`, so forwards normally evaluate directly and
+    /// this check is a fallback.
     pub(crate) fn is_comptime_param_forward(
         &self,
         inst_ref: InstRef,
@@ -721,15 +734,23 @@ impl Sema<'_> {
                 if let Some(&v) = env.locals.get(name) {
                     return Ok(Some(v));
                 }
-                // 2. Comptime type parameters in scope
+                // 2. Runtime locals shadow comptime parameters and file-level
+                //    constants: a reference that resolves to one is not
+                //    compile-time evaluable (spec 4.14:6).
+                if let Some(locals) = env.runtime_locals {
+                    if locals.contains_key(name) {
+                        return Ok(None);
+                    }
+                }
+                // 3. Comptime type parameters in scope
                 if let Some(&ty) = env.type_subst.get(name) {
                     return Ok(Some(ConstValue::Type(ty)));
                 }
-                // 3. Comptime value parameters in scope
+                // 4. Comptime value parameters in scope
                 if let Some(&v) = env.value_subst.get(name) {
                     return Ok(Some(v));
                 }
-                // 4. File-level constants: the value was evaluated once
+                // 5. File-level constants: the value was evaluated once
                 //    (and range-checked against the declared type) during
                 //    declaration gathering — use it directly. Re-evaluating
                 //    the initializer here would fail for forms only the
@@ -753,7 +774,7 @@ impl Sema<'_> {
                     )?;
                     return Ok(Some(info.value));
                 }
-                // 5. Type names used as values (e.g. `Point` in
+                // 6. Type names used as values (e.g. `Point` in
                 //    `fn make_type() -> type { Point }`)
                 Ok(self.resolve_named_type_value(name).map(ConstValue::Type))
             }

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -476,7 +476,7 @@ impl AnalysisResult {
 /// This is used for compile-time evaluation of expressions and for
 /// comptime parameters. For example, in `fn Buffer(comptime N: i32)`,
 /// the value of `N` is stored as a `ConstValue::Integer`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ConstValue {
     /// Integer value. Backed by `i128` so the full range of every Rue integer
     /// type is representable (u64 values above `i64::MAX` as well as negative

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -860,12 +860,13 @@ impl<'a> Sema<'a> {
         let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
         let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
 
-        // Check if this function has any comptime TYPE parameters (not value parameters).
-        // A type parameter is a comptime param where the type is `type`.
-        // - `comptime T: type` -> type parameter (is_generic = true)
-        // - `comptime n: i32` -> value parameter (is_generic = false)
+        // Check if this function has any comptime parameters. Both kinds
+        // require per-call-site specialization (RUE-166):
+        // - `comptime T: type` -> type parameter (specialized per type)
+        // - `comptime n: i32` -> value parameter (specialized per value, so
+        //   the body sees `n` as a compile-time constant)
         let type_sym = self.interner.get_or_intern("type");
-        let is_generic = params.iter().any(|p| p.is_comptime && p.ty == type_sym);
+        let is_generic = params.iter().any(|p| p.is_comptime);
 
         // Collect type parameter names (comptime parameters whose type is `type`)
         let type_param_names: Vec<Spur> = params

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -27,7 +27,8 @@ pub struct FunctionInfo {
     pub rir_params_len: u32,
     /// Span of the function declaration
     pub span: Span,
-    /// Whether this function has any comptime type parameters
+    /// Whether this function has any comptime parameters (type or value) and
+    /// therefore requires per-call-site specialization (RUE-166)
     pub is_generic: bool,
     /// Whether this function is public (visible outside its directory)
     pub is_pub: bool,

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -159,6 +159,17 @@ impl<'a> Sema<'a> {
             )?;
             Ok(Type::new_struct(struct_id))
         } else if let Some(&enum_id) = self.enums.get(&type_sym) {
+            // Privacy (E0460, RUE-185): same rule for enums — an unqualified
+            // type reference must not reach a private enum defined in another
+            // directory.
+            let enum_def = self.type_pool.enum_def(enum_id);
+            self.check_unqualified_visibility(
+                "enum",
+                type_name,
+                enum_def.file_id,
+                enum_def.is_pub,
+                span,
+            )?;
             Ok(Type::new_enum(enum_id))
         } else {
             // Check for array type syntax: [T; N]

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -56,13 +56,13 @@ impl Sema<'_> {
     }
 
     /// Check that an *unqualified* reference may reach the item (RUE-37,
-    /// RUE-180, RUE-183).
+    /// RUE-180, RUE-183, RUE-185).
     ///
     /// All loaded files share one flat global namespace for *name
     /// resolution* (spec 10.5:2, transitional), but privacy is uniform in
     /// every multi-file compilation, imports or not (spec 10.3:7), and it
-    /// covers every item kind — functions, structs, and constants alike
-    /// (spec 10.3:1):
+    /// covers every item kind — functions, structs, enums, and constants
+    /// alike (spec 10.3:1):
     ///
     /// - If the item is accessible per [`Sema::is_accessible`] (it is
     ///   `pub`, or the reference is in the item's directory — ADR-0026
@@ -72,7 +72,7 @@ impl Sema<'_> {
     ///   listed on the command line makes no difference.
     ///
     /// `item_kind` names the kind in the diagnostic ("function", "struct",
-    /// "constant").
+    /// "enum", "constant").
     pub(crate) fn check_unqualified_visibility(
         &self,
         item_kind: &str,

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -4,12 +4,20 @@
 //! instructions into regular `Call` instructions by:
 //!
 //! 1. Collecting all `CallGeneric` instructions in the analyzed functions
-//! 2. For each unique (func_name, type_args) combination, creating a specialized function
+//! 2. For each unique (func_name, type_args, value_args) combination, creating
+//!    a specialized function
 //! 3. Rewriting `CallGeneric` to `Call` with the specialized function name
 //!
+//! Specialization covers both comptime *type* parameters (`comptime T: type`)
+//! and comptime *value* parameters (`comptime n: i32`, RUE-166): each distinct
+//! combination of type and value arguments gets its own specialized body, in
+//! which the value parameters are compile-time constants (available to
+//! `comptime` blocks and forwardable to other comptime parameters).
+//!
 //! Specialized bodies can contain further `CallGeneric` instructions (a generic
-//! function forwarding its type parameter to another generic), so these steps
-//! repeat until no new specializations are discovered.
+//! function forwarding its type parameter to another generic, or a
+//! comptime-recursive function like `fact(comptime n)` calling `fact(n - 1)`),
+//! so these steps repeat until no new specializations are discovered.
 //!
 //! # Architecture
 //!
@@ -25,16 +33,98 @@ use rue_rir::RirParamMode;
 use rue_span::Span;
 
 use crate::inst::{Air, AirInstData};
-use crate::sema::{AnalyzedFunction, FunctionInfo, InferenceContext, Sema, SemaOutput};
+use crate::sema::{AnalyzedFunction, ConstValue, FunctionInfo, InferenceContext, Sema, SemaOutput};
 use crate::types::Type;
 
-/// A key for a specialized function: (base_function_name, type_arguments).
+/// A key for a specialized function:
+/// (base_function_name, type_arguments, value_arguments).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SpecializationKey {
     /// Base function name (e.g., "identity")
     pub base_name: Spur,
-    /// Type arguments (e.g., [Type::I32])
+    /// Type arguments (e.g., [Type::I32]), one per comptime type parameter
     pub type_args: Vec<Type>,
+    /// Comptime value arguments (e.g., [Integer(5)]), one per comptime value
+    /// parameter (RUE-166)
+    pub value_args: Vec<ConstValue>,
+}
+
+// ============================================================================
+// ConstValue <-> extra-array encoding
+// ============================================================================
+//
+// Comptime value arguments travel from the call site (sema) to this pass
+// inside the AIR extra array (a flat `u32` stream), as a tagged word stream:
+// each value is a tag word followed by its payload words.
+
+/// Tag for `ConstValue::Integer` (payload: 4 words, i128 as little-endian u32s).
+const CV_TAG_INTEGER: u32 = 0;
+/// Tag for `ConstValue::Bool` (payload: 1 word, 0 or 1).
+const CV_TAG_BOOL: u32 = 1;
+/// Tag for `ConstValue::Unit` (no payload).
+const CV_TAG_UNIT: u32 = 2;
+/// Tag for `ConstValue::Type` (payload: 1 word, `Type::as_u32`).
+const CV_TAG_TYPE: u32 = 3;
+
+/// Encode comptime value arguments as a tagged `u32` word stream for the AIR
+/// extra array. Decoded by [`decode_const_values`].
+pub fn encode_const_values(values: &[ConstValue]) -> Vec<u32> {
+    let mut words = Vec::with_capacity(values.len() * 5);
+    for value in values {
+        match value {
+            ConstValue::Integer(n) => {
+                words.push(CV_TAG_INTEGER);
+                let bits = *n as u128;
+                for i in 0..4 {
+                    words.push((bits >> (32 * i)) as u32);
+                }
+            }
+            ConstValue::Bool(b) => {
+                words.push(CV_TAG_BOOL);
+                words.push(u32::from(*b));
+            }
+            ConstValue::Unit => words.push(CV_TAG_UNIT),
+            ConstValue::Type(ty) => {
+                words.push(CV_TAG_TYPE);
+                words.push(ty.as_u32());
+            }
+        }
+    }
+    words
+}
+
+/// Decode a tagged word stream produced by [`encode_const_values`].
+pub fn decode_const_values(words: &[u32]) -> Vec<ConstValue> {
+    let mut values = Vec::new();
+    let mut i = 0;
+    while i < words.len() {
+        let tag = words[i];
+        i += 1;
+        let value = match tag {
+            CV_TAG_INTEGER => {
+                let mut bits: u128 = 0;
+                for j in 0..4 {
+                    bits |= u128::from(words[i + j]) << (32 * j);
+                }
+                i += 4;
+                ConstValue::Integer(bits as i128)
+            }
+            CV_TAG_BOOL => {
+                let b = words[i] != 0;
+                i += 1;
+                ConstValue::Bool(b)
+            }
+            CV_TAG_UNIT => ConstValue::Unit,
+            CV_TAG_TYPE => {
+                let ty = Type::from_u32(words[i]);
+                i += 1;
+                ConstValue::Type(ty)
+            }
+            _ => unreachable!("invalid ConstValue tag {tag} in extra array"),
+        };
+        values.push(value);
+    }
+    values
 }
 
 /// Info about a specialization: the mangled name and the first call site span.
@@ -49,8 +139,12 @@ struct SpecializationInfo {
 ///
 /// Each round creates the bodies for the specializations discovered in the
 /// previous round, so this bounds the nesting depth of generic-to-generic
-/// calls. Unbounded growth is possible when a generic function instantiates
-/// itself with an ever-growing type (e.g. `f(Pair(T), ...)` inside `f`).
+/// calls — including comptime-value recursion (`fact(comptime n)` calling
+/// `fact(n - 1)` adds one round per distinct value, RUE-166). Unbounded
+/// growth is possible when a generic function instantiates itself with an
+/// ever-growing type (e.g. `f(Pair(T), ...)` inside `f`) or a
+/// comptime-recursive function never reaches a comptime-known base case,
+/// so this cap turns a would-be-infinite loop into a clean E1200.
 const MAX_SPECIALIZATION_ROUNDS: usize = 64;
 
 /// Perform the specialization pass on the sema output.
@@ -98,8 +192,10 @@ pub fn specialize(
             return Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {
                     reason: format!(
-                        "generic specialization of '{}' exceeded the maximum nesting depth ({}); \
-                         is a generic function recursively instantiating itself with new types?",
+                        "specialization of '{}' exceeded the maximum nesting depth ({}); \
+                         is a comptime-recursive function missing a compile-time-known \
+                         base case, or a generic function recursively instantiating \
+                         itself with new types?",
                         interner.resolve(&key.base_name),
                         MAX_SPECIALIZATION_ROUNDS
                     ),
@@ -146,6 +242,8 @@ fn collect_specializations(
             name,
             type_args_start,
             type_args_len,
+            value_args_start,
+            value_args_len,
             ..
         } = &inst.data
         {
@@ -154,15 +252,21 @@ fn collect_specializations(
                 .iter()
                 .map(|&encoded| Type::from_u32(encoded))
                 .collect();
+            let value_args = decode_const_values(air.get_extra(*value_args_start, *value_args_len));
 
             let key = SpecializationKey {
                 base_name: *name,
                 type_args,
+                value_args,
             };
 
             if let Entry::Vacant(entry) = specializations.entry(key) {
                 let base_name = interner.resolve(name);
-                let mangled = mangle_specialized_name(base_name, &entry.key().type_args);
+                let mangled = mangle_specialized_name(
+                    base_name,
+                    &entry.key().type_args,
+                    &entry.key().value_args,
+                );
                 let mangled_sym = interner.get_or_intern(&mangled);
                 pending.push(entry.key().clone());
                 entry.insert(SpecializationInfo {
@@ -185,6 +289,8 @@ fn rewrite_call_generic(
             name,
             type_args_start,
             type_args_len,
+            value_args_start,
+            value_args_len,
             args_start,
             args_len,
         } = &inst.data
@@ -194,10 +300,12 @@ fn rewrite_call_generic(
                 .iter()
                 .map(|&encoded| Type::from_u32(encoded))
                 .collect();
+            let value_args = decode_const_values(air.get_extra(*value_args_start, *value_args_len));
 
             let key = SpecializationKey {
                 base_name: *name,
                 type_args,
+                value_args,
             };
 
             if let Some(info) = specializations.get(&key) {
@@ -219,13 +327,40 @@ fn rewrite_call_generic(
 }
 
 /// Generate a mangled name for a specialized function.
-fn mangle_specialized_name(base_name: &str, type_args: &[Type]) -> String {
+///
+/// Type arguments and value arguments each contribute a `__`-separated
+/// segment, so distinct comptime values yield distinct symbols
+/// (`fact__v5`, `fact__v4`, ...; RUE-166) exactly like distinct types do
+/// (RUE-100's lesson: colliding mangles mean duplicate symbols at link time).
+fn mangle_specialized_name(
+    base_name: &str,
+    type_args: &[Type],
+    value_args: &[ConstValue],
+) -> String {
     let mut mangled = base_name.to_string();
     for ty in type_args {
         mangled.push_str("__");
         mangled.push_str(&mangle_type(*ty));
     }
+    for value in value_args {
+        mangled.push_str("__");
+        mangled.push_str(&mangle_const_value(value));
+    }
     mangled
+}
+
+/// Mangle a single comptime value argument into a unique symbol fragment.
+///
+/// Negative integers use an `m` (minus) prefix on the magnitude because `-`
+/// is not a safe symbol character (`-3` -> `vm3`).
+fn mangle_const_value(value: &ConstValue) -> String {
+    match value {
+        ConstValue::Integer(n) if *n < 0 => format!("vm{}", n.unsigned_abs()),
+        ConstValue::Integer(n) => format!("v{}", n),
+        ConstValue::Bool(b) => format!("v{}", b),
+        ConstValue::Unit => "vunit".to_string(),
+        ConstValue::Type(ty) => format!("v{}", mangle_type(*ty)),
+    }
 }
 
 /// Mangle a single type argument into a unique string.
@@ -247,10 +382,13 @@ fn mangle_type(ty: Type) -> String {
     }
 }
 
-/// Create a specialized function by re-analyzing the body with type substitution.
+/// Create a specialized function by re-analyzing the body with type and
+/// value substitution.
 ///
-/// This builds a type substitution map from the comptime parameters to their concrete
-/// type arguments, then re-analyzes the function body with these substitutions.
+/// This builds a type substitution map from the comptime type parameters to
+/// their concrete type arguments and a value substitution map from the
+/// comptime value parameters to their concrete values (RUE-166), then
+/// re-analyzes the function body with these substitutions.
 fn create_specialized_function(
     sema: &mut Sema<'_>,
     infer_ctx: &InferenceContext,
@@ -261,12 +399,26 @@ fn create_specialized_function(
 ) -> CompileResult<AnalyzedFunction> {
     let specialized_name_str = interner.resolve(&specialized_name).to_string();
 
+    // Pair each comptime parameter with its argument: type parameters
+    // (declared `: type`) consume the type_args stream, value parameters
+    // consume the value_args stream — mirroring how the call site collected
+    // them (both in parameter order).
     let mut type_subst: HashMap<Spur, Type> = HashMap::new();
+    let mut value_subst: HashMap<Spur, ConstValue> = HashMap::new();
     let mut type_arg_idx = 0;
-    for (name, _, _, is_comptime) in sema.param_arena.iter(base_info.params) {
-        if *is_comptime && type_arg_idx < key.type_args.len() {
-            type_subst.insert(*name, key.type_args[type_arg_idx]);
-            type_arg_idx += 1;
+    let mut value_arg_idx = 0;
+    for (name, ty, _, is_comptime) in sema.param_arena.iter(base_info.params) {
+        if !*is_comptime {
+            continue;
+        }
+        if *ty == Type::COMPTIME_TYPE {
+            if type_arg_idx < key.type_args.len() {
+                type_subst.insert(*name, key.type_args[type_arg_idx]);
+                type_arg_idx += 1;
+            }
+        } else if value_arg_idx < key.value_args.len() {
+            value_subst.insert(*name, key.value_args[value_arg_idx]);
+            value_arg_idx += 1;
         }
     }
 
@@ -291,7 +443,16 @@ fn create_specialized_function(
         Vec::with_capacity(base_params.len());
     for (name, ty, mode, is_comptime) in base_params {
         if is_comptime {
-            // Comptime parameters are erased from the specialized signature.
+            if ty == Type::COMPTIME_TYPE {
+                // Comptime TYPE parameters are erased from the specialized
+                // signature (types don't exist at runtime).
+                continue;
+            }
+            // Comptime VALUE parameters stay in the runtime signature — the
+            // call site still passes them (see `analyze_call`); their constant
+            // value is additionally substituted into the body via value_subst
+            // so comptime contexts see it (RUE-166).
+            specialized_params.push((name, ty, mode, true));
             continue;
         }
         let concrete_ty = if ty == Type::COMPTIME_TYPE {
@@ -320,6 +481,7 @@ fn create_specialized_function(
         &specialized_params,
         base_info.body,
         &type_subst,
+        &value_subst,
     )?;
 
     Ok(AnalyzedFunction {

--- a/crates/rue-cli-tests/cases/comptime_value_params.toml
+++ b/crates/rue-cli-tests/cases/comptime_value_params.toml
@@ -1,0 +1,145 @@
+# Comptime value parameters are monomorphized per value (RUE-166).
+#
+# Before the fix, a function with a `comptime n: i32` parameter was analyzed
+# ONCE with `n` unknown: `comptime { n }` in its body failed E1200, and
+# recursion (`fact(n - 1)`) failed E1201 at the argument. Now every distinct
+# comptime value creates its own specialization (`f__v5`, `f__v3`, ...) —
+# mirroring the RUE-109 type-identity mangling — in which `n` is a
+# compile-time constant. Comptime-known `if` conditions inside such bodies
+# select their branch at compile time, so comptime recursion terminates; a
+# depth cap (64 rounds) diagnoses runaway recursion instead of hanging.
+
+[section]
+id = "cli.comptime_value_params"
+name = "Comptime value parameter specialization"
+description = "Per-value monomorphization of comptime value parameters through the real driver."
+
+[[case]]
+name = "comptime_block_uses_param"
+description = "The body's comptime block sees the concrete value of the comptime parameter."
+files = [{ path = "main.rue", source = """
+fn f(comptime n: i32) -> i32 {
+    comptime { n + 1 }
+}
+fn main() -> i32 {
+    @dbg(f(5));
+    0
+}
+""" }]
+stdout = "6\n"
+
+[[case]]
+name = "comptime_recursion_factorial"
+description = "Comptime recursion: each value specializes, dead branches prune, recursion terminates."
+files = [{ path = "main.rue", source = """
+fn fact(comptime n: i32) -> i32 {
+    if n <= 1 { 1 } else { n * fact(n - 1) }
+}
+fn main() -> i32 {
+    @dbg(fact(5));
+    0
+}
+""" }]
+stdout = "120\n"
+
+[[case]]
+name = "comptime_forwarding_still_works"
+description = "Pin: forwarding a comptime parameter to another comptime parameter (worked pre-fix)."
+files = [{ path = "main.rue", source = """
+fn g(comptime m: i32) -> i32 { m }
+fn f(comptime n: i32) -> i32 { g(n) }
+fn main() -> i32 {
+    @dbg(f(42));
+    0
+}
+""" }]
+stdout = "42\n"
+
+[[case]]
+name = "two_distinct_values_two_symbols"
+description = "f(3) and f(5) produce distinct specialized symbols; same value dedups (RUE-100's duplicate-symbol failure mode must not return)."
+files = [{ path = "main.rue", source = """
+fn f(comptime n: i32) -> i32 {
+    comptime { n + 1 }
+}
+fn main() -> i32 {
+    @dbg(f(3) + f(5) + f(5));
+    0
+}
+""" }]
+stdout = "16\n"
+
+[[case]]
+name = "mixed_type_and_value_params"
+description = "A function with both a comptime type parameter and a comptime value parameter specializes on both."
+files = [{ path = "main.rue", source = """
+fn scaled(comptime T: type, comptime k: i32, x: T) -> T {
+    x * comptime { k * 2 }
+}
+fn main() -> i32 {
+    @dbg(scaled(i32, 3, 7));
+    0
+}
+""" }]
+stdout = "42\n"
+
+[[case]]
+name = "runaway_comptime_recursion_diagnosed"
+description = "Recursion with no comptime-known base case hits the depth cap with a clean diagnostic (no hang, no ICE)."
+files = [{ path = "main.rue", source = """
+fn runaway(comptime n: i32) -> i32 {
+    runaway(n + 1)
+}
+fn main() -> i32 {
+    runaway(0)
+}
+""" }]
+compile_fail = true
+error_contains = ["exceeded the maximum"]
+
+[[case]]
+name = "deep_base_case_diagnosed_not_hung"
+description = "fact(1000000): a base case beyond the depth cap is a fast, clean error — not a compiler hang."
+files = [{ path = "main.rue", source = """
+fn fact(comptime n: i64) -> i64 {
+    if n <= 1 { 1 } else { n * fact(n - 1) }
+}
+fn main() -> i32 {
+    if fact(1000000) > 0 { 1 } else { 0 }
+}
+""" }]
+compile_fail = true
+error_contains = ["exceeded the maximum"]
+
+[[case]]
+name = "module_member_call_with_comptime_param"
+description = "Calling a comptime-value function through a module object routes through specialization."
+files = [
+    { path = "main.rue", source = """
+const util = @import("util");
+fn main() -> i32 {
+    @dbg(util.scale(5, 7));
+    0
+}
+""" },
+    { path = "util.rue", source = """
+pub fn scale(comptime k: i32, x: i32) -> i32 {
+    x * comptime { k + 1 }
+}
+""" },
+]
+args = ["main.rue", "util.rue", "-o", "prog"]
+stdout = "42\n"
+
+[[case]]
+name = "runtime_arg_to_comptime_param_still_rejected"
+description = "Pin: a runtime value passed to a comptime parameter is still E1201."
+files = [{ path = "main.rue", source = """
+fn double(comptime n: i32) -> i32 { n * 2 }
+fn main() -> i32 {
+    let x = 21;
+    double(x)
+}
+""" }]
+compile_fail = true
+error_contains = ["comptime parameter requires a compile-time known value"]

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -856,6 +856,188 @@ const BONUS: i32 = 10;
 ]
 exit_code = 42
 
+# Enums obey the same uniform rule (RUE-185): naming a private enum from
+# another directory — annotation, variant construction, or match pattern —
+# is E0460, whether the file was imported or merely listed.
+[[case]]
+name = "private_enum_cross_dir_unqualified_rejected"
+description = "Unqualified annotation/construction naming a private enum in another directory is E0460 (RUE-185), imported or not."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let c: Color = Color::Blue;
+    0
+}
+""" },
+    { path = "sub/lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "enum `Color` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "flat_multifile_private_enum_construction_rejected"
+description = "Uniform privacy for enums (RUE-185): a variant of a private enum in a never-imported listed file is not constructible cross-directory."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let c = Color::Blue;
+    0
+}
+""" },
+    { path = "sub/lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "enum `Color` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "flat_multifile_private_enum_match_pattern_rejected"
+description = "A match pattern is a reference site too (RUE-185): matching on a private cross-directory enum is E0460 with the pattern's own file-attributed span, even when the scrutinee arrives via a pub fn."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    match make() {
+        Color::Red => 1,
+        Color::Green => 2,
+        Color::Blue => 3,
+    }
+}
+""" },
+    { path = "sub/lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+pub fn make() -> Color {
+    Color::Green
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "enum `Color` is private (defined in `sub/lib.rue`)", "main.rue"]
+
+[[case]]
+name = "private_enum_module_qualified_pattern_rejected"
+description = "Through a module object the private enum stays E0706 (non-regression, RUE-185): `lib.Color::Red` in a match pattern."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    match lib.make() {
+        lib.Color::Red => 1,
+        _ => 0,
+    }
+}
+""" },
+    { path = "sub/lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+pub fn make() -> Color {
+    Color::Green
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0706", "enum `Color` is private"]
+
+[[case]]
+name = "flat_multifile_pub_enum_cross_dir_allowed"
+description = "Positive control (RUE-185): a pub enum in another never-imported directory remains usable unqualified — annotation, construction, and match (spec 10.3:8)."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let c: Color = Color::Blue;
+    match c {
+        Color::Red => 10,
+        Color::Green => 20,
+        Color::Blue => 42,
+    }
+}
+""" },
+    { path = "sub/lib.rue", source = """
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "pub_enum_module_qualified_pattern_allowed"
+description = "Positive control (RUE-185): a pub enum through a module object works in match patterns, verified by execution."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    match lib.make() {
+        lib.Color::Red => 1,
+        lib.Color::Green => 42,
+        lib.Color::Blue => 3,
+    }
+}
+""" },
+    { path = "sub/lib.rue", source = """
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+pub fn make() -> Color {
+    Color::Green
+}
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "flat_multifile_private_enum_same_dir_allowed"
+description = "Control (RUE-185): intra-directory visibility is unchanged — a private enum in another listed file in the SAME directory is usable."
+args = ["main.rue", "lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let c: Color = Color::Green;
+    match c {
+        Color::Red => 1,
+        Color::Green => 42,
+        Color::Blue => 3,
+    }
+}
+""" },
+    { path = "lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" },
+]
+exit_code = 42
+
 # ---------------------------------------------------------------------------
 # Nested module member access (RUE-122 regression coverage).
 #

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -823,7 +823,7 @@ pub struct AmbiguousModuleData {
 /// exceed it).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrivateUnqualifiedAccessData {
-    /// The kind of item ("function", "struct", "constant").
+    /// The kind of item ("function", "struct", "enum", "constant").
     pub item_kind: String,
     /// The item's name as written at the reference site.
     pub name: String,

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -181,11 +181,16 @@ pub enum PatternKind {
     Path = 3,
 }
 
-/// Size of each pattern kind in the extra array (including body InstRef)
-const PATTERN_WILDCARD_SIZE: u32 = 4; // kind, span_start, span_len, body
-const PATTERN_INT_SIZE: u32 = 7; // kind, span_start, span_len, value_lo, value_hi, negative, body
-const PATTERN_BOOL_SIZE: u32 = 5; // kind, span_start, span_len, value, body
-const PATTERN_PATH_SIZE: u32 = 7; // kind, span_start, span_len, module, type_name, variant, body
+/// Size of each pattern kind in the extra array (including body InstRef).
+///
+/// The span is stored as three words — start, len, AND file id — so pattern
+/// diagnostics in multi-file compilations attribute to the right file
+/// (dropping the file id here was why pattern-anchored errors reported
+/// "span has an unknown file id", RUE-185).
+const PATTERN_WILDCARD_SIZE: u32 = 5; // kind, span_start, span_len, span_file, body
+const PATTERN_INT_SIZE: u32 = 8; // kind, span_start, span_len, span_file, value_lo, value_hi, negative, body
+const PATTERN_BOOL_SIZE: u32 = 6; // kind, span_start, span_len, span_file, value, body
+const PATTERN_PATH_SIZE: u32 = 8; // kind, span_start, span_len, span_file, module, type_name, variant, body
 
 /// Stored representation of struct field initializer.
 /// Layout: [field_name: u32, value: u32] = 2 u32s per field
@@ -398,6 +403,7 @@ impl Rir {
                     self.extra.push(PatternKind::Wildcard as u32);
                     self.extra.push(span.start());
                     self.extra.push(span.len());
+                    self.extra.push(span.file_id.index());
                     self.extra.push(body.as_u32());
                 }
                 RirPattern::Int {
@@ -408,6 +414,7 @@ impl Rir {
                     self.extra.push(PatternKind::Int as u32);
                     self.extra.push(span.start());
                     self.extra.push(span.len());
+                    self.extra.push(span.file_id.index());
                     // Store u64 magnitude as two u32s (little-endian) plus sign flag
                     self.extra.push(*value as u32);
                     self.extra.push((*value >> 32) as u32);
@@ -418,6 +425,7 @@ impl Rir {
                     self.extra.push(PatternKind::Bool as u32);
                     self.extra.push(span.start());
                     self.extra.push(span.len());
+                    self.extra.push(span.file_id.index());
                     self.extra.push(if *value { 1 } else { 0 });
                     self.extra.push(body.as_u32());
                 }
@@ -430,6 +438,7 @@ impl Rir {
                     self.extra.push(PatternKind::Path as u32);
                     self.extra.push(span.start());
                     self.extra.push(span.len());
+                    self.extra.push(span.file_id.index());
                     // Store module as u32::MAX for None, otherwise the InstRef
                     self.extra.push(module.map_or(u32::MAX, |r| r.as_u32()));
                     self.extra.push(type_name.into_usize() as u32);
@@ -441,6 +450,16 @@ impl Rir {
         (start, arms.len() as u32)
     }
 
+    /// Decode a pattern's span from the extra array. Every pattern kind
+    /// stores its span as [start, len, file_id] at offsets 1..=3 after the
+    /// kind word (see the `PATTERN_*_SIZE` layout comments).
+    fn decode_pattern_span(extra: &[u32], pos: usize) -> Span {
+        let span_start = extra[pos + 1];
+        let span_len = extra[pos + 2];
+        let file_id = rue_span::FileId::new(extra[pos + 3]);
+        Span::with_file(file_id, span_start, span_start + span_len)
+    }
+
     /// Retrieve match arms from the extra array.
     pub fn get_match_arms(&self, start: u32, arm_count: u32) -> Vec<(RirPattern, InstRef)> {
         let mut arms = Vec::with_capacity(arm_count as usize);
@@ -450,22 +469,18 @@ impl Rir {
             let kind = self.extra[pos];
             match kind {
                 k if k == PatternKind::Wildcard as u32 => {
-                    let span_start = self.extra[pos + 1];
-                    let span_len = self.extra[pos + 2];
-                    let span = Span::new(span_start, span_start + span_len);
-                    let body = InstRef::from_raw(self.extra[pos + 3]);
+                    let span = Self::decode_pattern_span(&self.extra, pos);
+                    let body = InstRef::from_raw(self.extra[pos + 4]);
                     arms.push((RirPattern::Wildcard(span), body));
                     pos += PATTERN_WILDCARD_SIZE as usize;
                 }
                 k if k == PatternKind::Int as u32 => {
-                    let span_start = self.extra[pos + 1];
-                    let span_len = self.extra[pos + 2];
-                    let span = Span::new(span_start, span_start + span_len);
-                    let value_lo = self.extra[pos + 3] as u64;
-                    let value_hi = self.extra[pos + 4] as u64;
+                    let span = Self::decode_pattern_span(&self.extra, pos);
+                    let value_lo = self.extra[pos + 4] as u64;
+                    let value_hi = self.extra[pos + 5] as u64;
                     let value = value_lo | (value_hi << 32);
-                    let negative = self.extra[pos + 5] != 0;
-                    let body = InstRef::from_raw(self.extra[pos + 6]);
+                    let negative = self.extra[pos + 6] != 0;
+                    let body = InstRef::from_raw(self.extra[pos + 7]);
                     arms.push((
                         RirPattern::Int {
                             value,
@@ -477,28 +492,24 @@ impl Rir {
                     pos += PATTERN_INT_SIZE as usize;
                 }
                 k if k == PatternKind::Bool as u32 => {
-                    let span_start = self.extra[pos + 1];
-                    let span_len = self.extra[pos + 2];
-                    let span = Span::new(span_start, span_start + span_len);
-                    let value = self.extra[pos + 3] != 0;
-                    let body = InstRef::from_raw(self.extra[pos + 4]);
+                    let span = Self::decode_pattern_span(&self.extra, pos);
+                    let value = self.extra[pos + 4] != 0;
+                    let body = InstRef::from_raw(self.extra[pos + 5]);
                     arms.push((RirPattern::Bool(value, span), body));
                     pos += PATTERN_BOOL_SIZE as usize;
                 }
                 k if k == PatternKind::Path as u32 => {
-                    let span_start = self.extra[pos + 1];
-                    let span_len = self.extra[pos + 2];
-                    let span = Span::new(span_start, span_start + span_len);
+                    let span = Self::decode_pattern_span(&self.extra, pos);
                     // Decode module: u32::MAX means None
-                    let module_raw = self.extra[pos + 3];
+                    let module_raw = self.extra[pos + 4];
                     let module = if module_raw == u32::MAX {
                         None
                     } else {
                         Some(InstRef::from_raw(module_raw))
                     };
-                    let type_name = Spur::try_from_usize(self.extra[pos + 4] as usize).unwrap();
-                    let variant = Spur::try_from_usize(self.extra[pos + 5] as usize).unwrap();
-                    let body = InstRef::from_raw(self.extra[pos + 6]);
+                    let type_name = Spur::try_from_usize(self.extra[pos + 5] as usize).unwrap();
+                    let variant = Spur::try_from_usize(self.extra[pos + 6] as usize).unwrap();
+                    let body = InstRef::from_raw(self.extra[pos + 7]);
                     arms.push((
                         RirPattern::Path {
                             module,
@@ -1164,12 +1175,13 @@ impl Rir {
                             k if k == PatternKind::Path as u32 => PATTERN_PATH_SIZE as usize,
                             _ => panic!("Unknown pattern kind during merge: {}", kind),
                         };
-                        // Path patterns also embed a module InstRef at offset 3
-                        // (u32::MAX encodes None); it must be renumbered like
-                        // every other InstRef or it would point into the wrong
-                        // file's instruction space after merging.
-                        if kind == PatternKind::Path as u32 && extra[pos + 3] != u32::MAX {
-                            extra[pos + 3] += inst_offset;
+                        // Path patterns also embed a module InstRef at offset 4
+                        // (after kind + the 3-word span; u32::MAX encodes
+                        // None); it must be renumbered like every other
+                        // InstRef or it would point into the wrong file's
+                        // instruction space after merging.
+                        if kind == PatternKind::Path as u32 && extra[pos + 4] != u32::MAX {
+                            extra[pos + 4] += inst_offset;
                         }
                         // The body InstRef is always the last element of each pattern
                         extra[pos + pattern_size - 1] += inst_offset;

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1347,3 +1347,139 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "type mismatch"
+
+# =============================================================================
+# Per-Value Specialization of Comptime Value Parameters (RUE-166)
+# =============================================================================
+# Each distinct comptime value argument creates its own specialized function
+# body, in which the parameter is a compile-time constant.
+
+[[case]]
+name = "comptime_param_usable_in_comptime_block"
+spec = ["4.14:5"]
+description = "A comptime value parameter is a compile-time constant inside the body's comptime blocks"
+source = """
+fn f(comptime n: i32) -> i32 {
+    comptime { n + 1 }
+}
+fn main() -> i32 {
+    f(41)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_two_distinct_values_specialize"
+spec = ["4.14:5"]
+description = "Two distinct comptime values produce two specializations with distinct symbols (no duplicate-symbol link error, RUE-100)"
+source = """
+fn f(comptime n: i32) -> i32 {
+    comptime { n * n }
+}
+fn main() -> i32 {
+    f(4) + f(5) + 1
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_same_value_deduplicated"
+spec = ["4.14:5"]
+description = "Repeated calls with the same comptime value share one specialization"
+source = """
+fn f(comptime n: i32) -> i32 {
+    comptime { n + 7 }
+}
+fn main() -> i32 {
+    f(14) + f(14)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_forward_derived_expression"
+spec = ["4.14:5"]
+description = "An expression over a comptime parameter is itself comptime-known and can be forwarded"
+source = """
+fn g(comptime m: i32) -> i32 { m * 2 }
+fn f(comptime n: i32) -> i32 { g(n + 1) }
+fn main() -> i32 {
+    f(20)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_i64_specialization"
+spec = ["4.14:5"]
+description = "Comptime value parameters keep their declared type in the specialized body (i64, not i32)"
+source = """
+fn double(comptime n: i64) -> i64 {
+    n * 2
+}
+fn main() -> i32 {
+    if double(3000000000) == 6000000000 { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_if_selects_branch_recursion"
+spec = ["4.14:17"]
+description = "A comptime-known if selects its branch at compile time, letting comptime recursion terminate"
+source = """
+fn fact(comptime n: i32) -> i32 {
+    if n <= 1 { 1 } else { n * fact(n - 1) }
+}
+fn main() -> i32 {
+    if fact(5) == 120 { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_if_false_branch_no_else"
+spec = ["4.14:17"]
+description = "A comptime-known false condition with no else contributes unit and compiles nothing"
+source = """
+fn f(comptime n: i32) -> i32 {
+    if n > 100 {
+        return 0;
+    }
+    n
+}
+fn main() -> i32 {
+    f(42)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_recursion_depth_limit"
+spec = ["4.14:18"]
+description = "Comptime recursion without a compile-time-known base case is diagnosed, not an infinite loop"
+source = """
+fn runaway(comptime n: i32) -> i32 {
+    runaway(n + 1)
+}
+fn main() -> i32 {
+    runaway(0)
+}
+"""
+compile_fail = true
+error_contains = "exceeded the maximum"
+
+[[case]]
+name = "comptime_recursion_depth_limit_deep_base_case"
+spec = ["4.14:18"]
+description = "A base case beyond the maximum specialization depth is diagnosed cleanly (no hang)"
+source = """
+fn count(comptime n: i32) -> i32 {
+    if n <= 0 { 0 } else { 1 + count(n - 1) }
+}
+fn main() -> i32 {
+    count(1000000)
+}
+"""
+compile_fail = true
+error_contains = "exceeded the maximum"

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -486,3 +486,128 @@ const BONUS: i32 = 10;
 """ }
 pass_aux_files = true
 exit_code = 42
+
+# =============================================================================
+# Unqualified Cross-Directory Access: Enums (RUE-185)
+# =============================================================================
+# The uniform privacy rule (10.3:7) covers enums too: naming a private enum
+# from another directory — in a type annotation, a variant construction, or a
+# match pattern — is E0460, imported or flat-listed.
+
+[[case]]
+name = "cross_dir_unqualified_private_enum_error"
+spec = ["10.3:7"]
+description = "Unqualified annotation + variant construction naming a private enum of an imported module in another directory is rejected"
+source = """
+const defs = @import("subdir/defs");
+
+fn main() -> i32 {
+    let c: Color = Color::Blue;
+    0
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" }
+compile_fail = true
+error_contains = "enum `Color` is private (defined in"
+
+[[case]]
+name = "flat_multifile_unqualified_private_enum_construction_error"
+spec = ["10.3:7", "10.3:8"]
+description = "Uniform privacy: constructing a variant of a private enum in a never-imported, explicitly listed file in another directory is rejected"
+source = """
+fn main() -> i32 {
+    let c = Color::Blue;
+    0
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "enum `Color` is private (defined in"
+
+[[case]]
+name = "flat_multifile_private_enum_match_pattern_error"
+spec = ["10.3:7", "10.3:8"]
+description = "A match pattern names the enum unqualified too: matching on a private cross-directory enum is rejected even when the scrutinee arrives through a pub function"
+source = """
+fn main() -> i32 {
+    match make() {
+        Color::Red => 1,
+        Color::Green => 2,
+        Color::Blue => 3,
+    }
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+pub fn make() -> Color {
+    Color::Green
+}
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "enum `Color` is private (defined in"
+
+[[case]]
+name = "flat_multifile_unqualified_pub_enum_allowed"
+spec = ["10.3:8", "10.5:2"]
+description = "The flat namespace still resolves pub enums across directories without imports: annotation, construction, and match all work"
+source = """
+fn main() -> i32 {
+    let c: Color = Color::Blue;
+    match c {
+        Color::Red => 10,
+        Color::Green => 20,
+        Color::Blue => 42,
+    }
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" }
+pass_aux_files = true
+exit_code = 42
+
+[[case]]
+name = "flat_multifile_same_dir_private_enum_allowed"
+spec = ["10.3:2", "10.3:8"]
+description = "Intra-directory visibility (ADR-0026) is unchanged: a private enum in another listed file in the same directory is usable unqualified"
+source = """
+fn main() -> i32 {
+    let c: Color = Color::Green;
+    match c {
+        Color::Red => 1,
+        Color::Green => 42,
+        Color::Blue => 3,
+    }
+}
+"""
+aux_files = { "defs.rue" = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" }
+pass_aux_files = true
+exit_code = 42

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -137,6 +137,31 @@ fn main() -> i32 {
 }
 ```
 
+{{ rule(id="4.14:17", cat="normative") }}
+
+Within a specialized function body, an `if` expression whose condition can be evaluated at compile time (because it references comptime parameters in scope) selects its branch at compile time: only the taken branch is analyzed and compiled. This permits comptime-recursive functions, whose recursive call sits in a branch that is not taken once the recursion reaches its base case.
+
+```rue
+fn fact(comptime n: i32) -> i32 {
+    if n <= 1 { 1 } else { n * fact(n - 1) }
+}
+
+fn main() -> i32 {
+    fact(5)  // 120: fact(5) .. fact(1) are specialized; fact(1) takes the
+             // then-branch, so the recursion terminates
+}
+```
+
+{{ rule(id="4.14:18", cat="legality-rule") }}
+
+It is a compile-time error when specialization exceeds the implementation's maximum nesting depth (at least 64 levels), as happens when a comptime-recursive function never reaches a compile-time-known base case or a generic function recursively instantiates itself with new types. Implementations **MUST** diagnose this instead of failing to terminate.
+
+```rue
+fn runaway(comptime n: i32) -> i32 {
+    runaway(n + 1)  // ERROR: exceeds the maximum specialization depth
+}
+```
+
 ## Anonymous Struct Types
 
 {{ rule(id="4.14:7", cat="normative") }}

--- a/docs/spec/src/10-modules/03-visibility.md
+++ b/docs/spec/src/10-modules/03-visibility.md
@@ -67,8 +67,9 @@ private item by its unqualified name from a source file in a different
 directory than the item's defining file (error E0460). This covers every
 form of unqualified reference: calling a private function, naming a
 private struct (in a type annotation, a signature, or a struct literal),
-and reading a private constant — including from another constant's
-initializer.
+naming a private enum (in a type annotation, a signature, a variant
+construction, or a match pattern), and reading a private constant —
+including from another constant's initializer.
 
 {{ rule(id="10.3:8", cat="normative") }}
 
@@ -87,6 +88,8 @@ fn secret() -> i32 { 99 }       // private to sub/
 pub fn open() -> i32 { 7 }
 struct Hidden { n: i32, }       // private to sub/
 pub struct Shared { n: i32, }
+enum Mode { Fast, Slow, }       // private to sub/
+pub enum Level { Low, High, }
 const LIMIT: i32 = 8;           // private to sub/
 pub const MAX: i32 = 16;
 
@@ -94,8 +97,12 @@ pub const MAX: i32 = 16;
 fn main() -> i32 {
     // secret()                  // error E0460: private to sub/lib.rue
     // let h = Hidden { n: 1 };  // error E0460: private to sub/lib.rue
+    // let m = Mode::Fast;       // error E0460: private to sub/lib.rue
     // let l = LIMIT;            // error E0460: private to sub/lib.rue
     let s = Shared { n: MAX };   // OK: `Shared` and `MAX` are pub
-    open() + s.n
+    match Level::High {          // OK: `Level` is pub
+        Level::Low => 0,
+        Level::High => open() + s.n,
+    }
 }
 ```


### PR DESCRIPTION
Cycle-18 worker integration, **stacked on #1005** (shared `analyze_ops.rs`; diff shrinks to this work once #1005 merges).

**RUE-166** — the RUE-163 epic's largest residual: a comptime value param was analyzed once with its value unknown, so `comptime { n + 1 }` failed E1200 and comptime recursion failed E1201. `SpecializationKey` now carries value_args: per-call-site-value specialization (`fact__v5` mangling — RUE-109's type-identity pattern extended to values), bodies analyze under value substitution so the typed evaluator sees concrete values, and comptime-known `if` conditions select their branch at analysis time — which is what lets comptime recursion terminate. Depth-capped at the existing MAX_SPECIALIZATION_ROUNDS=64 with a diagnostic naming the function.

Two latent bugs fixed en route: value substitution clobbered non-i32 comptime param types, and the evaluator ignored runtime locals shadowing comptime params.

Integration verification by execution: `f(5)`=6, `fact(5)`=120, `f(3)+f(5)`=10 with distinct specialized symbols (no RUE-100 dup-symbol relapse), forwarding pin green, `fact(1000000)` → clean E1200 depth diagnostic, no hang. New spec rules 4.14:17–18, +9 spec / +9 CLI cases, traceability 576/576, full `./test.sh` green on the stack.

Fixes RUE-166

🤖 Generated with [Claude Code](https://claude.com/claude-code)