### PR TITLE
Linear arrays are consumable element-wise; per-element move tracking and drop flags

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ rue main.rue utils.rue lib.rue -o program
 
 **Key semantics:**
 - All top-level names resolve across files without imports (flat namespace),
-  but privacy is uniform (spec 10.3:7): an item — function, struct, or
+  but privacy is uniform (spec 10.3:7): an item — function, struct, enum, or
   constant — is usable outside its defining directory only if `pub`, whether
   its file is imported or just listed (E0460 otherwise; through a module
   object it's E0706)

--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -48,10 +48,14 @@ pub struct FunctionSig {
     pub param_types: Vec<InferType>,
     /// Return type, as InferType for uniform handling.
     pub return_type: InferType,
-    /// Whether this is a generic function (has comptime type parameters).
+    /// Whether this function requires specialization (has any comptime
+    /// parameters — type parameters like `comptime T: type` or value
+    /// parameters like `comptime n: i32`, RUE-166).
     /// Generic calls substitute the comptime type arguments into the parameter
     /// types before constraining arguments; type parameters that can't be
     /// resolved during constraint generation are checked in sema instead.
+    /// Comptime value parameters have concrete declared types, so their
+    /// arguments are constrained normally.
     pub is_generic: bool,
     /// Parameter modes (Normal, Inout, Borrow, Comptime).
     pub param_modes: Vec<rue_rir::RirParamMode>,

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -1051,22 +1051,25 @@ pub enum AirInstData {
     /// whose contents were moved out (the new owner is responsible for the
     /// drop). Emitted by sema wherever the move checker marks a whole
     /// variable as moved, and — with `place` set — wherever it marks a
-    /// struct field path as moved (a partial move, RUE-62/RUE-157).
+    /// struct field path (a partial move, RUE-62/RUE-157) or a
+    /// constant-index array element (RUE-186) as moved.
     MarkMoved {
-        /// The use of the variable (or field) that constitutes the move
+        /// The use of the variable (or field/element) that constitutes the move
         value: AirRef,
         /// The local slot (or parameter ABI slot when `is_param`) moved from
         slot: u32,
         /// True when `slot` refers to a parameter ABI slot
         is_param: bool,
         /// `None`: the slot's whole value moved out. `Some(place)`: only
-        /// the field path named by the place's projections moved out — a
-        /// pure `Field` projection chain of any depth (`o.a`, `o.a.b`);
-        /// drop elaboration then drops the struct field-granularly,
-        /// skipping the moved path. Paths through an array index
-        /// (`arr[i].a`) are NOT exported (no marker), keeping the
-        /// whole-slot drop — which re-drops the moved element (a known
-        /// gap: array-element moves aren't tracked by drop elaboration).
+        /// the path named by the place's projections moved out — a pure
+        /// `Field` projection chain of any depth (`o.a`, `o.a.b`), or a
+        /// single CONSTANT-index projection (`xs[K]`, RUE-186, whose index
+        /// operand is a dedicated `Const` instruction); drop elaboration
+        /// then drops the struct/array path-granularly, skipping the moved
+        /// path. Paths THROUGH an array index (`arr[i].a`) are NOT exported
+        /// (no marker), keeping the whole-slot drop — which re-drops the
+        /// moved element (a known gap: index-interior paths aren't tracked
+        /// by drop elaboration).
         place: Option<AirPlaceRef>,
     },
 }

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -818,12 +818,18 @@ pub enum AirInstData {
 
     /// Generic function call - requires specialization before codegen.
     ///
-    /// This is emitted when calling a function with `comptime T: type` parameters.
-    /// During a post-analysis specialization pass, this is rewritten to a regular
-    /// `Call` to a specialized version of the function (e.g., `identity__i32`).
+    /// This is emitted when calling a function with `comptime` parameters
+    /// (type parameters like `comptime T: type` or value parameters like
+    /// `comptime n: i32`, RUE-166). During a post-analysis specialization
+    /// pass, this is rewritten to a regular `Call` to a specialized version
+    /// of the function (e.g., `identity__i32`, `fact__v5`).
     ///
-    /// The type_args are encoded in the extra array as raw Type discriminant values.
-    /// The runtime args (non-comptime) are also in the extra array, after type_args.
+    /// The type_args are encoded in the extra array as raw Type discriminant
+    /// values. The comptime value arguments are encoded in the extra array as
+    /// a tagged word stream (see `specialize::encode_const_values`). The
+    /// runtime args are also in the extra array; comptime value arguments
+    /// remain part of the runtime argument list (they are still passed at
+    /// runtime), while type arguments are erased.
     CallGeneric {
         /// Base function name (interned symbol)
         name: Spur,
@@ -831,6 +837,10 @@ pub enum AirInstData {
         type_args_start: u32,
         /// Number of type arguments
         type_args_len: u32,
+        /// Start index into extra array for encoded comptime value arguments
+        value_args_start: u32,
+        /// Number of words (not values) in the encoded value-argument stream
+        value_args_len: u32,
         /// Start index into extra array for runtime arguments
         args_start: u32,
         /// Number of runtime arguments
@@ -1169,6 +1179,8 @@ impl fmt::Display for Air {
                     name,
                     type_args_start,
                     type_args_len,
+                    value_args_start,
+                    value_args_len,
                     args_start,
                     args_len,
                 } => {
@@ -1180,6 +1192,19 @@ impl fmt::Display for Air {
                         }
                         let type_val = self.extra[(*type_args_start + i) as usize];
                         write!(f, "type#{}", type_val)?;
+                    }
+                    // Show comptime value arguments (decoded from the tagged
+                    // word stream, see specialize::encode_const_values)
+                    for (i, value) in crate::specialize::decode_const_values(
+                        self.get_extra(*value_args_start, *value_args_len),
+                    )
+                    .iter()
+                    .enumerate()
+                    {
+                        if i > 0 || *type_args_len > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "value {:?}", value)?;
                     }
                     write!(f, ">(")?;
                     // Show runtime arguments

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -928,6 +928,50 @@ fn require_byref_place_arg(rir: &Rir, arg: &RirCallArg) -> CompileResult<Spur> {
     })
 }
 
+/// Result of the element-wise linear array consumption check (RUE-186); see
+/// [`Sema::check_array_elementwise_consumption`].
+enum ElementwiseConsumption {
+    /// Every element was moved out on every path: the array's must-consume
+    /// obligation is satisfied.
+    Complete,
+    /// No element was ever consumed (or the type is not an array): the
+    /// caller reports its usual whole-value diagnostic.
+    NotElementwise,
+}
+
+/// Intern the move-path segment for a constant array index (RUE-186).
+///
+/// Element paths reuse the field-path representation: index K becomes the
+/// interned decimal string of K. Identifiers can never be all digits, so
+/// these segments cannot collide with field names (see
+/// [`super::context::FieldPath`]).
+pub(crate) fn index_path_segment(interner: &ThreadedRodeo, index: u64) -> Spur {
+    interner.get_or_intern(index.to_string())
+}
+
+/// True when a move-path segment encodes a constant array index (all-digit
+/// interned string; see [`index_path_segment`]).
+pub(crate) fn is_index_segment(interner: &ThreadedRodeo, seg: Spur) -> bool {
+    let s = interner.resolve(&seg);
+    !s.is_empty() && s.bytes().all(|b| b.is_ascii_digit())
+}
+
+/// Format a move path for diagnostics: field segments as `.name`, constant
+/// array index segments as `[K]` (e.g. `xs[0]`, `o.a`, `o.items[2].name`).
+fn format_move_path(interner: &ThreadedRodeo, root_var: Spur, path: &[Spur]) -> String {
+    let mut out = interner.resolve(&root_var).to_string();
+    for seg in path {
+        let s = interner.resolve(seg);
+        if is_index_segment(interner, *seg) {
+            out.push_str(&format!("[{s}]"));
+        } else {
+            out.push('.');
+            out.push_str(s);
+        }
+    }
+    out
+}
+
 /// Build the use-after-move error for a field access whose path (or one of
 /// its ancestor prefixes) was moved at `moved_span`.
 pub(crate) fn use_after_move_path_error(
@@ -937,16 +981,7 @@ pub(crate) fn use_after_move_path_error(
     span: Span,
     moved_span: Span,
 ) -> CompileError {
-    let root_name = interner.resolve(&root_var);
-    let path_str = if field_path.is_empty() {
-        root_name.to_string()
-    } else {
-        let field_names: Vec<_> = field_path
-            .iter()
-            .map(|s| interner.resolve(s).to_string())
-            .collect();
-        format!("{}.{}", root_name, field_names.join("."))
-    };
+    let path_str = format_move_path(interner, root_var, field_path);
     CompileError::new(ErrorKind::UseAfterMove(path_str), span)
         .with_label("value moved here", moved_span)
 }
@@ -1601,6 +1636,17 @@ impl<'a> Sema<'a> {
                 }
                 let state = ctx.moved_vars.get(&p.name);
                 if !state.is_some_and(|s| s.full_move_on_all_paths) {
+                    // Element-wise consumption of a linear array parameter
+                    // (RUE-186) satisfies the obligation like a whole move.
+                    match self.check_array_elementwise_consumption(
+                        p.ty,
+                        state,
+                        p.name,
+                        self.rir.get(body).span,
+                    )? {
+                        ElementwiseConsumption::Complete => continue,
+                        ElementwiseConsumption::NotElementwise => {}
+                    }
                     let name = self.interner.resolve(&p.name);
                     let err = linear_not_consumed_error(
                         name,
@@ -2574,7 +2620,13 @@ impl<'a> Sema<'a> {
                 },
                 result_type: field_type,
                 field_name: Some(field),
+                const_index: None,
             });
+
+            // A write through an element of a partially moved array
+            // (`xs[0].f = ...` after an element of `xs` moved out) is
+            // rejected (RUE-186, E0480), like a direct element write.
+            self.reject_write_into_partially_moved_array(&trace, ctx, span)?;
 
             // Analyze the value
             let value_result = self.analyze_inst(air, value, ctx)?;
@@ -2730,7 +2782,12 @@ impl<'a> Sema<'a> {
                 },
                 result_type: elem_type,
                 field_name: None,
+                const_index: self.try_get_const_index(index),
             });
+
+            // Writing into an array with moved-out elements is rejected
+            // (RUE-186, E0480): the write can't re-arm per-element ownership.
+            self.reject_write_into_partially_moved_array(&trace, ctx, span)?;
 
             // Analyze the value
             let value_result = self.analyze_inst(air, value, ctx)?;
@@ -4483,7 +4540,8 @@ impl<'a> Sema<'a> {
 
             // Only check types that carry a linear value: linear structs
             // themselves, and arrays whose elements carry one (an array of
-            // linear values must be consumed as a whole; dropping it would
+            // linear values must be consumed — as a whole, or element-wise
+            // via constant-index moves (RUE-186); dropping it would
             // silently drop every element).
             if !self.type_carries_linear(local.ty) {
                 continue;
@@ -4494,15 +4552,80 @@ impl<'a> Sema<'a> {
             // consumed in only one branch of an if/match still leaks on the
             // other paths.
             let state = ctx.moved_vars.get(symbol);
-            if !state.is_some_and(|s| s.full_move_on_all_paths) {
-                let name = self.interner.resolve(&*symbol);
-                let err =
-                    linear_not_consumed_error(name, local.span, state.and_then(|s| s.full_move));
-                return Err(self.attach_infectious_linear_note(err, local.ty));
+            if state.is_some_and(|s| s.full_move_on_all_paths) {
+                continue;
             }
+
+            // Element-wise consumption of a linear array (RUE-186, spec
+            // 3.8:71): moving every element out (constant indices) on every
+            // path satisfies the array's must-consume obligation. Partial
+            // element consumption is an error naming the missing elements.
+            match self.check_array_elementwise_consumption(local.ty, state, *symbol, local.span)? {
+                ElementwiseConsumption::Complete => continue,
+                ElementwiseConsumption::NotElementwise => {}
+            }
+
+            let name = self.interner.resolve(&*symbol);
+            let err = linear_not_consumed_error(name, local.span, state.and_then(|s| s.full_move));
+            return Err(self.attach_infectious_linear_note(err, local.ty));
         }
 
         Ok(())
+    }
+
+    /// Shared element-wise consumption check for linear arrays (RUE-186):
+    /// returns `Complete` when every element of the array was moved out on
+    /// every path (the must-consume obligation is satisfied), an `Err`
+    /// naming the missing elements when the array was only PARTIALLY
+    /// consumed element-wise, and `NotElementwise` when no element was ever
+    /// consumed (or the type is not an array) — the caller then reports its
+    /// usual whole-value diagnostic.
+    fn check_array_elementwise_consumption(
+        &self,
+        ty: Type,
+        state: Option<&super::context::VariableMoveState>,
+        symbol: Spur,
+        decl_span: Span,
+    ) -> CompileResult<ElementwiseConsumption> {
+        let TypeKind::Array(array_id) = ty.kind() else {
+            return Ok(ElementwiseConsumption::NotElementwise);
+        };
+        let Some(s) = state else {
+            return Ok(ElementwiseConsumption::NotElementwise);
+        };
+        let (_elem, len) = self.type_pool.array_def(array_id);
+        let elem_path = |k: u64| vec![index_path_segment(self.interner, k)];
+        let unconsumed: Vec<u64> = (0..len)
+            .filter(|k| !s.partial_moves_on_all_paths.contains(&elem_path(*k)))
+            .collect();
+        if unconsumed.is_empty() {
+            return Ok(ElementwiseConsumption::Complete);
+        }
+        let touched_any_element = s.partial_moves.keys().any(|p| {
+            p.first()
+                .is_some_and(|seg| is_index_segment(self.interner, *seg))
+        });
+        if !touched_any_element {
+            return Ok(ElementwiseConsumption::NotElementwise);
+        }
+        let name = self.interner.resolve(&symbol);
+        // An unconsumed element that WAS moved on some path selects the
+        // more precise "not consumed on all paths" diagnostic (E0443 over
+        // E0406).
+        let some_path_span = unconsumed
+            .iter()
+            .find_map(|k| s.partial_moves.get(&elem_path(*k)).copied());
+        let list = unconsumed
+            .iter()
+            .map(|k| format!("[{k}]"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        Err(
+            linear_not_consumed_error(name, decl_span, some_path_span).with_note(format!(
+                "the array is partially consumed: element(s) {list} of \
+                 '{name}' are not consumed on every path"
+            )),
+        )
     }
 
     /// Reject a discarded expression value that carries a linear value
@@ -4540,7 +4663,8 @@ impl<'a> Sema<'a> {
         if let TypeKind::Array(_) = ty.kind() {
             return err.with_note(
                 "this is an array whose elements carry linear values; \
-                 the array must be consumed as a whole",
+                 consume the array as a whole, or move every element out \
+                 with constant indices (`consume(xs[0]); consume(xs[1]); ...`)",
             );
         }
         let Some(struct_id) = ty.as_struct() else {
@@ -4555,6 +4679,210 @@ impl<'a> Sema<'a> {
             )),
             None => err,
         }
+    }
+
+    /// Try to record a per-element move out of an array (RUE-186, spec
+    /// 3.8:68): `let x = xs[K];` with a CONSTANT index K, rooted directly at
+    /// an array variable, moves just element K out. Sibling elements stay
+    /// usable; drop elaboration is informed via the marker the caller emits
+    /// (see [`Self::emit_element_move_marker`]).
+    ///
+    /// Returns `Ok(Some(k))` when the move was recorded (the caller must
+    /// emit the marker and skip the E0904 rejection), `Ok(None)` when this
+    /// index expression is not element-trackable — dynamic index, or the
+    /// array is not the trace root — and the caller must keep the
+    /// conservative E0904 rejection (spec 7.1:28): with a runtime index sema
+    /// cannot know WHICH element moved, so neither use-after-move checking
+    /// nor drop suppression could stay sound.
+    pub(crate) fn record_element_move_out(
+        &mut self,
+        trace: &super::analyze_ops::PlaceTrace,
+        ctx: &mut AnalysisContext,
+        span: Span,
+    ) -> CompileResult<Option<i64>> {
+        if trace.projections.len() != 1 {
+            return Ok(None);
+        }
+        let Some(k) = trace.projections[0].const_index else {
+            return Ok(None);
+        };
+        if k < 0 {
+            // Negative constants are rejected by the bounds check before
+            // this is reached; defensive.
+            return Ok(None);
+        }
+        // Moving an element out of a borrow/inout parameter would leave the
+        // CALLER's array holed, exactly like a whole or field move.
+        self.reject_move_out_of_byref_param(trace.root_var, ctx, span)?;
+        let elem_path = vec![index_path_segment(self.interner, k as u64)];
+        if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
+            if let Some(moved_span) = state.is_path_moved(&elem_path) {
+                return Err(use_after_move_path_error(
+                    self.interner,
+                    trace.root_var,
+                    &elem_path,
+                    span,
+                    moved_span,
+                ));
+            }
+        }
+        ctx.moved_vars
+            .entry(trace.root_var)
+            .or_default()
+            .mark_path_moved(&elem_path, span);
+        Ok(Some(k))
+    }
+
+    /// Export a recorded element move (RUE-186) to drop elaboration: wrap
+    /// `value` in a [`AirInstData::MarkMoved`] whose place carries a
+    /// constant-index projection (the CFG builder resolves it back to the
+    /// element index; see `moved_field_path` in `rue-cfg`). Only bases that
+    /// drop elaboration would drop get a marker: locals, and Normal (owned)
+    /// params — mirroring the field-move marker conditions.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn emit_element_move_marker(
+        &self,
+        air: &mut Air,
+        trace: &super::analyze_ops::PlaceTrace,
+        ctx: &AnalysisContext,
+        value: AirRef,
+        k: i64,
+        elem_type: Type,
+        array_type: Type,
+        span: Span,
+    ) -> AirRef {
+        let droppable_base = match trace.base {
+            AirPlaceBase::Local(_) => true,
+            AirPlaceBase::Param(_) => ctx
+                .params
+                .iter()
+                .any(|p| p.name == trace.root_var && p.mode == RirParamMode::Normal),
+        };
+        if !droppable_base {
+            return value;
+        }
+        let (slot, is_param) = match trace.base {
+            AirPlaceBase::Local(slot) => (slot, false),
+            AirPlaceBase::Param(slot) => (slot, true),
+        };
+        // A dedicated Const instruction keeps the marker's index resolvable
+        // even when the source index expression was a folded constant
+        // rather than a literal.
+        let idx_const = air.add_inst(AirInst {
+            data: AirInstData::Const(k as u64),
+            ty: Type::U64,
+            span,
+        });
+        let marker_place = air.make_place(
+            trace.base,
+            std::iter::once(AirProjection::Index {
+                array_type,
+                index: idx_const,
+            }),
+        );
+        air.add_inst(AirInst {
+            data: AirInstData::MarkMoved {
+                value,
+                slot,
+                is_param,
+                place: Some(marker_place),
+            },
+            ty: elem_type,
+            span,
+        })
+    }
+
+    /// Reject a read through an array element that is (or may be) moved out
+    /// (RUE-186). Element moves only exist for indices rooted directly at an
+    /// array variable, so only a position-0 `Index` projection can read
+    /// through one. A constant index checks exactly that element's path; a
+    /// dynamic index conservatively fails on ANY outstanding partial move of
+    /// the root (sema can't know which element is read — soundness).
+    pub(crate) fn check_read_through_moved_element(
+        &self,
+        trace: &super::analyze_ops::PlaceTrace,
+        ctx: &AnalysisContext,
+        span: Span,
+    ) -> CompileResult<()> {
+        let Some(first) = trace.projections.first() else {
+            return Ok(());
+        };
+        if !matches!(first.proj, AirProjection::Index { .. }) {
+            return Ok(());
+        }
+        let Some(state) = ctx.moved_vars.get(&trace.root_var) else {
+            return Ok(());
+        };
+        match first.const_index {
+            Some(k) if k >= 0 => {
+                let elem_path = vec![index_path_segment(self.interner, k as u64)];
+                if let Some(moved_span) = state.is_path_moved(&elem_path) {
+                    return Err(use_after_move_path_error(
+                        self.interner,
+                        trace.root_var,
+                        &elem_path,
+                        span,
+                        moved_span,
+                    ));
+                }
+            }
+            _ => {
+                if let Some(moved_span) = state.is_any_part_moved() {
+                    return Err(use_after_move_path_error(
+                        self.interner,
+                        trace.root_var,
+                        &[],
+                        span,
+                        moved_span,
+                    )
+                    .with_note(
+                        "the index is not a compile-time constant, so any \
+                         moved-out element poisons the whole array",
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Reject a write into an array place while one or more of the root
+    /// array's elements are moved out (RUE-186, E0480). Re-arming
+    /// per-element ownership through an element (or through-element) write
+    /// is not supported — sema-side reinitialization and the runtime drop
+    /// flags would disagree — so the whole array must be reinitialized
+    /// instead. Writes into arrays with no outstanding element moves are
+    /// unaffected.
+    pub(crate) fn reject_write_into_partially_moved_array(
+        &self,
+        trace: &super::analyze_ops::PlaceTrace,
+        ctx: &AnalysisContext,
+        span: Span,
+    ) -> CompileResult<()> {
+        // The write must go through the root array (position-0 Index
+        // projection); element moves only exist for array roots.
+        if !matches!(
+            trace.projections.first().map(|p| &p.proj),
+            Some(AirProjection::Index { .. })
+        ) {
+            return Ok(());
+        }
+        let Some(state) = ctx.moved_vars.get(&trace.root_var) else {
+            return Ok(());
+        };
+        let element_move_span = state.partial_moves.iter().find_map(|(p, s)| {
+            p.first()
+                .filter(|seg| is_index_segment(self.interner, **seg))
+                .map(|_| *s)
+        });
+        let Some(moved_span) = element_move_span else {
+            return Ok(());
+        };
+        let name = self.interner.resolve(&trace.root_var).to_string();
+        Err(
+            CompileError::new(ErrorKind::AssignToPartiallyMovedArray { array: name }, span)
+                .with_label("element moved out here", moved_span)
+                .with_help("reinitialize the whole array instead (`xs = [...]`)"),
+        )
     }
 
     /// Extract the root variable symbol from an expression, if it refers to a variable.

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -123,7 +123,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                 continue;
             }
 
-            // Skip generic functions - they'll be analyzed during specialization
+            // Skip functions with comptime parameters - they are analyzed per specialization
             if let Some(fn_info) = sema.functions.get(name) {
                 if fn_info.is_generic {
                     continue;
@@ -476,7 +476,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                 None => continue, // Should not happen, but be defensive
             };
 
-            // Skip generic functions - they're analyzed during specialization
+            // Skip functions with comptime parameters - they are analyzed per specialization
             if fn_info.is_generic {
                 continue;
             }
@@ -1641,7 +1641,8 @@ impl<'a> Sema<'a> {
     ///
     /// This is similar to `analyze_function` but for generic function specialization.
     /// The `type_subst` map provides substitutions for type parameters to their
-    /// concrete types.
+    /// concrete types; the `value_subst` map provides the concrete values of the
+    /// comptime value parameters (RUE-166).
     ///
     /// For example, when specializing `fn identity<T>(x: T) -> T { x }` with `T = i32`,
     /// the `params` will be `[(x, i32, Normal)]` and `return_type` will be `i32`.
@@ -1652,6 +1653,7 @@ impl<'a> Sema<'a> {
         params: &[(Spur, Type, RirParamMode, bool)],
         body: InstRef,
         type_subst: &std::collections::HashMap<Spur, Type>,
+        value_subst: &std::collections::HashMap<Spur, ConstValue>,
     ) -> CompileResult<(
         Air,
         u32,
@@ -1664,14 +1666,17 @@ impl<'a> Sema<'a> {
     )> {
         // For specialized functions, we need to populate comptime_type_vars with the
         // type substitutions so that references to type parameters (like `P { ... }`)
-        // can be resolved in the function body.
+        // can be resolved in the function body, and comptime_value_vars with the
+        // value substitutions so comptime contexts (comptime blocks, arguments to
+        // further comptime parameters, comptime-known branch conditions) see the
+        // concrete values.
         self.analyze_function_internal(
             infer_ctx,
             return_type,
             params,
             body,
             Some(type_subst),
-            None,
+            Some(value_subst),
             false,
         )
     }
@@ -1805,6 +1810,12 @@ impl<'a> Sema<'a> {
 
         // Add comptime value variables as if they were parameters
         // This allows constraint generation to see captured comptime values
+        // (anonymous-struct methods capturing `comptime N` from the enclosing
+        // function). Real parameters keep their declared type: in a
+        // value-specialized body (RUE-166) the comptime value parameter is
+        // also a runtime parameter with a precise type (e.g. `comptime n:
+        // i64`), which the fallback below (i32 for any integer) must not
+        // clobber.
         if let Some(values) = value_subst {
             for (name, const_val) in values {
                 let ty = match const_val {
@@ -1813,12 +1824,9 @@ impl<'a> Sema<'a> {
                     ConstValue::Type(t) => *t,
                     ConstValue::Unit => Type::UNIT,
                 };
-                param_vars.insert(
-                    *name,
-                    ParamVarInfo {
-                        ty: self.type_to_infer_type(ty),
-                    },
-                );
+                param_vars.entry(*name).or_insert(ParamVarInfo {
+                    ty: self.type_to_infer_type(ty),
+                });
             }
         }
 
@@ -2944,6 +2952,15 @@ impl<'a> Sema<'a> {
             accessible,
             span,
         )?;
+
+        // Functions with comptime parameters need specialization: a plain
+        // Call to the base name would reference a body that is never
+        // analyzed (generic bodies are only materialized per specialization,
+        // RUE-166). Delegate to the unqualified call path, which emits
+        // CallGeneric; module membership and accessibility were checked above.
+        if fn_info.is_generic {
+            return self.analyze_call(air, function_name, args_start, args_len, span, ctx);
+        }
 
         // Check for exclusive access violation. (The old, pre-deduplication
         // copy of this function skipped this check entirely.)

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1188,12 +1188,29 @@ impl<'a> Sema<'a> {
                         self.resolve_enum_through_module(*module_ref, *type_name, pattern_span)?
                     } else {
                         // Unqualified access: EnumName::Variant
-                        *self.enums.get(type_name).ok_or_compile_error(
+                        let enum_id = *self.enums.get(type_name).ok_or_compile_error(
                             ErrorKind::UnknownEnumType(
                                 self.interner.resolve(&*type_name).to_string(),
                             ),
                             pattern_span,
-                        )?
+                        )?;
+                        // Privacy (E0460, RUE-185): a match pattern names the
+                        // enum unqualified, so a private enum from another
+                        // directory cannot be matched on — privacy is uniform
+                        // across item kinds (spec 10.3:1, 10.3:7). The
+                        // module-qualified branch above does its own check
+                        // (E0706). The pattern-to-AIR conversion later in
+                        // this loop re-resolves the same name but runs only
+                        // after this check has passed.
+                        let def = self.type_pool.enum_def(enum_id);
+                        self.check_unqualified_visibility(
+                            "enum",
+                            self.interner.resolve(&*type_name),
+                            def.file_id,
+                            def.is_pub,
+                            pattern_span,
+                        )?;
+                        enum_id
                     };
                     let enum_def = self.type_pool.enum_def(enum_id);
 
@@ -3351,10 +3368,25 @@ impl<'a> Sema<'a> {
                     self.resolve_enum_through_module(*module_ref, *type_name, inst.span)?
                 } else {
                     // Unqualified access: EnumName::Variant
-                    *self.enums.get(type_name).ok_or_compile_error(
+                    let enum_id = *self.enums.get(type_name).ok_or_compile_error(
                         ErrorKind::UnknownEnumType(self.interner.resolve(&*type_name).to_string()),
                         inst.span,
-                    )?
+                    )?;
+                    // Privacy (E0460, RUE-185): constructing a variant names
+                    // the enum unqualified, so a private enum from another
+                    // directory is not constructible here — privacy is
+                    // uniform across item kinds (spec 10.3:1, 10.3:7). The
+                    // module-qualified branch above does its own check
+                    // (E0706, `resolve_enum_through_module`).
+                    let def = self.type_pool.enum_def(enum_id);
+                    self.check_unqualified_visibility(
+                        "enum",
+                        self.interner.resolve(&*type_name),
+                        def.file_id,
+                        def.is_pub,
+                        inst.span,
+                    )?;
+                    enum_id
                 };
                 let enum_def = self.type_pool.enum_def(enum_id);
 

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -59,6 +59,10 @@ pub(crate) struct ProjectionInfo {
     /// For field projections: the field name (for move checking)
     /// For index projections: None
     pub field_name: Option<Spur>,
+    /// For index projections whose index is a compile-time constant: its
+    /// value (for per-element move tracking, RUE-186). None for field
+    /// projections and dynamic indices.
+    pub const_index: Option<i64>,
 }
 
 /// Result of tracing a place expression in RIR.
@@ -244,6 +248,7 @@ impl<'a> Sema<'a> {
                             },
                             result_type: field_type,
                             field_name: Some(*field),
+                            const_index: None,
                         });
 
                         Ok(Some(trace))
@@ -291,6 +296,7 @@ impl<'a> Sema<'a> {
                             },
                             result_type: elem_type,
                             field_name: None,
+                            const_index: self.try_get_const_index(*index),
                         });
 
                         Ok(Some(trace))
@@ -2444,7 +2450,7 @@ impl<'a> Sema<'a> {
     /// leave the CALLER's variable (partially) moved-from after the call
     /// returns, so both are rejected outright (RUE-127); reinitialization
     /// before exit is not tracked yet.
-    fn reject_move_out_of_byref_param(
+    pub(crate) fn reject_move_out_of_byref_param(
         &self,
         root_var: Spur,
         ctx: &AnalysisContext,
@@ -2630,6 +2636,10 @@ impl<'a> Sema<'a> {
                 }
             }
 
+            // A field read through an array element (`xs[0].f`) must not go
+            // through a moved-out element (RUE-186).
+            self.check_read_through_moved_element(&trace, ctx, span)?;
+
             // Get struct info for move checking
             // The trace's result type is the field type, but we need the parent struct type
             // to check if it's linear. The parent is the type *before* the last projection.
@@ -2707,11 +2717,12 @@ impl<'a> Sema<'a> {
                 // Export pure-field-path moves of any depth (`o.a`, `o.a.b`)
                 // to drop elaboration so the moved path's drop inside the
                 // struct's scope-exit drop is suppressed (RUE-62, RUE-157).
-                // Paths through an array index (`arr[i].a`) get no marker:
+                // Paths THROUGH an array index (`arr[i].a`) get no marker:
                 // drop elaboration keeps the whole-slot drop, which re-drops
-                // the moved element (a known gap — array-element moves
-                // aren't tracked by drop elaboration). Only Normal params
-                // occupy a real ABI slot that drop elaboration would drop.
+                // the moved element (a known gap; root-level element moves
+                // `arr[K]` ARE tracked — RUE-186 — but index-interior paths
+                // are not). Only Normal params occupy a real ABI slot that
+                // drop elaboration would drop.
                 let pure_field_path = trace
                     .projections
                     .iter()
@@ -3232,8 +3243,10 @@ impl<'a> Sema<'a> {
             // of the array (RUE-143), so the non-Copy rejection below does
             // not apply — but indexing an already-moved array is still a
             // use-after-move (`field_path()` of an index-terminated trace is
-            // empty, so this checks the root's full move).
+            // empty, so this checks the root's full move; the per-element
+            // check below covers a moved-out element, RUE-186).
             let is_byref_arg_use = ctx.byref_arg_root == Some(trace.root_var);
+            let mut element_move: Option<i64> = None;
             if is_byref_arg_use {
                 let field_path = trace.field_path();
                 if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
@@ -3247,24 +3260,50 @@ impl<'a> Sema<'a> {
                         ));
                     }
                 }
+                self.check_read_through_moved_element(&trace, ctx, span)?;
             } else if !self.is_type_copy(elem_type) {
-                // Prevent moving non-Copy elements out of arrays.
-                return Err(CompileError::new(
-                    ErrorKind::MoveOutOfIndex {
-                        element_type: elem_type.safe_name_with_pool(Some(&self.type_pool)),
-                    },
-                    span,
-                )
-                .with_help("use explicit methods like swap() or take() to remove elements"));
+                // A CONSTANT index directly into an array variable moves
+                // just that element out (per-element tracking, RUE-186,
+                // spec 3.8:68). Everything else — dynamic index, or an
+                // array that is not the trace root — keeps the rejection:
+                // with a runtime index sema cannot know which element
+                // moved, so neither use-after-move checking nor drop
+                // suppression could stay sound (spec 7.1:28).
+                element_move = self.record_element_move_out(&trace, ctx, span)?;
+                if element_move.is_none() {
+                    return Err(CompileError::new(
+                        ErrorKind::MoveOutOfIndex {
+                            element_type: elem_type.safe_name_with_pool(Some(&self.type_pool)),
+                        },
+                        span,
+                    )
+                    .with_help(
+                        "moving an element out requires a compile-time \
+                         constant index into an array variable",
+                    ));
+                }
             }
 
             // Emit PlaceRead instruction
             let place_ref = Self::build_place_ref(air, &trace);
-            let air_ref = air.add_inst(AirInst {
+            let mut air_ref = air.add_inst(AirInst {
                 data: AirInstData::PlaceRead { place: place_ref },
                 ty: elem_type,
                 span,
             });
+            if let Some(k) = element_move {
+                // Export the element move to drop elaboration (RUE-186).
+                air_ref = self.emit_element_move_marker(
+                    air,
+                    &trace,
+                    ctx,
+                    air_ref,
+                    k,
+                    elem_type,
+                    parent_type,
+                    span,
+                );
+            }
             return Ok(AnalysisResult::new(air_ref, elem_type));
         }
 

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -661,6 +661,58 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        // Comptime-known branch selection (RUE-166, spec 4.14:17): inside a
+        // body with comptime value parameters in scope (a value-specialized
+        // function or an anonymous-struct method capturing comptime values),
+        // an `if` whose condition is compile-time evaluable selects its
+        // branch during analysis — only the taken branch is analyzed and
+        // emitted. This is what lets comptime recursion terminate: in
+        // `fact(comptime n: i32)`, the body specialized for n == 1 must not
+        // analyze the `fact(n - 1)` call in the dead else-branch, or
+        // specialization would recurse until the depth cap.
+        if !ctx.comptime_value_vars.is_empty() {
+            if let Some(ConstValue::Bool(taken)) = self.try_evaluate_const_in_fn(cond, ctx) {
+                let taken_block = if taken { Some(then_block) } else { else_block };
+                return match taken_block {
+                    Some(block) => {
+                        ctx.push_scope();
+                        let result = self.analyze_inst(air, block, ctx)?;
+                        ctx.pop_scope();
+                        // An `if` without `else` is unit-typed, so its (taken)
+                        // then-branch must still be unit (spec 4.6:5).
+                        if else_block.is_none()
+                            && result.ty != Type::UNIT
+                            && !result.ty.is_never()
+                            && !result.ty.is_error()
+                        {
+                            return Err(CompileError::new(
+                                ErrorKind::TypeMismatch {
+                                    expected: "()".to_string(),
+                                    found: result.ty.safe_name_with_pool(Some(&self.type_pool)),
+                                },
+                                self.rir.get(block).span,
+                            )
+                            .with_help(
+                                "if expressions without else must have unit type; \
+                                 consider adding an else branch or making the body return ()",
+                            ));
+                        }
+                        Ok(result)
+                    }
+                    // `if false { ... }` with no else: nothing runs; the
+                    // expression is unit.
+                    None => {
+                        let air_ref = air.add_inst(AirInst {
+                            data: AirInstData::UnitConst,
+                            ty: Type::UNIT,
+                            span,
+                        });
+                        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+                    }
+                };
+            }
+        }
+
         // Condition must be bool
         let cond_result = self.analyze_inst(air, cond, ctx)?;
 
@@ -3486,7 +3538,10 @@ impl<'a> Sema<'a> {
     }
 
     /// Analyze a function call.
-    fn analyze_call(
+    ///
+    /// Also used by the module-member-call path for callees with comptime
+    /// parameters, which must go through generic specialization (RUE-166).
+    pub(crate) fn analyze_call(
         &mut self,
         air: &mut Air,
         name: Spur,
@@ -3650,8 +3705,10 @@ impl<'a> Sema<'a> {
 
         // Handle generic function calls differently
         if is_generic {
-            // Separate type arguments from runtime arguments
+            // Separate type arguments and comptime value arguments from
+            // runtime arguments
             let mut type_args: Vec<Type> = Vec::new();
+            let mut value_args: Vec<ConstValue> = Vec::new();
             let mut runtime_args: Vec<AirCallArg> = Vec::new();
             let mut type_subst: std::collections::HashMap<Spur, Type> =
                 std::collections::HashMap::new();
@@ -3680,10 +3737,29 @@ impl<'a> Sema<'a> {
                             ));
                         }
                     } else {
-                        // This is a VALUE parameter (e.g., comptime n: i32)
-                        // It's still passed at runtime but must be a compile-time constant.
-                        // The constant-ness has already been validated above.
-                        // We don't erase value parameters - they're passed normally.
+                        // This is a VALUE parameter (e.g., comptime n: i32).
+                        // Capture its concrete value: the callee is
+                        // specialized per value so its body sees the value as
+                        // a compile-time constant (RUE-166). The argument is
+                        // still also passed at runtime (value parameters are
+                        // not erased from the signature).
+                        match self.try_evaluate_const_in_fn(args[i].value, ctx) {
+                            Some(const_val) => value_args.push(const_val),
+                            None => {
+                                let param_name = self.interner.resolve(&param_names[i]).to_string();
+                                return Err(CompileError::new(
+                                    ErrorKind::ComptimeArgNotConst {
+                                        param_name: param_name.clone(),
+                                    },
+                                    self.rir.get(args[i].value).span,
+                                )
+                                .with_help(format!(
+                                    "parameter '{}' is declared as 'comptime' and requires \
+                                     a compile-time known value",
+                                    param_name
+                                )));
+                            }
+                        }
                         runtime_args.push(air_arg.clone());
                     }
                 } else {
@@ -3798,6 +3874,12 @@ impl<'a> Sema<'a> {
             let type_args_start = air.add_extra(&type_extra);
             let type_args_len = type_args.len() as u32;
 
+            // Encode comptime value arguments into extra array (as a tagged
+            // word stream; the length is in words, not values)
+            let value_words = crate::specialize::encode_const_values(&value_args);
+            let value_args_start = air.add_extra(&value_words);
+            let value_args_len = value_words.len() as u32;
+
             // Encode runtime args into extra array
             let mut args_extra = Vec::with_capacity(runtime_args.len() * 2);
             for arg in &runtime_args {
@@ -3812,6 +3894,8 @@ impl<'a> Sema<'a> {
                     name,
                     type_args_start,
                     type_args_len,
+                    value_args_start,
+                    value_args_len,
                     args_start: runtime_args_start,
                     args_len: runtime_args_len,
                 },

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -52,7 +52,7 @@ use rue_rir::{InstData, InstRef};
 use rue_span::Span;
 
 use super::Sema;
-use super::context::{AnalysisContext, ConstValue};
+use super::context::{AnalysisContext, ConstValue, LocalVar};
 use crate::types::{StructField, Type};
 
 /// Empty type substitution map for evaluation contexts without one.
@@ -70,6 +70,12 @@ pub(crate) struct ComptimeEnv<'a> {
     /// `None` when evaluating expressions outside a typed function context
     /// (comptime function bodies before specialization, const initializers).
     resolved_types: Option<&'a HashMap<InstRef, Type>>,
+    /// Runtime locals in scope at the point being evaluated. A runtime local
+    /// shadows same-named comptime parameters and file-level constants, so a
+    /// reference to it makes the expression non-evaluable — without this,
+    /// `let n = x; g(n)` inside a body with `comptime n` in scope would
+    /// wrongly evaluate `n` to the parameter's value (spec 4.14:6).
+    runtime_locals: Option<&'a HashMap<Spur, LocalVar>>,
     /// `let` bindings introduced by blocks inside the comptime expression.
     locals: HashMap<Spur, ConstValue>,
 }
@@ -81,6 +87,7 @@ impl<'a> ComptimeEnv<'a> {
             type_subst: &EMPTY_TYPE_SUBST,
             value_subst: &EMPTY_VALUE_SUBST,
             resolved_types: None,
+            runtime_locals: None,
             locals: HashMap::new(),
         }
     }
@@ -95,6 +102,7 @@ impl<'a> ComptimeEnv<'a> {
             type_subst,
             value_subst,
             resolved_types: None,
+            runtime_locals: None,
             locals: HashMap::new(),
         }
     }
@@ -106,6 +114,7 @@ impl<'a> ComptimeEnv<'a> {
             type_subst: &ctx.comptime_type_vars,
             value_subst: &ctx.comptime_value_vars,
             resolved_types: Some(ctx.resolved_types),
+            runtime_locals: Some(&ctx.locals),
             locals: HashMap::new(),
         }
     }
@@ -194,14 +203,18 @@ impl Sema<'_> {
     /// Check if an RIR instruction is a direct reference to a `comptime`
     /// parameter of the function currently being analyzed.
     ///
-    /// Such a reference is compile-time known *to every caller* even though
-    /// its value is unknown while the body is analyzed, so it may be
+    /// Such a reference is compile-time known to every caller, so it may be
     /// forwarded to another function's comptime parameter (spec 4.14:5):
     ///
     /// ```rue
     /// fn g(comptime m: i32) -> i32 { m * 2 }
     /// fn f(comptime n: i32) -> i32 { g(n) }  // forwarding
     /// ```
+    ///
+    /// Since per-value specialization (RUE-166), bodies with comptime value
+    /// parameters are only analyzed with the concrete values in
+    /// `ctx.comptime_value_vars`, so forwards normally evaluate directly and
+    /// this check is a fallback.
     pub(crate) fn is_comptime_param_forward(
         &self,
         inst_ref: InstRef,
@@ -721,15 +734,23 @@ impl Sema<'_> {
                 if let Some(&v) = env.locals.get(name) {
                     return Ok(Some(v));
                 }
-                // 2. Comptime type parameters in scope
+                // 2. Runtime locals shadow comptime parameters and file-level
+                //    constants: a reference that resolves to one is not
+                //    compile-time evaluable (spec 4.14:6).
+                if let Some(locals) = env.runtime_locals {
+                    if locals.contains_key(name) {
+                        return Ok(None);
+                    }
+                }
+                // 3. Comptime type parameters in scope
                 if let Some(&ty) = env.type_subst.get(name) {
                     return Ok(Some(ConstValue::Type(ty)));
                 }
-                // 3. Comptime value parameters in scope
+                // 4. Comptime value parameters in scope
                 if let Some(&v) = env.value_subst.get(name) {
                     return Ok(Some(v));
                 }
-                // 4. File-level constants: the value was evaluated once
+                // 5. File-level constants: the value was evaluated once
                 //    (and range-checked against the declared type) during
                 //    declaration gathering — use it directly. Re-evaluating
                 //    the initializer here would fail for forms only the
@@ -753,7 +774,7 @@ impl Sema<'_> {
                     )?;
                     return Ok(Some(info.value));
                 }
-                // 5. Type names used as values (e.g. `Point` in
+                // 6. Type names used as values (e.g. `Point` in
                 //    `fn make_type() -> type { Point }`)
                 Ok(self.resolve_named_type_value(name).map(ConstValue::Type))
             }

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -476,7 +476,7 @@ impl AnalysisResult {
 /// This is used for compile-time evaluation of expressions and for
 /// comptime parameters. For example, in `fn Buffer(comptime N: i32)`,
 /// the value of `N` is stored as a `ConstValue::Integer`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum ConstValue {
     /// Integer value. Backed by `i128` so the full range of every Rue integer
     /// type is representable (u64 values above `i64::MAX` as well as negative

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -32,6 +32,11 @@ pub(crate) struct LocalVar {
 
 /// A path of field accesses from a root variable.
 /// For example, `s.a.b` is represented as [sym("a"), sym("b")] with root sym("s").
+///
+/// Array element paths (RUE-186) reuse the same representation: a constant
+/// index K is encoded as the interned decimal string of K (`xs[0]` →
+/// [sym("0")]). Identifiers can never be all digits, so index segments can't
+/// collide with field names.
 pub(crate) type FieldPath = Vec<Spur>;
 
 /// Tracks move state for a variable, including partial (field-level) moves.
@@ -54,7 +59,16 @@ pub(crate) struct VariableMoveState {
     pub full_move_on_all_paths: bool,
     /// Partial moves: maps field paths to the span where they were moved.
     /// For example, if `s.a` was moved, this contains ([sym("a")], span).
+    ///
+    /// Like `full_move`, this is MAY-move (union at branch joins).
     pub partial_moves: HashMap<FieldPath, Span>,
+    /// Partial moves that happened on EVERY non-diverging path reaching this
+    /// point (intersection at branch joins) — the per-path analogue of
+    /// `full_move_on_all_paths`. Always a subset of `partial_moves`' keys.
+    /// The element-wise linear array consumption check (RUE-186) needs
+    /// MUST-move information: an element consumed in only one branch is
+    /// still dropped on the other paths.
+    pub partial_moves_on_all_paths: HashSet<FieldPath>,
 }
 
 impl VariableMoveState {
@@ -68,10 +82,12 @@ impl VariableMoveState {
             self.full_move_on_all_paths = true;
             // Clear partial moves since the whole thing is moved
             self.partial_moves.clear();
+            self.partial_moves_on_all_paths.clear();
         } else {
             // Partial move - only if not already fully moved
             if self.full_move.is_none() {
                 self.partial_moves.insert(path.to_vec(), span);
+                self.partial_moves_on_all_paths.insert(path.to_vec());
             }
         }
     }
@@ -85,6 +101,8 @@ impl VariableMoveState {
     pub fn mark_path_reinitialized(&mut self, path: &[Spur]) {
         self.partial_moves
             .retain(|moved, _| !(moved.len() >= path.len() && moved[..path.len()] == *path));
+        self.partial_moves_on_all_paths
+            .retain(|moved| !(moved.len() >= path.len() && moved[..path.len()] == *path));
     }
 
     /// Check if a field path is moved.
@@ -143,11 +161,28 @@ impl VariableMoveState {
             partial_moves.entry(path.clone()).or_insert(*span);
         }
 
+        // A path was moved on EVERY path only if both branches moved it.
+        // A branch that fully moved the value on all its paths covers every
+        // path (it has no per-path set of its own — the full move subsumed
+        // it), so the other branch's set survives.
+        let partial_moves_on_all_paths = if branch1.full_move_on_all_paths {
+            branch2.partial_moves_on_all_paths.clone()
+        } else if branch2.full_move_on_all_paths {
+            branch1.partial_moves_on_all_paths.clone()
+        } else {
+            branch1
+                .partial_moves_on_all_paths
+                .intersection(&branch2.partial_moves_on_all_paths)
+                .cloned()
+                .collect()
+        };
+
         Self {
             full_move,
             full_move_on_all_paths: branch1.full_move_on_all_paths
                 && branch2.full_move_on_all_paths,
             partial_moves,
+            partial_moves_on_all_paths,
         }
     }
 }
@@ -747,6 +782,68 @@ mod tests {
         // Partial move should be ignored when already fully moved
         assert_eq!(state.full_move, Some(span1));
         assert!(state.partial_moves.is_empty());
+    }
+
+    #[test]
+    fn variable_move_state_partial_must_move_tracks_and_reinit_clears() {
+        // RUE-186: partial moves are recorded in the MUST set on the
+        // straight-line path, and reinitialization clears them from it.
+        let mut state = VariableMoveState::default();
+        let interner = ThreadedRodeo::new();
+        let elem0 = interner.get_or_intern("0");
+        let span = Span::new(10, 20);
+
+        state.mark_path_moved(&[elem0], span);
+        assert!(state.partial_moves_on_all_paths.contains(&vec![elem0]));
+
+        state.mark_path_reinitialized(&[elem0]);
+        assert!(!state.partial_moves_on_all_paths.contains(&vec![elem0]));
+        assert!(state.partial_moves.is_empty());
+    }
+
+    #[test]
+    fn variable_move_state_merge_intersects_partial_must_moves() {
+        // RUE-186: a path moved in only one branch survives in the MAY set
+        // (union) but not the MUST set (intersection).
+        let interner = ThreadedRodeo::new();
+        let elem0 = interner.get_or_intern("0");
+        let elem1 = interner.get_or_intern("1");
+        let span = Span::new(10, 20);
+
+        let mut b1 = VariableMoveState::default();
+        b1.mark_path_moved(&[elem0], span);
+        b1.mark_path_moved(&[elem1], span);
+        let mut b2 = VariableMoveState::default();
+        b2.mark_path_moved(&[elem0], span);
+
+        let merged = VariableMoveState::merge_union(&b1, &b2);
+        assert!(merged.partial_moves.contains_key(&vec![elem0]));
+        assert!(merged.partial_moves.contains_key(&vec![elem1]));
+        assert!(merged.partial_moves_on_all_paths.contains(&vec![elem0]));
+        assert!(!merged.partial_moves_on_all_paths.contains(&vec![elem1]));
+    }
+
+    #[test]
+    fn variable_move_state_merge_full_move_branch_covers_partial_must() {
+        // RUE-186: a branch that fully moved the value on all its paths
+        // covers every path, so the other branch's per-path MUST set
+        // survives the join (whole-in-then / element-wise-in-else).
+        let interner = ThreadedRodeo::new();
+        let elem0 = interner.get_or_intern("0");
+        let span = Span::new(10, 20);
+
+        let mut whole = VariableMoveState::default();
+        whole.mark_path_moved(&[], span);
+        let mut elementwise = VariableMoveState::default();
+        elementwise.mark_path_moved(&[elem0], span);
+
+        let merged = VariableMoveState::merge_union(&whole, &elementwise);
+        assert!(!merged.full_move_on_all_paths);
+        assert!(merged.partial_moves_on_all_paths.contains(&vec![elem0]));
+
+        // Symmetric.
+        let merged = VariableMoveState::merge_union(&elementwise, &whole);
+        assert!(merged.partial_moves_on_all_paths.contains(&vec![elem0]));
     }
 
     #[test]

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -860,12 +860,13 @@ impl<'a> Sema<'a> {
         let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
         let param_modes: Vec<RirParamMode> = params.iter().map(|p| p.mode).collect();
 
-        // Check if this function has any comptime TYPE parameters (not value parameters).
-        // A type parameter is a comptime param where the type is `type`.
-        // - `comptime T: type` -> type parameter (is_generic = true)
-        // - `comptime n: i32` -> value parameter (is_generic = false)
+        // Check if this function has any comptime parameters. Both kinds
+        // require per-call-site specialization (RUE-166):
+        // - `comptime T: type` -> type parameter (specialized per type)
+        // - `comptime n: i32` -> value parameter (specialized per value, so
+        //   the body sees `n` as a compile-time constant)
         let type_sym = self.interner.get_or_intern("type");
-        let is_generic = params.iter().any(|p| p.is_comptime && p.ty == type_sym);
+        let is_generic = params.iter().any(|p| p.is_comptime);
 
         // Collect type parameter names (comptime parameters whose type is `type`)
         let type_param_names: Vec<Spur> = params

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -27,7 +27,8 @@ pub struct FunctionInfo {
     pub rir_params_len: u32,
     /// Span of the function declaration
     pub span: Span,
-    /// Whether this function has any comptime type parameters
+    /// Whether this function has any comptime parameters (type or value) and
+    /// therefore requires per-call-site specialization (RUE-166)
     pub is_generic: bool,
     /// Whether this function is public (visible outside its directory)
     pub is_pub: bool,

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -159,6 +159,17 @@ impl<'a> Sema<'a> {
             )?;
             Ok(Type::new_struct(struct_id))
         } else if let Some(&enum_id) = self.enums.get(&type_sym) {
+            // Privacy (E0460, RUE-185): same rule for enums — an unqualified
+            // type reference must not reach a private enum defined in another
+            // directory.
+            let enum_def = self.type_pool.enum_def(enum_id);
+            self.check_unqualified_visibility(
+                "enum",
+                type_name,
+                enum_def.file_id,
+                enum_def.is_pub,
+                span,
+            )?;
             Ok(Type::new_enum(enum_id))
         } else {
             // Check for array type syntax: [T; N]

--- a/crates/rue-air/src/sema/visibility.rs
+++ b/crates/rue-air/src/sema/visibility.rs
@@ -56,13 +56,13 @@ impl Sema<'_> {
     }
 
     /// Check that an *unqualified* reference may reach the item (RUE-37,
-    /// RUE-180, RUE-183).
+    /// RUE-180, RUE-183, RUE-185).
     ///
     /// All loaded files share one flat global namespace for *name
     /// resolution* (spec 10.5:2, transitional), but privacy is uniform in
     /// every multi-file compilation, imports or not (spec 10.3:7), and it
-    /// covers every item kind — functions, structs, and constants alike
-    /// (spec 10.3:1):
+    /// covers every item kind — functions, structs, enums, and constants
+    /// alike (spec 10.3:1):
     ///
     /// - If the item is accessible per [`Sema::is_accessible`] (it is
     ///   `pub`, or the reference is in the item's directory — ADR-0026
@@ -72,7 +72,7 @@ impl Sema<'_> {
     ///   listed on the command line makes no difference.
     ///
     /// `item_kind` names the kind in the diagnostic ("function", "struct",
-    /// "constant").
+    /// "enum", "constant").
     pub(crate) fn check_unqualified_visibility(
         &self,
         item_kind: &str,

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -4,12 +4,20 @@
 //! instructions into regular `Call` instructions by:
 //!
 //! 1. Collecting all `CallGeneric` instructions in the analyzed functions
-//! 2. For each unique (func_name, type_args) combination, creating a specialized function
+//! 2. For each unique (func_name, type_args, value_args) combination, creating
+//!    a specialized function
 //! 3. Rewriting `CallGeneric` to `Call` with the specialized function name
 //!
+//! Specialization covers both comptime *type* parameters (`comptime T: type`)
+//! and comptime *value* parameters (`comptime n: i32`, RUE-166): each distinct
+//! combination of type and value arguments gets its own specialized body, in
+//! which the value parameters are compile-time constants (available to
+//! `comptime` blocks and forwardable to other comptime parameters).
+//!
 //! Specialized bodies can contain further `CallGeneric` instructions (a generic
-//! function forwarding its type parameter to another generic), so these steps
-//! repeat until no new specializations are discovered.
+//! function forwarding its type parameter to another generic, or a
+//! comptime-recursive function like `fact(comptime n)` calling `fact(n - 1)`),
+//! so these steps repeat until no new specializations are discovered.
 //!
 //! # Architecture
 //!
@@ -25,16 +33,98 @@ use rue_rir::RirParamMode;
 use rue_span::Span;
 
 use crate::inst::{Air, AirInstData};
-use crate::sema::{AnalyzedFunction, FunctionInfo, InferenceContext, Sema, SemaOutput};
+use crate::sema::{AnalyzedFunction, ConstValue, FunctionInfo, InferenceContext, Sema, SemaOutput};
 use crate::types::Type;
 
-/// A key for a specialized function: (base_function_name, type_arguments).
+/// A key for a specialized function:
+/// (base_function_name, type_arguments, value_arguments).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct SpecializationKey {
     /// Base function name (e.g., "identity")
     pub base_name: Spur,
-    /// Type arguments (e.g., [Type::I32])
+    /// Type arguments (e.g., [Type::I32]), one per comptime type parameter
     pub type_args: Vec<Type>,
+    /// Comptime value arguments (e.g., [Integer(5)]), one per comptime value
+    /// parameter (RUE-166)
+    pub value_args: Vec<ConstValue>,
+}
+
+// ============================================================================
+// ConstValue <-> extra-array encoding
+// ============================================================================
+//
+// Comptime value arguments travel from the call site (sema) to this pass
+// inside the AIR extra array (a flat `u32` stream), as a tagged word stream:
+// each value is a tag word followed by its payload words.
+
+/// Tag for `ConstValue::Integer` (payload: 4 words, i128 as little-endian u32s).
+const CV_TAG_INTEGER: u32 = 0;
+/// Tag for `ConstValue::Bool` (payload: 1 word, 0 or 1).
+const CV_TAG_BOOL: u32 = 1;
+/// Tag for `ConstValue::Unit` (no payload).
+const CV_TAG_UNIT: u32 = 2;
+/// Tag for `ConstValue::Type` (payload: 1 word, `Type::as_u32`).
+const CV_TAG_TYPE: u32 = 3;
+
+/// Encode comptime value arguments as a tagged `u32` word stream for the AIR
+/// extra array. Decoded by [`decode_const_values`].
+pub fn encode_const_values(values: &[ConstValue]) -> Vec<u32> {
+    let mut words = Vec::with_capacity(values.len() * 5);
+    for value in values {
+        match value {
+            ConstValue::Integer(n) => {
+                words.push(CV_TAG_INTEGER);
+                let bits = *n as u128;
+                for i in 0..4 {
+                    words.push((bits >> (32 * i)) as u32);
+                }
+            }
+            ConstValue::Bool(b) => {
+                words.push(CV_TAG_BOOL);
+                words.push(u32::from(*b));
+            }
+            ConstValue::Unit => words.push(CV_TAG_UNIT),
+            ConstValue::Type(ty) => {
+                words.push(CV_TAG_TYPE);
+                words.push(ty.as_u32());
+            }
+        }
+    }
+    words
+}
+
+/// Decode a tagged word stream produced by [`encode_const_values`].
+pub fn decode_const_values(words: &[u32]) -> Vec<ConstValue> {
+    let mut values = Vec::new();
+    let mut i = 0;
+    while i < words.len() {
+        let tag = words[i];
+        i += 1;
+        let value = match tag {
+            CV_TAG_INTEGER => {
+                let mut bits: u128 = 0;
+                for j in 0..4 {
+                    bits |= u128::from(words[i + j]) << (32 * j);
+                }
+                i += 4;
+                ConstValue::Integer(bits as i128)
+            }
+            CV_TAG_BOOL => {
+                let b = words[i] != 0;
+                i += 1;
+                ConstValue::Bool(b)
+            }
+            CV_TAG_UNIT => ConstValue::Unit,
+            CV_TAG_TYPE => {
+                let ty = Type::from_u32(words[i]);
+                i += 1;
+                ConstValue::Type(ty)
+            }
+            _ => unreachable!("invalid ConstValue tag {tag} in extra array"),
+        };
+        values.push(value);
+    }
+    values
 }
 
 /// Info about a specialization: the mangled name and the first call site span.
@@ -49,8 +139,12 @@ struct SpecializationInfo {
 ///
 /// Each round creates the bodies for the specializations discovered in the
 /// previous round, so this bounds the nesting depth of generic-to-generic
-/// calls. Unbounded growth is possible when a generic function instantiates
-/// itself with an ever-growing type (e.g. `f(Pair(T), ...)` inside `f`).
+/// calls — including comptime-value recursion (`fact(comptime n)` calling
+/// `fact(n - 1)` adds one round per distinct value, RUE-166). Unbounded
+/// growth is possible when a generic function instantiates itself with an
+/// ever-growing type (e.g. `f(Pair(T), ...)` inside `f`) or a
+/// comptime-recursive function never reaches a comptime-known base case,
+/// so this cap turns a would-be-infinite loop into a clean E1200.
 const MAX_SPECIALIZATION_ROUNDS: usize = 64;
 
 /// Perform the specialization pass on the sema output.
@@ -98,8 +192,10 @@ pub fn specialize(
             return Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {
                     reason: format!(
-                        "generic specialization of '{}' exceeded the maximum nesting depth ({}); \
-                         is a generic function recursively instantiating itself with new types?",
+                        "specialization of '{}' exceeded the maximum nesting depth ({}); \
+                         is a comptime-recursive function missing a compile-time-known \
+                         base case, or a generic function recursively instantiating \
+                         itself with new types?",
                         interner.resolve(&key.base_name),
                         MAX_SPECIALIZATION_ROUNDS
                     ),
@@ -146,6 +242,8 @@ fn collect_specializations(
             name,
             type_args_start,
             type_args_len,
+            value_args_start,
+            value_args_len,
             ..
         } = &inst.data
         {
@@ -154,15 +252,21 @@ fn collect_specializations(
                 .iter()
                 .map(|&encoded| Type::from_u32(encoded))
                 .collect();
+            let value_args = decode_const_values(air.get_extra(*value_args_start, *value_args_len));
 
             let key = SpecializationKey {
                 base_name: *name,
                 type_args,
+                value_args,
             };
 
             if let Entry::Vacant(entry) = specializations.entry(key) {
                 let base_name = interner.resolve(name);
-                let mangled = mangle_specialized_name(base_name, &entry.key().type_args);
+                let mangled = mangle_specialized_name(
+                    base_name,
+                    &entry.key().type_args,
+                    &entry.key().value_args,
+                );
                 let mangled_sym = interner.get_or_intern(&mangled);
                 pending.push(entry.key().clone());
                 entry.insert(SpecializationInfo {
@@ -185,6 +289,8 @@ fn rewrite_call_generic(
             name,
             type_args_start,
             type_args_len,
+            value_args_start,
+            value_args_len,
             args_start,
             args_len,
         } = &inst.data
@@ -194,10 +300,12 @@ fn rewrite_call_generic(
                 .iter()
                 .map(|&encoded| Type::from_u32(encoded))
                 .collect();
+            let value_args = decode_const_values(air.get_extra(*value_args_start, *value_args_len));
 
             let key = SpecializationKey {
                 base_name: *name,
                 type_args,
+                value_args,
             };
 
             if let Some(info) = specializations.get(&key) {
@@ -219,13 +327,40 @@ fn rewrite_call_generic(
 }
 
 /// Generate a mangled name for a specialized function.
-fn mangle_specialized_name(base_name: &str, type_args: &[Type]) -> String {
+///
+/// Type arguments and value arguments each contribute a `__`-separated
+/// segment, so distinct comptime values yield distinct symbols
+/// (`fact__v5`, `fact__v4`, ...; RUE-166) exactly like distinct types do
+/// (RUE-100's lesson: colliding mangles mean duplicate symbols at link time).
+fn mangle_specialized_name(
+    base_name: &str,
+    type_args: &[Type],
+    value_args: &[ConstValue],
+) -> String {
     let mut mangled = base_name.to_string();
     for ty in type_args {
         mangled.push_str("__");
         mangled.push_str(&mangle_type(*ty));
     }
+    for value in value_args {
+        mangled.push_str("__");
+        mangled.push_str(&mangle_const_value(value));
+    }
     mangled
+}
+
+/// Mangle a single comptime value argument into a unique symbol fragment.
+///
+/// Negative integers use an `m` (minus) prefix on the magnitude because `-`
+/// is not a safe symbol character (`-3` -> `vm3`).
+fn mangle_const_value(value: &ConstValue) -> String {
+    match value {
+        ConstValue::Integer(n) if *n < 0 => format!("vm{}", n.unsigned_abs()),
+        ConstValue::Integer(n) => format!("v{}", n),
+        ConstValue::Bool(b) => format!("v{}", b),
+        ConstValue::Unit => "vunit".to_string(),
+        ConstValue::Type(ty) => format!("v{}", mangle_type(*ty)),
+    }
 }
 
 /// Mangle a single type argument into a unique string.
@@ -247,10 +382,13 @@ fn mangle_type(ty: Type) -> String {
     }
 }
 
-/// Create a specialized function by re-analyzing the body with type substitution.
+/// Create a specialized function by re-analyzing the body with type and
+/// value substitution.
 ///
-/// This builds a type substitution map from the comptime parameters to their concrete
-/// type arguments, then re-analyzes the function body with these substitutions.
+/// This builds a type substitution map from the comptime type parameters to
+/// their concrete type arguments and a value substitution map from the
+/// comptime value parameters to their concrete values (RUE-166), then
+/// re-analyzes the function body with these substitutions.
 fn create_specialized_function(
     sema: &mut Sema<'_>,
     infer_ctx: &InferenceContext,
@@ -261,12 +399,26 @@ fn create_specialized_function(
 ) -> CompileResult<AnalyzedFunction> {
     let specialized_name_str = interner.resolve(&specialized_name).to_string();
 
+    // Pair each comptime parameter with its argument: type parameters
+    // (declared `: type`) consume the type_args stream, value parameters
+    // consume the value_args stream — mirroring how the call site collected
+    // them (both in parameter order).
     let mut type_subst: HashMap<Spur, Type> = HashMap::new();
+    let mut value_subst: HashMap<Spur, ConstValue> = HashMap::new();
     let mut type_arg_idx = 0;
-    for (name, _, _, is_comptime) in sema.param_arena.iter(base_info.params) {
-        if *is_comptime && type_arg_idx < key.type_args.len() {
-            type_subst.insert(*name, key.type_args[type_arg_idx]);
-            type_arg_idx += 1;
+    let mut value_arg_idx = 0;
+    for (name, ty, _, is_comptime) in sema.param_arena.iter(base_info.params) {
+        if !*is_comptime {
+            continue;
+        }
+        if *ty == Type::COMPTIME_TYPE {
+            if type_arg_idx < key.type_args.len() {
+                type_subst.insert(*name, key.type_args[type_arg_idx]);
+                type_arg_idx += 1;
+            }
+        } else if value_arg_idx < key.value_args.len() {
+            value_subst.insert(*name, key.value_args[value_arg_idx]);
+            value_arg_idx += 1;
         }
     }
 
@@ -291,7 +443,16 @@ fn create_specialized_function(
         Vec::with_capacity(base_params.len());
     for (name, ty, mode, is_comptime) in base_params {
         if is_comptime {
-            // Comptime parameters are erased from the specialized signature.
+            if ty == Type::COMPTIME_TYPE {
+                // Comptime TYPE parameters are erased from the specialized
+                // signature (types don't exist at runtime).
+                continue;
+            }
+            // Comptime VALUE parameters stay in the runtime signature — the
+            // call site still passes them (see `analyze_call`); their constant
+            // value is additionally substituted into the body via value_subst
+            // so comptime contexts see it (RUE-166).
+            specialized_params.push((name, ty, mode, true));
             continue;
         }
         let concrete_ty = if ty == Type::COMPTIME_TYPE {
@@ -320,6 +481,7 @@ fn create_specialized_function(
         &specialized_params,
         base_info.body,
         &type_subst,
+        &value_subst,
     )?;
 
     Ok(AnalyzedFunction {

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -70,6 +70,9 @@ enum MovedSlot {
 /// A struct field path inside a slot, as declaration indices from the
 /// outermost struct inward: `o.a` → `[0]`, `o.a.b` → `[0, 1]` (for `a` and
 /// `b` at declaration index 0 and 1 of their respective structs).
+/// Array element paths (RUE-186) reuse the representation with the element
+/// index as the segment: `xs[2]` → `[2]`. Whether a segment is a field or an
+/// element is determined by the type at that level.
 type FieldPath = Vec<u32>;
 
 /// Move-out state for drop elaboration: whole slots and struct field paths
@@ -273,8 +276,9 @@ impl<'a> CfgBuilder<'a> {
         // Pre-scan for moves so drop flags can be initialized at the
         // value's init site, before the move is reached (RUE-108).
         // Whole-value MarkMoveds nominate the slot for a whole-slot flag;
-        // field-level MarkMoveds nominate their (slot, field path) for a
-        // per-field flag (RUE-156) when the moved type needs dropping.
+        // path-level MarkMoveds (struct field paths, and constant-index
+        // array elements per RUE-186) nominate their (slot, path) for a
+        // per-path flag (RUE-156) when the moved type needs dropping.
         for i in 0..air.len() {
             let inst = air.get(AirRef::from_raw(i as u32));
             if let AirInstData::MarkMoved {
@@ -2233,8 +2237,9 @@ impl<'a> CfgBuilder<'a> {
                 place,
             } => {
                 // Pure passthrough at runtime: lower the wrapped use and
-                // record that the slot's contents (or one field path of
-                // them, RUE-62/RUE-157) were moved out on this path, so
+                // record that the slot's contents (or one field path or
+                // array element of them, RUE-62/RUE-157/RUE-186) were
+                // moved out on this path, so
                 // drop elaboration skips the slot (or just that path) at
                 // scope exit.
                 let result = self.lower_inst(*value);
@@ -2492,9 +2497,12 @@ impl<'a> CfgBuilder<'a> {
         }
     }
 
-    /// The field path (declaration indices, outermost first) named by a
-    /// field-level MarkMoved's place. Sema only exports markers for pure
-    /// `Field` projection chains.
+    /// The path (declaration/element indices, outermost first) named by a
+    /// path-level MarkMoved's place. Sema only exports markers for pure
+    /// `Field` projection chains and for single CONSTANT-index projections
+    /// (per-element array moves, RUE-186): the marker's index operand is a
+    /// dedicated `Const` instruction, resolved back to the element index
+    /// here.
     fn moved_field_path(&self, place_ref: AirPlaceRef) -> FieldPath {
         let place = self.air.get_place(place_ref);
         self.air
@@ -2502,9 +2510,10 @@ impl<'a> CfgBuilder<'a> {
             .iter()
             .map(|proj| match proj {
                 AirProjection::Field { field_index, .. } => *field_index,
-                AirProjection::Index { .. } => {
-                    unreachable!("MarkMoved place contains a non-field projection")
-                }
+                AirProjection::Index { index, .. } => match self.air.get(*index).data {
+                    AirInstData::Const(k) => k as u32,
+                    _ => unreachable!("MarkMoved place contains a non-constant index projection"),
+                },
             })
             .collect()
     }
@@ -2532,7 +2541,7 @@ impl<'a> CfgBuilder<'a> {
             }
             if self.type_needs_drop(ty) {
                 self.emit_guarded(key, span, |b| {
-                    if !b.emit_partial_struct_drop(key, ty, span) {
+                    if !b.emit_partial_drop(key, ty, span) {
                         let param_val = b.emit(CfgInstData::Param { index: abi_slot }, ty, span);
                         b.emit(CfgInstData::Drop { value: param_val }, Type::UNIT, span);
                     }
@@ -2638,7 +2647,7 @@ impl<'a> CfgBuilder<'a> {
             let (slot, ty) = (live_slot.slot, live_slot.ty);
             self.emit_guarded(key, span, |b| {
                 // Fast path: nothing partially moved — drop the whole value.
-                if !b.emit_partial_struct_drop(key, ty, span) {
+                if !b.emit_partial_drop(key, ty, span) {
                     let slot_val = b.emit(CfgInstData::Load { slot }, ty, span);
                     b.emit(CfgInstData::Drop { value: slot_val }, Type::UNIT, span);
                 }
@@ -2668,7 +2677,7 @@ impl<'a> CfgBuilder<'a> {
             return;
         }
         self.emit_guarded(key, span, |b| {
-            if !b.emit_partial_struct_drop(key, ty, span) {
+            if !b.emit_partial_drop(key, ty, span) {
                 let old_val = match key {
                     MovedSlot::Local(slot) => b.emit(CfgInstData::Load { slot }, ty, span),
                     MovedSlot::Param(index) => b.emit(CfgInstData::Param { index }, ty, span),
@@ -2712,8 +2721,8 @@ impl<'a> CfgBuilder<'a> {
         });
     }
 
-    /// Field-granular drop of a partially-moved struct (RUE-62, RUE-156,
-    /// RUE-157).
+    /// Path-granular drop of a partially-moved struct or array (RUE-62,
+    /// RUE-156, RUE-157, RUE-186).
     ///
     /// When one or more field paths of a struct slot were (or may have
     /// been) moved out (`eat(o.a)`, `eat(o.a.b)`, `if c { eat(o.a) }`), the
@@ -2735,12 +2744,18 @@ impl<'a> CfgBuilder<'a> {
     ///      field-granular drop of the field instead of a whole `Drop`;
     ///    - untouched: a plain `Drop` of the field read via `PlaceRead`.
     ///
+    /// Arrays get the same treatment per ELEMENT (RUE-186): elements moved
+    /// out on every path are skipped, elements moved on some path are
+    /// dropped behind their runtime drop flag, untouched elements get a
+    /// plain drop. Arrays have no destructor of their own, so there is no
+    /// step-1 destructor call at array levels.
+    ///
     /// Returns `false` (caller emits the normal whole-value drop) when the
-    /// slot has no (possibly-)moved-out field paths or is not a struct.
-    /// Note each destructor still receives the WHOLE struct, including the
-    /// moved-out part's stale slots — reading a moved field in a destructor
-    /// is a use-after-move just like any other.
-    fn emit_partial_struct_drop(&mut self, key: MovedSlot, ty: Type, span: rue_span::Span) -> bool {
+    /// slot has no (possibly-)moved-out paths or is neither a struct nor an
+    /// array. Note each destructor still receives the WHOLE struct,
+    /// including the moved-out part's stale slots — reading a moved field
+    /// in a destructor is a use-after-move just like any other.
+    fn emit_partial_drop(&mut self, key: MovedSlot, ty: Type, span: rue_span::Span) -> bool {
         // `maybe` ⊇ `definite`: paths possibly vs. definitely moved out on
         // the paths reaching this exit.
         let definite = self.moved.moved_paths_of(key);
@@ -2748,25 +2763,42 @@ impl<'a> CfgBuilder<'a> {
         if maybe.is_empty() && definite.is_empty() {
             return false;
         }
-        let TypeKind::Struct(struct_id) = ty.kind() else {
-            // Per-field move markers are only emitted for struct fields, so
-            // this is unreachable today; fall back to the whole-value drop.
-            return false;
-        };
-        self.emit_partial_struct_drop_level(
-            key,
-            struct_id,
-            ty,
-            &mut Vec::new(),
-            &mut Vec::new(),
-            &definite,
-            &maybe,
-            span,
-        );
-        true
+        match ty.kind() {
+            TypeKind::Struct(struct_id) => {
+                self.emit_partial_struct_drop_level(
+                    key,
+                    struct_id,
+                    ty,
+                    &mut Vec::new(),
+                    &mut Vec::new(),
+                    &definite,
+                    &maybe,
+                    span,
+                );
+                true
+            }
+            TypeKind::Array(_) => {
+                self.emit_partial_array_drop_level(
+                    key,
+                    ty,
+                    &mut Vec::new(),
+                    &mut Vec::new(),
+                    &definite,
+                    &maybe,
+                    span,
+                );
+                true
+            }
+            _ => {
+                // Path-level move markers are only emitted for struct fields
+                // and array elements, so this is unreachable today; fall
+                // back to the whole-value drop.
+                false
+            }
+        }
     }
 
-    /// One struct level of [`Self::emit_partial_struct_drop`]: destructor
+    /// One struct level of [`Self::emit_partial_drop`]: destructor
     /// (without glue) plus per-field drops for the struct at field path
     /// `path` (projections `projs`) inside slot `key`.
     #[allow(clippy::too_many_arguments)]
@@ -2850,22 +2882,32 @@ impl<'a> CfgBuilder<'a> {
 
             let cont_block = guard_flag.map(|flag| self.begin_flag_guard(flag, span));
             let recursed = if has_deeper_move {
-                if let TypeKind::Struct(field_struct_id) = field.ty.kind() {
-                    self.emit_partial_struct_drop_level(
-                        key,
-                        field_struct_id,
-                        field.ty,
-                        path,
-                        projs,
-                        definite,
-                        maybe,
-                        span,
-                    );
-                    true
-                } else {
-                    // Deeper paths only exist through struct fields; keep a
-                    // whole drop as a defensive fallback.
-                    false
+                match field.ty.kind() {
+                    TypeKind::Struct(field_struct_id) => {
+                        self.emit_partial_struct_drop_level(
+                            key,
+                            field_struct_id,
+                            field.ty,
+                            path,
+                            projs,
+                            definite,
+                            maybe,
+                            span,
+                        );
+                        true
+                    }
+                    TypeKind::Array(_) => {
+                        self.emit_partial_array_drop_level(
+                            key, field.ty, path, projs, definite, maybe, span,
+                        );
+                        true
+                    }
+                    _ => {
+                        // Deeper paths only exist through struct fields and
+                        // array elements; keep a whole drop as a defensive
+                        // fallback.
+                        false
+                    }
                 }
             } else {
                 false
@@ -2874,6 +2916,98 @@ impl<'a> CfgBuilder<'a> {
                 let place = self.cfg.make_place(base, projs.iter().copied());
                 let field_val = self.emit(CfgInstData::PlaceRead { place }, field.ty, span);
                 self.emit(CfgInstData::Drop { value: field_val }, Type::UNIT, span);
+            }
+            if let Some(cont_block) = cont_block {
+                self.end_flag_guard(cont_block);
+            }
+
+            path.pop();
+            projs.pop();
+        }
+    }
+
+    /// One array level of [`Self::emit_partial_drop`] (RUE-186): per-element
+    /// drops for the array at path `path` (projections `projs`) inside slot
+    /// `key`, in ascending element order (matching drop-glue order). The
+    /// per-element cases mirror the struct-field cases: definitely moved →
+    /// skipped, possibly moved → guarded by the element path's runtime drop
+    /// flag, deeper moved path → recursive path-granular drop, untouched →
+    /// plain `Drop`. Arrays have no destructor of their own.
+    fn emit_partial_array_drop_level(
+        &mut self,
+        key: MovedSlot,
+        array_ty: Type,
+        path: &mut FieldPath,
+        projs: &mut Vec<Projection>,
+        definite: &std::collections::HashSet<FieldPath>,
+        maybe: &std::collections::HashSet<FieldPath>,
+        span: rue_span::Span,
+    ) {
+        let TypeKind::Array(array_id) = array_ty.kind() else {
+            unreachable!("emit_partial_array_drop_level called on non-array type");
+        };
+        let (elem_ty, len) = self.type_pool.array_def(array_id);
+        if !self.type_needs_drop(elem_ty) {
+            return;
+        }
+        let base = match key {
+            MovedSlot::Local(slot) => PlaceBase::Local(slot),
+            MovedSlot::Param(slot) => PlaceBase::Param(slot),
+        };
+
+        for k in 0..len {
+            path.push(k as u32);
+            if definite.contains(path) {
+                // Moved out on every path: the new owner drops it.
+                path.pop();
+                continue;
+            }
+            let has_deeper_move = maybe
+                .iter()
+                .any(|p| p.len() > path.len() && p.starts_with(path));
+            let guard_flag = if maybe.contains(path) {
+                self.field_drop_flags.get(&(key, path.clone())).copied()
+            } else {
+                None
+            };
+
+            let index_val = self.emit(CfgInstData::Const(k), Type::U64, span);
+            projs.push(Projection::Index {
+                array_type: array_ty,
+                index: index_val,
+            });
+
+            let cont_block = guard_flag.map(|flag| self.begin_flag_guard(flag, span));
+            let recursed = if has_deeper_move {
+                match elem_ty.kind() {
+                    TypeKind::Struct(elem_struct_id) => {
+                        self.emit_partial_struct_drop_level(
+                            key,
+                            elem_struct_id,
+                            elem_ty,
+                            path,
+                            projs,
+                            definite,
+                            maybe,
+                            span,
+                        );
+                        true
+                    }
+                    TypeKind::Array(_) => {
+                        self.emit_partial_array_drop_level(
+                            key, elem_ty, path, projs, definite, maybe, span,
+                        );
+                        true
+                    }
+                    _ => false,
+                }
+            } else {
+                false
+            };
+            if !recursed {
+                let place = self.cfg.make_place(base, projs.iter().copied());
+                let elem_val = self.emit(CfgInstData::PlaceRead { place }, elem_ty, span);
+                self.emit(CfgInstData::Drop { value: elem_val }, Type::UNIT, span);
             }
             if let Some(cont_block) = cont_block {
                 self.end_flag_guard(cont_block);

--- a/crates/rue-cli-tests/cases/comptime_value_params.toml
+++ b/crates/rue-cli-tests/cases/comptime_value_params.toml
@@ -1,0 +1,145 @@
+# Comptime value parameters are monomorphized per value (RUE-166).
+#
+# Before the fix, a function with a `comptime n: i32` parameter was analyzed
+# ONCE with `n` unknown: `comptime { n }` in its body failed E1200, and
+# recursion (`fact(n - 1)`) failed E1201 at the argument. Now every distinct
+# comptime value creates its own specialization (`f__v5`, `f__v3`, ...) —
+# mirroring the RUE-109 type-identity mangling — in which `n` is a
+# compile-time constant. Comptime-known `if` conditions inside such bodies
+# select their branch at compile time, so comptime recursion terminates; a
+# depth cap (64 rounds) diagnoses runaway recursion instead of hanging.
+
+[section]
+id = "cli.comptime_value_params"
+name = "Comptime value parameter specialization"
+description = "Per-value monomorphization of comptime value parameters through the real driver."
+
+[[case]]
+name = "comptime_block_uses_param"
+description = "The body's comptime block sees the concrete value of the comptime parameter."
+files = [{ path = "main.rue", source = """
+fn f(comptime n: i32) -> i32 {
+    comptime { n + 1 }
+}
+fn main() -> i32 {
+    @dbg(f(5));
+    0
+}
+""" }]
+stdout = "6\n"
+
+[[case]]
+name = "comptime_recursion_factorial"
+description = "Comptime recursion: each value specializes, dead branches prune, recursion terminates."
+files = [{ path = "main.rue", source = """
+fn fact(comptime n: i32) -> i32 {
+    if n <= 1 { 1 } else { n * fact(n - 1) }
+}
+fn main() -> i32 {
+    @dbg(fact(5));
+    0
+}
+""" }]
+stdout = "120\n"
+
+[[case]]
+name = "comptime_forwarding_still_works"
+description = "Pin: forwarding a comptime parameter to another comptime parameter (worked pre-fix)."
+files = [{ path = "main.rue", source = """
+fn g(comptime m: i32) -> i32 { m }
+fn f(comptime n: i32) -> i32 { g(n) }
+fn main() -> i32 {
+    @dbg(f(42));
+    0
+}
+""" }]
+stdout = "42\n"
+
+[[case]]
+name = "two_distinct_values_two_symbols"
+description = "f(3) and f(5) produce distinct specialized symbols; same value dedups (RUE-100's duplicate-symbol failure mode must not return)."
+files = [{ path = "main.rue", source = """
+fn f(comptime n: i32) -> i32 {
+    comptime { n + 1 }
+}
+fn main() -> i32 {
+    @dbg(f(3) + f(5) + f(5));
+    0
+}
+""" }]
+stdout = "16\n"
+
+[[case]]
+name = "mixed_type_and_value_params"
+description = "A function with both a comptime type parameter and a comptime value parameter specializes on both."
+files = [{ path = "main.rue", source = """
+fn scaled(comptime T: type, comptime k: i32, x: T) -> T {
+    x * comptime { k * 2 }
+}
+fn main() -> i32 {
+    @dbg(scaled(i32, 3, 7));
+    0
+}
+""" }]
+stdout = "42\n"
+
+[[case]]
+name = "runaway_comptime_recursion_diagnosed"
+description = "Recursion with no comptime-known base case hits the depth cap with a clean diagnostic (no hang, no ICE)."
+files = [{ path = "main.rue", source = """
+fn runaway(comptime n: i32) -> i32 {
+    runaway(n + 1)
+}
+fn main() -> i32 {
+    runaway(0)
+}
+""" }]
+compile_fail = true
+error_contains = ["exceeded the maximum"]
+
+[[case]]
+name = "deep_base_case_diagnosed_not_hung"
+description = "fact(1000000): a base case beyond the depth cap is a fast, clean error — not a compiler hang."
+files = [{ path = "main.rue", source = """
+fn fact(comptime n: i64) -> i64 {
+    if n <= 1 { 1 } else { n * fact(n - 1) }
+}
+fn main() -> i32 {
+    if fact(1000000) > 0 { 1 } else { 0 }
+}
+""" }]
+compile_fail = true
+error_contains = ["exceeded the maximum"]
+
+[[case]]
+name = "module_member_call_with_comptime_param"
+description = "Calling a comptime-value function through a module object routes through specialization."
+files = [
+    { path = "main.rue", source = """
+const util = @import("util");
+fn main() -> i32 {
+    @dbg(util.scale(5, 7));
+    0
+}
+""" },
+    { path = "util.rue", source = """
+pub fn scale(comptime k: i32, x: i32) -> i32 {
+    x * comptime { k + 1 }
+}
+""" },
+]
+args = ["main.rue", "util.rue", "-o", "prog"]
+stdout = "42\n"
+
+[[case]]
+name = "runtime_arg_to_comptime_param_still_rejected"
+description = "Pin: a runtime value passed to a comptime parameter is still E1201."
+files = [{ path = "main.rue", source = """
+fn double(comptime n: i32) -> i32 { n * 2 }
+fn main() -> i32 {
+    let x = 21;
+    double(x)
+}
+""" }]
+compile_fail = true
+error_contains = ["comptime parameter requires a compile-time known value"]

--- a/crates/rue-cli-tests/cases/linear_must_consume.toml
+++ b/crates/rue-cli-tests/cases/linear_must_consume.toml
@@ -213,3 +213,209 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["E0406", "linear value 'm' must be consumed"]
+
+# =============================================================================
+# Element-wise consumption of linear arrays (RUE-186, spec 3.8:68-73)
+#
+# A constant index into an array variable moves just that element out, so a
+# linear array can be consumed element by element. Dynamic indices stay
+# conservative (E0904); partial consumption at scope end is rejected; drop
+# elaboration must not double-drop moved-out elements nor leak unmoved ones.
+# =============================================================================
+
+[[case]]
+name = "linear_array_elementwise_consume_runs"
+description = "Element-wise consumption of a linear array compiles and runs (RUE-186)."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn consume(m: MustUse) -> i32 { m.value }
+fn main() -> i32 {
+    let xs = [MustUse { value: 40 }, MustUse { value: 2 }];
+    consume(xs[0]) + consume(xs[1])
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "linear_array_partial_consumption_rejected"
+description = "Consuming only some elements of a linear array names the unconsumed elements."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn consume(m: MustUse) -> i32 { m.value }
+fn main() -> i32 {
+    let xs = [MustUse { value: 1 }, MustUse { value: 2 }, MustUse { value: 3 }];
+    consume(xs[1])
+}
+""" }]
+compile_fail = true
+error_contains = ["E0406", "element(s) [0], [2]"]
+
+[[case]]
+name = "linear_array_element_one_branch_rejected"
+description = "An element consumed in only one branch is not consumed on all paths (E0443)."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn consume(m: MustUse) -> i32 { m.value }
+fn main() -> i32 {
+    let xs = [MustUse { value: 1 }, MustUse { value: 2 }];
+    let a = consume(xs[0]);
+    if a == 1 {
+        a + consume(xs[1])
+    } else {
+        a
+    }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0443", "element(s) [1]"]
+
+[[case]]
+name = "linear_array_dynamic_index_move_rejected"
+description = "Moving out through a non-constant index stays rejected (E0904, soundness pin)."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn consume(m: MustUse) -> i32 { m.value }
+fn pick() -> u64 { 0 }
+fn main() -> i32 {
+    let xs = [MustUse { value: 1 }, MustUse { value: 2 }];
+    let i = pick();
+    consume(xs[i]) + consume(xs[1])
+}
+""" }]
+compile_fail = true
+error_contains = ["E0904", "cannot move out of indexed position"]
+
+[[case]]
+name = "array_element_drop_order_after_move"
+description = "Drop ORDER with a moved-out element: the new owner drops it first; scope exit drops the remaining elements ascending, exactly once (RUE-186)."
+files = [{ path = "main.rue", source = """
+struct D { value: i32 }
+drop fn D(self) {
+    @dbg(self.value);
+}
+fn consume(d: D) -> i32 { d.value }
+fn main() -> i32 {
+    let xs = [D { value: 1 }, D { value: 2 }, D { value: 3 }];
+    let got = consume(xs[1]);
+    @dbg(100);
+    got - 2
+}
+""" }]
+exit_code = 0
+stdout = "2\n100\n1\n3\n"
+
+[[case]]
+name = "array_element_branch_drop_flag_runs"
+description = "An element moved on only one path is dropped at exit exactly when that path did not run (runtime drop flag, RUE-186)."
+files = [{ path = "main.rue", source = """
+struct D { value: i32 }
+drop fn D(self) {
+    @dbg(self.value);
+}
+fn consume(d: D) -> i32 { d.value }
+fn cond(x: i32) -> bool { x > 0 }
+fn main() -> i32 {
+    let xs = [D { value: 1 }, D { value: 2 }];
+    let mut total = 0;
+    if cond(0) {
+        total = total + consume(xs[0]);
+    }
+    @dbg(100);
+    total
+}
+""" }]
+exit_code = 0
+stdout = "100\n1\n2\n"
+
+[[case]]
+name = "array_early_return_drops_unmoved_elements_only"
+description = "A return with a partially moved array drops only the unmoved elements (no double drop, no leak)."
+files = [{ path = "main.rue", source = """
+struct D { value: i32 }
+drop fn D(self) {
+    @dbg(self.value);
+}
+fn consume(d: D) -> i32 { d.value }
+fn cond(x: i32) -> bool { x > 0 }
+fn main() -> i32 {
+    let xs = [D { value: 1 }, D { value: 2 }];
+    let a = consume(xs[0]);
+    if cond(1) {
+        @dbg(100);
+        return a - 1;
+    }
+    a + consume(xs[1])
+}
+""" }]
+exit_code = 0
+stdout = "1\n100\n2\n"
+
+[[case]]
+name = "array_whole_reinit_after_element_move_drops_once"
+description = "Overwriting a partially moved array drops only the unmoved old elements, then the new occupants at exit (RUE-64 x RUE-186)."
+files = [{ path = "main.rue", source = """
+struct D { value: i32 }
+drop fn D(self) {
+    @dbg(self.value);
+}
+fn consume(d: D) -> i32 { d.value }
+fn main() -> i32 {
+    let mut xs = [D { value: 1 }, D { value: 2 }];
+    let a = consume(xs[0]);
+    xs = [D { value: 7 }, D { value: 8 }];
+    @dbg(100);
+    a - 1
+}
+""" }]
+exit_code = 0
+stdout = "1\n2\n100\n7\n8\n"
+
+[[case]]
+name = "array_element_write_partially_moved_rejected"
+description = "Assignment into a partially moved array is rejected (E0480): writes cannot re-arm per-element ownership."
+files = [{ path = "main.rue", source = """
+struct D { value: i32 }
+fn consume(d: D) -> i32 { d.value }
+fn main() -> i32 {
+    let mut xs = [D { value: 1 }, D { value: 2 }];
+    let a = consume(xs[0]);
+    xs[0] = D { value: 9 };
+    a
+}
+""" }]
+compile_fail = true
+error_contains = ["E0480", "cannot assign into 'xs'"]
+
+[[case]]
+name = "array_element_move_in_loop_rejected"
+description = "A constant-index move inside a loop body is a use-after-move on the next iteration."
+files = [{ path = "main.rue", source = """
+struct D { value: i32 }
+fn consume(d: D) -> i32 { d.value }
+fn main() -> i32 {
+    let xs = [D { value: 1 }, D { value: 2 }];
+    let mut i = 0;
+    let mut total = 0;
+    while i < 2 {
+        total = total + consume(xs[0]);
+        i = i + 1;
+    }
+    total
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "use of moved value 'xs[0]'"]
+
+[[case]]
+name = "linear_array_param_elementwise_consume_runs"
+description = "A by-value linear array parameter is consumable element-wise by the callee; the caller's whole-array move still satisfies its own obligation."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn consume(m: MustUse) -> i32 { m.value }
+fn consume_all(xs: [MustUse; 2]) -> i32 { consume(xs[0]) + consume(xs[1]) }
+fn main() -> i32 {
+    let xs = [MustUse { value: 40 }, MustUse { value: 2 }];
+    consume_all(xs)
+}
+""" }]
+exit_code = 42

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -856,6 +856,188 @@ const BONUS: i32 = 10;
 ]
 exit_code = 42
 
+# Enums obey the same uniform rule (RUE-185): naming a private enum from
+# another directory — annotation, variant construction, or match pattern —
+# is E0460, whether the file was imported or merely listed.
+[[case]]
+name = "private_enum_cross_dir_unqualified_rejected"
+description = "Unqualified annotation/construction naming a private enum in another directory is E0460 (RUE-185), imported or not."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    let c: Color = Color::Blue;
+    0
+}
+""" },
+    { path = "sub/lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "enum `Color` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "flat_multifile_private_enum_construction_rejected"
+description = "Uniform privacy for enums (RUE-185): a variant of a private enum in a never-imported listed file is not constructible cross-directory."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let c = Color::Blue;
+    0
+}
+""" },
+    { path = "sub/lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "enum `Color` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "flat_multifile_private_enum_match_pattern_rejected"
+description = "A match pattern is a reference site too (RUE-185): matching on a private cross-directory enum is E0460 with the pattern's own file-attributed span, even when the scrutinee arrives via a pub fn."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    match make() {
+        Color::Red => 1,
+        Color::Green => 2,
+        Color::Blue => 3,
+    }
+}
+""" },
+    { path = "sub/lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+pub fn make() -> Color {
+    Color::Green
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "enum `Color` is private (defined in `sub/lib.rue`)", "main.rue"]
+
+[[case]]
+name = "private_enum_module_qualified_pattern_rejected"
+description = "Through a module object the private enum stays E0706 (non-regression, RUE-185): `lib.Color::Red` in a match pattern."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    match lib.make() {
+        lib.Color::Red => 1,
+        _ => 0,
+    }
+}
+""" },
+    { path = "sub/lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+pub fn make() -> Color {
+    Color::Green
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0706", "enum `Color` is private"]
+
+[[case]]
+name = "flat_multifile_pub_enum_cross_dir_allowed"
+description = "Positive control (RUE-185): a pub enum in another never-imported directory remains usable unqualified — annotation, construction, and match (spec 10.3:8)."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let c: Color = Color::Blue;
+    match c {
+        Color::Red => 10,
+        Color::Green => 20,
+        Color::Blue => 42,
+    }
+}
+""" },
+    { path = "sub/lib.rue", source = """
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "pub_enum_module_qualified_pattern_allowed"
+description = "Positive control (RUE-185): a pub enum through a module object works in match patterns, verified by execution."
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib.rue");
+
+fn main() -> i32 {
+    match lib.make() {
+        lib.Color::Red => 1,
+        lib.Color::Green => 42,
+        lib.Color::Blue => 3,
+    }
+}
+""" },
+    { path = "sub/lib.rue", source = """
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+pub fn make() -> Color {
+    Color::Green
+}
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "flat_multifile_private_enum_same_dir_allowed"
+description = "Control (RUE-185): intra-directory visibility is unchanged — a private enum in another listed file in the SAME directory is usable."
+args = ["main.rue", "lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let c: Color = Color::Green;
+    match c {
+        Color::Red => 1,
+        Color::Green => 42,
+        Color::Blue => 3,
+    }
+}
+""" },
+    { path = "lib.rue", source = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" },
+]
+exit_code = 42
+
 # ---------------------------------------------------------------------------
 # Nested module member access (RUE-122 regression coverage).
 #

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -146,6 +146,8 @@ impl ErrorCode {
     pub const CONST_MISSING_TYPE_ANNOTATION: Self = Self(475);
     // 476-477 are reserved by in-flight work.
     pub const LINEAR_VALUE_DISCARDED: Self = Self(478);
+    // 479 is reserved by in-flight work.
+    pub const ASSIGN_TO_PARTIALLY_MOVED_ARRAY: Self = Self(480);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -1165,9 +1167,19 @@ pub enum ErrorKind {
     IndexOutOfBounds { index: i64, length: u64 },
     #[error("type annotation required for empty array")]
     TypeAnnotationRequired,
-    /// Cannot move non-Copy element out of array index position
+    /// Cannot move non-Copy element out of array index position.
+    /// Raised only for moves the per-element tracker cannot follow: dynamic
+    /// (non-constant) indices, and indexing that is not rooted directly at an
+    /// array variable. A constant index into an array variable moves just
+    /// that element out (spec 3.8:68, RUE-186).
     #[error("cannot move out of indexed position: element type '{element_type}' is not Copy")]
     MoveOutOfIndex { element_type: String },
+    /// Assignment into an array (element write, or a write through an element)
+    /// while one or more of its elements are moved out (RUE-186). Reinstating
+    /// per-element ownership through writes is not supported; the whole array
+    /// must be reinitialized instead.
+    #[error("cannot assign into '{array}': one of its elements has been moved out")]
+    AssignToPartiallyMovedArray { array: String },
 
     // Linker errors
     #[error("link error: {0}")]
@@ -1324,6 +1336,9 @@ impl ErrorKind {
             ErrorKind::IndexOutOfBounds { .. } => ErrorCode::INDEX_OUT_OF_BOUNDS,
             ErrorKind::TypeAnnotationRequired => ErrorCode::TYPE_ANNOTATION_REQUIRED,
             ErrorKind::MoveOutOfIndex { .. } => ErrorCode::MOVE_OUT_OF_INDEX,
+            ErrorKind::AssignToPartiallyMovedArray { .. } => {
+                ErrorCode::ASSIGN_TO_PARTIALLY_MOVED_ARRAY
+            }
 
             // Linker/target errors (E1000-E1099)
             ErrorKind::LinkError(_) => ErrorCode::LINK_ERROR,

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -823,7 +823,7 @@ pub struct AmbiguousModuleData {
 /// exceed it).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PrivateUnqualifiedAccessData {
-    /// The kind of item ("function", "struct", "constant").
+    /// The kind of item ("function", "struct", "enum", "constant").
     pub item_kind: String,
     /// The item's name as written at the reference site.
     pub name: String,

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -181,11 +181,16 @@ pub enum PatternKind {
     Path = 3,
 }
 
-/// Size of each pattern kind in the extra array (including body InstRef)
-const PATTERN_WILDCARD_SIZE: u32 = 4; // kind, span_start, span_len, body
-const PATTERN_INT_SIZE: u32 = 7; // kind, span_start, span_len, value_lo, value_hi, negative, body
-const PATTERN_BOOL_SIZE: u32 = 5; // kind, span_start, span_len, value, body
-const PATTERN_PATH_SIZE: u32 = 7; // kind, span_start, span_len, module, type_name, variant, body
+/// Size of each pattern kind in the extra array (including body InstRef).
+///
+/// The span is stored as three words — start, len, AND file id — so pattern
+/// diagnostics in multi-file compilations attribute to the right file
+/// (dropping the file id here was why pattern-anchored errors reported
+/// "span has an unknown file id", RUE-185).
+const PATTERN_WILDCARD_SIZE: u32 = 5; // kind, span_start, span_len, span_file, body
+const PATTERN_INT_SIZE: u32 = 8; // kind, span_start, span_len, span_file, value_lo, value_hi, negative, body
+const PATTERN_BOOL_SIZE: u32 = 6; // kind, span_start, span_len, span_file, value, body
+const PATTERN_PATH_SIZE: u32 = 8; // kind, span_start, span_len, span_file, module, type_name, variant, body
 
 /// Stored representation of struct field initializer.
 /// Layout: [field_name: u32, value: u32] = 2 u32s per field
@@ -398,6 +403,7 @@ impl Rir {
                     self.extra.push(PatternKind::Wildcard as u32);
                     self.extra.push(span.start());
                     self.extra.push(span.len());
+                    self.extra.push(span.file_id.index());
                     self.extra.push(body.as_u32());
                 }
                 RirPattern::Int {
@@ -408,6 +414,7 @@ impl Rir {
                     self.extra.push(PatternKind::Int as u32);
                     self.extra.push(span.start());
                     self.extra.push(span.len());
+                    self.extra.push(span.file_id.index());
                     // Store u64 magnitude as two u32s (little-endian) plus sign flag
                     self.extra.push(*value as u32);
                     self.extra.push((*value >> 32) as u32);
@@ -418,6 +425,7 @@ impl Rir {
                     self.extra.push(PatternKind::Bool as u32);
                     self.extra.push(span.start());
                     self.extra.push(span.len());
+                    self.extra.push(span.file_id.index());
                     self.extra.push(if *value { 1 } else { 0 });
                     self.extra.push(body.as_u32());
                 }
@@ -430,6 +438,7 @@ impl Rir {
                     self.extra.push(PatternKind::Path as u32);
                     self.extra.push(span.start());
                     self.extra.push(span.len());
+                    self.extra.push(span.file_id.index());
                     // Store module as u32::MAX for None, otherwise the InstRef
                     self.extra.push(module.map_or(u32::MAX, |r| r.as_u32()));
                     self.extra.push(type_name.into_usize() as u32);
@@ -441,6 +450,16 @@ impl Rir {
         (start, arms.len() as u32)
     }
 
+    /// Decode a pattern's span from the extra array. Every pattern kind
+    /// stores its span as [start, len, file_id] at offsets 1..=3 after the
+    /// kind word (see the `PATTERN_*_SIZE` layout comments).
+    fn decode_pattern_span(extra: &[u32], pos: usize) -> Span {
+        let span_start = extra[pos + 1];
+        let span_len = extra[pos + 2];
+        let file_id = rue_span::FileId::new(extra[pos + 3]);
+        Span::with_file(file_id, span_start, span_start + span_len)
+    }
+
     /// Retrieve match arms from the extra array.
     pub fn get_match_arms(&self, start: u32, arm_count: u32) -> Vec<(RirPattern, InstRef)> {
         let mut arms = Vec::with_capacity(arm_count as usize);
@@ -450,22 +469,18 @@ impl Rir {
             let kind = self.extra[pos];
             match kind {
                 k if k == PatternKind::Wildcard as u32 => {
-                    let span_start = self.extra[pos + 1];
-                    let span_len = self.extra[pos + 2];
-                    let span = Span::new(span_start, span_start + span_len);
-                    let body = InstRef::from_raw(self.extra[pos + 3]);
+                    let span = Self::decode_pattern_span(&self.extra, pos);
+                    let body = InstRef::from_raw(self.extra[pos + 4]);
                     arms.push((RirPattern::Wildcard(span), body));
                     pos += PATTERN_WILDCARD_SIZE as usize;
                 }
                 k if k == PatternKind::Int as u32 => {
-                    let span_start = self.extra[pos + 1];
-                    let span_len = self.extra[pos + 2];
-                    let span = Span::new(span_start, span_start + span_len);
-                    let value_lo = self.extra[pos + 3] as u64;
-                    let value_hi = self.extra[pos + 4] as u64;
+                    let span = Self::decode_pattern_span(&self.extra, pos);
+                    let value_lo = self.extra[pos + 4] as u64;
+                    let value_hi = self.extra[pos + 5] as u64;
                     let value = value_lo | (value_hi << 32);
-                    let negative = self.extra[pos + 5] != 0;
-                    let body = InstRef::from_raw(self.extra[pos + 6]);
+                    let negative = self.extra[pos + 6] != 0;
+                    let body = InstRef::from_raw(self.extra[pos + 7]);
                     arms.push((
                         RirPattern::Int {
                             value,
@@ -477,28 +492,24 @@ impl Rir {
                     pos += PATTERN_INT_SIZE as usize;
                 }
                 k if k == PatternKind::Bool as u32 => {
-                    let span_start = self.extra[pos + 1];
-                    let span_len = self.extra[pos + 2];
-                    let span = Span::new(span_start, span_start + span_len);
-                    let value = self.extra[pos + 3] != 0;
-                    let body = InstRef::from_raw(self.extra[pos + 4]);
+                    let span = Self::decode_pattern_span(&self.extra, pos);
+                    let value = self.extra[pos + 4] != 0;
+                    let body = InstRef::from_raw(self.extra[pos + 5]);
                     arms.push((RirPattern::Bool(value, span), body));
                     pos += PATTERN_BOOL_SIZE as usize;
                 }
                 k if k == PatternKind::Path as u32 => {
-                    let span_start = self.extra[pos + 1];
-                    let span_len = self.extra[pos + 2];
-                    let span = Span::new(span_start, span_start + span_len);
+                    let span = Self::decode_pattern_span(&self.extra, pos);
                     // Decode module: u32::MAX means None
-                    let module_raw = self.extra[pos + 3];
+                    let module_raw = self.extra[pos + 4];
                     let module = if module_raw == u32::MAX {
                         None
                     } else {
                         Some(InstRef::from_raw(module_raw))
                     };
-                    let type_name = Spur::try_from_usize(self.extra[pos + 4] as usize).unwrap();
-                    let variant = Spur::try_from_usize(self.extra[pos + 5] as usize).unwrap();
-                    let body = InstRef::from_raw(self.extra[pos + 6]);
+                    let type_name = Spur::try_from_usize(self.extra[pos + 5] as usize).unwrap();
+                    let variant = Spur::try_from_usize(self.extra[pos + 6] as usize).unwrap();
+                    let body = InstRef::from_raw(self.extra[pos + 7]);
                     arms.push((
                         RirPattern::Path {
                             module,
@@ -1164,12 +1175,13 @@ impl Rir {
                             k if k == PatternKind::Path as u32 => PATTERN_PATH_SIZE as usize,
                             _ => panic!("Unknown pattern kind during merge: {}", kind),
                         };
-                        // Path patterns also embed a module InstRef at offset 3
-                        // (u32::MAX encodes None); it must be renumbered like
-                        // every other InstRef or it would point into the wrong
-                        // file's instruction space after merging.
-                        if kind == PatternKind::Path as u32 && extra[pos + 3] != u32::MAX {
-                            extra[pos + 3] += inst_offset;
+                        // Path patterns also embed a module InstRef at offset 4
+                        // (after kind + the 3-word span; u32::MAX encodes
+                        // None); it must be renumbered like every other
+                        // InstRef or it would point into the wrong file's
+                        // instruction space after merging.
+                        if kind == PatternKind::Path as u32 && extra[pos + 4] != u32::MAX {
+                            extra[pos + 4] += inst_offset;
                         }
                         // The body InstRef is always the last element of each pattern
                         extra[pos + pattern_size - 1] += inst_offset;

--- a/crates/rue-spec/cases/arrays/fixed.toml
+++ b/crates/rue-spec/cases/arrays/fixed.toml
@@ -587,18 +587,56 @@ exit_code = 42
 [[case]]
 name = "array_non_copy_element_move_error"
 spec = ["7.1:28"]
-description = "Cannot move non-Copy element out of array index"
+description = "Cannot move non-Copy element out with a non-constant index (RUE-186 keeps dynamic indices conservative)"
 source = """
 struct BigThing { value: i32 }
 
+fn first_index() -> u64 { 0 }
+
 fn main() -> i32 {
     let arr: [BigThing; 2] = [BigThing { value: 1 }, BigThing { value: 2 }];
-    let x = arr[0];
+    let i = first_index();
+    let x = arr[i];
     x.value
 }
 """
 compile_fail = true
 error_contains = "cannot move out of"
+
+[[case]]
+name = "array_non_copy_rvalue_element_move_error"
+spec = ["7.1:28"]
+description = "Cannot move a non-Copy element out of a computed (non-variable) array, even with a constant index"
+source = """
+struct BigThing { value: i32 }
+
+fn make() -> [BigThing; 2] {
+    [BigThing { value: 1 }, BigThing { value: 2 }]
+}
+
+fn main() -> i32 {
+    let x = make()[0];
+    x.value
+}
+"""
+compile_fail = true
+error_contains = "cannot move out of"
+
+[[case]]
+name = "array_non_copy_constant_index_move_ok"
+spec = ["7.1:28", "3.8:68"]
+description = "A constant index into an array variable moves the element out (per-element tracking)"
+source = """
+struct BigThing { value: i32 }
+
+fn main() -> i32 {
+    let arr: [BigThing; 2] = [BigThing { value: 40 }, BigThing { value: 2 }];
+    let x = arr[0];
+    let y = arr[1];
+    x.value + y.value
+}
+"""
+exit_code = 42
 
 [[case]]
 name = "array_non_copy_field_access_ok"

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1347,3 +1347,139 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "type mismatch"
+
+# =============================================================================
+# Per-Value Specialization of Comptime Value Parameters (RUE-166)
+# =============================================================================
+# Each distinct comptime value argument creates its own specialized function
+# body, in which the parameter is a compile-time constant.
+
+[[case]]
+name = "comptime_param_usable_in_comptime_block"
+spec = ["4.14:5"]
+description = "A comptime value parameter is a compile-time constant inside the body's comptime blocks"
+source = """
+fn f(comptime n: i32) -> i32 {
+    comptime { n + 1 }
+}
+fn main() -> i32 {
+    f(41)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_two_distinct_values_specialize"
+spec = ["4.14:5"]
+description = "Two distinct comptime values produce two specializations with distinct symbols (no duplicate-symbol link error, RUE-100)"
+source = """
+fn f(comptime n: i32) -> i32 {
+    comptime { n * n }
+}
+fn main() -> i32 {
+    f(4) + f(5) + 1
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_same_value_deduplicated"
+spec = ["4.14:5"]
+description = "Repeated calls with the same comptime value share one specialization"
+source = """
+fn f(comptime n: i32) -> i32 {
+    comptime { n + 7 }
+}
+fn main() -> i32 {
+    f(14) + f(14)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_forward_derived_expression"
+spec = ["4.14:5"]
+description = "An expression over a comptime parameter is itself comptime-known and can be forwarded"
+source = """
+fn g(comptime m: i32) -> i32 { m * 2 }
+fn f(comptime n: i32) -> i32 { g(n + 1) }
+fn main() -> i32 {
+    f(20)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_param_i64_specialization"
+spec = ["4.14:5"]
+description = "Comptime value parameters keep their declared type in the specialized body (i64, not i32)"
+source = """
+fn double(comptime n: i64) -> i64 {
+    n * 2
+}
+fn main() -> i32 {
+    if double(3000000000) == 6000000000 { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_if_selects_branch_recursion"
+spec = ["4.14:17"]
+description = "A comptime-known if selects its branch at compile time, letting comptime recursion terminate"
+source = """
+fn fact(comptime n: i32) -> i32 {
+    if n <= 1 { 1 } else { n * fact(n - 1) }
+}
+fn main() -> i32 {
+    if fact(5) == 120 { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_if_false_branch_no_else"
+spec = ["4.14:17"]
+description = "A comptime-known false condition with no else contributes unit and compiles nothing"
+source = """
+fn f(comptime n: i32) -> i32 {
+    if n > 100 {
+        return 0;
+    }
+    n
+}
+fn main() -> i32 {
+    f(42)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_recursion_depth_limit"
+spec = ["4.14:18"]
+description = "Comptime recursion without a compile-time-known base case is diagnosed, not an infinite loop"
+source = """
+fn runaway(comptime n: i32) -> i32 {
+    runaway(n + 1)
+}
+fn main() -> i32 {
+    runaway(0)
+}
+"""
+compile_fail = true
+error_contains = "exceeded the maximum"
+
+[[case]]
+name = "comptime_recursion_depth_limit_deep_base_case"
+spec = ["4.14:18"]
+description = "A base case beyond the maximum specialization depth is diagnosed cleanly (no hang)"
+source = """
+fn count(comptime n: i32) -> i32 {
+    if n <= 0 { 0 } else { 1 + count(n - 1) }
+}
+fn main() -> i32 {
+    count(1000000)
+}
+"""
+compile_fail = true
+error_contains = "exceeded the maximum"

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -486,3 +486,128 @@ const BONUS: i32 = 10;
 """ }
 pass_aux_files = true
 exit_code = 42
+
+# =============================================================================
+# Unqualified Cross-Directory Access: Enums (RUE-185)
+# =============================================================================
+# The uniform privacy rule (10.3:7) covers enums too: naming a private enum
+# from another directory — in a type annotation, a variant construction, or a
+# match pattern — is E0460, imported or flat-listed.
+
+[[case]]
+name = "cross_dir_unqualified_private_enum_error"
+spec = ["10.3:7"]
+description = "Unqualified annotation + variant construction naming a private enum of an imported module in another directory is rejected"
+source = """
+const defs = @import("subdir/defs");
+
+fn main() -> i32 {
+    let c: Color = Color::Blue;
+    0
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" }
+compile_fail = true
+error_contains = "enum `Color` is private (defined in"
+
+[[case]]
+name = "flat_multifile_unqualified_private_enum_construction_error"
+spec = ["10.3:7", "10.3:8"]
+description = "Uniform privacy: constructing a variant of a private enum in a never-imported, explicitly listed file in another directory is rejected"
+source = """
+fn main() -> i32 {
+    let c = Color::Blue;
+    0
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "enum `Color` is private (defined in"
+
+[[case]]
+name = "flat_multifile_private_enum_match_pattern_error"
+spec = ["10.3:7", "10.3:8"]
+description = "A match pattern names the enum unqualified too: matching on a private cross-directory enum is rejected even when the scrutinee arrives through a pub function"
+source = """
+fn main() -> i32 {
+    match make() {
+        Color::Red => 1,
+        Color::Green => 2,
+        Color::Blue => 3,
+    }
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+pub fn make() -> Color {
+    Color::Green
+}
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "enum `Color` is private (defined in"
+
+[[case]]
+name = "flat_multifile_unqualified_pub_enum_allowed"
+spec = ["10.3:8", "10.5:2"]
+description = "The flat namespace still resolves pub enums across directories without imports: annotation, construction, and match all work"
+source = """
+fn main() -> i32 {
+    let c: Color = Color::Blue;
+    match c {
+        Color::Red => 10,
+        Color::Green => 20,
+        Color::Blue => 42,
+    }
+}
+"""
+aux_files = { "subdir/defs.rue" = """
+pub enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" }
+pass_aux_files = true
+exit_code = 42
+
+[[case]]
+name = "flat_multifile_same_dir_private_enum_allowed"
+spec = ["10.3:2", "10.3:8"]
+description = "Intra-directory visibility (ADR-0026) is unchanged: a private enum in another listed file in the same directory is usable unqualified"
+source = """
+fn main() -> i32 {
+    let c: Color = Color::Green;
+    match c {
+        Color::Red => 1,
+        Color::Green => 42,
+        Color::Blue => 3,
+    }
+}
+"""
+aux_files = { "defs.rue" = """
+enum Color {
+    Red,
+    Green,
+    Blue,
+}
+""" }
+pass_aux_files = true
+exit_code = 42

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -1751,3 +1751,296 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Array Element Moves (RUE-186)
+# =============================================================================
+
+[[case]]
+name = "array_element_move_leaves_siblings_usable"
+spec = ["3.8:68"]
+description = "A constant-index move takes only that element; siblings stay usable"
+source = """
+struct Big { value: i32 }
+
+fn consume(b: Big) -> i32 { b.value }
+
+fn main() -> i32 {
+    let xs = [Big { value: 1 }, Big { value: 2 }];
+    let a = consume(xs[0]);
+    let b = consume(xs[1]);
+    a + b
+}
+"""
+exit_code = 3
+
+[[case]]
+name = "array_element_move_out_of_order"
+spec = ["3.8:68"]
+description = "Elements can be moved out in any order"
+source = """
+struct Big { value: i32 }
+
+fn consume(b: Big) -> i32 { b.value }
+
+fn main() -> i32 {
+    let xs = [Big { value: 1 }, Big { value: 2 }, Big { value: 39 }];
+    consume(xs[2]) + consume(xs[0]) + consume(xs[1])
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "array_moved_element_reuse_rejected"
+spec = ["3.8:70"]
+description = "Using a moved-out element again is a use-after-move"
+source = """
+struct Big { value: i32 }
+
+fn consume(b: Big) -> i32 { b.value }
+
+fn main() -> i32 {
+    let xs = [Big { value: 1 }, Big { value: 2 }];
+    let a = consume(xs[0]);
+    let b = consume(xs[0]);
+    a + b
+}
+"""
+compile_fail = true
+error_contains = "use of moved value 'xs[0]'"
+
+[[case]]
+name = "array_whole_use_after_element_move_rejected"
+spec = ["3.8:70"]
+description = "A partially moved array cannot be used as a whole value"
+source = """
+struct Big { value: i32 }
+
+fn consume(b: Big) -> i32 { b.value }
+fn take_all(xs: [Big; 2]) -> i32 { 0 }
+
+fn main() -> i32 {
+    let xs = [Big { value: 1 }, Big { value: 2 }];
+    let a = consume(xs[0]);
+    a + take_all(xs)
+}
+"""
+compile_fail = true
+error_contains = "use of moved value 'xs'"
+
+[[case]]
+name = "array_dynamic_index_after_element_move_rejected"
+spec = ["3.8:70"]
+description = "A non-constant index cannot read a partially moved array (soundness)"
+source = """
+struct Big { value: i32 }
+
+fn consume(b: Big) -> i32 { b.value }
+fn peek(borrow b: Big) -> i32 { b.value }
+fn one() -> u64 { 1 }
+
+fn main() -> i32 {
+    let xs = [Big { value: 1 }, Big { value: 2 }];
+    let a = consume(xs[0]);
+    let i = one();
+    a + peek(borrow xs[i])
+}
+"""
+compile_fail = true
+error_contains = "use of moved value 'xs'"
+
+[[case]]
+name = "array_field_read_through_moved_element_rejected"
+spec = ["3.8:70"]
+description = "Reading a field through a moved-out element is a use-after-move"
+source = """
+struct Big { value: i32 }
+
+fn consume(b: Big) -> i32 { b.value }
+
+fn main() -> i32 {
+    let xs = [Big { value: 1 }, Big { value: 2 }];
+    let a = consume(xs[0]);
+    a + xs[0].value
+}
+"""
+compile_fail = true
+error_contains = "use of moved value 'xs[0]'"
+
+[[case]]
+name = "linear_array_elementwise_consumption"
+spec = ["3.8:71"]
+description = "Moving every element out satisfies a linear array's must-consume obligation"
+source = """
+linear struct MustUse { value: i32 }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let xs = [MustUse { value: 40 }, MustUse { value: 2 }];
+    consume(xs[0]) + consume(xs[1])
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "linear_array_partial_elementwise_rejected"
+spec = ["3.8:71"]
+description = "Consuming only some elements of a linear array is an error naming the rest"
+source = """
+linear struct MustUse { value: i32 }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let xs = [MustUse { value: 1 }, MustUse { value: 2 }];
+    consume(xs[0])
+}
+"""
+compile_fail = true
+error_contains = ["must be consumed", "element(s) [1]"]
+
+[[case]]
+name = "linear_array_element_one_branch_rejected"
+spec = ["3.8:71"]
+description = "An element consumed on only some paths does not satisfy the obligation"
+source = """
+linear struct MustUse { value: i32 }
+
+fn consume(m: MustUse) -> i32 { m.value }
+
+fn main() -> i32 {
+    let xs = [MustUse { value: 1 }, MustUse { value: 2 }];
+    let a = consume(xs[0]);
+    if a == 1 {
+        a + consume(xs[1])
+    } else {
+        a
+    }
+}
+"""
+compile_fail = true
+error_contains = ["not consumed on all paths", "element(s) [1]"]
+
+[[case]]
+name = "linear_array_param_elementwise_consumption"
+spec = ["3.8:71"]
+description = "A by-value linear array parameter can be consumed element-wise by the callee"
+source = """
+linear struct MustUse { value: i32 }
+
+fn consume(m: MustUse) -> i32 { m.value }
+fn consume_all(xs: [MustUse; 2]) -> i32 { consume(xs[0]) + consume(xs[1]) }
+
+fn main() -> i32 {
+    let xs = [MustUse { value: 40 }, MustUse { value: 2 }];
+    consume_all(xs)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "array_element_write_partially_moved_rejected"
+spec = ["3.8:72"]
+description = "Assigning to an element of a partially moved array is rejected"
+source = """
+struct Big { value: i32 }
+
+fn consume(b: Big) -> i32 { b.value }
+
+fn main() -> i32 {
+    let mut xs = [Big { value: 1 }, Big { value: 2 }];
+    let a = consume(xs[0]);
+    xs[0] = Big { value: 9 };
+    a
+}
+"""
+compile_fail = true
+error_contains = "cannot assign into 'xs'"
+
+[[case]]
+name = "array_through_element_write_partially_moved_rejected"
+spec = ["3.8:72"]
+description = "Assigning through an element (to its field) of a partially moved array is rejected"
+source = """
+struct Big { value: i32 }
+
+fn consume(b: Big) -> i32 { b.value }
+
+fn main() -> i32 {
+    let mut xs = [Big { value: 1 }, Big { value: 2 }];
+    let a = consume(xs[0]);
+    xs[1].value = 9;
+    a
+}
+"""
+compile_fail = true
+error_contains = "cannot assign into 'xs'"
+
+[[case]]
+name = "array_whole_reinit_restores_ownership"
+spec = ["3.8:72"]
+description = "Reinitializing the whole array makes every element owned and usable again"
+source = """
+struct Big { value: i32 }
+
+fn consume(b: Big) -> i32 { b.value }
+
+fn main() -> i32 {
+    let mut xs = [Big { value: 1 }, Big { value: 2 }];
+    let a = consume(xs[0]);
+    xs = [Big { value: 20 }, Big { value: 21 }];
+    a + consume(xs[0]) + consume(xs[1])
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "array_moved_element_not_dropped"
+spec = ["3.8:73"]
+description = "A moved-out element is dropped by its new owner, not at the array's scope exit; unmoved elements still drop in ascending order"
+source = """
+struct D { value: i32 }
+
+drop fn D(self) {
+    @dbg(self.value);
+}
+
+fn consume(d: D) -> i32 { d.value }
+
+fn main() -> i32 {
+    let xs = [D { value: 1 }, D { value: 2 }, D { value: 3 }];
+    let got = consume(xs[1]);
+    @dbg(100);
+    got - 2
+}
+"""
+exit_code = 0
+expected_stdout = "2\n100\n1\n3\n"
+
+[[case]]
+name = "array_branch_dependent_element_drop"
+spec = ["3.8:73"]
+description = "An element moved on only some paths is dropped exactly when the executed path did not move it (runtime drop flag)"
+source = """
+struct D { value: i32 }
+
+drop fn D(self) {
+    @dbg(self.value);
+}
+
+fn consume(d: D) -> i32 { d.value }
+fn cond(x: i32) -> bool { x > 0 }
+
+fn main() -> i32 {
+    let xs = [D { value: 1 }, D { value: 2 }];
+    let mut total = 0;
+    if cond(1) {
+        total = total + consume(xs[0]);
+    }
+    @dbg(100);
+    total - 1
+}
+"""
+exit_code = 0
+expected_stdout = "1\n100\n2\n"

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -272,7 +272,7 @@ fn main() -> i32 {
 
 {{ rule(id="3.8:66", cat="legality-rule") }}
 
-The consumption requirement (3.8:32) applies to every binding whose type carries a linear value (3.8:57), not only to bindings of linear struct type. In particular, an array whose element type carries a linear value **MUST** be consumed as a whole (for example, by passing the array to a function by value); dropping the array would silently drop every element.
+The consumption requirement (3.8:32) applies to every binding whose type carries a linear value (3.8:57), not only to bindings of linear struct type. In particular, an array whose element type carries a linear value **MUST** be consumed — either as a whole (for example, by passing the array to a function by value) or element-wise via constant-index moves (3.8:71); dropping the array would silently drop every element.
 
 {{ rule(id="3.8:67", cat="example") }}
 
@@ -543,6 +543,43 @@ fn main() -> i32 {
     a + b                     // 3
 }
 ```
+
+## Array Element Moves
+
+{{ rule(id="3.8:68", cat="normative") }}
+
+Indexing an array variable with a compile-time constant index whose element type is not Copy moves that element out of the array. Only that element is invalidated; sibling elements remain usable and are still dropped normally. Element moves are tracked only for indexing applied directly to an array variable (or by-value array parameter); an array reached through another projection, or indexed with a non-constant index, cannot be moved out of (see the legality rule in the Arrays chapter).
+
+{{ rule(id="3.8:69", cat="example") }}
+
+```rue
+struct Big { value: i32 }
+
+fn consume(b: Big) -> i32 { b.value }
+
+fn main() -> i32 {
+    let xs = [Big { value: 1 }, Big { value: 2 }];
+    let a = consume(xs[0]);  // moves only xs[0]
+    let b = consume(xs[1]);  // xs[1] is still valid
+    a + b                    // 3
+}
+```
+
+{{ rule(id="3.8:70", cat="legality-rule") }}
+
+While one or more elements of an array are moved out, it is a compile-time error to use the moved element (including reading a field through it), to use the array as a whole value, or to index the array with a non-constant index. The non-constant-index restriction is required for soundness: the compiler cannot know at compile time whether a runtime index denotes a moved-out element.
+
+{{ rule(id="3.8:71", cat="normative") }}
+
+An array whose elements carry linear values may be consumed element-wise: its must-consume obligation is satisfied when every element has been moved out on every non-diverging path. Moving out only some elements, or moving an element on only some paths, is a compile-time error naming the elements that are not consumed.
+
+{{ rule(id="3.8:72", cat="legality-rule") }}
+
+While one or more elements of an array are moved out, it is a compile-time error to assign into the array — to an element, or through an element (e.g. to a field of an element). Element writes do not reinstate per-element ownership; the whole array must be reinitialized instead, which makes every element owned (and droppable) again.
+
+{{ rule(id="3.8:73", cat="dynamic-semantics") }}
+
+At scope exit (and when an array variable is overwritten), elements that were moved out on every path reaching that point are not dropped; elements moved out on only some paths are dropped exactly when the executed path did not move them; untouched elements are dropped, in ascending index order.
 
 ## Shadowing and Moves
 

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -137,6 +137,31 @@ fn main() -> i32 {
 }
 ```
 
+{{ rule(id="4.14:17", cat="normative") }}
+
+Within a specialized function body, an `if` expression whose condition can be evaluated at compile time (because it references comptime parameters in scope) selects its branch at compile time: only the taken branch is analyzed and compiled. This permits comptime-recursive functions, whose recursive call sits in a branch that is not taken once the recursion reaches its base case.
+
+```rue
+fn fact(comptime n: i32) -> i32 {
+    if n <= 1 { 1 } else { n * fact(n - 1) }
+}
+
+fn main() -> i32 {
+    fact(5)  // 120: fact(5) .. fact(1) are specialized; fact(1) takes the
+             // then-branch, so the recursion terminates
+}
+```
+
+{{ rule(id="4.14:18", cat="legality-rule") }}
+
+It is a compile-time error when specialization exceeds the implementation's maximum nesting depth (at least 64 levels), as happens when a comptime-recursive function never reaches a compile-time-known base case or a generic function recursively instantiates itself with new types. Implementations **MUST** diagnose this instead of failing to terminate.
+
+```rue
+fn runaway(comptime n: i32) -> i32 {
+    runaway(n + 1)  // ERROR: exceeds the maximum specialization depth
+}
+```
+
 ## Anonymous Struct Types
 
 {{ rule(id="4.14:7", cat="normative") }}

--- a/docs/spec/src/07-arrays/01-fixed-arrays.md
+++ b/docs/spec/src/07-arrays/01-fixed-arrays.md
@@ -183,17 +183,21 @@ fn main() -> i32 {
 
 {{ rule(id="7.1:28", cat="legality-rule") }}
 
-When reading an element of a non-Copy type, it is a compile-time error to move the element out of an array position. Use explicit methods like `swap` or `take` instead.
+When reading an element of a non-Copy type, the read moves the element out of the array only when the index is a compile-time constant and the indexing applies directly to an array variable (per-element move tracking; see Array Element Moves in the Move Semantics chapter). Any other such read — a non-constant index, or an array reached through another projection or computed by an expression — is a compile-time error: with a runtime index the compiler cannot know which element moved, so neither use-after-move checking nor drop elaboration could remain sound.
 
 {{ rule(id="7.1:29") }}
 
 ```rue
 struct BigThing { value: i32 }
 
+fn first_index() -> u64 { 0 }
+
 fn main() -> i32 {
     let arr: [BigThing; 2] = [BigThing { value: 1 }, BigThing { value: 2 }];
-    let x = arr[0];     // ERROR: cannot move out of indexed position
-    0
+    let x = arr[0];             // OK: constant index moves arr[0] out
+    let i = first_index();
+    let y = arr[i];             // ERROR: cannot move out of indexed position
+    x.value
 }
 ```
 

--- a/docs/spec/src/10-modules/03-visibility.md
+++ b/docs/spec/src/10-modules/03-visibility.md
@@ -67,8 +67,9 @@ private item by its unqualified name from a source file in a different
 directory than the item's defining file (error E0460). This covers every
 form of unqualified reference: calling a private function, naming a
 private struct (in a type annotation, a signature, or a struct literal),
-and reading a private constant — including from another constant's
-initializer.
+naming a private enum (in a type annotation, a signature, a variant
+construction, or a match pattern), and reading a private constant —
+including from another constant's initializer.
 
 {{ rule(id="10.3:8", cat="normative") }}
 
@@ -87,6 +88,8 @@ fn secret() -> i32 { 99 }       // private to sub/
 pub fn open() -> i32 { 7 }
 struct Hidden { n: i32, }       // private to sub/
 pub struct Shared { n: i32, }
+enum Mode { Fast, Slow, }       // private to sub/
+pub enum Level { Low, High, }
 const LIMIT: i32 = 8;           // private to sub/
 pub const MAX: i32 = 16;
 
@@ -94,8 +97,12 @@ pub const MAX: i32 = 16;
 fn main() -> i32 {
     // secret()                  // error E0460: private to sub/lib.rue
     // let h = Hidden { n: 1 };  // error E0460: private to sub/lib.rue
+    // let m = Mode::Fast;       // error E0460: private to sub/lib.rue
     // let l = LIMIT;            // error E0460: private to sub/lib.rue
     let s = Shared { n: MAX };   // OK: `Shared` and `MAX` are pub
-    open() + s.n
+    match Level::High {          // OK: `Level` is pub
+        Level::Low => 0,
+        Level::High => open() + s.n,
+    }
 }
 ```


### PR DESCRIPTION
Cycle-18 worker integration, **stacked on #1006** (shared sema files; diff shrinks once the stack merges).

**RUE-186:** after #1002 made bare arrays-of-linear must-consume, the obligation was unsatisfiable element-by-element — trunk rejected `xs[K]` moves outright (the worker honestly *refuted* the issue's literal "whole array marked moved" symptom; the real defect was unconsumability). Constant-index element moves now track per-element via the field-path machinery: siblings stay usable, the obligation requires every element consumed, by-value linear array params get the same in callees, dynamic indices stay conservatively rejected with the rationale spec'd, writes into partially-moved arrays are new **E0480**, and drop elaboration gained per-element runtime drop flags (destructor order/counts pinned by exact-stdout cases).

**Cross-mechanism check at integration** (×#1006): comptime per-value specialization + element-wise linear moves compose in one program, runs exit 42.

Integration verification by execution: element-wise consumption exit 42; partial consumption E0406; full `./test.sh` green on the stack (traceability 428/428 normative). +15 spec / +11 CLI / +3 unit cases.

Worker discoveries being filed: indexed access to multi-slot aggregates loads only slot 0 (pre-existing miscompile); array-literal-of-String ICE.

Fixes RUE-186

🤖 Generated with [Claude Code](https://claude.com/claude-code)