### PR TITLE
Zero-length arrays: constprop handles zero-slot locals; linear must-consume is vacuous for [L; 0]

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1631,7 +1631,7 @@ impl<'a> Sema<'a> {
                 if p.mode != RirParamMode::Normal || p.is_comptime {
                     continue;
                 }
-                if !self.type_carries_linear(p.ty) {
+                if !self.type_requires_consumption(p.ty) {
                     continue;
                 }
                 let state = ctx.moved_vars.get(&p.name);
@@ -4538,12 +4538,12 @@ impl<'a> Sema<'a> {
                 continue;
             };
 
-            // Only check types that carry a linear value: linear structs
-            // themselves, and arrays whose elements carry one (an array of
-            // linear values must be consumed — as a whole, or element-wise
-            // via constant-index moves (RUE-186); dropping it would
-            // silently drop every element).
-            if !self.type_carries_linear(local.ty) {
+            // Only check types that require consumption: linear structs
+            // themselves, and non-empty arrays whose elements carry one (an
+            // array of linear values must be consumed — as a whole, or
+            // element-wise via constant-index moves (RUE-186); dropping it
+            // would silently drop every element).
+            if !self.type_requires_consumption(local.ty) {
                 continue;
             }
 
@@ -4571,6 +4571,25 @@ impl<'a> Sema<'a> {
         }
 
         Ok(())
+    }
+
+    /// Does dropping a value of this type discard a linear value, i.e. does
+    /// the type carry a must-consume obligation?
+    ///
+    /// This is [`Self::type_carries_linear`] with one refinement (RUE-194,
+    /// spec 3.8:74): an array shape whose total element count is zero
+    /// (`[L; 0]`, `[[L; 5]; 0]`, `[[L; 0]; 5]`, ...) holds no linear values
+    /// at runtime, so its obligation is vacuously satisfied and dropping it
+    /// is fine. A linear STRUCT always requires consumption — the `linear`
+    /// declaration is the obligation, regardless of what its fields hold.
+    pub(crate) fn type_requires_consumption(&self, ty: Type) -> bool {
+        match ty.kind() {
+            TypeKind::Array(array_id) => {
+                let (element_type, length) = self.type_pool.array_def(array_id);
+                length > 0 && self.type_requires_consumption(element_type)
+            }
+            _ => self.type_carries_linear(ty),
+        }
     }
 
     /// Shared element-wise consumption check for linear arrays (RUE-186):
@@ -4638,7 +4657,7 @@ impl<'a> Sema<'a> {
         ty: Type,
         inst_ref: InstRef,
     ) -> CompileResult<()> {
-        if !self.type_carries_linear(ty) {
+        if !self.type_requires_consumption(ty) {
             return Ok(());
         }
         let err = CompileError::new(

--- a/crates/rue-cfg/src/opt/constprop.rs
+++ b/crates/rue-cfg/src/opt/constprop.rs
@@ -53,8 +53,15 @@ enum ConstPayload {
 pub fn run(cfg: &mut Cfg) -> bool {
     let mut slots = vec![SlotState::NoWrite; cfg.num_locals() as usize];
 
+    // Zero-sized locals (`[T; 0]`, `()`, empty structs) occupy 0 slots, so a
+    // zero-sized local at the end of the frame is assigned a slot index equal
+    // to `num_locals` — out of range for `slots`. Its Alloc/Load move no
+    // bytes, so there is nothing to track or rewrite: skip out-of-range slots
+    // (RUE-194).
     let record_write = |slots: &mut Vec<SlotState>, slot: u32, payload: Option<ConstPayload>| {
-        let state = &mut slots[slot as usize];
+        let Some(state) = slots.get_mut(slot as usize) else {
+            return;
+        };
         *state = match (*state, payload) {
             (SlotState::NoWrite, Some(c)) => SlotState::OneConstWrite(c),
             _ => SlotState::Disqualified,
@@ -129,7 +136,7 @@ pub fn run(cfg: &mut Cfg) -> bool {
             CfgInstData::Load { slot } => *slot,
             _ => continue,
         };
-        if let SlotState::OneConstWrite(payload) = slots[slot as usize] {
+        if let Some(&SlotState::OneConstWrite(payload)) = slots.get(slot as usize) {
             cfg.get_inst_mut(value).data = match payload {
                 ConstPayload::Int(v) => CfgInstData::Const(v),
                 ConstPayload::Bool(b) => CfgInstData::BoolConst(b),
@@ -284,6 +291,28 @@ mod tests {
             cfg.get_inst(arg_load).data,
             CfgInstData::Load { slot: 0 }
         ));
+        assert!(matches!(
+            cfg.get_inst(load).data,
+            CfgInstData::Load { slot: 0 }
+        ));
+    }
+
+    #[test]
+    fn test_zero_slot_local_out_of_range_is_ignored() {
+        // A zero-sized local ([T; 0], unit) occupies 0 slots, so a trailing
+        // one is assigned slot index == num_locals — out of range for the
+        // slot table. Its Alloc/Load must be skipped, not panic (RUE-194).
+        let mut cfg = make_cfg(0);
+        let c = push(&mut cfg, CfgInstData::Const(0), Type::I32);
+        push(
+            &mut cfg,
+            CfgInstData::Alloc { slot: 0, init: c },
+            Type::UNIT,
+        );
+        let load = push(&mut cfg, CfgInstData::Load { slot: 0 }, Type::UNIT);
+        cfg.set_terminator(cfg.entry, Terminator::Return { value: None });
+
+        assert!(!run(&mut cfg));
         assert!(matches!(
             cfg.get_inst(load).data,
             CfgInstData::Load { slot: 0 }

--- a/crates/rue-cli-tests/cases/zero_length_arrays.toml
+++ b/crates/rue-cli-tests/cases/zero_length_arrays.toml
@@ -1,0 +1,126 @@
+# Zero-length arrays (RUE-194).
+#
+# Zero-sized locals (`[T; 0]`) occupy 0 stack slots, so a zero-sized local
+# at the end of the frame gets a slot index equal to num_locals. Constprop's
+# slot table was sized by num_locals and indexed out of bounds -> ICE at
+# -O1/-O2 (fine at -O0, which skips the pass).
+#
+# Separately, the linear must-consume check fired on `[L; 0]` even though a
+# zero-length array holds no linear values: the obligation is vacuously
+# satisfied (spec 3.8:74).
+
+[section]
+id = "cli.zero_length_arrays"
+name = "Zero-length arrays"
+description = "[T; 0] compiles and runs at every opt level; [L; 0] is vacuously consumed (RUE-194)."
+
+[[case]]
+name = "zero_array_local_O0"
+description = "Control: a zero-length array local compiles and runs unoptimized."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let _arr: [i32; 0] = [];
+    0
+}
+""" }]
+args = ["main.rue", "-O0", "-o", "prog"]
+exit_code = 0
+
+[[case]]
+name = "zero_array_local_O1"
+description = "Regression: constprop indexed its slot table out of bounds for a zero-slot local (ICE)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let _arr: [i32; 0] = [];
+    0
+}
+""" }]
+args = ["main.rue", "-O1", "-o", "prog"]
+exit_code = 0
+
+[[case]]
+name = "zero_array_local_O2"
+description = "Regression: same zero-slot constprop ICE at -O2."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let _arr: [i32; 0] = [];
+    0
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 0
+
+[[case]]
+name = "zero_array_before_const_lets_O2"
+description = "A zero-slot local shares its slot index with the next local; constprop must still fold the neighbours correctly."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let _arr: [i32; 0] = [];
+    let a: i32 = 84;
+    let b: i32 = 2;
+    a / b
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 42
+
+[[case]]
+name = "zero_array_shapes_O2"
+description = "[T; 0] as a function argument, struct field, and return value at -O2."
+files = [{ path = "main.rue", source = """
+fn take(_a: [i32; 0]) -> i32 { 11 }
+fn make() -> [i32; 0] { [] }
+struct Holder { empty: [i32; 0], x: i32 }
+fn main() -> i32 {
+    let z: [i32; 0] = make();
+    let s = Holder { empty: z, x: 31 };
+    take(s.empty) + s.x
+}
+""" }]
+args = ["main.rue", "-O2", "-o", "prog"]
+exit_code = 42
+
+[[case]]
+name = "zero_array_shapes_O0"
+description = "Control: the same shapes unoptimized."
+files = [{ path = "main.rue", source = """
+fn take(_a: [i32; 0]) -> i32 { 11 }
+fn make() -> [i32; 0] { [] }
+struct Holder { empty: [i32; 0], x: i32 }
+fn main() -> i32 {
+    let z: [i32; 0] = make();
+    let s = Holder { empty: z, x: 31 };
+    take(s.empty) + s.x
+}
+""" }]
+args = ["main.rue", "-O0", "-o", "prog"]
+exit_code = 42
+
+[[case]]
+name = "zero_linear_array_accepted"
+description = "A zero-length array of a linear type holds no linear values; dropping it is fine (spec 3.8:74)."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn take(_xs: [MustUse; 0]) -> i32 { 40 }
+fn make() -> [MustUse; 0] { [] }
+fn main() -> i32 {
+    make();
+    let _local: [MustUse; 0] = [];
+    let _nested: [[MustUse; 3]; 0] = [];
+    take([]) + 2
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "one_linear_array_still_enforced"
+description = "Control: a ONE-element linear array dropped without consumption is still E0406."
+files = [{ path = "main.rue", source = """
+linear struct MustUse { value: i32 }
+fn main() -> i32 {
+    let a: [MustUse; 1] = [MustUse { value: 1 }];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0406", "linear value 'a' must be consumed"]

--- a/crates/rue-spec/cases/types/move-semantics.toml
+++ b/crates/rue-spec/cases/types/move-semantics.toml
@@ -1940,6 +1940,54 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "zero_length_linear_array_vacuously_consumed"
+spec = ["3.8:74"]
+description = "A zero-length array of a linear type holds no linear values; dropping it is fine"
+source = """
+linear struct MustUse { value: i32 }
+
+fn main() -> i32 {
+    let _none: [MustUse; 0] = [];
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "zero_length_linear_array_param_and_discard"
+spec = ["3.8:74"]
+description = "Vacuous consumption also covers by-value parameters, discarded values, and nested zero-count shapes"
+source = """
+linear struct MustUse { value: i32 }
+
+fn take(_xs: [MustUse; 0]) -> i32 { 40 }
+fn make() -> [MustUse; 0] { [] }
+
+fn main() -> i32 {
+    make();
+    let _nested_outer: [[MustUse; 5]; 0] = [];
+    let _nested_inner: [[MustUse; 0]; 2] = [[], []];
+    take([]) + 2
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "zero_length_vacuity_not_for_linear_structs"
+spec = ["3.8:74"]
+description = "Control: a one-element linear array (and a linear struct) still must be consumed"
+source = """
+linear struct MustUse { value: i32 }
+
+fn main() -> i32 {
+    let a: [MustUse; 1] = [MustUse { value: 1 }];
+    0
+}
+"""
+compile_fail = true
+error_contains = "linear value 'a' must be consumed"
+
+[[case]]
 name = "array_element_write_partially_moved_rejected"
 spec = ["3.8:72"]
 description = "Assigning to an element of a partially moved array is rejected"

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -581,6 +581,21 @@ While one or more elements of an array are moved out, it is a compile-time error
 
 At scope exit (and when an array variable is overwritten), elements that were moved out on every path reaching that point are not dropped; elements moved out on only some paths are dropped exactly when the executed path did not move them; untouched elements are dropped, in ascending index order.
 
+{{ rule(id="3.8:74", cat="normative") }}
+
+A zero-length array of a linear element type holds no linear values, so its must-consume obligation is vacuously satisfied: it may be dropped (as a local, a by-value parameter, or a discarded expression value) without error. This applies to any array shape whose total element count is zero (for example `[L; 0]`, `[[L; 5]; 0]`, and `[[L; 0]; 5]`). It does not apply to a linear struct itself: a value of a `linear struct` type must be consumed regardless of what its fields hold.
+
+{{ rule(id="3.8:75", cat="example") }}
+
+```rue
+linear struct MustUse { value: i32 }
+
+fn main() -> i32 {
+    let _none: [MustUse; 0] = [];  // OK: nothing to consume
+    0
+}
+```
+
 ## Shadowing and Moves
 
 {{ rule(id="3.8:12", cat="normative") }}


### PR DESCRIPTION
Cycle-19 worker integration (verified by hand at integration time).

**RUE-194 facets 1+3** (facet 2, the join assert, rides with the RUE-188 extract-class work): constprop's slot-forwarding indexed out of bounds for zero-sized locals — now skipped in both passes, other opt passes audited clean. The linear must-consume obligation is vacuously satisfied for zero-total-element arrays (`type_requires_consumption`, applied at scope-exit / by-value-param / discarded-value checks); `[L; 1]` control still enforced.

Integration verification by execution: `[i32; 0]` runs at -O2 (ICE'd before); `[L; 0]` accepted; `[L; 1]` still E0406. Spec 3.8:74–75, +3 spec / +8 CLI / +1 unit cases, traceability 429/429, full `./test.sh` green.

Part of RUE-194

🤖 Generated with [Claude Code](https://claude.com/claude-code)