### PR TITLE
Directive spans round-trip file_id; comptime-known match scrutinees prune arms

### DIFF
--- a/.claude/workflows/rue-fix-cycle.js
+++ b/.claude/workflows/rue-fix-cycle.js
@@ -28,12 +28,16 @@ if (!clusters.length) throw new Error('args.clusters is required: [{ key, prompt
 if (clusters.length > 4) throw new Error('max 4 workers per cycle — split the rest into the next cycle')
 
 phase('Fix')
+// Model policy (Steve, 2026-07-02): fix workers default to Opus — Fable is
+// reserved for the main loop's integration judgment and only assigned to a
+// cluster explicitly (c.model = 'fable') when the task demands it. c.effort
+// passes through (default: the session's).
 const results = await parallel(clusters.map((c, i) => () =>
   agent(`${PREAMBLE}
 
 OUTFILE: /tmp/cycle${cycle}_worker${i + 1}.diff
 
-${c.prompt}`, { label: `w${i + 1}:${c.key}`, phase: 'Fix', isolation: 'worktree' })
+${c.prompt}`, { label: `w${i + 1}:${c.key}`, phase: 'Fix', isolation: 'worktree', model: c.model || 'opus', ...(c.effort ? { effort: c.effort } : {}) })
 ))
 
 return results.filter(Boolean)

--- a/.claude/workflows/rue-overnight-hunt.js
+++ b/.claude/workflows/rue-overnight-hunt.js
@@ -103,7 +103,7 @@ const found = await parallel(
   Array.from({ length: NUM_FINDERS }, (_, i) => () =>
     agent(
       `${COMMON}\n\nYOUR FOCUS AREA: ${area}\n${angles}\n\nYou are finder #${i + 1} of ${NUM_FINDERS} on this area — explore a DIFFERENT angle/sub-area than a sibling would, to maximize coverage. Report every distinct, reproduced bug you find (aim for breadth; 0 is fine if the area is clean, but dig hard first).`,
-      { label: `find:${area}:${i + 1}`, phase: 'Find', schema: FINDINGS_SCHEMA }
+      { label: `find:${area}:${i + 1}`, phase: 'Find', model: 'sonnet', schema: FINDINGS_SCHEMA }
     )
   )
 )
@@ -131,7 +131,7 @@ const verified = await parallel(
   all.map((f, i) => () =>
     agent(
       `${COMMON}\n\nVerify this finding from area "${area}". Write its repro to /tmp/verify_${area}_${i}.rue, compile and run it on CURRENT TRUNK, and report whether the claimed bug actually occurs. Mark "confirmed" if you reproduce it, "plausible" if you can't fully reproduce but the mechanism looks real and worth filing, "refuted" if it's actually correct behavior (check docs/spec/src/). Minimize the repro. The project wants high capture, so prefer "plausible" over "refuted" when genuinely unsure — but never confirm something you couldn't run.\n\nFINDING:\n${JSON.stringify(f, null, 2)}`,
-      { label: `verify:${area}:${i}`, phase: 'Verify', schema: VERDICT_SCHEMA }
+      { label: `verify:${area}:${i}`, phase: 'Verify', model: 'opus', schema: VERDICT_SCHEMA }
     )
   )
 )

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1027,6 +1027,87 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        // Comptime-known arm selection (RUE-191, spec 4.14:19): inside a body
+        // with comptime value parameters in scope, a `match` whose scrutinee
+        // is compile-time evaluable selects its arm during analysis — only
+        // the matching arm's body is analyzed and emitted, exactly like
+        // comptime-known `if` conditions (analyze_branch above). This is what
+        // lets comptime recursion written with `match` terminate instead of
+        // hitting the specialization depth cap, and keeps statically-dead
+        // arms from being analyzed (they may only be legal for other
+        // specializations). Rue match arms have no guards, so whether a
+        // pattern matches is decidable from the pattern alone. Any
+        // pattern/value shape this selection doesn't understand (enum
+        // patterns, mismatched pattern types) falls back to analyzing all
+        // arms, as does a comptime value no arm matches (the normal path
+        // then reports non-exhaustiveness).
+        if !ctx.comptime_value_vars.is_empty() {
+            if let Some(value) = self.try_evaluate_const_in_fn(scrutinee, ctx) {
+                let arms = self.rir.get_match_arms(arms_start, arms_len);
+                let mut selected: Option<InstRef> = None;
+                let mut prunable = !arms.is_empty();
+                let mut has_wildcard = false;
+                let mut bool_true_covered = false;
+                let mut bool_false_covered = false;
+                for (pattern, body) in &arms {
+                    let matched = match (pattern, &value) {
+                        (RirPattern::Wildcard(_), _) => {
+                            has_wildcard = true;
+                            true
+                        }
+                        (
+                            RirPattern::Int {
+                                value: magnitude,
+                                negative,
+                                ..
+                            },
+                            ConstValue::Integer(n),
+                        ) => {
+                            let pat = if *negative {
+                                -(*magnitude as i128)
+                            } else {
+                                *magnitude as i128
+                            };
+                            pat == *n
+                        }
+                        (RirPattern::Bool(b, _), ConstValue::Bool(v)) => {
+                            if *b {
+                                bool_true_covered = true;
+                            } else {
+                                bool_false_covered = true;
+                            }
+                            b == v
+                        }
+                        _ => {
+                            prunable = false;
+                            break;
+                        }
+                    };
+                    if matched && selected.is_none() {
+                        selected = Some(*body);
+                    }
+                }
+                // Exhaustiveness is a property of the pattern set, not of
+                // the arm bodies, so it stays checked even when the match
+                // value is comptime-known (spec 4.7:9): a wildcard, or
+                // both bool values for a bool scrutinee. A non-exhaustive
+                // match falls through to the normal path for the proper
+                // diagnostic (which also covers "no arm matched").
+                let exhaustive = has_wildcard
+                    || (matches!(value, ConstValue::Bool(_))
+                        && bool_true_covered
+                        && bool_false_covered);
+                if prunable && exhaustive {
+                    if let Some(body) = selected {
+                        ctx.push_scope();
+                        let result = self.analyze_inst(air, body, ctx)?;
+                        ctx.pop_scope();
+                        return Ok(result);
+                    }
+                }
+            }
+        }
+
         // Analyze the scrutinee to determine its type
         let scrutinee_result = self.analyze_inst(air, scrutinee, ctx)?;
         let scrutinee_type = scrutinee_result.ty;

--- a/crates/rue-cli-tests/cases/comptime_value_params.toml
+++ b/crates/rue-cli-tests/cases/comptime_value_params.toml
@@ -143,3 +143,94 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["comptime parameter requires a compile-time known value"]
+
+[[case]]
+name = "comptime_recursion_factorial_via_match"
+description = "RUE-191: comptime recursion written with `match` instead of `if` — arm selection on the comptime-known scrutinee lets the recursion terminate instead of spuriously hitting the depth cap."
+files = [{ path = "main.rue", source = """
+fn fact(comptime n: i32) -> i32 {
+    match n {
+        0 => 1,
+        1 => 1,
+        _ => n * fact(n - 1),
+    }
+}
+fn main() -> i32 {
+    @dbg(fact(5));
+    0
+}
+""" }]
+stdout = "120\n"
+
+[[case]]
+name = "comptime_match_dead_arm_not_analyzed"
+description = "RUE-191: the unselected arm of a comptime-known match is not analyzed — its comptime block would divide by zero for THIS specialization but is dead."
+files = [{ path = "main.rue", source = """
+fn f(comptime n: i32) -> i32 {
+    match n {
+        0 => 7,
+        _ => comptime { 100 / n },
+    }
+}
+fn main() -> i32 {
+    @dbg(f(0));
+    @dbg(f(4));
+    0
+}
+""" }]
+stdout = "7\n25\n"
+
+[[case]]
+name = "comptime_match_bool_arms"
+description = "RUE-191: bool comptime scrutinees select their arm; each specialization takes a different arm."
+files = [{ path = "main.rue", source = """
+fn pick(comptime b: bool) -> i32 {
+    match b {
+        true => 1,
+        false => 2,
+    }
+}
+fn main() -> i32 {
+    @dbg(pick(false));
+    @dbg(pick(true));
+    0
+}
+""" }]
+stdout = "2\n1\n"
+
+[[case]]
+name = "comptime_match_nonexhaustive_still_rejected"
+description = "RUE-191 guard: exhaustiveness stays checked when the scrutinee is comptime-known — a matching arm does not excuse a non-exhaustive pattern set."
+files = [{ path = "main.rue", source = """
+fn f(comptime n: i32) -> i32 {
+    match n {
+        0 => 1,
+    }
+}
+fn main() -> i32 {
+    @dbg(f(0));
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0600", "not exhaustive"]
+
+[[case]]
+name = "runtime_match_unchanged_control"
+description = "RUE-191 control: a match on a RUNTIME scrutinee inside a value-specialized body still compiles to a real runtime match (all arms live)."
+files = [{ path = "main.rue", source = """
+fn classify(comptime unused: i32, x: i32) -> i32 {
+    match x {
+        0 => 10,
+        1 => 20,
+        _ => 30,
+    }
+}
+fn main() -> i32 {
+    @dbg(classify(9, 0));
+    @dbg(classify(9, 1));
+    @dbg(classify(9, 5));
+    0
+}
+""" }]
+stdout = "10\n20\n30\n"

--- a/crates/rue-cli-tests/cases/multifile_errors.toml
+++ b/crates/rue-cli-tests/cases/multifile_errors.toml
@@ -216,3 +216,63 @@ args = ["lib.rue", "main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E0206", "main.rue:3:13"]
 compile_stderr_not_contains = ["lib.rue"]
+
+[[case]]
+name = "directive_span_in_second_file"
+description = """
+RUE-189: the RIR directive encoding dropped the span's file id (and decoded
+len as end), the same loss shape as the RUE-185 pattern-span bug. The
+E0457 secondary label "type declared `@copy` here" anchors on the @copy
+directive's span in other.rue; before the fix it rendered the honest
+"unknown file id" fallback instead of the snippet. The label must show the
+@copy line from other.rue and never fall back.
+"""
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+""" },
+    { path = "other.rue", source = """
+@copy
+pub struct P { x: i32 }
+
+drop fn P(self) {
+    @dbg(self.x);
+}
+""" },
+]
+args = ["main.rue", "other.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0457", "other.rue:4:1", "type declared `@copy` here", "@copy"]
+compile_stderr_not_contains = ["unknown file id", "main.rue"]
+
+[[case]]
+name = "directive_span_in_first_file"
+description = """
+RUE-189, swapped order: with the @copy struct in the FIRST file, the file id
+is 0 (which coincidentally matched the pre-fix default), but the pre-fix
+decode also read the span's len word as its END offset — so any directive not
+at file offset 0 got a corrupted range. The `@copy` here sits mid-file after
+a leading comment; its label must still render the right line.
+"""
+files = [
+    { path = "lib.rue", source = """
+// leading comment so the directive is not at byte offset 0
+@copy
+pub struct Q { x: i32 }
+
+drop fn Q(self) {
+    @dbg(self.x);
+}
+""" },
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    0
+}
+""" },
+]
+args = ["lib.rue", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0457", "lib.rue:5:1", "type declared `@copy` here", "@copy"]
+compile_stderr_not_contains = ["unknown file id", "main.rue"]

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -29,7 +29,7 @@ impl InstRef {
 }
 
 /// A directive in the RIR (e.g., @allow(unused_variable))
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct RirDirective {
     /// Directive name (e.g., "allow")
     pub name: Spur,
@@ -576,13 +576,19 @@ impl Rir {
     }
 
     /// Store directives and return (start, directive_count).
-    /// Layout: [name: u32, span_start: u32, span_len: u32, args_len: u32, args...] per directive
+    /// Layout: [name: u32, span_start: u32, span_len: u32, span_file: u32, args_len: u32, args...] per directive
+    ///
+    /// The span is stored as three words — start, len, AND file id — so
+    /// directive-anchored diagnostics in multi-file compilations attribute
+    /// to the right file (dropping the file id here was the same loss shape
+    /// as the RUE-185 pattern-span bug; RUE-189).
     pub fn add_directives(&mut self, directives: &[RirDirective]) -> (u32, u32) {
         let start = self.extra.len() as u32;
         for directive in directives {
             self.extra.push(directive.name.into_usize() as u32);
             self.extra.push(directive.span.start());
             self.extra.push(directive.span.len());
+            self.extra.push(directive.span.file_id.index());
             self.extra.push(directive.args.len() as u32);
             for arg in &directive.args {
                 self.extra.push(arg.into_usize() as u32);
@@ -598,9 +604,12 @@ impl Rir {
 
         for _ in 0..directive_count {
             let name = Spur::try_from_usize(self.extra[pos] as usize).unwrap();
-            let span = Span::new(self.extra[pos + 1], self.extra[pos + 2]);
-            let args_len = self.extra[pos + 3] as usize;
-            pos += 4;
+            let span_start = self.extra[pos + 1];
+            let span_len = self.extra[pos + 2];
+            let file_id = rue_span::FileId::new(self.extra[pos + 3]);
+            let span = Span::with_file(file_id, span_start, span_start + span_len);
+            let args_len = self.extra[pos + 4] as usize;
+            pos += 5;
 
             let args: Vec<Spur> = (0..args_len)
                 .map(|i| Spur::try_from_usize(self.extra[pos + i] as usize).unwrap())
@@ -3111,6 +3120,34 @@ mod tests {
         let printer = RirPrinter::new(&rir, &interner);
         let output = printer.to_string();
         assert!(output.contains("@copy struct Point { x: i32 }"));
+    }
+
+    #[test]
+    fn test_directive_span_round_trips_file_id() {
+        // Directive spans must keep start, len, AND file id through the
+        // extra-array encoding (RUE-189): dropping the file id made every
+        // directive-anchored diagnostic in a multi-file build render
+        // "unknown file id", and decoding len as end corrupted the range.
+        let (mut rir, interner) = create_printer_test_rir();
+        let copy_name = interner.get_or_intern("copy");
+        let allow_name = interner.get_or_intern("allow");
+        let arg = interner.get_or_intern("unused_variable");
+
+        let original = vec![
+            RirDirective {
+                name: copy_name,
+                args: vec![],
+                span: Span::with_file(rue_span::FileId::new(2), 7, 12),
+            },
+            RirDirective {
+                name: allow_name,
+                args: vec![arg],
+                span: Span::with_file(rue_span::FileId::new(3), 40, 62),
+            },
+        ];
+        let (start, len) = rir.add_directives(&original);
+        let decoded = rir.get_directives(start, len);
+        assert_eq!(decoded, original);
     }
 
     #[test]

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1483,3 +1483,90 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "exceeded the maximum"
+
+[[case]]
+name = "comptime_match_selects_arm_recursion"
+spec = ["4.14:19"]
+description = "A match on a comptime-known scrutinee selects its arm at compile time, letting comptime recursion written with match terminate (RUE-191)"
+source = """
+fn fact(comptime n: i32) -> i32 {
+    match n {
+        0 => 1,
+        1 => 1,
+        _ => n * fact(n - 1),
+    }
+}
+fn main() -> i32 {
+    if fact(5) == 120 { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_match_dead_arm_not_analyzed"
+spec = ["4.14:19"]
+description = "An unselected arm body is not analyzed: a comptime expression that only fails for OTHER values does not error in a specialization that never reaches it"
+source = """
+fn f(comptime n: i32) -> i32 {
+    match n {
+        0 => 42,
+        _ => comptime { 100 / n },
+    }
+}
+fn main() -> i32 {
+    f(0)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_match_bool_scrutinee"
+spec = ["4.14:19"]
+description = "Arm selection works for bool comptime scrutinees; both specializations pick their own arm"
+source = """
+fn pick(comptime b: bool) -> i32 {
+    match b {
+        true => 40,
+        false => 2,
+    }
+}
+fn main() -> i32 {
+    pick(true) + pick(false)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_match_still_requires_exhaustiveness"
+spec = ["4.14:19", "4.7:9"]
+description = "Exhaustiveness is a property of the pattern set: a non-exhaustive integer match is rejected even when the comptime scrutinee value matches an arm"
+source = """
+fn f(comptime n: i32) -> i32 {
+    match n {
+        0 => 1,
+    }
+}
+fn main() -> i32 {
+    f(0)
+}
+"""
+compile_fail = true
+error_contains = "not exhaustive"
+
+[[case]]
+name = "comptime_match_wildcard_selected"
+spec = ["4.14:19"]
+description = "A comptime value matched by no literal pattern selects the wildcard arm"
+source = """
+fn sign(comptime n: i32) -> i32 {
+    match n {
+        -1 => 1,
+        0 => 2,
+        _ => 42,
+    }
+}
+fn main() -> i32 {
+    sign(7)
+}
+"""
+exit_code = 42

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -162,6 +162,24 @@ fn runaway(comptime n: i32) -> i32 {
 }
 ```
 
+{{ rule(id="4.14:19", cat="normative") }}
+
+Within a specialized function body, a `match` expression whose scrutinee can be evaluated at compile time likewise selects its arm at compile time: only the body of the first arm whose pattern matches the comptime value is analyzed and compiled. Comptime recursion may therefore equivalently be written with `match`. The pattern set itself must still be exhaustive (4.7:9) — exhaustiveness is a property of the patterns, which are checked even though unselected arm bodies are not.
+
+```rue
+fn fact(comptime n: i32) -> i32 {
+    match n {
+        0 => 1,
+        1 => 1,
+        _ => n * fact(n - 1),  // not analyzed once n reaches 1
+    }
+}
+
+fn main() -> i32 {
+    fact(5)  // 120: the recursion terminates exactly as with `if`
+}
+```
+
 ## Anonymous Struct Types
 
 {{ rule(id="4.14:7", cat="normative") }}


### PR DESCRIPTION
Cycle-19 worker integration (verified by hand at integration time).

**RUE-189:** directive spans in rue-rir's inst encoding dropped file_id (and decoded len as end) — the last span-carrying extra encoding with the loss shape #1005 fixed for match arms. Now round-trips `[start, len, file_id]`; directive-anchored diagnostics in multi-file builds attribute correctly, 5/5 deterministic runs.

**RUE-191:** per-value specialization (#1006) pruned comptime-known `if` conditions but analyzed every `match` arm — comptime recursion via match hit the depth cap spuriously and statically-dead arms could error. `analyze_match` now selects the matching arm for comptime-known scrutinees; exhaustiveness and runtime-scrutinee behavior unchanged.

Integration verification by execution: match-factorial `fact(5)`=120; dead-arm `comptime { 100/n }` at n=0 compiles and runs 7; multi-file directive diagnostic names the correct file; E0600 control intact. New spec rule 4.14:19, +5 spec / +7 CLI / +1 unit, traceability 429/429, full `./test.sh` green.

Fixes RUE-189
Fixes RUE-191

🤖 Generated with [Claude Code](https://claude.com/claude-code)