### PR TITLE
Accept signed integer array indices; negatives trap at runtime (RUE-81)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1310,8 +1310,11 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::IndexGet { base, index } => {
                 let base_info = self.generate(*base, ctx);
                 let index_info = self.generate(*index, ctx);
-                // Index must be an unsigned integer type
-                self.add_constraint(Constraint::is_unsigned(index_info.ty, index_info.span));
+                // Index must be an integer type (signed or unsigned) per spec
+                // 7.1:7. A negative or out-of-range index is not a type error;
+                // it is caught at runtime by the bounds check (unsigned 64-bit
+                // compare, so negatives fail and trap — RUE-81/RUE-87).
+                self.add_constraint(Constraint::is_integer(index_info.ty, index_info.span));
 
                 // Extract element type from array type.
                 // If base is InferType::Array, we can get the element type directly.
@@ -1331,8 +1334,10 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::IndexSet { base, index, value } => {
                 let base_info = self.generate(*base, ctx);
                 let index_info = self.generate(*index, ctx);
-                // Index must be an unsigned integer type
-                self.add_constraint(Constraint::is_unsigned(index_info.ty, index_info.span));
+                // Index must be an integer type (signed or unsigned) per spec
+                // 7.1:7. Negative/out-of-range indices trap at runtime via the
+                // bounds check, not at compile time (RUE-81/RUE-87).
+                self.add_constraint(Constraint::is_integer(index_info.ty, index_info.span));
 
                 let value_info = self.generate(*value, ctx);
 
@@ -2281,11 +2286,11 @@ mod tests {
 
         // Result is a type variable (element type unknown)
         assert!(info.ty.is_var());
-        // Should generate 1 constraint: index must be unsigned
+        // Should generate 1 constraint: index must be an integer (spec 7.1:7)
         assert_eq!(cgen.constraints().len(), 1);
         match &cgen.constraints()[0] {
-            Constraint::IsUnsigned(_, _) => {}
-            _ => panic!("Expected IsUnsigned constraint for index"),
+            Constraint::IsInteger(_, _) => {}
+            _ => panic!("Expected IsInteger constraint for index"),
         }
     }
 
@@ -2325,11 +2330,11 @@ mod tests {
 
         // Index assignment produces Unit
         assert_eq!(info.ty, InferType::Concrete(Type::UNIT));
-        // Should generate 1 constraint: index must be unsigned
+        // Should generate 1 constraint: index must be an integer (spec 7.1:7)
         assert_eq!(cgen.constraints().len(), 1);
         match &cgen.constraints()[0] {
-            Constraint::IsUnsigned(_, _) => {}
-            _ => panic!("Expected IsUnsigned constraint for index"),
+            Constraint::IsInteger(_, _) => {}
+            _ => panic!("Expected IsInteger constraint for index"),
         }
     }
 

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -2123,12 +2123,14 @@ impl<'a> Sema<'a> {
 
             let (element_type, length) = self.type_pool.array_def(array_type_id);
 
-            // Index must be an unsigned integer
+            // Index must be an integer type (signed or unsigned) per spec
+            // 7.1:7. A negative or out-of-range runtime index is not a type
+            // error; it traps at runtime via the bounds check (RUE-81).
             let index_result = self.analyze_inst(air, *index, ctx)?;
-            if !index_result.ty.is_unsigned() && !index_result.ty.is_error() {
+            if !index_result.ty.is_integer() && !index_result.ty.is_error() {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
-                        expected: "unsigned integer type".to_string(),
+                        expected: "integer type".to_string(),
                         found: index_result.ty.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     self.rir.get(*index).span,
@@ -2749,12 +2751,14 @@ impl<'a> Sema<'a> {
                 }
             };
 
-            // Analyze index
+            // Analyze index. Index must be an integer type (signed or
+            // unsigned) per spec 7.1:7; negative/out-of-range runtime indices
+            // trap at runtime via the bounds check (RUE-81).
             let index_result = self.analyze_inst(air, index, ctx)?;
-            if !index_result.ty.is_unsigned() && !index_result.ty.is_error() {
+            if !index_result.ty.is_integer() && !index_result.ty.is_error() {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
-                        expected: "unsigned integer type".to_string(),
+                        expected: "integer type".to_string(),
                         found: index_result.ty.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     self.rir.get(index).span,

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -799,13 +799,30 @@ mod tests {
     }
 
     #[test]
-    fn test_array_index_type_must_be_unsigned() {
-        // Array index must be unsigned integer
-        let result = compile_to_air(
+    fn test_array_index_signed_type_is_accepted() {
+        // Array index may be any integer type, signed or unsigned (spec
+        // 7.1:7). A negative/out-of-range value traps at runtime, it is not a
+        // compile-time type error (RUE-81).
+        let output = compile_to_air(
             "fn main() -> i32 {
                 let arr: [i32; 3] = [1, 2, 3];
                 let i: i32 = 1;
-                arr[i]  // Error: i32 is signed
+                arr[i]  // OK: signed index accepted
+            }",
+        )
+        .unwrap();
+
+        assert_eq!(output.functions[0].air.return_type(), Type::I32);
+    }
+
+    #[test]
+    fn test_array_index_non_integer_is_rejected() {
+        // A non-integer index (bool here) is still a type error.
+        let result = compile_to_air(
+            "fn main() -> i32 {
+                let arr: [i32; 3] = [1, 2, 3];
+                let b: bool = true;
+                arr[b]  // Error: bool is not an integer
             }",
         );
 
@@ -813,12 +830,13 @@ mod tests {
     }
 
     #[test]
-    fn test_array_index_literal_infers_u64() {
-        // Integer literal used as array index should infer to u64
+    fn test_array_index_literal_infers_integer() {
+        // Integer literal used as array index should compile; it defaults to
+        // i32 (the integer-literal default) rather than being forced unsigned.
         let output = compile_to_air(
             "fn main() -> i32 {
                 let arr: [i32; 3] = [1, 2, 3];
-                arr[1]  // 1 should infer to u64
+                arr[1]
             }",
         )
         .unwrap();

--- a/crates/rue-cli-tests/cases/signed_array_index.toml
+++ b/crates/rue-cli-tests/cases/signed_array_index.toml
@@ -1,0 +1,95 @@
+# Signed integer array indices (RUE-81).
+#
+# Spec 7.1:7 / 4.11:4 allow ANY integer type as an array index, signed or
+# unsigned. Previously a signed (i32/i64) index was rejected at compile time
+# with E0206 ("expected unsigned integer type"), contradicting the spec.
+#
+# A negative or out-of-range value is NOT a compile-time type error: the
+# runtime bounds check is an unsigned 64-bit comparison (RUE-87), so a negative
+# index (all high bits set) exceeds the length and traps at runtime.
+
+[section]
+id = "cli.signed_array_index"
+name = "Signed array indices"
+description = "i32/i64 indices read/write the right element; negative/OOB signed indices trap (RUE-81)."
+
+[[case]]
+name = "signed_i64_index_reads_element"
+description = "An i64 index reads the correct element."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    let i: i64 = 1;
+    @dbg(arr[i]);
+    0
+}
+""" }]
+stdout = "20\n"
+exit_code = 0
+
+[[case]]
+name = "signed_i32_index_reads_element"
+description = "An i32 index reads the correct element (control for width)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    let i: i32 = 2;
+    @dbg(arr[i]);
+    0
+}
+""" }]
+stdout = "30\n"
+exit_code = 0
+
+[[case]]
+name = "usize_index_reads_element"
+description = "Control: an unsigned index still works exactly as before."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    let i: usize = 0;
+    @dbg(arr[i]);
+    0
+}
+""" }]
+stdout = "10\n"
+exit_code = 0
+
+[[case]]
+name = "signed_i64_index_writes_element"
+description = "An i64 index on the write path (IndexSet) stores to the right element."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut arr: [i32; 3] = [0, 0, 0];
+    let i: i64 = 2;
+    arr[i] = 42;
+    @dbg(arr[i]);
+    0
+}
+""" }]
+stdout = "42\n"
+exit_code = 0
+
+[[case]]
+name = "negative_signed_index_traps"
+description = "A negative signed index is not a type error; it fails the bounds check and traps at runtime (exit 101)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    let i: i64 = -1;
+    arr[i]
+}
+""" }]
+exit_code = 101
+
+[[case]]
+name = "out_of_range_signed_index_traps"
+description = "An out-of-range signed index traps at runtime (exit 101)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    let i: i32 = 9;
+    arr[i]
+}
+""" }]
+exit_code = 101

--- a/crates/rue-spec/cases/expressions/index.toml
+++ b/crates/rue-spec/cases/expressions/index.toml
@@ -31,7 +31,7 @@ fn main() -> i32 {
 exit_code = 42
 
 # =============================================================================
-# Index Type Must Be Unsigned Integer
+# Index Type Must Be An Integer (Signed or Unsigned)
 # =============================================================================
 
 [[case]]
@@ -56,9 +56,12 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
+error_contains = "integer"
 
+# A signed index type is accepted (spec 4.11:4 / 7.1:7). A negative value is
+# not a type error; it traps at runtime via the bounds check (RUE-81).
 [[case]]
-name = "index_type_signed_error"
+name = "index_with_signed_i32_variable"
 spec = ["4.11:4"]
 source = """
 fn main() -> i32 {
@@ -67,8 +70,19 @@ fn main() -> i32 {
     arr[i]
 }
 """
-compile_fail = true
-error_contains = "unsigned"
+exit_code = 20
+
+[[case]]
+name = "index_with_signed_i64_variable"
+spec = ["4.11:4"]
+source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    let i: i64 = 2;
+    arr[i]
+}
+"""
+exit_code = 30
 
 # =============================================================================
 # Result Type is Element Type

--- a/crates/rue-spec/cases/runtime/bounds.toml
+++ b/crates/rue-spec/cases/runtime/bounds.toml
@@ -99,9 +99,11 @@ fn main() -> i32 {
 """
 compile_fail = true
 
+# A negative constant index is a compile-time out-of-bounds error (the
+# constant bounds check catches index < 0), not a type error (RUE-81).
 [[case]]
-name = "constant_expression_negation_rejected"
-spec = ["4.11:4"]
+name = "constant_negative_index_out_of_bounds"
+spec = ["8.2:3"]
 source = """
 fn main() -> i32 {
     let arr: [i32; 3] = [10, 20, 30];
@@ -109,7 +111,7 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "unsigned"
+error_contains = "out of bounds"
 
 [[case]]
 name = "constant_expression_division_valid"
@@ -144,6 +146,34 @@ source = """
 fn main() -> i32 {
     let arr: [i32; 3] = [10, 20, 30];
     let i: u64 = 100;
+    arr[i]
+}
+"""
+exit_code = 101
+
+# A negative signed index computed at runtime must trap: the bounds check is
+# an unsigned 64-bit comparison, so a negative value (all high bits set)
+# exceeds the length and fails (RUE-81 / RUE-87).
+[[case]]
+name = "negative_signed_index_traps_at_runtime"
+spec = ["8.2:5"]
+source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    let i: i64 = -1;
+    arr[i]
+}
+"""
+exit_code = 101
+
+# An out-of-range signed index also traps at runtime.
+[[case]]
+name = "out_of_range_signed_index_traps_at_runtime"
+spec = ["8.2:5"]
+source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    let i: i32 = 7;
     arr[i]
 }
 """

--- a/docs/spec/src/04-expressions/11-index-expressions.md
+++ b/docs/spec/src/04-expressions/11-index-expressions.md
@@ -22,7 +22,10 @@ The expression before the brackets **MUST** have an array type `[T; N]`.
 
 {{ rule(id="4.11:4", cat="legality-rule") }}
 
-The index expression **MUST** have an unsigned integer type (`u8`, `u16`, `u32`, or `u64`).
+The index expression **MUST** have an integer type (signed or unsigned:
+`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `isize`, or `usize`). A
+negative index value is not a compile-time type error; it is caught by bounds
+checking (a negative index always fails the bounds check and traps at runtime).
 
 {{ rule(id="4.11:5", cat="normative") }}
 


### PR DESCRIPTION
Cycle-20 worker integration (verified by hand at integration time).

**RUE-81:** spec 7.1:7 permits any integer type as an index, but two independent checks required `is_unsigned` — the constraint generator (`generate.rs`, `a[i]` reads) and two direct-analysis sites (`analysis.rs`, one covering `a[i] = v` writes). All now accept any integer type. No codegen change: both backends' `emit_bounds_check` already use an unsigned 64-bit comparison (RUE-87), so a negative index fails `< len` and traps regardless of sign-extension. Reconciled a spec inconsistency (4.11:4 'unsigned' vs 7.1:7 'integer' → both 'integer').

Integration verification by execution: i32/i64 positive read = 30; negative i64 index **traps** (exit 101, not a silent wrap); signed-index write correct; bool index still E0206. Full `./test.sh` green; aarch64 checked via `--emit asm`. New `signed_array_index.toml` + spec cases.

Fixes RUE-81

🤖 Generated with [Claude Code](https://claude.com/claude-code)