### PR TITLE
Array-literal error elements surface their real diagnostic instead of an ICE (RUE-190); RUE-18 regression pins

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3213,6 +3213,28 @@ impl<'a> Sema<'a> {
         // Get the array type from HM inference
         let array_type = Self::get_resolved_type(ctx, inst_ref, span, "array literal")?;
 
+        // If an element expression is itself ill-typed, HM inference collapses
+        // the whole array to `<error>` rather than a real `[T; N]` (see
+        // `infer_type_to_type`'s Array arm in typeck.rs). Analyzing the
+        // elements here surfaces the element's *real* diagnostic (e.g. the
+        // unknown-associated-function error on `[String::from(..)]`) instead of
+        // masking it with an ICE about the array literal being a non-array
+        // type (RUE-190).
+        if array_type.is_error() {
+            for elem_ref in &elem_refs {
+                self.analyze_inst(air, *elem_ref, ctx)?;
+            }
+            // Elements analyzed without surfacing an error yet the array type
+            // is still `<error>`: a diagnostic was already emitted upstream.
+            // Propagate an error-typed placeholder rather than emitting an ICE.
+            let air_ref = air.add_inst(AirInst {
+                data: AirInstData::UnitConst,
+                ty: Type::ERROR,
+                span,
+            });
+            return Ok(AnalysisResult::new(air_ref, Type::ERROR));
+        }
+
         let (_array_type_id, _elem_type, expected_len) = match array_type.as_array() {
             Some(type_id) => {
                 let (element_type, length) = self.type_pool.array_def(type_id);

--- a/crates/rue-cli-tests/cases/array_literal_string.toml
+++ b/crates/rue-cli-tests/cases/array_literal_string.toml
@@ -1,0 +1,113 @@
+[section]
+id = "array_literal_string"
+name = "Array literals of String-producing expressions (RUE-190)"
+description = """
+Regression tests for RUE-190: an array literal whose elements are
+String-producing expressions used to abort the compiler with
+E9000 "Array literal inferred as non-array type: <error>".
+
+Two flavors:
+  1. Valid String array literals must compile and run — elements are usable
+     (indexing, .len(), .capacity()), and each fat pointer materializes fully.
+  2. Ill-typed elements (e.g. a nonexistent `String::from`, an undefined
+     function) must surface the element's REAL diagnostic (E0412 / E0202),
+     never an internal-compiler-error about a non-array type. HM inference
+     collapses an array with an error-typed element to `<error>`; the array
+     analyzer now re-analyzes the elements to report their real error instead
+     of ICEing on the collapsed type.
+"""
+
+# --- Flavor 1: valid String array literals compile and run ----------------
+
+# Two String::new() elements; array indexes usable, .len() is 0.
+[[case]]
+name = "array_of_string_new_len"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr = [String::new(), String::new()];
+    let n: u64 = arr[0].len();
+    if n == 0 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+# String literal elements; both slots readable and correct.
+[[case]]
+name = "array_of_string_literals_len"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr = [\"hello\", \"hi\"];
+    let a: u64 = arr[0].len();
+    let b: u64 = arr[1].len();
+    if a == 5 { if b == 2 { 0 } else { 3 } } else { 2 }
+}
+""" }]
+exit_code = 0
+
+# with_capacity elements (heap-allocated); second slot's capacity readable.
+[[case]]
+name = "array_of_string_with_capacity"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr = [String::with_capacity(16), String::with_capacity(16)];
+    let a: u64 = arr[0].capacity();
+    let b: u64 = arr[1].capacity();
+    if a >= 16 { if b >= 16 { 0 } else { 2 } } else { 1 }
+}
+""" }]
+exit_code = 0
+
+# Single-element array built from a String binding, then indexed.
+[[case]]
+name = "array_of_string_var_single"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a = String::new();
+    let arr = [a];
+    let n: u64 = arr[0].len();
+    if n == 0 { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+# --- Flavor 2: ill-typed elements surface the real error, not an ICE ------
+
+# The reported RUE-190 shape: `String::from` does not exist. Must report
+# E0412 (unknown associated function), never E9000 about a non-array type.
+[[case]]
+name = "array_of_bad_assoc_fn_reports_real_error"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr = [String::from(\"a\"), String::from(\"b\")];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0412", "no associated function named 'from'"]
+compile_stderr_not_contains = ["internal compiler error", "non-array type"]
+
+# An undefined free function as the element expression.
+[[case]]
+name = "array_of_undefined_fn_reports_real_error"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr = [nope(), nope()];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0202", "undefined function 'nope'"]
+compile_stderr_not_contains = ["internal compiler error", "non-array type"]
+
+# Single ill-typed element (the collapse-to-error path with one elem).
+[[case]]
+name = "array_single_bad_element_reports_real_error"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr = [nope()];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0202", "undefined function 'nope'"]
+compile_stderr_not_contains = ["internal compiler error", "non-array type"]

--- a/crates/rue-ui-tests/cases/warnings/unused.toml
+++ b/crates/rue-ui-tests/cases/warnings/unused.toml
@@ -258,6 +258,21 @@ exit_code = 7
 no_warnings = true
 
 [[case]]
+name = "nested_field_read_no_warning"
+description = "A nested field read (o.inner.v) uses the outermost base variable (RUE-18)"
+source = """
+struct Inner { v: i32 }
+struct Outer { inner: Inner }
+
+fn main() -> i32 {
+    let o = Outer { inner: Inner { v: 5 } };
+    o.inner.v
+}
+"""
+exit_code = 5
+no_warnings = true
+
+[[case]]
 name = "dbg_field_operand_no_warning"
 description = "A field read as a @dbg operand uses the base variable (RUE-135)"
 source = """
@@ -266,6 +281,21 @@ struct S { a: i32 }
 fn main() -> i32 {
     let s = S { a: 5 };
     @dbg(s.a);
+    0
+}
+"""
+exit_code = 0
+no_warnings = true
+
+[[case]]
+name = "dbg_indexed_array_field_operand_no_warning"
+description = "A field-then-index read (s.items[0]) as a @dbg operand uses the base variable (RUE-18)"
+source = """
+struct S { items: [i32; 3] }
+
+fn main() -> i32 {
+    let s = S { items: [1, 2, 3] };
+    @dbg(s.items[0]);
     0
 }
 """


### PR DESCRIPTION
Cycle-21 worker integration (verified by hand at integration time).

**RUE-190:** an array literal with an error-typed element (`[nope()]`, or the issue's String shapes) ICE'd with E9000 'Array literal inferred as non-array type: <error>'. Not String-specific — HM inference collapses such arrays to `Type::ERROR` and `analyze_array_init` hit an ICE guard on the non-array type *before* analyzing elements, masking the element's real error. Now when the resolved type `is_error()`, elements are re-analyzed to surface the true diagnostic (E0202/E0412) and an error placeholder is returned. Sema only; #1011 had already made valid String array literals work.

**RUE-18:** **refuted** — the false unused-variable warning for a var read only via field access was already fixed by RUE-135 (#926, `try_trace_place`). Verified every issue shape; added the two not already pinned as UI regression cases.

Integration verification by execution: `[nope()]` → clean E0202 (was E9000 ICE); valid `[String::new(), ...]` compiles, runs, `arr[0].len()` correct. Full `./test.sh` green (431/431).

Fixes RUE-190
Fixes RUE-18

🤖 Generated with [Claude Code](https://claude.com/claude-code)