### PR TITLE
@dbg borrows its argument instead of consuming it (RUE-21)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -3260,7 +3260,19 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        let arg_result = self.analyze_inst(air, args[0].value, ctx)?;
+        // @dbg borrows its argument — it prints the value without consuming it,
+        // so a non-Copy argument (e.g. a String) remains usable afterwards and
+        // is dropped by its owner at scope exit (RUE-21). When the argument is
+        // a place rooted at a variable, set `byref_arg_root` so the var-ref /
+        // place analyses treat the read as a borrow and skip move tracking,
+        // exactly as they do for a `borrow`-mode call argument. A non-place
+        // argument (literal, arithmetic, call result) has no owning variable to
+        // preserve, so it is analyzed normally.
+        let byref_root = root_variable_of(self.rir, args[0].value);
+        let prev_byref_root = std::mem::replace(&mut ctx.byref_arg_root, byref_root);
+        let arg_result = self.analyze_inst(air, args[0].value, ctx);
+        ctx.byref_arg_root = prev_byref_root;
+        let arg_result = arg_result?;
         let arg_type = arg_result.ty;
 
         // An `<error>`-typed argument reaching here via `Ok` means no

--- a/crates/rue-cli-tests/cases/programs.toml
+++ b/crates/rue-cli-tests/cases/programs.toml
@@ -108,10 +108,9 @@ stdout = """
 Hello, Rue!
 """
 
-# @dbg moves non-Copy values, so print-then-use is a compile error (RUE-21).
+# @dbg borrows its argument, so print-then-use of a non-Copy value works (RUE-21).
 [[case]]
 name = "dbg_string_then_use"
-known_bug = "RUE-21"
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let mut s = String::new();

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -95,6 +95,49 @@ fn main() -> i32 {
 exit_code = 0
 
 [[case]]
+name = "dbg_string_borrows_not_consumed"
+spec = ["4.13:6", "4.13:7"]
+description = "@dbg borrows a String; the value stays usable after the call (RUE-21)"
+source = """
+fn main() -> i32 {
+    let mut s = String::new();
+    s.push_str("hello");
+    @dbg(s);
+    let n: u64 = s.len();
+    @dbg(s);
+    if n == 5 { 0 } else { 1 }
+}
+"""
+expected_stdout = """
+hello
+hello
+"""
+exit_code = 0
+
+[[case]]
+name = "dbg_string_dropped_exactly_once"
+spec = ["4.13:6"]
+description = "A @dbg'd String is dropped exactly once by its owner, not consumed by @dbg (RUE-21)"
+source = """
+struct Holder { s: String }
+drop fn Holder(self) {
+    @dbg(self.s);
+}
+fn main() -> i32 {
+    let mut tmp = String::new();
+    tmp.push_str("world");
+    let h = Holder { s: tmp };
+    @dbg(h.s);
+    0
+}
+"""
+expected_stdout = """
+world
+world
+"""
+exit_code = 0
+
+[[case]]
 name = "dbg_prints_with_newline"
 spec = ["4.13:8"]
 source = """

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -61,6 +61,10 @@ The following table provides a quick reference to all available intrinsics:
 {{ rule(id="4.13:6", cat="normative") }}
 
 The `@dbg` intrinsic prints a value to standard output for debugging purposes.
+It *borrows* its argument: the value is read but not consumed, so a non-`Copy`
+argument (such as a `String`) remains valid after the `@dbg` call and is dropped
+by its owner at the end of the enclosing scope, exactly as if the `@dbg` call had
+not occurred.
 
 {{ rule(id="4.13:7", cat="normative") }}
 


### PR DESCRIPTION
Cycle-22 worker integration (verified by hand at integration time).

**RUE-21:** `analyze_dbg_intrinsic` analyzed the @dbg argument as a by-value use, so a non-Copy value (String) was marked moved and any later use was E0205 — printing shouldn't consume. @dbg now sets `ctx.byref_arg_root` while analyzing the argument (the same borrow mechanism call args use), so the read is a borrow. No codegen change: both backends' @dbg lowering already only read the fat pointer and never free, so the owner drops exactly once.

Integration verification by execution: `@dbg(s); s.len(); @dbg(s)` prints hello/5/hello; a drop-fn test confirms valid-at-drop and dropped-once; Copy control intact. Un-marked the RUE-21 `known_bug` CLI case (now passing) + 2 spec cases; spec 4.13:6 clarifies @dbg borrows. Full `./test.sh` green (431/431).

Fixes RUE-21

🤖 Generated with [Claude Code](https://claude.com/claude-code)