### PR TITLE
Self resolves to the enclosing struct in method signatures and bodies (RUE-123)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1364,7 +1364,9 @@ impl<'a> Sema<'a> {
         HashSet<Spur>,
         HashSet<(StructId, Spur)>,
     )> {
-        let ret_type = self.resolve_type(return_type, span)?;
+        // `Self` in a method signature (return or parameter position) resolves
+        // to the enclosing struct's type, just like the receiver (RUE-123).
+        let ret_type = self.resolve_type_with_self(return_type, struct_type, span)?;
 
         // Build parameter list, adding self as first parameter for methods
         let mut param_info: Vec<(Spur, Type, RirParamMode, bool)> = Vec::new();
@@ -1377,9 +1379,16 @@ impl<'a> Sema<'a> {
 
         // Add regular parameters with their modes
         for p in params.iter() {
-            let ty = self.resolve_type(p.ty, span)?;
+            let ty = self.resolve_type_with_self(p.ty, struct_type, span)?;
             param_info.push((p.name, ty, p.mode, p.is_comptime));
         }
+
+        // Bind `Self` to the enclosing struct type so that `Self { ... }`
+        // literals and `Self`-typed locals resolve in the method body, exactly
+        // as they do for anonymous-struct methods (RUE-123).
+        let self_sym = self.interner.get_or_intern("Self");
+        let mut type_subst = HashMap::new();
+        type_subst.insert(self_sym, struct_type);
 
         let (
             air,
@@ -1390,7 +1399,15 @@ impl<'a> Sema<'a> {
             local_strings,
             ref_fns,
             ref_meths,
-        ) = self.analyze_function(infer_ctx, ret_type, &param_info, body)?;
+        ) = self.analyze_function_internal(
+            infer_ctx,
+            ret_type,
+            &param_info,
+            body,
+            Some(&type_subst),
+            None,
+            false,
+        )?;
 
         Ok((
             AnalyzedFunction {
@@ -5268,7 +5285,7 @@ impl<'a> Sema<'a> {
     ///
     /// If the type symbol is "Self", it resolves to the provided self_type.
     /// Otherwise, it delegates to the standard resolve_type method.
-    fn resolve_type_with_self(
+    pub(crate) fn resolve_type_with_self(
         &mut self,
         type_sym: Spur,
         self_type: Type,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -443,17 +443,36 @@ impl<'a> Sema<'a> {
         // - They may use `Self` type which requires struct context
         // - They are registered later during comptime evaluation with proper Self resolution
         let mut anon_struct_method_refs = std::collections::HashSet::new();
+        // Also collect method InstRefs from named struct declarations. Inline
+        // methods (including associated functions with no `self`) are collected
+        // via `collect_struct_methods`, which binds `Self` to the enclosing
+        // type. They must be skipped in the generic FnDecl branch below, whose
+        // `collect_function_signature` has no struct context and would reject a
+        // `Self` return/parameter type as an unknown type (RUE-123).
+        let mut named_struct_method_refs = std::collections::HashSet::new();
         for (_, inst) in self.rir.iter() {
-            if let InstData::AnonStructType {
-                methods_start,
-                methods_len,
-                ..
-            } = &inst.data
-            {
-                let method_refs = self.rir.get_inst_refs(*methods_start, *methods_len);
-                for method_ref in method_refs {
-                    anon_struct_method_refs.insert(method_ref);
+            match &inst.data {
+                InstData::AnonStructType {
+                    methods_start,
+                    methods_len,
+                    ..
+                } => {
+                    let method_refs = self.rir.get_inst_refs(*methods_start, *methods_len);
+                    for method_ref in method_refs {
+                        anon_struct_method_refs.insert(method_ref);
+                    }
                 }
+                InstData::StructDecl {
+                    methods_start,
+                    methods_len,
+                    ..
+                } => {
+                    let method_refs = self.rir.get_inst_refs(*methods_start, *methods_len);
+                    for method_ref in method_refs {
+                        named_struct_method_refs.insert(method_ref);
+                    }
+                }
+                _ => {}
             }
         }
 
@@ -507,6 +526,14 @@ impl<'a> Sema<'a> {
                     // Skip ALL methods from anonymous structs (including associated functions)
                     // These are registered during comptime evaluation with proper Self type context
                     if anon_struct_method_refs.contains(&inst_ref) {
+                        continue;
+                    }
+
+                    // Skip named-struct associated functions (no `self`): they are
+                    // collected via `collect_struct_methods` with `Self` bound to
+                    // the enclosing type (RUE-123). Collecting them here as free
+                    // functions would reject a `Self` signature type.
+                    if named_struct_method_refs.contains(&inst_ref) {
                         continue;
                     }
                     self.collect_function_signature(
@@ -982,11 +1009,16 @@ impl<'a> Sema<'a> {
 
                 let params = self.rir.get_params(*params_start, *params_len);
                 let param_names: Vec<Spur> = params.iter().map(|p| p.name).collect();
+                // `Self` in a method signature (parameter or return position)
+                // resolves to the enclosing struct's type, just like the
+                // receiver does. Named-struct inline methods reach this path;
+                // anonymous-struct methods resolve Self elsewhere (RUE-123).
                 let param_types: Vec<Type> = params
                     .iter()
-                    .map(|p| self.resolve_type(p.ty, method_inst.span))
+                    .map(|p| self.resolve_type_with_self(p.ty, struct_type, method_inst.span))
                     .collect::<CompileResult<Vec<_>>>()?;
-                let ret_type = self.resolve_type(*return_type, method_inst.span)?;
+                let ret_type =
+                    self.resolve_type_with_self(*return_type, struct_type, method_inst.span)?;
 
                 // Allocate method parameters in the arena
                 let param_range = self

--- a/crates/rue-cli-tests/cases/self_type_methods.toml
+++ b/crates/rue-cli-tests/cases/self_type_methods.toml
@@ -1,0 +1,71 @@
+# `Self` type in named-struct inline methods (RUE-123).
+#
+# `Self` must resolve to the enclosing struct type in a method's return type,
+# parameter types, and `Self { ... }` body literals — matching the receiver and
+# anonymous-struct methods. Before the fix, any of these positions produced
+# E0204 "unknown type 'Self'".
+
+[section]
+id = "cli.self_type_methods"
+name = "Self type in methods"
+description = "Self resolves to the enclosing struct in named-struct inline method signatures and bodies."
+
+[[case]]
+name = "self_return_type_associated_fn"
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i32,
+
+    fn make() -> Self {
+        P { x: 42 }
+    }
+
+    fn get(self) -> i32 { self.x }
+}
+
+fn main() -> i32 {
+    let p = P::make();
+    @dbg(p.get());
+    0
+}
+""" }]
+stdout = "42\n"
+
+[[case]]
+name = "self_in_param_return_and_body_literal"
+files = [{ path = "main.rue", source = """
+struct P {
+    x: i32,
+
+    fn make(v: i32) -> Self { Self { x: v } }
+    fn combine(self, other: Self) -> Self { Self { x: self.x + other.x } }
+    fn get(self) -> i32 { self.x }
+}
+
+fn main() -> i32 {
+    let a = P::make(30);
+    let b = P { x: 12 };
+    @dbg(a.combine(b).get());
+    0
+}
+""" }]
+stdout = "42\n"
+
+[[case]]
+name = "self_method_chaining_returning_self"
+files = [{ path = "main.rue", source = """
+struct Counter {
+    value: i32,
+
+    fn inc(self) -> Self {
+        Self { value: self.value + 1 }
+    }
+}
+
+fn main() -> i32 {
+    let c = Counter { value: 39 };
+    @dbg(c.inc().inc().inc().value);
+    0
+}
+""" }]
+stdout = "42\n"

--- a/crates/rue-spec/cases/items/impl-blocks.toml
+++ b/crates/rue-spec/cases/items/impl-blocks.toml
@@ -313,3 +313,50 @@ fn main() -> i32 { 0 }
 """
 compile_fail = true
 error_contains = "duplicate"
+
+# =============================================================================
+# The Self Type (RUE-123)
+# =============================================================================
+
+[[case]]
+name = "self_type_in_return_position"
+spec = ["6.4:18"]
+description = "Self in a method return type resolves to the enclosing struct"
+source = """
+struct P {
+    x: i32,
+
+    fn make() -> Self {
+        P { x: 42 }
+    }
+
+    fn get(self) -> i32 { self.x }
+}
+
+fn main() -> i32 {
+    let p = P::make();
+    p.get()
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "self_type_in_param_and_body"
+spec = ["6.4:18"]
+description = "Self in a parameter type and in a Self { ... } body literal"
+source = """
+struct P {
+    x: i32,
+
+    fn make(v: i32) -> Self { Self { x: v } }
+    fn combine(self, other: Self) -> Self { Self { x: self.x + other.x } }
+    fn get(self) -> i32 { self.x }
+}
+
+fn main() -> i32 {
+    let a = P::make(30);
+    let b = P { x: 12 };
+    a.combine(b).get()
+}
+"""
+exit_code = 42

--- a/docs/spec/src/06-items/04-impl-blocks.md
+++ b/docs/spec/src/06-items/04-impl-blocks.md
@@ -133,6 +133,37 @@ fn main() -> i32 {
 }
 ```
 
+## The `Self` Type
+
+{{ rule(id="6.4:18", cat="normative") }}
+
+Within a struct block, the type keyword `Self` denotes the enclosing struct
+type. It **MAY** be used wherever a type is expected — in a method's parameter
+types, in its return type, and in `Self { ... }` struct-literal expressions in
+the body — and is equivalent to writing the struct's name.
+
+{{ rule(id="6.4:19", cat="example") }}
+
+```rue
+struct Point {
+    x: i32,
+    y: i32,
+
+    fn origin() -> Self {
+        Self { x: 0, y: 0 }
+    }
+
+    fn translate(self, other: Self) -> Self {
+        Self { x: self.x + other.x, y: self.y + other.y }
+    }
+}
+
+fn main() -> i32 {
+    let p = Point::origin().translate(Point { x: 42, y: 0 });
+    p.x  // Returns 42
+}
+```
+
 ## Multiple Methods
 
 {{ rule(id="6.4:15", cat="normative") }}


### PR DESCRIPTION
Cycle-22 worker integration (verified by hand at integration time).

**RUE-123:** `Self` in a named struct's methods was rejected E0204 in return-type, parameter, and `Self { ... }` body positions (anon structs already worked). Three Sema paths lacked the Self binding: `collect_struct_methods` used plain `resolve_type` → now `resolve_type_with_self`; associated functions leaked into the global function table via `collect_function_signature` (no struct context) → now handled by `collect_struct_methods` with Self bound; `analyze_method_function` seeded no `type_subst` → now `Self → struct_type` so `Self { .. }` literals resolve.

Integration verification by execution: `-> Self`, Self param, `Self { .. }` body, and method chaining all compile and run (exit 42); `self` receiver and `-> P` controls intact; file-scope `fn foo() -> Self` still E0204. Spec 6.4:18, 2 spec + 3 CLI cases, traceability 432/432. Sema only.

Fixes RUE-123

🤖 Generated with [Claude Code](https://claude.com/claude-code)