### PR TITLE
Per-test execution timeout in both harnesses (RUE-44)

### DIFF
--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -46,6 +46,7 @@
 //! - `stdout` / `stdout_contains`: assert on the program's stdout
 //! - `runtime_error_contains`: assert on the program's stderr
 //! - `exit_code`: expected program exit code (default 0)
+//! - `timeout_ms`: wall-clock limit for running the program (default 10s)
 //! - `known_bug = "RUE-NN"`: expected failure (xfail). The case runs; if it
 //!   fails, it is reported as ignored with the bug reference. If it PASSES,
 //!   the suite fails loudly so the marker gets removed when the bug is fixed.
@@ -60,18 +61,23 @@
 //! failure class, regardless of what the case expected (it still counts as
 //! "failure" for `known_bug` purposes).
 //!
-//! # Limitations
+//! # Timeouts
 //!
-//! There is no per-case timeout; programs under test must terminate. Use
-//! `compile_only = true` for sources with infinite loops.
+//! The compiled program is run under a per-case wall-clock timeout (default
+//! [`rue_test_runner::DEFAULT_TIMEOUT_MS`], overridable per case with
+//! `timeout_ms`). If it runs long — e.g. an infinite loop in generated code —
+//! its whole process group is killed and the case is reported as a distinct
+//! TIMEOUT failure (see [`rue_test_runner::TIMEOUT_PREFIX`]), so one bad
+//! program can never hang the suite. `compile_only = true` still skips the run
+//! entirely for sources that are meant only to compile.
 
 use std::collections::HashMap;
-use std::io::Write;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
+use std::time::Duration;
 
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
-use rue_test_runner::{find_dir, find_rue_binary};
+use rue_test_runner::{DEFAULT_TIMEOUT_MS, find_dir, find_rue_binary, run_with_timeout};
 use serde::Deserialize;
 
 /// Possible paths for the cases directory.
@@ -167,6 +173,11 @@ struct Case {
     /// Expected program exit code (default 0).
     #[serde(default)]
     exit_code: Option<i32>,
+    /// Wall-clock timeout in milliseconds for RUNNING the compiled program.
+    /// Defaults to [`rue_test_runner::DEFAULT_TIMEOUT_MS`]. On timeout the
+    /// program's process group is killed and the case fails as a TIMEOUT.
+    #[serde(default)]
+    timeout_ms: Option<u64>,
     /// Expected failure: reference to the Linear issue tracking the bug.
     #[serde(default)]
     known_bug: Option<String>,
@@ -323,28 +334,14 @@ fn run_case(case: &Case, rue_binary: &Path, real_std: &Path) -> TestResult {
         ));
     }
 
+    // Run the produced binary under a per-case wall-clock timeout. An infinite
+    // loop in generated code must fail this one case (as a distinct TIMEOUT
+    // class), not hang the whole suite. `run_with_timeout` puts the program in
+    // its own process group and kills the group on timeout.
     let mut run_cmd = Command::new(&program);
-    run_cmd
-        .current_dir(dir)
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::piped());
-    let mut child = run_cmd
-        .spawn()
-        .map_err(|e| format!("failed to run compiled program: {}", e))?;
-
-    if let Some(input) = &case.stdin {
-        let mut stdin = child.stdin.take().expect("stdin was piped");
-        // The program may exit without reading all input; a broken pipe here
-        // is not a test failure.
-        let _ = stdin.write_all(input.as_bytes());
-    } else {
-        drop(child.stdin.take());
-    }
-
-    let run_output = child
-        .wait_with_output()
-        .map_err(|e| format!("failed to wait for program: {}", e))?;
+    run_cmd.current_dir(dir);
+    let timeout = Duration::from_millis(case.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS));
+    let run_output = run_with_timeout(run_cmd, timeout, case.stdin.as_deref())?;
 
     let run_stdout = String::from_utf8_lossy(&run_output.stdout).to_string();
     let run_stderr = String::from_utf8_lossy(&run_output.stderr).to_string();

--- a/crates/rue-test-runner/BUCK
+++ b/crates/rue-test-runner/BUCK
@@ -4,6 +4,7 @@ rue_crate(
     name = "rue-test-runner",
     deps = [
         "//crates/rue-error:rue-error",
+        "//third-party:libc",
         "//third-party:serde",
         "//third-party:tempfile",
         "//third-party:toml",

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -795,10 +795,52 @@ fn read_all_bytes<R: IoRead>(mut reader: R) -> Vec<u8> {
     bytes
 }
 
+/// Marker prefix identifying a timeout failure. A timed-out run is a distinct
+/// failure class (like an ICE): the process ran past its wall-clock budget and
+/// was killed, rather than producing a wrong-but-finite result. Both this
+/// harness and the CLI harness surface it via this prefix so an infinite loop
+/// in a test program is reported and skipped past, never hanging the suite.
+pub const TIMEOUT_PREFIX: &str = "TIMEOUT:";
+
+/// Put the spawned child in its own process group so a timeout can kill the
+/// whole group, not just the direct child. A compiled test program spawning
+/// nothing is the common case, but killing the group is the safe default: any
+/// grandchildren it forked are torn down too, so nothing survives to keep a
+/// pipe open and wedge the harness.
+#[cfg(unix)]
+fn configure_process_group(cmd: &mut Command) {
+    use std::os::unix::process::CommandExt;
+    // process_group(0) makes the child a new group leader whose pgid == its pid.
+    cmd.process_group(0);
+}
+
+#[cfg(not(unix))]
+fn configure_process_group(_cmd: &mut Command) {}
+
+/// Kill the timed-out child and everything in its process group, then reap it.
+#[cfg(unix)]
+fn kill_process_group(child: &mut std::process::Child) {
+    // The child leads its own group (see `configure_process_group`), so a
+    // negative pid targets every process in that group with SIGKILL.
+    let pid = child.id() as i32;
+    unsafe {
+        libc::kill(-pid, libc::SIGKILL);
+    }
+    let _ = child.kill(); // belt-and-suspenders in case the group send raced
+    let _ = child.wait(); // reap the zombie
+}
+
+#[cfg(not(unix))]
+fn kill_process_group(child: &mut std::process::Child) {
+    let _ = child.kill();
+    let _ = child.wait();
+}
+
 /// Run a command with a timeout and optional stdin input.
 ///
-/// This function spawns a child process, writes to its stdin if provided,
-/// and polls for completion, killing the process if it exceeds the specified timeout.
+/// This function spawns a child process (in its own process group), writes to
+/// its stdin if provided, and polls for completion, killing the whole process
+/// group if it exceeds the specified timeout.
 ///
 /// # Arguments
 /// * `cmd` - The command to run (already configured with arguments)
@@ -807,12 +849,15 @@ fn read_all_bytes<R: IoRead>(mut reader: R) -> Vec<u8> {
 ///
 /// # Returns
 /// * `Ok(Output)` - The process output (stdout, stderr, exit status)
-/// * `Err(String)` - Error message if the process timed out or failed to start
-fn run_with_timeout(
+/// * `Err(String)` - Error message if the process timed out or failed to start.
+///   A timeout error is prefixed with [`TIMEOUT_PREFIX`] so callers can report
+///   it as a distinct failure class.
+pub fn run_with_timeout(
     mut cmd: Command,
     timeout: Duration,
     stdin_input: Option<&str>,
 ) -> Result<Output, String> {
+    configure_process_group(&mut cmd);
     let mut child = cmd
         .stdin(if stdin_input.is_some() {
             Stdio::piped()
@@ -824,13 +869,13 @@ fn run_with_timeout(
         .spawn()
         .map_err(|e| format!("Failed to spawn process: {}", e))?;
 
-    // Write stdin input if provided
+    // Write stdin input if provided. A program may exit without reading all of
+    // its input; a broken pipe here is not a test failure, so errors are
+    // ignored (matching the CLI harness).
     if let Some(input) = stdin_input {
         if let Some(mut stdin) = child.stdin.take() {
-            stdin
-                .write_all(input.as_bytes())
-                .map_err(|e| format!("Failed to write stdin: {}", e))?;
-            // Closing stdin signals EOF to the child process
+            let _ = stdin.write_all(input.as_bytes());
+            // Dropping `stdin` closes it, signaling EOF to the child.
         }
     }
 
@@ -851,11 +896,11 @@ fn run_with_timeout(
             Ok(None) => {
                 // Still running - check timeout
                 if start.elapsed() > timeout {
-                    // Kill the process and return timeout error
-                    let _ = child.kill();
-                    let _ = child.wait(); // Reap the zombie process
+                    // Kill the whole process group and return a timeout error.
+                    kill_process_group(&mut child);
                     return Err(format!(
-                        "Test execution timed out after {} ms",
+                        "{} test execution timed out after {} ms (process group killed)",
+                        TIMEOUT_PREFIX,
                         timeout.as_millis()
                     ));
                 }
@@ -1683,6 +1728,11 @@ mod tests {
         assert!(
             err.contains("timed out"),
             "Error should mention timeout: {}",
+            err
+        );
+        assert!(
+            err.starts_with(TIMEOUT_PREFIX),
+            "Timeout error should be a distinct TIMEOUT failure class: {}",
             err
         );
     }


### PR DESCRIPTION
Cycle-23 worker integration (verified by hand at integration time).

**RUE-44:** the CLI harness ran compiled programs via `wait_with_output()` with no timeout — an infinite-loop program hung the whole suite/CI. Programs now run through the shared `run_with_timeout` (per-case `timeout_ms`, default 10s). The spec harness already timed out but killed only the direct child and didn't class timeouts; it now spawns each program in its own process group, kills the whole group on timeout (`libc::kill(-pid, SIGKILL)`), surfaces a distinct TIMEOUT failure class, and tolerates broken stdin.

Integration verification: full `./test.sh` green with timeouts armed (the whole suite runs through the new path); worker confirmed an infinite-loop program is caught as TIMEOUT in ~2s in both harnesses, 0 orphaned processes, fast tests unaffected. Harness only.

Fixes RUE-44

🤖 Generated with [Claude Code](https://claude.com/claude-code)