### PR TITLE
Fuzzer detects aborts (signals), saves reproducers, dedups (RUE-43)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -70,8 +70,14 @@ jobs:
             Please check the workflow logs and crash artifacts for details.
 
             ### Next Steps
-            1. Download the crash artifacts from the workflow run
-            2. Reproduce locally with \`./buck2 run //crates/rue:rue -- crashes/crash-*.txt output\`
+            1. Download the crash artifacts from the workflow run. Each
+               reproducer is named \`crash-<target>-<sighash>-<inputhash>.txt\`;
+               the fuzzer detects both panics and *aborts* (stack overflow /
+               SIGABRT / SIGSEGV / SIGFPE), and dedups by crash signature so
+               each distinct crash is saved once (RUE-43).
+            2. Reproduce locally by feeding the saved input to the target named
+               in the filename, e.g. for a source-level target:
+               \`./buck2 run //crates/rue-fuzz:rue-fuzz -- <target> <dir-with-the-file>\`
             3. Fix the issue and add a regression test
             `;
 

--- a/crates/rue-fuzz/BUCK
+++ b/crates/rue-fuzz/BUCK
@@ -8,6 +8,7 @@ rue_binary(
         "//crates/rue-lexer:rue-lexer",
         "//crates/rue-parser:rue-parser",
         "//third-party:anyhow",
+        "//third-party:libc",
         "//third-party:proptest",
     ],
 )

--- a/crates/rue-fuzz/README.md
+++ b/crates/rue-fuzz/README.md
@@ -64,14 +64,31 @@ When `--mutate` is enabled, the fuzzer applies these mutations to corpus inputs:
 
 ## Finding Bugs
 
-When a panic is detected, the crashing input is saved to the crash directory (defaults to `crashes/` next to the corpus). To reproduce:
+### Crash detection: panics *and* aborts (RUE-43)
+
+Each input is executed in a **forked child process** (see `src/harness.rs`).
+The parent inspects the child's `waitpid` status, so the fuzzer detects not
+only Rust panics but also *aborts* that tear the process down without
+unwinding — stack overflow (SIGSEGV on the guard page), OOM/`abort()`
+(SIGABRT), and SIGSEGV/SIGFPE from unsafe code. The previous in-process
+`catch_unwind` harness was blind to all of these (and, because this toolchain
+builds with `panic = abort`, it could not actually catch panics either — they
+abort). The child streams the panic message over a pipe from its panic hook so
+panics keep a source-location dedup signature even under `panic = abort`.
+
+When a crash is detected, the crashing input is saved to the crash directory
+(defaults to `crashes/` next to the corpus) as
+`crash-<target>-<sighash>-<inputhash>.txt`. Crashes are **deduplicated by
+signature** (panic message + location, or signal type), so one flooding bug
+saves a single reproducer instead of thousands. To reproduce, feed the saved
+input back to the target named in the filename:
 
 ```bash
-# After finding a crash
-./buck2 run //crates/rue:rue -- --emit tokens crashes/crash-*.txt
+# After finding a crash in, e.g., the parser target
+./buck2 run //crates/rue:rue -- --emit tokens crashes/crash-parser-*.txt
 
-# Or compile it
-./buck2 run //crates/rue:rue -- crashes/crash-*.txt output
+# Or run the same fuzz target on a directory containing just that input
+./buck2 run //crates/rue-fuzz:rue-fuzz -- parser <dir-with-the-file>
 ```
 
 ## Integration with CI
@@ -87,7 +104,8 @@ for target in lexer parser sema compiler emitter emitter_sequence; do
 done
 ```
 
-Any panics will cause a non-zero exit code.
+Any crash — panic or abort (signal) — causes a non-zero exit code, which fails
+the CI job and uploads the saved reproducers as artifacts.
 
 ## Proptest Integration
 
@@ -135,8 +153,9 @@ The fuzzer is designed to work with Buck2 without requiring cargo-fuzz or libFuz
 
 1. Loads inputs from a corpus directory
 2. Optionally mutates inputs (byte-level mutations)
-3. Runs the fuzz target in a panic-catching wrapper
-4. Saves any crashing inputs
+3. Runs each input in a forked child process, detecting panics *and* aborts
+   (signal deaths: SIGSEGV/SIGABRT/SIGFPE) via the child's wait-status
+4. Saves a deduplicated reproducer for each distinct crash signature
 
 Additionally, proptest-based generators create syntactically valid programs and structured codegen inputs for deeper testing.
 

--- a/crates/rue-fuzz/src/harness.rs
+++ b/crates/rue-fuzz/src/harness.rs
@@ -1,0 +1,434 @@
+//! Crash-detecting execution harness for fuzz targets.
+//!
+//! # Why this exists (RUE-43)
+//!
+//! The naive way to run a fuzz target is `catch_unwind` in-process. That only
+//! catches Rust **panics**. An *abort* — a stack overflow (SIGSEGV on the guard
+//! page), an out-of-memory `abort()`, an explicit `SIGABRT`, or a `SIGSEGV`/
+//! `SIGFPE` from unsafe code — tears the whole process down *without* unwinding,
+//! so `catch_unwind` never returns and the crash is completely invisible to the
+//! fuzzer. That is exactly how the RUE-42 stack overflow slipped through: the
+//! process just died and the loop reported a clean run.
+//!
+//! To see aborts we run every input in a **forked child process** and inspect
+//! the child's wait-status in the parent. A child killed by a signal shows up as
+//! `WIFSIGNALED`, so `SIGSEGV`/`SIGABRT`/`SIGFPE`/... are reported as crashes.
+//!
+//! ## Panics under `panic = abort`
+//!
+//! This toolchain builds with `panic = abort` (see
+//! `toolchains/rust/defs.bzl`), so a Rust panic does **not** unwind — it runs
+//! the panic hook and then calls `abort()` (SIGABRT). `catch_unwind` therefore
+//! catches nothing here. To keep panics distinguishable from raw aborts (and to
+//! give each panic a distinct dedup signature) the child installs a panic hook
+//! that streams the panic message — including its source location — over a pipe
+//! to the parent *before* the process dies. The parent uses that message when
+//! present, and falls back to the terminating signal otherwise. `catch_unwind`
+//! is still wrapped around the target so the harness also behaves correctly if
+//! ever built with `panic = unwind`.
+//!
+//! The parent process never executes target code, so a target that corrupts
+//! memory or blows the stack cannot damage the fuzzer itself.
+
+use std::collections::HashSet;
+use std::path::{Path, PathBuf};
+
+/// Exit code the child uses to signal "I caught a panic" (distinct from a
+/// signal death and from a clean exit). 101 matches rustc's own convention.
+const PANIC_EXIT_CODE: i32 = 101;
+
+/// The outcome of running one fuzz input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum RunOutcome {
+    /// The target returned normally.
+    Ok,
+    /// The target panicked; carries the panic message (best-effort).
+    Panic(String),
+    /// The child was killed by a terminating signal (e.g. SIGSEGV=11,
+    /// SIGABRT=6, SIGFPE=8). This is the case the old in-process harness was
+    /// completely blind to.
+    Signal(i32),
+}
+
+impl RunOutcome {
+    /// Whether this outcome represents a crash (anything other than a clean run).
+    pub fn is_crash(&self) -> bool {
+        !matches!(self, RunOutcome::Ok)
+    }
+
+    /// A stable signature used to collapse duplicate crashes.
+    ///
+    /// - Panics dedup on their message's first line (the crash site text).
+    /// - Signals dedup on the signal type. Async-signal-safe backtracing is out
+    ///   of scope, so all crashes of the same signal kind collapse to one entry
+    ///   — which is precisely the flood-control we want (the RUE-42 overflow
+    ///   made *every* deep input SIGSEGV).
+    pub fn signature(&self) -> Option<String> {
+        match self {
+            RunOutcome::Ok => None,
+            RunOutcome::Panic(msg) => Some(format!("panic:{}", first_line(msg))),
+            RunOutcome::Signal(sig) => Some(format!("signal:{}", signal_name(*sig))),
+        }
+    }
+
+    /// Short human-readable description for logs.
+    pub fn describe(&self) -> String {
+        match self {
+            RunOutcome::Ok => "ok".to_string(),
+            RunOutcome::Panic(msg) => format!("panic: {}", first_line(msg)),
+            RunOutcome::Signal(sig) => format!("signal: {} ({})", signal_name(*sig), sig),
+        }
+    }
+}
+
+fn first_line(s: &str) -> &str {
+    s.lines().next().unwrap_or("").trim()
+}
+
+/// Human-readable name for the common fatal signals.
+pub fn signal_name(sig: i32) -> String {
+    let name = match sig {
+        libc::SIGSEGV => "SIGSEGV",
+        libc::SIGABRT => "SIGABRT",
+        libc::SIGFPE => "SIGFPE",
+        libc::SIGILL => "SIGILL",
+        libc::SIGBUS => "SIGBUS",
+        libc::SIGKILL => "SIGKILL",
+        libc::SIGTRAP => "SIGTRAP",
+        _ => return format!("SIG{sig}"),
+    };
+    name.to_string()
+}
+
+/// Run `f` in a forked child process and report how it terminated.
+///
+/// The child runs the closure under `catch_unwind`; the parent `waitpid`s and
+/// classifies the result. Fatal signals become [`RunOutcome::Signal`], panics
+/// become [`RunOutcome::Panic`], a clean run is [`RunOutcome::Ok`].
+///
+/// If `fork`/`pipe` themselves fail (extremely unlikely), we degrade gracefully
+/// to an in-process `catch_unwind` run — that still catches panics, we just lose
+/// signal detection for that one input.
+pub fn run_forked<F: FnOnce()>(f: F) -> RunOutcome {
+    // Pipe for streaming the panic message from child to parent.
+    let mut fds = [0 as libc::c_int; 2];
+    if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
+        return run_in_process(f);
+    }
+    let (read_fd, write_fd) = (fds[0], fds[1]);
+
+    let pid = unsafe { libc::fork() };
+    if pid < 0 {
+        unsafe {
+            libc::close(read_fd);
+            libc::close(write_fd);
+        }
+        return run_in_process(f);
+    }
+
+    if pid == 0 {
+        // ---- Child: runs the (potentially crashing) target and never returns.
+        unsafe { libc::close(read_fd) };
+
+        // Stream the panic message to the parent from the panic hook, which runs
+        // *before* the process dies. Under `panic = abort` this is the only way
+        // to recover the message (the runtime aborts right after the hook);
+        // under `panic = unwind` `catch_unwind` below also handles it.
+        let hook_fd = write_fd;
+        std::panic::set_hook(Box::new(move |info| {
+            // `info` Displays as "panicked at <file>:<line>:<col>:\n<message>",
+            // so the location is included — that keeps distinct panic sites in
+            // distinct dedup buckets.
+            let text = info.to_string();
+            let bytes = text.as_bytes();
+            unsafe {
+                libc::write(hook_fd, bytes.as_ptr() as *const libc::c_void, bytes.len());
+            }
+        }));
+
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        let code = if result.is_ok() { 0 } else { PANIC_EXIT_CODE };
+        unsafe {
+            libc::close(write_fd);
+            // _exit, not exit: skip atexit handlers and stdio flushing so we
+            // don't double-flush buffers the parent also owns. `_exit` returns
+            // `!`, so the child branch diverges and never falls through to the
+            // parent code below (which would otherwise wait on itself).
+            libc::_exit(code);
+        }
+    }
+
+    // ---- Parent: collect any panic message, then reap the child.
+    unsafe { libc::close(write_fd) };
+    let mut msg = Vec::new();
+    let mut buf = [0u8; 4096];
+    loop {
+        let n = unsafe { libc::read(read_fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+        if n <= 0 {
+            break;
+        }
+        msg.extend_from_slice(&buf[..n as usize]);
+    }
+    unsafe { libc::close(read_fd) };
+
+    let mut status: libc::c_int = 0;
+    // Loop over EINTR.
+    loop {
+        let r = unsafe { libc::waitpid(pid, &mut status, 0) };
+        if r != -1 || std::io::Error::last_os_error().raw_os_error() != Some(libc::EINTR) {
+            break;
+        }
+    }
+
+    outcome_from_status(status, msg)
+}
+
+fn outcome_from_status(status: libc::c_int, panic_msg: Vec<u8>) -> RunOutcome {
+    // A captured panic message (from the child's panic hook) takes priority: it
+    // identifies the exact crash site, which is far more useful for dedup than
+    // the bare SIGABRT the abort runtime raises afterwards.
+    let msg = String::from_utf8_lossy(&panic_msg);
+    if !msg.trim().is_empty() {
+        return RunOutcome::Panic(msg.into_owned());
+    }
+
+    if libc::WIFSIGNALED(status) {
+        // Signal death with no panic message: a genuine abort — stack overflow,
+        // segfault, FPE, or a direct abort() — exactly what the old harness
+        // could not see.
+        return RunOutcome::Signal(libc::WTERMSIG(status));
+    }
+    if libc::WIFEXITED(status) {
+        let code = libc::WEXITSTATUS(status);
+        if code == 0 {
+            return RunOutcome::Ok;
+        }
+        // A non-zero exit with no panic message (e.g. the target called
+        // process::exit): still abnormal, treat it as a crash.
+        return RunOutcome::Panic(format!("child exited with status {code}"));
+    }
+    RunOutcome::Ok
+}
+
+/// Fallback path when fork/pipe are unavailable. Note: under `panic = abort`
+/// this cannot catch panics either (the process aborts), but it preserves
+/// correctness under `panic = unwind`.
+fn run_in_process<F: FnOnce()>(f: F) -> RunOutcome {
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(f)) {
+        Ok(()) => RunOutcome::Ok,
+        Err(_) => RunOutcome::Panic("panic (message unavailable)".to_string()),
+    }
+}
+
+/// Records crashes to disk, collapsing duplicates by [`RunOutcome::signature`].
+///
+/// A reproducer is written for the *first* occurrence of each distinct crash
+/// signature; subsequent identical crashes bump the duplicate counter and are
+/// not written again, so a single flooding bug can't fill the crashes dir.
+pub struct CrashReporter {
+    crash_dir: Option<PathBuf>,
+    seen: HashSet<String>,
+    pub unique_crashes: u64,
+    pub duplicate_crashes: u64,
+}
+
+impl CrashReporter {
+    pub fn new(crash_dir: Option<PathBuf>) -> Self {
+        Self {
+            crash_dir,
+            seen: HashSet::new(),
+            unique_crashes: 0,
+            duplicate_crashes: 0,
+        }
+    }
+
+    /// Report a crash. Returns the reproducer path if a *new* one was written,
+    /// or `None` if the crash was a duplicate (or `outcome` was not a crash).
+    pub fn report(&mut self, target: &str, input: &[u8], outcome: &RunOutcome) -> Option<PathBuf> {
+        let signature = outcome.signature()?;
+
+        if !self.seen.insert(signature.clone()) {
+            self.duplicate_crashes += 1;
+            return None;
+        }
+        self.unique_crashes += 1;
+
+        eprintln!(
+            "[{target}] new crash ({}) [signature: {signature}]",
+            outcome.describe()
+        );
+
+        let crash_dir = self.crash_dir.as_ref()?;
+        match write_reproducer(crash_dir, target, input, &signature) {
+            Ok(path) => {
+                eprintln!("[{target}] saved reproducer: {}", path.display());
+                Some(path)
+            }
+            Err(e) => {
+                eprintln!("[{target}] warning: failed to save reproducer: {e}");
+                None
+            }
+        }
+    }
+
+    /// Number of distinct crash signatures seen so far.
+    pub fn distinct_signatures(&self) -> usize {
+        self.seen.len()
+    }
+}
+
+/// Write the crashing input to `crash_dir` under a name that includes both a
+/// signature hash and an input hash, so identical inputs overwrite (not
+/// accumulate) and distinct crashes never collide.
+fn write_reproducer(
+    crash_dir: &Path,
+    target: &str,
+    input: &[u8],
+    signature: &str,
+) -> std::io::Result<PathBuf> {
+    use std::io::Write;
+
+    std::fs::create_dir_all(crash_dir)?;
+
+    let input_hash = fnv1a(input);
+    let sig_hash = fnv1a(signature.as_bytes()) as u32;
+
+    let filename = format!("crash-{target}-{sig_hash:08x}-{input_hash:016x}.txt");
+    let path = crash_dir.join(filename);
+
+    let mut file = std::fs::File::create(&path)?;
+    file.write_all(input)?;
+    Ok(path)
+}
+
+/// FNV-1a hash — small, dependency-free, good enough for filenames.
+fn fnv1a(bytes: &[u8]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for &b in bytes {
+        h ^= b as u64;
+        h = h.wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clean_run_is_ok() {
+        let outcome = run_forked(|| {
+            let _ = 1 + 1;
+        });
+        assert_eq!(outcome, RunOutcome::Ok);
+        assert!(!outcome.is_crash());
+        assert!(outcome.signature().is_none());
+    }
+
+    #[test]
+    fn panic_is_detected_with_message() {
+        let outcome = run_forked(|| {
+            panic!("boom-42");
+        });
+        match &outcome {
+            RunOutcome::Panic(msg) => assert!(msg.contains("boom-42"), "got: {msg}"),
+            other => panic!("expected panic, got {other:?}"),
+        }
+        assert!(outcome.is_crash());
+    }
+
+    // The core RUE-43 regression: an *abort* (signal death, which the old
+    // in-process catch_unwind harness could NOT see) must be reported as a
+    // crash carrying the terminating signal.
+    #[test]
+    fn abort_is_detected_as_signal() {
+        let outcome = run_forked(|| {
+            std::process::abort();
+        });
+        match outcome {
+            RunOutcome::Signal(sig) => assert_eq!(sig, libc::SIGABRT),
+            other => panic!("expected SIGABRT signal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn segfault_is_detected_as_signal() {
+        let outcome = run_forked(|| {
+            // Deliberate null dereference in the child only.
+            unsafe {
+                let p = std::ptr::null_mut::<u8>();
+                std::ptr::write_volatile(p, 1);
+            }
+        });
+        match outcome {
+            RunOutcome::Signal(sig) => {
+                assert!(
+                    sig == libc::SIGSEGV || sig == libc::SIGBUS,
+                    "got signal {sig}"
+                )
+            }
+            other => panic!("expected a segfault signal, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn signal_and_panic_have_distinct_signatures() {
+        let sig = RunOutcome::Signal(libc::SIGSEGV).signature();
+        let pnc = RunOutcome::Panic("index out of bounds".to_string()).signature();
+        assert!(sig.is_some() && pnc.is_some());
+        assert_ne!(sig, pnc);
+    }
+
+    #[test]
+    fn reporter_dedups_identical_crashes() {
+        let dir = std::env::temp_dir().join(format!("rue-fuzz-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let mut reporter = CrashReporter::new(Some(dir.clone()));
+
+        let outcome = RunOutcome::Signal(libc::SIGSEGV);
+
+        // First occurrence: written.
+        let first = reporter.report("parser", b"deep((((", &outcome);
+        assert!(first.is_some(), "first crash should be saved");
+        assert_eq!(reporter.unique_crashes, 1);
+        assert_eq!(reporter.duplicate_crashes, 0);
+
+        // Same signature again (even with different input bytes): deduped.
+        let second = reporter.report("parser", b"deep[[[[", &outcome);
+        assert!(second.is_none(), "duplicate crash should be deduped");
+        assert_eq!(reporter.unique_crashes, 1);
+        assert_eq!(reporter.duplicate_crashes, 1);
+        assert_eq!(reporter.distinct_signatures(), 1);
+
+        // A genuinely different crash: written.
+        let other = reporter.report("parser", b"x", &RunOutcome::Panic("nope".into()));
+        assert!(other.is_some(), "distinct crash should be saved");
+        assert_eq!(reporter.unique_crashes, 2);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn end_to_end_abort_is_saved_and_deduped() {
+        // Prove the full path: an aborting closure -> detected as a crash ->
+        // reproducer written -> re-running the same input dedups.
+        let dir = std::env::temp_dir().join(format!("rue-fuzz-e2e-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        let mut reporter = CrashReporter::new(Some(dir.clone()));
+        let input = b"aborting-input";
+
+        let outcome1 = run_forked(|| std::process::abort());
+        assert!(outcome1.is_crash());
+        let path = reporter.report("synthetic", input, &outcome1);
+        let path = path.expect("abort should be saved as a reproducer");
+        assert!(path.exists(), "reproducer file must exist on disk");
+        assert_eq!(std::fs::read(&path).unwrap(), input);
+
+        let outcome2 = run_forked(|| std::process::abort());
+        assert!(reporter.report("synthetic", input, &outcome2).is_none());
+        assert_eq!(reporter.unique_crashes, 1);
+        assert_eq!(reporter.duplicate_crashes, 1);
+
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/crates/rue-fuzz/src/main.rs
+++ b/crates/rue-fuzz/src/main.rs
@@ -19,13 +19,13 @@
 pub mod codegen_generators;
 mod corpus;
 pub mod generators;
+pub mod harness;
 mod mutate;
 mod targets;
 
+use harness::{CrashReporter, RunOutcome, run_forked};
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 
 /// A fuzz target that can be run with arbitrary input.
@@ -38,11 +38,17 @@ pub trait FuzzTarget: Send + Sync {
 }
 
 /// Statistics from a fuzzing run.
+///
+/// `crashes` counts *every* crashing input (panics and signal deaths alike),
+/// broken down into `panics` and `signals`. `unique_crashes` is the number of
+/// distinct crash signatures actually saved to disk (see [`CrashReporter`]).
 #[derive(Debug, Default)]
 pub struct FuzzStats {
     pub runs: u64,
     pub crashes: u64,
     pub panics: u64,
+    pub signals: u64,
+    pub unique_crashes: u64,
     pub elapsed: Duration,
 }
 
@@ -60,10 +66,12 @@ impl std::fmt::Display for FuzzStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "runs: {}, crashes: {}, panics: {}, exec/s: {:.1}, elapsed: {:.1}s",
+            "runs: {}, crashes: {} (panics: {}, signals: {}, unique: {}), exec/s: {:.1}, elapsed: {:.1}s",
             self.runs,
             self.crashes,
             self.panics,
+            self.signals,
+            self.unique_crashes,
             self.exec_per_sec(),
             self.elapsed.as_secs_f64()
         )
@@ -110,9 +118,15 @@ pub fn run_fuzzer<T: FuzzTarget + ?Sized>(
     );
 
     let start = Instant::now();
-    let runs = Arc::new(AtomicU64::new(0));
-    let panics = Arc::new(AtomicU64::new(0));
-    let crashes = Arc::new(AtomicU64::new(0));
+    let mut runs: u64 = 0;
+    let mut panics: u64 = 0;
+    let mut signals: u64 = 0;
+    let mut crashes: u64 = 0;
+
+    // Reproducer writing + dedup lives here; each distinct crash signature is
+    // saved once, so a single flooding bug (e.g. the RUE-42 stack overflow)
+    // can't bury the crashes dir under thousands of identical files.
+    let mut reporter = CrashReporter::new(config.crash_dir.clone());
 
     let mut rng = mutate::SimpleRng::new(42);
 
@@ -123,9 +137,8 @@ pub fn run_fuzzer<T: FuzzTarget + ?Sized>(
                 break;
             }
         }
-        let current_runs = runs.load(Ordering::Relaxed);
         if let Some(max_runs) = config.max_runs {
-            if current_runs >= max_runs {
+            if runs >= max_runs {
                 break;
             }
         }
@@ -137,27 +150,30 @@ pub fn run_fuzzer<T: FuzzTarget + ?Sized>(
             mutate::mutate(&mut input, &mut rng);
         }
 
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-            target.fuzz(&input);
-        }));
+        // Run each input in a forked child so that *aborts* (stack overflow,
+        // OOM, SIGABRT/SIGSEGV/SIGFPE) are detected via the child's wait-status,
+        // not just Rust panics. This is the core RUE-43 fix.
+        let outcome = run_forked(|| target.fuzz(&input));
 
-        if result.is_err() {
-            panics.fetch_add(1, Ordering::Relaxed);
-
-            if let Some(ref crash_dir) = config.crash_dir {
-                if let Err(e) = save_crash(crash_dir, &input, current_runs) {
-                    eprintln!("Warning: failed to save crash: {}", e);
-                }
+        if outcome.is_crash() {
+            crashes += 1;
+            match &outcome {
+                RunOutcome::Panic(_) => panics += 1,
+                RunOutcome::Signal(_) => signals += 1,
+                RunOutcome::Ok => unreachable!(),
             }
+            reporter.report(target.name(), &input, &outcome);
         }
 
-        runs.fetch_add(1, Ordering::Relaxed);
+        runs += 1;
 
-        if current_runs > 0 && current_runs % config.print_interval == 0 {
+        if runs > 0 && runs % config.print_interval == 0 {
             let stats = FuzzStats {
-                runs: current_runs,
-                crashes: crashes.load(Ordering::Relaxed),
-                panics: panics.load(Ordering::Relaxed),
+                runs,
+                crashes,
+                panics,
+                signals,
+                unique_crashes: reporter.unique_crashes,
                 elapsed,
             };
             eprintln!("[{}] {}", target.name(), stats);
@@ -165,34 +181,13 @@ pub fn run_fuzzer<T: FuzzTarget + ?Sized>(
     }
 
     Ok(FuzzStats {
-        runs: runs.load(Ordering::Relaxed),
-        crashes: crashes.load(Ordering::Relaxed),
-        panics: panics.load(Ordering::Relaxed),
+        runs,
+        crashes,
+        panics,
+        signals,
+        unique_crashes: reporter.unique_crashes,
         elapsed: start.elapsed(),
     })
-}
-
-fn save_crash(crash_dir: &Path, input: &[u8], run_id: u64) -> std::io::Result<()> {
-    use std::io::Write;
-
-    std::fs::create_dir_all(crash_dir)?;
-
-    let hash = {
-        let mut h: u64 = 0;
-        for &b in input {
-            h = h.wrapping_mul(31).wrapping_add(b as u64);
-        }
-        h
-    };
-
-    let filename = format!("crash-{:016x}-{}.txt", hash, run_id);
-    let path = crash_dir.join(filename);
-
-    let mut file = std::fs::File::create(&path)?;
-    file.write_all(input)?;
-
-    eprintln!("Saved crash to: {}", path.display());
-    Ok(())
 }
 
 fn main() {
@@ -307,8 +302,11 @@ fn main() {
     match run_fuzzer(target.as_ref(), &corpus_dir, &config) {
         Ok(stats) => {
             eprintln!("\nFuzzing complete: {}", stats);
-            if stats.panics > 0 {
-                eprintln!("Found {} panic(s)!", stats.panics);
+            if stats.crashes > 0 {
+                eprintln!(
+                    "Found {} crash(es): {} panic(s), {} signal(s); {} unique reproducer(s) saved.",
+                    stats.crashes, stats.panics, stats.signals, stats.unique_crashes
+                );
                 std::process::exit(1);
             }
         }


### PR DESCRIPTION
Cycle-23 worker integration (verified by hand at integration time).

**RUE-43:** the fuzzer ran inputs in-process under `catch_unwind`, which only catches panics — aborts (stack overflow/OOM/SIGABRT/SIGSEGV/SIGFPE) killed the process silently. Worse, the toolchain builds `panic=abort`, so `catch_unwind` caught **nothing**: even panics aborted. New `harness.rs` runs each input in a forked child and inspects `waitpid` status — `WIFSIGNALED` becomes a reported crash; a panic hook streams the message + source location over a pipe before the child dies, preserving messages under `panic=abort`. `CrashReporter` dedups by signature and writes one reproducer per distinct crash; any crash yields exit 1.

Integration verification: `fuzz.yml` lints clean (actionlint); 52 fuzz unit tests pass (7 new covering clean/panic/SIGABRT/SIGSEGV/dedup/end-to-end); worker drove the real binary with a temporary aborting target (reverted) — 104 SIGABRT crashes collapsed to 1 reproducer, exit 1; clean corpus exits 0. Full `./test.sh` green. Fuzz harness only.

Fixes RUE-43

🤖 Generated with [Claude Code](https://claude.com/claude-code)