### PR TITLE
Specialization symbols use an identifier-illegal separator; close the integer-literal-anchoring epic (RUE-41, RUE-110/112)

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -822,7 +822,9 @@ pub enum AirInstData {
     /// (type parameters like `comptime T: type` or value parameters like
     /// `comptime n: i32`, RUE-166). During a post-analysis specialization
     /// pass, this is rewritten to a regular `Call` to a specialized version
-    /// of the function (e.g., `identity__i32`, `fact__v5`).
+    /// of the function (e.g., `identity.i32`, `fact.v5`; the `.` separator is
+    /// illegal in Rue identifiers so specialized names can't collide with a
+    /// user-spellable function name, RUE-41).
     ///
     /// The type_args are encoded in the extra array as raw Type discriminant
     /// values. The comptime value arguments are encoded in the extra array as

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -326,12 +326,29 @@ fn rewrite_call_generic(
     }
 }
 
+/// Separator between mangled segments in a specialized symbol name.
+///
+/// A `.` is deliberately *illegal* in a Rue identifier (which is
+/// `[a-zA-Z_][a-zA-Z0-9_]*`), so a specialized symbol like `identity.i32`
+/// lives in a namespace disjoint from every name a user can spell. This is
+/// the targeted fix for RUE-41: previously the separator was `__`, so
+/// `identity<i32>` mangled to `identity__i32` — a name a user could legally
+/// define as a plain function, producing a duplicate-symbol link error for a
+/// valid program. Switching to an identifier-illegal separator makes the
+/// collision impossible by construction, without a full user-symbol mangling
+/// overhaul (that is RUE-178). The full user-symbol mangling scheme (RUE-178)
+/// is still future work; this only guarantees specialized names can't clash
+/// with user names.
+const SPEC_SEP: char = '.';
+
 /// Generate a mangled name for a specialized function.
 ///
-/// Type arguments and value arguments each contribute a `__`-separated
+/// Type arguments and value arguments each contribute a [`SPEC_SEP`]-separated
 /// segment, so distinct comptime values yield distinct symbols
-/// (`fact__v5`, `fact__v4`, ...; RUE-166) exactly like distinct types do
+/// (`fact.v5`, `fact.v4`, ...; RUE-166) exactly like distinct types do
 /// (RUE-100's lesson: colliding mangles mean duplicate symbols at link time).
+/// The `.` separator is illegal in Rue identifiers, so these names cannot
+/// collide with a user-spellable function name (RUE-41).
 fn mangle_specialized_name(
     base_name: &str,
     type_args: &[Type],
@@ -339,11 +356,11 @@ fn mangle_specialized_name(
 ) -> String {
     let mut mangled = base_name.to_string();
     for ty in type_args {
-        mangled.push_str("__");
+        mangled.push(SPEC_SEP);
         mangled.push_str(&mangle_type(*ty));
     }
     for value in value_args {
-        mangled.push_str("__");
+        mangled.push(SPEC_SEP);
         mangled.push_str(&mangle_const_value(value));
     }
     mangled

--- a/crates/rue-cli-tests/cases/comptime_value_params.toml
+++ b/crates/rue-cli-tests/cases/comptime_value_params.toml
@@ -3,7 +3,7 @@
 # Before the fix, a function with a `comptime n: i32` parameter was analyzed
 # ONCE with `n` unknown: `comptime { n }` in its body failed E1200, and
 # recursion (`fact(n - 1)`) failed E1201 at the argument. Now every distinct
-# comptime value creates its own specialization (`f__v5`, `f__v3`, ...) —
+# comptime value creates its own specialization (`f.v5`, `f.v3`, ...) —
 # mirroring the RUE-109 type-identity mangling — in which `n` is a
 # compile-time constant. Comptime-known `if` conditions inside such bodies
 # select their branch at compile time, so comptime recursion terminates; a

--- a/crates/rue-cli-tests/cases/const_ref_literal_anchor.toml
+++ b/crates/rue-cli-tests/cases/const_ref_literal_anchor.toml
@@ -1,0 +1,90 @@
+# A reference to a typed top-level `const` must anchor integer-literal
+# inference across a binary operator (RUE-112, part of the RUE-110 epic).
+#
+# `const BASE: i32 = 100; BASE + 1` once produced
+# `E0800: literal value 1 is out of range for type '<error>'` — the const
+# operand's declared type wasn't propagated to the *other* operand, so the
+# literal's inference context collapsed to the error type and the range check
+# rejected it. Fixed by the const-typing / per-value-comptime work (#973/#980/
+# #1006); these cases pin the behavior so it can't regress. The check is NOT
+# disabled: a literal that genuinely overflows the anchored type still E0800s.
+
+[section]
+id = "cli.const_ref_literal_anchor"
+name = "Const-reference literal anchoring"
+description = "A reference to a typed top-level const anchors an integer literal's type across a binary operator; range checks use the anchored type (RUE-112)."
+
+# The headline repro: const on the left, literal on the right.
+[[case]]
+name = "const_left_literal_right"
+files = [{ path = "main.rue", source = """
+const BASE: i32 = 100;
+
+fn main() -> i32 { BASE + 1 }
+""" }]
+exit_code = 101
+
+# Reversed operands: literal on the left, const on the right.
+[[case]]
+name = "literal_left_const_right"
+files = [{ path = "main.rue", source = """
+const BASE: i32 = 100;
+
+fn main() -> i32 { 1 + BASE }
+""" }]
+exit_code = 101
+
+# A narrow (u8) const anchors the literal to u8, not i32.
+[[case]]
+name = "narrow_const_anchors_u8"
+files = [{ path = "main.rue", source = """
+const N: u8 = 10;
+
+fn main() -> i32 {
+    let x: u8 = N + 1;
+    let r: i32 = @intCast(x);
+    r
+}
+""" }]
+exit_code = 11
+
+# Reversed narrow: literal on the left, u8 const on the right.
+[[case]]
+name = "narrow_const_anchors_u8_reversed"
+files = [{ path = "main.rue", source = """
+const N: u8 = 10;
+
+fn main() -> i32 {
+    let x: u8 = 1 + N;
+    let r: i32 = @intCast(x);
+    r
+}
+""" }]
+exit_code = 11
+
+# The range check is anchored to the const's type, not disabled: a literal
+# that overflows the anchored i32 is still rejected with E0800.
+[[case]]
+name = "overflow_against_i32_const_still_rejected"
+files = [{ path = "main.rue", source = """
+const BASE: i32 = 100;
+
+fn main() -> i32 { BASE + 5000000000 }
+""" }]
+compile_fail = true
+error_contains = ["E0800", "5000000000", "out of range", "i32"]
+
+# ...and a literal that overflows a narrow u8 const is rejected against u8.
+[[case]]
+name = "overflow_against_u8_const_still_rejected"
+files = [{ path = "main.rue", source = """
+const N: u8 = 10;
+
+fn main() -> i32 {
+    let x: u8 = N + 300;
+    let r: i32 = @intCast(x);
+    r
+}
+""" }]
+compile_fail = true
+error_contains = ["E0800", "300", "out of range", "u8"]

--- a/crates/rue-cli-tests/cases/generics.toml
+++ b/crates/rue-cli-tests/cases/generics.toml
@@ -142,6 +142,40 @@ fn main() -> i32 {
 exit_code = 32
 
 # =============================================================================
+# Specialized names live in a namespace disjoint from user names (RUE-41)
+# =============================================================================
+#
+# The specialized symbol for `identity<i32>` used to be `identity__i32` — a
+# string a user can legally spell as a plain function name — so a program that
+# defined BOTH failed to link with "duplicate symbol: identity__i32" even
+# though it is valid Rue. The mangling now joins segments with `.`, illegal in
+# a Rue identifier, so specialized names can never collide with user names.
+
+[[case]]
+name = "specialization_name_does_not_collide_with_user_fn"
+description = "identity<i32> plus a user fn literally named identity__i32 links and runs (RUE-41: used to be 'duplicate symbol: identity__i32')."
+files = [{ path = "main.rue", source = """
+fn identity(comptime T: type, x: T) -> T { x }
+fn identity__i32(x: i32) -> i32 { x + 100 }
+fn main() -> i32 { identity(i32, 7) + identity__i32(0) }
+""" }]
+exit_code = 107
+
+[[case]]
+name = "specialization_i32_and_i64_distinct_symbols"
+description = "identity<i32> and identity<i64> get distinct specialized symbols and distinct bodies (must not regress to RUE-100's single-symbol collapse)."
+files = [{ path = "main.rue", source = """
+fn identity(comptime T: type, x: T) -> T { x }
+fn widen(comptime T: type, x: i64) -> i64 { identity(T, x) }
+fn main() -> i32 {
+    @dbg(identity(i32, 5));
+    @dbg(widen(i64, 40));
+    0
+}
+""" }]
+stdout = "5\n40\n"
+
+# =============================================================================
 # Type parameter forwarding to nested generic calls (RUE-102)
 # =============================================================================
 


### PR DESCRIPTION
Cycle-24 worker integration (verified by hand at integration time).

**RUE-41 (fix):** the specialization pass joined mangled segments with `__`, so `identity<i32>` became the symbol `identity__i32` — a name a user can legally spell, causing a duplicate-symbol **link error** for a valid program. Changed the separator to `.` (`const SPEC_SEP`), illegal in Rue identifiers, so specialized names (`identity.i32`, `fact.v5`) live in a namespace disjoint from user names by construction. Only the join character changed — per-arg distinctness preserved (no RUE-100 collapse), both backends inherit it, no codegen change. Targeted collision fix, **not** the RUE-178 mangling overhaul (Backlog).

**RUE-110 / RUE-112 (refuted, already fixed):** the integer-literal range-check-anchoring epic was resolved by earlier const-typing / per-value-comptime work (#918/#937/#977/#973/#980/#1006). No source fix needed; added a 6-case regression pin.

Integration verification by execution: RUE-112 `BASE + 1` runs 101; RUE-41 repro links and runs 107 (was E1000 dup symbol); `identity<i32>` + `identity<i64>` link distinct; #1006 value specialization intact; overflow controls still E0800. Full `./test.sh` green (432/432).

Fixes RUE-41
Fixes RUE-112
Fixes RUE-110

🤖 Generated with [Claude Code](https://claude.com/claude-code)