### PR TITLE
Regression hardening: examples/ CI smoke test + committed ICE-regression corpus (RUE-48, RUE-51)

### DIFF
--- a/BUCK
+++ b/BUCK
@@ -29,6 +29,15 @@ filegroup(
     srcs = glob(["std/**"]),
 )
 
+# The example programs are runtime inputs to the CLI integration tests: the
+# suite compiles+runs every examples/*.rue through the real driver (RUE-48),
+# so an edit under examples/ MUST re-run the CLI suite (declared here as an
+# input, resolved to an absolute path via RUE_EXAMPLES_DIR below).
+filegroup(
+    name = "examples",
+    srcs = glob(["examples/**"]),
+)
+
 sh_test(
     name = "spec-tests",
     test = "//crates/rue-spec:rue-spec",
@@ -56,6 +65,7 @@ sh_test(
     env = {
         "RUE_BINARY": "$(exe_target //crates/rue:rue)",
         "RUE_CLI_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
+        "RUE_EXAMPLES_DIR": "$(location :examples)/examples",
         "RUE_STD_DIR": "$(location :std)/std",
     },
 )

--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -1,0 +1,300 @@
+# ICE regression corpus (RUE-51).
+#
+# Every case here is a minimal program that USED to crash the compiler
+# (SIGABRT / Rust panic / E9000 internal-compiler-error) and now must either
+# compile-and-run or produce a clean diagnostic (exit 1, NO signal). Each is
+# labelled with the RUE-NN it pins.
+#
+# The rue-cli-tests harness auto-classifies death-by-signal or a panic in
+# compiler stderr as a distinct INTERNAL COMPILER ERROR failure (see the
+# module doc in src/main.rs), so these cases are the durable net that keeps a
+# fixed crash fixed: reintroduce any of these ICEs and the case fails loudly as
+# an ICE rather than silently regressing. New fuzz crashes should be minimized
+# and added here as part of triage.
+#
+# Do NOT add a green (expected-pass) case for a program that still ICEs on
+# trunk: mark it `known_bug = "RUE-NN"` instead, so the harness tracks it as a
+# known failure until fixed. Every case below was verified to no longer ICE on
+# trunk before being committed.
+
+[section]
+id = "cli.ice_regressions"
+name = "ICE regressions"
+description = "Minimal programs that used to crash the compiler; each must now compile-or-cleanly-error with no signal (RUE-51)."
+
+[[case]]
+name = "nested_struct_field_into_if_merge_rue24"
+description = "RUE-24: a nested struct field flowing into an if/else merge block had no field vregs -> SIGABRT at cfg_lower."
+files = [{ path = "main.rue", source = """
+struct Inner { a: i32, b: i32 }
+struct Outer { inner: Inner }
+fn main() -> i32 {
+    let o = Outer { inner: Inner { a: 10, b: 32 } };
+    let r = if true { o.inner } else { Inner { a: 1, b: 2 } };
+    r.a + r.b
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "placeread_nested_struct_copy_rue22"
+description = "RUE-22: PlaceRead of a 2-slot nested struct loaded only slot 0 (miscompiled to 10; ICE family root)."
+files = [{ path = "main.rue", source = """
+struct Inner { a: i32, b: i32 }
+struct Outer { x: i32, inner: Inner }
+fn main() -> i32 {
+    let o = Outer { x: 1, inner: Inner { a: 10, b: 32 } };
+    let r = o.inner;
+    r.a + r.b
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "inout_struct_field_rue35"
+description = "RUE-35: inout of a struct field ('by-ref argument must be a variable') -> SIGABRT at cfg_lower."
+files = [{ path = "main.rue", source = """
+struct Pair { n: i32 }
+fn bump(inout v: i32) { v = v + 1; }
+fn main() -> i32 {
+    let mut p = Pair { n: 41 };
+    bump(inout p.n);
+    p.n
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "inout_array_element_rue35"
+description = "RUE-35: inout of an array element -> same SIGABRT at cfg_lower."
+files = [{ path = "main.rue", source = """
+fn bump(inout v: i32) { v = v + 1; }
+fn main() -> i32 {
+    let mut a: [i32; 3] = [41, 0, 0];
+    bump(inout a[0]);
+    a[0]
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "string_param_rebound_to_local_rue63"
+description = "RUE-63: rebinding a String parameter to a local ('string should have fat pointer fields in Alloc') -> SIGABRT."
+files = [{ path = "main.rue", source = """
+fn consume(s: String) -> i32 {
+    let held = s;
+    0
+}
+fn main() -> i32 { 0 }
+""" }]
+exit_code = 0
+
+[[case]]
+name = "struct_field_string_eq_rue94"
+description = "RUE-94: comparing a struct-field String with == ('builtin type should have field vregs') -> SIGABRT."
+files = [{ path = "main.rue", source = """
+struct Holder { s: String }
+fn main() -> i32 {
+    let h = Holder { s: "hello" };
+    if h.s == "hello" { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "array_literal_string_element_rue96"
+description = "RUE-96: array literal with a String element inferred the element as <error> -> E9000 ICE."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a = String::new();
+    let arr = [a];
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "array_literal_string_exprs_rue190"
+description = "RUE-190: array literal of String-producing expressions used to ICE (E9000)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr = [String::new(), String::new()];
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "array_literal_error_element_rue190"
+description = "RUE-190: array literal with an error-typed element must surface the real diagnostic, not an E9000 ICE."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr = [nonexistent_value];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0201"]
+
+[[case]]
+name = "neg_of_binary_in_intrinsic_arg_rue149"
+description = "RUE-149: @dbg(-(3 + 4)) was typed <error> then hit unreachable!() in cfg_lower -> SIGABRT."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @dbg(-(3 + 4));
+    0
+}
+""" }]
+stdout = "-7\n"
+exit_code = 0
+
+[[case]]
+name = "while_diverging_condition_rue77"
+description = "RUE-77: a while loop with an unconditionally-diverging condition left a block with no terminator -> SIGABRT."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    while return 8 {}
+    5
+}
+""" }]
+exit_code = 8
+
+[[case]]
+name = "empty_array_in_struct_field_rue82"
+description = "RUE-82: an empty array literal [] in a struct field initializer inferred <error> -> E9000 ICE."
+files = [{ path = "main.rue", source = """
+struct Z { a: [i32; 0], n: i32 }
+fn main() -> i32 {
+    let z = Z { a: [], n: 5 };
+    z.n
+}
+""" }]
+exit_code = 5
+
+[[case]]
+name = "placeread_struct_call_arg_rue118"
+description = "RUE-118: passing a place-read struct field by value passed only slot 0 (miscompiled to 10)."
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+struct Wrap { p: Point, tag: i32 }
+fn sum(pt: Point) -> i32 { pt.x + pt.y }
+fn main() -> i32 { let w = Wrap { p: Point { x: 10, y: 20 }, tag: 1 }; sum(w.p) }
+""" }]
+exit_code = 30
+
+[[case]]
+name = "placeread_struct_return_rue118"
+description = "RUE-118: returning a place-read struct field by value returned only slot 0 (miscompiled to 11)."
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+struct Wrap { p: Point, tag: i32 }
+fn get_p(w: Wrap) -> Point { w.p }
+fn main() -> i32 { let w = Wrap { p: Point { x: 10, y: 20 }, tag: 1 }; let p = get_p(w); p.x + p.y }
+""" }]
+exit_code = 30
+
+[[case]]
+name = "anon_struct_compound_field_init_rue170"
+description = "RUE-170: a compound field initializer on an anon-struct type alias ('did not resolve type for negation') -> E9000 ICE."
+files = [{ path = "main.rue", source = """
+fn F() -> type { struct { a: i32 } }
+fn main() -> i32 { let P = F(); let p: P = P { a: -1 }; 0 }
+""" }]
+exit_code = 0
+
+[[case]]
+name = "nested_generic_forward_concrete_rue102"
+description = "RUE-102: forwarding a comptime type param to a nested generic call left a CallGeneric that reached CFG building -> SIGABRT."
+files = [{ path = "main.rue", source = """
+fn inner(comptime T: type, v: T) -> i32 { 1 }
+fn outer(comptime T: type, v: T) -> i32 { inner(T, v) }
+fn main() -> i32 { outer(i32, 5) + 41 }
+""" }]
+exit_code = 42
+
+[[case]]
+name = "nested_generic_forward_typevar_rue102"
+description = "RUE-102: same nested forwarding where the inner fn returns T (previously reject-valid E0206)."
+files = [{ path = "main.rue", source = """
+fn inner(comptime T: type, v: T) -> T { v }
+fn outer(comptime T: type, v: T) -> T { inner(T, v) }
+fn main() -> i32 { outer(i32, 42) }
+""" }]
+exit_code = 42
+
+[[case]]
+name = "index_multislot_aggregate_rue188"
+description = "RUE-188: indexing an array of multi-slot structs loaded only slot 0 (miscompiled to 30)."
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let arr: [Point; 2] = [Point { x: 10, y: 20 }, Point { x: 30, y: 40 }];
+    let p = arr[1];
+    p.x + p.y
+}
+""" }]
+exit_code = 70
+
+[[case]]
+name = "dbg_string_array_element_rue192"
+description = "RUE-192: @dbg(arr[0]) on a [String; 1] ('string value should have field vregs for fat pointer') -> SIGABRT."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr: [String; 1] = ["hi"];
+    @dbg(arr[0]);
+    0
+}
+""" }]
+stdout = "hi\n"
+exit_code = 0
+
+[[case]]
+name = "array_drop_glue_multislot_rue193"
+description = "RUE-193: array drop glue for [D; 3] with a 2-slot destructor passed garbage to element destructors past element 0."
+files = [{ path = "main.rue", source = """
+struct D { a: i32, b: i32 }
+drop fn D(self) { @dbg(self.a); @dbg(self.b); }
+fn main() -> i32 {
+    let arr: [D; 3] = [D { a: 10, b: 11 }, D { a: 20, b: 21 }, D { a: 30, b: 31 }];
+    0
+}
+""" }]
+stdout = "10\n11\n20\n21\n30\n31\n"
+exit_code = 0
+
+[[case]]
+name = "string_array_drop_register_budget_rue193"
+description = "RUE-193: [String; 3] = 9 element slots exceeded the 6 argument registers in drop glue -> SIGABRT at cfg_lower."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr: [String; 3] = ["aa", "bb", "cc"];
+    0
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "by_value_wide_struct_abi_rue13"
+description = "RUE-13: passing and returning a >6-slot struct by value ICEd / miscompiled in the aggregate ABI."
+files = [{ path = "main.rue", source = """
+struct Big { a: i32, b: i32, c: i32, d: i32, e: i32, f: i32, g: i32 }
+fn id(x: Big) -> Big { x }
+fn main() -> i32 {
+    let b = Big { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 21 };
+    let r = id(b);
+    r.a + r.b + r.c + r.d + r.e + r.f + r.g
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "deep_nesting_no_stack_overflow_rue42"
+description = "RUE-42: deeply-nested parenthesized input overflowed the native stack (SIGABRT); now a clean E0482 nesting-limit diagnostic."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x = ((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((((1))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))))));
+    x
+}
+""" }]
+compile_fail = true
+error_contains = ["E0482"]

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -72,7 +72,7 @@
 //! entirely for sources that are meant only to compile.
 
 use std::collections::HashMap;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::time::Duration;
 
@@ -89,6 +89,110 @@ const CASES_DIR_PATHS: &[&str] = &[
 
 /// Possible paths for the repo's std library (for `${REAL_STD}` expansion).
 const STD_DIR_PATHS: &[&str] = &["std", "../std", "../../std"];
+
+/// Possible paths for the repo's `examples/` directory (RUE-48 smoke tests).
+const EXAMPLES_DIR_PATHS: &[&str] = &["examples", "../../examples", "../examples"];
+
+/// Expected outcome of compiling and running one `examples/*.rue` program.
+///
+/// Every file under `examples/` is compiled and run by the suite (see
+/// [`example_trials`]); this table pins the *deterministic* ones to an exact
+/// exit code and stdout so a regression that silently changes their output is
+/// caught. An example NOT listed here is still smoke-tested — it must compile,
+/// produce a binary, run, and exit *normally* (never die by SIGSEGV/SIGABRT) —
+/// so dropping a new file into `examples/` is covered automatically without
+/// editing this harness. Adding an entry here upgrades that smoke check into a
+/// pinned exact-output regression test.
+///
+/// Exit codes are the low byte of `main()`'s return value (a process exit code
+/// is 0-255), e.g. `power.rue` returns 5^6 = 15625, which exits as 15625 % 256
+/// = 9.
+struct ExampleExpectation {
+    /// File stem: the basename without the `.rue` extension.
+    name: &'static str,
+    /// Expected process exit code.
+    exit_code: i32,
+    /// Exact expected stdout.
+    stdout: &'static str,
+}
+
+const EXAMPLE_EXPECTATIONS: &[ExampleExpectation] = &[
+    ExampleExpectation {
+        name: "arrays",
+        exit_code: 157,
+        stdout: "157\n64\n12\n60\n",
+    },
+    ExampleExpectation {
+        name: "binary_search",
+        exit_code: 4,
+        stdout: "4\n",
+    },
+    ExampleExpectation {
+        name: "collatz",
+        exit_code: 97,
+        stdout: "27\n111\n",
+    },
+    ExampleExpectation {
+        name: "dbg",
+        exit_code: 0,
+        stdout: "42\n-17\ntrue\nfalse\n70\ntrue\ntrue\n120\n0\n1\n2\n3\n4\n",
+    },
+    ExampleExpectation {
+        name: "fibonacci",
+        exit_code: 55,
+        stdout: "0\n1\n1\n2\n3\n5\n8\n13\n21\n34\n55\n89\n144\n233\n377\n610\n987\n1597\n2584\n4181\n",
+    },
+    ExampleExpectation {
+        name: "fizzbuzz",
+        exit_code: 0,
+        stdout: "1\n2\n1\n4\n2\n1\n7\n8\n1\n2\n11\n1\n13\n14\n3\n16\n17\n1\n19\n2\n1\n22\n23\n1\n2\n26\n1\n28\n29\n3\n",
+    },
+    ExampleExpectation {
+        name: "gcd",
+        exit_code: 21,
+        stdout: "6\n1\n36\n",
+    },
+    ExampleExpectation {
+        name: "generics",
+        exit_code: 72,
+        stdout: "42\n20\n10\n100\n8\n17\n",
+    },
+    ExampleExpectation {
+        name: "hello",
+        exit_code: 42,
+        stdout: "",
+    },
+    ExampleExpectation {
+        name: "match",
+        exit_code: 5,
+        stdout: "5\n",
+    },
+    ExampleExpectation {
+        name: "power",
+        exit_code: 9,
+        stdout: "1\n2\n1024\n243\n2401\n1024\n",
+    },
+    ExampleExpectation {
+        name: "primes",
+        exit_code: 25,
+        stdout: "2\n3\n5\n7\n11\n13\n17\n19\n23\n29\n31\n37\n41\n43\n47\n",
+    },
+    ExampleExpectation {
+        name: "quicksort",
+        exit_code: 11,
+        stdout: "0\n64\n34\n25\n12\n22\n11\n90\n42\n15\n77\n1\n11\n12\n15\n22\n25\n34\n42\n64\n77\n90\n",
+    },
+    ExampleExpectation {
+        name: "sqrt",
+        exit_code: 12,
+        stdout: "0\n1\n2\n2\n3\n3\n4\n10\n31\n",
+    },
+    ExampleExpectation {
+        name: "structs",
+        exit_code: 50,
+        stdout: "25\n50\n30\ntrue\n",
+    },
+];
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
@@ -471,6 +575,153 @@ fn load_cases(cases_dir: &Path) -> Vec<(String, TestFile)> {
     out
 }
 
+/// Compile and run one `examples/*.rue` program end to end (RUE-48).
+///
+/// The example is written to a temp dir and compiled with the real driver
+/// (`rue <file> -o prog`), exactly as a user would. A compiler panic is an ICE;
+/// a compile failure fails the case. The produced binary is then run under the
+/// standard wall-clock timeout, and — crucially — must exit *normally*: a
+/// program killed by a signal (SIGSEGV/SIGABRT show up as a `None` exit code on
+/// unix) fails as a crash. If the example is in [`EXAMPLE_EXPECTATIONS`], its
+/// exact exit code and stdout are asserted; otherwise passing this "no crash"
+/// bar is enough (self-maintaining smoke coverage for newly added examples).
+fn run_example(
+    name: &str,
+    source: &str,
+    expectation: Option<&ExampleExpectation>,
+    rue_binary: &Path,
+) -> TestResult {
+    let temp_dir = tempfile::tempdir().map_err(|e| format!("failed to create temp dir: {}", e))?;
+    let dir = temp_dir.path();
+    let src_name = format!("{}.rue", name);
+    std::fs::write(dir.join(&src_name), source)
+        .map_err(|e| format!("failed to write {}: {}", src_name, e))?;
+
+    let mut cmd = Command::new(rue_binary);
+    cmd.args([src_name.as_str(), "-o", "prog"]).current_dir(dir);
+    let compile_output = cmd
+        .output()
+        .map_err(|e| format!("failed to invoke rue compiler: {}", e))?;
+    let compile_stderr = String::from_utf8_lossy(&compile_output.stderr).to_string();
+    let compile_stdout = String::from_utf8_lossy(&compile_output.stdout).to_string();
+
+    if let Some(ice) = ice_message(&compile_output.status, &compile_stderr) {
+        return Err(ice);
+    }
+    if !compile_output.status.success() {
+        return Err(format!(
+            "example failed to compile (exit: {:?}):\n--- compiler stdout ---\n{}\n--- compiler stderr ---\n{}",
+            compile_output.status.code(),
+            compile_stdout,
+            compile_stderr
+        ));
+    }
+
+    let program = dir.join("prog");
+    if !program.exists() {
+        return Err("compiler reported success but produced no 'prog' binary".to_string());
+    }
+
+    let mut run_cmd = Command::new(&program);
+    run_cmd.current_dir(dir);
+    let run_output = run_with_timeout(run_cmd, Duration::from_millis(DEFAULT_TIMEOUT_MS), None)?;
+    let run_stdout = String::from_utf8_lossy(&run_output.stdout).to_string();
+    let run_stderr = String::from_utf8_lossy(&run_output.stderr).to_string();
+
+    // "Runs without crashing": a normal exit yields Some(code); death by
+    // signal (SIGSEGV/SIGABRT) yields None on unix.
+    let actual_exit = match run_output.status.code() {
+        Some(code) => code,
+        None => {
+            return Err(format!(
+                "example crashed (killed by signal, status {:?})\n--- program stdout ---\n{}\n--- program stderr ---\n{}",
+                run_output.status, run_stdout, run_stderr
+            ));
+        }
+    };
+
+    if let Some(exp) = expectation {
+        if actual_exit != exp.exit_code {
+            return Err(format!(
+                "example exit code mismatch:\n  expected: {}\n  actual: {}\n--- program stdout ---\n{}\n--- program stderr ---\n{}",
+                exp.exit_code, actual_exit, run_stdout, run_stderr
+            ));
+        }
+        if run_stdout != exp.stdout {
+            return Err(format!(
+                "example stdout mismatch:\n--- expected ---\n{}\n--- actual ---\n{}",
+                exp.stdout, run_stdout
+            ));
+        }
+    }
+
+    Ok(())
+}
+
+/// Discover `examples/*.rue` and build one smoke-test trial per file (RUE-48).
+///
+/// This is self-maintaining: it enumerates the directory at run time, so a new
+/// example is picked up automatically. If the directory can't be found or holds
+/// no `.rue` files, a single loud failing trial is emitted rather than silently
+/// running zero example tests (which would let example rot slip through CI).
+fn example_trials(rue_binary: &Path) -> Vec<Trial> {
+    let examples_dir = find_dir("RUE_EXAMPLES_DIR", EXAMPLES_DIR_PATHS, "examples");
+
+    let mut example_files: Vec<PathBuf> = match std::fs::read_dir(&examples_dir) {
+        Ok(entries) => entries
+            .filter_map(|e| e.ok().map(|e| e.path()))
+            .filter(|p| p.extension().is_some_and(|ext| ext == "rue"))
+            .collect(),
+        Err(e) => {
+            let msg = format!(
+                "cannot read examples directory '{}': {} (set RUE_EXAMPLES_DIR)",
+                examples_dir.display(),
+                e
+            );
+            return vec![Trial::test("cli.examples::_discovery", move |_ctx| {
+                Err(RunError::fail(msg.clone()))
+            })];
+        }
+    };
+    example_files.sort();
+
+    if example_files.is_empty() {
+        let msg = format!(
+            "no *.rue examples found in '{}' — RUE-48 smoke coverage is empty",
+            examples_dir.display()
+        );
+        return vec![Trial::test("cli.examples::_discovery", move |_ctx| {
+            Err(RunError::fail(msg.clone()))
+        })];
+    }
+
+    let mut trials = Vec::with_capacity(example_files.len());
+    for path in example_files {
+        let name = path
+            .file_stem()
+            .map(|s| s.to_string_lossy().to_string())
+            .unwrap_or_default();
+        let source = match std::fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) => {
+                let msg = format!("failed to read {}: {}", path.display(), e);
+                trials.push(Trial::test(
+                    format!("cli.examples::{}", name),
+                    move |_ctx| Err(RunError::fail(msg.clone())),
+                ));
+                continue;
+            }
+        };
+        let rue_binary = rue_binary.to_path_buf();
+        let test_name = format!("cli.examples::{}", name);
+        trials.push(Trial::test(test_name, move |_ctx| {
+            let expectation = EXAMPLE_EXPECTATIONS.iter().find(|e| e.name == name);
+            run_example(&name, &source, expectation, &rue_binary).map_err(RunError::fail)
+        }));
+    }
+    trials
+}
+
 fn main() {
     // The compiler is invoked with the test's temp dir as cwd, so the binary
     // path must be absolute (find_rue_binary may return a relative path).
@@ -510,6 +761,11 @@ fn main() {
             cases_dir.display()
         );
     }
+
+    // RUE-48: compile+run every examples/*.rue through the real driver, so a
+    // regression that breaks a shipped example (or an example referencing a
+    // removed flag) can't slip past CI unnoticed.
+    tests.extend(example_trials(&rue_binary));
 
     Harness::with_env().discover(tests).main();
 }

--- a/examples/generics.rue
+++ b/examples/generics.rue
@@ -4,8 +4,8 @@
 // compile-time type parameters. The compiler creates specialized
 // versions for each concrete type used.
 //
-// NOTE: This is a preview feature. Compile with:
-//   rue --preview comptime generics.rue output
+// Compile with:
+//   rue generics.rue -o generics
 
 // A generic identity function that works with any type.
 // The `comptime T: type` parameter is resolved at compile time,

--- a/examples/match.rue
+++ b/examples/match.rue
@@ -39,5 +39,7 @@ fn count_weekdays(start: i32, end: i32) -> i32 {
 fn main() -> i32 {
     // Count weekdays from Sunday (0) through Saturday (6)
     // Should be 5 (Mon, Tue, Wed, Thu, Fri)
-    @dbg(count_weekdays(0, 6))
+    let weekdays = count_weekdays(0, 6);
+    @dbg(weekdays);
+    weekdays
 }

--- a/examples/structs.rue
+++ b/examples/structs.rue
@@ -1,13 +1,19 @@
 // Structs - custom data types with named fields
 //
-// Rue supports structs with value semantics, meaning they're
-// copied when assigned or passed to functions.
+// Structs in Rue are move types by default: using a struct value
+// (passing it to a function, assigning it) consumes the original.
+// The `@copy` directive opts a struct into Copy semantics, so its
+// values are implicitly duplicated on use instead of being moved.
+// Both Point and Rectangle below are `@copy`, which is why this
+// example can pass the same rectangle to several functions in a row.
 
+@copy
 struct Point {
     x: i32,
     y: i32,
 }
 
+@copy
 struct Rectangle {
     origin: Point,
     width: i32,

--- a/scripts/rue
+++ b/scripts/rue
@@ -66,6 +66,7 @@ case "$cmd" in
     cli)
         RUE_BINARY="$(scripts/rue-bin)" \
         RUE_CLI_CASES="crates/rue-cli-tests/cases" \
+        RUE_EXAMPLES_DIR="examples" \
         RUE_STD_DIR="std" \
         ./buck2 run //crates/rue-cli-tests:rue-cli-tests -- "$@"
         ;;

--- a/test.sh
+++ b/test.sh
@@ -41,6 +41,7 @@ else
     echo "Running CLI integration tests..."
     RUE_BINARY="$RUE_BINARY" \
     RUE_CLI_CASES="crates/rue-cli-tests/cases" \
+    RUE_EXAMPLES_DIR="examples" \
     RUE_STD_DIR="std" \
     ./buck2 run //crates/rue-cli-tests:rue-cli-tests -- --quiet "$@"
 fi


### PR DESCRIPTION
Cycle-25 worker integration (verified by hand at integration time). Two test-only regression guards, both closing exactly the classes of rot the recent work touched.

**RUE-48:** nothing in CI compiled or ran the `examples/` programs, so rot went unnoticed (`generics.rue` still cited the removed `--preview comptime` flag). Added a self-maintaining smoke test to the rue-cli-tests harness that discovers `examples/*.rue` at run time, compiles + runs each through the real driver, pins deterministic ones to exact exit+stdout, and smoke-runs the rest (death-by-signal = fail). Wired `RUE_EXAMPLES_DIR` + an `:examples` filegroup so editing `examples/` re-runs the suite. Fixed 3 stale examples (source/comment only): generics.rue, match.rue, structs.rue.

**RUE-51:** committed `ice_regressions.toml` — 23 minimal programs that formerly crashed the compiler (SIGABRT/panic/E9000), pinning 18 distinct issues (RUE-13/22/24/35/42/63/77/82/94/96/102/118/149/170/188/190/192/193). Each asserts exact runtime behavior (drop-glue order, multi-slot returns, clean E0482/E0201 for the reject cases); the CLI harness auto-flags death-by-signal as an INTERNAL COMPILER ERROR, so a reintroduced ICE fails loudly. All 23 verified fixed on trunk.

Integration verification: 15 example cases + 23 ICE cases pass; full `./test.sh` green (432/432). Test-only; no compiler crates touched.

Fixes RUE-48
Fixes RUE-51

🤖 Generated with [Claude Code](https://claude.com/claude-code)