### PR TITLE
Complete the bd→Linear ADR migration; VariableMoveState.partial_moves HashMap→Vec (RUE-53, RUE-124)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -4653,7 +4653,7 @@ impl<'a> Sema<'a> {
         if unconsumed.is_empty() {
             return Ok(ElementwiseConsumption::Complete);
         }
-        let touched_any_element = s.partial_moves.keys().any(|p| {
+        let touched_any_element = s.partial_moves.iter().any(|(p, _)| {
             p.first()
                 .is_some_and(|seg| is_index_segment(self.interner, *seg))
         });
@@ -4664,9 +4664,13 @@ impl<'a> Sema<'a> {
         // An unconsumed element that WAS moved on some path selects the
         // more precise "not consumed on all paths" diagnostic (E0443 over
         // E0406).
-        let some_path_span = unconsumed
-            .iter()
-            .find_map(|k| s.partial_moves.get(&elem_path(*k)).copied());
+        let some_path_span = unconsumed.iter().find_map(|k| {
+            let target = elem_path(*k);
+            s.partial_moves
+                .iter()
+                .find(|(p, _)| *p == target)
+                .map(|(_, span)| *span)
+        });
         let list = unconsumed
             .iter()
             .map(|k| format!("[{k}]"))

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -41,8 +41,11 @@ pub(crate) type FieldPath = Vec<Spur>;
 
 /// Tracks move state for a variable, including partial (field-level) moves.
 // PartialEq is used by the loop back-edge move recheck to detect whether a
-// loop body changed any move state.
-#[derive(Debug, Clone, Default, PartialEq)]
+// loop body changed any move state. It is implemented by hand (below) rather
+// than derived because `partial_moves` is an order-insensitive map stored as a
+// `Vec`: two states with the same (path, span) entries in a different order
+// must still compare equal, matching the `HashMap` this field replaced.
+#[derive(Debug, Clone, Default)]
 pub(crate) struct VariableMoveState {
     /// If Some, the entire variable has been fully moved at this span.
     ///
@@ -61,7 +64,14 @@ pub(crate) struct VariableMoveState {
     /// For example, if `s.a` was moved, this contains ([sym("a")], span).
     ///
     /// Like `full_move`, this is MAY-move (union at branch joins).
-    pub partial_moves: HashMap<FieldPath, Span>,
+    ///
+    /// Stored as an association `Vec` rather than a `HashMap` (RUE-124): the
+    /// typical variable has 0–5 partial moves, so a flat scan beats hashing,
+    /// and it lets `is_path_moved` do a single O(n) prefix pass instead of an
+    /// O(n×depth) per-ancestor probe. The invariant that each `FieldPath` key
+    /// appears at most once (upheld by `mark_path_moved` and `merge_union`)
+    /// makes it behave exactly like the map it replaced.
+    pub partial_moves: Vec<(FieldPath, Span)>,
     /// Partial moves that happened on EVERY non-diverging path reaching this
     /// point (intersection at branch joins) — the per-path analogue of
     /// `full_move_on_all_paths`. Always a subset of `partial_moves`' keys.
@@ -86,7 +96,15 @@ impl VariableMoveState {
         } else {
             // Partial move - only if not already fully moved
             if self.full_move.is_none() {
-                self.partial_moves.insert(path.to_vec(), span);
+                // Upsert to preserve the unique-key invariant of the map this
+                // `Vec` replaced: re-moving the same path overwrites its span
+                // (matching `HashMap::insert`) rather than appending a dup.
+                if let Some((_, existing)) = self.partial_moves.iter_mut().find(|(p, _)| p == path)
+                {
+                    *existing = span;
+                } else {
+                    self.partial_moves.push((path.to_vec(), span));
+                }
                 self.partial_moves_on_all_paths.insert(path.to_vec());
             }
         }
@@ -100,7 +118,7 @@ impl VariableMoveState {
     /// rejected before this is called).
     pub fn mark_path_reinitialized(&mut self, path: &[Spur]) {
         self.partial_moves
-            .retain(|moved, _| !(moved.len() >= path.len() && moved[..path.len()] == *path));
+            .retain(|(moved, _)| !(moved.len() >= path.len() && moved[..path.len()] == *path));
         self.partial_moves_on_all_paths
             .retain(|moved| !(moved.len() >= path.len() && moved[..path.len()] == *path));
     }
@@ -113,20 +131,28 @@ impl VariableMoveState {
             return Some(span);
         }
 
-        // Check if this exact path is moved
-        if let Some(span) = self.partial_moves.get(path) {
-            return Some(*span);
-        }
-
-        // Check if any prefix (ancestor) of this path is moved
-        // e.g., if s.a is moved, then s.a.b is also considered moved
-        for len in 1..path.len() {
-            if let Some(span) = self.partial_moves.get(&path[..len]) {
-                return Some(*span);
+        // Single O(n) scan over the partial moves (RUE-124), replacing the old
+        // exact-lookup-plus-per-ancestor-probe (O(n×depth)). A stored path
+        // `moved` affects `path` iff it is a prefix of it (an exact match or an
+        // ancestor: `s.a` moved implies `s.a.b` is moved).
+        //
+        // When several stored paths match — possible only after a branch join
+        // unions nested partials (e.g. both `s.a` and `s.a.b` moved on
+        // different arms) — we must return the SAME span the old probe order
+        // did: the exact match first, otherwise the shortest ancestor. `rank`
+        // encodes that priority (exact = 0, then ancestor length ascending);
+        // keys are unique, so no two candidates ever tie.
+        let mut best: Option<(usize, Span)> = None;
+        for (moved, span) in &self.partial_moves {
+            let len = moved.len();
+            if len <= path.len() && path[..len] == moved[..] {
+                let rank = if len == path.len() { 0 } else { len };
+                if best.is_none_or(|(best_rank, _)| rank < best_rank) {
+                    best = Some((rank, *span));
+                }
             }
         }
-
-        None
+        best.map(|(_, span)| span)
     }
 
     /// Check if the entire variable (including all fields) is fully valid to use.
@@ -135,7 +161,7 @@ impl VariableMoveState {
         if let Some(span) = self.full_move {
             return Some(span);
         }
-        self.partial_moves.values().next().copied()
+        self.partial_moves.first().map(|(_, span)| *span)
     }
 
     /// Check if the variable has any move state.
@@ -155,10 +181,15 @@ impl VariableMoveState {
         // (use the span from whichever branch has it, preferring branch1)
         let full_move = branch1.full_move.or(branch2.full_move);
 
-        // A partial move is kept if it appears in EITHER branch
+        // A partial move is kept if it appears in EITHER branch. When both
+        // branches moved the same path, branch1's span wins (`or_insert`
+        // semantics of the map this replaced): start from branch1's list and
+        // append only paths branch2 introduced.
         let mut partial_moves = branch1.partial_moves.clone();
         for (path, span) in &branch2.partial_moves {
-            partial_moves.entry(path.clone()).or_insert(*span);
+            if !partial_moves.iter().any(|(p, _)| p == path) {
+                partial_moves.push((path.clone(), *span));
+            }
         }
 
         // A path was moved on EVERY path only if both branches moved it.
@@ -184,6 +215,25 @@ impl VariableMoveState {
             partial_moves,
             partial_moves_on_all_paths,
         }
+    }
+}
+
+// Hand-written so `partial_moves` compares as an unordered (path -> span) map,
+// matching the `HashMap` it replaced (RUE-124). The unique-key invariant lets
+// equal length + one-directional containment stand in for full set equality.
+// The loop back-edge recheck relies on this being order-insensitive.
+impl PartialEq for VariableMoveState {
+    fn eq(&self, other: &Self) -> bool {
+        self.full_move == other.full_move
+            && self.full_move_on_all_paths == other.full_move_on_all_paths
+            && self.partial_moves_on_all_paths == other.partial_moves_on_all_paths
+            && self.partial_moves.len() == other.partial_moves.len()
+            && self.partial_moves.iter().all(|(p, s)| {
+                other
+                    .partial_moves
+                    .iter()
+                    .any(|(op, os)| op == p && os == s)
+            })
     }
 }
 
@@ -728,6 +778,48 @@ mod tests {
     }
 
     #[test]
+    fn variable_move_state_is_path_moved_prefix_cases() {
+        // RUE-124: is_path_moved does a single prefix scan over the Vec.
+        // Exercise exact, ancestor, sibling, and nested lookups, plus the
+        // exact-over-ancestor and shortest-ancestor precedence that only
+        // arises once a branch join has unioned nested partials together.
+        let interner = ThreadedRodeo::new();
+        let a = interner.get_or_intern("a");
+        let b = interner.get_or_intern("b");
+        let c = interner.get_or_intern("c");
+        let z = interner.get_or_intern("z");
+        let span_a = Span::new(1, 2);
+        let span_ab = Span::new(3, 4);
+
+        let mut state = VariableMoveState::default();
+        state.mark_path_moved(&[a, b], span_ab);
+
+        // Exact path moved.
+        assert_eq!(state.is_path_moved(&[a, b]), Some(span_ab));
+        // Descendant of a moved path is moved (ancestor prefix match).
+        assert_eq!(state.is_path_moved(&[a, b, c]), Some(span_ab));
+        // A shorter prefix that was NOT moved is not moved.
+        assert!(state.is_path_moved(&[a]).is_none());
+        // Sibling under the same root is not moved.
+        assert!(state.is_path_moved(&[a, c]).is_none());
+        // Unrelated path is not moved.
+        assert!(state.is_path_moved(&[z]).is_none());
+
+        // Now union in the ancestor `s.a` (as a branch join would), so both
+        // `[a]` and `[a, b]` are recorded. Precedence must be unchanged from
+        // the old exact-then-shortest-ancestor probe order regardless of the
+        // Vec's element order:
+        state.mark_path_moved(&[a], span_a);
+        // Exact match on `[a, b]` still wins over the `[a]` ancestor.
+        assert_eq!(state.is_path_moved(&[a, b]), Some(span_ab));
+        // For a deeper path with two matching ancestors, the shortest
+        // ancestor (`[a]`) is selected.
+        assert_eq!(state.is_path_moved(&[a, b, c]), Some(span_a));
+        // `[a]` itself is now an exact match.
+        assert_eq!(state.is_path_moved(&[a]), Some(span_a));
+    }
+
+    #[test]
     fn variable_move_state_multiple_partial_moves() {
         let mut state = VariableMoveState::default();
         let interner = ThreadedRodeo::new();
@@ -817,8 +909,8 @@ mod tests {
         b2.mark_path_moved(&[elem0], span);
 
         let merged = VariableMoveState::merge_union(&b1, &b2);
-        assert!(merged.partial_moves.contains_key(&vec![elem0]));
-        assert!(merged.partial_moves.contains_key(&vec![elem1]));
+        assert!(merged.partial_moves.iter().any(|(p, _)| p == &vec![elem0]));
+        assert!(merged.partial_moves.iter().any(|(p, _)| p == &vec![elem1]));
         assert!(merged.partial_moves_on_all_paths.contains(&vec![elem0]));
         assert!(!merged.partial_moves_on_all_paths.contains(&vec![elem1]));
     }

--- a/docs/designs/0000-template.md
+++ b/docs/designs/0000-template.md
@@ -31,8 +31,8 @@ What we're going to do. Technical details, syntax, semantics, etc.
 
 ## Implementation Phases
 
-- [ ] **Phase 1: Name** - bd-XXX
-- [ ] **Phase 2: Name** - bd-XXX
+- [ ] **Phase 1: Name** - RUE-NNN
+- [ ] **Phase 2: Name** - RUE-NNN
 
 ## Consequences
 

--- a/docs/designs/0008-affine-types-mvs.md
+++ b/docs/designs/0008-affine-types-mvs.md
@@ -367,11 +367,11 @@ The type and linearity are checked separately.
 
 ## Implementation Phases
 
-Epic: rue-dfr8
+Epic: rue-dfr8 (historical bd ID, pre-Linear; the `.N` suffixes below are its sub-phases)
 
 This is a large feature requiring multiple phases. Each phase is a **vertical slice** - a complete, testable feature end-to-end. This allows kicking the tires at each step.
 
-### Phase 1: Affine structs (rue-dfr8.1) ✅ COMPLETE
+### Phase 1: Affine structs (historical bd ID rue-dfr8.1, pre-Linear) ✅ COMPLETE
 
 Make user-defined structs affine by default. Primitives remain implicitly Copy.
 
@@ -395,7 +395,7 @@ fn main() -> i32 {
 }
 ```
 
-### Phase 2: @copy directive (rue-dfr8.2)
+### Phase 2: @copy directive (historical bd ID rue-dfr8.2, pre-Linear)
 
 Allow opting structs into Copy semantics.
 
@@ -416,7 +416,7 @@ fn main() -> i32 {
 }
 ```
 
-### Phase 3: Inout parameters (rue-dfr8.3)
+### Phase 3: Inout parameters (historical bd ID rue-dfr8.3, pre-Linear)
 
 Add mutation-without-ownership-transfer.
 
@@ -438,7 +438,7 @@ fn main() -> i32 {
 }
 ```
 
-### Phase 4: Linear types (rue-dfr8.4)
+### Phase 4: Linear types (historical bd ID rue-dfr8.4, pre-Linear)
 
 Add must-consume semantics.
 
@@ -460,7 +460,7 @@ fn main() -> i32 {
 // fn bad() { let m = MustUse { value: 1 }; }  // ERROR: linear value dropped
 ```
 
-### Phase 5: Projection semantics (rue-dfr8.5) ✅ COMPLETE
+### Phase 5: Projection semantics (historical bd ID rue-dfr8.5, pre-Linear) ✅ COMPLETE
 
 Add proper array access rules under affine semantics.
 
@@ -469,7 +469,7 @@ Add proper array access rules under affine semantics.
 - [x] Array write: inout projection to array
 - [x] Law of exclusivity for overlapping projections (via existing inout checks)
 
-**Note**: Compound assignment on array elements (`arr[0] += 5`) is not yet implemented (separate parser enhancement needed). Also, accessing fields of struct elements in arrays (`arr[i].field`) has an ICE in codegen (see rue-oqm6).
+**Note**: Compound assignment on array elements (`arr[0] += 5`) is not yet implemented (separate parser enhancement needed). Also, accessing fields of struct elements in arrays (`arr[i].field`) has an ICE in codegen (see rue-oqm6, historical bd ID, pre-Linear — no surviving Linear issue for this; file a new one if still reproducible).
 
 **Testable**: Can mutate array elements; can't move out non-Copy elements.
 
@@ -482,7 +482,7 @@ fn main() -> i32 {
 }
 ```
 
-### Phase 6: @handle directive (rue-dfr8.6)
+### Phase 6: @handle directive (historical bd ID rue-dfr8.6, pre-Linear)
 
 Add explicit duplication for reference-counted types.
 

--- a/docs/designs/0009-struct-methods.md
+++ b/docs/designs/0009-struct-methods.md
@@ -132,19 +132,19 @@ Methods can only be defined for structs in the same compilation unit. (This is a
 
 ## Implementation Phases
 
-- [x] **Phase 1: Parsing** - rue-qs3z.1
+- [x] **Phase 1: Parsing** - (historical bd ID rue-qs3z.1, pre-Linear)
   - Add `impl` keyword to lexer
   - Parse `impl Type { fn... }` blocks
   - Add `Item::ImplBlock` to AST
   - Parse method calls as a variant of field access
 
-- [x] **Phase 2: RIR Generation** - rue-qs3z.2
+- [x] **Phase 2: RIR Generation** - (historical bd ID rue-qs3z.2, pre-Linear)
   - Add method info to RIR (ImplDecl, MethodCall, AssocFnCall instructions)
   - Generate RIR for impl blocks
   - Handle method calls in expression generation
   - Parse associated function calls (Type::fn() syntax)
 
-- [x] **Phase 3: Type Checking** - rue-qs3z.3
+- [x] **Phase 3: Type Checking** - (historical bd ID rue-qs3z.3, pre-Linear)
   - Add method registry to struct definitions
   - Type check impl blocks
   - Resolve method calls to their definitions
@@ -155,12 +155,12 @@ Methods can only be defined for structs in the same compilation unit. (This is a
     3. Resolving the method name
     4. Type checking the arguments against method signature
 
-- [x] **Phase 4: Code Generation** - rue-qs3z.4
+- [x] **Phase 4: Code Generation** - (historical bd ID rue-qs3z.4, pre-Linear)
   - Lower method calls to regular calls with receiver as first argument
   - Update both x86_64 and aarch64 backends
   - Handle associated function calls (`Type::method()`)
 
-- [x] **Phase 5: Specification & Tests** - rue-qs3z.5
+- [x] **Phase 5: Specification & Tests** - (historical bd ID rue-qs3z.5, pre-Linear)
   - Add spec chapter 6.4 for impl blocks and methods
   - Add comprehensive spec tests
   - Ensure traceability coverage

--- a/docs/designs/0010-destructors.md
+++ b/docs/designs/0010-destructors.md
@@ -274,11 +274,11 @@ If unwinding is added in the future, destructor behavior during unwinding will n
 
 ## Implementation Phases
 
-Epic: rue-wjha
+Epic: rue-wjha (historical bd ID, pre-Linear; the `.N` suffixes below are its sub-phases)
 
 Following spec-first, test-driven development: each phase writes spec paragraphs, then tests that reference them, then implementation to make tests pass.
 
-### Phase 1: Spec and Infrastructure (rue-wjha.7)
+### Phase 1: Spec and Infrastructure (historical bd ID rue-wjha.7, pre-Linear)
 
 **Spec**: Add destructor chapter to specification (section 3.9 or similar):
 - When destructors run (scope exit, not moved)
@@ -295,7 +295,7 @@ Following spec-first, test-driven development: each phase writes spec paragraphs
 - Add `type_needs_drop()` method to `CfgBuilder` (requires access to struct/array type definitions)
 - Add drop elaboration pass stub in CFG builder
 
-### Phase 2: Drop Elaboration (rue-wjha.8)
+### Phase 2: Drop Elaboration (historical bd ID rue-wjha.8, pre-Linear)
 
 **Spec**: Add paragraphs for:
 - Drop at end of block scope
@@ -313,7 +313,7 @@ Following spec-first, test-driven development: each phase writes spec paragraphs
 - CFG builder inserts `Drop` at scope exits
 - Handle early returns, conditionals, loops
 
-### Phase 3: Codegen (rue-wjha.9)
+### Phase 3: Codegen (historical bd ID rue-wjha.9, pre-Linear)
 
 **Spec**: Add paragraphs for:
 - Drop calls generated for non-trivial types
@@ -329,7 +329,7 @@ Following spec-first, test-driven development: each phase writes spec paragraphs
 - Elide drops for trivially droppable types
 - Register allocation around drop calls
 
-### Phase 4: User-Defined Destructors (rue-wjha.10)
+### Phase 4: User-Defined Destructors (historical bd ID rue-wjha.10, pre-Linear)
 
 **Spec**: Add paragraphs for:
 - `drop fn TypeName(self)` syntax
@@ -347,7 +347,7 @@ Following spec-first, test-driven development: each phase writes spec paragraphs
 - Semantic analysis: validate signature
 - Generate drop function, wire into type's destructor
 
-### Phase 5: Integration with Built-in Types (rue-wjha.11)
+### Phase 5: Integration with Built-in Types (historical bd ID rue-wjha.11, pre-Linear)
 
 This phase is deferred until mutable strings or other heap-allocated types land. It will:
 - Add `__rue_drop_String` to runtime

--- a/docs/designs/0011-runtime-heap.md
+++ b/docs/designs/0011-runtime-heap.md
@@ -162,9 +162,9 @@ No panics in the allocator - it just returns null on failure. Higher-level code 
 
 ## Implementation Phases
 
-Epic: rue-n50n
+Epic: rue-n50n (historical bd ID, pre-Linear; the `.N` suffixes below are its sub-phases)
 
-### Phase 1: Syscall Wrappers (rue-n50n.1)
+### Phase 1: Syscall Wrappers (historical bd ID rue-n50n.1, pre-Linear)
 
 Add mmap/munmap wrappers to each platform module:
 - `x86_64_linux.rs`: `mmap()`, `munmap()`
@@ -173,7 +173,7 @@ Add mmap/munmap wrappers to each platform module:
 
 **Testable**: Call mmap, write to memory, munmap without crashing.
 
-### Phase 2: Bump Allocator Core (rue-n50n.2)
+### Phase 2: Bump Allocator Core (historical bd ID rue-n50n.2, pre-Linear)
 
 Implement the allocator logic:
 - Arena header structure
@@ -183,7 +183,7 @@ Implement the allocator logic:
 
 **Testable**: Allocate various sizes, verify returned pointers are aligned.
 
-### Phase 3: Realloc and Large Allocations (rue-n50n.3)
+### Phase 3: Realloc and Large Allocations (historical bd ID rue-n50n.3, pre-Linear)
 
 - `__rue_realloc` implementation
 - Large allocation handling (dedicated arenas)
@@ -191,7 +191,7 @@ Implement the allocator logic:
 
 **Testable**: Realloc growing and shrinking, large allocations.
 
-### Phase 4: Integration with Compiler (rue-n50n.4)
+### Phase 4: Integration with Compiler (historical bd ID rue-n50n.4, pre-Linear)
 
 - Add codegen support for calling `__rue_alloc`/`__rue_free`
 - Wire up for future String/Vec types

--- a/docs/designs/0012-optimization-passes.md
+++ b/docs/designs/0012-optimization-passes.md
@@ -246,18 +246,18 @@ CFG optimization is target-independent - it operates on typed CFG instructions b
 
 ## Implementation Phases
 
-- [x] **Phase 1: Optimization framework** - rue-aapc.1
+- [x] **Phase 1: Optimization framework** - (historical bd ID rue-aapc.1, pre-Linear)
   - Create `rue-cfg/src/opt/mod.rs` with `OptLevel` enum and pass orchestration
   - Add `-O0` through `-O3` flags to CLI
   - Add UI test infrastructure with `opt_level` support
   - Wire up in rue-compiler
 
-- [x] **Phase 2: Constant folding** - rue-aapc.2
+- [x] **Phase 2: Constant folding** - (historical bd ID rue-aapc.2, pre-Linear)
   - Implement `constfold.rs`
   - Add tests verifying folding occurs at -O1+
   - Update golden tests as needed
 
-- [x] **Phase 3: Dead code elimination** - rue-aapc.3
+- [x] **Phase 3: Dead code elimination** - (historical bd ID rue-aapc.3, pre-Linear)
   - Implement `dce.rs` with liveness analysis
   - Handle side-effects correctly (calls, escaping stores)
   - Add tests for dead store/block elimination

--- a/docs/designs/0013-borrowing-modes.md
+++ b/docs/designs/0013-borrowing-modes.md
@@ -311,12 +311,12 @@ This keeps the type system simple and avoids lifetime complexity.
 
 ## Implementation Phases
 
-Epic: rue-7lii
+Epic: rue-7lii (historical bd ID, pre-Linear; the `.N` suffixes below are its sub-phases)
 
-- [x] **Phase 1: Parser support** - rue-7lii.1 - Add `borrow` keyword, parse in parameter declarations and call sites
-- [x] **Phase 2: Semantic analysis** - rue-7lii.2 - Enforce immutability, prevent move-out, non-escaping check, exclusivity
-- [x] **Phase 3: Codegen** - rue-7lii.3 - Pass borrowed values by pointer, generate read-only accesses
-- [x] **Phase 4: Specification and tests** - rue-7lii.4 - Add spec sections, comprehensive tests
+- [x] **Phase 1: Parser support** - (historical bd ID rue-7lii.1, pre-Linear) - Add `borrow` keyword, parse in parameter declarations and call sites
+- [x] **Phase 2: Semantic analysis** - (historical bd ID rue-7lii.2, pre-Linear) - Enforce immutability, prevent move-out, non-escaping check, exclusivity
+- [x] **Phase 3: Codegen** - (historical bd ID rue-7lii.3, pre-Linear) - Pass borrowed values by pointer, generate read-only accesses
+- [x] **Phase 4: Specification and tests** - (historical bd ID rue-7lii.4, pre-Linear) - Add spec sections, comprehensive tests
 
 ## Consequences
 

--- a/docs/designs/0014-mutable-strings.md
+++ b/docs/designs/0014-mutable-strings.md
@@ -273,11 +273,11 @@ The promotion happens transparently inside mutation methods.
 
 ## Implementation Phases
 
-Epic: rue-0hef
+Epic: rue-0hef (historical bd ID, pre-Linear; the `.N` suffixes below are its sub-phases)
 
 **Note**: As of 2025-12-27, mutable strings are now stable. All phases are complete.
 
-### Phase 1: Specification and Feature Gate - rue-0hef.1 (COMPLETE)
+### Phase 1: Specification and Feature Gate - (historical bd ID rue-0hef.1, pre-Linear) (COMPLETE)
 
 Write the specification first:
 
@@ -289,7 +289,7 @@ Write the specification first:
 
 **Testable**: Spec tests exist and are ignored (preview feature not yet implemented).
 
-### Phase 2: Three-Field String Representation - rue-0hef.2 (COMPLETE)
+### Phase 2: Three-Field String Representation - (historical bd ID rue-0hef.2, pre-Linear) (COMPLETE)
 
 Extend String from 2 fields (ptr, len) to 3 fields (ptr, len, cap):
 
@@ -300,7 +300,7 @@ Extend String from 2 fields (ptr, len) to 3 fields (ptr, len, cap):
 
 **Testable**: Existing string tests still pass with new representation.
 
-### Phase 3: Runtime String Functions - rue-0hef.3 (COMPLETE)
+### Phase 3: Runtime String Functions - (historical bd ID rue-0hef.3, pre-Linear) (COMPLETE)
 
 Add string-specific functions to runtime:
 
@@ -312,7 +312,7 @@ Add string-specific functions to runtime:
 
 **Testable**: Unit tests in Rust for allocation/reallocation.
 
-### Phase 4: String Destructor Integration - rue-0hef.4 (COMPLETE)
+### Phase 4: String Destructor Integration - (historical bd ID rue-0hef.4, pre-Linear) (COMPLETE)
 
 Wire String type to use destructors:
 
@@ -322,7 +322,7 @@ Wire String type to use destructors:
 
 **Testable**: Valgrind-clean string allocation and deallocation.
 
-### Phase 5: Construction Methods - rue-0hef.5 (COMPLETE)
+### Phase 5: Construction Methods - (historical bd ID rue-0hef.5, pre-Linear) (COMPLETE)
 
 Add `impl String` with construction (gated):
 
@@ -331,7 +331,7 @@ Add `impl String` with construction (gated):
 
 **Testable**: Create strings, verify cap is set correctly.
 
-### Phase 6: Query Methods - rue-0hef.6 (COMPLETE)
+### Phase 6: Query Methods - (historical bd ID rue-0hef.6, pre-Linear) (COMPLETE)
 
 Add query methods (gated):
 
@@ -341,7 +341,7 @@ Add query methods (gated):
 
 **Testable**: Query methods return correct values.
 
-### Phase 7: Mutation Methods - rue-0hef.7 (COMPLETE)
+### Phase 7: Mutation Methods - (historical bd ID rue-0hef.7, pre-Linear) (COMPLETE)
 
 Add mutation methods with `inout self` (gated):
 
@@ -354,7 +354,7 @@ Add mutation methods with `inout self` (gated):
 
 **Testable**: Build strings through multiple appends.
 
-### Phase 8: Clone Method - rue-0hef.8 (COMPLETE)
+### Phase 8: Clone Method - (historical bd ID rue-0hef.8, pre-Linear) (COMPLETE)
 
 Add explicit cloning (gated):
 
@@ -363,7 +363,7 @@ Add explicit cloning (gated):
 
 **Testable**: Clone a string, verify both are independent.
 
-### Phase 9: Equality Optimization - rue-0hef.9 (COMPLETE)
+### Phase 9: Equality Optimization - (historical bd ID rue-0hef.9, pre-Linear) (COMPLETE)
 
 Optimize string comparison:
 

--- a/docs/designs/0015-test-suite-optimization.md
+++ b/docs/designs/0015-test-suite-optimization.md
@@ -172,30 +172,30 @@ Add a new script `./quick-test.sh` that runs only unit tests for faster iteratio
 
 ## Implementation Phases
 
-- [x] **Phase 1: Parameterized Test Support** - rue-9jdv.1
+- [x] **Phase 1: Parameterized Test Support** - (historical bd ID rue-9jdv.1, pre-Linear)
   - Added `ParamSet` struct and `params` field to `Case` in `rue-test-runner`
   - Implemented template expansion with `{param}` syntax
   - Implemented `expand_case()` and `expand_test_file()` functions
   - Added unit tests for expansion logic
   - Added example parameterized test to `integers.toml`
 
-- [x] **Phase 2: Consolidate Integer Tests** - rue-9jdv.2
+- [x] **Phase 2: Consolidate Integer Tests** - (historical bd ID rue-9jdv.2, pre-Linear)
   - Rewrote `integers.toml` using parameterized format (95 → 41 case definitions)
   - Fixed traceability report to handle parameterized tests with `spec_extra`
   - Verified 100% spec coverage maintained via traceability check
 
-- [x] **Phase 3: Consolidate Other Spec Tests** - rue-9jdv.3
+- [x] **Phase 3: Consolidate Other Spec Tests** - (historical bd ID rue-9jdv.3, pre-Linear)
   - Consolidated `arithmetic.toml` (530→274 lines), `let.toml` (688→400 lines)
   - Consolidated `functions.toml` (1405→800 lines, heavily reduced inout section)
   - Consolidated `bitwise.toml` (550→325 lines), `comparison.toml` (439→274 lines)
   - All 1021 tests pass with 100% normative spec coverage maintained
 
-- [x] **Phase 4: Integration Unit Tests** - rue-9jdv.4
+- [x] **Phase 4: Integration Unit Tests** - (historical bd ID rue-9jdv.4, pre-Linear)
   - Added `compile_to_air()` and `compile_to_cfg()` test helpers to `rue-compiler`
   - Added 115+ integration unit tests covering major language features
   - Tests organized by category: types, arithmetic, comparison, logical, bitwise, control flow, functions, structs, enums, arrays, strings, intrinsics, CFG construction, error messages, warnings, and edge cases
 
-- [x] **Phase 5: Workflow Documentation** - rue-9jdv.5
+- [x] **Phase 5: Workflow Documentation** - (historical bd ID rue-9jdv.5, pre-Linear)
   - Added Development Workflow section to CLAUDE.md
   - Added `./quick-test.sh` script for fast unit test iteration
   - Added "Choosing the Right Test Type" table documenting when to use each test level

--- a/docs/designs/0016-preview-feature-infrastructure.md
+++ b/docs/designs/0016-preview-feature-infrastructure.md
@@ -178,10 +178,10 @@ pub fn compile_to_air_with_preview(
 
 ## Implementation Phases
 
-- [x] **Phase 1: Pipeline threading** - rue-0slf.1
-- [x] **Phase 2: Gating method** - rue-0slf.2
-- [x] **Phase 3: test_infra feature** - rue-0slf.3
-- [x] **Phase 4: Cleanup** - rue-0slf.4
+- [x] **Phase 1: Pipeline threading** - (historical bd ID rue-0slf.1, pre-Linear)
+- [x] **Phase 2: Gating method** - (historical bd ID rue-0slf.2, pre-Linear)
+- [x] **Phase 3: test_infra feature** - (historical bd ID rue-0slf.3, pre-Linear)
+- [x] **Phase 4: Cleanup** - (historical bd ID rue-0slf.4, pre-Linear)
 
 ## Consequences
 

--- a/docs/designs/0017-emitter-instruction-abstraction.md
+++ b/docs/designs/0017-emitter-instruction-abstraction.md
@@ -217,17 +217,17 @@ fn emit_prologue(&mut self) {
 
 ## Implementation Phases
 
-- [x] **Phase 1: Core types and x86-64 refactor** - rue-hf6s (completed)
+- [x] **Phase 1: Core types and x86-64 refactor** - (historical bd ID rue-hf6s, pre-Linear) (completed)
   - Add `EmittedInst` and `EmittedCode` types
   - Refactor x86-64 emitter to use new pattern
   - Update `--emit asm` to use `to_asm()`
   - Verify byte output is identical (regression test)
 
-- [x] **Phase 2: aarch64 refactor** - rue-4rzx (depends on Phase 1)
+- [x] **Phase 2: aarch64 refactor** - (historical bd ID rue-4rzx, pre-Linear) (depends on Phase 1)
   - Apply same pattern to aarch64 emitter
   - Verify byte output is identical
 
-- [x] **Phase 3: Cleanup and optimization** - rue-h8r0 (completed)
+- [x] **Phase 3: Cleanup and optimization** - (historical bd ID rue-h8r0, pre-Linear) (completed)
   - Add shared `format_offset` helper to lib.rs
   - Add `callee_saved_size()` and `adjust_fp_offset()` helpers to x86_64 emitter
   - Add `adjust_fp_offset()` helper to aarch64 emitter
@@ -277,5 +277,5 @@ fn emit_prologue(&mut self) {
 
 ## References
 
-- Issue: rue-3dxp (`--emit asm should show actual emitted code including prologue/epilogue`)
+- Issue: rue-3dxp (historical bd ID, pre-Linear) (`--emit asm should show actual emitted code including prologue/epilogue`)
 - Current emit.rs files: `crates/rue-codegen/src/{x86_64,aarch64}/emit.rs`

--- a/docs/designs/0018-tracing-infrastructure.md
+++ b/docs/designs/0018-tracing-infrastructure.md
@@ -19,7 +19,7 @@ Implemented
 
 ## Summary
 
-Add the `tracing` crate to Rue for structured debug logging, following the "wide events" philosophy from loggingsucks.com. This provides rich, context-aware logging per compilation pass rather than scattered debug statements, and also implements the `--time-passes` feature (rue-uxgx).
+Add the `tracing` crate to Rue for structured debug logging, following the "wide events" philosophy from loggingsucks.com. This provides rich, context-aware logging per compilation pass rather than scattered debug statements, and also implements the `--time-passes` feature (historical bd ID rue-uxgx, pre-Linear).
 
 ## Context
 
@@ -32,7 +32,7 @@ The "wide events" philosophy (from loggingsucks.com) advocates for:
 
 For a compiler, this translates to emitting one structured span per compilation pass with rich context (timing, counts, outcomes).
 
-Additionally, there's an open feature request (rue-uxgx) for `--time-passes` to show compilation timing. The `tracing` crate provides timing spans naturally, so both needs are addressed by the same infrastructure.
+Additionally, there's an open feature request (historical bd ID rue-uxgx, pre-Linear) for `--time-passes` to show compilation timing. The `tracing` crate provides timing spans naturally, so both needs are addressed by the same infrastructure.
 
 ## Decision
 
@@ -114,28 +114,28 @@ pub fn compile_frontend_with_options(...) -> CompileResult<...> {
 
 ## Implementation Phases
 
-- [x] **Phase 1: Add dependencies** - rue-irz1.1
+- [x] **Phase 1: Add dependencies** - (historical bd ID rue-irz1.1, pre-Linear)
   - Update `third-party/Cargo.toml` with tracing, tracing-subscriber
   - Run `reindeer buckify`
   - Update crate BUCK files
 
-- [x] **Phase 2: CLI and subscriber** - rue-irz1.2
+- [x] **Phase 2: CLI and subscriber** - (historical bd ID rue-irz1.2, pre-Linear)
   - Initialize tracing-subscriber in main.rs
   - Add `--log-level` flag (off/error/warn/info/debug/trace)
   - Add `--log-format` flag (text/json)
   - Support `RUST_LOG` environment variable
 
-- [x] **Phase 3: --time-passes** - rue-irz1.3
+- [x] **Phase 3: --time-passes** - (historical bd ID rue-irz1.3, pre-Linear)
   - Implement `--time-passes` using tracing spans
   - Collect timing from spans and format output
-  - Closes rue-uxgx
+  - Closes rue-uxgx (historical bd ID, pre-Linear)
 
-- [x] **Phase 4: Instrument compiler** - rue-irz1.4
+- [x] **Phase 4: Instrument compiler** - (historical bd ID rue-irz1.4, pre-Linear)
   - Add spans to `compile_frontend_with_options()`
   - Add spans to backend functions
   - Include context: file size, token/instruction counts
 
-- [x] **Phase 5: Documentation** - rue-irz1.5
+- [x] **Phase 5: Documentation** - (historical bd ID rue-irz1.5, pre-Linear)
   - Add logging guidelines to CLAUDE.md
   - Document the "wide events" philosophy
   - Provide good/bad examples
@@ -173,4 +173,4 @@ None - resolved during planning:
 
 - https://loggingsucks.com/ - Wide events philosophy
 - https://docs.rs/tracing - Tracing crate documentation
-- rue-uxgx - Original --time-passes feature request
+- rue-uxgx (historical bd ID, pre-Linear) - Original --time-passes feature request

--- a/docs/designs/0019-performance-dashboard.md
+++ b/docs/designs/0019-performance-dashboard.md
@@ -168,31 +168,31 @@ website/
 
 ## Implementation Phases
 
-**Epic:** rue-a5ah
+**Epic:** rue-a5ah (historical bd ID, pre-Linear; the `.N` suffixes below are its sub-phases)
 
-- [x] **Phase 1: Benchmark corpus** - rue-a5ah.1
+- [x] **Phase 1: Benchmark corpus** - (historical bd ID rue-a5ah.1, pre-Linear)
   - Create `benchmarks/` directory structure
   - Write initial stress test programs (many_functions, deep_nesting, etc.)
   - Create `manifest.toml` format
 
-- [x] **Phase 2: Data collection** - rue-a5ah.2
+- [x] **Phase 2: Data collection** - (historical bd ID rue-a5ah.2, pre-Linear)
   - Implement `--benchmark-json` flag in the CLI
   - Extend `TimingData` to output JSON format
   - Support multiple iterations with mean/std calculation
 
-- [x] **Phase 3: Runner & storage** - rue-a5ah.3
+- [x] **Phase 3: Runner & storage** - (historical bd ID rue-a5ah.3, pre-Linear)
   - Create `./bench.sh` script
   - Create `scripts/append-benchmark.py` to manage history
   - Set up `perf` branch structure
   - Document benchmark workflow
   - Add release/debug build modes via Buck2 modifiers
 
-- [x] **Phase 4: CI integration** - rue-a5ah.4
+- [x] **Phase 4: CI integration** - (historical bd ID rue-a5ah.4, pre-Linear)
   - GitHub Actions workflow to run benchmarks on trunk commits
   - Push results to `perf` branch
   - Configure consistent benchmark environment
 
-- [x] **Phase 5: Website visualization** - rue-a5ah.5
+- [x] **Phase 5: Website visualization** - (historical bd ID rue-a5ah.5, pre-Linear)
   - Create SVG chart generator (Rust or Python)
   - Create `/performance/` page template
   - Integrate chart generation into website build

--- a/docs/designs/0020-builtin-types-as-structs.md
+++ b/docs/designs/0020-builtin-types-as-structs.md
@@ -398,11 +398,11 @@ let air_ref = self.air.add_inst(AirInst {
 
 ## Implementation Phases
 
-**Epic**: rue-c8lp
+**Epic**: rue-c8lp (historical bd ID, pre-Linear)
 
 ### Phase 1: Builtin Registry Infrastructure
 
-**Issues**: rue-fgx3 (crate), rue-cbsc (injection)
+**Issues**: rue-fgx3 (crate), rue-cbsc (injection) (historical bd IDs, pre-Linear)
 
 **Goal**: Create the builtin type registry without changing existing behavior.
 
@@ -419,7 +419,7 @@ let air_ref = self.air.add_inst(AirInst {
 
 ### Phase 2: Migrate Sema
 
-**Issue**: rue-hp13
+**Issue**: rue-hp13 (historical bd ID, pre-Linear)
 
 **Goal**: Replace `Type::String` checks in semantic analysis with struct-based queries.
 
@@ -435,7 +435,7 @@ let air_ref = self.air.add_inst(AirInst {
 
 ### Phase 3: Migrate Codegen
 
-**Issues**: rue-s6mk (x86_64), rue-tco7 (aarch64), rue-5cfw (other)
+**Issues**: rue-s6mk (x86_64), rue-tco7 (aarch64), rue-5cfw (other) (historical bd IDs, pre-Linear)
 
 **Goal**: Replace `Type::String` checks in both backends and remaining crates.
 
@@ -454,7 +454,7 @@ let air_ref = self.air.add_inst(AirInst {
 
 ### Phase 4: Remove Type::String
 
-**Issue**: rue-bmje
+**Issue**: rue-bmje (historical bd ID, pre-Linear)
 
 **Goal**: Delete the `Type::String` variant entirely.
 
@@ -468,7 +468,7 @@ let air_ref = self.air.add_inst(AirInst {
 
 ### Phase 5: Documentation and Cleanup
 
-**Issue**: rue-n20l
+**Issue**: rue-n20l (historical bd ID, pre-Linear)
 
 **Goal**: Document the new architecture for future contributors.
 

--- a/docs/designs/0024-type-intern-pool.md
+++ b/docs/designs/0024-type-intern-pool.md
@@ -46,7 +46,7 @@ pub enum Type {
 
 ### Problems
 
-1. **Dynamic array type creation**: Arrays are created during type inference, requiring mutable state during what should be parallel function analysis. This led to `FunctionAnalysisState` with per-function array registries that must be merged afterward (see rue-wcg7).
+1. **Dynamic array type creation**: Arrays are created during type inference, requiring mutable state during what should be parallel function analysis. This led to `FunctionAnalysisState` with per-function array registries that must be merged afterward (see rue-wcg7, historical bd ID, pre-Linear).
 
 2. **Inconsistent creation patterns**: Structs/enums use one path, arrays use another. This asymmetry complicates the codebase.
 
@@ -193,9 +193,9 @@ The key insight is that `Type` remains a small, Copy value - we're just changing
 
 ## Implementation Phases
 
-**Epic**: rue-igt6
+**Epic**: rue-igt6 (historical bd ID, pre-Linear)
 
-### Phase 1: Introduce TypeInternPool alongside existing system (rue-3mjg)
+### Phase 1: Introduce TypeInternPool alongside existing system (historical bd ID rue-3mjg, pre-Linear)
 
 Create the new `TypeInternPool` infrastructure without removing the old system. Both coexist temporarily.
 
@@ -206,7 +206,7 @@ Create the new `TypeInternPool` infrastructure without removing the old system. 
 
 **Ship criterion**: All existing tests pass, pool is populated but not yet used.
 
-### Phase 2: Migrate array types to the pool (rue-9e5t)
+### Phase 2: Migrate array types to the pool (historical bd ID rue-9e5t, pre-Linear)
 
 Replace `ArrayTypeId` and the per-function array type handling with pool interning.
 
@@ -217,7 +217,7 @@ Replace `ArrayTypeId` and the per-function array type handling with pool interni
 
 **Ship criterion**: Arrays work, parallel function analysis uses shared pool, no per-function array registries.
 
-### Phase 3: Migrate struct/enum IDs to pool indices (rue-ej3x)
+### Phase 3: Migrate struct/enum IDs to pool indices (historical bd ID rue-ej3x, pre-Linear)
 
 Replace `StructId` and `EnumId` with `Type` indices directly.
 
@@ -228,7 +228,7 @@ Replace `StructId` and `EnumId` with `Type` indices directly.
 
 **Ship criterion**: `Type` is now a u32 index. All lookups go through the pool.
 
-### Phase 4: Unify Type representation (rue-wsny)
+### Phase 4: Unify Type representation (historical bd ID rue-wsny, pre-Linear)
 
 Replace the `Type` enum entirely with the `Type(u32)` newtype.
 
@@ -239,7 +239,7 @@ Replace the `Type` enum entirely with the `Type(u32)` newtype.
 
 **Ship criterion**: Single unified type representation. Clean API.
 
-### Phase 5: Performance optimization (rue-ynk5, optional)
+### Phase 5: Performance optimization (historical bd ID rue-ynk5, pre-Linear; optional)
 
 If profiling shows lock contention:
 
@@ -305,5 +305,5 @@ If profiling shows lock contention:
 
 - [Zig InternPool PR #15569](https://github.com/ziglang/zig/pull/15569)
 - [Zig InternPool.zig source](https://github.com/ziglang/zig/blob/master/src/InternPool.zig)
-- [rue-50gf: Original issue on array type design](rue-50gf)
-- [rue-wcg7: Parallel function analysis](rue-wcg7)
+- rue-50gf (historical bd ID, pre-Linear): Original issue on array type design
+- rue-wcg7 (historical bd ID, pre-Linear): Parallel function analysis

--- a/docs/designs/0025-comptime.md
+++ b/docs/designs/0025-comptime.md
@@ -300,9 +300,9 @@ This is deferred to Phase 4.
 
 ## Implementation Phases
 
-Epic: rue-33lf (closed)
+Epic: rue-33lf (historical bd ID, pre-Linear; closed)
 
-### Phase 1: Comptime Expressions (rue-3xoq) - Complete
+### Phase 1: Comptime Expressions (historical bd ID rue-3xoq, pre-Linear) - Complete
 
 **Goal**: `comptime { expr }` syntax with basic expression evaluation.
 
@@ -315,7 +315,7 @@ Epic: rue-33lf (closed)
 
 **Deliverable**: Users can write `const X: i32 = comptime { 1 + 2 * 3 };`
 
-### Phase 2: Comptime Parameters (Value) (rue-ya9i) - Complete
+### Phase 2: Comptime Parameters (Value) (historical bd ID rue-ya9i, pre-Linear) - Complete
 
 **Goal**: Functions can take comptime value parameters.
 
@@ -327,7 +327,7 @@ Epic: rue-33lf (closed)
 
 **Deliverable**: Users can write `fn repeat(comptime n: i32, x: i32) -> i32`
 
-### Phase 3: Type Parameters (rue-fbwv) - Complete
+### Phase 3: Type Parameters (historical bd ID rue-fbwv, pre-Linear) - Complete
 
 **Goal**: The `type` type and comptime type parameters.
 
@@ -339,7 +339,7 @@ Epic: rue-33lf (closed)
 
 **Deliverable**: Users can write `fn max(comptime T: type, a: T, b: T) -> T`
 
-### Phase 4: Comptime Type Construction (rue-ak9z) - Complete
+### Phase 4: Comptime Type Construction (historical bd ID rue-ak9z, pre-Linear) - Complete
 
 **Goal**: Comptime functions can construct and return types.
 

--- a/docs/designs/0027-random-intrinsics.md
+++ b/docs/designs/0027-random-intrinsics.md
@@ -190,25 +190,25 @@ The return type of `@random_u64` is `u64`.
 
 ## Implementation Phases
 
-- [x] **Phase 1: Spec and tests** - rue-ddko
+- [x] **Phase 1: Spec and tests** - (historical bd ID rue-ddko, pre-Linear)
   - Add spec documentation for `@random_u32` and `@random_u64`
   - Add preview-gated spec tests (non-deterministic, so test compilation only)
   - Add `Random` to `PreviewFeature` enum
 
-- [x] **Phase 2: Parser and Sema** - rue-ub3z
+- [x] **Phase 2: Parser and Sema** - (historical bd ID rue-ub3z, pre-Linear)
   - Add `RandomU32` and `RandomU64` to intrinsic parsing
   - Add type checking (returns u32/u64, takes no args)
   - Add preview feature gate check
   - Add CFG lowering for random intrinsics
 
-- [x] **Phase 3: Runtime implementation** - rue-5852
+- [x] **Phase 3: Runtime implementation** - (historical bd ID rue-5852, pre-Linear)
   - Implement `__rue_random_u32` for x86-64 Linux
   - Implement `__rue_random_u64` for x86-64 Linux
   - Implement for aarch64 macOS (using getentropy from libSystem)
   - Implement for aarch64 Linux
   - Handle error cases (no entropy source)
 
-- [x] **Phase 4: Codegen** - rue-2h42
+- [x] **Phase 4: Codegen** - (historical bd ID rue-2h42, pre-Linear)
   - Add call generation for x86-64 backend
   - Add call generation for aarch64 backend
   - Integration testing with example programs (spec tests)

--- a/docs/designs/0028-unsafe-and-raw-pointers.md
+++ b/docs/designs/0028-unsafe-and-raw-pointers.md
@@ -321,12 +321,12 @@ Outside `checked` blocks, all of Rue's safety guarantees still hold.
 
 ## Implementation Phases
 
-- [x] **Phase 1: Parser support** (rue-7qxm) - Add `checked` block syntax, `unchecked` function modifier, `ptr const`/`ptr mut` types
-- [x] **Phase 2: Type system** (rue-pb4z) - Pointer types in sema, checked block tracking
-- [x] **Phase 3: Pointer intrinsics** (rue-u9a4) - `@ptr_read`, `@ptr_write`, `@ptr_offset`, `@addr_of`, `@addr_of_mut`, `@ptr_to_int`, `@int_to_ptr`
-- [x] **Phase 4: Syscall intrinsic** (rue-pwyw) - `@syscall` for direct OS calls
-- [x] **Phase 5: Codegen** (rue-bk7s) - Generate correct code for pointer operations in both x86_64 and aarch64 backends
-- [ ] **Phase 6: Stdlib foundation** (rue-i3ti) - Implement basic Vec and I/O using unchecked code (follow-on work)
+- [x] **Phase 1: Parser support** (historical bd ID rue-7qxm, pre-Linear) - Add `checked` block syntax, `unchecked` function modifier, `ptr const`/`ptr mut` types
+- [x] **Phase 2: Type system** (historical bd ID rue-pb4z, pre-Linear) - Pointer types in sema, checked block tracking
+- [x] **Phase 3: Pointer intrinsics** (historical bd ID rue-u9a4, pre-Linear) - `@ptr_read`, `@ptr_write`, `@ptr_offset`, `@addr_of`, `@addr_of_mut`, `@ptr_to_int`, `@int_to_ptr`
+- [x] **Phase 4: Syscall intrinsic** (historical bd ID rue-pwyw, pre-Linear) - `@syscall` for direct OS calls
+- [x] **Phase 5: Codegen** (historical bd ID rue-bk7s, pre-Linear) - Generate correct code for pointer operations in both x86_64 and aarch64 backends
+- [ ] **Phase 6: Stdlib foundation** (RUE-1) - Implement basic Vec and I/O using unchecked code (follow-on work)
 
 ## Consequences
 

--- a/docs/designs/0029-anonymous-struct-methods.md
+++ b/docs/designs/0029-anonymous-struct-methods.md
@@ -200,9 +200,9 @@ This is handled naturally by monomorphization - each specialization captures con
 
 ## Implementation Phases
 
-Epic: rue-nj40
+Epic: rue-nj40 (historical bd ID, pre-Linear; the `.N` suffixes below are its sub-phases)
 
-### Phase 1: Parser & AST (rue-nj40.1) ✅
+### Phase 1: Parser & AST (historical bd ID rue-nj40.1, pre-Linear) ✅
 
 - [x] Add `methods: Vec<Method>` to `TypeExpr::AnonymousStruct` in AST
 - [x] Update Chumsky parser to accept `fn` inside `struct { ... }`
@@ -213,7 +213,7 @@ Epic: rue-nj40
 
 **Deliverable**: Parser accepts `struct { x: i32, fn get(self) -> i32 { self.x } }` syntax.
 
-### Phase 2: RIR Generation (rue-nj40.2) ✅
+### Phase 2: RIR Generation (historical bd ID rue-nj40.2, pre-Linear) ✅
 
 - [x] Extend `InstData::AnonStructType` to include method references
 - [x] Store anonymous struct methods in RIR extra data
@@ -222,22 +222,22 @@ Epic: rue-nj40
 
 **Deliverable**: RIR correctly represents anonymous structs with methods.
 
-### Phase 3: Semantic Analysis (rue-nj40.3) 🔶
+### Phase 3: Semantic Analysis (historical bd ID rue-nj40.3, pre-Linear) 🔶
 
 - [x] Change method lookup key from `(Spur, Spur)` to `(StructId, Spur)`
 - [x] Register methods when creating anonymous struct types
 - [x] Resolve `Self` to the anonymous struct's `StructId` (in signatures only)
-- [x] Handle `Type::function()` call syntax for comptime type variables (rue-ybbz)
+- [x] Handle `Type::function()` call syntax for comptime type variables (historical bd ID rue-ybbz, pre-Linear)
 - [ ] Update structural equality to include method signatures
 - [ ] Handle comptime parameter capture in method bodies
 - [x] Analyze method bodies with `self` in scope
-- [x] Resolve `Self` in method body expressions (rue-h6zn)
+- [x] Resolve `Self` in method body expressions (historical bd ID rue-h6zn, pre-Linear)
 
 **Status**: Most items complete. Method registration, `self` in method bodies, associated function calls on comptime type variables (`P::constant()`), and `Self` type resolution all work. Remaining: structural equality with methods, comptime parameter capture.
 
 **Deliverable**: `v.push(42)` compiles when `v` is an anonymous struct type with a `push` method.
 
-### Phase 4: Specification & Tests (rue-nj40.4) ✅
+### Phase 4: Specification & Tests (historical bd ID rue-nj40.4, pre-Linear) ✅
 
 - [x] Add spec section for anonymous struct methods (4.14:10-15)
 - [x] Add comprehensive spec tests (17 tests, preview-gated)
@@ -320,4 +320,4 @@ Epic: rue-nj40
 - [ADR-0009: Struct Methods](0009-struct-methods.md) - Foundation for method implementation
 - [ADR-0025: Compile-Time Execution](0025-comptime.md) - Comptime infrastructure this builds on
 - [Zig Language Reference: struct](https://ziglang.org/documentation/master/#struct) - Inspiration for inline method syntax
-- [rue-nj40](https://github.com/...) - Original issue tracking this feature
+- rue-nj40 (historical bd ID, pre-Linear) - Original issue tracking this feature

--- a/docs/designs/0031-robust-performance-testing.md
+++ b/docs/designs/0031-robust-performance-testing.md
@@ -204,36 +204,36 @@ If the queue still backs up (e.g., during a period of intense development):
 
 ## Implementation Phases
 
-**Epic:** rue-1h38
+**Epic:** rue-1h38 (historical bd ID, pre-Linear; the `.N` suffixes below are its sub-phases)
 
-- [x] **Phase 1: Parallel execution + artifact upload** - rue-1h38.1
+- [x] **Phase 1: Parallel execution + artifact upload** - (historical bd ID rue-1h38.1, pre-Linear)
   - Modify benchmarks.yml to remove max-parallel constraint
   - Change platform jobs to upload artifacts instead of pushing to perf
   - Verify artifacts are created correctly
 
-- [x] **Phase 2: Atomic collector job** - rue-1h38.2
+- [x] **Phase 2: Atomic collector job** - (historical bd ID rue-1h38.2, pre-Linear)
   - Add collect-results job that downloads artifacts
   - Implement atomic push to perf branch
   - Test with multiple parallel platform jobs
 
-- [x] **Phase 3: Time-based batching** - rue-1h38.3
+- [x] **Phase 3: Time-based batching** - (historical bd ID rue-1h38.3, pre-Linear)
   - Add scheduled trigger (every 15 minutes)
   - Enable cancel-in-progress for concurrency control
   - Update documentation
 
-- [x] **Phase 4: Commit range tracking** - rue-1h38.4
+- [x] **Phase 4: Commit range tracking** - (historical bd ID rue-1h38.4, pre-Linear)
   - Update JSON schema to include commit_range field (version 2)
   - Capture commit range in collector job (last 24 hours)
   - Inject commit_range and benchmark_reason into results
   - Update append-benchmark.py documentation for version 2 schema
 
-- [x] **Phase 5: Graceful degradation** - rue-1h38.5
+- [x] **Phase 5: Graceful degradation** - (historical bd ID rue-1h38.5, pre-Linear)
   - Add queue depth monitoring using GitHub API
   - Implement adaptive sampling logic (skip if queue > 10 for push, > 20 for all)
   - Add logging for skipped commits with reason and queue depth
   - Manual runs always proceed regardless of queue depth
 
-- [x] **Phase 6: Dashboard improvements** - rue-1h38.6
+- [x] **Phase 6: Dashboard improvements** - (historical bd ID rue-1h38.6, pre-Linear)
   - Visualize benchmark coverage
   - Show commit ranges for each benchmark run
   - Highlight data gaps

--- a/docs/designs/0032-data-structure-selection.md
+++ b/docs/designs/0032-data-structure-selection.md
@@ -176,7 +176,7 @@ None - all questions resolved through benchmarking and implementation.
 
 ## References
 
-- Issue: rue-vfmy
+- Issue: rue-vfmy (historical bd ID, pre-Linear)
 - Commit: "Optimize: Convert AnalysisContext.params from HashMap to Vec"
 - Benchmark data: See "Benchmarks" section above
 - Rust std docs: [`HashMap`](https://doc.rust-lang.org/std/collections/struct.HashMap.html), [`Vec`](https://doc.rust-lang.org/std/vec/struct.Vec.html)

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -20,7 +20,7 @@ Write an ADR for **large features** that:
 - Introduce new type system concepts
 - May span multiple development sessions
 
-**Do NOT write an ADR for small features** like adding a single operator, fixing bugs, or simple refactoring. Those just need a bd issue.
+**Do NOT write an ADR for small features** like adding a single operator, fixing bugs, or simple refactoring. Those just need a Linear issue (team "Rue").
 
 **Rule of thumb**: If it needs a preview feature gate, it needs an ADR.
 
@@ -79,8 +79,8 @@ superseded-by:  # fill if superseded
 
 **Implementation Phases**: Break into independently-committable chunks
 ```markdown
-- [ ] **Phase 1: Core parsing** - bd-XXX
-- [ ] **Phase 2: Type checking** - bd-XXX
+- [ ] **Phase 1: Core parsing** - RUE-NNN
+- [ ] **Phase 2: Type checking** - RUE-NNN
 ```
 
 **Consequences**: Positive, negative, and neutral implications
@@ -89,19 +89,16 @@ superseded-by:  # fill if superseded
 
 **Future Work**: Out of scope for this ADR, but related
 
-### 4. Create bd Issues
+### 4. Create Linear Issues
 
-After the ADR is drafted:
+After the ADR is drafted, file the tracking issues in Linear (team "Rue") via the
+Linear MCP tools — see the "Issue Tracking with Linear" section of the root
+`CLAUDE.md` for the full workflow:
 
-```bash
-# Create epic
-bd create "<feature title>" -t epic -p 2 --json
+- Create a parent (epic) issue with `save_issue` (`team: "Rue"`), linking the ADR in the description
+- Create a sub-issue per phase with `save_issue` (`parentId: <epic RUE-NN>`)
 
-# Create subtask for each phase
-bd create "Phase 1: <description>" -t task --parent <epic-id> --json
-```
-
-Update the ADR with the bd issue IDs.
+Update the ADR with the resulting Linear issue IDs (`RUE-NN`).
 
 ### 5. Add Preview Feature
 


### PR DESCRIPTION
Cycle-27 worker integration (verified by hand at integration time).

**RUE-53** (redo — an earlier attempt's grep missed the phase-suffixed `rue-qs3z.N` form): swept all 116 retired bd-tracker citations across 20 ADRs + README.md + the template workflow section. Only `rue-i3ti` has a verified Linear mapping (→ RUE-1, per RUE-1's own note); everything else is annotated `(historical bd ID …, pre-Linear)` rather than an invented mapping. The filtered grep for live-looking bd references returns **zero**.

**RUE-124:** converted `VariableMoveState.partial_moves` from `HashMap<FieldPath, Span>` to an association `Vec<(FieldPath, Span)>` with a single-pass O(n) prefix scan (ADR-0032 precedent). A data-structure swap, **not** a semantics change — all three HashMap behaviors the move/linear soundness surface relies on are preserved: unique keys, exact-then-shortest-ancestor span selection (via a rank, diagnostics unchanged), and order-insensitive equality (hand-written `PartialEq` so the loop back-edge `moved_vars != snapshot` recheck can't trip on a reordered-but-equal Vec).

Integration verification by execution on the exact soundness surface: **ice_regressions 23/0, linear_must_consume 23/0, move-semantics 82/0, destructor 14/0, drop 66/0 — all unchanged**; new prefix unit test; full `./test.sh` green (432/432).

Fixes RUE-53
Fixes RUE-124

🤖 Generated with [Claude Code](https://claude.com/claude-code)