### PR TITLE
rue-oracle: drop/destructors slice — the soundness surface (RUE-50)

### DIFF
--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -21,10 +21,13 @@
 //! `loop` all lower to `Goto`/`Branch`/`Switch`), `@dbg`, `@intCast`, and the
 //! defined panics (overflow, divide/remainder-by-zero, int-cast overflow);
 //! aggregates (structs/arrays) with nested place projections and bounds traps;
-//! and `inout`/`borrow` parameters (copy-in / copy-out, observably identical to
-//! by-reference under the law of exclusivity). Not yet: strings (heap builtin)
-//! and drop/destructors — the next slices (see the `docs/formal` extension
-//! rubric). Programs using them return [`Unsupported`].
+//! `inout`/`borrow` parameters (copy-in / copy-out, observably identical to
+//! by-reference under the law of exclusivity); and drop/destructors, executed in
+//! spec-3.9 order (user destructor, then fields in declaration order / elements
+//! ascending) so the oracle validates drop *order* and drop-exactly-once, not
+//! just final values. Not yet: strings (heap builtin) — the last core slice (see
+//! the `docs/formal` extension rubric). Programs using them return
+//! [`Unsupported`].
 
 use lasso::ThreadedRodeo;
 use rue_air::{Type, TypeKind};
@@ -276,6 +279,44 @@ impl<'a> Interp<'a> {
         }
     }
 
+    /// Run the drop of a value of type `ty`, in the spec-3.9 order: the type's
+    /// user destructor first, then its fields (declaration order) / elements
+    /// (ascending). Scalars are trivially droppable (no-op). The compiler's drop
+    /// *elaboration* already decided where `drop` instructions live (suppressing
+    /// moved values), so this only executes the cleanup for a value that should
+    /// be dropped — it does not re-derive move analysis.
+    fn run_drop(&mut self, ty: Type, v: Value) -> Step<()> {
+        match ty.kind() {
+            TypeKind::Struct(sid) => {
+                let sd = self.state.type_pool.struct_def(sid);
+                if let Some(dtor) = sd.destructor.clone() {
+                    self.call(&dtor, &[v.clone()])?;
+                }
+                // A builtin type's destructor is its entire drop glue; a
+                // user struct then drops its fields in declaration order.
+                if !sd.is_builtin {
+                    if let Value::Aggregate(elems) = &v {
+                        for (i, field) in sd.fields.iter().enumerate() {
+                            if let Some(fv) = elems.get(i).cloned() {
+                                self.run_drop(field.ty, fv)?;
+                            }
+                        }
+                    }
+                }
+            }
+            TypeKind::Array(aid) => {
+                let (elem_ty, _len) = self.state.type_pool.array_def(aid);
+                if let Value::Aggregate(elems) = &v {
+                    for fv in elems.iter().cloned() {
+                        self.run_drop(elem_ty, fv)?;
+                    }
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
     fn eval_all(&mut self, cfg: &'a Cfg, frame: &mut Frame, vs: &[CfgValue]) -> Step<Vec<Value>> {
         vs.iter().map(|v| self.eval(cfg, frame, *v)).collect()
     }
@@ -513,9 +554,13 @@ impl<'a> Interp<'a> {
                 Value::Int(x)
             }
 
-            CfgInstData::Drop { .. }
-            | CfgInstData::StorageLive { .. }
-            | CfgInstData::StorageDead { .. } => Value::Unit,
+            CfgInstData::Drop { value } => {
+                let ty = cfg.get_inst(*value).ty;
+                let v = self.eval(cfg, frame, *value)?;
+                self.run_drop(ty, v)?;
+                Value::Unit
+            }
+            CfgInstData::StorageLive { .. } | CfgInstData::StorageDead { .. } => Value::Unit,
 
             other => {
                 return Err(Flow::Unsupported(Unsupported(format!(

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -253,6 +253,70 @@ fn inout_struct_field() {
 }
 
 #[test]
+fn destructor_runs_at_scope_exit() {
+    let src = "struct D { v: i32 }
+    drop fn D(self) { @dbg(self.v); }
+    fn main() -> i32 {
+        let d = D { v: 7 };
+        @dbg(100);
+        0
+    }";
+    assert_eq!(run(src).stdout, "100\n7\n");
+}
+
+#[test]
+fn locals_drop_in_reverse_order() {
+    let src = "struct D { v: i32 }
+    drop fn D(self) { @dbg(self.v); }
+    fn main() -> i32 {
+        let a = D { v: 1 };
+        let b = D { v: 2 };
+        0
+    }";
+    // LIFO: b dropped before a.
+    assert_eq!(run(src).stdout, "2\n1\n");
+}
+
+#[test]
+fn destructor_then_field_drop_order() {
+    let src = "struct A { x: i32 }
+    struct O { a: A, b: i32 }
+    drop fn A(self) { @dbg(self.x); }
+    drop fn O(self) { @dbg(800); }
+    fn main() -> i32 {
+        let o = O { a: A { x: 5 }, b: 9 };
+        0
+    }";
+    // O's destructor first, then field `a`'s destructor (b is trivially droppable).
+    assert_eq!(run(src).stdout, "800\n5\n");
+}
+
+#[test]
+fn array_elements_drop_ascending() {
+    let src = "struct D { v: i32 }
+    drop fn D(self) { @dbg(self.v); }
+    fn main() -> i32 {
+        let xs = [D { v: 1 }, D { v: 2 }, D { v: 3 }];
+        0
+    }";
+    assert_eq!(run(src).stdout, "1\n2\n3\n");
+}
+
+#[test]
+fn moved_value_drops_once_at_destination() {
+    let src = "struct D { v: i32 }
+    drop fn D(self) { @dbg(self.v); }
+    fn sink(d: D) -> i32 { d.v }
+    fn main() -> i32 {
+        let d = D { v: 42 };
+        sink(d);
+        0
+    }";
+    // d is moved into sink; it drops exactly once, inside sink at its scope exit.
+    assert_eq!(run(src).stdout, "42\n");
+}
+
+#[test]
 fn string_still_unsupported() {
     // Strings (heap builtin) are a later slice; must report cleanly, not crash.
     let src = "fn main() -> i32 {


### PR DESCRIPTION
Fourth oracle slice — the memory-safety-relevant one. Executes the `Drop` instruction, running destructor glue in **spec-3.9 order**: the type's user destructor first, then its fields in declaration order / array elements ascending; scalars are trivially droppable.

Implemented as a **codegen-independent recursion over the type_pool** (not by calling the compiler's `__rue_drop_*` glue), so the oracle encodes the *spec's* drop order — a divergence localizes a codegen drop bug rather than mirroring it.

The oracle does **not** re-derive move analysis: the compiler's drop *elaboration* already placed the `Drop` instructions (suppressing moved values via drop flags lowered to ordinary branches), so executing exactly the drops the CFG contains gives drop-exactly-once for free — including moved values dropped at their destination.

**Verification:** 30-case corpus passes; differentially confirmed against the compiled binary — destructor-then-field 800/5, array-ascending 1/2/3, LIFO locals 2/1, moved-value-drops-once 42. Only strings remain of the core language. Purely additive.

Part of RUE-50

🤖 Generated with [Claude Code](https://claude.com/claude-code)