### PR TITLE
spec prose: state value-denotation, retire 'implicit return', fix stale front matter

### DIFF
--- a/docs/spec/src/01-introduction.md
+++ b/docs/spec/src/01-introduction.md
@@ -17,11 +17,14 @@ This document is the Rue Language Specification. It defines the syntax and seman
 This specification describes the Rue programming language as implemented by the reference compiler. It covers:
 
 - Lexical structure (tokens, comments, whitespace)
-- Types (integers, booleans, arrays, structs)
-- Expressions and operators
+- Types (integers, booleans, arrays, structs, enums, strings, move semantics, destructors)
+- Expressions and operators (including compile-time expressions)
 - Statements
-- Items (functions, struct definitions)
-- Runtime behavior
+- Items (functions, structs, enums, constants)
+- Arrays
+- Runtime behavior (overflow, bounds, panics)
+- Unchecked code and raw pointers
+- Modules and program composition
 
 {{ rule(id="1.2:2") }}
 
@@ -145,7 +148,8 @@ Grammar rules use Extended Backus-Naur Form (EBNF) notation:
 {{ rule(id="1.5:3") }}
 
 ```ebnf
-if_expr = "if" expression "{" block "}" [ "else" "{" block "}" ] ;
+if_expr     = "if" expression "{" block "}" [ else_clause ] ;
+else_clause = "else" ( "{" block "}" | if_expr ) ;
 ```
 
 ## Organization
@@ -155,12 +159,14 @@ if_expr = "if" expression "{" block "}" [ "else" "{" block "}" ] ;
 This specification is organized as follows:
 
 - **Chapter 2: Lexical Structure** - Tokens, comments, whitespace, keywords
-- **Chapter 3: Types** - Integer types, booleans, unit, never, arrays, structs
-- **Chapter 4: Expressions** - Operators, control flow, function calls
+- **Chapter 3: Types** - Integer types, booleans, unit, never, arrays, structs, enums, strings, move semantics, destructors
+- **Chapter 4: Expressions** - Operators, control flow, function calls, compile-time expressions
 - **Chapter 5: Statements** - Variable bindings, assignment
-- **Chapter 6: Items** - Functions, struct definitions
+- **Chapter 6: Items** - Functions, structs, enums, constants
 - **Chapter 7: Arrays** - Fixed-size array behavior
 - **Chapter 8: Runtime Behavior** - Overflow, bounds checking, panics
+- **Chapter 9: Unchecked Code** - Raw pointers and unchecked intrinsics
+- **Chapter 10: Modules** - Module forms, import resolution, visibility, program composition
 - **Appendix A: Grammar** - Complete EBNF grammar
 - **Appendix B: Runtime Panics** - Summary of panic conditions
 - **Appendix C: Implementation Limits** - Minimum limits for conforming implementations

--- a/docs/spec/src/03-types/03-unit-type.md
+++ b/docs/spec/src/03-types/03-unit-type.md
@@ -12,7 +12,7 @@ The unit type, written `()`, has exactly one value, also written `()`.
 
 {{ rule(id="3.3:2", cat="normative") }}
 
-Functions without an explicit return type annotation implicitly return `()`.
+A function without an explicit return type annotation has return type `()`; its body block evaluates to `()`, which is the value it returns (see 6.1:4).
 
 {{ rule(id="3.3:3", cat="normative") }}
 
@@ -26,11 +26,11 @@ The unit type is a zero-sized type. See [Zero-Sized Types](../#zero-sized-types)
 
 ```rue
 fn do_nothing() {
-    // Implicitly returns ()
+    // body has no final expression, so it evaluates to ()
 }
 
 fn explicit_unit() -> () {
-    // Explicitly returns ()
+    // returns (), stated explicitly in the signature
 }
 
 fn main() -> i32 {

--- a/docs/spec/src/04-expressions/05-block-expressions.md
+++ b/docs/spec/src/04-expressions/05-block-expressions.md
@@ -18,7 +18,7 @@ block_expr = "{" { statement } [ expression ] "}" ;
 
 {{ rule(id="4.5:3", cat="normative") }}
 
-The type of a block expression is the type of its final expression. If the block ends with a statement, the type is `()`.
+A block expression evaluates to the value of its final expression, and its type is the type of that expression. If the block has no final expression (it ends with a statement, or is empty), it evaluates to `()` and has type `()`.
 
 {{ rule(id="4.5:4", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/06-if-expressions.md
+++ b/docs/spec/src/04-expressions/06-if-expressions.md
@@ -40,7 +40,7 @@ fn main() -> i32 {
 
 {{ rule(id="4.6:7", cat="normative") }}
 
-If the condition evaluates to `true`, the then-branch is executed. Otherwise, the else-branch is executed (if present).
+If the condition evaluates to `true`, the then-branch is evaluated and the `if` expression evaluates to the then-branch's value; otherwise the else-branch (if present) is evaluated and the `if` expression evaluates to its value. When no else-branch is present, the `if` expression evaluates to `()`.
 
 {{ rule(id="4.6:8") }}
 

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -24,23 +24,23 @@ param = IDENT ":" type ;
 
 Parameters **MUST** have explicit type annotations.
 
-{{ rule(id="6.1:4", cat="legality-rule") }}
+{{ rule(id="6.1:4", cat="dynamic-semantics") }}
 
-If a return type is specified, the function body **MUST** produce a value of that type.
+A function call evaluates to the value the function's body block evaluates to (see 4.5). Reaching the end of the body is not a distinct "implicit return": the body is an expression, and the call's value *is* that expression's value.
 
 {{ rule(id="6.1:5", cat="normative") }}
 
-If no return type is specified, the function returns `()`.
+If a return type is specified, the body block **MUST** evaluate to a value of that type. If no return type is specified, the return type is `()`, and the body block evaluates to `()`.
 
 {{ rule(id="6.1:6", cat="normative") }}
 
 ```rue
 fn add(x: i32, y: i32) -> i32 {
-    x + y
+    x + y   // the body block evaluates to x + y, which is returned
 }
 
 fn do_nothing() {
-    // implicitly returns ()
+    // the body block has no final expression, so it evaluates to ()
 }
 ```
 


### PR DESCRIPTION
First prose-rewrite pass — executing the ratified formal core (`docs/formal`) into the human-facing spec. This retires the **'implicit return'** folk-term that started this whole workstream, by stating what each construct *evaluates to* (the value-denotation the prose systematically omitted):

- **4.5:3 (blocks):** a block *evaluates to the value of its final expression* (was: only its *type* was specified, never its value).
- **4.6:7 (if):** the `if` expression evaluates to the taken branch's value, or `()` with no else (was: only which branch "is executed").
- **6.1:4 (functions):** a call evaluates to the value its body block evaluates to — *"reaching the end of the body is not a distinct implicit return; the body is an expression, and the call's value IS that expression's value."* Recategorized to `dynamic-semantics`.
- **3.3:2 + example comments:** "implicitly return ()" → the body block evaluates to `()`.

Also fixes stale front matter the audit found: the intro **Scope (1.2)** and **Organization (1.6)** lists omitted chapters **9 (Unchecked Code)** and **10 (Modules)** entirely (and never mentioned enums/comptime); and the illustrative `if_expr` grammar (1.5:3) lacked `else if`, diverging from 4.6:2.

Docs only, no behavior change. Traceability **100% normative (585/585)**, dynamic-semantics 43/43; full `./test.sh` green (spec example programs unchanged — only comments/prose reworded).

Part of the `docs/formal` prose-rewrite workstream. The remaining structural decision (adding C-style *implementation-defined* / *undefined* conformance categories) is held for a maintainer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)