### PR TITLE
Harden the CallGeneric-reaching-CFG panic into an internal-error diagnostic (RUE-7)

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -8,7 +8,7 @@ use rue_air::{
     Air, AirArgMode, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef, AirProjection, AirRef,
     StructId, Type, TypeInternPool, TypeKind,
 };
-use rue_error::{CompileWarning, WarningKind};
+use rue_error::{CompileError, CompileWarning, ErrorKind, WarningKind};
 
 use crate::CfgOutput;
 use crate::inst::{
@@ -190,6 +190,12 @@ pub struct CfgBuilder<'a> {
     value_cache: Vec<Option<CfgValue>>,
     /// Warnings collected during CFG construction (e.g., unreachable code)
     warnings: Vec<CompileWarning>,
+    /// Internal-compiler-error diagnostics collected during CFG construction
+    /// (RUE-7). These signal malformed AIR that upstream passes should have
+    /// ruled out (e.g. an un-specialized `CallGeneric`); rather than panicking
+    /// deep in lowering, we record a clean ICE here and let the driver abort
+    /// with a proper diagnostic (exit 1) instead of a process abort.
+    errors: Vec<CompileError>,
     /// Stack of scopes for drop elaboration.
     /// Each scope contains the slots that became live in that scope.
     /// Used to emit StorageDead (and Drop if needed) at scope exit.
@@ -261,6 +267,7 @@ impl<'a> CfgBuilder<'a> {
             loop_stack: Vec::new(),
             value_cache: vec![None; air.len()],
             warnings: Vec::new(),
+            errors: Vec::new(),
             scope_stack: vec![Vec::new()], // Start with one scope for the function body
             drop_flags: std::collections::HashMap::new(),
             field_drop_flags: std::collections::HashMap::new(),
@@ -326,6 +333,7 @@ impl<'a> CfgBuilder<'a> {
         CfgOutput {
             cfg: builder.cfg,
             warnings: builder.warnings,
+            errors: builder.errors,
         }
     }
 
@@ -399,16 +407,33 @@ impl<'a> CfgBuilder<'a> {
             }
 
             AirInstData::CallGeneric { .. } => {
-                // CallGeneric instructions must be specialized (rewritten to Call)
-                // before CFG building. If we reach here, specialization didn't run.
+                // CallGeneric instructions must be specialized (rewritten to a
+                // regular Call) by the specialization pass (see specialize.rs)
+                // before CFG building. Reaching here means specialization left a
+                // generic call behind — malformed AIR, i.e. a compiler bug.
                 //
-                // TODO(ICE): This should be converted to:
-                //   return Err(ice_error!("CallGeneric not specialized", phase: "cfg_builder"));
-                // But that requires refactoring build() to return CompileResult.
-                panic!(
-                    "CallGeneric instruction reached CFG building - this is a compiler bug. \
-                     CallGeneric must be specialized to regular Call before codegen."
-                );
+                // RUE-7: rather than panicking (a process abort deep in
+                // lowering), record a clean internal-compiler-error diagnostic
+                // on the error channel. The driver checks `CfgOutput.errors`
+                // and aborts with a proper ICE (exit 1, carrying this span)
+                // before optimizing or lowering the CFG further. We still emit a
+                // placeholder value so lowering can finish without cascading
+                // panics; the resulting CFG is discarded once the error surfaces.
+                self.errors.push(CompileError::new(
+                    ErrorKind::InternalError(
+                        "CallGeneric instruction reached CFG building; it must be \
+                         specialized to a regular Call before codegen (phase: \
+                         cfg_builder). This is a compiler bug."
+                            .to_string(),
+                    ),
+                    span,
+                ));
+                let value = self.emit(CfgInstData::Const(0), ty, span);
+                self.cache(air_ref, value);
+                ExprResult {
+                    value: Some(value),
+                    continuation: Continuation::Continues,
+                }
             }
 
             AirInstData::Param { index } => {
@@ -3596,5 +3621,59 @@ mod tests {
             "field a's exit drop must be guarded by a flag test"
         );
         assert_all_blocks_terminated(&main_cfg);
+    }
+
+    #[test]
+    fn callgeneric_reaching_cfg_is_internal_error_not_panic() {
+        // RUE-7: an un-specialized `CallGeneric` that survives to CFG building
+        // is malformed AIR (the specialization pass should have rewritten it to
+        // a regular `Call`). The builder must record a clean
+        // internal-compiler-error diagnostic on the error channel rather than
+        // panicking / aborting the process.
+        use rue_air::{Air, AirInst};
+        use rue_span::Span;
+
+        let interner = ThreadedRodeo::default();
+        let name = interner.get_or_intern("generic_fn");
+        let type_pool = TypeInternPool::new();
+
+        let mut air = Air::new(Type::I32);
+        let call = air.add_inst(AirInst {
+            data: AirInstData::CallGeneric {
+                name,
+                type_args_start: 0,
+                type_args_len: 0,
+                value_args_start: 0,
+                value_args_len: 0,
+                args_start: 0,
+                args_len: 0,
+            },
+            ty: Type::I32,
+            span: Span::new(0, 1),
+        });
+        // The root (last instruction) must be a Ret so `build` starts lowering
+        // from it and reaches the CallGeneric operand.
+        air.add_inst(AirInst {
+            data: AirInstData::Ret(Some(call)),
+            ty: Type::I32,
+            span: Span::new(0, 1),
+        });
+
+        let output = CfgBuilder::build(&air, 0, 0, "generic_fn", &type_pool, vec![], &interner);
+
+        assert!(
+            !output.errors.is_empty(),
+            "CallGeneric at CFG build time must record an internal-compiler-error \
+             diagnostic instead of panicking"
+        );
+        let msg = output.errors[0].to_string();
+        assert!(
+            msg.contains("internal compiler error"),
+            "diagnostic should be an ICE, got: {msg}"
+        );
+        assert!(
+            msg.contains("CallGeneric"),
+            "diagnostic should mention CallGeneric, got: {msg}"
+        );
     }
 }

--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -20,7 +20,7 @@ mod build;
 mod inst;
 pub mod opt;
 
-use rue_error::CompileWarning;
+use rue_error::{CompileError, CompileWarning};
 
 pub use build::CfgBuilder;
 pub use inst::{
@@ -41,4 +41,10 @@ pub struct CfgOutput {
     pub cfg: Cfg,
     /// Warnings detected during CFG construction.
     pub warnings: Vec<CompileWarning>,
+    /// Internal-compiler-error diagnostics detected during CFG construction
+    /// (RUE-7). Non-empty only for malformed AIR that upstream passes should
+    /// have ruled out (e.g. an un-specialized `CallGeneric`). The driver must
+    /// treat a non-empty `errors` as a hard failure and abort before
+    /// optimizing or lowering the (now-discarded) CFG.
+    pub errors: Vec<CompileError>,
 }

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -913,37 +913,50 @@ pub fn compile_frontend_from_ast_with_file_paths(
         let _span = info_span!("cfg_construction").entered();
 
         // Build CFGs in parallel - each function is independent
-        let results: Vec<(FunctionWithCfg, Vec<CompileWarning>)> = all_functions
-            .into_par_iter()
-            .map(|func| {
-                let cfg_output = CfgBuilder::build(
-                    &func.air,
-                    func.num_locals,
-                    func.num_param_slots,
-                    &func.name,
-                    &sema_output.type_pool,
-                    func.param_modes.clone(),
-                    &interner,
-                );
+        let results: Vec<Result<(FunctionWithCfg, Vec<CompileWarning>), CompileErrors>> =
+            all_functions
+                .into_par_iter()
+                .map(|func| {
+                    let cfg_output = CfgBuilder::build(
+                        &func.air,
+                        func.num_locals,
+                        func.num_param_slots,
+                        &func.name,
+                        &sema_output.type_pool,
+                        func.param_modes.clone(),
+                        &interner,
+                    );
 
-                // Apply optimizations to the CFG
-                let mut cfg = cfg_output.cfg;
-                rue_cfg::opt::optimize(&mut cfg, opt_level);
+                    // A non-empty `errors` means the CFG builder hit malformed
+                    // AIR (an internal compiler error, RUE-7). Abort before
+                    // optimizing the discarded CFG rather than working on it.
+                    if !cfg_output.errors.is_empty() {
+                        let mut errs = CompileErrors::new();
+                        for e in cfg_output.errors {
+                            errs.push(e);
+                        }
+                        return Err(errs);
+                    }
 
-                (
-                    FunctionWithCfg {
-                        analyzed: func,
-                        cfg,
-                    },
-                    cfg_output.warnings,
-                )
-            })
-            .collect();
+                    // Apply optimizations to the CFG
+                    let mut cfg = cfg_output.cfg;
+                    rue_cfg::opt::optimize(&mut cfg, opt_level);
+
+                    Ok((
+                        FunctionWithCfg {
+                            analyzed: func,
+                            cfg,
+                        },
+                        cfg_output.warnings,
+                    ))
+                })
+                .collect();
 
         // Unzip the results and collect all warnings
         let mut functions = Vec::with_capacity(results.len());
         let mut warnings = sema_output.warnings;
-        for (func, func_warnings) in results {
+        for result in results {
+            let (func, func_warnings) = result?;
             functions.push(func);
             warnings.extend(func_warnings);
         }
@@ -1039,37 +1052,50 @@ pub fn compile_frontend_from_rir_with_file_paths(
         let _span = info_span!("cfg_construction").entered();
 
         // Build CFGs in parallel - each function is independent
-        let results: Vec<(FunctionWithCfg, Vec<CompileWarning>)> = all_functions
-            .into_par_iter()
-            .map(|func| {
-                let cfg_output = CfgBuilder::build(
-                    &func.air,
-                    func.num_locals,
-                    func.num_param_slots,
-                    &func.name,
-                    &sema_output.type_pool,
-                    func.param_modes.clone(),
-                    &interner,
-                );
+        let results: Vec<Result<(FunctionWithCfg, Vec<CompileWarning>), CompileErrors>> =
+            all_functions
+                .into_par_iter()
+                .map(|func| {
+                    let cfg_output = CfgBuilder::build(
+                        &func.air,
+                        func.num_locals,
+                        func.num_param_slots,
+                        &func.name,
+                        &sema_output.type_pool,
+                        func.param_modes.clone(),
+                        &interner,
+                    );
 
-                // Apply optimizations to the CFG
-                let mut cfg = cfg_output.cfg;
-                rue_cfg::opt::optimize(&mut cfg, opt_level);
+                    // A non-empty `errors` means the CFG builder hit malformed
+                    // AIR (an internal compiler error, RUE-7). Abort before
+                    // optimizing the discarded CFG rather than working on it.
+                    if !cfg_output.errors.is_empty() {
+                        let mut errs = CompileErrors::new();
+                        for e in cfg_output.errors {
+                            errs.push(e);
+                        }
+                        return Err(errs);
+                    }
 
-                (
-                    FunctionWithCfg {
-                        analyzed: func,
-                        cfg,
-                    },
-                    cfg_output.warnings,
-                )
-            })
-            .collect();
+                    // Apply optimizations to the CFG
+                    let mut cfg = cfg_output.cfg;
+                    rue_cfg::opt::optimize(&mut cfg, opt_level);
+
+                    Ok((
+                        FunctionWithCfg {
+                            analyzed: func,
+                            cfg,
+                        },
+                        cfg_output.warnings,
+                    ))
+                })
+                .collect();
 
         // Unzip the results and collect all warnings
         let mut functions = Vec::with_capacity(results.len());
         let mut warnings = sema_output.warnings;
-        for (func, func_warnings) in results {
+        for result in results {
+            let (func, func_warnings) = result?;
             functions.push(func);
             warnings.extend(func_warnings);
         }

--- a/crates/rue-compiler/src/unit.rs
+++ b/crates/rue-compiler/src/unit.rs
@@ -289,7 +289,7 @@ impl<'src> CompilationUnit<'src> {
             .collect();
 
         // Build CFGs in parallel
-        let (functions, cfg_warnings) = self.build_cfgs(all_functions, &sema_output.type_pool);
+        let (functions, cfg_warnings) = self.build_cfgs(all_functions, &sema_output.type_pool)?;
 
         self.functions = Some(functions);
         self.type_pool = Some(sema_output.type_pool);
@@ -305,13 +305,13 @@ impl<'src> CompilationUnit<'src> {
         &self,
         functions: Vec<AnalyzedFunction>,
         type_pool: &TypeInternPool,
-    ) -> (Vec<FunctionWithCfg>, Vec<CompileWarning>) {
+    ) -> MultiErrorResult<(Vec<FunctionWithCfg>, Vec<CompileWarning>)> {
         let interner = self.interner.as_ref().expect("interner not initialized");
         let opt_level = self.options.opt_level;
 
         let _span = info_span!("cfg_construction").entered();
 
-        let results: Vec<(FunctionWithCfg, Vec<CompileWarning>)> = functions
+        let results: Vec<Result<(FunctionWithCfg, Vec<CompileWarning>), CompileErrors>> = functions
             .into_par_iter()
             .map(|func| {
                 let cfg_output = CfgBuilder::build(
@@ -324,23 +324,35 @@ impl<'src> CompilationUnit<'src> {
                     interner,
                 );
 
+                // A non-empty `errors` means the CFG builder hit malformed AIR
+                // (an internal compiler error, RUE-7). Abort before optimizing
+                // the discarded CFG rather than working on it.
+                if !cfg_output.errors.is_empty() {
+                    let mut errs = CompileErrors::new();
+                    for e in cfg_output.errors {
+                        errs.push(e);
+                    }
+                    return Err(errs);
+                }
+
                 // Apply optimizations
                 let mut cfg = cfg_output.cfg;
                 rue_cfg::opt::optimize(&mut cfg, opt_level);
 
-                (
+                Ok((
                     FunctionWithCfg {
                         analyzed: func,
                         cfg,
                     },
                     cfg_output.warnings,
-                )
+                ))
             })
             .collect();
 
         let mut functions = Vec::with_capacity(results.len());
         let mut warnings = Vec::new();
-        for (func, func_warnings) in results {
+        for result in results {
+            let (func, func_warnings) = result?;
             functions.push(func);
             warnings.extend(func_warnings);
         }
@@ -350,7 +362,7 @@ impl<'src> CompilationUnit<'src> {
             "CFG construction complete"
         );
 
-        (functions, warnings)
+        Ok((functions, warnings))
     }
 
     // =========================================================================


### PR DESCRIPTION
A `CallGeneric` that survives specialization and reaches CFG building used to `panic!` (process abort). It now records an `ErrorKind::InternalError` (E9000) diagnostic with a span on a new `CfgOutput.errors` channel; all three CFG-build call sites check that channel and abort cleanly (exit 1) before optimizing the discarded CFG. This flows through the normal error path (testable, spanned) rather than relying on the RUE-130 panic hook. Unit test added.

**Scope — the other two sites RUE-7 named were refuted, and that's the right call:** `generate.rs`'s panics are all inside `#[cfg(test)]` (a stale reference); `intern_pool.rs`'s "unexpected TypeKind" panics are unreachable invariant checks in `-> T` accessors (verified: `[M;3]`/array-of-type/fn-as-value are all rejected by sema with E0704/E0206/E0201 before interning), and converting them needs a cross-cutting `Result` refactor of the type-pool API that overlaps RUE-52.

Verified: rue-cfg (55) + rue-compiler (190) tests pass; full `./test.sh` green, 100% normative traceability.

Fixes RUE-7

🤖 Generated with [Claude Code](https://claude.com/claude-code)