### PR TITLE
Enforce the no-silent-<error> invariant; fix empty-array error decay (RUE-153)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -45,12 +45,65 @@ use crate::types::{ModuleId, StructField, StructId, Type, TypeKind};
 pub(crate) fn analyze_all_function_bodies(mut sema: Sema<'_>) -> MultiErrorResult<SemaOutput> {
     // Use lazy analysis when imports are present (multi-file compilation)
     // This ensures only reachable code is analyzed, per ADR-0026
-    if sema.has_imports() {
+    let result = if sema.has_imports() {
         analyze_function_bodies_lazy(&mut sema)
     } else {
         // Use eager analysis for single-file compilation (backwards compatibility)
         analyze_all_function_bodies_sequential(&mut sema)
+    };
+
+    // Sema→CFG boundary invariant (RUE-153): a value may only carry the
+    // `<error>` type as part of error recovery, i.e. when at least one
+    // diagnostic has already been emitted. If analysis reports `Ok` (no
+    // errors) yet some AIR value is still `<error>`-typed, an inference
+    // variable decayed to `<error>` on a path that forgot to emit its
+    // diagnostic (the RUE-149 class). That value would otherwise reach
+    // codegen and hit an `unreachable!()`; convert it into an actionable
+    // internal-error diagnostic (E9000) here instead.
+    if let Ok(output) = &result {
+        if let Some(err) = find_undiagnosed_error_type(output) {
+            return Err(CompileErrors::from(err));
+        }
     }
+
+    result
+}
+
+/// Scan analyzed AIR for an `<error>`-typed value that survived analysis with
+/// no diagnostic emitted (see the invariant in `analyze_all_function_bodies`).
+///
+/// Returns the first offending instruction as an internal-error `CompileError`
+/// (E9000), or `None` when every value is well-typed. Only called on the
+/// success (`Ok`) path, so any `<error>` found here is by definition
+/// undiagnosed and indicates a compiler bug.
+fn find_undiagnosed_error_type(output: &SemaOutput) -> Option<CompileError> {
+    for func in &output.functions {
+        if func.air.return_type().is_error() {
+            return Some(CompileError::without_span(ErrorKind::InternalError(
+                format!(
+                    "function '{}' has an <error> return type but no diagnostic was \
+                 emitted; an inference variable decayed to <error> without \
+                 reporting an error (RUE-153)",
+                    func.name
+                ),
+            )));
+        }
+        for (_air_ref, inst) in func.air.iter() {
+            if inst.ty.is_error() {
+                return Some(CompileError::new(
+                    ErrorKind::InternalError(format!(
+                        "an <error>-typed value reached the end of semantic \
+                         analysis in function '{}' but no diagnostic was \
+                         emitted; an inference variable decayed to <error> \
+                         without reporting an error (RUE-153)",
+                        func.name
+                    )),
+                    inst.span,
+                ));
+            }
+        }
+    }
+    None
 }
 
 /// Sequential analysis path (current implementation).
@@ -5888,5 +5941,68 @@ impl<'a> Sema<'a> {
             span,
         });
         Ok(AnalysisResult::new(air_ref, result_type))
+    }
+}
+
+#[cfg(test)]
+mod error_invariant_tests {
+    use super::*;
+    use crate::inst::Air;
+    use crate::intern_pool::TypeInternPool;
+
+    fn output_with(func: AnalyzedFunction) -> SemaOutput {
+        SemaOutput {
+            functions: vec![func],
+            strings: Vec::new(),
+            warnings: Vec::new(),
+            type_pool: TypeInternPool::new(),
+        }
+    }
+
+    fn func_named(name: &str, air: Air) -> AnalyzedFunction {
+        AnalyzedFunction {
+            name: name.to_string(),
+            air,
+            num_locals: 0,
+            num_param_slots: 0,
+            param_modes: Vec::new(),
+        }
+    }
+
+    /// A well-typed function must not trip the sema→CFG error invariant.
+    #[test]
+    fn no_error_type_is_clean() {
+        let mut air = Air::new(Type::I32);
+        air.add_inst(AirInst {
+            data: AirInstData::Const(0),
+            ty: Type::I32,
+            span: Span::new(0, 0),
+        });
+        let output = output_with(func_named("main", air));
+        assert!(find_undiagnosed_error_type(&output).is_none());
+    }
+
+    /// An `<error>`-typed instruction on the success path is a compiler bug and
+    /// must be reported as an internal error (RUE-153).
+    #[test]
+    fn error_typed_instruction_is_caught() {
+        let mut air = Air::new(Type::I32);
+        air.add_inst(AirInst {
+            data: AirInstData::UnitConst,
+            ty: Type::ERROR,
+            span: Span::new(0, 0),
+        });
+        let output = output_with(func_named("main", air));
+        let err = find_undiagnosed_error_type(&output).expect("error type must be caught");
+        assert!(matches!(err.kind, ErrorKind::InternalError(_)));
+    }
+
+    /// An `<error>` return type is likewise a bug and must be caught.
+    #[test]
+    fn error_return_type_is_caught() {
+        let air = Air::new(Type::ERROR);
+        let output = output_with(func_named("f", air));
+        let err = find_undiagnosed_error_type(&output).expect("error return type must be caught");
+        assert!(matches!(err.kind, ErrorKind::InternalError(_)));
     }
 }

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3224,15 +3224,16 @@ impl<'a> Sema<'a> {
             for elem_ref in &elem_refs {
                 self.analyze_inst(air, *elem_ref, ctx)?;
             }
-            // Elements analyzed without surfacing an error yet the array type
-            // is still `<error>`: a diagnostic was already emitted upstream.
-            // Propagate an error-typed placeholder rather than emitting an ICE.
-            let air_ref = air.add_inst(AirInst {
-                data: AirInstData::UnitConst,
-                ty: Type::ERROR,
-                span,
-            });
-            return Ok(AnalysisResult::new(air_ref, Type::ERROR));
+            // Analyzing the elements did not surface a diagnostic, yet the
+            // array's type is still `<error>`. This is the empty-array (`[]`)
+            // and unconstrained-element (`[[]]`) case: HM inference had no
+            // constraint to fix the element type, so the element type variable
+            // decayed to `<error>` with no diagnostic of its own (RUE-153).
+            // The precise, actionable error is that the element type cannot be
+            // inferred — emit "type annotation required for empty array"
+            // (E0903) rather than returning a silent `<error>`-typed value that
+            // would sail into codegen.
+            return Err(CompileError::new(ErrorKind::TypeAnnotationRequired, span));
         }
 
         let (_array_type_id, _elem_type, expected_len) = match array_type.as_array() {

--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -298,3 +298,51 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["E0482"]
+
+[[case]]
+name = "empty_array_unconstrained_let_rue153"
+description = "RUE-153: an unannotated empty array `let x = []` left the element type variable unbound; it decayed to <error> with no diagnostic and sailed into codegen. Now a clean E0903."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x = [];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0903"]
+
+[[case]]
+name = "nested_empty_array_unconstrained_rue153"
+description = "RUE-153: a nested unconstrained empty array `[[]]` decayed to <error> with no diagnostic. Now a clean E0903."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x = [[]];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0903"]
+
+[[case]]
+name = "neg_of_empty_array_rue153"
+description = "RUE-153: negating an unconstrained empty array `-([])` produced an <error>-typed value with no diagnostic. Now a clean E0903."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x = -([]);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0903"]
+
+[[case]]
+name = "dbg_empty_array_rue153"
+description = "RUE-153: @dbg([]) with an unconstrained empty array must surface the actionable element-type error, not an E9000 ICE."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @dbg([]);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0903"]


### PR DESCRIPTION
Two parts, both verified by execution:

1. **Live bug fixed:** an unannotated/unconstrained empty array literal (`let x = []`, `[[]]`, `-([])`) decayed to `<error>` in `infer_type_to_type` with **no diagnostic** and reached codegen (`--emit air` showed `%0 : <error>`). Root cause: `analyze_array_init`'s `is_error()` recovery branch (added for RUE-190) assumed a diagnostic had already been emitted upstream — false for empty arrays. It now emits **E0903** (`TypeAnnotationRequired`) after checking elements, so RUE-190's element errors still surface first.

2. **Defensive invariant (the RUE-153 ask):** `analyze_all_function_bodies` now scans analyzed AIR on the zero-errors path; any `<error>`-typed value or return type with no diagnostic emitted is an undiagnosed decay → reported as an internal error (**E9000**) instead of reaching codegen's `unreachable!()`. Mirrors the RUE-7 CallGeneric hardening.

Verified: `let x = []` → E0903 (clean, exit 1, no panic); `[i32;0]=[]` → exit 0; `[String::nope()]` → E0412; `[1,true]` → E0206; RUE-149 `@dbg(-(3-4))` → 1; all intact. Full `./test.sh` green, 100% normative traceability. 4 CLI regression cases + 3 unit tests.

Fixes RUE-153

🤖 Generated with [Claude Code](https://claude.com/claude-code)