### PR TITLE
Document field-order-independent struct init; retire dead E0422 (RUE-9)

### DIFF
--- a/crates/rue-cli-tests/cases/struct_field_order.toml
+++ b/crates/rue-cli-tests/cases/struct_field_order.toml
@@ -1,0 +1,118 @@
+# Field-order-independent struct initialization (RUE-9).
+#
+# Struct-literal fields may be written in any order; each initializer is
+# matched to its declared field by name and stored in the slot determined by
+# declaration order (spec 3.6:15, 3.6:16). Initializers are still evaluated
+# left-to-right in source order (spec 4.0:9), so a field written earlier runs
+# earlier even when it occupies a later slot. These cases pin both the storage
+# layout (via exit code / field reads) and the observable evaluation order
+# (via @dbg stdout) end-to-end through the real driver.
+
+[section]
+id = "cli.struct_field_order"
+name = "Field-order-independent struct init"
+description = "Struct literals accept fields in any order, matched by name, stored in declaration order."
+
+[[case]]
+name = "out_of_order_stored_by_name"
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    // Written y first, then x; matched by name.
+    let p = Point { y: 20, x: 10 };
+    // x must be in slot 0 (10), y in slot 1 (20): 10 - 20 + 42 = 32.
+    p.x - p.y + 42
+}
+""" }]
+exit_code = 32
+
+[[case]]
+name = "out_of_order_dbg_value"
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { y: 20, x: 10 };
+    @dbg(p.x);
+    @dbg(p.y);
+    0
+}
+""" }]
+stdout = "10\n20\n"
+
+[[case]]
+name = "three_fields_shuffled"
+files = [{ path = "main.rue", source = """
+struct Rec { a: i32, b: i32, c: i32 }
+
+fn main() -> i32 {
+    let r = Rec { c: 3, a: 1, b: 2 };
+    @dbg(r.a);
+    @dbg(r.b);
+    @dbg(r.c);
+    0
+}
+""" }]
+stdout = "1\n2\n3\n"
+
+[[case]]
+name = "source_order_eval_but_name_storage"
+files = [{ path = "main.rue", source = """
+fn side_effect(val: i32) -> i32 {
+    @dbg(val);
+    val
+}
+
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    // Written y first (side_effect(2)), then x (side_effect(1)).
+    // Source-order evaluation => prints 2 then 1.
+    // Stored by name => x holds 1, y holds 2.
+    let p = Point { y: side_effect(2), x: side_effect(1) };
+    @dbg(p.x);
+    @dbg(p.y);
+    0
+}
+""" }]
+stdout = "2\n1\n1\n2\n"
+
+[[case]]
+name = "duplicate_field_out_of_order_rejected"
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { y: 2, y: 3, x: 1 };
+    p.x
+}
+""" }]
+compile_fail = true
+error_contains = ["E0402", "duplicate field"]
+
+[[case]]
+name = "unknown_field_out_of_order_rejected"
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { y: 2, z: 9 };
+    p.x
+}
+""" }]
+compile_fail = true
+error_contains = ["E0401", "unknown field"]
+
+[[case]]
+name = "missing_field_out_of_order_rejected"
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { y: 2 };
+    p.y
+}
+""" }]
+compile_fail = true
+error_contains = ["E0400", "missing field"]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -124,7 +124,9 @@ impl ErrorCode {
     pub const DUPLICATE_VARIANT: Self = Self(419);
     pub const UNKNOWN_VARIANT: Self = Self(420);
     pub const UNKNOWN_ENUM_TYPE: Self = Self(421);
-    pub const FIELD_WRONG_ORDER: Self = Self(422);
+    // 422 (FIELD_WRONG_ORDER) is retired: struct-literal fields may now be
+    // given in any order, matched to declared fields by name (RUE-9). Do not
+    // reuse the number.
     pub const FIELD_ACCESS_ON_NON_STRUCT: Self = Self(423);
     pub const INVALID_ASSIGNMENT_TARGET: Self = Self(424);
     pub const INOUT_NON_LVALUE: Self = Self(425);
@@ -287,8 +289,8 @@ impl fmt::Display for ErrorCode {
 //
 // As of 2026-01-11:
 // - ErrorKind size: 56 bytes
-// - Boxed variants: 4 (MissingFields, CopyStructNonCopyField,
-//   IntrinsicTypeMismatch, FieldWrongOrder)
+// - Boxed variants: 3 (MissingFields, CopyStructNonCopyField,
+//   IntrinsicTypeMismatch)
 // - All boxed variants contain 3+ Strings or String + Vec
 // - Policy is consistently applied
 
@@ -321,14 +323,6 @@ pub struct IntrinsicTypeMismatchError {
     pub name: String,
     pub expected: String,
     pub found: String,
-}
-
-/// Payload for `ErrorKind::FieldWrongOrder`.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct FieldWrongOrderError {
-    pub struct_name: String,
-    pub expected_field: String,
-    pub found_field: String,
 }
 
 // ============================================================================
@@ -1053,8 +1047,6 @@ pub enum ErrorKind {
     },
     #[error("unknown enum type '{0}'")]
     UnknownEnumType(String),
-    #[error("struct '{struct_name}' fields must be initialized in declaration order: expected '{expected_field}', found '{found_field}'", struct_name = .0.struct_name, expected_field = .0.expected_field, found_field = .0.found_field)]
-    FieldWrongOrder(Box<FieldWrongOrderError>),
     #[error("field access on non-struct type '{found}'")]
     FieldAccessOnNonStruct { found: String },
     #[error("invalid assignment target")]
@@ -1303,7 +1295,6 @@ impl ErrorKind {
             ErrorKind::DuplicateVariant { .. } => ErrorCode::DUPLICATE_VARIANT,
             ErrorKind::UnknownVariant { .. } => ErrorCode::UNKNOWN_VARIANT,
             ErrorKind::UnknownEnumType(_) => ErrorCode::UNKNOWN_ENUM_TYPE,
-            ErrorKind::FieldWrongOrder(_) => ErrorCode::FIELD_WRONG_ORDER,
             ErrorKind::FieldAccessOnNonStruct { .. } => ErrorCode::FIELD_ACCESS_ON_NON_STRUCT,
             ErrorKind::InvalidAssignmentTarget => ErrorCode::INVALID_ASSIGNMENT_TARGET,
             ErrorKind::InoutNonLvalue => ErrorCode::INOUT_NON_LVALUE,
@@ -2555,10 +2546,6 @@ mod tests {
         println!(
             "IntrinsicTypeMismatchError: {} bytes",
             size_of::<IntrinsicTypeMismatchError>()
-        );
-        println!(
-            "FieldWrongOrderError: {} bytes",
-            size_of::<FieldWrongOrderError>()
         );
     }
 }

--- a/crates/rue-spec/cases/types/structs.toml
+++ b/crates/rue-spec/cases/types/structs.toml
@@ -261,3 +261,96 @@ fn main() -> i32 {
 """
 exit_code = 0
 
+
+# =============================================================================
+# Struct Literals: field order independence (RUE-9)
+# =============================================================================
+
+[[case]]
+name = "struct_init_any_order"
+spec = ["3.6:15"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    // Fields written out of declaration order, matched by name.
+    // x stored in slot 0 (10), y in slot 1 (20): 10 - 20 + 42 = 32.
+    let p = Point { y: 20, x: 10 };
+    p.x - p.y + 42
+}
+"""
+exit_code = 32
+
+[[case]]
+name = "struct_init_any_order_three_fields"
+spec = ["3.6:15"]
+source = """
+struct Rec { a: i32, b: i32, c: i32 }
+fn main() -> i32 {
+    let r = Rec { c: 3, a: 1, b: 2 };
+    r.a * 100 + r.b * 10 + r.c  // 123
+}
+"""
+exit_code = 123
+
+[[case]]
+name = "struct_init_out_of_order_duplicate_error"
+spec = ["3.6:15"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { y: 2, y: 3, x: 1 };
+    p.x
+}
+"""
+compile_fail = true
+error_contains = "duplicate field"
+
+[[case]]
+name = "struct_init_out_of_order_unknown_error"
+spec = ["3.6:15"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { y: 2, z: 9 };
+    p.x
+}
+"""
+compile_fail = true
+error_contains = "unknown field"
+
+[[case]]
+name = "struct_init_out_of_order_missing_error"
+spec = ["3.6:15"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { y: 2 };
+    p.y
+}
+"""
+compile_fail = true
+error_contains = "missing field"
+
+[[case]]
+name = "struct_init_source_order_stored_by_name"
+spec = ["3.6:16"]
+source = """
+fn side_effect(val: i32) -> i32 {
+    @dbg(val);
+    val
+}
+
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    // Written y first, then x: evaluated in SOURCE order (prints 2 then 1),
+    // but stored by name (x in slot 0, y in slot 1).
+    let p = Point { y: side_effect(2), x: side_effect(1) };
+    p.x * 100 + p.y  // 102
+}
+"""
+exit_code = 102
+expected_stdout = """
+2
+1
+"""

--- a/docs/spec/src/03-types/06-struct-types.md
+++ b/docs/spec/src/03-types/06-struct-types.md
@@ -93,3 +93,25 @@ fn main() -> i32 {
     @size_of(Empty)  // 0
 }
 ```
+
+## Struct Literals
+
+{{ rule(id="3.6:15", cat="normative") }}
+
+In a struct literal, field initializers may appear in any order. Each initializer is matched to a declared field by name; the order in which fields are written need not match the declaration order. Providing the same field more than once, omitting a field, or naming a field the struct does not declare are all errors (see 3.6:5, 3.6:6).
+
+{{ rule(id="3.6:16", cat="dynamic-semantics") }}
+
+Regardless of the order in which fields are written, the resulting value stores each field in the slot determined by declaration order (3.6:9). Field initializer expressions are still evaluated in source order (left-to-right as written; see 4.0:9), so a field written earlier is evaluated earlier even when it occupies a later slot.
+
+{{ rule(id="3.6:17") }}
+
+```rue
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    // Fields given out of declaration order; matched by name.
+    let p = Point { y: 20, x: 10 };
+    p.x - p.y  // -10, i.e. 10 - 20
+}
+```


### PR DESCRIPTION
RUE-9 turned out **already-implemented**: sema's `analyze_struct_init` already name-matches struct-literal fields, builds the aggregate in declaration order, and evaluates initializers in source order. Out-of-order init (`Point { y: 2, x: 1 }`) compiles and stores correctly; the `E0422 FieldWrongOrder` code was **dead** (defined in rue-error, never constructed).

This PR makes the working behavior explicit and removes the dead code:
- Removed the dead E0422 path (code 422 retired with a 'do not reuse' comment).
- Added spec rules **3.6:15/3.6:16** + example: struct-literal fields may appear in any order (matched by name), stored in declaration order, initializers evaluated in source order.
- Added 6 spec cases + a 7-case CLI file `struct_field_order.toml`.

Verified by execution: `Point { y: 2, x: 1 }` → x=1,y=2 (exit 12); guards intact (dup→E0402, missing→E0400, unknown→E0401); side-effect ordering is source-order-eval with name-storage. Full `./test.sh` green, 100% normative (430/430); aarch64 `--emit asm` confirms declaration-order slots.

Fixes RUE-9

🤖 Generated with [Claude Code](https://claude.com/claude-code)