### PR TITLE
Unary negation requires a signed integer operand (RUE-200)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1991,7 +1991,7 @@ impl<'a> Sema<'a> {
                     found: format!("{var} = {ty} (infinite type)"),
                 },
                 UnifyResult::NotSigned { ty } => {
-                    ErrorKind::CannotNegateUnsigned(ty.safe_name_with_pool(Some(&self.type_pool)))
+                    ErrorKind::CannotNegate(ty.safe_name_with_pool(Some(&self.type_pool)))
                 }
                 UnifyResult::NotInteger { ty } => ErrorKind::TypeMismatch {
                     expected: "integer type".to_string(),

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -423,15 +423,21 @@ impl<'a> Sema<'a> {
                 // Get the resolved type from HM inference
                 let ty = Self::get_resolved_type(ctx, inst_ref, inst.span, "negation operator")?;
 
-                // Check if trying to negate an unsigned type.
-                if ty.is_unsigned() {
+                // Unary `-` requires a signed integer operand (i8/i16/i32/i64/
+                // isize). Reject unsigned integers (no negative range), bool, and
+                // every other non-signed type. `<error>`/`never` pass through so a
+                // prior error isn't masked by a spurious second diagnostic.
+                if !ty.is_signed() && !ty.is_error() && !ty.is_never() {
+                    let note = if ty.is_unsigned() {
+                        "unsigned values cannot be negated"
+                    } else {
+                        "unary `-` requires a signed integer operand (i8, i16, i32, i64, isize)"
+                    };
                     return Err(CompileError::new(
-                        ErrorKind::CannotNegateUnsigned(
-                            ty.safe_name_with_pool(Some(&self.type_pool)),
-                        ),
+                        ErrorKind::CannotNegate(ty.safe_name_with_pool(Some(&self.type_pool))),
                         inst.span,
                     )
-                    .with_note("unsigned values cannot be negated"));
+                    .with_note(note));
                 }
 
                 // Special case: negating a literal that equals |MIN| for signed types.
@@ -979,7 +985,7 @@ impl<'a> Sema<'a> {
     ///
     /// Mirrors the `let`-binding literal checks (RUE-74): out-of-range
     /// literals are E0800 (`LiteralOutOfRange`) and negative literals on
-    /// unsigned scrutinees are E0801 (`CannotNegateUnsigned`) instead of
+    /// unsigned scrutinees are E0801 (`CannotNegate`) instead of
     /// silently wrapping into a different (or unmatchable) value.
     fn check_pattern_int(
         &self,
@@ -992,7 +998,7 @@ impl<'a> Sema<'a> {
         if negative {
             if scrutinee_type.is_unsigned() {
                 return Err(
-                    CompileError::new(ErrorKind::CannotNegateUnsigned(ty_name), span).with_note(
+                    CompileError::new(ErrorKind::CannotNegate(ty_name), span).with_note(
                         "unsigned values are never negative, so this pattern could never match",
                     ),
                 );

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -364,9 +364,7 @@ impl Sema<'_> {
                 if let Some(ty) = ty {
                     if ty.is_unsigned() {
                         return Err(CompileError::new(
-                            ErrorKind::CannotNegateUnsigned(
-                                ty.safe_name_with_pool(Some(&self.type_pool)),
-                            ),
+                            ErrorKind::CannotNegate(ty.safe_name_with_pool(Some(&self.type_pool))),
                             span,
                         ));
                     }

--- a/crates/rue-cli-tests/cases/unary_negation.toml
+++ b/crates/rue-cli-tests/cases/unary_negation.toml
@@ -1,0 +1,56 @@
+# Unary negation operand-type checking (RUE-200).
+#
+# Unary `-` requires a signed integer operand. Negating a bool (or any other
+# non-signed-integer type) used to compile silently, typing the result as the
+# operand's type. It is now E0801, the same code used for unsigned operands.
+# Signed negation still compiles and runs.
+
+[section]
+id = "cli.unary_negation"
+name = "Unary negation operand type"
+description = "Unary `-` requires a signed integer operand; bool/non-numeric operands are rejected (E0801), signed negation still runs (RUE-200)."
+
+# The headline repro: -true must be a compile error, not silent bool.
+[[case]]
+name = "negate_bool_rejected"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @dbg(-true);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0801", "cannot apply unary operator `-` to type 'bool'"]
+
+# Negating an unsigned value is still rejected.
+[[case]]
+name = "negate_unsigned_rejected"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: u32 = 5;
+    -x;
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0801", "cannot apply unary operator `-` to type 'u32'"]
+
+# Signed negation of a literal still compiles and runs: -5 as i32 -> exit 251.
+[[case]]
+name = "negate_signed_literal_runs"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    -5
+}
+""" }]
+exit_code = 251
+
+# Negation of a signed expression still works: -(3 - 4) == 1 (RUE-149 control).
+[[case]]
+name = "negate_signed_expr_runs"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    -(3 - 4)
+}
+""" }]
+exit_code = 1

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -199,7 +199,7 @@ impl ErrorCode {
     // Literal/operator errors (E0800-E0899)
     // ========================================================================
     pub const LITERAL_OUT_OF_RANGE: Self = Self(800);
-    pub const CANNOT_NEGATE_UNSIGNED: Self = Self(801);
+    pub const CANNOT_NEGATE: Self = Self(801);
     pub const CHAINED_COMPARISON: Self = Self(802);
 
     // ========================================================================
@@ -1174,7 +1174,7 @@ pub enum ErrorKind {
 
     // Operator errors
     #[error("cannot apply unary operator `-` to type '{0}'")]
-    CannotNegateUnsigned(String),
+    CannotNegate(String),
     #[error("comparison operators cannot be chained")]
     ChainedComparison,
 
@@ -1345,7 +1345,7 @@ impl ErrorKind {
 
             // Literal/operator errors (E0800-E0899)
             ErrorKind::LiteralOutOfRange { .. } => ErrorCode::LITERAL_OUT_OF_RANGE,
-            ErrorKind::CannotNegateUnsigned(_) => ErrorCode::CANNOT_NEGATE_UNSIGNED,
+            ErrorKind::CannotNegate(_) => ErrorCode::CANNOT_NEGATE,
             ErrorKind::ChainedComparison => ErrorCode::CHAINED_COMPARISON,
 
             // Array errors (E0900-E0999)

--- a/crates/rue-spec/cases/expressions/arithmetic.toml
+++ b/crates/rue-spec/cases/expressions/arithmetic.toml
@@ -245,6 +245,20 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = "cannot apply unary operator"
 
+# Negating a non-numeric operand (bool, unit, ...) is also a type error: unary
+# `-` requires a signed integer operand (RUE-200).
+[[case]]
+name = "negation_non_numeric_{variant}_error"
+spec = ["4.2:14"]
+source = "fn main() -> i32 { let x = {expr}; 0 }"
+compile_fail = true
+error_contains = "cannot apply unary operator"
+params = [
+  { variant = "bool_true", expr = "-true" },
+  { variant = "bool_false", expr = "-false" },
+  { variant = "unit", expr = "-()" },
+]
+
 # =============================================================================
 # Runtime Errors
 # =============================================================================

--- a/crates/rue-ui-tests/cases/diagnostics/unary_negation.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/unary_negation.toml
@@ -1,0 +1,59 @@
+[section]
+id = "diagnostics.unary-negation"
+name = "Unary negation operand type"
+description = "Unary `-` requires a signed integer operand; bool, unit, and unsigned operands are rejected with E0801 and a helpful note (RUE-200)."
+
+[[case]]
+name = "negate_bool_error_note"
+source = """
+fn main() -> i32 {
+    let x = -true;
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0801",
+    "cannot apply unary operator `-` to type 'bool'",
+    "unary `-` requires a signed integer operand (i8, i16, i32, i64, isize)",
+]
+
+[[case]]
+name = "negate_unit_error"
+source = """
+fn main() -> i32 {
+    let x = -();
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0801",
+    "cannot apply unary operator `-` to type '()'",
+]
+
+[[case]]
+name = "negate_unsigned_error_note"
+source = """
+fn main() -> i32 {
+    let x: u32 = 5;
+    let y = -x;
+    0
+}
+"""
+compile_fail = true
+error_contains = [
+    "E0801",
+    "cannot apply unary operator `-` to type 'u32'",
+    "unsigned values cannot be negated",
+]
+
+[[case]]
+name = "negate_signed_ok"
+source = """
+fn main() -> i32 {
+    let x: i32 = 5;
+    -x
+}
+"""
+exit_code = 251

--- a/docs/spec/src/04-expressions/02-arithmetic-operators.md
+++ b/docs/spec/src/04-expressions/02-arithmetic-operators.md
@@ -62,7 +62,10 @@ The unary negation operator `-` takes a single signed integer operand and produc
 
 {{ rule(id="4.2:14", cat="legality-rule") }}
 
-A compiler **MUST** reject unary negation applied to unsigned integer types.
+A compiler **MUST** reject unary negation whose operand is not a signed integer
+type. Unsigned integer types have no negative range, and non-numeric types
+(such as `bool` or `()`) are not negatable at all; applying `-` to any of them
+is a compile-time error.
 
 {{ rule(id="4.2:7", cat="normative") }}
 


### PR DESCRIPTION
The sema `Neg` arm only checked `ty.is_unsigned()`, so `-true` / `-()` / any non-signed operand passed through **silently**, typed as the operand's type. Now rejects when `!ty.is_signed() && !ty.is_error() && !ty.is_never()`, reusing E0801 with an operand-appropriate note. Renamed `ErrorKind::CannotNegateUnsigned` → `CannotNegate`. Broadened spec rule 4.2:14.

Verified by execution: `-true` → E0801 "cannot apply unary operator `-` to type 'bool'" (was: compiled silently as bool); `-()` rejected; `-x` on u32 still E0801; `-5` → 251 and `-(3-4)` → 1 intact. Full `./test.sh` green.

Fixes RUE-200

🤖 Generated with [Claude Code](https://claude.com/claude-code)