### PR TITLE
rue-oracle-diff: the corpus differential harness + 4 oracle fixes it found (RUE-50)

### DIFF
--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -1,0 +1,16 @@
+load("//crates:defs.bzl", "rue_binary")
+
+# The differential harness: runs the concrete rue-cli-tests corpus through the
+# rue-oracle reference interpreter and checks it agrees with each case's
+# expected exit code / stdout. A disagreement is a bug in the oracle or the
+# compiler (the compiler already matches these expectations, so a mismatch
+# localizes to codegen). No #[test] functions — it IS the harness.
+rue_binary(
+    name = "rue-oracle-diff",
+    tests = False,
+    deps = [
+        "//crates/rue-oracle:rue-oracle",
+        "//third-party:serde",
+        "//third-party:toml",
+    ],
+)

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -1,0 +1,211 @@
+//! # rue-oracle-diff — the differential harness (RUE-50)
+//!
+//! Runs the concrete [`rue-cli-tests`] corpus through the [`rue_oracle`]
+//! reference interpreter and checks the oracle agrees with each case's expected
+//! exit code / stdout. Those expectations are what the *compiled binary*
+//! already produces (the CLI suite enforces that), so a disagreement here means
+//! the oracle and the compiler disagree — which, since the oracle is an
+//! independent implementation of the semantics operating *before* codegen,
+//! localizes a miscompile. This is the automated bug-catcher of RUE-50: it
+//! turns "we check the outputs we thought to write down" into "we check that
+//! the semantics and codegen agree on every program in the corpus."
+//!
+//! Usage: `rue-oracle-diff [cases-dir ...]`
+//! (default: `crates/rue-cli-tests/cases`, resolved from the current directory).
+//! Exits non-zero if any disagreement is found.
+
+use rue_oracle::run_source;
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+#[derive(Deserialize)]
+struct TestFile {
+    #[serde(default, rename = "case")]
+    cases: Vec<Case>,
+}
+
+/// A permissive subset of the rue-cli-tests case schema — only the fields the
+/// oracle can act on. Unknown fields (spec references, substring matchers, …)
+/// are ignored.
+#[derive(Deserialize)]
+struct Case {
+    name: String,
+    #[serde(default)]
+    files: Vec<SourceFile>,
+    #[serde(default)]
+    args: Option<Vec<String>>,
+    #[serde(default)]
+    stdin: Option<String>,
+    #[serde(default)]
+    compile_fail: bool,
+    #[serde(default)]
+    compile_only: bool,
+    #[serde(default)]
+    stdout: Option<String>,
+    #[serde(default)]
+    runtime_error_contains: Vec<String>,
+    #[serde(default)]
+    exit_code: Option<i32>,
+    #[serde(default)]
+    known_bug: Option<String>,
+    #[serde(default)]
+    skip: bool,
+}
+
+#[derive(Deserialize)]
+struct SourceFile {
+    #[allow(dead_code)]
+    path: String,
+    source: String,
+}
+
+#[derive(Default)]
+struct Report {
+    agree: u32,
+    /// oracle could not model this program (outside its coverage) — not a bug
+    skip_unsupported: u32,
+    /// case shape the harness cannot drive (multi-file, stdin, custom args, …)
+    skip_nonrunnable: u32,
+    /// oracle ran but disagreed with the expected behavior — a bug
+    disagreements: Vec<String>,
+}
+
+fn main() -> ExitCode {
+    let dirs: Vec<PathBuf> = {
+        let args: Vec<String> = std::env::args().skip(1).collect();
+        if args.is_empty() {
+            vec![PathBuf::from("crates/rue-cli-tests/cases")]
+        } else {
+            args.into_iter().map(PathBuf::from).collect()
+        }
+    };
+
+    let mut report = Report::default();
+    let mut toml_files = Vec::new();
+    for dir in &dirs {
+        collect_toml(dir, &mut toml_files);
+    }
+    if toml_files.is_empty() {
+        eprintln!(
+            "no .toml case files found under {:?} (run from the repo root)",
+            dirs
+        );
+        return ExitCode::FAILURE;
+    }
+
+    for path in &toml_files {
+        let text = match std::fs::read_to_string(path) {
+            Ok(t) => t,
+            Err(e) => {
+                eprintln!("skip {}: {e}", path.display());
+                continue;
+            }
+        };
+        let file: TestFile = match toml::from_str(&text) {
+            Ok(f) => f,
+            // A case file the harness's subset schema can't parse is not a
+            // failure of the oracle — skip it (spec-only fields, etc.).
+            Err(_) => continue,
+        };
+        for case in &file.cases {
+            check_case(path, case, &mut report);
+        }
+    }
+
+    let total = report.agree
+        + report.skip_unsupported
+        + report.skip_nonrunnable
+        + report.disagreements.len() as u32;
+    println!("\n=== rue-oracle-diff: differential agreement over {total} cases ===");
+    println!("  agree:            {}", report.agree);
+    println!("  skip (unmodeled): {}", report.skip_unsupported);
+    println!("  skip (non-runnable shape): {}", report.skip_nonrunnable);
+    println!("  DISAGREEMENTS:    {}", report.disagreements.len());
+    for d in &report.disagreements {
+        println!("\n  ✗ {d}");
+    }
+
+    if report.disagreements.is_empty() {
+        println!("\noracle agrees with the compiler on every runnable case.");
+        ExitCode::SUCCESS
+    } else {
+        println!(
+            "\n{} disagreement(s) — each is a bug in the oracle or (more likely) codegen.",
+            report.disagreements.len()
+        );
+        ExitCode::FAILURE
+    }
+}
+
+fn check_case(path: &Path, case: &Case, report: &mut Report) {
+    // Shapes the harness cannot drive through the single-source oracle.
+    if case.skip
+        || case.compile_fail
+        || case.compile_only
+        || case.known_bug.is_some()
+        || case.args.is_some()
+        || case.stdin.is_some()
+        || case.files.len() != 1
+    {
+        report.skip_nonrunnable += 1;
+        return;
+    }
+    let source = &case.files[0].source;
+
+    // A program that expects a runtime panic exits 101 by convention.
+    let expected_exit = case
+        .exit_code
+        .unwrap_or(if case.runtime_error_contains.is_empty() {
+            0
+        } else {
+            101
+        });
+
+    match run_source(source) {
+        Err(_unsupported) => report.skip_unsupported += 1,
+        Ok(outcome) => {
+            let exit_ok = outcome.exit_code == expected_exit;
+            let stdout_ok = case.stdout.as_ref().is_none_or(|s| &outcome.stdout == s);
+            if exit_ok && stdout_ok {
+                report.agree += 1;
+            } else {
+                let mut msg = format!("{} :: {}", rel(path), case.name);
+                if !exit_ok {
+                    msg += &format!(
+                        "\n      exit: expected {expected_exit}, oracle got {}",
+                        outcome.exit_code
+                    );
+                }
+                if !stdout_ok {
+                    msg += &format!(
+                        "\n      stdout: expected {:?}, oracle got {:?}",
+                        case.stdout.as_deref().unwrap_or(""),
+                        outcome.stdout
+                    );
+                }
+                report.disagreements.push(msg);
+            }
+        }
+    }
+}
+
+fn rel(path: &Path) -> String {
+    path.file_name()
+        .map(|f| f.to_string_lossy().into_owned())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+fn collect_toml(dir: &Path, out: &mut Vec<PathBuf>) {
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    for entry in entries.flatten() {
+        let p = entry.path();
+        if p.is_dir() {
+            collect_toml(&p, out);
+        } else if p.extension().is_some_and(|e| e == "toml") {
+            out.push(p);
+        }
+    }
+}

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -271,9 +271,13 @@ impl<'a> Interp<'a> {
                 } => {
                     let s = self.eval(cfg, &mut frame, scrutinee)?.as_int();
                     let cases = cfg.get_switch_cases(cases_start, cases_len);
+                    // Case values are stored as i64 bit patterns; compare by the
+                    // 64-bit pattern so unsigned extremes (u64::MAX -> -1 as i64)
+                    // and i64::MIN match the scrutinee regardless of signedness.
+                    let s_bits = s as i64 as u64;
                     current = cases
                         .iter()
-                        .find(|(val, _)| *val as i128 == s)
+                        .find(|(val, _)| *val as u64 == s_bits)
                         .map(|(_, blk)| *blk)
                         .unwrap_or(default);
                     incoming = Vec::new();
@@ -377,7 +381,17 @@ impl<'a> Interp<'a> {
         let inst = cfg.get_inst(v);
         let ty = inst.ty;
         let result = match &inst.data {
-            CfgInstData::Const(n) => Value::Int(*n as i128),
+            CfgInstData::Const(n) => {
+                // The constant is stored as a 64-bit two's-complement bit
+                // pattern (e.g. i32::MIN is `18446744071562067968` =
+                // 0xFFFFFFFF80000000), so a signed type reinterprets it as
+                // signed; an unsigned type takes the u64 value directly.
+                if ty.is_signed() {
+                    Value::Int(*n as i64 as i128)
+                } else {
+                    Value::Int(*n as i128)
+                }
+            }
             CfgInstData::BoolConst(b) => Value::Bool(*b),
             CfgInstData::StringConst(idx) => Value::Str(
                 self.state
@@ -660,6 +674,14 @@ impl<'a> Interp<'a> {
             };
             return Err(Flow::Panic(Panic(reason.into())));
         }
+        // MIN / -1 (and MIN % -1) trap at the operand width: the hardware `idiv`
+        // faults even though the mathematical remainder is 0. Our i128 model
+        // wouldn't otherwise catch it (the value fits in i128).
+        if let Some((lo, _)) = int_bounds(ty) {
+            if ty.is_signed() && x == lo && y == -1 {
+                return Err(Flow::Panic(Panic("arithmetic overflow".into())));
+            }
+        }
         let r = if is_mod {
             x.checked_rem(y)
         } else {
@@ -676,9 +698,14 @@ impl<'a> Interp<'a> {
         b: CfgValue,
         pick: impl Fn(std::cmp::Ordering) -> bool,
     ) -> Step<Value> {
-        let x = self.eval(cfg, frame, a)?.as_int();
-        let y = self.eval(cfg, frame, b)?.as_int();
-        Ok(Value::Bool(pick(x.cmp(&y))))
+        let x = self.eval(cfg, frame, a)?;
+        let y = self.eval(cfg, frame, b)?;
+        // Strings compare by content (String ==/!=); everything else by value.
+        let ord = match (&x, &y) {
+            (Value::Str(sx), Value::Str(sy)) => sx.cmp(sy),
+            _ => x.as_int().cmp(&y.as_int()),
+        };
+        Ok(Value::Bool(pick(ord)))
     }
 
     fn bitop(

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -316,6 +316,44 @@ fn moved_value_drops_once_at_destination() {
     assert_eq!(run(src).stdout, "42\n");
 }
 
+// --- regressions found by the differential harness (rue-oracle-diff) ---
+
+#[test]
+fn i32_min_negated_literal() {
+    // -2147483648 is stored as the 64-bit sign-extended bit pattern; the Const
+    // must reinterpret it as signed, not as a huge positive.
+    let src = "fn main() -> i32 {
+        let a: i32 = -2147483648;
+        let b: i32 = 1;
+        a / b - a
+    }";
+    // a/b = i32::MIN; i32::MIN - i32::MIN = 0.
+    assert_eq!(exit(src), 0);
+}
+
+#[test]
+fn min_mod_neg_one_traps() {
+    // i32::MIN % -1 faults at the operand width even though the math is 0.
+    let src = "fn main() -> i32 {
+        let a: i32 = -2147483648;
+        let b: i32 = -1;
+        a % b
+    }";
+    assert_eq!(run(src).exit_code, 101);
+}
+
+#[test]
+fn string_equality_by_content() {
+    let src = "fn main() -> i32 {
+        let mut a = String::new();
+        a.push_str(\"hi\");
+        let mut b = String::new();
+        b.push_str(\"hi\");
+        if a == b { 7 } else { 0 }
+    }";
+    assert_eq!(exit(src), 7);
+}
+
 #[test]
 fn string_build_and_len() {
     let src = "fn main() -> i32 {


### PR DESCRIPTION
The RUE-50 payoff — an automated bug-catcher. `crates/rue-oracle-diff` runs the concrete rue-cli-tests corpus (**639 cases**) through the rue-oracle reference interpreter and checks it agrees with each case's expected exit code / stdout. Those expectations are what the compiled binary already produces, so a disagreement means the oracle and compiler disagree — and since the oracle is an *independent, pre-codegen* implementation of the semantics, that localizes a miscompile. "We test the outputs we wrote down" becomes "we test that the semantics and codegen agree on every program."

**The first run found 9 disagreements — all oracle gaps (the compiler was right), now fixed:**
1. **Const sign-interpretation** — a constant is stored as a 64-bit sign-extended bit pattern (`i32::MIN` = `18446744071562067968`), which the `Const` arm read as a huge *positive* i128. Now signed types reinterpret as signed. (This one bug cascaded into spurious overflow panics across the arithmetic cases.)
2. **`MIN / -1` and `MIN % -1`** now trap at the operand width (hardware `idiv` fault) instead of computing the math in i128.
3. **String `==`/`!=`** compare by content, not `as_int()` (which was `0 == 0`).
4. **Switch case values** compare by 64-bit pattern, so `u64::MAX` and `i64::MIN` match the scrutinee regardless of signedness.

After the fixes: **364 agree, 0 disagreements**, 265 skipped (multi-file/stdin/custom-arg shapes), 10 skipped (unmodeled). 3 oracle unit-test pins added; full `./test.sh` green.

**Follow-ups:** extend to the (templated) rue-spec corpus; wire as an sh_test so CI enforces agreement every commit.

Part of RUE-50

🤖 Generated with [Claude Code](https://claude.com/claude-code)