### PR TITLE
CI + build hardening: clippy gate, memory-sanitizer job, bench.sh strict mode (RUE-47, RUE-49, RUE-54)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,32 @@ jobs:
         # Uses hermetic rustfmt from Buck2 toolchain
         run: ./fmt.sh check
 
+  clippy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
+
+      # Cache the dotslash-downloaded buck2 binary (see the `test` job for the
+      # rationale on which paths are worth caching).
+      - name: Cache dotslash artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/dotslash
+            ~/Library/Caches/dotslash
+          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          restore-keys: |
+            dotslash-linux-x64-
+
+      - name: Run clippy
+        # Builds the [clippy.txt] subtarget for every first-party crate and
+        # fails on any clippy error. Workspace lint policy (deny warnings +
+        # grandfathered allow-list) lives in toolchains/rust/BUCK.
+        run: ./clippy.sh
+
   actionlint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/sanitizer.yml
+++ b/.github/workflows/sanitizer.yml
@@ -1,0 +1,63 @@
+name: Sanitizer
+
+# Runs compiled Rue programs under Valgrind's memcheck (RUE-49). Rue emits
+# static, no-libc, direct-syscall ELF, and valgrind's DBI runs such binaries
+# without recompilation, so this needs no special build — just the compiler
+# plus `valgrind` from apt.
+#
+# Scope (see scripts/run-sanitizer.sh for the full rationale): memcheck hooks
+# libc malloc/free, but the Rue runtime bump-allocates inside mmap'd arenas and
+# never calls libc, so to memcheck each program does "0 allocs". This job is
+# therefore a CODEGEN / generated-code memory-safety net (wild pointers, stack
+# overflow, bad syscall buffers, uninitialised-value use) that the source-level
+# fuzz job cannot provide. It does NOT catch intra-arena heap overflows like
+# RUE-34; that class needs an AddressSanitizer pass over rue-runtime's own unit
+# tests, tracked as follow-up work.
+#
+# It is a separate workflow so it runs in parallel with the fast `test` job in
+# ci.yml rather than serializing behind it.
+
+on:
+  push:
+    branches: [trunk]
+  pull_request:
+    branches: [trunk]
+  merge_group:
+    branches: [trunk]
+  workflow_dispatch:
+
+# Cancel in-progress runs for the same branch
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  valgrind:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
+
+      # Cache the dotslash-downloaded buck2 binary, matching ci.yml. OSS buck2
+      # has no persistent action cache across daemon restarts, so only the
+      # dotslash download is worth caching. (RUE-144)
+      - name: Cache dotslash artifacts
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/dotslash
+          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          restore-keys: |
+            dotslash-linux-x64-
+
+      - name: Install valgrind
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y valgrind
+
+      - name: Build rue compiler
+        run: ./buck2 build //crates/rue:rue
+
+      - name: Run programs under valgrind memcheck
+        run: scripts/run-sanitizer.sh

--- a/bench.sh
+++ b/bench.sh
@@ -12,7 +12,11 @@
 #   ./bench.sh --no-history       # Don't append to history file
 #   ./bench.sh --help             # Show usage
 
-set -e
+# Strict mode: -e exit on error, -u error on unset vars, pipefail so a failing
+# stage of a pipeline fails the whole pipeline. Pipelines that are *expected*
+# to fail (a grep with no match, jj/git in an environment without them) are
+# guarded explicitly with `|| true` below.
+set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 BENCHMARKS_DIR="$SCRIPT_DIR/benchmarks"
@@ -115,7 +119,9 @@ log_info "Using compiler: $RUE_BIN"
 
 # Create temp directory for outputs
 TEMP_DIR=$(mktemp -d)
-trap "rm -rf $TEMP_DIR" EXIT
+# Single-quote the trap so $TEMP_DIR is expanded (and quoted) at trap time,
+# not now — avoids word-splitting on the path and keeps shellcheck (SC2064) happy.
+trap 'rm -rf "$TEMP_DIR"' EXIT
 
 # Parse manifest and run benchmarks
 log_info "Running benchmarks ($ITERATIONS iterations each)..."
@@ -187,8 +193,9 @@ for i in "${!benchmark_names[@]}"; do
                 rm -f "$time_output"
                 continue
             fi
-            # Extract max RSS from time output (in bytes on macOS)
-            peak_mem_bytes=$(grep "maximum resident set size" "$time_output" 2>/dev/null | awk '{print $1}')
+            # Extract max RSS from time output (in bytes on macOS).
+            # `|| true`: a missing line is not fatal (pipefail would abort otherwise).
+            peak_mem_bytes=$(grep "maximum resident set size" "$time_output" 2>/dev/null | awk '{print $1}' || true)
         else
             # Linux: -v gives max resident set size in KB
             if ! timing_json=$(/usr/bin/time -v "$RUE_BIN" --benchmark-json "$full_path" -o "$output_binary" 2>"$time_output"); then
@@ -196,14 +203,18 @@ for i in "${!benchmark_names[@]}"; do
                 rm -f "$time_output"
                 continue
             fi
-            # Extract max RSS from time output (in KB on Linux, convert to bytes)
-            peak_mem_kb=$(grep "Maximum resident set size" "$time_output" 2>/dev/null | awk '{print $NF}')
-            peak_mem_bytes=$((peak_mem_kb * 1024))
+            # Extract max RSS from time output (in KB on Linux, convert to bytes).
+            # `|| true`: a missing line is not fatal (pipefail would abort otherwise);
+            # an empty peak_mem_kb is treated as 0 in the arithmetic below.
+            peak_mem_kb=$(grep "Maximum resident set size" "$time_output" 2>/dev/null | awk '{print $NF}' || true)
+            peak_mem_bytes=$(( ${peak_mem_kb:-0} * 1024 ))
         fi
         rm -f "$time_output"
 
-        # Extract total_ms from the JSON
-        total_ms=$(echo "$timing_json" | grep -o '"total_ms":[0-9.]*' | head -1 | cut -d: -f2)
+        # Extract total_ms from the JSON. `|| true`: grep may not match and
+        # `head -1` closing the pipe early can SIGPIPE grep — neither is fatal
+        # (the `-n "$total_ms"` check below handles a missing value).
+        total_ms=$(echo "$timing_json" | grep -o '"total_ms":[0-9.]*' | head -1 | cut -d: -f2 || true)
         if [[ -n "$total_ms" ]]; then
             iteration_results+=("$total_ms")
             # Store full JSON for pass data extraction
@@ -357,10 +368,12 @@ timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 # Note: We check if the result is non-empty because piped commands may succeed but return empty
 commit=""
 if command -v jj &>/dev/null; then
-    commit=$(jj log -r @ --no-graph -T 'commit_id' 2>/dev/null | head -c 12)
+    # `|| true`: jj may fail (or `head` may SIGPIPE it) outside a jj repo; we
+    # fall back to git, then to "unknown", so this must not abort under errexit.
+    commit=$(jj log -r @ --no-graph -T 'commit_id' 2>/dev/null | head -c 12 || true)
 fi
 if [[ -z "$commit" ]] && command -v git &>/dev/null; then
-    commit=$(git rev-parse --short HEAD 2>/dev/null)
+    commit=$(git rev-parse --short HEAD 2>/dev/null || true)
 fi
 if [[ -z "$commit" ]]; then
     commit="unknown"

--- a/clippy.sh
+++ b/clippy.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+set -euo pipefail
+
+# Clippy lint gate for the workspace (the CI `clippy` job runs this).
+#
+# Why not a single `buck2 build ...` that fails on lint? Buck2's rust rules run
+# clippy with "infallible diagnostics": the `[clippy.txt]` subtarget always
+# succeeds and merely *captures* clippy's output into a file (so downstream
+# actions consuming diagnostics don't break). There is no built-in
+# "fail-the-build-on-clippy" subtarget. So the gate is: build the
+# `[clippy.txt]` subtarget for every first-party crate target, then fail if any
+# of those diagnostic files is non-empty.
+#
+# The workspace lint policy lives in toolchains/rust/BUCK:
+#   deny_lints  = ["warnings"]   -> every rustc/clippy warning is an error
+#   allow_lints = _CLIPPY_ALLOW  -> grandfathered pre-existing clippy findings
+# Shrink _CLIPPY_ALLOW over time; a lint removed from it becomes gating here.
+
+cd "$(dirname "$0")"
+
+echo "Enumerating first-party Rust targets..."
+# One target per rust_library / rust_binary / rust_test under //crates/...
+mapfile -t TARGETS < <(./buck2 uquery \
+    "kind('rust_(library|binary|test)', 'root//crates/...')" 2>/dev/null)
+
+if [ "${#TARGETS[@]}" -eq 0 ]; then
+    echo "clippy.sh: no Rust targets found (uquery returned nothing)" >&2
+    exit 1
+fi
+
+CLIPPY_TARGETS=()
+for t in "${TARGETS[@]}"; do
+    CLIPPY_TARGETS+=("${t}[clippy.txt]")
+done
+
+echo "Running clippy on ${#CLIPPY_TARGETS[@]} targets..."
+# A real compile error (not a lint) makes this buck2 build fail non-zero, which
+# `set -e` propagates -- that is correct, the tree is broken.
+SHOW_OUTPUT="$(./buck2 build "${CLIPPY_TARGETS[@]}" --show-output 2>/dev/null)"
+
+FAILED=0
+# Each --show-output line is: "<target>[clippy.txt] <repo-root-relative-path>".
+# We only fail on clippy *errors*: deny_lints=["warnings"] turns every real
+# clippy finding into an `error:` line, whereas benign non-lint codegen output
+# (e.g. `-Ctarget-feature` `warning:` notes that rustc emits unconditionally
+# and that ordinary builds also print) must NOT gate. So grep for `^error`.
+while read -r TARGET ARTIFACT; do
+    [ -z "${ARTIFACT:-}" ] && continue
+    [ -s "$ARTIFACT" ] || continue
+    # Strip ANSI colour codes so CI logs stay readable and grep is reliable.
+    CLEANED="$(sed -E 's/\x1b\[[0-9;]*m//g' "$ARTIFACT")"
+    if printf '%s\n' "$CLEANED" | grep -qE '^error'; then
+        FAILED=1
+        echo "::group::clippy findings: $TARGET"
+        printf '%s\n' "$CLEANED"
+        echo "::endgroup::"
+    fi
+done <<< "$SHOW_OUTPUT"
+
+if [ "$FAILED" -ne 0 ]; then
+    echo ""
+    echo "clippy gate FAILED: lint violations above."
+    echo "Fix them, or (if intentional) adjust the workspace lint policy in"
+    echo "toolchains/rust/BUCK (deny_lints / allow_lints)."
+    exit 1
+fi
+
+echo "clippy gate passed: no lint violations."

--- a/scripts/run-sanitizer.sh
+++ b/scripts/run-sanitizer.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+#
+# run-sanitizer.sh — compile a corpus of Rue programs and run every resulting
+# binary under Valgrind's memcheck, failing if any program triggers a memory
+# error or a fatal signal.
+#
+# This is the local driver for the `sanitizer.yml` CI job (RUE-49). Run it from
+# anywhere in the repo:
+#
+#   scripts/run-sanitizer.sh                 # examples/*.rue + curated corpus
+#   scripts/run-sanitizer.sh path/to/x.rue   # ...plus extra programs
+#
+# Requirements: `valgrind` on PATH (CI installs it via apt-get). The rue
+# compiler is built on demand via scripts/rue-bin; set RUE_BINARY to reuse an
+# already-built binary.
+#
+# ---------------------------------------------------------------------------
+# What Valgrind does and does NOT catch on Rue binaries (verified 2026-07-02,
+# valgrind-3.22 on x86-64):
+#
+# Rue emits static, no-libc, direct-syscall ELF executables. Valgrind's dynamic
+# binary instrumentation loads and runs them WITHOUT recompilation, so memcheck
+# works out of the box — no ASAN build needed.
+#
+# HOWEVER: memcheck's heap tracking hooks libc malloc/free. Rue's runtime never
+# calls libc; it mmaps 64 KiB arenas and bump-allocates within them
+# (crates/rue-runtime/src/heap.rs), with free() a no-op. To memcheck every Rue
+# program therefore does "0 allocs, 0 frees" — the whole arena is one opaque,
+# addressable, mmap'd region. Consequences:
+#
+#   CAUGHT: wild pointers / accesses outside any mapped region, stack overflow,
+#           jumps to bad addresses, uninitialised values used in branches or
+#           passed to syscalls, bad syscall buffers — i.e. CODEGEN and
+#           generated-code correctness bugs, which the fuzz job (source-level,
+#           never runs a binary) cannot see.
+#
+#   MISSED: intra-arena heap overflow / use-after-free such as RUE-34 (a String
+#           grow path recording more capacity than it allocated). The overflow
+#           write lands inside the mmap'd arena, which memcheck considers valid,
+#           so no error fires. Catching that class needs the runtime's own unit
+#           tests built under AddressSanitizer against a real allocator; that is
+#           a separate surface tracked as follow-up work (blocked on a cargo /
+#           buck2 sanitizer toolchain for rue-runtime — see the RUE-49 PR).
+#
+# So this job is a codegen/generated-code memory-safety net, complementary to
+# (not a replacement for) an ASAN pass over rue-runtime.
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+if ! command -v valgrind >/dev/null 2>&1; then
+    echo "run-sanitizer: valgrind not found on PATH." >&2
+    echo "run-sanitizer: install it (Debian/Ubuntu: apt-get install valgrind)." >&2
+    exit 127
+fi
+
+# Build (or reuse) the compiler.
+if [[ -n "${RUE_BINARY:-}" ]]; then
+    rue="$RUE_BINARY"
+else
+    echo "run-sanitizer: building rue compiler..." >&2
+    rue="$(scripts/rue-bin)"
+fi
+if [[ ! -x "$rue" ]]; then
+    echo "run-sanitizer: rue binary is not executable: $rue" >&2
+    exit 1
+fi
+
+work="$(mktemp -d)"
+echo "run-sanitizer: workdir $work" >&2
+
+# --- Curated corpus: small programs that lean on heap/aggregate paths the
+#     stock examples touch only lightly. Kept here (not in examples/) so they
+#     can hammer growth loops without cluttering the user-facing examples.
+cat > "$work/san_str_grow.rue" <<'RUE'
+// Many push_str calls -> repeated String realloc (the RUE-34 grow path).
+fn main() -> i32 {
+    let mut s = String::new();
+    let mut i = 0;
+    while i < 500 {
+        s.push_str("abcdefghij");
+        i = i + 1;
+    }
+    let n: u64 = 5000;
+    if s.len() == n { 0 } else { 1 }
+}
+RUE
+
+cat > "$work/san_str_push_char.rue" <<'RUE'
+// Byte-at-a-time growth: exercises the smallest grow increments.
+fn main() -> i32 {
+    let mut s = String::new();
+    let mut i = 0;
+    while i < 300 {
+        s.push(65);
+        i = i + 1;
+    }
+    let n: u64 = 300;
+    if s.len() == n { 0 } else { 1 }
+}
+RUE
+
+cat > "$work/san_str_mixed.rue" <<'RUE'
+// with_capacity + mixed appends: pre-sized buffer then repeated growth.
+fn main() -> i32 {
+    let mut s = String::with_capacity(4);
+    s.push_str("hello");
+    s.push_str(" world");
+    let mut i = 0;
+    while i < 50 {
+        s.push_str("xyz");
+        i = i + 1;
+    }
+    let expected: u64 = 161;
+    if s.len() == expected { 0 } else { 1 }
+}
+RUE
+
+cat > "$work/san_struct_heavy.rue" <<'RUE'
+// Struct construction / field access in a loop (aggregate slot codegen).
+@copy
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let mut sum = 0;
+    let mut i = 0;
+    while i < 100 {
+        let p = Point { x: i, y: i + 1 };
+        sum = sum + p.x + p.y;
+        i = i + 1;
+    }
+    sum % 256
+}
+RUE
+
+# --- Assemble the program list: examples/ + curated + any CLI args.
+programs=()
+for f in "$repo_root"/examples/*.rue; do
+    [[ -e "$f" ]] && programs+=("$f")
+done
+for f in "$work"/san_*.rue; do
+    programs+=("$f")
+done
+for f in "$@"; do
+    programs+=("$f")
+done
+
+# --- Verdict from a valgrind log (NOT from the program's own exit code: Rue
+#     programs legitimately exit with codes up to 255, e.g. examples/arrays.rue
+#     exits 157). A fatal signal under valgrind still prints
+#     "ERROR SUMMARY: 0 errors", so we must check for it separately.
+verdict_ok() {
+    local log="$1"
+    if grep -q "Process terminating with default action of signal" "$log"; then
+        return 1
+    fi
+    if grep -qE "ERROR SUMMARY: [1-9][0-9]* errors" "$log"; then
+        return 1
+    fi
+    grep -q "ERROR SUMMARY: 0 errors" "$log"
+}
+
+failures=0
+checked=0
+for src in "${programs[@]}"; do
+    name="$(basename "$src" .rue)"
+    bin="$work/$name.bin"
+    log="$work/$name.vglog"
+
+    if ! "$rue" "$src" -o "$bin" > "$work/$name.compile" 2>&1; then
+        echo "FAIL(compile) $name"
+        sed 's/^/    /' "$work/$name.compile"
+        failures=$((failures + 1))
+        continue
+    fi
+
+    # Cap runtime: valgrind adds heavy slowdown and a codegen bug could loop.
+    timeout 120 valgrind \
+        --error-exitcode=1 \
+        --leak-check=full \
+        --show-leak-kinds=all \
+        --track-origins=yes \
+        --log-file="$log" \
+        "$bin" > /dev/null 2>&1 || true
+
+    checked=$((checked + 1))
+    if verdict_ok "$log"; then
+        echo "PASS $name"
+    else
+        echo "FAIL(memcheck) $name"
+        sed 's/^/    /' "$log"
+        failures=$((failures + 1))
+    fi
+done
+
+echo
+echo "run-sanitizer: checked $checked program(s), $failures failure(s)."
+if [[ "$failures" -ne 0 ]]; then
+    exit 1
+fi

--- a/toolchains/rust/BUCK
+++ b/toolchains/rust/BUCK
@@ -59,6 +59,75 @@ _OPT_FLAGS = select({
 # Using -ld_classic forces the older, more stable linker.
 _MACOS_LINKER_FLAGS = ["-Clink-arg=-ld_classic"]
 
+# Workspace clippy lint policy (the CI `clippy` gate; see clippy.sh).
+#
+# deny_lints = ["warnings"] below makes *every* rustc/clippy warning an error.
+# For rustc that is already satisfied (the tree builds -D warnings clean). For
+# clippy it would otherwise fail on ~1100 pre-existing style findings across
+# the tree. Rather than churn 100+ files in the gate-establishing change, we
+# grandfather in exactly the clippy lints that fire today via `allow_lints`
+# (`-A` overrides the `-D warnings` group for that specific lint). This makes
+# the gate GREEN now while still denying:
+#   - any clippy lint NOT in this list (new categories can't creep in), and
+#   - all rustc warnings.
+# These are `clippy::`-prefixed, so the prelude filters them out of ordinary
+# (non-clippy) rustc builds -- they only affect `clippy.txt`.
+#
+# This list is a debt ledger, not an endorsement: shrink it incrementally by
+# fixing the underlying findings and deleting the entry (RUE-47 follow-ups).
+# The deny-by-default entries (approx_constant,
+# inherent_to_string_shadow_display, not_unsafe_ptr_arg_deref) are the
+# higher-value ones to retire first.
+_CLIPPY_ALLOW = [
+    "clippy::approx_constant",
+    "clippy::assign_op_pattern",
+    "clippy::borrow_deref_ref",
+    "clippy::borrowed_box",
+    "clippy::clone_on_copy",
+    "clippy::cloned_ref_to_slice_refs",
+    "clippy::collapsible_if",
+    "clippy::collapsible_match",
+    "clippy::derivable_impls",
+    "clippy::double_must_use",
+    "clippy::empty_line_after_doc_comments",
+    "clippy::for_kv_map",
+    "clippy::identity_op",
+    "clippy::if_same_then_else",
+    "clippy::inherent_to_string_shadow_display",
+    "clippy::len_zero",
+    "clippy::let_and_return",
+    "clippy::manual_clamp",
+    "clippy::manual_div_ceil",
+    "clippy::manual_is_multiple_of",
+    "clippy::manual_map",
+    "clippy::manual_range_contains",
+    "clippy::manual_repeat_n",
+    "clippy::manual_strip",
+    "clippy::map_clone",
+    "clippy::missing_safety_doc",
+    "clippy::module_inception",
+    "clippy::needless_borrows_for_generic_args",
+    "clippy::needless_range_loop",
+    "clippy::not_unsafe_ptr_arg_deref",
+    "clippy::op_ref",
+    "clippy::ptr_arg",
+    "clippy::redundant_closure",
+    "clippy::result_large_err",
+    "clippy::same_item_push",
+    "clippy::should_implement_trait",
+    "clippy::too_many_arguments",
+    "clippy::type_complexity",
+    "clippy::unnecessary_cast",
+    "clippy::unnecessary_get_then_check",
+    "clippy::unnecessary_map_or",
+    "clippy::unnecessary_mut_passed",
+    "clippy::unwrap_or_default",
+    "clippy::useless_conversion",
+    "clippy::useless_vec",
+    "clippy::while_let_loop",
+    "clippy::write_with_newline",
+]
+
 # Hermetic toolchain for Linux x86_64
 hermetic_rust_toolchain(
     name = "hermetic-linux-x86_64",
@@ -66,6 +135,7 @@ hermetic_rust_toolchain(
     target_triple = "x86_64-unknown-linux-gnu",
     default_edition = "2024",
     deny_lints = ["warnings"],
+    allow_lints = _CLIPPY_ALLOW,
     rustc_flags = _OPT_FLAGS,
     visibility = ["PUBLIC"],
 )
@@ -77,6 +147,7 @@ hermetic_rust_toolchain(
     target_triple = "aarch64-unknown-linux-gnu",
     default_edition = "2024",
     deny_lints = ["warnings"],
+    allow_lints = _CLIPPY_ALLOW,
     rustc_flags = _OPT_FLAGS,
     visibility = ["PUBLIC"],
 )
@@ -88,6 +159,7 @@ hermetic_rust_toolchain(
     target_triple = "aarch64-apple-darwin",
     default_edition = "2024",
     deny_lints = ["warnings"],
+    allow_lints = _CLIPPY_ALLOW,
     rustc_flags = _OPT_FLAGS + _MACOS_LINKER_FLAGS,
     visibility = ["PUBLIC"],
 )
@@ -99,6 +171,7 @@ hermetic_rust_toolchain(
     target_triple = "x86_64-apple-darwin",
     default_edition = "2024",
     deny_lints = ["warnings"],
+    allow_lints = _CLIPPY_ALLOW,
     rustc_flags = _OPT_FLAGS + _MACOS_LINKER_FLAGS,
     visibility = ["PUBLIC"],
 )

--- a/toolchains/rust/defs.bzl
+++ b/toolchains/rust/defs.bzl
@@ -57,8 +57,34 @@ def _hermetic_rust_toolchain_impl(ctx: AnalysisContext) -> list[Provider]:
 
     # Create RunInfo for each tool
     compiler = RunInfo(args = [rustc_bin])
-    clippy_driver = RunInfo(args = [clippy_bin])
     rustdoc = RunInfo(args = [rustdoc_bin])
+
+    # clippy-driver dynamically loads librustc_driver from rustc/lib/, but
+    # unlike rustc that dir isn't on the loader's search path, so a bare
+    # invocation dies with "librustc_driver-*.so: cannot open shared object
+    # file". Wrap it to set LD_LIBRARY_PATH / DYLD_LIBRARY_PATH to rustc/lib
+    # before exec'ing the driver (same trick as the rustfmt wrapper below).
+    #
+    # Unlike rustfmt, clippy_driver must be a SINGLE executable, not a
+    # ["/bin/bash", wrapper, ...] arg list: the prelude re-wraps it with
+    # `cmd_args(clippy_driver, format = '{} "$@"')` (rust/context.bzl), and
+    # `format` is applied per-argument — a multi-arg RunInfo would emit one
+    # broken `<arg> "$@"` line per element. So we bake the paths into a
+    # self-contained script and point RunInfo at just that file.
+    clippy_lib_dir = dist.project("rustc/lib")
+    clippy_wrapper, _ = ctx.actions.write(
+        "clippy_driver_wrapper.sh",
+        [
+            "#!/usr/bin/env bash",
+            # Set library path for both macOS and Linux
+            cmd_args(clippy_lib_dir, format = "export DYLD_LIBRARY_PATH=\"{}\""),
+            cmd_args(clippy_lib_dir, format = "export LD_LIBRARY_PATH=\"{}\""),
+            cmd_args(clippy_bin, format = "exec {} \"$@\""),
+        ],
+        is_executable = True,
+        allow_args = True,
+    )
+    clippy_driver = RunInfo(args = cmd_args(clippy_wrapper, hidden = [clippy_bin, clippy_lib_dir]))
 
     # Build a merged sysroot by running a shell script
     # The Rust distribution has components in separate directories that need merging:


### PR DESCRIPTION
Three disjoint infra improvements from cycle 34, integrated together.

**RUE-47 — clippy gate.** New clippy CI job + `clippy.sh` gate over all 38 first-party targets. Fixed a latent toolchain bug (clippy-driver lacked `LD_LIBRARY_PATH`). A toolchain allow-policy grandfathers the 47 lints that fire today (`-A` over the existing `-D warnings`) so the gate is green now, while still denying any **new** clippy lint + all rustc warnings. Verified: `clippy.sh` exits 0; an injected `needless_return` is caught.

**RUE-49 — memory sanitizer.** New `.github/workflows/sanitizer.yml` + `scripts/run-sanitizer.sh` runs examples + curated String/heap programs under valgrind memcheck (works on the no-libc static ELF via DBI, no recompile). Verified 19/19 pass; a deliberate stack-overflow is caught. Honest limitation documented in-file: memcheck can't see the mmap-arena allocator, so the RUE-34 intra-arena class needs ASAN → filed **RUE-211**.

**RUE-54 — build hygiene.** BUCK boilerplate was already DRY (all crates route through the `defs.bzl` macros — refuted); hardened `bench.sh` to `set -euo pipefail` with guarded pipelines. (Discovered a `scripts/rue exec` temp-leak → filed **RUE-212**.)

Verified: clippy green, actionlint clean on both workflows, `buck2 build //...` succeeds, full `./test.sh` green. Disjoint files.

Fixes RUE-47
Fixes RUE-49
Fixes RUE-54

🤖 Generated with [Claude Code](https://claude.com/claude-code)