### PR TITLE
Parser statement-boundary fixes + raw-pointer sema (RUE-209, RUE-210, RUE-8)

### DIFF
--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -1813,4 +1813,39 @@ mod tests {
     fn test_pool_is_send_sync() {
         assert_send_sync::<TypeInternPool>();
     }
+
+    #[test]
+    fn test_ptr_type_error_name_shows_pointee() {
+        // Diagnostics must render the pointee type, not a bare `<ptr const>`
+        // placeholder that makes "expected X, found X" messages useless
+        // (RUE-8). Verify `safe_name_with_pool` resolves the pointee through
+        // the pool for both const and mut pointers, including nested pointers.
+        let pool = TypeInternPool::new();
+
+        let pc = pool.intern_ptr_const_from_type(Type::I32);
+        assert_eq!(
+            Type::new_ptr_const(pc).safe_name_with_pool(Some(&pool)),
+            "ptr const i32"
+        );
+
+        let pm = pool.intern_ptr_mut_from_type(Type::U64);
+        assert_eq!(
+            Type::new_ptr_mut(pm).safe_name_with_pool(Some(&pool)),
+            "ptr mut u64"
+        );
+
+        // Nested: ptr const (ptr mut i32)
+        let inner = Type::new_ptr_mut(pool.intern_ptr_mut_from_type(Type::I32));
+        let outer = pool.intern_ptr_const_from_type(inner);
+        assert_eq!(
+            Type::new_ptr_const(outer).safe_name_with_pool(Some(&pool)),
+            "ptr const ptr mut i32"
+        );
+
+        // Without a pool, fall back to a stable id-tagged placeholder.
+        assert_eq!(
+            Type::new_ptr_const(pc).safe_name_with_pool(None),
+            format!("<ptr const#{}>", pc.0)
+        );
+    }
 }

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1667,6 +1667,7 @@ impl<'a> Sema<'a> {
             params: &param_vec,
             next_slot: 0,
             loop_depth: 0,
+            checked_depth: 0,
             loop_break_stack: Vec::new(),
             used_locals: HashSet::new(),
             return_type,
@@ -2583,9 +2584,15 @@ impl<'a> Sema<'a> {
                 Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE))
             }
 
-            // Checked block: evaluate the inner expression
-            // The actual checking of unchecked operations happens in Phase 2
-            InstData::Checked { expr } => self.analyze_inst(air, *expr, ctx),
+            // Checked block: evaluate the inner expression within an unchecked
+            // context. Raw-pointer intrinsics and calls to `unchecked fn`s are
+            // only legal while `checked_depth > 0` (spec 9.1:1, chapter 9).
+            InstData::Checked { expr } => {
+                ctx.checked_depth += 1;
+                let result = self.analyze_inst(air, *expr, ctx);
+                ctx.checked_depth -= 1;
+                result
+            }
         }
     }
 
@@ -3256,6 +3263,31 @@ impl<'a> Sema<'a> {
             })
             .collect();
         let known = &self.known;
+
+        // Raw-pointer intrinsics are unchecked operations: they may only be
+        // used inside a `checked` block (spec 9.1:1, chapter 9). Gate them
+        // before the per-intrinsic dispatch so every pointer intrinsic shares
+        // one diagnostic. `@syscall` has its own gating; the pointer set here
+        // is @raw/@raw_mut/@ptr_read/@ptr_write/@ptr_offset/@ptr_to_int/
+        // @int_to_ptr.
+        if ctx.checked_depth == 0
+            && (name == known.ptr_read
+                || name == known.ptr_write
+                || name == known.ptr_offset
+                || name == known.ptr_to_int
+                || name == known.int_to_ptr
+                || name == known.raw
+                || name == known.raw_mut)
+        {
+            let intrinsic_name_str = self.interner.resolve(&name);
+            return Err(CompileError::new(
+                ErrorKind::UncheckedOpRequiresChecked {
+                    what: format!("raw-pointer intrinsic `@{intrinsic_name_str}`"),
+                },
+                span,
+            )
+            .with_help("wrap the operation in a `checked { ... }` block"));
+        }
 
         // Use pre-interned symbol comparison instead of string comparison
         if name == known.dbg {

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3719,6 +3719,19 @@ impl<'a> Sema<'a> {
             span,
         )?;
 
+        // An `unchecked fn` may only be called inside a `checked` block
+        // (spec 9.1:1). The callee's body is analyzed like any other function;
+        // it is the *call site* that must be in an unchecked context.
+        if fn_info.is_unchecked && ctx.checked_depth == 0 {
+            return Err(CompileError::new(
+                ErrorKind::UncheckedOpRequiresChecked {
+                    what: format!("calling unchecked function `{fn_name_str}`"),
+                },
+                span,
+            )
+            .with_help("wrap the call in a `checked { ... }` block"));
+        }
+
         // Track this function as referenced (for lazy analysis)
         ctx.referenced_functions.insert(name);
 

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -295,6 +295,12 @@ pub(crate) struct AnalysisContext<'a> {
     pub next_slot: u32,
     /// How many loops we're nested inside (for break/continue validation)
     pub loop_depth: u32,
+    /// How many `checked` blocks we're nested inside. Unchecked operations —
+    /// raw-pointer intrinsics (`@raw`, `@ptr_read`, …) and calls to `unchecked
+    /// fn`s — are only legal when this is greater than zero (spec 9.1:1,
+    /// chapter 9). An `unchecked fn` body does NOT implicitly count as a
+    /// checked context; the modifier only gates *callers* (see spec 9.1:1).
+    pub checked_depth: u32,
     /// One entry per enclosing loop (innermost last); set to `true` when a
     /// `break` targeting that loop is analyzed. An infinite loop containing a
     /// break has type `()`; without one it has type `!` (see spec 4.8).
@@ -408,6 +414,7 @@ impl<'a> AnalysisContext<'a> {
             params: self.params,
             next_slot: self.next_slot,
             loop_depth: self.loop_depth,
+            checked_depth: self.checked_depth,
             loop_break_stack: self.loop_break_stack.clone(),
             used_locals: self.used_locals.clone(),
             return_type: self.return_type,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -505,7 +505,7 @@ impl<'a> Sema<'a> {
 
                 InstData::FnDecl {
                     is_pub,
-                    is_unchecked: _,
+                    is_unchecked,
                     name,
                     params_start,
                     params_len,
@@ -541,6 +541,7 @@ impl<'a> Sema<'a> {
                         *body,
                         inst.span,
                         *is_pub,
+                        *is_unchecked,
                     )?;
                 }
 
@@ -732,6 +733,7 @@ impl<'a> Sema<'a> {
         body: InstRef,
         span: Span,
         is_pub: bool,
+        is_unchecked: bool,
     ) -> CompileResult<()> {
         // Reject user functions whose name collides with a runtime/codegen helper
         // symbol (e.g. `__rue_String_len`, `__rue_alloc`, `_start`). Without this, such a
@@ -837,6 +839,7 @@ impl<'a> Sema<'a> {
                 span,
                 is_generic,
                 is_pub,
+                is_unchecked,
                 file_id: span.file_id,
             },
         );

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -32,6 +32,9 @@ pub struct FunctionInfo {
     pub is_generic: bool,
     /// Whether this function is public (visible outside its directory)
     pub is_pub: bool,
+    /// Whether this function carries the `unchecked` modifier. Calling it
+    /// requires a `checked` block at the call site (spec 9.1:1).
+    pub is_unchecked: bool,
     /// File ID this function was declared in (for visibility checking)
     pub file_id: FileId,
 }

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -617,6 +617,20 @@ impl Type {
                 }
                 format!("<array#{}>", array_id.0)
             }
+            Some(TypeKind::PtrConst(ptr_id)) => {
+                if let Some(pool) = pool {
+                    let pointee = pool.ptr_const_def(ptr_id);
+                    return format!("ptr const {}", pointee.safe_name_with_pool(Some(pool)));
+                }
+                format!("<ptr const#{}>", ptr_id.0)
+            }
+            Some(TypeKind::PtrMut(ptr_id)) => {
+                if let Some(pool) = pool {
+                    let pointee = pool.ptr_mut_def(ptr_id);
+                    return format!("ptr mut {}", pointee.safe_name_with_pool(Some(pool)));
+                }
+                format!("<ptr mut#{}>", ptr_id.0)
+            }
             Some(_kind) => self.name().to_string(),
             None => format!("<invalid type encoding: {:#x}>", self.0),
         }

--- a/crates/rue-cli-tests/cases/pointers.toml
+++ b/crates/rue-cli-tests/cases/pointers.toml
@@ -1,0 +1,112 @@
+# Raw pointer semantics through the real driver (RUE-8).
+#
+# Exercises the full pointer surface end-to-end: taking a pointer with
+# @raw / @raw_mut, reading and writing through it, round-tripping an
+# address through @ptr_to_int / @int_to_ptr, passing pointers across
+# function boundaries, and the checked-context enforcement (spec 9.1:1,
+# 9.1:12) that rejects unchecked pointer operations outside a `checked`
+# block.
+
+[section]
+id = "cli.pointers"
+name = "Raw pointers"
+description = "Raw pointer operations and unchecked-context enforcement via the CLI driver."
+
+# Read through a pointer taken with @raw. Prints the pointed-to value.
+[[case]]
+name = "ptr_read_roundtrip"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = 123;
+    let v: i32 = checked {
+        let p: ptr const i32 = @raw(x);
+        @ptr_read(p)
+    };
+    @dbg(v);
+    0
+}
+""" }]
+stdout = "123\n"
+
+# Mutate a local through a ptr mut, then observe the mutation.
+[[case]]
+name = "ptr_write_mutates_local"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut x: i32 = 10;
+    checked {
+        let p: ptr mut i32 = @raw_mut(x);
+        @ptr_write(p, 77);
+    };
+    @dbg(x);
+    0
+}
+""" }]
+stdout = "77\n"
+
+# Round-trip an address through @ptr_to_int / @int_to_ptr and read it back.
+[[case]]
+name = "ptr_int_roundtrip"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = 42;
+    let addr: u64 = checked {
+        let p: ptr const i32 = @raw(x);
+        @ptr_to_int(p)
+    };
+    let v: i32 = checked {
+        let p2: ptr mut i32 = @int_to_ptr(addr);
+        @ptr_read(p2)
+    };
+    @dbg(v);
+    0
+}
+""" }]
+stdout = "42\n"
+
+# A pointer passes across a function boundary as a parameter and is read
+# in the callee.
+[[case]]
+name = "ptr_across_function"
+files = [{ path = "main.rue", source = """
+fn deref(p: ptr const i32) -> i32 {
+    checked { @ptr_read(p) }
+}
+fn main() -> i32 {
+    let x: i32 = 99;
+    let v: i32 = checked {
+        let p: ptr const i32 = @raw(x);
+        deref(p)
+    };
+    @dbg(v);
+    0
+}
+""" }]
+stdout = "99\n"
+
+# Enforcement: a pointer operation outside a `checked` block is rejected
+# with E1300, not silently accepted (spec 9.1:12).
+[[case]]
+name = "ptr_read_outside_checked_is_error"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = 5;
+    let p: ptr const i32 = checked { @raw(x) };
+    @ptr_read(p)
+}
+""" }]
+compile_fail = true
+error_contains = ["E1300", "requires a `checked` block"]
+
+# Enforcement: calling an `unchecked fn` outside a `checked` block is
+# rejected (spec 9.1:1).
+[[case]]
+name = "unchecked_fn_outside_checked_is_error"
+files = [{ path = "main.rue", source = """
+unchecked fn danger() -> i32 { 42 }
+fn main() -> i32 {
+    danger()
+}
+""" }]
+compile_fail = true
+error_contains = ["E1300", "unchecked function"]

--- a/crates/rue-cli-tests/cases/stmt_expr_boundary.toml
+++ b/crates/rue-cli-tests/cases/stmt_expr_boundary.toml
@@ -1,0 +1,105 @@
+[section]
+id = "cli.stmt_expr_boundary"
+name = "Statement / expression boundary parsing"
+description = """
+Regression coverage for two parser statement/expression-boundary bugs:
+RUE-209 (bare break/return used as a while/if condition swallowing the
+following block as a value operand) and RUE-210 (an if/match expression
+statement followed by a line starting with unary minus being greedily parsed
+as a subtraction spanning both lines).
+"""
+
+# =============================================================================
+# RUE-209: a bare `break`/`return` used as a while/if condition must NOT swallow
+# the following `{ ... }` block as its value operand. Before the fix this
+# desynced the parse and produced a wrong-location E0100 pointing at an outer
+# brace; after the fix the block attaches as the loop/if body and the program
+# gets a clean, correctly-located diagnostic (here E0206, a real type error).
+# =============================================================================
+
+[[case]]
+name = "while_break_condition_no_desync"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { loop { while break {} } }
+""" }]
+compile_fail = true
+error_contains = ["E0206"]
+
+[[case]]
+name = "if_break_condition_no_desync"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { loop { if break {} } }
+""" }]
+compile_fail = true
+error_contains = ["E0206"]
+
+# A bare `return` used as a loop condition in a unit-returning function: the
+# `{}` attaches as the while body, so the whole thing type-checks and compiles
+# cleanly. Before the fix this desynced with a wrong-location E0100.
+[[case]]
+name = "while_return_condition_compiles"
+files = [{ path = "main.rue", source = """
+fn sink() { loop { while return {} } }
+fn main() -> i32 { 0 }
+""" }]
+compile_only = true
+
+# The parenthesized control form was never affected and keeps working: `break`
+# is rejected as a real semantic error, not a parse desync.
+[[case]]
+name = "parenthesized_break_condition_semantic_error"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { while (break) {} 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0500"]
+
+# =============================================================================
+# RUE-210: an `if`/`match` expression statement followed by a line beginning
+# with unary `-` is two statements, not a subtraction. The `if`/`match` value
+# is discarded and `-1` is the block's tail expression (exit 255 = -1 & 0xFF).
+# Before the fix this parsed as `(if ...) - 1`, exiting 230.
+# =============================================================================
+
+[[case]]
+name = "if_statement_then_unary_minus"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    if true { 999 } else { 888 }
+    -1
+}
+""" }]
+exit_code = 255
+
+[[case]]
+name = "match_statement_then_unary_minus"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    match 1 { 1 => 999, _ => 888 }
+    -1
+}
+""" }]
+exit_code = 255
+
+# Statement-position only: as a `let` right-hand side the block-like expression
+# still binds the ambiguous `-` as subtraction (10 - 5 = 5).
+[[case]]
+name = "if_minus_operand_still_binds_in_expression_position"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x = if true { 10 } else { 20 } - 5;
+    x
+}
+""" }]
+exit_code = 5
+
+# In statement position, an unambiguously-binary `+` keeps the leading
+# block-like expression as its left operand (one addition, 10 + 5 = 15).
+[[case]]
+name = "if_then_plus_stays_binary"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    if true { 10 } else { 20 } + 5
+}
+""" }]
+exit_code = 15

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -49,6 +49,8 @@ use thiserror::Error;
 /// - **E0900-E0999**: Array errors
 /// - **E1000-E1099**: Linker/target errors
 /// - **E1100-E1199**: Preview feature errors
+/// - **E1200-E1299**: Comptime errors
+/// - **E1300-E1399**: Unchecked-code errors (raw pointers, `checked` blocks)
 /// - **E9000-E9999**: Internal compiler errors
 ///
 /// Once assigned, error codes must never change to maintain stability for
@@ -229,6 +231,11 @@ impl ErrorCode {
     // ========================================================================
     pub const COMPTIME_EVALUATION_FAILED: Self = Self(1200);
     pub const COMPTIME_ARG_NOT_CONST: Self = Self(1201);
+
+    // ========================================================================
+    // Unchecked-code errors (E1300-E1399)
+    // ========================================================================
+    pub const UNCHECKED_OP_REQUIRES_CHECKED: Self = Self(1300);
 
     // ========================================================================
     // Internal compiler errors (E9000-E9999)
@@ -1215,6 +1222,10 @@ pub enum ErrorKind {
     #[error("comptime parameter requires a compile-time known value")]
     ComptimeArgNotConst { param_name: String },
 
+    // Unchecked-code errors
+    #[error("{what} requires a `checked` block")]
+    UncheckedOpRequiresChecked { what: String },
+
     // Internal compiler errors (bugs in the compiler itself)
     #[error("internal compiler error: {0}")]
     InternalError(String),
@@ -1359,6 +1370,9 @@ impl ErrorKind {
             // Comptime errors (E1200-E1299)
             ErrorKind::ComptimeEvaluationFailed { .. } => ErrorCode::COMPTIME_EVALUATION_FAILED,
             ErrorKind::ComptimeArgNotConst { .. } => ErrorCode::COMPTIME_ARG_NOT_CONST,
+            ErrorKind::UncheckedOpRequiresChecked { .. } => {
+                ErrorCode::UNCHECKED_OP_REQUIRES_CHECKED
+            }
 
             // Internal compiler errors (E9000-E9999)
             ErrorKind::InternalError(_) => ErrorCode::INTERNAL_ERROR,

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -608,8 +608,13 @@ where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
     recursive(|expr| {
+        // Standalone block-like-statement parser (if/match/while/loop/block),
+        // threaded into the atom and block parsers so that a block-like
+        // expression in statement position is a complete statement (RUE-210).
+        let block_like = block_like_head_parser(expr.clone());
+
         // Atom parser - primary expressions
-        let atom = atom_parser(expr.clone());
+        let atom = atom_parser(expr.clone(), block_like);
 
         // Rust-refugee diagnostic: `expr as T` is not Rue syntax (`as` is an
         // ordinary identifier, so `5 as i64` used to die with a generic
@@ -936,8 +941,13 @@ where
 }
 
 /// Parser for control flow expressions: break, continue, return, if, while, loop, match
+///
+/// `block_like` is the standalone block-like-statement parser threaded down to
+/// the block bodies (`if`/`while`/`loop`/`match` arms) so those bodies apply
+/// the block-like statement-boundary rule (RUE-210).
 fn control_flow_parser<'src, I>(
     expr: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone + 'src,
+    block_like: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone + 'src,
 ) -> impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
@@ -945,8 +955,15 @@ where
     // Break: break <expr>? (a value operand parses, but sema always rejects
     // it - break does not carry a value; parsing it gives a better diagnostic
     // than treating the operand as a separate, unreachable statement)
+    //
+    // The operand is refused when it starts with `{` so that a bare `break`
+    // used as a loop/if condition does not swallow the following block as its
+    // value: in `while break {}` the `{}` is the loop body, not a block-valued
+    // operand of `break`. The `and_is(LBrace.not())` non-consuming guard makes
+    // the optional operand decline a leading brace, leaving it for the
+    // loop/if body parser (RUE-209). `break (expr)` is unaffected.
     let break_expr = just(TokenKind::Break)
-        .ignore_then(expr.clone().or_not())
+        .ignore_then(expr.clone().and_is(just(TokenKind::LBrace).not()).or_not())
         .map_with(|value, e| {
             Expr::Break(BreakExpr {
                 value: value.map(Box::new),
@@ -960,8 +977,12 @@ where
     };
 
     // Return expression: return <expr>? (expression is optional for unit-returning functions)
+    //
+    // As with `break` above, the optional operand declines a leading `{` so a
+    // bare `return` used as a loop/if condition does not swallow the following
+    // block as its value operand (RUE-209). `return (expr)` is unaffected.
     let return_expr = just(TokenKind::Return)
-        .ignore_then(expr.clone().or_not())
+        .ignore_then(expr.clone().and_is(just(TokenKind::LBrace).not()).or_not())
         .map_with(|value, e| {
             Expr::Return(ReturnExpr {
                 value: value.map(Box::new),
@@ -973,7 +994,7 @@ where
     let if_expr = recursive(|if_expr_rec| {
         just(TokenKind::If)
             .ignore_then(expr.clone())
-            .then(maybe_unit_block_parser(expr.clone()))
+            .then(maybe_unit_block_parser(expr.clone(), block_like.clone()))
             .then(
                 just(TokenKind::Else)
                     .ignore_then(choice((
@@ -987,7 +1008,7 @@ where
                             }
                         }),
                         // else { ... }: parse a regular block
-                        maybe_unit_block_parser(expr.clone()),
+                        maybe_unit_block_parser(expr.clone(), block_like.clone()),
                     )))
                     .or_not(),
             )
@@ -1005,7 +1026,7 @@ where
     // While expression
     let while_expr = just(TokenKind::While)
         .ignore_then(expr.clone())
-        .then(maybe_unit_block_parser(expr.clone()))
+        .then(maybe_unit_block_parser(expr.clone(), block_like.clone()))
         .map_with(|(cond, body), e| {
             Expr::While(WhileExpr {
                 cond: Box::new(cond),
@@ -1017,7 +1038,7 @@ where
 
     // Loop expression (infinite loop)
     let loop_expr = just(TokenKind::Loop)
-        .ignore_then(maybe_unit_block_parser(expr.clone()))
+        .ignore_then(maybe_unit_block_parser(expr.clone(), block_like.clone()))
         .map_with(|body, e| {
             Expr::Loop(LoopExpr {
                 body,
@@ -1367,6 +1388,7 @@ where
 /// Atom parser - primary expressions (literals, identifiers, parens, blocks, control flow)
 fn atom_parser<'src, I>(
     expr: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone + 'src,
+    block_like: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone + 'src,
 ) -> impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
@@ -1388,11 +1410,11 @@ where
         });
 
     // Block expression
-    let block_expr = block_parser(expr.clone());
+    let block_expr = block_parser(expr.clone(), block_like.clone());
 
     // Comptime block expression: comptime { expr }
     let comptime_expr = just(TokenKind::Comptime)
-        .ignore_then(block_parser(expr.clone()))
+        .ignore_then(block_parser(expr.clone(), block_like.clone()))
         .map_with(|inner_expr, e| {
             Expr::Comptime(ComptimeBlockExpr {
                 expr: Box::new(inner_expr),
@@ -1403,7 +1425,7 @@ where
     // Checked block expression: checked { expr }
     // Unchecked operations are only allowed inside checked blocks
     let checked_expr = just(TokenKind::Checked)
-        .ignore_then(block_parser(expr.clone()))
+        .ignore_then(block_parser(expr.clone(), block_like.clone()))
         .map_with(|inner_expr, e| {
             Expr::Checked(CheckedBlockExpr {
                 expr: Box::new(inner_expr),
@@ -1594,7 +1616,7 @@ where
     // Note: anon_struct_type_expr must come before call_and_access_parser since struct is a keyword
     let primary = choice((
         literal_parser(),
-        control_flow_parser(expr.clone()),
+        control_flow_parser(expr.clone(), block_like.clone()),
         self_expr,
         self_type_expr,
         any_intrinsic_call,
@@ -1800,6 +1822,24 @@ fn is_control_flow_expr(e: &Expr) -> bool {
     )
 }
 
+/// Returns true if the expression is "block-like": a control-flow form whose
+/// syntax ends in a `}` block (`if`/`match`/`while`/`loop`) or a bare block.
+///
+/// In statement position, a block-like expression immediately followed by a
+/// `-` is a complete statement, and the `-` starts a NEW statement as unary
+/// negation rather than continuing the subtraction `(block-like) - operand`.
+/// This is enforced in [`block_item_parser`] via [`block_like_head_parser`],
+/// which parses a leading block-like expression on its own (before the general
+/// Pratt expression that would otherwise absorb the `-`) (RUE-210). Note this
+/// excludes `break`/`continue`/`return`, which are diverging but not
+/// brace-terminated.
+fn is_block_like(e: &Expr) -> bool {
+    matches!(
+        e,
+        Expr::If(_) | Expr::Match(_) | Expr::While(_) | Expr::Loop(_) | Expr::Block(_)
+    )
+}
+
 /// Returns true if the expression diverges (has the Never type).
 /// These expressions can be promoted to the final expression of a block
 /// since Never coerces to any type.
@@ -1865,6 +1905,7 @@ fn is_diverging_expr(e: &Expr) -> bool {
 /// could otherwise be misparsed as expression `x` followed by unexpected `=`.
 fn block_item_parser<'src, I>(
     expr: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone + 'src,
+    block_like: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone + 'src,
 ) -> impl Parser<'src, I, BlockItem, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
@@ -1878,14 +1919,29 @@ where
     // Always requires a trailing semicolon.
     let assign_stmt = assign_statement_parser(expr.clone()).map(BlockItem::Statement);
 
+    // Block-like head: a leading `if`/`match`/`while`/`loop`/`{ }` in statement
+    // position that is immediately followed by a `-` is a *complete* statement,
+    // so it must be parsed on its own — NOT through the Pratt `expr` below,
+    // which would otherwise read the `-` as binary subtraction spanning two
+    // statements. Trying this before `expr` and stopping right after the block
+    // makes the `-` start a new statement (unary negation) instead (RUE-210).
+    // `block_like` only fires when a `-` follows; for every other follower it
+    // fails and `expr` handles the item unchanged. It is threaded in (rather
+    // than rebuilt here) because it is mutually recursive with this parser
+    // through the block bodies it contains, and it declines
+    // `break`/`return`/`continue`, which fall through to `expr`.
+    let block_like_head = block_like;
+
     // Expression-based item: parse expression ONCE, then decide based on what follows.
     // This avoids O(2^n) complexity from repeatedly re-parsing expressions with backtracking.
     //
-    // After parsing an expression, we check the next token:
+    // The head is `block_like_head` (a standalone block-like expression) or,
+    // failing that, the general Pratt `expr`. After parsing the head, we check
+    // the next token:
     // - `;` → expression statement (value discarded)
     // - `}` → final expression (block's return value)
     // - other → mid-block control flow (only valid for if/while/match/loop/break/continue/return)
-    let expr_item = expr
+    let expr_item = choice((block_like_head, expr))
         .then(
             choice((
                 just(TokenKind::Semi).to(ExprFollower::Semi),
@@ -1976,11 +2032,12 @@ fn process_block_items(items: Vec<BlockItem>, block_span: Span) -> (Vec<Statemen
 /// statement like `break`/`continue`/`return` to the final expression).
 fn maybe_unit_block_parser<'src, I>(
     expr: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone + 'src,
+    block_like: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone + 'src,
 ) -> impl Parser<'src, I, BlockExpr, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    block_item_parser(expr)
+    block_item_parser(expr, block_like)
         .repeated()
         .collect::<Vec<_>>()
         .delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace))
@@ -1999,11 +2056,58 @@ where
 /// for positions that need an expression (function bodies, standalone blocks).
 fn block_parser<'src, I>(
     expr: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone + 'src,
+    block_like: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone + 'src,
 ) -> impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    maybe_unit_block_parser(expr).map(Expr::Block)
+    maybe_unit_block_parser(expr, block_like).map(Expr::Block)
+}
+
+/// Standalone parser for a *block-like* expression (`if`/`match`/`while`/
+/// `loop`/`{ }`) in statement position that is immediately followed by a `-`.
+/// In that case the block-like expression is a complete statement and the `-`
+/// begins a NEW statement as unary negation, rather than continuing as the
+/// subtraction `(block-like) - operand` (RUE-210, see [`is_block_like`] and
+/// [`block_item_parser`]).
+///
+/// The `-` lookahead is what makes this narrow and safe: `-` is the only
+/// operator that is both a prefix (unary) and an infix (binary) operator, so it
+/// is the only token that can *silently* flip meaning across the boundary.
+/// Unambiguously-binary operators (`+`, `*`, `==`, ...) are left to the general
+/// Pratt expression, which keeps a leading block-like expression as their
+/// left operand (e.g. `{ a } + { b }` stays one addition). The other prefix
+/// operators (`!`, `~`) are never infix, so they already start a new statement
+/// without special handling.
+///
+/// It is `recursive` because the block bodies it contains hold block-items that
+/// again prefer this parser; the recursion knot lets those bodies reference the
+/// same parser lazily instead of triggering an infinite eager construction
+/// cycle. The `try_map` declines `break`/`return`/`continue`, so those fall
+/// through to the general Pratt expression and keep their optional operand.
+fn block_like_head_parser<'src, I>(
+    expr: impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone + 'src,
+) -> impl Parser<'src, I, Expr, ParserExtras<'src>> + Clone
+where
+    I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
+{
+    recursive(|block_like| {
+        choice((
+            control_flow_parser(expr.clone(), block_like.clone()),
+            block_parser(expr.clone(), block_like.clone()),
+        ))
+        .try_map(|e, span| {
+            if is_block_like(&e) {
+                Ok(e)
+            } else {
+                Err(Rich::custom(span, "not a block-like expression"))
+            }
+        })
+        // Only engage the statement boundary when a `-` follows (non-consuming),
+        // so all other operators keep binding through the Pratt path.
+        .then_ignore(just(TokenKind::Minus).rewind())
+        .boxed()
+    })
 }
 
 /// Parser for function definitions: [@directive]* [pub] [unchecked] fn name(params) -> Type { body }
@@ -2028,7 +2132,7 @@ where
         .then(just(TokenKind::Fn).ignore_then(ident_parser()))
         .then(params_parser().delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)))
         .then(just(TokenKind::Arrow).ignore_then(type_parser()).or_not())
-        .then(block_parser(expr))
+        .then(block_parser(expr.clone(), block_like_head_parser(expr)))
         .map_with(
             |((((((directives, visibility), is_unchecked), name), params), return_type), body),
              e| Function {
@@ -2190,7 +2294,7 @@ where
                 .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
         )
         .then(just(TokenKind::Arrow).ignore_then(type_parser()).or_not())
-        .then(block_parser(expr))
+        .then(block_parser(expr.clone(), block_like_head_parser(expr)))
         .map_with(
             |((((directives, name), (receiver, params)), return_type), body), e| Method {
                 directives,
@@ -2220,7 +2324,7 @@ where
         .ignore_then(just(TokenKind::Fn))
         .ignore_then(ident_parser())
         .then(self_param.delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)))
-        .then(block_parser(expr))
+        .then(block_parser(expr.clone(), block_like_head_parser(expr)))
         .map_with(|((type_name, self_param), body), e| DropFn {
             type_name,
             self_param,

--- a/crates/rue-spec/cases/items/unchecked.toml
+++ b/crates/rue-spec/cases/items/unchecked.toml
@@ -89,11 +89,11 @@ fn main() -> i32 {
 exit_code = 42
 
 # =============================================================================
-# Pointer type syntax - Phase 2 adds semantic analysis
+# Pointer type syntax and type checking
 # =============================================================================
 
-# These tests verify pointer types are recognized in the type system.
-# Phase 2 implemented pointer types (PtrConst, PtrMut).
+# These tests verify pointer types are recognized and type-checked
+# (PtrConst, PtrMut are fully analyzed; see spec 9.1:8-9.1:12).
 
 [[case]]
 name = "ptr_const_type_in_param"
@@ -133,3 +133,124 @@ fn takes_point_ptr(p: ptr const Point) -> i32 { 0 }
 fn main() -> i32 { 0 }
 """
 exit_code = 0
+
+# =============================================================================
+# Raw pointer type checking (spec 9.1:10)
+# =============================================================================
+
+# A pointer type is legal as a struct field (self-referential struct here).
+[[case]]
+name = "ptr_type_as_struct_field"
+spec = ["9.1:10"]
+source = """
+struct Node { next: ptr const Node, value: i32 }
+fn takes_node(n: Node) -> i32 { n.value }
+fn main() -> i32 { 0 }
+"""
+exit_code = 0
+
+# `ptr const T` and `ptr mut T` are distinct types: passing a const pointer
+# where a mut pointer is expected is a type error, and the diagnostic names the
+# pointee type on both sides.
+[[case]]
+name = "ptr_const_not_mut_mismatch"
+spec = ["9.1:10"]
+source = """
+fn wants_mut(p: ptr mut i32) -> i32 { 0 }
+fn main() -> i32 {
+    let x: i32 = 7;
+    let p: ptr const i32 = checked { @raw(x) };
+    wants_mut(p)
+}
+"""
+compile_fail = true
+error_contains = "expected ptr mut i32, found ptr const i32"
+
+# Two pointer types with different pointees are unequal; the message shows the
+# distinct pointee types rather than a bare `<ptr const>` placeholder.
+[[case]]
+name = "ptr_pointee_mismatch_names_pointee"
+spec = ["9.1:10"]
+source = """
+fn wants(p: ptr const i64) -> i32 { 0 }
+fn main() -> i32 {
+    let x: i32 = 7;
+    let p: ptr const i32 = checked { @raw(x) };
+    wants(p)
+}
+"""
+compile_fail = true
+error_contains = "expected ptr const i64, found ptr const i32"
+
+# =============================================================================
+# Unchecked-context enforcement (spec 9.1:1, 9.1:12)
+# =============================================================================
+
+# Calling an `unchecked fn` outside a `checked` block is a compile error.
+[[case]]
+name = "unchecked_fn_call_requires_checked"
+spec = ["9.1:1"]
+source = """
+unchecked fn danger() -> i32 { 42 }
+fn main() -> i32 {
+    danger()
+}
+"""
+compile_fail = true
+error_contains = "requires a `checked` block"
+
+# Calling an `unchecked fn` inside a `checked` block is legal.
+[[case]]
+name = "unchecked_fn_call_in_checked"
+spec = ["9.1:1"]
+source = """
+unchecked fn danger() -> i32 { 42 }
+fn main() -> i32 {
+    checked { danger() }
+}
+"""
+exit_code = 42
+
+# A raw-pointer intrinsic used outside a `checked` block is a compile error.
+[[case]]
+name = "ptr_read_outside_checked_rejected"
+spec = ["9.1:12"]
+source = """
+fn main() -> i32 {
+    let x: i32 = 5;
+    let p: ptr const i32 = checked { @raw(x) };
+    @ptr_read(p)
+}
+"""
+compile_fail = true
+error_contains = "requires a `checked` block"
+
+# `@raw` itself is an unchecked operation and is rejected outside `checked`.
+[[case]]
+name = "raw_outside_checked_rejected"
+spec = ["9.1:12"]
+source = """
+fn main() -> i32 {
+    let x: i32 = 5;
+    let p: ptr const i32 = @raw(x);
+    0
+}
+"""
+compile_fail = true
+error_contains = "requires a `checked` block"
+
+# The same pointer operations are accepted inside a `checked` block and run.
+[[case]]
+name = "ptr_ops_in_checked_ok"
+spec = ["9.1:12"]
+source = """
+fn main() -> i32 {
+    let mut x: i32 = 10;
+    checked {
+        let p: ptr mut i32 = @raw_mut(x);
+        @ptr_write(p, 42);
+    };
+    x
+}
+"""
+exit_code = 42

--- a/crates/rue-spec/cases/statements/expression-statements.toml
+++ b/crates/rue-spec/cases/statements/expression-statements.toml
@@ -72,3 +72,85 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Block-like Expression Statements (5.3:6, 5.3:7)
+# =============================================================================
+
+# A block-like expression in statement position is a complete statement without
+# a trailing semicolon.
+[[case]]
+name = "block_like_if_statement_no_semicolon"
+spec = ["5.3:6"]
+source = """
+fn main() -> i32 {
+    let mut x = 0;
+    if true { x = 42; } else { x = 0; }
+    x
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "block_like_match_statement_no_semicolon"
+spec = ["5.3:6"]
+source = """
+fn main() -> i32 {
+    let mut x = 0;
+    match 1 { 1 => { x = 7; }, _ => { x = 0; } }
+    x
+}
+"""
+exit_code = 7
+
+# A leading unary operator on the line after a block-like statement begins a NEW
+# statement; it does not extend the block-like expression into a subtraction.
+# The `if` value is discarded and `-1` is the block's tail (returns 255).
+[[case]]
+name = "block_like_if_then_unary_minus_is_new_statement"
+spec = ["5.3:7"]
+source = """
+fn main() -> i32 {
+    if true { 999 } else { 888 }
+    -1
+}
+"""
+exit_code = 255
+
+[[case]]
+name = "block_like_match_then_unary_minus_is_new_statement"
+spec = ["5.3:7"]
+source = """
+fn main() -> i32 {
+    match 1 { 1 => 999, _ => 888 }
+    -1
+}
+"""
+exit_code = 255
+
+# The rule is statement-position only: a block-like expression used as an
+# operand (here, a let right-hand side) still binds the ambiguous `-` as
+# subtraction as usual (10 - 5 = 5).
+[[case]]
+name = "block_like_minus_as_operand_still_binds"
+spec = ["5.3:7"]
+source = """
+fn main() -> i32 {
+    let x = if true { 10 } else { 20 } - 5;
+    x
+}
+"""
+exit_code = 5
+
+# In statement position, an unambiguously-binary operator (`+`) keeps a leading
+# block-like expression as its left operand: this is one addition, not two
+# statements (10 + 5 = 15).
+[[case]]
+name = "block_like_then_plus_stays_binary"
+spec = ["5.3:7"]
+source = """
+fn main() -> i32 {
+    if true { 10 } else { 20 } + 5
+}
+"""
+exit_code = 15

--- a/docs/spec/src/05-statements/03-expression-statements.md
+++ b/docs/spec/src/05-statements/03-expression-statements.md
@@ -34,3 +34,22 @@ fn main() -> i32 {
 {{ rule(id="5.3:5") }}
 
 Expression statements are useful for calling functions for their side effects while discarding their return values.
+
+## Block-like expression statements
+
+{{ rule(id="5.3:6", cat="normative") }}
+
+A *block-like expression* is an `if`, `match`, `while`, `loop`, or block (`{ ... }`) expression: one whose syntax is terminated by a closing brace. When a block-like expression appears in statement position (as an item of a block, rather than as an operand within a larger expression), it forms a complete statement on its own and does not require a trailing semicolon.
+
+{{ rule(id="5.3:7", cat="normative") }}
+
+When a block-like expression in statement position is immediately followed by a `-`, the `-` begins a *new* statement — a unary negation — rather than continuing the block-like expression as the left operand of a subtraction. For example, in a block containing `if c { a } else { b }` immediately followed by `-x`, the `if` expression is one statement and `-x` is a separate statement whose `-` is unary negation, not the subtraction `(if c { a } else { b }) - x`. The `-` is singled out because it is the only operator that is both a unary (prefix) and a binary (infix) operator, so it is the only one whose meaning at this boundary is otherwise ambiguous. This rule applies only in statement position: a block-like expression used as an operand (for example, on the right-hand side of a `let` binding, as in `let n = if c { a } else { b } - x;`) participates in the surrounding subtraction as usual.
+
+{{ rule(id="5.3:8") }}
+
+```rue
+fn main() -> i32 {
+    if true { 999 } else { 888 }  // a complete statement; value discarded
+    -1                            // a separate statement: unary negation
+}
+```

--- a/docs/spec/src/09-unchecked-code/01-syntax.md
+++ b/docs/spec/src/09-unchecked-code/01-syntax.md
@@ -75,15 +75,39 @@ Rue provides two raw pointer types for low-level memory access:
 ptr_type = "ptr" ( "const" | "mut" ) type ;
 ```
 
-{{ rule(id="9.1:10", cat="informative") }}
+{{ rule(id="9.1:10", cat="normative") }}
 
-Raw pointer types are parsed in Phase 1 but semantic analysis (type checking, pointer operations) is implemented in later phases. Until Phase 2 is implemented, using pointer types results in an "unknown type" error.
+Raw pointer types are fully type-checked: they may appear as the type of a
+local, a parameter, a struct field, or a function return type. A `ptr const T`
+and a `ptr mut T` are distinct types, and two pointer types are equal only when
+their pointee types `T` are equal — a `ptr const i32` is neither a `ptr mut
+i32` nor a `ptr const i64`.
 
 {{ rule(id="9.1:11", cat="example") }}
 
 ```rue
-// These parse correctly but fail type checking until Phase 2
 fn takes_ptr(p: ptr const i32) -> i32 { 0 }
 fn takes_mut_ptr(p: ptr mut i32) -> i32 { 0 }
-unchecked fn get_ptr() -> ptr const i32 { @panic() }
+fn identity_ptr(p: ptr const i32) -> ptr const i32 { p }
+struct Node { next: ptr const Node, value: i32 }
+```
+
+{{ rule(id="9.1:12", cat="legality-rule") }}
+
+A raw-pointer intrinsic — `@raw`, `@raw_mut`, `@ptr_read`, `@ptr_write`,
+`@ptr_offset`, `@ptr_to_int`, or `@int_to_ptr` — is an unchecked operation and
+**MUST** appear within a `checked` block. Using one outside a `checked` block is
+a compile error. (Defining a `ptr const T` / `ptr mut T` value's *type* is
+always legal; only the pointer *operations* require a `checked` block.)
+
+{{ rule(id="9.1:13", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    let x: i32 = 42;
+    // The pointer operations are wrapped in `checked`; the pointer types
+    // themselves need no `checked`.
+    let p: ptr const i32 = checked { @raw(x) };
+    checked { @ptr_read(p) }
+}
 ```


### PR DESCRIPTION
Three disjoint fixes from cycle 36 (parser + air), integrated together.

**RUE-209** — bare `break`/`return` used as a while/if condition no longer swallows the following body block; `while break {}` attaches its body and yields a clean, correctly-located E0206 instead of a desynced E0100 at an outer brace.

**RUE-210** — an `if`/`match`/block used as a *statement*, immediately followed by a line starting with unary `-`, now starts a new statement instead of parsing as a subtraction across two lines (narrowed to `-`, the only prefix+infix operator, so `{a}+{b}` still binds). Repro is now exit **255** (two statements), was 998; expression-position `-` still subtracts.

**RUE-8** (raw-pointer sema, ADR-0028 Phase 2) — audit found most of ADR-0028 already landed; closed two gaps: (A) pointer intrinsics / unchecked-fn calls compiled silently outside a `checked` block → now rejected with new **E1300** (unchecked-code error category) per spec 9.1; (B) pointer types printed as bare `<ptr const>` → now render the pointee (`ptr const i32`). Sema/error-only.

Verified by execution; full `./test.sh` green (432/432 normative). 14 new spec/CLI cases.

Fixes RUE-209
Fixes RUE-210
Fixes RUE-8

🤖 Generated with [Claude Code](https://claude.com/claude-code)