### PR TITLE
Comptime-match pattern legality + @ptr_offset miscompile (RUE-215, RUE-213)

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1104,6 +1104,38 @@ impl<'a> Sema<'a> {
                         && bool_true_covered
                         && bool_false_covered);
                 if prunable && exhaustive {
+                    // Pattern *legality* is independent of arm *selection*.
+                    // Spec 4.14:19 exempts only the analysis of unselected arm
+                    // *bodies* (and reaffirms exhaustiveness) — it does NOT
+                    // exempt the per-pattern legality rules of 4.7. So before
+                    // pruning we still range-check every integer pattern
+                    // against the scrutinee's declared type, exactly as the
+                    // normal path below does via check_pattern_int: E0800 for
+                    // an out-of-range literal (4.7:23) and E0801 for a negative
+                    // pattern on an unsigned scrutinee (4.7:24). The comptime
+                    // value substituted for the scrutinee mistypes as i32 at
+                    // AIR emission (a known limitation), so we take the
+                    // scrutinee's true type from Hindley-Milner inference
+                    // (RUE-215).
+                    let scrutinee_type =
+                        Self::get_resolved_type(ctx, scrutinee, span, "match scrutinee")?;
+                    if scrutinee_type.is_integer() {
+                        for (pattern, _) in &arms {
+                            if let RirPattern::Int {
+                                value: magnitude,
+                                negative,
+                                ..
+                            } = pattern
+                            {
+                                self.check_pattern_int(
+                                    *magnitude,
+                                    *negative,
+                                    scrutinee_type,
+                                    pattern.span(),
+                                )?;
+                            }
+                        }
+                    }
                     if let Some(body) = selected {
                         ctx.push_scope();
                         let result = self.analyze_inst(air, body, ctx)?;

--- a/crates/rue-cli-tests/cases/comptime_value_params.toml
+++ b/crates/rue-cli-tests/cases/comptime_value_params.toml
@@ -234,3 +234,95 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "10\n20\n30\n"
+
+[[case]]
+name = "comptime_match_out_of_range_pattern_rejected"
+description = "RUE-215 facet A: an out-of-range integer pattern is diagnosed (E0800) even when the comptime scrutinee lets the match be pruned. Pattern legality is independent of arm selection (spec 4.7:23)."
+files = [{ path = "main.rue", source = """
+fn f(comptime n: i8) -> i32 {
+    match n {
+        0 => 1,
+        200 => 2,
+        _ => 3,
+    }
+}
+fn main() -> i32 {
+    f(0)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0800", "out of range for type 'i8'"]
+
+[[case]]
+name = "match_out_of_range_pattern_control"
+description = "RUE-215 facet A control: identical body with a plain (non-comptime) i8 scrutinee is rejected the same way — confirms the check exists on the normal path."
+files = [{ path = "main.rue", source = """
+fn f(n: i8) -> i32 {
+    match n {
+        0 => 1,
+        200 => 2,
+        _ => 3,
+    }
+}
+fn main() -> i32 {
+    f(0)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0800", "out of range for type 'i8'"]
+
+[[case]]
+name = "comptime_match_negative_on_unsigned_rejected"
+description = "RUE-215 facet B: a negative pattern on an unsigned comptime scrutinee is diagnosed (E0801) even when the match is prunable (spec 4.7:24)."
+files = [{ path = "main.rue", source = """
+fn f(comptime n: u32) -> i32 {
+    match n {
+        0 => 1,
+        -1 => 2,
+        _ => 3,
+    }
+}
+fn main() -> i32 {
+    f(0)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0801", "u32"]
+
+[[case]]
+name = "match_negative_on_unsigned_control"
+description = "RUE-215 facet B control: identical body with a plain (non-comptime) u32 scrutinee is rejected the same way."
+files = [{ path = "main.rue", source = """
+fn f(n: u32) -> i32 {
+    match n {
+        0 => 1,
+        -1 => 2,
+        _ => 3,
+    }
+}
+fn main() -> i32 {
+    f(0)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0801", "u32"]
+
+[[case]]
+name = "comptime_match_in_range_pattern_still_runs"
+description = "RUE-215 guard: a valid comptime match with an in-range pattern still prunes and runs correctly — the added legality check does not disturb selection."
+files = [{ path = "main.rue", source = """
+fn f(comptime n: i8) -> i32 {
+    match n {
+        0 => 1,
+        100 => 2,
+        _ => 3,
+    }
+}
+fn main() -> i32 {
+    @dbg(f(100));
+    @dbg(f(0));
+    @dbg(f(50));
+    0
+}
+""" }]
+stdout = "2\n1\n3\n"

--- a/crates/rue-cli-tests/cases/pointers.toml
+++ b/crates/rue-cli-tests/cases/pointers.toml
@@ -84,6 +84,69 @@ fn main() -> i32 {
 """ }]
 stdout = "99\n"
 
+# @ptr_offset advances a pointer by offset * sizeof(pointee) and reads the
+# element at that offset — NOT element 0 (RUE-213). This differential case
+# asserts the exact runtime value at a non-zero offset: reading index 1 of
+# [10, 20, 30] must yield 20. A miscompiled address computation (missing or
+# wrong-direction scale) reads 10 or garbage instead.
+[[case]]
+name = "ptr_offset_reads_offset_element"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    let v: i32 = checked {
+        let base: ptr const i32 = @raw(arr[0]);
+        @ptr_read(@ptr_offset(base, 1))
+    };
+    @dbg(v);
+    let w: i32 = checked {
+        let base: ptr const i32 = @raw(arr[0]);
+        @ptr_read(@ptr_offset(base, 2))
+    };
+    @dbg(w);
+    0
+}
+""" }]
+stdout = "20\n30\n"
+
+# A negative @ptr_offset walks backward through the array: starting at
+# element 2 and offsetting by -1 must land on element 1 (20). This guards
+# the sign-extension of a narrow (i32) index — without it the -1 is treated
+# as ~4 billion and the address is corrupted (RUE-213).
+[[case]]
+name = "ptr_offset_negative_walks_backward"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    let v: i32 = checked {
+        let base: ptr const i32 = @raw(arr[2]);
+        @ptr_read(@ptr_offset(base, -1))
+    };
+    @dbg(v);
+    0
+}
+""" }]
+stdout = "20\n"
+
+# Writing through an offset `ptr mut` mutates the element at that offset,
+# not element 0 (RUE-213). Offset by 2 from arr[0], write 99, observe it at
+# arr[2].
+[[case]]
+name = "ptr_offset_write_hits_offset_element"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut arr: [i32; 3] = [10, 20, 30];
+    checked {
+        let base: ptr mut i32 = @raw_mut(arr[0]);
+        @ptr_write(@ptr_offset(base, 2), 99);
+    };
+    @dbg(arr[0]);
+    @dbg(arr[2]);
+    0
+}
+""" }]
+stdout = "10\n99\n"
+
 # Enforcement: a pointer operation outside a `checked` block is rejected
 # with E1300, not silently accepted (spec 9.1:12).
 [[case]]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2087,7 +2087,7 @@ impl<'a> CfgLower<'a> {
                     let ptr_val = args[0];
                     let offset_val = args[1];
                     let ptr_vreg = self.get_vreg(ptr_val);
-                    let offset_vreg = self.get_vreg(offset_val);
+                    let raw_offset_vreg = self.get_vreg(offset_val);
 
                     // Get the pointer type to determine element size
                     let ptr_type = self.ctx.cfg.get_inst(ptr_val).ty;
@@ -2098,8 +2098,53 @@ impl<'a> CfgLower<'a> {
                     };
                     let element_size = types::type_size_bytes(self.ctx.type_pool, pointee_type);
 
-                    // Calculate: ptr + (offset * element_size)
-                    // First, multiply offset by element size
+                    // Sign-/zero-extend the index to a full 64-bit value before
+                    // the 64-bit scale + subtract below. A narrow signed index
+                    // (e.g. an i32 `-1`) is zero-extended into the X register by
+                    // a W-write, so without an explicit sign-extend the 64-bit
+                    // multiply would treat it as ~4 billion and corrupt the
+                    // address (RUE-213).
+                    let offset_ty = self.ctx.cfg.get_inst(offset_val).ty;
+                    let offset_vreg = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(offset_vreg),
+                        src: Operand::Virtual(raw_offset_vreg),
+                    });
+                    let ext_dst = Operand::Virtual(offset_vreg);
+                    let ext_src = Operand::Virtual(offset_vreg);
+                    match (Self::type_bits(offset_ty), offset_ty.is_signed()) {
+                        (8, true) => self.mir.push(Aarch64Inst::Sxtb {
+                            dst: ext_dst,
+                            src: ext_src,
+                        }),
+                        (8, false) => self.mir.push(Aarch64Inst::Uxtb {
+                            dst: ext_dst,
+                            src: ext_src,
+                        }),
+                        (16, true) => self.mir.push(Aarch64Inst::Sxth {
+                            dst: ext_dst,
+                            src: ext_src,
+                        }),
+                        (16, false) => self.mir.push(Aarch64Inst::Uxth {
+                            dst: ext_dst,
+                            src: ext_src,
+                        }),
+                        (32, true) => self.mir.push(Aarch64Inst::Sxtw {
+                            dst: ext_dst,
+                            src: ext_src,
+                        }),
+                        // 32-bit unsigned already zero-extends; 64-bit is full width.
+                        _ => {}
+                    }
+
+                    // Calculate: ptr - (offset * element_size)
+                    // Aggregates (arrays) are laid out with element 0 at the
+                    // highest address and later elements at lower addresses
+                    // (the stack grows down), so array indexing subtracts
+                    // index * 8 from the base. @ptr_offset must subtract the
+                    // scaled offset too, so that advancing a pointer by N lands
+                    // on element N rather than walking off the array (RUE-213).
+                    // First, multiply offset by element size.
                     let scaled_offset_vreg = self.mir.alloc_vreg();
                     if element_size == 1 {
                         // No multiplication needed
@@ -2128,9 +2173,10 @@ impl<'a> CfgLower<'a> {
                         });
                     }
 
-                    // Add to pointer (64-bit add for addresses)
+                    // Subtract from pointer (64-bit sub for addresses); see the
+                    // descending-layout note above (RUE-213).
                     let result_vreg = self.mir.alloc_vreg();
-                    self.mir.push(Aarch64Inst::AddRR {
+                    self.mir.push(Aarch64Inst::SubRR {
                         dst: Operand::Virtual(result_vreg),
                         src1: Operand::Virtual(ptr_vreg),
                         src2: Operand::Virtual(scaled_offset_vreg),

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2410,7 +2410,7 @@ impl<'a> CfgLower<'a> {
                     let ptr_val = args[0];
                     let offset_val = args[1];
                     let ptr_vreg = self.get_vreg(ptr_val);
-                    let offset_vreg = self.get_vreg(offset_val);
+                    let raw_offset_vreg = self.get_vreg(offset_val);
 
                     // Get the pointer type to determine element size
                     let ptr_type = self.ctx.cfg.get_inst(ptr_val).ty;
@@ -2421,8 +2421,52 @@ impl<'a> CfgLower<'a> {
                     };
                     let element_size = types::type_size_bytes(self.ctx.type_pool, pointee_type);
 
-                    // Calculate: ptr + (offset * element_size)
-                    // First, multiply offset by element size
+                    // Sign-/zero-extend the index to a full 64-bit value before
+                    // the 64-bit scale + subtract below. A narrow signed index
+                    // (e.g. an i32 `-1`) sits in the low 32 bits with high bits
+                    // clear; without extension the 64-bit multiply would treat
+                    // it as ~4 billion and corrupt the address (RUE-213).
+                    let offset_ty = self.ctx.cfg.get_inst(offset_val).ty;
+                    let offset_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(offset_vreg),
+                        src: Operand::Virtual(raw_offset_vreg),
+                    });
+                    let ext_dst = Operand::Virtual(offset_vreg);
+                    let ext_src = Operand::Virtual(offset_vreg);
+                    match (Self::type_bits(offset_ty), offset_ty.is_signed()) {
+                        (8, true) => self.mir.push(X86Inst::Movsx8To64 {
+                            dst: ext_dst,
+                            src: ext_src,
+                        }),
+                        (8, false) => self.mir.push(X86Inst::Movzx8To64 {
+                            dst: ext_dst,
+                            src: ext_src,
+                        }),
+                        (16, true) => self.mir.push(X86Inst::Movsx16To64 {
+                            dst: ext_dst,
+                            src: ext_src,
+                        }),
+                        (16, false) => self.mir.push(X86Inst::Movzx16To64 {
+                            dst: ext_dst,
+                            src: ext_src,
+                        }),
+                        (32, true) => self.mir.push(X86Inst::Movsx32To64 {
+                            dst: ext_dst,
+                            src: ext_src,
+                        }),
+                        // 32-bit unsigned already zero-extends; 64-bit is full width.
+                        _ => {}
+                    }
+
+                    // Calculate: ptr - (offset * element_size)
+                    // Aggregates (arrays) are laid out with element 0 at the
+                    // highest address and later elements at lower addresses
+                    // (the stack grows down), so array indexing subtracts
+                    // index * 8 from the base. @ptr_offset must subtract the
+                    // scaled offset too, so that advancing a pointer by N lands
+                    // on element N rather than walking off the array (RUE-213).
+                    // First, multiply offset by element size.
                     let scaled_offset_vreg = self.mir.alloc_vreg();
                     if element_size == 1 {
                         // No multiplication needed
@@ -2453,13 +2497,14 @@ impl<'a> CfgLower<'a> {
                         });
                     }
 
-                    // Add to pointer (64-bit add for addresses)
+                    // Subtract from pointer (64-bit sub for addresses); see the
+                    // descending-layout note above (RUE-213).
                     let result_vreg = self.mir.alloc_vreg();
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Virtual(result_vreg),
                         src: Operand::Virtual(ptr_vreg),
                     });
-                    self.mir.push(X86Inst::AddRR64 {
+                    self.mir.push(X86Inst::SubRR64 {
                         dst: Operand::Virtual(result_vreg),
                         src: Operand::Virtual(scaled_offset_vreg),
                     });


### PR DESCRIPTION
**RUE-215** — the comptime match-pruning fast-path now runs the same per-pattern legality checks as the normal path before pruning (using the HM-resolved scrutinee type, since the comptime-substituted scrutinee mistypes as i32 at AIR emission). Out-of-range integer patterns (E0800) and negative-on-unsigned patterns (E0801) are now rejected in comptime matches, matching the non-comptime control. Comptime selection intact.

**RUE-213** (miscompile) — `@ptr_offset` read element 0 instead of the offset element. Root cause: this compiler lays aggregates with element 0 at the *highest* address (array indexing subtracts `index*size`), so `@ptr_offset` had to **subtract** the scaled offset. Also fixed a secondary bug: a narrow signed index (i32 `-1`) wasn't sign-extended before the 64-bit multiply → negative offsets segfaulted; added movsx/movzx (x86) + sxt/uxt (aarch64). Both backends.

Verified: RUE-215 both facets → E0800/E0801, controls intact; RUE-213 offsets 0/1/2 → 10/20/30 (was 10/0/0), negative -1/-2 → 20/10, aarch64 asm shows sxtw+sub. Full `./test.sh` green. 8 new CLI cases. Both found by autonomous hunts.

Fixes RUE-215
Fixes RUE-213

🤖 Generated with [Claude Code](https://claude.com/claude-code)