### PR TITLE
String byte access: s[i] -> u8 and substring (RUE-17 Phase 2, ADR-0035)

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -34,10 +34,10 @@ use rue_span::Span;
 
 use super::Sema;
 use super::analysis::move_out_of_inout_error;
-use super::context::{AnalysisContext, AnalysisResult, LocalVar};
+use super::context::{AnalysisContext, AnalysisResult, LocalVar, VariableMoveState};
 use crate::inst::{
-    Air, AirCallArg, AirInst, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef, AirProjection,
-    AirRef,
+    Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirPattern, AirPlaceBase, AirPlaceRef,
+    AirProjection, AirRef,
 };
 use crate::scope::ScopedContext;
 use crate::types::{Type, TypeKind};
@@ -3449,11 +3449,31 @@ impl<'a> Sema<'a> {
             return Ok(AnalysisResult::new(air_ref, elem_type));
         }
 
-        // Fallback: base is not a place (e.g., function call result)
-        // Spill the computed array to a temporary, then use PlaceRead.
-        // This handles `get_array()[i]` patterns.
+        // Fallback: base is not an array place (e.g. function-call result, or
+        // a String — which is a builtin struct, so `try_trace_place` bails at
+        // its non-array projection). Snapshot the base root's move state
+        // *before* analyzing it, in case this turns out to be a borrowing
+        // String index (see below).
+        let base_root = self.extract_root_variable(base);
+        let base_move_state_before = base_root.and_then(|v| ctx.moved_vars.get(&v).cloned());
         let base_result = self.analyze_inst(air, base, ctx)?;
         let base_type = base_result.ty;
+
+        // String byte indexing: `s[i]` reads the i-th BYTE of a String as `u8`
+        // (RUE-17 Phase 2, ADR-0035). O(1), bounds-checked at runtime: an
+        // `index >= s.len()` traps (exit 101), exactly like array indexing.
+        if self.is_builtin_string(base_type) {
+            return self.analyze_string_index_get(
+                air,
+                base_result,
+                base_root,
+                base_move_state_before,
+                index,
+                span,
+                ctx,
+            );
+        }
+
         let index_result = self.analyze_inst(air, index, ctx)?;
 
         // Verify base is an array
@@ -3545,6 +3565,81 @@ impl<'a> Sema<'a> {
             span,
         });
         Ok(AnalysisResult::new(block_ref, elem_type))
+    }
+
+    /// Analyze a String byte index read: `s[i] -> u8` (RUE-17 Phase 2,
+    /// ADR-0035).
+    ///
+    /// Indexing a String yields the i-th BYTE (not a char) as `u8`, lowering to
+    /// a checked runtime call `__rue_String_byte_at(ptr, len, cap, index)`. The
+    /// bounds check lives in the runtime: an `index >= len` traps (exit 101),
+    /// mirroring array indexing rather than producing UB.
+    ///
+    /// The index only *borrows* the String (it is neither consumed nor
+    /// mutated), so — like a `ByRef` builtin method — we undo the move the base
+    /// analysis recorded (`base_result` already analyzed) by restoring the
+    /// pre-analysis move state and cancelling the emitted move marker. That
+    /// keeps later uses of `s` valid and ensures the String is dropped exactly
+    /// once.
+    #[allow(clippy::too_many_arguments)]
+    fn analyze_string_index_get(
+        &mut self,
+        air: &mut Air,
+        base_result: AnalysisResult,
+        base_root: Option<Spur>,
+        base_move_state_before: Option<VariableMoveState>,
+        index: InstRef,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        // Un-move the borrowed receiver (mirrors ByRef builtin methods).
+        if let Some(var) = base_root {
+            match base_move_state_before {
+                Some(state) => {
+                    ctx.moved_vars.insert(var, state);
+                }
+                None => {
+                    ctx.moved_vars.remove(&var);
+                }
+            }
+        }
+        air.cancel_move_marker(base_result.air_ref);
+
+        // The index is an ordinary rvalue. Analyze it and require an integer
+        // type (signed or unsigned), matching array indexing (spec 7.1:7).
+        let index_result = self.analyze_inst(air, index, ctx)?;
+        if !index_result.ty.is_integer() && !index_result.ty.is_error() {
+            return Err(CompileError::new(
+                ErrorKind::TypeMismatch {
+                    expected: "an integer".to_string(),
+                    found: index_result.ty.safe_name_with_pool(Some(&self.type_pool)),
+                },
+                self.rir.get(index).span,
+            ));
+        }
+
+        // Lower to `__rue_String_byte_at(self, index) -> u8`. The String is
+        // passed by value in the AIR (codegen decomposes it into ptr/len/cap
+        // argument registers, as for other builtin String methods); the move
+        // was already cancelled above so this is a non-consuming read.
+        let call_name = self.interner.get_or_intern("__rue_String_byte_at");
+        let extra = [
+            base_result.air_ref.as_u32(),
+            AirArgMode::Normal.as_u32(),
+            index_result.air_ref.as_u32(),
+            AirArgMode::Normal.as_u32(),
+        ];
+        let args_start = air.add_extra(&extra);
+        let call_ref = air.add_inst(AirInst {
+            data: AirInstData::Call {
+                name: call_name,
+                args_start,
+                args_len: 2,
+            },
+            ty: Type::U8,
+            span,
+        });
+        Ok(AnalysisResult::new(call_ref, Type::U8))
     }
 
     /// Analyze an array index write.

--- a/crates/rue-builtins/src/lib.rs
+++ b/crates/rue-builtins/src/lib.rs
@@ -379,6 +379,26 @@ pub static STRING_TYPE: BuiltinTypeDef = BuiltinTypeDef {
             return_ty: BuiltinReturnType::SelfType,
             runtime_fn: "__rue_String_clone",
         },
+        // Byte-range slice: `s.substring(start, len)` returns a NEW String
+        // holding bytes [start, start+len) (RUE-17 Phase 2, ADR-0035). Since
+        // String is a byte string, any byte range is valid; only an
+        // out-of-range range traps at runtime (exit 101). Borrows self.
+        BuiltinMethod {
+            name: "substring",
+            receiver_mode: ReceiverMode::ByRef,
+            params: &[
+                BuiltinParam {
+                    name: "start",
+                    ty: BuiltinParamType::U64,
+                },
+                BuiltinParam {
+                    name: "len",
+                    ty: BuiltinParamType::U64,
+                },
+            ],
+            return_ty: BuiltinReturnType::SelfType,
+            runtime_fn: "__rue_String_substring",
+        },
         // Mutation methods (take &mut self, return modified String)
         BuiltinMethod {
             name: "push_str",
@@ -654,7 +674,15 @@ mod tests {
     fn test_all_string_methods_present() {
         // Verify all expected methods are defined
         let expected_methods = [
-            "len", "capacity", "is_empty", "clone", "push_str", "push", "clear", "reserve",
+            "len",
+            "capacity",
+            "is_empty",
+            "clone",
+            "substring",
+            "push_str",
+            "push",
+            "clear",
+            "reserve",
         ];
         for name in expected_methods {
             assert!(

--- a/crates/rue-cli-tests/cases/string_byte_access.toml
+++ b/crates/rue-cli-tests/cases/string_byte_access.toml
@@ -1,0 +1,106 @@
+# String byte access (RUE-17 Phase 2, ADR-0035).
+#
+# Rue's String is a byte string (conventionally UTF-8, not guaranteed valid).
+# `s[i]` reads the i-th BYTE as u8 (O(1), out-of-range traps exit 101), and
+# `s.substring(start, len)` returns a NEW String holding bytes [start, start+len)
+# (any byte range valid; out-of-range traps). These are exact-stdout runs of the
+# "café" demo through the real driver — the ABI (String passed as ptr/len/cap to
+# the runtime byte_at / substring calls) is exactly what a spec-harness stdout
+# check cannot exercise end to end.
+
+[section]
+id = "cli.string_byte_access"
+name = "String byte access"
+description = "Byte indexing and substring on the byte-string String type."
+
+[[case]]
+name = "cafe_byte_indexing"
+description = "The café demo: len is 5 bytes; s[0]=99 (c), s[3]=195/s[4]=169 (é), ASCII t[1]=98."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = "café";
+    @dbg(s.len());
+    @dbg(s[0]);
+    @dbg(s[3]);
+    @dbg(s[4]);
+    let t = "abc";
+    @dbg(t[1]);
+    0
+}
+""" }]
+exit_code = 0
+stdout = "5\n99\n195\n169\n98\n"
+
+[[case]]
+name = "index_out_of_bounds_traps"
+description = "Indexing past the last byte traps at runtime (exit 101), like array indexing."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = "café";
+    @dbg(s[5]);
+    0
+}
+""" }]
+exit_code = 101
+
+[[case]]
+name = "substring_byte_range"
+description = "s.substring(3, 2) yields the two bytes of é as an independent String; source s is untouched."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = "café";
+    let tail = s.substring(3, 2);
+    @dbg(tail.len());
+    @dbg(tail[0]);
+    @dbg(tail[1]);
+    @dbg(s.len());
+    0
+}
+""" }]
+exit_code = 0
+stdout = "2\n195\n169\n5\n"
+
+[[case]]
+name = "substring_result_is_mutable"
+description = "The new String from substring owns a heap buffer and can be mutated further."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = "café";
+    let mut g = s.substring(0, 3);
+    g.push_str("X");
+    @dbg(g.len());
+    @dbg(g[3]);
+    0
+}
+""" }]
+exit_code = 0
+stdout = "4\n88\n"
+
+[[case]]
+name = "substring_out_of_range_traps"
+description = "start+len past the end traps at runtime (exit 101)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = "café";
+    let bad = s.substring(3, 3);
+    @dbg(bad.len());
+    0
+}
+""" }]
+exit_code = 101
+
+[[case]]
+name = "indexed_byte_feeds_u8_arithmetic"
+description = "A u8 from s[i] must be zero-extended into the full return register so a later u8 overflow-checked add does not spuriously trap (byte_at returns u64 to honor the Rue sub-word return ABI)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = "abc";
+    let c: u8 = s[0];   // 97
+    let d: u8 = s[1];   // 98
+    let e: u8 = c + d;  // 195, must NOT trap as overflow
+    @dbg(e);
+    0
+}
+""" }]
+exit_code = 0
+stdout = "195\n"

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -551,6 +551,128 @@ pub extern "C" fn __rue_String_is_empty(_ptr: *const u8, len: u64, _cap: u64) ->
 }
 
 // =============================================================================
+// String Byte Access (RUE-17 Phase 2, ADR-0035)
+// =============================================================================
+//
+// Rue's String is a byte string (conventionally UTF-8, not guaranteed valid),
+// so byte-level access looks INSIDE the raw bytes. Both operations below take
+// a String by borrow (ptr, len, cap) and bounds-check against `len`, trapping
+// (exit 101, via `__rue_bounds_check`) on out-of-range access — exactly like
+// array indexing. Neither respects UTF-8 char boundaries: any in-range byte
+// index / byte range is valid.
+
+crate::define_for_all_platforms! {
+    /// Read the byte at `index` in a String, returning it as `u8`.
+    ///
+    /// Implements `s[i]` for String (ADR-0035). O(1): a single load from
+    /// `ptr + index` after a bounds check. An `index >= len` traps at runtime
+    /// (index-out-of-bounds panic, exit 101), matching array indexing.
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_String_byte_at(ptr: *const u8, len: u64, cap: u64, index: u64) -> u64
+    /// ```
+    ///
+    /// The String is passed by borrow as its three fields (ptr, len, cap);
+    /// `cap` is unused but part of the ABI. The byte is returned in the return
+    /// register (`rax` / `x0`).
+    ///
+    /// The result is the language-level `u8` `s[i]`, but the function returns
+    /// `u64` deliberately: the Rue calling convention expects a sub-word return
+    /// value to occupy the *entire* return register zero-extended (Rue's own
+    /// functions emit `mov rax, <u8>`, and the caller reads the full register
+    /// without re-narrowing). A Rust `-> u8` leaves the upper bits of `rax`
+    /// unspecified, which would poison a later `u8` arithmetic overflow check
+    /// on the value. Returning `u64` forces the byte into a clean, fully
+    /// zero-extended register that honors that contract.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `ptr` points to a valid buffer of at least `len`
+    /// bytes. The in-range read below is then sound because the bounds check
+    /// guarantees `index < len`.
+    #[allow(non_snake_case)]
+    pub extern "C" fn __rue_String_byte_at(ptr: *const u8, len: u64, _cap: u64, index: u64) -> u64 {
+        if index >= len {
+            // Never returns: prints "error: index out of bounds" and exits 101.
+            crate::error::__rue_bounds_check();
+        }
+        // SAFETY: `index < len` (checked above) and the caller guarantees `ptr`
+        // is valid for `len` bytes, so `ptr.add(index)` is in bounds. u8 has no
+        // alignment requirement. Zero-extend to u64 so the whole return
+        // register is clean (see ABI note above).
+        unsafe { *ptr.add(index as usize) as u64 }
+    }
+}
+
+crate::define_for_all_platforms! {
+    /// Return a NEW String containing the byte range `[start, start + sub_len)`.
+    ///
+    /// Implements `s.substring(start, sub_len)` (ADR-0035). Because String is a
+    /// byte string, ANY byte range is valid (no char-boundary trap, unlike
+    /// Rust's `str` slicing); only an out-of-range range (`start + sub_len >
+    /// len`, or an overflowing `start + sub_len`) traps (exit 101). The
+    /// returned String owns a fresh heap allocation holding a copy of the
+    /// bytes, so it can be mutated and dropped independently of the source.
+    ///
+    /// # ABI (sret convention)
+    ///
+    /// ```text
+    /// extern "C" fn __rue_String_substring(
+    ///     out: *mut StringResult, ptr: *const u8, len: u64, cap: u64,
+    ///     start: u64, sub_len: u64)
+    /// ```
+    ///
+    /// `out` (the sret pointer) comes first, then the source String's fields
+    /// (`cap` unused), then the range arguments.
+    #[allow(non_snake_case)]
+    pub extern "C" fn __rue_String_substring(
+        out: *mut StringResult,
+        ptr: *const u8,
+        len: u64,
+        _cap: u64,
+        start: u64,
+        sub_len: u64,
+    ) {
+        // Out-of-range (or overflowing) range traps, matching array indexing.
+        match start.checked_add(sub_len) {
+            Some(end) if end <= len => {}
+            _ => crate::error::__rue_bounds_check(),
+        }
+
+        if sub_len == 0 {
+            // Empty result: a valid literal-like String (cap == 0, ptr null)
+            // that drops without freeing.
+            // SAFETY: `out` is a valid sret pointer — see __rue_String_new.
+            unsafe {
+                (*out).ptr = core::ptr::null_mut();
+                (*out).len = 0;
+                (*out).cap = 0;
+            }
+            return;
+        }
+
+        let new_cap = if sub_len < STRING_MIN_CAPACITY {
+            STRING_MIN_CAPACITY
+        } else {
+            sub_len
+        };
+        let new_ptr = heap::alloc(new_cap, 1);
+
+        // SAFETY: `start + sub_len <= len` (checked above) so the source range
+        // is in bounds; `new_ptr` was just allocated with `new_cap >= sub_len`
+        // bytes; the regions don't overlap (fresh allocation).
+        unsafe {
+            core::ptr::copy_nonoverlapping(ptr.add(start as usize), new_ptr, sub_len as usize);
+            (*out).ptr = new_ptr;
+            (*out).len = sub_len;
+            (*out).cap = new_cap;
+        }
+    }
+}
+
+// =============================================================================
 // String Clone Method (Phase 8)
 // =============================================================================
 //

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -602,3 +602,133 @@ fn main() -> i32 {
 }
 """
 exit_code = 0
+
+# =============================================================================
+# Byte Access (RUE-17 Phase 2, ADR-0035)
+# =============================================================================
+
+[[case]]
+name = "string_index_ascii_byte"
+spec = ["3.7:15", "3.7:16"]
+source = """
+fn main() -> i32 {
+    let t = "abc";
+    @dbg(t[1]);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "98\n"
+
+[[case]]
+name = "string_index_utf8_bytes"
+spec = ["3.7:15", "3.7:16"]
+source = """
+fn main() -> i32 {
+    let s = "café";
+    @dbg(s[0]);
+    @dbg(s[3]);
+    @dbg(s[4]);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "99\n195\n169\n"
+
+[[case]]
+name = "string_index_does_not_consume"
+spec = ["3.7:16"]
+source = """
+fn main() -> i32 {
+    let s = "hello";
+    @dbg(s[0]);
+    @dbg(s.len());
+    @dbg(s[1]);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "104\n5\n101\n"
+
+[[case]]
+name = "string_index_out_of_bounds_traps"
+spec = ["3.7:17"]
+source = """
+fn main() -> i32 {
+    let s = "café";
+    @dbg(s[5]);
+    0
+}
+"""
+exit_code = 101
+
+[[case]]
+name = "string_substring_len"
+spec = ["3.7:19"]
+source = """
+fn main() -> i32 {
+    let s = "café";
+    let tail = s.substring(3, 2);
+    @dbg(tail.len());
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "2\n"
+
+[[case]]
+name = "string_substring_bytes"
+spec = ["3.7:15", "3.7:19"]
+source = """
+fn main() -> i32 {
+    let s = "café";
+    let tail = s.substring(3, 2);
+    @dbg(tail[0]);
+    @dbg(tail[1]);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "195\n169\n"
+
+[[case]]
+name = "string_substring_empty"
+spec = ["3.7:19"]
+source = """
+fn main() -> i32 {
+    let s = "café";
+    let e = s.substring(2, 0);
+    @dbg(e.len());
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "0\n"
+
+[[case]]
+name = "string_substring_does_not_consume"
+spec = ["3.7:19"]
+source = """
+fn main() -> i32 {
+    let s = "hello";
+    let mid = s.substring(1, 3);
+    @dbg(mid.len());
+    @dbg(s.len());
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "3\n5\n"
+
+[[case]]
+name = "string_substring_out_of_bounds_traps"
+spec = ["3.7:20"]
+source = """
+fn main() -> i32 {
+    let s = "café";
+    let bad = s.substring(3, 3);
+    @dbg(bad.len());
+    0
+}
+"""
+exit_code = 101

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -104,14 +104,68 @@ fn main() -> i32 {
 }
 ```
 
+## Byte Access
+
+{{ rule(id="3.7:15", cat="normative") }}
+
+A `String` is a byte string: its contents are conventionally UTF-8 but are not
+required to be valid UTF-8 (see ADR-0035). Byte access therefore operates on the
+raw bytes and never inspects UTF-8 character boundaries.
+
+{{ rule(id="3.7:16", cat="normative") }}
+
+Indexing a `String` with an integer, `s[i]`, evaluates to the byte at byte
+offset `i` as a value of type `u8`. The operation is `O(1)`.
+
+{{ rule(id="3.7:17", cat="dynamic-semantics") }}
+
+If the index `i` is greater than or equal to `s.len()`, evaluating `s[i]` traps
+(index out of bounds), terminating the program the same way an out-of-bounds
+array index does.
+
+{{ rule(id="3.7:18") }}
+
+```rue
+fn main() -> i32 {
+    let s = "café";   // 5 bytes: 'c' 'a' 'f' 0xC3 0xA9
+    @dbg(s[0]);        // 99  ('c')
+    @dbg(s[3]);        // 195 (0xC3)
+    @dbg(s[4]);        // 169 (0xA9)
+    0
+}
+```
+
+{{ rule(id="3.7:19", cat="normative") }}
+
+The method `s.substring(start, len)` returns a new `String` containing the byte
+range `[start, start + len)` copied from `s`. Because `String` is a byte string,
+any byte range is permitted; the range need not fall on UTF-8 character
+boundaries. The receiver `s` is borrowed, not consumed.
+
+{{ rule(id="3.7:20", cat="dynamic-semantics") }}
+
+If `start + len` is greater than `s.len()` (or the addition overflows),
+`s.substring(start, len)` traps (index out of bounds).
+
+{{ rule(id="3.7:21") }}
+
+```rue
+fn main() -> i32 {
+    let s = "café";
+    let tail = s.substring(3, 2);   // the two bytes of 'é'
+    @dbg(tail.len());               // 2
+    0
+}
+```
+
 ## Limitations
 
 {{ rule(id="3.7:14", cat="informative") }}
 
 The current implementation does not support:
 - String concatenation
-- String indexing or slicing
+- Slicing with range syntax (`s[a..b]`); use `s.substring(start, len)` instead
+- Decoding bytes into Unicode scalar values (e.g. iterating `chars`)
 - Pattern matching on strings
-- Mutable strings
 
 These features may be added in future versions.


### PR DESCRIPTION
First implementation of the byte-string model (ADR-0035) — a program can now look *inside* a String at the byte level.

- **`s[i] -> u8`** — O(1) byte indexing via a checked runtime call; index ≥ len traps (exit 101). **Café demo verified by execution:** `"café".len()` == 5, `s[0]`=99, `s[3]`=195, `s[4]`=169 (the two UTF-8 bytes of `é`), `s[5]` traps.
- **`s.substring(start, len) -> String`** — new heap String over bytes `[start, start+len)`; source not consumed; any in-range byte range is valid (no char-boundary trap — it's a byte string); out-of-range traps.

**Subtle ABI bug caught + fixed mid-implementation:** a `u8` from `s[i]` poisoned a later `u8` overflow-checked add (97+98 spuriously trapped) — Rue's ABI expects sub-word returns zero-extended into the full return register, but a Rust `-> u8` leaves the upper bits unspecified. Fixed by returning `u64` (zero-extended) from `byte_at`; one runtime change, both backends.

Phases 1 (int→string, concat) and 3 (`.chars()` decode — blocked on iterators, RUE-219) remain. Spec 3.7:15–21 added, citing ADR-0035. Full `./test.sh` green (596/596 normative). 6 CLI + 9 spec cases.

Part of RUE-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)