### PR TITLE
Conformance behavior taxonomy + prefer-defined ADR (RUE-203)

### DIFF
--- a/docs/designs/0036-behavior-classification-preference.md
+++ b/docs/designs/0036-behavior-classification-preference.md
@@ -1,0 +1,105 @@
+---
+id: 0036
+title: "Behavior classification preference: prefer the most-defined category"
+status: accepted
+tags: [spec, conformance, safety, principle]
+feature-flag:
+created: 2026-07-02
+accepted: 2026-07-02
+implemented:
+spec-sections: ["1.3"]
+superseded-by:
+---
+
+# ADR-0036: Behavior classification preference
+
+## Status
+
+Accepted. Ratified by Steve on 2026-07-02. This is a **design preference / spec-
+authoring principle**, not a normative rule of the specification — it guides how
+*we* classify a new behavior when extending the spec, not what a conforming
+implementation must do. It is recorded as its own ADR (per the "ADR-per-
+principle" decision, RUE-201) so it can be cited individually and repealed
+individually via `superseded-by:` if Rue's taste changes.
+
+## Summary
+
+When the specification assigns a program behavior to one of the four conformance
+categories (undefined / unspecified / implementation-defined / erroneous — see
+spec 1.3), Rue **prefers the most-defined category available**, and **confines
+undefined behavior to `unchecked` operations for which a check is genuinely
+impractical** (would require changing a value's representation, e.g. fat
+pointers, or would otherwise defeat the purpose of `unchecked`). This is a
+preference that admits case-by-case judgment, not an absolute rule.
+
+## Context
+
+Rue's whole personality is "trap, don't corrupt, and never invoke undefined
+behavior in safe code": integer overflow traps, out-of-bounds indexing traps,
+a live-unreachable block traps, a moved value is a compile error. The
+conformance taxonomy (spec 1.3, adopted from C/C++/Rust) gives four homes for
+behavior, and the question is *how opinionated Rue is about pushing behaviors
+toward the defined end*.
+
+The tension is that the cost of "define/trap instead of leaving undefined" is not
+uniform:
+
+- Some hazards are checkable for **free** — a null-pointer dereference already
+  faults in hardware; it can be defined-to-trap at no cost.
+- Some are **not checkable without changing the representation** — an
+  out-of-bounds raw-pointer access has no bounds to check against unless raw
+  pointers become fat pointers, which defeats the point of `unchecked`. These are
+  genuinely undefined.
+
+So a blanket "always trap in `unchecked`" rule would be wrong (it would gut
+`unchecked`), and a blanket "`unchecked` is C-style UB" rule would be more lax
+than Rue's character warrants. The preference below captures the intent without
+over-committing to either extreme.
+
+## Decision
+
+**Prefer the most-defined category available; confine undefined behavior to
+`unchecked` operations where a check is genuinely impractical.**
+
+Concretely, when classifying a behavior:
+
+1. If the result can be fully specified, it is **defined** (state it).
+2. If it is a checkable error, prefer to **trap** it as a defined panic (this is
+   why overflow/bounds/div-zero are *defined*, not erroneous) — or, where a
+   defined-but-wrong result plus a recommended diagnosis is the better fit, mark
+   it **erroneous**.
+3. Reserve **undefined** for `unchecked` operations whose validity cannot be
+   checked without changing a type's representation or otherwise defeating the
+   purpose of `unchecked` (out-of-bounds / dangling / type-punned raw-pointer
+   access).
+4. Free or already-happening checks (e.g. a hardware trap) should be *defined*,
+   not undefined, even inside `unchecked`.
+
+The per-`unchecked`-operation classifications are worked out as chapter 9 (raw
+pointers / unchecked code) is written; this ADR is the lens applied there.
+
+## Consequences
+
+### Positive
+- Keeps Rue's "no surprises" character consistent all the way to the unsafe
+  boundary: you get the fast path, and where you're wrong you find out (trap),
+  except where finding out is genuinely impossible.
+- Gives a single, citable rule for classifying future behaviors — the rail a
+  contributor (or a lesser model) follows so the taxonomy stays consistent.
+
+### Negative
+- It is a *preference*, so it still requires judgment per behavior (deliberately —
+  the alternative absolutes are both wrong).
+- Some `unchecked` operations remain genuinely undefined; Rue does not promise to
+  trap everything in `unchecked`.
+
+## Alternatives Considered
+
+- **"Always trap in `unchecked`."** Rejected: would require fat pointers /
+  representation changes and defeat the purpose of `unchecked`.
+- **"`unchecked` is C-style undefined behavior, full stop."** Rejected as the
+  *default lean*: more lax than Rue's character; free/cheap checks should be
+  defined.
+- **No stated preference (classify ad-hoc).** Rejected: without a written lens,
+  classifications drift and become inconsistent — exactly the kind of leak the
+  spec-quality rebuild (RUE-201) is closing.

--- a/docs/spec/src/01-introduction.md
+++ b/docs/spec/src/01-introduction.md
@@ -52,6 +52,28 @@ Paragraphs marked with rule categories are normative unless explicitly marked as
 | `informative` | Explanatory text that is not normative |
 | `example` | Code examples that are not normative |
 
+## Behavior Categories
+
+{{ rule(id="1.3:3", cat="informative") }}
+
+Beyond the paragraph categories above, this specification classifies the *behavior* of a program into four categories, following C, C++, and Rust. Rue's guiding design preference for how a behavior is assigned to a category — in short, prefer the most-defined category, and confine undefined behavior to `unchecked` operations that cannot be checked otherwise — is a design decision recorded in ADR-0036, not a normative rule of this document.
+
+{{ rule(id="1.3:4", cat="informative") }}
+
+**Undefined behavior** imposes no requirements on a conforming implementation: a program that exhibits undefined behavior is invalid, and the implementation may do anything. In Rue, undefined behavior arises **only within `unchecked` code** — raw-pointer operations whose validity cannot be checked without changing a value's representation. The safe subset of Rue has no undefined behavior; this is the language's central memory-safety guarantee.
+
+{{ rule(id="1.3:5", cat="informative") }}
+
+**Unspecified behavior** is behavior for which this specification permits a set of possibilities and does not require any particular one to be chosen or documented. Rue currently specifies most such choices — for example evaluation order (4.0) and drop order (3.9) — so this category has few instances today; it is defined for future use.
+
+{{ rule(id="1.3:6", cat="informative") }}
+
+**Implementation-defined behavior** is behavior for which this specification permits a set of possibilities and requires the implementation to choose one and **document** its choice. Examples: the growth strategy and resulting capacity of `String` (3.7); the in-memory layout of struct and array types (3.6); the width of `usize` and `isize` on a target (3.1); and the implementation limits of Appendix C.
+
+{{ rule(id="1.3:7", cat="informative") }}
+
+**Erroneous behavior** is behavior that is well-defined but constitutes a program error a conforming implementation is encouraged to diagnose — distinct from undefined behavior, which imposes no requirements at all. Rue currently has no erroneous behavior: conditions other languages leave erroneous, such as integer overflow, Rue instead *traps* as a defined runtime panic (3.1, 8.1). The category is defined so behaviors of this kind have a home if they later arise (for example, an opt-in wrapping-arithmetic mode).
+
 ## Normative Language
 
 {{ rule(id="1.4:1") }}

--- a/docs/spec/src/03-types/06-struct-types.md
+++ b/docs/spec/src/03-types/06-struct-types.md
@@ -50,7 +50,7 @@ Field names **MUST** be unique within a struct.
 
 {{ rule(id="3.6:7", cat="informative") }}
 
-The memory layout rules described in this section are provisional and may change in future versions of Rue. The current design prioritizes simplicity over space efficiency.
+The in-memory layout of struct types is **implementation-defined** (see 1.3:6): the implementation chooses and documents it. The current implementation prioritizes simplicity over space efficiency, and the layout may change between versions. A portable program must not depend on specific field offsets, padding, or overall size beyond what the specification guarantees; a program that inspects layout (for example through `unchecked` raw-pointer access) observes an implementation-defined result.
 
 {{ rule(id="3.6:8", cat="normative") }}
 


### PR DESCRIPTION
Implements the 2026-07-02 design decision (Steve + Fable). Adds the four-category conformance vocabulary to the spec — intro **1.3:3–7**, informative (following how the intro defines MUST/SHOULD): **undefined / unspecified / implementation-defined / erroneous**, per C/C++/Rust. Records the current Rue reality honestly:
- **undefined** arises *only* within `unchecked` code — the safe subset has none (the central memory-safety guarantee);
- **unspecified** — few instances today (eval/drop order are specified);
- **implementation-defined** — String capacity/growth, struct/array layout, usize/isize width, Appendix C limits;
- **erroneous** — currently *empty* (overflow etc. traps as a defined panic, not erroneous); defined for future use (e.g. an opt-in wrapping-arithmetic mode).

Retires the **"provisional"** hedge on struct layout (3.6:7) → implementation-defined.

The design *preference* (prefer the most-defined category; confine UB to `unchecked` where a check is impractical) is methodology, not a conformance rule — so it's **not** in the normative spec; it's **ADR-0036**, individually citable and repealable. Per-`unchecked`-operation classifications accrue as chapter 9 is written.

Traceability 100% normative (591/591); full `./test.sh` green. Shapes RUE-202 (the prose rewrite now has the vocabulary to fill silent gaps).

Fixes RUE-203

🤖 Generated with [Claude Code](https://claude.com/claude-code)