### PR TITLE
Reject type-valued values in runtime position instead of ICEing codegen (RUE-217)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1343,6 +1343,31 @@ impl<'a> Sema<'a> {
         )
     }
 
+    /// Reject a `type`-valued declaration that would need to exist at runtime.
+    ///
+    /// A parameter of type `type` must be marked `comptime` (spec 4.14:5); a
+    /// non-comptime `type` parameter would carry a type value at runtime, which
+    /// spec 4.14:6 forbids. Both facets otherwise slip past sema and ICE in
+    /// codegen ("block has no terminator", RUE-217), so we surface a clean
+    /// compile-time diagnostic here. Comptime `type` parameters are erased
+    /// during specialization and never reach runtime, so they are allowed.
+    fn reject_runtime_type_value(
+        &self,
+        ty: Type,
+        is_comptime: bool,
+        span: Span,
+    ) -> CompileResult<()> {
+        if ty.is_comptime_type() && !is_comptime {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: "a parameter of type `type` must be marked `comptime`".to_string(),
+                },
+                span,
+            ));
+        }
+        Ok(())
+    }
+
     fn analyze_single_function(
         &mut self,
         infer_ctx: &InferenceContext,
@@ -1365,6 +1390,11 @@ impl<'a> Sema<'a> {
             .iter()
             .map(|p| {
                 let ty = self.resolve_type(p.ty, span)?;
+                // spec 4.14:5 — a parameter of type `type` must be marked
+                // `comptime`. Without this gate a `type`-valued runtime
+                // parameter flows into codegen and ICEs ("block has no
+                // terminator", RUE-217) instead of a clean legality error.
+                self.reject_runtime_type_value(ty, p.is_comptime, span)?;
                 Ok((p.name, ty, p.mode, p.is_comptime))
             })
             .collect::<CompileResult<Vec<_>>>()?;
@@ -1433,6 +1463,10 @@ impl<'a> Sema<'a> {
         // Add regular parameters with their modes
         for p in params.iter() {
             let ty = self.resolve_type_with_self(p.ty, struct_type, span)?;
+            // spec 4.14:5 — a parameter of type `type` must be marked
+            // `comptime` (RUE-217); reject the runtime-`type` case cleanly
+            // rather than letting it ICE in codegen.
+            self.reject_runtime_type_value(ty, p.is_comptime, span)?;
             param_info.push((p.name, ty, p.mode, p.is_comptime));
         }
 

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -418,6 +418,21 @@ impl<'a> Sema<'a> {
                 let mut resolved_fields = Vec::new();
                 for (field_name, field_type) in &fields {
                     let field_ty = self.resolve_type(*field_type, inst.span)?;
+                    // spec 4.14:6 — type values cannot exist at runtime. A
+                    // struct field of type `type` is a runtime storage slot for
+                    // a type value, which is forbidden; reject it at the
+                    // declaration rather than letting a `Holder { t: i32 }`
+                    // literal ICE in codegen ("block has no terminator",
+                    // RUE-217). Mirrors the clean E1200 that
+                    // `let t = comptime { i32 };` already produces.
+                    if field_ty.is_comptime_type() {
+                        return Err(CompileError::new(
+                            ErrorKind::ComptimeEvaluationFailed {
+                                reason: "type values cannot exist at runtime".to_string(),
+                            },
+                            inst.span,
+                        ));
+                    }
                     resolved_fields.push(StructField {
                         name: self.interner.resolve(&*field_name).to_string(),
                         ty: field_ty,

--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -346,3 +346,42 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["E0903"]
+
+[[case]]
+name = "runtime_type_param_rue217"
+description = "RUE-217: a non-comptime parameter of type `type` reached codegen and ICEd ('block has no terminator'). Now a clean E1200 (spec 4.14:5)."
+files = [{ path = "main.rue", source = """
+fn f(t: type) -> i32 { 0 }
+fn main() -> i32 { f(i32) }
+""" }]
+compile_fail = true
+error_contains = ["E1200", "must be marked `comptime`"]
+
+[[case]]
+name = "type_struct_field_rue217"
+description = "RUE-217: a struct field of type `type` reached codegen and ICEd ('block has no terminator'). Now a clean E1200 (spec 4.14:6)."
+files = [{ path = "main.rue", source = """
+struct Holder { t: type }
+fn main() -> i32 { let h = Holder { t: i32 }; 0 }
+""" }]
+compile_fail = true
+error_contains = ["E1200", "type values cannot exist at runtime"]
+
+[[case]]
+name = "runtime_type_method_param_rue217"
+description = "RUE-217: a non-comptime `type` parameter on an inline struct method also ICEd; now a clean E1200 (spec 4.14:5)."
+files = [{ path = "main.rue", source = """
+struct S { x: i32, fn m(self, t: type) -> i32 { 0 } }
+fn main() -> i32 { let s = S { x: 1 }; s.m(i32) }
+""" }]
+compile_fail = true
+error_contains = ["E1200", "must be marked `comptime`"]
+
+[[case]]
+name = "comptime_type_param_still_ok_rue217"
+description = "RUE-217 guard: a properly-marked `comptime T: type` parameter must still compile and run (spec 4.14:5)."
+files = [{ path = "main.rue", source = """
+fn f(comptime T: type, x: T) -> T { x }
+fn main() -> i32 { f(i32, 5) }
+""" }]
+exit_code = 5


### PR DESCRIPTION
A value of type `type` in runtime position (a non-comptime parameter, or a struct field) was accepted by sema and then panicked codegen ("block has no terminator", SIGABRT/134). Now rejected in sema with a clean **E1200**:
- **Facet A** (spec 4.14:5): a non-comptime `type` parameter — new `reject_runtime_type_value` helper called after resolving each param in `analyze_single_function`/`analyze_method_function`.
- **Facet B** (spec 4.14:6): a `type` struct field — rejected at `resolve_struct_fields` in declarations.rs.

Reuses existing E1200; no new code. Verified: both facets → E1200/exit 1/no signal (were SIGABRT); valid `comptime T: type` params still run; the anon-struct `Wrapper(..)` pattern still runs; `comptime { i32 }` E1200 unchanged. Full `./test.sh` green; 4 CLI cases. Found by the type-inference hunt.

Fixes RUE-217

🤖 Generated with [Claude Code](https://claude.com/claude-code)