### PR TITLE
String design-light: @to_string, String + concat, contains/starts_with (RUE-17 Phase 1, ADR-0035)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -500,9 +500,14 @@ impl<'a> ConstraintGenerator<'a> {
 
             InstData::UnitConst => InferType::Concrete(Type::UNIT),
 
+            // Addition is overloaded: integer arithmetic OR String + String
+            // concatenation (RUE-17 Phase 1, ADR-0035). Split out from the pure
+            // arithmetic operators so it doesn't force an `is_integer`
+            // constraint on String operands.
+            InstData::Add { lhs, rhs } => self.generate_add(*lhs, *rhs, ctx),
+
             // Binary arithmetic: both operands must have the same type, result is that type
-            InstData::Add { lhs, rhs }
-            | InstData::Sub { lhs, rhs }
+            InstData::Sub { lhs, rhs }
             | InstData::Mul { lhs, rhs }
             | InstData::Div { lhs, rhs }
             | InstData::Mod { lhs, rhs } => self.generate_binary_arith(*lhs, *rhs, ctx),
@@ -860,6 +865,19 @@ impl<'a> ConstraintGenerator<'a> {
                     } else {
                         InferType::Concrete(Type::ERROR)
                     }
+                } else if intrinsic_name == "to_string" {
+                    // @to_string(n): takes an i64, returns String (RUE-17
+                    // Phase 1, ADR-0035). Constrain the argument to i64 so a
+                    // bare integer literal defaults to i64 here.
+                    for arg_ref in args.iter() {
+                        let arg_info = self.generate(*arg_ref, ctx);
+                        self.add_constraint(Constraint::equal(
+                            arg_info.ty,
+                            InferType::Concrete(Type::I64),
+                            arg_info.span,
+                        ));
+                    }
+                    self.string_infer_type()
                 } else if intrinsic_name == "parse_i32" {
                     // @parse_i32: takes a String, returns i32
                     for arg_ref in args.iter() {
@@ -1624,6 +1642,80 @@ impl<'a> ConstraintGenerator<'a> {
         self.add_constraint(Constraint::is_integer(result_ty.clone(), lhs_info.span));
 
         result_ty
+    }
+
+    /// Generate constraints for the `+` operator (RUE-17 Phase 1, ADR-0035).
+    ///
+    /// `+` is arithmetic addition on integers and concatenation on two
+    /// `String`s. When either operand is *concretely* the builtin `String`
+    /// type, both operands are constrained to `String` and the result is
+    /// `String` (a `String + int` mix then fails unification with E0206).
+    /// Otherwise this behaves exactly like [`generate_binary_arith`]: operands
+    /// and result share a type that must be an integer.
+    fn generate_add(
+        &mut self,
+        lhs: InstRef,
+        rhs: InstRef,
+        ctx: &mut ConstraintContext,
+    ) -> InferType {
+        let lhs_info = self.generate(lhs, ctx);
+        let rhs_info = self.generate(rhs, ctx);
+
+        if self.is_string_concrete(&lhs_info.ty) || self.is_string_concrete(&rhs_info.ty) {
+            let string_ty = self.string_infer_type();
+            self.add_constraint(Constraint::equal(
+                lhs_info.ty,
+                string_ty.clone(),
+                lhs_info.span,
+            ));
+            self.add_constraint(Constraint::equal(
+                rhs_info.ty,
+                string_ty.clone(),
+                rhs_info.span,
+            ));
+            return string_ty;
+        }
+
+        // Integer addition — identical to the other binary arithmetic operators.
+        let result_var = self.fresh_var();
+        let result_ty = InferType::Var(result_var);
+        self.add_constraint(Constraint::equal(
+            lhs_info.ty,
+            result_ty.clone(),
+            lhs_info.span,
+        ));
+        self.add_constraint(Constraint::equal(
+            rhs_info.ty,
+            result_ty.clone(),
+            rhs_info.span,
+        ));
+        self.add_constraint(Constraint::is_integer(result_ty.clone(), lhs_info.span));
+        result_ty
+    }
+
+    /// The builtin `String` type as an [`InferType::Concrete`], or
+    /// `Concrete(ERROR)` if it hasn't been injected (should not happen once
+    /// builtin types are registered).
+    fn string_infer_type(&self) -> InferType {
+        if let Some(string_spur) = self.interner.get("String") {
+            if let Some(&string_ty) = self.structs.get(&string_spur) {
+                return InferType::Concrete(string_ty);
+            }
+        }
+        InferType::Concrete(Type::ERROR)
+    }
+
+    /// Whether `ty` is *concretely* the builtin `String` struct (not a type
+    /// variable that might later resolve to it).
+    fn is_string_concrete(&self, ty: &InferType) -> bool {
+        if let InferType::Concrete(t) = ty {
+            if let Some(string_spur) = self.interner.get("String") {
+                if let Some(&string_ty) = self.structs.get(&string_spur) {
+                    return *t == string_ty;
+                }
+            }
+        }
+        false
     }
 
     /// Get the inferred type for a pattern.

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -2340,9 +2340,10 @@ impl<'a> Sema<'a> {
             | InstData::StringConst(_)
             | InstData::UnitConst => self.analyze_literal(air, inst_ref, ctx),
 
-            // Binary arithmetic operations
+            // Binary arithmetic operations (Add also covers String + String
+            // concatenation — see analyze_add).
             InstData::Add { lhs, rhs } => {
-                self.analyze_binary_arith(air, *lhs, *rhs, AirInstData::Add, inst.span, ctx)
+                self.analyze_add(air, inst_ref, *lhs, *rhs, inst.span, ctx)
             }
             InstData::Sub { lhs, rhs } => {
                 self.analyze_binary_arith(air, *lhs, *rhs, AirInstData::Sub, inst.span, ctx)
@@ -3332,6 +3333,8 @@ impl<'a> Sema<'a> {
             self.analyze_test_preview_gate_intrinsic(air, &args, span)
         } else if name == known.read_line {
             self.analyze_read_line_intrinsic(air, name, &args, span)
+        } else if name == known.to_string {
+            self.analyze_to_string_intrinsic(air, &args, span, ctx)
         } else if let Some(intrinsic_name_str) = known.get_parse_intrinsic_name(name) {
             self.analyze_parse_intrinsic(air, name, intrinsic_name_str, &args, span, ctx)
         } else if name == known.cast {
@@ -3752,6 +3755,69 @@ impl<'a> Sema<'a> {
         Ok(AnalysisResult::new(air_ref, string_type))
     }
 
+    /// Analyze the `@to_string(n)` intrinsic (RUE-17 Phase 1, ADR-0035).
+    ///
+    /// Formats an `i64` as its decimal representation in a fresh heap `String`.
+    /// Inference constrains the argument to `i64`, so by analysis time the
+    /// operand type is `i64` (or `error`). Rather than introduce a dedicated
+    /// codegen intrinsic, this lowers to an ordinary `extern "C"` call to the
+    /// runtime `__rue_to_string(out, n)`: the return type is the builtin
+    /// `String`, so the existing sret call convention allocates the result
+    /// buffer and passes it as the hidden first argument — no codegen change.
+    fn analyze_to_string_intrinsic(
+        &mut self,
+        air: &mut Air,
+        args: &[RirCallArg],
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        if args.len() != 1 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "to_string".to_string(),
+                    expected: 1,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        // The argument is consumed by value (an i64 is Copy, so this is a plain
+        // read). Inference has already unified it with i64.
+        let arg_result = self.analyze_inst(air, args[0].value, ctx)?;
+        let arg_type = arg_result.ty;
+        if arg_type != Type::I64 && !arg_type.is_error() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: "@to_string".to_string(),
+                    expected: "i64".to_string(),
+                    found: arg_type.safe_name_with_pool(Some(&self.type_pool)),
+                })),
+                span,
+            ));
+        }
+
+        let string_type = self.builtin_string_type();
+        let call_name = self
+            .interner
+            .get_or_intern(rue_builtins::TO_STRING_RUNTIME_FN);
+
+        // Encode the single by-value argument as a (value, mode) pair.
+        let extra_data = [arg_result.air_ref.as_u32(), AirArgMode::Normal.as_u32()];
+        let args_start = air.add_extra(&extra_data);
+
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Call {
+                name: call_name,
+                args_start,
+                args_len: 1,
+            },
+            ty: string_type,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, string_type))
+    }
+
     /// Analyze @parse_i32, @parse_i64, @parse_u32, @parse_u64 intrinsics.
     fn analyze_parse_intrinsic(
         &mut self,
@@ -4110,6 +4176,104 @@ impl<'a> Sema<'a> {
             RirArgMode::Borrow => AirArgMode::Borrow,
         }
     }
+    /// Analyze the `+` operator.
+    ///
+    /// `+` is overloaded: on integers it is arithmetic addition, and on two
+    /// `String`s it is concatenation (RUE-17 Phase 1, ADR-0035). HM inference
+    /// has already resolved the result type, so we dispatch on it: a `String`
+    /// result routes to [`analyze_string_concat`]; anything else is ordinary
+    /// integer arithmetic. A mixed `String + int` never resolves to `String`
+    /// (unification fails first with E0206), so it takes the arithmetic path and
+    /// is rejected there — the user sees a clear type-mismatch error.
+    fn analyze_add(
+        &mut self,
+        air: &mut Air,
+        inst_ref: InstRef,
+        lhs: InstRef,
+        rhs: InstRef,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        let is_concat = ctx
+            .resolved_types
+            .get(&inst_ref)
+            .is_some_and(|ty| self.is_builtin_string(*ty));
+        if is_concat {
+            return self.analyze_string_concat(air, lhs, rhs, span, ctx);
+        }
+        self.analyze_binary_arith(air, lhs, rhs, AirInstData::Add, span, ctx)
+    }
+
+    /// Analyze `s1 + s2` where both operands are `String`: produce a NEW
+    /// concatenated `String` (RUE-17 Phase 1, ADR-0035).
+    ///
+    /// Both operands are *borrowed* (read, not consumed) — like the operands of
+    /// `==` — so a named operand remains usable afterwards and a temporary is
+    /// dropped by its owner at statement end; neither is leaked. The operation
+    /// lowers to an `extern "C"` sret call to `__rue_String_concat(out, ptr1,
+    /// len1, cap1, ptr2, len2, cap2)`, reusing the ordinary aggregate-return and
+    /// String-flattening call paths (no codegen change).
+    fn analyze_string_concat(
+        &mut self,
+        air: &mut Air,
+        lhs: InstRef,
+        rhs: InstRef,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        // Analyze both operands in projection (borrow) mode so a named operand
+        // is neither moved nor consumed — exactly like the operands of `==`. A
+        // variable operand yields a plain Load (no move recorded, still dropped
+        // by its owner); a temporary operand (e.g. `@to_string(7) + ...`) falls
+        // through to analyze_inst, which marks it moved — cancel that marker so
+        // the temporary is instead dropped normally at statement end (no leak,
+        // no double free). cancel_move_marker is a no-op on the Load case.
+        let lhs_result = self.analyze_inst_for_projection(air, lhs, ctx)?;
+        air.cancel_move_marker(lhs_result.air_ref);
+        let rhs_result = self.analyze_inst_for_projection(air, rhs, ctx)?;
+        air.cancel_move_marker(rhs_result.air_ref);
+
+        // Defensive type check (HM inference already guarantees both are String
+        // when we get here; this guards against error-recovery paths).
+        for operand in [&lhs_result, &rhs_result] {
+            if !self.is_builtin_string(operand.ty) && !operand.ty.is_error() {
+                return Err(CompileError::new(
+                    ErrorKind::TypeMismatch {
+                        expected: "String".to_string(),
+                        found: operand.ty.safe_name_with_pool(Some(&self.type_pool)),
+                    },
+                    span,
+                ));
+            }
+        }
+
+        let string_type = self.builtin_string_type();
+        let call_name = self
+            .interner
+            .get_or_intern(rue_builtins::STRING_CONCAT_RUNTIME_FN);
+
+        // Both String operands are flattened into (ptr, len, cap) by codegen;
+        // Normal mode with the move cancelled gives flatten-without-consume.
+        let extra_data = [
+            lhs_result.air_ref.as_u32(),
+            AirArgMode::Normal.as_u32(),
+            rhs_result.air_ref.as_u32(),
+            AirArgMode::Normal.as_u32(),
+        ];
+        let args_start = air.add_extra(&extra_data);
+
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Call {
+                name: call_name,
+                args_start,
+                args_len: 2,
+            },
+            ty: string_type,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, string_type))
+    }
+
     /// Analyze a binary arithmetic operator (+, -, *, /, %).
     ///
     /// Follows Rust's type inference rules:

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -46,6 +46,8 @@ pub struct KnownSymbols {
     pub assert: Spur,
     /// The `read_line` intrinsic symbol.
     pub read_line: Spur,
+    /// The `to_string` intrinsic symbol - formats an i64 as a decimal String.
+    pub to_string: Spur,
     /// The `parse_i32` intrinsic symbol.
     pub parse_i32: Spur,
     /// The `parse_i64` intrinsic symbol.
@@ -106,6 +108,7 @@ impl KnownSymbols {
             panic: interner.get_or_intern_static("panic"),
             assert: interner.get_or_intern_static("assert"),
             read_line: interner.get_or_intern_static("read_line"),
+            to_string: interner.get_or_intern_static("to_string"),
             parse_i32: interner.get_or_intern_static("parse_i32"),
             parse_i64: interner.get_or_intern_static("parse_i64"),
             parse_u32: interner.get_or_intern_static("parse_u32"),

--- a/crates/rue-builtins/src/lib.rs
+++ b/crates/rue-builtins/src/lib.rs
@@ -379,6 +379,34 @@ pub static STRING_TYPE: BuiltinTypeDef = BuiltinTypeDef {
             return_ty: BuiltinReturnType::SelfType,
             runtime_fn: "__rue_String_clone",
         },
+        // Byte-level substring search: `s.contains(needle)` is true iff the
+        // bytes of `needle` occur as a contiguous run inside `s` (RUE-17
+        // Phase 1, ADR-0035). Byte-level, never inspects UTF-8 boundaries; the
+        // empty needle is always contained. Borrows self; `needle` is a String.
+        BuiltinMethod {
+            name: "contains",
+            receiver_mode: ReceiverMode::ByRef,
+            params: &[BuiltinParam {
+                name: "needle",
+                ty: BuiltinParamType::SelfType,
+            }],
+            return_ty: BuiltinReturnType::Bool,
+            runtime_fn: "__rue_String_contains",
+        },
+        // Byte-level prefix test: `s.starts_with(prefix)` is true iff the bytes
+        // of `prefix` are a prefix of the bytes of `s` (RUE-17 Phase 1,
+        // ADR-0035). Byte-level; the empty prefix always matches. Borrows self;
+        // `prefix` is a String.
+        BuiltinMethod {
+            name: "starts_with",
+            receiver_mode: ReceiverMode::ByRef,
+            params: &[BuiltinParam {
+                name: "prefix",
+                ty: BuiltinParamType::SelfType,
+            }],
+            return_ty: BuiltinReturnType::Bool,
+            runtime_fn: "__rue_String_starts_with",
+        },
         // Byte-range slice: `s.substring(start, len)` returns a NEW String
         // holding bytes [start, start+len) (RUE-17 Phase 2, ADR-0035). Since
         // String is a byte string, any byte range is valid; only an
@@ -439,6 +467,30 @@ pub static STRING_TYPE: BuiltinTypeDef = BuiltinTypeDef {
         },
     ],
 };
+
+// ============================================================================
+// Free-standing String runtime operations (RUE-17 Phase 1, ADR-0035)
+// ============================================================================
+
+// These operations are not `String` methods or associated functions, so they
+// have no entry in the [`BuiltinMethod`] / [`BuiltinAssociatedFn`] tables. They
+// are lowered directly by Sema into `extern "C"` runtime calls (routed through
+// the ordinary sret / by-value call convention), and their runtime symbols live
+// under the reserved `__rue_` prefix like every other builtin runtime helper.
+// The names are collected here so there is a single source of truth for what
+// the compiler emits and what `rue-runtime` must define.
+
+/// Runtime symbol for `@to_string(n)`: formats an `i64` as its decimal
+/// representation into a freshly heap-allocated `String` (full range including
+/// `i64::MIN`; negatives are prefixed with `-`). sret ABI:
+/// `extern "C" fn __rue_to_string(out: *mut StringResult, n: i64)`.
+pub const TO_STRING_RUNTIME_FN: &str = "__rue_to_string";
+
+/// Runtime symbol for `s1 + s2` on two `String`s: returns a NEW `String` whose
+/// bytes are the concatenation of `s1` and `s2`. Both operands are borrowed
+/// (neither is consumed). sret ABI: `extern "C" fn __rue_String_concat(out:
+/// *mut StringResult, ptr1, len1, cap1, ptr2, len2, cap2)`.
+pub const STRING_CONCAT_RUNTIME_FN: &str = "__rue_String_concat";
 
 // ============================================================================
 // Registry
@@ -615,6 +667,20 @@ mod tests {
         let push_str = STRING_TYPE.find_method("push_str").unwrap();
         assert_eq!(push_str.runtime_fn, "__rue_String_push_str");
         assert_eq!(push_str.receiver_mode, ReceiverMode::ByMutRef);
+
+        // Byte-level query methods (RUE-17 Phase 1): borrow self, take a String
+        // argument, return bool.
+        let contains = STRING_TYPE.find_method("contains").unwrap();
+        assert_eq!(contains.runtime_fn, "__rue_String_contains");
+        assert_eq!(contains.receiver_mode, ReceiverMode::ByRef);
+        assert_eq!(contains.return_ty, BuiltinReturnType::Bool);
+        assert_eq!(contains.params.len(), 1);
+        assert_eq!(contains.params[0].ty, BuiltinParamType::SelfType);
+
+        let starts_with = STRING_TYPE.find_method("starts_with").unwrap();
+        assert_eq!(starts_with.runtime_fn, "__rue_String_starts_with");
+        assert_eq!(starts_with.receiver_mode, ReceiverMode::ByRef);
+        assert_eq!(starts_with.return_ty, BuiltinReturnType::Bool);
     }
 
     #[test]

--- a/crates/rue-cli-tests/cases/string_phase1.toml
+++ b/crates/rue-cli-tests/cases/string_phase1.toml
@@ -1,0 +1,99 @@
+# Design-light String methods (RUE-17 Phase 1, ADR-0035).
+#
+# Phase 1 adds three runtime-visible String operations on top of the Phase 2
+# byte-access primitives: `@to_string(n)` (i64 -> decimal String),
+# `String + String` concatenation, and the byte-level `contains` / `starts_with`
+# predicates. Every operation lowers to an `extern "C"` runtime call whose ABI
+# (String flattened to ptr/len/cap, sret return buffer for the heap results) is
+# exactly what a spec-harness stdout check cannot exercise end to end — hence
+# these exact-stdout runs through the real driver.
+
+[section]
+id = "cli.string_phase1"
+name = "String Phase 1 methods"
+description = "Integer-to-String, concatenation, and byte-level search on String."
+
+[[case]]
+name = "to_string_demo"
+description = "@to_string formats an i64 in decimal, including negatives, zero, and the i64 extremes."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @dbg(@to_string(42));
+    @dbg(@to_string(-5));
+    @dbg(@to_string(0));
+    let lo: i64 = -9223372036854775808;
+    let hi: i64 = 9223372036854775807;
+    @dbg(@to_string(lo));
+    @dbg(@to_string(hi));
+    0
+}
+""" }]
+exit_code = 0
+stdout = "42\n-5\n0\n-9223372036854775808\n9223372036854775807\n"
+
+[[case]]
+name = "concat_is_concatenation_not_addition"
+description = "@to_string(7) + @to_string(8) concatenates to '78' (not the integer sum 15); operands are borrowed, so named Strings remain usable."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let msg = @to_string(7) + @to_string(8);
+    @dbg(msg);
+    let a = "foo";
+    let b = "bar";
+    let c = a + b;
+    @dbg(c);
+    @dbg(a);
+    @dbg(b);
+    0
+}
+""" }]
+exit_code = 0
+stdout = "78\nfoobar\nfoo\nbar\n"
+
+[[case]]
+name = "concat_chained_and_mutable_result"
+description = "Concatenation chains left-to-right and its result owns a heap buffer that can be mutated further."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let m = "a" + "b" + "c";
+    @dbg(m);
+    let mut g = @to_string(1) + @to_string(2);
+    g.push_str("Z");
+    @dbg(g);
+    0
+}
+""" }]
+exit_code = 0
+stdout = "abc\n12Z\n"
+
+[[case]]
+name = "contains_and_starts_with"
+description = "Byte-level contains/starts_with; the empty needle/prefix always matches; the receiver is borrowed (usable after)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let h = "hello";
+    @dbg(h.contains("ell"));
+    @dbg(h.contains("xyz"));
+    @dbg(h.contains(""));
+    @dbg(h.starts_with("he"));
+    @dbg(h.starts_with("lo"));
+    @dbg(h.len());
+    0
+}
+""" }]
+exit_code = 0
+stdout = "true\nfalse\ntrue\ntrue\nfalse\n5\n"
+
+[[case]]
+name = "string_plus_integer_rejected"
+description = "String + int is a type error (E0206); there is no implicit String/int conversion."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a = "foo";
+    let c = a + 5;
+    @dbg(c);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206"]

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -6,7 +6,10 @@
 //! - String-specific allocation functions
 //! - String constructors (`__rue_String_new`, `__rue_String_with_capacity`)
 //! - String query methods (`len`, `capacity`, `is_empty`)
+//! - Byte-string search (`contains`, `starts_with`)
 //! - String mutation methods (`push_str`, `push`, `clear`, `reserve`)
+//! - Integer-to-String formatting (`__rue_to_string`) and concatenation
+//!   (`__rue_String_concat`)
 //! - String cloning (`__rue_String_clone`)
 //! - String dropping (`__rue_drop_String`)
 
@@ -667,6 +670,250 @@ crate::define_for_all_platforms! {
             core::ptr::copy_nonoverlapping(ptr.add(start as usize), new_ptr, sub_len as usize);
             (*out).ptr = new_ptr;
             (*out).len = sub_len;
+            (*out).cap = new_cap;
+        }
+    }
+}
+
+// =============================================================================
+// Byte-string search predicates (RUE-17 Phase 1, ADR-0035)
+// =============================================================================
+//
+// `s.contains(needle)` and `s.starts_with(prefix)` are byte-level: they compare
+// raw bytes and never inspect UTF-8 character boundaries. Both take the receiver
+// and argument String by borrow (as three fields each: ptr, len, cap; the caps
+// are part of the ABI but unused) and return `u8` (0 or 1) in the return
+// register, matching the sub-word return convention used by `__rue_str_eq` and
+// `__rue_String_is_empty`. The empty needle / empty prefix always matches.
+
+crate::define_for_all_platforms! {
+    /// True (1) iff the bytes of `needle` occur as a contiguous run inside the
+    /// receiver's bytes. Naive O(len * needle_len) scan — adequate for the
+    /// design-light Phase 1; the empty needle is always contained.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be valid for `len` bytes and `needle_ptr` for `needle_len`
+    /// bytes; every read below is bounded by those lengths.
+    #[allow(non_snake_case)]
+    pub extern "C" fn __rue_String_contains(
+        ptr: *const u8,
+        len: u64,
+        _cap: u64,
+        needle_ptr: *const u8,
+        needle_len: u64,
+        _needle_cap: u64,
+    ) -> u8 {
+        // The empty needle is contained in every string.
+        if needle_len == 0 {
+            return 1;
+        }
+        // A needle longer than the haystack cannot occur.
+        if needle_len > len {
+            return 0;
+        }
+        // Try every start offset that still leaves room for the whole needle.
+        let last_start = len - needle_len;
+        let mut start: u64 = 0;
+        while start <= last_start {
+            let mut k: u64 = 0;
+            while k < needle_len {
+                // SAFETY: start + k <= last_start + (needle_len - 1) = len - 1,
+                // so the haystack read is in bounds; k < needle_len bounds the
+                // needle read. u8 has no alignment requirement.
+                let a = unsafe { *ptr.add((start + k) as usize) };
+                let b = unsafe { *needle_ptr.add(k as usize) };
+                if a != b {
+                    break;
+                }
+                k += 1;
+            }
+            if k == needle_len {
+                return 1;
+            }
+            start += 1;
+        }
+        0
+    }
+}
+
+crate::define_for_all_platforms! {
+    /// True (1) iff the bytes of `prefix` are a prefix of the receiver's bytes.
+    /// The empty prefix always matches.
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must be valid for `len` bytes and `prefix_ptr` for `prefix_len`
+    /// bytes; every read below is bounded by those lengths.
+    #[allow(non_snake_case)]
+    pub extern "C" fn __rue_String_starts_with(
+        ptr: *const u8,
+        len: u64,
+        _cap: u64,
+        prefix_ptr: *const u8,
+        prefix_len: u64,
+        _prefix_cap: u64,
+    ) -> u8 {
+        // The empty prefix matches every string.
+        if prefix_len == 0 {
+            return 1;
+        }
+        // A prefix longer than the string cannot match.
+        if prefix_len > len {
+            return 0;
+        }
+        let mut k: u64 = 0;
+        while k < prefix_len {
+            // SAFETY: k < prefix_len <= len, so both reads are in bounds. u8 has
+            // no alignment requirement.
+            let a = unsafe { *ptr.add(k as usize) };
+            let b = unsafe { *prefix_ptr.add(k as usize) };
+            if a != b {
+                return 0;
+            }
+            k += 1;
+        }
+        1
+    }
+}
+
+// =============================================================================
+// Integer-to-String formatting (RUE-17 Phase 1, ADR-0035)
+// =============================================================================
+
+crate::define_for_all_platforms! {
+    /// Format an `i64` in base 10 into a freshly heap-allocated `String`.
+    ///
+    /// Implements the `@to_string(n)` intrinsic. Handles the full `i64` range,
+    /// including `i64::MIN` (whose magnitude is not representable as a positive
+    /// `i64`), and prefixes negative values with `'-'`.
+    ///
+    /// # ABI (sret convention)
+    ///
+    /// ```text
+    /// extern "C" fn __rue_to_string(out: *mut StringResult, n: i64)
+    /// ```
+    ///
+    /// `out` (the sret pointer) comes first, then the integer argument. The
+    /// returned String owns a fresh heap buffer, so it can be mutated and
+    /// dropped independently.
+    ///
+    /// # Safety
+    ///
+    /// `out` must be a valid sret pointer — see `__rue_String_new`.
+    pub extern "C" fn __rue_to_string(out: *mut StringResult, n: i64) {
+        // "-9223372036854775808" (i64::MIN) is the longest result: 20 bytes.
+        let mut buf = [0u8; 20];
+        let negative = n < 0;
+        // Magnitude as u64. `wrapping_neg` yields the correct magnitude even for
+        // i64::MIN, whose positive value does not fit in an i64.
+        let mut mag = n as u64;
+        if negative {
+            mag = mag.wrapping_neg();
+        }
+        // Emit decimal digits least-significant first, filling `buf` from the
+        // back. `i` walks left toward the front of the buffer.
+        let mut i = buf.len();
+        if mag == 0 {
+            i -= 1;
+            buf[i] = b'0';
+        } else {
+            while mag > 0 {
+                i -= 1;
+                buf[i] = b'0' + (mag % 10) as u8;
+                mag /= 10;
+            }
+        }
+        if negative {
+            i -= 1;
+            buf[i] = b'-';
+        }
+
+        let len = (buf.len() - i) as u64;
+        let new_cap = if len < STRING_MIN_CAPACITY {
+            STRING_MIN_CAPACITY
+        } else {
+            len
+        };
+        let new_ptr = heap::alloc(new_cap, 1);
+
+        // SAFETY: `new_ptr` was just allocated with `new_cap >= len` bytes; the
+        // source range `buf[i..]` holds exactly `len` initialized bytes; the
+        // regions don't overlap (fresh allocation). `out` is a valid sret
+        // pointer (see __rue_String_new).
+        unsafe {
+            core::ptr::copy_nonoverlapping(buf.as_ptr().add(i), new_ptr, len as usize);
+            (*out).ptr = new_ptr;
+            (*out).len = len;
+            (*out).cap = new_cap;
+        }
+    }
+}
+
+crate::define_for_all_platforms! {
+    /// Return a NEW String whose bytes are the concatenation of two Strings.
+    ///
+    /// Implements `s1 + s2` (RUE-17 Phase 1, ADR-0035). Both operands are
+    /// borrowed (passed as their three fields each; the caps are unused but part
+    /// of the ABI) and neither is consumed. The result owns a fresh heap buffer.
+    ///
+    /// # ABI (sret convention)
+    ///
+    /// ```text
+    /// extern "C" fn __rue_String_concat(
+    ///     out: *mut StringResult,
+    ///     ptr1: *const u8, len1: u64, cap1: u64,
+    ///     ptr2: *const u8, len2: u64, cap2: u64)
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// `ptr1`/`ptr2` must be valid for `len1`/`len2` bytes respectively, and
+    /// `out` must be a valid sret pointer (see `__rue_String_new`).
+    #[allow(non_snake_case)]
+    pub extern "C" fn __rue_String_concat(
+        out: *mut StringResult,
+        ptr1: *const u8,
+        len1: u64,
+        _cap1: u64,
+        ptr2: *const u8,
+        len2: u64,
+        _cap2: u64,
+    ) {
+        let total = len1 + len2;
+
+        if total == 0 {
+            // Empty result: a valid literal-like String (cap == 0, ptr null)
+            // that drops without freeing.
+            // SAFETY: `out` is a valid sret pointer — see __rue_String_new.
+            unsafe {
+                (*out).ptr = core::ptr::null_mut();
+                (*out).len = 0;
+                (*out).cap = 0;
+            }
+            return;
+        }
+
+        let new_cap = if total < STRING_MIN_CAPACITY {
+            STRING_MIN_CAPACITY
+        } else {
+            total
+        };
+        let new_ptr = heap::alloc(new_cap, 1);
+
+        // SAFETY: `new_ptr` has `new_cap >= total = len1 + len2` bytes. The two
+        // source ranges are each in bounds for their lengths and don't overlap
+        // the fresh allocation; `new_ptr.add(len1)` is the first byte after the
+        // copied prefix, leaving room for `len2` more bytes.
+        unsafe {
+            if len1 > 0 && !ptr1.is_null() {
+                core::ptr::copy_nonoverlapping(ptr1, new_ptr, len1 as usize);
+            }
+            if len2 > 0 && !ptr2.is_null() {
+                core::ptr::copy_nonoverlapping(ptr2, new_ptr.add(len1 as usize), len2 as usize);
+            }
+            (*out).ptr = new_ptr;
+            (*out).len = total;
             (*out).cap = new_cap;
         }
     }

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -732,3 +732,149 @@ fn main() -> i32 {
 }
 """
 exit_code = 101
+
+# ---------------------------------------------------------------------------
+# Integer formatting, concatenation, and search (RUE-17 Phase 1, ADR-0035)
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "to_string_positive"
+spec = ["3.7:22"]
+source = """
+fn main() -> i32 {
+    @dbg(@to_string(42));
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "42\n"
+
+[[case]]
+name = "to_string_negative_and_zero"
+spec = ["3.7:23"]
+source = """
+fn main() -> i32 {
+    @dbg(@to_string(-5));
+    @dbg(@to_string(0));
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "-5\n0\n"
+
+[[case]]
+name = "to_string_i64_extremes"
+spec = ["3.7:23"]
+source = """
+fn main() -> i32 {
+    let lo: i64 = -9223372036854775808;
+    let hi: i64 = 9223372036854775807;
+    @dbg(@to_string(lo));
+    @dbg(@to_string(hi));
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "-9223372036854775808\n9223372036854775807\n"
+
+[[case]]
+name = "string_concat_literals"
+spec = ["3.7:25"]
+source = """
+fn main() -> i32 {
+    let g = "Hello, " + "world!";
+    @dbg(g);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "Hello, world!\n"
+
+[[case]]
+name = "string_concat_borrows_operands"
+spec = ["3.7:25"]
+source = """
+fn main() -> i32 {
+    let a = "foo";
+    let b = "bar";
+    let c = a + b;
+    @dbg(c);
+    @dbg(a);
+    @dbg(b);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "foobar\nfoo\nbar\n"
+
+[[case]]
+name = "string_concat_is_not_integer_add"
+spec = ["3.7:25"]
+source = """
+fn main() -> i32 {
+    let n = @to_string(7) + @to_string(8);
+    @dbg(n);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "78\n"
+
+[[case]]
+name = "string_plus_integer_is_type_error"
+spec = ["3.7:26"]
+compile_fail = true
+error_contains = "E0206"
+source = """
+fn main() -> i32 {
+    let a = "foo";
+    let c = a + 5;
+    @dbg(c);
+    0
+}
+"""
+
+[[case]]
+name = "string_contains_byte_level"
+spec = ["3.7:28"]
+source = """
+fn main() -> i32 {
+    let h = "hello";
+    @dbg(h.contains("ell"));
+    @dbg(h.contains("xyz"));
+    @dbg(h.contains(""));
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "true\nfalse\ntrue\n"
+
+[[case]]
+name = "string_starts_with_byte_level"
+spec = ["3.7:29"]
+source = """
+fn main() -> i32 {
+    let h = "hello";
+    @dbg(h.starts_with("he"));
+    @dbg(h.starts_with("lo"));
+    @dbg(h.starts_with(""));
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "true\nfalse\ntrue\n"
+
+[[case]]
+name = "string_search_does_not_consume"
+spec = ["3.7:28", "3.7:29"]
+source = """
+fn main() -> i32 {
+    let h = "hello";
+    @dbg(h.contains("ell"));
+    @dbg(h.starts_with("he"));
+    @dbg(h.len());
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "true\ntrue\n5\n"

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -158,12 +158,89 @@ fn main() -> i32 {
 }
 ```
 
+## Integer Formatting
+
+{{ rule(id="3.7:22", cat="normative") }}
+
+The intrinsic `@to_string(n)` takes an `i64` and returns a new, heap-allocated
+`String` containing the base-10 decimal representation of `n` (see ADR-0035).
+The argument is of type `i64`; a bare integer literal argument is inferred to be
+`i64`.
+
+{{ rule(id="3.7:23", cat="dynamic-semantics") }}
+
+`@to_string(n)` formats the entire range of `i64`, including `i64::MIN`. A
+negative value is prefixed with a single `-`; a zero value formats as `0`.
+
+{{ rule(id="3.7:24") }}
+
+```rue
+fn main() -> i32 {
+    @dbg(@to_string(42));    // 42
+    @dbg(@to_string(-5));    // -5
+    0
+}
+```
+
+## Concatenation
+
+{{ rule(id="3.7:25", cat="normative") }}
+
+When both operands of the `+` operator are `String`, `s1 + s2` evaluates to a
+new, heap-allocated `String` whose bytes are the bytes of `s1` followed by the
+bytes of `s2` (see ADR-0035). Both operands are borrowed, not consumed, and
+remain usable afterwards.
+
+{{ rule(id="3.7:26", cat="legality-rule") }}
+
+The `+` operator requires both operands to have the same type. Mixing a `String`
+and an integer (for example `s + 1`) is a type error; there is no implicit
+conversion between `String` and integers.
+
+{{ rule(id="3.7:27") }}
+
+```rue
+fn main() -> i32 {
+    let greeting = "Hello, " + "world!";
+    @dbg(greeting);   // Hello, world!
+    0
+}
+```
+
+## Search
+
+{{ rule(id="3.7:28", cat="normative") }}
+
+The method `s.contains(needle)` returns `true` if and only if the bytes of the
+`String` `needle` occur as a contiguous subsequence of the bytes of `s`. The
+comparison is byte-level and does not inspect UTF-8 character boundaries. The
+empty needle is contained in every string. The receiver `s` is borrowed, not
+consumed.
+
+{{ rule(id="3.7:29", cat="normative") }}
+
+The method `s.starts_with(prefix)` returns `true` if and only if the bytes of
+the `String` `prefix` are a prefix of the bytes of `s`. The comparison is
+byte-level. The empty prefix matches every string. The receiver `s` is borrowed,
+not consumed.
+
+{{ rule(id="3.7:30") }}
+
+```rue
+fn main() -> i32 {
+    let h = "hello";
+    @dbg(h.contains("ell"));      // true
+    @dbg(h.starts_with("he"));    // true
+    @dbg(h.starts_with("lo"));    // false
+    0
+}
+```
+
 ## Limitations
 
 {{ rule(id="3.7:14", cat="informative") }}
 
 The current implementation does not support:
-- String concatenation
 - Slicing with range syntax (`s[a..b]`); use `s.substring(start, len)` instead
 - Decoding bytes into Unicode scalar values (e.g. iterating `chars`)
 - Pattern matching on strings


### PR DESCRIPTION
The ergonomics slice of the byte-string model — programs can now produce *and* inspect real text. Built on Phase 2 (byte access).

- **`@to_string(n) -> String`**: i64 decimal formatting (full range incl i64::MIN, negatives), lowered to an sret Call reusing the aggregate-return path.
- **`String + String -> String`** (concat): one dispatch line in `sema/analysis.rs` routes a String-typed Add to `__rue_String_concat`; the Add constraint is split in `inference/generate.rs` so String operands don't force `is_integer`. Operands borrowed (stay usable). Integer `+` untouched; `String + int` stays E0206.
- **`s.contains` / `s.starts_with -> bool`**: byte-level builtin methods.

Verified: `@to_string(7)+@to_string(8)` → `78` (concat, not 15), `@to_string(-5)` → `-5`, contains/starts_with correct. Spec 3.7:22–30 added (citing ADR-0035); concatenation removed from Limitations. Full `./test.sh` green. 10 spec + 5 CLI cases.

Phase 2 shipped (#1044); Phase 3 (`.chars()` decode) blocked on iterators (RUE-219).

Part of RUE-17

🤖 Generated with [Claude Code](https://claude.com/claude-code)