### PR TITLE
Spec alignment: ch-3.8 'use' unification + integer-literal inference rule (RUE-202, RUE-218)

### DIFF
--- a/crates/rue-air/src/inference/mod.rs
+++ b/crates/rue-air/src/inference/mod.rs
@@ -25,12 +25,23 @@
 //! Type variables ([`TypeVarId`]) represent unknown types to be solved.
 //! The [`Substitution`] maps type variables to their resolved types.
 //!
-//! # Integer Literals
+//! # Integer Literals (unify-then-default)
 //!
-//! Integer literals get the special [`InferType::IntLiteral`] type rather than
-//! a type variable. This models the fact that a literal like `42` can become
-//! any integer type. When an `IntLiteral` unifies with a concrete integer type,
-//! it becomes that type. Unconstrained `IntLiteral`s default to `i32` at the end.
+//! Un-annotated integer literals follow HM **unify-then-default** (spec
+//! 3.1:14–15, ADR-0007, RUE-218), *not* an eager first-use pin. Each literal is
+//! given a fresh type variable (recorded in `int_literal_vars`) that unifies
+//! with **every** use across the enclosing function body's constraint set. Two
+//! uses that require different integer types therefore conflict regardless of
+//! textual order (E0206). A variable that is still unconstrained at the
+//! defaulting point — the end of the function's constraint solve — defaults to
+//! `i32` (see [`unify::Unifier::default_int_literal_vars`]).
+//!
+//! The order-independence is a property of solving the *whole* constraint set
+//! before defaulting: binding a literal variable to a concrete integer type on
+//! first contact is ordinary unification (the variable genuinely *is* that
+//! type), so a later conflicting use is still rejected. Defaulting is applied
+//! once, after solving, never mid-stream — do not reintroduce an eager i32
+//! default at the literal's definition site.
 
 mod constraint;
 mod generate;

--- a/crates/rue-cli-tests/cases/integer_literal_inference.toml
+++ b/crates/rue-cli-tests/cases/integer_literal_inference.toml
@@ -1,0 +1,72 @@
+# Un-annotated integer-literal inference is HM unify-then-default (RUE-218,
+# ADR-0007). A literal with no explicit type gets an integer inference variable
+# that unifies with every use in the enclosing function body; conflicting uses
+# are E0206 order-INDEPENDENTLY; if still unconstrained at the function-body
+# defaulting point it defaults to i32.
+#
+# These cases drive the real driver end-to-end (exact stdout, both conflict
+# orders) so a regression to the old order-dependent "pin to first use"
+# behavior is caught.
+
+[section]
+id = "cli.integer_literal_inference"
+name = "Integer-literal inference (unify-then-default)"
+description = "Un-annotated integer literals unify with every use; conflicts are order-independent; unconstrained defaults to i32."
+
+[[case]]
+name = "single_i64_use_unifies"
+description = "A literal's single i64 use fixes it to i64 (ergonomic; matches Rust)."
+files = [{ path = "main.rue", source = """
+fn takes_i64(v: i64) -> i64 { v }
+fn main() -> i32 {
+    let x = 5;
+    let a = takes_i64(x);
+    @dbg(a);
+    0
+}
+""" }]
+stdout = "5\n"
+exit_code = 0
+
+[[case]]
+name = "unconstrained_defaults_i32"
+description = "No constraining use: the literal defaults to i32 at the function-body defaulting point."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x = 5;
+    x
+}
+""" }]
+exit_code = 5
+
+[[case]]
+name = "conflict_i32_then_i64_rejected"
+description = "i32 use before i64 use: genuine conflict, E0206."
+files = [{ path = "main.rue", source = """
+fn takes_i32(v: i32) -> i32 { v }
+fn takes_i64(v: i64) -> i64 { v }
+fn main() -> i32 {
+    let x = 5;
+    takes_i32(x);
+    takes_i64(x);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "type mismatch"]
+
+[[case]]
+name = "conflict_i64_then_i32_rejected"
+description = "i64 use before i32 use: SAME rejection as the swapped order (order-independent)."
+files = [{ path = "main.rue", source = """
+fn takes_i32(v: i32) -> i32 { v }
+fn takes_i64(v: i64) -> i64 { v }
+fn main() -> i32 {
+    let x = 5;
+    takes_i64(x);
+    takes_i32(x);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206", "type mismatch"]

--- a/crates/rue-spec/cases/types/integers.toml
+++ b/crates/rue-spec/cases/types/integers.toml
@@ -103,6 +103,69 @@ fn main() -> i32 { takes_i32(42) }
 """
 exit_code = 42
 
+# Unify-then-default (HM / ADR-0007, RUE-218): an un-annotated literal gets an
+# integer inference variable that unifies with every use in the function body.
+# A single non-i32 use fixes the value to that type (ergonomic; matches Rust).
+[[case]]
+name = "int_literal_unifies_single_i64_use"
+spec = ["3.1:14"]
+source = """
+fn takes_i64(v: i64) -> i64 { v }
+fn main() -> i32 {
+    let x = 5;
+    let a = takes_i64(x);
+    if a == 5 { 42 } else { 0 }
+}
+"""
+exit_code = 42
+
+# Two uses that require different integer types conflict, and the conflict is
+# order-INDEPENDENT: both textual orders are rejected (E0206 type mismatch).
+[[case]]
+name = "int_literal_conflict_i32_then_i64"
+spec = ["3.1:14"]
+compile_fail = true
+error_contains = ["E0206", "type mismatch"]
+source = """
+fn takes_i32(v: i32) -> i32 { v }
+fn takes_i64(v: i64) -> i64 { v }
+fn main() -> i32 {
+    let x = 5;
+    takes_i32(x);
+    takes_i64(x);
+    0
+}
+"""
+
+[[case]]
+name = "int_literal_conflict_i64_then_i32"
+spec = ["3.1:14"]
+compile_fail = true
+error_contains = ["E0206", "type mismatch"]
+source = """
+fn takes_i32(v: i32) -> i32 { v }
+fn takes_i64(v: i64) -> i64 { v }
+fn main() -> i32 {
+    let x = 5;
+    takes_i64(x);
+    takes_i32(x);
+    0
+}
+"""
+
+# No constraining use: the inference variable is still unbound at the defaulting
+# point (end of the function body) and defaults to i32.
+[[case]]
+name = "int_literal_defaults_i32_when_unconstrained"
+spec = ["3.1:15"]
+source = """
+fn main() -> i32 {
+    let x = 5;
+    x
+}
+"""
+exit_code = 5
+
 # =============================================================================
 # Type Mismatch Errors
 # =============================================================================

--- a/docs/spec/src/03-types/01-integer-types.md
+++ b/docs/spec/src/03-types/01-integer-types.md
@@ -97,19 +97,39 @@ fn main() -> i32 {
 
 {{ rule(id="3.1:14", cat="normative") }}
 
-An integer literal without explicit type annotation defaults to type `i32`.
+An integer literal written without an explicit type does not eagerly acquire a
+default type. It is given a fresh integer inference variable that **unifies with
+every use** of the literal's value within the enclosing function body, following
+the language's Hindley–Milner type inference (Algorithm W; see ADR-0007). This
+unification is **order-independent**: all uses of the value must agree on a
+single integer type regardless of the textual order in which they appear, and
+two uses that require different integer types are a compile error, whichever
+use is written first.
 
 {{ rule(id="3.1:15", cat="normative") }}
 
-When an integer literal appears in a context where the expected type is known (e.g., assignment to a typed variable), the literal is inferred to have that type.
+The inference variable is resolved at the **defaulting point**, which is the end
+of the enclosing function body. If any use fixes the value to a concrete integer
+type — for example, assignment to a typed variable, or passing the value to a
+function parameter of known integer type — the literal takes that type. If the
+variable is still unconstrained at the defaulting point, it defaults to `i32`.
+
+> Rue's inference is local: parameters, return types, and constants are always
+> annotated, so every function boundary firewalls inference. A literal's type
+> therefore depends only on uses within its own function body, which is what
+> makes the unify-then-default rule safe here (see ADR-0007).
 
 {{ rule(id="3.1:16") }}
 
 ```rue
+fn takes_i64(v: i64) -> i64 { v }
+
 fn main() -> i32 {
-    let x = 42;           // x has type i32 (default)
-    let y: i64 = 100;     // 100 is inferred as i64
-    0
+    let a = 42;               // no constraining use: defaults to i32 at fn end
+    let b: i64 = 100;         // fixed by the annotation: b (and 100) are i64
+    let c = 7;
+    let _d = takes_i64(c);    // c's only use fixes it to i64 (order-independent)
+    a
 }
 ```
 

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -11,9 +11,9 @@ This section describes how values are moved and copied in Rue.
 
 {{ rule(id="3.8:1", cat="normative") }}
 
-Types in Rue are categorized by how they behave when used:
-- **Copy types** can be implicitly duplicated when used. Using a Copy type does not consume the original value.
-- **Move types** (also called affine types) are consumed when used. After using a move type value, the original binding becomes invalid.
+Types in Rue are categorized by how they behave when *used* (3.8:76):
+- **Copy types** are implicitly duplicated by a use; using a Copy value does not consume the original.
+- **Move types** (also called affine types) are consumed by a use; after a move type value is used, the original binding becomes invalid.
 
 {{ rule(id="3.8:2", cat="normative") }}
 
@@ -40,6 +40,12 @@ fn main() -> i32 {
     q.x + q.y
 }
 ```
+
+## Using a Value
+
+{{ rule(id="3.8:76", cat="informative") }}
+
+The single operation underlying moves, copies, and linear consumption is the *use* of a value. Every occurrence of a place expression — a binding, a field projection, or an array index — sits in exactly one of two syntactic contexts. In a **place context** the occurrence denotes a location and the value stored there is not consumed by appearing there; the place contexts are exactly the target of an assignment, the base of a field projection or array index, and the operand of a `borrow` or `inout` argument. Every other occurrence is a **value context** — an operator operand, the scrutinee of an `if` or `match`, a struct-field or array-element initializer, a by-value function argument, the operand of `return`, or the tail expression of a block — and such an occurrence is a **use** of the place. The effect of a use depends only on the value category of the place's type: a use of a Copy type copies the value and leaves the place valid (3.8:9); a use of a move type, whether affine or linear, moves — equivalently, *consumes* — the value, leaving the place invalid until it is reinitialized (3.8:7, 3.8:33). A use of a field projection or a constant array index moves only that sub-place, a partial move (3.8:22). The enumerations below — the move contexts (3.8:7), the linear consumption contexts (3.8:33), and the repeated use of Copy values (3.8:9) — are each a consequence of this one definition: which occurrences are value contexts, and which value category the used type has. The core calculus, `docs/formal/01-core-calculus.md` §4.2, states this precisely (place context versus value context, and the copy-versus-move effect of a use); the present paragraph is its informal gloss, and the formal definition governs.
 
 ## The `@copy` Directive
 
@@ -125,10 +131,7 @@ A linear type **MUST** be explicitly consumed. It is a compile-time error for a 
 
 {{ rule(id="3.8:33", cat="normative") }}
 
-A linear value is consumed when it is:
-- Passed as an argument to a function (the function is the consumer)
-- Returned from a function (the caller becomes responsible for consuming it)
-- Field access is performed on the value (the value is destructured)
+Consuming a linear value is the same operation as moving it: any use of a linear value (3.8:76) consumes it. Passing it as a by-value argument (the function becomes the consumer), returning it (the caller becomes responsible for consuming it), and moving a field out of it (a partial move that destructures it, 3.8:22) are all uses, and therefore each consumes the value.
 
 {{ rule(id="3.8:34", cat="example") }}
 
@@ -298,7 +301,7 @@ Linear types are useful for:
 
 {{ rule(id="3.8:5", cat="legality-rule") }}
 
-It is a compile-time error to use a value that has been moved.
+It is a compile-time error to use (3.8:76) a value that has been moved.
 
 {{ rule(id="3.8:6", cat="example") }}
 
@@ -315,10 +318,7 @@ fn main() -> i32 {
 
 {{ rule(id="3.8:7", cat="normative") }}
 
-A value is considered moved when it is:
-- Assigned to another variable
-- Passed as an argument to a function
-- Returned from a function
+A move type value is moved by any use of it (3.8:76). Assigning it to another binding, passing it as a by-value argument, and returning it from a function are all value-context occurrences, and are therefore all moves.
 
 {{ rule(id="3.8:8", cat="example") }}
 
@@ -339,7 +339,7 @@ fn main() -> i32 {
 
 {{ rule(id="3.8:9", cat="normative") }}
 
-Copy types can be used multiple times without being consumed.
+A use of a Copy type (3.8:76) copies the value and leaves the original valid, so a Copy value may be used any number of times without being consumed.
 
 {{ rule(id="3.8:10", cat="example") }}
 
@@ -354,13 +354,13 @@ fn main() -> i32 {
 
 {{ rule(id="3.8:11", cat="normative") }}
 
-Function parameters of Copy types receive a copy of the argument. Function parameters of move types receive ownership of the argument.
+Passing an argument by value is a use of it (3.8:76): a parameter of Copy type receives a copy of the argument, and a parameter of move type receives ownership by moving the argument.
 
 ## Partial Moves (Field-Level Moves)
 
 {{ rule(id="3.8:22", cat="normative") }}
 
-When a non-Copy field of a struct is accessed (moved out of), only that specific field is moved, not the entire struct. Other fields remain accessible.
+A use of a non-Copy field projection (3.8:76) is a partial move: only that specific field is moved, not the entire struct, and the sibling fields remain accessible.
 
 {{ rule(id="3.8:23", cat="example") }}
 
@@ -415,7 +415,7 @@ fn main() -> i32 {
 
 {{ rule(id="3.8:28", cat="normative") }}
 
-Accessing Copy-type fields does not move them. Copy-type fields can be accessed any number of times without affecting the struct's move state.
+A use of a Copy-type field (3.8:76) copies it and does not move it; Copy-type fields can therefore be accessed any number of times without affecting the struct's move state.
 
 {{ rule(id="3.8:29", cat="example") }}
 
@@ -433,7 +433,7 @@ fn main() -> i32 {
 
 {{ rule(id="3.8:53", cat="legality-rule") }}
 
-Accessing a field through a moved ancestor path is a compile-time error even when the accessed field is itself a Copy type. The moved ancestor's storage is no longer owned by the variable, so nothing within it may be read.
+The base of a field projection is read in place context (3.8:76), but it must still own its storage. Accessing a field through a moved ancestor path is therefore a compile-time error even when the accessed field is itself a Copy type: the moved ancestor's storage is no longer owned by the variable, so nothing within it may be read.
 
 {{ rule(id="3.8:54", cat="example") }}
 


### PR DESCRIPTION
Two docs-and-tests spec-quality changes, **no behavior change**.

**RUE-202** (ch-3.8 `use` rewrite) — unify the three overlapping folk-enumerations around the formal `use` definition. New **3.8:76** (informative, "Using a Value") defines *use* via place-context vs value-context with copy-vs-move keyed to value category, citing `docs/formal` §4.2 as governing; **3.8:7** (move contexts), **3.8:33** (linear consume), **3.8:9** (copy) reworded as consequences of it, plus cross-refs. Every id/category preserved.

**RUE-218** (integer-literal inference) — the reported order-dependent bug is **refuted**: the HM engine already does correct per-function unify-then-default (fresh int-literal var, unifies with every use, defaults i32 once; *both* conflict orders reject with E0206, order-independent — the hunt misread which call carries the message). The genuinely-wrong artifact was the **spec**: 3.1:14 said literals eagerly default to i32, contradicting the impl and ADR-0007. Rewrote **3.1:14–16** to the unify-then-default rule, added 4 spec + 4 CLI cases (both conflict orders) locking in the behavior, fixed a stale `mod.rs` doc. No behavior code changed.

Traceability 100% normative (602/602); full `./test.sh` green.

Part of RUE-202
Fixes RUE-218

🤖 Generated with [Claude Code](https://claude.com/claude-code)