### PR TITLE
Fix @raw operand move-tracking (destructor leak) + user-method String-name collision (RUE-222, RUE-223)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -2941,8 +2941,19 @@ impl<'a> Sema<'a> {
         let receiver_var = self.extract_root_variable(receiver);
         let method_name_str = self.interner.resolve(&method).to_string();
 
-        // Check if this is a builtin mutation method
-        let is_builtin_mutation_method = self.is_builtin_mutation_method(&method_name_str);
+        // Check if this is a builtin (String) mutation method. Gate the
+        // name-only match on the receiver's resolved type actually being the
+        // builtin: a user struct method that merely shares a name with a String
+        // mutation method (`push`/`push_str`/`clear`/`reserve`) must not be
+        // misclassified as a `ByMutRef` mutation and wrongly demand a `mut`
+        // receiver (RUE-223). The type is peeked from the binding without
+        // analyzing the receiver, because the storage location must be captured
+        // before the receiver expression is (potentially) consumed below.
+        let receiver_is_builtin_string = self
+            .peek_var_ref_type(receiver, ctx)
+            .is_some_and(|ty| self.is_builtin_string(ty));
+        let is_builtin_mutation_method =
+            receiver_is_builtin_string && self.is_builtin_mutation_method(&method_name_str);
 
         // Get storage location for mutation methods before analyzing receiver
         let receiver_storage = if is_builtin_mutation_method {
@@ -4676,6 +4687,24 @@ impl<'a> Sema<'a> {
     /// - An immutable binding (`let` instead of `var`)
     /// - A borrow parameter (can't mutate borrowed values)
     /// - Not an lvalue (e.g., a function call result)
+    /// Peek the declared type of a `VarRef` receiver (a local or parameter)
+    /// without analyzing it, so a builtin mutation-method call can be classified
+    /// before the receiver expression is (potentially) consumed. Returns `None`
+    /// for non-`VarRef` receivers or unknown names — such receivers are never
+    /// valid targets for a String mutation method anyway (see
+    /// `get_string_receiver_storage`).
+    fn peek_var_ref_type(&self, receiver_ref: InstRef, ctx: &AnalysisContext) -> Option<Type> {
+        if let InstData::VarRef { name } = &self.rir.get(receiver_ref).data {
+            if let Some(local) = ctx.locals.get(name) {
+                return Some(local.ty);
+            }
+            if let Some(param) = ctx.params.iter().find(|p| p.name == *name) {
+                return Some(param.ty);
+            }
+        }
+        None
+    }
+
     fn get_string_receiver_storage(
         &self,
         receiver_ref: InstRef,
@@ -5988,8 +6017,30 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        let arg_result = self.analyze_inst(air, args[0].value, ctx)?;
+        // @raw / @raw_mut take the ADDRESS of a place; per spec 3.8:57 a pointer
+        // does not own its pointee, so the operand is borrowed (address-of), not
+        // consumed. Mirror the ByRef un-move (as `borrow` operands and String
+        // index reads do): snapshot the root's move state, then cancel the move
+        // the operand analysis records. This keeps the operand live so its
+        // destructor still runs exactly once at scope exit and later uses remain
+        // legal (RUE-222) — rather than silently leaking it or rejecting a valid
+        // later use with E0205.
+        let operand = args[0].value;
+        let operand_root = self.extract_root_variable(operand);
+        let operand_move_state_before = operand_root.and_then(|v| ctx.moved_vars.get(&v).cloned());
+        let arg_result = self.analyze_inst(air, operand, ctx)?;
         let pointee_type = arg_result.ty;
+        if let Some(var) = operand_root {
+            match operand_move_state_before {
+                Some(state) => {
+                    ctx.moved_vars.insert(var, state);
+                }
+                None => {
+                    ctx.moved_vars.remove(&var);
+                }
+            }
+        }
+        air.cancel_move_marker(arg_result.air_ref);
 
         // For addr_of, we need the argument to be an lvalue (addressable)
         // This is validated at the RIR level - here we just compute the result type

--- a/crates/rue-cli-tests/cases/raw_ptr_and_method_name.toml
+++ b/crates/rue-cli-tests/cases/raw_ptr_and_method_name.toml
@@ -1,0 +1,142 @@
+# Sema fixes found by the aggregate-ABI hunt (2026-07-02).
+#
+# RUE-222: @raw / @raw_mut take the ADDRESS of a place (spec 3.8:57 — a pointer
+# does not own its pointee), so the operand must NOT be move-tracked/consumed.
+# Previously taking a raw pointer silently suppressed the operand's destructor
+# (leak) and rejected any later use with E0205.
+#
+# RUE-223: a user struct method whose name collides with a builtin String
+# mutation method (push/push_str/clear/reserve) must not be misclassified as a
+# String ByMutRef mutation demanding a `mut` receiver. Classification now gates
+# the name match on the receiver's resolved type actually being String.
+
+[section]
+id = "cli.raw_ptr_and_method_name"
+name = "Raw-pointer place semantics and method-name collisions"
+description = "@raw/@raw_mut borrow their operand as a place; user methods named like String mutators don't force a mut receiver."
+
+# --- RUE-222 facet A: destructor still runs exactly once after @raw ---------
+[[case]]
+name = "raw_ptr_does_not_suppress_destructor"
+files = [{ path = "main.rue", source = """
+struct Loud { a: i64 }
+drop fn Loud(self) { @dbg(self.a); }
+fn main() -> i32 {
+    let x = Loud { a: 777 };
+    let _p: ptr const Loud = checked { @raw(x) };
+    @dbg(999);
+    0
+}
+""" }]
+stdout = "999\n777\n"
+
+# --- RUE-222 facet A (mut): @raw_mut is likewise a place, not a move ---------
+[[case]]
+name = "raw_mut_ptr_does_not_suppress_destructor"
+files = [{ path = "main.rue", source = """
+struct Loud { a: i64 }
+drop fn Loud(self) { @dbg(self.a); }
+fn main() -> i32 {
+    let mut x = Loud { a: 777 };
+    let _p: ptr mut Loud = checked { @raw_mut(x) };
+    @dbg(999);
+    0
+}
+""" }]
+stdout = "999\n777\n"
+
+# --- RUE-222: moving the operand AFTER @raw is still legal and drops once ----
+# eat() consumes x (body prints 777, then drops its param -> 777). x is moved
+# out of main, so main does NOT drop it: exactly one destructor run, no double
+# free. Proves @raw left ownership with x rather than stealing it.
+[[case]]
+name = "raw_ptr_then_move_operand_single_drop"
+files = [{ path = "main.rue", source = """
+struct Loud { a: i64 }
+drop fn Loud(self) { @dbg(self.a); }
+fn eat(l: Loud) -> i32 { @dbg(l.a); 0 }
+fn main() -> i32 {
+    let x = Loud { a: 777 };
+    let _p: ptr const Loud = checked { @raw(x) };
+    @dbg(999);
+    eat(x);
+    @dbg(111);
+    0
+}
+""" }]
+stdout = "999\n777\n777\n111\n"
+
+# --- RUE-222 facet B: using the operand after @raw is legal (no E0205) -------
+[[case]]
+name = "raw_ptr_operand_usable_after"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = "hello";
+    let _p: ptr const String = checked { @raw(s) };
+    @dbg(s.len());
+    0
+}
+""" }]
+stdout = "5\n"
+
+# --- RUE-223: user method named `push` on an immutable binding compiles ------
+[[case]]
+name = "user_struct_push_no_mut_required"
+files = [{ path = "main.rue", source = """
+struct Counter {
+    value: i32,
+    fn push(self, v: i32) -> Counter { Counter { value: self.value + v } }
+}
+fn main() -> i32 {
+    let c = Counter { value: 1 };
+    let d = c.push(41);
+    @dbg(d.value);
+    0
+}
+""" }]
+stdout = "42\n"
+
+# --- RUE-223: user `clear` / `reserve` on immutable bindings compile ---------
+[[case]]
+name = "user_struct_clear_reserve_no_mut_required"
+files = [{ path = "main.rue", source = """
+struct Bag {
+    n: i32,
+    fn clear(self) -> i32 { 5 }
+    fn reserve(self, k: i32) -> i32 { k }
+}
+fn main() -> i32 {
+    let b = Bag { n: 1 };
+    @dbg(b.clear());
+    let b2 = Bag { n: 2 };
+    @dbg(b2.reserve(9));
+    0
+}
+""" }]
+stdout = "5\n9\n"
+
+# --- RUE-223 guard: String's real mutation methods STILL require `mut` -------
+[[case]]
+name = "string_push_str_still_requires_mut"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = String::new();
+    s.push_str("x");
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0203"]
+
+# --- RUE-223 guard: String mutation on a `mut` binding still works -----------
+[[case]]
+name = "string_push_str_on_mut_ok"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut s = String::new();
+    s.push_str("hi");
+    @dbg(s.len());
+    0
+}
+""" }]
+stdout = "2\n"


### PR DESCRIPTION
Two sema bugs from the aggregate-ABI hunt. Sema-only.

**RUE-222** — `@raw`/`@raw_mut` analyzed their operand as a value/move, so taking a raw pointer *stole ownership*: the destructor was silently omitted (**leak**) and later use was falsely rejected E0205. Fixed in `analyze_addr_of_intrinsic` (analysis.rs ~5991) by snapshotting the root's move state and restoring it (+ `cancel_move_marker`) after analysis, mirroring the ByRef un-move. Per spec 3.8:57 a pointer does not own its pointee. Verified: destructor runs exactly once (`999` then `777`, no double-free), `@raw(s)` then use compiles, both backends emit drop glue.

**RUE-223** — a user struct method named `push`/`push_str`/`clear`/`reserve` was misclassified as a String `ByMutRef` mutation (name-only match *before* the receiver type was resolved), forcing a `mut` receiver (E0203). Fixed at the call site (analysis.rs ~2945) by gating `is_builtin_mutation_method` on the receiver's resolved type being the builtin String. Verified: user `push`/`clear`/`reserve` on immutable bindings compile; String's real mutators still require `mut`.

8 CLI cases. Full `./test.sh` green.

Fixes RUE-222
Fixes RUE-223

🤖 Generated with [Claude Code](https://claude.com/claude-code)