### PR TITLE
Borrow/inout method receivers (RUE-15, preview method_receivers)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -238,6 +238,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                     return_type,
                     body,
                     has_self,
+                    self_mode,
                     ..
                 } = &method_inst.data
                 {
@@ -259,6 +260,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                         method_inst.span,
                         struct_type,
                         *has_self,
+                        *self_mode,
                     ) {
                         Ok((analyzed, warnings, local_strings, _ref_fns, _ref_meths)) => {
                             functions_with_strings.push((analyzed, local_strings));
@@ -356,12 +358,13 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
             let mut param_info: Vec<(Spur, Type, RirParamMode, bool)> = Vec::new();
 
             if method_info.has_self {
-                // Add self parameter (Normal mode - passed by value)
+                // Add self parameter in the receiver's declared mode
+                // (by-value `self`, or by-ref `borrow`/`inout self`; RUE-15).
                 let self_sym = sema.interner.get_or_intern("self");
                 param_info.push((
                     self_sym,
                     method_info.struct_type,
-                    RirParamMode::Normal,
+                    method_info.self_mode,
                     false,
                 ));
             }
@@ -631,12 +634,13 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                 let mut param_info: Vec<(Spur, Type, RirParamMode, bool)> = Vec::new();
 
                 if method_info.has_self {
-                    // Add self parameter (Normal mode - passed by value)
+                    // Add self parameter in the receiver's declared mode
+                    // (by-value `self`, or by-ref `borrow`/`inout self`; RUE-15).
                     let self_sym = sema.interner.get_or_intern("self");
                     param_info.push((
                         self_sym,
                         method_info.struct_type,
-                        RirParamMode::Normal,
+                        method_info.self_mode,
                         false,
                     ));
                 }
@@ -730,6 +734,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                             return_type,
                             body,
                             has_self,
+                            self_mode,
                             ..
                         } = &method_inst.data
                         {
@@ -753,6 +758,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                                 method_inst.span,
                                 method_info.struct_type,
                                 *has_self,
+                                *self_mode,
                             ) {
                                 Ok((
                                     analyzed,
@@ -1440,6 +1446,7 @@ impl<'a> Sema<'a> {
         span: Span,
         struct_type: Type,
         has_self: bool,
+        self_mode: RirParamMode,
     ) -> CompileResult<(
         AnalyzedFunction,
         Vec<CompileWarning>,
@@ -1455,9 +1462,10 @@ impl<'a> Sema<'a> {
         let mut param_info: Vec<(Spur, Type, RirParamMode, bool)> = Vec::new();
 
         if has_self {
-            // Add self parameter (Normal mode - passed by value)
+            // Add self parameter in the receiver's declared mode (by-value
+            // `self`, or by-ref `borrow`/`inout self`; RUE-15).
             let self_sym = self.interner.get_or_intern("self");
-            param_info.push((self_sym, struct_type, RirParamMode::Normal, false));
+            param_info.push((self_sym, struct_type, self_mode, false));
         }
 
         // Add regular parameters with their modes
@@ -1633,6 +1641,27 @@ impl<'a> Sema<'a> {
         HashSet<(StructId, Spur)>,
     )> {
         let mut air = Air::new(return_type);
+
+        // Preview gate (RUE-15 / ADR-0037): a `borrow self` / `inout self`
+        // receiver lowers to a synthetic `self` parameter carrying a non-Normal
+        // mode. `self` can never be a user-written parameter name (it is a
+        // dedicated keyword), so this is a reliable single chokepoint for
+        // every method body — named or anonymous struct — that actually
+        // reaches analysis. By-value `self` (Normal) and destructors are
+        // unaffected.
+        let self_sym = self.interner.get_or_intern("self");
+        if let Some((_, _, mode, _)) = params
+            .iter()
+            .find(|(name, _, mode, _)| *name == self_sym && *mode != RirParamMode::Normal)
+        {
+            debug_assert!(matches!(mode, RirParamMode::Inout | RirParamMode::Borrow));
+            self.require_preview(
+                PreviewFeature::MethodReceivers,
+                "borrow/inout method receivers",
+                self.rir.get(body).span,
+            )?;
+        }
+
         let mut param_vec: Vec<ParamInfo> = Vec::new();
         let mut param_modes: Vec<bool> = Vec::new();
 
@@ -3046,16 +3075,93 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        // Check for exclusive access violation
-        self.check_exclusive_access(&args, span)?;
-
         // Clone data needed before mutable borrow
         let return_type = method_info.return_type;
+        let self_mode = method_info.self_mode;
+
+        // Receiver passing mode (autoref, RUE-15). `borrow self` / `inout
+        // self` receivers are accessed by reference — the receiver is passed
+        // by address, reusing the by-ref parameter calling convention — so the
+        // call does NOT consume the receiver. Bare `self` stays by-value.
+        let receiver_mode = match self_mode {
+            RirParamMode::Inout => AirArgMode::Inout,
+            RirParamMode::Borrow => AirArgMode::Borrow,
+            _ => AirArgMode::Normal,
+        };
+
+        if receiver_mode != AirArgMode::Normal {
+            // The receiver must be a place (a variable or a field/index chain
+            // rooted at one): codegen forms its address. A temporary (call
+            // result, literal, …) has no caller-visible storage to borrow.
+            let Some(receiver_root) = receiver_var else {
+                return Err(CompileError::new(
+                    if receiver_mode == AirArgMode::Inout {
+                        ErrorKind::InoutNonLvalue
+                    } else {
+                        ErrorKind::BorrowNonLvalue
+                    },
+                    self.rir.get(receiver).span,
+                ));
+            };
+
+            // `inout self` requires a mutable receiver binding (spec 6, reuses
+            // E0203), mirroring Rust. `borrow self` works on any binding.
+            if receiver_mode == AirArgMode::Inout
+                && !self.receiver_root_is_mutable(receiver_root, ctx)
+            {
+                let name = self.interner.resolve(&receiver_root).to_string();
+                return Err(
+                    CompileError::new(ErrorKind::AssignToImmutable(name.clone()), span).with_help(
+                        format!(
+                            "`inout self` needs a mutable receiver; make the binding \
+                     mutable: `let mut {name} = ...`"
+                        ),
+                    ),
+                );
+            }
+
+            // Access-point exclusivity (ADR-0037): the receiver's inout/borrow
+            // access is scoped to this call. Reject genuine overlap — the
+            // receiver root also passed as an inout/borrow argument
+            // (`s.absorb(inout s)`). An argument that merely READS self
+            // (`v.push(v.len())`) is fine: its read completes before the
+            // receiver access begins, and it is not a by-ref argument so it
+            // never enters the exclusivity sets.
+            let mut excl_args: Vec<RirCallArg> = Vec::with_capacity(args.len() + 1);
+            excl_args.push(RirCallArg {
+                value: receiver,
+                mode: if receiver_mode == AirArgMode::Inout {
+                    RirArgMode::Inout
+                } else {
+                    RirArgMode::Borrow
+                },
+            });
+            excl_args.extend(args.iter().cloned());
+            self.check_exclusive_access(&excl_args, span)?;
+
+            // By-ref receivers are borrows, not moves: undo the move the
+            // receiver analysis recorded (restoring the pre-receiver snapshot,
+            // so sibling moves stay recorded) and cancel its move marker, so
+            // drop elaboration does not treat this borrow as a move. Mirrors
+            // the builtin ByRef/ByMutRef receiver handling.
+            match receiver_move_state_before.clone() {
+                Some(state) => {
+                    ctx.moved_vars.insert(receiver_root, state);
+                }
+                None => {
+                    ctx.moved_vars.remove(&receiver_root);
+                }
+            }
+            air.cancel_move_marker(receiver_result.air_ref);
+        } else {
+            // Check for exclusive access violation (by-value receiver)
+            self.check_exclusive_access(&args, span)?;
+        }
 
         // Analyze arguments - receiver first, then remaining args
         let mut air_args = vec![AirCallArg {
             value: receiver_result.air_ref,
-            mode: AirArgMode::Normal,
+            mode: receiver_mode,
         }];
         air_args.extend(self.analyze_call_args(air, &args, ctx)?);
 
@@ -5435,6 +5541,21 @@ impl<'a> Sema<'a> {
         root_variable_of(self.rir, inst_ref)
     }
 
+    /// Whether a method receiver rooted at `root` binds a mutable place, for
+    /// the `inout self` mut-binding requirement (RUE-15). A `let mut` local is
+    /// mutable; an `inout` parameter is mutable (it already names mutable
+    /// caller storage); everything else (`let`, `borrow` params) is not.
+    /// Mirrors `PlaceTrace::is_root_mutable`.
+    fn receiver_root_is_mutable(&self, root: Spur, ctx: &AnalysisContext) -> bool {
+        if let Some(param) = ctx.params.iter().find(|p| p.name == root) {
+            return param.mode == RirParamMode::Inout;
+        }
+        if let Some(local) = ctx.locals.get(&root) {
+            return local.is_mut;
+        }
+        false
+    }
+
     /// Check exclusivity rules for inout and borrow parameters in a call
     /// (adapter over the shared [`check_exclusive_access_in`], RUE-141).
     pub(crate) fn check_exclusive_access(
@@ -5529,6 +5650,7 @@ impl<'a> Sema<'a> {
                 return_type,
                 body,
                 has_self,
+                self_mode,
                 ..
             } = &method_inst.data
             {
@@ -5570,6 +5692,7 @@ impl<'a> Sema<'a> {
                     MethodInfo {
                         struct_type,
                         has_self: *has_self,
+                        self_mode: *self_mode,
                         params: param_range,
                         return_type: ret_type,
                         body: *body,
@@ -5612,6 +5735,7 @@ impl<'a> Sema<'a> {
                 return_type,
                 body,
                 has_self,
+                self_mode,
                 ..
             } = &method_inst.data
             {
@@ -5656,6 +5780,7 @@ impl<'a> Sema<'a> {
                     MethodInfo {
                         struct_type,
                         has_self: *has_self,
+                        self_mode: *self_mode,
                         params: param_range,
                         return_type: ret_type,
                         body: *body,
@@ -5713,6 +5838,7 @@ impl<'a> Sema<'a> {
                 return_type,
                 body,
                 has_self,
+                self_mode,
                 ..
             } = &method_inst.data
             {
@@ -5771,6 +5897,7 @@ impl<'a> Sema<'a> {
                     MethodInfo {
                         struct_type,
                         has_self: *has_self,
+                        self_mode: *self_mode,
                         params: param_range,
                         return_type: ret_type,
                         body: *body,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -891,6 +891,7 @@ impl<'a> Sema<'a> {
                 return_type,
                 body,
                 has_self,
+                self_mode,
                 ..
             } = &method_inst.data
             {
@@ -931,6 +932,7 @@ impl<'a> Sema<'a> {
                     MethodInfo {
                         struct_type,
                         has_self: *has_self,
+                        self_mode: *self_mode,
                         params: param_range,
                         return_type: ret_type,
                         body: *body,

--- a/crates/rue-air/src/sema/info.rs
+++ b/crates/rue-air/src/sema/info.rs
@@ -50,6 +50,10 @@ pub struct MethodInfo {
     pub struct_type: Type,
     /// Whether this is a method (has self) or associated function (no self)
     pub has_self: bool,
+    /// The receiver's passing mode when `has_self` is true (`Normal`
+    /// by-value, `Borrow`, or `Inout`; RUE-15). Determines how the receiver
+    /// is passed at call sites (by value vs. by reference / autoref).
+    pub self_mode: rue_rir::RirParamMode,
     /// Parameter data (names, types, modes, comptime flags) stored in arena.
     /// Access via `arena.names(params)`, `arena.types(params)`, etc.
     /// Note: This excludes `self` if present - only explicit parameters.

--- a/crates/rue-cli-tests/cases/method_receivers.toml
+++ b/crates/rue-cli-tests/cases/method_receivers.toml
@@ -1,0 +1,116 @@
+# Borrow/inout method receivers (RUE-15, ADR-0037).
+#
+# `borrow self` / `inout self` receivers are accessed by reference (reusing the
+# by-ref parameter calling convention) instead of consuming the receiver. These
+# cases exercise the runtime behavior end-to-end through the real driver with
+# exact stdout, on both backends (aarch64 runs natively in CI). Gated behind
+# `--preview method_receivers`.
+
+[section]
+id = "cli.method_receivers"
+name = "Borrow/inout method receivers"
+description = "borrow self getters and inout self mutators via the real driver."
+
+# inout self mutates the receiver in place across multiple calls; a borrow self
+# getter observes the mutations and does not consume the receiver.
+[[case]]
+name = "stack_push_top_count"
+args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Stack {
+    a: i32,
+    b: i32,
+    n: i32,
+
+    fn push(inout self, v: i32) {
+        if self.n == 0 {
+            self.a = v;
+        } else {
+            self.b = v;
+        }
+        self.n = self.n + 1;
+    }
+
+    fn top(borrow self) -> i32 {
+        if self.n == 1 { self.a } else { self.b }
+    }
+
+    fn count(borrow self) -> i32 {
+        self.n
+    }
+}
+
+fn main() -> i32 {
+    let mut s = Stack { a: 0, b: 0, n: 0 };
+    s.push(10);
+    s.push(20);
+    @dbg(s.top());
+    @dbg(s.count());
+    s.push(30);
+    @dbg(s.count());
+    @dbg(s.top());
+    0
+}
+""" }]
+stdout = "20\n2\n3\n30\n"
+
+# A borrow self getter is callable repeatedly without moving the receiver.
+[[case]]
+name = "borrow_getter_repeatable"
+args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Counter {
+    n: i32,
+
+    fn get(borrow self) -> i32 {
+        self.n
+    }
+
+    fn bump(inout self) {
+        self.n = self.n + 1;
+    }
+}
+
+fn main() -> i32 {
+    let mut c = Counter { n: 0 };
+    c.bump();
+    c.bump();
+    @dbg(c.get());
+    c.bump();
+    @dbg(c.get());
+    @dbg(c.get());
+    0
+}
+""" }]
+stdout = "2\n3\n3\n"
+
+# An argument that only reads self is allowed alongside the inout receiver
+# access (the read completes before the receiver access begins).
+[[case]]
+name = "arg_reads_receiver"
+args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Stack {
+    a: i32,
+    b: i32,
+    n: i32,
+
+    fn push(inout self, v: i32) {
+        if self.n == 0 { self.a = v; } else { self.b = v; }
+        self.n = self.n + 1;
+    }
+
+    fn count(borrow self) -> i32 { self.n }
+}
+
+fn main() -> i32 {
+    let mut s = Stack { a: 0, b: 0, n: 0 };
+    s.push(s.count());
+    s.push(s.count());
+    @dbg(s.a);
+    @dbg(s.b);
+    @dbg(s.n);
+    0
+}
+""" }]
+stdout = "0\n1\n2\n"

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -357,6 +357,10 @@ pub enum PreviewFeature {
     /// Layer 1 of the iteration model: `for x in <iterable> { body }` in
     /// read/borrow mode over arrays, String bytes, and `s.chars()`.
     ForLoops,
+    /// Borrow/inout method receivers (`fn f(borrow self)` / `fn f(inout
+    /// self)`), RUE-15 / ADR-0037. Lets methods access `self` by reference
+    /// instead of consuming it.
+    MethodReceivers,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -378,6 +382,7 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::ForLoops => "for_loops",
+            PreviewFeature::MethodReceivers => "method_receivers",
         }
     }
 
@@ -387,12 +392,17 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::ForLoops => "ADR-0037",
+            PreviewFeature::MethodReceivers => "ADR-0037",
         }
     }
 
     /// Get all available preview features.
     pub fn all() -> &'static [PreviewFeature] {
-        &[PreviewFeature::TestInfra, PreviewFeature::ForLoops]
+        &[
+            PreviewFeature::TestInfra,
+            PreviewFeature::ForLoops,
+            PreviewFeature::MethodReceivers,
+        ]
     }
 
     /// Get a comma-separated list of all feature names (for help text).
@@ -416,6 +426,7 @@ impl std::str::FromStr for PreviewFeature {
         match s {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "for_loops" => Ok(PreviewFeature::ForLoops),
+            "method_receivers" => Ok(PreviewFeature::MethodReceivers),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -2192,7 +2203,15 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, for_loops");
+        assert_eq!(names, "test_infra, for_loops, method_receivers");
+    }
+
+    #[test]
+    fn test_preview_feature_method_receivers_roundtrip() {
+        use std::str::FromStr;
+        let f = PreviewFeature::from_str("method_receivers").unwrap();
+        assert_eq!(f, PreviewFeature::MethodReceivers);
+        assert_eq!(f.name(), "method_receivers");
     }
 
     // ========================================================================

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -201,9 +201,16 @@ pub struct Method {
 }
 
 /// A self parameter in a method.
+///
+/// The receiver mode mirrors the parameter modes (`borrow self` / `inout
+/// self` / bare `self`), so the compiler can access `self` by reference for
+/// borrow/inout receivers (RUE-15). Only `Normal`, `Borrow`, and `Inout` are
+/// ever produced here — `Comptime` is not a valid receiver mode.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SelfParam {
-    /// Span covering the `self` keyword
+    /// Receiver passing mode (`Normal` by-value, `Borrow`, or `Inout`).
+    pub mode: ParamMode,
+    /// Span covering the `self` keyword (and any leading mode keyword).
     pub span: Span,
 }
 
@@ -1105,7 +1112,12 @@ fn fmt_method(f: &mut fmt::Formatter<'_>, method: &Method, level: usize) -> fmt:
     indent(f, level)?;
     write!(f, "Method sym:{}", method.name.name.into_usize())?;
     write!(f, "(")?;
-    if method.receiver.is_some() {
+    if let Some(receiver) = &method.receiver {
+        match receiver.mode {
+            ParamMode::Inout => write!(f, "inout ")?,
+            ParamMode::Borrow => write!(f, "borrow ")?,
+            _ => {}
+        }
         write!(f, "self")?;
         if !method.params.is_empty() {
             write!(f, ", ")?;

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -1736,68 +1736,85 @@ where
         .delimited_by(just(TokenKind::LBracket), just(TokenKind::RBracket))
         .map(AssignSuffix::Index);
 
-    ident_parser()
-        .then(
-            choice((field_suffix, index_suffix))
-                .repeated()
-                .collect::<Vec<_>>(),
-        )
+    let suffix = choice((field_suffix, index_suffix));
+
+    // Identifier base: `x`, `x.a[0].b`, ... (a bare `x` is a variable target).
+    let ident_target = ident_parser()
+        .then(suffix.clone().repeated().collect::<Vec<_>>())
         .map(|(base_ident, suffixes)| {
             if suffixes.is_empty() {
                 // Simple variable: x
-                AssignTarget::Var(base_ident)
+                AssignTarget::Var(base_ident.clone())
             } else {
-                // Chain of field/index accesses: x.a[0].b...
-                // Build up the expression from left to right, consuming suffixes by value
-                let mut base_expr = Expr::Ident(base_ident);
-                let mut suffixes = suffixes.into_iter().peekable();
-                while let Some(suffix) = suffixes.next() {
-                    let is_last = suffixes.peek().is_none();
-                    if is_last {
-                        // The last suffix determines the target type
-                        return match suffix {
-                            AssignSuffix::Field(field) => {
-                                let span = base_expr.span().extend_to(field.span.end);
-                                AssignTarget::Field(FieldExpr {
-                                    base: Box::new(base_expr),
-                                    field,
-                                    span,
-                                })
-                            }
-                            AssignSuffix::Index(index) => {
-                                let span = base_expr.span().extend_to(index.span().end);
-                                AssignTarget::Index(IndexExpr {
-                                    base: Box::new(base_expr),
-                                    index: Box::new(index),
-                                    span,
-                                })
-                            }
-                        };
-                    }
-                    // Build intermediate expressions
-                    match suffix {
-                        AssignSuffix::Field(field) => {
-                            let span = base_expr.span().extend_to(field.span.end);
-                            base_expr = Expr::Field(FieldExpr {
-                                base: Box::new(base_expr),
-                                field,
-                                span,
-                            });
-                        }
-                        AssignSuffix::Index(index) => {
-                            let span = base_expr.span().extend_to(index.span().end);
-                            base_expr = Expr::Index(IndexExpr {
-                                base: Box::new(base_expr),
-                                index: Box::new(index),
-                                span,
-                            });
-                        }
-                    }
-                }
-                // This is unreachable since we already checked suffixes.is_empty()
-                unreachable!()
+                build_projected_assign_target(Expr::Ident(base_ident), suffixes)
             }
+        });
+
+    // `self` base: `self.a`, `self.a[0]`, ... — for mutating a field of an
+    // `inout self` receiver (RUE-15). At least one projection is required: a
+    // bare `self` is not an assignable place.
+    let self_target = just(TokenKind::SelfValue)
+        .map_with(|_, e| SelfExpr {
+            span: span_from_extra(e),
         })
+        .then(suffix.repeated().at_least(1).collect::<Vec<_>>())
+        .map(|(self_expr, suffixes)| {
+            build_projected_assign_target(Expr::SelfExpr(self_expr), suffixes)
+        });
+
+    choice((self_target, ident_target))
+}
+
+/// Build a field/index assignment target from a base expression and a
+/// non-empty chain of field/index projections. The last projection determines
+/// whether the target is a `Field` or `Index` place; earlier ones become
+/// intermediate `Expr::Field`/`Expr::Index` accesses on the base.
+fn build_projected_assign_target(base: Expr, suffixes: Vec<AssignSuffix>) -> AssignTarget {
+    debug_assert!(!suffixes.is_empty());
+    let mut base_expr = base;
+    let mut suffixes = suffixes.into_iter().peekable();
+    while let Some(suffix) = suffixes.next() {
+        let is_last = suffixes.peek().is_none();
+        if is_last {
+            return match suffix {
+                AssignSuffix::Field(field) => {
+                    let span = base_expr.span().extend_to(field.span.end);
+                    AssignTarget::Field(FieldExpr {
+                        base: Box::new(base_expr),
+                        field,
+                        span,
+                    })
+                }
+                AssignSuffix::Index(index) => {
+                    let span = base_expr.span().extend_to(index.span().end);
+                    AssignTarget::Index(IndexExpr {
+                        base: Box::new(base_expr),
+                        index: Box::new(index),
+                        span,
+                    })
+                }
+            };
+        }
+        match suffix {
+            AssignSuffix::Field(field) => {
+                let span = base_expr.span().extend_to(field.span.end);
+                base_expr = Expr::Field(FieldExpr {
+                    base: Box::new(base_expr),
+                    field,
+                    span,
+                });
+            }
+            AssignSuffix::Index(index) => {
+                let span = base_expr.span().extend_to(index.span().end);
+                base_expr = Expr::Index(IndexExpr {
+                    base: Box::new(base_expr),
+                    index: Box::new(index),
+                    span,
+                });
+            }
+        }
+    }
+    unreachable!("suffixes is non-empty")
 }
 
 /// Parser for assignment statements: target = expr;
@@ -2294,10 +2311,22 @@ fn method_parser_with_expr<'src, I>(
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    // Parse optional self parameter
-    let self_param = just(TokenKind::SelfValue).map_with(|_, e| SelfParam {
-        span: span_from_extra(e),
-    });
+    // Parse optional self parameter, with an optional receiver mode keyword
+    // (`borrow self` / `inout self`), mirroring the parameter modes (RUE-15).
+    // Bare `self` stays by-value (`Normal`).
+    let receiver_mode = choice((
+        just(TokenKind::Inout).to(ParamMode::Inout),
+        just(TokenKind::Borrow).to(ParamMode::Borrow),
+    ))
+    .or_not()
+    .map(|opt| opt.unwrap_or(ParamMode::Normal));
+
+    let self_param = receiver_mode
+        .then(just(TokenKind::SelfValue))
+        .map_with(|(mode, _), e| SelfParam {
+            mode,
+            span: span_from_extra(e),
+        });
 
     // Parse self followed by optional regular params
     let self_then_params = self_param
@@ -2343,8 +2372,9 @@ where
 {
     let expr = expr_parser();
 
-    // Parse self parameter
+    // Parse self parameter (destructors always take self by value)
     let self_param = just(TokenKind::SelfValue).map_with(|_, e| SelfParam {
+        mode: ParamMode::Normal,
         span: span_from_extra(e),
     });
 

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -254,11 +254,18 @@ impl<'a> AstGen<'a> {
         // Generate body expression
         let body = self.gen_expr(&method.body);
 
-        // Track whether this method has a self receiver (method vs associated function)
+        // Track whether this method has a self receiver (method vs associated
+        // function) and, if so, the receiver's passing mode (`borrow self` /
+        // `inout self` / bare by-value `self`, RUE-15).
         let has_self = method.receiver.is_some();
+        let self_mode = match &method.receiver {
+            Some(receiver) => self.convert_param_mode(receiver.mode),
+            None => RirParamMode::Normal,
+        };
 
         // Emit methods as FnDecl instructions with has_self flag.
-        // Sema uses has_self to add the implicit self parameter for methods.
+        // Sema uses has_self to add the implicit self parameter for methods,
+        // and self_mode to add it in the declared borrow/inout/by-value mode.
         // Methods don't have their own visibility - they're accessible if the type is accessible.
         // Methods cannot be marked unchecked (that's a function-level modifier).
         let decl = self.rir.add_inst(Inst {
@@ -273,6 +280,7 @@ impl<'a> AstGen<'a> {
                 return_type,
                 body,
                 has_self,
+                self_mode,
             },
             span: method.span,
         });
@@ -373,6 +381,7 @@ impl<'a> AstGen<'a> {
                 return_type,
                 body,
                 has_self: false,
+                self_mode: RirParamMode::Normal,
             },
             span: func.span,
         });

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -875,6 +875,7 @@ impl Rir {
                 return_type,
                 body,
                 has_self,
+                self_mode,
             } => InstData::FnDecl {
                 directives_start: *directives_start + extra_offset,
                 directives_len: *directives_len,
@@ -886,6 +887,7 @@ impl Rir {
                 return_type: *return_type,
                 body: renumber(*body),
                 has_self: *has_self,
+                self_mode: *self_mode,
             },
 
             // Constant declaration - init is an InstRef
@@ -1383,6 +1385,10 @@ pub enum InstData {
         /// Only true for methods in impl blocks that have a self parameter.
         /// Used by sema to know to add the implicit self parameter.
         has_self: bool,
+        /// The receiver's passing mode when `has_self` is true (`Normal`
+        /// by-value, `Borrow`, or `Inout`; RUE-15). Always `Normal` for
+        /// associated functions and free functions.
+        self_mode: RirParamMode,
     },
 
     /// Constant declaration
@@ -1830,12 +1836,21 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     return_type,
                     body,
                     has_self,
+                    self_mode,
                 } => {
                     let pub_str = if *is_pub { "pub " } else { "" };
                     let unchecked_str = if *is_unchecked { "unchecked " } else { "" };
                     let name_str = self.interner.resolve(&*name);
                     let ret_str = self.interner.resolve(&*return_type);
-                    let self_str = if *has_self { "self, " } else { "" };
+                    let self_str = if *has_self {
+                        match self_mode {
+                            RirParamMode::Inout => "inout self, ",
+                            RirParamMode::Borrow => "borrow self, ",
+                            _ => "self, ",
+                        }
+                    } else {
+                        ""
+                    };
                     let params = self.rir.get_params(*params_start, *params_len);
                     let params_str: Vec<String> = params
                         .iter()
@@ -2673,6 +2688,7 @@ mod tests {
                 return_type,
                 body,
                 has_self: false,
+                self_mode: RirParamMode::Normal,
             },
             span: Span::new(0, 30),
         });
@@ -2708,6 +2724,7 @@ mod tests {
                 return_type,
                 body,
                 has_self: true,
+                self_mode: RirParamMode::Normal,
             },
             span: Span::new(0, 30),
         });
@@ -2768,6 +2785,7 @@ mod tests {
                 return_type,
                 body,
                 has_self: false,
+                self_mode: RirParamMode::Normal,
             },
             span: Span::new(0, 50),
         });
@@ -3379,6 +3397,7 @@ mod tests {
                 return_type,
                 body: method_body,
                 has_self: true,
+                self_mode: RirParamMode::Normal,
             },
             span: Span::new(0, 30),
         });

--- a/crates/rue-spec/cases/items/impl-blocks.toml
+++ b/crates/rue-spec/cases/items/impl-blocks.toml
@@ -360,3 +360,200 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Receiver Modes: borrow self / inout self (preview: method_receivers, RUE-15)
+# =============================================================================
+
+[[case]]
+name = "borrow_self_getter_repeatable"
+spec = ["6.4:24", "6.4:25", "6.4:29"]
+preview = "method_receivers"
+description = "borrow self does not consume the receiver; callable repeatedly"
+source = """
+struct Counter {
+    n: i32,
+
+    fn get(borrow self) -> i32 {
+        self.n
+    }
+}
+
+fn main() -> i32 {
+    let c = Counter { n: 21 };
+    c.get() + c.get()
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "inout_self_mutates_in_place"
+spec = ["6.4:24", "6.4:25", "6.4:29"]
+preview = "method_receivers"
+description = "inout self mutates the receiver in place across multiple calls"
+source = """
+struct Counter {
+    n: i32,
+
+    fn bump(inout self) {
+        self.n = self.n + 1;
+    }
+
+    fn get(borrow self) -> i32 {
+        self.n
+    }
+}
+
+fn main() -> i32 {
+    let mut c = Counter { n: 0 };
+    c.bump();
+    c.bump();
+    let a = c.get();
+    c.bump();
+    a * 10 + c.get()
+}
+"""
+exit_code = 23
+
+[[case]]
+name = "inout_self_with_arg_and_field_writes"
+spec = ["6.4:24", "6.4:29"]
+preview = "method_receivers"
+description = "inout self method with an extra parameter writing several fields"
+source = """
+struct Stack {
+    a: i32,
+    b: i32,
+    n: i32,
+
+    fn push(inout self, v: i32) {
+        if self.n == 0 {
+            self.a = v;
+        } else {
+            self.b = v;
+        }
+        self.n = self.n + 1;
+    }
+
+    fn top(borrow self) -> i32 {
+        if self.n == 1 { self.a } else { self.b }
+    }
+}
+
+fn main() -> i32 {
+    let mut s = Stack { a: 0, b: 0, n: 0 };
+    s.push(10);
+    s.push(20);
+    let t = s.top();
+    s.push(30);
+    t + s.n
+}
+"""
+exit_code = 23
+
+[[case]]
+name = "arg_reads_receiver_allowed"
+spec = ["6.4:28"]
+preview = "method_receivers"
+description = "an argument that only reads self is allowed alongside inout self"
+source = """
+struct Stack {
+    a: i32,
+    b: i32,
+    n: i32,
+
+    fn push(inout self, v: i32) {
+        if self.n == 0 { self.a = v; } else { self.b = v; }
+        self.n = self.n + 1;
+    }
+
+    fn count(borrow self) -> i32 { self.n }
+}
+
+fn main() -> i32 {
+    let mut s = Stack { a: 0, b: 0, n: 0 };
+    s.push(s.count());
+    s.push(s.count());
+    s.a + s.b + s.n
+}
+"""
+exit_code = 3
+
+[[case]]
+name = "receiver_mode_requires_preview"
+spec = ["6.4:24"]
+compile_fail = true
+error_contains = "requires preview feature"
+description = "borrow/inout receivers are gated behind --preview method_receivers"
+source = """
+struct P {
+    n: i32,
+    fn get(borrow self) -> i32 { self.n }
+}
+
+fn main() -> i32 {
+    let p = P { n: 0 };
+    p.get()
+}
+"""
+
+[[case]]
+name = "inout_self_requires_mut_receiver"
+spec = ["6.4:26"]
+preview = "method_receivers"
+compile_fail = true
+error_contains = "immutable"
+description = "inout self needs a mutable receiver binding"
+source = """
+struct P {
+    n: i32,
+    fn set(inout self, v: i32) { self.n = v; }
+}
+
+fn main() -> i32 {
+    let p = P { n: 0 };
+    p.set(5);
+    p.n
+}
+"""
+
+[[case]]
+name = "receiver_overlap_rejected"
+spec = ["6.4:28"]
+preview = "method_receivers"
+compile_fail = true
+error_contains = "inout"
+description = "passing the receiver's own place as an inout argument is rejected"
+source = """
+struct P {
+    n: i32,
+    fn absorb(inout self, inout other: P) {
+        self.n = self.n + other.n;
+    }
+}
+
+fn main() -> i32 {
+    let mut s = P { n: 3 };
+    s.absorb(inout s);
+    s.n
+}
+"""
+
+[[case]]
+name = "borrow_self_non_place_receiver_rejected"
+spec = ["6.4:27"]
+preview = "method_receivers"
+compile_fail = true
+error_contains = "borrow argument must be"
+description = "a borrow/inout receiver must be a place, not a temporary"
+source = """
+struct P {
+    n: i32,
+    fn make(v: i32) -> P { P { n: v } }
+    fn get(borrow self) -> i32 { self.n }
+}
+
+fn main() -> i32 {
+    P::make(5).get()
+}
+"""

--- a/docs/spec/src/06-items/04-impl-blocks.md
+++ b/docs/spec/src/06-items/04-impl-blocks.md
@@ -18,7 +18,8 @@ field_list = field_def { "," field_def } [ "," ] ;
 method_list = method_def { method_def } ;
 method_def = [ directives ] "fn" IDENT "(" [ method_params ] ")" [ "->" type ] block ;
 method_params = method_param { "," method_param } [ "," ] ;
-method_param = "self" | ( IDENT ":" type ) ;
+method_param = receiver | ( [ "inout" | "borrow" ] IDENT ":" type ) ;
+receiver = [ "inout" | "borrow" ] "self" ;
 ```
 
 ## Method Definition
@@ -209,3 +210,80 @@ Calling an associated function with method call syntax (receiver.function()) is 
 {{ rule(id="6.4:23", cat="legality-rule") }}
 
 Calling a method with associated function syntax (Type::method()) is a compile-time error.
+
+## Receiver Modes
+
+> Note: `borrow self` and `inout self` receivers are a preview feature
+> (`--preview method_receivers`, ADR-0037 / RUE-15). Bare `self` (by-value) is
+> stable.
+
+{{ rule(id="6.4:24", cat="normative") }}
+
+A receiver **MAY** be declared `borrow self` or `inout self`, mirroring the
+`borrow`/`inout` parameter modes. A bare `self` receiver is passed by value
+(copied if the struct is `Copy`, otherwise moved). A `borrow self` receiver
+grants read-only access to the receiver without taking ownership. An `inout
+self` receiver grants exclusive mutable access without taking ownership, and
+mutations to `self` are observed by the caller after the call returns.
+
+{{ rule(id="6.4:25", cat="normative") }}
+
+The receiver mode is a property of the method signature; it is **NOT** written
+at the call site. A call `receiver.method(args)` accesses the receiver in the
+method's declared mode automatically (autoref): by value for `self`, by
+immutable reference for `borrow self`, and by exclusive mutable reference for
+`inout self`.
+
+{{ rule(id="6.4:26", cat="legality-rule") }}
+
+Calling an `inout self` method requires the receiver to be a mutable place
+(for example a `let mut` binding, or a field or element reachable from one). A
+call whose receiver is not mutable is a compile-time error.
+
+{{ rule(id="6.4:27", cat="legality-rule") }}
+
+A `borrow self` or `inout self` method call whose receiver is not a place (for
+example the result of a function or method call) is a compile-time error: the
+receiver has no caller-visible storage to reference.
+
+{{ rule(id="6.4:28", cat="legality-rule") }}
+
+The law of exclusivity extends to receivers: the access implied by a `borrow
+self` or `inout self` receiver participates in exclusivity checking together
+with the call's `borrow`/`inout` arguments. Passing the receiver's own place
+as an `inout` (or conflicting `borrow`) argument to the same call is a
+compile-time error. An argument that only reads the receiver (for example
+`v.push(v.len())`) is permitted, because its read completes before the
+receiver access begins.
+
+{{ rule(id="6.4:29", cat="dynamic-semantics") }}
+
+A `borrow self` or `inout self` method call does not consume the receiver: the
+receiver remains usable after the call. In particular, a `borrow self` getter
+**MAY** be called repeatedly, and an `inout self` mutator mutates the receiver
+in place rather than requiring the caller to rebuild it.
+
+{{ rule(id="6.4:30", cat="example") }}
+
+```rue
+struct Counter {
+    n: i32,
+
+    fn get(borrow self) -> i32 {
+        self.n
+    }
+
+    fn bump(inout self) {
+        self.n = self.n + 1;
+    }
+}
+
+fn main() -> i32 {
+    let mut c = Counter { n: 0 };
+    c.bump();
+    c.bump();
+    let a = c.get();   // borrow does not consume `c`
+    c.bump();
+    a + c.get()        // 2 + 3 = 5
+}
+```


### PR DESCRIPTION
"The single highest-leverage ergonomics fix in the language." Methods can now take `fn f(borrow self)` / `fn f(inout self)` receivers, not just by-value `self` — so getters no longer consume the object and mutation happens in place. Gated behind `--preview method_receivers` (ADR-0037).

- **Implicit autoref** call sites: `s.top()` / `s.push(v)`, no `(inout s).push(v)`.
- Bare `self` stays by-value; `inout self` requires a `mut` receiver (E0203); `borrow self` works on any binding.
- **Access-point exclusivity** (ADR-0037): `s.absorb(inout s)` rejected (E0426); `v.push(v.count())` allowed (the arg read completes before the receiver's inout access).
- **by-ref self reuses the existing inout/borrow *parameter* calling convention** (synthetic `self` param carries the mode) — **no new MIR**, both backends work (verified via `--emit asm`).
- Also fixed a real parser gap: `self.field = v` assignment targets were unparseable at base (needed for `inout self`).

Verified by execution: `inout self` mutates in place + `borrow self` getter non-consuming and repeatable (exit 4); no-preview → E1100; non-mut receiver → E0203; self-alias → E0426. Full `./test.sh` green, traceability 100%. 8 spec + 3 CLI cases.

**Unblocks stateful objects for dogfooding (RUE-226).**

Fixes RUE-15

🤖 Generated with [Claude Code](https://claude.com/claude-code)