### PR TITLE
Fix three drop/linear/const soundness bugs (RUE-224, RUE-228, RUE-229)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -2938,6 +2938,34 @@ impl<'a> Sema<'a> {
             // Analyze the value
             let value_result = self.analyze_inst(air, value, ctx)?;
 
+            // The write reinitializes its destination element: the assigned
+            // path is no longer moved, so `arr[0] = arr[0]` un-marks the
+            // move-out the RHS `arr[0]` just recorded and leaves the element
+            // usable again (spec 3.8:55). This mirrors `analyze_field_set_impl`,
+            // which reinitializes an assigned field path. Only a direct,
+            // constant-index element of a root array is reinitialized: that is
+            // exactly the shape `record_element_move_out` tracks per element
+            // (`projections == [Index]` with a known index), so a nested or
+            // dynamic index — which was never recorded as a per-element move —
+            // is conservatively left alone (RUE-228).
+            if let [
+                ProjectionInfo {
+                    const_index: Some(k),
+                    ..
+                },
+            ] = trace.projections.as_slice()
+            {
+                if *k >= 0 {
+                    let elem_path = vec![index_path_segment(self.interner, *k as u64)];
+                    if let Some(state) = ctx.moved_vars.get_mut(&trace.root_var) {
+                        state.mark_path_reinitialized(&elem_path);
+                        if state.is_empty() {
+                            ctx.moved_vars.remove(&trace.root_var);
+                        }
+                    }
+                }
+            }
+
             // Emit PlaceWrite instruction
             let place_ref = Self::build_place_ref(air, &trace);
             let air_ref = air.add_inst(AirInst {
@@ -5070,7 +5098,33 @@ impl<'a> Sema<'a> {
             }),
         };
 
-        Ok(AnalysisResult::new(store_ref, Type::UNIT))
+        // A bare `Store`/`ParamStore` produces no CFG value, so returning it as
+        // the expression's value leaves an argument position with no operand —
+        // `lower_value` returns `None`, the CFG block ends unterminated, and
+        // codegen aborts ("block has no terminator", RUE-224). Wrap the store as
+        // a side-effect statement inside a Block whose value is a genuine
+        // `UnitConst`. In statement position (`s.clear();`) the block runs the
+        // store and discards the unit; in value position (`take(s.clear())`) the
+        // expression is now a real Unit value, so the argument type check rejects
+        // it with a clean E0206 (Unit vs the expected argument type) instead of
+        // ICEing.
+        let unit_ref = air.add_inst(AirInst {
+            data: AirInstData::UnitConst,
+            ty: Type::UNIT,
+            span,
+        });
+        let stmts_start = air.add_extra(&[store_ref.as_u32()]);
+        let block_ref = air.add_inst(AirInst {
+            data: AirInstData::Block {
+                stmts_start,
+                stmts_len: 1,
+                value: unit_ref,
+            },
+            ty: Type::UNIT,
+            span,
+        });
+
+        Ok(AnalysisResult::new(block_ref, Type::UNIT))
     }
 
     /// Check if directives contain @allow for a specific warning name.

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1805,8 +1805,16 @@ impl<'a> Sema<'a> {
         let init_result = self.analyze_inst(air, init, ctx)?;
         let var_type = init_result.ty;
 
-        // If name is None, this is a wildcard pattern `_` that discards the value
+        // If name is None, this is a wildcard pattern `_` that discards the value.
+        // `let _ = <expr>;` (and `let _: T = <expr>;`) is a discard site (spec
+        // 3.9:18): discarding a value that carries a linear value would
+        // implicitly drop it, which linearity forbids (spec 3.8:64). Reject it
+        // with the same E0478 as a bare statement-expression discard (`make();`)
+        // — without this, `let _` was a soundness hole that silently dropped
+        // linear values (RUE-229). Once `@drop(x)` lands (RUE-187) that is the
+        // sanctioned way to discard a linear value; `let _` stays an error.
         let Some(name) = name else {
+            self.reject_discarded_linear_value(var_type, init)?;
             return Ok(AnalysisResult::new(init_result.air_ref, Type::UNIT));
         };
 

--- a/crates/rue-air/src/sema/sema_ctx_builder.rs
+++ b/crates/rue-air/src/sema/sema_ctx_builder.rs
@@ -24,7 +24,7 @@ impl<'a> Sema<'a> {
         &self,
         method_sigs: &mut HashMap<(StructId, Spur), MethodSig>,
     ) {
-        use rue_builtins::{BUILTIN_TYPES, BuiltinParamType, BuiltinReturnType};
+        use rue_builtins::{BUILTIN_TYPES, BuiltinParamType, BuiltinReturnType, ReceiverMode};
 
         for builtin in BUILTIN_TYPES {
             let Some(name_spur) = self.interner.get(builtin.name) else {
@@ -52,12 +52,24 @@ impl<'a> Sema<'a> {
                         self.type_to_infer_type(ty)
                     })
                     .collect();
-                let return_ty = match method.return_ty {
-                    BuiltinReturnType::Unit => Type::UNIT,
-                    BuiltinReturnType::U64 => Type::U64,
-                    BuiltinReturnType::U8 => Type::U8,
-                    BuiltinReturnType::Bool => Type::BOOL,
-                    BuiltinReturnType::SelfType => struct_type,
+                // A `ByMutRef` mutation method (`push_str`, `clear`, ...) returns
+                // `SelfType` at the *runtime* ABI level so sema can store the
+                // updated value back into the receiver (see `store_string_result`
+                // in analysis.rs), but the *user-visible expression* is Unit — the
+                // result cannot be used as a value. Register the inference-visible
+                // return type as Unit so inference and sema agree; this is what
+                // turns `take(s.clear())` into a clean E0206 (Unit vs the expected
+                // argument type) instead of an ICE (RUE-224).
+                let return_ty = if method.receiver_mode == ReceiverMode::ByMutRef {
+                    Type::UNIT
+                } else {
+                    match method.return_ty {
+                        BuiltinReturnType::Unit => Type::UNIT,
+                        BuiltinReturnType::U64 => Type::U64,
+                        BuiltinReturnType::U8 => Type::U8,
+                        BuiltinReturnType::Bool => Type::BOOL,
+                        BuiltinReturnType::SelfType => struct_type,
+                    }
                 };
                 method_sigs.insert(
                     (struct_id, method_spur),

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -2094,17 +2094,31 @@ impl<'a> CfgBuilder<'a> {
                 if air_place.projections_len == 0 {
                     self.emit_overwrite_drop(base_key, val_ty, span);
                 } else {
-                    // A single top-level field write: skip the old-value
-                    // drop when the field was definitely moved out, and guard
-                    // it with the field's runtime drop flag when the move was
-                    // path-dependent (RUE-156 x RUE-64 interaction).
+                    // A single top-level field OR constant-index element write:
+                    // skip the old-value drop when that path was definitely
+                    // moved out, and guard it with the path's runtime drop flag
+                    // when the move was path-dependent (RUE-156 x RUE-64
+                    // interaction). Constant array elements share the field-path
+                    // representation (index K -> segment K, RUE-186), so
+                    // `arr[0] = arr[0]` must not drop element 0 mid-write after
+                    // the RHS moved it out (RUE-228).
                     let mut field_flag: Option<u32> = None;
-                    let field_moved = match self
+                    let single_path: Option<FieldPath> = match self
                         .air
                         .get_projections(air_place.projections_start, air_place.projections_len)
                     {
-                        [AirProjection::Field { field_index, .. }] => {
-                            let path = vec![*field_index];
+                        [AirProjection::Field { field_index, .. }] => Some(vec![*field_index]),
+                        [AirProjection::Index { index, .. }] => match self.air.get(*index).data {
+                            AirInstData::Const(k) => Some(vec![k as u32]),
+                            // A dynamic index can't identify a single element,
+                            // so there is no per-element move to skip: drop the
+                            // old value as usual.
+                            _ => None,
+                        },
+                        _ => None,
+                    };
+                    let field_moved = match single_path {
+                        Some(path) => {
                             if self.moved.moved_paths_of(base_key).contains(&path) {
                                 true
                             } else {
@@ -2115,7 +2129,7 @@ impl<'a> CfgBuilder<'a> {
                                 false
                             }
                         }
-                        _ => false,
+                        None => false,
                     };
                     self.emit_projected_overwrite_drop(
                         base_key,
@@ -2147,15 +2161,28 @@ impl<'a> CfgBuilder<'a> {
                     self.moved.clear_slot(MovedSlot::Param(slot));
                     self.update_drop_flag(MovedSlot::Param(slot), true, span);
                 } else if air_place.projections_len == 1 {
-                    if let [AirProjection::Field { field_index, .. }] = self
+                    match self
                         .air
                         .get_projections(air_place.projections_start, air_place.projections_len)
                     {
-                        self.moved.clear_field(base_key, *field_index);
-                        // The field is re-initialized: re-arm its runtime
-                        // drop flag so scope-exit (and later overwrite)
-                        // drops fire again (RUE-156).
-                        self.update_field_drop_flag(base_key, &[*field_index], true, span);
+                        [AirProjection::Field { field_index, .. }] => {
+                            self.moved.clear_field(base_key, *field_index);
+                            // The field is re-initialized: re-arm its runtime
+                            // drop flag so scope-exit (and later overwrite)
+                            // drops fire again (RUE-156).
+                            self.update_field_drop_flag(base_key, &[*field_index], true, span);
+                        }
+                        // A constant-index element write re-initializes that
+                        // element: clear its moved state and re-arm its drop
+                        // flag so it is dropped once at scope exit (RUE-228).
+                        [AirProjection::Index { index, .. }] => {
+                            if let AirInstData::Const(k) = self.air.get(*index).data {
+                                let seg = k as u32;
+                                self.moved.clear_field(base_key, seg);
+                                self.update_field_drop_flag(base_key, &[seg], true, span);
+                            }
+                        }
+                        _ => {}
                     }
                 }
                 ExprResult {

--- a/crates/rue-cli-tests/cases/array_element_self_assign.toml
+++ b/crates/rue-cli-tests/cases/array_element_self_assign.toml
@@ -1,0 +1,76 @@
+# Array-element self-assign `arr[i] = arr[i]` (RUE-228). `analyze_index_set_impl`
+# did not reinitialize the assigned index path the way `analyze_field_set_impl`
+# does, so the write never un-marked the move-out the RHS `arr[0]` recorded.
+# Two facets, one root:
+#
+#   A (reject-valid): `arr[0] = arr[0]; arr[0].v` wrongly errored E0205 even
+#     though spec 3.8:55 says the write reinitializes `arr[0]`.
+#   B (miscompile): with a destructor the element's drop fired mid-statement
+#     (the moved-out slot was still overwrite-dropped) and the element was
+#     never dropped at scope exit.
+#
+# The whole-variable (`a = a`) and whole-array (`arr = arr`) forms were already
+# correct and are kept here as controls.
+
+[section]
+id = "cli.array_element_self_assign"
+name = "Array-element self-assign"
+description = "`arr[i] = arr[i]` reinitializes the element: usable after, dropped only at scope exit (RUE-228)."
+
+[[case]]
+name = "self_assign_element_reinitializes_facet_a"
+description = "RUE-228 facet A: `arr[0] = arr[0]` then reading `arr[0].v` compiles and returns 7 (was wrongly E0205)."
+files = [{ path = "main.rue", source = """
+struct Data { v: i32 }
+fn main() -> i32 {
+    let mut arr = [Data { v: 7 }, Data { v: 2 }];
+    arr[0] = arr[0];
+    arr[0].v
+}
+""" }]
+exit_code = 7
+
+[[case]]
+name = "self_assign_element_drops_only_at_scope_exit_facet_b"
+description = "RUE-228 facet B: element destructor fires only at scope exit, not mid-statement. Expect -1 (marker) then 1 and 2 (both elements dropped at scope exit)."
+files = [{ path = "main.rue", source = """
+struct Data { v: i32 }
+drop fn Data(self) { @dbg(self.v); }
+fn main() -> i32 {
+    let mut arr = [Data { v: 1 }, Data { v: 2 }];
+    arr[0] = arr[0];
+    @dbg(-1);
+    0
+}
+""" }]
+stdout = "-1\n1\n2\n"
+
+[[case]]
+name = "whole_value_self_assign_control"
+description = "Control: `a = a` on a whole struct already reinitializes and drops only at scope exit (-1 then 1)."
+files = [{ path = "main.rue", source = """
+struct Data { v: i32 }
+drop fn Data(self) { @dbg(self.v); }
+fn main() -> i32 {
+    let mut a = Data { v: 1 };
+    a = a;
+    @dbg(-1);
+    0
+}
+""" }]
+stdout = "-1\n1\n"
+
+[[case]]
+name = "element_overwrite_still_drops_old_value"
+description = "Control: overwriting `arr[0]` with a fresh value (not a self-move) still drops the old element mid-write (1) then the fresh 9 and 2 at scope exit."
+files = [{ path = "main.rue", source = """
+struct Data { v: i32 }
+drop fn Data(self) { @dbg(self.v); }
+fn main() -> i32 {
+    let mut arr = [Data { v: 1 }, Data { v: 2 }];
+    arr[0] = Data { v: 9 };
+    @dbg(-1);
+    0
+}
+""" }]
+stdout = "1\n-1\n9\n2\n"

--- a/crates/rue-cli-tests/cases/let_wildcard_linear_discard.toml
+++ b/crates/rue-cli-tests/cases/let_wildcard_linear_discard.toml
@@ -1,0 +1,66 @@
+# `let _ = <linear>` must reject the discard (RUE-229). Binding a linear-carrying
+# value to the wildcard `_` is a discard site (spec 3.9:18); discarding a linear
+# value would implicitly drop it, which linearity forbids (spec 3.8:64). The
+# wildcard path in `analyze_alloc` skipped the discarded-linear check, so
+# `let _ = make();` silently dropped the value — a soundness hole. It now emits
+# the same E0478 as the bare statement-expression discard (`make();`).
+
+[section]
+id = "cli.let_wildcard_linear_discard"
+name = "let _ linear discard"
+description = "`let _ = <linear>` and `let _: T = <linear>` are rejected with E0478 like a bare discard (RUE-229)."
+
+[[case]]
+name = "let_wildcard_discards_linear_rejected"
+description = "RUE-229 repro: `let _ = make();` on a linear type used to compile and silently drop the value; now E0478."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+fn make() -> L { L { v: 1 } }
+fn main() -> i32 {
+    let _ = make();
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0478", "linear value"]
+
+[[case]]
+name = "let_typed_wildcard_discards_linear_rejected"
+description = "The typed form `let _: L = make();` is the same discard site and is rejected identically."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+fn make() -> L { L { v: 1 } }
+fn main() -> i32 {
+    let _: L = make();
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0478", "linear value"]
+
+[[case]]
+name = "bare_statement_discard_control"
+description = "Control: the bare statement-expression discard `make();` was already rejected with E0478."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+fn make() -> L { L { v: 1 } }
+fn main() -> i32 {
+    make();
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0478"]
+
+[[case]]
+name = "let_wildcard_non_linear_still_compiles"
+description = "Control: discarding a non-linear value with `let _` remains legal and runs."
+files = [{ path = "main.rue", source = """
+struct P { v: i32 }
+fn make() -> P { P { v: 1 } }
+fn main() -> i32 {
+    let _ = make();
+    0
+}
+""" }]
+exit_code = 0

--- a/crates/rue-cli-tests/cases/string_mutation_value_position.toml
+++ b/crates/rue-cli-tests/cases/string_mutation_value_position.toml
@@ -1,0 +1,47 @@
+# String mutation-method result in value position no longer ICEs (RUE-224).
+#
+# A String `ByMutRef` mutator (`push_str`, `clear`, `reserve`, ...) returns
+# `SelfType` at the runtime ABI level so sema can store the updated value back
+# into the receiver, but the user-visible expression is Unit — the result may
+# not be used as a value. Previously sema returned the bare `Store` as the
+# expression's value; a `Store` produces no CFG value, so in an argument
+# position `lower_value` returned `None`, the block ended unterminated, and
+# codegen aborted ("block has no terminator", SIGABRT/134).
+#
+# The fix (rue-air) is twofold: the inference-visible return type of a
+# ByMutRef method is now Unit (so a type mismatch is caught as E0206), and the
+# store is wrapped in a Block whose value is a genuine `UnitConst` (so a
+# genuinely Unit-typed argument position lowers cleanly). Statement-position
+# mutation keeps working and running.
+
+[section]
+id = "cli.string_mutation_value_position"
+name = "String mutation-method result in value position"
+description = "Using a String mutator's result as a value is a clean E0206, not an ICE (RUE-224)."
+
+[[case]]
+name = "mutation_result_as_arg_is_e0206_not_ice"
+description = "RUE-224 repro: `take(s.clear())` used to ICE at cfg_lower ('block has no terminator'); now a clean E0206 (Unit vs String)."
+files = [{ path = "main.rue", source = """
+fn take(s: String) -> i32 { 0 }
+fn main() -> i32 {
+    let mut s = String::new();
+    take(s.clear())
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206"]
+
+[[case]]
+name = "statement_position_mutation_still_runs"
+description = "Statement-position String mutation (`push_str`/`clear`) compiles and runs (control)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut s = String::new();
+    s.push_str("hi");
+    s.clear();
+    s.push_str("done");
+    0
+}
+""" }]
+exit_code = 0


### PR DESCRIPTION
All found by the drops/ownership + aggregate-ABI hunts. Sema (+ one CFG) fixes.

**RUE-224** — a String `ByMutRef` mutator's result used in *value* position (`take(s.clear())`) ICEd codegen ("block has no terminator"; the Unit-typed `Store` produced no CFG value). Fixed in `store_string_result` (wrap the store in a Block yielding a real `UnitConst`) + `register_builtin_method_sigs` (ByMutRef methods type as Unit for inference), so `take(s.clear())` is now a clean **E0206**. Statement-position mutation still runs.

**RUE-228** — `arr[i] = arr[i]` self-assign. Facet A (reject-valid): fixed in `analyze_index_set_impl` (reinitialize the const-index element path like the field arm). Facet B (miscompile — element destructor ran *mid-statement*): required a `rue-cfg/build.rs` fix (PlaceWrite index-write now consults moved state like the field arm). Now facet A returns 7; facet B drops only at scope exit (`-1,1,2`). rue-cfg is arch-independent → both backends.

**RUE-229** — `let _ = <linear expr>` (and `let _: T = …`) silently discarded a linear value, bypassing E0478. Fixed in `analyze_alloc`'s wildcard path. Both `let _` forms now E0478; non-linear still compiles.

Verified by execution. Full `./test.sh` green (100% traceability); 10 new CLI cases.

Fixes RUE-224
Fixes RUE-228
Fixes RUE-229

🤖 Generated with [Claude Code](https://claude.com/claude-code)