### PR TITLE
Const-eval operand-type checking + comptime untaken-branch poison (RUE-230, RUE-231)

### DIFF
--- a/crates/rue-air/src/inference/unify.rs
+++ b/crates/rue-air/src/inference/unify.rs
@@ -312,7 +312,21 @@ impl Unifier {
                     self.int_literal_vars.insert(*other);
                 }
                 InferType::Concrete(t) => {
-                    if !t.is_integer() && !t.is_error() && !t.is_never() {
+                    if t.is_error() {
+                        // Don't let an `<error>` type poison an integer
+                        // literal. This binding arises when a live literal
+                        // branch shares an if/match result variable with an
+                        // erroneous (or comptime-untaken) sibling branch: the
+                        // sibling's `<error>` would otherwise drag the literal
+                        // to `<error>`, producing a bogus "literal out of range
+                        // for '<error>'" (E0800) and swallowing the real error.
+                        // Leave the literal free so it defaults to i32; the
+                        // real error is reported at its own site, and a
+                        // comptime-pruned untaken branch is never analyzed at
+                        // all (RUE-231).
+                        return UnifyResult::Ok;
+                    }
+                    if !t.is_integer() && !t.is_never() {
                         return UnifyResult::IntLiteralNonInteger { found: *t };
                     }
                 }

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -26,9 +26,12 @@
 //! - `~` (BitNot) truncates to the operand width (`~0` as u8 is 255).
 //!
 //! When no resolved types are available (evaluating a comptime function body
-//! before specialization, or a file-level const initializer), arithmetic
-//! falls back to checked `i64` semantics: results outside the `i64` range
-//! make the expression non-evaluable (`Ok(None)`) rather than an error.
+//! before specialization), arithmetic falls back to checked `i64` semantics:
+//! results outside the `i64` range make the expression non-evaluable
+//! (`Ok(None)`) rather than an error. A file-level const initializer supplies
+//! operand types up front (`infer_const_init_types` builds a `resolved_types`
+//! map from the declared const type), so it takes the typed path and gets the
+//! same operand-type overflow checks as a `comptime { }` block (RUE-230).
 //!
 //! # Outcome encoding
 //!
@@ -115,6 +118,24 @@ impl<'a> ComptimeEnv<'a> {
             value_subst: &ctx.comptime_value_vars,
             resolved_types: Some(ctx.resolved_types),
             runtime_locals: Some(&ctx.locals),
+            locals: HashMap::new(),
+        }
+    }
+
+    /// The environment for a file-level const initializer: no comptime
+    /// parameters and no runtime locals, but a `resolved_types` map inferred
+    /// from the declared const type (see `infer_const_init_types`). Threading
+    /// these operand types lets `finish_arith` check arithmetic at the operand
+    /// type — the same operand-type overflow (E1200, including intermediate
+    /// results) the `comptime { }` block path gets from HM inference, instead
+    /// of the raw-`i64` fallback that only range-checked the final value
+    /// against the declared type (RUE-230).
+    pub(crate) fn for_const_init(resolved_types: &'a HashMap<InstRef, Type>) -> Self {
+        Self {
+            type_subst: &EMPTY_TYPE_SUBST,
+            value_subst: &EMPTY_VALUE_SUBST,
+            resolved_types: Some(resolved_types),
+            runtime_locals: None,
             locals: HashMap::new(),
         }
     }

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1016,8 +1016,19 @@ impl<'a> Sema<'a> {
             ));
         }
 
+        // The declared integer type (when the annotation names one) becomes
+        // the type context for arithmetic in the initializer, so intermediate
+        // results are checked at the operand type just like a `comptime { }`
+        // block (RUE-230). A non-integer or unresolvable annotation yields
+        // `None`; the annotation error, if any, resurfaces in
+        // `const_type_for_value` where it did before.
+        let declared_ty = p
+            .ty_sym
+            .and_then(|sym| self.resolve_type(sym, p.span).ok())
+            .filter(Type::is_integer);
+
         st.in_progress.push(key);
-        let outcome = self.eval_const_initializer(p.init, file_id, st);
+        let outcome = self.eval_const_initializer(p.init, file_id, st, declared_ty);
         st.in_progress.pop();
         let outcome = outcome?;
         st.done.insert(key);
@@ -1151,6 +1162,7 @@ impl<'a> Sema<'a> {
         init: InstRef,
         file_id: FileId,
         st: &mut ConstCollector,
+        declared_ty: Option<Type>,
     ) -> CompileResult<ConstInit> {
         let init_inst = self.rir.get(init);
         let span = init_inst.span;
@@ -1236,7 +1248,7 @@ impl<'a> Sema<'a> {
                 }
                 // Not a constant: let the comptime engine decide (it rejects
                 // unknown names and type names as non-evaluable).
-                self.eval_const_value_expr(init, file_id, st, span)
+                self.eval_const_value_expr(init, file_id, st, span, declared_ty)
             }
 
             // Member access: `base.member` where `base` is a module —
@@ -1244,7 +1256,7 @@ impl<'a> Sema<'a> {
             // `const X: i32 = m.ANSWER;` (a member value constant).
             InstData::FieldGet { base, field } => {
                 let (base, field) = (*base, *field);
-                match self.eval_const_initializer(base, file_id, st)? {
+                match self.eval_const_initializer(base, file_id, st, None)? {
                     ConstInit::Module(module_ty) => {
                         let module_id = module_ty
                             .as_module()
@@ -1271,31 +1283,43 @@ impl<'a> Sema<'a> {
 
             // Everything else: literals, arithmetic, comptime blocks, ... —
             // evaluated by the comptime engine.
-            _ => self.eval_const_value_expr(init, file_id, st, span),
+            _ => self.eval_const_value_expr(init, file_id, st, span, declared_ty),
         }
     }
 
     /// Evaluate a (non-module) constant initializer through the comptime
     /// engine (`sema::comptime_eval`).
     ///
-    /// The engine runs without HM type information here (a file-level const
-    /// has no enclosing function), so arithmetic uses the checked-`i64`
-    /// fallback semantics; the result is range-checked against the declared
-    /// type in [`Self::const_type_for_value`] (which also rejects a missing
-    /// annotation, E0475).
+    /// A file-level const has no enclosing function, so there is no HM
+    /// `resolved_types` map. Instead we infer one up front from the declared
+    /// integer type (`infer_const_init_types`) and hand it to the engine, so
+    /// arithmetic is checked at the operand type — matching the `comptime { }`
+    /// block path (operand-type mismatch → E0206, operand/intermediate
+    /// overflow → E1200, RUE-230). The final value is still range-checked
+    /// against the declared type in [`Self::const_type_for_value`] (which also
+    /// rejects a missing annotation, E0475).
     fn eval_const_value_expr(
         &mut self,
         init: InstRef,
         file_id: FileId,
         st: &mut ConstCollector,
         span: Span,
+        declared_ty: Option<Type>,
     ) -> CompileResult<ConstInit> {
         // Pre-collect referenced constants: the engine's file-level-constant
         // lookup only consults the finished `constants` table, so anything
-        // this initializer names must be collected first.
+        // this initializer names must be collected first. (Also required
+        // before type inference so referenced constants' types are known.)
         self.ensure_const_init_deps_collected(init, file_id, st)?;
 
-        let mut env = super::comptime_eval::ComptimeEnv::new();
+        // Infer operand types for the initializer expression so the engine
+        // checks arithmetic at the operand type instead of the raw-i64
+        // fallback (RUE-230). Reports E0206 on a mismatched-operand-type
+        // binary op before evaluation, mirroring the runtime path.
+        let mut resolved_types: HashMap<InstRef, Type> = HashMap::new();
+        self.infer_const_init_types(init, declared_ty, &mut resolved_types)?;
+
+        let mut env = super::comptime_eval::ComptimeEnv::for_const_init(&resolved_types);
         match self.eval_const_expr(init, &mut env)? {
             // Type values (e.g. `const T = i32;`) are not supported as
             // constants: nothing can materialize them at a use site yet.
@@ -1313,6 +1337,173 @@ impl<'a> Sema<'a> {
                 span,
             )),
         }
+    }
+
+    /// Infer integer operand types for a const initializer's expression tree,
+    /// recording each integer-typed node in `map`, so the comptime engine can
+    /// apply the same operand-type checks a `comptime { }` block gets from HM
+    /// inference (RUE-230). Two effects:
+    ///
+    /// - **E1200 (operand/intermediate overflow):** every arithmetic node is
+    ///   typed, so `finish_arith` range-checks each intermediate at the
+    ///   operand type (not just the final value against the declared type).
+    /// - **E0206 (mixed operand types):** a binary op whose operands carry
+    ///   different concrete integer types is rejected here, before evaluation,
+    ///   mirroring the runtime diagnostic (`expected <lhs>, found <rhs>`, span
+    ///   on the rhs operand).
+    ///
+    /// `expected` is the type context flowing down from the declared const
+    /// type: integer literals adopt it, while references to other constants
+    /// carry their own declared type. Returns the node's integer type when
+    /// known (`None` for non-integer or unconstrained nodes).
+    fn infer_const_init_types(
+        &mut self,
+        expr: InstRef,
+        expected: Option<Type>,
+        map: &mut HashMap<InstRef, Type>,
+    ) -> CompileResult<Option<Type>> {
+        let expected = expected.filter(Type::is_integer);
+        let ty = match &self.rir.get(expr).data {
+            // A literal adopts the type context (the declared const type, or a
+            // surrounding operand's type propagated down).
+            InstData::IntConst(_) => expected,
+
+            // A reference to another constant carries that constant's declared
+            // type, regardless of the surrounding context.
+            InstData::VarRef { name } => self
+                .constants
+                .get(name)
+                .map(|info| info.ty)
+                .filter(|t| t.is_integer()),
+
+            // Unary ops preserve the operand's (integer) type. A bare integer
+            // literal operand is left untyped, though: typing `-5` as `u8`
+            // would make the engine reject it as `E0801 cannot negate u8`
+            // before the value/annotation range check runs, whereas a negative
+            // literal const is diagnosed as out-of-range against its declared
+            // type in `const_type_for_value` (spec 6.5:5). Only the facets that
+            // need operand types — binary arithmetic — are threaded here.
+            InstData::Neg { operand } | InstData::BitNot { operand } => {
+                let operand = *operand;
+                if matches!(self.rir.get(operand).data, InstData::IntConst(_)) {
+                    None
+                } else {
+                    self.infer_const_init_types(operand, expected, map)?
+                }
+            }
+
+            // Logical NOT is a bool; still walk the operand for nested checks.
+            InstData::Not { operand } => {
+                let operand = *operand;
+                self.infer_const_init_types(operand, None, map)?;
+                None
+            }
+
+            // Arithmetic/bitwise binary ops: operands must share a type. The
+            // result type is that shared type (so `finish_arith` checks at the
+            // operand width). A mismatch of two known concrete types is E0206.
+            InstData::Add { lhs, rhs }
+            | InstData::Sub { lhs, rhs }
+            | InstData::Mul { lhs, rhs }
+            | InstData::Div { lhs, rhs }
+            | InstData::Mod { lhs, rhs }
+            | InstData::BitAnd { lhs, rhs }
+            | InstData::BitOr { lhs, rhs }
+            | InstData::BitXor { lhs, rhs } => {
+                let (lhs, rhs) = (*lhs, *rhs);
+                let lt = self.infer_const_init_types(lhs, expected, map)?;
+                let rt = self.infer_const_init_types(rhs, expected, map)?;
+                if let (Some(l), Some(r)) = (lt, rt) {
+                    if l != r {
+                        return Err(CompileError::new(
+                            ErrorKind::TypeMismatch {
+                                expected: l.safe_name_with_pool(Some(&self.type_pool)),
+                                found: r.safe_name_with_pool(Some(&self.type_pool)),
+                            },
+                            self.rir.get(rhs).span,
+                        ));
+                    }
+                }
+                lt.or(rt).or(expected)
+            }
+
+            // Shifts: the result follows the lhs; the shift amount is an
+            // independent operand (spec 4.3a:10).
+            InstData::Shl { lhs, rhs } | InstData::Shr { lhs, rhs } => {
+                let (lhs, rhs) = (*lhs, *rhs);
+                let lt = self.infer_const_init_types(lhs, expected, map)?;
+                self.infer_const_init_types(rhs, None, map)?;
+                lt
+            }
+
+            // Comparisons/logical: bool result. Operands anchor each other so
+            // a bare literal compared against a typed const is checked at that
+            // const's type; the node itself is not integer-typed.
+            InstData::Eq { lhs, rhs }
+            | InstData::Ne { lhs, rhs }
+            | InstData::Lt { lhs, rhs }
+            | InstData::Gt { lhs, rhs }
+            | InstData::Le { lhs, rhs }
+            | InstData::Ge { lhs, rhs } => {
+                let (lhs, rhs) = (*lhs, *rhs);
+                let lt = self.infer_const_init_types(lhs, None, map)?;
+                let rt = self.infer_const_init_types(rhs, None, map)?;
+                if lt.is_some() && rt.is_none() {
+                    self.infer_const_init_types(rhs, lt, map)?;
+                } else if rt.is_some() && lt.is_none() {
+                    self.infer_const_init_types(lhs, rt, map)?;
+                }
+                None
+            }
+
+            InstData::And { lhs, rhs } | InstData::Or { lhs, rhs } => {
+                let (lhs, rhs) = (*lhs, *rhs);
+                self.infer_const_init_types(lhs, None, map)?;
+                self.infer_const_init_types(rhs, None, map)?;
+                None
+            }
+
+            // `comptime { expr }` forwards the context to its inner expression.
+            InstData::Comptime { expr: inner } => {
+                let inner = *inner;
+                self.infer_const_init_types(inner, expected, map)?
+            }
+
+            // A block's tail expression carries the context; `let` initializers
+            // are typed by their own value (no annotation context available
+            // here), and non-tail statements carry no expected type.
+            InstData::Block { extra_start, len } => {
+                let stmt_refs: Vec<InstRef> = self
+                    .rir
+                    .get_extra(*extra_start, *len)
+                    .iter()
+                    .map(|&raw| InstRef::from_raw(raw))
+                    .collect();
+                let n = stmt_refs.len();
+                let mut tail_ty = None;
+                for (i, &stmt_ref) in stmt_refs.iter().enumerate() {
+                    let is_tail = i + 1 == n;
+                    let stmt_expected = if is_tail { expected } else { None };
+                    let t = if let InstData::Alloc { init, .. } = &self.rir.get(stmt_ref).data {
+                        let init = *init;
+                        self.infer_const_init_types(init, None, map)?;
+                        None
+                    } else {
+                        self.infer_const_init_types(stmt_ref, stmt_expected, map)?
+                    };
+                    if is_tail {
+                        tail_ty = t;
+                    }
+                }
+                tail_ty
+            }
+
+            _ => None,
+        };
+        if let Some(t) = ty {
+            map.insert(expr, t);
+        }
+        Ok(ty)
     }
 
     /// Walk a constant initializer expression and collect (on demand) every

--- a/crates/rue-cli-tests/cases/const_comptime_operand_types.toml
+++ b/crates/rue-cli-tests/cases/const_comptime_operand_types.toml
@@ -1,0 +1,154 @@
+# Const-initializer arithmetic must be checked at the *operand* type, the same
+# as a `comptime { }` block, not just range-checked against the declared type
+# (RUE-230). And a comptime-pruned untaken if/match branch must not poison the
+# taken branch through type inference (RUE-231).
+#
+# Before RUE-230 the const-initializer path evaluated arithmetic as raw i128
+# with `resolved_types: None`, so it never learned operand types: it skipped the
+# operand-type match (E0206) and operand/intermediate overflow (E1200) checks
+# that the comptime-block engine performs. Facets A/B/C below pin the fixed
+# behavior; the valid-const and comptime-block controls guard against
+# over-rejection / regressing the already-correct path.
+
+[section]
+id = "cli.const_comptime_operand_types"
+name = "Const-initializer operand-type checks and comptime branch pruning"
+description = "Const-initializer arithmetic is checked at the operand type (E0206 mixed types, E1200 operand/intermediate overflow) like a comptime block, and comptime-pruned untaken branches don't poison the taken branch (RUE-230, RUE-231)."
+
+# --- RUE-230 facet A: mixed incompatible integer operands → E0206 ------------
+# `X - Y` mixes u32 and i32; even though the result fits the declared i32, the
+# operands' types don't match — the same E0206 the runtime `x - y` reports.
+[[case]]
+name = "mixed_operand_types_rejected_e0206"
+files = [{ path = "main.rue", source = """
+const X: u32 = 10;
+const Y: i32 = 3;
+const Z: i32 = X - Y;
+
+fn main() -> i32 { Z }
+""" }]
+compile_fail = true
+error_contains = ["E0206", "expected u32", "found i32"]
+
+# --- RUE-230 facet B: operand-type underflow → E1200 -------------------------
+# `3 - 10` underflows at u32 (would panic at runtime), so it is a comptime
+# error even though the signed result -7 fits the declared i32.
+[[case]]
+name = "operand_underflow_rejected_e1200"
+files = [{ path = "main.rue", source = """
+const X: u32 = 3;
+const Y: u32 = 10;
+const Z: i32 = X - Y;
+
+fn main() -> i32 { Z }
+""" }]
+compile_fail = true
+error_contains = ["E1200", "at type u32", "-7 does not fit in u32"]
+
+# --- RUE-230 facet C: intermediate overflow → E1200 --------------------------
+# The intermediate 4e9 overflows i32 even though the final result fits; the
+# byte-identical `comptime { ... }` block is rejected the same way (control
+# below), so the two paths must agree.
+[[case]]
+name = "intermediate_overflow_rejected_e1200"
+files = [{ path = "main.rue", source = """
+const A: i32 = 2000000000 + 2000000000 - 3000000000;
+
+fn main() -> i32 { A }
+""" }]
+compile_fail = true
+error_contains = ["E1200", "at type i32", "4000000000 does not fit in i32"]
+
+# --- RUE-230 control: valid const arithmetic still compiles and evaluates -----
+[[case]]
+name = "valid_const_arithmetic_still_evaluates"
+files = [{ path = "main.rue", source = """
+const N: i32 = 2 + 3;
+const M: i32 = N * 4;
+
+fn main() -> i32 { M }
+""" }]
+exit_code = 20
+
+# --- RUE-230 control: comptime-block path is unchanged ------------------------
+# The same intermediate overflow inside an explicit comptime block was already
+# rejected E1200; it must stay rejected (no behavior change).
+[[case]]
+name = "comptime_block_intermediate_overflow_unchanged"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    comptime { 2000000000 + 2000000000 - 3000000000 }
+}
+""" }]
+compile_fail = true
+error_contains = ["E1200", "at type i32", "4000000000 does not fit in i32"]
+
+# --- RUE-230 control: mixed operands are fine when both fit the shared type ---
+# u8 + u8 = 255 fits u8; the const evaluates and is @intCast for the exit code.
+[[case]]
+name = "same_type_operands_evaluate"
+files = [{ path = "main.rue", source = """
+const A: u8 = 200;
+const B: u8 = 55;
+const SUM: u8 = A + B;
+
+fn main() -> i32 {
+    let s: u8 = SUM;
+    let r: i32 = @intCast(s);
+    r
+}
+""" }]
+exit_code = 255
+
+# --- RUE-231: comptime-pruned untaken branch must not poison the taken one ----
+# `n == 0` selects the then-branch; the else-branch's undefined name must not be
+# analyzed (spec 4.14:19), and its `<error>` type must not leak into the taken
+# literal `1` (which previously failed E0800 "out of range for '<error>'").
+[[case]]
+name = "comptime_if_untaken_branch_error_ignored"
+files = [{ path = "main.rue", source = """
+fn pick(comptime n: i32) -> i32 {
+    if n == 0 {
+        1
+    } else {
+        undefined_name
+    }
+}
+
+fn main() -> i32 { pick(0) }
+""" }]
+exit_code = 1
+
+# --- RUE-231: same, via `match` ----------------------------------------------
+[[case]]
+name = "comptime_match_untaken_arm_error_ignored"
+files = [{ path = "main.rue", source = """
+fn pick(comptime n: i32) -> i32 {
+    match n {
+        0 => 1,
+        _ => undefined_name,
+    }
+}
+
+fn main() -> i32 { pick(0) }
+""" }]
+exit_code = 1
+
+# --- RUE-231: the SELECTED branch's own error is still reported ---------------
+# Here the taken then-branch itself references an undefined name; pruning the
+# untaken branch must not silence the selected branch's real error.
+[[case]]
+name = "comptime_selected_branch_error_still_caught"
+files = [{ path = "main.rue", source = """
+fn pick(comptime n: i32) -> i32 {
+    if n == 0 {
+        undefined_in_taken
+    } else {
+        2
+    }
+}
+
+fn main() -> i32 { pick(0) }
+""" }]
+compile_fail = true
+error_contains = ["E0201", "undefined_in_taken"]


### PR DESCRIPTION
Both found by the comptime/const-eval hunt. Sema + inference only (no codegen).

**RUE-230** — const initializers evaluated arithmetic as raw i128 and only range-checked the *final* result against the declared type, skipping the operand-type checks the `comptime { }` block engine does. Added `ComptimeEnv::for_const_init` + an `infer_const_init_types` walk that types nodes from the declared integer type and threads them into `finish_arith`. Now mismatched operands → **E0206**; operand-type over/underflow *including intermediate results* → **E1200** (matching the comptime block). Verified: u32−i32 mix → E0206; u32 underflow → E1200; intermediate i32 overflow → E1200; valid const arithmetic still evaluates.

**RUE-231** — an untaken comptime branch's `<error>` type poisoned the taken branch. The root wasn't branch analysis (which prunes correctly) but HM constraint generation: `unify.rs::bind` let an `<error>` type bind an integer-literal var. Now `<error>` no longer binds an int-literal var (stays free, defaults i32). Bonus: the plain non-comptime `if/else`-with-error case now reports a real **E0201** instead of a bogus E0800.

Full `./test.sh` green (100% traceability); 9 new CLI cases.

Fixes RUE-230
Fixes RUE-231

🤖 Generated with [Claude Code](https://claude.com/claude-code)