### PR TITLE
Enum payloads (sum types) — core: tuple variants + match bindings (RUE-221 phase 1, preview enum_payloads)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1199,8 +1199,51 @@ impl<'a> ConstraintGenerator<'a> {
                         pattern.span(),
                     ));
 
+                    // Register any tuple-variant payload bindings as locals
+                    // scoped to the arm body, with their declared payload
+                    // types, so the body's references resolve during inference
+                    // (RUE-221). Without this, `Circle(r) => r` leaves `r`
+                    // unbound and its type poisons the match result.
+                    use crate::scope::ScopedContext;
+                    ctx.push_scope();
+                    if let rue_rir::RirPattern::Path {
+                        type_name,
+                        variant,
+                        bindings,
+                        span: pat_span,
+                        ..
+                    } = pattern
+                    {
+                        if !bindings.is_empty() {
+                            if let Some(payload) = self
+                                .enums
+                                .get(type_name)
+                                .and_then(|ty| ty.as_enum())
+                                .map(|id| self.type_pool.enum_def(id))
+                                .and_then(|def| {
+                                    def.find_variant(self.interner.resolve(variant))
+                                        .map(|v| def.variant_payload(v).to_vec())
+                                })
+                            {
+                                for (i, bname) in bindings.iter().enumerate() {
+                                    if let Some(&pty) = payload.get(i) {
+                                        ctx.insert_local(
+                                            *bname,
+                                            LocalVarInfo {
+                                                ty: InferType::Concrete(pty),
+                                                is_mut: false,
+                                                span: *pat_span,
+                                            },
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     // Generate body and collect its type
                     let body_info = self.generate(*body, ctx);
+                    ctx.pop_scope();
                     arm_types.push(body_info);
                 }
 
@@ -1555,6 +1598,38 @@ impl<'a> ConstraintGenerator<'a> {
                 args_len,
             } => {
                 let args = self.rir.get_call_args(*args_start, *args_len);
+
+                // Enum tuple-variant construction: `Shape::Circle(5)` parses as
+                // an associated-function call. If `type_name` is an enum and
+                // `function` names one of its variants, constrain each payload
+                // argument to the declared payload type and yield the enum type
+                // (RUE-221). Checked here first so it takes precedence over the
+                // struct-method path below.
+                let enum_variant = self
+                    .enums
+                    .get(type_name)
+                    .and_then(|ty| ty.as_enum().map(|id| (*ty, id)))
+                    .and_then(|(ty, id)| {
+                        let def = self.type_pool.enum_def(id);
+                        def.find_variant(self.interner.resolve(function))
+                            .map(|vidx| (ty, def.variant_payload(vidx).to_vec()))
+                    });
+                if let Some((enum_ty, payload)) = enum_variant {
+                    for (i, arg) in args.iter().enumerate() {
+                        let arg_info = self.generate(arg.value, ctx);
+                        if let Some(&pty) = payload.get(i) {
+                            self.add_constraint(Constraint::equal(
+                                arg_info.ty,
+                                InferType::Concrete(pty),
+                                arg_info.span,
+                            ));
+                        }
+                    }
+                    let ty = InferType::Concrete(enum_ty);
+                    self.record_type(inst_ref, ty.clone());
+                    return ExprInfo::new(ty, span);
+                }
+
                 // Get struct ID from type name for method lookup
                 let struct_id = self.structs.get(type_name).and_then(|ty| ty.as_struct());
                 let result_type = if let Some(struct_id) = struct_id {

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -1004,6 +1004,28 @@ pub enum AirInstData {
         enum_id: crate::types::EnumId,
         /// The variant index (0-based)
         variant_index: u32,
+        /// Start index into the extra array for payload operand `AirRef`s, in
+        /// payload declaration order (RUE-221). Zero-length for a
+        /// discriminant-only variant.
+        payload_start: u32,
+        /// Number of payload operands.
+        payload_len: u32,
+    },
+
+    /// Read payload field `field_index` of a tuple variant from an enum value
+    /// (RUE-221). Materialized when lowering a match arm whose pattern binds
+    /// the payload (`Circle(r)`); the discriminant is assumed to match the
+    /// variant (the enclosing `match` dispatched on it). The result type is
+    /// the payload field's type.
+    EnumPayloadGet {
+        /// The enum value being read.
+        base: AirRef,
+        /// The enum type ID.
+        enum_id: crate::types::EnumId,
+        /// The variant whose payload layout applies.
+        variant_index: u32,
+        /// The payload field index (0-based).
+        field_index: u32,
     },
 
     // Type conversion operations
@@ -1369,8 +1391,36 @@ impl fmt::Display for Air {
                 AirInstData::EnumVariant {
                     enum_id,
                     variant_index,
+                    payload_start,
+                    payload_len,
                 } => {
-                    writeln!(f, "enum_variant #{}::{}", enum_id.0, variant_index)?;
+                    if *payload_len == 0 {
+                        writeln!(f, "enum_variant #{}::{}", enum_id.0, variant_index)?;
+                    } else {
+                        let payload: Vec<String> = self
+                            .get_air_refs(*payload_start, *payload_len)
+                            .map(|r| r.to_string())
+                            .collect();
+                        writeln!(
+                            f,
+                            "enum_variant #{}::{}({})",
+                            enum_id.0,
+                            variant_index,
+                            payload.join(", ")
+                        )?;
+                    }
+                }
+                AirInstData::EnumPayloadGet {
+                    base,
+                    enum_id,
+                    variant_index,
+                    field_index,
+                } => {
+                    writeln!(
+                        f,
+                        "enum_payload_get {} #{}::{}.{}",
+                        base, enum_id.0, variant_index, field_index
+                    )?;
                 }
                 AirInstData::IntCast { value, from_ty } => {
                     writeln!(f, "intcast {} from {}", value, from_ty.name())?;

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -1216,6 +1216,7 @@ mod tests {
         let def = EnumDef {
             name: "Color".to_string(),
             variants: vec!["Red".to_string(), "Green".to_string(), "Blue".to_string()],
+            variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
         };
@@ -1292,6 +1293,7 @@ mod tests {
         let def = EnumDef {
             name: "Status".to_string(),
             variants: vec!["Active".to_string(), "Inactive".to_string()],
+            variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
         };
@@ -1375,6 +1377,7 @@ mod tests {
         let enum_def = EnumDef {
             name: "Color".to_string(),
             variants: vec!["Red".to_string()],
+            variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
         };
@@ -1447,6 +1450,7 @@ mod tests {
         let def = EnumDef {
             name: "Status".to_string(),
             variants: vec!["A".to_string(), "B".to_string()],
+            variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
         };
@@ -1538,6 +1542,7 @@ mod tests {
             EnumDef {
                 name: "E1".to_string(),
                 variants: vec![],
+                variant_payloads: Vec::new(),
                 is_pub: false,
                 file_id: rue_span::FileId::DEFAULT,
             },

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -6518,6 +6518,8 @@ impl<'a> Sema<'a> {
             data: AirInstData::EnumVariant {
                 enum_id: arch_enum_id,
                 variant_index,
+                payload_start: 0,
+                payload_len: 0,
             },
             ty: result_type,
             span,
@@ -6563,6 +6565,8 @@ impl<'a> Sema<'a> {
             data: AirInstData::EnumVariant {
                 enum_id: os_enum_id,
                 variant_index,
+                payload_start: 0,
+                payload_len: 0,
             },
             ty: result_type,
             span,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use lasso::Spur;
 use rue_error::{
     CompileError, CompileResult, CompileWarning, ErrorKind, MissingFieldsError, OptionExt,
-    WarningKind,
+    PreviewFeature, WarningKind,
 };
 use rue_rir::{InstData, InstRef, RirArgMode, RirParamMode, RirPattern};
 
@@ -1445,6 +1445,13 @@ impl<'a> Sema<'a> {
             ctx.moved_vars = moves_before_arms.clone();
             ctx.push_scope();
 
+            // Materialize tuple-variant payload bindings (RUE-221) into fresh
+            // locals before the body, so the body's references resolve to them.
+            // The enclosing match dispatched on the discriminant, so in this
+            // arm the payload is read (move mode) via `EnumPayloadGet`.
+            let binding_stmts =
+                self.materialize_match_bindings(air, pattern, scrutinee_result.air_ref, ctx)?;
+
             // Analyze arm body
             let body_result = self.analyze_inst(air, *body, ctx)?;
             let body_type = body_result.ty;
@@ -1527,7 +1534,24 @@ impl<'a> Sema<'a> {
                 }
             };
 
-            air_arms.push((air_pattern, body_result.air_ref));
+            // If the pattern bound payload data, wrap the body so the binding
+            // Alloc statements run before it (RUE-221).
+            let arm_body_ref = if binding_stmts.is_empty() {
+                body_result.air_ref
+            } else {
+                let stmts_start = air.add_extra(&binding_stmts);
+                air.add_inst(AirInst {
+                    data: AirInstData::Block {
+                        stmts_start,
+                        stmts_len: binding_stmts.len() as u32,
+                        value: body_result.air_ref,
+                    },
+                    ty: body_type,
+                    span: pattern_span,
+                })
+            };
+
+            air_arms.push((air_pattern, arm_body_ref));
         }
 
         // Join the arms' move states (union of non-diverging arms;
@@ -1588,6 +1612,124 @@ impl<'a> Sema<'a> {
             span,
         });
         Ok(AnalysisResult::new(air_ref, final_type))
+    }
+
+    /// Materialize the payload bindings of a tuple-variant match pattern
+    /// (`Circle(r)`) into fresh locals in the current (arm) scope, returning
+    /// the AIR statement refs (StorageLive + Alloc per binding) that must run
+    /// before the arm body (RUE-221, ADR-0038).
+    ///
+    /// Returns an empty vector for patterns without payload bindings. Assumes
+    /// the pattern has already been validated against the scrutinee type by
+    /// the caller (`analyze_match`); re-resolves the enum for convenience.
+    fn materialize_match_bindings(
+        &mut self,
+        air: &mut Air,
+        pattern: &RirPattern,
+        scrutinee_ref: AirRef,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<Vec<u32>> {
+        let RirPattern::Path {
+            module,
+            type_name,
+            variant,
+            bindings,
+            span,
+        } = pattern
+        else {
+            return Ok(Vec::new());
+        };
+        if bindings.is_empty() {
+            return Ok(Vec::new());
+        }
+        let pattern_span = *span;
+
+        // Binding payload data requires the preview feature.
+        self.require_preview(
+            PreviewFeature::EnumPayloads,
+            "enum payload bindings in a match pattern",
+            pattern_span,
+        )?;
+
+        let enum_id = if let Some(module_ref) = module {
+            self.resolve_enum_through_module(*module_ref, *type_name, pattern_span)?
+        } else {
+            *self.enums.get(type_name).ok_or_compile_error(
+                ErrorKind::UnknownEnumType(self.interner.resolve(&*type_name).to_string()),
+                pattern_span,
+            )?
+        };
+        let def = self.type_pool.enum_def(enum_id);
+        let variant_name = self.interner.resolve(&*variant).to_string();
+        let variant_index = def.find_variant(&variant_name).ok_or_compile_error(
+            ErrorKind::UnknownVariant {
+                enum_name: def.name.clone(),
+                variant_name: variant_name.clone(),
+            },
+            pattern_span,
+        )? as u32;
+        let payload = def.variant_payload(variant_index as usize).to_vec();
+
+        // The number of bindings must equal the variant's payload arity.
+        if bindings.len() != payload.len() {
+            return Err(CompileError::new(
+                ErrorKind::WrongArgumentCount {
+                    expected: payload.len(),
+                    found: bindings.len(),
+                },
+                pattern_span,
+            ));
+        }
+
+        let mut stmts: Vec<u32> = Vec::with_capacity(bindings.len() * 2);
+        for (i, binding_name) in bindings.iter().enumerate() {
+            let field_ty = payload[i];
+
+            // Read the payload field out of the scrutinee.
+            let get_ref = air.add_inst(AirInst {
+                data: AirInstData::EnumPayloadGet {
+                    base: scrutinee_ref,
+                    enum_id,
+                    variant_index,
+                    field_index: i as u32,
+                },
+                ty: field_ty,
+                span: pattern_span,
+            });
+
+            // Allocate a local slot and register the binding.
+            let slot = ctx.next_slot;
+            let num_slots = self.abi_slot_count(field_ty);
+            ctx.next_slot += num_slots;
+            ctx.insert_local(
+                *binding_name,
+                LocalVar {
+                    slot,
+                    ty: field_ty,
+                    is_mut: false,
+                    span: pattern_span,
+                    allow_unused: false,
+                },
+            );
+
+            let storage_live = air.add_inst(AirInst {
+                data: AirInstData::StorageLive { slot },
+                ty: field_ty,
+                span: pattern_span,
+            });
+            let alloc = air.add_inst(AirInst {
+                data: AirInstData::Alloc {
+                    slot,
+                    init: get_ref,
+                },
+                ty: Type::UNIT,
+                span: pattern_span,
+            });
+            stmts.push(storage_live.as_u32());
+            stmts.push(alloc.as_u32());
+        }
+
+        Ok(stmts)
     }
 
     /// Analyze a return statement.
@@ -3736,12 +3878,24 @@ impl<'a> Sema<'a> {
                     inst.span,
                 )?;
 
+                // A tuple variant used as a bare path (no payload arguments)
+                // is missing its data — reject it with an arity error (RUE-221).
+                let expected = enum_def.variant_payload(variant_index).len();
+                if expected > 0 {
+                    return Err(CompileError::new(
+                        ErrorKind::WrongArgumentCount { expected, found: 0 },
+                        inst.span,
+                    ));
+                }
+
                 let ty = Type::new_enum(enum_id);
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::EnumVariant {
                         enum_id,
                         variant_index: variant_index as u32,
+                        payload_start: 0,
+                        payload_len: 0,
                     },
                     ty,
                     span: inst.span,
@@ -4273,8 +4427,118 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        // Enum tuple-variant construction: `Shape::Circle(5)` (RUE-221). If
+        // `type_name` is an enum whose variant is `function`, build an
+        // `EnumVariant` value carrying the analyzed payload operands rather
+        // than dispatching to associated-function resolution.
+        if let Some(&enum_id) = self.enums.get(&type_name) {
+            let variant_name = self.interner.resolve(&function).to_string();
+            let def = self.type_pool.enum_def(enum_id);
+            if let Some(variant_index) = def.find_variant(&variant_name) {
+                return self.analyze_enum_variant_construction(
+                    air,
+                    enum_id,
+                    variant_index as u32,
+                    type_name,
+                    args_start,
+                    args_len,
+                    span,
+                    ctx,
+                );
+            }
+        }
+
         // Delegate to the main implementation in analysis.rs
         self.analyze_assoc_fn_call_impl(air, type_name, function, args_start, args_len, span, ctx)
+    }
+
+    /// Analyze construction of an enum tuple variant with a payload
+    /// (`Shape::Circle(5)`), producing an `EnumVariant` AIR value (RUE-221).
+    #[allow(clippy::too_many_arguments)]
+    fn analyze_enum_variant_construction(
+        &mut self,
+        air: &mut Air,
+        enum_id: crate::types::EnumId,
+        variant_index: u32,
+        type_name: Spur,
+        args_start: u32,
+        args_len: u32,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        let def = self.type_pool.enum_def(enum_id);
+        let payload_types = def.variant_payload(variant_index as usize).to_vec();
+        let variant_name = def.variants[variant_index as usize].clone();
+        let enum_name = def.name.clone();
+
+        // Constructing a payload-carrying variant requires the preview feature.
+        if !payload_types.is_empty() {
+            self.require_preview(
+                PreviewFeature::EnumPayloads,
+                "enum payloads (variants that carry data)",
+                span,
+            )?;
+        }
+
+        // Visibility check, mirroring the bare-path `EnumVariant` handler
+        // (E0460, privacy is uniform across item kinds).
+        self.check_unqualified_visibility(
+            "enum",
+            self.interner.resolve(&type_name),
+            def.file_id,
+            def.is_pub,
+            span,
+        )?;
+
+        let args = self.rir.get_call_args(args_start, args_len);
+
+        // Arity check.
+        if args.len() != payload_types.len() {
+            return Err(CompileError::new(
+                ErrorKind::WrongArgumentCount {
+                    expected: payload_types.len(),
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        // Analyze each payload argument and type-check against the declared
+        // payload type (inference already constrained them; this is the final
+        // legality check).
+        let mut payload_refs: Vec<u32> = Vec::with_capacity(args.len());
+        for (i, arg) in args.iter().enumerate() {
+            let arg_result = self.analyze_inst(air, arg.value, ctx)?;
+            let expected = payload_types[i];
+            let actual = arg_result.ty;
+            if actual != expected && !actual.can_coerce_to(&expected) && actual != Type::ERROR {
+                return Err(self.type_mismatch_error(
+                    expected,
+                    actual,
+                    self.rir.get(arg.value).span,
+                ));
+            }
+            payload_refs.push(arg_result.air_ref.as_u32());
+        }
+
+        let payload_start = air.add_extra(&payload_refs);
+        let payload_len = payload_refs.len() as u32;
+        let ty = Type::new_enum(enum_id);
+
+        // Suppress unused-variable warnings for names only used in messages.
+        let _ = (&variant_name, &enum_name);
+
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::EnumVariant {
+                enum_id,
+                variant_index,
+                payload_start,
+                payload_len,
+            },
+            ty,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, ty))
     }
 
     // ========================================================================

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -80,6 +80,7 @@ impl<'a> Sema<'a> {
             let enum_def = EnumDef {
                 name: builtin_enum.name.to_string(),
                 variants,
+                variant_payloads: Vec::new(),
                 is_pub: true,                      // Built-in enums are always public
                 file_id: rue_span::FileId::new(0), // Synthetic, no source file
             };

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -11,9 +11,11 @@
 
 use std::collections::{HashMap, HashSet};
 
-use lasso::Spur;
+use lasso::{Key, Spur};
 use rue_builtins::is_reserved_type_name;
-use rue_error::{CompileError, CompileResult, CopyStructNonCopyFieldError, ErrorKind, ice};
+use rue_error::{
+    CompileError, CompileResult, CopyStructNonCopyFieldError, ErrorKind, PreviewFeature, ice,
+};
 use rue_rir::{InstData, InstRef, RirDirective, RirParamMode};
 use rue_span::{FileId, Span};
 
@@ -168,7 +170,21 @@ impl<'a> Sema<'a> {
                     name,
                     variants_start,
                     variants_len,
+                    payloads_len,
+                    ..
                 } => {
+                    // Tuple-variant payloads (RUE-221, ADR-0038) are gated
+                    // behind the `enum_payloads` preview feature. A payload
+                    // region of length 0 means every variant is
+                    // discriminant-only (C-like), which is always allowed.
+                    if *payloads_len > 0 {
+                        self.require_preview(
+                            PreviewFeature::EnumPayloads,
+                            "enum payloads (variants that carry data)",
+                            inst.span,
+                        )?;
+                    }
+
                     let enum_name = self.interner.resolve(&*name).to_string();
 
                     // Check for collision with built-in type names
@@ -218,6 +234,10 @@ impl<'a> Sema<'a> {
                     let enum_def = EnumDef {
                         name: enum_name,
                         variants: variant_names,
+                        // Payload types are resolved in phase 2
+                        // (`resolve_enum_payloads`), once all type names are
+                        // registered, so payloads may reference any struct/enum.
+                        variant_payloads: Vec::new(),
                         is_pub: *is_pub,
                         file_id: inst.span.file_id,
                     };
@@ -308,8 +328,71 @@ impl<'a> Sema<'a> {
     /// body analysis.
     pub(crate) fn resolve_declarations(&mut self) -> CompileResult<()> {
         self.resolve_struct_fields()?;
+        self.resolve_enum_payloads()?;
         self.propagate_field_linearity();
         self.resolve_remaining_declarations()?;
+        Ok(())
+    }
+
+    /// Phase 2: Resolve tuple-variant payload types (RUE-221, ADR-0038).
+    ///
+    /// Runs after all type names are registered, so payloads may reference any
+    /// struct or enum regardless of declaration order. Decodes the
+    /// self-describing payload region stored in the RIR `EnumDecl`
+    /// (`[k, t0, ..., t_{k-1}]` per variant) into concrete `Type`s and updates
+    /// the registered [`EnumDef`].
+    pub(crate) fn resolve_enum_payloads(&mut self) -> CompileResult<()> {
+        // Collect the work first to avoid borrowing `self.rir` while mutating
+        // the type pool through `self`.
+        let mut jobs: Vec<(Spur, u32, u32, Span)> = Vec::new();
+        for (_, inst) in self.rir.iter() {
+            if let InstData::EnumDecl {
+                name,
+                payloads_start,
+                payloads_len,
+                ..
+            } = &inst.data
+            {
+                if *payloads_len > 0 {
+                    jobs.push((*name, *payloads_start, *payloads_len, inst.span));
+                }
+            }
+        }
+
+        for (name, payloads_start, payloads_len, span) in jobs {
+            let words = self.rir.get_extra(payloads_start, payloads_len).to_vec();
+            // Decode per-variant payload type symbols.
+            let mut variant_payloads: Vec<Vec<Type>> = Vec::new();
+            let mut i = 0usize;
+            while i < words.len() {
+                let k = words[i] as usize;
+                i += 1;
+                let mut payload = Vec::with_capacity(k);
+                for _ in 0..k {
+                    let ty_sym = Spur::try_from_usize(words[i] as usize)
+                        .expect("valid interned type symbol in payload region");
+                    i += 1;
+                    let ty = self.resolve_type(ty_sym, span)?;
+                    // A payload of type `type` cannot exist at runtime
+                    // (spec 4.14:6); reject it like struct fields do.
+                    if ty.is_comptime_type() {
+                        return Err(CompileError::new(
+                            ErrorKind::ComptimeEvaluationFailed {
+                                reason: "type values cannot exist at runtime".to_string(),
+                            },
+                            span,
+                        ));
+                    }
+                    payload.push(ty);
+                }
+                variant_payloads.push(payload);
+            }
+
+            let enum_id = *self.enums.get(&name).expect("enum registered in phase 1");
+            let mut def = self.type_pool.enum_def(enum_id);
+            def.variant_payloads = variant_payloads;
+            self.type_pool.update_enum_def(enum_id, def);
+        }
         Ok(())
     }
 

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -523,8 +523,24 @@ impl<'a> Sema<'a> {
             // Zero-sized types use 0 slots
             // ComptimeType is comptime-only and uses 0 runtime slots
             TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType => 0,
-            // Enums are represented as their discriminant type (a scalar), so 1 slot
-            TypeKind::Enum(_) => 1,
+            // Tagged-union layout (RUE-221, ADR-0038): slot 0 is the
+            // discriminant, followed by payload space sized to the largest
+            // variant. A discriminant-only (C-like) enum has no payload and so
+            // occupies exactly one slot. This MUST match the codegen layout in
+            // `rue_codegen::types::type_slot_count`.
+            TypeKind::Enum(enum_id) => {
+                let enum_def = self.type_pool.enum_def(enum_id);
+                let mut max_payload = 0u32;
+                for i in 0..enum_def.variant_count() {
+                    let variant_slots: u32 = enum_def
+                        .variant_payload(i)
+                        .iter()
+                        .map(|&ty| self.abi_slot_count(ty))
+                        .sum();
+                    max_payload = max_payload.max(variant_slots);
+                }
+                1 + max_payload
+            }
             // Struct uses sum of all field slots (includes builtin String with 3 fields)
             TypeKind::Struct(struct_id) => {
                 // Sum the slot counts of all fields (handles arrays, nested structs, and builtins)

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -401,6 +401,13 @@ pub struct EnumDef {
     pub name: String,
     /// Variant names in declaration order
     pub variants: Vec<String>,
+    /// Payload field types for each variant, in declaration order (RUE-221,
+    /// ADR-0038). Parallel to `variants`: `variant_payloads[i]` is the list of
+    /// payload types carried by tuple variant `variants[i]`, or empty for a
+    /// discriminant-only variant. An **empty outer vector** means the enum is
+    /// entirely discriminant-only (C-like), the common case; use
+    /// [`EnumDef::variant_payload`] to read a variant's payload uniformly.
+    pub variant_payloads: Vec<Vec<Type>>,
     /// Whether this enum is public (visible outside its directory)
     pub is_pub: bool,
     /// File ID this enum was declared in (for visibility checking)
@@ -416,6 +423,24 @@ impl EnumDef {
     /// Find a variant by name and return its index.
     pub fn find_variant(&self, name: &str) -> Option<usize> {
         self.variants.iter().position(|v| v == name)
+    }
+
+    /// Get the payload field types carried by variant `index`.
+    ///
+    /// Returns an empty slice for a discriminant-only variant (or when this
+    /// enum has no payloads at all). Tolerates an empty `variant_payloads`
+    /// vector so discriminant-only enums need not populate it.
+    pub fn variant_payload(&self, index: usize) -> &[Type] {
+        self.variant_payloads
+            .get(index)
+            .map(|v| v.as_slice())
+            .unwrap_or(&[])
+    }
+
+    /// Whether any variant of this enum carries a payload (i.e. this is a
+    /// sum type with data rather than a C-like discriminant-only enum).
+    pub fn has_payloads(&self) -> bool {
+        self.variant_payloads.iter().any(|p| !p.is_empty())
     }
 
     /// Get the discriminant type for this enum.
@@ -1627,6 +1652,7 @@ mod tests {
         let empty = EnumDef {
             name: "Empty".to_string(),
             variants: vec![],
+            variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
         };
@@ -1635,6 +1661,7 @@ mod tests {
         let color = EnumDef {
             name: "Color".to_string(),
             variants: vec!["Red".to_string(), "Green".to_string(), "Blue".to_string()],
+            variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
         };
@@ -1646,6 +1673,7 @@ mod tests {
         let color = EnumDef {
             name: "Color".to_string(),
             variants: vec!["Red".to_string(), "Green".to_string(), "Blue".to_string()],
+            variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
         };
@@ -1661,6 +1689,7 @@ mod tests {
         let empty = EnumDef {
             name: "Empty".to_string(),
             variants: vec![],
+            variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
         };
@@ -1673,6 +1702,7 @@ mod tests {
         let small = EnumDef {
             name: "Small".to_string(),
             variants: vec!["A".to_string()],
+            variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
         };
@@ -1681,6 +1711,7 @@ mod tests {
         let max_u8 = EnumDef {
             name: "MaxU8".to_string(),
             variants: (0..256).map(|i| format!("V{}", i)).collect(),
+            variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
         };
@@ -1693,6 +1724,7 @@ mod tests {
         let medium = EnumDef {
             name: "Medium".to_string(),
             variants: (0..257).map(|i| format!("V{}", i)).collect(),
+            variant_payloads: Vec::new(),
             is_pub: false,
             file_id: rue_span::FileId::DEFAULT,
         };

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -2194,12 +2194,53 @@ impl<'a> CfgBuilder<'a> {
             AirInstData::EnumVariant {
                 enum_id,
                 variant_index,
+                payload_start,
+                payload_len,
             } => {
-                // Enum variants are just their discriminant value
+                // Lower payload operands (RUE-221) in order, then store them in
+                // the Cfg's extra array. A discriminant-only variant has no
+                // payload and lowers to just its discriminant value.
+                let payload_refs = self.air.get_air_refs(*payload_start, *payload_len);
+                let mut payload_vals: Vec<CfgValue> = Vec::with_capacity(*payload_len as usize);
+                for pref in payload_refs {
+                    let Some(v) = self.lower_value(pref) else {
+                        return Self::diverged();
+                    };
+                    payload_vals.push(v);
+                }
+                let (cfg_payload_start, cfg_payload_len) = self.cfg.push_extra(payload_vals);
                 let value = self.emit(
                     CfgInstData::EnumVariant {
                         enum_id: *enum_id,
                         variant_index: *variant_index,
+                        payload_start: cfg_payload_start,
+                        payload_len: cfg_payload_len,
+                    },
+                    ty,
+                    span,
+                );
+                self.cache(air_ref, value);
+                ExprResult {
+                    value: Some(value),
+                    continuation: Continuation::Continues,
+                }
+            }
+
+            AirInstData::EnumPayloadGet {
+                base,
+                enum_id,
+                variant_index,
+                field_index,
+            } => {
+                let Some(base_val) = self.lower_value(*base) else {
+                    return Self::diverged();
+                };
+                let value = self.emit(
+                    CfgInstData::EnumPayloadGet {
+                        base: base_val,
+                        enum_id: *enum_id,
+                        variant_index: *variant_index,
+                        field_index: *field_index,
                     },
                     ty,
                     span,

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -423,10 +423,26 @@ pub enum CfgInstData {
     },
 
     // Enum operations
-    /// Create an enum variant (discriminant value)
+    /// Create an enum variant value: the discriminant plus (for tuple
+    /// variants, RUE-221) the payload operands, stored in the Cfg's extra
+    /// array. Use `Cfg::get_extra(payload_start, payload_len)` to retrieve the
+    /// payload values (empty for a discriminant-only variant).
     EnumVariant {
         enum_id: EnumId,
         variant_index: u32,
+        /// Start index into the Cfg's extra array for payload values.
+        payload_start: u32,
+        /// Number of payload values.
+        payload_len: u32,
+    },
+    /// Read payload field `field_index` of a tuple variant from an enum value
+    /// (RUE-221). The result is the payload field, read from the tagged-union
+    /// slots of `base` (slot 0 is the discriminant).
+    EnumPayloadGet {
+        base: CfgValue,
+        enum_id: EnumId,
+        variant_index: u32,
+        field_index: u32,
     },
 
     // Type conversion operations
@@ -1241,8 +1257,30 @@ impl Cfg {
             CfgInstData::EnumVariant {
                 enum_id,
                 variant_index,
+                payload_len,
+                ..
             } => {
-                write!(f, "enum_variant #{}::{}", enum_id.0, variant_index)
+                if *payload_len == 0 {
+                    write!(f, "enum_variant #{}::{}", enum_id.0, variant_index)
+                } else {
+                    write!(
+                        f,
+                        "enum_variant #{}::{}(payload x{})",
+                        enum_id.0, variant_index, payload_len
+                    )
+                }
+            }
+            CfgInstData::EnumPayloadGet {
+                base,
+                enum_id,
+                variant_index,
+                field_index,
+            } => {
+                write!(
+                    f,
+                    "enum_payload_get {} #{}::{}.{}",
+                    base, enum_id.0, variant_index, field_index
+                )
             }
             CfgInstData::IntCast { value, from_ty } => {
                 write!(f, "intcast {} from {}", value, from_ty.name())

--- a/crates/rue-cfg/src/opt/constfold.rs
+++ b/crates/rue-cfg/src/opt/constfold.rs
@@ -283,6 +283,7 @@ fn get_enum_variant(cfg: &Cfg, value: CfgValue) -> Option<(EnumId, u32)> {
         CfgInstData::EnumVariant {
             enum_id,
             variant_index,
+            ..
         } => Some((*enum_id, *variant_index)),
         _ => None,
     }

--- a/crates/rue-cfg/src/opt/dce.rs
+++ b/crates/rue-cfg/src/opt/dce.rs
@@ -327,8 +327,17 @@ fn visit_instruction_uses(cfg: &Cfg, value: CfgValue, mut f: impl FnMut(CfgValue
             f(*value);
         }
 
-        // Enum operations
-        CfgInstData::EnumVariant { .. } => {}
+        // Enum operations: a tuple variant reads its payload operands.
+        CfgInstData::EnumVariant {
+            payload_start,
+            payload_len,
+            ..
+        } => {
+            for &v in cfg.get_extra(*payload_start, *payload_len) {
+                f(v);
+            }
+        }
+        CfgInstData::EnumPayloadGet { base, .. } => f(*base),
 
         // Type conversion
         CfgInstData::IntCast { value, .. } => f(*value),

--- a/crates/rue-cli-tests/cases/enum_payloads.toml
+++ b/crates/rue-cli-tests/cases/enum_payloads.toml
@@ -1,0 +1,64 @@
+# Enum payloads — sum types with data (RUE-221, ADR-0038), gated behind the
+# `enum_payloads` preview feature. These cases drive the real compiler with
+# `--preview enum_payloads` and assert exact runtime behavior: tuple-variant
+# construction, tagged-union layout, match-with-payload-bindings (move mode),
+# and drop-through-the-active-variant running exactly once.
+
+[section]
+id = "cli.enum_payloads"
+name = "Enum payloads"
+description = "Tuple-variant construction, match-with-bindings, and drop of the active variant's payload (RUE-221)."
+
+# Circle(5) -> 5, Rect(3,4) -> 7, Empty -> 0, exercised through a function call
+# (so the multi-slot tagged-union value crosses the call ABI).
+[[case]]
+name = "construct_match_compute"
+description = "Construct each variant form, match to extract payloads, compute 5+7+0 = 12."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+fn area(s: Shape) -> i32 {
+    match s {
+        Shape::Circle(r) => r,
+        Shape::Rect(w, h) => w + h,
+        Shape::Empty => 0,
+    }
+}
+fn main() -> i32 {
+    area(Shape::Circle(5)) + area(Shape::Rect(3, 4)) + area(Shape::Empty)
+}
+""" }]
+exit_code = 12
+
+# A struct payload with a destructor, moved out by a match binding, drops
+# exactly once (its @dbg fires exactly once) when the binding leaves scope.
+[[case]]
+name = "drop_once_via_active_variant"
+description = "Payload struct with `drop fn` moved out of the enum via a match binding drops exactly once: @dbg prints 7 once, exit 7."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Res { id: i32 }
+drop fn Res(self) { @dbg(self.id); }
+enum Holder { Full(Res), Nothing }
+fn main() -> i32 {
+    let h = Holder::Full(Res { id: 7 });
+    match h {
+        Holder::Full(r) => r.id,
+        Holder::Nothing => 0,
+    }
+}
+""" }]
+stdout = "7\n"
+exit_code = 7
+
+# Without the preview flag, a payload-carrying enum is a clean preview error
+# (the driver reports it, no ICE).
+[[case]]
+name = "payload_requires_preview_flag"
+description = "Declaring a tuple variant without --preview enum_payloads is a preview-feature error, not an ICE."
+files = [{ path = "main.rue", source = """
+enum Shape { Circle(i32), Empty }
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["requires preview feature"]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1290,13 +1290,16 @@ impl<'a> CfgLower<'a> {
                         .get_or_compute_field_vregs(*init)
                         .unwrap_or_else(|| self.collect_array_scalar_vregs(*init));
                     crate::agg_slots::store_slots(self, &scalar_vregs, *slot);
-                } else if init_type.is_struct() && !self.ctx.is_builtin_string(init_type) {
-                    // Struct: store all slots via the single accessor. It materializes a
-                    // struct read from a place (`let q = a.p`) by loading its slot_count
-                    // consecutive slots, and cache-hits StructInit/Load/Param/Call/
-                    // BlockParam — all of which now carry fully-flattened slot lists
-                    // (nested arrays included). Fall back to the flattener for any source
-                    // the accessor doesn't model. (RUE-118 / RUE-22)
+                } else if self.ctx.is_multislot_aggregate(init_type)
+                    && !self.ctx.is_builtin_string(init_type)
+                {
+                    // Struct or payload enum (RUE-221): store all slots via the
+                    // single accessor. It materializes a struct read from a place
+                    // (`let q = a.p`) by loading its slot_count consecutive slots,
+                    // and cache-hits StructInit/EnumVariant/Load/Param/Call/
+                    // BlockParam — all of which carry fully-flattened slot lists.
+                    // Fall back to the flattener for any source the accessor
+                    // doesn't model. (RUE-118 / RUE-22)
                     // (Builtin String is excluded above — it takes the fat-pointer branch.)
                     let scalar_vregs = self
                         .get_or_compute_field_vregs(*init)
@@ -1387,9 +1390,11 @@ impl<'a> CfgLower<'a> {
                         let vreg = self.mir.alloc_vreg();
                         self.value_map.insert(value, vreg);
                     }
-                } else if let Some(struct_id) = load_type.as_struct() {
-                    // Struct: load all field slots (recursively flattened)
-                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                } else if self.ctx.is_multislot_aggregate(load_type) {
+                    // Struct or payload enum (RUE-221): load all slots. For an
+                    // enum, slot 0 is the discriminant (what a `match`
+                    // switches on).
+                    let slot_count = self.ctx.type_slot_count(load_type);
                     let mut slot_vregs = Vec::with_capacity(slot_count as usize);
 
                     for i in 0..slot_count {
@@ -1526,12 +1531,11 @@ impl<'a> CfgLower<'a> {
                 // param); other aggregates do when their slots exceed the
                 // return registers. See crate::cfg_lower::type_uses_sret_return.
                 let is_sret_call = self.ctx.type_uses_sret(ty, RET_REGS.len() as u32);
-                let ret_slot_count =
-                    if matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
-                        self.ctx.type_slot_count(ty)
-                    } else {
-                        1
-                    };
+                let ret_slot_count = if self.ctx.is_multislot_aggregate(ty) {
+                    self.ctx.type_slot_count(ty)
+                } else {
+                    1
+                };
                 // Caller-allocated return buffer: one 8-byte slot per
                 // aggregate slot, padded to keep sp 16-byte aligned.
                 let sret_bytes = ((ret_slot_count as i32 * 8) + 15) / 16 * 16;
@@ -1573,25 +1577,19 @@ impl<'a> CfgLower<'a> {
                         continue;
                     }
 
-                    match arg_type.kind() {
-                        TypeKind::Struct(_) | TypeKind::Array(_) => {
-                            // Pass all slots of the (possibly multi-slot) aggregate arg —
-                            // struct, builtin String, or fixed-size array — regardless of
-                            // how it was produced. The accessor materializes lazily-sourced
-                            // values (Load/Param/PlaceRead) and cache-hits eager ones
-                            // (StructInit/ArrayInit/Call/BlockParam). The old per-source
-                            // array ladder iterated array_len (element count), not
-                            // slot_count, so a multidimensional array dropped every row
-                            // after the first. (RUE-118, RUE-79)
-                            if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_value) {
-                                flattened_vregs.extend(field_vregs);
-                            } else {
-                                flattened_vregs.push(self.get_vreg(arg_value));
-                            }
-                        }
-                        _ => {
+                    if self.ctx.is_multislot_aggregate(arg_type) {
+                        // Pass all slots of the (possibly multi-slot) aggregate arg —
+                        // struct, builtin String, fixed-size array, or payload enum
+                        // (RUE-221) — regardless of how it was produced. The accessor
+                        // materializes lazily-sourced values (Load/Param/PlaceRead) and
+                        // cache-hits eager ones (StructInit/ArrayInit/Call/BlockParam).
+                        if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_value) {
+                            flattened_vregs.extend(field_vregs);
+                        } else {
                             flattened_vregs.push(self.get_vreg(arg_value));
                         }
+                    } else {
+                        flattened_vregs.push(self.get_vreg(arg_value));
                     }
                 }
 
@@ -2393,15 +2391,64 @@ impl<'a> CfgLower<'a> {
                 });
             }
 
-            CfgInstData::EnumVariant { variant_index, .. } => {
-                // Enum variants are represented as their discriminant (variant index)
+            CfgInstData::EnumVariant {
+                variant_index,
+                payload_start,
+                payload_len,
+                ..
+            } => {
+                let vty = self.ctx.cfg.get_inst(value).ty;
+                if *payload_len == 0 && self.ctx.type_slot_count(vty) <= 1 {
+                    // Discriminant-only (C-like) enum: single-slot scalar.
+                    let vreg = self.mir.alloc_vreg();
+                    self.value_map.insert(value, vreg);
+                    self.mir.push(Aarch64Inst::MovImm {
+                        dst: Operand::Virtual(vreg),
+                        imm: *variant_index as i64,
+                    });
+                } else {
+                    // Tagged-union value (RUE-221): discriminant + payload slots.
+                    let (ps, pl) = (*payload_start, *payload_len);
+                    crate::agg_slots::lower_enum_variant(self, value, ps, pl);
+                }
+            }
+
+            CfgInstData::EnumPayloadGet {
+                base,
+                enum_id,
+                variant_index,
+                field_index,
+            } => {
+                // Read payload field from the scrutinee's tagged-union slots.
+                let (enum_id, variant_index, field_index) =
+                    (*enum_id, *variant_index, *field_index);
+                let base = *base;
+                let vty = self.ctx.cfg.get_inst(value).ty;
+                let field_slots = self.ctx.type_slot_count(vty) as usize;
+                let offset = types::enum_payload_slot_offset(
+                    self.ctx.type_pool,
+                    enum_id,
+                    variant_index,
+                    field_index,
+                ) as usize;
+                let base_slots = self
+                    .get_or_compute_field_vregs(base)
+                    .expect("enum payload base must have slot vregs");
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
-
-                self.mir.push(Aarch64Inst::MovImm {
-                    dst: Operand::Virtual(vreg),
-                    imm: *variant_index as i64,
-                });
+                if field_slots > 1 {
+                    let slots: Vec<VReg> = base_slots[offset..offset + field_slots].to_vec();
+                    self.struct_slot_vregs.insert(value, slots.clone());
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(slots[0]),
+                    });
+                } else {
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(base_slots[offset]),
+                    });
+                }
             }
 
             CfgInstData::IntCast {
@@ -4314,6 +4361,12 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
         self.mir.push(Aarch64Inst::MovImm {
             dst: Operand::Virtual(dst),
             imm: 0,
+        });
+    }
+    fn emit_load_imm(&mut self, dst: VReg, imm: i64) {
+        self.mir.push(Aarch64Inst::MovImm {
+            dst: Operand::Virtual(dst),
+            imm,
         });
     }
     fn collect_array_scalars(&mut self, value: CfgValue) -> Vec<VReg> {

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -64,6 +64,10 @@ pub trait SlotBackend {
     /// Emit a load of the constant zero into `dst`.
     fn emit_load_zero(&mut self, dst: VReg);
 
+    /// Emit a load of the integer constant `imm` into `dst` (used for an
+    /// enum discriminant, RUE-221).
+    fn emit_load_imm(&mut self, dst: VReg, imm: i64);
+
     /// Recursively collect the scalar slot vregs of an array value
     /// (the backends' thin wrapper over `types::collect_array_scalar_vregs`).
     fn collect_array_scalars(&mut self, value: CfgValue) -> Vec<VReg>;
@@ -114,7 +118,11 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
         let inst = b.ctx().cfg.get_inst(value);
         (inst.ty, inst.data.clone())
     };
-    if !matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+    // Aggregates are structs, arrays, and payload-carrying enums (a
+    // discriminant-only enum stays a 1-slot scalar and is handled by the
+    // ordinary single-vreg path). (RUE-221)
+    let is_payload_enum = matches!(ty.kind(), TypeKind::Enum(_)) && b.ctx().type_slot_count(ty) > 1;
+    if !matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) && !is_payload_enum {
         return None;
     }
 
@@ -260,6 +268,69 @@ pub fn lower_struct_init<B: SlotBackend>(
         b.emit_reg_move(vreg, first_vreg);
     } else {
         b.emit_load_zero(vreg);
+    }
+
+    b.slot_cache().insert(value, slot_vregs);
+}
+
+/// Lower an `EnumVariant` tuple-variant construction into slot vregs (RUE-221).
+///
+/// Tagged-union layout: slot 0 is the discriminant (`variant_index`), followed
+/// by the payload operands flattened to one vreg per slot. The payload area is
+/// padded with zero slots so every value of the enum type occupies the same
+/// number of slots (sized to the largest variant), which is what consumers
+/// (Alloc, Store, match extraction) expect. The value's primary vreg is slot 0
+/// (the discriminant), so a `match` can switch on it directly.
+pub fn lower_enum_variant<B: SlotBackend>(
+    b: &mut B,
+    value: CfgValue,
+    payload_start: u32,
+    payload_len: u32,
+) {
+    let ty = b.ctx().cfg.get_inst(value).ty;
+    let total_slots = b.ctx().type_slot_count(ty);
+
+    // Slot 0: the discriminant.
+    let disc_vreg = b.alloc_vreg();
+    let variant_index = match &b.ctx().cfg.get_inst(value).data {
+        CfgInstData::EnumVariant { variant_index, .. } => *variant_index,
+        _ => unreachable!("lower_enum_variant on non-EnumVariant"),
+    };
+    b.emit_load_imm(disc_vreg, variant_index as i64);
+    b.map_value(value, disc_vreg);
+
+    let mut slot_vregs: Vec<VReg> = Vec::with_capacity(total_slots as usize);
+    slot_vregs.push(disc_vreg);
+
+    // Payload slots, flattening nested aggregates like StructInit does.
+    let payload = b.ctx().cfg.get_extra(payload_start, payload_len).to_vec();
+    for field in &payload {
+        let field_ty = b.ctx().cfg.get_inst(*field).ty;
+        match field_ty.kind() {
+            TypeKind::Struct(_) | TypeKind::Enum(_) => {
+                if let Some(nested) = get_or_compute_field_vregs(b, *field) {
+                    slot_vregs.extend(nested);
+                } else {
+                    slot_vregs.push(b.get_vreg(*field));
+                }
+            }
+            TypeKind::Array(_) => {
+                if let Some(nested) = get_or_compute_field_vregs(b, *field) {
+                    slot_vregs.extend(nested);
+                } else {
+                    slot_vregs.extend(b.collect_array_scalars(*field));
+                }
+            }
+            _ => slot_vregs.push(b.get_vreg(*field)),
+        }
+    }
+
+    // Pad the payload area to the enum's full slot count so all values of this
+    // type are the same size (the union is sized to the largest variant).
+    while (slot_vregs.len() as u32) < total_slots {
+        let pad = b.alloc_vreg();
+        b.emit_load_zero(pad);
+        slot_vregs.push(pad);
     }
 
     b.slot_cache().insert(value, slot_vregs);

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -230,8 +230,20 @@ pub fn format_cfg_inst_data(data: &rue_cfg::CfgInstData) -> String {
         CfgInstData::EnumVariant {
             enum_id,
             variant_index,
+            ..
         } => {
             format!("enum_variant #{}.{}", enum_id.0, variant_index)
+        }
+        CfgInstData::EnumPayloadGet {
+            base,
+            enum_id,
+            variant_index,
+            field_index,
+        } => {
+            format!(
+                "enum_payload_get {} #{}.{}.{}",
+                base, enum_id.0, variant_index, field_index
+            )
         }
         CfgInstData::IntCast { value, from_ty } => {
             format!("int_cast {} : {}", value, from_ty.name())
@@ -430,6 +442,16 @@ impl<'a> CfgLowerContext<'a> {
     /// Calculate the total number of slots needed to store a type.
     pub fn type_slot_count(&self, ty: Type) -> u32 {
         types::type_slot_count(self.type_pool, ty)
+    }
+
+    /// Whether `ty` is a multi-slot aggregate that must be materialized and
+    /// stored slot-by-slot (struct, fixed-size array, or a payload-carrying
+    /// enum). A discriminant-only (C-like) enum is a 1-slot scalar and is
+    /// deliberately excluded so it keeps its existing scalar codegen path
+    /// (RUE-221).
+    pub fn is_multislot_aggregate(&self, ty: Type) -> bool {
+        matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_))
+            || (ty.is_enum() && self.type_slot_count(ty) > 1)
     }
 
     /// Calculate the slot count for a single element of an array type.

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -6,7 +6,7 @@
 //! As of Phase 3 (ADR-0024), all struct/enum lookups go through `TypeInternPool`
 //! instead of separate `&[StructDef]` slices.
 
-use rue_air::{ArrayTypeId, StructId, TypeInternPool, TypeKind};
+use rue_air::{ArrayTypeId, EnumId, StructId, TypeInternPool, TypeKind};
 use rue_cfg::{Cfg, CfgInstData, CfgValue, Type};
 use std::collections::HashMap;
 
@@ -82,9 +82,49 @@ pub fn type_slot_count(type_pool: &TypeInternPool, ty: Type) -> u32 {
             }
             total
         }
+        TypeKind::Enum(enum_id) => {
+            // Tagged-union layout (RUE-221, ADR-0038): slot 0 holds the
+            // discriminant; the payload area that follows is sized to the
+            // largest variant. A discriminant-only (C-like) enum has no
+            // payload and therefore occupies exactly one slot, unchanged from
+            // before payloads existed.
+            let enum_def = type_pool.enum_def(enum_id);
+            let mut max_payload = 0u32;
+            for i in 0..enum_def.variant_count() {
+                let mut variant_slots = 0u32;
+                for &ty in enum_def.variant_payload(i) {
+                    variant_slots += type_slot_count(type_pool, ty);
+                }
+                max_payload = max_payload.max(variant_slots);
+            }
+            1 + max_payload
+        }
         // Scalars and other types use 1 slot
         _ => 1,
     }
+}
+
+/// Slot offset of payload field `field_index` within an enum's payload area.
+///
+/// The discriminant occupies slot 0, so payload fields begin at slot 1. This
+/// accounts for the slot sizes of all preceding payload fields of the same
+/// variant (RUE-221).
+pub fn enum_payload_slot_offset(
+    type_pool: &TypeInternPool,
+    enum_id: EnumId,
+    variant_index: u32,
+    field_index: u32,
+) -> u32 {
+    let enum_def = type_pool.enum_def(enum_id);
+    let payload = enum_def.variant_payload(variant_index as usize);
+    // 1 for the discriminant slot.
+    let mut offset = 1u32;
+    for i in 0..(field_index as usize) {
+        if let Some(&ty) = payload.get(i) {
+            offset += type_slot_count(type_pool, ty);
+        }
+    }
+    offset
 }
 
 /// Calculate the slot count for a single element of an array type.

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -500,7 +500,7 @@ impl<'a> CfgLower<'a> {
                 // fieldless struct) gets an EMPTY list, matching the empty
                 // slot lists its sources cache — a phantom slot here tripped
                 // the join's count assert (RUE-194).
-                if matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                if self.ctx.is_multislot_aggregate(*ty) {
                     let slot_count = self.ctx.type_slot_count(*ty);
                     let mut slot_vregs = Vec::with_capacity(slot_count as usize);
                     if slot_count > 0 {
@@ -546,7 +546,7 @@ impl<'a> CfgLower<'a> {
                     .insert((block.id, param_idx as u32), vreg);
                 self.value_map.insert(*param_val, vreg);
 
-                if matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                if self.ctx.is_multislot_aggregate(*ty) {
                     // Exactly slot_count vregs; zero-slot aggregates get an
                     // empty list (RUE-194) — same as lower().
                     let slot_count = self.ctx.type_slot_count(*ty);
@@ -1644,13 +1644,14 @@ impl<'a> CfgLower<'a> {
                         "string should have 3 fields (ptr, len, cap)"
                     );
                     crate::agg_slots::store_slots(self, &field_vregs, *slot);
-                } else if matches!(init_type.kind(), TypeKind::Struct(_)) {
-                    // Struct: store all slots via the single accessor. It materializes a
-                    // struct read from a place (`let q = a.p`) by loading its slot_count
-                    // consecutive slots, and cache-hits StructInit/Load/Param/Call/
-                    // BlockParam — all of which now carry fully-flattened slot lists
-                    // (nested arrays included). Fall back to the flattener for any source
-                    // the accessor doesn't model. (RUE-118 / RUE-22)
+                } else if self.ctx.is_multislot_aggregate(init_type) {
+                    // Struct or payload enum (RUE-221): store all slots via the
+                    // single accessor. It materializes a struct read from a place
+                    // (`let q = a.p`) by loading its slot_count consecutive slots,
+                    // and cache-hits StructInit/EnumVariant/Load/Param/Call/
+                    // BlockParam — all of which carry fully-flattened slot lists.
+                    // Fall back to the flattener for any source the accessor
+                    // doesn't model. (RUE-118 / RUE-22)
                     let scalar_vregs = self
                         .get_or_compute_field_vregs(*init)
                         .unwrap_or_else(|| self.collect_struct_scalar_vregs(*init));
@@ -1730,9 +1731,11 @@ impl<'a> CfgLower<'a> {
                         let vreg = self.mir.alloc_vreg();
                         self.value_map.insert(value, vreg);
                     }
-                } else if let TypeKind::Struct(struct_id) = load_type.kind() {
-                    // Struct: load all field slots (recursively flattened)
-                    let slot_count = self.ctx.type_slot_count(Type::new_struct(struct_id));
+                } else if self.ctx.is_multislot_aggregate(load_type) {
+                    // Struct or payload enum (RUE-221): load all slots. For an
+                    // enum, slot 0 is the discriminant, so the primary vreg set
+                    // below is what a `match` switches on.
+                    let slot_count = self.ctx.type_slot_count(load_type);
                     let mut slot_vregs = Vec::with_capacity(slot_count as usize);
 
                     for i in 0..slot_count {
@@ -1776,12 +1779,11 @@ impl<'a> CfgLower<'a> {
                 // lazily-sourced values and cache-hits eager ones; if it can't model
                 // the source (e.g. a dynamically-indexed place-read) fall back to the
                 // old single-slot behavior rather than ICE. (RUE-118, RUE-80)
-                let aggregate_vregs =
-                    if matches!(val_type.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
-                        self.get_or_compute_field_vregs(*val)
-                    } else {
-                        None
-                    };
+                let aggregate_vregs = if self.ctx.is_multislot_aggregate(val_type) {
+                    self.get_or_compute_field_vregs(*val)
+                } else {
+                    None
+                };
 
                 if let Some(slot_vregs) = aggregate_vregs {
                     // Check if this slot corresponds to an inout parameter
@@ -1840,12 +1842,11 @@ impl<'a> CfgLower<'a> {
                 // the pointer (stack grows down), so slot i lives at ptr - i*8.
                 // Unmodeled sources fall back to single-slot. (RUE-145)
                 let val_type = self.ctx.cfg.get_inst(*val).ty;
-                let aggregate_vregs =
-                    if matches!(val_type.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
-                        self.get_or_compute_field_vregs(*val)
-                    } else {
-                        None
-                    };
+                let aggregate_vregs = if self.ctx.is_multislot_aggregate(val_type) {
+                    self.get_or_compute_field_vregs(*val)
+                } else {
+                    None
+                };
 
                 // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
                 let ptr_vreg = self.ensure_inout_param_ptr(*param_slot);
@@ -1874,12 +1875,11 @@ impl<'a> CfgLower<'a> {
                 // param); other aggregates do when their slots exceed the
                 // return registers. See crate::cfg_lower::type_uses_sret_return.
                 let is_sret_call = self.ctx.type_uses_sret(ty, RET_REGS.len() as u32);
-                let ret_slot_count =
-                    if matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
-                        self.ctx.type_slot_count(ty)
-                    } else {
-                        1
-                    };
+                let ret_slot_count = if self.ctx.is_multislot_aggregate(ty) {
+                    self.ctx.type_slot_count(ty)
+                } else {
+                    1
+                };
                 // Caller-allocated return buffer: one 8-byte slot per
                 // aggregate slot, padded to keep rsp 16-byte aligned.
                 let sret_bytes = ((ret_slot_count as i32 * 8) + 15) / 16 * 16;
@@ -1921,26 +1921,23 @@ impl<'a> CfgLower<'a> {
                         continue;
                     }
 
-                    match arg_type.kind() {
-                        TypeKind::Struct(_) | TypeKind::Array(_) => {
-                            // Pass all slots of the (possibly multi-slot) aggregate arg —
-                            // struct, builtin String, or fixed-size array — regardless of
-                            // how it was produced. The accessor materializes lazily-sourced
-                            // values (Load/Param/PlaceRead) and cache-hits eager ones
-                            // (StructInit/ArrayInit/Call/BlockParam). The old per-source
-                            // array ladder iterated array_len (element count), not
-                            // slot_count, so a multidimensional array dropped every row
-                            // after the first. (RUE-118, RUE-79)
-                            if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_value) {
-                                flattened_vregs.extend(field_vregs);
-                            } else {
-                                flattened_vregs.push(self.get_vreg(arg_value));
-                            }
-                        }
-                        // Note: String is now Type::Struct, handled above
-                        _ => {
+                    if self.ctx.is_multislot_aggregate(arg_type) {
+                        // Pass all slots of the (possibly multi-slot) aggregate arg —
+                        // struct, builtin String, fixed-size array, or payload enum
+                        // (RUE-221) — regardless of how it was produced. The accessor
+                        // materializes lazily-sourced values (Load/Param/PlaceRead) and
+                        // cache-hits eager ones (StructInit/ArrayInit/Call/BlockParam).
+                        // The old per-source array ladder iterated array_len (element
+                        // count), not slot_count, so a multidimensional array dropped
+                        // every row after the first. (RUE-118, RUE-79)
+                        if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_value) {
+                            flattened_vregs.extend(field_vregs);
+                        } else {
                             flattened_vregs.push(self.get_vreg(arg_value));
                         }
+                    } else {
+                        // Note: String is now Type::Struct, handled above
+                        flattened_vregs.push(self.get_vreg(arg_value));
                     }
                 }
 
@@ -2030,7 +2027,7 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(result_vreg),
                         src: Operand::Virtual(slot_vregs[0]),
                     });
-                } else if matches!(ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                } else if self.ctx.is_multislot_aggregate(ty) {
                     // Aggregates that fit return in registers. Capture
                     // every slot from RET_REGS, not just rax — arrays previously fell
                     // to the scalar path and lost all elements but the first. (RUE-78)
@@ -2770,15 +2767,66 @@ impl<'a> CfgLower<'a> {
                 });
             }
 
-            CfgInstData::EnumVariant { variant_index, .. } => {
-                // Enum variants are represented as their discriminant (variant index)
+            CfgInstData::EnumVariant {
+                variant_index,
+                payload_start,
+                payload_len,
+                ..
+            } => {
+                let vty = self.ctx.cfg.get_inst(value).ty;
+                if *payload_len == 0 && self.ctx.type_slot_count(vty) <= 1 {
+                    // Discriminant-only (C-like) enum: a single-slot scalar
+                    // holding the variant index.
+                    let vreg = self.mir.alloc_vreg();
+                    self.value_map.insert(value, vreg);
+                    self.mir.push(X86Inst::MovRI32 {
+                        dst: Operand::Virtual(vreg),
+                        imm: *variant_index as i32,
+                    });
+                } else {
+                    // Tagged-union value (RUE-221): discriminant + payload slots.
+                    let (ps, pl) = (*payload_start, *payload_len);
+                    crate::agg_slots::lower_enum_variant(self, value, ps, pl);
+                }
+            }
+
+            CfgInstData::EnumPayloadGet {
+                base,
+                enum_id,
+                variant_index,
+                field_index,
+            } => {
+                // Read payload field from the scrutinee's tagged-union slots.
+                let (enum_id, variant_index, field_index) =
+                    (*enum_id, *variant_index, *field_index);
+                let base = *base;
+                let vty = self.ctx.cfg.get_inst(value).ty;
+                let field_slots = self.ctx.type_slot_count(vty) as usize;
+                let offset = types::enum_payload_slot_offset(
+                    self.ctx.type_pool,
+                    enum_id,
+                    variant_index,
+                    field_index,
+                ) as usize;
+                let base_slots = self
+                    .get_or_compute_field_vregs(base)
+                    .expect("enum payload base must have slot vregs");
                 let vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, vreg);
-
-                self.mir.push(X86Inst::MovRI32 {
-                    dst: Operand::Virtual(vreg),
-                    imm: *variant_index as i32,
-                });
+                if field_slots > 1 {
+                    // Multi-slot payload (nested aggregate): expose all slots.
+                    let slots: Vec<VReg> = base_slots[offset..offset + field_slots].to_vec();
+                    self.struct_slot_vregs.insert(value, slots.clone());
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(slots[0]),
+                    });
+                } else {
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(vreg),
+                        src: Operand::Virtual(base_slots[offset]),
+                    });
+                }
             }
 
             CfgInstData::IntCast {
@@ -2935,7 +2983,7 @@ impl<'a> CfgLower<'a> {
                 // materializes lazily-sourced values; if it can't model the source,
                 // fall back to the old single-slot behavior. (RUE-118, RUE-23)
                 let val_type = self.ctx.cfg.get_inst(*val).ty;
-                let vals = if matches!(val_type.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                let vals = if self.ctx.is_multislot_aggregate(val_type) {
                     self.get_or_compute_field_vregs(*val)
                         .unwrap_or_else(|| vec![self.get_vreg(*val)])
                 } else {
@@ -3497,7 +3545,7 @@ impl<'a> CfgLower<'a> {
                 let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                 for (i, &arg) in args.iter().enumerate() {
                     let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if matches!(arg_type.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                    if self.ctx.is_multislot_aggregate(arg_type) {
                         // For aggregate args (structs, String, arrays), copy all slot vregs
                         self.copy_aggregate_to_block_param(arg, *target, i as u32);
                     } else {
@@ -3549,7 +3597,7 @@ impl<'a> CfgLower<'a> {
                 let then_args = self.ctx.cfg.get_extra(*then_args_start, *then_args_len);
                 for (i, &arg) in then_args.iter().enumerate() {
                     let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if matches!(arg_type.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                    if self.ctx.is_multislot_aggregate(arg_type) {
                         // For aggregate args (structs, String, arrays), copy all slot vregs
                         self.copy_aggregate_to_block_param(arg, *then_block, i as u32);
                     } else {
@@ -3575,7 +3623,7 @@ impl<'a> CfgLower<'a> {
                 let else_args = self.ctx.cfg.get_extra(*else_args_start, *else_args_len);
                 for (i, &arg) in else_args.iter().enumerate() {
                     let arg_type = self.ctx.cfg.get_inst(arg).ty;
-                    if matches!(arg_type.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
+                    if self.ctx.is_multislot_aggregate(arg_type) {
                         // For aggregate args (structs, String, arrays), copy all slot vregs
                         self.copy_aggregate_to_block_param(arg, *else_block, i as u32);
                     } else {
@@ -4302,6 +4350,12 @@ impl crate::agg_slots::SlotBackend for CfgLower<'_> {
         self.mir.push(X86Inst::MovRI32 {
             dst: Operand::Virtual(dst),
             imm: 0,
+        });
+    }
+    fn emit_load_imm(&mut self, dst: VReg, imm: i64) {
+        self.mir.push(X86Inst::MovRI32 {
+            dst: Operand::Virtual(dst),
+            imm: imm as i32,
         });
     }
     fn collect_array_scalars(&mut self, value: CfgValue) -> Vec<VReg> {

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -361,6 +361,11 @@ pub enum PreviewFeature {
     /// self)`), RUE-15 / ADR-0037. Lets methods access `self` by reference
     /// instead of consuming it.
     MethodReceivers,
+    /// Enum payloads — sum types with data (RUE-221, ADR-0038). Tuple
+    /// variants (`Circle(i32)`) carrying data, tagged-union layout, and
+    /// pattern matching with payload bindings (`match s { Circle(r) => r }`).
+    /// The prerequisite for `Option`/`Result`.
+    EnumPayloads,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -383,6 +388,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::ForLoops => "for_loops",
             PreviewFeature::MethodReceivers => "method_receivers",
+            PreviewFeature::EnumPayloads => "enum_payloads",
         }
     }
 
@@ -393,6 +399,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::ForLoops => "ADR-0037",
             PreviewFeature::MethodReceivers => "ADR-0037",
+            PreviewFeature::EnumPayloads => "ADR-0038",
         }
     }
 
@@ -402,6 +409,7 @@ impl PreviewFeature {
             PreviewFeature::TestInfra,
             PreviewFeature::ForLoops,
             PreviewFeature::MethodReceivers,
+            PreviewFeature::EnumPayloads,
         ]
     }
 
@@ -427,6 +435,7 @@ impl std::str::FromStr for PreviewFeature {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "for_loops" => Ok(PreviewFeature::ForLoops),
             "method_receivers" => Ok(PreviewFeature::MethodReceivers),
+            "enum_payloads" => Ok(PreviewFeature::EnumPayloads),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -2203,7 +2212,10 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, for_loops, method_receivers");
+        assert_eq!(
+            names,
+            "test_infra, for_loops, method_receivers, enum_payloads"
+        );
     }
 
     #[test]

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -520,6 +520,18 @@ impl<'a> Interp<'a> {
             }
             CfgInstData::EnumVariant { variant_index, .. } => Value::Int(*variant_index as i128),
 
+            // Enum payloads (RUE-221) are a preview feature the oracle does not
+            // model yet — it represents an enum by its discriminant only. Return
+            // Unsupported (a clean skip) rather than a guessed value, so payload-
+            // bearing programs drop out of the differential path instead of
+            // reporting a false disagreement. (Proper modeling: RUE-221 oracle
+            // follow-up.)
+            CfgInstData::EnumPayloadGet { .. } => {
+                return Err(Flow::Unsupported(Unsupported(
+                    "enum payload get (RUE-221 preview)".into(),
+                )));
+            }
+
             // Writes to an `inout` parameter inside the callee (visible to the
             // caller via copy-out).
             CfgInstData::ParamStore { param_slot, value } => {

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -158,10 +158,18 @@ pub struct EnumDecl {
 }
 
 /// A variant in an enum declaration.
+///
+/// A variant may be discriminant-only (`Empty`) or a **tuple variant** that
+/// carries positional payload data (`Circle(i32)`, `Rect(i32, i32)`). The
+/// `payload` vector holds the payload field types in declaration order; it is
+/// empty for a discriminant-only variant. Tuple variants require the
+/// `enum_payloads` preview feature (RUE-221, ADR-0038).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct EnumVariant {
     /// Variant name
     pub name: Ident,
+    /// Payload field types (empty = discriminant-only variant).
+    pub payload: Vec<TypeExpr>,
     /// Span covering the variant
     pub span: Span,
 }
@@ -643,6 +651,11 @@ pub struct NegIntLit {
 }
 
 /// A path pattern (e.g., `Color::Red` or `module.Color::Red` for enum variant matching).
+///
+/// A tuple-variant pattern binds the variant's payload into fresh names:
+/// `Circle(r)`, `Rect(w, h)`. The `bindings` vector holds those binding names
+/// in payload order; it is empty for a discriminant-only pattern (`Color::Red`).
+/// Payload bindings require the `enum_payloads` preview feature (RUE-221).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct PathPattern {
     /// Optional module/namespace prefix (e.g., `utils` in `utils.Color::Red`)
@@ -651,6 +664,8 @@ pub struct PathPattern {
     pub type_name: Ident,
     /// The variant name (e.g., `Red`)
     pub variant: Ident,
+    /// Payload binding names (empty = no payload pattern).
+    pub bindings: Vec<Ident>,
     pub span: Span,
 }
 
@@ -1075,7 +1090,16 @@ fn fmt_enum(f: &mut fmt::Formatter<'_>, e: &EnumDecl, level: usize) -> fmt::Resu
     writeln!(f, "Enum sym:{}", e.name.name.into_usize())?;
     for variant in &e.variants {
         indent(f, level + 1)?;
-        writeln!(f, "Variant sym:{}", variant.name.name.into_usize())?;
+        if variant.payload.is_empty() {
+            writeln!(f, "Variant sym:{}", variant.name.name.into_usize())?;
+        } else {
+            writeln!(
+                f,
+                "Variant sym:{} payload:{}",
+                variant.name.name.into_usize(),
+                variant.payload.len()
+            )?;
+        }
     }
     Ok(())
 }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -802,18 +802,32 @@ where
         }),
     };
 
-    // Simple path pattern: Enum::Variant (no module prefix)
+    // Optional payload bindings for a tuple-variant pattern: `(a, b, ...)`
+    // (RUE-221). At least one binding required inside the parens.
+    let pattern_bindings = ident_parser()
+        .separated_by(just(TokenKind::Comma))
+        .at_least(1)
+        .allow_trailing()
+        .collect::<Vec<_>>()
+        .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen))
+        .or_not()
+        .map(|opt| opt.unwrap_or_default());
+
+    // Simple path pattern: Enum::Variant (no module prefix), optionally with
+    // payload bindings `Enum::Variant(a, b)`.
     let simple_path_pat = ident_parser()
         .then_ignore(just(TokenKind::ColonColon))
         .then(ident_parser())
+        .then(pattern_bindings.clone())
         // Negative lookahead to ensure we're not at the start of a qualified path
         // (i.e., ensure there's no `.` before this pattern that would make it
         // part of a module.Enum::Variant pattern)
-        .map_with(|(type_name, variant), e| {
+        .map_with(|((type_name, variant), bindings), e| {
             Pattern::Path(PathPattern {
                 base: None,
                 type_name,
                 variant,
+                bindings,
                 span: span_from_extra(e),
             })
         });
@@ -831,7 +845,8 @@ where
         )
         .then_ignore(just(TokenKind::ColonColon))
         .then(ident_parser())
-        .map_with(|((first, mut rest), variant), e| {
+        .then(pattern_bindings)
+        .map_with(|(((first, mut rest), variant), bindings), e| {
             // first is the first module identifier
             // rest contains all subsequent identifiers up to and including type_name
             // The last element of rest is the type_name
@@ -859,6 +874,7 @@ where
                 base: Some(Box::new(base_expr)),
                 type_name,
                 variant,
+                bindings,
                 span: span_from_extra(e),
             })
         });
@@ -2234,15 +2250,30 @@ where
         )
 }
 
-/// Parser for enum variant: just an identifier
+/// Parser for enum variant: `Name` (discriminant-only) or `Name(T1, T2, ...)`
+/// (tuple variant carrying payload data, RUE-221).
 fn enum_variant_parser<'src, I>() -> impl Parser<'src, I, EnumVariant, ParserExtras<'src>> + Clone
 where
     I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
 {
-    ident_parser().map_with(|name, e| EnumVariant {
-        name,
-        span: span_from_extra(e),
-    })
+    // Optional tuple payload: `(T1, T2, ...)`. At least one type required
+    // inside the parens; `V()` is not a valid tuple variant.
+    let payload = type_parser()
+        .separated_by(just(TokenKind::Comma))
+        .at_least(1)
+        .allow_trailing()
+        .collect::<Vec<_>>()
+        .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen))
+        .or_not()
+        .map(|opt| opt.unwrap_or_default());
+
+    ident_parser()
+        .then(payload)
+        .map_with(|(name, payload), e| EnumVariant {
+            name,
+            payload,
+            span: span_from_extra(e),
+        })
 }
 
 /// Parser for comma-separated enum variants

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -3,7 +3,7 @@
 //! AstGen converts the Abstract Syntax Tree into RIR instructions.
 //! This is analogous to Zig's AstGen phase.
 
-use lasso::{Spur, ThreadedRodeo};
+use lasso::{Key, Spur, ThreadedRodeo};
 
 /// Known type intrinsics that take a type argument rather than an expression.
 /// These intrinsics operate on types at compile time (e.g., @size_of(i32)).
@@ -183,12 +183,34 @@ impl<'a> AstGen<'a> {
             .collect();
         let (variants_start, variants_len) = self.rir.add_symbols(&variants);
 
+        // Encode tuple-variant payloads (RUE-221) as a self-describing flat
+        // sequence: for each variant, a count `k` followed by `k` payload
+        // type-name symbols. Discriminant-only variants contribute a `0`.
+        // The whole region is omitted (len 0) when no variant carries data.
+        let has_any_payload = enum_decl.variants.iter().any(|v| !v.payload.is_empty());
+        let (payloads_start, payloads_len) = if has_any_payload {
+            let mut payload_words: Vec<u32> = Vec::new();
+            for variant in &enum_decl.variants {
+                payload_words.push(variant.payload.len() as u32);
+                for ty in &variant.payload {
+                    let ty_sym = self.intern_type(ty);
+                    payload_words.push(ty_sym.into_usize() as u32);
+                }
+            }
+            let start = self.rir.add_extra(&payload_words);
+            (start, payload_words.len() as u32)
+        } else {
+            (0, 0)
+        };
+
         self.rir.add_inst(Inst {
             data: InstData::EnumDecl {
                 is_pub: enum_decl.visibility == Visibility::Public,
                 name,
                 variants_start,
                 variants_len,
+                payloads_start,
+                payloads_len,
             },
             span: enum_decl.span,
         })
@@ -835,10 +857,13 @@ impl<'a> AstGen<'a> {
             Pattern::Path(path) => {
                 // If there's a base expression (module reference), generate it first
                 let module = path.base.as_ref().map(|base| self.gen_expr(base));
+                // Payload binding names for a tuple-variant pattern (RUE-221).
+                let bindings: Vec<Spur> = path.bindings.iter().map(|b| b.name).collect();
                 RirPattern::Path {
                     module,
                     type_name: path.type_name.name, // Already a Spur
                     variant: path.variant.name,     // Already a Spur
+                    bindings,
                     span: path.span,
                 }
             }

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -134,6 +134,9 @@ pub enum RirPattern {
         type_name: Spur,
         /// The variant name
         variant: Spur,
+        /// Payload binding names for a tuple-variant pattern `Circle(r)`
+        /// (RUE-221), in payload order. Empty for a discriminant-only pattern.
+        bindings: Vec<Spur>,
         /// Span of the pattern
         span: Span,
     },
@@ -190,7 +193,9 @@ pub enum PatternKind {
 const PATTERN_WILDCARD_SIZE: u32 = 5; // kind, span_start, span_len, span_file, body
 const PATTERN_INT_SIZE: u32 = 8; // kind, span_start, span_len, span_file, value_lo, value_hi, negative, body
 const PATTERN_BOOL_SIZE: u32 = 6; // kind, span_start, span_len, span_file, value, body
-const PATTERN_PATH_SIZE: u32 = 8; // kind, span_start, span_len, span_file, module, type_name, variant, body
+// Path patterns are variable-length (RUE-221): kind, span×3, module,
+// type_name, variant, n_bindings, bindings…, body = 9 + n_bindings words.
+// See `add_match_arms`/`get_match_arms` for the layout.
 
 /// Stored representation of struct field initializer.
 /// Layout: [field_name: u32, value: u32] = 2 u32s per field
@@ -433,6 +438,7 @@ impl Rir {
                     module,
                     type_name,
                     variant,
+                    bindings,
                     span,
                 } => {
                     self.extra.push(PatternKind::Path as u32);
@@ -443,6 +449,12 @@ impl Rir {
                     self.extra.push(module.map_or(u32::MAX, |r| r.as_u32()));
                     self.extra.push(type_name.into_usize() as u32);
                     self.extra.push(variant.into_usize() as u32);
+                    // Variable-length payload bindings (RUE-221): a count
+                    // followed by the binding symbols, then the body last.
+                    self.extra.push(bindings.len() as u32);
+                    for b in bindings {
+                        self.extra.push(b.into_usize() as u32);
+                    }
                     self.extra.push(body.as_u32());
                 }
             }
@@ -509,17 +521,25 @@ impl Rir {
                     };
                     let type_name = Spur::try_from_usize(self.extra[pos + 5] as usize).unwrap();
                     let variant = Spur::try_from_usize(self.extra[pos + 6] as usize).unwrap();
-                    let body = InstRef::from_raw(self.extra[pos + 7]);
+                    // Variable-length payload bindings (RUE-221).
+                    let n_bindings = self.extra[pos + 7] as usize;
+                    let mut bindings = Vec::with_capacity(n_bindings);
+                    for i in 0..n_bindings {
+                        bindings
+                            .push(Spur::try_from_usize(self.extra[pos + 8 + i] as usize).unwrap());
+                    }
+                    let body = InstRef::from_raw(self.extra[pos + 8 + n_bindings]);
                     arms.push((
                         RirPattern::Path {
                             module,
                             type_name,
                             variant,
+                            bindings,
                             span,
                         },
                         body,
                     ));
-                    pos += PATTERN_PATH_SIZE as usize;
+                    pos += 9 + n_bindings;
                 }
                 _ => panic!("Unknown pattern kind: {}", kind),
             }
@@ -978,11 +998,21 @@ impl Rir {
                 name,
                 variants_start,
                 variants_len,
+                payloads_start,
+                payloads_len,
             } => InstData::EnumDecl {
                 is_pub: *is_pub,
                 name: *name,
                 variants_start: *variants_start + extra_offset,
                 variants_len: *variants_len,
+                // Only offset a non-empty payload region; an empty region has
+                // no allocated extra slot, so keep its start at 0.
+                payloads_start: if *payloads_len == 0 {
+                    0
+                } else {
+                    *payloads_start + extra_offset
+                },
+                payloads_len: *payloads_len,
             },
 
             // Array operations
@@ -1183,7 +1213,11 @@ impl Rir {
                             }
                             k if k == PatternKind::Int as u32 => PATTERN_INT_SIZE as usize,
                             k if k == PatternKind::Bool as u32 => PATTERN_BOOL_SIZE as usize,
-                            k if k == PatternKind::Path as u32 => PATTERN_PATH_SIZE as usize,
+                            // Path is variable-length (RUE-221): the payload
+                            // binding count sits at offset 7, so the record is
+                            // 9 + n_bindings words (kind, span×3, module,
+                            // type_name, variant, n, bindings…, body).
+                            k if k == PatternKind::Path as u32 => 9 + extra[pos + 7] as usize,
                             _ => panic!("Unknown pattern kind during merge: {}", kind),
                         };
                         // Path patterns also embed a module InstRef at offset 4
@@ -1567,6 +1601,15 @@ pub enum InstData {
         variants_start: u32,
         /// Number of variants
         variants_len: u32,
+        /// Index into extra data where the tuple-variant payloads start
+        /// (RUE-221). The region is a self-describing flat sequence: for each
+        /// variant in declaration order, a count `k` followed by `k`
+        /// type-name symbols (as `Spur`s). A count of 0 means a
+        /// discriminant-only variant. `payloads_len` is the total number of
+        /// u32 words in the region (0 when no variant carries a payload).
+        payloads_start: u32,
+        /// Number of u32 words in the payloads region.
+        payloads_len: u32,
     },
 
     /// Enum variant: creates a value of an enum type
@@ -1734,6 +1777,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 module,
                 type_name,
                 variant,
+                bindings,
                 ..
             } => {
                 let prefix = if let Some(module_ref) = module {
@@ -1741,12 +1785,19 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 } else {
                     String::new()
                 };
-                format!(
+                let base = format!(
                     "{}{}::{}",
                     prefix,
                     self.interner.resolve(&*type_name),
                     self.interner.resolve(&*variant)
-                )
+                );
+                if bindings.is_empty() {
+                    base
+                } else {
+                    let names: Vec<&str> =
+                        bindings.iter().map(|b| self.interner.resolve(b)).collect();
+                    format!("{}({})", base, names.join(", "))
+                }
             }
         }
     }
@@ -2061,13 +2112,31 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     name,
                     variants_start,
                     variants_len,
+                    payloads_start,
+                    payloads_len,
                 } => {
                     let pub_str = if *is_pub { "pub " } else { "" };
                     let name_str = self.interner.resolve(&*name);
                     let variants = self.rir.get_symbols(*variants_start, *variants_len);
+                    // Decode payloads (self-describing [k, t0..t_{k-1}] per variant).
+                    let payload_words = self.rir.get_extra(*payloads_start, *payloads_len);
+                    let mut payload_arities: Vec<usize> = Vec::new();
+                    let mut pi = 0usize;
+                    while pi < payload_words.len() {
+                        let k = payload_words[pi] as usize;
+                        payload_arities.push(k);
+                        pi += 1 + k;
+                    }
                     let variants_str: Vec<String> = variants
                         .iter()
-                        .map(|v| self.interner.resolve(&*v).to_string())
+                        .enumerate()
+                        .map(|(i, v)| {
+                            let base = self.interner.resolve(&*v).to_string();
+                            match payload_arities.get(i) {
+                                Some(k) if *k > 0 => format!("{}/{}", base, k),
+                                _ => base,
+                            }
+                        })
                         .collect();
                     writeln!(
                         out,
@@ -2332,6 +2401,7 @@ mod tests {
             module: None,
             type_name,
             variant,
+            bindings: Vec::new(),
             span,
         };
         assert_eq!(pattern.span(), span);
@@ -3261,6 +3331,8 @@ mod tests {
                 name,
                 variants_start,
                 variants_len,
+                payloads_start: 0,
+                payloads_len: 0,
             },
             span: Span::new(0, 35),
         });
@@ -3741,6 +3813,7 @@ mod tests {
                     module: None,
                     type_name: color,
                     variant: red,
+                    bindings: Vec::new(),
                     span: Span::new(0, 10),
                 },
                 body_red,
@@ -3750,6 +3823,7 @@ mod tests {
                     module: None,
                     type_name: color,
                     variant: green,
+                    bindings: Vec::new(),
                     span: Span::new(0, 12),
                 },
                 body_green,
@@ -4054,6 +4128,7 @@ mod tests {
                     module: Some(module),
                     type_name,
                     variant,
+                    bindings: Vec::new(),
                     span: Span::new(10, 13),
                 },
                 body1,
@@ -4127,6 +4202,7 @@ mod tests {
                 module: None,
                 type_name,
                 variant,
+                bindings: Vec::new(),
                 span: Span::new(10, 13),
             },
             body,

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -928,3 +928,56 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "parentheses"
+
+# =============================================================================
+# Patterns with Payload Bindings (RUE-221, ADR-0038)
+# =============================================================================
+
+# A tuple-variant pattern binds the payload; the arity must match (4.7:30).
+[[case]]
+name = "match_payload_binding_extracts"
+spec = ["4.7:30"]
+preview = "enum_payloads"
+source = """
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+fn main() -> i32 {
+    match Shape::Rect(3, 4) {
+        Shape::Circle(r) => r,
+        Shape::Rect(w, h) => w + h,
+        Shape::Empty => 0,
+    }
+}
+"""
+exit_code = 7
+
+# Bindings move the payload out in value context and are usable in the arm
+# body (4.7:31).
+[[case]]
+name = "match_payload_binding_move_mode"
+spec = ["4.7:31"]
+preview = "enum_payloads"
+source = """
+enum Wrap { One(i32) }
+fn main() -> i32 {
+    let w = Wrap::One(10);
+    match w {
+        Wrap::One(x) => x + x,
+    }
+}
+"""
+exit_code = 20
+
+# Wrong number of bindings for a variant's payload arity is rejected (4.7:30).
+[[case]]
+name = "match_payload_binding_wrong_arity"
+spec = ["4.7:30"]
+preview = "enum_payloads"
+source = """
+enum Shape { Rect(i32, i32) }
+fn main() -> i32 {
+    match Shape::Rect(3, 4) {
+        Shape::Rect(w) => w,
+    }
+}
+"""
+compile_fail = true

--- a/crates/rue-spec/cases/items/enums.toml
+++ b/crates/rue-spec/cases/items/enums.toml
@@ -255,3 +255,130 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Variant Payloads (RUE-221, ADR-0038) — enum_payloads preview feature
+# =============================================================================
+
+# A payload-carrying variant requires the preview feature.
+[[case]]
+name = "enum_payload_requires_preview"
+spec = ["6.3:14"]
+source = """
+enum Shape { Circle(i32), Empty }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "requires preview feature"
+
+# Declaring and constructing tuple variants (grammar 6.3:2, payloads 6.3:13).
+[[case]]
+name = "enum_payload_declare_construct"
+spec = ["6.3:2", "6.3:13"]
+preview = "enum_payloads"
+source = """
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+fn main() -> i32 {
+    let a = Shape::Circle(5);
+    let b = Shape::Rect(3, 4);
+    let c = Shape::Empty;
+    0
+}
+"""
+exit_code = 0
+
+# Construction + tagged-union layout + match extraction: Circle(5) -> 5.
+[[case]]
+name = "enum_payload_match_circle"
+spec = ["6.3:15", "6.3:16"]
+preview = "enum_payloads"
+source = """
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+fn area(s: Shape) -> i32 {
+    match s {
+        Shape::Circle(r) => r,
+        Shape::Rect(w, h) => w + h,
+        Shape::Empty => 0,
+    }
+}
+fn main() -> i32 { area(Shape::Circle(5)) }
+"""
+exit_code = 5
+
+# Multi-field payload: Rect(3, 4) -> 7 (largest-variant layout).
+[[case]]
+name = "enum_payload_match_rect"
+spec = ["6.3:15", "6.3:16"]
+preview = "enum_payloads"
+source = """
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+fn area(s: Shape) -> i32 {
+    match s {
+        Shape::Circle(r) => r,
+        Shape::Rect(w, h) => w + h,
+        Shape::Empty => 0,
+    }
+}
+fn main() -> i32 { area(Shape::Rect(3, 4)) }
+"""
+exit_code = 7
+
+# Discriminant-only variant of a sum type: Empty -> 0.
+[[case]]
+name = "enum_payload_match_empty"
+spec = ["6.3:16"]
+preview = "enum_payloads"
+source = """
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+fn area(s: Shape) -> i32 {
+    match s {
+        Shape::Circle(r) => r,
+        Shape::Rect(w, h) => w + h,
+        Shape::Empty => 0,
+    }
+}
+fn main() -> i32 { area(Shape::Empty) }
+"""
+exit_code = 0
+
+# Wrong payload arity is rejected.
+[[case]]
+name = "enum_payload_wrong_arity"
+spec = ["6.3:16"]
+preview = "enum_payloads"
+source = """
+enum Shape { Rect(i32, i32) }
+fn main() -> i32 { let r = Shape::Rect(3); 0 }
+"""
+compile_fail = true
+
+# A payload-carrying variant used as a bare path is an error.
+[[case]]
+name = "enum_payload_bare_path_error"
+spec = ["6.3:16"]
+preview = "enum_payloads"
+source = """
+enum Shape { Circle(i32) }
+fn main() -> i32 { let c = Shape::Circle; 0 }
+"""
+compile_fail = true
+
+# A payload with a destructor, moved out by a match binding, is dropped
+# exactly once when the binding leaves scope (6.3:17).
+[[case]]
+name = "enum_payload_drop_once_via_match"
+spec = ["6.3:17"]
+preview = "enum_payloads"
+source = """
+struct Res { id: i32 }
+drop fn Res(self) { @dbg(self.id); }
+enum Holder { Full(Res), Nothing }
+fn main() -> i32 {
+    let h = Holder::Full(Res { id: 7 });
+    match h {
+        Holder::Full(r) => r.id,
+        Holder::Nothing => 0,
+    }
+}
+"""
+exit_code = 7

--- a/docs/spec/src/04-expressions/07-match-expressions.md
+++ b/docs/spec/src/04-expressions/07-match-expressions.md
@@ -220,3 +220,35 @@ fn absurd(n: Never) -> i32 {
     match n {}  // legal: zero arms cover the zero values of `Never`
 }
 ```
+
+## Patterns with Payload Bindings
+
+{{ rule(id="4.7:30", cat="normative") }}
+
+A tuple-variant pattern binds the variant's payload into fresh names:
+`EnumName::Variant(a, b)` matches a value of that variant and binds `a`, `b`
+to its payload fields in order. The number of bindings **MUST** equal the
+variant's payload arity. Payload bindings require the `enum_payloads` preview
+feature (see spec 6.3).
+
+{{ rule(id="4.7:31", cat="normative") }}
+
+Payload bindings inherit the scrutinee's access mode (ADR-0037/ADR-0038). A
+bare `match e` uses the scrutinee in value context: the matched arm's bindings
+**move** the payload out of the enum (or copy it, if the payload type is
+`Copy`). Each binding is in scope for its arm's body and shadows any outer
+binding of the same name.
+
+{{ rule(id="4.7:32") }}
+
+```rue
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+
+fn main() -> i32 {
+    match Shape::Rect(3, 4) {
+        Shape::Circle(r) => r,
+        Shape::Rect(w, h) => w + h,
+        Shape::Empty => 0,
+    }
+}
+```

--- a/docs/spec/src/06-items/03-enums.md
+++ b/docs/spec/src/06-items/03-enums.md
@@ -14,7 +14,8 @@ An enum is defined using the `enum` keyword.
 
 ```ebnf
 enum_def = "enum" IDENT "{" [ enum_variants ] "}" ;
-enum_variants = IDENT { "," IDENT } [ "," ] ;
+enum_variants = enum_variant { "," enum_variant } [ "," ] ;
+enum_variant = IDENT [ "(" type { "," type } [ "," ] ")" ] ;
 ```
 
 ## Enum Definition
@@ -96,5 +97,73 @@ fn get_value(c: Color) -> i32 {
         Color::Green => 2,
         Color::Blue => 3,
     }
+}
+```
+
+## Variant Payloads
+
+{{ rule(id="6.3:13", cat="normative") }}
+
+A variant **MAY** carry data as a **tuple variant** — a parenthesized,
+comma-separated list of one or more payload field types written after the
+variant name (`Circle(i32)`, `Rect(i32, i32)`). A variant without a payload
+list is a discriminant-only variant, as before. An enum in which at least one
+variant carries a payload is a *sum type*.
+
+{{ rule(id="6.3:14", cat="normative") }}
+
+Tuple-variant payloads are a preview feature: an enum declaration containing a
+payload-carrying variant requires the `enum_payloads` preview feature to be
+enabled (ADR-0038). Discriminant-only enums remain available without any
+preview feature.
+
+{{ rule(id="6.3:15", cat="normative") }}
+
+The representation of an enum is a **tagged union**: a discriminant that
+selects the active variant, together with payload storage sized to accommodate
+the largest variant's payload. The exact layout is **implementation-defined**
+(see spec 1.3), so niche optimizations are permitted without a change to this
+specification.
+
+{{ rule(id="6.3:16", cat="normative") }}
+
+A tuple variant is constructed by applying the variant path to payload
+arguments: `EnumName::Variant(arg, ...)`. The number of arguments **MUST**
+equal the variant's payload arity, and each argument's type **MUST** match the
+corresponding declared payload type. Using a payload-carrying variant as a
+bare path (`EnumName::Variant`, with no arguments) is an error.
+
+{{ rule(id="6.3:17", cat="normative") }}
+
+Binding a variant's payload in a `match` arm (see spec 4.7) moves the payload
+out of the enum value in move mode; a moved-out payload that has a destructor
+runs that destructor exactly once, when its binding leaves scope.
+
+{{ rule(id="6.3:19") }}
+
+The intended full model is that an enum's multiplicity is the join of its
+variants' payload multiplicities — an enum a variant of which carries a linear
+payload is itself linear and must be consumed — and that dropping an enum value
+without consuming it drops the payload of its **active** variant (the one
+selected by the discriminant). Multiplicity infectiousness and implicit
+active-variant drop glue are a follow-up phase of the `enum_payloads` preview
+feature (RUE-221); until then, implicitly dropping an unconsumed
+payload-carrying enum leaks (but never double-drops) its payload.
+
+{{ rule(id="6.3:18") }}
+
+```rue
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+
+fn area(s: Shape) -> i32 {
+    match s {
+        Shape::Circle(r) => r,
+        Shape::Rect(w, h) => w + h,
+        Shape::Empty => 0,
+    }
+}
+
+fn main() -> i32 {
+    area(Shape::Rect(3, 4))
 }
 ```


### PR DESCRIPTION
The prerequisite for Option/Result (RUE-6, ADR-0038). Gated behind `--preview enum_payloads`.

**Core delivered** (verified by execution, both backends):
- **Tuple variants**: `enum Shape { Circle(i32), Rect(i32,i32), Empty }`.
- **Construction** `Shape::Circle(5)`; **tagged-union layout** (discriminant + payload sized to the largest variant), routed through the aggregate-slot machinery — enums had been excluded from the `Struct|Array` codegen gates (fixed via a new `is_multislot_aggregate` helper + the three layout fns that hardcoded enum=1-slot).
- **match with qualified payload-binding patterns** (move mode): `match s { Shape::Circle(r) => r, Shape::Rect(w,h) => w+h, Shape::Empty => 0 }`. Exhaustiveness extends to payload variants.
- A struct payload with a `drop fn`, moved out via a match binding, **drops exactly once**.

Verified: `area(Circle(5))+area(Rect(3,4))+area(Empty)` = 12; drop-once prints `7`; exhaustiveness error; preview-gate error. Full `./test.sh` green (623/623 normative); spec 6.3 + 4.7; 11 spec + 3 CLI cases. Also hardened the rue-oracle `EnumPayloadGet` arm to return Unsupported (clean differential-skip) rather than a guessed 0.

**Follow-ups** (tracked; safe interim = leaks not UB): implicit active-variant drop glue, linear/multiplicity infectiousness, struct variants, borrow/inout match modes, proper oracle modeling.

Part of RUE-221

🤖 Generated with [Claude Code](https://claude.com/claude-code)