### PR TITLE
Fix three array/borrow/const soundness holes (RUE-232, RUE-233, RUE-234)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1140,7 +1140,7 @@ impl<'a> ConstraintGenerator<'a> {
             }
 
             // Infinite loop
-            InstData::InfiniteLoop { body } => {
+            InstData::InfiniteLoop { body, .. } => {
                 ctx.loop_depth += 1;
                 ctx.loop_break_stack.push(false);
                 self.generate(*body, ctx);
@@ -2426,7 +2426,10 @@ mod tests {
             span: Span::new(6, 7),
         });
         let loop_inst = rir.add_inst(rue_rir::Inst {
-            data: InstData::InfiniteLoop { body },
+            data: InstData::InfiniteLoop {
+                body,
+                iter_borrow: None,
+            },
             span: Span::new(0, 10),
         });
 

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1746,6 +1746,7 @@ impl<'a> Sema<'a> {
             referenced_methods: HashSet::new(),
             byref_arg_root: None,
             in_loop_move_recheck: false,
+            iter_borrows: Vec::new(),
         };
 
         // ======================================================================
@@ -2274,8 +2275,10 @@ impl<'a> Sema<'a> {
 
             let array_length = length;
 
-            // Compile-time bounds check for constant indices
-            if let Some(const_index) = self.try_get_const_index(*index) {
+            // Compile-time bounds check for constant indices, evaluated at the
+            // index's resolved operand types so an overflowing index expression
+            // is a compile-time error, not a folded runtime panic (RUE-234).
+            if let Some(const_index) = self.try_get_const_index_checked(*index, ctx)? {
                 if const_index < 0 || const_index as u64 >= array_length {
                     return Err(CompileError::new(
                         ErrorKind::IndexOutOfBounds {
@@ -2691,6 +2694,11 @@ impl<'a> Sema<'a> {
                 }
             }
 
+            // Writing through a field of a collection an enclosing `for` loop
+            // is iterating mutates a shared-borrowed value (spec 4.8:26,
+            // RUE-233) — E0428, like an explicit `borrow` parameter.
+            self.reject_mutate_iter_borrowed(trace.root_var, span, ctx)?;
+
             // Check mutability
             let root_name = self.interner.resolve(&trace.root_var).to_string();
             if !trace.is_root_mutable {
@@ -2840,6 +2848,11 @@ impl<'a> Sema<'a> {
                 }
             }
 
+            // Writing an element of a collection an enclosing `for` loop is
+            // iterating mutates a shared-borrowed value (spec 4.8:26,
+            // RUE-233) — E0428, like an explicit `borrow` parameter.
+            self.reject_mutate_iter_borrowed(trace.root_var, span, ctx)?;
+
             // Check mutability
             let root_name = self.interner.resolve(&trace.root_var).to_string();
             if !trace.is_root_mutable {
@@ -2907,8 +2920,10 @@ impl<'a> Sema<'a> {
                 ));
             }
 
-            // Compile-time bounds check for constant indices
-            if let Some(const_index) = self.try_get_const_index(index) {
+            // Compile-time bounds check for constant indices, evaluated at the
+            // index's resolved operand types so an overflowing index expression
+            // is a compile-time error, not a folded runtime panic (RUE-234).
+            if let Some(const_index) = self.try_get_const_index_checked(index, ctx)? {
                 if const_index < 0 || const_index as u64 >= array_len {
                     return Err(CompileError::new(
                         ErrorKind::IndexOutOfBounds {
@@ -5608,6 +5623,28 @@ impl<'a> Sema<'a> {
             return local.is_mut;
         }
         false
+    }
+
+    /// Reject a mutation of a collection that an enclosing `for` loop is
+    /// iterating (spec 4.8:26, RUE-233). A `for` over a named variable holds a
+    /// scoped shared borrow of it for the loop's duration, so mutating that
+    /// place inside the body — whole-variable, field, or element — is E0428,
+    /// exactly like mutating through an explicit `borrow` parameter.
+    pub(crate) fn reject_mutate_iter_borrowed(
+        &self,
+        root_var: Spur,
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<()> {
+        if ctx.iter_borrows.contains(&root_var) {
+            return Err(CompileError::new(
+                ErrorKind::MutateBorrowedValue {
+                    variable: self.interner.resolve(&root_var).to_string(),
+                },
+                span,
+            ));
+        }
+        Ok(())
     }
 
     /// Check exclusivity rules for inout and borrow parameters in a call

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -594,8 +594,8 @@ impl<'a> Sema<'a> {
                 self.analyze_while_loop(air, *cond, *body, inst.span, ctx)
             }
 
-            InstData::InfiniteLoop { body } => {
-                self.analyze_infinite_loop(air, *body, inst.span, ctx)
+            InstData::InfiniteLoop { body, iter_borrow } => {
+                self.analyze_infinite_loop(air, *body, *iter_borrow, inst.span, ctx)
             }
 
             InstData::Match {
@@ -929,6 +929,7 @@ impl<'a> Sema<'a> {
         &mut self,
         air: &mut Air,
         body: InstRef,
+        iter_borrow: Option<Spur>,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
@@ -942,7 +943,16 @@ impl<'a> Sema<'a> {
         ctx.push_scope();
         ctx.loop_depth += 1;
         ctx.loop_break_stack.push(false);
+        // A `for` over a named variable borrows it (shared) for the body's
+        // duration (spec 4.8:26, RUE-233): record the borrow so a mutation of
+        // the iterated collection inside the body is rejected (E0428).
+        if let Some(var) = iter_borrow {
+            ctx.iter_borrows.push(var);
+        }
         let body_result = self.analyze_inst(air, body, ctx)?;
+        if iter_borrow.is_some() {
+            ctx.iter_borrows.pop();
+        }
         let has_break = ctx.loop_break_stack.pop().unwrap_or(false);
         ctx.loop_depth -= 1;
         ctx.pop_scope();
@@ -961,8 +971,14 @@ impl<'a> Sema<'a> {
             scratch_ctx.push_scope();
             scratch_ctx.loop_depth += 1;
             scratch_ctx.loop_break_stack.push(false);
+            if let Some(var) = iter_borrow {
+                scratch_ctx.iter_borrows.push(var);
+            }
             self.analyze_inst(&mut scratch_air, body, &mut scratch_ctx)
                 .map_err(|e| e.with_note("value was moved in a previous iteration of the loop"))?;
+            if iter_borrow.is_some() {
+                scratch_ctx.iter_borrows.pop();
+            }
             scratch_ctx.loop_break_stack.pop();
             scratch_ctx.loop_depth -= 1;
             scratch_ctx.pop_scope();
@@ -2375,6 +2391,18 @@ impl<'a> Sema<'a> {
     ) -> CompileResult<AnalysisResult> {
         let name_str = self.interner.resolve(&name);
 
+        // Reassigning a collection that an enclosing `for` loop is iterating
+        // mutates a shared-borrowed value (spec 4.8:26, RUE-233) — E0428, just
+        // like assigning through an explicit `borrow` parameter.
+        if ctx.iter_borrows.contains(&name) {
+            return Err(CompileError::new(
+                ErrorKind::MutateBorrowedValue {
+                    variable: name_str.to_string(),
+                },
+                span,
+            ));
+        }
+
         // First check if it's a parameter (for inout params)
         if let Some(param_info) = ctx.params.iter().find(|p| p.name == name) {
             // Check parameter mode - only inout can be assigned to
@@ -3494,6 +3522,31 @@ impl<'a> Sema<'a> {
         if let Some(trace) = self.try_trace_place(inst_ref, air, ctx)? {
             let elem_type = trace.result_type();
 
+            // Reading through an index expression whose base place has been
+            // moved is a use-after-move (RUE-232), exactly like a field read
+            // of a moved place. A plain (Copy-element, non-byref) index read
+            // reached neither move check below — the byref branch checks its
+            // own path and the non-Copy branch records an element move — so
+            // `moved.field[i]` after `let b = moved` slipped through. Check the
+            // base place's move state here for every index read. `field_path()`
+            // stops at the last index projection, so this catches a full move
+            // of the root (or a moved field prefix) without falsely flagging a
+            // previously moved-out *element* (those use a longer index path).
+            {
+                let field_path = trace.field_path();
+                if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
+                    if let Some(moved_span) = state.is_path_moved(&field_path) {
+                        return Err(super::analysis::use_after_move_path_error(
+                            self.interner,
+                            trace.root_var,
+                            &field_path,
+                            span,
+                            moved_span,
+                        ));
+                    }
+                }
+            }
+
             // Get array info from the parent type (before the last projection)
             let parent_type = if trace.projections.len() > 1 {
                 trace.projections[trace.projections.len() - 2].result_type
@@ -3517,8 +3570,11 @@ impl<'a> Sema<'a> {
                 }
             };
 
-            // Check for constant out-of-bounds index
-            if let Some(const_idx) = self.try_get_const_index(index) {
+            // Check for constant out-of-bounds index. Evaluate at the index's
+            // resolved operand types so an expression that overflows its own
+            // integer type (`arr[X + 1]`, X: i8 = 127) is a compile-time error
+            // rather than a folded-then-bounds-checked value (RUE-234).
+            if let Some(const_idx) = self.try_get_const_index_checked(index, ctx)? {
                 if const_idx < 0 || const_idx as u64 >= array_len {
                     return Err(CompileError::new(
                         ErrorKind::IndexOutOfBounds {
@@ -3642,8 +3698,10 @@ impl<'a> Sema<'a> {
             }
         };
 
-        // Check for constant out-of-bounds index
-        if let Some(const_idx) = self.try_get_const_index(index) {
+        // Check for constant out-of-bounds index (at the index's resolved
+        // operand types, so an overflowing index expression is a compile-time
+        // error rather than a folded runtime panic — RUE-234).
+        if let Some(const_idx) = self.try_get_const_index_checked(index, ctx)? {
             if const_idx < 0 || const_idx as u64 >= array_len {
                 return Err(CompileError::new(
                     ErrorKind::IndexOutOfBounds {

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -221,6 +221,34 @@ impl Sema<'_> {
         self.try_evaluate_const(inst_ref)?.as_integer()
     }
 
+    /// Like [`try_get_const_index`], but evaluated inside the function being
+    /// analyzed, so the index is checked at its HM-resolved operand types.
+    ///
+    /// The type-unaware [`try_get_const_index`] folds `arr[X + 1]` as raw
+    /// `i128` and only the array-length bound is checked — so `X + 1` where
+    /// `X: i8 = 127` folds to `128`, fits a length-129 array, and the operand
+    /// overflow is silently deferred to a runtime panic (RUE-234). Threading
+    /// the resolved operand types (as [`try_evaluate_const_in_fn`] does)
+    /// surfaces that overflow as a compile-time E1200/E0800 — the same check
+    /// the const-initializer path gets (RUE-230) — *before* the length bound is
+    /// consulted. Returns:
+    /// - `Ok(Some(i))` — a compile-time-known, in-operand-type index `i`;
+    /// - `Ok(None)`    — not a compile-time constant (runtime index);
+    /// - `Err(..)`     — the index expression overflows at its operand type.
+    ///
+    /// [`try_get_const_index`]: Sema::try_get_const_index
+    /// [`try_evaluate_const_in_fn`]: Sema::try_evaluate_const_in_fn
+    pub(crate) fn try_get_const_index_checked(
+        &mut self,
+        inst_ref: InstRef,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<Option<i64>> {
+        let mut env = ComptimeEnv::for_analysis(ctx);
+        Ok(self
+            .eval_const_expr(inst_ref, &mut env)?
+            .and_then(|v| v.as_integer()))
+    }
+
     /// Check if an RIR instruction is a direct reference to a `comptime`
     /// parameter of the function currently being analyzed.
     ///
@@ -885,7 +913,7 @@ impl Sema<'_> {
                     self.walk_comptime_type_locals(else_block, discovered, eval_types, eval_values);
                 }
             }
-            InstData::Loop { body, .. } | InstData::InfiniteLoop { body } => {
+            InstData::Loop { body, .. } | InstData::InfiniteLoop { body, .. } => {
                 let body = *body;
                 self.walk_comptime_type_locals(body, discovered, eval_types, eval_values);
             }

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -361,6 +361,14 @@ pub(crate) struct AnalysisContext<'a> {
     /// performs, so nested loops analyzed within it don't need (and must not
     /// trigger) their own recheck — that would make nested loops exponential.
     pub in_loop_move_recheck: bool,
+    /// Collection variables currently held as a scoped shared borrow by an
+    /// enclosing `for` loop (innermost last), spec 4.8:26 / RUE-233. While a
+    /// name is here, any mutation of it in the loop body — whole-variable
+    /// assignment (`a = …`), field set (`a.f = …`), or element set
+    /// (`a[i] = …`) — is rejected with E0428 (`MutateBorrowedValue`), matching
+    /// the treatment of an explicit `borrow` parameter. Reads (including the
+    /// loop's own element reads) are permitted.
+    pub iter_borrows: Vec<Spur>,
 }
 
 // Import InstRef for use in resolved_types
@@ -436,6 +444,7 @@ impl<'a> AnalysisContext<'a> {
             // analyses.
             byref_arg_root: None,
             in_loop_move_recheck: true,
+            iter_borrows: self.iter_borrows.clone(),
         }
     }
 

--- a/crates/rue-cli-tests/cases/array_index_operand_overflow.toml
+++ b/crates/rue-cli-tests/cases/array_index_operand_overflow.toml
@@ -1,0 +1,65 @@
+# Constant array-index evaluation ignored the operand integer width (RUE-234),
+# the same const-eval-type-unaware class as RUE-230 at a different site. The
+# array-index folder used the type-unaware `try_get_const_index` (raw i128, no
+# resolved types), so an index expression that overflows its own integer type
+# was accepted at compile time and deferred to a runtime panic — while the same
+# expression in a plain const initializer was caught (E0800/E1200). The folder
+# now evaluates the index at its HM-resolved operand types (mirroring the
+# RUE-230 fix), so an operand overflow is a compile-time error *before* the
+# array-length bound is consulted.
+
+[section]
+id = "cli.array_index_operand_overflow"
+name = "Array-index operand overflow"
+description = "An index expression overflowing its operand type is a compile-time error (RUE-234)."
+
+[[case]]
+name = "i8_index_operand_overflow_is_compile_error"
+description = "RUE-234: `arr[X + 1]` with `X: i8 = 127` overflows i8 (128) at the operand type; a compile-time E1200, caught during folding before the length bound (before the fix this folded to 128 and was deferred to a runtime panic)."
+compile_fail = true
+error_contains = ["E1200", "i8"]
+files = [{ path = "main.rue", source = """
+const X: i8 = 127;
+fn main() -> i32 {
+    let arr: [i32; 3] = [1, 2, 3];
+    arr[X + 1]
+}
+""" }]
+
+[[case]]
+name = "u8_index_operand_overflow_not_bogus_bounds"
+description = "RUE-234: `arr[IDX + 1]` with `IDX: u8 = 255` reports the u8 operand overflow (256 does not fit u8), not a bogus `index is 256` bounds error."
+compile_fail = true
+error_contains = ["E1200", "u8"]
+files = [{ path = "main.rue", source = """
+const IDX: u8 = 255;
+fn main() -> i32 {
+    let arr: [i32; 3] = [1, 2, 3];
+    arr[IDX + 1]
+}
+""" }]
+
+[[case]]
+name = "valid_index_expr_still_folds_and_bounds_checks"
+description = "Control: `arr[X + 1]` with in-range `X: i8 = 5` still folds to 6 and reads the element (returns 6)."
+files = [{ path = "main.rue", source = """
+const X: i8 = 5;
+fn main() -> i32 {
+    let arr: [i32; 10] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
+    arr[X + 1]
+}
+""" }]
+exit_code = 6
+
+[[case]]
+name = "in_type_index_still_out_of_bounds_reports_bounds"
+description = "Control: an in-type but out-of-bounds constant index still reports the length/index bounds error (E0902)."
+compile_fail = true
+error_contains = ["E0902"]
+files = [{ path = "main.rue", source = """
+const X: i32 = 20;
+fn main() -> i32 {
+    let arr: [i32; 3] = [1, 2, 3];
+    arr[X + 1]
+}
+""" }]

--- a/crates/rue-cli-tests/cases/for_loop_iter_borrow.toml
+++ b/crates/rue-cli-tests/cases/for_loop_iter_borrow.toml
@@ -1,0 +1,84 @@
+# A `for` loop over a named variable holds a scoped shared borrow of the
+# collection for the loop's duration (spec 4.8:26, RUE-233). Mutating the
+# iterated collection inside the body used to be silently accepted and affected
+# later iterations (`for x in a { a[2] = 100; }` exited 103, not 6). The
+# implicit borrow now participates in exclusivity checking: mutating the
+# iterated place — element (`a[i]=`), whole variable (`a=`), or field — inside
+# the body is E0428 (`MutateBorrowedValue`), just like an explicit `borrow`
+# parameter. Iterating a different collection, and read-only iteration, still
+# compile.
+
+[section]
+id = "cli.for_loop_iter_borrow"
+name = "For-loop iterable borrow-check"
+description = "Mutating the iterated collection inside a `for` body is E0428 (RUE-233)."
+
+[[case]]
+name = "mutate_iterated_element_is_e0428"
+description = "RUE-233: `a[2] = 100` inside `for x in a` mutates a shared-borrowed collection (E0428)."
+args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0428"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut a: [i32; 3] = [1, 2, 3];
+    let mut sum = 0;
+    for x in a {
+        sum = sum + x;
+        a[2] = 100;
+    }
+    sum
+}
+""" }]
+
+[[case]]
+name = "reassign_iterated_array_is_e0428"
+description = "RUE-233: whole-array reassign `a = [7,8,9]` inside `for x in a` is E0428."
+args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0428"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut a: [i32; 3] = [1, 2, 3];
+    let mut sum = 0;
+    for x in a {
+        sum = sum + x;
+        a = [7, 8, 9];
+    }
+    sum
+}
+""" }]
+
+[[case]]
+name = "mutate_different_array_is_fine"
+description = "Control: iterating `b` while mutating a DIFFERENT array `a` compiles and runs (60 + 100)."
+args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut a: [i32; 3] = [1, 2, 3];
+    let b: [i32; 3] = [10, 20, 30];
+    let mut sum = 0;
+    for x in b {
+        sum = sum + x;
+        a[0] = 100;
+    }
+    sum + a[0]
+}
+""" }]
+exit_code = 160
+
+[[case]]
+name = "read_only_for_loop_still_works"
+description = "Control: a read-only `for x in a` still compiles and sums correctly (1+2+3 = 6)."
+args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: [i32; 3] = [1, 2, 3];
+    let mut sum = 0;
+    for x in a {
+        sum = sum + x;
+    }
+    sum
+}
+""" }]
+exit_code = 6

--- a/crates/rue-cli-tests/cases/move_index_expr_use.toml
+++ b/crates/rue-cli-tests/cases/move_index_expr_use.toml
@@ -1,0 +1,70 @@
+# Use-after-move through an index expression on a moved base (RUE-232).
+#
+# The move-checker rejected scalar-field use (`a.v`), base-field access
+# (`let d = a.data`), and whole-value re-use (`let c = a`) after `let b = a`
+# moved `a`, but SKIPPED an *index-expression* use `moved.field[i]`: a plain
+# (Copy-element, non-by-ref) index read reached neither of the two move checks
+# in `analyze_index_get_impl` (the by-ref branch checks its own path; the
+# non-Copy branch records an element move). So `a.data[0]` after the move
+# compiled and ran to a garbage exit instead of E0205. The fix checks the base
+# place's move state for every index read.
+
+[section]
+id = "cli.move_index_expr_use"
+name = "Use-after-move via index expression"
+description = "`moved.field[i]` after a move is E0205 (RUE-232); non-moved index reads still work."
+
+[[case]]
+name = "index_expr_on_moved_struct_is_e0205"
+description = "RUE-232: reading `a.data[0]` after `let b = a` moved `a` is a use-after-move (E0205)."
+compile_fail = true
+error_contains = ["E0205"]
+files = [{ path = "main.rue", source = """
+struct C { data: [i32; 2] }
+fn main() -> i32 {
+    let a = C { data: [1, 2] };
+    let b = a;
+    a.data[0]
+}
+""" }]
+
+[[case]]
+name = "index_expr_on_second_array_field_is_e0205"
+description = "RUE-232: `x.b[1]` after `let y = x` moved `x` is E0205 (second array field, still caught)."
+compile_fail = true
+error_contains = ["E0205"]
+files = [{ path = "main.rue", source = """
+struct C { a: [i32; 2], b: [i32; 2] }
+fn main() -> i32 {
+    let x = C { a: [1, 2], b: [3, 4] };
+    let y = x;
+    x.b[1]
+}
+""" }]
+
+[[case]]
+name = "non_moved_index_read_still_works"
+description = "Control: an index read of a NON-moved struct array field compiles and returns 1."
+files = [{ path = "main.rue", source = """
+struct C { data: [i32; 2] }
+fn main() -> i32 {
+    let a = C { data: [1, 2] };
+    a.data[0]
+}
+""" }]
+exit_code = 1
+
+[[case]]
+name = "base_field_access_after_move_still_e0205_control"
+description = "Control: base-field access (`let d = a.data`) after the move stays E0205 (unchanged path)."
+compile_fail = true
+error_contains = ["E0205"]
+files = [{ path = "main.rue", source = """
+struct C { data: [i32; 2] }
+fn main() -> i32 {
+    let a = C { data: [1, 2] };
+    let b = a;
+    let d = a.data;
+    d[0]
+}
+""" }]

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -508,7 +508,10 @@ impl<'a> AstGen<'a> {
             Expr::Loop(loop_expr) => {
                 let body = self.gen_block(&loop_expr.body);
                 self.rir.add_inst(Inst {
-                    data: InstData::InfiniteLoop { body },
+                    data: InstData::InfiniteLoop {
+                        body,
+                        iter_borrow: None,
+                    },
                     span: loop_expr.span,
                 })
             }
@@ -949,6 +952,7 @@ impl<'a> AstGen<'a> {
         // Collection reference. A bare variable is referenced directly so the
         // loop's non-consuming reads leave it usable afterward (a scoped
         // borrow); any other expression is a temporary bound once.
+        let coll_is_var = matches!(coll_expr, Expr::Ident(_));
         let coll_name: Spur = if let Expr::Ident(id) = coll_expr {
             id.name
         } else {
@@ -1163,8 +1167,16 @@ impl<'a> AstGen<'a> {
             span,
         });
 
+        // A `for` over a named variable holds a scoped shared borrow of that
+        // variable for the loop's duration (spec 4.8:26): sema rejects any
+        // mutation of it in the body (RUE-233). A `for` over a temporary binds
+        // an unnameable local, so there is nothing to borrow-check.
+        let iter_borrow = if coll_is_var { Some(coll_name) } else { None };
         let infinite_loop = self.rir.add_inst(Inst {
-            data: InstData::InfiniteLoop { body: loop_body },
+            data: InstData::InfiniteLoop {
+                body: loop_body,
+                iter_borrow,
+            },
             span,
         });
         outer_stmts.push(infinite_loop.as_u32());

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -837,8 +837,9 @@ impl Rir {
                 cond: renumber(*cond),
                 body: renumber(*body),
             },
-            InstData::InfiniteLoop { body } => InstData::InfiniteLoop {
+            InstData::InfiniteLoop { body, iter_borrow } => InstData::InfiniteLoop {
                 body: renumber(*body),
+                iter_borrow: *iter_borrow,
             },
             InstData::Ret(value) => InstData::Ret(renumber_opt(*value)),
             InstData::Break { value } => InstData::Break {
@@ -1374,7 +1375,17 @@ pub enum InstData {
     Loop { cond: InstRef, body: InstRef },
 
     /// Infinite loop: loop { body }
-    InfiniteLoop { body: InstRef },
+    ///
+    /// `iter_borrow` names the collection variable held as a scoped shared
+    /// borrow for the loop's duration when this loop is the desugaring of a
+    /// `for` over a named variable (spec 4.8:26, RUE-233). Sema rejects
+    /// mutation of that variable inside the body (E0428). `None` for a plain
+    /// `loop {}` or a `for` over a temporary (which is unnameable, so
+    /// unmutatable, in the body).
+    InfiniteLoop {
+        body: InstRef,
+        iter_borrow: Option<Spur>,
+    },
 
     /// Match expression: match scrutinee { pattern => expr, ... }
     /// Arms are stored in the extra array using add_match_arms/get_match_arms.
@@ -1856,7 +1867,9 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     }
                 }
                 InstData::Loop { cond, body } => writeln!(out, "loop {}, {}", cond, body).unwrap(),
-                InstData::InfiniteLoop { body } => writeln!(out, "infinite_loop {}", body).unwrap(),
+                InstData::InfiniteLoop { body, .. } => {
+                    writeln!(out, "infinite_loop {}", body).unwrap()
+                }
                 InstData::Match {
                     scrutinee,
                     arms_start,
@@ -2673,7 +2686,10 @@ mod tests {
         });
 
         rir.add_inst(Inst {
-            data: InstData::InfiniteLoop { body },
+            data: InstData::InfiniteLoop {
+                body,
+                iter_borrow: None,
+            },
             span: Span::new(0, 15),
         });
 


### PR DESCRIPTION
All found by the arrays/indexing hunt. rue-air/rir only (no codegen).

**RUE-232** — use-after-move was not detected when the use is an *index expression* on a moved base (`a.field[i]` after `let b = a`). `analyze_index_get_impl` now checks the base place's move state (`field_path()` + `is_path_moved`), like the field-projection path. `moved.field[i]` → **E0205**; non-moved index still works.

**RUE-233** — the for-loop's implicit borrow of the iterated collection wasn't exclusivity-checked, so mutating the array in the body was accepted (wrong results, violating spec 4.8:26). Added `iter_borrow` to RIR `InfiniteLoop` (set by the for-desugaring for named collections), tracked in `ctx.iter_borrows`; whole-var/field/element writes to the iterated variable in the body → **E0428**. Iterating a different/temporary collection and read-only loops still compile.

**RUE-234** — array-index const-eval ignored operand width (same class as RUE-230, different site): `arr[X+1]` with i8 X=127 overflowed i8 but was accepted and deferred to a runtime panic. New `try_get_const_index_checked` evaluates the index at HM-resolved operand types, wired into all four bounds-check sites. `arr[X+1]` → compile-time **E1200**; the u8 case reports the u8 overflow, not a bogus "index 256".

Verified by execution. Full `./test.sh` green (100% traceability); 12 new CLI cases.

Fixes RUE-232
Fixes RUE-233
Fixes RUE-234

🤖 Generated with [Claude Code](https://claude.com/claude-code)