### PR TITLE
Wire rue-oracle-diff as a Buck sh_test — CI enforces oracle/compiler agreement every commit (RUE-205)

### DIFF
--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -14,3 +14,19 @@ rue_binary(
         "//third-party:toml",
     ],
 )
+
+# Run the differential harness under `buck2 test //...` (and hence CI): the
+# harness reads the rue-cli-tests `cases` filegroup via RUE_ORACLE_DIFF_CASES
+# and exits non-zero on ANY oracle/compiler disagreement, so a codegen change
+# that diverges from the semantics fails CI here (RUE-205). Mirrors the
+# examples smoke test wiring (RUE-48): filegroup input + env var + sh_test.
+# Preview-gated / multi-file / custom-arg / compile-fail cases are skipped by
+# the harness (Unsupported or non-runnable shape), not counted as
+# disagreements, so they cannot cause spurious failures.
+sh_test(
+    name = "oracle-diff-test",
+    test = ":rue-oracle-diff",
+    env = {
+        "RUE_ORACLE_DIFF_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
+    },
+)

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -11,7 +11,10 @@
 //! the semantics and codegen agree on every program in the corpus."
 //!
 //! Usage: `rue-oracle-diff [cases-dir ...]`
-//! (default: `crates/rue-cli-tests/cases`, resolved from the current directory).
+//! Case-directory resolution, in order: explicit argv paths; else the
+//! `RUE_ORACLE_DIFF_CASES` env var (a single dir — how the `buck2 test`
+//! sh_test feeds the rue-cli-tests `cases` filegroup); else the default
+//! `crates/rue-cli-tests/cases`, resolved from the current directory.
 //! Exits non-zero if any disagreement is found.
 
 use rue_oracle::run_source;
@@ -74,10 +77,14 @@ struct Report {
 fn main() -> ExitCode {
     let dirs: Vec<PathBuf> = {
         let args: Vec<String> = std::env::args().skip(1).collect();
-        if args.is_empty() {
-            vec![PathBuf::from("crates/rue-cli-tests/cases")]
-        } else {
+        if !args.is_empty() {
             args.into_iter().map(PathBuf::from).collect()
+        } else if let Some(cases) = std::env::var_os("RUE_ORACLE_DIFF_CASES") {
+            // Set by the `//crates/rue-oracle-diff:oracle-diff-test` sh_test to
+            // the rue-cli-tests `cases` filegroup's absolute location.
+            vec![PathBuf::from(cases)]
+        } else {
+            vec![PathBuf::from("crates/rue-cli-tests/cases")]
         }
     };
 


### PR DESCRIPTION
The differential harness (`crates/rue-oracle-diff`, RUE-50) was a runnable binary run by hand; now it runs under `buck2 test //...` (and CI) **every commit**, failing on any oracle/compiler disagreement. A future codegen change that diverges from the reference semantics fails CI as a harness disagreement, instead of silently miscompiling until someone runs it by hand — closing the RUE-213/217/224 miscompile class going forward.

- `crates/rue-oracle-diff/src/main.rs`: `RUE_ORACLE_DIFF_CASES` env-var fallback for the cases dir (argv still wins; default unchanged).
- `crates/rue-oracle-diff/BUCK`: new `sh_test` `oracle-diff-test` feeding the rue-cli-tests `cases` filegroup via that env var (mirrors the RUE-48 examples-smoke-test pattern). Build/CI wiring only — no compiler crates.

Verified: sh_test passes on trunk (**395 agree, 0 disagreements**, 337 skipped incl. all preview-gated cases — cleanly skipped, not counted as disagreements); a deliberate oracle Add→Sub bug makes it **fail**; reverting restores pass. Full `./test.sh` green.

Fixes RUE-205

🤖 Generated with [Claude Code](https://claude.com/claude-code)