### PR TITLE
Release-mode CI + promote correctness debug_assert! to assert! (RUE-45)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,3 +109,42 @@ jobs:
 
       - name: Run tests
         run: ./test.sh
+
+  # Release-mode build + test (RUE-45). CI otherwise builds/tests the compiler
+  # in debug ONLY, so release-only miscompiles never run — a correctness check
+  # written as `debug_assert!` (or `#[cfg(debug_assertions)]`) is compiled out
+  # in release and silently turns an ICE into wrong codegen (RUE-24 is the
+  # precedent). This job exercises the whole suite against a `-Copt-level=3`
+  # build of the compiler. linux-x64 only: the aim is to catch opt-level and
+  # cfg(debug_assertions) divergence, which is architecture-independent, so a
+  # single release target is enough without tripling CI cost.
+  test-release:
+    runs-on: ubuntu-latest
+    name: test (linux-x64, release)
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
+
+      # Reuse the debug job's dotslash cache (the buck2 binary download is
+      # build-mode independent) via the shared `dotslash-linux-x64-` prefix.
+      - name: Cache dotslash artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/dotslash
+            ~/Library/Caches/dotslash
+          key: dotslash-linux-x64-release-${{ hashFiles('buck2') }}
+          restore-keys: |
+            dotslash-linux-x64-
+
+      - name: Build all targets (release)
+        run: ./buck2 build //crates/... --modifier //constraints:release
+
+      # RUE_BUCK_MODIFIERS threads the release modifier through every buck2
+      # invocation in test.sh, including the rue binary the suites compile with.
+      - name: Run tests (release)
+        run: ./test.sh
+        env:
+          RUE_BUCK_MODIFIERS: "--modifier //constraints:release"

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -481,13 +481,17 @@ impl Air {
 
     /// Add extra data and return the start index.
     pub fn add_extra(&mut self, data: &[u32]) -> u32 {
-        // Debug assertions for u32 overflow
-        debug_assert!(
+        // Always-on overflow guards: `start`/`len` are stored as u32 and the
+        // `as u32` cast below would silently wrap on overflow, producing
+        // corrupt AIR references (wrong codegen). Correctness invariants must
+        // hold in release builds too, so these are `assert!`, not
+        // `debug_assert!` (RUE-45).
+        assert!(
             self.extra.len() <= u32::MAX as usize,
             "AIR extra data overflow: {} entries exceeds u32::MAX",
             self.extra.len()
         );
-        debug_assert!(
+        assert!(
             self.extra.len().saturating_add(data.len()) <= u32::MAX as usize,
             "AIR extra data would overflow: {} + {} exceeds u32::MAX",
             self.extra.len(),

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1654,6 +1654,10 @@ impl<'a> Sema<'a> {
             .iter()
             .find(|(name, _, mode, _)| *name == self_sym && *mode != RirParamMode::Normal)
         {
+            // Pure dev sanity check with no correctness role: the gate below
+            // (`require_preview`) does not branch on `mode`, so an unexpected
+            // mode here changes no codegen. Kept as `debug_assert!` per RUE-45
+            // (only correctness-guarding checks were promoted to `assert!`).
             debug_assert!(matches!(mode, RirParamMode::Inout | RirParamMode::Borrow));
             self.require_preview(
                 PreviewFeature::MethodReceivers,

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -481,8 +481,12 @@ fn create_specialized_function(
         let concrete_ty = if ty == Type::COMPTIME_TYPE {
             substitute_param_type(sema, base_info, name, &type_subst, &value_subst).unwrap_or_else(
                 || {
-                    debug_assert!(false, "type substitution failed for param");
-                    ty
+                    // Falling back to `ty` here would leave a COMPTIME_TYPE
+                    // placeholder in the specialized runtime signature — silent
+                    // wrong codegen. Panic unconditionally (was a `debug_assert!`
+                    // that vanished in release) so the invariant is enforced in
+                    // release builds too (RUE-45).
+                    panic!("type substitution failed for param")
                 },
             )
         } else {

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -884,10 +884,11 @@ impl Cfg {
     /// A block's terminator may only be set once (from `None`), or may replace
     /// an `Unreachable` placeholder. Silently overwriting a real terminator is
     /// how divergence bugs hide — e.g. a diverging let-initializer's `Return`
-    /// being clobbered by the code after the `let` (RUE-128) — so that is a
-    /// loud debug assertion instead.
+    /// being clobbered by the code after the `let` (RUE-128) — so that is an
+    /// always-on assertion (not `debug_assert!`: it guards codegen correctness,
+    /// which must hold in release builds too — RUE-45).
     pub fn set_terminator(&mut self, block: BlockId, term: Terminator) {
-        debug_assert!(
+        assert!(
             matches!(
                 self.blocks[block.0 as usize].terminator,
                 Terminator::None | Terminator::Unreachable

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -295,7 +295,7 @@ impl<'a> CfgLower<'a> {
             .cloned()
             .expect("aggregate block param should have slot vregs pre-allocated");
 
-        debug_assert_eq!(
+        assert_eq!(
             src_slots.len(),
             dst_slots.len(),
             "source and destination aggregate slot counts must match"
@@ -1310,7 +1310,7 @@ impl<'a> CfgLower<'a> {
                     let field_vregs = self
                         .get_or_compute_field_vregs(*init)
                         .expect("string should have fat pointer fields in Alloc");
-                    debug_assert_eq!(
+                    assert_eq!(
                         field_vregs.len(),
                         3,
                         "string should have 3 fields (ptr, len, cap)"
@@ -2508,7 +2508,7 @@ impl<'a> CfgLower<'a> {
                         .get_or_compute_field_vregs(*dropped_value)
                         .expect("String value should have field vregs");
 
-                    debug_assert_eq!(
+                    assert_eq!(
                         field_vregs.len(),
                         3,
                         "String should have 3 slots (ptr, len, cap)"
@@ -3512,12 +3512,12 @@ impl<'a> CfgLower<'a> {
             .get_or_compute_field_vregs(rhs)
             .expect("string should have fat pointer fields");
 
-        debug_assert_eq!(
+        assert_eq!(
             lhs_fields.len(),
             3,
             "string should have 3 fields (ptr, len, cap)"
         );
-        debug_assert_eq!(
+        assert_eq!(
             rhs_fields.len(),
             3,
             "string should have 3 fields (ptr, len, cap)"

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -1358,7 +1358,7 @@ impl<'a> Emitter<'a> {
                     fixup.label
                 )))
             })?;
-            debug_assert_eq!(
+            assert_eq!(
                 (target as i64 - fixup.offset as i64) % 4,
                 0,
                 "branch target/site must be 4-byte aligned"
@@ -1546,7 +1546,7 @@ impl<'a> Emitter<'a> {
             // and may be the very rd/rs of this access. Previously the offset
             // was masked & 0x1FF, silently WRAPPING — locals deeper than 256
             // bytes loaded from above the frame pointer. (RUE-129)
-            debug_assert!(
+            assert!(
                 base != Reg::Sp && base != Reg::X15,
                 "large-offset load needs a general base register"
             );
@@ -1580,7 +1580,7 @@ impl<'a> Emitter<'a> {
             // was masked & 0x1FF, silently WRAPPING — locals deeper than 256
             // bytes stored ABOVE the frame pointer, corrupting the caller's
             // stack. (RUE-129)
-            debug_assert!(
+            assert!(
                 base != Reg::Sp && base != Reg::X15 && rs != Reg::X15,
                 "large-offset store needs a general base register"
             );
@@ -1664,7 +1664,7 @@ impl<'a> Emitter<'a> {
         // ADD for the low part. Previously the immediate was masked & 0xFFF,
         // silently truncating — e.g. epilogues of frames >4095 bytes
         // mis-adjusted SP by multiples of 4096. (RUE-129)
-        debug_assert!(imm < (1 << 24), "ADD immediate exceeds 24 bits: {imm}");
+        assert!(imm < (1 << 24), "ADD immediate exceeds 24 bits: {imm}");
         if imm > 0xFFF {
             let inst = OPCODE_ADD_IMM_X
                 | (1 << 22)
@@ -1741,7 +1741,7 @@ impl<'a> Emitter<'a> {
         // silently truncating — prologues of frames >4095 bytes UNDER-ALLOCATED
         // by multiples of 4096, so locals overlapped the caller's stack.
         // (RUE-129)
-        debug_assert!(imm < (1 << 24), "SUB immediate exceeds 24 bits: {imm}");
+        assert!(imm < (1 << 24), "SUB immediate exceeds 24 bits: {imm}");
         if imm > 0xFFF {
             let inst = OPCODE_SUB_IMM_X
                 | (1 << 22)

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -70,8 +70,9 @@ pub fn generate(
     // Schedule instructions for better performance
     schedule::schedule(&mut mir);
 
-    // Verify stack alignment in debug builds
-    #[cfg(debug_assertions)]
+    // Verify stack alignment. Runs in every build (not `#[cfg(debug_assertions)]`):
+    // a stack-misalignment miscompile is an ABI-level correctness bug that must
+    // be caught in release too, not silently emitted (RUE-45; cf. RUE-24).
     verify::verify_stack_alignment(&mir)?;
 
     // Emit machine code bytes
@@ -124,8 +125,9 @@ pub fn generate_with_asm(
     // Schedule instructions for better performance
     schedule::schedule(&mut mir);
 
-    // Verify stack alignment in debug builds
-    #[cfg(debug_assertions)]
+    // Verify stack alignment. Runs in every build (not `#[cfg(debug_assertions)]`):
+    // a stack-misalignment miscompile is an ABI-level correctness bug that must
+    // be caught in release too, not silently emitted (RUE-45; cf. RUE-24).
     verify::verify_stack_alignment(&mir)?;
 
     // Emit machine code bytes with assembly text

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -469,7 +469,7 @@ impl<'a> CfgLower<'a> {
             .cloned()
             .expect("aggregate block param should have slot vregs pre-allocated");
 
-        debug_assert_eq!(
+        assert_eq!(
             src_slots.len(),
             dst_slots.len(),
             "source and destination aggregate slot counts must match"
@@ -1638,7 +1638,7 @@ impl<'a> CfgLower<'a> {
                     let field_vregs = self
                         .get_or_compute_field_vregs(*init)
                         .expect("string should have fat pointer fields in Alloc");
-                    debug_assert_eq!(
+                    assert_eq!(
                         field_vregs.len(),
                         3,
                         "string should have 3 fields (ptr, len, cap)"
@@ -2124,7 +2124,7 @@ impl<'a> CfgLower<'a> {
                         // Get the fat pointer (ptr, len, cap) — materializes a String read
                         // from a place (`@dbg(h.s)`) as well as cached sources. (RUE-118)
                         if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_val) {
-                            debug_assert_eq!(
+                            assert_eq!(
                                 field_vregs.len(),
                                 3,
                                 "string should have exactly 3 vregs (ptr, len, cap)"
@@ -2246,7 +2246,7 @@ impl<'a> CfgLower<'a> {
                     // Get the String fat pointer (ptr, len, cap) — materializes a String
                     // read from a place (`@parse_i32(h.s)`) as well as cached sources. (RUE-118)
                     if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_val) {
-                        debug_assert_eq!(
+                        assert_eq!(
                             field_vregs.len(),
                             3,
                             "string should have exactly 3 vregs (ptr, len, cap)"
@@ -2888,7 +2888,7 @@ impl<'a> CfgLower<'a> {
                         .get_or_compute_field_vregs(*dropped_value)
                         .expect("String value should have field vregs");
 
-                    debug_assert_eq!(
+                    assert_eq!(
                         field_vregs.len(),
                         3,
                         "String should have 3 slots (ptr, len, cap)"
@@ -3487,11 +3487,11 @@ impl<'a> CfgLower<'a> {
             .get_or_compute_field_vregs(rhs)
             .expect("builtin type should have field vregs");
 
-        debug_assert!(
+        assert!(
             lhs_fields.len() >= 2,
             "builtin type should have at least 2 fields for comparison"
         );
-        debug_assert!(
+        assert!(
             rhs_fields.len() >= 2,
             "builtin type should have at least 2 fields for comparison"
         );

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -68,8 +68,9 @@ pub fn generate(
     // Schedule instructions for better performance
     schedule::schedule(&mut mir);
 
-    // Verify stack alignment in debug builds
-    #[cfg(debug_assertions)]
+    // Verify stack alignment. Runs in every build (not `#[cfg(debug_assertions)]`):
+    // a stack-misalignment miscompile is an ABI-level correctness bug that must
+    // be caught in release too, not silently emitted (RUE-45; cf. RUE-24).
     verify::verify_stack_alignment(&mir)?;
 
     // Emit machine code bytes (with prologue for stack frame setup)
@@ -124,8 +125,9 @@ pub fn generate_with_asm(
     // Schedule instructions for better performance
     schedule::schedule(&mut mir);
 
-    // Verify stack alignment in debug builds
-    #[cfg(debug_assertions)]
+    // Verify stack alignment. Runs in every build (not `#[cfg(debug_assertions)]`):
+    // a stack-misalignment miscompile is an ABI-level correctness bug that must
+    // be caught in release too, not silently emitted (RUE-45; cf. RUE-24).
     verify::verify_stack_alignment(&mir)?;
 
     // Emit machine code bytes with assembly text

--- a/test.sh
+++ b/test.sh
@@ -12,42 +12,56 @@ set -euo pipefail
 #
 # With a pattern argument, the spec/UI/CLI suites are instead run directly
 # with the filter (unit tests still run in full, as before).
+#
+# RUE_BUCK_MODIFIERS lets a caller inject Buck2 build modifiers into every
+# buck2 invocation below (including the rue binary the suites compile with).
+# CI uses it to run the whole suite against a RELEASE build of the compiler —
+# `RUE_BUCK_MODIFIERS="--modifier //constraints:release" ./test.sh` — so
+# release-only miscompiles (e.g. a correctness check that used to be a
+# `debug_assert!` and vanished in release) are actually exercised (RUE-45).
+# Empty by default, so the debug path is byte-for-byte unchanged.
 
 cd "$(dirname "$0")"
 
+# Split the modifier string into an array so word-splitting is explicit and
+# safe under `set -u`; an empty value yields an empty array (expands to
+# nothing). `|| true` absorbs read's EOF-nonzero on empty input under `set -e`.
+IFS=' ' read -ra BUCK_MODIFIERS <<< "${RUE_BUCK_MODIFIERS:-}" || true
+
 if [[ $# -eq 0 ]]; then
     echo "Running unit tests and spec/UI/CLI suites..."
-    ./buck2 test //...
+    ./buck2 test //... "${BUCK_MODIFIERS[@]}"
 else
     # Unit tests live under //crates/...; the suite sh_tests are at the repo
     # root, so this scope keeps them out of the unfiltered step below.
     echo "Running unit tests..."
-    ./buck2 test //crates/...
+    ./buck2 test //crates/... "${BUCK_MODIFIERS[@]}"
 
     # Get the path to the rue binary (this also builds it if needed).
-    # scripts/rue-bin resolves it to a stable absolute path.
-    RUE_BINARY="$(./scripts/rue-bin)"
+    # scripts/rue-bin resolves it to a stable absolute path; the same
+    # modifiers must reach it so the suites compile with the release binary.
+    RUE_BINARY="$(./scripts/rue-bin "${BUCK_MODIFIERS[@]}")"
 
     echo "Running spec tests..."
     RUE_BINARY="$RUE_BINARY" \
     RUE_SPEC_CASES="crates/rue-spec/cases" \
-    ./buck2 run //crates/rue-spec:rue-spec -- --quiet "$@"
+    ./buck2 run //crates/rue-spec:rue-spec "${BUCK_MODIFIERS[@]}" -- --quiet "$@"
 
     echo "Running UI tests..."
     RUE_BINARY="$RUE_BINARY" \
     RUE_UI_CASES="crates/rue-ui-tests/cases" \
-    ./buck2 run //crates/rue-ui-tests:rue-ui-tests -- --quiet "$@"
+    ./buck2 run //crates/rue-ui-tests:rue-ui-tests "${BUCK_MODIFIERS[@]}" -- --quiet "$@"
 
     echo "Running CLI integration tests..."
     RUE_BINARY="$RUE_BINARY" \
     RUE_CLI_CASES="crates/rue-cli-tests/cases" \
     RUE_EXAMPLES_DIR="examples" \
     RUE_STD_DIR="std" \
-    ./buck2 run //crates/rue-cli-tests:rue-cli-tests -- --quiet "$@"
+    ./buck2 run //crates/rue-cli-tests:rue-cli-tests "${BUCK_MODIFIERS[@]}" -- --quiet "$@"
 fi
 
 # Run traceability check (fails if coverage < 100% or orphan references exist)
 echo "Running spec traceability check..."
 RUE_SPEC_DIR="docs/spec/src" \
 RUE_SPEC_CASES="crates/rue-spec/cases" \
-./buck2 run //crates/rue-spec:rue-spec -- --traceability
+./buck2 run //crates/rue-spec:rue-spec "${BUCK_MODIFIERS[@]}" -- --traceability


### PR DESCRIPTION
Per Steve's ruling: **test both modes**, and **`debug_assert!` is not for correctness** (RUE-24 precedent — an aggregate miscompile masked by a `debug_assert!` that vanishes in release turned an ICE into silent wrong codegen).

**Part A — test both modes:** new CI job `test (linux-x64, release)` runs the full suite against a `-Copt-level=3` compiler, via a `RUE_BUCK_MODIFIERS` env var threaded through `test.sh` (debug path unchanged). actionlint clean.

**Part B — debug_assert audit:** promoted every correctness-guarding `debug_assert!`/`debug_assert_eq!` in the codegen path to always-on `assert!` across **both** backends — cfg_lower slot-count checks (incl. the RUE-24-class one), aarch64 emit encoding guards, CFG `set_terminator`, AIR u32-overflow; `verify_stack_alignment` now runs in every build; the `specialize` `debug_assert!(false)` is now an unconditional `panic!`. Only genuine non-correctness dev checks remain `debug_assert!` (documented).

**Part C** (opt-level `-O0/-O2/-O3` cross-check) deferred → **RUE-236**: the `opt_level` Case field is gone and `-O2/-O3` alias `-O1` today.

Verified: `./test.sh` green in **both** debug and release (1677 unit + 21 suite each); release build compiles + runs the RUE-24-class nested-aggregate program correctly (exit 42, no spurious assert); actionlint + fmt clean.

Part of RUE-45

🤖 Generated with [Claude Code](https://claude.com/claude-code)