### PR TITLE
Enum payload soundness: linear infectiousness + active-variant drop glue (RUE-221)

### DIFF
--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -193,6 +193,19 @@ impl<'a> Sema<'a> {
                 let (element_type, _length) = self.type_pool.array_def(array_id);
                 self.type_carries_linear(element_type)
             }
+            // An enum carries a linear value when any variant payload does
+            // (RUE-221, multiplicity join: a linear-payload variant makes the
+            // whole enum linear/must-consume). The discriminant selects the
+            // active variant at runtime, so a conservative static check
+            // requires consumption if *any* variant could carry one.
+            TypeKind::Enum(enum_id) => {
+                let enum_def = self.type_pool.enum_def(enum_id);
+                enum_def
+                    .variant_payloads
+                    .iter()
+                    .flatten()
+                    .any(|&payload_ty| self.type_carries_linear(payload_ty))
+            }
             _ => false,
         }
     }

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -69,8 +69,18 @@ impl<'a> Sema<'a> {
             | TypeKind::U64
             | TypeKind::Bool
             | TypeKind::Unit => true,
-            // Enum types are Copy (they're small discriminant values)
-            TypeKind::Enum(_) => true,
+            // An enum is Copy iff every variant payload is Copy (RUE-221:
+            // enum multiplicity is the join of its variants' payload
+            // multiplicities, lattice Copy ⊑ Affine ⊑ Linear). A
+            // discriminant-only (C-like) enum has no payloads and is Copy.
+            TypeKind::Enum(enum_id) => {
+                let enum_def = self.type_pool.enum_def(enum_id);
+                enum_def
+                    .variant_payloads
+                    .iter()
+                    .flatten()
+                    .all(|&ty| self.is_type_copy(ty))
+            }
             // Never and Error are Copy for convenience
             TypeKind::Never | TypeKind::Error => true,
             // Struct types: check if marked with @copy

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -2435,8 +2435,18 @@ impl<'a> CfgBuilder<'a> {
             | TypeKind::Error
             | TypeKind::ComptimeType => false,
 
-            // Enum types are trivially droppable (just discriminant values)
-            TypeKind::Enum(_) => false,
+            // An enum needs drop if any variant payload needs drop (RUE-221):
+            // at scope exit the discriminant selects the active variant and
+            // its payload's drop glue runs. A discriminant-only (C-like) enum
+            // has no payloads and is trivially droppable.
+            TypeKind::Enum(enum_id) => {
+                let enum_def = self.type_pool.enum_def(enum_id);
+                enum_def
+                    .variant_payloads
+                    .iter()
+                    .flatten()
+                    .any(|&ty| self.type_needs_drop(ty))
+            }
 
             // Struct types need drop if they have a destructor (e.g., builtin String)
             // or if any field needs drop

--- a/crates/rue-cli-tests/cases/enum_payloads.toml
+++ b/crates/rue-cli-tests/cases/enum_payloads.toml
@@ -51,6 +51,120 @@ fn main() -> i32 {
 stdout = "7\n"
 exit_code = 7
 
+# Active-variant drop glue (RUE-221 piece #1): an enum whose active variant
+# carries a droppable payload, dropped implicitly at scope exit (never matched),
+# drops that payload exactly once. `@dbg(-1)` prints before the scope-exit drop
+# of the payload struct's destructor `@dbg(9)`, so order is -1 then 9.
+[[case]]
+name = "active_variant_drop_glue_has"
+description = "Unmatched enum with a droppable active-variant payload drops it once at scope exit: prints -1 then 9."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+enum E { Has(D), None }
+fn main() -> i32 {
+    let e = E::Has(D { v: 9 });
+    @dbg(-1);
+    0
+}
+""" }]
+stdout = "-1\n9\n"
+exit_code = 0
+
+# The inactive (discriminant-only) variant has no payload to drop: only -1 prints.
+[[case]]
+name = "active_variant_drop_glue_none"
+description = "Unmatched enum whose active variant is discriminant-only drops nothing: prints only -1."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+enum E { Has(D), None }
+fn main() -> i32 {
+    let e = E::None;
+    @dbg(-1);
+    0
+}
+""" }]
+stdout = "-1\n"
+exit_code = 0
+
+# The match-move path still drops exactly once (regression): a payload moved out
+# via a match binding is NOT also dropped by the scope-exit active-variant glue.
+[[case]]
+name = "match_move_no_double_drop"
+description = "A payload moved out via a match binding drops exactly once — the scope-exit glue does not double-drop it: prints 7 once."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+enum E { Has(D), None }
+fn main() -> i32 {
+    let e = E::Has(D { v: 7 });
+    match e {
+        E::Has(d) => d.v,
+        E::None => 0,
+    }
+}
+""" }]
+stdout = "7\n"
+exit_code = 7
+
+# Linear/multiplicity infectiousness (RUE-221 piece #2): a variant carrying a
+# linear payload makes the whole enum linear — an unconsumed enum value is a
+# must-consume error (E0406), not a silent leak.
+[[case]]
+name = "linear_enum_must_consume"
+description = "An enum with a linear-payload variant is linear: leaving a value unconsumed is E0406."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+enum E { Has(L), None }
+fn main() -> i32 {
+    let e = E::Has(L { v: 1 });
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0406", "must be consumed"]
+
+# Consuming the linear enum via a match that binds and consumes the payload
+# satisfies the obligation and compiles/runs.
+[[case]]
+name = "linear_enum_consumed_ok"
+description = "Consuming a linear enum via a match that moves and consumes the payload satisfies must-consume: exit 5."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+enum E { Has(L), None }
+fn sink(l: L) -> i32 { l.v }
+fn main() -> i32 {
+    let e = E::Has(L { v: 5 });
+    match e {
+        E::Has(l) => sink(l),
+        E::None => 0,
+    }
+}
+""" }]
+exit_code = 5
+
+# An all-Copy-payload enum stays Copy (multiplicity join bottoms out at Copy):
+# it can be used twice without a move error.
+[[case]]
+name = "copy_payload_enum_stays_copy"
+description = "An enum whose only payloads are Copy stays Copy — usable twice with no must-consume/move error: exit 6."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum C { A(i32), B }
+fn val(c: C) -> i32 { match c { C::A(x) => x, C::B => 0 } }
+fn main() -> i32 {
+    let c = C::A(3);
+    val(c) + val(c)
+}
+""" }]
+exit_code = 6
+
 # Without the preview flag, a payload-carrying enum is a clean preview error
 # (the driver reports it, no ICE).
 [[case]]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2560,6 +2560,20 @@ impl<'a> CfgLower<'a> {
                     return;
                 }
 
+                // Handle enum drops (RUE-221): pass the enum's flattened slots
+                // (discriminant + payload union) to its synthesized drop glue,
+                // which switches on the discriminant and drops the active
+                // variant's payload.
+                if let Some(enum_id) = dropped_ty.as_enum() {
+                    let field_vregs = self
+                        .get_or_compute_field_vregs(*dropped_value)
+                        .expect("payload enum value should have field vregs");
+                    let enum_def = self.ctx.type_pool.enum_def(enum_id);
+                    let drop_fn_name = format!("__rue_drop_{}", enum_def.name);
+                    self.emit_call_with_slot_args(&field_vregs, &drop_fn_name);
+                    return;
+                }
+
                 // For other types that might need drop in the future
                 unreachable!(
                     "Drop instruction reached codegen for unexpected type: {:?}",

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2950,6 +2950,20 @@ impl<'a> CfgLower<'a> {
                     return;
                 }
 
+                // Handle enum drops (RUE-221): pass the enum's flattened slots
+                // (discriminant + payload union) to its synthesized drop glue,
+                // which switches on the discriminant and drops the active
+                // variant's payload.
+                if let TypeKind::Enum(enum_id) = dropped_ty.kind() {
+                    let field_vregs = self
+                        .get_or_compute_field_vregs(*dropped_value)
+                        .expect("payload enum value should have field vregs");
+                    let enum_def = self.ctx.type_pool.enum_def(enum_id);
+                    let drop_fn_name = format!("__rue_drop_{}", enum_def.name);
+                    self.emit_call_with_slot_args(&field_vregs, &drop_fn_name);
+                    return;
+                }
+
                 // For other types that might need drop in the future
                 unreachable!(
                     "Drop instruction reached codegen for unexpected type: {:?}",

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -21,7 +21,8 @@
 //! 2. Drops each element in index order (element 0 first, then 1, etc.)
 
 use rue_air::{
-    Air, AirInst, AirInstData, AnalyzedFunction, StructDef, Type, TypeInternPool, TypeKind,
+    Air, AirInst, AirInstData, AirPattern, AirRef, AnalyzedFunction, EnumId, StructDef, Type,
+    TypeInternPool, TypeKind,
 };
 use rue_span::Span;
 
@@ -44,8 +45,17 @@ fn type_needs_drop(ty: Type, type_pool: &TypeInternPool) -> bool {
         | TypeKind::Error
         | TypeKind::ComptimeType => false,
 
-        // Enum types are trivially droppable (just discriminant values)
-        TypeKind::Enum(_) => false,
+        // An enum needs drop if any variant payload needs drop (RUE-221): at
+        // scope exit its active-variant drop glue switches on the discriminant
+        // and drops the selected payload. Discriminant-only enums are trivial.
+        TypeKind::Enum(enum_id) => {
+            let enum_def = type_pool.enum_def(enum_id);
+            enum_def
+                .variant_payloads
+                .iter()
+                .flatten()
+                .any(|&ty| type_needs_drop(ty, type_pool))
+        }
 
         // Struct types need drop if they have a destructor (e.g., builtin String)
         // or if any field needs drop
@@ -94,9 +104,25 @@ fn type_slot_count(ty: Type, type_pool: &TypeInternPool) -> u32 {
         | TypeKind::Bool
         | TypeKind::Unit
         | TypeKind::Never
-        | TypeKind::Error
-        | TypeKind::Enum(_) => 1,
+        | TypeKind::Error => 1,
         TypeKind::ComptimeType => 0,
+
+        // Tagged union: 1 discriminant slot + payload area sized to the
+        // largest variant (RUE-221). Mirrors `types::type_slot_count` in
+        // rue-codegen. A discriminant-only enum has no payload → 1 slot.
+        TypeKind::Enum(enum_id) => {
+            let enum_def = type_pool.enum_def(enum_id);
+            let mut max_payload = 0u32;
+            for i in 0..enum_def.variant_count() {
+                let variant_slots: u32 = enum_def
+                    .variant_payload(i)
+                    .iter()
+                    .map(|&ty| type_slot_count(ty, type_pool))
+                    .sum();
+                max_payload = max_payload.max(variant_slots);
+            }
+            1 + max_payload
+        }
 
         // Struct uses sum of all field slots (including builtin String with 3 fields)
         TypeKind::Struct(struct_id) => {
@@ -161,6 +187,18 @@ pub fn synthesize_drop_glue(type_pool: &TypeInternPool) -> Vec<AnalyzedFunction>
 
         // Create drop glue function for array
         let func = create_array_drop_glue_function(array_id, type_pool);
+        drop_glue_functions.push(func);
+    }
+
+    // Create drop glue for payload-carrying enums (RUE-221). The glue switches
+    // on the discriminant and drops the active variant's payload.
+    for enum_id in type_pool.all_enum_ids() {
+        let enum_ty = Type::new_enum(enum_id);
+        if !type_needs_drop(enum_ty, type_pool) {
+            continue;
+        }
+
+        let func = create_enum_drop_glue_function(enum_id, type_pool);
         drop_glue_functions.push(func);
     }
 
@@ -233,7 +271,12 @@ fn create_struct_drop_glue_function(
                     });
                     drop_statements.push(drop_ref);
                 }
-                // Other types don't need drop
+                // A payload-carrying enum *field* is not yet dropped by struct
+                // glue (RUE-221 follow-up): active-variant drop glue currently
+                // fires only for a top-level enum value at scope exit, not for
+                // one nested inside another aggregate. Such a field leaks (but
+                // never double-drops); `type_slot_count` still counts its slots
+                // so later fields stay correctly offset.
                 _ => {}
             }
         }
@@ -349,7 +392,9 @@ fn create_array_drop_glue_function(
                 });
                 drop_statements.push(drop_ref);
             }
-            // Primitives don't need drop - this shouldn't happen since we check type_needs_drop
+            // A payload-carrying enum element is not yet dropped by array glue
+            // (RUE-221 follow-up, same interim as struct glue above): it leaks
+            // rather than double-dropping.
             _ => {}
         }
     }
@@ -396,6 +441,143 @@ fn create_array_drop_glue_function(
         num_param_slots,
         param_modes,
     }
+}
+
+/// Create a drop glue function for a payload-carrying enum type (RUE-221).
+///
+/// The function receives the enum's flattened slots as parameters: slot 0 is
+/// the discriminant, slots 1.. are the payload union sized to the largest
+/// variant. It switches on the discriminant and, for the active variant, drops
+/// each droppable payload field in declaration order. Variants whose payload
+/// needs no drop (and discriminant-only variants) fall through to a no-op
+/// wildcard default arm, so exactly the active variant's payload is dropped.
+fn create_enum_drop_glue_function(enum_id: EnumId, type_pool: &TypeInternPool) -> AnalyzedFunction {
+    let enum_def = type_pool.enum_def(enum_id);
+    let fn_name = enum_drop_glue_name(enum_id, type_pool);
+    let span = Span::new(0, 0); // Synthetic span
+
+    let mut air = Air::new(Type::UNIT);
+
+    // Total ABI slots: discriminant (slot 0) + payload area (largest variant).
+    let num_param_slots = type_slot_count(Type::new_enum(enum_id), type_pool);
+
+    // The discriminant lives in param slot 0; the match switches on it.
+    let disc_ty = enum_def.discriminant_type();
+    let disc_param = air.add_inst(AirInst {
+        data: AirInstData::Param { index: 0 },
+        ty: disc_ty,
+        span,
+    });
+
+    // A single shared unit value for every arm body and the outer block.
+    let unit_const = air.add_inst(AirInst {
+        data: AirInstData::UnitConst,
+        ty: Type::UNIT,
+        span,
+    });
+
+    // Build one Int-pattern arm per variant that carries a droppable payload.
+    // Payload fields overlay the union starting at slot 1, so field j of a
+    // variant sits at slot `1 + sum(slot_count(field_k) for k < j)`.
+    let mut arm_data: Vec<u32> = Vec::new();
+    let mut arm_count = 0u32;
+
+    for variant_index in 0..enum_def.variant_count() {
+        let payload = enum_def.variant_payload(variant_index);
+        if !payload.iter().any(|&ty| type_needs_drop(ty, type_pool)) {
+            continue;
+        }
+
+        let mut drop_stmts: Vec<AirRef> = Vec::new();
+        let mut field_slot = 1u32; // slot 0 is the discriminant
+        for &field_ty in payload {
+            let field_slots = type_slot_count(field_ty, type_pool);
+            if type_needs_drop(field_ty, type_pool) {
+                let param_ref = air.add_inst(AirInst {
+                    data: AirInstData::Param { index: field_slot },
+                    ty: field_ty,
+                    span,
+                });
+                let drop_ref = air.add_inst(AirInst {
+                    data: AirInstData::Drop { value: param_ref },
+                    ty: Type::UNIT,
+                    span,
+                });
+                drop_stmts.push(drop_ref);
+            }
+            field_slot += field_slots;
+        }
+
+        // Arm body: a Block running the drops, yielding unit.
+        let stmt_u32s: Vec<u32> = drop_stmts.iter().map(|r| r.as_u32()).collect();
+        let stmts_start = air.add_extra(&stmt_u32s);
+        let stmts_len = drop_stmts.len() as u32;
+        let arm_body = air.add_inst(AirInst {
+            data: AirInstData::Block {
+                stmts_start,
+                stmts_len,
+                value: unit_const,
+            },
+            ty: Type::UNIT,
+            span,
+        });
+
+        AirPattern::Int(variant_index as i64).encode(arm_body, &mut arm_data);
+        arm_count += 1;
+    }
+
+    // A wildcard default arm (drops nothing) covers variants with no droppable
+    // payload and keeps the switch total for codegen.
+    AirPattern::Wildcard.encode(unit_const, &mut arm_data);
+    arm_count += 1;
+
+    let arms_start = air.add_extra(&arm_data);
+    let match_ref = air.add_inst(AirInst {
+        data: AirInstData::Match {
+            scrutinee: disc_param,
+            arms_start,
+            arms_len: arm_count,
+        },
+        ty: Type::UNIT,
+        span,
+    });
+
+    // Return unit; the match runs as a side-effecting statement of the body.
+    let body_stmts = [match_ref.as_u32()];
+    let body_start = air.add_extra(&body_stmts);
+    let body = air.add_inst(AirInst {
+        data: AirInstData::Block {
+            stmts_start: body_start,
+            stmts_len: 1,
+            value: unit_const,
+        },
+        ty: Type::UNIT,
+        span,
+    });
+
+    air.add_inst(AirInst {
+        data: AirInstData::Ret(Some(body)),
+        ty: Type::UNIT,
+        span,
+    });
+
+    let param_modes = vec![false; num_param_slots as usize];
+
+    AnalyzedFunction {
+        name: fn_name,
+        air,
+        num_locals: 0,
+        num_param_slots,
+        param_modes,
+    }
+}
+
+/// Generate the drop glue function name for a payload-carrying enum type.
+///
+/// Types share a namespace, so the enum's own name cannot collide with a
+/// struct's `__rue_drop_<name>` glue.
+pub fn enum_drop_glue_name(enum_id: EnumId, type_pool: &TypeInternPool) -> String {
+    format!("__rue_drop_{}", type_pool.enum_def(enum_id).name)
 }
 
 /// Generate the drop glue function name for an array type.

--- a/crates/rue-spec/cases/items/enums.toml
+++ b/crates/rue-spec/cases/items/enums.toml
@@ -382,3 +382,99 @@ fn main() -> i32 {
 }
 """
 exit_code = 7
+
+# Multiplicity infectiousness (6.3:19): a variant carrying a linear payload
+# makes the whole enum linear — an unconsumed value is a must-consume error.
+[[case]]
+name = "enum_linear_infectious_must_consume"
+spec = ["6.3:19"]
+preview = "enum_payloads"
+preview_should_pass = true
+source = """
+linear struct L { v: i32 }
+enum E { Has(L), None }
+fn main() -> i32 {
+    let e = E::Has(L { v: 1 });
+    0
+}
+"""
+compile_fail = true
+error_contains = "must be consumed"
+
+# Consuming a linear enum via a match that binds and consumes the payload
+# discharges the obligation (6.3:19).
+[[case]]
+name = "enum_linear_consumed_via_match"
+spec = ["6.3:19"]
+preview = "enum_payloads"
+preview_should_pass = true
+source = """
+linear struct L { v: i32 }
+enum E { Has(L), None }
+fn sink(l: L) -> i32 { l.v }
+fn main() -> i32 {
+    let e = E::Has(L { v: 5 });
+    match e {
+        E::Has(l) => sink(l),
+        E::None => 0,
+    }
+}
+"""
+exit_code = 5
+
+# An all-Copy-payload enum bottoms out at Copy in the multiplicity join and
+# stays usable more than once (6.3:19).
+[[case]]
+name = "enum_copy_payload_stays_copy"
+spec = ["6.3:19"]
+preview = "enum_payloads"
+preview_should_pass = true
+source = """
+enum C { A(i32), B }
+fn val(c: C) -> i32 { match c { C::A(x) => x, C::B => 0 } }
+fn main() -> i32 {
+    let c = C::A(3);
+    val(c) + val(c)
+}
+"""
+exit_code = 6
+
+# Active-variant drop glue (6.3:20): an unmatched enum drops its active
+# variant's payload exactly once at scope exit. @dbg(-1) prints before the
+# scope-exit drop's @dbg(9).
+[[case]]
+name = "enum_active_variant_drop_glue"
+spec = ["6.3:20"]
+preview = "enum_payloads"
+preview_should_pass = true
+source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+enum E { Has(D), None }
+fn main() -> i32 {
+    let e = E::Has(D { v: 9 });
+    @dbg(-1);
+    0
+}
+"""
+expected_stdout = "-1\n9\n"
+exit_code = 0
+
+# A discriminant-only active variant has no payload to drop (6.3:20): only -1.
+[[case]]
+name = "enum_active_variant_none_no_drop"
+spec = ["6.3:20"]
+preview = "enum_payloads"
+preview_should_pass = true
+source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+enum E { Has(D), None }
+fn main() -> i32 {
+    let e = E::None;
+    @dbg(-1);
+    0
+}
+"""
+expected_stdout = "-1\n"
+exit_code = 0

--- a/docs/spec/src/06-items/03-enums.md
+++ b/docs/spec/src/06-items/03-enums.md
@@ -139,16 +139,24 @@ Binding a variant's payload in a `match` arm (see spec 4.7) moves the payload
 out of the enum value in move mode; a moved-out payload that has a destructor
 runs that destructor exactly once, when its binding leaves scope.
 
-{{ rule(id="6.3:19") }}
+{{ rule(id="6.3:19", cat="legality-rule") }}
 
-The intended full model is that an enum's multiplicity is the join of its
-variants' payload multiplicities — an enum a variant of which carries a linear
-payload is itself linear and must be consumed — and that dropping an enum value
-without consuming it drops the payload of its **active** variant (the one
-selected by the discriminant). Multiplicity infectiousness and implicit
-active-variant drop glue are a follow-up phase of the `enum_payloads` preview
-feature (RUE-221); until then, implicitly dropping an unconsumed
-payload-carrying enum leaks (but never double-drops) its payload.
+An enum's multiplicity is the **join** of its variants' payload multiplicities
+over the lattice Copy ⊑ Affine ⊑ Linear. An enum whose every payload is Copy
+(including a discriminant-only enum) is itself Copy; an enum a variant of which
+carries an Affine (drop-carrying) payload is Affine; an enum a variant of which
+carries a **linear** payload is itself linear and **MUST** be consumed —
+letting such a value be implicitly dropped is a must-consume error, exactly as
+for a linear struct. Consuming the enum (for example, by a `match` that binds
+and consumes the payload) discharges the obligation.
+
+{{ rule(id="6.3:20", cat="dynamic-semantics") }}
+
+Dropping an enum value that is not consumed drops the payload of its **active**
+variant — the one selected by the discriminant at run time — running that
+payload's drop glue exactly once, and nothing for a discriminant-only active
+variant. A payload moved out of the enum beforehand (for example, through a
+`match` binding) is not dropped again at scope exit.
 
 {{ rule(id="6.3:18") }}
 


### PR DESCRIPTION
The soundness gate for **RUE-6 phase 2** (a linear `Result`). Extends the `enum_payloads` preview.

**Linear/multiplicity infectiousness** — an enum's multiplicity is now the *join* of its variant payload multiplicities. A linear-payload variant makes the enum must-consume (**E0406**, like a linear struct); an all-Copy-payload enum stays Copy. Done via Enum arms in `is_type_copy` (typeck) + `type_carries_linear` (builtins), feeding the existing E0406 check — no new enforcement code.

**Active-variant drop glue** — an unconsumed payload enum drops its *active* variant's payload at scope exit, via a synthesized `__rue_drop_<Enum>` that switches on the discriminant (an AIR Match) — routed through the existing drop-glue machinery, no new per-backend MIR. Both backends route enum Drops to the glue.

Verified by execution: linear-unconsumed → E0406; consumed-via-match → ok; `E::Has(D{9})` unmatched → drops `9` at scope exit (`-1` then `9`); `E::None` → no drop; match-move drops exactly once (no double-drop); Copy enum usable twice. aarch64 `--emit asm` confirmed. Full `./test.sh` green (625/625 normative).

Deferred (RUE-221 follow-up): nested enum-as-struct-field/array-element drop (safe leak-not-UB interim). **Unblocks RUE-6 phase 2.**

Part of RUE-221

🤖 Generated with [Claude Code](https://claude.com/claude-code)