### PR TITLE
@drop intentional-destroy intrinsic (RUE-187, ADR-0039)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -3487,6 +3487,8 @@ impl<'a> Sema<'a> {
         // Use pre-interned symbol comparison instead of string comparison
         if name == known.dbg {
             self.analyze_dbg_intrinsic(air, inst_ref, &args, span, ctx)
+        } else if name == known.drop {
+            self.analyze_drop_intrinsic(air, &args, span, ctx)
         } else if name == known.int_cast {
             self.analyze_intcast_intrinsic(air, inst_ref, &args, span, ctx)
         } else if name == known.test_preview_gate {
@@ -3778,6 +3780,78 @@ impl<'a> Sema<'a> {
                 name: self.known.dbg,
                 args_start,
                 args_len: 1,
+            },
+            ty: Type::UNIT,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+    }
+
+    /// Analyze the `@drop(x)` intentional-destroy intrinsic (RUE-187,
+    /// ADR-0039).
+    ///
+    /// `@drop(x)` runs `x`'s full drop glue (destructor + recursive field
+    /// drops) at this site AND discharges `x`'s consumption obligation:
+    ///
+    /// - *linear* — the operand is consumed like any move, so the
+    ///   must-consume check (E0406) is satisfied and reusing `x` afterwards is
+    ///   a use-after-move (E0205);
+    /// - *affine with a destructor* — the glue runs EARLY (deterministic
+    ///   cleanup before scope exit), and the suppressed scope-exit drop keeps
+    ///   the "dropped exactly once" invariant;
+    /// - *Copy* — no move, no glue: a no-op.
+    ///
+    /// The obligation-discharge rides on the ordinary move machinery: analyzing
+    /// the operand as a by-value use marks its slot moved (so drop elaboration
+    /// skips the scope-exit drop, RUE-61) and records the consumption. The
+    /// emitted `Drop` reuses the exact glue path that scope-exit drops use, so
+    /// both backends already lower it and no `unchecked` context is required
+    /// (drop glue is memory-safe).
+    fn analyze_drop_intrinsic(
+        &mut self,
+        air: &mut Air,
+        args: &[RirCallArg],
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        if args.len() != 1 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "drop".to_string(),
+                    expected: 1,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        // Analyze the operand as an ordinary by-value use: for a variable this
+        // emits a `MarkMoved`-wrapped load, which both records the move (later
+        // use -> E0205, and the linear must-consume obligation is satisfied)
+        // and tells drop elaboration to skip the slot's scope-exit drop.
+        let arg_result = self.analyze_inst(air, args[0].value, ctx)?;
+        let arg_type = arg_result.ty;
+
+        // An `<error>`-typed operand reaching here via `Ok` means inference
+        // failed silently with no diagnostic; report it rather than letting a
+        // later stage hit an `unreachable!` (mirrors @dbg, RUE-149).
+        if arg_type.is_error() {
+            return Err(CompileError::new(
+                ErrorKind::InternalError(
+                    "@drop operand type failed to resolve during inference".to_string(),
+                ),
+                span,
+            ));
+        }
+
+        // Emit the drop glue at this site. The CFG builder elides the `Drop`
+        // for trivially droppable types (so `@drop` of a Copy value or a
+        // glue-free linear marker is a pure no-op beyond discharging the
+        // obligation), and otherwise lowers it through the same destructor +
+        // field-drop path as a scope-exit drop.
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Drop {
+                value: arg_result.air_ref,
             },
             ty: Type::UNIT,
             span,

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -36,6 +36,10 @@ pub struct KnownSymbols {
     // Intrinsic names
     /// The `dbg` intrinsic symbol.
     pub dbg: Spur,
+    /// The `drop` intrinsic symbol - the intentional-destroy escape hatch
+    /// (RUE-187, ADR-0039). Runs a value's drop glue and discharges its
+    /// consumption obligation (linear/affine).
+    pub drop: Spur,
     /// The `intCast` intrinsic symbol (deprecated, use `cast`).
     pub int_cast: Spur,
     /// The `cast` intrinsic symbol.
@@ -103,6 +107,7 @@ impl KnownSymbols {
         Self {
             // Intrinsic names
             dbg: interner.get_or_intern_static("dbg"),
+            drop: interner.get_or_intern_static("drop"),
             int_cast: interner.get_or_intern_static("intCast"),
             cast: interner.get_or_intern_static("cast"),
             panic: interner.get_or_intern_static("panic"),
@@ -168,6 +173,7 @@ mod tests {
 
         // Verify symbols can be resolved back to their expected strings
         assert_eq!(interner.resolve(&known.dbg), "dbg");
+        assert_eq!(interner.resolve(&known.drop), "drop");
         assert_eq!(interner.resolve(&known.int_cast), "intCast");
         assert_eq!(interner.resolve(&known.cast), "cast");
         assert_eq!(interner.resolve(&known.panic), "panic");

--- a/crates/rue-cli-tests/cases/drop_intrinsic.toml
+++ b/crates/rue-cli-tests/cases/drop_intrinsic.toml
@@ -1,0 +1,164 @@
+# The `@drop(x)` intentional-destroy intrinsic (RUE-187, ADR-0039).
+#
+# `@drop(x)` runs `x`'s full drop glue (destructor + recursive field/element
+# drops) at the call site and discharges `x`'s consumption obligation:
+#
+#   - LINEAR: the value is consumed, so the must-consume rule is satisfied
+#     (no E0406) and reusing it afterwards is E0205.
+#   - AFFINE (has a `drop fn`): the glue runs EARLY — deterministic cleanup
+#     before scope exit — and the scope-exit drop is suppressed so it runs
+#     exactly once.
+#   - COPY: a no-op (Copy values carry no glue and no obligation).
+#
+# These cases pin EXACT stdout (drop ORDER, not just exit code) so the
+# early-run / exactly-once behavior is regression-tested through the real
+# driver.
+
+[section]
+id = "cli.drop_intrinsic"
+name = "@drop intentional-destroy intrinsic"
+description = "@drop runs drop glue at the call site and discharges the linear/affine consumption obligation (RUE-187)."
+
+# (b) Affine early-drop: the destructor runs at the @drop site (42 before 2),
+# and NOT again at scope exit.
+[[case]]
+name = "affine_early_drop_runs_destructor_at_site"
+description = "@drop(x) runs the destructor early: 42 prints between the 1 and 2 markers, exactly once."
+files = [{ path = "main.rue", source = """
+struct Guard { v: i32 }
+
+drop fn Guard(self) { @dbg(self.v); }
+
+fn main() -> i32 {
+    let g = Guard { v: 42 };
+    @dbg(1);
+    @drop(g);
+    @dbg(2);
+    0
+}
+""" }]
+stdout = "1\n42\n2\n"
+exit_code = 0
+
+# Control: WITHOUT @drop the destructor runs at scope exit — 2 before 42.
+[[case]]
+name = "affine_control_drops_at_scope_exit"
+description = "Control: without @drop the destructor runs at scope exit (2 prints before 42)."
+files = [{ path = "main.rue", source = """
+struct Guard { v: i32 }
+
+drop fn Guard(self) { @dbg(self.v); }
+
+fn main() -> i32 {
+    let g = Guard { v: 42 };
+    @dbg(1);
+    @dbg(2);
+    let _ = g;
+    0
+}
+""" }]
+stdout = "1\n2\n42\n"
+exit_code = 0
+
+# (a) Linear discharge: a linear value @drop'ped is no longer E0406 and runs.
+[[case]]
+name = "linear_discharged_by_drop"
+description = "@drop satisfies a linear value's must-consume obligation; the program compiles and runs."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+
+fn main() -> i32 {
+    let x = L { v: 7 };
+    @drop(x);
+    x.v
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "use of moved value"]
+
+# (a') Linear discharge that actually runs: @drop is the ONLY consumer, so no
+# E0406, and a linear struct WITH a destructor runs it exactly once.
+[[case]]
+name = "linear_with_destructor_discharged_and_runs"
+description = "A linear value with a destructor is discharged by @drop and its destructor runs exactly once (42)."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+
+drop fn L(self) { @dbg(self.v); }
+
+fn main() -> i32 {
+    let x = L { v: 42 };
+    @drop(x);
+    @dbg(99);
+    0
+}
+""" }]
+stdout = "42\n99\n"
+exit_code = 0
+
+# Control: a linear value that is NEVER consumed is rejected (E0406).
+[[case]]
+name = "linear_unconsumed_rejected"
+description = "Control: without @drop (or another consumer) the linear value is E0406."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+
+fn main() -> i32 {
+    let x = L { v: 7 };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0406", "must be consumed"]
+
+# (c) Use after @drop is a use-after-move error (E0205).
+[[case]]
+name = "use_after_drop_is_e0205"
+description = "After @drop(x), x is consumed — using it again is E0205."
+files = [{ path = "main.rue", source = """
+linear struct L { v: i32 }
+
+fn take(l: L) -> i32 { l.v }
+
+fn main() -> i32 {
+    let x = L { v: 7 };
+    @drop(x);
+    take(x)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "use of moved value"]
+
+# (d) @drop of a payload-carrying enum (enum_payloads preview): discharges the
+# value, runs, and drops exactly once. Enum payloads are trivially droppable
+# today, so this pins compile+run (7) rather than payload-glue side effects.
+[[case]]
+name = "drop_payload_enum"
+description = "@drop of a payload-carrying enum compiles, consumes the value, and runs (preview enum_payloads)."
+files = [{ path = "main.rue", source = """
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
+
+fn main() -> i32 {
+    let s = Shape::Circle(5);
+    @drop(s);
+    @dbg(7);
+    0
+}
+""" }]
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+stdout = "7\n"
+exit_code = 0
+
+# (e) Copy value: @drop is a no-op and does NOT consume, so reuse is fine.
+[[case]]
+name = "copy_drop_is_noop_and_reusable"
+description = "@drop of a Copy value is a no-op: it neither runs glue nor consumes, so the value is still usable."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = 9;
+    @drop(x);
+    x
+}
+""" }]
+stdout = ""
+exit_code = 9

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -45,6 +45,11 @@ pub struct PrimitiveTypeSpurs {
     /// expression to give Rust users a targeted "no 'as' operator" error
     /// instead of a generic parse error. (RUE-133)
     pub as_kw: Spur,
+    /// The keyword `drop` — a reserved keyword (for `drop fn`) that is ALSO
+    /// the name of the `@drop(x)` intrinsic (RUE-187). Because the lexer emits
+    /// a dedicated `Drop` token rather than an `Ident`, the intrinsic-name
+    /// parser maps that token back to this interned "drop" symbol.
+    pub drop_kw: Spur,
 }
 
 impl PrimitiveTypeSpurs {
@@ -62,6 +67,7 @@ impl PrimitiveTypeSpurs {
             bool: interner.get_or_intern("bool"),
             self_type: interner.get_or_intern("Self"),
             as_kw: interner.get_or_intern("as"),
+            drop_kw: interner.get_or_intern("drop"),
         }
     }
 }
@@ -1516,10 +1522,23 @@ where
     // Try unambiguous type syntax first, then fall back to expression
     let intrinsic_arg = unambiguous_type.or(expr.clone().map(IntrinsicArg::Expr));
 
+    // The intrinsic name is normally an identifier, but `@drop` (RUE-187)
+    // names the intentional-destroy intrinsic with the `drop` KEYWORD (also
+    // used by `drop fn`). The lexer emits a dedicated `Drop` token for it, so
+    // accept that token here and map it back to the interned "drop" symbol.
+    let drop_intrinsic_name =
+        just(TokenKind::Drop).map_with(|_, e: &mut MapExtra<'src, '_, I, ParserExtras<'src>>| {
+            Ident {
+                name: e.state().0.syms.drop_kw,
+                span: span_from_extra(e),
+            }
+        });
+    let intrinsic_name = ident_parser().or(drop_intrinsic_name);
+
     // Intrinsic call: @name(args) or @import(args)
     // The lexer tokenizes @import specially, so we need to handle both cases
     let intrinsic_call = just(TokenKind::At)
-        .ignore_then(ident_parser())
+        .ignore_then(intrinsic_name)
         .then(
             intrinsic_arg
                 .clone()

--- a/crates/rue-spec/cases/types/destructors.toml
+++ b/crates/rue-spec/cases/types/destructors.toml
@@ -1082,3 +1082,94 @@ fn main() -> i32 {
 """
 exit_code = 0
 expected_stdout = "7\n800\n7\n"
+
+# =============================================================================
+# The `@drop` intrinsic (RUE-187, ADR-0039)
+# =============================================================================
+
+[[case]]
+name = "drop_intrinsic_runs_glue_early"
+spec = ["3.9:37", "3.9:38"]
+description = "@drop(x) runs the destructor at the call site, not at scope exit; expected_stdout pins the ORDER (42 before 2)"
+source = """
+struct Guard { v: i32 }
+
+drop fn Guard(self) { @dbg(self.v); }
+
+fn main() -> i32 {
+    let g = Guard { v: 42 };
+    @dbg(1);
+    @drop(g);   // destructor runs HERE: prints 42
+    @dbg(2);
+    0           // g already consumed — no second drop at scope exit
+}
+"""
+exit_code = 0
+expected_stdout = "1\n42\n2\n"
+
+[[case]]
+name = "drop_intrinsic_dropped_exactly_once"
+spec = ["3.9:38"]
+description = "The scope-exit drop is suppressed after @drop, so the destructor runs exactly once (42 prints once)"
+source = """
+struct Guard { v: i32 }
+
+drop fn Guard(self) { @dbg(self.v); }
+
+fn main() -> i32 {
+    let g = Guard { v: 42 };
+    @drop(g);
+    @dbg(99);
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "42\n99\n"
+
+[[case]]
+name = "drop_intrinsic_use_after_is_error"
+spec = ["3.9:38"]
+description = "Using a value after @drop is a use-after-move error (E0205)"
+source = """
+struct Guard { v: i32 }
+
+drop fn Guard(self) { @dbg(self.v); }
+
+fn take(g: Guard) -> i32 { g.v }
+
+fn main() -> i32 {
+    let g = Guard { v: 1 };
+    @drop(g);
+    take(g)
+}
+"""
+compile_fail = true
+error_contains = "use of moved value"
+
+[[case]]
+name = "drop_intrinsic_discharges_linear"
+spec = ["3.9:39"]
+description = "@drop satisfies a linear value's must-consume obligation: no E0406, program runs"
+source = """
+linear struct L { v: i32 }
+
+fn main() -> i32 {
+    let x = L { v: 7 };
+    @drop(x);   // discharges the linear obligation
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "drop_intrinsic_copy_is_noop"
+spec = ["3.9:39"]
+description = "@drop of a @copy value is a no-op: it neither consumes nor errors, so the value is still usable"
+source = """
+fn main() -> i32 {
+    let x: i32 = 9;
+    @drop(x);   // no-op: i32 is Copy
+    x           // still usable
+}
+"""
+exit_code = 9

--- a/docs/spec/src/03-types/09-destructors.md
+++ b/docs/spec/src/03-types/09-destructors.md
@@ -243,3 +243,34 @@ fn main() -> i32 {
     eat(o.f)  // ERROR: cannot move field `f` out of a value of type 'Outer'
 }
 ```
+
+## The `@drop` intrinsic
+
+{{ rule(id="3.9:37", cat="normative") }}
+
+The `@drop(x)` intrinsic runs the drop glue of its operand `x` — the operand's destructor, if any, followed by the recursive drop of its fields and array elements — at the point of the call, and consumes `x`. It is the deliberate, visible discard of a value: "the drop that would otherwise run at scope exit, invoked by hand." `@drop` is memory-safe and requires no `checked` context.
+
+{{ rule(id="3.9:38", cat="dynamic-semantics") }}
+
+`@drop(x)` consumes `x`: after it, `x` is moved-from, so using `x` again is a use-after-move error (E0205), and the scope-exit drop that would otherwise run for `x` is suppressed. Together these preserve the "dropped exactly once" invariant — the glue runs once, at the `@drop` site, and not again at scope exit.
+
+{{ rule(id="3.9:39", cat="dynamic-semantics") }}
+
+Applied to a `linear` value, `@drop(x)` both runs the glue and satisfies the must-consume obligation (the value is no longer reported as an unconsumed linear value, E0406). Applied to an affine value, it runs the glue early — deterministic cleanup before the end of the enclosing scope. Applied to a `@copy` value, it is a no-op, because a `@copy` value carries no drop glue and no consumption obligation.
+
+{{ rule(id="3.9:40", cat="example") }}
+
+```rue
+linear struct Guard { v: i32 }
+
+drop fn Guard(self) { @dbg(self.v); }
+
+fn main() -> i32 {
+    let g = Guard { v: 42 };
+    @dbg(1);
+    @drop(g);  // runs Guard's destructor here: prints 42
+    @dbg(2);
+    0          // g is already consumed — no drop at scope exit
+}
+// prints: 1, 42, 2
+```


### PR DESCRIPTION
The explicit-discard escape hatch for linear values — the third way (with `match` and `?`) to satisfy a linear obligation, and the completion of the linear-types story. Core, **ungated** intrinsic (linear enforcement already ships ungated, so `@drop` must too, or linear values couldn't be deliberately discarded).

`@drop(x)` runs `x`'s full drop glue **and** discharges its consumption obligation:
- **linear**: discharges the must-consume rule (no longer E0406) + runs glue.
- **affine**: runs the destructor *early* (deterministic cleanup before scope end).
- **Copy**: no-op (still reusable).
- After `@drop(x)`, `x` is consumed (E0205 on reuse).

Reuses existing machinery (**no codegen changes**, both backends): parser accepts the `drop` keyword token as the `@`-intrinsic name; sema `analyze_drop_intrinsic` analyzes the operand as a by-value move (discharges linear, makes later use E0205, suppresses scope-exit drop) then emits the existing `AirInstData::Drop`.

Verified by execution: affine early-drop (`5` then `-1`, once); linear discharged (no E0406); use-after-`@drop` → E0205; `@drop` of a payload enum runs the active-variant glue (`8` then `-1`, composing with #1061); Copy no-op. Full `./test.sh` green; spec 3.9:37–40; 5 spec + 8 CLI cases.

**Completes the linear-`Result` discard needed for RUE-6 phase 2.**

Fixes RUE-187

🤖 Generated with [Claude Code](https://claude.com/claude-code)