### PR TITLE
Generic enums: enum payloads over comptime type params — Option/Result now expressible (RUE-6 phase 2)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1216,8 +1216,7 @@ impl<'a> ConstraintGenerator<'a> {
                     {
                         if !bindings.is_empty() {
                             if let Some(payload) = self
-                                .enums
-                                .get(type_name)
+                                .enum_type_for(type_name)
                                 .and_then(|ty| ty.as_enum())
                                 .map(|id| self.type_pool.enum_def(id))
                                 .and_then(|def| {
@@ -1374,7 +1373,7 @@ impl<'a> ConstraintGenerator<'a> {
 
             // Enum variant
             InstData::EnumVariant { type_name, .. } => {
-                if let Some(&enum_ty) = self.enums.get(type_name) {
+                if let Some(enum_ty) = self.enum_type_for(type_name) {
                     InferType::Concrete(enum_ty)
                 } else {
                     InferType::Concrete(Type::ERROR)
@@ -1606,9 +1605,8 @@ impl<'a> ConstraintGenerator<'a> {
                 // (RUE-221). Checked here first so it takes precedence over the
                 // struct-method path below.
                 let enum_variant = self
-                    .enums
-                    .get(type_name)
-                    .and_then(|ty| ty.as_enum().map(|id| (*ty, id)))
+                    .enum_type_for(type_name)
+                    .and_then(|ty| ty.as_enum().map(|id| (ty, id)))
                     .and_then(|(ty, id)| {
                         let def = self.type_pool.enum_def(id);
                         def.find_variant(self.interner.resolve(function))
@@ -1697,6 +1695,9 @@ impl<'a> ConstraintGenerator<'a> {
             // Anonymous struct type: a struct type used as a comptime value
             // This also has the ComptimeType type.
             InstData::AnonStructType { .. } => InferType::Concrete(Type::COMPTIME_TYPE),
+
+            // Anonymous enum type: an enum (sum) type used as a comptime value.
+            InstData::AnonEnumType { .. } => InferType::Concrete(Type::COMPTIME_TYPE),
         };
 
         // Record the type for this expression
@@ -1810,6 +1811,18 @@ impl<'a> ConstraintGenerator<'a> {
         false
     }
 
+    /// Resolve an enum type name that may be a comptime type-variable binding
+    /// (`let O = Option(i32); O::Some(..)`), falling back to the named-enum
+    /// table. Mirrors sema's `resolve_enum_type_name`; without the
+    /// comptime-alias lookup, generic-enum construction/matching inferred
+    /// `<error>` and poisoned the surrounding constraints (RUE-6 phase 2).
+    fn enum_type_for(&self, type_name: &Spur) -> Option<Type> {
+        self.comptime_local_types
+            .and_then(|aliases| aliases.get(type_name).copied())
+            .filter(|ty| ty.is_enum())
+            .or_else(|| self.enums.get(type_name).copied())
+    }
+
     /// Get the inferred type for a pattern.
     fn pattern_type(&mut self, pattern: &rue_rir::RirPattern) -> InferType {
         match pattern {
@@ -1821,7 +1834,7 @@ impl<'a> ConstraintGenerator<'a> {
             rue_rir::RirPattern::Int { .. } => InferType::IntLiteral,
             rue_rir::RirPattern::Bool(_, _) => InferType::Concrete(Type::BOOL),
             rue_rir::RirPattern::Path { type_name, .. } => {
-                if let Some(&enum_ty) = self.enums.get(type_name) {
+                if let Some(enum_ty) = self.enum_type_for(type_name) {
                     InferType::Concrete(enum_ty)
                 } else {
                     InferType::Concrete(Type::ERROR)

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -14,7 +14,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use lasso::{Spur, ThreadedRodeo};
+use lasso::{Key, Spur, ThreadedRodeo};
 use rue_builtins::{BuiltinReturnType, BuiltinTypeDef};
 use rue_error::{
     CompileError, CompileErrors, CompileResult, CompileWarning, ErrorKind,
@@ -2645,6 +2645,68 @@ impl<'a> Sema<'a> {
 
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::TypeConst(struct_ty),
+                    ty: Type::COMPTIME_TYPE,
+                    span: inst.span,
+                });
+                Ok(AnalysisResult::new(air_ref, Type::COMPTIME_TYPE))
+            }
+
+            // Anonymous enum type: an enum (sum) type constructed at comptime
+            // (e.g., `enum { Some(T), None }` in a comptime type function). The
+            // enum analog of the AnonStructType arm above. Generic anon enums
+            // (payloads mentioning a `comptime T`) are comptime-evaluated, not
+            // analyzed here — this path resolves a concrete anon enum, exactly
+            // as the struct arm does (ADR-0038, RUE-6 phase 2).
+            InstData::AnonEnumType {
+                variants_start,
+                variants_len,
+                payloads_start,
+                payloads_len,
+            } => {
+                let variant_syms = self
+                    .rir
+                    .get_symbols(*variants_start, *variants_len)
+                    .to_vec();
+                let payload_words = self.rir.get_extra(*payloads_start, *payloads_len).to_vec();
+
+                let mut variant_names: Vec<String> = Vec::with_capacity(variant_syms.len());
+                let mut variant_payloads: Vec<Vec<Type>> = Vec::with_capacity(variant_syms.len());
+                let mut pi = 0usize;
+                for vsym in &variant_syms {
+                    variant_names.push(self.interner.resolve(vsym).to_string());
+                    let k = if payload_words.is_empty() {
+                        0
+                    } else {
+                        let k = payload_words[pi] as usize;
+                        pi += 1;
+                        k
+                    };
+                    let mut tys: Vec<Type> = Vec::with_capacity(k);
+                    for _ in 0..k {
+                        let ty_sym = Spur::try_from_usize(payload_words[pi] as usize)
+                            .expect("valid interned type symbol in payload region");
+                        pi += 1;
+                        let field_ty = self.resolve_type(ty_sym, inst.span)?;
+                        // A payload of type `type` cannot exist at runtime
+                        // (spec 4.14:6); reject it like struct fields / enum
+                        // declarations do.
+                        if field_ty.is_comptime_type() {
+                            return Err(CompileError::new(
+                                ErrorKind::ComptimeEvaluationFailed {
+                                    reason: "type values cannot exist at runtime".to_string(),
+                                },
+                                inst.span,
+                            ));
+                        }
+                        tys.push(field_ty);
+                    }
+                    variant_payloads.push(tys);
+                }
+
+                let enum_ty = self.find_or_create_anon_enum(&variant_names, &variant_payloads);
+
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::TypeConst(enum_ty),
                     ty: Type::COMPTIME_TYPE,
                     span: inst.span,
                 });

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1380,13 +1380,17 @@ impl<'a> Sema<'a> {
                         // Qualified access: module.EnumName::Variant
                         self.resolve_enum_through_module(*module_ref, *type_name, pattern_span)?
                     } else {
-                        // Unqualified access: EnumName::Variant
-                        let enum_id = *self.enums.get(type_name).ok_or_compile_error(
-                            ErrorKind::UnknownEnumType(
-                                self.interner.resolve(&*type_name).to_string(),
-                            ),
-                            pattern_span,
-                        )?;
+                        // Unqualified access: EnumName::Variant, or the generic
+                        // form `O::Some(..)` where `O` is a comptime type
+                        // variable bound to `Option(i32)` (RUE-6 phase 2).
+                        let (enum_id, via_comptime) = self
+                            .resolve_enum_type_name(*type_name, ctx)
+                            .ok_or_compile_error(
+                                ErrorKind::UnknownEnumType(
+                                    self.interner.resolve(&*type_name).to_string(),
+                                ),
+                                pattern_span,
+                            )?;
                         // Privacy (E0460, RUE-185): a match pattern names the
                         // enum unqualified, so a private enum from another
                         // directory cannot be matched on — privacy is uniform
@@ -1394,15 +1398,18 @@ impl<'a> Sema<'a> {
                         // module-qualified branch above does its own check
                         // (E0706). The pattern-to-AIR conversion later in
                         // this loop re-resolves the same name but runs only
-                        // after this check has passed.
-                        let def = self.type_pool.enum_def(enum_id);
-                        self.check_unqualified_visibility(
-                            "enum",
-                            self.interner.resolve(&*type_name),
-                            def.file_id,
-                            def.is_pub,
-                            pattern_span,
-                        )?;
+                        // after this check has passed. A comptime-bound enum is
+                        // exempt (the type arrived through a binding).
+                        if !via_comptime {
+                            let def = self.type_pool.enum_def(enum_id);
+                            self.check_unqualified_visibility(
+                                "enum",
+                                self.interner.resolve(&*type_name),
+                                def.file_id,
+                                def.is_pub,
+                                pattern_span,
+                            )?;
+                        }
                         enum_id
                     };
                     let enum_def = self.type_pool.enum_def(enum_id);
@@ -1522,15 +1529,17 @@ impl<'a> Sema<'a> {
                     let enum_id = if let Some(module_ref) = module {
                         self.resolve_enum_through_module(*module_ref, *type_name, pattern_span)?
                     } else {
-                        *self.enums.get(type_name).ok_or_else(|| {
-                            CompileError::new(
-                                ErrorKind::InternalError(format!(
-                                    "enum type '{}' not found during pattern conversion",
-                                    type_name_str
-                                )),
-                                pattern_span,
-                            )
-                        })?
+                        self.resolve_enum_type_name(*type_name, ctx)
+                            .map(|(id, _)| id)
+                            .ok_or_else(|| {
+                                CompileError::new(
+                                    ErrorKind::InternalError(format!(
+                                        "enum type '{}' not found during pattern conversion",
+                                        type_name_str
+                                    )),
+                                    pattern_span,
+                                )
+                            })?
                     };
                     let enum_def = self.type_pool.enum_def(enum_id);
                     let variant_name = self.interner.resolve(&*variant);
@@ -1670,10 +1679,12 @@ impl<'a> Sema<'a> {
         let enum_id = if let Some(module_ref) = module {
             self.resolve_enum_through_module(*module_ref, *type_name, pattern_span)?
         } else {
-            *self.enums.get(type_name).ok_or_compile_error(
-                ErrorKind::UnknownEnumType(self.interner.resolve(&*type_name).to_string()),
-                pattern_span,
-            )?
+            self.resolve_enum_type_name(*type_name, ctx)
+                .map(|(id, _)| id)
+                .ok_or_compile_error(
+                    ErrorKind::UnknownEnumType(self.interner.resolve(&*type_name).to_string()),
+                    pattern_span,
+                )?
         };
         let def = self.type_pool.enum_def(enum_id);
         let variant_name = self.interner.resolve(&*variant).to_string();
@@ -3878,7 +3889,7 @@ impl<'a> Sema<'a> {
         &mut self,
         air: &mut Air,
         inst_ref: InstRef,
-        _ctx: &mut AnalysisContext,
+        ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         let inst = self.rir.get(inst_ref);
 
@@ -3903,25 +3914,34 @@ impl<'a> Sema<'a> {
                     // Qualified access: module.EnumName::Variant
                     self.resolve_enum_through_module(*module_ref, *type_name, inst.span)?
                 } else {
-                    // Unqualified access: EnumName::Variant
-                    let enum_id = *self.enums.get(type_name).ok_or_compile_error(
-                        ErrorKind::UnknownEnumType(self.interner.resolve(&*type_name).to_string()),
-                        inst.span,
-                    )?;
+                    // Unqualified access: EnumName::Variant, or the generic
+                    // form `O::None` where `O` is a comptime type-variable
+                    // bound to `Option(i32)` (RUE-6 phase 2).
+                    let (enum_id, via_comptime) = self
+                        .resolve_enum_type_name(*type_name, ctx)
+                        .ok_or_compile_error(
+                            ErrorKind::UnknownEnumType(
+                                self.interner.resolve(&*type_name).to_string(),
+                            ),
+                            inst.span,
+                        )?;
                     // Privacy (E0460, RUE-185): constructing a variant names
                     // the enum unqualified, so a private enum from another
                     // directory is not constructible here — privacy is
                     // uniform across item kinds (spec 10.3:1, 10.3:7). The
                     // module-qualified branch above does its own check
-                    // (E0706, `resolve_enum_through_module`).
-                    let def = self.type_pool.enum_def(enum_id);
-                    self.check_unqualified_visibility(
-                        "enum",
-                        self.interner.resolve(&*type_name),
-                        def.file_id,
-                        def.is_pub,
-                        inst.span,
-                    )?;
+                    // (E0706, `resolve_enum_through_module`). A comptime-bound
+                    // enum is exempt (the type arrived through a binding).
+                    if !via_comptime {
+                        let def = self.type_pool.enum_def(enum_id);
+                        self.check_unqualified_visibility(
+                            "enum",
+                            self.interner.resolve(&*type_name),
+                            def.file_id,
+                            def.is_pub,
+                            inst.span,
+                        )?;
+                    }
                     enum_id
                 };
                 let enum_def = self.type_pool.enum_def(enum_id);
@@ -4472,6 +4492,25 @@ impl<'a> Sema<'a> {
         self.analyze_method_call_impl(air, receiver, method, args_start, args_len, span, ctx)
     }
 
+    /// Resolve a path/pattern enum type name that may be a comptime
+    /// type-variable binding (`let O = Option(i32); O::Some(..)`), falling
+    /// back to the named-enum table. Returns `(enum_id, via_comptime_binding)`,
+    /// or `None` if the name is not an enum. When `via_comptime_binding` is
+    /// true the enum arrived through a `let` binding (an anonymous enum from a
+    /// comptime type function), so privacy does not apply — mirroring how the
+    /// struct-literal / annotation paths treat comptime type variables as
+    /// privacy-exempt (RUE-6 phase 2).
+    pub(crate) fn resolve_enum_type_name(
+        &self,
+        type_name: Spur,
+        ctx: &AnalysisContext,
+    ) -> Option<(crate::types::EnumId, bool)> {
+        if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
+            return ty.as_enum().map(|id| (id, true));
+        }
+        self.enums.get(&type_name).map(|&id| (id, false))
+    }
+
     /// Analyze an associated function call.
     ///
     /// This is a complex operation. The full implementation is in analysis.rs.
@@ -4485,11 +4524,13 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // Enum tuple-variant construction: `Shape::Circle(5)` (RUE-221). If
-        // `type_name` is an enum whose variant is `function`, build an
-        // `EnumVariant` value carrying the analyzed payload operands rather
-        // than dispatching to associated-function resolution.
-        if let Some(&enum_id) = self.enums.get(&type_name) {
+        // Enum tuple-variant construction: `Shape::Circle(5)` (RUE-221), and
+        // its generic form `O::Some(5)` where `O` is a comptime type-variable
+        // bound to `Option(i32)` (RUE-6 phase 2). If `type_name` resolves to an
+        // enum whose variant is `function`, build an `EnumVariant` value
+        // carrying the analyzed payload operands rather than dispatching to
+        // associated-function resolution.
+        if let Some((enum_id, via_comptime)) = self.resolve_enum_type_name(type_name, ctx) {
             let variant_name = self.interner.resolve(&function).to_string();
             let def = self.type_pool.enum_def(enum_id);
             if let Some(variant_index) = def.find_variant(&variant_name) {
@@ -4498,6 +4539,7 @@ impl<'a> Sema<'a> {
                     enum_id,
                     variant_index as u32,
                     type_name,
+                    via_comptime,
                     args_start,
                     args_len,
                     span,
@@ -4519,6 +4561,7 @@ impl<'a> Sema<'a> {
         enum_id: crate::types::EnumId,
         variant_index: u32,
         type_name: Spur,
+        privacy_exempt: bool,
         args_start: u32,
         args_len: u32,
         span: Span,
@@ -4539,14 +4582,18 @@ impl<'a> Sema<'a> {
         }
 
         // Visibility check, mirroring the bare-path `EnumVariant` handler
-        // (E0460, privacy is uniform across item kinds).
-        self.check_unqualified_visibility(
-            "enum",
-            self.interner.resolve(&type_name),
-            def.file_id,
-            def.is_pub,
-            span,
-        )?;
+        // (E0460, privacy is uniform across item kinds). A comptime-bound enum
+        // (`let O = Option(i32); O::Some(..)`) is exempt: the type value
+        // arrived through a binding, not by naming the enum (privacy_exempt).
+        if !privacy_exempt {
+            self.check_unqualified_visibility(
+                "enum",
+                self.interner.resolve(&type_name),
+                def.file_id,
+                def.is_pub,
+                span,
+            )?;
+        }
 
         let args = self.rir.get_call_args(args_start, args_len);
 

--- a/crates/rue-air/src/sema/anon_structs.rs
+++ b/crates/rue-air/src/sema/anon_structs.rs
@@ -3,13 +3,18 @@
 //! This module implements structural type equality for anonymous structs.
 //! Two anonymous structs with the same field names/types (in order) AND
 //! the same method signatures AND the same captured comptime values are the same type.
+//!
+//! It also implements the enum analog (`find_or_create_anon_enum`): anonymous
+//! enum types produced by comptime type functions like
+//! `fn Option(comptime T: type) -> type { enum { Some(T), None } }`
+//! (ADR-0038, RUE-6 phase 2).
 
 use std::collections::HashMap;
 
 use lasso::Spur;
 
 use crate::sema::context::ConstValue;
-use crate::types::{StructDef, StructField, Type};
+use crate::types::{EnumDef, StructDef, StructField, Type};
 
 use super::Sema;
 use super::info::AnonMethodSig;
@@ -145,5 +150,66 @@ impl Sema<'_> {
 
         // Return with is_new=true
         (Type::new_struct(struct_id), true)
+    }
+
+    /// Find an existing anonymous enum with the same variants and payload
+    /// types, or create a new one. The enum analog of
+    /// [`Self::find_or_create_anon_struct`].
+    ///
+    /// Structural equality is achieved via a *canonical name* that fully
+    /// encodes the variant names and their resolved payload types: two
+    /// instantiations with identical structure (`Option(i32)` reused) intern
+    /// the same name and dedup to one `EnumId`, while distinct structure
+    /// (`Option(i32)` vs `Option(bool)`) interns different names and yields
+    /// distinct enums with correctly-sized tagged-union layouts. Because
+    /// payload types are already fully monomorphized here, captured comptime
+    /// values (e.g. an `[i32; N]` payload) are reflected in the name too, so
+    /// no separate captured-value tracking is needed (unlike anon structs,
+    /// which can capture a value without it appearing in a field type).
+    pub(crate) fn find_or_create_anon_enum(
+        &mut self,
+        variant_names: &[String],
+        variant_payloads: &[Vec<Type>],
+    ) -> Type {
+        // Build the canonical, structure-encoding name.
+        let mut name = String::from("enum { ");
+        for (i, vname) in variant_names.iter().enumerate() {
+            if i > 0 {
+                name.push_str(", ");
+            }
+            name.push_str(vname);
+            let payload = &variant_payloads[i];
+            if !payload.is_empty() {
+                name.push('(');
+                for (j, ty) in payload.iter().enumerate() {
+                    if j > 0 {
+                        name.push_str(", ");
+                    }
+                    name.push_str(&ty.safe_name_with_pool(Some(&self.type_pool)));
+                }
+                name.push(')');
+            }
+        }
+        name.push_str(" }");
+
+        let name_spur = self.interner.get_or_intern(&name);
+
+        let def = EnumDef {
+            name,
+            variants: variant_names.to_vec(),
+            variant_payloads: variant_payloads.to_vec(),
+            is_pub: false,                     // Anonymous enums are private
+            file_id: rue_span::FileId::new(0), // Anonymous, no source file
+        };
+
+        // `register_enum` dedups by interned name, so an equivalent anonymous
+        // enum interned earlier is reused.
+        let (enum_id, _is_new) = self.type_pool.register_enum(name_spur, def);
+
+        // Mirror `find_or_create_anon_struct`, which records the type in the
+        // name→id lookup so later resolution paths see it.
+        self.enums.insert(name_spur, enum_id);
+
+        Type::new_enum(enum_id)
     }
 }

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -49,7 +49,7 @@
 use std::collections::HashMap;
 use std::sync::LazyLock;
 
-use lasso::Spur;
+use lasso::{Key, Spur};
 use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_rir::{InstData, InstRef};
 use rue_span::Span;
@@ -767,6 +767,62 @@ impl Sema<'_> {
                     }
                 }
                 Ok(Some(ConstValue::Type(struct_ty)))
+            }
+
+            // Anonymous enum type: evaluate to a comptime type value, resolving
+            // each variant's payload types through the type/value substitution.
+            // The enum analog of the AnonStructType arm above — this is what
+            // makes `fn Option(comptime T: type) -> type { enum { Some(T), None } }`
+            // monomorphize per instantiation (ADR-0038, RUE-6 phase 2).
+            InstData::AnonEnumType {
+                variants_start,
+                variants_len,
+                payloads_start,
+                payloads_len,
+            } => {
+                let variant_syms: Vec<lasso::Spur> = self
+                    .rir
+                    .get_symbols(*variants_start, *variants_len)
+                    .to_vec();
+                let payload_words: Vec<u32> =
+                    self.rir.get_extra(*payloads_start, *payloads_len).to_vec();
+
+                // Decode the self-describing payload region into per-variant
+                // type-symbol lists (parallel to `variant_syms`), then resolve
+                // each payload type through the substitutions.
+                let mut variant_names: Vec<String> = Vec::with_capacity(variant_syms.len());
+                let mut variant_payloads: Vec<Vec<Type>> = Vec::with_capacity(variant_syms.len());
+                let mut pi = 0usize;
+                for &vsym in &variant_syms {
+                    variant_names.push(self.interner.resolve(&vsym).to_string());
+                    // A variant carries a payload only when the payload region
+                    // is present (`payloads_len > 0`) and describes arity `k`.
+                    let k = if payload_words.is_empty() {
+                        0
+                    } else {
+                        let k = payload_words[pi] as usize;
+                        pi += 1;
+                        k
+                    };
+                    let mut tys: Vec<Type> = Vec::with_capacity(k);
+                    for _ in 0..k {
+                        let ty_sym = lasso::Spur::try_from_usize(payload_words[pi] as usize)
+                            .expect("valid payload type symbol");
+                        pi += 1;
+                        let Some(ty) = self.resolve_type_for_comptime_with_subst_and_values(
+                            ty_sym,
+                            env.type_subst,
+                            env.value_subst,
+                        ) else {
+                            return Ok(None);
+                        };
+                        tys.push(ty);
+                    }
+                    variant_payloads.push(tys);
+                }
+
+                let enum_ty = self.find_or_create_anon_enum(&variant_names, &variant_payloads);
+                Ok(Some(ConstValue::Type(enum_ty)))
             }
 
             // TypeConst: a type used as a value (e.g., `i32` in `identity(i32, 42)`)

--- a/crates/rue-cli-tests/cases/enum_payloads.toml
+++ b/crates/rue-cli-tests/cases/enum_payloads.toml
@@ -176,3 +176,120 @@ fn main() -> i32 { 0 }
 """ }]
 compile_fail = true
 error_contains = ["requires preview feature"]
+
+# =============================================================================
+# Generic enums — Option/Result as comptime type functions (RUE-6 phase 2,
+# ADR-0038). The enum analog of the anonymous-struct comptime type functions:
+# an enum body over a comptime type parameter, monomorphized per instantiation.
+# Definitions are inline (no prelude — RUE-1 is out of scope).
+# =============================================================================
+
+# Option(i32): Some(5) -> 5 and None -> 0, both through a match.
+[[case]]
+name = "generic_option_construct_match"
+description = "Inline generic Option enum: Some(5) matches to 5, None matches to 0; sum is 5."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn main() -> i32 {
+    let O = Option(i32);
+    let x: O = O::Some(5);
+    let y: O = O::None;
+    let a = match x { O::Some(n) => n, O::None => 0 };
+    let b = match y { O::Some(n) => n, O::None => 0 };
+    a + b
+}
+""" }]
+exit_code = 5
+
+# Option(bool) is a distinct instantiation with its own layout and works.
+[[case]]
+name = "generic_option_bool_instantiation"
+description = "Option(bool) is a distinct monomorphization: Some(true) matches to 7."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn main() -> i32 {
+    let O = Option(bool);
+    let x: O = O::Some(true);
+    match x { O::Some(b) => if b { 7 } else { 8 }, O::None => 0 }
+}
+""" }]
+exit_code = 7
+
+# Two-type-parameter Result: both Ok and Err arms construct and match.
+[[case]]
+name = "generic_result_two_params"
+description = "Two-param Result enum: Ok(100) -> 100, Err(true) -> 42; sum is 142."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn main() -> i32 {
+    let R = Result(i32, bool);
+    let ok: R = R::Ok(100);
+    let er: R = R::Err(true);
+    let a = match ok { R::Ok(v) => v, R::Err(e) => if e { 1 } else { 2 } };
+    let b = match er { R::Ok(v) => v, R::Err(e) => if e { 42 } else { 43 } };
+    a + b
+}
+""" }]
+exit_code = 142
+
+# Mixing distinct instantiations (Option(bool) value into Option(i32) slot) is
+# a compile-time type error — monomorphization keeps the types apart.
+[[case]]
+name = "generic_option_distinct_types_rejected"
+description = "Assigning an Option(bool) value to an Option(i32)-typed binding is a type error."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn main() -> i32 {
+    let Oi = Option(i32);
+    let Ob = Option(bool);
+    let x: Oi = Ob::Some(true);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["type mismatch"]
+
+# A payload struct with a destructor, carried by Some(D) of a generic Option,
+# drops through the active variant exactly once at scope exit.
+[[case]]
+name = "generic_enum_payload_drop_once"
+description = "Generic Option holding a struct with `drop fn`: dropping the enum runs the payload destructor once (@dbg prints 33)."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Noisy { code: i32 }
+drop fn Noisy(self) { @dbg(self.code); }
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn main() -> i32 {
+    let O = Option(Noisy);
+    let x: O = O::Some(Noisy { code: 33 });
+    match x {
+        O::Some(v) => v.code,
+        O::None => 0,
+    }
+}
+""" }]
+stdout = "33\n"
+exit_code = 33
+
+# A linear payload type makes the generic enum linear (multiplicity join),
+# so an unconsumed value is a compile error — linearity composes for free,
+# with no special "Result is linear" rule (ADR-0038).
+[[case]]
+name = "generic_enum_linear_payload_must_consume"
+description = "A generic Result whose Err payload is a linear struct is itself linear: leaving it unconsumed is E0406."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+linear struct Token { v: i32 }
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn main() -> i32 {
+    let R = Result(i32, Token);
+    let x: R = R::Ok(5);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["must be consumed"]

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -340,6 +340,17 @@ pub enum TypeExpr {
         methods: Vec<Method>,
         span: Span,
     },
+    /// Anonymous enum type: enum { Variant1, Variant2(T), ... }
+    /// The enum analog of `AnonymousStruct`, used in comptime type
+    /// construction (e.g.
+    /// `fn Option(comptime T: type) -> type { enum { Some(T), None } }`).
+    /// This makes generic sum types like `Option`/`Result` expressible as
+    /// ordinary comptime type functions (ADR-0038, RUE-6 phase 2).
+    AnonymousEnum {
+        /// Variant declarations (name and optional tuple payload types)
+        variants: Vec<EnumVariant>,
+        span: Span,
+    },
     /// Raw pointer to immutable data: ptr const T
     PointerConst { pointee: Box<TypeExpr>, span: Span },
     /// Raw pointer to mutable data: ptr mut T
@@ -390,6 +401,7 @@ impl TypeExpr {
             TypeExpr::Never(span) => *span,
             TypeExpr::Array { span, .. } => *span,
             TypeExpr::AnonymousStruct { span, .. } => *span,
+            TypeExpr::AnonymousEnum { span, .. } => *span,
             TypeExpr::PointerConst { span, .. } => *span,
             TypeExpr::PointerMut { span, .. } => *span,
         }
@@ -420,6 +432,26 @@ impl fmt::Display for TypeExpr {
                         write!(f, ", ")?;
                     }
                     write!(f, "fn sym:{}", method.name.name.into_usize())?;
+                }
+                write!(f, " }}")
+            }
+            TypeExpr::AnonymousEnum { variants, .. } => {
+                write!(f, "enum {{ ")?;
+                for (i, variant) in variants.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "sym:{}", variant.name.name.into_usize())?;
+                    if !variant.payload.is_empty() {
+                        write!(f, "(")?;
+                        for (j, ty) in variant.payload.iter().enumerate() {
+                            if j > 0 {
+                                write!(f, ", ")?;
+                            }
+                            write!(f, "{}", ty)?;
+                        }
+                        write!(f, ")")?;
+                    }
                 }
                 write!(f, " }}")
             }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -1643,6 +1643,22 @@ where
             })
         });
 
+    // Anonymous enum type as expression: enum { Variant1, Variant2(T), ... }
+    // The enum analog of anon_struct_type_expr; enables comptime generic sum
+    // types like `fn Option(comptime T: type) -> type { enum { Some(T), None } }`
+    // (ADR-0038, RUE-6 phase 2).
+    let anon_enum_type_expr = just(TokenKind::Enum)
+        .ignore_then(
+            enum_variants_parser().delimited_by(just(TokenKind::LBrace), just(TokenKind::RBrace)),
+        )
+        .map_with(|variants, e| {
+            let span = span_from_extra(e);
+            Expr::TypeLit(TypeLitExpr {
+                type_expr: TypeExpr::AnonymousEnum { variants, span },
+                span,
+            })
+        });
+
     // Self type expression: Self { field: value } (struct literal with Self as type)
     // This enables constructing instances of anonymous struct types from methods
     let self_type_expr = just(TokenKind::SelfType)
@@ -1679,6 +1695,7 @@ where
         any_intrinsic_call,
         array_lit,
         anon_struct_type_expr,
+        anon_enum_type_expr,
         type_lit_expr,
         call_and_access_parser(expr.clone()),
         paren_expr,
@@ -3974,6 +3991,37 @@ mod tests {
     }
 
     // ==================== Anonymous Struct Method Parsing Tests ====================
+
+    #[test]
+    fn test_anon_enum_type_expr() {
+        // Anonymous enum type as a comptime type-function body: variant names
+        // plus a tuple payload referring to a comptime type parameter (RUE-6
+        // phase 2).
+        let result =
+            parse("fn Option(comptime T: type) -> type { enum { Some(T), None } }").unwrap();
+        match &result.ast.items[0] {
+            Item::Function(f) => {
+                assert_eq!(result.get(f.name.name), "Option");
+                match &f.body {
+                    Expr::Block(block) => match block.expr.as_ref() {
+                        Expr::TypeLit(type_lit) => match &type_lit.type_expr {
+                            TypeExpr::AnonymousEnum { variants, .. } => {
+                                assert_eq!(variants.len(), 2);
+                                assert_eq!(result.get(variants[0].name.name), "Some");
+                                assert_eq!(variants[0].payload.len(), 1);
+                                assert_eq!(result.get(variants[1].name.name), "None");
+                                assert!(variants[1].payload.is_empty());
+                            }
+                            _ => panic!("expected AnonymousEnum"),
+                        },
+                        _ => panic!("expected TypeLit"),
+                    },
+                    _ => panic!("expected Block"),
+                }
+            }
+            _ => panic!("expected Function"),
+        }
+    }
 
     #[test]
     fn test_anon_struct_with_fields_only() {

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -230,6 +230,9 @@ impl Validator<'_> {
                     self.check_method(method);
                 }
             }
+            // Anonymous enum types carry only variant payload type expressions;
+            // no nested methods/bodies to validate.
+            TypeExpr::AnonymousEnum { .. } => {}
             TypeExpr::PointerConst { pointee, .. } | TypeExpr::PointerMut { pointee, .. } => {
                 self.check_type_expr(pointee)
             }

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -118,6 +118,32 @@ impl<'a> AstGen<'a> {
                 s.push_str(" }");
                 self.interner.get_or_intern(&s)
             }
+            TypeExpr::AnonymousEnum { variants, .. } => {
+                // Canonical name representation for an anonymous enum type used
+                // in type position (rare — anon enums normally appear as the
+                // body of a comptime type function, handled via AnonEnumType).
+                let mut s = String::from("enum { ");
+                for (i, variant) in variants.iter().enumerate() {
+                    if i > 0 {
+                        s.push_str(", ");
+                    }
+                    let name = self.interner.resolve(&variant.name.name);
+                    s.push_str(name);
+                    if !variant.payload.is_empty() {
+                        s.push('(');
+                        for (j, ty) in variant.payload.iter().enumerate() {
+                            if j > 0 {
+                                s.push_str(", ");
+                            }
+                            let ty_sym = self.intern_type(ty);
+                            s.push_str(self.interner.resolve(&ty_sym));
+                        }
+                        s.push(')');
+                    }
+                }
+                s.push_str(" }");
+                self.interner.get_or_intern(&s)
+            }
             TypeExpr::PointerConst { pointee, .. } => {
                 // ptr const T
                 let pointee_sym = self.intern_type(pointee);
@@ -804,6 +830,41 @@ impl<'a> AstGen<'a> {
                             span: type_lit.span,
                         })
                     }
+                    TypeExpr::AnonymousEnum { variants, .. } => {
+                        // Generate an anonymous enum type instruction. Variant
+                        // names and tuple-variant payloads are encoded exactly
+                        // as `gen_enum` does for a top-level `enum` declaration
+                        // (RUE-221, ADR-0038).
+                        let variant_syms: Vec<Spur> =
+                            variants.iter().map(|v| v.name.name).collect();
+                        let (variants_start, variants_len) = self.rir.add_symbols(&variant_syms);
+
+                        let has_any_payload = variants.iter().any(|v| !v.payload.is_empty());
+                        let (payloads_start, payloads_len) = if has_any_payload {
+                            let mut payload_words: Vec<u32> = Vec::new();
+                            for variant in variants {
+                                payload_words.push(variant.payload.len() as u32);
+                                for ty in &variant.payload {
+                                    let ty_sym = self.intern_type(ty);
+                                    payload_words.push(ty_sym.into_usize() as u32);
+                                }
+                            }
+                            let start = self.rir.add_extra(&payload_words);
+                            (start, payload_words.len() as u32)
+                        } else {
+                            (0, 0)
+                        };
+
+                        self.rir.add_inst(Inst {
+                            data: InstData::AnonEnumType {
+                                variants_start,
+                                variants_len,
+                                payloads_start,
+                                payloads_len,
+                            },
+                            span: type_lit.span,
+                        })
+                    }
                     _ => {
                         // For named types, unit, never, arrays, and pointers, generate TypeConst
                         let type_name = match &type_lit.type_expr {
@@ -815,7 +876,7 @@ impl<'a> AstGen<'a> {
                                 // For now, use a placeholder
                                 self.interner.get_or_intern_static("array")
                             }
-                            TypeExpr::AnonymousStruct { .. } => {
+                            TypeExpr::AnonymousStruct { .. } | TypeExpr::AnonymousEnum { .. } => {
                                 unreachable!("handled above")
                             }
                             TypeExpr::PointerConst { .. } | TypeExpr::PointerMut { .. } => {

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -1081,6 +1081,22 @@ impl Rir {
                 methods_start: *methods_start + extra_offset,
                 methods_len: *methods_len,
             },
+            InstData::AnonEnumType {
+                variants_start,
+                variants_len,
+                payloads_start,
+                payloads_len,
+            } => InstData::AnonEnumType {
+                variants_start: *variants_start + extra_offset,
+                variants_len: *variants_len,
+                // Empty payload region has no allocated slot (mirrors EnumDecl).
+                payloads_start: if *payloads_len == 0 {
+                    0
+                } else {
+                    *payloads_start + extra_offset
+                },
+                payloads_len: *payloads_len,
+            },
         };
 
         Inst {
@@ -1283,6 +1299,9 @@ impl Rir {
                 | InstData::DropFnDecl { .. }
                 | InstData::Comptime { .. }
                 | InstData::Checked { .. }
+                // AnonEnumType stores only variant-name and payload type
+                // symbols in extra, never InstRefs — nothing to renumber.
+                | InstData::AnonEnumType { .. }
                 | InstData::TypeConst { .. } => {}
             }
         }
@@ -1732,6 +1751,25 @@ pub enum InstData {
         methods_start: u32,
         /// Number of methods (InstRefs to FnDecl instructions)
         methods_len: u32,
+    },
+
+    /// Anonymous enum type: an enum (sum) type used as a value expression
+    /// (e.g., `enum { Some(T), None }` in comptime type construction). The
+    /// enum analog of [`InstData::AnonStructType`]; enables generic sum types
+    /// like `Option`/`Result` as comptime type functions (ADR-0038, RUE-6
+    /// phase 2). Variant names and tuple-variant payloads are encoded exactly
+    /// as in [`InstData::EnumDecl`].
+    AnonEnumType {
+        /// Index into extra data where variant name symbols start
+        variants_start: u32,
+        /// Number of variants
+        variants_len: u32,
+        /// Index into extra data where the tuple-variant payloads start,
+        /// encoded as in [`InstData::EnumDecl`]: a self-describing flat
+        /// sequence of `count` + `count` type-name symbols per variant.
+        payloads_start: u32,
+        /// Number of u32 words in the payloads region (0 when no payloads).
+        payloads_len: u32,
     },
 }
 
@@ -2283,6 +2321,37 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                         write!(out, "methods: [{}]", methods_str.join(", ")).unwrap();
                     }
                     writeln!(out, " }}").unwrap();
+                }
+
+                // Anonymous enum type
+                InstData::AnonEnumType {
+                    variants_start,
+                    variants_len,
+                    payloads_start,
+                    payloads_len,
+                } => {
+                    let variants = self.rir.get_symbols(*variants_start, *variants_len);
+                    // Decode payloads (self-describing [k, t0..t_{k-1}] per variant).
+                    let payload_words = self.rir.get_extra(*payloads_start, *payloads_len);
+                    let mut payload_arities: Vec<usize> = Vec::new();
+                    let mut pi = 0usize;
+                    while pi < payload_words.len() {
+                        let k = payload_words[pi] as usize;
+                        payload_arities.push(k);
+                        pi += 1 + k;
+                    }
+                    let variants_str: Vec<String> = variants
+                        .iter()
+                        .enumerate()
+                        .map(|(i, v)| {
+                            let base = self.interner.resolve(&*v).to_string();
+                            match payload_arities.get(i) {
+                                Some(k) if *k > 0 => format!("{}/{}", base, k),
+                                _ => base,
+                            }
+                        })
+                        .collect();
+                    writeln!(out, "enum {{ {} }}", variants_str.join(", ")).unwrap();
                 }
             }
         }

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1570,3 +1570,101 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Anonymous enum types (generic sum types: Option/Result) — RUE-6 phase 2,
+# ADR-0038. The enum analog of the anonymous-struct comptime type functions
+# above; each instantiation is monomorphized with its own tagged-union layout.
+# =============================================================================
+
+[[case]]
+name = "anon_enum_generic_option_some"
+spec = ["4.14:20"]
+preview = "enum_payloads"
+description = "Generic Option enum: construct Some(T) and match it out (ADR-0038 deliverable)"
+source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn main() -> i32 {
+    let O = Option(i32);
+    let x: O = O::Some(42);
+    match x { O::Some(n) => n, O::None => 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "anon_enum_generic_option_none"
+spec = ["4.14:20"]
+preview = "enum_payloads"
+description = "Generic Option enum: the None variant selects the default arm"
+source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn main() -> i32 {
+    let O = Option(i32);
+    let x: O = O::None;
+    match x { O::Some(n) => n, O::None => 42 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "anon_enum_two_type_params_result"
+spec = ["4.14:20"]
+preview = "enum_payloads"
+description = "Two-type-parameter Result enum: both Ok and Err arms construct and match"
+source = """
+fn Result(comptime T: type, comptime E: type) -> type {
+    enum { Ok(T), Err(E) }
+}
+fn main() -> i32 {
+    let R = Result(i32, bool);
+    let ok: R = R::Ok(40);
+    let er: R = R::Err(true);
+    let a = match ok { R::Ok(v) => v, R::Err(e) => if e { 1 } else { 2 } };
+    let b = match er { R::Ok(v) => v, R::Err(e) => if e { 2 } else { 3 } };
+    a + b
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "anon_enum_monomorphized_distinct"
+spec = ["4.14:21"]
+preview = "enum_payloads"
+description = "Option(i32) and Option(bool) are distinct types: mixing them is a type error"
+source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn main() -> i32 {
+    let Oi = Option(i32);
+    let Ob = Option(bool);
+    let x: Oi = Ob::Some(true);
+    0
+}
+"""
+compile_fail = true
+error_contains = "type mismatch"
+
+[[case]]
+name = "anon_enum_structural_reuse"
+spec = ["4.14:21"]
+preview = "enum_payloads"
+description = "Two Option(i32) instantiations are structurally equal and interchangeable"
+source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn main() -> i32 {
+    let A = Option(i32);
+    let B = Option(i32);
+    let x: A = A::Some(42);
+    let y: B = x;
+    match y { B::Some(n) => n, B::None => 0 }
+}
+"""
+exit_code = 42

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -363,3 +363,44 @@ fn C() -> type {
     struct { x: i32, fn get(self) -> i64 { self.x as i64 } }  // Different type (i64 vs i32)
 }
 ```
+
+{{ rule(id="4.14:20", cat="normative") }}
+
+A comptime function that returns `type` can construct an anonymous enum (sum) type using the following syntax:
+
+```ebnf
+anon_enum_type = "enum" "{" [ enum_variant { "," enum_variant } ] "}" ;
+enum_variant = IDENT [ "(" type { "," type } ")" ] ;
+```
+
+Anonymous enums are the sum-type analog of anonymous struct types (rule 4.14:7) and may be parameterized by comptime type parameters, which makes generic sum types such as `Option` and `Result` expressible as ordinary library functions rather than compiler builtins:
+
+```rue
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+
+fn main() -> i32 {
+    let O = Option(i32);
+    let x: O = O::Some(5);
+    match x { O::Some(n) => n, O::None => 0 }
+}
+```
+
+Each instantiation is monomorphized: `Option(i32)` and `Option(bool)` are distinct types with independent tagged-union layouts (the payload types differ). A variant that carries a payload requires the `enum_payloads` preview feature, exactly as for a named enum declaration.
+
+{{ rule(id="4.14:21", cat="normative") }}
+
+Two anonymous enum types are structurally equal if and only if they have the same variant names in the same order carrying the same payload types. Consequently, two instantiations of the same comptime type function with the same type arguments (for example `Option(i32)` evaluated twice) denote the same type, while instantiations with different type arguments denote different, non-assignable types.
+
+```rue
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+
+fn main() -> i32 {
+    let A = Option(i32);
+    let B = Option(i32);
+    let x: A = A::Some(10);
+    let y: B = x;  // OK: A and B are structurally equal
+    match y { B::Some(n) => n, B::None => 0 }
+}
+```


### PR DESCRIPTION
The enum analog of anonymous-struct comptime type functions (ADR-0038). A comptime type function returning an enum with a type-parameter payload now compiles, constructs, matches, and monomorphizes per instantiation:

    fn Option(comptime T: type) -> type { enum { Some(T), None } }
    fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }

- Parser \`TypeExpr::AnonymousEnum\` + \`anon_enum_type_expr\`; RIR \`AnonEnumType\`; sema \`find_or_create_anon_enum\` (structural equality then monomorphization) + \`resolve_enum_type_name\` so a \`let O = Option(i32)\` binding resolves at construction/match/pattern sites.
- No codegen/CFG changes: a monomorphized generic enum is an ordinary EnumDef, so RUE-221 tagged-union layout + drop glue + linear infectiousness compose for free.

The design held: \`Result(i32, LinearToken)\` is automatically must-consume via the existing linear infectiousness — no special 'Result is always linear' rule.

Verified by execution: Option(i32) Some(5) gives 5, None gives 0; Option(bool) distinct; two-param Result both arms; mixing Option(i32)/Option(bool) is E0206; Some(D) with a drop fn drops once; Result(i32, LinearToken) linear gives E0406. aarch64 asm clean. Full ./test.sh green; spec 4.14:20/21; 5 spec + 6 CLI cases.

Prelude auto-availability (RUE-1) and the ? operator (phase 3) remain.

Part of RUE-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)