### PR TITLE
Array-repeat literal [value; N] (RUE-235, preview array_repeat)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -15,7 +15,7 @@ use crate::types::{
     ArrayLen, PtrMutability, StructId, TypeKind, parse_array_type_syntax, parse_pointer_type_syntax,
 };
 use lasso::{Spur, ThreadedRodeo};
-use rue_rir::{InstData, InstRef, Rir};
+use rue_rir::{InstData, InstRef, RepeatCount, Rir};
 use rue_span::{FileId, Span};
 use std::collections::HashMap;
 
@@ -1410,6 +1410,30 @@ impl<'a> ConstraintGenerator<'a> {
                         element: Box::new(first_info.ty),
                         length: elements.len() as u64,
                     }
+                }
+            }
+
+            // Array-repeat literal `[value; count]` (RUE-235). The array type
+            // is `[typeof value; count]`; every slot has the value's type. The
+            // count is a compile-time constant resolved here (literal or a
+            // file-level `const`); an unresolved count (e.g. a `comptime` value
+            // parameter, only known at specialization) yields a fresh variable
+            // and is resolved/diagnosed by sema.
+            InstData::ArrayRepeat { value, count } => {
+                let value_info = self.generate(*value, ctx);
+                let resolved = match count {
+                    RepeatCount::Literal(n) => Some(*n),
+                    RepeatCount::Named(sym) => self
+                        .const_values
+                        .and_then(|cv| cv.get(sym))
+                        .and_then(|v| u64::try_from(*v).ok()),
+                };
+                match resolved {
+                    Some(length) => InferType::Array {
+                        element: Box::new(value_info.ty),
+                        length,
+                    },
+                    None => InferType::Var(self.fresh_var()),
                 }
             }
 

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -2460,9 +2460,10 @@ impl<'a> Sema<'a> {
             | InstData::FieldSet { .. } => self.analyze_struct_ops(air, inst_ref, ctx),
 
             // Array operations
-            InstData::ArrayInit { .. } | InstData::IndexGet { .. } | InstData::IndexSet { .. } => {
-                self.analyze_array_ops(air, inst_ref, ctx)
-            }
+            InstData::ArrayInit { .. }
+            | InstData::ArrayRepeat { .. }
+            | InstData::IndexGet { .. }
+            | InstData::IndexSet { .. } => self.analyze_array_ops(air, inst_ref, ctx),
 
             // Enum operations
             InstData::EnumDecl { .. } | InstData::EnumVariant { .. } => {

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3407,6 +3407,10 @@ impl<'a> Sema<'a> {
                 elems_len,
             } => self.analyze_array_init(air, inst_ref, *elems_start, *elems_len, inst.span, ctx),
 
+            InstData::ArrayRepeat { value, .. } => {
+                self.analyze_array_repeat(air, inst_ref, *value, inst.span, ctx)
+            }
+
             InstData::IndexGet { base, index } => {
                 self.analyze_index_get(air, inst_ref, *base, *index, inst.span, ctx)
             }
@@ -3500,6 +3504,88 @@ impl<'a> Sema<'a> {
         // Encode into extra array
         let elems_len = air_elems.len() as u32;
         let elem_u32s: Vec<u32> = air_elems.iter().map(|r| r.as_u32()).collect();
+        let elems_start = air.add_extra(&elem_u32s);
+
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::ArrayInit {
+                elems_start,
+                elems_len,
+            },
+            ty: array_type,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, array_type))
+    }
+
+    /// Analyze an array-repeat literal `[value; count]` (RUE-235).
+    ///
+    /// The result type `[ElemType; count]` was inferred by HM (the count is a
+    /// compile-time constant resolved during constraint generation via the
+    /// array-length const-eval path). This analysis:
+    /// 1. gates the form behind the `array_repeat` preview feature;
+    /// 2. requires the element type to be `Copy` — a repeat materializes
+    ///    `count` copies of one value, which is only sound for Copy elements
+    ///    (matching Rust's `[v; N]: Copy`);
+    /// 3. evaluates `value` exactly once and desugars to an `ArrayInit` whose
+    ///    `count` elements all reference that single evaluated value, so the
+    ///    existing per-element store lowering fills every slot on both
+    ///    backends with no codegen changes.
+    fn analyze_array_repeat(
+        &mut self,
+        air: &mut Air,
+        inst_ref: InstRef,
+        value_ref: InstRef,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        // Gate the whole form: without `--preview array_repeat`, using
+        // `[value; count]` is a "requires preview feature" error.
+        self.require_preview(
+            PreviewFeature::ArrayRepeat,
+            "array-repeat literal `[value; count]`",
+            span,
+        )?;
+
+        let array_type = Self::get_resolved_type(ctx, inst_ref, span, "array-repeat literal")?;
+
+        // If the value expression is ill-typed, HM collapses the array to
+        // `<error>`; analyze the value to surface its real diagnostic rather
+        // than masking it with an ICE about a non-array type (mirrors
+        // `analyze_array_init`, RUE-190/RUE-153).
+        if array_type.is_error() {
+            self.analyze_inst(air, value_ref, ctx)?;
+            return Err(CompileError::new(ErrorKind::TypeAnnotationRequired, span));
+        }
+
+        let (elem_type, length) = match array_type.as_array() {
+            Some(type_id) => self.type_pool.array_def(type_id),
+            None => {
+                return Err(CompileError::new(
+                    ErrorKind::InternalError(format!(
+                        "Array-repeat literal inferred as non-array type: {}",
+                        array_type.safe_name_with_pool(Some(&self.type_pool))
+                    )),
+                    span,
+                ));
+            }
+        };
+
+        // Require the element type to be Copy (RUE-235).
+        if !self.is_type_copy(elem_type) {
+            return Err(CompileError::new(
+                ErrorKind::ArrayRepeatNonCopy {
+                    element_type: elem_type.safe_name_with_pool(Some(&self.type_pool)),
+                },
+                span,
+            ));
+        }
+
+        // Evaluate the repeated value exactly once.
+        let value_result = self.analyze_inst(air, value_ref, ctx)?;
+
+        // Desugar to ArrayInit: `length` elements, each the single value.
+        let elem_u32s: Vec<u32> = vec![value_result.air_ref.as_u32(); length as usize];
+        let elems_len = elem_u32s.len() as u32;
         let elems_start = air.add_extra(&elem_u32s);
 
         let air_ref = air.add_inst(AirInst {

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -79,6 +79,7 @@ mod tests {
         "EnumVariant",
         // Arrays
         "ArrayInit",
+        "ArrayRepeat",
         "IndexGet",
         "IndexSet",
         // Methods

--- a/crates/rue-cli-tests/cases/array_repeat.toml
+++ b/crates/rue-cli-tests/cases/array_repeat.toml
@@ -1,0 +1,91 @@
+# Array-repeat literal `[value; count]` (RUE-235, preview: array_repeat).
+#
+# Exercises the real driver end-to-end: the repeat form fills `count` slots
+# with copies of a single value, the count may be a literal or a named const,
+# a non-Copy element is rejected, and the form is preview-gated. stdout is
+# pinned (via @dbg) so a miscompiled fill is caught, not just the exit code.
+
+[section]
+id = "cli.array_repeat"
+name = "Array-repeat literals"
+description = "The `[value; count]` array-repeat literal fills count slots with copies of value (RUE-235)."
+
+[[case]]
+name = "repeat_literal_count"
+args = ["--preview", "array_repeat", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let b = [7; 3];
+    @dbg(b[0] + b[1] + b[2]);
+    0
+}
+""" }]
+stdout = "21\n"
+
+[[case]]
+name = "repeat_zeros_128_all_zero"
+args = ["--preview", "array_repeat", "--preview", "for_loops", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: [i32; 128] = [0; 128];
+    let mut sum: i32 = 0;
+    for x in a {
+        sum = sum + x;
+    }
+    @dbg(sum);
+    0
+}
+""" }]
+stdout = "0\n"
+
+[[case]]
+name = "repeat_named_const_count"
+args = ["--preview", "array_repeat", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+const N: usize = 4;
+fn main() -> i32 {
+    let c = [5; N];
+    @dbg(c[0] + c[1] + c[2] + c[3]);
+    0
+}
+""" }]
+stdout = "20\n"
+
+[[case]]
+name = "repeat_copy_struct_fills_each_slot"
+args = ["--preview", "array_repeat", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+@copy
+struct P { x: i32, y: i32 }
+fn main() -> i32 {
+    let arr = [P { x: 3, y: 4 }; 2];
+    @dbg(arr[0].x + arr[0].y + arr[1].x + arr[1].y);
+    0
+}
+""" }]
+stdout = "14\n"
+
+[[case]]
+name = "repeat_non_copy_element_rejected"
+args = ["--preview", "array_repeat", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Data { value: i32 }
+fn main() -> i32 {
+    let d = Data { value: 1 };
+    let arr = [d; 3];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0905", "not Copy"]
+
+[[case]]
+name = "repeat_requires_preview"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let b = [7; 3];
+    b[0]
+}
+""" }]
+compile_fail = true
+error_contains = ["requires preview feature", "array_repeat"]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -214,6 +214,7 @@ impl ErrorCode {
     pub const INDEX_OUT_OF_BOUNDS: Self = Self(902);
     pub const TYPE_ANNOTATION_REQUIRED: Self = Self(903);
     pub const MOVE_OUT_OF_INDEX: Self = Self(904);
+    pub const ARRAY_REPEAT_NON_COPY: Self = Self(905);
 
     // ========================================================================
     // Linker/target errors (E1000-E1099)
@@ -366,6 +367,10 @@ pub enum PreviewFeature {
     /// pattern matching with payload bindings (`match s { Circle(r) => r }`).
     /// The prerequisite for `Option`/`Result`.
     EnumPayloads,
+    /// Array-repeat literal `[value; count]` — build an array of `count`
+    /// copies of `value` (RUE-235). `count` is a compile-time constant and
+    /// the element type must be `Copy`.
+    ArrayRepeat,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -389,6 +394,7 @@ impl PreviewFeature {
             PreviewFeature::ForLoops => "for_loops",
             PreviewFeature::MethodReceivers => "method_receivers",
             PreviewFeature::EnumPayloads => "enum_payloads",
+            PreviewFeature::ArrayRepeat => "array_repeat",
         }
     }
 
@@ -400,6 +406,7 @@ impl PreviewFeature {
             PreviewFeature::ForLoops => "ADR-0037",
             PreviewFeature::MethodReceivers => "ADR-0037",
             PreviewFeature::EnumPayloads => "ADR-0038",
+            PreviewFeature::ArrayRepeat => "ADR-0005",
         }
     }
 
@@ -410,6 +417,7 @@ impl PreviewFeature {
             PreviewFeature::ForLoops,
             PreviewFeature::MethodReceivers,
             PreviewFeature::EnumPayloads,
+            PreviewFeature::ArrayRepeat,
         ]
     }
 
@@ -436,6 +444,7 @@ impl std::str::FromStr for PreviewFeature {
             "for_loops" => Ok(PreviewFeature::ForLoops),
             "method_receivers" => Ok(PreviewFeature::MethodReceivers),
             "enum_payloads" => Ok(PreviewFeature::EnumPayloads),
+            "array_repeat" => Ok(PreviewFeature::ArrayRepeat),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -1220,6 +1229,12 @@ pub enum ErrorKind {
     /// that element out (spec 3.8:68, RUE-186).
     #[error("cannot move out of indexed position: element type '{element_type}' is not Copy")]
     MoveOutOfIndex { element_type: String },
+    /// Array-repeat literal `[value; count]` whose element type is not Copy.
+    /// A repeat literal materializes `count` copies of a single value, so the
+    /// element type must be Copy (matching Rust's `[v; N]: Copy` requirement,
+    /// RUE-235).
+    #[error("array-repeat literal requires a Copy element type, but '{element_type}' is not Copy")]
+    ArrayRepeatNonCopy { element_type: String },
     /// Assignment into an array (element write, or a write through an element)
     /// while one or more of its elements are moved out (RUE-186). Reinstating
     /// per-element ownership through writes is not supported; the whole array
@@ -1383,6 +1398,7 @@ impl ErrorKind {
             ErrorKind::IndexOutOfBounds { .. } => ErrorCode::INDEX_OUT_OF_BOUNDS,
             ErrorKind::TypeAnnotationRequired => ErrorCode::TYPE_ANNOTATION_REQUIRED,
             ErrorKind::MoveOutOfIndex { .. } => ErrorCode::MOVE_OUT_OF_INDEX,
+            ErrorKind::ArrayRepeatNonCopy { .. } => ErrorCode::ARRAY_REPEAT_NON_COPY,
             ErrorKind::AssignToPartiallyMovedArray { .. } => {
                 ErrorCode::ASSIGN_TO_PARTIALLY_MOVED_ARRAY
             }
@@ -2214,7 +2230,7 @@ mod tests {
         let names = PreviewFeature::all_names();
         assert_eq!(
             names,
-            "test_infra, for_loops, method_receivers, enum_payloads"
+            "test_infra, for_loops, method_receivers, enum_payloads, array_repeat"
         );
     }
 

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -823,11 +823,24 @@ pub struct MethodCallExpr {
     pub span: Span,
 }
 
-/// An array literal expression (e.g., `[1, 2, 3]`).
+/// An array literal expression.
+///
+/// Two forms share this node:
+/// * List form `[1, 2, 3]`: `elements` holds every element and `repeat` is
+///   `None`.
+/// * Repeat form `[value; count]` (RUE-235): `elements` holds the single
+///   `value` expression and `repeat` holds the `count`. The count is a
+///   compile-time constant (an integer literal or a named `const` /
+///   `comptime` value parameter), resolved during semantic analysis via the
+///   same const-eval path as array-type lengths.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ArrayLitExpr {
-    /// Array elements
+    /// Array elements. For the repeat form this holds exactly one element: the
+    /// value being repeated.
     pub elements: Vec<Expr>,
+    /// For the repeat form `[value; count]`, the repeat count; `None` for the
+    /// list form.
+    pub repeat: Option<ArrayLength>,
     pub span: Span,
 }
 
@@ -1395,7 +1408,10 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
             Ok(())
         }
         Expr::ArrayLit(array) => {
-            writeln!(f, "ArrayLit")?;
+            match &array.repeat {
+                Some(count) => writeln!(f, "ArrayLit (repeat; count={count})")?,
+                None => writeln!(f, "ArrayLit")?,
+            }
             for elem in &array.elements {
                 fmt_expr(f, elem, level + 1)?;
             }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -1580,15 +1580,38 @@ where
     // Combined intrinsic parser: try @import first, then general @name pattern
     let any_intrinsic_call = import_call.or(intrinsic_call);
 
-    // Array literal: [expr, expr, ...]
-    let array_lit = args_parser(expr.clone())
+    // Array literal, two forms (RUE-235):
+    //   list form:   [expr, expr, ...]
+    //   repeat form: [value ; count]   where count is a compile-time constant
+    //                                  (integer literal or named const/comptime)
+    // The repeat form is distinguished by the `;` following the first expr; it
+    // is tried first and backtracks to the list form when there is no `;`.
+    let array_repeat_count = choice((
+        select! { TokenKind::Int(n) => ArrayLength::Literal(n as u64) },
+        ident_parser().map(ArrayLength::Named),
+    ));
+    let array_repeat = expr
+        .clone()
+        .then_ignore(just(TokenKind::Semi))
+        .then(array_repeat_count)
+        .delimited_by(just(TokenKind::LBracket), just(TokenKind::RBracket))
+        .map_with(|(value, count), e| {
+            Expr::ArrayLit(ArrayLitExpr {
+                elements: vec![value],
+                repeat: Some(count),
+                span: span_from_extra(e),
+            })
+        });
+    let array_list = args_parser(expr.clone())
         .delimited_by(just(TokenKind::LBracket), just(TokenKind::RBracket))
         .map_with(|elements, e| {
             Expr::ArrayLit(ArrayLitExpr {
                 elements,
+                repeat: None,
                 span: span_from_extra(e),
             })
         });
+    let array_lit = array_repeat.or(array_list);
 
     // Type literal expression: i32, bool, etc. used as values
     // This enables generic function calls like identity(i32, 42)

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -16,8 +16,8 @@ use rue_parser::{
 };
 
 use crate::inst::{
-    Inst, InstData, InstRef, Rir, RirArgMode, RirCallArg, RirDirective, RirParam, RirParamMode,
-    RirPattern,
+    Inst, InstData, InstRef, RepeatCount, Rir, RirArgMode, RirCallArg, RirDirective, RirParam,
+    RirParamMode, RirPattern,
 };
 
 /// Generates RIR from an AST.
@@ -694,20 +694,35 @@ impl<'a> AstGen<'a> {
                 })
             }
             Expr::ArrayLit(array_lit) => {
-                let elements: Vec<_> = array_lit
-                    .elements
-                    .iter()
-                    .map(|e| self.gen_expr(e))
-                    .collect();
-                let (elems_start, elems_len) = self.rir.add_inst_refs(&elements);
+                if let Some(count) = &array_lit.repeat {
+                    // Repeat form `[value; count]` (RUE-235): the single value
+                    // is evaluated once; the count is carried symbolically and
+                    // resolved during sema via the array-length const-eval path.
+                    let value = self.gen_expr(&array_lit.elements[0]);
+                    let count = match count {
+                        ArrayLength::Literal(n) => RepeatCount::Literal(*n),
+                        ArrayLength::Named(ident) => RepeatCount::Named(ident.name),
+                    };
+                    self.rir.add_inst(Inst {
+                        data: InstData::ArrayRepeat { value, count },
+                        span: array_lit.span,
+                    })
+                } else {
+                    let elements: Vec<_> = array_lit
+                        .elements
+                        .iter()
+                        .map(|e| self.gen_expr(e))
+                        .collect();
+                    let (elems_start, elems_len) = self.rir.add_inst_refs(&elements);
 
-                self.rir.add_inst(Inst {
-                    data: InstData::ArrayInit {
-                        elems_start,
-                        elems_len,
-                    },
-                    span: array_lit.span,
-                })
+                    self.rir.add_inst(Inst {
+                        data: InstData::ArrayInit {
+                            elems_start,
+                            elems_len,
+                        },
+                        span: array_lit.span,
+                    })
+                }
             }
             Expr::Index(index_expr) => {
                 let base = self.gen_expr(&index_expr.base);

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -1024,6 +1024,10 @@ impl Rir {
                 elems_start: *elems_start + extra_offset,
                 elems_len: *elems_len,
             },
+            InstData::ArrayRepeat { value, count } => InstData::ArrayRepeat {
+                value: renumber(*value),
+                count: *count,
+            },
             InstData::IndexGet { base, index } => InstData::IndexGet {
                 base: renumber(*base),
                 index: renumber(*index),
@@ -1293,6 +1297,7 @@ impl Rir {
                 | InstData::FieldSet { .. }
                 | InstData::EnumDecl { .. }
                 | InstData::EnumVariant { .. }
+                | InstData::ArrayRepeat { .. }
                 | InstData::IndexGet { .. }
                 | InstData::IndexSet { .. }
                 | InstData::TypeIntrinsic { .. }
@@ -1313,6 +1318,20 @@ impl Rir {
 pub struct Inst {
     pub data: InstData,
     pub span: Span,
+}
+
+/// The repeat count of an array-repeat literal `[value; count]` (RUE-235).
+///
+/// The count is a compile-time constant: either an integer literal (`[0; 128]`)
+/// or a name referring to a `const` / `comptime` value parameter (`[0; N]`).
+/// Named counts are resolved to a concrete value during semantic analysis using
+/// the same const-eval machinery as array-type lengths.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RepeatCount {
+    /// A literal count, e.g. the `128` in `[0; 128]`.
+    Literal(u64),
+    /// A named count, e.g. the `N` in `[0; N]`.
+    Named(Spur),
 }
 
 /// Instruction data - the actual operation.
@@ -1661,6 +1680,17 @@ pub enum InstData {
         elems_start: u32,
         /// Number of elements
         elems_len: u32,
+    },
+
+    /// Array-repeat literal `[value; count]` (RUE-235): creates an array of
+    /// `count` copies of a single `value`. `value` is evaluated once and its
+    /// (Copy) result fills every slot. The count is a compile-time constant
+    /// resolved during semantic analysis.
+    ArrayRepeat {
+        /// The value being repeated (evaluated once).
+        value: InstRef,
+        /// The repeat count (literal or named compile-time constant).
+        count: RepeatCount,
     },
 
     /// Array index read: reads an element from an array
@@ -2223,6 +2253,15 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     let elems_str: Vec<String> =
                         elements.iter().map(|e| format!("{}", e)).collect();
                     writeln!(out, "array_init [{}]", elems_str.join(", ")).unwrap();
+                }
+                InstData::ArrayRepeat { value, count } => {
+                    let count_str = match count {
+                        RepeatCount::Literal(n) => n.to_string(),
+                        RepeatCount::Named(sym) => {
+                            format!("sym:{}", sym.into_usize())
+                        }
+                    };
+                    writeln!(out, "array_repeat [{}; {}]", value, count_str).unwrap();
                 }
                 InstData::IndexGet { base, index } => {
                     writeln!(out, "index_get {}[{}]", base, index).unwrap();

--- a/crates/rue-rir/src/lib.rs
+++ b/crates/rue-rir/src/lib.rs
@@ -15,6 +15,6 @@ mod inst;
 
 pub use astgen::AstGen;
 pub use inst::{
-    Inst, InstData, InstRef, Rir, RirArgMode, RirCallArg, RirDirective, RirParam, RirParamMode,
-    RirPattern, RirPrinter,
+    Inst, InstData, InstRef, RepeatCount, Rir, RirArgMode, RirCallArg, RirDirective, RirParam,
+    RirParamMode, RirPattern, RirPrinter,
 };

--- a/crates/rue-spec/cases/arrays/fixed.toml
+++ b/crates/rue-spec/cases/arrays/fixed.toml
@@ -873,3 +873,89 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "not a compile-time constant"
+
+# =============================================================================
+# Array-Repeat Literals (RUE-235, preview: array_repeat)
+# =============================================================================
+
+[[case]]
+name = "array_repeat_literal_count"
+spec = ["7.1:36", "7.1:39"]
+preview = "array_repeat"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let b = [7; 3];
+    b[0] + b[1] + b[2]
+}
+"""
+exit_code = 21
+
+[[case]]
+name = "array_repeat_zeros_annotated"
+spec = ["7.1:36"]
+preview = "array_repeat"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let a: [i32; 4] = [0; 4];
+    a[0] + a[1] + a[2] + a[3]
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "array_repeat_named_const_count"
+spec = ["7.1:37"]
+preview = "array_repeat"
+preview_should_pass = true
+source = """
+const N: usize = 4;
+fn main() -> i32 {
+    let c = [5; N];
+    c[0] + c[1] + c[2] + c[3]
+}
+"""
+exit_code = 20
+
+[[case]]
+name = "array_repeat_evaluates_value_once"
+spec = ["7.1:39"]
+preview = "array_repeat"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let v = 6;
+    let a = [v; 5];
+    a[0] + a[4]
+}
+"""
+exit_code = 12
+
+[[case]]
+name = "array_repeat_non_copy_element_error"
+spec = ["7.1:38"]
+preview = "array_repeat"
+preview_should_pass = true
+source = """
+struct Data { value: i32 }
+fn main() -> i32 {
+    let d = Data { value: 1 };
+    let arr = [d; 3];
+    0
+}
+"""
+compile_fail = true
+error_contains = "Copy"
+
+[[case]]
+name = "array_repeat_requires_preview"
+spec = ["7.1:36"]
+source = """
+fn main() -> i32 {
+    let b = [7; 3];
+    b[0]
+}
+"""
+compile_fail = true
+error_contains = "requires preview feature"

--- a/docs/spec/src/07-arrays/01-fixed-arrays.md
+++ b/docs/spec/src/07-arrays/01-fixed-arrays.md
@@ -35,6 +35,48 @@ fn main() -> i32 {
 }
 ```
 
+## Array-Repeat Literals
+
+{{ rule(id="7.1:36", cat="normative") }}
+
+```ebnf
+array_literal = "[" ( [ expression { "," expression } ]
+                    | expression ";" array_length ) "]" ;
+```
+
+An array literal has two forms. The *list form* `[e0, e1, …]` gives each
+element explicitly. The *repeat form* `[value; count]` constructs an array of
+`count` elements, each equal to `value`. The result type is `[T; count]` where
+`T` is the type of `value`.
+
+{{ rule(id="7.1:37", cat="legality-rule") }}
+
+In the repeat form, `count` **MUST** be a non-negative integer compile-time
+constant — an integer literal or an identifier naming a compile-time constant
+(a file-level `const` or an in-scope `comptime` value parameter), resolved by
+the same rules as an array-type length.
+
+{{ rule(id="7.1:38", cat="legality-rule") }}
+
+The element type of a repeat literal **MUST** be `Copy`. A repeat literal
+materializes `count` copies of a single value, which is only well-defined when
+the value can be copied; a non-Copy element type is a compile-time error.
+
+{{ rule(id="7.1:39", cat="dynamic-semantics") }}
+
+The `value` expression is evaluated exactly once; its result is copied into
+each of the `count` array slots.
+
+{{ rule(id="7.1:40") }}
+
+```rue
+fn main() -> i32 {
+    let zeros: [i32; 128] = [0; 128];   // 128 copies of 0
+    let sevens = [7; 3];                 // [7, 7, 7]
+    zeros[0] + sevens[0] + sevens[1] + sevens[2]  // 21
+}
+```
+
 ## Array Indexing
 
 {{ rule(id="7.1:6", cat="normative") }}

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -158,7 +158,8 @@ for_expr       = "for" ( IDENT | "_" ) "in" expression "{" block "}" ;
 break_expr     = "break" [ expression ] ;   (* an operand parses but is always
                                                rejected in semantic analysis *)
 return_expr    = "return" [ expression ] ;
-array_literal  = "[" [ expression { "," expression } ] "]" ;
+array_literal  = "[" ( [ expression { "," expression } ]
+                     | expression ";" array_length ) "]" ;  (* repeat form: array_length is a compile-time constant *)
 field_inits    = field_init { "," field_init } [ "," ] ;
 field_init     = IDENT ":" expression ;
 


### PR DESCRIPTION
A dogfooding ergonomics win: zero/default-init arrays without writing every element. Gated behind a new array_repeat preview flag.

- Parser: array-literal grammar extended to distinguish the repeat form (expr, semicolon, count) from the element-list form.
- count reuses the array-length const-eval path (literal or named const); must be a non-negative comptime usize.
- Element type must be Copy (repeat is N copies of one value; N moves from one value is impossible) — non-Copy is a clean E0905.
- Key design: value evaluated once, desugared in SEMA to the existing ArrayInit with the AIR value repeated N times, so both backends fill slots via existing lowering — zero codegen changes.

Verified by execution: [0;128] all zeros, [7;3]=21, const-N count works, copy-struct fill works, zero-length works, non-Copy gives E0905, no-preview gives E1100; aarch64 asm shows the fill stores. Full test.sh green; 6 spec + 6 CLI cases.

Fixes RUE-235

Generated with Claude Code