### PR TITLE
Wire payload enums into all aggregate-slot codegen paths + fix wildcard-arm payload leak (RUE-237, RUE-238)

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1472,8 +1472,31 @@ impl<'a> Sema<'a> {
             // locals before the body, so the body's references resolve to them.
             // The enclosing match dispatched on the discriminant, so in this
             // arm the payload is read (move mode) via `EnumPayloadGet`.
-            let binding_stmts =
+            let mut binding_stmts =
                 self.materialize_match_bindings(air, pattern, scrutinee_result.air_ref, ctx)?;
+
+            // RUE-238: a non-binding arm (a wildcard `_`, or a variant matched
+            // without binding its payload) still *consumes* the scrutinee — the
+            // match marked it moved (see the `mark_moved` in the emitted AIR) —
+            // but extracts nothing, so its active-variant payload would leak.
+            // Emit a drop of the whole scrutinee value; for an enum this lowers
+            // to the variant-dispatched drop glue (`__rue_drop_E`), which drops
+            // exactly the active variant's payload (a no-op when that variant
+            // carries nothing droppable). Arms that DO bind the payload move it
+            // into their binding locals — dropped when those go out of scope —
+            // so they must not also drop the scrutinee, or the payload would be
+            // dropped twice; `binding_stmts.is_empty()` is precisely that guard
+            // (Rue variant patterns bind either all payload fields or none).
+            if binding_stmts.is_empty() && scrutinee_type.is_enum() {
+                let drop_ref = air.add_inst(AirInst {
+                    data: AirInstData::Drop {
+                        value: scrutinee_result.air_ref,
+                    },
+                    ty: Type::UNIT,
+                    span: pattern_span,
+                });
+                binding_stmts.push(drop_ref.as_u32());
+            }
 
             // Analyze arm body
             let body_result = self.analyze_inst(air, *body, ctx)?;

--- a/crates/rue-cli-tests/cases/enum_payloads.toml
+++ b/crates/rue-cli-tests/cases/enum_payloads.toml
@@ -165,6 +165,140 @@ fn main() -> i32 {
 """ }]
 exit_code = 6
 
+# RUE-237 facet A: a payload enum returned BY VALUE round-trips its payload
+# through the call ABI. The return terminator's aggregate-slot gate omitted
+# enums, so `make` shipped only the discriminant in the first return register
+# and the payload slot was never written — the match read garbage (0).
+[[case]]
+name = "by_value_enum_return_carries_payload"
+description = "A function returning a payload enum by value carries the payload through the ABI: make() -> Some(42), match extracts 42."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Opt { Some(i32), None }
+fn make() -> Opt { Opt::Some(42) }
+fn main() -> i32 {
+    match make() {
+        Opt::Some(v) => v,
+        Opt::None => 0,
+    }
+}
+""" }]
+exit_code = 42
+
+# RUE-237 facet A: a payload enum passed in AND returned (identity) keeps its
+# payload across both ABI crossings.
+[[case]]
+name = "enum_passthru_roundtrip"
+description = "Passing a payload enum in and returning it unchanged round-trips the payload: passthru(Circle(9)) -> 9."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Shape { Circle(i32), Square(i32) }
+fn passthru(s: Shape) -> Shape { s }
+fn main() -> i32 {
+    match passthru(Shape::Circle(9)) {
+        Shape::Circle(r) => r,
+        Shape::Square(x) => x,
+    }
+}
+""" }]
+exit_code = 9
+
+# RUE-237 facet C: reading a payload enum out of a STRUCT FIELD round-trips the
+# payload. The struct-init slot flattening omitted enum fields, so the struct
+# stored only the discriminant and dropped the payload; the field read then
+# saw garbage (0).
+[[case]]
+name = "struct_field_enum_carries_payload"
+description = "A payload enum stored in a struct field keeps its payload: w.o = Some(42), match extracts 42."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Opt { Some(i32), None }
+struct Wrapper { o: Opt }
+fn main() -> i32 {
+    let w = Wrapper { o: Opt::Some(42) };
+    match w.o {
+        Opt::Some(v) => v,
+        Opt::None => 0,
+    }
+}
+""" }]
+exit_code = 42
+
+# RUE-237: a payload enum stored in an ARRAY element keeps its payload (the
+# array-init slot flattening had the same enum omission as struct-init).
+[[case]]
+name = "array_element_enum_carries_payload"
+description = "Payload enums in an array literal keep their payloads: [Some(10), Some(32)], 10 + 32 = 42."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Opt { Some(i32), None }
+fn main() -> i32 {
+    let a = [Opt::Some(10), Opt::Some(32)];
+    match a[0] {
+        Opt::Some(x) => match a[1] { Opt::Some(y) => x + y, Opt::None => 0 },
+        Opt::None => 0,
+    }
+}
+""" }]
+exit_code = 42
+
+# RUE-238: a bare `_` arm consumes the scrutinee but binds nothing, so its
+# active-variant payload must still be dropped — exactly once. Previously the
+# discarded payload leaked (its destructor never ran, nothing printed).
+[[case]]
+name = "wildcard_arm_drops_discarded_payload"
+description = "A bare `_` match arm over a payload enum drops the discarded active payload exactly once: prints 7."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+enum E { Has(D), None }
+fn main() -> i32 {
+    let e = E::Has(D { v: 7 });
+    match e { _ => 0 }
+}
+""" }]
+stdout = "7\n"
+exit_code = 0
+
+# RUE-238: the same wildcard drop over a discriminant-only active variant drops
+# nothing (the drop glue dispatches on the runtime discriminant): no output.
+[[case]]
+name = "wildcard_arm_no_payload_drops_nothing"
+description = "A bare `_` arm whose active variant is discriminant-only drops nothing: no output, exit 0."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+enum E { Has(D), None }
+fn main() -> i32 {
+    let e = E::None;
+    match e { _ => 0 }
+}
+""" }]
+exit_code = 0
+
+# RUE-238: a wildcard catch-all alongside an explicit no-payload variant arm
+# still drops the payload of a value the wildcard catches, exactly once.
+[[case]]
+name = "wildcard_catchall_drops_caught_payload"
+description = "A `_` catch-all that catches a droppable variant drops its payload once: E::Has caught by `_`, prints 7."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct D { v: i32 }
+drop fn D(self) { @dbg(self.v); }
+enum E { Has(D), None }
+fn main() -> i32 {
+    let e = E::Has(D { v: 7 });
+    match e {
+        E::None => 1,
+        _ => 0,
+    }
+}
+""" }]
+stdout = "7\n"
+exit_code = 0
+
 # Without the preview flag, a payload-carrying enum is a clean preview error
 # (the driver reports it, no ICE).
 [[case]]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1671,10 +1671,12 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(result_vreg),
                         src: Operand::Virtual(slot_vregs[0]),
                     });
-                } else if ty.is_struct() || ty.is_array() {
+                } else if self.ctx.is_multislot_aggregate(ty) {
                     // Aggregates that fit return in registers. Capture
                     // every slot from RET_REGS, not just x0 — arrays previously fell
-                    // to the scalar path and lost all elements but the first. (RUE-78)
+                    // to the scalar path and lost all elements but the first (RUE-78),
+                    // and payload enums fell there too, leaving the call result with
+                    // no slot vregs and ICEing the enum-payload read (RUE-237).
                     let slot_count = ret_slot_count;
                     let mut slot_vregs = Vec::new();
                     for slot_idx in 0..slot_count {
@@ -3746,8 +3748,14 @@ impl<'a> CfgLower<'a> {
                     });
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(Aarch64Inst::Bl { symbol_id });
-                } else if return_type.as_struct().is_some() || return_type.is_array() {
-                    // Return a multi-slot aggregate (struct or array).
+                } else if self.ctx.is_multislot_aggregate(return_type) {
+                    // Return a multi-slot aggregate (struct, array, or a
+                    // payload-carrying enum). Payload enums were previously
+                    // omitted from this gate (it tested `struct || array`
+                    // only), so a by-value enum return fell into the scalar
+                    // branch, shipping only the discriminant in x0 while the
+                    // payload slot base had no slot vregs — ICEing at the
+                    // enum-payload place-read (RUE-237).
                     // Gather all slots through the single accessor, regardless of source
                     // (StructInit/ArrayInit/Call/BlockParam cache-hit; Load/Param/
                     // PlaceRead materialize). Previously the `_` arm returned only slot 0

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -240,10 +240,18 @@ pub fn lower_struct_init<B: SlotBackend>(
     for field in &fields {
         let field_ty = b.ctx().cfg.get_inst(*field).ty;
         match field_ty.kind() {
-            TypeKind::Struct(_) => {
-                let nested = get_or_compute_field_vregs(b, *field)
-                    .expect("nested struct field should have slot vregs");
-                slot_vregs.extend(nested);
+            TypeKind::Struct(_) | TypeKind::Enum(_) => {
+                // Struct/payload-enum field: contribute every slot. A
+                // payload enum here previously fell to the scalar `_` arm and
+                // contributed only its discriminant vreg, so the struct stored
+                // just the tag and dropped the payload (RUE-237). The accessor
+                // returns None for a discriminant-only (1-slot) enum, which
+                // correctly falls back to the single-vreg push.
+                if let Some(nested) = get_or_compute_field_vregs(b, *field) {
+                    slot_vregs.extend(nested);
+                } else {
+                    slot_vregs.push(b.get_vreg(*field));
+                }
             }
             TypeKind::Array(_) => {
                 // Try the accessor first: it materializes lazily-sourced
@@ -357,10 +365,19 @@ pub fn lower_array_init<B: SlotBackend>(
     let mut element_vregs: Vec<VReg> = Vec::new();
     for e in &elements {
         let e_ty = b.ctx().cfg.get_inst(*e).ty;
-        if matches!(e_ty.kind(), TypeKind::Struct(_) | TypeKind::Array(_)) {
-            let nested = get_or_compute_field_vregs(b, *e)
-                .expect("nested aggregate element should have slot vregs");
-            element_vregs.extend(nested);
+        // Payload enums are multi-slot aggregates too: a discriminant-only
+        // enum (accessor returns None) stays a single-vreg scalar, but a
+        // payload-carrying element must contribute all its slots or the array
+        // stores only the tag and drops the payload (RUE-237).
+        if matches!(
+            e_ty.kind(),
+            TypeKind::Struct(_) | TypeKind::Array(_) | TypeKind::Enum(_)
+        ) {
+            if let Some(nested) = get_or_compute_field_vregs(b, *e) {
+                element_vregs.extend(nested);
+            } else {
+                element_vregs.push(b.get_vreg(*e));
+            }
         } else {
             element_vregs.push(b.get_vreg(*e));
         }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -3725,8 +3725,13 @@ impl<'a> CfgLower<'a> {
                     // it 0 mod 16 at callee entry, violating SysV ABI).
                     let symbol_id = self.intern_symbol("__rue_exit");
                     self.mir.push(X86Inst::CallRel { symbol_id });
-                } else if return_type.as_struct().is_some() || return_type.is_array() {
-                    // Return a multi-slot aggregate (struct or array).
+                } else if self.ctx.is_multislot_aggregate(return_type) {
+                    // Return a multi-slot aggregate (struct, array, or a
+                    // payload-carrying enum). Payload enums were previously
+                    // omitted from this gate (it tested `struct || array`
+                    // only), so a by-value enum return fell into the scalar
+                    // branch and shipped only the discriminant in rax while
+                    // the payload slot in rdx was never written (RUE-237).
                     // Gather all slots through the single accessor, regardless of source
                     // (StructInit/ArrayInit/Call/BlockParam cache-hit; Load/Param/
                     // PlaceRead materialize). Previously the `_` arm returned only slot 0


### PR DESCRIPTION
Critical enum-payload codegen fixes (preview enum_payloads), found by the enums/generics/match hunt. **Unblocks payload enums crossing function/aggregate boundaries.**

**RUE-237** — payload enums were omitted from the struct-or-array gates that route multi-slot aggregates, so a by-value payload enum lost its payload (only the discriminant reached the caller) and aarch64 ICEd. Routed FOUR gate sites through is_multislot_aggregate: x86_64 + aarch64 Return terminators; the aarch64 non-sret Call-result capture gate (the actual persistent aarch64 ICE, not in the original report); and the shared agg_slots lower_struct_init / lower_array_init (the real root of the struct-field/array-element facet was payload loss at STORE time, not the read path). Verified x86-64 (-O0 and -O2): by-value return 42, passthru 9, struct-field 42, array-element 42; aarch64 --emit asm no ICE.

**RUE-238** — a non-binding match arm over a payload enum leaked the payload. analyze_match now emits Drop of the scrutinee in arms with empty bindings over an enum (variant-dispatched drop glue); binding arms excluded to avoid double-drop. Verified: wildcard/bare-_ arm drops once; binding arm still drops once.

Full test.sh green; 16 enum_payloads CLI cases (7 new). Note: the Variant(_) payload-wildcard PATTERN is a separate parser E0100 (not addressed here); the bare-_ case is fixed.

Fixes RUE-237
Fixes RUE-238

Generated with Claude Code