### PR TITLE
Fix cross-file duplicate-name detection + equivalent import-path member access (RUE-239, RUE-240)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -21,7 +21,7 @@ use rue_error::{
     IntrinsicTypeMismatchError, MultiErrorResult, OptionExt, PreviewFeature, WarningKind,
 };
 use rue_rir::{InstData, InstRef, Rir, RirArgMode, RirCallArg, RirDirective, RirParamMode};
-use rue_span::Span;
+use rue_span::{FileId, Span};
 use rue_target::{Arch, Os};
 
 use super::context::{
@@ -1168,9 +1168,11 @@ fn check_exclusive_access_in(
 /// declarations from the imported file, but the function table is a flat
 /// global namespace, so a name-only lookup would resolve a function from
 /// any file in the compilation. The callee must be defined in the receiver
-/// module's file: `member_file_path` (the callee's source file) must equal
-/// `module_file_path`, otherwise the call is rejected as an unknown member
-/// of `module_name`.
+/// module's file: `member_file_id` (the callee's source file) must equal the
+/// module's canonical file `module_file_id`, otherwise the call is rejected as
+/// an unknown member of `module_name`. Comparing by canonical FileId (rather
+/// than raw path string) makes equivalent import spellings — `helper.rue` vs
+/// `./helper.rue` — resolve members identically (spec 10.2:4, RUE-240).
 ///
 /// Two operations deliberately stay per-pipeline at the call sites: argument
 /// analysis (it recurses into the owning pipeline) and the exclusive-access
@@ -1179,8 +1181,8 @@ fn check_exclusive_access_in(
 fn check_module_member_call(
     rir: &Rir,
     module_name: &str,
-    module_file_path: &str,
-    member_file_path: Option<&str>,
+    module_file_id: Option<FileId>,
+    member_file_id: FileId,
     fn_name_str: &str,
     param_types: &[Type],
     param_modes: &[RirParamMode],
@@ -1189,9 +1191,9 @@ fn check_module_member_call(
     span: Span,
 ) -> CompileResult<()> {
     // Check membership: the function must be defined in the module's file.
-    // (Strict path equality, mirroring the struct/enum/const member-access
+    // (Canonical FileId equality, mirroring the struct/enum/const member-access
     // checks in analyze_module_type_member_access.)
-    if member_file_path != Some(module_file_path) {
+    if module_file_id != Some(member_file_id) {
         return Err(CompileError::new(
             ErrorKind::UnknownModuleMember {
                 module_name: module_name.to_string(),
@@ -3340,8 +3342,8 @@ impl<'a> Sema<'a> {
         check_module_member_call(
             self.rir,
             &module_def.import_path,
-            &module_def.file_path,
-            self.get_file_path(fn_info.file_id),
+            self.canonical_file_id(&module_def.file_path),
+            fn_info.file_id,
             &fn_name_str,
             &param_types,
             &param_modes,

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3251,9 +3251,17 @@ impl<'a> Sema<'a> {
     ) -> CompileResult<AnalysisResult> {
         let member_name_str = self.interner.resolve(&member_name).to_string();
 
-        // Get the module definition to find its file path
+        // Get the module definition and resolve its file to a canonical
+        // FileId, so equivalent path spellings (`helper.rue` vs
+        // `./helper.rue`) refer to the same module (spec 10.2:4, RUE-240).
+        // `module_file_path` is then that file's stored path, used for the
+        // directory-based visibility checks below.
         let module_def = self.module_registry.get_def(module_id);
-        let module_file_path = module_def.file_path.clone();
+        let module_file_id = self.canonical_file_id(&module_def.file_path);
+        let module_file_path = module_file_id
+            .and_then(|id| self.get_file_path(id))
+            .map(str::to_string)
+            .unwrap_or_else(|| module_def.file_path.clone());
 
         // Get the accessing file's directory for visibility check
         let accessing_file_path = self.get_source_path(span).map(|s| s.to_string());
@@ -3263,8 +3271,8 @@ impl<'a> Sema<'a> {
             let struct_def = self.type_pool.struct_def(struct_id);
 
             // Check if this struct was defined in the module's file
-            if let Some(struct_file_path) = self.get_file_path(struct_def.file_id) {
-                if struct_file_path == module_file_path {
+            {
+                if module_file_id == Some(struct_def.file_id) {
                     // Check visibility: pub structs are visible to all, private only to same directory
                     if !struct_def.is_pub {
                         // Check if accessing from same directory
@@ -3305,8 +3313,8 @@ impl<'a> Sema<'a> {
             let enum_def = self.type_pool.enum_def(enum_id);
 
             // Check if this enum was defined in the module's file
-            if let Some(enum_file_path) = self.get_file_path(enum_def.file_id) {
-                if enum_file_path == module_file_path {
+            {
+                if module_file_id == Some(enum_def.file_id) {
                     // Check visibility: pub enums are visible to all, private only to same directory
                     if !enum_def.is_pub {
                         // Check if accessing from same directory
@@ -3350,13 +3358,12 @@ impl<'a> Sema<'a> {
         // `module_bindings` table keyed by the facade's FileId (RUE-113);
         // value consts are found by name in the flat constants table,
         // filtered to the module's file via the declaration span.
-        let member_const = self
-            .get_file_id(&module_file_path)
+        let member_const = module_file_id
             .and_then(|file_id| self.module_bindings.get(&(file_id, member_name)))
             .or_else(|| {
-                self.constants.get(&member_name).filter(|const_info| {
-                    self.get_file_path(const_info.span.file_id) == Some(module_file_path.as_str())
-                })
+                self.constants
+                    .get(&member_name)
+                    .filter(|const_info| module_file_id == Some(const_info.span.file_id))
             });
         if let Some(const_info) = member_const {
             if !const_info.is_pub {

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -157,6 +157,129 @@ impl<'a> Sema<'a> {
         false
     }
 
+    /// Phase 0: Order-independent name-collision check across the function and
+    /// type (struct/enum) name spaces (spec 10.3:1, 10.5:1, RUE-239).
+    ///
+    /// Functions, structs, enums, and constants are all top-level items sharing
+    /// **one** name space, so any two of them with the same name collide —
+    /// regardless of their kinds, their order within a file, or the
+    /// command-line order of the files they come from. This pass over the
+    /// merged RIR is the order-independent source of truth for collisions among
+    /// **functions, structs, and enums**; the previously order-dependent gap
+    /// was a function colliding with a struct/enum, which was never checked.
+    /// The per-kind checks in [`register_type_names`](Self::register_type_names)
+    /// and the compiler's cross-file duplicate scan remain as backstops but no
+    /// longer decide legality by order.
+    ///
+    /// Constants are handled separately, after collection, in
+    /// [`check_const_cross_kind_collisions`](Self::check_const_cross_kind_collisions):
+    /// their global-vs-per-file identity (value constant vs `@import` module
+    /// binding, spec 10.4:8) is only known once initializers are evaluated, so
+    /// they cannot be classified from the raw RIR here.
+    ///
+    /// The error code reuses the existing per-kind codes based on the kinds
+    /// involved, so pre-existing diagnostics are unchanged:
+    /// - two types (struct/enum) → E0405 (`DuplicateTypeDefinition`)
+    /// - any pair involving a function → E0436 (`DuplicateFunctionDefinition`)
+    ///
+    /// Methods and associated functions live in a type-scoped namespace, not
+    /// the global one, so they are excluded here (matching the collection
+    /// logic in `resolve_remaining_declarations`).
+    pub(crate) fn check_top_level_name_collisions(&self) -> CompileResult<()> {
+        // Gather method / associated-function inst refs to exclude: they are
+        // namespaced under their enclosing type, not the global name space.
+        let mut method_refs: HashSet<InstRef> = HashSet::new();
+        for (_, inst) in self.rir.iter() {
+            match &inst.data {
+                InstData::AnonStructType {
+                    methods_start,
+                    methods_len,
+                    ..
+                }
+                | InstData::StructDecl {
+                    methods_start,
+                    methods_len,
+                    ..
+                } => {
+                    for r in self.rir.get_inst_refs(*methods_start, *methods_len) {
+                        method_refs.insert(r);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        // For each name, whether the first item seen was a type (struct/enum);
+        // the alternative is a function.
+        let mut seen: HashMap<Spur, (bool, Span)> = HashMap::new();
+        for (inst_ref, inst) in self.rir.iter() {
+            let (name, is_type) = match &inst.data {
+                InstData::StructDecl { name, .. } | InstData::EnumDecl { name, .. } => {
+                    (*name, true)
+                }
+                InstData::FnDecl { name, has_self, .. } => {
+                    if *has_self || method_refs.contains(&inst_ref) {
+                        continue;
+                    }
+                    (*name, false)
+                }
+                _ => continue,
+            };
+
+            match seen.get(&name).copied() {
+                None => {
+                    seen.insert(name, (is_type, inst.span));
+                }
+                Some((first_is_type, first_span)) => {
+                    let name_str = self.interner.resolve(&name).to_string();
+                    // Two types collide as a duplicate type (E0405); any pair
+                    // involving a function is a duplicate function (E0436).
+                    let err_kind = if first_is_type && is_type {
+                        ErrorKind::DuplicateTypeDefinition {
+                            type_name: name_str,
+                        }
+                    } else {
+                        ErrorKind::DuplicateFunctionDefinition {
+                            function_name: name_str,
+                        }
+                    };
+                    return Err(CompileError::new(err_kind, inst.span)
+                        .with_label("first defined here".to_string(), first_span));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Post-collection check: a value constant's name must not collide with a
+    /// function, struct, or enum (spec 10.3:1, 10.5:1, RUE-239).
+    ///
+    /// Runs after [`resolve_declarations`](Self::resolve_declarations), when
+    /// [`Sema::constants`] holds exactly the value constants — module bindings
+    /// went to [`Sema::module_bindings`], which are per-file scoped and exempt
+    /// (spec 10.4:8). Comparing the fully-populated tables makes the check
+    /// order-independent: a `const shared` and a `fn shared` collide whichever
+    /// file or definition comes first. All such collisions reuse E0436, so a
+    /// value-constant-vs-function collision no longer depends on which was
+    /// collected first (previously E0418 only when the function came first).
+    pub(crate) fn check_const_cross_kind_collisions(&self) -> CompileResult<()> {
+        for (name, info) in self.constants.iter() {
+            if self.functions.contains_key(name)
+                || self.structs.contains_key(name)
+                || self.enums.contains_key(name)
+            {
+                let name_str = self.interner.resolve(name).to_string();
+                return Err(CompileError::new(
+                    ErrorKind::DuplicateFunctionDefinition {
+                        function_name: name_str,
+                    },
+                    info.span,
+                ));
+            }
+        }
+        Ok(())
+    }
+
     /// Phase 1: Register all type names (enum and struct IDs).
     ///
     /// This creates name → ID mappings for all enums and structs in a single pass,
@@ -331,6 +454,10 @@ impl<'a> Sema<'a> {
         self.resolve_enum_payloads()?;
         self.propagate_field_linearity();
         self.resolve_remaining_declarations()?;
+        // Now that value constants are separated from module bindings, reject
+        // any value-constant name that collides with a function/struct/enum
+        // (order-independent E0436, spec 10.3:1/10.5:1, RUE-239).
+        self.check_const_cross_kind_collisions()?;
         Ok(())
     }
 
@@ -1085,19 +1212,12 @@ impl<'a> Sema<'a> {
         let (file_id, name) = key;
         let name_str = self.interner.resolve(&name).to_string();
 
-        // Check for collision with function names. (Functions are collected
-        // in the same declaration walk, so this catches `fn` before `const`;
-        // a `const` collected on demand before a later same-named `fn` is
-        // not — matching the previous collection behavior.)
-        if self.functions.contains_key(&name) {
-            return Err(CompileError::new(
-                ErrorKind::DuplicateConstant {
-                    name: name_str.clone(),
-                    kind: "constant (conflicts with function)".to_string(),
-                },
-                p.span,
-            ));
-        }
+        // A value-constant name that collides with a function, struct, or enum
+        // is a top-level name collision (E0436), but that decision is made
+        // order-independently after all declarations are collected, in
+        // `check_const_cross_kind_collisions` — not here, where collection is
+        // dependency-ordered and the conflicting item may not be registered
+        // yet (RUE-239).
 
         // The declared integer type (when the annotation names one) becomes
         // the type context for arithmetic in the initializer, so intermediate
@@ -1674,13 +1794,21 @@ impl<'a> Sema<'a> {
         st: &mut ConstCollector,
     ) -> CompileResult<ConstInit> {
         let module_def = self.module_registry.get_def(module_id);
-        let module_file_path = module_def.file_path.clone();
         let import_path = module_def.import_path.clone();
         let member_str = self.interner.resolve(&member).to_string();
 
+        // Resolve the module's file by canonical FileId so equivalent path
+        // spellings (`helper.rue` vs `./helper.rue`) refer to the same module
+        // (spec 10.2:4, RUE-240), then use that file's stored path for
+        // downstream directory-based visibility checks.
+        let module_file_id = self.canonical_file_id(&module_def.file_path);
+        let module_file_path = module_file_id
+            .and_then(|id| self.get_file_path(id))
+            .map(str::to_string)
+            .unwrap_or(module_def.file_path);
+
         // Collect the member's declaration on demand (the module's file may
         // appear later in the declaration walk).
-        let module_file_id = self.get_file_id(&module_file_path);
         if let Some(mfile) = module_file_id {
             self.collect_const_by_key((mfile, member), st)?;
         }
@@ -1702,7 +1830,7 @@ impl<'a> Sema<'a> {
 
         // A value constant declared in the module's file yields its value.
         if let Some(info) = self.constants.get(&member) {
-            if self.get_file_path(info.span.file_id) == Some(module_file_path.as_str()) {
+            if module_file_id == Some(info.span.file_id) {
                 let (is_pub, value) = (info.is_pub, info.value);
                 self.check_const_member_visibility(
                     is_pub,

--- a/crates/rue-air/src/sema/file_paths.rs
+++ b/crates/rue-air/src/sema/file_paths.rs
@@ -4,10 +4,26 @@
 //! for module resolution and relative imports.
 
 use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
 
 use rue_span::FileId;
 
 use super::Sema;
+
+/// Normalize a source-file path for equivalence comparison by dropping `.`
+/// (current-directory) components, so `./helper.rue` and `helper.rue` compare
+/// equal. Parent (`..`) and normal components are preserved, so the
+/// normalization is purely lexical and never touches the filesystem.
+fn normalize_module_path(path: &str) -> String {
+    let mut out = PathBuf::new();
+    for comp in Path::new(path).components() {
+        match comp {
+            Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out.to_string_lossy().into_owned()
+}
 
 impl<'a> Sema<'a> {
     /// Set file paths for module resolution in multi-file compilation.
@@ -39,6 +55,28 @@ impl<'a> Sema<'a> {
         self.file_paths
             .iter()
             .find(|(_, p)| p.as_str() == path)
+            .map(|(id, _)| *id)
+    }
+
+    /// Resolve a source-file path to its canonical [`FileId`](rue_span::FileId),
+    /// tolerating equivalent spellings of the same file.
+    ///
+    /// A module imported as `@import("./helper.rue")` records its resolved path
+    /// with the leading `./` (or other `.` components) still attached, while
+    /// the file table stores the plain `helper.rue`. An exact
+    /// [`get_file_id`](Self::get_file_id) match would miss it, so member access
+    /// through that binding spuriously failed (E0707, RUE-240). Comparing by
+    /// normalized path (dropping `.` components) makes both spellings resolve
+    /// to the same file, matching spec 10.2:4 (an import resolving to an
+    /// already-loaded file refers to that same module).
+    pub(crate) fn canonical_file_id(&self, path: &str) -> Option<FileId> {
+        if let Some(id) = self.get_file_id(path) {
+            return Some(id);
+        }
+        let norm = normalize_module_path(path);
+        self.file_paths
+            .iter()
+            .find(|(_, p)| normalize_module_path(p) == norm)
             .map(|(id, _)| *id)
     }
 

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -161,7 +161,15 @@ impl<'a> Sema<'a> {
     /// This is the main entry point for semantic analysis. It returns analyzed
     /// functions, struct definitions, enum definitions, and any warnings.
     pub fn analyze_all(mut self) -> MultiErrorResult<SemaOutput> {
-        // Phase 0: Inject built-in types (String, etc.) before user code
+        // Phase 0a: Reject a top-level name claimed by two of function /
+        // struct / enum, order-independently (spec 10.3:1, 10.5:1, RUE-239).
+        // Runs before builtin injection so it scans only user RIR. Value
+        // constants are folded in later, after collection separates them from
+        // per-file module bindings (see `check_const_cross_kind_collisions`).
+        self.check_top_level_name_collisions()
+            .map_err(CompileErrors::from)?;
+
+        // Phase 0b: Inject built-in types (String, etc.) before user code
         self.inject_builtin_types();
 
         // Phase 1: Register type names

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -1234,3 +1234,249 @@ pub fn abs(x: i32) -> i32 {
 ]
 compile_fail = true
 error_contains = ["E0707", "module `math` has no member `nosuch`"]
+
+# ---------------------------------------------------------------------------
+# RUE-239: top-level duplicate-name detection spans ALL item kinds
+# (fn/struct/enum/const share one name space, spec 10.3:1 + 10.5:1) and is
+# order-independent — legality no longer flips on definition order or CLI
+# file order. Reuses E0436 for cross-kind collisions; same-kind keeps its
+# existing code (E0405 types, E0418 constants).
+# ---------------------------------------------------------------------------
+
+# const + fn, const listed first: previously compiled (accept-invalid); now
+# E0436 regardless of order.
+[[case]]
+name = "dup_const_fn_const_first"
+description = "RUE-239: const then fn with the same name is E0436 even when the const file is first."
+files = [
+    { path = "a.rue", source = """
+const shared: i32 = 5;
+""" },
+    { path = "b.rue", source = """
+pub fn shared() -> i32 {
+    100
+}
+
+fn main() -> i32 {
+    shared()
+}
+""" },
+]
+args = ["a.rue", "b.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0436", "shared"]
+
+# Same program, files in the other CLI order — still E0436 (was E0418 before).
+[[case]]
+name = "dup_const_fn_fn_first"
+description = "RUE-239: order-independent — swapping the CLI file order still yields E0436."
+files = [
+    { path = "a.rue", source = """
+const shared: i32 = 5;
+""" },
+    { path = "b.rue", source = """
+pub fn shared() -> i32 {
+    100
+}
+
+fn main() -> i32 {
+    shared()
+}
+""" },
+]
+args = ["b.rue", "a.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0436", "shared"]
+
+# fn + struct in ONE file: previously compiled (both coexisted); now E0436.
+[[case]]
+name = "dup_fn_struct_same_file"
+description = "RUE-239: a function and a struct with the same name collide (E0436), same file."
+files = [
+    { path = "main.rue", source = """
+fn Thing() -> i32 {
+    5
+}
+
+pub struct Thing {
+    n: i32,
+}
+
+fn main() -> i32 {
+    let t = Thing { n: 3 };
+    Thing() + t.n
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0436", "Thing"]
+
+# fn + struct across two files: same collision, cross-file.
+[[case]]
+name = "dup_fn_struct_cross_file"
+description = "RUE-239: a function and a struct with the same name collide (E0436) across files."
+files = [
+    { path = "main.rue", source = """
+fn Thing() -> i32 {
+    5
+}
+
+fn main() -> i32 {
+    Thing()
+}
+""" },
+    { path = "other.rue", source = """
+pub struct Thing {
+    n: i32,
+}
+""" },
+]
+args = ["main.rue", "other.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0436", "Thing"]
+
+# enum + const: cross-namespace collision (type vs const) is E0436.
+[[case]]
+name = "dup_enum_const_same_file"
+description = "RUE-239: an enum and a constant with the same name collide (E0436)."
+files = [
+    { path = "main.rue", source = """
+enum Color {
+    Red,
+    Green,
+}
+
+const Color: i32 = 5;
+
+fn main() -> i32 {
+    Color
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0436", "Color"]
+
+# Regression: fn + fn duplicate still E0436 (the check that already existed).
+[[case]]
+name = "dup_fn_fn_still_errors"
+description = "RUE-239 regression: two functions with the same name remain E0436."
+files = [
+    { path = "main.rue", source = """
+fn dup() -> i32 {
+    1
+}
+
+fn dup() -> i32 {
+    2
+}
+
+fn main() -> i32 {
+    dup()
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0436", "dup"]
+
+# Distinct names across all four kinds still compile and run.
+[[case]]
+name = "dup_distinct_names_ok"
+description = "RUE-239: distinct top-level names (const/fn/struct/enum) compile and run."
+files = [
+    { path = "main.rue", source = """
+const X: i32 = 3;
+
+fn Y() -> i32 {
+    5
+}
+
+struct Z {
+    n: i32,
+}
+
+enum W {
+    A,
+    B,
+}
+
+fn main() -> i32 {
+    let z = Z { n: X };
+    Y() + z.n
+}
+""" },
+]
+exit_code = 8
+
+# ---------------------------------------------------------------------------
+# RUE-240: equivalent @import path spellings (`helper.rue` vs `./helper.rue`)
+# resolve to the same module, so member access through either spelling works
+# identically (spec 10.2:4). Member access is compared by canonical FileId.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "import_equivalent_spellings_member_access"
+description = "RUE-240: two spellings of the same file resolve both a fn and a const member (9 + 42 = 51)."
+files = [
+    { path = "main.rue", source = """
+const h1 = @import("helper.rue");
+const h2 = @import("./helper.rue");
+
+fn main() -> i32 {
+    h1.value() + h2.ANSWER
+}
+""" },
+    { path = "helper.rue", source = """
+pub const ANSWER: i32 = 42;
+
+pub fn value() -> i32 {
+    9
+}
+""" },
+]
+exit_code = 51
+
+# The `./`-spelled binding also resolves BOTH member kinds on its own.
+[[case]]
+name = "import_dot_slash_spelling_resolves_both_kinds"
+description = "RUE-240: member access through the ./-prefixed spelling resolves both fn and const (9 + 42 = 51)."
+files = [
+    { path = "main.rue", source = """
+const h1 = @import("helper.rue");
+const h2 = @import("./helper.rue");
+
+fn main() -> i32 {
+    h2.value() + h1.ANSWER
+}
+""" },
+    { path = "helper.rue", source = """
+pub const ANSWER: i32 = 42;
+
+pub fn value() -> i32 {
+    9
+}
+""" },
+]
+exit_code = 51
+
+# A genuinely-missing member through the ./ spelling still errors (E0707).
+[[case]]
+name = "import_dot_slash_spelling_missing_member_errors"
+description = "RUE-240: a truly-absent member through the ./ spelling still reports E0707."
+files = [
+    { path = "main.rue", source = """
+const h2 = @import("./helper.rue");
+
+fn main() -> i32 {
+    h2.NOPE
+}
+""" },
+    { path = "helper.rue", source = """
+pub const ANSWER: i32 = 42;
+
+pub fn value() -> i32 {
+    9
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0707", "NOPE"]

--- a/crates/rue-spec/cases/modules/composition.toml
+++ b/crates/rue-spec/cases/modules/composition.toml
@@ -39,3 +39,33 @@ pub fn go2() -> i32 { LIMIT }
 """ }
 compile_fail = true
 error_contains = "duplicate"
+
+# Cross-KIND collisions across files: a top-level item is a function, struct,
+# enum, OR constant, and all four share one name space (RUE-239). A function
+# in one file and a struct with the same name in another collide (E0436),
+# regardless of order or visibility.
+[[case]]
+name = "duplicate_fn_and_struct_across_files_error"
+spec = ["10.5:1"]
+description = "A function and a struct with the same name collide across files (one shared top-level name space)"
+source = """
+fn Thing() -> i32 { 5 }
+fn main() -> i32 { Thing() }
+"""
+aux_files = { "other.rue" = "pub struct Thing { n: i32 }" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "E0436"
+
+[[case]]
+name = "duplicate_enum_and_const_across_files_error"
+spec = ["10.5:1"]
+description = "An enum and a constant with the same name collide across files (E0436)"
+source = """
+enum Color { Red, Green }
+fn main() -> i32 { 0 }
+"""
+aux_files = { "other.rue" = "pub const Color: i32 = 5;" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "E0436"


### PR DESCRIPTION
Both found by the modules/multi-file hunt.

**RUE-239** — top-level duplicate-name detection was order-dependent and didn't span item kinds. Added an order-independent pre-pass check_top_level_name_collisions (fn/struct/enum) + a post-collection check_const_cross_kind_collisions for value constants, and removed the order-dependent E0418 conflicts-with-function branch. Per-file module bindings stay exempt (spec 10.4:8). Now: const/fn both CLI orders give E0436; fn/struct same-file + cross-file give E0436; enum/const give E0436; fn/fn give E0436; distinct names run.

**RUE-240** — equivalent import spellings (helper.rue vs ./helper.rue) loaded the file once but member access through the second spelling failed E0707 (raw-string path compare). Added normalize_module_path + canonical_file_id; all three member-access sites now compare by canonical FileId. Now both spellings resolve fn + const members (51); a truly-missing member still gives E0707.

Full test.sh green; 10 CLI + 2 spec cases. Target-independent.

Fixes RUE-239
Fixes RUE-240

Generated with Claude Code