### PR TITLE
Generic types usable in function signatures via a type constant — real error handling (RUE-241, part of RUE-6)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1720,10 +1720,21 @@ impl<'a> Sema<'a> {
             value_subst,
         )?;
 
-        // Create analysis context with resolved types
-        // If type_subst is provided, initialize comptime_type_vars with the substitutions
-        // so that type parameters can be resolved during struct initialization.
-        let comptime_type_vars = type_subst.map(|s| s.clone()).unwrap_or_else(HashMap::new);
+        // Create analysis context with resolved types.
+        // Base the comptime type environment on file-level type constants
+        // (`const R: type = Result(i32, i32);`, RUE-241) so that enum/struct
+        // paths and match patterns that name `R` resolve to its concrete type,
+        // just as a `let`-bound type alias would. Type-parameter substitutions
+        // (specialized generic bodies) and later `let`-bound aliases override
+        // these, so a local binding shadows a file-level const of the same name.
+        let mut comptime_type_vars: HashMap<Spur, Type> = self
+            .type_constants
+            .iter()
+            .map(|(name, info)| (*name, info.ty))
+            .collect();
+        if let Some(s) = type_subst {
+            comptime_type_vars.extend(s.iter().map(|(k, v)| (*k, *v)));
+        }
         let comptime_value_vars = value_subst.map(|s| s.clone()).unwrap_or_else(HashMap::new);
         let mut ctx = AnalysisContext {
             locals: HashMap::new(),

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -340,6 +340,10 @@ impl Sema<'_> {
                     Type::new_struct(struct_id)
                 } else if let Some(&enum_id) = self.enums.get(name) {
                     Type::new_enum(enum_id)
+                } else if let Some(info) = self.type_constants.get(name) {
+                    // A type-valued const (`const R: type = Result(i32,i32);`,
+                    // RUE-241) names its monomorphized concrete type.
+                    info.ty
                 } else {
                     return None;
                 }
@@ -997,7 +1001,7 @@ impl Sema<'_> {
     /// `FixedBuffer(8)` — mirroring `analyze_call`'s implicit-comptime gate)
     /// and direct type expressions (`let P = Q;`, `let P = struct { .. };`).
     /// Returns `None` for anything else.
-    fn try_eval_type_alias_init(
+    pub(crate) fn try_eval_type_alias_init(
         &mut self,
         init: InstRef,
         eval_types: &HashMap<Spur, Type>,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1166,6 +1166,43 @@ impl<'a> Sema<'a> {
                     },
                 );
             }
+            ConstInit::Type(ty) => {
+                // A type-valued const (`const R: type = Result(i32, i32);`).
+                // If annotated, the annotation must be `type` (RUE-241).
+                if let Some(ty_sym) = p.ty_sym {
+                    let declared = self.resolve_type(ty_sym, p.span)?;
+                    if declared != Type::COMPTIME_TYPE {
+                        return Err(CompileError::new(
+                            ErrorKind::TypeMismatch {
+                                expected: declared.safe_name_with_pool(Some(&self.type_pool)),
+                                found: "type".to_string(),
+                            },
+                            p.span,
+                        ));
+                    }
+                }
+                // Type constants share the global namespace (10.5:1): a second
+                // declaration of the same name (of any const kind) is E0418.
+                if self.constants.contains_key(&name) || self.type_constants.contains_key(&name) {
+                    return Err(CompileError::new(
+                        ErrorKind::DuplicateConstant {
+                            name: name_str,
+                            kind: "constant".to_string(),
+                        },
+                        p.span,
+                    ));
+                }
+                self.type_constants.insert(
+                    name,
+                    ConstInfo {
+                        is_pub: p.is_pub,
+                        ty,
+                        init: p.init,
+                        value: ConstValue::Type(ty),
+                        span: p.span,
+                    },
+                );
+            }
         }
         Ok(())
     }
@@ -1346,13 +1383,31 @@ impl<'a> Sema<'a> {
                             .expect("ConstInit::Module holds a module type");
                         self.resolve_module_member_const(module_id, field, file_id, span, st)
                     }
-                    ConstInit::Value(_) => Err(CompileError::new(
+                    ConstInit::Value(_) | ConstInit::Type(_) => Err(CompileError::new(
                         ErrorKind::ConstExprNotSupported {
                             expr_kind: "member access on a non-module value".to_string(),
                         },
                         span,
                     )),
                 }
+            }
+
+            // A call to a type-returning function (`Result(i32, i32)`,
+            // `Pair(i32)`) evaluates to a compile-time type value, so it can
+            // name a type constant usable in signature position (RUE-241).
+            // Mirrors the `let`-bound type alias path (`try_eval_type_alias_init`).
+            InstData::Call { .. } => {
+                // Collect any constants the call arguments reference first; the
+                // callee function is collected in the declaration walk.
+                self.ensure_const_init_deps_collected(init, file_id, st)?;
+                if let Some(ty) =
+                    self.try_eval_type_alias_init(init, &HashMap::new(), &HashMap::new())
+                {
+                    return Ok(ConstInit::Type(ty));
+                }
+                // Not a type-returning call (e.g. a runtime function): the
+                // comptime engine will reject it as non-evaluable.
+                self.eval_const_value_expr(init, file_id, st, span, declared_ty)
             }
 
             // String constants would need the String type; not supported in
@@ -1404,14 +1459,10 @@ impl<'a> Sema<'a> {
 
         let mut env = super::comptime_eval::ComptimeEnv::for_const_init(&resolved_types);
         match self.eval_const_expr(init, &mut env)? {
-            // Type values (e.g. `const T = i32;`) are not supported as
-            // constants: nothing can materialize them at a use site yet.
-            Some(ConstValue::Type(_)) => Err(CompileError::new(
-                ErrorKind::ConstExprNotSupported {
-                    expr_kind: "a type value".to_string(),
-                },
-                span,
-            )),
+            // Type values (`const Int = i32;`, or an alias of another type
+            // const) become type constants usable in signature/annotation
+            // position (RUE-241).
+            Some(ConstValue::Type(ty)) => Ok(ConstInit::Type(ty)),
             Some(value) => Ok(ConstInit::Value(value)),
             None => Err(CompileError::new(
                 ErrorKind::ConstExprNotSupported {
@@ -1931,4 +1982,9 @@ enum ConstInit {
     Module(Type),
     /// A compile-time value: becomes a global value constant.
     Value(ConstValue),
+    /// A compile-time type value (`const R: type = Result(i32, i32);`, a
+    /// primitive alias `const Int = i32;`, or an alias of another type const).
+    /// Becomes a global type constant usable in signature/annotation position
+    /// (RUE-241). The `Type` is the monomorphized concrete type.
+    Type(Type),
 }

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -60,6 +60,8 @@ pub struct GatherOutput<'a> {
     pub methods: HashMap<(StructId, Spur), MethodInfo>,
     /// Constant lookup: maps const name to info (value constants only).
     pub constants: HashMap<Spur, ConstInfo>,
+    /// Type-valued constants (`const R: type = Result(i32, i32);`, RUE-241).
+    pub type_constants: HashMap<Spur, ConstInfo>,
     /// Module-binding constants (`const m = @import(...)`), keyed by the
     /// declaring file — per-file scoped (RUE-113).
     pub module_bindings: HashMap<(rue_span::FileId, Spur), ConstInfo>,
@@ -91,6 +93,7 @@ impl<'a> GatherOutput<'a> {
             enums: self.enums,
             methods: self.methods,
             constants: self.constants,
+            type_constants: self.type_constants,
             module_bindings: self.module_bindings,
             preview_features: self.preview_features,
             builtin_string_id: self.builtin_string_id,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -80,6 +80,13 @@ pub struct Sema<'a> {
     /// Holds value constants only (e.g. `const MAX: i32 = 10`); module bindings
     /// live in [`Self::module_bindings`].
     pub(crate) constants: HashMap<Spur, ConstInfo>,
+    /// Type-valued constants (`const R: type = Result(i32, i32);`, RUE-241).
+    /// Maps the const name to the monomorphized concrete type it names, so a
+    /// signature (`fn divide(..) -> R`), annotation, or type-position use can
+    /// resolve it. Kept separate from [`Self::constants`] so a use as a value
+    /// falls through to the type-name path (emitting a `TypeConst`) instead of
+    /// materializing a value. Shares the global constant namespace (10.5:1).
+    pub(crate) type_constants: HashMap<Spur, ConstInfo>,
     /// Module-binding constants (`const utils = @import("...")`), keyed by
     /// the declaring file. Unlike value constants, module bindings are
     /// per-file scoped (ADR-0026): every file writes its own imports, so two
@@ -139,6 +146,7 @@ impl<'a> Sema<'a> {
             enums: HashMap::new(),
             methods: HashMap::new(),
             constants: HashMap::new(),
+            type_constants: HashMap::new(),
             module_bindings: HashMap::new(),
             preview_features,
             builtin_string_id: None,

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -184,6 +184,15 @@ impl<'a> Sema<'a> {
                 span,
             )?;
             Ok(Type::new_enum(enum_id))
+        } else if let Some(info) = self.type_constants.get(&type_sym) {
+            // A type-valued const (`const R: type = Result(i32, i32);`, RUE-241)
+            // used in signature/annotation position resolves to the concrete
+            // monomorphized type it names. Privacy is uniform across item kinds
+            // (spec 10.3:7): an unqualified reference must not reach a private
+            // type const defined in another directory (E0460).
+            let (ty, file_id, is_pub) = (info.ty, info.span.file_id, info.is_pub);
+            self.check_unqualified_visibility("constant", type_name, file_id, is_pub, span)?;
+            Ok(ty)
         } else {
             // Check for array type syntax: [T; N]
             if let Some((element_type, len)) = parse_array_type_syntax(type_name) {
@@ -273,6 +282,9 @@ impl<'a> Sema<'a> {
             Some(Type::new_struct(struct_id))
         } else if let Some(&enum_id) = self.enums.get(&type_sym) {
             Some(Type::new_enum(enum_id))
+        } else if let Some(info) = self.type_constants.get(&type_sym) {
+            // A type-valued const (`const R: type = Result(i32,i32);`, RUE-241).
+            Some(info.ty)
         } else if let Some((element_type, len)) = parse_array_type_syntax(type_name) {
             // Resolve the element type first
             let element_sym = self.interner.get_or_intern(&element_type);

--- a/crates/rue-cli-tests/cases/const_init.toml
+++ b/crates/rue-cli-tests/cases/const_init.toml
@@ -143,20 +143,20 @@ pub const ANSWER: i32 = 42;
 ]
 exit_code = 42
 
-# A type-valued initializer is still E0434 (not E0475): type aliases are not
-# value constants, and fn-call initializers are not const-evaluable today
-# (fn-valued constants are RUE-173). If type aliases become legal they stay
-# exempt from the annotation requirement.
+# A type-valued initializer (a call to a comptime function returning `type`)
+# is a legal *type constant* (RUE-241): it is not a value constant, so it is
+# exempt from the annotation requirement (no E0475), and `T` is usable as a
+# type in signature position. Formerly rejected with E0434.
 [[case]]
-name = "type_alias_initializer_still_e0434"
+name = "type_alias_initializer_is_type_constant"
 files = [{ path = "main.rue", source = """
 fn MakeT() -> type { i32 }
 const T = MakeT();
 
-fn main() -> i32 { 0 }
+fn id(x: T) -> T { x }
+fn main() -> i32 { id(42) }
 """ }]
-compile_fail = true
-error_contains = ["E0434", "not supported in const context"]
+exit_code = 42
 
 # Annotated out-of-range value is rejected AT THE DECLARATION (E0800).
 [[case]]

--- a/crates/rue-cli-tests/cases/enum_payloads.toml
+++ b/crates/rue-cli-tests/cases/enum_payloads.toml
@@ -427,3 +427,54 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["must be consumed"]
+
+# Generic type constants in function signatures (RUE-241). A generic Option /
+# Result, named through a file-level `const R: type = ...`, can appear in a
+# function's parameter and return type — the resolution monomorphizes to the
+# concrete enum. These cross a real call ABI.
+
+# Parameter position: construct the generic enum in `main`, pass it by value to
+# a function whose parameter type is the type constant, and match it there.
+[[case]]
+name = "type_const_generic_option_param"
+description = "Generic Option via `const OptI: type = Option(i32);` used as a parameter type: unwrap_or(Some(42), 0) = 42 across a call (RUE-241)."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const OptI: type = Option(i32);
+fn unwrap_or(o: OptI, d: i32) -> i32 {
+    match o { OptI::Some(v) => v, OptI::None => d }
+}
+fn main() -> i32 { unwrap_or(OptI::Some(42), 0) }
+""" }]
+exit_code = 42
+
+# Two-parameter Result via a type constant, also in parameter position: both
+# arms round-trip through a function boundary.
+[[case]]
+name = "type_const_generic_result_param"
+description = "Generic Result via `const R: type = Result(i32, i32);` as a parameter type: Ok(84)/2-style value threaded through unwrap = 42 (RUE-241)."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+const R: type = Result(i32, i32);
+fn unwrap(r: R) -> i32 { match r { R::Ok(v) => v, R::Err(e) => 0 - e } }
+fn main() -> i32 { unwrap(R::Ok(42)) }
+""" }]
+exit_code = 42
+
+# Return position: `fn divide(..) -> R` compiles, is called, and returns the
+# payload enum by value (RUE-241 resolves the type constant in return position;
+# RUE-237's aggregate-return fix, now merged, round-trips the payload). This is
+# real error handling end-to-end: a fn returning a generic Result, matched -> 42.
+[[case]]
+name = "type_const_generic_result_return"
+description = "Generic Result named via a type constant in return position: fn divide -> R compiles, runs, and returns the payload by value, matched to 42 (RUE-241 + RUE-237)."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+const R: type = Result(i32, i32);
+fn divide(a: i32, b: i32) -> R { if b == 0 { R::Err(1) } else { R::Ok(a / b) } }
+fn main() -> i32 { match divide(84, 2) { R::Ok(v) => v, R::Err(e) => 0 - e } }
+""" }]
+exit_code = 42

--- a/crates/rue-spec/cases/items/constants.toml
+++ b/crates/rue-spec/cases/items/constants.toml
@@ -260,3 +260,86 @@ fn main() -> i32 { 0 }
 """
 compile_fail = true
 error_contains = "cycle detected in constant initializers"
+
+# =============================================================================
+# Type constants (6.5:12, 6.5:13, 6.5:14) — RUE-241
+# =============================================================================
+
+# A constant bound to a primitive type name is a type constant, usable as a
+# parameter and return type.
+[[case]]
+name = "type_constant_primitive_alias"
+spec = ["6.5:12", "6.5:13"]
+description = "A `const Int: type = i32;` names a type usable in parameter and return position"
+source = """
+const Int: type = i32;
+
+fn add(a: Int, b: Int) -> Int { a + b }
+
+fn main() -> i32 { add(40, 2) }
+"""
+exit_code = 42
+
+# An unannotated type constant is legal (like a module binding): no E0475.
+[[case]]
+name = "type_constant_unannotated"
+spec = ["6.5:12"]
+description = "A type constant needs no `type` annotation (it is not a value constant, so E0475 does not apply)"
+source = """
+const Int = i32;
+
+fn id(x: Int) -> Int { x }
+
+fn main() -> i32 { id(42) }
+"""
+exit_code = 42
+
+# A generic Option named through a type constant crosses a function boundary as
+# a parameter type: construct in `main`, match inside `unwrap_or`.
+[[case]]
+name = "type_constant_generic_option_param"
+spec = ["6.5:13", "6.5:14"]
+preview = "enum_payloads"
+description = "A generic Option, named via `const OptI: type = Option(i32);`, is usable as a parameter type across a call"
+source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const OptI: type = Option(i32);
+
+fn unwrap_or(o: OptI, d: i32) -> i32 {
+    match o { OptI::Some(v) => v, OptI::None => d }
+}
+
+fn main() -> i32 { unwrap_or(OptI::Some(42), 0) }
+"""
+exit_code = 42
+
+# A local `let`-bound type alias shadows a file-level type constant of the same
+# name (6.5:13).
+[[case]]
+name = "type_constant_shadowed_by_let"
+spec = ["6.5:13"]
+preview = "enum_payloads"
+description = "A `let`-bound type alias inside a function shadows a file-level type constant of the same name"
+source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const OptI: type = Option(i32);
+
+fn main() -> i32 {
+    let OptI: type = Option(i32);
+    match OptI::Some(42) { OptI::Some(v) => v, OptI::None => 0 }
+}
+"""
+exit_code = 42
+
+# A non-`type` annotation on a type-valued initializer is a type error (6.5:12).
+[[case]]
+name = "type_constant_non_type_annotation_rejected"
+spec = ["6.5:12"]
+description = "Annotating a type-valued constant with a non-`type` type is a type error"
+source = """
+const Bad: i32 = i32;
+
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "type mismatch"

--- a/docs/spec/src/06-items/05-constants.md
+++ b/docs/spec/src/06-items/05-constants.md
@@ -19,9 +19,10 @@ The initializer of a constant **MUST** be evaluable at compile time.
 Compile-time evaluable expressions include literals, the arithmetic,
 comparison, logical, bitwise, and shift operators applied to compile-time
 evaluable operands, `comptime` block expressions, references to other
-constants, and module expressions (`@import(...)` and module member access
-— chapter 10). An initializer that is not compile-time evaluable produces a
-compile-time error (E0434).
+constants, module expressions (`@import(...)` and module member access
+— chapter 10), and type expressions (type names and calls to comptime
+functions returning `type`, 6.5:12). An initializer that is not compile-time
+evaluable produces a compile-time error (E0434).
 
 {{ rule(id="6.5:3", cat="example") }}
 
@@ -75,6 +76,52 @@ const SMALL: u8 = 200;           // u8: annotation adopted, value fits
 // const BAD: u8 = 300;          // error: out of range for u8 (E0800)
 // const NONE = 5;               // error: missing type annotation (E0475)
 ```
+
+## Type Constants
+
+{{ rule(id="6.5:12", cat="normative") }}
+
+A *type constant* is a constant whose initializer evaluates to a type: a type
+name (`const Int = i32;`), a call to a comptime function returning `type`
+(`const R = Result(i32, i32);`, 4.14:7), or an alias of another type constant.
+Like a module binding, a type constant is not a value constant: it takes an
+optional `type` annotation (`const R: type = ...;`) and, unlike a value
+constant, requires none. A non-`type` annotation on a type-valued initializer
+is a type error.
+
+{{ rule(id="6.5:13", cat="normative") }}
+
+A type constant may be used wherever a type name may appear — as a type
+annotation, and as a function parameter or return type — resolving to the
+concrete (monomorphized) type its initializer names. This lets a comptime
+type function's result cross a function boundary in the signature, so a
+function can take or return a generic `Option`/`Result` named through a
+constant. A `let`-bound type alias of the same name inside a function body
+shadows the constant.
+
+{{ rule(id="6.5:14", cat="example") }}
+
+```rue
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+const OptI: type = Option(i32);
+
+fn unwrap_or(o: OptI, d: i32) -> i32 {
+    match o { OptI::Some(v) => v, OptI::None => d }
+}
+
+fn main() -> i32 {
+    unwrap_or(OptI::Some(42), 0)  // 42
+}
+```
+
+{{ rule(id="6.5:15", cat="informative") }}
+
+In the current implementation, a type constant used in a function *signature*
+(a parameter or return type) must be declared before that function, since
+signature types are resolved as each function is collected. This ordering
+restriction is an implementation artifact, not a language guarantee: unlike
+6.5:7 (which governs a constant's own value), it applies only to signature-
+position uses of a type constant.
 
 ## Evaluation Order
 


### PR DESCRIPTION
**Named form:** a const bound to a type value (const R: type = Result(i32,i32);, a primitive alias const Int = i32;, etc.) is now a TYPE CONSTANT usable in function parameter and return positions. Was E0434/E0204/E0421. Sema-only: a type_constants table fed by the existing type-alias-init path; resolve_type consults it; each function's comptime_type_vars is seeded with file-level type constants so R.Ok(..)/patterns resolve (locals shadow).

**This unblocks real error handling end-to-end** — with RUE-237's aggregate-return fix now merged, a function returning a generic Result by value works:

    fn divide(a, b) -> R { if b == 0 { R::Err(1) } else { R::Ok(a / b) } }
    match divide(84, 2) { R::Ok(v) => v, R::Err(e) => 0 - e }   // 42

(Removed the known_bug=RUE-237 marker on the return case — RUE-237 landed, so it now passes.)

Verified by execution: generic Option/Result named via a type const, constructed, passed as a PARAMETER, RETURNED by value, and matched give 42; primitive alias param+return give 42; shadowing; non-type annotation is a type error. Full test.sh green; aarch64 asm clean.

Remaining (follow-ups): the DIRECT call form fn f() -> Result(i32,i32) is still parser E0100 (type-expr grammar); type consts in signatures must be declared before use.

Part of RUE-241

Generated with Claude Code