### PR TITLE
Raw pointers: multi-slot @ptr_read/@ptr_write + @ptr_read result-type checking (RUE-242, RUE-244)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -3575,7 +3575,7 @@ impl<'a> Sema<'a> {
         } else if name == known.random_u64 {
             self.analyze_random_u64_intrinsic(air, name, &args, span)
         } else if name == known.ptr_read {
-            self.analyze_ptr_read_intrinsic(air, name, &args, span, ctx)
+            self.analyze_ptr_read_intrinsic(air, name, inst_ref, &args, span, ctx)
         } else if name == known.ptr_write {
             self.analyze_ptr_write_intrinsic(air, name, &args, span, ctx)
         } else if name == known.ptr_offset {
@@ -6206,6 +6206,7 @@ impl<'a> Sema<'a> {
         &mut self,
         air: &mut Air,
         name: Spur,
+        inst_ref: InstRef,
         args: &[RirCallArg],
         span: Span,
         ctx: &mut AnalysisContext,
@@ -6239,6 +6240,23 @@ impl<'a> Sema<'a> {
                 ));
             }
         };
+
+        // The result type is the pointee type. Inference modeled @ptr_read's
+        // result as a fresh type variable (the pointee is only known here), so
+        // a binding/annotation constrained that variable to some concrete type
+        // without ever comparing it to the pointee. Reconcile them now so a
+        // mismatch (`let x: i32 = @ptr_read(p_to_i64)`) is E0206 like every
+        // other path, instead of silently truncating (RUE-244). Skip when the
+        // resolved type is unconstrained (`<error>` — e.g. no annotation) or
+        // never; those carry no expectation to check against.
+        if let Some(&expected) = ctx.resolved_types.get(&inst_ref)
+            && expected != pointee_type
+            && !expected.is_error()
+            && !expected.is_never()
+            && !pointee_type.is_error()
+        {
+            return Err(self.type_mismatch_error(expected, pointee_type, span));
+        }
 
         // Create the intrinsic call instruction
         let args_start = air.add_extra(&[ptr_result.air_ref.as_u32()]);

--- a/crates/rue-cli-tests/cases/ptr_read_write_aggregate.toml
+++ b/crates/rue-cli-tests/cases/ptr_read_write_aggregate.toml
@@ -1,0 +1,141 @@
+# Raw-pointer read/write fixes found by the codegen-arithmetic/ABI hunt
+# (2026-07-02).
+#
+# RUE-242: @ptr_read / @ptr_write on a multi-slot aggregate pointee
+# (struct/array/nested struct) only transferred the first 8-byte slot, silently
+# dropping every other field. Both now iterate over ALL slots of the pointee at
+# their descending byte offsets (slot i at ptr - i*8), reusing the aggregate
+# slot machinery.
+#
+# RUE-244: a @ptr_read result type was not reconciled against the binding's
+# type annotation (inference modeled it as an unconstrained fresh variable), so
+# an i64 pointee flowed into an i32 binding with no E0206 and a silent runtime
+# truncation. The pointee type now participates in ordinary type-checking.
+
+[section]
+id = "cli.ptr_read_write_aggregate"
+name = "Raw-pointer read/write over multi-field aggregates and result-type checking"
+description = "@ptr_read/@ptr_write transfer every slot of an aggregate pointee, and @ptr_read's result type is checked against the binding annotation."
+
+# --- RUE-242: @ptr_read of a 2-field struct reads BOTH fields ----------------
+[[case]]
+name = "ptr_read_two_field_struct"
+files = [{ path = "main.rue", source = """
+struct P { x: i32, y: i32 }
+fn main() -> i32 {
+    let arr: [P; 1] = [P { x: 1, y: 2 }];
+    checked {
+        let p: ptr const P = @raw(arr[0]);
+        let v = @ptr_read(p);
+        @dbg(v.x);
+        @dbg(v.y);
+    };
+    0
+}
+""" }]
+stdout = "1\n2\n"
+
+# --- RUE-242: @ptr_write of a 2-field struct writes BOTH fields --------------
+[[case]]
+name = "ptr_write_two_field_struct"
+files = [{ path = "main.rue", source = """
+struct P { x: i32, y: i32 }
+fn main() -> i32 {
+    let mut arr: [P; 1] = [P { x: 0, y: 0 }];
+    checked {
+        let p: ptr mut P = @raw_mut(arr[0]);
+        @ptr_write(p, P { x: 7, y: 9 });
+    };
+    @dbg(arr[0].x);
+    @dbg(arr[0].y);
+    0
+}
+""" }]
+stdout = "7\n9\n"
+
+# --- RUE-242: nested struct (3 slots) round-trips through read and write -----
+[[case]]
+name = "ptr_read_write_nested_struct"
+files = [{ path = "main.rue", source = """
+struct Inner { a: i32, b: i32 }
+struct Outer { p: Inner, q: i32 }
+fn main() -> i32 {
+    let mut arr: [Outer; 1] = [Outer { p: Inner { a: 10, b: 20 }, q: 30 }];
+    checked {
+        let rp: ptr const Outer = @raw(arr[0]);
+        let v = @ptr_read(rp);
+        @dbg(v.p.a);
+        @dbg(v.p.b);
+        @dbg(v.q);
+        let wp: ptr mut Outer = @raw_mut(arr[0]);
+        @ptr_write(wp, Outer { p: Inner { a: 1, b: 2 }, q: 3 });
+    };
+    @dbg(arr[0].p.a);
+    @dbg(arr[0].p.b);
+    @dbg(arr[0].q);
+    0
+}
+""" }]
+stdout = "10\n20\n30\n1\n2\n3\n"
+
+# --- RUE-242 guard: scalar pointee read/write still works --------------------
+[[case]]
+name = "ptr_read_write_scalar"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut v: i32 = 5;
+    checked {
+        let p: ptr mut i32 = @raw_mut(v);
+        let r = @ptr_read(p);
+        @dbg(r);
+        @ptr_write(p, 42);
+    };
+    @dbg(v);
+    0
+}
+""" }]
+stdout = "5\n42\n"
+
+# --- RUE-244: i64 pointee into an i32 annotation is a type error ------------
+[[case]]
+name = "ptr_read_result_type_mismatch_i32"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let v: i64 = 42;
+    let x: i32 = checked { @ptr_read(@raw(v)) };
+    x
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206"]
+
+# --- RUE-244: matching pointee/annotation compiles and runs -----------------
+[[case]]
+name = "ptr_read_result_type_match_i32"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let v: i32 = 42;
+    let x: i32 = checked { @ptr_read(@raw(v)) };
+    x
+}
+""" }]
+exit_code = 42
+
+# --- RUE-244: struct pointee into a wrong struct annotation is E0206 --------
+[[case]]
+name = "ptr_read_result_type_mismatch_struct"
+files = [{ path = "main.rue", source = """
+struct P { x: i32, y: i32 }
+struct Q { a: i32 }
+fn main() -> i32 {
+    let arr: [P; 1] = [P { x: 4, y: 8 }];
+    checked {
+        let p: ptr const P = @raw(arr[0]);
+        let v: Q = @ptr_read(p);
+        @dbg(v.a);
+    };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206"]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2049,19 +2049,33 @@ impl<'a> CfgLower<'a> {
                     });
                     self.value_map.insert(value, result_vreg);
                 } else if name_str == "ptr_read" {
-                    // @ptr_read(ptr) - Read value at pointer
-                    // The pointer is in the first argument, we load from [ptr].
+                    // @ptr_read(ptr) - Read the pointee value through the pointer.
                     let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                     let ptr_val = args[0];
                     let ptr_vreg = self.get_vreg(ptr_val);
 
-                    // Load from memory at the pointer address
-                    let result_vreg = self.mir.alloc_vreg();
-                    self.mir.push(Aarch64Inst::LdrIndexed {
-                        dst: Operand::Virtual(result_vreg),
-                        base: ptr_vreg,
-                    });
-                    self.value_map.insert(value, result_vreg);
+                    // The result type is the pointee type. An aggregate pointee
+                    // (struct/array/payload enum) occupies several 8-byte slots;
+                    // read EVERY slot at its descending byte offset (slot i at
+                    // ptr - i*8, matching how @raw addresses the place and the
+                    // by-ref aggregate load path). Reading only slot 0 dropped
+                    // every field but the first (RUE-242).
+                    let result_ty = self.ctx.cfg.get_inst(value).ty;
+                    let slot_count = self.ctx.type_slot_count(result_ty);
+                    if slot_count > 1 {
+                        let slot_vregs =
+                            crate::agg_slots::load_slots_through_ptr(self, ptr_vreg, slot_count);
+                        let first = slot_vregs[0];
+                        self.struct_slot_vregs.insert(value, slot_vregs);
+                        self.value_map.insert(value, first);
+                    } else {
+                        let result_vreg = self.mir.alloc_vreg();
+                        self.mir.push(Aarch64Inst::LdrIndexed {
+                            dst: Operand::Virtual(result_vreg),
+                            base: ptr_vreg,
+                        });
+                        self.value_map.insert(value, result_vreg);
+                    }
                 } else if name_str == "ptr_write" {
                     // @ptr_write(ptr, value) - Write value at pointer
                     // First argument is pointer, second is value to write.
@@ -2069,13 +2083,25 @@ impl<'a> CfgLower<'a> {
                     let ptr_val = args[0];
                     let value_val = args[1];
                     let ptr_vreg = self.get_vreg(ptr_val);
-                    let value_vreg = self.get_vreg(value_val);
 
-                    // Store value to memory at the pointer address
-                    self.mir.push(Aarch64Inst::StrIndexed {
-                        src: Operand::Virtual(value_vreg),
-                        base: ptr_vreg,
-                    });
+                    // An aggregate value spans several 8-byte slots; store EVERY
+                    // slot at its descending byte offset (slot i at ptr - i*8),
+                    // symmetric with @ptr_read. Storing only slot 0 dropped
+                    // every field but the first (RUE-242).
+                    let value_ty = self.ctx.cfg.get_inst(value_val).ty;
+                    let slot_count = self.ctx.type_slot_count(value_ty);
+                    if slot_count > 1 {
+                        let slot_vregs = self
+                            .get_or_compute_field_vregs(value_val)
+                            .unwrap_or_else(|| vec![self.get_vreg(value_val)]);
+                        crate::agg_slots::store_slots_through_ptr(self, &slot_vregs, ptr_vreg, 0);
+                    } else {
+                        let value_vreg = self.get_vreg(value_val);
+                        self.mir.push(Aarch64Inst::StrIndexed {
+                            src: Operand::Virtual(value_vreg),
+                            base: ptr_vreg,
+                        });
+                    }
 
                     // Result is unit (no meaningful value)
                     let result_vreg = self.mir.alloc_vreg();

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -425,6 +425,16 @@ pub fn store_slots_to_sret<B: SlotBackend>(b: &mut B, vals: &[VReg]) {
     }
 }
 
+/// Load `count` slots through `ptr` at descending byte offsets (slot i at
+/// `ptr - i*8`), returning the freshly-allocated vregs in slot order. The
+/// public counterpart of [`store_slots_through_ptr`]: used by `@ptr_read` to
+/// read an aggregate pointee through a raw pointer, one 8-byte slot per field
+/// (RUE-242). Every value of an aggregate type occupies `type_slot_count`
+/// consecutive descending slots, matching how `@raw` addresses the place.
+pub fn load_slots_through_ptr<B: SlotBackend>(b: &mut B, ptr: VReg, count: u32) -> Vec<VReg> {
+    load_through_ptr(b, ptr, count)
+}
+
 /// Load `count` consecutive frame slots starting at `base_slot`, returning the
 /// freshly-allocated vregs in slot order.
 fn load_consecutive<B: SlotBackend>(b: &mut B, base_slot: u32, count: u32) -> Vec<VReg> {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2367,20 +2367,34 @@ impl<'a> CfgLower<'a> {
                     });
                     self.value_map.insert(value, result_vreg);
                 } else if name_str == "ptr_read" {
-                    // @ptr_read(ptr) - Read value at pointer
-                    // The pointer is in the first argument, we load from [ptr].
+                    // @ptr_read(ptr) - Read the pointee value through the pointer.
                     let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                     let ptr_val = args[0];
                     let ptr_vreg = self.get_vreg(ptr_val);
 
-                    // Load from memory at the pointer address
-                    let result_vreg = self.mir.alloc_vreg();
-                    self.mir.push(X86Inst::MovRMIndexed {
-                        dst: Operand::Virtual(result_vreg),
-                        base: ptr_vreg,
-                        offset: 0,
-                    });
-                    self.value_map.insert(value, result_vreg);
+                    // The result type is the pointee type. An aggregate pointee
+                    // (struct/array/payload enum) occupies several 8-byte slots;
+                    // read EVERY slot at its descending byte offset (slot i at
+                    // ptr - i*8, matching how @raw addresses the place and the
+                    // by-ref aggregate load path). Reading only slot 0 dropped
+                    // every field but the first (RUE-242).
+                    let result_ty = self.ctx.cfg.get_inst(value).ty;
+                    let slot_count = self.ctx.type_slot_count(result_ty);
+                    if slot_count > 1 {
+                        let slot_vregs =
+                            crate::agg_slots::load_slots_through_ptr(self, ptr_vreg, slot_count);
+                        let first = slot_vregs[0];
+                        self.struct_slot_vregs.insert(value, slot_vregs);
+                        self.value_map.insert(value, first);
+                    } else {
+                        let result_vreg = self.mir.alloc_vreg();
+                        self.mir.push(X86Inst::MovRMIndexed {
+                            dst: Operand::Virtual(result_vreg),
+                            base: ptr_vreg,
+                            offset: 0,
+                        });
+                        self.value_map.insert(value, result_vreg);
+                    }
                 } else if name_str == "ptr_write" {
                     // @ptr_write(ptr, value) - Write value at pointer
                     // First argument is pointer, second is value to write.
@@ -2388,14 +2402,26 @@ impl<'a> CfgLower<'a> {
                     let ptr_val = args[0];
                     let value_val = args[1];
                     let ptr_vreg = self.get_vreg(ptr_val);
-                    let value_vreg = self.get_vreg(value_val);
 
-                    // Store value to memory at the pointer address
-                    self.mir.push(X86Inst::MovMRIndexed {
-                        base: ptr_vreg,
-                        offset: 0,
-                        src: Operand::Virtual(value_vreg),
-                    });
+                    // An aggregate value spans several 8-byte slots; store EVERY
+                    // slot at its descending byte offset (slot i at ptr - i*8),
+                    // symmetric with @ptr_read. Storing only slot 0 dropped
+                    // every field but the first (RUE-242).
+                    let value_ty = self.ctx.cfg.get_inst(value_val).ty;
+                    let slot_count = self.ctx.type_slot_count(value_ty);
+                    if slot_count > 1 {
+                        let slot_vregs = self
+                            .get_or_compute_field_vregs(value_val)
+                            .unwrap_or_else(|| vec![self.get_vreg(value_val)]);
+                        crate::agg_slots::store_slots_through_ptr(self, &slot_vregs, ptr_vreg, 0);
+                    } else {
+                        let value_vreg = self.get_vreg(value_val);
+                        self.mir.push(X86Inst::MovMRIndexed {
+                            base: ptr_vreg,
+                            offset: 0,
+                            src: Operand::Virtual(value_vreg),
+                        });
+                    }
 
                     // Result is unit (no meaningful value)
                     let result_vreg = self.mir.alloc_vreg();


### PR DESCRIPTION
Both found by the codegen-arithmetic/ABI hunt.

**RUE-242** — @ptr_read/@ptr_write transferred only the first 8-byte slot of a multi-slot pointee (struct/array), silently dropping the rest. Both backends now iterate over ALL slots at their offsets, reusing the aggregate slot machinery (new agg_slots::load_slots_through_ptr mirroring the existing store helper). Verified: 2-field struct reads 1,2 and writes 7,9; nested 3-slot struct round-trips; scalar still works; aarch64 slot loop via --emit asm.

**RUE-244** — @ptr_read's result type was an unconstrained inference variable, so a binding annotation was never checked (i64 value silently accepted into i32). Sema now reconciles the resolved type against the pointee type and emits E0206 on mismatch. Verified: i64->i32 and struct->wrong-struct now E0206; matching cases compile+run; no-annotation reads unaffected.

Full test.sh green; 7 new CLI cases. Matters for RUE-1 (Vec walks raw pointers to aggregates). @ptr_offset direction is a separate decision (RUE-243/ADR-0040, queued), untouched here.

Fixes RUE-242
Fixes RUE-244

Generated with Claude Code