### PR TITLE
CFG verifier pass + opt-level differential harness (RUE-227, RUE-236)

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -2387,15 +2387,35 @@ impl<'a> CfgBuilder<'a> {
         self.value_cache[air_ref.as_u32() as usize] = Some(value);
     }
 
-    /// Lower an instruction and return its value, or None if it diverged.
-    /// This is a helper for use with the `?` operator when processing operands.
-    /// If the operand diverged, the caller should propagate the divergence.
+    /// Lower an instruction used in **value position** and return its value, or
+    /// `None` **only** if it diverged (return/break/continue).
+    ///
+    /// Callers use the `let Some(v) = self.lower_value(x) else { return
+    /// Self::diverged(); }` idiom, so `None` here means "control did not reach
+    /// this point" and the caller propagates the divergence (which terminates
+    /// the block). That idiom is only sound if `None` ⇔ divergence.
+    ///
+    /// The trap it guards against (RUE-227, the "block has no terminator" ICE
+    /// class): some AIR forms legitimately produce **no** CFG value while
+    /// control *continues* — statement-only, Unit-typed forms such as `Store`,
+    /// `ParamStore`, `Alloc`, and `StorageLive`/`StorageDead`. If such a form is
+    /// used in value position (e.g. `let x = (s.push(b));` where the mutation is
+    /// Unit — RUE-224), returning its raw `None` would make the caller wrongly
+    /// believe control diverged and bail out mid-block, leaving the block
+    /// unterminated → SIGABRT in codegen. Instead, when the expression
+    /// *continues* but yielded no value, we materialize a real Unit value here.
+    /// A well-typed program only reaches this branch for a genuinely Unit-typed
+    /// expression (sema rejects a non-Unit value being consumed where none is
+    /// produced), so a Unit `Const` is the correct, ABI-neutral filler.
     fn lower_value(&mut self, air_ref: AirRef) -> Option<CfgValue> {
         let result = self.lower_inst(air_ref);
-        if matches!(result.continuation, Continuation::Diverged) {
-            None
-        } else {
-            result.value
+        match result.continuation {
+            Continuation::Diverged => None,
+            Continuation::Continues => Some(result.value.unwrap_or_else(|| {
+                let inst = self.air.get(air_ref);
+                let (ty, span) = (inst.ty, inst.span);
+                self.emit(CfgInstData::Const(0), ty, span)
+            })),
         }
     }
 

--- a/crates/rue-cfg/src/lib.rs
+++ b/crates/rue-cfg/src/lib.rs
@@ -19,6 +19,7 @@
 mod build;
 mod inst;
 pub mod opt;
+mod verify;
 
 use rue_error::{CompileError, CompileWarning};
 

--- a/crates/rue-cfg/src/opt/mod.rs
+++ b/crates/rue-cfg/src/opt/mod.rs
@@ -153,6 +153,17 @@ pub fn optimize(cfg: &mut Cfg, level: OptLevel) {
             dce::run(cfg);
         }
     }
+
+    // Structural verification (RUE-227). This runs at EVERY opt level (O0
+    // included) so the CFG handed to codegen is always checked — the AIR→CFG
+    // "block has no terminator" bug class becomes a loud, localized panic here
+    // instead of a mysterious SIGABRT deep in cfg_lower. `optimize` is the
+    // single choke point every build site funnels through right before
+    // lowering, so verifying here covers both construction and optimization
+    // output. Malformed-AIR cases that populate `CfgOutput.errors` (e.g. an
+    // un-specialized CallGeneric) abort before this is reached, so they are
+    // never verified. See `crate::verify`.
+    cfg.verify();
 }
 
 #[cfg(test)]

--- a/crates/rue-cfg/src/verify.rs
+++ b/crates/rue-cfg/src/verify.rs
@@ -1,0 +1,408 @@
+//! CFG structural verifier (RUE-227).
+//!
+//! After the CFG is built (and optimized) but before it is lowered to machine
+//! code, this pass asserts the structural invariants that codegen relies on.
+//! Its whole purpose is to convert a *class* of latent lowering bugs — most
+//! notoriously "block has no terminator", which historically surfaced as a
+//! `SIGABRT` deep inside `cfg_lower.rs` (RUE-213 / RUE-217 / RUE-224) — into a
+//! **loud, early, localized** compiler-bug report naming the function and the
+//! offending block.
+//!
+//! # Why a hard panic (not a `debug_assert`)
+//!
+//! A CFG that violates these invariants is malformed AIR→CFG output: continuing
+//! anyway miscompiles the program (wrong ABI, double-free, silent corruption).
+//! Per RUE-45 the guard must fire in **release** builds too, so this uses
+//! `panic!`/`assert!`, never `debug_assert!`.
+//!
+//! # Invariants checked (for every *reachable* block)
+//!
+//! 1. **Termination** — the block ends in a real terminator (`Goto`, `Branch`,
+//!    `Switch`, `Return`, or `Unreachable`), never the `None` placeholder that a
+//!    mid-block `diverged()` bail leaves behind.
+//! 2. **Value definition** — every `CfgValue` referenced by an instruction or a
+//!    terminator indexes a value that actually exists in the CFG.
+//! 3. **Block-param arity** — the number of block-arguments passed along each
+//!    edge equals the arity of the successor block's parameter list.
+//!
+//! Unreachable blocks are intentionally skipped: an orphan block created but
+//! never wired in (or one left behind before DCE) may legitimately carry a
+//! `None` terminator, and it never reaches codegen.
+
+use crate::inst::{Cfg, CfgInstData, CfgValue, Projection, Terminator};
+
+impl Cfg {
+    /// Verify the CFG's structural invariants, panicking with a precise,
+    /// function- and block-localized message on any violation.
+    ///
+    /// See the module docs for the invariants and the rationale for the hard
+    /// panic. This is a compiler-bug guard: a well-formed pipeline never trips
+    /// it, so the cost (one linear walk of reachable blocks) is paid only to
+    /// pin future lowering regressions to their source.
+    pub fn verify(&self) {
+        let reachable = self.reachable_blocks();
+        let value_count = self.value_count() as u32;
+
+        for block in self.blocks() {
+            if !reachable[block.id.as_u32() as usize] {
+                continue;
+            }
+
+            // (1) Termination.
+            if matches!(block.terminator, Terminator::None) {
+                panic!(
+                    "internal compiler error: CFG verification failed in function \
+                     `{}`: reachable block {} has no terminator (an AIR→CFG lowering \
+                     path left the block unterminated — likely an expression used in \
+                     value position that produced no CFG value). This is a compiler \
+                     bug (RUE-227).",
+                    self.fn_name(),
+                    block.id,
+                );
+            }
+
+            // (2) Value definition — block params and instruction operands.
+            for &(param_val, _) in &block.params {
+                self.check_value_defined(param_val, value_count, block.id, "block parameter");
+            }
+            for &inst_val in &block.insts {
+                self.check_value_defined(inst_val, value_count, block.id, "instruction result");
+                let mut operands = Vec::new();
+                self.collect_inst_operands(&self.get_inst(inst_val).data, &mut operands);
+                for op in operands {
+                    self.check_value_defined(op, value_count, block.id, "instruction operand");
+                }
+            }
+
+            // (2) + (3) Terminator operands and edge arities.
+            self.verify_terminator(block.id, &block.terminator, value_count);
+        }
+    }
+
+    /// Panic if `value` does not index a defined value in this CFG.
+    #[inline]
+    fn check_value_defined(
+        &self,
+        value: CfgValue,
+        value_count: u32,
+        block: crate::inst::BlockId,
+        role: &str,
+    ) {
+        assert!(
+            value.as_u32() < value_count,
+            "internal compiler error: CFG verification failed in function `{}`: {} \
+             {} in block {} references an undefined value (only {} values exist). \
+             This is a compiler bug (RUE-227).",
+            self.fn_name(),
+            role,
+            value,
+            block,
+            value_count,
+        );
+    }
+
+    /// Verify a block's terminator: operand definedness and successor arities.
+    fn verify_terminator(&self, block: crate::inst::BlockId, term: &Terminator, value_count: u32) {
+        match term {
+            Terminator::Goto {
+                target,
+                args_start,
+                args_len,
+            } => {
+                let args = self.get_extra(*args_start, *args_len);
+                for &arg in args {
+                    self.check_value_defined(arg, value_count, block, "goto argument");
+                }
+                self.check_edge_arity(block, *target, args.len());
+            }
+            Terminator::Branch {
+                cond,
+                then_block,
+                then_args_start,
+                then_args_len,
+                else_block,
+                else_args_start,
+                else_args_len,
+            } => {
+                self.check_value_defined(*cond, value_count, block, "branch condition");
+                let then_args = self.get_extra(*then_args_start, *then_args_len);
+                for &arg in then_args {
+                    self.check_value_defined(arg, value_count, block, "branch-then argument");
+                }
+                self.check_edge_arity(block, *then_block, then_args.len());
+                let else_args = self.get_extra(*else_args_start, *else_args_len);
+                for &arg in else_args {
+                    self.check_value_defined(arg, value_count, block, "branch-else argument");
+                }
+                self.check_edge_arity(block, *else_block, else_args.len());
+            }
+            Terminator::Switch {
+                scrutinee,
+                cases_start,
+                cases_len,
+                default,
+            } => {
+                self.check_value_defined(*scrutinee, value_count, block, "switch scrutinee");
+                // Switch edges carry no block-arguments, so every successor
+                // must have an empty parameter list.
+                for (_, target) in self.get_switch_cases(*cases_start, *cases_len) {
+                    self.check_edge_arity(block, *target, 0);
+                }
+                self.check_edge_arity(block, *default, 0);
+            }
+            Terminator::Return { value } => {
+                if let Some(v) = value {
+                    self.check_value_defined(*v, value_count, block, "return value");
+                }
+            }
+            Terminator::Unreachable | Terminator::None => {}
+        }
+    }
+
+    /// Panic if the number of block-arguments on an edge does not match the
+    /// successor block's parameter arity.
+    fn check_edge_arity(&self, from: crate::inst::BlockId, to: crate::inst::BlockId, args: usize) {
+        let params = self.get_block(to).params.len();
+        assert!(
+            params == args,
+            "internal compiler error: CFG verification failed in function `{}`: edge \
+             {} -> {} passes {} block-argument(s) but the target expects {} block \
+             parameter(s). This is a compiler bug (RUE-227).",
+            self.fn_name(),
+            from,
+            to,
+            args,
+            params,
+        );
+    }
+
+    /// Compute which blocks are reachable from the entry block by following
+    /// terminator successors.
+    fn reachable_blocks(&self) -> Vec<bool> {
+        let mut reachable = vec![false; self.block_count()];
+        if self.block_count() == 0 {
+            return reachable;
+        }
+        let mut stack = vec![self.entry];
+        reachable[self.entry.as_u32() as usize] = true;
+        while let Some(id) = stack.pop() {
+            let mut push = |succ: crate::inst::BlockId| {
+                let idx = succ.as_u32() as usize;
+                if !reachable[idx] {
+                    reachable[idx] = true;
+                    stack.push(succ);
+                }
+            };
+            match &self.get_block(id).terminator {
+                Terminator::Goto { target, .. } => push(*target),
+                Terminator::Branch {
+                    then_block,
+                    else_block,
+                    ..
+                } => {
+                    push(*then_block);
+                    push(*else_block);
+                }
+                Terminator::Switch {
+                    cases_start,
+                    cases_len,
+                    default,
+                    ..
+                } => {
+                    for (_, target) in self.get_switch_cases(*cases_start, *cases_len) {
+                        push(*target);
+                    }
+                    push(*default);
+                }
+                Terminator::Return { .. } | Terminator::Unreachable | Terminator::None => {}
+            }
+        }
+        reachable
+    }
+
+    /// Collect every `CfgValue` operand referenced by an instruction into
+    /// `out`. This mirrors the `CfgInstData` variants; a new variant with value
+    /// operands must be added here so the verifier keeps seeing all references.
+    fn collect_inst_operands(&self, data: &CfgInstData, out: &mut Vec<CfgValue>) {
+        match data {
+            // No value operands.
+            CfgInstData::Const(_)
+            | CfgInstData::BoolConst(_)
+            | CfgInstData::StringConst(_)
+            | CfgInstData::Param { .. }
+            | CfgInstData::BlockParam { .. }
+            | CfgInstData::Load { .. }
+            | CfgInstData::StorageLive { .. }
+            | CfgInstData::StorageDead { .. } => {}
+
+            // Binary operations.
+            CfgInstData::Add(a, b)
+            | CfgInstData::Sub(a, b)
+            | CfgInstData::Mul(a, b)
+            | CfgInstData::Div(a, b)
+            | CfgInstData::Mod(a, b)
+            | CfgInstData::Eq(a, b)
+            | CfgInstData::Ne(a, b)
+            | CfgInstData::Lt(a, b)
+            | CfgInstData::Gt(a, b)
+            | CfgInstData::Le(a, b)
+            | CfgInstData::Ge(a, b)
+            | CfgInstData::BitAnd(a, b)
+            | CfgInstData::BitOr(a, b)
+            | CfgInstData::BitXor(a, b)
+            | CfgInstData::Shl(a, b)
+            | CfgInstData::Shr(a, b) => {
+                out.push(*a);
+                out.push(*b);
+            }
+
+            // Unary operations.
+            CfgInstData::Neg(v) | CfgInstData::Not(v) | CfgInstData::BitNot(v) => out.push(*v),
+
+            CfgInstData::Alloc { init, .. } => out.push(*init),
+            CfgInstData::Store { value, .. } => out.push(*value),
+            CfgInstData::ParamStore { value, .. } => out.push(*value),
+
+            CfgInstData::PlaceRead { place } => self.collect_place_operands(place, out),
+            CfgInstData::PlaceWrite { place, value } => {
+                self.collect_place_operands(place, out);
+                out.push(*value);
+            }
+
+            CfgInstData::Call {
+                args_start,
+                args_len,
+                ..
+            } => {
+                for arg in self.get_call_args(*args_start, *args_len) {
+                    out.push(arg.value);
+                }
+            }
+            CfgInstData::Intrinsic {
+                args_start,
+                args_len,
+                ..
+            } => out.extend_from_slice(self.get_extra(*args_start, *args_len)),
+
+            CfgInstData::StructInit {
+                fields_start,
+                fields_len,
+                ..
+            } => out.extend_from_slice(self.get_extra(*fields_start, *fields_len)),
+            CfgInstData::FieldSet { value, .. } => out.push(*value),
+            CfgInstData::ParamFieldSet { value, .. } => out.push(*value),
+
+            CfgInstData::ArrayInit {
+                elements_start,
+                elements_len,
+            } => out.extend_from_slice(self.get_extra(*elements_start, *elements_len)),
+            CfgInstData::IndexSet { index, value, .. } => {
+                out.push(*index);
+                out.push(*value);
+            }
+            CfgInstData::ParamIndexSet { index, value, .. } => {
+                out.push(*index);
+                out.push(*value);
+            }
+
+            CfgInstData::EnumVariant {
+                payload_start,
+                payload_len,
+                ..
+            } => out.extend_from_slice(self.get_extra(*payload_start, *payload_len)),
+            CfgInstData::EnumPayloadGet { base, .. } => out.push(*base),
+
+            CfgInstData::IntCast { value, .. } => out.push(*value),
+            CfgInstData::Drop { value } => out.push(*value),
+        }
+    }
+
+    /// Collect the `CfgValue` operands hiding inside a place's `Index`
+    /// projections.
+    fn collect_place_operands(&self, place: &crate::inst::Place, out: &mut Vec<CfgValue>) {
+        for proj in self.get_place_projections(place) {
+            if let Projection::Index { index, .. } = proj {
+                out.push(*index);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::inst::{Cfg, CfgInst, CfgInstData, Terminator};
+    use rue_air::Type;
+    use rue_span::Span;
+
+    fn unit_cfg() -> Cfg {
+        Cfg::new(Type::I32, 0, 0, "test".to_string(), vec![])
+    }
+
+    #[test]
+    fn verify_accepts_terminated_block() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let v = cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(42),
+                ty: Type::I32,
+                span: Span::new(0, 2),
+            },
+        );
+        cfg.set_terminator(entry, Terminator::Return { value: Some(v) });
+        cfg.verify(); // must not panic
+    }
+
+    #[test]
+    #[should_panic(expected = "has no terminator")]
+    fn verify_catches_missing_terminator() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.add_inst_to_block(
+            entry,
+            CfgInst {
+                data: CfgInstData::Const(1),
+                ty: Type::I32,
+                span: Span::new(0, 1),
+            },
+        );
+        // Deliberately leave the reachable entry block with Terminator::None.
+        cfg.verify();
+    }
+
+    #[test]
+    fn verify_ignores_unreachable_unterminated_block() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        cfg.set_terminator(entry, Terminator::Return { value: None });
+        // An orphan block, never wired in, with no terminator: must be skipped.
+        let _orphan = cfg.new_block();
+        cfg.verify();
+    }
+
+    #[test]
+    #[should_panic(expected = "block-argument")]
+    fn verify_catches_arity_mismatch() {
+        let mut cfg = unit_cfg();
+        let entry = cfg.new_block();
+        cfg.entry = entry;
+        let target = cfg.new_block();
+        // Target expects one block parameter...
+        cfg.add_block_param(target, Type::I32);
+        cfg.set_terminator(target, Terminator::Return { value: None });
+        // ...but the goto edge passes zero arguments.
+        cfg.set_terminator(
+            entry,
+            Terminator::Goto {
+                target,
+                args_start: 0,
+                args_len: 0,
+            },
+        );
+        cfg.verify();
+    }
+}

--- a/crates/rue-cli-tests/cases/cfg_value_position_unit.toml
+++ b/crates/rue-cli-tests/cases/cfg_value_position_unit.toml
@@ -1,0 +1,46 @@
+# Unit-typed expressions used in value position lower cleanly (RUE-227).
+#
+# This is the general form of the "block has no terminator" ICE class
+# (RUE-213 / RUE-217 / RUE-224): an AIR expression that produces no CFG value
+# (statement-only / Unit-typed forms) used where a value is required. The
+# AIR→CFG `lower_value` helper now materializes a real Unit value for any
+# expression that *continues* but yields no value, so the caller never mistakes
+# "no value" for divergence and leaves the block unterminated. A CFG verifier
+# pass (crate rue-cfg::verify) additionally asserts every reachable block is
+# terminated before codegen, turning any future lowering gap into a loud,
+# localized compiler-bug panic instead of a mystery SIGABRT.
+#
+# These cases must COMPILE AND RUN: a genuinely Unit-typed expression is a
+# legal argument to a `()` parameter, and its Unit value flows through the ABI
+# like any other value.
+
+[section]
+id = "cli.cfg_value_position_unit"
+name = "Unit expressions in value position"
+description = "Unit-typed expressions used as values compile and run; no 'block has no terminator' ICE (RUE-227)."
+
+[[case]]
+name = "unit_call_result_as_argument"
+description = "A unit-returning call used as a `()` argument lowers to a real Unit value and runs."
+files = [{ path = "main.rue", source = """
+fn noop() {}
+fn take(x: ()) -> i32 { 42 }
+fn main() -> i32 {
+    @dbg(take(noop()));
+    0
+}
+""" }]
+stdout = "42\n"
+
+[[case]]
+name = "unit_if_without_else_as_argument"
+description = "A unit `if`-without-else used as a `()` argument lowers cleanly and runs."
+files = [{ path = "main.rue", source = """
+fn take(x: ()) -> i32 { 7 }
+fn main() -> i32 {
+    let c: bool = true;
+    @dbg(take(if c { let _z: i32 = 1; }));
+    0
+}
+""" }]
+stdout = "7\n"

--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -1,0 +1,149 @@
+# Opt-level differential tests (RUE-236).
+#
+# Each case here is marked `differential_opt = true`: the harness compiles and
+# runs it once per optimization level (-O0, -O1, -O2, -O3) and asserts the exit
+# code AND stdout are IDENTICAL across all of them. This is the program-opt-
+# level analogue of the release-mode CI job (RUE-45), which catches compiler
+# `cfg(debug_assertions)` divergence — here we catch optimizer passes that
+# change a program's observable behavior.
+#
+# -O2/-O3 currently alias -O1 (const-fold + DCE), so results match today; the
+# point is to set the net now so a FUTURE optimizer change that breaks
+# semantics at a higher level is caught immediately, naming the diverging level.
+#
+# Keep this subset SMALL and representative (bounded CI cost): one case each for
+# arithmetic, control flow, an ABI/by-value-aggregate path, and a
+# call/recursion path. Each declares exact stdout+exit_code so every level is
+# also anchored to the known-good result, not just to the other levels.
+
+[section]
+id = "cli.differential_opt"
+name = "Opt-level differential"
+description = "Marked cases must produce identical results at -O0/-O1/-O2/-O3."
+
+# Arithmetic: a spread of operators, widths, and folds. Constant-heavy so the
+# const-fold pass has plenty to chew on; the runtime baseline (-O0) must agree.
+[[case]]
+name = "arithmetic_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i32 = 6;
+    let b: i32 = 7;
+    let c: i32 = a * b + 100 / 5 - 3;
+    let d: i32 = (c << 2) ^ 0x0F;
+    let e: u32 = ~0 - 4294967200;
+    @dbg(c);
+    @dbg(d);
+    @dbg(e);
+    c
+}
+""" }]
+stdout = """59
+227
+95
+"""
+exit_code = 59
+
+# Control flow: nested loops, branches, mutation, early-ish exits. Exercises
+# CFG-shaped code where a bad block-simplification would show up.
+[[case]]
+name = "control_flow_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut sum: i32 = 0;
+    let mut i: i32 = 0;
+    while i < 10 {
+        if i % 2 == 0 {
+            sum = sum + i;
+        } else {
+            sum = sum - 1;
+        }
+        let mut j: i32 = 0;
+        while j < i {
+            sum = sum + 1;
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    @dbg(sum);
+    sum
+}
+""" }]
+stdout = "60\n"
+exit_code = 60
+
+# ABI / by-value aggregate: a struct passed and returned by value, with a
+# large-enough field mix to exercise the aggregate-slot path that has
+# historically miscompiled (RUE-13/14). Divergence here would be an ABI bug the
+# optimizer exposed.
+[[case]]
+name = "aggregate_abi_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+struct Vec3 {
+    x: i64,
+    y: i64,
+    z: i64,
+}
+
+fn add(a: Vec3, b: Vec3) -> Vec3 {
+    Vec3 { x: a.x + b.x, y: a.y + b.y, z: a.z + b.z }
+}
+
+fn dot(a: Vec3, b: Vec3) -> i64 {
+    a.x * b.x + a.y * b.y + a.z * b.z
+}
+
+fn main() -> i32 {
+    let s = add(Vec3 { x: 1, y: 2, z: 3 }, Vec3 { x: 10, y: 20, z: 30 });
+    @dbg(s.x);
+    @dbg(s.y);
+    @dbg(s.z);
+    let d = dot(Vec3 { x: 1, y: 2, z: 3 }, Vec3 { x: 10, y: 20, z: 30 });
+    @dbg(d);
+    let r: i32 = @intCast(d % 256);
+    r
+}
+""" }]
+stdout = """11
+22
+33
+140
+"""
+exit_code = 140
+
+# Call / recursion: mutual + self recursion, so inlining or tail-call style
+# opts (should they ever land) can't silently change the result.
+[[case]]
+name = "recursion_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+fn fib(n: i32) -> i32 {
+    if n < 2 {
+        n
+    } else {
+        fib(n - 1) + fib(n - 2)
+    }
+}
+
+fn is_even(n: i32) -> bool {
+    if n == 0 { true } else { is_odd(n - 1) }
+}
+
+fn is_odd(n: i32) -> bool {
+    if n == 0 { false } else { is_even(n - 1) }
+}
+
+fn main() -> i32 {
+    let f: i32 = fib(15);
+    @dbg(f);
+    if is_even(f) { @dbg(0); } else { @dbg(1); }
+    f
+}
+""" }]
+stdout = """610
+0
+"""
+exit_code = 98

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -53,6 +53,11 @@
 //! - `only_on = ["x86-64-linux", ...]`: run the case only on these hosts
 //!   (ignored elsewhere). For behavior that depends on the host platform,
 //!   e.g. whether `--target X` is a cross-compile or a native compile.
+//! - `differential_opt = true`: compile+run the case once per optimization
+//!   level (`-O0`/`-O1`/`-O2`/`-O3`) and assert identical exit code AND stdout
+//!   across all levels, catching optimizer miscompiles (RUE-236). The runner
+//!   drives `-O`, so the case must not set its own `-O` in `args` and must not
+//!   be `compile_fail`/`compile_only`. Give it exact `stdout`/`exit_code`.
 //!
 //! # ICE detection
 //!
@@ -299,9 +304,36 @@ struct Case {
     /// Skip this case entirely.
     #[serde(default)]
     skip: bool,
+    /// Opt-level differential test (RUE-236): compile+run this case once per
+    /// optimization level (`-O0`, `-O1`, `-O2`, `-O3`) and assert IDENTICAL
+    /// exit code AND stdout across all levels. A divergence fails the case,
+    /// naming the level that differs. This catches optimizer passes that break
+    /// semantics — the analogue, at the *program's* opt level, of the
+    /// release-mode CI job (RUE-45) that catches `cfg(debug_assertions)`
+    /// divergence in the *compiler*. `-O2`/`-O3` alias `-O1` today, so results
+    /// match now; the net is set so a future divergence is caught.
+    ///
+    /// Marked cases must be plain compile-and-run cases: `compile_fail`,
+    /// `compile_only`, and an explicit `-O` in `args` are rejected (the runner
+    /// drives the opt level itself). Give the case exact `stdout` and
+    /// `exit_code` so each level is also checked against the known-good result,
+    /// not merely against the other levels.
+    #[serde(default)]
+    differential_opt: bool,
 }
 
 type TestResult = Result<(), String>;
+
+/// What running one case produced: the compiled program's exit code and
+/// stdout. For cases that don't run a program (`compile_fail`/`compile_only`),
+/// `ran` is false and the other fields are empty. Used by the opt-level
+/// differential runner to compare results across `-O` levels.
+#[derive(Debug, Default, PartialEq, Eq)]
+struct RunOutcome {
+    ran: bool,
+    exit_code: Option<i32>,
+    stdout: String,
+}
 
 /// Check a finished process for signs of a compiler panic / ICE.
 fn ice_message(status: &std::process::ExitStatus, stderr: &str) -> Option<String> {
@@ -326,7 +358,17 @@ fn expand_env_value(value: &str, real_std: &Path) -> String {
     value.replace("${REAL_STD}", &real_std.to_string_lossy())
 }
 
-fn run_case(case: &Case, rue_binary: &Path, real_std: &Path) -> TestResult {
+/// Compile and run one case, returning the program's outcome.
+///
+/// When `opt_level` is `Some("-O2")` etc., that flag is appended to the
+/// compiler args so the same case can be driven across optimization levels
+/// (see [`run_case_differential`]); when `None`, args are used verbatim.
+fn run_case(
+    case: &Case,
+    rue_binary: &Path,
+    real_std: &Path,
+    opt_level: Option<&str>,
+) -> Result<RunOutcome, String> {
     let temp_dir = tempfile::tempdir().map_err(|e| format!("failed to create temp dir: {}", e))?;
     let dir = temp_dir.path();
 
@@ -345,13 +387,20 @@ fn run_case(case: &Case, rue_binary: &Path, real_std: &Path) -> TestResult {
 
     // Default invocation mirrors what a user types: `rue main.rue -o prog`,
     // with RELATIVE paths and the temp dir as the working directory.
-    let args: Vec<String> = match &case.args {
+    let mut args: Vec<String> = match &case.args {
         Some(args) => args.clone(),
         None => {
             let first = case.files.first().ok_or("case has no files")?.path.clone();
             vec![first, "-o".to_string(), output_name.clone()]
         }
     };
+    // For an opt-level differential run, append the level flag. Flag position
+    // is irrelevant to the CLI, so this composes with either default or
+    // explicit args (differential cases are validated to not carry their own
+    // `-O`, so there's no conflict).
+    if let Some(level) = opt_level {
+        args.push(level.to_string());
+    }
 
     let mut cmd = Command::new(rue_binary);
     cmd.args(&args).current_dir(dir);
@@ -404,7 +453,7 @@ fn run_case(case: &Case, rue_binary: &Path, real_std: &Path) -> TestResult {
                 ));
             }
         }
-        return Ok(());
+        return Ok(RunOutcome::default());
     }
 
     if !compile_succeeded {
@@ -426,7 +475,7 @@ fn run_case(case: &Case, rue_binary: &Path, real_std: &Path) -> TestResult {
     }
 
     if case.compile_only {
-        return Ok(());
+        return Ok(RunOutcome::default());
     }
 
     // Run the produced binary from the temp dir.
@@ -486,6 +535,65 @@ fn run_case(case: &Case, rue_binary: &Path, real_std: &Path) -> TestResult {
         }
     }
 
+    Ok(RunOutcome {
+        ran: true,
+        exit_code: actual_exit,
+        stdout: run_stdout,
+    })
+}
+
+/// Opt-level differential runner (RUE-236): compile+run a marked case at every
+/// optimization level and assert identical exit code AND stdout across all of
+/// them, so an optimizer pass that miscompiles is caught.
+///
+/// Each level runs through the full [`run_case`] machinery, so its declared
+/// `exit_code`/`stdout` are checked at *every* level (a correctness anchor),
+/// and then the levels' outcomes are cross-checked against the first level so a
+/// divergence that still matches no declared value can't slip through. On a
+/// mismatch the error names the diverging level.
+fn run_case_differential(case: &Case, rue_binary: &Path, real_std: &Path) -> TestResult {
+    // Levels to compare. -O2/-O3 alias -O1 today; the net catches a future
+    // divergence.
+    const OPT_LEVELS: &[&str] = &["-O0", "-O1", "-O2", "-O3"];
+
+    // Guard against misuse: the runner drives the opt level, so these would be
+    // ambiguous or meaningless.
+    if case.compile_fail || case.compile_only {
+        return Err(
+            "differential_opt case must be a compile-and-run case (not compile_fail/compile_only)"
+                .to_string(),
+        );
+    }
+    if let Some(args) = &case.args {
+        if args.iter().any(|a| a.starts_with("-O")) {
+            return Err(
+                "differential_opt case must not set its own -O flag in args (the runner drives it)"
+                    .to_string(),
+            );
+        }
+    }
+
+    let mut baseline: Option<(&str, RunOutcome)> = None;
+    for level in OPT_LEVELS {
+        let outcome = run_case(case, rue_binary, real_std, Some(level))
+            .map_err(|e| format!("at {}: {}", level, e))?;
+        match &baseline {
+            None => baseline = Some((level, outcome)),
+            Some((base_level, base)) => {
+                if &outcome != base {
+                    return Err(format!(
+                        "opt-level divergence: {} produced (exit={:?}, stdout={:?}) but {} produced (exit={:?}, stdout={:?})",
+                        base_level,
+                        base.exit_code,
+                        base.stdout,
+                        level,
+                        outcome.exit_code,
+                        outcome.stdout
+                    ));
+                }
+            }
+        }
+    }
     Ok(())
 }
 
@@ -513,7 +621,11 @@ fn run_case_wrapper(
         ));
     }
 
-    let result = run_case(case, rue_binary, real_std);
+    let result = if case.differential_opt {
+        run_case_differential(case, rue_binary, real_std)
+    } else {
+        run_case(case, rue_binary, real_std, None).map(|_| ())
+    };
 
     // A known_bug scoped to other platforms doesn't apply here: the case
     // runs as a normal test on this host.


### PR DESCRIPTION
Two robustness/CI wins.

**RUE-227** — a CFG verifier (crates/rue-cfg/src/verify.rs): Cfg::verify() checks every reachable block for a real terminator, all referenced CfgValues defined, and matching block-param arities at each edge; violations panic!/assert! (NOT debug_assert, per RUE-45 — runs in release) with function name + block id. Wired at the end of opt::optimize (the choke point all build sites pass through before codegen). Turns the recurring block-has-no-terminator SIGABRT class (RUE-213/217/224) into a loud, localized compiler-bug report. Part B: lower_value now distinguishes true divergence (None) from continues-but-no-value (materializes a real Unit), generalizing the RUE-224 fix to the whole no-value class.

**RUE-236** — opt-level differential harness: a differential_opt marker runs a CLI-test case across -O0/-O1/-O2/-O3 and asserts identical exit + stdout, naming the diverging level on mismatch. Marks a bounded 4-case subset (arithmetic, control-flow, by-value aggregate, call/recursion). -O2/-O3 alias -O1 today so results match; the net is set so a future opt divergence is caught. Test-infra only.

Verified: verifier fires in debug AND release (59 rue-cfg tests pass in both; deliberately-broken-CFG tests panic as expected); opt divergence detection confirmed (mangled -O3 gives a clear failure, reverted). Full test.sh green.

Fixes RUE-227
Fixes RUE-236

Generated with Claude Code