### PR TITLE
Comptime type-function fixes: delegation, nesting, array-length-by-value-param, array-of-types ICE (RUE-251, RUE-252, RUE-253)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -331,6 +331,32 @@ impl<'a> ConstraintGenerator<'a> {
         }
     }
 
+    /// Like [`Self::resolve_infer_array_length`], but a comptime *value*
+    /// parameter captured at the call site (`values`, e.g. `N=3` for
+    /// `make_array(3)`) resolves a named length before the file-level
+    /// `const_values` table is consulted. Without this, a generic function
+    /// whose return/param type is `[i32; N]` sized by a comptime value param
+    /// couldn't resolve `N`, so the type fell back to the `COMPTIME_TYPE`
+    /// placeholder and the call was misinferred as returning `type`
+    /// (RUE-252).
+    fn resolve_infer_array_length_with_values(
+        &self,
+        len: &ArrayLen,
+        values: &HashMap<Spur, i128>,
+    ) -> Option<u64> {
+        match len {
+            ArrayLen::Literal(n) => Some(*n),
+            ArrayLen::Named(name) => {
+                let sym = self.interner.get(name)?;
+                let value = values
+                    .get(&sym)
+                    .copied()
+                    .or_else(|| self.const_values.and_then(|m| m.get(&sym).copied()))?;
+                u64::try_from(value).ok()
+            }
+        }
+    }
+
     /// Get the type variables allocated for integer literals.
     pub fn int_literal_vars(&self) -> &[TypeVarId] {
         &self.int_literal_vars
@@ -738,18 +764,29 @@ impl<'a> ConstraintGenerator<'a> {
                         // Build the type substitution map from comptime type arguments
                         let mut type_subst: std::collections::HashMap<lasso::Spur, Type> =
                             std::collections::HashMap::new();
+                        // Comptime VALUE arguments (`comptime N: i32`) captured
+                        // as their integer constant, so a return/param type
+                        // sized by one — an array length `[i32; N]` — resolves
+                        // at this call (RUE-252).
+                        let mut value_subst: std::collections::HashMap<lasso::Spur, i128> =
+                            std::collections::HashMap::new();
                         for (i, arg) in args.iter().enumerate() {
-                            if i < func.param_comptime.len()
-                                && func.param_comptime[i]
-                                && func.param_types.get(i)
-                                    == Some(&InferType::Concrete(Type::COMPTIME_TYPE))
-                                && i < func.param_names.len()
+                            if i >= func.param_comptime.len()
+                                || !func.param_comptime[i]
+                                || i >= func.param_names.len()
+                            {
+                                continue;
+                            }
+                            if func.param_types.get(i)
+                                == Some(&InferType::Concrete(Type::COMPTIME_TYPE))
                             {
                                 if let Some(concrete_ty) =
                                     self.extract_type_argument(arg.value, ctx)
                                 {
                                     type_subst.insert(func.param_names[i], concrete_ty);
                                 }
+                            } else if let Some(v) = self.extract_int_argument(arg.value) {
+                                value_subst.insert(func.param_names[i], v);
                             }
                         }
 
@@ -773,7 +810,11 @@ impl<'a> ConstraintGenerator<'a> {
                                 // mentioning a type parameter like `a: [T; 3]`
                                 // (RUE-172) - substitute T
                                 match func.param_type_syms.get(i).and_then(|sym| {
-                                    self.resolve_type_sym_with_subst(*sym, &type_subst)
+                                    self.resolve_type_sym_with_subst(
+                                        *sym,
+                                        &type_subst,
+                                        &value_subst,
+                                    )
                                 }) {
                                     Some(ty) => ty,
                                     // Unknown type parameter - checked in sema
@@ -794,8 +835,12 @@ impl<'a> ConstraintGenerator<'a> {
                         // (`-> [T; 3]`, RUE-172).
                         let return_type =
                             if func.return_type == InferType::Concrete(Type::COMPTIME_TYPE) {
-                                self.resolve_type_sym_with_subst(func.return_type_sym, &type_subst)
-                                    .unwrap_or_else(|| func.return_type.clone())
+                                self.resolve_type_sym_with_subst(
+                                    func.return_type_sym,
+                                    &type_subst,
+                                    &value_subst,
+                                )
+                                .unwrap_or_else(|| func.return_type.clone())
                             } else {
                                 func.return_type.clone()
                             };
@@ -1924,6 +1969,28 @@ impl<'a> ConstraintGenerator<'a> {
         }
     }
 
+    /// Extract a comptime *value* argument as an integer constant, for
+    /// resolving an array length parameterized by a comptime value param
+    /// (`fn f(comptime N: i32) -> [i32; N]`, RUE-252). Handles an integer
+    /// literal, its negation, and a reference to a file-level `const`; other
+    /// forms (checked fully in sema) yield `None`.
+    fn extract_int_argument(&self, arg: InstRef) -> Option<i128> {
+        match &self.rir.get(arg).data {
+            InstData::IntConst(v) => Some(*v as i128),
+            InstData::Neg { operand } => {
+                if let InstData::IntConst(v) = &self.rir.get(*operand).data {
+                    Some(-(*v as i128))
+                } else {
+                    None
+                }
+            }
+            InstData::VarRef { name } | InstData::ParamRef { name, .. } => {
+                self.const_values.and_then(|m| m.get(name).copied())
+            }
+            _ => None,
+        }
+    }
+
     /// Resolve a signature type symbol with type-parameter substitution,
     /// looking through composite syntax (RUE-172).
     ///
@@ -1935,17 +2002,19 @@ impl<'a> ConstraintGenerator<'a> {
         &self,
         sym: Spur,
         subst: &HashMap<Spur, Type>,
+        values: &HashMap<Spur, i128>,
     ) -> Option<InferType> {
         if let Some(&ty) = subst.get(&sym) {
             return Some(InferType::Concrete(ty));
         }
-        self.resolve_type_name_with_subst(self.interner.resolve(&sym), subst)
+        self.resolve_type_name_with_subst(self.interner.resolve(&sym), subst, values)
     }
 
     fn resolve_type_name_with_subst(
         &self,
         name: &str,
         subst: &HashMap<Spur, Type>,
+        values: &HashMap<Spur, i128>,
     ) -> Option<InferType> {
         if let Some(name_spur) = self.interner.get(name) {
             if let Some(&ty) = subst.get(&name_spur) {
@@ -1955,8 +2024,8 @@ impl<'a> ConstraintGenerator<'a> {
 
         // Array syntax: [T; N] - recurse so substituted element types work.
         if let Some((element_type_str, len)) = parse_array_type_syntax(name) {
-            let element_ty = self.resolve_type_name_with_subst(&element_type_str, subst)?;
-            let length = self.resolve_infer_array_length(&len)?;
+            let element_ty = self.resolve_type_name_with_subst(&element_type_str, subst, values)?;
+            let length = self.resolve_infer_array_length_with_values(&len, values)?;
             return Some(InferType::Array {
                 element: Box::new(element_ty),
                 length,
@@ -1965,7 +2034,8 @@ impl<'a> ConstraintGenerator<'a> {
 
         // Pointer syntax: ptr mut T / ptr const T - recurse on the pointee.
         if let Some((pointee_type_str, mutability)) = parse_pointer_type_syntax(name) {
-            let pointee_infer_ty = self.resolve_type_name_with_subst(&pointee_type_str, subst)?;
+            let pointee_infer_ty =
+                self.resolve_type_name_with_subst(&pointee_type_str, subst, values)?;
             // Only concrete pointees can be interned during constraint generation
             // (same limitation as resolve_type_name).
             let pointee_ty = match pointee_infer_ty {

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3471,6 +3471,23 @@ impl<'a> Sema<'a> {
     ) -> CompileResult<AnalysisResult> {
         let elem_refs = self.rir.get_inst_refs(elems_start, elems_len);
 
+        // An array literal of `type` values (`[i32, i32]`) has no runtime
+        // representation: type values only exist at compile time (spec
+        // 4.14:6). Reject it with E1200 — the same diagnostic `let t =
+        // comptime { i32 };` gets — before the array type, whose element is
+        // the comptime-only `type`, would reach the intern pool and panic
+        // (RUE-253).
+        for elem_ref in &elem_refs {
+            if ctx.resolved_types.get(elem_ref).copied() == Some(Type::COMPTIME_TYPE) {
+                return Err(CompileError::new(
+                    ErrorKind::ComptimeEvaluationFailed {
+                        reason: "type values cannot exist at runtime".to_string(),
+                    },
+                    span,
+                ));
+            }
+        }
+
         // Get the array type from HM inference
         let array_type = Self::get_resolved_type(ctx, inst_ref, span, "array literal")?;
 
@@ -3568,6 +3585,19 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        // A repeat literal of a `type` value (`[i32; 2]`) has no runtime
+        // representation (spec 4.14:6). Reject it with E1200 — before the
+        // preview gate below and before the comptime-only element type would
+        // reach the intern pool and panic (RUE-253).
+        if ctx.resolved_types.get(&value_ref).copied() == Some(Type::COMPTIME_TYPE) {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: "type values cannot exist at runtime".to_string(),
+                },
+                span,
+            ));
+        }
+
         // Gate the whole form: without `--preview array_repeat`, using
         // `[value; count]` is a "requires preview feature" error.
         self.require_preview(
@@ -4284,25 +4314,37 @@ impl<'a> Sema<'a> {
         //   - `fn FixedBuffer(comptime N: i32) -> type { struct { fn capacity(self) -> i32 { N } } }`
         let all_params_comptime = param_comptime.iter().all(|&c| c);
         if base_return_type == Type::COMPTIME_TYPE && (args.is_empty() || all_params_comptime) {
-            // Build value_subst from comptime VALUE parameters (e.g., comptime N: i32)
+            // Build the substitutions for the callee body from its comptime
+            // arguments: TYPE parameters (`comptime T: type`) into `type_subst`
+            // and VALUE parameters (`comptime N: i32`) into `value_subst`. Both
+            // are needed so a type constructor whose body mentions a type
+            // parameter (`struct { value: T }`) reduces here — including when
+            // this call is itself a nested argument (`WrapA(WrapA(i32))`), so
+            // the inner call analyzes to a `TypeConst` (RUE-251).
+            let mut type_subst: std::collections::HashMap<Spur, Type> =
+                std::collections::HashMap::new();
             let mut value_subst: std::collections::HashMap<Spur, ConstValue> =
                 std::collections::HashMap::new();
             for (i, is_comptime) in param_comptime.iter().enumerate() {
-                if *is_comptime && param_types[i] != Type::COMPTIME_TYPE {
-                    // This is a comptime VALUE parameter - extract its const value
-                    // (evaluated in the calling function's context so comptime
-                    // parameters in scope and resolved types are visible)
-                    if let Some(const_val) = self.try_evaluate_const_in_fn(args[i].value, ctx) {
+                if !*is_comptime {
+                    continue;
+                }
+                // Evaluated in the calling function's context so comptime
+                // parameters in scope and resolved types are visible.
+                match self.try_evaluate_const_in_fn(args[i].value, ctx) {
+                    Some(ConstValue::Type(t)) if param_types[i] == Type::COMPTIME_TYPE => {
+                        type_subst.insert(param_names[i], t);
+                    }
+                    Some(const_val) if param_types[i] != Type::COMPTIME_TYPE => {
                         value_subst.insert(param_names[i], const_val);
                     }
+                    _ => {}
                 }
             }
             // Try to evaluate the function body at compile time
-            if let Some(ConstValue::Type(ty)) = self.try_evaluate_const_with_subst(
-                fn_body,
-                &std::collections::HashMap::new(),
-                &value_subst,
-            ) {
+            if let Some(ConstValue::Type(ty)) =
+                self.try_evaluate_const_with_subst(fn_body, &type_subst, &value_subst)
+            {
                 // Success! Return a TypeConst instruction instead of a runtime call
                 let air_ref = air.add_inst(AirInst {
                     data: AirInstData::TypeConst(ty),

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -888,9 +888,87 @@ impl Sema<'_> {
                 Ok(self.resolve_named_type_value(name).map(ConstValue::Type))
             }
 
+            // Call to a `-> type` function: reduce it to the resulting type
+            // value when the callee is a type constructor and every argument
+            // is compile-time known. This makes comptime type-function calls
+            // compose in ANY position — a delegating return body
+            // (`fn Alias() -> type { Point() }`), a nested argument
+            // (`WrapA(WrapA(i32))`), and chains thereof (RUE-251).
+            InstData::Call {
+                name,
+                args_start,
+                args_len,
+            } => {
+                let (name, args_start, args_len) = (*name, *args_start, *args_len);
+                self.eval_comptime_type_call(name, args_start, args_len, env)
+            }
+
             // Everything else requires runtime evaluation
             _ => Ok(None),
         }
+    }
+
+    /// Reduce a call to a `-> type` function to its resulting type value, when
+    /// the callee is a type constructor and every argument is compile-time
+    /// known. Shared by [`eval_const_expr`]'s `Call` arm (so nested/delegating
+    /// type-function calls compose) and the analysis pass (RUE-251).
+    ///
+    /// Returns `Ok(None)` — not an error — for a callee that does not return
+    /// `type`, a non-type-constructor arity/mode, or a non-const argument: the
+    /// call is then just a runtime call and simply non-evaluable here.
+    ///
+    /// [`eval_const_expr`]: Sema::eval_const_expr
+    fn eval_comptime_type_call(
+        &mut self,
+        name: Spur,
+        args_start: u32,
+        args_len: u32,
+        env: &mut ComptimeEnv,
+    ) -> CompileResult<Option<ConstValue>> {
+        let Some(fn_info) = self.functions.get(&name) else {
+            return Ok(None);
+        };
+        // Only `-> type` functions reduce to a type value at compile time.
+        if fn_info.return_type != Type::COMPTIME_TYPE {
+            return Ok(None);
+        }
+        let fn_body = fn_info.body;
+        let params = fn_info.params;
+        let param_names = self.param_arena.names(params).to_vec();
+        let param_comptime = self.param_arena.comptime(params).to_vec();
+        let args = self.rir.get_call_args(args_start, args_len).to_vec();
+        // Same gate as `analyze_call`'s implicit-comptime path: only a no-arg
+        // or all-comptime-param type constructor is implicitly evaluated.
+        if args.len() != param_names.len()
+            || !(args.is_empty() || param_comptime.iter().all(|&c| c))
+        {
+            return Ok(None);
+        }
+        // Evaluate each argument compositionally in the current environment,
+        // so a nested type-function call (`WrapA(i32)` inside
+        // `WrapA(WrapA(i32))`) and references to enclosing comptime
+        // params/aliases both resolve. A non-const argument makes the whole
+        // call non-evaluable.
+        let mut callee_types: HashMap<Spur, Type> = HashMap::new();
+        let mut callee_values: HashMap<Spur, ConstValue> = HashMap::new();
+        for (i, arg) in args.iter().enumerate() {
+            let Some(v) = self.eval_const_expr(arg.value, env)? else {
+                return Ok(None);
+            };
+            match v {
+                ConstValue::Type(t) => {
+                    callee_types.insert(param_names[i], t);
+                }
+                value => {
+                    callee_values.insert(param_names[i], value);
+                }
+            }
+        }
+        // The callee body sees only its own parameters. Evaluate it directly
+        // (rather than via the error-swallowing `try_*` wrapper) so a
+        // diagnostic raised inside the constructor propagates.
+        let mut callee_env = ComptimeEnv::with_subst(&callee_types, &callee_values);
+        self.eval_const_expr(fn_body, &mut callee_env)
     }
 
     /// Pre-resolve `let`-bound compile-time type aliases in a function body,
@@ -1003,49 +1081,13 @@ impl Sema<'_> {
         eval_types: &HashMap<Spur, Type>,
         eval_values: &HashMap<Spur, ConstValue>,
     ) -> Option<Type> {
-        if let InstData::Call {
-            name,
-            args_start,
-            args_len,
-        } = &self.rir.get(init).data
-        {
-            let fn_info = self.functions.get(name)?;
-            if fn_info.return_type != Type::COMPTIME_TYPE {
-                return None;
-            }
-            let fn_body = fn_info.body;
-            let params = fn_info.params;
-            let param_names = self.param_arena.names(params).to_vec();
-            let param_comptime = self.param_arena.comptime(params).to_vec();
-            let args = self.rir.get_call_args(*args_start, *args_len).to_vec();
-            // Same gate as `analyze_call`: only no-arg or all-comptime-param
-            // type constructors are implicitly comptime-evaluated.
-            if args.len() != param_names.len()
-                || !(args.is_empty() || param_comptime.iter().all(|&c| c))
-            {
-                return None;
-            }
-            let mut callee_types: HashMap<Spur, Type> = HashMap::new();
-            let mut callee_values: HashMap<Spur, ConstValue> = HashMap::new();
-            for (i, arg) in args.iter().enumerate() {
-                match self.try_evaluate_const_with_subst(arg.value, eval_types, eval_values)? {
-                    ConstValue::Type(t) => {
-                        callee_types.insert(param_names[i], t);
-                    }
-                    value => {
-                        callee_values.insert(param_names[i], value);
-                    }
-                }
-            }
-            match self.try_evaluate_const_with_subst(fn_body, &callee_types, &callee_values) {
-                Some(ConstValue::Type(t)) => Some(t),
-                _ => None,
-            }
-        } else {
-            match self.try_evaluate_const_with_subst(init, eval_types, eval_values) {
-                Some(ConstValue::Type(t)) => Some(t),
-                _ => None,
-            }
+        // `eval_const_expr`'s `Call` arm reduces type-function calls
+        // compositionally (including nested/delegating ones), so a single
+        // evaluation of the initializer handles `let P = Q;`,
+        // `let P = struct { .. };`, and `let P = Pair(i32);` alike (RUE-251).
+        match self.try_evaluate_const_with_subst(init, eval_types, eval_values) {
+            Some(ConstValue::Type(t)) => Some(t),
+            _ => None,
         }
     }
 }

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -115,7 +115,11 @@ impl<'a> Sema<'a> {
             InferType::Array { element, length } => {
                 // Recursively convert element type
                 let elem_ty = self.infer_type_to_type(element);
-                if elem_ty == Type::ERROR {
+                // A `type`-valued element is comptime-only and cannot be
+                // interned (spec 4.14:6); leave the array as `<error>` so sema
+                // rejects it with E1200 rather than panicking in the intern
+                // pool (RUE-253). `<error>` elements decay the same way.
+                if elem_ty == Type::ERROR || elem_ty == Type::COMPTIME_TYPE {
                     return Type::ERROR;
                 }
                 // Get or create the array type ID
@@ -480,7 +484,10 @@ impl<'a> Sema<'a> {
                 // Convert the element type to get the concrete Type
                 // (This is safe because we processed nested arrays first)
                 let elem_ty = self.infer_type_to_concrete_type_for_key(element);
-                if elem_ty != Type::ERROR {
+                // Skip `<error>` and comptime-only `type` elements: neither can
+                // be interned. A `[type; N]` array is diagnosed as E1200 in
+                // sema instead of panicking here (RUE-253).
+                if elem_ty != Type::ERROR && elem_ty != Type::COMPTIME_TYPE {
                     // Pre-create this array type
                     self.get_or_create_array_type(elem_ty, *length);
                 }
@@ -504,7 +511,10 @@ impl<'a> Sema<'a> {
             InferType::Array { element, length } => {
                 // For nested arrays, look up or create the array type
                 let elem_ty = self.infer_type_to_concrete_type_for_key(element);
-                if elem_ty == Type::ERROR {
+                // A comptime-only `type` element (or `<error>`) cannot be
+                // interned; propagate `<error>` so the enclosing array is
+                // diagnosed as E1200 in sema rather than panicking (RUE-253).
+                if elem_ty == Type::ERROR || elem_ty == Type::COMPTIME_TYPE {
                     return Type::ERROR;
                 }
                 // Get or create the array type in the pool

--- a/crates/rue-cli-tests/cases/comptime_type_functions.toml
+++ b/crates/rue-cli-tests/cases/comptime_type_functions.toml
@@ -1,0 +1,152 @@
+# Comptime type-function composition and array-of-type diagnostics.
+#
+# Type-returning functions (`-> type`) are load-bearing for Option/Result/Vec,
+# so their calls must reduce compositionally — in a delegating return body and
+# as a nested argument — and an array literal of `type` values must produce a
+# clean diagnostic instead of an ICE. These exercise the real driver
+# end-to-end.
+
+[section]
+id = "cli.comptime_type_functions"
+name = "Comptime type-function composition"
+description = "Delegating/nested `-> type` calls reduce; array-of-type is E1200, not an ICE (RUE-251, RUE-252, RUE-253)."
+
+# --- RUE-251: delegating type-function call (body is a CALL, not a literal) ---
+
+[[case]]
+name = "delegating_type_alias"
+files = [{ path = "main.rue", source = """
+fn Point() -> type { struct { x: i32, y: i32 } }
+fn PointAlias() -> type { Point() }
+
+fn main() -> i32 {
+    let A = PointAlias();
+    let a: A = A { x: 10, y: 32 };
+    @dbg(a.x + a.y);
+    0
+}
+""" }]
+stdout = "42\n"
+
+[[case]]
+name = "two_level_delegation"
+files = [{ path = "main.rue", source = """
+fn Point() -> type { struct { x: i32, y: i32 } }
+fn PointAlias() -> type { Point() }
+fn PointAlias2() -> type { PointAlias() }
+
+fn main() -> i32 {
+    let A = PointAlias2();
+    let a: A = A { x: 40, y: 2 };
+    @dbg(a.x + a.y);
+    0
+}
+""" }]
+stdout = "42\n"
+
+# --- RUE-251: nested type-function call as an argument ---
+
+[[case]]
+name = "nested_type_function_call"
+files = [{ path = "main.rue", source = """
+fn WrapA(comptime T: type) -> type { struct { value: T } }
+
+fn main() -> i32 {
+    let Inner = WrapA(i32);
+    let W = WrapA(WrapA(i32));
+    let w: W = W { value: Inner { value: 42 } };
+    @dbg(w.value.value);
+    0
+}
+""" }]
+stdout = "42\n"
+
+[[case]]
+name = "three_level_nesting_compiles"
+files = [{ path = "main.rue", source = """
+fn WrapA(comptime T: type) -> type { struct { value: T } }
+
+fn main() -> i32 {
+    let W = WrapA(WrapA(WrapA(i32)));
+    0
+}
+""" }]
+stdout = ""
+
+[[case]]
+name = "runtime_value_to_comptime_param_rejected"
+files = [{ path = "main.rue", source = """
+fn ident(comptime N: i32) -> i32 { N }
+
+fn main() -> i32 {
+    let r: i32 = 3;
+    ident(r)
+}
+""" }]
+compile_fail = true
+error_contains = ["E1201", "compile-time known value"]
+
+# --- RUE-252: generic fn returning [i32; N] sized by a comptime VALUE param ---
+
+[[case]]
+name = "make_array_return_type"
+files = [{ path = "main.rue", source = """
+fn make_array(comptime N: i32) -> [i32; N] { [7, 7, 7] }
+
+fn main() -> i32 {
+    let a: [i32; 3] = make_array(3);
+    @dbg(a[0] + a[1] + a[2]);
+    0
+}
+""" }]
+stdout = "21\n"
+
+[[case]]
+name = "make_array_two_sizes"
+files = [{ path = "main.rue", source = """
+fn make3(comptime N: i32) -> [i32; N] { [1, 2, 3] }
+fn make4(comptime N: i32) -> [i32; N] { [10, 20, 30, 40] }
+
+fn main() -> i32 {
+    let a: [i32; 3] = make3(3);
+    let b: [i32; 4] = make4(4);
+    @dbg(a[2] + b[3]);
+    0
+}
+""" }]
+stdout = "43\n"
+
+# --- RUE-253: array literal / repeat of `type` values is E1200, not an ICE ---
+
+[[case]]
+name = "array_literal_of_types_e1200"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr = [i32, i32];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E1200", "type values cannot exist at runtime"]
+
+[[case]]
+name = "array_repeat_of_types_e1200"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr = [i32; 2];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E1200", "type values cannot exist at runtime"]
+
+[[case]]
+name = "valid_array_still_works"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr = [10, 20, 12];
+    @dbg(arr[0] + arr[1] + arr[2]);
+    0
+}
+""" }]
+stdout = "42\n"


### PR DESCRIPTION
All found by the generics/error-handling hunt; all rue-air, target-independent.

**RUE-251** — comptime type-function calls now reduce compositionally. Added a Call arm to eval_const_expr (comptime_eval.rs) + made the analyze_ops implicit-comptime gate build type_subst from comptime type args, so a delegating body (fn PointAlias() -> type { Point() }) and a nested argument (WrapA(WrapA(i32)), 3-level) both work. A runtime arg to a comptime param still correctly E1201.

**RUE-252** — a generic fn returning an array sized by a comptime VALUE param (fn make_array(comptime N: i32) -> [i32; N]) is no longer misinferred as returning type. Threaded a call-site comptime-value substitution through the inference resolvers (generate.rs) so [i32; N] resolves at the call. make_array(3) gives 21; different N gives different sizes.

**RUE-253** — an array literal of type values ([i32, i32]) no longer ICEs. typeck helpers treat a COMPTIME_TYPE array element like the error type (never interned) and analyze_array_init/repeat emit the existing E1200.

Verified by execution: PointAlias gives 42, WrapA(WrapA(i32)) works, make_array(3) gives 21, [i32, i32] gives E1200. Full test.sh green; new comptime_type_functions.toml (10 cases). Matters for real generic code (Option/Result/Vec composition).

Fixes RUE-251
Fixes RUE-252
Fixes RUE-253

Generated with Claude Code