### PR TITLE
Array layout ascending + @ptr_offset standard pointer arithmetic (RUE-243, ADR-0040)

### DIFF
--- a/crates/rue-cli-tests/cases/pointers.toml
+++ b/crates/rue-cli-tests/cases/pointers.toml
@@ -147,6 +147,84 @@ fn main() -> i32 {
 """ }]
 stdout = "10\n99\n"
 
+# @ptr_offset is standard pointer arithmetic: a plain ADD, forward toward
+# HIGHER addresses, uniform for every pointer origin (ADR-0040 / RUE-243).
+# This walks a fresh mmap region (NOT a local array): @ptr_offset(base, 1)
+# must land one element FORWARD (higher address), so writing 100/200/300 at
+# offsets 0/1/2 and reading them back returns them in order, and the address
+# delta base->base+1 is exactly sizeof(pointee) (8, one slot). Before RUE-243
+# @ptr_offset subtracted, so it walked mmap pointers BACKWARD and this read
+# garbage. mmap uses the x86-64 Linux syscall ABI, so scope to that host.
+[[case]]
+name = "ptr_offset_forward_on_mmap_pointer"
+only_on = ["x86-64-linux"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    checked {
+        let sys_mmap: u64 = 9;
+        let zero: u64 = 0;
+        let len: u64 = 4096;
+        let prot: u64 = 3;
+        let flags: u64 = 34;
+        let fdneg: u64 = 18446744073709551615;
+        let addr: i64 = @syscall(sys_mmap, zero, len, prot, flags, fdneg, zero);
+        let au: u64 = @intCast(addr);
+        let base: ptr mut i32 = @int_to_ptr(au);
+        @ptr_write(@ptr_offset(base, 0), 100);
+        @ptr_write(@ptr_offset(base, 1), 200);
+        @ptr_write(@ptr_offset(base, 2), 300);
+        let d: u64 = @ptr_to_int(@ptr_offset(base, 1)) - @ptr_to_int(base);
+        @dbg(d);
+        @dbg(@ptr_read(@ptr_offset(base, 0)));
+        @dbg(@ptr_read(@ptr_offset(base, 1)));
+        @dbg(@ptr_read(@ptr_offset(base, 2)));
+    };
+    0
+}
+""" }]
+stdout = "8\n100\n200\n300\n"
+
+# Array indexing and @ptr_offset AGREE by construction (ADR-0040 / RUE-243):
+# both compute base + i*size (ascending). Write element 2 through the index
+# path (`a[2] = 77`), then read it back through the pointer path
+# (@ptr_offset(@raw(a[0]), 2)); the two must resolve to the same address, so
+# the read observes 77. Conversely, write through the pointer path and read
+# through the index path.
+[[case]]
+name = "array_index_and_ptr_offset_agree"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut a: [i32; 4] = [0, 0, 0, 0];
+    a[2] = 77;
+    let via_ptr: i32 = checked { @ptr_read(@ptr_offset(@raw(a[0]), 2)) };
+    @dbg(via_ptr);
+    checked {
+        @ptr_write(@ptr_offset(@raw_mut(a[0]), 3), 88);
+    };
+    @dbg(a[3]);
+    0
+}
+""" }]
+stdout = "77\n88\n"
+
+# @ptr_offset moves toward HIGHER addresses for a positive index and LOWER
+# for a negative one, on an ordinary (non-array-origin) local pointer
+# (ADR-0040 / RUE-243). The forward delta is exactly sizeof(pointee) = 8.
+[[case]]
+name = "ptr_offset_forward_is_higher_address"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = 0;
+    checked {
+        let p: ptr const i32 = @raw(x);
+        let fwd: u64 = @ptr_to_int(@ptr_offset(p, 1)) - @ptr_to_int(p);
+        @dbg(fwd);
+    };
+    0
+}
+""" }]
+stdout = "8\n"
+
 # Enforcement: a pointer operation outside a `checked` block is rejected
 # with E1300, not silently accepted (spec 9.1:12).
 [[case]]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2125,7 +2125,7 @@ impl<'a> CfgLower<'a> {
                     let element_size = types::type_size_bytes(self.ctx.type_pool, pointee_type);
 
                     // Sign-/zero-extend the index to a full 64-bit value before
-                    // the 64-bit scale + subtract below. A narrow signed index
+                    // the 64-bit scale + add below. A narrow signed index
                     // (e.g. an i32 `-1`) is zero-extended into the X register by
                     // a W-write, so without an explicit sign-extend the 64-bit
                     // multiply would treat it as ~4 billion and corrupt the
@@ -2163,13 +2163,13 @@ impl<'a> CfgLower<'a> {
                         _ => {}
                     }
 
-                    // Calculate: ptr - (offset * element_size)
-                    // Aggregates (arrays) are laid out with element 0 at the
-                    // highest address and later elements at lower addresses
-                    // (the stack grows down), so array indexing subtracts
-                    // index * 8 from the base. @ptr_offset must subtract the
-                    // scaled offset too, so that advancing a pointer by N lands
-                    // on element N rather than walking off the array (RUE-213).
+                    // Calculate: ptr + (offset * element_size)
+                    // Standard pointer arithmetic, an unconditional add
+                    // (ADR-0040 / RUE-243): arrays are now laid out ascending
+                    // (element i at base + i*size), so array indexing adds and
+                    // @ptr_offset adds too — they agree, and the add is uniform
+                    // for every pointer origin (local array, heap, mmap,
+                    // @int_to_ptr). Positive n moves toward higher addresses.
                     // First, multiply offset by element size.
                     let scaled_offset_vreg = self.mir.alloc_vreg();
                     if element_size == 1 {
@@ -2199,10 +2199,10 @@ impl<'a> CfgLower<'a> {
                         });
                     }
 
-                    // Subtract from pointer (64-bit sub for addresses); see the
-                    // descending-layout note above (RUE-213).
+                    // Add to pointer (64-bit add for addresses); see the
+                    // ascending-layout note above (ADR-0040 / RUE-243).
                     let result_vreg = self.mir.alloc_vreg();
-                    self.mir.push(Aarch64Inst::SubRR {
+                    self.mir.push(Aarch64Inst::AddRR {
                         dst: Operand::Virtual(result_vreg),
                         src1: Operand::Virtual(ptr_vreg),
                         src2: Operand::Virtual(scaled_offset_vreg),
@@ -3914,6 +3914,11 @@ impl<'a> CfgLower<'a> {
                     self.emit_bounds_check(index_vreg, array_length);
 
                     let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
+                    // Ascending array layout (ADR-0040 / RUE-243): shift the
+                    // origin to the array's lowest-address element so the ADDed
+                    // scaled index below resolves element i to base + i*size.
+                    let array_len = self.ctx.array_length(*array_type);
+                    static_slot_offset += (array_len.max(1) - 1) as u32 * elem_slot_count;
                     index_levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
@@ -3937,14 +3942,16 @@ impl<'a> CfgLower<'a> {
                 let base_offset = self.ctx.local_offset(base_slot);
 
                 if let Some(dyn_offset) = dynamic_offset_vreg {
-                    // Compute address: fp + base_offset - dynamic_offset
+                    // Compute address: fp + base_offset + dynamic_offset (ascending, ADR-0040)
                     let addr_vreg = self.mir.alloc_vreg();
                     self.mir.push(Aarch64Inst::AddImm {
                         dst: Operand::Virtual(addr_vreg),
                         src: Operand::Physical(Reg::Fp),
                         imm: base_offset,
                     });
-                    self.mir.push(Aarch64Inst::SubRR {
+                    // Ascending layout: element i is at base + i*size, so ADD
+                    // the scaled index to the (lowest-address) origin (ADR-0040).
+                    self.mir.push(Aarch64Inst::AddRR {
                         dst: Operand::Virtual(addr_vreg),
                         src1: Operand::Virtual(addr_vreg),
                         src2: Operand::Virtual(dyn_offset),
@@ -3969,7 +3976,7 @@ impl<'a> CfgLower<'a> {
                     let static_byte_offset = (static_slot_offset as i32) * 8;
 
                     if let Some(dyn_offset) = dynamic_offset_vreg {
-                        // Compute address: ptr - static_offset - dynamic_offset
+                        // Compute address: ptr - static_offset + dynamic_offset (ascending, ADR-0040)
                         let addr_vreg = self.mir.alloc_vreg();
                         self.mir.push(Aarch64Inst::MovRR {
                             dst: Operand::Virtual(addr_vreg),
@@ -3982,7 +3989,7 @@ impl<'a> CfgLower<'a> {
                                 imm: static_byte_offset,
                             });
                         }
-                        self.mir.push(Aarch64Inst::SubRR {
+                        self.mir.push(Aarch64Inst::AddRR {
                             dst: Operand::Virtual(addr_vreg),
                             src1: Operand::Virtual(addr_vreg),
                             src2: Operand::Virtual(dyn_offset),
@@ -4011,7 +4018,7 @@ impl<'a> CfgLower<'a> {
                             src: Operand::Physical(Reg::Fp),
                             imm: base_offset,
                         });
-                        self.mir.push(Aarch64Inst::SubRR {
+                        self.mir.push(Aarch64Inst::AddRR {
                             dst: Operand::Virtual(addr_vreg),
                             src1: Operand::Virtual(addr_vreg),
                             src2: Operand::Virtual(dyn_offset),
@@ -4096,6 +4103,11 @@ impl<'a> CfgLower<'a> {
                     self.emit_bounds_check(index_vreg, array_length);
 
                     let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
+                    // Ascending array layout (ADR-0040 / RUE-243): shift the
+                    // origin to the array's lowest-address element so the ADDed
+                    // scaled index below resolves element i to base + i*size.
+                    let array_len = self.ctx.array_length(*array_type);
+                    static_slot_offset += (array_len.max(1) - 1) as u32 * elem_slot_count;
                     index_levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
@@ -4125,7 +4137,9 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Physical(Reg::Fp),
                         imm: base_offset,
                     });
-                    self.mir.push(Aarch64Inst::SubRR {
+                    // Ascending layout: element i is at base + i*size, so ADD
+                    // the scaled index to the (lowest-address) origin (ADR-0040).
+                    self.mir.push(Aarch64Inst::AddRR {
                         dst: Operand::Virtual(addr_vreg),
                         src1: Operand::Virtual(addr_vreg),
                         src2: Operand::Virtual(dyn_offset),
@@ -4153,7 +4167,7 @@ impl<'a> CfgLower<'a> {
                                 imm: static_byte_offset,
                             });
                         }
-                        self.mir.push(Aarch64Inst::SubRR {
+                        self.mir.push(Aarch64Inst::AddRR {
                             dst: Operand::Virtual(addr_vreg),
                             src1: Operand::Virtual(addr_vreg),
                             src2: Operand::Virtual(dyn_offset),
@@ -4178,7 +4192,7 @@ impl<'a> CfgLower<'a> {
                             src: Operand::Physical(Reg::Fp),
                             imm: base_offset,
                         });
-                        self.mir.push(Aarch64Inst::SubRR {
+                        self.mir.push(Aarch64Inst::AddRR {
                             dst: Operand::Virtual(addr_vreg),
                             src1: Operand::Virtual(addr_vreg),
                             src2: Operand::Virtual(dyn_offset),
@@ -4271,6 +4285,11 @@ impl<'a> CfgLower<'a> {
                 }
                 Projection::Index { array_type, index } => {
                     let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
+                    // Ascending array layout (ADR-0040 / RUE-243): shift the
+                    // origin to the array's lowest-address element so the ADDed
+                    // scaled index below resolves element i to base + i*size.
+                    let array_len = self.ctx.array_length(*array_type);
+                    static_slot_offset += (array_len.max(1) - 1) as u32 * elem_slot_count;
                     index_levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
@@ -4302,7 +4321,7 @@ impl<'a> CfgLower<'a> {
 
                 // Subtract dynamic offset if any
                 if let Some(dyn_offset) = dynamic_offset_vreg {
-                    self.mir.push(Aarch64Inst::SubRR {
+                    self.mir.push(Aarch64Inst::AddRR {
                         dst: Operand::Virtual(dst),
                         src1: Operand::Virtual(dst),
                         src2: Operand::Virtual(dyn_offset),
@@ -4331,7 +4350,7 @@ impl<'a> CfgLower<'a> {
 
                     // Subtract dynamic offset
                     if let Some(dyn_offset) = dynamic_offset_vreg {
-                        self.mir.push(Aarch64Inst::SubRR {
+                        self.mir.push(Aarch64Inst::AddRR {
                             dst: Operand::Virtual(dst),
                             src1: Operand::Virtual(dst),
                             src2: Operand::Virtual(dyn_offset),
@@ -4348,7 +4367,7 @@ impl<'a> CfgLower<'a> {
                     });
 
                     if let Some(dyn_offset) = dynamic_offset_vreg {
-                        self.mir.push(Aarch64Inst::SubRR {
+                        self.mir.push(Aarch64Inst::AddRR {
                             dst: Operand::Virtual(dst),
                             src1: Operand::Virtual(dst),
                             src2: Operand::Virtual(dyn_offset),

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -361,9 +361,19 @@ pub fn lower_array_init<B: SlotBackend>(
     let vreg = b.alloc_vreg();
     b.map_value(value, vreg);
 
+    // Array elements are laid out ASCENDING in memory: element 0 at the
+    // array's lowest address, element i at base + i*element_size (ADR-0040 /
+    // RUE-243). Frame slots descend in address (slot k lives at a lower
+    // address than slot k-1), so we store the elements in REVERSE order —
+    // element N-1 into the first (highest-address) slot, element 0 into the
+    // last (lowest-address) slot. Array-index address computation applies the
+    // matching `+(N-1)*elem_slot_count` origin shift and adds the scaled
+    // index, so indexing and @ptr_offset agree. Each element's own slots stay
+    // in natural order (struct fields remain descending; nested arrays are
+    // reversed by their own recursion). (ADR-0040)
     let elements = b.ctx().cfg.get_extra(elements_start, elements_len).to_vec();
     let mut element_vregs: Vec<VReg> = Vec::new();
-    for e in &elements {
+    for e in elements.iter().rev() {
         let e_ty = b.ctx().cfg.get_inst(*e).ty;
         // Payload enums are multi-slot aggregates too: a discriminant-only
         // enum (accessor returns None) stays a single-vreg scalar, but a

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -190,7 +190,12 @@ pub fn collect_array_scalar_vregs(
         } => {
             let elements = cfg.get_extra(*elements_start, *elements_len);
             let mut result = Vec::new();
-            for elem in elements {
+            // Store elements in REVERSE order so element 0 lands at the array's
+            // lowest address (frame slots descend in address): ascending array
+            // layout per ADR-0040 / RUE-243. Mirror of `lower_array_init`. Each
+            // element's own slots stay in natural order (nested arrays reverse
+            // via this same recursion; structs keep descending fields).
+            for elem in elements.iter().rev() {
                 let elem_inst = cfg.get_inst(*elem);
                 if elem_inst.ty.is_array() {
                     // Recursively collect from nested array

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2445,7 +2445,7 @@ impl<'a> CfgLower<'a> {
                     let element_size = types::type_size_bytes(self.ctx.type_pool, pointee_type);
 
                     // Sign-/zero-extend the index to a full 64-bit value before
-                    // the 64-bit scale + subtract below. A narrow signed index
+                    // the 64-bit scale + add below. A narrow signed index
                     // (e.g. an i32 `-1`) sits in the low 32 bits with high bits
                     // clear; without extension the 64-bit multiply would treat
                     // it as ~4 billion and corrupt the address (RUE-213).
@@ -2482,13 +2482,13 @@ impl<'a> CfgLower<'a> {
                         _ => {}
                     }
 
-                    // Calculate: ptr - (offset * element_size)
-                    // Aggregates (arrays) are laid out with element 0 at the
-                    // highest address and later elements at lower addresses
-                    // (the stack grows down), so array indexing subtracts
-                    // index * 8 from the base. @ptr_offset must subtract the
-                    // scaled offset too, so that advancing a pointer by N lands
-                    // on element N rather than walking off the array (RUE-213).
+                    // Calculate: ptr + (offset * element_size)
+                    // Standard pointer arithmetic, an unconditional add
+                    // (ADR-0040 / RUE-243): arrays are now laid out ascending
+                    // (element i at base + i*size), so array indexing adds and
+                    // @ptr_offset adds too — they agree, and the add is uniform
+                    // for every pointer origin (local array, heap, mmap,
+                    // @int_to_ptr). Positive n moves toward higher addresses.
                     // First, multiply offset by element size.
                     let scaled_offset_vreg = self.mir.alloc_vreg();
                     if element_size == 1 {
@@ -2520,14 +2520,14 @@ impl<'a> CfgLower<'a> {
                         });
                     }
 
-                    // Subtract from pointer (64-bit sub for addresses); see the
-                    // descending-layout note above (RUE-213).
+                    // Add to pointer (64-bit add for addresses); see the
+                    // ascending-layout note above (ADR-0040 / RUE-243).
                     let result_vreg = self.mir.alloc_vreg();
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Virtual(result_vreg),
                         src: Operand::Virtual(ptr_vreg),
                     });
-                    self.mir.push(X86Inst::SubRR64 {
+                    self.mir.push(X86Inst::AddRR64 {
                         dst: Operand::Virtual(result_vreg),
                         src: Operand::Virtual(scaled_offset_vreg),
                     });
@@ -3897,6 +3897,11 @@ impl<'a> CfgLower<'a> {
                     self.emit_bounds_check(index_vreg, array_length);
 
                     let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
+                    // Ascending array layout (ADR-0040 / RUE-243): shift the
+                    // origin to the array's lowest-address element so the ADDed
+                    // scaled index below resolves element i to base + i*size.
+                    let array_len = self.ctx.array_length(*array_type);
+                    static_slot_offset += (array_len.max(1) - 1) as u32 * elem_slot_count;
                     index_levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
@@ -3920,14 +3925,16 @@ impl<'a> CfgLower<'a> {
                 let base_offset = self.ctx.local_offset(base_slot);
 
                 if let Some(dyn_offset) = dynamic_offset_vreg {
-                    // Compute address: rbp + base_offset - dynamic_offset
+                    // Compute address: rbp + base_offset + dynamic_offset (ascending, ADR-0040)
                     let addr_vreg = self.mir.alloc_vreg();
                     self.mir.push(X86Inst::Lea {
                         dst: Operand::Virtual(addr_vreg),
                         base: Reg::Rbp,
                         disp: base_offset,
                     });
-                    self.mir.push(X86Inst::SubRR64 {
+                    // Ascending layout: element i is at base + i*size, so ADD
+                    // the scaled index to the (lowest-address) origin (ADR-0040).
+                    self.mir.push(X86Inst::AddRR64 {
                         dst: Operand::Virtual(addr_vreg),
                         src: Operand::Virtual(dyn_offset),
                     });
@@ -3952,7 +3959,7 @@ impl<'a> CfgLower<'a> {
                     let static_byte_offset = (static_slot_offset as i32) * 8;
 
                     if let Some(dyn_offset) = dynamic_offset_vreg {
-                        // Compute address: ptr - static_offset - dynamic_offset
+                        // Compute address: ptr - static_offset + dynamic_offset (ascending, ADR-0040)
                         let addr_vreg = self.mir.alloc_vreg();
                         self.mir.push(X86Inst::MovRR {
                             dst: Operand::Virtual(addr_vreg),
@@ -3969,7 +3976,7 @@ impl<'a> CfgLower<'a> {
                                 src: Operand::Virtual(offset_vreg),
                             });
                         }
-                        self.mir.push(X86Inst::SubRR64 {
+                        self.mir.push(X86Inst::AddRR64 {
                             dst: Operand::Virtual(addr_vreg),
                             src: Operand::Virtual(dyn_offset),
                         });
@@ -3998,7 +4005,7 @@ impl<'a> CfgLower<'a> {
                             base: Reg::Rbp,
                             disp: base_offset,
                         });
-                        self.mir.push(X86Inst::SubRR64 {
+                        self.mir.push(X86Inst::AddRR64 {
                             dst: Operand::Virtual(addr_vreg),
                             src: Operand::Virtual(dyn_offset),
                         });
@@ -4083,6 +4090,11 @@ impl<'a> CfgLower<'a> {
                     self.emit_bounds_check(index_vreg, array_length);
 
                     let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
+                    // Ascending array layout (ADR-0040 / RUE-243): shift the
+                    // origin to the array's lowest-address element so the ADDed
+                    // scaled index below resolves element i to base + i*size.
+                    let array_len = self.ctx.array_length(*array_type);
+                    static_slot_offset += (array_len.max(1) - 1) as u32 * elem_slot_count;
                     index_levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
@@ -4112,7 +4124,9 @@ impl<'a> CfgLower<'a> {
                         base: Reg::Rbp,
                         disp: base_offset,
                     });
-                    self.mir.push(X86Inst::SubRR64 {
+                    // Ascending layout: element i is at base + i*size, so ADD
+                    // the scaled index to the (lowest-address) origin (ADR-0040).
+                    self.mir.push(X86Inst::AddRR64 {
                         dst: Operand::Virtual(addr_vreg),
                         src: Operand::Virtual(dyn_offset),
                     });
@@ -4143,7 +4157,7 @@ impl<'a> CfgLower<'a> {
                                 src: Operand::Virtual(offset_vreg),
                             });
                         }
-                        self.mir.push(X86Inst::SubRR64 {
+                        self.mir.push(X86Inst::AddRR64 {
                             dst: Operand::Virtual(addr_vreg),
                             src: Operand::Virtual(dyn_offset),
                         });
@@ -4167,7 +4181,7 @@ impl<'a> CfgLower<'a> {
                             base: Reg::Rbp,
                             disp: base_offset,
                         });
-                        self.mir.push(X86Inst::SubRR64 {
+                        self.mir.push(X86Inst::AddRR64 {
                             dst: Operand::Virtual(addr_vreg),
                             src: Operand::Virtual(dyn_offset),
                         });
@@ -4261,6 +4275,11 @@ impl<'a> CfgLower<'a> {
                 }
                 Projection::Index { array_type, index } => {
                     let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
+                    // Ascending array layout (ADR-0040 / RUE-243): shift the
+                    // origin to the array's lowest-address element so the ADDed
+                    // scaled index below resolves element i to base + i*size.
+                    let array_len = self.ctx.array_length(*array_type);
+                    static_slot_offset += (array_len.max(1) - 1) as u32 * elem_slot_count;
                     index_levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
@@ -4290,7 +4309,7 @@ impl<'a> CfgLower<'a> {
                 });
 
                 if let Some(dyn_offset) = dynamic_offset_vreg {
-                    self.mir.push(X86Inst::SubRR64 {
+                    self.mir.push(X86Inst::AddRR64 {
                         dst: Operand::Virtual(dst),
                         src: Operand::Virtual(dyn_offset),
                     });
@@ -4319,7 +4338,7 @@ impl<'a> CfgLower<'a> {
                     }
 
                     if let Some(dyn_offset) = dynamic_offset_vreg {
-                        self.mir.push(X86Inst::SubRR64 {
+                        self.mir.push(X86Inst::AddRR64 {
                             dst: Operand::Virtual(dst),
                             src: Operand::Virtual(dyn_offset),
                         });
@@ -4335,7 +4354,7 @@ impl<'a> CfgLower<'a> {
                     });
 
                     if let Some(dyn_offset) = dynamic_offset_vreg {
-                        self.mir.push(X86Inst::SubRR64 {
+                        self.mir.push(X86Inst::AddRR64 {
                             dst: Operand::Virtual(dst),
                             src: Operand::Virtual(dyn_offset),
                         });

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -355,10 +355,19 @@ fn create_array_drop_glue_function(
     // Collect drop statements for each element
     let mut drop_statements = Vec::new();
 
-    // For each element, emit a Drop instruction.
+    // For each element, emit a Drop instruction, in ASCENDING index order
+    // (element 0 dropped first — the language-visible order the oracle checks).
+    //
+    // Array elements are laid out ascending in memory but stored REVERSED in the
+    // flattened slot list (ADR-0040 / RUE-243): frame slots descend in address,
+    // so element 0 occupies the LAST element-chunk of the received parameter
+    // slots and element N-1 the first. Iterate physical chunks back-to-front so
+    // the drops fire in ascending logical-index order. Each chunk's own slots
+    // stay in natural order (structs keep field order; nested arrays are
+    // reversed again by their own glue via this same recursion).
     // Type::Struct handles both user-defined structs and builtin String.
-    for elem_idx in 0..length {
-        let current_param_slot = elem_idx as u32 * element_slot_count;
+    for phys_chunk in (0..length).rev() {
+        let current_param_slot = phys_chunk as u32 * element_slot_count;
 
         // Emit Drop for this element
         match element_type.kind() {

--- a/crates/rue-spec/cases/runtime/pointers.toml
+++ b/crates/rue-spec/cases/runtime/pointers.toml
@@ -181,3 +181,39 @@ fn main() -> i32 {
 }
 """
 exit_code = 57  # 12345 % 256 = 57
+
+# @ptr_offset is standard pointer arithmetic: p + n*size_of(pointee), a plain
+# add, forward for positive n (ADR-0040 / RUE-243). arr[0]+1 lands on element
+# 1, and arr[0]+2 on element 2 — indexing and pointer arithmetic agree because
+# array elements are laid out ascending (spec 3.5:4).
+[[case]]
+name = "ptr_offset_add_forward"
+spec = ["9.2:7"]
+source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    checked {
+        let base: ptr const i32 = @raw(arr[0]);
+        let a: i32 = @ptr_read(@ptr_offset(base, 1));
+        let b: i32 = @ptr_read(@ptr_offset(base, 2));
+        a + b
+    }
+}
+"""
+exit_code = 50  # 20 + 30
+
+# A negative @ptr_offset moves toward lower addresses: from element 2, offset
+# -1 lands on element 1 (spec 9.2:7).
+[[case]]
+name = "ptr_offset_add_backward"
+spec = ["9.2:7"]
+source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    checked {
+        let base: ptr const i32 = @raw(arr[2]);
+        @ptr_read(@ptr_offset(base, -1))
+    }
+}
+"""
+exit_code = 20

--- a/docs/designs/0040-array-layout-ascending.md
+++ b/docs/designs/0040-array-layout-ascending.md
@@ -6,7 +6,7 @@ tags: [layout, arrays, pointers, codegen, abi]
 feature-flag:
 created: 2026-07-03
 accepted: 2026-07-03
-implemented:
+implemented: 2026-07-03
 spec-sections: ["3.6", "9"]
 superseded-by:
 ---

--- a/docs/spec/src/03-types/05-array-types.md
+++ b/docs/spec/src/03-types/05-array-types.md
@@ -20,7 +20,7 @@ All elements of an array **MUST** have the same type `T`.
 
 {{ rule(id="3.5:4", cat="normative") }}
 
-Arrays are stored contiguously in memory. The size of `[T; N]` is `N * size_of(T)`. Zero-length arrays `[T; 0]` are zero-sized types. See [Zero-Sized Types](../#zero-sized-types) for the general definition.
+Arrays are stored contiguously in memory in **ascending** order: element `i` is located at offset `i * size_of(T)` from the start of the array, so element `0` occupies the array's lowest address and element `N-1` its highest. Consequently array indexing and pointer arithmetic (`@ptr_offset`, §9.2) agree by construction — both advance by `size_of(T)` per element. The size of `[T; N]` is `N * size_of(T)`. Zero-length arrays `[T; 0]` are zero-sized types. See [Zero-Sized Types](../#zero-sized-types) for the general definition. (Struct field layout, by contrast, remains implementation-defined; see ADR-0040.)
 
 {{ rule(id="3.5:5") }}
 

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -48,3 +48,31 @@ fn main() -> i32 {
     0
 }
 ```
+
+## Pointer Arithmetic Intrinsic
+
+{{ rule(id="9.2:7", cat="dynamic-semantics") }}
+
+The `@ptr_offset(p, n)` intrinsic performs **standard pointer arithmetic**: it
+returns the pointer whose address is `address_of(p) + n * size_of(T)`, where `T`
+is the pointee type of `p`. A positive `n` moves toward **higher** addresses and
+a negative `n` toward lower addresses. This is a plain addition of the scaled
+offset and is **uniform for every pointer origin** — a pointer into a local
+array, a heap allocation, a memory-mapped region, or an address produced by
+`@int_to_ptr` all advance identically. Because array elements are laid out
+ascending (§3.5), advancing a pointer to element `i` by `1` yields a pointer to
+element `i+1`, so `@ptr_offset` and array indexing agree. Offsetting outside the
+bounds of the pointed-to allocation is undefined behavior (see ADR-0028).
+
+{{ rule(id="9.2:8", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 20, 30];
+    checked {
+        let base: ptr const i32 = @raw(arr[0]);
+        // base points at element 0; +1 advances to element 1 (value 20).
+        @ptr_read(@ptr_offset(base, 1))
+    }
+}
+```


### PR DESCRIPTION
Implements Steve's decision (ADR-0040): be like every other language.

- @ptr_offset(p, n) reverted to a plain ADD (p + n*size_of(pointee)) on both backends — fixes heap/mmap/@int_to_ptr pointers walking BACKWARD (the RUE-243 bug). Uniform for all pointer origins now.
- Local arrays laid out ASCENDING: storage reverses element order (shared code); all 6 index-address sites apply a +(N-1)*elem origin shift and ADD the dynamic index. Array indexing and @ptr_offset now AGREE by construction. Struct field layout stays as-is (per ADR-0040). Array drop glue drops in ascending index order.

Removes the RUE-213 subtract, which was patching a symptom of the descending layout. The descending-array anomaly that made @ptr_offset ambiguous is gone.

Verified by execution (both backends — x86 run + aarch64 --emit asm shows ADD): array indexing correct (10,20,30 in order); 2D arrays + arrays-of-structs correct; mmap @ptr_offset walks FORWARD; @ptr_offset into a local array agrees with indexing (230); negative offset backward; identical across -O0..-O3; drop order ascending (1,2,3); oracle-diff 0 disagreements; full test.sh green. Added 3 CLI + 2 spec cases; pinned spec 3.5:4 (ascending array layout) and 9.2:7 (@ptr_offset add).

Fixes RUE-243

Generated with Claude Code