### PR TITLE
inout/borrow-self methods borrow the receiver in all place positions, not just bare locals (RUE-254)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -3104,8 +3104,33 @@ impl<'a> Sema<'a> {
         // undo the move the receiver analysis records (see ReceiverInfo).
         let receiver_move_state_before = receiver_var.and_then(|v| ctx.moved_vars.get(&v).cloned());
 
-        // Analyze the receiver expression
-        let receiver_result = self.analyze_inst(air, receiver, ctx)?;
+        // Decide up front whether this receiver is accessed by reference
+        // (`inout self` / `borrow self`), so it is analyzed as a BORROW — not
+        // a move — in every place position (a field, an array element by
+        // const or dynamic index, a field of `self`, or through an
+        // inout/borrow parameter), mirroring the by-ref *argument* path
+        // (RUE-254, spec 6.4:25/6.4:29). Method resolution needs the receiver
+        // type, which is peeked WITHOUT emitting AIR or recording a move: a
+        // move-based analysis would hard-reject the read of any non-local
+        // place (E0437/E0429/E0904) before the by-ref intent is known. Only
+        // user-struct methods are considered here; builtin (String) and
+        // module receivers keep their existing post-analysis handling.
+        let receiver_byref_root = receiver_var
+            .filter(|_| !is_builtin_mutation_method)
+            .and_then(|root| {
+                let ty = self.peek_place_type(receiver, ctx)?;
+                let struct_id = ty.as_struct()?;
+                let info = self.methods.get(&(struct_id, method))?;
+                matches!(info.self_mode, RirParamMode::Inout | RirParamMode::Borrow).then_some(root)
+            });
+
+        // Analyze the receiver expression. When it is a by-ref receiver,
+        // `byref_arg_root` makes the var-ref / field / index reads borrow the
+        // place instead of moving out of it (restored afterwards).
+        let prev_byref_root = std::mem::replace(&mut ctx.byref_arg_root, receiver_byref_root);
+        let receiver_result = self.analyze_inst(air, receiver, ctx);
+        ctx.byref_arg_root = prev_byref_root;
+        let receiver_result = receiver_result?;
         let receiver_type = receiver_result.ty;
 
         // Handle module member access: module.function() becomes a direct function call
@@ -3247,11 +3272,13 @@ impl<'a> Sema<'a> {
             excl_args.extend(args.iter().cloned());
             self.check_exclusive_access(&excl_args, span)?;
 
-            // By-ref receivers are borrows, not moves: undo the move the
-            // receiver analysis recorded (restoring the pre-receiver snapshot,
-            // so sibling moves stay recorded) and cancel its move marker, so
-            // drop elaboration does not treat this borrow as a move. Mirrors
-            // the builtin ByRef/ByMutRef receiver handling.
+            // By-ref receivers are borrows, not moves. The receiver was
+            // already analyzed under `byref_arg_root` above (RUE-254), so no
+            // move was recorded and no marker emitted; this restore of the
+            // pre-receiver snapshot and marker cancellation are defensive
+            // no-ops for a well-formed place receiver (and still cover the
+            // now-vestigial path where the receiver root differs from the
+            // byref root). Mirrors the builtin ByRef/ByMutRef handling.
             match receiver_move_state_before.clone() {
                 Some(state) => {
                     ctx.moved_vars.insert(receiver_root, state);
@@ -5156,6 +5183,47 @@ impl<'a> Sema<'a> {
             }
         }
         None
+    }
+
+    /// Resolve the TYPE of a place expression without emitting any AIR or
+    /// recording a move (RUE-254).
+    ///
+    /// Used to learn a method receiver's type — and thus, via method
+    /// resolution, whether the method takes `self` by reference (`inout
+    /// self` / `borrow self`) — *before* the receiver expression is analyzed.
+    /// A by-ref receiver must be analyzed as a borrow rather than a move
+    /// (spec 6.4:25, 6.4:29), and that decision needs the type; a move-based
+    /// analysis would hard-reject the read of any non-local place (an inout
+    /// parameter, an indexed element, a field of `self`, ...) before the
+    /// by-ref intent could be recovered. The index expression of an
+    /// `IndexGet` is intentionally NOT visited — the element type does not
+    /// depend on the index value, and visiting it here would double-analyze
+    /// its side effects. Returns `None` for anything that is not a statically
+    /// typed place chain rooted at a variable (call results, literals, ...).
+    fn peek_place_type(&self, inst_ref: InstRef, ctx: &AnalysisContext) -> Option<Type> {
+        match &self.rir.get(inst_ref).data {
+            InstData::VarRef { name } | InstData::ParamRef { name, .. } => {
+                if let Some(local) = ctx.locals.get(name) {
+                    return Some(local.ty);
+                }
+                ctx.params.iter().find(|p| p.name == *name).map(|p| p.ty)
+            }
+            InstData::FieldGet { base, field } => {
+                let base_ty = self.peek_place_type(*base, ctx)?;
+                let struct_id = base_ty.as_struct()?;
+                let struct_def = self.type_pool.struct_def(struct_id);
+                let field_name_str = self.interner.resolve(field);
+                let (_field_index, struct_field) = struct_def.find_field(field_name_str)?;
+                Some(struct_field.ty)
+            }
+            InstData::IndexGet { base, .. } => {
+                let base_ty = self.peek_place_type(*base, ctx)?;
+                let array_id = base_ty.as_array()?;
+                let (elem_type, _len) = self.type_pool.array_def(array_id);
+                Some(elem_type)
+            }
+            _ => None,
+        }
     }
 
     fn get_string_receiver_storage(

--- a/crates/rue-cli-tests/cases/method_receiver_byref_places.toml
+++ b/crates/rue-cli-tests/cases/method_receiver_byref_places.toml
@@ -1,0 +1,153 @@
+# `inout self` / `borrow self` method calls must work in EVERY receiver
+# position, not just a bare local binding (RUE-254).
+#
+# An `inout self` receiver accesses the receiver by exclusive mutable ref and a
+# `borrow self` receiver by immutable ref (spec 6.4:25); such a call does NOT
+# consume the receiver (spec 6.4:29). Sema used to analyze the receiver
+# expression as a by-VALUE move, which hard-rejected the read of any non-local
+# place: an inout/borrow parameter (E0437/E0429), an indexed element
+# (E0904, const or dynamic index), a struct-field array element (E0904), or a
+# field of `self` (E0437) — a whole reject-valid class that blocked real
+# method code. The fix routes a by-ref receiver through the same by-ref-access
+# logic the inout/borrow ARGUMENT path uses (peek the receiver type, then
+# analyze the receiver as a borrow rather than a move).
+#
+# Each facet asserts the mutation actually happened (exit code reflects the
+# post-call field value), not merely that it compiled. The final two cases are
+# no-regression controls: a by-value (`sink`) `self` method STILL moves.
+
+[section]
+id = "cli.method_receiver_byref_places"
+name = "by-ref method receivers in all place positions"
+description = "inout/borrow self methods work through params, array elements (const+dynamic index), struct-field arrays, and fields of self; by-value self still moves (RUE-254)."
+
+# Facet 1: by-ref parameter receiver (inout).
+[[case]]
+name = "inout_self_through_inout_param"
+description = "c.bump() (inout self) where c is an inout parameter mutates in place; two bumps -> 2."
+args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Counter { n: i32, fn bump(inout self) { self.n = self.n + 1; } }
+fn bump_twice(inout c: Counter) { c.bump(); c.bump(); }
+fn main() -> i32 {
+    let mut c = Counter { n: 0 };
+    bump_twice(inout c);
+    c.n
+}
+""" }]
+exit_code = 2
+
+# Facet 1: by-ref parameter receiver (borrow).
+[[case]]
+name = "borrow_self_through_borrow_param"
+description = "c.get() (borrow self) where c is a borrow parameter reads without moving; returns 7."
+args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Counter { n: i32, fn get(borrow self) -> i32 { self.n } }
+fn read(borrow c: Counter) -> i32 { c.get() }
+fn main() -> i32 {
+    let c = Counter { n: 7 };
+    read(borrow c)
+}
+""" }]
+exit_code = 7
+
+# Facet 2: dynamically-indexed array element.
+[[case]]
+name = "inout_self_on_dynamic_index_element"
+description = "arr[i].bump() with a runtime index mutates element i in place; arr[0] -> 1."
+args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Counter { n: i32, fn bump(inout self) { self.n = self.n + 1; } }
+fn main() -> i32 {
+    let mut arr = [Counter { n: 0 }, Counter { n: 10 }];
+    let i = 0;
+    arr[i].bump();
+    arr[0].n
+}
+""" }]
+exit_code = 1
+
+# Facet 2 (variant): constant-index array element.
+[[case]]
+name = "inout_self_on_const_index_element"
+description = "arr[1].bump() (const index) mutates that element; the sibling element is untouched."
+args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Counter { n: i32, fn bump(inout self) { self.n = self.n + 1; } }
+fn main() -> i32 {
+    let mut arr = [Counter { n: 0 }, Counter { n: 10 }];
+    arr[1].bump();
+    arr[1].n
+}
+""" }]
+exit_code = 11
+
+# Facet 3: struct-field array element (Field + Index projections).
+[[case]]
+name = "inout_self_on_struct_field_array_element"
+description = "w.items[0].bump() through a nested field+index place mutates the element; w.items[0].n -> 1."
+args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Counter { n: i32, fn bump(inout self) { self.n = self.n + 1; } }
+struct Wrapper { items: [Counter; 2] }
+fn main() -> i32 {
+    let mut w = Wrapper { items: [Counter { n: 0 }, Counter { n: 5 }] };
+    w.items[0].bump();
+    w.items[0].n
+}
+""" }]
+exit_code = 1
+
+# Facet 4: field of self / of an inout param.
+[[case]]
+name = "inout_self_on_field_of_self"
+description = "self.inner.bump() inside a method (field-of-inout-param receiver) mutates; o.inner.v -> 1."
+args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32, fn bump(inout self) { self.v = self.v + 1; } }
+struct Outer { inner: Inner, fn go(inout self) { self.inner.bump(); } }
+fn main() -> i32 {
+    let mut o = Outer { inner: Inner { v: 0 } };
+    o.go();
+    o.inner.v
+}
+""" }]
+exit_code = 1
+
+# Control: a by-value (`sink`) self method STILL moves its receiver, so a
+# double call is a use-after-move — the fix must not over-permissively treat
+# by-value receivers as borrows.
+[[case]]
+name = "by_value_self_still_moves_double_call"
+description = "Control: bare `self` (by-value) consumes the receiver; calling it twice is E0205."
+args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Counter { n: i32, fn consume(self) -> i32 { self.n } }
+fn main() -> i32 {
+    let c = Counter { n: 3 };
+    let a = c.consume();
+    let b = c.consume();
+    a + b
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "use of moved value 'c'"]
+
+# Control: `borrow self` on a value already moved out still errors — the
+# borrow-undo must not resurrect a genuinely moved receiver.
+[[case]]
+name = "borrow_self_on_moved_value_still_errors"
+description = "Control: calling a borrow-self method after the value was moved into a by-value call is E0205."
+args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Counter { n: i32, fn get(borrow self) -> i32 { self.n } }
+fn sink(c: Counter) -> i32 { c.n }
+fn main() -> i32 {
+    let c = Counter { n: 5 };
+    let x = sink(c);
+    x + c.get()
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "use of moved value 'c'"]


### PR DESCRIPTION
Found by the method-receivers hunt. A whole reject-valid class: an inout self / borrow self method call was analyzed as a by-VALUE move of the receiver, so any receiver that wasn't a bare local was hard-rejected (E0437/E0429/E0904) before the by-ref intent was known — blocking most real method code (mutating methods on params, array elements, struct fields).

Fix (rue-air/src/sema/analysis.rs): added a move-neutral peek_place_type to resolve the receiver place's type without emitting AIR or recording a move, then — when the method takes self by reference — set ctx.byref_arg_root while analyzing the receiver, mirroring the already-correct by-ref ARGUMENT path. The receiver now borrows in all place positions (params, array elements const/dynamic index, struct-field arrays, fields of self), per spec 6.4:25 (autoref) and 6.4:29 (does not consume).

Verified by execution: inout param gives 2, borrow param gives 7, arr[i].bump() mutates in place, w.items[0].bump() gives 1, self.inner.bump() gives 1. No-regression: by-value self double-call still E0205, borrow-self on moved value still E0205, inout on immutable still E0203, side-effecting index not double-evaluated. Sema-only (aarch64 asm clean). 8 new CLI cases; full test.sh green.

Fixes RUE-254

Generated with Claude Code