### PR TITLE
Differential fuzzer: generate valid programs, cross-check oracle vs compiled (RUE-247)

### DIFF
--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -47,6 +47,16 @@ jobs:
       - name: Fuzz x86-64 emitter sequences (5 minutes)
         run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 emitter_sequence crates/rue-fuzz/corpus
 
+      # Differential fuzzing: generate valid programs and cross-check the
+      # rue-oracle reference interpreter against the compiled native binary
+      # (RUE-247). Any exit-code / stdout disagreement is an automatically-found
+      # miscompile; the step exits non-zero and a self-contained repro (named by
+      # its seed) lands in crates/rue-fuzz/crashes/ for the upload step below.
+      - name: Differential fuzz (oracle vs compiled, 500 seeds)
+        run: |
+          RUE_BINARY="$(scripts/rue-bin)" ./buck2 run //crates/rue-oracle-diff:rue-oracle-diff -- \
+            fuzz --seeds 500 --crash-dir crates/rue-fuzz/crashes
+
       - name: Upload crash artifacts
         if: failure()
         uses: actions/upload-artifact@v6

--- a/crates/rue-fuzz/README.md
+++ b/crates/rue-fuzz/README.md
@@ -91,9 +91,26 @@ input back to the target named in the filename:
 ./buck2 run //crates/rue-fuzz:rue-fuzz -- parser <dir-with-the-file>
 ```
 
+## Differential fuzzing (oracle vs compiled) — RUE-247
+
+A separate, complementary fuzzer lives in `crates/rue-oracle-diff`: it generates
+random **valid, well-typed** programs (in the subset the `rue-oracle` reference
+interpreter models) and runs each through *both* the oracle and the real
+compiler + native binary, comparing exit code and `@dbg` stdout. A disagreement
+is an automatically-discovered **miscompile** with a deterministic, seed-based
+repro (not a crash — a *wrong answer*). Its repros land in this crate's
+`crashes/` directory as `oracle-diff-seed-<seed>.rue` and are uploaded by the
+same CI artifact step.
+
+```bash
+RUE_BINARY="$(scripts/rue-bin)" ./buck2 run //crates/rue-oracle-diff:rue-oracle-diff -- \
+    fuzz --seeds 500                 # cross-check 500 generated programs
+./buck2 run //crates/rue-oracle-diff:rue-oracle-diff -- dump 42   # inspect seed 42's program
+```
+
 ## Integration with CI
 
-Fuzzing runs automatically in CI via `.github/workflows/fuzz.yml`. Each target runs for 5 minutes daily.
+Fuzzing runs automatically in CI via `.github/workflows/fuzz.yml`. Each target runs for 5 minutes daily; the differential fuzzer (above) runs a bounded 500-seed batch in the same workflow.
 
 To run fuzzing locally for a limited time:
 

--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -1,13 +1,19 @@
 load("//crates:defs.bzl", "rue_binary")
 
-# The differential harness: runs the concrete rue-cli-tests corpus through the
-# rue-oracle reference interpreter and checks it agrees with each case's
-# expected exit code / stdout. A disagreement is a bug in the oracle or the
-# compiler (the compiler already matches these expectations, so a mismatch
-# localizes to codegen). No #[test] functions — it IS the harness.
+# The differential harness. Two modes:
+#  * default: runs the concrete rue-cli-tests corpus through the rue-oracle
+#    reference interpreter and checks it agrees with each case's expected exit
+#    code / stdout (a mismatch localizes to codegen; wired as the sh_test below).
+#  * `fuzz`: the differential *fuzzer* (RUE-247) — generates random valid
+#    programs and cross-checks the oracle against the real compiler + native
+#    binary, reporting any exit/stdout disagreement as a miscompile with a
+#    seed-based repro. Driven by `.github/workflows/fuzz.yml` nightly; needs the
+#    `rue` binary via RUE_BINARY (or the bin/rue symlink).
+# The harness driver itself has no #[test] functions — it IS the harness — but
+# the `generator` module carries unit tests (determinism + always-emits-main),
+# so the rust_test target (`:rue-oracle-diff-test`) is kept enabled.
 rue_binary(
     name = "rue-oracle-diff",
-    tests = False,
     deps = [
         "//crates/rue-oracle:rue-oracle",
         "//third-party:serde",

--- a/crates/rue-oracle-diff/src/fuzz.rs
+++ b/crates/rue-oracle-diff/src/fuzz.rs
@@ -1,0 +1,460 @@
+//! # Differential fuzzer (`rue-oracle-diff fuzz`) — RUE-247
+//!
+//! Generate random **valid** Rue programs (see [`crate::gen`]) and run each one
+//! through *both* engines:
+//!
+//! 1. the [`rue_oracle`] reference interpreter (`run_source`), and
+//! 2. the real compiler + the produced native binary.
+//!
+//! Then compare the observable behavior — process exit code and `@dbg` stdout.
+//! A disagreement is an **automatically-discovered miscompile** with a concrete,
+//! deterministic repro: the seed regenerates the exact program. This is the
+//! RUE-50 payoff wired to RUE-205's harness — "Fable runs a hunt and files bugs"
+//! becomes "CI files the bugs."
+//!
+//! Determinism: programs are a pure function of their `u64` seed, so the fuzzer
+//! is fully reproducible (`fuzz --start S --seeds 1` re-runs exactly seed `S`).
+//!
+//! The compiler binary is located via `RUE_BINARY` (what `scripts/rue` /
+//! `test.sh` set) or the `bin/rue` symlink, mirroring `rue-test-runner`.
+
+use crate::generator;
+use rue_oracle::run_source;
+use std::io::Read;
+use std::os::unix::process::ExitStatusExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, ExitCode, Stdio};
+use std::time::{Duration, Instant};
+
+/// Outcome of compiling and running a generated program natively.
+enum Compiled {
+    /// The compiler rejected a program the oracle's frontend accepted — an ICE
+    /// or backend gap (carries the compiler's stderr, truncated).
+    CompileFail(String),
+    /// The binary ran to completion: process exit code + captured stdout.
+    Ran { exit: i32, stdout: String },
+    /// The binary was killed by a signal (e.g. SIGSEGV) — a hard miscompile.
+    Crash(i32),
+    /// The binary did not terminate within the per-program timeout.
+    Timeout,
+}
+
+struct Config {
+    start: u64,
+    seeds: u64,
+    timeout: Duration,
+    crash_dir: PathBuf,
+    verbose: bool,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Config {
+            start: 0,
+            seeds: 200,
+            timeout: Duration::from_secs(10),
+            crash_dir: PathBuf::from("crates/rue-fuzz/crashes"),
+            verbose: false,
+        }
+    }
+}
+
+fn parse_args(args: &[String]) -> Result<Config, String> {
+    let mut cfg = Config::default();
+    let mut it = args.iter();
+    while let Some(a) = it.next() {
+        // Support both `--flag value` and `--flag=value`.
+        let (key, inline) = match a.split_once('=') {
+            Some((k, v)) => (k, Some(v.to_string())),
+            None => (a.as_str(), None),
+        };
+        let mut value = || -> Result<String, String> {
+            if let Some(v) = inline.clone() {
+                Ok(v)
+            } else {
+                it.next()
+                    .cloned()
+                    .ok_or_else(|| format!("missing value for {key}"))
+            }
+        };
+        match key {
+            "--start" => cfg.start = value()?.parse().map_err(|_| "bad --start")?,
+            "--seeds" => cfg.seeds = value()?.parse().map_err(|_| "bad --seeds")?,
+            "--timeout" => {
+                cfg.timeout = Duration::from_secs(value()?.parse().map_err(|_| "bad --timeout")?)
+            }
+            "--crash-dir" => cfg.crash_dir = PathBuf::from(value()?),
+            "--verbose" | "-v" => cfg.verbose = true,
+            other => return Err(format!("unknown argument: {other}")),
+        }
+    }
+    Ok(cfg)
+}
+
+/// Locate the `rue` compiler binary the same way the rest of the test harness
+/// does: `RUE_BINARY` override, else the `bin/rue` symlink.
+fn find_rue_binary() -> Result<PathBuf, String> {
+    if let Ok(p) = std::env::var("RUE_BINARY") {
+        return Ok(PathBuf::from(p));
+    }
+    let sym = Path::new("bin/rue");
+    if sym.exists() {
+        // Canonicalize to an absolute path: each generated program is compiled
+        // with `current_dir` set to the temp workdir, so a relative `bin/rue`
+        // would no longer resolve. (The harness normally runs with an absolute
+        // RUE_BINARY; this keeps the bare `bin/rue` fallback working too.)
+        return Ok(sym.canonicalize().unwrap_or_else(|_| sym.to_path_buf()));
+    }
+    Err(
+        "cannot locate the rue compiler: set RUE_BINARY to an explicit path, \
+         or run `scripts/rue build` to refresh the bin/rue symlink"
+            .to_string(),
+    )
+}
+
+pub fn run(args: &[String]) -> ExitCode {
+    let cfg = match parse_args(args) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("rue-oracle-diff fuzz: {e}");
+            eprintln!(
+                "usage: rue-oracle-diff fuzz [--start N] [--seeds N] [--timeout SECS] \
+                 [--crash-dir DIR] [--verbose]"
+            );
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let rue = match find_rue_binary() {
+        Ok(p) => p,
+        Err(e) => {
+            eprintln!("rue-oracle-diff fuzz: {e}");
+            return ExitCode::FAILURE;
+        }
+    };
+
+    let workdir = std::env::temp_dir().join(format!("rue-oracle-fuzz-{}", std::process::id()));
+    if let Err(e) = std::fs::create_dir_all(&workdir) {
+        eprintln!("cannot create work dir {}: {e}", workdir.display());
+        return ExitCode::FAILURE;
+    }
+
+    println!(
+        "=== rue-oracle-diff fuzz: seeds {}..{} (compiler: {}) ===",
+        cfg.start,
+        cfg.start + cfg.seeds,
+        rue.display()
+    );
+
+    let mut agree = 0u32;
+    let mut skip_unsupported = 0u32;
+    let mut disagreements: Vec<Disagreement> = Vec::new();
+
+    for seed in cfg.start..cfg.start + cfg.seeds {
+        let source = generator::generate(seed);
+
+        let oracle = match run_source(&source) {
+            // Outside the modeled subset (or a front-end compile error): a clean
+            // skip, exactly as intended — never a false disagreement.
+            Err(unsupported) => {
+                skip_unsupported += 1;
+                if cfg.verbose {
+                    println!("  seed {seed}: skip ({})", unsupported.0);
+                }
+                continue;
+            }
+            Ok(o) => o,
+        };
+
+        let compiled = match compile_and_run(&rue, &workdir, &source, cfg.timeout) {
+            Ok(c) => c,
+            Err(e) => {
+                // An infrastructure failure (couldn't invoke the tools) is fatal
+                // — better to stop loudly than silently pass.
+                eprintln!("seed {seed}: harness error: {e}");
+                return ExitCode::FAILURE;
+            }
+        };
+
+        match classify(&oracle, &compiled) {
+            Verdict::Agree => {
+                agree += 1;
+                if cfg.verbose {
+                    println!("  seed {seed}: agree (exit {})", oracle.exit_code);
+                }
+            }
+            Verdict::Disagree(reason) => {
+                let d = Disagreement {
+                    seed,
+                    source: source.clone(),
+                    oracle_exit: oracle.exit_code,
+                    oracle_stdout: oracle.stdout.clone(),
+                    oracle_panic: oracle.panic.clone(),
+                    compiled: describe(&compiled),
+                    reason,
+                };
+                eprintln!("{}", d.render());
+                let _ = save_repro(&cfg.crash_dir, &d);
+                disagreements.push(d);
+            }
+        }
+    }
+
+    let total = agree + skip_unsupported + disagreements.len() as u32;
+    println!("\n=== summary over {total} generated programs ===");
+    println!("  agree:            {agree}");
+    println!("  skip (unmodeled): {skip_unsupported}");
+    println!("  DISAGREEMENTS:    {}", disagreements.len());
+
+    if disagreements.is_empty() {
+        println!("\noracle and compiler agree on every generated program.");
+        ExitCode::SUCCESS
+    } else {
+        println!(
+            "\n{} disagreement(s) — each is an automatically-found miscompile. \
+             Repros saved to {}.",
+            disagreements.len(),
+            cfg.crash_dir.display()
+        );
+        ExitCode::FAILURE
+    }
+}
+
+/// The comparison verdict.
+enum Verdict {
+    Agree,
+    Disagree(String),
+}
+
+fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Verdict {
+    match compiled {
+        Compiled::Ran { exit, stdout } => {
+            let exit_ok = oracle.exit_code == *exit;
+            let stdout_ok = &oracle.stdout == stdout;
+            if exit_ok && stdout_ok {
+                Verdict::Agree
+            } else {
+                let mut r = String::new();
+                if !exit_ok {
+                    r += &format!("exit: oracle {} vs compiled {exit}; ", oracle.exit_code);
+                }
+                if !stdout_ok {
+                    r += &format!(
+                        "stdout: oracle {:?} vs compiled {:?}",
+                        oracle.stdout, stdout
+                    );
+                }
+                Verdict::Disagree(r)
+            }
+        }
+        Compiled::CompileFail(stderr) => Verdict::Disagree(format!(
+            "compiler rejected a program the oracle accepted (possible ICE/backend gap): {}",
+            first_line(stderr)
+        )),
+        Compiled::Crash(sig) => Verdict::Disagree(format!(
+            "compiled binary killed by signal {sig} (oracle ran cleanly)"
+        )),
+        Compiled::Timeout => {
+            Verdict::Disagree("compiled binary did not terminate (oracle ran cleanly)".to_string())
+        }
+    }
+}
+
+fn compile_and_run(
+    rue: &Path,
+    dir: &Path,
+    source: &str,
+    timeout: Duration,
+) -> std::io::Result<Compiled> {
+    let src_path = dir.join("prog.rue");
+    std::fs::write(&src_path, source)?;
+    let bin_path = dir.join("prog");
+    // Best-effort remove of a stale binary so a compile failure can't run last
+    // iteration's executable.
+    let _ = std::fs::remove_file(&bin_path);
+
+    let compile = Command::new(rue)
+        .arg("prog.rue")
+        .arg("-o")
+        .arg("prog")
+        .current_dir(dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .output()?;
+    if !compile.status.success() {
+        let stderr = String::from_utf8_lossy(&compile.stderr).into_owned();
+        return Ok(Compiled::CompileFail(stderr));
+    }
+
+    // Run the produced binary directly with a manual timeout so we can read the
+    // child's own exit code / terminating signal unambiguously.
+    let mut child = Command::new(&bin_path)
+        .current_dir(dir)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()?;
+
+    let start = Instant::now();
+    loop {
+        match child.try_wait()? {
+            Some(status) => {
+                let mut stdout = String::new();
+                if let Some(mut out) = child.stdout.take() {
+                    out.read_to_string(&mut stdout).ok();
+                }
+                return Ok(match status.code() {
+                    Some(code) => Compiled::Ran { exit: code, stdout },
+                    None => Compiled::Crash(status.signal().unwrap_or(0)),
+                });
+            }
+            None => {
+                if start.elapsed() > timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Ok(Compiled::Timeout);
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+    }
+}
+
+struct Disagreement {
+    seed: u64,
+    source: String,
+    oracle_exit: i32,
+    oracle_stdout: String,
+    oracle_panic: Option<String>,
+    compiled: String,
+    reason: String,
+}
+
+impl Disagreement {
+    fn render(&self) -> String {
+        format!(
+            "\n\u{2717} DISAGREEMENT (seed {seed})\n  {reason}\n  oracle:   exit={exit} panic={panic:?} stdout={stdout:?}\n  compiled: {compiled}\n  --- source (regenerate with `fuzz --start {seed} --seeds 1`) ---\n{source}",
+            seed = self.seed,
+            reason = self.reason,
+            exit = self.oracle_exit,
+            panic = self.oracle_panic,
+            stdout = self.oracle_stdout,
+            compiled = self.compiled,
+            source = self.source,
+        )
+    }
+}
+
+fn describe(c: &Compiled) -> String {
+    match c {
+        Compiled::Ran { exit, stdout } => format!("ran exit={exit} stdout={stdout:?}"),
+        Compiled::CompileFail(e) => format!("compile-fail: {}", first_line(e)),
+        Compiled::Crash(sig) => format!("crash signal={sig}"),
+        Compiled::Timeout => "timeout".to_string(),
+    }
+}
+
+fn first_line(s: &str) -> String {
+    s.lines()
+        .find(|l| !l.trim().is_empty())
+        .unwrap_or("")
+        .chars()
+        .take(200)
+        .collect()
+}
+
+/// Persist a repro so a CI failure uploads a concrete, self-contained program.
+fn save_repro(dir: &Path, d: &Disagreement) -> std::io::Result<()> {
+    std::fs::create_dir_all(dir)?;
+    let path = dir.join(format!("oracle-diff-seed-{}.rue", d.seed));
+    let contents = format!(
+        "// rue-oracle-diff differential miscompile (seed {seed})\n\
+         // reason: {reason}\n\
+         // oracle:   exit={exit} panic={panic:?} stdout={stdout:?}\n\
+         // compiled: {compiled}\n\
+         // regenerate: rue-oracle-diff fuzz --start {seed} --seeds 1\n\n{source}",
+        seed = d.seed,
+        reason = d.reason,
+        exit = d.oracle_exit,
+        panic = d.oracle_panic,
+        stdout = d.oracle_stdout,
+        compiled = d.compiled,
+        source = d.source,
+    );
+    std::fs::write(path, contents)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rue_oracle::Outcome;
+
+    fn oc(exit: i32, stdout: &str) -> Outcome {
+        Outcome {
+            exit_code: exit,
+            stdout: stdout.to_string(),
+            panic: None,
+        }
+    }
+
+    fn is_disagree(v: Verdict) -> bool {
+        matches!(v, Verdict::Disagree(_))
+    }
+
+    #[test]
+    fn agrees_when_exit_and_stdout_match() {
+        let v = classify(
+            &oc(42, "7\n"),
+            &Compiled::Ran {
+                exit: 42,
+                stdout: "7\n".to_string(),
+            },
+        );
+        assert!(matches!(v, Verdict::Agree));
+    }
+
+    #[test]
+    fn detects_exit_mismatch() {
+        // The planted-bug shape: same stdout, wrong exit code.
+        let v = classify(
+            &oc(42, ""),
+            &Compiled::Ran {
+                exit: 43,
+                stdout: String::new(),
+            },
+        );
+        assert!(is_disagree(v));
+    }
+
+    #[test]
+    fn detects_stdout_mismatch() {
+        let v = classify(
+            &oc(0, "7\n"),
+            &Compiled::Ran {
+                exit: 0,
+                stdout: "8\n".to_string(),
+            },
+        );
+        assert!(is_disagree(v));
+    }
+
+    #[test]
+    fn compile_fail_and_crash_and_timeout_are_disagreements() {
+        // Oracle produced a clean outcome, so any non-Ran compiled result is a
+        // divergence worth reporting.
+        assert!(is_disagree(classify(
+            &oc(0, ""),
+            &Compiled::CompileFail("boom".into())
+        )));
+        assert!(is_disagree(classify(&oc(0, ""), &Compiled::Crash(11))));
+        assert!(is_disagree(classify(&oc(0, ""), &Compiled::Timeout)));
+    }
+
+    #[test]
+    fn args_parse_flags() {
+        let cfg = parse_args(&["--start=5".into(), "--seeds".into(), "12".into()]).expect("parse");
+        assert_eq!(cfg.start, 5);
+        assert_eq!(cfg.seeds, 12);
+    }
+}

--- a/crates/rue-oracle-diff/src/generator.rs
+++ b/crates/rue-oracle-diff/src/generator.rs
@@ -1,0 +1,742 @@
+//! Seed-driven generator of **valid, well-typed** Rue programs in the subset the
+//! [`rue_oracle`] reference interpreter models (RUE-247).
+//!
+//! Everything here is deterministic from a `u64` seed — no clock, no `rand` — so
+//! a disagreement found by the differential fuzzer (`--fuzz` mode of
+//! `rue-oracle-diff`) reproduces exactly from its seed. Programs are constructed
+//! to be well-typed *by construction*: every expression is generated to an exact
+//! required type, every literal is emitted inside a typed context (a `let`
+//! annotation, a struct-field position, or a same-typed sibling), and aggregate
+//! values are never used after a by-value move. A generated program therefore
+//! compiles cleanly (a compile failure is itself a finding, not noise) and stays
+//! inside the oracle's coverage, so `Unsupported` is a clean skip.
+//!
+//! The generator biases toward the historically-fragile shapes that every
+//! 2026-07 miscompile lived in: aggregates crossing the call ABI (struct
+//! by-value parameter + return), nested struct projections, mixed-width struct
+//! fields (multi-slot layout), arithmetic with trapping overflow, `@intCast`
+//! range checks, match/enum, and recursion.
+
+/// A `splitmix64` PRNG — tiny, fast, and fully determined by its seed.
+pub struct Rng {
+    state: u64,
+}
+
+impl Rng {
+    pub fn new(seed: u64) -> Self {
+        Rng { state: seed }
+    }
+
+    fn next_u64(&mut self) -> u64 {
+        self.state = self.state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = self.state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^ (z >> 31)
+    }
+
+    /// Uniform in `[0, n)` (returns 0 when `n == 0`).
+    fn below(&mut self, n: u64) -> u64 {
+        if n == 0 { 0 } else { self.next_u64() % n }
+    }
+
+    fn chance(&mut self, num: u64, den: u64) -> bool {
+        self.below(den) < num
+    }
+
+    fn pick<'a, T>(&mut self, xs: &'a [T]) -> &'a T {
+        let i = self.below(xs.len() as u64) as usize;
+        &xs[i]
+    }
+}
+
+/// The scalar types the generator uses. Aggregates (structs/arrays/enums/String)
+/// are handled by dedicated snippet emitters, not by the scalar-expression core.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum Ty {
+    I8,
+    I16,
+    I32,
+    I64,
+    U8,
+    U16,
+    U32,
+    U64,
+    Bool,
+}
+
+const INT_TYPES: [Ty; 8] = [
+    Ty::I8,
+    Ty::I16,
+    Ty::I32,
+    Ty::I64,
+    Ty::U8,
+    Ty::U16,
+    Ty::U32,
+    Ty::U64,
+];
+
+impl Ty {
+    fn name(self) -> &'static str {
+        match self {
+            Ty::I8 => "i8",
+            Ty::I16 => "i16",
+            Ty::I32 => "i32",
+            Ty::I64 => "i64",
+            Ty::U8 => "u8",
+            Ty::U16 => "u16",
+            Ty::U32 => "u32",
+            Ty::U64 => "u64",
+            Ty::Bool => "bool",
+        }
+    }
+
+    fn is_signed(self) -> bool {
+        matches!(self, Ty::I8 | Ty::I16 | Ty::I32 | Ty::I64)
+    }
+
+    /// Inclusive `[min, max]` literal range for an integer type. Emitting only
+    /// in-range literals keeps generated programs compiling (an out-of-range
+    /// literal is a *compile* error, whereas arithmetic overflow at runtime is a
+    /// trap both engines agree on).
+    fn int_range(self) -> (i128, i128) {
+        match self {
+            Ty::I8 => (i8::MIN as i128, i8::MAX as i128),
+            Ty::I16 => (i16::MIN as i128, i16::MAX as i128),
+            Ty::I32 => (i32::MIN as i128, i32::MAX as i128),
+            Ty::I64 => (i64::MIN as i128, i64::MAX as i128),
+            Ty::U8 => (0, u8::MAX as i128),
+            Ty::U16 => (0, u16::MAX as i128),
+            Ty::U32 => (0, u32::MAX as i128),
+            Ty::U64 => (0, u64::MAX as i128),
+            Ty::Bool => (0, 1),
+        }
+    }
+}
+
+/// A scalar variable in scope, tracked so leaves are always a typed variable
+/// (never an inference-ambiguous bare literal).
+#[derive(Clone)]
+struct Var {
+    name: String,
+    ty: Ty,
+}
+
+#[derive(Default, Clone)]
+struct Scope {
+    vars: Vec<Var>,
+}
+
+impl Scope {
+    fn of(&self, ty: Ty) -> Vec<&Var> {
+        self.vars.iter().filter(|v| v.ty == ty).collect()
+    }
+    fn push(&mut self, name: String, ty: Ty) {
+        self.vars.push(Var { name, ty });
+    }
+}
+
+/// A generated struct type: `f0` is always `i32` (so a helper can return it
+/// without a cast), the remaining fields are mixed-width ints or a nested struct
+/// — the multi-slot / nested-projection shapes that broke codegen historically.
+struct StructDef {
+    name: String,
+    /// Scalar fields (name, type).
+    scalar_fields: Vec<(String, Ty)>,
+    /// Optional single nested-struct field (name, index into `structs`).
+    nested: Option<(String, usize)>,
+    /// Whether this struct has a `drop fn` (exercises drop order/exactly-once).
+    has_drop: bool,
+}
+
+/// A generated scalar helper `fn(a: T, b: T) -> T`, used to cross the call ABI
+/// with scalar arguments and recursion.
+struct HelperSig {
+    name: String,
+    param_ty: Ty,
+    ret_ty: Ty,
+}
+
+pub struct Program {
+    rng: Rng,
+    counter: usize,
+    structs: Vec<StructDef>,
+    helpers: Vec<HelperSig>,
+    /// Whether a recursive helper `rec0` was emitted.
+    has_rec: bool,
+    /// Whether the scalar in/out helper `bump0` was emitted.
+    has_bump: bool,
+    /// Number of generated enums (variants are always 3: `V0`,`V1`,`V2`).
+    enums: usize,
+    top_level: Vec<String>,
+}
+
+/// Generate a complete, well-typed Rue program from `seed`.
+pub fn generate(seed: u64) -> String {
+    let mut p = Program {
+        rng: Rng::new(seed),
+        counter: 0,
+        structs: Vec::new(),
+        helpers: Vec::new(),
+        has_rec: false,
+        has_bump: false,
+        enums: 0,
+        top_level: Vec::new(),
+    };
+    p.build()
+}
+
+impl Program {
+    fn fresh(&mut self, prefix: &str) -> String {
+        let n = self.counter;
+        self.counter += 1;
+        format!("{prefix}{n}")
+    }
+
+    fn int_literal(&mut self, ty: Ty) -> String {
+        let (lo, hi) = ty.int_range();
+        // Bias toward boundary values (where width bugs hide) and small values.
+        let v: i128 = match self.rng.below(6) {
+            0 => lo,
+            1 => hi,
+            2 => hi - 1,
+            3 => 0,
+            4 => 1,
+            _ => self.rng.below(64) as i128,
+        };
+        let v = v.clamp(lo, hi);
+        v.to_string()
+    }
+
+    fn bool_literal(&mut self) -> &'static str {
+        if self.rng.chance(1, 2) {
+            "true"
+        } else {
+            "false"
+        }
+    }
+
+    /// A leaf of exact type `ty`: a variable if one is in scope, else a literal
+    /// (only reached for the seed `let`s, which carry an explicit annotation).
+    fn leaf(&mut self, ty: Ty, scope: &Scope) -> String {
+        let candidates = scope.of(ty);
+        if !candidates.is_empty() {
+            return self.rng.pick(&candidates).name.clone();
+        }
+        if ty == Ty::Bool {
+            self.bool_literal().to_string()
+        } else {
+            self.int_literal(ty)
+        }
+    }
+
+    /// A well-typed expression of exact type `ty`.
+    fn expr(&mut self, ty: Ty, scope: &Scope, depth: u32) -> String {
+        if depth == 0 || self.rng.chance(1, 3) {
+            return self.leaf(ty, scope);
+        }
+        if ty == Ty::Bool {
+            return self.bool_expr(scope, depth);
+        }
+        self.int_expr(ty, scope, depth)
+    }
+
+    fn bool_expr(&mut self, scope: &Scope, depth: u32) -> String {
+        if depth == 0 {
+            return self.leaf(Ty::Bool, scope);
+        }
+        match self.rng.below(4) {
+            0 => {
+                // Comparison of two same-typed ints. Only compare a type that
+                // has a variable in scope, so both operands are typed
+                // variables — comparing bare literals (`0 != 4294967295`) has no
+                // inference context and would default to `i32` (out of range).
+                let usable: Vec<Ty> = INT_TYPES
+                    .iter()
+                    .copied()
+                    .filter(|t| !scope.of(*t).is_empty())
+                    .collect();
+                if usable.is_empty() {
+                    return self.leaf(Ty::Bool, scope);
+                }
+                let it = *self.rng.pick(&usable);
+                let cmp = *self.rng.pick(&["==", "!=", "<", ">", "<=", ">="]);
+                let l = self.expr(it, scope, depth - 1);
+                let r = self.expr(it, scope, depth - 1);
+                format!("({l} {cmp} {r})")
+            }
+            1 => {
+                let op = *self.rng.pick(&["&&", "||"]);
+                let l = self.expr(Ty::Bool, scope, depth - 1);
+                let r = self.expr(Ty::Bool, scope, depth - 1);
+                format!("({l} {op} {r})")
+            }
+            2 => {
+                let inner = self.bool_expr(scope, depth - 1);
+                format!("(!{inner})")
+            }
+            _ => self.leaf(Ty::Bool, scope),
+        }
+    }
+
+    fn int_expr(&mut self, ty: Ty, scope: &Scope, depth: u32) -> String {
+        match self.rng.below(8) {
+            0 => {
+                let op = *self.rng.pick(&["+", "-", "*", "&", "|", "^"]);
+                let l = self.expr(ty, scope, depth - 1);
+                let r = self.expr(ty, scope, depth - 1);
+                format!("({l} {op} {r})")
+            }
+            1 => {
+                // Division / remainder — guard the divisor nonzero with `| 1`
+                // (keeps type `ty`, is always odd hence never 0). Overflow cases
+                // like `i32::MIN % -1` still trap, and both engines agree.
+                let op = *self.rng.pick(&["/", "%"]);
+                let l = self.expr(ty, scope, depth - 1);
+                let r = self.expr(ty, scope, depth - 1);
+                format!("({l} {op} ({r} | 1))")
+            }
+            2 => {
+                // Shift by a same-typed amount; over-shift traps in both engines.
+                let op = *self.rng.pick(&["<<", ">>"]);
+                let l = self.expr(ty, scope, depth - 1);
+                let r = self.expr(ty, scope, depth - 1);
+                format!("({l} {op} {r})")
+            }
+            3 if ty.is_signed() => {
+                let inner = self.expr(ty, scope, depth - 1);
+                format!("(0 - {inner})")
+            }
+            4 => {
+                let inner = self.expr(ty, scope, depth - 1);
+                format!("(~{inner})")
+            }
+            5 => {
+                let cond = self.bool_expr(scope, depth - 1);
+                let then = self.expr(ty, scope, depth - 1);
+                let els = self.expr(ty, scope, depth - 1);
+                format!("(if {cond} {{ {then} }} else {{ {els} }})")
+            }
+            6 => {
+                // Call a scalar helper returning `ty`, if one exists.
+                let matches: Vec<(String, Ty)> = self
+                    .helpers
+                    .iter()
+                    .filter(|h| h.ret_ty == ty)
+                    .map(|h| (h.name.clone(), h.param_ty))
+                    .collect();
+                if let Some((name, pty)) = matches.first().cloned() {
+                    let a = self.expr(pty, scope, depth - 1);
+                    let b = self.expr(pty, scope, depth - 1);
+                    format!("{name}({a}, {b})")
+                } else {
+                    self.leaf(ty, scope)
+                }
+            }
+            _ => self.leaf(ty, scope),
+        }
+    }
+
+    // ---- top-level item emitters ------------------------------------------
+
+    fn emit_structs(&mut self) {
+        let count = self.rng.below(3); // 0..=2
+        for _ in 0..count {
+            let idx = self.structs.len();
+            let name = format!("S{idx}");
+            // f0 is always i32 (returnable without cast).
+            let mut scalar_fields = vec![("f0".to_string(), Ty::I32)];
+            let extra = 1 + self.rng.below(3); // 1..=3 more scalar fields
+            for fi in 0..extra {
+                let ty = *self.rng.pick(&INT_TYPES);
+                scalar_fields.push((format!("f{}", fi + 1), ty));
+            }
+            // Optionally nest a previously-defined struct (nested projection).
+            let nested = if idx > 0 && self.rng.chance(1, 3) {
+                Some(("inner".to_string(), self.rng.below(idx as u64) as usize))
+            } else {
+                None
+            };
+            let has_drop = self.rng.chance(1, 3);
+            self.structs.push(StructDef {
+                name: name.clone(),
+                scalar_fields,
+                nested,
+                has_drop,
+            });
+        }
+        // Emit definitions and a by-value `pass`/`make`/`borrow` helper per struct.
+        for i in 0..self.structs.len() {
+            let def_src = self.struct_def_src(i);
+            self.top_level.push(def_src);
+            if self.structs[i].has_drop {
+                let sname = self.structs[i].name.clone();
+                self.top_level
+                    .push(format!("drop fn {sname}(self) {{ @dbg(self.f0); }}"));
+            }
+            let name = self.structs[i].name.clone();
+            // by-value in, i32 out — the ABI-crossing shape.
+            self.top_level
+                .push(format!("fn pass{name}(s: {name}) -> i32 {{ s.f0 }}"));
+            // borrow in, i32 out.
+            self.top_level.push(format!(
+                "fn borrow{name}(borrow s: {name}) -> i32 {{ s.f0 }}"
+            ));
+            // by-value out (return an aggregate).
+            let ctor = self.struct_ctor_src(i);
+            self.top_level
+                .push(format!("fn make{name}() -> {name} {{ {ctor} }}"));
+        }
+    }
+
+    fn struct_def_src(&self, i: usize) -> String {
+        let def = &self.structs[i];
+        let mut fields: Vec<String> = def
+            .scalar_fields
+            .iter()
+            .map(|(n, t)| format!("    {}: {},", n, t.name()))
+            .collect();
+        if let Some((fname, target)) = &def.nested {
+            fields.push(format!("    {}: {},", fname, self.structs[*target].name));
+        }
+        format!("struct {} {{\n{}\n}}", def.name, fields.join("\n"))
+    }
+
+    /// A constructor expression for struct `i` with all-literal leaves (used in
+    /// `make`/inline contexts that have no scope). Recurses into nested structs.
+    fn struct_ctor_src(&mut self, i: usize) -> String {
+        let plan: Vec<(String, Ty)> = self.structs[i].scalar_fields.clone();
+        let nested = self.structs[i].nested.clone();
+        let mut parts = Vec::new();
+        for (fname, fty) in plan {
+            let val = if fty == Ty::Bool {
+                self.bool_literal().to_string()
+            } else {
+                self.int_literal(fty)
+            };
+            parts.push(format!("{fname}: {val}"));
+        }
+        if let Some((fname, target)) = nested {
+            let inner = self.struct_ctor_src(target);
+            parts.push(format!("{fname}: {inner}"));
+        }
+        format!("{} {{ {} }}", self.structs[i].name, parts.join(", "))
+    }
+
+    fn emit_helpers(&mut self) {
+        let count = self.rng.below(3); // 0..=2 scalar helpers
+        for _ in 0..count {
+            let ty = *self.rng.pick(&INT_TYPES);
+            let name = self.fresh("h");
+            let mut scope = Scope::default();
+            scope.push("a".to_string(), ty);
+            scope.push("b".to_string(), ty);
+            let body = self.expr(ty, &scope, 2);
+            self.top_level.push(format!(
+                "fn {name}(a: {t}, b: {t}) -> {t} {{ {body} }}",
+                t = ty.name()
+            ));
+            self.helpers.push(HelperSig {
+                name,
+                param_ty: ty,
+                ret_ty: ty,
+            });
+        }
+        if self.rng.chance(1, 2) {
+            self.top_level.push(
+                "fn rec0(n: i32, acc: i32) -> i32 { if n <= 0 { acc } else { rec0(n - 1, acc + n) } }"
+                    .to_string(),
+            );
+            self.has_rec = true;
+        }
+        if self.rng.chance(1, 2) {
+            self.top_level
+                .push("fn bump0(inout x: i32) { x = x + 1; }".to_string());
+            self.has_bump = true;
+        }
+    }
+
+    fn emit_enums(&mut self) {
+        if self.rng.chance(1, 2) {
+            self.top_level.push("enum E0 { V0, V1, V2 }".to_string());
+            self.enums = 1;
+        }
+    }
+
+    // ---- main-body snippet emitters ---------------------------------------
+
+    /// Seed 1-2 variables of each integer type plus a couple of bools, so every
+    /// expression leaf can be a typed variable.
+    fn seed_vars(&mut self, body: &mut Vec<String>, scope: &mut Scope) {
+        for &ty in &INT_TYPES {
+            let n = 1 + self.rng.below(2);
+            for _ in 0..n {
+                let name = self.fresh("v");
+                let lit = self.int_literal(ty);
+                body.push(format!("    let {name}: {t} = {lit};", t = ty.name()));
+                scope.push(name, ty);
+            }
+        }
+        for _ in 0..2 {
+            let name = self.fresh("b");
+            let lit = self.bool_literal();
+            body.push(format!("    let {name}: bool = {lit};"));
+            scope.push(name, Ty::Bool);
+        }
+    }
+
+    /// A `let vN: T = <expr>;` statement, registering the new variable.
+    fn snippet_let(&mut self, body: &mut Vec<String>, scope: &mut Scope) {
+        let ty = if self.rng.chance(1, 4) {
+            Ty::Bool
+        } else {
+            *self.rng.pick(&INT_TYPES)
+        };
+        let name = self.fresh("v");
+        let e = self.expr(ty, scope, 3);
+        body.push(format!("    let {name}: {t} = {e};", t = ty.name()));
+        scope.push(name, ty);
+    }
+
+    /// `let vN: T = @intCast(<src var>);` — exercises the range-checked cast.
+    fn snippet_intcast(&mut self, body: &mut Vec<String>, scope: &mut Scope) {
+        let dst = *self.rng.pick(&INT_TYPES);
+        // Cast *from* a variable of some int type.
+        let src_candidates: Vec<Var> = scope
+            .vars
+            .iter()
+            .filter(|v| v.ty != Ty::Bool)
+            .cloned()
+            .collect();
+        if src_candidates.is_empty() {
+            return;
+        }
+        let src = self.rng.pick(&src_candidates).clone();
+        let name = self.fresh("v");
+        body.push(format!(
+            "    let {name}: {t} = @intCast({s});",
+            t = dst.name(),
+            s = src.name
+        ));
+        scope.push(name, dst);
+    }
+
+    fn snippet_dbg(&mut self, body: &mut Vec<String>, scope: &Scope) {
+        // @dbg only supports int/bool (and String, handled separately).
+        if scope.vars.is_empty() {
+            return;
+        }
+        let names: Vec<String> = scope.vars.iter().map(|v| v.name.clone()).collect();
+        let name = self.rng.pick(&names).clone();
+        body.push(format!("    @dbg({name});"));
+    }
+
+    fn snippet_struct(&mut self, body: &mut Vec<String>, scope: &mut Scope) {
+        if self.structs.is_empty() {
+            return;
+        }
+        let i = self.rng.below(self.structs.len() as u64) as usize;
+        let name = self.structs[i].name.clone();
+        let pname = self.fresh("p");
+        // Bind a value: either freshly constructed or returned by `make` (ABI).
+        if self.rng.chance(1, 2) {
+            let ctor = self.struct_ctor_src(i);
+            body.push(format!("    let {pname}: {name} = {ctor};"));
+        } else {
+            body.push(format!("    let {pname} = make{name}();"));
+        }
+        // Read scalar fields into typed vars (scalar copies; struct still owned).
+        let fields: Vec<(String, Ty)> = self.structs[i].scalar_fields.clone();
+        for (fname, fty) in &fields {
+            if self.rng.chance(1, 2) {
+                let vn = self.fresh("v");
+                body.push(format!(
+                    "    let {vn}: {t} = {pname}.{fname};",
+                    t = fty.name()
+                ));
+                scope.push(vn, *fty);
+            }
+        }
+        // Nested projection read.
+        if let Some((fname, _target)) = self.structs[i].nested.clone() {
+            let vn = self.fresh("v");
+            body.push(format!("    let {vn}: i32 = {pname}.{fname}.f0;"));
+            scope.push(vn, Ty::I32);
+        }
+        // borrow (does not move) — always safe on the bound value.
+        let vb = self.fresh("v");
+        body.push(format!("    let {vb}: i32 = borrow{name}(borrow {pname});"));
+        scope.push(vb, Ty::I32);
+        // by-value pass: only via a fresh inline temp (never move the bound
+        // `pname`, which must survive to its scope-exit drop when droppable).
+        let vp = self.fresh("v");
+        let ctor = self.struct_ctor_src(i);
+        body.push(format!("    let {vp}: i32 = pass{name}({ctor});"));
+        scope.push(vp, Ty::I32);
+    }
+
+    fn snippet_array(&mut self, body: &mut Vec<String>, scope: &mut Scope) {
+        let elems: Vec<String> = (0..3).map(|_| self.int_literal(Ty::I32)).collect();
+        let aname = self.fresh("a");
+        body.push(format!(
+            "    let {aname}: [i32; 3] = [{}];",
+            elems.join(", ")
+        ));
+        // Index — in-bounds usually; occasionally out of bounds (both trap).
+        let idx = if self.rng.chance(1, 8) {
+            3 + self.rng.below(3)
+        } else {
+            self.rng.below(3)
+        };
+        let iname = self.fresh("ix");
+        body.push(format!("    let {iname}: usize = {idx};"));
+        let vn = self.fresh("v");
+        body.push(format!("    let {vn}: i32 = {aname}[{iname}];"));
+        scope.push(vn, Ty::I32);
+    }
+
+    fn snippet_match_int(&mut self, body: &mut Vec<String>, scope: &mut Scope) {
+        let scr = self.leaf(Ty::I32, scope);
+        let a = self.expr(Ty::I32, scope, 1);
+        let b = self.expr(Ty::I32, scope, 1);
+        let vn = self.fresh("v");
+        body.push(format!(
+            "    let {vn}: i32 = match ({scr} & 1) {{ 0 => {a}, _ => {b} }};"
+        ));
+        scope.push(vn, Ty::I32);
+    }
+
+    fn snippet_match_enum(&mut self, body: &mut Vec<String>, scope: &mut Scope) {
+        if self.enums == 0 {
+            return;
+        }
+        let variant = self.rng.below(3);
+        let ename = self.fresh("e");
+        body.push(format!("    let {ename}: E0 = E0::V{variant};"));
+        let a = self.expr(Ty::I32, scope, 1);
+        let b = self.expr(Ty::I32, scope, 1);
+        let c = self.expr(Ty::I32, scope, 1);
+        let vn = self.fresh("v");
+        body.push(format!(
+            "    let {vn}: i32 = match {ename} {{ E0::V0 => {a}, E0::V1 => {b}, E0::V2 => {c} }};"
+        ));
+        scope.push(vn, Ty::I32);
+    }
+
+    fn snippet_inout(&mut self, body: &mut Vec<String>, scope: &mut Scope) {
+        if !self.has_bump {
+            return;
+        }
+        let mname = self.fresh("m");
+        let lit = self.int_literal(Ty::I32);
+        body.push(format!("    let mut {mname}: i32 = {lit};"));
+        body.push(format!("    bump0(inout {mname});"));
+        scope.push(mname, Ty::I32);
+    }
+
+    fn snippet_recursion(&mut self, body: &mut Vec<String>, scope: &mut Scope) {
+        if !self.has_rec {
+            return;
+        }
+        let n = self.rng.below(12); // small, guarantees termination
+        let vn = self.fresh("v");
+        body.push(format!("    let {vn}: i32 = rec0({n}, 0);"));
+        scope.push(vn, Ty::I32);
+    }
+
+    fn snippet_loop(&mut self, body: &mut Vec<String>, scope: &mut Scope) {
+        // A bounded counted loop; the constant bound guarantees termination.
+        let bound = 1 + self.rng.below(6);
+        let acc = self.fresh("v");
+        let ctr = self.fresh("ix");
+        body.push(format!("    let mut {acc}: i32 = 0;"));
+        body.push(format!("    let mut {ctr}: i32 = 0;"));
+        body.push(format!(
+            "    loop {{ if {ctr} >= {bound} {{ break; }} {acc} = {acc} + {ctr}; {ctr} = {ctr} + 1; }}"
+        ));
+        scope.push(acc, Ty::I32);
+    }
+
+    fn snippet_string(&mut self, body: &mut Vec<String>, scope: &mut Scope) {
+        let sname = self.fresh("s");
+        body.push(format!("    let mut {sname} = String::new();"));
+        let chunks = 1 + self.rng.below(3);
+        for _ in 0..chunks {
+            let word = *self.rng.pick(&["foo", "bar", "baz", "hi", "x"]);
+            body.push(format!("    {sname}.push_str(\"{word}\");"));
+        }
+        let ln = self.fresh("v");
+        body.push(format!("    let {ln}: u64 = {sname}.len();"));
+        scope.push(ln, Ty::U64);
+        // @dbg last (String may be consumed by dbg in codegen; keep it terminal).
+        body.push(format!("    @dbg({sname});"));
+    }
+
+    fn build(&mut self) -> String {
+        // Top-level items first (main refers to them; forward refs are fine).
+        self.emit_structs();
+        self.emit_enums();
+        self.emit_helpers();
+
+        let mut body: Vec<String> = Vec::new();
+        let mut scope = Scope::default();
+        self.seed_vars(&mut body, &mut scope);
+
+        // A random sequence of feature snippets.
+        let steps = 4 + self.rng.below(8);
+        for _ in 0..steps {
+            match self.rng.below(11) {
+                0 => self.snippet_let(&mut body, &mut scope),
+                1 => self.snippet_intcast(&mut body, &mut scope),
+                2 => self.snippet_struct(&mut body, &mut scope),
+                3 => self.snippet_array(&mut body, &mut scope),
+                4 => self.snippet_match_int(&mut body, &mut scope),
+                5 => self.snippet_match_enum(&mut body, &mut scope),
+                6 => self.snippet_inout(&mut body, &mut scope),
+                7 => self.snippet_recursion(&mut body, &mut scope),
+                8 => self.snippet_loop(&mut body, &mut scope),
+                9 => self.snippet_string(&mut body, &mut scope),
+                _ => self.snippet_dbg(&mut body, &scope),
+            }
+        }
+
+        // A couple of @dbg calls for stdout coverage, then return an i32.
+        self.snippet_dbg(&mut body, &scope);
+        let ret = self.expr(Ty::I32, &scope, 2);
+        body.push(format!("    return {ret};"));
+
+        let mut out = String::new();
+        for item in &self.top_level {
+            out.push_str(item);
+            out.push_str("\n\n");
+        }
+        out.push_str("fn main() -> i32 {\n");
+        out.push_str(&body.join("\n"));
+        out.push_str("\n}\n");
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_from_seed() {
+        for seed in 0..50u64 {
+            assert_eq!(
+                generate(seed),
+                generate(seed),
+                "seed {seed} not deterministic"
+            );
+        }
+    }
+
+    #[test]
+    fn always_has_main() {
+        for seed in 0..200u64 {
+            let src = generate(seed);
+            assert!(src.contains("fn main() -> i32 {"), "seed {seed}: {src}");
+        }
+    }
+}

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -10,12 +10,22 @@
 //! turns "we check the outputs we thought to write down" into "we check that
 //! the semantics and codegen agree on every program in the corpus."
 //!
-//! Usage: `rue-oracle-diff [cases-dir ...]`
-//! Case-directory resolution, in order: explicit argv paths; else the
-//! `RUE_ORACLE_DIFF_CASES` env var (a single dir — how the `buck2 test`
-//! sh_test feeds the rue-cli-tests `cases` filegroup); else the default
-//! `crates/rue-cli-tests/cases`, resolved from the current directory.
-//! Exits non-zero if any disagreement is found.
+//! Two modes:
+//!
+//! - **corpus** (default): `rue-oracle-diff [cases-dir ...]` runs the concrete
+//!   rue-cli-tests corpus through the oracle. Case-directory resolution, in
+//!   order: explicit argv paths; else the `RUE_ORACLE_DIFF_CASES` env var (a
+//!   single dir — how the `buck2 test` sh_test feeds the rue-cli-tests `cases`
+//!   filegroup); else the default `crates/rue-cli-tests/cases`.
+//! - **fuzz** (`rue-oracle-diff fuzz [...]`): the differential *fuzzer* of
+//!   RUE-247 — generate random valid programs and cross-check the oracle
+//!   against the real compiler + native binary. See [`fuzz`]. A `dump <seed>`
+//!   subcommand prints a generated program for inspection.
+//!
+//! Every mode exits non-zero if any disagreement is found.
+
+mod fuzz;
+mod generator;
 
 use rue_oracle::run_source;
 use serde::Deserialize;
@@ -75,8 +85,36 @@ struct Report {
 }
 
 fn main() -> ExitCode {
+    // Subcommand dispatch: `rue-oracle-diff fuzz [...]` runs the differential
+    // *fuzzer* (generate valid programs, cross-check oracle vs compiled binary);
+    // with no subcommand it runs the corpus differential (below).
+    let raw: Vec<String> = std::env::args().skip(1).collect();
+    if raw.first().map(String::as_str) == Some("fuzz") {
+        return fuzz::run(&raw[1..]);
+    }
+    // `dump <seed>...` prints the generated program(s) — a debugging aid for
+    // inspecting what a seed produces (and reducing a repro by hand).
+    if raw.first().map(String::as_str) == Some("dump") {
+        for s in &raw[1..] {
+            match s.parse::<u64>() {
+                Ok(seed) => {
+                    println!("// ===== seed {seed} =====");
+                    print!("{}", generator::generate(seed));
+                }
+                Err(_) => eprintln!("dump: not a seed: {s}"),
+            }
+        }
+        return ExitCode::SUCCESS;
+    }
+
+    corpus_mode(raw)
+}
+
+/// The original corpus differential: run each rue-cli-tests case through the
+/// oracle and check it agrees with the case's expected exit code / stdout.
+fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
     let dirs: Vec<PathBuf> = {
-        let args: Vec<String> = std::env::args().skip(1).collect();
+        let args: Vec<String> = raw_args;
         if !args.is_empty() {
             args.into_iter().map(PathBuf::from).collect()
         } else if let Some(cases) = std::env::var_os("RUE_ORACLE_DIFF_CASES") {


### PR DESCRIPTION
Automated miscompile discovery — the RUE-50 payoff wired to the RUE-205 oracle harness. Test/tooling only; no compiler crate touched. **CI will now find miscompiles on its own.**

- crates/rue-oracle-diff/src/generator.rs: a deterministic splitmix64 generator of well-typed programs in the oracle modeled subset, biased to the historically-fragile shapes (struct by-value ABI, nested/mixed-width projections, trapping arithmetic, intCast, match/enum, recursion, arrays, inout/borrow, drops, String).
- crates/rue-oracle-diff/src/fuzz.rs: a fuzz subcommand runs each seed through the oracle AND compile+run, comparing exit/stdout; disagreements are saved as seed-named repros in crates/rue-fuzz/crashes/. Plus a per-seed dump command.
- main.rs dispatch (corpus mode preserved), BUCK test target, a 500-seed nightly step in .github/workflows/fuzz.yml (auto-files a GH issue on disagreement).
- find_rue_binary canonicalizes the bin/rue fallback to an absolute path (each program compiles with current_dir set to a temp workdir, so a relative symlink would not resolve).

Verified by running: 600 seeds gives 599 agree / 1 skip / 0 disagreements; the 100 and 300-seed runs on current trunk (arrays-ascending + receivers landed) also 0 disagreements — independent confirmation those changes are miscompile-free. Planted-bug sanity check (oracle Add to Sub) reported disagreements with repros, then reverted. Full test.sh green; actionlint clean.

Fixes RUE-247

Generated with Claude Code