### PR TITLE
String: with_capacity(huge) no longer segfaults; mutation methods accept any place receiver (RUE-255, RUE-256)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -3083,46 +3083,54 @@ impl<'a> Sema<'a> {
         // builtin: a user struct method that merely shares a name with a String
         // mutation method (`push`/`push_str`/`clear`/`reserve`) must not be
         // misclassified as a `ByMutRef` mutation and wrongly demand a `mut`
-        // receiver (RUE-223). The type is peeked from the binding without
-        // analyzing the receiver, because the storage location must be captured
-        // before the receiver expression is (potentially) consumed below.
-        let receiver_is_builtin_string = self
-            .peek_var_ref_type(receiver, ctx)
+        // receiver (RUE-223). The type is read from HM inference without
+        // analyzing the receiver, so ANY place receiver (a local, a struct
+        // field, an array element, an inout parameter, or a chain rooted at
+        // one) is recognized, not just a bare local (RUE-256).
+        let receiver_is_builtin_string = ctx
+            .resolved_types
+            .get(&receiver)
+            .copied()
             .is_some_and(|ty| self.is_builtin_string(ty));
         let is_builtin_mutation_method =
             receiver_is_builtin_string && self.is_builtin_mutation_method(&method_name_str);
 
-        // Get storage location for mutation methods before analyzing receiver
-        let receiver_storage = if is_builtin_mutation_method {
-            self.get_string_receiver_storage(receiver, ctx, span)?
-        } else {
-            None
-        };
+        // A String mutation method is `inout self` (spec 3.10:15-19): it
+        // accesses the receiver by reference and writes the result back in
+        // place, so the receiver must name a MUTABLE place. Reject an immutable
+        // binding up front (reusing the assignment-target diagnostics), before
+        // the receiver is analyzed as a borrow below.
+        if is_builtin_mutation_method {
+            self.check_string_receiver_mutable(receiver_var, ctx, span)?;
+        }
 
         // Snapshot the receiver root's move state before analyzing the
         // receiver expression: builtin ByRef/ByMutRef methods restore it to
         // undo the move the receiver analysis records (see ReceiverInfo).
         let receiver_move_state_before = receiver_var.and_then(|v| ctx.moved_vars.get(&v).cloned());
 
-        // Decide up front whether this receiver is accessed by reference
-        // (`inout self` / `borrow self`), so it is analyzed as a BORROW — not
-        // a move — in every place position (a field, an array element by
-        // const or dynamic index, a field of `self`, or through an
-        // inout/borrow parameter), mirroring the by-ref *argument* path
-        // (RUE-254, spec 6.4:25/6.4:29). Method resolution needs the receiver
-        // type, which is peeked WITHOUT emitting AIR or recording a move: a
+        // Decide up front whether this receiver is accessed by reference, so
+        // it is analyzed as a BORROW — not a move — in every place position (a
+        // field, an array element by const or dynamic index, a field of
+        // `self`, or through an inout/borrow parameter), mirroring the by-ref
+        // *argument* path (spec 6.4:25/6.4:29). For a builtin String mutation
+        // method the receiver is always by-ref, so its root is the by-ref root
+        // (RUE-256). For a user-struct method, resolution needs the receiver
+        // type — peeked WITHOUT emitting AIR or recording a move, since a
         // move-based analysis would hard-reject the read of any non-local
-        // place (E0437/E0429/E0904) before the by-ref intent is known. Only
-        // user-struct methods are considered here; builtin (String) and
-        // module receivers keep their existing post-analysis handling.
-        let receiver_byref_root = receiver_var
-            .filter(|_| !is_builtin_mutation_method)
-            .and_then(|root| {
+        // place (E0437/E0429/E0904) before the by-ref intent is known — and the
+        // root is by-ref only when the method takes `self` by reference
+        // (RUE-254). Module receivers keep their existing post-analysis handling.
+        let receiver_byref_root = if is_builtin_mutation_method {
+            receiver_var
+        } else {
+            receiver_var.and_then(|root| {
                 let ty = self.peek_place_type(receiver, ctx)?;
                 let struct_id = ty.as_struct()?;
                 let info = self.methods.get(&(struct_id, method))?;
                 matches!(info.self_mode, RirParamMode::Inout | RirParamMode::Borrow).then_some(root)
-            });
+            })
+        };
 
         // Analyze the receiver expression. When it is a by-ref receiver,
         // `byref_arg_root` makes the var-ref / field / index reads borrow the
@@ -3132,6 +3140,17 @@ impl<'a> Sema<'a> {
         ctx.byref_arg_root = prev_byref_root;
         let receiver_result = receiver_result?;
         let receiver_type = receiver_result.ty;
+
+        // The write-back target for a String mutation method is the place the
+        // receiver read just produced (a `PlaceRead` for a field/element, a
+        // `Load` for a local, or a `Param` for an inout parameter). Reusing
+        // that place — rather than re-tracing the receiver — evaluates any
+        // index expression exactly once (RUE-256).
+        let receiver_storage = if is_builtin_mutation_method {
+            Some(self.string_receiver_storage_from_read(air, receiver_result.air_ref, span)?)
+        } else {
+            None
+        };
 
         // Handle module member access: module.function() becomes a direct function call
         if let Some(module_id) = receiver_type.as_module() {
@@ -5157,34 +5176,15 @@ impl<'a> Sema<'a> {
         Ok(AnalysisResult::new(call_ref, return_ty))
     }
 
-    /// Get the storage location for a String receiver in a mutation method call.
+    /// Validate that a String mutation-method receiver names a MUTABLE place.
     ///
-    /// For mutation methods like `push_str`, `push`, `clear`, `reserve`, we need
-    /// to know where to store the updated String after the runtime function returns.
+    /// A mutation method (`push_str`, `push`, `clear`, `reserve`) is `inout
+    /// self`: it writes the updated String back through the receiver place, so
+    /// the place's root binding must be mutable. The receiver value itself is
+    /// read as a borrow (via `byref_arg_root`), so use-after-move and the
+    /// projection reads are checked by the normal receiver analysis; this only
+    /// enforces mutability of the write target, mirroring assignment.
     ///
-    /// Returns `Some(storage)` if the receiver is a mutable local or inout parameter.
-    /// Returns an error if the receiver is:
-    /// - An immutable binding (`let` instead of `var`)
-    /// - A borrow parameter (can't mutate borrowed values)
-    /// - Not an lvalue (e.g., a function call result)
-    /// Peek the declared type of a `VarRef` receiver (a local or parameter)
-    /// without analyzing it, so a builtin mutation-method call can be classified
-    /// before the receiver expression is (potentially) consumed. Returns `None`
-    /// for non-`VarRef` receivers or unknown names — such receivers are never
-    /// valid targets for a String mutation method anyway (see
-    /// `get_string_receiver_storage`).
-    fn peek_var_ref_type(&self, receiver_ref: InstRef, ctx: &AnalysisContext) -> Option<Type> {
-        if let InstData::VarRef { name } = &self.rir.get(receiver_ref).data {
-            if let Some(local) = ctx.locals.get(name) {
-                return Some(local.ty);
-            }
-            if let Some(param) = ctx.params.iter().find(|p| p.name == *name) {
-                return Some(param.ty);
-            }
-        }
-        None
-    }
-
     /// Resolve the TYPE of a place expression without emitting any AIR or
     /// recording a move (RUE-254).
     ///
@@ -5226,67 +5226,72 @@ impl<'a> Sema<'a> {
         }
     }
 
-    fn get_string_receiver_storage(
+    /// Errors when the receiver is:
+    /// - not a place rooted at a variable (`String::new().push(..)`) → E0424
+    /// - an immutable `let` binding or a normal/comptime parameter → E0203
+    /// - a `borrow` parameter (can't mutate borrowed memory) → E0428
+    fn check_string_receiver_mutable(
         &self,
-        receiver_ref: InstRef,
+        receiver_var: Option<Spur>,
         ctx: &AnalysisContext,
         span: Span,
-    ) -> CompileResult<Option<StringReceiverStorage>> {
-        let receiver_inst = self.rir.get(receiver_ref);
+    ) -> CompileResult<()> {
+        let Some(root) = receiver_var else {
+            return Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span));
+        };
 
-        match &receiver_inst.data {
-            InstData::VarRef { name } => {
-                // Check if this is a parameter
-                if let Some(param_info) = ctx.params.iter().find(|p| p.name == *name) {
-                    // Check parameter mode
-                    match param_info.mode {
-                        RirParamMode::Inout => {
-                            return Ok(Some(StringReceiverStorage::Param {
-                                abi_slot: param_info.abi_slot,
-                            }));
-                        }
-                        RirParamMode::Borrow => {
-                            let name_str = self.interner.resolve(&*name);
-                            return Err(CompileError::new(
-                                ErrorKind::MutateBorrowedValue {
-                                    variable: name_str.to_string(),
-                                },
-                                span,
-                            ));
-                        }
-                        RirParamMode::Normal | RirParamMode::Comptime => {
-                            // Normal and comptime parameters are immutable
-                            let name_str = self.interner.resolve(&*name);
-                            return Err(CompileError::new(
-                                ErrorKind::AssignToImmutable(name_str.to_string()),
-                                span,
-                            ));
-                        }
-                    }
-                }
-
-                // Check if it's a local variable
-                if let Some(local) = ctx.locals.get(name) {
-                    if !local.is_mut {
-                        let name_str = self.interner.resolve(&*name);
-                        return Err(CompileError::new(
-                            ErrorKind::AssignToImmutable(name_str.to_string()),
-                            span,
-                        ));
-                    }
-                    return Ok(Some(StringReceiverStorage::Local { slot: local.slot }));
-                }
-
-                // Variable not found
-                let name_str = self.interner.resolve(&*name);
-                Err(CompileError::new(
-                    ErrorKind::UndefinedVariable(name_str.to_string()),
+        // Root parameter: only `inout` names mutable caller storage.
+        if let Some(param) = ctx.params.iter().find(|p| p.name == root) {
+            return match param.mode {
+                RirParamMode::Inout => Ok(()),
+                RirParamMode::Borrow => Err(CompileError::new(
+                    ErrorKind::MutateBorrowedValue {
+                        variable: self.interner.resolve(&root).to_string(),
+                    },
                     span,
-                ))
-            }
+                )),
+                RirParamMode::Normal | RirParamMode::Comptime => Err(CompileError::new(
+                    ErrorKind::AssignToImmutable(self.interner.resolve(&root).to_string()),
+                    span,
+                )),
+            };
+        }
 
-            // For other receiver types (field access, function calls, etc.),
-            // we don't support mutation for now
+        // Root local: must be `let mut`.
+        if let Some(local) = ctx.locals.get(&root) {
+            if !local.is_mut {
+                return Err(CompileError::new(
+                    ErrorKind::AssignToImmutable(self.interner.resolve(&root).to_string()),
+                    span,
+                ));
+            }
+            return Ok(());
+        }
+
+        Err(CompileError::new(
+            ErrorKind::UndefinedVariable(self.interner.resolve(&root).to_string()),
+            span,
+        ))
+    }
+
+    /// Derive the write-back storage for a String mutation method from the AIR
+    /// the receiver read produced. The receiver was read as a borrow, so its
+    /// value instruction is a plain `Load` (local), `Param` (inout parameter),
+    /// or `PlaceRead` (struct field / array element / projection chain); each
+    /// maps directly to the matching store target. Reusing the already-built
+    /// place means any index expression is evaluated exactly once (RUE-256).
+    fn string_receiver_storage_from_read(
+        &self,
+        air: &Air,
+        receiver_ref: AirRef,
+        span: Span,
+    ) -> CompileResult<StringReceiverStorage> {
+        match &air.get(receiver_ref).data {
+            AirInstData::Load { slot } => Ok(StringReceiverStorage::Local { slot: *slot }),
+            AirInstData::Param { index } => Ok(StringReceiverStorage::Param { abi_slot: *index }),
+            AirInstData::PlaceRead { place } => Ok(StringReceiverStorage::Place { place: *place }),
+            // Any other value (a literal, a call result, …) has no caller-visible
+            // storage to write back to.
             _ => Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span)),
         }
     }
@@ -5313,6 +5318,14 @@ impl<'a> Sema<'a> {
             StringReceiverStorage::Param { abi_slot } => air.add_inst(AirInst {
                 data: AirInstData::ParamStore {
                     param_slot: abi_slot,
+                    value: call_ref,
+                },
+                ty: Type::UNIT,
+                span,
+            }),
+            StringReceiverStorage::Place { place } => air.add_inst(AirInst {
+                data: AirInstData::PlaceWrite {
+                    place,
                     value: call_ref,
                 },
                 ty: Type::UNIT,

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -563,7 +563,7 @@ pub(crate) struct AnalysisResult {
     pub ty: Type,
 }
 
-use crate::inst::AirRef;
+use crate::inst::{AirPlaceRef, AirRef};
 
 impl AnalysisResult {
     #[must_use]
@@ -666,6 +666,11 @@ pub(crate) enum StringReceiverStorage {
     Local { slot: u32 },
     /// The receiver is a parameter with the given ABI slot.
     Param { abi_slot: u32 },
+    /// The receiver is a projection place — a struct field, an array element,
+    /// or a chain rooted at a local/parameter (`b.data`, `arr[0]`,
+    /// `self.inner`). The mutation result is written back through this place
+    /// (RUE-256).
+    Place { place: AirPlaceRef },
 }
 
 /// Context for analyzing a method call on a builtin type.

--- a/crates/rue-cli-tests/cases/string_alloc_failure.toml
+++ b/crates/rue-cli-tests/cases/string_alloc_failure.toml
@@ -1,0 +1,43 @@
+# String::with_capacity allocation-failure safety (RUE-255).
+#
+# A huge requested capacity makes the heap allocation fail and return null.
+# with_capacity used to store ptr=null / cap=<huge> unconditionally, so a
+# later push saw "capacity sufficient" and wrote through the null pointer —
+# SIGSEGV (memory-unsafe). It must instead record cap=0 on failure so a later
+# push grows a fresh buffer (or the program traps cleanly), never a nonzero
+# capacity backed by null.
+
+[section]
+id = "cli.string_alloc_failure"
+name = "String allocation-failure safety"
+description = "String::with_capacity must not poison capacity when allocation fails."
+
+[[case]]
+name = "with_capacity_huge_no_segfault"
+description = "with_capacity(u64::MAX) fails the alloc: capacity reports 0 and a subsequent push grows fresh instead of writing through null (no SIGSEGV)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut s = String::with_capacity(18446744073709551615);
+    @dbg(s.capacity());
+    s.push(65);
+    @dbg(s.len());
+    0
+}
+""" }]
+exit_code = 0
+stdout = "0\n1\n"
+
+[[case]]
+name = "with_capacity_normal_reserves"
+description = "A satisfiable with_capacity still reserves the requested capacity and appends normally."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut s = String::with_capacity(16);
+    @dbg(s.capacity());
+    s.push(65);
+    @dbg(s.len());
+    0
+}
+""" }]
+exit_code = 0
+stdout = "16\n1\n"

--- a/crates/rue-cli-tests/cases/string_mutation_receivers.toml
+++ b/crates/rue-cli-tests/cases/string_mutation_receivers.toml
@@ -1,0 +1,134 @@
+# Builtin String mutation methods on non-bare-local receivers (RUE-256).
+#
+# push_str/push/clear/reserve are `inout self`: they access the receiver by
+# reference and write the result back in place. They used to accept only a
+# bare `let mut` local receiver, rejecting a struct field or array element as
+# E0424 and an inout-parameter receiver as E0437. Any mutable place is now a
+# valid receiver (the builtin analog of RUE-254), routed through the same
+# by-ref place logic as a by-ref call argument.
+
+[section]
+id = "cli.string_mutation_receivers"
+name = "String mutation-method receivers"
+description = "String mutation methods accept struct-field, array-element, and inout-parameter receivers."
+
+# Struct-field receiver: b.data.push_str(..) mutates the field in place.
+[[case]]
+name = "field_receiver_push_str"
+description = "push_str through a struct field mutates the field (observed via its length)."
+files = [{ path = "main.rue", source = """
+struct Buf { data: String }
+fn main() -> i32 {
+    let mut b = Buf { data: String::new() };
+    b.data.push_str("hi");
+    b.data.push_str("!!!");
+    @dbg(b.data.len());
+    0
+}
+""" }]
+exit_code = 0
+stdout = "5\n"
+
+# Constant array-element receiver: only the indexed element is mutated.
+[[case]]
+name = "array_element_const_index_push"
+description = "arr[0].push(65) mutates element 0 and leaves element 1 untouched."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut arr = [String::new(), String::new()];
+    arr[0].push(65);
+    @dbg(arr[0].len());
+    @dbg(arr[1].len());
+    0
+}
+""" }]
+exit_code = 0
+stdout = "1\n0\n"
+
+# Dynamic array-element receiver: the index variable selects the element.
+[[case]]
+name = "array_element_dynamic_index_push"
+description = "arr[i].push(66) with a runtime index mutates exactly the selected element."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut arr = [String::new(), String::new()];
+    let i: u64 = 1;
+    arr[i].push(66);
+    @dbg(arr[1].len());
+    @dbg(arr[0].len());
+    0
+}
+""" }]
+exit_code = 0
+stdout = "1\n0\n"
+
+# inout-parameter receiver: the mutation is visible in the caller's variable.
+[[case]]
+name = "inout_param_receiver_push_str"
+description = "push_str on an inout String parameter mutates the caller's variable through the borrow."
+files = [{ path = "main.rue", source = """
+fn appendit(inout s: String) {
+    s.push_str("more");
+}
+fn main() -> i32 {
+    let mut s = String::new();
+    appendit(inout s);
+    appendit(inout s);
+    @dbg(s.len());
+    0
+}
+""" }]
+exit_code = 0
+stdout = "8\n"
+
+# Field-of-self receiver inside an inout-self method (method_receivers preview).
+[[case]]
+name = "self_field_receiver_via_method"
+description = "self.data.push_str(..) inside an `inout self` method mutates the receiver's String field."
+args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Buf {
+    data: String,
+    fn append(inout self) { self.data.push_str("ab"); }
+}
+fn main() -> i32 {
+    let mut b = Buf { data: String::new() };
+    b.append();
+    b.append();
+    b.append();
+    @dbg(b.data.len());
+    0
+}
+""" }]
+exit_code = 0
+stdout = "6\n"
+
+# Control: an immutable-local receiver is still rejected (mutation needs `let mut`).
+[[case]]
+name = "immutable_local_receiver_rejected"
+description = "A String mutation method on an immutable binding is still E0203."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = String::new();
+    s.push_str("x");
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0203", "cannot assign"]
+
+# Control: a genuinely-moved String is still caught (use-after-move).
+[[case]]
+name = "moved_string_receiver_rejected"
+description = "Mutating a String after it was moved is still a use-after-move error."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut s = String::new();
+    let s2 = s;
+    s.push_str("x");
+    @dbg(s2.len());
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0205", "moved"]

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -407,6 +407,16 @@ pub extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_c
         requested_cap
     };
     let ptr = heap::alloc(actual_cap, 1);
+    // On allocation failure `heap::alloc` returns null. Store cap=0 (not the
+    // requested capacity) so a later `push` sees "no room", grows fresh from
+    // the null buffer (or traps cleanly), rather than believing it may write
+    // `actual_cap` bytes through a null pointer (RUE-255). Mirrors the null
+    // handling in `__rue_String_clone` and `string_ensure_capacity`.
+    let (ptr, actual_cap) = if ptr.is_null() {
+        (core::ptr::null_mut(), 0)
+    } else {
+        (ptr, actual_cap)
+    };
     unsafe {
         (*out).ptr = ptr;
         (*out).len = 0;
@@ -424,6 +434,16 @@ pub extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_c
         requested_cap
     };
     let ptr = heap::alloc(actual_cap, 1);
+    // On allocation failure `heap::alloc` returns null. Store cap=0 (not the
+    // requested capacity) so a later `push` sees "no room", grows fresh from
+    // the null buffer (or traps cleanly), rather than believing it may write
+    // `actual_cap` bytes through a null pointer (RUE-255). Mirrors the null
+    // handling in `__rue_String_clone` and `string_ensure_capacity`.
+    let (ptr, actual_cap) = if ptr.is_null() {
+        (core::ptr::null_mut(), 0)
+    } else {
+        (ptr, actual_cap)
+    };
     unsafe {
         (*out).ptr = ptr;
         (*out).len = 0;
@@ -441,6 +461,16 @@ pub extern "C" fn __rue_String_with_capacity(out: *mut StringResult, requested_c
         requested_cap
     };
     let ptr = heap::alloc(actual_cap, 1);
+    // On allocation failure `heap::alloc` returns null. Store cap=0 (not the
+    // requested capacity) so a later `push` sees "no room", grows fresh from
+    // the null buffer (or traps cleanly), rather than believing it may write
+    // `actual_cap` bytes through a null pointer (RUE-255). Mirrors the null
+    // handling in `__rue_String_clone` and `string_ensure_capacity`.
+    let (ptr, actual_cap) = if ptr.is_null() {
+        (core::ptr::null_mut(), 0)
+    } else {
+        (ptr, actual_cap)
+    };
     unsafe {
         (*out).ptr = ptr;
         (*out).len = 0;


### PR DESCRIPTION
Both found by the strings hunt.

**RUE-255** (memory-unsafe): __rue_String_with_capacity stored cap=requested even when heap::alloc returned null on a huge request, so a later push wrote byte 65 through the null pointer (SIGSEGV). All three cfg variants now record cap=0 on null (mirroring __rue_String_clone / string_ensure_capacity); a later push grows fresh. Verified: with_capacity(u64::MAX) reports cap 0, push works, exit 0; with_capacity(16) unchanged.

**RUE-256** (the builtin-String analog of RUE-254): push_str/push/clear/reserve now accept struct-field, array-element (const+dynamic index), and inout-parameter receivers, not just a bare local. Detection uses the HM-resolved type of any place; the receiver is read as a borrow via byref_arg_root; the write-back place is derived from the receiver read so any index is evaluated exactly once. Merged cleanly with RUE-254 (user inout/borrow-self methods) — one receiver-by-ref-root computation now covers both builtin String and user methods. Verified: b.data.push_str gives field len 2; fn f(inout s: String) gives len 4; RUE-254 user inout-self through a param still gives 2. Negative controls still error (E0203/E0428/E0424/E0205).

Full test.sh green; 9 new CLI cases.

Fixes RUE-255
Fixes RUE-256

Generated with Claude Code