### PR TITLE
Fix field-projection-off-temporary double-free + array-typed enum payloads (RUE-258, RUE-260)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1685,9 +1685,18 @@ impl<'a> ConstraintGenerator<'a> {
                     for (i, arg) in args.iter().enumerate() {
                         let arg_info = self.generate(arg.value, ctx);
                         if let Some(&pty) = payload.get(i) {
+                            // Convert the declared payload type structurally so
+                            // an array payload (`[i32; 2]`) unifies with an
+                            // array-literal argument (`[1, 2]`) and propagates
+                            // the expected element type into its literal
+                            // elements — exactly as struct-field init does.
+                            // Using `InferType::Concrete` here left the literal
+                            // element type unconstrained, so `[{integer}; 2]`
+                            // failed to unify with `[i32; 2]` (RUE-260).
+                            let expected = self.type_to_infer(pty);
                             self.add_constraint(Constraint::equal(
                                 arg_info.ty,
-                                InferType::Concrete(pty),
+                                expected,
                                 arg_info.span,
                             ));
                         }

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3187,11 +3187,31 @@ impl<'a> Sema<'a> {
                 field_index: field_index as u32,
             }),
         );
-        let read_ref = air.add_inst(AirInst {
+        let mut value_ref = air.add_inst(AirInst {
             data: AirInstData::PlaceRead { place: place_ref },
             ty: field_type,
             span,
         });
+
+        // Projecting a non-Copy field out of this spilled temporary MOVES it
+        // out of the temporary. The temporary is dropped whole at scope exit
+        // (drop elaboration in rue-cfg), so without a move marker its per-field
+        // drop glue would re-drop the extracted field that the new owner (e.g.
+        // the `let` binding) also drops — a double free (RUE-258). Emit a
+        // field-path MarkMoved on the temp slot, exactly as the named-place
+        // path above does, so the temporary's scope-exit drop skips this field.
+        if !self.is_type_copy(field_type) {
+            value_ref = air.add_inst(AirInst {
+                data: AirInstData::MarkMoved {
+                    value: value_ref,
+                    slot: temp_slot,
+                    is_param: false,
+                    place: Some(place_ref),
+                },
+                ty: field_type,
+                span,
+            });
+        }
 
         // Note: We don't emit StorageDead here. The temporary will be cleaned up by
         // scope-based drop elaboration in the CFG builder. This is slightly conservative
@@ -3202,7 +3222,7 @@ impl<'a> Sema<'a> {
             data: AirInstData::Block {
                 stmts_start,
                 stmts_len: 2,
-                value: read_ref,
+                value: value_ref,
             },
             ty: field_type,
             span,

--- a/crates/rue-cli-tests/cases/enum_array_payload.toml
+++ b/crates/rue-cli-tests/cases/enum_array_payload.toml
@@ -1,0 +1,79 @@
+# Array-typed enum tuple-variant payloads (RUE-260), gated behind the
+# `enum_payloads` preview feature.
+#
+# Before the fix, constructing an enum tuple-variant whose declared payload is
+# an array spuriously failed with E0206: the construction path wrapped the
+# declared payload type as `InferType::Concrete([i32; 2])` instead of
+# converting it structurally, so an array-literal argument (`[1, 2]`, typed
+# `[{integer}; 2]`) never unified against it — and even a struct-element array
+# printed "expected [Guard; 2], found [Guard; 2]" (identical strings) because
+# the integer elements were left undefaulted. The fix converts the declared
+# payload type with `type_to_infer` (structural arrays) exactly as struct-field
+# init does, so array literals unify and integer elements default. A genuinely
+# mismatched payload still reports E0206 / E0901.
+
+[section]
+id = "cli.enum_array_payload"
+name = "Array-typed enum tuple-variant payloads"
+description = "Enum tuple variants may carry array payloads; array literals unify against the declared element type (RUE-260)."
+
+[[case]]
+name = "int_array_payload_constructs_and_round_trips"
+description = "RUE-260: `Wrapper::Has([1, 2])` compiles and the payload round-trips through a match: 10 + 20 = 30."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Wrapper { Has([i32; 2]), None }
+fn main() -> i32 {
+    let w = Wrapper::Has([10, 20]);
+    match w {
+        Wrapper::Has(a) => a[0] + a[1],
+        Wrapper::None => 0,
+    }
+}
+""" }]
+exit_code = 30
+
+[[case]]
+name = "struct_element_array_payload_constructs"
+description = "RUE-260: an array-of-struct payload (`[Guard; 2]`) constructs and round-trips: 1 + 2 = 3."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Guard { v: i32 }
+enum Wrapper { Has([Guard; 2]), None }
+fn main() -> i32 {
+    let w = Wrapper::Has([Guard{v:1}, Guard{v:2}]);
+    match w {
+        Wrapper::Has(a) => a[0].v + a[1].v,
+        Wrapper::None => 0,
+    }
+}
+""" }]
+exit_code = 3
+
+[[case]]
+name = "wrong_element_type_array_payload_rejected"
+description = "RUE-260 control: an array payload with the wrong element type still reports E0206."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Wrapper { Has([i32; 2]), None }
+fn main() -> i32 {
+    let w = Wrapper::Has([true, false]);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206"]
+
+[[case]]
+name = "wrong_length_array_payload_rejected"
+description = "RUE-260 control: an array payload with the wrong length still reports E0901."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Wrapper { Has([i32; 2]), None }
+fn main() -> i32 {
+    let w = Wrapper::Has([1, 2, 3]);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0901"]

--- a/crates/rue-cli-tests/cases/temporary_field_projection_drops.toml
+++ b/crates/rue-cli-tests/cases/temporary_field_projection_drops.toml
@@ -1,0 +1,80 @@
+# Projecting a field out of a TEMPORARY struct value (`(Pair { .. }).a`) moves
+# that field out of the temporary. The temporary is spilled to a hidden slot
+# and dropped whole at scope exit; before RUE-258 was fixed its per-field drop
+# glue re-dropped the extracted field that the `let` binding also drops — a
+# double free (the extracted field's destructor ran TWICE).
+#
+# The fix emits a field-path MarkMoved on the spill temporary, exactly as the
+# named-place field-move path does, so the temporary's scope-exit drop skips
+# the moved-out field. Each destructor now runs exactly once (spec 3.9:2).
+
+[section]
+id = "cli.temporary_field_projection_drops"
+name = "Field projection off a temporary struct drops the extracted field once"
+description = "Moving a field out of an anonymous struct temporary must not double-drop it (RUE-258)."
+
+[[case]]
+name = "temporary_field_projection_drops_once"
+description = "RUE-258 repro: `(Pair { a, b }).a` bound to `x` drops Inner{v:1} exactly once (at `x` exit) and Inner{v:2} exactly once (at temp exit); before the fix stdout was `1 2 999 1` — v=1 dropped twice."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+drop fn Inner(self) { @dbg(self.v); }
+struct Pair { a: Inner, b: Inner }
+fn main() -> i32 {
+    let x = (Pair { a: Inner{v:1}, b: Inner{v:2} }).a;
+    @dbg(999);
+    0
+}
+""" }]
+stdout = "2\n999\n1\n"
+exit_code = 0
+
+[[case]]
+name = "temporary_both_fields_projected_each_drops_once"
+description = "RUE-258: two temporaries, opposite fields extracted; each of the four Inner values drops exactly once."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+drop fn Inner(self) { @dbg(self.v); }
+struct Pair { a: Inner, b: Inner }
+fn main() -> i32 {
+    let x = (Pair { a: Inner{v:1}, b: Inner{v:2} }).a;
+    let y = (Pair { a: Inner{v:3}, b: Inner{v:4} }).b;
+    @dbg(999);
+    0
+}
+""" }]
+stdout = "2\n3\n999\n4\n1\n"
+exit_code = 0
+
+[[case]]
+name = "temporary_copy_field_projection_sibling_drops_once"
+description = "RUE-258 sibling check: extracting a Copy field from a temporary still drops the non-Copy sibling exactly once."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+drop fn Inner(self) { @dbg(self.v); }
+struct Pair { n: i32, b: Inner }
+fn main() -> i32 {
+    let x = (Pair { n: 7, b: Inner{v:2} }).n;
+    @dbg(x);
+    0
+}
+""" }]
+stdout = "2\n7\n"
+exit_code = 0
+
+[[case]]
+name = "named_place_field_move_control_drops_once"
+description = "Control: the analogous field move out of a NAMED place drops each value exactly once (this path already worked; guards against regressing it)."
+files = [{ path = "main.rue", source = """
+struct Inner { v: i32 }
+drop fn Inner(self) { @dbg(self.v); }
+struct Pair { a: Inner, b: Inner }
+fn main() -> i32 {
+    let p = Pair { a: Inner{v:1}, b: Inner{v:2} };
+    let x = p.a;
+    @dbg(999);
+    0
+}
+""" }]
+stdout = "999\n1\n2\n"
+exit_code = 0


### PR DESCRIPTION
Both found by the drops hunt; both rue-air.

**RUE-258 (URGENT, double-free / unsound):** projecting a field out of a TEMPORARY struct ((Pair{...}).a) spilled the struct to a hidden slot but emitted no move marker, so the temporary's whole-value scope-exit drop re-dropped the extracted field — the destructor ran twice (spec 3.9:2 violation). analyze_field_get now emits a field-path MarkMoved on the spill temp when the projected field is non-Copy, reusing the existing backend-agnostic drop-flag machinery. Repro went from 1 2 999 1 (v=1 dropped twice) to each destructor firing exactly once (2, 999, 1); both-fields-moved, copy-sibling, and named-place controls all drop once.

**RUE-260 (array-typed enum payload rejected E0206):** the enum tuple-variant constraint wrapped the declared payload type as InferType::Concrete instead of structurally, so array literals never unified (even when both sides printed the identical type). Now uses type_to_infer(pty) like struct-field init. Wrapper::Has([1,2]) and struct-element [Guard;2] compile and round-trip; wrong-element / wrong-length still error.

Verified: full test.sh green; oracle-diff fuzzer 0 disagreements over 300 seeds (debug) + 200 (release); aarch64 --emit asm clean. 8 new CLI cases.

Fixes RUE-258
Fixes RUE-260

Generated with Claude Code