### PR TITLE
for-loops iterate by shared borrow: non-Copy elements, per-element drop, mutation-exclusivity (RUE-259, RUE-257, RUE-233)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -658,6 +658,7 @@ impl<'a> ConstraintGenerator<'a> {
                 is_mut,
                 ty: type_annotation,
                 init,
+                iter_elem: _,
             } => {
                 let init_info = self.generate(*init, ctx);
 

--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -390,6 +390,12 @@ pub struct Air {
     /// (see [`AirInstData::MarkMoved`]). Empty for destructors (a destructor
     /// must not re-drop `self`) and for synthesized drop-glue functions.
     param_drops: Vec<(u32, Type)>,
+    /// Local slots that hold a non-owning *borrow* value and so must NOT be
+    /// dropped at scope exit. Currently the element binder of a `for` loop
+    /// over a non-Copy collection: iteration is a shared read (spec 4.8:26),
+    /// so the binder aliases an element the collection still owns and drops —
+    /// dropping the binder too would double-free (RUE-259).
+    borrow_slots: Vec<u32>,
 }
 
 impl Air {
@@ -402,7 +408,22 @@ impl Air {
             projections: Vec::new(),
             places: Vec::new(),
             param_drops: Vec::new(),
+            borrow_slots: Vec::new(),
         }
+    }
+
+    /// Record a local slot as a non-owning borrow binding (see `borrow_slots`).
+    pub fn add_borrow_slot(&mut self, slot: u32) {
+        if !self.borrow_slots.contains(&slot) {
+            self.borrow_slots.push(slot);
+        }
+    }
+
+    /// True when `slot` holds a non-owning borrow value that drop elaboration
+    /// must not drop (see `borrow_slots`).
+    #[inline]
+    pub fn is_borrow_slot(&self, slot: u32) -> bool {
+        self.borrow_slots.contains(&slot)
     }
 
     /// Add an instruction and return its reference.

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1077,7 +1077,7 @@ pub(crate) fn linear_not_consumed_error(
 /// Extract the root variable symbol from an expression, if it refers to a
 /// variable. Canonical, pipeline-agnostic implementation; see
 /// [`Sema::extract_root_variable`] for the full contract.
-fn root_variable_of(rir: &Rir, inst_ref: InstRef) -> Option<Spur> {
+pub(crate) fn root_variable_of(rir: &Rir, inst_ref: InstRef) -> Option<Spur> {
     let inst = rir.get(inst_ref);
     match &inst.data {
         InstData::VarRef { name } => Some(*name),
@@ -3256,6 +3256,14 @@ impl<'a> Sema<'a> {
                 ));
             };
 
+            // Calling an `inout self` method on a collection an enclosing
+            // `for` loop is iterating mutates a shared-borrowed value (spec
+            // 4.8:26, RUE-257) — E0428. A `borrow self` method only reads it,
+            // which coexists with the loop's shared borrow, so it is allowed.
+            if receiver_mode == AirArgMode::Inout {
+                self.reject_mutate_iter_borrowed(receiver_root, span, ctx)?;
+            }
+
             // `inout self` requires a mutable receiver binding (spec 6, reuses
             // E0203), mirroring Rust. `borrow self` works on any binding.
             if receiver_mode == AirArgMode::Inout
@@ -5239,6 +5247,12 @@ impl<'a> Sema<'a> {
         let Some(root) = receiver_var else {
             return Err(CompileError::new(ErrorKind::InvalidAssignmentTarget, span));
         };
+
+        // A builtin mutation method takes the receiver by `inout`, so calling
+        // one on a collection an enclosing `for` loop is iterating mutates a
+        // shared-borrowed value (spec 4.8:26, RUE-257) — E0428, exactly like a
+        // direct `a[i] = …` or reassignment inside the body.
+        self.reject_mutate_iter_borrowed(root, span, ctx)?;
 
         // Root parameter: only `inout` names mutable caller storage.
         if let Some(param) = ctx.params.iter().find(|p| p.name == root) {

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1934,6 +1934,7 @@ impl<'a> Sema<'a> {
                 is_mut,
                 ty,
                 init,
+                iter_elem,
             } => self.analyze_alloc(
                 air,
                 *directives_start,
@@ -1942,6 +1943,7 @@ impl<'a> Sema<'a> {
                 *is_mut,
                 *ty,
                 *init,
+                *iter_elem,
                 inst.span,
                 ctx,
             ),
@@ -1976,6 +1978,7 @@ impl<'a> Sema<'a> {
         is_mut: bool,
         ty: Option<Spur>,
         init: InstRef,
+        iter_elem: bool,
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
@@ -1993,8 +1996,22 @@ impl<'a> Sema<'a> {
             }
         }
 
-        // Analyze the initializer
-        let init_result = self.analyze_inst(air, init, ctx)?;
+        // Analyze the initializer. A `for`-loop element binding is a shared
+        // read of the collection (spec 4.8:26): analyze the element read under
+        // `byref_arg_root` so it borrows the element in place rather than
+        // moving it out — a non-Copy element is then read, not consumed
+        // (RUE-259), exactly as a `borrow`-mode argument would be. The root is
+        // the collection variable (`a` in `a[__p]`); a `.chars()` scalar read
+        // has no place root, so this is a no-op there.
+        let init_result = if iter_elem {
+            let byref_root = super::analysis::root_variable_of(self.rir, init);
+            let prev = std::mem::replace(&mut ctx.byref_arg_root, byref_root);
+            let r = self.analyze_inst(air, init, ctx);
+            ctx.byref_arg_root = prev;
+            r?
+        } else {
+            self.analyze_inst(air, init, ctx)?
+        };
         let var_type = init_result.ty;
 
         // If name is None, this is a wildcard pattern `_` that discards the value.
@@ -2049,6 +2066,15 @@ impl<'a> Sema<'a> {
         let slot = ctx.next_slot;
         let num_slots = self.abi_slot_count(var_type);
         ctx.next_slot += num_slots;
+
+        // A `for`-loop element binder over a NON-Copy collection aliases an
+        // element the collection still owns and drops (spec 4.8:26): mark its
+        // slot as a non-owning borrow so drop elaboration does not drop it too
+        // (which would double-free the element, RUE-259). A Copy binder owns a
+        // trivially-droppable copy, so it needs no marker.
+        if iter_elem && !self.is_type_copy(var_type) {
+            air.add_borrow_slot(slot);
+        }
 
         // Register the variable
         ctx.insert_local(
@@ -2231,6 +2257,20 @@ impl<'a> Sema<'a> {
             // If type is not Copy, mark as moved — unless this use is a by-ref
             // call argument, which borrows the variable rather than moving it.
             let moves_out = !self.is_type_copy(ty) && ctx.byref_arg_root != Some(name);
+            // A `for`-loop element binder over a non-Copy collection is a
+            // non-owning shared borrow of an element the collection still owns
+            // (spec 4.8:26): reading it is fine, but moving it out would let
+            // the new owner AND the collection both drop the element
+            // (double-free), so a move is rejected like moving out of a
+            // `borrow` parameter (RUE-259).
+            if moves_out && air.is_borrow_slot(slot) {
+                return Err(CompileError::new(
+                    ErrorKind::MoveOutOfBorrow {
+                        variable: name_str.to_string(),
+                    },
+                    span,
+                ));
+            }
             if moves_out {
                 ctx.moved_vars
                     .entry(name)
@@ -2996,6 +3036,24 @@ impl<'a> Sema<'a> {
             // rejections don't apply — but reading through an already-moved
             // path is still a use-after-move.
             let is_byref_arg_use = ctx.byref_arg_root == Some(trace.root_var);
+
+            // Moving a (non-Copy) field or the whole value out of a `for`-loop
+            // element binder over a non-Copy collection would let the new owner
+            // AND the collection both drop it (double-free): iteration is a
+            // shared read (spec 4.8:26), so the binder may be read but not
+            // moved out, whole-value or field-granular (RUE-259).
+            if !is_byref_arg_use
+                && (is_linear || !self.is_type_copy(field_type))
+                && matches!(trace.base, AirPlaceBase::Local(s) if air.is_borrow_slot(s))
+            {
+                return Err(CompileError::new(
+                    ErrorKind::MoveOutOfBorrow {
+                        variable: self.interner.resolve(&trace.root_var).to_string(),
+                    },
+                    span,
+                ));
+            }
+
             let mut emit_move_marker = false;
             let mut move_is_partial = false;
             if is_byref_arg_use {

--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -2751,9 +2751,15 @@ impl<'a> CfgBuilder<'a> {
     /// is still emitted to end the slot's storage lifetime. A struct slot
     /// with moved-out FIELDS is dropped field-granularly instead (RUE-62).
     fn emit_drop_for_slot(&mut self, live_slot: &LiveSlot, span: rue_span::Span) {
-        // Emit Drop if the type needs it and the value wasn't moved out
+        // A `for`-loop element binder over a non-Copy collection is a
+        // non-owning borrow (spec 4.8:26): it aliases an element the collection
+        // still owns and drops, so dropping it here would double-free
+        // (RUE-259). Its storage still ends normally (StorageDead below).
         let key = MovedSlot::Local(live_slot.slot);
-        if !self.moved.is_slot_moved(key) && self.type_needs_drop(live_slot.ty) {
+        if !self.air.is_borrow_slot(live_slot.slot)
+            && !self.moved.is_slot_moved(key)
+            && self.type_needs_drop(live_slot.ty)
+        {
             let (slot, ty) = (live_slot.slot, live_slot.ty);
             self.emit_guarded(key, span, |b| {
                 // Fast path: nothing partially moved — drop the whole value.

--- a/crates/rue-cli-tests/cases/for_loop_iter_borrow.toml
+++ b/crates/rue-cli-tests/cases/for_loop_iter_borrow.toml
@@ -1,17 +1,23 @@
-# A `for` loop over a named variable holds a scoped shared borrow of the
-# collection for the loop's duration (spec 4.8:26, RUE-233). Mutating the
-# iterated collection inside the body used to be silently accepted and affected
-# later iterations (`for x in a { a[2] = 100; }` exited 103, not 6). The
-# implicit borrow now participates in exclusivity checking: mutating the
-# iterated place — element (`a[i]=`), whole variable (`a=`), or field — inside
-# the body is E0428 (`MutateBorrowedValue`), just like an explicit `borrow`
-# parameter. Iterating a different collection, and read-only iteration, still
-# compile.
+# A `for` loop is a shared borrow of the collection for the loop's duration
+# (spec 4.8:26, RUE-233/RUE-257/RUE-259 — one root: the loop desugared to a
+# move-out instead of the shared borrow the spec mandates). Three faces:
+#
+#  * RUE-233: mutating the iterated place — element (`a[i]=`), whole variable
+#    (`a=`), or field — inside the body is E0428 (`MutateBorrowedValue`), like
+#    an explicit `borrow` parameter (used to be silently accepted).
+#  * RUE-257: mutating the collection through an `inout self` method (String
+#    `.clear()`/`.push()`) inside the body is E0428 too — previously a runtime
+#    miscompile (a spurious `invalid UTF-8` / out-of-bounds trap).
+#  * RUE-259: a NON-Copy element type is bound by shared borrow, not moved out
+#    of the collection — the loop compiles (used to be E0904), the array drops
+#    each element exactly once, and moving the binder out is rejected.
+#
+# Iterating a different collection, and read-only iteration, still compile.
 
 [section]
 id = "cli.for_loop_iter_borrow"
 name = "For-loop iterable borrow-check"
-description = "Mutating the iterated collection inside a `for` body is E0428 (RUE-233)."
+description = "A `for` loop is a shared borrow: non-Copy elements iterate without moving, per-element destructors run once, mutating the collection mid-loop is E0428 (RUE-233/257/259)."
 
 [[case]]
 name = "mutate_iterated_element_is_e0428"
@@ -82,3 +88,131 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 6
+
+# --- RUE-259: non-Copy element type iterates by shared borrow -----------------
+
+[[case]]
+name = "non_copy_element_iterates"
+description = "RUE-259: a non-Copy struct element iterates by shared borrow (was wrongly E0904); sums to 4."
+args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let a = [Point { x: 1, y: 2 }, Point { x: 3, y: 4 }];
+    let mut sum = 0;
+    for p in a {
+        sum = sum + p.x;
+    }
+    sum
+}
+""" }]
+exit_code = 4
+
+[[case]]
+name = "non_copy_element_destructor_runs_once"
+description = "RUE-259: the array (not the loop binder) drops each element once — destructor fires exactly once per element."
+args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Res { tag: i32 }
+drop fn Res(self) { @dbg(self.tag); }
+fn main() -> i32 {
+    let a = [Res { tag: 11 }, Res { tag: 22 }];
+    let mut total = 0;
+    for r in a {
+        total = total + r.tag;
+    }
+    total
+}
+""" }]
+stdout = "11\n22\n"
+exit_code = 33
+
+[[case]]
+name = "non_copy_wildcard_binder_destructor_once"
+description = "RUE-259: `for _ in a` over a drop-bearing element also borrows (not discards) it — the array drops each element once, not twice."
+args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Res { tag: i32 }
+drop fn Res(self) { @dbg(self.tag); }
+fn main() -> i32 {
+    let a = [Res { tag: 7 }, Res { tag: 8 }];
+    let mut n = 0;
+    for _ in a {
+        n = n + 1;
+    }
+    n
+}
+""" }]
+stdout = "7\n8\n"
+exit_code = 2
+
+[[case]]
+name = "move_element_out_is_error"
+description = "RUE-259: moving the binder out of the loop would double-drop — rejected (cannot move out of borrowed value)."
+args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["cannot move out of borrowed value"]
+files = [{ path = "main.rue", source = """
+struct Res { tag: i32 }
+drop fn Res(self) { @dbg(self.tag); }
+fn eat(r: Res) -> i32 { r.tag }
+fn main() -> i32 {
+    let a = [Res { tag: 1 }, Res { tag: 2 }];
+    let mut s = 0;
+    for r in a {
+        s = s + eat(r);
+    }
+    s
+}
+""" }]
+
+# --- RUE-257: mutating the collection via an inout-self method ----------------
+
+[[case]]
+name = "mutate_via_method_in_chars_loop_is_e0428"
+description = "RUE-257: `s.clear()` inside `for c in s.chars()` mutates a shared-borrowed String (E0428), not a runtime UTF-8 trap."
+args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0428"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut s = "abc".clone();
+    for c in s.chars() {
+        s.clear();
+        @dbg(c);
+    }
+    0
+}
+""" }]
+
+[[case]]
+name = "mutate_via_method_in_byte_loop_is_e0428"
+description = "RUE-257: `s.clear()` inside `for b in s` (byte view) is E0428, not an out-of-bounds trap."
+args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0428"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut s = "abc".clone();
+    for b in s {
+        s.clear();
+    }
+    0
+}
+""" }]
+
+[[case]]
+name = "read_collection_elsewhere_in_body_is_fine"
+description = "Control: reading (not mutating) the iterated array elsewhere in the body is a shared+shared read — fine."
+args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a = [1, 2, 3];
+    let mut sum = 0;
+    for x in a {
+        sum = sum + x + a[0];
+    }
+    sum
+}
+""" }]
+exit_code = 9

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -1043,6 +1043,7 @@ impl<'a> AstGen<'a> {
                     is_mut: false,
                     ty: None,
                     init,
+                    iter_elem: false,
                 },
                 span,
             });
@@ -1066,6 +1067,7 @@ impl<'a> AstGen<'a> {
                 is_mut: true,
                 ty: Some(u64_sym),
                 init: zero,
+                iter_elem: false,
             },
             span,
         });
@@ -1096,6 +1098,7 @@ impl<'a> AstGen<'a> {
                 is_mut: false,
                 ty: Some(u64_sym),
                 init: len_call,
+                iter_elem: false,
             },
             span,
         });
@@ -1135,9 +1138,17 @@ impl<'a> AstGen<'a> {
         body_stmts.push(end_branch.as_u32());
 
         // let <binder> = <get>;
+        // A `_` binder still binds a (named, underscore-prefixed so it never
+        // warns unused) local rather than a discarding `let _`: the element is
+        // a shared borrow of the collection (spec 4.8:26), not a value being
+        // discarded, so it must NOT go through the discard path — which would
+        // drop the borrowed element as a temporary and double-free it (the
+        // collection still owns and drops it, RUE-259).
         let binder_name: Option<Spur> = match &for_expr.binder {
             LetPattern::Ident(id) => Some(id.name),
-            LetPattern::Wildcard(_) => None,
+            LetPattern::Wildcard(_) => {
+                Some(self.interner.get_or_intern(format!("_rue_for_elem_{n}")))
+            }
         };
         let p_for_get = self.rir.add_inst(Inst {
             data: InstData::VarRef { name: p_name },
@@ -1176,6 +1187,11 @@ impl<'a> AstGen<'a> {
                 is_mut: false,
                 ty: None,
                 init: get_inst,
+                // The element binding is a shared read of the collection
+                // (spec 4.8:26): analyzed as a by-ref read so a non-Copy
+                // element is not moved out (RUE-259), and a non-Copy binder is
+                // a non-owning borrow slot the collection still drops.
+                iter_elem: true,
             },
             span,
         });
@@ -1293,6 +1309,7 @@ impl<'a> AstGen<'a> {
                         is_mut: let_stmt.is_mut,
                         ty,
                         init,
+                        iter_elem: false,
                     },
                     span: let_stmt.span,
                 })

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -871,6 +871,7 @@ impl Rir {
                 is_mut,
                 ty,
                 init,
+                iter_elem,
             } => InstData::Alloc {
                 directives_start: *directives_start + extra_offset,
                 directives_len: *directives_len,
@@ -878,6 +879,7 @@ impl Rir {
                 is_mut: *is_mut,
                 ty: *ty,
                 init: renumber(*init),
+                iter_elem: *iter_elem,
             },
             InstData::Assign { name, value } => InstData::Assign {
                 name: *name,
@@ -1566,6 +1568,13 @@ pub enum InstData {
         ty: Option<Spur>,
         /// Initial value instruction
         init: InstRef,
+        /// True when this binding is a `for`-loop element binding, which reads
+        /// the element by shared borrow (spec 4.8:26): the initializer is
+        /// analyzed as a by-ref read (never a move-out of the collection, so a
+        /// non-Copy element is fine, RUE-259) and a non-Copy binder is a
+        /// non-owning borrow slot that drop elaboration must not drop (the
+        /// collection retains ownership and drops the element).
+        iter_elem: bool,
     },
 
     /// Variable reference: reads the value of a variable
@@ -2076,6 +2085,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     is_mut,
                     ty,
                     init,
+                    iter_elem: _,
                 } => {
                     let name_str = name
                         .map(|n| self.interner.resolve(&n).to_string())
@@ -3165,6 +3175,7 @@ mod tests {
                 is_mut: false,
                 ty: Some(ty),
                 init,
+                iter_elem: false,
             },
             span: Span::new(0, 15),
         });
@@ -3194,6 +3205,7 @@ mod tests {
                 is_mut: true,
                 ty: None,
                 init,
+                iter_elem: false,
             },
             span: Span::new(0, 15),
         });
@@ -3221,6 +3233,7 @@ mod tests {
                 is_mut: false,
                 ty: None,
                 init,
+                iter_elem: false,
             },
             span: Span::new(0, 10),
         });

--- a/crates/rue-spec/cases/expressions/for.toml
+++ b/crates/rue-spec/cases/expressions/for.toml
@@ -28,6 +28,92 @@ fn main() -> i32 {
 """
 exit_code = 60
 
+# Iteration is a shared read (4.8:26): a non-Copy element type is bound by
+# shared borrow, NOT moved out of the array, so the loop compiles and reads
+# fields fine (RUE-259 — previously wrongly rejected E0904 "cannot move out of
+# indexed position").
+[[case]]
+name = "for_array_non_copy_element"
+spec = ["4.8:25", "4.8:26"]
+preview = "for_loops"
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let a = [Point { x: 1, y: 2 }, Point { x: 3, y: 4 }];
+    let mut sum = 0;
+    for p in a {
+        sum = sum + p.x;
+    }
+    sum
+}
+"""
+exit_code = 4
+
+# Because the element is borrowed (not moved out), the ARRAY still owns each
+# element and drops it exactly once at scope exit — the per-element destructor
+# runs once per element, driven by the array, not the loop binder (RUE-259).
+[[case]]
+name = "for_array_non_copy_destructor_once"
+spec = ["4.8:26"]
+preview = "for_loops"
+source = """
+struct Res { tag: i32 }
+drop fn Res(self) { @dbg(self.tag); }
+fn main() -> i32 {
+    let a = [Res { tag: 11 }, Res { tag: 22 }];
+    let mut total = 0;
+    for r in a {
+        total = total + r.tag;
+    }
+    total
+}
+"""
+exit_code = 33
+expected_stdout = "11\n22\n"
+
+# The element binding is a shared borrow: it may be read but not moved out of
+# the collection (that would double-drop — the new owner and the array would
+# both drop it). Moving the whole binder is rejected (RUE-259).
+[[case]]
+name = "for_move_element_out_error"
+spec = ["4.8:26"]
+preview = "for_loops"
+source = """
+struct Res { tag: i32 }
+drop fn Res(self) { @dbg(self.tag); }
+fn eat(r: Res) -> i32 { r.tag }
+fn main() -> i32 {
+    let a = [Res { tag: 1 }, Res { tag: 2 }];
+    let mut s = 0;
+    for r in a {
+        s = s + eat(r);
+    }
+    s
+}
+"""
+compile_fail = true
+error_contains = "cannot move out of borrowed value"
+
+# Iteration holds a shared borrow of the collection for the loop's duration, so
+# mutating it in the body — here via an `inout self` String method — is a
+# compile-time exclusivity error, not a runtime miscompile (RUE-257).
+[[case]]
+name = "for_mutate_collection_in_body_error"
+spec = ["4.8:26"]
+preview = "for_loops"
+source = """
+fn main() -> i32 {
+    let mut s = "abc".clone();
+    for c in s.chars() {
+        s.clear();
+        @dbg(c);
+    }
+    0
+}
+"""
+compile_fail = true
+error_contains = "cannot mutate borrowed value"
+
 # The collection is borrowed for the loop, not consumed: a String iterated in a
 # `for` stays usable afterward (a second loop would be a use-after-move if the
 # first had moved it).


### PR DESCRIPTION
One root, three symptoms: 'for' desugared its element binding to a move-out of a non-const indexed position instead of the shared borrow spec 4.8:26 mandates ('Iteration is a shared read... elements are not moved out of it').

Mechanism: a RIR Alloc.iter_elem marker tells sema to analyze the element read as a by-ref BORROW and record a non-owning Air::borrow_slots entry; CFG drop elaboration then skips it (no double-free). Moving the binder out (whole or a field) is E0429; a _ binder binds an underscore-named borrow local (fixed a wildcard double-drop found inline). The collection is held as a live shared borrow for the loop body, so mutating it in the body is an exclusivity error.

- **RUE-259**: a non-Copy element (struct) now iterates by shared borrow (was E0904) — compiles, sums to 4; a per-element DESTRUCTOR runs exactly once per element (11, 22 -> total 33). Iterating drop-bearing structs was impossible before.
- **RUE-257**: s.clear() inside for c in s.chars() is now a clean E0428 compile error (was a spurious runtime UTF-8 trap); byte-view variant too.
- **RUE-233**: mutating the iterated array in the body stays E0428; extended to inout-self methods with regression tests.

Reused E0428/E0429 (no new codes). Verified by execution + full test.sh green; differential fuzzer 300 seeds 0 disagreements; aarch64 --emit asm clean. Unblocks real for-loops over structs + RUE-17 chars_lossy.

Fixes RUE-259
Fixes RUE-257
Fixes RUE-233

Generated with Claude Code