### PR TITLE
Harden three compiler-crash ICEs into clean diagnostics (RUE-261, RUE-264, RUE-265)

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -3537,6 +3537,36 @@ impl<'a> Sema<'a> {
         }
     }
 
+    /// Reject an array element (of a literal or a repeat) whose type has no
+    /// runtime representation, before it can reach the intern pool — which
+    /// panics on both `type` values and modules (intern_pool.rs, RUE-253,
+    /// RUE-265).
+    ///
+    /// - A `type` value is comptime-only (spec 4.14:6): E1200, matching the
+    ///   diagnostic `let t = comptime { i32 };` gets.
+    /// - A module is not a runtime value (spec 10.4:145): E0206, matching the
+    ///   diagnostic a module passed as a function argument gets.
+    fn reject_non_runtime_array_element(&self, elem_ty: Type, span: Span) -> CompileResult<()> {
+        if elem_ty == Type::COMPTIME_TYPE {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: "type values cannot exist at runtime".to_string(),
+                },
+                span,
+            ));
+        }
+        if matches!(elem_ty.kind(), TypeKind::Module(_)) {
+            return Err(CompileError::new(
+                ErrorKind::TypeMismatch {
+                    expected: "a runtime value".to_string(),
+                    found: elem_ty.safe_name_with_pool(Some(&self.type_pool)),
+                },
+                span,
+            ));
+        }
+        Ok(())
+    }
+
     /// Analyze an array initialization.
     fn analyze_array_init(
         &mut self,
@@ -3556,13 +3586,8 @@ impl<'a> Sema<'a> {
         // the comptime-only `type`, would reach the intern pool and panic
         // (RUE-253).
         for elem_ref in &elem_refs {
-            if ctx.resolved_types.get(elem_ref).copied() == Some(Type::COMPTIME_TYPE) {
-                return Err(CompileError::new(
-                    ErrorKind::ComptimeEvaluationFailed {
-                        reason: "type values cannot exist at runtime".to_string(),
-                    },
-                    span,
-                ));
+            if let Some(elem_ty) = ctx.resolved_types.get(elem_ref).copied() {
+                self.reject_non_runtime_array_element(elem_ty, span)?;
             }
         }
 
@@ -3663,17 +3688,13 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // A repeat literal of a `type` value (`[i32; 2]`) has no runtime
-        // representation (spec 4.14:6). Reject it with E1200 — before the
-        // preview gate below and before the comptime-only element type would
-        // reach the intern pool and panic (RUE-253).
-        if ctx.resolved_types.get(&value_ref).copied() == Some(Type::COMPTIME_TYPE) {
-            return Err(CompileError::new(
-                ErrorKind::ComptimeEvaluationFailed {
-                    reason: "type values cannot exist at runtime".to_string(),
-                },
-                span,
-            ));
+        // A repeat literal of a non-runtime value — a `type` value (`[i32; 2]`,
+        // spec 4.14:6) or a module (`[@import("m"); 2]`, spec 10.4:145) — has no
+        // runtime representation. Reject it (E1200 / E0206) before the preview
+        // gate below and before the comptime-only/module element type would
+        // reach the intern pool and panic (RUE-253, RUE-265).
+        if let Some(value_ty) = ctx.resolved_types.get(&value_ref).copied() {
+            self.reject_non_runtime_array_element(value_ty, span)?;
         }
 
         // Gate the whole form: without `--preview array_repeat`, using
@@ -4419,9 +4440,14 @@ impl<'a> Sema<'a> {
                     _ => {}
                 }
             }
-            // Try to evaluate the function body at compile time
+            // Try to evaluate the function body at compile time. A hard error
+            // raised while reducing the constructor (e.g. an unbounded
+            // self-recursive `-> type` function exceeding the comptime depth
+            // limit, RUE-261) must surface as its real diagnostic (E1200)
+            // rather than being swallowed into a downstream link error, so use
+            // the propagating reduction entry point.
             if let Some(ConstValue::Type(ty)) =
-                self.try_evaluate_const_with_subst(fn_body, &type_subst, &value_subst)
+                self.eval_type_constructor_body(fn_body, &type_subst, &value_subst)?
             {
                 // Success! Return a TypeConst instruction instead of a runtime call
                 let air_ref = air.add_inst(AirInst {

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -56,6 +56,7 @@ use rue_span::Span;
 
 use super::Sema;
 use super::context::{AnalysisContext, ConstValue, LocalVar};
+use crate::specialize::MAX_SPECIALIZATION_ROUNDS;
 use crate::types::{StructField, Type};
 
 /// Empty type substitution map for evaluation contexts without one.
@@ -211,6 +212,28 @@ impl Sema<'_> {
     ) -> Option<ConstValue> {
         let mut env = ComptimeEnv::with_subst(type_subst, value_subst);
         self.eval_const_expr(inst_ref, &mut env).ok().flatten()
+    }
+
+    /// Like [`try_evaluate_const_with_subst`], but *propagates* a hard
+    /// diagnostic raised while reducing the body instead of swallowing it.
+    ///
+    /// Reducing a `-> type` constructor body may legitimately be non-evaluable
+    /// (`Ok(None)` — defer to a runtime call) or raise a genuine compile error
+    /// (`Err` — e.g. an arithmetic overflow, a privacy violation, or exceeding
+    /// the comptime-recursion depth limit for a non-terminating type
+    /// constructor, RUE-261). The type-constructor reduction site uses this so
+    /// the latter surfaces as its real diagnostic (E1200) rather than being
+    /// swallowed and mis-reported as a downstream link error.
+    ///
+    /// [`try_evaluate_const_with_subst`]: Sema::try_evaluate_const_with_subst
+    pub(crate) fn eval_type_constructor_body(
+        &mut self,
+        inst_ref: InstRef,
+        type_subst: &HashMap<Spur, Type>,
+        value_subst: &HashMap<Spur, ConstValue>,
+    ) -> CompileResult<Option<ConstValue>> {
+        let mut env = ComptimeEnv::with_subst(type_subst, value_subst);
+        self.eval_const_expr(inst_ref, &mut env)
     }
 
     /// Try to extract a constant integer value from an RIR index expression.
@@ -933,6 +956,7 @@ impl Sema<'_> {
             return Ok(None);
         }
         let fn_body = fn_info.body;
+        let fn_span = fn_info.span;
         let params = fn_info.params;
         let param_names = self.param_arena.names(params).to_vec();
         let param_comptime = self.param_arena.comptime(params).to_vec();
@@ -967,8 +991,35 @@ impl Sema<'_> {
         // The callee body sees only its own parameters. Evaluate it directly
         // (rather than via the error-swallowing `try_*` wrapper) so a
         // diagnostic raised inside the constructor propagates.
+        //
+        // Guard the reduction against unbounded self-recursion. A `-> type`
+        // function reduces eagerly on the host stack, so a constructor with no
+        // compile-time-known base case (`fn Bad() -> type { Bad() }`,
+        // `fn Wrap(comptime n: i32) -> type { Wrap(n + 1) }`) would overflow
+        // that stack and abort the compiler (SIGABRT) with no diagnostic. Cap
+        // the depth at the same bound the specialization pass uses for value
+        // recursion, emitting the identical E1200 (RUE-261, spec 4.14:18).
         let mut callee_env = ComptimeEnv::with_subst(&callee_types, &callee_values);
-        self.eval_const_expr(fn_body, &mut callee_env)
+        self.comptime_type_call_depth += 1;
+        if self.comptime_type_call_depth > MAX_SPECIALIZATION_ROUNDS {
+            self.comptime_type_call_depth -= 1;
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: format!(
+                        "specialization of '{}' exceeded the maximum nesting depth ({}); \
+                         is a comptime-recursive function missing a compile-time-known \
+                         base case, or a generic function recursively instantiating \
+                         itself with new types?",
+                        self.interner.resolve(&name),
+                        MAX_SPECIALIZATION_ROUNDS
+                    ),
+                },
+                fn_span,
+            ));
+        }
+        let result = self.eval_const_expr(fn_body, &mut callee_env);
+        self.comptime_type_call_depth -= 1;
+        result
     }
 
     /// Pre-resolve `let`-bound compile-time type aliases in a function body,

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -21,7 +21,17 @@ use rue_span::{FileId, Span};
 
 use super::{ConstInfo, ConstValue, FunctionInfo, InferenceContext, MethodInfo, Sema};
 use crate::inference::{FunctionSig, MethodSig};
-use crate::types::{EnumDef, StructDef, StructField, StructId, Type};
+use crate::types::{EnumDef, EnumId, StructDef, StructField, StructId, Type, TypeKind};
+
+/// A node in the "contains by value" type graph, used by
+/// [`Sema::check_recursive_value_types`] to detect infinite-size cycles
+/// (RUE-264). Only aggregate types (struct, enum) can participate in such a
+/// cycle; the array element is followed transitively but is not itself a node.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum TypeNode {
+    Struct(StructId),
+    Enum(EnumId),
+}
 
 impl<'a> Sema<'a> {
     /// Build an `InferenceContext` from the collected type information.
@@ -452,6 +462,11 @@ impl<'a> Sema<'a> {
     pub(crate) fn resolve_declarations(&mut self) -> CompileResult<()> {
         self.resolve_struct_fields()?;
         self.resolve_enum_payloads()?;
+        // Reject infinite-size types now that every struct field and enum
+        // payload is resolved, before any later pass (layout, drop-glue)
+        // recurses through the field graph and overflows the host stack
+        // (RUE-264).
+        self.check_recursive_value_types()?;
         self.propagate_field_linearity();
         self.resolve_remaining_declarations()?;
         // Now that value constants are separated from module bindings, reject
@@ -656,6 +671,116 @@ impl<'a> Sema<'a> {
             }
         }
         Ok(())
+    }
+
+    /// Reject types whose size is infinite because they contain themselves by
+    /// value (RUE-264). A well-formed type must have a finite layout: a struct
+    /// field, enum payload, or array element stores its value *inline*, so a
+    /// type that transitively contains itself through only such by-value edges
+    /// has no finite size. Such a definition would otherwise recurse forever in
+    /// layout / drop-glue computation and overflow the compiler's own stack
+    /// (a SIGABRT that even bypasses the ICE panic-hook). This is the
+    /// type-graph analogue of the constant-initializer cycle check (E0461):
+    /// it detects a cycle in the "contains by value" graph and reports E0483
+    /// (cf. Rust's E0072).
+    ///
+    /// A pointer field (`ptr const T` / `ptr mut T`) is indirection, not
+    /// by-value containment, so it breaks the cycle and is allowed — that is
+    /// how a recursive data structure is written.
+    pub(crate) fn check_recursive_value_types(&self) -> CompileResult<()> {
+        // Drive from each user-declared struct/enum so the diagnostic points at
+        // the offending declaration (the RIR carries the span; the type pool
+        // does not).
+        for (_, inst) in self.rir.iter() {
+            let (name_sym, span) = match &inst.data {
+                InstData::StructDecl { name, .. } | InstData::EnumDecl { name, .. } => {
+                    (*name, inst.span)
+                }
+                _ => continue,
+            };
+            let start_ty = if let Some(&struct_id) = self.structs.get(&name_sym) {
+                Type::new_struct(struct_id)
+            } else if let Some(&enum_id) = self.enums.get(&name_sym) {
+                Type::new_enum(enum_id)
+            } else {
+                continue;
+            };
+
+            let mut on_path: HashSet<TypeNode> = HashSet::new();
+            let mut path: Vec<String> = Vec::new();
+            if let Some(cycle) = self.find_value_cycle(start_ty, &mut on_path, &mut path) {
+                let name = self.interner.resolve(&name_sym).to_string();
+                return Err(CompileError::new(
+                    ErrorKind::RecursiveTypeInfiniteSize {
+                        name,
+                        cycle: cycle.join(" -> "),
+                    },
+                    span,
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Depth-first search for a by-value containment cycle in the type graph,
+    /// mirroring the traversal `drop_glue::type_needs_drop` performs (structs
+    /// recurse through fields, enums through variant payloads, arrays through
+    /// the element type; pointers and scalars terminate). Returns the cyclic
+    /// containment path (as type names) if `ty` transitively contains a struct
+    /// or enum already on the current path.
+    fn find_value_cycle(
+        &self,
+        ty: Type,
+        on_path: &mut HashSet<TypeNode>,
+        path: &mut Vec<String>,
+    ) -> Option<Vec<String>> {
+        match ty.kind() {
+            TypeKind::Struct(id) => {
+                let def = self.type_pool.struct_def(id);
+                if !on_path.insert(TypeNode::Struct(id)) {
+                    // Back-edge: this struct is already on the current path.
+                    let mut cycle = path.clone();
+                    cycle.push(def.name.clone());
+                    return Some(cycle);
+                }
+                path.push(def.name.clone());
+                for field in &def.fields {
+                    if let Some(cycle) = self.find_value_cycle(field.ty, on_path, path) {
+                        return Some(cycle);
+                    }
+                }
+                path.pop();
+                on_path.remove(&TypeNode::Struct(id));
+                None
+            }
+            TypeKind::Enum(id) => {
+                let def = self.type_pool.enum_def(id);
+                if !on_path.insert(TypeNode::Enum(id)) {
+                    let mut cycle = path.clone();
+                    cycle.push(def.name.clone());
+                    return Some(cycle);
+                }
+                path.push(def.name.clone());
+                for payload_ty in def.variant_payloads.iter().flatten() {
+                    if let Some(cycle) = self.find_value_cycle(*payload_ty, on_path, path) {
+                        return Some(cycle);
+                    }
+                }
+                path.pop();
+                on_path.remove(&TypeNode::Enum(id));
+                None
+            }
+            // An array stores its elements inline, so a by-value cycle can run
+            // through the element type (`struct A { a: [A; 1] }`).
+            TypeKind::Array(array_id) => {
+                let (element_ty, _length) = self.type_pool.array_def(array_id);
+                self.find_value_cycle(element_ty, on_path, path)
+            }
+            // Pointers are indirection (they break the cycle); scalars, unit,
+            // never, error, module and comptime-type carry no by-value struct
+            // containment.
+            _ => None,
+        }
     }
 
     /// Resolve @copy validation, destructors, functions, and methods.

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -105,6 +105,7 @@ impl<'a> GatherOutput<'a> {
             anon_struct_captured_values: HashMap::new(),
             destructor_spans: HashMap::new(),
             infectious_linear: HashMap::new(),
+            comptime_type_call_depth: 0,
         }
     }
 }

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -122,6 +122,14 @@ pub struct Sema<'a> {
     /// Maps the struct to the (field name, field type name) that caused it,
     /// for diagnostics explaining why the container is linear.
     pub(crate) infectious_linear: HashMap<StructId, (String, String)>,
+    /// Current recursion depth of `-> type` comptime-function reduction
+    /// (`eval_comptime_type_call`). Unlike value functions — whose comptime
+    /// recursion is bounded by the specialization-round limit — a `-> type`
+    /// function reduces eagerly on the host stack, so an unbounded
+    /// self-recursive type constructor (`fn Bad() -> type { Bad() }`) would
+    /// overflow that stack (SIGABRT) without this guard. Bounded at
+    /// `MAX_SPECIALIZATION_ROUNDS`, emitting the same E1200 (RUE-261).
+    pub(crate) comptime_type_call_depth: usize,
 }
 
 impl<'a> Sema<'a> {
@@ -153,6 +161,7 @@ impl<'a> Sema<'a> {
             anon_struct_captured_values: HashMap::new(),
             destructor_spans: HashMap::new(),
             infectious_linear: HashMap::new(),
+            comptime_type_call_depth: 0,
         }
     }
 

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -103,6 +103,17 @@ impl<'a> Sema<'a> {
         }
     }
 
+    /// A `type` value or a module value has no runtime representation and so
+    /// cannot be interned as an array element (`type` values: spec 4.14:6;
+    /// modules: spec 10.4:145). An array with such an element decays to
+    /// `<error>` during type resolution; sema then rejects the offending
+    /// element with a clean diagnostic (E1200 for a `type` value, E0206 for a
+    /// module) rather than reaching the intern pool, which panics on both kinds
+    /// (RUE-253, RUE-265).
+    pub(crate) fn is_non_internable_element(elem_ty: Type) -> bool {
+        matches!(elem_ty.kind(), TypeKind::ComptimeType | TypeKind::Module(_))
+    }
+
     /// Convert a fully-resolved InferType to a concrete Type.
     ///
     /// This handles the conversion of InferType::Array to Type::new_array(id)
@@ -115,11 +126,11 @@ impl<'a> Sema<'a> {
             InferType::Array { element, length } => {
                 // Recursively convert element type
                 let elem_ty = self.infer_type_to_type(element);
-                // A `type`-valued element is comptime-only and cannot be
-                // interned (spec 4.14:6); leave the array as `<error>` so sema
-                // rejects it with E1200 rather than panicking in the intern
-                // pool (RUE-253). `<error>` elements decay the same way.
-                if elem_ty == Type::ERROR || elem_ty == Type::COMPTIME_TYPE {
+                // A comptime-only (`type`) or module element cannot be interned;
+                // leave the array as `<error>` so sema rejects it with a clean
+                // diagnostic rather than panicking in the intern pool. `<error>`
+                // elements decay the same way (RUE-253, RUE-265).
+                if elem_ty == Type::ERROR || Self::is_non_internable_element(elem_ty) {
                     return Type::ERROR;
                 }
                 // Get or create the array type ID
@@ -484,10 +495,11 @@ impl<'a> Sema<'a> {
                 // Convert the element type to get the concrete Type
                 // (This is safe because we processed nested arrays first)
                 let elem_ty = self.infer_type_to_concrete_type_for_key(element);
-                // Skip `<error>` and comptime-only `type` elements: neither can
-                // be interned. A `[type; N]` array is diagnosed as E1200 in
-                // sema instead of panicking here (RUE-253).
-                if elem_ty != Type::ERROR && elem_ty != Type::COMPTIME_TYPE {
+                // Skip `<error>`, comptime-only `type`, and module elements:
+                // none can be interned. A `[type; N]` array is diagnosed as
+                // E1200 and a `[module; N]` array as E0206 in sema instead of
+                // panicking here (RUE-253, RUE-265).
+                if elem_ty != Type::ERROR && !Self::is_non_internable_element(elem_ty) {
                     // Pre-create this array type
                     self.get_or_create_array_type(elem_ty, *length);
                 }
@@ -511,10 +523,11 @@ impl<'a> Sema<'a> {
             InferType::Array { element, length } => {
                 // For nested arrays, look up or create the array type
                 let elem_ty = self.infer_type_to_concrete_type_for_key(element);
-                // A comptime-only `type` element (or `<error>`) cannot be
-                // interned; propagate `<error>` so the enclosing array is
-                // diagnosed as E1200 in sema rather than panicking (RUE-253).
-                if elem_ty == Type::ERROR || elem_ty == Type::COMPTIME_TYPE {
+                // A comptime-only `type` or module element (or `<error>`)
+                // cannot be interned; propagate `<error>` so the enclosing array
+                // is diagnosed as E1200 / E0206 in sema rather than panicking
+                // (RUE-253, RUE-265).
+                if elem_ty == Type::ERROR || Self::is_non_internable_element(elem_ty) {
                     return Type::ERROR;
                 }
                 // Get or create the array type in the pool

--- a/crates/rue-air/src/specialize.rs
+++ b/crates/rue-air/src/specialize.rs
@@ -145,7 +145,7 @@ struct SpecializationInfo {
 /// ever-growing type (e.g. `f(Pair(T), ...)` inside `f`) or a
 /// comptime-recursive function never reaches a comptime-known base case,
 /// so this cap turns a would-be-infinite loop into a clean E1200.
-const MAX_SPECIALIZATION_ROUNDS: usize = 64;
+pub(crate) const MAX_SPECIALIZATION_ROUNDS: usize = 64;
 
 /// Perform the specialization pass on the sema output.
 ///

--- a/crates/rue-cli-tests/cases/array_element_module.toml
+++ b/crates/rue-cli-tests/cases/array_element_module.toml
@@ -1,0 +1,65 @@
+# A non-runtime value used as an array element must be rejected with the normal
+# type diagnostic before it reaches the intern pool — which panics on both
+# module and `type` values ("Cannot intern module types"). RUE-265 (module
+# elements) and RUE-253 (type-value elements) are the same class.
+#
+# A module value has no runtime representation (spec 10.4:145); putting one in
+# an array literal or repeat used to reach the intern pool and abort the
+# compiler (SIGABRT, exit 134). The array-element check now rejects it with
+# E0206 — the same diagnostic a module passed as a function argument gets —
+# before the intern pool. The `type`-value control (RUE-253) still produces
+# E1200, and ordinary runtime arrays are unaffected.
+
+[section]
+id = "cli.array_element_module"
+name = "Non-runtime array elements"
+description = "A module (E0206) or `type` value (E1200) as an array element is a clean diagnostic, not an intern-pool ICE (RUE-265, RUE-253)."
+
+[[case]]
+name = "module_in_array_literal_is_e0206"
+description = "`[h, h]` where `h` is an imported module → clean E0206 (was intern-pool SIGABRT)."
+compile_fail = true
+error_contains = ["E0206", "<module>"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 { let h = @import("helper"); let arr = [h, h]; 0 }
+""" },
+    { path = "helper.rue", source = """
+pub fn value() -> i32 { 1 }
+""" },
+]
+
+[[case]]
+name = "module_in_array_repeat_is_e0206"
+description = "`[h; 3]` where `h` is an imported module → clean E0206 (was intern-pool SIGABRT)."
+args = ["main.rue", "--preview", "array_repeat", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0206", "<module>"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 { let h = @import("helper"); let arr = [h; 3]; 0 }
+""" },
+    { path = "helper.rue", source = """
+pub fn value() -> i32 { 1 }
+""" },
+]
+
+[[case]]
+name = "type_value_in_array_literal_is_e1200_control"
+description = "Control (RUE-253): an array literal of `type` values remains a clean E1200."
+compile_fail = true
+error_contains = ["E1200"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { let arr = [i32, i32]; 0 }
+""" }]
+
+[[case]]
+name = "runtime_array_unaffected_control"
+description = "Control: an ordinary runtime array still compiles and runs (exit 6)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr = [1, 2, 3];
+    arr[0] + arr[1] + arr[2]
+}
+""" }]
+exit_code = 6

--- a/crates/rue-cli-tests/cases/comptime_type_recursion_depth.toml
+++ b/crates/rue-cli-tests/cases/comptime_type_recursion_depth.toml
@@ -1,0 +1,64 @@
+# Unbounded comptime `-> type` recursion must produce a clean, bounded
+# diagnostic (E1200) instead of overflowing the compiler's own stack (SIGABRT,
+# exit 134) — RUE-261.
+#
+# The comptime evaluator reduces a type-returning function eagerly on the host
+# stack. Without a depth guard, a self-recursive type constructor with no
+# compile-time-known base case recurses forever and aborts the compiler with no
+# diagnostic (the raw stack overflow even bypasses the ICE panic-hook). The
+# value-returning analog was already bounded by the specialization-round limit;
+# this pins the same E1200 on the `-> type` reduction path. Legitimate bounded
+# composition (a delegation chain well under the limit) must still compile.
+
+[section]
+id = "cli.comptime_type_recursion_depth"
+name = "Comptime type-recursion depth limit"
+description = "Unbounded `-> type` recursion is E1200, not a stack-overflow ICE; bounded composition still compiles (RUE-261)."
+
+[[case]]
+name = "no_arg_type_recursion_is_e1200"
+description = "`fn Bad() -> type { Bad() }` → clean E1200 (was SIGABRT 134)."
+compile_fail = true
+error_contains = ["E1200", "exceeded the maximum nesting depth"]
+files = [{ path = "main.rue", source = """
+fn Bad() -> type { Bad() }
+fn main() -> i32 { Bad(); 0 }
+""" }]
+
+[[case]]
+name = "comptime_value_type_recursion_is_e1200"
+description = "`fn Wrap(comptime n: i32) -> type { Wrap(n + 1) }` → clean E1200 (was SIGABRT 134)."
+compile_fail = true
+error_contains = ["E1200", "exceeded the maximum nesting depth"]
+files = [{ path = "main.rue", source = """
+fn Wrap(comptime n: i32) -> type { Wrap(n + 1) }
+fn main() -> i32 { let W = Wrap(0); 0 }
+""" }]
+
+[[case]]
+name = "value_returning_runaway_still_e1200_control"
+description = "Control: the value-returning analog remains a clean E1200."
+compile_fail = true
+error_contains = ["E1200", "exceeded the maximum nesting depth"]
+files = [{ path = "main.rue", source = """
+fn runaway(comptime n: i32) -> i32 { runaway(n + 1) }
+fn main() -> i32 { runaway(0) }
+""" }]
+
+[[case]]
+name = "bounded_delegation_chain_still_compiles_control"
+description = "Control: a six-level delegating `-> type` chain (well under the limit) still reduces and runs (exit 42)."
+files = [{ path = "main.rue", source = """
+fn Base() -> type { struct { x: i32 } }
+fn A1() -> type { Base() }
+fn A2() -> type { A1() }
+fn A3() -> type { A2() }
+fn A4() -> type { A3() }
+fn A5() -> type { A4() }
+fn main() -> i32 {
+    let T = A5();
+    let v: T = T { x: 41 };
+    v.x + 1
+}
+""" }]
+exit_code = 42

--- a/crates/rue-cli-tests/cases/recursive_value_type.toml
+++ b/crates/rue-cli-tests/cases/recursive_value_type.toml
@@ -1,0 +1,75 @@
+# An infinite-size type — one that (transitively) contains itself by value with
+# no pointer indirection — must be rejected with a clean bounded diagnostic
+# (E0483), not crash the compiler. RUE-264.
+#
+# Layout / drop-glue computation recurses through struct fields, enum payloads,
+# and array elements. A by-value cycle makes that recursion unbounded and
+# overflows the compiler's own stack (SIGABRT, exit 134) — the raw overflow
+# even bypasses the ICE panic-hook, so no banner prints. A well-formedness
+# check now detects the cycle up front (the type-graph analogue of the cyclic
+# const-initializer check, E0461) and reports E0483 (cf. Rust E0072). A cycle
+# broken by a pointer is a legitimate recursive data structure and still
+# compiles.
+
+[section]
+id = "cli.recursive_value_type"
+name = "Recursive-by-value type (infinite size)"
+description = "Infinite-size types are E0483, not a stack-overflow ICE; pointer indirection and ordinary structs are unaffected (RUE-264)."
+
+[[case]]
+name = "self_recursive_struct_is_e0483"
+description = "`struct A { a: A }` → clean E0483 (was SIGABRT 134)."
+compile_fail = true
+error_contains = ["E0483", "infinite size", "A -> A"]
+files = [{ path = "main.rue", source = """
+struct A { a: A }
+fn main() -> i32 { 0 }
+""" }]
+
+[[case]]
+name = "mutually_recursive_structs_multifile_is_e0483"
+description = "Cross-file mutual recursion `struct A { b: B }` / `struct B { a: A }` → clean E0483 (was SIGABRT 134)."
+args = ["a.rue", "b.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0483", "infinite size"]
+files = [
+    { path = "a.rue", source = """
+struct A { b: B }
+fn main() -> i32 { 0 }
+""" },
+    { path = "b.rue", source = """
+struct B { a: A }
+""" },
+]
+
+[[case]]
+name = "array_by_value_recursion_is_e0483"
+description = "`struct A { a: [A; 1] }` (arrays store elements inline) → clean E0483."
+compile_fail = true
+error_contains = ["E0483", "infinite size"]
+files = [{ path = "main.rue", source = """
+struct A { a: [A; 1] }
+fn main() -> i32 { 0 }
+""" }]
+
+[[case]]
+name = "pointer_indirection_breaks_cycle_control"
+description = "Control: recursion through a pointer is a valid recursive type and compiles."
+compile_only = true
+files = [{ path = "main.rue", source = """
+struct Node { next: ptr const Node, val: i32 }
+fn main() -> i32 { 0 }
+""" }]
+
+[[case]]
+name = "ordinary_nested_struct_unaffected_control"
+description = "Control: an ordinary non-recursive nested struct still compiles and runs (exit 8)."
+files = [{ path = "main.rue", source = """
+struct Inner { x: i32 }
+struct Outer { i: Inner, y: i32 }
+fn main() -> i32 {
+    let o = Outer { i: Inner { x: 5 }, y: 3 };
+    o.i.x + o.y
+}
+""" }]
+exit_code = 8

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -171,6 +171,11 @@ impl ErrorCode {
     /// resource-limit diagnostic rather than a struct/enum error, but the
     /// reserved code lives in this block.
     pub const NESTING_LIMIT_EXCEEDED: Self = Self(482);
+    /// A struct or enum (transitively) contains itself by value with no
+    /// pointer indirection, so it has no finite size/layout (RUE-264).
+    /// Analogous to Rust's E0072 and a sibling of [`Self::CONST_INITIALIZER_CYCLE`]
+    /// (E0461) for the type-definition graph.
+    pub const RECURSIVE_TYPE_INFINITE_SIZE: Self = Self(483);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -1071,6 +1076,13 @@ pub enum ErrorKind {
     /// being defined, so no evaluation order exists.
     #[error("cycle detected in constant initializers: {cycle}")]
     ConstInitializerCycle { cycle: String },
+    /// A struct or enum (transitively) contains itself by value with no
+    /// pointer indirection, so it has infinite size and no valid layout
+    /// (RUE-264). `cycle` names the containment path (e.g. `A -> B -> A`).
+    #[error(
+        "recursive type '{name}' has infinite size (contains itself by value: {cycle}); break the cycle with a pointer (`ptr const {name}` / `ptr mut {name}`)"
+    )]
+    RecursiveTypeInfiniteSize { name: String, cycle: String },
     /// A value constant declared without a type annotation. Annotations are
     /// required on value constants (spec 6.5:4, RUE-179); only module
     /// bindings (`const m = @import(...)` and aliases) are exempt.
@@ -1342,6 +1354,7 @@ impl ErrorKind {
             ErrorKind::DuplicateConstant { .. } => ErrorCode::DUPLICATE_CONSTANT,
             ErrorKind::ConstExprNotSupported { .. } => ErrorCode::CONST_EXPR_NOT_SUPPORTED,
             ErrorKind::ConstInitializerCycle { .. } => ErrorCode::CONST_INITIALIZER_CYCLE,
+            ErrorKind::RecursiveTypeInfiniteSize { .. } => ErrorCode::RECURSIVE_TYPE_INFINITE_SIZE,
             ErrorKind::ConstMissingTypeAnnotation { .. } => {
                 ErrorCode::CONST_MISSING_TYPE_ANNOTATION
             }


### PR DESCRIPTION
No user source should crash the compiler. All three reproduced as SIGABRT/exit 134, now clean diagnostics.

**RUE-261:** unbounded comptime -> type recursion (fn Bad() -> type { Bad() }). Added a depth counter (bounded at the shared MAX_SPECIALIZATION_ROUNDS=64) in eval_comptime_type_call + a propagating reduction entry point so the existing E1200 surfaces instead of a stack overflow. Both repros give E1200; value runaway still E1200; a 6-level delegation chain still compiles.

**RUE-264:** infinite-size recursive-by-value struct/enum (struct A { a: A }; the overflow was in drop_glue.rs). Added check_recursive_value_types in sema (after fields/payloads resolve, before layout/drop-glue recurse) — a by-value type-graph DFS. Reserved ONE new code E0483 (RECURSIVE_TYPE_INFINITE_SIZE, cf. Rust E0072). Self / mutual / array-by-value / by-value-enum give E0483; pointer indirection still allowed.

**RUE-265:** a module value in an array literal/repeat ([h, h] / [h; 3]) panicked 'Cannot intern module types'. Extended the RUE-253 array-element guard to reject any non-runtime element kind before interning: E0206 for modules, E1200 for type values, in both array-init and array-repeat.

Verified by execution (E1200 / E0483 / E0206, no SIGABRT; valid programs still compile); full test.sh green; 13 new CLI cases. No codegen touched.

Fixes RUE-261
Fixes RUE-264
Fixes RUE-265

Generated with Claude Code