### PR TITLE
Comptime if/match reduction in -> type functions + comptime-type vars in composite annotations (RUE-262, RUE-263)

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1988,12 +1988,12 @@ impl<'a> Sema<'a> {
         // compile (RUE-155). Resolve the name here so unknown annotations get
         // the same E0204 as signature positions. Comptime type variables
         // (e.g. `let P = Pair(i32); let p: P = ...`) and substituted type
-        // parameters live in ctx, not in the type tables, so accept those
-        // first.
+        // parameters live in ctx, not in the type tables, so resolution goes
+        // through `resolve_type_with_ctx`, which consults those local comptime
+        // bindings at every level of a composite annotation — a scalar `P`, and
+        // an inner element/pointee of `[P; 2]` / `ptr const P` alike (RUE-263).
         if let Some(ty_sym) = ty {
-            if !ctx.comptime_type_vars.contains_key(&ty_sym) {
-                self.resolve_type(ty_sym, span)?;
-            }
+            self.resolve_type_with_ctx(ty_sym, span, ctx)?;
         }
 
         // Analyze the initializer. A `for`-loop element binding is a shared

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -51,7 +51,7 @@ use std::sync::LazyLock;
 
 use lasso::{Key, Spur};
 use rue_error::{CompileError, CompileResult, ErrorKind};
-use rue_rir::{InstData, InstRef};
+use rue_rir::{InstData, InstRef, RirPattern};
 use rue_span::Span;
 
 use super::Sema;
@@ -139,6 +139,35 @@ impl<'a> ComptimeEnv<'a> {
             runtime_locals: None,
             locals: HashMap::new(),
         }
+    }
+}
+
+/// Decide whether a compile-time-known scrutinee value matches a match arm's
+/// pattern (RUE-262). Returns:
+/// - `Some(true)` / `Some(false)` — the pattern definitely does / does not match;
+/// - `None` — the match can't be decided at compile time here (an enum-variant
+///   `Path` pattern, or a scrutinee whose kind the pattern can't compare
+///   against), so the caller treats the whole `match` as non-evaluable.
+fn const_pattern_matches(pattern: &RirPattern, scrut: ConstValue) -> Option<bool> {
+    match pattern {
+        RirPattern::Wildcard(_) => Some(true),
+        RirPattern::Bool(b, _) => match scrut {
+            ConstValue::Bool(sb) => Some(sb == *b),
+            _ => None,
+        },
+        RirPattern::Int {
+            value, negative, ..
+        } => match scrut {
+            ConstValue::Integer(n) => {
+                let pv = *value as i128;
+                let pv = if *negative { -pv } else { pv };
+                Some(n == pv)
+            }
+            _ => None,
+        },
+        // Enum-variant patterns aren't representable as a `ConstValue` (there
+        // is no comptime enum-value form), so they can't be decided here.
+        RirPattern::Path { .. } => None,
     }
 }
 
@@ -714,6 +743,59 @@ impl Sema<'_> {
                 }
                 env.locals = saved_locals;
                 Ok(result)
+            }
+
+            // Comptime-known `if`: select the taken branch and reduce to its
+            // value. This is what lets an `if` in a `-> type` body pick a
+            // struct/enum branch at compile time (spec 4.14:17, RUE-262) — the
+            // same branch selection ordinary comptime values already relied on
+            // through the block/let path, now available as an expression. A
+            // non-constant condition makes the whole `if` non-evaluable.
+            InstData::Branch {
+                cond,
+                then_block,
+                else_block,
+            } => {
+                let (cond, then_block, else_block) = (*cond, *then_block, *else_block);
+                match self.eval_const_expr(cond, env)? {
+                    Some(ConstValue::Bool(true)) => self.eval_const_expr(then_block, env),
+                    Some(ConstValue::Bool(false)) => match else_block {
+                        Some(else_block) => self.eval_const_expr(else_block, env),
+                        // `if c { .. }` with no else yields unit when false.
+                        None => Ok(Some(ConstValue::Unit)),
+                    },
+                    // Non-constant (or non-bool) condition: not evaluable.
+                    _ => Ok(None),
+                }
+            }
+
+            // Comptime-known `match`: evaluate the scrutinee, select the first
+            // arm whose pattern matches, and reduce to that arm's body value
+            // (spec 4.14:19, RUE-262). An enum-variant (`Path`) pattern isn't
+            // representable as a `ConstValue`, and a non-constant scrutinee is
+            // not decidable here — both make the `match` non-evaluable.
+            InstData::Match {
+                scrutinee,
+                arms_start,
+                arms_len,
+            } => {
+                let (scrutinee, arms_start, arms_len) = (*scrutinee, *arms_start, *arms_len);
+                let Some(scrut) = self.eval_const_expr(scrutinee, env)? else {
+                    return Ok(None);
+                };
+                let arms = self.rir.get_match_arms(arms_start, arms_len);
+                for (pattern, body) in arms {
+                    match const_pattern_matches(&pattern, scrut) {
+                        Some(true) => return self.eval_const_expr(body, env),
+                        Some(false) => continue,
+                        // Undecidable pattern (e.g. an enum-variant `Path`
+                        // against a non-representable scrutinee): bail out.
+                        None => return Ok(None),
+                    }
+                }
+                // No arm matched. Exhaustiveness checking should make this
+                // unreachable for a well-typed match; treat as non-evaluable.
+                Ok(None)
             }
 
             // Anonymous struct type: evaluate to a comptime type value,

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -13,6 +13,7 @@ use rue_error::{CompileError, CompileResult, ErrorKind};
 use rue_span::Span;
 
 use super::Sema;
+use super::context::AnalysisContext;
 use crate::inference::InferType;
 use crate::sema::ConstValue;
 use crate::types::{ArrayLen, ArrayTypeId, Type, TypeKind, parse_array_type_syntax};
@@ -231,6 +232,68 @@ impl<'a> Sema<'a> {
                     span,
                 ))
             }
+        }
+    }
+
+    /// Resolve a type-annotation symbol to a `Type`, consulting the analysis
+    /// context's local comptime type bindings at every level of a composite
+    /// annotation (RUE-263).
+    ///
+    /// [`resolve_type`] takes no context, so it can validate a *scalar*
+    /// comptime-type-var annotation (`let p: P`, which the caller special-cases
+    /// before ever reaching resolution) but not a *composite* one: `[P; 2]` or
+    /// `ptr const P` misses in the local-binding map as a whole symbol, and the
+    /// context-free recursion then can't resolve the inner `P` (it isn't a named
+    /// struct/enum), yielding a spurious E0204. This variant threads
+    /// `ctx.comptime_type_vars` through the recursion so an inner
+    /// element/pointee that is a local comptime type var resolves. Non-composite
+    /// leaves and genuinely-unknown names fall through to [`resolve_type`],
+    /// keeping the primitive/struct/enum resolution, privacy checks (E0460), and
+    /// the E0204 for a truly unknown type in one place so the two paths can't
+    /// drift.
+    ///
+    /// Array lengths are resolved context-free (literals and file-level
+    /// `const`s), exactly as [`resolve_type`] does — a length naming a local
+    /// `comptime N: i32` parameter (`[P; N]`) is *not* resolved here and gets
+    /// the same E0481 it does today. Threading the comptime value map so `N`
+    /// resolves would surface a latent rue-cfg drop-analysis ICE for
+    /// comptime-value-length *local* arrays (the length only works in signature
+    /// and return positions so far, RUE-252); that gap is tracked separately.
+    ///
+    /// [`resolve_type`]: Sema::resolve_type
+    pub(crate) fn resolve_type_with_ctx(
+        &mut self,
+        type_sym: Spur,
+        span: Span,
+        ctx: &AnalysisContext,
+    ) -> CompileResult<Type> {
+        // A local comptime type variable (`let P = Point();`) or a substituted
+        // comptime type parameter is a type value already — resolve it directly.
+        if let Some(&ty) = ctx.comptime_type_vars.get(&type_sym) {
+            return Ok(ty);
+        }
+        let type_name = self.interner.resolve(&type_sym);
+        if let Some((element_type, len)) = parse_array_type_syntax(type_name) {
+            let element_sym = self.interner.get_or_intern(&element_type);
+            let element_ty = self.resolve_type_with_ctx(element_sym, span, ctx)?;
+            let length = self.resolve_array_length(&len, span, None)?;
+            let array_type_id = self.get_or_create_array_type(element_ty, length);
+            Ok(Type::new_array(array_type_id))
+        } else if let Some(pointee) = type_name.strip_prefix("ptr const ") {
+            let pointee_sym = self.interner.get_or_intern(pointee);
+            let pointee_ty = self.resolve_type_with_ctx(pointee_sym, span, ctx)?;
+            let ptr_type_id = self.type_pool.intern_ptr_const_from_type(pointee_ty);
+            Ok(Type::new_ptr_const(ptr_type_id))
+        } else if let Some(pointee) = type_name.strip_prefix("ptr mut ") {
+            let pointee_sym = self.interner.get_or_intern(pointee);
+            let pointee_ty = self.resolve_type_with_ctx(pointee_sym, span, ctx)?;
+            let ptr_type_id = self.type_pool.intern_ptr_mut_from_type(pointee_ty);
+            Ok(Type::new_ptr_mut(ptr_type_id))
+        } else {
+            // Non-composite leaf: primitive / struct / enum / unknown. Defer to
+            // the context-free resolver for identical resolution, privacy
+            // checks, and the E0204 on a genuinely-unknown name.
+            self.resolve_type(type_sym, span)
         }
     }
 

--- a/crates/rue-cli-tests/cases/comptime_type_functions.toml
+++ b/crates/rue-cli-tests/cases/comptime_type_functions.toml
@@ -150,3 +150,87 @@ fn main() -> i32 {
 }
 """ }]
 stdout = "42\n"
+
+# Comptime-known if/match in a `-> type` body selects the taken branch and
+# reduces to that branch's struct/enum type (RUE-262). Before the fix these
+# rejected with E1200 "cannot store type value in variable at runtime" because
+# the comptime evaluator didn't reduce `if`/`match` expressions.
+
+[[case]]
+name = "if_branch_selects_struct_type"
+description = "A comptime `if` in a `-> type` body reduces to the taken branch's struct; the result is usable as a type (RUE-262)."
+files = [{ path = "main.rue", source = """
+fn Choose(comptime flag: bool) -> type {
+    if flag { struct { x: i32 } } else { struct { y: i32 } }
+}
+fn main() -> i32 {
+    let A = Choose(true);
+    let a: A = A { x: 41 };
+    @dbg(a.x + 1);
+    0
+}
+""" }]
+stdout = "42\n"
+
+[[case]]
+name = "if_branch_false_arm"
+description = "The false arm of a comptime `if` in a `-> type` body is selected when the condition is false (RUE-262)."
+files = [{ path = "main.rue", source = """
+fn Choose(comptime flag: bool) -> type {
+    if flag { struct { x: i32 } } else { struct { y: i32 } }
+}
+fn main() -> i32 {
+    let B = Choose(false);
+    let b: B = B { y: 7 };
+    @dbg(b.y);
+    0
+}
+""" }]
+stdout = "7\n"
+
+[[case]]
+name = "match_branch_selects_struct_type"
+description = "A comptime `match` in a `-> type` body reduces to the matched arm's struct (RUE-262)."
+files = [{ path = "main.rue", source = """
+fn Choose(comptime n: i32) -> type {
+    match n { 0 => struct { a: i32 }, 1 => struct { b: i32 }, _ => struct { c: i32 } }
+}
+fn main() -> i32 {
+    let T = Choose(1);
+    let t: T = T { b: 5 };
+    @dbg(t.b);
+    0
+}
+""" }]
+stdout = "5\n"
+
+[[case]]
+name = "recursive_type_fn_via_if"
+description = "A `-> type` function that recurses through a comptime `if` terminates and reduces to the base struct (RUE-262)."
+files = [{ path = "main.rue", source = """
+fn Nest(comptime n: i32) -> type {
+    if n == 0 { struct { base: i32 } } else { Nest(n - 1) }
+}
+fn main() -> i32 {
+    let T = Nest(3);
+    let t: T = T { base: 8 };
+    @dbg(t.base);
+    0
+}
+""" }]
+stdout = "8\n"
+
+[[case]]
+name = "runtime_condition_in_type_fn_rejected"
+description = "A genuinely runtime condition in a `-> type` body cannot be reduced and is rejected cleanly, not accepted (RUE-262)."
+files = [{ path = "main.rue", source = """
+fn Choose(flag: bool) -> type {
+    if flag { struct { x: i32 } } else { struct { y: i32 } }
+}
+fn main() -> i32 {
+    let A = Choose(true);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E1200"]

--- a/crates/rue-cli-tests/cases/comptime_type_var_composite.toml
+++ b/crates/rue-cli-tests/cases/comptime_type_var_composite.toml
@@ -1,0 +1,84 @@
+# A local bound to a comptime type value (`let P = Point();`) works as a
+# composite type annotation — an array element or a pointer pointee — not just
+# as a scalar type (RUE-263).
+#
+# Before the fix, `let arr: [P; 2]` / `let pp: ptr const P` rejected with E0204
+# "unknown type 'P'": the whole composite symbol `[P; 2]` missed the local
+# comptime-type-var map, so annotation validation fell into the context-free
+# `resolve_type`, which couldn't resolve the inner `P`. Sema now resolves
+# composite annotations through the comptime type context (`resolve_type_with_ctx`).
+
+[section]
+id = "cli.comptime_type_var_composite"
+name = "Comptime type var in composite annotations"
+description = "Local comptime type value as an array-element / pointer-pointee type (RUE-263)."
+
+[[case]]
+name = "array_of_comptime_type_var"
+description = "`let arr: [P; 2]` where P is a local comptime type value compiles and runs (RUE-263)."
+files = [{ path = "main.rue", source = """
+fn Point() -> type { struct { x: i32, y: i32 } }
+fn main() -> i32 {
+    let P = Point();
+    let arr: [P; 2] = [P { x: 1, y: 2 }, P { x: 3, y: 4 }];
+    @dbg(arr[0].x + arr[1].y);
+    0
+}
+""" }]
+stdout = "5\n"
+
+[[case]]
+name = "nested_array_of_comptime_type_var"
+description = "A doubly-nested `[[P; 2]; 2]` annotation resolves the inner comptime type var at every level (RUE-263)."
+files = [{ path = "main.rue", source = """
+fn Point() -> type { struct { x: i32, y: i32 } }
+fn main() -> i32 {
+    let P = Point();
+    let grid: [[P; 2]; 2] = [[P { x: 1, y: 1 }, P { x: 2, y: 2 }], [P { x: 3, y: 3 }, P { x: 4, y: 4 }]];
+    @dbg(grid[0][1].x + grid[1][0].y);
+    0
+}
+""" }]
+stdout = "5\n"
+
+[[case]]
+name = "array_length_from_file_const"
+description = "A comptime-type-var array whose length is a file-level `const` resolves (RUE-263)."
+files = [{ path = "main.rue", source = """
+const K: i32 = 2;
+fn Point() -> type { struct { x: i32, y: i32 } }
+fn main() -> i32 {
+    let P = Point();
+    let arr: [P; K] = [P { x: 4, y: 1 }, P { x: 9, y: 3 }];
+    @dbg(arr[0].x + arr[1].y);
+    0
+}
+""" }]
+stdout = "7\n"
+
+[[case]]
+name = "pointer_to_comptime_type_var"
+description = "`ptr const P` where P is a local comptime type value resolves as a pointee type (RUE-263)."
+files = [{ path = "main.rue", source = """
+fn Point() -> type { struct { x: i32, y: i32 } }
+fn main() -> i32 {
+    let P = Point();
+    let p: P = P { x: 10, y: 20 };
+    let pp: ptr const P = checked { @raw(p) };
+    @dbg(checked { @ptr_read(pp).x });
+    0
+}
+""" }]
+stdout = "10\n"
+
+[[case]]
+name = "unknown_composite_element_still_e0204"
+description = "A genuinely-unknown array-element type is still rejected with E0204, not silently accepted (RUE-263)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let arr: [Bogus; 2] = [1, 2];
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0204", "Bogus"]


### PR DESCRIPTION
Both rue-air; comptime type functions are Rue's generics, so these unblock more real generic code.

**RUE-262:** eval_const_expr now reduces a comptime-known if/match to the taken branch (new Branch/Match arms + a const_pattern_matches helper in comptime_eval.rs), so struct/enum branches in -> type bodies work: fn Choose(comptime flag: bool) -> type { if flag { struct { x: i32 } } else { struct { y: i32 } } } now reduces and A is usable as a type. Verified: if / false-arm / int-match / nested / recursive all compile and run; a runtime condition in a -> type body still errors E1200.

**RUE-263:** new resolve_type_with_ctx threads ctx.comptime_type_vars through composite annotations (wired into analyze_alloc), so a local comptime-type var works as an array element or pointer pointee: let P = Point(); let arr: [P; 2] = ...; and ptr const P. Verified [P;2], [[P;2];2], [P;K] const-length, and ptr const P all work; an unknown element type still E0204.

Scoping: array lengths kept context-free — threading a comptime-VALUE length so [P;N] resolves converts a clean E0481 into a rue-cfg drop-analysis ICE (out of scope), filed as RUE-271 with repro + the one-line re-enable point.

Verified by execution + full test.sh green; 21 comptime CLI cases; diff-fuzzer 300 seeds 0 disagreements. No codegen/aarch64 changes.

Fixes RUE-262
Fixes RUE-263

Generated with Claude Code