### PR TITLE
Make relative @import resolution and ambiguity importer-relative (RUE-266)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -4549,21 +4549,56 @@ impl<'a> Sema<'a> {
         // (unit tests, multi-file compilation, and files the driver's import
         // discovery loaded). Delegates to the structured ModulePath resolver
         // so loaded-path matching has exactly one implementation.
+        //
+        // Resolution is importer-relative (spec 10.2:2, RUE-266): candidates
+        // are anchored to base directories searched in order — the importing
+        // file's own directory first, then the root file's directory. This
+        // keeps both resolution AND the dual-entity ambiguity check
+        // per-importer rather than program-global, so two unrelated
+        // `@import("foo")` sites in different directories each resolve to their
+        // own `foo` with no false cross-directory collision.
         let module_path = super::module_path::ModulePath::parse(import_path);
-        if let Some((file_module, dir_module)) =
-            module_path.find_ambiguity(self.file_paths.values())
-        {
-            return Err(CompileError::new(
-                ErrorKind::AmbiguousModule(Box::new(rue_error::AmbiguousModuleData {
-                    path: import_path.to_string(),
-                    file_module,
-                    dir_module,
-                })),
-                span,
-            ));
+        let dir_of = |p: &str| {
+            Path::new(p)
+                .parent()
+                .map(|d| d.to_string_lossy().into_owned())
+                .unwrap_or_default()
+        };
+        let importer_dir = self.get_source_path(span).map(&dir_of);
+        let root_dir = self
+            .file_paths
+            .iter()
+            .min_by_key(|(id, _)| id.index())
+            .map(|(_, p)| dir_of(p));
+        let mut base_dirs: Vec<String> = Vec::new();
+        if let Some(d) = importer_dir {
+            base_dirs.push(d);
         }
-        if let Some(resolved) = module_path.resolve(self.file_paths.values()) {
-            return Ok(resolved);
+        if let Some(d) = root_dir
+            && !base_dirs.contains(&d)
+        {
+            base_dirs.push(d);
+        }
+        if base_dirs.is_empty() {
+            base_dirs.push(String::new());
+        }
+        let base_refs: Vec<&str> = base_dirs.iter().map(|s| s.as_str()).collect();
+        match module_path.resolve_in_dirs(&base_refs, self.file_paths.values()) {
+            super::module_path::DirResolution::Ambiguous {
+                file_module,
+                dir_module,
+            } => {
+                return Err(CompileError::new(
+                    ErrorKind::AmbiguousModule(Box::new(rue_error::AmbiguousModuleData {
+                        path: import_path.to_string(),
+                        file_module,
+                        dir_module,
+                    })),
+                    span,
+                ));
+            }
+            super::module_path::DirResolution::Resolved(resolved) => return Ok(resolved),
+            super::module_path::DirResolution::NotFound => {}
         }
 
         // Phase 2: Try to find the file on disk (for directory modules and actual file imports)

--- a/crates/rue-air/src/sema/module_path.rs
+++ b/crates/rue-air/src/sema/module_path.rs
@@ -10,13 +10,69 @@
 //!
 //! 1. **Standard library** - if the path is exactly "std"
 //! 2. **Exact path with extension** - if path includes ".rue" extension
-//! 3. **Simple file match** - look for `foo.rue` or path ending with `foo.rue`
+//! 3. **Simple file match** - look for `foo.rue`
 //! 4. **Facade module** - look for `foo/_foo.rue` (the directory module's entry point, inside the directory — RUE-137)
 //!
 //! Both module forms existing at once (`foo.rue` AND `foo/_foo.rue`) is an
-//! ambiguity error (E0708), mirroring Rust's E0761 — see [`ModulePath::find_ambiguity`].
+//! ambiguity error (E0708), mirroring Rust's E0761 — see [`ModulePath::resolve_in_dirs`].
+//!
+//! # Importer-relative resolution (spec 10.2:2)
+//!
+//! Resolution is **importer-relative**, not program-global. A relative import
+//! candidate is joined against a list of base directories, searched in order:
+//! first the directory containing the *importing* file, then the directory
+//! containing the *root* file. The first base directory that yields a match
+//! wins, and ambiguity is judged **within** that base directory. This is why
+//! two unrelated `@import("foo")` sites in different directories each resolve
+//! to their own `foo.rue` (no false cross-directory ambiguity), and why the
+//! same source text always imports the file next to it rather than an
+//! unrelated same-named file elsewhere in the program (RUE-266).
 
-use std::path::Path;
+use std::path::{Component, Path, PathBuf};
+
+/// Lexically normalize a path for equivalence comparison by dropping `.`
+/// (current-directory) components, so `./foo.rue`, `sub/./foo.rue` and
+/// `sub/foo.rue` compare equal. Parent (`..`) and normal components are
+/// preserved, so the normalization is purely lexical and never touches the
+/// filesystem. Mirrors `file_paths::normalize_module_path`.
+fn normalize(path: &str) -> String {
+    let mut out = PathBuf::new();
+    for comp in Path::new(path).components() {
+        match comp {
+            Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out.to_string_lossy().into_owned()
+}
+
+/// Join a base directory with a relative path. An empty base directory yields
+/// the relative path unchanged (the importer sits at the search root).
+fn join_base(base: &str, rel: &str) -> String {
+    if base.is_empty() {
+        rel.to_string()
+    } else {
+        Path::new(base).join(rel).to_string_lossy().into_owned()
+    }
+}
+
+/// The outcome of resolving an import path against the loaded files, anchored
+/// to a set of base directories.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DirResolution {
+    /// A unique loaded file matched. Carries the original (un-normalized)
+    /// loaded path so downstream lookups key into `file_paths` as stored.
+    Resolved(String),
+    /// Both a file module (`{path}.rue`) and a directory-module facade
+    /// (`{path}/_{basename}.rue`) exist within the same base directory. Callers
+    /// raise E0708. Carries both original paths.
+    Ambiguous {
+        file_module: String,
+        dir_module: String,
+    },
+    /// No loaded file matched in any base directory.
+    NotFound,
+}
 
 /// Represents a parsed import path with its resolution strategy.
 ///
@@ -32,16 +88,15 @@ pub enum ModulePath {
 
     /// Import with explicit `.rue` extension: `@import("foo.rue")`
     ///
-    /// The path is taken as-is and matched against loaded file paths.
+    /// The path is taken as-is (joined against a base directory) and matched
+    /// against loaded file paths.
     ExplicitRue { path: String },
 
     /// Simple module import: `@import("foo")` or `@import("utils/strings")`
     ///
-    /// Resolution tries:
+    /// Resolution tries, within each base directory:
     /// 1. `{path}.rue` - standard file
     /// 2. `{path}/_{basename}.rue` - in-directory facade for directory modules
-    ///
-    /// For nested paths like `utils/strings`, we look for `utils/strings.rue`.
     Simple { path: String },
 }
 
@@ -77,168 +132,103 @@ impl ModulePath {
         }
     }
 
-    /// Resolve this import path against a collection of loaded file paths.
+    /// Resolve this import path against the loaded files, anchored to
+    /// `base_dirs` (searched in order — importer's directory first, then the
+    /// root file's directory; see spec 10.2:2).
     ///
-    /// Returns `Some(resolved_path)` if a match is found, or `None` if the
-    /// module cannot be found.
+    /// The first base directory that yields any candidate determines the
+    /// result: if both a file module and a directory-module facade exist
+    /// *there*, the result is [`DirResolution::Ambiguous`]; otherwise the
+    /// single match is [`DirResolution::Resolved`]. A base directory with no
+    /// candidate is skipped in favor of the next. If no base directory yields a
+    /// match, the result is [`DirResolution::NotFound`].
     ///
-    /// The resolution order is:
-    /// 1. Exact match (for ExplicitRue)
-    /// 2. Standard file match (`{path}.rue`)
-    /// 3. Path suffix match (for nested paths)
-    /// 4. In-directory facade match (`{basename}/_{basename}.rue`)
-    pub fn resolve<'a, I>(&self, loaded_paths: I) -> Option<String>
+    /// Matching is by lexically-normalized path equality (dropping `.`
+    /// components), so `./foo.rue` and `foo.rue` are the same file (spec
+    /// 10.2:4). The returned string is the original loaded path.
+    pub fn resolve_in_dirs<'a, I>(&self, base_dirs: &[&str], loaded_paths: I) -> DirResolution
     where
         I: Iterator<Item = &'a String>,
     {
+        // Pair each loaded path with its normalized form once.
+        let normalized: Vec<(String, &String)> = loaded_paths.map(|p| (normalize(p), p)).collect();
+
+        let find_exact = |candidate: &str| -> Option<String> {
+            let cand = normalize(candidate);
+            normalized
+                .iter()
+                .find(|(norm, _)| *norm == cand)
+                .map(|(_, orig)| (*orig).clone())
+        };
+
         match self {
             ModulePath::Std => {
-                // The standard library's entry point is std/_std.rue. The
-                // driver loads it from $RUE_STD_PATH or an adjacent std/
-                // directory (see discover_and_load_imports in the rue crate);
-                // here we just match it among the loaded files.
-                self.resolve_explicit("_std.rue", loaded_paths)
+                // The standard library's entry point is `_std.rue`. The driver
+                // loads it from $RUE_STD_PATH or an adjacent std/ directory
+                // (see discover_and_load_imports in the rue crate); here we
+                // just match it among the loaded files. Std is not
+                // importer-relative, so base_dirs are ignored.
+                for (_, orig) in &normalized {
+                    if boundary_ends(orig, "_std.rue") {
+                        return DirResolution::Resolved((*orig).clone());
+                    }
+                }
+                DirResolution::NotFound
             }
-            ModulePath::ExplicitRue { path } => self.resolve_explicit(path, loaded_paths),
-            ModulePath::Simple { path } => self.resolve_simple(path, loaded_paths),
+            ModulePath::ExplicitRue { path } => {
+                for base in base_dirs {
+                    if let Some(hit) = find_exact(&join_base(base, path)) {
+                        return DirResolution::Resolved(hit);
+                    }
+                }
+                DirResolution::NotFound
+            }
+            ModulePath::Simple { path } => {
+                let basename = Path::new(path)
+                    .file_name()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or(path);
+                for base in base_dirs {
+                    let file_module = find_exact(&join_base(base, &format!("{path}.rue")));
+                    let dir_module =
+                        find_exact(&join_base(base, &format!("{path}/_{basename}.rue")));
+                    match (file_module, dir_module) {
+                        (Some(file_module), Some(dir_module)) => {
+                            // Both forms present in the SAME base directory:
+                            // ambiguous, not a precedence question (E0708),
+                            // mirroring Rust's E0761.
+                            return DirResolution::Ambiguous {
+                                file_module,
+                                dir_module,
+                            };
+                        }
+                        (Some(f), None) => return DirResolution::Resolved(f),
+                        (None, Some(d)) => return DirResolution::Resolved(d),
+                        (None, None) => continue,
+                    }
+                }
+                DirResolution::NotFound
+            }
         }
     }
+}
 
-    /// Detect the dual-entity ambiguity for a simple import: BOTH a file
-    /// module `{path}.rue` and a directory module `{path}/_{basename}.rue`
-    /// exist among the loaded files. Mirrors Rust's E0761 (module file found
-    /// at both locations): silently preferring one is a footgun, so callers
-    /// turn this into a hard error. Returns (file_module, dir_module).
-    pub fn find_ambiguity<'a, I>(&self, loaded_paths: I) -> Option<(String, String)>
-    where
-        I: Iterator<Item = &'a String>,
-    {
-        let ModulePath::Simple { path } = self else {
-            return None;
-        };
-        let import_with_rue = format!("{}.rue", path);
-        let basename = Path::new(path)
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or(path);
-        let facade_suffix = format!("{}/_{}.rue", basename, basename);
-
-        let boundary_match = |candidate: &str, suffix: &str| -> bool {
-            candidate.ends_with(suffix) && {
-                let prefix_len = candidate.len() - suffix.len();
-                prefix_len == 0 || candidate.as_bytes()[prefix_len - 1] == b'/'
-            }
-        };
-
-        let mut file_module = None;
-        let mut dir_module = None;
-        for p in loaded_paths {
-            if file_module.is_none() && boundary_match(p, &import_with_rue) {
-                file_module = Some(p.clone());
-            } else if dir_module.is_none() && boundary_match(p, &facade_suffix) {
-                dir_module = Some(p.clone());
-            }
-        }
-        file_module.zip(dir_module)
-    }
-
-    /// Resolve an explicit `.rue` path.
-    fn resolve_explicit<'a, I>(&self, import_path: &str, loaded_paths: I) -> Option<String>
-    where
-        I: Iterator<Item = &'a String>,
-    {
-        let collected: Vec<_> = loaded_paths.collect();
-
-        // Priority 1: Exact match
-        for file_path in &collected {
-            if *file_path == import_path {
-                return Some((*file_path).clone());
-            }
-        }
-
-        // Priority 2: Path ends with import_path
-        // This handles cases like "foo.rue" matching "/path/to/foo.rue"
-        for file_path in &collected {
-            if file_path.ends_with(import_path) {
-                // Verify it's a proper path boundary (preceded by / or start of string)
-                let prefix_len = file_path.len() - import_path.len();
-                if prefix_len == 0 || file_path.as_bytes()[prefix_len - 1] == b'/' {
-                    return Some((*file_path).clone());
-                }
-            }
-        }
-
-        None
-    }
-
-    /// Resolve a simple (no extension) import path.
-    fn resolve_simple<'a, I>(&self, import_path: &str, loaded_paths: I) -> Option<String>
-    where
-        I: Iterator<Item = &'a String>,
-    {
-        let import_with_rue = format!("{}.rue", import_path);
-        let collected: Vec<_> = loaded_paths.collect();
-
-        // The directory-module facade lives INSIDE the directory:
-        // `@import("utils")` -> `utils/_utils.rue`, like the stdlib's
-        // `std/_std.rue` (placement ratified in RUE-137). Matching the bare
-        // basename would let a stray sibling `_utils.rue` masquerade as a
-        // directory module.
-        let basename = Path::new(import_path)
-            .file_name()
-            .and_then(|s| s.to_str())
-            .unwrap_or(import_path);
-        let facade_suffix = format!("{}/_{}.rue", basename, basename);
-
-        // Priority 1: Look for exact {path}.rue
-        for file_path in &collected {
-            if *file_path == &import_with_rue {
-                return Some((*file_path).clone());
-            }
-        }
-
-        // Priority 2: Look for path ending with {path}.rue
-        // This handles "utils/strings" matching "/project/utils/strings.rue"
-        for file_path in &collected {
-            if file_path.ends_with(&import_with_rue) {
-                // Verify it's a proper path boundary
-                let prefix_len = file_path.len() - import_with_rue.len();
-                if prefix_len == 0 || file_path.as_bytes()[prefix_len - 1] == b'/' {
-                    return Some((*file_path).clone());
-                }
-            }
-        }
-
-        // Priority 3: Look for files matching just the basename (e.g., "math" matches "src/math.rue")
-        for file_path in &collected {
-            if let Some(file_name) = Path::new(file_path.as_str())
-                .file_stem()
-                .and_then(|s| s.to_str())
-            {
-                if file_name == basename {
-                    return Some((*file_path).clone());
-                }
-            }
-        }
-
-        // Priority 4: Look for the in-directory facade ({foo}/_{foo}.rue)
-        for file_path in &collected {
-            if file_path.ends_with(&facade_suffix) {
-                // Verify it's a proper path boundary
-                let prefix_len = file_path.len() - facade_suffix.len();
-                if prefix_len == 0 || file_path.as_bytes()[prefix_len - 1] == b'/' {
-                    return Some((*file_path).clone());
-                }
-            }
-        }
-
-        None
+/// Whether `candidate` ends with `suffix` at a path boundary (start of string
+/// or immediately after a `/`).
+fn boundary_ends(candidate: &str, suffix: &str) -> bool {
+    candidate.ends_with(suffix) && {
+        let prefix_len = candidate.len() - suffix.len();
+        prefix_len == 0 || candidate.as_bytes()[prefix_len - 1] == b'/'
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn owned(paths: &[&str]) -> Vec<String> {
+        paths.iter().map(|s| s.to_string()).collect()
+    }
 
     // =========================================================================
     // Parsing tests
@@ -286,10 +276,23 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_resolve_std_not_supported() {
-        let paths = vec!["main.rue".to_string()];
+    fn test_resolve_std_not_present() {
+        let paths = owned(&["main.rue"]);
         let module = ModulePath::Std;
-        assert_eq!(module.resolve(paths.iter()), None);
+        assert_eq!(
+            module.resolve_in_dirs(&[""], paths.iter()),
+            DirResolution::NotFound
+        );
+    }
+
+    #[test]
+    fn test_resolve_std_present() {
+        let paths = owned(&["main.rue", "std/_std.rue"]);
+        let module = ModulePath::Std;
+        assert_eq!(
+            module.resolve_in_dirs(&[""], paths.iter()),
+            DirResolution::Resolved("std/_std.rue".to_string())
+        );
     }
 
     // =========================================================================
@@ -297,45 +300,44 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_resolve_explicit_exact_match() {
-        let paths = vec!["foo.rue".to_string(), "bar.rue".to_string()];
+    fn test_resolve_explicit_in_importer_dir() {
+        let paths = owned(&["a/foo.rue", "b/foo.rue"]);
         let module = ModulePath::ExplicitRue {
             path: "foo.rue".to_string(),
         };
-        assert_eq!(module.resolve(paths.iter()), Some("foo.rue".to_string()));
-    }
-
-    #[test]
-    fn test_resolve_explicit_suffix_match() {
-        let paths = vec!["/project/src/foo.rue".to_string()];
-        let module = ModulePath::ExplicitRue {
-            path: "foo.rue".to_string(),
-        };
+        // Importer in `a/` gets a/foo.rue; importer in `b/` gets b/foo.rue.
         assert_eq!(
-            module.resolve(paths.iter()),
-            Some("/project/src/foo.rue".to_string())
+            module.resolve_in_dirs(&["a"], paths.iter()),
+            DirResolution::Resolved("a/foo.rue".to_string())
+        );
+        assert_eq!(
+            module.resolve_in_dirs(&["b"], paths.iter()),
+            DirResolution::Resolved("b/foo.rue".to_string())
         );
     }
 
     #[test]
     fn test_resolve_explicit_no_false_substring_match() {
-        // "foo.rue" should NOT match "xfoo.rue" (no path boundary)
-        let paths = vec!["xfoo.rue".to_string()];
+        // "foo.rue" from base "" should NOT match "xfoo.rue".
+        let paths = owned(&["xfoo.rue"]);
         let module = ModulePath::ExplicitRue {
             path: "foo.rue".to_string(),
         };
-        assert_eq!(module.resolve(paths.iter()), None);
+        assert_eq!(
+            module.resolve_in_dirs(&[""], paths.iter()),
+            DirResolution::NotFound
+        );
     }
 
     #[test]
     fn test_resolve_explicit_nested_path() {
-        let paths = vec!["/project/utils/strings.rue".to_string()];
+        let paths = owned(&["proj/utils/strings.rue"]);
         let module = ModulePath::ExplicitRue {
             path: "utils/strings.rue".to_string(),
         };
         assert_eq!(
-            module.resolve(paths.iter()),
-            Some("/project/utils/strings.rue".to_string())
+            module.resolve_in_dirs(&["proj"], paths.iter()),
+            DirResolution::Resolved("proj/utils/strings.rue".to_string())
         );
     }
 
@@ -344,106 +346,182 @@ mod tests {
     // =========================================================================
 
     #[test]
-    fn test_resolve_simple_exact_match() {
-        let paths = vec!["foo.rue".to_string()];
-        let module = ModulePath::Simple {
-            path: "foo".to_string(),
-        };
-        assert_eq!(module.resolve(paths.iter()), Some("foo.rue".to_string()));
-    }
-
-    #[test]
-    fn test_resolve_simple_suffix_match() {
-        let paths = vec!["/project/src/foo.rue".to_string()];
+    fn test_resolve_simple_in_importer_dir() {
+        let paths = owned(&["foo.rue"]);
         let module = ModulePath::Simple {
             path: "foo".to_string(),
         };
         assert_eq!(
-            module.resolve(paths.iter()),
-            Some("/project/src/foo.rue".to_string())
+            module.resolve_in_dirs(&[""], paths.iter()),
+            DirResolution::Resolved("foo.rue".to_string())
+        );
+    }
+
+    #[test]
+    fn test_resolve_simple_importer_relative_disambiguates() {
+        // Face A (RUE-266): two foo.rue in different dirs; each importer gets
+        // its OWN foo, not whichever happens to iterate first.
+        let paths = owned(&["a/foo.rue", "b/foo.rue"]);
+        let module = ModulePath::Simple {
+            path: "foo".to_string(),
+        };
+        assert_eq!(
+            module.resolve_in_dirs(&["a"], paths.iter()),
+            DirResolution::Resolved("a/foo.rue".to_string())
+        );
+        assert_eq!(
+            module.resolve_in_dirs(&["b"], paths.iter()),
+            DirResolution::Resolved("b/foo.rue".to_string())
         );
     }
 
     #[test]
     fn test_resolve_simple_nested_path() {
-        let paths = vec!["/project/utils/strings.rue".to_string()];
+        let paths = owned(&["proj/utils/strings.rue"]);
         let module = ModulePath::Simple {
             path: "utils/strings".to_string(),
         };
         assert_eq!(
-            module.resolve(paths.iter()),
-            Some("/project/utils/strings.rue".to_string())
-        );
-    }
-
-    #[test]
-    fn test_resolve_simple_basename_match() {
-        // "math" should match "src/math.rue" by basename
-        let paths = vec!["src/math.rue".to_string()];
-        let module = ModulePath::Simple {
-            path: "math".to_string(),
-        };
-        assert_eq!(
-            module.resolve(paths.iter()),
-            Some("src/math.rue".to_string())
+            module.resolve_in_dirs(&["proj"], paths.iter()),
+            DirResolution::Resolved("proj/utils/strings.rue".to_string())
         );
     }
 
     #[test]
     fn test_resolve_simple_facade_file() {
         // The facade lives INSIDE the directory (RUE-137): utils/_utils.rue.
-        let paths = vec!["utils/_utils.rue".to_string()];
+        let paths = owned(&["utils/_utils.rue"]);
         let module = ModulePath::Simple {
             path: "utils".to_string(),
         };
         assert_eq!(
-            module.resolve(paths.iter()),
-            Some("utils/_utils.rue".to_string())
+            module.resolve_in_dirs(&[""], paths.iter()),
+            DirResolution::Resolved("utils/_utils.rue".to_string())
         );
     }
 
     #[test]
     fn test_resolve_simple_sibling_facade_rejected() {
         // The pre-RUE-137 sibling layout is NOT a directory module.
-        let paths = vec!["_utils.rue".to_string()];
+        let paths = owned(&["_utils.rue"]);
         let module = ModulePath::Simple {
             path: "utils".to_string(),
         };
-        assert_eq!(module.resolve(paths.iter()), None);
-    }
-
-    #[test]
-    fn test_find_ambiguity_both_forms() {
-        // Both "foo.rue" and "foo/_foo.rue" loaded: ambiguous, not a
-        // precedence question (callers raise E0708).
-        let paths = vec!["foo/_foo.rue".to_string(), "foo.rue".to_string()];
-        let module = ModulePath::Simple {
-            path: "foo".to_string(),
-        };
         assert_eq!(
-            module.find_ambiguity(paths.iter()),
-            Some(("foo.rue".to_string(), "foo/_foo.rue".to_string()))
+            module.resolve_in_dirs(&[""], paths.iter()),
+            DirResolution::NotFound
         );
     }
 
     #[test]
-    fn test_find_ambiguity_single_form_is_none() {
-        let paths = vec!["foo.rue".to_string()];
+    fn test_resolve_simple_no_cross_dir_basename_match() {
+        // The old program-global resolver matched "math" against "src/math.rue"
+        // by bare basename regardless of the importer's directory — the root of
+        // Face A. Anchored resolution refuses it: from base "" there is no
+        // math.rue.
+        let paths = owned(&["src/math.rue"]);
+        let module = ModulePath::Simple {
+            path: "math".to_string(),
+        };
+        assert_eq!(
+            module.resolve_in_dirs(&[""], paths.iter()),
+            DirResolution::NotFound
+        );
+        // ...but from base "src" it resolves.
+        assert_eq!(
+            module.resolve_in_dirs(&["src"], paths.iter()),
+            DirResolution::Resolved("src/math.rue".to_string())
+        );
+    }
+
+    #[test]
+    fn test_ambiguity_within_one_dir() {
+        // Both "foo.rue" and "foo/_foo.rue" in the SAME base dir: ambiguous.
+        let paths = owned(&["d/foo/_foo.rue", "d/foo.rue"]);
         let module = ModulePath::Simple {
             path: "foo".to_string(),
         };
-        assert_eq!(module.find_ambiguity(paths.iter()), None);
+        assert_eq!(
+            module.resolve_in_dirs(&["d"], paths.iter()),
+            DirResolution::Ambiguous {
+                file_module: "d/foo.rue".to_string(),
+                dir_module: "d/foo/_foo.rue".to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_no_false_cross_dir_ambiguity() {
+        // Face B (RUE-266): a file module in one dir and a facade in ANOTHER dir
+        // are two unrelated, individually-unambiguous imports — not a
+        // collision. Each importer resolves within its own dir.
+        let paths = owned(&["sub/foo.rue", "facdir/foo/_foo.rue"]);
+        let module = ModulePath::Simple {
+            path: "foo".to_string(),
+        };
+        assert_eq!(
+            module.resolve_in_dirs(&["sub"], paths.iter()),
+            DirResolution::Resolved("sub/foo.rue".to_string())
+        );
+        assert_eq!(
+            module.resolve_in_dirs(&["facdir"], paths.iter()),
+            DirResolution::Resolved("facdir/foo/_foo.rue".to_string())
+        );
+    }
+
+    #[test]
+    fn test_root_dir_fallback() {
+        // Importer's own dir has no match; the root dir (second base) does
+        // (spec 10.2:2).
+        let paths = owned(&["shared.rue", "sub/user.rue"]);
+        let module = ModulePath::Simple {
+            path: "shared".to_string(),
+        };
+        // base_dirs = [importer "sub", root ""]
+        assert_eq!(
+            module.resolve_in_dirs(&["sub", ""], paths.iter()),
+            DirResolution::Resolved("shared.rue".to_string())
+        );
+    }
+
+    #[test]
+    fn test_importer_dir_takes_precedence_over_root() {
+        // A module exists both next to the importer and at the root; the
+        // importer-relative one wins (spec 10.2:2).
+        let paths = owned(&["foo.rue", "sub/foo.rue"]);
+        let module = ModulePath::Simple {
+            path: "foo".to_string(),
+        };
+        assert_eq!(
+            module.resolve_in_dirs(&["sub", ""], paths.iter()),
+            DirResolution::Resolved("sub/foo.rue".to_string())
+        );
     }
 
     #[test]
     fn test_resolve_simple_no_false_substring_match() {
-        // "math" should NOT match "mathematics.rue"
-        let paths = vec!["mathematics.rue".to_string()];
+        // "math" should NOT match "mathematics.rue".
+        let paths = owned(&["mathematics.rue"]);
         let module = ModulePath::Simple {
             path: "math".to_string(),
         };
-        // The basename "mathematics" != "math", so no match
-        assert_eq!(module.resolve(paths.iter()), None);
+        assert_eq!(
+            module.resolve_in_dirs(&[""], paths.iter()),
+            DirResolution::NotFound
+        );
+    }
+
+    #[test]
+    fn test_normalized_dot_components_match() {
+        // Loaded path spelled with a leading "./" still matches (spec 10.2:4).
+        let paths = owned(&["./helper.rue"]);
+        let module = ModulePath::Simple {
+            path: "helper".to_string(),
+        };
+        assert_eq!(
+            module.resolve_in_dirs(&["."], paths.iter()),
+            DirResolution::Resolved("./helper.rue".to_string())
+        );
     }
 
     // =========================================================================
@@ -452,11 +530,14 @@ mod tests {
 
     #[test]
     fn test_resolve_not_found() {
-        let paths = vec!["other.rue".to_string()];
+        let paths = owned(&["other.rue"]);
         let module = ModulePath::Simple {
             path: "foo".to_string(),
         };
-        assert_eq!(module.resolve(paths.iter()), None);
+        assert_eq!(
+            module.resolve_in_dirs(&[""], paths.iter()),
+            DirResolution::NotFound
+        );
     }
 
     #[test]
@@ -465,6 +546,9 @@ mod tests {
         let module = ModulePath::Simple {
             path: "foo".to_string(),
         };
-        assert_eq!(module.resolve(paths.iter()), None);
+        assert_eq!(
+            module.resolve_in_dirs(&[""], paths.iter()),
+            DirResolution::NotFound
+        );
     }
 }

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -10,9 +10,24 @@
 //! parallel-analysis pipeline and was removed per ADR-0033 phase 1b.
 
 use std::collections::HashMap;
+use std::path::{Component, Path, PathBuf};
 use std::sync::{PoisonError, RwLock};
 
 use crate::types::{ModuleDef, ModuleId};
+
+/// Lexically normalize a resolved file path for use as a registry key, dropping
+/// `.` (current-directory) components so `./foo.rue` and `foo.rue` key to the
+/// same module (spec 10.2:4). Purely lexical — never touches the filesystem.
+fn normalize_key(path: &str) -> String {
+    let mut out = PathBuf::new();
+    for comp in Path::new(path).components() {
+        match comp {
+            Component::CurDir => {}
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out.to_string_lossy().into_owned()
+}
 
 /// Thread-safe registry for modules.
 ///
@@ -20,7 +35,13 @@ use crate::types::{ModuleDef, ModuleId};
 /// parallel function analysis. It uses double-checked locking to minimize contention.
 #[derive(Debug)]
 pub struct ModuleRegistry {
-    /// Maps import path (e.g., "math.rue") to ModuleId.
+    /// Maps a module's *resolved* file path (normalized) to its ModuleId.
+    ///
+    /// Keying by the resolved file rather than the `@import` string is what
+    /// makes modules importer-relative (RUE-266): two `@import("foo")` sites in
+    /// different directories resolve to different files and get distinct
+    /// modules, while any two imports that resolve to the *same* file share one
+    /// module (spec 10.2:4), whatever string or spelling reached it.
     paths: RwLock<HashMap<String, ModuleId>>,
     /// Module definitions indexed by ModuleId.
     defs: RwLock<Vec<ModuleDef>>,
@@ -35,23 +56,21 @@ impl ModuleRegistry {
         }
     }
 
-    /// Look up a module by import path.
-    pub fn get(&self, import_path: &str) -> Option<ModuleId> {
-        self.paths
-            .read()
-            .unwrap_or_else(PoisonError::into_inner)
-            .get(import_path)
-            .copied()
-    }
-
     /// Get or create a module for the given import path and resolved file path.
+    ///
+    /// The module is keyed by its *resolved* `file_path` (normalized), so two
+    /// importers that reach the same file share one module and two that reach
+    /// different files get distinct modules even under the same `@import`
+    /// string (RUE-266). The `import_path` is retained only for diagnostics.
     ///
     /// Returns the ModuleId and whether it was newly created.
     pub fn get_or_create(&self, import_path: String, file_path: String) -> (ModuleId, bool) {
+        let key = normalize_key(&file_path);
+
         // Fast path: check if already exists
         {
             let paths = self.paths.read().unwrap_or_else(PoisonError::into_inner);
-            if let Some(id) = paths.get(&import_path) {
+            if let Some(id) = paths.get(&key) {
                 return (*id, false);
             }
         }
@@ -59,14 +78,14 @@ impl ModuleRegistry {
         // Slow path: acquire write lock and insert
         let mut paths = self.paths.write().unwrap_or_else(PoisonError::into_inner);
         // Double-check after acquiring write lock
-        if let Some(id) = paths.get(&import_path) {
+        if let Some(id) = paths.get(&key) {
             return (*id, false);
         }
 
         let mut defs = self.defs.write().unwrap_or_else(PoisonError::into_inner);
         let id = ModuleId::new(defs.len() as u32);
-        defs.push(ModuleDef::new(import_path.clone(), file_path));
-        paths.insert(import_path, id);
+        defs.push(ModuleDef::new(import_path, file_path));
+        paths.insert(key, id);
         (id, true)
     }
 

--- a/crates/rue-cli-tests/cases/module_importer_relative.toml
+++ b/crates/rue-cli-tests/cases/module_importer_relative.toml
@@ -1,0 +1,99 @@
+# Importer-relative @import resolution (RUE-266).
+#
+# @import resolution and the dual-entity ambiguity check are judged relative
+# to the IMPORTING file's own directory (spec 10.2:2), not program-globally.
+# Before the fix, a relative `@import("foo")` resolved to whichever `foo.rue`
+# happened to iterate first across the whole program (Face A), and two
+# unrelated, individually-unambiguous `@import("foo")` sites in different
+# directories tripped a false E0708 (Face B).
+
+[section]
+id = "cli.module_importer_relative"
+name = "Importer-relative module resolution"
+description = "Relative @import resolves against the importing file's own directory."
+
+# Face A: two directories each define their OWN foo.rue and each contain a
+# module that does `@import("foo")`. Each must bind to the foo NEXT TO IT, so
+# the two modules see different values (10 vs 20). The driver auto-discovers
+# a/foo.rue and b/foo.rue transitively from the importing files.
+[[case]]
+name = "same_import_string_resolves_per_directory"
+files = [
+    { path = "main.rue", source = """
+const a = @import("a/mod_a");
+const b = @import("b/mod_b");
+
+fn main() -> i32 {
+    @dbg(a.a_val());
+    @dbg(b.b_val());
+    0
+}
+""" },
+    { path = "a/mod_a.rue", source = """
+const foo = @import("foo");
+pub fn a_val() -> i32 { foo.a_foo() }
+""" },
+    { path = "a/foo.rue", source = """
+pub fn a_foo() -> i32 { 10 }
+""" },
+    { path = "b/mod_b.rue", source = """
+const foo = @import("foo");
+pub fn b_val() -> i32 { foo.b_foo() }
+""" },
+    { path = "b/foo.rue", source = """
+pub fn b_foo() -> i32 { 20 }
+""" },
+]
+stdout = "10\n20\n"
+
+# Face B: one importer resolves `foo` to a FILE module (sub/foo.rue), another
+# resolves `foo` to a DIRECTORY-module facade (facdir/foo/_foo.rue). These are
+# two unrelated imports, each unambiguous in its own directory — no E0708.
+[[case]]
+name = "file_module_and_facade_in_different_dirs_are_not_ambiguous"
+files = [
+    { path = "main.rue", source = """
+const u1 = @import("sub/user1");
+const u2 = @import("facdir/user2");
+
+fn main() -> i32 {
+    @dbg(u1.one());
+    @dbg(u2.two());
+    0
+}
+""" },
+    { path = "sub/user1.rue", source = """
+const foo = @import("foo");
+pub fn one() -> i32 { foo.sfoo() }
+""" },
+    { path = "sub/foo.rue", source = """
+pub fn sfoo() -> i32 { 3 }
+""" },
+    { path = "facdir/user2.rue", source = """
+const foo = @import("foo");
+pub fn two() -> i32 { foo.dfoo() }
+""" },
+    { path = "facdir/foo/_foo.rue", source = """
+pub fn dfoo() -> i32 { 4 }
+""" },
+]
+stdout = "3\n4\n"
+
+# A genuine dual-entity ambiguity within ONE directory still errors (E0708):
+# both `foo.rue` and `foo/_foo.rue` sit next to the importer.
+[[case]]
+name = "genuine_single_dir_ambiguity_still_errors"
+files = [
+    { path = "main.rue", source = """
+const foo = @import("foo");
+fn main() -> i32 { foo.v_file() }
+""" },
+    { path = "foo.rue", source = """
+pub fn v_file() -> i32 { 1 }
+""" },
+    { path = "foo/_foo.rue", source = """
+pub fn v_dir() -> i32 { 2 }
+""" },
+]
+compile_fail = true
+error_contains = ["E0708", "foo"]


### PR DESCRIPTION
@import resolution and the ambiguity check were program-global, not importer-relative (spec 10.2:2) — a correctness bug in multi-directory projects: the same @import(foo) could resolve to a different foo.rue depending on unrelated imports elsewhere, and two unrelated individually-unambiguous @import(foo) sites in different dirs falsely collided (E0708).

- module_path.rs: new resolve_in_dirs / DirResolution API anchors candidates to base dirs (importer's dir, then root's) and judges ambiguity within one dir.
- analysis.rs (minimal): derive importer dir (from the import span) + root dir (min FileId), pass into resolve_in_dirs.
- sema_context.rs: a third face of the same root — the module registry keyed modules by the @import STRING, collapsing two foo imports into one module. Now keyed by resolved file path (spec 10.2:4); without this, importer-relative resolution still failed at runtime.

Verified by running the real CLI on disk: two directories each with their own foo.rue and a local @import(foo) each resolve to their OWN foo (gives 30, no false E0708); genuine single-dir ambiguity still E0708; existing single-dir multi-file programs (RUE-239/240) unaffected; both explicit-file-list and driver auto-discovery. Full test.sh green; 3 new CLI cases; module_path unit tests rewritten.

Fixes RUE-266

Generated with Claude Code