### PR TITLE
Pattern matching: comptime dead-arm inference, duplicate-binding rejection, never-coercion (RUE-268, RUE-269, RUE-270)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -11,6 +11,7 @@ use super::types::{InferType, TypeVarAllocator, TypeVarId};
 use crate::Type;
 use crate::intern_pool::TypeInternPool;
 use crate::scope::ScopedContext;
+use crate::sema::ConstValue;
 use crate::types::{
     ArrayLen, PtrMutability, StructId, TypeKind, parse_array_type_syntax, parse_pointer_type_syntax,
 };
@@ -211,6 +212,15 @@ pub struct ConstraintGenerator<'a> {
     /// constraint generation (RUE-16). `None` only in unit tests; production
     /// passes the map via [`Self::with_const_values`].
     const_values: Option<&'a HashMap<Spur, i128>>,
+    /// Comptime *value* parameters known for the specialization currently being
+    /// analyzed (`comptime n: i32` → `n = 0` for the call `f(0)`). Lets a
+    /// `match` on a comptime-known scrutinee prune to its selected arm during
+    /// constraint generation, so only that arm participates in inference —
+    /// mirroring sema's arm selection (spec 4.14:19). Without this, inference
+    /// cross-constrains every arm and rejects a valid program whose statically
+    /// unselected arm has a different type (RUE-268). `None` for ordinary
+    /// (non-specialized) functions, where every match is treated as runtime.
+    comptime_values: Option<&'a HashMap<Spur, ConstValue>>,
     /// Type intern pool for creating pointer and array types during constraint generation.
     type_pool: &'a TypeInternPool,
 }
@@ -264,6 +274,7 @@ impl<'a> ConstraintGenerator<'a> {
             comptime_local_types: None,
             extra_method_sigs: None,
             const_values: None,
+            comptime_values: None,
             type_pool,
         }
     }
@@ -312,6 +323,19 @@ impl<'a> ConstraintGenerator<'a> {
     /// `const_values` field (RUE-16).
     pub fn with_const_values(mut self, const_values: &'a HashMap<Spur, i128>) -> Self {
         self.const_values = Some(const_values);
+        self
+    }
+
+    /// Provide the comptime value parameters of the specialization being
+    /// analyzed so a `match` on a comptime-known scrutinee prunes to its
+    /// selected arm during constraint generation. See the `comptime_values`
+    /// field (RUE-268). `None` (ordinary functions) leaves every match
+    /// runtime.
+    pub fn with_comptime_values(
+        mut self,
+        comptime_values: Option<&'a HashMap<Spur, ConstValue>>,
+    ) -> Self {
+        self.comptime_values = comptime_values;
         self
     }
 
@@ -1234,6 +1258,26 @@ impl<'a> ConstraintGenerator<'a> {
                 let scrutinee_info = self.generate(*scrutinee, ctx);
                 let arms = self.rir.get_match_arms(*arms_start, *arms_len);
 
+                // Comptime-known scrutinee (spec 4.14:19): when the scrutinee
+                // is a comptime value known for this specialization, sema
+                // selects and analyzes only the matching arm's body. Inference
+                // must mirror that here — cross-constraining all arms would
+                // reject a valid program whose statically-unselected arm has a
+                // deliberately different type (RUE-268). Only the selected arm
+                // participates; its body's type is the match's type. Any shape
+                // this doesn't understand falls through to the runtime path,
+                // which unifies every arm (so a genuine runtime match still
+                // errors when arms disagree). This is a strict subset of the
+                // scrutinees sema prunes, so the selected arm always has an
+                // inferred type when sema later prunes to it.
+                if let Some(selected) = self.comptime_selected_arm(*scrutinee, &arms) {
+                    ctx.push_scope();
+                    let body_info = self.generate(selected, ctx);
+                    ctx.pop_scope();
+                    self.record_type(inst_ref, body_info.ty.clone());
+                    return ExprInfo::new(body_info.ty, span);
+                }
+
                 // Collect arm types, handling Never coercion
                 let mut arm_types: Vec<ExprInfo> = Vec::new();
                 for (pattern, body) in arms.iter() {
@@ -1794,6 +1838,15 @@ impl<'a> ConstraintGenerator<'a> {
         let lhs_info = self.generate(lhs, ctx);
         let rhs_info = self.generate(rhs, ctx);
 
+        // A diverging operand (`!`, e.g. `n - match m {}`) makes the whole
+        // expression diverge. Never coerces to any type (spec 3.4:3-4), so
+        // don't constrain the operands to one another — doing so would drag an
+        // integer literal to `!` and then bogusly range-check it against `!`
+        // (RUE-270). The result is `!`; the surrounding context coerces it.
+        if Self::is_never_concrete(&lhs_info.ty) || Self::is_never_concrete(&rhs_info.ty) {
+            return InferType::Concrete(Type::NEVER);
+        }
+
         // Both operands must have the same type
         // Use a fresh type variable for the result
         let result_var = self.fresh_var();
@@ -1816,6 +1869,12 @@ impl<'a> ConstraintGenerator<'a> {
         result_ty
     }
 
+    /// Whether `ty` is *concretely* the never type `!` (a diverging expression),
+    /// as opposed to an unresolved type variable that might resolve to it.
+    fn is_never_concrete(ty: &InferType) -> bool {
+        matches!(ty, InferType::Concrete(t) if t.is_never())
+    }
+
     /// Generate constraints for the `+` operator (RUE-17 Phase 1, ADR-0035).
     ///
     /// `+` is arithmetic addition on integers and concatenation on two
@@ -1832,6 +1891,15 @@ impl<'a> ConstraintGenerator<'a> {
     ) -> InferType {
         let lhs_info = self.generate(lhs, ctx);
         let rhs_info = self.generate(rhs, ctx);
+
+        // A diverging operand (`!`, e.g. `1 + match n {}`) makes the whole
+        // expression diverge; never coerces to any type (spec 3.4:3-4). Don't
+        // constrain the operands to one another (that would drag the integer
+        // literal `1` to `!` and range-check it against `!`, RUE-270). Checked
+        // before the String-concat overload so `s + match n {}` also diverges.
+        if Self::is_never_concrete(&lhs_info.ty) || Self::is_never_concrete(&rhs_info.ty) {
+            return InferType::Concrete(Type::NEVER);
+        }
 
         if self.is_string_concrete(&lhs_info.ty) || self.is_string_concrete(&rhs_info.ty) {
             let string_ty = self.string_infer_type();
@@ -1999,6 +2067,91 @@ impl<'a> ConstraintGenerator<'a> {
             }
             _ => None,
         }
+    }
+
+    /// If `scrutinee` is a comptime value known for this specialization and the
+    /// arm patterns form an exhaustive set this understands (integer/boolean
+    /// literals plus a wildcard), return the body of the single arm the value
+    /// selects. Mirrors sema's comptime arm selection (`analyze_match`, spec
+    /// 4.14:19) so inference constrains only the selected arm; the constraint
+    /// generator otherwise cross-constrains every arm and rejects a valid
+    /// program whose statically-unselected arm has a different type (RUE-268).
+    ///
+    /// Returns `None` — meaning "constrain all arms as a runtime match" — for
+    /// any shape not understood (a non-comptime or compound scrutinee, an enum
+    /// pattern, a non-exhaustive set). The comptime cases handled here are a
+    /// strict subset of those sema prunes with the same value and patterns, so
+    /// whenever this prunes, sema also prunes to the *same* arm — the only arm
+    /// whose body inference generated a type for.
+    fn comptime_selected_arm(
+        &self,
+        scrutinee: InstRef,
+        arms: &[(rue_rir::RirPattern, InstRef)],
+    ) -> Option<InstRef> {
+        use rue_rir::RirPattern;
+
+        // Only a bare reference to a comptime value parameter is evaluated
+        // here; richer scrutinees are left to sema's own selection.
+        // `ConstValue` is `Copy`, so take an owned copy for the match below.
+        let value: ConstValue = match &self.rir.get(scrutinee).data {
+            InstData::VarRef { name } | InstData::ParamRef { name, .. } => {
+                *self.comptime_values?.get(name)?
+            }
+            _ => return None,
+        };
+
+        let mut selected: Option<InstRef> = None;
+        let mut has_wildcard = false;
+        let mut bool_true_covered = false;
+        let mut bool_false_covered = false;
+        for (pattern, body) in arms {
+            let matched = match pattern {
+                RirPattern::Wildcard(_) => {
+                    has_wildcard = true;
+                    true
+                }
+                RirPattern::Int {
+                    value: magnitude,
+                    negative,
+                    ..
+                } => match value {
+                    ConstValue::Integer(n) => {
+                        let pat = if *negative {
+                            -(*magnitude as i128)
+                        } else {
+                            *magnitude as i128
+                        };
+                        pat == n
+                    }
+                    // Value/pattern kind mismatch — fall back to runtime path.
+                    _ => return None,
+                },
+                RirPattern::Bool(b, _) => match value {
+                    ConstValue::Bool(v) => {
+                        if *b {
+                            bool_true_covered = true;
+                        } else {
+                            bool_false_covered = true;
+                        }
+                        *b == v
+                    }
+                    _ => return None,
+                },
+                // Enum patterns: not understood here — runtime path.
+                _ => return None,
+            };
+            if matched && selected.is_none() {
+                selected = Some(*body);
+            }
+        }
+
+        // Exhaustiveness is a property of the pattern set (spec 4.7:9), still
+        // required when the value is comptime-known: a wildcard, or both bool
+        // values for a bool scrutinee. A non-exhaustive set falls back so sema
+        // reports the proper diagnostic on the runtime path.
+        let exhaustive = has_wildcard
+            || (matches!(value, ConstValue::Bool(_)) && bool_true_covered && bool_false_covered);
+        if exhaustive { selected } else { None }
     }
 
     /// Resolve a signature type symbol with type-parameter substitution,

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1976,6 +1976,7 @@ impl<'a> Sema<'a> {
         .with_const_values(&infer_ctx.const_values)
         .with_module_binding_types(&infer_ctx.module_binding_types)
         .with_comptime_local_types(&comptime_local_types)
+        .with_comptime_values(value_subst)
         .with_extra_method_sigs(&extra_method_sigs);
 
         // Build parameter map for constraint context.

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1731,6 +1731,22 @@ impl<'a> Sema<'a> {
             ));
         }
 
+        // Every payload binding must be a fresh name (spec 4.7:30). Reusing an
+        // identifier — `Rect(w, w)` — silently shadows the earlier binding and
+        // discards its value, so reject it (E0484, analogous to Rust E0416)
+        // rather than losing a field (RUE-269). Wildcards never reach here:
+        // `_` in payload position isn't a binding.
+        for (i, name) in bindings.iter().enumerate() {
+            if bindings[..i].contains(name) {
+                return Err(CompileError::new(
+                    ErrorKind::DuplicatePatternBinding {
+                        name: self.interner.resolve(name).to_string(),
+                    },
+                    pattern_span,
+                ));
+            }
+        }
+
         let mut stmts: Vec<u32> = Vec::with_capacity(bindings.len() * 2);
         for (i, binding_name) in bindings.iter().enumerate() {
             let field_ty = payload[i];

--- a/crates/rue-cli-tests/cases/match_inference_fixes.toml
+++ b/crates/rue-cli-tests/cases/match_inference_fixes.toml
@@ -1,0 +1,170 @@
+# Pattern-matching / type-inference fixes driven through the real CLI.
+#
+# Three bugs found by the 2026-07-03 pattern-matching hunt:
+#   RUE-268 comptime match arm pruning didn't exempt unselected arms from HM
+#           type-inference (a valid program with a wrong-typed dead arm was
+#           rejected with a bogus E0206).
+#   RUE-269 a duplicate binding name in an enum-payload pattern (`Rect(w, w)`)
+#           was silently accepted, shadowing and losing a field. Now E0484.
+#   RUE-270 an integer literal added to a never-typed `match n {}` was rejected
+#           with a bogus E0800 "literal out of range for '!'". `!` coerces.
+
+[section]
+id = "cli.match_inference_fixes"
+name = "Match arm pruning, duplicate bindings, never coercion"
+description = "Comptime match arm inference (RUE-268), duplicate pattern bindings (RUE-269), never-vs-literal coercion (RUE-270) through the real driver."
+
+# ---------------------------------------------------------------------------
+# RUE-268: comptime match only analyzes/type-checks the selected arm.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "comptime_match_dead_arm_wrong_type_ok"
+description = "RUE-268: a comptime match's statically-unselected arm may have a different type; only the selected arm is type-checked (spec 4.14:19)."
+files = [{ path = "main.rue", source = """
+fn f(comptime n: i32) -> i32 { match n { 0 => 42, _ => "never taken, wrong type" } }
+fn main() -> i32 {
+    @dbg(f(0));
+    0
+}
+""" }]
+stdout = "42\n"
+
+[[case]]
+name = "comptime_match_selects_other_arm_type"
+description = "RUE-268: when the comptime value selects a different arm, that arm's type is the match type (the dead first arm's String is ignored)."
+files = [{ path = "main.rue", source = """
+fn f(comptime n: i32) -> i32 { match n { 0 => "wrong", _ => 7 } }
+fn main() -> i32 {
+    @dbg(f(1));
+    0
+}
+""" }]
+stdout = "7\n"
+
+[[case]]
+name = "comptime_match_two_specializations"
+description = "RUE-268: distinct comptime values pick distinct arms; both specializations compile and run."
+files = [{ path = "main.rue", source = """
+fn f(comptime n: i32) -> i32 { match n { 0 => 42, _ => 99 } }
+fn main() -> i32 {
+    @dbg(f(0));
+    @dbg(f(5));
+    0
+}
+""" }]
+stdout = "42\n99\n"
+
+[[case]]
+name = "comptime_match_bool_dead_arm_wrong_type_ok"
+description = "RUE-268: same pruning for a comptime bool scrutinee — the unselected `false` arm's wrong type is not checked."
+files = [{ path = "main.rue", source = """
+fn f(comptime b: bool) -> i32 { match b { true => 42, false => "wrong type" } }
+fn main() -> i32 {
+    @dbg(f(true));
+    0
+}
+""" }]
+stdout = "42\n"
+
+[[case]]
+name = "runtime_match_disagreeing_arms_still_error"
+description = "RUE-268 control: a genuinely runtime match (non-comptime param) must still unify all arms and reject disagreeing types (E0206)."
+files = [{ path = "main.rue", source = """
+fn f(n: i32) -> i32 { match n { 0 => 42, _ => "runtime wrong" } }
+fn main() -> i32 { f(0) }
+""" }]
+compile_fail = true
+error_contains = ["E0206"]
+
+# ---------------------------------------------------------------------------
+# RUE-269: duplicate binding name in an enum-payload pattern is E0484.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "duplicate_payload_binding_rejected"
+description = "RUE-269: `Rect(w, w)` binds `w` twice — rejected with E0484 instead of silently dropping the first field."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Shape { Rect(i32, i32) }
+fn main() -> i32 { match Shape::Rect(3, 4) { Shape::Rect(w, w) => w } }
+""" }]
+compile_fail = true
+error_contains = ["E0484", "bound more than once"]
+
+[[case]]
+name = "distinct_payload_bindings_ok"
+description = "RUE-269 control: distinct payload binding names still compile and both fields are available."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Shape { Rect(i32, i32) }
+fn main() -> i32 {
+    @dbg(match Shape::Rect(3, 4) { Shape::Rect(w, h) => w + h });
+    0
+}
+""" }]
+stdout = "7\n"
+
+[[case]]
+name = "duplicate_payload_binding_three_fields"
+description = "RUE-269: a reused name anywhere in a longer payload (`Tri(a, b, a)`) is caught."
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+enum Tri { T(i32, i32, i32) }
+fn main() -> i32 { match Tri::T(1, 2, 3) { Tri::T(a, b, a) => a + b } }
+""" }]
+compile_fail = true
+error_contains = ["E0484"]
+
+# ---------------------------------------------------------------------------
+# RUE-270: never coerces past the integer-literal range check.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "literal_plus_empty_match_compiles"
+description = "RUE-270: `1 + match n {}` — the empty match has type `!`, which coerces to the literal's type (spec 3.4:3-4). Compiles (the fn is uncallable — Never is uninhabited)."
+compile_only = true
+files = [{ path = "main.rue", source = """
+enum Never {}
+fn absurd(n: Never) -> i32 { 1 + match n {} }
+fn main() -> i32 { 0 }
+""" }]
+
+[[case]]
+name = "let_annotated_empty_match_compiles"
+description = "RUE-270: `let x: i32 = match n {}` — `!` coerces to i32."
+compile_only = true
+files = [{ path = "main.rue", source = """
+enum Never {}
+fn absurd(n: Never) -> i32 { let x: i32 = match n {}; x }
+fn main() -> i32 { 0 }
+""" }]
+
+[[case]]
+name = "literal_plus_diverging_match_runs"
+description = "RUE-270: `1 + (match x { _ => return 1 })` — the arm diverges (`!`), coerces, and the function returns 1."
+files = [{ path = "main.rue", source = """
+fn absurd(x: i32) -> i32 { 1 + (match x { _ => return 1 }) }
+fn main() -> i32 { absurd(5) }
+""" }]
+exit_code = 1
+
+[[case]]
+name = "real_out_of_range_literal_still_errors"
+description = "RUE-270 control: `!` coercion must not suppress the range check against a *real* integer type — 300 doesn't fit u8, still E0800."
+compile_fail = true
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { let x: u8 = 300; 0 }
+""" }]
+error_contains = ["E0800"]
+
+[[case]]
+name = "out_of_range_literal_with_never_in_scope_still_errors"
+description = "RUE-270 control: a never-typed match elsewhere in the body must not mask an out-of-range literal (E0800 still fires)."
+compile_fail = true
+files = [{ path = "main.rue", source = """
+enum Never {}
+fn absurd(n: Never) -> i32 { let y: u8 = 300; let _ = match n {}; 0 }
+fn main() -> i32 { 0 }
+""" }]
+error_contains = ["E0800"]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -176,6 +176,11 @@ impl ErrorCode {
     /// Analogous to Rust's E0072 and a sibling of [`Self::CONST_INITIALIZER_CYCLE`]
     /// (E0461) for the type-definition graph.
     pub const RECURSIVE_TYPE_INFINITE_SIZE: Self = Self(483);
+    /// A pattern binds the same identifier more than once (e.g. an enum
+    /// payload pattern `Rect(w, w)`). Every binding in a pattern must be a
+    /// fresh name (spec 4.7:30); reusing one silently shadows the earlier
+    /// binding and discards its value (RUE-269, analogous to Rust E0416).
+    pub const DUPLICATE_PATTERN_BINDING: Self = Self(484);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -965,6 +970,11 @@ pub enum ErrorKind {
     TypeMismatch { expected: String, found: String },
     #[error("{}", format_argument_count(*.expected, *.found))]
     WrongArgumentCount { expected: usize, found: usize },
+    /// A pattern binds the same identifier more than once (spec 4.7:30):
+    /// e.g. an enum payload pattern `Rect(w, w)`. Reusing a name silently
+    /// shadows the earlier binding and discards its value (RUE-269).
+    #[error("identifier '{name}' is bound more than once in the same pattern")]
+    DuplicatePatternBinding { name: String },
 
     // Struct errors
     #[error("{}", format_missing_fields(.0))]
@@ -1321,6 +1331,7 @@ impl ErrorKind {
             ErrorKind::UseAfterMove(_) => ErrorCode::USE_AFTER_MOVE,
             ErrorKind::TypeMismatch { .. } => ErrorCode::TYPE_MISMATCH,
             ErrorKind::WrongArgumentCount { .. } => ErrorCode::WRONG_ARGUMENT_COUNT,
+            ErrorKind::DuplicatePatternBinding { .. } => ErrorCode::DUPLICATE_PATTERN_BINDING,
 
             // Struct/enum errors (E0400-E0499)
             ErrorKind::MissingFields(_) => ErrorCode::MISSING_FIELDS,

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1520,6 +1520,40 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "comptime_match_dead_arm_not_type_checked"
+spec = ["4.14:19"]
+description = "An unselected arm body is exempt from type inference too: a dead arm may have a different type from the selected one without a type-mismatch error (RUE-268). The sibling comptime_match_dead_arm_not_analyzed used an i32 dead arm, so it never exercised the cross-arm type-equality constraint."
+source = """
+fn f(comptime n: i32) -> i32 {
+    match n {
+        0 => 42,
+        _ => "never taken, wrong type",
+    }
+}
+fn main() -> i32 {
+    f(0)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_match_selected_arm_is_match_type"
+spec = ["4.14:19"]
+description = "When the comptime value selects a later arm, that arm's type is the match's type — the dead first arm's incompatible type is ignored (RUE-268)"
+source = """
+fn f(comptime n: i32) -> i32 {
+    match n {
+        0 => "wrong",
+        _ => 7,
+    }
+}
+fn main() -> i32 {
+    f(1)
+}
+"""
+exit_code = 7
+
+[[case]]
 name = "comptime_match_bool_scrutinee"
 spec = ["4.14:19"]
 description = "Arm selection works for bool comptime scrutinees; both specializations pick their own arm"

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -981,3 +981,21 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
+
+# Each payload binding must be a fresh name (4.7:30). Reusing an identifier —
+# `Rect(w, w)` — silently shadowed the earlier binding and lost its value;
+# it is now an E0484 error (RUE-269, analogous to Rust E0416).
+[[case]]
+name = "match_payload_binding_duplicate_name"
+spec = ["4.7:30"]
+preview = "enum_payloads"
+source = """
+enum Shape { Rect(i32, i32) }
+fn main() -> i32 {
+    match Shape::Rect(3, 4) {
+        Shape::Rect(w, w) => w,
+    }
+}
+"""
+compile_fail = true
+error_contains = "bound more than once"

--- a/crates/rue-spec/cases/types/never.toml
+++ b/crates/rue-spec/cases/types/never.toml
@@ -83,6 +83,28 @@ fn main() -> i32 {
 exit_code = 20
 
 [[case]]
+name = "never_empty_match_coerces_with_int_literal"
+spec = ["3.4:3", "3.4:4"]
+description = "A never-typed empty match (`match n {}` over an uninhabited enum) coerces to the integer type demanded by an arithmetic context: `1 + match n {}` must type-check, not be rejected as a literal out of range for '!' (RUE-270). `absurd` is uncallable — Never is uninhabited — so main is trivial."
+source = """
+enum Never {}
+fn absurd(n: Never) -> i32 { 1 + match n {} }
+fn main() -> i32 { 0 }
+"""
+exit_code = 0
+
+[[case]]
+name = "never_empty_match_coerces_in_let"
+spec = ["3.4:3", "3.4:4"]
+description = "A never-typed empty match coerces to an annotated let type (RUE-270)."
+source = """
+enum Never {}
+fn absurd(n: Never) -> i32 { let x: i32 = match n {}; x }
+fn main() -> i32 { 0 }
+"""
+exit_code = 0
+
+[[case]]
 name = "never_in_if_branch"
 spec = ["3.4:3", "3.4:4"]
 source = """


### PR DESCRIPTION
All found by the pattern-matching hunt; all rue-air.

**RUE-268:** a comptime match now prunes to the selected arm in HM inference (new comptime_selected_arm in generate.rs + a one-line value_subst plumb), so an unselected arm of a different type no longer forces a cross-arm type-equality error. f(comptime n){ match n { 0 => 42, _ => str } }; f(0) gives 42. Runtime matches still unify all arms (E0206 preserved). Side effect: the comptime-bool match/if form is fixed too.

**RUE-269:** a duplicate payload binding (Rect(w, w)) is now rejected with the new code E0484 (check in materialize_match_bindings) instead of silently shadowing and discarding a field. Distinct names still work.

**RUE-270:** 1 + match n {} (never-typed) no longer bogus-E0800s. The suggested unify.rs::bind fix broke let x: ! = 5 (bind can't tell a never VALUE from a ! ANNOTATION), so instead a binop with a never operand short-circuits to ! in generate.rs. Verified: 1 + match n {} compiles; let x: ! = 5 still E0800; a real out-of-range literal still E0800.

Verified by execution + full test.sh green; diff-fuzzer 300 seeds 0 disagreements. Follow-up noted: comptime-if had the same latent inference bug (fixed here as a side effect).

Fixes RUE-268
Fixes RUE-269
Fixes RUE-270

Generated with Claude Code