### PR TITLE
Generic type-function call directly in type position: fn f() -> Result(i32,i32) (RUE-241 complete)

### DIFF
--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1037,8 +1037,6 @@ impl Sema<'_> {
         if fn_info.return_type != Type::COMPTIME_TYPE {
             return Ok(None);
         }
-        let fn_body = fn_info.body;
-        let fn_span = fn_info.span;
         let params = fn_info.params;
         let param_names = self.param_arena.names(params).to_vec();
         let param_comptime = self.param_arena.comptime(params).to_vec();
@@ -1070,18 +1068,42 @@ impl Sema<'_> {
                 }
             }
         }
-        // The callee body sees only its own parameters. Evaluate it directly
-        // (rather than via the error-swallowing `try_*` wrapper) so a
-        // diagnostic raised inside the constructor propagates.
-        //
-        // Guard the reduction against unbounded self-recursion. A `-> type`
-        // function reduces eagerly on the host stack, so a constructor with no
-        // compile-time-known base case (`fn Bad() -> type { Bad() }`,
-        // `fn Wrap(comptime n: i32) -> type { Wrap(n + 1) }`) would overflow
-        // that stack and abort the compiler (SIGABRT) with no diagnostic. Cap
-        // the depth at the same bound the specialization pass uses for value
-        // recursion, emitting the identical E1200 (RUE-261, spec 4.14:18).
-        let mut callee_env = ComptimeEnv::with_subst(&callee_types, &callee_values);
+        // The callee body sees only its own parameters. Reduce it with the
+        // freshly-built substitution maps.
+        self.reduce_type_ctor_body(name, &callee_types, &callee_values)
+    }
+
+    /// Reduce a `-> type` constructor's body to a type value under the given
+    /// comptime parameter substitutions. Shared by
+    /// [`eval_comptime_type_call`] (value/const-expr positions, args evaluated
+    /// via [`eval_const_expr`]) and [`resolve_type_function_call`] (a
+    /// type-function call written directly in a signature/annotation position,
+    /// args resolved as types; RUE-241) so both produce the identical
+    /// monomorphized type.
+    ///
+    /// Guards the reduction against unbounded self-recursion. A `-> type`
+    /// function reduces eagerly on the host stack, so a constructor with no
+    /// compile-time-known base case (`fn Bad() -> type { Bad() }`,
+    /// `fn Wrap(comptime n: i32) -> type { Wrap(n + 1) }`) would overflow that
+    /// stack and abort the compiler (SIGABRT) with no diagnostic. Cap the
+    /// depth at the same bound the specialization pass uses for value
+    /// recursion, emitting the identical E1200 (RUE-261, spec 4.14:18).
+    ///
+    /// [`eval_comptime_type_call`]: Sema::eval_comptime_type_call
+    /// [`eval_const_expr`]: Sema::eval_const_expr
+    /// [`resolve_type_function_call`]: Sema::resolve_type_function_call
+    pub(crate) fn reduce_type_ctor_body(
+        &mut self,
+        name: Spur,
+        callee_types: &HashMap<Spur, Type>,
+        callee_values: &HashMap<Spur, ConstValue>,
+    ) -> CompileResult<Option<ConstValue>> {
+        let Some(fn_info) = self.functions.get(&name) else {
+            return Ok(None);
+        };
+        let fn_body = fn_info.body;
+        let fn_span = fn_info.span;
+        let mut callee_env = ComptimeEnv::with_subst(callee_types, callee_values);
         self.comptime_type_call_depth += 1;
         if self.comptime_type_call_depth > MAX_SPECIALIZATION_ROUNDS {
             self.comptime_type_call_depth -= 1;

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -16,7 +16,9 @@ use super::Sema;
 use super::context::AnalysisContext;
 use crate::inference::InferType;
 use crate::sema::ConstValue;
-use crate::types::{ArrayLen, ArrayTypeId, Type, TypeKind, parse_array_type_syntax};
+use crate::types::{
+    ArrayLen, ArrayTypeId, Type, TypeKind, parse_array_type_syntax, parse_type_call_syntax,
+};
 
 impl<'a> Sema<'a> {
     /// Get a human-readable name for a type.
@@ -226,6 +228,11 @@ impl<'a> Sema<'a> {
                 let pointee_ty = self.resolve_type(pointee_sym, span)?;
                 let ptr_type_id = self.type_pool.intern_ptr_mut_from_type(pointee_ty);
                 Ok(Type::new_ptr_mut(ptr_type_id))
+            } else if let Some((call_name, arg_strs)) = parse_type_call_syntax(type_name) {
+                // A type-function application written directly in type position
+                // (`Result(i32, i32)`; RUE-241). Reduce the comptime type call
+                // to its monomorphized concrete type.
+                self.resolve_type_function_call(&call_name, &arg_strs, span)
             } else {
                 Err(CompileError::new(
                     ErrorKind::UnknownType(type_name.to_string()),
@@ -294,6 +301,98 @@ impl<'a> Sema<'a> {
             // the context-free resolver for identical resolution, privacy
             // checks, and the E0204 on a genuinely-unknown name.
             self.resolve_type(type_sym, span)
+        }
+    }
+
+    /// Resolve a type-function application written directly in type position
+    /// (`Result(i32, i32)`; RUE-241) to its monomorphized concrete type.
+    ///
+    /// The callee must be a comptime `-> type` constructor already collected
+    /// into the function table (constructors are conventionally declared before
+    /// use, the same order the named-const form and value-position use require).
+    /// Each argument string is resolved as a type (so nested calls like
+    /// `Result(Option(i32), i32)` compose), then the constructor body is
+    /// reduced under that substitution — yielding the identical type a
+    /// value-position call (`let R = Result(i32, i32)`) or the named-const form
+    /// (`const R: type = Result(i32, i32)`) produces.
+    ///
+    /// A call to a callee that is not a `-> type` function (a value-returning
+    /// function, `fn f() -> some_value_fn()`), an arity mismatch, or a body
+    /// that does not reduce to a type is reported cleanly as E1200 (an unknown
+    /// callee as E0204), never a crash.
+    fn resolve_type_function_call(
+        &mut self,
+        call_name: &str,
+        arg_strs: &[String],
+        span: Span,
+    ) -> CompileResult<Type> {
+        let name_sym = self.interner.get_or_intern(call_name);
+
+        // The callee must be a known `-> type` constructor.
+        let Some(fn_info) = self.functions.get(&name_sym) else {
+            return Err(CompileError::new(
+                ErrorKind::UnknownType(format!("{}(...)", call_name)),
+                span,
+            ));
+        };
+        let is_type_ctor = fn_info.return_type == Type::COMPTIME_TYPE;
+        let params = fn_info.params;
+        if !is_type_ctor {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: format!(
+                        "'{}' is not a type: only a function returning `type` (a type \
+                         constructor) can be applied as a type here",
+                        call_name
+                    ),
+                },
+                span,
+            ));
+        }
+
+        let param_names = self.param_arena.names(params).to_vec();
+        let param_comptime = self.param_arena.comptime(params).to_vec();
+        if arg_strs.len() != param_names.len()
+            || !(param_names.is_empty() || param_comptime.iter().all(|&c| c))
+        {
+            return Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: format!(
+                        "type constructor '{}' expects {} comptime type argument(s), \
+                         but {} were provided",
+                        call_name,
+                        param_names.len(),
+                        arg_strs.len()
+                    ),
+                },
+                span,
+            ));
+        }
+
+        // Resolve each argument as a type and bind it to the corresponding
+        // comptime type parameter.
+        let mut callee_types: HashMap<Spur, Type> = HashMap::new();
+        for (i, arg) in arg_strs.iter().enumerate() {
+            let arg_sym = self.interner.get_or_intern(arg);
+            let arg_ty = self.resolve_type(arg_sym, span)?;
+            callee_types.insert(param_names[i], arg_ty);
+        }
+
+        // Reduce the constructor body under the substitution. Shares the exact
+        // reduction path (and E1200 recursion guard) with value-position calls.
+        let empty_values: HashMap<Spur, ConstValue> = HashMap::new();
+        match self.reduce_type_ctor_body(name_sym, &callee_types, &empty_values)? {
+            Some(ConstValue::Type(t)) => Ok(t),
+            _ => Err(CompileError::new(
+                ErrorKind::ComptimeEvaluationFailed {
+                    reason: format!(
+                        "the type constructor '{}' did not reduce to a concrete type \
+                         at compile time",
+                        call_name
+                    ),
+                },
+                span,
+            )),
         }
     }
 

--- a/crates/rue-air/src/types.rs
+++ b/crates/rue-air/src/types.rs
@@ -1139,9 +1139,116 @@ pub fn parse_array_type_syntax(type_name: &str) -> Option<(String, ArrayLen)> {
     Some((element_type, length))
 }
 
+/// Parse a type-function application `Name(arg, ...)` and return
+/// `(name, [arg_str, ...])` (RUE-241).
+///
+/// Recognizes the canonical string [`intern_type`] produces for a
+/// `TypeExpr::TypeCall`: an identifier immediately followed by a
+/// parenthesized, comma-separated argument list. Arguments are returned as raw
+/// substrings (the caller resolves each as a type), split only at top-level
+/// commas so nested calls, arrays, and braces are preserved intact
+/// (`Result(Option(i32), i32)` -> `("Result", ["Option(i32)", "i32"])`).
+///
+/// Returns `None` for anything that is not this shape — array (`[T; N]`),
+/// pointer (`ptr const T`), and anonymous type strings (`enum { Ok(i32) }`,
+/// whose prefix before the first `(` is not a bare identifier) all fall
+/// through so their dedicated resolution paths still apply.
+///
+/// [`intern_type`]: (rue_rir astgen)
+pub fn parse_type_call_syntax(type_name: &str) -> Option<(String, Vec<String>)> {
+    let s = type_name.trim();
+    if !s.ends_with(')') {
+        return None;
+    }
+    let open = s.find('(')?;
+    let name = &s[..open];
+    // The callee name must be a bare identifier. This is what excludes
+    // anonymous type strings like `enum { Ok(i32) }`, whose text before the
+    // first `(` contains spaces/braces.
+    let mut name_chars = name.chars();
+    match name_chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => {}
+        _ => return None,
+    }
+    if !name_chars.all(|c| c.is_ascii_alphanumeric() || c == '_') {
+        return None;
+    }
+
+    // Split the argument list at top-level commas, tracking nesting depth so a
+    // comma inside a nested call/array/brace does not split an argument.
+    let inner = &s[open + 1..s.len() - 1];
+    let mut args = Vec::new();
+    let mut depth = 0i32;
+    let mut start = 0usize;
+    for (i, ch) in inner.char_indices() {
+        match ch {
+            '(' | '[' | '{' => depth += 1,
+            ')' | ']' | '}' => depth -= 1,
+            ',' if depth == 0 => {
+                let arg = inner[start..i].trim();
+                if !arg.is_empty() {
+                    args.push(arg.to_string());
+                }
+                start = i + 1;
+            }
+            _ => {}
+        }
+    }
+    let last = inner[start..].trim();
+    if !last.is_empty() {
+        args.push(last.to_string());
+    }
+
+    Some((name.to_string(), args))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_parse_type_call_syntax_basic() {
+        assert_eq!(
+            parse_type_call_syntax("Result(i32, i32)"),
+            Some((
+                "Result".to_string(),
+                vec!["i32".to_string(), "i32".to_string()]
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_type_call_syntax_nested() {
+        assert_eq!(
+            parse_type_call_syntax("Result(Option(i32), i32)"),
+            Some((
+                "Result".to_string(),
+                vec!["Option(i32)".to_string(), "i32".to_string()]
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_type_call_syntax_zero_args() {
+        assert_eq!(
+            parse_type_call_syntax("Foo()"),
+            Some(("Foo".to_string(), vec![]))
+        );
+    }
+
+    #[test]
+    fn test_parse_type_call_syntax_rejects_anon_enum() {
+        // Anonymous enum canonical strings contain `(` but their prefix is not
+        // a bare identifier, so they must not be mistaken for a type call.
+        assert_eq!(parse_type_call_syntax("enum { Ok(i32), Err(i32) }"), None);
+    }
+
+    #[test]
+    fn test_parse_type_call_syntax_rejects_plain() {
+        assert_eq!(parse_type_call_syntax("i32"), None);
+        assert_eq!(parse_type_call_syntax("[i32; 4]"), None);
+        assert_eq!(parse_type_call_syntax("ptr const i32"), None);
+    }
 
     // ========== Type ID tests ==========
 

--- a/crates/rue-cli-tests/cases/generic_type_call_sigs.toml
+++ b/crates/rue-cli-tests/cases/generic_type_call_sigs.toml
@@ -1,0 +1,127 @@
+# Generic types (comptime `-> type` function results) applied DIRECTLY in a
+# signature or annotation: `fn divide(...) -> Result(i32, i32)` (RUE-241).
+#
+# Before RUE-241 the type grammar rejected a type-function *call* in type
+# position (parser E0100), so a function could not return/accept a generic
+# `Result`/`Option` without a named `const` alias. The parser now accepts
+# `Name(args...)` as a type expression and sema reduces the comptime type call
+# to the same monomorphized enum the value-position call produces — the real
+# unblocker for Option/Result error handling (RUE-6). These drive the real
+# driver end-to-end with `--preview enum_payloads` and assert exact behavior.
+
+[section]
+id = "cli.generic_type_call_sigs"
+name = "Generic type-call signatures"
+description = "A comptime `-> type` call used directly as a return/param/annotation type (RUE-241)."
+
+# --- Direct call in RETURN position (the headline repro) ---
+
+[[case]]
+name = "result_return_direct"
+description = "fn divide(...) -> Result(i32, i32) compiles, is called, and its result is matched."
+files = [{ path = "main.rue", source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn divide(a: i32, b: i32) -> Result(i32, i32) {
+    if b == 0 { let R = Result(i32, i32); R::Err(1) }
+    else { let R = Result(i32, i32); R::Ok(a / b) }
+}
+fn main() -> i32 {
+    let R = Result(i32, i32);
+    match divide(84, 2) { R::Ok(v) => v, R::Err(e) => 0 - e }
+}
+""" }]
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+exit_code = 42
+
+# --- Direct call in PARAMETER position ---
+
+[[case]]
+name = "result_param_direct"
+description = "A generic type used directly as a parameter type: fn unwrap_or(r: Result(i32, i32), ...)."
+files = [{ path = "main.rue", source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn unwrap_or(r: Result(i32, i32), d: i32) -> i32 {
+    let R = Result(i32, i32);
+    match r { R::Ok(v) => v, R::Err(e) => d }
+}
+fn divide(a: i32, b: i32) -> Result(i32, i32) {
+    let R = Result(i32, i32);
+    if b == 0 { R::Err(1) } else { R::Ok(a / b) }
+}
+fn main() -> i32 { unwrap_or(divide(84, 2), 0) }
+""" }]
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+exit_code = 42
+
+# --- Nested type-function calls compose in type position ---
+
+[[case]]
+name = "nested_result_of_option_direct"
+description = "Result(Option(i32), i32) as a direct return type; nested type calls compose."
+files = [{ path = "main.rue", source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn make() -> Result(Option(i32), i32) {
+    let O = Option(i32);
+    let R = Result(Option(i32), i32);
+    R::Ok(O::Some(42))
+}
+fn main() -> i32 {
+    let O = Option(i32);
+    let R = Result(Option(i32), i32);
+    match make() {
+        R::Ok(o) => match o { O::Some(v) => v, O::None => 0 },
+        R::Err(e) => 0 - e
+    }
+}
+""" }]
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+exit_code = 42
+
+# --- Direct call in a LET ANNOTATION (falls out of the same resolver) ---
+
+[[case]]
+name = "result_let_annotation_direct"
+description = "The same generic type written directly in a `let x: Result(i32, i32)` annotation."
+files = [{ path = "main.rue", source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn divide(a: i32, b: i32) -> Result(i32, i32) {
+    let R = Result(i32, i32);
+    if b == 0 { R::Err(1) } else { R::Ok(a / b) }
+}
+fn main() -> i32 {
+    let x: Result(i32, i32) = divide(84, 2);
+    let R = Result(i32, i32);
+    match x { R::Ok(v) => v, R::Err(e) => 0 - e }
+}
+""" }]
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+exit_code = 42
+
+# --- A non-type-returning call in type position errors cleanly (no crash) ---
+
+[[case]]
+name = "value_fn_in_type_position_errors"
+description = "Applying a value-returning function as a type is a clean E1200, not an ICE."
+files = [{ path = "main.rue", source = """
+fn some_value_fn() -> i32 { 5 }
+fn f() -> some_value_fn() { 3 }
+fn main() -> i32 { f() }
+""" }]
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E1200", "is not a type"]
+
+# --- Arity mismatch in a type-call errors cleanly ---
+
+[[case]]
+name = "type_call_arity_mismatch_errors"
+description = "Wrong number of type arguments to a type constructor is a clean E1200."
+files = [{ path = "main.rue", source = """
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn f() -> Result(i32) { 3 }
+fn main() -> i32 { 0 }
+""" }]
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E1200", "expects 2 comptime type argument"]

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -355,6 +355,18 @@ pub enum TypeExpr {
     PointerConst { pointee: Box<TypeExpr>, span: Span },
     /// Raw pointer to mutable data: ptr mut T
     PointerMut { pointee: Box<TypeExpr>, span: Span },
+    /// A type-function application used directly in type position:
+    /// `Name(arg, ...)` — e.g. `Result(i32, i32)` (RUE-241). This calls a
+    /// comptime `-> type` function (a type constructor) with type arguments;
+    /// sema reduces it to the monomorphized concrete type. The named-const
+    /// form (`const R: type = Result(i32, i32); fn f() -> R`) resolves to the
+    /// same type. Arguments are themselves type expressions, so nested calls
+    /// (`Result(Option(i32), i32)`) compose.
+    TypeCall {
+        name: Ident,
+        args: Vec<TypeExpr>,
+        span: Span,
+    },
 }
 
 /// The length of an array type `[T; N]`.
@@ -404,6 +416,7 @@ impl TypeExpr {
             TypeExpr::AnonymousEnum { span, .. } => *span,
             TypeExpr::PointerConst { span, .. } => *span,
             TypeExpr::PointerMut { span, .. } => *span,
+            TypeExpr::TypeCall { span, .. } => *span,
         }
     }
 }
@@ -457,6 +470,16 @@ impl fmt::Display for TypeExpr {
             }
             TypeExpr::PointerConst { pointee, .. } => write!(f, "ptr const {}", pointee),
             TypeExpr::PointerMut { pointee, .. } => write!(f, "ptr mut {}", pointee),
+            TypeExpr::TypeCall { name, args, .. } => {
+                write!(f, "sym:{}(", name.name.into_usize())?;
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", arg)?;
+                }
+                write!(f, ")")
+            }
         }
     }
 }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -315,6 +315,27 @@ where
                 span: span_from_extra(e),
             });
 
+        // Type-function application in type position: `Name(arg, ...)`
+        // (RUE-241). Calls a comptime `-> type` constructor with type
+        // arguments; e.g. `Result(i32, i32)`. Arguments are themselves types
+        // (parsed via the recursive `ty`), so nested calls compose
+        // (`Result(Option(i32), i32)`). Must precede `named_type` in the
+        // choice so `Name(...)` is not mis-parsed as a bare `Name` leaving the
+        // argument list dangling.
+        let type_call = ident_parser()
+            .then(
+                ty.clone()
+                    .separated_by(just(TokenKind::Comma))
+                    .allow_trailing()
+                    .collect::<Vec<_>>()
+                    .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
+            )
+            .map_with(|(name, args), e| TypeExpr::TypeCall {
+                name,
+                args,
+                span: span_from_extra(e),
+            });
+
         // Named type: user-defined types like MyStruct
         let named_type = ident_parser().map(TypeExpr::Named);
 
@@ -336,6 +357,7 @@ where
             ptr_mut_type,
             primitive_type_parser(),
             self_type,
+            type_call,
             named_type,
         ))
     })
@@ -4042,6 +4064,59 @@ mod tests {
                     _ => panic!("expected Block"),
                 }
             }
+            _ => panic!("expected Function"),
+        }
+    }
+
+    #[test]
+    fn test_type_call_in_return_position() {
+        // A comptime type-function application used directly as a return type
+        // (RUE-241): `-> Result(i32, i32)`. The type grammar now accepts a
+        // `Name(args...)` call in type position.
+        let result = parse("fn divide(a: i32, b: i32) -> Result(i32, i32) { 0 }").unwrap();
+        match &result.ast.items[0] {
+            Item::Function(f) => match f.return_type.as_ref().expect("return type") {
+                TypeExpr::TypeCall { name, args, .. } => {
+                    assert_eq!(result.get(name.name), "Result");
+                    assert_eq!(args.len(), 2);
+                    match (&args[0], &args[1]) {
+                        (TypeExpr::Named(a), TypeExpr::Named(b)) => {
+                            assert_eq!(result.get(a.name), "i32");
+                            assert_eq!(result.get(b.name), "i32");
+                        }
+                        _ => panic!("expected two Named type args"),
+                    }
+                }
+                other => panic!("expected TypeCall, got {other:?}"),
+            },
+            _ => panic!("expected Function"),
+        }
+    }
+
+    #[test]
+    fn test_type_call_nested_in_param_position() {
+        // Nested type-function calls compose in type position, here as a
+        // parameter type: `r: Result(Option(i32), i32)` (RUE-241).
+        let result = parse("fn f(r: Result(Option(i32), i32)) -> i32 { 0 }").unwrap();
+        match &result.ast.items[0] {
+            Item::Function(f) => match &f.params[0].ty {
+                TypeExpr::TypeCall { name, args, .. } => {
+                    assert_eq!(result.get(name.name), "Result");
+                    assert_eq!(args.len(), 2);
+                    match &args[0] {
+                        TypeExpr::TypeCall {
+                            name: inner_name,
+                            args: inner_args,
+                            ..
+                        } => {
+                            assert_eq!(result.get(inner_name.name), "Option");
+                            assert_eq!(inner_args.len(), 1);
+                        }
+                        _ => panic!("expected nested TypeCall as first arg"),
+                    }
+                }
+                other => panic!("expected TypeCall param type, got {other:?}"),
+            },
             _ => panic!("expected Function"),
         }
     }

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -236,6 +236,12 @@ impl Validator<'_> {
             TypeExpr::PointerConst { pointee, .. } | TypeExpr::PointerMut { pointee, .. } => {
                 self.check_type_expr(pointee)
             }
+            // Type-function application: recurse into each type argument.
+            TypeExpr::TypeCall { args, .. } => {
+                for arg in args {
+                    self.check_type_expr(arg);
+                }
+            }
         }
     }
 }

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -158,6 +158,25 @@ impl<'a> AstGen<'a> {
                 let s = format!("ptr mut {}", pointee_name);
                 self.interner.get_or_intern(&s)
             }
+            TypeExpr::TypeCall { name, args, .. } => {
+                // Type-function application `Name(arg, ...)` (RUE-241). Encode a
+                // canonical `Name(arg1, arg2)` string; sema (`resolve_type`)
+                // detects this call syntax and reduces the comptime type call
+                // to the monomorphized concrete type. Arguments are interned
+                // recursively so nested calls compose
+                // (`Result(Option(i32), i32)`).
+                let mut s = self.interner.resolve(&name.name).to_string();
+                s.push('(');
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        s.push_str(", ");
+                    }
+                    let arg_sym = self.intern_type(arg);
+                    s.push_str(self.interner.resolve(&arg_sym));
+                }
+                s.push(')');
+                self.interner.get_or_intern(&s)
+            }
         }
     }
 
@@ -896,6 +915,14 @@ impl<'a> AstGen<'a> {
                             }
                             TypeExpr::PointerConst { .. } | TypeExpr::PointerMut { .. } => {
                                 // Pointer types as values - use intern_type to get representation
+                                self.intern_type(&type_lit.type_expr)
+                            }
+                            TypeExpr::TypeCall { .. } => {
+                                // A type-function application in *value* position
+                                // (`let R = Result(i32, i32)`) is parsed as an
+                                // ordinary call expression, not a TypeLit, so it
+                                // does not normally reach here. Intern its
+                                // canonical string for completeness (RUE-241).
                                 self.intern_type(&type_lit.type_expr)
                             }
                         };


### PR DESCRIPTION
Completes RUE-241: the direct-call form. The named form (const R: type = Result(i32,i32); fn f() -> R, #1068) and comptime if/match reduction + resolve_type_with_ctx (#1080) already landed; this adds the direct syntax.

- crates/rue-parser: the type grammar now accepts a type-function application Name(args...) in type position via a new TypeExpr::TypeCall.
- crates/rue-air: resolve_type_function_call reduces that comptime type call to the monomorphized concrete type in return, parameter, and let-annotation positions. It shares the exact reduction path (and E1200 recursion guard) with value-position calls via an extracted reduce_type_ctor_body, so both yield the identical enum type.

Verified by execution (debug + release): direct -> Result(i32,i32) returns 42; direct generic as a PARAMETER returns 42; nested Result(Option(i32), i32) returns 42; let-annotation form returns 42; a non-type-returning call and an arity mismatch both error cleanly (E1200/E0204, no ICE); concrete-enum return still works; RUE-263's resolve_type_with_ctx ([P;2]) still works (merged — both helpers coexist). Full test.sh green; diff-fuzzer 300 seeds 0 disagreements.

This means real error handling reads naturally now: fn divide(a, b) -> Result(i32, i32).

Fixes RUE-241

Generated with Claude Code