### PR TITLE
Compiler performance baseline: per-pass harness + measured baseline (RUE-249)

### DIFF
--- a/docs/process/perf-baseline.md
+++ b/docs/process/perf-baseline.md
@@ -1,0 +1,172 @@
+# Compiler performance baseline
+
+**Purpose.** Establish *where compile time goes today* so that any future
+"faster compilation" work (RUE-249, and the `-O` policy in RUE-245) is driven
+by data instead of guesswork. This is a measurement + tracking document, not a
+set of guarantees.
+
+**How to reproduce.** Run the harness from the repo root:
+
+```bash
+scripts/perf-baseline.py                 # text report (default corpus, 5 warm iters)
+scripts/perf-baseline.py --iterations 7  # more iterations = steadier medians
+scripts/perf-baseline.py --format markdown   # regenerates the tables below
+scripts/perf-baseline.py --format json       # machine-readable aggregate
+```
+
+The harness compiles a representative corpus with the real `rue` binary using
+`--benchmark-json` (the machine-readable form of `--time-passes`, see
+[logging.md](logging.md)), runs several *warm* iterations, and reports the
+**median** per-pass timing plus the end-to-end wall clock. It is separate from
+`bench.sh` (which feeds the historical website dashboard); this one is a quick,
+self-contained snapshot with no history/network side effects.
+
+## Reading the numbers
+
+The compiler wraps each pass in a tracing span, and some spans are **nested**,
+so the raw timing JSON contains both leaf passes and their aggregate parents:
+
+```
+compile                 <- top-level span, ~= end-to-end wall clock
+├─ parse                <- aggregate of the two parse leaves (excluded below)
+│  ├─ parse_file        <- leaf: lex + parse, summed over all input files
+│  └─ merge_symbols     <- leaf: cross-file symbol merge
+├─ astgen               <- leaf: AST -> RIR
+├─ sema                 <- leaf: type checking / AIR
+├─ cfg_construction     <- leaf
+├─ codegen              <- leaf: MIR lower + regalloc + emit
+└─ linker               <- leaf: ELF link
+```
+
+> **Caveat about `--time-passes`.** Its printed **"Total"** line *sums every
+> span*, so it double-counts the aggregate parents (`parse` + `compile`) and
+> comes out ~2× the real wall clock. This document (and the harness) instead
+> use the `compile` span as the wall-clock total and report each **leaf** pass
+> as a percentage of it. When you read `--time-passes` output by hand, ignore
+> the `parse` and `compile` rows and the inflated `Total`.
+
+## Baseline (measured 2026-07-03)
+
+**These are absolute milliseconds and are MACHINE-SPECIFIC — treat them as a
+relative profile (which passes dominate), not a hard threshold.**
+
+- Host: Intel Core i9-14900K, Linux x86-64 (WSL2), 32 logical CPUs.
+- Build: the buck2 **DEFAULT** profile as produced by `scripts/rue-bin`
+  (unoptimized — see "Build caveat" below). Numbers on an optimized build
+  would be smaller, but the *pass profile* (parse-dominated) holds.
+- Corpus: `examples/` (small/medium) + `benchmarks/stress/` (large) + a
+  synthesized 3-file program (multi-file merge path). `deep_nesting.rue` is
+  excluded — see "Known pathology".
+- 7 warm iterations, median.
+
+### Small / medium programs (ms)
+
+| program | parse_file | merge_symbols | astgen | sema | cfg | codegen | linker | **total** |
+|---|---|---|---|---|---|---|---|---|
+| hello | 0.60 | 0.01 | 0.01 | 0.12 | 1.23 | 0.09 | 8.43 | **10.58** |
+| fibonacci | 1.52 | 0.02 | 0.03 | 0.27 | 1.42 | 0.38 | 7.94 | **11.94** |
+| quicksort | 2.45 | 0.03 | 0.04 | 0.44 | 1.61 | 1.22 | 8.29 | **14.33** |
+| structs | 2.11 | 0.03 | 0.03 | 0.48 | 1.60 | 1.14 | 8.41 | **13.94** |
+| multi_file | 1.72 | 0.02 | 0.02 | 0.23 | 1.45 | 0.36 | 8.17 | **12.30** |
+
+### Large (generated stress) programs (ms)
+
+| program | parse_file | merge_symbols | astgen | sema | cfg | codegen | linker | **total** |
+|---|---|---|---|---|---|---|---|---|
+| many_functions | 112.90 | 1.32 | 0.80 | 15.93 | 4.49 | 70.20 | 16.12 | **223.80** |
+| large_structs | 132.10 | 2.12 | 1.33 | 36.11 | 4.83 | 79.49 | 14.52 | **273.60** |
+| arithmetic_heavy | 179.36 | 3.15 | 2.45 | 54.50 | 4.22 | 49.97 | 15.80 | **312.92** |
+| control_flow | 395.94 | 1.93 | 1.38 | 28.54 | 4.28 | 54.33 | 12.17 | **502.14** |
+| register_pressure | 163.20 | 1.78 | 1.22 | 36.43 | 3.86 | 22.68 | 11.75 | **243.69** |
+
+### Hot passes across the corpus (sum of per-program medians)
+
+| pass | total ms | share |
+|---|---|---|
+| **parse_file** | 991.88 | **61.9%** |
+| **codegen** | 279.84 | **17.5%** |
+| **sema** | 173.05 | 10.8% |
+| linker | 111.60 | 7.0% |
+| cfg_construction | 29.00 | 1.8% |
+| merge_symbols | 10.44 | 0.7% |
+| astgen | 7.31 | 0.5% |
+
+## Findings
+
+1. **`parse_file` is the dominant cost — by a wide margin.** It is 62% of total
+   corpus time and rises to **48–79% of a single large compile**. Lexing itself
+   is cheap (measured ~20 ms for the 12k-line `deep_nesting.rue`); the cost is
+   in the recursive-descent **parser** and AST construction. This is the first
+   place to look for a speedup, and it is a good parallelization candidate
+   (files already parse in parallel; the win now is per-file parser throughput).
+
+2. **`codegen` is second (~17%)**, concentrated where there is a lot of code to
+   emit (`many_functions`, `large_structs`). This covers MIR lowering, register
+   allocation, and instruction emission together — worth splitting into finer
+   spans before optimizing, so the hot sub-phase is visible.
+
+3. **`sema` is third (~11%)** and scales with type/expression volume
+   (`arithmetic_heavy`, `large_structs`, `register_pressure`).
+
+4. **`linker` is a fixed ~8 ms floor.** On the small programs it is 60–80% of a
+   sub-15 ms compile purely because of that fixed ELF-emit cost; it is
+   negligible on large programs. It matters for edit-compile-run latency on
+   small inputs but is not a throughput bottleneck.
+
+5. **`astgen`, `merge_symbols`, `cfg_construction` are all <2%** — not worth
+   optimizing at current program sizes.
+
+### What would speed the hot passes up
+
+- **parse_file:** profile the parser proper (lexing is already cheap). Reduce
+  per-token allocation, avoid re-scanning, and fix the exponential blowup
+  below (which is the extreme tail of "parsing is expensive"). Finer spans
+  (lex vs. parse vs. RIR-build) would sharpen the target.
+- **codegen:** add per-sub-phase spans (lower / regalloc / emit) to see which
+  dominates before touching it; regalloc is the usual suspect under pressure.
+- **sema:** watch for quadratic scans over symbols/types as programs grow.
+
+## Known pathology: exponential parse time on nested blocks
+
+`benchmarks/stress/deep_nesting.rue` is **excluded from the default corpus**
+because the parser is **exponential in block-nesting depth**. Lexing is fine
+(~20 ms), but `--emit ast` never completes in reasonable time. A controlled
+measurement (plain `{ … }` blocks nested N deep, DEFAULT build, this host):
+
+| nesting depth | parse (`--emit ast`) |
+|---|---|
+| 10 | 0.05 s |
+| 12 | 0.11 s |
+| 14 | 0.42 s |
+| 16 | 1.73 s |
+| 18 | 6.94 s |
+| 20 | > 30 s (killed) |
+
+Each added level roughly **doubles** parse time — i.e. **O(2^depth)**. That
+means `deep_nesting.rue` (nests ~40 levels) cannot be parsed, and `bench.sh`
+has almost certainly been silently skipping it (a failed benchmark iteration is
+logged and dropped, and `validate-benchmark.py` only fails when *all*
+benchmarks fail). This is a real parser bug, filed separately; it is out of
+scope for this measurement-only change. Once fixed, add `deep_nesting` back to
+`default_corpus()` in `scripts/perf-baseline.py`.
+
+## Build caveat (affects absolute numbers, not the profile)
+
+The numbers above come from the buck2 **DEFAULT** build profile. The
+`//constraints:release` opt-level flags (`-Copt-level=3 -Clto=thin`, defined in
+`toolchains/rust/BUCK`) are **not currently applied** to `//crates/rue:rue`:
+building with `--modifier //constraints:release` produces a byte-identical
+configuration hash / output path, so `scripts/rue-bin --modifier
+//constraints:release` (used by `bench.sh`) returns the *same unoptimized
+binary*. This makes the parser's constant factor much larger than it should be
+and is relevant to RUE-45 (release-mode CI). Wiring the constraint through is a
+build change, out of scope here, but it means today's baseline is a
+**worst-case (unoptimized-compiler)** profile; the relative ranking of passes is
+unaffected.
+
+## Related
+
+- RUE-245 — define what each `-O` level does (this baseline informs it).
+- RUE-45 — release-mode CI (the build caveat above is a symptom).
+- `docs/process/logging.md` — the wide-events instrumentation behind
+  `--time-passes` / `--benchmark-json`.

--- a/scripts/perf-baseline.py
+++ b/scripts/perf-baseline.py
@@ -1,0 +1,377 @@
+#!/usr/bin/env python3
+"""
+Per-pass compiler performance baseline harness (RUE-249).
+
+Compiles a representative corpus with the real `rue` binary using
+`--benchmark-json` (the machine-readable form of `--time-passes`, see
+docs/process/logging.md), runs several *warm* iterations per program, and
+reports the median per-pass timing plus the end-to-end wall-clock total.
+
+This is the tool behind docs/process/perf-baseline.md: run it, read the
+"hot passes", and re-run it after a "faster compilation" change to see
+whether a pass got cheaper. It is intentionally separate from bench.sh
+(which feeds the historical website dashboard): this one is a quick,
+human-readable, self-contained snapshot with no history/network side effects.
+
+## Timing model (important)
+
+The compiler wraps each pass in a tracing span. Some spans are *nested*, so
+the raw JSON contains both leaf passes and their aggregate parents:
+
+    compile                         <- top-level, ~= end-to-end wall clock
+    |- parse                        <- aggregate of the two parse leaves
+    |  |- parse_file                <- leaf (lex + parse, summed over files)
+    |  |- merge_symbols             <- leaf
+    |- astgen                       <- leaf
+    |- sema                         <- leaf
+    |- cfg_construction             <- leaf
+    |- codegen                      <- leaf
+    |- linker                       <- leaf
+
+`--time-passes`'s printed "Total" line SUMS every span, so it double-counts
+the aggregate parents (parse + compile) and is ~2x the real wall clock. This
+harness instead uses the `compile` span as the wall-clock total and reports
+each *leaf* pass as a percentage of it, which is the number you actually want
+when deciding what to optimize.
+
+## Usage
+
+    scripts/perf-baseline.py                     # default corpus, 5 warm iters
+    scripts/perf-baseline.py --iterations 9
+    scripts/perf-baseline.py --rue-bin /path/to/rue
+    scripts/perf-baseline.py --format markdown   # tables for the baseline doc
+    scripts/perf-baseline.py --format json       # machine-readable aggregate
+
+By default the compiler is located via `scripts/rue-bin` (a normal build).
+Pass `--release` to build/locate it with `--modifier //constraints:release`,
+or `--rue-bin PATH` / the `RUE` env var to use an already-built binary.
+
+Numbers are absolute milliseconds and are therefore MACHINE-SPECIFIC; treat
+them as a relative profile (which passes dominate), not a hard guarantee.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import statistics
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+# Aggregate/parent spans to exclude from the per-leaf table. `compile` is the
+# end-to-end wall clock; `parse` is just parse_file + merge_symbols.
+AGGREGATE_PASSES = {"parse", "compile"}
+WALL_CLOCK_PASS = "compile"
+
+# Canonical leaf-pass order for deterministic, pipeline-ordered output. Any
+# leaf the compiler emits that is not listed here is appended afterwards in
+# first-seen order, so a newly instrumented pass still shows up.
+CANONICAL_LEAF_ORDER = [
+    "parse_file",
+    "merge_symbols",
+    "astgen",
+    "sema",
+    "cfg_construction",
+    "codegen",
+    "linker",
+]
+
+
+def repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def default_corpus(root: Path):
+    """The representative corpus: (label, size-bucket, [files]).
+
+    Small/medium come from examples/; the large programs are the generated
+    stress suite (benchmarks/stress/, also used by bench.sh); the multi-file
+    entry is synthesized at run time (see run_corpus).
+    """
+    ex = root / "examples"
+    st = root / "benchmarks" / "stress"
+    return [
+        ("hello", "small", [ex / "hello.rue"]),
+        ("fibonacci", "small", [ex / "fibonacci.rue"]),
+        ("quicksort", "medium", [ex / "quicksort.rue"]),
+        ("structs", "medium", [ex / "structs.rue"]),
+        ("many_functions", "large", [st / "many_functions.rue"]),
+        ("large_structs", "large", [st / "large_structs.rue"]),
+        ("arithmetic_heavy", "large", [st / "arithmetic_heavy.rue"]),
+        ("control_flow", "large", [st / "control_flow.rue"]),
+        ("register_pressure", "large", [st / "register_pressure.rue"]),
+        # NOTE: benchmarks/stress/deep_nesting.rue is deliberately NOT in the
+        # default corpus. Its parser stage is superlinear in block-nesting
+        # depth (lexing ~20ms, but `--emit ast` exceeds a minute), so it hangs
+        # the harness. See docs/process/perf-baseline.md ("Known pathology").
+        # Add it back once that is fixed, or run it directly with --timeout.
+    ]
+
+
+# A small, deterministic multi-file program written to a temp dir so the
+# corpus exercises the multi-file merge path (merge_symbols) without depending
+# on files that live in the tree.
+MULTI_MAIN = """\
+fn main() -> i64 {
+    let mut total: i64 = 0;
+    let mut i: i64 = 0;
+    while i < 100 {
+        total = total + square(i) + cube(i);
+        i = i + 1;
+    }
+    total
+}
+"""
+
+MULTI_A = """\
+pub fn square(x: i64) -> i64 {
+    x * x
+}
+"""
+
+MULTI_B = """\
+pub fn cube(x: i64) -> i64 {
+    x * x * x
+}
+"""
+
+
+def resolve_rue_bin(args, root: Path) -> str:
+    if args.rue_bin:
+        return args.rue_bin
+    env = os.environ.get("RUE")
+    if env:
+        return env
+    cmd = [str(root / "scripts" / "rue-bin")]
+    if args.release:
+        cmd += ["--modifier", "//constraints:release"]
+    out = subprocess.run(cmd, capture_output=True, text=True)
+    if out.returncode != 0:
+        sys.stderr.write(out.stderr)
+        sys.exit(f"perf-baseline: scripts/rue-bin failed: {out.stderr.strip()}")
+    return out.stdout.strip()
+
+
+def compile_once(rue_bin: str, files, out_path: str, timeout: float):
+    """Run one compilation with --benchmark-json; return the parsed JSON."""
+    cmd = [rue_bin, "--benchmark-json"] + [str(f) for f in files] + ["-o", out_path]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except subprocess.TimeoutExpired as e:
+        raise RuntimeError(f"compile exceeded {timeout:.0f}s timeout") from e
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"compile failed ({' '.join(cmd)}):\n{proc.stderr}\n{proc.stdout}"
+        )
+    # --benchmark-json prints the JSON object on stdout as the last line.
+    line = proc.stdout.strip().splitlines()[-1]
+    return json.loads(line)
+
+
+def aggregate(samples):
+    """Given a list of per-run JSON dicts, return the median per-pass timing.
+
+    Returns (leaf_rows, wall_ms, source_metrics) where leaf_rows is an ordered
+    list of (name, median_ms, percent_of_wall).
+    """
+    # Collect per-pass duration lists.
+    per_pass = {}
+    order_seen = []
+    wall_samples = []
+    source_metrics = None
+    for s in samples:
+        pass_ms = {p["name"]: p["duration_ms"] for p in s.get("passes", [])}
+        wall_samples.append(pass_ms.get(WALL_CLOCK_PASS, s.get("total_ms", 0.0)))
+        if source_metrics is None:
+            source_metrics = s.get("source_metrics")
+        for name, ms in pass_ms.items():
+            if name in AGGREGATE_PASSES:
+                continue
+            if name not in per_pass:
+                per_pass[name] = []
+                order_seen.append(name)
+        for name in per_pass:
+            per_pass[name].append(pass_ms.get(name, 0.0))
+
+    wall_ms = statistics.median(wall_samples) if wall_samples else 0.0
+
+    # Deterministic order: canonical first, then any extras in first-seen order.
+    ordered = [n for n in CANONICAL_LEAF_ORDER if n in per_pass]
+    ordered += [n for n in order_seen if n not in CANONICAL_LEAF_ORDER]
+
+    rows = []
+    for name in ordered:
+        med = statistics.median(per_pass[name])
+        pct = (med / wall_ms * 100.0) if wall_ms > 0 else 0.0
+        rows.append((name, med, pct))
+    return rows, wall_ms, source_metrics
+
+
+def run_corpus(rue_bin, corpus, iterations, warmup, workdir, timeout):
+    """Run every corpus program; return an ordered list of result dicts."""
+    results = []
+    out_bin = os.path.join(workdir, "perf_out")
+
+    # Synthesize the multi-file program.
+    multi_dir = os.path.join(workdir, "multi")
+    os.makedirs(multi_dir, exist_ok=True)
+    with open(os.path.join(multi_dir, "main.rue"), "w") as f:
+        f.write(MULTI_MAIN)
+    with open(os.path.join(multi_dir, "a.rue"), "w") as f:
+        f.write(MULTI_A)
+    with open(os.path.join(multi_dir, "b.rue"), "w") as f:
+        f.write(MULTI_B)
+    multi_files = [
+        os.path.join(multi_dir, "main.rue"),
+        os.path.join(multi_dir, "a.rue"),
+        os.path.join(multi_dir, "b.rue"),
+    ]
+
+    full = list(corpus) + [("multi_file", "multi", multi_files)]
+
+    for label, bucket, files in full:
+        missing = [f for f in files if not Path(f).exists()]
+        if missing:
+            sys.stderr.write(f"  skip {label}: missing {missing}\n")
+            continue
+        sys.stderr.write(f"  {label} ({bucket}) ... ")
+        sys.stderr.flush()
+        try:
+            for _ in range(warmup):
+                compile_once(rue_bin, files, out_bin, timeout)
+            samples = [
+                compile_once(rue_bin, files, out_bin, timeout)
+                for _ in range(iterations)
+            ]
+        except RuntimeError as e:
+            sys.stderr.write(f"FAILED\n{e}\n")
+            continue
+        rows, wall_ms, sm = aggregate(samples)
+        results.append(
+            {
+                "name": label,
+                "bucket": bucket,
+                "wall_ms": wall_ms,
+                "passes": [
+                    {"name": n, "median_ms": ms, "percent": pct} for n, ms, pct in rows
+                ],
+                "source_metrics": sm,
+            }
+        )
+        sys.stderr.write(f"{wall_ms:.1f}ms\n")
+    return results
+
+
+def hot_passes(results, top=3):
+    """Sum each leaf pass's median ms across the corpus; return sorted list."""
+    totals = {}
+    for r in results:
+        for p in r["passes"]:
+            totals[p["name"]] = totals.get(p["name"], 0.0) + p["median_ms"]
+    grand = sum(totals.values()) or 1.0
+    ranked = sorted(totals.items(), key=lambda kv: kv[1], reverse=True)
+    return [(name, ms, ms / grand * 100.0) for name, ms in ranked]
+
+
+def print_text(results, iterations):
+    for r in results:
+        print(f"\n{r['name']}  ({r['bucket']}, n={iterations} warm, median)")
+        sm = r["source_metrics"] or {}
+        if sm:
+            print(
+                f"  source: {sm.get('lines', '?')} lines, "
+                f"{sm.get('bytes', '?')} bytes, {sm.get('tokens', '?')} tokens"
+            )
+        namew = max((len(p["name"]) for p in r["passes"]), default=8)
+        for p in r["passes"]:
+            print(
+                f"  {p['name']:<{namew}}  {p['median_ms']:>8.2f} ms  "
+                f"({p['percent']:>4.1f}%)"
+            )
+        print(f"  {'TOTAL':<{namew}}  {r['wall_ms']:>8.2f} ms  (compile span)")
+
+    print("\nHot passes across the whole corpus (sum of medians):")
+    for name, ms, pct in hot_passes(results):
+        print(f"  {name:<18} {ms:>9.2f} ms  ({pct:>4.1f}%)")
+
+
+def _md_table(results, bucket_filter=None):
+    rows = [r for r in results if bucket_filter is None or r["bucket"] in bucket_filter]
+    if not rows:
+        return ""
+    # Union of leaf pass names in canonical order.
+    names = []
+    for n in CANONICAL_LEAF_ORDER:
+        if any(p["name"] == n for r in rows for p in r["passes"]):
+            names.append(n)
+    header = "| program | " + " | ".join(names) + " | **total** |"
+    sep = "|" + "|".join(["---"] * (len(names) + 2)) + "|"
+    lines = [header, sep]
+    for r in rows:
+        pm = {p["name"]: p["median_ms"] for p in r["passes"]}
+        cells = [f"{pm.get(n, 0.0):.2f}" for n in names]
+        lines.append(
+            f"| {r['name']} | " + " | ".join(cells) + f" | **{r['wall_ms']:.2f}** |"
+        )
+    return "\n".join(lines)
+
+
+def print_markdown(results):
+    print("<!-- generated by scripts/perf-baseline.py; ms are machine-specific -->\n")
+    print("### Small / medium programs\n")
+    print(_md_table(results, {"small", "medium", "multi"}))
+    print("\n### Large (generated stress) programs\n")
+    print(_md_table(results, {"large"}))
+    print("\n### Hot passes across the corpus (sum of per-program medians)\n")
+    print("| pass | total ms | share |")
+    print("|---|---|---|")
+    for name, ms, pct in hot_passes(results):
+        print(f"| {name} | {ms:.2f} | {pct:.1f}% |")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Per-pass compiler perf baseline (RUE-249)")
+    ap.add_argument("--iterations", type=int, default=5, help="warm iterations (default 5)")
+    ap.add_argument("--warmup", type=int, default=1, help="warmup runs before timing (default 1)")
+    ap.add_argument("--timeout", type=float, default=60.0, help="per-compile timeout seconds (default 60)")
+    ap.add_argument("--rue-bin", help="path to an already-built rue binary")
+    ap.add_argument("--release", action="store_true", help="locate the compiler via //constraints:release")
+    ap.add_argument("--format", choices=["text", "markdown", "json"], default="text")
+    args = ap.parse_args()
+
+    root = repo_root()
+    rue_bin = resolve_rue_bin(args, root)
+    if not (Path(rue_bin).exists() and os.access(rue_bin, os.X_OK)):
+        sys.exit(f"perf-baseline: rue binary not usable: {rue_bin}")
+
+    sys.stderr.write(f"perf-baseline: using {rue_bin}\n")
+    sys.stderr.write(f"perf-baseline: {args.iterations} warm iterations per program\n")
+
+    workdir = tempfile.mkdtemp(prefix="rue-perf-")
+    try:
+        results = run_corpus(
+            rue_bin,
+            default_corpus(root),
+            args.iterations,
+            args.warmup,
+            workdir,
+            args.timeout,
+        )
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+    if not results:
+        sys.exit("perf-baseline: no results collected")
+
+    if args.format == "json":
+        print(json.dumps({"iterations": args.iterations, "results": results}, indent=2))
+    elif args.format == "markdown":
+        print_markdown(results)
+    else:
+        print_text(results, args.iterations)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rue
+++ b/scripts/rue
@@ -11,6 +11,7 @@
 #   scripts/rue spec [pattern]     Spec tests, optional filter
 #   scripts/rue cli [pattern]      CLI integration tests, optional filter
 #   scripts/rue ui [pattern]       UI/diagnostics tests, optional filter
+#   scripts/rue perf [args...]     Per-pass compiler perf baseline (scripts/perf-baseline.py)
 #   scripts/rue fmt                Format the code (./fmt.sh)
 #   scripts/rue gc                 Reclaim disk: drop buck-out artifacts unused for 1+ week
 #   scripts/rue path               Print the absolute binary path (build if needed)
@@ -80,6 +81,13 @@ case "$cmd" in
         RUE_BINARY="$(scripts/rue-bin)" \
         RUE_UI_CASES="crates/rue-ui-tests/cases" \
         ./buck2 run //crates/rue-ui-tests:rue-ui-tests -- "$@"
+        ;;
+    perf)
+        # Per-pass compiler performance baseline (RUE-249). Builds the compiler
+        # first so the harness times a fresh binary, then hands off remaining
+        # args (e.g. --iterations, --format) to the Python harness.
+        scripts/rue-bin >/dev/null
+        python3 scripts/perf-baseline.py "$@"
         ;;
     fmt)
         ./fmt.sh "$@"


### PR DESCRIPTION
Measurement/tooling only; no compiler logic touched.

- scripts/perf-baseline.py (wired as scripts/rue perf): compiles a representative corpus (examples + benchmarks/stress + a synthesized multi-file build) via --benchmark-json, runs warm iterations, reports median per-pass timing + wall clock (text/json/markdown), with a per-compile --timeout guard.
- docs/process/perf-baseline.md: the measured baseline (7 warm iters, host-labeled/machine-specific), hot-pass ranking, and the --time-passes double-counting nuance.

Measured hot passes (not guessed): **parse_file 62%** (48-79% of a large compile; lexing itself is cheap), codegen 17%, sema 11%, linker a fixed ~8ms floor. So faster-compilation work should target the PARSER first.

Discovered (filed separately, NOT fixed here): the parser is O(2^depth) on nested blocks (depth 18 ~7s, 20 >30s) — explains the parse hot-spot; and //constraints:release is a no-op on //crates/rue:rue so bench.sh's release build is unoptimized (relates to RUE-45).

Full test.sh green. Additive only.

Fixes RUE-249

Generated with Claude Code