### PR TITLE
Raw pointers: @raw requires a place, @raw of a param takes its address, @ptr_write infers pointee type (RUE-273, RUE-274, RUE-275)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -6426,10 +6426,11 @@ impl<'a> Sema<'a> {
             ));
         }
 
+        // Analyze the pointer first so the pointee type is known before the
+        // value argument is analyzed — a bare integer-literal value must infer
+        // to the pointee type, not default to i32 (RUE-275).
         let ptr_result = self.analyze_inst(air, args[0].value, ctx)?;
-        let value_result = self.analyze_inst(air, args[1].value, ctx)?;
         let ptr_type = ptr_result.ty;
-        let value_type = value_result.ty;
 
         // Pointer must be ptr mut T
         let pointee_type = match ptr_type.kind() {
@@ -6455,6 +6456,35 @@ impl<'a> Sema<'a> {
                 ));
             }
         };
+
+        // Analyze the value argument, propagating the expected pointee type into
+        // a bare integer literal so `@ptr_write(p_i64, 99)` unifies the literal
+        // to the pointee type (i64/u8/…) instead of defaulting to i32 and then
+        // spuriously failing the equality check below (RUE-275). Mirrors the
+        // struct-init field-literal coercion in `analyze_struct_init`; the
+        // range check keeps `@ptr_write(p_u8, 300)` an honest E0800.
+        let value_inst = self.rir.get(args[1].value);
+        let value_result = match &value_inst.data {
+            InstData::IntConst(value) if pointee_type.is_integer() => {
+                if !pointee_type.literal_fits(*value) {
+                    return Err(CompileError::new(
+                        ErrorKind::LiteralOutOfRange {
+                            value: *value,
+                            ty: self.format_type_name(pointee_type),
+                        },
+                        value_inst.span,
+                    ));
+                }
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::Const(*value),
+                    ty: pointee_type,
+                    span: value_inst.span,
+                });
+                AnalysisResult::new(air_ref, pointee_type)
+            }
+            _ => self.analyze_inst(air, args[1].value, ctx)?,
+        };
+        let value_type = value_result.ty;
 
         // Check that value type matches pointee type
         if value_type != pointee_type && !value_type.is_error() && !value_type.is_never() {
@@ -6700,6 +6730,33 @@ impl<'a> Sema<'a> {
         let operand_root = self.extract_root_variable(operand);
         let operand_move_state_before = operand_root.and_then(|v| ctx.moved_vars.get(&v).cloned());
         let arg_result = self.analyze_inst(air, operand, ctx)?;
+
+        // @raw/@raw_mut take the ADDRESS of an addressable PLACE (spec 9.1:12,
+        // ADR-0028), so the operand MUST be a place. A non-place operand
+        // (literal, arithmetic, call result, inlined global const, module
+        // member) has no storage to address; codegen would reinterpret the
+        // computed value's bits as a pointer and dereference garbage (RUE-274,
+        // a soundness hole). A place read analyzes to exactly a variable load
+        // (`Load`), a parameter read (`Param`), or a projected place-read
+        // (field/element `PlaceRead`) — the same set `try_trace_place` accepts
+        // for inout/borrow operands. A non-Copy place read is additionally
+        // wrapped in a `MarkMoved` move marker (which the address-of below
+        // cancels, since taking an address borrows rather than moves), so peel
+        // that wrapper before inspecting the underlying read. Every non-place
+        // lowers to some other AIR inst (`Const`, an arithmetic op, `Call`, a
+        // non-place `FieldGet`/`IndexGet` off a temporary, ...) and is rejected.
+        let mut place_ref = arg_result.air_ref;
+        if let AirInstData::MarkMoved { value, .. } = air.get(place_ref).data {
+            place_ref = value;
+        }
+        let operand_is_place = matches!(
+            air.get(place_ref).data,
+            AirInstData::Load { .. } | AirInstData::Param { .. } | AirInstData::PlaceRead { .. }
+        );
+        if !operand_is_place && !arg_result.ty.is_error() {
+            return Err(CompileError::new(ErrorKind::RawRequiresPlace, span));
+        }
+
         let pointee_type = arg_result.ty;
         if let Some(var) = operand_root {
             match operand_move_state_before {
@@ -6712,9 +6769,6 @@ impl<'a> Sema<'a> {
             }
         }
         air.cancel_move_marker(arg_result.air_ref);
-
-        // For addr_of, we need the argument to be an lvalue (addressable)
-        // This is validated at the RIR level - here we just compute the result type
 
         // Create the pointer type
         let result_type = if is_mut {

--- a/crates/rue-cli-tests/cases/pointers.toml
+++ b/crates/rue-cli-tests/cases/pointers.toml
@@ -251,3 +251,188 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["E1300", "unchecked function"]
+
+# RUE-273: @raw of a function PARAMETER must take the ADDRESS of the param's
+# stack slot (LEA), not load its value. Previously codegen emitted the param's
+# value as the pointer, so dereferencing it segfaulted. Here addr(77) reads the
+# param's own value back through the pointer -> 77 (an exact-value differential
+# that a value-as-address miscompile can't satisfy).
+[[case]]
+name = "raw_of_parameter_takes_address"
+files = [{ path = "main.rue", source = """
+fn addr(x: i32) -> i32 {
+    let p: ptr const i32 = checked { @raw(x) };
+    checked { @ptr_read(p) }
+}
+fn main() -> i32 {
+    @dbg(addr(77));
+    0
+}
+""" }]
+stdout = "77\n"
+
+# RUE-273: @raw_mut of a parameter yields the address of the param slot, so a
+# write through it mutates the callee's copy of the parameter.
+[[case]]
+name = "raw_mut_of_parameter_mutates_it"
+files = [{ path = "main.rue", source = """
+fn bump(x: i32) -> i32 {
+    checked {
+        let p: ptr mut i32 = @raw_mut(x);
+        @ptr_write(p, 123);
+    };
+    x
+}
+fn main() -> i32 {
+    @dbg(bump(5));
+    0
+}
+""" }]
+stdout = "123\n"
+
+# RUE-273: @raw of a field of a struct PARAMETER (a projected place rooted at a
+# param) still computes the field's address, not a reinterpreted value.
+[[case]]
+name = "raw_of_param_struct_field"
+files = [{ path = "main.rue", source = """
+struct P { x: i32, y: i32 }
+fn rd(s: P) -> i32 {
+    let v: i32 = checked {
+        let p: ptr const i32 = @raw(s.y);
+        @ptr_read(p)
+    };
+    v
+}
+fn main() -> i32 {
+    @dbg(rd(P { x: 1, y: 88 }));
+    0
+}
+""" }]
+stdout = "88\n"
+
+# RUE-274: @raw of a non-place operand (an integer literal) has no storage to
+# address; it must be rejected at compile time (E0485), not silently accepted
+# and then dereferenced as address 0x2A at runtime (a soundness hole).
+[[case]]
+name = "raw_of_literal_rejected"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let p: ptr const i32 = checked { @raw(42) };
+    checked { @ptr_read(p) }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0485", "addressable place"]
+
+# RUE-274: @raw of an arithmetic (non-place) operand is likewise rejected.
+[[case]]
+name = "raw_of_arithmetic_rejected"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let p: ptr const i32 = checked { @raw(5 + 5) };
+    checked { @ptr_read(p) }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0485", "addressable place"]
+
+# RUE-274: @raw of a call result (non-place) is rejected.
+[[case]]
+name = "raw_of_call_result_rejected"
+files = [{ path = "main.rue", source = """
+fn g() -> i32 { 7 }
+fn main() -> i32 {
+    let p: ptr const i32 = checked { @raw(g()) };
+    checked { @ptr_read(p) }
+}
+""" }]
+compile_fail = true
+error_contains = ["E0485", "addressable place"]
+
+# RUE-274 control: @raw of a genuine place (a local) still compiles and works.
+[[case]]
+name = "raw_of_local_still_works"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = 55;
+    let v: i32 = checked {
+        let p: ptr const i32 = @raw(x);
+        @ptr_read(p)
+    };
+    @dbg(v);
+    0
+}
+""" }]
+stdout = "55\n"
+
+# RUE-275: a bare integer-literal value argument to @ptr_write must infer to the
+# pointer's pointee type (here i64), not default to i32 and spuriously fail with
+# E0206. The write of 99 through the ptr mut i64 is then observed.
+[[case]]
+name = "ptr_write_literal_infers_i64_pointee"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut v: i64 = 5;
+    checked {
+        let p: ptr mut i64 = @raw_mut(v);
+        @ptr_write(p, 99);
+    };
+    let r: i32 = @intCast(v);
+    @dbg(r);
+    0
+}
+""" }]
+stdout = "99\n"
+
+# RUE-275: same for a u8 pointee — the literal infers to u8, not i32.
+[[case]]
+name = "ptr_write_literal_infers_u8_pointee"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut v: u8 = 5;
+    checked {
+        let p: ptr mut u8 = @raw_mut(v);
+        @ptr_write(p, 200);
+    };
+    let r: i32 = @intCast(v);
+    @dbg(r);
+    0
+}
+""" }]
+stdout = "200\n"
+
+# RUE-275 control: a genuinely mismatched TYPED value (an i64 variable written
+# through a ptr mut i32) is still rejected with E0206 — the fix only infers bare
+# literals, it does not paper over real type mismatches.
+[[case]]
+name = "ptr_write_typed_mismatch_still_rejected"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut v: i32 = 5;
+    let w: i64 = 99;
+    checked {
+        let p: ptr mut i32 = @raw_mut(v);
+        @ptr_write(p, w);
+    };
+    v
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206"]
+
+# RUE-275 control: an out-of-range literal for the pointee is still an honest
+# E0800, not a silent truncation.
+[[case]]
+name = "ptr_write_literal_out_of_range_rejected"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut v: u8 = 5;
+    checked {
+        let p: ptr mut u8 = @raw_mut(v);
+        @ptr_write(p, 300);
+    };
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0800"]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2269,9 +2269,35 @@ impl<'a> CfgLower<'a> {
                         let result_vreg = self.mir.alloc_vreg();
                         self.lower_place_addr(result_vreg, place);
                         self.value_map.insert(value, result_vreg);
+                    } else if let CfgInstData::Param { index } = &lvalue_inst.data {
+                        // @raw of a function parameter: take the ADDRESS of the
+                        // parameter's storage, not its value (RUE-273). The
+                        // prologue spills every param into the contiguous frame
+                        // param area (slots num_locals..), so the address is the
+                        // frame slot; previously this fell through to the
+                        // value-load fallback below, reinterpreting the param's
+                        // value as a pointer -> segfault.
+                        let index = *index;
+                        if self.ctx.cfg.is_param_inout(index) {
+                            // inout params hold a POINTER to the caller's storage;
+                            // that pointer already IS the address of the place.
+                            let ptr_vreg = self.ensure_inout_param_ptr(index);
+                            self.value_map.insert(value, ptr_vreg);
+                        } else {
+                            let slot = self.ctx.num_locals + index;
+                            let offset = self.ctx.local_offset(slot);
+                            let result_vreg = self.mir.alloc_vreg();
+                            self.mir.push(Aarch64Inst::AddImm {
+                                dst: Operand::Virtual(result_vreg),
+                                src: Operand::Physical(Reg::Fp),
+                                imm: offset,
+                            });
+                            self.value_map.insert(value, result_vreg);
+                        }
                     } else {
-                        // For other lvalue types (Param, etc.), fall back to vreg
-                        // This is a limitation that can be addressed later.
+                        // Sema (RUE-274) requires @raw's operand to be a place, so
+                        // Load/PlaceRead/Param above cover every legal case. Keep a
+                        // defensive fallback for any not-yet-modeled place kind.
                         let vreg = self.get_vreg(lvalue_val);
                         self.value_map.insert(value, vreg);
                     }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2583,9 +2583,35 @@ impl<'a> CfgLower<'a> {
                         let result_vreg = self.mir.alloc_vreg();
                         self.lower_place_addr(result_vreg, place);
                         self.value_map.insert(value, result_vreg);
+                    } else if let CfgInstData::Param { index } = &lvalue_inst.data {
+                        // @raw of a function parameter: take the ADDRESS of the
+                        // parameter's storage, not its value (RUE-273). The
+                        // prologue spills every param into the contiguous frame
+                        // param area (slots num_locals..), so the address is the
+                        // frame slot; previously this fell through to the
+                        // value-load fallback below, reinterpreting the param's
+                        // value as a pointer -> segfault.
+                        let index = *index;
+                        if self.ctx.cfg.is_param_inout(index) {
+                            // inout params hold a POINTER to the caller's storage;
+                            // that pointer already IS the address of the place.
+                            let ptr_vreg = self.ensure_inout_param_ptr(index);
+                            self.value_map.insert(value, ptr_vreg);
+                        } else {
+                            let slot = self.ctx.num_locals + index;
+                            let offset = self.ctx.local_offset(slot);
+                            let result_vreg = self.mir.alloc_vreg();
+                            self.mir.push(X86Inst::Lea {
+                                dst: Operand::Virtual(result_vreg),
+                                base: Reg::Rbp,
+                                disp: offset,
+                            });
+                            self.value_map.insert(value, result_vreg);
+                        }
                     } else {
-                        // For other lvalue types (Param, etc.), fall back to vreg
-                        // This is a limitation that can be addressed later.
+                        // Sema (RUE-274) requires @raw's operand to be a place, so
+                        // Load/PlaceRead/Param above cover every legal case. Keep a
+                        // defensive fallback for any not-yet-modeled place kind.
                         let vreg = self.get_vreg(lvalue_val);
                         self.value_map.insert(value, vreg);
                     }

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -181,6 +181,11 @@ impl ErrorCode {
     /// fresh name (spec 4.7:30); reusing one silently shadows the earlier
     /// binding and discards its value (RUE-269, analogous to Rust E0416).
     pub const DUPLICATE_PATTERN_BINDING: Self = Self(484);
+    /// `@raw`/`@raw_mut` applied to a non-place operand (literal, arithmetic,
+    /// call result). A raw pointer must address an addressable place (spec
+    /// 9.1:12, ADR-0028); taking the "address" of a temporary value would
+    /// reinterpret the value's bits as a pointer (RUE-274).
+    pub const RAW_REQUIRES_PLACE: Self = Self(485);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -1116,6 +1121,11 @@ pub enum ErrorKind {
     FieldAccessOnNonStruct { found: String },
     #[error("invalid assignment target")]
     InvalidAssignmentTarget,
+    /// `@raw`/`@raw_mut` operand is not an addressable place
+    #[error(
+        "@raw requires an addressable place (a variable, field, or array element), not a temporary value"
+    )]
+    RawRequiresPlace,
     /// Inout argument is not an lvalue (variable, field, or array element)
     #[error("inout argument must be an lvalue (variable, field, or array element)")]
     InoutNonLvalue,
@@ -1374,6 +1384,7 @@ impl ErrorKind {
             ErrorKind::UnknownEnumType(_) => ErrorCode::UNKNOWN_ENUM_TYPE,
             ErrorKind::FieldAccessOnNonStruct { .. } => ErrorCode::FIELD_ACCESS_ON_NON_STRUCT,
             ErrorKind::InvalidAssignmentTarget => ErrorCode::INVALID_ASSIGNMENT_TARGET,
+            ErrorKind::RawRequiresPlace => ErrorCode::RAW_REQUIRES_PLACE,
             ErrorKind::InoutNonLvalue => ErrorCode::INOUT_NON_LVALUE,
             ErrorKind::InoutExclusiveAccess { .. } => ErrorCode::INOUT_EXCLUSIVE_ACCESS,
             ErrorKind::BorrowNonLvalue => ErrorCode::BORROW_NON_LVALUE,


### PR DESCRIPTION
Found by the unchecked/raw-pointer hunt; two were memory-safety holes (compile-clean code segfaulted). @raw takes the ADDRESS of an addressable place (spec 9.1:12, ADR-0028).

**RUE-274 (unsound):** @raw/@raw_mut on a NON-PLACE operand (literal, arithmetic, call result) was accepted and codegen reinterpreted the value's bits as a pointer -> segfault. analyze_addr_of_intrinsic now gates on the operand's analyzed AIR being a Load/Param/PlaceRead (peeling a MarkMoved wrapper for non-Copy places), else the new E0485. @raw(42) / @raw(5+5) / @raw(g()) now clean-error instead of segfaulting.

**RUE-273 (miscompile):** @raw of a function PARAMETER (a valid place) emitted the param's VALUE as a pointer (missing LEA) -> segfault. Added a CfgInstData::Param arm to the @raw lowering in BOTH backends — a normal param takes its frame-slot address (lea rbp+off / aarch64 sub fp,#N), an inout param takes the caller pointer. addr(77) returns 77; asm confirms lea/sub.

**RUE-275 (reject-valid):** @ptr_write(p, int-literal) defaulted the literal to i32 -> spurious E0206 for non-i32 pointees. Reordered to analyze the pointer first, then coerce a bare int literal to the pointee type (range-checked). @ptr_write(p_i64, 99) and u8/200 compile + write; a typed mismatch still E0206, overflow still E0800.

Verified by execution (E0485 / 77 / correct writes, no segfaults); full test.sh green; 12 new pointer CLI cases; oracle-diff 300 seeds 0 disagreements. Both backends. Matters for RUE-1 (Vec/stdlib on raw pointers).

Fixes RUE-273
Fixes RUE-274
Fixes RUE-275

Generated with Claude Code