### PR TITLE
Generic functions over Option/Result: type-function applied to an enclosing type param (RUE-272)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -13,7 +13,8 @@ use crate::intern_pool::TypeInternPool;
 use crate::scope::ScopedContext;
 use crate::sema::ConstValue;
 use crate::types::{
-    ArrayLen, PtrMutability, StructId, TypeKind, parse_array_type_syntax, parse_pointer_type_syntax,
+    ArrayLen, PtrMutability, StructId, TypeKind, parse_array_type_syntax,
+    parse_pointer_type_syntax, parse_type_call_syntax,
 };
 use lasso::{Spur, ThreadedRodeo};
 use rue_rir::{InstData, InstRef, RepeatCount, Rir};
@@ -860,12 +861,41 @@ impl<'a> ConstraintGenerator<'a> {
                         // (`-> [T; 3]`, RUE-172).
                         let return_type =
                             if func.return_type == InferType::Concrete(Type::COMPTIME_TYPE) {
-                                self.resolve_type_sym_with_subst(
+                                match self.resolve_type_sym_with_subst(
                                     func.return_type_sym,
                                     &type_subst,
                                     &value_subst,
-                                )
-                                .unwrap_or_else(|| func.return_type.clone())
+                                ) {
+                                    Some(ty) => ty,
+                                    None => {
+                                        // The declared return type is a
+                                        // type-function application to a type
+                                        // parameter (`-> Option(T)`; RUE-272).
+                                        // The constraint generator can't reduce
+                                        // a `-> type` constructor body, so it
+                                        // can't name the monomorphized
+                                        // struct/enum here — sema computes the
+                                        // true type in the analyze pass. Use a
+                                        // fresh inference variable (pinned by
+                                        // the call's use site) rather than the
+                                        // `COMPTIME_TYPE` placeholder, which
+                                        // would spuriously unify against the real
+                                        // result type and reject the program
+                                        // (E0206). A literal `-> type`
+                                        // constructor call is NOT a type-call in
+                                        // this sense and still yields
+                                        // `COMPTIME_TYPE`.
+                                        let is_type_call = parse_type_call_syntax(
+                                            self.interner.resolve(&func.return_type_sym),
+                                        )
+                                        .is_some();
+                                        if is_type_call {
+                                            InferType::Var(self.fresh_var())
+                                        } else {
+                                            func.return_type.clone()
+                                        }
+                                    }
+                                }
                             } else {
                                 func.return_type.clone()
                             };

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -231,8 +231,11 @@ impl<'a> Sema<'a> {
             } else if let Some((call_name, arg_strs)) = parse_type_call_syntax(type_name) {
                 // A type-function application written directly in type position
                 // (`Result(i32, i32)`; RUE-241). Reduce the comptime type call
-                // to its monomorphized concrete type.
-                self.resolve_type_function_call(&call_name, &arg_strs, span)
+                // to its monomorphized concrete type. No analysis context is
+                // available on this context-free path, so arguments resolve
+                // context-free (a signature/return position collected before any
+                // body context exists).
+                self.resolve_type_function_call(&call_name, &arg_strs, span, None)
             } else {
                 Err(CompileError::new(
                     ErrorKind::UnknownType(type_name.to_string()),
@@ -296,6 +299,14 @@ impl<'a> Sema<'a> {
             let pointee_ty = self.resolve_type_with_ctx(pointee_sym, span, ctx)?;
             let ptr_type_id = self.type_pool.intern_ptr_mut_from_type(pointee_ty);
             Ok(Type::new_ptr_mut(ptr_type_id))
+        } else if let Some((call_name, arg_strs)) = parse_type_call_syntax(type_name) {
+            // A type-function application in an annotation position whose
+            // arguments may name enclosing comptime type parameters or local
+            // comptime type variables (`let x: Option(T)` / `let x: Option(P)`).
+            // Thread `ctx` so each argument resolves through this same
+            // context-aware resolver rather than context-free — otherwise the
+            // inner `T`/`P` would miss and yield a spurious E0204 (RUE-272).
+            self.resolve_type_function_call(&call_name, &arg_strs, span, Some(ctx))
         } else {
             // Non-composite leaf: primitive / struct / enum / unknown. Defer to
             // the context-free resolver for identical resolution, privacy
@@ -320,11 +331,23 @@ impl<'a> Sema<'a> {
     /// function, `fn f() -> some_value_fn()`), an arity mismatch, or a body
     /// that does not reduce to a type is reported cleanly as E1200 (an unknown
     /// callee as E0204), never a crash.
+    ///
+    /// When `ctx` is `Some`, each argument is resolved through
+    /// [`resolve_type_with_ctx`] so an argument naming an enclosing comptime
+    /// type parameter or a local comptime type variable (`Option(T)` inside a
+    /// generic function, `let x: Option(P)` where `P` is a local type alias)
+    /// resolves from the analysis context rather than being reported as an
+    /// unknown type (RUE-272). When `ctx` is `None` (a signature/return
+    /// position, collected before any body context exists) arguments resolve
+    /// context-free, exactly as before.
+    ///
+    /// [`resolve_type_with_ctx`]: Sema::resolve_type_with_ctx
     fn resolve_type_function_call(
         &mut self,
         call_name: &str,
         arg_strs: &[String],
         span: Span,
+        ctx: Option<&AnalysisContext>,
     ) -> CompileResult<Type> {
         let name_sym = self.interner.get_or_intern(call_name);
 
@@ -374,7 +397,10 @@ impl<'a> Sema<'a> {
         let mut callee_types: HashMap<Spur, Type> = HashMap::new();
         for (i, arg) in arg_strs.iter().enumerate() {
             let arg_sym = self.interner.get_or_intern(arg);
-            let arg_ty = self.resolve_type(arg_sym, span)?;
+            let arg_ty = match ctx {
+                Some(ctx) => self.resolve_type_with_ctx(arg_sym, span, ctx)?,
+                None => self.resolve_type(arg_sym, span)?,
+            };
             callee_types.insert(param_names[i], arg_ty);
         }
 
@@ -488,6 +514,51 @@ impl<'a> Sema<'a> {
             )?;
             let ptr_type_id = self.type_pool.intern_ptr_mut_from_type(pointee_ty);
             Some(Type::new_ptr_mut(ptr_type_id))
+        } else if let Some((call_name, arg_strs)) = parse_type_call_syntax(type_name) {
+            // A type-function application whose arguments may name enclosing
+            // comptime type parameters (`Option(T)` with `T` in `type_subst`).
+            // Resolve each argument under the current substitution, then reduce
+            // the constructor body to its monomorphized type — so a generic
+            // signature/return type applying an enclosing constructor to a type
+            // parameter (`fn wrap(comptime T: type, ...) -> Option(T)`)
+            // monomorphizes at each call site (RUE-272). Shares the reduction
+            // path (and E1200 recursion guard) with the signature-position
+            // resolver `resolve_type_function_call`. On the comptime path we
+            // can't emit a diagnostic, so any failure (unknown callee,
+            // non-`type` callee, arity mismatch, non-reducing body, recursion
+            // guard) just makes the type non-evaluable (`None`); the caller
+            // reports it.
+            let name_sym = self.interner.get_or_intern(&call_name);
+            let fn_info = self.functions.get(&name_sym)?;
+            if fn_info.return_type != Type::COMPTIME_TYPE {
+                return None;
+            }
+            let params = fn_info.params;
+            let param_names = self.param_arena.names(params).to_vec();
+            let param_comptime = self.param_arena.comptime(params).to_vec();
+            if arg_strs.len() != param_names.len()
+                || !(param_names.is_empty() || param_comptime.iter().all(|&c| c))
+            {
+                return None;
+            }
+            let mut callee_types: HashMap<Spur, Type> = HashMap::new();
+            for (i, arg) in arg_strs.iter().enumerate() {
+                let arg_sym = self.interner.get_or_intern(arg);
+                let arg_ty = self.resolve_type_for_comptime_with_subst_and_values(
+                    arg_sym,
+                    type_subst,
+                    value_subst,
+                )?;
+                callee_types.insert(param_names[i], arg_ty);
+            }
+            let empty_values: HashMap<Spur, ConstValue> = HashMap::new();
+            match self
+                .reduce_type_ctor_body(name_sym, &callee_types, &empty_values)
+                .ok()?
+            {
+                Some(ConstValue::Type(t)) => Some(t),
+                _ => None,
+            }
         } else {
             None // Unknown type
         }
@@ -579,6 +650,17 @@ impl<'a> Sema<'a> {
             .or_else(|| type_name.strip_prefix("ptr mut "))
         {
             return self.type_name_mentions_type_param(pointee, type_params);
+        }
+        // A type-function application `Name(arg, ...)` mentions a type parameter
+        // if any argument does — `Option(T)` mentions `T`, so a signature/return
+        // type applying an enclosing constructor to a type parameter is deferred
+        // (as `Type::COMPTIME_TYPE`) until specialization, exactly like `[T; N]`
+        // (RUE-272). The constructor name itself is never a type parameter, so
+        // only the arguments are inspected.
+        if let Some((_call_name, arg_strs)) = parse_type_call_syntax(type_name) {
+            return arg_strs
+                .iter()
+                .any(|arg| self.type_name_mentions_type_param(arg, type_params));
         }
         // Leaf name: only a match against an already-interned symbol counts
         // (type parameter names are interned by the parser).

--- a/crates/rue-cli-tests/cases/generic_type_call_sigs.toml
+++ b/crates/rue-cli-tests/cases/generic_type_call_sigs.toml
@@ -125,3 +125,109 @@ fn main() -> i32 { 0 }
 args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E1200", "expects 2 comptime type argument"]
+
+# --- Type function applied to an ENCLOSING type parameter (RUE-272) ---
+#
+# Composing RUE-241 (type-call in a signature) with RUE-263
+# (comptime-type-var-in-context): a generic function whose signature applies a
+# constructor to its own type parameter (`fn wrap(comptime T: type, v: T) ->
+# Option(T)`). The `T` in `Option(T)` resolves from the enclosing comptime
+# parameter and monomorphizes at each call site — the milestone that makes
+# generic FUNCTIONS OVER Option/Result usable, not just concrete
+# instantiations.
+
+[[case]]
+name = "type_fn_over_enclosing_param_return"
+description = "fn wrap(comptime T: type, v: T) -> Option(T): the enclosing T resolves and Some carries 42."
+files = [{ path = "main.rue", source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn wrap(comptime T: type, v: T) -> Option(T) {
+    let O = Option(T);
+    O::Some(v)
+}
+fn main() -> i32 {
+    let O = Option(i32);
+    match wrap(i32, 42) { O::Some(x) => x, O::None => 0 }
+}
+""" }]
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+exit_code = 42
+
+[[case]]
+name = "type_fn_over_enclosing_param_two_instantiations"
+description = "Two instantiations (i32 and bool) monomorphize independently: 40 + 2 = 42."
+files = [{ path = "main.rue", source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn wrap(comptime T: type, v: T) -> Option(T) {
+    let O = Option(T);
+    O::Some(v)
+}
+fn main() -> i32 {
+    let Oi = Option(i32);
+    let a = match wrap(i32, 40) { Oi::Some(x) => x, Oi::None => 0 };
+    let Ob = Option(bool);
+    let b = match wrap(bool, true) { Ob::Some(x) => 2, Ob::None => 0 };
+    a + b
+}
+""" }]
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+exit_code = 42
+
+[[case]]
+name = "type_fn_over_enclosing_param_array"
+description = "Composes with [T; N]: fn first(comptime T: type, xs: [T; 2]) -> Option(T) returns xs[0]."
+files = [{ path = "main.rue", source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn first(comptime T: type, xs: [T; 2]) -> Option(T) {
+    let O = Option(T);
+    O::Some(xs[0])
+}
+fn main() -> i32 {
+    let arr = [7, 9];
+    let O = Option(i32);
+    match first(i32, arr) { O::Some(x) => x, O::None => 0 }
+}
+""" }]
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+exit_code = 7
+
+[[case]]
+name = "type_fn_over_enclosing_param_nested"
+description = "Nested Result(Option(T), i32) return type resolves and constructs through both layers."
+files = [{ path = "main.rue", source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
+fn wrap_ok(comptime T: type, v: T) -> Result(Option(T), i32) {
+    let O = Option(T);
+    let R = Result(Option(T), i32);
+    R::Ok(O::Some(v))
+}
+fn main() -> i32 {
+    let O = Option(i32);
+    let R = Result(Option(i32), i32);
+    match wrap_ok(i32, 42) {
+        R::Ok(o) => match o { O::Some(v) => v, O::None => 0 },
+        R::Err(e) => 0 - e,
+    }
+}
+""" }]
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+exit_code = 42
+
+[[case]]
+name = "type_fn_over_enclosing_param_let_annotation"
+description = "A `let x: Option(T)` annotation inside the generic body resolves T from the enclosing param."
+files = [{ path = "main.rue", source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn wrap(comptime T: type, v: T) -> Option(T) {
+    let O = Option(T);
+    let x: Option(T) = O::Some(v);
+    x
+}
+fn main() -> i32 {
+    let O = Option(i32);
+    match wrap(i32, 42) { O::Some(x) => x, O::None => 0 }
+}
+""" }]
+args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+exit_code = 42

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1702,3 +1702,42 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+[[case]]
+name = "anon_enum_type_fn_over_enclosing_param"
+spec = ["4.14:20"]
+preview = "enum_payloads"
+description = "A generic function whose signature applies a type constructor to its own type parameter (`-> Option(T)`) resolves and monomorphizes at the call site (RUE-272)"
+source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn wrap(comptime T: type, v: T) -> Option(T) {
+    let O = Option(T);
+    O::Some(v)
+}
+fn main() -> i32 {
+    let O = Option(i32);
+    match wrap(i32, 42) { O::Some(x) => x, O::None => 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "anon_enum_type_fn_over_param_two_instantiations"
+spec = ["4.14:21"]
+preview = "enum_payloads"
+description = "The same generic function over Option(T) monomorphizes independently for i32 and bool (RUE-272)"
+source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn wrap(comptime T: type, v: T) -> Option(T) {
+    let O = Option(T);
+    O::Some(v)
+}
+fn main() -> i32 {
+    let Oi = Option(i32);
+    let a = match wrap(i32, 40) { Oi::Some(x) => x, Oi::None => 0 };
+    let Ob = Option(bool);
+    let b = match wrap(bool, true) { Ob::Some(x) => 2, Ob::None => 0 };
+    a + b
+}
+"""
+exit_code = 42


### PR DESCRIPTION
Completes the generics-over-Option/Result milestone: fn wrap(comptime T: type, v: T) -> Option(T) now compiles and monomorphizes at each call site. Composes RUE-241 (type-call in signature) + RUE-263 (comptime-type-var-in-context).

The issue's named cause (context-free arg resolution in resolve_type_function_call) was one of FOUR sites; the E0206 the repro hit came from a fourth, undocumented one — the inference/constraint-generation pass, which couldn't reduce constructor bodies and emitted the wrong COMPTIME_TYPE placeholder. Fixes (all rue-air):
- type_name_mentions_type_param looks through Name(args) so -> Option(T) is deferred like [T; N].
- resolve_type_for_comptime_with_subst_and_values + resolve_type_function_call (now ctx-aware, for let x: Option(T)) resolve type-call args under the active substitution/context and reduce the body.
- the constraint generator uses a fresh inference variable for an unresolvable deferred type-call return (sema computes the real type), instead of the COMPTIME_TYPE that spuriously unified into E0206.

Verified by execution: wrap(i32,42) -> 42; two independent instantiations -> 42; [T;2] compose -> 7; nested Result(Option(T),i32) -> 42; let x: Option(T) -> 42; concrete RUE-241 cases no regression. Full test.sh green; diff-fuzzer 300 seeds 0 disagreements. 5 CLI + 2 spec cases.

Fixes RUE-272

Generated with Claude Code