### PR TITLE
Parameter shadowing miscompile + partial-move soundness at depth (RUE-278, RUE-279, RUE-280)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -2127,33 +2127,37 @@ impl<'a> Sema<'a> {
 
         // For VarRef, we handle it specially: check for full moves but don't mark as moved
         if let InstData::VarRef { name } = &inst.data {
-            // First check if it's a parameter
-            if let Some(param_info) = ctx.params.iter().find(|p| p.name == *name) {
-                let ty = param_info.ty;
+            // Check if it's a parameter — unless a `let` shadowed it with a
+            // same-named local, which then wins for all later references
+            // (spec 5.1:10, RUE-278); the local is resolved just below.
+            if !ctx.locals.contains_key(name) {
+                if let Some(param_info) = ctx.params.iter().find(|p| p.name == *name) {
+                    let ty = param_info.ty;
 
-                // Check if this parameter has been fully moved
-                // (Partial moves are checked at the FieldGet level)
-                if let Some(move_state) = ctx.moved_vars.get(name) {
-                    if let Some(moved_span) = move_state.full_move {
-                        let name_str = self.interner.resolve(&*name);
-                        return Err(CompileError::new(
-                            ErrorKind::UseAfterMove(name_str.to_string()),
-                            inst.span,
-                        )
-                        .with_label("value moved here", moved_span));
+                    // Check if this parameter has been fully moved
+                    // (Partial moves are checked at the FieldGet level)
+                    if let Some(move_state) = ctx.moved_vars.get(name) {
+                        if let Some(moved_span) = move_state.full_move {
+                            let name_str = self.interner.resolve(&*name);
+                            return Err(CompileError::new(
+                                ErrorKind::UseAfterMove(name_str.to_string()),
+                                inst.span,
+                            )
+                            .with_label("value moved here", moved_span));
+                        }
                     }
+
+                    // NOTE: We do NOT mark as moved here - this is a projection
+
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::Param {
+                            index: param_info.abi_slot,
+                        },
+                        ty,
+                        span: inst.span,
+                    });
+                    return Ok(AnalysisResult::new(air_ref, ty));
                 }
-
-                // NOTE: We do NOT mark as moved here - this is a projection
-
-                let air_ref = air.add_inst(AirInst {
-                    data: AirInstData::Param {
-                        index: param_info.abi_slot,
-                    },
-                    ty,
-                    span: inst.span,
-                });
-                return Ok(AnalysisResult::new(air_ref, ty));
             }
 
             // Look up the variable in locals
@@ -2839,6 +2843,7 @@ impl<'a> Sema<'a> {
                 result_type: field_type,
                 field_name: Some(field),
                 const_index: None,
+                index_segment: None,
             });
 
             // A write through an element of a partially moved array
@@ -2852,10 +2857,11 @@ impl<'a> Sema<'a> {
             // The write reinitializes its destination: the assigned path
             // (and any moved sub-paths under it) is no longer moved, so
             // `o.f = ...` after `consume(o.f)` makes `o.f` usable again.
-            // Index projections are skipped: `arr[i].f` records its moves
-            // under the index-agnostic path `f` (see PlaceTrace::field_path),
-            // so unmarking on a write to `arr[0].f` would wrongly forget a
-            // move out of `arr[1].f`.
+            // Writes through an index projection are skipped: a partially
+            // moved array is already rejected outright above (E0480), and
+            // per-element write re-arm is unsupported (the sema path and the
+            // runtime drop flags would disagree), so the whole array must be
+            // reinitialized instead — never a single `arr[0].f` write.
             if !trace
                 .projections
                 .iter()
@@ -3001,7 +3007,13 @@ impl<'a> Sema<'a> {
                 }
             }
 
-            // Add the index projection
+            // Add the index projection. A non-negative constant index carries
+            // its element path segment so field_path nests through it (RUE-279).
+            let const_index = self.try_get_const_index(index);
+            let index_segment = match const_index {
+                Some(k) if k >= 0 => Some(index_path_segment(self.interner, k as u64)),
+                _ => None,
+            };
             trace.projections.push(ProjectionInfo {
                 proj: AirProjection::Index {
                     array_type: base_type,
@@ -3009,7 +3021,8 @@ impl<'a> Sema<'a> {
                 },
                 result_type: elem_type,
                 field_name: None,
-                const_index: self.try_get_const_index(index),
+                const_index,
+                index_segment,
             });
 
             // Writing into an array with moved-out elements is rejected
@@ -5290,6 +5303,19 @@ impl<'a> Sema<'a> {
         // direct `a[i] = …` or reassignment inside the body.
         self.reject_mutate_iter_borrowed(root, span, ctx)?;
 
+        // Root local: must be `let mut`. Checked before parameters because a
+        // `let` that shadows a param name rebinds the receiver to that local
+        // (spec 5.1:10, RUE-278).
+        if let Some(local) = ctx.locals.get(&root) {
+            if !local.is_mut {
+                return Err(CompileError::new(
+                    ErrorKind::AssignToImmutable(self.interner.resolve(&root).to_string()),
+                    span,
+                ));
+            }
+            return Ok(());
+        }
+
         // Root parameter: only `inout` names mutable caller storage.
         if let Some(param) = ctx.params.iter().find(|p| p.name == root) {
             return match param.mode {
@@ -5305,17 +5331,6 @@ impl<'a> Sema<'a> {
                     span,
                 )),
             };
-        }
-
-        // Root local: must be `let mut`.
-        if let Some(local) = ctx.locals.get(&root) {
-            if !local.is_mut {
-                return Err(CompileError::new(
-                    ErrorKind::AssignToImmutable(self.interner.resolve(&root).to_string()),
-                    span,
-                ));
-            }
-            return Ok(());
         }
 
         Err(CompileError::new(
@@ -5695,7 +5710,10 @@ impl<'a> Sema<'a> {
         self.reject_move_out_of_byref_param(trace.root_var, ctx, span)?;
         let elem_path = vec![index_path_segment(self.interner, k as u64)];
         if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
-            if let Some(moved_span) = state.is_path_moved(&elem_path) {
+            // Whole-element move: reject if the element itself, an ancestor, or
+            // any descendant subfield was already moved (`arr[0]` can't be
+            // moved once `arr[0].s` moved — spec 3.8, RUE-279).
+            if let Some(moved_span) = state.is_path_or_descendant_moved(&elem_path) {
                 return Err(use_after_move_path_error(
                     self.interner,
                     trace.root_var,
@@ -5886,11 +5904,13 @@ impl<'a> Sema<'a> {
     /// caller storage); everything else (`let`, `borrow` params) is not.
     /// Mirrors `PlaceTrace::is_root_mutable`.
     fn receiver_root_is_mutable(&self, root: Spur, ctx: &AnalysisContext) -> bool {
-        if let Some(param) = ctx.params.iter().find(|p| p.name == root) {
-            return param.mode == RirParamMode::Inout;
-        }
+        // Locals shadow parameters (RUE-278): a `let mut` rebinding a param
+        // name is the mutable binding that later receiver uses see.
         if let Some(local) = ctx.locals.get(&root) {
             return local.is_mut;
+        }
+        if let Some(param) = ctx.params.iter().find(|p| p.name == root) {
+            return param.mode == RirParamMode::Inout;
         }
         false
     }

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -63,6 +63,14 @@ pub(crate) struct ProjectionInfo {
     /// value (for per-element move tracking, RUE-186). None for field
     /// projections and dynamic indices.
     pub const_index: Option<i64>,
+    /// For index projections with a non-negative constant index: the interned
+    /// decimal-string path segment for that element (`arr[0]` → `"0"`),
+    /// matching the encoding [`super::analysis::index_path_segment`] uses for
+    /// whole-element moves. Lets `field_path` nest a projection through a
+    /// constant index under the correct element (`arr[0].s` → `["0", "s"]`)
+    /// instead of stripping the index (RUE-279). None for field projections,
+    /// dynamic indices, and negative constants.
+    pub index_segment: Option<Spur>,
 }
 
 /// Result of tracing a place expression in RIR.
@@ -94,25 +102,38 @@ impl PlaceTrace {
             .unwrap_or(self.base_type)
     }
 
-    /// Build the field path for move checking (list of field name symbols).
+    /// Build the field path for move checking (list of path segments).
     ///
-    /// Returns the field names in the projection chain. Index projections
-    /// break the field path (you can't partially move out of arrays), so
-    /// this returns field names from the last index projection to the end.
+    /// Fields contribute their name; an index through a **non-negative
+    /// constant** contributes its decimal-string element segment, so a
+    /// projection through a constant index nests under the right element
+    /// (`arr[0].s` → `["0", "s"]`, matching whole-element moves — RUE-279).
+    ///
+    /// A **dynamic** (or negative) index cannot be named, so it resets the
+    /// path: segments before it are dropped and collection continues after it.
+    /// This keeps the old "you can't statically track a partial move through a
+    /// runtime index" behavior for that case (the caller falls back to the
+    /// conservative whole-array E0904 rejection), while constant indices are
+    /// now tracked precisely instead of being conflated (every `arr[K].f`
+    /// previously collapsed to `["f"]`, which both hid nested partial moves
+    /// and false-rejected sibling-element moves).
     pub fn field_path(&self) -> Vec<Spur> {
-        // Find the last index projection (if any)
-        let start_from = self
-            .projections
-            .iter()
-            .rposition(|p| matches!(p.proj, AirProjection::Index { .. }))
-            .map(|i| i + 1)
-            .unwrap_or(0);
-
-        // Collect field names from that point to the end
-        self.projections[start_from..]
-            .iter()
-            .filter_map(|p| p.field_name)
-            .collect()
+        let mut path = Vec::new();
+        for p in &self.projections {
+            match p.proj {
+                AirProjection::Index { .. } => match p.index_segment {
+                    Some(seg) => path.push(seg),
+                    // Dynamic/negative index: unnameable element — restart.
+                    None => path.clear(),
+                },
+                AirProjection::Field { .. } => {
+                    if let Some(name) = p.field_name {
+                        path.push(name);
+                    }
+                }
+            }
+        }
+        path
     }
 }
 
@@ -169,19 +190,10 @@ impl<'a> Sema<'a> {
         match &inst.data {
             // Base case: local variable reference
             InstData::VarRef { name } => {
-                // First check if it's actually a parameter
-                if let Some(param_info) = ctx.params.iter().find(|p| p.name == *name) {
-                    return Ok(Some(PlaceTrace {
-                        base: AirPlaceBase::Param(param_info.abi_slot),
-                        base_type: param_info.ty,
-                        projections: Vec::new(),
-                        root_var: *name,
-                        is_root_mutable: matches!(param_info.mode, RirParamMode::Inout),
-                        is_borrow_param: matches!(param_info.mode, RirParamMode::Borrow),
-                    }));
-                }
-
-                // Check if it's a local variable
+                // Locals shadow parameters (spec 5.1:10): a `let` that rebinds a
+                // parameter name makes every later reference resolve to the new
+                // local, not the parameter (RUE-278). A local with a param's
+                // name can only arise by shadowing, so locals always win here.
                 if let Some(local) = ctx.locals.get(name) {
                     return Ok(Some(PlaceTrace {
                         base: AirPlaceBase::Local(local.slot),
@@ -190,6 +202,18 @@ impl<'a> Sema<'a> {
                         root_var: *name,
                         is_root_mutable: local.is_mut,
                         is_borrow_param: false,
+                    }));
+                }
+
+                // Otherwise it may be a parameter.
+                if let Some(param_info) = ctx.params.iter().find(|p| p.name == *name) {
+                    return Ok(Some(PlaceTrace {
+                        base: AirPlaceBase::Param(param_info.abi_slot),
+                        base_type: param_info.ty,
+                        projections: Vec::new(),
+                        root_var: *name,
+                        is_root_mutable: matches!(param_info.mode, RirParamMode::Inout),
+                        is_borrow_param: matches!(param_info.mode, RirParamMode::Borrow),
                     }));
                 }
 
@@ -249,6 +273,7 @@ impl<'a> Sema<'a> {
                             result_type: field_type,
                             field_name: Some(*field),
                             const_index: None,
+                            index_segment: None,
                         });
 
                         Ok(Some(trace))
@@ -288,7 +313,17 @@ impl<'a> Sema<'a> {
                         ctx.byref_arg_root = saved_byref_root;
                         let index_result = index_result?;
 
-                        // Add this projection (no field name for indices)
+                        // Add this projection (no field name for indices).
+                        // A non-negative constant index also gets its interned
+                        // element path segment so field_path can nest through
+                        // it (RUE-279); negative/dynamic indices leave it None.
+                        let const_index = self.try_get_const_index(*index);
+                        let index_segment = match const_index {
+                            Some(k) if k >= 0 => {
+                                Some(super::analysis::index_path_segment(self.interner, k as u64))
+                            }
+                            _ => None,
+                        };
                         trace.projections.push(ProjectionInfo {
                             proj: AirProjection::Index {
                                 array_type: base_type,
@@ -296,7 +331,8 @@ impl<'a> Sema<'a> {
                             },
                             result_type: elem_type,
                             field_name: None,
-                            const_index: self.try_get_const_index(*index),
+                            const_index,
+                            index_segment,
                         });
 
                         Ok(Some(trace))
@@ -2158,97 +2194,102 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // First check if it's a parameter
-        if let Some(param_info) = ctx.params.iter().find(|p| p.name == name) {
-            let ty = param_info.ty;
-            let name_str = self.interner.resolve(&name);
+        // Check if it's a parameter — but a `let` that shadows the parameter
+        // rebinds the name to a new local, and that local wins for all later
+        // reads (spec 5.1:10, RUE-278). A same-named local can only exist by
+        // shadowing, so its presence means "resolve as local" (handled below).
+        if !ctx.locals.contains_key(&name) {
+            if let Some(param_info) = ctx.params.iter().find(|p| p.name == name) {
+                let ty = param_info.ty;
+                let name_str = self.interner.resolve(&name);
 
-            // Check if this parameter has been moved
-            if let Some(move_state) = ctx.moved_vars.get(&name) {
-                if let Some(moved_span) = move_state.is_any_part_moved() {
-                    return Err(CompileError::new(
-                        ErrorKind::UseAfterMove(name_str.to_string()),
-                        span,
-                    )
-                    .with_label("value moved here", moved_span));
-                }
-            }
-
-            // Handle move semantics based on parameter mode.
-            // A use as a by-ref call argument is a borrow, not a move
-            // (`analyze_call_args` sets `byref_arg_root`), so it neither marks
-            // the parameter moved nor counts as moving out of it. This is what
-            // permits forwarding an inout parameter: `f(inout v)` inside
-            // `fn g(inout v: T)`.
-            let is_byref_arg_use = ctx.byref_arg_root == Some(name);
-            let mut moves_out = false;
-            if !self.is_type_copy(ty) {
-                match param_info.mode {
-                    // Normal and comptime parameters behave similarly for moves
-                    // (comptime params are substituted at compile time)
-                    RirParamMode::Normal | RirParamMode::Comptime => {
-                        if !is_byref_arg_use {
-                            ctx.moved_vars
-                                .entry(name)
-                                .or_default()
-                                .mark_path_moved(&[], span);
-                            // Only Normal params occupy a real ABI slot that
-                            // drop elaboration would otherwise drop at exit.
-                            moves_out = param_info.mode == RirParamMode::Normal;
-                        }
-                    }
-                    RirParamMode::Inout => {
-                        // Moving out of an inout parameter would leave the
-                        // CALLER's variable moved-from after the call returns,
-                        // so it is rejected outright (RUE-127).
-                        if !is_byref_arg_use {
-                            return Err(move_out_of_inout_error(name_str, span));
-                        }
-                    }
-                    RirParamMode::Borrow => {
-                        // A by-ref argument use re-borrows the parameter:
-                        // `f(borrow v)` inside `fn g(borrow v: T)` is a sound
-                        // read-only re-borrow and is allowed (RUE-143).
-                        // `f(inout v)` — a mutable view of read-only memory —
-                        // was already rejected in `analyze_call_args` (E0428),
-                        // so a by-ref use reaching here is borrow-mode.
-                        // Anything else moves out of the borrow: rejected.
-                        if !is_byref_arg_use {
-                            let name_str = self.interner.resolve(&name);
-                            return Err(CompileError::new(
-                                ErrorKind::MoveOutOfBorrow {
-                                    variable: name_str.to_string(),
-                                },
-                                span,
-                            ));
-                        }
+                // Check if this parameter has been moved
+                if let Some(move_state) = ctx.moved_vars.get(&name) {
+                    if let Some(moved_span) = move_state.is_any_part_moved() {
+                        return Err(CompileError::new(
+                            ErrorKind::UseAfterMove(name_str.to_string()),
+                            span,
+                        )
+                        .with_label("value moved here", moved_span));
                     }
                 }
-            }
 
-            let mut air_ref = air.add_inst(AirInst {
-                data: AirInstData::Param {
-                    index: param_info.abi_slot,
-                },
-                ty,
-                span,
-            });
-            if moves_out {
-                // Export the move to drop elaboration: the callee-side drop
-                // of this parameter is suppressed on paths where its value
-                // moved out (RUE-61).
-                air_ref = air.add_inst(AirInst {
-                    data: AirInstData::MarkMoved {
-                        value: air_ref,
-                        slot: param_info.abi_slot,
-                        is_param: true,
-                        place: None,
+                // Handle move semantics based on parameter mode.
+                // A use as a by-ref call argument is a borrow, not a move
+                // (`analyze_call_args` sets `byref_arg_root`), so it neither marks
+                // the parameter moved nor counts as moving out of it. This is what
+                // permits forwarding an inout parameter: `f(inout v)` inside
+                // `fn g(inout v: T)`.
+                let is_byref_arg_use = ctx.byref_arg_root == Some(name);
+                let mut moves_out = false;
+                if !self.is_type_copy(ty) {
+                    match param_info.mode {
+                        // Normal and comptime parameters behave similarly for moves
+                        // (comptime params are substituted at compile time)
+                        RirParamMode::Normal | RirParamMode::Comptime => {
+                            if !is_byref_arg_use {
+                                ctx.moved_vars
+                                    .entry(name)
+                                    .or_default()
+                                    .mark_path_moved(&[], span);
+                                // Only Normal params occupy a real ABI slot that
+                                // drop elaboration would otherwise drop at exit.
+                                moves_out = param_info.mode == RirParamMode::Normal;
+                            }
+                        }
+                        RirParamMode::Inout => {
+                            // Moving out of an inout parameter would leave the
+                            // CALLER's variable moved-from after the call returns,
+                            // so it is rejected outright (RUE-127).
+                            if !is_byref_arg_use {
+                                return Err(move_out_of_inout_error(name_str, span));
+                            }
+                        }
+                        RirParamMode::Borrow => {
+                            // A by-ref argument use re-borrows the parameter:
+                            // `f(borrow v)` inside `fn g(borrow v: T)` is a sound
+                            // read-only re-borrow and is allowed (RUE-143).
+                            // `f(inout v)` — a mutable view of read-only memory —
+                            // was already rejected in `analyze_call_args` (E0428),
+                            // so a by-ref use reaching here is borrow-mode.
+                            // Anything else moves out of the borrow: rejected.
+                            if !is_byref_arg_use {
+                                let name_str = self.interner.resolve(&name);
+                                return Err(CompileError::new(
+                                    ErrorKind::MoveOutOfBorrow {
+                                        variable: name_str.to_string(),
+                                    },
+                                    span,
+                                ));
+                            }
+                        }
+                    }
+                }
+
+                let mut air_ref = air.add_inst(AirInst {
+                    data: AirInstData::Param {
+                        index: param_info.abi_slot,
                     },
                     ty,
                     span,
                 });
+                if moves_out {
+                    // Export the move to drop elaboration: the callee-side drop
+                    // of this parameter is suppressed on paths where its value
+                    // moved out (RUE-61).
+                    air_ref = air.add_inst(AirInst {
+                        data: AirInstData::MarkMoved {
+                            value: air_ref,
+                            slot: param_info.abi_slot,
+                            is_param: true,
+                            place: None,
+                        },
+                        ty,
+                        span,
+                    });
+                }
+                return Ok(AnalysisResult::new(air_ref, ty));
             }
-            return Ok(AnalysisResult::new(air_ref, ty));
         }
 
         // Look up the variable in locals
@@ -2493,53 +2534,59 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        // First check if it's a parameter (for inout params)
-        if let Some(param_info) = ctx.params.iter().find(|p| p.name == name) {
-            // Check parameter mode - only inout can be assigned to
-            match param_info.mode {
-                // Normal and comptime parameters are immutable
-                RirParamMode::Normal | RirParamMode::Comptime => {
-                    return Err(CompileError::new(
-                        ErrorKind::AssignToImmutable(name_str.to_string()),
-                        span,
-                    )
-                    .with_help(format!(
-                        "consider making parameter `{}` inout: `inout {}: {}`",
-                        name_str,
-                        name_str,
-                        param_info.ty.safe_name_with_pool(Some(&self.type_pool))
-                    )));
+        // Check if it's a parameter (for inout params) — unless a `let mut`
+        // shadowed it with a local of the same name, in which case the
+        // assignment targets that mutable local, not the parameter (RUE-278).
+        // Without this guard, `let mut x = x; x = x + 1;` wrongly reports E0203
+        // against the immutable parameter with a bogus "make it inout" hint.
+        if !ctx.locals.contains_key(&name) {
+            if let Some(param_info) = ctx.params.iter().find(|p| p.name == name) {
+                // Check parameter mode - only inout can be assigned to
+                match param_info.mode {
+                    // Normal and comptime parameters are immutable
+                    RirParamMode::Normal | RirParamMode::Comptime => {
+                        return Err(CompileError::new(
+                            ErrorKind::AssignToImmutable(name_str.to_string()),
+                            span,
+                        )
+                        .with_help(format!(
+                            "consider making parameter `{}` inout: `inout {}: {}`",
+                            name_str,
+                            name_str,
+                            param_info.ty.safe_name_with_pool(Some(&self.type_pool))
+                        )));
+                    }
+                    RirParamMode::Inout => {
+                        // Inout parameters can be assigned to
+                    }
+                    RirParamMode::Borrow => {
+                        return Err(CompileError::new(
+                            ErrorKind::MutateBorrowedValue {
+                                variable: name_str.to_string(),
+                            },
+                            span,
+                        ));
+                    }
                 }
-                RirParamMode::Inout => {
-                    // Inout parameters can be assigned to
-                }
-                RirParamMode::Borrow => {
-                    return Err(CompileError::new(
-                        ErrorKind::MutateBorrowedValue {
-                            variable: name_str.to_string(),
-                        },
-                        span,
-                    ));
-                }
+
+                let abi_slot = param_info.abi_slot;
+
+                // Analyze the value
+                let value_result = self.analyze_inst(air, value, ctx)?;
+
+                // Assignment to a parameter resets its move state
+                ctx.moved_vars.remove(&name);
+
+                let air_ref = air.add_inst(AirInst {
+                    data: AirInstData::ParamStore {
+                        param_slot: abi_slot,
+                        value: value_result.air_ref,
+                    },
+                    ty: Type::UNIT,
+                    span,
+                });
+                return Ok(AnalysisResult::new(air_ref, Type::UNIT));
             }
-
-            let abi_slot = param_info.abi_slot;
-
-            // Analyze the value
-            let value_result = self.analyze_inst(air, value, ctx)?;
-
-            // Assignment to a parameter resets its move state
-            ctx.moved_vars.remove(&name);
-
-            let air_ref = air.add_inst(AirInst {
-                data: AirInstData::ParamStore {
-                    param_slot: abi_slot,
-                    value: value_result.air_ref,
-                },
-                ty: Type::UNIT,
-                span,
-            });
-            return Ok(AnalysisResult::new(air_ref, Type::UNIT));
         }
 
         // Look up local variable
@@ -2843,6 +2890,12 @@ impl<'a> Sema<'a> {
         ctx: &AnalysisContext,
         span: Span,
     ) -> CompileResult<()> {
+        // A `let` shadowing the by-ref parameter rebinds the name to an owned
+        // local; moving out of that local is fine, so the parameter rule no
+        // longer applies (RUE-278).
+        if ctx.locals.contains_key(&root_var) {
+            return Ok(());
+        }
         if let Some(param_info) = ctx.params.iter().find(|p| p.name == root_var) {
             match param_info.mode {
                 RirParamMode::Inout => {
@@ -3100,9 +3153,14 @@ impl<'a> Sema<'a> {
                 self.reject_field_move_out_of_destructor_type(&trace, span)?;
                 let field_path = trace.field_path();
 
-                // Check if this field path is already moved (partial moves)
+                // Check if this field path is already moved. Moving the field
+                // out as a whole value is illegal if the path itself, an
+                // ancestor, OR any descendant subfield was already moved
+                // (`o.inner` cannot be passed by value once `o.inner.s` moved —
+                // spec 3.8, RUE-279), so check both directions here, unlike a
+                // Copy leaf read below which only cares about ancestors.
                 if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
-                    if let Some(moved_span) = state.is_path_moved(&field_path) {
+                    if let Some(moved_span) = state.is_path_or_descendant_moved(&field_path) {
                         return Err(super::analysis::use_after_move_path_error(
                             self.interner,
                             trace.root_var,
@@ -3801,9 +3859,11 @@ impl<'a> Sema<'a> {
             // own path and the non-Copy branch records an element move — so
             // `moved.field[i]` after `let b = moved` slipped through. Check the
             // base place's move state here for every index read. `field_path()`
-            // stops at the last index projection, so this catches a full move
-            // of the root (or a moved field prefix) without falsely flagging a
-            // previously moved-out *element* (those use a longer index path).
+            // names this element (constant index) or the base up to a dynamic
+            // index, so `is_path_moved` catches a full move of the root, a
+            // moved field/element prefix, or this exact constant element,
+            // without flagging a *sibling* element (`arr[1]` after `arr[0]`
+            // moved has a disjoint path).
             {
                 let field_path = trace.field_path();
                 if let Some(state) = ctx.moved_vars.get(&trace.root_var) {
@@ -3862,9 +3922,10 @@ impl<'a> Sema<'a> {
             // a[i])`) borrows the element in place rather than moving it out
             // of the array (RUE-143), so the non-Copy rejection below does
             // not apply — but indexing an already-moved array is still a
-            // use-after-move (`field_path()` of an index-terminated trace is
-            // empty, so this checks the root's full move; the per-element
-            // check below covers a moved-out element, RUE-186).
+            // use-after-move (`field_path()` names this element for a constant
+            // index, so this catches the root's full move or this exact
+            // element; the per-element check below also covers a moved-out
+            // element, RUE-186).
             let is_byref_arg_use = ctx.byref_arg_root == Some(trace.root_var);
             let mut element_move: Option<i64> = None;
             if is_byref_arg_use {

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -155,6 +155,30 @@ impl VariableMoveState {
         best.map(|(_, span)| span)
     }
 
+    /// Check whether `path` is valid to use as a WHOLE value (moving or
+    /// passing the aggregate by value). Returns `Some(span)` if the path
+    /// itself, any ancestor, OR any descendant has been moved.
+    ///
+    /// `is_path_moved` only checks the exact-and-ancestor direction, which is
+    /// right for reading a single leaf: a moved *sibling* subfield is
+    /// irrelevant to reading `o.inner.n`. But using `o.inner` as a whole value
+    /// after `o.inner.s` was moved out would let the new owner and the hole
+    /// coexist — spec 3.8 forbids using a struct with any moved field as a
+    /// whole value, at any depth (RUE-279). So the whole-value-use sites must
+    /// also reject when a DESCENDANT path (a stored moved path that has `path`
+    /// as a strict prefix) is moved.
+    pub fn is_path_or_descendant_moved(&self, path: &[Spur]) -> Option<Span> {
+        if let Some(span) = self.is_path_moved(path) {
+            return Some(span);
+        }
+        // Descendant direction: a longer stored moved path (`o.inner.s`) whose
+        // prefix is the queried whole-value path (`o.inner`).
+        self.partial_moves
+            .iter()
+            .find(|(moved, _)| moved.len() > path.len() && moved[..path.len()] == *path)
+            .map(|(_, span)| *span)
+    }
+
     /// Check if the entire variable (including all fields) is fully valid to use.
     /// Returns Some(span) if there's any move (full or partial) that would prevent use.
     pub fn is_any_part_moved(&self) -> Option<Span> {

--- a/crates/rue-cli-tests/cases/partial_move_depth.toml
+++ b/crates/rue-cli-tests/cases/partial_move_depth.toml
@@ -1,0 +1,125 @@
+# Partial moves must be enforced at depth (RUE-279).
+#
+# Spec 3.8: a struct (or array element) with any moved field cannot be used as
+# a WHOLE value. This held one level deep but not deeper: after moving a
+# sub-subfield (`o.inner.s`), the intermediate `o.inner` was still passable by
+# value — a soundness hole (the new owner and the hole coexisted). The move
+# checker now rejects using a path as a whole value when any DESCENDANT path
+# was moved, at any depth, for structs and array elements alike.
+
+[section]
+id = "cli.partial_move_depth"
+name = "Partial moves at depth"
+description = "Using an aggregate whole after a nested subfield moved is E0205."
+
+# Depth 2: `consume(o.inner.s)` moves `o.inner.s`; passing `o.inner` whole must
+# be rejected.
+[[case]]
+name = "use_whole_after_subfield_move_depth2"
+files = [
+    { path = "main.rue", source = """
+struct Inner { s: String, n: i32 }
+struct Outer { inner: Inner, tag: i32 }
+fn consume(s: String) -> i32 { @intCast(s.len()) }
+fn consume_inner(i: Inner) -> i32 { @intCast(i.s.len()) + i.n }
+fn main() -> i32 {
+    let o = Outer { inner: Inner { s: "hi", n: 5 }, tag: 9 };
+    consume(o.inner.s);
+    consume_inner(o.inner)
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0205", "o.inner"]
+
+# Depth 3: same rule one level deeper (`c.b.a.s` moved, `c.b` used whole).
+[[case]]
+name = "use_whole_after_subfield_move_depth3"
+files = [
+    { path = "main.rue", source = """
+struct A { s: String, k: i32 }
+struct B { a: A, k: i32 }
+struct C { b: B, k: i32 }
+fn cs(s: String) -> i32 { @intCast(s.len()) }
+fn cb(b: B) -> i32 { @intCast(b.a.s.len()) }
+fn main() -> i32 {
+    let c = C { b: B { a: A { s: "hi", k: 1 }, k: 2 }, k: 3 };
+    cs(c.b.a.s);
+    cb(c.b)
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0205", "c.b"]
+
+# Depth 1 (regression): the original one-level case must still be rejected.
+[[case]]
+name = "use_whole_after_field_move_depth1"
+files = [
+    { path = "main.rue", source = """
+struct Inner { s: String, n: i32 }
+fn consume(s: String) -> i32 { @intCast(s.len()) }
+fn consume_inner(i: Inner) -> i32 { @intCast(i.s.len()) + i.n }
+fn main() -> i32 {
+    let inner = Inner { s: "hi", n: 5 };
+    consume(inner.s);
+    consume_inner(inner)
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0205", "inner"]
+
+# Array element variant: `consume(arr[0].s)` moves a subfield of element 0;
+# passing `arr[0]` whole must be rejected.
+[[case]]
+name = "use_whole_element_after_subfield_move"
+files = [
+    { path = "main.rue", source = """
+struct Inner { s: String, n: i32 }
+fn consume(s: String) -> i32 { @intCast(s.len()) }
+fn consume_inner(i: Inner) -> i32 { @intCast(i.s.len()) + i.n }
+fn main() -> i32 {
+    let arr = [Inner { s: "hi", n: 5 }, Inner { s: "yo", n: 6 }];
+    consume(arr[0].s);
+    consume_inner(arr[0])
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0205", "arr[0]"]
+
+# Disjoint sibling stays legal: after moving `o.inner.s`, the untouched Copy
+# field `o.tag` is still readable (return 9).
+[[case]]
+name = "disjoint_sibling_after_subfield_move_ok"
+files = [
+    { path = "main.rue", source = """
+struct Inner { s: String, n: i32 }
+struct Outer { inner: Inner, tag: i32 }
+fn consume(s: String) -> i32 { @intCast(s.len()) }
+fn main() -> i32 {
+    let o = Outer { inner: Inner { s: "hi", n: 5 }, tag: 9 };
+    consume(o.inner.s);
+    o.tag
+}
+""" },
+]
+exit_code = 9
+
+# Sibling ELEMENT stays legal: moving `arr[0].s` must not poison `arr[1].s`
+# (constant indices are now tracked per element, not conflated). "yo".len() = 2.
+[[case]]
+name = "disjoint_sibling_element_move_ok"
+files = [
+    { path = "main.rue", source = """
+struct Inner { s: String, n: i32 }
+fn consume(s: String) -> i32 { @intCast(s.len()) }
+fn main() -> i32 {
+    let arr = [Inner { s: "hi", n: 5 }, Inner { s: "yo", n: 6 }];
+    consume(arr[0].s);
+    consume(arr[1].s)
+}
+""" },
+]
+exit_code = 2

--- a/crates/rue-cli-tests/cases/shadow_param.toml
+++ b/crates/rue-cli-tests/cases/shadow_param.toml
@@ -1,0 +1,84 @@
+# Shadowing a function parameter with `let` (RUE-278).
+#
+# A `let` that rebinds a parameter name must resolve every LATER reference
+# (reads, assignments, mutability) to the new local, exactly like shadowing a
+# local. Before the fix, post-shadow reads still hit the original parameter
+# slot (a miscompile: `let x = x + 5; x` returned the parameter, not `x + 5`),
+# and `let mut x = x; x = x + 1` wrongly reported E0203 against the immutable
+# parameter with a bogus "make it inout" hint.
+
+[section]
+id = "cli.shadow_param"
+name = "Parameter shadowing with let"
+description = "A let shadowing a parameter rebinds the name for all later uses."
+
+# Face A: `let x = x + 5; x` reads the new local (15), not the parameter (10).
+[[case]]
+name = "shadow_param_scalar_read"
+files = [
+    { path = "main.rue", source = """
+fn f(x: i32) -> i32 { let x = x + 5; x }
+fn main() -> i32 { f(10) }
+""" },
+]
+exit_code = 15
+
+# Face B: a struct parameter shadowed by a struct local; the field read after
+# the shadow sees the new local's field (1001 mod 256 = 233), not the original.
+[[case]]
+name = "shadow_param_struct_field"
+files = [
+    { path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+fn g(p: Point) -> i32 { let p = Point { x: p.x + 1000, y: p.y }; p.x }
+fn main() -> i32 { g(Point { x: 1, y: 0 }) }
+""" },
+]
+exit_code = 233
+
+# Face C: `let mut x = x` produces a fresh MUTABLE local, so `x = x + 1` is a
+# legal assignment to that local — not E0203 against the immutable parameter.
+[[case]]
+name = "shadow_param_let_mut_assign"
+files = [
+    { path = "main.rue", source = """
+fn h(x: i32) -> i32 { let mut x = x; x = x + 1; x }
+fn main() -> i32 { h(10) }
+""" },
+]
+exit_code = 11
+
+# Control: shadowing a LOCAL (not a parameter) already worked; keep it green so
+# the fix didn't regress the local-over-local path.
+[[case]]
+name = "shadow_local_control"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 { let x = 10; let x = x + 5; x }
+""" },
+]
+exit_code = 15
+
+# A parameter read BEFORE the shadow still reads the parameter: `let a = x`
+# binds a = 2, then `let x = x + 5` binds x = 7, so a*100 + x = 207.
+[[case]]
+name = "shadow_param_read_before_shadow"
+files = [
+    { path = "main.rue", source = """
+fn f(x: i32) -> i32 { let a = x; let x = x + 5; a * 100 + x }
+fn main() -> i32 { f(2) }
+""" },
+]
+exit_code = 207
+
+# A shadow inside an inner block is scoped to that block: after the block the
+# name resolves to the parameter again (x = 7).
+[[case]]
+name = "shadow_param_inner_block_scope"
+files = [
+    { path = "main.rue", source = """
+fn f(x: i32) -> i32 { { let x = x + 5; } x }
+fn main() -> i32 { f(7) }
+""" },
+]
+exit_code = 7

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -38,12 +38,19 @@ Syscall numbers and conventions differ between operating systems. Linux x86-64 s
 
 ```rue
 fn main() -> i32 {
+    let msg: [u8; 3] = [72, 73, 10]; // "HI\n"
+    let write_num: u64 = 1;          // Linux x86-64: write
+    let fd: u64 = 1;                 // stdout
+    let exit_num: u64 = 231;         // Linux x86-64: exit_group
+    let code: u64 = 0;
     checked {
-        // Linux x86-64: write(fd=1, buf, len)
-        let result = @syscall(1_u64, 1_u64, msg_ptr, msg_len);
+        // write(fd=1, buf, len)
+        let msg_ptr: u64 = @ptr_to_int(@raw(msg[0]));
+        let msg_len: u64 = 3;
+        let result = @syscall(write_num, fd, msg_ptr, msg_len);
 
-        // Linux x86-64: exit_group(code)
-        @syscall(231_u64, 0_u64);
+        // exit_group(code)
+        @syscall(exit_num, code);
     };
     0
 }


### PR DESCRIPTION
Both dogfooding-critical, found by the nested-aggregates hunt.

**RUE-278 (miscompile):** a let shadowing a PARAMETER never took effect — sema resolved names param-first, so post-shadow reads (and the mutability check) hit the original parameter slot. fn f(x: i32) { let x = x + 5; x } returned 10 not 15. Fixed by making locals shadow params at all 7 resolution sites (one shadowable name->binding map, newest wins). Verified: f(10)->15 (warning gone), struct face->233, let mut x=x; x=x+1 ->11 (was bogus E0203); param-read-before-shadow and inner-block scoping correct; aarch64 asm too.

**RUE-279 (unsound):** use-after-partial-move wasn't caught at depth 2+ — is_path_moved only checked the ancestor direction, so after consume(o.inner.s), consume_inner(o.inner) (whole value) compiled. Added is_path_or_descendant_moved for whole-value uses; also fixed field_path to preserve constant array-index segments (arr[0].s -> [0, s]). Verified depth-2/3 + array variants -> E0205; disjoint siblings (o.tag after o.inner.s moved) still compile; also fixed a latent FALSE rejection where moving arr[0].s poisoned arr[1].s.

**RUE-280 (docs):** rewrote the @syscall spec example off _u64 suffix literals (not in the normative grammar) to typed let bindings; verified it compiles + runs.

Verified by execution + full test.sh green; diff-fuzzer 300 seeds 0 disagreements (it catches the RUE-278 class); 12 new CLI cases.

Fixes RUE-278
Fixes RUE-279
Fixes RUE-280

Generated with Claude Code