### PR TITLE
Promote correctness-guarding debug_assert! to assert! across codegen (part of RUE-45)

### DIFF
--- a/crates/rue-air/src/inst.rs
+++ b/crates/rue-air/src/inst.rs
@@ -502,13 +502,16 @@ impl Air {
 
     /// Add extra data and return the start index.
     pub fn add_extra(&mut self, data: &[u32]) -> u32 {
-        // Debug assertions for u32 overflow
-        debug_assert!(
+        // Correctness guard (must run in release): `start` and the extra
+        // indices are truncated to u32 below, so an overflow would silently
+        // alias unrelated extra data. Plain `assert!` not `debug_assert!`
+        // (RUE-45).
+        assert!(
             self.extra.len() <= u32::MAX as usize,
             "AIR extra data overflow: {} entries exceeds u32::MAX",
             self.extra.len()
         );
-        debug_assert!(
+        assert!(
             self.extra.len().saturating_add(data.len()) <= u32::MAX as usize,
             "AIR extra data would overflow: {} + {} exceeds u32::MAX",
             self.extra.len(),

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -885,9 +885,9 @@ impl Cfg {
     /// an `Unreachable` placeholder. Silently overwriting a real terminator is
     /// how divergence bugs hide — e.g. a diverging let-initializer's `Return`
     /// being clobbered by the code after the `let` (RUE-128) — so that is a
-    /// loud debug assertion instead.
+    /// loud assertion that runs in release too (correctness guard, RUE-45).
     pub fn set_terminator(&mut self, block: BlockId, term: Terminator) {
-        debug_assert!(
+        assert!(
             matches!(
                 self.blocks[block.0 as usize].terminator,
                 Terminator::None | Terminator::Unreachable

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -295,7 +295,10 @@ impl<'a> CfgLower<'a> {
             .cloned()
             .expect("aggregate block param should have slot vregs pre-allocated");
 
-        debug_assert_eq!(
+        // Correctness guard (must run in release): a slot-count mismatch would
+        // move the wrong number of aggregate slots and silently miscompile, so
+        // this is a plain `assert!` rather than a `debug_assert!` (RUE-45).
+        assert_eq!(
             src_slots.len(),
             dst_slots.len(),
             "source and destination aggregate slot counts must match"
@@ -1314,7 +1317,10 @@ impl<'a> CfgLower<'a> {
                     let field_vregs = self
                         .get_or_compute_field_vregs(*init)
                         .expect("string should have fat pointer fields in Alloc");
-                    debug_assert_eq!(
+                    // Correctness guard (must run in release): storing the wrong
+                    // number of fat-pointer slots miscompiles the String, so this
+                    // is a plain `assert!` not `debug_assert!` (RUE-45).
+                    assert_eq!(
                         field_vregs.len(),
                         3,
                         "string should have 3 fields (ptr, len, cap)"
@@ -2571,7 +2577,10 @@ impl<'a> CfgLower<'a> {
                         .get_or_compute_field_vregs(*dropped_value)
                         .expect("String value should have field vregs");
 
-                    debug_assert_eq!(
+                    // Correctness guard (must run in release): passing the wrong
+                    // slot count to __rue_drop_String corrupts the drop call, so
+                    // plain `assert!` not `debug_assert!` (RUE-45).
+                    assert_eq!(
                         field_vregs.len(),
                         3,
                         "String should have 3 slots (ptr, len, cap)"
@@ -3592,12 +3601,15 @@ impl<'a> CfgLower<'a> {
             .get_or_compute_field_vregs(rhs)
             .expect("string should have fat pointer fields");
 
-        debug_assert_eq!(
+        // Correctness guard (must run in release): reading ptr/len from a
+        // String with the wrong field count would index garbage, so plain
+        // `assert!` not `debug_assert!` (RUE-45).
+        assert_eq!(
             lhs_fields.len(),
             3,
             "string should have 3 fields (ptr, len, cap)"
         );
-        debug_assert_eq!(
+        assert_eq!(
             rhs_fields.len(),
             3,
             "string should have 3 fields (ptr, len, cap)"

--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -1358,7 +1358,11 @@ impl<'a> Emitter<'a> {
                     fixup.label
                 )))
             })?;
-            debug_assert_eq!(
+            // Correctness guard (must run in release): a misaligned branch
+            // distance would lose its low bits in the `/ 4` below and branch to
+            // the wrong instruction, so plain `assert!` not `debug_assert!`
+            // (RUE-45).
+            assert_eq!(
                 (target as i64 - fixup.offset as i64) % 4,
                 0,
                 "branch target/site must be 4-byte aligned"
@@ -1546,7 +1550,10 @@ impl<'a> Emitter<'a> {
             // and may be the very rd/rs of this access. Previously the offset
             // was masked & 0x1FF, silently WRAPPING — locals deeper than 256
             // bytes loaded from above the frame pointer. (RUE-129)
-            debug_assert!(
+            // Correctness guard (must run in release): if the base were X15 we
+            // would clobber it while materializing the address and load from the
+            // wrong location, so plain `assert!` not `debug_assert!` (RUE-45).
+            assert!(
                 base != Reg::Sp && base != Reg::X15,
                 "large-offset load needs a general base register"
             );
@@ -1580,7 +1587,11 @@ impl<'a> Emitter<'a> {
             // was masked & 0x1FF, silently WRAPPING — locals deeper than 256
             // bytes stored ABOVE the frame pointer, corrupting the caller's
             // stack. (RUE-129)
-            debug_assert!(
+            // Correctness guard (must run in release): if the base or source
+            // were X15 we would clobber it while materializing the address and
+            // store to/from the wrong location, so plain `assert!` not
+            // `debug_assert!` (RUE-45).
+            assert!(
                 base != Reg::Sp && base != Reg::X15 && rs != Reg::X15,
                 "large-offset store needs a general base register"
             );
@@ -1664,7 +1675,11 @@ impl<'a> Emitter<'a> {
         // ADD for the low part. Previously the immediate was masked & 0xFFF,
         // silently truncating — e.g. epilogues of frames >4095 bytes
         // mis-adjusted SP by multiples of 4096. (RUE-129)
-        debug_assert!(imm < (1 << 24), "ADD immediate exceeds 24 bits: {imm}");
+        // Correctness guard (must run in release): an immediate wider than the
+        // 24 bits the two-instruction shifted form can encode would be silently
+        // truncated below, mis-adjusting SP, so plain `assert!` not
+        // `debug_assert!` (RUE-45).
+        assert!(imm < (1 << 24), "ADD immediate exceeds 24 bits: {imm}");
         if imm > 0xFFF {
             let inst = OPCODE_ADD_IMM_X
                 | (1 << 22)
@@ -1741,7 +1756,11 @@ impl<'a> Emitter<'a> {
         // silently truncating — prologues of frames >4095 bytes UNDER-ALLOCATED
         // by multiples of 4096, so locals overlapped the caller's stack.
         // (RUE-129)
-        debug_assert!(imm < (1 << 24), "SUB immediate exceeds 24 bits: {imm}");
+        // Correctness guard (must run in release): an immediate wider than the
+        // 24 bits the two-instruction shifted form can encode would be silently
+        // truncated below, under-allocating the frame, so plain `assert!` not
+        // `debug_assert!` (RUE-45).
+        assert!(imm < (1 << 24), "SUB immediate exceeds 24 bits: {imm}");
         if imm > 0xFFF {
             let inst = OPCODE_SUB_IMM_X
                 | (1 << 22)

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -70,8 +70,10 @@ pub fn generate(
     // Schedule instructions for better performance
     schedule::schedule(&mut mir);
 
-    // Verify stack alignment in debug builds
-    #[cfg(debug_assertions)]
+    // Verify stack alignment. This is a correctness check (a misaligned call
+    // violates the AAPCS64 ABI and can crash at runtime) and already returns a
+    // real ice_error, so it runs in release too — not gated on
+    // debug_assertions (RUE-45).
     verify::verify_stack_alignment(&mir)?;
 
     // Emit machine code bytes
@@ -124,8 +126,10 @@ pub fn generate_with_asm(
     // Schedule instructions for better performance
     schedule::schedule(&mut mir);
 
-    // Verify stack alignment in debug builds
-    #[cfg(debug_assertions)]
+    // Verify stack alignment. This is a correctness check (a misaligned call
+    // violates the AAPCS64 ABI and can crash at runtime) and already returns a
+    // real ice_error, so it runs in release too — not gated on
+    // debug_assertions (RUE-45).
     verify::verify_stack_alignment(&mir)?;
 
     // Emit machine code bytes with assembly text

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -469,7 +469,10 @@ impl<'a> CfgLower<'a> {
             .cloned()
             .expect("aggregate block param should have slot vregs pre-allocated");
 
-        debug_assert_eq!(
+        // Correctness guard (must run in release): a slot-count mismatch would
+        // move the wrong number of aggregate slots and silently miscompile, so
+        // this is a plain `assert!` rather than a `debug_assert!` (RUE-45).
+        assert_eq!(
             src_slots.len(),
             dst_slots.len(),
             "source and destination aggregate slot counts must match"
@@ -1638,7 +1641,10 @@ impl<'a> CfgLower<'a> {
                     let field_vregs = self
                         .get_or_compute_field_vregs(*init)
                         .expect("string should have fat pointer fields in Alloc");
-                    debug_assert_eq!(
+                    // Correctness guard (must run in release): storing the wrong
+                    // number of fat-pointer slots miscompiles the String, so this
+                    // is a plain `assert!` not `debug_assert!` (RUE-45).
+                    assert_eq!(
                         field_vregs.len(),
                         3,
                         "string should have 3 fields (ptr, len, cap)"
@@ -2124,7 +2130,10 @@ impl<'a> CfgLower<'a> {
                         // Get the fat pointer (ptr, len, cap) — materializes a String read
                         // from a place (`@dbg(h.s)`) as well as cached sources. (RUE-118)
                         if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_val) {
-                            debug_assert_eq!(
+                            // Correctness guard (must run in release): a wrong
+                            // vreg count feeds garbage to @dbg, so plain `assert!`
+                            // not `debug_assert!` (RUE-45).
+                            assert_eq!(
                                 field_vregs.len(),
                                 3,
                                 "string should have exactly 3 vregs (ptr, len, cap)"
@@ -2246,7 +2255,10 @@ impl<'a> CfgLower<'a> {
                     // Get the String fat pointer (ptr, len, cap) — materializes a String
                     // read from a place (`@parse_i32(h.s)`) as well as cached sources. (RUE-118)
                     if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_val) {
-                        debug_assert_eq!(
+                        // Correctness guard (must run in release): a wrong vreg
+                        // count feeds garbage to @parse_*, so plain `assert!`
+                        // not `debug_assert!` (RUE-45).
+                        assert_eq!(
                             field_vregs.len(),
                             3,
                             "string should have exactly 3 vregs (ptr, len, cap)"
@@ -2940,7 +2952,10 @@ impl<'a> CfgLower<'a> {
                         .get_or_compute_field_vregs(*dropped_value)
                         .expect("String value should have field vregs");
 
-                    debug_assert_eq!(
+                    // Correctness guard (must run in release): passing the wrong
+                    // slot count to __rue_drop_String corrupts the drop call, so
+                    // plain `assert!` not `debug_assert!` (RUE-45).
+                    assert_eq!(
                         field_vregs.len(),
                         3,
                         "String should have 3 slots (ptr, len, cap)"
@@ -3553,11 +3568,14 @@ impl<'a> CfgLower<'a> {
             .get_or_compute_field_vregs(rhs)
             .expect("builtin type should have field vregs");
 
-        debug_assert!(
+        // Correctness guard (must run in release): reading ptr/len from a
+        // builtin with fewer than 2 fields would index garbage, so plain
+        // `assert!` not `debug_assert!` (RUE-45).
+        assert!(
             lhs_fields.len() >= 2,
             "builtin type should have at least 2 fields for comparison"
         );
-        debug_assert!(
+        assert!(
             rhs_fields.len() >= 2,
             "builtin type should have at least 2 fields for comparison"
         );

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -68,8 +68,10 @@ pub fn generate(
     // Schedule instructions for better performance
     schedule::schedule(&mut mir);
 
-    // Verify stack alignment in debug builds
-    #[cfg(debug_assertions)]
+    // Verify stack alignment. This is a correctness check (a misaligned call
+    // violates the SysV ABI and can crash at runtime) and already returns a
+    // real ice_error, so it runs in release too — not gated on
+    // debug_assertions (RUE-45).
     verify::verify_stack_alignment(&mir)?;
 
     // Emit machine code bytes (with prologue for stack frame setup)
@@ -124,8 +126,10 @@ pub fn generate_with_asm(
     // Schedule instructions for better performance
     schedule::schedule(&mut mir);
 
-    // Verify stack alignment in debug builds
-    #[cfg(debug_assertions)]
+    // Verify stack alignment. This is a correctness check (a misaligned call
+    // violates the SysV ABI and can crash at runtime) and already returns a
+    // real ice_error, so it runs in release too — not gated on
+    // debug_assertions (RUE-45).
     verify::verify_stack_alignment(&mir)?;
 
     // Emit machine code bytes with assembly text


### PR DESCRIPTION
Per Steve's ruling: debug_assert is not for correctness — either a real error or a plain assert! that runs in release. Audited every debug_assert! in rue-codegen (~21) and codegen-adjacent guards, converting the correctness ones to assert! (they now fire in release, where a violation would otherwise be a silent miscompile):

- x86_64/cfg_lower.rs + aarch64/cfg_lower.rs: aggregate slot-count match + String 3-field / >=2-field guards.
- aarch64/emit.rs: branch 4-byte alignment, large-offset load/store base-reg, ADD/SUB 24-bit immediate guards (silent-truncation miscompiles).
- x86_64/mod.rs + aarch64/mod.rs: un-gated verify_stack_alignment (already a real ice_error) from #[cfg(debug_assertions)] so the ABI check runs in release.
- rue-cfg/inst.rs set_terminator guard + rue-air/inst.rs add_extra u32-overflow guards -> assert!.

Zero correctness debug_assert! remain in rue-codegen/src (grep-confirmed). Genuine debug-only internal sanity checks left as debug_assert! with a comment.

Verified: ./clippy.sh clippy-gate-passed; ./test.sh green.

**NOTE** — the other half of RUE-45 (a release-mode CI job) is deferred: it depends on RUE-277 (make -c rue.opt=release actually produce an optimized build). The read_root_config approach does NOT create a distinct configured artifact — buck2 resolves debug and release to the same output path/hash, so a cmp-based CI guard would be a no-op. RUE-277 needs a real target-platform constraint/transition; tracked there.

Part of RUE-45

Generated with Claude Code