### PR TITLE
Generics: privacy of type-annotations, comptime-type-param array ICE, local-type-var generic args (RUE-281, RUE-282, RUE-283)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -2062,12 +2062,29 @@ impl<'a> ConstraintGenerator<'a> {
             // A struct/enum name or forwarded type parameter used as a value
             // parses as a variable reference, not a type literal.
             InstData::VarRef { name } | InstData::ParamRef { name, .. } => {
-                // A local or parameter shadows any same-named struct/enum. A local
-                // bound to a type value (e.g. `let P = Pair(i32)`) only has a
-                // concrete type during sema's comptime evaluation, so don't
-                // resolve it here. Forwarded type parameters (`T` inside a
-                // specialized generic body) are not in scope as runtime
-                // params/locals and resolve via `self.type_subst` above.
+                // A local bound to a type value (`let X = i32; identity(X, 42)`
+                // or `let P = Pair(i32); f(P, ..)`) resolves to that bound type
+                // via the precomputed comptime-local-types map — the same map
+                // generic-enum construction/matching consults (`enum_type_for`).
+                // Without this the type argument was left unresolved, so the
+                // call's return type defaulted to the literal `type` and
+                // mismatched the substituted element type (spurious E0206,
+                // RUE-281). The literal form (`identity(i32, 42)`) already
+                // worked via the `TypeConst` arm; this makes an aliased type
+                // behave identically.
+                if let Some(ty) = self
+                    .comptime_local_types
+                    .and_then(|aliases| aliases.get(name).copied())
+                {
+                    return Some(ty);
+                }
+                // A local or parameter shadows any same-named struct/enum. A
+                // local *not* bound to a comptime type value (a runtime value)
+                // has no concrete type here, so don't resolve it — a runtime
+                // value passed to a `comptime T: type` param is still rejected
+                // in sema. Forwarded type parameters (`T` inside a specialized
+                // generic body) are not in scope as runtime params/locals and
+                // resolve via `self.type_subst` above.
                 if ctx.locals.contains_key(name) || ctx.params.contains_key(name) {
                     return None;
                 }

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -455,6 +455,10 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
         functions,
         strings: global_strings,
         warnings: all_warnings,
+        // Provisional: refreshed after specialization below. Specialized
+        // bodies can intern *new* composite types (e.g. `[i32; N]` from a
+        // `let y: [T; 2]` once `T := i32`) into `sema.type_pool`, so the pool
+        // handed to CFG/codegen must be cloned *after* the specialize pass.
         type_pool: sema.type_pool.clone(),
     };
 
@@ -463,6 +467,13 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
     if let Err(e) = crate::specialize::specialize(&mut output, sema, &infer_ctx, sema.interner) {
         errors.push(e);
     }
+
+    // Specialization interns new composite types into `sema.type_pool` (see the
+    // provisional-clone note above); re-snapshot so every array/pointer type a
+    // specialized body references exists in the pool CFG and codegen consult.
+    // Without this, a specialization-only `[i32; N]` decayed to an out-of-bounds
+    // ArrayTypeId and ICE'd in drop analysis (RUE-282).
+    output.type_pool = sema.type_pool.clone();
 
     errors.into_result_with(output)
 }
@@ -849,6 +860,8 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
         functions,
         strings: global_strings,
         warnings: all_warnings,
+        // Provisional: refreshed after specialization below (see the eager
+        // path's note). Specialized bodies may intern new composite types.
         type_pool: sema.type_pool.clone(),
     };
 
@@ -857,6 +870,11 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
     if let Err(e) = crate::specialize::specialize(&mut output, sema, &infer_ctx, sema.interner) {
         errors.push(e);
     }
+
+    // Re-snapshot the pool after specialization so specialization-only composite
+    // types (e.g. `[i32; N]` from `let y: [T; 2]`) reach CFG/codegen; otherwise
+    // an out-of-bounds ArrayTypeId ICE'd in drop analysis (RUE-282).
+    output.type_pool = sema.type_pool.clone();
 
     errors.into_result_with(output)
 }

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -360,6 +360,17 @@ impl<'a> Sema<'a> {
         };
         let is_type_ctor = fn_info.return_type == Type::COMPTIME_TYPE;
         let params = fn_info.params;
+        let ctor_file_id = fn_info.file_id;
+        let ctor_is_pub = fn_info.is_pub;
+
+        // Privacy (E0460, RUE-283): applying a type constructor in type-
+        // annotation position (`let x: Secret(i32)`, a param/return type) is a
+        // reference to that function and must obey the same uniform-privacy
+        // rule the value/call path enforces (spec 10.3:7) — a non-`pub`
+        // constructor defined in another directory is not usable here. Without
+        // this, a private `-> type` constructor leaked across directories via a
+        // type annotation (a privacy-soundness hole).
+        self.check_unqualified_visibility("function", call_name, ctor_file_id, ctor_is_pub, span)?;
         if !is_type_ctor {
             return Err(CompileError::new(
                 ErrorKind::ComptimeEvaluationFailed {

--- a/crates/rue-cli-tests/cases/comptime_alias_infer.toml
+++ b/crates/rue-cli-tests/cases/comptime_alias_infer.toml
@@ -186,3 +186,45 @@ fn main() -> i32 {
 }
 """ }]
 exit_code = 0
+
+# A local comptime type alias (`let X = i32;`) passed as a generic `comptime
+# T: type` argument must resolve the type argument to its bound type, exactly
+# as the literal type name does (RUE-281). Before the fix, inference's
+# `extract_type_argument` skipped the comptime-local-types lookup for a local,
+# so `T` was left unresolved and the call's return type defaulted to the
+# literal `type` — a spurious E0206 (`expected i32, found type`). The literal
+# form already worked; these pin that the aliased form now behaves identically.
+
+[[case]]
+name = "local_type_alias_as_generic_arg"
+description = "RUE-281: `let X = i32; identity(X, 42)` resolves T:=i32 and returns 42, matching the literal `identity(i32, 42)`."
+files = [{ path = "main.rue", source = """
+fn identity(comptime T: type, x: T) -> T { x }
+fn main() -> i32 {
+    let X = i32;
+    identity(X, 42)
+}
+""" }]
+exit_code = 42
+
+[[case]]
+name = "literal_type_as_generic_arg_control"
+description = "Control for RUE-281: the literal type-name form of the generic argument still returns 42."
+files = [{ path = "main.rue", source = """
+fn identity(comptime T: type, x: T) -> T { x }
+fn main() -> i32 { identity(i32, 42) }
+""" }]
+exit_code = 42
+
+[[case]]
+name = "runtime_value_to_comptime_type_param_still_rejected"
+description = "Control for RUE-281: a runtime value passed where a `comptime T: type` argument is expected is still rejected (the fix only resolves comptime type aliases, not runtime values)."
+files = [{ path = "main.rue", source = """
+fn identity(comptime T: type, x: T) -> T { x }
+fn main() -> i32 {
+    let r: i32 = 3;
+    identity(r, 42)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0206"]

--- a/crates/rue-cli-tests/cases/generic_type_call_sigs.toml
+++ b/crates/rue-cli-tests/cases/generic_type_call_sigs.toml
@@ -231,3 +231,45 @@ fn main() -> i32 {
 """ }]
 args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
 exit_code = 42
+
+# A local array annotation `[T; N]` whose element is a comptime type parameter
+# used to ICE: specialization interns `[i32; N]` into the type pool only after
+# sema had already snapshotted the pool for CFG/codegen, so drop analysis
+# indexed an out-of-bounds ArrayTypeId (RUE-282). The pool is now re-snapshotted
+# after specialization, so the specialized `[i32; 2]` reaches the backend.
+
+[[case]]
+name = "local_array_of_comptime_type_param_no_ice"
+description = "RUE-282: `let y: [T; 2]` with a comptime type param T compiles and runs (no out-of-bounds ArrayTypeId ICE)."
+files = [{ path = "main.rue", source = """
+fn f(comptime T: type, x: T) -> i32 {
+    let y: [T; 2] = [x, x];
+    y[0] + y[1]
+}
+fn main() -> i32 { f(i32, 5) }
+""" }]
+exit_code = 10
+
+[[case]]
+name = "array_literal_of_comptime_type_param_no_ice"
+description = "RUE-282: an array literal `[x, x]` of a comptime-type-param element (no annotation) also reaches codegen through a re-snapshotted pool."
+files = [{ path = "main.rue", source = """
+fn f(comptime T: type, x: T) -> i32 {
+    let y = [x, x];
+    y[0] + y[1]
+}
+fn main() -> i32 { f(i32, 21) }
+""" }]
+exit_code = 42
+
+[[case]]
+name = "concrete_local_array_control"
+description = "Control for RUE-282: a concrete `[i32; 2]` local array (interned before the pool snapshot) still works."
+files = [{ path = "main.rue", source = """
+fn f(x: i32) -> i32 {
+    let y: [i32; 2] = [x, x];
+    y[0] + y[1]
+}
+fn main() -> i32 { f(5) }
+""" }]
+exit_code = 10

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -1480,3 +1480,65 @@ pub fn value() -> i32 {
 ]
 compile_fail = true
 error_contains = ["E0707", "NOPE"]
+
+# A private comptime type constructor (`fn Secret(comptime T) -> type`) applied
+# in type-annotation position (`let s: Secret(i32)`, a param/return type) is a
+# reference to that function and obeys the same uniform-privacy rule the
+# value/call path enforces (RUE-283). Before the fix the annotation path
+# skipped the E0460 check, so a private type constructor leaked across
+# directories via an annotation — a privacy-soundness hole (accept-invalid).
+
+[[case]]
+name = "private_type_ctor_annotation_cross_dir_rejected"
+description = "Applying a private comptime type constructor in type-annotation position from another directory is E0460 (RUE-283) — the annotation path must gate privacy like the call path."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let s: Secret(i32) = mk();
+    s.v
+}
+""" },
+    { path = "sub/lib.rue", source = """
+fn Secret(comptime T: type) -> type { struct { v: T } }
+pub fn mk() -> Secret(i32) { let S = Secret(i32); S { v: 7 } }
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "function `Secret` is private (defined in `sub/lib.rue`)"]
+
+[[case]]
+name = "pub_type_ctor_annotation_cross_dir_allowed"
+description = "Positive control for RUE-283: a pub comptime type constructor applied as an annotation from another directory is allowed."
+args = ["main.rue", "sub/lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let s: Secret(i32) = mk();
+    s.v
+}
+""" },
+    { path = "sub/lib.rue", source = """
+pub fn Secret(comptime T: type) -> type { struct { v: T } }
+pub fn mk() -> Secret(i32) { let S = Secret(i32); S { v: 7 } }
+""" },
+]
+exit_code = 7
+
+[[case]]
+name = "private_type_ctor_annotation_same_dir_allowed"
+description = "Control for RUE-283: a private comptime type constructor applied as an annotation from the SAME directory is still allowed (intra-directory visibility, ADR-0026)."
+args = ["main.rue", "lib.rue", "-o", "prog"]
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let s: Secret(i32) = mk();
+    s.v
+}
+""" },
+    { path = "lib.rue", source = """
+fn Secret(comptime T: type) -> type { struct { v: T } }
+pub fn mk() -> Secret(i32) { let S = Secret(i32); S { v: 7 } }
+""" },
+]
+exit_code = 7

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -333,6 +333,21 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "generic_function_type_arg_via_local_alias"
+spec = ["4.14:5"]
+description = "A comptime type argument may be a local type alias (`let X = i32; identity(X, 42)`), resolving T:=i32 exactly as the literal type name does (RUE-281)"
+source = """
+fn identity(comptime T: type, x: T) -> T {
+    x
+}
+fn main() -> i32 {
+    let X = i32;
+    identity(X, 42)
+}
+"""
+exit_code = 42
+
+[[case]]
 name = "generic_function_with_bool"
 spec = ["4.14:5"]
 description = "Generic identity function specialized for bool"
@@ -1291,6 +1306,32 @@ fn main() -> i32 {
 }
 """
 exit_code = 40
+
+[[case]]
+name = "type_param_in_local_array_annotation"
+spec = ["4.14:16"]
+description = "A comptime type parameter may be the element type of a LOCAL array annotation `let y: [T; N]` (RUE-282); the specialized array type must reach codegen, not ICE"
+source = """
+fn f(comptime T: type, x: T) -> i32 {
+    let y: [T; 2] = [x, x];
+    y[0] + y[1]
+}
+fn main() -> i32 { f(i32, 5) }
+"""
+exit_code = 10
+
+[[case]]
+name = "type_param_in_local_array_literal"
+spec = ["4.14:16"]
+description = "An unannotated local array literal `[x, x]` of a comptime-type-param element also specializes and reaches codegen (RUE-282)"
+source = """
+fn f(comptime T: type, x: T) -> i32 {
+    let y = [x, x];
+    y[0] + y[1]
+}
+fn main() -> i32 { f(i32, 21) }
+"""
+exit_code = 42
 
 [[case]]
 name = "type_param_in_ptr_param_and_return"

--- a/crates/rue-spec/cases/modules/intra_directory.toml
+++ b/crates/rue-spec/cases/modules/intra_directory.toml
@@ -611,3 +611,62 @@ enum Color {
 """ }
 pass_aux_files = true
 exit_code = 42
+
+# The uniform privacy rule (10.3:7) also covers a comptime type constructor
+# (`fn Secret(comptime T) -> type`) applied in type-annotation position: naming
+# a private constructor from another directory in a `let x: Secret(i32)`
+# annotation is E0460, exactly as a value/call reference is. Before RUE-283 the
+# annotation path skipped this check, leaking the private constructor
+# cross-directory (a privacy-soundness hole).
+
+[[case]]
+name = "cross_dir_private_type_ctor_annotation_error"
+spec = ["10.3:7"]
+description = "Applying a private comptime type constructor in type-annotation position from another directory is rejected (E0460)"
+source = """
+fn main() -> i32 {
+    let s: Secret(i32) = mk();
+    s.v
+}
+"""
+aux_files = { "subdir/lib.rue" = """
+fn Secret(comptime T: type) -> type { struct { v: T } }
+pub fn mk() -> Secret(i32) { let S = Secret(i32); S { v: 7 } }
+""" }
+pass_aux_files = true
+compile_fail = true
+error_contains = "function `Secret` is private (defined in"
+
+[[case]]
+name = "cross_dir_pub_type_ctor_annotation_allowed"
+spec = ["10.3:7", "10.3:8"]
+description = "A pub comptime type constructor applied as an annotation across directories is allowed (flat namespace resolves the name)"
+source = """
+fn main() -> i32 {
+    let s: Secret(i32) = mk();
+    s.v
+}
+"""
+aux_files = { "subdir/lib.rue" = """
+pub fn Secret(comptime T: type) -> type { struct { v: T } }
+pub fn mk() -> Secret(i32) { let S = Secret(i32); S { v: 7 } }
+""" }
+pass_aux_files = true
+exit_code = 7
+
+[[case]]
+name = "same_dir_private_type_ctor_annotation_allowed"
+spec = ["10.3:2", "10.3:7"]
+description = "Intra-directory visibility (ADR-0026) is unchanged: a private comptime type constructor applied as an annotation in another listed file in the same directory is allowed"
+source = """
+fn main() -> i32 {
+    let s: Secret(i32) = mk();
+    s.v
+}
+"""
+aux_files = { "lib.rue" = """
+fn Secret(comptime T: type) -> type { struct { v: T } }
+pub fn mk() -> Secret(i32) { let S = Secret(i32); S { v: 7 } }
+""" }
+pass_aux_files = true
+exit_code = 7


### PR DESCRIPTION
All found by the generic-instantiation hunt; all rue-air.

**RUE-283 (privacy soundness / accept-invalid):** a private -> type constructor used in TYPE-ANNOTATION position (let x: Secret(i32)) bypassed the E0460 uniform-privacy check (call/value path was gated, annotation path was not). Fixed in resolve_type_function_call (typeck.rs) by running check_unqualified_visibility on the constructor.

**RUE-282 (ICE):** let y: [T; N] with a comptime type param crashed with an out-of-bounds ArrayTypeId. Root was deeper than the report guessed — SemaOutput.type_pool was cloned BEFORE specialization, so a specialized [i32; N] was never in the pool CFG/codegen saw. Fixed by re-snapshotting output.type_pool AFTER specialize() in both eager and lazy paths (analysis.rs). Target-independent.

**RUE-281 (reject-valid):** extract_type_argument (generate.rs) skipped comptime_local_types, so let X = i32; identity(X, 42) left T unresolved -> spurious E0206. Now resolves a local comptime type alias to its bound type.

Verified by execution (typevar->42, [T;2]->42 no ICE, 2-dir private annotation -> E0460); controls hold. clippy-gate-passed; test.sh green; diff-fuzzer 300 seeds 0 disagreements. 9 CLI + 6 spec cases.

Fixes RUE-281
Fixes RUE-282
Fixes RUE-283

Generated with Claude Code