### PR TITLE
String.chars_lossy(): non-trapping lossy UTF-8 char iteration (part of RUE-17 Phase 3)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1108,19 +1108,24 @@ impl<'a> ConstraintGenerator<'a> {
                         self.generate(*arg_ref, ctx);
                     }
                     InferType::Concrete(Type::new_module(crate::types::ModuleId::UNRESOLVED))
-                } else if intrinsic_name == "__rue_iter_len" || intrinsic_name == "__rue_char_next"
+                } else if intrinsic_name == "__rue_iter_len"
+                    || intrinsic_name == "__rue_char_next"
+                    || intrinsic_name == "__rue_char_next_lossy"
                 {
                     // Compiler-internal `for`-loop leaves (RUE-220):
                     // @__rue_iter_len(coll) is the loop bound (byte length /
-                    // array length) and @__rue_char_next(s, p) is the next byte
-                    // offset — both `usize` (u64).
+                    // array length) and @__rue_char_next{,_lossy}(s, p) is the
+                    // next byte offset — both `usize` (u64).
                     for arg_ref in args.iter() {
                         self.generate(*arg_ref, ctx);
                     }
                     InferType::Concrete(Type::U64)
-                } else if intrinsic_name == "__rue_char_scalar" {
-                    // @__rue_char_scalar(s, p): the Unicode scalar at byte
-                    // offset `p`, a u32 (RUE-220).
+                } else if intrinsic_name == "__rue_char_scalar"
+                    || intrinsic_name == "__rue_char_scalar_lossy"
+                {
+                    // @__rue_char_scalar{,_lossy}(s, p): the Unicode scalar at
+                    // byte offset `p`, a u32 (RUE-220; lossy variant RUE-17
+                    // Phase 3).
                     for arg_ref in args.iter() {
                         self.generate(*arg_ref, ctx);
                     }

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -3690,10 +3690,16 @@ impl<'a> Sema<'a> {
             match self.interner.resolve(&name) {
                 "__rue_iter_len" => self.analyze_iter_len_intrinsic(air, &args, span, ctx),
                 "__rue_char_scalar" => {
-                    self.analyze_string_char_op_intrinsic(air, &args, span, ctx, false)
+                    self.analyze_string_char_op_intrinsic(air, &args, span, ctx, false, false)
                 }
                 "__rue_char_next" => {
-                    self.analyze_string_char_op_intrinsic(air, &args, span, ctx, true)
+                    self.analyze_string_char_op_intrinsic(air, &args, span, ctx, true, false)
+                }
+                "__rue_char_scalar_lossy" => {
+                    self.analyze_string_char_op_intrinsic(air, &args, span, ctx, false, true)
+                }
+                "__rue_char_next_lossy" => {
+                    self.analyze_string_char_op_intrinsic(air, &args, span, ctx, true, true)
                 }
                 other => Err(CompileError::new(
                     ErrorKind::UnknownIntrinsic(other.to_string()),
@@ -3779,7 +3785,9 @@ impl<'a> Sema<'a> {
     /// `@__rue_char_scalar(s, offset)` → the Unicode scalar (`u32`) at byte
     /// `offset`, and `@__rue_char_next(s, offset)` → the byte offset of the
     /// next character (`usize`). Both back `for c in s.chars()`; the receiver
-    /// must be a String, and both trap at runtime on invalid UTF-8 (ADR-0035).
+    /// must be a String. When `lossy` is false these trap at runtime on invalid
+    /// UTF-8; when true (`.chars_lossy()`) they substitute U+FFFD instead
+    /// (ADR-0035).
     fn analyze_string_char_op_intrinsic(
         &mut self,
         air: &mut Air,
@@ -3787,6 +3795,7 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
         is_next: bool,
+        lossy: bool,
     ) -> CompileResult<AnalysisResult> {
         let coll = args[0].value;
         let pos = args[1].value;
@@ -3805,10 +3814,11 @@ impl<'a> Sema<'a> {
 
         let pos_result = self.analyze_inst(air, pos, ctx)?;
 
-        let (fn_name, ret_ty) = if is_next {
-            ("__rue_String_char_next", Type::U64)
-        } else {
-            ("__rue_String_char_scalar", Type::U32)
+        let (fn_name, ret_ty) = match (is_next, lossy) {
+            (true, false) => ("__rue_String_char_next", Type::U64),
+            (true, true) => ("__rue_String_char_next_lossy", Type::U64),
+            (false, false) => ("__rue_String_char_scalar", Type::U32),
+            (false, true) => ("__rue_String_char_scalar_lossy", Type::U32),
         };
         let call_name = self.interner.get_or_intern(fn_name);
         let extra = [

--- a/crates/rue-cli-tests/cases/for_loops.toml
+++ b/crates/rue-cli-tests/cases/for_loops.toml
@@ -86,6 +86,45 @@ stdout = "99\n97\n102\n"
 runtime_error_contains = ["invalid UTF-8"]
 
 [[case]]
+name = "for_chars_lossy_valid_dbg"
+description = "for c in s.chars_lossy() decodes well-formed UTF-8 identically to .chars(); 'café' is 4 scalars ending in é = 233."
+args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = "café";
+    let mut count = 0;
+    for c in s.chars_lossy() {
+        @dbg(c);
+        count = count + 1;
+    }
+    count
+}
+""" }]
+exit_code = 4
+stdout = "99\n97\n102\n233\n"
+
+[[case]]
+name = "for_chars_lossy_replaces_raw_invalid_bytes"
+description = "Lossy decode over a String holding a raw invalid byte (0xFF): the bad byte becomes U+FFFD (65533) and iteration continues without trapping — the surrounding ASCII bytes decode normally."
+args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut s = String::new();
+    s.push(97);
+    s.push(255);
+    s.push(98);
+    let mut count = 0;
+    for c in s.chars_lossy() {
+        @dbg(c);
+        count = count + 1;
+    }
+    count
+}
+""" }]
+exit_code = 3
+stdout = "97\n65533\n98\n"
+
+[[case]]
 name = "for_without_preview_is_gated"
 description = "Without --preview for_loops the for loop is rejected as a preview feature."
 args = ["main.rue", "-o", "prog"]

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -1026,9 +1026,11 @@ impl<'a> AstGen<'a> {
     ///
     /// The type-dependent pieces are three compiler-internal intrinsics that
     /// Sema resolves by the collection's type (dispatching the three iterable
-    /// kinds — array, String byte view, String `.chars()` scalar view):
-    /// `@__rue_iter_len`, and for the char view `@__rue_char_scalar` /
-    /// `@__rue_char_next`. Everything else reuses the ordinary
+    /// kinds — array, String byte view, String `.chars()` / `.chars_lossy()`
+    /// scalar views): `@__rue_iter_len`, and for the char views
+    /// `@__rue_char_scalar` / `@__rue_char_next` (strict, trap on invalid
+    /// UTF-8) or their `_lossy` counterparts (substitute U+FFFD). Everything
+    /// else reuses the ordinary
     /// loop/branch/break/index lowering, so move-checking, drop elaboration,
     /// and codegen come for free. The whole thing is preview-gated in Sema at
     /// the `@__rue_iter_len` intrinsic, which every for-loop emits.
@@ -1037,17 +1039,21 @@ impl<'a> AstGen<'a> {
         let n = self.for_counter;
         self.for_counter += 1;
 
-        // Recognize the `.chars()` scalar view syntactically: `for c in
-        // s.chars()` iterates Unicode scalars, everything else iterates by
-        // position (array element / String byte). The receiver of `.chars()`
-        // is the actual collection.
-        let (coll_expr, is_chars): (&Expr, bool) = match &*for_expr.iterable {
-            Expr::MethodCall(mc)
-                if mc.args.is_empty() && self.interner.resolve(&mc.method.name) == "chars" =>
-            {
-                (&mc.receiver, true)
+        // Recognize the `.chars()` / `.chars_lossy()` scalar views
+        // syntactically: `for c in s.chars()` iterates Unicode scalars and traps
+        // on invalid UTF-8, `for c in s.chars_lossy()` iterates scalars but
+        // substitutes U+FFFD for invalid sequences (ADR-0035). Everything else
+        // iterates by position (array element / String byte). The receiver of
+        // the call is the actual collection.
+        let (coll_expr, is_chars, is_lossy): (&Expr, bool, bool) = match &*for_expr.iterable {
+            Expr::MethodCall(mc) if mc.args.is_empty() => {
+                match self.interner.resolve(&mc.method.name) {
+                    "chars" => (&mc.receiver, true, false),
+                    "chars_lossy" => (&mc.receiver, true, true),
+                    _ => (&*for_expr.iterable, false, false),
+                }
             }
-            other => (other, false),
+            other => (other, false, false),
         };
 
         let mut outer_stmts: Vec<u32> = Vec::new();
@@ -1186,7 +1192,11 @@ impl<'a> AstGen<'a> {
             span,
         });
         let get_inst = if is_chars {
-            let sym = self.interner.get_or_intern("__rue_char_scalar");
+            let sym = self.interner.get_or_intern(if is_lossy {
+                "__rue_char_scalar_lossy"
+            } else {
+                "__rue_char_scalar"
+            });
             let (s, l) = self.rir.add_inst_refs(&[coll_for_get, p_for_get]);
             self.rir.add_inst(Inst {
                 data: InstData::Intrinsic {
@@ -1234,7 +1244,11 @@ impl<'a> AstGen<'a> {
                 data: InstData::VarRef { name: coll_name },
                 span,
             });
-            let sym = self.interner.get_or_intern("__rue_char_next");
+            let sym = self.interner.get_or_intern(if is_lossy {
+                "__rue_char_next_lossy"
+            } else {
+                "__rue_char_next"
+            });
             let (s, l) = self.rir.add_inst_refs(&[coll_for_adv, p_for_adv]);
             self.rir.add_inst(Inst {
                 data: InstData::Intrinsic {

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -765,6 +765,150 @@ crate::define_for_all_platforms! {
     }
 }
 
+/// Leniently decode one UTF-8 scalar starting at byte `offset` in the `len`-byte
+/// buffer at `ptr`, returning `(scalar, width_in_bytes)`.
+///
+/// This backs `for c in s.chars_lossy()` (RUE-17 Phase 3, ADR-0035). Unlike the
+/// strict [`__rue_decode_utf8_at`], which traps at the decode boundary, this
+/// **never traps**: an invalid, truncated, overlong, or surrogate sequence
+/// yields the Unicode replacement scalar `U+FFFD` and advances past its
+/// *maximal subpart of an ill-formed subsequence* — one byte for a lone
+/// invalid lead/continuation, more when a partly-valid multi-byte sequence
+/// breaks or runs off the end. This is the Unicode-recommended substitution
+/// (matching Rust's `String::from_utf8_lossy`), so a valid string decodes
+/// identically to `.chars()` while garbage bytes are replaced instead of
+/// aborting. Lossiness is opt-in: the default `.chars()` still traps.
+///
+/// # Safety
+///
+/// `ptr` must point to a valid buffer of at least `len` bytes.
+unsafe fn __rue_decode_utf8_lossy_at(ptr: *const u8, len: u64, offset: u64) -> (u32, u64) {
+    const FFFD: u32 = 0xFFFD;
+    let len = len as usize;
+    let i = offset as usize;
+    if i >= len {
+        return (FFFD, 1);
+    }
+    // SAFETY: `i < len` and the caller guarantees `ptr` is valid for `len`
+    // bytes, so `ptr.add(i)` is in bounds.
+    let b0 = unsafe { *ptr.add(i) };
+    // ASCII fast path (single byte).
+    if b0 < 0x80 {
+        return (b0 as u32, 1);
+    }
+    // The lead byte fixes the sequence width and the valid range of the FIRST
+    // continuation byte. That first-byte range is what enforces non-overlong
+    // (0xE0 needs >= 0xA0, 0xF0 needs >= 0x90), non-surrogate (0xED needs
+    // <= 0x9F), and in-range (0xF4 needs <= 0x8F) — so a full-width sequence
+    // that clears these checks is always a valid scalar. Leads 0x80..=0xC1 and
+    // 0xF5..=0xFF can never begin a sequence: substitute one U+FFFD, step 1.
+    let (width, second_lo, second_hi) = match b0 {
+        0xC2..=0xDF => (2usize, 0x80u8, 0xBFu8),
+        0xE0 => (3, 0xA0, 0xBF),
+        0xE1..=0xEC => (3, 0x80, 0xBF),
+        0xED => (3, 0x80, 0x9F),
+        0xEE..=0xEF => (3, 0x80, 0xBF),
+        0xF0 => (4, 0x90, 0xBF),
+        0xF1..=0xF3 => (4, 0x80, 0xBF),
+        0xF4 => (4, 0x80, 0x8F),
+        _ => return (FFFD, 1),
+    };
+    let mask = match width {
+        2 => 0x1F,
+        3 => 0x0F,
+        _ => 0x07,
+    };
+    let mut cp = (b0 as u32) & mask;
+    // First continuation: uses the width-specific range above.
+    if i + 1 >= len {
+        return (FFFD, 1);
+    }
+    // SAFETY: `i + 1 < len`, in bounds.
+    let b1 = unsafe { *ptr.add(i + 1) };
+    if b1 < second_lo || b1 > second_hi {
+        return (FFFD, 1);
+    }
+    cp = (cp << 6) | ((b1 as u32) & 0x3F);
+    // Remaining continuations (positions 3..width) accept the generic
+    // 0x80..=0xBF range. On a break, the maximal subpart is everything
+    // consumed so far.
+    let mut consumed = 2usize;
+    while consumed < width {
+        if i + consumed >= len {
+            return (FFFD, consumed as u64);
+        }
+        // SAFETY: `i + consumed < len`, in bounds.
+        let b = unsafe { *ptr.add(i + consumed) };
+        if b & 0xC0 != 0x80 {
+            return (FFFD, consumed as u64);
+        }
+        cp = (cp << 6) | ((b as u32) & 0x3F);
+        consumed += 1;
+    }
+    (cp, width as u64)
+}
+
+crate::define_for_all_platforms! {
+    /// Decode the Unicode scalar at byte `offset`, replacing invalid UTF-8.
+    ///
+    /// Backs the element projection of `for c in s.chars_lossy()` (RUE-17
+    /// Phase 3). Like [`__rue_String_char_scalar`] but never traps: an invalid
+    /// sequence yields `U+FFFD` (see [`__rue_decode_utf8_lossy_at`]). Returns
+    /// the scalar zero-extended into `u64` (language-level type `u32`).
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_String_char_scalar_lossy(ptr: *const u8, len: u64, cap: u64, offset: u64) -> u64
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to a valid buffer of at least `len` bytes.
+    #[allow(non_snake_case)]
+    pub extern "C" fn __rue_String_char_scalar_lossy(
+        ptr: *const u8,
+        len: u64,
+        _cap: u64,
+        offset: u64,
+    ) -> u64 {
+        // SAFETY: the for-loop desugaring passes the String's own (ptr, len).
+        let (scalar, _width) = unsafe { __rue_decode_utf8_lossy_at(ptr, len, offset) };
+        scalar as u64
+    }
+}
+
+crate::define_for_all_platforms! {
+    /// Return the byte offset of the character AFTER the one at `offset`,
+    /// replacing invalid UTF-8.
+    ///
+    /// Backs the position advance of `for c in s.chars_lossy()` (RUE-17
+    /// Phase 3). Like [`__rue_String_char_next`] but never traps: the advance
+    /// past an invalid sequence is the width of its maximal subpart (see
+    /// [`__rue_decode_utf8_lossy_at`]), guaranteeing forward progress.
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_String_char_next_lossy(ptr: *const u8, len: u64, cap: u64, offset: u64) -> u64
+    /// ```
+    ///
+    /// # Safety
+    ///
+    /// `ptr` must point to a valid buffer of at least `len` bytes.
+    #[allow(non_snake_case)]
+    pub extern "C" fn __rue_String_char_next_lossy(
+        ptr: *const u8,
+        len: u64,
+        _cap: u64,
+        offset: u64,
+    ) -> u64 {
+        // SAFETY: the for-loop desugaring passes the String's own (ptr, len).
+        let (_scalar, width) = unsafe { __rue_decode_utf8_lossy_at(ptr, len, offset) };
+        offset + width
+    }
+}
+
 crate::define_for_all_platforms! {
     /// Return a NEW String containing the byte range `[start, start + sub_len)`.
     ///

--- a/crates/rue-spec/cases/expressions/for.toml
+++ b/crates/rue-spec/cases/expressions/for.toml
@@ -264,6 +264,52 @@ exit_code = 101
 expected_stdout = "99\n97\n102\n"
 
 # =============================================================================
+# Lossy char iteration: `.chars_lossy()` substitutes U+FFFD, never traps
+# (ADR-0035, RUE-17 Phase 3)
+# =============================================================================
+
+# Over well-formed UTF-8, the lossy view decodes identically to `.chars()`.
+[[case]]
+name = "for_chars_lossy_valid"
+spec = ["3.7:34"]
+preview = "for_loops"
+source = """
+fn main() -> i32 {
+    let s = "café";
+    let mut count = 0;
+    for c in s.chars_lossy() {
+        @dbg(c);
+        count = count + 1;
+    }
+    count
+}
+"""
+exit_code = 4
+expected_stdout = "99\n97\n102\n233\n"
+
+# substring(0, 4) of "café" keeps the lead byte of `é` (0xC3) without its
+# continuation. The strict view traps here; the lossy view substitutes one
+# U+FFFD (65533) for the truncated sequence and finishes without trapping.
+[[case]]
+name = "for_chars_lossy_replaces_invalid"
+spec = ["3.7:34"]
+preview = "for_loops"
+source = """
+fn main() -> i32 {
+    let full = "café";
+    let s = full.substring(0, 4);
+    let mut count = 0;
+    for c in s.chars_lossy() {
+        @dbg(c);
+        count = count + 1;
+    }
+    count
+}
+"""
+exit_code = 4
+expected_stdout = "99\n97\n102\n65533\n"
+
+# =============================================================================
 # Preview gating
 # =============================================================================
 

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -248,11 +248,21 @@ byte order.
 
 {{ rule(id="3.7:32", cat="dynamic-semantics") }}
 
-Decoding is strict: a byte sequence that is not well-formed UTF-8 (an
-ill-formed, truncated, overlong, or surrogate sequence) traps at runtime when it
-is decoded. Because a `String` is a byte string that may hold arbitrary bytes,
-this "trap, don't corrupt" behavior at the decode boundary is where invalidity
-is caught; a lossy view that substitutes `U+FFFD` is not yet provided.
+Decoding through `s.chars()` is strict: a byte sequence that is not well-formed
+UTF-8 (an ill-formed, truncated, overlong, or surrogate sequence) traps at
+runtime when it is decoded. Because a `String` is a byte string that may hold
+arbitrary bytes, this "trap, don't corrupt" behavior at the decode boundary is
+where invalidity is caught.
+
+{{ rule(id="3.7:34", cat="dynamic-semantics") }}
+
+The lossy character view `s.chars_lossy()` yields the same Unicode scalar values
+as `s.chars()` for well-formed UTF-8, but instead of trapping it substitutes the
+Unicode replacement scalar `U+FFFD` (decimal `65533`) for each maximal subpart
+of an ill-formed subsequence and continues. Lossiness is explicit: `chars_lossy`
+is the only way to decode without trapping, so silent corruption is never the
+default. Like `chars`, it is used as the iterable of a `for` loop and binds each
+scalar value as a `u32`.
 
 {{ rule(id="3.7:33") }}
 

--- a/docs/spec/src/04-expressions/08-loop-expressions.md
+++ b/docs/spec/src/04-expressions/08-loop-expressions.md
@@ -203,7 +203,8 @@ element type and iteration order:
   order;
 - a `String` — each byte is bound as `u8` in ascending byte order;
 - the character view `s.chars()` of a `String` — each Unicode scalar value is
-  bound as `u32`, in ascending byte order.
+  bound as `u32`, in ascending byte order (or `s.chars_lossy()`, which decodes
+  invalid UTF-8 to `U+FFFD` instead of trapping).
 
 {{ rule(id="4.8:26", cat="normative") }}
 
@@ -220,8 +221,9 @@ terminates the loop.
 {{ rule(id="4.8:28", cat="dynamic-semantics") }}
 
 Iterating `s.chars()` decodes the bytes of `s` as UTF-8. A byte sequence that is
-not well-formed UTF-8 traps at runtime when it is decoded (see ADR-0035); a
-lossy variant is not yet provided.
+not well-formed UTF-8 traps at runtime when it is decoded (see ADR-0035).
+Iterating the lossy view `s.chars_lossy()` instead substitutes `U+FFFD` for each
+ill-formed subsequence and never traps.
 
 {{ rule(id="4.8:29") }}
 


### PR DESCRIPTION
Completes the string-iteration story per ADR-0035 (bstr model, trap-don't-corrupt at the decode boundary). Characterized first: strict .chars() already existed as a decoded-scalar view that TRAPS cleanly on invalid UTF-8 (café -> 99 97 102 233; a/0xFF/b -> 97 then trap 101) — the strict half was done. The only gap was .chars_lossy() (was E0411).

Added the lossy view: a non-trapping runtime decoder (__rue_decode_utf8_lossy_at, Unicode maximal-subpart substitution matching Rust's from_utf8_lossy) + __rue_String_char_scalar_lossy / _char_next_lossy shared across backends, wired through gen_for desugaring, sema dispatch, and type inference. No codegen changes (aarch64 emits the calls, verified via --emit asm).

Verified by execution: lossy over café -> 99 97 102 233; lossy over raw invalid bytes -> 97 65533 98 (U+FFFD, no trap); strict .chars() over the same -> traps 101; ASCII abc -> sum 294. clippy-gate-passed; test.sh green (100% traceability); diff-fuzzer 300 seeds 0 disagreements. 2 spec + 2 CLI cases.

Part of RUE-17

Generated with Claude Code