### PR TITLE
Make release builds genuinely optimized + distinct via target platforms (RUE-277)

### DIFF
--- a/bench.sh
+++ b/bench.sh
@@ -109,7 +109,7 @@ log_info "Building rue compiler ($BUILD_MODE mode)..."
 
 # Get the path to the built compiler (scripts/rue-bin builds it and resolves a
 # stable absolute path; extra args pass through to buck2 build).
-RUE_BIN="$(./scripts/rue-bin --modifier //constraints:$BUILD_MODE)"
+RUE_BIN="$(./scripts/rue-bin --target-platforms //platforms:$BUILD_MODE)"
 if [[ ! -x "$RUE_BIN" ]]; then
     log_error "Failed to find rue binary at: $RUE_BIN"
     exit 1

--- a/constraints/BUCK
+++ b/constraints/BUCK
@@ -1,11 +1,16 @@
 # Build configuration constraints
 #
 # These constraints control build-time options like optimization level.
-# Use with --modifier or in platform definitions.
+#
+# NOTE: select this via a target *platform*, not a bare `--modifier`. A bare
+# `--modifier //constraints:release` does not change the configured target's
+# hash (debug and release resolve to the same buck-out path, so the build is a
+# no-op and the toolchain never sees the flag — RUE-277). The //platforms
+# targets bake these constraints into a distinct target configuration:
 #
 # Example usage:
-#   buck2 build //crates/rue:rue --modifier //constraints:release
-#   buck2 build //crates/rue:rue --modifier //constraints:debug
+#   buck2 build //crates/rue:rue --target-platforms //platforms:release
+#   buck2 build //crates/rue:rue --target-platforms //platforms:debug
 
 # Optimization level constraint setting
 constraint_setting(

--- a/docs/process/perf-baseline.md
+++ b/docs/process/perf-baseline.md
@@ -150,19 +150,32 @@ benchmarks fail). This is a real parser bug, filed separately; it is out of
 scope for this measurement-only change. Once fixed, add `deep_nesting` back to
 `default_corpus()` in `scripts/perf-baseline.py`.
 
-## Build caveat (affects absolute numbers, not the profile)
+## Build profile (release vs. DEFAULT)
 
-The numbers above come from the buck2 **DEFAULT** build profile. The
-`//constraints:release` opt-level flags (`-Copt-level=3 -Clto=thin`, defined in
-`toolchains/rust/BUCK`) are **not currently applied** to `//crates/rue:rue`:
-building with `--modifier //constraints:release` produces a byte-identical
-configuration hash / output path, so `scripts/rue-bin --modifier
-//constraints:release` (used by `bench.sh`) returns the *same unoptimized
-binary*. This makes the parser's constant factor much larger than it should be
-and is relevant to RUE-45 (release-mode CI). Wiring the constraint through is a
-build change, out of scope here, but it means today's baseline is a
-**worst-case (unoptimized-compiler)** profile; the relative ranking of passes is
-unaffected.
+The numbers above may come from either the buck2 **DEFAULT** (unoptimized)
+profile or the optimized **release** profile, depending on how the compiler was
+built. The `-Copt-level=3 -Clto=thin` release flags live in
+`toolchains/rust/BUCK` and are applied to `//crates/rue:rue` when it is built
+through the **`//platforms:release` target platform**:
+
+```bash
+buck2 build //crates/rue:rue --target-platforms //platforms:release
+scripts/rue-bin --target-platforms //platforms:release   # absolute path to it
+```
+
+`bench.sh` (and `scripts/perf-baseline.py --release`) build through
+`//platforms:release`, so their "release" numbers now measure a genuinely
+optimized binary — release is byte-distinct from and roughly 2x smaller than the
+DEFAULT build.
+
+Historical note (RUE-277): a bare `--modifier //constraints:release` was a
+**no-op** — it left the configured-target hash unchanged, so debug and "release"
+resolved to the same `buck-out/.../<hash>/rue` path and `bench.sh` measured an
+unoptimized binary. The fix routes the opt-level constraint through a target
+*platform* (`//platforms:{debug,release}`), which gives each mode a distinct
+configuration the toolchain's `rustc_flags` select can actually see. A plain
+`//crates/rue:rue` build (no `--target-platforms`) still uses the DEFAULT
+unoptimized profile.
 
 ## Related
 

--- a/platforms/BUCK
+++ b/platforms/BUCK
@@ -1,0 +1,36 @@
+# Build-mode target platforms (RUE-277)
+#
+# These platforms put the //constraints:opt-level value into the *target
+# configuration*, which is what buck2 keys output paths (and cache) on. Select
+# one with `--target-platforms`:
+#
+#   buck2 build //crates/rue:rue --target-platforms //platforms:release
+#   buck2 build //crates/rue:rue --target-platforms //platforms:debug
+#
+# WHY A PLATFORM AND NOT `--modifier //constraints:release`:
+# A bare `--modifier //constraints:release` (or `-c`/read_root_config) does NOT
+# change the configured target's hash — debug and "release" resolve to the SAME
+# `buck-out/.../<hash>/rue` path, so buck2 serves one cached artifact for both
+# and the toolchain's `rustc_flags` select (evaluated in the target
+# configuration) never sees the constraint. Baking the constraint into a target
+# platform gives each build mode a DISTINCT configuration hash AND makes the
+# `_OPT_FLAGS` select in `toolchains/rust/BUCK` resolve to the release flags —
+# so `//platforms:release` yields a genuinely optimized, byte-distinct binary.
+#
+# Each platform inherits the host os/cpu from `prelude//platforms:default`
+# (evaluated via host_info() on the building machine), so the correct hermetic
+# toolchain is still selected on every host (linux x86_64/arm64, macOS arm64).
+
+platform(
+    name = "debug",
+    constraint_values = ["//constraints:debug"],
+    deps = ["prelude//platforms:default"],
+    visibility = ["PUBLIC"],
+)
+
+platform(
+    name = "release",
+    constraint_values = ["//constraints:release"],
+    deps = ["prelude//platforms:default"],
+    visibility = ["PUBLIC"],
+)

--- a/scripts/perf-baseline.py
+++ b/scripts/perf-baseline.py
@@ -43,7 +43,7 @@ when deciding what to optimize.
     scripts/perf-baseline.py --format json       # machine-readable aggregate
 
 By default the compiler is located via `scripts/rue-bin` (a normal build).
-Pass `--release` to build/locate it with `--modifier //constraints:release`,
+Pass `--release` to build/locate it with `--target-platforms //platforms:release`,
 or `--rue-bin PATH` / the `RUE` env var to use an already-built binary.
 
 Numbers are absolute milliseconds and are therefore MACHINE-SPECIFIC; treat
@@ -146,7 +146,7 @@ def resolve_rue_bin(args, root: Path) -> str:
         return env
     cmd = [str(root / "scripts" / "rue-bin")]
     if args.release:
-        cmd += ["--modifier", "//constraints:release"]
+        cmd += ["--target-platforms", "//platforms:release"]
     out = subprocess.run(cmd, capture_output=True, text=True)
     if out.returncode != 0:
         sys.stderr.write(out.stderr)
@@ -337,7 +337,7 @@ def main():
     ap.add_argument("--warmup", type=int, default=1, help="warmup runs before timing (default 1)")
     ap.add_argument("--timeout", type=float, default=60.0, help="per-compile timeout seconds (default 60)")
     ap.add_argument("--rue-bin", help="path to an already-built rue binary")
-    ap.add_argument("--release", action="store_true", help="locate the compiler via //constraints:release")
+    ap.add_argument("--release", action="store_true", help="locate the compiler via //platforms:release")
     ap.add_argument("--format", choices=["text", "markdown", "json"], default="text")
     args = ap.parse_args()
 

--- a/scripts/rue-bin
+++ b/scripts/rue-bin
@@ -14,7 +14,7 @@
 #
 # Any extra arguments are passed through to `buck2 build`, e.g. a release build:
 #
-#   RUE_BINARY="$(scripts/rue-bin --modifier //constraints:release)"
+#   RUE_BINARY="$(scripts/rue-bin --target-platforms //platforms:release)"
 #
 set -euo pipefail
 

--- a/toolchains/rust/BUCK
+++ b/toolchains/rust/BUCK
@@ -45,8 +45,22 @@ http_archive(
     visibility = [],
 )
 
-# Optimization flags based on build mode
-# DEFAULT matches when no opt-level constraint is set (debug by default)
+# Optimization flags based on build mode (RUE-277).
+#
+# This select is evaluated in the *target configuration* of whatever depends on
+# the toolchain, so the release arm only fires when the opt-level constraint is
+# actually part of that configuration. A bare `--modifier //constraints:release`
+# does NOT put it there (it leaves the config hash unchanged), so release builds
+# must go through a target platform that bakes the constraint in — build with
+# `--target-platforms //platforms:release` (see platforms/BUCK). DEFAULT matches
+# when no opt-level constraint is set (a plain `//crates/rue:rue` build stays
+# debug/unoptimized).
+#
+# `-Clto=thin` is only applied to crates configured under the release target
+# platform. Proc-macro crates (serde_derive, logos-derive, ...) are exec-deps
+# configured under the execution platform, which has no opt-level constraint, so
+# they hit the DEFAULT arm and never receive `-Clto=thin` — sidestepping rustc's
+# refusal to thin-LTO a proc-macro crate.
 _OPT_FLAGS = select({
     "DEFAULT": [],
     "root//constraints:debug": [],


### PR DESCRIPTION
The --modifier //constraints:release left the configured-target hash unchanged (debug and release both resolved to the same hash), because toolchains is a separate cell whose is_toolchain_rule never sees target-platform modifiers — so the rustc_flags select never fired and bench.sh measured an UNOPTIMIZED binary.

Fix: added platforms/BUCK with //platforms:{debug,release} target platforms that bake the opt-level constraint into the target CONFIGURATION (inheriting host os/cpu from prelude//platforms:default). Building --target-platforms //platforms:release now yields a DISTINCT config hash AND fires the existing -Copt-level=3 -Clto=thin select. No compiler-crate or toolchain-rule logic changed; rewired the callers (bench.sh, scripts/rue-bin, perf-baseline.py) and docs off the no-op modifier.

Verified by running: distinct config hashes; cmp DIFFERS; release ~2.2x smaller (42MB -> 18.7MB); the full graph builds in release (proc-macros are exec-configured so thin-LTO never hits them — kept + documented); buck2 test //... --target-platforms //platforms:release = Pass 23. clippy-gate-passed; test.sh green.

This unblocks RUE-45's release-mode CI half (a job can now build+test a genuinely-optimized compiler, and cfg(debug_assertions) is off at -Copt-level=3).

Fixes RUE-277

Generated with Claude Code