### PR TITLE
Extend rue-oracle-diff to the rue-spec corpus (RUE-204)

### DIFF
--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -16,6 +16,9 @@ rue_binary(
     name = "rue-oracle-diff",
     deps = [
         "//crates/rue-oracle:rue-oracle",
+        # rue-test-runner parses + template-expands the rue-spec corpus exactly
+        # as the spec suite does, so the `spec` mode's templating can't drift.
+        "//crates/rue-test-runner:rue-test-runner",
         "//third-party:serde",
         "//third-party:toml",
     ],
@@ -34,5 +37,19 @@ sh_test(
     test = ":rue-oracle-diff",
     env = {
         "RUE_ORACLE_DIFF_CASES": "$(location //crates/rue-cli-tests:cases)/cases",
+    },
+)
+
+# The same differential over the rue-spec corpus (RUE-204). Runs the harness in
+# `spec` mode against the rue-spec `cases` filegroup, so a codegen change that
+# diverges from the spec-defined semantics also fails CI here. Templated cases
+# are expanded via rue-test-runner; golden-IR-only / preview-gated / compile-fail
+# cases are skipped by the harness, not counted as disagreements.
+sh_test(
+    name = "oracle-diff-spec-test",
+    test = ":rue-oracle-diff",
+    args = ["spec"],
+    env = {
+        "RUE_ORACLE_DIFF_SPEC_CASES": "$(location //crates/rue-spec:cases)/cases",
     },
 )

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -10,13 +10,24 @@
 //! turns "we check the outputs we thought to write down" into "we check that
 //! the semantics and codegen agree on every program in the corpus."
 //!
-//! Two modes:
+//! Modes:
 //!
 //! - **corpus** (default): `rue-oracle-diff [cases-dir ...]` runs the concrete
 //!   rue-cli-tests corpus through the oracle. Case-directory resolution, in
 //!   order: explicit argv paths; else the `RUE_ORACLE_DIFF_CASES` env var (a
 //!   single dir — how the `buck2 test` sh_test feeds the rue-cli-tests `cases`
 //!   filegroup); else the default `crates/rue-cli-tests/cases`.
+//! - **spec** (`rue-oracle-diff spec [cases-dir ...]`): the same differential
+//!   over the **rue-spec** corpus (RUE-204). The spec schema is richer than
+//!   rue-cli-tests — templated `params`, `spec=[...]` refs, golden-IR and
+//!   preview assertions — so we lean on [`rue_test_runner`] (the spec runner's
+//!   own crate) to parse and template-expand every case exactly as the spec
+//!   suite does, then filter to the runnable subset the oracle can model
+//!   (concrete `source` + expected exit/stdout; golden-IR-only, preview-gated,
+//!   `compile_fail`, multi-file and stdin cases are skipped, not disagreements).
+//!   Dir resolution mirrors corpus mode: argv; else `RUE_ORACLE_DIFF_SPEC_CASES`
+//!   (how the `buck2 test` sh_test feeds the rue-spec `cases` filegroup); else
+//!   `crates/rue-spec/cases`.
 //! - **fuzz** (`rue-oracle-diff fuzz [...]`): the differential *fuzzer* of
 //!   RUE-247 — generate random valid programs and cross-check the oracle
 //!   against the real compiler + native binary. See [`fuzz`]. A `dump <seed>`
@@ -107,6 +118,11 @@ fn run() -> ExitCode {
     if raw.first().map(String::as_str) == Some("fuzz") {
         return fuzz::run(&raw[1..]);
     }
+    // `spec [cases-dir ...]` runs the differential over the rue-spec corpus
+    // (templated cases expanded via rue-test-runner) instead of rue-cli-tests.
+    if raw.first().map(String::as_str) == Some("spec") {
+        return spec_mode(raw[1..].to_vec());
+    }
     // `dump <seed>...` prints the generated program(s) — a debugging aid for
     // inspecting what a seed produces (and reducing a repro by hand).
     if raw.first().map(String::as_str) == Some("dump") {
@@ -173,11 +189,19 @@ fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
         }
     }
 
+    finish_report(&report, "rue-cli-tests")
+}
+
+/// Print the tallied report and turn it into a process exit code: success when
+/// the oracle agreed with the compiler on every runnable case, failure on any
+/// disagreement. Shared by [`corpus_mode`] and [`spec_mode`]; `corpus` names
+/// which corpus was differenced, for the header.
+fn finish_report(report: &Report, corpus: &str) -> ExitCode {
     let total = report.agree
         + report.skip_unsupported
         + report.skip_nonrunnable
         + report.disagreements.len() as u32;
-    println!("\n=== rue-oracle-diff: differential agreement over {total} cases ===");
+    println!("\n=== rue-oracle-diff: differential agreement over {total} {corpus} cases ===");
     println!("  agree:            {}", report.agree);
     println!("  skip (unmodeled): {}", report.skip_unsupported);
     println!("  skip (non-runnable shape): {}", report.skip_nonrunnable);
@@ -197,6 +221,187 @@ fn corpus_mode(raw_args: Vec<String>) -> ExitCode {
         ExitCode::FAILURE
     }
 }
+
+/// The spec-corpus differential (RUE-204): expand each rue-spec templated case
+/// and run the runnable subset through the oracle, checking three-way agreement
+/// (oracle == expected == compiler).
+///
+/// Parsing and `params` template-expansion are delegated to
+/// [`rue_test_runner::load_test_files`] — the exact code the spec suite uses —
+/// so template semantics can never drift from the real runner. We then filter
+/// to the shapes the single-source oracle can model (see [`check_spec_case`]).
+fn spec_mode(raw_args: Vec<String>) -> ExitCode {
+    let dirs: Vec<PathBuf> = if !raw_args.is_empty() {
+        raw_args.into_iter().map(PathBuf::from).collect()
+    } else if let Some(cases) = std::env::var_os("RUE_ORACLE_DIFF_SPEC_CASES") {
+        // Set by the `//crates/rue-oracle-diff:oracle-diff-spec-test` sh_test to
+        // the rue-spec `cases` filegroup's absolute location.
+        vec![PathBuf::from(cases)]
+    } else {
+        vec![PathBuf::from("crates/rue-spec/cases")]
+    };
+
+    if !dirs.iter().any(|d| d.exists()) {
+        eprintln!(
+            "no rue-spec cases dir found under {:?} (run from the repo root)",
+            dirs
+        );
+        return ExitCode::FAILURE;
+    }
+
+    let mut report = Report::default();
+    for dir in &dirs {
+        // `load_test_files` expands `params` templates and validates preview
+        // feature names exactly as the spec runner does; it needs only the
+        // cases dir (no spec markdown).
+        for (ident, file) in rue_test_runner::load_test_files(dir) {
+            for case in &file.case {
+                check_spec_case(&ident, case, &mut report);
+            }
+        }
+    }
+
+    finish_report(&report, "rue-spec")
+}
+
+/// Run one expanded rue-spec case through the oracle, tallying the outcome.
+///
+/// Skipped (as a non-runnable shape, never a disagreement) when the case is not
+/// a single concrete program the oracle can execute and compare: `compile_fail`
+/// (no runtime output), `preview`-gated (the oracle models only stable
+/// semantics), `compile_only` (never executed), golden-IR-only (an IR dump, not
+/// a run), or a shape with no oracle model (stdin, multi-file `aux_files`).
+/// Cases the oracle simply can't model yet return [`Unsupported`] and count as
+/// unmodeled skips.
+fn check_spec_case(ident: &str, case: &rue_test_runner::Case, report: &mut Report) {
+    let golden_only = case.has_golden_ir_assertions() && !case.has_execution_assertions();
+    // A `target`-pinned case's expected exit is target-specific (e.g. it matches
+    // on `@target_arch()`), and a case restricted by `only_on` to other hosts is
+    // built for a target the oracle isn't evaluating for. The oracle interprets a
+    // single source with no `--target` notion, so neither is a program it can be
+    // asked to reproduce — skip both, exactly as the spec runner skips `only_on`.
+    let target_specific =
+        case.target.is_some() || rue_test_runner::should_skip_for_platform(&case.only_on).is_some();
+    if case.skip
+        || case.compile_fail
+        || case.preview.is_some()
+        || case.compile_only
+        || case.stdin.is_some()
+        || !case.aux_files.is_empty()
+        || golden_only
+        || target_specific
+    {
+        report.skip_nonrunnable += 1;
+        return;
+    }
+
+    // The exit code the compiled binary is expected to produce. A runtime-error
+    // case exits with its runtime exit code (101 by convention); otherwise the
+    // case's explicit `exit_code`. A case with neither (e.g. a warnings-only
+    // check) describes no concrete run to diff against.
+    let expected_exit = if case.runtime_error.is_some() {
+        case.runtime_exit_code
+            .unwrap_or(rue_test_runner::RUNTIME_ERROR_EXIT_CODE)
+    } else if let Some(code) = case.exit_code {
+        code
+    } else {
+        report.skip_nonrunnable += 1;
+        return;
+    };
+
+    let is_known_gap = KNOWN_ORACLE_GAPS
+        .iter()
+        .any(|(i, n, _)| *i == ident && *n == case.name);
+
+    match run_source(&case.source) {
+        // Oracle bailed (unmodeled construct). For a tracked gap this is the
+        // "skip Unsupported cleanly" outcome; either way it's a skip, not a bug.
+        Err(_unsupported) => report.skip_unsupported += 1,
+        Ok(outcome) => {
+            let exit_ok = outcome.exit_code == expected_exit;
+            // Compare stdout under the spec runner's own normalization so a
+            // trailing-newline difference is not reported as a miscompile.
+            let stdout_ok = case.expected_stdout.as_ref().is_none_or(|s| {
+                rue_test_runner::normalize_golden(&outcome.stdout)
+                    == rue_test_runner::normalize_golden(s)
+            });
+            let agrees = exit_ok && stdout_ok;
+
+            if is_known_gap {
+                // xfail semantics (mirroring rue-cli-tests `known_bug`): the case
+                // is expected to diverge because of a tracked oracle bug. If it
+                // now AGREES, the gap is fixed — fail loudly so the entry is
+                // removed and the case becomes a live regression check again.
+                if agrees {
+                    report.disagreements.push(format!(
+                        "{ident} :: {} — KNOWN_ORACLE_GAPS entry now AGREES; the tracked \
+                         oracle gap is fixed, so delete its entry in \
+                         crates/rue-oracle-diff/src/main.rs",
+                        case.name
+                    ));
+                } else {
+                    report.skip_nonrunnable += 1;
+                }
+                return;
+            }
+
+            if agrees {
+                report.agree += 1;
+            } else {
+                let mut msg = format!("{ident} :: {}", case.name);
+                if !exit_ok {
+                    msg += &format!(
+                        "\n      exit: expected {expected_exit}, oracle got {}",
+                        outcome.exit_code
+                    );
+                }
+                if !stdout_ok {
+                    msg += &format!(
+                        "\n      stdout: expected {:?}, oracle got {:?}",
+                        case.expected_stdout.as_deref().unwrap_or(""),
+                        outcome.stdout
+                    );
+                }
+                report.disagreements.push(msg);
+            }
+        }
+    }
+}
+
+/// Spec-corpus cases the oracle is known to model incorrectly (returning a
+/// wrong-but-`Ok` result rather than [`Unsupported`]), each paired with the
+/// tracking issue. These are **not** miscompiles — the compiler is correct; the
+/// oracle is. They are carried as xfails (see [`check_spec_case`]): each is
+/// asserted to *still* diverge, so when its tracked bug is fixed the harness
+/// fails and points at the entry to delete. Keep this list tiny — it exists
+/// only to keep CI green over a documented, tracked oracle limitation, never to
+/// paper over a real codegen disagreement.
+///
+/// Entry: `(section-identifier, case-name, tracking-issue)`.
+const KNOWN_ORACLE_GAPS: &[(&str, &str, &str)] = &[
+    // RUE-285: aggregate ==/!= compares every struct/array as equal because
+    // `Value::as_int()` yields 0 for aggregates, instead of a field-wise compare.
+    (
+        "expressions/comparison",
+        "struct_equality_different_values",
+        "RUE-285",
+    ),
+    (
+        "expressions/comparison",
+        "struct_equality_inequality",
+        "RUE-285",
+    ),
+    (
+        "expressions/comparison",
+        "struct_equality_many_fields",
+        "RUE-285",
+    ),
+    (
+        "expressions/comparison",
+        "struct_with_bool_field_equality",
+        "RUE-285",
+    ),
+];
 
 fn check_case(path: &Path, case: &Case, report: &mut Report) {
     // Shapes the harness cannot drive through the single-source oracle.


### PR DESCRIPTION
Added a spec mode to rue-oracle-diff that runs the rue-spec corpus through the oracle for three-way agreement (oracle == expected == compiled), alongside the existing (untouched) cli-tests mode. Reused rue-test-runner — the spec suite's own crate — for params template-expansion so it can't drift from the real runner. Wired a second sh_test (oracle-diff-spec-test) feeding the rue-spec cases filegroup, so buck2 test / CI check spec-corpus agreement too. Roughly DOUBLES the differential-harness coverage.

Verified by running: spec mode = 1130 agree / 0 disagreements over 1742 cases; default cli mode unchanged; all 3 oracle-diff buck targets pass. clippy-gate-passed; test.sh green.

Note: the run surfaced a real ORACLE gap (aggregate == reads every struct as equal via as_int()=0) — NOT a compiler miscompile (the compiler is correct by execution). Filed as RUE-285 and carried as a loud xfail. 11 apparent intrinsics disagreements were only_on/target-pinned cases the runner skips on non-matching hosts — added the matching filters.

Fixes RUE-204

Generated with Claude Code