### PR TITLE
Comptime value params track their declared type; module const usable as an operator operand (RUE-216, RUE-267)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -440,6 +440,19 @@ impl<'a> ConstraintGenerator<'a> {
         self.type_vars.fresh()
     }
 
+    /// Allocate a fresh type variable that behaves like an integer literal:
+    /// the unifier rejects binding it to a non-integer type, and if it is
+    /// still unbound after solving it defaults to i32. Used for a captured
+    /// comptime integer value (an anonymous-struct method reading `comptime
+    /// N: u8` from its enclosing function), whose declared width is not
+    /// threaded through the capture and is instead recovered from use, exactly
+    /// like the literal it stands in for (RUE-216).
+    pub fn fresh_int_literal_var(&mut self) -> TypeVarId {
+        let var = self.fresh_var();
+        self.int_literal_vars.push(var);
+        var
+    }
+
     /// Check whether an instruction is a comparison operator.
     ///
     /// Mirrors `Sema::is_comparison`; used to recognize chained comparisons

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -30,7 +30,8 @@ use super::context::{
 };
 use super::{AnalyzedFunction, InferenceContext, MethodInfo, Sema, SemaOutput};
 use crate::inference::{
-    Constraint, ConstraintContext, ConstraintGenerator, ParamVarInfo, Unifier, UnifyResult,
+    Constraint, ConstraintContext, ConstraintGenerator, InferType, ParamVarInfo, Unifier,
+    UnifyResult,
 };
 use crate::inst::{
     Air, AirArgMode, AirCallArg, AirInst, AirInstData, AirPlaceBase, AirProjection, AirRef,
@@ -2017,12 +2018,25 @@ impl<'a> Sema<'a> {
         // function). Real parameters keep their declared type: in a
         // value-specialized body (RUE-166) the comptime value parameter is
         // also a runtime parameter with a precise type (e.g. `comptime n:
-        // i64`), which the fallback below (i32 for any integer) must not
-        // clobber.
+        // i64`), inserted into `param_vars` above, which the gap-filling
+        // `or_insert` here must not clobber.
+        //
+        // A *captured* integer value carries only its magnitude — its declared
+        // width is not threaded through the capture — so it is typed as a
+        // fresh integer-literal variable and takes its width from use (a
+        // `comptime N: u8` read where u8 is expected unifies to u8), exactly
+        // like the literal it stands in for. Emission then reads that resolved
+        // width back out of `resolved_types` instead of hard-coding i32
+        // (RUE-216).
         if let Some(values) = value_subst {
             for (name, const_val) in values {
                 let ty = match const_val {
-                    ConstValue::Integer(_) => Type::I32, // TODO: Track actual type
+                    ConstValue::Integer(_) => {
+                        param_vars.entry(*name).or_insert(ParamVarInfo {
+                            ty: InferType::Var(cgen.fresh_int_literal_var()),
+                        });
+                        continue;
+                    }
                     ConstValue::Bool(_) => Type::BOOL,
                     ConstValue::Type(t) => *t,
                     ConstValue::Unit => Type::UNIT,
@@ -2187,7 +2201,8 @@ impl<'a> Sema<'a> {
                 // operands through here (RUE-165). Constants inline a fresh
                 // value, so there is no move state to preserve, and unknown
                 // names still get E0201 from the fallback.
-                return self.analyze_var_ref(air, *name, inst.span, ctx);
+                let resolved_ty = ctx.resolved_types.get(&inst_ref).copied();
+                return self.analyze_var_ref(air, *name, inst.span, resolved_ty, ctx);
             };
 
             let ty = local.ty;

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2000,7 +2000,10 @@ impl<'a> Sema<'a> {
                 ctx,
             ),
 
-            InstData::VarRef { name } => self.analyze_var_ref(air, *name, inst.span, ctx),
+            InstData::VarRef { name } => {
+                let resolved_ty = ctx.resolved_types.get(&inst_ref).copied();
+                self.analyze_var_ref(air, *name, inst.span, resolved_ty, ctx)
+            }
 
             InstData::ParamRef { index: _, name } => {
                 self.analyze_param_ref(air, *name, inst.span, ctx)
@@ -2192,6 +2195,11 @@ impl<'a> Sema<'a> {
         air: &mut Air,
         name: Spur,
         span: Span,
+        // The Hindley-Milner-resolved type of this reference, if known. Used
+        // to recover the declared width of a captured comptime value parameter
+        // (a `comptime n: u8` reference), whose `ConstValue` carries only the
+        // integer magnitude, not its type (RUE-216).
+        resolved_ty: Option<Type>,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         // Check if it's a parameter — but a `let` that shadows the parameter
@@ -2380,13 +2388,23 @@ impl<'a> Sema<'a> {
         if let Some(const_value) = ctx.comptime_value_vars.get(&name) {
             match const_value {
                 ConstValue::Integer(val) => {
-                    // For now, emit as i32 const. TODO: Track actual type.
+                    // Emit the const with the parameter's declared width. The
+                    // `ConstValue` carries only the integer magnitude, so the
+                    // type comes from the HM-resolved type of this reference
+                    // (a captured `comptime n: u8` reference resolves to u8).
+                    // Falling back to i32 when no integer type was resolved
+                    // preserves the historical behavior for the untyped case
+                    // (RUE-216).
+                    let ty = match resolved_ty {
+                        Some(t) if t.is_integer() => t,
+                        _ => Type::I32,
+                    };
                     let air_ref = air.add_inst(AirInst {
                         data: AirInstData::Const(*val as u64),
-                        ty: Type::I32,
+                        ty,
                         span,
                     });
-                    return Ok(AnalysisResult::new(air_ref, Type::I32));
+                    return Ok(AnalysisResult::new(air_ref, ty));
                 }
                 ConstValue::Bool(val) => {
                     let air_ref = air.add_inst(AirInst {

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -63,6 +63,8 @@ use crate::types::{StructField, Type};
 static EMPTY_TYPE_SUBST: LazyLock<HashMap<Spur, Type>> = LazyLock::new(HashMap::new);
 /// Empty value substitution map for evaluation contexts without one.
 static EMPTY_VALUE_SUBST: LazyLock<HashMap<Spur, ConstValue>> = LazyLock::new(HashMap::new);
+/// Empty module-member map for evaluation contexts without one.
+static EMPTY_MODULE_MEMBERS: LazyLock<HashMap<InstRef, ConstValue>> = LazyLock::new(HashMap::new);
 
 /// The environment a compile-time expression is evaluated in.
 pub(crate) struct ComptimeEnv<'a> {
@@ -82,6 +84,13 @@ pub(crate) struct ComptimeEnv<'a> {
     runtime_locals: Option<&'a HashMap<Spur, LocalVar>>,
     /// `let` bindings introduced by blocks inside the comptime expression.
     locals: HashMap<Spur, ConstValue>,
+    /// Values of module-member accesses (`m.CONST`) appearing in this
+    /// expression, pre-resolved from the module's file (with privacy checks)
+    /// before evaluation. The engine has no file/collector context of its own,
+    /// so a `FieldGet` on a module is only evaluable as a sub-expression
+    /// operand (`1 + m.CONST`) by looking its value up here (RUE-267). Keyed by
+    /// the `FieldGet` instruction. Empty outside const-initializer evaluation.
+    const_module_members: &'a HashMap<InstRef, ConstValue>,
 }
 
 impl<'a> ComptimeEnv<'a> {
@@ -93,6 +102,7 @@ impl<'a> ComptimeEnv<'a> {
             resolved_types: None,
             runtime_locals: None,
             locals: HashMap::new(),
+            const_module_members: &EMPTY_MODULE_MEMBERS,
         }
     }
 
@@ -108,6 +118,7 @@ impl<'a> ComptimeEnv<'a> {
             resolved_types: None,
             runtime_locals: None,
             locals: HashMap::new(),
+            const_module_members: &EMPTY_MODULE_MEMBERS,
         }
     }
 
@@ -120,6 +131,7 @@ impl<'a> ComptimeEnv<'a> {
             resolved_types: Some(ctx.resolved_types),
             runtime_locals: Some(&ctx.locals),
             locals: HashMap::new(),
+            const_module_members: &EMPTY_MODULE_MEMBERS,
         }
     }
 
@@ -131,13 +143,17 @@ impl<'a> ComptimeEnv<'a> {
     /// results) the `comptime { }` block path gets from HM inference, instead
     /// of the raw-`i64` fallback that only range-checked the final value
     /// against the declared type (RUE-230).
-    pub(crate) fn for_const_init(resolved_types: &'a HashMap<InstRef, Type>) -> Self {
+    pub(crate) fn for_const_init(
+        resolved_types: &'a HashMap<InstRef, Type>,
+        const_module_members: &'a HashMap<InstRef, ConstValue>,
+    ) -> Self {
         Self {
             type_subst: &EMPTY_TYPE_SUBST,
             value_subst: &EMPTY_VALUE_SUBST,
             resolved_types: Some(resolved_types),
             runtime_locals: None,
             locals: HashMap::new(),
+            const_module_members,
         }
     }
 }
@@ -1007,6 +1023,15 @@ impl Sema<'_> {
                 let (name, args_start, args_len) = (*name, *args_start, *args_len);
                 self.eval_comptime_type_call(name, args_start, args_len, env)
             }
+
+            // Module-member access (`m.CONST`) as an operand of a larger const
+            // initializer. The value was pre-resolved from the module's file
+            // (with privacy checks) before evaluation — see the
+            // `const_module_members` field — since the engine has no file or
+            // constant-collector context to resolve it here. A member absent
+            // from the map (a non-module base, or a re-export used as a value)
+            // is not evaluable, so the caller reports it (RUE-267).
+            InstData::FieldGet { .. } => Ok(env.const_module_members.get(&inst_ref).copied()),
 
             // Everything else requires runtime evaluation
             _ => Ok(None),

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1640,6 +1640,14 @@ impl<'a> Sema<'a> {
         // before type inference so referenced constants' types are known.)
         self.ensure_const_init_deps_collected(init, file_id, st)?;
 
+        // Pre-resolve module-member accesses (`m.CONST`) appearing as
+        // operands. The engine can't resolve them itself (no file/collector
+        // context), so it reads their values from this map keyed by the
+        // `FieldGet` instruction (RUE-267). Runs before type inference so the
+        // members' constants are collected for `infer_const_init_types`.
+        let mut const_module_members: HashMap<InstRef, ConstValue> = HashMap::new();
+        self.collect_const_module_members(init, file_id, st, &mut const_module_members)?;
+
         // Infer operand types for the initializer expression so the engine
         // checks arithmetic at the operand type instead of the raw-i64
         // fallback (RUE-230). Reports E0206 on a mismatched-operand-type
@@ -1647,7 +1655,10 @@ impl<'a> Sema<'a> {
         let mut resolved_types: HashMap<InstRef, Type> = HashMap::new();
         self.infer_const_init_types(init, declared_ty, &mut resolved_types)?;
 
-        let mut env = super::comptime_eval::ComptimeEnv::for_const_init(&resolved_types);
+        let mut env = super::comptime_eval::ComptimeEnv::for_const_init(
+            &resolved_types,
+            &const_module_members,
+        );
         match self.eval_const_expr(init, &mut env)? {
             // Type values (e.g. `const T = i32;`) are not supported as
             // constants: nothing can materialize them at a use site yet.
@@ -1701,6 +1712,17 @@ impl<'a> Sema<'a> {
             InstData::VarRef { name } => self
                 .constants
                 .get(name)
+                .map(|info| info.ty)
+                .filter(|t| t.is_integer()),
+
+            // A module-member access (`m.CONST`) carries the member constant's
+            // declared type, so arithmetic against it is checked at that width
+            // (RUE-267). The member name is globally unique in the flat
+            // namespace, so the global constants table resolves it, matching
+            // the plain-`VarRef` arm above.
+            InstData::FieldGet { field, .. } => self
+                .constants
+                .get(field)
                 .map(|info| info.ty)
                 .filter(|t| t.is_integer()),
 
@@ -1900,6 +1922,100 @@ impl<'a> Sema<'a> {
             InstData::Alloc { init, .. } => {
                 let init = *init;
                 self.ensure_const_init_deps_collected(init, file_id, st)
+            }
+            _ => Ok(()),
+        }
+    }
+
+    /// Walk a constant initializer and resolve every module-member access
+    /// (`m.CONST`) appearing in it to its compile-time value, keyed by the
+    /// `FieldGet` instruction. The comptime engine has no file or
+    /// constant-collector context, so it can only evaluate a module member as
+    /// a whole initializer (via [`Self::eval_const_initializer`]'s `FieldGet`
+    /// arm); this pre-pass lets one appear as an operand of a larger
+    /// expression too — `const A: i32 = 1 + m.ANSWER;` (RUE-267).
+    ///
+    /// Only a member whose base resolves to a module and whose value is a
+    /// scalar constant is recorded. A non-module base is left untouched (the
+    /// engine reports it), while a privacy violation propagates as its usual
+    /// error (E0706). The tree walk mirrors [`Self::ensure_const_init_deps_collected`].
+    fn collect_const_module_members(
+        &mut self,
+        expr: InstRef,
+        file_id: FileId,
+        st: &mut ConstCollector,
+        out: &mut HashMap<InstRef, ConstValue>,
+    ) -> CompileResult<()> {
+        match &self.rir.get(expr).data {
+            InstData::FieldGet { base, field } => {
+                let (base, field) = (*base, *field);
+                // Probe the base; only a module base has a member value here.
+                // A non-module base (or an unresolvable one) is left for the
+                // engine to reject, matching the pre-fix behavior.
+                if let Ok(ConstInit::Module(module_ty)) =
+                    self.eval_const_initializer(base, file_id, st, None)
+                {
+                    let module_id = module_ty
+                        .as_module()
+                        .expect("ConstInit::Module holds a module type");
+                    let span = self.rir.get(expr).span;
+                    // Privacy errors (E0706) propagate; a re-export member
+                    // yields a module, not a value, so it stays unrecorded.
+                    if let ConstInit::Value(value) =
+                        self.resolve_module_member_const(module_id, field, file_id, span, st)?
+                    {
+                        out.insert(expr, value);
+                    }
+                }
+                Ok(())
+            }
+            InstData::Neg { operand }
+            | InstData::Not { operand }
+            | InstData::BitNot { operand } => {
+                let operand = *operand;
+                self.collect_const_module_members(operand, file_id, st, out)
+            }
+            InstData::Add { lhs, rhs }
+            | InstData::Sub { lhs, rhs }
+            | InstData::Mul { lhs, rhs }
+            | InstData::Div { lhs, rhs }
+            | InstData::Mod { lhs, rhs }
+            | InstData::Eq { lhs, rhs }
+            | InstData::Ne { lhs, rhs }
+            | InstData::Lt { lhs, rhs }
+            | InstData::Gt { lhs, rhs }
+            | InstData::Le { lhs, rhs }
+            | InstData::Ge { lhs, rhs }
+            | InstData::And { lhs, rhs }
+            | InstData::Or { lhs, rhs }
+            | InstData::BitAnd { lhs, rhs }
+            | InstData::BitOr { lhs, rhs }
+            | InstData::BitXor { lhs, rhs }
+            | InstData::Shl { lhs, rhs }
+            | InstData::Shr { lhs, rhs } => {
+                let (lhs, rhs) = (*lhs, *rhs);
+                self.collect_const_module_members(lhs, file_id, st, out)?;
+                self.collect_const_module_members(rhs, file_id, st, out)
+            }
+            InstData::Comptime { expr: inner } => {
+                let inner = *inner;
+                self.collect_const_module_members(inner, file_id, st, out)
+            }
+            InstData::Block { extra_start, len } => {
+                let stmt_refs: Vec<InstRef> = self
+                    .rir
+                    .get_extra(*extra_start, *len)
+                    .iter()
+                    .map(|&raw| InstRef::from_raw(raw))
+                    .collect();
+                for stmt_ref in stmt_refs {
+                    self.collect_const_module_members(stmt_ref, file_id, st, out)?;
+                }
+                Ok(())
+            }
+            InstData::Alloc { init, .. } => {
+                let init = *init;
+                self.collect_const_module_members(init, file_id, st, out)
             }
             _ => Ok(()),
         }

--- a/crates/rue-cli-tests/cases/module_consts.toml
+++ b/crates/rue-cli-tests/cases/module_consts.toml
@@ -47,6 +47,48 @@ pub const ANSWER: i32 = 21;
 ]
 exit_code = 42
 
+# Member access as an OPERATOR OPERAND in a const initializer, not just as the
+# whole initializer (RUE-267): `1 + m.ANSWER` used to be rejected (E0434)
+# while `m.ANSWER` alone compiled. The comptime engine now reads the member's
+# pre-resolved value, so it composes in any operand position.
+[[case]]
+name = "member_const_as_operator_operand"
+files = [
+    { path = "main.rue", source = """
+const math = @import("math");
+const A: i32 = 1 + math.ANSWER;
+const B: i32 = math.ANSWER * 2 - 4;
+
+fn main() -> i32 {
+    A + B
+}
+""" },
+    { path = "math.rue", source = """
+pub const ANSWER: i32 = 42;
+""" },
+]
+exit_code = 123
+
+# A private member used as an operator operand reports the privacy violation
+# (E0706) rather than the generic "not supported in const context" (E0434),
+# confirming the pre-resolution propagates the real error (RUE-267).
+[[case]]
+name = "private_member_as_operator_operand_rejected"
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib");
+const A: i32 = 1 + lib.SECRET;
+
+fn main() -> i32 { A }
+""" },
+    { path = "sub/lib.rue", source = """
+const SECRET: i32 = 99;
+pub fn touch() -> i32 { SECRET }
+""" },
+]
+compile_fail = true
+error_contains = ["E0706", "SECRET", "private"]
+
 # The member const's declared width survives the access: an i64 member used
 # in arithmetic must be anchored to i64 by inference, not mis-defaulted.
 [[case]]

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -810,6 +810,57 @@ fn main() -> i32 {
 """
 exit_code = 42
 
+# A captured comptime value parameter keeps its DECLARED width, not a
+# hard-coded i32 (RUE-216): reading a captured `comptime N: u8` in a method
+# returning u8 must type as u8. Before the fix the reference was emitted as
+# i32 and the method's u8 return type mismatched (E0206).
+[[case]]
+name = "anon_struct_comptime_param_capture_u8"
+spec = ["4.14:12"]
+description = "Captured comptime value parameter keeps its declared u8 width"
+source = """
+fn FixedBuffer(comptime N: u8) -> type {
+    struct {
+        len: i32,
+
+        fn capacity(self) -> u8 {
+            N
+        }
+    }
+}
+fn main() -> i32 {
+    let B = FixedBuffer(200);
+    let b: B = B { len: 0 };
+    @intCast(b.capacity())
+}
+"""
+exit_code = 200
+
+# The same, for a value wider than i32: a captured `comptime N: i64` keeps
+# i64, so a value above i32::MAX round-trips instead of truncating (RUE-216).
+[[case]]
+name = "anon_struct_comptime_param_capture_i64"
+spec = ["4.14:12"]
+description = "Captured comptime value parameter keeps its declared i64 width"
+source = """
+fn FixedBuffer(comptime N: i64) -> type {
+    struct {
+        len: i32,
+
+        fn capacity(self) -> i64 {
+            N
+        }
+    }
+}
+fn main() -> i32 {
+    let B = FixedBuffer(9000000000);
+    let b: B = B { len: 0 };
+    let c: i64 = b.capacity();
+    @intCast(c / 1000000000)
+}
+"""
+exit_code = 9
+
 [[case]]
 name = "anon_struct_associated_fn"
 spec = ["4.14:13"]

--- a/docs/spec/src/06-items/05-constants.md
+++ b/docs/spec/src/06-items/05-constants.md
@@ -34,11 +34,10 @@ const FLAG: bool = !false;       // boolean operators
 
 {{ rule(id="6.5:10", cat="informative") }}
 
-In the current implementation, a module member access (`m.CONST`, 10.4:12)
-is compile-time evaluable only as a whole initializer, not as the operand of
-an operator: write `const BASE: i32 = m.LIMIT; const N: i32 = BASE + 1;`
-rather than `const N: i32 = m.LIMIT + 1;`. This restriction is an
-implementation artifact, not a language guarantee.
+A module member access (`m.CONST`, 10.4:12) is itself compile-time evaluable,
+so it composes in any operand position of a constant initializer just like a
+reference to a local constant: `const N: i32 = m.LIMIT + 1;` is accepted, as
+is the whole-initializer form `const N: i32 = m.LIMIT;`.
 
 ## Types of Constants
 


### PR DESCRIPTION
**RUE-216:** a captured comptime integer value was hard-typed i32 at BOTH inference (analysis.rs ~2025) and emission (analyze_ops.rs ~2383) — the emission-only TODO named in the issue wasn't the whole story; the inference site is what produced the visible E0206. Fixed by typing captures as fresh integer-literal variables (width from use) and emitting the HM-resolved width. Verified: u8 capture -> 200, i64 capture -> 9, i32 unchanged -> 42.

**RUE-267:** m.CONST was evaluable only as a whole const initializer. Added a pre-resolution pass (with privacy checks) + a comptime-engine FieldGet arm so it composes as an operator operand. Verified: 1 + math.ANSWER -> 43; a private member operand -> E0706 (not E0434); whole-initializer still works. Updated the informative spec 6.5:10 artifact note.

clippy-gate-passed; test.sh green; 2 spec + 2 CLI regression tests.

Fixes RUE-216
Fixes RUE-267

Generated with Claude Code