### PR TITLE
Method-owned comptime type param no longer poisons the anon-struct constructor (RUE-284)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -6201,6 +6201,50 @@ impl<'a> Sema<'a> {
         Some(())
     }
 
+    /// Scan an anonymous struct's methods for a method that declares its *own*
+    /// `comptime T: type` parameter (a type parameter owned by the method, not
+    /// by the enclosing `-> type` constructor). Returns the offending method's
+    /// span and name if found.
+    ///
+    /// Such a method would need to be monomorphized per call over its own type
+    /// parameter — a generics feature that is not yet supported (RUE-284).
+    /// Detecting it here lets the constructor's comptime reduction raise a clear
+    /// diagnostic *at the method* instead of silently failing method
+    /// registration, which used to poison the whole constructor and surface as a
+    /// misleading E1200 mis-located at the `let` that instantiates it.
+    pub(crate) fn find_method_own_comptime_type_param(
+        &self,
+        methods_start: u32,
+        methods_len: u32,
+    ) -> Option<(Span, String)> {
+        let method_refs = self.rir.get_inst_refs(methods_start, methods_len);
+        for method_ref in method_refs {
+            let method_inst = self.rir.get(method_ref);
+            if let InstData::FnDecl {
+                name: method_name,
+                params_start,
+                params_len,
+                ..
+            } = &method_inst.data
+            {
+                let params = self.rir.get_params(*params_start, *params_len);
+                for p in params {
+                    // A method-owned `comptime T: type` parameter: `comptime`
+                    // modifier plus the `type` type. (The enclosing
+                    // constructor's own comptime params are not method params,
+                    // so they are never seen here.)
+                    if p.is_comptime && self.interner.resolve(&p.ty) == "type" {
+                        return Some((
+                            method_inst.span,
+                            self.interner.resolve(method_name).to_string(),
+                        ));
+                    }
+                }
+            }
+        }
+        None
+    }
+
     /// Register methods from an anonymous struct type with type substitution (comptime-safe).
     ///
     /// This variant supports comptime parameter capture by using `resolve_type_for_comptime_with_subst`

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -837,6 +837,34 @@ impl Sema<'_> {
                 // Register methods if present and not yet registered for this
                 // struct (it may have been created earlier without methods).
                 if *methods_len > 0 {
+                    // A method that declares its own `comptime T: type`
+                    // parameter would need to be monomorphized per call over
+                    // that parameter — a generics feature not yet supported
+                    // (RUE-284). Merely *defining* such a method used to make
+                    // the enclosing `-> type` constructor non-evaluable
+                    // (registration returned None → the reduction bailed with
+                    // Ok(None)), surfacing as a misleading E1200 mis-located at
+                    // the `let` that instantiates the constructor. Detect it
+                    // here and raise a clear diagnostic pointing *at the
+                    // method* instead, without poisoning the rest of the
+                    // reduction.
+                    if let Some((method_span, method_name)) =
+                        self.find_method_own_comptime_type_param(*methods_start, *methods_len)
+                    {
+                        return Err(CompileError::new(
+                            ErrorKind::ComptimeEvaluationFailed {
+                                reason: format!(
+                                    "method '{}' declares its own `comptime` type parameter, \
+                                     which is not yet supported (a method cannot be \
+                                     monomorphized over its own type parameter); \
+                                     move the type parameter to the enclosing type \
+                                     constructor instead",
+                                    method_name
+                                ),
+                            },
+                            method_span,
+                        ));
+                    }
                     let Some(struct_id) = struct_ty.as_struct() else {
                         return Ok(None);
                     };

--- a/crates/rue-cli-tests/cases/method_own_comptime_type_param.toml
+++ b/crates/rue-cli-tests/cases/method_own_comptime_type_param.toml
@@ -1,0 +1,68 @@
+# A method that declares its OWN `comptime T: type` parameter inside an
+# anon-struct `-> type` constructor (RUE-284).
+#
+# Monomorphizing a method over its own type parameter is a generics feature
+# that is not yet supported. Before the fix, merely *defining* such a method
+# poisoned the enclosing constructor's comptime reduction:
+# `register_anon_struct_methods_for_comptime_with_subst` resolved the method's
+# types with only the constructor's substitution, so the method-owned
+# `comptime U` was out of scope → registration returned None → the reduction
+# bailed with Ok(None). That non-evaluable result surfaced as a misleading
+# `E1200 cannot store type value in 'CI' at runtime` MIS-LOCATED at the `let CI`
+# binding — blaming the instantiation instead of the unsupported method.
+#
+# The fix detects a method-owned `comptime T: type` parameter during reduction
+# and raises a clear diagnostic pointing AT THE METHOD, so a supported sibling
+# constructor (a method with no type parameter of its own) still reduces, binds,
+# and its methods remain callable.
+
+[section]
+id = "cli.method_own_comptime_type_param"
+name = "Method-owned comptime type parameter is a clear at-the-method error"
+description = "A method declaring its own `comptime T: type` inside a `-> type` constructor errors at the method, not with a mislocated E1200 at the `let` (RUE-284)."
+
+# (a)+(b) The core repro: the error points at the `cast_via` method, mentions
+# the method by name, and is NOT the old mislocated `store type value in 'CI'`
+# E1200 at the `let`.
+[[case]]
+name = "unsupported_method_own_comptime_type_errors_at_method"
+description = "RUE-284: `fn cast_via(self, comptime U: type) -> U` → clear at-method error naming `cast_via`, not E1200 at the `let CI`."
+compile_fail = true
+error_contains = ["E1200", "cast_via", "its own `comptime` type parameter"]
+files = [{ path = "main.rue", source = """
+fn Container(comptime T: type) -> type {
+    struct { v: T, fn cast_via(self, comptime U: type) -> U { self.v } }
+}
+fn main() -> i32 { let CI = Container(i32); 0 }
+""" }]
+
+# (d) A method-owned comptime type param used as ANOTHER param's type — same
+# root, same clear at-method error (was a separate mislocated failure).
+[[case]]
+name = "method_own_comptime_type_used_as_param_type_errors_at_method"
+description = "RUE-284 facet (d): `comptime U: type` used as `x: U` also errors at the method."
+compile_fail = true
+error_contains = ["E1200", "add", "its own `comptime` type parameter"]
+files = [{ path = "main.rue", source = """
+fn Container(comptime T: type) -> type {
+    struct { v: T, fn add(self, comptime U: type, x: U) -> T { self.v } }
+}
+fn main() -> i32 { let CI = Container(i32); 0 }
+""" }]
+
+# Control: a NORMAL method (whose return type is the constructor's own type
+# parameter, no method-owned comptime) still reduces, binds, and is callable.
+[[case]]
+name = "normal_generic_method_still_works_control"
+description = "Control: a method returning the constructor's type parameter `T` still compiles and runs (exit 42)."
+files = [{ path = "main.rue", source = """
+fn Wrapper(comptime T: type) -> type {
+    struct { value: T, fn get(self) -> T { self.value } }
+}
+fn main() -> i32 {
+    let W = Wrapper(i32);
+    let w = W { value: 42 };
+    w.get()
+}
+""" }]
+exit_code = 42


### PR DESCRIPTION
A method declaring its own comptime T: type inside an anon-struct -> type constructor used to make the WHOLE constructor non-evaluable, surfacing a misleading E1200 mis-located at the let binding. Root: register_anon_struct_methods_for_comptime_with_subst resolved method types with only the constructor's type_subst, so a method-owned comptime U resolved to None -> registration None -> reduction bailed Ok(None).

Fix: added find_method_own_comptime_type_param (analysis.rs); the AnonStructType arm in comptime_eval.rs now detects a method-owned comptime type param and raises a clear E1200 pointing AT THE METHOD (naming it + explaining the limitation and the fix). Reused E1200. The feature itself (monomorphizing a method over its own type param) remains unsupported — a separate design item — but it no longer poisons the constructor or mis-locates the error.

Verified by execution: the repro errors AT the method; a normal generic method (fn get(self) -> T) still compiles/binds/runs -> 42. clippy-gate-passed; test.sh green; 3 new CLI cases.

Fixes RUE-284

Generated with Claude Code