### PR TITLE
Comptime recursion: value-returning functions fold in comptime (part of RUE-163)

### DIFF
--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -1066,14 +1066,29 @@ impl Sema<'_> {
         }
     }
 
-    /// Reduce a call to a `-> type` function to its resulting type value, when
-    /// the callee is a type constructor and every argument is compile-time
-    /// known. Shared by [`eval_const_expr`]'s `Call` arm (so nested/delegating
-    /// type-function calls compose) and the analysis pass (RUE-251).
+    /// Reduce a call to a comptime-evaluable function to its resulting value,
+    /// when every argument is compile-time known. Shared by
+    /// [`eval_const_expr`]'s `Call` arm (so nested/delegating calls compose)
+    /// and the analysis pass (RUE-251).
     ///
-    /// Returns `Ok(None)` — not an error — for a callee that does not return
-    /// `type`, a non-type-constructor arity/mode, or a non-const argument: the
-    /// call is then just a runtime call and simply non-evaluable here.
+    /// Two callee shapes reduce here:
+    ///
+    /// - **`-> type` constructors** — reduce to a [`ConstValue::Type`], so
+    ///   `Pair(i32)` composes in any position (RUE-251).
+    /// - **Value-returning functions with all-comptime (or no) parameters** —
+    ///   reduce to their [`ConstValue::Integer`]/[`ConstValue::Bool`] result,
+    ///   which is what lets a comptime-recursive `fn fact(comptime n: i32)`
+    ///   produce a compile-time constant usable as an array length or inside a
+    ///   `comptime { }` block (RUE-163 facet 1, spec 4.14:5). A function with
+    ///   any *runtime* parameter is a genuine runtime call and is left
+    ///   non-evaluable, so ordinary calls like `add(3, 5)` (runtime `a`, `b`)
+    ///   are not folded here.
+    ///
+    /// Returns `Ok(None)` — not an error — for an unknown callee, a
+    /// non-const argument, or an arity/mode that does not match the
+    /// implicit-comptime gate: the call is then just a runtime call and simply
+    /// non-evaluable here. Reducing the body may still raise `Err` (arithmetic
+    /// overflow, recursion-depth overrun); opportunistic callers swallow it.
     ///
     /// [`eval_const_expr`]: Sema::eval_const_expr
     fn eval_comptime_type_call(
@@ -1086,19 +1101,30 @@ impl Sema<'_> {
         let Some(fn_info) = self.functions.get(&name) else {
             return Ok(None);
         };
-        // Only `-> type` functions reduce to a type value at compile time.
-        if fn_info.return_type != Type::COMPTIME_TYPE {
-            return Ok(None);
-        }
+        let is_type_fn = fn_info.return_type == Type::COMPTIME_TYPE;
         let params = fn_info.params;
         let param_names = self.param_arena.names(params).to_vec();
         let param_comptime = self.param_arena.comptime(params).to_vec();
         let args = self.rir.get_call_args(args_start, args_len).to_vec();
-        // Same gate as `analyze_call`'s implicit-comptime path: only a no-arg
-        // or all-comptime-param type constructor is implicitly evaluated.
-        if args.len() != param_names.len()
-            || !(args.is_empty() || param_comptime.iter().all(|&c| c))
-        {
+        if args.len() != param_names.len() {
+            return Ok(None);
+        }
+        // Same gate as `analyze_call`'s implicit-comptime path. A `-> type`
+        // constructor reduces with no args (a nullary type alias) or when every
+        // parameter is comptime. A *value*-returning function reduces only when
+        // it has at least one parameter and every one is comptime — the
+        // comptime-recursion / forwarding shape (`fn fact(comptime n: i32)`,
+        // RUE-163 facet 1). A nullary or runtime-parametered value function is a
+        // genuine runtime call, not a compile-time-known value: folding
+        // `get_value()` (a plain `fn get_value() -> i32`) would wrongly make it
+        // acceptable as a `comptime` argument (spec 4.14:6).
+        let all_params_comptime = !param_names.is_empty() && param_comptime.iter().all(|&c| c);
+        let eligible = if is_type_fn {
+            param_names.is_empty() || all_params_comptime
+        } else {
+            all_params_comptime
+        };
+        if !eligible {
             return Ok(None);
         }
         // Evaluate each argument compositionally in the current environment,
@@ -1126,13 +1152,15 @@ impl Sema<'_> {
         self.reduce_type_ctor_body(name, &callee_types, &callee_values)
     }
 
-    /// Reduce a `-> type` constructor's body to a type value under the given
-    /// comptime parameter substitutions. Shared by
+    /// Reduce a comptime-evaluable function's body to a [`ConstValue`] under
+    /// the given comptime parameter substitutions — a type value for a
+    /// `-> type` constructor, or an integer/bool for a value-returning
+    /// comptime function (RUE-163 facet 1). Shared by
     /// [`eval_comptime_type_call`] (value/const-expr positions, args evaluated
     /// via [`eval_const_expr`]) and [`resolve_type_function_call`] (a
     /// type-function call written directly in a signature/annotation position,
     /// args resolved as types; RUE-241) so both produce the identical
-    /// monomorphized type.
+    /// monomorphized result.
     ///
     /// Guards the reduction against unbounded self-recursion. A `-> type`
     /// function reduces eagerly on the host stack, so a constructor with no

--- a/crates/rue-cli-tests/cases/comptime_eval.toml
+++ b/crates/rue-cli-tests/cases/comptime_eval.toml
@@ -61,3 +61,28 @@ fn main() -> i32 {
 args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E1200", "integer overflow", "i32"]
+
+[[case]]
+name = "comptime_value_recursion"
+description = "A comptime-recursive value function folds to a compile-time constant usable inside comptime {} and as a const initializer (RUE-163 facet 1)."
+files = [{ path = "main.rue", source = """
+fn fact(comptime n: i32) -> i32 {
+    if n <= 1 { 1 } else { n * fact(n - 1) }
+}
+const F6: i32 = fact(6);
+fn main() -> i32 {
+    // Reduction inside a comptime block (the recursive call fact(n-1) folds).
+    @dbg(comptime { fact(5) });
+    // Reduction as a file-level const initializer.
+    @dbg(F6);
+    // Forwarding a comptime value parameter through another comptime function.
+    @dbg(fact(4));
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 0
+stdout = """120
+720
+24
+"""

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1257,6 +1257,49 @@ fn main() -> i32 {
 exit_code = 42
 
 [[case]]
+name = "comptime_value_recursion"
+spec = ["4.14:5"]
+description = "A comptime value parameter is a constant in the body, so a comptime-recursive value function folds to a compile-time constant - RUE-163 facet 1"
+source = """
+fn fact(comptime n: i32) -> i32 {
+    if n <= 1 { 1 } else { n * fact(n - 1) }
+}
+fn main() -> i32 {
+    comptime { fact(5) - 78 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_value_recursion_const_init"
+spec = ["4.14:5"]
+description = "A comptime-recursive value function reduces in a const initializer - RUE-163 facet 1"
+source = """
+fn fib(comptime n: i32) -> i32 {
+    if n < 2 { n } else { fib(n - 1) + fib(n - 2) }
+}
+const F9: i32 = fib(9);
+fn main() -> i32 {
+    if F9 == 34 { 42 } else { 1 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "comptime_plain_call_not_comptime_arg"
+spec = ["4.14:6"]
+description = "A call to a function with no comptime parameters is a runtime value, not a comptime-known argument - RUE-163 facet 1 boundary"
+source = """
+fn get_value() -> i32 { 5 }
+fn scale(comptime factor: i32, value: i32) -> i32 { factor * value }
+fn main() -> i32 {
+    scale(get_value(), 10)
+}
+"""
+compile_fail = true
+error_contains = "comptime parameter requires a compile-time known value"
+
+[[case]]
 name = "comptime_file_level_const"
 spec = ["4.14:2"]
 description = "File-level constants are usable inside comptime blocks"


### PR DESCRIPTION
Most of RUE-163's premise is stale — the typed ConstValue evaluator (i128-backed, per-width checked, u64, negatives, wide shifts, blocks, file-consts) already landed via RUE-230/262/271; the worker reproduced + refuted every listed facet as already-passing.

The one genuinely-open facet: eval_const_expr's Call arm only reduced -> type constructors, so a value-returning recursive call (fact(n-1)) inside comptime {} or a const initializer was rejected E1200. Fix (comptime_eval.rs): eval_comptime_type_call now reduces value-returning functions too, gated to callees whose params are all comptime — so recursion/forwarding folds, but a nullary/runtime-param call stays a runtime value (spec 4.14:6 boundary preserved).

Verified by execution: comptime { fact(5) } -> 120; const F9 = fib(9) -> 34; overflow still trapped; runtime add(3,5) still not folded. clippy-gate-passed; test.sh green; diff-fuzzer 300 seeds 0 disagreements; 1 CLI + 3 spec cases.

Follow-up noted: the parser rejects a call directly in array-length position ([i32; fact(4)]) — a rue-parser gap.

Part of RUE-163

Generated with Claude Code