### PR TITLE
Release-mode CI job + pin the aarch64-macos cross-link diagnostic (RUE-45, RUE-85)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,3 +109,57 @@ jobs:
 
       - name: Run tests
         run: ./test.sh
+
+  # Release-mode build + test (RUE-45). Every other job builds the compiler in
+  # debug, so release-only miscompiles — the ones previously masked by a
+  # `debug_assert!` that vanishes when `cfg(debug_assertions)` is off (RUE-24 is
+  # the precedent) — never ran anywhere. This job builds the whole workspace
+  # optimized via `//platforms:release` (RUE-277 made that a genuinely
+  # optimized, byte-distinct build) and runs the full suite against it, so
+  # release codegen is exercised. Bounded to linux-x64 to keep CI time in check;
+  # the debug matrix above still covers arm64/macOS.
+  release:
+    runs-on: ubuntu-latest
+    name: release (linux-x64)
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2  # pinned: the moving `latest` branch broke macOS runners (sha256sum flags) on 2026-06-18
+
+      # Same dotslash cache as the other jobs (buck2 binary only; see the `test`
+      # job for why buck-out isn't worth caching).
+      - name: Cache dotslash artifacts
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cache/dotslash
+            ~/Library/Caches/dotslash
+          key: dotslash-linux-x64-${{ hashFiles('buck2') }}
+          restore-keys: |
+            dotslash-linux-x64-
+
+      # Regression guard for RUE-277: `//platforms:release` must produce a
+      # genuinely-optimized binary that differs from the debug build. If the
+      # opt-level constraint ever silently reverts to a no-op (debug == release,
+      # as it was before RUE-277), `cmp -s` succeeds and we fail — the release
+      # suite below would otherwise be a pointless re-run of the debug build.
+      - name: Assert release build is distinct from debug
+        run: |
+          debug_bin="$(./scripts/rue-bin --target-platforms //platforms:debug)"
+          release_bin="$(./scripts/rue-bin --target-platforms //platforms:release)"
+          if cmp -s "$debug_bin" "$release_bin"; then
+            echo "::error::release build is byte-identical to debug — //platforms:release opt-level is a no-op (RUE-277 regression)"
+            exit 1
+          fi
+          echo "release build differs from debug build (optimized) — OK"
+
+      # Build every crate optimized (catches build breaks that only surface with
+      # optimizations on), then run the full suite — including the spec/UI/CLI
+      # sh_tests, which spawn the release-configured rue binary — so any
+      # cfg(debug_assertions)-off miscompile is caught.
+      - name: Build all targets (release)
+        run: ./buck2 build //crates/... --target-platforms //platforms:release
+
+      - name: Run tests (release)
+        run: ./buck2 test //... --target-platforms //platforms:release

--- a/crates/rue-cli-tests/cases/linker.toml
+++ b/crates/rue-cli-tests/cases/linker.toml
@@ -19,11 +19,16 @@ description = "Cross-compile and link-path behavior, including diagnostic cleanl
 #     so this runs as a real regression test (DEBUG guard + successful compile).
 #   - linux (x86-64 / aarch64): aarch64-macos can't cross-link. Since the
 #     RUE-36 stopgap, the compile fails *by design* with the clear
-#     cross-target-runtime error (before that it failed deep in the Mach-O
-#     link path, RUE-85). Marked known_bug RUE-85 on those platforms (xfail).
-#     When cross-target runtimes land (RUE-36 / ADR-0034) and Mach-O
-#     cross-linking works (RUE-85), drop `known_bug_on` and this becomes a
-#     real test on linux too.
+#     cross-target-runtime error. RUE-85 was the older, *confusing* form of
+#     that failure (a deep Mach-O `E1000: unsupported relocation: Plt32` — the
+#     host x86 runtime's Plt32 relocs fed into the aarch64 Mach-O reloc path);
+#     the RUE-36 guard replaced it with the clear diagnostic now pinned by
+#     `cross_link_to_aarch64_macos_refused` below, so RUE-85 is resolved.
+#     What still fails here is that cross-linking can't yet *produce a runnable
+#     aarch64-macos binary* on a linux host — that needs per-target runtime
+#     archives (RUE-36 / ADR-0034). Hence the xfail is marked known_bug RUE-36
+#     (not RUE-85, which is done): when per-target runtimes land, drop
+#     `known_bug_on` and this becomes a real test on linux too.
 [[case]]
 name = "aarch64_macos_link_no_debug_spew"
 files = [{ path = "main.rue", source = """
@@ -32,7 +37,7 @@ fn main() -> i32 { 0 }
 args = ["main.rue", "--target", "aarch64-macos", "-o", "prog"]
 compile_only = true
 compile_stderr_not_contains = ["DEBUG"]
-known_bug = "RUE-85"
+known_bug = "RUE-36"
 known_bug_on = ["x86-64-linux", "aarch64-linux"]
 
 # ---------------------------------------------------------------------------
@@ -100,6 +105,11 @@ error_contains = [
     "RUE-36",
     "--emit asm",
 ]
+# RUE-85 regression: this must be the clean up-front refusal, never the old
+# confusing deep Mach-O link failure (`E1000: unsupported relocation: Plt32`,
+# from the host x86 runtime's Plt32 relocs hitting the aarch64 Mach-O reloc
+# path). Guard the exact stale text so it can't come back.
+compile_stderr_not_contains = ["Plt32", "unsupported relocation"]
 only_on = ["x86-64-linux", "aarch64-linux"]
 
 # Cross-target CODEGEN must keep working everywhere: --emit asm doesn't link,


### PR DESCRIPTION
**RUE-45 (release-mode CI):** added a bounded release job (linux-x64) that (1) builds //crates/rue:rue under //platforms:debug AND //platforms:release and cmp -s FAILS if byte-identical — a regression guard on RUE-277's opt-level constraint; (2) builds + tests //crates/... --target-platforms //platforms:release, so cfg(debug_assertions)-off codegen (the RUE-24 miscompile class) is exercised. Verified: debug 42MB vs release 18MB, byte-distinct; release suite Pass 24; actionlint exit 0. Completes RUE-45 (debug_assert audit #1090; release-optimized #1095).

**RUE-85 (aarch64-macos linker):** a refutation-with-a-pin. The confusing 'unsupported relocation: Plt32' no longer reproduces — RUE-36's runtime_for_target guard (#978) refuses cross-target links up front. Added compile_stderr_not_contains ['Plt32','unsupported relocation'] to pin the stale text, and re-pointed the remaining xfail from RUE-85 to RUE-36 (per-target-runtime, ADR-0034).

clippy-gate-passed; test.sh green.

Fixes RUE-45
Fixes RUE-85

Generated with Claude Code