### PR TITLE
ADR-0041: Vec — a growable collection on unchecked raw pointers (RUE-1, RUE-226)

### DIFF
--- a/docs/designs/0041-vec.md
+++ b/docs/designs/0041-vec.md
@@ -1,0 +1,132 @@
+---
+id: 0041
+title: "Vec — a growable collection on unchecked raw pointers"
+status: accepted
+tags: [stdlib, collections, generics, ownership, unchecked]
+feature-flag: vec
+created: 2026-07-03
+accepted: 2026-07-03
+implemented:
+spec-sections: ["3.x (builtin types)", "9 (unchecked)"]
+supersedes:
+---
+
+# ADR-0041: Vec — a growable collection on unchecked raw pointers
+
+## Status
+
+Accepted. Direction ratified by Steve on 2026-07-03 ("your suggestions make
+sense for now"). Implements the keystone prerequisite of the dogfoodable
+milestone (RUE-226, RUE-1). Gate behind the `vec` preview feature until complete.
+
+## Summary
+
+`Vec(T)` is a heap-backed, growable, owned collection generic over its element
+type. It is deliberately **not** a design frontier: it falls out of the pieces
+already in the language, and its implementation mirrors the existing built-in
+`String` (which is itself a growable byte buffer built on unchecked code). The
+value of building it now is that a single type exercises comptime generics,
+affine ownership + drop, `inout self` mutation, the access model, and the raw
+pointer intrinsics all at once — and it is the thing real programs need most.
+
+## Context — Vec falls out of the spine
+
+Each ingredient already exists and shipped:
+
+- **Generic** — `Vec(T)` is a comptime type function returning a struct, exactly
+  like `Option(T)`/`Result(T,E)` (RUE-6/221/241/272). No traits needed.
+- **Storage** — it owns a heap buffer addressed by `ptr mut T`. The raw-pointer
+  intrinsics (`@raw`/`@ptr_read`/`@ptr_write`/`@ptr_offset`) are now sound and
+  multi-slot-correct (RUE-242/273/274/243), and `heap::alloc`/grow already back
+  `String` in `rue-runtime`. Vec reuses that proven pattern; the unsafe lives in
+  `checked {}` blocks internal to Vec, behind a safe API (this is the RUE-1
+  "stdlib on unchecked code" framing).
+- **Mutation** — `push(inout self, …)` / `pop(inout self)` use `inout self`
+  receivers, which work on any place (RUE-15/254).
+- **Ownership + drop** — Vec is affine: it owns its buffer, so scope exit frees
+  the buffer *and* runs each live element's destructor (indices `0..len`). This
+  is ordinary drop-glue.
+- **Multiplicity** — `Vec(T)`'s multiplicity is the join of `T`'s (infectiousness,
+  the lattice): a `Vec` of a linear type is itself linear/must-consume.
+- **Iteration** — `for x in v` iterates by shared borrow, same as arrays
+  (RUE-259).
+
+## Decision — the API and semantics
+
+### Layout & construction
+A 3-slot struct `{ ptr: ptr mut T, len: u64, cap: u64 }` (mirrors `String`).
+- `Vec::new() -> Vec(T)` — empty, no allocation (`ptr` null, `cap` 0).
+- `Vec::with_capacity(n) -> Vec(T)` — pre-reserve (null-alloc-safe, cf. RUE-255).
+
+### Mutation (`inout self`)
+- `push(inout self, x: T)` — moves `x` into the buffer, growing (amortized 2×)
+  when `len == cap`.
+- `pop(inout self) -> Option(T)` — **moves the last element out** to the caller
+  (removal, not aliasing — see the non-Copy note below), decrements `len`.
+- `clear(inout self)` — drops all live elements, sets `len = 0`, keeps `cap`.
+
+### Reads
+- `len(borrow self) -> u64`, `capacity(borrow self) -> u64`,
+  `is_empty(borrow self) -> bool`.
+- **`v[i]` is a place**, exactly like array indexing: readable as a borrow
+  within an expression, assignable (`v[i] = x`), and usable as an `inout`/`borrow`
+  method receiver (`v[i].bump()`, RUE-254). Out-of-bounds **traps** (consistent
+  with array indexing and the "trap don't corrupt" string stance, ADR-0035). You
+  **cannot move a non-Copy element out by `v[i]`** — identical to arrays
+  (RUE-259). A `Copy` element read via `v[i]` copies.
+- `get(borrow self, i) -> Option(T)` — the non-trapping accessor, **for `Copy`
+  `T`** (returns a copy). See the non-Copy limitation below for why it is not
+  `Option(borrow T)`.
+
+### Drop
+Affine: scope exit runs each live element's destructor for `0..len` (element
+drop order ascending), then frees the buffer. A moved-out (`pop`ped) element is
+not double-dropped (per-element live tracking, as with the array/temporary work
+RUE-258).
+
+## The non-Copy access tension (explicitly noted)
+
+Steve flagged a real worry: the combination of **second-class borrows** (loans
+can't escape — ADR-0037/spine #3) and **no-move-out-of-an-indexed-position** (a
+non-Copy element can't leave via `v[i]`) makes *non-trapping single-element
+access of a non-`Copy` element* awkward:
+
+- `get(i) -> Option(borrow T)` would return a loan, which second-class borrows
+  forbid — so `get` can only hand back a **copy**, i.e. it is `Copy`-only.
+- For a non-`Copy` `T` the ergonomic paths are: iterate (`for x in v`, shared
+  borrow), index as a place after a manual bounds check (`if i < v.len() { …
+  v[i] … }`, which traps if you get the check wrong), operate in place via an
+  `inout`-receiver method, or **remove** it (`pop`, and a future
+  `swap_remove(i)` / `remove(i)`) — removal is a move-out and *is* allowed.
+
+So non-`Copy` elements can *leave* a Vec (by removal) and be *used in place*
+(borrow/inout), but there is no `Option`-returning, non-trapping, non-removing
+peek for them. That is a language-shape question broader than Vec — filed
+separately for us to ponder (does Rue want a limited first-class borrow for
+this? an `Option`-of-place sugar? accept the trap-or-iterate idiom?). This ADR
+ships the trap-or-iterate idiom now and does not prejudge that discussion.
+
+## Consequences
+
+### Positive
+- Unblocks the dogfooding milestone (RUE-226) — Vec is the keystone.
+- Reuses the String runtime pattern and tonight's raw-pointer soundness; low
+  design risk, mostly mechanical build.
+- Validates the whole spine end-to-end in one type (generics + affine + inout +
+  access model + unchecked).
+
+### Negative / deferred
+- The non-`Copy` non-trapping-peek gap above (tracked separately).
+- No `Vec<T>`-style trait-bounded generics (sorting, hashing, display) until
+  traits (RUE-246) — Vec is monomorphic-generic for now.
+- Amortized-growth policy and capacity semantics are implementation-defined
+  (like String); niche/SSO optimizations later.
+
+## Alternatives considered
+- **`v[i] -> Option(T)` (index returns Option, no trap).** Rejected: inconsistent
+  with array indexing (which traps), and it wouldn't solve the non-`Copy` case
+  anyway (still can't return a borrow). Trapping index + `.get` for `Copy`
+  matches arrays and Rust.
+- **First-class borrows just for `get`.** Rejected *here* — it reopens the
+  second-class-loans decision (ADR-0037), which is load-bearing for the no-`Pin`
+  async story. Left to the separate ponder issue.


### PR DESCRIPTION
Ratifies Steve's 2026-07-03 direction for the dogfooding keystone. Vec(T) is a comptime-generic heap-backed owned collection that falls out of the existing spine (comptime generics + affine/drop + inout-self + access model + sound raw pointers) and mirrors the built-in String runtime.

Key decisions: v[i] is a trapping place (read/assign/inout-receiver, no move-out of non-Copy — like arrays); get(i) -> Option(T) for Copy; push/pop/clear via inout self; drop frees the buffer + runs element destructors. Honestly notes the non-Copy non-trapping-peek tension (second-class borrows + no-move-out) and defers it to RUE-286; prelude deferred to RUE-287. Gate behind the vec preview feature.

Part of RUE-1
Part of RUE-226

Generated with Claude Code