### PR TITLE
print/println: real stdout output (part of RUE-1, option a)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -786,7 +786,24 @@ impl<'a> ConstraintGenerator<'a> {
                 args_len,
             } => {
                 let args = self.rir.get_call_args(*args_start, *args_len);
-                if let Some(func) = self.functions.get(name) {
+                // `print(s)` / `println(s)` builtin free functions (RUE-1):
+                // constrain the single argument to String and yield unit, so a
+                // literal argument resolves to String and the call type-checks.
+                // Only when the program hasn't shadowed the name with its own
+                // `fn print`/`fn println` (a user definition wins).
+                let is_print_builtin = !self.functions.contains_key(name)
+                    && matches!(self.interner.resolve(name), "print" | "println");
+                if is_print_builtin {
+                    for arg in args.iter() {
+                        let arg_info = self.generate(arg.value, ctx);
+                        self.add_constraint(Constraint::equal(
+                            arg_info.ty,
+                            self.string_infer_type(),
+                            arg_info.span,
+                        ));
+                    }
+                    InferType::Concrete(Type::UNIT)
+                } else if let Some(func) = self.functions.get(name) {
                     // For generic functions, build the type substitution map from the
                     // comptime type arguments, then constrain each runtime argument
                     // against its (substituted) parameter type. When a type parameter

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -4884,6 +4884,92 @@ impl<'a> Sema<'a> {
         Ok(AnalysisResult::new(air_ref, string_type))
     }
 
+    /// Analyze the `print(s)` / `println(s)` builtin free functions (RUE-1).
+    ///
+    /// Both take a single `String` and return unit: `print` writes its raw
+    /// bytes to stdout with nothing added, `println` appends a single `\n`.
+    /// Formatting and interpolation are deliberately out of scope — callers
+    /// compose with `@to_string` and `+` (e.g. `println("n=" + @to_string(n))`).
+    ///
+    /// The `String` argument is *borrowed* (read, not consumed), exactly like
+    /// the operands of `s1 + s2`: a named argument stays usable afterwards and
+    /// a temporary is dropped by its owner at statement end (no leak, no double
+    /// free). This lowers to an ordinary `extern "C"` call to the runtime
+    /// `__rue_print` / `__rue_println`, reusing the String-flattening call path
+    /// (the String passes as its three fields ptr/len/cap; the runtime ignores
+    /// cap) — so no codegen change is needed.
+    pub(crate) fn analyze_print_builtin(
+        &mut self,
+        air: &mut Air,
+        name: Spur,
+        args_start: u32,
+        args_len: u32,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        let fn_name = if name == self.known.println {
+            "println"
+        } else {
+            "print"
+        };
+
+        let args = self.rir.get_call_args(args_start, args_len);
+        if args.len() != 1 {
+            return Err(CompileError::new(
+                ErrorKind::WrongArgumentCount {
+                    expected: 1,
+                    found: args.len(),
+                },
+                span,
+            )
+            .with_help(format!("`{fn_name}` takes exactly one String argument")));
+        }
+        let arg_value = args[0].value;
+
+        // Borrow the argument (like a `+` operand): analyze in projection mode
+        // and cancel any move marker so a variable operand is not consumed and
+        // a temporary is still dropped by its owner at statement end.
+        let arg_result = self.analyze_inst_for_projection(air, arg_value, ctx)?;
+        air.cancel_move_marker(arg_result.air_ref);
+
+        if !self.is_builtin_string(arg_result.ty) && !arg_result.ty.is_error() {
+            return Err(CompileError::new(
+                ErrorKind::TypeMismatch {
+                    expected: "String".to_string(),
+                    found: arg_result.ty.safe_name_with_pool(Some(&self.type_pool)),
+                },
+                self.rir.get(arg_value).span,
+            )
+            .with_help(format!(
+                "`{fn_name}` takes a String; build one with `@to_string`, `+`, or String methods"
+            )));
+        }
+
+        let runtime_fn = if name == self.known.println {
+            rue_builtins::PRINTLN_RUNTIME_FN
+        } else {
+            rue_builtins::PRINT_RUNTIME_FN
+        };
+        let call_name = self.interner.get_or_intern(runtime_fn);
+
+        // The String is flattened into (ptr, len, cap) by codegen; Normal mode
+        // with the move cancelled gives flatten-without-consume (same as the
+        // operands of `__rue_String_concat`).
+        let extra_data = [arg_result.air_ref.as_u32(), AirArgMode::Normal.as_u32()];
+        let args_start = air.add_extra(&extra_data);
+
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Call {
+                name: call_name,
+                args_start,
+                args_len: 1,
+            },
+            ty: Type::UNIT,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+    }
+
     /// Analyze a binary arithmetic operator (+, -, *, /, %).
     ///
     /// Follows Rust's type inference rules:

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -4406,6 +4406,17 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
+        // `print(s)` / `println(s)` are builtin free functions (RUE-1), not
+        // user-defined ones: intercept them here before the function lookup,
+        // but only when the program hasn't shadowed the name with its own
+        // `fn print`/`fn println` (a user definition wins, keeping these names
+        // unreserved).
+        if (name == self.known.print || name == self.known.println)
+            && !self.functions.contains_key(&name)
+        {
+            return self.analyze_print_builtin(air, name, args_start, args_len, span, ctx);
+        }
+
         // Look up the function
         let fn_name_str = self.interner.resolve(&name).to_string();
         let fn_info = self

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -52,6 +52,11 @@ pub struct KnownSymbols {
     pub read_line: Spur,
     /// The `to_string` intrinsic symbol - formats an i64 as a decimal String.
     pub to_string: Spur,
+    /// The `print` builtin free function - writes a String to stdout (RUE-1).
+    pub print: Spur,
+    /// The `println` builtin free function - writes a String plus a newline to
+    /// stdout (RUE-1).
+    pub println: Spur,
     /// The `parse_i32` intrinsic symbol.
     pub parse_i32: Spur,
     /// The `parse_i64` intrinsic symbol.
@@ -114,6 +119,8 @@ impl KnownSymbols {
             assert: interner.get_or_intern_static("assert"),
             read_line: interner.get_or_intern_static("read_line"),
             to_string: interner.get_or_intern_static("to_string"),
+            print: interner.get_or_intern_static("print"),
+            println: interner.get_or_intern_static("println"),
             parse_i32: interner.get_or_intern_static("parse_i32"),
             parse_i64: interner.get_or_intern_static("parse_i64"),
             parse_u32: interner.get_or_intern_static("parse_u32"),
@@ -179,6 +186,8 @@ mod tests {
         assert_eq!(interner.resolve(&known.panic), "panic");
         assert_eq!(interner.resolve(&known.assert), "assert");
         assert_eq!(interner.resolve(&known.read_line), "read_line");
+        assert_eq!(interner.resolve(&known.print), "print");
+        assert_eq!(interner.resolve(&known.println), "println");
         assert_eq!(interner.resolve(&known.parse_i32), "parse_i32");
         assert_eq!(interner.resolve(&known.parse_i64), "parse_i64");
         assert_eq!(interner.resolve(&known.parse_u32), "parse_u32");

--- a/crates/rue-builtins/src/lib.rs
+++ b/crates/rue-builtins/src/lib.rs
@@ -492,6 +492,18 @@ pub const TO_STRING_RUNTIME_FN: &str = "__rue_to_string";
 /// *mut StringResult, ptr1, len1, cap1, ptr2, len2, cap2)`.
 pub const STRING_CONCAT_RUNTIME_FN: &str = "__rue_String_concat";
 
+/// Runtime symbol for `print(s)`: writes the raw bytes of `s` to stdout with no
+/// added newline. The `String` is passed by borrow (not consumed), flattened
+/// into three ABI slots: `extern "C" fn __rue_print(ptr, len, cap)` (`cap`
+/// unused). Returns unit (RUE-1).
+pub const PRINT_RUNTIME_FN: &str = "__rue_print";
+
+/// Runtime symbol for `println(s)`: writes the raw bytes of `s` to stdout
+/// followed by a single `\n`. Same borrow ABI as [`PRINT_RUNTIME_FN`]:
+/// `extern "C" fn __rue_println(ptr, len, cap)` (`cap` unused). Returns unit
+/// (RUE-1).
+pub const PRINTLN_RUNTIME_FN: &str = "__rue_println";
+
 // ============================================================================
 // Registry
 // ============================================================================

--- a/crates/rue-cli-tests/cases/print_output.toml
+++ b/crates/rue-cli-tests/cases/print_output.toml
@@ -1,0 +1,93 @@
+# `print` / `println` builtin free functions (RUE-1).
+#
+# `print(s: String)` writes the raw bytes of `s` to stdout with nothing added;
+# `println(s: String)` writes the bytes then a single `\n`. They borrow the
+# String (do not consume it), so the argument stays usable afterwards. These
+# are runtime-visible, so every case pins the exact stdout bytes (including the
+# presence or absence of a trailing newline) — the one thing the spec harness's
+# exit-code assertions can't see.
+
+[section]
+id = "cli.print"
+name = "print / println output"
+description = "Raw-byte stdout output via the print and println builtins."
+
+[[case]]
+name = "print_no_trailing_newline"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    print("hello");
+    print(" world");
+    0
+}
+""" }]
+stdout = "hello world"
+
+[[case]]
+name = "println_adds_single_newline"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    println("hi");
+    0
+}
+""" }]
+stdout = "hi\n"
+
+[[case]]
+name = "println_composed_with_to_string_and_concat"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    println("value is " + @to_string(42));
+    0
+}
+""" }]
+stdout = "value is 42\n"
+
+[[case]]
+name = "print_empty_and_println_empty"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    print("");
+    println("");
+    print("end");
+    0
+}
+""" }]
+stdout = "\nend"
+
+[[case]]
+name = "print_borrows_string_reusable_after_call"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut s = String::new();
+    s.push_str("built ");
+    s.push_str("string");
+    print(s);
+    print(s);
+    println(s);
+    0
+}
+""" }]
+stdout = "built stringbuilt stringbuilt string\n"
+
+[[case]]
+name = "print_utf8_bytes_verbatim"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    println("café");
+    0
+}
+""" }]
+# café = 63 61 66 c3 a9, then a newline — the raw UTF-8 bytes, unmodified.
+stdout = "café\n"
+
+[[case]]
+name = "user_defined_print_shadows_builtin"
+files = [{ path = "main.rue", source = """
+fn print(x: i32) -> i32 { x + 1 }
+
+fn main() -> i32 {
+    print(41)
+}
+""" }]
+exit_code = 42

--- a/crates/rue-runtime/src/io.rs
+++ b/crates/rue-runtime/src/io.rs
@@ -2,10 +2,88 @@
 //!
 //! This module provides I/O operations for Rue programs:
 //! - `__rue_read_line` - Read a line from standard input
+//! - `__rue_print` - Write a String's raw bytes to stdout (no newline)
+//! - `__rue_println` - Write a String's raw bytes to stdout, then a newline
 
 use crate::heap;
 use crate::platform;
 use crate::string::{STRING_MIN_CAPACITY, StringResult};
+
+// =============================================================================
+// String output (RUE-1: print / println)
+// =============================================================================
+//
+// `print(s)` and `println(s)` write the raw bytes of a `String` to stdout via
+// the same `write(1, ptr, len)` syscall path `@dbg` uses, but they emit the
+// string's actual bytes rather than a debug format. Unlike `@dbg`, `print`
+// adds nothing and `println` adds exactly one `\n`.
+//
+// The String argument is passed by borrow, flattened into three ABI slots
+// (ptr, len, cap) exactly like the borrowed operands of `s1 + s2` and the
+// arguments to `s.contains(needle)`. `cap` is part of the ABI but unused here:
+// output only needs the pointer and length, and the borrow means neither
+// function takes ownership, so the caller's String stays valid and is dropped
+// by its owner as usual.
+
+crate::define_for_all_platforms! {
+    /// Write a String's raw bytes to stdout with no trailing newline.
+    ///
+    /// Called by the `print(s: String)` builtin free function (RUE-1). Writes
+    /// exactly `len` bytes starting at `ptr` to file descriptor 1.
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_print(ptr: *const u8, len: u64, cap: u64)
+    /// ```
+    ///
+    /// - `ptr` / `len` / `cap` are the flattened fields of a borrowed String
+    ///   (first three argument registers). `cap` is unused.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `ptr` points to `len` valid, initialized bytes
+    /// that remain valid for the duration of the call. The borrow ABI
+    /// guarantees this: the String is not consumed and outlives the call.
+    #[allow(non_snake_case)]
+    pub extern "C" fn __rue_print(ptr: *const u8, len: u64, _cap: u64) {
+        // SAFETY: `ptr` points to `len` valid bytes owned by the caller's
+        // String (borrowed, not consumed), and we only read from the slice.
+        let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
+        platform::write_stdout(bytes);
+    }
+}
+
+crate::define_for_all_platforms! {
+    /// Write a String's raw bytes to stdout followed by a single newline.
+    ///
+    /// Called by the `println(s: String)` builtin free function (RUE-1). Writes
+    /// exactly `len` bytes starting at `ptr` to file descriptor 1, then a lone
+    /// `\n`.
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_println(ptr: *const u8, len: u64, cap: u64)
+    /// ```
+    ///
+    /// - `ptr` / `len` / `cap` are the flattened fields of a borrowed String
+    ///   (first three argument registers). `cap` is unused.
+    ///
+    /// # Safety
+    ///
+    /// See [`__rue_print`].
+    #[allow(non_snake_case)]
+    pub extern "C" fn __rue_println(ptr: *const u8, len: u64, _cap: u64) {
+        // SAFETY: see `__rue_print` — `ptr` is valid for `len` borrowed bytes.
+        let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
+        platform::write_stdout(bytes);
+        // Byte-array literal (not `b"\n"`) to avoid a macOS linker quirk seen
+        // with `b"..."` in `__rue_dbg_str`.
+        let newline = [b'\n'];
+        platform::write_stdout(&newline);
+    }
+}
 
 /// Initial buffer size for reading lines.
 /// This is a reasonable size for most interactive input.

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -878,3 +878,71 @@ fn main() -> i32 {
 """
 exit_code = 0
 expected_stdout = "true\ntrue\n5\n"
+
+# --- Output: print / println (RUE-1) ---
+
+[[case]]
+name = "print_writes_bytes_without_newline"
+spec = ["3.7:35", "3.7:37"]
+source = """
+fn main() -> i32 {
+    print("hello");
+    print(" world");
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "hello world"
+
+[[case]]
+name = "println_appends_single_newline"
+spec = ["3.7:36", "3.7:37"]
+source = """
+fn main() -> i32 {
+    println("hi");
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "hi\n"
+
+[[case]]
+name = "println_composes_with_to_string_and_concat"
+spec = ["3.7:36"]
+source = """
+fn main() -> i32 {
+    println("value is " + @to_string(42));
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "value is 42\n"
+
+[[case]]
+name = "print_empty_writes_nothing_println_empty_writes_newline"
+spec = ["3.7:37"]
+source = """
+fn main() -> i32 {
+    print("");
+    println("");
+    print("end");
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "\nend"
+
+[[case]]
+name = "print_borrows_argument_string"
+spec = ["3.7:35"]
+source = """
+fn main() -> i32 {
+    let s = "reused";
+    print(s);
+    print(s);
+    @dbg(s.len());
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "reusedreused6\n"

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -207,6 +207,42 @@ fn main() -> i32 {
 }
 ```
 
+## Output
+
+{{ rule(id="3.7:35", cat="normative") }}
+
+The free function `print(s)` takes a `String` and writes its raw bytes to
+standard output, adding nothing. Unlike `@dbg`, it does not append a newline and
+does not apply any debug formatting. The argument `s` is borrowed, not consumed,
+and remains usable afterwards.
+
+{{ rule(id="3.7:36", cat="normative") }}
+
+The free function `println(s)` takes a `String` and writes its raw bytes to
+standard output followed by a single newline (`U+000A`). The argument `s` is
+borrowed, not consumed. Together with `@to_string` and `+`, `println` composes
+line-oriented output; there is no formatting or interpolation syntax.
+
+{{ rule(id="3.7:37", cat="dynamic-semantics") }}
+
+`print(s)` and `println(s)` write exactly the bytes of `s`, in order, without
+transformation: because a `String` is a byte string, the output is byte-for-byte
+identical to the string's contents (the only difference between the two is the
+single trailing newline `println` adds). Writing an empty `String` writes no
+bytes (for `print`) or a lone newline (for `println`).
+
+{{ rule(id="3.7:38") }}
+
+```rue
+fn main() -> i32 {
+    print("hello");                       // hello
+    print(" world");                      // hello world   (no newline yet)
+    println("");                          // hello world\n
+    println("value is " + @to_string(42)); // value is 42\n
+    0
+}
+```
+
 ## Search
 
 {{ rule(id="3.7:28", cat="normative") }}

--- a/e1.rue
+++ b/e1.rue
@@ -1,0 +1,3 @@
+enum E{A,B
+ fn f(self)->i32{1} }
+fn main()->i32{ E::A.f() }

--- a/lc.rue
+++ b/lc.rue
@@ -1,0 +1,1 @@
+fn main()->i32{ const C: i32 = 5; C }


### PR DESCRIPTION
Adds print(s: String) / println(s: String) — real output beyond @dbg. Modeled on the @to_string / String-concat freestanding-runtime-op pattern: sema lowers print/println to an extern C call to __rue_print/__rue_println reusing the String-flattening call convention — the String is passed by BORROW (not consumed). Zero codegen changes; both backends. Option a per Steve (plain String args; formatting deferred).

Verified: print('hello'); print(' world') -> 'hello world' (no newline); println('hi') -> 'hi\n'; println('value is ' + @to_string(42)) -> 'value is 42\n'; borrow confirmed (reused var); UTF-8 café verbatim; user fn print shadows builtin. aarch64 asm correct.

clippy-gate-passed; test.sh green (639/639); diff-fuzzer 0 disagreements. 7 CLI + 5 spec cases + a spec Output section.

Part of RUE-1

Generated with Claude Code