### PR TITLE
Harden borrow/inout of a module const: SIGABRT -> clean diagnostic (part of RUE-52)

### DIFF
--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -385,3 +385,30 @@ fn f(comptime T: type, x: T) -> T { x }
 fn main() -> i32 { f(i32, 5) }
 """ }]
 exit_code = 5
+
+[[case]]
+name = "borrow_const_not_lvalue_rue52"
+description = "RUE-52: `borrow CONST` reached codegen as an immediate `Const` and hit panic!(\"by-ref argument must be a place\") in byref_args -> SIGABRT. Now a clean E0427."
+files = [{ path = "main.rue", source = """
+const C: i32 = 5;
+fn take(borrow v: i32) -> i32 { v }
+fn main() -> i32 {
+    take(borrow C)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0427", "borrow argument must be"]
+
+[[case]]
+name = "inout_const_not_lvalue_rue52"
+description = "RUE-52: `inout CONST` reached codegen as an immediate `Const` and hit panic!(\"by-ref argument must be a place\") in byref_args -> SIGABRT. Now a clean E0425."
+files = [{ path = "main.rue", source = """
+const C: i32 = 5;
+fn bump(inout v: i32) { v = v + 1; }
+fn main() -> i32 {
+    bump(inout C);
+    C
+}
+""" }]
+compile_fail = true
+error_contains = ["E0425", "inout argument must be"]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -10,6 +10,7 @@ use rue_air::{StructId, TypeInternPool, TypeKind};
 use rue_cfg::{
     BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator, Type,
 };
+use rue_error::{CompileError, CompileResult};
 use rue_target::Target;
 
 use super::mir::{Aarch64Inst, Aarch64Mir, Cond, LabelId, Operand, Reg, VReg};
@@ -68,6 +69,11 @@ pub struct CfgLower<'a> {
     /// For inout params, the slot contains a pointer to the caller's memory.
     /// This map stores the vreg holding that pointer so Store can use it.
     inout_param_ptrs: HashMap<u32, VReg>,
+    /// First user-facing diagnostic recorded during lowering (RUE-52). Lowering
+    /// is infallible for speed; a by-ref argument with no addressable storage
+    /// (a `const` folded to an immediate) records its error here and `lower()`
+    /// surfaces it instead of the process aborting.
+    deferred_error: Option<CompileError>,
 }
 
 impl<'a> CfgLower<'a> {
@@ -100,6 +106,7 @@ impl<'a> CfgLower<'a> {
             fn_name: cfg.fn_name(),
             struct_slot_vregs: HashMap::with_capacity(estimated_struct_inits),
             inout_param_ptrs: HashMap::with_capacity(estimated_inout_params),
+            deferred_error: None,
         }
     }
 
@@ -312,7 +319,7 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Lower CFG to Aarch64Mir.
-    pub fn lower(mut self) -> Aarch64Mir {
+    pub fn lower(mut self) -> CompileResult<Aarch64Mir> {
         // Pre-allocate vregs for block parameters
         for block in self.ctx.cfg.blocks() {
             for (param_idx, (param_val, ty)) in block.params.iter().enumerate() {
@@ -351,7 +358,10 @@ impl<'a> CfgLower<'a> {
             self.lower_block(block);
         }
 
-        self.mir
+        if let Some(err) = self.deferred_error.take() {
+            return Err(err);
+        }
+        Ok(self.mir)
     }
 
     /// Lower CFG to Aarch64Mir with debug information about instruction selection.
@@ -1587,7 +1597,11 @@ impl<'a> CfgLower<'a> {
                     // element (RUE-143). Single shared implementation — see
                     // crate::byref_args.
                     if arg.is_by_ref() {
-                        let addr_vreg = crate::byref_args::lower_byref_arg_addr(self, arg_value);
+                        let addr_vreg = crate::byref_args::lower_byref_arg_addr(
+                            self,
+                            arg_value,
+                            arg.is_inout(),
+                        );
                         flattened_vregs.push(addr_vreg);
                         continue;
                     }
@@ -4537,6 +4551,9 @@ impl crate::byref_args::ByrefAddrBackend for CfgLower<'_> {
             imm: offset,
         });
     }
+    fn record_deferred_error(&mut self, err: CompileError) {
+        self.deferred_error.get_or_insert(err);
+    }
 }
 
 #[cfg(test)]
@@ -4574,7 +4591,9 @@ mod tests {
         );
 
         // Use host target for tests
-        CfgLower::new(&cfg_output.cfg, type_pool, &interner, Target::host()).lower()
+        CfgLower::new(&cfg_output.cfg, type_pool, &interner, Target::host())
+            .lower()
+            .expect("test lowering should succeed")
     }
 
     #[test]

--- a/crates/rue-codegen/src/aarch64/mod.rs
+++ b/crates/rue-codegen/src/aarch64/mod.rs
@@ -56,7 +56,7 @@ pub fn generate(
         crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner, target).lower();
+    let mir = CfgLower::new(cfg, type_pool, interner, target).lower()?;
 
     // Allocate physical registers
     // Spill slots go after locals, parameters AND the sret pointer slot to avoid conflicts
@@ -113,7 +113,7 @@ pub fn generate_with_asm(
         crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner, target).lower();
+    let mir = CfgLower::new(cfg, type_pool, interner, target).lower()?;
 
     // Allocate physical registers
     let existing_slots = num_locals + num_params + has_sret as u32;
@@ -171,7 +171,7 @@ pub fn generate_regalloc_info(
         crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner, target).lower();
+    let mir = CfgLower::new(cfg, type_pool, interner, target).lower()?;
 
     // Allocate physical registers with debug info
     let existing_slots = num_locals + num_params + has_sret as u32;

--- a/crates/rue-codegen/src/byref_args.rs
+++ b/crates/rue-codegen/src/byref_args.rs
@@ -21,6 +21,7 @@
 //! offsets descend per the ABI convention — caller slots grow downward.
 
 use rue_cfg::{CfgInstData, CfgValue, Place, Projection};
+use rue_error::{CompileError, ErrorKind};
 
 use crate::agg_slots::SlotBackend;
 use crate::vreg::VReg;
@@ -36,30 +37,59 @@ pub trait ByrefAddrBackend: SlotBackend {
     /// Emit `dst = address of frame slot` (`lea dst, [rbp+off]` /
     /// `add dst, fp, #off`).
     fn emit_frame_addr(&mut self, dst: VReg, slot: u32);
+
+    /// Record a user-facing diagnostic discovered during the (infallible)
+    /// lowering pass, to be surfaced by `generate()` once lowering finishes.
+    /// Only the FIRST recorded error is kept. See [`lower_byref_arg_addr`].
+    fn record_deferred_error(&mut self, err: CompileError);
 }
 
 /// Lower a by-ref (inout/borrow) call argument to the vreg holding its
 /// address.
 ///
-/// Sema guarantees the argument is a place: a variable (`Load`/`Param`) or a
-/// field/index projection chain rooted at one (`PlaceRead`). Anything else is
-/// a compiler bug, hence the panic.
-pub fn lower_byref_arg_addr<B: ByrefAddrBackend + ?Sized>(b: &mut B, arg_value: CfgValue) -> VReg {
+/// Sema accepts as a by-ref argument a place: a variable (`Load`/`Param`) or a
+/// field/index projection chain rooted at one (`PlaceRead`). A non-place value
+/// with no storage to address — most reachably a `const` folded to an
+/// immediate, which sema currently lets slip through as a bare identifier
+/// (RUE-52) — records a clean diagnostic (`inout`/`borrow` argument must be an
+/// lvalue) via [`ByrefAddrBackend::record_deferred_error`] and falls back to a
+/// dummy vreg so lowering finishes before `generate()` surfaces the error,
+/// rather than aborting the process.
+pub fn lower_byref_arg_addr<B: ByrefAddrBackend + ?Sized>(
+    b: &mut B,
+    arg_value: CfgValue,
+    is_inout: bool,
+) -> VReg {
     // Extract the small Copy payload first so the CFG borrow ends before we
     // emit (emission needs `&mut B`).
     enum ArgShape {
         Local(u32),
         Param(u32),
         Place(Place),
+        NotAPlace,
     }
+    // The argument span, captured (Copy) before the match so the borrow of the
+    // CFG ends and a diagnostic can carry a source location.
+    let arg_span = b.ctx().cfg.get_inst(arg_value).span;
     let shape = match &b.ctx().cfg.get_inst(arg_value).data {
         CfgInstData::Load { slot } => ArgShape::Local(*slot),
         CfgInstData::Param { index } => ArgShape::Param(*index),
         CfgInstData::PlaceRead { place } => ArgShape::Place(*place),
-        other => panic!("by-ref argument must be a place, not {:?}", other),
+        _ => ArgShape::NotAPlace,
     };
 
     match shape {
+        ArgShape::NotAPlace => {
+            let kind = if is_inout {
+                ErrorKind::InoutNonLvalue
+            } else {
+                ErrorKind::BorrowNonLvalue
+            };
+            b.record_deferred_error(CompileError::new(kind, arg_span));
+            // Dead value: the whole codegen result is discarded once the
+            // deferred error is surfaced, but lowering must produce SOME vreg.
+            b.alloc_vreg()
+        }
         ArgShape::Local(slot) => {
             let addr_vreg = b.alloc_vreg();
             b.emit_frame_addr(addr_vreg, slot);

--- a/crates/rue-codegen/src/stack_frame.rs
+++ b/crates/rue-codegen/src/stack_frame.rs
@@ -286,7 +286,7 @@ fn generate_x86_64_stack_frame(
     let sret_slots = has_sret as u32;
 
     // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, interner).lower()?;
 
     // Allocate physical registers (may add spill slots)
     let existing_slots = num_locals + num_params + sret_slots;
@@ -434,7 +434,7 @@ fn generate_aarch64_stack_frame(
     let sret_slots = has_sret as u32;
 
     // Lower CFG to Aarch64Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner, target).lower();
+    let mir = CfgLower::new(cfg, type_pool, interner, target).lower()?;
 
     // Allocate physical registers (may add spill slots)
     let existing_slots = num_locals + num_params + sret_slots;

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -33,6 +33,7 @@ use rue_builtins::BinOp;
 use rue_cfg::{
     BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator, Type,
 };
+use rue_error::{CompileError, CompileResult};
 
 use super::mir::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
 use crate::cfg_lower::{CfgLowerContext, IndexLevel};
@@ -76,6 +77,11 @@ pub struct CfgLower<'a> {
     /// For inout params, the slot contains a pointer to the caller's memory.
     /// This map stores the vreg holding that pointer so Store can use it.
     inout_param_ptrs: HashMap<u32, VReg>,
+    /// First user-facing diagnostic recorded during lowering (RUE-52). Lowering
+    /// is infallible for speed; a by-ref argument with no addressable storage
+    /// (a `const` folded to an immediate) records its error here and `lower()`
+    /// surfaces it instead of the process aborting.
+    deferred_error: Option<CompileError>,
 }
 
 impl<'a> CfgLower<'a> {
@@ -103,6 +109,7 @@ impl<'a> CfgLower<'a> {
             fn_name: cfg.fn_name(),
             struct_slot_vregs: HashMap::with_capacity(estimated_struct_inits),
             inout_param_ptrs: HashMap::with_capacity(estimated_inout_params),
+            deferred_error: None,
         }
     }
 
@@ -486,7 +493,7 @@ impl<'a> CfgLower<'a> {
     }
 
     /// Lower CFG to X86Mir.
-    pub fn lower(mut self) -> X86Mir {
+    pub fn lower(mut self) -> CompileResult<X86Mir> {
         // Pre-allocate vregs for block parameters
         for block in self.ctx.cfg.blocks() {
             for (param_idx, (param_val, ty)) in block.params.iter().enumerate() {
@@ -522,7 +529,10 @@ impl<'a> CfgLower<'a> {
             self.lower_block(block);
         }
 
-        self.mir
+        if let Some(err) = self.deferred_error.take() {
+            return Err(err);
+        }
+        Ok(self.mir)
     }
 
     /// Lower CFG to X86Mir with debug information about instruction selection.
@@ -1922,7 +1932,11 @@ impl<'a> CfgLower<'a> {
                     // element (RUE-143). Single shared implementation — see
                     // crate::byref_args.
                     if arg.is_by_ref() {
-                        let addr_vreg = crate::byref_args::lower_byref_arg_addr(self, arg_value);
+                        let addr_vreg = crate::byref_args::lower_byref_arg_addr(
+                            self,
+                            arg_value,
+                            arg.is_inout(),
+                        );
                         flattened_vregs.push(addr_vreg);
                         continue;
                     }
@@ -4511,6 +4525,9 @@ impl crate::byref_args::ByrefAddrBackend for CfgLower<'_> {
             disp: offset,
         });
     }
+    fn record_deferred_error(&mut self, err: CompileError) {
+        self.deferred_error.get_or_insert(err);
+    }
 }
 
 #[cfg(test)]
@@ -4547,7 +4564,9 @@ mod tests {
             &interner,
         );
 
-        CfgLower::new(&cfg_output.cfg, type_pool, &interner).lower()
+        CfgLower::new(&cfg_output.cfg, type_pool, &interner)
+            .lower()
+            .expect("test lowering should succeed")
     }
 
     #[test]

--- a/crates/rue-codegen/src/x86_64/mod.rs
+++ b/crates/rue-codegen/src/x86_64/mod.rs
@@ -54,7 +54,7 @@ pub fn generate(
         crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
 
     // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, interner).lower()?;
 
     // Allocate physical registers (may add spill slots)
     // Spill slots go after locals, parameters AND the sret pointer slot to avoid conflicts
@@ -113,7 +113,7 @@ pub fn generate_with_asm(
         crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
 
     // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, interner).lower()?;
 
     // Allocate physical registers (may add spill slots)
     let existing_slots = num_locals + num_params + has_sret as u32;
@@ -170,7 +170,7 @@ pub fn generate_regalloc_info(
         crate::cfg_lower::fn_uses_sret_return(cfg, type_pool, cfg_lower::RET_REGS.len() as u32);
 
     // Lower CFG to X86Mir with virtual registers
-    let mir = CfgLower::new(cfg, type_pool, interner).lower();
+    let mir = CfgLower::new(cfg, type_pool, interner).lower()?;
 
     // Allocate physical registers with debug info
     let existing_slots = num_locals + num_params + has_sret as u32;

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -1613,15 +1613,16 @@ pub fn generate_mir(
     type_pool: &TypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,
-) -> Mir {
+) -> CompileResult<Mir> {
     match target.arch() {
         Arch::X86_64 => {
-            let mir = rue_codegen::x86_64::CfgLower::new(cfg, type_pool, interner).lower();
-            Mir::X86_64(mir)
+            let mir = rue_codegen::x86_64::CfgLower::new(cfg, type_pool, interner).lower()?;
+            Ok(Mir::X86_64(mir))
         }
         Arch::Aarch64 => {
-            let mir = rue_codegen::aarch64::CfgLower::new(cfg, type_pool, interner, target).lower();
-            Mir::Aarch64(mir)
+            let mir =
+                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, interner, target).lower()?;
+            Ok(Mir::Aarch64(mir))
         }
     }
 }
@@ -1643,7 +1644,7 @@ pub fn generate_allocated_mir(
     match target.arch() {
         Arch::X86_64 => {
             // Lower CFG to X86Mir with virtual registers
-            let mir = rue_codegen::x86_64::CfgLower::new(cfg, type_pool, interner).lower();
+            let mir = rue_codegen::x86_64::CfgLower::new(cfg, type_pool, interner).lower()?;
 
             // Allocate physical registers
             let (mir, _num_spills, _used_callee_saved) =
@@ -1653,7 +1654,8 @@ pub fn generate_allocated_mir(
         }
         Arch::Aarch64 => {
             // Lower CFG to Aarch64Mir with virtual registers
-            let mir = rue_codegen::aarch64::CfgLower::new(cfg, type_pool, interner, target).lower();
+            let mir =
+                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, interner, target).lower()?;
 
             // Allocate physical registers
             let (mir, _num_spills, _used_callee_saved) =
@@ -1675,15 +1677,16 @@ pub fn generate_liveness_info(
     type_pool: &TypeInternPool,
     interner: &ThreadedRodeo,
     target: Target,
-) -> rue_codegen::LivenessDebugInfo {
+) -> CompileResult<rue_codegen::LivenessDebugInfo> {
     match target.arch() {
         Arch::X86_64 => {
-            let mir = rue_codegen::x86_64::CfgLower::new(cfg, type_pool, interner).lower();
-            rue_codegen::x86_64::liveness::analyze_debug(&mir)
+            let mir = rue_codegen::x86_64::CfgLower::new(cfg, type_pool, interner).lower()?;
+            Ok(rue_codegen::x86_64::liveness::analyze_debug(&mir))
         }
         Arch::Aarch64 => {
-            let mir = rue_codegen::aarch64::CfgLower::new(cfg, type_pool, interner, target).lower();
-            rue_codegen::aarch64::liveness::analyze_debug(&mir)
+            let mir =
+                rue_codegen::aarch64::CfgLower::new(cfg, type_pool, interner, target).lower()?;
+            Ok(rue_codegen::aarch64::liveness::analyze_debug(&mir))
         }
     }
 }

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -1268,12 +1268,18 @@ fn handle_emit_multi_file(
                 println!("=== MIR ({}) ===", options.target);
                 if let Some(ref state) = frontend_state {
                     for func in &state.functions {
-                        let mir = generate_mir(
+                        let mir = match generate_mir(
                             &func.cfg,
                             &state.type_pool,
                             &state.interner,
                             options.target,
-                        );
+                        ) {
+                            Ok(mir) => mir,
+                            Err(e) => {
+                                eprintln!("{}", formatter.format_error(&e));
+                                return Err(());
+                            }
+                        };
                         println!("function {}:", func.analyzed.name);
                         println!("{}", mir);
                     }
@@ -1285,12 +1291,18 @@ fn handle_emit_multi_file(
                 if let Some(ref state) = frontend_state {
                     for func in &state.functions {
                         println!("function {}:", func.analyzed.name);
-                        let liveness_info = generate_liveness_info(
+                        let liveness_info = match generate_liveness_info(
                             &func.cfg,
                             &state.type_pool,
                             &state.interner,
                             options.target,
-                        );
+                        ) {
+                            Ok(info) => info,
+                            Err(e) => {
+                                eprintln!("{}", formatter.format_error(&e));
+                                return Err(());
+                            }
+                        };
                         println!("{}", liveness_info);
                     }
                 }


### PR DESCRIPTION
A by-ref argument (borrow C / inout C) where C is a module const hit panic!("by-ref argument must be a place") in codegen — sema accepts a bare const as a by-ref arg but a const has no address, so it aborted the process (SIGABRT) instead of diagnosing. Exactly the reachable-panic class RUE-52 targets.

Fix: the shared lower_byref_arg_addr now records a deferred diagnostic (E0427 borrow, E0425 inout, with span) instead of panicking; both backends' CfgLower::lower() return CompileResult, surfacing the error through generate() and all --emit paths. Threaded through mod.rs / stack_frame.rs / rue-compiler / main.rs. Covers x86-64 and aarch64.

Verified by execution: borrow C / inout C -> exit 1 with a clean E0427/E0425 (no SIGABRT); --emit mir/liveness/asm/regalloc clean; aarch64 via --emit asm; neighbors still compile+run. clippy-gate-passed; test.sh green; 2 ICE-corpus regression cases.

Follow-ups noted separately: const-as-by-ref should ideally be rejected in sema (RUE-7); a possible O(n^2) on very large array literals.

Part of RUE-52

Generated with Claude Code