### PR TITLE
Structural equality across structs, arrays, and enums + spec stance + oracle (RUE-285)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -5053,17 +5053,21 @@ impl<'a> Sema<'a> {
 
         // Validate the type is appropriate for this comparison
         if allow_bool {
-            // Equality operators (==, !=) work on integers, booleans, strings, unit, and structs
-            // Note: String is now a struct, so is_struct() covers it
+            // Equality operators (==, !=) are structural over aggregates
+            // (RUE-285): they work on integers, booleans, strings, unit, and
+            // any struct, array, or enum (whose leaves bottom out at these).
+            // Note: String is now a struct, so is_struct() covers it.
             if !lhs_type.is_integer()
                 && lhs_type != Type::BOOL
                 && lhs_type != Type::UNIT
                 && !lhs_type.is_struct()
+                && !lhs_type.is_array()
+                && !lhs_type.is_enum()
                 && !self.is_builtin_string(lhs_type)
             {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
-                        expected: "integer, bool, string, unit, or struct".to_string(),
+                        expected: "integer, bool, string, unit, struct, array, or enum".to_string(),
                         found: lhs_type.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     self.rir.get(lhs).span,

--- a/crates/rue-cli-tests/cases/aggregate_equality.toml
+++ b/crates/rue-cli-tests/cases/aggregate_equality.toml
@@ -1,0 +1,71 @@
+# Structural equality across aggregates (RUE-285): `==` / `!=` on structs,
+# arrays, and enums compares field-by-field / element-by-element / same-variant.
+# Runtime-visible via @dbg so the exact result of each comparison is asserted
+# (not just the process exit code). Also guards the old nested-struct bug where
+# only the first slot of a multi-slot field was compared.
+
+[section]
+id = "cli.aggregate_equality"
+name = "Structural equality across aggregates"
+description = "== / != on structs (incl. nested), arrays, and enums is structural (RUE-285)."
+
+[[case]]
+name = "aggregate_equality_structural"
+description = "Each comparison prints 1: struct ==/!=, nested struct-of-struct (deep field), array ==/!=, C-like enum ==/!=."
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+struct Line { a: Point, b: Point }
+enum Color { Red, Green, Blue }
+
+fn main() -> i32 {
+    let p1 = Point { x: 1, y: 2 };
+    let p2 = Point { x: 1, y: 2 };
+    let p3 = Point { x: 1, y: 3 };
+    @dbg(if p1 == p2 { 1 } else { 0 });
+    @dbg(if p1 != p3 { 1 } else { 0 });
+
+    // Nested struct: l1 and l3 differ only in b.y, a non-first slot of the
+    // nested `b` field — the old bug compared only slot 0 and missed it.
+    let l1 = Line { a: Point { x: 1, y: 2 }, b: Point { x: 3, y: 4 } };
+    let l2 = Line { a: Point { x: 1, y: 2 }, b: Point { x: 3, y: 4 } };
+    let l3 = Line { a: Point { x: 1, y: 2 }, b: Point { x: 3, y: 5 } };
+    @dbg(if l1 == l2 { 1 } else { 0 });
+    @dbg(if l1 != l3 { 1 } else { 0 });
+
+    let arr1 = [10, 20, 30];
+    let arr2 = [10, 20, 30];
+    let arr3 = [10, 99, 30];
+    @dbg(if arr1 == arr2 { 1 } else { 0 });
+    @dbg(if arr1 != arr3 { 1 } else { 0 });
+
+    @dbg(if Color::Red == Color::Red { 1 } else { 0 });
+    @dbg(if Color::Red != Color::Green { 1 } else { 0 });
+    0
+}
+""" }]
+stdout = "1\n1\n1\n1\n1\n1\n1\n1\n"
+exit_code = 0
+
+[[case]]
+name = "aggregate_equality_borrows_operands"
+description = "== borrows its operands: a struct and an array are still usable after being compared (no move)."
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let p = Point { x: 4, y: 5 };
+    let q = Point { x: 4, y: 5 };
+    let eq = p == q;              // borrows p and q
+    @dbg(if eq { 1 } else { 0 }); // 1
+    @dbg(p.x + q.y);             // 9 — p and q still usable
+
+    let a = [1, 2, 3];
+    let b = [1, 2, 3];
+    let ae = a == b;             // borrows a and b
+    @dbg(if ae { 1 } else { 0 }); // 1
+    @dbg(a[0] + b[2]);           // 4 — a and b still usable
+    0
+}
+""" }]
+stdout = "1\n9\n1\n4\n"
+exit_code = 0

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
-use rue_air::{StructId, TypeInternPool, TypeKind};
+use rue_air::{TypeInternPool, TypeKind};
 use rue_cfg::{
     BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator, Type,
 };
@@ -1027,9 +1027,10 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         imm: 1,
                     });
-                } else if let Some(struct_id) = lhs_ty.as_struct() {
-                    // Struct equality: compare all fields
-                    self.emit_struct_equality(value, *lhs, *rhs, struct_id, false);
+                } else if self.ctx.is_multislot_aggregate(lhs_ty) {
+                    // Structural equality: compare every slot (struct fields,
+                    // array elements, or an enum's tag + payload). (RUE-285)
+                    self.emit_aggregate_equality(value, *lhs, *rhs, lhs_ty, false);
                 } else {
                     self.emit_comparison(value, *lhs, *rhs, Cond::Eq);
                 }
@@ -1056,9 +1057,10 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         imm: 0,
                     });
-                } else if let Some(struct_id) = lhs_ty.as_struct() {
-                    // Struct inequality: compare all fields, invert result
-                    self.emit_struct_equality(value, *lhs, *rhs, struct_id, true);
+                } else if self.ctx.is_multislot_aggregate(lhs_ty) {
+                    // Structural inequality: compare every slot, invert result.
+                    // (RUE-285)
+                    self.emit_aggregate_equality(value, *lhs, *rhs, lhs_ty, true);
                 } else {
                     self.emit_comparison(value, *lhs, *rhs, Cond::Ne);
                 }
@@ -3502,30 +3504,33 @@ impl<'a> CfgLower<'a> {
     ///
     /// Compares all fields of two structs and returns true only if all fields are equal.
     /// If `invert` is true, returns true if any field is different (for !=).
-    fn emit_struct_equality(
+    /// Structural equality (`==` / `!=`) for a multi-slot aggregate: struct,
+    /// fixed-size array, or a payload-carrying enum (RUE-285).
+    ///
+    /// The aggregate is flattened to one vreg per storage slot (via
+    /// [`get_or_compute_field_vregs`]); we compare every slot pairwise and AND
+    /// the results, so nested aggregates recurse for free. Each slot's compare
+    /// width is selected by its leaf type ([`types::aggregate_leaf_types`]) so
+    /// 64-bit leaves and raw pointers (which compare by ADDRESS) are compared at
+    /// full width. For an enum, slot 0 is the discriminant, so two different
+    /// variants are never equal and two same-variant values compare payloads
+    /// (padding beyond a variant's payload is a deterministic zero). Reading
+    /// each operand's slots does not consume it, so `==` borrows its operands.
+    fn emit_aggregate_equality(
         &mut self,
         value: CfgValue,
         lhs: CfgValue,
         rhs: CfgValue,
-        struct_id: StructId,
+        ty: Type,
         invert: bool,
     ) {
         let result_vreg = self.mir.alloc_vreg();
         self.value_map.insert(value, result_vreg);
 
-        // Get the struct field vregs
-        let lhs_fields = self
-            .get_or_compute_field_vregs(lhs)
-            .expect("struct should have field vregs");
-        let rhs_fields = self
-            .get_or_compute_field_vregs(rhs)
-            .expect("struct should have field vregs");
+        let leaf_types = types::aggregate_leaf_types(self.ctx.type_pool, ty);
 
-        let struct_def = self.ctx.type_pool.struct_def(struct_id);
-        let field_count = struct_def.fields.len();
-
-        if field_count == 0 {
-            // Empty struct: always equal
+        if leaf_types.is_empty() {
+            // Zero-slot aggregate (empty struct, zero-length array): always equal.
             self.mir.push(Aarch64Inst::MovImm {
                 dst: Operand::Virtual(result_vreg),
                 imm: if invert { 0 } else { 1 },
@@ -3533,32 +3538,36 @@ impl<'a> CfgLower<'a> {
             return;
         }
 
-        // Start with 1 (true), AND each field comparison result
+        // Flattened slot vregs, one per leaf.
+        let lhs_slots = self
+            .get_or_compute_field_vregs(lhs)
+            .expect("aggregate should have slot vregs");
+        let rhs_slots = self
+            .get_or_compute_field_vregs(rhs)
+            .expect("aggregate should have slot vregs");
+        debug_assert_eq!(lhs_slots.len(), leaf_types.len());
+        debug_assert_eq!(rhs_slots.len(), leaf_types.len());
+
+        // Start with 1 (true), AND each slot comparison result.
         self.mir.push(Aarch64Inst::MovImm {
             dst: Operand::Virtual(result_vreg),
             imm: 1,
         });
 
-        // Compare each field and AND with result
-        let mut field_slot = 0usize;
-        for field in &struct_def.fields {
-            let field_slots = self.ctx.type_slot_count(field.ty) as usize;
-            let lhs_field_vreg = lhs_fields[field_slot];
-            let rhs_field_vreg = rhs_fields[field_slot];
-
-            // Allocate a vreg for this field's comparison result
+        for (i, leaf_ty) in leaf_types.iter().enumerate() {
+            let lhs_slot_vreg = lhs_slots[i];
+            let rhs_slot_vreg = rhs_slots[i];
             let cmp_vreg = self.mir.alloc_vreg();
 
-            // Use 64-bit compare for i64/u64 types
-            if matches!(field.ty, Type::I64 | Type::U64) {
+            if types::slot_needs_wide_compare(*leaf_ty) {
                 self.mir.push(Aarch64Inst::Cmp64RR {
-                    src1: Operand::Virtual(lhs_field_vreg),
-                    src2: Operand::Virtual(rhs_field_vreg),
+                    src1: Operand::Virtual(lhs_slot_vreg),
+                    src2: Operand::Virtual(rhs_slot_vreg),
                 });
             } else {
                 self.mir.push(Aarch64Inst::CmpRR {
-                    src1: Operand::Virtual(lhs_field_vreg),
-                    src2: Operand::Virtual(rhs_field_vreg),
+                    src1: Operand::Virtual(lhs_slot_vreg),
+                    src2: Operand::Virtual(rhs_slot_vreg),
                 });
             }
             self.mir.push(Aarch64Inst::Cset {
@@ -3572,8 +3581,6 @@ impl<'a> CfgLower<'a> {
                 src1: Operand::Virtual(result_vreg),
                 src2: Operand::Virtual(cmp_vreg),
             });
-
-            field_slot += field_slots;
         }
 
         // Invert result if needed (for !=)

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -104,6 +104,88 @@ pub fn type_slot_count(type_pool: &TypeInternPool, ty: Type) -> u32 {
     }
 }
 
+/// Whether comparing a slot holding `ty` needs a full 64-bit compare.
+///
+/// Narrow scalars (i8..i32, bool) live in 32-bit-comparable slots; 64-bit
+/// integers and raw pointers must be compared at full width so two pointers or
+/// i64s that differ only in their high 32 bits are not judged equal. Raw
+/// pointers compare by ADDRESS (identity), which a 64-bit compare of the
+/// pointer value gives directly.
+pub fn slot_needs_wide_compare(ty: Type) -> bool {
+    matches!(
+        ty.kind(),
+        TypeKind::I64 | TypeKind::U64 | TypeKind::PtrConst(_) | TypeKind::PtrMut(_)
+    )
+}
+
+/// Flatten an aggregate type into the list of leaf types, one entry per storage
+/// slot, in slot order. The length equals [`type_slot_count`].
+///
+/// This drives structural equality (RUE-285): a struct/array/payload-enum `==`
+/// compares every slot pairwise, and each slot's leaf type selects the compare
+/// width via [`slot_needs_wide_compare`].
+///
+/// Layout mirrors [`type_slot_count`]:
+/// - **struct**: fields in declaration order, each recursively flattened
+/// - **array**: the element leaf types repeated `length` times
+/// - **payload enum**: slot 0 is the discriminant (a narrow tag), followed by
+///   the payload area sized to the widest variant. For each payload slot we
+///   pick a representative leaf type that is wide if *any* variant places a
+///   wide leaf there, so a mixed `i64`/`i32` payload slot is compared at 64
+///   bits (narrow values are zero-extended in their slot, so a wide compare of
+///   a narrow value is still correct). Padding slots beyond every variant's
+///   payload are zero and compare as narrow.
+/// - **unit / never**: zero slots (no entries)
+pub fn aggregate_leaf_types(type_pool: &TypeInternPool, ty: Type) -> Vec<Type> {
+    let mut out = Vec::new();
+    push_leaf_types(type_pool, ty, &mut out);
+    out
+}
+
+fn push_leaf_types(type_pool: &TypeInternPool, ty: Type, out: &mut Vec<Type>) {
+    match ty.kind() {
+        TypeKind::Unit | TypeKind::Never => {}
+        TypeKind::Struct(struct_id) => {
+            let struct_def = type_pool.struct_def(struct_id);
+            for field in &struct_def.fields {
+                push_leaf_types(type_pool, field.ty, out);
+            }
+        }
+        TypeKind::Array(array_id) => {
+            let (element_type, length) = type_pool.array_def(array_id);
+            for _ in 0..length {
+                push_leaf_types(type_pool, element_type, out);
+            }
+        }
+        TypeKind::Enum(enum_id) => {
+            // Slot 0: the discriminant. Variant indices are small, and both the
+            // tag and any padding are materialized as clean (zero-extended)
+            // values, so a narrow compare of the tag is correct.
+            out.push(Type::I32);
+            // Payload area sized to the widest variant. For each slot position,
+            // prefer a wide leaf type if any variant carries one there.
+            let enum_def = type_pool.enum_def(enum_id);
+            let mut per_slot: Vec<Type> = Vec::new();
+            for v in 0..enum_def.variant_count() {
+                let mut variant_leaves: Vec<Type> = Vec::new();
+                for &pty in enum_def.variant_payload(v) {
+                    push_leaf_types(type_pool, pty, &mut variant_leaves);
+                }
+                for (i, leaf) in variant_leaves.into_iter().enumerate() {
+                    if i >= per_slot.len() {
+                        per_slot.push(leaf);
+                    } else if slot_needs_wide_compare(leaf) && !slot_needs_wide_compare(per_slot[i])
+                    {
+                        per_slot[i] = leaf;
+                    }
+                }
+            }
+            out.extend(per_slot);
+        }
+        _ => out.push(ty),
+    }
+}
+
 /// Slot offset of payload field `field_index` within an enum's payload area.
 ///
 /// The discriminant occupies slot 0, so payload fields begin at slot 1. This

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -28,7 +28,7 @@
 use std::collections::HashMap;
 
 use lasso::ThreadedRodeo;
-use rue_air::{StructId, TypeInternPool, TypeKind};
+use rue_air::{TypeInternPool, TypeKind};
 use rue_builtins::BinOp;
 use rue_cfg::{
     BasicBlock, BlockId, Cfg, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator, Type,
@@ -1516,9 +1516,10 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         imm: 1,
                     });
-                } else if let TypeKind::Struct(struct_id) = lhs_ty.kind() {
-                    // Struct equality: compare all fields
-                    self.emit_struct_equality(value, *lhs, *rhs, struct_id, false);
+                } else if self.ctx.is_multislot_aggregate(lhs_ty) {
+                    // Structural equality: compare every slot (struct fields,
+                    // array elements, or an enum's tag + payload). (RUE-285)
+                    self.emit_aggregate_equality(value, *lhs, *rhs, lhs_ty, false);
                 } else {
                     self.emit_comparison(value, *lhs, *rhs, |mir, vreg| {
                         mir.push(X86Inst::Sete {
@@ -1551,9 +1552,10 @@ impl<'a> CfgLower<'a> {
                         dst: Operand::Virtual(vreg),
                         imm: 0,
                     });
-                } else if let TypeKind::Struct(struct_id) = lhs_ty.kind() {
-                    // Struct inequality: compare all fields, invert result
-                    self.emit_struct_equality(value, *lhs, *rhs, struct_id, true);
+                } else if self.ctx.is_multislot_aggregate(lhs_ty) {
+                    // Structural inequality: compare every slot, invert result.
+                    // (RUE-285)
+                    self.emit_aggregate_equality(value, *lhs, *rhs, lhs_ty, true);
                 } else {
                     self.emit_comparison(value, *lhs, *rhs, |mir, vreg| {
                         mir.push(X86Inst::Setne {
@@ -3467,30 +3469,35 @@ impl<'a> CfgLower<'a> {
     ///
     /// Compares all fields of two structs and returns true only if all fields are equal.
     /// If `invert` is true, returns true if any field is different (for !=).
-    fn emit_struct_equality(
+    /// Structural equality (`==` / `!=`) for a multi-slot aggregate: struct,
+    /// fixed-size array, or a payload-carrying enum (RUE-285).
+    ///
+    /// The aggregate is flattened to one vreg per storage slot (via
+    /// [`get_or_compute_field_vregs`]); we compare every slot pairwise and AND
+    /// the results, so nested aggregates recurse for free (a nested struct or
+    /// array contributes all of its leaf slots). Each slot's compare width is
+    /// selected by its leaf type ([`types::aggregate_leaf_types`]) so 64-bit
+    /// leaves and raw pointers (which compare by ADDRESS) are compared at full
+    /// width. For an enum, slot 0 is the discriminant: two different variants
+    /// differ in the tag and are never equal; two same-variant values compare
+    /// their payloads (the padding beyond a variant's payload is a deterministic
+    /// zero, so it never spuriously distinguishes equal values). Reading each
+    /// operand's slots does not consume it, so `==` borrows its operands.
+    fn emit_aggregate_equality(
         &mut self,
         value: CfgValue,
         lhs: CfgValue,
         rhs: CfgValue,
-        struct_id: StructId,
+        ty: Type,
         invert: bool,
     ) {
         let result_vreg = self.mir.alloc_vreg();
         self.value_map.insert(value, result_vreg);
 
-        // Get the struct field vregs
-        let lhs_fields = self
-            .get_or_compute_field_vregs(lhs)
-            .expect("struct should have field vregs");
-        let rhs_fields = self
-            .get_or_compute_field_vregs(rhs)
-            .expect("struct should have field vregs");
+        let leaf_types = types::aggregate_leaf_types(self.ctx.type_pool, ty);
 
-        let struct_def = self.ctx.type_pool.struct_def(struct_id);
-        let field_count = struct_def.fields.len();
-
-        if field_count == 0 {
-            // Empty struct: always equal
+        if leaf_types.is_empty() {
+            // Zero-slot aggregate (empty struct, zero-length array): always equal.
             self.mir.push(X86Inst::MovRI32 {
                 dst: Operand::Virtual(result_vreg),
                 imm: if invert { 0 } else { 1 },
@@ -3498,32 +3505,36 @@ impl<'a> CfgLower<'a> {
             return;
         }
 
-        // Start with 1 (true), AND each field comparison result
+        // Flattened slot vregs, one per leaf.
+        let lhs_slots = self
+            .get_or_compute_field_vregs(lhs)
+            .expect("aggregate should have slot vregs");
+        let rhs_slots = self
+            .get_or_compute_field_vregs(rhs)
+            .expect("aggregate should have slot vregs");
+        debug_assert_eq!(lhs_slots.len(), leaf_types.len());
+        debug_assert_eq!(rhs_slots.len(), leaf_types.len());
+
+        // Start with 1 (true), AND each slot comparison result.
         self.mir.push(X86Inst::MovRI32 {
             dst: Operand::Virtual(result_vreg),
             imm: 1,
         });
 
-        // Compare each field and AND with result
-        let mut field_slot = 0usize;
-        for field in &struct_def.fields {
-            let field_slots = self.ctx.type_slot_count(field.ty) as usize;
-            let lhs_field_vreg = lhs_fields[field_slot];
-            let rhs_field_vreg = rhs_fields[field_slot];
-
-            // Allocate a vreg for this field's comparison result
+        for (i, leaf_ty) in leaf_types.iter().enumerate() {
+            let lhs_slot_vreg = lhs_slots[i];
+            let rhs_slot_vreg = rhs_slots[i];
             let cmp_vreg = self.mir.alloc_vreg();
 
-            // Use 64-bit compare for i64/u64 types
-            if matches!(field.ty.kind(), TypeKind::I64 | TypeKind::U64) {
+            if types::slot_needs_wide_compare(*leaf_ty) {
                 self.mir.push(X86Inst::Cmp64RR {
-                    src1: Operand::Virtual(lhs_field_vreg),
-                    src2: Operand::Virtual(rhs_field_vreg),
+                    src1: Operand::Virtual(lhs_slot_vreg),
+                    src2: Operand::Virtual(rhs_slot_vreg),
                 });
             } else {
                 self.mir.push(X86Inst::CmpRR {
-                    src1: Operand::Virtual(lhs_field_vreg),
-                    src2: Operand::Virtual(rhs_field_vreg),
+                    src1: Operand::Virtual(lhs_slot_vreg),
+                    src2: Operand::Virtual(rhs_slot_vreg),
                 });
             }
             self.mir.push(X86Inst::Sete {
@@ -3539,8 +3550,6 @@ impl<'a> CfgLower<'a> {
                 dst: Operand::Virtual(result_vreg),
                 src: Operand::Virtual(cmp_vreg),
             });
-
-            field_slot += field_slots;
         }
 
         // Invert result if needed (for !=)

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -379,28 +379,9 @@ fn check_spec_case(ident: &str, case: &rue_test_runner::Case, report: &mut Repor
 ///
 /// Entry: `(section-identifier, case-name, tracking-issue)`.
 const KNOWN_ORACLE_GAPS: &[(&str, &str, &str)] = &[
-    // RUE-285: aggregate ==/!= compares every struct/array as equal because
-    // `Value::as_int()` yields 0 for aggregates, instead of a field-wise compare.
-    (
-        "expressions/comparison",
-        "struct_equality_different_values",
-        "RUE-285",
-    ),
-    (
-        "expressions/comparison",
-        "struct_equality_inequality",
-        "RUE-285",
-    ),
-    (
-        "expressions/comparison",
-        "struct_equality_many_fields",
-        "RUE-285",
-    ),
-    (
-        "expressions/comparison",
-        "struct_with_bool_field_equality",
-        "RUE-285",
-    ),
+    // (empty) — RUE-285 fixed: the oracle now models structural ==/!= over
+    // structs, arrays, and payload enums, so the former aggregate-equality gaps
+    // run as normal three-way-agreement checks again.
 ];
 
 fn check_case(path: &Path, case: &Case, report: &mut Report) {

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -80,8 +80,10 @@ enum Value {
     Bool(bool),
     Unit,
     /// A struct or array value: its fields (declaration order) or elements
-    /// (ascending index). Enums are payload-less today, so an enum value is an
-    /// `Int` discriminant, not an aggregate.
+    /// (ascending index). A payload-carrying enum variant is also an
+    /// `Aggregate`: element 0 is the discriminant (`Int` tag), followed by the
+    /// variant's payload fields in declaration order (RUE-285). A
+    /// discriminant-only enum (or C-like enum) stays a bare `Int` tag.
     Aggregate(Vec<Value>),
     /// A `String`, modeled by its content only; the heap layout (ptr, len, cap)
     /// and capacity are implementation details the oracle abstracts over
@@ -269,7 +271,13 @@ impl<'a> Interp<'a> {
                     cases_len,
                     default,
                 } => {
-                    let s = self.eval(cfg, &mut frame, scrutinee)?.as_int();
+                    // The scrutinee is an integer, a discriminant-only enum
+                    // (`Int` tag), or a payload-carrying enum (`Aggregate` whose
+                    // element 0 is the tag, RUE-285). Switch on the discriminant.
+                    let s = match self.eval(cfg, &mut frame, scrutinee)? {
+                        Value::Aggregate(elems) => elems.first().map(Value::as_int).unwrap_or(0),
+                        other => other.as_int(),
+                    };
                     let cases = cfg.get_switch_cases(cases_start, cases_len);
                     // Case values are stored as i64 bit patterns; compare by the
                     // 64-bit pattern so unsigned extremes (u64::MAX -> -1 as i64)
@@ -518,19 +526,43 @@ impl<'a> Interp<'a> {
                 Self::set_agg_elem(frame, *slot, idx as usize, val)?;
                 Value::Unit
             }
-            CfgInstData::EnumVariant { variant_index, .. } => Value::Int(*variant_index as i128),
-
-            // Enum payloads (RUE-221) are a preview feature the oracle does not
-            // model yet — it represents an enum by its discriminant only. Return
-            // Unsupported (a clean skip) rather than a guessed value, so payload-
-            // bearing programs drop out of the differential path instead of
-            // reporting a false disagreement. (Proper modeling: RUE-221 oracle
-            // follow-up.)
-            CfgInstData::EnumPayloadGet { .. } => {
-                return Err(Flow::Unsupported(Unsupported(
-                    "enum payload get (RUE-221 preview)".into(),
-                )));
+            // A discriminant-only variant is its tag (an `Int`); a payload-
+            // carrying variant is an `Aggregate` whose element 0 is the tag and
+            // the rest are the payload fields, in declaration order (RUE-285).
+            // This lets structural `==` distinguish `Circle(5)` from `Circle(6)`
+            // and from `Square(5)`, and lets `EnumPayloadGet` project a field.
+            CfgInstData::EnumVariant {
+                variant_index,
+                payload_start,
+                payload_len,
+                ..
+            } => {
+                if *payload_len == 0 {
+                    Value::Int(*variant_index as i128)
+                } else {
+                    let payload_refs = cfg.get_extra(*payload_start, *payload_len).to_vec();
+                    let mut elems = Vec::with_capacity(1 + payload_refs.len());
+                    elems.push(Value::Int(*variant_index as i128));
+                    elems.extend(self.eval_all(cfg, frame, &payload_refs)?);
+                    Value::Aggregate(elems)
+                }
             }
+
+            // Read payload field `field_index` of a payload-carrying variant:
+            // element `1 + field_index` of the enum's `Aggregate` (element 0 is
+            // the discriminant). A discriminant-only enum never reaches here.
+            CfgInstData::EnumPayloadGet {
+                base, field_index, ..
+            } => match self.eval(cfg, frame, *base)? {
+                Value::Aggregate(mut elems) if (*field_index as usize) + 1 < elems.len() => {
+                    elems.swap_remove(*field_index as usize + 1)
+                }
+                _ => {
+                    return Err(Flow::Unsupported(Unsupported(
+                        "enum payload get on non-payload value".into(),
+                    )));
+                }
+            },
 
             // Writes to an `inout` parameter inside the callee (visible to the
             // caller via copy-out).
@@ -712,9 +744,23 @@ impl<'a> Interp<'a> {
     ) -> Step<Value> {
         let x = self.eval(cfg, frame, a)?;
         let y = self.eval(cfg, frame, b)?;
-        // Strings compare by content (String ==/!=); everything else by value.
+        // Strings compare by content (String ==/!=). Aggregates (structs,
+        // arrays, payload enums) compare STRUCTURALLY, field-by-field /
+        // element-by-element / same-variant-and-equal-payload, via `Value`'s
+        // derived `PartialEq` which recurses into nested aggregates (RUE-285).
+        // Only `==` / `!=` reach an aggregate here (ordering `< > <= >=` is a
+        // type error on aggregates), so we report `Equal` iff structurally
+        // equal and an arbitrary non-`Equal` ordering otherwise — enough for
+        // `pick` to decide `==`/`!=`. Everything else compares by integer value.
         let ord = match (&x, &y) {
             (Value::Str(sx), Value::Str(sy)) => sx.cmp(sy),
+            (Value::Aggregate(_), _) | (_, Value::Aggregate(_)) => {
+                if x == y {
+                    std::cmp::Ordering::Equal
+                } else {
+                    std::cmp::Ordering::Less
+                }
+            }
             _ => x.as_int().cmp(&y.as_int()),
         };
         Ok(Value::Bool(pick(ord)))

--- a/crates/rue-spec/cases/expressions/comparison.toml
+++ b/crates/rue-spec/cases/expressions/comparison.toml
@@ -274,3 +274,176 @@ fn main() -> i32 {
 }
 """
 exit_code = 1
+
+# =============================================================================
+# Array Equality (RUE-285): structural, element-by-element
+# =============================================================================
+
+[[case]]
+name = "array_equality_{variant}"
+spec = ["4.3:2", "4.3:3c"]
+source = """
+fn main() -> i32 {
+    let a = [{a0}, {a1}, {a2}];
+    let b = [{b0}, {b1}, {b2}];
+    if a {op} b { 1 } else { 0 }
+}
+"""
+params = [
+  { variant = "equal", a0 = "1", a1 = "2", a2 = "3", b0 = "1", b1 = "2", b2 = "3", op = "==", exit_code = 1 },
+  { variant = "different", a0 = "1", a1 = "2", a2 = "3", b0 = "1", b1 = "2", b2 = "9", op = "==", exit_code = 0 },
+  { variant = "inequality", a0 = "1", a1 = "2", a2 = "3", b0 = "1", b1 = "2", b2 = "9", op = "!=", exit_code = 1 },
+]
+
+# Nested aggregates recurse: array-of-struct and struct-of-array.
+[[case]]
+name = "array_of_struct_equality"
+spec = ["4.3:2", "4.3:3c", "4.3:3b"]
+source = """
+struct P { x: i32, y: i32 }
+
+fn main() -> i32 {
+    let a = [P { x: 1, y: 2 }, P { x: 3, y: 4 }];
+    let b = [P { x: 1, y: 2 }, P { x: 3, y: 4 }];
+    let c = [P { x: 1, y: 2 }, P { x: 3, y: 5 }];
+    if a == b && a != c { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "struct_of_array_equality"
+spec = ["4.3:2", "4.3:3b", "4.3:3c"]
+source = """
+struct S { v: [i32; 3] }
+
+fn main() -> i32 {
+    let a = S { v: [1, 2, 3] };
+    let b = S { v: [1, 2, 3] };
+    let c = S { v: [1, 2, 4] };
+    if a == b && a != c { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+# Nested struct: a difference in a non-first slot of a nested field must be seen
+# (regression guard for the old slot-0-only struct-equality bug, RUE-285).
+[[case]]
+name = "nested_struct_equality_deep_field"
+spec = ["4.3:2", "4.3:3b"]
+source = """
+struct Inner { a: i32, b: i32 }
+struct Outer { p: Inner, q: i32 }
+
+fn main() -> i32 {
+    let x = Outer { p: Inner { a: 1, b: 2 }, q: 5 };
+    let y = Outer { p: Inner { a: 1, b: 2 }, q: 5 };
+    let z = Outer { p: Inner { a: 1, b: 99 }, q: 5 };
+    if x == y && x != z { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+[[case]]
+name = "array_ordering_disallowed"
+spec = ["4.3:6"]
+source = """
+fn main() -> i32 {
+    let a = [1, 2];
+    let b = [1, 2];
+    if a < b { 1 } else { 0 }
+}
+"""
+compile_fail = true
+
+# Equality borrows its operands: both arrays remain usable after `==`.
+[[case]]
+name = "array_equality_borrows_operands"
+spec = ["4.3:3f"]
+source = """
+fn main() -> i32 {
+    let a = [1, 2, 3];
+    let b = [1, 2, 3];
+    let equal = a == b;
+    if equal { a[0] + b[2] } else { 0 }
+}
+"""
+exit_code = 4
+
+# A raw-pointer leaf compares by ADDRESS (identity): two structs holding the
+# address of the same local are equal; one holding a different local is not.
+[[case]]
+name = "struct_raw_pointer_field_equality_by_address"
+spec = ["4.3:2", "4.3:3b", "4.3:3e"]
+source = """
+struct Pw { p: ptr const i32 }
+
+fn main() -> i32 {
+    let x: i32 = 42;
+    let y: i32 = 42;
+    let a = checked { Pw { p: @raw(x) } };
+    let b = checked { Pw { p: @raw(x) } };
+    let c = checked { Pw { p: @raw(y) } };
+    if a == b && a != c { 1 } else { 0 }
+}
+"""
+exit_code = 1
+
+# =============================================================================
+# Enum Equality (RUE-285): same variant and equal payload
+# =============================================================================
+
+# Discriminant-only (C-like) enums: equal iff the same variant. Not preview.
+[[case]]
+name = "enum_clike_equality_{variant}"
+spec = ["4.3:2", "4.3:3d"]
+source = """
+enum Color { Red, Green, Blue }
+
+fn main() -> i32 {
+    let a = Color::{a};
+    let b = Color::{b};
+    if a {op} b { 1 } else { 0 }
+}
+"""
+params = [
+  { variant = "same", a = "Red", b = "Red", op = "==", exit_code = 1 },
+  { variant = "different", a = "Red", b = "Green", op = "==", exit_code = 0 },
+  { variant = "inequality", a = "Red", b = "Green", op = "!=", exit_code = 1 },
+]
+
+[[case]]
+name = "enum_clike_ordering_disallowed"
+spec = ["4.3:6"]
+source = """
+enum Color { Red, Green }
+
+fn main() -> i32 {
+    let a = Color::Red;
+    let b = Color::Green;
+    if a < b { 1 } else { 0 }
+}
+"""
+compile_fail = true
+
+# Payload-carrying enums: same variant AND equal payload; different variants
+# are never equal. Gated on the enum_payloads preview feature (RUE-221).
+[[case]]
+name = "enum_payload_equality_{variant}"
+spec = ["4.3:2", "4.3:3d"]
+preview = "enum_payloads"
+source = """
+enum Shape { Circle(i32), Square(i32) }
+
+fn main() -> i32 {
+    let a = Shape::{a};
+    let b = Shape::{b};
+    if a {op} b { 1 } else { 0 }
+}
+"""
+params = [
+  { variant = "same", a = "Circle(5)", b = "Circle(5)", op = "==", exit_code = 1 },
+  { variant = "same_variant_diff_payload", a = "Circle(5)", b = "Circle(6)", op = "==", exit_code = 0 },
+  { variant = "different_variant", a = "Circle(5)", b = "Square(5)", op = "==", exit_code = 0 },
+  { variant = "inequality", a = "Circle(5)", b = "Square(5)", op = "!=", exit_code = 1 },
+]

--- a/docs/spec/src/04-expressions/03-comparison-operators.md
+++ b/docs/spec/src/04-expressions/03-comparison-operators.md
@@ -14,7 +14,8 @@ Comparison operators compare two values and produce a `bool` result.
 
 {{ rule(id="4.3:2", cat="normative") }}
 
-Equality operators work on integers, booleans, strings, the unit type, and struct types.
+Equality operators work on integers, booleans, strings, the unit type, and the
+aggregate types: structs, arrays, and enums.
 
 | Operator | Name | Description |
 |----------|------|-------------|
@@ -31,7 +32,46 @@ Two unit values are always equal.
 
 {{ rule(id="4.3:3b", cat="normative") }}
 
-Two struct values are equal if and only if they have the same struct type and all corresponding fields are equal.
+Equality on the aggregate types is **structural**: two aggregate values are
+equal if and only if they have the same type and their components — determined
+recursively by this rule down to scalar leaves — are equal. Specifically, two
+struct values are equal if and only if they have the same struct type and all
+corresponding fields are equal.
+
+{{ rule(id="4.3:3c", cat="normative") }}
+
+Two array values are equal if and only if they have the same element type and
+length and their elements are equal index-by-index. (Two array types of
+different lengths are distinct types and cannot be compared; see rule 4.3:10.)
+
+{{ rule(id="4.3:3d", cat="normative") }}
+
+Two enum values are equal if and only if they have the same enum type, are the
+same variant, and — for a variant carrying a payload — their payload fields are
+equal field-by-field. Two values of different variants are never equal.
+
+{{ rule(id="4.3:3e", cat="normative") }}
+
+A raw-pointer leaf (a `*const T` or `*mut T` field or element reached while
+comparing an aggregate) compares by **address**: two raw pointers are equal if
+and only if they hold the same address. The pointees are not examined.
+
+{{ rule(id="4.3:3f", cat="dynamic-semantics") }}
+
+Equality **borrows** its operands: evaluating `a == b` or `a != b` reads both
+operands without consuming them. An affine or linear value may therefore be
+compared without discharging its move obligation, and both operands remain
+usable afterward.
+
+{{ rule(id="4.3:3g", cat="informative") }}
+
+Equality is structural **by default**. Trait-based refinement of equality —
+opting a type out of comparison, or giving it a user-defined equality (a
+`PartialEq`-style mechanism) — is deferred until traits exist (RUE-246). A
+related future consideration, once floating-point types exist, is the
+partial-equality of `NaN` (where `NaN != NaN`), which motivates the eventual
+`PartialEq`/`Eq` split; today no leaf type has such a value, so structural
+equality is a total equivalence.
 
 {{ rule(id="4.3:4") }}
 
@@ -59,6 +99,20 @@ fn main() -> i32 {
 }
 ```
 
+{{ rule(id="4.3:4b", cat="example") }}
+
+Arrays compare element-by-element; nested aggregates recurse. Comparing does
+not consume the operands, so `a` and `b` remain usable afterward.
+
+```rue
+fn main() -> i32 {
+    let a = [1, 2, 3];
+    let b = [1, 2, 3];
+    let equal = a == b;      // borrows a and b
+    if equal && a[0] == b[0] { 1 } else { 0 }
+}
+```
+
 ## Ordering Operators
 
 {{ rule(id="4.3:5", cat="normative") }}
@@ -74,7 +128,9 @@ Ordering operators work only on integers.
 
 {{ rule(id="4.3:6", cat="legality-rule") }}
 
-Ordering operators on boolean, string, unit, or struct values are a compile-time error. Implementations **MUST** reject such programs.
+Ordering operators on boolean, string, unit, or aggregate (struct, array, or
+enum) values are a compile-time error. Implementations **MUST** reject such
+programs.
 
 {{ rule(id="4.3:7") }}
 


### PR DESCRIPTION
Completes structural ==/!= over all aggregates, ratified by Steve 2026-07-03.

**Compiler:** sema equality now accepts array + payload-enum operands (E0206 unchanged; no new codes). BOTH backends generalized emit_struct_equality -> emit_aggregate_equality (per-slot compare; raw-pointer fields compare by ADDRESS). This also fixed a **latent nested-struct bug**: the old struct == compared only slot 0 of each multi-slot field, so a struct with a struct/array-typed field compared wrong (verified: Line{a:P,b:P} with a differing b.y now correctly !=, was silently ==). Equality BORROWS its operands (works on affine/linear values without discharging must-consume).

**Oracle:** aggregate cmp is now structural (recursive leaf compare); payload enums modeled as Aggregate([tag, payload..]); the 4 RUE-285 KNOWN_ORACLE_GAPS entries removed (now agree).

**Spec:** new rules 4.3:3c-3g + 4.3:6 — ==/!= on structs/arrays/payload-enums is structural, borrows operands, compares raw-pointer fields by address, structural-by-default with trait-refinement deferred to RUE-246; float NaN noted.

Verified: array/enum/nested-multi-slot == by execution; clippy-gate-passed; test.sh green (640/640); oracle-diff CLI/SPEC + fuzz-300 all 0 disagreements; aarch64 via --emit asm. 10 spec + 2 CLI cases.

Fixes RUE-285

Generated with Claude Code