### PR TITLE
CI: cut Website deploy frequency to stop flaky-Pages red runs (RUE-310)

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,25 +1,32 @@
 name: Website
 
 on:
+  # Deploy (post-merge on trunk) only on real website changes. The spec is
+  # published from docs/spec, but re-deploying on every spec commit rolls the
+  # dice against the flaky GitHub Pages backend far too often; spec, benchmark,
+  # and status-board changes are picked up by the weekly schedule (or a manual
+  # run) instead.
   push:
     branches: [trunk]
     paths:
       - 'website/**'
-      - 'docs/spec/**'
       - 'scripts/generate-charts.py'
+      - 'scripts/generate-site-status.py'
       - '.github/workflows/deploy-website.yml'
+  # PRs still build (no deploy — that's trunk-only) on spec changes too, so a
+  # spec edit that breaks the website build is caught before merge.
   pull_request:
     branches: [trunk]
     paths:
       - 'website/**'
       - 'docs/spec/**'
       - 'scripts/generate-charts.py'
+      - 'scripts/generate-site-status.py'
       - '.github/workflows/deploy-website.yml'
-  # Trigger when benchmarks complete (updates perf branch with new data)
-  workflow_run:
-    workflows: ["Benchmarks"]
-    types: [completed]
-    branches: [trunk]
+  # Weekly refresh so the published spec, benchmark sparkline, and status board
+  # don't drift more than ~7 days behind trunk. Switch to '0 6 1 * *' for monthly.
+  schedule:
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
The Deploy-to-Pages job intermittently fails with 'Deployment failed, try again later' — a transient GitHub Pages backend error, not a build problem (build/test is green; deploy runs only post-merge on trunk and never gates a PR). It fired on every push touching docs/spec (the spec is published from docs/spec via website/build.sh), so the ongoing spec-quality work triggered a Pages deploy on nearly every merge — each a roll of the dice against the flaky backend, each leaving a red run on a trunk commit.

Fix: reduce deploy frequency rather than retry a symptom.
- push->trunk (deploys) only on real website changes: website/**, the build scripts (generate-charts.py, generate-site-status.py), and this workflow. Dropped docs/spec/** and the Benchmarks workflow_run trigger from the deploy path.
- pull_request keeps docs/spec/** (build-only; deploy is trunk-only) so a spec edit that breaks the website build is still caught pre-merge, flakiness-free.
- Added a weekly schedule (0 6 * * 1) to publish accumulated spec/benchmark/status changes, plus the existing workflow_dispatch for on-demand.

Tradeoff: the published spec lags trunk by <=7 days. Switch the cron to '0 6 1 * *' for monthly.

Fixes RUE-310

Generated with Claude Code