### PR TITLE
Heap intrinsics @alloc/@free/@realloc + a source-level Vec(T) library (RUE-1, RUE-226)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1090,6 +1090,60 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
+                } else if intrinsic_name == "alloc" {
+                    // @alloc(count: u64) -> ptr mut T. The element type T (and
+                    // thus the result pointer type) is inferred from context,
+                    // exactly like @int_to_ptr; sema validates it is `ptr mut T`.
+                    // Constrain `count` to u64 so a bare integer literal
+                    // (`@alloc(4)`) defaults to u64 rather than i64.
+                    for arg_ref in args.iter() {
+                        let info = self.generate(*arg_ref, ctx);
+                        self.add_constraint(Constraint::equal(
+                            info.ty,
+                            InferType::Concrete(Type::U64),
+                            info.span,
+                        ));
+                    }
+                    let result_var = self.fresh_var();
+                    InferType::Var(result_var)
+                } else if intrinsic_name == "realloc" {
+                    // @realloc(ptr: ptr mut T, old_count: u64, new_count: u64)
+                    // -> ptr mut T. The result type is the same pointer type as
+                    // the first argument; unify a fresh var with arg0's type so
+                    // it flows in both directions. Counts are constrained to u64.
+                    let mut first_ty: Option<InferType> = None;
+                    for (i, arg_ref) in args.iter().enumerate() {
+                        let info = self.generate(*arg_ref, ctx);
+                        if i == 0 {
+                            first_ty = Some(info.ty);
+                        } else {
+                            self.add_constraint(Constraint::equal(
+                                info.ty,
+                                InferType::Concrete(Type::U64),
+                                info.span,
+                            ));
+                        }
+                    }
+                    let result_var = self.fresh_var();
+                    let result_ty = InferType::Var(result_var);
+                    if let Some(arg0_ty) = first_ty {
+                        self.add_constraint(Constraint::equal(result_ty.clone(), arg0_ty, span));
+                    }
+                    result_ty
+                } else if intrinsic_name == "free" {
+                    // @free(ptr: ptr mut T, count: u64) -> (). Constrain the
+                    // `count` (second) argument to u64.
+                    for (i, arg_ref) in args.iter().enumerate() {
+                        let info = self.generate(*arg_ref, ctx);
+                        if i == 1 {
+                            self.add_constraint(Constraint::equal(
+                                info.ty,
+                                InferType::Concrete(Type::U64),
+                                info.span,
+                            ));
+                        }
+                    }
+                    InferType::Concrete(Type::UNIT)
                 } else if intrinsic_name == "int_to_ptr" || intrinsic_name == "null_ptr" {
                     // @int_to_ptr / @null_ptr: returns a pointer type inferred from context
                     for arg_ref in args.iter() {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -3625,12 +3625,12 @@ impl<'a> Sema<'a> {
             .collect();
         let known = &self.known;
 
-        // Raw-pointer intrinsics are unchecked operations: they may only be
-        // used inside a `checked` block (spec 9.1:1, chapter 9). Gate them
-        // before the per-intrinsic dispatch so every pointer intrinsic shares
-        // one diagnostic. `@syscall` has its own gating; the pointer set here
-        // is @raw/@raw_mut/@ptr_read/@ptr_write/@ptr_offset/@ptr_to_int/
-        // @int_to_ptr.
+        // Raw-pointer and heap intrinsics are unchecked operations: they may
+        // only be used inside a `checked` block (spec 9.1:1, chapter 9). Gate
+        // them before the per-intrinsic dispatch so every one shares a single
+        // diagnostic. `@syscall` has its own gating; the set here is
+        // @raw/@raw_mut/@ptr_read/@ptr_write/@ptr_offset/@ptr_to_int/
+        // @int_to_ptr plus the heap intrinsics @alloc/@free/@realloc (RUE-1).
         if ctx.checked_depth == 0
             && (name == known.ptr_read
                 || name == known.ptr_write
@@ -3638,12 +3638,20 @@ impl<'a> Sema<'a> {
                 || name == known.ptr_to_int
                 || name == known.int_to_ptr
                 || name == known.raw
-                || name == known.raw_mut)
+                || name == known.raw_mut
+                || name == known.alloc
+                || name == known.free
+                || name == known.realloc)
         {
             let intrinsic_name_str = self.interner.resolve(&name);
+            let kind = if name == known.alloc || name == known.free || name == known.realloc {
+                "heap"
+            } else {
+                "raw-pointer"
+            };
             return Err(CompileError::new(
                 ErrorKind::UncheckedOpRequiresChecked {
-                    what: format!("raw-pointer intrinsic `@{intrinsic_name_str}`"),
+                    what: format!("{kind} intrinsic `@{intrinsic_name_str}`"),
                 },
                 span,
             )
@@ -3687,6 +3695,12 @@ impl<'a> Sema<'a> {
             self.analyze_ptr_to_int_intrinsic(air, name, &args, span, ctx)
         } else if name == known.int_to_ptr {
             self.analyze_int_to_ptr_intrinsic(air, name, inst_ref, &args, span, ctx)
+        } else if name == known.alloc {
+            self.analyze_alloc_intrinsic(air, name, inst_ref, &args, span, ctx)
+        } else if name == known.free {
+            self.analyze_free_intrinsic(air, name, &args, span, ctx)
+        } else if name == known.realloc {
+            self.analyze_realloc_intrinsic(air, name, &args, span, ctx)
         } else if name == known.raw {
             self.analyze_addr_of_intrinsic(air, &args, span, ctx, false)
         } else if name == known.raw_mut {
@@ -6889,6 +6903,204 @@ impl<'a> Sema<'a> {
             span,
         });
         Ok(AnalysisResult::new(air_ref, result_type))
+    }
+
+    /// Analyze @alloc intrinsic: allocate an uninitialized heap block (RUE-1).
+    /// Signature: @alloc(count: u64) -> ptr mut T
+    /// The element type T (and thus the result pointer type `ptr mut T`) is
+    /// inferred from context, exactly like @int_to_ptr. The allocation is
+    /// `count * size_of(T)` bytes; the returned pointer is null on failure
+    /// (the caller is expected to check), so this is an unchecked operation.
+    fn analyze_alloc_intrinsic(
+        &mut self,
+        air: &mut Air,
+        name: Spur,
+        inst_ref: InstRef,
+        args: &[RirCallArg],
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        if args.len() != 1 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "alloc".to_string(),
+                    expected: 1,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        let count_result = self.analyze_inst(air, args[0].value, ctx)?;
+        let count_type = count_result.ty;
+        if count_type != Type::U64 && !count_type.is_error() && !count_type.is_never() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: "alloc".to_string(),
+                    expected: "u64".to_string(),
+                    found: self.format_type_name(count_type),
+                })),
+                span,
+            ));
+        }
+
+        // The result type comes from HM inference (assignment/annotation
+        // context) and must be a mutable pointer `ptr mut T`.
+        let result_type = Self::get_resolved_type(ctx, inst_ref, span, "@alloc intrinsic")?;
+        if !result_type.is_ptr_mut() && !result_type.is_error() && !result_type.is_never() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: "alloc".to_string(),
+                    expected: "ptr mut T".to_string(),
+                    found: self.format_type_name(result_type),
+                })),
+                span,
+            ));
+        }
+
+        let args_start = air.add_extra(&[count_result.air_ref.as_u32()]);
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name,
+                args_start,
+                args_len: 1,
+            },
+            ty: result_type,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, result_type))
+    }
+
+    /// Analyze @free intrinsic: free a block previously `@alloc`'d (RUE-1).
+    /// Signature: @free(ptr: ptr mut T, count: u64) -> ()
+    /// `count` must match the element count passed to `@alloc` so the runtime
+    /// can compute the block size.
+    fn analyze_free_intrinsic(
+        &mut self,
+        air: &mut Air,
+        name: Spur,
+        args: &[RirCallArg],
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        if args.len() != 2 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "free".to_string(),
+                    expected: 2,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        let ptr_result = self.analyze_inst(air, args[0].value, ctx)?;
+        let ptr_type = ptr_result.ty;
+        if !ptr_type.is_ptr_mut() && !ptr_type.is_error() && !ptr_type.is_never() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: "free".to_string(),
+                    expected: "ptr mut T".to_string(),
+                    found: self.format_type_name(ptr_type),
+                })),
+                span,
+            ));
+        }
+
+        let count_result = self.analyze_inst(air, args[1].value, ctx)?;
+        let count_type = count_result.ty;
+        if count_type != Type::U64 && !count_type.is_error() && !count_type.is_never() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: "free".to_string(),
+                    expected: "u64".to_string(),
+                    found: self.format_type_name(count_type),
+                })),
+                span,
+            ));
+        }
+
+        let args_start =
+            air.add_extra(&[ptr_result.air_ref.as_u32(), count_result.air_ref.as_u32()]);
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name,
+                args_start,
+                args_len: 2,
+            },
+            ty: Type::UNIT,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::UNIT))
+    }
+
+    /// Analyze @realloc intrinsic: grow/shrink an `@alloc`'d block (RUE-1).
+    /// Signature: @realloc(ptr: ptr mut T, old_count: u64, new_count: u64) -> ptr mut T
+    /// The result pointer has the same type as `ptr`; contents up to
+    /// `min(old_count, new_count)` elements are preserved (runtime copies).
+    fn analyze_realloc_intrinsic(
+        &mut self,
+        air: &mut Air,
+        name: Spur,
+        args: &[RirCallArg],
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        if args.len() != 3 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "realloc".to_string(),
+                    expected: 3,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        let ptr_result = self.analyze_inst(air, args[0].value, ctx)?;
+        let ptr_type = ptr_result.ty;
+        if !ptr_type.is_ptr_mut() && !ptr_type.is_error() && !ptr_type.is_never() {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: "realloc".to_string(),
+                    expected: "ptr mut T".to_string(),
+                    found: self.format_type_name(ptr_type),
+                })),
+                span,
+            ));
+        }
+
+        let old_result = self.analyze_inst(air, args[1].value, ctx)?;
+        let new_result = self.analyze_inst(air, args[2].value, ctx)?;
+        for count_result in [&old_result, &new_result] {
+            let count_type = count_result.ty;
+            if count_type != Type::U64 && !count_type.is_error() && !count_type.is_never() {
+                return Err(CompileError::new(
+                    ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                        name: "realloc".to_string(),
+                        expected: "u64".to_string(),
+                        found: self.format_type_name(count_type),
+                    })),
+                    span,
+                ));
+            }
+        }
+
+        let args_start = air.add_extra(&[
+            ptr_result.air_ref.as_u32(),
+            old_result.air_ref.as_u32(),
+            new_result.air_ref.as_u32(),
+        ]);
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name,
+                args_start,
+                args_len: 3,
+            },
+            ty: ptr_type,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, ptr_type))
     }
 
     /// Analyze @addr_of / @addr_of_mut intrinsics: takes address of lvalue.

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -93,6 +93,13 @@ pub struct KnownSymbols {
     pub raw_mut: Spur,
     /// The `syscall` intrinsic symbol - direct OS syscall.
     pub syscall: Spur,
+    /// The `alloc` intrinsic symbol - allocate an uninitialized heap block
+    /// of `count` elements of the (context-inferred) element type (RUE-1).
+    pub alloc: Spur,
+    /// The `free` intrinsic symbol - free a block previously `@alloc`'d.
+    pub free: Spur,
+    /// The `realloc` intrinsic symbol - grow/shrink an `@alloc`'d block.
+    pub realloc: Spur,
 
     // Target platform intrinsics
     /// The `target_arch` intrinsic symbol - returns target CPU architecture.
@@ -141,6 +148,9 @@ impl KnownSymbols {
             raw: interner.get_or_intern_static("raw"),
             raw_mut: interner.get_or_intern_static("raw_mut"),
             syscall: interner.get_or_intern_static("syscall"),
+            alloc: interner.get_or_intern_static("alloc"),
+            free: interner.get_or_intern_static("free"),
+            realloc: interner.get_or_intern_static("realloc"),
 
             // Target platform intrinsics
             target_arch: interner.get_or_intern_static("target_arch"),
@@ -207,6 +217,9 @@ mod tests {
         assert_eq!(interner.resolve(&known.raw), "raw");
         assert_eq!(interner.resolve(&known.raw_mut), "raw_mut");
         assert_eq!(interner.resolve(&known.syscall), "syscall");
+        assert_eq!(interner.resolve(&known.alloc), "alloc");
+        assert_eq!(interner.resolve(&known.free), "free");
+        assert_eq!(interner.resolve(&known.realloc), "realloc");
         assert_eq!(interner.resolve(&known.target_arch), "target_arch");
         assert_eq!(interner.resolve(&known.target_os), "target_os");
     }

--- a/crates/rue-cli-tests/cases/heap_intrinsics.toml
+++ b/crates/rue-cli-tests/cases/heap_intrinsics.toml
@@ -1,0 +1,105 @@
+# @alloc / @free / @realloc heap intrinsics driven the way a user does — real
+# files, the real driver, real program exit codes and stdout (RUE-1).
+#
+# These are the unchecked heap primitives a source-level Vec is built on. The
+# runtime __rue_alloc/__rue_free/__rue_realloc are already used by String, so
+# these cases also confirm the archive symbols resolve when referenced only
+# from user code.
+
+[section]
+id = "cli.heap_intrinsics"
+name = "Heap allocation intrinsics"
+description = "@alloc/@free/@realloc allocate, free, and grow heap blocks (RUE-1)."
+
+# Allocate a buffer, write/read three elements through it, then free it.
+[[case]]
+name = "alloc_write_read_free"
+description = "Round-trips values through an @alloc'd i32 buffer and frees it."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut i32 = @alloc(3);
+        @ptr_write(p, 10);
+        @ptr_write(@ptr_offset(p, 1), 20);
+        @ptr_write(@ptr_offset(p, 2), 30);
+        @dbg(@ptr_read(p));
+        @dbg(@ptr_read(@ptr_offset(p, 1)));
+        @dbg(@ptr_read(@ptr_offset(p, 2)));
+        @free(p, 3);
+        @ptr_read(p) + @ptr_read(@ptr_offset(p, 1)) + @ptr_read(@ptr_offset(p, 2))
+    }
+}
+""" }]
+stdout = "10\n20\n30\n"
+exit_code = 60
+
+# @realloc grows a block and preserves the earlier contents.
+[[case]]
+name = "realloc_grows_and_preserves"
+description = "Growing an @alloc'd block with @realloc keeps the existing elements."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    checked {
+        let mut p: ptr mut i32 = @alloc(2);
+        @ptr_write(p, 5);
+        @ptr_write(@ptr_offset(p, 1), 7);
+        p = @realloc(p, 2, 16);
+        @ptr_write(@ptr_offset(p, 8), 100);
+        let sum: i32 = @ptr_read(p) + @ptr_read(@ptr_offset(p, 1)) + @ptr_read(@ptr_offset(p, 8));
+        @free(p, 16);
+        sum
+    }
+}
+""" }]
+exit_code = 112
+
+# @free called from a user destructor: the whole owned-buffer-with-drop pattern
+# works on a concrete named struct (the generic-struct attachment is blocked;
+# see the meta report). Prints the live value, then the destructor's marker.
+[[case]]
+name = "free_from_destructor"
+description = "A struct that owns an @alloc'd buffer frees it in its `drop fn` at scope exit."
+files = [{ path = "main.rue", source = """
+struct Buf {
+    data: ptr mut i32,
+    cap: u64,
+    fn init() -> Self {
+        checked {
+            let p: ptr mut i32 = @alloc(4);
+            @ptr_write(p, 111);
+            Self { data: p, cap: 4 }
+        }
+    }
+    fn first(borrow self) -> i32 {
+        checked { @ptr_read(self.data) }
+    }
+}
+
+drop fn Buf(self) {
+    checked { @free(self.data, self.cap); };
+    @dbg(999);
+}
+
+fn main() -> i32 {
+    let b = Buf::init();
+    @dbg(b.first());
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "method_receivers", "-o", "prog"]
+stdout = "111\n999\n"
+exit_code = 0
+
+# Heap intrinsics are unchecked: using @alloc outside a `checked` block is a
+# compile error.
+[[case]]
+name = "alloc_outside_checked_rejected"
+description = "@alloc outside a checked block is rejected (E1300)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let p: ptr mut i32 = @alloc(4);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["heap intrinsic `@alloc`", "checked"]

--- a/crates/rue-cli-tests/cases/vec_library.toml
+++ b/crates/rue-cli-tests/cases/vec_library.toml
@@ -1,0 +1,126 @@
+# The source-level Vec(T) library (examples/std/vec.rue) driven end-to-end as a
+# user would: a multi-file compile of a program that @imports the library and
+# exercises push / len / get / set / pop / a while-loop sum / out-of-bounds
+# access on a Vec(i32) (RUE-1, ADR-0041).
+#
+# Vec is generic over a Copy element type and is built entirely on the unchecked
+# heap intrinsics @alloc/@realloc/@free behind a safe method API. See vec.rue's
+# header for the (separately tracked) limitations this stays within: Copy
+# elements, explicit free() instead of an automatic destructor, and single-slot
+# element types.
+
+[section]
+id = "cli.vec_library"
+name = "Source-level Vec(T) library"
+description = "A Rue-source Vec(T) on @alloc/@free with a full push/pop/get/set dogfood (RUE-1)."
+
+[[case]]
+name = "vec_i32_dogfood"
+description = "push/len/get/set/pop/while-sum/out-of-bounds on Vec(i32), via @import + multi-file."
+files = [
+  { path = "main.rue", source = """
+fn main() -> i32 {
+    let m = @import(\"vec.rue\");
+    let V = m.Vec(i32);
+
+    let mut v = V::new();
+    v.push(10);
+    v.push(20);
+    v.push(30);
+    @dbg(v.len());          // 3
+
+    @dbg(v.get(1));         // 20
+    v.set(0, 99);
+    @dbg(v.get(0));         // 99
+
+    @dbg(v.pop_or(0));      // 30 (removed)
+    @dbg(v.len());          // 2
+
+    @dbg(v.get_or(99, 0));  // 0  (out-of-bounds -> default)
+
+    let mut i: u64 = 0;
+    let mut sum: i32 = 0;
+    while i < v.len() {
+        sum = sum + v.get(i);
+        i = i + 1;
+    }
+    @dbg(sum);              // 99 + 20 = 119
+
+    v.free();
+    sum
+}
+""" },
+  { path = "vec.rue", source = """
+pub fn Vec(comptime T: type) -> type {
+    struct {
+        buf: ptr mut T,
+        len: u64,
+        cap: u64,
+
+        fn new() -> Self {
+            let zero: u64 = 0;
+            Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 }
+        }
+        fn len(borrow self) -> u64 { self.len }
+        fn is_empty(borrow self) -> bool { self.len == 0 }
+        fn capacity(borrow self) -> u64 { self.cap }
+
+        fn reserve(inout self) {
+            if self.len == self.cap {
+                let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
+                checked {
+                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    self.buf = grown;
+                };
+                self.cap = new_cap;
+            }
+        }
+        fn push(inout self, x: T) {
+            self.reserve();
+            checked {
+                let slot = @ptr_offset(self.buf, self.len);
+                @ptr_write(slot, x);
+            };
+            self.len = self.len + 1;
+        }
+        fn get(borrow self, i: u64) -> T {
+            checked { @ptr_read(@ptr_offset(self.buf, i)) }
+        }
+        fn get_or(borrow self, i: u64, default: T) -> T {
+            if i < self.len {
+                checked { @ptr_read(@ptr_offset(self.buf, i)) }
+            } else {
+                default
+            }
+        }
+        fn set(inout self, i: u64, x: T) {
+            if i < self.len {
+                checked {
+                    let slot = @ptr_offset(self.buf, i);
+                    @ptr_write(slot, x);
+                };
+            }
+        }
+        fn pop_or(inout self, default: T) -> T {
+            if self.len == 0 {
+                default
+            } else {
+                self.len = self.len - 1;
+                checked { @ptr_read(@ptr_offset(self.buf, self.len)) }
+            }
+        }
+        fn clear(inout self) { self.len = 0; }
+        fn free(inout self) {
+            checked { @free(self.buf, self.cap); };
+            let zero: u64 = 0;
+            self.buf = checked { @int_to_ptr(zero) };
+            self.len = 0;
+            self.cap = 0;
+        }
+    }
+}
+""" },
+]
+args = ["main.rue", "vec.rue", "--preview", "method_receivers", "-o", "prog"]
+stdout = "3\n20\n99\n30\n2\n0\n119\n"
+exit_code = 119

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -119,6 +119,49 @@ impl<'a> CfgLower<'a> {
         self.mir.intern_symbol(symbol)
     }
 
+    /// Per-element stride in bytes for a heap intrinsic (`@alloc`/`@free`/
+    /// `@realloc`) whose pointer type is `ty` (a `ptr mut T`/`ptr const T`):
+    /// `size_of(T)`. All Rue types are 8-byte-slotted, so this is
+    /// `slot_count(T) * 8` — the same stride `@ptr_offset` uses (RUE-1).
+    fn alloc_element_size(&self, ty: Type) -> u64 {
+        let pointee = match ty.kind() {
+            TypeKind::PtrMut(id) => self.ctx.type_pool.ptr_mut_def(id),
+            TypeKind::PtrConst(id) => self.ctx.type_pool.ptr_const_def(id),
+            // Sema guarantees a pointer type here; be defensive on error/never.
+            _ => return 8,
+        };
+        types::type_size_bytes(self.ctx.type_pool, pointee)
+    }
+
+    /// Emit `count_vreg * element_size` (a compile-time constant stride) into a
+    /// fresh vreg. Mirrors the scaling used by `@ptr_offset`.
+    fn scale_by_size(&mut self, count_vreg: VReg, element_size: u64) -> VReg {
+        let out = self.mir.alloc_vreg();
+        if element_size == 0 {
+            self.mir.push(Aarch64Inst::MovImm {
+                dst: Operand::Virtual(out),
+                imm: 0,
+            });
+        } else if element_size == 1 {
+            self.mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Virtual(out),
+                src: Operand::Virtual(count_vreg),
+            });
+        } else {
+            let size_vreg = self.mir.alloc_vreg();
+            self.mir.push(Aarch64Inst::MovImm {
+                dst: Operand::Virtual(size_vreg),
+                imm: element_size as i64,
+            });
+            self.mir.push(Aarch64Inst::MulRR {
+                dst: Operand::Virtual(out),
+                src1: Operand::Virtual(count_vreg),
+                src2: Operand::Virtual(size_vreg),
+            });
+        }
+        out
+    }
+
     /// Recursively collect all scalar vregs from an array value.
     fn collect_array_scalar_vregs(&mut self, value: CfgValue) -> Vec<VReg> {
         let slot_vregs = self.struct_slot_vregs.clone();
@@ -2263,6 +2306,105 @@ impl<'a> CfgLower<'a> {
                     self.mir.push(Aarch64Inst::MovRR {
                         dst: Operand::Virtual(result_vreg),
                         src: Operand::Virtual(addr_vreg),
+                    });
+                    self.value_map.insert(value, result_vreg);
+                } else if name_str == "alloc" {
+                    // @alloc(count) -> ptr mut T. Allocate count * size_of(T)
+                    // bytes via __rue_alloc(size, align). Element type T is the
+                    // pointee of the result pointer type (RUE-1).
+                    let args = self.ctx.cfg.get_extra(*args_start, *args_len);
+                    let count_vreg = self.get_vreg(args[0]);
+
+                    let result_ty = self.ctx.cfg.get_inst(value).ty;
+                    let element_size = self.alloc_element_size(result_ty);
+                    let size_vreg = self.scale_by_size(count_vreg, element_size);
+
+                    // size -> X0, align=8 -> X1 (AArch64 C ABI arg registers).
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Physical(Reg::X0),
+                        src: Operand::Virtual(size_vreg),
+                    });
+                    self.mir.push(Aarch64Inst::MovImm {
+                        dst: Operand::Physical(Reg::X1),
+                        imm: 8,
+                    });
+                    let symbol_id = self.intern_symbol("__rue_alloc");
+                    self.mir.push(Aarch64Inst::Bl { symbol_id });
+
+                    let result_vreg = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(result_vreg),
+                        src: Operand::Physical(Reg::X0),
+                    });
+                    self.value_map.insert(value, result_vreg);
+                } else if name_str == "free" {
+                    // @free(ptr, count) -> (). __rue_free(ptr, size, align)
+                    // where size = count * size_of(T) (RUE-1).
+                    let args = self.ctx.cfg.get_extra(*args_start, *args_len);
+                    let ptr_val = args[0];
+                    let ptr_vreg = self.get_vreg(ptr_val);
+                    let count_vreg = self.get_vreg(args[1]);
+
+                    let ptr_ty = self.ctx.cfg.get_inst(ptr_val).ty;
+                    let element_size = self.alloc_element_size(ptr_ty);
+                    let size_vreg = self.scale_by_size(count_vreg, element_size);
+
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Physical(Reg::X0),
+                        src: Operand::Virtual(ptr_vreg),
+                    });
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Physical(Reg::X1),
+                        src: Operand::Virtual(size_vreg),
+                    });
+                    self.mir.push(Aarch64Inst::MovImm {
+                        dst: Operand::Physical(Reg::X2),
+                        imm: 8,
+                    });
+                    let symbol_id = self.intern_symbol("__rue_free");
+                    self.mir.push(Aarch64Inst::Bl { symbol_id });
+
+                    // Result is unit.
+                    let result_vreg = self.mir.alloc_vreg();
+                    self.value_map.insert(value, result_vreg);
+                } else if name_str == "realloc" {
+                    // @realloc(ptr, old_count, new_count) -> ptr mut T.
+                    // __rue_realloc(ptr, old_size, new_size, align). Element type
+                    // T is the pointee of the result (=arg0) pointer type (RUE-1).
+                    let args = self.ctx.cfg.get_extra(*args_start, *args_len);
+                    let ptr_val = args[0];
+                    let ptr_vreg = self.get_vreg(ptr_val);
+                    let old_vreg = self.get_vreg(args[1]);
+                    let new_vreg = self.get_vreg(args[2]);
+
+                    let result_ty = self.ctx.cfg.get_inst(value).ty;
+                    let element_size = self.alloc_element_size(result_ty);
+                    let old_size_vreg = self.scale_by_size(old_vreg, element_size);
+                    let new_size_vreg = self.scale_by_size(new_vreg, element_size);
+
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Physical(Reg::X0),
+                        src: Operand::Virtual(ptr_vreg),
+                    });
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Physical(Reg::X1),
+                        src: Operand::Virtual(old_size_vreg),
+                    });
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Physical(Reg::X2),
+                        src: Operand::Virtual(new_size_vreg),
+                    });
+                    self.mir.push(Aarch64Inst::MovImm {
+                        dst: Operand::Physical(Reg::X3),
+                        imm: 8,
+                    });
+                    let symbol_id = self.intern_symbol("__rue_realloc");
+                    self.mir.push(Aarch64Inst::Bl { symbol_id });
+
+                    let result_vreg = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::MovRR {
+                        dst: Operand::Virtual(result_vreg),
+                        src: Operand::Physical(Reg::X0),
                     });
                     self.value_map.insert(value, result_vreg);
                 } else if name_str == "raw" || name_str == "raw_mut" {

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -122,6 +122,52 @@ impl<'a> CfgLower<'a> {
         self.mir.intern_symbol(symbol)
     }
 
+    /// Per-element stride in bytes for a heap intrinsic (`@alloc`/`@free`/
+    /// `@realloc`) whose pointer type is `ty` (a `ptr mut T`/`ptr const T`):
+    /// `size_of(T)`. All Rue types are 8-byte-slotted, so this is
+    /// `slot_count(T) * 8` — the same stride `@ptr_offset` uses (RUE-1).
+    fn alloc_element_size(&self, ty: Type) -> u64 {
+        let pointee = match ty.kind() {
+            TypeKind::PtrMut(id) => self.ctx.type_pool.ptr_mut_def(id),
+            TypeKind::PtrConst(id) => self.ctx.type_pool.ptr_const_def(id),
+            // Sema guarantees a pointer type here; be defensive on error/never.
+            _ => return 8,
+        };
+        types::type_size_bytes(self.ctx.type_pool, pointee)
+    }
+
+    /// Emit `count_vreg * element_size` (a compile-time constant stride) into a
+    /// fresh vreg. Mirrors the scaling used by `@ptr_offset`.
+    fn scale_by_size(&mut self, count_vreg: VReg, element_size: u64) -> VReg {
+        let out = self.mir.alloc_vreg();
+        if element_size == 0 {
+            self.mir.push(X86Inst::MovRI32 {
+                dst: Operand::Virtual(out),
+                imm: 0,
+            });
+        } else if element_size == 1 {
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Virtual(out),
+                src: Operand::Virtual(count_vreg),
+            });
+        } else {
+            let size_vreg = self.mir.alloc_vreg();
+            self.mir.push(X86Inst::MovRI64 {
+                dst: Operand::Virtual(size_vreg),
+                imm: element_size as i64,
+            });
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Virtual(out),
+                src: Operand::Virtual(count_vreg),
+            });
+            self.mir.push(X86Inst::ImulRR64 {
+                dst: Operand::Virtual(out),
+                src: Operand::Virtual(size_vreg),
+            });
+        }
+        out
+    }
+
     /// Recursively collect all scalar vregs from an array value.
     fn collect_array_scalar_vregs(&mut self, value: CfgValue) -> Vec<VReg> {
         let slot_vregs = self.struct_slot_vregs.clone();
@@ -2584,6 +2630,110 @@ impl<'a> CfgLower<'a> {
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Virtual(result_vreg),
                         src: Operand::Virtual(addr_vreg),
+                    });
+                    self.value_map.insert(value, result_vreg);
+                } else if name_str == "alloc" {
+                    // @alloc(count) -> ptr mut T. Allocate count * size_of(T)
+                    // bytes on the heap via __rue_alloc(size, align). The
+                    // element type T is the pointee of the result pointer type
+                    // (RUE-1). Returns the block pointer (null on failure).
+                    let args = self.ctx.cfg.get_extra(*args_start, *args_len);
+                    let count_vreg = self.get_vreg(args[0]);
+
+                    let result_ty = self.ctx.cfg.get_inst(value).ty;
+                    let element_size = self.alloc_element_size(result_ty);
+
+                    // size = count * element_size in RDI (first arg register).
+                    let size_vreg = self.scale_by_size(count_vreg, element_size);
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(Reg::Rdi),
+                        src: Operand::Virtual(size_vreg),
+                    });
+                    // align = 8 (all Rue types are 8-byte-slotted) in RSI.
+                    self.mir.push(X86Inst::MovRI64 {
+                        dst: Operand::Physical(Reg::Rsi),
+                        imm: 8,
+                    });
+                    let symbol_id = self.intern_symbol("__rue_alloc");
+                    self.mir.push(X86Inst::CallRel { symbol_id });
+
+                    let result_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(result_vreg),
+                        src: Operand::Physical(Reg::Rax),
+                    });
+                    self.value_map.insert(value, result_vreg);
+                } else if name_str == "free" {
+                    // @free(ptr, count) -> (). Free a block via
+                    // __rue_free(ptr, size, align) where size = count *
+                    // size_of(T), T the pointee of the argument type (RUE-1).
+                    let args = self.ctx.cfg.get_extra(*args_start, *args_len);
+                    let ptr_val = args[0];
+                    let count_val = args[1];
+                    let ptr_vreg = self.get_vreg(ptr_val);
+                    let count_vreg = self.get_vreg(count_val);
+
+                    let ptr_ty = self.ctx.cfg.get_inst(ptr_val).ty;
+                    let element_size = self.alloc_element_size(ptr_ty);
+                    let size_vreg = self.scale_by_size(count_vreg, element_size);
+
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(Reg::Rdi),
+                        src: Operand::Virtual(ptr_vreg),
+                    });
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(Reg::Rsi),
+                        src: Operand::Virtual(size_vreg),
+                    });
+                    self.mir.push(X86Inst::MovRI64 {
+                        dst: Operand::Physical(Reg::Rdx),
+                        imm: 8,
+                    });
+                    let symbol_id = self.intern_symbol("__rue_free");
+                    self.mir.push(X86Inst::CallRel { symbol_id });
+
+                    // Result is unit.
+                    let result_vreg = self.mir.alloc_vreg();
+                    self.value_map.insert(value, result_vreg);
+                } else if name_str == "realloc" {
+                    // @realloc(ptr, old_count, new_count) -> ptr mut T. Grow or
+                    // shrink a block via __rue_realloc(ptr, old_size, new_size,
+                    // align). Element type T is the pointee of the result (=arg0)
+                    // pointer type (RUE-1).
+                    let args = self.ctx.cfg.get_extra(*args_start, *args_len);
+                    let ptr_val = args[0];
+                    let ptr_vreg = self.get_vreg(ptr_val);
+                    let old_vreg = self.get_vreg(args[1]);
+                    let new_vreg = self.get_vreg(args[2]);
+
+                    let result_ty = self.ctx.cfg.get_inst(value).ty;
+                    let element_size = self.alloc_element_size(result_ty);
+                    let old_size_vreg = self.scale_by_size(old_vreg, element_size);
+                    let new_size_vreg = self.scale_by_size(new_vreg, element_size);
+
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(Reg::Rdi),
+                        src: Operand::Virtual(ptr_vreg),
+                    });
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(Reg::Rsi),
+                        src: Operand::Virtual(old_size_vreg),
+                    });
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Physical(Reg::Rdx),
+                        src: Operand::Virtual(new_size_vreg),
+                    });
+                    self.mir.push(X86Inst::MovRI64 {
+                        dst: Operand::Physical(Reg::Rcx),
+                        imm: 8,
+                    });
+                    let symbol_id = self.intern_symbol("__rue_realloc");
+                    self.mir.push(X86Inst::CallRel { symbol_id });
+
+                    let result_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::MovRR {
+                        dst: Operand::Virtual(result_vreg),
+                        src: Operand::Physical(Reg::Rax),
                     });
                     self.value_map.insert(value, result_vreg);
                 } else if name_str == "raw" || name_str == "raw_mut" {

--- a/crates/rue-spec/cases/runtime/heap.toml
+++ b/crates/rue-spec/cases/runtime/heap.toml
@@ -1,0 +1,135 @@
+# Heap Allocation Intrinsic Tests
+#
+# Tests for @alloc / @free / @realloc — the raw, unchecked heap primitives
+# (RUE-1). Like the raw-pointer intrinsics they must appear inside a `checked`
+# block. These are the primitives a source-level `Vec` is built on.
+
+[section]
+id = "runtime.heap"
+spec_chapter = "9.2"
+name = "Heap Allocation Intrinsics"
+description = "Tests for @alloc, @free, and @realloc heap intrinsics"
+
+# =============================================================================
+# @alloc allocates a typed block; write/read through the returned pointer.
+# =============================================================================
+
+[[case]]
+name = "alloc_write_read"
+spec = ["9.2:9", "9.2:10"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut i32 = @alloc(4);
+        @ptr_write(p, 42);
+        @ptr_read(p)
+    }
+}
+"""
+exit_code = 42
+
+# @alloc + @ptr_offset addresses successive elements (element i at offset i).
+[[case]]
+name = "alloc_multiple_elements"
+spec = ["9.2:10"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut i32 = @alloc(3);
+        @ptr_write(p, 10);
+        @ptr_write(@ptr_offset(p, 1), 20);
+        @ptr_write(@ptr_offset(p, 2), 30);
+        @ptr_read(p) + @ptr_read(@ptr_offset(p, 1)) + @ptr_read(@ptr_offset(p, 2))
+    }
+}
+"""
+exit_code = 60
+
+# =============================================================================
+# @free releases an allocated block (value read out before freeing).
+# =============================================================================
+
+[[case]]
+name = "alloc_then_free"
+spec = ["9.2:11"]
+source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut i32 = @alloc(2);
+        @ptr_write(p, 7);
+        let v: i32 = @ptr_read(p);
+        @free(p, 2);
+        v
+    }
+}
+"""
+exit_code = 7
+
+# =============================================================================
+# @realloc grows a block and preserves the existing contents.
+# =============================================================================
+
+[[case]]
+name = "realloc_preserves_contents"
+spec = ["9.2:12"]
+source = """
+fn main() -> i32 {
+    checked {
+        let mut p: ptr mut i32 = @alloc(2);
+        @ptr_write(p, 5);
+        @ptr_write(@ptr_offset(p, 1), 7);
+        p = @realloc(p, 2, 8);
+        let sum: i32 = @ptr_read(p) + @ptr_read(@ptr_offset(p, 1));
+        @free(p, 8);
+        sum
+    }
+}
+"""
+exit_code = 12
+
+# @realloc of a null pointer behaves like a fresh @alloc.
+[[case]]
+name = "realloc_null_is_alloc"
+spec = ["9.2:12"]
+source = """
+fn main() -> i32 {
+    checked {
+        let zero: u64 = 0;
+        let start: ptr mut i32 = @int_to_ptr(zero);
+        let p: ptr mut i32 = @realloc(start, 0, 4);
+        @ptr_write(p, 99);
+        let v: i32 = @ptr_read(p);
+        @free(p, 4);
+        v
+    }
+}
+"""
+exit_code = 99
+
+# =============================================================================
+# Legality: heap intrinsics require a `checked` block.
+# =============================================================================
+
+[[case]]
+name = "alloc_requires_checked"
+spec = ["9.2:13"]
+source = """
+fn main() -> i32 {
+    let p: ptr mut i32 = @alloc(4);
+    0
+}
+"""
+compile_fail = true
+
+[[case]]
+name = "free_requires_checked"
+spec = ["9.2:13"]
+source = """
+fn main() -> i32 {
+    let zero: u64 = 0;
+    let p: ptr mut i32 = checked { @int_to_ptr(zero) };
+    @free(p, 4);
+    0
+}
+"""
+compile_fail = true

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -83,3 +83,66 @@ fn main() -> i32 {
     }
 }
 ```
+
+## Heap Allocation Intrinsics
+
+{{ rule(id="9.2:9", cat="normative") }}
+
+The `@alloc`, `@free`, and `@realloc` intrinsics provide raw, unchecked access
+to the heap. Like the raw-pointer intrinsics they may only appear inside a
+`checked` block (§9.1). They are the primitives on which safe, owned
+collections (for example a source-level `Vec`) are built: the unsafety is
+confined to the collection's internals behind a checked API.
+
+{{ rule(id="9.2:10", cat="dynamic-semantics") }}
+
+`@alloc(count)` allocates a heap block large enough to hold `count` elements of
+type `T` — that is, `count * size_of(T)` bytes of **uninitialized** storage —
+and returns a `ptr mut T` addressing the block. The element type `T` (and hence
+the result type `ptr mut T`) is inferred from the surrounding context, exactly
+as for `@int_to_ptr`. `count` must have type `u64`. On allocation failure the
+returned pointer is null; the caller is responsible for checking. The returned
+pointer is suitable for `@ptr_offset`/`@ptr_read`/`@ptr_write` over the
+`count` elements (element `i` at `@ptr_offset(p, i)`).
+
+{{ rule(id="9.2:11", cat="dynamic-semantics") }}
+
+`@free(p, count)` releases a block previously returned by `@alloc`/`@realloc`,
+where `p` is a `ptr mut T` and `count` (a `u64`) is the element count that was
+allocated. Using `p` after it is freed is undefined behavior. Freeing a null
+pointer is permitted and has no effect.
+
+{{ rule(id="9.2:12", cat="dynamic-semantics") }}
+
+`@realloc(p, old_count, new_count)` resizes the block addressed by `p` (a
+`ptr mut T`) from `old_count` to `new_count` elements and returns a `ptr mut T`
+to the resized block, which may differ from `p`. The first
+`min(old_count, new_count)` elements are preserved. If `p` is null it behaves
+like `@alloc(new_count)`. `old_count` and `new_count` must have type `u64`. The
+result type is the same pointer type as `p`.
+
+{{ rule(id="9.2:13", cat="legality-rule") }}
+
+`@alloc`, `@free`, and `@realloc` may only be used inside a `checked` block. The
+element-count arguments (`count`, `old_count`, `new_count`) must be `u64`, and
+the pointer arguments of `@free`/`@realloc` must be a mutable pointer
+`ptr mut T`. The result type of `@alloc` must be resolvable to a `ptr mut T`
+from context.
+
+{{ rule(id="9.2:14", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    checked {
+        // Allocate room for 4 i32s, write three, read one back, then free.
+        let p: ptr mut i32 = @alloc(4);
+        @ptr_write(p, 10);
+        @ptr_write(@ptr_offset(p, 1), 20);
+        @ptr_write(@ptr_offset(p, 2), 30);
+        let grown: ptr mut i32 = @realloc(p, 4, 8); // contents preserved
+        let v: i32 = @ptr_read(@ptr_offset(grown, 1)); // 20
+        @free(grown, 8);
+        v
+    }
+}
+```

--- a/examples/std/option.rue
+++ b/examples/std/option.rue
@@ -1,0 +1,24 @@
+// Option(T) — an optional value, written in Rue as a comptime-generic enum.
+//
+//     let OptI = @import("option.rue").Option(i32);
+//     let x: OptI = OptI::Some(42);
+//     match x {
+//         OptI::Some(v) => v,
+//         OptI::None => 0,
+//     }
+//
+// Requires `--preview enum_payloads`.
+//
+// NOTE: `Option(T)` works standalone (see the dogfood test), but it cannot yet
+// be *returned from a `Vec(T)` method* — the enclosing comptime type parameter
+// `T` is not usable inside a method body to name `Option(T)` (E1201), and
+// binding the type in the type-function body breaks comptime type folding
+// (E1200). Until that gap is closed, `Vec` uses caller-supplied defaults
+// (`get_or`/`pop_or`) rather than `Option(T)` accessors. See the meta report.
+
+pub fn Option(comptime T: type) -> type {
+    enum {
+        Some(T),
+        None,
+    }
+}

--- a/examples/std/vec.rue
+++ b/examples/std/vec.rue
@@ -1,0 +1,167 @@
+// Vec(T) — a growable, heap-backed collection written in Rue (RUE-1, ADR-0041).
+//
+// This is a *source-level* standard-library type: it owns a heap buffer
+// addressed by a raw `ptr mut T` and grows it (amortized 2x) with the unchecked
+// heap intrinsics `@alloc`/`@realloc`/`@free`, all confined to `checked {}`
+// blocks behind a safe method API. It exercises comptime generics, `inout self`
+// mutation, and the raw-pointer intrinsics all at once — exactly the "stdlib on
+// unchecked code" framing of RUE-1.
+//
+// Usage (the element type is chosen when you instantiate the type function):
+//
+//     let V = @import("vec.rue").Vec(i32);   // or, same-directory, just Vec(i32)
+//     let mut v = V::new();
+//     v.push(10);
+//     v.push(20);
+//     let n = v.len();          // 2
+//     let x = v.get(0);         // 10
+//     v.set(0, 99);
+//     let last = v.pop_or(0);   // 20
+//     v.free();                 // release the buffer
+//
+// Requires `--preview method_receivers` (borrow/inout receivers, ADR-0037).
+//
+// SCOPE / KNOWN LIMITATIONS (tracked separately — this file deliberately does
+// not work around them):
+//
+//   * Copy element types only. `get`/`pop_or` return an element *by copy*
+//     (`@ptr_read`). Move-out of a non-Copy element and an `Option`-returning
+//     accessor are blocked today because the enclosing comptime type parameter
+//     `T` is not usable inside a method body to name `Option(T)` (E1201), so the
+//     API uses caller-supplied defaults (`get_or`, `pop_or`) for out-of-bounds
+//     instead of `Option(T)`. See the meta report for RUE issue references.
+//   * No automatic destructor. A `drop fn` cannot attach to the anonymous
+//     struct produced by a comptime type function (E0417), so the buffer is not
+//     freed automatically at scope exit — call `free()` explicitly. (The
+//     `@free`-from-a-destructor path itself works and is proven on a concrete
+//     named struct; it is the *generic* attachment that is blocked.)
+//   * Element type must be a single 8-byte slot (scalars: iN/uN/bool, or a
+//     one-field struct). Multi-slot aggregate elements are miscompiled by the
+//     aggregate raw-pointer path (descending slot offsets underflow the
+//     ascending heap element base) — a separate raw-pointer bug, not a Vec bug.
+
+pub fn Vec(comptime T: type) -> type {
+    struct {
+        buf: ptr mut T,
+        len: u64,
+        cap: u64,
+
+        // --- construction ---
+
+        // An empty vector. No allocation is performed until the first push.
+        fn new() -> Self {
+            let zero: u64 = 0;
+            Self {
+                buf: checked { @int_to_ptr(zero) },
+                len: 0,
+                cap: 0,
+            }
+        }
+
+        // An empty vector with room pre-reserved for `n` elements.
+        fn with_capacity(n: u64) -> Self {
+            let zero: u64 = 0;
+            let mut v = Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 };
+            if n > 0 {
+                // `@realloc` of the null buffer allocates a fresh block; its
+                // result type is inferred from `v.buf` (a `ptr mut T` field),
+                // so no `T` annotation is needed in the method body.
+                checked {
+                    let grown = @realloc(v.buf, v.cap, n);
+                    v.buf = grown;
+                };
+                v.cap = n;
+            }
+            v
+        }
+
+        // --- reads ---
+
+        fn len(borrow self) -> u64 { self.len }
+        fn capacity(borrow self) -> u64 { self.cap }
+        fn is_empty(borrow self) -> bool { self.len == 0 }
+
+        // Element `i` by copy. The caller must ensure `i < len` (use `get_or`
+        // for a bounds-checked read). Reading out of bounds is a heap OOB read.
+        fn get(borrow self, i: u64) -> T {
+            checked { @ptr_read(@ptr_offset(self.buf, i)) }
+        }
+
+        // Element `i` by copy, or `default` when `i` is out of bounds. This is
+        // the non-trapping accessor (the `Copy`-only stand-in for the
+        // `Option(T)`-returning `get` described in ADR-0041, blocked today).
+        fn get_or(borrow self, i: u64, default: T) -> T {
+            if i < self.len {
+                checked { @ptr_read(@ptr_offset(self.buf, i)) }
+            } else {
+                default
+            }
+        }
+
+        // --- mutation ---
+
+        // Ensure there is room for at least one more element, growing the
+        // buffer (amortized 2x) when full. Internal helper.
+        fn reserve(inout self) {
+            if self.len == self.cap {
+                let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
+                checked {
+                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    self.buf = grown;
+                };
+                self.cap = new_cap;
+            }
+        }
+
+        // Append `x` to the end, growing if necessary.
+        fn push(inout self, x: T) {
+            self.reserve();
+            checked {
+                let slot = @ptr_offset(self.buf, self.len);
+                @ptr_write(slot, x);
+            };
+            self.len = self.len + 1;
+        }
+
+        // Remove and return the last element, or `default` when empty. (The
+        // `Option(T)`-returning `pop` of ADR-0041 is blocked today; this is the
+        // Copy-typed stand-in.)
+        fn pop_or(inout self, default: T) -> T {
+            if self.len == 0 {
+                default
+            } else {
+                self.len = self.len - 1;
+                checked { @ptr_read(@ptr_offset(self.buf, self.len)) }
+            }
+        }
+
+        // Overwrite element `i` with `x`. Out-of-bounds indices are ignored.
+        fn set(inout self, i: u64, x: T) {
+            if i < self.len {
+                checked {
+                    let slot = @ptr_offset(self.buf, i);
+                    @ptr_write(slot, x);
+                };
+            }
+        }
+
+        // Drop all elements (keeps the allocated capacity). For Copy `T` this
+        // just resets the length.
+        fn clear(inout self) {
+            self.len = 0;
+        }
+
+        // --- teardown ---
+
+        // Release the heap buffer and reset to the empty state. Because a
+        // generic anonymous struct cannot yet carry a `drop fn` (E0417), this
+        // must be called explicitly to avoid leaking the buffer.
+        fn free(inout self) {
+            checked { @free(self.buf, self.cap); };
+            let zero: u64 = 0;
+            self.buf = checked { @int_to_ptr(zero) };
+            self.len = 0;
+            self.cap = 0;
+        }
+    }
+}

--- a/examples/std/vec_demo.rue
+++ b/examples/std/vec_demo.rue
@@ -1,0 +1,39 @@
+// Dogfood for the source-level Vec(T) library (examples/std/vec.rue, RUE-1).
+//
+// Compile (multi-file; names resolve across the listed files):
+//   rue examples/std/vec_demo.rue examples/std/vec.rue \
+//       --preview method_receivers -o vec_demo
+//
+// Exercises push/len/get/set/pop/while-sum/out-of-bounds on a Vec(i32).
+
+fn main() -> i32 {
+    let m = @import("vec.rue");
+    let V = m.Vec(i32);
+
+    let mut v = V::new();
+    v.push(10);
+    v.push(20);
+    v.push(30);
+    @dbg(v.len());          // 3
+
+    @dbg(v.get(1));         // 20
+    v.set(0, 99);
+    @dbg(v.get(0));         // 99
+
+    @dbg(v.pop_or(0));      // 30 (removed)
+    @dbg(v.len());          // 2
+
+    @dbg(v.get_or(99, 0));  // 0  (out-of-bounds -> default)
+
+    // Sum the remaining elements with a manual while loop (no for/index sugar).
+    let mut i: u64 = 0;
+    let mut sum: i32 = 0;
+    while i < v.len() {
+        sum = sum + v.get(i);
+        i = i + 1;
+    }
+    @dbg(sum);              // 99 + 20 = 119
+
+    v.free();
+    sum
+}


### PR DESCRIPTION
The dogfooding keystone, per Steve's ratified path (2026-07-03): expose heap to Rue source, then write Vec in Rue. (The ADR-0041 'falls out of the spine' premise was refuted — a source Vec was blocked with no reachable heap; this fixes that; the v[i]/for sugar stays deferred to traits, Vec uses methods.)

**Part 1** — @alloc(comptime T, count)->ptr mut T, @free(ptr, count), @realloc: unchecked heap intrinsics (checked{}-gated like @raw, E1300 outside checked), wired known_symbols -> inference -> sema -> BOTH codegen backends, calling the existing __rue_alloc/__rue_free/__rue_realloc runtime (rue-runtime unchanged).

**Part 2** — examples/std/{vec,option,vec_demo}.rue: a generic Vec(T) on @alloc/@realloc/@free with new/push/pop/get/set/len/free, plus Option. The dogfood runs (--preview method_receivers): push/len/get/set/pop/while-sum/OOB -> stdout 3,20,99,30,2,0,119.

Verified: @alloc/write/read/free -> 60, realloc preserves, gate E1300, aarch64 asm; vec_i32_dogfood + alloc_write_read_free CLI tests pass. clippy-gate-passed; test.sh green (641/641); oracle-diff 300 seeds 0 disagreements. 7 spec + 5 CLI cases.

Three real gaps hit and filed separately (not forced): drop-fn on a comptime-fn's anon struct; enclosing comptime T in method bodies; and a multi-slot-aggregate @ptr_write/@ptr_read descending-offset bug — so Vec is currently scoped to single-slot Copy element types.

Part of RUE-1
Part of RUE-226

Generated with Claude Code