### PR TITLE
Stabilize for_loops, method_receivers, enum_payloads, array_repeat + sound enum spec (RUE-294)

### DIFF
--- a/.buckconfig.local
+++ b/.buckconfig.local
@@ -1,2 +1,0 @@
-[buck2]
-file_watcher = fs_hash_crawler

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1676,11 +1676,6 @@ impl<'a> Sema<'a> {
             .find(|(name, _, mode, _)| *name == self_sym && *mode != RirParamMode::Normal)
         {
             debug_assert!(matches!(mode, RirParamMode::Inout | RirParamMode::Borrow));
-            self.require_preview(
-                PreviewFeature::MethodReceivers,
-                "borrow/inout method receivers",
-                self.rir.get(body).span,
-            )?;
         }
 
         let mut param_vec: Vec<ParamInfo> = Vec::new();
@@ -3760,8 +3755,6 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        self.require_preview(PreviewFeature::ForLoops, "the `for` loop", span)?;
-
         let coll = args[0].value;
         let coll_result = self.analyze_borrowed_collection(air, coll, ctx)?;
         let coll_type = coll_result.ty;

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -25,7 +25,7 @@ use std::collections::HashMap;
 use lasso::Spur;
 use rue_error::{
     CompileError, CompileResult, CompileWarning, ErrorKind, MissingFieldsError, OptionExt,
-    PreviewFeature, WarningKind,
+    WarningKind,
 };
 use rue_rir::{InstData, InstRef, RirArgMode, RirParamMode, RirPattern};
 
@@ -1727,13 +1727,6 @@ impl<'a> Sema<'a> {
             return Ok(Vec::new());
         }
         let pattern_span = *span;
-
-        // Binding payload data requires the preview feature.
-        self.require_preview(
-            PreviewFeature::EnumPayloads,
-            "enum payload bindings in a match pattern",
-            pattern_span,
-        )?;
 
         let enum_id = if let Some(module_ref) = module {
             self.resolve_enum_through_module(*module_ref, *type_name, pattern_span)?
@@ -3789,14 +3782,6 @@ impl<'a> Sema<'a> {
             self.reject_non_runtime_array_element(value_ty, span)?;
         }
 
-        // Gate the whole form: without `--preview array_repeat`, using
-        // `[value; count]` is a "requires preview feature" error.
-        self.require_preview(
-            PreviewFeature::ArrayRepeat,
-            "array-repeat literal `[value; count]`",
-            span,
-        )?;
-
         let array_type = Self::get_resolved_type(ctx, inst_ref, span, "array-repeat literal")?;
 
         // If the value expression is ill-typed, HM collapses the array to
@@ -4939,15 +4924,6 @@ impl<'a> Sema<'a> {
         let payload_types = def.variant_payload(variant_index as usize).to_vec();
         let variant_name = def.variants[variant_index as usize].clone();
         let enum_name = def.name.clone();
-
-        // Constructing a payload-carrying variant requires the preview feature.
-        if !payload_types.is_empty() {
-            self.require_preview(
-                PreviewFeature::EnumPayloads,
-                "enum payloads (variants that carry data)",
-                span,
-            )?;
-        }
 
         // Visibility check, mirroring the bare-path `EnumVariant` handler
         // (E0460, privacy is uniform across item kinds). A comptime-bound enum

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -13,9 +13,7 @@ use std::collections::{HashMap, HashSet};
 
 use lasso::{Key, Spur};
 use rue_builtins::is_reserved_type_name;
-use rue_error::{
-    CompileError, CompileResult, CopyStructNonCopyFieldError, ErrorKind, PreviewFeature, ice,
-};
+use rue_error::{CompileError, CompileResult, CopyStructNonCopyFieldError, ErrorKind, ice};
 use rue_rir::{InstData, InstRef, RirDirective, RirParamMode};
 use rue_span::{FileId, Span};
 
@@ -303,21 +301,8 @@ impl<'a> Sema<'a> {
                     name,
                     variants_start,
                     variants_len,
-                    payloads_len,
                     ..
                 } => {
-                    // Tuple-variant payloads (RUE-221, ADR-0038) are gated
-                    // behind the `enum_payloads` preview feature. A payload
-                    // region of length 0 means every variant is
-                    // discriminant-only (C-like), which is always allowed.
-                    if *payloads_len > 0 {
-                        self.require_preview(
-                            PreviewFeature::EnumPayloads,
-                            "enum payloads (variants that carry data)",
-                            inst.span,
-                        )?;
-                    }
-
                     let enum_name = self.interner.resolve(&*name).to_string();
 
                     // Check for collision with built-in type names

--- a/crates/rue-cli-tests/cases/aggregate_abi_matrix.toml
+++ b/crates/rue-cli-tests/cases/aggregate_abi_matrix.toml
@@ -19,7 +19,7 @@
 #   S1   struct, 1 slot        S8    struct, 8 slots (> the 6-register budget)
 #   S2   struct, 2 slots       NEST  nested struct (Inner in Outer)
 #   S3   struct, 3 slots       ARR   fixed array [i32; N]
-#   AOS  array-of-struct       ENUM  payload enum (--preview enum_payloads)
+#   AOS  array-of-struct       ENUM  payload enum
 #
 # POSITIONS (columns), each a boundary an aggregate must cross intact:
 #   let-init (Alloc) · fn param by-value · by-value return · struct field
@@ -490,7 +490,7 @@ stdout = "1\n4\n"
 
 # =============================================================================
 # ENUM — payload enum (tagged union: slot 0 discriminant + payload slots).
-# The whole family is gated behind --preview enum_payloads. These are the RUE-237
+# These are the RUE-237
 # class: enums were forgotten by scattered `is_struct() || is_array()` gates, so
 # their payload slots were dropped crossing exactly these boundaries.
 # =============================================================================
@@ -498,7 +498,7 @@ stdout = "1\n4\n"
 # match binding: construct each variant, cross the call ABI, extract payloads.
 [[case]]
 name = "enum_param_match"
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn area(s: Shape) -> i32 {
@@ -521,7 +521,7 @@ stdout = "5\n7\n0\n"
 # block param (the exact aarch64 gate RUE-248 repaired) then out by value.
 [[case]]
 name = "enum_return_join"
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum E { V(i32, i32), Empty }
 fn sum(e: E) -> i32 { match e { E::V(x, y) => x + y, E::Empty => 0 } }
@@ -540,7 +540,7 @@ stdout = "7\n70\n"
 # then read back.
 [[case]]
 name = "enum_field_write_read"
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum E { V(i32, i32), Empty }
 fn sum(e: E) -> i32 { match e { E::V(x, y) => x + y, E::Empty => 0 } }
@@ -557,7 +557,7 @@ stdout = "15\n9\n"
 # array element write/read: a payload enum in an array slot.
 [[case]]
 name = "enum_array_elem_rw"
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum E { V(i32, i32), Empty }
 fn sum(e: E) -> i32 { match e { E::V(x, y) => x + y, E::Empty => 0 } }
@@ -573,7 +573,7 @@ stdout = "11\n"
 # mutable-local reassign (Store) of a whole payload enum.
 [[case]]
 name = "enum_mut_reassign"
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum E { V(i32, i32), Empty }
 fn sum(e: E) -> i32 { match e { E::V(x, y) => x + y, E::Empty => 0 } }
@@ -590,7 +590,7 @@ stdout = "50\n"
 # through the pointer.
 [[case]]
 name = "enum_inout_reassign"
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum E { V(i32, i32), Empty }
 fn sum(e: E) -> i32 { match e { E::V(x, y) => x + y, E::Empty => 0 } }
@@ -607,7 +607,7 @@ stdout = "123\n"
 # @ptr_read / @ptr_write round trip over a whole payload enum value.
 [[case]]
 name = "enum_ptr_rw"
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum E { V(i32, i32), Empty }
 fn sum(e: E) -> i32 { match e { E::V(x, y) => x + y, E::Empty => 0 } }

--- a/crates/rue-cli-tests/cases/array_element_module.toml
+++ b/crates/rue-cli-tests/cases/array_element_module.toml
@@ -32,7 +32,7 @@ pub fn value() -> i32 { 1 }
 [[case]]
 name = "module_in_array_repeat_is_e0206"
 description = "`[h; 3]` where `h` is an imported module → clean E0206 (was intern-pool SIGABRT)."
-args = ["main.rue", "--preview", "array_repeat", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E0206", "<module>"]
 files = [

--- a/crates/rue-cli-tests/cases/array_repeat.toml
+++ b/crates/rue-cli-tests/cases/array_repeat.toml
@@ -1,8 +1,8 @@
-# Array-repeat literal `[value; count]` (RUE-235, preview: array_repeat).
+# Array-repeat literal `[value; count]` (RUE-235).
 #
 # Exercises the real driver end-to-end: the repeat form fills `count` slots
 # with copies of a single value, the count may be a literal or a named const,
-# a non-Copy element is rejected, and the form is preview-gated. stdout is
+# a non-Copy element is rejected. stdout is
 # pinned (via @dbg) so a miscompiled fill is caught, not just the exit code.
 
 [section]
@@ -12,7 +12,7 @@ description = "The `[value; count]` array-repeat literal fills count slots with 
 
 [[case]]
 name = "repeat_literal_count"
-args = ["--preview", "array_repeat", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let b = [7; 3];
@@ -24,7 +24,7 @@ stdout = "21\n"
 
 [[case]]
 name = "repeat_zeros_128_all_zero"
-args = ["--preview", "array_repeat", "--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let a: [i32; 128] = [0; 128];
@@ -40,7 +40,7 @@ stdout = "0\n"
 
 [[case]]
 name = "repeat_named_const_count"
-args = ["--preview", "array_repeat", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 const N: usize = 4;
 fn main() -> i32 {
@@ -53,7 +53,7 @@ stdout = "20\n"
 
 [[case]]
 name = "repeat_copy_struct_fills_each_slot"
-args = ["--preview", "array_repeat", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 @copy
 struct P { x: i32, y: i32 }
@@ -67,7 +67,7 @@ stdout = "14\n"
 
 [[case]]
 name = "repeat_non_copy_element_rejected"
-args = ["--preview", "array_repeat", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Data { value: i32 }
 fn main() -> i32 {
@@ -78,14 +78,3 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["E0905", "not Copy"]
-
-[[case]]
-name = "repeat_requires_preview"
-files = [{ path = "main.rue", source = """
-fn main() -> i32 {
-    let b = [7; 3];
-    b[0]
-}
-""" }]
-compile_fail = true
-error_contains = ["requires preview feature", "array_repeat"]

--- a/crates/rue-cli-tests/cases/drop_intrinsic.toml
+++ b/crates/rue-cli-tests/cases/drop_intrinsic.toml
@@ -129,12 +129,12 @@ fn main() -> i32 {
 compile_fail = true
 error_contains = ["E0205", "use of moved value"]
 
-# (d) @drop of a payload-carrying enum (enum_payloads preview): discharges the
-# value, runs, and drops exactly once. Enum payloads are trivially droppable
-# today, so this pins compile+run (7) rather than payload-glue side effects.
+# (d) @drop of a payload-carrying enum: discharges the
+# value, runs, and drops exactly once. This enum's payload is trivially
+# droppable (i32), so this pins compile+run (7) rather than payload-glue side effects.
 [[case]]
 name = "drop_payload_enum"
-description = "@drop of a payload-carrying enum compiles, consumes the value, and runs (preview enum_payloads)."
+description = "@drop of a payload-carrying enum compiles, consumes the value, and runs."
 files = [{ path = "main.rue", source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 
@@ -145,7 +145,7 @@ fn main() -> i32 {
     0
 }
 """ }]
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 stdout = "7\n"
 exit_code = 0
 

--- a/crates/rue-cli-tests/cases/enum_array_payload.toml
+++ b/crates/rue-cli-tests/cases/enum_array_payload.toml
@@ -1,5 +1,4 @@
-# Array-typed enum tuple-variant payloads (RUE-260), gated behind the
-# `enum_payloads` preview feature.
+# Array-typed enum tuple-variant payloads (RUE-260).
 #
 # Before the fix, constructing an enum tuple-variant whose declared payload is
 # an array spuriously failed with E0206: the construction path wrapped the
@@ -20,7 +19,7 @@ description = "Enum tuple variants may carry array payloads; array literals unif
 [[case]]
 name = "int_array_payload_constructs_and_round_trips"
 description = "RUE-260: `Wrapper::Has([1, 2])` compiles and the payload round-trips through a match: 10 + 20 = 30."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Wrapper { Has([i32; 2]), None }
 fn main() -> i32 {
@@ -36,7 +35,7 @@ exit_code = 30
 [[case]]
 name = "struct_element_array_payload_constructs"
 description = "RUE-260: an array-of-struct payload (`[Guard; 2]`) constructs and round-trips: 1 + 2 = 3."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Guard { v: i32 }
 enum Wrapper { Has([Guard; 2]), None }
@@ -53,7 +52,7 @@ exit_code = 3
 [[case]]
 name = "wrong_element_type_array_payload_rejected"
 description = "RUE-260 control: an array payload with the wrong element type still reports E0206."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Wrapper { Has([i32; 2]), None }
 fn main() -> i32 {
@@ -67,7 +66,7 @@ error_contains = ["E0206"]
 [[case]]
 name = "wrong_length_array_payload_rejected"
 description = "RUE-260 control: an array payload with the wrong length still reports E0901."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Wrapper { Has([i32; 2]), None }
 fn main() -> i32 {

--- a/crates/rue-cli-tests/cases/enum_payloads.toml
+++ b/crates/rue-cli-tests/cases/enum_payloads.toml
@@ -1,6 +1,5 @@
-# Enum payloads — sum types with data (RUE-221, ADR-0038), gated behind the
-# `enum_payloads` preview feature. These cases drive the real compiler with
-# `--preview enum_payloads` and assert exact runtime behavior: tuple-variant
+# Enum payloads — sum types with data (RUE-221, ADR-0038). These cases drive the
+# real compiler and assert exact runtime behavior: tuple-variant
 # construction, tagged-union layout, match-with-payload-bindings (move mode),
 # and drop-through-the-active-variant running exactly once.
 
@@ -14,7 +13,7 @@ description = "Tuple-variant construction, match-with-bindings, and drop of the 
 [[case]]
 name = "construct_match_compute"
 description = "Construct each variant form, match to extract payloads, compute 5+7+0 = 12."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn area(s: Shape) -> i32 {
@@ -35,7 +34,7 @@ exit_code = 12
 [[case]]
 name = "drop_once_via_active_variant"
 description = "Payload struct with `drop fn` moved out of the enum via a match binding drops exactly once: @dbg prints 7 once, exit 7."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Res { id: i32 }
 drop fn Res(self) { @dbg(self.id); }
@@ -58,7 +57,7 @@ exit_code = 7
 [[case]]
 name = "active_variant_drop_glue_has"
 description = "Unmatched enum with a droppable active-variant payload drops it once at scope exit: prints -1 then 9."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
@@ -76,7 +75,7 @@ exit_code = 0
 [[case]]
 name = "active_variant_drop_glue_none"
 description = "Unmatched enum whose active variant is discriminant-only drops nothing: prints only -1."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
@@ -95,7 +94,7 @@ exit_code = 0
 [[case]]
 name = "match_move_no_double_drop"
 description = "A payload moved out via a match binding drops exactly once — the scope-exit glue does not double-drop it: prints 7 once."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
@@ -117,7 +116,7 @@ exit_code = 7
 [[case]]
 name = "linear_enum_must_consume"
 description = "An enum with a linear-payload variant is linear: leaving a value unconsumed is E0406."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 linear struct L { v: i32 }
 enum E { Has(L), None }
@@ -134,7 +133,7 @@ error_contains = ["E0406", "must be consumed"]
 [[case]]
 name = "linear_enum_consumed_ok"
 description = "Consuming a linear enum via a match that moves and consumes the payload satisfies must-consume: exit 5."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 linear struct L { v: i32 }
 enum E { Has(L), None }
@@ -154,7 +153,7 @@ exit_code = 5
 [[case]]
 name = "copy_payload_enum_stays_copy"
 description = "An enum whose only payloads are Copy stays Copy — usable twice with no must-consume/move error: exit 6."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum C { A(i32), B }
 fn val(c: C) -> i32 { match c { C::A(x) => x, C::B => 0 } }
@@ -172,7 +171,7 @@ exit_code = 6
 [[case]]
 name = "by_value_enum_return_carries_payload"
 description = "A function returning a payload enum by value carries the payload through the ABI: make() -> Some(42), match extracts 42."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Opt { Some(i32), None }
 fn make() -> Opt { Opt::Some(42) }
@@ -190,7 +189,7 @@ exit_code = 42
 [[case]]
 name = "enum_passthru_roundtrip"
 description = "Passing a payload enum in and returning it unchanged round-trips the payload: passthru(Circle(9)) -> 9."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Shape { Circle(i32), Square(i32) }
 fn passthru(s: Shape) -> Shape { s }
@@ -210,7 +209,7 @@ exit_code = 9
 [[case]]
 name = "struct_field_enum_carries_payload"
 description = "A payload enum stored in a struct field keeps its payload: w.o = Some(42), match extracts 42."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Opt { Some(i32), None }
 struct Wrapper { o: Opt }
@@ -229,7 +228,7 @@ exit_code = 42
 [[case]]
 name = "array_element_enum_carries_payload"
 description = "Payload enums in an array literal keep their payloads: [Some(10), Some(32)], 10 + 32 = 42."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Opt { Some(i32), None }
 fn main() -> i32 {
@@ -248,7 +247,7 @@ exit_code = 42
 [[case]]
 name = "wildcard_arm_drops_discarded_payload"
 description = "A bare `_` match arm over a payload enum drops the discarded active payload exactly once: prints 7."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
@@ -266,7 +265,7 @@ exit_code = 0
 [[case]]
 name = "wildcard_arm_no_payload_drops_nothing"
 description = "A bare `_` arm whose active variant is discriminant-only drops nothing: no output, exit 0."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
@@ -283,7 +282,7 @@ exit_code = 0
 [[case]]
 name = "wildcard_catchall_drops_caught_payload"
 description = "A `_` catch-all that catches a droppable variant drops its payload once: E::Has caught by `_`, prints 7."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
@@ -299,18 +298,6 @@ fn main() -> i32 {
 stdout = "7\n"
 exit_code = 0
 
-# Without the preview flag, a payload-carrying enum is a clean preview error
-# (the driver reports it, no ICE).
-[[case]]
-name = "payload_requires_preview_flag"
-description = "Declaring a tuple variant without --preview enum_payloads is a preview-feature error, not an ICE."
-files = [{ path = "main.rue", source = """
-enum Shape { Circle(i32), Empty }
-fn main() -> i32 { 0 }
-""" }]
-compile_fail = true
-error_contains = ["requires preview feature"]
-
 # =============================================================================
 # Generic enums — Option/Result as comptime type functions (RUE-6 phase 2,
 # ADR-0038). The enum analog of the anonymous-struct comptime type functions:
@@ -322,7 +309,7 @@ error_contains = ["requires preview feature"]
 [[case]]
 name = "generic_option_construct_match"
 description = "Inline generic Option enum: Some(5) matches to 5, None matches to 0; sum is 5."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
@@ -340,7 +327,7 @@ exit_code = 5
 [[case]]
 name = "generic_option_bool_instantiation"
 description = "Option(bool) is a distinct monomorphization: Some(true) matches to 7."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
@@ -355,7 +342,7 @@ exit_code = 7
 [[case]]
 name = "generic_result_two_params"
 description = "Two-param Result enum: Ok(100) -> 100, Err(true) -> 42; sum is 142."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
 fn main() -> i32 {
@@ -374,7 +361,7 @@ exit_code = 142
 [[case]]
 name = "generic_option_distinct_types_rejected"
 description = "Assigning an Option(bool) value to an Option(i32)-typed binding is a type error."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
@@ -392,7 +379,7 @@ error_contains = ["type mismatch"]
 [[case]]
 name = "generic_enum_payload_drop_once"
 description = "Generic Option holding a struct with `drop fn`: dropping the enum runs the payload destructor once (@dbg prints 33)."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Noisy { code: i32 }
 drop fn Noisy(self) { @dbg(self.code); }
@@ -415,7 +402,7 @@ exit_code = 33
 [[case]]
 name = "generic_enum_linear_payload_must_consume"
 description = "A generic Result whose Err payload is a linear struct is itself linear: leaving it unconsumed is E0406."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 linear struct Token { v: i32 }
 fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }

--- a/crates/rue-cli-tests/cases/for_loop_iter_borrow.toml
+++ b/crates/rue-cli-tests/cases/for_loop_iter_borrow.toml
@@ -22,7 +22,7 @@ description = "A `for` loop is a shared borrow: non-Copy elements iterate withou
 [[case]]
 name = "mutate_iterated_element_is_e0428"
 description = "RUE-233: `a[2] = 100` inside `for x in a` mutates a shared-borrowed collection (E0428)."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E0428"]
 files = [{ path = "main.rue", source = """
@@ -40,7 +40,7 @@ fn main() -> i32 {
 [[case]]
 name = "reassign_iterated_array_is_e0428"
 description = "RUE-233: whole-array reassign `a = [7,8,9]` inside `for x in a` is E0428."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E0428"]
 files = [{ path = "main.rue", source = """
@@ -58,7 +58,7 @@ fn main() -> i32 {
 [[case]]
 name = "mutate_different_array_is_fine"
 description = "Control: iterating `b` while mutating a DIFFERENT array `a` compiles and runs (60 + 100)."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let mut a: [i32; 3] = [1, 2, 3];
@@ -76,7 +76,7 @@ exit_code = 160
 [[case]]
 name = "read_only_for_loop_still_works"
 description = "Control: a read-only `for x in a` still compiles and sums correctly (1+2+3 = 6)."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let a: [i32; 3] = [1, 2, 3];
@@ -94,7 +94,7 @@ exit_code = 6
 [[case]]
 name = "non_copy_element_iterates"
 description = "RUE-259: a non-Copy struct element iterates by shared borrow (was wrongly E0904); sums to 4."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Point { x: i32, y: i32 }
 fn main() -> i32 {
@@ -111,7 +111,7 @@ exit_code = 4
 [[case]]
 name = "non_copy_element_destructor_runs_once"
 description = "RUE-259: the array (not the loop binder) drops each element once — destructor fires exactly once per element."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Res { tag: i32 }
 drop fn Res(self) { @dbg(self.tag); }
@@ -130,7 +130,7 @@ exit_code = 33
 [[case]]
 name = "non_copy_wildcard_binder_destructor_once"
 description = "RUE-259: `for _ in a` over a drop-bearing element also borrows (not discards) it — the array drops each element once, not twice."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Res { tag: i32 }
 drop fn Res(self) { @dbg(self.tag); }
@@ -149,7 +149,7 @@ exit_code = 2
 [[case]]
 name = "move_element_out_is_error"
 description = "RUE-259: moving the binder out of the loop would double-drop — rejected (cannot move out of borrowed value)."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["cannot move out of borrowed value"]
 files = [{ path = "main.rue", source = """
@@ -171,7 +171,7 @@ fn main() -> i32 {
 [[case]]
 name = "mutate_via_method_in_chars_loop_is_e0428"
 description = "RUE-257: `s.clear()` inside `for c in s.chars()` mutates a shared-borrowed String (E0428), not a runtime UTF-8 trap."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E0428"]
 files = [{ path = "main.rue", source = """
@@ -188,7 +188,7 @@ fn main() -> i32 {
 [[case]]
 name = "mutate_via_method_in_byte_loop_is_e0428"
 description = "RUE-257: `s.clear()` inside `for b in s` (byte view) is E0428, not an out-of-bounds trap."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E0428"]
 files = [{ path = "main.rue", source = """
@@ -204,7 +204,7 @@ fn main() -> i32 {
 [[case]]
 name = "read_collection_elsewhere_in_body_is_fine"
 description = "Control: reading (not mutating) the iterated array elsewhere in the body is a shared+shared read — fine."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let a = [1, 2, 3];

--- a/crates/rue-cli-tests/cases/for_loops.toml
+++ b/crates/rue-cli-tests/cases/for_loops.toml
@@ -1,6 +1,6 @@
 # Built-in `for` loops over arrays and string views (RUE-220, ADR-0037).
 #
-# These drive the real compiler with `--preview for_loops` and check exact
+# These drive the real compiler and check exact
 # stdout / exit codes end to end. The `.chars()` cases in particular exercise
 # the `__rue_String_char_scalar` / `__rue_String_char_next` runtime ABI (a
 # String flattened to ptr/len/cap plus a byte offset, returning a scalar / next
@@ -10,12 +10,12 @@
 [section]
 id = "cli.for_loops"
 name = "For loops (iteration layer 1)"
-description = "for over arrays, String bytes, and String .chars(), preview-gated."
+description = "for over arrays, String bytes, and String .chars()."
 
 [[case]]
 name = "for_array_dbg_elements"
 description = "for over an array binds each element in index order; the array is only read, so it stays usable after the loop."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let a: [i32; 4] = [3, 1, 4, 1];
@@ -34,7 +34,7 @@ stdout = "3\n1\n4\n1\n3\n"
 [[case]]
 name = "for_string_bytes_dbg"
 description = "for over a String yields each byte as u8 in ascending byte order; 'café' is 5 bytes (é = 0xC3 0xA9 = 195, 169)."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let s = "café";
@@ -52,7 +52,7 @@ stdout = "99\n97\n102\n195\n169\n"
 [[case]]
 name = "for_chars_scalars_dbg"
 description = "for c in s.chars() decodes UTF-8 and binds each Unicode scalar as u32; 'café' is 4 scalars with é = U+00E9 = 233."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let s = "héllo";
@@ -70,7 +70,7 @@ stdout = "104\n233\n108\n108\n111\n"
 [[case]]
 name = "for_chars_invalid_utf8_traps"
 description = "Strict decode: a truncated multi-byte sequence traps at the decode boundary (exit 101) after the valid prefix has been emitted."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let full = "café";
@@ -88,7 +88,7 @@ runtime_error_contains = ["invalid UTF-8"]
 [[case]]
 name = "for_chars_lossy_valid_dbg"
 description = "for c in s.chars_lossy() decodes well-formed UTF-8 identically to .chars(); 'café' is 4 scalars ending in é = 233."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let s = "café";
@@ -106,7 +106,7 @@ stdout = "99\n97\n102\n233\n"
 [[case]]
 name = "for_chars_lossy_replaces_raw_invalid_bytes"
 description = "Lossy decode over a String holding a raw invalid byte (0xFF): the bad byte becomes U+FFFD (65533) and iteration continues without trapping — the surrounding ASCII bytes decode normally."
-args = ["--preview", "for_loops", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn main() -> i32 {
     let mut s = String::new();
@@ -123,19 +123,3 @@ fn main() -> i32 {
 """ }]
 exit_code = 3
 stdout = "97\n65533\n98\n"
-
-[[case]]
-name = "for_without_preview_is_gated"
-description = "Without --preview for_loops the for loop is rejected as a preview feature."
-args = ["main.rue", "-o", "prog"]
-files = [{ path = "main.rue", source = """
-fn main() -> i32 {
-    let a: [i32; 2] = [1, 2];
-    for x in a {
-        let _y = x;
-    }
-    0
-}
-""" }]
-compile_fail = true
-error_contains = ["requires preview feature"]

--- a/crates/rue-cli-tests/cases/generic_type_call_sigs.toml
+++ b/crates/rue-cli-tests/cases/generic_type_call_sigs.toml
@@ -7,7 +7,7 @@
 # `Name(args...)` as a type expression and sema reduces the comptime type call
 # to the same monomorphized enum the value-position call produces — the real
 # unblocker for Option/Result error handling (RUE-6). These drive the real
-# driver end-to-end with `--preview enum_payloads` and assert exact behavior.
+# driver end-to-end and assert exact behavior.
 
 [section]
 id = "cli.generic_type_call_sigs"
@@ -30,7 +30,7 @@ fn main() -> i32 {
     match divide(84, 2) { R::Ok(v) => v, R::Err(e) => 0 - e }
 }
 """ }]
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 exit_code = 42
 
 # --- Direct call in PARAMETER position ---
@@ -50,7 +50,7 @@ fn divide(a: i32, b: i32) -> Result(i32, i32) {
 }
 fn main() -> i32 { unwrap_or(divide(84, 2), 0) }
 """ }]
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 exit_code = 42
 
 # --- Nested type-function calls compose in type position ---
@@ -75,7 +75,7 @@ fn main() -> i32 {
     }
 }
 """ }]
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 exit_code = 42
 
 # --- Direct call in a LET ANNOTATION (falls out of the same resolver) ---
@@ -95,7 +95,7 @@ fn main() -> i32 {
     match x { R::Ok(v) => v, R::Err(e) => 0 - e }
 }
 """ }]
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 exit_code = 42
 
 # --- A non-type-returning call in type position errors cleanly (no crash) ---
@@ -108,7 +108,7 @@ fn some_value_fn() -> i32 { 5 }
 fn f() -> some_value_fn() { 3 }
 fn main() -> i32 { f() }
 """ }]
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E1200", "is not a type"]
 
@@ -122,7 +122,7 @@ fn Result(comptime T: type, comptime E: type) -> type { enum { Ok(T), Err(E) } }
 fn f() -> Result(i32) { 3 }
 fn main() -> i32 { 0 }
 """ }]
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 compile_fail = true
 error_contains = ["E1200", "expects 2 comptime type argument"]
 
@@ -150,7 +150,7 @@ fn main() -> i32 {
     match wrap(i32, 42) { O::Some(x) => x, O::None => 0 }
 }
 """ }]
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 exit_code = 42
 
 [[case]]
@@ -170,7 +170,7 @@ fn main() -> i32 {
     a + b
 }
 """ }]
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 exit_code = 42
 
 [[case]]
@@ -188,7 +188,7 @@ fn main() -> i32 {
     match first(i32, arr) { O::Some(x) => x, O::None => 0 }
 }
 """ }]
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 exit_code = 7
 
 [[case]]
@@ -211,7 +211,7 @@ fn main() -> i32 {
     }
 }
 """ }]
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 exit_code = 42
 
 [[case]]
@@ -229,7 +229,7 @@ fn main() -> i32 {
     match wrap(i32, 42) { O::Some(x) => x, O::None => 0 }
 }
 """ }]
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 exit_code = 42
 
 # A local array annotation `[T; N]` whose element is a comptime type parameter

--- a/crates/rue-cli-tests/cases/heap_intrinsics.toml
+++ b/crates/rue-cli-tests/cases/heap_intrinsics.toml
@@ -86,7 +86,7 @@ fn main() -> i32 {
     0
 }
 """ }]
-args = ["main.rue", "--preview", "method_receivers", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 stdout = "111\n999\n"
 exit_code = 0
 

--- a/crates/rue-cli-tests/cases/match_inference_fixes.toml
+++ b/crates/rue-cli-tests/cases/match_inference_fixes.toml
@@ -84,7 +84,7 @@ error_contains = ["E0206"]
 [[case]]
 name = "duplicate_payload_binding_rejected"
 description = "RUE-269: `Rect(w, w)` binds `w` twice — rejected with E0484 instead of silently dropping the first field."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Shape { Rect(i32, i32) }
 fn main() -> i32 { match Shape::Rect(3, 4) { Shape::Rect(w, w) => w } }
@@ -95,7 +95,7 @@ error_contains = ["E0484", "bound more than once"]
 [[case]]
 name = "distinct_payload_bindings_ok"
 description = "RUE-269 control: distinct payload binding names still compile and both fields are available."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Shape { Rect(i32, i32) }
 fn main() -> i32 {
@@ -108,7 +108,7 @@ stdout = "7\n"
 [[case]]
 name = "duplicate_payload_binding_three_fields"
 description = "RUE-269: a reused name anywhere in a longer payload (`Tri(a, b, a)`) is caught."
-args = ["--preview", "enum_payloads", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 enum Tri { T(i32, i32, i32) }
 fn main() -> i32 { match Tri::T(1, 2, 3) { Tri::T(a, b, a) => a + b } }

--- a/crates/rue-cli-tests/cases/method_receiver_byref_places.toml
+++ b/crates/rue-cli-tests/cases/method_receiver_byref_places.toml
@@ -25,7 +25,7 @@ description = "inout/borrow self methods work through params, array elements (co
 [[case]]
 name = "inout_self_through_inout_param"
 description = "c.bump() (inout self) where c is an inout parameter mutates in place; two bumps -> 2."
-args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Counter { n: i32, fn bump(inout self) { self.n = self.n + 1; } }
 fn bump_twice(inout c: Counter) { c.bump(); c.bump(); }
@@ -41,7 +41,7 @@ exit_code = 2
 [[case]]
 name = "borrow_self_through_borrow_param"
 description = "c.get() (borrow self) where c is a borrow parameter reads without moving; returns 7."
-args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Counter { n: i32, fn get(borrow self) -> i32 { self.n } }
 fn read(borrow c: Counter) -> i32 { c.get() }
@@ -56,7 +56,7 @@ exit_code = 7
 [[case]]
 name = "inout_self_on_dynamic_index_element"
 description = "arr[i].bump() with a runtime index mutates element i in place; arr[0] -> 1."
-args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Counter { n: i32, fn bump(inout self) { self.n = self.n + 1; } }
 fn main() -> i32 {
@@ -72,7 +72,7 @@ exit_code = 1
 [[case]]
 name = "inout_self_on_const_index_element"
 description = "arr[1].bump() (const index) mutates that element; the sibling element is untouched."
-args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Counter { n: i32, fn bump(inout self) { self.n = self.n + 1; } }
 fn main() -> i32 {
@@ -87,7 +87,7 @@ exit_code = 11
 [[case]]
 name = "inout_self_on_struct_field_array_element"
 description = "w.items[0].bump() through a nested field+index place mutates the element; w.items[0].n -> 1."
-args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Counter { n: i32, fn bump(inout self) { self.n = self.n + 1; } }
 struct Wrapper { items: [Counter; 2] }
@@ -103,7 +103,7 @@ exit_code = 1
 [[case]]
 name = "inout_self_on_field_of_self"
 description = "self.inner.bump() inside a method (field-of-inout-param receiver) mutates; o.inner.v -> 1."
-args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Inner { v: i32, fn bump(inout self) { self.v = self.v + 1; } }
 struct Outer { inner: Inner, fn go(inout self) { self.inner.bump(); } }
@@ -121,7 +121,7 @@ exit_code = 1
 [[case]]
 name = "by_value_self_still_moves_double_call"
 description = "Control: bare `self` (by-value) consumes the receiver; calling it twice is E0205."
-args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Counter { n: i32, fn consume(self) -> i32 { self.n } }
 fn main() -> i32 {
@@ -139,7 +139,7 @@ error_contains = ["E0205", "use of moved value 'c'"]
 [[case]]
 name = "borrow_self_on_moved_value_still_errors"
 description = "Control: calling a borrow-self method after the value was moved into a by-value call is E0205."
-args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Counter { n: i32, fn get(borrow self) -> i32 { self.n } }
 fn sink(c: Counter) -> i32 { c.n }

--- a/crates/rue-cli-tests/cases/method_receivers.toml
+++ b/crates/rue-cli-tests/cases/method_receivers.toml
@@ -3,8 +3,7 @@
 # `borrow self` / `inout self` receivers are accessed by reference (reusing the
 # by-ref parameter calling convention) instead of consuming the receiver. These
 # cases exercise the runtime behavior end-to-end through the real driver with
-# exact stdout, on both backends (aarch64 runs natively in CI). Gated behind
-# `--preview method_receivers`.
+# exact stdout, on both backends (aarch64 runs natively in CI).
 
 [section]
 id = "cli.method_receivers"
@@ -15,7 +14,7 @@ description = "borrow self getters and inout self mutators via the real driver."
 # getter observes the mutations and does not consume the receiver.
 [[case]]
 name = "stack_push_top_count"
-args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Stack {
     a: i32,
@@ -57,7 +56,7 @@ stdout = "20\n2\n3\n30\n"
 # A borrow self getter is callable repeatedly without moving the receiver.
 [[case]]
 name = "borrow_getter_repeatable"
-args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Counter {
     n: i32,
@@ -88,7 +87,7 @@ stdout = "2\n3\n3\n"
 # access (the read completes before the receiver access begins).
 [[case]]
 name = "arg_reads_receiver"
-args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Stack {
     a: i32,

--- a/crates/rue-cli-tests/cases/string_mutation_receivers.toml
+++ b/crates/rue-cli-tests/cases/string_mutation_receivers.toml
@@ -81,11 +81,11 @@ fn main() -> i32 {
 exit_code = 0
 stdout = "8\n"
 
-# Field-of-self receiver inside an inout-self method (method_receivers preview).
+# Field-of-self receiver inside an inout-self method.
 [[case]]
 name = "self_field_receiver_via_method"
 description = "self.data.push_str(..) inside an `inout self` method mutates the receiver's String field."
-args = ["--preview", "method_receivers", "main.rue", "-o", "prog"]
+args = ["main.rue", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 struct Buf {
     data: String,

--- a/crates/rue-cli-tests/cases/vec_library.toml
+++ b/crates/rue-cli-tests/cases/vec_library.toml
@@ -121,6 +121,6 @@ pub fn Vec(comptime T: type) -> type {
 }
 """ },
 ]
-args = ["main.rue", "vec.rue", "--preview", "method_receivers", "-o", "prog"]
+args = ["main.rue", "vec.rue", "-o", "prog"]
 stdout = "3\n20\n99\n30\n2\n0\n119\n"
 exit_code = 119

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -369,23 +369,6 @@ pub enum PreviewFeature {
     /// Testing infrastructure feature - permanently unstable.
     /// Used to verify the preview feature gating mechanism works.
     TestInfra,
-    /// Built-in `for` loops over arrays and string views (RUE-220, ADR-0037).
-    /// Layer 1 of the iteration model: `for x in <iterable> { body }` in
-    /// read/borrow mode over arrays, String bytes, and `s.chars()`.
-    ForLoops,
-    /// Borrow/inout method receivers (`fn f(borrow self)` / `fn f(inout
-    /// self)`), RUE-15 / ADR-0037. Lets methods access `self` by reference
-    /// instead of consuming it.
-    MethodReceivers,
-    /// Enum payloads — sum types with data (RUE-221, ADR-0038). Tuple
-    /// variants (`Circle(i32)`) carrying data, tagged-union layout, and
-    /// pattern matching with payload bindings (`match s { Circle(r) => r }`).
-    /// The prerequisite for `Option`/`Result`.
-    EnumPayloads,
-    /// Array-repeat literal `[value; count]` — build an array of `count`
-    /// copies of `value` (RUE-235). `count` is a compile-time constant and
-    /// the element type must be `Copy`.
-    ArrayRepeat,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -406,10 +389,6 @@ impl PreviewFeature {
     pub fn name(&self) -> &'static str {
         match *self {
             PreviewFeature::TestInfra => "test_infra",
-            PreviewFeature::ForLoops => "for_loops",
-            PreviewFeature::MethodReceivers => "method_receivers",
-            PreviewFeature::EnumPayloads => "enum_payloads",
-            PreviewFeature::ArrayRepeat => "array_repeat",
         }
     }
 
@@ -418,22 +397,12 @@ impl PreviewFeature {
     pub fn adr(&self) -> &'static str {
         match *self {
             PreviewFeature::TestInfra => "ADR-0005",
-            PreviewFeature::ForLoops => "ADR-0037",
-            PreviewFeature::MethodReceivers => "ADR-0037",
-            PreviewFeature::EnumPayloads => "ADR-0038",
-            PreviewFeature::ArrayRepeat => "ADR-0005",
         }
     }
 
     /// Get all available preview features.
     pub fn all() -> &'static [PreviewFeature] {
-        &[
-            PreviewFeature::TestInfra,
-            PreviewFeature::ForLoops,
-            PreviewFeature::MethodReceivers,
-            PreviewFeature::EnumPayloads,
-            PreviewFeature::ArrayRepeat,
-        ]
+        &[PreviewFeature::TestInfra]
     }
 
     /// Get a comma-separated list of all feature names (for help text).
@@ -456,10 +425,6 @@ impl std::str::FromStr for PreviewFeature {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "test_infra" => Ok(PreviewFeature::TestInfra),
-            "for_loops" => Ok(PreviewFeature::ForLoops),
-            "method_receivers" => Ok(PreviewFeature::MethodReceivers),
-            "enum_payloads" => Ok(PreviewFeature::EnumPayloads),
-            "array_repeat" => Ok(PreviewFeature::ArrayRepeat),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -2263,18 +2228,32 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(
-            names,
-            "test_infra, for_loops, method_receivers, enum_payloads, array_repeat"
-        );
+        assert_eq!(names, "test_infra");
     }
 
     #[test]
-    fn test_preview_feature_method_receivers_roundtrip() {
+    fn test_preview_feature_test_infra_roundtrip() {
         use std::str::FromStr;
-        let f = PreviewFeature::from_str("method_receivers").unwrap();
-        assert_eq!(f, PreviewFeature::MethodReceivers);
-        assert_eq!(f.name(), "method_receivers");
+        let f = PreviewFeature::from_str("test_infra").unwrap();
+        assert_eq!(f, PreviewFeature::TestInfra);
+        assert_eq!(f.name(), "test_infra");
+    }
+
+    #[test]
+    fn test_preview_feature_stabilized_are_unknown() {
+        // for_loops, method_receivers, enum_payloads, and array_repeat were
+        // stabilized (no longer gated) — their names must now be rejected.
+        for name in [
+            "for_loops",
+            "method_receivers",
+            "enum_payloads",
+            "array_repeat",
+        ] {
+            assert!(
+                name.parse::<PreviewFeature>().is_err(),
+                "{name} should be an unknown preview feature after stabilization"
+            );
+        }
     }
 
     // ========================================================================

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -373,6 +373,25 @@ impl<'a> Interp<'a> {
                     }
                 }
             }
+            // Dropping an enum runs the drop glue of its *active* variant's
+            // payload (spec 6.3:20). The Aggregate layout is [tag, payload
+            // fields...] (see `EnumVariant`), so element 0 selects the variant
+            // and elements 1.. are its payload fields, in declaration order. A
+            // discriminant-only value is a bare `Int` (no `Aggregate`), so there
+            // is nothing to drop.
+            TypeKind::Enum(eid) => {
+                if let Value::Aggregate(elems) = &v
+                    && let Some(Value::Int(tag)) = elems.first()
+                {
+                    let def = self.state.type_pool.enum_def(eid);
+                    let payload_tys = def.variant_payload(*tag as usize).to_vec();
+                    for (i, pty) in payload_tys.into_iter().enumerate() {
+                        if let Some(fv) = elems.get(i + 1).cloned() {
+                            self.run_drop(pty, fv)?;
+                        }
+                    }
+                }
+            }
             _ => {}
         }
         Ok(())

--- a/crates/rue-spec/cases/arrays/fixed.toml
+++ b/crates/rue-spec/cases/arrays/fixed.toml
@@ -903,14 +903,12 @@ compile_fail = true
 error_contains = "not a compile-time constant"
 
 # =============================================================================
-# Array-Repeat Literals (RUE-235, preview: array_repeat)
+# Array-Repeat Literals (RUE-235)
 # =============================================================================
 
 [[case]]
 name = "array_repeat_literal_count"
 spec = ["7.1:36", "7.1:39"]
-preview = "array_repeat"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let b = [7; 3];
@@ -922,8 +920,6 @@ exit_code = 21
 [[case]]
 name = "array_repeat_zeros_annotated"
 spec = ["7.1:36"]
-preview = "array_repeat"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let a: [i32; 4] = [0; 4];
@@ -935,8 +931,6 @@ exit_code = 0
 [[case]]
 name = "array_repeat_named_const_count"
 spec = ["7.1:37"]
-preview = "array_repeat"
-preview_should_pass = true
 source = """
 const N: usize = 4;
 fn main() -> i32 {
@@ -949,8 +943,6 @@ exit_code = 20
 [[case]]
 name = "array_repeat_evaluates_value_once"
 spec = ["7.1:39"]
-preview = "array_repeat"
-preview_should_pass = true
 source = """
 fn main() -> i32 {
     let v = 6;
@@ -963,8 +955,6 @@ exit_code = 12
 [[case]]
 name = "array_repeat_non_copy_element_error"
 spec = ["7.1:38"]
-preview = "array_repeat"
-preview_should_pass = true
 source = """
 struct Data { value: i32 }
 fn main() -> i32 {
@@ -975,15 +965,3 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "Copy"
-
-[[case]]
-name = "array_repeat_requires_preview"
-spec = ["7.1:36"]
-source = """
-fn main() -> i32 {
-    let b = [7; 3];
-    b[0]
-}
-"""
-compile_fail = true
-error_contains = "requires preview feature"

--- a/crates/rue-spec/cases/expressions/comparison.toml
+++ b/crates/rue-spec/cases/expressions/comparison.toml
@@ -393,7 +393,7 @@ exit_code = 1
 # Enum Equality (RUE-285): same variant and equal payload
 # =============================================================================
 
-# Discriminant-only (C-like) enums: equal iff the same variant. Not preview.
+# Discriminant-only (C-like) enums: equal iff the same variant.
 [[case]]
 name = "enum_clike_equality_{variant}"
 spec = ["4.3:2", "4.3:3d"]
@@ -427,11 +427,10 @@ fn main() -> i32 {
 compile_fail = true
 
 # Payload-carrying enums: same variant AND equal payload; different variants
-# are never equal. Gated on the enum_payloads preview feature (RUE-221).
+# are never equal (RUE-221).
 [[case]]
 name = "enum_payload_equality_{variant}"
 spec = ["4.3:2", "4.3:3d"]
-preview = "enum_payloads"
 source = """
 enum Shape { Circle(i32), Square(i32) }
 

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1749,7 +1749,6 @@ exit_code = 42
 [[case]]
 name = "anon_enum_generic_option_some"
 spec = ["4.14:20"]
-preview = "enum_payloads"
 description = "Generic Option enum: construct Some(T) and match it out (ADR-0038 deliverable)"
 source = """
 fn Option(comptime T: type) -> type {
@@ -1766,7 +1765,6 @@ exit_code = 42
 [[case]]
 name = "anon_enum_generic_option_none"
 spec = ["4.14:20"]
-preview = "enum_payloads"
 description = "Generic Option enum: the None variant selects the default arm"
 source = """
 fn Option(comptime T: type) -> type {
@@ -1783,7 +1781,6 @@ exit_code = 42
 [[case]]
 name = "anon_enum_two_type_params_result"
 spec = ["4.14:20"]
-preview = "enum_payloads"
 description = "Two-type-parameter Result enum: both Ok and Err arms construct and match"
 source = """
 fn Result(comptime T: type, comptime E: type) -> type {
@@ -1803,7 +1800,6 @@ exit_code = 42
 [[case]]
 name = "anon_enum_monomorphized_distinct"
 spec = ["4.14:21"]
-preview = "enum_payloads"
 description = "Option(i32) and Option(bool) are distinct types: mixing them is a type error"
 source = """
 fn Option(comptime T: type) -> type {
@@ -1822,7 +1818,6 @@ error_contains = "type mismatch"
 [[case]]
 name = "anon_enum_structural_reuse"
 spec = ["4.14:21"]
-preview = "enum_payloads"
 description = "Two Option(i32) instantiations are structurally equal and interchangeable"
 source = """
 fn Option(comptime T: type) -> type {
@@ -1841,7 +1836,6 @@ exit_code = 42
 [[case]]
 name = "anon_enum_type_fn_over_enclosing_param"
 spec = ["4.14:20"]
-preview = "enum_payloads"
 description = "A generic function whose signature applies a type constructor to its own type parameter (`-> Option(T)`) resolves and monomorphizes at the call site (RUE-272)"
 source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }
@@ -1859,7 +1853,6 @@ exit_code = 42
 [[case]]
 name = "anon_enum_type_fn_over_param_two_instantiations"
 spec = ["4.14:21"]
-preview = "enum_payloads"
 description = "The same generic function over Option(T) monomorphizes independently for i32 and bool (RUE-272)"
 source = """
 fn Option(comptime T: type) -> type { enum { Some(T), None } }

--- a/crates/rue-spec/cases/expressions/for.toml
+++ b/crates/rue-spec/cases/expressions/for.toml
@@ -4,8 +4,7 @@ spec_chapter = "4.8"
 name = "For Loop Expressions"
 description = """
 Built-in `for` loops (RUE-220, ADR-0037) iterate in read mode over an array, a
-String's bytes, or a String's `.chars()` scalar view. Preview-gated behind
-`--preview for_loops`.
+String's bytes, or a String's `.chars()` scalar view.
 """
 
 # =============================================================================
@@ -15,7 +14,6 @@ String's bytes, or a String's `.chars()` scalar view. Preview-gated behind
 [[case]]
 name = "for_array_sum"
 spec = ["4.8:23", "4.8:24", "4.8:25", "4.8:26"]
-preview = "for_loops"
 source = """
 fn main() -> i32 {
     let a: [i32; 3] = [10, 20, 30];
@@ -35,7 +33,6 @@ exit_code = 60
 [[case]]
 name = "for_array_non_copy_element"
 spec = ["4.8:25", "4.8:26"]
-preview = "for_loops"
 source = """
 struct Point { x: i32, y: i32 }
 fn main() -> i32 {
@@ -55,7 +52,6 @@ exit_code = 4
 [[case]]
 name = "for_array_non_copy_destructor_once"
 spec = ["4.8:26"]
-preview = "for_loops"
 source = """
 struct Res { tag: i32 }
 drop fn Res(self) { @dbg(self.tag); }
@@ -77,7 +73,6 @@ expected_stdout = "11\n22\n"
 [[case]]
 name = "for_move_element_out_error"
 spec = ["4.8:26"]
-preview = "for_loops"
 source = """
 struct Res { tag: i32 }
 drop fn Res(self) { @dbg(self.tag); }
@@ -100,7 +95,6 @@ error_contains = "cannot move out of borrowed value"
 [[case]]
 name = "for_mutate_collection_in_body_error"
 spec = ["4.8:26"]
-preview = "for_loops"
 source = """
 fn main() -> i32 {
     let mut s = "abc".clone();
@@ -120,7 +114,6 @@ error_contains = "cannot mutate borrowed value"
 [[case]]
 name = "for_string_borrows_not_consumes"
 spec = ["4.8:26"]
-preview = "for_loops"
 source = """
 fn main() -> i32 {
     let s = "abcd";
@@ -143,7 +136,6 @@ exit_code = 8
 [[case]]
 name = "for_string_bytes_count"
 spec = ["4.8:25"]
-preview = "for_loops"
 source = """
 fn main() -> i32 {
     let s = "abc";
@@ -160,7 +152,6 @@ exit_code = 3
 [[case]]
 name = "for_string_bytes_multibyte"
 spec = ["4.8:25"]
-preview = "for_loops"
 source = """
 fn main() -> i32 {
     let s = "café";
@@ -180,7 +171,6 @@ exit_code = 5
 [[case]]
 name = "for_chars_scalars"
 spec = ["4.8:25", "3.7:31"]
-preview = "for_loops"
 source = """
 fn main() -> i32 {
     let s = "café";
@@ -202,7 +192,6 @@ expected_stdout = "99\n97\n102\n233\n"
 [[case]]
 name = "for_break_continue"
 spec = ["4.8:27"]
-preview = "for_loops"
 source = """
 fn main() -> i32 {
     let a: [i32; 5] = [1, 2, 3, 4, 5];
@@ -224,7 +213,6 @@ exit_code = 4
 [[case]]
 name = "for_nested"
 spec = ["4.8:23"]
-preview = "for_loops"
 source = """
 fn main() -> i32 {
     let a: [i32; 2] = [1, 2];
@@ -249,7 +237,6 @@ exit_code = 129
 [[case]]
 name = "for_chars_invalid_utf8_traps"
 spec = ["4.8:28", "3.7:32"]
-preview = "for_loops"
 source = """
 fn main() -> i32 {
     let full = "café";
@@ -272,7 +259,6 @@ expected_stdout = "99\n97\n102\n"
 [[case]]
 name = "for_chars_lossy_valid"
 spec = ["3.7:34"]
-preview = "for_loops"
 source = """
 fn main() -> i32 {
     let s = "café";
@@ -293,7 +279,6 @@ expected_stdout = "99\n97\n102\n233\n"
 [[case]]
 name = "for_chars_lossy_replaces_invalid"
 spec = ["3.7:34"]
-preview = "for_loops"
 source = """
 fn main() -> i32 {
     let full = "café";
@@ -309,30 +294,10 @@ fn main() -> i32 {
 exit_code = 4
 expected_stdout = "99\n97\n102\n65533\n"
 
-# =============================================================================
-# Preview gating
-# =============================================================================
-
-[[case]]
-name = "for_requires_preview"
-spec = ["4.8:23"]
-source = """
-fn main() -> i32 {
-    let a: [i32; 3] = [1, 2, 3];
-    for x in a {
-        let _y = x;
-    }
-    0
-}
-"""
-compile_fail = true
-error_contains = "requires preview feature"
-
-# A non-iterable operand is rejected (with the preview enabled).
+# A non-iterable operand is rejected.
 [[case]]
 name = "for_non_iterable_rejected"
 spec = ["4.8:25"]
-preview = "for_loops"
 source = """
 fn main() -> i32 {
     let n = 5;

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -937,7 +937,6 @@ error_contains = "parentheses"
 [[case]]
 name = "match_payload_binding_extracts"
 spec = ["4.7:30"]
-preview = "enum_payloads"
 source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn main() -> i32 {
@@ -955,7 +954,6 @@ exit_code = 7
 [[case]]
 name = "match_payload_binding_move_mode"
 spec = ["4.7:31"]
-preview = "enum_payloads"
 source = """
 enum Wrap { One(i32) }
 fn main() -> i32 {
@@ -971,7 +969,6 @@ exit_code = 20
 [[case]]
 name = "match_payload_binding_wrong_arity"
 spec = ["4.7:30"]
-preview = "enum_payloads"
 source = """
 enum Shape { Rect(i32, i32) }
 fn main() -> i32 {
@@ -988,7 +985,6 @@ compile_fail = true
 [[case]]
 name = "match_payload_binding_duplicate_name"
 spec = ["4.7:30"]
-preview = "enum_payloads"
 source = """
 enum Shape { Rect(i32, i32) }
 fn main() -> i32 {

--- a/crates/rue-spec/cases/items/enums.toml
+++ b/crates/rue-spec/cases/items/enums.toml
@@ -257,25 +257,24 @@ fn main() -> i32 {
 exit_code = 42
 
 # =============================================================================
-# Variant Payloads (RUE-221, ADR-0038) — enum_payloads preview feature
+# Variant Payloads (RUE-221, ADR-0038)
 # =============================================================================
 
-# A payload-carrying variant requires the preview feature.
+# A variant may carry a payload, and an enum may freely mix payload-carrying
+# and discriminant-only variants (6.3:14).
 [[case]]
-name = "enum_payload_requires_preview"
+name = "enum_payload_mixed_variants_ok"
 spec = ["6.3:14"]
 source = """
-enum Shape { Circle(i32), Empty }
+enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn main() -> i32 { 0 }
 """
-compile_fail = true
-error_contains = "requires preview feature"
+exit_code = 0
 
 # Declaring and constructing tuple variants (grammar 6.3:2, payloads 6.3:13).
 [[case]]
 name = "enum_payload_declare_construct"
 spec = ["6.3:2", "6.3:13"]
-preview = "enum_payloads"
 source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn main() -> i32 {
@@ -291,7 +290,6 @@ exit_code = 0
 [[case]]
 name = "enum_payload_match_circle"
 spec = ["6.3:15", "6.3:16"]
-preview = "enum_payloads"
 source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn area(s: Shape) -> i32 {
@@ -309,7 +307,6 @@ exit_code = 5
 [[case]]
 name = "enum_payload_match_rect"
 spec = ["6.3:15", "6.3:16"]
-preview = "enum_payloads"
 source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn area(s: Shape) -> i32 {
@@ -327,7 +324,6 @@ exit_code = 7
 [[case]]
 name = "enum_payload_match_empty"
 spec = ["6.3:16"]
-preview = "enum_payloads"
 source = """
 enum Shape { Circle(i32), Rect(i32, i32), Empty }
 fn area(s: Shape) -> i32 {
@@ -345,7 +341,6 @@ exit_code = 0
 [[case]]
 name = "enum_payload_wrong_arity"
 spec = ["6.3:16"]
-preview = "enum_payloads"
 source = """
 enum Shape { Rect(i32, i32) }
 fn main() -> i32 { let r = Shape::Rect(3); 0 }
@@ -356,7 +351,6 @@ compile_fail = true
 [[case]]
 name = "enum_payload_bare_path_error"
 spec = ["6.3:16"]
-preview = "enum_payloads"
 source = """
 enum Shape { Circle(i32) }
 fn main() -> i32 { let c = Shape::Circle; 0 }
@@ -368,7 +362,6 @@ compile_fail = true
 [[case]]
 name = "enum_payload_drop_once_via_match"
 spec = ["6.3:17"]
-preview = "enum_payloads"
 source = """
 struct Res { id: i32 }
 drop fn Res(self) { @dbg(self.id); }
@@ -388,8 +381,6 @@ exit_code = 7
 [[case]]
 name = "enum_linear_infectious_must_consume"
 spec = ["6.3:19"]
-preview = "enum_payloads"
-preview_should_pass = true
 source = """
 linear struct L { v: i32 }
 enum E { Has(L), None }
@@ -406,8 +397,6 @@ error_contains = "must be consumed"
 [[case]]
 name = "enum_linear_consumed_via_match"
 spec = ["6.3:19"]
-preview = "enum_payloads"
-preview_should_pass = true
 source = """
 linear struct L { v: i32 }
 enum E { Has(L), None }
@@ -427,8 +416,6 @@ exit_code = 5
 [[case]]
 name = "enum_copy_payload_stays_copy"
 spec = ["6.3:19"]
-preview = "enum_payloads"
-preview_should_pass = true
 source = """
 enum C { A(i32), B }
 fn val(c: C) -> i32 { match c { C::A(x) => x, C::B => 0 } }
@@ -445,8 +432,6 @@ exit_code = 6
 [[case]]
 name = "enum_active_variant_drop_glue"
 spec = ["6.3:20"]
-preview = "enum_payloads"
-preview_should_pass = true
 source = """
 struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }
@@ -464,8 +449,6 @@ exit_code = 0
 [[case]]
 name = "enum_active_variant_none_no_drop"
 spec = ["6.3:20"]
-preview = "enum_payloads"
-preview_should_pass = true
 source = """
 struct D { v: i32 }
 drop fn D(self) { @dbg(self.v); }

--- a/crates/rue-spec/cases/items/impl-blocks.toml
+++ b/crates/rue-spec/cases/items/impl-blocks.toml
@@ -362,13 +362,12 @@ fn main() -> i32 {
 exit_code = 42
 
 # =============================================================================
-# Receiver Modes: borrow self / inout self (preview: method_receivers, RUE-15)
+# Receiver Modes: borrow self / inout self (RUE-15)
 # =============================================================================
 
 [[case]]
 name = "borrow_self_getter_repeatable"
 spec = ["6.4:24", "6.4:25", "6.4:29"]
-preview = "method_receivers"
 description = "borrow self does not consume the receiver; callable repeatedly"
 source = """
 struct Counter {
@@ -389,7 +388,6 @@ exit_code = 42
 [[case]]
 name = "inout_self_mutates_in_place"
 spec = ["6.4:24", "6.4:25", "6.4:29"]
-preview = "method_receivers"
 description = "inout self mutates the receiver in place across multiple calls"
 source = """
 struct Counter {
@@ -418,7 +416,6 @@ exit_code = 23
 [[case]]
 name = "inout_self_with_arg_and_field_writes"
 spec = ["6.4:24", "6.4:29"]
-preview = "method_receivers"
 description = "inout self method with an extra parameter writing several fields"
 source = """
 struct Stack {
@@ -454,7 +451,6 @@ exit_code = 23
 [[case]]
 name = "arg_reads_receiver_allowed"
 spec = ["6.4:28"]
-preview = "method_receivers"
 description = "an argument that only reads self is allowed alongside inout self"
 source = """
 struct Stack {
@@ -480,27 +476,8 @@ fn main() -> i32 {
 exit_code = 3
 
 [[case]]
-name = "receiver_mode_requires_preview"
-spec = ["6.4:24"]
-compile_fail = true
-error_contains = "requires preview feature"
-description = "borrow/inout receivers are gated behind --preview method_receivers"
-source = """
-struct P {
-    n: i32,
-    fn get(borrow self) -> i32 { self.n }
-}
-
-fn main() -> i32 {
-    let p = P { n: 0 };
-    p.get()
-}
-"""
-
-[[case]]
 name = "inout_self_requires_mut_receiver"
 spec = ["6.4:26"]
-preview = "method_receivers"
 compile_fail = true
 error_contains = "immutable"
 description = "inout self needs a mutable receiver binding"
@@ -520,7 +497,6 @@ fn main() -> i32 {
 [[case]]
 name = "receiver_overlap_rejected"
 spec = ["6.4:28"]
-preview = "method_receivers"
 compile_fail = true
 error_contains = "inout"
 description = "passing the receiver's own place as an inout argument is rejected"
@@ -542,7 +518,6 @@ fn main() -> i32 {
 [[case]]
 name = "borrow_self_non_place_receiver_rejected"
 spec = ["6.4:27"]
-preview = "method_receivers"
 compile_fail = true
 error_contains = "borrow argument must be"
 description = "a borrow/inout receiver must be a place, not a temporary"

--- a/docs/designs/0005-preview-features.md
+++ b/docs/designs/0005-preview-features.md
@@ -167,6 +167,19 @@ When all tests for a preview feature pass:
 
 The feature is now part of stable Rue.
 
+### Stabilized features
+
+The following preview features completed this process and are now stable (their
+`--preview` gates and `PreviewFeature` variants were removed):
+
+- `array_repeat` — the `[value; count]` array-repeat literal (RUE-235), gated
+  under this ADR; stabilized 2026-07-03.
+- `for_loops` and `method_receivers` — see ADR-0037; stabilized 2026-07-03.
+- `enum_payloads` — see ADR-0038; stabilized 2026-07-03.
+
+`test_infra` remains permanently unstable (it exists only to exercise the gating
+mechanism), so the `PreviewFeature` enum is not empty.
+
 ## Implementation Phases
 
 - [x] **Phase 1: Infrastructure** - Add PreviewFeature enum, CompileOptions, CLI flag, error kind

--- a/docs/designs/0037-exclusivity-model-access-point-based.md
+++ b/docs/designs/0037-exclusivity-model-access-point-based.md
@@ -22,6 +22,11 @@ load-bearing question in RUE-15 (method receivers) and states the global
 discipline that complements ADR-0013 (borrowing modes) and formalization
 decision 4 (loans strictly second-class, no lifetimes).
 
+**Stabilized (2026-07-03):** the two preview features that rode on this access
+model — borrow/inout method receivers (`method_receivers`, RUE-15) and built-in
+`for` loops iterating in read/borrow mode (`for_loops`, RUE-220) — are complete
+and were stabilized (their `--preview` gates removed).
+
 ## Summary
 
 Rue's law of exclusivity is **access-point-based**, not span/region-based: an

--- a/docs/designs/0038-error-handling-sum-types-result-must-check.md
+++ b/docs/designs/0038-error-handling-sum-types-result-must-check.md
@@ -3,10 +3,10 @@ id: 0038
 title: "Error handling: sum types, Result/Option, and must-check via linearity"
 status: accepted
 tags: [error-handling, enums, sum-types, linearity, pattern-matching]
-feature-flag: enum_payloads
+feature-flag:
 created: 2026-07-02
 accepted: 2026-07-02
-implemented:
+implemented: 2026-07-03
 spec-sections: ["3.5", "4.7", "6.3"]
 superseded-by:
 ---
@@ -20,6 +20,13 @@ payloads (a prerequisite feature, tracked as a phase of RUE-6) and makes RUE-187
 (intentional-destroy escape hatch) a required companion. Builds on ADR-0037
 (access model), ADR-0013 (borrowing modes), and the multiplicity lattice
 (docs/formal §3), and reuses ADR-0020 (comptime type functions).
+
+**Stabilized (2026-07-03):** the `enum_payloads` preview feature — tuple-variant
+payloads, tagged-union layout, and match-with-payload-bindings — is complete and
+was stabilized (its `--preview enum_payloads` gate removed). Payload-carrying
+enums take their multiplicity from the join of their variants' payloads
+(spec 6.3:19/6.3:20), and the pre-payload blanket ownership rules were narrowed
+to discriminant-only enums (RUE-294).
 
 ## Summary
 

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -278,9 +278,8 @@ fn main() -> i32 {
 
 The character view `s.chars()` yields the Unicode scalar values of a `String`,
 decoding its bytes as UTF-8. It is used as the iterable of a `for` loop (see
-[Loop Expressions](@/04-expressions/08-loop-expressions.md); a preview feature,
-`--preview for_loops`), which binds each scalar value as a `u32` in ascending
-byte order.
+[Loop Expressions](@/04-expressions/08-loop-expressions.md)), which binds each
+scalar value as a `u32` in ascending byte order.
 
 {{ rule(id="3.7:32", cat="dynamic-semantics") }}
 

--- a/docs/spec/src/03-types/08-move-semantics.md
+++ b/docs/spec/src/03-types/08-move-semantics.md
@@ -21,8 +21,13 @@ The following types are Copy types:
 - All integer types (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`)
 - The boolean type (`bool`)
 - The unit type (`()`)
-- Enum types (all variants of an enum)
+- Discriminant-only enum types (every variant is payload-free, C-like)
 - Array types `[T; N]` where `T` is a Copy type
+
+A payload-carrying enum is **not** unconditionally Copy: its multiplicity is the
+join of its variants' payload multiplicities over Copy ⊑ Affine ⊑ Linear
+(6.3:19). Such an enum is Copy only when every payload is itself Copy; a variant
+carrying a move (affine or linear) payload makes the whole enum a move type.
 
 {{ rule(id="3.8:3", cat="normative") }}
 
@@ -92,7 +97,7 @@ struct Outer { inner: Inner }  // ERROR: field 'inner' has non-Copy type 'Inner'
 
 {{ rule(id="3.8:20", cat="normative") }}
 
-A `@copy` struct **MAY** contain fields of primitive Copy types (integers, booleans, unit), enum types, arrays of Copy types, or other `@copy` struct types.
+A `@copy` struct **MAY** contain fields of primitive Copy types (integers, booleans, unit), discriminant-only enum types, arrays of Copy types, or other `@copy` struct types. A field whose type is a payload-carrying enum is admissible only when that enum is itself Copy under the join of 6.3:19 — that is, only when every one of its payloads is Copy; a `@copy` struct field must itself be a Copy type (3.8:18), so a move-typed enum field is rejected.
 
 {{ rule(id="3.8:21", cat="example") }}
 

--- a/docs/spec/src/03-types/09-destructors.md
+++ b/docs/spec/src/03-types/09-destructors.md
@@ -63,8 +63,13 @@ The following types are trivially droppable:
 - The boolean type (`bool`)
 - The unit type (`()`)
 - The never type (`!`)
-- Enum types
+- Discriminant-only enum types (every variant is payload-free)
 - Arrays of trivially droppable types
+
+A payload-carrying enum is **not** trivially droppable unless every payload is
+itself trivially droppable. Dropping such an enum runs the drop glue of its
+**active** variant's payload exactly once, and nothing for a discriminant-only
+active variant (6.3:20).
 
 {{ rule(id="3.9:9", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/07-match-expressions.md
+++ b/docs/spec/src/04-expressions/07-match-expressions.md
@@ -228,8 +228,7 @@ fn absurd(n: Never) -> i32 {
 A tuple-variant pattern binds the variant's payload into fresh names:
 `EnumName::Variant(a, b)` matches a value of that variant and binds `a`, `b`
 to its payload fields in order. The number of bindings **MUST** equal the
-variant's payload arity. Payload bindings require the `enum_payloads` preview
-feature (see spec 6.3).
+variant's payload arity (see spec 6.3).
 
 {{ rule(id="4.7:31", cat="normative") }}
 

--- a/docs/spec/src/04-expressions/08-loop-expressions.md
+++ b/docs/spec/src/04-expressions/08-loop-expressions.md
@@ -185,8 +185,7 @@ fn main() -> i32 {
 {{ rule(id="4.8:23", cat="normative") }}
 
 A `for` loop iterates over a built-in iterable, binding each element in turn and
-executing its body once per element. `for` is a preview feature (enabled with
-`--preview for_loops`; see ADR-0037).
+executing its body once per element (see ADR-0037).
 
 {{ rule(id="4.8:24", cat="syntax") }}
 

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -387,7 +387,7 @@ fn main() -> i32 {
 }
 ```
 
-Each instantiation is monomorphized: `Option(i32)` and `Option(bool)` are distinct types with independent tagged-union layouts (the payload types differ). A variant that carries a payload requires the `enum_payloads` preview feature, exactly as for a named enum declaration.
+Each instantiation is monomorphized: `Option(i32)` and `Option(bool)` are distinct types with independent tagged-union layouts (the payload types differ).
 
 {{ rule(id="4.14:21", cat="normative") }}
 

--- a/docs/spec/src/06-items/03-enums.md
+++ b/docs/spec/src/06-items/03-enums.md
@@ -112,10 +112,10 @@ variant carries a payload is a *sum type*.
 
 {{ rule(id="6.3:14", cat="normative") }}
 
-Tuple-variant payloads are a preview feature: an enum declaration containing a
-payload-carrying variant requires the `enum_payloads` preview feature to be
-enabled (ADR-0038). Discriminant-only enums remain available without any
-preview feature.
+A variant **MAY** carry a payload: a parenthesized, comma-separated list of one
+or more types written after the variant name (ADR-0038). A variant with no such
+list is discriminant-only, and an enum may freely mix payload-carrying and
+discriminant-only variants.
 
 {{ rule(id="6.3:15", cat="normative") }}
 

--- a/docs/spec/src/06-items/04-impl-blocks.md
+++ b/docs/spec/src/06-items/04-impl-blocks.md
@@ -213,10 +213,6 @@ Calling a method with associated function syntax (Type::method()) is a compile-t
 
 ## Receiver Modes
 
-> Note: `borrow self` and `inout self` receivers are a preview feature
-> (`--preview method_receivers`, ADR-0037 / RUE-15). Bare `self` (by-value) is
-> stable.
-
 {{ rule(id="6.4:24", cat="normative") }}
 
 A receiver **MAY** be declared `borrow self` or `inout self`, mirroring the

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -154,7 +154,6 @@ pattern        = "_"
 while_expr     = "while" expression "{" block "}" ;
 loop_expr      = "loop" "{" block "}" ;
 for_expr       = "for" ( IDENT | "_" ) "in" expression "{" block "}" ;
-                 (* preview: --preview for_loops *)
 break_expr     = "break" [ expression ] ;   (* an operand parses but is always
                                                rejected in semantic analysis *)
 return_expr    = "return" [ expression ] ;


### PR DESCRIPTION
The dogfooding feature set is now flag-free. Steve ratified stabilizing all four (2026-07-03) after each passed a readiness check; test_infra stays gated (internal scaffolding).

**RUE-294 (done first):** narrowed the three unsound blanket enum rules — 3.8:2 (all enums Copy), 3.8:20 (@copy struct enum fields), 3.9:8 (all enums trivially droppable) — to DISCRIMINANT-ONLY enums, deferring payload enums to the 6.3:19/6.3:20 multiplicity join. Rule text only; traceability preserved. A faithful compiler reading the old prose would have double-freed a drop-carrying enum; the compiler already implemented the join, so this makes the prose match the sound compiler.

**Stabilization:** removed PreviewFeature::{ForLoops,MethodReceivers,EnumPayloads,ArrayRepeat} (kept TestInfra), all require_preview gates, all preview=/--preview test fields + 5 obsolete negative gate tests, doc/example/script flags; ADRs 0005/0037/0038 -> Implemented.

**Also** fixed a latent rue-oracle bug: run_drop fell through for enums, never running the active-variant payload's drop glue (6.3:20) — added the Enum arm, now regression-covered.

Verified by execution WITHOUT flags: vec_demo -> 3,20,99,30,2,0,119; for+repeat -> 21; payload enum -> 42; borrow/inout/plain-self -> 6; payload enum w/ String still moves (E0205) + drops; discriminant-only enum still Copy; --preview method_receivers -> clean 'unknown preview feature' error. clippy-gate-passed; test.sh Pass 24 (100% traceability 643/643); diff-fuzzer 300 seeds 0 disagreements.

Fixes RUE-294

Generated with Claude Code