### PR TITLE
Allow a comptime-evaluable call in array-length position ([T; f(n)]) (RUE-309)

### DIFF
--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -595,6 +595,15 @@ impl<'a> Sema<'a> {
         match len {
             ArrayLen::Literal(n) => Ok(*n),
             ArrayLen::Named(name) => {
+                // A comptime-evaluable call in length position, e.g.
+                // `[i32; fact(4)]` (RUE-309). The interned type string carries
+                // the call syntax verbatim (`fact(4)`); fold it via the same
+                // comptime machinery that reduces value-returning calls
+                // elsewhere (RUE-163). Bare names fall through to the
+                // const/comptime-parameter lookup below.
+                if let Some((callee, args)) = parse_type_call_syntax(name) {
+                    return self.resolve_array_length_call(&callee, &args, span, value_subst);
+                }
                 let sym = self.interner.get_or_intern(name);
                 // 1. A `comptime` value parameter in scope (per specialization).
                 let value = if let Some(v) = value_subst.and_then(|vs| vs.get(&sym)) {
@@ -637,6 +646,87 @@ impl<'a> Sema<'a> {
                     )),
                 }
             }
+        }
+    }
+
+    /// Fold a comptime-evaluable call in array-length position (`[T; f(args)]`,
+    /// RUE-309) to a concrete `u64`.
+    ///
+    /// The callee must be a value-returning function with at least one
+    /// parameter, all `comptime` — the same implicit-comptime shape
+    /// `eval_comptime_type_call` accepts for value-returning calls (RUE-163,
+    /// spec 4.14:5). A runtime-parametered or nullary callee is a genuine
+    /// runtime call and is not a compile-time-known length, so it errors as
+    /// E0481 rather than being silently accepted.
+    ///
+    /// Arguments arrive as raw substrings of the interned type string; each is
+    /// itself an array-length expression (a literal, a `const`/`comptime`
+    /// name, or a nested call), so it is resolved through
+    /// [`resolve_array_length`] recursively. The resulting integer bindings
+    /// feed [`reduce_type_ctor_body`], which evaluates the callee body under
+    /// that substitution — the identical reducer the value/const-expr paths
+    /// use — so a comptime-recursive `fn fact(comptime n: i32)` yields its
+    /// compile-time length.
+    ///
+    /// [`resolve_array_length`]: Sema::resolve_array_length
+    /// [`reduce_type_ctor_body`]: Sema::reduce_type_ctor_body
+    fn resolve_array_length_call(
+        &mut self,
+        callee: &str,
+        args: &[String],
+        span: Span,
+        value_subst: Option<&HashMap<Spur, ConstValue>>,
+    ) -> CompileResult<u64> {
+        let invalid =
+            |reason: String| CompileError::new(ErrorKind::InvalidArrayLength { reason }, span);
+
+        let callee_sym = self.interner.get_or_intern(callee);
+        let Some(fn_info) = self.functions.get(&callee_sym) else {
+            return Err(invalid(format!(
+                "'{callee}' is not a function; array lengths must be an integer literal, a \
+                 `const`, a `comptime` value parameter, or a call to a comptime function"
+            )));
+        };
+        if fn_info.return_type == Type::COMPTIME_TYPE {
+            return Err(invalid(format!(
+                "array length call '{callee}(...)' must return a value, not a type"
+            )));
+        }
+        let params = fn_info.params;
+        let param_names = self.param_arena.names(params).to_vec();
+        let param_comptime = self.param_arena.comptime(params).to_vec();
+        // Same implicit-comptime gate as `eval_comptime_type_call`: a value
+        // function reduces only with at least one parameter, every one
+        // `comptime`. A runtime parameter makes this a genuine runtime call.
+        let all_comptime = !param_names.is_empty() && param_comptime.iter().all(|&c| c);
+        if args.len() != param_names.len() || !all_comptime {
+            return Err(invalid(format!(
+                "array length call '{callee}(...)' is not a compile-time constant; its callee \
+                 must be a value-returning function whose parameters are all `comptime`"
+            )));
+        }
+        let mut callee_values: HashMap<Spur, ConstValue> = HashMap::new();
+        for (i, arg) in args.iter().enumerate() {
+            // Mirror `parse_array_type_syntax`: a decimal literal is a
+            // `Literal`, anything else (a name or nested call) is a `Named`
+            // resolved recursively.
+            let arg_len = match arg.parse::<u64>() {
+                Ok(n) => ArrayLen::Literal(n),
+                Err(_) => ArrayLen::Named(arg.clone()),
+            };
+            let v = self.resolve_array_length(&arg_len, span, value_subst)?;
+            callee_values.insert(param_names[i], ConstValue::Integer(v as i128));
+        }
+        let empty_types: HashMap<Spur, Type> = HashMap::new();
+        match self.reduce_type_ctor_body(callee_sym, &empty_types, &callee_values)? {
+            Some(ConstValue::Integer(n)) if n >= 0 => u64::try_from(n)
+                .map_err(|_| invalid(format!("array length '{callee}(...)' ({n}) is too large"))),
+            Some(ConstValue::Integer(n)) => Err(invalid(format!(
+                "array length '{callee}(...)' is negative ({n})"
+            ))),
+            _ => Err(invalid(format!(
+                "array length call '{callee}(...)' did not evaluate to a compile-time integer"
+            ))),
         }
     }
 

--- a/crates/rue-cli-tests/cases/array_length_comptime_call.toml
+++ b/crates/rue-cli-tests/cases/array_length_comptime_call.toml
@@ -1,0 +1,72 @@
+# A comptime-evaluable call in array-length position (RUE-309).
+#
+# The parser now accepts `[T; f(args)]`; sema folds the call to a concrete
+# length through the same const evaluator that reduces `comptime` blocks
+# (RUE-163). These cases drive the real binary end-to-end so the folded length
+# is exercised at runtime (indexing near the last element) and the clean-error
+# paths are checked as a user would hit them.
+
+[section]
+id = "cli.array_length_comptime_call"
+name = "Comptime-call array lengths"
+description = "Array types whose length is a comptime-evaluable function call."
+
+[[case]]
+name = "fact_length_indexes_last_element"
+files = [{ path = "main.rue", source = """
+fn fact(comptime n: i32) -> i32 {
+    if n <= 1 { 1 } else { n * fact(n - 1) }
+}
+
+fn main() -> i32 {
+    let a: [i32; fact(4)] = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
+    ];
+    // Length is fact(4) = 24, so the last valid index is 23.
+    @dbg(a[23]);
+    0
+}
+""" }]
+stdout = "24\n"
+exit_code = 0
+
+[[case]]
+name = "nested_call_length"
+files = [{ path = "main.rue", source = """
+fn g(comptime n: i32) -> i32 { n + 2 }
+fn dbl(comptime n: i32) -> i32 { n * 2 }
+
+fn main() -> i32 {
+    // dbl(g(1)) = dbl(3) = 6
+    let a: [i32; dbl(g(1))] = [10, 20, 30, 40, 50, 60];
+    @dbg(a[5]);
+    0
+}
+""" }]
+stdout = "60\n"
+exit_code = 0
+
+[[case]]
+name = "runtime_param_call_length_errors_cleanly"
+files = [{ path = "main.rue", source = """
+fn add(a: i32, b: i32) -> i32 { a + b }
+
+fn main() -> i32 {
+    let a: [i32; add(2, 3)] = [0, 0, 0, 0, 0];
+    a[0]
+}
+""" }]
+compile_fail = true
+error_contains = ["E0481", "not a compile-time constant"]
+
+[[case]]
+name = "unknown_call_length_errors_cleanly"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: [i32; nope(3)] = [0, 0, 0];
+    a[0]
+}
+""" }]
+compile_fail = true
+error_contains = ["E0481", "not a function"]

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -381,6 +381,14 @@ pub enum ArrayLength {
     Literal(u64),
     /// A named length, e.g. the `N` in `[i32; N]`.
     Named(Ident),
+    /// A comptime-evaluable call in length position, e.g. the `fact(4)` in
+    /// `[i32; fact(4)]` (RUE-309). The callee must be a value-returning
+    /// function whose parameters are all `comptime`; sema folds the call to a
+    /// concrete length via the same const evaluator that reduces `comptime`
+    /// blocks (RUE-163). Arguments are themselves array-length expressions
+    /// (a literal, a `const`/`comptime` name, or a nested call), so calls
+    /// compose (`[i32; fact(g(2))]`).
+    Call { name: Ident, args: Vec<ArrayLength> },
 }
 
 impl fmt::Display for ArrayLength {
@@ -389,6 +397,16 @@ impl fmt::Display for ArrayLength {
             ArrayLength::Literal(n) => write!(f, "{}", n),
             // Match the canonical name encoding used elsewhere for identifiers.
             ArrayLength::Named(ident) => write!(f, "sym:{}", ident.name.into_usize()),
+            ArrayLength::Call { name, args } => {
+                write!(f, "sym:{}(", name.name.into_usize())?;
+                for (i, arg) in args.iter().enumerate() {
+                    if i > 0 {
+                        write!(f, ", ")?;
+                    }
+                    write!(f, "{}", arg)?;
+                }
+                write!(f, ")")
+            }
         }
     }
 }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -255,15 +255,31 @@ where
         // Never type: !
         let never_type = just(TokenKind::Bang).map_with(|_, e| TypeExpr::Never(span_from_extra(e)));
 
-        // Array type: [T; N] where N is an integer literal or a name referring
-        // to a file-level `const` or a `comptime` value parameter (RUE-16).
-        let array_length = choice((
-            select! { TokenKind::Int(n) => ArrayLength::Literal(n as u64) },
-            ident_parser().map(ArrayLength::Named),
-        ))
-        // Otherwise an empty/invalid length reports the bare-`select!`
-        // catch-all "expected something else". (RUE-19)
-        .labelled("array length");
+        // Array type: [T; N] where N is an integer literal, a name referring
+        // to a file-level `const` or a `comptime` value parameter (RUE-16), or
+        // a comptime-evaluable call `f(args)` (RUE-309). The call form is a
+        // recursive grammar so arguments (literals, names, or nested calls)
+        // compose; it is tried before the bare-name form so `f(...)` is not
+        // mis-parsed as a name `f` with a dangling argument list.
+        let array_length = recursive(|array_length| {
+            let call = ident_parser()
+                .then(
+                    array_length
+                        .separated_by(just(TokenKind::Comma))
+                        .allow_trailing()
+                        .collect::<Vec<_>>()
+                        .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
+                )
+                .map(|(name, args)| ArrayLength::Call { name, args });
+            choice((
+                select! { TokenKind::Int(n) => ArrayLength::Literal(n as u64) },
+                call,
+                ident_parser().map(ArrayLength::Named),
+            ))
+            // Otherwise an empty/invalid length reports the bare-`select!`
+            // catch-all "expected something else". (RUE-19)
+            .labelled("array length")
+        });
         let array_type = just(TokenKind::LBracket)
             .ignore_then(ty.clone())
             .then_ignore(just(TokenKind::Semi))
@@ -1525,14 +1541,28 @@ where
             .then_ignore(one_of([TokenKind::Comma, TokenKind::RParen]).rewind())
             .map_with(|_, e| IntrinsicArg::Type(TypeExpr::Never(span_from_extra(e))));
 
-        // Array type: [T; N] where N is a literal or a named length (RUE-16).
+        // Array type: [T; N] where N is a literal, a named length (RUE-16), or
+        // a comptime-evaluable call `f(args)` (RUE-309).
+        let array_length = recursive(|array_length| {
+            let call = ident_parser()
+                .then(
+                    array_length
+                        .separated_by(just(TokenKind::Comma))
+                        .allow_trailing()
+                        .collect::<Vec<_>>()
+                        .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
+                )
+                .map(|(name, args)| ArrayLength::Call { name, args });
+            choice((
+                select! { TokenKind::Int(n) => ArrayLength::Literal(n as u64) },
+                call,
+                ident_parser().map(ArrayLength::Named),
+            ))
+        });
         let array_type = just(TokenKind::LBracket)
             .ignore_then(type_parser())
             .then_ignore(just(TokenKind::Semi))
-            .then(choice((
-                select! { TokenKind::Int(n) => ArrayLength::Literal(n as u64) },
-                ident_parser().map(ArrayLength::Named),
-            )))
+            .then(array_length)
             .then_ignore(just(TokenKind::RBracket))
             .map_with(|(element, length), e| {
                 IntrinsicArg::Type(TypeExpr::Array {
@@ -3659,6 +3689,41 @@ mod tests {
             }
             _ => panic!("expected Function"),
         }
+    }
+
+    #[test]
+    fn test_array_length_call_form() {
+        // RUE-309: a comptime-evaluable call is accepted in array-length
+        // position and parses to `ArrayLength::Call`, with a nested call as an
+        // argument (`[i32; dbl(g(1))]`).
+        let result = parse("fn f() { let a: [i32; dbl(g(1))] = x; }").unwrap();
+        let Item::Function(func) = &result.ast.items[0] else {
+            panic!("expected Function");
+        };
+        // Dig into the `let` statement's declared type.
+        let Expr::Block(block) = &func.body else {
+            panic!("expected block body");
+        };
+        let Statement::Let(let_stmt) = &block.statements[0] else {
+            panic!("expected Let statement");
+        };
+        let Some(TypeExpr::Array { length, .. }) = &let_stmt.ty else {
+            panic!("expected array type annotation");
+        };
+        let ArrayLength::Call { name, args } = length else {
+            panic!("expected call-form array length, got {length:?}");
+        };
+        assert_eq!(result.get(name.name), "dbl");
+        assert_eq!(args.len(), 1);
+        let ArrayLength::Call {
+            name: inner_name,
+            args: inner_args,
+        } = &args[0]
+        else {
+            panic!("expected nested call argument");
+        };
+        assert_eq!(result.get(inner_name.name), "g");
+        assert_eq!(inner_args, &[ArrayLength::Literal(1)]);
     }
 
     #[test]

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -89,16 +89,12 @@ impl<'a> AstGen<'a> {
                 // Get the element symbol first, then look it up
                 let elem_sym = self.intern_type(element);
                 let elem_name = self.interner.resolve(&elem_sym);
-                // The length component is either a literal (`4`) or a name
-                // referring to a `const` / `comptime` value parameter (`N`),
-                // resolved to a concrete value during sema (RUE-16).
-                let s = match length {
-                    ArrayLength::Literal(n) => format!("[{}; {}]", elem_name, n),
-                    ArrayLength::Named(ident) => {
-                        let len_name = self.interner.resolve(&ident.name);
-                        format!("[{}; {}]", elem_name, len_name)
-                    }
-                };
+                // The length component is a literal (`4`), a name referring to
+                // a `const` / `comptime` value parameter (`N`), or a
+                // comptime-evaluable call (`fact(4)`), all resolved to a
+                // concrete value during sema (RUE-16, RUE-309).
+                let len_str = self.render_array_length(length);
+                let s = format!("[{}; {}]", elem_name, len_str);
                 self.interner.get_or_intern(&s)
             }
             TypeExpr::AnonymousStruct { fields, .. } => {
@@ -176,6 +172,26 @@ impl<'a> AstGen<'a> {
                 }
                 s.push(')');
                 self.interner.get_or_intern(&s)
+            }
+        }
+    }
+
+    /// Render an array-length component to its canonical string form for the
+    /// interned type name (`[element; <this>]`).
+    ///
+    /// A literal renders as its decimal value, a name as the identifier text,
+    /// and a call as `callee(arg, ...)` with each argument rendered by the same
+    /// rule so nested calls compose (RUE-309). Sema parses these forms back out
+    /// of the type string and folds them to a concrete length (RUE-16).
+    fn render_array_length(&self, length: &ArrayLength) -> String {
+        match length {
+            ArrayLength::Literal(n) => n.to_string(),
+            ArrayLength::Named(ident) => self.interner.resolve(&ident.name).to_string(),
+            ArrayLength::Call { name, args } => {
+                let callee = self.interner.resolve(&name.name);
+                let rendered: Vec<String> =
+                    args.iter().map(|a| self.render_array_length(a)).collect();
+                format!("{}({})", callee, rendered.join(", "))
             }
         }
     }
@@ -721,6 +737,13 @@ impl<'a> AstGen<'a> {
                     let count = match count {
                         ArrayLength::Literal(n) => RepeatCount::Literal(*n),
                         ArrayLength::Named(ident) => RepeatCount::Named(ident.name),
+                        // The array-literal repeat grammar (`[value; count]`)
+                        // only parses a literal or a bare name, never a call,
+                        // so this arm is unreachable. The call form is accepted
+                        // only in array-*type* length position (RUE-309).
+                        ArrayLength::Call { .. } => {
+                            unreachable!("array repeat count never parses a call form")
+                        }
                     };
                     self.rir.add_inst(Inst {
                         data: InstData::ArrayRepeat { value, count },

--- a/crates/rue-spec/cases/arrays/fixed.toml
+++ b/crates/rue-spec/cases/arrays/fixed.toml
@@ -903,6 +903,80 @@ compile_fail = true
 error_contains = "not a compile-time constant"
 
 # =============================================================================
+# Array lengths from comptime-evaluable calls (RUE-309)
+# =============================================================================
+
+[[case]]
+name = "array_length_from_comptime_call"
+spec = ["7.1:41", "7.1:42"]
+source = """
+fn fact(comptime n: i32) -> i32 {
+    if n <= 1 { 1 } else { n * fact(n - 1) }
+}
+fn main() -> i32 {
+    let a: [i32; fact(4)] = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
+    ];
+    a[23]
+}
+"""
+exit_code = 24
+
+[[case]]
+name = "array_length_from_nested_comptime_call"
+spec = ["7.1:41"]
+source = """
+fn g(comptime n: i32) -> i32 { n + 2 }
+fn dbl(comptime n: i32) -> i32 { n * 2 }
+fn main() -> i32 {
+    let a: [i32; dbl(g(1))] = [10, 20, 30, 40, 50, 60];
+    a[5]
+}
+"""
+exit_code = 60
+
+[[case]]
+name = "array_length_call_with_comptime_param_arg"
+spec = ["7.1:41"]
+source = """
+fn dbl(comptime n: i32) -> i32 { n * 2 }
+fn f(comptime N: i32) -> i32 {
+    let a: [i32; dbl(N)] = [1, 2, 3, 4];
+    a[0] + a[3]
+}
+fn main() -> i32 {
+    f(2)
+}
+"""
+exit_code = 5
+
+[[case]]
+name = "array_length_runtime_call_error"
+spec = ["7.1:41"]
+source = """
+fn add(a: i32, b: i32) -> i32 { a + b }
+fn main() -> i32 {
+    let a: [i32; add(2, 3)] = [0, 0, 0, 0, 0];
+    a[0]
+}
+"""
+compile_fail = true
+error_contains = "not a compile-time constant"
+
+[[case]]
+name = "array_length_unknown_call_error"
+spec = ["7.1:41"]
+source = """
+fn main() -> i32 {
+    let a: [i32; nope(3)] = [0, 0, 0];
+    a[0]
+}
+"""
+compile_fail = true
+error_contains = "not a function"
+
+# =============================================================================
 # Array-Repeat Literals (RUE-235)
 # =============================================================================
 

--- a/docs/spec/src/07-arrays/01-fixed-arrays.md
+++ b/docs/spec/src/07-arrays/01-fixed-arrays.md
@@ -133,14 +133,16 @@ fn main() -> i32 {
 
 ```ebnf
 array_type   = "[" type ";" array_length "]" ;
-array_length = INTEGER | IDENTIFIER ;
+array_length = INTEGER | IDENTIFIER | length_call ;
+length_call  = IDENTIFIER "(" [ array_length { "," array_length } ] ")" ;
 ```
 
 {{ rule(id="7.1:15", cat="legality-rule") }}
 
 The length **MUST** be a non-negative integer value known at compile time. It is
-either an integer literal, or an identifier naming a compile-time constant — a
-file-level `const` or an in-scope `comptime` value parameter.
+either an integer literal, an identifier naming a compile-time constant — a
+file-level `const` or an in-scope `comptime` value parameter — or a call to a
+comptime-evaluable function (rule 7.1:41).
 
 ## Compile-Time Array Lengths
 
@@ -177,6 +179,35 @@ fn main() -> i32 {
     let b2: B2 = B2 { data: [1, 2], len: 2 };
     let b4: B4 = B4 { data: [10, 20, 30, 40], len: 4 };
     b2.data[1] + b4.data[3]  // 42
+}
+```
+
+{{ rule(id="7.1:41", cat="normative") }}
+
+An array length **MAY** also be a call to a comptime-evaluable function, in
+addition to a literal or a named constant. The callee **MUST** be a
+value-returning function whose parameters are all `comptime` (the same
+implicit-comptime shape that makes a call foldable in a `comptime` context);
+its arguments are themselves array-length forms (a literal, a named constant,
+or a nested call). The call is folded to the concrete length using the same
+compile-time evaluator that reduces `comptime` blocks, and its result **MUST**
+be a non-negative integer. A call whose callee takes a runtime parameter, is
+nullary, returns a type, or names no known function is not a compile-time
+length and is a compile-time error.
+
+{{ rule(id="7.1:42") }}
+
+```rue
+fn fact(comptime n: i32) -> i32 {
+    if n <= 1 { 1 } else { n * fact(n - 1) }
+}
+
+fn main() -> i32 {
+    let a: [i32; fact(4)] = [
+        1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12,
+        13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24
+    ];  // length is fact(4) = 24
+    a[23]  // 24
 }
 ```
 

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -74,7 +74,8 @@ type           = "i8" | "i16" | "i32" | "i64"
                | anon_struct_type
                | "Self"
                | IDENT ;
-array_length   = INTEGER | IDENT ;
+array_length   = INTEGER | IDENT | length_call ;
+length_call    = IDENT "(" [ array_length { "," array_length } ] ")" ;  (* comptime-evaluable call, e.g. fact(4) *)
 anon_struct_type = "struct" "{" [ anon_struct_fields ] { method } "}" ;
 anon_struct_fields = struct_field { "," struct_field } [ "," ] ;
 
@@ -158,7 +159,8 @@ break_expr     = "break" [ expression ] ;   (* an operand parses but is always
                                                rejected in semantic analysis *)
 return_expr    = "return" [ expression ] ;
 array_literal  = "[" ( [ expression { "," expression } ]
-                     | expression ";" array_length ) "]" ;  (* repeat form: array_length is a compile-time constant *)
+                     | expression ";" repeat_count ) "]" ;
+repeat_count   = INTEGER | IDENT ;  (* repeat form: a literal or named compile-time constant (no call form) *)
 field_inits    = field_init { "," field_init } [ "," ] ;
 field_init     = IDENT ":" expression ;
 


### PR DESCRIPTION
The array-length grammar only accepted an integer literal or a bare identifier, so a call like fact(4) in [T; f(n)] never reached sema (E0100 at the '('). Added ArrayLength::Call + a recursive call form in both array-TYPE length positions (parser), rendered it into the canonical interned type string (rir), and fold it in resolve_array_length via the shared reduce_type_ctor_body reducer, gated to value-returning all-comptime callees (rue-air, isolated to the array-length path). No preview/rue-error/codegen changes.

Verified by execution: [i32; fact(4)] yields length 24 (a[23]=24); nested dbl(g(1)) and dbl(N) fold; a runtime/unknown callee gives a clean error; [i32;3] and [i32;N] still work; aarch64 asm OK. clippy-gate-passed; test.sh Pass 24 (100% traceability incl. new rules 7.1:41/7.1:42); oracle-diff 0 disagreements. 5 spec + 4 CLI cases + a parser unit test.

Fixes RUE-309

Generated with Claude Code