### PR TITLE
First real Rue program: stdin integer stats (RUE-226 milestone)

### DIFF
--- a/.buckconfig.local
+++ b/.buckconfig.local
@@ -1,0 +1,2 @@
+[buck2]
+file_watcher = fs_hash_crawler

--- a/crates/rue-cli-tests/cases/first_program.toml
+++ b/crates/rue-cli-tests/cases/first_program.toml
@@ -1,0 +1,80 @@
+# The first real Rue program (RUE-226 dogfooding milestone): examples/first/stats.rue.
+# Reads a count N, then N integers, and prints count/sum/max. Regression-locks the
+# whole freshly-stabilized dogfooding set working together end to end.
+
+[section]
+id = "cli.first_program"
+name = "First dogfood program (stats)"
+description = "count-prefixed integers -> count/sum/max via @read_line, @parse_i64, a payload enum, and println."
+
+[[case]]
+name = "stats_three_numbers"
+files = [{ path = "stats.rue", source = """
+enum Maybe { Some(i64), None }
+
+fn main() -> i32 {
+    let n = @parse_i64(@read_line());
+    let mut i: i64 = 0;
+    let mut sum: i64 = 0;
+    let mut max: Maybe = Maybe::None;
+    while i < n {
+        let x = @parse_i64(@read_line());
+        sum = sum + x;
+        max = match max {
+            Maybe::None => Maybe::Some(x),
+            Maybe::Some(m) => if x > m { Maybe::Some(x) } else { Maybe::Some(m) },
+        };
+        i = i + 1;
+    }
+    println("count: " + @to_string(n));
+    println("sum: " + @to_string(sum));
+    match max {
+        Maybe::Some(m) => println("max: " + @to_string(m)),
+        Maybe::None => println("max: (no input)"),
+    }
+    @intCast(n)
+}
+""" }]
+stdin = "3\n7\n5\n1\n"
+stdout = """
+count: 3
+sum: 13
+max: 7
+"""
+exit_code = 3
+
+[[case]]
+name = "stats_empty_set"
+files = [{ path = "stats.rue", source = """
+enum Maybe { Some(i64), None }
+
+fn main() -> i32 {
+    let n = @parse_i64(@read_line());
+    let mut i: i64 = 0;
+    let mut sum: i64 = 0;
+    let mut max: Maybe = Maybe::None;
+    while i < n {
+        let x = @parse_i64(@read_line());
+        sum = sum + x;
+        max = match max {
+            Maybe::None => Maybe::Some(x),
+            Maybe::Some(m) => if x > m { Maybe::Some(x) } else { Maybe::Some(m) },
+        };
+        i = i + 1;
+    }
+    println("count: " + @to_string(n));
+    println("sum: " + @to_string(sum));
+    match max {
+        Maybe::Some(m) => println("max: " + @to_string(m)),
+        Maybe::None => println("max: (no input)"),
+    }
+    @intCast(n)
+}
+""" }]
+stdin = "0\n"
+stdout = """
+count: 0
+sum: 0
+max: (no input)
+"""
+exit_code = 0

--- a/examples/first/stats.rue
+++ b/examples/first/stats.rue
@@ -1,0 +1,46 @@
+// The first real Rue program (RUE-226 dogfooding milestone).
+//
+// Reads a count N on the first line, then N integers (one per line), and
+// prints how many were read, their sum, and the maximum.
+//
+//   $ printf '3\n7\n5\n1\n' | rue examples/first/stats.rue -o stats && ./stats
+//   count: 3
+//   sum: 13
+//   max: 7
+//
+// (A count-prefixed format is used because @read_line currently traps on EOF
+// rather than signalling it — see RUE follow-up. Once @read_line reports EOF,
+// this becomes a natural read-until-end loop.)
+//
+// Exercises the freshly-stabilized dogfooding set: @read_line, @parse_i64,
+// String concatenation + @to_string, println, a payload enum (Maybe) for
+// "the max of possibly-empty input", and a while loop with a match expression.
+
+enum Maybe { Some(i64), None }
+
+fn main() -> i32 {
+    let n = @parse_i64(@read_line());
+
+    let mut i: i64 = 0;
+    let mut sum: i64 = 0;
+    let mut max: Maybe = Maybe::None;
+
+    while i < n {
+        let x = @parse_i64(@read_line());
+        sum = sum + x;
+        max = match max {
+            Maybe::None => Maybe::Some(x),
+            Maybe::Some(m) => if x > m { Maybe::Some(x) } else { Maybe::Some(m) },
+        };
+        i = i + 1;
+    }
+
+    println("count: " + @to_string(n));
+    println("sum: " + @to_string(sum));
+    match max {
+        Maybe::Some(m) => println("max: " + @to_string(m)),
+        Maybe::None => println("max: (no input)"),
+    }
+
+    @intCast(n)
+}


### PR DESCRIPTION
examples/first/stats.rue — reads a count N then N integers from stdin and prints count/sum/max. The first program written in Rue as real code, flag-free, now that the four dogfooding features are stabilized (#1108).

Exercises the set end to end: @read_line, @parse_i64, String concat + @to_string, println, a payload enum (Maybe) modelling 'max of possibly-empty input', and a while loop with a match expression. Locked in as a CLI regression (cli.first_program: three-numbers + empty-set).

**Dogfooding surfaced real friction (the point of RUE-226):**
- @to_string only accepts i64 (i32 needs a cast) -> filed RUE-314.
- @parse bare-int failure + @read_line EOF both trap -> already tracked under RUE-6 error handling (stdin.toml); this is why the program uses a count-prefixed format instead of read-until-EOF.

Verified: '3/7/5/1' -> count 3/sum 13/max 7; '0' -> max '(no input)'; negatives -> max -5/sum -14. clippy-gate-passed; test.sh Pass 24.

Part of RUE-226
Part of RUE-1

Generated with Claude Code