### PR TITLE
First real Rue program: stdin integer stats (RUE-226 milestone)

### DIFF
--- a/crates/rue-cli-tests/cases/first_program.toml
+++ b/crates/rue-cli-tests/cases/first_program.toml
@@ -1,0 +1,52 @@
+# The first real Rue program (RUE-226 dogfooding milestone): examples/first/stats.rue.
+# Reads a count N, then N integers, and prints count/sum/max. Regression-locks the
+# whole freshly-stabilized dogfooding set working together end to end, including the
+# generic Option imported from the std library (no prelude yet, so it's imported).
+
+[section]
+id = "cli.first_program"
+name = "First dogfood program (stats)"
+description = "count-prefixed integers -> count/sum/max via @read_line, @parse_i64, an imported generic Option, and println."
+
+[[case]]
+name = "stats_three_numbers"
+files = [
+  { path = "stats.rue", source = """
+fn main() -> i32 {
+    let Opt = @import("option.rue").Option(i64);
+    let n = @parse_i64(@read_line());
+    let mut i: i64 = 0;
+    let mut sum: i64 = 0;
+    let mut max: Opt = Opt::None;
+    while i < n {
+        let x = @parse_i64(@read_line());
+        sum = sum + x;
+        max = match max {
+            Opt::None => Opt::Some(x),
+            Opt::Some(m) => if x > m { Opt::Some(x) } else { Opt::Some(m) },
+        };
+        i = i + 1;
+    }
+    println("count: " + @to_string(n));
+    println("sum: " + @to_string(sum));
+    match max {
+        Opt::Some(m) => println("max: " + @to_string(m)),
+        Opt::None => println("max: (no input)"),
+    }
+    @intCast(n)
+}
+""" },
+  { path = "option.rue", source = """
+pub fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+""" },
+]
+args = ["stats.rue", "option.rue", "-o", "prog"]
+stdin = "3\n7\n5\n1\n"
+stdout = """
+count: 3
+sum: 13
+max: 7
+"""
+exit_code = 3

--- a/examples/first/stats.rue
+++ b/examples/first/stats.rue
@@ -1,0 +1,51 @@
+// The first real Rue program (RUE-226 dogfooding milestone).
+//
+// Reads a count N on the first line, then N integers (one per line), and
+// prints how many were read, their sum, and the maximum.
+//
+//   $ printf '3\n7\n5\n1\n' | rue examples/first/stats.rue examples/std/option.rue -o stats && ./stats
+//   count: 3
+//   sum: 13
+//   max: 7
+//
+// Two things this program reveals about Rue today (the point of dogfooding):
+//
+//   * No prelude yet (RUE-287): `Option` is not in scope automatically, so we
+//     @import it from the std library. Every peer language (Rust, Swift, Zig)
+//     has an optional type built in.
+//   * A count-prefixed format is used because @read_line traps on EOF and
+//     @parse_i64 traps on bad input rather than signalling failure. Once error
+//     handling lands (RUE-6), this becomes a natural read-until-EOF loop.
+//
+// Exercises the now-stabilized dogfooding set: @read_line, @parse_i64, a generic
+// Option, String concatenation + @to_string, println, and a while loop with a
+// match expression modelling "the max of a possibly-empty set".
+
+fn main() -> i32 {
+    let Opt = @import("../std/option.rue").Option(i64);
+
+    let n = @parse_i64(@read_line());
+
+    let mut i: i64 = 0;
+    let mut sum: i64 = 0;
+    let mut max: Opt = Opt::None;
+
+    while i < n {
+        let x = @parse_i64(@read_line());
+        sum = sum + x;
+        max = match max {
+            Opt::None => Opt::Some(x),
+            Opt::Some(m) => if x > m { Opt::Some(x) } else { Opt::Some(m) },
+        };
+        i = i + 1;
+    }
+
+    println("count: " + @to_string(n));
+    println("sum: " + @to_string(sum));
+    match max {
+        Opt::Some(m) => println("max: " + @to_string(m)),
+        Opt::None => println("max: (no input)"),
+    }
+
+    @intCast(n)
+}


### PR DESCRIPTION
examples/first/stats.rue — reads a count N then N integers from stdin and prints count/sum/max. The first program written in Rue as real code, flag-free, now that the four dogfooding features are stabilized (#1108).

Exercises the set end to end: @read_line, @parse_i64, a generic Option (@import'd from std), String concat + @to_string, println, and a while loop with a match expression modelling 'max of a possibly-empty set'. Locked in as a CLI regression (cli.first_program, bundled option.rue).

**Dogfooding surfaced real friction (the point of RUE-226):**
- No prelude (RUE-287): Option must be @import'd — peer languages have an optional type built in.
- @read_line traps on EOF + @parse_i64 traps on bad input -> already tracked under RUE-6 error handling; this is why the program uses a count-prefixed format instead of read-until-EOF. RUE-6 is now the clear top feature priority.
- @to_string only accepts i64 -> filed RUE-314.

Verified: '3/7/5/1' -> count 3/sum 13/max 7; '0' -> max '(no input)'; negatives -> max -5/sum -14. clippy-gate-passed; test.sh Pass 24.

(Supersedes #1110, which used a local Maybe enum.)

Part of RUE-226
Part of RUE-1

Generated with Claude Code