### PR TITLE
Finish ADR-0040: aggregates ascending-in-address everywhere (fixes heap corruption, RUE-311)

### DIFF
--- a/crates/rue-cli-tests/cases/aggregate_ascending_layout.toml
+++ b/crates/rue-cli-tests/cases/aggregate_ascending_layout.toml
@@ -1,0 +1,120 @@
+# Ascending aggregate layout end-to-end (RUE-311 / ADR-0040).
+#
+# Every aggregate (struct/array/String) is laid out ascending-in-address:
+# field 0 / element 0 at the LOWEST address, slot k at base + k*8. `@raw`
+# returns the low end and `@ptr_read`/`@ptr_write`/`@ptr_offset` walk slots
+# UPWARD from it, so a raw pointer behaves identically whether it points into a
+# stack local or an `@alloc`'d heap block. Before the fix, multi-slot aggregates
+# were written descending through a raw pointer (slot i at ptr - i*8), which on
+# the ascending heap underflowed into the PRECEDING allocation — silent memory
+# corruption with zero test coverage. These cases pin the fixed behavior via
+# exact stdout (drops printed for ordering), not just exit codes.
+
+[section]
+id = "cli.aggregate_ascending_layout"
+name = "Ascending aggregate layout: heap round-trip, non-clobber, array-of-struct, ABI"
+description = "Multi-slot aggregates round-trip through raw pointers and the call ABI with no adjacent-allocation corruption (RUE-311)."
+
+# --- Multi-slot heap round-trip + adjacent-allocation non-clobber -----------
+# A 999-filled guard block is allocated BEFORE the pair buffer. Writing two
+# adjacent 2-slot Pairs must stay within their own block and leave the guard
+# intact (the descending-offset bug wrote the second slot at ptr-8, corrupting
+# the guard).
+[[case]]
+name = "heap_multislot_roundtrip_no_clobber"
+files = [{ path = "main.rue", source = """
+struct Pair { a: i32, b: i32 }
+fn main() -> i32 {
+    checked {
+        let guard: ptr mut Pair = @alloc(1);
+        @ptr_write(guard, Pair { a: 999, b: 999 });
+        let p: ptr mut Pair = @alloc(2);
+        @ptr_write(p, Pair { a: 11, b: 22 });
+        let q: ptr mut Pair = @ptr_offset(p, 1);
+        @ptr_write(q, Pair { a: 33, b: 44 });
+        let v0 = @ptr_read(p);
+        @dbg(v0.a); @dbg(v0.b);
+        let v1 = @ptr_read(q);
+        @dbg(v1.a); @dbg(v1.b);
+        let g = @ptr_read(guard);
+        @dbg(g.a); @dbg(g.b);
+        @free(p, 2);
+        @free(guard, 1);
+    };
+    0
+}
+""" }]
+stdout = "11\n22\n33\n44\n999\n999\n"
+
+# --- @raw of a stack struct + @ptr round-trip (low-end ascending) -----------
+[[case]]
+name = "stack_raw_ptr_roundtrip"
+files = [{ path = "main.rue", source = """
+struct P { x: i32, y: i32, z: i32 }
+fn main() -> i32 {
+    let mut v: P = P { x: 5, y: 7, z: 9 };
+    checked {
+        let p: ptr mut P = @raw_mut(v);
+        let r = @ptr_read(p);
+        @dbg(r.x); @dbg(r.y); @dbg(r.z);
+        @ptr_write(p, P { x: 40, y: 50, z: 60 });
+    };
+    @dbg(v.x); @dbg(v.y); @dbg(v.z);
+    0
+}
+""" }]
+stdout = "5\n7\n9\n40\n50\n60\n"
+
+# --- Array-of-struct: whole-element and field write/read --------------------
+[[case]]
+name = "array_of_struct_read_write"
+files = [{ path = "main.rue", source = """
+struct P { a: i32, b: i32 }
+fn main() -> i32 {
+    let mut arr: [P; 3] = [P{a:1,b:2}, P{a:3,b:4}, P{a:5,b:6}];
+    arr[1] = P { a: 30, b: 40 };
+    arr[2].a = 50;
+    @dbg(arr[0].a); @dbg(arr[0].b);
+    @dbg(arr[1].a); @dbg(arr[1].b);
+    @dbg(arr[2].a); @dbg(arr[2].b);
+    0
+}
+""" }]
+stdout = "1\n2\n30\n40\n50\n6\n"
+
+# --- Struct pass-by-value + return across the ABI (register + sret) ---------
+[[case]]
+name = "struct_abi_roundtrip"
+files = [{ path = "main.rue", source = """
+struct P { x: i32, y: i32 }
+struct Big { a: i64, b: i64, c: i64, d: i64, e: i64 }
+fn mkP(a: i32, b: i32) -> P { P { x: a, y: b } }
+fn useP(p: P) -> i32 { p.x * 10 + p.y }
+fn mkBig(x: i64) -> Big { Big { a: x, b: x+1, c: x+2, d: x+3, e: x+4 } }
+fn sumBig(g: Big) -> i64 { g.a + g.b + g.c + g.d + g.e }
+fn main() -> i32 {
+    let p = mkP(6, 8);
+    @dbg(p.x); @dbg(p.y);
+    @dbg(useP(p));
+    let g = mkBig(10);
+    @dbg(g.a); @dbg(g.e);
+    @dbg(sumBig(g));
+    0
+}
+""" }]
+stdout = "6\n8\n68\n10\n14\n60\n"
+
+# --- inout struct: callee mutates every field through the by-ref pointer ----
+[[case]]
+name = "inout_struct_field_writeback"
+files = [{ path = "main.rue", source = """
+struct P { x: i32, y: i32, z: i32 }
+fn setAll(inout p: P) { p.x = 77; p.y = 88; p.z = 99; }
+fn main() -> i32 {
+    let mut p: P = P { x: 1, y: 2, z: 3 };
+    setAll(inout p);
+    @dbg(p.x); @dbg(p.y); @dbg(p.z);
+    0
+}
+""" }]
+stdout = "77\n88\n99\n"

--- a/crates/rue-cli-tests/cases/vec_library.toml
+++ b/crates/rue-cli-tests/cases/vec_library.toml
@@ -124,3 +124,104 @@ pub fn Vec(comptime T: type) -> type {
 args = ["main.rue", "vec.rue", "-o", "prog"]
 stdout = "3\n20\n99\n30\n2\n0\n119\n"
 exit_code = 119
+
+# Multi-slot struct element type: push/get/set/pop of a two-field `Point`
+# round-trips correctly now that aggregates are laid out ascending and raw
+# pointers walk their slots upward (ADR-0040 / RUE-311). Previously the second
+# field was written at `ptr - 8`, corrupting the preceding element/allocation,
+# so Vec was scoped to single-slot Copy elements.
+[[case]]
+name = "vec_struct_element_dogfood"
+description = "push/get/set/pop on Vec(Point) with a two-field struct element (RUE-311)."
+files = [
+  { path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let m = @import(\"vec.rue\");
+    let V = m.Vec(Point);
+
+    let mut v = V::new();
+    v.push(Point { x: 1, y: 2 });
+    v.push(Point { x: 3, y: 4 });
+    v.push(Point { x: 5, y: 6 });
+    @dbg(v.len());                       // 3
+
+    let p1 = v.get(1);
+    @dbg(p1.x); @dbg(p1.y);              // 3 4
+
+    v.set(0, Point { x: 90, y: 91 });
+    let p0 = v.get(0);
+    @dbg(p0.x); @dbg(p0.y);              // 90 91
+
+    let last = v.pop_or(Point { x: 0, y: 0 });
+    @dbg(last.x); @dbg(last.y);          // 5 6
+    @dbg(v.len());                       // 2
+
+    v.free();
+    0
+}
+""" },
+  { path = "vec.rue", source = """
+pub fn Vec(comptime T: type) -> type {
+    struct {
+        buf: ptr mut T,
+        len: u64,
+        cap: u64,
+
+        fn new() -> Self {
+            let zero: u64 = 0;
+            Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 }
+        }
+        fn len(borrow self) -> u64 { self.len }
+
+        fn reserve(inout self) {
+            if self.len == self.cap {
+                let new_cap: u64 = if self.cap == 0 { 4 } else { self.cap * 2 };
+                checked {
+                    let grown = @realloc(self.buf, self.cap, new_cap);
+                    self.buf = grown;
+                };
+                self.cap = new_cap;
+            }
+        }
+        fn push(inout self, x: T) {
+            self.reserve();
+            checked {
+                let slot = @ptr_offset(self.buf, self.len);
+                @ptr_write(slot, x);
+            };
+            self.len = self.len + 1;
+        }
+        fn get(borrow self, i: u64) -> T {
+            checked { @ptr_read(@ptr_offset(self.buf, i)) }
+        }
+        fn set(inout self, i: u64, x: T) {
+            if i < self.len {
+                checked {
+                    let slot = @ptr_offset(self.buf, i);
+                    @ptr_write(slot, x);
+                };
+            }
+        }
+        fn pop_or(inout self, default: T) -> T {
+            if self.len == 0 {
+                default
+            } else {
+                self.len = self.len - 1;
+                checked { @ptr_read(@ptr_offset(self.buf, self.len)) }
+            }
+        }
+        fn free(inout self) {
+            checked { @free(self.buf, self.cap); };
+            let zero: u64 = 0;
+            self.buf = checked { @int_to_ptr(zero) };
+            self.len = 0;
+            self.cap = 0;
+        }
+    }
+}
+""" },
+]
+args = ["main.rue", "vec.rue", "-o", "prog"]
+stdout = "3\n3\n4\n90\n91\n5\n6\n2\n"
+exit_code = 0

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -713,11 +713,17 @@ impl<'a> CfgLower<'a> {
 
                     self.value_map.insert(value, val_vreg);
                 } else {
-                    // Normal parameter: load the value directly from the slot
+                    // Normal parameter: the primary vreg is the value's LOGICAL
+                    // slot 0 (e.g. an enum's discriminant). Ascending layout
+                    // (ADR-0040 / RUE-311): logical slot 0 of a multi-slot param
+                    // is at its region's low end, frame slot `base + count - 1`;
+                    // a scalar (count 1) is at `base` unchanged.
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
 
-                    let slot = self.ctx.num_locals + *index;
+                    let param_ty = self.ctx.cfg.get_inst(value).ty;
+                    let count = self.ctx.type_slot_count(param_ty).max(1);
+                    let slot = self.ctx.num_locals + *index + count - 1;
                     let offset = self.ctx.local_offset(slot);
                     self.mir.push(Aarch64Inst::Ldr {
                         dst: Operand::Virtual(vreg),
@@ -1396,54 +1402,24 @@ impl<'a> CfgLower<'a> {
                 let load_type = self.ctx.cfg.get_inst(value).ty;
 
                 if self.ctx.is_builtin_string(load_type) {
-                    // String: load ptr, len, and cap from consecutive slots
-                    let ptr_vreg = self.mir.alloc_vreg();
-                    let len_vreg = self.mir.alloc_vreg();
-                    let cap_vreg = self.mir.alloc_vreg();
-
-                    // Load ptr from slot
-                    let ptr_offset = self.ctx.local_offset(*slot);
-                    self.mir.push(Aarch64Inst::Ldr {
-                        dst: Operand::Virtual(ptr_vreg),
-                        base: Reg::Fp,
-                        offset: ptr_offset,
-                    });
-
-                    // Load len from slot + 1
-                    let len_offset = self.ctx.local_offset(slot + 1);
-                    self.mir.push(Aarch64Inst::Ldr {
-                        dst: Operand::Virtual(len_vreg),
-                        base: Reg::Fp,
-                        offset: len_offset,
-                    });
-
-                    // Load cap from slot + 2
-                    let cap_offset = self.ctx.local_offset(slot + 2);
-                    self.mir.push(Aarch64Inst::Ldr {
-                        dst: Operand::Virtual(cap_vreg),
-                        base: Reg::Fp,
-                        offset: cap_offset,
-                    });
-
+                    // String fat pointer (ptr, len, cap). Ascending layout
+                    // (ADR-0040 / RUE-311): logical slot 0 (ptr) is at the
+                    // region's low end (highest-numbered slot `slot + 2`),
+                    // slot k at `slot + 2 - k`.
+                    let slot_vregs = crate::agg_slots::load_slots_at_low(self, slot + 2, 3);
+                    let ptr_vreg = slot_vregs[0];
                     // Register String fields (ptr, len, cap)
-                    self.struct_slot_vregs
-                        .insert(value, vec![ptr_vreg, len_vreg, cap_vreg]);
+                    self.struct_slot_vregs.insert(value, slot_vregs);
                     self.value_map.insert(value, ptr_vreg);
                 } else if load_type.is_array() {
-                    // Array: load all element slots (recursively flattened)
+                    // Array: load every logical slot (ascending, ADR-0040 /
+                    // RUE-311): slot 0 at the region's low end.
                     let slot_count = self.ctx.type_slot_count(load_type);
-                    let mut slot_vregs = Vec::with_capacity(slot_count as usize);
-
-                    for i in 0..slot_count {
-                        let elem_vreg = self.mir.alloc_vreg();
-                        let elem_offset = self.ctx.local_offset(slot + i);
-                        self.mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Virtual(elem_vreg),
-                            base: Reg::Fp,
-                            offset: elem_offset,
-                        });
-                        slot_vregs.push(elem_vreg);
-                    }
+                    let slot_vregs = if slot_count > 0 {
+                        crate::agg_slots::load_slots_at_low(self, slot + slot_count - 1, slot_count)
+                    } else {
+                        Vec::new()
+                    };
 
                     // Register array element vregs
                     self.struct_slot_vregs.insert(value, slot_vregs.clone());
@@ -1456,22 +1432,15 @@ impl<'a> CfgLower<'a> {
                         self.value_map.insert(value, vreg);
                     }
                 } else if self.ctx.is_multislot_aggregate(load_type) {
-                    // Struct or payload enum (RUE-221): load all slots. For an
-                    // enum, slot 0 is the discriminant (what a `match`
-                    // switches on).
+                    // Struct or payload enum (RUE-221): load all slots ascending
+                    // (ADR-0040 / RUE-311). For an enum, slot 0 is the
+                    // discriminant (what a `match` switches on).
                     let slot_count = self.ctx.type_slot_count(load_type);
-                    let mut slot_vregs = Vec::with_capacity(slot_count as usize);
-
-                    for i in 0..slot_count {
-                        let field_vreg = self.mir.alloc_vreg();
-                        let field_offset = self.ctx.local_offset(slot + i);
-                        self.mir.push(Aarch64Inst::Ldr {
-                            dst: Operand::Virtual(field_vreg),
-                            base: Reg::Fp,
-                            offset: field_offset,
-                        });
-                        slot_vregs.push(field_vreg);
-                    }
+                    let slot_vregs = if slot_count > 0 {
+                        crate::agg_slots::load_slots_at_low(self, slot + slot_count - 1, slot_count)
+                    } else {
+                        Vec::new()
+                    };
 
                     // Register struct field vregs
                     self.struct_slot_vregs.insert(value, slot_vregs.clone());
@@ -1632,6 +1601,13 @@ impl<'a> CfgLower<'a> {
                     });
                     flattened_vregs.push(sret_ptr_vreg);
                 }
+                // By-value aggregate arguments are passed in REVERSED logical
+                // slot order to Rue-compiled callees (ADR-0040 / RUE-311), which
+                // read them back with the ascending frame convention. Runtime
+                // helpers (`__rue_*`, hand-written with the C ABI) instead expect
+                // a builtin aggregate's slots (e.g. a String's ptr/len/cap) in
+                // natural order, so calls to them are NOT reversed.
+                let callee_is_runtime = self.interner.resolve(name).starts_with("__rue_");
                 let args = self.ctx.cfg.get_call_args(*args_start, *args_len).to_vec();
                 for arg in &args {
                     let arg_value = arg.value;
@@ -1657,8 +1633,13 @@ impl<'a> CfgLower<'a> {
                         // (RUE-221) — regardless of how it was produced. The accessor
                         // materializes lazily-sourced values (Load/Param/PlaceRead) and
                         // cache-hits eager ones (StructInit/ArrayInit/Call/BlockParam).
+                        // Reversed for Rue callees, natural for runtime (RUE-311).
                         if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_value) {
-                            flattened_vregs.extend(field_vregs);
+                            if callee_is_runtime {
+                                flattened_vregs.extend(field_vregs);
+                            } else {
+                                flattened_vregs.extend(field_vregs.into_iter().rev());
+                            }
                         } else {
                             flattened_vregs.push(self.get_vreg(arg_value));
                         }
@@ -2415,9 +2396,13 @@ impl<'a> CfgLower<'a> {
 
                     // Get the local slot for this value
                     let lvalue_inst = self.ctx.cfg.get_inst(lvalue_val);
+                    let lvalue_ty = lvalue_inst.ty;
                     if let CfgInstData::Load { slot } = &lvalue_inst.data {
-                        // Simple case: address of a local variable
-                        let offset = self.ctx.local_offset(*slot);
+                        // Address of a whole local: @raw yields the value's LOW
+                        // end (ADR-0040 / RUE-311) — the highest-numbered frame
+                        // slot `slot + count - 1`.
+                        let count = self.ctx.type_slot_count(lvalue_ty).max(1);
+                        let offset = self.ctx.local_offset(*slot + count - 1);
                         let result_vreg = self.mir.alloc_vreg();
                         // ADD to compute address: result = fp + offset
                         // Since offset is negative (locals below FP), we use AddImm
@@ -2448,7 +2433,10 @@ impl<'a> CfgLower<'a> {
                             let ptr_vreg = self.ensure_inout_param_ptr(index);
                             self.value_map.insert(value, ptr_vreg);
                         } else {
-                            let slot = self.ctx.num_locals + index;
+                            // Whole by-value param: its low end is the highest
+                            // slot of its frame region (ADR-0040 / RUE-311).
+                            let count = self.ctx.type_slot_count(lvalue_ty).max(1);
+                            let slot = self.ctx.num_locals + index + count - 1;
                             let offset = self.ctx.local_offset(slot);
                             let result_vreg = self.mir.alloc_vreg();
                             self.mir.push(Aarch64Inst::AddImm {
@@ -2484,7 +2472,11 @@ impl<'a> CfgLower<'a> {
             } => {
                 let val_vreg = self.get_vreg(*val);
                 let field_slot_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
-                let actual_slot = slot + field_slot_offset;
+                // Ascending layout (ADR-0040 / RUE-311): the field's slot sits
+                // at the struct's low end (`slot + count - 1`) plus the field's
+                // byte offset — i.e. minus the offset in slot number.
+                let struct_count = self.ctx.struct_total_slot_count(*struct_id);
+                let actual_slot = slot + (struct_count - 1) - field_slot_offset;
                 let offset = self.ctx.local_offset(actual_slot);
                 self.mir.push(Aarch64Inst::Str {
                     src: Operand::Virtual(val_vreg),
@@ -2506,14 +2498,14 @@ impl<'a> CfgLower<'a> {
 
                 // Check if this is an inout parameter
                 if self.ctx.cfg.is_param_inout(*param_slot) {
-                    // For inout params, store through the pointer
-                    // Use ensure_inout_param_ptr in case the param was never accessed via Param instruction
+                    // For inout params, store through the pointer. The pointer is
+                    // the caller place's low end, so the field's ascending byte
+                    // offset is added (ADR-0040 / RUE-311).
                     let ptr_vreg = self.ensure_inout_param_ptr(*param_slot);
-                    // Negative offset because stack grows down
                     self.mir.push(Aarch64Inst::StrIndexedOffset {
                         src: Operand::Virtual(val_vreg),
                         base: ptr_vreg,
-                        offset: -((total_offset as i32) * 8),
+                        offset: (total_offset as i32) * 8,
                     });
                 } else {
                     // Non-inout param: struct is on our stack
@@ -2761,17 +2753,43 @@ impl<'a> CfgLower<'a> {
                         .get_or_compute_field_vregs(*dropped_value)
                         .unwrap_or_else(|| self.collect_struct_scalar_vregs(*dropped_value));
 
-                    // For user-defined destructor, we need to call it first with all fields
+                    // For user-defined destructor, we need to call it first with all fields.
                     if let Some(ref destructor_name) = struct_def.destructor {
-                        // Pass all fields to the user destructor
-                        self.emit_call_with_slot_args(&field_vregs, destructor_name);
+                        if struct_def.is_builtin {
+                            // Builtin destructor is a runtime `__rue_*` fn: pass
+                            // the fat pointer slots in natural order.
+                            self.emit_call_with_slot_args(&field_vregs, destructor_name);
+                        } else {
+                            // A user destructor takes `self` as ONE by-value
+                            // struct parameter, so its slots go in the reversed
+                            // by-value aggregate ABI order (ADR-0040 / RUE-311),
+                            // matching the general `Call` lowering.
+                            let mut self_vregs = field_vregs.clone();
+                            self_vregs.reverse();
+                            self.emit_call_with_slot_args(&self_vregs, destructor_name);
+                        }
                     }
 
                     // Now call the drop glue function to drop fields, passing
                     // all fields again (the destructor call clobbered the
-                    // argument registers)
+                    // argument registers). Drop glue receives the flattened
+                    // fields as individual parameters in declaration order, but
+                    // reconstructs any multi-slot field (nested struct/array) via
+                    // one aggregate `Param` read, which uses the reversed
+                    // by-value ABI (ADR-0040 / RUE-311) — so reverse each such
+                    // field's own slots within their sub-range; scalars are
+                    // unaffected.
+                    let mut glue_vregs = field_vregs.clone();
+                    let mut off = 0usize;
+                    for field in &struct_def.fields {
+                        let fc = self.ctx.type_slot_count(field.ty) as usize;
+                        if fc > 1 && off + fc <= glue_vregs.len() {
+                            glue_vregs[off..off + fc].reverse();
+                        }
+                        off += fc;
+                    }
                     let drop_fn_name = format!("__rue_drop_{}", struct_def.name);
-                    self.emit_call_with_slot_args(&field_vregs, &drop_fn_name);
+                    self.emit_call_with_slot_args(&glue_vregs, &drop_fn_name);
                     return;
                 }
 
@@ -2781,9 +2799,21 @@ impl<'a> CfgLower<'a> {
                     // slot counts past the argument registers go on the stack
                     // via emit_call_with_slot_args — e.g. [String; 3] is 9
                     // slots, RUE-193)
-                    let element_vregs = self
+                    let mut element_vregs = self
                         .get_or_compute_field_vregs(*dropped_value)
                         .unwrap_or_else(|| self.collect_array_scalar_vregs(*dropped_value));
+
+                    // The array drop glue reconstructs each multi-slot element
+                    // via one aggregate `Param` read, which uses the reversed
+                    // by-value ABI (ADR-0040 / RUE-311). Reverse each element's
+                    // own slots within its sub-range so that read recovers
+                    // logical order; single-slot elements are unaffected.
+                    let elem_slots = self.ctx.array_element_slot_count(dropped_ty) as usize;
+                    if elem_slots > 1 {
+                        for chunk in element_vregs.chunks_mut(elem_slots) {
+                            chunk.reverse();
+                        }
+                    }
 
                     let drop_fn_name = types::array_drop_glue_name(array_id, self.ctx.type_pool);
                     self.emit_call_with_slot_args(&element_vregs, &drop_fn_name);
@@ -4133,11 +4163,10 @@ impl<'a> CfgLower<'a> {
                     self.emit_bounds_check(index_vreg, array_length);
 
                     let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
-                    // Ascending array layout (ADR-0040 / RUE-243): shift the
-                    // origin to the array's lowest-address element so the ADDed
-                    // scaled index below resolves element i to base + i*size.
-                    let array_len = self.ctx.array_length(*array_type);
-                    static_slot_offset += (array_len.max(1) - 1) as u32 * elem_slot_count;
+                    // Ascending layout (ADR-0040 / RUE-311): the element's byte
+                    // offset from the low-end origin is `index*size`, added
+                    // below; the single root-object origin shift covers the
+                    // array's own origin (no per-array `(N-1)` shift).
                     index_levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
@@ -4146,6 +4175,9 @@ impl<'a> CfgLower<'a> {
                 }
             }
         }
+
+        // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311).
+        let root_count = crate::agg_slots::root_slot_count(self, projections, 1);
 
         // Calculate dynamic offset from index projections
         let dynamic_offset_vreg = if !index_levels.is_empty() {
@@ -4157,7 +4189,7 @@ impl<'a> CfgLower<'a> {
         // Compute final address based on base type
         match place.base {
             PlaceBase::Local(slot) => {
-                let base_slot = slot + static_slot_offset;
+                let base_slot = slot + (root_count - 1) - static_slot_offset;
                 let base_offset = self.ctx.local_offset(base_slot);
 
                 if let Some(dyn_offset) = dynamic_offset_vreg {
@@ -4190,19 +4222,21 @@ impl<'a> CfgLower<'a> {
             }
             PlaceBase::Param(param_slot) => {
                 if self.ctx.cfg.is_param_inout(param_slot) {
-                    // Inout param - use pointer
+                    // Inout param - use pointer. Received pointer is the caller
+                    // place's low end; field offset and scaled index both ADD
+                    // (ascending, ADR-0040 / RUE-311).
                     let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
                     let static_byte_offset = (static_slot_offset as i32) * 8;
 
                     if let Some(dyn_offset) = dynamic_offset_vreg {
-                        // Compute address: ptr - static_offset + dynamic_offset (ascending, ADR-0040)
+                        // Compute address: ptr + static_offset + dynamic_offset (ascending)
                         let addr_vreg = self.mir.alloc_vreg();
                         self.mir.push(Aarch64Inst::MovRR {
                             dst: Operand::Virtual(addr_vreg),
                             src: Operand::Virtual(ptr_vreg),
                         });
                         if static_byte_offset != 0 {
-                            self.mir.push(Aarch64Inst::SubImm {
+                            self.mir.push(Aarch64Inst::AddImm {
                                 dst: Operand::Virtual(addr_vreg),
                                 src: Operand::Virtual(addr_vreg),
                                 imm: static_byte_offset,
@@ -4218,16 +4252,17 @@ impl<'a> CfgLower<'a> {
                             base: addr_vreg,
                         });
                     } else {
-                        // Static offset only
+                        // Static offset only (ascending: field at ptr + off)
                         self.mir.push(Aarch64Inst::LdrIndexedOffset {
                             dst: Operand::Virtual(dst),
                             base: ptr_vreg,
-                            offset: -static_byte_offset,
+                            offset: static_byte_offset,
                         });
                     }
                 } else {
                     // Normal param - treat like local
-                    let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
+                    let base_slot =
+                        self.ctx.num_locals + param_slot + (root_count - 1) - static_slot_offset;
                     let base_offset = self.ctx.local_offset(base_slot);
 
                     if let Some(dyn_offset) = dynamic_offset_vreg {
@@ -4322,11 +4357,10 @@ impl<'a> CfgLower<'a> {
                     self.emit_bounds_check(index_vreg, array_length);
 
                     let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
-                    // Ascending array layout (ADR-0040 / RUE-243): shift the
-                    // origin to the array's lowest-address element so the ADDed
-                    // scaled index below resolves element i to base + i*size.
-                    let array_len = self.ctx.array_length(*array_type);
-                    static_slot_offset += (array_len.max(1) - 1) as u32 * elem_slot_count;
+                    // Ascending layout (ADR-0040 / RUE-311): the element's byte
+                    // offset from the low-end origin is `index*size`, added
+                    // below; the single root-object origin shift covers the
+                    // array's own origin (no per-array `(N-1)` shift).
                     index_levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
@@ -4335,6 +4369,9 @@ impl<'a> CfgLower<'a> {
                 }
             }
         }
+
+        // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311).
+        let root_count = crate::agg_slots::root_slot_count(self, projections, vals.len() as u32);
 
         // Calculate dynamic offset from index projections
         let dynamic_offset_vreg = if !index_levels.is_empty() {
@@ -4346,8 +4383,8 @@ impl<'a> CfgLower<'a> {
         // Compute final address based on base type
         match place.base {
             PlaceBase::Local(slot) => {
-                let base_slot = slot + static_slot_offset;
-                let base_offset = self.ctx.local_offset(base_slot);
+                let base_low_slot = slot + (root_count - 1) - static_slot_offset;
+                let base_offset = self.ctx.local_offset(base_low_slot);
 
                 if let Some(dyn_offset) = dynamic_offset_vreg {
                     let addr_vreg = self.mir.alloc_vreg();
@@ -4365,11 +4402,13 @@ impl<'a> CfgLower<'a> {
                     });
                     crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
                 } else {
-                    crate::agg_slots::store_slots(self, vals, base_slot);
+                    crate::agg_slots::store_slots_at_low(self, vals, base_low_slot);
                 }
             }
             PlaceBase::Param(param_slot) => {
                 if self.ctx.cfg.is_param_inout(param_slot) {
+                    // Received pointer is the caller place's low end; field
+                    // offsets and the scaled index both ADD (ascending).
                     let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
                     let static_byte_offset = (static_slot_offset as i32) * 8;
 
@@ -4380,7 +4419,7 @@ impl<'a> CfgLower<'a> {
                             src: Operand::Virtual(ptr_vreg),
                         });
                         if static_byte_offset != 0 {
-                            self.mir.push(Aarch64Inst::SubImm {
+                            self.mir.push(Aarch64Inst::AddImm {
                                 dst: Operand::Virtual(addr_vreg),
                                 src: Operand::Virtual(addr_vreg),
                                 imm: static_byte_offset,
@@ -4401,8 +4440,9 @@ impl<'a> CfgLower<'a> {
                         );
                     }
                 } else {
-                    let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
-                    let base_offset = self.ctx.local_offset(base_slot);
+                    let base_low_slot =
+                        self.ctx.num_locals + param_slot + (root_count - 1) - static_slot_offset;
+                    let base_offset = self.ctx.local_offset(base_low_slot);
 
                     if let Some(dyn_offset) = dynamic_offset_vreg {
                         let addr_vreg = self.mir.alloc_vreg();
@@ -4418,7 +4458,7 @@ impl<'a> CfgLower<'a> {
                         });
                         crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
                     } else {
-                        crate::agg_slots::store_slots(self, vals, base_slot);
+                        crate::agg_slots::store_slots_at_low(self, vals, base_low_slot);
                     }
                 }
             }
@@ -4504,11 +4544,10 @@ impl<'a> CfgLower<'a> {
                 }
                 Projection::Index { array_type, index } => {
                     let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
-                    // Ascending array layout (ADR-0040 / RUE-243): shift the
-                    // origin to the array's lowest-address element so the ADDed
-                    // scaled index below resolves element i to base + i*size.
-                    let array_len = self.ctx.array_length(*array_type);
-                    static_slot_offset += (array_len.max(1) - 1) as u32 * elem_slot_count;
+                    // Ascending layout (ADR-0040 / RUE-311): the element's byte
+                    // offset from the low-end origin is `index*size`, added
+                    // below; the single root-object origin shift covers the
+                    // array's own origin (no per-array `(N-1)` shift).
                     index_levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
@@ -4517,6 +4556,11 @@ impl<'a> CfgLower<'a> {
                 }
             }
         }
+
+        // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311); the
+        // resulting address is the accessed place's LOW end, from which slots
+        // ascend. With no projections the place is a scalar (root_count 1).
+        let root_count = crate::agg_slots::root_slot_count(self, projections, 1);
 
         // Calculate dynamic offset from index projections
         let dynamic_offset_vreg = if !index_levels.is_empty() {
@@ -4528,8 +4572,8 @@ impl<'a> CfgLower<'a> {
         // Compute address based on base type
         match place.base {
             PlaceBase::Local(slot) => {
-                let base_slot = slot + static_slot_offset;
-                let base_offset = self.ctx.local_offset(base_slot);
+                let base_low_slot = slot + (root_count - 1) - static_slot_offset;
+                let base_offset = self.ctx.local_offset(base_low_slot);
 
                 // Start with fp + base_offset
                 self.mir.push(Aarch64Inst::AddImm {
@@ -4538,7 +4582,7 @@ impl<'a> CfgLower<'a> {
                     imm: base_offset,
                 });
 
-                // Subtract dynamic offset if any
+                // Add dynamic offset if any (ascending)
                 if let Some(dyn_offset) = dynamic_offset_vreg {
                     self.mir.push(Aarch64Inst::AddRR {
                         dst: Operand::Virtual(dst),
@@ -4549,6 +4593,8 @@ impl<'a> CfgLower<'a> {
             }
             PlaceBase::Param(param_slot) => {
                 if self.ctx.cfg.is_param_inout(param_slot) {
+                    // Received pointer is the caller place's low end; field
+                    // offset and scaled index both ADD (ascending).
                     let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
                     let static_byte_offset = (static_slot_offset as i32) * 8;
 
@@ -4558,16 +4604,16 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Virtual(ptr_vreg),
                     });
 
-                    // Subtract static offset
+                    // Add static offset
                     if static_byte_offset != 0 {
-                        self.mir.push(Aarch64Inst::SubImm {
+                        self.mir.push(Aarch64Inst::AddImm {
                             dst: Operand::Virtual(dst),
                             src: Operand::Virtual(dst),
                             imm: static_byte_offset,
                         });
                     }
 
-                    // Subtract dynamic offset
+                    // Add dynamic offset
                     if let Some(dyn_offset) = dynamic_offset_vreg {
                         self.mir.push(Aarch64Inst::AddRR {
                             dst: Operand::Virtual(dst),
@@ -4576,8 +4622,9 @@ impl<'a> CfgLower<'a> {
                         });
                     }
                 } else {
-                    let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
-                    let base_offset = self.ctx.local_offset(base_slot);
+                    let base_low_slot =
+                        self.ctx.num_locals + param_slot + (root_count - 1) - static_slot_offset;
+                    let base_offset = self.ctx.local_offset(base_low_slot);
 
                     self.mir.push(Aarch64Inst::AddImm {
                         dst: Operand::Virtual(dst),

--- a/crates/rue-codegen/src/agg_slots.rs
+++ b/crates/rue-codegen/src/agg_slots.rs
@@ -84,11 +84,11 @@ pub trait SlotBackend {
     /// Emit a bounds check trapping when `index_vreg >= length`.
     fn emit_bounds_check(&mut self, index_vreg: VReg, length: u64);
 
-    /// Emit `dst = address of the (possibly projected) place` — the backend's
-    /// `lower_place_addr` (frame base + static field-slot offsets, minus
-    /// dynamic index offsets; through a by-ref pointer per the descending ABI
-    /// convention). Does NOT bounds-check index projections; callers do that
-    /// first.
+    /// Emit `dst = low-end address of the (possibly projected) place` — the
+    /// backend's `lower_place_addr`. The result is the place's lowest-address
+    /// byte; aggregate slots ascend from it (`slot k` at `dst + k*8`), uniform
+    /// for frame- and heap-rooted places (ADR-0040 / RUE-311). Does NOT
+    /// bounds-check index projections; callers do that first.
     fn emit_place_addr(&mut self, dst: VReg, place: &Place);
 }
 
@@ -169,8 +169,13 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
             let slot_count = b.ctx().type_slot_count(ty);
 
             if !has_index && !is_by_ref_base {
-                // Purely static projection chain rooted at a frame slot:
-                // load the field's consecutive slots directly.
+                // Purely static projection chain rooted at a frame slot.
+                // Ascending layout (ADR-0040 / RUE-311): the accessed field's
+                // low end (its logical slot 0) sits at the ROOT object's low
+                // end plus the summed field byte offset. In frame-slot terms
+                // the root's low end is `root_base + (C_root - 1)` (its
+                // highest-numbered = lowest-address slot), and adding the field
+                // offset in ADDRESS space means SUBTRACTING it in slot number.
                 let mut static_slot_offset: u32 = 0;
                 for proj in &projections {
                     match proj {
@@ -184,23 +189,23 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
                         Projection::Index { .. } => unreachable!("has_index is false"),
                     }
                 }
-                let base_slot = match place.base {
-                    PlaceBase::Local(slot) => slot + static_slot_offset,
-                    PlaceBase::Param(param_slot) => {
-                        b.ctx().num_locals + param_slot + static_slot_offset
-                    }
+                let root_base = match place.base {
+                    PlaceBase::Local(slot) => slot,
+                    PlaceBase::Param(param_slot) => b.ctx().num_locals + param_slot,
                 };
-                return Some(load_consecutive(b, base_slot, slot_count));
+                let root_count = root_slot_count(b, &projections, slot_count);
+                let field_low_slot = root_base + (root_count - 1) - static_slot_offset;
+                return Some(load_slots_at_low(b, field_low_slot, slot_count));
             }
 
             // Indexed element (`arr[i]`, `s.rows[i]` — constant or dynamic
             // index) or a projection through a by-ref param: bounds-check
-            // every index projection, form the place's address, then load
-            // each slot through it. Slot i lives at addr - i*8 (frame slots
-            // descend; the stack grows down), matching
-            // `store_slots_through_ptr`. Previously these sources returned
-            // None and every consumer's fallback materialized only slot 0 —
-            // the RUE-188 miscompile family. (RUE-188/192)
+            // every index projection, form the place's low-end address, then
+            // load each slot through it. Slot k lives at addr + k*8 (ascending,
+            // ADR-0040 / RUE-311), matching `store_slots_through_ptr`.
+            // Previously these sources returned None and every consumer's
+            // fallback materialized only slot 0 — the RUE-188 miscompile
+            // family. (RUE-188/192)
             for proj in &projections {
                 if let Projection::Index { array_type, index } = proj {
                     let length = b.ctx().array_length(*array_type);
@@ -214,6 +219,22 @@ pub fn get_or_compute_field_vregs<B: SlotBackend>(b: &mut B, value: CfgValue) ->
         }
         // BlockParam and Call should already have slot vregs in the cache
         _ => None,
+    }
+}
+
+/// Total slot count of the ROOT object a projected place is rooted at — the
+/// container the first projection indexes into. Ascending place addressing
+/// (ADR-0040 / RUE-311) anchors every field/element at the root object's low
+/// end (`root_base + root_count - 1` in frame slots), so the root's own slot
+/// count is the one origin shift a projection chain needs; nested containers
+/// contribute only their byte offsets from that anchor. With no projections the
+/// place *is* the root, so `fallback` (the accessed value's own slot count) is
+/// used.
+pub fn root_slot_count<B: SlotBackend>(b: &B, projections: &[Projection], fallback: u32) -> u32 {
+    match projections.first() {
+        Some(Projection::Field { struct_id, .. }) => b.ctx().struct_total_slot_count(*struct_id),
+        Some(Projection::Index { array_type, .. }) => b.ctx().type_slot_count(*array_type),
+        None => fallback,
     }
 }
 
@@ -361,19 +382,18 @@ pub fn lower_array_init<B: SlotBackend>(
     let vreg = b.alloc_vreg();
     b.map_value(value, vreg);
 
-    // Array elements are laid out ASCENDING in memory: element 0 at the
-    // array's lowest address, element i at base + i*element_size (ADR-0040 /
-    // RUE-243). Frame slots descend in address (slot k lives at a lower
-    // address than slot k-1), so we store the elements in REVERSE order —
-    // element N-1 into the first (highest-address) slot, element 0 into the
-    // last (lowest-address) slot. Array-index address computation applies the
-    // matching `+(N-1)*elem_slot_count` origin shift and adds the scaled
-    // index, so indexing and @ptr_offset agree. Each element's own slots stay
-    // in natural order (struct fields remain descending; nested arrays are
-    // reversed by their own recursion). (ADR-0040)
+    // The slot cache holds the aggregate's logical slots in ascending order —
+    // element 0 first, then element 1, and so on, each element's own slots in
+    // logical order (RUE-311). Physical ascending layout (element 0 at the
+    // array's lowest address, element i at base + i*element_size — ADR-0040 /
+    // RUE-243) is produced when this list is *stored*: `store_slots` reverses
+    // it into the frame (logical slot 0 at the highest-numbered = lowest-
+    // address slot), and `store_slots_through_ptr` writes it ascending from a
+    // low-end pointer. So every consumer — frame store, `@ptr_write`, the call
+    // ABI, structural equality — sees one uniform slot order.
     let elements = b.ctx().cfg.get_extra(elements_start, elements_len).to_vec();
     let mut element_vregs: Vec<VReg> = Vec::new();
-    for e in elements.iter().rev() {
+    for e in elements.iter() {
         let e_ty = b.ctx().cfg.get_inst(*e).ty;
         // Payload enums are multi-slot aggregates too: a discriminant-only
         // enum (accessor returns None) stays a single-vreg scalar, but a
@@ -397,17 +417,33 @@ pub fn lower_array_init<B: SlotBackend>(
     b.emit_load_zero(vreg);
 }
 
-/// Store `vals` to consecutive frame slots starting at `base_slot`
-/// (slot `base_slot + i` gets `vals[i]`).
+/// Store a whole aggregate value's `vals` (one vreg per logical slot, slot 0
+/// first) to the frame region beginning at `base_slot`, laid out
+/// ASCENDING-in-address (ADR-0040): logical slot 0 at the region's LOWEST
+/// address, slot `k` at `base_low_addr + k*8`. Frame slots descend in address
+/// (a higher slot number is a lower address), so logical slot `k` is stored at
+/// frame slot `base_slot + (len-1) - k` — the region's low end is its
+/// highest-numbered slot.
 pub fn store_slots<B: SlotBackend>(b: &mut B, vals: &[VReg], base_slot: u32) {
-    for (i, val) in vals.iter().enumerate() {
-        b.emit_store_slot(*val, base_slot + i as u32);
+    let low_slot = base_slot + (vals.len() as u32).saturating_sub(1);
+    store_slots_at_low(b, vals, low_slot);
+}
+
+/// Store `vals` (logical slot 0 first) into the frame with the value's
+/// low-end (slot-0) at frame slot `low_slot`; logical slot `k` lands at frame
+/// slot `low_slot - k` (each higher slot at a higher address — ascending,
+/// ADR-0040).
+pub fn store_slots_at_low<B: SlotBackend>(b: &mut B, vals: &[VReg], low_slot: u32) {
+    for (k, val) in vals.iter().enumerate() {
+        b.emit_store_slot(*val, low_slot - k as u32);
     }
 }
 
-/// Store `vals` through `ptr` at descending byte offsets: `vals[i]` goes to
-/// `ptr - static_byte_offset - i*8`. Caller-frame slots descend from an inout
-/// pointer (the stack grows down), matching the place-read path.
+/// Store `vals` (logical slot 0 first) through `ptr` at ASCENDING byte
+/// offsets: `vals[k]` goes to `ptr + static_byte_offset + k*8`. `ptr` is the
+/// pointee's low-end address (what `@raw` and `@ptr_offset` yield, and where
+/// `@alloc` blocks begin), so aggregate slots ascend uniformly for pointers of
+/// every origin — stack, heap, or `@int_to_ptr` (ADR-0040 / RUE-311).
 pub fn store_slots_through_ptr<B: SlotBackend>(
     b: &mut B,
     vals: &[VReg],
@@ -415,15 +451,15 @@ pub fn store_slots_through_ptr<B: SlotBackend>(
     static_byte_offset: i32,
 ) {
     for (i, val) in vals.iter().enumerate() {
-        b.emit_store_through_ptr(*val, ptr, -static_byte_offset - (i as i32) * 8);
+        b.emit_store_through_ptr(*val, ptr, static_byte_offset + (i as i32) * 8);
     }
 }
 
 /// Callee side of the sret return convention (RUE-106): load the sret buffer
 /// pointer the prologue saved at the frame slot one past the param area, then
 /// store every slot of the return value through it at ascending byte offsets
-/// (`vals[i]` to `ptr + i*8` — the buffer is caller-allocated and addressed
-/// upward, unlike the descending inout frame-slot writes).
+/// (`vals[i]` to `ptr + i*8`) — the same low-end-ascending convention every
+/// aggregate memory access now uses (ADR-0040 / RUE-311).
 ///
 /// See `crate::cfg_lower::type_uses_sret_return` for when returns use sret.
 pub fn store_slots_to_sret<B: SlotBackend>(b: &mut B, vals: &[VReg]) {
@@ -435,37 +471,47 @@ pub fn store_slots_to_sret<B: SlotBackend>(b: &mut B, vals: &[VReg]) {
     }
 }
 
-/// Load `count` slots through `ptr` at descending byte offsets (slot i at
-/// `ptr - i*8`), returning the freshly-allocated vregs in slot order. The
-/// public counterpart of [`store_slots_through_ptr`]: used by `@ptr_read` to
-/// read an aggregate pointee through a raw pointer, one 8-byte slot per field
-/// (RUE-242). Every value of an aggregate type occupies `type_slot_count`
-/// consecutive descending slots, matching how `@raw` addresses the place.
+/// Load `count` slots through `ptr` at ASCENDING byte offsets (slot k at
+/// `ptr + k*8`), returning the freshly-allocated vregs in logical slot order.
+/// The public counterpart of [`store_slots_through_ptr`]: used by `@ptr_read`
+/// to read an aggregate pointee through a raw pointer, one 8-byte slot per
+/// field (RUE-242). `ptr` is the pointee's low-end address; every value of an
+/// aggregate type occupies `type_slot_count` consecutive ascending slots
+/// (ADR-0040 / RUE-311).
 pub fn load_slots_through_ptr<B: SlotBackend>(b: &mut B, ptr: VReg, count: u32) -> Vec<VReg> {
     load_through_ptr(b, ptr, count)
 }
 
-/// Load `count` consecutive frame slots starting at `base_slot`, returning the
-/// freshly-allocated vregs in slot order.
+/// Load a whole aggregate value's `count` logical slots from the frame region
+/// beginning at `base_slot` (ascending layout, ADR-0040): logical slot 0 is at
+/// the region's low end (frame slot `base_slot + count - 1`), slot `k` at
+/// `base_slot + count - 1 - k`. Returns the vregs in logical slot order.
 fn load_consecutive<B: SlotBackend>(b: &mut B, base_slot: u32, count: u32) -> Vec<VReg> {
+    load_slots_at_low(b, base_slot + count.saturating_sub(1), count)
+}
+
+/// Load `count` logical slots (slot 0 first) from the frame with the value's
+/// low-end (slot 0) at frame slot `low_slot`; logical slot `k` is read from
+/// frame slot `low_slot - k` (ascending, ADR-0040).
+pub fn load_slots_at_low<B: SlotBackend>(b: &mut B, low_slot: u32, count: u32) -> Vec<VReg> {
     let mut vregs = Vec::with_capacity(count as usize);
-    for i in 0..count {
+    for k in 0..count {
         let vreg = b.alloc_vreg();
-        b.emit_load_slot(vreg, base_slot + i);
+        b.emit_load_slot(vreg, low_slot - k);
         vregs.push(vreg);
     }
     vregs
 }
 
-/// Load `count` slots through `addr_vreg` at descending byte offsets (slot i
-/// at `addr - i*8` — frame slots descend; the stack grows down, matching
-/// [`store_slots_through_ptr`]), returning the freshly-allocated vregs in
-/// slot order.
+/// Load `count` slots through `addr_vreg` at ASCENDING byte offsets (slot k at
+/// `addr + k*8`, matching [`store_slots_through_ptr`]), returning the
+/// freshly-allocated vregs in logical slot order. `addr_vreg` is the pointee's
+/// low-end address (ADR-0040 / RUE-311).
 fn load_through_ptr<B: SlotBackend>(b: &mut B, addr_vreg: VReg, count: u32) -> Vec<VReg> {
     let mut vregs = Vec::with_capacity(count as usize);
-    for i in 0..count {
+    for k in 0..count {
         let vreg = b.alloc_vreg();
-        b.emit_load_through_ptr(vreg, addr_vreg, -(i as i32) * 8);
+        b.emit_load_through_ptr(vreg, addr_vreg, (k as i32) * 8);
         vregs.push(vreg);
     }
     vregs

--- a/crates/rue-codegen/src/byref_args.rs
+++ b/crates/rue-codegen/src/byref_args.rs
@@ -16,9 +16,9 @@
 //! projected-place address formation that now live on [`SlotBackend`]
 //! (the indexed-place-read materialization in `agg_slots` needs them too,
 //! RUE-188). `emit_place_addr` is the same math the backend's
-//! `PlaceRead`/`PlaceWrite` lowering uses: frame base + static field-slot
-//! offsets, minus dynamic index offsets; through a by-ref pointer the
-//! offsets descend per the ABI convention — caller slots grow downward.
+//! `PlaceRead`/`PlaceWrite` lowering uses: it yields the place's LOW-end
+//! address, from which aggregate slots ascend (`slot k` at `+k*8`), uniform
+//! for frame- and heap-rooted places (ADR-0040 / RUE-311).
 
 use rue_cfg::{CfgInstData, CfgValue, Place, Projection};
 use rue_error::{CompileError, ErrorKind};
@@ -71,6 +71,11 @@ pub fn lower_byref_arg_addr<B: ByrefAddrBackend + ?Sized>(
     // The argument span, captured (Copy) before the match so the borrow of the
     // CFG ends and a diagnostic can carry a source location.
     let arg_span = b.ctx().cfg.get_inst(arg_value).span;
+    // Slot count of the addressed value: a by-ref pointer must point at the
+    // place's LOW end (ADR-0040 / RUE-311), which for a frame-resident
+    // aggregate is its highest-numbered slot `base + count - 1`.
+    let arg_ty = b.ctx().cfg.get_inst(arg_value).ty;
+    let low_shift = b.ctx().type_slot_count(arg_ty).saturating_sub(1);
     let shape = match &b.ctx().cfg.get_inst(arg_value).data {
         CfgInstData::Load { slot } => ArgShape::Local(*slot),
         CfgInstData::Param { index } => ArgShape::Param(*index),
@@ -92,7 +97,7 @@ pub fn lower_byref_arg_addr<B: ByrefAddrBackend + ?Sized>(
         }
         ArgShape::Local(slot) => {
             let addr_vreg = b.alloc_vreg();
-            b.emit_frame_addr(addr_vreg, slot);
+            b.emit_frame_addr(addr_vreg, slot + low_shift);
             addr_vreg
         }
         ArgShape::Param(index) => {
@@ -106,7 +111,7 @@ pub fn lower_byref_arg_addr<B: ByrefAddrBackend + ?Sized>(
             } else {
                 // Normal param: it lives in a frame slot after the locals.
                 let slot = b.ctx().num_locals + index;
-                b.emit_frame_addr(addr_vreg, slot);
+                b.emit_frame_addr(addr_vreg, slot + low_shift);
             }
             addr_vreg
         }

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -464,6 +464,13 @@ impl<'a> CfgLowerContext<'a> {
         types::struct_field_slot_offset(self.type_pool, struct_id, field_index)
     }
 
+    /// Total slot count of a struct (sum of its fields' slot counts). Used as
+    /// the root-object origin shift for ascending place addressing
+    /// (ADR-0040 / RUE-311).
+    pub fn struct_total_slot_count(&self, struct_id: StructId) -> u32 {
+        types::struct_slot_count(self.type_pool, struct_id)
+    }
+
     // ========================================================================
     // Builtin type helpers
     // ========================================================================

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -228,6 +228,19 @@ pub fn type_size_bytes(type_pool: &TypeInternPool, ty: Type) -> u64 {
     (slots as u64) * 8
 }
 
+/// Total slot count of a struct: the sum of every field's slot count. Equal to
+/// `type_slot_count(Struct(struct_id))`, but reachable directly from a
+/// `StructId` (used to anchor ascending place addressing at a struct root —
+/// ADR-0040 / RUE-311).
+pub fn struct_slot_count(type_pool: &TypeInternPool, struct_id: StructId) -> u32 {
+    let struct_def = type_pool.struct_def(struct_id);
+    let mut total = 0u32;
+    for field in &struct_def.fields {
+        total += type_slot_count(type_pool, field.ty);
+    }
+    total
+}
+
 /// Calculate the slot offset for a field within a struct.
 ///
 /// This accounts for the sizes of all preceding fields.
@@ -272,12 +285,11 @@ pub fn collect_array_scalar_vregs(
         } => {
             let elements = cfg.get_extra(*elements_start, *elements_len);
             let mut result = Vec::new();
-            // Store elements in REVERSE order so element 0 lands at the array's
-            // lowest address (frame slots descend in address): ascending array
-            // layout per ADR-0040 / RUE-243. Mirror of `lower_array_init`. Each
-            // element's own slots stay in natural order (nested arrays reverse
-            // via this same recursion; structs keep descending fields).
-            for elem in elements.iter().rev() {
+            // Collect elements in logical order (element 0 first), matching
+            // `lower_array_init`: the slot cache is uniform ascending order and
+            // the ascending physical layout is produced at store time (ADR-0040
+            // / RUE-311).
+            for elem in elements.iter() {
                 let elem_inst = cfg.get_inst(*elem);
                 if elem_inst.ty.is_array() {
                     // Recursively collect from nested array

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -934,11 +934,17 @@ impl<'a> CfgLower<'a> {
 
                     self.value_map.insert(value, val_vreg);
                 } else {
-                    // Normal parameter: load the value directly from the slot
+                    // Normal parameter: the primary vreg is the value's LOGICAL
+                    // slot 0 (e.g. an enum's discriminant). Ascending layout
+                    // (ADR-0040 / RUE-311): logical slot 0 of a multi-slot param
+                    // is at its region's low end, frame slot `base + count - 1`;
+                    // a scalar (count 1) is at `base` unchanged.
                     let vreg = self.mir.alloc_vreg();
                     self.value_map.insert(value, vreg);
 
-                    let slot = self.ctx.num_locals + *index;
+                    let param_ty = self.ctx.cfg.get_inst(value).ty;
+                    let count = self.ctx.type_slot_count(param_ty).max(1);
+                    let slot = self.ctx.num_locals + *index + count - 1;
                     let offset = self.ctx.local_offset(slot);
                     self.mir.push(X86Inst::MovRM {
                         dst: Operand::Virtual(vreg),
@@ -1735,55 +1741,24 @@ impl<'a> CfgLower<'a> {
                 let load_type = self.ctx.cfg.get_inst(value).ty;
 
                 if self.ctx.is_builtin_string(load_type) {
-                    // Builtin String: load ptr, len, and cap from consecutive slots
-                    // Check this before generic Struct case so builtin String uses this path
-                    let ptr_vreg = self.mir.alloc_vreg();
-                    let len_vreg = self.mir.alloc_vreg();
-                    let cap_vreg = self.mir.alloc_vreg();
-
-                    // Load ptr from slot
-                    let ptr_offset = self.ctx.local_offset(*slot);
-                    self.mir.push(X86Inst::MovRM {
-                        dst: Operand::Virtual(ptr_vreg),
-                        base: Reg::Rbp,
-                        offset: ptr_offset,
-                    });
-
-                    // Load len from slot + 1
-                    let len_offset = self.ctx.local_offset(slot + 1);
-                    self.mir.push(X86Inst::MovRM {
-                        dst: Operand::Virtual(len_vreg),
-                        base: Reg::Rbp,
-                        offset: len_offset,
-                    });
-
-                    // Load cap from slot + 2
-                    let cap_offset = self.ctx.local_offset(slot + 2);
-                    self.mir.push(X86Inst::MovRM {
-                        dst: Operand::Virtual(cap_vreg),
-                        base: Reg::Rbp,
-                        offset: cap_offset,
-                    });
-
+                    // Builtin String fat pointer (ptr, len, cap). Ascending
+                    // layout (ADR-0040 / RUE-311): logical slot 0 (ptr) is at
+                    // the region's low end (highest-numbered slot `slot + 2`),
+                    // slot k at `slot + 2 - k`.
+                    let slot_vregs = crate::agg_slots::load_slots_at_low(self, slot + 2, 3);
+                    let ptr_vreg = slot_vregs[0];
                     // Register String fields (ptr, len, cap)
-                    self.struct_slot_vregs
-                        .insert(value, vec![ptr_vreg, len_vreg, cap_vreg]);
+                    self.struct_slot_vregs.insert(value, slot_vregs);
                     self.value_map.insert(value, ptr_vreg);
                 } else if let TypeKind::Array(_) = load_type.kind() {
-                    // Array: load all element slots (recursively flattened)
+                    // Array: load every logical slot (ascending, ADR-0040 /
+                    // RUE-311): slot 0 at the region's low end.
                     let slot_count = self.ctx.type_slot_count(load_type);
-                    let mut slot_vregs = Vec::with_capacity(slot_count as usize);
-
-                    for i in 0..slot_count {
-                        let elem_vreg = self.mir.alloc_vreg();
-                        let elem_offset = self.ctx.local_offset(slot + i);
-                        self.mir.push(X86Inst::MovRM {
-                            dst: Operand::Virtual(elem_vreg),
-                            base: Reg::Rbp,
-                            offset: elem_offset,
-                        });
-                        slot_vregs.push(elem_vreg);
-                    }
+                    let slot_vregs = if slot_count > 0 {
+                        crate::agg_slots::load_slots_at_low(self, slot + slot_count - 1, slot_count)
+                    } else {
+                        Vec::new()
+                    };
 
                     // Register array element vregs
                     self.struct_slot_vregs.insert(value, slot_vregs.clone());
@@ -1796,22 +1771,16 @@ impl<'a> CfgLower<'a> {
                         self.value_map.insert(value, vreg);
                     }
                 } else if self.ctx.is_multislot_aggregate(load_type) {
-                    // Struct or payload enum (RUE-221): load all slots. For an
-                    // enum, slot 0 is the discriminant, so the primary vreg set
-                    // below is what a `match` switches on.
+                    // Struct or payload enum (RUE-221): load all slots
+                    // ascending (ADR-0040 / RUE-311). For an enum, slot 0 is the
+                    // discriminant, so the primary vreg set below is what a
+                    // `match` switches on.
                     let slot_count = self.ctx.type_slot_count(load_type);
-                    let mut slot_vregs = Vec::with_capacity(slot_count as usize);
-
-                    for i in 0..slot_count {
-                        let field_vreg = self.mir.alloc_vreg();
-                        let field_offset = self.ctx.local_offset(slot + i);
-                        self.mir.push(X86Inst::MovRM {
-                            dst: Operand::Virtual(field_vreg),
-                            base: Reg::Rbp,
-                            offset: field_offset,
-                        });
-                        slot_vregs.push(field_vreg);
-                    }
+                    let slot_vregs = if slot_count > 0 {
+                        crate::agg_slots::load_slots_at_low(self, slot + slot_count - 1, slot_count)
+                    } else {
+                        Vec::new()
+                    };
 
                     // Register struct field vregs
                     self.struct_slot_vregs.insert(value, slot_vregs.clone());
@@ -1934,6 +1903,14 @@ impl<'a> CfgLower<'a> {
                 let result_vreg = self.mir.alloc_vreg();
                 self.value_map.insert(value, result_vreg);
 
+                // By-value aggregate arguments are passed in REVERSED logical
+                // slot order to Rue-compiled callees (ADR-0040 / RUE-311), which
+                // read them back with the ascending frame convention. Runtime
+                // helpers (`__rue_*`, hand-written with the C ABI) instead expect
+                // a builtin aggregate's slots (e.g. a String's ptr/len/cap) in
+                // natural order, so calls to them are NOT reversed.
+                let callee_is_runtime = self.interner.resolve(name).starts_with("__rue_");
+
                 // Does this call return via the sret convention? Builtin
                 // String always does (runtime fns take an out-pointer first
                 // param); other aggregates do when their slots exceed the
@@ -1999,7 +1976,23 @@ impl<'a> CfgLower<'a> {
                         // count), not slot_count, so a multidimensional array dropped
                         // every row after the first. (RUE-118, RUE-79)
                         if let Some(field_vregs) = self.get_or_compute_field_vregs(arg_value) {
-                            flattened_vregs.extend(field_vregs);
+                            // Pass a Rue callee's aggregate slots in REVERSED
+                            // logical order (ADR-0040 / RUE-311). The callee
+                            // prologue spills ABI slot j to frame slot base+j, so
+                            // pushing logical slot k at ABI slot (C-1-k) lands it
+                            // at frame slot base + (C-1-k) — exactly the
+                            // ascending frame layout `store_slots`/
+                            // `load_consecutive` use for locals (logical slot 0
+                            // at the low-address end). Without this, by-value
+                            // aggregate params would sit in descending order
+                            // while every other aggregate is ascending, and field
+                            // reads (which now assume ascending) would transpose
+                            // the fields. Runtime callees keep natural order.
+                            if callee_is_runtime {
+                                flattened_vregs.extend(field_vregs);
+                            } else {
+                                flattened_vregs.extend(field_vregs.into_iter().rev());
+                            }
                         } else {
                             flattened_vregs.push(self.get_vreg(arg_value));
                         }
@@ -2744,9 +2737,14 @@ impl<'a> CfgLower<'a> {
 
                     // Get the local slot for this value
                     let lvalue_inst = self.ctx.cfg.get_inst(lvalue_val);
+                    let lvalue_ty = lvalue_inst.ty;
                     if let CfgInstData::Load { slot } = &lvalue_inst.data {
-                        // Simple case: address of a local variable
-                        let offset = self.ctx.local_offset(*slot);
+                        // Simple case: address of a whole local variable. @raw
+                        // yields the value's LOW end (ADR-0040 / RUE-311): an
+                        // aggregate's low-address end is its highest-numbered
+                        // frame slot, `slot + count - 1`.
+                        let count = self.ctx.type_slot_count(lvalue_ty).max(1);
+                        let offset = self.ctx.local_offset(*slot + count - 1);
                         let result_vreg = self.mir.alloc_vreg();
                         // LEA to compute address: result = rbp + offset
                         self.mir.push(X86Inst::Lea {
@@ -2776,7 +2774,10 @@ impl<'a> CfgLower<'a> {
                             let ptr_vreg = self.ensure_inout_param_ptr(index);
                             self.value_map.insert(value, ptr_vreg);
                         } else {
-                            let slot = self.ctx.num_locals + index;
+                            // Whole by-value param: its low end is the highest
+                            // slot of its frame region (ADR-0040 / RUE-311).
+                            let count = self.ctx.type_slot_count(lvalue_ty).max(1);
+                            let slot = self.ctx.num_locals + index + count - 1;
                             let offset = self.ctx.local_offset(slot);
                             let result_vreg = self.mir.alloc_vreg();
                             self.mir.push(X86Inst::Lea {
@@ -2812,7 +2813,11 @@ impl<'a> CfgLower<'a> {
             } => {
                 let val_vreg = self.get_vreg(*val);
                 let field_slot_offset = self.ctx.struct_field_slot_offset(*struct_id, *field_index);
-                let actual_slot = slot + field_slot_offset;
+                // Ascending layout (ADR-0040 / RUE-311): the field's slot sits
+                // at the struct's low end (`slot + count - 1`) plus the field's
+                // byte offset — i.e. minus the offset in slot number.
+                let struct_count = self.ctx.struct_total_slot_count(*struct_id);
+                let actual_slot = slot + (struct_count - 1) - field_slot_offset;
                 let offset = self.ctx.local_offset(actual_slot);
                 self.mir.push(X86Inst::MovMR {
                     base: Reg::Rbp,
@@ -2834,12 +2839,13 @@ impl<'a> CfgLower<'a> {
 
                 // Check if this is an inout parameter
                 if self.ctx.cfg.is_param_inout(*param_slot) {
-                    // For inout params, store through the pointer
+                    // For inout params, store through the pointer. The pointer is
+                    // the caller place's low end, so the field's ascending byte
+                    // offset is added (ADR-0040 / RUE-311).
                     let ptr_vreg = self.ensure_inout_param_ptr(*param_slot);
-                    // Negative offset because stack grows down
                     self.mir.push(X86Inst::MovMRIndexed {
                         base: ptr_vreg,
-                        offset: -((total_offset as i32) * 8),
+                        offset: (total_offset as i32) * 8,
                         src: Operand::Virtual(val_vreg),
                     });
                 } else {
@@ -3154,17 +3160,40 @@ impl<'a> CfgLower<'a> {
                         return;
                     }
 
-                    // For user-defined structs, call destructor first (if any), then drop glue
+                    // For user-defined structs, call destructor first (if any), then drop glue.
                     if let Some(ref destructor_name) = struct_def.destructor {
-                        // Pass all fields to the user destructor
-                        self.emit_call_with_slot_args(&field_vregs, destructor_name);
+                        // The user destructor takes `self` as ONE by-value
+                        // struct parameter, so its slots are passed in the
+                        // reversed by-value aggregate ABI order (ADR-0040 /
+                        // RUE-311) — see the reversal in the general `Call`
+                        // lowering. (The drop glue below instead takes each
+                        // field as a separate scalar parameter, in declaration
+                        // order, so it is NOT reversed.)
+                        let mut self_vregs = field_vregs.clone();
+                        self_vregs.reverse();
+                        self.emit_call_with_slot_args(&self_vregs, destructor_name);
                     }
 
                     // Now call the drop glue function to drop fields, passing
                     // all fields again (the destructor call clobbered the
-                    // argument registers)
+                    // argument registers). Drop glue receives the flattened
+                    // fields as individual parameters in declaration order, but
+                    // it reconstructs any multi-slot field (a nested struct or
+                    // array) by reading it as one aggregate `Param` — which uses
+                    // the reversed by-value aggregate ABI (ADR-0040 / RUE-311).
+                    // So each such field's own slots are reversed within their
+                    // sub-range here; scalar fields (one slot) are unaffected.
+                    let mut glue_vregs = field_vregs.clone();
+                    let mut off = 0usize;
+                    for field in &struct_def.fields {
+                        let fc = self.ctx.type_slot_count(field.ty) as usize;
+                        if fc > 1 && off + fc <= glue_vregs.len() {
+                            glue_vregs[off..off + fc].reverse();
+                        }
+                        off += fc;
+                    }
                     let drop_fn_name = format!("__rue_drop_{}", struct_def.name);
-                    self.emit_call_with_slot_args(&field_vregs, &drop_fn_name);
+                    self.emit_call_with_slot_args(&glue_vregs, &drop_fn_name);
                     return;
                 }
 
@@ -3174,9 +3203,21 @@ impl<'a> CfgLower<'a> {
                     // slot counts past the argument registers go on the stack
                     // via emit_call_with_slot_args — e.g. [String; 3] is 9
                     // slots, RUE-193)
-                    let element_vregs = self
+                    let mut element_vregs = self
                         .get_or_compute_field_vregs(*dropped_value)
                         .unwrap_or_else(|| self.collect_array_scalar_vregs(*dropped_value));
+
+                    // The array drop glue reconstructs each multi-slot element
+                    // via one aggregate `Param` read, which uses the reversed
+                    // by-value ABI (ADR-0040 / RUE-311). Reverse each element's
+                    // own slots within its sub-range so that read recovers
+                    // logical order; single-slot elements are unaffected.
+                    let elem_slots = self.ctx.array_element_slot_count(dropped_ty) as usize;
+                    if elem_slots > 1 {
+                        for chunk in element_vregs.chunks_mut(elem_slots) {
+                            chunk.reverse();
+                        }
+                    }
 
                     let drop_fn_name = types::array_drop_glue_name(array_id, self.ctx.type_pool);
                     self.emit_call_with_slot_args(&element_vregs, &drop_fn_name);
@@ -4114,11 +4155,11 @@ impl<'a> CfgLower<'a> {
                     self.emit_bounds_check(index_vreg, array_length);
 
                     let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
-                    // Ascending array layout (ADR-0040 / RUE-243): shift the
-                    // origin to the array's lowest-address element so the ADDed
-                    // scaled index below resolves element i to base + i*size.
-                    let array_len = self.ctx.array_length(*array_type);
-                    static_slot_offset += (array_len.max(1) - 1) as u32 * elem_slot_count;
+                    // Ascending layout (ADR-0040 / RUE-311): the element's byte
+                    // offset from the array's low-end origin is `index*size`,
+                    // added below. The single root-object origin shift (applied
+                    // when forming the base address) already places us at the
+                    // low end, so no per-array `(N-1)` shift is needed.
                     index_levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
@@ -4127,6 +4168,12 @@ impl<'a> CfgLower<'a> {
                 }
             }
         }
+
+        // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311): a
+        // frame-resident aggregate's low-address end is its highest-numbered
+        // slot, `root_base + root_count - 1`. Field offsets then move UP in
+        // address (toward higher addresses = lower slot numbers).
+        let root_count = crate::agg_slots::root_slot_count(self, projections, 1);
 
         // Calculate dynamic offset from index projections
         let dynamic_offset_vreg = if !index_levels.is_empty() {
@@ -4138,7 +4185,7 @@ impl<'a> CfgLower<'a> {
         // Compute final address based on base type
         match place.base {
             PlaceBase::Local(slot) => {
-                let base_slot = slot + static_slot_offset;
+                let base_slot = slot + (root_count - 1) - static_slot_offset;
                 let base_offset = self.ctx.local_offset(base_slot);
 
                 if let Some(dyn_offset) = dynamic_offset_vreg {
@@ -4171,12 +4218,14 @@ impl<'a> CfgLower<'a> {
             }
             PlaceBase::Param(param_slot) => {
                 if self.ctx.cfg.is_param_inout(param_slot) {
-                    // Inout param - use pointer
+                    // Inout param - use pointer. The received pointer is the
+                    // caller place's low end, so field offsets and the scaled
+                    // index both ADD (ascending, ADR-0040 / RUE-311).
                     let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
                     let static_byte_offset = (static_slot_offset as i32) * 8;
 
                     if let Some(dyn_offset) = dynamic_offset_vreg {
-                        // Compute address: ptr - static_offset + dynamic_offset (ascending, ADR-0040)
+                        // Compute address: ptr + static_offset + dynamic_offset (ascending)
                         let addr_vreg = self.mir.alloc_vreg();
                         self.mir.push(X86Inst::MovRR {
                             dst: Operand::Virtual(addr_vreg),
@@ -4188,7 +4237,7 @@ impl<'a> CfgLower<'a> {
                                 dst: Operand::Virtual(offset_vreg),
                                 imm: static_byte_offset as i64,
                             });
-                            self.mir.push(X86Inst::SubRR64 {
+                            self.mir.push(X86Inst::AddRR64 {
                                 dst: Operand::Virtual(addr_vreg),
                                 src: Operand::Virtual(offset_vreg),
                             });
@@ -4203,16 +4252,17 @@ impl<'a> CfgLower<'a> {
                             offset: 0,
                         });
                     } else {
-                        // Static offset only
+                        // Static offset only (ascending: field at ptr + off)
                         self.mir.push(X86Inst::MovRMIndexed {
                             dst: Operand::Virtual(dst),
                             base: ptr_vreg,
-                            offset: -static_byte_offset,
+                            offset: static_byte_offset,
                         });
                     }
                 } else {
                     // Normal param - treat like local
-                    let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
+                    let base_slot =
+                        self.ctx.num_locals + param_slot + (root_count - 1) - static_slot_offset;
                     let base_offset = self.ctx.local_offset(base_slot);
 
                     if let Some(dyn_offset) = dynamic_offset_vreg {
@@ -4307,11 +4357,10 @@ impl<'a> CfgLower<'a> {
                     self.emit_bounds_check(index_vreg, array_length);
 
                     let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
-                    // Ascending array layout (ADR-0040 / RUE-243): shift the
-                    // origin to the array's lowest-address element so the ADDed
-                    // scaled index below resolves element i to base + i*size.
-                    let array_len = self.ctx.array_length(*array_type);
-                    static_slot_offset += (array_len.max(1) - 1) as u32 * elem_slot_count;
+                    // Ascending layout (ADR-0040 / RUE-311): the element's byte
+                    // offset from the low-end origin is `index*size`, added
+                    // below; the single root-object origin shift covers the
+                    // array's own origin (no per-array `(N-1)` shift).
                     index_levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
@@ -4320,6 +4369,9 @@ impl<'a> CfgLower<'a> {
                 }
             }
         }
+
+        // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311).
+        let root_count = crate::agg_slots::root_slot_count(self, projections, vals.len() as u32);
 
         // Calculate dynamic offset from index projections
         let dynamic_offset_vreg = if !index_levels.is_empty() {
@@ -4331,8 +4383,9 @@ impl<'a> CfgLower<'a> {
         // Compute final address based on base type
         match place.base {
             PlaceBase::Local(slot) => {
-                let base_slot = slot + static_slot_offset;
-                let base_offset = self.ctx.local_offset(base_slot);
+                // The accessed value's low-end (slot-0) frame slot.
+                let base_low_slot = slot + (root_count - 1) - static_slot_offset;
+                let base_offset = self.ctx.local_offset(base_low_slot);
 
                 if let Some(dyn_offset) = dynamic_offset_vreg {
                     let addr_vreg = self.mir.alloc_vreg();
@@ -4349,11 +4402,13 @@ impl<'a> CfgLower<'a> {
                     });
                     crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
                 } else {
-                    crate::agg_slots::store_slots(self, vals, base_slot);
+                    crate::agg_slots::store_slots_at_low(self, vals, base_low_slot);
                 }
             }
             PlaceBase::Param(param_slot) => {
                 if self.ctx.cfg.is_param_inout(param_slot) {
+                    // Received pointer is the caller place's low end; field
+                    // offsets and the scaled index both ADD (ascending).
                     let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
                     let static_byte_offset = (static_slot_offset as i32) * 8;
 
@@ -4369,7 +4424,7 @@ impl<'a> CfgLower<'a> {
                                 dst: Operand::Virtual(offset_vreg),
                                 imm: static_byte_offset as i64,
                             });
-                            self.mir.push(X86Inst::SubRR64 {
+                            self.mir.push(X86Inst::AddRR64 {
                                 dst: Operand::Virtual(addr_vreg),
                                 src: Operand::Virtual(offset_vreg),
                             });
@@ -4388,8 +4443,9 @@ impl<'a> CfgLower<'a> {
                         );
                     }
                 } else {
-                    let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
-                    let base_offset = self.ctx.local_offset(base_slot);
+                    let base_low_slot =
+                        self.ctx.num_locals + param_slot + (root_count - 1) - static_slot_offset;
+                    let base_offset = self.ctx.local_offset(base_low_slot);
 
                     if let Some(dyn_offset) = dynamic_offset_vreg {
                         let addr_vreg = self.mir.alloc_vreg();
@@ -4404,7 +4460,7 @@ impl<'a> CfgLower<'a> {
                         });
                         crate::agg_slots::store_slots_through_ptr(self, vals, addr_vreg, 0);
                     } else {
-                        crate::agg_slots::store_slots(self, vals, base_slot);
+                        crate::agg_slots::store_slots_at_low(self, vals, base_low_slot);
                     }
                 }
             }
@@ -4492,11 +4548,10 @@ impl<'a> CfgLower<'a> {
                 }
                 Projection::Index { array_type, index } => {
                     let elem_slot_count = self.ctx.array_element_slot_count(*array_type);
-                    // Ascending array layout (ADR-0040 / RUE-243): shift the
-                    // origin to the array's lowest-address element so the ADDed
-                    // scaled index below resolves element i to base + i*size.
-                    let array_len = self.ctx.array_length(*array_type);
-                    static_slot_offset += (array_len.max(1) - 1) as u32 * elem_slot_count;
+                    // Ascending layout (ADR-0040 / RUE-311): the element's byte
+                    // offset from the low-end origin is `index*size`, added
+                    // below; the single root-object origin shift covers the
+                    // array's own origin (no per-array `(N-1)` shift).
                     index_levels.push(IndexLevel {
                         index: *index,
                         elem_slot_count,
@@ -4505,6 +4560,11 @@ impl<'a> CfgLower<'a> {
                 }
             }
         }
+
+        // Origin shift to the ROOT object's low end (ADR-0040 / RUE-311); the
+        // resulting address is the accessed place's LOW end, from which slots
+        // ascend. With no projections the place is a scalar (root_count 1).
+        let root_count = crate::agg_slots::root_slot_count(self, projections, 1);
 
         // Calculate dynamic offset from index projections
         let dynamic_offset_vreg = if !index_levels.is_empty() {
@@ -4516,8 +4576,8 @@ impl<'a> CfgLower<'a> {
         // Compute address based on base type
         match place.base {
             PlaceBase::Local(slot) => {
-                let base_slot = slot + static_slot_offset;
-                let base_offset = self.ctx.local_offset(base_slot);
+                let base_low_slot = slot + (root_count - 1) - static_slot_offset;
+                let base_offset = self.ctx.local_offset(base_low_slot);
 
                 self.mir.push(X86Inst::Lea {
                     dst: Operand::Virtual(dst),
@@ -4534,6 +4594,8 @@ impl<'a> CfgLower<'a> {
             }
             PlaceBase::Param(param_slot) => {
                 if self.ctx.cfg.is_param_inout(param_slot) {
+                    // Received pointer is the caller place's low end; field
+                    // offset and scaled index both ADD (ascending).
                     let ptr_vreg = self.ensure_inout_param_ptr(param_slot);
                     let static_byte_offset = (static_slot_offset as i32) * 8;
 
@@ -4548,7 +4610,7 @@ impl<'a> CfgLower<'a> {
                             dst: Operand::Virtual(offset_vreg),
                             imm: static_byte_offset as i64,
                         });
-                        self.mir.push(X86Inst::SubRR64 {
+                        self.mir.push(X86Inst::AddRR64 {
                             dst: Operand::Virtual(dst),
                             src: Operand::Virtual(offset_vreg),
                         });
@@ -4561,8 +4623,9 @@ impl<'a> CfgLower<'a> {
                         });
                     }
                 } else {
-                    let base_slot = self.ctx.num_locals + param_slot + static_slot_offset;
-                    let base_offset = self.ctx.local_offset(base_slot);
+                    let base_low_slot =
+                        self.ctx.num_locals + param_slot + (root_count - 1) - static_slot_offset;
+                    let base_offset = self.ctx.local_offset(base_low_slot);
 
                     self.mir.push(X86Inst::Lea {
                         dst: Operand::Virtual(dst),

--- a/crates/rue-compiler/src/drop_glue.rs
+++ b/crates/rue-compiler/src/drop_glue.rs
@@ -358,15 +358,14 @@ fn create_array_drop_glue_function(
     // For each element, emit a Drop instruction, in ASCENDING index order
     // (element 0 dropped first — the language-visible order the oracle checks).
     //
-    // Array elements are laid out ascending in memory but stored REVERSED in the
-    // flattened slot list (ADR-0040 / RUE-243): frame slots descend in address,
-    // so element 0 occupies the LAST element-chunk of the received parameter
-    // slots and element N-1 the first. Iterate physical chunks back-to-front so
-    // the drops fire in ascending logical-index order. Each chunk's own slots
-    // stay in natural order (structs keep field order; nested arrays are
-    // reversed again by their own glue via this same recursion).
+    // The flattened parameter slots are in LOGICAL order (ADR-0040 / RUE-311):
+    // element 0 occupies the first element-chunk, element N-1 the last. So
+    // iterate chunks front-to-back to drop in ascending index order. Each chunk
+    // is read back as one aggregate `Param`, which the codegen `Drop` lowering
+    // hands over in the reversed by-value ABI order, so the drop caller reverses
+    // each element's own slots to compensate (see the array `Drop` handler).
     // Type::Struct handles both user-defined structs and builtin String.
-    for phys_chunk in (0..length).rev() {
+    for phys_chunk in 0..length {
         let current_param_slot = phys_chunk as u32 * element_slot_count;
 
         // Emit Drop for this element

--- a/examples/std/vec.rue
+++ b/examples/std/vec.rue
@@ -35,10 +35,11 @@
 //     freed automatically at scope exit — call `free()` explicitly. (The
 //     `@free`-from-a-destructor path itself works and is proven on a concrete
 //     named struct; it is the *generic* attachment that is blocked.)
-//   * Element type must be a single 8-byte slot (scalars: iN/uN/bool, or a
-//     one-field struct). Multi-slot aggregate elements are miscompiled by the
-//     aggregate raw-pointer path (descending slot offsets underflow the
-//     ascending heap element base) — a separate raw-pointer bug, not a Vec bug.
+//   * Multi-slot aggregate element types (e.g. a two-field struct) now work:
+//     every aggregate is laid out ascending-in-address and `@ptr_read`/
+//     `@ptr_write` walk slots upward from the element base, matching the
+//     ascending heap layout (ADR-0040 / RUE-311). The Copy restriction above
+//     still applies (elements are transferred by copy).
 
 pub fn Vec(comptime T: type) -> type {
     struct {


### PR DESCRIPTION
**Memory-corruption fix.** Stack aggregates were laid out descending-in-address (field 0 at the high end; @raw returned the high end; place-read used addr-i*8) while heap/@alloc/@ptr were ascending (ADR-0040). So @ptr_write of a multi-slot aggregate wrote slot i at ptr-i*8, underflowing the preceding heap allocation (confirmed: a 999-guard came back 999/1032). A scoped per-slot flip was refuted earlier — it just moved the corruption to the stack path.

Fix completes ADR-0040: EVERY aggregate (struct/array/String/enum) is ascending-in-address — slot 0 at the low end, slot k at base+k*8, @raw returns the low end, @ptr walks upward. Mirrored across BOTH backends + shared agg_slots/types/cfg_lower/byref_args + drop_glue order. By-value aggregate args reversed at the call site (slot 0 at frame low end); runtime __rue_* callees exempted (expect natural ptr/len/cap order — load-bearing, found via String push_str).

Verified by execution: heap 2-slot round-trip + non-clobber; stack @raw+@ptr; array-of-struct; struct ABI (register + 5xi64 sret); inout writeback; enum payload; String mutation; drop order; **Vec(Point) 2-field struct element** (the goal). RUE-242 raw-pointer cases (17) all green. clippy-gate-passed; test.sh Pass 24 (6 new CLI cases); oracle 0 disagreements over 300 seeds (~1600 across iterations); aarch64 ascending via --emit asm.

Also closes the coverage gap that hid this (zero multi-slot-heap cases before).

Fixes RUE-311

Generated with Claude Code