### PR TITLE
Enclosing comptime T usable in anon-struct method bodies; Vec get/pop return Option(T) (RUE-313)

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -391,6 +391,11 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                 .get(&struct_id)
                 .cloned()
                 .unwrap_or_else(HashMap::new);
+            let enclosing_type_subst = sema
+                .anon_struct_type_subst
+                .get(&struct_id)
+                .cloned()
+                .unwrap_or_else(HashMap::new);
 
             match sema.analyze_method_body(
                 &infer_ctx,
@@ -399,6 +404,7 @@ fn analyze_all_function_bodies_sequential(sema: &mut Sema<'_>) -> MultiErrorResu
                 method_info.body,
                 method_info.struct_type,
                 &captured_values,
+                &enclosing_type_subst,
             ) {
                 Ok((
                     air,
@@ -678,6 +684,11 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                     .get(&struct_id)
                     .cloned()
                     .unwrap_or_else(HashMap::new);
+                let enclosing_type_subst = sema
+                    .anon_struct_type_subst
+                    .get(&struct_id)
+                    .cloned()
+                    .unwrap_or_else(HashMap::new);
 
                 match sema.analyze_method_body(
                     &infer_ctx,
@@ -686,6 +697,7 @@ fn analyze_function_bodies_lazy(sema: &mut Sema<'_>) -> MultiErrorResult<SemaOut
                     method_info.body,
                     method_info.struct_type,
                     &captured_values,
+                    &enclosing_type_subst,
                 ) {
                     Ok((
                         air,
@@ -1892,6 +1904,7 @@ impl<'a> Sema<'a> {
         body: InstRef,
         self_type: Type,
         captured_comptime_values: &std::collections::HashMap<Spur, ConstValue>,
+        enclosing_type_subst: &std::collections::HashMap<Spur, Type>,
     ) -> CompileResult<(
         Air,
         u32,
@@ -1902,9 +1915,13 @@ impl<'a> Sema<'a> {
         HashSet<Spur>,
         HashSet<(StructId, Spur)>,
     )> {
-        // Create a type substitution map with Self -> the struct type
+        // Create a type substitution map with Self -> the struct type, plus the
+        // enclosing `-> type` constructor's type parameters (e.g. `T -> i32`
+        // for `Vec(i32)`), so those parameters resolve throughout the method
+        // body — `let x: T`, `Option(T)`, etc. (RUE-313). `Self` is inserted
+        // last so it always wins over any same-named constructor parameter.
         let self_sym = self.interner.get_or_intern("Self");
-        let mut type_subst = HashMap::new();
+        let mut type_subst = enclosing_type_subst.clone();
         type_subst.insert(self_sym, self_type);
 
         self.analyze_function_internal(

--- a/crates/rue-air/src/sema/comptime_eval.rs
+++ b/crates/rue-air/src/sema/comptime_eval.rs
@@ -913,6 +913,17 @@ impl Sema<'_> {
                             // caller reports the comptime failure.
                             return Ok(None);
                         }
+
+                        // Remember the enclosing type substitution (e.g.
+                        // `T -> i32` for `Vec(i32)`) so it resolves inside every
+                        // method *body*, not just the signatures registered
+                        // above (RUE-313). Method bodies are analyzed later, in
+                        // a separate pass that has no other way to recover the
+                        // constructor's type parameters.
+                        if needs_registration && !env.type_subst.is_empty() {
+                            self.anon_struct_type_subst
+                                .insert(struct_id, env.type_subst.clone());
+                        }
                     }
                 }
                 Ok(Some(ConstValue::Type(struct_ty)))

--- a/crates/rue-air/src/sema/gather.rs
+++ b/crates/rue-air/src/sema/gather.rs
@@ -103,6 +103,7 @@ impl<'a> GatherOutput<'a> {
             param_arena: self.param_arena,
             anon_struct_method_sigs: HashMap::new(),
             anon_struct_captured_values: HashMap::new(),
+            anon_struct_type_subst: HashMap::new(),
             destructor_spans: HashMap::new(),
             infectious_linear: HashMap::new(),
             comptime_type_call_depth: 0,

--- a/crates/rue-air/src/sema/mod.rs
+++ b/crates/rue-air/src/sema/mod.rs
@@ -62,7 +62,7 @@ use rue_span::{FileId, Span};
 
 use crate::intern_pool::TypeInternPool;
 use crate::param_arena::ParamArena;
-use crate::types::{EnumId, StructId};
+use crate::types::{EnumId, StructId, Type};
 
 /// Semantic analyzer that converts RIR to AIR.
 pub struct Sema<'a> {
@@ -112,6 +112,14 @@ pub struct Sema<'a> {
     /// stored here, keyed by StructId. These values become part of type identity:
     /// FixedBuffer(42) and FixedBuffer(100) are different types.
     pub(crate) anon_struct_captured_values: HashMap<StructId, HashMap<Spur, ConstValue>>,
+    /// Captured comptime *type* substitution for anonymous structs produced by
+    /// a `-> type` comptime constructor. When `Vec(comptime T: type)` is
+    /// instantiated as `Vec(i32)`, this stores `T -> i32` keyed by the
+    /// resulting StructId, so the enclosing type parameter resolves not just in
+    /// field/method *signatures* (done at registration) but throughout every
+    /// method *body* at analysis time (RUE-313). Empty for non-generic anon
+    /// structs.
+    pub(crate) anon_struct_type_subst: HashMap<StructId, HashMap<Spur, Type>>,
     /// Span of each user-defined `drop fn` declaration, keyed by the struct
     /// it destructs. Used by diagnostics that point at the destructor
     /// (E0456 field-move-out-of-destructor-type, E0457 @copy-with-destructor).
@@ -159,6 +167,7 @@ impl<'a> Sema<'a> {
             param_arena: ParamArena::new(),
             anon_struct_method_sigs: HashMap::new(),
             anon_struct_captured_values: HashMap::new(),
+            anon_struct_type_subst: HashMap::new(),
             destructor_spans: HashMap::new(),
             infectious_linear: HashMap::new(),
             comptime_type_call_depth: 0,

--- a/crates/rue-cli-tests/cases/comptime_enclosing_type_in_method.toml
+++ b/crates/rue-cli-tests/cases/comptime_enclosing_type_in_method.toml
@@ -1,0 +1,90 @@
+# The enclosing `comptime T: type` parameter of a `-> type` constructor is
+# usable throughout its anonymous struct's method BODIES — not just the
+# field/method signatures (RUE-313). Before the fix, referencing `T` inside a
+# method body (to declare a `T`-typed local, or to build `Option(T)`) failed
+# with "unknown type 'T'" (E0204), so a source-level `Vec(T)` could not return
+# `Option(T)`.
+
+[section]
+id = "cli.comptime_enclosing_type_in_method"
+name = "Enclosing comptime T usable in method bodies"
+description = "The constructor's comptime type parameter resolves inside anonymous-struct method bodies (RUE-313)."
+
+# A `T`-typed local declared inside a method body resolves to the concrete
+# instantiation type (i32 here).
+[[case]]
+name = "enclosing_type_local_in_method_body"
+description = "`let x: T` inside a method body resolves to the instantiation's element type."
+files = [{ path = "main.rue", source = """
+fn Box(comptime T: type) -> type {
+    struct {
+        v: T,
+        fn dup(borrow self) -> T {
+            let x: T = self.v;
+            x
+        }
+    }
+}
+fn main() -> i32 {
+    let B = Box(i32);
+    let b = B { v: 42 };
+    b.dup()
+}
+""" }]
+exit_code = 42
+
+# The enclosing `T` can name `Option(T)` in the method's return type AND build
+# it in the body (via `let O = Option(T)`), so a method can return a real
+# Option over the element type.
+[[case]]
+name = "enclosing_type_builds_option_in_method_body"
+description = "A method returns Option(T) built from the enclosing comptime T."
+files = [{ path = "main.rue", source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn Box(comptime T: type) -> type {
+    struct {
+        v: T,
+        fn wrap(borrow self) -> Option(T) {
+            let O = Option(T);
+            O::Some(self.v)
+        }
+    }
+}
+fn main() -> i32 {
+    let B = Box(i32);
+    let O = Option(i32);
+    let b = B { v: 42 };
+    match b.wrap() {
+        O::Some(x) => x,
+        O::None => 0,
+    }
+}
+""" }]
+exit_code = 42
+
+# Two distinct instantiations each resolve their own enclosing T inside the
+# shared method source (bool vs i32), and stay distinct types.
+[[case]]
+name = "enclosing_type_two_instantiations"
+description = "Distinct instantiations resolve their own T in the same method body."
+files = [{ path = "main.rue", source = """
+fn Box(comptime T: type) -> type {
+    struct {
+        v: T,
+        fn echo(borrow self) -> T {
+            let x: T = self.v;
+            x
+        }
+    }
+}
+fn main() -> i32 {
+    let Bi = Box(i32);
+    let Bb = Box(bool);
+    let bi = Bi { v: 7 };
+    let bb = Bb { v: true };
+    if bb.echo() { bi.echo() } else { 0 }
+}
+""" }]
+exit_code = 7

--- a/crates/rue-cli-tests/cases/vec_library.toml
+++ b/crates/rue-cli-tests/cases/vec_library.toml
@@ -1,27 +1,29 @@
 # The source-level Vec(T) library (examples/std/vec.rue) driven end-to-end as a
-# user would: a multi-file compile of a program that @imports the library and
-# exercises push / len / get / set / pop / a while-loop sum / out-of-bounds
-# access on a Vec(i32) (RUE-1, ADR-0041).
+# user would: a flat multi-file compile of a program that exercises
+# push / len / get / set / pop / a while-loop sum / out-of-bounds access on a
+# Vec(i32) (RUE-1, ADR-0041).
 #
 # Vec is generic over a Copy element type and is built entirely on the unchecked
-# heap intrinsics @alloc/@realloc/@free behind a safe method API. See vec.rue's
-# header for the (separately tracked) limitations this stays within: Copy
-# elements, explicit free() instead of an automatic destructor, and single-slot
-# element types.
+# heap intrinsics @alloc/@realloc/@free behind a safe method API. Its `get`/`pop`
+# accessors return `Option(T)` (from option.rue) — the enclosing element type
+# `T` is usable inside the method bodies (RUE-313). See vec.rue's header for the
+# (separately tracked) limitations this stays within: Copy elements, explicit
+# free() instead of an automatic destructor (RUE-312), and single-slot element
+# types.
 
 [section]
 id = "cli.vec_library"
 name = "Source-level Vec(T) library"
-description = "A Rue-source Vec(T) on @alloc/@free with a full push/pop/get/set dogfood (RUE-1)."
+description = "A Rue-source Vec(T) on @alloc/@free with a full push/pop/get/set dogfood returning Option(T) (RUE-1, RUE-313)."
 
 [[case]]
 name = "vec_i32_dogfood"
-description = "push/len/get/set/pop/while-sum/out-of-bounds on Vec(i32), via @import + multi-file."
+description = "push/len/get/set/pop/while-sum/out-of-bounds on Vec(i32), Option(T) accessors, flat multi-file."
 files = [
   { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import(\"vec.rue\");
-    let V = m.Vec(i32);
+    let V = Vec(i32);
+    let O = Option(i32);
 
     let mut v = V::new();
     v.push(10);
@@ -29,25 +31,30 @@ fn main() -> i32 {
     v.push(30);
     @dbg(v.len());          // 3
 
-    @dbg(v.get(1));         // 20
+    @dbg(match v.get(1) { O::Some(x) => x, O::None => -1 });   // 20
     v.set(0, 99);
-    @dbg(v.get(0));         // 99
+    @dbg(match v.get(0) { O::Some(x) => x, O::None => -1 });   // 99
 
-    @dbg(v.pop_or(0));      // 30 (removed)
+    @dbg(match v.pop() { O::Some(x) => x, O::None => -1 });    // 30 (removed)
     @dbg(v.len());          // 2
 
-    @dbg(v.get_or(99, 0));  // 0  (out-of-bounds -> default)
+    @dbg(match v.get(99) { O::Some(x) => x, O::None => -1 });  // -1 (out of bounds)
 
     let mut i: u64 = 0;
     let mut sum: i32 = 0;
     while i < v.len() {
-        sum = sum + v.get(i);
+        sum = sum + v.get_or(i, 0);
         i = i + 1;
     }
     @dbg(sum);              // 99 + 20 = 119
 
     v.free();
     sum
+}
+""" },
+  { path = "option.rue", source = """
+pub fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
 }
 """ },
   { path = "vec.rue", source = """
@@ -83,8 +90,13 @@ pub fn Vec(comptime T: type) -> type {
             };
             self.len = self.len + 1;
         }
-        fn get(borrow self, i: u64) -> T {
-            checked { @ptr_read(@ptr_offset(self.buf, i)) }
+        fn get(borrow self, i: u64) -> Option(T) {
+            let O = Option(T);
+            if i < self.len {
+                O::Some(checked { @ptr_read(@ptr_offset(self.buf, i)) })
+            } else {
+                O::None
+            }
         }
         fn get_or(borrow self, i: u64, default: T) -> T {
             if i < self.len {
@@ -101,12 +113,13 @@ pub fn Vec(comptime T: type) -> type {
                 };
             }
         }
-        fn pop_or(inout self, default: T) -> T {
+        fn pop(inout self) -> Option(T) {
+            let O = Option(T);
             if self.len == 0 {
-                default
+                O::None
             } else {
                 self.len = self.len - 1;
-                checked { @ptr_read(@ptr_offset(self.buf, self.len)) }
+                O::Some(checked { @ptr_read(@ptr_offset(self.buf, self.len)) })
             }
         }
         fn clear(inout self) { self.len = 0; }
@@ -121,8 +134,8 @@ pub fn Vec(comptime T: type) -> type {
 }
 """ },
 ]
-args = ["main.rue", "vec.rue", "-o", "prog"]
-stdout = "3\n20\n99\n30\n2\n0\n119\n"
+args = ["main.rue", "vec.rue", "option.rue", "-o", "prog"]
+stdout = "3\n20\n99\n30\n2\n-1\n119\n"
 exit_code = 119
 
 # Multi-slot struct element type: push/get/set/pop of a two-field `Point`

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -861,6 +861,65 @@ fn main() -> i32 {
 """
 exit_code = 9
 
+# The enclosing `comptime T: type` parameter is usable inside a method BODY,
+# not only in field/method signatures (RUE-313). Declaring a `T`-typed local
+# inside the body resolves `T` to the instantiation's concrete type.
+[[case]]
+name = "anon_struct_enclosing_type_local_in_body"
+spec = ["4.14:12"]
+description = "Enclosing comptime T names a local variable type inside a method body"
+source = """
+fn Box(comptime T: type) -> type {
+    struct {
+        v: T,
+
+        fn dup(self) -> T {
+            let x: T = self.v;
+            x
+        }
+    }
+}
+fn main() -> i32 {
+    let B = Box(i32);
+    let b: B = B { v: 42 };
+    b.dup()
+}
+"""
+exit_code = 42
+
+# The enclosing `T` can also build a generic type application `Option(T)` inside
+# a method body (bound to a local, then constructed), so a method returns a real
+# Option over the element type (RUE-313).
+[[case]]
+name = "anon_struct_enclosing_type_builds_option"
+spec = ["4.14:12"]
+description = "Enclosing comptime T builds Option(T) inside a method body"
+source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn Box(comptime T: type) -> type {
+    struct {
+        v: T,
+
+        fn wrap(self) -> Option(T) {
+            let O = Option(T);
+            O::Some(self.v)
+        }
+    }
+}
+fn main() -> i32 {
+    let B = Box(i32);
+    let O = Option(i32);
+    let b: B = B { v: 42 };
+    match b.wrap() {
+        O::Some(x) => x,
+        O::None => 0,
+    }
+}
+"""
+exit_code = 42
+
 [[case]]
 name = "anon_struct_associated_fn"
 spec = ["4.14:13"]

--- a/examples/std/vec.rue
+++ b/examples/std/vec.rue
@@ -7,32 +7,33 @@
 // mutation, and the raw-pointer intrinsics all at once — exactly the "stdlib on
 // unchecked code" framing of RUE-1.
 //
+// `get`/`pop` return `Option(T)` (from the sibling `option.rue`), so Vec must
+// be compiled together with `option.rue` in the same flat multi-file namespace:
+//
+//     rue my_program.rue vec.rue option.rue -o my_program
+//
 // Usage (the element type is chosen when you instantiate the type function):
 //
-//     let V = @import("vec.rue").Vec(i32);   // or, same-directory, just Vec(i32)
+//     let V = Vec(i32);
+//     let O = Option(i32);
 //     let mut v = V::new();
 //     v.push(10);
 //     v.push(20);
-//     let n = v.len();          // 2
-//     let x = v.get(0);         // 10
+//     let n = v.len();                                 // 2
+//     let x = match v.get(0) { O::Some(e) => e, O::None => -1 };   // 10
 //     v.set(0, 99);
-//     let last = v.pop_or(0);   // 20
-//     v.free();                 // release the buffer
-//
-// Requires `--preview method_receivers` (borrow/inout receivers, ADR-0037).
+//     let last = match v.pop() { O::Some(e) => e, O::None => -1 }; // 20
+//     v.free();                                        // release the buffer
 //
 // SCOPE / KNOWN LIMITATIONS (tracked separately — this file deliberately does
 // not work around them):
 //
-//   * Copy element types only. `get`/`pop_or` return an element *by copy*
-//     (`@ptr_read`). Move-out of a non-Copy element and an `Option`-returning
-//     accessor are blocked today because the enclosing comptime type parameter
-//     `T` is not usable inside a method body to name `Option(T)` (E1201), so the
-//     API uses caller-supplied defaults (`get_or`, `pop_or`) for out-of-bounds
-//     instead of `Option(T)`. See the meta report for RUE issue references.
-//   * No automatic destructor. A `drop fn` cannot attach to the anonymous
-//     struct produced by a comptime type function (E0417), so the buffer is not
-//     freed automatically at scope exit — call `free()` explicitly. (The
+//   * Copy element types only. `get`/`pop` return an element *by copy* wrapped
+//     in `Option(T)` (`@ptr_read`). Move-out of a non-Copy element is not yet
+//     supported.
+//   * No automatic destructor. A `drop fn` cannot yet attach to the anonymous
+//     struct produced by a comptime type function (RUE-312), so the buffer is
+//     not freed automatically at scope exit — call `free()` explicitly. (The
 //     `@free`-from-a-destructor path itself works and is proven on a concrete
 //     named struct; it is the *generic* attachment that is blocked.)
 //   * Multi-slot aggregate element types (e.g. a two-field struct) now work:
@@ -40,6 +41,9 @@
 //     `@ptr_write` walk slots upward from the element base, matching the
 //     ascending heap layout (ADR-0040 / RUE-311). The Copy restriction above
 //     still applies (elements are transferred by copy).
+//
+// The enclosing element type `T` is usable throughout the method bodies below —
+// e.g. to name `Option(T)` and bind `let O = Option(T)` (RUE-313).
 
 pub fn Vec(comptime T: type) -> type {
     struct {
@@ -82,15 +86,22 @@ pub fn Vec(comptime T: type) -> type {
         fn capacity(borrow self) -> u64 { self.cap }
         fn is_empty(borrow self) -> bool { self.len == 0 }
 
-        // Element `i` by copy. The caller must ensure `i < len` (use `get_or`
-        // for a bounds-checked read). Reading out of bounds is a heap OOB read.
-        fn get(borrow self, i: u64) -> T {
-            checked { @ptr_read(@ptr_offset(self.buf, i)) }
+        // Element `i` by copy, wrapped in `Option(T)`: `Some(x)` when in
+        // bounds, `None` otherwise (ADR-0041). The enclosing element type `T`
+        // is in scope here, so the method can name `Option(T)` directly
+        // (RUE-313).
+        fn get(borrow self, i: u64) -> Option(T) {
+            let O = Option(T);
+            if i < self.len {
+                O::Some(checked { @ptr_read(@ptr_offset(self.buf, i)) })
+            } else {
+                O::None
+            }
         }
 
-        // Element `i` by copy, or `default` when `i` is out of bounds. This is
-        // the non-trapping accessor (the `Copy`-only stand-in for the
-        // `Option(T)`-returning `get` described in ADR-0041, blocked today).
+        // Element `i` by copy, or `default` when `i` is out of bounds. An
+        // ergonomic default-based read for callers that don't want to match on
+        // `Option`.
         fn get_or(borrow self, i: u64, default: T) -> T {
             if i < self.len {
                 checked { @ptr_read(@ptr_offset(self.buf, i)) }
@@ -124,9 +135,21 @@ pub fn Vec(comptime T: type) -> type {
             self.len = self.len + 1;
         }
 
-        // Remove and return the last element, or `default` when empty. (The
-        // `Option(T)`-returning `pop` of ADR-0041 is blocked today; this is the
-        // Copy-typed stand-in.)
+        // Remove and return the last element as `Some(x)`, or `None` when the
+        // vector is empty (ADR-0041).
+        fn pop(inout self) -> Option(T) {
+            let O = Option(T);
+            if self.len == 0 {
+                O::None
+            } else {
+                self.len = self.len - 1;
+                O::Some(checked { @ptr_read(@ptr_offset(self.buf, self.len)) })
+            }
+        }
+
+        // Remove and return the last element, or `default` when empty. An
+        // ergonomic default-based pop for callers that don't want to match on
+        // `Option`.
         fn pop_or(inout self, default: T) -> T {
             if self.len == 0 {
                 default
@@ -155,7 +178,7 @@ pub fn Vec(comptime T: type) -> type {
         // --- teardown ---
 
         // Release the heap buffer and reset to the empty state. Because a
-        // generic anonymous struct cannot yet carry a `drop fn` (E0417), this
+        // generic anonymous struct cannot yet carry a `drop fn` (RUE-312), this
         // must be called explicitly to avoid leaking the buffer.
         fn free(inout self) {
             checked { @free(self.buf, self.cap); };

--- a/examples/std/vec_demo.rue
+++ b/examples/std/vec_demo.rue
@@ -1,14 +1,16 @@
 // Dogfood for the source-level Vec(T) library (examples/std/vec.rue, RUE-1).
 //
-// Compile (multi-file; names resolve across the listed files):
-//   rue examples/std/vec_demo.rue examples/std/vec.rue \
-//       --preview method_receivers -o vec_demo
+// Compile (flat multi-file namespace; names resolve across the listed files,
+// and Vec's `get`/`pop` return `Option(T)` from option.rue):
+//   rue examples/std/vec_demo.rue examples/std/vec.rue examples/std/option.rue \
+//       -o vec_demo
 //
-// Exercises push/len/get/set/pop/while-sum/out-of-bounds on a Vec(i32).
+// Exercises push/len/get/set/pop/while-sum/out-of-bounds on a Vec(i32), with
+// the `Option(T)`-returning accessors (RUE-313).
 
 fn main() -> i32 {
-    let m = @import("vec.rue");
-    let V = m.Vec(i32);
+    let V = Vec(i32);
+    let O = Option(i32);
 
     let mut v = V::new();
     v.push(10);
@@ -16,20 +18,23 @@ fn main() -> i32 {
     v.push(30);
     @dbg(v.len());          // 3
 
-    @dbg(v.get(1));         // 20
+    // `get` returns Option(i32): Some in bounds, None otherwise.
+    @dbg(match v.get(1) { O::Some(x) => x, O::None => -1 });   // 20
     v.set(0, 99);
-    @dbg(v.get(0));         // 99
+    @dbg(match v.get(0) { O::Some(x) => x, O::None => -1 });   // 99
 
-    @dbg(v.pop_or(0));      // 30 (removed)
+    // `pop` returns Option(i32): Some(last) or None when empty.
+    @dbg(match v.pop() { O::Some(x) => x, O::None => -1 });    // 30 (removed)
     @dbg(v.len());          // 2
 
-    @dbg(v.get_or(99, 0));  // 0  (out-of-bounds -> default)
+    @dbg(match v.get(99) { O::Some(x) => x, O::None => -1 });  // -1 (out of bounds)
 
     // Sum the remaining elements with a manual while loop (no for/index sugar).
+    // `get_or` is the ergonomic default-based read used inside the loop.
     let mut i: u64 = 0;
     let mut sum: i32 = 0;
     while i < v.len() {
-        sum = sum + v.get(i);
+        sum = sum + v.get_or(i, 0);
         i = i + 1;
     }
     @dbg(sum);              // 99 + 20 = 119


### PR DESCRIPTION
A '-> type' constructor's comptime type substitution (e.g. T becomes i32 for Vec(i32)) was applied to field/method SIGNATURES but never to method BODIES, so a T-typed local or Option(T) inside a body failed with E0204 'unknown type T'. Fix threads the per-instantiation subst (new anon_struct_type_subst map keyed by StructId) into analyze_method_body, so the enclosing T resolves throughout the struct body including method bodies at each monomorphization.

Vec's get/pop now return real Option(T) instead of copy+default. Verified: Box(i32) with a T-typed body local returns 42; vec_demo (get/pop as Option(T)) prints 3/20/99/30/2/-1/119 (the -1 is the Option::None out-of-bounds path). examples/std/vec.rue + vec_demo.rue updated (flat multi-file namespace; header comment updated).

clippy-gate-passed; test.sh Pass 24; oracle 0 disagreements over 300 seeds.

Note: RUE-312 (drop fn on a comptime-fn anon struct) NOT landed — drop fn there doesn't even parse (E0100), a feature spanning rue-parser + rue-rir + rue-cfg; left open with a plan.

Fixes RUE-313

Generated with Claude Code