### PR TITLE
Buck2 remote build cache scaffolding: BuildBuddy cache-only (RUE-316)

### DIFF
--- a/.buckconfig.local.example
+++ b/.buckconfig.local.example
@@ -1,0 +1,28 @@
+# BuildBuddy remote build cache — opt-in local config (RUE-316).
+#
+# Copy this file to `.buckconfig.local` (gitignored) and paste your BuildBuddy
+# API key. buck2 reads `.buckconfig.local` automatically and layers it over
+# `.buckconfig`, so the shared config stays cache-agnostic — nobody without a key
+# is affected.
+#
+#   cp .buckconfig.local.example .buckconfig.local
+#   # then replace <YOUR_BUILDBUDDY_API_KEY> below
+#
+# Get the key from https://app.buildbuddy.io (Settings -> API keys). CI reads the
+# same key from the BUILDBUDDY_API_KEY repo secret instead of this file.
+#
+# This is CACHE-ONLY: actions execute locally, only the action cache + CAS are
+# remote (so it can't affect build correctness, only speed). The remote cache
+# persists across daemon restarts and machines — which the local OSS buck2 cache
+# does not (see .github/workflows/ci.yml).
+
+[buck2_re_client]
+engine_address = remote.buildbuddy.io
+action_cache_address = remote.buildbuddy.io
+cas_address = remote.buildbuddy.io
+tls = true
+http_headers = x-buildbuddy-api-key:<YOUR_BUILDBUDDY_API_KEY>
+
+[build]
+# Route execution through the cache-only platform (local exec + remote cache).
+execution_platforms = root//platforms:remote_cache

--- a/.github/workflows/cache-probe.yml
+++ b/.github/workflows/cache-probe.yml
@@ -1,0 +1,66 @@
+name: Cache probe
+
+# Validates + measures the BuildBuddy remote cache (RUE-316). Non-blocking:
+# never gates a merge. Run manually with `gh workflow run cache-probe.yml`
+# (on a repo that has the BUILDBUDDY_API_KEY secret). It does a cold build,
+# then clears the local buck-out and rebuilds — the second build should show
+# remote cache hits in buck2's "Commands:" line.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install dotslash
+        uses: facebook/install-dotslash@v2
+
+      - name: Guard — secret present
+        env:
+          KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if [ -z "$KEY" ]; then
+            echo "::error::BUILDBUDDY_API_KEY secret is not set on this repo — nothing to probe."
+            exit 1
+          fi
+
+      - name: Write .buckconfig.local from the secret
+        env:
+          KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          cat > .buckconfig.local <<EOF
+          [buck2_re_client]
+          engine_address = remote.buildbuddy.io
+          action_cache_address = remote.buildbuddy.io
+          cas_address = remote.buildbuddy.io
+          tls = true
+          http_headers = x-buildbuddy-api-key:${KEY}
+
+          [build]
+          execution_platforms = root//platforms:remote_cache
+          EOF
+          echo "wrote .buckconfig.local (key redacted)"
+
+      - name: Cold build (populates the remote cache)
+        run: |
+          /usr/bin/time -v ./buck2 build //crates/rue:rue 2>&1 | tee cold.log | tail -3
+
+      - name: Clear local buck-out, rebuild (should hit the remote cache)
+        run: |
+          ./buck2 clean
+          /usr/bin/time -v ./buck2 build //crates/rue:rue 2>&1 | tee warm.log | tail -3
+
+      - name: Cache-hit summary
+        if: always()
+        run: |
+          echo "### Remote cache probe" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "COLD: $(grep -oE 'Commands: .*' cold.log | tail -1)" >> "$GITHUB_STEP_SUMMARY"
+          echo "WARM: $(grep -oE 'Commands: .*' warm.log | tail -1)" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "A non-zero 'cached'/'remote' count on WARM means the remote cache is working."

--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ third-party/.cargo/.global-cache/
 
 # Stable symlink to the built rue binary (scripts/rue-bin)
 /bin/
+
+# BuildBuddy remote cache local config (RUE-316) — holds the API key, never committed
+.buckconfig.local

--- a/docs/process/build-cache.md
+++ b/docs/process/build-cache.md
@@ -1,0 +1,43 @@
+# Remote build cache (BuildBuddy)
+
+Buck2 rebuilds everything from scratch in each `buck-out`, and OSS buck2 has **no
+persistent action cache across daemon restarts** (noted in `ci.yml`). That means
+every CI run and every isolated worktree rebuilds unchanged crates. A remote
+action cache fixes both. We use **BuildBuddy** (free tier), **cache-only**: actions
+still execute locally, only the action cache + CAS are remote — so it can only
+affect *speed*, never correctness (a bad entry is at worst a cache miss's worth of
+wrong; local execution is the source of truth for anything not already cached).
+
+Tracking: RUE-316.
+
+## Local dev
+
+```bash
+cp .buckconfig.local.example .buckconfig.local
+# paste your key (https://app.buildbuddy.io -> Settings -> API keys) into the
+# x-buildbuddy-api-key line
+```
+
+`.buckconfig.local` is gitignored (holds the key) and buck2 layers it over
+`.buckconfig` automatically. It sets `[buck2_re_client]` (pointed at
+`remote.buildbuddy.io`) and routes execution through `root//platforms:remote_cache`
+(local execution + remote cache). Without the file, nothing changes — the shared
+config stays cache-agnostic.
+
+## CI
+
+CI reads the key from the `BUILDBUDDY_API_KEY` repo secret (never from a file).
+The `cache-probe` workflow (`.github/workflows/cache-probe.yml`) writes a
+transient `.buckconfig.local` from the secret, does a cold build then a
+clean-and-rebuild, and reports buck2's `Commands: (cached / remote / local)`
+line — the second build should show remote hits. Run it with
+`gh workflow run cache-probe.yml` on a repo that has the secret. Once it's proven
+green with real hit-rates, the cache config can be promoted into the main build
+and test jobs.
+
+## Why cache-only, not remote execution
+
+Remote *execution* (offloading compiles to the cloud) needs hermetic actions +
+platform matching, and our toolchains-as-a-separate-cell setup already made
+configuration subtle (RUE-277). Cache-only gets most of the win (skip unchanged
+rebuilds) with none of that risk. Revisit RE later if the cache proves out.

--- a/platforms/BUCK
+++ b/platforms/BUCK
@@ -1,3 +1,5 @@
+load(":remote_cache.bzl", "remote_cache_platform")
+
 # Build-mode target platforms (RUE-277)
 #
 # These platforms put the //constraints:opt-level value into the *target
@@ -32,5 +34,12 @@ platform(
     name = "release",
     constraint_values = ["//constraints:release"],
     deps = ["prelude//platforms:default"],
+    visibility = ["PUBLIC"],
+)
+
+# Cache-only EXECUTION platform (RUE-316) — opt-in via .buckconfig.local.
+# Unused by default; select with `[build] execution_platforms = root//platforms:remote_cache`.
+remote_cache_platform(
+    name = "remote_cache",
     visibility = ["PUBLIC"],
 )

--- a/platforms/remote_cache.bzl
+++ b/platforms/remote_cache.bzl
@@ -1,0 +1,40 @@
+# Cache-only execution platform (RUE-316).
+#
+# Same as the default execution platform (local execution), but with the remote
+# ACTION CACHE + CAS enabled — so unchanged actions are served from BuildBuddy
+# instead of rebuilt, while actions still *execute* locally (no remote execution
+# offload). Opt-in: nothing uses this unless `.buckconfig.local` sets
+# `[build] execution_platforms = root//platforms:remote_cache` (see
+# .buckconfig.local.example).
+#
+# remote_enabled=False + remote_cache_enabled=True is the cache-only combination:
+# reads/writes the remote cache, never dispatches execution remotely. That keeps
+# it correctness-neutral (a stale/poisoned entry can only ever be a cache miss's
+# worth of wrong; local execution is always the source of truth for new actions).
+
+def _remote_cache_platform_impl(ctx):
+    return [
+        DefaultInfo(),
+        ExecutionPlatformRegistrationInfo(
+            platforms = [
+                ExecutionPlatformInfo(
+                    label = ctx.label.raw_target(),
+                    configuration = ConfigurationInfo(constraints = {}, values = {}),
+                    executor_config = CommandExecutorConfig(
+                        local_enabled = True,
+                        remote_enabled = False,
+                        remote_cache_enabled = True,
+                        remote_execution_use_case = "buck2-default",
+                        remote_output_paths = "output_paths",
+                        remote_execution_properties = {},
+                        use_limited_hybrid = False,
+                    ),
+                ),
+            ],
+        ),
+    ]
+
+remote_cache_platform = rule(
+    impl = _remote_cache_platform_impl,
+    attrs = {},
+)


### PR DESCRIPTION
Opt-in remote action cache via BuildBuddy (free tier), cache-only (local execution + remote cache — correctness-neutral). Fixes the redundant rebuilds: OSS buck2 has no persistent action cache across daemon restarts (per ci.yml), so every CI run + isolated worktree rebuilds unchanged crates from scratch.

- **platforms/remote_cache.bzl** + //platforms:remote_cache: a cache-only execution platform (local_enabled + remote_cache_enabled, remote_enabled=False). Validated: it parses/analyzes and the default build is unchanged (opt-in — nobody without a key is affected).
- **.buckconfig.local.example**: dev template -> .buckconfig.local (gitignored, holds the key), layered over .buckconfig.
- **.github/workflows/cache-probe.yml**: non-blocking workflow_dispatch job — writes .buckconfig.local from the BUILDBUDDY_API_KEY secret, cold build then clean+rebuild, reports buck2's cached/remote/local counts (warm build should show remote hits).
- **docs/process/build-cache.md**.

Next: validate real hit-rates (locally with a key, or the probe on a repo with the secret), then promote the cache into the main build/test jobs. The exact CommandExecutorConfig cache knobs may need a tweak once measured against a live key.

Part of RUE-316

Generated with Claude Code