### PR TITLE
Error handling: @read_line and @parse_* return Option instead of trapping (part of RUE-6)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -984,17 +984,14 @@ impl<'a> ConstraintGenerator<'a> {
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
                 } else if intrinsic_name == "read_line" {
-                    // @read_line: returns String (same as string constants)
-                    if let Some(string_spur) = self.interner.get("String") {
-                        if let Some(&string_ty) = self.structs.get(&string_spur) {
-                            InferType::Concrete(string_ty)
-                        } else {
-                            // Fallback if String struct not found
-                            InferType::Concrete(Type::ERROR)
-                        }
-                    } else {
-                        InferType::Concrete(Type::ERROR)
-                    }
+                    // @read_line: returns `Option(String)` (RUE-6, ADR-0038).
+                    // The concrete Option type comes from context (a `let`
+                    // annotation or the match arms the result feeds), so use a
+                    // fresh variable and let unification resolve it — mirroring
+                    // @intCast/@cast. Sema validates the resolved type is an
+                    // Option-shaped enum over String.
+                    let result_var = self.fresh_var();
+                    InferType::Var(result_var)
                 } else if intrinsic_name == "to_string" {
                     // @to_string(n): takes an i64, returns String (RUE-17
                     // Phase 1, ADR-0035). Constrain the argument to i64 so a
@@ -1008,30 +1005,20 @@ impl<'a> ConstraintGenerator<'a> {
                         ));
                     }
                     self.string_infer_type()
-                } else if intrinsic_name == "parse_i32" {
-                    // @parse_i32: takes a String, returns i32
+                } else if intrinsic_name == "parse_i32"
+                    || intrinsic_name == "parse_i64"
+                    || intrinsic_name == "parse_u32"
+                    || intrinsic_name == "parse_u64"
+                {
+                    // @parse_*: takes a String, returns `Option(int)` (RUE-6,
+                    // ADR-0038). The concrete Option type (and thus the payload
+                    // int type) is resolved from context, so use a fresh
+                    // variable and let sema validate the resolved Option shape.
                     for arg_ref in args.iter() {
                         self.generate(*arg_ref, ctx);
                     }
-                    InferType::Concrete(Type::I32)
-                } else if intrinsic_name == "parse_i64" {
-                    // @parse_i64: takes a String, returns i64
-                    for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
-                    }
-                    InferType::Concrete(Type::I64)
-                } else if intrinsic_name == "parse_u32" {
-                    // @parse_u32: takes a String, returns u32
-                    for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
-                    }
-                    InferType::Concrete(Type::U32)
-                } else if intrinsic_name == "parse_u64" {
-                    // @parse_u64: takes a String, returns u64
-                    for arg_ref in args.iter() {
-                        self.generate(*arg_ref, ctx);
-                    }
-                    InferType::Concrete(Type::U64)
+                    let result_var = self.fresh_var();
+                    InferType::Var(result_var)
                 } else if intrinsic_name == "random_u32" {
                     // @random_u32: no arguments, returns u32
                     InferType::Concrete(Type::U32)

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1763,6 +1763,7 @@ impl<'a> Sema<'a> {
             byref_arg_root: None,
             in_loop_move_recheck: false,
             iter_borrows: Vec::new(),
+            expected_type: None,
         };
 
         // ======================================================================
@@ -3663,11 +3664,11 @@ impl<'a> Sema<'a> {
         } else if name == known.test_preview_gate {
             self.analyze_test_preview_gate_intrinsic(air, &args, span)
         } else if name == known.read_line {
-            self.analyze_read_line_intrinsic(air, name, &args, span)
+            self.analyze_read_line_intrinsic(air, name, inst_ref, &args, span, ctx)
         } else if name == known.to_string {
             self.analyze_to_string_intrinsic(air, &args, span, ctx)
         } else if let Some(intrinsic_name_str) = known.get_parse_intrinsic_name(name) {
-            self.analyze_parse_intrinsic(air, name, intrinsic_name_str, &args, span, ctx)
+            self.analyze_parse_intrinsic(air, name, inst_ref, intrinsic_name_str, &args, span, ctx)
         } else if name == known.cast {
             self.analyze_cast_intrinsic(air, inst_ref, &args, span, ctx)
         } else if name == known.panic {
@@ -4300,16 +4301,94 @@ impl<'a> Sema<'a> {
         Ok(AnalysisResult::new(air_ref, Type::UNIT))
     }
 
+    /// Validate that inference resolved a fallible intrinsic's result to an
+    /// `Option`-shaped enum whose `Some` variant carries `expected_payload` and
+    /// whose `None` variant is empty, and return that enum type.
+    ///
+    /// This is how `@read_line` / `@parse_*` obtain the concrete library
+    /// `Option` from context (RUE-6, ADR-0038): the intrinsic's return unifies
+    /// with the in-scope `Option(T)` (a `let` annotation, or the match arms the
+    /// result feeds), so no new "blessed builtin" tier is introduced — the
+    /// ordinary comptime-generic `Option` enum is used. The runtime signals
+    /// success/failure and codegen fills in this enum's discriminant + payload.
+    fn resolve_option_result_type(
+        &self,
+        ctx: &AnalysisContext,
+        inst_ref: InstRef,
+        expected_payload: Type,
+        intrinsic_display: &str,
+        payload_display: &str,
+        span: Span,
+    ) -> CompileResult<Type> {
+        // Prefer the sema-supplied expected type (a let annotation or match
+        // scrutinee pattern), which is how the concrete comptime-generic
+        // `Option` reaches us. Without one, there is no context to infer the
+        // Option type from — report that plainly rather than letting an
+        // unresolved inference variable decay to `<error>` (E9000).
+        let (ty, from_expected) = match ctx.expected_type {
+            Some(ty) => (ty, true),
+            None => (
+                Self::get_resolved_type(ctx, inst_ref, span, intrinsic_display)?,
+                false,
+            ),
+        };
+
+        // A bad annotation/pattern already produced its own diagnostic and
+        // poisoned the expected type to `error`; do not cascade a second one.
+        if from_expected && ty.is_error() {
+            return Ok(ty);
+        }
+
+        let valid = if let TypeKind::Enum(enum_id) = ty.kind() {
+            let def = self.type_pool.enum_def(enum_id);
+            match (def.find_variant("Some"), def.find_variant("None")) {
+                (Some(si), Some(ni)) if def.variant_count() == 2 => {
+                    let some_payload = def.variant_payload(si);
+                    let none_payload = def.variant_payload(ni);
+                    some_payload.len() == 1
+                        && some_payload[0] == expected_payload
+                        && none_payload.is_empty()
+                }
+                _ => false,
+            }
+        } else {
+            false
+        };
+
+        if !valid {
+            // With no context at all the resolved type is `<error>`; point the
+            // user at the fix instead of printing the placeholder.
+            let found = if ty.is_error() {
+                "no expected type — annotate the binding or `match` on the result".to_string()
+            } else {
+                ty.safe_name_with_pool(Some(&self.type_pool))
+            };
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
+                    name: intrinsic_display.to_string(),
+                    expected: format!("Option({payload_display})"),
+                    found,
+                })),
+                span,
+            ));
+        }
+
+        Ok(ty)
+    }
+
     /// Analyze @read_line intrinsic.
     fn analyze_read_line_intrinsic(
         &mut self,
         air: &mut Air,
         name: Spur,
+        inst_ref: InstRef,
         args: &[RirCallArg],
         span: Span,
+        ctx: &AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        // @read_line() - reads a line from stdin and returns it as a String.
-        // Takes no arguments, returns String.
+        // @read_line() - reads a line from stdin. Takes no arguments and
+        // returns `Option(String)`: `Some(line)` normally, `None` at EOF
+        // (RUE-6, ADR-0038). The concrete Option type is taken from context.
         if !args.is_empty() {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicWrongArgCount {
@@ -4321,20 +4400,28 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        // Get the String type
         let string_type = self.builtin_string_type();
+        let option_ty = self.resolve_option_result_type(
+            ctx,
+            inst_ref,
+            string_type,
+            "read_line",
+            "String",
+            span,
+        )?;
 
-        // Create the intrinsic instruction that returns String
+        // The intrinsic lowers to a runtime call whose result codegen packs
+        // into this `Option(String)` enum (discriminant + String payload).
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
                 name,
                 args_start: 0, // No args
                 args_len: 0,
             },
-            ty: string_type,
+            ty: option_ty,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, string_type))
+        Ok(AnalysisResult::new(air_ref, option_ty))
     }
 
     /// Analyze the `@to_string(n)` intrinsic (RUE-17 Phase 1, ADR-0035).
@@ -4405,6 +4492,7 @@ impl<'a> Sema<'a> {
         &mut self,
         air: &mut Air,
         name: Spur,
+        inst_ref: InstRef,
         intrinsic_name_str: &str,
         args: &[RirCallArg],
         span: Span,
@@ -4439,14 +4527,26 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        // Determine the return type based on the intrinsic name
-        let return_type = match intrinsic_name_str {
-            "parse_i32" => Type::I32,
-            "parse_i64" => Type::I64,
-            "parse_u32" => Type::U32,
-            "parse_u64" => Type::U64,
+        // Determine the payload integer type based on the intrinsic name.
+        let (payload_type, payload_display) = match intrinsic_name_str {
+            "parse_i32" => (Type::I32, "i32"),
+            "parse_i64" => (Type::I64, "i64"),
+            "parse_u32" => (Type::U32, "u32"),
+            "parse_u64" => (Type::U64, "u64"),
             _ => unreachable!(),
         };
+
+        // The result is `Option(int)`: `Some(n)` on success, `None` on parse
+        // failure (RUE-6, ADR-0038). The concrete Option type comes from
+        // context and is validated to carry the matching integer payload.
+        let option_ty = self.resolve_option_result_type(
+            ctx,
+            inst_ref,
+            payload_type,
+            intrinsic_name_str,
+            payload_display,
+            span,
+        )?;
 
         // Encode args into extra array
         let args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
@@ -4456,10 +4556,10 @@ impl<'a> Sema<'a> {
                 args_start,
                 args_len: 1,
             },
-            ty: return_type,
+            ty: option_ty,
             span,
         });
-        Ok(AnalysisResult::new(air_ref, return_type))
+        Ok(AnalysisResult::new(air_ref, option_ty))
     }
 
     /// Analyze @random_u32 intrinsic.

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -1198,8 +1198,30 @@ impl<'a> Sema<'a> {
             }
         }
 
+        // Derive the expected scrutinee type from the arm patterns, so a
+        // fallible-intrinsic scrutinee learns which in-scope `Option(T)` to
+        // return (`match @read_line() { Option::Some(l) => .., Option::None =>
+        // .. }`, RUE-6). Only sema resolves the comptime-generic `Option`
+        // alias the pattern names, so we resolve the first enum pattern's type
+        // here and expose it while the scrutinee is analyzed. Resolution errors
+        // are ignored — pattern legality is checked on the normal path below.
+        let arms_for_expected = self.rir.get_match_arms(arms_start, arms_len);
+        let expected_scrutinee = arms_for_expected.iter().find_map(|(pattern, _)| {
+            if let RirPattern::Path { type_name, .. } = pattern {
+                self.resolve_type_with_ctx(*type_name, span, ctx)
+                    .ok()
+                    .filter(|ty| ty.is_enum())
+            } else {
+                None
+            }
+        });
+        let prev_expected = ctx.expected_type.take();
+        ctx.expected_type = expected_scrutinee;
+
         // Analyze the scrutinee to determine its type
-        let scrutinee_result = self.analyze_inst(air, scrutinee, ctx)?;
+        let scrutinee_outcome = self.analyze_inst(air, scrutinee, ctx);
+        ctx.expected_type = prev_expected;
+        let scrutinee_result = scrutinee_outcome?;
         let scrutinee_type = scrutinee_result.ty;
 
         // Validate that we can match on this type (integers, booleans, and enums)
@@ -2040,8 +2062,22 @@ impl<'a> Sema<'a> {
         // through `resolve_type_with_ctx`, which consults those local comptime
         // bindings at every level of a composite annotation — a scalar `P`, and
         // an inner element/pointee of `[P; 2]` / `ptr const P` alike (RUE-263).
-        if let Some(ty_sym) = ty {
-            self.resolve_type_with_ctx(ty_sym, span, ctx)?;
+        let annotation_type = if let Some(ty_sym) = ty {
+            Some(self.resolve_type_with_ctx(ty_sym, span, ctx)?)
+        } else {
+            None
+        };
+
+        // A resolved enum annotation is the expected type for the initializer.
+        // This is how a fallible intrinsic learns its `Option(T)` return from a
+        // `let x: Option(T) = @read_line()` annotation (RUE-6): only sema can
+        // resolve the comptime-generic `Option` alias, so inference cannot
+        // thread it. Narrow to enums so unrelated `let`s are unaffected.
+        let prev_expected = ctx.expected_type.take();
+        if let Some(annot) = annotation_type {
+            if annot.is_enum() {
+                ctx.expected_type = Some(annot);
+            }
         }
 
         // Analyze the initializer. A `for`-loop element binding is a shared
@@ -2051,15 +2087,19 @@ impl<'a> Sema<'a> {
         // (RUE-259), exactly as a `borrow`-mode argument would be. The root is
         // the collection variable (`a` in `a[__p]`); a `.chars()` scalar read
         // has no place root, so this is a no-op there.
-        let init_result = if iter_elem {
+        let init_outcome = if iter_elem {
             let byref_root = super::analysis::root_variable_of(self.rir, init);
             let prev = std::mem::replace(&mut ctx.byref_arg_root, byref_root);
             let r = self.analyze_inst(air, init, ctx);
             ctx.byref_arg_root = prev;
-            r?
+            r
         } else {
-            self.analyze_inst(air, init, ctx)?
+            self.analyze_inst(air, init, ctx)
         };
+        // Restore the previous expected type before propagating any error so it
+        // never leaks into a sibling statement.
+        ctx.expected_type = prev_expected;
+        let init_result = init_outcome?;
         let var_type = init_result.ty;
 
         // If name is None, this is a wildcard pattern `_` that discards the value.

--- a/crates/rue-air/src/sema/context.rs
+++ b/crates/rue-air/src/sema/context.rs
@@ -393,6 +393,15 @@ pub(crate) struct AnalysisContext<'a> {
     /// the treatment of an explicit `borrow` parameter. Reads (including the
     /// loop's own element reads) are permitted.
     pub iter_borrows: Vec<Spur>,
+    /// The type this expression is expected to produce, when sema knows it from
+    /// a surrounding annotation or pattern. Set narrowly around a
+    /// let-initializer (to the resolved annotation type) and around a `match`
+    /// scrutinee (to the enum named by the arm patterns). The fallible
+    /// intrinsics (`@read_line`, `@parse_*`) read this to learn which in-scope
+    /// `Option(T)` to return (RUE-6, ADR-0038) — inference cannot supply it
+    /// because comptime-generic library enums are resolved only in sema. Left
+    /// `None` everywhere else, so no other analysis is affected.
+    pub expected_type: Option<Type>,
 }
 
 // Import InstRef for use in resolved_types
@@ -469,6 +478,7 @@ impl<'a> AnalysisContext<'a> {
             byref_arg_root: None,
             in_loop_move_recheck: true,
             iter_borrows: self.iter_borrows.clone(),
+            expected_type: None,
         }
     }
 

--- a/crates/rue-cli-tests/cases/first_program.toml
+++ b/crates/rue-cli-tests/cases/first_program.toml
@@ -1,39 +1,53 @@
 # The first real Rue program (RUE-226 dogfooding milestone): examples/first/stats.rue.
-# Reads a count N, then N integers, and prints count/sum/max. Regression-locks the
-# whole freshly-stabilized dogfooding set working together end to end, including the
-# generic Option imported from the std library (no prelude yet, so it's imported).
+# A natural read-until-EOF loop (no count prefix) — reads integers one per line
+# until end-of-input and prints count/sum/max. Regression-locks the dogfooding
+# set working together end to end now that error handling has landed (RUE-6,
+# ADR-0038): @read_line returns Option(String) (None at EOF) and @parse_i64
+# returns Option(i64) (None on a non-numeric line) instead of trapping, so the
+# loop terminates on EOF and skips unparseable lines. The generic Option is
+# imported from the std library (no prelude yet).
 
 [section]
 id = "cli.first_program"
 name = "First dogfood program (stats)"
-description = "count-prefixed integers -> count/sum/max via @read_line, @parse_i64, an imported generic Option, and println."
+description = "read-until-EOF integers -> count/sum/max via @read_line/@parse_i64 returning Option, an imported generic Option, and println."
 
 [[case]]
-name = "stats_three_numbers"
+name = "stats_read_until_eof"
 files = [
   { path = "stats.rue", source = """
 fn main() -> i32 {
-    let Opt = @import("option.rue").Option(i64);
-    let n = @parse_i64(@read_line());
-    let mut i: i64 = 0;
+    let OptStr = @import("option.rue").Option(String);
+    let OptInt = @import("option.rue").Option(i64);
+    let mut count: i64 = 0;
     let mut sum: i64 = 0;
-    let mut max: Opt = Opt::None;
-    while i < n {
-        let x = @parse_i64(@read_line());
-        sum = sum + x;
-        max = match max {
-            Opt::None => Opt::Some(x),
-            Opt::Some(m) => if x > m { Opt::Some(x) } else { Opt::Some(m) },
-        };
-        i = i + 1;
+    let mut max: OptInt = OptInt::None;
+    loop {
+        let line: OptStr = @read_line();
+        match line {
+            OptStr::None => break,
+            OptStr::Some(text) => {
+                match @parse_i64(text) {
+                    OptInt::Some(x) => {
+                        count = count + 1;
+                        sum = sum + x;
+                        max = match max {
+                            OptInt::None => OptInt::Some(x),
+                            OptInt::Some(m) => if x > m { OptInt::Some(x) } else { OptInt::Some(m) },
+                        };
+                    },
+                    OptInt::None => {},
+                }
+            },
+        }
     }
-    println("count: " + @to_string(n));
+    println("count: " + @to_string(count));
     println("sum: " + @to_string(sum));
     match max {
-        Opt::Some(m) => println("max: " + @to_string(m)),
-        Opt::None => println("max: (no input)"),
+        OptInt::Some(m) => println("max: " + @to_string(m)),
+        OptInt::None => println("max: (no input)"),
     }
-    @intCast(n)
+    @intCast(count)
 }
 """ },
   { path = "option.rue", source = """
@@ -43,10 +57,120 @@ pub fn Option(comptime T: type) -> type {
 """ },
 ]
 args = ["stats.rue", "option.rue", "-o", "prog"]
-stdin = "3\n7\n5\n1\n"
+stdin = "7\n5\n1\n"
 stdout = """
 count: 3
 sum: 13
 max: 7
 """
 exit_code = 3
+
+# A non-numeric line in the middle is skipped (parse -> None), not fatal, and
+# EOF ends the loop cleanly. Proves the recoverable error model end to end.
+[[case]]
+name = "stats_skips_bad_lines"
+files = [
+  { path = "stats.rue", source = """
+fn main() -> i32 {
+    let OptStr = @import("option.rue").Option(String);
+    let OptInt = @import("option.rue").Option(i64);
+    let mut count: i64 = 0;
+    let mut sum: i64 = 0;
+    let mut max: OptInt = OptInt::None;
+    loop {
+        let line: OptStr = @read_line();
+        match line {
+            OptStr::None => break,
+            OptStr::Some(text) => {
+                match @parse_i64(text) {
+                    OptInt::Some(x) => {
+                        count = count + 1;
+                        sum = sum + x;
+                        max = match max {
+                            OptInt::None => OptInt::Some(x),
+                            OptInt::Some(m) => if x > m { OptInt::Some(x) } else { OptInt::Some(m) },
+                        };
+                    },
+                    OptInt::None => {},
+                }
+            },
+        }
+    }
+    println("count: " + @to_string(count));
+    println("sum: " + @to_string(sum));
+    match max {
+        OptInt::Some(m) => println("max: " + @to_string(m)),
+        OptInt::None => println("max: (no input)"),
+    }
+    @intCast(count)
+}
+""" },
+  { path = "option.rue", source = """
+pub fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+""" },
+]
+args = ["stats.rue", "option.rue", "-o", "prog"]
+stdin = "10\nnot a number\n20\n"
+stdout = """
+count: 2
+sum: 30
+max: 20
+"""
+exit_code = 2
+
+# Empty input (immediate EOF): the loop never enters, no trap. Before RUE-6 the
+# first @read_line would have aborted with exit 101; now it is `None`.
+[[case]]
+name = "stats_empty_input_no_trap"
+files = [
+  { path = "stats.rue", source = """
+fn main() -> i32 {
+    let OptStr = @import("option.rue").Option(String);
+    let OptInt = @import("option.rue").Option(i64);
+    let mut count: i64 = 0;
+    let mut sum: i64 = 0;
+    let mut max: OptInt = OptInt::None;
+    loop {
+        let line: OptStr = @read_line();
+        match line {
+            OptStr::None => break,
+            OptStr::Some(text) => {
+                match @parse_i64(text) {
+                    OptInt::Some(x) => {
+                        count = count + 1;
+                        sum = sum + x;
+                        max = match max {
+                            OptInt::None => OptInt::Some(x),
+                            OptInt::Some(m) => if x > m { OptInt::Some(x) } else { OptInt::Some(m) },
+                        };
+                    },
+                    OptInt::None => {},
+                }
+            },
+        }
+    }
+    println("count: " + @to_string(count));
+    println("sum: " + @to_string(sum));
+    match max {
+        OptInt::Some(m) => println("max: " + @to_string(m)),
+        OptInt::None => println("max: (no input)"),
+    }
+    @intCast(count)
+}
+""" },
+  { path = "option.rue", source = """
+pub fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+""" },
+]
+args = ["stats.rue", "option.rue", "-o", "prog"]
+stdin = ""
+stdout = """
+count: 0
+sum: 0
+max: (no input)
+"""
+exit_code = 0

--- a/crates/rue-cli-tests/cases/programs.toml
+++ b/crates/rue-cli-tests/cases/programs.toml
@@ -127,17 +127,28 @@ Hello
 
 [[case]]
 name = "string_equality_branches"
-files = [{ path = "main.rue", source = """
+files = [
+  { path = "main.rue", source = """
 fn main() -> i32 {
-    let answer = @read_line();
-    if answer == "yes" {
-        @dbg("affirmative");
-    } else {
-        @dbg("negative");
+    let OptStr = @import("opt.rue").Option(String);
+    match @read_line() {
+        OptStr::Some(answer) => {
+            if answer == "yes" {
+                @dbg("affirmative");
+            } else {
+                @dbg("negative");
+            }
+        },
+        OptStr::None => {},
     }
     0
 }
-""" }]
+""" },
+  { path = "opt.rue", source = """
+pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
+""" },
+]
+args = ["main.rue", "opt.rue", "-o", "prog"]
 stdin = "yes"
 stdout = "affirmative\n"
 

--- a/crates/rue-cli-tests/cases/stdin.toml
+++ b/crates/rue-cli-tests/cases/stdin.toml
@@ -1,42 +1,81 @@
 # Programs that read stdin: the @read_line / @parse_i32 loop.
+#
+# Since RUE-6 (ADR-0038) these intrinsics are fallible-by-Option, not
+# trapping: @read_line returns Option(String) (None at EOF) and @parse_* return
+# Option(int) (None on bad input). The concrete Option is imported from a small
+# local module (no prelude yet) and threaded via a `let` annotation or the
+# match arms.
 
 [section]
 id = "cli.stdin"
 name = "Standard input interaction"
-description = "Piping input to compiled programs; current panic behavior on bad input."
+description = "Piping input to compiled programs; recoverable Option-based read/parse."
 
 [[case]]
 name = "read_and_echo_number"
-files = [{ path = "main.rue", source = """
+files = [
+  { path = "main.rue", source = """
 fn main() -> i32 {
-    let line = @read_line();
-    let n = @parse_i32(line);
-    @dbg(n);
+    let OptStr = @import("opt.rue").Option(String);
+    let OptInt = @import("opt.rue").Option(i32);
+    let line: OptStr = @read_line();
+    match line {
+        OptStr::Some(text) => {
+            match @parse_i32(text) {
+                OptInt::Some(n) => { @dbg(n); },
+                OptInt::None => {},
+            }
+        },
+        OptStr::None => {},
+    }
     0
 }
-""" }]
+""" },
+  { path = "opt.rue", source = """
+pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
+""" },
+]
+args = ["main.rue", "opt.rue", "-o", "prog"]
 stdin = "42\n"
 stdout = "42\n"
 
 [[case]]
 name = "guessing_loop_scripted"
-files = [{ path = "main.rue", source = """
+files = [
+  { path = "main.rue", source = """
 fn main() -> i32 {
+    let OptStr = @import("opt.rue").Option(String);
+    let OptInt = @import("opt.rue").Option(i32);
     let secret = 73;
     loop {
-        let guess = @parse_i32(@read_line());
-        if guess < secret {
-            @dbg("Too low!");
-        } else if guess > secret {
-            @dbg("Too high!");
-        } else {
-            @dbg("You got it!");
-            break;
+        let line: OptStr = @read_line();
+        match line {
+            OptStr::None => break,
+            OptStr::Some(text) => {
+                match @parse_i32(text) {
+                    OptInt::Some(guess) => {
+                        if guess < secret {
+                            @dbg("Too low!");
+                        } else if guess > secret {
+                            @dbg("Too high!");
+                        } else {
+                            @dbg("You got it!");
+                            break;
+                        }
+                    },
+                    OptInt::None => {},
+                }
+            },
         }
     }
     0
 }
-""" }]
+""" },
+  { path = "opt.rue", source = """
+pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
+""" },
+]
+args = ["main.rue", "opt.rue", "-o", "prog"]
 stdin = "50\n90\n73\n"
 stdout = """
 Too low!
@@ -44,30 +83,54 @@ Too high!
 You got it!
 """
 
-# Current behavior: invalid input is an unrecoverable runtime panic.
-# When error handling lands (RUE-6), these tests should change to assert
-# the recoverable behavior instead.
-[[case]]
-name = "parse_error_panics_with_exit_101"
-files = [{ path = "main.rue", source = """
-fn main() -> i32 {
-    let n = @parse_i32(@read_line());
-    @dbg(n);
-    0
-}
-""" }]
-stdin = "banana\n"
-exit_code = 101
-runtime_error_contains = ["parse error"]
+# Recoverable error model (RUE-6, ADR-0038). Before error handling landed these
+# two cases trapped with exit 101 ("parse error" / "unexpected end of input").
+# Now a bad parse is `None` and EOF is `None` — the program chooses what to do.
 
 [[case]]
-name = "read_line_at_eof_panics_with_exit_101"
-files = [{ path = "main.rue", source = """
+name = "parse_error_yields_none"
+files = [
+  { path = "main.rue", source = """
 fn main() -> i32 {
-    let line = @read_line();
-    0
+    let OptStr = @import("opt.rue").Option(String);
+    let OptInt = @import("opt.rue").Option(i32);
+    let line: OptStr = @read_line();
+    match line {
+        OptStr::Some(text) => {
+            match @parse_i32(text) {
+                OptInt::Some(n) => n,
+                OptInt::None => 7,
+            }
+        },
+        OptStr::None => 0,
+    }
 }
-""" }]
+""" },
+  { path = "opt.rue", source = """
+pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
+""" },
+]
+args = ["main.rue", "opt.rue", "-o", "prog"]
+stdin = "banana\n"
+exit_code = 7
+
+[[case]]
+name = "read_line_at_eof_yields_none"
+files = [
+  { path = "main.rue", source = """
+fn main() -> i32 {
+    let OptStr = @import("opt.rue").Option(String);
+    let line: OptStr = @read_line();
+    match line {
+        OptStr::Some(_text) => 1,
+        OptStr::None => 0,
+    }
+}
+""" },
+  { path = "opt.rue", source = """
+pub fn Option(comptime T: type) -> type { enum { Some(T), None } }
+""" },
+]
+args = ["main.rue", "opt.rue", "-o", "prog"]
 stdin = ""
-exit_code = 101
-runtime_error_contains = ["unexpected end of input"]
+exit_code = 0

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -1767,29 +1767,47 @@ impl<'a> CfgLower<'a> {
             } => {
                 let name_str = self.interner.resolve(name);
                 if name_str == "read_line" {
-                    // @read_line() intrinsic - reads a line from stdin and returns String.
-                    // Uses sret convention: allocate space on stack for the result (ptr, len, cap).
+                    // @read_line() intrinsic - reads a line from stdin and
+                    // returns `Option(String)`: `Some(line)` normally, `None`
+                    // at EOF (RUE-6, ADR-0038). The runtime writes the whole
+                    // tagged-union `Option` to an sret buffer laid out as
+                    // [disc, ptr, len, cap] (slot 0 = discriminant, RUE-221);
+                    // we pass the Some/None discriminant values and load the
+                    // slots back. No branch needed — the runtime picks the
+                    // discriminant.
+                    let vty = self.ctx.cfg.get_inst(value).ty;
+                    let (some_disc, none_disc) =
+                        types::option_variant_discriminants(self.ctx.type_pool, vty);
+                    let total_slots = self.ctx.type_slot_count(vty);
+                    let sret_bytes = (total_slots as i32 * 8 + 15) & !15;
 
-                    // Allocate 32 bytes on stack for sret (24 bytes for String + 8 for alignment)
                     self.mir.push(Aarch64Inst::SubImm {
                         dst: Operand::Physical(Reg::Sp),
                         src: Operand::Physical(Reg::Sp),
-                        imm: 32,
+                        imm: sret_bytes,
                     });
 
-                    // Move SP (pointer to sret space) to X0 as first argument
+                    // Args: X0 = out ptr, X1 = some_disc, X2 = none_disc.
                     self.mir.push(Aarch64Inst::MovRR {
                         dst: Operand::Physical(Reg::X0),
                         src: Operand::Physical(Reg::Sp),
+                    });
+                    self.mir.push(Aarch64Inst::MovImm {
+                        dst: Operand::Physical(Reg::X1),
+                        imm: some_disc as i64,
+                    });
+                    self.mir.push(Aarch64Inst::MovImm {
+                        dst: Operand::Physical(Reg::X2),
+                        imm: none_disc as i64,
                     });
 
                     // Call __rue_read_line
                     let symbol_id = self.intern_symbol("__rue_read_line");
                     self.mir.push(Aarch64Inst::Bl { symbol_id });
 
-                    // Load ptr, len, cap from stack into vregs
-                    let mut slot_vregs = Vec::new();
-                    for slot_idx in 0..3 {
+                    // Load the enum's slots (disc, ptr, len, cap) into vregs.
+                    let mut slot_vregs = Vec::with_capacity(total_slots as usize);
+                    for slot_idx in 0..total_slots {
                         let slot_vreg = self.mir.alloc_vreg();
                         let offset = (slot_idx * 8) as i32;
                         self.mir.push(Aarch64Inst::Ldr {
@@ -1804,19 +1822,14 @@ impl<'a> CfgLower<'a> {
                     self.mir.push(Aarch64Inst::AddImm {
                         dst: Operand::Physical(Reg::Sp),
                         src: Operand::Physical(Reg::Sp),
-                        imm: 32,
+                        imm: sret_bytes,
                     });
 
-                    // Store the slot vregs for the String value
-                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
-
-                    // Create a result vreg (for the primary value representation)
-                    let result_vreg = self.mir.alloc_vreg();
-                    self.mir.push(Aarch64Inst::MovRR {
-                        dst: Operand::Virtual(result_vreg),
-                        src: Operand::Virtual(slot_vregs[0]),
-                    });
-                    self.value_map.insert(value, result_vreg);
+                    // Slot 0 (discriminant) is the value's primary vreg, so a
+                    // `match` switches on it directly (like EnumVariant).
+                    let disc_vreg = slot_vregs[0];
+                    self.struct_slot_vregs.insert(value, slot_vregs);
+                    self.value_map.insert(value, disc_vreg);
                 } else if name_str == "dbg" {
                     let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                     let arg_val = args[0];
@@ -1936,9 +1949,19 @@ impl<'a> CfgLower<'a> {
                     || name_str == "parse_u32"
                     || name_str == "parse_u64"
                 {
-                    // @parse_* intrinsics: take a String, return an integer
+                    // @parse_* intrinsics: take a String, return `Option(int)`:
+                    // `Some(n)` on success, `None` on parse failure (RUE-6,
+                    // ADR-0038). The runtime writes the whole tagged-union
+                    // `Option` to an sret buffer laid out as [disc, value]
+                    // (slot 0 = discriminant, RUE-221); we pass ptr/len plus the
+                    // Some/None discriminant values and load the slots back.
                     let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                     let arg_val = args[0];
+                    let vty = self.ctx.cfg.get_inst(value).ty;
+                    let (some_disc, none_disc) =
+                        types::option_variant_discriminants(self.ctx.type_pool, vty);
+                    let total_slots = self.ctx.type_slot_count(vty);
+                    let sret_bytes = (total_slots as i32 * 8 + 15) & !15;
 
                     // Get the String fat pointer (ptr, len, cap) — materialize a String
                     // read from a place (`@parse_i32(h.s)`) as well as cached sources. (RUE-118)
@@ -1946,14 +1969,34 @@ impl<'a> CfgLower<'a> {
                         let ptr_vreg = field_vregs[0];
                         let len_vreg = field_vregs[1];
 
-                        // Move ptr to X0, len to X1
+                        // Allocate the sret buffer for the Option(int) result.
+                        self.mir.push(Aarch64Inst::SubImm {
+                            dst: Operand::Physical(Reg::Sp),
+                            src: Operand::Physical(Reg::Sp),
+                            imm: sret_bytes,
+                        });
+
+                        // Args: X0 = out, X1 = ptr, X2 = len,
+                        //       X3 = some_disc, X4 = none_disc.
                         self.mir.push(Aarch64Inst::MovRR {
                             dst: Operand::Physical(Reg::X0),
-                            src: Operand::Virtual(ptr_vreg),
+                            src: Operand::Physical(Reg::Sp),
                         });
                         self.mir.push(Aarch64Inst::MovRR {
                             dst: Operand::Physical(Reg::X1),
+                            src: Operand::Virtual(ptr_vreg),
+                        });
+                        self.mir.push(Aarch64Inst::MovRR {
+                            dst: Operand::Physical(Reg::X2),
                             src: Operand::Virtual(len_vreg),
+                        });
+                        self.mir.push(Aarch64Inst::MovImm {
+                            dst: Operand::Physical(Reg::X3),
+                            imm: some_disc as i64,
+                        });
+                        self.mir.push(Aarch64Inst::MovImm {
+                            dst: Operand::Physical(Reg::X4),
+                            imm: none_disc as i64,
                         });
 
                         // Determine the runtime function based on intrinsic name
@@ -1969,13 +2012,30 @@ impl<'a> CfgLower<'a> {
                         let symbol_id = self.intern_symbol(runtime_fn);
                         self.mir.push(Aarch64Inst::Bl { symbol_id });
 
-                        // Result is in X0, move to a vreg
-                        let result_vreg = self.mir.alloc_vreg();
-                        self.mir.push(Aarch64Inst::MovRR {
-                            dst: Operand::Virtual(result_vreg),
-                            src: Operand::Physical(Reg::X0),
+                        // Load the enum's slots (disc, value) into vregs.
+                        let mut slot_vregs = Vec::with_capacity(total_slots as usize);
+                        for slot_idx in 0..total_slots {
+                            let slot_vreg = self.mir.alloc_vreg();
+                            let offset = (slot_idx * 8) as i32;
+                            self.mir.push(Aarch64Inst::Ldr {
+                                dst: Operand::Virtual(slot_vreg),
+                                base: Reg::Sp,
+                                offset,
+                            });
+                            slot_vregs.push(slot_vreg);
+                        }
+
+                        // Pop the sret space.
+                        self.mir.push(Aarch64Inst::AddImm {
+                            dst: Operand::Physical(Reg::Sp),
+                            src: Operand::Physical(Reg::Sp),
+                            imm: sret_bytes,
                         });
-                        self.value_map.insert(value, result_vreg);
+
+                        // Slot 0 (discriminant) is the value's primary vreg.
+                        let disc_vreg = slot_vregs[0];
+                        self.struct_slot_vregs.insert(value, slot_vregs);
+                        self.value_map.insert(value, disc_vreg);
                     } else {
                         unreachable!("String fat pointer not found in struct_slot_vregs");
                     }

--- a/crates/rue-codegen/src/types.rs
+++ b/crates/rue-codegen/src/types.rs
@@ -104,6 +104,28 @@ pub fn type_slot_count(type_pool: &TypeInternPool, ty: Type) -> u32 {
     }
 }
 
+/// Return the `(Some, None)` discriminant values for an `Option`-shaped enum
+/// type, i.e. the variant indices of its `Some` and `None` variants.
+///
+/// Used to lower the fallible intrinsics (`@read_line`, `@parse_*`), whose
+/// runtime writes the caller's `Some`/`None` discriminant into the tagged-union
+/// result (RUE-6, ADR-0038). Sema has already validated the result is
+/// `Option`-shaped, so both variants are present; a missing one is a compiler
+/// bug and panics (a correctness guard, RUE-45).
+pub fn option_variant_discriminants(type_pool: &TypeInternPool, ty: Type) -> (u64, u64) {
+    let enum_id = ty
+        .as_enum()
+        .expect("fallible intrinsic result must be an Option enum");
+    let enum_def = type_pool.enum_def(enum_id);
+    let some_disc = enum_def
+        .find_variant("Some")
+        .expect("Option result enum must have a `Some` variant") as u64;
+    let none_disc = enum_def
+        .find_variant("None")
+        .expect("Option result enum must have a `None` variant") as u64;
+    (some_disc, none_disc)
+}
+
 /// Whether comparing a slot holding `ty` needs a full 64-bit compare.
 ///
 /// Narrow scalars (i8..i32, bool) live in 32-bit-comparable slots; 64-bit

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2126,29 +2126,47 @@ impl<'a> CfgLower<'a> {
             } => {
                 let name_str = self.interner.resolve(name);
                 if name_str == "read_line" {
-                    // @read_line() intrinsic - reads a line from stdin and returns String.
-                    // Uses sret convention: allocate space on stack for the result (ptr, len, cap).
+                    // @read_line() intrinsic - reads a line from stdin and
+                    // returns `Option(String)`: `Some(line)` normally, `None`
+                    // at EOF (RUE-6, ADR-0038). The runtime writes the whole
+                    // tagged-union `Option` to an sret buffer laid out as
+                    // [disc, ptr, len, cap] (slot 0 = discriminant, RUE-221);
+                    // we pass the Some/None discriminant values and load the
+                    // slots back. No branch needed — the runtime picks the
+                    // discriminant.
+                    let vty = self.ctx.cfg.get_inst(value).ty;
+                    let (some_disc, none_disc) =
+                        types::option_variant_discriminants(self.ctx.type_pool, vty);
+                    let total_slots = self.ctx.type_slot_count(vty);
+                    // sret buffer sized to the enum's slots, rounded to 16.
+                    let sret_bytes = (total_slots as i32 * 8 + 15) & !15;
 
-                    // Allocate 32 bytes on stack for sret (24 bytes for String + 8 for alignment)
-                    // Use AddRI with negative immediate (no SubRI in MIR)
                     self.mir.push(X86Inst::AddRI {
                         dst: Operand::Physical(Reg::Rsp),
-                        imm: -32,
+                        imm: -sret_bytes,
                     });
 
-                    // Move RSP (pointer to sret space) to RDI as first argument
+                    // Args: RDI = out ptr, RSI = some_disc, RDX = none_disc.
                     self.mir.push(X86Inst::MovRR {
                         dst: Operand::Physical(Reg::Rdi),
                         src: Operand::Physical(Reg::Rsp),
+                    });
+                    self.mir.push(X86Inst::MovRI32 {
+                        dst: Operand::Physical(Reg::Rsi),
+                        imm: some_disc as i32,
+                    });
+                    self.mir.push(X86Inst::MovRI32 {
+                        dst: Operand::Physical(Reg::Rdx),
+                        imm: none_disc as i32,
                     });
 
                     // Call __rue_read_line
                     let symbol_id = self.intern_symbol("__rue_read_line");
                     self.mir.push(X86Inst::CallRel { symbol_id });
 
-                    // Load ptr, len, cap from stack into vregs
-                    let mut slot_vregs = Vec::new();
-                    for slot_idx in 0..3 {
+                    // Load the enum's slots (disc, ptr, len, cap) into vregs.
+                    let mut slot_vregs = Vec::with_capacity(total_slots as usize);
+                    for slot_idx in 0..total_slots {
                         let slot_vreg = self.mir.alloc_vreg();
                         let offset = (slot_idx * 8) as i32;
                         self.mir.push(X86Inst::MovRM {
@@ -2162,19 +2180,14 @@ impl<'a> CfgLower<'a> {
                     // Pop the sret space
                     self.mir.push(X86Inst::AddRI {
                         dst: Operand::Physical(Reg::Rsp),
-                        imm: 32,
+                        imm: sret_bytes,
                     });
 
-                    // Store the slot vregs for the String value
-                    self.struct_slot_vregs.insert(value, slot_vregs.clone());
-
-                    // Create a result vreg (for the primary value representation)
-                    let result_vreg = self.mir.alloc_vreg();
-                    self.mir.push(X86Inst::MovRR {
-                        dst: Operand::Virtual(result_vreg),
-                        src: Operand::Virtual(slot_vregs[0]),
-                    });
-                    self.value_map.insert(value, result_vreg);
+                    // Slot 0 is the discriminant and the value's primary vreg,
+                    // so a `match` switches on it directly (like EnumVariant).
+                    let disc_vreg = slot_vregs[0];
+                    self.struct_slot_vregs.insert(value, slot_vregs);
+                    self.value_map.insert(value, disc_vreg);
                 } else if name_str == "dbg" {
                     let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                     let arg_val = args[0];
@@ -2303,9 +2316,19 @@ impl<'a> CfgLower<'a> {
                     || name_str == "parse_u32"
                     || name_str == "parse_u64"
                 {
-                    // @parse_* intrinsics: take a String, return an integer
+                    // @parse_* intrinsics: take a String, return `Option(int)`:
+                    // `Some(n)` on success, `None` on parse failure (RUE-6,
+                    // ADR-0038). The runtime writes the whole tagged-union
+                    // `Option` to an sret buffer laid out as [disc, value]
+                    // (slot 0 = discriminant, RUE-221); we pass ptr/len plus the
+                    // Some/None discriminant values and load the slots back.
                     let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                     let arg_val = args[0];
+                    let vty = self.ctx.cfg.get_inst(value).ty;
+                    let (some_disc, none_disc) =
+                        types::option_variant_discriminants(self.ctx.type_pool, vty);
+                    let total_slots = self.ctx.type_slot_count(vty);
+                    let sret_bytes = (total_slots as i32 * 8 + 15) & !15;
 
                     // Get the String fat pointer (ptr, len, cap) — materializes a String
                     // read from a place (`@parse_i32(h.s)`) as well as cached sources. (RUE-118)
@@ -2321,14 +2344,33 @@ impl<'a> CfgLower<'a> {
                         let ptr_vreg = field_vregs[0];
                         let len_vreg = field_vregs[1];
 
-                        // Move ptr to RDI, len to RSI
+                        // Allocate the sret buffer for the Option(int) result.
+                        self.mir.push(X86Inst::AddRI {
+                            dst: Operand::Physical(Reg::Rsp),
+                            imm: -sret_bytes,
+                        });
+
+                        // Args: RDI = out, RSI = ptr, RDX = len,
+                        //       RCX = some_disc, R8 = none_disc.
                         self.mir.push(X86Inst::MovRR {
                             dst: Operand::Physical(Reg::Rdi),
-                            src: Operand::Virtual(ptr_vreg),
+                            src: Operand::Physical(Reg::Rsp),
                         });
                         self.mir.push(X86Inst::MovRR {
                             dst: Operand::Physical(Reg::Rsi),
+                            src: Operand::Virtual(ptr_vreg),
+                        });
+                        self.mir.push(X86Inst::MovRR {
+                            dst: Operand::Physical(Reg::Rdx),
                             src: Operand::Virtual(len_vreg),
+                        });
+                        self.mir.push(X86Inst::MovRI32 {
+                            dst: Operand::Physical(Reg::Rcx),
+                            imm: some_disc as i32,
+                        });
+                        self.mir.push(X86Inst::MovRI32 {
+                            dst: Operand::Physical(Reg::R8),
+                            imm: none_disc as i32,
                         });
 
                         // Determine the runtime function based on intrinsic name
@@ -2344,13 +2386,29 @@ impl<'a> CfgLower<'a> {
                         let symbol_id = self.intern_symbol(runtime_fn);
                         self.mir.push(X86Inst::CallRel { symbol_id });
 
-                        // Result is in RAX, move to a vreg
-                        let result_vreg = self.mir.alloc_vreg();
-                        self.mir.push(X86Inst::MovRR {
-                            dst: Operand::Virtual(result_vreg),
-                            src: Operand::Physical(Reg::Rax),
+                        // Load the enum's slots (disc, value) into vregs.
+                        let mut slot_vregs = Vec::with_capacity(total_slots as usize);
+                        for slot_idx in 0..total_slots {
+                            let slot_vreg = self.mir.alloc_vreg();
+                            let offset = (slot_idx * 8) as i32;
+                            self.mir.push(X86Inst::MovRM {
+                                dst: Operand::Virtual(slot_vreg),
+                                base: Reg::Rsp,
+                                offset,
+                            });
+                            slot_vregs.push(slot_vreg);
+                        }
+
+                        // Pop the sret space.
+                        self.mir.push(X86Inst::AddRI {
+                            dst: Operand::Physical(Reg::Rsp),
+                            imm: sret_bytes,
                         });
-                        self.value_map.insert(value, result_vreg);
+
+                        // Slot 0 (discriminant) is the value's primary vreg.
+                        let disc_vreg = slot_vregs[0];
+                        self.struct_slot_vregs.insert(value, slot_vregs);
+                        self.value_map.insert(value, disc_vreg);
                     } else {
                         unreachable!("string value should have field vregs for fat pointer");
                     }

--- a/crates/rue-runtime/src/io.rs
+++ b/crates/rue-runtime/src/io.rs
@@ -7,7 +7,7 @@
 
 use crate::heap;
 use crate::platform;
-use crate::string::{STRING_MIN_CAPACITY, StringResult};
+use crate::string::STRING_MIN_CAPACITY;
 
 // =============================================================================
 // String output (RUE-1: print / println)
@@ -89,61 +89,84 @@ crate::define_for_all_platforms! {
 /// This is a reasonable size for most interactive input.
 const READ_LINE_INITIAL_CAPACITY: u64 = 128;
 
-/// Read a line from standard input.
+/// Result of `@read_line`: a tagged-union `Option(String)` written via sret.
+///
+/// The compiler lays a payload-carrying enum out as slot 0 = discriminant
+/// followed by the payload slots (RUE-221), so the in-memory layout of
+/// `Option(String)` is `[disc, ptr, len, cap]`. This struct mirrors that
+/// layout exactly so the runtime can write the whole `Option` in one place and
+/// codegen simply loads the four slots back (RUE-6).
+#[repr(C)]
+pub struct OptionStringResult {
+    /// Discriminant slot: `some_disc` on success, `none_disc` at EOF.
+    pub disc: u64,
+    pub ptr: *mut u8,
+    pub len: u64,
+    pub cap: u64,
+}
+
+/// Read a line from standard input, returning `Option(String)`.
 ///
 /// Reads bytes from stdin (file descriptor 0) until a newline character (`\n`)
-/// is encountered or EOF is reached. Returns the line as a String (excluding
-/// the trailing newline).
+/// is encountered or EOF is reached. Yields the line (excluding the trailing
+/// newline) as `Some(String)`, or `None` at end-of-input (RUE-6, ADR-0038).
 ///
 /// # Returns
 ///
-/// Returns the string data via sret convention. Writes to `out`:
-/// - ptr: Pointer to the string data (heap-allocated)
-/// - len: Length of the string in bytes (excluding newline)
-/// - cap: Capacity of the allocated buffer
+/// Writes the whole `Option(String)` to `out` via sret:
+/// - On success (line read, or partial line at EOF): `disc = some_disc` and the
+///   String fields `ptr`/`len`/`cap` are populated.
+/// - At EOF with no data read: `disc = none_disc` and the payload slots are
+///   zeroed (a `None` never drops its payload, so the zeros are inert).
+///
+/// `some_disc`/`none_disc` are the caller's `Some`/`None` variant indices,
+/// passed in so the runtime need not know the compiler's discriminant
+/// assignment.
 ///
 /// # Panics
 ///
-/// - If EOF is reached with no data read: panics with "unexpected end of input"
 /// - If a read error occurs: panics with "input error"
+/// - If memory allocation fails: panics with "out of memory"
+///
+/// EOF is **not** a panic — it is reported as `None`.
 ///
 /// # ABI (sret convention)
 ///
 /// ```text
-/// extern "C" fn __rue_read_line(out: *mut StringResult)
+/// extern "C" fn __rue_read_line(out: *mut OptionStringResult, some_disc: u64, none_disc: u64)
 /// ```
 ///
 /// Caller allocates space for the return value and passes pointer.
 #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_read_line(out: *mut StringResult) {
-    read_line_impl(out);
+pub extern "C" fn __rue_read_line(out: *mut OptionStringResult, some_disc: u64, none_disc: u64) {
+    read_line_impl(out, some_disc, none_disc);
 }
 
 #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_read_line(out: *mut StringResult) {
-    read_line_impl(out);
+pub extern "C" fn __rue_read_line(out: *mut OptionStringResult, some_disc: u64, none_disc: u64) {
+    read_line_impl(out, some_disc, none_disc);
 }
 
 #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
 #[unsafe(no_mangle)]
 #[allow(non_snake_case)]
-pub extern "C" fn __rue_read_line(out: *mut StringResult) {
-    read_line_impl(out);
+pub extern "C" fn __rue_read_line(out: *mut OptionStringResult, some_disc: u64, none_disc: u64) {
+    read_line_impl(out, some_disc, none_disc);
 }
 
 /// Implementation of read_line shared across platforms.
 ///
 /// This function reads from stdin byte-by-byte until:
-/// - A newline character is found (returns line without the newline)
-/// - EOF is reached with some data (returns partial line)
-/// - EOF is reached with no data (panics)
+/// - A newline character is found (returns `Some` line without the newline)
+/// - EOF is reached with some data (returns `Some` partial line)
+/// - EOF is reached with no data (returns `None`)
 /// - A read error occurs (panics)
 #[inline]
-fn read_line_impl(out: *mut StringResult) {
+fn read_line_impl(out: *mut OptionStringResult, some_disc: u64, none_disc: u64) {
     // Allocate initial buffer
     let mut cap = READ_LINE_INITIAL_CAPACITY;
     let mut ptr = heap::alloc(cap, 1);
@@ -212,43 +235,21 @@ fn read_line_impl(out: *mut StringResult) {
         if result == 0 {
             // EOF reached
             if len == 0 {
-                // EOF with no data - free buffer and panic
+                // EOF with no data: this is not an error (RUE-6, ADR-0038).
+                // Free the empty buffer and report `None` so a read-until-EOF
+                // loop can terminate cleanly instead of trapping.
                 heap::free(ptr, cap, 1);
-                // Build error message in buffer (like print_i64 does)
-                let mut msg = [0u8; 31];
-                msg[0] = b'e';
-                msg[1] = b'r';
-                msg[2] = b'r';
-                msg[3] = b'o';
-                msg[4] = b'r';
-                msg[5] = b':';
-                msg[6] = b' ';
-                msg[7] = b'u';
-                msg[8] = b'n';
-                msg[9] = b'e';
-                msg[10] = b'x';
-                msg[11] = b'p';
-                msg[12] = b'e';
-                msg[13] = b'c';
-                msg[14] = b't';
-                msg[15] = b'e';
-                msg[16] = b'd';
-                msg[17] = b' ';
-                msg[18] = b'e';
-                msg[19] = b'n';
-                msg[20] = b'd';
-                msg[21] = b' ';
-                msg[22] = b'o';
-                msg[23] = b'f';
-                msg[24] = b' ';
-                msg[25] = b'i';
-                msg[26] = b'n';
-                msg[27] = b'p';
-                msg[28] = b'u';
-                msg[29] = b't';
-                msg[30] = b'\n';
-                platform::write_stderr(&msg);
-                platform::exit(101);
+                // SAFETY: `out` points to caller-allocated space for the
+                // Option(String) result (4 slots). We write `None` and zero
+                // the payload; a `None` never has its payload dropped, so the
+                // zeroed String slots are inert.
+                unsafe {
+                    (*out).disc = none_disc;
+                    (*out).ptr = core::ptr::null_mut();
+                    (*out).len = 0;
+                    (*out).cap = 0;
+                }
+                return;
             }
             // EOF with data - return partial line
             break;
@@ -288,9 +289,10 @@ fn read_line_impl(out: *mut StringResult) {
         len += 1;
     }
 
-    // Return the string
+    // Return `Some(string)`.
     // SAFETY: Writing to `out` is safe - see __rue_String_new for rationale
     unsafe {
+        (*out).disc = some_disc;
         (*out).ptr = ptr;
         (*out).len = len;
         (*out).cap = cap;

--- a/crates/rue-runtime/src/parse.rs
+++ b/crates/rue-runtime/src/parse.rs
@@ -3,348 +3,273 @@
 //! This module implements the `@parse_i32`, `@parse_i64`, `@parse_u32`, and
 //! `@parse_u64` intrinsics for parsing strings into integers.
 //!
-//! See ADR-0022 for the design rationale.
+//! See ADR-0022 for the design rationale and ADR-0038 / RUE-6 for the error
+//! model: a parse that fails (empty string, invalid character, overflow, or a
+//! negative value for an unsigned type) yields `None` rather than trapping, so
+//! callers recover instead of aborting.
 
-use crate::platform;
+/// Result of an `@parse_*` intrinsic: a tagged-union `Option(int)` written via
+/// sret. The compiler lays a payload-carrying enum out as slot 0 =
+/// discriminant followed by the payload slots (RUE-221), so the in-memory
+/// layout of `Option(iN)` is `[disc, value]`. This struct mirrors that layout
+/// exactly (RUE-6).
+#[repr(C)]
+pub struct OptionIntResult {
+    /// Discriminant slot: `some_disc` on success, `none_disc` on failure.
+    pub disc: u64,
+    /// Payload slot: the parsed integer's bit pattern (only meaningful when
+    /// `disc == some_disc`). Narrower types occupy the low bits.
+    pub value: u64,
+}
 
-/// Parse a string as an i32.
+/// Parse decimal ASCII into an `i64`, returning `None` on empty input, an
+/// invalid character, or overflow. Shared core for the signed parsers.
+fn parse_i64_checked(ptr: *const u8, len: u64) -> Option<i64> {
+    if len == 0 {
+        return None;
+    }
+
+    // SAFETY: the caller (an `@parse_*` intrinsic) passes the ptr/len of a
+    // live borrowed String; we only read `len` bytes.
+    let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
+    let mut idx = 0;
+    let is_negative = bytes[0] == b'-';
+
+    if is_negative {
+        idx = 1;
+        if idx >= bytes.len() {
+            return None;
+        }
+    }
+
+    let mut result: i64 = 0;
+    while idx < bytes.len() {
+        let byte = bytes[idx];
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+
+        let digit = (byte - b'0') as i64;
+
+        if is_negative {
+            // For negative numbers, check against i64::MIN
+            if result < i64::MIN / 10 {
+                return None;
+            }
+            result *= 10;
+            if result < i64::MIN + digit {
+                return None;
+            }
+            result -= digit;
+        } else {
+            // For positive numbers, check against i64::MAX
+            if result > i64::MAX / 10 {
+                return None;
+            }
+            result *= 10;
+            if result > i64::MAX - digit {
+                return None;
+            }
+            result += digit;
+        }
+
+        idx += 1;
+    }
+
+    Some(result)
+}
+
+/// Parse decimal ASCII into a `u64`, returning `None` on empty input, a leading
+/// minus, an invalid character, or overflow. Shared core for the unsigned
+/// parsers.
+fn parse_u64_checked(ptr: *const u8, len: u64) -> Option<u64> {
+    if len == 0 {
+        return None;
+    }
+
+    // SAFETY: see `parse_i64_checked`.
+    let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
+
+    // A leading minus is invalid for unsigned types.
+    if bytes[0] == b'-' {
+        return None;
+    }
+
+    let mut result: u64 = 0;
+    for &byte in bytes {
+        if !byte.is_ascii_digit() {
+            return None;
+        }
+
+        let digit = (byte - b'0') as u64;
+
+        if result > u64::MAX / 10 {
+            return None;
+        }
+        result *= 10;
+        if result > u64::MAX - digit {
+            return None;
+        }
+        result += digit;
+    }
+
+    Some(result)
+}
+
+/// Parse decimal ASCII into an `i32` (range-checked), `None` on failure.
+fn parse_i32_checked(ptr: *const u8, len: u64) -> Option<i32> {
+    let v = parse_i64_checked(ptr, len)?;
+    if v < i32::MIN as i64 || v > i32::MAX as i64 {
+        return None;
+    }
+    Some(v as i32)
+}
+
+/// Parse decimal ASCII into a `u32` (range-checked), `None` on failure.
+fn parse_u32_checked(ptr: *const u8, len: u64) -> Option<u32> {
+    let v = parse_u64_checked(ptr, len)?;
+    if v > u32::MAX as u64 {
+        return None;
+    }
+    Some(v as u32)
+}
+
+/// Write an `Option(int)` result: `Some(value)` or `None`, per the caller's
+/// discriminant assignment.
 ///
-/// # Behavior
+/// # Safety
 ///
-/// - Accepts optional leading `-`
-/// - Parses ASCII decimal digits
-/// - Panics on empty string, invalid characters, overflow, or other errors
-///
-/// # Calling Convention
-///
-/// - `ptr`: Pointer to the string bytes
-/// - `len`: Length of the string in bytes
-/// - Returns: Parsed i32 value
+/// `out` must point to caller-allocated space for an `OptionIntResult`.
+#[inline]
+unsafe fn write_parse_result(
+    out: *mut OptionIntResult,
+    parsed: Option<u64>,
+    some_disc: u64,
+    none_disc: u64,
+) {
+    // SAFETY: `out` points to caller-allocated space for the Option(int)
+    // result (2 slots). On `None` we zero the payload; a `None` never has its
+    // payload read, so the zero is inert.
+    unsafe {
+        match parsed {
+            Some(v) => {
+                (*out).disc = some_disc;
+                (*out).value = v;
+            }
+            None => {
+                (*out).disc = none_disc;
+                (*out).value = 0;
+            }
+        }
+    }
+}
+
 crate::define_for_all_platforms! {
-    /// extern "C" fn __rue_parse_i32(ptr: *const u8, len: u64) -> i32
-    pub extern "C" fn __rue_parse_i32(ptr: *const u8, len: u64) -> i32 {
-        // Delegate to i64 parser, then check range
-        let result = __rue_parse_i64(ptr, len);
-        if result < i32::MIN as i64 || result > i32::MAX as i64 {
-            parse_error_overflow();
-        }
-        result as i32
+    /// extern "C" fn __rue_parse_i32(out, ptr, len, some_disc, none_disc)
+    pub extern "C" fn __rue_parse_i32(out: *mut OptionIntResult, ptr: *const u8, len: u64, some_disc: u64, none_disc: u64) {
+        let parsed = parse_i32_checked(ptr, len).map(|v| v as u64);
+        // SAFETY: `out` is the caller-allocated sret buffer for the result.
+        unsafe { write_parse_result(out, parsed, some_disc, none_disc) };
     }
 }
 
 define_for_all_platforms! {
-    /// extern "C" fn __rue_parse_i64(ptr: *const u8, len: u64) -> i64
-    pub extern "C" fn __rue_parse_i64(ptr: *const u8, len: u64) -> i64 {
-        if len == 0 {
-            parse_error_empty();
-        }
-
-        unsafe {
-            let bytes = core::slice::from_raw_parts(ptr, len as usize);
-            let mut idx = 0;
-            let is_negative = bytes[0] == b'-';
-
-            if is_negative {
-                idx = 1;
-                if idx >= bytes.len() {
-                    parse_error_char();
-                }
-            }
-
-            let mut result: i64 = 0;
-            while idx < bytes.len() {
-                let byte = bytes[idx];
-                if byte < b'0' || byte > b'9' {
-                    parse_error_char();
-                }
-
-                let digit = (byte - b'0') as i64;
-
-                // Check for overflow before multiplying
-                if is_negative {
-                    // For negative numbers, check against i64::MIN
-                    if result < i64::MIN / 10 {
-                        parse_error_overflow();
-                    }
-                    result = result * 10;
-                    if result < i64::MIN + digit {
-                        parse_error_overflow();
-                    }
-                    result = result - digit;
-                } else {
-                    // For positive numbers, check against i64::MAX
-                    if result > i64::MAX / 10 {
-                        parse_error_overflow();
-                    }
-                    result = result * 10;
-                    if result > i64::MAX - digit {
-                        parse_error_overflow();
-                    }
-                    result = result + digit;
-                }
-
-                idx += 1;
-            }
-
-            result
-        }
+    /// extern "C" fn __rue_parse_i64(out, ptr, len, some_disc, none_disc)
+    pub extern "C" fn __rue_parse_i64(out: *mut OptionIntResult, ptr: *const u8, len: u64, some_disc: u64, none_disc: u64) {
+        let parsed = parse_i64_checked(ptr, len).map(|v| v as u64);
+        // SAFETY: `out` is the caller-allocated sret buffer for the result.
+        unsafe { write_parse_result(out, parsed, some_disc, none_disc) };
     }
 }
 
 define_for_all_platforms! {
-    /// extern "C" fn __rue_parse_u32(ptr: *const u8, len: u64) -> u32
-    pub extern "C" fn __rue_parse_u32(ptr: *const u8, len: u64) -> u32 {
-        // Delegate to u64 parser, then check range
-        let result = __rue_parse_u64(ptr, len);
-        if result > u32::MAX as u64 {
-            parse_error_overflow();
-        }
-        result as u32
+    /// extern "C" fn __rue_parse_u32(out, ptr, len, some_disc, none_disc)
+    pub extern "C" fn __rue_parse_u32(out: *mut OptionIntResult, ptr: *const u8, len: u64, some_disc: u64, none_disc: u64) {
+        let parsed = parse_u32_checked(ptr, len).map(|v| v as u64);
+        // SAFETY: `out` is the caller-allocated sret buffer for the result.
+        unsafe { write_parse_result(out, parsed, some_disc, none_disc) };
     }
 }
 
 define_for_all_platforms! {
-    /// extern "C" fn __rue_parse_u64(ptr: *const u8, len: u64) -> u64
-    pub extern "C" fn __rue_parse_u64(ptr: *const u8, len: u64) -> u64 {
-        if len == 0 {
-            parse_error_empty();
-        }
-
-        unsafe {
-            let bytes = core::slice::from_raw_parts(ptr, len as usize);
-
-            // Check for negative sign (invalid for unsigned)
-            if bytes[0] == b'-' {
-                parse_error_negative();
-            }
-
-            let mut result: u64 = 0;
-            for &byte in bytes {
-                if byte < b'0' || byte > b'9' {
-                    parse_error_char();
-                }
-
-                let digit = (byte - b'0') as u64;
-
-                // Check for overflow before multiplying
-                if result > u64::MAX / 10 {
-                    parse_error_overflow();
-                }
-                result = result * 10;
-                if result > u64::MAX - digit {
-                    parse_error_overflow();
-                }
-                result = result + digit;
-            }
-
-            result
-        }
+    /// extern "C" fn __rue_parse_u64(out, ptr, len, some_disc, none_disc)
+    pub extern "C" fn __rue_parse_u64(out: *mut OptionIntResult, ptr: *const u8, len: u64, some_disc: u64, none_disc: u64) {
+        let parsed = parse_u64_checked(ptr, len);
+        // SAFETY: `out` is the caller-allocated sret buffer for the result.
+        unsafe { write_parse_result(out, parsed, some_disc, none_disc) };
     }
-}
-
-/// Print "parse error: empty string\n" and exit.
-fn parse_error_empty() -> ! {
-    // Build error message byte-by-byte to avoid macOS linker bug with byte strings
-    let mut msg = [0u8; 28];
-    msg[0] = b'p';
-    msg[1] = b'a';
-    msg[2] = b'r';
-    msg[3] = b's';
-    msg[4] = b'e';
-    msg[5] = b' ';
-    msg[6] = b'e';
-    msg[7] = b'r';
-    msg[8] = b'r';
-    msg[9] = b'o';
-    msg[10] = b'r';
-    msg[11] = b':';
-    msg[12] = b' ';
-    msg[13] = b'e';
-    msg[14] = b'm';
-    msg[15] = b'p';
-    msg[16] = b't';
-    msg[17] = b'y';
-    msg[18] = b' ';
-    msg[19] = b's';
-    msg[20] = b't';
-    msg[21] = b'r';
-    msg[22] = b'i';
-    msg[23] = b'n';
-    msg[24] = b'g';
-    msg[25] = b'\n';
-    platform::write_stderr(&msg[0..26]);
-    platform::exit(101);
-}
-
-/// Print "parse error: invalid character\n" and exit.
-fn parse_error_char() -> ! {
-    // Build error message byte-by-byte to avoid macOS linker bug with byte strings
-    let mut msg = [0u8; 32];
-    msg[0] = b'p';
-    msg[1] = b'a';
-    msg[2] = b'r';
-    msg[3] = b's';
-    msg[4] = b'e';
-    msg[5] = b' ';
-    msg[6] = b'e';
-    msg[7] = b'r';
-    msg[8] = b'r';
-    msg[9] = b'o';
-    msg[10] = b'r';
-    msg[11] = b':';
-    msg[12] = b' ';
-    msg[13] = b'i';
-    msg[14] = b'n';
-    msg[15] = b'v';
-    msg[16] = b'a';
-    msg[17] = b'l';
-    msg[18] = b'i';
-    msg[19] = b'd';
-    msg[20] = b' ';
-    msg[21] = b'c';
-    msg[22] = b'h';
-    msg[23] = b'a';
-    msg[24] = b'r';
-    msg[25] = b'a';
-    msg[26] = b'c';
-    msg[27] = b't';
-    msg[28] = b'e';
-    msg[29] = b'r';
-    msg[30] = b'\n';
-    platform::write_stderr(&msg[0..31]);
-    platform::exit(101);
-}
-
-/// Print "parse error: integer overflow\n" and exit.
-fn parse_error_overflow() -> ! {
-    // Build error message byte-by-byte to avoid macOS linker bug with byte strings
-    let mut msg = [0u8; 32];
-    msg[0] = b'p';
-    msg[1] = b'a';
-    msg[2] = b'r';
-    msg[3] = b's';
-    msg[4] = b'e';
-    msg[5] = b' ';
-    msg[6] = b'e';
-    msg[7] = b'r';
-    msg[8] = b'r';
-    msg[9] = b'o';
-    msg[10] = b'r';
-    msg[11] = b':';
-    msg[12] = b' ';
-    msg[13] = b'i';
-    msg[14] = b'n';
-    msg[15] = b't';
-    msg[16] = b'e';
-    msg[17] = b'g';
-    msg[18] = b'e';
-    msg[19] = b'r';
-    msg[20] = b' ';
-    msg[21] = b'o';
-    msg[22] = b'v';
-    msg[23] = b'e';
-    msg[24] = b'r';
-    msg[25] = b'f';
-    msg[26] = b'l';
-    msg[27] = b'o';
-    msg[28] = b'w';
-    msg[29] = b'\n';
-    platform::write_stderr(&msg[0..30]);
-    platform::exit(101);
-}
-
-/// Print "parse error: negative value for unsigned type\n" and exit.
-fn parse_error_negative() -> ! {
-    // Build error message byte-by-byte to avoid macOS linker bug with byte strings
-    let mut msg = [0u8; 48];
-    msg[0] = b'p';
-    msg[1] = b'a';
-    msg[2] = b'r';
-    msg[3] = b's';
-    msg[4] = b'e';
-    msg[5] = b' ';
-    msg[6] = b'e';
-    msg[7] = b'r';
-    msg[8] = b'r';
-    msg[9] = b'o';
-    msg[10] = b'r';
-    msg[11] = b':';
-    msg[12] = b' ';
-    msg[13] = b'n';
-    msg[14] = b'e';
-    msg[15] = b'g';
-    msg[16] = b'a';
-    msg[17] = b't';
-    msg[18] = b'i';
-    msg[19] = b'v';
-    msg[20] = b'e';
-    msg[21] = b' ';
-    msg[22] = b'v';
-    msg[23] = b'a';
-    msg[24] = b'l';
-    msg[25] = b'u';
-    msg[26] = b'e';
-    msg[27] = b' ';
-    msg[28] = b'f';
-    msg[29] = b'o';
-    msg[30] = b'r';
-    msg[31] = b' ';
-    msg[32] = b'u';
-    msg[33] = b'n';
-    msg[34] = b's';
-    msg[35] = b'i';
-    msg[36] = b'g';
-    msg[37] = b'n';
-    msg[38] = b'e';
-    msg[39] = b'd';
-    msg[40] = b' ';
-    msg[41] = b't';
-    msg[42] = b'y';
-    msg[43] = b'p';
-    msg[44] = b'e';
-    msg[45] = b'\n';
-    platform::write_stderr(&msg[0..46]);
-    platform::exit(101);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    // The parsing core is exercised directly through the `_checked` helpers;
+    // the extern wrappers just marshal the result into the sret Option layout.
+
     #[test]
     fn test_parse_i32_basic() {
-        assert_eq!(__rue_parse_i32(b"42".as_ptr(), 2), 42);
-        assert_eq!(__rue_parse_i32(b"0".as_ptr(), 1), 0);
-        assert_eq!(__rue_parse_i32(b"2147483647".as_ptr(), 10), 2147483647);
+        assert_eq!(parse_i32_checked(b"42".as_ptr(), 2), Some(42));
+        assert_eq!(parse_i32_checked(b"0".as_ptr(), 1), Some(0));
+        assert_eq!(
+            parse_i32_checked(b"2147483647".as_ptr(), 10),
+            Some(2147483647)
+        );
     }
 
     #[test]
     fn test_parse_i32_negative() {
-        assert_eq!(__rue_parse_i32(b"-17".as_ptr(), 3), -17);
-        assert_eq!(__rue_parse_i32(b"-2147483648".as_ptr(), 11), -2147483648);
+        assert_eq!(parse_i32_checked(b"-17".as_ptr(), 3), Some(-17));
+        assert_eq!(
+            parse_i32_checked(b"-2147483648".as_ptr(), 11),
+            Some(-2147483648)
+        );
     }
 
     #[test]
     fn test_parse_i64_basic() {
-        assert_eq!(__rue_parse_i64(b"42".as_ptr(), 2), 42);
+        assert_eq!(parse_i64_checked(b"42".as_ptr(), 2), Some(42));
         assert_eq!(
-            __rue_parse_i64(b"9223372036854775807".as_ptr(), 19),
-            9223372036854775807
+            parse_i64_checked(b"9223372036854775807".as_ptr(), 19),
+            Some(9223372036854775807)
         );
     }
 
     #[test]
     fn test_parse_u32_basic() {
-        assert_eq!(__rue_parse_u32(b"42".as_ptr(), 2), 42);
-        assert_eq!(__rue_parse_u32(b"4294967295".as_ptr(), 10), 4294967295);
+        assert_eq!(parse_u32_checked(b"42".as_ptr(), 2), Some(42));
+        assert_eq!(
+            parse_u32_checked(b"4294967295".as_ptr(), 10),
+            Some(4294967295)
+        );
     }
 
     #[test]
     fn test_parse_u64_basic() {
-        assert_eq!(__rue_parse_u64(b"42".as_ptr(), 2), 42);
+        assert_eq!(parse_u64_checked(b"42".as_ptr(), 2), Some(42));
         assert_eq!(
-            __rue_parse_u64(b"18446744073709551615".as_ptr(), 20),
-            18446744073709551615
+            parse_u64_checked(b"18446744073709551615".as_ptr(), 20),
+            Some(18446744073709551615)
         );
+    }
+
+    #[test]
+    fn test_parse_failure_returns_none() {
+        // Empty, invalid character, and lone-minus all fail to `None`.
+        assert_eq!(parse_i64_checked(b"".as_ptr(), 0), None);
+        assert_eq!(parse_i64_checked(b"12abc".as_ptr(), 5), None);
+        assert_eq!(parse_i64_checked(b"-".as_ptr(), 1), None);
+        // Overflow past i64 range.
+        assert_eq!(parse_i64_checked(b"9223372036854775808".as_ptr(), 19), None);
+        // i32 range check.
+        assert_eq!(parse_i32_checked(b"2147483648".as_ptr(), 10), None);
+    }
+
+    #[test]
+    fn test_parse_unsigned_rejects_negative() {
+        assert_eq!(parse_u32_checked(b"-17".as_ptr(), 3), None);
+        assert_eq!(parse_u64_checked(b"-1".as_ptr(), 2), None);
+        // u32 range check.
+        assert_eq!(parse_u32_checked(b"4294967296".as_ptr(), 10), None);
     }
 }

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -573,17 +573,27 @@ stderr_contains = "integer cast overflow"
 
 # =============================================================================
 # @read_line Intrinsic
+#
+# Since RUE-6 (ADR-0038) @read_line returns Option(String): Some(line) normally,
+# None at end-of-input (no trap). The concrete Option is taken from context, so
+# each case defines the ordinary comptime-generic Option enum in-file and
+# threads it via a `let` annotation or the match arms.
 # =============================================================================
 
 [[case]]
-name = "read_line_returns_string"
+name = "read_line_returns_option_string"
 spec = ["4.13:33", "4.13:35"]
 source = """
-fn takes_string(s: String) -> i32 { 0 }
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    // Type checking: @read_line returns String
-    let line: String = @read_line();
-    takes_string(@read_line())
+    // Type checking: @read_line returns Option(String).
+    let Opt = Option(String);
+    let line: Opt = @read_line();
+    match line {
+        Opt::Some(s) => @dbg(s),
+        Opt::None => {},
+    }
+    0
 }
 """
 # This test will hang waiting for stdin input, so we use compile_only=true
@@ -594,9 +604,15 @@ compile_only = true
 name = "read_line_no_args"
 spec = ["4.13:34"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    // Verify @read_line takes no arguments
-    let line: String = @read_line();
+    // Verify @read_line takes no arguments.
+    let Opt = Option(String);
+    let line: Opt = @read_line();
+    match line {
+        Opt::Some(s) => @dbg(s),
+        Opt::None => {},
+    }
     0
 }
 """
@@ -607,7 +623,7 @@ name = "read_line_wrong_arg_count_one"
 spec = ["4.13:4", "4.13:34"]
 source = """
 fn main() -> i32 {
-    let line: String = @read_line(42);
+    @read_line(42);
     0
 }
 """
@@ -619,7 +635,7 @@ name = "read_line_wrong_arg_count_two"
 spec = ["4.13:4", "4.13:34"]
 source = """
 fn main() -> i32 {
-    let line: String = @read_line(1, 2);
+    @read_line(1, 2);
     0
 }
 """
@@ -634,9 +650,13 @@ error_contains = "argument"
 name = "read_line_basic_input"
 spec = ["4.13:33", "4.13:36", "4.13:37"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let line = @read_line();
-    @dbg(line);
+    let Opt = Option(String);
+    match @read_line() {
+        Opt::Some(line) => @dbg(line),
+        Opt::None => {},
+    }
     0
 }
 """
@@ -648,9 +668,13 @@ exit_code = 0
 name = "read_line_strips_newline"
 spec = ["4.13:37"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let line = @read_line();
-    @dbg(line);
+    let Opt = Option(String);
+    match @read_line() {
+        Opt::Some(line) => @dbg(line),
+        Opt::None => {},
+    }
     0
 }
 """
@@ -662,11 +686,17 @@ exit_code = 0
 name = "read_line_multiple_lines"
 spec = ["4.13:36"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let line1 = @read_line();
-    let line2 = @read_line();
-    @dbg(line1);
-    @dbg(line2);
+    let Opt = Option(String);
+    match @read_line() {
+        Opt::Some(line) => @dbg(line),
+        Opt::None => {},
+    }
+    match @read_line() {
+        Opt::Some(line) => @dbg(line),
+        Opt::None => {},
+    }
     0
 }
 """
@@ -681,13 +711,17 @@ exit_code = 0
 name = "read_line_partial_line_at_eof"
 spec = ["4.13:38"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let line = @read_line();
-    @dbg(line);
+    let Opt = Option(String);
+    match @read_line() {
+        Opt::Some(line) => @dbg(line),
+        Opt::None => {},
+    }
     0
 }
 """
-# No trailing newline - should still return the partial line
+# No trailing newline - should still return Some(partial line)
 stdin = "partial"
 expected_stdout = "partial"
 exit_code = 0
@@ -696,42 +730,58 @@ exit_code = 0
 name = "read_line_empty_line"
 spec = ["4.13:36", "4.13:37"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let line = @read_line();
-    @dbg(line);
+    let Opt = Option(String);
+    match @read_line() {
+        Opt::Some(line) => @dbg(line),
+        Opt::None => {},
+    }
     0
 }
 """
-# Just a newline - should return empty string
+# Just a newline - should return Some("")
 stdin = "\n"
 expected_stdout = ""
 exit_code = 0
 
 [[case]]
-name = "read_line_eof_no_data_panics"
+name = "read_line_eof_no_data_yields_none"
 spec = ["4.13:39"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let line = @read_line();
-    0
+    let Opt = Option(String);
+    let line: Opt = @read_line();
+    // EOF with no data is None, not a trap: this returns 0, exit success.
+    match line {
+        Opt::Some(_s) => 1,
+        Opt::None => 0,
+    }
 }
 """
-# Empty stdin - should panic
+# Empty stdin - EOF with no data yields None (no panic).
 stdin = ""
-exit_code = 101
-stderr_contains = "unexpected end of input"
+exit_code = 0
 
 # =============================================================================
 # @parse_* Intrinsics
+#
+# Since RUE-6 (ADR-0038) the parse intrinsics return Option(int): Some(n) on
+# success, None on failure (empty/invalid/overflow/negative-for-unsigned).
 # =============================================================================
 
 [[case]]
 name = "parse_i32_basic"
 spec = ["4.13:43", "4.13:44", "4.13:45"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let s = "42";
-    @parse_i32(s)
+    let Opt = Option(i32);
+    match @parse_i32("42") {
+        Opt::Some(n) => n,
+        Opt::None => 0,
+    }
 }
 """
 exit_code = 42
@@ -740,9 +790,13 @@ exit_code = 42
 name = "parse_i32_negative"
 spec = ["4.13:43", "4.13:44", "4.13:47"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let s = "-17";
-    @parse_i32(s)
+    let Opt = Option(i32);
+    match @parse_i32("-17") {
+        Opt::Some(n) => n,
+        Opt::None => 0,
+    }
 }
 """
 exit_code = 239
@@ -751,9 +805,13 @@ exit_code = 239
 name = "parse_i32_zero"
 spec = ["4.13:43", "4.13:44"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let s = "0";
-    @parse_i32(s)
+    let Opt = Option(i32);
+    match @parse_i32("0") {
+        Opt::Some(n) => n,
+        Opt::None => 1,
+    }
 }
 """
 exit_code = 0
@@ -762,9 +820,13 @@ exit_code = 0
 name = "parse_i32_leading_zeros"
 spec = ["4.13:43", "4.13:47"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let s = "007";
-    @parse_i32(s)
+    let Opt = Option(i32);
+    match @parse_i32("007") {
+        Opt::Some(n) => n,
+        Opt::None => 0,
+    }
 }
 """
 exit_code = 7
@@ -773,11 +835,16 @@ exit_code = 7
 name = "parse_i32_string_not_consumed"
 spec = ["4.13:46"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
+    let Opt = Option(i32);
     let s = "42";
-    let n = @parse_i32(s);
+    let n: Opt = @parse_i32(s);
     @dbg(s);
-    n
+    match n {
+        Opt::Some(v) => v,
+        Opt::None => 0,
+    }
 }
 """
 exit_code = 42
@@ -786,10 +853,13 @@ exit_code = 42
 name = "parse_i64_basic"
 spec = ["4.13:43", "4.13:44", "4.13:45"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let s = "123";
-    let n = @parse_i64(s);
-    @intCast(n)
+    let Opt = Option(i64);
+    match @parse_i64("123") {
+        Opt::Some(n) => @intCast(n),
+        Opt::None => 0,
+    }
 }
 """
 exit_code = 123
@@ -798,10 +868,13 @@ exit_code = 123
 name = "parse_i64_negative"
 spec = ["4.13:43", "4.13:44", "4.13:47"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let s = "-5";
-    let n = @parse_i64(s);
-    @intCast(n)
+    let Opt = Option(i64);
+    match @parse_i64("-5") {
+        Opt::Some(n) => @intCast(n),
+        Opt::None => 0,
+    }
 }
 """
 exit_code = 251
@@ -810,10 +883,13 @@ exit_code = 251
 name = "parse_u32_basic"
 spec = ["4.13:43", "4.13:44", "4.13:45"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let s = "42";
-    let n = @parse_u32(s);
-    @intCast(n)
+    let Opt = Option(u32);
+    match @parse_u32("42") {
+        Opt::Some(n) => @intCast(n),
+        Opt::None => 0,
+    }
 }
 """
 exit_code = 42
@@ -822,10 +898,13 @@ exit_code = 42
 name = "parse_u64_basic"
 spec = ["4.13:43", "4.13:44", "4.13:45"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let s = "99";
-    let n = @parse_u64(s);
-    @intCast(n)
+    let Opt = Option(u64);
+    match @parse_u64("99") {
+        Opt::Some(n) => @intCast(n),
+        Opt::None => 0,
+    }
 }
 """
 exit_code = 99
@@ -862,74 +941,91 @@ compile_fail = true
 error_contains = "String"
 
 [[case]]
-name = "parse_empty_string_panic"
+name = "parse_empty_string_yields_none"
 spec = ["4.13:49"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let s = "";
-    @parse_i32(s)
+    let Opt = Option(i32);
+    match @parse_i32("") {
+        Opt::Some(n) => n,
+        Opt::None => 42,
+    }
 }
 """
-exit_code = 101
-stderr_contains = "parse error"
+exit_code = 42
 
 [[case]]
-name = "parse_invalid_char_panic"
+name = "parse_invalid_char_yields_none"
 spec = ["4.13:49"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let s = "12abc";
-    @parse_i32(s)
+    let Opt = Option(i32);
+    match @parse_i32("12abc") {
+        Opt::Some(n) => n,
+        Opt::None => 42,
+    }
 }
 """
-exit_code = 101
-stderr_contains = "parse error"
+exit_code = 42
 
 [[case]]
-name = "parse_overflow_i32_panic"
+name = "parse_overflow_i32_yields_none"
 spec = ["4.13:49"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let s = "2147483648";
-    @parse_i32(s)
+    let Opt = Option(i32);
+    match @parse_i32("2147483648") {
+        Opt::Some(n) => n,
+        Opt::None => 42,
+    }
 }
 """
-exit_code = 101
-stderr_contains = "parse error"
+exit_code = 42
 
 [[case]]
-name = "parse_overflow_u32_panic"
+name = "parse_overflow_u32_yields_none"
 spec = ["4.13:49"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let s = "4294967296";
-    let n = @parse_u32(s);
-    @intCast(n)
+    let Opt = Option(u32);
+    match @parse_u32("4294967296") {
+        Opt::Some(n) => @intCast(n),
+        Opt::None => 42,
+    }
 }
 """
-exit_code = 101
-stderr_contains = "parse error"
+exit_code = 42
 
 [[case]]
-name = "parse_negative_unsigned_panic"
+name = "parse_negative_unsigned_yields_none"
 spec = ["4.13:48", "4.13:49"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let s = "-1";
-    let n = @parse_u32(s);
-    @intCast(n)
+    let Opt = Option(u32);
+    match @parse_u32("-1") {
+        Opt::Some(n) => @intCast(n),
+        Opt::None => 42,
+    }
 }
 """
-exit_code = 101
-stderr_contains = "parse error"
+exit_code = 42
 
 [[case]]
 name = "parse_i32_max"
 spec = ["4.13:43", "4.13:44"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
-    let s = "127";
-    @parse_i32(s)
+    let Opt = Option(i32);
+    match @parse_i32("127") {
+        Opt::Some(n) => n,
+        Opt::None => 0,
+    }
 }
 """
 exit_code = 127
@@ -938,12 +1034,14 @@ exit_code = 127
 name = "parse_i32_boundary"
 spec = ["4.13:43", "4.13:44"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     // Test parsing of i32::MAX (doesn't overflow)
-    let s = "2147483647";
-    let n = @parse_i32(s);
-    // Return a value we can verify (255 & 0xFF = 255)
-    if n == 2147483647 { 255 } else { 1 }
+    let Opt = Option(i32);
+    match @parse_i32("2147483647") {
+        Opt::Some(n) => if n == 2147483647 { 255 } else { 1 },
+        Opt::None => 1,
+    }
 }
 """
 exit_code = 255
@@ -952,12 +1050,14 @@ exit_code = 255
 name = "parse_i32_min"
 spec = ["4.13:43", "4.13:44", "4.13:47"]
 source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
 fn main() -> i32 {
     // Test parsing of i32::MIN (doesn't overflow)
-    let s = "-2147483648";
-    let n = @parse_i32(s);
-    // Return a value we can verify
-    if n == -2147483648 { 254 } else { 1 }
+    let Opt = Option(i32);
+    match @parse_i32("-2147483648") {
+        Opt::Some(n) => if n == -2147483648 { 254 } else { 1 },
+        Opt::None => 1,
+    }
 }
 """
 exit_code = 254

--- a/docs/designs/0021-stdin-input.md
+++ b/docs/designs/0021-stdin-input.md
@@ -17,6 +17,13 @@ superseded-by:
 
 Implemented
 
+> **Amended by RUE-6 / ADR-0038 (error handling).** `@read_line` no longer
+> returns a bare `String` and no longer panics at end-of-input. It now returns
+> `Option(String)`: `Some(line)` on a successful read (including a partial line
+> at EOF) and `None` when EOF is reached with no data, so a read-until-EOF loop
+> terminates cleanly instead of trapping. A genuine I/O read error still panics.
+> See ADR-0038 and spec §4.13 for the current behavior.
+
 ## Summary
 
 Add a `@read_line()` intrinsic that reads a line of text from standard input and returns it as a `String`. On EOF or I/O error, the intrinsic panics. This provides the simplest possible input mechanism for Rue programs.

--- a/docs/designs/0022-integer-parsing.md
+++ b/docs/designs/0022-integer-parsing.md
@@ -17,6 +17,14 @@ superseded-by:
 
 Implemented
 
+> **Amended by RUE-6 / ADR-0038 (error handling).** These intrinsics no longer
+> return a bare integer and no longer panic on bad input. Each now returns
+> `Option(T)` for its target type `T`: `Some(n)` on a successful parse and
+> `None` on failure (empty string, invalid character, overflow, or a negative
+> value for an unsigned type). The `@try_parse_*` idea below is subsumed — the
+> ordinary `@parse_*` is now the fallible-by-`Option` form. See ADR-0038 and
+> spec §4.13.
+
 ## Summary
 
 Add intrinsics to parse strings into integer values: `@parse_i32`, `@parse_i64`, `@parse_u32`, `@parse_u64`. These intrinsics accept a `String` and return the corresponding integer type, panicking on invalid input or overflow. This enables programs to process numeric input from users or files.

--- a/docs/notes/first-program-cross-language.md
+++ b/docs/notes/first-program-cross-language.md
@@ -130,34 +130,46 @@ model Rue is built on, and the felt experience of the mutation is identical.
 
 ```rue
 fn main() -> i32 {
-    let Opt = @import("../std/option.rue").Option(i64);   // no prelude yet
-    let n = @parse_i64(@read_line());                     // count prefix required
+    let OptStr = @import("../std/option.rue").Option(String);  // no prelude yet
+    let OptInt = @import("../std/option.rue").Option(i64);
 
-    let mut i: i64 = 0;
+    let mut count: i64 = 0;
     let mut sum: i64 = 0;
-    let mut max: Opt = Opt::None;
-    while i < n {
-        let x = @parse_i64(@read_line());                 // traps on bad input
-        sum = sum + x;
-        max = match max {
-            Opt::None => Opt::Some(x),
-            Opt::Some(m) => if x > m { Opt::Some(x) } else { Opt::Some(m) },
-        };
-        i = i + 1;
+    let mut max: OptInt = OptInt::None;
+    loop {
+        let line: OptStr = @read_line();                       // None at EOF
+        match line {
+            OptStr::None => break,                             // read-until-EOF
+            OptStr::Some(text) => {
+                match @parse_i64(text) {                       // None on bad input
+                    OptInt::Some(x) => {
+                        count = count + 1;
+                        sum = sum + x;
+                        max = match max {
+                            OptInt::None => OptInt::Some(x),
+                            OptInt::Some(m) => if x > m { OptInt::Some(x) } else { OptInt::Some(m) },
+                        };
+                    },
+                    OptInt::None => {},                        // skip, no trap
+                }
+            },
+        }
     }
 
-    println("count: " + @to_string(n));
+    println("count: " + @to_string(count));
     println("sum: " + @to_string(sum));
     match max {
-        Opt::Some(m) => println("max: " + @to_string(m)),
-        Opt::None => println("max: (no input)"),
+        OptInt::Some(m) => println("max: " + @to_string(m)),
+        OptInt::None => println("max: (no input)"),
     }
-    @intCast(n)
+    @intCast(count)
 }
 ```
 
-The logic is the same. The friction is entirely in three seams the other four
-languages don't have.
+The logic is the same, and — since error handling landed (RUE-6, ADR-0038) —
+the EOF and parse-failure seams are gone: this is a natural read-until-EOF loop
+with no count prefix and no traps. The remaining friction is the imported
+`Option` (no prelude yet) and i64-only `@to_string`.
 
 ---
 
@@ -165,8 +177,8 @@ languages don't have.
 
 | | Rust | Swift | Zig | Hylo | **Rue (today)** |
 |---|---|---|---|---|---|
-| **EOF** | iterator / read-to-end | `readLine() -> String?` | `…OrEof -> ?[]u8` | Optional | **traps** — needs a count prefix |
-| **Parse failure** | `Result` + `?` | `Int() -> Int?` | error union + `catch` | Optional | **traps** — `@parse_i64 -> i64` |
+| **EOF** | iterator / read-to-end | `readLine() -> String?` | `…OrEof -> ?[]u8` | Optional | `@read_line -> Option(String)`, `None` at EOF |
+| **Parse failure** | `Result` + `?` | `Int() -> Int?` | error union + `catch` | Optional | `@parse_i64 -> Option(i64)`, `None` on bad input |
 | **Optional type** | `Option<T>` (prelude) | `T?` (built in) | `?T` (built in) | `Optional` (std) | **`@import`ed** — no prelude |
 | **Error propagation** | `?` | `try` / `do`-`catch` | `try` / `catch` | — | **none yet** |
 | **Numeric formatting** | `{}` any width | `\()` any | `{d}` any | `\()` any | **`@to_string` is i64-only** |

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -45,11 +45,11 @@ The following table provides a quick reference to all available intrinsics:
 | `@size_of` | Get type size in bytes | 1 type | `i32` |
 | `@align_of` | Get type alignment in bytes | 1 type | `i32` |
 | `@intCast` | Convert between integer types | 1 expression (integer) | inferred integer type |
-| `@read_line` | Read line from stdin | none | `String` |
-| `@parse_i32` | Parse string to i32 | 1 expression (`String`) | `i32` |
-| `@parse_i64` | Parse string to i64 | 1 expression (`String`) | `i64` |
-| `@parse_u32` | Parse string to u32 | 1 expression (`String`) | `u32` |
-| `@parse_u64` | Parse string to u64 | 1 expression (`String`) | `u64` |
+| `@read_line` | Read line from stdin | none | `Option(String)` |
+| `@parse_i32` | Parse string to i32 | 1 expression (`String`) | `Option(i32)` |
+| `@parse_i64` | Parse string to i64 | 1 expression (`String`) | `Option(i64)` |
+| `@parse_u32` | Parse string to u32 | 1 expression (`String`) | `Option(u32)` |
+| `@parse_u64` | Parse string to u64 | 1 expression (`String`) | `Option(u64)` |
 | `@random_u32` | Generate random u32 | none | `u32` |
 | `@random_u64` | Generate random u64 | none | `u64` |
 | `@target_arch` | Get target architecture | none | `Arch` |
@@ -255,7 +255,7 @@ The `@read_line` intrinsic reads a line of text from standard input.
 
 {{ rule(id="4.13:35", cat="normative") }}
 
-The return type of `@read_line` is `String`.
+The return type of `@read_line` is `Option(String)`, where `Option` is the ordinary comptime-generic library enum (`enum { Some(T), None }`, ADR-0038). The concrete `Option(String)` type is taken from the surrounding context — a `let` binding annotation, or the arms of a `match` on the result — so `Option` must be in scope (e.g. imported) at the call site.
 
 {{ rule(id="4.13:36", cat="dynamic-semantics") }}
 
@@ -263,15 +263,15 @@ The return type of `@read_line` is `String`.
 
 {{ rule(id="4.13:37", cat="dynamic-semantics") }}
 
-The returned `String` does **not** include the trailing newline character.
+On a successful read the result is `Some(line)`, where the `line` `String` does **not** include the trailing newline character.
 
 {{ rule(id="4.13:38", cat="dynamic-semantics") }}
 
-If end-of-file is reached with some data read, the partial line is returned.
+If end-of-file is reached with some data read, the partial line is returned as `Some(line)`.
 
 {{ rule(id="4.13:39", cat="dynamic-semantics") }}
 
-If end-of-file is reached with no data read, a runtime panic occurs with the message "unexpected end of input".
+If end-of-file is reached with no data read, the result is `None` (this is not an error; a read-until-end-of-input loop terminates by observing `None`).
 
 {{ rule(id="4.13:40", cat="informative") }}
 
@@ -281,24 +281,30 @@ If a read error occurs, a runtime panic occurs with the message "input error". (
 
 ```rue
 fn main() -> i32 {
+    let Opt = @import("std/option.rue").Option(String);
     @dbg("What is your name?");
-    let name = @read_line();
-    @dbg("Hello, ");
-    @dbg(name);
+    match @read_line() {
+        Opt::Some(name) => @dbg(name),
+        Opt::None => @dbg("(no input)"),
+    }
     0
 }
 ```
 
 {{ rule(id="4.13:42") }}
 
-Reading multiple lines:
+Reading every line until end-of-input:
 
 ```rue
 fn main() -> i32 {
-    let line1 = @read_line();  // First line
-    let line2 = @read_line();  // Second line
-    @dbg(line1);
-    @dbg(line2);
+    let Opt = @import("std/option.rue").Option(String);
+    loop {
+        let line: Opt = @read_line();
+        match line {
+            Opt::None => break,
+            Opt::Some(text) => @dbg(text),
+        }
+    }
     0
 }
 ```
@@ -311,11 +317,13 @@ The integer parsing intrinsics convert a string to an integer value.
 
 {{ rule(id="4.13:44", cat="normative") }}
 
-The following parsing intrinsics are available:
-- `@parse_i32` returns `i32`
-- `@parse_i64` returns `i64`
-- `@parse_u32` returns `u32`
-- `@parse_u64` returns `u64`
+Each parsing intrinsic returns `Option(T)` for its target integer type `T`, where `Option` is the ordinary comptime-generic library enum (ADR-0038):
+- `@parse_i32` returns `Option(i32)`
+- `@parse_i64` returns `Option(i64)`
+- `@parse_u32` returns `Option(u32)`
+- `@parse_u64` returns `Option(u64)`
+
+The concrete `Option(T)` type is taken from the surrounding context (a `let` annotation, or the arms of a `match` on the result), so `Option` must be in scope at the call site.
 
 {{ rule(id="4.13:45", cat="normative") }}
 
@@ -327,7 +335,7 @@ The string argument is borrowed, not consumed. The original string remains valid
 
 {{ rule(id="4.13:47", cat="normative") }}
 
-The parsed string must match the following grammar:
+A successful parse yields `Some(n)`. The parsed string is parsed successfully when it matches the following grammar:
 
 ```ebnf
 integer_string = [ "-" ] digit { digit } ;
@@ -336,11 +344,11 @@ digit = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "8" | "9" ;
 
 {{ rule(id="4.13:48", cat="legality-rule") }}
 
-Leading minus signs are only allowed for signed types (`@parse_i32`, `@parse_i64`).
+Leading minus signs are only allowed for signed types (`@parse_i32`, `@parse_i64`); a negative value for an unsigned type is a parse failure (yields `None`).
 
 {{ rule(id="4.13:49", cat="dynamic-semantics") }}
 
-A runtime panic occurs if:
+The result is `None` (a recoverable parse failure, not a panic) if:
 - The string is empty
 - The string contains non-digit characters (other than an optional leading minus)
 - The value overflows the target type
@@ -350,9 +358,11 @@ A runtime panic occurs if:
 
 ```rue
 fn main() -> i32 {
-    let s = "42";
-    let n = @parse_i32(s);
-    n  // returns 42
+    let Opt = @import("std/option.rue").Option(i32);
+    match @parse_i32("42") {
+        Opt::Some(n) => n,   // returns 42
+        Opt::None => 0,
+    }
 }
 ```
 
@@ -360,9 +370,11 @@ fn main() -> i32 {
 
 ```rue
 fn main() -> i32 {
-    let s = "-17";
-    let n = @parse_i32(s);
-    n  // returns -17
+    let Opt = @import("std/option.rue").Option(i32);
+    match @parse_i32("-17") {
+        Opt::Some(n) => n,   // returns -17
+        Opt::None => 0,
+    }
 }
 ```
 
@@ -370,33 +382,41 @@ fn main() -> i32 {
 
 ```rue
 fn main() -> i32 {
+    let Opt = @import("std/option.rue").Option(i32);
     let s = "42";
     // String is borrowed, not consumed
-    let n = @parse_i32(s);
+    let parsed: Opt = @parse_i32(s);
     @dbg(s);  // s is still valid
-    n
+    match parsed {
+        Opt::Some(n) => n,
+        Opt::None => 0,
+    }
 }
 ```
 
 {{ rule(id="4.13:53") }}
 
 ```rue
-// This panics at runtime: invalid character
+// An invalid character is a recoverable failure: `None`, not a panic.
 fn main() -> i32 {
-    let s = "12abc";
-    let n = @parse_i32(s);  // panic: invalid character
-    n
+    let Opt = @import("std/option.rue").Option(i32);
+    match @parse_i32("12abc") {
+        Opt::Some(n) => n,
+        Opt::None => -1,   // taken: "12abc" is not an integer
+    }
 }
 ```
 
 {{ rule(id="4.13:54") }}
 
 ```rue
-// This panics at runtime: negative for unsigned
+// A negative value for an unsigned type is a recoverable failure: `None`.
 fn main() -> i32 {
-    let s = "-17";
-    let n: u32 = @parse_u32(s);  // panic: negative value for unsigned type
-    @intCast(n)
+    let Opt = @import("std/option.rue").Option(u32);
+    match @parse_u32("-17") {
+        Opt::Some(n) => @intCast(n),
+        Opt::None => 0,   // taken: "-17" is negative
+    }
 }
 ```
 
@@ -438,22 +458,32 @@ Using `@random_u32` in a guessing game:
 
 ```rue
 fn main() -> i32 {
+    let OptStr = @import("std/option.rue").Option(String);
+    let OptU32 = @import("std/option.rue").Option(u32);
     let secret: u32 = (@random_u32() % 100) + 1;  // 1-100
     @dbg("Guess the number between 1 and 100!");
 
     let mut guesses = 0;
     loop {
-        let input = @read_line();
-        let guess = @parse_u32(input);
-        guesses = guesses + 1;
-
-        if guess < secret {
-            @dbg("Too low!");
-        } else if guess > secret {
-            @dbg("Too high!");
-        } else {
-            @dbg("You got it!");
-            break;
+        let input: OptStr = @read_line();
+        match input {
+            OptStr::None => break,          // end of input
+            OptStr::Some(text) => {
+                match @parse_u32(text) {
+                    OptU32::Some(guess) => {
+                        guesses = guesses + 1;
+                        if guess < secret {
+                            @dbg("Too low!");
+                        } else if guess > secret {
+                            @dbg("Too high!");
+                        } else {
+                            @dbg("You got it!");
+                            break;
+                        }
+                    },
+                    OptU32::None => @dbg("not a number, try again"),
+                }
+            },
         }
     }
 

--- a/examples/first/stats.rue
+++ b/examples/first/stats.rue
@@ -1,51 +1,61 @@
 // The first real Rue program (RUE-226 dogfooding milestone).
 //
-// Reads a count N on the first line, then N integers (one per line), and
+// Reads integers from standard input, one per line, until end-of-input, and
 // prints how many were read, their sum, and the maximum.
 //
-//   $ printf '3\n7\n5\n1\n' | rue examples/first/stats.rue examples/std/option.rue -o stats && ./stats
+//   $ printf '7\n5\n1\n' | rue examples/first/stats.rue -o stats && ./stats
 //   count: 3
 //   sum: 13
 //   max: 7
 //
-// Two things this program reveals about Rue today (the point of dogfooding):
+// This is now a *natural read-until-EOF loop* — no count prefix. Error handling
+// landed (RUE-6, ADR-0038), so @read_line returns Option(String) (None at EOF)
+// and @parse_i64 returns Option(i64) (None on a non-numeric line) instead of
+// trapping. The loop `break`s on None from @read_line and simply skips lines
+// that fail to parse. This is what the dogfooding milestone was reaching for:
+// the first real program can read an unbounded stream cleanly.
 //
-//   * No prelude yet (RUE-287): `Option` is not in scope automatically, so we
-//     @import it from the std library. Every peer language (Rust, Swift, Zig)
-//     has an optional type built in.
-//   * A count-prefixed format is used because @read_line traps on EOF and
-//     @parse_i64 traps on bad input rather than signalling failure. Once error
-//     handling lands (RUE-6), this becomes a natural read-until-EOF loop.
+// The one rough edge that remains (RUE-287): no prelude yet, so `Option` is not
+// in scope automatically — we @import it from the std library. Every peer
+// language (Rust, Swift, Zig) has an optional type built in.
 //
-// Exercises the now-stabilized dogfooding set: @read_line, @parse_i64, a generic
-// Option, String concatenation + @to_string, println, and a while loop with a
-// match expression modelling "the max of a possibly-empty set".
+// Exercises the dogfooding set end to end: @read_line, @parse_i64, a generic
+// Option, String concatenation + @to_string, println, a loop, and match.
 
 fn main() -> i32 {
-    let Opt = @import("../std/option.rue").Option(i64);
+    let OptStr = @import("../std/option.rue").Option(String);
+    let OptInt = @import("../std/option.rue").Option(i64);
 
-    let n = @parse_i64(@read_line());
-
-    let mut i: i64 = 0;
+    let mut count: i64 = 0;
     let mut sum: i64 = 0;
-    let mut max: Opt = Opt::None;
+    let mut max: OptInt = OptInt::None;
 
-    while i < n {
-        let x = @parse_i64(@read_line());
-        sum = sum + x;
-        max = match max {
-            Opt::None => Opt::Some(x),
-            Opt::Some(m) => if x > m { Opt::Some(x) } else { Opt::Some(m) },
-        };
-        i = i + 1;
+    loop {
+        let line: OptStr = @read_line();
+        match line {
+            OptStr::None => break,
+            OptStr::Some(text) => {
+                match @parse_i64(text) {
+                    OptInt::Some(x) => {
+                        count = count + 1;
+                        sum = sum + x;
+                        max = match max {
+                            OptInt::None => OptInt::Some(x),
+                            OptInt::Some(m) => if x > m { OptInt::Some(x) } else { OptInt::Some(m) },
+                        };
+                    },
+                    OptInt::None => {},
+                }
+            },
+        }
     }
 
-    println("count: " + @to_string(n));
+    println("count: " + @to_string(count));
     println("sum: " + @to_string(sum));
     match max {
-        Opt::Some(m) => println("max: " + @to_string(m)),
-        Opt::None => println("max: (no input)"),
+        OptInt::Some(m) => println("max: " + @to_string(m)),
+        OptInt::None => println("max: (no input)"),
     }
 
-    @intCast(n)
+    @intCast(count)
 }


### PR DESCRIPTION
The #1 dogfooding gap: the first real program couldn't loop over stdin because @read_line trapped on EOF and @parse_* trapped on bad input. Now both signal failure through the ordinary in-scope library Option (ADR-0038):
- @read_line() -> Option(String): Some(line), None at EOF.
- @parse_i32/i64/u32/u64 -> Option(int): Some(n), None on parse failure.

**Answers the RUE-315 mechanism question without a new magic tier**: the intrinsic's return unifies with the in-scope std Option. Since inference can't resolve a comptime-generic Option alias alone, the concrete type is threaded through sema via a narrow expected_type around let-initializers + match scrutinees; runtime writes the tagged-union Option to an sret buffer, codegen loads its slots (both backends).

examples/first/stats.rue is now a natural read-until-EOF loop (count-prefix workaround gone); stdin.toml's parse/EOF cases changed from 'panics' to recoverable None.

Verified: read-until-EOF sum (3/7/1 -> sum 11); empty stdin no trap; bad lines skip; String payload round-trips. clippy-gate-passed; test.sh Pass 24 (649/649); 8000 fuzz runs 0 crashes.

Deferred (separable): the ?-operator. Discovered a pre-existing @import ../-relative-path quirk (E0707) worth filing.

Part of RUE-6

Generated with Claude Code