### PR TITLE
cache-probe workflow: fix actionlint SC2129 + use the working RE config

### DIFF
--- a/.github/workflows/cache-probe.yml
+++ b/.github/workflows/cache-probe.yml
@@ -35,11 +35,14 @@ jobs:
         run: |
           cat > .buckconfig.local <<EOF
           [buck2_re_client]
-          engine_address = remote.buildbuddy.io
-          action_cache_address = remote.buildbuddy.io
-          cas_address = remote.buildbuddy.io
+          engine_address = grpc://remote.buildbuddy.io
+          action_cache_address = grpc://remote.buildbuddy.io
+          cas_address = grpc://remote.buildbuddy.io
           tls = true
           http_headers = x-buildbuddy-api-key:${KEY}
+
+          [buck2]
+          digest_algorithms = SHA256
 
           [build]
           execution_platforms = root//platforms:remote_cache
@@ -58,9 +61,11 @@ jobs:
       - name: Cache-hit summary
         if: always()
         run: |
-          echo "### Remote cache probe" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          echo "COLD: $(grep -oE 'Commands: .*' cold.log | tail -1)" >> "$GITHUB_STEP_SUMMARY"
-          echo "WARM: $(grep -oE 'Commands: .*' warm.log | tail -1)" >> "$GITHUB_STEP_SUMMARY"
-          echo '```' >> "$GITHUB_STEP_SUMMARY"
-          echo "A non-zero 'cached'/'remote' count on WARM means the remote cache is working."
+          {
+            echo "### Remote cache probe"
+            echo '```'
+            echo "COLD: $(grep -oE 'Commands: .*' cold.log | tail -1)"
+            echo "WARM: $(grep -oE 'Commands: .*' warm.log | tail -1)"
+            echo '```'
+            echo "A non-zero 'cached'/'remote' count on WARM means the remote cache is working."
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
The actionlint gate flagged **SC2129** (individual redirects) in the cache-probe summary step — grouped into a single `{ ...; } >> ` block. Also updated the transient `.buckconfig.local` the probe writes to the config that actually connects: `grpc://` scheme (buck2 rejects `grpcs://`) + `digest_algorithms = SHA256`, matching `.buckconfig.local.example` (RUE-316).

Doc/CI-only; actionlint clean locally.

Generated with Claude Code