### PR TITLE
Error handling: the ? (try) operator for Option (part of RUE-6)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -651,6 +651,27 @@ impl<'a> ConstraintGenerator<'a> {
                 result_ty
             }
 
+            // Try/`?`: unwraps `Option(T)` to `T` (RUE-6, ADR-0038). When the
+            // operand's type is already a concrete `Option`-shaped enum, the
+            // result is its `Some` payload; otherwise a fresh variable that
+            // sema types authoritatively from the operand's enum. Sema does the
+            // full checking (operand is Option, enclosing fn returns Option).
+            InstData::Try { operand } => {
+                let operand_info = self.generate(*operand, ctx);
+                match &operand_info.ty {
+                    InferType::Concrete(ty) => ty
+                        .as_enum()
+                        .map(|enum_id| self.type_pool.enum_def(enum_id))
+                        .and_then(|def| {
+                            def.find_variant("Some")
+                                .and_then(|si| def.variant_payload(si).first().copied())
+                        })
+                        .map(InferType::Concrete)
+                        .unwrap_or_else(|| InferType::Var(self.fresh_var())),
+                    _ => InferType::Var(self.fresh_var()),
+                }
+            }
+
             // Variable reference
             InstData::VarRef { name } => {
                 if let Some(local) = ctx.locals.get(name) {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -2478,6 +2478,7 @@ impl<'a> Sema<'a> {
             | InstData::Loop { .. }
             | InstData::InfiniteLoop { .. }
             | InstData::Match { .. }
+            | InstData::Try { .. }
             | InstData::Break { .. }
             | InstData::Continue
             | InstData::Ret(_)

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -640,6 +640,8 @@ impl<'a> Sema<'a> {
                 arms_len,
             } => self.analyze_match(air, *scrutinee, *arms_start, *arms_len, inst.span, ctx),
 
+            InstData::Try { operand } => self.analyze_try(air, *operand, inst.span, ctx),
+
             InstData::Break { value } => {
                 // Validate that we're inside a loop
                 if ctx.loop_depth == 0 {
@@ -1718,6 +1720,189 @@ impl<'a> Sema<'a> {
             span,
         });
         Ok(AnalysisResult::new(air_ref, final_type))
+    }
+
+    /// If `enum_id` names an `Option`-shaped enum — exactly two variants, a
+    /// single-payload `Some(T)` and an empty `None` — return
+    /// `(some_index, none_index, payload_type)`. Used by the `?` operator to
+    /// recognise the in-scope library `Option` by structure and name
+    /// (RUE-6, ADR-0038), rather than as a privileged builtin.
+    fn option_enum_shape(&self, enum_id: crate::types::EnumId) -> Option<(u32, u32, Type)> {
+        let def = self.type_pool.enum_def(enum_id);
+        if def.variant_count() != 2 {
+            return None;
+        }
+        let some_idx = def.find_variant("Some")?;
+        let none_idx = def.find_variant("None")?;
+        let some_payload = def.variant_payload(some_idx);
+        let none_payload = def.variant_payload(none_idx);
+        if some_payload.len() == 1 && none_payload.is_empty() {
+            Some((some_idx as u32, none_idx as u32, some_payload[0]))
+        } else {
+            None
+        }
+    }
+
+    /// Analyze the `?` operator (RUE-6, ADR-0038).
+    ///
+    /// `operand?` requires `operand` to be an `Option(T)` and the enclosing
+    /// function to return an `Option(U)`. It evaluates to `T` on `Some(v)` and
+    /// early-returns the enclosing function's `None` on `None`. This is the
+    /// desugaring `match operand { Some(v) => v, None => return None }`, built
+    /// directly against the resolved enum types (so no source type name is
+    /// needed): a two-arm discriminant `Match` whose `None` arm returns.
+    fn analyze_try(
+        &mut self,
+        air: &mut Air,
+        operand: InstRef,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        // The enclosing function must return an `Option`; `?` propagates its
+        // `None`. Resolve that shape first so a clear error fires even when the
+        // operand is fine (E0503).
+        let return_type = ctx.return_type;
+        let ret_shape = return_type.as_enum().and_then(|rid| {
+            self.option_enum_shape(rid)
+                .map(|(_, none_idx, _)| (rid, none_idx))
+        });
+        let (ret_enum_id, ret_none_idx) = match ret_shape {
+            Some(s) => s,
+            None => {
+                // Still analyze the operand so unrelated errors inside it are
+                // reported, but the `?` itself is the diagnostic.
+                if return_type.is_error() {
+                    let r = self.analyze_inst(air, operand, ctx)?;
+                    return Ok(AnalysisResult::new(r.air_ref, Type::ERROR));
+                }
+                return Err(CompileError::new(
+                    ErrorKind::QuestionOutsideOptionFn {
+                        return_type: return_type.safe_name_with_pool(Some(&self.type_pool)),
+                    },
+                    span,
+                ));
+            }
+        };
+
+        // Analyze the operand.
+        //
+        // The operand's own type must already be known: `?` works on any typed
+        // `Option` value (a function result, constructor, variable, etc.). A BARE
+        // fallible-intrinsic operand — `@read_line()?` / `@parse_i64(s)?` — is NOT
+        // yet supported: those intrinsics need their exact `Option` return type
+        // (e.g. `Option(String)`) as an expected type, which the `?` site cannot
+        // supply (the enclosing fn's `Option(U)` has the wrong payload — E0702).
+        // Use `let x: Option(String) = @read_line();` + `match` for now; resolving
+        // a fallible intrinsic through `?`-context is a follow-up (RUE-318).
+        let operand_result = self.analyze_inst(air, operand, ctx)?;
+        let operand_ty = operand_result.ty;
+
+        if operand_ty.is_error() {
+            return Ok(AnalysisResult::new(operand_result.air_ref, Type::ERROR));
+        }
+
+        // The operand must be an `Option`-shaped enum (E0504).
+        let (some_idx, none_idx, payload_ty) = match operand_ty
+            .as_enum()
+            .and_then(|oid| self.option_enum_shape(oid).map(|s| (oid, s)))
+        {
+            Some((_oid, shape)) => shape,
+            None => {
+                return Err(CompileError::new(
+                    ErrorKind::QuestionOnNonOption {
+                        found: operand_ty.safe_name_with_pool(Some(&self.type_pool)),
+                    },
+                    span,
+                ));
+            }
+        };
+        let operand_enum_id = operand_ty
+            .as_enum()
+            .expect("operand is an Option-shaped enum");
+
+        // Some(v) arm: read the payload out of the scrutinee; that value is the
+        // arm's (and the whole `?`-expression's) result. Mirrors the payload
+        // read that a `Some(v) => v` match arm performs (RUE-221).
+        let some_body = air.add_inst(AirInst {
+            data: AirInstData::EnumPayloadGet {
+                base: operand_result.air_ref,
+                enum_id: operand_enum_id,
+                variant_index: some_idx,
+                field_index: 0,
+            },
+            ty: payload_ty,
+            span,
+        });
+
+        // None arm: drop the scrutinee (a non-binding arm consumes it; the
+        // active `None` variant carries nothing, so the drop glue is a no-op),
+        // then `return` the enclosing function's `None`.
+        let drop_scrutinee = air.add_inst(AirInst {
+            data: AirInstData::Drop {
+                value: operand_result.air_ref,
+            },
+            ty: Type::UNIT,
+            span,
+        });
+        let none_ctor = air.add_inst(AirInst {
+            data: AirInstData::EnumVariant {
+                enum_id: ret_enum_id,
+                variant_index: ret_none_idx,
+                payload_start: 0,
+                payload_len: 0,
+            },
+            ty: return_type,
+            span,
+        });
+        let ret = air.add_inst(AirInst {
+            data: AirInstData::Ret(Some(none_ctor)),
+            ty: Type::NEVER,
+            span,
+        });
+        let none_stmts = air.add_extra(&[drop_scrutinee.as_u32()]);
+        let none_body = air.add_inst(AirInst {
+            data: AirInstData::Block {
+                stmts_start: none_stmts,
+                stmts_len: 1,
+                value: ret,
+            },
+            ty: Type::NEVER,
+            span,
+        });
+
+        // Encode the two arms and emit the dispatching match. Its value type is
+        // the `Some` payload (the `None` arm diverges).
+        let air_arms = [
+            (
+                AirPattern::EnumVariant {
+                    enum_id: operand_enum_id,
+                    variant_index: some_idx,
+                },
+                some_body,
+            ),
+            (
+                AirPattern::EnumVariant {
+                    enum_id: operand_enum_id,
+                    variant_index: none_idx,
+                },
+                none_body,
+            ),
+        ];
+        let mut extra_data = Vec::new();
+        for (pattern, body) in &air_arms {
+            pattern.encode(*body, &mut extra_data);
+        }
+        let arms_start = air.add_extra(&extra_data);
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Match {
+                scrutinee: operand_result.air_ref,
+                arms_start,
+                arms_len: air_arms.len() as u32,
+            },
+            ty: payload_ty,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, payload_ty))
     }
 
     /// Materialize the payload bindings of a tuple-variant match pattern

--- a/crates/rue-cli-tests/cases/try_operator.toml
+++ b/crates/rue-cli-tests/cases/try_operator.toml
@@ -1,0 +1,128 @@
+[section]
+id = "cli.try_operator"
+name = "The `?` (try) operator on Option"
+description = "End-to-end runtime behavior of `?`: unwrap Some, short-circuit None, propagate a String payload, and the two static errors (E0503/E0504). RUE-6, ADR-0038."
+
+# The `?` operator unwraps Some and short-circuits None, driven from real stdin
+# through the compiled binary. `pick` returns Some for a positive count and None
+# otherwise; `run` uses `?` to propagate.
+[[case]]
+name = "try_unwrap_and_short_circuit"
+files = [
+  { path = "main.rue", source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn parse_positive(n: i64) -> Option(i64) {
+    let O = Option(i64);
+    if n > 0 { O::Some(n) } else { O::None }
+}
+fn triple(n: i64) -> Option(i64) {
+    let O = Option(i64);
+    let v = parse_positive(n)?;
+    O::Some(v * 3)
+}
+fn report(n: i64) {
+    let O = Option(i64);
+    match triple(n) {
+        O::Some(m) => println("triple: " + @to_string(m)),
+        O::None => println("triple: none"),
+    }
+}
+fn main() -> i32 {
+    report(4);
+    report(0 - 2);
+    report(0);
+    0
+}
+""" },
+]
+args = ["main.rue", "-o", "prog"]
+stdout = """
+triple: 12
+triple: none
+triple: none
+"""
+exit_code = 0
+
+# A non-Copy (String) payload moves out through `?` correctly on the Some path
+# and is not touched on the None path.
+[[case]]
+name = "try_string_payload"
+files = [
+  { path = "main.rue", source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn lookup(found: bool) -> Option(String) {
+    let O = Option(String);
+    if found { O::Some("world") } else { O::None }
+}
+fn greet(found: bool) -> Option(String) {
+    let O = Option(String);
+    let name = lookup(found)?;
+    O::Some("hello " + name)
+}
+fn show(found: bool) {
+    let O = Option(String);
+    match greet(found) {
+        O::Some(s) => println(s),
+        O::None => println("(nothing)"),
+    }
+}
+fn main() -> i32 {
+    show(true);
+    show(false);
+    0
+}
+""" },
+]
+args = ["main.rue", "-o", "prog"]
+stdout = """
+hello world
+(nothing)
+"""
+exit_code = 0
+
+# `?` in a function that does not return Option is E0503.
+[[case]]
+name = "try_outside_option_fn_is_e0503"
+files = [
+  { path = "main.rue", source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn some_val() -> Option(i64) {
+    let O = Option(i64);
+    O::Some(1)
+}
+fn main() -> i32 {
+    let v = some_val()?;
+    @intCast(v)
+}
+""" },
+]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0503", "returns an `Option`"]
+
+# `?` applied to a non-Option value is E0504.
+[[case]]
+name = "try_on_non_option_is_e0504"
+files = [
+  { path = "main.rue", source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn f() -> Option(i64) {
+    let x = 5;
+    let y = x?;
+    let O = Option(i64);
+    O::Some(y)
+}
+fn main() -> i32 { 0 }
+""" },
+]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0504", "applied to an `Option`"]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -193,6 +193,13 @@ impl ErrorCode {
     pub const BREAK_OUTSIDE_LOOP: Self = Self(500);
     pub const CONTINUE_OUTSIDE_LOOP: Self = Self(501);
     pub const BREAK_WITH_VALUE: Self = Self(502);
+    /// The `?` operator was used in a function whose return type is not an
+    /// `Option` (RUE-6, ADR-0038): `?` early-returns `None`, so the enclosing
+    /// function must return an `Option`.
+    pub const QUESTION_OUTSIDE_OPTION_FN: Self = Self(503);
+    /// The `?` operator was applied to a value that is not an `Option`
+    /// (RUE-6, ADR-0038).
+    pub const QUESTION_ON_NON_OPTION: Self = Self(504);
 
     // ========================================================================
     // Match errors (E0600-E0699)
@@ -1156,6 +1163,14 @@ pub enum ErrorKind {
     /// `break` with a value operand (e.g. `break 42`); break does not carry a value
     #[error("'break' with a value is not supported")]
     BreakWithValue,
+    /// The `?` operator used in a function that does not return an `Option`.
+    #[error(
+        "the `?` operator can only be used in a function that returns an `Option` (found return type `{return_type}`)"
+    )]
+    QuestionOutsideOptionFn { return_type: String },
+    /// The `?` operator applied to a value that is not an `Option`.
+    #[error("the `?` operator can only be applied to an `Option` (found `{found}`)")]
+    QuestionOnNonOption { found: String },
 
     // Match errors
     #[error("match is not exhaustive")]
@@ -1369,6 +1384,8 @@ impl ErrorKind {
             ErrorKind::BreakOutsideLoop => ErrorCode::BREAK_OUTSIDE_LOOP,
             ErrorKind::ContinueOutsideLoop => ErrorCode::CONTINUE_OUTSIDE_LOOP,
             ErrorKind::BreakWithValue => ErrorCode::BREAK_WITH_VALUE,
+            ErrorKind::QuestionOutsideOptionFn { .. } => ErrorCode::QUESTION_OUTSIDE_OPTION_FN,
+            ErrorKind::QuestionOnNonOption { .. } => ErrorCode::QUESTION_ON_NON_OPTION,
 
             // Match errors (E0600-E0699)
             ErrorKind::NonExhaustiveMatch => ErrorCode::NON_EXHAUSTIVE_MATCH,

--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -106,8 +106,9 @@ pub enum TokenKind {
     Colon,
     Semi,
     Comma,
-    Dot, // .
-    At,  // @
+    Dot,      // .
+    At,       // @
+    Question, // ?
 
     // Builtins
     AtImport(Spur), // @import - contains interned "import" string
@@ -181,6 +182,7 @@ impl TokenKind {
             TokenKind::Pipe => "'|'",
             TokenKind::Caret => "'^'",
             TokenKind::Tilde => "'~'",
+            TokenKind::Question => "'?'",
             TokenKind::LtLt => "'<<'",
             TokenKind::GtGt => "'>>'",
             TokenKind::LParen => "'('",
@@ -300,6 +302,7 @@ impl std::fmt::Display for TokenKind {
             TokenKind::Comma => write!(f, "COMMA"),
             TokenKind::Dot => write!(f, "DOT"),
             TokenKind::At => write!(f, "AT"),
+            TokenKind::Question => write!(f, "QUESTION"),
             TokenKind::AtImport(_) => write!(f, "AT_IMPORT"),
             TokenKind::Eof => write!(f, "EOF"),
         }

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -405,6 +405,8 @@ pub enum LogosTokenKind {
     Dot,
     #[token("@")]
     At,
+    #[token("?")]
+    Question,
 
     // Builtins. Exactly "@import" is its own token; the regex below wins the
     // longest-match for "@import" followed by more identifier chars (e.g.
@@ -504,6 +506,7 @@ impl From<LogosTokenKind> for TokenKind {
             LogosTokenKind::Comma => TokenKind::Comma,
             LogosTokenKind::Dot => TokenKind::Dot,
             LogosTokenKind::At => TokenKind::At,
+            LogosTokenKind::Question => TokenKind::Question,
             // AtImport is handled specially in tokenize() to provide the interned "import" Spur
             LogosTokenKind::AtImport => unreachable!("AtImport should be handled specially"),
             // AtImportPrefixedIdent is split into At + Ident in tokenize()
@@ -988,6 +991,15 @@ mod tests {
         assert_eq!(get_ident_str(&tokens[10].kind, &interner), Some("f"));
         assert!(matches!(tokens[11].kind, TokenKind::GtGt));
         assert_eq!(get_ident_str(&tokens[12].kind, &interner), Some("g"));
+    }
+
+    #[test]
+    fn test_logos_question_token() {
+        // The `?` (try) operator lexes to a single Question token (RUE-6).
+        let lexer = LogosLexer::new("x?");
+        let (tokens, interner) = lexer.tokenize().unwrap();
+        assert_eq!(get_ident_str(&tokens[0].kind, &interner), Some("x"));
+        assert!(matches!(tokens[1].kind, TokenKind::Question));
     }
 
     #[test]

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -554,6 +554,9 @@ pub enum Expr {
     Field(FieldExpr),
     /// Method call (e.g., `point.distance()`)
     MethodCall(MethodCallExpr),
+    /// Try/`?` propagation (e.g., `foo()?`): unwraps an `Option`, early-returning
+    /// `None` from the enclosing (Option-returning) function on `None` (RUE-6).
+    Try(TryExpr),
     /// Intrinsic call (e.g., `@dbg(42)`)
     IntrinsicCall(IntrinsicCallExpr),
     /// Array literal (e.g., `[1, 2, 3]`)
@@ -852,6 +855,20 @@ pub struct FieldExpr {
     pub span: Span,
 }
 
+/// A try/`?` propagation expression (e.g., `foo()?`).
+///
+/// `operand` must evaluate to an `Option`; the `?` unwraps it to the `Some`
+/// payload, early-returning `None` from the enclosing function when the operand
+/// is `None` (RUE-6, ADR-0038). The enclosing function must itself return an
+/// `Option`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TryExpr {
+    /// The operand whose `Option` is unwrapped/propagated.
+    pub operand: Box<Expr>,
+    /// Span covering `operand?` (through the `?`).
+    pub span: Span,
+}
+
 /// A method call expression (e.g., `point.distance()`).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MethodCallExpr {
@@ -1108,6 +1125,7 @@ impl Expr {
             Expr::StructLit(struct_lit) => struct_lit.span,
             Expr::Field(field_expr) => field_expr.span,
             Expr::MethodCall(method_call) => method_call.span,
+            Expr::Try(try_expr) => try_expr.span,
             Expr::IntrinsicCall(intrinsic) => intrinsic.span,
             Expr::ArrayLit(array_lit) => array_lit.span,
             Expr::Index(index_expr) => index_expr.span,
@@ -1429,6 +1447,10 @@ fn fmt_expr(f: &mut fmt::Formatter<'_>, expr: &Expr, level: usize) -> fmt::Resul
         Expr::Field(field) => {
             writeln!(f, "Field .sym:{}", field.field.name.into_usize())?;
             fmt_expr(f, &field.base, level + 1)
+        }
+        Expr::Try(try_expr) => {
+            writeln!(f, "Try ?")?;
+            fmt_expr(f, &try_expr.operand, level + 1)
         }
         Expr::MethodCall(method_call) => {
             writeln!(

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -11,8 +11,8 @@ use crate::ast::{
     Function, Ident, IfExpr, IndexExpr, IntLit, IntrinsicArg, IntrinsicCallExpr, Item, LetPattern,
     LetStatement, LoopExpr, MatchArm, MatchExpr, Method, MethodCallExpr, NegIntLit, Param,
     ParamMode, ParenExpr, PathExpr, PathPattern, Pattern, ReturnExpr, SelfExpr, SelfParam,
-    Statement, StringLit, StructDecl, StructLitExpr, TypeExpr, TypeLitExpr, UnaryExpr, UnaryOp,
-    UnitLit, Visibility, WhileExpr,
+    Statement, StringLit, StructDecl, StructLitExpr, TryExpr, TypeExpr, TypeLitExpr, UnaryExpr,
+    UnaryOp, UnitLit, Visibility, WhileExpr,
 };
 use chumsky::input::{Input as ChumskyInput, MapExtra, Stream, ValueInput};
 use chumsky::pratt::{infix, left, prefix};
@@ -143,6 +143,19 @@ where
             name,
             span: span_from_extra(e),
         },
+    }
+}
+
+/// Parser for the `?` (try) postfix suffix (RUE-6, ADR-0038). Kept as a
+/// standalone helper (rather than an inline branch) so its input type is
+/// pinned by the return-type annotation. Emits [`Suffix::Try`] carrying the
+/// offset just past the `?` token.
+fn question_suffix_parser<'src, I>() -> impl Parser<'src, I, Suffix, ParserExtras<'src>> + Clone
+where
+    I: ValueInput<'src, Token = TokenKind, Span = SimpleSpan>,
+{
+    select! {
+        TokenKind::Question = e => Suffix::Try(span_from_extra(e).end),
     }
 }
 
@@ -1290,6 +1303,9 @@ enum Suffix {
     QualifiedPath(Ident, Ident, u32),
     /// Qualified associated function call: .TypeName::function(args)
     QualifiedAssocFnCall(Ident, Ident, Vec<CallArg>, u32),
+    /// Try/`?` propagation: the `?` postfix operator, carrying the position
+    /// just past the `?` token so the resulting span covers `operand?`.
+    Try(u32),
 }
 
 /// Wraps a primary expression parser with field access, method call, and indexing suffixes
@@ -1407,6 +1423,7 @@ where
             qualified_path_suffix,
             field_suffix,
             index_suffix,
+            question_suffix_parser(),
         ))
         .boxed()
         .repeated(),
@@ -1436,6 +1453,14 @@ where
                 Expr::Index(IndexExpr {
                     base: Box::new(base),
                     index: Box::new(index),
+                    span,
+                })
+            }
+            Suffix::Try(end) => {
+                // Extend the base span through the `?`, preserving file_id.
+                let span = base.span().extend_to(end);
+                Expr::Try(TryExpr {
+                    operand: Box::new(base),
                     span,
                 })
             }
@@ -3515,6 +3540,38 @@ mod tests {
                 }
             }
             _ => panic!("expected MethodCall"),
+        }
+    }
+
+    #[test]
+    fn test_try_postfix_on_call() {
+        // `foo()?` parses as Try wrapping a Call (RUE-6).
+        let result = parse_expr("foo()?").unwrap();
+        match &result.expr {
+            Expr::Try(try_expr) => match try_expr.operand.as_ref() {
+                Expr::Call(_) => {}
+                other => panic!("expected Call operand, got {:?}", other),
+            },
+            other => panic!("expected Try, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_try_postfix_chains_with_field() {
+        // `x?.field` — `?` binds to `x`, then `.field` applies to the result.
+        let result = parse_expr("x?.field").unwrap();
+        match &result.expr {
+            Expr::Field(field) => {
+                assert_eq!(result.get(field.field.name), "field");
+                match field.base.as_ref() {
+                    Expr::Try(try_expr) => match try_expr.operand.as_ref() {
+                        Expr::Ident(ident) => assert_eq!(result.get(ident.name), "x"),
+                        other => panic!("expected Ident operand, got {:?}", other),
+                    },
+                    other => panic!("expected Try base, got {:?}", other),
+                }
+            }
+            other => panic!("expected Field, got {:?}", other),
         }
     }
 

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -170,6 +170,7 @@ impl Validator<'_> {
                 }
             }
             Expr::Field(f) => self.check_expr(&f.base),
+            Expr::Try(t) => self.check_expr(&t.operand),
             Expr::MethodCall(m) => {
                 self.check_expr(&m.receiver);
                 for arg in &m.args {

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -538,6 +538,13 @@ impl<'a> AstGen<'a> {
                     span: un.span,
                 })
             }
+            Expr::Try(try_expr) => {
+                let operand = self.gen_expr(&try_expr.operand);
+                self.rir.add_inst(Inst {
+                    data: InstData::Try { operand },
+                    span: try_expr.span,
+                })
+            }
             Expr::Paren(paren) => {
                 // Parentheses are transparent in the IR - just generate the inner expression
                 self.gen_expr(&paren.inner)

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -822,6 +822,9 @@ impl Rir {
             InstData::BitNot { operand } => InstData::BitNot {
                 operand: renumber(*operand),
             },
+            InstData::Try { operand } => InstData::Try {
+                operand: renumber(*operand),
+            },
 
             // Control flow
             InstData::Branch {
@@ -1283,6 +1286,7 @@ impl Rir {
                 | InstData::Neg { .. }
                 | InstData::Not { .. }
                 | InstData::BitNot { .. }
+                | InstData::Try { .. }
                 | InstData::Branch { .. }
                 | InstData::Loop { .. }
                 | InstData::InfiniteLoop { .. }
@@ -1402,6 +1406,13 @@ pub enum InstData {
     Not { operand: InstRef },
     /// Bitwise NOT: ~operand
     BitNot { operand: InstRef },
+
+    /// Try/`?` propagation: `operand?` unwraps an `Option`, evaluating to the
+    /// `Some` payload, and early-returns `None` from the enclosing function
+    /// when the operand is `None` (RUE-6, ADR-0038). Sema lowers it to a
+    /// discriminant match with an early `return` on the `None` arm; the
+    /// enclosing function must itself return an `Option`.
+    Try { operand: InstRef },
 
     // Control flow
     /// Branch: if cond then then_block else else_block
@@ -1930,6 +1941,7 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                 InstData::Neg { operand } => writeln!(out, "neg {}", operand).unwrap(),
                 InstData::Not { operand } => writeln!(out, "not {}", operand).unwrap(),
                 InstData::BitNot { operand } => writeln!(out, "bit_not {}", operand).unwrap(),
+                InstData::Try { operand } => writeln!(out, "try {}", operand).unwrap(),
 
                 // Control flow
                 InstData::Branch {

--- a/crates/rue-spec/cases/expressions/try.toml
+++ b/crates/rue-spec/cases/expressions/try.toml
@@ -1,0 +1,146 @@
+[section]
+id = "expressions.try"
+spec_chapter = "4.15"
+name = "Try Expressions"
+description = "The postfix `?` operator unwraps an Option, short-circuiting the enclosing Option-returning function with None (RUE-6, ADR-0038)."
+
+# =============================================================================
+# Some(v): `?` unwraps to the payload and execution continues (4.15:1, 4.15:5,
+# 4.15:6). The syntax production is exercised by every case (4.15:2).
+# =============================================================================
+
+[[case]]
+name = "try_some_unwraps"
+spec = ["4.15:1", "4.15:2", "4.15:5", "4.15:6"]
+description = "`?` on a Some value unwraps the payload; the function continues."
+source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn some_val() -> Option(i64) {
+    let O = Option(i64);
+    O::Some(20)
+}
+fn use_it() -> Option(i64) {
+    let O = Option(i64);
+    let v = some_val()?;
+    O::Some(v + 1)
+}
+fn main() -> i32 {
+    let O = Option(i64);
+    match use_it() {
+        O::Some(n) => @intCast(n),
+        O::None => 0,
+    }
+}
+"""
+exit_code = 21
+
+# =============================================================================
+# None: `?` short-circuits, the enclosing function returns None (4.15:7).
+# =============================================================================
+
+[[case]]
+name = "try_none_short_circuits"
+spec = ["4.15:1", "4.15:7"]
+description = "`?` on a None value returns None from the enclosing function; code after it does not run."
+source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn none_val() -> Option(i64) {
+    let O = Option(i64);
+    O::None
+}
+fn use_it() -> Option(i64) {
+    let O = Option(i64);
+    let v = none_val()?;
+    O::Some(v + 1)
+}
+fn main() -> i32 {
+    let O = Option(i64);
+    match use_it() {
+        O::Some(n) => @intCast(n),
+        O::None => 7,
+    }
+}
+"""
+exit_code = 7
+
+# =============================================================================
+# The whole `?`-expression has the Some payload type (4.15:5).
+# =============================================================================
+
+[[case]]
+name = "try_result_type_is_payload"
+spec = ["4.15:5", "4.15:6"]
+description = "`operand?` where operand: Option(i64) has type i64 and is usable directly."
+source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn wrap(x: i64) -> Option(i64) {
+    let O = Option(i64);
+    O::Some(x)
+}
+fn add_two(x: i64) -> Option(i64) {
+    let O = Option(i64);
+    O::Some(wrap(x)? + 2)
+}
+fn main() -> i32 {
+    let O = Option(i64);
+    match add_two(40) {
+        O::Some(n) => @intCast(n),
+        O::None => 0,
+    }
+}
+"""
+exit_code = 42
+
+# =============================================================================
+# Legality: operand of `?` must be an Option (4.15:3, E0504).
+# =============================================================================
+
+[[case]]
+name = "try_on_non_option_error"
+spec = ["4.15:3"]
+description = "Applying `?` to a non-Option value is a compile error (E0504)."
+compile_fail = true
+error_contains = "the `?` operator can only be applied to an `Option`"
+source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn f() -> Option(i64) {
+    let x = 5;
+    let y = x?;
+    let O = Option(i64);
+    O::Some(y)
+}
+fn main() -> i32 { 0 }
+"""
+
+# =============================================================================
+# Legality: `?` requires the enclosing function to return an Option
+# (4.15:4, E0503).
+# =============================================================================
+
+[[case]]
+name = "try_outside_option_fn_error"
+spec = ["4.15:4"]
+description = "Using `?` in a function whose return type is not Option is a compile error (E0503)."
+compile_fail = true
+error_contains = "the `?` operator can only be used in a function that returns an `Option`"
+source = """
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+fn some_val() -> Option(i64) {
+    let O = Option(i64);
+    O::Some(1)
+}
+fn main() -> i32 {
+    let v = some_val()?;
+    @intCast(v)
+}
+"""

--- a/docs/spec/src/04-expressions/15-try-expressions.md
+++ b/docs/spec/src/04-expressions/15-try-expressions.md
@@ -1,0 +1,89 @@
++++
+title = "Try Expressions"
+weight = 15
+template = "spec/page.html"
++++
+
+# Try Expressions
+
+{{ rule(id="4.15:1", cat="normative") }}
+
+A try expression applies the postfix `?` operator to an operand of an `Option`
+type. It evaluates to the payload of the `Some` variant, and short-circuits the
+enclosing function by returning `None` when the operand is the `None` variant
+(the propagation form of error handling, see ADR-0038).
+
+{{ rule(id="4.15:2", cat="syntax") }}
+
+```ebnf
+try_expr = expression "?" ;
+```
+
+The `?` operator is postfix and binds as tightly as the other postfix operators
+(field access, indexing, and calls).
+
+{{ rule(id="4.15:3", cat="legality-rule") }}
+
+The operand of `?` **MUST** have an `Option` type: an enum with exactly two
+variants, a single-payload `Some(T)` and a payload-less `None`. Applying `?` to
+any other type is a compile error (E0504).
+
+{{ rule(id="4.15:4", cat="legality-rule") }}
+
+A try expression **MUST** appear in the body of a function whose declared return
+type is an `Option`. Using `?` in a function that does not return an `Option` is
+a compile error (E0503).
+
+{{ rule(id="4.15:5", cat="normative") }}
+
+The type of a try expression `operand?`, where `operand` has type `Option(T)`,
+is `T`.
+
+{{ rule(id="4.15:6", cat="dynamic-semantics") }}
+
+When a try expression is evaluated and the operand is `Some(v)`, the expression
+evaluates to `v` and execution continues normally.
+
+{{ rule(id="4.15:7", cat="dynamic-semantics") }}
+
+When a try expression is evaluated and the operand is `None`, the enclosing
+function immediately returns `None`. No further code in the function is executed.
+This is equivalent to the desugaring:
+
+```rue
+match operand {
+    Some(v) => v,
+    None => return None,
+}
+```
+
+where the returned `None` is the `None` variant of the enclosing function's
+`Option` return type.
+
+{{ rule(id="4.15:8") }}
+
+```rue
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+
+fn checked_div(a: i64, b: i64) -> Option(i64) {
+    let O = Option(i64);
+    if b == 0 { O::None } else { O::Some(a / b) }
+}
+
+fn halve_then_div(a: i64, b: i64) -> Option(i64) {
+    let O = Option(i64);
+    // `?` unwraps the quotient, or short-circuits to None when b == 0.
+    let q = checked_div(a, b)?;
+    O::Some(q / 2)
+}
+
+fn main() -> i32 {
+    let O = Option(i64);
+    match halve_then_div(40, 4) {
+        O::Some(n) => n,      // 40 / 4 / 2 == 5
+        O::None => 0 - 1,
+    }
+}
+```

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -100,6 +100,7 @@ postfix        = primary { suffix } ;
 suffix         = "." IDENT                                     (* field access *)
                | "." IDENT "(" [ call_args ] ")"               (* method call *)
                | "[" expression "]"                            (* indexing *)
+               | "?"                                           (* try / Option propagation *)
                | "." IDENT "{" [ field_inits ] "}"             (* qualified struct literal *)
                | "." IDENT "::" IDENT                          (* qualified enum variant *)
                | "." IDENT "::" IDENT "(" [ call_args ] ")" ;  (* qualified assoc fn call *)

--- a/examples/first/option_try.rue
+++ b/examples/first/option_try.rue
@@ -1,0 +1,57 @@
+// The `?` operator: Option propagation (RUE-6, ADR-0038).
+//
+//   $ rue examples/first/option_try.rue examples/std/option.rue -o try && ./try
+//   triple: 12
+//   triple: none
+//
+// This is the ergonomic payoff of error handling. Compare `triple` below, which
+// unwraps with a single `?`, against the nested `match` it desugars to:
+//
+//     fn triple(n: i64) -> Option(i64) {
+//         let O = Option(i64);
+//         match parse_positive(n) {           // the `?`-free equivalent
+//             O::Some(v) => O::Some(v * 3),
+//             O::None => O::None,
+//         }
+//     }
+//
+// `expr?` evaluates to the `Some` payload, and early-returns `None` from the
+// enclosing function (whose return type must itself be an `Option`) when `expr`
+// is `None`. The library `Option` is an ordinary comptime-generic enum, not a
+// builtin (examples/std/option.rue); `?` recognises it by shape (Some(T)/None).
+//
+// NOTE: `Option(i64)` names the type directly in a return position (RUE-241),
+// but constructing a variant or matching still needs a bound name
+// (`let O = Option(i64); O::Some(..)`), so each function opens with that `let`.
+
+fn Option(comptime T: type) -> type {
+    enum { Some(T), None }
+}
+
+// parse_positive: Some(n) when n is positive, else None.
+fn parse_positive(n: i64) -> Option(i64) {
+    let O = Option(i64);
+    if n > 0 { O::Some(n) } else { O::None }
+}
+
+// triple: unwrap the positive value with `?`, then wrap n * 3. On a None input
+// the `?` short-circuits and `triple` itself returns None.
+fn triple(n: i64) -> Option(i64) {
+    let O = Option(i64);
+    let v = parse_positive(n)?;
+    O::Some(v * 3)
+}
+
+fn report(n: i64) {
+    let O = Option(i64);
+    match triple(n) {
+        O::Some(m) => println("triple: " + @to_string(m)),
+        O::None => println("triple: none"),
+    }
+}
+
+fn main() -> i32 {
+    report(4);        // parse_positive(4) = Some(4) -> triple = Some(12)
+    report(0 - 2);    // parse_positive(-2) = None   -> `?` short-circuits to None
+    0
+}


### PR DESCRIPTION
`expr?` on a typed `Option(T)` evaluates to `T` for `Some(v)`, or early-returns `None` from the enclosing function (which must return `Option(U)`). lexer (`?` token) → parser (`Expr::Try`) → rir (`InstData::Try`) → sema (`analyze_try`), lowered to a two-arm discriminant match — no new codegen. E0503 if the enclosing fn isn't Option-returning; E0504 if the operand isn't an Option.

Verified by execution (**5 CLI cases**): unwrap Some + short-circuit None from real stdin, non-Copy String payload moved through `?`, both static errors. clippy + test.sh Pass 24, 100% traceability, oracle-diff 300 seeds 0 disagreements. Adds spec §4.15 + grammar, examples/first/option_try.rue.

**Scope note:** `?` needs the operand's Option type known — a bare fallible intrinsic (`@read_line()?`) is NOT yet supported (those resolve their Option from an expected type the `?` site can't supply — the enclosing fn's Option has the wrong payload). Filed **RUE-318**. The worker's untested integration note (thread the return type) was refuted at integration time (E0702). Result/Ok/Err `?` is a later follow-up.

Part of RUE-6

Generated with Claude Code