### PR TITLE
Intrinsics: @panic and @assert now trap instead of silently no-op'ing (RUE-319)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -992,14 +992,16 @@ impl<'a> ConstraintGenerator<'a> {
                 let intrinsic_name = self.interner.resolve(name);
                 let args = self.rir.get_inst_refs(*args_start, *args_len);
 
-                if intrinsic_name == "intCast" {
-                    // @intCast: target type is inferred from context
-                    // The argument must be an integer type
-                    if !args.is_empty() {
-                        let arg_info = self.generate(args[0], ctx);
-                        // Constraint: argument must be an integer
-                        // We'll check this in sema, for now just process the argument
-                        let _ = arg_info;
+                if intrinsic_name == "intCast" || intrinsic_name == "cast" {
+                    // @intCast: target type is inferred from context.
+                    // @cast: a fresh var here too, so sema can reject it with a
+                    // clean "use @intCast" diagnostic instead of inference
+                    // masking it with a type-mismatch error (RUE-319).
+                    // The argument must be an integer type.
+                    for arg_ref in args.iter() {
+                        // Process arguments for constraint generation; the
+                        // integer check happens in sema.
+                        let _ = self.generate(*arg_ref, ctx);
                     }
                     // Return type is inferred from context - create a fresh type variable
                     let result_var = self.fresh_var();
@@ -1009,7 +1011,7 @@ impl<'a> ConstraintGenerator<'a> {
                     // The concrete Option type comes from context (a `let`
                     // annotation or the match arms the result feeds), so use a
                     // fresh variable and let unification resolve it — mirroring
-                    // @intCast/@cast. Sema validates the resolved type is an
+                    // @intCast. Sema validates the resolved type is an
                     // Option-shaped enum over String.
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -4064,64 +4064,26 @@ impl<'a> Sema<'a> {
     fn analyze_cast_intrinsic(
         &mut self,
         air: &mut Air,
-        inst_ref: InstRef,
+        _inst_ref: InstRef,
         args: &[RirCallArg],
         span: Span,
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
-        if args.len() != 1 {
-            return Err(CompileError::new(
-                ErrorKind::IntrinsicWrongArgCount {
-                    name: "cast".to_string(),
-                    expected: 1,
-                    found: args.len(),
-                },
-                span,
-            ));
+        // `@cast` never had a working inference rule and is fully redundant with
+        // `@intCast` (RUE-319). Rather than silently accept it and then fail
+        // inference (the old E0206/E0702 confusion), reject it up front with a
+        // clear pointer to the working intrinsic. Inference gives `@cast` a
+        // fresh type variable (like `@intCast`) precisely so this diagnostic is
+        // what the user sees, in every context, instead of a masking
+        // type-mismatch error. Arguments are still analyzed so any error inside
+        // them is reported too.
+        for arg in args {
+            let _ = self.analyze_inst(air, arg.value, ctx);
         }
-
-        // Get target type from HM inference
-        let target_type = Self::get_resolved_type(ctx, inst_ref, span, "@cast intrinsic")?;
-
-        let arg_result = self.analyze_inst(air, args[0].value, ctx)?;
-        let source_type = arg_result.ty;
-
-        // Validate types
-        if !source_type.is_integer() && !source_type.is_error() && !source_type.is_never() {
-            return Err(CompileError::new(
-                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                    name: "cast".to_string(),
-                    expected: "integer type".to_string(),
-                    found: source_type.safe_name_with_pool(Some(&self.type_pool)),
-                })),
-                span,
-            ));
-        }
-        if !target_type.is_integer() && !target_type.is_error() && !target_type.is_never() {
-            return Err(CompileError::new(
-                ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
-                    name: "cast".to_string(),
-                    expected: "integer target type".to_string(),
-                    found: target_type.safe_name_with_pool(Some(&self.type_pool)),
-                })),
-                span,
-            ));
-        }
-
-        // Skip cast if types are the same
-        if source_type == target_type || source_type.is_error() || source_type.is_never() {
-            return Ok(arg_result);
-        }
-
-        let air_ref = air.add_inst(AirInst {
-            data: AirInstData::IntCast {
-                value: arg_result.air_ref,
-                from_ty: source_type,
-            },
-            ty: target_type,
-            span,
-        });
-        Ok(AnalysisResult::new(air_ref, target_type))
+        Err(
+            CompileError::new(ErrorKind::UnknownIntrinsic("cast".to_string()), span)
+                .with_help("use `@intCast` to cast between integer types"),
+        )
     }
 
     fn analyze_panic_intrinsic(
@@ -4144,9 +4106,16 @@ impl<'a> Sema<'a> {
         }
 
         if args.is_empty() {
-            // Panic with no message
+            // Panic with no message: still a real trap (RUE-319). Emitting an
+            // Intrinsic with zero args (not a UnitConst) is what makes cfg_lower
+            // lower it to the `__rue_panic_no_msg` abort call instead of a
+            // silent no-op.
             let air_ref = air.add_inst(AirInst {
-                data: AirInstData::UnitConst,
+                data: AirInstData::Intrinsic {
+                    name: self.known.panic,
+                    args_start: 0,
+                    args_len: 0,
+                },
                 ty: Type::NEVER,
                 span,
             });

--- a/crates/rue-cli-tests/cases/panic_assert.toml
+++ b/crates/rue-cli-tests/cases/panic_assert.toml
@@ -1,0 +1,155 @@
+# @panic / @assert runtime abort behavior (RUE-319).
+#
+# Before this fix, @panic and @assert were accepted by sema but had NO
+# cfg_lower branch in either backend, so they were SILENT RUNTIME NO-OPS:
+# `@panic("boom")` ran past and the program exited 0, and `@assert(false)`
+# did nothing. That silent failure of an abort primitive is dangerous.
+#
+# Now both lower to a runtime abort modeled on the existing @intCast overflow
+# trap: they write a message to stderr and exit with status 101. @assert only
+# aborts when its condition is false; a true condition is a no-op.
+#
+# These are runtime-visible (exit code + stderr), so they belong here as CLI
+# cases with exact assertions, not just spec cases.
+
+[section]
+id = "cli.panic_assert"
+name = "@panic / @assert runtime abort"
+description = "@panic and @assert abort with a message and exit 101; @assert passes when true."
+
+# ── @panic ───────────────────────────────────────────────────────────────────
+
+# @panic with a message: aborts, message on stderr prefixed with "panic: ".
+[[case]]
+name = "panic_with_message_aborts"
+description = "@panic(\"boom\") aborts with exit 101 and writes the message to stderr."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @panic("boom");
+    0
+}
+""" }]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["panic: boom"]
+
+# @panic with no message: aborts, writes "panic".
+[[case]]
+name = "panic_no_message_aborts"
+description = "@panic() with no argument aborts with exit 101 and writes \"panic\"."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @panic();
+    0
+}
+""" }]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["panic"]
+
+# Statements before @panic still run (so their stdout is observable); the
+# statement after @panic must NOT run (it's dead at runtime).
+[[case]]
+name = "panic_is_reached_after_side_effects"
+description = "Code before @panic runs; code after it does not (real divergence)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @dbg(1);
+    @panic("stop");
+    @dbg(2);
+    0
+}
+""" }]
+exit_code = 101
+stdout = "1\n"
+runtime_error_contains = ["panic: stop"]
+
+# ── @assert ──────────────────────────────────────────────────────────────────
+
+# @assert(false): aborts with "assertion failed".
+[[case]]
+name = "assert_false_aborts"
+description = "@assert(false) aborts with exit 101 and writes \"assertion failed\"."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @assert(false);
+    0
+}
+""" }]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["assertion failed"]
+
+# @assert(true): no effect, program continues to its normal exit.
+[[case]]
+name = "assert_true_passes"
+description = "@assert(true) has no effect; the program returns normally."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @assert(true);
+    42
+}
+""" }]
+exit_code = 42
+stdout = ""
+
+# @assert with a runtime-computed condition that holds: passes.
+[[case]]
+name = "assert_runtime_true_passes"
+description = "@assert on a runtime-true condition falls through."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = 5;
+    @assert(x > 3);
+    x
+}
+""" }]
+exit_code = 5
+stdout = ""
+
+# @assert with a runtime-computed condition that fails: aborts.
+[[case]]
+name = "assert_runtime_false_aborts"
+description = "@assert on a runtime-false condition aborts with exit 101."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = 2;
+    @assert(x > 3);
+    x
+}
+""" }]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["assertion failed"]
+
+# @assert with a message: the failing form shows the user's text via the
+# @panic path ("panic: <msg>").
+[[case]]
+name = "assert_false_with_message_aborts"
+description = "@assert(cond, \"msg\") aborts showing the message when cond is false."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @assert(1 == 2, "one is not two");
+    0
+}
+""" }]
+exit_code = 101
+stdout = ""
+runtime_error_contains = ["one is not two"]
+
+# ── @cast rejection ──────────────────────────────────────────────────────────
+
+# @cast is redundant with @intCast and never had a working inference rule; it
+# is now rejected at compile time with a diagnostic pointing to @intCast.
+[[case]]
+name = "cast_is_rejected_use_intcast"
+description = "@cast is a compile error directing the user to @intCast."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i64 = 5;
+    let y: i32 = @cast(x);
+    y
+}
+""" }]
+compile_fail = true
+error_contains = ["cast", "intCast"]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2513,6 +2513,39 @@ impl<'a> CfgLower<'a> {
                         let vreg = self.get_vreg(lvalue_val);
                         self.value_map.insert(value, vreg);
                     }
+                } else if name_str == "panic" {
+                    // @panic(msg?) — abort the process with a message on stderr
+                    // and exit code 101, the same abort discipline as the other
+                    // runtime traps (RUE-319). Never returns; any code the
+                    // compiler emits after this point is dead at runtime.
+                    let args = self.ctx.cfg.get_extra(*args_start, *args_len);
+                    if args.is_empty() {
+                        let symbol_id = self.intern_symbol("__rue_panic_no_msg");
+                        self.mir.push(Aarch64Inst::Bl { symbol_id });
+                    } else {
+                        self.emit_panic_with_msg(args[0]);
+                    }
+                } else if name_str == "assert" {
+                    // @assert(cond, msg?) — abort iff `cond` is false (RUE-319).
+                    // A true condition falls through with no effect.
+                    let args = self.ctx.cfg.get_extra(*args_start, *args_len);
+                    let cond_val = args[0];
+                    let msg_val = args.get(1).copied();
+                    let cond_vreg = self.get_vreg(cond_val);
+                    let pass_label = self.mir.alloc_label();
+                    // cond != 0 (true) → skip the abort.
+                    self.mir.push(Aarch64Inst::Cbnz {
+                        src: Operand::Virtual(cond_vreg),
+                        label: pass_label,
+                    });
+                    match msg_val {
+                        Some(msg) => self.emit_panic_with_msg(msg),
+                        None => {
+                            let symbol_id = self.intern_symbol("__rue_assert_failed");
+                            self.mir.push(Aarch64Inst::Bl { symbol_id });
+                        }
+                    }
+                    self.mir.push(Aarch64Inst::Label { id: pass_label });
                 }
             }
 
@@ -3390,6 +3423,30 @@ impl<'a> CfgLower<'a> {
                 src1: Operand::Virtual(src1),
                 src2: Operand::Virtual(src2),
             });
+        }
+    }
+
+    /// Emit an aborting call to `__rue_panic(ptr, len)` for `@panic("msg")` and
+    /// `@assert(cond, "msg")` (RUE-319). `msg_val` is the CFG value of the
+    /// message `String`; its fat pointer supplies the `ptr`/`len` arguments
+    /// (X0/X1). Never returns at runtime.
+    fn emit_panic_with_msg(&mut self, msg_val: CfgValue) {
+        if let Some(field_vregs) = self.get_or_compute_field_vregs(msg_val) {
+            // A String is a (ptr, len, cap) fat pointer; pass ptr in X0, len in X1.
+            let ptr_vreg = field_vregs[0];
+            let len_vreg = field_vregs[1];
+            self.mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X0),
+                src: Operand::Virtual(ptr_vreg),
+            });
+            self.mir.push(Aarch64Inst::MovRR {
+                dst: Operand::Physical(Reg::X1),
+                src: Operand::Virtual(len_vreg),
+            });
+            let symbol_id = self.intern_symbol("__rue_panic");
+            self.mir.push(Aarch64Inst::Bl { symbol_id });
+        } else {
+            unreachable!("panic/assert message must be a string with field vregs");
         }
     }
 

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2852,6 +2852,40 @@ impl<'a> CfgLower<'a> {
                         let vreg = self.get_vreg(lvalue_val);
                         self.value_map.insert(value, vreg);
                     }
+                } else if name_str == "panic" {
+                    // @panic(msg?) — abort the process with a message on stderr
+                    // and exit code 101, the same abort discipline as the other
+                    // runtime traps (RUE-319). Never returns; any code the
+                    // compiler emits after this point is dead at runtime.
+                    let args = self.ctx.cfg.get_extra(*args_start, *args_len);
+                    if args.is_empty() {
+                        let symbol_id = self.intern_symbol("__rue_panic_no_msg");
+                        self.mir.push(X86Inst::CallRel { symbol_id });
+                    } else {
+                        self.emit_panic_with_msg(args[0]);
+                    }
+                } else if name_str == "assert" {
+                    // @assert(cond, msg?) — abort iff `cond` is false (RUE-319).
+                    // A true condition falls through with no effect.
+                    let args = self.ctx.cfg.get_extra(*args_start, *args_len);
+                    let cond_val = args[0];
+                    let msg_val = args.get(1).copied();
+                    let cond_vreg = self.get_vreg(cond_val);
+                    let pass_label = self.new_label();
+                    // cond != 0 (true) → skip the abort.
+                    self.mir.push(X86Inst::CmpRI {
+                        src: Operand::Virtual(cond_vreg),
+                        imm: 0,
+                    });
+                    self.mir.push(X86Inst::Jnz { label: pass_label });
+                    match msg_val {
+                        Some(msg) => self.emit_panic_with_msg(msg),
+                        None => {
+                            let symbol_id = self.intern_symbol("__rue_assert_failed");
+                            self.mir.push(X86Inst::CallRel { symbol_id });
+                        }
+                    }
+                    self.mir.push(X86Inst::Label { id: pass_label });
                 }
             }
 
@@ -3474,6 +3508,35 @@ impl<'a> CfgLower<'a> {
         let symbol_id = self.intern_symbol("__rue_overflow");
         self.mir.push(X86Inst::CallRel { symbol_id });
         self.mir.push(X86Inst::Label { id: ok_label });
+    }
+
+    /// Emit an aborting call to `__rue_panic(ptr, len)` for `@panic("msg")` and
+    /// `@assert(cond, "msg")` (RUE-319). `msg_val` is the CFG value of the
+    /// message `String`; its fat pointer supplies the `ptr`/`len` arguments.
+    /// Never returns at runtime.
+    fn emit_panic_with_msg(&mut self, msg_val: CfgValue) {
+        if let Some(field_vregs) = self.get_or_compute_field_vregs(msg_val) {
+            // A String is a (ptr, len, cap) fat pointer; pass ptr in RDI, len in RSI.
+            assert_eq!(
+                field_vregs.len(),
+                3,
+                "panic message string should have exactly 3 vregs (ptr, len, cap)"
+            );
+            let ptr_vreg = field_vregs[0];
+            let len_vreg = field_vregs[1];
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rdi),
+                src: Operand::Virtual(ptr_vreg),
+            });
+            self.mir.push(X86Inst::MovRR {
+                dst: Operand::Physical(Reg::Rsi),
+                src: Operand::Virtual(len_vreg),
+            });
+            let symbol_id = self.intern_symbol("__rue_panic");
+            self.mir.push(X86Inst::CallRel { symbol_id });
+        } else {
+            unreachable!("panic/assert message must be a string with field vregs");
+        }
     }
 
     /// Emit integer cast range check.

--- a/crates/rue-runtime/src/error.rs
+++ b/crates/rue-runtime/src/error.rs
@@ -279,6 +279,126 @@ crate::define_for_all_platforms! {
     }
 }
 
+crate::define_for_all_platforms! {
+    /// Runtime error: explicit `@panic(msg)` with a message.
+    ///
+    /// Called by code generated for the `@panic("...")` intrinsic. Writes
+    /// `"panic: "`, the user-supplied message bytes, and a trailing newline to
+    /// stderr, then exits with code 101 (the same abort path as the other
+    /// runtime traps: division by zero, overflow, bounds, cast overflow).
+    ///
+    /// # Behavior
+    ///
+    /// 1. Writes `"panic: {msg}\n"` to stderr (best-effort)
+    /// 2. Exits with code 101
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_panic(ptr: *const u8, len: u64) -> !
+    /// ```
+    ///
+    /// - `ptr` / `len` are the message string's fat-pointer fields (the `cap`
+    ///   field is not needed and is not passed).
+    /// - Never returns.
+    ///
+    /// # Safety
+    ///
+    /// The caller (Rue-generated code) guarantees `ptr` points to `len` valid,
+    /// initialized, byte-aligned bytes that stay valid for the call.
+    pub extern "C" fn __rue_panic(ptr: *const u8, len: u64) -> ! {
+        // "panic: " built byte-by-byte to avoid the macOS byte-string linker bug.
+        let mut prefix = [0u8; 7];
+        prefix[0] = b'p';
+        prefix[1] = b'a';
+        prefix[2] = b'n';
+        prefix[3] = b'i';
+        prefix[4] = b'c';
+        prefix[5] = b':';
+        prefix[6] = b' ';
+        platform::write_stderr(&prefix);
+        // SAFETY: the caller guarantees `ptr`/`len` describe a valid byte range.
+        let bytes = unsafe { core::slice::from_raw_parts(ptr, len as usize) };
+        platform::write_stderr(bytes);
+        let newline = [b'\n'];
+        platform::write_stderr(&newline);
+        platform::exit(101)
+    }
+}
+
+crate::define_for_all_platforms! {
+    /// Runtime error: explicit `@panic()` with no message.
+    ///
+    /// Called by code generated for the message-less `@panic()` intrinsic.
+    ///
+    /// # Behavior
+    ///
+    /// 1. Writes `"panic\n"` to stderr (best-effort)
+    /// 2. Exits with code 101
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_panic_no_msg() -> !
+    /// ```
+    ///
+    /// No arguments. Never returns.
+    pub extern "C" fn __rue_panic_no_msg() -> ! {
+        let mut msg = [0u8; 6];
+        msg[0] = b'p';
+        msg[1] = b'a';
+        msg[2] = b'n';
+        msg[3] = b'i';
+        msg[4] = b'c';
+        msg[5] = b'\n';
+        platform::write_stderr(&msg);
+        platform::exit(101)
+    }
+}
+
+crate::define_for_all_platforms! {
+    /// Runtime error: failed `@assert(cond)` (no message).
+    ///
+    /// Called by code generated for `@assert(cond)` when `cond` is false.
+    /// The message-carrying form `@assert(cond, "msg")` routes to
+    /// [`__rue_panic`] instead so the user's text is shown.
+    ///
+    /// # Behavior
+    ///
+    /// 1. Writes `"assertion failed\n"` to stderr (best-effort)
+    /// 2. Exits with code 101
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_assert_failed() -> !
+    /// ```
+    ///
+    /// No arguments. Never returns.
+    pub extern "C" fn __rue_assert_failed() -> ! {
+        let mut msg = [0u8; 17];
+        msg[0] = b'a';
+        msg[1] = b's';
+        msg[2] = b's';
+        msg[3] = b'e';
+        msg[4] = b'r';
+        msg[5] = b't';
+        msg[6] = b'i';
+        msg[7] = b'o';
+        msg[8] = b'n';
+        msg[9] = b' ';
+        msg[10] = b'f';
+        msg[11] = b'a';
+        msg[12] = b'i';
+        msg[13] = b'l';
+        msg[14] = b'e';
+        msg[15] = b'd';
+        msg[16] = b'\n';
+        platform::write_stderr(&msg);
+        platform::exit(101)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -288,6 +408,9 @@ mod tests {
         assert_eq!(b"error: integer overflow\n".len(), 24);
         assert_eq!(b"error: integer cast overflow\n".len(), 29);
         assert_eq!(b"error: index out of bounds\n".len(), 27);
+        assert_eq!(b"panic: ".len(), 7);
+        assert_eq!(b"panic\n".len(), 6);
+        assert_eq!(b"assertion failed\n".len(), 17);
     }
 
     #[test]

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -43,6 +43,87 @@ compile_fail = true
 error_contains = "unknown intrinsic"
 
 # =============================================================================
+# Reserved-but-unspecified intrinsics: @panic / @assert / @cast (4.13:5b, RUE-319)
+#
+# @panic and @assert are not in the normative inventory yet, but they are no
+# longer silent no-ops: they abort the process (message to stderr, exit 101),
+# the same abort discipline as the @intCast overflow trap. @cast is rejected
+# at compile time in favor of @intCast.
+# =============================================================================
+
+[[case]]
+name = "panic_with_message_aborts"
+spec = ["4.13:5b"]
+source = """
+fn main() -> i32 {
+    @panic("boom");
+    0
+}
+"""
+exit_code = 101
+stderr_contains = "panic: boom"
+
+[[case]]
+name = "panic_no_message_aborts"
+spec = ["4.13:5b"]
+source = """
+fn main() -> i32 {
+    @panic();
+    0
+}
+"""
+exit_code = 101
+stderr_contains = "panic"
+
+[[case]]
+name = "assert_false_aborts"
+spec = ["4.13:5b"]
+source = """
+fn main() -> i32 {
+    @assert(false);
+    0
+}
+"""
+exit_code = 101
+stderr_contains = "assertion failed"
+
+[[case]]
+name = "assert_true_passes"
+spec = ["4.13:5b"]
+source = """
+fn main() -> i32 {
+    @assert(true);
+    42
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "assert_false_with_message_aborts"
+spec = ["4.13:5b"]
+source = """
+fn main() -> i32 {
+    @assert(1 == 2, "one is not two");
+    0
+}
+"""
+exit_code = 101
+stderr_contains = "one is not two"
+
+[[case]]
+name = "cast_rejected_use_intcast"
+spec = ["4.13:5b"]
+source = """
+fn main() -> i32 {
+    let x: i64 = 5;
+    let y: i32 = @cast(x);
+    y
+}
+"""
+compile_fail = true
+error_contains = "intCast"
+
+# =============================================================================
 # @dbg Intrinsic
 # =============================================================================
 

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -87,11 +87,20 @@ full semantics):
 {{ rule(id="4.13:5b", cat="informative") }}
 
 The compiler frontend additionally reserves the names `@cast`, `@panic`, and
-`@assert`. Their behavior is not yet stabilized — the current implementation
-does not lower them to correct code (`@cast` fails type inference; `@panic` and
-`@assert` compile but have no runtime effect) — so they are intentionally
-omitted from the inventory above and left unspecified. Use `@intCast` for
-integer conversions until `@cast` is specified.
+`@assert`. Their surface syntax is not yet fully stabilized, so they are omitted
+from the normative inventory above, but they are no longer no-ops (RUE-319):
+
+- `@panic(msg?)` aborts the process. It writes `panic: <msg>` (or just `panic`
+  when called with no argument) to standard error and exits with status 101 —
+  the same abort discipline as the `@intCast` overflow, division-by-zero, and
+  bounds-check traps.
+- `@assert(cond, msg?)` evaluates the boolean `cond`. When `cond` is `false` it
+  aborts exactly like `@panic`: with a message it writes `panic: <msg>`,
+  otherwise it writes `assertion failed`, and in both cases exits with status
+  101. When `cond` is `true` it has no effect.
+- `@cast` is rejected at compile time with a diagnostic directing the programmer
+  to `@intCast`; it never had a working inference rule and is fully redundant
+  with `@intCast`. Use `@intCast` for integer conversions.
 
 ## `@dbg`
 


### PR DESCRIPTION
@panic/@assert were accepted by sema but never lowered — `@panic("x")` ran past and exited 0, `@assert(false)` did nothing. Both now abort via runtime handlers modeled on the @intCast overflow trap: message to stderr, exit 101 (@assert only when its condition is false). **Both backends** (x86_64 by execution; aarch64 by --emit asm). @cast is now rejected with E0700 + a 'use @intCast' hint instead of a masked E0206.

Spec 4.13:5b rewritten. clippy clean; test.sh Pass 24, 100% traceability; oracle-diff 0; 9 CLI + 6 spec cases.

Fixes RUE-319

Generated with Claude Code