### PR TITLE
ADR-0043 Phase 2: rename Vec(T) -> ArrayBuf(T) (part of RUE-321)

### DIFF
--- a/crates/rue-cli-tests/cases/arraybuf_library.toml
+++ b/crates/rue-cli-tests/cases/arraybuf_library.toml
@@ -1,28 +1,30 @@
-# The source-level Vec(T) library (examples/std/vec.rue) driven end-to-end as a
-# user would: a flat multi-file compile of a program that exercises
-# push / len / get / set / pop / a while-loop sum / out-of-bounds access on a
-# Vec(i32) (RUE-1, ADR-0041).
+# The source-level ArrayBuf(T) library (examples/std/arraybuf.rue) driven
+# end-to-end as a user would: a flat multi-file compile of a program that
+# exercises push / len / get / set / pop / a while-loop sum / out-of-bounds
+# access on an ArrayBuf(i32) (RUE-1, ADR-0041; renamed from Vec to ArrayBuf,
+# ADR-0043 / RUE-323).
 #
-# Vec is generic over a Copy element type and is built entirely on the unchecked
-# heap intrinsics @alloc/@realloc/@free behind a safe method API. Its `get`/`pop`
-# accessors return `Option(T)` (from option.rue), with the enclosing element type
-# `T` usable inside the method bodies (RUE-313). It also owns its buffer and frees
-# it automatically in a `drop fn` at scope exit (RUE-312); the
-# `vec_i32_raii_auto_free` case below exercises that path with no explicit free()
-# call. See vec.rue's header for the remaining limitation: Copy element types only.
+# ArrayBuf is generic over a Copy element type and is built entirely on the
+# unchecked heap intrinsics @alloc/@realloc/@free behind a safe method API. Its
+# `get`/`pop` accessors return `Option(T)` (from option.rue), with the enclosing
+# element type `T` usable inside the method bodies (RUE-313). It also owns its
+# buffer and frees it automatically in a `drop fn` at scope exit (RUE-312); the
+# `arraybuf_i32_raii_auto_free` case below exercises that path with no explicit
+# free() call. See arraybuf.rue's header for the remaining limitation: Copy
+# element types only.
 
 [section]
-id = "cli.vec_library"
-name = "Source-level Vec(T) library"
-description = "A Rue-source Vec(T) on @alloc/@free with a full push/pop/get/set dogfood returning Option(T) (RUE-1, RUE-313)."
+id = "cli.arraybuf_library"
+name = "Source-level ArrayBuf(T) library"
+description = "A Rue-source ArrayBuf(T) on @alloc/@free with a full push/pop/get/set dogfood returning Option(T) (RUE-1, RUE-313)."
 
 [[case]]
-name = "vec_i32_dogfood"
-description = "push/len/get/set/pop/while-sum/out-of-bounds on Vec(i32), Option(T) accessors, flat multi-file."
+name = "arraybuf_i32_dogfood"
+description = "push/len/get/set/pop/while-sum/out-of-bounds on ArrayBuf(i32), Option(T) accessors, flat multi-file."
 files = [
   { path = "main.rue", source = """
 fn main() -> i32 {
-    let V = Vec(i32);
+    let V = ArrayBuf(i32);
     let O = Option(i32);
 
     let mut v = V::new();
@@ -57,8 +59,8 @@ pub fn Option(comptime T: type) -> type {
     enum { Some(T), None }
 }
 """ },
-  { path = "vec.rue", source = """
-pub fn Vec(comptime T: type) -> type {
+  { path = "arraybuf.rue", source = """
+pub fn ArrayBuf(comptime T: type) -> type {
     struct {
         buf: ptr mut T,
         len: u64,
@@ -134,7 +136,7 @@ pub fn Vec(comptime T: type) -> type {
 }
 """ },
 ]
-args = ["main.rue", "vec.rue", "option.rue", "-o", "prog"]
+args = ["main.rue", "arraybuf.rue", "option.rue", "-o", "prog"]
 stdout = "3\n20\n99\n30\n2\n-1\n119\n"
 exit_code = 119
 
@@ -142,16 +144,16 @@ exit_code = 119
 # round-trips correctly now that aggregates are laid out ascending and raw
 # pointers walk their slots upward (ADR-0040 / RUE-311). Previously the second
 # field was written at `ptr - 8`, corrupting the preceding element/allocation,
-# so Vec was scoped to single-slot Copy elements.
+# so ArrayBuf was scoped to single-slot Copy elements.
 [[case]]
-name = "vec_struct_element_dogfood"
-description = "push/get/set/pop on Vec(Point) with a two-field struct element (RUE-311)."
+name = "arraybuf_struct_element_dogfood"
+description = "push/get/set/pop on ArrayBuf(Point) with a two-field struct element (RUE-311)."
 files = [
   { path = "main.rue", source = """
 struct Point { x: i32, y: i32 }
 fn main() -> i32 {
-    let m = @import(\"vec.rue\");
-    let V = m.Vec(Point);
+    let m = @import(\"arraybuf.rue\");
+    let V = m.ArrayBuf(Point);
 
     let mut v = V::new();
     v.push(Point { x: 1, y: 2 });
@@ -174,8 +176,8 @@ fn main() -> i32 {
     0
 }
 """ },
-  { path = "vec.rue", source = """
-pub fn Vec(comptime T: type) -> type {
+  { path = "arraybuf.rue", source = """
+pub fn ArrayBuf(comptime T: type) -> type {
     struct {
         buf: ptr mut T,
         len: u64,
@@ -235,26 +237,26 @@ pub fn Vec(comptime T: type) -> type {
 }
 """ },
 ]
-args = ["main.rue", "vec.rue", "-o", "prog"]
+args = ["main.rue", "arraybuf.rue", "-o", "prog"]
 stdout = "3\n3\n4\n90\n91\n5\n6\n2\n"
 exit_code = 0
 
-# RAII: the Vec owns its buffer and frees it automatically in its `drop fn` at
-# scope exit — the program never calls free(). This exercises the real Vec
-# destructor end-to-end (parse + monomorphize + drop-glue + @free), the last
-# gap to a real Vec (RUE-312). The `drop fn(self)` here mirrors examples/std/
-# vec.rue. Output is the same as the explicit-free dogfood; the destructor's
-# @free is a silent no-op under the bump allocator, so correctness is that the
-# program compiles, runs, and exits cleanly with the buffer released by the
-# destructor rather than a manual call.
+# RAII: the ArrayBuf owns its buffer and frees it automatically in its `drop fn`
+# at scope exit — the program never calls free(). This exercises the real
+# ArrayBuf destructor end-to-end (parse + monomorphize + drop-glue + @free), the
+# last gap to a real ArrayBuf (RUE-312). The `drop fn(self)` here mirrors
+# examples/std/arraybuf.rue. Output is the same as the explicit-free dogfood; the
+# destructor's @free is a silent no-op under the bump allocator, so correctness
+# is that the program compiles, runs, and exits cleanly with the buffer released
+# by the destructor rather than a manual call.
 [[case]]
-name = "vec_i32_raii_auto_free"
-description = "Vec(i32) frees its buffer via its drop fn at scope exit — no explicit free() call (RUE-312)."
+name = "arraybuf_i32_raii_auto_free"
+description = "ArrayBuf(i32) frees its buffer via its drop fn at scope exit — no explicit free() call (RUE-312)."
 files = [
   { path = "main.rue", source = """
 fn main() -> i32 {
-    let m = @import(\"vec.rue\");
-    let V = m.Vec(i32);
+    let m = @import(\"arraybuf.rue\");
+    let V = m.ArrayBuf(i32);
 
     let mut v = V::new();
     v.push(10);
@@ -269,8 +271,8 @@ fn main() -> i32 {
     // v is dropped here: its drop fn frees the buffer automatically.
 }
 """ },
-  { path = "vec.rue", source = """
-pub fn Vec(comptime T: type) -> type {
+  { path = "arraybuf.rue", source = """
+pub fn ArrayBuf(comptime T: type) -> type {
     struct {
         buf: ptr mut T,
         len: u64,
@@ -311,6 +313,6 @@ pub fn Vec(comptime T: type) -> type {
 }
 """ },
 ]
-args = ["main.rue", "vec.rue", "-o", "prog"]
+args = ["main.rue", "arraybuf.rue", "-o", "prog"]
 stdout = "3\n10\n30\n60\n"
 exit_code = 60

--- a/docs/designs/0041-vec.md
+++ b/docs/designs/0041-vec.md
@@ -60,8 +60,8 @@ Each ingredient already exists and shipped:
 
 ### Layout & construction
 A 3-slot struct `{ ptr: ptr mut T, len: u64, cap: u64 }` (mirrors `String`).
-- `Vec::new() -> Vec(T)` — empty, no allocation (`ptr` null, `cap` 0).
-- `Vec::with_capacity(n) -> Vec(T)` — pre-reserve (null-alloc-safe, cf. RUE-255).
+- `ArrayBuf::new() -> ArrayBuf(T)` — empty, no allocation (`ptr` null, `cap` 0).
+- `ArrayBuf::with_capacity(n) -> ArrayBuf(T)` — pre-reserve (null-alloc-safe, cf. RUE-255).
 
 ### Mutation (`inout self`)
 - `push(inout self, x: T)` — moves `x` into the buffer, growing (amortized 2×)

--- a/examples/std/arraybuf.rue
+++ b/examples/std/arraybuf.rue
@@ -1,4 +1,6 @@
-// Vec(T) — a growable, heap-backed collection written in Rue (RUE-1, ADR-0041).
+// ArrayBuf(T) — a growable, heap-backed collection written in Rue (RUE-1,
+// ADR-0041; renamed from Vec to ArrayBuf, the growable rung of the collection
+// trio `[T; N]` / `borrow [T]` / `ArrayBuf(T)`, ADR-0043 / RUE-323).
 //
 // This is a *source-level* standard-library type: it owns a heap buffer
 // addressed by a raw `ptr mut T` and grows it (amortized 2x) with the unchecked
@@ -7,14 +9,15 @@
 // mutation, and the raw-pointer intrinsics all at once — exactly the "stdlib on
 // unchecked code" framing of RUE-1.
 //
-// `get`/`pop` return `Option(T)` (from the sibling `option.rue`), so Vec must
-// be compiled together with `option.rue` in the same flat multi-file namespace:
+// `get`/`pop` return `Option(T)` (from the sibling `option.rue`), so ArrayBuf
+// must be compiled together with `option.rue` in the same flat multi-file
+// namespace:
 //
-//     rue my_program.rue vec.rue option.rue -o my_program
+//     rue my_program.rue arraybuf.rue option.rue -o my_program
 //
 // Usage (the element type is chosen when you instantiate the type function):
 //
-//     let V = Vec(i32);
+//     let V = ArrayBuf(i32);
 //     let O = Option(i32);
 //     let mut v = V::new();
 //     v.push(10);
@@ -26,9 +29,9 @@
 //     // the heap buffer is freed AUTOMATICALLY when `v` goes out of scope
 //     // (the `drop fn` below); call `v.free()` only for explicit early release.
 //
-// RAII: `Vec` owns its buffer and frees it in its destructor at scope exit
+// RAII: `ArrayBuf` owns its buffer and frees it in its destructor at scope exit
 // (RUE-312), so callers no longer have to remember `free()`. `free()` remains
-// available to release the buffer early; it resets the vector to empty, so the
+// available to release the buffer early; it resets the buffer to empty, so the
 // scope-exit destructor is then a safe no-op. `get`/`pop` return `Option(T)`
 // (RUE-313).
 //
@@ -48,7 +51,7 @@
 // The enclosing element type `T` is usable throughout the method bodies below —
 // e.g. to name `Option(T)` and bind `let O = Option(T)` (RUE-313).
 
-pub fn Vec(comptime T: type) -> type {
+pub fn ArrayBuf(comptime T: type) -> type {
     struct {
         buf: ptr mut T,
         len: u64,
@@ -56,7 +59,7 @@ pub fn Vec(comptime T: type) -> type {
 
         // --- construction ---
 
-        // An empty vector. No allocation is performed until the first push.
+        // An empty buffer. No allocation is performed until the first push.
         fn new() -> Self {
             let zero: u64 = 0;
             Self {
@@ -66,7 +69,7 @@ pub fn Vec(comptime T: type) -> type {
             }
         }
 
-        // An empty vector with room pre-reserved for `n` elements.
+        // An empty buffer with room pre-reserved for `n` elements.
         fn with_capacity(n: u64) -> Self {
             let zero: u64 = 0;
             let mut v = Self { buf: checked { @int_to_ptr(zero) }, len: 0, cap: 0 };
@@ -139,7 +142,7 @@ pub fn Vec(comptime T: type) -> type {
         }
 
         // Remove and return the last element as `Some(x)`, or `None` when the
-        // vector is empty (ADR-0041).
+        // buffer is empty (ADR-0041).
         fn pop(inout self) -> Option(T) {
             let O = Option(T);
             if self.len == 0 {
@@ -192,14 +195,14 @@ pub fn Vec(comptime T: type) -> type {
             self.cap = 0;
         }
 
-        // Destructor: free the backing buffer automatically when a `Vec` value
-        // goes out of scope (RUE-312). A `drop fn(self)` inside the anonymous
-        // struct is monomorphized with the type and registered as the concrete
-        // type's destructor, so the ordinary scope-exit drop glue runs it — the
-        // same machinery a named struct's top-level `drop fn` uses. For a Copy
-        // `T` there is no per-element glue, so freeing the buffer is all that is
-        // required. (After an explicit `free()`, `buf` is null and `cap` is 0,
-        // so `@free(null, 0)` here is a no-op.)
+        // Destructor: free the backing buffer automatically when an `ArrayBuf`
+        // value goes out of scope (RUE-312). A `drop fn(self)` inside the
+        // anonymous struct is monomorphized with the type and registered as the
+        // concrete type's destructor, so the ordinary scope-exit drop glue runs
+        // it — the same machinery a named struct's top-level `drop fn` uses. For
+        // a Copy `T` there is no per-element glue, so freeing the buffer is all
+        // that is required. (After an explicit `free()`, `buf` is null and `cap`
+        // is 0, so `@free(null, 0)` here is a no-op.)
         drop fn(self) {
             checked { @free(self.buf, self.cap); };
         }

--- a/examples/std/arraybuf_demo.rue
+++ b/examples/std/arraybuf_demo.rue
@@ -1,16 +1,18 @@
-// Dogfood for the source-level Vec(T) library (examples/std/vec.rue, RUE-1).
+// Dogfood for the source-level ArrayBuf(T) library (examples/std/arraybuf.rue,
+// RUE-1).
 //
 // Compile (flat multi-file namespace; names resolve across the listed files,
-// and Vec's `get`/`pop` return `Option(T)` from option.rue):
-//   rue examples/std/vec_demo.rue examples/std/vec.rue examples/std/option.rue \
-//       -o vec_demo
+// and ArrayBuf's `get`/`pop` return `Option(T)` from option.rue):
+//   rue examples/std/arraybuf_demo.rue examples/std/arraybuf.rue \
+//       examples/std/option.rue -o arraybuf_demo
 //
-// Exercises push/len/get/set/pop/while-sum/out-of-bounds on a Vec(i32) with the
-// `Option(T)`-returning accessors (RUE-313). The buffer is freed automatically
-// when `v` goes out of scope (Vec's `drop fn`, RUE-312) — no explicit `free()`.
+// Exercises push/len/get/set/pop/while-sum/out-of-bounds on an ArrayBuf(i32)
+// with the `Option(T)`-returning accessors (RUE-313). The buffer is freed
+// automatically when `v` goes out of scope (ArrayBuf's `drop fn`, RUE-312) — no
+// explicit `free()`.
 
 fn main() -> i32 {
-    let V = Vec(i32);
+    let V = ArrayBuf(i32);
     let O = Option(i32);
 
     let mut v = V::new();

--- a/examples/std/option.rue
+++ b/examples/std/option.rue
@@ -10,10 +10,10 @@
 // Requires `--preview enum_payloads`.
 //
 // NOTE: `Option(T)` works standalone (see the dogfood test), but it cannot yet
-// be *returned from a `Vec(T)` method* — the enclosing comptime type parameter
-// `T` is not usable inside a method body to name `Option(T)` (E1201), and
-// binding the type in the type-function body breaks comptime type folding
-// (E1200). Until that gap is closed, `Vec` uses caller-supplied defaults
+// be *returned from an `ArrayBuf(T)` method* — the enclosing comptime type
+// parameter `T` is not usable inside a method body to name `Option(T)` (E1201),
+// and binding the type in the type-function body breaks comptime type folding
+// (E1200). Until that gap is closed, `ArrayBuf` uses caller-supplied defaults
 // (`get_or`/`pop_or`) rather than `Option(T)` accessors. See the meta report.
 
 pub fn Option(comptime T: type) -> type {


### PR DESCRIPTION
Mechanical rename of the source-level growable collection to its trio name (ADR-0043). No behavior change; verified arraybuf_demo runs identically (119) + 3 CLI cases pass; test.sh Pass 24, 100% traceability. Part of RUE-321