### PR TITLE
ADR-0043 Phase 1: slice type front-end + preview gate (part of RUE-321)

### DIFF
--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -9,7 +9,7 @@
 use std::collections::HashMap;
 
 use lasso::Spur;
-use rue_error::{CompileError, CompileResult, ErrorKind};
+use rue_error::{CompileError, CompileResult, ErrorKind, PreviewFeature};
 use rue_span::Span;
 
 use super::Sema;
@@ -164,6 +164,31 @@ impl<'a> Sema<'a> {
     /// Resolve a type symbol to a Type.
     ///
     /// Handles array types with the syntax "[T; N]".
+    /// Recognize slice type syntax `[T]` (ADR-0043, RUE-322).
+    ///
+    /// A slice is a bracketed type that is *not* a fixed array `[T; N]` (which
+    /// [`parse_array_type_syntax`] handles). Returns `Some(result)` when the
+    /// canonical type string is slice syntax so the caller short-circuits;
+    /// `None` otherwise (a genuinely unknown type falls through to E0204).
+    ///
+    /// This gates the surface behind `--preview slices` and, until the
+    /// fat-pointer runtime (ABI + codegen on both backends) lands, reports
+    /// [`ErrorKind::SliceNotYetImplemented`] (E0486) rather than letting an
+    /// unfinished slice reach lowering.
+    fn try_resolve_slice_type(&self, type_name: &str, span: Span) -> Option<CompileResult<Type>> {
+        if type_name.starts_with('[')
+            && type_name.ends_with(']')
+            && parse_array_type_syntax(type_name).is_none()
+        {
+            Some(
+                self.require_preview(PreviewFeature::Slices, "the slice type `[T]`", span)
+                    .and_then(|()| Err(CompileError::new(ErrorKind::SliceNotYetImplemented, span))),
+            )
+        } else {
+            None
+        }
+    }
+
     pub(crate) fn resolve_type(&mut self, type_sym: Spur, span: Span) -> CompileResult<Type> {
         let type_name = self.interner.resolve(&type_sym);
 
@@ -236,6 +261,9 @@ impl<'a> Sema<'a> {
                 // context-free (a signature/return position collected before any
                 // body context exists).
                 self.resolve_type_function_call(&call_name, &arg_strs, span, None)
+            } else if let Some(result) = self.try_resolve_slice_type(type_name, span) {
+                // Slice type `[T]` (ADR-0043, RUE-322): gated + not-yet-runnable.
+                result
             } else {
                 Err(CompileError::new(
                     ErrorKind::UnknownType(type_name.to_string()),

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -186,6 +186,18 @@ impl ErrorCode {
     /// 9.1:12, ADR-0028); taking the "address" of a temporary value would
     /// reinterpret the value's bits as a pointer (RUE-274).
     pub const RAW_REQUIRES_PLACE: Self = Self(485);
+    /// A second-class slice type (`borrow [T]` / `inout [T]`) or range slice
+    /// (`x[a..b]`) was used with `--preview slices` enabled, but the
+    /// fat-pointer runtime (ABI + codegen on both backends) is not yet
+    /// implemented (ADR-0043 Phase 1, RUE-322). Emitted so the gated syntax
+    /// fails cleanly instead of reaching an unfinished codegen path.
+    ///
+    /// Note: the second-class-escape diagnostics named in the RUE-322 brief
+    /// (return / store-in-field / bind-past-scope) will be allocated when the
+    /// slice type itself lands; the brief's suggested E0435-E0437 numbers were
+    /// already taken (`RESERVED_FUNCTION_NAME` / `DUPLICATE_FUNCTION_DEFINITION`
+    /// / `MOVE_OUT_OF_INOUT`), so a fresh free range will be used then.
+    pub const SLICE_NOT_YET_IMPLEMENTED: Self = Self(486);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -376,6 +388,11 @@ pub enum PreviewFeature {
     /// Testing infrastructure feature - permanently unstable.
     /// Used to verify the preview feature gating mechanism works.
     TestInfra,
+    /// Second-class slice types `borrow [T]` / `inout [T]` and range slicing
+    /// `x[a..b]` (ADR-0043, RUE-322). The keystone view type of the
+    /// collection/string trio. Gated until the fat-pointer ABI lands on both
+    /// backends.
+    Slices,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -396,6 +413,7 @@ impl PreviewFeature {
     pub fn name(&self) -> &'static str {
         match *self {
             PreviewFeature::TestInfra => "test_infra",
+            PreviewFeature::Slices => "slices",
         }
     }
 
@@ -404,12 +422,13 @@ impl PreviewFeature {
     pub fn adr(&self) -> &'static str {
         match *self {
             PreviewFeature::TestInfra => "ADR-0005",
+            PreviewFeature::Slices => "ADR-0043",
         }
     }
 
     /// Get all available preview features.
     pub fn all() -> &'static [PreviewFeature] {
-        &[PreviewFeature::TestInfra]
+        &[PreviewFeature::TestInfra, PreviewFeature::Slices]
     }
 
     /// Get a comma-separated list of all feature names (for help text).
@@ -432,6 +451,7 @@ impl std::str::FromStr for PreviewFeature {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "test_infra" => Ok(PreviewFeature::TestInfra),
+            "slices" => Ok(PreviewFeature::Slices),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -1269,6 +1289,11 @@ pub enum ErrorKind {
         what: String,
     },
 
+    /// A slice type / range-slice was used under `--preview slices` but the
+    /// fat-pointer runtime is not implemented yet (ADR-0043 Phase 1, RUE-322).
+    #[error("slice types are not yet fully implemented (ADR-0043 Phase 1, RUE-322)")]
+    SliceNotYetImplemented,
+
     // Comptime errors
     #[error("comptime evaluation failed: {reason}")]
     ComptimeEvaluationFailed { reason: String },
@@ -1426,6 +1451,7 @@ impl ErrorKind {
 
             // Preview feature errors (E1100-E1199)
             ErrorKind::PreviewFeatureRequired { .. } => ErrorCode::PREVIEW_FEATURE_REQUIRED,
+            ErrorKind::SliceNotYetImplemented => ErrorCode::SLICE_NOT_YET_IMPLEMENTED,
 
             // Comptime errors (E1200-E1299)
             ErrorKind::ComptimeEvaluationFailed { .. } => ErrorCode::COMPTIME_EVALUATION_FAILED,
@@ -2245,7 +2271,17 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra");
+        assert_eq!(names, "test_infra, slices");
+    }
+
+    #[test]
+    fn test_preview_feature_slices() {
+        // ADR-0043 Phase 1 (RUE-322): the slice preview feature.
+        let feature: PreviewFeature = "slices".parse().unwrap();
+        assert_eq!(feature, PreviewFeature::Slices);
+        assert_eq!(feature.name(), "slices");
+        assert_eq!(feature.adr(), "ADR-0043");
+        assert!(PreviewFeature::all().contains(&PreviewFeature::Slices));
     }
 
     #[test]

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -330,6 +330,11 @@ pub enum TypeExpr {
         length: ArrayLength,
         span: Span,
     },
+    /// Slice type: `[T]` — a second-class fat-pointer view (ptr + runtime len)
+    /// over a fixed array or growable buffer (ADR-0043, RUE-322). In parameter
+    /// position the `borrow`/`inout` mode selects the shared/exclusive form
+    /// (`borrow [T]` / `inout [T]`). Gated behind `--preview slices`.
+    Slice { element: Box<TypeExpr>, span: Span },
     /// Anonymous struct type: struct { field: Type, fn method(...) { ... }, ... }
     /// Used in comptime type construction (e.g., `fn Pair(comptime T: type) -> type { struct { first: T, second: T } }`)
     /// Methods can be included inside the struct definition (Zig-style).
@@ -430,6 +435,7 @@ impl TypeExpr {
             TypeExpr::Unit(span) => *span,
             TypeExpr::Never(span) => *span,
             TypeExpr::Array { span, .. } => *span,
+            TypeExpr::Slice { span, .. } => *span,
             TypeExpr::AnonymousStruct { span, .. } => *span,
             TypeExpr::AnonymousEnum { span, .. } => *span,
             TypeExpr::PointerConst { span, .. } => *span,
@@ -448,6 +454,7 @@ impl fmt::Display for TypeExpr {
             TypeExpr::Array {
                 element, length, ..
             } => write!(f, "[{}; {}]", element, length),
+            TypeExpr::Slice { element, .. } => write!(f, "[{}]", element),
             TypeExpr::AnonymousStruct {
                 fields, methods, ..
             } => {

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -312,6 +312,17 @@ where
                 span: span_from_extra(e),
             });
 
+        // Slice type: `[T]` (no length) — a second-class fat-pointer view
+        // (ADR-0043, RUE-322). Tried after `array_type` so `[T; N]` is not
+        // mis-parsed; the two diverge on whether a `;` follows the element.
+        let slice_type = just(TokenKind::LBracket)
+            .ignore_then(ty.clone())
+            .then_ignore(just(TokenKind::RBracket))
+            .map_with(|element, e| TypeExpr::Slice {
+                element: Box::new(element),
+                span: span_from_extra(e),
+            });
+
         // Anonymous struct type: struct { field: Type, ... }
         // Used in comptime type construction
         let anon_struct_field = ident_parser()
@@ -392,6 +403,7 @@ where
             unit_type,
             never_type,
             array_type,
+            slice_type,
             anon_struct_type,
             ptr_const_type,
             ptr_mut_type,
@@ -3808,6 +3820,37 @@ mod tests {
             }
             _ => panic!("expected Function"),
         }
+    }
+
+    #[test]
+    fn test_slice_type_param_parses() {
+        // ADR-0043 / RUE-322: `[T]` (no length) parses to TypeExpr::Slice; the
+        // `borrow` mode is carried separately on the parameter.
+        let result = parse("fn sum(borrow s: [i32]) -> i32 { 0 }").unwrap();
+        match &result.ast.items[0] {
+            Item::Function(f) => {
+                assert_eq!(f.params.len(), 1);
+                assert_eq!(f.params[0].mode, ParamMode::Borrow);
+                match &f.params[0].ty {
+                    TypeExpr::Slice { element, .. } => match element.as_ref() {
+                        TypeExpr::Named(ident) => assert_eq!(result.get(ident.name), "i32"),
+                        other => panic!("expected named element, got {other:?}"),
+                    },
+                    other => panic!("expected Slice type, got {other:?}"),
+                }
+            }
+            _ => panic!("expected Function"),
+        }
+    }
+
+    #[test]
+    fn test_array_vs_slice_type_distinct() {
+        // `[i32; 3]` remains an Array; only the length-less `[i32]` is a Slice.
+        let result = parse("fn f(borrow a: [i32; 3]) -> i32 { 0 }").unwrap();
+        let Item::Function(func) = &result.ast.items[0] else {
+            panic!("expected Function");
+        };
+        assert!(matches!(func.params[0].ty, TypeExpr::Array { .. }));
     }
 
     #[test]

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -226,6 +226,7 @@ impl Validator<'_> {
         match ty {
             TypeExpr::Named(_) | TypeExpr::Unit(_) | TypeExpr::Never(_) => {}
             TypeExpr::Array { element, .. } => self.check_type_expr(element),
+            TypeExpr::Slice { element, .. } => self.check_type_expr(element),
             TypeExpr::AnonymousStruct { methods, .. } => {
                 for method in methods {
                     self.check_method(method);

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -97,6 +97,17 @@ impl<'a> AstGen<'a> {
                 let s = format!("[{}; {}]", elem_name, len_str);
                 self.interner.get_or_intern(&s)
             }
+            TypeExpr::Slice { element, .. } => {
+                // Slice type `[T]` (ADR-0043, RUE-322): canonical string is
+                // `[elem]` (no length), distinguishing it from `[elem; N]`.
+                // Sema recognizes this shape, gates it behind `--preview
+                // slices`, and (until the fat-pointer runtime lands) reports it
+                // as not-yet-implemented.
+                let elem_sym = self.intern_type(element);
+                let elem_name = self.interner.resolve(&elem_sym);
+                let s = format!("[{}]", elem_name);
+                self.interner.get_or_intern(&s)
+            }
             TypeExpr::AnonymousStruct { fields, .. } => {
                 // For anonymous structs, generate a canonical name representation
                 let mut s = String::from("struct { ");
@@ -939,6 +950,13 @@ impl<'a> AstGen<'a> {
                                 // Array types as values are not yet supported
                                 // For now, use a placeholder
                                 self.interner.get_or_intern_static("array")
+                            }
+                            TypeExpr::Slice { .. } => {
+                                // Slice type `[T]` in value position (ADR-0043,
+                                // RUE-322). Intern its canonical string; sema
+                                // gates it behind `--preview slices` and reports
+                                // it not-yet-implemented.
+                                self.intern_type(&type_lit.type_expr)
                             }
                             TypeExpr::AnonymousStruct { .. } | TypeExpr::AnonymousEnum { .. } => {
                                 unreachable!("handled above")

--- a/crates/rue-ui-tests/cases/diagnostics/slice_preview_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/slice_preview_gate.toml
@@ -1,0 +1,42 @@
+[section]
+id = "diagnostics.slice-preview-gate"
+name = "Slice type preview gating (ADR-0043 Phase 1)"
+description = """
+The second-class slice type `[T]` (ADR-0043, RUE-322) is gated behind
+`--preview slices`. Without the flag, using slice syntax reports E1100
+(preview feature required). With the flag, the syntax is accepted by the
+parser and type resolver but reports E0486 because the fat-pointer runtime
+(ABI + codegen on both backends) is not yet implemented. These UI cases pin
+that gating behaviour; they become regression tests for the follow-up phase
+that lands the runtime.
+"""
+
+[[case]]
+name = "slice_param_requires_preview"
+description = "A `borrow [T]` slice parameter without --preview slices is E1100."
+source = """
+fn sum(borrow s: [i32]) -> i32 { 0 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "requires preview feature"
+
+[[case]]
+name = "slice_let_annotation_requires_preview"
+description = "A `[T]` slice let-annotation without --preview slices is E1100."
+source = """
+fn main() -> i32 { let s: [i32] = other(); 0 }
+"""
+compile_fail = true
+error_contains = "requires preview feature"
+
+[[case]]
+name = "slice_param_under_preview_not_yet_implemented"
+description = "Under --preview slices, slice syntax parses but reports E0486 (runtime unimplemented)."
+preview = "slices"
+source = """
+fn sum(borrow s: [i32]) -> i32 { 0 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = "not yet fully implemented"


### PR DESCRIPTION
Groundwork for the second-class slice `borrow [T]`/`inout [T]`: parser + AST + rir + typeck accept the syntax, gated behind `--preview slices`. Without the flag → E1100; with it → E0486 'not yet fully implemented' (the runtime — fat-pointer ABI, slice index/len codegen both backends, second-class enforcement, range slicing — is the follow-up pass, specced in the worker meta). No codegen touched; arrays unaffected.

Verified: slice param → E1100/E0486 as gated; `[i32;3]` still runs (10); clippy clean; test.sh Pass 24, 100% traceability, oracle-diff 0. Part of RUE-321