### PR TITLE
Spec + formal fixes: mutable-strings var, never-coercion, grammar sync, module-qualified usage

### DIFF
--- a/crates/rue-spec/cases/modules/bindings.toml
+++ b/crates/rue-spec/cases/modules/bindings.toml
@@ -299,3 +299,96 @@ pub fn touch() -> i32 { SECRET }
 """ }
 compile_fail = true
 error_contains = "private"
+
+# =============================================================================
+# Types, Enum Variants, and Associated Functions Through a Module (RUE-293)
+# =============================================================================
+# A module's types, enum variants, and associated functions are referenced
+# through a module binding in expression/pattern positions (10.4:15); a
+# qualified path is rejected in a type position (10.4:16); privacy is uniform
+# (10.4:18).
+
+[[case]]
+name = "qualified_type_variant_and_assoc_fn_forms"
+spec = ["10.4:15"]
+description = "Struct literal, associated function, variant expression, and variant pattern are all usable through a module binding"
+source = """
+const lib = @import("sub/lib");
+
+fn main() -> i32 {
+    let p = lib.Point { x: 40, y: 2 };
+    let q = lib.Point::origin();
+    let c = lib.Color::Green;
+    let base = p.x + p.y + q.x + q.y;
+    match c {
+        lib.Color::Red => 0,
+        lib.Color::Green => base,
+        lib.Color::Blue => 0,
+    }
+}
+"""
+aux_files = { "sub/lib.rue" = """
+pub struct Point {
+    x: i32,
+    y: i32,
+    fn origin() -> Point { Point { x: 30, y: 12 } }
+}
+pub enum Color { Red, Green, Blue, }
+""" }
+exit_code = 84
+
+[[case]]
+name = "qualified_path_in_type_position_rejected"
+spec = ["10.4:16"]
+description = "A module-qualified path in a type-annotation position is a parse error (E0100); types are named by bare identifier only"
+source = """
+const lib = @import("sub/lib");
+
+fn main() -> i32 {
+    let p: lib.Point = lib.Point { x: 1, y: 2 };
+    p.x + p.y
+}
+"""
+aux_files = { "sub/lib.rue" = """
+pub struct Point { x: i32, y: i32, }
+""" }
+compile_fail = true
+error_contains = ["E0100"]
+
+[[case]]
+name = "qualified_private_struct_literal_rejected"
+spec = ["10.4:18"]
+description = "A private struct named in a module-qualified struct literal from another directory is E0460 (resolves through the flat namespace)"
+source = """
+const lib = @import("sub/lib");
+
+fn main() -> i32 {
+    let s = lib.Secret { n: 3 };
+    s.n
+}
+"""
+aux_files = { "sub/lib.rue" = """
+struct Secret { n: i32, }
+pub fn touch() -> i32 { let s = Secret { n: 1 }; s.n }
+""" }
+compile_fail = true
+error_contains = ["E0460", "is private"]
+
+[[case]]
+name = "qualified_private_enum_variant_rejected"
+spec = ["10.4:18"]
+description = "A private enum's variant named through a module from another directory is E0706 (routes through module-member resolution)"
+source = """
+const lib = @import("sub/lib");
+
+fn main() -> i32 {
+    let h = lib.Hidden::A;
+    0
+}
+"""
+aux_files = { "sub/lib.rue" = """
+enum Hidden { A, B, }
+pub fn touch() -> i32 { let h = Hidden::A; match h { Hidden::A => 1, Hidden::B => 2, } }
+""" }
+compile_fail = true
+error_contains = ["E0706", "is private"]

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -375,7 +375,9 @@ ill-formed (`3.8:50` — a linear value consumed on only some paths). For non-li
 (the value is conservatively considered gone), and the dynamic semantics uses a
 per-path drop flag so the runtime drops it on exactly the paths that did not
 (`3.8:73`). A branch ending in `return`/`break` has outgoing state `⊥` (diverged)
-and is excluded from the join (`3.8:51`).
+and is excluded from the join (`3.8:51`); its *type* is `never`, which
+(Sub-Never), §5.7, coerces to the sibling arm's type `T`, so a diverging arm
+still satisfies the (If)/(Match) same-type premise.
 
 `match` is the elimination form for enums, and its arms join exactly as `if`'s do.
 Typing the scrutinee is a value-context **use** of it (§4.2): a move-typed enum is
@@ -443,6 +445,69 @@ glue) owns them.
 > This section is the precise content behind "implicitly drops"/"goes out of
 > scope": end-of-scope is where drop *and* the linear leak check happen, driven by
 > the ownership state Σ, not by syntax.
+
+### 5.7 Divergence and never-coercion
+
+Prose `3.4` gives Rue its **single** type coercion: the never type `!`
+(`never` here) coerces to any type. The core realizes this as one subsumption
+rule, plus typing rules that give the diverging expression forms type `never`.
+
+The expressions that *have* type `never` are those that transfer control away
+instead of yielding a value to their context (`3.4:1/2`): `return e`, `break`,
+and an infinite `loop { e }` (one with no reachable `break`). (Surface
+`continue` elaborates to the loop's back-edge and is likewise never-typed; it is
+not a distinct core form. `@panic(...)` is **not** a never form — it elaborates
+to an ordinary call of type `unit`, matching `3.4:2`, which lists only these
+control-transfer forms, and the compiler, which types a `@panic` expression at
+`unit`.)
+
+```
+  Γ;Σ;Λ ⊢ e ⇒ T_ret ⊣ _        T_ret = the enclosing function's declared return type
+  ─────────────────────────────────────────────────────── (Return)
+  Γ;Σ;Λ ⊢ return e ⇒ never ⊣ ⊥
+
+  ───────────────────────── (Break)      -- well-formed only inside a loop; hands unit to the loop
+  Γ;Σ;Λ ⊢ break ⇒ never ⊣ ⊥
+
+  Γ;Σ;Λ ⊢ e ⇒ unit ⊣ _        the loop body has no reachable `break`
+  ─────────────────────────────────────────────────────── (Loop-Div)
+  Γ;Σ;Λ ⊢ loop { e } ⇒ never ⊣ ⊥
+```
+
+`break` yields no value to its *own* context, so its type is `never`; the "value
+unit" of the grammar (§2) is what it hands to the enclosing loop, not the type of
+the `break` expression. The outgoing state `⊥` ("diverged") is exactly the `⊥`
+that §5.5's join excludes: a branch ending in one of these forms contributes no
+ownership state to the merge. (A `loop` that *is* exited by a `break` yields
+`unit` at the break's state; formalizing multi-`break` loop ownership is
+orthogonal to coercion and left to a future loop section.)
+
+A `never`-typed expression is accepted wherever a value of any type is expected —
+this is the coercion, stated as **subsumption on the bottom type** (`3.4:3/4`):
+
+```
+  Γ;Σ;Λ ⊢ e ⇒ never ⊣ Σ'
+  ───────────────────────── (Sub-Never)      -- for any type T
+  Γ;Σ;Λ ⊢ e ⇒ T ⊣ Σ'
+```
+
+Because `never` has no values (`3.4:1`), this coercion is vacuously sound: there
+is no run-time value to convert, so re-typing a diverging expression at `T`
+cannot misclassify any value. It also creates no ownership obligation: `never` is
+zero-sized (`3.4:9`) and §3 sets `class(never) = Copy`, so a `never`-typed
+expression has nothing to move, drop, or leak, and (Sub-Never) leaves `Σ'`
+untouched.
+
+(Sub-Never) is what makes §5.5's (If)/(Match) admit a diverging arm while their
+premises still demand a single common type `T`. In
+`if c { 5 } else { return 0 }` the `else` arm has type `never`, which
+(Sub-Never) re-types to `i32` to meet the `then` arm; the whole `if` is `i32`,
+and since the `else` arm's outgoing state is `⊥` the branch join is just the
+`then` arm's state. When *every* arm diverges (`3.4:6`, e.g.
+`if c { return 1 } else { return 0 }`), the principal type is `never`, which
+(Sub-Never) then coerces to whatever the surrounding context needs (there, the
+function's `i32` return type). This is the **only** coercion in the language:
+every other typing rule demands exact type identity.
 
 ---
 
@@ -579,6 +644,7 @@ far. As breadth is filled in, each new rule adds its citation.
 | §5.4 borrows / exclusivity | 6.1:14–33, 6.1:20, 6.1:30 |
 | §5.5 branch join | 3.8:50/51, 3.8:73 |
 | §5.6 scope exit: drop + leak | 3.8:32/62/66, 3.9 (drop order) |
+| §5.7 divergence + never-coercion | 3.4:1/2/3/4/6/8, 3.4:9 |
 | §6 overflow/bounds/div-zero panics | 3.1:6/13, 8.1, 8.2, 8.3, Appendix B |
 | §7 soundness | the informal safety intent throughout ch. 3 and 8 |
 

--- a/docs/spec/src/03-types/10-mutable-strings.md
+++ b/docs/spec/src/03-types/10-mutable-strings.md
@@ -40,7 +40,7 @@ This representation allows string literals to remain cheap (no allocation) while
 fn takes_string(s: String) -> i32 { 0 }
 
 fn main() -> i32 {
-    var s = "hello";
+    let mut s = "hello";
     takes_string(s);    // s is moved
     // takes_string(s); // ERROR: use of moved value
     0
@@ -118,13 +118,13 @@ fn main() -> i32 {
 
 {{ rule(id="3.10:19", cat="informative") }}
 
-Mutation methods use `inout self` to modify the string in place. The variable must be declared with `var` to allow mutation.
+Mutation methods use `inout self` to modify the string in place. The variable must be declared with `let mut` to allow mutation.
 
 {{ rule(id="3.10:20", cat="example") }}
 
 ```rue
 fn main() -> i32 {
-    var s = String::new();
+    let mut s = String::new();
     s.push_str("hello");
     s.push_str(" world");
     s.push(33);  // '!' character
@@ -150,7 +150,7 @@ Heap promotion is transparent to the user. There is no separate "owned" vs "borr
 
 ```rue
 fn main() -> i32 {
-    var s = "hello";     // literal: capacity = 0
+    let mut s = "hello";     // literal: capacity = 0
     s.push_str("!");     // promotes to heap, then appends
     // s is now "hello!" with capacity > 0
     0
@@ -204,7 +204,7 @@ The destructor automatically distinguishes between string literals and heap-allo
 
 ```rue
 fn main() -> i32 {
-    var s = "hello";
+    let mut s = "hello";
     s.push_str("!");  // promotes to heap
     0
 }  // destructor frees the heap buffer

--- a/docs/spec/src/05-statements/02-assignment.md
+++ b/docs/spec/src/05-statements/02-assignment.md
@@ -13,10 +13,16 @@ An assignment statement assigns a new value to a mutable variable.
 {{ rule(id="5.2:2", cat="normative") }}
 
 ```ebnf
-assign_stmt = IDENT "=" expression ";"
-            | IDENT "[" expression "]" "=" expression ";"
-            | expression "." IDENT "=" expression ";" ;
+assign_stmt   = assign_target "=" expression ";" ;
+assign_target = IDENT { "." IDENT | "[" expression "]" }
+              | "self" ( "." IDENT | "[" expression "]" ) { "." IDENT | "[" expression "]" } ;
 ```
+
+The assignment target is a *place*: a variable (or, inside a method, `self`)
+followed by any number of field (`.f`) and index (`[e]`) projections, freely
+mixed. All of `x`, `p.f`, `arr[i]`, `arr[i].f`, `p.arr[i]`, `a.b.c`, and
+`o.items[i].arr[j]` are valid targets. (Appendix A's `place_expr` is the
+normative statement of this production; see that appendix.)
 
 ## Variable Assignment
 

--- a/docs/spec/src/05-statements/_index.md
+++ b/docs/spec/src/05-statements/_index.md
@@ -10,6 +10,11 @@ page_template = "spec/page.html"
 
 This chapter describes statements in Rue.
 
+> **Grammar note.** The EBNF fragments in this chapter are illustrative
+> excerpts scoped to the construct under discussion. [Appendix A](../appendices/a-grammar/)
+> is the normative grammar; where a fragment here differs from it, Appendix A
+> governs.
+
 {{ rule(id="5.0:1") }}
 
 A statement is a syntactic construct that performs an action but does not produce a value. Statements have type `()`.

--- a/docs/spec/src/06-items/_index.md
+++ b/docs/spec/src/06-items/_index.md
@@ -10,6 +10,13 @@ page_template = "spec/page.html"
 
 This chapter describes items in Rue.
 
+> **Grammar note.** The EBNF fragments in this chapter are illustrative
+> excerpts scoped to the construct under discussion, and are deliberately
+> narrower than the full syntax (they may omit `pub`, directives, receiver
+> modes, method bodies, or variant payloads). [Appendix A](../appendices/a-grammar/)
+> is the normative grammar; where a fragment here differs from it, Appendix A
+> governs.
+
 {{ rule(id="6.0:1") }}
 
 Items are top-level definitions in a program. Unlike statements, items are visible throughout the module.

--- a/docs/spec/src/10-modules/04-module-bindings.md
+++ b/docs/spec/src/10-modules/04-module-bindings.md
@@ -138,6 +138,93 @@ const COPY: i32 = math.ANSWER;   // const-evaluable member access
 fn main() -> i32 { math.ANSWER + COPY }   // 84
 ```
 
+## Types, Enum Variants, and Associated Functions Through a Module
+
+The preceding sections cover functions and value constants as module members.
+This section specifies how a module's **types**, **enum variants**, and
+**associated functions** (6.4:11) are referenced through a module binding, and
+how privacy applies to each form.
+
+{{ rule(id="10.4:15", cat="normative") }}
+
+A type, enum variant, or associated function of a module **MAY** be named
+through a module binding in an *expression* or *pattern* position by writing
+the binding, a `.`, and the item's path: a struct type in a struct-literal
+expression (`m.Point { .. }`), an enum variant in a variant expression or a
+match pattern (`m.Color::Red`), and an associated function in a call
+(`m.Point::origin()`). Each of these forms is accepted wherever the
+corresponding *bare* path — `Point { .. }`, `Color::Red`, `Point::origin()` —
+is accepted, and has the same meaning.
+
+{{ rule(id="10.4:16", cat="legality-rule") }}
+
+A module-qualified path is **not** accepted in a *type* position — a type
+annotation, a field type, or a parameter or return type. In those positions a
+type is named only by a bare identifier (resolved through the flat namespace,
+10.5:2); writing `m.Type` where a type is expected is a compile-time error
+reported during parsing (E0100).
+
+{{ rule(id="10.4:17") }}
+
+Resolution of the tail path in the forms of 10.4:15 currently proceeds through
+the transitional flat namespace (10.5:2): the type, variant, or associated
+function is looked up by name across the whole compilation, and the leading
+module qualifier does **not** restrict the lookup to members of the named
+module. A program must not rely on the qualifier naming the module that defines
+the item; unlike functions and value constants (10.4:3, 10.4:12), which resolve
+as genuine module members, the qualifier is not yet load-bearing for these item
+kinds. This is a transitional artifact that will change when top-level names
+become module-scoped (10.5:2).
+
+{{ rule(id="10.4:18", cat="legality-rule") }}
+
+Privacy of module-qualified type and enum-variant access is uniform (10.3:7).
+Naming a private struct in a module-qualified struct literal from a source file
+in another directory is a compile-time error (E0460, the same error as the
+unqualified form, because the type resolves through the flat namespace).
+Naming a private enum's variant through a module from another directory is a
+compile-time error (E0706, because a variant path routes through
+module-member resolution).
+
+{{ rule(id="10.4:19") }}
+
+An associated function's visibility is intended to follow the visibility of its
+enclosing type (10.3:7): an associated function of a private type should not be
+callable from another directory. The current implementation does **not** yet
+enforce this — an associated-function call on a private type is accepted across
+the directory boundary, whether written unqualified or module-qualified
+(RUE-330). Programs must not rely on this gap; it is an implementation
+artifact, not a guarantee.
+
+{{ rule(id="10.4:20", cat="example") }}
+
+```rue
+// sub/lib.rue
+pub struct Point {
+    x: i32,
+    y: i32,
+    fn origin() -> Point { Point { x: 30, y: 12 } }  // associated fn
+}
+pub enum Color { Red, Green, Blue, }
+enum Hidden { A, B, }               // private outside sub/
+
+// main.rue — a different directory
+const lib = @import("sub/lib");
+fn main() -> i32 {
+    let p = lib.Point { x: 40, y: 2 };     // qualified struct literal
+    let q = lib.Point::origin();           // qualified associated fn
+    let c = lib.Color::Green;              // qualified variant expression
+    // let bad: lib.Point = p;           // error E0100: no qualified path in a type position
+    // let h = lib.Hidden::A;            // error E0706: `Hidden` is private outside sub/
+    let base = p.x + p.y + q.x + q.y;    // 40 + 2 + 30 + 12 = 84
+    match c {
+        lib.Color::Red => 0,             // qualified variant pattern
+        lib.Color::Green => base,        // 84
+        lib.Color::Blue => 0,
+    }
+}
+```
+
 ## Modules Are Not Runtime Values
 
 {{ rule(id="10.4:6", cat="legality-rule") }}

--- a/docs/spec/src/appendices/A-grammar.md
+++ b/docs/spec/src/appendices/A-grammar.md
@@ -10,6 +10,12 @@ This appendix contains the complete EBNF grammar for Rue. It is maintained by
 hand against the parser in `crates/rue-parser/src/chumsky_parser.rs`; when the
 parser changes, this appendix must be updated in the same change.
 
+This grammar is **normative**: it is the authoritative syntactic definition of
+Rue. The EBNF fragments that appear inline in Chapters 5 and 6 are
+**illustrative excerpts** for local exposition and are deliberately narrowed to
+the construct under discussion; where any of them differs from this appendix,
+this appendix governs.
+
 ```ebnf
 (* Program structure *)
 program        = { item } ;
@@ -37,12 +43,13 @@ struct_def     = directives [ "pub" ] [ "linear" ]
 struct_fields  = struct_field { "," struct_field } [ "," ] ;
 struct_field   = IDENT ":" type ;
 method         = directives "fn" IDENT
-                 "(" [ "self" [ "," params ] | params ] ")"
+                 "(" [ [ "inout" | "borrow" ] "self" [ "," params ] | params ] ")"
                  [ "->" type ] "{" block "}" ;
 
 (* Enums *)
 enum_def       = [ "pub" ] "enum" IDENT "{" [ enum_variants ] "}" ;
-enum_variants  = IDENT { "," IDENT } [ "," ] ;
+enum_variants  = enum_variant { "," enum_variant } [ "," ] ;
+enum_variant   = IDENT [ "(" type { "," type } [ "," ] ")" ] ;  (* optional tuple payload; at least one type inside the parens *)
 
 (* Destructors *)
 drop_fn        = "drop" "fn" IDENT "(" "self" ")" "{" block "}" ;
@@ -59,9 +66,11 @@ expr_stmt      = expression ";"
                | control_flow_expr ;   (* if/match/while/loop/for/break/continue/
                                           return and bare blocks need no semicolon *)
 
-(* Place expressions: a variable with zero or more field/index projections.
-   Used as assignment targets and as inout/borrow call arguments. *)
-place_expr     = IDENT { "." IDENT | "[" expression "]" } ;
+(* Place expressions: a variable — or `self`, inside a method — followed by
+   zero or more field/index projections. Used as assignment targets. A bare
+   `self` is not a place: when the base is `self`, at least one projection is
+   required (a legality rule). *)
+place_expr     = ( IDENT | "self" ) { "." IDENT | "[" expression "]" } ;
 
 (* Types *)
 type           = "i8" | "i16" | "i32" | "i64"
@@ -73,9 +82,11 @@ type           = "i8" | "i16" | "i32" | "i64"
                | "ptr" "mut" type
                | anon_struct_type
                | "Self"
+               | type_call
                | IDENT ;
+type_call      = IDENT "(" [ type { "," type } [ "," ] ] ")" ;  (* type-function application, e.g. Pair(i32), Result(Option(i32), i32) *)
 array_length   = INTEGER | IDENT | length_call ;
-length_call    = IDENT "(" [ array_length { "," array_length } ] ")" ;  (* comptime-evaluable call, e.g. fact(4) *)
+length_call    = IDENT "(" [ array_length { "," array_length } [ "," ] ] ")" ;  (* comptime-evaluable call, e.g. fact(4) *)
 anon_struct_type = "struct" "{" [ anon_struct_fields ] { method } "}" ;
 anon_struct_fields = struct_field { "," struct_field } [ "," ] ;
 
@@ -105,12 +116,12 @@ suffix         = "." IDENT                                     (* field access *
                | "." IDENT "::" IDENT                          (* qualified enum variant *)
                | "." IDENT "::" IDENT "(" [ call_args ] ")" ;  (* qualified assoc fn call *)
 
-(* Call arguments: inout/borrow arguments must be place expressions
-   (a variable, optionally with field/index projections); plain
-   arguments are arbitrary expressions. *)
+(* Call arguments: any argument may carry an `inout`/`borrow` mode. The
+   argument itself is parsed as an arbitrary expression; the requirement that
+   an inout/borrow argument denote a place (a variable, optionally with field/
+   index projections) is a legality rule (6.1:17), not a syntactic one. *)
 call_args      = call_arg { "," call_arg } ;
-call_arg       = ( "inout" | "borrow" ) place_expr
-               | expression ;
+call_arg       = [ "inout" | "borrow" ] expression ;
 
 primary        = INTEGER | STRING | BOOL | "()"
                | "self"
@@ -200,9 +211,20 @@ Notes:
   unambiguously a type (`()`, `[T; N]`, a primitive type keyword, or a `!`
   that is the entire argument) parses as a type; anything else — including
   `!expr`, which is logical not — parses as an expression.
-- **`inout`/`borrow` call arguments** must be place expressions: a variable
-  optionally followed by field and index projections (e.g. `inout s.arr[i]`),
-  not arbitrary expressions.
+- **`inout`/`borrow` call arguments** are parsed as ordinary expressions; the
+  rule that such an argument must denote a place — a variable optionally
+  followed by field and index projections (e.g. `inout s.arr[i]`) — is a
+  legality rule enforced during semantic analysis (6.1:17), not a syntactic
+  restriction. A non-place argument such as `inout a + 1` parses but is
+  rejected with an lvalue error (E0425).
+- **Type-function application in type position** (`type_call`): a name applied
+  to type arguments, e.g. `Pair(i32)` or `Result(Option(i32), i32)`, denotes
+  the type produced by a comptime `-> type` constructor (RUE-241). Nested
+  applications compose. Its result cannot yet head a struct literal
+  (`Pair(i32) { … }` does not parse); bind it via a `let` of that type instead.
+- **Anonymous struct types** carry inline methods only when a `struct { … }`
+  appears as a *value* (e.g. the body of a comptime `-> type` function); in
+  pure type position (a type annotation) a `struct { … }` parses fields only.
 - **A parameter takes at most one mode** (`comptime`, `inout`, or `borrow`);
   duplicate or conflicting modes are a parse error.
 - **Statement termination**: `let`, assignment, and ordinary expression
@@ -211,3 +233,6 @@ Notes:
   statements without a trailing semicolon.
 - There are no `impl` blocks: methods are declared inline inside the
   `struct` body, after the fields.
+- **Method receivers** may carry a mode: `inout self` (mutating receiver) or
+  `borrow self` (read-only receiver); a bare `self` is by-value. This mirrors
+  the `inout`/`borrow` parameter modes; `comptime self` is not permitted.


### PR DESCRIPTION
Four disjoint spec/formal corrections from the RUE-201 audit (docs only):
- **RUE-307**: 3.10 mutable-strings `var` → `let mut` (var isn't a keyword; examples now compile).
- **RUE-306**: added never-type coercion to the formal core (§5.7 + a (Sub-Never) rule) — prose 3.4's only coercion.
- **RUE-292**: reconciled Appendix A with the real parser (fixed 5.2:2 assignment grammar + receiver modes/enum payloads/type-function application); Appendix A normative.
- **RUE-293**: specified module-qualified type/variant/assoc-fn usage (10.4:15-20, +4 cases); filed RUE-330.

Verified by execution; clippy clean; test.sh Pass 24, 100% traceability (662/662).

Fixes RUE-307
Fixes RUE-306
Fixes RUE-292
Fixes RUE-293

Generated with Claude Code