### PR TITLE
Spec: UB/conformance appendix + value-denotation & evaluation order

### DIFF
--- a/crates/rue-spec/cases/expressions/call.toml
+++ b/crates/rue-spec/cases/expressions/call.toml
@@ -98,3 +98,31 @@ fn sub(x: i32, y: i32) -> i32 { x - y }
 fn main() -> i32 { sub(50, 8) }
 """
 exit_code = 42
+
+# =============================================================================
+# Value Denotation (RUE-298)
+# A call expression denotes the value returned by invoking the function.
+# =============================================================================
+
+[[case]]
+name = "call_denotes_return_value"
+spec = ["4.10:9"]
+source = """
+fn answer() -> i32 { 42 }
+fn main() -> i32 {
+    answer()
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "call_denotes_computed_return_value"
+spec = ["4.10:9"]
+source = """
+fn add(x: i32, y: i32) -> i32 { x + y }
+fn main() -> i32 {
+    // The call expression denotes the value produced by the body: 40 + 2.
+    add(40, 2)
+}
+"""
+exit_code = 42

--- a/crates/rue-spec/cases/expressions/evaluation-order.toml
+++ b/crates/rue-spec/cases/expressions/evaluation-order.toml
@@ -383,3 +383,38 @@ fn main() -> i32 {
 }
 """
 exit_code = 14
+
+# =============================================================================
+# Array Literals - Elements evaluated in source order (RUE-298)
+# =============================================================================
+
+[[case]]
+name = "array_literal_source_order_mutable"
+spec = ["4.0:3", "4.0:10"]
+source = """
+fn main() -> i32 {
+    let mut x = 0;
+    // Each element mutates x and reads it back.
+    // Left-to-right: [1, 2, 3]; encode as arr[0]*100 + arr[1]*10 + arr[2].
+    let arr: [i32; 3] = [{ x = x + 1; x }, { x = x + 1; x }, { x = x + 1; x }];
+    arr[0] * 100 + arr[1] * 10 + arr[2]
+}
+"""
+exit_code = 123
+
+[[case]]
+name = "array_literal_source_order_observable"
+spec = ["4.0:3", "4.0:10"]
+source = """
+fn tap(n: i32) -> i32 { @dbg(n); n }
+fn main() -> i32 {
+    let arr: [i32; 3] = [tap(1), tap(2), tap(3)];
+    arr[0] + arr[1] + arr[2]
+}
+"""
+exit_code = 6
+expected_stdout = """
+1
+2
+3
+"""

--- a/crates/rue-spec/cases/expressions/field.toml
+++ b/crates/rue-spec/cases/expressions/field.toml
@@ -94,3 +94,35 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
+
+# =============================================================================
+# Value Denotation (RUE-298)
+# A field access denotes the value currently held in the named field.
+# =============================================================================
+
+[[case]]
+name = "field_denotes_field_value"
+spec = ["4.12:9"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let p = Point { x: 42, y: 10 };
+    // p.x denotes the value held in field x.
+    p.x
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "field_denotes_value_after_store"
+spec = ["4.12:9"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let mut p = Point { x: 0, y: 0 };
+    p.x = 42;
+    // The field access reads back the value currently held.
+    p.x
+}
+"""
+exit_code = 42

--- a/crates/rue-spec/cases/expressions/index.toml
+++ b/crates/rue-spec/cases/expressions/index.toml
@@ -146,3 +146,33 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Value Denotation (RUE-298)
+# An index expression denotes the element stored at the given position.
+# =============================================================================
+
+[[case]]
+name = "index_denotes_element_value"
+spec = ["4.11:14"]
+source = """
+fn main() -> i32 {
+    let arr: [i32; 3] = [10, 42, 100];
+    // arr[1] denotes the element stored at position 1.
+    arr[1]
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "index_denotes_element_after_store"
+spec = ["4.11:14"]
+source = """
+fn main() -> i32 {
+    let mut arr: [i32; 2] = [0, 0];
+    arr[0] = 42;
+    // The index expression reads back the value currently stored.
+    arr[0]
+}
+"""
+exit_code = 42

--- a/crates/rue-spec/cases/statements/assignment.toml
+++ b/crates/rue-spec/cases/statements/assignment.toml
@@ -214,3 +214,39 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
+
+# =============================================================================
+# Evaluation Order (RUE-298)
+# The right-hand side is evaluated before the target place's index.
+# =============================================================================
+
+[[case]]
+name = "assignment_rhs_before_place_index_observable"
+spec = ["5.2:14"]
+source = """
+fn tap(n: i32) -> i32 { @dbg(n); n }
+fn main() -> i32 {
+    let mut arr: [i32; 4] = [0, 0, 0, 0];
+    // RHS (tap(2)) is evaluated before the place index (tap(1)):
+    // prints 2 then 1.
+    arr[tap(1)] = tap(2);
+    arr[1]
+}
+"""
+exit_code = 2
+expected_stdout = """
+2
+1
+"""
+
+[[case]]
+name = "assignment_stores_rhs_value"
+spec = ["5.2:14"]
+source = """
+fn main() -> i32 {
+    let mut arr: [i32; 2] = [0, 0];
+    arr[1] = 42;
+    arr[1]
+}
+"""
+exit_code = 42

--- a/docs/spec/src/04-expressions/10-call-expressions.md
+++ b/docs/spec/src/04-expressions/10-call-expressions.md
@@ -28,6 +28,14 @@ Each argument type **MUST** be compatible with the corresponding parameter type.
 
 The type of a call expression is the function's return type.
 
+{{ rule(id="4.10:9", cat="dynamic-semantics") }}
+
+A call expression evaluates to the value produced by invoking the function:
+the callee's body is executed with each parameter bound to the corresponding
+evaluated argument value, and the call expression denotes the value the
+invocation returns (see section 4.9 for how a function produces its return
+value). When the return type is `()`, the call denotes the unit value.
+
 {{ rule(id="4.10:6") }}
 
 ```rue

--- a/docs/spec/src/04-expressions/11-index-expressions.md
+++ b/docs/spec/src/04-expressions/11-index-expressions.md
@@ -31,6 +31,13 @@ checking (a negative index always fails the bounds check and traps at runtime).
 
 The type of an index expression is the element type `T`.
 
+{{ rule(id="4.11:14", cat="dynamic-semantics") }}
+
+An index expression `base[index]` evaluates to the element stored at position
+`index` of the array denoted by `base` (elements are numbered from zero). The
+base expression is evaluated before the index expression (section 4.0), and the
+resulting index is bounds-checked (see below) before the element is read.
+
 {{ rule(id="4.11:6") }}
 
 ```rue

--- a/docs/spec/src/04-expressions/12-field-access.md
+++ b/docs/spec/src/04-expressions/12-field-access.md
@@ -28,6 +28,13 @@ The identifier **MUST** be a valid field name for that struct type.
 
 The type of a field access expression is the type of the accessed field.
 
+{{ rule(id="4.12:9", cat="dynamic-semantics") }}
+
+A field access expression `base.field` evaluates to the value currently held in
+the named `field` of the struct denoted by `base`. The base expression is
+evaluated first (section 4.0); the result is the value of that field at the
+point the access is evaluated.
+
 {{ rule(id="4.12:6") }}
 
 ```rue

--- a/docs/spec/src/04-expressions/_index.md
+++ b/docs/spec/src/04-expressions/_index.md
@@ -47,3 +47,7 @@ Logical operators `&&` and `||` are an exception to the normal left-to-right eva
 {{ rule(id="4.0:9", cat="normative") }}
 
 For struct literal expressions of the form `Type { field1: expr1, field2: expr2, ... }`, the field initializer expressions are evaluated in source order (left-to-right as written).
+
+{{ rule(id="4.0:10", cat="normative") }}
+
+For array literal expressions of the list form `[e0, e1, ..., en]`, the element expressions are evaluated in source order (left-to-right, `e0` first). For the repeat form `[value; count]`, the `value` expression is evaluated exactly once (see section 7.1).

--- a/docs/spec/src/05-statements/02-assignment.md
+++ b/docs/spec/src/05-statements/02-assignment.md
@@ -24,6 +24,30 @@ mixed. All of `x`, `p.f`, `arr[i]`, `arr[i].f`, `p.arr[i]`, `a.b.c`, and
 `o.items[i].arr[j]` are valid targets. (Appendix A's `place_expr` is the
 normative statement of this production; see that appendix.)
 
+## Evaluation Order
+
+{{ rule(id="5.2:14", cat="dynamic-semantics") }}
+
+In an assignment `target = expression`, the right-hand side `expression` is
+evaluated first to produce the value to be stored. The assignment target names
+a *place*; any index subexpressions appearing in the target (the `[e]` in an
+`arr[e]` target) are evaluated after the right-hand side, in source order
+(left-to-right). Once the place has been resolved, the produced value is
+written into it.
+
+{{ rule(id="5.2:15") }}
+
+```rue
+fn tap(n: i32) -> i32 { @dbg(n); n }
+
+fn main() -> i32 {
+    let mut arr: [i32; 4] = [0, 0, 0, 0];
+    // Prints 2 (the right-hand side) before 1 (the index of the place).
+    arr[tap(1)] = tap(2);
+    arr[1]  // 2
+}
+```
+
 ## Variable Assignment
 
 {{ rule(id="5.2:3", cat="legality-rule") }}

--- a/docs/spec/src/09-unchecked-code/_index.md
+++ b/docs/spec/src/09-unchecked-code/_index.md
@@ -13,3 +13,12 @@ This chapter describes Rue's mechanism for low-level operations that bypass norm
 {{ rule(id="9.0:1") }}
 
 Rue provides `checked` blocks and `unchecked` functions to enable low-level memory operations while keeping such code visibly separate from normal safe code.
+
+{{ rule(id="9.0:2", cat="informative") }}
+
+The operations in this chapter are the **only** source of undefined behavior in
+Rue: raw-pointer and heap intrinsics whose validity the compiler cannot check
+without changing a value's representation (ADR-0036). Appendix B (B.3) catalogues
+the specific conditions that are undefined, and B.1 places them within Rue's
+conformance taxonomy. Outside a `checked` block none of these operations is
+reachable, so the safe subset of Rue has no undefined behavior.

--- a/docs/spec/src/appendices/B-undefined-behavior.md
+++ b/docs/spec/src/appendices/B-undefined-behavior.md
@@ -1,48 +1,116 @@
 +++
-title = "Undefined Behavior and Runtime Panics"
+title = "Conformance, Undefined Behavior, and Runtime Panics"
 weight = 2
 template = "spec/page.html"
 +++
 
-# Appendix B: Undefined Behavior and Runtime Panics
+# Appendix B: Conformance, Undefined Behavior, and Runtime Panics
 
-{{ rule(id="B.1:1") }}
+This appendix is a consolidated reference for how Rue classifies program
+behavior. It restates the conformance taxonomy introduced in §1.3, catalogues
+the concrete conditions Rue **traps** as defined runtime panics, and enumerates
+the narrow set of operations that are genuinely **undefined**. It is normative
+only where a rule carries a normative category (see B.1:5); the catalogues
+themselves are informative summaries whose normative homes are the chapters they
+cross-reference.
 
-Rue currently has no undefined behavior. All operations in Rue have defined semantics: they either complete successfully, fail to compile, or cause a runtime panic.
+## Behavior Classification
 
-{{ rule(id="B.1:2") }}
+{{ rule(id="B.1:1", cat="informative") }}
 
-This is a deliberate design choice. Where other systems languages define certain conditions as undefined behavior (allowing implementations to assume they never occur), Rue instead detects these conditions and responds with a defined runtime panic.
+This specification classifies the behavior of a program into four conformance
+categories — **undefined**, **unspecified**, **implementation-defined**, and
+**erroneous** — following C, C++, and Rust. The categories are introduced in
+§1.3; this appendix collects the concrete instances of each. How a behavior is
+assigned to a category is governed by a design preference (prefer the
+most-defined category; confine undefined behavior to `unchecked` operations that
+cannot be checked otherwise) recorded in ADR-0036, not by a normative rule of
+this document.
 
-{{ rule(id="B.1:3") }}
+{{ rule(id="B.1:2", cat="informative") }}
 
-Future versions of Rue may introduce undefined behavior for specific low-level operations (such as unchecked arithmetic or raw pointer manipulation), but these will be explicitly marked as such and will require opt-in syntax.
+The four behavior categories and the obligations each places on a conforming
+implementation:
+
+| Category | Obligation on the implementation |
+|----------|----------------------------------|
+| **Undefined** | None. A program that exhibits undefined behavior is invalid and the implementation may do anything. In Rue this arises **only within `unchecked` code** (see B.3). |
+| **Unspecified** | Choose from a permitted set of behaviors; no particular choice is required and none need be documented. Rue specifies most such choices (e.g. evaluation order §4.0, drop order §3.9), so this category has few instances today. |
+| **Implementation-defined** | Choose from a permitted set **and document** the choice. Examples: `String` growth/capacity (§3.7), struct and array layout (§3.6), the width of `usize`/`isize` (§3.1), and the limits of Appendix C. |
+| **Erroneous** | Well-defined behavior that is nonetheless a program error a conforming implementation is encouraged to diagnose. Rue currently has **no** erroneous behavior — conditions other languages leave erroneous (e.g. integer overflow) Rue instead *traps* as a defined panic (see B.2). |
+
+{{ rule(id="B.1:3", cat="informative") }}
+
+The distinction between **undefined** and **erroneous** is central to Rue's
+character: an erroneous operation still has a defined result (and is merely
+diagnosable), whereas an undefined operation imposes no requirements at all.
+Rue's memory-safety guarantee is precisely that the safe subset of the language
+has **no undefined behavior**; every hazard reachable outside a `checked` block
+is either rejected at compile time or trapped at runtime (B.2). Undefined
+behavior is confined to the `unchecked` operations catalogued in B.3.
+
+{{ rule(id="B.1:4", cat="informative") }}
+
+Separately from the *behavior* categories above, each normative paragraph in
+this specification carries a **paragraph category** (the `cat=` marker) that
+states what kind of requirement it is. These are defined in §1.3 and summarized
+here:
+
+| Paragraph category | Meaning | Normative? |
+|--------------------|---------|------------|
+| `normative` | A general requirement on a conforming implementation. | Yes |
+| `legality-rule` | A compile-time requirement that must be enforced. | Yes |
+| `syntax` | A grammar rule defining valid program structure. | Yes |
+| `dynamic-semantics` | A runtime-behavior requirement. | Yes |
+| `undefined-behavior` | A condition whose behavior is undefined (imposes no requirement, but identifies the hazard). | Yes |
+| `informative` | Explanatory text. | No |
+| `example` | A code example. | No |
+
+{{ rule(id="B.1:5", cat="informative") }}
+
+The two axes are independent: a paragraph's `cat=` marker classifies the
+*paragraph*, while the four behavior categories classify a *program's
+behavior*. A `dynamic-semantics` paragraph may, for instance, define a trap
+(B.2) or state that an `unchecked` operation is undefined (B.3). Paragraphs
+without an explicit `cat=` marker are informative.
 
 ## Runtime Panics
 
 {{ rule(id="B.2:1") }}
 
-Rue detects certain error conditions at runtime and responds with a panic, terminating the program with a specific exit code.
+Rue detects certain error conditions at runtime and responds with a **trap**: a
+defined runtime panic that terminates the program with a specific exit code.
+These are *defined* behaviors, not undefined behavior — the program's response
+is fully specified. This is the mechanism by which Rue keeps conditions other
+languages leave undefined (overflow, out-of-bounds access, division by zero)
+inside the defined end of the taxonomy (B.1).
 
-## Integer Overflow
+### Integer Overflow
 
 {{ rule(id="B.2:2", cat="dynamic-semantics") }}
 
-Signed or unsigned integer arithmetic that overflows the representable range **MUST** cause a runtime panic.
+Signed or unsigned integer arithmetic that overflows the representable range
+**MUST** cause a runtime panic (§8.1).
 
 **Operations affected:**
 - Addition (`+`)
 - Subtraction (`-`)
 - Multiplication (`*`)
 - Unary negation (`-`)
+- Division (`/`) and remainder (`%`), **exactly** when the dividend is the
+  signed type's minimum value and the divisor is `-1` (the quotient `-MIN` is
+  not representable; the remainder operation overflows in the same case even
+  though its mathematical result would be `0`). This is distinct from division
+  by zero (B.2:3).
 
 **Runtime behavior:** Panic with exit code 101.
 
-## Division by Zero
+### Division by Zero
 
 {{ rule(id="B.2:3", cat="dynamic-semantics") }}
 
-Division or remainder with a divisor of zero **MUST** cause a runtime panic.
+Division or remainder with a divisor of zero **MUST** cause a runtime panic
+(§8.3).
 
 **Operations affected:**
 - Division (`/`)
@@ -50,11 +118,12 @@ Division or remainder with a divisor of zero **MUST** cause a runtime panic.
 
 **Runtime behavior:** Panic with exit code 101.
 
-## Array Bounds Violation
+### Array Bounds Violation
 
 {{ rule(id="B.2:4", cat="dynamic-semantics") }}
 
-Accessing an array element with an index outside the valid range `[0, length)` **MUST** cause a runtime panic.
+Accessing an array element with an index outside the valid range `[0, length)`
+**MUST** cause a runtime panic (§8.2).
 
 **Operations affected:**
 - Array indexing (`arr[i]`)
@@ -62,14 +131,61 @@ Accessing an array element with an index outside the valid range `[0, length)` *
 
 **Runtime behavior:** Panic with exit code 101.
 
-## Exit Codes
+### Exit Codes
 
 | Condition | Exit Code |
 |-----------|-----------|
-| Integer overflow | 101 |
+| Integer overflow (incl. signed `MIN / -1`) | 101 |
 | Division by zero | 101 |
 | Array out of bounds | 101 |
 
 {{ rule(id="B.2:5") }}
 
-All runtime panics produce exit code 101, matching Rust's convention for unwinding panics.
+All runtime panics produce exit code 101, matching Rust's convention for
+unwinding panics.
+
+## Undefined Behavior
+
+{{ rule(id="B.3:1", cat="informative") }}
+
+Rue has undefined behavior **only within `unchecked` code** — the raw-pointer
+and heap intrinsics of Chapter 9, which may appear only inside a `checked` block
+(§9.1). No operation reachable from the safe subset is undefined; safe hazards
+are rejected at compile time or trapped (B.2). The design preference confining
+undefined behavior to `unchecked` operations that cannot be checked without
+changing a value's representation is recorded in ADR-0036.
+
+{{ rule(id="B.3:2", cat="informative") }}
+
+Inside a `checked` block, the following operations have **undefined behavior**.
+The compiler does **not** verify these conditions; the programmer is responsible
+for upholding them (§9, ADR-0028). Each entry cites the normative rule that
+defines it.
+
+| Undefined operation | Normative rule |
+|---------------------|----------------|
+| Reading (`@ptr_read`) or writing (`@ptr_write`) through a pointer that does not address valid, live storage for the pointee type — including a null pointer, a misaligned address, or memory that was never allocated. | §9.1, ADR-0028 |
+| Offsetting a pointer (`@ptr_offset`) outside the bounds of the allocation it addresses (a one-past-the-end pointer may be formed but not dereferenced). | §9.2 (9.2:7) |
+| Using a pointer after the block it addressed has been released with `@free` (use-after-free), or freeing a block that was not returned by `@alloc`/`@realloc`, or freeing one twice. | §9.2 (9.2:11) |
+| Accessing storage through a pointer produced by `@int_to_ptr` from an address that does not name valid, correctly typed, correctly aligned storage. | §9.2, ADR-0028 |
+| Using a pointer obtained from `@raw`/`@raw_mut` after the value it borrowed has been moved, dropped, or otherwise gone out of scope (a dangling pointer). | ADR-0028 |
+| Mutating storage through a `ptr mut T` while another live pointer aliases the same storage in a way the program's reasoning assumes cannot happen (aliasing violation). | ADR-0028 |
+| Accessing storage through a pointer that does not satisfy the pointee type's alignment requirement. | ADR-0028 |
+
+{{ rule(id="B.3:3", cat="informative") }}
+
+These are the memory-safety obligations a `checked` block places on the
+programmer (ADR-0028): do not dereference null or dangling pointers, do not
+create aliasing violations, respect alignment, keep pointed-to memory valid for
+its type, and do not let `@raw`/`@raw_mut` pointers outlive their source. Outside
+`checked` blocks, all of Rue's safety guarantees hold and none of the above is
+reachable.
+
+{{ rule(id="B.3:4", cat="informative") }}
+
+Undefined behavior is not the same as a trap. A trapped condition (B.2) has a
+defined outcome — a panic with exit code 101 — and can be relied upon; an
+undefined operation imposes no requirements and may produce any result,
+including silent corruption. This is why Rue traps every hazard it can check
+cheaply and reserves undefined behavior for the `unchecked` operations where a
+check would require changing a value's representation (ADR-0036).


### PR DESCRIPTION
Two RUE-201 audit fixes (docs only):
- **RUE-297**: rewrote Appendix B around the ADR-0036 conformance taxonomy — removed the false 'no UB' claim, added the four behavior categories + the real UB surface (OOB raw ptr ops, use-after-free, @int_to_ptr, etc.) + signed MIN/-1 overflow + ch9 cross-ref.
- **RUE-298**: value-denotation rules (4.10:9 call / 4.11:14 index / 4.12:9 field) + normative evaluation order (array elements source-order; assignment RHS-first-then-place-index), each verified by running side-effecting @dbg programs; 10 spec cases.

(RUE-308 re-runs on fresh trunk — its §5.7 collided with the merged RUE-306.) clippy clean; test.sh Pass 24, 100% traceability (667/667).

Fixes RUE-297
Fixes RUE-298

Generated with Claude Code