### PR TITLE
ADR-0043 Phase 1: slice second-class escape enforcement (part of RUE-322)

### DIFF
--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2255,6 +2255,11 @@ impl<'a> Sema<'a> {
         // bindings at every level of a composite annotation — a scalar `P`, and
         // an inner element/pointee of `[P; 2]` / `ptr const P` alike (RUE-263).
         let annotation_type = if let Some(ty_sym) = ty {
+            // A slice type `[T]` is second-class (ADR-0037, ADR-0043, RUE-322):
+            // it may only name a function parameter, never a `let` local, so a
+            // `let s: [i32] = ...` binding would let the view escape its
+            // argument scope (E0489).
+            self.reject_slice_escape(ty_sym, span, ErrorKind::SliceEscapesScope)?;
             Some(self.resolve_type_with_ctx(ty_sym, span, ctx)?)
         } else {
             None

--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -499,6 +499,10 @@ impl<'a> Sema<'a> {
                     let ty_sym = Spur::try_from_usize(words[i] as usize)
                         .expect("valid interned type symbol in payload region");
                     i += 1;
+                    // A slice type `[T]` is second-class (ADR-0037, ADR-0043,
+                    // RUE-322): an enum payload is aggregate storage, so it
+                    // cannot hold a fat-pointer view (E0488).
+                    self.reject_slice_escape(ty_sym, span, ErrorKind::SliceInAggregateField)?;
                     let ty = self.resolve_type(ty_sym, span)?;
                     // A payload of type `type` cannot exist at runtime
                     // (spec 4.14:6); reject it like struct fields do.
@@ -627,6 +631,14 @@ impl<'a> Sema<'a> {
                 // Resolve field types
                 let mut resolved_fields = Vec::new();
                 for (field_name, field_type) in &fields {
+                    // A slice type `[T]` is second-class (ADR-0037, ADR-0043,
+                    // RUE-322): storing it in a struct field would let the
+                    // fat-pointer view escape its borrow's scope (E0488).
+                    self.reject_slice_escape(
+                        *field_type,
+                        inst.span,
+                        ErrorKind::SliceInAggregateField,
+                    )?;
                     let field_ty = self.resolve_type(*field_type, inst.span)?;
                     // spec 4.14:6 — type values cannot exist at runtime. A
                     // struct field of type `type` is a runtime storage slot for
@@ -1151,6 +1163,10 @@ impl<'a> Sema<'a> {
             // RUE-16) - use placeholder, resolved at specialization.
             Type::COMPTIME_TYPE
         } else {
+            // A slice type `[T]` is second-class (ADR-0037, ADR-0043,
+            // RUE-322): it is a fat-pointer view valid only in argument
+            // position and may not be returned (E0487).
+            self.reject_slice_escape(return_type_sym, span, ErrorKind::SliceReturnNotAllowed)?;
             self.resolve_type(return_type_sym, span)?
         };
 
@@ -2204,6 +2220,10 @@ impl<'a> Sema<'a> {
         };
         // The annotation resolves like any signature type (unknown names are
         // E0204) and the value is validated against it.
+        // A slice type `[T]` is second-class (ADR-0037, ADR-0043, RUE-322): a
+        // `const` is a top-level binding, never an argument, so it cannot name
+        // a slice (E0489).
+        self.reject_slice_escape(ty_sym, span, ErrorKind::SliceEscapesScope)?;
         let declared = self.resolve_type(ty_sym, span)?;
 
         // An integer value adopts any integer annotation it fits in.

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -189,6 +189,35 @@ impl<'a> Sema<'a> {
         }
     }
 
+    /// Is `type_sym` the syntax of a slice type `[T]` (as opposed to a fixed
+    /// array `[T; N]`)? Slices are second-class (ADR-0037, ADR-0043, RUE-322):
+    /// callers use this to reject a slice type in a non-argument position
+    /// (return / struct field / `let` / `const`) with a targeted diagnostic
+    /// before the generic `resolve_type` path would report it.
+    pub(crate) fn is_slice_type_syntax(&self, type_sym: Spur) -> bool {
+        let name = self.interner.resolve(&type_sym);
+        name.starts_with('[') && name.ends_with(']') && parse_array_type_syntax(name).is_none()
+    }
+
+    /// Reject a slice type appearing outside argument position. When `type_sym`
+    /// is slice syntax and `--preview slices` is enabled, this returns the
+    /// second-class-escape error `kind` (E0487/E0488/E0489); otherwise it
+    /// returns `Ok(())` and the caller proceeds. The preview gate is checked
+    /// first so that, without the flag, the user still sees the uniform
+    /// "requires preview feature" message rather than a bespoke slice error.
+    pub(crate) fn reject_slice_escape(
+        &self,
+        type_sym: Spur,
+        span: Span,
+        kind: ErrorKind,
+    ) -> CompileResult<()> {
+        if self.is_slice_type_syntax(type_sym) {
+            self.require_preview(PreviewFeature::Slices, "the slice type `[T]`", span)?;
+            return Err(CompileError::new(kind, span));
+        }
+        Ok(())
+    }
+
     pub(crate) fn resolve_type(&mut self, type_sym: Spur, span: Span) -> CompileResult<Type> {
         let type_name = self.interner.resolve(&type_sym);
 

--- a/crates/rue-cli-tests/cases/slice_second_class.toml
+++ b/crates/rue-cli-tests/cases/slice_second_class.toml
@@ -1,0 +1,76 @@
+# Second-class slice enforcement through the real driver (ADR-0043 Phase 1,
+# RUE-322). A slice `[T]` is a second-class fat-pointer view (ADR-0037): valid
+# only in argument position. These cases drive the real `rue` binary with
+# `--preview slices` on real files and pin the escape-family diagnostics
+# (E0487 return / E0488 aggregate field / E0489 let-or-const) plus the E0486
+# "runtime not yet implemented" gate for the one legal position (a parameter).
+#
+# The fat-pointer runtime (ABI + slice index/len codegen on both backends) is a
+# follow-up sub-phase; until it lands, a slice *parameter* compiles no further
+# than E0486, so there is no runtime behaviour (trap exit code, sums) to pin
+# here yet.
+
+[section]
+id = "cli.slice_second_class"
+name = "Slice second-class enforcement (ADR-0043 Phase 1)"
+description = "A second-class slice `[T]` may only name a function parameter; every escaping position is a clean compile error (RUE-322)."
+
+# Return position: a slice cannot be returned (E0487).
+[[case]]
+name = "slice_return_rejected_e0487"
+description = "fn -> [i32] is E0487: a slice cannot be returned."
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn f() -> [i32] { 0 }
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0487", "cannot be returned"]
+
+# Struct field: a slice cannot be stored in an aggregate (E0488).
+[[case]]
+name = "slice_struct_field_rejected_e0488"
+description = "A struct field of slice type is E0488."
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct Holder { s: [i32] }
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0488", "cannot be stored in a struct field"]
+
+# let binding: a slice cannot be bound past its argument scope (E0489).
+[[case]]
+name = "slice_let_rejected_e0489"
+description = "A `let s: [i32]` local is E0489."
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { let s: [i32] = 0; 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0489", "can only name a function parameter"]
+
+# Argument position (the one legal spot): resolves, but the runtime is not yet
+# implemented, so it stops at E0486 rather than reaching an unfinished codegen
+# path or ICE-ing.
+[[case]]
+name = "slice_param_runtime_not_yet_implemented_e0486"
+description = "A slice parameter is the one legal position; it reports E0486 until the fat-pointer runtime lands."
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn sum(borrow s: [i32]) -> i32 { 0 }
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E0486", "not yet fully implemented"]
+
+# Without the preview flag, the same parameter is gated at E1100.
+[[case]]
+name = "slice_requires_preview_e1100"
+description = "Without --preview slices, a slice parameter is E1100."
+files = [{ path = "main.rue", source = """
+fn sum(borrow s: [i32]) -> i32 { 0 }
+fn main() -> i32 { 0 }
+""" }]
+compile_fail = true
+error_contains = ["E1100", "requires preview feature"]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -193,11 +193,25 @@ impl ErrorCode {
     /// fails cleanly instead of reaching an unfinished codegen path.
     ///
     /// Note: the second-class-escape diagnostics named in the RUE-322 brief
-    /// (return / store-in-field / bind-past-scope) will be allocated when the
-    /// slice type itself lands; the brief's suggested E0435-E0437 numbers were
-    /// already taken (`RESERVED_FUNCTION_NAME` / `DUPLICATE_FUNCTION_DEFINITION`
-    /// / `MOVE_OUT_OF_INOUT`), so a fresh free range will be used then.
+    /// (return / store-in-field / bind-past-scope) are allocated below
+    /// (E0487-E0489); the brief's suggested E0435-E0437 numbers were already
+    /// taken (`RESERVED_FUNCTION_NAME` / `DUPLICATE_FUNCTION_DEFINITION` /
+    /// `MOVE_OUT_OF_INOUT`).
     pub const SLICE_NOT_YET_IMPLEMENTED: Self = Self(486);
+    /// A slice type `[T]` was written in return position (`fn f(...) -> [T]`).
+    /// A slice is a *second-class* fat-pointer view (ADR-0037, ADR-0043,
+    /// RUE-322): it is valid only in argument position and may not be
+    /// returned, since the view would outlive the borrow it aliases.
+    pub const SLICE_RETURN_NOT_ALLOWED: Self = Self(487);
+    /// A slice type `[T]` was written as a struct field type. A slice is
+    /// second-class (ADR-0037, ADR-0043, RUE-322) and cannot be stored in an
+    /// aggregate — storing it would let the view escape its borrow's scope.
+    pub const SLICE_IN_AGGREGATE_FIELD: Self = Self(488);
+    /// A slice type `[T]` was written in a binding position other than a
+    /// parameter — a `let` local or a `const`. A slice is second-class
+    /// (ADR-0037, ADR-0043, RUE-322): it may only name a function parameter,
+    /// so it cannot be bound past its argument scope.
+    pub const SLICE_ESCAPES_SCOPE: Self = Self(489);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -1294,6 +1308,30 @@ pub enum ErrorKind {
     #[error("slice types are not yet fully implemented (ADR-0043 Phase 1, RUE-322)")]
     SliceNotYetImplemented,
 
+    /// A slice type `[T]` appeared in return position — forbidden because a
+    /// slice is second-class (ADR-0037, ADR-0043, RUE-322).
+    #[error(
+        "a slice type `[T]` cannot be returned: slices are second-class views \
+         valid only in argument position (ADR-0043)"
+    )]
+    SliceReturnNotAllowed,
+
+    /// A slice type `[T]` appeared as a struct field type — forbidden because
+    /// a slice is second-class (ADR-0037, ADR-0043, RUE-322).
+    #[error(
+        "a slice type `[T]` cannot be stored in a struct field: slices are \
+         second-class views valid only in argument position (ADR-0043)"
+    )]
+    SliceInAggregateField,
+
+    /// A slice type `[T]` appeared in a `let` or `const` binding — forbidden
+    /// because a slice is second-class (ADR-0037, ADR-0043, RUE-322).
+    #[error(
+        "a slice type `[T]` can only name a function parameter: slices are \
+         second-class views and cannot be bound past their argument scope (ADR-0043)"
+    )]
+    SliceEscapesScope,
+
     // Comptime errors
     #[error("comptime evaluation failed: {reason}")]
     ComptimeEvaluationFailed { reason: String },
@@ -1452,6 +1490,9 @@ impl ErrorKind {
             // Preview feature errors (E1100-E1199)
             ErrorKind::PreviewFeatureRequired { .. } => ErrorCode::PREVIEW_FEATURE_REQUIRED,
             ErrorKind::SliceNotYetImplemented => ErrorCode::SLICE_NOT_YET_IMPLEMENTED,
+            ErrorKind::SliceReturnNotAllowed => ErrorCode::SLICE_RETURN_NOT_ALLOWED,
+            ErrorKind::SliceInAggregateField => ErrorCode::SLICE_IN_AGGREGATE_FIELD,
+            ErrorKind::SliceEscapesScope => ErrorCode::SLICE_ESCAPES_SCOPE,
 
             // Comptime errors (E1200-E1299)
             ErrorKind::ComptimeEvaluationFailed { .. } => ErrorCode::COMPTIME_EVALUATION_FAILED,
@@ -2282,6 +2323,28 @@ mod tests {
         assert_eq!(feature.name(), "slices");
         assert_eq!(feature.adr(), "ADR-0043");
         assert!(PreviewFeature::all().contains(&PreviewFeature::Slices));
+    }
+
+    #[test]
+    fn test_slice_second_class_escape_codes() {
+        // ADR-0043 Phase 1 (RUE-322): the second-class-escape diagnostics for
+        // a slice type used outside argument position.
+        assert_eq!(
+            ErrorKind::SliceReturnNotAllowed.code(),
+            ErrorCode::SLICE_RETURN_NOT_ALLOWED
+        );
+        assert_eq!(
+            ErrorKind::SliceInAggregateField.code(),
+            ErrorCode::SLICE_IN_AGGREGATE_FIELD
+        );
+        assert_eq!(
+            ErrorKind::SliceEscapesScope.code(),
+            ErrorCode::SLICE_ESCAPES_SCOPE
+        );
+        // Codes are contiguous with the not-yet-implemented gate (E0486).
+        assert_eq!(ErrorCode::SLICE_RETURN_NOT_ALLOWED.0, 487);
+        assert_eq!(ErrorCode::SLICE_IN_AGGREGATE_FIELD.0, 488);
+        assert_eq!(ErrorCode::SLICE_ESCAPES_SCOPE.0, 489);
     }
 
     #[test]

--- a/crates/rue-ui-tests/cases/diagnostics/slice_preview_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/slice_preview_gate.toml
@@ -5,10 +5,17 @@ description = """
 The second-class slice type `[T]` (ADR-0043, RUE-322) is gated behind
 `--preview slices`. Without the flag, using slice syntax reports E1100
 (preview feature required). With the flag, the syntax is accepted by the
-parser and type resolver but reports E0486 because the fat-pointer runtime
-(ABI + codegen on both backends) is not yet implemented. These UI cases pin
-that gating behaviour; they become regression tests for the follow-up phase
-that lands the runtime.
+parser and type resolver.
+
+A slice is a second-class fat-pointer view (ADR-0037): it is valid only in
+argument position and may not escape. These cases pin the second-class
+enforcement — return position is E0487, a struct field / enum payload is
+E0488, and a `let` / `const` binding is E0489 — which fire *before* the
+runtime is consulted. In argument position (the one legal spot) the slice
+type is accepted by resolution but reports E0486, because the fat-pointer
+runtime (ABI + codegen on both backends) is not yet implemented. These UI
+cases pin the gating + enforcement behaviour; the E0486 case becomes a
+regression test for the follow-up phase that lands the runtime.
 """
 
 [[case]]
@@ -32,7 +39,7 @@ error_contains = "requires preview feature"
 
 [[case]]
 name = "slice_param_under_preview_not_yet_implemented"
-description = "Under --preview slices, slice syntax parses but reports E0486 (runtime unimplemented)."
+description = "Under --preview slices, a slice parameter (the one legal position) parses but reports E0486 (runtime unimplemented)."
 preview = "slices"
 source = """
 fn sum(borrow s: [i32]) -> i32 { 0 }
@@ -40,3 +47,57 @@ fn main() -> i32 { 0 }
 """
 compile_fail = true
 error_contains = "not yet fully implemented"
+
+[[case]]
+name = "slice_return_is_second_class_e0487"
+description = "A slice in return position is second-class: E0487 (cannot be returned)."
+preview = "slices"
+source = """
+fn f() -> [i32] { 0 }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0487", "cannot be returned"]
+
+[[case]]
+name = "slice_struct_field_is_second_class_e0488"
+description = "A slice as a struct field is second-class: E0488 (cannot be stored in a struct field)."
+preview = "slices"
+source = """
+struct Holder { s: [i32] }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0488", "cannot be stored in a struct field"]
+
+[[case]]
+name = "slice_enum_payload_is_second_class_e0488"
+description = "A slice as an enum variant payload is aggregate storage: E0488."
+preview = "slices"
+source = """
+enum Maybe { None, Some([i32]) }
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0488", "cannot be stored in a struct field"]
+
+[[case]]
+name = "slice_let_binding_is_second_class_e0489"
+description = "A slice in a `let` annotation is second-class: E0489 (can only name a function parameter)."
+preview = "slices"
+source = """
+fn main() -> i32 { let s: [i32] = 0; 0 }
+"""
+compile_fail = true
+error_contains = ["E0489", "can only name a function parameter"]
+
+[[case]]
+name = "slice_const_binding_is_second_class_e0489"
+description = "A slice in a `const` annotation is second-class: E0489."
+preview = "slices"
+source = """
+const S: [i32] = 0;
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["E0489", "can only name a function parameter"]


### PR DESCRIPTION
Makes the E0487/E0488/E0489 escape errors real: a slice `[T]` is rejected in return (E0487), struct field/enum payload (E0488), and let/const binding (E0489); a slice param still hits the E0486 runtime gate. No codegen; arrays unaffected. Verified 6 positions by execution; clippy clean, Pass 24. Runtime is the follow-up. Part of RUE-322