### PR TITLE
Formal core §5.8, generics spec, + slice acceptance-criteria xfails

### DIFF
--- a/crates/rue-cli-tests/cases/slices_mvp.toml
+++ b/crates/rue-cli-tests/cases/slices_mvp.toml
@@ -1,0 +1,63 @@
+# ADR-0043 Phase 1 slice runtime — executable acceptance tests (RUE-322).
+#
+# The slice front-end (parser + `--preview slices` gate + E0486 stub) and the
+# second-class escape enforcement (E0487-E0489) have landed, but the RUNTIME —
+# the {ptr, len} fat-pointer ABI, `borrow arr` -> slice materialization, slice
+# `.len()`, and bounds-checked read-indexing `s[i]` on BOTH backends — is not
+# yet implemented, so `borrow s: [T]` in argument position still reports E0486
+# ("slice types are not yet fully implemented").
+#
+# These cases pin the exact end-to-end behavior the MVP runtime must produce.
+# They are `known_bug = "RUE-322"` xfails today (the compile fails cleanly with
+# E0486); when the fat-pointer runtime lands, drop the `known_bug` markers and
+# they become the runtime's regression tests. See the ABI analysis in the
+# RUE-322 worklog: the blockers are (1) `borrow` currently passes a single
+# pointer, not a 2-word aggregate; (2) `emit_bounds_check` takes a compile-time
+# constant length, but a slice length is runtime; (3) array indexing lowers via
+# `Place` projections tied to a compile-time `array_type`, whereas a slice index
+# is a raw-pointer load off the fat pointer's `ptr` word.
+
+[section]
+id = "cli.slices"
+name = "Slice runtime (ADR-0043 Phase 1)"
+description = "borrow-a-whole-array slice parameter: len() and bounds-checked read-indexing."
+
+# The canonical verify-by-execution case from RUE-322: sum a borrowed array
+# through a `borrow s: [i32]` slice parameter using `s.len()` and `s[i]`.
+[[case]]
+name = "slice_param_sum_len_index"
+known_bug = "RUE-322"
+files = [{ path = "main.rue", source = """
+fn sum(borrow s: [i32]) -> i32 {
+    let mut t = 0;
+    let mut i: u64 = 0;
+    while i < s.len() {
+        t = t + s[i];
+        i = i + 1;
+    }
+    t
+}
+fn main() -> i32 {
+    let a: [i32; 3] = [10, 20, 30];
+    sum(borrow a)
+}
+""" }]
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+exit_code = 60
+
+# Out-of-bounds read-index through a slice parameter must trap at runtime with
+# the same abort discipline as array indexing (`__rue_bounds_check`, exit 101).
+[[case]]
+name = "slice_param_index_out_of_bounds_traps"
+known_bug = "RUE-322"
+files = [{ path = "main.rue", source = """
+fn get(borrow s: [i32], i: u64) -> i32 {
+    s[i]
+}
+fn main() -> i32 {
+    let a: [i32; 3] = [10, 20, 30];
+    get(borrow a, 5)
+}
+""" }]
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+exit_code = 101

--- a/crates/rue-spec/cases/expressions/comptime.toml
+++ b/crates/rue-spec/cases/expressions/comptime.toml
@@ -1928,3 +1928,163 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Generic Types / Type-Function Application (RUE-289)
+# =============================================================================
+# The generics mechanism: a `-> type` function is a type constructor; applying
+# it (F(i32)) reduces to a concrete type in both value and type position;
+# instantiation identity is structural; comptime params scope into method
+# bodies and nest into other constructors.
+
+[[case]]
+name = "type_constructor_value_position"
+spec = ["4.14:22"]
+description = "Type-function application in value position: bind the reduced type and use its variants (RUE-289)"
+source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn main() -> i32 {
+    let O = Option(i32);
+    let x: O = O::Some(42);
+    match x { O::Some(n) => n, O::None => 0 }
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "type_constructor_in_annotation_position"
+spec = ["4.14:23"]
+description = "F(i32) used directly as a let type annotation (RUE-289, RUE-241)"
+source = """
+fn Pair(comptime T: type) -> type { struct { first: T, second: T } }
+fn main() -> i32 {
+    let P = Pair(i32);
+    let p: Pair(i32) = P { first: 40, second: 2 };
+    p.first + p.second
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "type_constructor_in_return_and_param_position"
+spec = ["4.14:23"]
+description = "F(i32) used directly as a return type and a parameter type (RUE-289, RUE-241)"
+source = """
+fn Pair(comptime T: type) -> type { struct { first: T, second: T } }
+fn mk() -> Pair(i32) {
+    let P = Pair(i32);
+    P { first: 40, second: 2 }
+}
+fn sum(p: Pair(i32)) -> i32 { p.first + p.second }
+fn main() -> i32 { sum(mk()) }
+"""
+exit_code = 42
+
+[[case]]
+name = "type_constructor_in_field_and_array_position"
+spec = ["4.14:23"]
+description = "F(i32) used directly as a struct field type and an array element type (RUE-289)"
+source = """
+fn Pair(comptime T: type) -> type { struct { first: T, second: T } }
+fn Wrapper() -> type { struct { inner: Pair(i32) } }
+fn main() -> i32 {
+    let P = Pair(i32);
+    let W = Wrapper();
+    let w: W = W { inner: P { first: 30, second: 10 } };
+    let arr: [Pair(i32); 2] = [P { first: 1, second: 1 }, P { first: 1, second: 1 }];
+    w.inner.first + w.inner.second + arr[0].first + arr[1].second
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "type_constructor_call_not_a_struct_literal_path"
+spec = ["4.14:23"]
+description = "A type-constructor call is not a struct-literal path: F(args) { ... } does not parse; bind an alias first (RUE-289)"
+source = """
+fn Pair(comptime T: type) -> type { struct { first: T, second: T } }
+fn main() -> i32 {
+    let p = Pair(i32) { first: 1, second: 2 };
+    p.first
+}
+"""
+compile_fail = true
+error_contains = "found '{'"
+
+[[case]]
+name = "type_param_scopes_into_method_body"
+spec = ["4.14:24"]
+description = "The enclosing type parameter T names types in a method body and nests into another constructor Option(T) (RUE-289, RUE-313)"
+source = """
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+fn Wrap(comptime T: type) -> type {
+    struct {
+        inner: Option(T),
+        fn get_or(self, d: T) -> T {
+            let O = Option(T);
+            match self.inner { O::Some(v) => v, O::None => d }
+        }
+    }
+}
+fn main() -> i32 {
+    let W = Wrap(i32);
+    let O = Option(i32);
+    let w: W = W { inner: O::Some(42) };
+    w.get_or(0)
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "type_param_names_local_type_in_method"
+spec = ["4.14:24"]
+description = "The enclosing type parameter T is usable as a local let annotation inside a method body (RUE-289, RUE-313)"
+source = """
+fn Cell(comptime T: type) -> type {
+    struct {
+        v: T,
+        fn doubled(self) -> T {
+            let x: T = self.v;
+            x + x
+        }
+    }
+}
+fn main() -> i32 {
+    let C = Cell(i32);
+    let c: C = C { v: 21 };
+    c.doubled()
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "instantiation_identity_is_structural_across_functions"
+spec = ["4.14:25"]
+description = "F(i32) in two separate functions denotes the same type (structural identity) (RUE-289)"
+source = """
+fn Pair(comptime T: type) -> type { struct { first: T, second: T } }
+fn produce() -> Pair(i32) {
+    let P = Pair(i32);
+    P { first: 40, second: 2 }
+}
+fn consume(p: Pair(i32)) -> i32 { p.first + p.second }
+fn main() -> i32 { consume(produce()) }
+"""
+exit_code = 42
+
+[[case]]
+name = "instantiation_distinct_arguments_are_distinct_types"
+spec = ["4.14:25"]
+description = "F(i32) and F(i64) are distinct, non-assignable types (RUE-289)"
+source = """
+fn Pair(comptime T: type) -> type { struct { first: T, second: T } }
+fn main() -> i32 {
+    let A = Pair(i32);
+    let B = Pair(i64);
+    let a: A = A { first: 1, second: 2 };
+    let b: B = a;
+    0
+}
+"""
+compile_fail = true
+error_contains = "type mismatch"

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -58,7 +58,7 @@ Expressions
       | if e0 { e1 } else { e2 }
       | match e0 { pat1 => e1, ..., patk => ek }
       | let x = e1 ; e2        -- binding; scope of x is e2
-      | e1 ; e2                -- sequence; e1's value is DISCARDED (must be unit or a leak error)
+      | e1 ; e2                -- sequence; e1's value is DISCARDED (well-formed unless it carries a linear value — §5.3, 3.8:64)
       | loop { e }             -- infinite loop; exited only by break
       | break                  -- exit the nearest enclosing loop, value unit
       | return e               -- exit the enclosing function with e's value
@@ -509,6 +509,134 @@ and since the `else` arm's outgoing state is `⊥` the branch join is just the
 function's `i32` return type). This is the **only** coercion in the language:
 every other typing rule demands exact type identity.
 
+### 5.8 Leaf, operator, aggregate, and call forms
+
+§5.5 gave the rules for the branching and enum forms (`if`/`match`, enum
+intro/elim) and §5.7 the diverging forms (`return`/`break`/`loop`). This
+subsection completes the statics with the remaining **non-diverging** expression
+forms of §2 — literals, primitive arithmetic/bitwise, equality compare, struct
+and array construction, and calls — closing the "thin statics" gap (RUE-308).
+None of these adds ownership machinery beyond the *use* discipline of §4.2 and
+the loan discipline of §5.4; they are collected here so §5 covers every §2
+expression form, not because they introduce anything new. Each threads the
+ownership state Σ left-to-right through its subexpressions (evaluation order
+`4.0`). The diverging forms are **not** restated here (they live in §5.7), and
+`match`/enum construction are **not** restated here (they live in §5.5).
+
+**Literals.** A literal denotes a fresh `Copy` value of its own type and reads no
+place, so Σ is unchanged.
+
+```
+  lit is an integer / bool / unit literal of type T       -- T ∈ { int(w,s), bool, unit }
+  ─────────────────────────────────────────────────────── (Lit)
+  Γ;Σ;Λ ⊢ lit ⇒ T ⊣ Σ
+```
+
+An integer literal's width and signedness are fixed *before* the core: elaboration
+has already resolved the surface "an integer literal defaults to `i32` unless the
+context requires another type" (`4.1:3`) into a concrete `int(w, s)`, so the core
+sees only the resolved type (`4.1:2` for integers, `4.1:5` for `true`/`false`,
+`4.1:7` for `()`).
+
+**Primitive arithmetic / bitwise `⊕`.** Both operands share one integer type and
+the result has that same type; the operands are `Copy` scalars, so each is an
+ordinary value-context use that *copies* (§4.2) and the only effect on Σ is
+whatever uses the operand subexpressions themselves perform.
+
+```
+  Γ;Σ;Λ ⊢ e1 ⇒ int(w,s) ⊣ Σ1     Γ;Σ1;Λ ⊢ e2 ⇒ int(w,s) ⊣ Σ2     ⊕ ∈ { +,-,*,/,%, &,|,^,<<,>> }
+  ─────────────────────────────────────────────────────────────────────────────────────── (Arith)
+  Γ;Σ;Λ ⊢ e1 ⊕ e2 ⇒ int(w,s) ⊣ Σ2
+```
+
+The same-type/same-result-type shape is `4.2:1`. Overflow, division-by-zero, and
+remainder-by-zero are *dynamic* panics (§6), not typing errors. (Equality `≟` is
+a separate rule below because, unlike `⊕`, it *borrows* rather than copies its
+operands.)
+
+**Equality compare `≟`.** Comparison of two values of the same type yields `bool`.
+Unlike `⊕`, a place appearing **directly** as an operand is read through a
+call-scoped *shared loan* and is **not** moved, even when its type is `Affine` or
+`Linear` — this side condition overrides the default (Use-Move) of §4.2 for the
+operand position, exactly the equality-compare loan of §5.4 (`4.3:3f`).
+
+```
+  Γ;Σ;Λ ⊢ e1 ⇒ T ⊣ Σ1     Γ;Σ1;Λ ⊢ e2 ⇒ T ⊣ Σ2     ≟ ∈ { ==, != }
+  a place operand p is read through a (root(p), shared) loan and is NOT moved  (§4.1, §5.4, 4.3:3f)
+  ─────────────────────────────────────────────────────────────────────── (Eq)
+  Γ;Σ;Λ ⊢ e1 ≟ e2 ⇒ bool ⊣ Σ2
+```
+
+The result is always `bool` (`4.3:1`); equality is defined for scalars, `unit`,
+strings, and the aggregate types — structs, arrays, enums (`4.3:2`) — and
+recurses structurally without ever consuming an operand. Because a place operand
+leaves Σ untouched, its move obligation is undischarged: `let c = a; a ≟ b` is
+well-formed, and two shared reads are always consistent, so `a == a` is too
+(§5.4). Σ2 reflects only the uses performed *inside* compound operand
+subexpressions (e.g. `f() == g()`), never a move of a directly-named operand
+place.
+
+**Struct construction.** Each field initializer is a value-context use of the
+declared field type — a move for a non-`Copy` field, a copy for a `Copy` one
+(§4.2) — and the result owns every field.
+
+```
+  S = struct { f1: T1, ..., fk: Tk }        all k fields supplied, each exactly once  (3.6:5, 3.6:6, 3.6:15)
+  Γ;Σ;Λ ⊢ e1 ⇒ T1 ⊣ Σ1     Γ;Σ1;Λ ⊢ e2 ⇒ T2 ⊣ Σ2     ...     Γ;Σ_{k-1};Λ ⊢ ek ⇒ Tk ⊣ Σk
+  ─────────────────────────────────────────────────────────────────────────────── (Struct-Intro)
+  Γ;Σ;Λ ⊢ S { f1: e1, ..., fk: ek } ⇒ S ⊣ Σk
+```
+
+Initializers are typed in the order written and Σ is threaded through them,
+matching the source-order evaluation of `3.6:16`/`4.0:9` even though the stored
+value places each field in its *declaration* slot (`3.6:9`). A well-formed
+literal supplies every field exactly once (`3.6:5`, `3.6:6`); a surface literal
+written field-out-of-order (`3.6:15`) is presented here in declaration order by
+elaboration without loss of generality. The result owns all fields, so
+`class(S)` is the field join of §3.
+
+**Array construction.** All `n` elements share one element type `T`, and the
+result has type `[T; n]`.
+
+```
+  Γ;Σ;Λ ⊢ e1 ⇒ T ⊣ Σ1     Γ;Σ1;Λ ⊢ e2 ⇒ T ⊣ Σ2     ...     Γ;Σ_{n-1};Λ ⊢ en ⇒ T ⊣ Σn      n ≥ 0
+  ─────────────────────────────────────────────────────────────────────────────── (Array-Intro)
+  Γ;Σ;Λ ⊢ [ e1, ..., en ] ⇒ [T; n] ⊣ Σn
+```
+
+Every element is a value-context use of `T` (`3.5:2` — one shared element type),
+typed left-to-right with Σ threaded, and the array owns all `n` elements;
+`class([T; n])` is given by §3 (`3.5:1` for the type form). The empty array `[]`
+(`n = 0`) is the `Copy`, zero-sized `[T; 0]` and uses nothing.
+
+**Call.** A call's type is the callee's return type; its arguments are checked
+against the parameter list, each in its call-site mode. By-value arguments are
+value-context uses that thread Σ; by-reference arguments take a call-scoped loan
+and leave Σ unchanged, per §5.4.
+
+```
+  g : fn ( m1 x1:T1, ..., mm xm:Tm ) -> Tr        -- the (monomorphic) signature of g
+  the m argument forms a1..am match the m parameters in count and mode  (4.10:3)
+  for each i, threading Σ left-to-right (Σ0 = Σ):
+      a_i = e          (mi = ∅):       Γ;Σ_{i-1};Λ ⊢ e ⇒ Ti ⊣ Σi                          -- by value: value-context use, §4.2
+      a_i = borrow p   (mi = borrow):  Σ_{i-1}(p)=Owned;            Σi = Σ_{i-1};  add (root(p), shared)    to Λ_call   -- §5.4
+      a_i = inout p    (mi = inout):   Σ_{i-1}(p)=Owned, p mutable; Σi = Σ_{i-1};  add (root(p), exclusive) to Λ_call   -- §5.4
+  Λ_call is CONSISTENT  (law of exclusivity, §5.4)
+  ─────────────────────────────────────────────────────────────────────────────── (Call)
+  Γ;Σ;Λ ⊢ g ( a1, ..., am ) ⇒ Tr ⊣ Σm
+```
+
+The result type is the callee's return type `Tr` (`4.10:5`); the argument count
+must match the parameter count (`4.10:3`) and each argument's type its parameter
+(`4.10:4`). A by-value argument moves a non-`Copy` value into the parameter and
+copies a `Copy` one (§4.2), recording that in Σ; a `borrow`/`inout` argument
+leaves Σ unchanged and instead contributes a loan to `Λ_call`, which must satisfy
+the law of exclusivity (§5.4). The loans are second-class — released when the
+call returns — so the outgoing Σm carries only the moves performed by the
+by-value arguments. Because the core is fully monomorphic (§1), `g` names a
+single concrete signature: there is no overload or generic instantiation to
+resolve at the call.
+
 ---
 
 ## 6. Dynamic semantics (small-step) *(sketch — shape fixed, rules being filled in)*
@@ -637,6 +765,7 @@ far. As breadth is filled in, each new rule adds its citation.
 | §4.2 definition of *use* | 3.8:5, 3.8:7, 3.8:9, 3.8:11, 3.8:22, 3.8:33, 3.8:53 |
 | §4.1/§5.4 equality borrows its operands | 4.3:3f |
 | §5.5 match / enum elim + intro | 6.3:17, 3.8:33 (destructure), 4.7 (match) |
+| §5.8 leaf/operator/aggregate/call statics | 4.1:2/5/7, 4.2:1, 4.3:1/2, 3.6:5/6/15/16, 3.5:1/2, 4.10:3/4/5/7 |
 | §5.6 enum drop (active payload) | 6.3:20 |
 | §4.3 expression/return value | 4.5:3 (→ value, not just type), 6.1:4/5, 4.9:1/7 |
 | §5.2 assignment / reinit | 3.8:55/56, 3.8:72 |

--- a/docs/formal/README.md
+++ b/docs/formal/README.md
@@ -158,8 +158,10 @@ shape.
 
 - **`01-core-calculus.md`** — the keystone. Abstract syntax; the multiplicity
   lattice (Copy / Affine / Linear); **the definition of *use* (place vs. value
-  context)**; the ownership-threading type judgment; the operational semantics
-  and drop; and the soundness theorems (memory safety), stated precisely.
+  context)**; the ownership-threading type judgment — including the leaf,
+  operator, aggregate, and call statics (§5.8) that complete every §2 expression
+  form; the operational semantics and drop; and the soundness theorems (memory
+  safety), stated precisely.
 - *(planned)* `02-elaboration.md` — surface→core desugaring and the comptime /
   monomorphization semantics.
 - *(planned)* `03-metatheory.md` — proofs (progress, preservation, and the

--- a/docs/spec/src/04-expressions/14-comptime.md
+++ b/docs/spec/src/04-expressions/14-comptime.md
@@ -406,3 +406,134 @@ fn main() -> i32 {
     match y { B::Some(n) => n, B::None => 0 }
 }
 ```
+
+## Generic Types (Comptime Type Functions)
+
+The rules in this section describe the generics mechanism of Rue. A generic
+type is not a distinct language construct: it is an ordinary function whose
+comptime parameters and `type` return make it a *type constructor*. This is how
+`Option`, `Result`, and array-buffer types are expressed as library code rather
+than compiler builtins.
+
+{{ rule(id="4.14:22", cat="normative") }}
+
+A comptime function whose declared return type is `type` is a *type
+constructor* (equivalently, a *generic type*). Its body evaluates at compile
+time (rule 4.14:1) to an anonymous struct type (rule 4.14:7) or anonymous enum
+type (rule 4.14:20). Calling a type constructor is *type-function application*;
+the call is evaluated at compile time and reduces to a single concrete type.
+Because application is comptime evaluation, every argument must be
+compile-time known (rule 4.14:6), and each `type`-typed argument must be
+supplied by a `comptime` parameter or another type value.
+
+In *value position*, the reduced type is an ordinary compile-time type value:
+it may be bound with `let` and then used as the path of a struct-literal
+expression (`P { … }`), a method call, or an associated-function call
+(`P::origin()`), exactly as in rules 4.14:7 through 4.14:13.
+
+```rue
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+
+fn main() -> i32 {
+    let O = Option(i32);        // type-function application in value position
+    let x: O = O::Some(42);
+    match x { O::Some(n) => n, O::None => 0 }
+}
+```
+
+{{ rule(id="4.14:23", cat="normative") }}
+
+A type-constructor call may appear directly wherever a type is expected — in a
+`let` type annotation, a function parameter type, a function return type, a
+struct field type, an array element type (`[F(i32); N]`), or a pointer pointee
+— and may be nested within composite types (rule 4.14:16). The call is
+evaluated at compile time and the resulting concrete type is substituted in
+that position.
+
+```rue
+fn Pair(comptime T: type) -> type { struct { first: T, second: T } }
+
+fn mk() -> Pair(i32) {                 // application in return position
+    let P = Pair(i32);
+    P { first: 40, second: 2 }
+}
+
+fn sum(p: Pair(i32)) -> i32 {          // application in parameter position
+    p.first + p.second
+}
+
+fn main() -> i32 {
+    let p: Pair(i32) = mk();           // application in annotation position
+    sum(p)
+}
+```
+
+A type-constructor call is a type, not a path expression: the forms
+`F(args) { … }` (a struct literal) and `F(args)::NAME` (an associated item or
+enum variant) are not accepted, because a call expression is not a permitted
+struct-literal or pattern path. Bind the resulting type to a name first — with
+`let P = F(args);` — and use that name as the path in expression and pattern
+position (`P { … }`, `P::NAME`).
+
+{{ rule(id="4.14:24", cat="normative") }}
+
+The comptime parameters of a type constructor — both `type` parameters and
+ordinary `comptime` value parameters — are in scope throughout its entire body,
+including the signatures and bodies of the methods and associated functions
+(rules 4.14:10, 4.14:13) of the anonymous type it returns (extending rule
+4.14:12, which captures a value parameter, to `type` parameters). A `type`
+parameter `T` may be used anywhere a type is expected — as a field type, a
+method parameter or return type, or a local `let` annotation — and may be
+passed as an argument to another type constructor (for example `Option(T)`),
+nesting generic types.
+
+```rue
+fn Option(comptime T: type) -> type { enum { Some(T), None } }
+
+fn Wrap(comptime T: type) -> type {
+    struct {
+        inner: Option(T),               // T passed to another constructor
+        fn get_or(self, d: T) -> T {    // T names the parameter/return type
+            let O = Option(T);          // T in scope in the method body
+            match self.inner { O::Some(v) => v, O::None => d }
+        }
+    }
+}
+
+fn main() -> i32 {
+    let W = Wrap(i32);
+    let O = Option(i32);
+    let w: W = W { inner: O::Some(7) };
+    w.get_or(0)
+}
+```
+
+{{ rule(id="4.14:25", cat="normative") }}
+
+Each type produced by type-function application is monomorphized
+independently: instantiations with different arguments have independent layouts
+and are distinct, non-assignable types. The identity of an instantiation is
+*structural* — determined by the structural-equality rules for anonymous struct
+(rules 4.14:8, 4.14:15) and enum (rule 4.14:21) types — and does not depend on
+the identity of the constructor or of its arguments. Consequently `F(i32)` and
+`F(i32)` denote the same type wherever they appear, including across separate
+functions; `F(i32)` and `F(i64)` denote different types; and a structurally
+identical result produced by a *different* constructor denotes the same type as
+well (rule 4.14:8).
+
+```rue
+fn Pair(comptime T: type) -> type { struct { first: T, second: T } }
+
+fn produce() -> Pair(i32) {
+    let P = Pair(i32);
+    P { first: 10, second: 5 }
+}
+
+fn consume(p: Pair(i32)) -> i32 {  // same type as produce()'s return
+    p.first + p.second
+}
+
+fn main() -> i32 {
+    consume(produce())  // 15
+}
+```


### PR DESCRIPTION
- **RUE-308** (formal): §5.8 typing rules for the six remaining non-diverging forms (Lit/Arith/Eq/Struct-Intro/Array-Intro/Call), no duplication with §5.5/§5.7.
- **RUE-289** (spec): specified the comptime-type-function generics mechanism (4.14:22-25) — reduction in value+type position, path restrictions, comptime-param scoping, structural monomorphization identity. Derived from execution; 9 cases.
- **RUE-322**: the slice runtime is a confirmed multi-session keystone (3 workers judged it too big for one green session — 2-word {ptr,len} ABI + runtime bounds-check + slice-index-as-load, both backends). Landed the acceptance criteria as executable xfails.

clippy clean; test.sh Pass 24, 100% traceability (671/671).

Fixes RUE-308
Fixes RUE-289
Part of RUE-322

Generated with Claude Code