### PR TITLE
@to_string for any integer width (RUE-314) + type-inference spec (RUE-291)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1016,16 +1016,13 @@ impl<'a> ConstraintGenerator<'a> {
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
                 } else if intrinsic_name == "to_string" {
-                    // @to_string(n): takes an i64, returns String (RUE-17
-                    // Phase 1, ADR-0035). Constrain the argument to i64 so a
-                    // bare integer literal defaults to i64 here.
+                    // @to_string(n): takes any integer width, returns String
+                    // (RUE-17 Phase 1, ADR-0035; RUE-314). No i64 constraint is
+                    // added, so the argument keeps its own type; a bare integer
+                    // literal defaults to i32 like everywhere else. Sema checks
+                    // the resolved type is an integer and widens per signedness.
                     for arg_ref in args.iter() {
-                        let arg_info = self.generate(*arg_ref, ctx);
-                        self.add_constraint(Constraint::equal(
-                            arg_info.ty,
-                            InferType::Concrete(Type::I64),
-                            arg_info.span,
-                        ));
+                        self.generate(*arg_ref, ctx);
                     }
                     self.string_infer_type()
                 } else if intrinsic_name == "parse_i32"

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -4530,15 +4530,22 @@ impl<'a> Sema<'a> {
         Ok(AnalysisResult::new(air_ref, option_ty))
     }
 
-    /// Analyze the `@to_string(n)` intrinsic (RUE-17 Phase 1, ADR-0035).
+    /// Analyze the `@to_string(n)` intrinsic (RUE-17 Phase 1, ADR-0035;
+    /// RUE-314).
     ///
-    /// Formats an `i64` as its decimal representation in a fresh heap `String`.
-    /// Inference constrains the argument to `i64`, so by analysis time the
-    /// operand type is `i64` (or `error`). Rather than introduce a dedicated
+    /// Formats any integer (`i8`/`i16`/`i32`/`i64`/`u8`/`u16`/`u32`/`u64`) as
+    /// its decimal representation in a fresh heap `String`. The runtime
+    /// formatters operate on a 64-bit value, so a narrower argument is widened
+    /// to 64 bits first: signed types sign-extend to `i64` and use
+    /// `__rue_to_string`; unsigned types zero-extend to `u64` and use
+    /// `__rue_to_string_unsigned` (so a `u32`/`u64` with the high bit set
+    /// prints as its unsigned value, not a negative number). The widening
+    /// reuses the ordinary `IntCast` path, which the backends already
+    /// sign/zero-extend correctly (RUE-88). Rather than introduce a dedicated
     /// codegen intrinsic, this lowers to an ordinary `extern "C"` call to the
-    /// runtime `__rue_to_string(out, n)`: the return type is the builtin
-    /// `String`, so the existing sret call convention allocates the result
-    /// buffer and passes it as the hidden first argument — no codegen change.
+    /// runtime: the return type is the builtin `String`, so the existing sret
+    /// call convention allocates the result buffer and passes it as the hidden
+    /// first argument — no codegen change.
     fn analyze_to_string_intrinsic(
         &mut self,
         air: &mut Air,
@@ -4557,28 +4564,50 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        // The argument is consumed by value (an i64 is Copy, so this is a plain
-        // read). Inference has already unified it with i64.
+        // The argument is consumed by value (every integer is Copy, so this is a
+        // plain read). Any integer width is accepted (RUE-314).
         let arg_result = self.analyze_inst(air, args[0].value, ctx)?;
         let arg_type = arg_result.ty;
-        if arg_type != Type::I64 && !arg_type.is_error() {
+        if !arg_type.is_integer() && !arg_type.is_error() {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: "@to_string".to_string(),
-                    expected: "i64".to_string(),
+                    expected: "integer".to_string(),
                     found: arg_type.safe_name_with_pool(Some(&self.type_pool)),
                 })),
                 span,
             ));
         }
 
+        // Widen the argument to a 64-bit value and pick the runtime formatter by
+        // signedness. Unsigned types must format their zero-extended value, so
+        // route them through the unsigned formatter; an error-typed argument is
+        // treated as signed (it never reaches codegen).
+        let unsigned = arg_type.is_unsigned();
+        let widen_to = if unsigned { Type::U64 } else { Type::I64 };
+        let arg_air_ref = if arg_type.is_error() || arg_type == widen_to {
+            arg_result.air_ref
+        } else {
+            air.add_inst(AirInst {
+                data: AirInstData::IntCast {
+                    value: arg_result.air_ref,
+                    from_ty: arg_type,
+                },
+                ty: widen_to,
+                span,
+            })
+        };
+
         let string_type = self.builtin_string_type();
-        let call_name = self
-            .interner
-            .get_or_intern(rue_builtins::TO_STRING_RUNTIME_FN);
+        let runtime_fn = if unsigned {
+            rue_builtins::TO_STRING_UNSIGNED_RUNTIME_FN
+        } else {
+            rue_builtins::TO_STRING_RUNTIME_FN
+        };
+        let call_name = self.interner.get_or_intern(runtime_fn);
 
         // Encode the single by-value argument as a (value, mode) pair.
-        let extra_data = [arg_result.air_ref.as_u32(), AirArgMode::Normal.as_u32()];
+        let extra_data = [arg_air_ref.as_u32(), AirArgMode::Normal.as_u32()];
         let args_start = air.add_extra(&extra_data);
 
         let air_ref = air.add_inst(AirInst {

--- a/crates/rue-builtins/src/lib.rs
+++ b/crates/rue-builtins/src/lib.rs
@@ -480,11 +480,20 @@ pub static STRING_TYPE: BuiltinTypeDef = BuiltinTypeDef {
 // The names are collected here so there is a single source of truth for what
 // the compiler emits and what `rue-runtime` must define.
 
-/// Runtime symbol for `@to_string(n)`: formats an `i64` as its decimal
-/// representation into a freshly heap-allocated `String` (full range including
-/// `i64::MIN`; negatives are prefixed with `-`). sret ABI:
-/// `extern "C" fn __rue_to_string(out: *mut StringResult, n: i64)`.
+/// Runtime symbol for `@to_string(n)` on a signed integer: formats an `i64` as
+/// its decimal representation into a freshly heap-allocated `String` (full range
+/// including `i64::MIN`; negatives are prefixed with `-`). Narrower signed
+/// operands (`i8`/`i16`/`i32`) are sign-extended to `i64` before the call. sret
+/// ABI: `extern "C" fn __rue_to_string(out: *mut StringResult, n: i64)`.
 pub const TO_STRING_RUNTIME_FN: &str = "__rue_to_string";
+
+/// Runtime symbol for `@to_string(n)` on an unsigned integer: formats a `u64` as
+/// its decimal representation into a freshly heap-allocated `String` (full
+/// range, so a value with the high bit set prints as its unsigned magnitude, not
+/// a negative number). Narrower unsigned operands (`u8`/`u16`/`u32`) are
+/// zero-extended to `u64` before the call. sret ABI:
+/// `extern "C" fn __rue_to_string_unsigned(out: *mut StringResult, n: u64)`.
+pub const TO_STRING_UNSIGNED_RUNTIME_FN: &str = "__rue_to_string_unsigned";
 
 /// Runtime symbol for `s1 + s2` on two `String`s: returns a NEW `String` whose
 /// bytes are the concatenation of `s1` and `s2`. Both operands are borrowed

--- a/crates/rue-cli-tests/cases/string_phase1.toml
+++ b/crates/rue-cli-tests/cases/string_phase1.toml
@@ -1,7 +1,7 @@
 # Design-light String methods (RUE-17 Phase 1, ADR-0035).
 #
 # Phase 1 adds three runtime-visible String operations on top of the Phase 2
-# byte-access primitives: `@to_string(n)` (i64 -> decimal String),
+# byte-access primitives: `@to_string(n)` (any integer -> decimal String),
 # `String + String` concatenation, and the byte-level `contains` / `starts_with`
 # predicates. Every operation lowers to an `extern "C"` runtime call whose ABI
 # (String flattened to ptr/len/cap, sret return buffer for the heap results) is
@@ -30,6 +30,48 @@ fn main() -> i32 {
 """ }]
 exit_code = 0
 stdout = "42\n-5\n0\n-9223372036854775808\n9223372036854775807\n"
+
+[[case]]
+name = "to_string_all_integer_widths"
+description = "@to_string accepts any integer width (RUE-314): each of i8/i16/i32/i64/u8/u16/u32/u64 formats correctly, and an unsigned value with the high bit set prints as its unsigned magnitude, not a negative number."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: i8 = -128;
+    let b: i16 = -32768;
+    let c: i32 = -2147483648;
+    let d: i64 = -9223372036854775808;
+    let e: u8 = 255;
+    let f: u16 = 65535;
+    let g: u32 = 4294967295;
+    let h: u64 = 18446744073709551615;
+    println(@to_string(a));
+    println(@to_string(b));
+    println(@to_string(c));
+    println(@to_string(d));
+    println(@to_string(e));
+    println(@to_string(f));
+    println(@to_string(g));
+    println(@to_string(h));
+    0
+}
+""" }]
+exit_code = 0
+stdout = "-128\n-32768\n-2147483648\n-9223372036854775808\n255\n65535\n4294967295\n18446744073709551615\n"
+
+[[case]]
+name = "to_string_i32_no_cast_needed"
+description = "@to_string of an i32 value (the default width, and what @parse_i32 returns) compiles without an @intCast (RUE-314 regression)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let x: i32 = 12345;
+    let y: i32 = -6789;
+    println(@to_string(x));
+    println(@to_string(y));
+    0
+}
+""" }]
+exit_code = 0
+stdout = "12345\n-6789\n"
 
 [[case]]
 name = "concat_is_concatenation_not_addition"

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -310,6 +310,12 @@ impl<'a> Interp<'a> {
             _ => String::new(),
         };
         let out = match name {
+            // `@to_string(n)` (RUE-314). The argument is already widened to a
+            // 64-bit value by sema (sign-extended to i64 for signed types,
+            // zero-extended to u64 for unsigned); format it with the matching
+            // signedness so a high-bit-set unsigned value prints unsigned.
+            "__rue_to_string" => Value::Str((args[0].as_int() as i64).to_string()),
+            "__rue_to_string_unsigned" => Value::Str((args[0].as_int() as u64).to_string()),
             "__rue_String_new" => Value::Str(String::new()),
             "__rue_String_with_capacity" => Value::Str(String::new()),
             "__rue_String_push_str" => Value::Str(s(&args[0]) + &s(&args[1])),

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -1151,6 +1151,68 @@ crate::define_for_all_platforms! {
 }
 
 crate::define_for_all_platforms! {
+    /// Format a `u64` in base 10 into a freshly heap-allocated `String`.
+    ///
+    /// Implements `@to_string(n)` for unsigned integers (RUE-314). The compiler
+    /// zero-extends narrower unsigned operands (`u8`/`u16`/`u32`) to `u64`
+    /// before the call, so this handles the full `u64` range — a value with the
+    /// high bit set prints as its unsigned magnitude (e.g. `u64::MAX` prints
+    /// `18446744073709551615`), never as a negative number. There is no sign
+    /// prefix.
+    ///
+    /// # ABI (sret convention)
+    ///
+    /// ```text
+    /// extern "C" fn __rue_to_string_unsigned(out: *mut StringResult, n: u64)
+    /// ```
+    ///
+    /// `out` (the sret pointer) comes first, then the integer argument. The
+    /// returned String owns a fresh heap buffer, so it can be mutated and
+    /// dropped independently.
+    ///
+    /// # Safety
+    ///
+    /// `out` must be a valid sret pointer — see `__rue_String_new`.
+    pub extern "C" fn __rue_to_string_unsigned(out: *mut StringResult, n: u64) {
+        // "18446744073709551615" (u64::MAX) is the longest result: 20 bytes.
+        let mut buf = [0u8; 20];
+        let mut mag = n;
+        // Emit decimal digits least-significant first, filling `buf` from the
+        // back. `i` walks left toward the front of the buffer.
+        let mut i = buf.len();
+        if mag == 0 {
+            i -= 1;
+            buf[i] = b'0';
+        } else {
+            while mag > 0 {
+                i -= 1;
+                buf[i] = b'0' + (mag % 10) as u8;
+                mag /= 10;
+            }
+        }
+
+        let len = (buf.len() - i) as u64;
+        let new_cap = if len < STRING_MIN_CAPACITY {
+            STRING_MIN_CAPACITY
+        } else {
+            len
+        };
+        let new_ptr = heap::alloc(new_cap, 1);
+
+        // SAFETY: `new_ptr` was just allocated with `new_cap >= len` bytes; the
+        // source range `buf[i..]` holds exactly `len` initialized bytes; the
+        // regions don't overlap (fresh allocation). `out` is a valid sret
+        // pointer (see __rue_String_new).
+        unsafe {
+            core::ptr::copy_nonoverlapping(buf.as_ptr().add(i), new_ptr, len as usize);
+            (*out).ptr = new_ptr;
+            (*out).len = len;
+            (*out).cap = new_cap;
+        }
+    }
+}
+
+crate::define_for_all_platforms! {
     /// Return a NEW String whose bytes are the concatenation of two Strings.
     ///
     /// Implements `s1 + s2` (RUE-17 Phase 1, ADR-0035). Both operands are

--- a/crates/rue-spec/cases/types/inference.toml
+++ b/crates/rue-spec/cases/types/inference.toml
@@ -1,0 +1,159 @@
+[section]
+id = "types.inference"
+spec_chapter = "3.11"
+name = "Type Inference"
+description = "Local constraint-based type inference: locality, the constraint model, expected-type propagation, compatibility, and comptime interaction"
+
+# =============================================================================
+# 3.11:2 — Locality: annotations required at function/const boundaries
+# =============================================================================
+# Inference runs per function body; nothing crosses a boundary, so parameters,
+# return types, and value constants must be annotated. A `let` may be inferred.
+
+[[case]]
+name = "let_may_omit_annotation"
+spec = ["3.11:2"]
+source = """
+fn main() -> i32 {
+    let a = 1;
+    let b = a + 2;
+    b
+}
+"""
+exit_code = 3
+
+[[case]]
+name = "param_requires_annotation"
+spec = ["3.11:2"]
+compile_fail = true
+error_contains = ["E0100"]
+source = """
+fn f(x) -> i32 { x }
+fn main() -> i32 { f(1) }
+"""
+
+[[case]]
+name = "value_const_requires_annotation"
+spec = ["3.11:2"]
+compile_fail = true
+error_contains = ["E0475"]
+source = """
+const K = 5;
+fn main() -> i32 { K }
+"""
+
+# =============================================================================
+# 3.11:4 — Constraint model: whole-body solve, order-independent
+# =============================================================================
+# An unannotated literal unifies with every use; a single non-i32 use fixes it,
+# and conflicting uses are rejected regardless of textual order.
+
+[[case]]
+name = "constraint_solve_use_before_source"
+spec = ["3.11:4"]
+source = """
+fn takes_i64(v: i64) -> i64 { v }
+fn main() -> i32 {
+    let c = 7;
+    let d = takes_i64(c);
+    if d == 7 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "constraint_conflict_order_independent"
+spec = ["3.11:4"]
+compile_fail = true
+error_contains = ["E0206", "type mismatch"]
+source = """
+fn takes_i32(v: i32) -> i32 { v }
+fn takes_i64(v: i64) -> i64 { v }
+fn main() -> i32 {
+    let c = 7;
+    takes_i64(c);
+    takes_i32(c);
+    0
+}
+"""
+
+# =============================================================================
+# 3.11:6 — Expected-type (bidirectional) propagation
+# =============================================================================
+# An expected type flows inward; a literal in that position takes it rather than
+# defaulting. Element values that only fit i64 prove the annotation reached them.
+
+[[case]]
+name = "expected_type_array_element"
+spec = ["3.11:6"]
+source = """
+fn main() -> i32 {
+    let a: [i64; 3] = [1, 2, 3000000000];
+    if a[2] == 3000000000 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "expected_type_return_position"
+spec = ["3.11:6"]
+source = """
+fn big() -> i64 { 5000000000 }
+fn main() -> i32 {
+    let x: i64 = big();
+    if x == 5000000000 { 0 } else { 1 }
+}
+"""
+exit_code = 0
+
+# =============================================================================
+# 3.11:8 — Compatibility: no implicit conversion between concrete int types
+# =============================================================================
+
+[[case]]
+name = "no_implicit_int_widening"
+spec = ["3.11:8"]
+compile_fail = true
+error_contains = ["E0206", "type mismatch"]
+source = """
+fn takes_i64(v: i64) -> i64 { v }
+fn main() -> i32 {
+    let x: i32 = 5;
+    takes_i64(x);
+    0
+}
+"""
+
+# =============================================================================
+# 3.11:9 — The never type is the only coercion applied during inference
+# =============================================================================
+
+[[case]]
+name = "never_coerces_in_expected_position"
+spec = ["3.11:9"]
+source = """
+fn diverge() -> ! { loop {} }
+fn main() -> i32 {
+    let x: i32 = if true { 0 } else { diverge() };
+    x
+}
+"""
+exit_code = 0
+
+# =============================================================================
+# 3.11:11 — Comptime type-parameter substitution feeds argument inference
+# =============================================================================
+# T is substituted with i64 before the argument is inferred, so a literal that
+# does not fit i32 is accepted at the type-parameterized position.
+
+[[case]]
+name = "comptime_type_param_arg_inference"
+spec = ["3.11:11"]
+source = """
+fn identity(comptime T: type, x: T) -> T { x }
+fn main() -> i32 {
+    let r: i64 = identity(i64, 3000000000);
+    if r == 3000000000 { 0 } else { 1 }
+}
+"""
+exit_code = 0

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -778,6 +778,55 @@ exit_code = 0
 expected_stdout = "-9223372036854775808\n9223372036854775807\n"
 
 [[case]]
+name = "to_string_signed_widths"
+spec = ["3.7:22", "3.7:23"]
+source = """
+fn main() -> i32 {
+    let a: i8 = -128;
+    let b: i16 = -32768;
+    let c: i32 = -2147483648;
+    @dbg(@to_string(a));
+    @dbg(@to_string(b));
+    @dbg(@to_string(c));
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "-128\n-32768\n-2147483648\n"
+
+[[case]]
+name = "to_string_unsigned_widths_high_bit"
+spec = ["3.7:22", "3.7:23"]
+source = """
+fn main() -> i32 {
+    let a: u8 = 255;
+    let b: u16 = 65535;
+    let c: u32 = 4294967295;
+    let d: u64 = 18446744073709551615;
+    @dbg(@to_string(a));
+    @dbg(@to_string(b));
+    @dbg(@to_string(c));
+    @dbg(@to_string(d));
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "255\n65535\n4294967295\n18446744073709551615\n"
+
+[[case]]
+name = "to_string_i32_default_literal"
+spec = ["3.7:22"]
+source = """
+fn main() -> i32 {
+    let n: i32 = 42;
+    @dbg(@to_string(n));
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "42\n"
+
+[[case]]
 name = "string_concat_literals"
 spec = ["3.7:25"]
 source = """

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -162,15 +162,19 @@ fn main() -> i32 {
 
 {{ rule(id="3.7:22", cat="normative") }}
 
-The intrinsic `@to_string(n)` takes an `i64` and returns a new, heap-allocated
-`String` containing the base-10 decimal representation of `n` (see ADR-0035).
-The argument is of type `i64`; a bare integer literal argument is inferred to be
-`i64`.
+The intrinsic `@to_string(n)` takes an argument of any integer type (`i8`,
+`i16`, `i32`, `i64`, `u8`, `u16`, `u32`, or `u64`) and returns a new,
+heap-allocated `String` containing the base-10 decimal representation of `n`
+(see ADR-0035). The argument keeps its own type; a bare integer literal argument
+is inferred to be `i32` (the default integer type).
 
 {{ rule(id="3.7:23", cat="dynamic-semantics") }}
 
-`@to_string(n)` formats the entire range of `i64`, including `i64::MIN`. A
-negative value is prefixed with a single `-`; a zero value formats as `0`.
+`@to_string(n)` formats the entire range of the argument's type, including
+`i64::MIN` and `u64::MAX`. The value is formatted according to its type's
+signedness: an unsigned value with its high bit set formats as its unsigned
+magnitude, never as a negative number. A negative signed value is prefixed with
+a single `-`; a zero value formats as `0`.
 
 {{ rule(id="3.7:24") }}
 

--- a/docs/spec/src/03-types/11-type-inference.md
+++ b/docs/spec/src/03-types/11-type-inference.md
@@ -1,0 +1,152 @@
++++
+title = "Type Inference"
+weight = 11
+template = "spec/page.html"
++++
+
+# Type Inference
+
+Rue determines the type of every expression through *local type inference*: a
+constraint-based algorithm derived from Hindley–Milner inference (Algorithm W;
+see ADR-0007) that runs over one function body at a time. This section specifies
+that algorithm — the constraint model, how an expected type flows inward, which
+positions require an explicit annotation, and how inference interacts with
+comptime — so that an independent implementation infers the same types and
+accepts the same programs.
+
+{{ rule(id="3.11:1") }}
+
+The integer-literal rules of this section (defaulting to `i32`, unify-then-
+default) are stated normatively in [Integer Literal Type Inference](@/03-types/01-integer-types.md#integer-literal-type-inference)
+(3.1:14, 3.1:15); this section describes the surrounding algorithm they are part
+of.
+
+## Locality
+
+{{ rule(id="3.11:2", cat="normative") }}
+
+Type inference operates on one function body in isolation. Type information does
+not flow across a function boundary: a callee's parameter and return types are
+not inferred from its call sites, and a caller does not observe inference
+variables of a callee. To make each boundary self-describing, every function
+parameter, every function return type, and every value constant (6.5) **MUST**
+carry an explicit type annotation. A `let` binding (5.1) **MAY** omit its
+annotation, in which case its type is determined by inference from its
+initializer and later uses.
+
+{{ rule(id="3.11:3") }}
+
+```rue
+fn main() -> i32 {
+    let a = 1;        // inferred, no annotation needed
+    let b = a + 2;    // inferred from a
+    b
+}
+```
+
+## Constraint Model
+
+{{ rule(id="3.11:4", cat="normative") }}
+
+The compiler assigns a fresh type variable to each expression whose type is not
+syntactically determined, and generates equality constraints from the structure
+of the program: the two operands of a binary operator share a type, a call
+argument has its parameter's type, a `let` initializer has its annotation's
+type, an array element has the array's element type, and a returned expression
+has the function's return type. All constraints collected from a function body
+are solved together, and the resulting types **MUST NOT** depend on the textual
+order in which the constraints were generated. In particular, an unannotated
+integer literal (3.1:14) unifies with every use of its value across the body,
+and two uses that demand different integer types are a compile-time error
+(E0206) whichever use is written first.
+
+{{ rule(id="3.11:5") }}
+
+```rue
+fn takes_i64(v: i64) -> i64 { v }
+
+fn main() -> i32 {
+    let c = 7;              // no type yet
+    let _d = takes_i64(c);  // this use fixes c (and 7) to i64, order-independently
+    0
+}
+```
+
+## Expected Types (Bidirectional Propagation)
+
+{{ rule(id="3.11:6", cat="normative") }}
+
+When the surrounding context fixes the type an expression must produce, that
+type is supplied to the expression as its *expected type* and flows inward to
+the expression's sub-expressions. The contexts that impose an expected type are:
+a `let` initializer under a type annotation, an argument at a call (the
+parameter type), an element of an array literal under an array-typed annotation,
+the operand of a `return` and a block's tail expression (the return type), and a
+`match` scrutinee under typed arm patterns. An unannotated integer literal in an
+expected-type position takes the expected integer type rather than defaulting
+(3.1:15).
+
+{{ rule(id="3.11:7") }}
+
+```rue
+fn main() -> i32 {
+    // The annotation makes [i64; 3] the expected type, so each element literal
+    // — including 3000000000, which does not fit i32 — is inferred as i64.
+    let a: [i64; 3] = [1, 2, 3000000000];
+    if a[2] == 3000000000 { 0 } else { 1 }
+}
+```
+
+## Compatibility
+
+{{ rule(id="3.11:8", cat="legality-rule") }}
+
+When an expected type is imposed on an expression, the expression's inferred
+type **MUST** be compatible with it (1.1): the two types are equal, or the
+inferred type coerces to the expected type. There are no implicit conversions
+between distinct concrete integer types; an incompatible type is a compile-time
+error (E0206).
+
+{{ rule(id="3.11:9", cat="normative") }}
+
+The only coercion applied during inference is the never type coercing to any
+type (3.4): a diverging expression (type `!`) is accepted in any expected-type
+position. The resolution of an unannotated integer literal to a concrete integer
+type (3.1:14) is inference, not a coercion — the literal has no fixed type until
+it is solved.
+
+{{ rule(id="3.11:10") }}
+
+```rue
+fn diverge() -> ! { loop {} }
+
+fn main() -> i32 {
+    // The else branch has type `!`, which coerces to the i32 expected here.
+    let x: i32 = if true { 5 } else { diverge() };
+    x
+}
+```
+
+## Interaction with Comptime
+
+{{ rule(id="3.11:11", cat="normative") }}
+
+A `comptime T: type` parameter (4.14) is substituted with its concrete type
+argument before the corresponding runtime argument is inferred, and the
+substituted type becomes that argument's expected type (3.11:6). A literal
+passed at a `type`-parameterized position is therefore inferred at the
+substituted type. A `comptime { … }` block contributes a value whose type is the
+concrete, already-known type of the block's tail expression; it is not an
+inference variable.
+
+{{ rule(id="3.11:12") }}
+
+```rue
+fn identity(comptime T: type, x: T) -> T { x }
+
+fn main() -> i32 {
+    // T is substituted with i64, so 3000000000 is inferred as i64, not i32.
+    let r: i64 = identity(i64, 3000000000);
+    if r == 3000000000 { 0 } else { 1 }
+}
+```

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -54,7 +54,7 @@ Expression intrinsics (usable in any expression position):
 | `@size_of` | Get type size in bytes | 1 type | `i32` |
 | `@align_of` | Get type alignment in bytes | 1 type | `i32` |
 | `@intCast` | Convert between integer types | 1 expression (integer) | inferred integer type |
-| `@to_string` | Format an integer as its decimal `String` | 1 expression (`i64`) | `String` |
+| `@to_string` | Format an integer as its decimal `String` | 1 expression (any integer) | `String` |
 | `@drop` | Run a value's drop glue and consume it (RUE-187) | 1 expression (any type) | `()` |
 | `@read_line` | Read line from stdin | none | `Option(String)` |
 | `@parse_i32` | Parse string to i32 | 1 expression (`String`) | `Option(i32)` |


### PR DESCRIPTION
- **RUE-314**: @to_string only accepted i64 (E0206 on i32 — the default width). Sema now accepts any integer width and widens to 64 bits via IntCast; signed→i64 (__rue_to_string), unsigned→u64 (new __rue_to_string_unsigned) so high-bit-set u32/u64 print unsigned. No codegen change. Verified every width by execution; 3 spec + 2 CLI cases.
- **RUE-291**: specified local type inference as normative section 3.11 (literal defaulting + expected-type override, required vs optional annotations, bidirectional propagation, never-coercion, comptime substitution) — every rule backed by a run program; 10 cases.

clippy clean; test.sh Pass 24, 100% traceability (677/677).

Fixes RUE-314
Fixes RUE-291

Generated with Claude Code