### PR TITLE
Oracle: String::push appends a raw byte, not a UTF-8 codepoint

### DIFF
--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -321,8 +321,20 @@ impl<'a> Interp<'a> {
             "__rue_String_push_str" => Value::Str(s(&args[0]) + &s(&args[1])),
             "__rue_String_push" => {
                 let mut base = s(&args[0]);
-                if let Some(c) = char::from_u32(args[1].as_int() as u32) {
-                    base.push(c);
+                let byte = args[1].as_int() as u8;
+                if byte < 0x80 {
+                    // ASCII: exactly one byte, matching the runtime's raw-byte
+                    // buffer (__rue_String_push writes a single byte).
+                    base.push(byte as char);
+                } else {
+                    // push takes a u8 and a Rue String is a raw byte buffer, but
+                    // a byte >= 0x80 is not valid standalone UTF-8, which
+                    // Value::Str (a Rust String) cannot represent. The runtime
+                    // stores the single raw byte; encoding a char here would
+                    // store two. Skip rather than silently diverge (see RUE-342).
+                    return Err(Flow::Unsupported(Unsupported(
+                        "String::push of a non-ASCII byte (oracle cannot model non-UTF-8 String content)".into(),
+                    )));
                 }
                 Value::Str(base)
             }


### PR DESCRIPTION
From the rue-oracle code review. The oracle's __rue_String_push UTF-8-encoded any byte >= 0x80 into two bytes, while the runtime writes one raw byte — a silent false-DISAGREE making a correct compiler look buggy on len()/@dbg/String ==. Minimal decision-free fix: ASCII byte → single byte (matches runtime); byte >= 0x80 → Unsupported (differential harness cleanly skips) since Value::Str can't hold non-UTF-8. Full fix (String as Vec<u8>) tracked in RUE-342.

clippy clean; test.sh Pass 24.

Generated with Claude Code