### PR TITLE
@offset_of/@field_ptr intrinsics, String-rep spec, Mach-O guards, formal §6

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -1088,10 +1088,15 @@ impl<'a> ConstraintGenerator<'a> {
                     }
                     let result_var = self.fresh_var();
                     InferType::Var(result_var)
-                } else if intrinsic_name == "raw" || intrinsic_name == "raw_mut" {
-                    // @raw / @raw_mut: takes a value, returns a pointer to it
-                    // The return type is ptr const T or ptr mut T where T is the argument type.
-                    // We create a fresh type variable for proper inference.
+                } else if intrinsic_name == "raw"
+                    || intrinsic_name == "raw_mut"
+                    || intrinsic_name == "field_ptr"
+                {
+                    // @raw / @raw_mut / @field_ptr: takes a place, returns a
+                    // pointer to it (RUE-301). The return type is a pointer
+                    // whose pointee is only known once the operand is analyzed,
+                    // so we create a fresh type variable for proper inference
+                    // (Sema fixes it to `ptr const T`/`ptr mut T`).
                     for arg_ref in args.iter() {
                         self.generate(*arg_ref, ctx);
                     }
@@ -1239,6 +1244,14 @@ impl<'a> ConstraintGenerator<'a> {
                 // Type intrinsics return i32 (the size or alignment value)
                 InferType::Concrete(Type::I32)
             }
+
+            // Field-offset intrinsic (@offset_of) — the compile-time byte
+            // offset of a field within a struct (RUE-301). Returns u64, like
+            // Rust's `core::mem::offset_of!`.
+            InstData::OffsetOf {
+                type_arg: _,
+                field: _,
+            } => InferType::Concrete(Type::U64),
 
             // Block
             InstData::Block { extra_start, len } => {

--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -2513,7 +2513,7 @@ impl<'a> Sema<'a> {
     /// - **Arrays**: ArrayInit, IndexGet, IndexSet
     /// - **Enums**: EnumDecl, EnumVariant
     /// - **Calls**: Call, MethodCall, AssocFnCall
-    /// - **Intrinsics**: Intrinsic, TypeIntrinsic
+    /// - **Intrinsics**: Intrinsic, TypeIntrinsic, OffsetOf
     /// - **Declarations**: DropFnDecl, FnDecl
     pub(crate) fn analyze_inst(
         &mut self,
@@ -2635,9 +2635,9 @@ impl<'a> Sema<'a> {
             }
 
             // Intrinsic operations
-            InstData::Intrinsic { .. } | InstData::TypeIntrinsic { .. } => {
-                self.analyze_intrinsic_ops(air, inst_ref, ctx)
-            }
+            InstData::Intrinsic { .. }
+            | InstData::TypeIntrinsic { .. }
+            | InstData::OffsetOf { .. } => self.analyze_intrinsic_ops(air, inst_ref, ctx),
 
             // Declaration no-ops (produce Unit in expression context)
             InstData::DropFnDecl { .. } | InstData::FnDecl { .. } | InstData::ConstDecl { .. } => {
@@ -3748,8 +3748,9 @@ impl<'a> Sema<'a> {
         // only be used inside a `checked` block (spec 9.1:1, chapter 9). Gate
         // them before the per-intrinsic dispatch so every one shares a single
         // diagnostic. `@syscall` has its own gating; the set here is
-        // @raw/@raw_mut/@ptr_read/@ptr_write/@ptr_offset/@ptr_to_int/
-        // @int_to_ptr plus the heap intrinsics @alloc/@free/@realloc (RUE-1).
+        // @raw/@raw_mut/@field_ptr/@ptr_read/@ptr_write/@ptr_offset/
+        // @ptr_to_int/@int_to_ptr plus the heap intrinsics
+        // @alloc/@free/@realloc (RUE-1, RUE-301).
         if ctx.checked_depth == 0
             && (name == known.ptr_read
                 || name == known.ptr_write
@@ -3758,6 +3759,7 @@ impl<'a> Sema<'a> {
                 || name == known.int_to_ptr
                 || name == known.raw
                 || name == known.raw_mut
+                || name == known.field_ptr
                 || name == known.alloc
                 || name == known.free
                 || name == known.realloc)
@@ -3821,9 +3823,13 @@ impl<'a> Sema<'a> {
         } else if name == known.realloc {
             self.analyze_realloc_intrinsic(air, name, &args, span, ctx)
         } else if name == known.raw {
-            self.analyze_addr_of_intrinsic(air, &args, span, ctx, false)
+            let raw = self.known.raw;
+            self.analyze_addr_of_intrinsic(air, &args, span, ctx, false, raw, "addr_of")
         } else if name == known.raw_mut {
-            self.analyze_addr_of_intrinsic(air, &args, span, ctx, true)
+            let raw_mut = self.known.raw_mut;
+            self.analyze_addr_of_intrinsic(air, &args, span, ctx, true, raw_mut, "addr_of_mut")
+        } else if name == known.field_ptr {
+            self.analyze_field_ptr_intrinsic(air, &args, span, ctx)
         } else if name == known.syscall {
             self.analyze_syscall_intrinsic(air, name, &args, span, ctx)
         } else if name == known.target_arch {
@@ -7331,9 +7337,16 @@ impl<'a> Sema<'a> {
         Ok(AnalysisResult::new(air_ref, ptr_type))
     }
 
-    /// Analyze @addr_of / @addr_of_mut intrinsics: takes address of lvalue.
-    /// Signature: @addr_of(lvalue) -> ptr const T
-    /// Signature: @addr_of_mut(lvalue) -> ptr mut T
+    /// Analyze @raw / @field_ptr address-of intrinsics: forms a raw pointer to
+    /// an addressable place without taking a reference.
+    ///
+    /// `@raw(place) -> ptr const T` / `@raw_mut(place) -> ptr mut T` accept any
+    /// place; `@field_ptr(s.field) -> ptr mut F` (RUE-301) is the same address
+    /// computation restricted to a struct-field place (the field-place check is
+    /// enforced by [`Self::analyze_field_ptr_intrinsic`] before it delegates
+    /// here). `result_name` is the intrinsic name recorded in the AIR — codegen
+    /// treats `raw`/`raw_mut`/`field_ptr` identically (all lower the place's
+    /// address), so the three share this analysis and this lowering path.
     fn analyze_addr_of_intrinsic(
         &mut self,
         air: &mut Air,
@@ -7341,8 +7354,10 @@ impl<'a> Sema<'a> {
         span: Span,
         ctx: &mut AnalysisContext,
         is_mut: bool,
+        result_name: Spur,
+        diag_name: &str,
     ) -> CompileResult<AnalysisResult> {
-        let intrinsic_name = if is_mut { "addr_of_mut" } else { "addr_of" };
+        let intrinsic_name = diag_name;
 
         if args.len() != 1 {
             return Err(CompileError::new(
@@ -7416,12 +7431,10 @@ impl<'a> Sema<'a> {
             Type::new_ptr_const(ptr_type_id)
         };
 
-        // Create the intrinsic call instruction
-        let name = if is_mut {
-            self.known.raw_mut
-        } else {
-            self.known.raw
-        };
+        // Create the intrinsic call instruction. `result_name` distinguishes
+        // @raw/@raw_mut/@field_ptr in the AIR; codegen lowers all three the
+        // same way (address of the operand place).
+        let name = result_name;
         let args_start = air.add_extra(&[arg_result.air_ref.as_u32()]);
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
@@ -7433,6 +7446,48 @@ impl<'a> Sema<'a> {
             span,
         });
         Ok(AnalysisResult::new(air_ref, result_type))
+    }
+
+    /// Analyze `@field_ptr(s.field)` (RUE-301): a raw `ptr mut F` to a struct
+    /// field place, the `&raw mut (*p).field` analog. Unlike `@raw`, the
+    /// operand MUST be a field-access expression (`s.field`) — that is exactly
+    /// what makes it "compiler-mediated field access": the pointer addresses
+    /// the field the compiler placed, so unchecked code walks a struct without
+    /// hardcoding slot offsets. The address computation, place liveness
+    /// handling, and codegen are shared with `@raw_mut` via
+    /// [`Self::analyze_addr_of_intrinsic`]; the only extra obligation here is
+    /// requiring a field place.
+    fn analyze_field_ptr_intrinsic(
+        &mut self,
+        air: &mut Air,
+        args: &[RirCallArg],
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        if args.len() != 1 {
+            return Err(CompileError::new(
+                ErrorKind::IntrinsicWrongArgCount {
+                    name: "field_ptr".to_string(),
+                    expected: 1,
+                    found: args.len(),
+                },
+                span,
+            ));
+        }
+
+        // The operand must be a field access `s.field`. Inspect the RIR operand
+        // directly: a field access lowers to `InstData::FieldGet` before
+        // analysis, so a non-field operand (a bare variable, an index, a call
+        // result, a literal) is rejected up front with a targeted diagnostic
+        // rather than @raw's generic "not a place" message.
+        if !matches!(self.rir.get(args[0].value).data, InstData::FieldGet { .. }) {
+            return Err(CompileError::new(ErrorKind::FieldPtrRequiresField, span));
+        }
+
+        // @field_ptr yields a mutable raw pointer (like `&raw mut`), so it
+        // supports both @ptr_read and @ptr_write round-trips through the field.
+        let field_ptr = self.known.field_ptr;
+        self.analyze_addr_of_intrinsic(air, args, span, ctx, true, field_ptr, "field_ptr")
     }
 
     /// Analyze @syscall intrinsic: perform a raw OS syscall.

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -5255,6 +5255,10 @@ impl<'a> Sema<'a> {
                 self.analyze_type_intrinsic(air, *name, *type_arg, inst.span)
             }
 
+            InstData::OffsetOf { type_arg, field } => {
+                self.analyze_offset_of(air, *type_arg, *field, inst.span)
+            }
+
             _ => Err(CompileError::new(
                 ErrorKind::InternalError(format!(
                     "analyze_intrinsic_ops called with non-intrinsic instruction: {:?}",
@@ -5302,6 +5306,89 @@ impl<'a> Sema<'a> {
             span,
         });
         Ok(AnalysisResult::new(air_ref, Type::I32))
+    }
+
+    /// Analyze `@offset_of(T, field)` (RUE-301): the compile-time byte offset of
+    /// `field` within struct type `T`.
+    ///
+    /// The offset is computed from the layout the compiler assigns — the sum of
+    /// the ABI slot counts of all preceding fields, times the 8-byte slot size
+    /// (spec 3.6). This MUST match `struct_field_slot_offset` in
+    /// `rue-codegen::types` (which multiplies the same preceding-field slot sum
+    /// by 8 when addressing a field), so that `@offset_of(T, f)` and
+    /// `@field_ptr(s.f)` agree with direct `s.f` access under any layout. The
+    /// result is a comptime-known `u64`, mirroring Rust's
+    /// `core::mem::offset_of!` (return type) and `@size_of`/`@align_of` (which
+    /// likewise fold to a `Const` at analysis time).
+    fn analyze_offset_of(
+        &mut self,
+        air: &mut Air,
+        type_arg: Spur,
+        field: Spur,
+        span: Span,
+    ) -> CompileResult<AnalysisResult> {
+        let ty = self.resolve_type(type_arg, span)?;
+
+        // `@offset_of` is only meaningful for a struct type: only structs have
+        // named fields. A non-struct operand is the same error class as `.f`
+        // on a non-struct (E0428).
+        let struct_id = match ty.as_struct() {
+            Some(id) => id,
+            None => {
+                if ty.is_error() {
+                    let air_ref = air.add_inst(AirInst {
+                        data: AirInstData::Const(0),
+                        ty: Type::U64,
+                        span,
+                    });
+                    return Ok(AnalysisResult::new(air_ref, Type::U64));
+                }
+                return Err(CompileError::new(
+                    ErrorKind::FieldAccessOnNonStruct {
+                        found: self.format_type_name(ty),
+                    },
+                    span,
+                ));
+            }
+        };
+
+        let struct_def = self.type_pool.struct_def(struct_id);
+        let field_name_str = self.interner.resolve(&field);
+        let field_index = match struct_def.find_field(field_name_str) {
+            Some((index, _)) => index,
+            None => {
+                return Err(CompileError::new(
+                    ErrorKind::UnknownField {
+                        struct_name: struct_def.name.clone(),
+                        field_name: field_name_str.to_string(),
+                    },
+                    span,
+                ));
+            }
+        };
+
+        // Sum the slot counts of every field preceding `field`, then scale by
+        // the 8-byte slot size. Cloning the field types first keeps the
+        // immutable borrow of `struct_def` from colliding with `abi_slot_count`
+        // (which borrows `self`).
+        let preceding_field_types: Vec<Type> = struct_def
+            .fields
+            .iter()
+            .take(field_index)
+            .map(|f| f.ty)
+            .collect();
+        let slot_offset: u32 = preceding_field_types
+            .iter()
+            .map(|&fty| self.abi_slot_count(fty))
+            .sum();
+        let byte_offset = (slot_offset as u64) * 8;
+
+        let air_ref = air.add_inst(AirInst {
+            data: AirInstData::Const(byte_offset),
+            ty: Type::U64,
+            span,
+        });
+        Ok(AnalysisResult::new(air_ref, Type::U64))
     }
 
     /// Analyze an intrinsic call.

--- a/crates/rue-air/src/sema/consistency_tests.rs
+++ b/crates/rue-air/src/sema/consistency_tests.rs
@@ -61,6 +61,7 @@ mod tests {
         "Call",
         "Intrinsic",
         "TypeIntrinsic",
+        "OffsetOf",
         "ParamRef",
         "Ret",
         // Blocks

--- a/crates/rue-air/src/sema/known_symbols.rs
+++ b/crates/rue-air/src/sema/known_symbols.rs
@@ -91,6 +91,9 @@ pub struct KnownSymbols {
     pub raw: Spur,
     /// The `raw_mut` intrinsic symbol - takes mutable address of lvalue.
     pub raw_mut: Spur,
+    /// The `field_ptr` intrinsic symbol - raw `ptr mut` to a struct field place
+    /// without forming a reference (RUE-301), the `&raw mut (*p).field` analog.
+    pub field_ptr: Spur,
     /// The `syscall` intrinsic symbol - direct OS syscall.
     pub syscall: Spur,
     /// The `alloc` intrinsic symbol - allocate an uninitialized heap block
@@ -147,6 +150,7 @@ impl KnownSymbols {
             int_to_ptr: interner.get_or_intern_static("int_to_ptr"),
             raw: interner.get_or_intern_static("raw"),
             raw_mut: interner.get_or_intern_static("raw_mut"),
+            field_ptr: interner.get_or_intern_static("field_ptr"),
             syscall: interner.get_or_intern_static("syscall"),
             alloc: interner.get_or_intern_static("alloc"),
             free: interner.get_or_intern_static("free"),

--- a/crates/rue-cli-tests/cases/offset_of_field_ptr.toml
+++ b/crates/rue-cli-tests/cases/offset_of_field_ptr.toml
@@ -1,0 +1,171 @@
+# Compiler-mediated field access through the real driver (RUE-301).
+#
+# Exercises @offset_of (comptime byte offset of a struct field) and @field_ptr
+# (a raw `ptr mut` to a field place) end-to-end: correct offsets for mixed
+# scalar / array / nested-struct layouts, read/write round-trips through a
+# field pointer, and agreement between @offset_of + @ptr_offset and a direct
+# field access. These are the primitives that let unchecked code walk a struct
+# without hardcoding the 8-byte-slot layout (RUE-288). The `differential_opt`
+# cases also assert identical results across -O0..-O3 (constant offsets must
+# not be miscompiled by the optimizer).
+
+[section]
+id = "cli.offset_of_field_ptr"
+name = "@offset_of / @field_ptr"
+description = "Compiler-mediated field offsets and field pointers via the CLI driver."
+
+# @offset_of returns the byte offset of each field under the current 8-byte
+# slot layout. i32 `a` occupies one slot, so `b` is at byte 8 and `c` at 16.
+[[case]]
+name = "offset_of_mixed_scalars"
+files = [{ path = "main.rue", source = """
+struct Mixed { a: i32, b: i64, c: bool }
+fn main() -> i32 {
+    let oa: u64 = @offset_of(Mixed, a);
+    let ob: u64 = @offset_of(Mixed, b);
+    let oc: u64 = @offset_of(Mixed, c);
+    @dbg(oa);
+    @dbg(ob);
+    @dbg(oc);
+    0
+}
+""" }]
+stdout = "0\n8\n16\n"
+exit_code = 0
+
+# Multi-slot preceding fields (an array and a nested struct) shift later
+# offsets by their full slot count.
+[[case]]
+name = "offset_of_array_and_nested"
+files = [{ path = "main.rue", source = """
+struct Inner { x: i32, y: i32 }
+struct Outer { flag: bool, arr: [i32; 3], inner: Inner, last: i64 }
+fn main() -> i32 {
+    @dbg(@offset_of(Outer, flag) == 0);
+    @dbg(@offset_of(Outer, arr) == 8);
+    @dbg(@offset_of(Outer, inner) == 32);
+    @dbg(@offset_of(Outer, last) == 48);
+    0
+}
+""" }]
+stdout = "true\ntrue\ntrue\ntrue\n"
+exit_code = 0
+
+# @field_ptr read round-trip: the pointer observes the same value as the direct
+# field access, for both the first field (offset 0) and a later field.
+[[case]]
+name = "field_ptr_read_roundtrip"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+struct Mixed { a: i32, b: i64, c: bool }
+fn main() -> i32 {
+    let m = Mixed { a: 11, b: 22, c: true };
+    let a: i32 = checked { @ptr_read(@field_ptr(m.a)) };
+    let b: i64 = checked { @ptr_read(@field_ptr(m.b)) };
+    @dbg(a);
+    @dbg(b);
+    let bi: i32 = @intCast(b);
+    a + bi
+}
+""" }]
+stdout = "11\n22\n"
+exit_code = 33
+
+# @field_ptr yields a mutable pointer: writing through it updates the field in
+# place, observable via a later direct read.
+[[case]]
+name = "field_ptr_write_updates_field"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+struct Pair { a: i32, b: i32 }
+fn main() -> i32 {
+    let mut p = Pair { a: 7, b: 9 };
+    checked {
+        let fp: ptr mut i32 = @field_ptr(p.b);
+        @ptr_write(fp, 100);
+    };
+    @dbg(p.a);
+    @dbg(p.b);
+    p.b
+}
+""" }]
+stdout = "7\n100\n"
+exit_code = 100
+
+# @offset_of + @ptr_offset over the struct base reaches the same field as
+# @field_ptr and as a direct access — the layout-agnostic navigation RUE-301
+# unlocks. `Cell` has two i64 fields, so element-stride @ptr_offset(base, 1)
+# lands exactly on the second field (offset 8).
+[[case]]
+name = "offset_of_ptr_offset_agrees_with_field_ptr"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+struct Cell { first: i64, second: i64 }
+fn main() -> i32 {
+    let c = Cell { first: 40, second: 2 };
+    let via_field_ptr: i64 = checked { @ptr_read(@field_ptr(c.second)) };
+    let via_offset: i64 = checked {
+        let base: ptr const i64 = @raw(c.first);
+        // second is at byte offset 8 == one i64 element from base.
+        @ptr_read(@ptr_offset(base, 1))
+    };
+    @dbg(via_field_ptr == via_offset);
+    @dbg(via_field_ptr == c.second);
+    let s: i32 = @intCast(via_field_ptr);
+    s
+}
+""" }]
+stdout = "true\ntrue\n"
+exit_code = 2
+
+# @field_ptr on a struct received by value as a parameter addresses the
+# parameter's own storage; reading it matches the field.
+[[case]]
+name = "field_ptr_on_param_struct"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+struct Point { x: i32, y: i32 }
+fn second(p: Point) -> i32 {
+    checked { @ptr_read(@field_ptr(p.y)) }
+}
+fn main() -> i32 {
+    let pt = Point { x: 3, y: 44 };
+    let r: i32 = second(pt);
+    @dbg(r);
+    r
+}
+""" }]
+stdout = "44\n"
+exit_code = 44
+
+# @field_ptr requires a field-access expression; a bare variable is E0490.
+[[case]]
+name = "field_ptr_rejects_bare_variable"
+files = [{ path = "main.rue", source = """
+struct Pair { a: i32, b: i32 }
+fn main() -> i32 {
+    let p = Pair { a: 7, b: 9 };
+    let v: u64 = checked {
+        let fp = @field_ptr(p);
+        @ptr_to_int(fp)
+    };
+    @intCast(v)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0490", "field access"]
+
+# @field_ptr outside a checked block is rejected like the other raw-pointer
+# intrinsics.
+[[case]]
+name = "field_ptr_requires_checked"
+files = [{ path = "main.rue", source = """
+struct Pair { a: i32, b: i32 }
+fn main() -> i32 {
+    let p = Pair { a: 7, b: 9 };
+    let fp: ptr mut i32 = @field_ptr(p.a);
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E1300", "checked"]

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -2448,8 +2448,12 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Physical(Reg::X0),
                     });
                     self.value_map.insert(value, result_vreg);
-                } else if name_str == "raw" || name_str == "raw_mut" {
-                    // @raw(lvalue) / @raw_mut(lvalue) - Take address of a value
+                } else if name_str == "raw" || name_str == "raw_mut" || name_str == "field_ptr" {
+                    // @raw(lvalue) / @raw_mut(lvalue) / @field_ptr(s.field) -
+                    // Take the address of a place. @field_ptr (RUE-301) is the
+                    // field-restricted form; its operand analyzes to a field
+                    // PlaceRead, so it flows through the same PlaceRead arm
+                    // below (lower_place_addr computes the field's address).
                     // The argument should be a local variable, and we compute its stack address.
                     let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                     let lvalue_val = args[0];

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -2787,8 +2787,12 @@ impl<'a> CfgLower<'a> {
                         src: Operand::Physical(Reg::Rax),
                     });
                     self.value_map.insert(value, result_vreg);
-                } else if name_str == "raw" || name_str == "raw_mut" {
-                    // @raw(lvalue) / @raw_mut(lvalue) - Take address of a value
+                } else if name_str == "raw" || name_str == "raw_mut" || name_str == "field_ptr" {
+                    // @raw(lvalue) / @raw_mut(lvalue) / @field_ptr(s.field) -
+                    // Take the address of a place. @field_ptr (RUE-301) is the
+                    // field-restricted form; its operand analyzes to a field
+                    // PlaceRead, so it flows through the same PlaceRead arm
+                    // below (lower_place_addr computes the field's address).
                     // The argument should be a local variable, and we compute its stack address.
                     let args = self.ctx.cfg.get_extra(*args_start, *args_len);
                     let lvalue_val = args[0];

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -212,6 +212,12 @@ impl ErrorCode {
     /// (ADR-0037, ADR-0043, RUE-322): it may only name a function parameter,
     /// so it cannot be bound past its argument scope.
     pub const SLICE_ESCAPES_SCOPE: Self = Self(489);
+    /// `@field_ptr(...)` was applied to something other than a field-access
+    /// expression `s.field` (RUE-301). `@field_ptr` is *compiler-mediated
+    /// field access*: it forms a raw pointer to the field the compiler placed,
+    /// so its operand MUST name a struct field. Use `@raw`/`@raw_mut` for the
+    /// address of a whole variable or array element.
+    pub const FIELD_PTR_REQUIRES_FIELD: Self = Self(490);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -1132,6 +1138,9 @@ pub enum ErrorKind {
         "@raw requires an addressable place (a variable, field, or array element), not a temporary value"
     )]
     RawRequiresPlace,
+    /// `@field_ptr` operand is not a field-access expression `s.field`
+    #[error("@field_ptr requires a field access expression (for example `s.field`)")]
+    FieldPtrRequiresField,
     /// Inout argument is not an lvalue (variable, field, or array element)
     #[error("inout argument must be an lvalue (variable, field, or array element)")]
     InoutNonLvalue,
@@ -1428,6 +1437,7 @@ impl ErrorKind {
             ErrorKind::FieldAccessOnNonStruct { .. } => ErrorCode::FIELD_ACCESS_ON_NON_STRUCT,
             ErrorKind::InvalidAssignmentTarget => ErrorCode::INVALID_ASSIGNMENT_TARGET,
             ErrorKind::RawRequiresPlace => ErrorCode::RAW_REQUIRES_PLACE,
+            ErrorKind::FieldPtrRequiresField => ErrorCode::FIELD_PTR_REQUIRES_FIELD,
             ErrorKind::InoutNonLvalue => ErrorCode::INOUT_NON_LVALUE,
             ErrorKind::InoutExclusiveAccess { .. } => ErrorCode::INOUT_EXCLUSIVE_ACCESS,
             ErrorKind::BorrowNonLvalue => ErrorCode::BORROW_NON_LVALUE,

--- a/crates/rue-linker/src/elf.rs
+++ b/crates/rue-linker/src/elf.rs
@@ -493,8 +493,19 @@ impl ObjectFile {
                         let size = read_u64(data, sect_offset + 40);
                         // offset: u32 at offset 48
                         let offset = read_u32(data, sect_offset + 48) as usize;
-                        // align: u32 at offset 52
-                        let align = 1u64 << read_u32(data, sect_offset + 52);
+                        // align: u32 at offset 52. Mach-O stores alignment as a
+                        // power-of-2 exponent; `1 << exp` is UB / panics for an
+                        // exponent >= 64 (a malformed or oversized field). Use a
+                        // checked shift and reject out-of-range values with a
+                        // clean error, mirroring the ELF path's checked
+                        // arithmetic (RUE-334).
+                        let align_exp = read_u32(data, sect_offset + 52);
+                        let Some(align) = 1u64.checked_shl(align_exp) else {
+                            return Err(ParseError::InvalidSection(format!(
+                                "section {} has out-of-range alignment exponent {}",
+                                full_name, align_exp
+                            )));
+                        };
                         // reloff: u32 at offset 56
                         let reloff = read_u32(data, sect_offset + 56) as usize;
                         // nreloc: u32 at offset 60
@@ -514,12 +525,18 @@ impl ObjectFile {
                             section_flags |= SectionFlags::WRITE;
                         }
 
-                        // Read section data
+                        // Read section data. Compute the end offset with a
+                        // checked add so a malformed offset/size near usize::MAX
+                        // is rejected instead of wrapping (RUE-334), mirroring
+                        // the ELF path's checked_add bounds validation.
                         let section_data = if size > 0 && offset > 0 {
-                            if offset + size as usize > data.len() {
+                            let end = offset
+                                .checked_add(size as usize)
+                                .ok_or_else(|| ParseError::SectionOutOfBounds(full_name.clone()))?;
+                            if end > data.len() {
                                 return Err(ParseError::SectionOutOfBounds(full_name.clone()));
                             }
-                            data[offset..offset + size as usize].to_vec()
+                            data[offset..end].to_vec()
                         } else {
                             Vec::new()
                         };
@@ -563,9 +580,16 @@ impl ObjectFile {
         // Parse symbols
         let mut symbols = Vec::new();
         if symtab_count > 0 {
-            // Verify bounds
-            let symtab_end = symtab_offset + symtab_count * MACHO64_NLIST_SIZE;
-            let strtab_end = strtab_offset + strtab_size;
+            // Verify bounds. Compute the table ends with checked mul/add so a
+            // malformed count/offset can't overflow and wrap past the length
+            // check (RUE-334), mirroring the ELF path's checked arithmetic.
+            let symtab_end = symtab_count
+                .checked_mul(MACHO64_NLIST_SIZE)
+                .and_then(|n| symtab_offset.checked_add(n))
+                .ok_or_else(|| ParseError::InvalidSymbol("symbol table out of bounds".into()))?;
+            let strtab_end = strtab_offset
+                .checked_add(strtab_size)
+                .ok_or_else(|| ParseError::InvalidSymbol("string table out of bounds".into()))?;
             if symtab_end > data.len() || strtab_end > data.len() {
                 return Err(ParseError::InvalidSymbol(
                     "symbol table out of bounds".into(),
@@ -683,7 +707,12 @@ impl ObjectFile {
                 continue;
             }
 
-            let reloc_end = reloff + nreloc * MACHO64_RELOC_SIZE;
+            // Checked mul/add so a malformed nreloc/reloff can't overflow past
+            // the length check (RUE-334), mirroring the ELF reloc bounds guard.
+            let reloc_end = nreloc
+                .checked_mul(MACHO64_RELOC_SIZE)
+                .and_then(|n| reloff.checked_add(n))
+                .ok_or(ParseError::RelocationOutOfBounds)?;
             if reloc_end > data.len() {
                 return Err(ParseError::RelocationOutOfBounds);
             }
@@ -1683,6 +1712,48 @@ mod tests {
             ObjectFile::parse(&data),
             Err(ParseError::TooShort)
         ));
+    }
+
+    /// RUE-334: an out-of-range Mach-O section alignment exponent must be
+    /// rejected with a clean Err, not overflow the `1 << exp` shift (which
+    /// panics in debug / is UB in release). The parser's shift is now checked.
+    #[test]
+    fn test_macho_out_of_range_alignment() {
+        let mut obj_bytes = build_test_macho(
+            &[TestMachoSection {
+                sectname: "__text",
+                segname: "__TEXT",
+                addr: 0,
+                data: vec![0u8; 8],
+                relocs: vec![],
+            }],
+            &[],
+        );
+
+        // The align field is a u32 at offset 52 within section 0's header,
+        // which begins right after the segment command.
+        let align_field = MACHO64_HEADER_SIZE + MACHO64_SEGMENT_CMD_SIZE + 52;
+
+        // Sanity: the unmodified object parses fine (align exponent 3).
+        assert!(ObjectFile::parse(&obj_bytes).is_ok());
+
+        // An exponent >= 64 would overflow `1u64 << exp`. Must be rejected.
+        obj_bytes[align_field..align_field + 4].copy_from_slice(&64_u32.to_le_bytes());
+        assert!(matches!(
+            ObjectFile::parse(&obj_bytes),
+            Err(ParseError::InvalidSection(_))
+        ));
+
+        // u32::MAX is the pathological worst case; also cleanly rejected.
+        obj_bytes[align_field..align_field + 4].copy_from_slice(&u32::MAX.to_le_bytes());
+        assert!(matches!(
+            ObjectFile::parse(&obj_bytes),
+            Err(ParseError::InvalidSection(_))
+        ));
+
+        // Exponent 63 is the largest in-range value and must still parse.
+        obj_bytes[align_field..align_field + 4].copy_from_slice(&63_u32.to_le_bytes());
+        assert!(ObjectFile::parse(&obj_bytes).is_ok());
     }
 
     #[test]

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -689,6 +689,36 @@ impl<'a> AstGen<'a> {
                 let name = intrinsic.name.name; // Already a Spur
                 let intrinsic_name_str = self.interner.resolve(&name);
 
+                // `@offset_of(T, field)` (RUE-301) is compiler-mediated field
+                // addressing: the first argument names a struct type and the
+                // second names one of its fields. Both spell as bare
+                // identifiers (`Point`, `x`) — the parser hands them over as
+                // `Expr::Ident` (or the first as a `Type` when it is an
+                // unambiguous type form). Lower the pair into a dedicated
+                // `OffsetOf` node so Sema can compute the offset from the
+                // layout it assigns, rather than the user hardcoding a literal.
+                if intrinsic_name_str == "offset_of" && intrinsic.args.len() == 2 {
+                    let type_arg = match &intrinsic.args[0] {
+                        IntrinsicArg::Type(ty) => Some(self.intern_type(ty)),
+                        IntrinsicArg::Expr(Expr::Ident(ident)) => Some(ident.name),
+                        _ => None,
+                    };
+                    if let (Some(type_arg), IntrinsicArg::Expr(Expr::Ident(field))) =
+                        (type_arg, &intrinsic.args[1])
+                    {
+                        return self.rir.add_inst(Inst {
+                            data: InstData::OffsetOf {
+                                type_arg,
+                                field: field.name,
+                            },
+                            span: intrinsic.span,
+                        });
+                    }
+                    // Fall through to the generic expression-intrinsic path,
+                    // which surfaces a proper diagnostic (wrong argument shape)
+                    // during semantic analysis.
+                }
+
                 let is_type_intrinsic = TYPE_INTRINSICS.contains(&intrinsic_name_str);
 
                 if is_type_intrinsic && intrinsic.args.len() == 1 {

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -737,6 +737,10 @@ impl Rir {
                 name: *name,
                 type_arg: *type_arg,
             },
+            InstData::OffsetOf { type_arg, field } => InstData::OffsetOf {
+                type_arg: *type_arg,
+                field: *field,
+            },
 
             // Binary operations - renumber both operands
             InstData::Add { lhs, rhs } => InstData::Add {
@@ -1307,6 +1311,7 @@ impl Rir {
                 | InstData::IndexGet { .. }
                 | InstData::IndexSet { .. }
                 | InstData::TypeIntrinsic { .. }
+                | InstData::OffsetOf { .. }
                 | InstData::DropFnDecl { .. }
                 | InstData::Comptime { .. }
                 | InstData::Checked { .. }
@@ -1534,6 +1539,17 @@ pub enum InstData {
         name: Spur,
         /// Type argument (as an interned string, e.g., "i32", "Point", "[i32; 4]")
         type_arg: Spur,
+    },
+
+    /// `@offset_of(T, field)` — the compile-time byte offset of `field` within
+    /// struct type `T` (RUE-301). Carries a type argument (as an interned
+    /// string, exactly like [`InstData::TypeIntrinsic`]) and the field name;
+    /// neither is an `InstRef`, so this variant has no operands to renumber.
+    OffsetOf {
+        /// Type argument (as an interned string, e.g., "Point").
+        type_arg: Spur,
+        /// Field name whose offset is requested.
+        field: Spur,
     },
 
     /// Reference to a function parameter.
@@ -2081,6 +2097,11 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     let name_str = self.interner.resolve(&*name);
                     let type_str = self.interner.resolve(&*type_arg);
                     writeln!(out, "type_intrinsic @{}({})", name_str, type_str).unwrap();
+                }
+                InstData::OffsetOf { type_arg, field } => {
+                    let type_str = self.interner.resolve(&*type_arg);
+                    let field_str = self.interner.resolve(&*field);
+                    writeln!(out, "offset_of @offset_of({}, {})", type_str, field_str).unwrap();
                 }
                 InstData::ParamRef { index, name } => {
                     writeln!(out, "param {} ({})", index, self.interner.resolve(&*name)).unwrap();

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -410,6 +410,104 @@ fn main() -> i32 {
 exit_code = 0
 
 # =============================================================================
+# @offset_of Intrinsic (RUE-301)
+# =============================================================================
+
+[[case]]
+name = "offset_of_first_field_is_zero"
+spec = ["4.13:91", "4.13:92"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let off: u64 = @offset_of(Point, x);
+    @intCast(off)
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "offset_of_second_field"
+spec = ["4.13:91", "4.13:94"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let off: u64 = @offset_of(Point, y);
+    @intCast(off)
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "offset_of_returns_u64"
+spec = ["4.13:93"]
+source = """
+fn takes_u64(x: u64) -> u64 { x }
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let off: u64 = takes_u64(@offset_of(Point, y));
+    @intCast(off)
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "offset_of_accounts_for_multislot_fields"
+spec = ["4.13:94"]
+source = """
+struct Inner { x: i32, y: i32 }
+struct Outer { flag: bool, arr: [i32; 3], inner: Inner, last: i64 }
+fn main() -> i32 {
+    // flag: 1 slot -> arr at slot 1 (byte 8)
+    // arr: 3 slots -> inner at slot 4 (byte 32)
+    // inner: 2 slots -> last at slot 6 (byte 48)
+    if @offset_of(Outer, flag) != 0 { return 1; }
+    if @offset_of(Outer, arr) != 8 { return 2; }
+    if @offset_of(Outer, inner) != 32 { return 3; }
+    if @offset_of(Outer, last) != 48 { return 4; }
+    0
+}
+"""
+exit_code = 0
+
+[[case]]
+name = "offset_of_compile_time_const_context"
+spec = ["4.13:94"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    // @offset_of folds to a compile-time constant, like @size_of.
+    let off: u64 = @offset_of(Point, y);
+    @intCast(off)
+}
+"""
+exit_code = 8
+
+[[case]]
+name = "offset_of_non_struct_type_errors"
+spec = ["4.13:95"]
+source = """
+fn main() -> i32 {
+    let off: u64 = @offset_of(i32, a);
+    @intCast(off)
+}
+"""
+compile_fail = true
+error_contains = "non-struct"
+
+[[case]]
+name = "offset_of_unknown_field_errors"
+spec = ["4.13:95"]
+source = """
+struct Point { x: i32, y: i32 }
+fn main() -> i32 {
+    let off: u64 = @offset_of(Point, z);
+    @intCast(off)
+}
+"""
+compile_fail = true
+error_contains = "unknown field"
+
+# =============================================================================
 # @intCast Intrinsic
 # =============================================================================
 

--- a/crates/rue-spec/cases/runtime/pointers.toml
+++ b/crates/rue-spec/cases/runtime/pointers.toml
@@ -217,3 +217,94 @@ fn main() -> i32 {
 }
 """
 exit_code = 20
+
+# =============================================================================
+# @field_ptr — compiler-mediated field pointer (RUE-301)
+# =============================================================================
+
+# @field_ptr(s.field) yields a mutable raw pointer to the field; reading it
+# observes the same value as the direct field access (spec 9.2:15, 9.2:18).
+[[case]]
+name = "field_ptr_read_matches_direct"
+spec = ["9.2:15", "9.2:16", "9.2:18"]
+source = """
+struct Mixed { a: i32, b: i64, c: bool }
+fn main() -> i32 {
+    let m = Mixed { a: 11, b: 22, c: true };
+    let got: i64 = checked {
+        let p: ptr mut i64 = @field_ptr(m.b);
+        @ptr_read(p)
+    };
+    @intCast(got)
+}
+"""
+exit_code = 22
+
+# @field_ptr addresses the first field (offset 0) correctly too.
+[[case]]
+name = "field_ptr_first_field"
+spec = ["9.2:15", "9.2:18"]
+source = """
+struct Pair { a: i32, b: i32 }
+fn main() -> i32 {
+    let p = Pair { a: 7, b: 9 };
+    checked {
+        let fp: ptr mut i32 = @field_ptr(p.a);
+        @ptr_read(fp)
+    }
+}
+"""
+exit_code = 7
+
+# The pointer from @field_ptr is mutable: @ptr_write through it updates the
+# field in place (spec 9.2:18).
+[[case]]
+name = "field_ptr_write_updates_field"
+spec = ["9.2:18"]
+source = """
+struct Pair { a: i32, b: i32 }
+fn main() -> i32 {
+    let mut p = Pair { a: 7, b: 9 };
+    checked {
+        let fp: ptr mut i32 = @field_ptr(p.b);
+        @ptr_write(fp, 100);
+    };
+    p.b
+}
+"""
+exit_code = 100
+
+# @field_ptr requires a field-access expression; a bare variable is rejected
+# (spec 9.2:17).
+[[case]]
+name = "field_ptr_requires_field_access"
+spec = ["9.2:17"]
+source = """
+struct Pair { a: i32, b: i32 }
+fn main() -> i32 {
+    let p = Pair { a: 7, b: 9 };
+    let v: u64 = checked {
+        let fp = @field_ptr(p);
+        @ptr_to_int(fp)
+    };
+    @intCast(v)
+}
+"""
+compile_fail = true
+error_contains = "field access"
+
+# @field_ptr may only appear inside a checked block (spec 9.2:15, cross-ref
+# 9.1).
+[[case]]
+name = "field_ptr_requires_checked_block"
+spec = ["9.2:15"]
+source = """
+struct Pair { a: i32, b: i32 }
+fn main() -> i32 {
+    let p = Pair { a: 7, b: 9 };
+    let fp: ptr mut i32 = @field_ptr(p.a);
+    0
+}
+"""
+compile_fail = true
+error_contains = "checked"

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -42,6 +42,84 @@ fn main() -> i32 {
 exit_code = 0
 
 # =============================================================================
+# String Representation and Ownership
+# =============================================================================
+
+# 3.7:2 — a String is three machine words (ptr, len, capacity), 24 bytes.
+[[case]]
+name = "string_size_is_24"
+spec = ["3.7:2"]
+description = "@size_of(String) is 24: three machine words (ptr, len, capacity)."
+source = """
+fn main() -> i32 {
+    @size_of(String)
+}
+"""
+exit_code = 24
+
+# 3.7:39 — String is a move type: using it after a move is E0205.
+[[case]]
+name = "string_is_move_type"
+spec = ["3.7:39"]
+description = "String is an affine (move) type; use after move is a compile error."
+source = """
+fn main() -> i32 {
+    let a = "hello";
+    let b = a;      // 'a' is moved into 'b'
+    @dbg(a);        // ERROR: use of moved value 'a'
+    @dbg(b);
+    0
+}
+"""
+compile_fail = true
+error_contains = "use of moved value"
+
+# 3.7:39 — String is not a Copy type, so a @copy struct cannot hold one.
+[[case]]
+name = "string_not_copy_field"
+spec = ["3.7:39"]
+description = "String is not Copy: a @copy struct with a String field is rejected."
+source = """
+@copy
+struct Bad { s: String }
+
+fn main() -> i32 {
+    0
+}
+"""
+compile_fail = true
+error_contains = "non-Copy type 'String'"
+
+# 3.7:39 — an unused String is dropped implicitly (affine, not linear).
+[[case]]
+name = "string_dropped_implicitly"
+spec = ["3.7:39"]
+description = "A String need not be explicitly consumed; an unused one drops at scope end."
+source = """
+fn main() -> i32 {
+    let _s = "foo" + "bar";   // heap-allocated, never used again
+    0
+}
+"""
+exit_code = 0
+
+# 3.7:40 — a heap-owning String is freed exactly once; the program runs cleanly.
+[[case]]
+name = "string_heap_freed_once"
+spec = ["3.7:40"]
+description = "A heap-allocated String is dropped once (no double free); program runs to completion."
+source = """
+fn main() -> i32 {
+    let a = "foo" + "bar";   // heap-allocated: capacity > 0
+    let b = a;               // ownership moves to 'b'
+    @dbg(b);                 // foobar
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "foobar\n"
+
+# =============================================================================
 # String Escape Sequences
 # =============================================================================
 

--- a/docs/formal/01-core-calculus.md
+++ b/docs/formal/01-core-calculus.md
@@ -639,62 +639,513 @@ resolve at the call.
 
 ---
 
-## 6. Dynamic semantics (small-step) *(sketch — shape fixed, rules being filled in)*
+## 6. Dynamic semantics (small-step)
 
-The machine configuration:
+This section gives the small-step operational semantics for **every** core form
+of §2. It is the paper form of `crates/rue-oracle` — the executable reference
+interpreter that runs a core program and produces its exit code, its `@dbg`
+output, its panics, and its drop trace, and is differential-tested against the
+compiler on the RUE-50 corpus. Each rule group below cites the oracle function
+that realizes it (`crates/rue-oracle/src/lib.rs`), so the paper semantics and the
+executable semantics are one artifact read two ways: **the thing that governs the
+spec is the thing we can run.** Where a rule and the interpreter disagree, one of
+them is a bug (RUE-305) — that is the point of pinning both.
+
+> The oracle interprets over the compiler's typed **CFG**, not directly over the
+> §2 surface AST; the CFG is that AST after control flow is made explicit
+> (`if`/`match`/`loop` become `Branch`/`Switch`/`Goto`, `let`/`;` become straight-
+> line SSA). The reduction below is over the §2 forms; the correspondence is the
+> obvious one, noted per group. Any place where the two could observably differ
+> is a differential-test obligation.
+
+### 6.1 The machine configuration
 
 ```
-  Config  =  ⟨ H ; K ; e ⟩
-    H : Loc ⇀ StoredValue          -- the store: locations to values (scalars, struct/array aggregates, tagged enum values ⟨Kj; payload⟩)
-    K : evaluation context / control stack   -- holds pending frames, loop and function boundaries,
-                                                and the per-scope list of drop obligations
-    e : the expression being reduced
-  Env  :  x ⇀ Loc                  -- carried per frame in K; binds each live local to its storage
+  Locations      ℓ ∈ Loc                    -- one storage cell per live let-binding or by-value parameter
+  Cell contents  c ::= v | ⊘                 -- ⊘ = uninitialised / moved-out (the dynamic image of Σ's absence/MovedOut, §5)
+  Store          H : Loc ⇀ c
+  Values         v ::= n_T                    -- a scalar integer n of type T = int(w,s), with min_T ≤ n ≤ max_T
+                     | b                       -- b ∈ { true, false }
+                     | ⟨⟩                      -- unit
+                     | { v1, …, vk }_S         -- a struct-S value (fields in declaration order)
+                     | [ v1, …, vn ]           -- an array value (elements in ascending index)
+                     | Kj⟨ v1, …, va ⟩         -- an enum value: variant tag Kj (0-based index j) + payload v1..va (a = 0 ⇒ just the tag)
+  Environment    ρ : Var ⇀ Loc               -- per frame: each in-scope binding → its cell
+  Scope record   s = [ℓ1, …, ℓq]             -- cells owed a drop at this scope's exit, in creation order (dropped newest-first)
+  Frame          φ = ⟨ ρ ; σ ⟩ ,  σ = [s1, …, sr]   -- a stack of r ≥ 1 open scopes; σ's top is the innermost scope
+  Control stack  K ::= halt                    -- bottom: nothing pending; a returned value is the program result
+                     | ret(E, φ) · K           -- a caller suspended in evaluation context E (§6.2), frame φ, awaiting a callee's value
+                     | loopβ(e_body, φ) · K    -- a loop boundary: its body e_body and the frame φ to resume; break unwinds to here
+  Config         C ::= ⟨ H ; φ ; K ; e ⟩       -- active frame φ evaluating expression e
+                     | ↯κ                        -- halted in a trap of category κ ∈ { overflow, div-zero, rem-zero, bounds } (exit 101)
+                     | ✓n                        -- halted normally with process exit code n
 ```
 
-Reduction `⟨H;K;e⟩ → ⟨H';K';e'⟩` is small-step and left-to-right per §4.0-order of
-the prose (`4.0:3–9`), which the core inherits verbatim. The load-bearing,
-Rue-specific rules — the ones an alternate compiler and a proof both need
-pinned — are:
+The reduction relation is `C → C'`. The store `H` is global (locations never
+alias across frames except through the by-reference sharing of §6.9); `φ` and `K`
+carry the per-call control state the sketch attributed to `K`. This matches the
+oracle's `Interp`/`Frame` (`lib.rs:132`, `lib.rs:141`): a `Frame` is `φ`, its
+`locals`/`params` vectors are the cells reachable through `ρ`, and its evaluation
+proceeds block-by-block exactly as `E`-decomposition proceeds redex-by-redex.
 
-- **Use/Move (read a place in value context).** Reads the aggregate at the
-  place's location. For a moved place this rule is *unreachable* in a well-typed
-  program (that is the safety theorem, §7); the interpreter still asserts
-  `Owned`-ness dynamically to serve as the oracle.
-- **Drop.** When a scope's frame is popped (or a place is overwritten, or a loop
-  body iterates), the drop obligations recorded for that scope run: for each
-  Owned droppable place, in `3.9` order, run its destructor then recursively drop
-  its contents — a struct's fields and an array's elements, or, for an **enum**,
-  *only the payload of the variant its stored tag names* (`6.3:20`); **a
-  `MovedOut` place is skipped** (this single skip is what makes double-free
-  impossible — §7). The enum case reads the tag from the store `H` to choose the
-  one payload to recurse into: an inactive variant's payload has no storage to
-  free, and a discriminant-only active variant drops nothing.
-- **Match / variant.** `E::Kj(v1, ..., va)` is a stored value carrying tag `Kj`
-  and its payload aggregate. `match v { ..., Kj(x1, ..., xa) => ej, ... }` reads
-  the tag, selects the arm for `Kj`, **binds `x1..xa` to the payload components**
-  (moving them out of the enum for a move-typed payload, copying for a Copy one),
-  and reduces `ej`; the other arms and their bindings never come into being. The
-  scrutinee value is consumed by the match, so it is not dropped again — the
-  moved-out payload is now owned by the arm's locals, which drop (or must be
-  consumed) at the arm's end per §5.6. Construction `E::Kj(e1, ..., ea)` evaluates
-  the payloads left-to-right and stores the tagged aggregate.
-- **Call / Return.** A call evaluates arguments (moving/copying by-value ones,
-  binding by-reference ones to the caller's locations via the loan), pushes a
-  frame binding parameters, and reduces the body; the call **evaluates to the
-  value the body evaluates to**; `return e` discards intervening frames up to the
-  function boundary and yields `e`'s value. (This is §4.3 made operational.)
-- **inout / borrow.** The parameter's location *is* the argument place's location
-  (no copy); writes through an `inout` parameter are visible to the caller after
-  return (`6.1:18`); a `borrow` parameter's location is read-only for the callee.
-- **Overflow / bounds / div-zero.** Arithmetic that overflows the operands' type,
-  an out-of-range index, and division/remainder by zero each step to a **panic**
-  configuration that halts with the exit code of Appendix B (`3.1:6/13`,
-  `8.1`–`8.3`). These are total, deterministic, and observable — an alternate
-  compiler must reproduce them exactly.
+`n_T` records the value's integer type because overflow, comparison signedness,
+and bitwise width all depend on it; the oracle carries the same information out of
+band on each CFG instruction's `ty` (`lib.rs:415`). A discriminant-only enum value
+`Kj⟨⟩` is stored as its bare tag (the oracle's `Value::Int` tag, `lib.rs:565`); a
+payload-carrying `Kj⟨v1..va⟩` as the tagged aggregate (`lib.rs:559`, RUE-285).
 
-The interpreter implementing this relation is the executable oracle (README §
-"The executable oracle" / RUE-50).
+Four **scope helpers** on frames, used by the rules below, all defined in terms of
+the drop relation `drop(H, ℓ)` of §6.11 (which is itself a no-op on a `⊘` or
+`Copy` cell, so these fold harmlessly over non-droppable bindings):
+
+```
+  push-scope(⟨ρ;σ⟩)              = ⟨ρ; [] :: σ⟩                    -- open a fresh, empty innermost scope
+  run-scope-drops(H, ⟨ρ; s::σ⟩) = drop the cells of s newest-first, yielding H'; result frame ⟨ρ; σ⟩   -- close ONE (innermost) scope
+  run-all-scope-drops(H, φ)      = iterate run-scope-drops until φ has no open scopes (whole-frame teardown, on return)
+  unwind-drops(H, φ', φ)         = run-scope-drops repeatedly on φ' until its open-scope stack equals φ's (break: down to a boundary)
+```
+
+A scope gains a cell to drop when a `let` (§6.7) or a `match` arm (§6.6) binds one;
+`inout`/`borrow` parameters are deliberately never recorded (§6.9), which is how
+they escape the drop obligation (§5.6).
+
+### 6.2 Evaluation order: contexts, search, and panic propagation
+
+Evaluation is left-to-right, inheriting the prose order `4.0:3–9` verbatim (the
+same order §5 threads Σ through). This is fixed by a grammar of single-hole
+**evaluation contexts** `E`, whose hole marks the one subexpression reduced next:
+
+```
+  E ::= [·]
+      | E ⊕ e  | v ⊕ E                                   -- arithmetic / bitwise / shift operands, left then right
+      | E ≟ e  | v ≟ E                                   -- equality operands (the operand is BORROWED, not moved — §6.3)
+      | ⊖ E                                              -- unary neg / not / bitnot
+      | S{ f1=v1, …, f_{i-1}=v_{i-1}, fi=E, f_{i+1}=e, … }  -- struct field i (earlier fields already values)
+      | [ v1, …, v_{i-1}, E, e_{i+1}, … ]                -- array element i
+      | Kj( v1, …, v_{i-1}, E, e_{i+1}, … )              -- enum payload component i
+      | E . f  | E [ e ]  | v [ E ]                       -- projection base, then index
+      | g( v̄, …, E, … )                                  -- a by-VALUE call argument (a by-ref arg is a place, not reduced — §6.9)
+      | if E { e1 } else { e2 }                          -- scrutinee
+      | match E { … }                                    -- scrutinee
+      | let x = E ; e2                                   -- bound expression (e2 not entered until E is a value)
+      | E ; e2                                           -- discarded expression
+      | assign p = E                                     -- right-hand side (p's index subexpressions reduce first, below)
+      | return E
+```
+
+A place `p` used in value context (the `e ::= p` production) is a redex once its
+index subexpressions are values; the contexts `E[e]`/`v[E]` reduce those indices
+left-to-right first (as `resolve_path` does, `lib.rs:858`). The two structural
+rules that drive every reduction:
+
+```
+  ⟨ H ; φ ; K ; r ⟩ → ⟨ H' ; φ' ; K' ; e' ⟩          -- r is a redex reduced by a §6.3–§6.11 rule
+  ───────────────────────────────────────────────────────────────── (Search)
+  ⟨ H ; φ ; K ; E[r] ⟩ → ⟨ H' ; φ' ; K' ; E[e'] ⟩
+
+  a redex rule fires ↯κ                                -- a trap (§6.12)
+  ─────────────────────────────────── (Panic-Lift)     -- for any context E
+  ⟨ H ; φ ; K ; E[r] ⟩ → ↯κ
+```
+
+(Search) also carries `Call`/`Return`/`break` steps that rewrite `φ`/`K`; those
+appear below with the frame explicit. (Panic-Lift) is why a trap anywhere
+abandons the whole configuration: a panic is not a value and no context can
+consume it, so it propagates to the top and halts (`Interp::run`, `lib.rs:172`).
+
+### 6.3 Literals and the use of a place (copy / move)
+
+A literal is already a value; it takes no step except to *be* one. Its width and
+signedness were resolved by elaboration (§5.8), so the machine stores the concrete
+`n_T` / `b` / `⟨⟩` (`Const`/`BoolConst`, `lib.rs:417`).
+
+Using a place `p` in value context is the operational side of §4.2 / §5.1. Let
+`p` resolve, under ρ, to a root cell `ℓ` and an evaluated projection path `π`
+(field indices and already-reduced array indices, §6.2); write `H(ℓ)@π` for the
+sub-value reached by following `π` into `H(ℓ)`, and `H[ℓ@π ↦ ⊘]` for the store
+with that sub-position replaced by the moved-out marker. Reading navigates the
+stored aggregate exactly as `place_read` does (`lib.rs:892`).
+
+```
+  ρ(root(p)) = ℓ      H(ℓ)@π = v      class(T) = Copy           -- T the type of p (§5)
+  ─────────────────────────────────────────────────────────────────── (D-Use-Copy)
+  ⟨ H ; φ ; K ; p ⟩ → ⟨ H ; φ ; K ; v ⟩                         -- the cell is left untouched
+
+  ρ(root(p)) = ℓ      H(ℓ)@π = v      class(T) ∈ {Affine, Linear}
+  ─────────────────────────────────────────────────────────────────── (D-Use-Move)
+  ⟨ H ; φ ; K ; p ⟩ → ⟨ H[ℓ@π ↦ ⊘] ; φ ; K ; v ⟩               -- whole- or partial-place move; source becomes ⊘
+```
+
+`(D-Use-Move)` writes `⊘` at exactly the sub-position moved (the whole cell for a
+whole-place use, one field/element for a projection — the *partial move* of
+§4.2), so the later scope-exit drop of `ℓ` (§6.11) skips it and cannot free it a
+second time. In a **well-typed** program `H(ℓ)@π` is never `⊘` when a use fires —
+that is the no-use-after-move theorem (§7); the oracle nonetheless treats a read
+of an absent cell as a hard error (`get_local`, `lib.rs:845`) so a violation is
+caught rather than masked. The oracle achieves the `⊘`-marking *statically* — the
+compiler's drop elaboration omits the drop of a moved place, so no runtime marker
+is needed (`run_drop`'s note, `lib.rs:344`); the paper machine marks it
+dynamically. The two are observably identical: the same values are dropped the
+same number of times.
+
+Equality operands are the exception (§4.1, §5.4, `4.3:3f`): the operand place is
+**read through a shared loan and not moved**, so even an `Affine`/`Linear`
+operand steps by `(D-Use-Copy)` in the `E ≟ e` / `v ≟ E` positions, leaving its
+cell `Owned`. This is the dynamic image of the equality-borrow side condition; the
+oracle simply reads both operands without disturbing storage (`cmp`, `lib.rs:762`).
+
+### 6.4 Primitive operators
+
+All operands are `Copy` scalars, already reduced to `n_T` (or `b`) by §6.2.
+
+**Arithmetic `+ - *` and unary `neg`** compute over ℤ and **trap on overflow** —
+Rue arithmetic never wraps (`3.1:6/13`). Let `n1 ⊕_ℤ n2` be the exact integer
+result:
+
+```
+  min_T ≤ (n1 ⊕_ℤ n2) ≤ max_T          ⊕ ∈ { +, -, * }
+  ───────────────────────────────────────────────────── (D-Arith)
+  (n1)_T ⊕ (n2)_T  →  (n1 ⊕_ℤ n2)_T
+
+  (n1 ⊕_ℤ n2) < min_T   or   (n1 ⊕_ℤ n2) > max_T
+  ───────────────────────────────────────────────────── (D-Arith-Trap)
+  (n1)_T ⊕ (n2)_T  →  ↯overflow
+```
+
+`(D-Arith)`/`(D-Arith-Trap)` are `arith` + `range_check` (`lib.rs:713`,
+`lib.rs:1037`): the interpreter computes in `i128` (wide enough that no host
+overflow precedes the range check) and traps when the result leaves `[min_T,
+max_T]`. `neg` is the unary case: `neg (min_T)_T → ↯overflow` because `-min_T >
+max_T` for a signed `T` (`Neg`, `lib.rs:484`).
+
+**Division and remainder `/ %`** add two extra traps before the range check
+(`divmod`, `lib.rs:727`):
+
+```
+  n2 ≠ 0    ¬(s = signed ∧ n1 = min_T ∧ n2 = -1)      q = n1 quot n2 (truncated toward zero)
+  ───────────────────────────────────────────────────────────────────────────── (D-Div)
+  (n1)_{int(w,s)} / (n2)_{int(w,s)}  →  (q)_{int(w,s)}
+
+  (n2)_T = 0_T                                    ───────────────────────── (D-Div-Zero)
+                                                  (n1)_T / (n2)_T → ↯div-zero
+
+  s = signed    n1 = min_T    n2 = -1             ─────────────────────────── (D-Div-Overflow)
+                                                  (n1)_T / (n2)_T → ↯overflow
+```
+
+`%` is identical with `q` the truncated remainder `n1 rem n2`, trapping
+`↯rem-zero` on a zero divisor and `↯overflow` on `min_T % -1` (the hardware
+`idiv` faults there even though the mathematical remainder is 0 — `lib.rs:748`).
+
+**Comparison `≟` and the ordering compares `< > <= >=`** yield `bool`
+(`cmp`, `lib.rs:762`). Scalars compare by their integer value, respecting
+signedness (the value `n_T` already carries the sign). Only `==`/`!=` may reach an
+aggregate (ordering on aggregates is a §5 type error); there they compare
+**structurally** — a struct field-by-field, an array element-by-element, an enum
+same-tag-and-equal-payload, recursing into nested aggregates (RUE-285) — and a
+`String` by its byte content (`4.3:2`):
+
+```
+  v1 ≈ v2  ⟺  v1 and v2 are structurally equal      (scalars by value; aggregates componentwise; strings by content)
+  ─────────────────────────────────────────────────────────────────────────────────── (D-Eq)
+  v1 == v2 → (v1 ≈ v2)                v1 != v2 → ¬(v1 ≈ v2)
+```
+
+**Bitwise `& | ^ ~` and shifts `<< >>`** operate on the `w`-bit two's-complement
+representation and never trap (`bitop`/`shift`, `lib.rs:794`). Write `β_w(n)` for
+the `w`-bit pattern of `n` and `val_{w,s}(β)` for its reinterpretation at
+signedness `s`:
+
+```
+  ⊛ ∈ { &, |, ^ }        β = β_w(n1) ⊛_bits β_w(n2)
+  ───────────────────────────────────────────────────── (D-Bit)
+  (n1)_{int(w,s)} ⊛ (n2)_{int(w,s)} → ( val_{w,s}(β) )_{int(w,s)}
+
+  (n1)_{int(w,s)}  ~  → ( val_{w,s}( ¬β_w(n1) ) )_{int(w,s)}       -- bitwise complement (BitNot, lib.rs:489)
+```
+
+Shifts mask the shift amount modulo the operand width `w` (`4.3a:10`); `>>` on a
+signed type is arithmetic (sign-replicating), on an unsigned type logical
+(`shift`, `lib.rs:810`):
+
+```
+  k = amt mod w        β = β_w(n) shifted left by k, masked to w bits
+  ───────────────────────────────────────────────────────────────── (D-Shl)
+  (n)_{int(w,s)} << (amt)_T → ( val_{w,s}(β) )_{int(w,s)}
+
+  k = amt mod w        β = ( arithmetic-if-signed / logical-if-unsigned ) right shift of β_w(n) by k
+  ───────────────────────────────────────────────────────────────── (D-Shr)
+  (n)_{int(w,s)} >> (amt)_T → ( val_{w,s}(β) )_{int(w,s)}
+```
+
+`not` on `bool` is `not true → false`, `not false → true` (`Not`, `lib.rs:488`).
+
+### 6.5 Aggregate introduction and projection
+
+A struct, array, or enum literal is a redex once **all** its components are values
+(the `E` contexts of §6.2 reduce them left-to-right, threading `H`). It steps to
+the corresponding aggregate value, owning every component (`StructInit`/
+`ArrayInit`, `lib.rs:518`):
+
+```
+  ────────────────────────────────────────────────── (D-Struct)
+  S{ f1=v1, …, fk=vk } → { v1, …, vk }_S
+
+  ────────────────────────────────────────────────── (D-Array)
+  [ v1, …, vn ] → [ v1, …, vn ]                       -- (n ≥ 0; the empty array [] is the zero-sized [T;0])
+```
+
+Projection in value context is subsumed by the place-use rules of §6.3 (a
+projection `p.f` / `p[e]` is a place); an **array index is bounds-checked** at the
+moment the path is navigated, and an out-of-range or negative index traps
+(`resolve_path`/`place_read`, `lib.rs:869`, `lib.rs:897`):
+
+```
+  0 ≤ i < n
+  ───────────────────────────────── (D-Index)         -- [v0,…,v_{n-1}] @ [i] = vi (then §6.3 copies or moves)
+  reading [ v0, …, v_{n-1} ][ i ] yields vi
+
+  i < 0   or   i ≥ n
+  ───────────────────────────────── (D-Index-Trap)
+  reading [ v0, …, v_{n-1} ][ i ] → ↯bounds
+```
+
+### 6.6 Enum introduction and the `match` elimination
+
+Enum construction evaluates its payload left-to-right (§6.2) and builds the tagged
+value; a discriminant-only variant is just its tag (`EnumVariant`, `lib.rs:559`):
+
+```
+  ────────────────────────────────────────────────── (D-Enum-Intro)
+  E::Kj( v1, …, va ) → Kj⟨ v1, …, va ⟩                -- a = 0 ⇒ the bare tag Kj⟨⟩
+```
+
+`match` first reduces its scrutinee to an enum value `Kj⟨v1,…,va⟩` (a
+value-context **use** of the scrutinee, §5.5: a move for a non-`Copy` enum — its
+source cell became `⊘` by §6.3 — a copy otherwise). The tag `Kj` selects the one
+covering arm (exhaustiveness, §5.5, guarantees exactly one), which **binds the
+payload components to fresh cells** and reduces the arm body in a new scope owning
+those cells; the other arms never come into being (`Switch` + `EnumPayloadGet`,
+`lib.rs:268`, `lib.rs:579`):
+
+```
+  arm j is  Kj(x1, …, xa) => ej        ℓ1..ℓa fresh        ρ' = ρ[ x1↦ℓ1, …, xa↦ℓa ]
+  H' = H[ ℓ1↦v1, …, ℓa↦va ]           φ' = push-scope(φ with ρ', owing [ℓ1,…,ℓa])
+  ────────────────────────────────────────────────────────────────────────────────── (D-Match)
+  ⟨ H ; φ ; K ; match Kj⟨v1,…,va⟩ { …, Kj(x1..xa) => ej, … } ⟩  →  ⟨ H' ; φ' ; K ; ej ⟩
+```
+
+The scrutinee value is **consumed** by the match: its payload now lives in the
+`ℓi`, so it is not dropped again, and each `xi` is an ordinary `Owned` binding
+governed by §6.11 at the arm's end (a `Linear` payload the arm neither moves nor
+consumes is the leak the statics already rejected; an `Affine` one is dropped
+once). This is the operational content of "binding a variant's payload moves it
+out; a moved-out payload runs its destructor exactly once when its binding leaves
+scope" (`6.3:17`, `6.3:20`). `if` is the two-armed boolean special case:
+
+```
+  ─────────────────────────────────────── (D-If-T)          ─────────────────────────────────────── (D-If-F)
+  if true { e1 } else { e2 } → e1                            if false { e1 } else { e2 } → e2
+```
+
+`if`'s arms are entered directly (they open scopes for their own `let`-bindings by
+§6.7); the boolean scrutinee is `Copy`, so no drop attends the branch itself.
+
+### 6.7 `let`, sequencing, and scope-exit drop
+
+`let x = v ; e2` allocates a fresh cell for `x`, binds it, and reduces the body in
+a scope that **owes `x` a drop**. To make scope exit a reduction step, the machine
+uses one administrative runtime form, `endscope(ℓ̄) in e` (not a §2 surface form),
+which runs the drops of cells `ℓ̄` when `e` has become a value:
+
+```
+  ℓ fresh
+  ─────────────────────────────────────────────────────────────────── (D-Let)
+  ⟨ H ; ⟨ρ;σ⟩ ; K ; let x = v ; e2 ⟩ → ⟨ H[ℓ↦v] ; ⟨ρ[x↦ℓ];σ⟩ ; K ; endscope([ℓ]) in e2 ⟩
+
+  ─────────────────────────────────────────────────────────────────── (D-EndScope)     -- ℓ̄ dropped newest-first
+  ⟨ H ; φ ; K ; endscope([ℓ1,…,ℓq]) in v ⟩ → ⟨ drop(H, ℓq) ; …; drop(H, ℓ1) ; φ ; K ; v ⟩
+```
+
+where `drop(H, ℓ)` is the drop relation of §6.11 (a no-op on a `⊘` or `Copy`
+cell). Nested `let`s nest their `endscope`s, so cells are dropped in **reverse
+declaration order** (RAII) — the innermost/newest binding first. A bare sequence
+`e1 ; e2` evaluates `e1` to a value and **discards** it; because §5.3 guarantees
+`e1` carries no linear value, the discarded temporary is simply dropped (a no-op
+for a `Copy` value) and control passes to `e2`:
+
+```
+  ─────────────────────────────────────────────────────────── (D-Seq)
+  ⟨ H ; φ ; K ; v1 ; e2 ⟩ → ⟨ drop(H, v1) ; φ ; K ; e2 ⟩       -- drop the discarded temporary, then continue
+```
+
+(The oracle realizes both via the compiler's explicit `Drop` CFG instructions,
+which its elaboration inserts at exactly these scope/temporary boundaries and the
+interpreter executes with `run_drop`, `lib.rs:701`; `drop(H, v)` on an already-
+owned temporary value is `drop` on a cell whose contents is `v` and never `⊘`.)
+
+### 6.8 Assignment: overwrite-drop and reinitialisation
+
+`assign p = v` stores `v` into the cell/sub-position `p` denotes. If that position
+currently holds an `Owned` droppable value, it is **dropped first** (overwrite-
+drop, §5.2, `3.8:55`); reinitialising a `⊘` (moved-out) position drops nothing.
+The result is `⟨⟩` and the position becomes `Owned` (`place_write`, `lib.rs:911`):
+
+```
+  ρ(root(p)) = ℓ      H(ℓ)@π = c      H1 = ( drop(H, c-at-ℓ@π) if c ≠ ⊘ else H )      H2 = H1[ ℓ@π ↦ v ]
+  ─────────────────────────────────────────────────────────────────────────────────────────────────── (D-Assign)
+  ⟨ H ; φ ; K ; assign p = v ⟩ → ⟨ H2 ; φ ; K ; ⟨⟩ ⟩
+```
+
+(The compiler elaborates the overwrite-drop as an explicit `Drop` emitted before
+the store, so the oracle's `place_write` needs only to overwrite — the drop
+instruction ran first; consistent with `3.8` overwrite-drop.)
+
+### 6.9 Calls, parameters, and return
+
+A call `g(a1, …, am)` evaluates its arguments left-to-right (§6.2). A by-value
+argument reduces to a value `vi` that is **moved or copied into** the parameter
+cell (per §4.2 — the source place, if any, was already marked `⊘` by §6.3). A
+by-reference argument `inout p` / `borrow p` is **not** reduced to a value:
+instead the parameter cell *is* the argument place's cell — the callee and caller
+share storage for the call's dynamic extent, so a write through an `inout`
+parameter is visible to the caller on return (`6.1:18`), and a `borrow` parameter
+is read-only. Let `g` be `fn g(m1 x1:T1, …, mm xm:Tm) -> Tr { e_body }`:
+
+```
+  for each i:  arg a_i  is  either  a value v_i (by-value: fresh cell ℓ_i, H'(ℓ_i)=v_i)
+                          or  a by-ref place p_i (inout/borrow: ℓ_i = ρ(root(p_i)) shared, no copy)
+  ρ_g = [ x1↦ℓ1, …, xm↦ℓm ]        φ_g = ⟨ ρ_g ; [ [by-value ℓ_i only] ] ⟩        -- by-ref params owe NO drop (§5.6)
+  ────────────────────────────────────────────────────────────────────────────────────────────── (D-Call)
+  ⟨ H ; φ ; K ; E[ g(a1,…,am) ] ⟩ → ⟨ H' ; φ_g ; ret(E, φ)·K ; e_body ⟩
+```
+
+The callee's entry scope owes a drop **only** for the by-value parameter cells;
+`inout`/`borrow` parameters are owned by the caller and are exempt (§5.6,
+`3.8:62`). When the body reduces to a value `v`, the frame is popped: its open
+scopes' drops run (freeing the by-value params and any still-live locals), and `v`
+is handed back to the suspended caller context:
+
+```
+  ────────────────────────────────────────────────────────────────────────── (D-Return-Value)
+  ⟨ H ; φ_g ; ret(E, φ)·K ; v ⟩ → ⟨ run-all-scope-drops(H, φ_g) ; φ ; K ; E[v] ⟩
+
+  ────────────────────────────────────────────────────────────────────────── (D-Return)
+  ⟨ H ; φ_g ; ret(E, φ)·K ; return v ⟩ → ⟨ run-all-scope-drops(H, φ_g) ; φ ; K ; E[v] ⟩
+```
+
+`(D-Return-Value)` is the "a function evaluates to the value its body evaluates
+to" rule of §4.3 — there is no implicit action, the body simply *is* an
+expression that reduced to `v`. `(D-Return)` is the explicit form: `return v`
+discards the intervening scopes up to the function boundary, running their drops,
+and yields `v` (the oracle's `Terminator::Return`, `lib.rs:240`, with the
+compiler having placed the pre-return `Drop`s). The oracle models `inout` by
+**copy-in / copy-out** rather than true sharing — it copies the argument in, runs
+the callee, then copies each `inout` parameter's final value back into the caller
+place (`lib.rs:640`, `lib.rs:657`). Under the law of exclusivity (§5.4) an `inout`
+place is unaliased for the call's duration, so copy-out is observably identical to
+the shared-cell rule above; the paper machine takes the sharing form because it is
+simpler to state and the two agree exactly on well-typed programs.
+
+A call whose callee is a builtin with no core body (e.g. a `String` method, or
+`@dbg` / `@to_string`) reduces by the builtin's defining equation rather than by
+`(D-Call)`; these are elaboration-level primitives, and the oracle dispatches them
+directly (`string_builtin`, `lib.rs:307`; `@dbg` appends its argument's rendering
+to the observable output, `lib.rs:667`). The core-form call rule above governs
+every user function.
+
+### 6.10 `loop` and `break`
+
+`loop { e }` pushes a loop boundary and enters the body in a fresh scope; when the
+body reduces to a value (necessarily `⟨⟩`, discarded), its scope drops run and the
+loop **re-enters** its body — so a value's storage from one iteration is reclaimed
+before the next, exactly as a `let` inside the loop body drops each turn (in the
+oracle the loop is `Goto`/`Branch`/`Switch` back-edges, `lib.rs:247`, and the
+compiler places a `Drop` on the back-edge that `run_drop` executes each turn).
+`break` unwinds to the nearest loop boundary, running the drops of every scope it
+discards, and the whole `loop` yields `⟨⟩`:
+
+```
+  ─────────────────────────────────────────────────────────────────── (D-Loop-Enter)
+  ⟨ H ; φ ; K ; loop { e } ⟩ → ⟨ H ; push-scope(φ) ; loopβ(e, φ)·K ; e ⟩
+
+  ─────────────────────────────────────────────────────────────────── (D-Loop-Iter)
+  ⟨ H ; φ' ; loopβ(e, φ)·K ; v ⟩ → ⟨ run-scope-drops(H, φ') ; push-scope(φ) ; loopβ(e, φ)·K ; e ⟩
+
+  ─────────────────────────────────────────────────────────────────── (D-Break)      -- unwinds scopes down to the loop boundary
+  ⟨ H ; φ' ; loopβ(e, φ)·K ; break ⟩ → ⟨ unwind-drops(H, φ', φ) ; φ ; K ; ⟨⟩ ⟩
+```
+
+`unwind-drops(H, φ', φ)` runs the scope-exit drops of every scope open in `φ'`
+that is not already open in the enclosing `φ`. A `loop` with no reachable `break`
+never fires `(D-Break)` and so runs forever — its static type is `never` (§5.7,
+`Loop-Div`), consistent with its never yielding a value to its context.
+(Multi-`break` and `break e` value-carrying loops are elaborated to this shape;
+formalizing their ownership join is the deferred loop-section work noted in §5.7.)
+
+### 6.11 Drop
+
+`drop(H, ℓ)` and `drop(H, c)` are the operational core of Rue's memory safety.
+Dropping a cell holding `⊘` — a moved-out or uninitialised position — does
+**nothing** (this single skip is what makes double-free impossible, §7). Otherwise
+the value's user destructor, if any, runs **first**, then its droppable *contents*
+drop in `3.9` order (`run_drop`, `lib.rs:350`):
+
+```
+  drop(H, ⊘)                       = H                                   -- moved-out / uninitialised: skip
+  drop(H, n_T) = drop(H, b) = drop(H, ⟨⟩) = H                            -- scalars are Copy: nothing to drop
+  drop(H, { v1,…,vk }_S)           = drop*( dtor_S(H, {v̄}_S) , [v1,…,vk] )   -- run S's destructor (if any), then fields in DECLARATION order
+  drop(H, [ v1,…,vn ])             = drop*( H , [v1,…,vn] )              -- elements in ASCENDING index order
+  drop(H, Kj⟨ v1,…,va ⟩)           = drop*( H , [v1,…,va] )              -- ONLY the ACTIVE variant Kj's payload (6.3:20)
+```
+
+where `drop*(H, [c1,…,cm])` folds `drop` over the list left-to-right, and
+`dtor_S` runs `S`'s destructor as an ordinary call (§6.9) if `S` declares one
+(skipping it, and the whole field recursion, for a **builtin** `S` such as
+`String`, whose destructor *is* its entire drop glue and has no observable effect
+in the model — `lib.rs:356`). The **enum** case reads the runtime tag `Kj` to
+recurse into the *active* variant's payload only: an inactive variant's payload
+has no storage, and a discriminant-only active variant (`a = 0`) drops nothing
+(`lib.rs:388`). A payload already moved out by a `match` binding (§6.6) left the
+enum place `⊘`, so it is skipped here and never dropped twice.
+
+Because a destructor is a normal function, dropping can itself step the machine
+(and can even trap — a destructor that overflows halts with `↯overflow`, exactly
+as the oracle would, since `run_drop` calls back into `call`). Drops are therefore
+sequenced, not atomic; `endscope`/`return`/`break`/overwrite all expand to `drop`
+applications in the orders fixed above.
+
+### 6.12 Traps and the top-level result
+
+The four trap categories — `overflow` (arithmetic, `neg`, `min_T / -1`),
+`div-zero`, `rem-zero`, and `bounds` (a negative or out-of-range array index) —
+each abandon the configuration to `↯κ` and halt the program with the panic exit
+code of Appendix B (101), regardless of surrounding context (§6.2, Panic-Lift).
+They are **total, deterministic, and observable**: an alternate compiler must
+reproduce the same trap on the same input (`3.1:6/13`, `8.1`–`8.3`). The top-level
+result is fixed by running `main`:
+
+```
+  ⟨ H0 ; φ_main ; halt ; e_main ⟩ →* ⟨ H ; φ_main ; halt ; v ⟩
+  ────────────────────────────────────────────────────────────── (Result-Ok)
+  program result = ✓( n mod 256 )        where v = n_{int(32,signed)}, or ✓0 if v = ⟨⟩
+
+  ⟨ H0 ; φ_main ; halt ; e_main ⟩ →* ↯κ
+  ────────────────────────────────────────────────────────────── (Result-Panic)
+  program result = ✓101
+```
+
+`main`'s returned `i32` is masked to a byte for the process exit code, and a
+`unit`-returning `main` exits 0 (`Interp::run`, `lib.rs:165`); any trap exits 101
+(`lib.rs:172`). These two rules, plus the observable `@dbg` output accumulated
+during reduction, are precisely the `Outcome` (`exit_code`, `stdout`, `panic`) the
+differential harness compares against the compiled binary (RUE-50).
+
+The interpreter implementing this whole relation is the executable oracle
+(`crates/rue-oracle`; README § "The executable oracle" / RUE-50). Every rule group
+above names the function that realizes it, so a change to either must be mirrored
+in the other or the differential tests will diverge — which is the mechanism that
+keeps the paper semantics and the running semantics one artifact.
 
 ---
 
@@ -757,7 +1208,9 @@ on "use", "moved", "consumed", "dropped" being defined — which §3–§6 final
 ## 8. Traceability: prose paragraphs this core subsumes
 
 For the spec-traceability discipline (`crates/rue-spec`), the correspondence so
-far. As breadth is filled in, each new rule adds its citation.
+far. As breadth is filled in, each new rule adds its citation. The §6 rows below
+also correspond, function-for-function, to `crates/rue-oracle` — the executable
+witness of the dynamic semantics (RUE-50), cited inline in each §6 rule group.
 
 | Formal notion | Prose paragraphs it formalizes / replaces |
 |---|---|
@@ -774,7 +1227,16 @@ far. As breadth is filled in, each new rule adds its citation.
 | §5.5 branch join | 3.8:50/51, 3.8:73 |
 | §5.6 scope exit: drop + leak | 3.8:32/62/66, 3.9 (drop order) |
 | §5.7 divergence + never-coercion | 3.4:1/2/3/4/6/8, 3.4:9 |
-| §6 overflow/bounds/div-zero panics | 3.1:6/13, 8.1, 8.2, 8.3, Appendix B |
+| §6.2 evaluation order (contexts, left-to-right) | 4.0:3–9 |
+| §6.3 dynamic use: copy vs. move; equality borrows | 3.8:5/7/22, 4.3:3f |
+| §6.4 operator dynamics: arith/div/mod, compare, bitwise/shift | 4.2:1, 4.3:1/2, 4.3a:10, 3.1:6/13 |
+| §6.5 aggregate intro + projection (bounds) | 3.5:2, 3.6:16, 8.2 |
+| §6.6 enum intro + match dynamics | 6.3:17, 4.7 |
+| §6.7/§6.8 let/seq/scope-drop, assignment overwrite-drop | 4.5:3, 3.8:55/64, 3.9 |
+| §6.9 call / return / inout copy-out | 6.1:4/5/18, 4.9:1/7 |
+| §6.10 loop / break dynamics | 4.9 (loop), 3.4:2 |
+| §6.11 drop relation (active enum payload; skip moved) | 3.9, 6.3:20 |
+| §6.12 overflow/bounds/div-zero panics + exit code | 3.1:6/13, 8.1, 8.2, 8.3, Appendix B |
 | §7 soundness | the informal safety intent throughout ch. 3 and 8 |
 
 ---

--- a/docs/formal/README.md
+++ b/docs/formal/README.md
@@ -167,8 +167,10 @@ shape.
   lattice (Copy / Affine / Linear); **the definition of *use* (place vs. value
   context)**; the ownership-threading type judgment — including the leaf,
   operator, aggregate, and call statics (§5.8) that complete every §2 expression
-  form; the operational semantics and drop; and the soundness theorems (memory
-  safety), stated precisely.
+  form; the **complete small-step dynamic semantics (§6)** — a reduction rule for
+  every §2 form, grounded function-for-function in the `rue-oracle` interpreter
+  (RUE-50) — and drop; and the soundness theorems (memory safety), stated
+  precisely.
 - *(planned)* `02-elaboration.md` — surface→core desugaring and the comptime /
   monomorphization semantics.
 - *(planned)* `03-metatheory.md` — proofs (progress, preservation, and the

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -12,7 +12,12 @@ The type `String` represents an immutable sequence of UTF-8 encoded bytes.
 
 {{ rule(id="3.7:2", cat="normative") }}
 
-A `String` value is a fat pointer consisting of a pointer to the string data and the length in bytes.
+A `String` value occupies three machine words — a pointer to the string data,
+the length in bytes, and the allocated capacity in bytes — so `@size_of(String)`
+is `24` on a 64-bit target. A string literal has a capacity of zero and its
+pointer refers to read-only memory (3.7:3); a `String` produced by an operation
+that allocates (`@to_string`, 3.7:22, or `+`, 3.7:25) has a capacity greater
+than zero and owns a heap buffer of that size.
 
 {{ rule(id="3.7:3", cat="normative") }}
 
@@ -25,6 +30,47 @@ fn main() -> i32 {
     let s = "hello";
     0
 }
+```
+
+## Representation and Ownership
+
+{{ rule(id="3.7:39", cat="normative") }}
+
+`String` is a move type (an affine type), not a `Copy` type (see
+[Move Semantics](@/03-types/08-move-semantics.md)). Assigning a `String` to
+another binding, passing it by value, or returning it moves it; the source
+binding is left invalid, and using a moved `String` is a compile-time error
+(E0205). Because `String` is not a `Copy` type, a `@copy` struct may not have a
+`String` field. Unlike a `linear` type, a `String` need not be explicitly
+consumed: an unused `String` is dropped implicitly at the end of its scope.
+
+{{ rule(id="3.7:40", cat="dynamic-semantics") }}
+
+A `String` owns its heap allocation and has a destructor (see
+[Destructors](@/03-types/09-destructors.md)). When a `String` is dropped: if its
+capacity is zero (a literal) no action is taken; if its capacity is greater than
+zero the owned heap buffer is freed. Because a move transfers ownership, the
+buffer is freed exactly once — at the drop of the final owner — and never at a
+moved-from binding.
+
+{{ rule(id="3.7:41", cat="informative") }}
+
+The capacity of a heap-allocated `String`, and the growth strategy that chooses
+it, are implementation-defined (1.3:6): a conforming program observes only the
+length and byte content of a `String`, never its exact capacity. The
+mutable-string extension ([Mutable Strings](@/03-types/10-mutable-strings.md),
+section 3.10) builds on this same three-word representation.
+
+{{ rule(id="3.7:42") }}
+
+```rue
+fn main() -> i32 {
+    let a = "foo" + "bar";   // heap-allocated: capacity > 0
+    let b = a;               // 'a' is moved into 'b'
+    // let c = a;            // ERROR (E0205): use of moved value 'a'
+    @dbg(b);                 // foobar
+    0
+}                            // 'b' is dropped: its heap buffer is freed once
 ```
 
 ## String Literals

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -53,6 +53,7 @@ Expression intrinsics (usable in any expression position):
 | `@dbg` | Print debug output | 1 expression (int, bool, or string) | `()` |
 | `@size_of` | Get type size in bytes | 1 type | `i32` |
 | `@align_of` | Get type alignment in bytes | 1 type | `i32` |
+| `@offset_of` | Get a struct field's byte offset | 1 type, 1 field name | `u64` |
 | `@intCast` | Convert between integer types | 1 expression (integer) | inferred integer type |
 | `@to_string` | Format an integer as its decimal `String` | 1 expression (any integer) | `String` |
 | `@drop` | Run a value's drop glue and consume it (RUE-187) | 1 expression (any type) | `()` |
@@ -75,6 +76,7 @@ full semantics):
 | `@syscall` | Direct system call | 1–7 expressions (`u64`) | `i64` |
 | `@raw` | `const` pointer to a place | 1 place expression | `ptr const T` |
 | `@raw_mut` | `mut` pointer to a place | 1 place expression | `ptr mut T` |
+| `@field_ptr` | `mut` pointer to a struct field place | 1 field-access expression | `ptr mut F` |
 | `@ptr_read` | Read through a pointer | 1 expression (`ptr const T`/`ptr mut T`) | `T` |
 | `@ptr_write` | Write through a pointer | 2 expressions (`ptr mut T`, `T`) | `()` |
 | `@ptr_offset` | Pointer arithmetic | 2 expressions (`ptr T`, integer) | `ptr T` |
@@ -220,6 +222,50 @@ All types in Rue currently have 8-byte alignment.
 ```rue
 fn main() -> i32 {
     @align_of(i32)    // 8
+}
+```
+
+## `@offset_of`
+
+{{ rule(id="4.13:91", cat="normative") }}
+
+The `@offset_of` intrinsic returns the byte offset of a field within a struct
+type, mirroring Rust's `core::mem::offset_of!`.
+
+{{ rule(id="4.13:92", cat="normative") }}
+
+`@offset_of` accepts exactly two arguments: the first **MUST** be a struct type,
+and the second **MUST** be the name of one of that struct's fields.
+
+{{ rule(id="4.13:93", cat="normative") }}
+
+The return type of `@offset_of` is `u64`.
+
+{{ rule(id="4.13:94", cat="normative") }}
+
+The value returned by `@offset_of` is the offset the compiler assigns to the
+field under the layout it chooses for the struct, determined at compile time.
+Because the value comes from the compiler's own layout rather than a
+hand-computed constant, `@offset_of` remains correct even if the struct layout
+is implementation-defined. The offset of a field is the sum of the sizes of all
+preceding fields under the current layout (§3.6).
+
+{{ rule(id="4.13:95", cat="legality-rule") }}
+
+It is a compile-time error to apply `@offset_of` to a non-struct type, or to
+name a field that the struct does not declare.
+
+{{ rule(id="4.13:96") }}
+
+```rue
+struct Mixed { a: i32, b: i64, c: bool }
+
+fn main() -> i32 {
+    let off_a: u64 = @offset_of(Mixed, a);   // 0
+    let off_b: u64 = @offset_of(Mixed, b);   // 8  (a occupies one 8-byte slot)
+    let off_c: u64 = @offset_of(Mixed, c);   // 16 (a and b occupy two slots)
+    let sum: u64 = off_a + off_b + off_c;    // 24
+    @intCast(sum)
 }
 ```
 

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -146,3 +146,52 @@ fn main() -> i32 {
     }
 }
 ```
+
+## Field Pointer Intrinsic
+
+{{ rule(id="9.2:15", cat="normative") }}
+
+The `@field_ptr` intrinsic forms a raw pointer to a struct field place without
+taking a reference, the analog of Rust's `&raw mut (*p).field`. Like the other
+raw-pointer intrinsics it may only appear inside a `checked` block (§9.1). It is
+compiler-mediated field access: the pointer addresses the field at the offset
+the compiler assigns, so unchecked code can walk a struct without hardcoding
+slot offsets, remaining correct even if the struct layout is
+implementation-defined.
+
+{{ rule(id="9.2:16", cat="syntax") }}
+
+```ebnf
+field_ptr_intrinsic = "@field_ptr" "(" field_access ")" ;
+field_access = expression "." IDENT ;
+```
+
+{{ rule(id="9.2:17", cat="legality-rule") }}
+
+The `@field_ptr` intrinsic takes exactly one argument, which **MUST** be a
+field-access expression `s.field`. Applying it to any other expression (a bare
+variable, an array element, a call result, or a literal) is a compile-time
+error; use `@raw`/`@raw_mut` to address those places.
+
+{{ rule(id="9.2:18", cat="dynamic-semantics") }}
+
+`@field_ptr(s.field)` returns a `ptr mut F`, where `F` is the type of `field`,
+addressing the storage of that field within `s`. The result addresses the same
+location as `@raw_mut` applied to the field, and reading it with `@ptr_read`
+observes the same value as the ordinary field access `s.field`. Because the
+returned pointer is mutable, `@ptr_write` through it updates the field in place.
+
+{{ rule(id="9.2:19", cat="example") }}
+
+```rue
+struct Mixed { a: i32, b: i64, c: bool }
+
+fn main() -> i32 {
+    let m = Mixed { a: 11, b: 22, c: true };
+    let got: i64 = checked {
+        let p: ptr mut i64 = @field_ptr(m.b);
+        @ptr_read(p)                              // 22, same as m.b
+    };
+    @intCast(got)
+}
+```


### PR DESCRIPTION
Four disjoint fixes (cycle 102):
- **RUE-301**: `@offset_of(T, field) -> u64` (comptime byte offset, like Rust offset_of!) + `@field_ptr(s.field) -> ptr mut F` (&raw mut analog, checked-only; reuses @raw address-of + lower_place_addr on both backends). The layout primitives unblocking RUE-288. Verified both backends; 12 spec + 8 CLI cases.
- **RUE-295**: chapter 3.7 corrected — String is 3 words/24 bytes (ptr,len,cap), @size_of=24 (was 2-word/16); added move/affine + destructor + impl-defined-capacity semantics.
- **RUE-334**: Mach-O parser (elf.rs) alignment `1<<exp` overflowed for exp>=64 — now checked_shl + checked_add/mul; regression test.
- **RUE-214**: formal core §6 backfilled from sketch into complete small-step rules for every core form, grounded in the rue-oracle interpreter.

clippy clean; test.sh Pass 24, 100% traceability (692/692), oracle-diff 0.

Fixes RUE-301
Fixes RUE-295
Fixes RUE-334
Fixes RUE-214

Generated with Claude Code