### PR TITLE
Assoc-fn privacy, layout observe-vs-guarantee spec, oracle panic-category, linker reloc dedup

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -3614,7 +3614,16 @@ impl<'a> Sema<'a> {
 
         // Check that the type exists and is a struct
         // First check if it's a comptime type variable (e.g., `let P = Point(); P::origin()`)
+        //
+        // `privacy_exempt` mirrors the enum-variant construction handler: a
+        // comptime-bound type (`let P = Point(); P::origin()`) arrived through a
+        // binding, not by naming the struct, so it is exempt from the
+        // unqualified-privacy check. A bare `Point::origin()` names the struct
+        // and must obey the same uniform-privacy rule (spec 10.3:7) as a struct
+        // literal or type annotation would.
+        let mut privacy_exempt = false;
         let struct_id = if let Some(&ty) = ctx.comptime_type_vars.get(&type_name) {
+            privacy_exempt = true;
             // Extract struct ID from the comptime type
             match ty.kind() {
                 TypeKind::Struct(id) => id,
@@ -3634,6 +3643,23 @@ impl<'a> Sema<'a> {
                 .get(&type_name)
                 .ok_or_compile_error(ErrorKind::UnknownType(type_name_str.clone()), span)?
         };
+
+        // Privacy (E0460, RUE-330): naming a private struct to call one of its
+        // associated functions (`Secret::make()`) across a directory boundary is
+        // rejected, matching struct-literal / type-annotation references. Privacy
+        // is uniform across item kinds (spec 10.3:1, 10.3:7). Builtin structs
+        // (String, ...) have no source path, so `is_accessible` is permissive and
+        // this is a no-op for them.
+        if !privacy_exempt {
+            let struct_def = self.type_pool.struct_def(struct_id);
+            self.check_unqualified_visibility(
+                "struct",
+                &type_name_str,
+                struct_def.file_id,
+                struct_def.is_pub,
+                span,
+            )?;
+        }
 
         // Handle builtin type associated functions
         if let Some(builtin_def) = self.get_builtin_type_def(struct_id) {

--- a/crates/rue-cli-tests/cases/assoc_fn_privacy.toml
+++ b/crates/rue-cli-tests/cases/assoc_fn_privacy.toml
@@ -1,0 +1,126 @@
+# Associated-function calls respect the enclosing type's privacy across a
+# directory boundary (RUE-330). Calling an associated function of a private
+# struct from a source file in a different directory is E0460 — the same rule
+# that already governs naming that struct in a struct literal or type
+# annotation. This holds for both the unqualified (`Secret::make()`) and the
+# module-qualified (`lib.Secret::make()`) forms, since both resolve the
+# receiver type through the transitional flat namespace. A receiver reached
+# through a comptime binding (`let P = lib.Point; P::origin()`) is exempt, and
+# intra-directory access is unchanged.
+
+[section]
+id = "cli.assoc_fn_privacy"
+name = "Associated-function privacy across directories"
+description = "Cross-directory associated-function calls on a private struct are rejected (RUE-330)."
+
+# Unqualified call on a private struct from another directory: rejected.
+[[case]]
+name = "cross_dir_unqualified_private_assoc_fn_rejected"
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib");
+
+fn main() -> i32 {
+    let s = Secret::make();
+    s.n
+}
+""" },
+    { path = "sub/lib.rue", source = """
+struct Secret {
+    n: i32,
+    fn make() -> Secret { Secret { n: 5 } }
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "struct `Secret` is private"]
+
+# Module-qualified call on a private struct from another directory: also
+# rejected (the type resolves through the flat namespace, so it is E0460 too).
+[[case]]
+name = "cross_dir_qualified_private_assoc_fn_rejected"
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib");
+
+fn main() -> i32 {
+    let s = lib.Secret::make();
+    s.n
+}
+""" },
+    { path = "sub/lib.rue", source = """
+struct Secret {
+    n: i32,
+    fn make() -> Secret { Secret { n: 5 } }
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0460", "struct `Secret` is private"]
+
+# Pub struct: the associated-function call across directories is allowed.
+[[case]]
+name = "cross_dir_pub_assoc_fn_allowed"
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib");
+
+fn main() -> i32 {
+    let p = Point::origin();
+    p.x + p.y
+}
+""" },
+    { path = "sub/lib.rue", source = """
+pub struct Point {
+    x: i32,
+    y: i32,
+    fn origin() -> Point { Point { x: 30, y: 12 } }
+}
+""" },
+]
+exit_code = 42
+
+# Same directory: the private struct's associated function is callable
+# (privacy is directory-scoped).
+[[case]]
+name = "same_dir_private_assoc_fn_allowed"
+files = [
+    { path = "main.rue", source = """
+fn main() -> i32 {
+    let s = Secret::make();
+    s.n
+}
+""" },
+    { path = "lib.rue", source = """
+struct Secret {
+    n: i32,
+    fn make() -> Secret { Secret { n: 42 } }
+}
+""" },
+]
+args = ["main.rue", "lib.rue", "-o", "prog"]
+exit_code = 42
+
+# Receiver type reached through a comptime binding, not by naming the struct:
+# exempt from the privacy check, matching every other binding-reached type.
+[[case]]
+name = "cross_dir_comptime_bound_assoc_fn_allowed"
+files = [
+    { path = "main.rue", source = """
+const lib = @import("sub/lib");
+
+fn main() -> i32 {
+    let P = lib.Point;
+    let p = P::origin();
+    p.x + p.y
+}
+""" },
+    { path = "sub/lib.rue", source = """
+pub struct Point {
+    x: i32,
+    y: i32,
+    fn origin() -> Point { Point { x: 30, y: 12 } }
+}
+""" },
+]
+exit_code = 42

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -56,6 +56,384 @@ fn is_bss_section(name: &str) -> bool {
     name.starts_with(".bss") || name == "__DATA,__bss" || name.starts_with("__bss")
 }
 
+/// Apply a single already-resolved relocation by patching `buf` in place.
+///
+/// Shared by both `link_elf` and `link_macho` (RUE-335): the per-kind patch
+/// encoding is identical across object formats, so it lives here once instead
+/// of being duplicated in each linker path — a relocation fix now lands in a
+/// single place. The caller resolves the format-specific inputs first (which
+/// merged buffer the patch site lives in, its base virtual address, and the
+/// symbol's resolved address) and passes them in.
+///
+/// Parameters use the usual ELF relocation notation:
+/// * `buf`          — merged output buffer containing the patch site.
+/// * `patch_offset` — byte offset of the patch site within `buf`.
+/// * `place`        — virtual address of the patch site (`P` = base vaddr + offset).
+/// * `target_addr`  — resolved virtual address of the referenced symbol (`S`).
+/// * `addend`       — relocation addend (`A`).
+/// * `rel_type`     — relocation kind.
+/// * `sym_name`     — referenced symbol name, used only for diagnostics.
+fn apply_relocation(
+    buf: &mut [u8],
+    patch_offset: usize,
+    place: u64,
+    target_addr: u64,
+    addend: i64,
+    rel_type: RelocationType,
+    sym_name: &str,
+) -> Result<(), LinkError> {
+    let pc = place; // `P` in the S + A - P PC-relative arms below
+    match rel_type {
+        RelocationType::Pc32 | RelocationType::Plt32 => {
+            // S + A - P, where S is symbol address, A is addend, P is place
+            let value = target_addr as i64 + addend - pc as i64;
+            // Check for overflow: value must fit in i32
+            if value < i32::MIN as i64 || value > i32::MAX as i64 {
+                return Err(LinkError::RelocationOverflow {
+                    symbol: sym_name.to_string(),
+                    rel_type: format!("{:?}", rel_type),
+                });
+            }
+            if patch_offset + 4 > buf.len() {
+                return Err(LinkError::RelocationPatchOutOfBounds {
+                    patch_offset,
+                    patch_size: 4,
+                    section_size: buf.len(),
+                    rel_type: format!("{:?}", rel_type),
+                });
+            }
+            buf[patch_offset..patch_offset + 4].copy_from_slice(&(value as i32).to_le_bytes());
+        }
+        RelocationType::GotPcRel => {
+            // R_X86_64_GOTPCREL: Load from GOT entry.
+            // For static linking, we relax this to use the symbol address directly.
+            // This requires rewriting indirect calls/jumps to direct ones, similar to
+            // GotPcRelX but without the compiler's guarantee that it's safe.
+            // In static linking, we know all symbols are resolved, so it's always safe.
+            //
+            // Transform indirect call: `call *[rip+disp]` (FF /2) -> `addr32 call rel32` (67 E8)
+            // Transform indirect jmp:  `jmp *[rip+disp]` (FF /4) -> `addr32 jmp rel32` (67 E9)
+            // Transform indirect mov:  `mov reg, [rip+disp]` (8B) -> `lea reg, [rip+disp]` (8D)
+            if patch_offset >= 2 {
+                let opcode_offset = patch_offset - 2;
+                if buf[opcode_offset] == 0xFF {
+                    let modrm = buf[opcode_offset + 1];
+                    let reg_field = (modrm >> 3) & 0x7;
+                    if reg_field == 2 {
+                        // Indirect call: `call *[rip+disp]` (FF /2, ModR/M 15)
+                        // Transform to: `addr32 call rel32` (67 E8)
+                        buf[opcode_offset] = 0x67; // addr32 prefix
+                        buf[opcode_offset + 1] = 0xE8; // direct call opcode
+                    } else if reg_field == 4 {
+                        // Indirect jmp: `jmp *[rip+disp]` (FF /4, ModR/M 25)
+                        // Transform to: `addr32 jmp rel32` (67 E9)
+                        buf[opcode_offset] = 0x67; // addr32 prefix
+                        buf[opcode_offset + 1] = 0xE9; // direct jmp opcode
+                    }
+                } else if buf[opcode_offset] == 0x8B {
+                    // MOV: `mov reg, [rip+disp]` -> `lea reg, [rip+disp]`
+                    buf[opcode_offset] = 0x8D; // LEA opcode
+                }
+                // Other patterns: just patch displacement (best effort)
+            }
+
+            let value = target_addr as i64 + addend - pc as i64;
+            if value < i32::MIN as i64 || value > i32::MAX as i64 {
+                return Err(LinkError::RelocationOverflow {
+                    symbol: sym_name.to_string(),
+                    rel_type: format!("{:?}", rel_type),
+                });
+            }
+            if patch_offset + 4 > buf.len() {
+                return Err(LinkError::RelocationPatchOutOfBounds {
+                    patch_offset,
+                    patch_size: 4,
+                    section_size: buf.len(),
+                    rel_type: format!("{:?}", rel_type),
+                });
+            }
+            buf[patch_offset..patch_offset + 4].copy_from_slice(&(value as i32).to_le_bytes());
+        }
+        RelocationType::GotPcRelX => {
+            // R_X86_64_GOTPCRELX: GOT access without REX prefix.
+            // For static linking, we perform GOT relaxation:
+            // - `mov reg, [rip+disp]` (8B) -> `lea reg, [rip+disp]` (8D)
+            // - `call *[rip+disp]` (FF /2) -> `addr32 call rel32` (67 E8)
+            // - `jmp *[rip+disp]` (FF /4) -> `addr32 jmp rel32` (67 E9)
+            //
+            // The relocation offset points to the displacement, so:
+            // - For MOV: opcode is at offset - 2
+            // - For CALL/JMP: opcode (FF) is at offset - 2, ModR/M is at offset - 1
+            if patch_offset >= 2 {
+                let opcode_offset = patch_offset - 2;
+                if buf[opcode_offset] == 0xFF {
+                    let modrm = buf[opcode_offset + 1];
+                    let reg_field = (modrm >> 3) & 0x7;
+                    if reg_field == 2 {
+                        // Indirect call: `call *[rip+disp]` (FF /2, ModR/M 15)
+                        // Transform to: `addr32 call rel32` (67 E8)
+                        buf[opcode_offset] = 0x67; // addr32 prefix
+                        buf[opcode_offset + 1] = 0xE8; // direct call opcode
+                    } else if reg_field == 4 {
+                        // Indirect jmp: `jmp *[rip+disp]` (FF /4, ModR/M 25)
+                        // Transform to: `addr32 jmp rel32` (67 E9)
+                        buf[opcode_offset] = 0x67; // addr32 prefix
+                        buf[opcode_offset + 1] = 0xE9; // direct jmp opcode
+                    }
+                } else if buf[opcode_offset] == 0x8B {
+                    // MOV: `mov reg, [rip+disp]` -> `lea reg, [rip+disp]`
+                    buf[opcode_offset] = 0x8D; // LEA opcode
+                }
+                // Other patterns: just patch displacement (best effort)
+            }
+
+            let value = target_addr as i64 + addend - pc as i64;
+            if value < i32::MIN as i64 || value > i32::MAX as i64 {
+                return Err(LinkError::RelocationOverflow {
+                    symbol: sym_name.to_string(),
+                    rel_type: format!("{:?}", rel_type),
+                });
+            }
+            if patch_offset + 4 > buf.len() {
+                return Err(LinkError::RelocationPatchOutOfBounds {
+                    patch_offset,
+                    patch_size: 4,
+                    section_size: buf.len(),
+                    rel_type: format!("{:?}", rel_type),
+                });
+            }
+            buf[patch_offset..patch_offset + 4].copy_from_slice(&(value as i32).to_le_bytes());
+        }
+        RelocationType::RexGotPcRelX => {
+            // R_X86_64_REX_GOTPCRELX: GOT access with REX prefix.
+            // For static linking, we perform GOT relaxation:
+            // - `mov reg, [rip+disp]` (REX 8B) -> `lea reg, [rip+disp]` (REX 8D)
+            // - `call *[rip+disp]` (REX FF /2) -> `addr32 call rel32` (REX 67 E8)
+            // - `jmp *[rip+disp]` (REX FF /4) -> `addr32 jmp rel32` (REX 67 E9)
+            //
+            // The relocation offset points to the displacement, so:
+            // - For MOV with REX: REX is at offset - 3, opcode at offset - 2
+            // - For CALL/JMP with REX: similar layout
+            if patch_offset >= 2 {
+                let opcode_offset = patch_offset - 2;
+                if buf[opcode_offset] == 0xFF {
+                    let modrm = buf[opcode_offset + 1];
+                    let reg_field = (modrm >> 3) & 0x7;
+                    if reg_field == 2 {
+                        // Indirect call with REX: `REX call *[rip+disp]` (4x FF /2)
+                        // Transform to: `addr32 call rel32` (67 E8) - REX stays at offset-3
+                        buf[opcode_offset] = 0x67; // addr32 prefix
+                        buf[opcode_offset + 1] = 0xE8; // direct call opcode
+                    // Note: REX prefix at offset-3 becomes harmless (no-op for CALL)
+                    } else if reg_field == 4 {
+                        // Indirect jmp with REX: `REX jmp *[rip+disp]` (4x FF /4)
+                        // Transform to: `addr32 jmp rel32` (67 E9)
+                        buf[opcode_offset] = 0x67; // addr32 prefix
+                        buf[opcode_offset + 1] = 0xE9; // direct jmp opcode
+                    }
+                } else if buf[opcode_offset] == 0x8B {
+                    // MOV with REX: `REX mov reg, [rip+disp]` -> `REX lea reg, [rip+disp]`
+                    buf[opcode_offset] = 0x8D; // LEA opcode
+                }
+                // Other patterns: just patch displacement (best effort)
+            }
+
+            let value = target_addr as i64 + addend - pc as i64;
+            if value < i32::MIN as i64 || value > i32::MAX as i64 {
+                return Err(LinkError::RelocationOverflow {
+                    symbol: sym_name.to_string(),
+                    rel_type: format!("{:?}", rel_type),
+                });
+            }
+            if patch_offset + 4 > buf.len() {
+                return Err(LinkError::RelocationPatchOutOfBounds {
+                    patch_offset,
+                    patch_size: 4,
+                    section_size: buf.len(),
+                    rel_type: format!("{:?}", rel_type),
+                });
+            }
+            buf[patch_offset..patch_offset + 4].copy_from_slice(&(value as i32).to_le_bytes());
+        }
+        RelocationType::Abs64 | RelocationType::Aarch64Abs64 => {
+            // 64-bit absolute address (pointer slots in rodata/data).
+            let value = (target_addr as i64 + addend) as u64;
+            if patch_offset + 8 > buf.len() {
+                return Err(LinkError::RelocationPatchOutOfBounds {
+                    patch_offset,
+                    patch_size: 8,
+                    section_size: buf.len(),
+                    rel_type: format!("{:?}", rel_type),
+                });
+            }
+            buf[patch_offset..patch_offset + 8].copy_from_slice(&value.to_le_bytes());
+        }
+        RelocationType::Abs32 => {
+            let value = target_addr as i64 + addend;
+            // Check for overflow: value must fit in u32
+            if value < 0 || value > u32::MAX as i64 {
+                return Err(LinkError::RelocationOverflow {
+                    symbol: sym_name.to_string(),
+                    rel_type: "Abs32".to_string(),
+                });
+            }
+            if patch_offset + 4 > buf.len() {
+                return Err(LinkError::RelocationPatchOutOfBounds {
+                    patch_offset,
+                    patch_size: 4,
+                    section_size: buf.len(),
+                    rel_type: "Abs32".to_string(),
+                });
+            }
+            buf[patch_offset..patch_offset + 4].copy_from_slice(&(value as u32).to_le_bytes());
+        }
+        RelocationType::Abs32S => {
+            let value = target_addr as i64 + addend;
+            // Check for overflow: value must fit in i32
+            if value < i32::MIN as i64 || value > i32::MAX as i64 {
+                return Err(LinkError::RelocationOverflow {
+                    symbol: sym_name.to_string(),
+                    rel_type: "Abs32S".to_string(),
+                });
+            }
+            if patch_offset + 4 > buf.len() {
+                return Err(LinkError::RelocationPatchOutOfBounds {
+                    patch_offset,
+                    patch_size: 4,
+                    section_size: buf.len(),
+                    rel_type: "Abs32S".to_string(),
+                });
+            }
+            buf[patch_offset..patch_offset + 4].copy_from_slice(&(value as i32).to_le_bytes());
+        }
+        RelocationType::Jump26 | RelocationType::Call26 => {
+            // AArch64 branch (B) or branch with link (BL) - 26-bit PC-relative offset
+            // Both use identical encoding for the immediate field
+            let value = target_addr as i64 + addend - pc as i64;
+            // Offset is in units of 4 bytes (instructions)
+            let offset = value >> 2;
+            // Check for overflow: must fit in 26 bits signed
+            let rel_name = if matches!(rel_type, RelocationType::Jump26) {
+                "Jump26"
+            } else {
+                "Call26"
+            };
+            if offset < -(1 << 25) || offset >= (1 << 25) {
+                return Err(LinkError::RelocationOverflow {
+                    symbol: sym_name.to_string(),
+                    rel_type: rel_name.to_string(),
+                });
+            }
+            if patch_offset + 4 > buf.len() {
+                return Err(LinkError::RelocationPatchOutOfBounds {
+                    patch_offset,
+                    patch_size: 4,
+                    section_size: buf.len(),
+                    rel_type: rel_name.to_string(),
+                });
+            }
+            // Read existing instruction and patch the immediate field
+            let mut inst =
+                u32::from_le_bytes(buf[patch_offset..patch_offset + 4].try_into().unwrap());
+            inst = (inst & 0xFC000000) | ((offset as u32) & 0x03FFFFFF);
+            buf[patch_offset..patch_offset + 4].copy_from_slice(&inst.to_le_bytes());
+        }
+        RelocationType::AdrpPage21 => {
+            // AArch64 ADRP - loads PC-relative page address (21-bit page offset)
+            // S + A gives the effective address; we need the page containing that
+            // Result is the page containing (S + A) minus page containing PC
+            let effective_addr = (target_addr as i64 + addend) as u64;
+            let target_page = effective_addr & !0xFFF;
+            let pc_page = pc & !0xFFF;
+            let page_offset = (target_page as i64) - (pc_page as i64);
+            // ADRP encodes a 21-bit signed page offset (each unit = 4KB page)
+            let page_count = page_offset >> 12;
+            // Check for overflow: must fit in 21 bits signed
+            if page_count < -(1 << 20) || page_count >= (1 << 20) {
+                return Err(LinkError::RelocationOverflow {
+                    symbol: sym_name.to_string(),
+                    rel_type: "AdrpPage21".to_string(),
+                });
+            }
+            if patch_offset + 4 > buf.len() {
+                return Err(LinkError::RelocationPatchOutOfBounds {
+                    patch_offset,
+                    patch_size: 4,
+                    section_size: buf.len(),
+                    rel_type: "AdrpPage21".to_string(),
+                });
+            }
+            // ADRP instruction format: imm is split into immlo (bits 29-30) and immhi (bits 5-23)
+            let imm = page_count as u32;
+            let immlo = (imm & 0x3) << 29; // bits 0-1 of imm -> bits 29-30
+            let immhi = ((imm >> 2) & 0x7FFFF) << 5; // bits 2-20 of imm -> bits 5-23
+            let mut inst =
+                u32::from_le_bytes(buf[patch_offset..patch_offset + 4].try_into().unwrap());
+            // Clear immlo and immhi fields, then set them
+            inst = (inst & 0x9F00001F) | immlo | immhi;
+            buf[patch_offset..patch_offset + 4].copy_from_slice(&inst.to_le_bytes());
+        }
+        RelocationType::AddLo12 => {
+            // AArch64 ADD/load-store PAGEOFF12 - low 12 bits of the effective
+            // address. S + A gives the effective address; extract its low 12 bits.
+            let effective_addr = (target_addr as i64 + addend) as u64;
+            let lo12 = (effective_addr & 0xFFF) as u32;
+            if patch_offset + 4 > buf.len() {
+                return Err(LinkError::RelocationPatchOutOfBounds {
+                    patch_offset,
+                    patch_size: 4,
+                    section_size: buf.len(),
+                    rel_type: "AddLo12".to_string(),
+                });
+            }
+            let mut inst =
+                u32::from_le_bytes(buf[patch_offset..patch_offset + 4].try_into().unwrap());
+
+            // PAGEOFF12 applies to both ADD and load/store instructions. For
+            // loads/stores the imm12 field is SCALED by the access size encoded
+            // in the instruction — writing the raw byte offset would multiply
+            // the effective displacement by the access size at runtime.
+            // (RUE-131 item 5a.) Rue's codegen only ever emits this on an ADD
+            // (the `else` branch), where the value is unscaled; handling the
+            // load/store form keeps both linker paths correct for any input.
+            let imm = if inst & 0x3B00_0000 == 0x3900_0000 {
+                // Load/store register, unsigned immediate class:
+                // scale = size bits [31:30]; 128-bit vector ops
+                // (size == 0b00, V == 1, opc<1> == 1) scale by 16.
+                let mut scale = inst >> 30;
+                if scale == 0 && inst & 0x0480_0000 == 0x0480_0000 {
+                    scale = 4;
+                }
+                if lo12 & ((1u32 << scale) - 1) != 0 {
+                    return Err(LinkError::RelocationOverflow {
+                        symbol: sym_name.to_string(),
+                        rel_type: format!(
+                            "AddLo12 (offset 0x{lo12:x} misaligned for {}-byte access)",
+                            1u32 << scale
+                        ),
+                    });
+                }
+                lo12 >> scale
+            } else {
+                // ADD immediate: unscaled
+                lo12
+            };
+
+            // ADD instruction format: imm12 is in bits 10-21
+            // Clear imm12 field (bits 10-21) and set it
+            inst = (inst & 0xFFC003FF) | (imm << 10);
+            buf[patch_offset..patch_offset + 4].copy_from_slice(&inst.to_le_bytes());
+        }
+        RelocationType::Unknown(t) => {
+            return Err(LinkError::UnsupportedRelocation(format!(
+                "unknown type {}",
+                t
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// A relocation waiting to be applied once all section addresses are known.
 struct PendingRelocation {
     /// Patch offset within the home buffer.
@@ -799,121 +1177,18 @@ impl Linker {
                 "relocating symbol"
             );
 
-            // Bounds-check the patch site against ITS OWN buffer — the old
-            // code indexed merged_text unconditionally. (RUE-131 item 8)
-            let check_bounds = |size: usize| -> Result<(), LinkError> {
-                if patch_idx + size > buf.len() {
-                    return Err(LinkError::RelocationPatchOutOfBounds {
-                        patch_offset: patch_idx,
-                        patch_size: size,
-                        section_size: buf.len(),
-                        rel_type: format!("{:?}", rel_type),
-                    });
-                }
-                Ok(())
-            };
-
-            // Apply the relocation based on type
-            match rel_type {
-                RelocationType::Call26 | RelocationType::Jump26 => {
-                    // ARM64 branch instruction: imm26 * 4 gives PC-relative offset
-                    check_bounds(4)?;
-                    let offset_bytes = target_vaddr as i64 - patch_vaddr as i64 + addend;
-                    let offset_words = offset_bytes >> 2;
-
-                    // Check range: 26-bit signed field gives ±128MB range
-                    if offset_words < -(1 << 25) || offset_words >= (1 << 25) {
-                        return Err(LinkError::RelocationOverflow {
-                            symbol: sym_name,
-                            rel_type: "ARM64_RELOC_BRANCH26".to_string(),
-                        });
-                    }
-
-                    // Read existing instruction and patch imm26 field
-                    let mut insn =
-                        u32::from_le_bytes(buf[patch_idx..patch_idx + 4].try_into().unwrap());
-                    insn = (insn & 0xFC000000) | ((offset_words as u32) & 0x03FFFFFF);
-                    buf[patch_idx..patch_idx + 4].copy_from_slice(&insn.to_le_bytes());
-                }
-                RelocationType::AdrpPage21 => {
-                    // ADRP: load page address (bits 12-32 of PC-relative offset)
-                    check_bounds(4)?;
-                    let target_page = (target_vaddr as i64 + addend) & !0xFFF;
-                    let patch_page = patch_vaddr as i64 & !0xFFF;
-                    let page_offset = (target_page - patch_page) >> 12;
-
-                    // 21-bit signed field
-                    if page_offset < -(1 << 20) || page_offset >= (1 << 20) {
-                        return Err(LinkError::RelocationOverflow {
-                            symbol: sym_name,
-                            rel_type: "ARM64_RELOC_PAGE21".to_string(),
-                        });
-                    }
-
-                    // Encode into ADRP instruction
-                    let mut insn =
-                        u32::from_le_bytes(buf[patch_idx..patch_idx + 4].try_into().unwrap());
-                    let imm = page_offset as u32 & 0x1FFFFF;
-                    let immlo = imm & 0x3;
-                    let immhi = (imm >> 2) & 0x7FFFF;
-                    insn = (insn & 0x9F00001F) | (immlo << 29) | (immhi << 5);
-                    buf[patch_idx..patch_idx + 4].copy_from_slice(&insn.to_le_bytes());
-                }
-                RelocationType::AddLo12 => {
-                    // ARM64_RELOC_PAGEOFF12: low 12 bits of the target address,
-                    // encoded in the imm12 field (bits 10-21).
-                    check_bounds(4)?;
-                    let lo12 = ((target_vaddr as i64 + addend) & 0xFFF) as u32;
-
-                    let mut insn =
-                        u32::from_le_bytes(buf[patch_idx..patch_idx + 4].try_into().unwrap());
-
-                    // PAGEOFF12 applies to both ADD and load/store
-                    // instructions. For loads/stores the imm12 field is
-                    // SCALED by the access size encoded in the instruction —
-                    // writing the raw byte offset multiplies the effective
-                    // displacement by the access size at runtime.
-                    // (RUE-131 item 5a)
-                    let imm = if insn & 0x3B00_0000 == 0x3900_0000 {
-                        // Load/store register, unsigned immediate class:
-                        // scale = size bits [31:30]; 128-bit vector ops
-                        // (size == 0b00, V == 1, opc<1> == 1) scale by 16.
-                        let mut scale = insn >> 30;
-                        if scale == 0 && insn & 0x0480_0000 == 0x0480_0000 {
-                            scale = 4;
-                        }
-                        if lo12 & ((1u32 << scale) - 1) != 0 {
-                            return Err(LinkError::RelocationOverflow {
-                                symbol: sym_name,
-                                rel_type: format!(
-                                    "ARM64_RELOC_PAGEOFF12 (offset 0x{lo12:x} misaligned \
-                                     for {}-byte access)",
-                                    1u32 << scale
-                                ),
-                            });
-                        }
-                        lo12 >> scale
-                    } else {
-                        // ADD immediate: unscaled
-                        lo12
-                    };
-
-                    insn = (insn & 0xFFC003FF) | (imm << 10);
-                    buf[patch_idx..patch_idx + 4].copy_from_slice(&insn.to_le_bytes());
-                }
-                RelocationType::Aarch64Abs64 | RelocationType::Abs64 => {
-                    // ARM64_RELOC_UNSIGNED: 64-bit absolute address (pointer
-                    // slots in rodata/data). Previously unsupported on the
-                    // Mach-O path because rodata/data relocations were never
-                    // collected at all. (RUE-131 item 11)
-                    check_bounds(8)?;
-                    let value = (target_vaddr as i64 + addend) as u64;
-                    buf[patch_idx..patch_idx + 8].copy_from_slice(&value.to_le_bytes());
-                }
-                _ => {
-                    return Err(LinkError::UnsupportedRelocation(format!("{:?}", rel_type)));
-                }
-            }
+            // Patch the site. The per-kind encoding — including the bounds
+            // check against ITS OWN buffer (RUE-131 item 8) — is shared with
+            // the ELF path via `apply_relocation` (RUE-335).
+            apply_relocation(
+                buf,
+                patch_idx,
+                patch_vaddr,
+                target_vaddr,
+                addend,
+                rel_type,
+                &sym_name,
+            )?;
         }
 
         // Now build the binary with the relocated code.
@@ -1291,328 +1566,17 @@ impl Linker {
             let pc = base_vaddr + offset;
             let patch_offset = offset as usize;
 
-            match rel_type {
-                RelocationType::Pc32 | RelocationType::Plt32 => {
-                    // S + A - P, where S is symbol address, A is addend, P is place
-                    let value = target_addr as i64 + addend - pc as i64;
-                    // Check for overflow: value must fit in i32
-                    if value < i32::MIN as i64 || value > i32::MAX as i64 {
-                        return Err(LinkError::RelocationOverflow {
-                            symbol: sym_name.clone(),
-                            rel_type: format!("{:?}", rel_type),
-                        });
-                    }
-                    if patch_offset + 4 > buf.len() {
-                        return Err(LinkError::RelocationPatchOutOfBounds {
-                            patch_offset,
-                            patch_size: 4,
-                            section_size: buf.len(),
-                            rel_type: format!("{:?}", rel_type),
-                        });
-                    }
-                    buf[patch_offset..patch_offset + 4]
-                        .copy_from_slice(&(value as i32).to_le_bytes());
-                }
-                RelocationType::GotPcRel => {
-                    // R_X86_64_GOTPCREL: Load from GOT entry.
-                    // For static linking, we relax this to use the symbol address directly.
-                    // This requires rewriting indirect calls/jumps to direct ones, similar to
-                    // GotPcRelX but without the compiler's guarantee that it's safe.
-                    // In static linking, we know all symbols are resolved, so it's always safe.
-                    //
-                    // Transform indirect call: `call *[rip+disp]` (FF /2) -> `addr32 call rel32` (67 E8)
-                    // Transform indirect jmp:  `jmp *[rip+disp]` (FF /4) -> `addr32 jmp rel32` (67 E9)
-                    // Transform indirect mov:  `mov reg, [rip+disp]` (8B) -> `lea reg, [rip+disp]` (8D)
-                    if patch_offset >= 2 {
-                        let opcode_offset = patch_offset - 2;
-                        if buf[opcode_offset] == 0xFF {
-                            let modrm = buf[opcode_offset + 1];
-                            let reg_field = (modrm >> 3) & 0x7;
-                            if reg_field == 2 {
-                                // Indirect call: `call *[rip+disp]` (FF /2, ModR/M 15)
-                                // Transform to: `addr32 call rel32` (67 E8)
-                                buf[opcode_offset] = 0x67; // addr32 prefix
-                                buf[opcode_offset + 1] = 0xE8; // direct call opcode
-                            } else if reg_field == 4 {
-                                // Indirect jmp: `jmp *[rip+disp]` (FF /4, ModR/M 25)
-                                // Transform to: `addr32 jmp rel32` (67 E9)
-                                buf[opcode_offset] = 0x67; // addr32 prefix
-                                buf[opcode_offset + 1] = 0xE9; // direct jmp opcode
-                            }
-                        } else if buf[opcode_offset] == 0x8B {
-                            // MOV: `mov reg, [rip+disp]` -> `lea reg, [rip+disp]`
-                            buf[opcode_offset] = 0x8D; // LEA opcode
-                        }
-                        // Other patterns: just patch displacement (best effort)
-                    }
-
-                    let value = target_addr as i64 + addend - pc as i64;
-                    if value < i32::MIN as i64 || value > i32::MAX as i64 {
-                        return Err(LinkError::RelocationOverflow {
-                            symbol: sym_name.clone(),
-                            rel_type: format!("{:?}", rel_type),
-                        });
-                    }
-                    if patch_offset + 4 > buf.len() {
-                        return Err(LinkError::RelocationPatchOutOfBounds {
-                            patch_offset,
-                            patch_size: 4,
-                            section_size: buf.len(),
-                            rel_type: format!("{:?}", rel_type),
-                        });
-                    }
-                    buf[patch_offset..patch_offset + 4]
-                        .copy_from_slice(&(value as i32).to_le_bytes());
-                }
-                RelocationType::GotPcRelX => {
-                    // R_X86_64_GOTPCRELX: GOT access without REX prefix.
-                    // For static linking, we perform GOT relaxation:
-                    // - `mov reg, [rip+disp]` (8B) -> `lea reg, [rip+disp]` (8D)
-                    // - `call *[rip+disp]` (FF /2) -> `addr32 call rel32` (67 E8)
-                    // - `jmp *[rip+disp]` (FF /4) -> `addr32 jmp rel32` (67 E9)
-                    //
-                    // The relocation offset points to the displacement, so:
-                    // - For MOV: opcode is at offset - 2
-                    // - For CALL/JMP: opcode (FF) is at offset - 2, ModR/M is at offset - 1
-                    if patch_offset >= 2 {
-                        let opcode_offset = patch_offset - 2;
-                        if buf[opcode_offset] == 0xFF {
-                            let modrm = buf[opcode_offset + 1];
-                            let reg_field = (modrm >> 3) & 0x7;
-                            if reg_field == 2 {
-                                // Indirect call: `call *[rip+disp]` (FF /2, ModR/M 15)
-                                // Transform to: `addr32 call rel32` (67 E8)
-                                buf[opcode_offset] = 0x67; // addr32 prefix
-                                buf[opcode_offset + 1] = 0xE8; // direct call opcode
-                            } else if reg_field == 4 {
-                                // Indirect jmp: `jmp *[rip+disp]` (FF /4, ModR/M 25)
-                                // Transform to: `addr32 jmp rel32` (67 E9)
-                                buf[opcode_offset] = 0x67; // addr32 prefix
-                                buf[opcode_offset + 1] = 0xE9; // direct jmp opcode
-                            }
-                        } else if buf[opcode_offset] == 0x8B {
-                            // MOV: `mov reg, [rip+disp]` -> `lea reg, [rip+disp]`
-                            buf[opcode_offset] = 0x8D; // LEA opcode
-                        }
-                        // Other patterns: just patch displacement (best effort)
-                    }
-
-                    let value = target_addr as i64 + addend - pc as i64;
-                    if value < i32::MIN as i64 || value > i32::MAX as i64 {
-                        return Err(LinkError::RelocationOverflow {
-                            symbol: sym_name.clone(),
-                            rel_type: format!("{:?}", rel_type),
-                        });
-                    }
-                    if patch_offset + 4 > buf.len() {
-                        return Err(LinkError::RelocationPatchOutOfBounds {
-                            patch_offset,
-                            patch_size: 4,
-                            section_size: buf.len(),
-                            rel_type: format!("{:?}", rel_type),
-                        });
-                    }
-                    buf[patch_offset..patch_offset + 4]
-                        .copy_from_slice(&(value as i32).to_le_bytes());
-                }
-                RelocationType::RexGotPcRelX => {
-                    // R_X86_64_REX_GOTPCRELX: GOT access with REX prefix.
-                    // For static linking, we perform GOT relaxation:
-                    // - `mov reg, [rip+disp]` (REX 8B) -> `lea reg, [rip+disp]` (REX 8D)
-                    // - `call *[rip+disp]` (REX FF /2) -> `addr32 call rel32` (REX 67 E8)
-                    // - `jmp *[rip+disp]` (REX FF /4) -> `addr32 jmp rel32` (REX 67 E9)
-                    //
-                    // The relocation offset points to the displacement, so:
-                    // - For MOV with REX: REX is at offset - 3, opcode at offset - 2
-                    // - For CALL/JMP with REX: similar layout
-                    if patch_offset >= 2 {
-                        let opcode_offset = patch_offset - 2;
-                        if buf[opcode_offset] == 0xFF {
-                            let modrm = buf[opcode_offset + 1];
-                            let reg_field = (modrm >> 3) & 0x7;
-                            if reg_field == 2 {
-                                // Indirect call with REX: `REX call *[rip+disp]` (4x FF /2)
-                                // Transform to: `addr32 call rel32` (67 E8) - REX stays at offset-3
-                                buf[opcode_offset] = 0x67; // addr32 prefix
-                                buf[opcode_offset + 1] = 0xE8; // direct call opcode
-                            // Note: REX prefix at offset-3 becomes harmless (no-op for CALL)
-                            } else if reg_field == 4 {
-                                // Indirect jmp with REX: `REX jmp *[rip+disp]` (4x FF /4)
-                                // Transform to: `addr32 jmp rel32` (67 E9)
-                                buf[opcode_offset] = 0x67; // addr32 prefix
-                                buf[opcode_offset + 1] = 0xE9; // direct jmp opcode
-                            }
-                        } else if buf[opcode_offset] == 0x8B {
-                            // MOV with REX: `REX mov reg, [rip+disp]` -> `REX lea reg, [rip+disp]`
-                            buf[opcode_offset] = 0x8D; // LEA opcode
-                        }
-                        // Other patterns: just patch displacement (best effort)
-                    }
-
-                    let value = target_addr as i64 + addend - pc as i64;
-                    if value < i32::MIN as i64 || value > i32::MAX as i64 {
-                        return Err(LinkError::RelocationOverflow {
-                            symbol: sym_name.clone(),
-                            rel_type: format!("{:?}", rel_type),
-                        });
-                    }
-                    if patch_offset + 4 > buf.len() {
-                        return Err(LinkError::RelocationPatchOutOfBounds {
-                            patch_offset,
-                            patch_size: 4,
-                            section_size: buf.len(),
-                            rel_type: format!("{:?}", rel_type),
-                        });
-                    }
-                    buf[patch_offset..patch_offset + 4]
-                        .copy_from_slice(&(value as i32).to_le_bytes());
-                }
-                RelocationType::Abs64 | RelocationType::Aarch64Abs64 => {
-                    let value = (target_addr as i64 + addend) as u64;
-                    if patch_offset + 8 > buf.len() {
-                        return Err(LinkError::RelocationPatchOutOfBounds {
-                            patch_offset,
-                            patch_size: 8,
-                            section_size: buf.len(),
-                            rel_type: format!("{:?}", rel_type),
-                        });
-                    }
-                    buf[patch_offset..patch_offset + 8].copy_from_slice(&value.to_le_bytes());
-                }
-                RelocationType::Abs32 => {
-                    let value = target_addr as i64 + addend;
-                    // Check for overflow: value must fit in u32
-                    if value < 0 || value > u32::MAX as i64 {
-                        return Err(LinkError::RelocationOverflow {
-                            symbol: sym_name.clone(),
-                            rel_type: "Abs32".to_string(),
-                        });
-                    }
-                    if patch_offset + 4 > buf.len() {
-                        return Err(LinkError::RelocationPatchOutOfBounds {
-                            patch_offset,
-                            patch_size: 4,
-                            section_size: buf.len(),
-                            rel_type: "Abs32".to_string(),
-                        });
-                    }
-                    buf[patch_offset..patch_offset + 4]
-                        .copy_from_slice(&(value as u32).to_le_bytes());
-                }
-                RelocationType::Abs32S => {
-                    let value = target_addr as i64 + addend;
-                    // Check for overflow: value must fit in i32
-                    if value < i32::MIN as i64 || value > i32::MAX as i64 {
-                        return Err(LinkError::RelocationOverflow {
-                            symbol: sym_name.clone(),
-                            rel_type: "Abs32S".to_string(),
-                        });
-                    }
-                    if patch_offset + 4 > buf.len() {
-                        return Err(LinkError::RelocationPatchOutOfBounds {
-                            patch_offset,
-                            patch_size: 4,
-                            section_size: buf.len(),
-                            rel_type: "Abs32S".to_string(),
-                        });
-                    }
-                    buf[patch_offset..patch_offset + 4]
-                        .copy_from_slice(&(value as i32).to_le_bytes());
-                }
-                RelocationType::Jump26 | RelocationType::Call26 => {
-                    // AArch64 branch (B) or branch with link (BL) - 26-bit PC-relative offset
-                    // Both use identical encoding for the immediate field
-                    let value = target_addr as i64 + addend - pc as i64;
-                    // Offset is in units of 4 bytes (instructions)
-                    let offset = value >> 2;
-                    // Check for overflow: must fit in 26 bits signed
-                    let rel_name = if matches!(rel_type, RelocationType::Jump26) {
-                        "Jump26"
-                    } else {
-                        "Call26"
-                    };
-                    if offset < -(1 << 25) || offset >= (1 << 25) {
-                        return Err(LinkError::RelocationOverflow {
-                            symbol: sym_name.clone(),
-                            rel_type: rel_name.to_string(),
-                        });
-                    }
-                    if patch_offset + 4 > buf.len() {
-                        return Err(LinkError::RelocationPatchOutOfBounds {
-                            patch_offset,
-                            patch_size: 4,
-                            section_size: buf.len(),
-                            rel_type: rel_name.to_string(),
-                        });
-                    }
-                    // Read existing instruction and patch the immediate field
-                    let mut inst =
-                        u32::from_le_bytes(buf[patch_offset..patch_offset + 4].try_into().unwrap());
-                    inst = (inst & 0xFC000000) | ((offset as u32) & 0x03FFFFFF);
-                    buf[patch_offset..patch_offset + 4].copy_from_slice(&inst.to_le_bytes());
-                }
-                RelocationType::AdrpPage21 => {
-                    // AArch64 ADRP - loads PC-relative page address (21-bit page offset)
-                    // S + A gives the effective address; we need the page containing that
-                    // Result is the page containing (S + A) minus page containing PC
-                    let effective_addr = (target_addr as i64 + addend) as u64;
-                    let target_page = effective_addr & !0xFFF;
-                    let pc_page = pc & !0xFFF;
-                    let page_offset = (target_page as i64) - (pc_page as i64);
-                    // ADRP encodes a 21-bit signed page offset (each unit = 4KB page)
-                    let page_count = page_offset >> 12;
-                    // Check for overflow: must fit in 21 bits signed
-                    if page_count < -(1 << 20) || page_count >= (1 << 20) {
-                        return Err(LinkError::RelocationOverflow {
-                            symbol: sym_name.clone(),
-                            rel_type: "AdrpPage21".to_string(),
-                        });
-                    }
-                    if patch_offset + 4 > buf.len() {
-                        return Err(LinkError::RelocationPatchOutOfBounds {
-                            patch_offset,
-                            patch_size: 4,
-                            section_size: buf.len(),
-                            rel_type: "AdrpPage21".to_string(),
-                        });
-                    }
-                    // ADRP instruction format: imm is split into immlo (bits 29-30) and immhi (bits 5-23)
-                    let imm = page_count as u32;
-                    let immlo = (imm & 0x3) << 29; // bits 0-1 of imm -> bits 29-30
-                    let immhi = ((imm >> 2) & 0x7FFFF) << 5; // bits 2-20 of imm -> bits 5-23
-                    let mut inst =
-                        u32::from_le_bytes(buf[patch_offset..patch_offset + 4].try_into().unwrap());
-                    // Clear immlo and immhi fields, then set them
-                    inst = (inst & 0x9F00001F) | immlo | immhi;
-                    buf[patch_offset..patch_offset + 4].copy_from_slice(&inst.to_le_bytes());
-                }
-                RelocationType::AddLo12 => {
-                    // AArch64 ADD - adds 12-bit page offset
-                    // S + A gives the effective address; extract low 12 bits as page offset
-                    let effective_addr = (target_addr as i64 + addend) as u64;
-                    let page_offset = (effective_addr & 0xFFF) as u32;
-                    if patch_offset + 4 > buf.len() {
-                        return Err(LinkError::RelocationPatchOutOfBounds {
-                            patch_offset,
-                            patch_size: 4,
-                            section_size: buf.len(),
-                            rel_type: "AddLo12".to_string(),
-                        });
-                    }
-                    // ADD instruction format: imm12 is in bits 10-21
-                    let mut inst =
-                        u32::from_le_bytes(buf[patch_offset..patch_offset + 4].try_into().unwrap());
-                    // Clear imm12 field (bits 10-21) and set it
-                    inst = (inst & 0xFFC003FF) | (page_offset << 10);
-                    buf[patch_offset..patch_offset + 4].copy_from_slice(&inst.to_le_bytes());
-                }
-                RelocationType::Unknown(t) => {
-                    return Err(LinkError::UnsupportedRelocation(format!(
-                        "unknown type {}",
-                        t
-                    )));
-                }
-            }
+            // Patch the site; the per-kind encoding is shared with the
+            // Mach-O path via `apply_relocation` (RUE-335).
+            apply_relocation(
+                buf,
+                patch_offset,
+                pc,
+                target_addr,
+                addend,
+                rel_type,
+                &sym_name,
+            )?;
         }
 
         // Build the ELF with proper W^X segment separation

--- a/crates/rue-oracle-diff/src/fuzz.rs
+++ b/crates/rue-oracle-diff/src/fuzz.rs
@@ -31,8 +31,15 @@ enum Compiled {
     /// The compiler rejected a program the oracle's frontend accepted — an ICE
     /// or backend gap (carries the compiler's stderr, truncated).
     CompileFail(String),
-    /// The binary ran to completion: process exit code + captured stdout.
-    Ran { exit: i32, stdout: String },
+    /// The binary ran to completion: process exit code + captured stdout +
+    /// captured stderr. `stderr` carries the runtime's trap message (e.g.
+    /// `"error: integer overflow\n"`) so that when both engines exit 101 we can
+    /// compare *which* trap fired, not just that one did (RUE-339).
+    Ran {
+        exit: i32,
+        stdout: String,
+        stderr: String,
+    },
     /// The binary was killed by a signal (e.g. SIGSEGV) — a hard miscompile.
     Crash(i32),
     /// The binary did not terminate within the per-program timeout.
@@ -226,14 +233,67 @@ enum Verdict {
     Disagree(String),
 }
 
+/// A category of runtime trap, shared vocabulary between the oracle's panic
+/// reason ([`rue_oracle::Outcome::panic`]) and the compiled runtime's stderr
+/// message (`rue-runtime/src/error.rs`). Every defined Rue trap exits 101, so
+/// the exit code alone cannot tell two traps apart; this is what lets
+/// [`classify`] catch a miscompile that traps for the *wrong reason* (RUE-339).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TrapCategory {
+    DivideByZero,
+    Overflow,
+    IntCastOverflow,
+    Bounds,
+}
+
+/// Classify the oracle's panic reason (the exact strings raised in
+/// `rue-oracle/src/lib.rs`) into a [`TrapCategory`]. Reasons we don't map (e.g.
+/// `"reached unreachable"`, which has no distinct runtime message class) return
+/// `None`, so the caller falls back to plain exit-code agreement rather than
+/// inventing a disagreement.
+fn oracle_trap_category(reason: &str) -> Option<TrapCategory> {
+    match reason {
+        // The runtime routes both `x / 0` and `x % 0` to the single
+        // `error: division by zero` handler, so both oracle reasons map here.
+        "divide by zero" | "remainder by zero" => Some(TrapCategory::DivideByZero),
+        "arithmetic overflow" => Some(TrapCategory::Overflow),
+        "integer cast overflow" => Some(TrapCategory::IntCastOverflow),
+        "index out of bounds" => Some(TrapCategory::Bounds),
+        _ => None,
+    }
+}
+
+/// Classify the compiled runtime's stderr message into a [`TrapCategory`] by its
+/// distinguishing class substring (the messages are defined in
+/// `rue-runtime/src/error.rs`). We match on the class rather than the exact
+/// bytes so wording tweaks don't cause false-disagrees, and check the more
+/// specific `integer cast overflow` before `integer overflow`. An unrecognized
+/// message (a `@panic`/`@assert`/UTF-8/unreachable trap, or future wording)
+/// returns `None`, falling back to exit-code agreement.
+fn runtime_trap_category(stderr: &str) -> Option<TrapCategory> {
+    if stderr.contains("integer cast overflow") {
+        Some(TrapCategory::IntCastOverflow)
+    } else if stderr.contains("integer overflow") {
+        Some(TrapCategory::Overflow)
+    } else if stderr.contains("division by zero") {
+        Some(TrapCategory::DivideByZero)
+    } else if stderr.contains("index out of bounds") {
+        Some(TrapCategory::Bounds)
+    } else {
+        None
+    }
+}
+
 fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Verdict {
     match compiled {
-        Compiled::Ran { exit, stdout } => {
+        Compiled::Ran {
+            exit,
+            stdout,
+            stderr,
+        } => {
             let exit_ok = oracle.exit_code == *exit;
             let stdout_ok = &oracle.stdout == stdout;
-            if exit_ok && stdout_ok {
-                Verdict::Agree
-            } else {
+            if !exit_ok || !stdout_ok {
                 let mut r = String::new();
                 if !exit_ok {
                     r += &format!("exit: oracle {} vs compiled {exit}; ", oracle.exit_code);
@@ -244,8 +304,29 @@ fn classify(oracle: &rue_oracle::Outcome, compiled: &Compiled) -> Verdict {
                         oracle.stdout, stdout
                     );
                 }
-                Verdict::Disagree(r)
+                return Verdict::Disagree(r);
             }
+            // Exit code and stdout agree. When both engines ended in a runtime
+            // trap (exit 101), also compare *which* trap fired: since every Rue
+            // trap exits 101, a miscompile that traps for the wrong reason at
+            // the same point would otherwise be a false-AGREE (RUE-339). We
+            // compare category classes, not exact message bytes, to avoid
+            // false-disagrees; if either side's cause can't be classified (e.g.
+            // a `@panic`/unreachable trap, or an unmapped oracle reason) we fall
+            // back to the exit-code agreement above — a documented residual
+            // blind spot, never a manufactured disagreement.
+            if *exit == 101
+                && let Some(want) = oracle.panic.as_deref().and_then(oracle_trap_category)
+                && let Some(got) = runtime_trap_category(stderr)
+                && want != got
+            {
+                return Verdict::Disagree(format!(
+                    "panic category: oracle {want:?} vs compiled {got:?} \
+                     (both exit 101; compiled stderr {:?})",
+                    first_line(stderr)
+                ));
+            }
+            Verdict::Agree
         }
         Compiled::CompileFail(stderr) => Verdict::Disagree(format!(
             "compiler rejected a program the oracle accepted (possible ICE/backend gap): {}",
@@ -288,12 +369,14 @@ fn compile_and_run(
     }
 
     // Run the produced binary directly with a manual timeout so we can read the
-    // child's own exit code / terminating signal unambiguously.
+    // child's own exit code / terminating signal unambiguously. stderr is
+    // captured (not `Stdio::null`) so a trap's message is available to
+    // `classify` for panic-category comparison (RUE-339).
     let mut child = Command::new(&bin_path)
         .current_dir(dir)
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
-        .stderr(Stdio::null())
+        .stderr(Stdio::piped())
         .spawn()?;
 
     let start = Instant::now();
@@ -304,8 +387,20 @@ fn compile_and_run(
                 if let Some(mut out) = child.stdout.take() {
                     out.read_to_string(&mut stdout).ok();
                 }
+                // Bounded read: trap messages are short, and the child has
+                // already exited, so its full output is buffered in the pipe —
+                // no drain-deadlock. The cap just guards against a chatty
+                // program making us buffer unbounded stderr.
+                let mut stderr = String::new();
+                if let Some(err) = child.stderr.take() {
+                    err.take(8192).read_to_string(&mut stderr).ok();
+                }
                 return Ok(match status.code() {
-                    Some(code) => Compiled::Ran { exit: code, stdout },
+                    Some(code) => Compiled::Ran {
+                        exit: code,
+                        stdout,
+                        stderr,
+                    },
                     None => Compiled::Crash(status.signal().unwrap_or(0)),
                 });
             }
@@ -348,7 +443,7 @@ impl Disagreement {
 
 fn describe(c: &Compiled) -> String {
     match c {
-        Compiled::Ran { exit, stdout } => format!("ran exit={exit} stdout={stdout:?}"),
+        Compiled::Ran { exit, stdout, .. } => format!("ran exit={exit} stdout={stdout:?}"),
         Compiled::CompileFail(e) => format!("compile-fail: {}", first_line(e)),
         Compiled::Crash(sig) => format!("crash signal={sig}"),
         Compiled::Timeout => "timeout".to_string(),
@@ -398,45 +493,109 @@ mod tests {
         }
     }
 
+    /// An oracle outcome that ended in a runtime trap (exit 101) with `reason`.
+    fn trap(reason: &str) -> Outcome {
+        Outcome {
+            exit_code: 101,
+            stdout: String::new(),
+            panic: Some(reason.to_string()),
+        }
+    }
+
+    /// A `Compiled::Ran` with no captured stderr (for the non-trap tests).
+    fn ran(exit: i32, stdout: &str) -> Compiled {
+        Compiled::Ran {
+            exit,
+            stdout: stdout.to_string(),
+            stderr: String::new(),
+        }
+    }
+
+    /// A `Compiled::Ran` that trapped at exit 101 with the given stderr message.
+    fn ran_trap(stderr: &str) -> Compiled {
+        Compiled::Ran {
+            exit: 101,
+            stdout: String::new(),
+            stderr: stderr.to_string(),
+        }
+    }
+
     fn is_disagree(v: Verdict) -> bool {
         matches!(v, Verdict::Disagree(_))
     }
 
     #[test]
     fn agrees_when_exit_and_stdout_match() {
-        let v = classify(
-            &oc(42, "7\n"),
-            &Compiled::Ran {
-                exit: 42,
-                stdout: "7\n".to_string(),
-            },
-        );
+        let v = classify(&oc(42, "7\n"), &ran(42, "7\n"));
         assert!(matches!(v, Verdict::Agree));
     }
 
     #[test]
     fn detects_exit_mismatch() {
         // The planted-bug shape: same stdout, wrong exit code.
-        let v = classify(
-            &oc(42, ""),
-            &Compiled::Ran {
-                exit: 43,
-                stdout: String::new(),
-            },
-        );
+        let v = classify(&oc(42, ""), &ran(43, ""));
         assert!(is_disagree(v));
     }
 
     #[test]
     fn detects_stdout_mismatch() {
+        let v = classify(&oc(0, "7\n"), &ran(0, "8\n"));
+        assert!(is_disagree(v));
+    }
+
+    #[test]
+    fn detects_wrong_trap_at_exit_101() {
+        // RUE-339: the false-AGREE this fix closes. Both engines exit 101 with
+        // identical (empty) stdout, but the oracle expected an arithmetic
+        // overflow while the compiled binary trapped on a bounds check — a
+        // miscompile that the old exit-code-only comparator scored as Agree.
         let v = classify(
-            &oc(0, "7\n"),
-            &Compiled::Ran {
-                exit: 0,
-                stdout: "8\n".to_string(),
-            },
+            &trap("arithmetic overflow"),
+            &ran_trap("error: index out of bounds\n"),
         );
         assert!(is_disagree(v));
+    }
+
+    #[test]
+    fn agrees_when_trap_categories_match() {
+        // Same cause on both sides -> genuine agreement, not a false-disagree.
+        let v = classify(
+            &trap("divide by zero"),
+            &ran_trap("error: division by zero\n"),
+        );
+        assert!(matches!(v, Verdict::Agree));
+        // The oracle's `remainder by zero` maps to the runtime's single
+        // `division by zero` handler — must still agree (category, not bytes).
+        let v = classify(
+            &trap("remainder by zero"),
+            &ran_trap("error: division by zero\n"),
+        );
+        assert!(matches!(v, Verdict::Agree));
+        // `integer cast overflow` must not be confused with `integer overflow`.
+        let v = classify(
+            &trap("integer cast overflow"),
+            &ran_trap("error: integer cast overflow\n"),
+        );
+        assert!(matches!(v, Verdict::Agree));
+        let v = classify(
+            &trap("integer cast overflow"),
+            &ran_trap("error: integer overflow\n"),
+        );
+        assert!(is_disagree(v));
+    }
+
+    #[test]
+    fn falls_back_when_cause_unclassifiable() {
+        // An unmapped runtime message (e.g. a `@panic`/unreachable trap) must
+        // NOT manufacture a disagreement — we fall back to exit-code agreement.
+        let v = classify(&trap("arithmetic overflow"), &ran_trap("panic: boom\n"));
+        assert!(matches!(v, Verdict::Agree));
+        // Likewise an oracle reason we don't map (e.g. reached unreachable).
+        let v = classify(
+            &trap("reached unreachable"),
+            &ran_trap("error: integer overflow\n"),
+        );
+        assert!(matches!(v, Verdict::Agree));
     }
 
     #[test]

--- a/crates/rue-spec/cases/modules/bindings.toml
+++ b/crates/rue-spec/cases/modules/bindings.toml
@@ -392,3 +392,113 @@ pub fn touch() -> i32 { let h = Hidden::A; match h { Hidden::A => 1, Hidden::B =
 """ }
 compile_fail = true
 error_contains = ["E0706", "is private"]
+
+# =============================================================================
+# Associated-function privacy follows the enclosing type (10.4:19, RUE-330).
+# Calling an associated function of a private struct across a directory
+# boundary is E0460 — the same rule as naming that struct in a literal or
+# annotation — whether the call is unqualified or module-qualified.
+
+[[case]]
+name = "cross_dir_unqualified_private_assoc_fn_rejected"
+spec = ["10.4:19"]
+description = "An unqualified associated-function call on a private struct from another directory is E0460 (RUE-330)"
+source = """
+const lib = @import("sub/lib");
+
+fn main() -> i32 {
+    let s = Secret::make();
+    s.n
+}
+"""
+aux_files = { "sub/lib.rue" = """
+struct Secret {
+    n: i32,
+    fn make() -> Secret { Secret { n: 5 } }
+}
+""" }
+compile_fail = true
+error_contains = ["E0460", "struct `Secret` is private"]
+
+[[case]]
+name = "cross_dir_qualified_private_assoc_fn_rejected"
+spec = ["10.4:19"]
+description = "A module-qualified associated-function call on a private struct from another directory is E0460 (resolves the type through the flat namespace, RUE-330)"
+source = """
+const lib = @import("sub/lib");
+
+fn main() -> i32 {
+    let s = lib.Secret::make();
+    s.n
+}
+"""
+aux_files = { "sub/lib.rue" = """
+struct Secret {
+    n: i32,
+    fn make() -> Secret { Secret { n: 5 } }
+}
+""" }
+compile_fail = true
+error_contains = ["E0460", "struct `Secret` is private"]
+
+[[case]]
+name = "cross_dir_pub_assoc_fn_allowed"
+spec = ["10.4:19"]
+description = "An associated-function call on a pub struct across directories is allowed"
+source = """
+const lib = @import("sub/lib");
+
+fn main() -> i32 {
+    let p = Point::origin();
+    p.x + p.y
+}
+"""
+aux_files = { "sub/lib.rue" = """
+pub struct Point {
+    x: i32,
+    y: i32,
+    fn origin() -> Point { Point { x: 30, y: 12 } }
+}
+""" }
+exit_code = 42
+
+[[case]]
+name = "same_dir_private_assoc_fn_allowed"
+spec = ["10.4:19"]
+description = "Intra-directory visibility is unchanged: an associated-function call on a private struct in another listed file in the same directory is allowed"
+source = """
+fn main() -> i32 {
+    let s = Secret::make();
+    s.n
+}
+"""
+aux_files = { "lib.rue" = """
+struct Secret {
+    n: i32,
+    fn make() -> Secret { Secret { n: 42 } }
+}
+""" }
+pass_aux_files = true
+exit_code = 42
+
+[[case]]
+name = "cross_dir_comptime_bound_assoc_fn_allowed"
+spec = ["10.4:19"]
+description = "A receiver type reached through a comptime binding (not by naming the struct) is exempt: `let P = lib.Point; P::origin()` is allowed"
+source = """
+const lib = @import("sub/lib");
+
+fn main() -> i32 {
+    let P = lib.Point;
+    let p = P::origin();
+    p.x + p.y
+}
+"""
+aux_files = { "sub/lib.rue" = """
+pub struct Point {
+    x: i32,
+    y: i32,
+    fn origin() -> Point { Point { x: 30, y: 12 } }
+}
+""" }
+exit_code = 42

--- a/crates/rue-spec/cases/types/structs.toml
+++ b/crates/rue-spec/cases/types/structs.toml
@@ -82,11 +82,20 @@ exit_code = 42
 
 # =============================================================================
 # Memory Layout
+#
+# Layout is implementation-defined (3.6:7): @size_of/@align_of report the layout
+# the current implementation chose, they do not guarantee a value. The guarantee
+# tested here is that @size_of/@align_of are well-defined observations (3.6:8);
+# the specific numbers (8-byte slots, declaration order, no padding, 8-byte
+# alignment) are documented observations of the current layout (3.6:9/10/12),
+# not language guarantees.
 # =============================================================================
 
+# @size_of is a well-defined observation (3.6:8); the concrete 8-byte slot is
+# this implementation's documented choice (3.6:9).
 [[case]]
 name = "scalar_size_8_bytes"
-spec = ["3.6:8"]
+spec = ["3.6:8", "3.6:9"]
 source = """
 fn main() -> i32 {
     @size_of(i32)
@@ -96,7 +105,7 @@ exit_code = 8
 
 [[case]]
 name = "bool_size_8_bytes"
-spec = ["3.6:8"]
+spec = ["3.6:8", "3.6:9"]
 source = """
 fn main() -> i32 {
     @size_of(bool)
@@ -114,25 +123,29 @@ fn main() -> i32 {
 """
 exit_code = 0
 
+# Declaration-order, 8-byte-slot layout is this implementation's documented
+# observation (3.6:9), not a language guarantee.
 [[case]]
 name = "struct_fields_declaration_order"
 spec = ["3.6:9"]
 source = """
 struct Point { x: i32, y: i32 }
 fn main() -> i32 {
-    // Two fields, each 8 bytes = 16 bytes total
+    // Current implementation: two fields, each in one 8-byte slot = 16 bytes.
     @size_of(Point)
 }
 """
 exit_code = 16
 
+# Size = sum of field sizes with no padding is a documented observation of the
+# current layout (3.6:10), not guaranteed.
 [[case]]
 name = "struct_size_sum_of_fields"
 spec = ["3.6:10"]
 source = """
 struct Triple { a: i32, b: i32, c: i32 }
 fn main() -> i32 {
-    // Three fields, each 8 bytes = 24 bytes
+    // Current implementation: three 8-byte slots = 24 bytes.
     @size_of(Triple)
 }
 """
@@ -145,15 +158,17 @@ source = """
 struct Point { x: i32, y: i32 }
 struct Line { start: Point, end: Point }
 fn main() -> i32 {
-    // Two Points, each 16 bytes = 32 bytes
+    // Current implementation: two Points, each 16 bytes = 32 bytes.
     @size_of(Line)
 }
 """
 exit_code = 32
 
+# @align_of is a well-defined observation (3.6:8); the concrete 8-byte alignment
+# is this implementation's documented choice (3.6:12).
 [[case]]
 name = "struct_alignment_8_bytes"
-spec = ["3.6:12"]
+spec = ["3.6:8", "3.6:12"]
 source = """
 struct Point { x: i32, y: i32 }
 fn main() -> i32 {
@@ -164,7 +179,7 @@ exit_code = 8
 
 [[case]]
 name = "scalar_alignment_8_bytes"
-spec = ["3.6:12"]
+spec = ["3.6:8", "3.6:12"]
 source = """
 fn main() -> i32 {
     @align_of(i64)

--- a/docs/spec/src/03-types/06-struct-types.md
+++ b/docs/spec/src/03-types/06-struct-types.md
@@ -50,33 +50,40 @@ Field names **MUST** be unique within a struct.
 
 {{ rule(id="3.6:7", cat="informative") }}
 
-The in-memory layout of struct types is **implementation-defined** (see 1.3:6): the implementation chooses and documents it. The current implementation prioritizes simplicity over space efficiency, and the layout may change between versions. A portable program must not depend on specific field offsets, padding, or overall size beyond what the specification guarantees; a program that inspects layout (for example through `unchecked` raw-pointer access) observes an implementation-defined result.
+The in-memory layout of a struct — the byte offset of each field, any padding, the overall size, and the alignment — is **implementation-defined** (see 1.3:6). The implementation is free to choose any layout consistent with the guarantees of 3.6:8, and **MAY** place fields in any order, pack small scalars together, insert or omit padding, drop storage for zero-sized fields, or exploit value-representation ("niche") optimizations; the chosen layout may change between versions. A program can *observe* the chosen layout — through `@size_of`, `@align_of`, or `unchecked` raw-pointer access — but those observations report the current choice, they do **not** guarantee a particular value. To obtain a field's offset or a pointer to a field without hard-coding a layout, use the compiler-mediated intrinsics `@offset_of(T, field)` and `@field_ptr(place)` (see the [Intrinsics](@/04-expressions/13-intrinsics.md) chapter): they report the offset under whatever layout the implementation chose, so `unchecked` code that reaches fields through them stays correct under any layout. A portable program must not hand-compute a field offset from a literal.
 
 {{ rule(id="3.6:8", cat="normative") }}
 
-Non-zero-sized types in Rue occupy one or more 8-byte slots. Scalar types (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `bool`) each occupy one slot.
+Whatever layout the implementation chooses, every value of a struct type satisfies these guarantees:
 
-{{ rule(id="3.6:9", cat="normative") }}
+- Each field is accessible by name (3.6:4) and reads back the value most recently stored to it.
+- Distinct fields occupy non-overlapping storage.
+- `@size_of(T)` and `@align_of(T)` are well-defined for every sized type `T` and report the size and alignment the implementation has chosen for `T`.
+- The size of a type is a multiple of its alignment.
 
-Struct fields are laid out in memory in declaration order, with each field occupying a number of slots determined by its type.
+These are the only layout properties a portable program may rely on; the specific offsets, slot sizes, and paddings the current implementation happens to use (3.6:9, 3.6:10, 3.6:12) are documented observations, not part of this set.
 
-{{ rule(id="3.6:10", cat="normative") }}
+{{ rule(id="3.6:9", cat="informative") }}
 
-The size of a struct is the sum of the sizes of all its fields. There is no padding between fields or at the end of the struct.
+Under the current implementation, every non-zero-sized value occupies one or more 8-byte slots: each scalar type (`i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64`, `bool`) occupies a single slot, and a struct's fields are placed in declaration order, each in the slots determined by its type, with no padding between or after them. This is a documented property of the current implementation (1.3:6), not a language guarantee.
+
+{{ rule(id="3.6:10", cat="informative") }}
+
+It follows that, under the current implementation, the size of a struct is the sum of the sizes of all its fields, with no padding between fields or at the end (a zero-sized field contributes nothing). A future version that packed scalars or reordered fields would change this observation.
 
 {{ rule(id="3.6:11") }}
 
 ```rue
-// A struct with two i32 fields occupies 2 slots (16 bytes)
+// Under the current implementation, two i32 fields occupy 2 slots (16 bytes).
 struct Point { x: i32, y: i32 }
 
-// A struct with a nested struct occupies the sum of all nested field slots
-struct Line { start: Point, end: Point }  // 4 slots (32 bytes)
+// A nested struct occupies the sum of all nested field slots: 4 slots (32 bytes).
+struct Line { start: Point, end: Point }
 ```
 
-{{ rule(id="3.6:12", cat="normative") }}
+{{ rule(id="3.6:12", cat="informative") }}
 
-Structs with one or more fields have 8-byte alignment. Empty structs (zero-sized types) have 1-byte alignment.
+Under the current implementation, a struct with one or more fields has 8-byte alignment, and an empty struct (a zero-sized type) has 1-byte alignment; `@align_of` observes these values. Like the sizes above, these are documented observations of the current layout, not language guarantees.
 
 {{ rule(id="3.6:13", cat="normative") }}
 
@@ -102,7 +109,7 @@ In a struct literal, field initializers may appear in any order. Each initialize
 
 {{ rule(id="3.6:16", cat="dynamic-semantics") }}
 
-Regardless of the order in which fields are written, the resulting value stores each field in the slot determined by declaration order (3.6:9). Field initializer expressions are still evaluated in source order (left-to-right as written; see 4.0:9), so a field written earlier is evaluated earlier even when it occupies a later slot.
+Regardless of the order in which fields are written, each field of the resulting value is set from the initializer that names it (field matching is by name, not by position). Field initializer expressions are still evaluated in source order (left-to-right as written; see 4.0:9), so a field written earlier is evaluated earlier even when the implementation stores it in a later location.
 
 {{ rule(id="3.6:17") }}
 

--- a/docs/spec/src/10-modules/04-module-bindings.md
+++ b/docs/spec/src/10-modules/04-module-bindings.md
@@ -186,15 +186,18 @@ Naming a private enum's variant through a module from another directory is a
 compile-time error (E0706, because a variant path routes through
 module-member resolution).
 
-{{ rule(id="10.4:19") }}
+{{ rule(id="10.4:19", cat="legality-rule") }}
 
-An associated function's visibility is intended to follow the visibility of its
-enclosing type (10.3:7): an associated function of a private type should not be
-callable from another directory. The current implementation does **not** yet
-enforce this — an associated-function call on a private type is accepted across
-the directory boundary, whether written unqualified or module-qualified
-(RUE-330). Programs must not rely on this gap; it is an implementation
-artifact, not a guarantee.
+An associated function's visibility follows the visibility of its enclosing type
+(10.3:7): calling an associated function of a private struct from a source file
+in another directory is a compile-time error (E0460), exactly as naming that
+struct in a struct literal or type annotation would be. This holds whether the
+call is written unqualified (`Point::origin()`) or module-qualified
+(`lib.Point::origin()`) — both resolve the receiver type through the flat
+namespace (10.5:2), so both report E0460 (RUE-330). A call whose receiver type
+arrives through a comptime binding rather than by naming the struct
+(`let P = lib.Point; P::origin()`) is exempt, matching every other reference
+that reaches a type through a binding.
 
 {{ rule(id="10.4:20", cat="example") }}
 


### PR DESCRIPTION
Four disjoint fixes (cycle 103):
- **RUE-330**: assoc-fn call now enforces the enclosing type's cross-directory privacy (E0460) — was a hole vs struct-literal/annotation. Verified multi-dir; 5 spec + 5 CLI cases.
- **RUE-288**: chapter 3.6 rewritten to Rust's observe-vs-guarantee layout model — layout impl-defined, the slot/order/padding numbers demoted to documented observations, offsets observed via @offset_of/@field_ptr (RUE-301). Resolves the pinned-yet-impl-defined contradiction.
- **RUE-339**: differential comparator now catches panic-cause divergence (was a false-AGREE since all traps exit 101) — captures stderr + compares a TrapCategory; 0 new false-disagrees over 500 seeds / 123 trap cases.
- **RUE-335**: relocation-apply dedup'd into one helper — surfaced + fixed a real latent aarch64 bug (Mach-O had a RUE-131 AddLo12 fix the ELF path lacked). Zero byte change today.

clippy clean; test.sh Pass 24, 100% traceability (690/690), oracle-diff 0.

Fixes RUE-330
Fixes RUE-288
Fixes RUE-339
Fixes RUE-335

Generated with Claude Code