### PR TITLE
Module-path normalization, linker section-classify, oracle recursion bound, array/match spec gaps

### DIFF
--- a/crates/rue-air/src/lib.rs
+++ b/crates/rue-air/src/lib.rs
@@ -14,6 +14,7 @@ mod inference;
 mod inst;
 mod intern_pool;
 mod param_arena;
+mod path_norm;
 mod scope;
 mod sema;
 mod sema_context;

--- a/crates/rue-air/src/path_norm.rs
+++ b/crates/rue-air/src/path_norm.rs
@@ -1,0 +1,86 @@
+//! Lexical path normalization shared across module resolution.
+//!
+//! Module identity is keyed by a file's *resolved* path (spec 10.2:4: an import
+//! that resolves to an already-loaded file refers to that same module). But the
+//! same physical file reaches the resolver under several spellings — a
+//! command-line source might be listed as `std/opt.rue` while a `../`-relative
+//! `@import("../std/opt.rue")` from a sibling directory resolves to
+//! `a/../std/opt.rue`. These must collapse to one key, or the file is
+//! double-registered and member access fails (E0707, RUE-317).
+//!
+//! [`normalize_module_path`] performs that collapse **lexically**: it drops `.`
+//! (current-dir) components and resolves `..` against the preceding *normal*
+//! component. It never touches the filesystem, so it does not follow symlinks;
+//! a leading `..` with nothing to cancel (or a `..` after the root) is
+//! preserved verbatim. Every module-registry / file-table key must pass through
+//! this one function so all spellings of a file agree.
+
+use std::path::{Component, Path, PathBuf};
+
+/// Lexically normalize a path for equivalence comparison: drop `.` components
+/// and collapse `..` against a preceding normal component. Purely lexical —
+/// never touches the filesystem (no symlink resolution).
+///
+/// Examples (`/` shown for clarity; output uses the platform separator):
+/// - `./foo.rue` -> `foo.rue`
+/// - `sub/./foo.rue` -> `sub/foo.rue`
+/// - `a/../std/opt.rue` -> `std/opt.rue`
+/// - `../std/opt.rue` -> `../std/opt.rue` (leading `..` has nothing to cancel)
+pub(crate) fn normalize_module_path(path: &str) -> String {
+    let mut out: Vec<Component> = Vec::new();
+    for comp in Path::new(path).components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                // Cancel a preceding *normal* component; otherwise (empty, a
+                // leading `..`, or a root/prefix) keep the `..` verbatim so the
+                // normalization stays purely lexical.
+                if matches!(out.last(), Some(Component::Normal(_))) {
+                    out.pop();
+                } else {
+                    out.push(comp);
+                }
+            }
+            other => out.push(other),
+        }
+    }
+    let mut buf = PathBuf::new();
+    for comp in out {
+        buf.push(comp.as_os_str());
+    }
+    buf.to_string_lossy().into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::normalize_module_path as n;
+
+    #[test]
+    fn drops_cur_dir() {
+        assert_eq!(n("./foo.rue"), "foo.rue");
+        assert_eq!(n("sub/./foo.rue"), "sub/foo.rue");
+    }
+
+    #[test]
+    fn collapses_parent_dir() {
+        // The RUE-317 case: a `../`-relative import from `a/` reconciles with a
+        // command-line-listed `std/opt.rue`.
+        assert_eq!(n("a/../std/opt.rue"), "std/opt.rue");
+        assert_eq!(n("a/b/../../std/opt.rue"), "std/opt.rue");
+        assert_eq!(n("a/b/../c.rue"), "a/c.rue");
+    }
+
+    #[test]
+    fn preserves_uncancelable_parent() {
+        // A leading `..` has no preceding normal component to cancel.
+        assert_eq!(n("../std/opt.rue"), "../std/opt.rue");
+        assert_eq!(n("../../x.rue"), "../../x.rue");
+    }
+
+    #[test]
+    fn both_spellings_agree() {
+        // The two spellings of the same physical file must normalize equal.
+        assert_eq!(n("a/../std/opt.rue"), n("std/opt.rue"));
+        assert_eq!(n("./std/opt.rue"), n("std/opt.rue"));
+    }
+}

--- a/crates/rue-air/src/sema/file_paths.rs
+++ b/crates/rue-air/src/sema/file_paths.rs
@@ -4,26 +4,11 @@
 //! for module resolution and relative imports.
 
 use std::collections::HashMap;
-use std::path::{Component, Path, PathBuf};
 
 use rue_span::FileId;
 
 use super::Sema;
-
-/// Normalize a source-file path for equivalence comparison by dropping `.`
-/// (current-directory) components, so `./helper.rue` and `helper.rue` compare
-/// equal. Parent (`..`) and normal components are preserved, so the
-/// normalization is purely lexical and never touches the filesystem.
-fn normalize_module_path(path: &str) -> String {
-    let mut out = PathBuf::new();
-    for comp in Path::new(path).components() {
-        match comp {
-            Component::CurDir => {}
-            other => out.push(other.as_os_str()),
-        }
-    }
-    out.to_string_lossy().into_owned()
-}
+use crate::path_norm::normalize_module_path;
 
 impl<'a> Sema<'a> {
     /// Set file paths for module resolution in multi-file compilation.
@@ -68,7 +53,9 @@ impl<'a> Sema<'a> {
     /// through that binding spuriously failed (E0707, RUE-240). Comparing by
     /// normalized path (dropping `.` components) makes both spellings resolve
     /// to the same file, matching spec 10.2:4 (an import resolving to an
-    /// already-loaded file refers to that same module).
+    /// already-loaded file refers to that same module). Normalization also
+    /// collapses `..`, so a `../`-relative `@import` and a command-line-listed
+    /// file resolve to the same file (RUE-317).
     pub(crate) fn canonical_file_id(&self, path: &str) -> Option<FileId> {
         if let Some(id) = self.get_file_id(path) {
             return Some(id);

--- a/crates/rue-air/src/sema/module_path.rs
+++ b/crates/rue-air/src/sema/module_path.rs
@@ -28,23 +28,9 @@
 //! same source text always imports the file next to it rather than an
 //! unrelated same-named file elsewhere in the program (RUE-266).
 
-use std::path::{Component, Path, PathBuf};
+use std::path::Path;
 
-/// Lexically normalize a path for equivalence comparison by dropping `.`
-/// (current-directory) components, so `./foo.rue`, `sub/./foo.rue` and
-/// `sub/foo.rue` compare equal. Parent (`..`) and normal components are
-/// preserved, so the normalization is purely lexical and never touches the
-/// filesystem. Mirrors `file_paths::normalize_module_path`.
-fn normalize(path: &str) -> String {
-    let mut out = PathBuf::new();
-    for comp in Path::new(path).components() {
-        match comp {
-            Component::CurDir => {}
-            other => out.push(other.as_os_str()),
-        }
-    }
-    out.to_string_lossy().into_owned()
-}
+use crate::path_norm::normalize_module_path as normalize;
 
 /// Join a base directory with a relative path. An empty base directory yields
 /// the relative path unchanged (the importer sits at the search root).
@@ -144,8 +130,9 @@ impl ModulePath {
     /// match, the result is [`DirResolution::NotFound`].
     ///
     /// Matching is by lexically-normalized path equality (dropping `.`
-    /// components), so `./foo.rue` and `foo.rue` are the same file (spec
-    /// 10.2:4). The returned string is the original loaded path.
+    /// components and collapsing `..`), so `./foo.rue` and `foo.rue`, or a
+    /// `../`-relative import and a command-line-listed file, are the same file
+    /// (spec 10.2:4, RUE-317). The returned string is the original loaded path.
     pub fn resolve_in_dirs<'a, I>(&self, base_dirs: &[&str], loaded_paths: I) -> DirResolution
     where
         I: Iterator<Item = &'a String>,

--- a/crates/rue-air/src/sema_context.rs
+++ b/crates/rue-air/src/sema_context.rs
@@ -10,23 +10,17 @@
 //! parallel-analysis pipeline and was removed per ADR-0033 phase 1b.
 
 use std::collections::HashMap;
-use std::path::{Component, Path, PathBuf};
 use std::sync::{PoisonError, RwLock};
 
+use crate::path_norm::normalize_module_path;
 use crate::types::{ModuleDef, ModuleId};
 
-/// Lexically normalize a resolved file path for use as a registry key, dropping
-/// `.` (current-directory) components so `./foo.rue` and `foo.rue` key to the
-/// same module (spec 10.2:4). Purely lexical — never touches the filesystem.
+/// Lexically normalize a resolved file path for use as a registry key so all
+/// spellings of the same physical file key to one module (spec 10.2:4):
+/// `./foo.rue` == `foo.rue`, and `a/../std/opt.rue` == `std/opt.rue`
+/// (RUE-317). Purely lexical — never touches the filesystem.
 fn normalize_key(path: &str) -> String {
-    let mut out = PathBuf::new();
-    for comp in Path::new(path).components() {
-        match comp {
-            Component::CurDir => {}
-            other => out.push(other.as_os_str()),
-        }
-    }
-    out.to_string_lossy().into_owned()
+    normalize_module_path(path)
 }
 
 /// Thread-safe registry for modules.

--- a/crates/rue-cli-tests/cases/modules.toml
+++ b/crates/rue-cli-tests/cases/modules.toml
@@ -1542,3 +1542,89 @@ pub fn mk() -> Secret(i32) { let S = Secret(i32); S { v: 7 } }
 """ },
 ]
 exit_code = 7
+
+# ---------------------------------------------------------------------------
+# RUE-317: a `../`-relative @import reconciles with the SAME physical file
+# listed on the command line. Module identity is keyed by a file's
+# lexically-normalized resolved path (`.`/`..` collapsed), so
+# `a/../std/opt.rue` (the resolved `@import("../std/opt.rue")` from `a/`) and
+# the command-line-listed `std/opt.rue` are ONE module — not two, which used
+# to spuriously fail member access with E0707.
+# ---------------------------------------------------------------------------
+
+[[case]]
+name = "dotdot_import_reconciles_with_cli_listed_pub_fn"
+description = "RUE-317: `a/main.rue` @imports `../std/opt.rue` while `std/opt.rue` is also listed on the CLI; the pub fn member resolves through the module (single module identity, no E0707)."
+args = ["a/main.rue", "std/opt.rue", "-o", "prog"]
+files = [
+    { path = "a/main.rue", source = """
+fn main() -> i32 {
+    let o = @import("../std/opt.rue");
+    o.make()
+}
+""" },
+    { path = "std/opt.rue", source = """
+pub fn make() -> i32 {
+    42
+}
+""" },
+]
+exit_code = 42
+
+[[case]]
+name = "dotdot_import_reconciles_with_cli_listed_pub_const"
+description = "RUE-317: same reconciliation for a pub const member accessed through a `../`-relative import that is also CLI-listed."
+args = ["a/main.rue", "std/opt.rue", "-o", "prog"]
+files = [
+    { path = "a/main.rue", source = """
+const opt = @import("../std/opt.rue");
+
+fn main() -> i32 {
+    opt.ANSWER
+}
+""" },
+    { path = "std/opt.rue", source = """
+pub const ANSWER: i32 = 7;
+""" },
+]
+exit_code = 7
+
+[[case]]
+name = "dotdot_import_unknown_member_still_errors"
+description = "RUE-317 negative control: path reconciliation must not mask a genuinely absent member — accessing a non-existent member of the reconciled module still fails with E0707."
+args = ["a/main.rue", "std/opt.rue", "-o", "prog"]
+files = [
+    { path = "a/main.rue", source = """
+fn main() -> i32 {
+    let o = @import("../std/opt.rue");
+    o.nope()
+}
+""" },
+    { path = "std/opt.rue", source = """
+pub fn make() -> i32 {
+    42
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0707", "has no member `nope`"]
+
+[[case]]
+name = "dotdot_import_private_member_cross_dir_still_rejected"
+description = "RUE-317 negative control: reconciling the path must not weaken privacy — a NON-pub member of the reconciled module in another directory is still private (E0706)."
+args = ["a/main.rue", "std/opt.rue", "-o", "prog"]
+files = [
+    { path = "a/main.rue", source = """
+fn main() -> i32 {
+    let o = @import("../std/opt.rue");
+    o.secret()
+}
+""" },
+    { path = "std/opt.rue", source = """
+fn secret() -> i32 {
+    42
+}
+""" },
+]
+compile_fail = true
+error_contains = ["E0706", "function `secret` is private"]

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -29,31 +29,70 @@ enum PatchHome {
     Data,
 }
 
-/// Is this a code section? Accepts both ELF (`.text*`) and Mach-O
-/// (`__TEXT,__text` / `__text*`) names.
-fn is_text_section(name: &str) -> bool {
-    name.starts_with(".text") || name == "__TEXT,__text" || name.starts_with("__text")
+/// The output-segment class a section merges into. Derived purely from the
+/// section name so both the ELF (`link_elf`) and Mach-O (`link_macho`) paths
+/// classify sections through the single [`classify_section`] source of truth
+/// instead of re-deriving it inline (RUE-336).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum SectionKind {
+    /// Executable code (`.text*` / `__TEXT,__text` / `__text*`).
+    Text,
+    /// Read-only data (`.rodata*` / `.cstring*` / Mach-O `__const`/`__cstring`).
+    Rodata,
+    /// Writable initialized data (`.data*` / `__DATA,__data` / `__data*`).
+    Data,
+    /// Zero-initialized data (`.bss*` / `__DATA,__bss` / `__bss*`).
+    Bss,
+    /// Anything else (debug info, notes, etc.) — not merged into a segment.
+    Other,
 }
 
-/// Is this a read-only data section? Accepts both ELF and Mach-O names.
-fn is_rodata_section(name: &str) -> bool {
-    name.starts_with(".rodata")
+/// Classify a section by name, accepting both ELF (`.text*`, `.rodata*`, …) and
+/// Mach-O (`__TEXT,__text`, `__DATA,__const`, …) conventions. This is the sole
+/// section-classification authority; every merge/base-address decision routes
+/// through it so the classes cannot drift out of sync (RUE-336).
+///
+/// The prefix sets are mutually exclusive, so the check order is immaterial.
+fn classify_section(name: &str) -> SectionKind {
+    if name.starts_with(".text") || name == "__TEXT,__text" || name.starts_with("__text") {
+        SectionKind::Text
+    } else if name.starts_with(".rodata")
         || name == "__DATA,__const"
         || name == "__TEXT,__const"
         || name == "__TEXT,__cstring"
         || name == "__TEXT,__rodata"
         || name.starts_with("__const")
         || name.starts_with(".cstring")
+    {
+        SectionKind::Rodata
+    } else if name.starts_with(".data") || name == "__DATA,__data" || name.starts_with("__data") {
+        SectionKind::Data
+    } else if name.starts_with(".bss") || name == "__DATA,__bss" || name.starts_with("__bss") {
+        SectionKind::Bss
+    } else {
+        SectionKind::Other
+    }
+}
+
+/// Is this a code section? Accepts both ELF (`.text*`) and Mach-O
+/// (`__TEXT,__text` / `__text*`) names.
+fn is_text_section(name: &str) -> bool {
+    classify_section(name) == SectionKind::Text
+}
+
+/// Is this a read-only data section? Accepts both ELF and Mach-O names.
+fn is_rodata_section(name: &str) -> bool {
+    classify_section(name) == SectionKind::Rodata
 }
 
 /// Is this a writable data section? Accepts both ELF and Mach-O names.
 fn is_data_section(name: &str) -> bool {
-    name.starts_with(".data") || name == "__DATA,__data" || name.starts_with("__data")
+    classify_section(name) == SectionKind::Data
 }
 
 /// Is this a zero-initialized (bss) section? Accepts both ELF and Mach-O names.
 fn is_bss_section(name: &str) -> bool {
-    name.starts_with(".bss") || name == "__DATA,__bss" || name.starts_with("__bss")
+    classify_section(name) == SectionKind::Bss
 }
 
 /// Apply a single already-resolved relocation by patching `buf` in place.
@@ -1260,7 +1299,7 @@ impl Linker {
         // Merge code sections (.text*)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for (sec_idx, section) in obj.sections.iter().enumerate() {
-                if !section.name.starts_with(".text") || section.data.is_empty() {
+                if classify_section(&section.name) != SectionKind::Text || section.data.is_empty() {
                     continue;
                 }
 
@@ -1290,7 +1329,7 @@ impl Linker {
         // memory protections at runtime.
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for (sec_idx, section) in obj.sections.iter().enumerate() {
-                if !section.name.starts_with(".rodata") {
+                if classify_section(&section.name) != SectionKind::Rodata {
                     continue;
                 }
                 // Note: we don't skip empty sections because they may still have
@@ -1320,7 +1359,7 @@ impl Linker {
         // Merge .data sections (initialized data - placed in data segment)
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for (sec_idx, section) in obj.sections.iter().enumerate() {
-                if !section.name.starts_with(".data") {
+                if classify_section(&section.name) != SectionKind::Data {
                     continue;
                 }
                 // Skip empty .data sections
@@ -1354,7 +1393,7 @@ impl Linker {
 
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for (sec_idx, section) in obj.sections.iter().enumerate() {
-                if !section.name.starts_with(".bss") {
+                if classify_section(&section.name) != SectionKind::Bss {
                     continue;
                 }
 
@@ -1417,16 +1456,12 @@ impl Linker {
                     }
                     if let Some(&section_offset) = section_offsets.get(&(obj_idx, sec_idx)) {
                         let section = &obj.sections[sec_idx];
-                        let base = if section.name.starts_with(".text") {
-                            code_vaddr
-                        } else if section.name.starts_with(".rodata") {
-                            rodata_vaddr
-                        } else if section.name.starts_with(".data") {
-                            data_vaddr
-                        } else if section.name.starts_with(".bss") {
-                            bss_vaddr
-                        } else {
-                            continue;
+                        let base = match classify_section(&section.name) {
+                            SectionKind::Text => code_vaddr,
+                            SectionKind::Rodata => rodata_vaddr,
+                            SectionKind::Data => data_vaddr,
+                            SectionKind::Bss => bss_vaddr,
+                            SectionKind::Other => continue,
                         };
 
                         let addr = base + section_offset + sym.value;
@@ -1463,16 +1498,12 @@ impl Linker {
         for (obj_idx, obj) in self.objects.iter().enumerate() {
             for (sec_idx, section) in obj.sections.iter().enumerate() {
                 if let Some(&offset) = section_offsets.get(&(obj_idx, sec_idx)) {
-                    let addr = if section.name.starts_with(".text") {
-                        code_vaddr + offset
-                    } else if section.name.starts_with(".rodata") {
-                        rodata_vaddr + offset
-                    } else if section.name.starts_with(".data") {
-                        data_vaddr + offset
-                    } else if section.name.starts_with(".bss") {
-                        bss_vaddr + offset
-                    } else {
-                        continue;
+                    let addr = match classify_section(&section.name) {
+                        SectionKind::Text => code_vaddr + offset,
+                        SectionKind::Rodata => rodata_vaddr + offset,
+                        SectionKind::Data => data_vaddr + offset,
+                        SectionKind::Bss => bss_vaddr + offset,
+                        SectionKind::Other => continue,
                     };
                     // Use section name as fallback
                     symbol_addresses
@@ -1525,19 +1556,17 @@ impl Linker {
                     }
                     let section = &obj.sections[sec_idx];
                     if let Some(&sec_offset) = section_offsets.get(&(obj_idx, sec_idx)) {
-                        let base = if section.name.starts_with(".text") {
-                            code_vaddr
-                        } else if section.name.starts_with(".rodata") {
-                            rodata_vaddr
-                        } else if section.name.starts_with(".data") {
-                            data_vaddr
-                        } else if section.name.starts_with(".bss") {
-                            bss_vaddr
-                        } else {
-                            return Err(LinkError::UndefinedSymbol(format!(
-                                "{} (in section '{}')",
-                                sym_name, section.name
-                            )));
+                        let base = match classify_section(&section.name) {
+                            SectionKind::Text => code_vaddr,
+                            SectionKind::Rodata => rodata_vaddr,
+                            SectionKind::Data => data_vaddr,
+                            SectionKind::Bss => bss_vaddr,
+                            SectionKind::Other => {
+                                return Err(LinkError::UndefinedSymbol(format!(
+                                    "{} (in section '{}')",
+                                    sym_name, section.name
+                                )));
+                            }
                         };
                         base + sec_offset
                     } else {

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -64,12 +64,55 @@ pub struct Unsupported(pub String);
 /// program in the supported subset always yields `Ok`.
 pub fn run_source(source: &str) -> Result<Outcome, Unsupported> {
     let state = compile_to_cfg(source).map_err(|e| Unsupported(format!("compile: {e:?}")))?;
-    Interp {
-        state: &state,
-        stdout: String::new(),
-    }
-    .run()
+    // Interpret on a dedicated large-stack worker thread. The tree-walking
+    // interpreter recurses per expression *and* per call, so deep-but-valid
+    // programs need far more stack than a default thread provides. Running on
+    // our own generous stack makes `run_source` safe to call from any thread
+    // (a 2 MiB Rust test thread included) and, together with `MAX_DEPTH`, lets
+    // unbounded recursion resolve to an `Unsupported` skip *before* the Rust
+    // stack is exhausted rather than aborting the process (RUE-340).
+    std::thread::scope(|scope| {
+        std::thread::Builder::new()
+            .stack_size(WORKER_STACK)
+            .spawn_scoped(scope, || {
+                Interp {
+                    state: &state,
+                    stdout: String::new(),
+                    budget: STEP_BUDGET,
+                    depth: 0,
+                }
+                .run()
+            })
+            .expect("spawn oracle interpreter worker thread")
+            .join()
+            .expect("oracle interpreter worker thread panicked")
+    })
 }
+
+/// Stack size of the interpreter worker thread. Sized so all `MAX_DEPTH`
+/// activations (each ~a few tens of KiB of Rust stack in an unoptimized build,
+/// so ~tens of MiB total) fit with several-fold headroom, plus room for
+/// per-expression eval recursion. Only touched pages are committed, so the
+/// large reservation is cheap; it matches the harness's own worker stack.
+const WORKER_STACK: usize = 256 * 1024 * 1024;
+
+/// Total interpreter step budget, shared across **all** call activations (not
+/// per-frame): every instruction executed anywhere in the run decrements it, so
+/// it bounds *total work* — a runaway loop, deep/unbounded recursion, or any
+/// combination — and reports [`Unsupported`] instead of hanging. Generous
+/// enough that no legitimate program in the differential corpus reaches it.
+const STEP_BUDGET: u64 = 50_000_000;
+
+/// Maximum interpreter call-recursion depth, shared across all activations.
+/// Each Rue call activation is a nested `call` -> `eval` Rust recursion, so
+/// unbounded Rue recursion would otherwise overflow the *Rust* stack — an
+/// uncatchable process abort that kills the whole differential harness rather
+/// than yielding a clean skip (RUE-340). This bound fires first, turning
+/// deep/infinite recursion into an [`Unsupported`] skip. It sits far above any
+/// legitimately-recursive corpus/fuzzer program yet far below the number of
+/// activations that fit in `WORKER_STACK`, so the skip always wins the race
+/// against stack exhaustion.
+const MAX_DEPTH: u32 = 2_000;
 
 /// A runtime value. Integers are held in `i128` (wide enough for every Rue
 /// integer type, and to detect overflow of any of them before range-checking).
@@ -132,6 +175,13 @@ impl From<Unsupported> for Flow {
 struct Interp<'a> {
     state: &'a CompileState,
     stdout: String,
+    /// Remaining total step budget (see [`STEP_BUDGET`]). Shared across every
+    /// activation and decremented per instruction, so it bounds total work
+    /// including recursion, not just per-frame loops.
+    budget: u64,
+    /// Current call-recursion depth (see [`MAX_DEPTH`]). Incremented on entry to
+    /// each `call` and decremented on exit, bounding Rust-stack recursion.
+    depth: u32,
 }
 
 /// Per-call activation record. `cache` is scoped to a *single block execution*
@@ -194,6 +244,22 @@ impl<'a> Interp<'a> {
     /// can copy out `inout` parameters (Rue `inout` is copy-in / copy-out, which
     /// is observably identical to by-reference under the law of exclusivity).
     fn call(&mut self, name: &str, args: &[Value]) -> Step<(Value, Vec<Option<Value>>)> {
+        // Bound recursion *depth* (shared across activations) before descending,
+        // so unbounded Rue recursion resolves to a clean `Unsupported` skip
+        // instead of overflowing the Rust stack and aborting the process
+        // (RUE-340). Decrement on every exit path by capturing the result.
+        if self.depth >= MAX_DEPTH {
+            return Err(Flow::Unsupported(Unsupported(
+                "recursion depth budget exhausted".into(),
+            )));
+        }
+        self.depth += 1;
+        let result = self.call_inner(name, args);
+        self.depth -= 1;
+        result
+    }
+
+    fn call_inner(&mut self, name: &str, args: &[Value]) -> Step<(Value, Vec<Option<Value>>)> {
         let cfg = self
             .find_cfg(name)
             .ok_or_else(|| Flow::Unsupported(Unsupported(format!("call to '{name}'"))))?;
@@ -215,8 +281,6 @@ impl<'a> Interp<'a> {
 
         let mut current = cfg.entry;
         let mut incoming: Vec<Value> = Vec::new();
-        // A generous step budget so a mis-modeled loop reports instead of hanging.
-        let mut budget: u64 = 50_000_000;
 
         loop {
             let block = cfg.get_block(current);
@@ -229,7 +293,10 @@ impl<'a> Interp<'a> {
                 frame.cache.insert(pv.as_u32(), val);
             }
             for &v in &block.insts {
-                budget = budget.checked_sub(1).ok_or_else(|| {
+                // Decrement the shared total-work budget (see `STEP_BUDGET`): a
+                // runaway loop or deep recursion reports `Unsupported` here
+                // rather than hanging.
+                self.budget = self.budget.checked_sub(1).ok_or_else(|| {
                     Flow::Unsupported(Unsupported("step budget exhausted".into()))
                 })?;
                 self.eval(cfg, &mut frame, v)?;

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -129,6 +129,67 @@ fn intcast_in_range_and_overflow() {
 }
 
 #[test]
+fn unbounded_recursion_is_unsupported() {
+    // A recursive function with no base case would recurse forever and overflow
+    // the Rust stack (an uncatchable abort). The shared recursion-depth bound
+    // (MAX_DEPTH) must turn it into a clean `Unsupported` skip instead (RUE-340).
+    let src = "fn r(n: i32) -> i32 { r(n) }
+    fn main() -> i32 { r(0) }";
+    let err = run_source(src).expect_err("unbounded recursion must not produce an Outcome");
+    assert!(
+        err.0.contains("depth budget"),
+        "expected a depth-budget skip, got: {}",
+        err.0
+    );
+}
+
+#[test]
+fn deep_bounded_recursion_is_unsupported() {
+    // Recursion that is bounded but far deeper than MAX_DEPTH must also skip
+    // cleanly (hitting the depth bound) rather than overflow the stack.
+    let src = "fn r(n: i32) -> i32 { if n <= 0 { 0 } else { r(n - 1) } }
+    fn main() -> i32 { r(100000) }";
+    let err = run_source(src).expect_err("deep recursion must not produce an Outcome");
+    assert!(
+        err.0.contains("depth budget"),
+        "expected a depth-budget skip, got: {}",
+        err.0
+    );
+}
+
+#[test]
+fn shallow_recursion_still_runs() {
+    // Recursion well within MAX_DEPTH must still execute and agree, so the depth
+    // bound doesn't reject legitimate programs. Fibonacci(15) = 610.
+    let src = "fn fib(n: i32) -> i32 { if n < 2 { n } else { fib(n - 1) + fib(n - 2) } }
+    fn main() -> i32 { fib(15) & 0xFF }";
+    // 610 & 0xFF = 98.
+    assert_eq!(exit(src), 98);
+    // And a linear recursion right up to (just under) the depth bound resolves.
+    let src = "fn r(n: i32) -> i32 { if n <= 0 { 7 } else { r(n - 1) } }
+    fn main() -> i32 { r(1500) }";
+    assert_eq!(exit(src), 7);
+}
+
+// Ignored by default: exercises the full 50M-step budget, which takes ~12s in
+// an unoptimized build. Run explicitly (`--ignored`) as a loop-bounding
+// regression guard.
+#[test]
+#[ignore = "burns the full step budget (~12s in debug); run with --ignored"]
+fn runaway_loop_is_unsupported() {
+    // A loop that never terminates must be bounded by the shared step budget and
+    // reported `Unsupported`, never hang. Each iteration flips `b` (a `Not`
+    // instruction), so the budget is decremented every turn of the loop.
+    let src = "fn main() -> i32 { let mut b = true; loop { b = !b; } }";
+    let err = run_source(src).expect_err("a runaway loop must not produce an Outcome");
+    assert!(
+        err.0.contains("step budget"),
+        "expected a step-budget skip, got: {}",
+        err.0
+    );
+}
+
+#[test]
 fn loop_via_recursion_sum() {
     // Gauss sum 1..=10 = 55, exercised through recursion + branch joins.
     let src = "fn sum(n: i32, acc: i32) -> i32 {

--- a/crates/rue-spec/cases/arrays/fixed.toml
+++ b/crates/rue-spec/cases/arrays/fixed.toml
@@ -1039,3 +1039,146 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "Copy"
+
+# =============================================================================
+# Array Element Moves (RUE-299): the array-chapter statement of the move
+# legality rules cross-referenced from the Move Semantics chapter (3.8:68-73).
+# =============================================================================
+
+# A constant-index move takes a non-Copy element out of an array variable; the
+# sibling element remains usable (7.1:43).
+[[case]]
+name = "array_element_constant_index_move"
+spec = ["7.1:43"]
+source = """
+struct Big { value: i32 }
+fn consume(b: Big) -> i32 { b.value }
+fn main() -> i32 {
+    let xs = [Big { value: 40 }, Big { value: 2 }];
+    let a = consume(xs[0]);
+    let b = consume(xs[1]);
+    a + b
+}
+"""
+exit_code = 42
+
+# While an element is moved out, the array cannot be used as a whole value
+# (7.1:45).
+[[case]]
+name = "array_partial_move_whole_use_rejected"
+spec = ["7.1:45"]
+source = """
+struct Big { value: i32 }
+fn consume(b: Big) -> i32 { b.value }
+fn take_all(xs: [Big; 2]) -> i32 { 0 }
+fn main() -> i32 {
+    let xs = [Big { value: 1 }, Big { value: 2 }];
+    let a = consume(xs[0]);
+    a + take_all(xs)
+}
+"""
+compile_fail = true
+error_contains = "use of moved value 'xs'"
+
+# While an element is moved out, a moved-out element cannot be used again
+# (7.1:45).
+[[case]]
+name = "array_partial_move_element_reuse_rejected"
+spec = ["7.1:45"]
+source = """
+struct Big { value: i32 }
+fn consume(b: Big) -> i32 { b.value }
+fn main() -> i32 {
+    let xs = [Big { value: 1 }, Big { value: 2 }];
+    let a = consume(xs[0]);
+    let b = consume(xs[0]);
+    a + b
+}
+"""
+compile_fail = true
+error_contains = "use of moved value 'xs[0]'"
+
+# While an element is moved out, assigning into the array is rejected; the whole
+# array must be reinitialized instead (7.1:46).
+[[case]]
+name = "array_partial_move_assign_rejected"
+spec = ["7.1:46"]
+source = """
+struct Big { value: i32 }
+fn consume(b: Big) -> i32 { b.value }
+fn main() -> i32 {
+    let mut xs = [Big { value: 40 }, Big { value: 2 }];
+    let a = consume(xs[0]);
+    xs[1] = Big { value: 5 };
+    a
+}
+"""
+compile_fail = true
+error_contains = "cannot assign into 'xs'"
+
+# Reinitializing the whole array reinstates per-element ownership, so it can be
+# used again after a partial move (7.1:46).
+[[case]]
+name = "array_reinit_after_partial_move"
+spec = ["7.1:46"]
+source = """
+struct Big { value: i32 }
+fn consume(b: Big) -> i32 { b.value }
+fn take_all(xs: [Big; 2]) -> i32 { xs[0].value + xs[1].value }
+fn main() -> i32 {
+    let mut xs = [Big { value: 40 }, Big { value: 2 }];
+    let a = consume(xs[0]);
+    xs = [Big { value: 1 }, Big { value: 1 }];
+    a + take_all(xs)
+}
+"""
+exit_code = 42
+
+# An array of a linear (must-consume) element type is consumed element-wise by
+# moving every element out (7.1:47).
+[[case]]
+name = "array_linear_elementwise_consumption"
+spec = ["7.1:47"]
+source = """
+linear struct MustUse { value: i32 }
+fn consume(m: MustUse) -> i32 { m.value }
+fn main() -> i32 {
+    let xs = [MustUse { value: 40 }, MustUse { value: 2 }];
+    consume(xs[0]) + consume(xs[1])
+}
+"""
+exit_code = 42
+
+# Consuming only some elements of a linear array is an error naming the rest
+# (7.1:47).
+[[case]]
+name = "array_linear_partial_consumption_rejected"
+spec = ["7.1:47"]
+source = """
+linear struct MustUse { value: i32 }
+fn consume(m: MustUse) -> i32 { m.value }
+fn main() -> i32 {
+    let xs = [MustUse { value: 1 }, MustUse { value: 2 }];
+    consume(xs[0])
+}
+"""
+compile_fail = true
+
+# A moved-out element is dropped by its new owner, not at the array's scope
+# exit; the unmoved elements still drop in ascending index order (7.1:48).
+[[case]]
+name = "array_partial_move_drop_order"
+spec = ["7.1:48"]
+source = """
+struct D { value: i32 }
+drop fn D(self) { @dbg(self.value); }
+fn consume(d: D) -> i32 { d.value }
+fn main() -> i32 {
+    let xs = [D { value: 1 }, D { value: 2 }, D { value: 3 }];
+    let got = consume(xs[1]);
+    @dbg(100);
+    got - 2
+}
+"""
+exit_code = 0
+expected_stdout = "2\n100\n1\n3\n"

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -995,3 +995,67 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "bound more than once"
+
+# =============================================================================
+# Scrutinee access mode (RUE-299): a match uses its scrutinee in value context.
+# =============================================================================
+
+# A Copy scrutinee is copied by the match and remains valid afterward (4.7:33).
+[[case]]
+name = "match_copy_scrutinee_remains_valid"
+spec = ["4.7:33"]
+source = """
+enum E { A(i32), B }
+fn use_again(e: E) -> i32 { 2 }
+fn main() -> i32 {
+    let e = E::A(40);
+    let r = match e {
+        E::A(x) => x,
+        E::B => 0,
+    };
+    r + use_again(e)
+}
+"""
+exit_code = 42
+
+# A move-type scrutinee is consumed by the match; using it afterward is a
+# use-after-move error (4.7:33).
+[[case]]
+name = "match_move_scrutinee_consumed"
+spec = ["4.7:33"]
+source = """
+struct Big { value: i32 }
+enum E { A(Big), B }
+fn use_again(e: E) -> i32 { 0 }
+fn main() -> i32 {
+    let e = E::A(Big { value: 7 });
+    let r = match e {
+        E::A(s) => s.value,
+        E::B => 0,
+    };
+    r + use_again(e)
+}
+"""
+compile_fail = true
+error_contains = "use of moved value 'e'"
+
+# A move-type scrutinee is consumed even when the matched arm binds no payload
+# (4.7:34).
+[[case]]
+name = "match_move_scrutinee_consumed_without_binding"
+spec = ["4.7:34"]
+source = """
+struct Big { value: i32 }
+enum E { A(Big), B }
+fn use_again(e: E) -> i32 { 0 }
+fn main() -> i32 {
+    let e = E::A(Big { value: 7 });
+    let r = match e {
+        E::A => 1,
+        E::B => 2,
+    };
+    r + use_again(e)
+}
+"""
+compile_fail = true
+error_contains = "use of moved value 'e'"

--- a/docs/spec/src/04-expressions/07-match-expressions.md
+++ b/docs/spec/src/04-expressions/07-match-expressions.md
@@ -251,3 +251,59 @@ fn main() -> i32 {
     }
 }
 ```
+
+## Scrutinee Access Mode
+
+{{ rule(id="4.7:33", cat="normative") }}
+
+The scrutinee of a match is used in **value context** (3.8:76): evaluating a match
+*uses* its scrutinee. If the scrutinee's type is `Copy`, the match copies it and the
+scrutinee remains valid after the match. If the scrutinee's type is a move type, the
+match consumes — moves — the scrutinee, which is invalid after the match. Rue has no
+`borrow` or `inout` scrutinee form (those access modes apply only to function
+parameters and arguments, 6.1); `match e` always uses `e` by value. The payload
+bindings introduced by a matched arm (4.7:31) then project sub-places of the value
+the match has already used.
+
+{{ rule(id="4.7:34", cat="legality-rule") }}
+
+A move-type scrutinee is consumed by the match independently of whether the matched
+arm binds a payload. A match whose selected arm binds nothing — a bare variant
+pattern, a wildcard `_`, or a literal pattern — still moves a move-type scrutinee,
+because the scrutinee occurs in value context regardless of the pattern. Using the
+scrutinee after such a match is therefore a use-after-move error (3.8:5).
+
+{{ rule(id="4.7:35", cat="example") }}
+
+```rue
+enum E { A(i32), B }
+
+fn use_again(e: E) -> i32 { 2 }
+
+fn main() -> i32 {
+    let e = E::A(40);       // payload is Copy, so E is a Copy type
+    let r = match e {
+        E::A(x) => x,
+        E::B => 0,
+    };
+    r + use_again(e)        // OK: Copy scrutinee still valid -> 42
+}
+```
+
+{{ rule(id="4.7:36", cat="example") }}
+
+```rue
+struct Big { value: i32 }
+enum E { A(Big), B }
+
+fn use_again(e: E) -> i32 { 0 }
+
+fn main() -> i32 {
+    let e = E::A(Big { value: 7 });   // move type: Big is not Copy
+    let r = match e {
+        E::A => 1,                    // binds nothing, yet consumes `e`
+        E::B => 2,
+    };
+    r + use_again(e)                  // ERROR: use of moved value 'e'
+}
+```

--- a/docs/spec/src/07-arrays/01-fixed-arrays.md
+++ b/docs/spec/src/07-arrays/01-fixed-arrays.md
@@ -329,3 +329,65 @@ fn main() -> i32 {
     arr[0] + arr[1]     // 30
 }
 ```
+
+## Array Element Moves
+
+The general move framework — value versus place context, and the copy-versus-move
+effect of a *use* — is defined in the Move Semantics chapter (3.8:76). The rules in
+this section are its array-chapter statement, and are the legality rules referenced
+from that chapter (3.8:68).
+
+{{ rule(id="7.1:43", cat="normative") }}
+
+A non-`Copy` array element **MAY** be moved out of an array. Using `arr[i]` in a
+value context moves the indexed element out of the array — but, per 7.1:28, only
+when `i` is a compile-time constant and the indexing applies directly to an array
+variable or by-value array parameter (a *constant-index move*). The move is a
+partial move: only the indexed element is invalidated, and the sibling elements
+remain usable (3.8:68).
+
+{{ rule(id="7.1:44") }}
+
+```rue
+struct Big { value: i32 }
+
+fn consume(b: Big) -> i32 { b.value }
+
+fn main() -> i32 {
+    let xs = [Big { value: 40 }, Big { value: 2 }];
+    let a = consume(xs[0]);   // moves element 0 out
+    let b = consume(xs[1]);   // sibling element 1 still usable
+    a + b                     // 42
+}
+```
+
+{{ rule(id="7.1:45", cat="legality-rule") }}
+
+While one or more elements of an array have been moved out, it is a compile-time
+error to use the array as a whole value, to use a moved-out element (including
+reading a field through it), or to index the array with a non-constant index. The
+non-constant-index restriction is required for soundness: with a runtime index the
+compiler cannot know at compile time which element was moved. The sibling elements
+that were not moved remain usable through constant-index projection (3.8:70).
+
+{{ rule(id="7.1:46", cat="legality-rule") }}
+
+While one or more elements of an array have been moved out, it is a compile-time
+error to assign into the array — to an element (`arr[k] = …`) or through an element
+(`arr[k].f = …`). An element write does not reinstate per-element ownership; the
+whole array **MUST** be reinitialized (`arr = [ … ]`) instead, which makes every
+element owned — and therefore droppable — again (3.8:72).
+
+{{ rule(id="7.1:47", cat="normative") }}
+
+An array whose element type carries a must-consume (linear) value satisfies its
+consumption obligation when every element has been moved out on every non-diverging
+path. Moving out only some elements, or moving an element on only some paths, is a
+compile-time error naming the elements that remain unconsumed (3.8:71).
+
+{{ rule(id="7.1:48", cat="dynamic-semantics") }}
+
+At scope exit — and when an array variable is overwritten — elements that were moved
+out on every path reaching that point are not dropped; an element moved out on only
+some paths is dropped exactly on the paths that did not move it; untouched elements
+are dropped in ascending index order (3.8:73).


### PR DESCRIPTION
Cycle 104:
- **RUE-317**: @import via a ../-relative path + the same file on the command line registered as two modules (E0707) — added one normalize_module_path that collapses `..`, routed all 3 sites through it. Repro compiles+runs; real duplicates still error. 4 CLI + 5 unit tests.
- **RUE-336**: section classification (7 inline sites) → one SectionKind + classify_section. Pure refactor; 126/126 linker tests.
- **RUE-340**: oracle step budget was per-activation → deep recursion overflowed the Rust stack, aborting the differential run. Global budget + depth counter (2000) + 256 MiB interp thread → clean Unsupported skip.
- **RUE-299** (2 medium gaps): array-element move-legality rules (dangling 3.8:68 cross-ref) + match scrutinee access mode. 11 cases. Remaining low-pri items stay tracked in RUE-299.

clippy clean; test.sh Pass 24, 100% traceability (697/697), oracle 0.

Fixes RUE-317
Fixes RUE-336
Fixes RUE-340

Generated with Claude Code