### PR TITLE
Runtime: null-check before copy on OOM in 4 String functions + fix stale docs

### DIFF
--- a/crates/rue-runtime/src/error.rs
+++ b/crates/rue-runtime/src/error.rs
@@ -235,8 +235,8 @@ crate::define_for_all_platforms! {
     /// sequence that is not well-formed UTF-8. Rue's `String` is a byte string
     /// that may hold arbitrary bytes; the "trap, don't corrupt" discipline
     /// applies at the decode boundary, so interpreting invalid bytes as
-    /// Unicode scalars traps loudly (a `.chars_lossy()` that substitutes
-    /// `U+FFFD` is a future addition).
+    /// Unicode scalars traps loudly; the lossy `.chars_lossy()` variant
+    /// substitutes `U+FFFD` instead of trapping.
     ///
     /// # Behavior
     ///

--- a/crates/rue-runtime/src/lib.rs
+++ b/crates/rue-runtime/src/lib.rs
@@ -51,8 +51,7 @@
 //! | Code | Meaning |
 //! |------|---------|
 //! | 0 | Success (or whatever `main()` returned) |
-//! | 1 | Panic (from Rust runtime, shouldn't happen in normal operation) |
-//! | 101 | Runtime error (division by zero, overflow) |
+//! | 101 | Any panic or runtime trap — overflow, division by zero, bounds check, cast overflow, invalid UTF-8, `@panic`/`@assert`, allocation failure, and the Rust `panic_handler` (spec Appendix B) |
 //!
 //! # Integration with the Compiler
 //!

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -645,8 +645,8 @@ crate::define_for_all_platforms! {
 /// This backs `for c in s.chars()` (RUE-220, ADR-0035). Rue's `String` is a
 /// byte string that may hold arbitrary bytes; decoding is where invalidity is
 /// caught, so any malformed, truncated, overlong, or surrogate sequence traps
-/// (`__rue_invalid_utf8`, exit 101) rather than producing `U+FFFD` (a lossy
-/// `.chars_lossy()` is a future addition). Callers only invoke this when
+/// (`__rue_invalid_utf8`, exit 101) rather than producing `U+FFFD` (the lossy
+/// `.chars_lossy()` variant substitutes it instead of trapping). Callers only invoke this when
 /// `offset < len` (the loop's end test guarantees a byte remains), but a
 /// multi-byte sequence that runs past `len` is a truncated sequence and traps.
 ///
@@ -963,6 +963,18 @@ crate::define_for_all_platforms! {
         };
         let new_ptr = heap::alloc(new_cap, 1);
 
+        // Check for allocation failure before the copy to avoid UB (mirrors
+        // __rue_String_clone): on OOM, publish an empty String and return.
+        if new_ptr.is_null() {
+            // SAFETY: writing to `out` is valid — see __rue_String_new.
+            unsafe {
+                (*out).ptr = core::ptr::null_mut();
+                (*out).len = 0;
+                (*out).cap = 0;
+            }
+            return;
+        }
+
         // SAFETY: `start + sub_len <= len` (checked above) so the source range
         // is in bounds; `new_ptr` was just allocated with `new_cap >= sub_len`
         // bytes; the regions don't overlap (fresh allocation).
@@ -1137,6 +1149,18 @@ crate::define_for_all_platforms! {
         };
         let new_ptr = heap::alloc(new_cap, 1);
 
+        // Check for allocation failure before the copy to avoid UB (mirrors
+        // __rue_String_clone): on OOM, publish an empty String and return.
+        if new_ptr.is_null() {
+            // SAFETY: writing to `out` is valid — see __rue_String_new.
+            unsafe {
+                (*out).ptr = core::ptr::null_mut();
+                (*out).len = 0;
+                (*out).cap = 0;
+            }
+            return;
+        }
+
         // SAFETY: `new_ptr` was just allocated with `new_cap >= len` bytes; the
         // source range `buf[i..]` holds exactly `len` initialized bytes; the
         // regions don't overlap (fresh allocation). `out` is a valid sret
@@ -1198,6 +1222,18 @@ crate::define_for_all_platforms! {
             len
         };
         let new_ptr = heap::alloc(new_cap, 1);
+
+        // Check for allocation failure before the copy to avoid UB (mirrors
+        // __rue_String_clone): on OOM, publish an empty String and return.
+        if new_ptr.is_null() {
+            // SAFETY: writing to `out` is valid — see __rue_String_new.
+            unsafe {
+                (*out).ptr = core::ptr::null_mut();
+                (*out).len = 0;
+                (*out).cap = 0;
+            }
+            return;
+        }
 
         // SAFETY: `new_ptr` was just allocated with `new_cap >= len` bytes; the
         // source range `buf[i..]` holds exactly `len` initialized bytes; the
@@ -1262,6 +1298,18 @@ crate::define_for_all_platforms! {
             total
         };
         let new_ptr = heap::alloc(new_cap, 1);
+
+        // Check for allocation failure before the copy to avoid UB (mirrors
+        // __rue_String_clone): on OOM, publish an empty String and return.
+        if new_ptr.is_null() {
+            // SAFETY: writing to `out` is valid — see __rue_String_new.
+            unsafe {
+                (*out).ptr = core::ptr::null_mut();
+                (*out).len = 0;
+                (*out).cap = 0;
+            }
+            return;
+        }
 
         // SAFETY: `new_ptr` has `new_cap >= total = len1 + len2` bytes. The two
         // source ranges are each in bounds for their lengths and don't overlap


### PR DESCRIPTION
From the rue-runtime code review (memory-safety hardening — bugs here escape the RUE-50 oracle, which abstracts over heap layout):
- **OOM null-deref**: `__rue_String_substring`/`__rue_to_string`/`__rue_to_string_unsigned`/`__rue_String_concat` called `heap::alloc` then `copy_nonoverlapping` with no null check — on allocation failure (mmap exhaustion) they wrote through null (UB/SIGSEGV) and published a corrupt String. Their siblings (clone/with_capacity/ensure_capacity) already guard; added the same guard (empty String + return on null), mirroring `__rue_String_clone`.
- **Stale exit-code table** (lib.rs): removed the nonexistent `1 = Panic` row and broadened `101` to any trap, per spec Appendix B.
- **Stale docs**: two comments called `chars_lossy`/U+FFFD substitution "a future addition" — it already ships (RUE-17 Phase 3); reworded.

clippy clean; test.sh Pass 24. (Other review findings filed: RUE-344 arena-alignment overflow, RUE-345 @alloc multiply-overflow needs-ruling.)

Generated with Claude Code