### PR TITLE
Codegen O(n²)→O(n) on large array literals, oracle stdout drain, align_up dedup, intrinsic-arg pin

### DIFF
--- a/crates/rue-cli-tests/cases/large_array_literal.toml
+++ b/crates/rue-cli-tests/cases/large_array_literal.toml
@@ -1,0 +1,33 @@
+# Large explicit array literal `[e0, e1, ..., e_n]` (RUE-302).
+#
+# A big element-by-element array literal used to compile in O(n^2) time because
+# several per-element codegen steps (live-range construction, the linear-scan
+# spill-slot search, loop-depth range queries, and the x86 `mov 0` peephole)
+# each rescanned an O(n) structure. This case pins that a 256-element literal
+# compiles and stores every element into its own slot: individual reads catch a
+# wrong-slot store and the sum (0 + 1 + ... + 255 = 32640) catches a dropped or
+# duplicated element.
+
+[section]
+id = "cli.large_array_literal"
+name = "Large explicit array literal"
+description = "A 256-element explicit array literal compiles correctly with each element in its own slot (RUE-302)."
+
+[[case]]
+name = "explicit_256_elements_sequential"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: [i32; 256] = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152, 153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164, 165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176, 177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188, 189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200, 201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212, 213, 214, 215, 216, 217, 218, 219, 220, 221, 222, 223, 224, 225, 226, 227, 228, 229, 230, 231, 232, 233, 234, 235, 236, 237, 238, 239, 240, 241, 242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255];
+    @dbg(a[0]);
+    @dbg(a[128]);
+    @dbg(a[255]);
+    let mut sum: i32 = 0;
+    for x in a {
+        sum = sum + x;
+    }
+    @dbg(sum);
+    0
+}
+""" }]
+stdout = "0\n128\n255\n32640\n"

--- a/crates/rue-cli-tests/cases/nested_intrinsic_argument.toml
+++ b/crates/rue-cli-tests/cases/nested_intrinsic_argument.toml
@@ -1,0 +1,67 @@
+# Regression pin for RUE-343: a bare intrinsic call CAN be a direct argument to
+# another intrinsic. `@dbg(@size_of(i32))` was reported (2026-07-03) to fail to
+# parse, but it does not reproduce — the intrinsic-argument grammar
+# (`intrinsic_arg` in rue-parser/src/chumsky_parser.rs) has accepted a full
+# expression, including a nested intrinsic-call atom, since the intrinsics
+# landed (Dec 2025). These cases lock that behavior in against regression:
+# nested intrinsic-call expressions compose in every value-argument position,
+# while the type-first argument position (@size_of/@offset_of's first arg) still
+# parses a type.
+#
+# NOTE: what these cases pin is PARSING (RUE-343), not any intrinsic's value.
+# Value assertions here use @offset_of, which yields correct, field-distinct
+# offsets (x=0, y=8). @size_of currently reports 8 for every width — a separate,
+# unrelated codegen bug — so the pure-@size_of repro below only checks that it
+# parses and runs, not that 8 is the right size of an i32.
+
+[section]
+id = "cli.nested_intrinsic_argument"
+name = "Nested intrinsic-call arguments"
+description = "An intrinsic call is a full expression and composes as a direct argument to another intrinsic (RUE-343)."
+
+# The exact RUE-343 repro: a bare @size_of(i32) call passed directly as the
+# argument to @dbg. The point is that it PARSES and runs; the printed value
+# reflects @size_of's current (buggy) behavior, tracked separately.
+[[case]]
+name = "dbg_of_size_of"
+description = "@dbg(@size_of(i32)) parses and runs (exact RUE-343 repro)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    @dbg(@size_of(i32));
+    0
+}
+""" }]
+stdout = "8\n"
+exit_code = 0
+
+# A second intrinsic (@offset_of) whose own first argument is a TYPE, nested as
+# a direct @dbg argument: exercises the type-first + value-argument mix in the
+# nested position, with field-distinct values proving real evaluation.
+[[case]]
+name = "dbg_of_offset_of"
+description = "@dbg(@offset_of(Pair, field)) composes a type-first intrinsic inside @dbg."
+files = [{ path = "main.rue", source = """
+struct Pair { x: i32, y: i64 }
+fn main() -> i32 {
+    @dbg(@offset_of(Pair, x));
+    @dbg(@offset_of(Pair, y));
+    0
+}
+""" }]
+stdout = "0\n8\n"
+exit_code = 0
+
+# The "works fine" comparison form from the issue: an intrinsic call embedded in
+# a larger expression that is itself the argument to another intrinsic.
+[[case]]
+name = "dbg_of_intrinsic_arithmetic"
+description = "An intrinsic call inside a larger expression is a valid argument to @dbg."
+files = [{ path = "main.rue", source = """
+struct Pair { x: i32, y: i64 }
+fn main() -> i32 {
+    @dbg(@offset_of(Pair, y) + 1);
+    0
+}
+""" }]
+stdout = "9\n"
+exit_code = 0

--- a/crates/rue-codegen/src/liveness.rs
+++ b/crates/rue-codegen/src/liveness.rs
@@ -86,8 +86,15 @@ where
         compute_dataflow(num_insts, vreg_count, &successors, &inst_uses, &inst_defs);
 
     // Step 5: Build live ranges from dataflow results
+    let has_back_edge = has_back_edge(&successors);
     let ranges = build_live_ranges(
-        num_insts, vreg_count, &inst_uses, &inst_defs, &live_in, &live_out,
+        num_insts,
+        vreg_count,
+        &inst_uses,
+        &inst_defs,
+        &live_in,
+        &live_out,
+        has_back_edge,
     );
 
     // Step 6: Compute live_at for each instruction (union of live_in and live_out)
@@ -143,8 +150,15 @@ where
         compute_dataflow(num_insts, vreg_count, &successors, &inst_uses, &inst_defs);
 
     // Step 5: Build live ranges from dataflow results
+    let has_back_edge = has_back_edge(&successors);
     let live_ranges = build_live_ranges(
-        num_insts, vreg_count, &inst_uses, &inst_defs, &live_in, &live_out,
+        num_insts,
+        vreg_count,
+        &inst_uses,
+        &inst_defs,
+        &live_in,
+        &live_out,
+        has_back_edge,
     );
 
     // Step 6: Build per-instruction liveness info
@@ -198,6 +212,16 @@ fn build_successor_lists<I>(
         .enumerate()
         .map(|(idx, inst)| get_successors(idx, inst, label_to_idx))
         .collect()
+}
+
+/// Return `true` if any instruction has a successor at an index `<= its own`,
+/// i.e. the control-flow graph contains a back-edge (a loop). Used to pick the
+/// fast, loop-free live-range construction path in [`build_live_ranges`].
+fn has_back_edge(successors: &[Vec<usize>]) -> bool {
+    successors
+        .iter()
+        .enumerate()
+        .any(|(from, succs)| succs.iter().any(|&to| to <= from))
 }
 
 /// Perform backward dataflow analysis to compute live-in and live-out sets.
@@ -254,6 +278,21 @@ fn compute_dataflow(
 }
 
 /// Build live ranges from dataflow results.
+///
+/// `has_back_edge` selects the algorithm:
+///
+/// * **No back-edges (loop-free control flow):** a vreg's live range is exactly
+///   `[first def/use, last def/use]`. Scanning `live_in`/`live_out` cannot widen
+///   it — a vreg can only be live at an instruction that is neither a def nor a
+///   use of it if that instruction sits *between* a def and a later use (already
+///   inside the def/use span) or across a back-edge (excluded here). So we skip
+///   the per-instruction bitset scan entirely and read ranges off the def/use
+///   lists in O(defs + uses). This matters because a single basic block can hold
+///   many simultaneously-live vregs (e.g. a large array literal materializes N
+///   element values before storing them); the bitset scan is then O(N²) in the
+///   number of live bits, whereas this path stays linear (RUE-302).
+/// * **Has back-edges (loops):** loop-carried values are live past their textual
+///   last use, so we fall back to the exact `live_in`/`live_out` scan.
 fn build_live_ranges(
     num_insts: usize,
     vreg_count: u32,
@@ -261,7 +300,36 @@ fn build_live_ranges(
     inst_defs: &[Vec<VReg>],
     live_in: &[FixedBitSet],
     live_out: &[FixedBitSet],
+    has_back_edge: bool,
 ) -> IndexMap<VReg, Option<LiveRange>> {
+    let mut ranges: IndexMap<VReg, Option<LiveRange>> =
+        IndexMap::with_capacity(vreg_count as usize);
+    ranges.resize(vreg_count as usize, None);
+
+    if !has_back_edge {
+        // Fast O(defs + uses) path: no loops, so def/use extents are the range.
+        let mut extend = |vreg: VReg, idx: usize| match &mut ranges[vreg] {
+            Some(range) => {
+                if idx < range.start {
+                    range.start = idx;
+                }
+                if idx > range.end {
+                    range.end = idx;
+                }
+            }
+            slot @ None => *slot = Some(LiveRange::new(idx, idx)),
+        };
+        for idx in 0..num_insts {
+            for vreg in &inst_defs[idx] {
+                extend(*vreg, idx);
+            }
+            for vreg in &inst_uses[idx] {
+                extend(*vreg, idx);
+            }
+        }
+        return ranges;
+    }
+
     let mut first_live: HashMap<VReg, usize> = HashMap::new();
     let mut last_live: HashMap<VReg, usize> = HashMap::new();
 
@@ -295,9 +363,6 @@ fn build_live_ranges(
     }
 
     // Build ranges using dense Vec storage
-    let mut ranges: IndexMap<VReg, Option<LiveRange>> =
-        IndexMap::with_capacity(vreg_count as usize);
-    ranges.resize(vreg_count as usize, None);
     for vreg_idx in 0..vreg_count {
         let vreg = VReg::new(vreg_idx);
         if let (Some(&start), Some(&end)) = (first_live.get(&vreg), last_live.get(&vreg)) {
@@ -384,7 +449,7 @@ pub fn compute_loop_info(num_insts: usize, successors: &[Vec<usize>]) -> LoopInf
         }
     }
 
-    LoopInfo { depths }
+    LoopInfo::from_depths(depths)
 }
 
 /// Compute loop info from instructions using the provided callbacks.

--- a/crates/rue-codegen/src/regalloc.rs
+++ b/crates/rue-codegen/src/regalloc.rs
@@ -182,6 +182,13 @@ pub struct LoopInfo {
     /// Loop depth for each instruction index.
     /// 0 = not in a loop, 1 = in one loop, 2 = nested two levels, etc.
     pub depths: Vec<u32>,
+    /// Maximum loop depth across all instructions, cached so that loop-free code
+    /// (`max_depth == 0`) answers range-max queries in O(1) instead of scanning
+    /// the range. Register allocation queries the max depth over a vreg's whole
+    /// live range once per vreg; on loop-free code with long live ranges (e.g. a
+    /// large array literal) the scan was O(range) per vreg and quadratic overall
+    /// (RUE-302).
+    max_depth: u32,
 }
 
 impl LoopInfo {
@@ -189,7 +196,14 @@ impl LoopInfo {
     pub fn no_loops(instruction_count: usize) -> Self {
         Self {
             depths: vec![0; instruction_count],
+            max_depth: 0,
         }
+    }
+
+    /// Create loop info from a per-instruction depth vector, caching the max.
+    pub fn from_depths(depths: Vec<u32>) -> Self {
+        let max_depth = depths.iter().copied().max().unwrap_or(0);
+        Self { depths, max_depth }
     }
 
     /// Get the loop depth for an instruction.
@@ -199,6 +213,10 @@ impl LoopInfo {
 
     /// Get the maximum loop depth across a range of instructions.
     pub fn max_depth_in_range(&self, start: usize, end: usize) -> u32 {
+        // Loop-free code: the max is trivially 0, no scan needed.
+        if self.max_depth == 0 {
+            return 0;
+        }
         if start > end || start >= self.depths.len() {
             return 0;
         }
@@ -805,6 +823,14 @@ struct SpillSlotAllocator {
     /// For each spill slot, the end point of its current occupant.
     /// None means the slot is free (never used or occupant has ended).
     slots: Vec<Option<usize>>,
+    /// Smallest occupant end point across all slots (`None` when there are no
+    /// occupied slots). A slot is reusable for a range starting at `start` only
+    /// if some occupant ends before `start`; when `min_slot_end >= start` no slot
+    /// can be reused, so the O(slots) scan is skipped. Without this, spilling many
+    /// simultaneously-live values (e.g. a large array literal, where no slot is
+    /// ever reusable) rescans the whole growing slot list per spill — O(spills²)
+    /// (RUE-302).
+    min_slot_end: Option<usize>,
     /// Base offset for spill slots (after existing locals).
     base_offset: i32,
 }
@@ -817,6 +843,7 @@ impl SpillSlotAllocator {
     fn new(existing_locals: u32) -> Self {
         Self {
             slots: Vec::new(),
+            min_slot_end: None,
             base_offset: -((existing_locals as i32 + 1) * 8),
         }
     }
@@ -828,23 +855,37 @@ impl SpillSlotAllocator {
     ///
     /// Returns the stack offset for the spill slot.
     fn allocate(&mut self, live_range_start: usize, live_range_end: usize) -> i32 {
-        // Try to find a reusable slot whose occupant ended before this range starts
-        for (i, slot_end) in self.slots.iter_mut().enumerate() {
-            if let Some(end) = slot_end {
-                // The occupant is dead if its end point is strictly before our start.
-                // Note: We use < not <= because at the same instruction index,
-                // both ranges are considered live (inclusive endpoints).
-                if *end < live_range_start {
-                    // Reuse this slot
-                    *slot_end = Some(live_range_end);
-                    return self.offset_for_slot(i);
+        // Try to find a reusable slot whose occupant ended before this range
+        // starts. Skip the scan entirely when no occupant can possibly qualify
+        // (the common case when many live ranges overlap); this scan is otherwise
+        // O(slots) per call and quadratic overall (RUE-302).
+        if self
+            .min_slot_end
+            .is_some_and(|min_end| min_end < live_range_start)
+        {
+            for (i, slot_end) in self.slots.iter_mut().enumerate() {
+                if let Some(end) = slot_end {
+                    // The occupant is dead if its end point is strictly before our start.
+                    // Note: We use < not <= because at the same instruction index,
+                    // both ranges are considered live (inclusive endpoints).
+                    if *end < live_range_start {
+                        // Reuse this slot. Its end point grows, so the cached
+                        // minimum may no longer hold; recompute it exactly.
+                        *slot_end = Some(live_range_end);
+                        self.min_slot_end = self.slots.iter().flatten().copied().min();
+                        return self.offset_for_slot(i);
+                    }
                 }
             }
         }
 
-        // No reusable slot found, allocate a new one
+        // No reusable slot found, allocate a new one.
         let slot_index = self.slots.len();
         self.slots.push(Some(live_range_end));
+        self.min_slot_end = Some(match self.min_slot_end {
+            Some(min_end) => min_end.min(live_range_end),
+            None => live_range_end,
+        });
         self.offset_for_slot(slot_index)
     }
 
@@ -978,6 +1019,7 @@ pub fn linear_scan<Reg: Copy + Eq + std::hash::Hash>(
         liveness,
         allocatable_regs,
         existing_locals,
+        false,
         &cost_model,
         &loop_info,
     );
@@ -1019,6 +1061,7 @@ pub fn linear_scan_with_cost_model<Reg: Copy + Eq + std::hash::Hash>(
         liveness,
         allocatable_regs,
         existing_locals,
+        false,
         cost_model,
         loop_info,
     );
@@ -1062,6 +1105,7 @@ pub fn linear_scan_with_remat<Reg: Copy + Eq + std::hash::Hash>(
         liveness,
         allocatable_regs,
         existing_locals,
+        false,
         &cost_model,
         &loop_info,
         vreg_info,
@@ -1095,6 +1139,7 @@ pub fn linear_scan_with_debug<Reg: Copy + Eq + std::hash::Hash>(
         liveness,
         allocatable_regs,
         existing_locals,
+        true,
         &cost_model,
         &loop_info,
     )
@@ -1122,6 +1167,7 @@ pub fn linear_scan_with_cost_model_and_debug<Reg: Copy + Eq + std::hash::Hash>(
         liveness,
         allocatable_regs,
         existing_locals,
+        true,
         cost_model,
         loop_info,
     )
@@ -1130,13 +1176,17 @@ pub fn linear_scan_with_cost_model_and_debug<Reg: Copy + Eq + std::hash::Hash>(
 /// Internal implementation of linear scan register allocation.
 ///
 /// This is the shared implementation used by both [`linear_scan`] and
-/// [`linear_scan_with_debug`]. It always collects debug information,
-/// which is discarded by [`linear_scan`].
+/// [`linear_scan_with_debug`]. When `collect_debug` is `false` (the normal
+/// compilation path, where callers discard the debug info) the O(V²)
+/// interference-graph construction is skipped — it feeds only `--emit regalloc`
+/// output and building it on every compile made allocation quadratic in the
+/// number of virtual registers (e.g. large array literals) (RUE-302).
 fn linear_scan_impl<Reg: Copy + Eq + std::hash::Hash>(
     vreg_count: u32,
     liveness: &LivenessInfo<Reg>,
     allocatable_regs: &[Reg],
     existing_locals: u32,
+    collect_debug: bool,
     cost_model: &CostModel,
     loop_info: &LoopInfo,
 ) -> (
@@ -1167,18 +1217,23 @@ fn linear_scan_impl<Reg: Copy + Eq + std::hash::Hash>(
         let vreg = VReg::new(vreg_idx);
         if let Some(&range) = liveness.range(vreg) {
             vregs_by_start.push((vreg, range));
-            debug_live_ranges.push((vreg_idx, range.start, range.end));
+            if collect_debug {
+                debug_live_ranges.push((vreg_idx, range.start, range.end));
+            }
         }
     }
     vregs_by_start.sort_by_key(|(_, range)| range.start);
 
-    // Build interference graph: vregs that overlap
-    for i in 0..vregs_by_start.len() {
-        for j in (i + 1)..vregs_by_start.len() {
-            let (vreg1, range1) = &vregs_by_start[i];
-            let (vreg2, range2) = &vregs_by_start[j];
-            if range1.overlaps(range2) {
-                debug_interference.push((vreg1.index(), vreg2.index()));
+    // Build interference graph: vregs that overlap. This is O(V²) and feeds only
+    // `--emit regalloc`; skip it on the normal compilation path (RUE-302).
+    if collect_debug {
+        for i in 0..vregs_by_start.len() {
+            for j in (i + 1)..vregs_by_start.len() {
+                let (vreg1, range1) = &vregs_by_start[i];
+                let (vreg2, range2) = &vregs_by_start[j];
+                if range1.overlaps(range2) {
+                    debug_interference.push((vreg1.index(), vreg2.index()));
+                }
             }
         }
     }
@@ -1292,6 +1347,7 @@ fn linear_scan_impl_with_remat<Reg: Copy + Eq + std::hash::Hash>(
     liveness: &LivenessInfo<Reg>,
     allocatable_regs: &[Reg],
     existing_locals: u32,
+    collect_debug: bool,
     cost_model: &CostModel,
     loop_info: &LoopInfo,
     vreg_info: &IndexMap<VReg, VRegInfo>,
@@ -1327,18 +1383,23 @@ fn linear_scan_impl_with_remat<Reg: Copy + Eq + std::hash::Hash>(
         let vreg = VReg::new(vreg_idx);
         if let Some(&range) = liveness.range(vreg) {
             vregs_by_start.push((vreg, range));
-            debug_live_ranges.push((vreg_idx, range.start, range.end));
+            if collect_debug {
+                debug_live_ranges.push((vreg_idx, range.start, range.end));
+            }
         }
     }
     vregs_by_start.sort_by_key(|(_, range)| range.start);
 
-    // Build interference graph: vregs that overlap
-    for i in 0..vregs_by_start.len() {
-        for j in (i + 1)..vregs_by_start.len() {
-            let (vreg1, range1) = &vregs_by_start[i];
-            let (vreg2, range2) = &vregs_by_start[j];
-            if range1.overlaps(range2) {
-                debug_interference.push((vreg1.index(), vreg2.index()));
+    // Build interference graph: vregs that overlap. This is O(V²) and feeds only
+    // `--emit regalloc`; skip it on the normal compilation path (RUE-302).
+    if collect_debug {
+        for i in 0..vregs_by_start.len() {
+            for j in (i + 1)..vregs_by_start.len() {
+                let (vreg1, range1) = &vregs_by_start[i];
+                let (vreg2, range2) = &vregs_by_start[j];
+                if range1.overlaps(range2) {
+                    debug_interference.push((vreg1.index(), vreg2.index()));
+                }
             }
         }
     }
@@ -2271,9 +2332,7 @@ mod tests {
 
     #[test]
     fn test_loop_info_with_depths() {
-        let info = LoopInfo {
-            depths: vec![0, 0, 1, 1, 1, 2, 2, 1, 0, 0],
-        };
+        let info = LoopInfo::from_depths(vec![0, 0, 1, 1, 1, 2, 2, 1, 0, 0]);
 
         assert_eq!(info.depth(0), 0);
         assert_eq!(info.depth(2), 1);
@@ -2304,9 +2363,7 @@ mod tests {
         loop_depths: Vec<u32>,
     ) -> (LivenessInfo<TestReg>, LoopInfo) {
         let liveness = make_liveness(ranges);
-        let loop_info = LoopInfo {
-            depths: loop_depths,
-        };
+        let loop_info = LoopInfo::from_depths(loop_depths);
         (liveness, loop_info)
     }
 

--- a/crates/rue-codegen/src/x86_64/peephole.rs
+++ b/crates/rue-codegen/src/x86_64/peephole.rs
@@ -44,9 +44,17 @@ use super::schedule::{reads_flags, writes_flags};
 pub fn optimize(instructions: &mut Vec<X86Inst>) -> usize {
     let mut changes = 0;
 
+    // Precompute FLAGS-liveness for every index in one backward pass. Pass 1
+    // only inspects the FLAGS state of instructions *after* `i`, which it does
+    // not mutate during the pass (it only rewrites index `i` in place), so this
+    // snapshot is valid for the whole pass. Without it, each `mov r, 0` rewrite
+    // rescans the tail via `flags_dead_after`, making pass 1 O(n²) on long
+    // flag-neutral runs such as large array-literal stores (RUE-302).
+    let flags_dead = compute_flags_dead(instructions);
+
     // Pass 1: Single-instruction transforms (mov 0 -> xor, cmp 0 -> test)
     for i in 0..instructions.len() {
-        if let Some(new_inst) = transform_single(instructions, i) {
+        if let Some(new_inst) = transform_single(instructions, i, flags_dead[i]) {
             instructions[i] = new_inst;
             changes += 1;
         }
@@ -103,6 +111,39 @@ fn flags_dead_after(instructions: &[X86Inst], idx: usize) -> bool {
     true
 }
 
+/// Compute [`flags_dead_after`] for every index in a single backward pass.
+///
+/// `result[i] == flags_dead_after(instructions, i)`. Each entry depends only on
+/// the instructions after `i`, so scanning once from the end (carrying the
+/// answer for `i + 1` into `i`) yields all of them in O(n) instead of O(n) per
+/// query (RUE-302).
+fn compute_flags_dead(instructions: &[X86Inst]) -> Vec<bool> {
+    let n = instructions.len();
+    let mut result = vec![true; n];
+    // `scan_after` holds `flags_dead_after(j)` for the index just processed,
+    // i.e. the result of scanning the tail starting at `j + 1`. Seeded with the
+    // empty-tail case (`flags_dead_after(n - 1) == true`).
+    let mut scan_after = true;
+    for j in (0..n).rev() {
+        result[j] = scan_after;
+        let inst = &instructions[j];
+        scan_after = if is_shift_by_zero(inst) {
+            scan_after
+        } else if reads_flags(inst) {
+            false
+        } else if writes_flags(inst) {
+            true
+        } else {
+            match inst {
+                X86Inst::CallRel { .. } | X86Inst::Syscall | X86Inst::Ret => true,
+                X86Inst::Jmp { .. } | X86Inst::Label { .. } => false,
+                _ => scan_after,
+            }
+        };
+    }
+    result
+}
+
 /// Shift-immediate-by-zero forms: architecturally, a shift count of 0
 /// leaves FLAGS unmodified, so these are neither flag writers (despite
 /// [`writes_flags`] reporting the non-zero forms) nor unsafe to remove.
@@ -133,19 +174,20 @@ fn removal_preserves_flags(instructions: &[X86Inst], idx: usize) -> bool {
 
 /// Transform the instruction at `idx` to a more efficient form.
 ///
+/// `flags_dead` must equal `flags_dead_after(instructions, idx)` (precomputed by
+/// the caller so a whole pass costs O(n), not O(n²)).
+///
 /// Returns `Some(new_inst)` if a transformation applies, `None` otherwise.
-fn transform_single(instructions: &[X86Inst], idx: usize) -> Option<X86Inst> {
+fn transform_single(instructions: &[X86Inst], idx: usize, flags_dead: bool) -> Option<X86Inst> {
     match &instructions[idx] {
         // mov r, 0 → xor r, r (smaller encoding: 5 bytes → 2 bytes)
         // Also breaks false dependencies on modern CPUs.
         // XOR writes FLAGS where MOV does not, so this is only legal where
         // the flags state at this point is dead (RUE-152).
-        X86Inst::MovRI32 { dst, imm: 0 } if flags_dead_after(instructions, idx) => {
-            Some(X86Inst::XorRR {
-                dst: *dst,
-                src: *dst,
-            })
-        }
+        X86Inst::MovRI32 { dst, imm: 0 } if flags_dead => Some(X86Inst::XorRR {
+            dst: *dst,
+            src: *dst,
+        }),
 
         // cmp r, 0 → test r, r (same flags, often faster)
         // Flag-equivalent for every consumed flag: both set CF=0, OF=0 and

--- a/crates/rue-linker/src/emit.rs
+++ b/crates/rue-linker/src/emit.rs
@@ -996,8 +996,10 @@ impl ObjectBuilder {
     }
 }
 
+/// `usize` adapter over the shared [`crate::util::align_up`] used by the ELF/Mach-O
+/// object emitters, whose offsets are all `usize`.
 fn align_up(value: usize, align: usize) -> usize {
-    (value + align - 1) & !(align - 1)
+    crate::util::align_up(value as u64, align as u64) as usize
 }
 
 #[cfg(test)]

--- a/crates/rue-linker/src/lib.rs
+++ b/crates/rue-linker/src/lib.rs
@@ -16,6 +16,7 @@ mod elf;
 mod emit;
 mod linker;
 pub mod macho;
+mod util;
 
 pub use archive::{Archive, ArchiveError};
 pub use elf::{ObjectFile, Relocation, RelocationType, Section, Symbol};

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -11,6 +11,7 @@ use crate::constants::{
 };
 use crate::elf::Section;
 use crate::elf::{ObjectFile, RelocationType, Symbol, SymbolBinding};
+use crate::util::align_up;
 
 /// Which merged output buffer a relocation's patch site lives in.
 ///
@@ -1781,11 +1782,6 @@ impl Default for Linker {
     }
 }
 
-/// Align a value up to the given alignment.
-fn align_up(value: u64, align: u64) -> u64 {
-    (value + align - 1) & !(align - 1)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1800,14 +1796,6 @@ mod tests {
     // Use X86_64Linux explicitly for ELF tests since ObjectFile only parses ELF
     // and the Linker produces ELF executables
     const ELF_TARGET: Target = Target::X86_64Linux;
-
-    #[test]
-    fn test_align_up() {
-        assert_eq!(align_up(0, 16), 0);
-        assert_eq!(align_up(1, 16), 16);
-        assert_eq!(align_up(16, 16), 16);
-        assert_eq!(align_up(17, 16), 32);
-    }
 
     #[test]
     fn test_linker_x86_64_linux() {

--- a/crates/rue-linker/src/macho.rs
+++ b/crates/rue-linker/src/macho.rs
@@ -23,6 +23,7 @@
 //! ```
 
 use crate::constants::*;
+use crate::util::align_up;
 
 /// ARM64 macOS page size (16KB).
 pub const PAGE_SIZE: u64 = 0x4000;
@@ -1141,11 +1142,6 @@ impl Default for MachOBuilder {
     fn default() -> Self {
         Self::new()
     }
-}
-
-/// Align a value up to the given alignment.
-fn align_up(value: u64, align: u64) -> u64 {
-    (value + align - 1) & !(align - 1)
 }
 
 #[cfg(test)]

--- a/crates/rue-linker/src/util.rs
+++ b/crates/rue-linker/src/util.rs
@@ -1,0 +1,25 @@
+//! Small shared helpers used across the linker's emitters.
+
+/// Align a value up to the given alignment.
+///
+/// `align` must be a power of two.
+pub(crate) fn align_up(value: u64, align: u64) -> u64 {
+    (value + align - 1) & !(align - 1)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_align_up() {
+        assert_eq!(align_up(0, 16), 0);
+        assert_eq!(align_up(1, 16), 16);
+        assert_eq!(align_up(16, 16), 16);
+        assert_eq!(align_up(17, 16), 32);
+        assert_eq!(align_up(0, 8), 0);
+        assert_eq!(align_up(7, 8), 8);
+        assert_eq!(align_up(8, 8), 8);
+        assert_eq!(align_up(9, 8), 16);
+    }
+}

--- a/crates/rue-oracle-diff/src/fuzz.rs
+++ b/crates/rue-oracle-diff/src/fuzz.rs
@@ -372,48 +372,111 @@ fn compile_and_run(
     // child's own exit code / terminating signal unambiguously. stderr is
     // captured (not `Stdio::null`) so a trap's message is available to
     // `classify` for panic-category comparison (RUE-339).
-    let mut child = Command::new(&bin_path)
-        .current_dir(dir)
+    let mut cmd = Command::new(&bin_path);
+    cmd.current_dir(dir);
+    run_with_timeout(cmd, timeout)
+}
+
+/// Maximum stderr bytes retained from a run. Trap messages are short; the cap
+/// only bounds how much we *keep* — the pipe is still drained to EOF (see
+/// [`read_capped`]) so a chatty program can never deadlock the wait loop.
+const STDERR_CAP: usize = 8192;
+
+/// Spawn `cmd` with piped stdout/stderr, drain both pipes **concurrently** via
+/// reader threads, and wait with a manual timeout.
+///
+/// Draining concurrently is essential (RUE-338): if the pipes were only read
+/// after the child exits, a program that writes more than the OS pipe capacity
+/// (~64KB on Linux) would block on `write()` forever, `try_wait` would never
+/// report an exit, and the timeout would manufacture a false `Compiled::Timeout`
+/// (→ a fabricated `Verdict::Disagree`). The reader threads start immediately
+/// after `spawn` so the child always has a consumer. On timeout we kill first,
+/// then join the readers — killing closes the child's write ends, the pipes hit
+/// EOF, and the readers finish, so no thread leaks.
+fn run_with_timeout(mut cmd: Command, timeout: Duration) -> std::io::Result<Compiled> {
+    let mut child = cmd
         .stdin(Stdio::null())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
         .spawn()?;
 
+    // stdout is captured in full (the oracle compares complete output, so it
+    // cannot be truncated); stderr is drained to EOF but only `STDERR_CAP` bytes
+    // are retained. Both readers run on their own thread so neither pipe can
+    // fill and block the child.
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let stdout_reader = std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        if let Some(mut out) = stdout_pipe {
+            out.read_to_end(&mut buf).ok();
+        }
+        buf
+    });
+    let stderr_reader =
+        std::thread::spawn(move || stderr_pipe.map(|err| read_capped(err, STDERR_CAP)));
+
     let start = Instant::now();
-    loop {
+    let status = loop {
         match child.try_wait()? {
-            Some(status) => {
-                let mut stdout = String::new();
-                if let Some(mut out) = child.stdout.take() {
-                    out.read_to_string(&mut stdout).ok();
-                }
-                // Bounded read: trap messages are short, and the child has
-                // already exited, so its full output is buffered in the pipe —
-                // no drain-deadlock. The cap just guards against a chatty
-                // program making us buffer unbounded stderr.
-                let mut stderr = String::new();
-                if let Some(err) = child.stderr.take() {
-                    err.take(8192).read_to_string(&mut stderr).ok();
-                }
-                return Ok(match status.code() {
-                    Some(code) => Compiled::Ran {
-                        exit: code,
-                        stdout,
-                        stderr,
-                    },
-                    None => Compiled::Crash(status.signal().unwrap_or(0)),
-                });
-            }
+            Some(status) => break status,
             None => {
                 if start.elapsed() > timeout {
                     let _ = child.kill();
                     let _ = child.wait();
+                    // Join so the reader threads don't leak; the killed child's
+                    // closed fds give them EOF, so these return promptly.
+                    let _ = stdout_reader.join();
+                    let _ = stderr_reader.join();
                     return Ok(Compiled::Timeout);
                 }
                 std::thread::sleep(Duration::from_millis(10));
             }
         }
+    };
+
+    // The child has exited; its write ends are closed, so the readers hit EOF
+    // and finish. Join to collect the fully-drained output.
+    let stdout_bytes = stdout_reader.join().unwrap_or_default();
+    let stderr_bytes = stderr_reader.join().unwrap_or_default().unwrap_or_default();
+    // Lossy decode so garbage bytes from a miscompile surface as a stdout
+    // mismatch rather than silently becoming empty (as `read_to_string` would).
+    let stdout = String::from_utf8_lossy(&stdout_bytes).into_owned();
+    let stderr = String::from_utf8_lossy(&stderr_bytes).into_owned();
+
+    Ok(match status.code() {
+        Some(code) => Compiled::Ran {
+            exit: code,
+            stdout,
+            stderr,
+        },
+        None => Compiled::Crash(status.signal().unwrap_or(0)),
+    })
+}
+
+/// Read `r` to EOF, retaining at most `cap` bytes. Reading all the way to EOF
+/// (rather than stopping after `cap`, as `Read::take` would) is what prevents a
+/// drain-deadlock: a program that writes more than `cap` to this pipe must still
+/// have every byte consumed or it blocks on a full pipe forever (RUE-338). The
+/// cap bounds only the memory we keep, not how much we drain.
+fn read_capped<R: Read>(mut r: R, cap: usize) -> Vec<u8> {
+    let mut kept = Vec::new();
+    let mut chunk = [0u8; 8192];
+    loop {
+        match r.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(n) => {
+                if kept.len() < cap {
+                    let take = (cap - kept.len()).min(n);
+                    kept.extend_from_slice(&chunk[..take]);
+                }
+                // Bytes beyond `cap` are read and discarded — draining, not
+                // storing — so the pipe never fills.
+            }
+            Err(_) => break,
+        }
     }
+    kept
 }
 
 struct Disagreement {
@@ -608,6 +671,89 @@ mod tests {
         )));
         assert!(is_disagree(classify(&oc(0, ""), &Compiled::Crash(11))));
         assert!(is_disagree(classify(&oc(0, ""), &Compiled::Timeout)));
+    }
+
+    #[test]
+    fn large_stdout_does_not_deadlock() {
+        // RUE-338: a program that writes far more than the OS pipe capacity
+        // (~64KB) must be drained concurrently while it runs. Before the fix the
+        // pipe filled, the writer blocked on `write()`, `try_wait` never saw an
+        // exit, and the 10s timeout fabricated a `Compiled::Timeout` (→ a false
+        // Disagree). Emit ~200KB and assert we capture every byte as `Ran`.
+        let n = 200_000usize;
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg(format!("yes y | head -c {n}"));
+        let result = run_with_timeout(cmd, Duration::from_secs(30)).expect("spawn");
+        match result {
+            Compiled::Ran { exit, stdout, .. } => {
+                assert_eq!(exit, 0, "pipeline should exit cleanly");
+                assert_eq!(
+                    stdout.len(),
+                    n,
+                    "full stdout must be captured, not truncated"
+                );
+            }
+            other => panic!("expected Ran with full stdout, got {}", describe(&other)),
+        }
+    }
+
+    #[test]
+    fn large_stderr_does_not_deadlock() {
+        // The stderr cap must not reintroduce the deadlock: even though we retain
+        // only STDERR_CAP bytes, the pipe is drained to EOF, so a program spewing
+        // >64KB to stderr still terminates as `Ran` (RUE-338).
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("yes e | head -c 200000 1>&2");
+        let result = run_with_timeout(cmd, Duration::from_secs(30)).expect("spawn");
+        match result {
+            Compiled::Ran { exit, stderr, .. } => {
+                assert_eq!(exit, 0);
+                assert!(!stderr.is_empty(), "some stderr should be retained");
+                assert!(
+                    stderr.len() <= STDERR_CAP,
+                    "stderr retained ({}) must not exceed the cap {STDERR_CAP}",
+                    stderr.len()
+                );
+            }
+            other => panic!("expected Ran, got {}", describe(&other)),
+        }
+    }
+
+    #[test]
+    fn read_capped_drains_to_eof_but_keeps_only_cap() {
+        // The drain-vs-keep contract in isolation: given more bytes than the cap,
+        // we consume all of them (Cursor reaches EOF) but retain exactly `cap`.
+        let data = vec![b'z'; 100_000];
+        let kept = read_capped(std::io::Cursor::new(data), STDERR_CAP);
+        assert_eq!(kept.len(), STDERR_CAP);
+        assert!(kept.iter().all(|&b| b == b'z'));
+        // Fewer bytes than the cap: keep them all.
+        let kept = read_capped(std::io::Cursor::new(vec![b'q'; 10]), STDERR_CAP);
+        assert_eq!(kept.len(), 10);
+    }
+
+    #[test]
+    fn timeout_still_reported_for_a_hung_child() {
+        // A genuine non-terminating program must still yield `Timeout` (and the
+        // reader threads must be joined, not leaked). We exec `sleep` directly
+        // (not via `sh -c`): the harness always runs a single-process compiled
+        // binary, so killing the child closes every pipe write-end, the readers
+        // hit EOF, and the post-kill join returns at once. `sleep` writes
+        // nothing, so this is the honest timeout path, distinct from the false
+        // one the large-output tests guard against.
+        let mut cmd = Command::new("sleep");
+        cmd.arg("30");
+        let start = Instant::now();
+        let result = run_with_timeout(cmd, Duration::from_millis(200)).expect("spawn");
+        assert!(
+            start.elapsed() < Duration::from_secs(5),
+            "kill-then-join must return promptly, not block on the child's full runtime"
+        );
+        assert!(
+            matches!(result, Compiled::Timeout),
+            "a truly hung child must report Timeout, got {}",
+            describe(&result)
+        );
     }
 
     #[test]


### PR DESCRIPTION
Cycle 105:
- **RUE-302**: large array literals were O(n²) — in **codegen** (not the frontend): ~N vregs simultaneously live × five per-element O(n) rescans (liveness, regalloc interference/spill/loop-depth, x86 peephole). Made each loop-free-fast-path/O(1); **107× faster at N=4000** (6635ms→62ms), output byte-identical (golden asm). Shared-file fixes benefit both backends.
- **RUE-338**: harness drained stdout only post-exit → >64KB output deadlocked → fabricated Disagree. Now drains both pipes on reader threads (unified with RUE-339's stderr capture); 200KB regression tests.
- **RUE-337**: align_up dedup'd into one util.rs fn. Pure refactor.
- **RUE-343**: **refuted** — nested intrinsic args parse fine (stale-binary report); shipped a regression pin.

clippy clean; test.sh Pass 24, 100% traceability (697/697), oracle-diff 0.

Fixes RUE-302
Fixes RUE-338
Fixes RUE-337
Fixes RUE-343

Generated with Claude Code