### PR TITLE
constfold: fix enum ==/!= folding on tag alone for payload-carrying enums (RUE-348 miscompile)

### DIFF
--- a/crates/rue-cfg/src/opt/constfold.rs
+++ b/crates/rue-cfg/src/opt/constfold.rs
@@ -164,16 +164,23 @@ fn fold_enum_comparison<F>(cfg: &Cfg, lhs: CfgValue, rhs: CfgValue, op: F) -> Op
 where
     F: FnOnce(u32, u32) -> bool,
 {
-    let (lhs_enum_id, lhs_variant) = get_enum_variant(cfg, lhs)?;
-    let (rhs_enum_id, rhs_variant) = get_enum_variant(cfg, rhs)?;
+    let (lhs_enum_id, lhs_variant, lhs_payload_len) = get_enum_variant(cfg, lhs)?;
+    let (rhs_enum_id, rhs_variant, rhs_payload_len) = get_enum_variant(cfg, rhs)?;
 
-    // Only fold if both operands are from the same enum type
-    if lhs_enum_id == rhs_enum_id {
+    // Only fold when both operands are the same enum AND payload-less: comparing
+    // the variant index alone is correct only for fieldless variants (e.g.
+    // `@target_arch() == Arch::X86_64`). For payload-carrying variants,
+    // structural equality must also compare the payloads — `Opt::Some(5)` and
+    // `Opt::Some(6)` share variant index 1 but are NOT equal — so those must fall
+    // through to codegen's `emit_aggregate_equality` rather than folding on the
+    // tag alone (RUE-348).
+    if lhs_enum_id == rhs_enum_id && lhs_payload_len == 0 && rhs_payload_len == 0 {
         let result = op(lhs_variant, rhs_variant);
         Some(CfgInstData::BoolConst(result))
     } else {
-        // Different enum types - this would be a type error,
-        // but let it pass through unfold for error reporting
+        // Different enum types (a type error, left to pass through for error
+        // reporting) or a payload-carrying comparison (folded structurally by
+        // codegen instead). Do not fold.
         None
     }
 }
@@ -219,8 +226,12 @@ fn fold_shift(
 
     // Shift amount must be less than the bit width
     let bits = type_bits(ty);
+    // A shift amount >= the bit width is masked modulo the width at runtime
+    // (spec 4.3a:10), consistent with dce.rs treating shifts as non-trapping —
+    // it is NOT UB. This fold path assumes rhs < bits (it does not re-narrow the
+    // result for the masked count), so defer the masked case to the backend,
+    // which masks the count correctly.
     if rhs_val >= bits as u64 {
-        // Would be UB at runtime - don't fold
         return None;
     }
 
@@ -278,13 +289,14 @@ fn get_const_bool(cfg: &Cfg, value: CfgValue) -> Option<bool> {
 }
 
 /// Get the enum variant info of an instruction, if it's an EnumVariant.
-fn get_enum_variant(cfg: &Cfg, value: CfgValue) -> Option<(EnumId, u32)> {
+fn get_enum_variant(cfg: &Cfg, value: CfgValue) -> Option<(EnumId, u32, u32)> {
     match &cfg.get_inst(value).data {
         CfgInstData::EnumVariant {
             enum_id,
             variant_index,
+            payload_len,
             ..
-        } => Some((*enum_id, *variant_index)),
+        } => Some((*enum_id, *variant_index, *payload_len)),
         _ => None,
     }
 }

--- a/crates/rue-cli-tests/cases/differential_opt.toml
+++ b/crates/rue-cli-tests/cases/differential_opt.toml
@@ -147,3 +147,29 @@ stdout = """610
 0
 """
 exit_code = 98
+
+# Enum structural equality with payloads: the same variant with a DIFFERENT
+# payload must not compare equal. Regression for RUE-348 — const-folding compared
+# only the variant tag, so `Opt::Some(5) == Opt::Some(6)` folded to `true` at
+# -O1+ while -O0 (deferring to codegen's structural compare) was correct.
+[[case]]
+name = "enum_payload_equality_across_opt_levels"
+differential_opt = true
+files = [{ path = "main.rue", source = """
+enum Opt { None, Some(i32) }
+
+fn main() -> i32 {
+    let ne: bool = Opt::Some(5) == Opt::Some(6);   // false: same variant, diff payload
+    let eq: bool = Opt::Some(5) == Opt::Some(5);   // true
+    let tag: bool = Opt::None == Opt::Some(0);     // false: different variant
+    if ne { @dbg(1); } else { @dbg(0); }
+    if eq { @dbg(1); } else { @dbg(0); }
+    if tag { @dbg(1); } else { @dbg(0); }
+    0
+}
+""" }]
+stdout = """0
+1
+0
+"""
+exit_code = 0


### PR DESCRIPTION
From the rue-cfg code review — a **real silent miscompile at -O1+** (default opt level). `fold_enum_comparison` folded enum `==`/`!=` using only the variant index, so same-variant/different-payload operands folded to 'equal':

```
enum Opt { None, Some(i32) }
if Opt::Some(5) == Opt::Some(6) { 1 } else { 0 }   // -O0: 0 (correct), -O1: 1 (WRONG)
```

Fix: `get_enum_variant` returns `payload_len`; fold only when both operands are payload-less. Fieldless folding (`@target_arch()`) stays; payload comparisons fall through to codegen's `emit_aggregate_equality`. Verified across -O0/-O1/-O2; added a `differential_opt` regression case. Also corrected a `fold_shift` comment (shift ≥ width is masked per spec 4.3a:10, not UB).

clippy clean; test.sh Pass 24, 100% traceability, oracle-diff 0.

Fixes RUE-348

Generated with Claude Code