### PR TITLE
Arena alignment fix, Vec→ArrayBuf cleanup, spec completeness gaps, statements prose pass

### DIFF
--- a/crates/rue-cli-tests/cases/anon_struct_destructor.toml
+++ b/crates/rue-cli-tests/cases/anon_struct_destructor.toml
@@ -8,7 +8,7 @@
 # These cases pin EXACT stdout (order matters) so the destructor's presence,
 # count, and ordering are all regression-tested. The heap case proves the
 # buffer is freed AUTOMATICALLY at scope exit with no explicit free() call —
-# the last gap to a "real" RAII Vec (RUE-1).
+# the last gap to a "real" RAII ArrayBuf (RUE-1).
 
 [section]
 id = "cli.anon_struct_destructor"

--- a/crates/rue-cli-tests/cases/comptime_enclosing_type_in_method.toml
+++ b/crates/rue-cli-tests/cases/comptime_enclosing_type_in_method.toml
@@ -2,7 +2,7 @@
 # usable throughout its anonymous struct's method BODIES — not just the
 # field/method signatures (RUE-313). Before the fix, referencing `T` inside a
 # method body (to declare a `T`-typed local, or to build `Option(T)`) failed
-# with "unknown type 'T'" (E0204), so a source-level `Vec(T)` could not return
+# with "unknown type 'T'" (E0204), so a source-level `ArrayBuf(T)` could not return
 # `Option(T)`.
 
 [section]

--- a/crates/rue-cli-tests/cases/comptime_type_functions.toml
+++ b/crates/rue-cli-tests/cases/comptime_type_functions.toml
@@ -1,6 +1,6 @@
 # Comptime type-function composition and array-of-type diagnostics.
 #
-# Type-returning functions (`-> type`) are load-bearing for Option/Result/Vec,
+# Type-returning functions (`-> type`) are load-bearing for Option/Result/ArrayBuf,
 # so their calls must reduce compositionally — in a delegating return body and
 # as a nested argument — and an array literal of `type` values must produce a
 # clean diagnostic instead of an ICE. These exercise the real driver

--- a/crates/rue-cli-tests/cases/heap_intrinsics.toml
+++ b/crates/rue-cli-tests/cases/heap_intrinsics.toml
@@ -1,7 +1,7 @@
 # @alloc / @free / @realloc heap intrinsics driven the way a user does — real
 # files, the real driver, real program exit codes and stdout (RUE-1).
 #
-# These are the unchecked heap primitives a source-level Vec is built on. The
+# These are the unchecked heap primitives a source-level ArrayBuf is built on. The
 # runtime __rue_alloc/__rue_free/__rue_realloc are already used by String, so
 # these cases also confirm the archive symbols resolve when referenced only
 # from user code.

--- a/crates/rue-runtime/src/heap.rs
+++ b/crates/rue-runtime/src/heap.rs
@@ -103,15 +103,27 @@ const fn is_power_of_two(n: u64) -> bool {
     n != 0 && (n & (n - 1)) == 0
 }
 
-/// Allocate a new arena of at least `min_size` bytes.
+/// Allocate a new arena with room for a `min_size` allocation at `align`.
+///
+/// The arena must hold the header plus the requested block *after* the block
+/// has been aligned. The allocation is placed at `align_up(header_size, align)`
+/// (see `alloc_from_arena`), so the arena must be at least
+/// `align_up(header_size, align) + min_size` bytes — the alignment padding
+/// between the header and the block counts against the arena size. Sizing it
+/// as merely `header_size + min_size` (ignoring the padding) would under-size
+/// the region and let the fresh-arena fast path hand out a block past the
+/// mmap'd mapping (RUE-344).
 ///
 /// Returns a pointer to the arena header, or null on failure.
-fn alloc_arena(min_size: usize) -> *mut ArenaHeader {
-    // Ensure we have room for the header plus the requested size
+fn alloc_arena(min_size: usize, align: usize) -> *mut ArenaHeader {
+    // Ensure we have room for the header, the alignment padding, and the block.
     let header_size = core::mem::size_of::<ArenaHeader>();
 
+    // Offset at which alloc_from_arena will place the block (header + padding).
+    let aligned_header = align_up(header_size, align);
+
     // Use checked_add to prevent overflow
-    let Some(total) = header_size.checked_add(min_size) else {
+    let Some(total) = aligned_header.checked_add(min_size) else {
         return ptr::null_mut();
     };
     let total_size = align_up(total, 4096); // Page-align
@@ -184,7 +196,7 @@ pub fn alloc(size: u64, align: u64) -> *mut u8 {
 
         if arena.is_null() {
             // No arena yet - try to create one
-            let new_arena = alloc_arena(size);
+            let new_arena = alloc_arena(size, align);
             if new_arena.is_null() {
                 return ptr::null_mut();
             }
@@ -263,7 +275,7 @@ pub fn alloc(size: u64, align: u64) -> *mut u8 {
             }
 
             // Allocation doesn't fit in current arena - create a new one
-            let new_arena = alloc_arena(size);
+            let new_arena = alloc_arena(size, align);
             if new_arena.is_null() {
                 return ptr::null_mut();
             }
@@ -309,13 +321,17 @@ fn alloc_from_arena(arena: *mut ArenaHeader, size: usize, align: usize) -> *mut 
     // - `arena` was just created by alloc_arena and is valid
     // - We just installed it via compare_exchange, so we have logical ownership
     // - No other thread can see this arena yet (we're the first to allocate)
-    // - The offset store and pointer arithmetic are within the arena bounds
-    //   (alloc_arena ensures the arena is large enough for header + size)
+    // - The offset store and pointer arithmetic are within the arena bounds:
+    //   alloc_arena was called with this same `align` and sized the region as
+    //   align_up(align_up(header_size, align) + size, 4096), so the block at
+    //   align_up(header_size, align) spanning `size` bytes fits with room to
+    //   spare. This is why no bounds check is needed on this fast path.
     unsafe {
         let header_size = core::mem::size_of::<ArenaHeader>();
         let aligned_offset = align_up(header_size, align);
-        // Note: overflow is impossible here because alloc_arena already ensured
-        // the arena is large enough for header_size + size (with alignment padding)
+        // Overflow is impossible: alloc_arena computed the same
+        // align_up(header_size, align) + size via checked_add and only returned
+        // non-null if it did not overflow, and the arena is at least that large.
         let new_offset = aligned_offset + size;
         (*arena).offset.store(new_offset, Ordering::Relaxed);
         (arena as *mut u8).add(aligned_offset)
@@ -661,6 +677,72 @@ mod tests {
         // Zero alignment should fail
         let result = realloc(ptr, 64, 128, 0);
         assert!(result.is_null());
+    }
+
+    #[test]
+    fn test_alloc_arena_sizes_in_alignment_padding() {
+        // RUE-344: alloc_arena must reserve room for the alignment padding
+        // between the header and the block, not just header_size + min_size.
+        // For align > 8, alloc_from_arena places the block at
+        // align_up(header_size, align) > header_size, so that padding counts.
+        let header_size = core::mem::size_of::<ArenaHeader>();
+        for &align in &[1usize, 8, 16, 32, 64, 256, 4096] {
+            let min_size = 65512;
+            let arena = alloc_arena(min_size, align);
+            assert!(!arena.is_null(), "alloc_arena failed for align={align}");
+
+            // SAFETY: arena is a valid, freshly-created arena we own.
+            unsafe {
+                let arena_size = (*arena).size;
+                let aligned_offset = align_up(header_size, align);
+
+                // The whole aligned block must fit inside the mapping.
+                assert!(
+                    aligned_offset + min_size <= arena_size,
+                    "arena under-sized for align={align}: offset {aligned_offset} + \
+                     size {min_size} = {} exceeds arena_size {arena_size}",
+                    aligned_offset + min_size
+                );
+
+                // Now actually place the allocation and prove its end is within
+                // the mmap'd region, then write the final byte (would corrupt
+                // adjacent memory / segfault under the RUE-344 bug).
+                let base = arena as usize;
+                let block = alloc_from_arena(arena, min_size, align);
+                assert!(!block.is_null());
+                assert_eq!(block as usize % align, 0, "bad alignment for align={align}");
+                let end = block as usize + min_size;
+                assert!(
+                    end <= base + arena_size,
+                    "block end {end} past mapping end {} for align={align}",
+                    base + arena_size
+                );
+
+                // Touch first and last byte of the block.
+                *block = 0xAA;
+                *block.add(min_size - 1) = 0xBB;
+                assert_eq!(*block, 0xAA);
+                assert_eq!(*block.add(min_size - 1), 0xBB);
+
+                platform::munmap(arena as *mut u8, arena_size);
+            }
+        }
+    }
+
+    #[test]
+    fn test_alloc_high_align_boundary() {
+        // End-to-end through the public alloc() with a >8 alignment and a size
+        // near the arena boundary. Under RUE-344 the returned block spilled
+        // past the mmap region; writing the last byte must be safe now.
+        let ptr = alloc(65512, 16);
+        assert!(!ptr.is_null());
+        assert_eq!(ptr as usize % 16, 0);
+        unsafe {
+            *ptr = 1;
+            *ptr.add(65512 - 1) = 2;
+            assert_eq!(*ptr, 1);
+            assert_eq!(*ptr.add(65512 - 1), 2);
+        }
     }
 
     #[test]

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -164,6 +164,29 @@ fn main() -> i32 {
 exit_code = 0
 
 [[case]]
+name = "dbg_output_format_pinned"
+spec = ["4.13:8", "4.13:8a"]
+description = "The exact textual form @dbg prints: decimal integers (signed with -), true/false, raw String bytes, each newline-terminated (RUE-299)"
+source = """
+fn main() -> i32 {
+    @dbg(42);
+    @dbg(-17);
+    @dbg(true);
+    @dbg(false);
+    @dbg("hi");
+    0
+}
+"""
+expected_stdout = """
+42
+-17
+true
+false
+hi
+"""
+exit_code = 0
+
+[[case]]
 name = "dbg_expression"
 spec = ["4.13:6", "4.13:7"]
 source = """

--- a/crates/rue-spec/cases/items/constants.toml
+++ b/crates/rue-spec/cases/items/constants.toml
@@ -260,3 +260,52 @@ fn main() -> i32 { 0 }
 """
 compile_fail = true
 error_contains = "cycle detected in constant initializers"
+
+# =============================================================================
+# Const-evaluation trapping (6.5:12) — RUE-299
+# =============================================================================
+
+[[case]]
+name = "const_overflow_is_compile_error"
+spec = ["6.5:12"]
+description = "Integer overflow while evaluating a const initializer is a compile-time error (E1200)"
+source = """
+const OVF: i32 = 2147483647 + 1;
+fn main() -> i32 { OVF }
+"""
+compile_fail = true
+error_contains = ["E1200", "overflow"]
+
+[[case]]
+name = "const_division_by_zero_is_compile_error"
+spec = ["6.5:12"]
+description = "Division by zero while evaluating a const initializer is a compile-time error (E1200)"
+source = """
+const DIV: i32 = 5 / 0;
+fn main() -> i32 { DIV }
+"""
+compile_fail = true
+error_contains = ["E1200", "division by zero"]
+
+[[case]]
+name = "const_remainder_by_zero_is_compile_error"
+spec = ["6.5:12"]
+description = "Remainder by zero while evaluating a const initializer is a compile-time error (E1200)"
+source = """
+const REM: i32 = 5 % 0;
+fn main() -> i32 { REM }
+"""
+compile_fail = true
+error_contains = ["E1200", "remainder by zero"]
+
+[[case]]
+name = "const_aggregate_initializer_rejected"
+spec = ["6.5:2"]
+description = "A struct literal is not compile-time evaluable, so an aggregate value const is rejected (E0434) (RUE-299)"
+source = """
+struct P { x: i32, y: i32 }
+const O: P = P { x: 1, y: 2 };
+fn main() -> i32 { O.x }
+"""
+compile_fail = true
+error_contains = ["E0434"]

--- a/crates/rue-spec/cases/items/impl-blocks.toml
+++ b/crates/rue-spec/cases/items/impl-blocks.toml
@@ -532,3 +532,25 @@ fn main() -> i32 {
     P::make(5).get()
 }
 """
+
+# =============================================================================
+# Fields and methods are separate name spaces (6.4:33) — RUE-299
+# =============================================================================
+
+[[case]]
+name = "field_and_method_same_name"
+spec = ["6.4:33"]
+description = "A field and a method may share a name; r.name is the field, r.name() the method (RUE-299)"
+source = """
+struct P {
+    x: i32,
+
+    fn x(self) -> i32 { 99 }
+}
+
+fn main() -> i32 {
+    let p = P { x: 5 };
+    p.x + p.x()
+}
+"""
+exit_code = 104

--- a/crates/rue-spec/cases/lexical/tokens.toml
+++ b/crates/rue-spec/cases/lexical/tokens.toml
@@ -544,3 +544,33 @@ fn main() -> i32 {
 }
 """
 exit_code = 1
+
+# =============================================================================
+# Source encoding (2.0:5, 2.0:6) — RUE-299
+# =============================================================================
+
+[[case]]
+name = "utf8_source_in_comment_and_string"
+spec = ["2.0:5", "2.0:6"]
+description = "Non-ASCII UTF-8 is accepted inside comments and string literals"
+source = """
+fn main() -> i32 {
+    // Non-ASCII text is fine in a comment: café résumé π
+    let s = "héllo, 世界";
+    @intCast(s.len())
+}
+"""
+exit_code = 14
+
+[[case]]
+name = "non_ascii_identifier_rejected"
+spec = ["2.0:6"]
+description = "A non-ASCII character outside a comment or string literal is a lexical error (E0001)"
+source = """
+fn main() -> i32 {
+    let café = 5;
+    café
+}
+"""
+compile_fail = true
+error_contains = ["E0001"]

--- a/crates/rue-spec/cases/statements/let.toml
+++ b/crates/rue-spec/cases/statements/let.toml
@@ -397,3 +397,65 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Parameter shadowing (5.1:14) — RUE-299
+# =============================================================================
+
+[[case]]
+name = "let_shadows_parameter"
+spec = ["5.1:14"]
+description = "A let binding may shadow a parameter; the initializer reads the parameter (RUE-299)"
+source = """
+fn f(x: i32) -> i32 {
+    let x = x + 100;
+    x
+}
+fn main() -> i32 { f(5) }
+"""
+exit_code = 105
+
+# =============================================================================
+# Wildcard bindings (5.1:16) — RUE-299
+# =============================================================================
+
+[[case]]
+name = "wildcard_let_discards_value"
+spec = ["5.1:16"]
+description = "let _ evaluates and discards its initializer, introducing no binding (RUE-299)"
+source = """
+fn main() -> i32 {
+    let _ = 5 + 5;
+    let _ = 99;
+    3
+}
+"""
+exit_code = 3
+
+[[case]]
+name = "wildcard_let_moves_affine_value"
+spec = ["5.1:16"]
+description = "let _ = affine_value moves out of the place, which is then no longer usable (RUE-299)"
+source = """
+fn main() -> i32 {
+    let s = "hello";
+    let _ = s;
+    @intCast(s.len())
+}
+"""
+compile_fail = true
+error_contains = ["E0205"]
+
+[[case]]
+name = "wildcard_let_does_not_consume_linear"
+spec = ["5.1:16"]
+description = "Discarding a linear value with let _ is a compile-time error; it is not consumed (RUE-299)"
+source = """
+linear struct R { fd: i32 }
+fn main() -> i32 {
+    let _ = R { fd: 3 };
+    0
+}
+"""
+compile_fail = true
+error_contains = ["E0478"]

--- a/crates/rue-spec/cases/types/never.toml
+++ b/crates/rue-spec/cases/types/never.toml
@@ -157,6 +157,48 @@ fn main() -> i32 {
 """
 exit_code = 20
 
+[[case]]
+name = "block_tail_diverges_has_never_type"
+spec = ["3.4:6a"]
+description = "A block whose tail expression diverges has type ! and coerces (RUE-299)"
+source = """
+fn test(x: i32) -> i32 {
+    let y = { return 100 };
+    y * 2
+}
+fn main() -> i32 { test(3) }
+"""
+exit_code = 100
+
+[[case]]
+name = "block_inner_statement_diverges_has_never_type"
+spec = ["3.4:6a"]
+description = "A block with a diverging statement (making its end unreachable) has type ! (RUE-299)"
+source = """
+fn test() -> i32 {
+    let y = {
+        return 7;
+        0
+    };
+    y * 2
+}
+fn main() -> i32 { test() }
+"""
+exit_code = 7
+
+[[case]]
+name = "infinite_loop_value_coerces"
+spec = ["3.4:6a"]
+description = "An infinite loop with no reachable break has type ! and coerces into a binding (RUE-299)"
+source = """
+fn pick(x: i32) -> i32 {
+    let y: i32 = if x > 0 { 42 } else { loop { } };
+    y
+}
+fn main() -> i32 { pick(1) }
+"""
+exit_code = 42
+
 # =============================================================================
 # Diverging Functions (3.4:8)
 # =============================================================================

--- a/docs/spec/src/02-lexical-structure/_index.md
+++ b/docs/spec/src/02-lexical-structure/_index.md
@@ -33,3 +33,31 @@ fn main() -> i32 {
     if true && false { 0 } else { 1 }  // && is a single logical AND token
 }
 ```
+
+## Source Encoding
+
+{{ rule(id="2.0:5", cat="normative") }}
+
+Source text is encoded in UTF-8. The compiler reads each source file as a
+sequence of Unicode scalar values decoded from its UTF-8 bytes. A file whose
+bytes are not valid UTF-8 is rejected before lexing begins.
+
+{{ rule(id="2.0:6", cat="legality-rule") }}
+
+A Unicode scalar value outside the ASCII range (`U+0080` and above) **MAY**
+appear only within a comment or a string literal. Everywhere else — in
+identifiers, keywords, numeric literals, operators, and delimiters — the lexer
+recognizes only ASCII characters, and a non-ASCII character encountered in such
+a position is a lexical error (E0001). Identifiers are therefore limited to
+ASCII letters, digits, and underscores (2.1), while the *contents* of a comment
+or string literal may be any UTF-8 text.
+
+{{ rule(id="2.0:7", cat="example") }}
+
+```rue
+fn main() -> i32 {
+    // Non-ASCII text is fine in a comment: café résumé π
+    let s = "héllo, 世界";   // and inside a string literal
+    0
+}
+```

--- a/docs/spec/src/03-types/04-never-type.md
+++ b/docs/spec/src/03-types/04-never-type.md
@@ -58,6 +58,30 @@ fn diverges(x: i32) -> i32 {
 fn main() -> i32 { diverges(5) }
 ```
 
+{{ rule(id="3.4:6a", cat="normative") }}
+
+`!` propagates through any composite expression that control cannot fall out
+of, not only `if` and `match`. A block expression has type `!` when control
+cannot reach its end: either its tail expression has type `!`, or a statement
+within it diverges — for example an expression statement whose expression has
+type `!` — which makes the remainder of the block, and thus the block's end,
+unreachable. A `loop` expression with no reachable `break` likewise has type
+`!` (3.4:2). By the coercion of 3.4:3, such an expression may appear wherever a
+value of any type is expected.
+
+{{ rule(id="3.4:6b") }}
+
+```rue
+fn test(x: i32) -> i32 {
+    // The block's tail expression is `return`, so the block has type !,
+    // which coerces to the i32 the `let` expects.
+    let y = { return 100 };
+    y * 2
+}
+
+fn main() -> i32 { test(3) }  // exit code 100
+```
+
 ## Diverging Functions
 
 {{ rule(id="3.4:8", cat="normative") }}

--- a/docs/spec/src/04-expressions/13-intrinsics.md
+++ b/docs/spec/src/04-expressions/13-intrinsics.md
@@ -122,6 +122,14 @@ not occurred.
 
 `@dbg` prints the value followed by a newline character.
 
+{{ rule(id="4.13:8a", cat="normative") }}
+
+The textual form `@dbg` prints for its argument is determined by the argument's
+type: an integer is printed in base 10, with a leading `-` when a signed integer
+is negative and no sign otherwise; a boolean is printed as `true` or `false`; a
+`String` is printed as its exact bytes, byte-for-byte, with no quoting or
+escaping (mirroring `print`, 3.7). The newline of 4.13:8 follows this text.
+
 {{ rule(id="4.13:9", cat="normative") }}
 
 The return type of `@dbg` is `()`.

--- a/docs/spec/src/05-statements/01-let-statements.md
+++ b/docs/spec/src/05-statements/01-let-statements.md
@@ -13,7 +13,8 @@ A let statement introduces a new variable binding.
 {{ rule(id="5.1:2", cat="normative") }}
 
 ```ebnf
-let_stmt = "let" [ "mut" ] IDENT [ ":" type ] "=" expression ";" ;
+let_stmt = "let" [ "mut" ] let_pattern [ ":" type ] "=" expression ";" ;
+let_pattern = IDENT | "_" ;
 ```
 
 ## Immutable Bindings
@@ -80,7 +81,7 @@ When shadowing, the new variable **MAY** have a different type.
 
 {{ rule(id="5.1:12", cat="normative") }}
 
-The scope of a binding introduced by a let statement begins after the complete let statement, including its initializer. The initializer expression is evaluated before the new binding is introduced, so references to a shadowed name within the initializer resolve to the previous binding.
+The scope of a binding introduced by a let statement begins after the complete let statement, including its initializer. The initializer expression is evaluated before the new binding is introduced, so references to a shadowed name within the initializer resolve to the previous binding. This is exactly the core calculus's `let x = e1 ; e2` form (`docs/formal/01-core-calculus.md` §6.7, rule `(D-Let)`): the initializer `e1` is reduced to a value before the cell for `x` is bound in the environment, so `x` is not in scope while `e1` is evaluated.
 
 {{ rule(id="5.1:13") }}
 
@@ -89,5 +90,47 @@ fn main() -> i32 {
     let x = 10;
     let x = x + 5;  // shadows previous x, initializer uses old x
     x  // 15
+}
+```
+
+{{ rule(id="5.1:14", cat="normative") }}
+
+A let binding **MAY** shadow a function parameter of the same name, following
+the same rules as shadowing a previous let binding (5.1:10–5.1:12): the
+initializer is evaluated before the new binding is introduced, so a reference to
+the name in the initializer resolves to the parameter, and the new binding **MAY**
+have a different type.
+
+{{ rule(id="5.1:15") }}
+
+```rue
+fn f(x: i32) -> i32 {
+    let x = x + 100;  // shadows the parameter; initializer reads the parameter
+    x
+}
+
+fn main() -> i32 { f(5) }  // 105
+```
+
+## Wildcard Bindings
+
+{{ rule(id="5.1:16", cat="normative") }}
+
+The wildcard `_` **MAY** appear in place of the binding name. `let _ = e;`
+evaluates `e` and discards its value exactly as an expression statement would
+(5.3): it introduces no binding, and `_` **MUST NOT** be referred to as a value.
+Because `_` discards rather than consumes, a discarded value of a type that
+carries a linear value (3.8) is not thereby consumed; discarding a linear value
+this way is a compile-time error (E0478). A discarded value of a Copy or affine
+type is dropped in place, and an affine value is moved out of any place named in
+`e` just as by-value use elsewhere.
+
+{{ rule(id="5.1:17") }}
+
+```rue
+fn main() -> i32 {
+    let _ = 5 + 5;   // evaluated, then discarded; no binding introduced
+    let _ = 99;
+    3
 }
 ```

--- a/docs/spec/src/05-statements/02-assignment.md
+++ b/docs/spec/src/05-statements/02-assignment.md
@@ -8,7 +8,7 @@ template = "spec/page.html"
 
 {{ rule(id="5.2:1", cat="normative") }}
 
-An assignment statement assigns a new value to a mutable variable.
+An assignment statement evaluates its right-hand side to a value and stores that value into the *place* named by its target (the target is a place, not merely a variable; see 5.2:2). If the target place currently holds a live (owned) value, that value is dropped before the new value is stored (overwrite-drop); storing into a moved-out place reinitializes it. The assignment itself evaluates to unit. These ownership effects are those of the core calculus's `assign p = e` form (`docs/formal/01-core-calculus.md` §5.2, §6.8) and of 3.8:55–56.
 
 {{ rule(id="5.2:2", cat="normative") }}
 
@@ -33,7 +33,10 @@ evaluated first to produce the value to be stored. The assignment target names
 a *place*; any index subexpressions appearing in the target (the `[e]` in an
 `arr[e]` target) are evaluated after the right-hand side, in source order
 (left-to-right). Once the place has been resolved, the produced value is
-written into it.
+written into it. This matches the core calculus's evaluation order: the
+assignment context `assign p = E` reduces the right-hand side `E` first, and
+the target place's index subexpressions are reduced as part of resolving the
+place for the store (`docs/formal/01-core-calculus.md` §6.2, §6.8).
 
 {{ rule(id="5.2:15") }}
 

--- a/docs/spec/src/05-statements/03-expression-statements.md
+++ b/docs/spec/src/05-statements/03-expression-statements.md
@@ -18,7 +18,7 @@ expr_stmt = expression ";" ;
 
 {{ rule(id="5.3:3", cat="normative") }}
 
-The value of the expression is discarded. The type of an expression statement is `()`.
+The expression is evaluated and its value is discarded; the expression statement itself has type `()`. This is the core calculus's discarding sequence `e1 ; e2` (`docs/formal/01-core-calculus.md` §5.3, §6.7, rule `(D-Seq)`): `e1` is reduced to a value, that value is dropped, and control passes to the following statement `e2` — whose value is the value of the enclosing block.
 
 {{ rule(id="5.3:4") }}
 

--- a/docs/spec/src/05-statements/_index.md
+++ b/docs/spec/src/05-statements/_index.md
@@ -17,4 +17,4 @@ This chapter describes statements in Rue.
 
 {{ rule(id="5.0:1") }}
 
-A statement is a syntactic construct that performs an action but does not produce a value. Statements have type `()`.
+A statement is a construct evaluated for its effect rather than for a value delivered to its context; every statement has type `()` (unit). The three statement forms — `let` bindings, assignments, and expression statements — elaborate in the core calculus (`docs/formal/01-core-calculus.md`) to a binding sequence `let x = e1 ; e2`, an `assign p = e`, and a discarding sequence `e1 ; e2` respectively, and none of these delivers a value to the block that contains it (core §6.7, §6.8).

--- a/docs/spec/src/06-items/02-structs.md
+++ b/docs/spec/src/06-items/02-structs.md
@@ -33,6 +33,14 @@ struct Point {
 }
 ```
 
+{{ rule(id="6.2:11", cat="informative") }}
+
+A struct definition **MAY** be prefixed with the `linear` keyword, making it a
+*linear* (must-consume) type: a value of a `linear struct` type must be
+explicitly consumed and cannot be implicitly dropped. The `linear` modifier and
+its full semantics — including infectious linearity through fields and arrays —
+are specified with move semantics (3.8), not repeated here.
+
 ## Struct Instantiation
 
 {{ rule(id="6.2:5", cat="legality-rule") }}

--- a/docs/spec/src/06-items/04-impl-blocks.md
+++ b/docs/spec/src/06-items/04-impl-blocks.md
@@ -193,6 +193,33 @@ fn main() -> i32 {
 }
 ```
 
+## Fields and Methods Are Separate Name Spaces
+
+{{ rule(id="6.4:33", cat="normative") }}
+
+Field names (6.2:3) and method names (6.4:16) occupy separate name spaces
+within a struct: a struct **MAY** declare a field and a method with the same
+name. The two are disambiguated by the form of the access. A postfix access
+without an argument list, `receiver.name`, is a field access (4.12) and denotes
+the field. An access with an argument list, `receiver.name(args)`, is a method
+call (6.4:6) and invokes the method. The two forms never conflict, so the shared
+name is unambiguous at every use site.
+
+{{ rule(id="6.4:34", cat="example") }}
+
+```rue
+struct P {
+    x: i32,
+
+    fn x(self) -> i32 { 99 }
+}
+
+fn main() -> i32 {
+    let p = P { x: 5 };
+    p.x + p.x()   // 5 (field) + 99 (method) = 104
+}
+```
+
 ## Error Conditions
 
 {{ rule(id="6.4:20", cat="legality-rule") }}

--- a/docs/spec/src/06-items/05-constants.md
+++ b/docs/spec/src/06-items/05-constants.md
@@ -75,6 +75,33 @@ const SMALL: u8 = 200;           // u8: annotation adopted, value fits
 // const NONE = 5;               // error: missing type annotation (E0475)
 ```
 
+{{ rule(id="6.5:12", cat="legality-rule") }}
+
+If evaluating a constant initializer would trap — an arithmetic operation that
+overflows its result type, or a division or remainder by zero — the constant is
+rejected at compile time (E1200). The trap is reported as a compile-time error
+rather than deferring to a runtime panic, because the initializer is evaluated
+during compilation (6.5:2). This applies whether the trapping operation is the
+whole initializer or a sub-expression of it.
+
+{{ rule(id="6.5:13", cat="example") }}
+
+```rue
+// const OVF: i32 = 2147483647 + 1;  // error: integer overflow (E1200)
+// const DIV: i32 = 5 / 0;           // error: division by zero (E1200)
+// const REM: i32 = 5 % 0;           // error: remainder by zero (E1200)
+const OK: i32 = 2147483647;          // in range: fine
+```
+
+{{ rule(id="6.5:14", cat="informative") }}
+
+In the current revision the compile-time-evaluable expression forms (6.5:2)
+produce only scalar values — integers and `bool` — so a value constant's type
+is in practice a scalar type. There is no const-evaluable form that yields a
+struct or an array: an aggregate initializer such as a struct literal or an
+array literal is not compile-time evaluable and is rejected (E0434). Constants
+of aggregate type may be revisited in a future revision.
+
 ## Evaluation Order
 
 {{ rule(id="6.5:7", cat="normative") }}

--- a/docs/spec/src/06-items/_index.md
+++ b/docs/spec/src/06-items/_index.md
@@ -21,6 +21,23 @@ This chapter describes items in Rue.
 
 Items are top-level definitions in a program. Unlike statements, items are visible throughout the module.
 
+{{ rule(id="6.0:1a", cat="informative") }}
+
+The item kinds are:
+
+- **Functions** (`fn`, 6.1), including the program entry point `main`.
+- **Structs** (`struct`, 6.2), which may declare methods and associated
+  functions in the struct body (6.4).
+- **Enums** (`enum`, 6.3).
+- **Constants** (`const`, 6.5).
+- **Top-level destructors** (`drop fn`, 3.9), which are declared at the top
+  level rather than inside any enclosing block.
+
+Rue has no separate `impl` block: methods and associated functions are written
+inside the struct body (6.4), and a user-defined destructor for a named struct
+is a top-level `drop fn` item (3.9). There is no item form that groups
+implementations under a type the way an `impl` block does in other languages.
+
 ## Type Name Uniqueness
 
 {{ rule(id="6.0:2", cat="legality-rule") }}

--- a/docs/spec/src/09-unchecked-code/02-intrinsics.md
+++ b/docs/spec/src/09-unchecked-code/02-intrinsics.md
@@ -91,7 +91,7 @@ fn main() -> i32 {
 The `@alloc`, `@free`, and `@realloc` intrinsics provide raw, unchecked access
 to the heap. Like the raw-pointer intrinsics they may only appear inside a
 `checked` block (§9.1). They are the primitives on which safe, owned
-collections (for example a source-level `Vec`) are built: the unsafety is
+collections (for example a source-level `ArrayBuf`) are built: the unsafety is
 confined to the collection's internals behind a checked API.
 
 {{ rule(id="9.2:10", cat="dynamic-semantics") }}


### PR DESCRIPTION
Cycle 108:
- **RUE-344**: arena allocator ignored alignment padding — `alloc(65512, 16)` returned a block 8 bytes past the mmap region (align > 8 fast path, no bounds check). Threaded `align` into `alloc_arena`; 2 boundary tests. Public `__rue_alloc` ABI (not codegen-reachable today).
- **RUE-323**: the Vec→ArrayBuf rename already landed; cleaned up 5 stragglers.
- **RUE-299**: filled the remaining documenting-existing-behavior spec gaps (16 cases, all execution-verified); 2 design-gated remainders tracked elsewhere.
- **RUE-202** (statements chapter): retired folk-terms in ch5 against the formal core (value-denotation, assignment-as-place-store, RHS-first eval), no normative change.

clippy clean; test.sh Pass 24, 100% traceability (705/705), oracle 0.

Fixes RUE-344
Fixes RUE-323
Fixes RUE-299

Generated with Claude Code