### PR TITLE
Slice runtime: borrow-array read slices via desugaring to a {ptr,len} struct (RUE-322)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -280,6 +280,23 @@ impl<'a> ConstraintGenerator<'a> {
         }
     }
 
+    /// Is `ty` the synthetic slice struct `[T]` (ADR-0043, RUE-322)? A slice
+    /// parameter accepts an array argument by coercion (`sum(borrow a)`), so the
+    /// constraint generator must NOT impose strict `arg == param` equality when
+    /// the parameter is a slice; the real element-compatibility check and the
+    /// fat-pointer materialization happen in semantic analysis.
+    fn is_slice_struct_type(&self, ty: InferType) -> bool {
+        if let InferType::Concrete(t) = ty
+            && let Some(id) = t.as_struct()
+        {
+            let name = &self.type_pool.struct_def(id).name;
+            return name.starts_with('[')
+                && name.ends_with(']')
+                && crate::types::parse_array_type_syntax(name).is_none();
+        }
+        false
+    }
+
     /// Provide file-level constant types (name -> declared type) for `VarRef`
     /// resolution. See the `const_types` field for details (RUE-142).
     pub fn with_const_types(mut self, const_types: &'a HashMap<Spur, Type>) -> Self {
@@ -900,6 +917,11 @@ impl<'a> ConstraintGenerator<'a> {
                             } else {
                                 declared.clone()
                             };
+                            // Slice parameters coerce from an array argument
+                            // (ADR-0043, RUE-322); see the non-generic path.
+                            if self.is_slice_struct_type(expected.clone()) {
+                                continue;
+                            }
                             self.add_constraint(Constraint::equal(
                                 arg_info.ty.clone(),
                                 expected,
@@ -966,6 +988,12 @@ impl<'a> ConstraintGenerator<'a> {
                         // Generate constraints for each argument
                         for (arg, param_ty) in args.iter().zip(func.param_types.iter()) {
                             let arg_info = self.generate(arg.value, ctx);
+                            // Slice parameters coerce from an array argument
+                            // (`borrow arr`); skip strict equality and let sema
+                            // materialize the fat pointer (ADR-0043, RUE-322).
+                            if self.is_slice_struct_type(param_ty.clone()) {
+                                continue;
+                            }
                             self.add_constraint(Constraint::equal(
                                 arg_info.ty,
                                 param_ty.clone(),

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -21,6 +21,26 @@ impl<'a> Sema<'a> {
         let receiver_var = self.extract_root_variable(receiver);
         let method_name_str = self.interner.resolve(&method).to_string();
 
+        // Slice methods (ADR-0043, RUE-322): `s.len()` reads the fat pointer's
+        // runtime `len` word. Detected from the receiver's inferred type so it
+        // is intercepted before user/builtin method resolution.
+        if ctx
+            .resolved_types
+            .get(&receiver)
+            .copied()
+            .is_some_and(|ty| self.slice_element_type(ty).is_some())
+        {
+            return self.analyze_slice_method(
+                air,
+                receiver,
+                receiver_var,
+                &method_name_str,
+                args.len(),
+                span,
+                ctx,
+            );
+        }
+
         // Check if this is a builtin (String) mutation method. Gate the
         // name-only match on the receiver's resolved type actually being the
         // builtin: a user struct method that merely shares a name with a String

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -307,7 +307,16 @@ impl<'a> Sema<'a> {
             // Inout and Borrow parameters are passed by reference.
             // Comptime parameters are VALUE params (like `comptime n: i32`), passed by value.
             // Normal parameters are passed by value.
-            let is_by_ref = *mode == RirParamMode::Inout || *mode == RirParamMode::Borrow;
+            //
+            // Exception (ADR-0043, RUE-322): a slice parameter `borrow s: [T]`
+            // is itself a two-word fat pointer `{ptr, len}`. The `borrow`/`inout`
+            // keyword marks shared-vs-exclusive access, not an extra level of
+            // indirection, so the slice value is passed BY VALUE through the
+            // existing multi-slot aggregate ABI (2 slots) rather than as a
+            // pointer-to-slice. The call site materializes the fat pointer.
+            let is_slice = self.slice_element_type(*ptype).is_some();
+            let is_by_ref =
+                (*mode == RirParamMode::Inout || *mode == RirParamMode::Borrow) && !is_slice;
             let slot_count = if is_by_ref {
                 // By-ref parameters are always 1 slot (pointer)
                 1

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -580,4 +580,178 @@ impl<'a> Sema<'a> {
         }
         Ok(air_args)
     }
+
+    /// Analyze call arguments, materializing a fat-pointer slice value for any
+    /// argument whose parameter is a slice type (ADR-0043, RUE-322).
+    ///
+    /// `borrow arr` (where `arr: [T; N]`) passed to a `borrow s: [T]` parameter
+    /// is coerced to a by-value slice `{ptr: @raw(arr[0]), len: N}`, which flows
+    /// through the existing by-value aggregate ABI (the parameter is by-value —
+    /// see [`crate::sema::Sema`] parameter setup). Non-slice parameters use the
+    /// ordinary [`Self::analyze_call_args`] argument path unchanged.
+    pub(crate) fn analyze_call_args_coerced(
+        &mut self,
+        air: &mut Air,
+        args: &[RirCallArg],
+        param_types: &[Type],
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<Vec<AirCallArg>> {
+        let mut air_args = Vec::with_capacity(args.len());
+        for (i, arg) in args.iter().enumerate() {
+            let is_slice_param = param_types
+                .get(i)
+                .is_some_and(|pt| self.slice_element_type(*pt).is_some());
+            if is_slice_param {
+                let slice_ty = param_types[i];
+                let value = self.coerce_borrow_array_to_slice(air, arg, slice_ty, ctx)?;
+                air_args.push(AirCallArg {
+                    value,
+                    // The fat pointer is passed BY VALUE (multi-slot aggregate).
+                    mode: AirArgMode::Normal,
+                });
+                continue;
+            }
+
+            let byref_root = if arg.is_inout() || arg.is_borrow() {
+                let root = require_byref_place_arg(self.rir, arg)?;
+                if arg.is_inout()
+                    && ctx
+                        .params
+                        .iter()
+                        .any(|p| p.name == root && p.mode == RirParamMode::Borrow)
+                {
+                    return Err(CompileError::new(
+                        ErrorKind::MutateBorrowedValue {
+                            variable: self.interner.resolve(&root).to_string(),
+                        },
+                        self.rir.get(arg.value).span,
+                    ));
+                }
+                Some(root)
+            } else {
+                None
+            };
+            let prev_byref_root = std::mem::replace(&mut ctx.byref_arg_root, byref_root);
+            let arg_result = self.analyze_inst(air, arg.value, ctx);
+            ctx.byref_arg_root = prev_byref_root;
+            let arg_result = arg_result?;
+            air_args.push(AirCallArg {
+                value: arg_result.air_ref,
+                mode: Self::convert_arg_mode(arg.mode),
+            });
+        }
+        Ok(air_args)
+    }
+
+    /// Build a by-value slice `{ptr, len}` value from a `borrow arr` argument
+    /// (ADR-0043, RUE-322). The array must be a place whose element type matches
+    /// the slice's; the pointer word is `@raw(arr[0])` and the length word is
+    /// the array's compile-time length `N`.
+    fn coerce_borrow_array_to_slice(
+        &mut self,
+        air: &mut Air,
+        arg: &RirCallArg,
+        slice_ty: Type,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AirRef> {
+        use crate::inst::{AirInstData, AirProjection};
+
+        let span = self.rir.get(arg.value).span;
+        let slice_struct_id = slice_ty
+            .as_struct()
+            .expect("slice type is a synthetic struct");
+        let slice_elem = self
+            .slice_element_type(slice_ty)
+            .expect("slice type has an element");
+        let ptr_ty = self.type_pool.struct_def(slice_struct_id).fields[0].ty;
+
+        // A slice argument must be `borrow arr` (the shared form; `inout` slices
+        // are a later phase). The array is borrowed (address taken), not moved.
+        if !arg.is_borrow() {
+            return Err(CompileError::new(ErrorKind::BorrowKeywordMissing, span));
+        }
+        let root = require_byref_place_arg(self.rir, arg)?;
+        let prev_byref_root = ctx.byref_arg_root.replace(root);
+        let trace = self.try_trace_place(arg.value, air, ctx);
+        ctx.byref_arg_root = prev_byref_root;
+        let trace = trace?.ok_or_else(|| CompileError::new(ErrorKind::BorrowNonLvalue, span))?;
+
+        let arr_ty = trace.result_type();
+
+        // Forwarding an existing slice (`inner(borrow s)` where `s: [T]`): the
+        // fat pointer is already built, so read it by value (a slice is `@copy`)
+        // and pass it through — no re-materialization.
+        if arr_ty == slice_ty {
+            let projs: Vec<AirProjection> = trace.projections.iter().map(|p| p.proj).collect();
+            let place_ref = air.make_place(trace.base, projs);
+            let val = air.add_inst(AirInst {
+                data: AirInstData::PlaceRead { place: place_ref },
+                ty: slice_ty,
+                span,
+            });
+            return Ok(val);
+        }
+
+        let (arr_elem, arr_len) = match arr_ty.as_array() {
+            Some(id) => self.type_pool.array_def(id),
+            None => {
+                // Only whole-array borrow-to-slice is supported in Phase 1.
+                return Err(self.type_mismatch_error(slice_ty, arr_ty, span));
+            }
+        };
+        if arr_elem != slice_elem {
+            return Err(self.type_mismatch_error(slice_ty, arr_ty, span));
+        }
+
+        // ptr word = @raw(arr[0]) : ptr const T. Build a place read of element 0
+        // and take its address, exactly as source `@raw(arr[0])` would.
+        let zero_ref = air.add_inst(AirInst {
+            data: AirInstData::Const(0),
+            ty: Type::U64,
+            span,
+        });
+        let mut projs: Vec<AirProjection> = trace.projections.iter().map(|p| p.proj).collect();
+        projs.push(AirProjection::Index {
+            array_type: arr_ty,
+            index: zero_ref,
+        });
+        let place_ref = air.make_place(trace.base, projs);
+        let elem0_read = air.add_inst(AirInst {
+            data: AirInstData::PlaceRead { place: place_ref },
+            ty: arr_elem,
+            span,
+        });
+        let raw_args = air.add_extra(&[elem0_read.as_u32()]);
+        let ptr_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name: self.known.raw,
+                args_start: raw_args,
+                args_len: 1,
+            },
+            ty: ptr_ty,
+            span,
+        });
+
+        // len word = N (compile-time array length).
+        let len_ref = air.add_inst(AirInst {
+            data: AirInstData::Const(arr_len),
+            ty: Type::U64,
+            span,
+        });
+
+        // Materialize the fat pointer `{ptr, len}` struct value.
+        let fields = air.add_extra(&[ptr_ref.as_u32(), len_ref.as_u32()]);
+        let source_order = air.add_extra(&[0u32, 1u32]);
+        let slice_val = air.add_inst(AirInst {
+            data: AirInstData::StructInit {
+                struct_id: slice_struct_id,
+                fields_start: fields,
+                fields_len: 2,
+                source_order_start: source_order,
+            },
+            ty: slice_ty,
+            span,
+        });
+        Ok(slice_val)
+    }
 }

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -4253,6 +4253,23 @@ impl<'a> Sema<'a> {
             );
         }
 
+        // Slice read-indexing `s[i]` (ADR-0043, RUE-322): the base is the
+        // synthetic 2-word fat-pointer struct `{ptr, len}`. Lower to a
+        // runtime-bounds-checked pointer load through the fat pointer's `ptr`
+        // word — no array place is involved.
+        if let Some(elem_ty) = self.slice_element_type(base_type) {
+            return self.analyze_slice_index_get(
+                air,
+                base_result,
+                base_root,
+                base_move_state_before,
+                index,
+                elem_ty,
+                span,
+                ctx,
+            );
+        }
+
         let index_result = self.analyze_inst(air, index, ctx)?;
 
         // Verify base is an array
@@ -4421,6 +4438,198 @@ impl<'a> Sema<'a> {
             span,
         });
         Ok(AnalysisResult::new(call_ref, Type::U8))
+    }
+
+    /// Analyze a slice read-index `s[i]` (ADR-0043, RUE-322).
+    ///
+    /// The slice `base_result` is the synthetic 2-word fat-pointer struct
+    /// `{ptr: ptr const T, len: u64}`. The read desugars to, in order:
+    ///
+    /// 1. a runtime bounds check `@assert(i < len)` — traps with exit 101 (the
+    ///    same discipline as array indexing) when the index is out of range;
+    /// 2. `@ptr_read(@ptr_offset(ptr, i))` — `@ptr_offset` scales by
+    ///    `size_of(T)`, so this reads the i-th element.
+    ///
+    /// Everything is built from existing intrinsics, so no new codegen (or
+    /// backend-specific work) is required; the fat pointer flows through the
+    /// same struct/field/pointer paths the manual `{ptr,len}` form already uses.
+    #[allow(clippy::too_many_arguments)]
+    fn analyze_slice_index_get(
+        &mut self,
+        air: &mut Air,
+        base_result: AnalysisResult,
+        base_root: Option<Spur>,
+        base_move_state_before: Option<VariableMoveState>,
+        index: InstRef,
+        elem_ty: Type,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        // Indexing reads (never consumes) the slice receiver; undo any move the
+        // receiver analysis recorded (mirrors the String index / ByRef paths).
+        if let Some(var) = base_root {
+            match base_move_state_before {
+                Some(state) => {
+                    ctx.moved_vars.insert(var, state);
+                }
+                None => {
+                    ctx.moved_vars.remove(&var);
+                }
+            }
+        }
+        air.cancel_move_marker(base_result.air_ref);
+
+        let slice_struct_id = base_result
+            .ty
+            .as_struct()
+            .expect("slice receiver is a synthetic struct");
+        let ptr_ty = self.type_pool.struct_def(slice_struct_id).fields[0].ty;
+
+        // The index is an ordinary rvalue; require an integer (spec 7.1:7).
+        let index_result = self.analyze_inst(air, index, ctx)?;
+        if !index_result.ty.is_integer() && !index_result.ty.is_error() {
+            return Err(CompileError::new(
+                ErrorKind::TypeMismatch {
+                    expected: "an integer".to_string(),
+                    found: index_result.ty.safe_name_with_pool(Some(&self.type_pool)),
+                },
+                self.rir.get(index).span,
+            ));
+        }
+
+        // Read the fat pointer's two words from the slice value.
+        let ptr_ref = air.add_inst(AirInst {
+            data: AirInstData::FieldGet {
+                base: base_result.air_ref,
+                struct_id: slice_struct_id,
+                field_index: 0,
+            },
+            ty: ptr_ty,
+            span,
+        });
+        let len_ref = air.add_inst(AirInst {
+            data: AirInstData::FieldGet {
+                base: base_result.air_ref,
+                struct_id: slice_struct_id,
+                field_index: 1,
+            },
+            ty: Type::U64,
+            span,
+        });
+
+        // Runtime bounds check: `@assert(index < len)` traps (exit 101) when the
+        // index is out of range.
+        let cond_ref = air.add_inst(AirInst {
+            data: AirInstData::Lt(index_result.air_ref, len_ref),
+            ty: Type::BOOL,
+            span,
+        });
+        let assert_args = air.add_extra(&[cond_ref.as_u32()]);
+        let assert_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name: self.known.assert,
+                args_start: assert_args,
+                args_len: 1,
+            },
+            ty: Type::UNIT,
+            span,
+        });
+
+        // element = @ptr_read(@ptr_offset(ptr, index)).
+        let off_args = air.add_extra(&[ptr_ref.as_u32(), index_result.air_ref.as_u32()]);
+        let off_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name: self.known.ptr_offset,
+                args_start: off_args,
+                args_len: 2,
+            },
+            ty: ptr_ty,
+            span,
+        });
+        let read_args = air.add_extra(&[off_ref.as_u32()]);
+        let elem_ref = air.add_inst(AirInst {
+            data: AirInstData::Intrinsic {
+                name: self.known.ptr_read,
+                args_start: read_args,
+                args_len: 1,
+            },
+            ty: elem_ty,
+            span,
+        });
+
+        // Demand-driven lowering only pulls the returned value's dependencies,
+        // so the bounds-check assertion (a pure side effect) must be an explicit
+        // statement of the block that yields the element.
+        let stmts = air.add_extra(&[assert_ref.as_u32()]);
+        let block_ref = air.add_inst(AirInst {
+            data: AirInstData::Block {
+                stmts_start: stmts,
+                stmts_len: 1,
+                value: elem_ref,
+            },
+            ty: elem_ty,
+            span,
+        });
+        Ok(AnalysisResult::new(block_ref, elem_ty))
+    }
+
+    /// Analyze a slice method call (ADR-0043, RUE-322). Only `.len()` is
+    /// supported today: it reads the fat pointer's `len` word (runtime length).
+    pub(crate) fn analyze_slice_method(
+        &mut self,
+        air: &mut Air,
+        receiver: InstRef,
+        receiver_var: Option<Spur>,
+        method_name: &str,
+        arg_count: usize,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        // The receiver is read, not consumed: analyze it as a borrow and undo
+        // the move the analysis records.
+        let move_state_before = receiver_var.and_then(|v| ctx.moved_vars.get(&v).cloned());
+        let prev_byref_root = std::mem::replace(&mut ctx.byref_arg_root, receiver_var);
+        let recv_result = self.analyze_inst(air, receiver, ctx);
+        ctx.byref_arg_root = prev_byref_root;
+        let recv_result = recv_result?;
+        if let Some(var) = receiver_var {
+            match move_state_before {
+                Some(state) => {
+                    ctx.moved_vars.insert(var, state);
+                }
+                None => {
+                    ctx.moved_vars.remove(&var);
+                }
+            }
+        }
+        air.cancel_move_marker(recv_result.air_ref);
+
+        let slice_struct_id = recv_result
+            .ty
+            .as_struct()
+            .expect("slice receiver is a synthetic struct");
+
+        if method_name == "len" && arg_count == 0 {
+            // Read the `len` word (field 1) from the fat pointer.
+            let len_ref = air.add_inst(AirInst {
+                data: AirInstData::FieldGet {
+                    base: recv_result.air_ref,
+                    struct_id: slice_struct_id,
+                    field_index: 1,
+                },
+                ty: Type::U64,
+                span,
+            });
+            return Ok(AnalysisResult::new(len_ref, Type::U64));
+        }
+
+        Err(CompileError::new(
+            ErrorKind::UndefinedMethod {
+                method_name: method_name.to_string(),
+                type_name: self.type_pool.struct_def(slice_struct_id).name.clone(),
+            },
+            span,
+        ))
     }
 
     /// Analyze an array index write.
@@ -4819,8 +5028,9 @@ impl<'a> Sema<'a> {
             }
         }
 
-        // Analyze all arguments
-        let air_args = self.analyze_call_args(air, &args, ctx)?;
+        // Analyze all arguments. Slice parameters (ADR-0043, RUE-322) coerce a
+        // `borrow arr` argument into a by-value fat pointer here.
+        let air_args = self.analyze_call_args_coerced(air, &args, &param_types, ctx)?;
 
         // Handle generic function calls differently
         if is_generic {

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -171,22 +171,102 @@ impl<'a> Sema<'a> {
     /// canonical type string is slice syntax so the caller short-circuits;
     /// `None` otherwise (a genuinely unknown type falls through to E0204).
     ///
-    /// This gates the surface behind `--preview slices` and, until the
-    /// fat-pointer runtime (ABI + codegen on both backends) lands, reports
-    /// [`ErrorKind::SliceNotYetImplemented`] (E0486) rather than letting an
-    /// unfinished slice reach lowering.
-    fn try_resolve_slice_type(&self, type_name: &str, span: Span) -> Option<CompileResult<Type>> {
+    /// This gates the surface behind `--preview slices` and, when enabled,
+    /// resolves the slice to its synthetic fat-pointer struct
+    /// (see [`Self::get_or_create_slice_struct`]) so it flows through the
+    /// existing aggregate ABI, field, and pointer codegen paths (ADR-0043
+    /// Phase 1 runtime, RUE-322). Escape positions (return / field / binding)
+    /// are rejected by [`Self::reject_slice_escape`] before reaching here.
+    fn try_resolve_slice_type(
+        &mut self,
+        type_name: &str,
+        span: Span,
+    ) -> Option<CompileResult<Type>> {
         if type_name.starts_with('[')
             && type_name.ends_with(']')
             && parse_array_type_syntax(type_name).is_none()
         {
             Some(
                 self.require_preview(PreviewFeature::Slices, "the slice type `[T]`", span)
-                    .and_then(|()| Err(CompileError::new(ErrorKind::SliceNotYetImplemented, span))),
+                    .and_then(|()| self.get_or_create_slice_struct(type_name, span)),
             )
         } else {
             None
         }
+    }
+
+    /// Get (or lazily create) the synthetic 2-field struct that represents the
+    /// second-class slice type `[T]` (ADR-0043, RUE-322).
+    ///
+    /// A slice is a fat pointer `{ ptr: ptr const T, len: u64 }`. Rather than
+    /// invent a new `TypeKind`, the slice is modeled as a `@copy` synthetic
+    /// struct so it flows through the existing multi-slot aggregate ABI, field
+    /// reads (for `.len()`), and by-ref (`borrow`) parameter passing — exactly
+    /// like the builtin `String` fat pointer. The struct is keyed by its slice
+    /// syntax name (`[i32]`), so repeated references share one `StructId`.
+    ///
+    /// The element type is parsed out of the bracket syntax and resolved first;
+    /// the pointer field is `ptr const T` so that `s[i]` can lower to
+    /// `@ptr_read(@ptr_offset(ptr, i))` with the correct element stride.
+    fn get_or_create_slice_struct(&mut self, type_name: &str, span: Span) -> CompileResult<Type> {
+        use crate::types::{StructDef, StructField};
+
+        let type_sym = self.interner.get_or_intern(type_name);
+        if let Some(&struct_id) = self.structs.get(&type_sym) {
+            return Ok(Type::new_struct(struct_id));
+        }
+
+        // Parse `[T]` -> element type name `T` and resolve it.
+        let element_name = type_name[1..type_name.len() - 1].trim().to_string();
+        let element_sym = self.interner.get_or_intern(&element_name);
+        let element_ty = self.resolve_type(element_sym, span)?;
+        let ptr_type_id = self.type_pool.intern_ptr_const_from_type(element_ty);
+        let ptr_ty = Type::new_ptr_const(ptr_type_id);
+
+        let struct_def = StructDef {
+            name: type_name.to_string(),
+            fields: vec![
+                StructField {
+                    name: "ptr".to_string(),
+                    ty: ptr_ty,
+                },
+                StructField {
+                    name: "len".to_string(),
+                    ty: Type::U64,
+                },
+            ],
+            // A slice is a copyable view (no ownership of the backing store).
+            is_copy: true,
+            is_linear: false,
+            destructor: None,
+            // Marked builtin so it never participates in user drop-glue etc.
+            is_builtin: true,
+            is_pub: true,
+            file_id: rue_span::FileId::new(0),
+        };
+        let (struct_id, _) = self.type_pool.register_struct(type_sym, struct_def);
+        self.structs.insert(type_sym, struct_id);
+        Ok(Type::new_struct(struct_id))
+    }
+
+    /// If `ty` is a synthetic slice struct `[T]` (ADR-0043, RUE-322), return its
+    /// element type `T`; otherwise `None`. Detected by the struct name being
+    /// slice syntax (`[..]` that is not a fixed-array `[T; N]`), the same naming
+    /// trick used for anonymous structs.
+    pub(crate) fn slice_element_type(&self, ty: Type) -> Option<Type> {
+        if let TypeKind::Struct(struct_id) = ty.kind() {
+            let def = self.type_pool.struct_def(struct_id);
+            if def.name.starts_with('[')
+                && def.name.ends_with(']')
+                && parse_array_type_syntax(&def.name).is_none()
+            {
+                // Field 0 is `ptr const T`; recover T from its pointee.
+                if let TypeKind::PtrConst(ptr_id) = def.fields[0].ty.kind() {
+                    return Some(self.type_pool.ptr_const_def(ptr_id));
+                }
+            }
+        }
+        None
     }
 
     /// Is `type_sym` the syntax of a slice type `[T]` (as opposed to a fixed
@@ -219,7 +299,11 @@ impl<'a> Sema<'a> {
     }
 
     pub(crate) fn resolve_type(&mut self, type_sym: Spur, span: Span) -> CompileResult<Type> {
-        let type_name = self.interner.resolve(&type_sym);
+        // Own the name so the read-only branches below borrow this local rather
+        // than `self.interner`, leaving `self` free for the `&mut self` slice
+        // path (`try_resolve_slice_type` lazily registers a synthetic struct).
+        let type_name_owned = self.interner.resolve(&type_sym).to_string();
+        let type_name = type_name_owned.as_str();
 
         // Check primitive types first (single shared table, RUE-155).
         // Note: String is handled below via struct lookup (it's a builtin struct).

--- a/crates/rue-cli-tests/cases/slice_second_class.toml
+++ b/crates/rue-cli-tests/cases/slice_second_class.toml
@@ -2,13 +2,12 @@
 # RUE-322). A slice `[T]` is a second-class fat-pointer view (ADR-0037): valid
 # only in argument position. These cases drive the real `rue` binary with
 # `--preview slices` on real files and pin the escape-family diagnostics
-# (E0487 return / E0488 aggregate field / E0489 let-or-const) plus the E0486
-# "runtime not yet implemented" gate for the one legal position (a parameter).
+# (E0487 return / E0488 aggregate field / E0489 let-or-const) and confirm the
+# one legal position (a parameter) is accepted.
 #
-# The fat-pointer runtime (ABI + slice index/len codegen on both backends) is a
-# follow-up sub-phase; until it lands, a slice *parameter* compiles no further
-# than E0486, so there is no runtime behaviour (trap exit code, sums) to pin
-# here yet.
+# The fat-pointer runtime (the by-value `{ptr, len}` ABI plus slice `.len()` and
+# bounds-checked read-indexing on both backends) has landed; its end-to-end
+# runtime behaviour (sums, the OOB trap) is pinned in slices_mvp.toml.
 
 [section]
 id = "cli.slice_second_class"
@@ -50,19 +49,19 @@ fn main() -> i32 { let s: [i32] = 0; 0 }
 compile_fail = true
 error_contains = ["E0489", "can only name a function parameter"]
 
-# Argument position (the one legal spot): resolves, but the runtime is not yet
-# implemented, so it stops at E0486 rather than reaching an unfinished codegen
-# path or ICE-ing.
+# Argument position (the one legal spot): a slice parameter compiles and runs
+# (ADR-0043 Phase 1 fat-pointer runtime, RUE-322). The end-to-end runtime
+# behaviour — `.len()`, bounds-checked `s[i]`, the OOB trap — is pinned in
+# slices_mvp.toml; here we only confirm the legal position is accepted.
 [[case]]
-name = "slice_param_runtime_not_yet_implemented_e0486"
-description = "A slice parameter is the one legal position; it reports E0486 until the fat-pointer runtime lands."
+name = "slice_param_position_compiles"
+description = "A slice parameter is the one legal position; it compiles and runs."
 args = ["main.rue", "--preview", "slices", "-o", "prog"]
 files = [{ path = "main.rue", source = """
 fn sum(borrow s: [i32]) -> i32 { 0 }
 fn main() -> i32 { 0 }
 """ }]
-compile_fail = true
-error_contains = ["E0486", "not yet fully implemented"]
+exit_code = 0
 
 # Without the preview flag, the same parameter is gated at E1100.
 [[case]]

--- a/crates/rue-cli-tests/cases/slices_mvp.toml
+++ b/crates/rue-cli-tests/cases/slices_mvp.toml
@@ -1,21 +1,16 @@
-# ADR-0043 Phase 1 slice runtime — executable acceptance tests (RUE-322).
+# ADR-0043 Phase 1 slice runtime — executable regression tests (RUE-322).
 #
-# The slice front-end (parser + `--preview slices` gate + E0486 stub) and the
-# second-class escape enforcement (E0487-E0489) have landed, but the RUNTIME —
-# the {ptr, len} fat-pointer ABI, `borrow arr` -> slice materialization, slice
-# `.len()`, and bounds-checked read-indexing `s[i]` on BOTH backends — is not
-# yet implemented, so `borrow s: [T]` in argument position still reports E0486
-# ("slice types are not yet fully implemented").
+# The second-class slice `[T]` is a two-word fat pointer `{ptr, len}` modeled as
+# a synthetic `@copy` struct (so it reuses the multi-slot aggregate ABI, struct
+# field reads, and by-value parameter passing — no new codegen, both backends).
+# A `borrow s: [T]` parameter is passed by value; `borrow arr` at the call site
+# materializes `{ptr: @raw(arr[0]), len: N}`; `s.len()` reads the runtime `len`
+# word; and `s[i]` lowers to `@ptr_read(@ptr_offset(ptr, i))` guarded by a
+# runtime bounds check that traps (exit 101) like array indexing.
 #
-# These cases pin the exact end-to-end behavior the MVP runtime must produce.
-# They are `known_bug = "RUE-322"` xfails today (the compile fails cleanly with
-# E0486); when the fat-pointer runtime lands, drop the `known_bug` markers and
-# they become the runtime's regression tests. See the ABI analysis in the
-# RUE-322 worklog: the blockers are (1) `borrow` currently passes a single
-# pointer, not a 2-word aggregate; (2) `emit_bounds_check` takes a compile-time
-# constant length, but a slice length is runtime; (3) array indexing lowers via
-# `Place` projections tied to a compile-time `array_type`, whereas a slice index
-# is a raw-pointer load off the fat pointer's `ptr` word.
+# Deferred to later phases (still reported cleanly, not runnable here):
+# `inout [T]` write-slices, range slicing `x[a..b]`, ArrayBuf/Vec slices, and
+# returning/storing a slice (E0487-E0489 second-class enforcement).
 
 [section]
 id = "cli.slices"
@@ -26,7 +21,6 @@ description = "borrow-a-whole-array slice parameter: len() and bounds-checked re
 # through a `borrow s: [i32]` slice parameter using `s.len()` and `s[i]`.
 [[case]]
 name = "slice_param_sum_len_index"
-known_bug = "RUE-322"
 files = [{ path = "main.rue", source = """
 fn sum(borrow s: [i32]) -> i32 {
     let mut t = 0;
@@ -46,10 +40,9 @@ args = ["main.rue", "--preview", "slices", "-o", "prog"]
 exit_code = 60
 
 # Out-of-bounds read-index through a slice parameter must trap at runtime with
-# the same abort discipline as array indexing (`__rue_bounds_check`, exit 101).
+# the same abort discipline as array indexing (exit 101).
 [[case]]
 name = "slice_param_index_out_of_bounds_traps"
-known_bug = "RUE-322"
 files = [{ path = "main.rue", source = """
 fn get(borrow s: [i32], i: u64) -> i32 {
     s[i]
@@ -61,3 +54,113 @@ fn main() -> i32 {
 """ }]
 args = ["main.rue", "--preview", "slices", "-o", "prog"]
 exit_code = 101
+
+# A constant read-index resolves the element position (discriminating value: the
+# middle element 5 catches an off-by-one or wrong-stride lowering).
+[[case]]
+name = "slice_param_constant_index"
+files = [{ path = "main.rue", source = """
+fn second(borrow s: [i32]) -> i32 {
+    s[1]
+}
+fn main() -> i32 {
+    let a: [i32; 4] = [3, 5, 7, 9];
+    second(borrow a)
+}
+""" }]
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+exit_code = 5
+
+# `.len()` returns the runtime length word (whole-array borrow -> N).
+[[case]]
+name = "slice_param_len"
+files = [{ path = "main.rue", source = """
+fn ln(borrow s: [i32]) -> i32 {
+    @intCast(s.len())
+}
+fn main() -> i32 {
+    let a: [i32; 6] = [9, 9, 9, 9, 9, 9];
+    ln(borrow a)
+}
+""" }]
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+exit_code = 6
+
+# A `[u8]` slice exercises a different element type: the pointer field is
+# `ptr const u8` and `@ptr_offset` stride must still land on each element
+# (sum 1+2+3+4 = 10).
+[[case]]
+name = "slice_param_u8_element"
+files = [{ path = "main.rue", source = """
+fn sum(borrow s: [u8]) -> i32 {
+    let mut t: i32 = 0;
+    let mut i: u64 = 0;
+    while i < s.len() {
+        t = t + @intCast(s[i]);
+        i = i + 1;
+    }
+    t
+}
+fn main() -> i32 {
+    let a: [u8; 4] = [1, 2, 3, 4];
+    sum(borrow a)
+}
+""" }]
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+exit_code = 10
+
+# A slice parameter can be forwarded to another slice parameter (`borrow s`
+# where `s` is itself a slice): the fat pointer is passed through by value
+# rather than re-materialized.
+[[case]]
+name = "slice_param_forwarding"
+files = [{ path = "main.rue", source = """
+fn sum(borrow s: [i32]) -> i32 {
+    let mut t = 0;
+    let mut i: u64 = 0;
+    while i < s.len() {
+        t = t + s[i];
+        i = i + 1;
+    }
+    t
+}
+fn outer(borrow s: [i32]) -> i32 {
+    sum(borrow s)
+}
+fn main() -> i32 {
+    let a: [i32; 3] = [10, 20, 30];
+    outer(borrow a)
+}
+""" }]
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+exit_code = 60
+
+# Passing an array whose element type does not match the slice element type is
+# a clean compile error (the coercion validates element compatibility, since
+# inference relaxes the whole-type equality for slice parameters).
+[[case]]
+name = "slice_param_element_mismatch"
+files = [{ path = "main.rue", source = """
+fn h(borrow s: [u8]) -> i32 { 0 }
+fn main() -> i32 {
+    let a: [i32; 3] = [1, 2, 3];
+    h(borrow a)
+}
+""" }]
+args = ["main.rue", "--preview", "slices", "-o", "prog"]
+compile_fail = true
+error_contains = ["type mismatch"]
+
+# The slice surface stays gated behind `--preview slices`.
+[[case]]
+name = "slice_param_requires_preview"
+files = [{ path = "main.rue", source = """
+fn ln(borrow s: [i32]) -> i32 { @intCast(s.len()) }
+fn main() -> i32 {
+    let a: [i32; 2] = [1, 2];
+    ln(borrow a)
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["requires preview feature"]

--- a/crates/rue-ui-tests/cases/diagnostics/slice_preview_gate.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/slice_preview_gate.toml
@@ -12,10 +12,9 @@ argument position and may not escape. These cases pin the second-class
 enforcement — return position is E0487, a struct field / enum payload is
 E0488, and a `let` / `const` binding is E0489 — which fire *before* the
 runtime is consulted. In argument position (the one legal spot) the slice
-type is accepted by resolution but reports E0486, because the fat-pointer
-runtime (ABI + codegen on both backends) is not yet implemented. These UI
-cases pin the gating + enforcement behaviour; the E0486 case becomes a
-regression test for the follow-up phase that lands the runtime.
+type is accepted and its fat-pointer runtime (`.len()`, bounds-checked
+`s[i]`) runs; that end-to-end behaviour is pinned in the CLI suite
+(slices_mvp.toml). These UI cases pin the gating + enforcement diagnostics.
 """
 
 [[case]]
@@ -37,16 +36,6 @@ fn main() -> i32 { let s: [i32] = other(); 0 }
 compile_fail = true
 error_contains = "requires preview feature"
 
-[[case]]
-name = "slice_param_under_preview_not_yet_implemented"
-description = "Under --preview slices, a slice parameter (the one legal position) parses but reports E0486 (runtime unimplemented)."
-preview = "slices"
-source = """
-fn sum(borrow s: [i32]) -> i32 { 0 }
-fn main() -> i32 { 0 }
-"""
-compile_fail = true
-error_contains = "not yet fully implemented"
 
 [[case]]
 name = "slice_return_is_second_class_e0487"


### PR DESCRIPTION
The ADR-0043 Phase-1 slice runtime — the keystone blocking the str/StrBuf chain (RUE-324..327). Three prior workers judged the 2-word fat-pointer ABI a multi-session codegen effort; the winning insight is a second-class slice is **just a 2-field @copy struct {ptr, len} desugared onto existing intrinsics** — collapsing all three ABI blockers into **zero new codegen / zero new MIR variants, both backends for free**.

Implemented (rue-air, under `--preview slices`): `[T]`→synthetic {ptr,len} struct; slice params by-value via the multi-slot struct ABI; array→slice coercion; `borrow arr`→`{@raw(arr[0]), N}`; `s.len()`→field read; `s[i]`→`@assert(i<len)` + `@ptr_read(@ptr_offset(ptr,i))` (bounds-checked); retired the E0486 gate; un-marked both slices_mvp xfails.

Verified by execution: sum over [i32;3]=60, OOB traps (exit 101), aarch64 asm correct. clippy clean; test.sh Pass 24, 100% traceability (705/705), oracle-diff 0. Deferred: inout write-slices, range `x[a..b]`, ArrayBuf slices.

Part of RUE-322

Generated with Claude Code