### PR TITLE
Test-harness honesty fixes, form-feed strictness, + opt-level & lazy-analysis ADRs

### DIFF
--- a/crates/rue-cli-tests/BUCK
+++ b/crates/rue-cli-tests/BUCK
@@ -1,10 +1,10 @@
 load("//crates:defs.bzl", "rue_binary")
 
-# tests = False: this binary IS the CLI integration test harness; its sources
-# contain no #[test] functions, so a rust_test target would be empty.
+# This binary IS the CLI integration test harness, but its sources also carry a
+# small #[cfg(test)] module unit-testing the case-file load-time validation
+# (e.g. differential_opt pinning), so the generated rust_test target is kept.
 rue_binary(
     name = "rue-cli-tests",
-    tests = False,
     deps = [
         "//crates/rue-test-runner:rue-test-runner",
         "//third-party:libtest2-mimic",

--- a/crates/rue-cli-tests/cases/large_stdout_no_deadlock.toml
+++ b/crates/rue-cli-tests/cases/large_stdout_no_deadlock.toml
@@ -1,0 +1,24 @@
+[section]
+id = "cli.large_stdout"
+name = "Large program stdout does not deadlock the harness (RUE-132)"
+
+# A program that writes far more than the OS pipe buffer (~64KB) must run to
+# completion through the real harness. run_with_timeout drains stdout/stderr on
+# reader threads started right after spawn; before that fix the pipe would fill,
+# the program would block in write(), and the case would time out (same class as
+# RUE-338). ~168KB of output here is comfortably past the buffer.
+[[case]]
+name = "program_emitting_over_64kb_completes"
+description = "Prints 30000 lines (~168KB) via @dbg and exits 0 without deadlocking."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut i = 0;
+    while i < 30000 {
+        @dbg(i);
+        i = i + 1;
+    }
+    0
+}
+""" }]
+stdout_contains = ["0\n", "29999\n"]
+exit_code = 0

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -225,7 +225,7 @@ struct SourceFile {
     source: String,
 }
 
-#[derive(Debug, Clone, Deserialize)]
+#[derive(Debug, Clone, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct Case {
     name: String,
@@ -662,6 +662,14 @@ fn run_case_wrapper(
     }
 }
 
+/// A `differential_opt` case's cross-level check is only meaningful if each opt
+/// level is also pinned to a known-good result, so it must declare both an
+/// explicit `stdout` and `exit_code`. Returns true when the case is
+/// `differential_opt` but missing either — a load-time error (RUE-132).
+fn differential_opt_missing_pin(case: &Case) -> bool {
+    case.differential_opt && (case.stdout.is_none() || case.exit_code.is_none())
+}
+
 fn load_cases(cases_dir: &Path) -> Vec<(String, TestFile)> {
     let mut toml_files = Vec::new();
     rue_test_runner::collect_toml_files(cases_dir, &mut toml_files);
@@ -677,7 +685,27 @@ fn load_cases(cases_dir: &Path) -> Vec<(String, TestFile)> {
             }
         };
         match toml::from_str::<TestFile>(&content) {
-            Ok(tf) => out.push((path.display().to_string(), tf)),
+            Ok(tf) => {
+                // A differential_opt case's cross-level check is trivially green
+                // today (-O2/-O3 alias -O1), so it only catches a *consistently*
+                // wrong program if each level is also pinned to a known-good
+                // result. Require both an explicit `stdout` and `exit_code` at
+                // load time so the doc comment's promise is enforced, not merely
+                // documented (RUE-132).
+                for case in &tf.cases {
+                    if differential_opt_missing_pin(case) {
+                        eprintln!(
+                            "error: {}: differential_opt case '{}' must declare both an explicit \
+                             `stdout` and `exit_code` (each opt level is checked against them, so \
+                             the cross-level compare can't pass a consistently-wrong program)",
+                            path.display(),
+                            case.name
+                        );
+                        std::process::exit(1);
+                    }
+                }
+                out.push((path.display().to_string(), tf));
+            }
             Err(e) => {
                 eprintln!("error: failed to parse {}: {}", path.display(), e);
                 std::process::exit(1);
@@ -880,4 +908,45 @@ fn main() {
     tests.extend(example_trials(&rue_binary));
 
     Harness::with_env().discover(tests).main();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn differential_opt_requires_stdout_and_exit_code() {
+        // Missing both -> rejected.
+        let mut case = Case {
+            name: "c".to_string(),
+            differential_opt: true,
+            ..Default::default()
+        };
+        assert!(differential_opt_missing_pin(&case));
+
+        // Only stdout -> still rejected (exit_code missing).
+        case.stdout = Some("59\n".to_string());
+        assert!(differential_opt_missing_pin(&case));
+
+        // Only exit_code -> still rejected (stdout missing).
+        case.stdout = None;
+        case.exit_code = Some(59);
+        assert!(differential_opt_missing_pin(&case));
+
+        // Both present -> accepted.
+        case.stdout = Some("59\n".to_string());
+        assert!(!differential_opt_missing_pin(&case));
+    }
+
+    #[test]
+    fn non_differential_case_not_required_to_pin() {
+        // A plain case missing stdout/exit_code is fine — the requirement only
+        // applies to differential_opt cases.
+        let case = Case {
+            name: "c".to_string(),
+            differential_opt: false,
+            ..Default::default()
+        };
+        assert!(!differential_opt_missing_pin(&case));
+    }
 }

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -230,7 +230,11 @@ fn parse_based_literal(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Result<u64
 #[derive(Logos, Debug, Clone, PartialEq, Eq)]
 #[logos(error = LexError)]
 #[logos(extras = ThreadedRodeo)]
-#[logos(skip r"[ \t\n\r\f]+")]
+// Whitespace per spec 2.3:1 — space, tab, newline, carriage return only.
+// Deliberately excludes form-feed (U+000C): Rust treats FF as whitespace
+// (Pattern_White_Space), but Zig does not, and Rue follows Zig's strict,
+// explicit set here (RUE-333). A stray FF byte therefore lexes to an error.
+#[logos(skip r"[ \t\n\r]+")]
 #[logos(skip r"//[^\n]*")]
 pub enum LogosTokenKind {
     // Keywords - logos prefers longer/specific matches over shorter/generic ones

--- a/crates/rue-spec/cases/lexical/whitespace.toml
+++ b/crates/rue-spec/cases/lexical/whitespace.toml
@@ -26,6 +26,17 @@ spec = ["2.3:1"]
 source = "fn\tmain()\t->\ti32\t{\t42\t}"
 exit_code = 42
 
+# Form-feed (U+000C) is deliberately NOT whitespace: spec 2.3:1 lists only
+# space, tab, newline, and carriage return. This matches Zig's strict set and
+# diverges from Rust, which treats form-feed as Pattern_White_Space (RUE-333).
+# A stray form-feed must therefore produce a clean lex error, not be skipped.
+[[case]]
+name = "form_feed_not_whitespace"
+spec = ["2.3:1"]
+source = "fn main() -> i32 {\f42 }"
+compile_fail = true
+error_contains = "unexpected character"
+
 [[case]]
 name = "newlines"
 spec = ["2.3:1"]

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -569,6 +569,66 @@ pub fn validate_preview_features(test_file: &TestFile) -> Vec<UnknownPreviewFeat
     errors
 }
 
+/// An error indicating a case declares a compile-error assertion
+/// (`error_contains` / `expected_error`) without `compile_fail = true`.
+///
+/// Those assertions are only ever checked inside the `compile_fail` branch of
+/// [`run_test_case`]; on a case expected to compile they would silently never
+/// run, turning a typo'd expectation into a vacuous pass. Rejecting the
+/// combination at load time is cleaner than half-honoring it (RUE-132).
+#[derive(Debug, Clone)]
+pub struct StrayErrorAssertionError {
+    /// The name of the offending test case.
+    pub test_name: String,
+    /// The section ID the test belongs to.
+    pub section_id: String,
+    /// Which field(s) were set: `error_contains`, `expected_error`, or both.
+    pub fields: String,
+}
+
+impl std::fmt::Display for StrayErrorAssertionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "test '{}::{}' sets {} but is not `compile_fail` — that assertion is \
+             only checked when compilation is expected to fail, so it would never \
+             run. Add `compile_fail = true`, or (for a runtime failure) use \
+             `runtime_error`, or remove the field.",
+            self.section_id, self.test_name, self.fields
+        )
+    }
+}
+
+impl std::error::Error for StrayErrorAssertionError {}
+
+/// Validate that no case carries a compile-error assertion without
+/// `compile_fail`. Returns one error per offending case.
+pub fn validate_error_assertions(test_file: &TestFile) -> Vec<StrayErrorAssertionError> {
+    let mut errors = Vec::new();
+    for case in &test_file.case {
+        if case.compile_fail {
+            continue;
+        }
+        let has_error_contains = !case.error_contains.is_empty();
+        let has_expected_error = case.expected_error.is_some();
+        if !has_error_contains && !has_expected_error {
+            continue;
+        }
+        let fields = match (has_error_contains, has_expected_error) {
+            (true, true) => "`error_contains` and `expected_error`",
+            (true, false) => "`error_contains`",
+            (false, true) => "`expected_error`",
+            (false, false) => unreachable!(),
+        };
+        errors.push(StrayErrorAssertionError {
+            test_name: case.name.clone(),
+            section_id: test_file.section.id.clone(),
+            fields: fields.to_string(),
+        });
+    }
+    errors
+}
+
 /// Recursively collect all files with the given extension from a directory.
 pub fn collect_files_by_ext(dir: &Path, ext: &str, files: &mut Vec<PathBuf>) {
     if let Ok(entries) = fs::read_dir(dir) {
@@ -603,6 +663,7 @@ pub fn collect_toml_files(dir: &Path, files: &mut Vec<PathBuf>) {
 pub fn load_test_files(cases_dir: &Path) -> Vec<(String, TestFile)> {
     let mut specs = Vec::new();
     let mut preview_errors: Vec<UnknownPreviewFeatureError> = Vec::new();
+    let mut stray_error_assertions: Vec<StrayErrorAssertionError> = Vec::new();
 
     if !cases_dir.exists() {
         eprintln!(
@@ -633,6 +694,9 @@ pub fn load_test_files(cases_dir: &Path) -> Vec<(String, TestFile)> {
 
                 // Validate preview feature names
                 preview_errors.extend(validate_preview_features(&spec));
+
+                // Reject compile-error assertions on cases that aren't compile_fail
+                stray_error_assertions.extend(validate_error_assertions(&spec));
 
                 // Build a relative path from cases_dir to create the identifier
                 // e.g., "expressions/match" for "cases/expressions/match.toml"
@@ -684,6 +748,22 @@ Error: {} test file(s) failed to load:",
         );
     }
 
+    // Report stray compile-error assertions and fail if any were found
+    if !stray_error_assertions.is_empty() {
+        eprintln!(
+            "\nError: Found {} case(s) with a compile-error assertion but no `compile_fail`:",
+            stray_error_assertions.len()
+        );
+        for error in &stray_error_assertions {
+            eprintln!("  - {}", error);
+        }
+        panic!(
+            "Test loading failed: {} case(s) set `error_contains`/`expected_error` without \
+             `compile_fail`. See errors above for details.",
+            stray_error_assertions.len()
+        );
+    }
+
     // Sort by identifier for deterministic ordering
     specs.sort_by(|a, b| a.0.cmp(&b.0));
     specs
@@ -698,6 +778,30 @@ pub fn normalize_golden(s: &str) -> String {
         .join("\n")
         .trim()
         .to_string()
+}
+
+/// Strip the single boundary newline that a TOML `"""` multi-line block adds
+/// around authored content: at most one leading and at most one trailing
+/// newline (`\r\n` or `\n`).
+///
+/// This is the *only* leniency applied when comparing a spec case's
+/// `expected_stdout` against a program's actual stdout — the compare is
+/// otherwise byte-exact (matching the CLI runner in rue-cli-tests). Unlike
+/// [`normalize_golden`], it does NOT trim per-line trailing whitespace or
+/// internal blank lines, so a stdout-formatting regression (e.g. a stray
+/// trailing space or an extra blank line) is still caught. It exists purely so
+/// the readable `"""` authoring convention — closing delimiter on its own line,
+/// which forces a trailing newline — doesn't force every expectation to be
+/// written on one crowded line. Reserve [`normalize_golden`] for `--emit` IR
+/// golden dumps, which are inherently multi-line and formatting-insensitive.
+fn strip_block_boundary_newlines(s: &str) -> &str {
+    let s = s
+        .strip_prefix("\r\n")
+        .or_else(|| s.strip_prefix('\n'))
+        .unwrap_or(s);
+    s.strip_suffix("\r\n")
+        .or_else(|| s.strip_suffix('\n'))
+        .unwrap_or(s)
 }
 
 /// Normalize error output for golden test comparison.
@@ -765,12 +869,15 @@ fn run_golden_ir_test(
     stage: &str,
     expected: &str,
     build_command: impl Fn(&Path) -> Command,
+    timeout: Duration,
 ) -> TestResult {
-    let output = build_command(rue_binary)
-        .arg("--emit")
-        .arg(stage)
-        .arg(source_path)
-        .output()
+    // Run the emit under the same timeout as the rest of the case, so a compiler
+    // that hangs while dumping an IR fails this one case instead of wedging the
+    // whole suite (RUE-132). `run_with_timeout` surfaces a hang as a distinct
+    // [`TIMEOUT_PREFIX`] error.
+    let mut cmd = build_command(rue_binary);
+    cmd.arg("--emit").arg(stage).arg(source_path);
+    let output = run_with_timeout(cmd, timeout, None)
         .map_err(|e| format!("Failed to run rue --emit {}: {}", stage, e))?;
 
     if !output.status.success() {
@@ -838,9 +945,21 @@ fn kill_process_group(child: &mut std::process::Child) {
 
 /// Run a command with a timeout and optional stdin input.
 ///
-/// This function spawns a child process (in its own process group), writes to
-/// its stdin if provided, and polls for completion, killing the whole process
-/// group if it exceeds the specified timeout.
+/// This function spawns a child process (in its own process group), drains its
+/// stdout and stderr on dedicated reader threads, feeds it stdin (if provided)
+/// on its own writer thread, and polls for completion, killing the whole
+/// process group if it exceeds the specified timeout.
+///
+/// # Why the reader/writer threads (RUE-338 deadlock class)
+///
+/// Draining stdout AND stderr **concurrently**, starting immediately after
+/// spawn, is essential: if the pipes were read only after the child exits, a
+/// program that writes more than the OS pipe capacity (~64KB on Linux) would
+/// block forever in `write()`, `try_wait` would never report an exit, and the
+/// timeout would manufacture a false failure. For the same reason stdin is
+/// written on its own thread — a large input can't block the drain, and the
+/// drain can't block the stdin write. Mirrors the oracle-diff fuzzer's
+/// `run_with_timeout` (RUE-338).
 ///
 /// # Arguments
 /// * `cmd` - The command to run (already configured with arguments)
@@ -869,24 +988,39 @@ pub fn run_with_timeout(
         .spawn()
         .map_err(|e| format!("Failed to spawn process: {}", e))?;
 
-    // Write stdin input if provided. A program may exit without reading all of
-    // its input; a broken pipe here is not a test failure, so errors are
-    // ignored (matching the CLI harness).
-    if let Some(input) = stdin_input {
-        if let Some(mut stdin) = child.stdin.take() {
+    // Drain stdout and stderr on their own threads, started right after spawn so
+    // neither pipe can fill and wedge the child (see the RUE-338 note above).
+    let stdout_pipe = child.stdout.take();
+    let stderr_pipe = child.stderr.take();
+    let stdout_reader =
+        std::thread::spawn(move || stdout_pipe.map(read_all_bytes).unwrap_or_default());
+    let stderr_reader =
+        std::thread::spawn(move || stderr_pipe.map(read_all_bytes).unwrap_or_default());
+
+    // Feed stdin on its own thread so a large input can't block the drain (and
+    // vice versa). A program may exit without reading all of its input; a broken
+    // pipe here is not a test failure, so errors are ignored (matching the CLI
+    // harness). Dropping the pipe when the closure ends closes it, signaling EOF.
+    let stdin_writer = child.stdin.take().map(|mut stdin| {
+        let input = stdin_input.unwrap_or_default().to_string();
+        std::thread::spawn(move || {
             let _ = stdin.write_all(input.as_bytes());
-            // Dropping `stdin` closes it, signaling EOF to the child.
-        }
-    }
+        })
+    });
 
     let start = Instant::now();
 
     loop {
         match child.try_wait() {
             Ok(Some(status)) => {
-                // Process finished - collect output
-                let stdout = child.stdout.take().map(read_all_bytes).unwrap_or_default();
-                let stderr = child.stderr.take().map(read_all_bytes).unwrap_or_default();
+                // Process finished: its write ends are closed, so the reader
+                // threads hit EOF and finish. Join to collect the fully-drained
+                // output.
+                let stdout = stdout_reader.join().unwrap_or_default();
+                let stderr = stderr_reader.join().unwrap_or_default();
+                if let Some(writer) = stdin_writer {
+                    let _ = writer.join();
+                }
                 return Ok(Output {
                     status,
                     stdout,
@@ -896,8 +1030,15 @@ pub fn run_with_timeout(
             Ok(None) => {
                 // Still running - check timeout
                 if start.elapsed() > timeout {
-                    // Kill the whole process group and return a timeout error.
+                    // Kill the whole process group, then join the helper threads:
+                    // killing closes the child's fds, so the readers hit EOF and
+                    // the stdin writer's `write_all` gets EPIPE, and none leak.
                     kill_process_group(&mut child);
+                    let _ = stdout_reader.join();
+                    let _ = stderr_reader.join();
+                    if let Some(writer) = stdin_writer {
+                        let _ = writer.join();
+                    }
                     return Err(format!(
                         "{} test execution timed out after {} ms (process group killed)",
                         TIMEOUT_PREFIX,
@@ -981,6 +1122,11 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         cmd
     };
 
+    // Timeout applied to every compiler invocation in this case (golden-IR
+    // emits and the compile step), so a compiler hang fails the case instead of
+    // wedging the whole suite.
+    let compile_timeout = Duration::from_millis(case.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS));
+
     // Check for golden IR tests (tokens, AST, RIR, AIR, CFG, MIR)
     if case.has_golden_ir_assertions() {
         // A program that fails to compile has no IR to dump, so this
@@ -994,23 +1140,58 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
 
         // Run dump commands and check golden output
         if let Some(ref expected) = case.expected_tokens {
-            run_golden_ir_test(rue_binary, &source_path, "tokens", expected, &build_command)?;
+            run_golden_ir_test(
+                rue_binary,
+                &source_path,
+                "tokens",
+                expected,
+                &build_command,
+                compile_timeout,
+            )?;
         }
 
         if let Some(ref expected) = case.expected_ast {
-            run_golden_ir_test(rue_binary, &source_path, "ast", expected, &build_command)?;
+            run_golden_ir_test(
+                rue_binary,
+                &source_path,
+                "ast",
+                expected,
+                &build_command,
+                compile_timeout,
+            )?;
         }
 
         if let Some(ref expected) = case.expected_rir {
-            run_golden_ir_test(rue_binary, &source_path, "rir", expected, &build_command)?;
+            run_golden_ir_test(
+                rue_binary,
+                &source_path,
+                "rir",
+                expected,
+                &build_command,
+                compile_timeout,
+            )?;
         }
 
         if let Some(ref expected) = case.expected_air {
-            run_golden_ir_test(rue_binary, &source_path, "air", expected, &build_command)?;
+            run_golden_ir_test(
+                rue_binary,
+                &source_path,
+                "air",
+                expected,
+                &build_command,
+                compile_timeout,
+            )?;
         }
 
         if let Some(ref expected) = case.expected_cfg {
-            run_golden_ir_test(rue_binary, &source_path, "cfg", expected, &build_command)?;
+            run_golden_ir_test(
+                rue_binary,
+                &source_path,
+                "cfg",
+                expected,
+                &build_command,
+                compile_timeout,
+            )?;
         }
 
         if let Some(ref expected) = case.expected_mir {
@@ -1021,7 +1202,14 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
                         .to_string(),
                 );
             }
-            run_golden_ir_test(rue_binary, &source_path, "mir", expected, &build_command)?;
+            run_golden_ir_test(
+                rue_binary,
+                &source_path,
+                "mir",
+                expected,
+                &build_command,
+                compile_timeout,
+            )?;
         }
 
         // A case may combine golden-IR assertions with execution assertions
@@ -1045,9 +1233,9 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         }
     }
     compile_cmd.arg("-o").arg(&output_path);
-    // Run the compiler under the same timeout as the compiled program, so a
-    // compiler hang fails the case instead of wedging the whole suite.
-    let compile_timeout = Duration::from_millis(case.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS));
+    // Run the compiler under the same timeout as the golden emits and the
+    // compiled program, so a compiler hang fails the case instead of wedging
+    // the whole suite.
     let compile_output = run_with_timeout(compile_cmd, compile_timeout, None)
         .map_err(|e| format!("Failed to run rue compiler: {}", e))?;
 
@@ -1175,15 +1363,23 @@ pub fn run_test_case(case: &Case, rue_binary: &Path) -> TestResult {
         return Ok(());
     }
 
-    // Check expected stdout output (e.g., from @dbg calls)
+    // Check expected stdout output (e.g., from @dbg calls).
+    //
+    // The compare is byte-exact — matching the CLI runner in rue-cli-tests —
+    // except for the single boundary newline the TOML `"""` block adds (see
+    // `strip_block_boundary_newlines`). It deliberately does NOT run
+    // `normalize_golden`, which would trim per-line trailing whitespace and
+    // internal blank lines and thereby let a stdout-formatting regression pass
+    // the spec suite while failing the byte-exact CLI runner (RUE-132). Values
+    // are shown `{:?}`-quoted so a whitespace-only difference is visible.
     if let Some(ref expected) = case.expected_stdout {
         let stdout = String::from_utf8_lossy(&run_output.stdout);
-        let expected_normalized = normalize_golden(expected);
-        let actual_normalized = normalize_golden(&stdout);
-        if actual_normalized != expected_normalized {
+        let expected_cmp = strip_block_boundary_newlines(expected);
+        let actual_cmp = strip_block_boundary_newlines(&stdout);
+        if actual_cmp != expected_cmp {
             return Err(format!(
-                "Stdout mismatch:\n--- expected ---\n{}\n--- actual ---\n{}\n  source: {}",
-                expected_normalized, actual_normalized, case.source
+                "Stdout mismatch:\n--- expected ---\n{:?}\n--- actual ---\n{:?}\n  source: {}",
+                expected_cmp, actual_cmp, case.source
             ));
         }
     }
@@ -1950,5 +2146,120 @@ mod tests {
         assert!(msg.contains("my_test"), "Should contain test name");
         assert!(msg.contains("section.id"), "Should contain section ID");
         assert!(msg.contains("test_infra"), "Should list valid features");
+    }
+
+    // Tests for strip_block_boundary_newlines (RUE-132: exact stdout compare).
+
+    #[test]
+    fn test_strip_block_boundary_newlines_strips_one_each_end() {
+        // A leading and a trailing newline (the TOML `"""` authoring boundary)
+        // are stripped; content in between is untouched.
+        assert_eq!(strip_block_boundary_newlines("\n2\n1\n"), "2\n1");
+        assert_eq!(strip_block_boundary_newlines("2\n1\n"), "2\n1");
+        assert_eq!(strip_block_boundary_newlines("2\n1"), "2\n1");
+    }
+
+    #[test]
+    fn test_strip_block_boundary_newlines_preserves_internal_and_trailing_ws() {
+        // Internal blank lines and per-line trailing whitespace survive, so a
+        // stdout-formatting regression is still caught by the byte-exact compare
+        // (unlike normalize_golden, which would erase both).
+        assert_eq!(strip_block_boundary_newlines("a\n\nb\n"), "a\n\nb");
+        assert_eq!(strip_block_boundary_newlines("a \nb\n"), "a \nb");
+    }
+
+    #[test]
+    fn test_strip_block_boundary_newlines_only_one_trailing() {
+        // Only ONE trailing newline is stripped: an extra trailing blank line
+        // survives and would (correctly) fail the compare.
+        assert_eq!(strip_block_boundary_newlines("a\n\n"), "a\n");
+    }
+
+    #[test]
+    fn test_strip_block_boundary_newlines_handles_crlf() {
+        assert_eq!(strip_block_boundary_newlines("\r\na\r\n"), "a");
+    }
+
+    // Tests for validate_error_assertions (RUE-132: reject stray compile-error
+    // assertions on cases that aren't compile_fail).
+
+    #[test]
+    fn test_validate_error_assertions_rejects_error_contains_without_compile_fail() {
+        // make_test_case sets compile_fail = false, exit_code = Some(0).
+        let mut case = make_test_case("stray", None);
+        case.error_contains = ErrorContains(vec!["type mismatch".to_string()]);
+        let tf = make_test_file("sec", vec![case]);
+        let errors = validate_error_assertions(&tf);
+        assert_eq!(errors.len(), 1);
+        assert_eq!(errors[0].test_name, "stray");
+        assert!(errors[0].fields.contains("error_contains"));
+    }
+
+    #[test]
+    fn test_validate_error_assertions_rejects_expected_error_without_compile_fail() {
+        let mut case = make_test_case("stray2", None);
+        case.expected_error = Some("error[E0001]".to_string());
+        let tf = make_test_file("sec", vec![case]);
+        let errors = validate_error_assertions(&tf);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].fields.contains("expected_error"));
+    }
+
+    #[test]
+    fn test_validate_error_assertions_allows_error_contains_with_compile_fail() {
+        let mut case = make_test_case("ok", None);
+        case.compile_fail = true;
+        case.exit_code = None;
+        case.error_contains = ErrorContains(vec!["type mismatch".to_string()]);
+        let tf = make_test_file("sec", vec![case]);
+        assert!(validate_error_assertions(&tf).is_empty());
+    }
+
+    #[test]
+    fn test_validate_error_assertions_clean_case_ok() {
+        let case = make_test_case("plain", None);
+        let tf = make_test_file("sec", vec![case]);
+        assert!(validate_error_assertions(&tf).is_empty());
+    }
+
+    // Tests for run_with_timeout draining large output without deadlock
+    // (RUE-132 / same class as RUE-338). With the pre-fix code — write all
+    // stdin, then read the pipes only after exit — each of these would fill the
+    // ~64KB OS pipe buffer, block the child in write(), and time out.
+
+    #[test]
+    fn test_run_with_timeout_drains_large_stdout() {
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c").arg("head -c 200000 /dev/zero");
+        let output = run_with_timeout(cmd, Duration::from_secs(10), None)
+            .expect("large-stdout program should complete, not time out");
+        assert!(output.status.success());
+        assert_eq!(output.stdout.len(), 200_000);
+    }
+
+    #[test]
+    fn test_run_with_timeout_drains_large_stdout_and_stderr() {
+        // Both pipes must be drained concurrently; filling either alone wedges
+        // the child.
+        let mut cmd = Command::new("sh");
+        cmd.arg("-c")
+            .arg("head -c 200000 /dev/zero; head -c 200000 /dev/zero >&2");
+        let output = run_with_timeout(cmd, Duration::from_secs(10), None)
+            .expect("large stdout+stderr program should complete");
+        assert!(output.status.success());
+        assert_eq!(output.stdout.len(), 200_000);
+        assert_eq!(output.stderr.len(), 200_000);
+    }
+
+    #[test]
+    fn test_run_with_timeout_large_stdin_and_stdout() {
+        // `cat` echoes stdin to stdout: feeding a large stdin and draining a
+        // large stdout must proceed concurrently, or both sides deadlock.
+        let big = "a".repeat(200_000);
+        let cmd = Command::new("cat");
+        let output = run_with_timeout(cmd, Duration::from_secs(10), Some(&big))
+            .expect("large stdin echoed to stdout should complete");
+        assert!(output.status.success());
+        assert_eq!(output.stdout.len(), 200_000);
     }
 }

--- a/docs/designs/0044-optimization-levels.md
+++ b/docs/designs/0044-optimization-levels.md
@@ -1,0 +1,332 @@
+---
+id: 0044
+title: Optimization Levels (-O0/-O1/-O2/-O3)
+status: accepted
+tags: [compiler, codegen, process]
+feature-flag: none
+created: 2026-07-03
+accepted: 2026-07-03
+implemented:
+spec-sections: []
+superseded-by:
+---
+
+<!-- Note: Optimization levels are a compiler-internal policy, not a language
+     feature. They never change what a program means, only how fast/small the
+     emitted code is (see the Invariant below). No preview gate applies. -->
+
+# ADR-0044: Optimization Levels (-O0/-O1/-O2/-O3)
+
+## Status
+
+Accepted
+
+Steve endorsed the straw-man direction on RUE-245 ("sounds pretty good to me
+at the moment, and what i'd expect, but look into it"). This ADR documents and
+refines that direction after surveying how mainstream compilers assign passes
+to levels. It is a **policy/plan document**: it defines the contract each level
+promises and the pass-to-level mapping, but implements nothing. The
+implementation tasks (adding new passes and slotting them into levels) follow
+as separate Linear issues.
+
+## Summary
+
+Rue exposes the conventional `-O0`/`-O1`/`-O2`/`-O3` optimization levels. This
+ADR fixes what each level *promises* to a user (its cost/benefit contract) and
+which passes populate it, so that `-O2` and `-O3` stop being undefined
+placeholders that silently alias `-O1`. The single non-negotiable rule across
+every level is the **observable-behavior invariant**: for any program with
+defined behavior, exit code and I/O are byte-for-byte identical at `-O0`,
+`-O1`, `-O2`, and `-O3`. Levels may trade compile time, code size, and run time
+against each other; they may never change what a program computes. That
+invariant is mechanically enforced by the RUE-236 differential-opt harness,
+which is the prerequisite safety net for ever giving the higher levels
+distinct content.
+
+## Context
+
+Today the Rue compiler accepts `-O0` through `-O3` (`OptLevel` in
+`crates/rue-cfg/src/opt/mod.rs`, driven by `-O<level>` in `crates/rue/src/main.rs`),
+but the mapping is:
+
+| Level | Today's behavior |
+|-------|------------------|
+| `-O0` | Nothing. CFG passes straight to lowering (plus the always-on structural `verify()`). |
+| `-O1` | Constant folding ⇄ store-to-load constant propagation to a fixpoint, then dead-code elimination. |
+| `-O2` | **Aliases `-O1`.** |
+| `-O3` | **Aliases `-O1`.** |
+
+So the only behavioral fork is `-O0` vs `-O1+`; `-O2`/`-O3` are reserved names
+with no distinct meaning. RUE-245 asks us to *deliberately decide* what belongs
+at each level rather than leave the top two as accidental synonyms — both so
+users get the contract they expect from `-O` flags, and so that when we do add
+inlining / CSE / peephole / loop passes, there is already a documented home for
+each.
+
+### The current pipeline (ground truth)
+
+The optimizer lives entirely in `crates/rue-cfg/src/opt/` and runs as
+CFG → CFG transforms between CFG construction and MIR lowering. `optimize()` is
+the single choke point every build funnels through:
+
+```
+AIR -> CfgBuilder -> CFG -> [opt::optimize(level)] -> CfgLower -> MIR -> RegAlloc -> Emit
+```
+
+The passes that exist:
+
+- **`constfold.rs`** — folds arithmetic/comparison/bitwise/unary ops on
+  `Const` operands (with overflow and div-by-zero guards). Complements the
+  RIR-level `try_evaluate_const` from ADR-0003.
+- **`constprop.rs`** — store-to-load constant propagation for single-assignment
+  local slots, so constants flow through chains of `let`s (RUE-154). Interleaved
+  with `constfold` to a fixpoint.
+- **`dce.rs`** — liveness-based dead-code elimination: drops unused values and
+  unreachable blocks, preserving side-effecting instructions (calls, stores,
+  intrinsics, drops).
+
+`cfg.verify()` (RUE-227) runs at **every** level, `-O0` included — it is a
+correctness check, not an optimization, so it is outside the level contract.
+
+### Why this is timely
+
+The RUE-236 differential-opt harness (landed, PR #1092) runs a marked subset of
+CLI cases across `["-O0", "-O1", "-O2", "-O3"]` and asserts identical exit code
+and stdout at every level (`run_case_differential` in
+`crates/rue-cli-tests/src/main.rs`, gated by `differential_opt = true`). It was
+deliberately set up *now*, while `-O2`/`-O3` still alias `-O1`, so the results
+already match and any future divergence a new pass introduces is caught the
+moment it appears. The `rue-cfg` review exercised exactly this net when it
+caught the RUE-348 enum-fold miscompile. With that net in place, we can safely
+start populating the higher levels.
+
+## Prior art: how mainstream compilers assign passes to levels
+
+The industry consensus is remarkably uniform. The levels are a *cost ladder*:
+each rung buys more run-time performance (or smaller size) with more compile
+time and, from `-O2` up, more divergence between emitted code and source
+structure.
+
+**GCC** ([Optimize-Options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html)):
+
+- `-O0`: no optimization; fastest compile, best debugging. Default.
+- `-O1`: the cheap, almost-always-worth-it set — basic DCE/DSE, simple inlining,
+  jump/branch cleanups, if-conversion. Reduces code *and* compile time vs naive.
+- `-O2`: the recommended release level — turns on nearly all optimizations that
+  do **not** involve a space/speed tradeoff: global CSE, loop strength
+  reduction, more inlining, and (in modern GCC) vectorization.
+- `-O3`: `-O2` plus the transforms that may **grow code** to chase speed —
+  aggressive `-finline-functions`, `-frename-registers`, heavier loop work.
+- `-Os`: `-O2` minus anything that tends to increase size; `-Oz`: size at all
+  costs.
+
+**Clang / LLVM** ([Clang User Manual](https://clang.llvm.org/docs/UsersManual.html)):
+Same ladder. `-O1` = quick, keeps most debug info; `-O2` = "all optimization"
+(the balanced default most software ships with); `-O3` = `-O2` plus transforms
+that take longer or **generate larger code** to run faster — chiefly aggressive
+loop unrolling, more inlining, and auto-vectorization. `-Os`/`-Oz` optimize for
+size.
+
+**rustc** ([rustc codegen options](https://doc.rust-lang.org/rustc/codegen-options/index.html)):
+Feeds LLVM's pass-manager builder. `opt-level` 0/1/2/3 plus `s`/`z`. Both `2`
+and `3` optimize for speed at the expense of size; **`3` does more
+vectorization and inlining than `2`**. Loops are unrolled at `>= 2`. `s`/`z`
+sharply lower the inline threshold to shrink binaries (`z` smaller than `s`).
+
+**Zig** ([Zig overview](https://ziglang.org/learn/overview/)): orthogonal axes
+rather than a single ladder — `Debug` (no opt, all safety checks),
+`ReleaseSafe` (optimized, safety checks retained), `ReleaseFast` (all major
+opts — inlining, vectorization, unrolling — safety checks off), `ReleaseSmall`
+(size). The instructive part for Rue is that Zig makes the *safety* dimension
+explicit and separate from the *optimization* dimension.
+
+### The consensus, distilled
+
+- **`-O0`** = no optimization; the debugging / fast-compile baseline; the level
+  whose codegen tracks source structure one-to-one.
+- **`-O1`** = the cheap, always-safe, compile-time-positive set: local folding,
+  propagation, DCE, trivial cleanups. Never a space/speed gamble.
+- **`-O2`** = the release default: the full set of *balanced* optimizations that
+  reliably help without blowing up code size — CSE, peephole, better regalloc,
+  conservative inlining. This is the level real software ships at.
+- **`-O3`** = `-O2` plus the *speculative* transforms that spend code size and
+  compile time to chase speed — aggressive inlining, loop unrolling, and
+  (eventually) vectorization — with no guarantee of a win on every program.
+- The size levels (`-Os`/`-Oz`) are a *separate* axis; Rue does not have them
+  yet (see Future Work).
+
+## Decision
+
+### The invariant (applies to all levels)
+
+> **For any Rue program whose behavior is defined, the observable behavior —
+> process exit code and all I/O — is identical at `-O0`, `-O1`, `-O2`, and
+> `-O3`.**
+
+Optimization is permitted to change only *non-observable* properties: compile
+time, binary size, instruction count/selection, register allocation, and run
+time. A pass that can change exit code or I/O for a well-defined program is a
+**miscompile**, not an optimization, regardless of level.
+
+Two clarifications that keep the invariant honest:
+
+1. **Undefined behavior is exempt.** A program that already has UB (e.g. reads
+   an uninitialized slot, overflows where overflow is UB) has no guaranteed
+   behavior to preserve, so levels may differ there. The invariant is a promise
+   about *defined* programs only — the same carve-out every optimizing compiler
+   makes.
+2. **Checked-arithmetic semantics are part of "defined behavior."** Rue's
+   overflow/div-by-zero traps are observable (they set the exit status), so no
+   level may optimize them away or let a fold silently wrap. `constfold` already
+   guards these; any future pass inherits the obligation. This is precisely the
+   class RUE-348 lived in.
+
+The invariant is not merely aspirational: it is **mechanically enforced** by the
+RUE-236 differential-opt harness. Every pass we add at `-O2`/`-O3` must keep the
+marked differential set green, and the marked set must grow to cover the code
+shapes each new pass targets (see Sequencing).
+
+### Level contract for Rue
+
+| Level | Contract | Passes (today) | Passes (planned home) |
+|-------|----------|----------------|-----------------------|
+| `-O0` | No optimization. Codegen tracks source; fastest compile; best debugging. **Default.** | none (only always-on `verify()`) | stays empty |
+| `-O1` | Cheap, always-safe, compile-time-neutral-or-positive local cleanups. | constfold ⇄ constprop (fixpoint) → DCE | + peephole/strength-reduction; simplify-cfg (block merging, jump threading) |
+| `-O2` | **Release default.** All balanced optimizations that reliably help without a size blow-up. Superset of `-O1`. | = `-O1` today | + CSE (GVN); conservative inlining (small/leaf fns); copy propagation; better regalloc |
+| `-O3` | `-O2` plus speculative, size-spending, speed-chasing transforms. Superset of `-O2`. | = `-O1` today | + aggressive inlining; loop opts (LICM, unrolling); later, vectorization |
+
+Rules that make the table a *contract* rather than a wishlist:
+
+- **Monotonic supersets.** `-O3 ⊇ -O2 ⊇ -O1 ⊇ -O0`. A higher level never *drops*
+  a lower level's pass; it only adds. This is the property `OptLevel::O1 |
+  OptLevel::O2 | OptLevel::O3` already encodes and that new passes must respect.
+- **`-O0` means `-O0`.** The default stays genuinely unoptimized so `-O0` remains
+  the reliable debugging baseline and the differential oracle's ground truth.
+- **`-O2` is the recommendation.** When Rue documents a "release build", it means
+  `-O2`. `-O3` is opt-in for users who measured a win.
+- **A pass's level is set by its cost/risk, not its cleverness.** Cheap + always-a-win
+  → `-O1`. Reliable-win-but-not-free → `-O2`. Might-grow-code / might-not-pay-off
+  → `-O3`. This is the same triage GCC/LLVM/rustc use.
+
+### How current passes map
+
+The passes that exist (`constfold`, `constprop`, `dce`) are exactly the "cheap,
+always-safe, local" set, so they belong at **`-O1`**, which is where they run
+today. **No code change is required to adopt this ADR**: the present behavior is
+already the correct `-O1` content, and `-O2`/`-O3` legitimately *alias* `-O1`
+until a genuinely `-O2`-class pass exists. Aliasing is the honest state when a
+level has no distinct content yet — it is not a bug, and the differential
+harness confirms the three levels agree. The `mod.rs` doc comment and the
+`OptLevel` variant docs already describe this; they stay accurate under this
+ADR.
+
+### How plausible future passes map
+
+These are *illustrative placements*, not commitments — each lands via its own
+Linear issue and ADR-if-warranted, and each must ship with differential
+coverage. Placement follows the cost/risk triage above:
+
+- **Peephole / strength reduction** (`x*2 → x<<1`, `x/const` → mul-shift):
+  cheap, local, always-a-win → **`-O1`**.
+- **CFG simplification** (empty-block removal, jump threading, block merging):
+  cheap, enables later passes → **`-O1`**.
+- **Common subexpression elimination / GVN**: reliable win, moderate cost →
+  **`-O2`**.
+- **Copy propagation, more aggressive DCE**: **`-O2`**.
+- **Conservative inlining** (small / single-use / leaf functions): reliable win,
+  modest size cost → **`-O2`**.
+- **Register-allocation quality improvements** (better spilling, coalescing):
+  these live in `rue-codegen` (per-backend, post-CFG), but their *aggressiveness*
+  is gated by the same level knob → tuned up at **`-O2`**.
+- **Aggressive inlining** (larger thresholds, hot call sites): may grow code →
+  **`-O3`**.
+- **Loop optimizations** (invariant hoisting / LICM, unrolling): compile-time and
+  size cost, speculative payoff → **`-O3`**.
+- **Vectorization / SIMD**: far future, most speculative, per-backend → **`-O3`**.
+
+### Where the level knob lives
+
+`OptLevel` stays the single source of truth in `crates/rue-cfg/src/opt/mod.rs`,
+threaded through `optimize(cfg, level)`. As passes accrue, the `match` in
+`optimize()` gains per-level arms (e.g. `O2 | O3 => { cse::run(cfg); … }`)
+layered on top of the `O1` set, preserving the monotonic-superset rule.
+Codegen-side knobs (regalloc aggressiveness) read the same `OptLevel` rather
+than inventing a parallel flag, so there is one dial for the whole pipeline.
+
+## Implementation Phases
+
+This ADR is the plan; the phases below are *tracking placeholders* to be filed
+as Linear issues under RUE-245. **This ADR implements none of them.**
+
+- [x] **Phase 0: Differential net** — RUE-236 (done; PR #1092). Prerequisite.
+- [x] **Phase 1: Define the contract** — this ADR (RUE-245).
+- [ ] **Phase 2: `-O1` completions** — peephole/strength-reduction + simplify-cfg,
+  added at `-O1` with differential coverage. (file RUE-NNN)
+- [ ] **Phase 3: `-O2` content** — CSE/GVN, copy prop, conservative inlining;
+  `-O2` stops aliasing `-O1`. (file RUE-NNN)
+- [ ] **Phase 4: `-O3` content** — aggressive inlining + loop opts; `-O3` stops
+  aliasing `-O2`. (file RUE-NNN)
+- [ ] **Phase 5 (optional): size levels** — `-Os`/`-Oz` if a size-sensitive
+  target (WASM/embedded) materializes. (file RUE-NNN)
+
+Each of Phases 2–4 must, in the same change, (a) place the pass at the level
+this ADR assigns, (b) add multi-case differential CLI coverage for the code
+shapes the pass rewrites, and (c) keep the full differential set green.
+
+## Consequences
+
+### Positive
+
+- **`-O2`/`-O3` gain defined meaning** instead of being accidental `-O1`
+  synonyms; users get the `-O` contract they expect from GCC/Clang/rustc.
+- **Every future pass has a documented home** decided by a consistent cost/risk
+  rule, so pass placement is not re-litigated case by case.
+- **The invariant is explicit and enforced**, making "optimization" vs
+  "miscompile" a bright line the differential harness already polices.
+- **Zero code churn to adopt**: today's behavior is already the correct `-O1`,
+  and aliasing is the honest state for empty upper levels.
+
+### Negative
+
+- **Growing the differential set is now mandatory** for every opt PR — more test
+  authoring per pass (deliberate: coverage must follow capability, the gap that
+  let RUE-311 ship).
+- **Higher levels will eventually diverge in codegen**, so `-O3` bug reports may
+  not reproduce at `-O0`; the differential harness is the mitigation.
+
+### Neutral
+
+- **No language-semantics change; no spec sections; no preview gate.** Levels are
+  compiler-internal policy (echoing ADR-0012's framing).
+- **`-O0` remains the default**, matching debug-first ergonomics until a release
+  profile decides otherwise.
+
+## Open Questions
+
+- **Should `-O2` become the default for a future `--release`/`build` mode?** Out
+  of scope here; this ADR only defines what each level *contains*, not which the
+  driver picks. (Relates to RUE-45's release-CI work.)
+- **Do we want `-Os`/`-Oz`?** Deferred until a size-sensitive target exists
+  (Phase 5).
+
+## Future Work
+
+- Size-optimization axis (`-Os`/`-Oz`) — separate cost axis, per prior art.
+- A possible Zig-style split of the *safety* dimension from the *optimization*
+  dimension, if Rue ever gains checks that a level might elide. Today Rue's
+  traps are always-on and observable, so there is no such axis yet.
+- Profile-guided and link-time optimization — far future, their own ADRs.
+
+## References
+
+- [ADR-0012: Compiler Optimization Passes](0012-optimization-passes.md) — the
+  CFG opt framework and the original (now refined) level table this ADR builds on.
+- [ADR-0003: Constant Expression Evaluation](0003-constant-evaluation.md) —
+  RIR-level folding that `constfold` complements.
+- RUE-245 (this design), RUE-236 (differential-opt harness, the enforcing net),
+  RUE-45 (release-mode CI), RUE-348 (enum-fold miscompile the net caught),
+  RUE-311 (heap corruption a coverage gap let ship).
+- [GCC Optimize Options](https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html)
+- [Clang User Manual — Optimization](https://clang.llvm.org/docs/UsersManual.html)
+- [rustc Codegen Options — opt-level](https://doc.rust-lang.org/rustc/codegen-options/index.html)
+- [Zig Language Overview — build modes](https://ziglang.org/learn/overview/)

--- a/docs/designs/0045-lazy-semantic-analysis.md
+++ b/docs/designs/0045-lazy-semantic-analysis.md
@@ -1,0 +1,350 @@
+---
+id: 0045
+title: Lazy semantic analysis (compile-on-reference)
+status: accepted
+tags: [compiler, semantics, comptime, modules, stdlib, language-shape]
+feature-flag: lazy-analysis
+created: 2026-07-03
+accepted: 2026-07-03
+implemented:
+spec-sections: []
+relates: ["ADR-0025", "ADR-0026", "ADR-0042", "RUE-315", "RUE-328"]
+---
+
+# ADR-0045: Lazy semantic analysis (compile-on-reference)
+
+## Status
+
+**Accepted — ratified by Steve, 2026-07-03 (RUE-328, out of the ADR-0042
+discussion).** The *design* is decided (Zig-style lazy analysis, rolled out
+incrementally); the implementation is tracked separately and broken into Linear
+tasks after this ADR lands. This ADR documents the decided model, not a menu of
+options.
+
+## Summary
+
+Rue analyzes **only the declarations that are actually referenced**, transitively
+from a program's entry point (`main`, the *reference root*). A declaration that
+nothing reaches — on the current target, with the current comptime configuration
+— is never type-checked, lowered, or codegen'd. This is the Zig model, chosen
+deliberately over "check everything by default." Its headline consequence is
+**conditional compilation for free**: a `@target_os()`/`@target_arch()` comptime
+branch that is false on the current target selects code that is never analyzed,
+so platform-specific declarations simply don't need to compile off-target — no
+`#ifdef`, no `cfg`, no preprocessor. This falls out of comptime (ADR-0025) plus
+lazy analysis, and it is the primary motivation, not merely a compile-time
+optimization. The accepted tradeoff is the Zig bet: a type error in an
+*unreferenced* declaration stays hidden until something references it. A future
+opt-in `check-all` mode may force full analysis for CI / library validation, but
+the model **must not depend on it**.
+
+## Context
+
+### The pressure: a growing `std` and off-target code
+
+ADR-0042 (std availability, Option C) commits Rue to an explicit
+`@import("std")` bundle backed by a comptime-source standard library — generic
+type functions (`Option(T)`, `Vec(T)`, `StrBuf`) instantiated on use. Two forces
+make **eager, whole-program** semantic analysis untenable as that library grows:
+
+1. **Cost.** Eagerly analyzing every declaration in `std` (and every
+   `@import`ed module) on every compile scales with the size of the library, not
+   the size of the program. A hello-world that imports `std` should not pay to
+   type-check `Vec`, `HashMap`, and the parser combinators nobody called.
+2. **Correctness across targets.** More fundamentally, eager analysis *forces
+   off-target code to compile*. A function that calls a Windows-only syscall
+   wrapper cannot be type-checked on Linux if the wrapper's types don't exist
+   there. Under eager analysis you need a preprocessor (`#ifdef`/`cfg`) to
+   physically remove that code before the type-checker sees it. Rue does not want
+   a preprocessor — it wants comptime to be the *only* metaprogramming layer.
+
+Rue already does on-demand work in one place: **comptime monomorphization**
+(ADR-0025). A generic function `fn id(comptime T: type, x: T) T` is not analyzed
+as a template; it is analyzed *per instantiation*, when a concrete `T` is
+supplied at a call site. Lazy semantic analysis is the generalization of that
+principle from "generic instantiations" to "all declarations": nothing is a
+template the compiler eagerly walks; everything is analyzed the first time it is
+reached from the reference root.
+
+### Why the pure Zig model (not check-all-by-default)
+
+The considered alternative was a **hybrid**: analyze lazily for speed, but still
+walk every declaration once ("check-all by default") so that dead code is still
+type-checked. Steve chose the **pure** model instead, because the conditional-
+compilation payoff *requires* it: if off-target declarations are still checked,
+`@target_os` branches don't give you free conditional compilation — the
+Windows-only code must still type-check on Linux, which is exactly the problem.
+You cannot have both "dead code is always checked" and "off-target code need not
+compile." Rue picks the second. Check-all becomes an **opt-in mode** (see below),
+never the default, and the language semantics are defined so that programs never
+*rely* on unreferenced code being checked.
+
+## Decision
+
+### 1. The reference root and the analysis frontier
+
+Analysis is a **reachability walk** over declarations, seeded from a set of
+**reference roots** and driven by references discovered during analysis.
+
+- **Reference root (the seed).** For an executable, the root is the program's
+  `main`. Analysis begins at `main`, and a declaration is analyzed the first time
+  it is referenced from an already-analyzed declaration — a called function, a
+  named type, a read constant, an instantiated generic. The transitive closure of
+  references from the roots is the **analyzed set**; everything else is the
+  **unanalyzed remainder** and is, by design, unchecked.
+- **References that pull a declaration in** include: a call or method resolution,
+  a type appearing in a signature/annotation/struct field that must be laid out,
+  a `const` whose value is read, a comptime evaluation that touches a declaration,
+  and a generic instantiation (which pulls the *specific monomorphization*, per
+  ADR-0025, not the generic body abstractly).
+- **The frontier is comptime-configured.** Reachability is computed *after* the
+  comptime facts of the current build are known — target OS/arch, comptime
+  constants, `@import` results. A branch that comptime-evaluates to false
+  contributes no references, so its body never enters the analyzed set. This is
+  the mechanism behind conditional compilation (§4).
+
+### 2. Eager → on-demand across the pipeline
+
+The compiler pipeline (Lexer → Parser → AstGen → Sema → CfgBuilder → Lower →
+RegAlloc → Emit → Link) is today driven eagerly: each pass processes *every*
+item before the next pass runs. Lazy analysis reorganizes the front half of the
+pipeline to be **demand-driven per declaration**, converging on the model
+comptime monomorphization already uses:
+
+| Stage | Today (eager) | Under lazy analysis |
+|-------|---------------|---------------------|
+| Lexer | whole file | whole file (unchanged — lexing is cheap, and a file is the unit of parse) |
+| Parser → AST | whole file | whole file, but a **module is not parsed until referenced** (§3) |
+| AstGen → RIR | every item | still builds RIR for parsed items (untyped, cheap); this is the "declaration index" the frontier walks |
+| **Sema → AIR** | every item | **on demand**: a declaration is type-checked the first time the frontier reaches it; results are memoized so a declaration is analyzed at most once (or once per monomorphization) |
+| CfgBuilder → CFG | every function | only for functions in the analyzed set |
+| Lower → MIR | every function | only for functions in the analyzed set |
+| RegAlloc / Emit / Link | every function | only for functions in the analyzed set |
+
+The key move is at **Sema**: it becomes a memoized, reentrant query
+("analyze declaration D") rather than a pass over a list. Lowering and codegen
+then naturally process only what Sema produced. RIR/AstGen stays eager *per
+parsed file* because it is cheap and gives the frontier a name-indexed table of
+declarations to resolve references against; what lazy analysis avoids is the
+expensive part — type-checking, layout, CFG, lowering — for unreferenced decls.
+
+Parsing granularity is a **file** (a module is parsed whole or not at all);
+analysis granularity is a **declaration**. That split is deliberate: it makes the
+first rollout (lazy *module* loading) a coarse, low-risk cut, with per-declaration
+laziness layered on later (§6).
+
+### 3. Lazy module / `@import` loading
+
+The coarse-grained first increment: an `@import`ed module is **not read, parsed,
+or analyzed until a name from it is referenced**. `@import("std")` binds a
+namespace handle; touching `std.Vec` is what forces `std`'s `Vec` submodule to be
+located, parsed, and analyzed. Consequences:
+
+- **`std` is structured as fine-grained submodules** so that importing the bundle
+  pulls in only the pieces actually used. A program that uses `std.Option` does
+  not parse `std.Hash`. This is where most of the compile-time win lands with the
+  least machinery, and it is why the rollout starts here (RUE-315 provides the
+  `std` bundle + namespacing this rides on).
+- Module resolution and parse become **demand-driven queries** keyed by the
+  imported path, memoized so each module is parsed at most once.
+- A module that is imported but never dereferenced is never even parsed — so a
+  syntax error inside an unreferenced submodule is, like a type error, not
+  surfaced until something reaches it. Same Zig bet, one stage earlier.
+
+### 4. Conditional compilation for free (the headline)
+
+Because the reachability frontier is computed against comptime facts, a comptime
+`if` on the target selects which declarations are analyzed:
+
+```rue
+fn open_console() {
+    if @target_os() == .windows {
+        win_alloc_console();   // analyzed ONLY when target_os == windows
+    } else {
+        posix_isatty();        // analyzed ONLY otherwise
+    }
+}
+```
+
+On Linux, `@target_os() == .windows` comptime-evaluates to false; the `then`
+branch contributes no references; `win_alloc_console` never enters the analyzed
+set and is **never type-checked or lowered**. It may reference Windows-only types
+that don't exist on this target — that is fine, because the compiler never looks
+at it. On Windows the branches swap. No preprocessor, no `cfg` attribute, no
+separate build-config language: conditional compilation is just comptime plus
+lazy analysis.
+
+This pattern (`@target_os()` / `@target_arch()` comptime branches guarding
+platform-specific declarations) is a **supported, tested** idiom, not an
+accident. The implementation work includes CLI cases that compile the *same*
+source for two targets and assert each target analyzes (and rejects errors in)
+only its own branch — the differential oracle for this feature is "an error
+planted in the off-target branch does not fail the on-target build, and vice
+versa."
+
+### 5. The accepted tradeoff and where `check-all` hooks in
+
+**The Zig bet.** A type error (or syntax error) in a declaration that nothing
+references is **not reported**. A library can ship a broken, unused `fn` and any
+program that doesn't call it compiles clean. This is the deliberate cost of the
+conditional-compilation payoff — the two are the same coin. Rue accepts it.
+
+**`check-all` (future, opt-in, non-load-bearing).** A later mode may force
+analysis of a broader set than the reference closure — e.g. "every `pub` item in
+the crate being built" — so that CI and library authors can validate code no test
+happens to reach. Its natural hook is **seeding the frontier with extra roots**:
+`check-all` adds all `pub` declarations (and, for a fully exhaustive mode, all
+declarations) to the root set before the reachability walk, then runs the exact
+same on-demand Sema. It changes *what is rooted*, not *how analysis works*.
+Crucially, the language is specified so that **no program's meaning depends on
+`check-all`**: it can only turn currently-hidden errors into reported ones; it can
+never change which code runs. That is what "the model must not depend on it"
+means, and it is why `check-all` can be added later without disturbing this ADR.
+
+### 6. Rollout (incremental)
+
+1. **Lazy module loading** (first): don't parse/analyze an `@import`ed module
+   until a name from it is referenced; ship `std` as fine-grained submodules
+   (rides on RUE-315). Most of the compile-time win, coarse granularity, lowest
+   risk.
+2. **Per-declaration laziness** (later, if profiling justifies it): make Sema a
+   memoized per-declaration query so unreferenced declarations *within an analyzed
+   module* are also skipped, and so intra-file `@target_os` branches get the same
+   free-conditional-compilation treatment as cross-module code.
+3. **`check-all` mode** (later, optional): opt-in extra roots for CI / library
+   validation, as in §5.
+
+Each step is independently shippable and independently valuable; the model is
+defined by the end state, but the language semantics (only referenced code is
+guaranteed checked) hold from step 1.
+
+### Scope boundary
+
+This ADR is **within-compilation laziness only**: within a single `rue` invocation,
+analyze only what the reference root reaches. **Cross-compilation incremental
+caching** — persisting analysis results between separate compiles, invalidation,
+a query database on disk — is a *separate, later* concern and explicitly out of
+scope here. The two are often conflated ("lazy/incremental"); this ADR is the
+first, and does not presuppose the second.
+
+## Implementation Phases
+
+Phases are recorded here for context; Steve breaks them into Linear tasks under
+RUE-328 after this ADR lands.
+
+- [ ] **Phase 1: Lazy module loading** — parse/analyze `@import`ed modules
+  on first reference; memoized module-resolution query. (rides on RUE-315)
+- [ ] **Phase 2: `std` as fine-grained submodules** — restructure the bundle so
+  import pulls only referenced pieces. (RUE-315)
+- [ ] **Phase 3: On-demand Sema** — memoized per-declaration `analyze(D)` query
+  seeded from `main`; CFG/Lower/codegen consume only the analyzed set.
+- [ ] **Phase 4: Conditional-compilation idiom + oracle** — `@target_os`/
+  `@target_arch` comptime branches as a supported pattern; differential CLI cases
+  compiling one source for two targets, asserting per-target branch selection and
+  that off-target errors don't fail the on-target build.
+- [ ] **Phase 5 (optional, later): `check-all` mode** — opt-in extra roots (all
+  `pub`, or all decls) for CI / library validation.
+
+## Consequences
+
+### Positive
+
+- **Conditional compilation with no preprocessor** — the headline. `@target_os`/
+  `@target_arch` comptime branches give platform-conditional code that falls out
+  of comptime + laziness, keeping comptime the single metaprogramming layer.
+- **Compile time scales with the program, not the library.** Importing `std`
+  costs only the parts used; a growing standard library stays cheap. This is what
+  makes ADR-0042's explicit-`std`-bundle model viable long-term.
+- **Consistent with comptime.** Generalizes the on-demand analysis comptime
+  monomorphization already does (ADR-0025) from generic instantiations to all
+  declarations — one mental model, not two.
+- **Off-target code need not compile on the host** — no `cfg`/`#ifdef` gymnastics,
+  no "stub the other platform's types" boilerplate.
+
+### Negative
+
+- **Unreferenced errors hide (the Zig bet).** Type/syntax errors in code no
+  reference reaches are not reported until reached. A library's untested, unused
+  function can be broken and still ship green. Mitigation is opt-in `check-all`
+  (later) plus the testing story below — but the model deliberately does not
+  *depend* on either.
+- **Sema becomes reentrant and memoized**, not a straight pass — more machinery,
+  and cycle handling (a declaration referencing itself / mutual reference) must be
+  explicit. This mirrors work comptime already required.
+- **Error ordering / determinism.** Which errors surface, and in what order,
+  depends on the reachability walk rather than source order; diagnostics must be
+  made deterministic (stable frontier ordering) so builds are reproducible.
+
+### Neutral
+
+- Parsing stays whole-file; only *which files/modules* are parsed becomes lazy at
+  first. Per-declaration parse laziness is not pursued (declarations are cheap to
+  keep as an untyped RIR index; the expensive stages are the ones made lazy).
+- Cross-compilation incremental caching is left for a future ADR; nothing here
+  forecloses it (the memoized-query shape is, in fact, a natural foundation for
+  it).
+
+## Testing and spec-traceability implications
+
+Lazy analysis interacts with Rue's two verification nets in a way that is
+**self-consistent rather than a problem**, and this is the reasoning that makes
+"unreferenced code is unchecked" acceptable in practice:
+
+- **Tests are reference roots.** A spec/CLI/UI test that exercises a feature
+  *references* the code implementing it, so that code is pulled into the analyzed
+  set and fully checked. **Covered code is force-analyzed by the very test that
+  covers it.** There is no "tested but unchecked" gap: coverage *is* analysis.
+- **`pub` library items are exercised by their tests, not by mere existence.** A
+  `pub fn` in `std` is checked when a test (or a program) references it — which,
+  under the traceability regime, is exactly when it has spec coverage. An
+  unreferenced *and* untested `pub` item is unchecked **by design**; that is the
+  Zig bet stated in coverage terms.
+- **Differential oracle.** The conditional-compilation idiom is validated by
+  compiling one source for multiple targets and asserting each target analyzes
+  only its branch (an error planted off-target does not fail the on-target build).
+  Any new codegen/ABI surface a target-specific branch introduces carries its own
+  multi-case CLI coverage in the same change, per the project's
+  coverage-follows-capability rule.
+- **`check-all` and CI.** If/when a `check-all` mode lands, CI may run it to close
+  the untested-`pub` gap for library crates — but because no program's meaning
+  depends on it, it is a *belt-and-suspenders* validation layer, not part of the
+  language definition.
+
+Net: the traceability check ("every normative paragraph has a test") continues to
+mean what it meant — a covered paragraph's implementation is analyzed because the
+test references it. What lazy analysis adds is that *un*covered, *un*referenced
+code is unanalyzed, which is the intended semantics, not a regression in the net.
+
+## Open questions
+
+Deferred to the implementation tasks; none block accepting the model:
+
+1. **Cycle handling** — the exact protocol for mutually-referential declarations
+   in the memoized Sema query (in-progress markers, error recovery).
+2. **Diagnostic determinism** — the canonical frontier-ordering that makes error
+   output reproducible independent of walk scheduling.
+3. **`check-all` root set** — when it lands, does "all decls" or "all `pub`
+   decls" become the default exhaustive set, and is it per-crate or whole-program?
+4. **Interaction with future incremental caching** — confirming the memoized-query
+   shape chosen here is the one a later on-disk cache wants.
+
+## Future Work
+
+- **Cross-compilation incremental caching** — persisting and invalidating
+  analysis results across compiles (separate ADR; out of scope here).
+- **`check-all` mode** — opt-in full analysis for CI / library validation (§5).
+
+## References
+
+- RUE-328 — Lazy semantic analysis (compile-on-reference); the decision recorded
+  here.
+- [ADR-0042](0042-std-availability-model.md) — std availability (Option C,
+  explicit `@import("std")` bundle); the pressure that motivates lazy analysis,
+  and which this ADR backs.
+- [ADR-0025](0025-comptime.md) — comptime; monomorphization is the existing
+  on-demand analysis this ADR generalizes, and the mechanism behind free
+  conditional compilation.
+- [ADR-0026](0026-module-system.md) — module system / `@import`; the loading path
+  made lazy in Phase 1.
+- RUE-315 — std bundle + `@import("std")` namespacing; Phases 1–2 ride on it.
+- Zig's lazy compilation / comptime conditional compilation — the model Rue adopts.

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -167,3 +167,5 @@ See [ADR-0005: Preview Features](0005-preview-features.md) for details on the ga
 | [0007](0007-hindley-milner-inference.md) | Hindley-Milner Type Inference | Implemented | types, compiler |
 | [0008](0008-affine-types-mvs.md) | Affine Types and Mutable Value Semantics | Accepted | types, semantics, ownership |
 | [0009](0009-struct-methods.md) | Struct Methods | Proposal | types, syntax |
+| [0044](0044-optimization-levels.md) | Optimization Levels (-O0/-O1/-O2/-O3) | Accepted | compiler, codegen, process |
+| [0045](0045-lazy-semantic-analysis.md) | Lazy Semantic Analysis (compile-on-reference) | Accepted | compiler, semantics, comptime |


### PR DESCRIPTION
- **RUE-132** (Part of): harness honesty/robustness — spec stdout byte-exact compare, differential_opt stdout requirement, error_contains-without-compile_fail rejected at load, run_with_timeout drains both pipes (no >64KB deadlock), golden-IR under timeout. 13 tests.
- **RUE-333**: form-feed no longer whitespace (lexer-vs-spec drift). Confirmed the split — Rust: FF=whitespace (verified via rustc); Zig: strict, not. Matched spec+Zig.
- **RUE-245** (Part of): ADR-0044 optimization-levels — GCC/Clang/rustc/Zig research → Rue's -O contract, observable-behavior-identical invariant.
- **RUE-328** (Part of): ADR-0045 lazy-semantic-analysis — documents the decided Zig-style model.

clippy clean; test.sh Pass 25, 100% traceability (705/705), oracle 0.

Fixes RUE-333

Generated with Claude Code