### PR TITLE
Flat-mode-deletion ADR, diagnostics hints, expressions-operator prose pass

### DIFF
--- a/crates/rue-air/src/sema/analysis.rs
+++ b/crates/rue-air/src/sema/analysis.rs
@@ -1090,6 +1090,15 @@ fn format_move_path(interner: &ThreadedRodeo, root_var: Spur, path: &[Spur]) -> 
     out
 }
 
+/// The standard fix hint appended to every use-after-move (E0205) diagnostic:
+/// Rue's mechanism for using a value without consuming it is to pass it by
+/// `borrow`, so naming the moved value makes the suggestion copy-pasteable
+/// (RUE-19 item 4). `name` is the value as it appears in the message (a bare
+/// variable like `b`, or a path like `o.a`).
+pub(crate) fn borrow_instead_of_move_help(name: &str) -> String {
+    format!("to use `{name}` after the move, pass it by borrow instead: `borrow {name}`")
+}
+
 /// Build the use-after-move error for a field access whose path (or one of
 /// its ancestor prefixes) was moved at `moved_span`.
 pub(crate) fn use_after_move_path_error(
@@ -1100,8 +1109,10 @@ pub(crate) fn use_after_move_path_error(
     moved_span: Span,
 ) -> CompileError {
     let path_str = format_move_path(interner, root_var, field_path);
+    let help = borrow_instead_of_move_help(&path_str);
     CompileError::new(ErrorKind::UseAfterMove(path_str), span)
         .with_label("value moved here", moved_span)
+        .with_help(help)
 }
 
 /// Build the error for a linear value that goes out of scope without being

--- a/crates/rue-air/src/sema/analysis/instructions.rs
+++ b/crates/rue-air/src/sema/analysis/instructions.rs
@@ -427,7 +427,8 @@ impl<'a> Sema<'a> {
                         ErrorKind::UseAfterMove(root_name.to_string()),
                         span,
                     )
-                    .with_label("value moved here", moved_span));
+                    .with_label("value moved here", moved_span)
+                    .with_help(super::borrow_instead_of_move_help(root_name)));
                 }
             }
 
@@ -583,7 +584,8 @@ impl<'a> Sema<'a> {
                         ErrorKind::UseAfterMove(root_name.to_string()),
                         span,
                     )
-                    .with_label("value moved here", moved_span));
+                    .with_label("value moved here", moved_span)
+                    .with_help(super::borrow_instead_of_move_help(root_name)));
                 }
             }
 

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -172,7 +172,10 @@ impl<'a> Sema<'a> {
                 },
                 UnifyResult::OccursCheck { var, ty } => ErrorKind::TypeMismatch {
                     expected: "non-recursive type".to_string(),
-                    found: format!("{var} = {ty} (infinite type)"),
+                    found: format!(
+                        "{var} = {} (infinite type)",
+                        ty.name_with_pool(&self.type_pool)
+                    ),
                 },
                 UnifyResult::NotSigned { ty } => {
                     ErrorKind::CannotNegate(ty.safe_name_with_pool(Some(&self.type_pool)))
@@ -259,7 +262,8 @@ impl<'a> Sema<'a> {
                                 ErrorKind::UseAfterMove(name_str.to_string()),
                                 inst.span,
                             )
-                            .with_label("value moved here", moved_span));
+                            .with_label("value moved here", moved_span)
+                            .with_help(super::borrow_instead_of_move_help(name_str)));
                         }
                     }
 
@@ -300,7 +304,8 @@ impl<'a> Sema<'a> {
                         ErrorKind::UseAfterMove(name_str.to_string()),
                         inst.span,
                     )
-                    .with_label("value moved here", moved_span));
+                    .with_label("value moved here", moved_span)
+                    .with_help(super::borrow_instead_of_move_help(name_str)));
                 }
             }
 

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -2448,7 +2448,8 @@ impl<'a> Sema<'a> {
                             ErrorKind::UseAfterMove(name_str.to_string()),
                             span,
                         )
-                        .with_label("value moved here", moved_span));
+                        .with_label("value moved here", moved_span)
+                        .with_help(super::analysis::borrow_instead_of_move_help(name_str)));
                     }
                 }
 
@@ -2545,7 +2546,8 @@ impl<'a> Sema<'a> {
                         ErrorKind::UseAfterMove(name_str.to_string()),
                         span,
                     )
-                    .with_label("value moved here", moved_span));
+                    .with_label("value moved here", moved_span)
+                    .with_help(super::analysis::borrow_instead_of_move_help(name_str)));
                 }
             }
 
@@ -3320,7 +3322,8 @@ impl<'a> Sema<'a> {
                         ErrorKind::UseAfterMove(root_name.to_string()),
                         span,
                     )
-                    .with_label("value moved here", moved_span));
+                    .with_label("value moved here", moved_span)
+                    .with_help(super::analysis::borrow_instead_of_move_help(root_name)));
                 }
             }
 

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -2826,7 +2826,7 @@ fn format_pattern(pattern: &chumsky::error::RichPattern<'_, TokenKind>) -> Strin
 /// The `file_id` is threaded in from the parser so that error spans point at
 /// the file being parsed; without it, spans would default to `FileId::DEFAULT`
 /// and multi-file compilations would attribute errors to the wrong file.
-fn convert_error(err: Rich<'_, TokenKind>, file_id: FileId) -> CompileError {
+fn convert_error(err: Rich<'_, TokenKind>, file_id: FileId, impl_spur: Spur) -> CompileError {
     let span = to_rue_span_with_file(*err.span(), file_id);
 
     // Build the base error from the reason
@@ -2872,6 +2872,14 @@ fn convert_error(err: Rich<'_, TokenKind>, file_id: FileId) -> CompileError {
             // opaque, so point the user at the rule. (RUE-19)
             let found_is_self =
                 matches!(found.as_ref(), Some(t) if t.name() == TokenKind::SelfValue.name());
+            // `impl` is Rust muscle memory: Rue has no `impl` blocks, so it
+            // lexes as a plain identifier and dies at item position with an
+            // opaque "expected item, found identifier". Point the user at where
+            // methods actually go. (RUE-19 item 4)
+            let found_is_impl = matches!(
+                found.as_ref().map(|m| &**m),
+                Some(TokenKind::Ident(s)) if *s == impl_spur
+            );
             let mut err = CompileError::new(
                 ErrorKind::UnexpectedToken {
                     expected: expected_str,
@@ -2881,6 +2889,11 @@ fn convert_error(err: Rich<'_, TokenKind>, file_id: FileId) -> CompileError {
             );
             if found_is_self {
                 err = err.with_help("methods take `self` as the first parameter");
+            } else if found_is_impl {
+                err = err.with_help(
+                    "Rue has no `impl` blocks; define methods inside the struct body, \
+                     e.g. `struct S { x: i32, fn m(self) -> i32 { self.x } }`",
+                );
             }
             err
         }
@@ -3109,6 +3122,12 @@ impl ChumskyParser {
         // (tens of KB per nesting level), so a 256-deep parse would blow the
         // default thread stack. The nesting pre-scan above caps the depth; the
         // roomy stack here ensures the capped depth parses cleanly.
+        // Pre-intern `impl` so `convert_error` (which runs on the parse thread
+        // without the interner) can recognize the Rust-muscle-memory `impl`
+        // identifier and offer a targeted hint (RUE-19 item 4). Interning here
+        // shares the lexer's interner, so the returned spur matches any lexed
+        // `impl` token.
+        let impl_spur = self.interner.get_or_intern("impl");
         let tokens = std::mem::take(&mut self.tokens);
         let source_len = self.source_len;
         let file_id = self.file_id;
@@ -3132,7 +3151,7 @@ impl ChumskyParser {
                     .map_err(|errs| {
                         let mut errors: Vec<CompileError> = errs
                             .into_iter()
-                            .map(|err| convert_error(err, file_id))
+                            .map(|err| convert_error(err, file_id, impl_spur))
                             .collect();
                         dedupe_parse_errors(&mut errors);
                         CompileErrors::from(errors)

--- a/crates/rue-ui-tests/cases/diagnostics/rust_refugees.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/rust_refugees.toml
@@ -11,7 +11,7 @@
 [section]
 id = "diagnostics.rust_refugees"
 name = "Rust-refugee diagnostics"
-description = "Targeted errors for `as` casts."
+description = "Targeted errors for Rust-isms: `as` casts and `impl` blocks."
 
 [[case]]
 name = "as_cast_targeted_error"
@@ -47,6 +47,35 @@ source = """
 fn main() -> i32 {
     let as = 40;
     as + 2
+}
+"""
+exit_code = 42
+
+[[case]]
+name = "impl_block_hint"
+description = """
+RUE-19 item 4: `impl` is Rust muscle memory. Rue has no `impl` blocks, so it
+lexes as a plain identifier and dies at item position with an opaque
+"expected item, found identifier". The error must point the user at where
+methods actually go (inside the struct body).
+"""
+source = """
+struct Block { x: i32 }
+impl Block {
+    fn foo(self) -> i32 { self.x }
+}
+fn main() -> i32 { 0 }
+"""
+compile_fail = true
+error_contains = ["Rue has no `impl` blocks", "inside the struct body"]
+
+[[case]]
+name = "impl_still_valid_as_identifier"
+description = "`impl` is NOT reserved; only an `impl` at item position gets the hint."
+source = """
+fn main() -> i32 {
+    let impl = 42;
+    impl
 }
 """
 exit_code = 42

--- a/crates/rue-ui-tests/cases/diagnostics/use_after_move_hint.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/use_after_move_hint.toml
@@ -1,0 +1,53 @@
+# Use-after-move (E0205) fix hints (RUE-19 item 4).
+#
+# A use-after-move already carries a beautiful labeled span ("value moved
+# here"), but it never told the user how to fix it. Rue's mechanism for using a
+# value without consuming it is to pass it by `borrow`, so every E0205 now ends
+# with a copy-pasteable hint naming the moved value.
+
+[section]
+id = "diagnostics.use_after_move_hint"
+name = "Use-after-move fix hints"
+description = "E0205 suggests passing the value by `borrow` instead of moving it."
+
+[[case]]
+name = "moved_variable_suggests_borrow"
+description = "A whole-variable move re-used at a later call site."
+source = """
+struct Big { a: i32, b: i32, c: i32, d: i32, e: i32 }
+fn consume(x: Big) -> i32 { x.a }
+fn main() -> i32 {
+    let b = Big { a: 1, b: 2, c: 3, d: 4, e: 5 };
+    let r1 = consume(b);
+    let r2 = consume(b);
+    r1 + r2
+}
+"""
+compile_fail = true
+error_contains = [
+    "use of moved value 'b'",
+    "value moved here",
+    "pass it by borrow instead: `borrow b`",
+]
+
+[[case]]
+name = "moved_field_path_names_the_path"
+description = """
+A moved field path re-used later names the exact path in the hint
+(`borrow o.i`), not just the root variable.
+"""
+source = """
+struct Inner { a: i32, b: i32, c: i32, d: i32 }
+struct Outer { i: Inner, x: i32 }
+fn consume(v: Inner) -> i32 { v.a }
+fn main() -> i32 {
+    let o = Outer { i: Inner { a: 1, b: 2, c: 3, d: 4 }, x: 5 };
+    let r = consume(o.i);
+    r + o.i.a
+}
+"""
+compile_fail = true
+error_contains = [
+    "use of moved value 'o.i",
+    "pass it by borrow instead: `borrow o.i",
+]

--- a/docs/designs/0046-delete-flat-mode.md
+++ b/docs/designs/0046-delete-flat-mode.md
@@ -1,0 +1,333 @@
+---
+id: 0046
+title: "Delete flat multi-file mode (all cross-file references go through @import)"
+status: accepted
+tags: [modules, semantics, cli, language-shape, ergonomics]
+created: 2026-07-03
+accepted: 2026-07-03
+implemented:
+spec-sections: ["10.3 (visibility)", "10.5 (program composition)"]
+supersedes:
+relates: ["ADR-0023", "ADR-0026", "RUE-180", "RUE-181", "RUE-116"]
+---
+
+# ADR-0046: Delete Flat Multi-File Mode
+
+## Status
+
+Accepted — Steve, 2026-07-02 ("i want to delete flat mode entirely"), tracked by
+RUE-181. This ADR designs **how** the deletion happens; it does not implement it.
+Implementation is broken into tracked tasks after this ADR lands.
+
+## Summary
+
+Today `rue a.rue b.rue -o prog` loads every listed file into **one flat global
+namespace**, so a function in `a.rue` can call a `pub` function in `b.rue` by its
+bare name with no `@import` (spec 10.5:2, marked *transitional*). This ADR deletes
+that behavior. After the deletion, **the command-line file list only seeds the
+compilation unit / module graph — it never creates a shared namespace.** Every
+cross-file reference must be reached through an `@import` module binding (ADR-0026),
+exactly as if the file had not been listed on the command line. A bare name that
+today resolves to another file becomes an "unresolved name" diagnostic. The change
+ships as a **warn-then-error** deprecation so existing multi-file programs get one
+release of migration lead time.
+
+## Context
+
+### Where flat mode came from
+
+ADR-0023 introduced multi-file compilation with a flat global namespace as an
+explicit stepping stone ("The UX is admittedly awkward … this is a stepping stone,
+not the final design"). ADR-0026 then introduced the real module system
+(`@import`, file-as-struct, directory modules, `pub`/private) and **superseded**
+the flat namespace on paper — but the flat namespace was never removed. Both
+mechanisms are live simultaneously today:
+
+- `@import("b")` returns a module value; `b.foo()` is a qualified reference. This
+  is the ADR-0026 model and the intended future.
+- Bare `foo()` resolving to a `pub fn foo` in another listed file is flat mode.
+  Spec 10.3:8 and 10.5:2 keep this alive as "transitional."
+
+### What RUE-180 already did
+
+The privacy-everywhere rule (RUE-180, merged 2026-06-11, spec 10.3:7) made
+visibility *uniform*: an item is usable outside its directory iff it is `pub`,
+whether its file was `@import`ed or merely listed (E0460 for an unqualified
+private reference; E0706 through a module). That closed flat mode's one genuine
+soundness anomaly — a shared namespace *without* a visibility gate.
+
+The consequence for this ADR is important: **flat mode's only remaining special
+case is "name resolution without an import."** It no longer has a privacy
+dimension. Deleting it is therefore a *resolution-only* change — we remove one
+name-lookup fallback (the cross-file scan of listed files) and keep every
+visibility rule exactly as RUE-180 left it. Nothing about `pub`, E0460, or E0706
+changes semantically; those rules simply stop having an unqualified-reference case
+to apply to, because unqualified cross-file references cease to exist.
+
+### Why delete it at all
+
+1. **Two ways to do one thing.** A `pub fn` in a sibling file is reachable two
+   ways (bare and `mod.foo`), which is exactly the redundancy ADR-0026 set out to
+   remove. New users can't tell which is idiomatic.
+2. **The flat namespace is program-global.** Names collide across the entire
+   compilation (spec 10.5:1, E0436), even between files that never reference each
+   other. That is a scaling dead-end and directly contradicts the per-module
+   scoping ADR-0026 promises. Flat mode is the reason 10.5:1 has to exist as a
+   collision rule at all.
+3. **The driver secretly changes semantics.** Whether `foo()` resolves depends on
+   whether some *other* file happened to be on the command line — spooky action at
+   a distance that `@import` makes explicit and local.
+4. **It blocks the module-scoping revision.** 10.5:2 explicitly says the flat
+   namespace is expected to be replaced by per-module scoping. That revision can't
+   land while bare cross-file resolution is a supported guarantee.
+
+## Decision
+
+### The rule
+
+> The list of source files on the `rue` command line **seeds the compilation
+> unit** (the set of files the driver will parse and make available to
+> `@import`). It does **not** introduce any name into any file's scope. A name
+> that is not declared in the current file, imported via `@import`, or provided
+> by the prelude is unresolved.
+
+Concretely, after deletion:
+
+```rue
+// a.rue
+pub fn helper() -> i32 { 42 }
+
+// main.rue
+fn main() -> i32 {
+    helper()                       // ERROR (post-deletion): unresolved name `helper`
+    let a = @import("a");          // the one supported path:
+    a.helper()                     // qualified reference through a module binding
+}
+```
+
+`rue main.rue a.rue -o prog` and `rue main.rue -o prog` become **semantically
+identical** for `main.rue`: listing `a.rue` no longer changes what names
+`main.rue` can see. Listing files remains meaningful only as a way to hand the
+driver a file set (and, transitionally, for whole-program checking — see below).
+
+### What stays exactly as-is
+
+- `@import` resolution, directory modules, facade files, `pub const` re-exports
+  (ADR-0026) — untouched.
+- The visibility rules of spec 10.3 (RUE-180) — untouched. E0460/E0706 keep their
+  meaning; they simply no longer fire on cross-file *unqualified* references,
+  because those are now unresolved-name errors, not privacy errors.
+- Duplicate-definition detection **within a directory / module** (E0436) — a
+  directory is still one module (ADR-0026), and two files in the same directory
+  defining the same top-level name still collide. What goes away is
+  *program-global* collision across unrelated directories, which was purely an
+  artifact of the flat namespace.
+- Single-file compilation (`rue main.rue -o prog`) — unaffected; it has no
+  cross-file references.
+
+### Migration sequence (warn → error)
+
+The compiler can and should warn before it errors. There is already a
+`WarningKind` / `CompileWarning` channel in `rue-error` (`UnusedVariable`,
+`UnreachableCode`, …); this adds one variant.
+
+- **Phase A — Warn (one release).** Bare cross-file resolution still *works*, but
+  every use emits a deprecation warning: *"`helper` is resolved through the
+  transitional flat namespace and will require an explicit `@import` in a future
+  release; add `const a = @import(\"a\"); … a.helper()`."* The warning is emitted
+  at the *use* site (where the bare name resolves to another file), carries a
+  machine-applicable suggestion where the fix is unambiguous, and is on by default
+  (not gated behind a flag) so it is visible to everyone still relying on the
+  mode. Programs that already use `@import` for all cross-file references see no
+  warning — the warning is a precise detector of flat-mode reliance.
+- **Phase B — Error.** The cross-file fallback in name resolution is deleted. A
+  bare name that used to resolve to another file now produces a normal
+  unresolved-name diagnostic. A **new diagnostic code** is allocated at
+  implementation time (E0461 is already taken by the type-definition graph; the
+  implementer picks the next free code in the module/name-resolution band and,
+  ideally, points the message at the `@import` fix). The transitional paragraphs
+  10.3:8 and 10.5:2 are struck from the spec, and 10.5:1's *program-global*
+  collision rule narrows to *intra-module* collision.
+
+Phase A is optional-but-recommended: because RUE-180 already made the behavior
+uniform, we *could* delete flat mode in a single step. The warn phase is cheap
+(one `WarningKind` + one resolver hook) and buys goodwill and a clean migration of
+our own test corpus (see blast radius), so this ADR recommends shipping it.
+
+### Ergonomics: the boilerplate gap and how we answer it
+
+Deleting flat mode means every file that references a sibling pays `@import`
+boilerplate. The honest worry: does this make small multi-file programs annoying?
+Three candidate mitigations, and this ADR's recommendation:
+
+1. **Prelude.** A small implicit prelude (ADR-0042 / RUE-315 territory) covers
+   *std* names, not *user* cross-file names, so it does **not** address this gap.
+   Out of scope here; it does not block deletion.
+2. **Project file (`rue.toml`) / directory auto-import.** A build-manifest or a
+   rule like "every file in a directory is implicitly in scope for its siblings"
+   would remove the boilerplate — but directory-auto-import is *precisely flat
+   mode scoped to a directory*, and re-introduces the "resolution depends on what
+   else is in the folder" spookiness we are deleting. If we ever want it, it
+   should be a **separate, deliberate ADR** with its own opt-in, not a silent
+   consolation prize bundled into this deletion.
+3. **Explicit `@import` only.** Accept the one-line-per-dependency cost.
+
+**Recommendation: ship the deletion with explicit `@import` only; do not block it
+on a prelude or a project file.** Rationale: (a) the boilerplate is one
+`const x = @import("x");` line per *distinct* sibling a file actually uses, which
+is proportionate and local; (b) it is exactly the Zig model ADR-0026 already chose,
+so it is not a new tax, just the removal of an undocumented shortcut; (c) bundling
+an auto-import mechanism into the deletion would re-create the very coupling we are
+removing. A prelude for *std* (ADR-0042) and a possible future `rue.toml` are
+tracked independently and can land whenever their own designs are ready — neither
+is a prerequisite for RUE-181.
+
+### `main.rue` and sibling discovery post-deletion
+
+Question: once bare cross-file names are gone, how does a program with
+`main.rue` + siblings hold together — does the driver auto-import the directory,
+or must `main.rue` `@import` each sibling?
+
+**Decision: `main.rue` must `@import` what it uses; the driver does not
+auto-import siblings.** The entry file is an ordinary module (ADR-0026:
+file-as-struct); it reaches siblings the same way any file does. The command-line
+file list seeds *which files are available to load*, but availability ≠ scope.
+This keeps one rule for all files (no special "the entry directory is magic" case)
+and matches ADR-0026's "filesystem is the source of truth, imports are explicit."
+
+The facade convention generalizes cleanly for the "many small siblings" case: a
+directory module's `_dir.rue` facade `pub const`-re-exports its submodules, so a
+consumer writes one `@import("dir")` and reaches everything the facade chooses to
+expose — the intended replacement for "throw all the files on the command line."
+
+Transitional note on the file list: today the driver both (a) discovers `main()`
+among the listed files and (b) makes all listed files mutually visible. After
+deletion only (a) survives, plus the whole-program *checking* extent (spec 10.5:4
+currently analyzes every loaded file eagerly). Whether a listed-but-never-imported
+file should still be *analyzed* (dead-correct checking) or dropped is an
+ADR-0026-lazy-analysis question (RUE-134) and is **out of scope** here; this ADR
+only removes cross-file *name resolution*, not the extent-of-analysis rule.
+
+### Interaction with privacy-everywhere (RUE-180)
+
+Already covered above, restated as the key invariant: **RUE-180 is the reason this
+deletion is small.** Because visibility is already uniform, removing flat mode
+removes *only* the unqualified cross-file resolution path — no visibility rule
+changes. Post-deletion, `pub` regains a single, honest meaning: "reachable
+**through an `@import`** from another directory." E0460 (unqualified private
+reference) loses its cross-file trigger entirely and becomes reachable only in the
+narrowing window before Phase B; after Phase B, a private *or* public sibling name
+used unqualified is uniformly an unresolved-name error, and privacy is enforced
+solely at the qualified `mod.item` access point (E0706). This is strictly simpler
+than today's split where the *same* cross-file reference is either E0460 (private)
+or silently-OK (pub) depending on visibility.
+
+## Implementation Phases
+
+Implementation is deferred; these phases are the task breakdown for RUE-181's
+follow-up issues (filed after this ADR lands, not before).
+
+- [ ] **Phase A: Deprecation warning** — add `WarningKind::FlatNamespaceReference`
+      (name + suggestion), emit it at the resolver site where a bare name resolves
+      to another file, on by default; UI test cases pinning the message. — RUE-181
+      follow-up
+- [ ] **Phase B: Delete resolution fallback** — remove the cross-file scan from
+      name resolution; allocate the new unresolved-cross-file diagnostic code;
+      narrow E0436 to intra-module. — RUE-181 follow-up
+- [ ] **Phase C: Spec update** — strike 10.3:8 and 10.5:2; rewrite 10.5:1 to
+      intra-module collision; adjust 10.3:7/10.5:4 wording; keep traceability 100%
+      (retarget or replace the flat-namespace example cases). — RUE-181 follow-up
+- [ ] **Phase D: Test-corpus migration** — add `@import` to the flat-mode cases in
+      the harnesses (see blast radius). — RUE-181 follow-up
+- [ ] **Phase E: Docs** — update CLAUDE.md "Multi-File Compilation" section and
+      ADR-0023/0026 cross-references to describe the file list as a module-graph
+      seed, not a shared namespace. — RUE-181 follow-up
+
+## Blast Radius (measured on trunk @ this ADR)
+
+Estimated by scanning the test corpora for multi-file cases that reach a sibling
+**without** an `@import` (i.e. genuinely rely on flat mode):
+
+| Harness | Flat-mode-reliant cases | Where |
+|---------|------------------------|-------|
+| CLI (`crates/rue-cli-tests/cases/`) | ~36 cases across 9 files | `basics`, `modules`, `multifile_errors`, `assoc_fn_privacy`, `arraybuf_library`, `const_init`, `emit_pipeline`, `output_guard`, `recursive_value_type` |
+| Spec (`crates/rue-spec/cases/`) | ~18 cases (of 29 `pass_aux_files=true`) | `modules/intra_directory` (15), `modules/composition` (2), `modules/bindings` (1) |
+
+Notes for the implementer:
+
+- The **spec `modules/composition` cases** directly *test the flat namespace's
+  collision behavior* (10.5:1/10.5:2). Those aren't "add an `@import`" migrations —
+  they are the cases whose *rule* changes in Phase C, so they get rewritten (or
+  moved to intra-module collision), not merely patched.
+- The `intra_directory` cases test RUE-180 visibility using bare references; most
+  migrate mechanically by wrapping the cross-file call in `@import` + qualified
+  access, and several are already redundant with the qualified-access cases.
+- CLI cases assert exact stdout; migrations must preserve the asserted output, so
+  each is a real (small) code edit, not a find-replace.
+- No compiler-crate error codes are allocated by this ADR; Phase B picks the code.
+
+This is a **bounded, mechanical** migration (~54 cases, no runtime-behavior
+changes for correctly-`@import`ing programs), which is why the warn phase is worth
+having: Phase A lets us migrate the corpus under a green warning before Phase B
+turns it red.
+
+## Consequences
+
+### Positive
+
+- **One way to reference another file** — `@import`, matching ADR-0026's whole
+  premise; removes the redundant bare-name path.
+- **Name resolution is local and explicit** — a file's meaning no longer depends
+  on its command-line neighbors.
+- **Unblocks per-module name scoping** — 10.5:1's program-global collision rule
+  can narrow to intra-module, the direction 10.5:2 always pointed at.
+- **`pub` gets a single honest meaning** — "reachable through an import," full
+  stop; privacy enforced only at the `mod.item` access point.
+- **Smaller spec** — two transitional paragraphs deleted, one collision rule
+  narrowed.
+
+### Negative
+
+- **Per-file import boilerplate** — one `@import` line per distinct sibling used.
+  Mitigated by facade re-exports; explicitly *not* mitigated by auto-import (which
+  we reject as re-introducing flat mode).
+- **Corpus migration cost** — ~54 test cases need `@import` added or rules
+  rewritten (bounded, mechanical; see blast radius).
+- **Breaking change for any external multi-file program** — mitigated by the
+  warn→error sequence and the fact that the fix is purely additive (`@import`).
+
+### Neutral
+
+- **Extent-of-analysis unchanged here** — whether a listed-but-unimported file is
+  still analyzed is left to the lazy-analysis work (RUE-134), not decided here.
+- **Prelude and `rue.toml` remain independent** — neither is required by this ADR;
+  both can land on their own timelines (ADR-0042 / RUE-315).
+
+## Open Questions
+
+1. **Skip the warn phase?** RUE-180 makes a single-step deletion sound. This ADR
+   recommends the warn phase for corpus-migration hygiene and external goodwill,
+   but Steve may choose to collapse A+B into one change.
+2. **Fate of listed-but-unimported files** — analyze eagerly (dead-correct) or
+   drop them? Deferred to RUE-134 / ADR-0026 lazy analysis; not blocking.
+
+## Future Work
+
+- **Per-module name scoping** — the 10.5:2 revision this deletion unblocks.
+- **Directory auto-import** — if ever wanted, a *separate* opt-in ADR, not a
+  silent rider on this one.
+- **`rue.toml` project file** — dependency and file-set declaration; independent.
+
+## References
+
+- [ADR-0023: Multi-File Compilation](0023-multi-file-compilation.md) — introduced
+  the flat namespace as a stepping stone.
+- [ADR-0026: Module System](0026-module-system.md) — `@import`, file-as-struct,
+  directory modules; superseded the flat namespace on paper.
+- [ADR-0042: Standard-library availability model](0042-std-availability-model.md) —
+  prelude vs. explicit std, independent of this deletion.
+- RUE-181 — this design's tracking issue ("delete flat mode entirely").
+- RUE-180 — privacy everywhere; made this deletion resolution-only.
+- RUE-116 — module-system epic; end-to-end `@import` correctness.
+- Spec chapter 10 (`docs/spec/src/10-modules/`) — 10.3 visibility, 10.5 program
+  composition; 10.3:8 and 10.5:2 are the paragraphs this deletion strikes.

--- a/docs/designs/README.md
+++ b/docs/designs/README.md
@@ -169,3 +169,4 @@ See [ADR-0005: Preview Features](0005-preview-features.md) for details on the ga
 | [0009](0009-struct-methods.md) | Struct Methods | Proposal | types, syntax |
 | [0044](0044-optimization-levels.md) | Optimization Levels (-O0/-O1/-O2/-O3) | Accepted | compiler, codegen, process |
 | [0045](0045-lazy-semantic-analysis.md) | Lazy Semantic Analysis (compile-on-reference) | Accepted | compiler, semantics, comptime |
+| [0046](0046-delete-flat-mode.md) | Delete Flat Multi-File Mode | Accepted | modules, semantics, cli |

--- a/docs/spec/src/04-expressions/02-arithmetic-operators.md
+++ b/docs/spec/src/04-expressions/02-arithmetic-operators.md
@@ -10,7 +10,15 @@ template = "spec/page.html"
 
 {{ rule(id="4.2:1", cat="normative") }}
 
-Binary arithmetic operators take two operands of the same integer type and produce a result of that type.
+Binary arithmetic operators take two operands of the same integer type and
+produce a value of that same type (core calculus
+`docs/formal/01-core-calculus.md` §5.8, rule `(Arith)`). Each operator denotes
+the corresponding operation on the two operands' integer values, computed
+exactly over the mathematical integers: when that exact result lies within the
+operand type's range it is the value produced, and when it does not the
+operation traps at runtime rather than wrapping (§6.4, rules
+`(D-Arith)`/`(D-Arith-Trap)`; see 4.2:9). Division and remainder additionally
+trap on a zero divisor (4.2:11).
 
 | Operator | Name | Description |
 |----------|------|-------------|
@@ -58,7 +66,12 @@ fn main() -> i32 {
 
 {{ rule(id="4.2:6", cat="normative") }}
 
-The unary negation operator `-` takes a single signed integer operand and produces its arithmetic negation.
+The unary negation operator `-` takes a single signed integer operand and
+produces the arithmetic negation of the operand's value, computed exactly over
+the mathematical integers (core calculus `docs/formal/01-core-calculus.md` §6.4,
+the `neg` case of `(D-Arith)`). The only value whose negation is not
+representable is the type's minimum: negating it has no in-range result and
+traps at runtime (4.2:16), except for the compile-time literal case of 4.2:15.
 
 {{ rule(id="4.2:14", cat="legality-rule") }}
 
@@ -87,7 +100,10 @@ When a negated integer literal represents the minimum value of a signed integer 
 
 {{ rule(id="4.2:16", cat="dynamic-semantics") }}
 
-When negation is applied to a non-literal expression holding the minimum value of a signed integer type, the operation overflows and **MUST** cause a runtime panic.
+When negation is applied to a non-literal expression holding the minimum value
+of a signed integer type, the operation overflows and **MUST** cause a runtime
+panic (core calculus `docs/formal/01-core-calculus.md` §6.4: `neg (min_T)_T →
+↯overflow`).
 
 {{ rule(id="4.2:17") }}
 
@@ -103,7 +119,9 @@ fn main() -> i32 {
 
 {{ rule(id="4.2:9", cat="dynamic-semantics") }}
 
-Arithmetic operations that overflow the range of their type **MUST** cause a runtime panic.
+Arithmetic operations that overflow the range of their type **MUST** cause a
+runtime panic; the result is never silently wrapped or truncated (core calculus
+`docs/formal/01-core-calculus.md` §6.4, rule `(D-Arith-Trap)`).
 
 {{ rule(id="4.2:10") }}
 
@@ -117,7 +135,11 @@ fn main() -> i32 {
 
 {{ rule(id="4.2:11", cat="dynamic-semantics") }}
 
-Division or remainder by zero **MUST** cause a runtime panic.
+Division or remainder by zero **MUST** cause a runtime panic (core calculus
+`docs/formal/01-core-calculus.md` §6.4, rules `(D-Div-Zero)` and the
+corresponding `↯rem-zero` trap for `%`). Signed division or remainder of a
+type's minimum value by `-1` likewise traps as an overflow (§6.4,
+`(D-Div-Overflow)`).
 
 {{ rule(id="4.2:12") }}
 

--- a/docs/spec/src/04-expressions/03-comparison-operators.md
+++ b/docs/spec/src/04-expressions/03-comparison-operators.md
@@ -8,7 +8,11 @@ template = "spec/page.html"
 
 {{ rule(id="4.3:1", cat="normative") }}
 
-Comparison operators compare two values and produce a `bool` result.
+A comparison operator takes two operands of the same type and produces a `bool`
+(core calculus `docs/formal/01-core-calculus.md` §5.8, rule `(Eq)` for `==`/`!=`;
+§6.4, rules `(D-Eq)` and the ordering compares): the value produced is `true`
+exactly when the two operand values stand in the operator's relation, and
+`false` otherwise.
 
 ## Equality Operators
 
@@ -34,9 +38,10 @@ Two unit values are always equal.
 
 Equality on the aggregate types is **structural**: two aggregate values are
 equal if and only if they have the same type and their components — determined
-recursively by this rule down to scalar leaves — are equal. Specifically, two
-struct values are equal if and only if they have the same struct type and all
-corresponding fields are equal.
+recursively by this rule down to scalar leaves — are equal (core calculus
+`docs/formal/01-core-calculus.md` §6.4, the structural-equality relation `≈` of
+rule `(D-Eq)`). Specifically, two struct values are equal if and only if they
+have the same struct type and all corresponding fields are equal.
 
 {{ rule(id="4.3:3c", cat="normative") }}
 
@@ -59,8 +64,11 @@ and only if they hold the same address. The pointees are not examined.
 {{ rule(id="4.3:3f", cat="dynamic-semantics") }}
 
 Equality **borrows** its operands: evaluating `a == b` or `a != b` reads both
-operands without consuming them. An affine or linear value may therefore be
-compared without discharging its move obligation, and both operands remain
+operands without consuming them. When an operand is a named place it is read
+through a comparison-scoped shared loan rather than moved (core calculus
+`docs/formal/01-core-calculus.md` §4.1, §5.4, and the operand side condition of
+rule `(Eq)` in §5.8; dynamically §6.3). An affine or linear value may therefore
+be compared without discharging its move obligation, and both operands remain
 usable afterward.
 
 {{ rule(id="4.3:3g", cat="informative") }}
@@ -117,7 +125,11 @@ fn main() -> i32 {
 
 {{ rule(id="4.3:5", cat="normative") }}
 
-Ordering operators work only on integers.
+Ordering operators work only on integers. They compare the two operands by their
+integer values, respecting the signedness of the shared operand type — a signed
+type orders negatives below non-negatives, an unsigned type orders by magnitude
+(core calculus `docs/formal/01-core-calculus.md` §6.4: scalars compare by their
+integer value, respecting signedness).
 
 | Operator | Name | Description |
 |----------|------|-------------|

--- a/docs/spec/src/04-expressions/03a-bitwise-operators.md
+++ b/docs/spec/src/04-expressions/03a-bitwise-operators.md
@@ -12,7 +12,12 @@ Bitwise operators perform bit-level operations on integer values.
 
 {{ rule(id="4.3a:1", cat="normative") }}
 
-Binary bitwise operators take two operands of the same integer type and produce a result of that type.
+Binary bitwise operators take two operands of the same integer type and produce
+a value of that same type. Each operator acts on the two operands' `w`-bit
+two's-complement representations bit-by-bit and the result is that bit pattern
+reinterpreted at the operand type's signedness; unlike arithmetic, a bitwise
+operation never traps (core calculus `docs/formal/01-core-calculus.md` §6.4,
+rule `(D-Bit)`).
 
 | Operator | Name | Description |
 |----------|------|-------------|
@@ -41,7 +46,10 @@ The bitwise NOT operator `~` inverts all bits of its operand.
 
 {{ rule(id="4.3a:4", cat="normative") }}
 
-Bitwise NOT takes a single integer operand and produces a result of the same type.
+Bitwise NOT takes a single integer operand and produces a value of the same
+type whose bits are the complement of the operand's `w`-bit two's-complement
+representation, reinterpreted at that signedness (core calculus
+`docs/formal/01-core-calculus.md` §6.4, the `~` case of rule `(D-Bit)`).
 
 {{ rule(id="4.3a:5") }}
 
@@ -74,13 +82,16 @@ For right shift (`>>`), the behavior depends on the signedness of the operand ty
 - For unsigned types, vacated bit positions are filled with zeros (logical shift).
 - For signed types, vacated bit positions are filled with copies of the sign bit (arithmetic shift).
 
+(Core calculus `docs/formal/01-core-calculus.md` §6.4, rule `(D-Shr)`:
+sign-replicating on a signed operand type, zero-filling on an unsigned one.)
+
 {{ rule(id="4.3a:9", cat="normative") }}
 
 The shift amount operand **MUST** have the same type as the value being shifted.
 
 {{ rule(id="4.3a:10", cat="normative") }}
 
-If the shift amount is greater than or equal to the bit width of the type, the behavior is defined as shifting by the amount modulo the bit width. For example, shifting an `i32` by 33 positions is equivalent to shifting by 1 position.
+If the shift amount is greater than or equal to the bit width of the type, the behavior is defined as shifting by the amount modulo the bit width. For example, shifting an `i32` by 33 positions is equivalent to shifting by 1 position. (Core calculus `docs/formal/01-core-calculus.md` §6.4, rules `(D-Shl)`/`(D-Shr)`: the shift amount is reduced modulo the operand width `w` before shifting. Shifting never traps.)
 
 {{ rule(id="4.3a:11") }}
 

--- a/docs/spec/src/04-expressions/04-logical-operators.md
+++ b/docs/spec/src/04-expressions/04-logical-operators.md
@@ -14,7 +14,10 @@ Logical operators operate on `bool` values and produce `bool` results.
 
 {{ rule(id="4.4:2", cat="normative") }}
 
-The logical NOT operator `!` negates its operand.
+The logical NOT operator `!` takes a single `bool` operand and produces a
+`bool`: the result is `true` when the operand is `false` and `false` when the
+operand is `true` (core calculus `docs/formal/01-core-calculus.md` §6.4: `not
+true → false`, `not false → true`).
 
 {{ rule(id="4.4:3") }}
 
@@ -35,7 +38,7 @@ The logical AND operator `&&` returns `true` if both operands are `true`.
 
 {{ rule(id="4.4:5", cat="normative") }}
 
-The `&&` operator uses short-circuit evaluation: if the left operand is `false`, the right operand is not evaluated.
+The `&&` operator uses short-circuit evaluation: if the left operand is `false`, the right operand is not evaluated. This short-circuiting is why the core calculus carries no `&&` form of its own: elaboration removes the sugar by lowering `a && b` to an `if` that evaluates the right operand only on the branch the left operand selects (core calculus `docs/formal/01-core-calculus.md` §1; the taken-branch-only evaluation is §6.2).
 
 {{ rule(id="4.4:6") }}
 
@@ -54,7 +57,7 @@ The logical OR operator `||` returns `true` if either operand is `true`.
 
 {{ rule(id="4.4:8", cat="normative") }}
 
-The `||` operator uses short-circuit evaluation: if the left operand is `true`, the right operand is not evaluated.
+The `||` operator uses short-circuit evaluation: if the left operand is `true`, the right operand is not evaluated. As with `&&`, the core calculus carries no `||` form: elaboration lowers `a || b` to an `if` that evaluates the right operand only on the branch the left operand selects (core calculus `docs/formal/01-core-calculus.md` §1; the taken-branch-only evaluation is §6.2).
 
 {{ rule(id="4.4:9") }}
 


### PR DESCRIPTION
- **RUE-181** (Part of): ADR-0046 'Delete Flat Multi-File Mode' (Accepted) — warn→error migration to @import-only, explicit-import recommendation, measured blast radius (~36 CLI / ~18 spec cases). Docs only.
- **RUE-19** (Part of, items 2-4): use-after-move now suggests `borrow x`; `impl Block {}` gets a real hint; occurs-check <struct> name fixed. Item 3 refuted (already deduped).
- **RUE-202** (Part of, expressions): folk-terms retired in the operator sections against the formal core, verified by execution.

clippy clean; test.sh Pass 25, 100% traceability (705/705), oracle 0.

Generated with Claude Code