### PR TITLE
str type core, test-harness compile_fail honesty, types prose

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -280,19 +280,22 @@ impl<'a> ConstraintGenerator<'a> {
         }
     }
 
-    /// Is `ty` the synthetic slice struct `[T]` (ADR-0043, RUE-322)? A slice
-    /// parameter accepts an array argument by coercion (`sum(borrow a)`), so the
-    /// constraint generator must NOT impose strict `arg == param` equality when
-    /// the parameter is a slice; the real element-compatibility check and the
-    /// fat-pointer materialization happen in semantic analysis.
+    /// Is `ty` the synthetic slice struct `[T]` (ADR-0043, RUE-322) or the
+    /// `str` string type (RUE-324)? A slice parameter accepts an array argument
+    /// by coercion (`sum(borrow a)`), and a `str` position accepts a string
+    /// literal (whose HM type is `String`) by coercion, so the constraint
+    /// generator must NOT impose strict `arg == expected` equality when the
+    /// expected type is a slice or `str`; the real compatibility check and the
+    /// fat-pointer/`str` materialization happen in semantic analysis.
     fn is_slice_struct_type(&self, ty: InferType) -> bool {
         if let InferType::Concrete(t) = ty
             && let Some(id) = t.as_struct()
         {
             let name = &self.type_pool.struct_def(id).name;
-            return name.starts_with('[')
-                && name.ends_with(']')
-                && crate::types::parse_array_type_syntax(name).is_none();
+            return name == "str"
+                || (name.starts_with('[')
+                    && name.ends_with(']')
+                    && crate::types::parse_array_type_syntax(name).is_none());
         }
         false
     }
@@ -751,11 +754,19 @@ impl<'a> ConstraintGenerator<'a> {
                         .map(|ty| self.type_to_infer(ty))
                         .or_else(|| self.resolve_type_name(self.interner.resolve(ty_sym)));
                     if let Some(annotated_ty) = annotated {
-                        self.add_constraint(Constraint::equal(
-                            init_info.ty,
-                            annotated_ty.clone(),
-                            span,
-                        ));
+                        // A `str` annotation (ADR-0043 Phase 3, RUE-324) accepts
+                        // a string literal (HM type `String`) by coercion, and a
+                        // `[T]` slice annotation is second-class (rejected by
+                        // sema anyway); in both cases skip strict equality and
+                        // let sema materialize the value (mirrors the call-arg
+                        // slice/`str` coercion below).
+                        if !self.is_slice_struct_type(annotated_ty.clone()) {
+                            self.add_constraint(Constraint::equal(
+                                init_info.ty,
+                                annotated_ty.clone(),
+                                span,
+                            ));
+                        }
                         annotated_ty
                     } else {
                         // Unknown type name (e.g., struct/enum) - use init type for now.
@@ -788,8 +799,14 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::Assign { name, value } => {
                 let value_info = self.generate(*value, ctx);
                 if let Some(local) = ctx.locals.get(name) {
-                    // Constrain value to match variable type
-                    self.add_constraint(Constraint::equal(value_info.ty, local.ty.clone(), span));
+                    let local_ty = local.ty.clone();
+                    // A `str` target (ADR-0043 Phase 3, RUE-324) accepts a string
+                    // literal (HM type `String`) by coercion; skip strict
+                    // equality and let sema materialize the `str` on the store.
+                    if !self.is_slice_struct_type(local_ty.clone()) {
+                        // Constrain value to match variable type
+                        self.add_constraint(Constraint::equal(value_info.ty, local_ty, span));
+                    }
                 }
                 // Assignment produces unit
                 InferType::Concrete(Type::UNIT)
@@ -799,12 +816,17 @@ impl<'a> ConstraintGenerator<'a> {
             InstData::Ret(value) => {
                 if let Some(val_ref) = value {
                     let value_info = self.generate(*val_ref, ctx);
-                    // Constrain return value to match function return type
-                    self.add_constraint(Constraint::equal(
-                        value_info.ty,
-                        InferType::Concrete(ctx.return_type),
-                        span,
-                    ));
+                    // Constrain return value to match function return type. A
+                    // `str` return (ADR-0043 Phase 3, RUE-324) accepts a string
+                    // literal (HM type `String`) by coercion; skip strict
+                    // equality there and let sema materialize the `str`.
+                    if !self.is_slice_struct_type(InferType::Concrete(ctx.return_type)) {
+                        self.add_constraint(Constraint::equal(
+                            value_info.ty,
+                            InferType::Concrete(ctx.return_type),
+                            span,
+                        ));
+                    }
                 } else {
                     // Return without value - function must return unit
                     self.add_constraint(Constraint::equal(
@@ -1560,7 +1582,16 @@ impl<'a> ConstraintGenerator<'a> {
                         let value_info = self.generate(*value_ref, ctx);
                         if let Some(field_ty) = self.field_type_of(struct_ty, *field_name) {
                             let expected = self.type_to_infer(field_ty);
-                            self.add_constraint(Constraint::equal(value_info.ty, expected, span));
+                            // A `str` field (ADR-0043 Phase 3, RUE-324) accepts a
+                            // string literal (HM type `String`) by coercion; skip
+                            // strict equality and let sema materialize the `str`.
+                            if !self.is_slice_struct_type(expected.clone()) {
+                                self.add_constraint(Constraint::equal(
+                                    value_info.ty,
+                                    expected,
+                                    span,
+                                ));
+                            }
                         }
                     }
                     InferType::Concrete(struct_ty)

--- a/crates/rue-air/src/sema/analysis/calls.rs
+++ b/crates/rue-air/src/sema/analysis/calls.rs
@@ -22,14 +22,15 @@ impl<'a> Sema<'a> {
         let method_name_str = self.interner.resolve(&method).to_string();
 
         // Slice methods (ADR-0043, RUE-322): `s.len()` reads the fat pointer's
-        // runtime `len` word. Detected from the receiver's inferred type so it
-        // is intercepted before user/builtin method resolution.
-        if ctx
-            .resolved_types
-            .get(&receiver)
-            .copied()
-            .is_some_and(|ty| self.slice_element_type(ty).is_some())
-        {
+        // runtime `len` word. Detected from the receiver's type. The `str`
+        // string type (RUE-324) shares this path; a `str` local's HM-inferred
+        // type is `String` (inference does not model `str`), so the sema place
+        // type is consulted first (via `peek_place_type`) and only then the
+        // inferred type — otherwise `str.len()` would miss this route.
+        let receiver_slice_ty = receiver_var
+            .and_then(|_| self.peek_place_type(receiver, ctx))
+            .or_else(|| ctx.resolved_types.get(&receiver).copied());
+        if receiver_slice_ty.is_some_and(|ty| self.slice_element_type(ty).is_some()) {
             return self.analyze_slice_method(
                 air,
                 receiver,

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -390,8 +390,17 @@ impl<'a> Sema<'a> {
         // ======================================================================
         // Phase 3: AIR Emission
         // ======================================================================
-        // Analyze the body expression, emitting AIR with resolved types
+        // Analyze the body expression, emitting AIR with resolved types. A
+        // `str`-returning function (ADR-0043 Phase 3, RUE-324) supplies `str` as
+        // the expected type so an implicit-return string literal (the block's
+        // tail expression) materializes as a static-backed first-class `str`.
+        // Inner `let`s clear `expected_type` for their own initializers (they
+        // `take()` it), so this only reaches the tail value.
+        if self.is_str_struct(return_type) {
+            ctx.expected_type = Some(return_type);
+        }
         let body_result = self.analyze_inst(&mut air, body, &mut ctx)?;
+        ctx.expected_type = None;
 
         // Linear parameters: the callee owns its pass-by-value parameters and
         // drops them at exit unless moved out (RUE-61), so a by-value

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -598,6 +598,26 @@ impl<'a> Sema<'a> {
     ) -> CompileResult<Vec<AirCallArg>> {
         let mut air_args = Vec::with_capacity(args.len());
         for (i, arg) in args.iter().enumerate() {
+            // A `str` parameter (ADR-0043 Phase 3, RUE-324) is a first-class
+            // 2-word value, not a `borrow`-materialized fat pointer. A string
+            // literal argument materializes as a `str` under the expected type;
+            // a `str` variable is passed through by value. Either way it flows
+            // through the by-value aggregate ABI, so it is handled here before
+            // the array→slice `borrow` coercion below.
+            let is_str_param = param_types.get(i).is_some_and(|pt| self.is_str_struct(*pt));
+            if is_str_param {
+                let str_ty = param_types[i];
+                let prev_expected = ctx.expected_type.replace(str_ty);
+                let arg_result = self.analyze_inst(air, arg.value, ctx);
+                ctx.expected_type = prev_expected;
+                let arg_result = arg_result?;
+                air_args.push(AirCallArg {
+                    value: arg_result.air_ref,
+                    mode: AirArgMode::Normal,
+                });
+                continue;
+            }
+
             let is_slice_param = param_types
                 .get(i)
                 .is_some_and(|pt| self.slice_element_type(*pt).is_some());

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -140,11 +140,18 @@ impl<'a> Sema<'a> {
         // The function body's type must match the return type.
         // This handles implicit returns like `fn foo() -> i8 { 42 }`.
         // For arrays, we need to convert Type to InferType structurally.
-        cgen.add_constraint(Constraint::equal(
-            body_info.ty,
-            self.type_to_infer_type(return_type),
-            body_info.span,
-        ));
+        //
+        // A `str` return type (ADR-0043 Phase 3, RUE-324) accepts an
+        // implicit-return string literal (HM type `String`) by coercion; skip
+        // strict equality there and let sema materialize the static-backed
+        // first-class `str` at the tail expression.
+        if !self.is_str_struct(return_type) {
+            cgen.add_constraint(Constraint::equal(
+                body_info.ty,
+                self.type_to_infer_type(return_type),
+                body_info.span,
+            ));
+        }
 
         // Consume the constraint generator to release borrows
         let (constraints, int_literal_vars, expr_types, type_var_count) = cgen.into_parts();

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -405,8 +405,19 @@ impl<'a> Sema<'a> {
             }
 
             InstData::StringConst(symbol) => {
-                // String literals use the builtin String struct type.
-                let ty = self.builtin_string_type();
+                // A string literal is static-backed: its bytes live in `.rodata`
+                // (the local string table), and the value is the fat pointer to
+                // them. When a `str` is expected (ADR-0043 Phase 3, RUE-324) the
+                // literal materializes as the 2-word `str` `{ptr, len}`; the same
+                // `StringConst` AIR node lowers to only the ptr+len words there
+                // (the cap word is dropped in codegen). Otherwise it is the
+                // 3-word heap `String` as before.
+                let want_str = ctx.expected_type.is_some_and(|ty| self.is_str_struct(ty));
+                let ty = if want_str {
+                    ctx.expected_type.unwrap()
+                } else {
+                    self.builtin_string_type()
+                };
                 // Add string to the local string table (per-function for parallel analysis)
                 let string_content = self.interner.resolve(&*symbol).to_string();
                 let local_string_id = ctx.add_local_string(string_content);
@@ -2050,8 +2061,19 @@ impl<'a> Sema<'a> {
         ctx: &mut AnalysisContext,
     ) -> CompileResult<AnalysisResult> {
         let inner_air_ref = if let Some(inner) = inner {
-            // Explicit return with value
-            let inner_result = self.analyze_inst(air, inner, ctx)?;
+            // Explicit return with value. A `str`-returning function
+            // (ADR-0043 Phase 3, RUE-324) supplies `str` as the expected type so
+            // a string-literal `return "..."` materializes as a static-backed,
+            // first-class `str` (it cannot dangle, so returning it is sound).
+            let ret_ty = ctx.return_type;
+            let inner_result = if self.is_str_struct(ret_ty) {
+                let prev_expected = ctx.expected_type.replace(ret_ty);
+                let r = self.analyze_inst(air, inner, ctx);
+                ctx.expected_type = prev_expected;
+                r?
+            } else {
+                self.analyze_inst(air, inner, ctx)?
+            };
             let inner_ty = inner_result.ty;
 
             // Type check: returned value must match function's return type.
@@ -2272,7 +2294,11 @@ impl<'a> Sema<'a> {
         // thread it. Narrow to enums so unrelated `let`s are unaffected.
         let prev_expected = ctx.expected_type.take();
         if let Some(annot) = annotation_type {
-            if annot.is_enum() {
+            // A `str` annotation is the expected type for the initializer so a
+            // string literal `"..."` materializes as a 2-word static-backed
+            // `str` rather than the 3-word heap `String` (ADR-0043 Phase 3,
+            // RUE-324). Enums do the same for fallible-intrinsic `Option(T)`.
+            if annot.is_enum() || self.is_str_struct(annot) {
                 ctx.expected_type = Some(annot);
             }
         }
@@ -2859,9 +2885,21 @@ impl<'a> Sema<'a> {
         }
 
         let slot = local.slot;
+        let local_ty = local.ty;
 
-        // Analyze the value
-        let value_result = self.analyze_inst(air, value, ctx)?;
+        // Analyze the value. When the target is a `str` (ADR-0043 Phase 3,
+        // RUE-324), supply it as the expected type so a string literal RHS
+        // materializes as a 2-word `str` rather than a 3-word `String` (which
+        // would corrupt the 2-slot local); this is what makes `let mut s: str;
+        // s = "hi";` reassignment sound.
+        let value_result = if self.is_str_struct(local_ty) {
+            let prev_expected = ctx.expected_type.replace(local_ty);
+            let r = self.analyze_inst(air, value, ctx);
+            ctx.expected_type = prev_expected;
+            r?
+        } else {
+            self.analyze_inst(air, value, ctx)?
+        };
 
         // Assignment to a mutable variable resets its move state.
         ctx.moved_vars.remove(&name);
@@ -3074,6 +3112,15 @@ impl<'a> Sema<'a> {
                     span: field_inst.span,
                 });
                 AnalysisResult::new(air_ref, expected_field_type)
+            } else if self.is_str_struct(expected_field_type) {
+                // A `str`-typed field (ADR-0043 Phase 3, RUE-324): supply the
+                // field type as the expected type so a string-literal value
+                // materializes as a static-backed 2-word `str` (first-class,
+                // storable in a struct) rather than a 3-word `String`.
+                let prev_expected = ctx.expected_type.replace(expected_field_type);
+                let r = self.analyze_inst(air, *field_value, ctx);
+                ctx.expected_type = prev_expected;
+                r?
             } else {
                 // Not an integer literal - analyze normally
                 self.analyze_inst(air, *field_value, ctx)?
@@ -4256,6 +4303,25 @@ impl<'a> Sema<'a> {
             );
         }
 
+        // `str` byte indexing: `s[i]` reads the i-th BYTE of a `str` as `u8`
+        // (ADR-0043 Phase 3, RUE-324). A `str` is `[u8]` + UTF-8, but its bytes
+        // are PACKED (1 byte each in `.rodata`), unlike an array slice whose
+        // elements are 8-byte-slotted. So it cannot reuse the slice
+        // `@ptr_offset`/`@ptr_read` path (which strides by `slot_count * 8`);
+        // it lowers to the same packed-byte runtime read as `String`, but with
+        // the 2-word `{ptr, len}` receiver: `__rue_str_byte_at(ptr, len, index)`.
+        if self.is_str_struct(base_type) {
+            return self.analyze_str_index_get(
+                air,
+                base_result,
+                base_root,
+                base_move_state_before,
+                index,
+                span,
+                ctx,
+            );
+        }
+
         // Slice read-indexing `s[i]` (ADR-0043, RUE-322): the base is the
         // synthetic 2-word fat-pointer struct `{ptr, len}`. Lower to a
         // runtime-bounds-checked pointer load through the fat pointer's `ptr`
@@ -4424,6 +4490,77 @@ impl<'a> Sema<'a> {
         // argument registers, as for other builtin String methods); the move
         // was already cancelled above so this is a non-consuming read.
         let call_name = self.interner.get_or_intern("__rue_String_byte_at");
+        let extra = [
+            base_result.air_ref.as_u32(),
+            AirArgMode::Normal.as_u32(),
+            index_result.air_ref.as_u32(),
+            AirArgMode::Normal.as_u32(),
+        ];
+        let args_start = air.add_extra(&extra);
+        let call_ref = air.add_inst(AirInst {
+            data: AirInstData::Call {
+                name: call_name,
+                args_start,
+                args_len: 2,
+            },
+            ty: Type::U8,
+            span,
+        });
+        Ok(AnalysisResult::new(call_ref, Type::U8))
+    }
+
+    /// Analyze a `str` byte index read: `s[i] -> u8` (ADR-0043 Phase 3,
+    /// RUE-324).
+    ///
+    /// A `str` is `[u8]` + UTF-8, but its bytes are PACKED (1 byte each, in
+    /// `.rodata` for a literal), so indexing yields the i-th BYTE via a checked
+    /// runtime call `__rue_str_byte_at(ptr, len, index)` — the same packed-byte
+    /// read as `String`, minus the (nonexistent) `cap` word. The bounds check
+    /// lives in the runtime: an `index >= len` traps (exit 101), mirroring array
+    /// and `String` indexing rather than producing UB.
+    ///
+    /// Like `String` indexing, the read only *borrows* the receiver (a `str` is
+    /// `Copy` anyway), so the pre-analysis move state is restored and the move
+    /// marker cancelled.
+    fn analyze_str_index_get(
+        &mut self,
+        air: &mut Air,
+        base_result: AnalysisResult,
+        base_root: Option<Spur>,
+        base_move_state_before: Option<VariableMoveState>,
+        index: InstRef,
+        span: Span,
+        ctx: &mut AnalysisContext,
+    ) -> CompileResult<AnalysisResult> {
+        // Un-move the borrowed receiver (mirrors the String index path).
+        if let Some(var) = base_root {
+            match base_move_state_before {
+                Some(state) => {
+                    ctx.moved_vars.insert(var, state);
+                }
+                None => {
+                    ctx.moved_vars.remove(&var);
+                }
+            }
+        }
+        air.cancel_move_marker(base_result.air_ref);
+
+        // The index is an ordinary rvalue; require an integer (spec 7.1:7).
+        let index_result = self.analyze_inst(air, index, ctx)?;
+        if !index_result.ty.is_integer() && !index_result.ty.is_error() {
+            return Err(CompileError::new(
+                ErrorKind::TypeMismatch {
+                    expected: "an integer".to_string(),
+                    found: index_result.ty.safe_name_with_pool(Some(&self.type_pool)),
+                },
+                self.rir.get(index).span,
+            ));
+        }
+
+        // Lower to `__rue_str_byte_at(self, index) -> u8`. The 2-word `str`
+        // value is passed by value; codegen decomposes it into ptr/len argument
+        // registers, exactly as it decomposes the 3-word String for byte_at.
+        let call_name = self.interner.get_or_intern("__rue_str_byte_at");
         let extra = [
             base_result.air_ref.as_u32(),
             AirArgMode::Normal.as_u32(),

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -249,6 +249,68 @@ impl<'a> Sema<'a> {
         Ok(Type::new_struct(struct_id))
     }
 
+    /// Get (or lazily create) the synthetic 2-field struct that represents the
+    /// `str` string type (ADR-0043 Phase 3, RUE-324).
+    ///
+    /// `str` is `[u8]` + the UTF-8 byte-string convention (ADR-0035): a
+    /// read-only slice of bytes `{ ptr: ptr const u8, len: u64 }`, sharing the
+    /// slice fat-pointer representation so `.len()` and byte-indexing `s[i]`
+    /// reuse the slice machinery verbatim. Unlike a plain `[T]` slice, `str` is
+    /// **first-class**: string literals are static-backed (their bytes live in
+    /// `.rodata`, which cannot dangle), so a `str` value is storable, `Copy`,
+    /// and reassignable — it is exempt from the second-class-escape rule. The
+    /// struct is keyed by the name `str`, so every reference shares one
+    /// `StructId`.
+    fn get_or_create_str_struct(&mut self, span: Span) -> CompileResult<Type> {
+        use crate::types::{StructDef, StructField};
+
+        let type_sym = self.interner.get_or_intern("str");
+        if let Some(&struct_id) = self.structs.get(&type_sym) {
+            return Ok(Type::new_struct(struct_id));
+        }
+
+        let ptr_type_id = self.type_pool.intern_ptr_const_from_type(Type::U8);
+        let ptr_ty = Type::new_ptr_const(ptr_type_id);
+
+        let struct_def = StructDef {
+            name: "str".to_string(),
+            fields: vec![
+                StructField {
+                    name: "ptr".to_string(),
+                    ty: ptr_ty,
+                },
+                StructField {
+                    name: "len".to_string(),
+                    ty: Type::U64,
+                },
+            ],
+            // `str` is a copyable, static-backed view (no ownership of bytes).
+            is_copy: true,
+            is_linear: false,
+            destructor: None,
+            // Builtin so it never participates in user drop-glue etc.
+            is_builtin: true,
+            is_pub: true,
+            file_id: rue_span::FileId::new(0),
+        };
+        let (struct_id, _) = self.type_pool.register_struct(type_sym, struct_def);
+        self.structs.insert(type_sym, struct_id);
+        let _ = span;
+        Ok(Type::new_struct(struct_id))
+    }
+
+    /// Is `ty` the synthetic `str` struct (ADR-0043 Phase 3, RUE-324)? Detected
+    /// by the struct name being exactly `str`. Used to route string literals and
+    /// slice-style `.len()`/index operations through the fat-pointer paths while
+    /// keeping `str` first-class (exempt from the slice second-class rule).
+    pub(crate) fn is_str_struct(&self, ty: Type) -> bool {
+        if let TypeKind::Struct(struct_id) = ty.kind() {
+            self.type_pool.struct_def(struct_id).name == "str"
+        } else {
+            false
+        }
+    }
+
     /// If `ty` is a synthetic slice struct `[T]` (ADR-0043, RUE-322), return its
     /// element type `T`; otherwise `None`. Detected by the struct name being
     /// slice syntax (`[..]` that is not a fixed-array `[T; N]`), the same naming
@@ -256,10 +318,13 @@ impl<'a> Sema<'a> {
     pub(crate) fn slice_element_type(&self, ty: Type) -> Option<Type> {
         if let TypeKind::Struct(struct_id) = ty.kind() {
             let def = self.type_pool.struct_def(struct_id);
-            if def.name.starts_with('[')
+            // A `[T]` slice, or the `str` string type which is `[u8]` + UTF-8
+            // (ADR-0043 Phase 3, RUE-324): both are `{ptr: ptr const E, len}`
+            // fat pointers, so `.len()` and `s[i]` reuse one path.
+            let is_slice = def.name.starts_with('[')
                 && def.name.ends_with(']')
-                && parse_array_type_syntax(&def.name).is_none()
-            {
+                && parse_array_type_syntax(&def.name).is_none();
+            if is_slice || def.name == "str" {
                 // Field 0 is `ptr const T`; recover T from its pointee.
                 if let TypeKind::PtrConst(ptr_id) = def.fields[0].ty.kind() {
                     return Some(self.type_pool.ptr_const_def(ptr_id));
@@ -309,6 +374,14 @@ impl<'a> Sema<'a> {
         // Note: String is handled below via struct lookup (it's a builtin struct).
         if let Some(ty) = Type::from_primitive_name(type_name) {
             return Ok(ty);
+        }
+
+        // The `str` string type (ADR-0043 Phase 3, RUE-324): `[u8]` + UTF-8,
+        // gated behind `--preview string_trio`. Resolved to a first-class 2-word
+        // fat-pointer struct so it flows through the existing slice/struct paths.
+        if type_name == "str" {
+            self.require_preview(PreviewFeature::StringTrio, "the string type `str`", span)?;
+            return self.get_or_create_str_struct(span);
         }
 
         if let Some(&struct_id) = self.structs.get(&type_sym) {

--- a/crates/rue-cli-tests/cases/str_type.toml
+++ b/crates/rue-cli-tests/cases/str_type.toml
@@ -1,0 +1,138 @@
+# The `str` string type — executable regression tests (ADR-0043 Phase 3,
+# RUE-324).
+#
+# `str` is `[u8]` + the UTF-8 byte-string convention: a read-only two-word view
+# `{ptr, len}` that reuses the slice representation. String literals have type
+# `str` where a `str` is expected, and are STATIC-BACKED — their bytes live in
+# `.rodata`, and the value is `{ptr -> rodata bytes, len = byte length}` (a
+# 2-word value, not the 3-word heap `String`). Because static data cannot
+# dangle, a literal `str` is FIRST-CLASS: `@copy`, storable, reassignable,
+# returnable, passable.
+#
+# `.len()` reads the runtime `len` word (byte length). `s[i]` reads the i-th
+# PACKED byte via `__rue_str_byte_at(ptr, len, index)` (bounds-checked, traps
+# exit 101) — packed bytes, NOT the 8-byte-slotted stride an array slice uses.
+#
+# Deferred to later phases: `str` concat/comparison, `str`<->`String` interop,
+# methods beyond `.len()`/index, and char iteration.
+
+[section]
+id = "cli.str_type"
+name = "str type (ADR-0043 Phase 3)"
+description = "Static-backed first-class string literals: len(), packed byte-indexing, params, storage."
+
+# The canonical verify-by-execution: a `str` local, `.len()` == 5, and s[0] the
+# first byte 'h' == 104.
+[[case]]
+name = "str_len_and_first_byte"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: str = "hello";
+    let n: u64 = s.len();
+    let b: u8 = s[0];
+    if n == 5 && b == 104 { 42 } else { 0 }
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 42
+
+# Byte indexing sees raw packed bytes (a multibyte char decomposes into its
+# UTF-8 bytes), never char boundaries. "café" = c a f 0xC3 0xA9.
+[[case]]
+name = "str_packed_byte_indexing"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: str = "café";
+    @dbg(s.len());   // 5 bytes
+    @dbg(s[2]);      // 102 'f'
+    @dbg(s[3]);      // 195 0xC3
+    @dbg(s[4]);      // 169 0xA9
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 0
+stdout = "5\n102\n195\n169\n"
+
+# An out-of-bounds byte index traps at runtime (exit 101), like array/String.
+[[case]]
+name = "str_index_out_of_bounds_traps"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: str = "hi";
+    let b: u8 = s[5];
+    @intCast(b)
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 101
+
+# A `str` parameter receives a string literal (first-class argument) and a
+# forwarded `str` variable, both by value.
+[[case]]
+name = "str_param_literal_and_forward"
+files = [{ path = "main.rue", source = """
+fn first_byte(s: str) -> u8 {
+    s[0]
+}
+fn len_of(s: str) -> u64 {
+    s.len()
+}
+fn main() -> i32 {
+    let lit: u8 = first_byte("hello");     // 104
+    let s: str = "world";
+    let n: u64 = len_of(s);                 // 5 (forwarded str var)
+    if lit == 104 && n == 5 { 7 } else { 0 }
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 7
+
+# A literal `str` is first-class: returned from a function, stored in a struct
+# field, and reassigned through a `let mut`.
+[[case]]
+name = "str_first_class_return_store_reassign"
+files = [{ path = "main.rue", source = """
+struct Tag { name: str }
+fn pick(b: bool) -> str {
+    if b { return "yes"; }
+    "no"
+}
+fn main() -> i32 {
+    let t: Tag = Tag { name: "abc" };       // stored in a field
+    let picked: str = pick(true);           // returned
+    let mut m: str = "hello";
+    m = "hi";                               // reassigned
+    // 3 (field) + 3 (picked "yes") + 2 (m "hi") = 8
+    @intCast(t.name.len() + picked.len() + m.len())
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 8
+
+# Without the preview flag, `str` is gated with a clear diagnostic (not an ICE).
+[[case]]
+name = "str_requires_preview_flag"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: str = "hello";
+    @intCast(s.len())
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["requires preview feature"]
+
+# A string literal with NO `str` expectation stays the 3-word heap `String`, so
+# existing String operations are unaffected by the `str` preview.
+[[case]]
+name = "str_preview_does_not_change_string_default"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s = "hello";        // no annotation -> String
+    let t: String = s;      // String, not str
+    @intCast(t.len())
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 5

--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -670,6 +670,16 @@ fn differential_opt_missing_pin(case: &Case) -> bool {
     case.differential_opt && (case.stdout.is_none() || case.exit_code.is_none())
 }
 
+/// A `compile_fail` case that pins nothing about *why* compilation fails passes
+/// on ANY rejection — a diagnostic for an unrelated reason, or (before ICE
+/// detection) even a compiler crash. Require it to assert on the compiler's
+/// output via `error_contains` or `compile_stderr_contains`, so it verifies the
+/// specific error it is testing (RUE-132). Returns true when the case is
+/// `compile_fail` but carries neither assertion — a load-time error.
+fn compile_fail_missing_assertion(case: &Case) -> bool {
+    case.compile_fail && case.error_contains.is_empty() && case.compile_stderr_contains.is_empty()
+}
+
 fn load_cases(cases_dir: &Path) -> Vec<(String, TestFile)> {
     let mut toml_files = Vec::new();
     rue_test_runner::collect_toml_files(cases_dir, &mut toml_files);
@@ -698,6 +708,18 @@ fn load_cases(cases_dir: &Path) -> Vec<(String, TestFile)> {
                             "error: {}: differential_opt case '{}' must declare both an explicit \
                              `stdout` and `exit_code` (each opt level is checked against them, so \
                              the cross-level compare can't pass a consistently-wrong program)",
+                            path.display(),
+                            case.name
+                        );
+                        std::process::exit(1);
+                    }
+                    // A compile_fail case with no error assertion passes on any
+                    // rejection, verifying nothing about why it failed (RUE-132).
+                    if compile_fail_missing_assertion(case) {
+                        eprintln!(
+                            "error: {}: compile_fail case '{}' declares neither `error_contains` \
+                             nor `compile_stderr_contains`, so it would pass on ANY rejection. \
+                             Add an assertion pinning the specific error.",
                             path.display(),
                             case.name
                         );
@@ -948,5 +970,36 @@ mod tests {
             ..Default::default()
         };
         assert!(!differential_opt_missing_pin(&case));
+    }
+
+    #[test]
+    fn compile_fail_case_must_pin_an_error() {
+        // Bare compile_fail -> rejected.
+        let mut case = Case {
+            name: "c".to_string(),
+            compile_fail: true,
+            ..Default::default()
+        };
+        assert!(compile_fail_missing_assertion(&case));
+
+        // error_contains satisfies the guard.
+        case.error_contains = vec!["[E0206]".to_string()];
+        assert!(!compile_fail_missing_assertion(&case));
+
+        // compile_stderr_contains also satisfies it (pins stderr content).
+        case.error_contains = vec![];
+        case.compile_stderr_contains = vec!["bad.rue:".to_string()];
+        assert!(!compile_fail_missing_assertion(&case));
+    }
+
+    #[test]
+    fn non_compile_fail_case_not_required_to_pin_error() {
+        // A compile-and-run case needs no compile-error assertion.
+        let case = Case {
+            name: "c".to_string(),
+            compile_fail: false,
+            ..Default::default()
+        };
+        assert!(!compile_fail_missing_assertion(&case));
     }
 }

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -651,9 +651,13 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::StringConst(string_id) => {
+                // A string literal is a fat pointer to its `.rodata` bytes. The
+                // slot count comes from the value's type: a `str` (ADR-0043
+                // Phase 3, RUE-324) is 2 words `{ptr, len}`; a `String` is 3
+                // words `{ptr, len, cap}`. The ptr/len words are identical in
+                // both — only `str` drops the (static, non-owning) cap word.
                 let ptr_vreg = self.mir.alloc_vreg();
                 let len_vreg = self.mir.alloc_vreg();
-                let cap_vreg = self.mir.alloc_vreg();
 
                 self.mir.push(Aarch64Inst::StringConstPtr {
                     dst: Operand::Virtual(ptr_vreg),
@@ -665,14 +669,17 @@ impl<'a> CfgLower<'a> {
                     string_id: *string_id,
                 });
 
-                self.mir.push(Aarch64Inst::StringConstCap {
-                    dst: Operand::Virtual(cap_vreg),
-                    string_id: *string_id,
-                });
+                let mut slot_vregs = vec![ptr_vreg, len_vreg];
+                if self.ctx.type_slot_count(ty) >= 3 {
+                    let cap_vreg = self.mir.alloc_vreg();
+                    self.mir.push(Aarch64Inst::StringConstCap {
+                        dst: Operand::Virtual(cap_vreg),
+                        string_id: *string_id,
+                    });
+                    slot_vregs.push(cap_vreg);
+                }
 
-                // Store all three in struct_slot_vregs for String (ptr, len, cap)
-                self.struct_slot_vregs
-                    .insert(value, vec![ptr_vreg, len_vreg, cap_vreg]);
+                self.struct_slot_vregs.insert(value, slot_vregs);
                 self.value_map.insert(value, ptr_vreg);
             }
 

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -871,9 +871,13 @@ impl<'a> CfgLower<'a> {
             }
 
             CfgInstData::StringConst(string_id) => {
+                // A string literal is a fat pointer to its `.rodata` bytes. The
+                // slot count comes from the value's type: a `str` (ADR-0043
+                // Phase 3, RUE-324) is 2 words `{ptr, len}`; a `String` is 3
+                // words `{ptr, len, cap}`. The ptr/len words are identical in
+                // both — only `str` drops the (static, non-owning) cap word.
                 let ptr_vreg = self.mir.alloc_vreg();
                 let len_vreg = self.mir.alloc_vreg();
-                let cap_vreg = self.mir.alloc_vreg();
 
                 self.mir.push(X86Inst::StringConstPtr {
                     dst: Operand::Virtual(ptr_vreg),
@@ -885,14 +889,17 @@ impl<'a> CfgLower<'a> {
                     string_id: *string_id,
                 });
 
-                self.mir.push(X86Inst::StringConstCap {
-                    dst: Operand::Virtual(cap_vreg),
-                    string_id: *string_id,
-                });
+                let mut slot_vregs = vec![ptr_vreg, len_vreg];
+                if self.ctx.type_slot_count(ty) >= 3 {
+                    let cap_vreg = self.mir.alloc_vreg();
+                    self.mir.push(X86Inst::StringConstCap {
+                        dst: Operand::Virtual(cap_vreg),
+                        string_id: *string_id,
+                    });
+                    slot_vregs.push(cap_vreg);
+                }
 
-                // Store all three in struct_slot_vregs for String (ptr, len, cap)
-                self.struct_slot_vregs
-                    .insert(value, vec![ptr_vreg, len_vreg, cap_vreg]);
+                self.struct_slot_vregs.insert(value, slot_vregs);
                 self.value_map.insert(value, ptr_vreg);
             }
 

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -413,6 +413,12 @@ pub enum PreviewFeature {
     /// collection/string trio. Gated until the fat-pointer ABI lands on both
     /// backends.
     Slices,
+    /// The `str` string type — a read-only `[u8]` slice carrying the UTF-8
+    /// byte-string convention, plus static-backed first-class string literals
+    /// (ADR-0043 Phase 3, RUE-324). `str` reuses the slice `{ptr, len}`
+    /// representation; string literals live in `.rodata` and produce a 2-word
+    /// `str` value where a `str` is expected.
+    StringTrio,
 }
 
 /// Error returned when parsing a preview feature name fails.
@@ -434,6 +440,7 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "test_infra",
             PreviewFeature::Slices => "slices",
+            PreviewFeature::StringTrio => "string_trio",
         }
     }
 
@@ -443,12 +450,17 @@ impl PreviewFeature {
         match *self {
             PreviewFeature::TestInfra => "ADR-0005",
             PreviewFeature::Slices => "ADR-0043",
+            PreviewFeature::StringTrio => "ADR-0043",
         }
     }
 
     /// Get all available preview features.
     pub fn all() -> &'static [PreviewFeature] {
-        &[PreviewFeature::TestInfra, PreviewFeature::Slices]
+        &[
+            PreviewFeature::TestInfra,
+            PreviewFeature::Slices,
+            PreviewFeature::StringTrio,
+        ]
     }
 
     /// Get a comma-separated list of all feature names (for help text).
@@ -472,6 +484,7 @@ impl std::str::FromStr for PreviewFeature {
         match s {
             "test_infra" => Ok(PreviewFeature::TestInfra),
             "slices" => Ok(PreviewFeature::Slices),
+            "string_trio" => Ok(PreviewFeature::StringTrio),
             _ => Err(ParsePreviewFeatureError(s.to_string())),
         }
     }
@@ -2322,7 +2335,7 @@ mod tests {
     #[test]
     fn test_preview_feature_all_names() {
         let names = PreviewFeature::all_names();
-        assert_eq!(names, "test_infra, slices");
+        assert_eq!(names, "test_infra, slices, string_trio");
     }
 
     #[test]
@@ -2333,6 +2346,16 @@ mod tests {
         assert_eq!(feature.name(), "slices");
         assert_eq!(feature.adr(), "ADR-0043");
         assert!(PreviewFeature::all().contains(&PreviewFeature::Slices));
+    }
+
+    #[test]
+    fn test_preview_feature_string_trio() {
+        // ADR-0043 Phase 3 (RUE-324): the `str` string-type preview feature.
+        let feature: PreviewFeature = "string_trio".parse().unwrap();
+        assert_eq!(feature, PreviewFeature::StringTrio);
+        assert_eq!(feature.name(), "string_trio");
+        assert_eq!(feature.adr(), "ADR-0043");
+        assert!(PreviewFeature::all().contains(&PreviewFeature::StringTrio));
     }
 
     #[test]

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -450,6 +450,20 @@ impl<'a> Interp<'a> {
                 }
                 Value::Int(bytes[idx as usize] as i128)
             }
+            // `str` byte indexing `s[i]` (ADR-0043 Phase 3, RUE-324): the runtime
+            // `__rue_str_byte_at(ptr, len, index)` is the 2-word analog of
+            // `__rue_String_byte_at`, reading the i-th PACKED byte with the same
+            // bounds-check-and-trap discipline. Modeled identically over the byte
+            // content (the `str` receiver is `arg[0]`, the index `arg[1]`).
+            "__rue_str_byte_at" => {
+                let text = s(&args[0]);
+                let bytes = text.as_bytes();
+                let idx = args[1].as_int();
+                if idx < 0 || idx as u128 >= bytes.len() as u128 {
+                    return Err(Flow::Panic(Panic("index out of bounds".into())));
+                }
+                Value::Int(bytes[idx as usize] as i128)
+            }
             // `for c in s.chars()` scalar view (RUE-220): `__rue_String_char_scalar`
             // decodes the Unicode scalar at byte `offset`, and
             // `__rue_String_char_next` returns the byte offset of the following

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -639,6 +639,46 @@ crate::define_for_all_platforms! {
     }
 }
 
+crate::define_for_all_platforms! {
+    /// Read the byte at `index` in a `str`, returning it as `u8` (ADR-0043
+    /// Phase 3, RUE-324).
+    ///
+    /// Implements `s[i]` for the `str` string type. A `str` is `[u8]` + UTF-8:
+    /// its bytes are PACKED (1 byte each, in `.rodata` for a literal), so like
+    /// `String` this reads a single byte at `ptr + index` after a bounds check.
+    /// It is the 2-word (`{ptr, len}`) analog of `__rue_String_byte_at`, without
+    /// the (nonexistent) `cap` word. An `index >= len` traps at runtime
+    /// (index-out-of-bounds panic, exit 101), matching array/`String` indexing.
+    ///
+    /// # ABI
+    ///
+    /// ```text
+    /// extern "C" fn __rue_str_byte_at(ptr: *const u8, len: u64, index: u64) -> u64
+    /// ```
+    ///
+    /// The `str` is passed by value as its two fields (ptr, len); the byte is
+    /// returned zero-extended in the return register — see the
+    /// `__rue_String_byte_at` ABI note on why a clean full register is required.
+    ///
+    /// # Safety
+    ///
+    /// The caller must ensure `ptr` points to a valid buffer of at least `len`
+    /// bytes. The in-range read below is then sound because the bounds check
+    /// guarantees `index < len`.
+    #[allow(non_snake_case)]
+    pub extern "C" fn __rue_str_byte_at(ptr: *const u8, len: u64, index: u64) -> u64 {
+        if index >= len {
+            // Never returns: prints "error: index out of bounds" and exits 101.
+            crate::error::__rue_bounds_check();
+        }
+        // SAFETY: `index < len` (checked above) and the caller guarantees `ptr`
+        // is valid for `len` bytes, so `ptr.add(index)` is in bounds. u8 has no
+        // alignment requirement. Zero-extend to u64 so the whole return
+        // register is clean (see the `__rue_String_byte_at` ABI note).
+        unsafe { *ptr.add(index as usize) as u64 }
+    }
+}
+
 /// Strictly decode one UTF-8 scalar starting at byte `offset` in the `len`-byte
 /// buffer at `ptr`, returning `(scalar, width_in_bytes)`.
 ///

--- a/crates/rue-spec/cases/arrays/fixed.toml
+++ b/crates/rue-spec/cases/arrays/fixed.toml
@@ -47,6 +47,7 @@ exit_code = 6
 
 [[case]]
 name = "array_elements_type_mismatch"
+error_contains = "[E0206]"
 spec = ["7.1:3"]
 source = """
 fn main() -> i32 {
@@ -73,6 +74,7 @@ exit_code = 30
 
 [[case]]
 name = "array_too_few_elements"
+error_contains = "[E0901]"
 spec = ["7.1:4"]
 source = """
 fn main() -> i32 {
@@ -84,6 +86,7 @@ compile_fail = true
 
 [[case]]
 name = "array_too_many_elements"
+error_contains = "[E0901]"
 spec = ["7.1:4"]
 source = """
 fn main() -> i32 {
@@ -137,6 +140,7 @@ exit_code = 20
 
 [[case]]
 name = "array_index_bool_error"
+error_contains = "[E0206]"
 spec = ["7.1:7"]
 source = """
 fn main() -> i32 {
@@ -163,6 +167,7 @@ exit_code = 30
 
 [[case]]
 name = "constant_index_out_of_bounds"
+error_contains = "[E0902]"
 spec = ["7.1:9"]
 source = """
 fn main() -> i32 {
@@ -232,6 +237,7 @@ exit_code = 42
 
 [[case]]
 name = "immutable_array_assign_error"
+error_contains = "[E0203]"
 spec = ["7.1:12"]
 source = """
 fn main() -> i32 {
@@ -1153,6 +1159,7 @@ exit_code = 42
 # (7.1:47).
 [[case]]
 name = "array_linear_partial_consumption_rejected"
+error_contains = "[E0406]"
 spec = ["7.1:47"]
 source = """
 linear struct MustUse { value: i32 }

--- a/crates/rue-spec/cases/expressions/blocks.toml
+++ b/crates/rue-spec/cases/expressions/blocks.toml
@@ -68,6 +68,7 @@ exit_code = 30
 
 [[case]]
 name = "variable_not_visible_outside_block"
+error_contains = "[E0201]"
 spec = ["4.5:4", "4.5:6"]
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/expressions/call.toml
+++ b/crates/rue-spec/cases/expressions/call.toml
@@ -41,6 +41,7 @@ exit_code = 42
 
 [[case]]
 name = "too_few_arguments"
+error_contains = "[E0207]"
 spec = ["4.10:3"]
 source = """
 fn add(x: i32, y: i32) -> i32 { x + y }
@@ -50,6 +51,7 @@ compile_fail = true
 
 [[case]]
 name = "too_many_arguments"
+error_contains = "[E0207]"
 spec = ["4.10:3"]
 source = """
 fn foo(x: i32) -> i32 { x }
@@ -63,6 +65,7 @@ compile_fail = true
 
 [[case]]
 name = "argument_type_mismatch"
+error_contains = "[E0206]"
 spec = ["4.10:4"]
 source = """
 fn foo(x: i32) -> i32 { x }

--- a/crates/rue-spec/cases/expressions/comparison.toml
+++ b/crates/rue-spec/cases/expressions/comparison.toml
@@ -65,6 +65,7 @@ params = [
 
 [[case]]
 name = "ordering_{op}_on_bool"
+error_contains = "[E0206]"
 spec = ["4.3:5"]
 source = """
 fn main() -> i32 {
@@ -106,6 +107,7 @@ params = [
 
 [[case]]
 name = "type_mismatch_{types}"
+error_contains = "[E0206]"
 spec = ["4.3:10"]
 source = """
 fn main() -> i32 {
@@ -187,6 +189,7 @@ params = [
 
 [[case]]
 name = "unit_ordering_disallowed"
+error_contains = "[E0206]"
 spec = ["4.3:6"]
 source = """
 fn main() -> i32 {
@@ -248,6 +251,7 @@ exit_code = 1
 
 [[case]]
 name = "struct_ordering_disallowed"
+error_contains = "[E0206]"
 spec = ["4.3:6"]
 source = """
 struct Point { x: i32, y: i32 }
@@ -346,6 +350,7 @@ exit_code = 1
 
 [[case]]
 name = "array_ordering_disallowed"
+error_contains = "[E0206]"
 spec = ["4.3:6"]
 source = """
 fn main() -> i32 {
@@ -414,6 +419,7 @@ params = [
 
 [[case]]
 name = "enum_clike_ordering_disallowed"
+error_contains = "[E0206]"
 spec = ["4.3:6"]
 source = """
 enum Color { Red, Green }

--- a/crates/rue-spec/cases/expressions/field.toml
+++ b/crates/rue-spec/cases/expressions/field.toml
@@ -38,6 +38,7 @@ exit_code = 42
 
 [[case]]
 name = "field_not_found"
+error_contains = "[E0401]"
 spec = ["4.12:4"]
 source = """
 struct Point { x: i32, y: i32 }
@@ -84,6 +85,7 @@ exit_code = 42
 
 [[case]]
 name = "immutable_field_assignment_error"
+error_contains = "[E0203]"
 spec = ["4.12:7"]
 source = """
 struct Point { x: i32, y: i32 }

--- a/crates/rue-spec/cases/expressions/if.toml
+++ b/crates/rue-spec/cases/expressions/if.toml
@@ -34,6 +34,7 @@ exit_code = 42
 
 [[case]]
 name = "condition_must_be_bool"
+error_contains = "[E0206]"
 spec = ["4.6:3"]
 source = """
 fn main() -> i32 {
@@ -69,6 +70,7 @@ exit_code = 10
 
 [[case]]
 name = "branches_different_types"
+error_contains = "[E0206]"
 spec = ["4.6:4"]
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/expressions/index.toml
+++ b/crates/rue-spec/cases/expressions/index.toml
@@ -106,6 +106,7 @@ exit_code = 20
 
 [[case]]
 name = "constant_index_out_of_bounds"
+error_contains = "[E0902]"
 spec = ["4.11:7"]
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -265,6 +265,7 @@ exit_code = 0
 
 [[case]]
 name = "dbg_wrong_arg_count_zero"
+error_contains = "[E0701]"
 spec = ["4.13:4", "4.13:7"]
 source = """
 fn main() -> i32 {
@@ -276,6 +277,7 @@ compile_fail = true
 
 [[case]]
 name = "dbg_wrong_arg_count_two"
+error_contains = "[E0701]"
 spec = ["4.13:4", "4.13:7"]
 source = """
 fn main() -> i32 {
@@ -287,6 +289,7 @@ compile_fail = true
 
 [[case]]
 name = "dbg_invalid_type_unit"
+error_contains = "[E0702]"
 spec = ["4.13:7"]
 source = """
 fn main() -> i32 {
@@ -298,6 +301,7 @@ compile_fail = true
 
 [[case]]
 name = "dbg_invalid_type_array"
+error_contains = "[E0702]"
 spec = ["4.13:7"]
 source = """
 fn main() -> i32 {
@@ -310,6 +314,7 @@ compile_fail = true
 
 [[case]]
 name = "dbg_invalid_type_struct"
+error_contains = "[E0702]"
 spec = ["4.13:7"]
 source = """
 struct Point { x: i32, y: i32 }
@@ -627,6 +632,7 @@ error_contains = "integer"
 
 [[case]]
 name = "intcast_wrong_arg_count_zero"
+error_contains = "[E0701]"
 spec = ["4.13:4", "4.13:25"]
 source = """
 fn main() -> i32 {
@@ -638,6 +644,7 @@ compile_fail = true
 
 [[case]]
 name = "intcast_wrong_arg_count_two"
+error_contains = "[E0701]"
 spec = ["4.13:4", "4.13:25"]
 source = """
 fn main() -> i32 {
@@ -1113,6 +1120,7 @@ exit_code = 99
 
 [[case]]
 name = "parse_wrong_arg_count_zero"
+error_contains = "[E0701]"
 spec = ["4.13:4", "4.13:45"]
 source = """
 fn main() -> i32 {
@@ -1123,6 +1131,7 @@ compile_fail = true
 
 [[case]]
 name = "parse_wrong_arg_count_two"
+error_contains = "[E0701]"
 spec = ["4.13:4", "4.13:45"]
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/expressions/logical.toml
+++ b/crates/rue-spec/cases/expressions/logical.toml
@@ -146,6 +146,7 @@ exit_code = 1
 
 [[case]]
 name = "and_requires_bool_left"
+error_contains = "[E0206]"
 spec = ["4.4:12"]
 source = """
 fn main() -> i32 {
@@ -156,6 +157,7 @@ compile_fail = true
 
 [[case]]
 name = "and_requires_bool_right"
+error_contains = "[E0206]"
 spec = ["4.4:12"]
 source = """
 fn main() -> i32 {
@@ -166,6 +168,7 @@ compile_fail = true
 
 [[case]]
 name = "or_requires_bool_left"
+error_contains = "[E0206]"
 spec = ["4.4:12"]
 source = """
 fn main() -> i32 {
@@ -176,6 +179,7 @@ compile_fail = true
 
 [[case]]
 name = "not_requires_bool"
+error_contains = "[E0206]"
 spec = ["4.4:12"]
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/expressions/match.toml
+++ b/crates/rue-spec/cases/expressions/match.toml
@@ -433,6 +433,7 @@ exit_code = 1
 
 [[case]]
 name = "non_exhaustive_int"
+error_contains = "[E0600]"
 spec = ["4.7:9", "4.7:10"]
 source = """
 fn main() -> i32 {
@@ -446,6 +447,7 @@ compile_fail = true
 
 [[case]]
 name = "non_exhaustive_bool_missing_false"
+error_contains = "[E0600]"
 spec = ["4.7:9", "4.7:10"]
 source = """
 fn main() -> i32 {
@@ -458,6 +460,7 @@ compile_fail = true
 
 [[case]]
 name = "non_exhaustive_bool_missing_true"
+error_contains = "[E0600]"
 spec = ["4.7:9", "4.7:10"]
 source = """
 fn main() -> i32 {
@@ -474,6 +477,7 @@ compile_fail = true
 
 [[case]]
 name = "empty_match"
+error_contains = "[E0601]"
 spec = ["4.7:9"]
 source = """
 fn main() -> i32 {
@@ -492,6 +496,7 @@ compile_fail = true
 
 [[case]]
 name = "arm_type_mismatch"
+error_contains = "[E0206]"
 spec = ["4.7:12"]
 source = """
 fn main() -> i32 {
@@ -509,6 +514,7 @@ compile_fail = true
 
 [[case]]
 name = "pattern_type_mismatch"
+error_contains = "[E0206]"
 spec = ["4.7:13"]
 source = """
 fn main() -> i32 {
@@ -835,6 +841,7 @@ error_contains = "unary operator"
 
 [[case]]
 name = "negative_pattern_on_u8_scrutinee"
+error_contains = "[E0801]"
 spec = ["4.7:24"]
 source = """
 fn main() -> i32 {
@@ -968,6 +975,7 @@ exit_code = 20
 # Wrong number of bindings for a variant's payload arity is rejected (4.7:30).
 [[case]]
 name = "match_payload_binding_wrong_arity"
+error_contains = "[E0207]"
 spec = ["4.7:30"]
 source = """
 enum Shape { Rect(i32, i32) }

--- a/crates/rue-spec/cases/expressions/return.toml
+++ b/crates/rue-spec/cases/expressions/return.toml
@@ -72,6 +72,7 @@ exit_code = 42
 
 [[case]]
 name = "return_type_mismatch"
+error_contains = "[E0206]"
 spec = ["4.9:4"]
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/expressions/while.toml
+++ b/crates/rue-spec/cases/expressions/while.toml
@@ -42,6 +42,7 @@ exit_code = 0
 
 [[case]]
 name = "while_condition_must_be_bool"
+error_contains = "[E0206]"
 spec = ["4.8:3"]
 source = """
 fn main() -> i32 {
@@ -145,6 +146,7 @@ exit_code = 4
 
 [[case]]
 name = "break_outside_loop"
+error_contains = "[E0500]"
 spec = ["4.8:9"]
 source = """
 fn main() -> i32 {
@@ -156,6 +158,7 @@ compile_fail = true
 
 [[case]]
 name = "continue_outside_loop"
+error_contains = "[E0501]"
 spec = ["4.8:9"]
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/items/enums.toml
+++ b/crates/rue-spec/cases/items/enums.toml
@@ -340,6 +340,7 @@ exit_code = 0
 # Wrong payload arity is rejected.
 [[case]]
 name = "enum_payload_wrong_arity"
+error_contains = "[E0207]"
 spec = ["6.3:16"]
 source = """
 enum Shape { Rect(i32, i32) }
@@ -350,6 +351,7 @@ compile_fail = true
 # A payload-carrying variant used as a bare path is an error.
 [[case]]
 name = "enum_payload_bare_path_error"
+error_contains = "[E0207]"
 spec = ["6.3:16"]
 source = """
 enum Shape { Circle(i32) }

--- a/crates/rue-spec/cases/items/structs.toml
+++ b/crates/rue-spec/cases/items/structs.toml
@@ -38,6 +38,7 @@ exit_code = 42
 
 [[case]]
 name = "duplicate_field_names_error"
+error_contains = "[E0402]"
 spec = ["6.2:3"]
 source = """
 struct Bad { x: i32, x: i32 }
@@ -63,6 +64,7 @@ exit_code = 30
 
 [[case]]
 name = "missing_field_error"
+error_contains = "[E0400]"
 spec = ["6.2:5"]
 source = """
 struct Point { x: i32, y: i32 }
@@ -174,6 +176,7 @@ exit_code = 42
 
 [[case]]
 name = "immutable_field_assign_error"
+error_contains = "[E0203]"
 spec = ["6.2:9"]
 source = """
 struct Point { x: i32, y: i32 }

--- a/crates/rue-spec/cases/lexical/keywords.toml
+++ b/crates/rue-spec/cases/lexical/keywords.toml
@@ -10,96 +10,112 @@ description = "Keywords are reserved words with special meaning and cannot be us
 
 [[case]]
 name = "keyword_fn_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let fn = 1; fn }"
 compile_fail = true
 
 [[case]]
 name = "keyword_let_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let let = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_mut_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let mut = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_if_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let if = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_else_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let else = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_while_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let while = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_loop_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let loop = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_match_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let match = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_return_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let return = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_break_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let break = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_continue_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let continue = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_true_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let true = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_false_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let false = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_struct_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let struct = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_inout_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let inout = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "keyword_borrow_reserved"
+error_contains = "[E0100]"
 spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let borrow = 1; 0 }"
 compile_fail = true
@@ -110,6 +126,7 @@ compile_fail = true
 
 [[case]]
 name = "type_i8_as_variable"
+error_contains = "[E0100]"
 spec = ["2.4:3"]
 source = """
 fn main() -> i32 {
@@ -121,6 +138,7 @@ compile_fail = true
 
 [[case]]
 name = "type_i16_as_variable"
+error_contains = "[E0100]"
 spec = ["2.4:3"]
 source = """
 fn main() -> i32 {
@@ -132,6 +150,7 @@ compile_fail = true
 
 [[case]]
 name = "type_i32_as_variable"
+error_contains = "[E0100]"
 spec = ["2.4:3"]
 source = """
 fn main() -> i32 {
@@ -143,6 +162,7 @@ compile_fail = true
 
 [[case]]
 name = "type_i64_as_variable"
+error_contains = "[E0100]"
 spec = ["2.4:3"]
 source = """
 fn main() -> i32 {
@@ -154,6 +174,7 @@ compile_fail = true
 
 [[case]]
 name = "type_u8_as_variable"
+error_contains = "[E0100]"
 spec = ["2.4:3"]
 source = """
 fn main() -> i32 {
@@ -165,6 +186,7 @@ compile_fail = true
 
 [[case]]
 name = "type_bool_as_variable"
+error_contains = "[E0100]"
 spec = ["2.4:3"]
 source = """
 fn main() -> i32 {
@@ -176,6 +198,7 @@ compile_fail = true
 
 [[case]]
 name = "type_i32_as_function_name"
+error_contains = "[E0100]"
 spec = ["2.4:3"]
 source = """
 fn i32() -> i32 { 0 }
@@ -185,6 +208,7 @@ compile_fail = true
 
 [[case]]
 name = "type_bool_as_parameter"
+error_contains = "[E0100]"
 spec = ["2.4:3"]
 source = """
 fn foo(bool: i32) -> i32 { 0 }
@@ -194,6 +218,7 @@ compile_fail = true
 
 [[case]]
 name = "type_i32_as_struct_name"
+error_contains = "[E0100]"
 spec = ["2.4:3"]
 source = """
 struct i32 { x: i64 }
@@ -203,6 +228,7 @@ compile_fail = true
 
 [[case]]
 name = "type_bool_as_struct_field"
+error_contains = "[E0100]"
 spec = ["2.4:3"]
 source = """
 struct Foo { bool: i32 }

--- a/crates/rue-spec/cases/lexical/tokens.toml
+++ b/crates/rue-spec/cases/lexical/tokens.toml
@@ -359,18 +359,21 @@ exit_code = 42
 
 [[case]]
 name = "identifier_cannot_be_keyword_fn"
+error_contains = "[E0100]"
 spec = ["2.1:12"]
 source = "fn main() -> i32 { let fn = 1; fn }"
 compile_fail = true
 
 [[case]]
 name = "identifier_cannot_be_keyword_let"
+error_contains = "[E0100]"
 spec = ["2.1:12"]
 source = "fn main() -> i32 { let let = 1; 0 }"
 compile_fail = true
 
 [[case]]
 name = "identifier_cannot_be_keyword_if"
+error_contains = "[E0100]"
 spec = ["2.1:12"]
 source = "fn main() -> i32 { let if = 1; 0 }"
 compile_fail = true

--- a/crates/rue-spec/cases/runtime/bounds.toml
+++ b/crates/rue-spec/cases/runtime/bounds.toml
@@ -42,6 +42,7 @@ exit_code = 101
 
 [[case]]
 name = "constant_index_checked"
+error_contains = "[E0902]"
 spec = ["8.2:3"]
 source = """
 fn main() -> i32 {
@@ -57,6 +58,7 @@ compile_fail = true
 
 [[case]]
 name = "constant_expression_addition_checked"
+error_contains = "[E0902]"
 spec = ["8.2:3", "8.2:4"]
 source = """
 fn main() -> i32 {
@@ -68,6 +70,7 @@ compile_fail = true
 
 [[case]]
 name = "constant_expression_multiplication_checked"
+error_contains = "[E0902]"
 spec = ["8.2:3", "8.2:4"]
 source = """
 fn main() -> i32 {
@@ -90,6 +93,7 @@ exit_code = 30
 
 [[case]]
 name = "constant_expression_complex_checked"
+error_contains = "[E0902]"
 spec = ["8.2:3", "8.2:4"]
 source = """
 fn main() -> i32 {
@@ -126,6 +130,7 @@ exit_code = 30
 
 [[case]]
 name = "constant_expression_division_out_of_bounds"
+error_contains = "[E0902]"
 spec = ["8.2:3", "8.2:4"]
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/runtime/heap.toml
+++ b/crates/rue-spec/cases/runtime/heap.toml
@@ -112,6 +112,7 @@ exit_code = 99
 
 [[case]]
 name = "alloc_requires_checked"
+error_contains = "[E1300]"
 spec = ["9.2:13"]
 source = """
 fn main() -> i32 {
@@ -123,6 +124,7 @@ compile_fail = true
 
 [[case]]
 name = "free_requires_checked"
+error_contains = "[E1300]"
 spec = ["9.2:13"]
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/statements/assignment.toml
+++ b/crates/rue-spec/cases/statements/assignment.toml
@@ -38,6 +38,7 @@ exit_code = 42
 
 [[case]]
 name = "assign_immutable_error"
+error_contains = "[E0203]"
 spec = ["5.2:3"]
 source = """
 fn main() -> i32 {
@@ -54,6 +55,7 @@ compile_fail = true
 
 [[case]]
 name = "assign_type_mismatch"
+error_contains = "[E0206]"
 spec = ["5.2:4"]
 source = """
 fn main() -> i32 {
@@ -82,6 +84,7 @@ exit_code = 42
 
 [[case]]
 name = "assign_immutable_array_error"
+error_contains = "[E0203]"
 spec = ["5.2:6"]
 source = """
 fn main() -> i32 {
@@ -111,6 +114,7 @@ exit_code = 42
 
 [[case]]
 name = "assign_immutable_struct_error"
+error_contains = "[E0203]"
 spec = ["5.2:8"]
 source = """
 struct Point { x: i32, y: i32 }
@@ -172,6 +176,7 @@ exit_code = 42
 
 [[case]]
 name = "assign_nested_immutable_error"
+error_contains = "[E0203]"
 spec = ["5.2:12"]
 source = """
 struct Inner { value: i32 }
@@ -205,6 +210,7 @@ exit_code = 45
 
 [[case]]
 name = "assignment_not_expression"
+error_contains = "[E0100]"
 spec = ["5.2:10"]
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/types/arrays.toml
+++ b/crates/rue-spec/cases/types/arrays.toml
@@ -81,6 +81,7 @@ exit_code = 42
 
 [[case]]
 name = "array_bounds_compile_time"
+error_contains = "[E0902]"
 spec = ["3.5:7"]
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/types/booleans.toml
+++ b/crates/rue-spec/cases/types/booleans.toml
@@ -77,6 +77,7 @@ exit_code = 1
 
 [[case]]
 name = "bool_no_ordering_lt"
+error_contains = "[E0206]"
 spec = ["3.2:4"]
 source = """
 fn main() -> i32 {
@@ -87,6 +88,7 @@ compile_fail = true
 
 [[case]]
 name = "bool_no_ordering_gt"
+error_contains = "[E0206]"
 spec = ["3.2:4"]
 source = """
 fn main() -> i32 {
@@ -97,6 +99,7 @@ compile_fail = true
 
 [[case]]
 name = "bool_no_ordering_le"
+error_contains = "[E0206]"
 spec = ["3.2:4"]
 source = """
 fn main() -> i32 {
@@ -107,6 +110,7 @@ compile_fail = true
 
 [[case]]
 name = "bool_no_ordering_ge"
+error_contains = "[E0206]"
 spec = ["3.2:4"]
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/types/integers.toml
+++ b/crates/rue-spec/cases/types/integers.toml
@@ -172,6 +172,7 @@ exit_code = 5
 
 [[case]]
 name = "type_mismatch_{from}_{to}"
+error_contains = "[E0206]"
 spec = ["3.1:1"]
 compile_fail = true
 source = """

--- a/crates/rue-spec/cases/types/str-type.toml
+++ b/crates/rue-spec/cases/types/str-type.toml
@@ -1,0 +1,186 @@
+# The `str` string type (ADR-0043 Phase 3, RUE-324).
+#
+# `str` is `[u8]` + the UTF-8 byte-string convention: a read-only two-word view
+# `{ptr, len}`. String literals have type `str` where a `str` is expected, are
+# static-backed (bytes in .rodata), and are first-class (Copy, storable,
+# reassignable, returnable). `.len()` is the byte length; `s[i]` is the i-th
+# byte as `u8`, bounds-checked (an out-of-range index traps, exit 101).
+#
+# Gated behind `--preview string_trio`. Deferred to later phases: `str`
+# concatenation, comparison/equality, `str`<->`String` interop, methods beyond
+# `.len()`/index, and char iteration.
+
+[section]
+id = "types.str_type"
+spec_chapter = "3.7"
+name = "The str Type"
+description = "str is the read-only [u8] byte-string slice with static-backed first-class literals."
+
+# 3.7:43 — `str` is a resolvable type, gated behind `--preview string_trio`.
+[[case]]
+name = "str_type_requires_preview"
+spec = ["3.7:43"]
+source = """
+fn main() -> i32 {
+    let s: str = "hello";
+    0
+}
+"""
+compile_fail = true
+error_contains = "requires preview feature"
+
+# 3.7:43 / 3.7:44 — a string literal has type `str` where a `str` is expected,
+# static-backed and storable in a binding.
+[[case]]
+name = "str_literal_binding"
+spec = ["3.7:43", "3.7:44"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let s: str = "hello";
+    0
+}
+"""
+exit_code = 0
+
+# 3.7:45 — `.len()` is the byte length.
+[[case]]
+name = "str_len_bytes"
+spec = ["3.7:45"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let s: str = "hello";
+    @intCast(s.len())
+}
+"""
+exit_code = 5
+
+# 3.7:45 — `.len()` counts bytes, not scalars (a multibyte char).
+[[case]]
+name = "str_len_multibyte"
+spec = ["3.7:45"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let s: str = "café";   // 5 bytes ('é' is 2 bytes)
+    @intCast(s.len())
+}
+"""
+exit_code = 5
+
+# 3.7:46 — `s[i]` is the i-th byte as `u8`.
+[[case]]
+name = "str_byte_index"
+spec = ["3.7:46"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let s: str = "hello";
+    @dbg(s[0]);   // 104 'h'
+    @dbg(s[1]);   // 101 'e'
+    @dbg(s[4]);   // 111 'o'
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "104\n101\n111\n"
+
+# 3.7:46 — byte indexing sees raw bytes, not char boundaries.
+[[case]]
+name = "str_byte_index_multibyte"
+spec = ["3.7:46"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let s: str = "café";   // 'c' 'a' 'f' 0xC3 0xA9
+    @dbg(s[3]);   // 195 (0xC3)
+    @dbg(s[4]);   // 169 (0xA9)
+    0
+}
+"""
+exit_code = 0
+expected_stdout = "195\n169\n"
+
+# 3.7:47 — an out-of-bounds byte index traps (exit 101).
+[[case]]
+name = "str_byte_index_oob_traps"
+spec = ["3.7:47"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let s: str = "hi";
+    let b: u8 = s[9];
+    @intCast(b)
+}
+"""
+exit_code = 101
+
+# 3.7:44 — a literal `str` is first-class: passable as a `str` argument.
+[[case]]
+name = "str_first_class_param"
+spec = ["3.7:44"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn first(s: str) -> u8 {
+    s[0]
+}
+fn main() -> i32 {
+    @intCast(first("hello"))
+}
+"""
+exit_code = 104
+
+# 3.7:44 — a literal `str` is first-class: returnable from a function.
+[[case]]
+name = "str_first_class_return"
+spec = ["3.7:44"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn greeting() -> str {
+    "hello"
+}
+fn main() -> i32 {
+    let s: str = greeting();
+    @intCast(s.len())
+}
+"""
+exit_code = 5
+
+# 3.7:44 — a literal `str` is first-class: storable in a struct field.
+[[case]]
+name = "str_first_class_struct_field"
+spec = ["3.7:44"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+struct Named { label: str }
+fn main() -> i32 {
+    let n: Named = Named { label: "hey" };
+    @intCast(n.label.len())
+}
+"""
+exit_code = 3
+
+# 3.7:44 — a `str` is `@copy` and reassignable.
+[[case]]
+name = "str_first_class_reassign"
+spec = ["3.7:44"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let mut s: str = "hello";
+    s = "hi";
+    @intCast(s.len())
+}
+"""
+exit_code = 2

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -202,6 +202,7 @@ exit_code = 0
 
 [[case]]
 name = "string_invalid_escape"
+error_contains = "[E0003]"
 spec = ["3.7:7", "2.1:8"]
 source = """
 fn main() -> i32 {
@@ -267,6 +268,7 @@ exit_code = 0
 
 [[case]]
 name = "string_no_ordering_lt"
+error_contains = "[E0206]"
 spec = ["3.7:9", "4.3:6"]
 source = """
 fn main() -> i32 {
@@ -277,6 +279,7 @@ compile_fail = true
 
 [[case]]
 name = "string_no_ordering_gt"
+error_contains = "[E0206]"
 spec = ["3.7:9", "4.3:6"]
 source = """
 fn main() -> i32 {
@@ -287,6 +290,7 @@ compile_fail = true
 
 [[case]]
 name = "string_no_ordering_le"
+error_contains = "[E0206]"
 spec = ["3.7:9", "4.3:6"]
 source = """
 fn main() -> i32 {
@@ -297,6 +301,7 @@ compile_fail = true
 
 [[case]]
 name = "string_no_ordering_ge"
+error_contains = "[E0206]"
 spec = ["3.7:9", "4.3:6"]
 source = """
 fn main() -> i32 {

--- a/crates/rue-spec/cases/types/structs.toml
+++ b/crates/rue-spec/cases/types/structs.toml
@@ -54,6 +54,7 @@ exit_code = 42
 
 [[case]]
 name = "struct_missing_field_error"
+error_contains = "[E0400]"
 spec = ["3.6:5"]
 source = """
 struct Point { x: i32, y: i32 }

--- a/crates/rue-spec/src/main.rs
+++ b/crates/rue-spec/src/main.rs
@@ -73,9 +73,13 @@ fn run_traceability(detailed: bool) {
         report.print_summary();
     }
 
-    // Exit with error if there are uncovered normative paragraphs or orphan references
-    // Informative paragraphs don't require test coverage
-    if report.normative_uncovered_count() > 0 || !report.orphan_references.is_empty() {
+    // Exit with error if the gate is failing: an *unexpected* uncovered
+    // normative paragraph (one not on the known-gap allowlist), a stale
+    // allowlist entry, or an orphan reference. Rules whose only tests are
+    // skipped/preview-allowed-to-fail no longer count as coverage (RUE-132);
+    // the ones tracked in KNOWN_UNCOVERED_NORMATIVE are reported but don't fail
+    // the gate. Informative paragraphs never require coverage.
+    if report.gate_failing() {
         std::process::exit(1);
     }
 }

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -140,7 +140,56 @@ pub struct TraceabilityReport {
     pub orphan_references: Vec<(String, String)>,
 }
 
+/// Normative paragraphs that currently have no *running* test, tracked as known
+/// gaps pending compiler-feature implementation.
+///
+/// Each entry is `(paragraph_id, reason)`. These are rules whose only spec tests
+/// are `skip = true` because the behavior they pin isn't implemented yet — the
+/// tests are written and ready to un-skip the moment the feature lands. Before
+/// RUE-132, such a skipped test silently *counted* as coverage, so the report
+/// falsely claimed 100%. Now skipped tests don't count, and these genuine gaps
+/// are listed here explicitly: the gate stays green while the report tells the
+/// truth (the rules are shown as known-uncovered, not as covered).
+///
+/// **Maintenance:** when a feature ships and its test un-skips, the rule regains
+/// real coverage and its entry here becomes stale — the gate will fail and tell
+/// you to remove it (see [`TraceabilityReport::stale_known_uncovered`]). This
+/// mirrors the `known_bug` xfail convention: an exemption that starts passing
+/// must be retired so it converts back into an enforced check.
+pub const KNOWN_UNCOVERED_NORMATIVE: &[(&str, &str)] = &[
+    (
+        "2.5:10",
+        "'@directive must precede item' error not implemented \
+         (lexical/builtins.toml::directive_must_precede_item, skipped)",
+    ),
+    (
+        "2.5:14",
+        "unrecognized-warning-name error not implemented \
+         (lexical/builtins.toml::allow_unknown_warning_error, skipped)",
+    ),
+    (
+        "2.5:17",
+        "function-level @allow(unused_variable) not implemented \
+         (lexical/builtins.toml::allow_unused_variable_on_function, skipped)",
+    ),
+    (
+        "2.5:19",
+        "unused-function warning not implemented \
+         (lexical/builtins.toml::allow_unused_function, skipped)",
+    ),
+    (
+        "2.5:21",
+        "@allow(unreachable_code) suppression not implemented \
+         (lexical/builtins.toml::allow_unreachable_code, skipped)",
+    ),
+];
+
 impl TraceabilityReport {
+    /// Whether `id` is on the [`KNOWN_UNCOVERED_NORMATIVE`] allowlist.
+    fn is_known_uncovered(id: &str) -> bool {
+        KNOWN_UNCOVERED_NORMATIVE.iter().any(|(k, _)| *k == id)
+    }
+
     /// Check if a paragraph is normative (requires test coverage).
     /// Normative categories: normative, legality-rule, dynamic-semantics, syntax, undefined-behavior
     fn is_normative(para: &SpecParagraph) -> bool {
@@ -203,6 +252,51 @@ impl TraceabilityReport {
             .collect()
     }
 
+    /// Uncovered normative paragraphs that are **not** on the
+    /// [`KNOWN_UNCOVERED_NORMATIVE`] allowlist.
+    ///
+    /// This is the set the traceability gate fails on: a genuinely-uncovered
+    /// normative rule that isn't a tracked, known gap. Allowlisted rules are
+    /// reported separately (see [`Self::print_summary`]) but don't fail the gate.
+    pub fn unexpected_uncovered_normative_paragraphs(&self) -> Vec<&String> {
+        self.uncovered_normative_paragraphs()
+            .into_iter()
+            .filter(|id| !Self::is_known_uncovered(id))
+            .collect()
+    }
+
+    /// Stale [`KNOWN_UNCOVERED_NORMATIVE`] entries: allowlisted IDs that are no
+    /// longer legitimately-uncovered normative rules — either the paragraph now
+    /// has a running test (the feature shipped; un-skip happened) or the ID no
+    /// longer names a normative paragraph at all.
+    ///
+    /// A non-empty result fails the gate, demanding the stale entry be removed —
+    /// so the allowlist can never silently mask a rule that regained coverage.
+    pub fn stale_known_uncovered(&self) -> Vec<&'static str> {
+        KNOWN_UNCOVERED_NORMATIVE
+            .iter()
+            .filter(|(id, _)| {
+                let is_uncovered_normative =
+                    self.paragraphs.get(*id).is_some_and(Self::is_normative)
+                        && self
+                            .coverage
+                            .get(*id)
+                            .map(|tests| tests.is_empty())
+                            .unwrap_or(true);
+                !is_uncovered_normative
+            })
+            .map(|(id, _)| *id)
+            .collect()
+    }
+
+    /// Whether the traceability gate should fail: any *unexpected* uncovered
+    /// normative rule, any stale allowlist entry, or any orphan reference.
+    pub fn gate_failing(&self) -> bool {
+        !self.unexpected_uncovered_normative_paragraphs().is_empty()
+            || !self.stale_known_uncovered().is_empty()
+            || !self.orphan_references.is_empty()
+    }
+
     /// Returns the coverage percentage for normative paragraphs (0.0 to 100.0).
     ///
     /// Returns 100.0 if there are no normative paragraphs.
@@ -248,12 +342,14 @@ impl TraceabilityReport {
         // Normative coverage stats (what matters for pass/fail)
         let normative_total = self.normative_count();
         let normative_covered = self.normative_covered_count();
-        let normative_uncovered = self.normative_uncovered_count();
         let normative_pct = self.normative_coverage_percentage();
 
         println!(
-            "Normative Coverage: {:.1}% ({}/{} paragraphs)",
-            normative_pct, normative_covered, normative_total
+            "Normative Coverage: {:.1}% ({}/{} paragraphs, {} uncovered)",
+            normative_pct,
+            normative_covered,
+            normative_total,
+            self.normative_uncovered_count()
         );
 
         // Overall stats (informative)
@@ -307,10 +403,54 @@ impl TraceabilityReport {
         }
         println!();
 
-        // Uncovered normative paragraphs (what needs to be fixed)
-        let uncovered_normative = self.uncovered_normative_paragraphs();
+        // Known-gap normative paragraphs: uncovered, but explicitly allowlisted
+        // as pending a compiler feature (their only tests are skipped). Reported
+        // honestly but not gate-failing.
+        let known_gaps: Vec<&String> = self
+            .uncovered_normative_paragraphs()
+            .into_iter()
+            .filter(|id| Self::is_known_uncovered(id))
+            .collect();
+        if !known_gaps.is_empty() {
+            println!(
+                "Known-uncovered normative paragraphs ({}, pending implementation):",
+                known_gaps.len()
+            );
+            for id in known_gaps {
+                let reason = KNOWN_UNCOVERED_NORMATIVE
+                    .iter()
+                    .find(|(k, _)| k == id)
+                    .map(|(_, r)| *r)
+                    .unwrap_or("");
+                if let Some(para) = self.paragraphs.get(id) {
+                    println!("  {} [{}]: {}", id, para.category, reason);
+                }
+            }
+            println!();
+        }
+
+        // Stale allowlist entries: an allowlisted rule that regained coverage (or
+        // no longer exists) must be de-listed — this fails the gate.
+        let stale = self.stale_known_uncovered();
+        if !stale.is_empty() {
+            println!("Stale KNOWN_UNCOVERED_NORMATIVE entries ({}):", stale.len());
+            for id in stale {
+                println!(
+                    "  {} is now covered (or not a normative paragraph) — remove it \
+                     from KNOWN_UNCOVERED_NORMATIVE",
+                    id
+                );
+            }
+            println!();
+        }
+
+        // Unexpected uncovered normative paragraphs (what needs to be fixed).
+        let uncovered_normative = self.unexpected_uncovered_normative_paragraphs();
         if !uncovered_normative.is_empty() {
-            println!("Uncovered normative paragraphs ({}):", normative_uncovered);
+            println!(
+                "Uncovered normative paragraphs ({}):",
+                uncovered_normative.len()
+            );
             for id in uncovered_normative {
                 if let Some(para) = self.paragraphs.get(id) {
                     let text = truncate_with_ellipsis(&para.text, 60);
@@ -508,6 +648,16 @@ pub struct TestCase {
     pub name: String,
     /// Specification paragraph IDs that this test covers (e.g., ["3.1:5", "3.1:6"]).
     pub spec_refs: Vec<String>,
+    /// Whether this case actually *runs* and so can satisfy coverage.
+    ///
+    /// A rule's behavior is only exercised by a test that runs and is required
+    /// to pass. A case does **not** count as coverage if it is `skip = true`, or
+    /// if it is a preview-feature test that is allowed to fail (`preview` set
+    /// without `preview_should_pass`). Such a case's spec references still count
+    /// for orphan detection — a dangling reference is broken whether or not the
+    /// case runs — but they do not mark a normative paragraph as covered
+    /// (RUE-132).
+    pub counts_as_coverage: bool,
 }
 
 /// Parses test files and extracts specification references.
@@ -581,6 +731,21 @@ pub fn parse_test_files(cases_dir: &Path) -> Vec<TestFile> {
                     })
                     .unwrap_or_default();
 
+                // A case only counts as coverage if it actually runs and is
+                // required to pass (RUE-132): a `skip = true` case never runs,
+                // and a preview-feature test without `preview_should_pass` is
+                // allowed to fail, so neither exercises the rule it references.
+                let base_skip = case.get("skip").and_then(|s| s.as_bool()).unwrap_or(false);
+                let is_preview = case
+                    .get("preview")
+                    .and_then(|p| p.as_str())
+                    .is_some_and(|s| !s.is_empty());
+                let preview_should_pass = case
+                    .get("preview_should_pass")
+                    .and_then(|p| p.as_bool())
+                    .unwrap_or(false);
+                let preview_allowed_to_fail = is_preview && !preview_should_pass;
+
                 // Check if this is a parameterized test
                 if let Some(params_array) = case.get("params").and_then(|p| p.as_array()) {
                     // Expand parameterized test - each param set becomes a test case
@@ -614,9 +779,19 @@ pub fn parse_test_files(cases_dir: &Path) -> Vec<TestFile> {
                             }
                         }
 
+                        // A per-param `skip = true` override also disqualifies
+                        // just that instance from counting as coverage.
+                        let param_skip = param_table
+                            .get("skip")
+                            .and_then(|s| s.as_bool())
+                            .unwrap_or(false);
+                        let counts_as_coverage =
+                            !base_skip && !param_skip && !preview_allowed_to_fail;
+
                         cases.push(TestCase {
                             name: expanded_name,
                             spec_refs,
+                            counts_as_coverage,
                         });
                     }
                 } else {
@@ -624,6 +799,7 @@ pub fn parse_test_files(cases_dir: &Path) -> Vec<TestFile> {
                     cases.push(TestCase {
                         name: base_name,
                         spec_refs: base_spec_refs,
+                        counts_as_coverage: !base_skip && !preview_allowed_to_fail,
                     });
                 }
             }
@@ -682,9 +858,15 @@ pub fn generate_report(spec_dir: &Path, cases_dir: &Path) -> TraceabilityReport 
 
             for spec_ref in &case.spec_refs {
                 if let Some(tests) = coverage.get_mut(spec_ref) {
-                    tests.push(TestReference {
-                        test_name: test_name.clone(),
-                    });
+                    // A skipped or preview-allowed-to-fail case never exercises
+                    // the rule, so it must not mark the paragraph as covered
+                    // (RUE-132). Its reference is still valid, so it is not an
+                    // orphan — it simply doesn't contribute coverage.
+                    if case.counts_as_coverage {
+                        tests.push(TestReference {
+                            test_name: test_name.clone(),
+                        });
+                    }
                 } else {
                     orphan_references.push((test_name.clone(), spec_ref.clone()));
                 }
@@ -827,6 +1009,143 @@ fn main() { }
         // One of the two paragraphs is uncovered.
         assert_eq!(report.paragraphs.len() - report.covered_count(), 1);
         assert_eq!(report.coverage_percentage(), 50.0);
+    }
+
+    #[test]
+    fn test_skipped_and_preview_tests_do_not_count_as_coverage() {
+        // Four paragraphs, each referenced by exactly one test: a normal test, a
+        // skipped test, a preview test allowed to fail, and a preview test
+        // required to pass. Only the normal and the required-to-pass tests
+        // should count as coverage (RUE-132).
+        let spec = r#"
+{{ rule(id="1.1:1", cat="normative") }}
+Covered by a normal test.
+
+{{ rule(id="1.1:2", cat="normative") }}
+Referenced only by a skipped test.
+
+{{ rule(id="1.1:3", cat="normative") }}
+Referenced only by a preview test allowed to fail.
+
+{{ rule(id="1.1:4", cat="normative") }}
+Referenced by a preview test required to pass.
+"#;
+        let cases = r#"
+[section]
+id = "t.section"
+name = "T"
+
+[[case]]
+name = "normal"
+spec = ["1.1:1"]
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+
+[[case]]
+name = "skipped"
+spec = ["1.1:2"]
+skip = true
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+
+[[case]]
+name = "preview_may_fail"
+spec = ["1.1:3"]
+preview = "some_feature"
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+
+[[case]]
+name = "preview_must_pass"
+spec = ["1.1:4"]
+preview = "some_feature"
+preview_should_pass = true
+source = "fn main() -> i32 { 0 }"
+exit_code = 0
+"#;
+        let spec_dir = tempfile::tempdir().unwrap();
+        fs::write(spec_dir.path().join("s.md"), spec).unwrap();
+        let cases_dir = tempfile::tempdir().unwrap();
+        fs::write(cases_dir.path().join("c.toml"), cases).unwrap();
+
+        let report = generate_report(spec_dir.path(), cases_dir.path());
+
+        // Only 1.1:1 and 1.1:4 are exercised by a running, must-pass test.
+        assert!(!report.coverage["1.1:1"].is_empty(), "normal test covers");
+        assert!(
+            report.coverage["1.1:2"].is_empty(),
+            "skipped test must not count as coverage"
+        );
+        assert!(
+            report.coverage["1.1:3"].is_empty(),
+            "preview-allowed-to-fail test must not count as coverage"
+        );
+        assert!(
+            !report.coverage["1.1:4"].is_empty(),
+            "preview-must-pass test covers"
+        );
+        assert_eq!(report.normative_covered_count(), 2);
+        assert_eq!(report.normative_uncovered_count(), 2);
+        // The skipped/preview references are valid, so they are not orphans.
+        assert!(report.orphan_references.is_empty());
+    }
+
+    #[test]
+    fn test_known_uncovered_allowlist_gates_correctly() {
+        // Build a report seeding EVERY allowlisted rule as an uncovered
+        // normative paragraph (mirroring production, where they all exist), plus
+        // any extra `(id, covered)` paragraphs the caller wants.
+        fn report_with(extra: &[(&str, bool)]) -> TraceabilityReport {
+            let mut paragraphs = BTreeMap::new();
+            let mut coverage = BTreeMap::new();
+            let mut add = |id: &str, covered: bool| {
+                paragraphs.insert(
+                    id.to_string(),
+                    SpecParagraph {
+                        id: id.to_string(),
+                        category: "normative".to_string(),
+                        text: "t".to_string(),
+                    },
+                );
+                let tests = if covered {
+                    vec![TestReference {
+                        test_name: "t::c".to_string(),
+                    }]
+                } else {
+                    vec![]
+                };
+                coverage.insert(id.to_string(), tests);
+            };
+            for (id, _) in KNOWN_UNCOVERED_NORMATIVE {
+                add(id, false);
+            }
+            for (id, covered) in extra {
+                add(id, *covered);
+            }
+            TraceabilityReport {
+                paragraphs,
+                coverage,
+                orphan_references: vec![],
+            }
+        }
+
+        // All allowlisted rules uncovered, nothing else: reported, but the gate
+        // passes and nothing is stale.
+        let r = report_with(&[]);
+        assert!(r.unexpected_uncovered_normative_paragraphs().is_empty());
+        assert!(r.stale_known_uncovered().is_empty());
+        assert!(!r.gate_failing());
+
+        // A non-allowlisted uncovered normative rule fails the gate.
+        let r = report_with(&[("99.9:1", false)]);
+        assert_eq!(r.unexpected_uncovered_normative_paragraphs().len(), 1);
+        assert!(r.gate_failing());
+
+        // An allowlisted rule that is now COVERED is stale and fails the gate.
+        let allow_id = KNOWN_UNCOVERED_NORMATIVE[0].0;
+        let r = report_with(&[(allow_id, true)]);
+        assert_eq!(r.stale_known_uncovered(), vec![allow_id]);
+        assert!(r.gate_failing());
     }
 
     #[test]

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -496,6 +496,34 @@ pub fn expand_case(case: Case) -> Vec<Case> {
                     expanded.timeout_ms = Some(i as u64);
                 }
             }
+            // A per-param `error_contains` / `expected_error` lets a
+            // parameterized case give each variant its own diagnostic assertion
+            // (e.g. a mix of failing and succeeding variants). Without honoring
+            // it here, the override was silently dropped and never checked — the
+            // same vacuous-pass hole RUE-132 closes elsewhere. Accepts a string
+            // or an array of strings, matching the case-level field.
+            if let Some(value) = params.get("error_contains") {
+                match value {
+                    toml::Value::String(s) => {
+                        expanded.error_contains =
+                            ErrorContains(vec![substitute_placeholders(s, params)]);
+                    }
+                    toml::Value::Array(arr) => {
+                        expanded.error_contains = ErrorContains(
+                            arr.iter()
+                                .filter_map(|v| v.as_str())
+                                .map(|s| substitute_placeholders(s, params))
+                                .collect(),
+                        );
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(value) = params.get("expected_error") {
+                if let Some(s) = value.as_str() {
+                    expanded.expected_error = Some(substitute_placeholders(s, params));
+                }
+            }
 
             // Merge spec_extra into spec
             if let Some(value) = params.get("spec_extra") {
@@ -629,6 +657,62 @@ pub fn validate_error_assertions(test_file: &TestFile) -> Vec<StrayErrorAssertio
     errors
 }
 
+/// An error indicating a `compile_fail` case declares no error assertion at all
+/// (neither `error_contains` nor `expected_error`).
+///
+/// Without an assertion, such a case passes on *any* rejection — a diagnostic
+/// for an unrelated reason, or (before ICE detection) even a compiler crash —
+/// so it verifies nothing about *why* the program is rejected. Requiring at
+/// least one assertion at load time forces every `compile_fail` case to pin the
+/// specific error it is testing (RUE-132).
+#[derive(Debug, Clone)]
+pub struct BareCompileFailError {
+    /// The name of the offending test case.
+    pub test_name: String,
+    /// The section ID the test belongs to.
+    pub section_id: String,
+}
+
+impl std::fmt::Display for BareCompileFailError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "test '{}::{}' is `compile_fail` but declares no `error_contains` or \
+             `expected_error` — it would pass on ANY rejection, verifying nothing \
+             about why the program is rejected. Add an assertion pinning the \
+             specific error (e.g. `error_contains = \"[E0206]\"`).",
+            self.section_id, self.test_name
+        )
+    }
+}
+
+impl std::error::Error for BareCompileFailError {}
+
+/// Validate that every `compile_fail` case declares at least one error
+/// assertion. Returns one error per offending case.
+///
+/// This is the inverse of [`validate_error_assertions`]: that check rejects a
+/// compile-error assertion on a case that is *not* `compile_fail`; this one
+/// rejects a `compile_fail` case that carries *no* such assertion.
+pub fn validate_compile_fail_assertions(test_file: &TestFile) -> Vec<BareCompileFailError> {
+    let mut errors = Vec::new();
+    for case in &test_file.case {
+        if !case.compile_fail {
+            continue;
+        }
+        let has_error_contains = !case.error_contains.is_empty();
+        let has_expected_error = case.expected_error.is_some();
+        if has_error_contains || has_expected_error {
+            continue;
+        }
+        errors.push(BareCompileFailError {
+            test_name: case.name.clone(),
+            section_id: test_file.section.id.clone(),
+        });
+    }
+    errors
+}
+
 /// Recursively collect all files with the given extension from a directory.
 pub fn collect_files_by_ext(dir: &Path, ext: &str, files: &mut Vec<PathBuf>) {
     if let Ok(entries) = fs::read_dir(dir) {
@@ -664,6 +748,7 @@ pub fn load_test_files(cases_dir: &Path) -> Vec<(String, TestFile)> {
     let mut specs = Vec::new();
     let mut preview_errors: Vec<UnknownPreviewFeatureError> = Vec::new();
     let mut stray_error_assertions: Vec<StrayErrorAssertionError> = Vec::new();
+    let mut bare_compile_fail: Vec<BareCompileFailError> = Vec::new();
 
     if !cases_dir.exists() {
         eprintln!(
@@ -697,6 +782,9 @@ pub fn load_test_files(cases_dir: &Path) -> Vec<(String, TestFile)> {
 
                 // Reject compile-error assertions on cases that aren't compile_fail
                 stray_error_assertions.extend(validate_error_assertions(&spec));
+
+                // Reject `compile_fail` cases that carry no error assertion at all
+                bare_compile_fail.extend(validate_compile_fail_assertions(&spec));
 
                 // Build a relative path from cases_dir to create the identifier
                 // e.g., "expressions/match" for "cases/expressions/match.toml"
@@ -761,6 +849,23 @@ Error: {} test file(s) failed to load:",
             "Test loading failed: {} case(s) set `error_contains`/`expected_error` without \
              `compile_fail`. See errors above for details.",
             stray_error_assertions.len()
+        );
+    }
+
+    // Report bare compile_fail cases and fail if any were found
+    if !bare_compile_fail.is_empty() {
+        eprintln!(
+            "\nError: Found {} `compile_fail` case(s) with no error assertion:",
+            bare_compile_fail.len()
+        );
+        for error in &bare_compile_fail {
+            eprintln!("  - {}", error);
+        }
+        panic!(
+            "Test loading failed: {} `compile_fail` case(s) declare neither \
+             `error_contains` nor `expected_error`, so they pass on any rejection. \
+             See errors above for details.",
+            bare_compile_fail.len()
         );
     }
 
@@ -1701,6 +1806,48 @@ mod tests {
     }
 
     #[test]
+    fn test_expand_case_per_param_error_contains_override() {
+        // A mixed parameterized case: one failing variant with its own
+        // `error_contains`, one succeeding variant with none. The per-param
+        // override must land on the failing variant (and be substituted), while
+        // the succeeding variant carries no assertion — so the bare-compile_fail
+        // guard is satisfied for the former and doesn't fire on the latter.
+        let toml = r#"
+[section]
+id = "t.section"
+name = "T"
+
+[[case]]
+name = "mixed_{variant}"
+source = "fn f() -> {ty} { {body} }"
+params = [
+  { variant = "bad", ty = "i32", body = "true", compile_fail = true, error_contains = "expected {ty}" },
+  { variant = "ok", ty = "i32", body = "0", compile_fail = false, exit_code = 0 },
+]
+"#;
+        let tf: TestFile = toml::from_str(toml).expect("valid TOML");
+        let expanded = expand_test_file(tf);
+        let cases = &expanded.case;
+        assert_eq!(cases.len(), 2);
+
+        let bad = cases.iter().find(|c| c.name == "mixed_bad").unwrap();
+        assert!(bad.compile_fail);
+        // Placeholder in the override is substituted with the param value.
+        assert_eq!(
+            bad.error_contains,
+            ErrorContains(vec!["expected i32".to_string()])
+        );
+
+        let ok = cases.iter().find(|c| c.name == "mixed_ok").unwrap();
+        assert!(!ok.compile_fail);
+        assert!(ok.error_contains.is_empty());
+
+        // The guard accepts the failing variant and ignores the succeeding one.
+        assert!(validate_compile_fail_assertions(&expanded).is_empty());
+        assert!(validate_error_assertions(&expanded).is_empty());
+    }
+
+    #[test]
     fn test_toml_value_to_string() {
         assert_eq!(
             toml_value_to_string(&toml::Value::String("hello".to_string())),
@@ -2261,5 +2408,78 @@ mod tests {
             .expect("large stdin echoed to stdout should complete");
         assert!(output.status.success());
         assert_eq!(output.stdout.len(), 200_000);
+    }
+
+    // Tests for the load-time guard requiring every `compile_fail` case to
+    // declare an error assertion (RUE-132). A bare `compile_fail` case passes on
+    // ANY rejection, verifying nothing about *why* the program is rejected.
+
+    #[test]
+    fn test_bare_compile_fail_case_is_rejected() {
+        let toml = r#"
+[section]
+id = "test.section"
+name = "Test"
+
+[[case]]
+name = "bare_reject"
+compile_fail = true
+source = "fn main() -> i32 { true }"
+"#;
+        let tf: TestFile = toml::from_str(toml).expect("valid TOML");
+        let errors = validate_compile_fail_assertions(&tf);
+        assert_eq!(errors.len(), 1, "bare compile_fail case must be flagged");
+        assert_eq!(errors[0].test_name, "bare_reject");
+        assert_eq!(errors[0].section_id, "test.section");
+    }
+
+    #[test]
+    fn test_compile_fail_with_error_contains_is_accepted() {
+        let toml = r#"
+[section]
+id = "test.section"
+name = "Test"
+
+[[case]]
+name = "pinned_reject"
+compile_fail = true
+error_contains = "[E0206]"
+source = "fn main() -> i32 { true }"
+"#;
+        let tf: TestFile = toml::from_str(toml).expect("valid TOML");
+        assert!(validate_compile_fail_assertions(&tf).is_empty());
+    }
+
+    #[test]
+    fn test_compile_fail_with_expected_error_is_accepted() {
+        let toml = r#"
+[section]
+id = "test.section"
+name = "Test"
+
+[[case]]
+name = "golden_reject"
+compile_fail = true
+expected_error = "error: [E0206]: type mismatch"
+source = "fn main() -> i32 { true }"
+"#;
+        let tf: TestFile = toml::from_str(toml).expect("valid TOML");
+        assert!(validate_compile_fail_assertions(&tf).is_empty());
+    }
+
+    #[test]
+    fn test_non_compile_fail_case_needs_no_error_assertion() {
+        let toml = r#"
+[section]
+id = "test.section"
+name = "Test"
+
+[[case]]
+name = "runs_fine"
+source = "fn main() -> i32 { 42 }"
+exit_code = 42
+"#;
+        let tf: TestFile = toml::from_str(toml).expect("valid TOML");
+        assert!(validate_compile_fail_assertions(&tf).is_empty());
     }
 }

--- a/docs/spec/src/03-types/04-never-type.md
+++ b/docs/spec/src/03-types/04-never-type.md
@@ -8,7 +8,7 @@ template = "spec/page.html"
 
 {{ rule(id="3.4:1", cat="normative") }}
 
-The never type, written `!`, is the type of expressions that never produce a value.
+The never type, written `!`, is the type of an expression that transfers control away from its context rather than producing a value — a diverging expression (`docs/formal/01-core-calculus.md` §5.7).
 
 {{ rule(id="3.4:2", cat="normative") }}
 
@@ -22,11 +22,11 @@ Expressions of type `!` include:
 
 {{ rule(id="3.4:3", cat="normative") }}
 
-A type coercion is an implicit type conversion that occurs automatically during type checking. Rue has exactly one coercion: the never type coerces to any type.
+A type coercion is an implicit type conversion applied during type checking. Rue has exactly one coercion: the never type coerces to any type. The core states this as subsumption on the bottom type — the (Sub-Never) rule of `docs/formal/01-core-calculus.md` §5.7 — while every other typing rule demands exact type identity.
 
 {{ rule(id="3.4:4", cat="normative") }}
 
-When type checking requires a value of type `T`, a value of type `!` is accepted. This allows diverging expressions to appear in any context where a value is expected.
+When type checking requires a value of type `T`, an expression of type `!` is accepted at `T`. The conversion is vacuously sound: `!` has no values (3.4:9), so re-typing a diverging expression at `T` converts no run-time value and creates no ownership obligation (`docs/formal/01-core-calculus.md` §5.7). This lets diverging expressions appear in any context where a value is expected.
 
 {{ rule(id="3.4:5") }}
 

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -363,6 +363,58 @@ fn main() -> i32 {
 }
 ```
 
+## The `str` Type
+
+{{ preview_feature(feature="string_trio", adr="ADR-0043") }}
+
+{{ rule(id="3.7:43", cat="normative") }}
+
+The type `str` is the byte-string slice type: it is `[u8]` (a read-only slice of
+bytes) carrying the same byte-string convention as `String` (§3.7:15) — its
+contents are conventionally UTF-8 but are not required to be valid UTF-8. A `str`
+value is a two-word view `{ptr, len}`: a pointer to the bytes and a byte length.
+
+{{ rule(id="3.7:44", cat="normative") }}
+
+Where a `str` is expected, a string literal has type `str` and is *static-backed*
+and *first-class*: its bytes reside in read-only data that cannot dangle, so the
+`str` value is `@copy`, storable in a binding or a struct field, reassignable,
+returnable from a function, and passable as an argument.
+
+{{ rule(id="3.7:45", cat="normative") }}
+
+For a `str` value `s`, `s.len()` evaluates to the length of `s` in bytes as a
+`u64`. The operation is `O(1)`.
+
+{{ rule(id="3.7:46", cat="normative") }}
+
+Indexing a `str` with an integer, `s[i]`, evaluates to the byte at byte offset
+`i` as a value of type `u8`. Like `String` byte access (§3.7:16) it operates on
+the raw bytes and never inspects UTF-8 character boundaries. The operation is
+`O(1)`.
+
+{{ rule(id="3.7:47", cat="dynamic-semantics") }}
+
+If the index `i` is greater than or equal to `s.len()`, evaluating `s[i]` traps
+(index out of bounds), terminating the program the same way an out-of-bounds
+array or `String` index does.
+
+{{ rule(id="3.7:48") }}
+
+```rue
+fn describe(s: str) -> u8 {
+    s[0]              // first byte
+}
+
+fn main() -> i32 {
+    let s: str = "hello";
+    @dbg(s.len());    // 5
+    @dbg(s[0]);       // 104 ('h')
+    @dbg(describe("hi"));  // 104
+    0
+}
+```
+
 ## Limitations
 
 {{ rule(id="3.7:14", cat="informative") }}

--- a/docs/spec/src/03-types/09-destructors.md
+++ b/docs/spec/src/03-types/09-destructors.md
@@ -5,17 +5,17 @@ weight = 9
 
 # Destructors
 
-This section describes when and how values are cleaned up in Rue.
+This section describes when and how values are dropped in Rue.
 
 ## Drop Semantics
 
 {{ rule(id="3.9:1", cat="normative") }}
 
-When a value's owning binding goes out of scope and the value has not been moved elsewhere, the value is *dropped*. Dropping a value runs its destructor, if it has one.
+When a value's owning binding goes out of scope and the value has not been moved out of it, the value is *dropped*. Dropping runs the value's *drop glue* — its user destructor if it has one, then the drop of its droppable contents (3.9:28) — as fixed by the drop relation in `docs/formal/01-core-calculus.md` §6.11.
 
 {{ rule(id="3.9:2", cat="normative") }}
 
-A value is dropped exactly once. Values that are moved are not dropped at their original binding site; they are dropped at their final destination.
+A value is dropped exactly once. A move sets the source place to moved-out, and the drop relation skips a moved-out place (`docs/formal/01-core-calculus.md` §6.11): so a moved value is not dropped at its original binding site but through its final owner. This is the no-double-free guarantee (`docs/formal/01-core-calculus.md` §7).
 
 {{ rule(id="3.9:3", cat="example") }}
 


### PR DESCRIPTION
- **RUE-324** (ADR-0043 Phase 3): `str` core — {ptr,len} view (reuses slice repr, --preview string_trio), static-backed .rodata literals, `.len()`, bounds-checked byte-index (traps on OOB), first-class param/return/field. str indexing routes through new `__rue_str_byte_at` (slice stride is slot*8, wrong for packed bytes). Both backends. Deferred: concat/compare/interop/range/borrow-str.
- **RUE-132** (completes the epic): load-time guard requiring every compile_fail case to assert its error + backfilled 106 bare cases with real E-codes; found+fixed expand_case dropping per-param assertions; honest traceability (skipped/preview-allowed-to-fail don't count) → 99.3% real, 5 allowlisted @allow rules pending.
- **RUE-202** (types): folk-terms retired in 3.4 never + 3.9 destructors vs the core.

clippy clean; test.sh Pass 25, honest traceability 99.3%, oracle 0.

Fixes RUE-324
Fixes RUE-132

Generated with Claude Code