### PR TITLE
Diagnostics: fix E0102 'as' hint to suggest the correct @intCast(value) form

### DIFF
--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -843,8 +843,8 @@ where
                 None => Ok(parsed),
                 Some(span) => Err(Rich::custom(
                     span,
-                    "Rue has no 'as' cast operator; use '@intCast(T, value)' or give the target \
-                     type on the binding: 'let x: i64 = value'",
+                    "Rue has no 'as' cast operator; use '@intCast(value)' (the target type comes \
+                     from context) or give the target type on the binding: 'let x: i64 = value'",
                 )),
             })
     })


### PR DESCRIPTION
The E0102 message for a Rust-style `as` cast suggested `@intCast(T, value)` — a 2-arg form that doesn't exist (@intCast takes 1 arg; target type from context). Following the hint gave a *second* error (E0701). Spec 9.2 confirms the 1-arg form; `@cast` isn't a real intrinsic. Corrected to `@intCast(value)`, which compiles+runs.

Found while capturing the agent-ergonomics data in **RUE-353** (agents keep reaching for `as`, and the error's own fix then misled a second time). clippy clean; test.sh Pass 25.

Part of RUE-353

Generated with Claude Code