### PR TITLE
Duplicate-param error (E0491), driver -j/clobber fixes, ch8 runtime prose

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -861,6 +861,15 @@ impl<'a> Sema<'a> {
                     has_self,
                     ..
                 } => {
+                    // Reject duplicate parameter names (RUE-349) for EVERY
+                    // function/method form. `rir.iter()` visits every `FnDecl`
+                    // in the arena exactly once — free functions, named-struct
+                    // methods, associated functions, and anonymous-struct
+                    // methods alike — so checking here before the
+                    // signature-collection skips below covers them all in one
+                    // place without double-reporting.
+                    self.check_duplicate_param_names(*params_start, *params_len)?;
+
                     // Skip methods (has_self = true) - these are handled elsewhere:
                     // - Named struct methods are collected via ImplDecl
                     if *has_self {
@@ -1068,6 +1077,32 @@ impl<'a> Sema<'a> {
             }
         }
         None
+    }
+
+    /// Reject a parameter list that names the same parameter twice, e.g.
+    /// `fn f(x: i32, x: i32)` (RUE-349). Without this check the later binding
+    /// silently shadows the earlier one on a first-wins basis, so a typo'd or
+    /// duplicated name compiles instead of erroring and which parameter a
+    /// reference resolves to is an unstated policy. The diagnostic points at
+    /// the second (duplicate) occurrence, mirroring the duplicate
+    /// pattern-binding check (E0484). `self` is never in this list — a method
+    /// receiver is carried separately (`has_self`) — so `fn m(self, a, a)`
+    /// still errors on the repeated `a` while `self` plus one distinct param
+    /// is fine.
+    fn check_duplicate_param_names(&self, params_start: u32, params_len: u32) -> CompileResult<()> {
+        let params = self.rir.get_params(params_start, params_len);
+        let mut seen: HashSet<Spur> = HashSet::with_capacity(params.len());
+        for param in &params {
+            if !seen.insert(param.name) {
+                return Err(CompileError::new(
+                    ErrorKind::DuplicateParameter {
+                        name: self.interner.resolve(&param.name).to_string(),
+                    },
+                    param.span,
+                ));
+            }
+        }
+        Ok(())
     }
 
     /// Collect a function signature for forward reference.

--- a/crates/rue-cli-tests/cases/duplicate_parameters.toml
+++ b/crates/rue-cli-tests/cases/duplicate_parameters.toml
@@ -1,0 +1,60 @@
+# Duplicate parameter names (RUE-349). A parameter list that names the same
+# parameter twice is rejected at sema with E0491, pointing at the second
+# occurrence, instead of silently binding references first-wins. Distinct
+# names still compile and run through the real driver end-to-end.
+
+[section]
+id = "cli.duplicate_parameters"
+name = "Duplicate parameter names"
+description = "A repeated parameter name is an E0491 error; distinct names compile and run (RUE-349)."
+
+[[case]]
+name = "duplicate_free_fn_param_rejected"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn f(x: i32, x: i32) -> i32 { x }
+fn main() -> i32 { f(1, 2) }
+""" }]
+compile_fail = true
+error_contains = ["E0491", "duplicate parameter name 'x'"]
+
+[[case]]
+name = "duplicate_method_param_rejected"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct S {
+    v: i32,
+    fn m(self, a: i32, a: i32) -> i32 { a }
+}
+fn main() -> i32 { let s = S { v: 0 }; s.m(1, 2) }
+""" }]
+compile_fail = true
+error_contains = ["E0491", "duplicate parameter name 'a'"]
+
+[[case]]
+name = "distinct_params_run"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+fn f(x: i32, y: i32) -> i32 { x + y }
+fn main() -> i32 {
+    @dbg(f(11, 31));
+    0
+}
+""" }]
+stdout = "42\n"
+
+[[case]]
+name = "method_self_plus_distinct_runs"
+args = ["main.rue", "-o", "prog"]
+files = [{ path = "main.rue", source = """
+struct S {
+    v: i32,
+    fn m(self, a: i32, b: i32) -> i32 { self.v + a + b }
+}
+fn main() -> i32 {
+    let s = S { v: 30 };
+    @dbg(s.m(4, 8));
+    0
+}
+""" }]
+stdout = "42\n"

--- a/crates/rue-cli-tests/cases/emit_pipeline.toml
+++ b/crates/rue-cli-tests/cases/emit_pipeline.toml
@@ -63,3 +63,19 @@ args = ["--emit", "tokens", "main.rue", "bad.rue"]
 compile_fail = true
 compile_stderr_contains = ["bad.rue:", "let # = 3;"]
 compile_stderr_not_contains = ["main.rue:"]
+
+# RUE-352: `-j`/`--jobs` was silently ignored under --emit. The jobs setting was
+# only applied inside compile_multi_file_with_options, which the --emit path
+# never calls, so `--emit asm -j1` ran multi-threaded. The pool config is now
+# hoisted into main() ahead of both paths. This case pins that --emit still
+# produces asm when a jobs count is requested (and that it doesn't panic on a
+# double thread-pool init).
+[[case]]
+name = "emit_asm_honors_jobs_flag"
+description = "-j/--jobs is accepted and applied in --emit mode (RUE-352)."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 { 42 }
+""" }]
+args = ["--emit", "asm", "-j1", "main.rue"]
+compile_only = true
+compile_stdout_contains = ["=== Assembly", "main"]

--- a/crates/rue-cli-tests/cases/output_guard.toml
+++ b/crates/rue-cli-tests/cases/output_guard.toml
@@ -35,3 +35,22 @@ name = "legacy_non_rue_output_still_works"
 files = [{ path = "a.rue", source = "fn main() -> i32 { 5 }\n" }]
 args = ["a.rue", "prog"]
 exit_code = 5
+
+[[case]]
+# RUE-351: an EXTENSIONLESS source used as `-o` must be refused. The old guard
+# only recognized inputs by a `.rue` suffix, so `rue prog -o prog` (prog is a
+# source) slipped through and the compiled ELF silently overwrote the source.
+name = "extensionless_output_equal_to_input_refused"
+files = [{ path = "prog", source = "fn main() -> i32 { 7 }\n" }]
+args = ["prog", "-o", "prog"]
+compile_fail = true
+error_contains = ["also an input source file"]
+
+[[case]]
+# RUE-351: the guard compares RESOLVED paths, so a different spelling of the
+# same file (`./prog` vs `prog`) is caught too, not just a byte-for-byte match.
+name = "output_equal_to_input_different_spelling_refused"
+files = [{ path = "prog", source = "fn main() -> i32 { 7 }\n" }]
+args = ["./prog", "-o", "prog"]
+compile_fail = true
+error_contains = ["also an input source file"]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -1162,6 +1162,27 @@ pub fn compile_with_options(
     compile_multi_file_with_options(&sources, options)
 }
 
+/// Configure Rayon's global thread pool for the requested number of jobs.
+///
+/// Call this **exactly once**, early in the driver's `main()`, before any
+/// parallel work and before dispatching to the emit-vs-compile branches.
+/// `ThreadPoolBuilder::build_global()` panics if called twice, so this must
+/// live in the single-entry driver, not inside a per-compilation function
+/// like [`compile_multi_file_with_options`] which several code paths call
+/// (and which the `--emit` path skips entirely — the RUE-352 bug).
+///
+/// `jobs == 0` means auto-detect (Rayon's default: all available cores), so
+/// the global pool is left untouched.
+pub fn configure_thread_pool(jobs: usize) {
+    if jobs > 0 {
+        // Ignore the error if the pool was already initialized (e.g. a test
+        // harness in the same process). We only want to set the thread count.
+        let _ = rayon::ThreadPoolBuilder::new()
+            .num_threads(jobs)
+            .build_global();
+    }
+}
+
 /// Compile multiple source files to an ELF binary.
 ///
 /// This is the main entry point for multi-file compilation. It:
@@ -1200,16 +1221,11 @@ pub fn compile_multi_file_with_options(
     sources: &[SourceFile<'_>],
     options: &CompileOptions,
 ) -> MultiErrorResult<CompileOutput> {
-    // Configure Rayon's global thread pool based on the jobs setting.
-    // This must happen before any parallel operations.
-    // 0 means auto-detect (use all cores), which is Rayon's default.
-    if options.jobs > 0 {
-        // Ignore the error if the pool has already been initialized (e.g., in tests).
-        // This is safe because we're just trying to set the thread count.
-        let _ = rayon::ThreadPoolBuilder::new()
-            .num_threads(options.jobs)
-            .build_global();
-    }
+    // NOTE: the Rayon global thread pool is deliberately NOT configured here.
+    // `build_global()` panics if called twice, and the `--emit` driver path
+    // never reaches this function, so it was silently ignoring `-j`/`--jobs`
+    // (RUE-352). The jobs setting is now applied once in the driver's `main()`
+    // via `configure_thread_pool` before dispatching to any path.
 
     let total_source_bytes: usize = sources.iter().map(|s| s.source.len()).sum();
     let _span = info_span!(

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -218,6 +218,13 @@ impl ErrorCode {
     /// so its operand MUST name a struct field. Use `@raw`/`@raw_mut` for the
     /// address of a whole variable or array element.
     pub const FIELD_PTR_REQUIRES_FIELD: Self = Self(490);
+    /// A function or method parameter list names the same parameter twice
+    /// (e.g. `fn f(x: i32, x: i32)`). Every parameter in a single list must
+    /// have a distinct name (spec 6.1); a repeated name silently shadows the
+    /// earlier binding on a first-wins basis, so the declaration is rejected
+    /// (RUE-349, a sibling of [`Self::DUPLICATE_PATTERN_BINDING`] (E0484) and
+    /// analogous to Rust's E0415).
+    pub const DUPLICATE_PARAMETER: Self = Self(491);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -1065,6 +1072,10 @@ pub enum ErrorKind {
         type_name: String,
         method_name: String,
     },
+    /// A function or method parameter list names the same parameter twice.
+    /// The span points at the second (duplicate) occurrence (RUE-349).
+    #[error("duplicate parameter name '{name}'")]
+    DuplicateParameter { name: String },
     /// Method not found on a type
     #[error("no method named '{method_name}' found for type '{type_name}'")]
     UndefinedMethod {
@@ -1430,6 +1441,7 @@ impl ErrorKind {
                 ErrorCode::LINEAR_FIELD_DROPPED_BY_DESTRUCTURE
             }
             ErrorKind::DuplicateMethod { .. } => ErrorCode::DUPLICATE_METHOD,
+            ErrorKind::DuplicateParameter { .. } => ErrorCode::DUPLICATE_PARAMETER,
             ErrorKind::UndefinedMethod { .. } => ErrorCode::UNDEFINED_METHOD,
             ErrorKind::UndefinedAssocFn { .. } => ErrorCode::UNDEFINED_ASSOC_FN,
             ErrorKind::MethodCallOnNonStruct { .. } => ErrorCode::METHOD_CALL_ON_NON_STRUCT,

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -341,6 +341,7 @@ impl<'a> AstGen<'a> {
                 ty: self.intern_type(&p.ty),
                 mode: self.convert_param_mode(p.mode),
                 is_comptime: p.mode == ParamMode::Comptime,
+                span: p.name.span,
             })
             .collect();
         let (params_start, params_len) = self.rir.add_params(&params);
@@ -454,6 +455,7 @@ impl<'a> AstGen<'a> {
                 ty: self.intern_type(&p.ty),
                 mode: self.convert_param_mode(p.mode),
                 is_comptime: p.mode == ParamMode::Comptime,
+                span: p.name.span,
             })
             .collect();
         let (params_start, params_len) = self.rir.add_params(&params);

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -6,7 +6,7 @@
 use std::fmt;
 
 use lasso::{Key, Spur};
-use rue_span::Span;
+use rue_span::{FileId, Span};
 
 /// A reference to an instruction in the RIR.
 ///
@@ -71,6 +71,9 @@ pub struct RirParam {
     /// the `comptime` modifier; carried separately from `mode`, which stays
     /// `Normal` for comptime parameters)
     pub is_comptime: bool,
+    /// Span of the parameter's name, used to point diagnostics (e.g. the
+    /// duplicate-parameter error, RUE-349) at the offending occurrence.
+    pub span: Span,
 }
 
 /// Argument passing mode in RIR.
@@ -163,7 +166,7 @@ const CALL_ARG_SIZE: u32 = 2;
 
 /// Stored representation of RirParam in the extra array.
 /// Layout: [name: u32, ty: u32, mode: u32, is_comptime: u32] = 4 u32s per param
-const PARAM_SIZE: u32 = 4;
+const PARAM_SIZE: u32 = 7;
 
 /// Stored representation of match arm in the extra array.
 /// Layout: pattern data + [body: u32]
@@ -360,7 +363,8 @@ impl Rir {
     }
 
     /// Store RirParams and return (start, len).
-    /// Layout: [name: u32, ty: u32, mode: u32, is_comptime: u32] per param
+    /// Layout: [name: u32, ty: u32, mode: u32, is_comptime: u32,
+    ///          span.file_id: u32, span.start: u32, span.end: u32] per param
     pub fn add_params(&mut self, params: &[RirParam]) -> (u32, u32) {
         let mut data = Vec::with_capacity(params.len() * PARAM_SIZE as usize);
         for param in params {
@@ -368,6 +372,9 @@ impl Rir {
             data.push(param.ty.into_usize() as u32);
             data.push(param.mode as u32);
             data.push(param.is_comptime as u32);
+            data.push(param.span.file_id.index());
+            data.push(param.span.start);
+            data.push(param.span.end);
         }
         let start = self.add_extra(&data);
         (start, params.len() as u32)
@@ -388,11 +395,13 @@ impl Rir {
                 _ => RirParamMode::Normal, // Fallback
             };
             let is_comptime = chunk[3] != 0;
+            let span = Span::with_file(FileId::new(chunk[4]), chunk[5], chunk[6]);
             params.push(RirParam {
                 name,
                 ty,
                 mode,
                 is_comptime,
+                span,
             });
         }
         params
@@ -2911,6 +2920,7 @@ mod tests {
             ty: param_type,
             mode: RirParamMode::Normal,
             is_comptime: false,
+            span: Span::default(),
         }]);
 
         rir.add_inst(Inst {
@@ -2995,18 +3005,21 @@ mod tests {
                 ty: param1_type,
                 mode: RirParamMode::Normal,
                 is_comptime: false,
+                span: Span::default(),
             },
             RirParam {
                 name: param2_name,
                 ty: param2_type,
                 mode: RirParamMode::Inout,
                 is_comptime: false,
+                span: Span::default(),
             },
             RirParam {
                 name: param3_name,
                 ty: param3_type,
                 mode: RirParamMode::Borrow,
                 is_comptime: false,
+                span: Span::default(),
             },
         ]);
 

--- a/crates/rue-spec/cases/items/functions.toml
+++ b/crates/rue-spec/cases/items/functions.toml
@@ -1025,3 +1025,58 @@ fn main() -> i32 {
 }
 """
 exit_code = 42
+
+# =============================================================================
+# Duplicate parameter names (6.1:34, RUE-349): the parameters in a single list
+# must have distinct names. A repeated name is an E0491 error; without the
+# check it silently shadows on a first-wins basis. `self` is not a named
+# parameter for this rule.
+# =============================================================================
+
+[[case]]
+name = "duplicate_parameter_name_is_error"
+spec = ["6.1:34"]
+description = "Two parameters with the same name are rejected (E0491)"
+source = """
+fn f(x: i32, x: i32) -> i32 { x }
+fn main() -> i32 { f(1, 2) }
+"""
+compile_fail = true
+error_contains = "duplicate parameter name 'x'"
+
+[[case]]
+name = "distinct_parameter_names_ok"
+spec = ["6.1:34"]
+description = "Parameters with distinct names compile and run"
+source = """
+fn f(x: i32, y: i32) -> i32 { x + y }
+fn main() -> i32 { f(11, 31) }
+"""
+exit_code = 42
+
+[[case]]
+name = "method_duplicate_parameter_name_is_error"
+spec = ["6.1:34"]
+description = "A method's non-self parameters must also be distinct (E0491)"
+source = """
+struct S {
+    v: i32,
+    fn m(self, a: i32, a: i32) -> i32 { a }
+}
+fn main() -> i32 { let s = S { v: 0 }; s.m(1, 2) }
+"""
+compile_fail = true
+error_contains = "duplicate parameter name 'a'"
+
+[[case]]
+name = "method_self_plus_distinct_params_ok"
+spec = ["6.1:34"]
+description = "self plus distinctly-named parameters is fine"
+source = """
+struct S {
+    v: i32,
+    fn m(self, a: i32, b: i32) -> i32 { self.v + a + b }
+}
+fn main() -> i32 { let s = S { v: 30 }; s.m(4, 8) }
+"""
+exit_code = 42

--- a/crates/rue-ui-tests/cases/diagnostics/duplicate-parameters.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/duplicate-parameters.toml
@@ -1,0 +1,70 @@
+[section]
+id = "diagnostics.duplicate-parameters"
+name = "Duplicate Parameter Names"
+description = "Tests that a repeated parameter name is rejected (E0491) with a diagnostic that points at the second occurrence (RUE-349)."
+
+# =============================================================================
+# Free functions
+# =============================================================================
+
+# The diagnostic blames the SECOND `x` (column 14), not the first, since that
+# is the offending duplicate declaration.
+[[case]]
+name = "duplicate_param_points_at_second"
+source = """
+fn f(x: i32, x: i32) -> i32 { x }
+fn main() -> i32 { f(1, 2) }
+"""
+compile_fail = true
+error_contains = ["E0491", "duplicate parameter name 'x'", "1:14"]
+
+# A non-adjacent duplicate (x, y, x) is still caught and points at the third
+# parameter's `x`.
+[[case]]
+name = "duplicate_param_non_adjacent"
+source = """
+fn f(x: i32, y: i32, x: i32) -> i32 { y }
+fn main() -> i32 { f(1, 2, 3) }
+"""
+compile_fail = true
+error_contains = ["E0491", "1:22"]
+
+# Duplicate comptime parameters are rejected too.
+[[case]]
+name = "duplicate_comptime_param"
+source = """
+fn f(comptime N: i32, comptime N: i32) -> i32 { N }
+fn main() -> i32 { f(1, 2) }
+"""
+compile_fail = true
+error_contains = ["E0491", "duplicate parameter name 'N'"]
+
+# =============================================================================
+# Methods and associated functions
+# =============================================================================
+
+# A method's `self` receiver is not a named parameter, so it is the repeated
+# non-self parameter `a` (not `self`) that is blamed.
+[[case]]
+name = "duplicate_method_param"
+source = """
+struct S {
+    v: i32,
+    fn m(self, a: i32, a: i32) -> i32 { a }
+}
+fn main() -> i32 { let s = S { v: 0 }; s.m(1, 2) }
+"""
+compile_fail = true
+error_contains = ["E0491", "duplicate parameter name 'a'"]
+
+[[case]]
+name = "duplicate_associated_fn_param"
+source = """
+struct S {
+    v: i32,
+    fn mk(a: i32, a: i32) -> i32 { a }
+}
+fn main() -> i32 { S::mk(1, 2) }
+"""
+compile_fail = true
+error_contains = ["E0491", "duplicate parameter name 'a'"]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -2,8 +2,7 @@ use std::env;
 use std::fs;
 #[cfg(unix)]
 use std::os::unix::fs::PermissionsExt;
-#[cfg(unix)]
-use std::path::Path;
+use std::path::{Path, PathBuf};
 #[cfg(target_os = "macos")]
 use std::process::Command;
 
@@ -16,9 +15,9 @@ mod timing;
 use rue_compiler::{
     CompileOptions, FileId, Lexer, LinkerMode, MultiFileFormatter, OptLevel, ParsedProgram,
     PreviewFeature, PreviewFeatures, SourceFile, SourceInfo, TokenKind,
-    compile_multi_file_with_options, generate_emitted_asm, generate_liveness_info,
-    generate_lowering_info, generate_mir, generate_regalloc_info, generate_stack_frame_info,
-    merge_symbols, parse_all_files,
+    compile_multi_file_with_options, configure_thread_pool, generate_emitted_asm,
+    generate_liveness_info, generate_lowering_info, generate_mir, generate_regalloc_info,
+    generate_stack_frame_info, merge_symbols, parse_all_files,
 };
 use rue_rir::RirPrinter;
 use rue_target::Target;
@@ -265,6 +264,38 @@ enum ParseResult {
     Exit,
 }
 
+/// Resolve a path to a canonical key for the output-clobber comparison.
+///
+/// Sources always exist, so they canonicalize directly. The output file
+/// usually does NOT exist yet, so `canonicalize` fails on it; in that case we
+/// canonicalize the parent directory and re-attach the file name, which still
+/// collapses `./prog` and `prog` (or `dir/../prog`) to the same key. When even
+/// the parent can't be resolved — as in unit tests with fake paths that touch
+/// no real files — we fall back to the raw path, preserving the old
+/// exact-string behavior. Extension is irrelevant; only the resolved location
+/// matters (RUE-351).
+fn clobber_key(path: &str) -> PathBuf {
+    let p = Path::new(path);
+    if let Ok(canon) = fs::canonicalize(p) {
+        return canon;
+    }
+    match (p.parent(), p.file_name()) {
+        (Some(parent), Some(name)) => {
+            // An empty parent means the path is a bare file name in the cwd.
+            let parent = if parent.as_os_str().is_empty() {
+                Path::new(".")
+            } else {
+                parent
+            };
+            match fs::canonicalize(parent) {
+                Ok(canon_parent) => canon_parent.join(name),
+                Err(_) => p.to_path_buf(),
+            }
+        }
+        _ => p.to_path_buf(),
+    }
+}
+
 /// Parse arguments from a slice of strings (for testing).
 fn parse_args_from(args: &[&str]) -> ParseResult {
     if args.is_empty() {
@@ -486,9 +517,14 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         return ParseResult::Error;
     };
 
-    // In every mode: the output must not clobber an input. (Catches explicit
-    // footguns like `rue a.rue -o a.rue` too.)
-    if source_paths.contains(&final_output_path) {
+    // In every mode: the output must not clobber an input. Compare RESOLVED
+    // filesystem paths, not raw strings, so different spellings of the same
+    // file are all caught — `rue a.rue -o a.rue`, `rue ./prog -o prog`, or an
+    // extensionless source `rue prog -o prog`. The earlier guard keyed off a
+    // `.rue` suffix, so extensionless sources slipped through and the compiled
+    // output silently overwrote the source (RUE-351).
+    let output_key = clobber_key(&final_output_path);
+    if source_paths.iter().any(|s| clobber_key(s) == output_key) {
         eprintln!(
             "Error: output path '{}' is also an input source file; refusing to overwrite it",
             final_output_path
@@ -900,6 +936,13 @@ fn main() {
         options.time_passes,
         options.benchmark_json,
     );
+
+    // Configure Rayon's global thread pool ONCE, before dispatching to either
+    // the `--emit` path or the normal compile path. `build_global()` panics if
+    // called twice, so it lives here rather than inside a per-compilation entry
+    // point — the previous placement meant `--emit` ignored `-j`/`--jobs`
+    // entirely (RUE-352).
+    configure_thread_pool(options.jobs);
 
     // Read all source files into memory
     let mut sources: Vec<(String, String)> = options
@@ -1457,6 +1500,29 @@ mod tests {
     fn parse_multi_file_without_output_flag_error() {
         // Three positional args without -o should error
         assert!(is_error(&parse_args_from(&["a.rue", "b.rue", "c.rue"])));
+    }
+
+    #[test]
+    fn parse_output_equals_extensionless_input_error() {
+        // RUE-351: `-o` targeting an extensionless input source is refused. The
+        // old guard only recognized inputs by a `.rue` suffix. Paths resolve
+        // against the cwd; neither file needs to exist for the keys to match.
+        assert!(is_error(&parse_args_from(&["prog", "-o", "prog"])));
+    }
+
+    #[test]
+    fn parse_output_equals_input_different_spelling_error() {
+        // RUE-351: resolved-path comparison catches `./prog` vs `prog` — the
+        // same file spelled two ways — not just a byte-for-byte string match.
+        assert!(is_error(&parse_args_from(&["./prog", "-o", "prog"])));
+    }
+
+    #[test]
+    fn parse_distinct_output_and_input_ok() {
+        // A genuinely different output path must still be accepted.
+        let opts = unwrap_options(parse_args_from(&["prog.rue", "-o", "prog"]));
+        assert_eq!(opts.source_paths, vec!["prog.rue"]);
+        assert_eq!(opts.output_path, "prog");
     }
 
     #[test]

--- a/docs/spec/src/06-items/01-functions.md
+++ b/docs/spec/src/06-items/01-functions.md
@@ -24,6 +24,10 @@ param = IDENT ":" type ;
 
 Parameters **MUST** have explicit type annotations.
 
+{{ rule(id="6.1:34", cat="legality-rule") }}
+
+The parameters in a single parameter list **MUST** have distinct names. It is a compile-time error for a function or method to declare two parameters with the same name (for example, `fn f(x: i32, x: i32)`); the diagnostic identifies the second occurrence. A method's `self` receiver is not a named parameter for the purpose of this rule.
+
 {{ rule(id="6.1:4", cat="dynamic-semantics") }}
 
 A function call evaluates to the value the function's body block evaluates to (see 4.5). Reaching the end of the body is not a distinct "implicit return": the body is an expression, and the call's value *is* that expression's value.

--- a/docs/spec/src/08-runtime-behavior/01-overflow.md
+++ b/docs/spec/src/08-runtime-behavior/01-overflow.md
@@ -8,15 +8,24 @@ template = "spec/page.html"
 
 {{ rule(id="8.1:1", cat="dynamic-semantics") }}
 
-Integer overflow during arithmetic operations **MUST** cause a runtime panic.
+Integer overflow during an arithmetic operation **MUST** cause a runtime panic:
+when the mathematical result of the operation falls outside the range
+`[min, max]` of its integer type, the operation traps rather than wrapping or
+truncating (core calculus `docs/formal/01-core-calculus.md` §6.4, rule
+`(D-Arith-Trap)`, and the `neg (min_T)_T → ↯overflow` case for unary negation).
 
 {{ rule(id="8.1:2", cat="dynamic-semantics") }}
 
-On overflow, the program **MUST** terminate with exit code 101 and print an error message.
+On an overflow trap, the program **MUST** terminate with exit code 101 — the panic
+exit code of Appendix B — after printing an error message identifying the overflow
+(core calculus `docs/formal/01-core-calculus.md` §6.12, rule `(Result-Panic)`).
 
 {{ rule(id="8.1:3", cat="normative") }}
 
-The following operations **MAY** overflow:
+The following operations **MAY** overflow (core calculus
+`docs/formal/01-core-calculus.md` §6.4: `+`, `-`, `*`, and `neg` trap by rule
+`(D-Arith-Trap)`; the `min / -1` and `min % -1` cases trap by rule
+`(D-Div-Overflow)`):
 - Addition (`+`)
 - Subtraction (`-`)
 - Multiplication (`*`)

--- a/docs/spec/src/08-runtime-behavior/02-bounds-checking.md
+++ b/docs/spec/src/08-runtime-behavior/02-bounds-checking.md
@@ -8,15 +8,24 @@ template = "spec/page.html"
 
 {{ rule(id="8.2:1", cat="dynamic-semantics") }}
 
-Array access with an out-of-bounds index **MUST** cause a runtime panic.
+Array access with an out-of-range index **MUST** cause a runtime panic. The bound
+is checked at the moment the index is used to navigate into the array; an index
+`i` is out of range for an `[T; n]` when `i` is negative or `i ≥ n`, and either
+case traps (core calculus `docs/formal/01-core-calculus.md` §6.5, and the `bounds`
+trap category of §6.12).
 
 {{ rule(id="8.2:2", cat="dynamic-semantics") }}
 
-On out-of-bounds access, the program **MUST** terminate with exit code 101 and print an error message.
+On an out-of-range access, the program **MUST** terminate with exit code 101 — the
+panic exit code of Appendix B — after printing an error message identifying the
+out-of-bounds access (core calculus `docs/formal/01-core-calculus.md` §6.12, rule
+`(Result-Panic)`).
 
 {{ rule(id="8.2:3", cat="legality-rule") }}
 
-For constant indices, bounds checking **MUST** be performed at compile time.
+For constant indices, bounds checking **MUST** be performed at compile time. A
+constant index that is out of range is rejected during compilation and so never
+reaches the runtime `bounds` check of the core calculus (§6.5).
 
 {{ rule(id="8.2:4", cat="normative") }}
 
@@ -24,7 +33,10 @@ A constant index is an expression that can be fully evaluated at compile time. T
 
 {{ rule(id="8.2:5", cat="dynamic-semantics") }}
 
-For variable indices, bounds checking **MUST** be performed at runtime before the access.
+For variable indices, bounds checking **MUST** be performed at runtime, before the
+element is read, at the point where the index navigates into the array (core
+calculus `docs/formal/01-core-calculus.md` §6.5: the check precedes the projection
+that reads the element).
 
 {{ rule(id="8.2:6") }}
 

--- a/docs/spec/src/08-runtime-behavior/03-division-by-zero.md
+++ b/docs/spec/src/08-runtime-behavior/03-division-by-zero.md
@@ -8,11 +8,17 @@ template = "spec/page.html"
 
 {{ rule(id="8.3:1", cat="dynamic-semantics") }}
 
-Division or remainder by zero **MUST** cause a runtime panic.
+Evaluating `/` or `%` with a zero divisor **MUST** cause a runtime panic: the
+operation traps before it computes a result (core calculus
+`docs/formal/01-core-calculus.md` §6.4, rule `(D-Div-Zero)` and its remainder
+analogue — these are the distinct `div-zero` and `rem-zero` trap categories of
+§6.12).
 
 {{ rule(id="8.3:2", cat="dynamic-semantics") }}
 
-On division by zero, the program **MUST** terminate with exit code 101 and print an error message.
+On a division- or remainder-by-zero trap, the program **MUST** terminate with exit
+code 101 — the panic exit code of Appendix B — after printing an error message
+(core calculus `docs/formal/01-core-calculus.md` §6.12, rule `(Result-Panic)`).
 
 {{ rule(id="8.3:3", cat="normative") }}
 

--- a/docs/spec/src/08-runtime-behavior/_index.md
+++ b/docs/spec/src/08-runtime-behavior/_index.md
@@ -12,4 +12,14 @@ This chapter describes runtime behavior in Rue, including error conditions and p
 
 {{ rule(id="8.0:1") }}
 
-Certain operations can fail at runtime. These failures are detected and cause the program to terminate with a non-zero exit code.
+A small, fixed set of primitive operations can **trap** at runtime: integer
+overflow, division or remainder by zero, and an out-of-range array index. A trap
+is not a value, and no surrounding expression can consume it; it abandons the rest
+of the evaluation and halts the program with exit code 101 (the panic exit code of
+Appendix B). The core calculus fixes exactly these trap categories — `overflow`,
+`div-zero`, `rem-zero`, and `bounds` — together with their propagation and exit
+code (core calculus `docs/formal/01-core-calculus.md` §6.12, and the `(Panic-Lift)`
+rule of §6.2 by which a trap in any subexpression aborts the whole evaluation).
+Each is total, deterministic, and observable, so a conforming compiler reproduces
+the same trap on the same input. The following sections state each category
+normatively.


### PR DESCRIPTION
- **RUE-349**: duplicate parameter names now error (E0491, points at the 2nd occurrence) instead of silent first-wins. Covers fns/methods/assoc-fns; 4 spec/5 UI/4 CLI cases.
- **RUE-352**: -j/--jobs now honored in --emit (hoisted rayon config to main via configure_thread_pool, removed the double build_global).
- **RUE-351**: clobber guard now compares resolved paths, catching extensionless/re-spelled sources.
- **RUE-202** (ch8 runtime): folk-terms retired into the core's trap vocabulary.

clippy clean; test.sh Pass 25, honest traceability 99.3%.

Fixes RUE-349
Fixes RUE-351
Fixes RUE-352

Generated with Claude Code