### PR TITLE
rue-builtins: test coverage gap + two stale docs

### DIFF
--- a/crates/rue-builtins/src/lib.rs
+++ b/crates/rue-builtins/src/lib.rs
@@ -110,7 +110,7 @@
 //!         let data_ptr = *ptr as *mut u8;
 //!         let cap = *ptr.add(2);
 //!         if cap > 0 {
-//!             __rue_free(data_ptr, cap as usize);
+//!             __rue_free(data_ptr, cap as usize, 1); // (ptr, size, align)
 //!         }
 //!     }
 //! }
@@ -477,8 +477,11 @@ pub static STRING_TYPE: BuiltinTypeDef = BuiltinTypeDef {
 // are lowered directly by Sema into `extern "C"` runtime calls (routed through
 // the ordinary sret / by-value call convention), and their runtime symbols live
 // under the reserved `__rue_` prefix like every other builtin runtime helper.
-// The names are collected here so there is a single source of truth for what
-// the compiler emits and what `rue-runtime` must define.
+// The formatting/print symbols below are collected here as consts. Note this is
+// NOT the complete set of directly-lowered runtime calls: String/str byte
+// indexing (`__rue_String_byte_at`, `__rue_str_byte_at`) and `chars()`
+// (`__rue_String_char_*`) are also Sema-lowered `extern "C"` calls, declared
+// near their use rather than in this block.
 
 /// Runtime symbol for `@to_string(n)` on a signed integer: formats an `i64` as
 /// its decimal representation into a freshly heap-allocated `String` (full range
@@ -770,6 +773,8 @@ mod tests {
             "push",
             "clear",
             "reserve",
+            "contains",
+            "starts_with",
         ];
         for name in expected_methods {
             assert!(


### PR DESCRIPTION
From the rue-builtins code review:
- `test_all_string_methods_present` omitted `contains`/`starts_with` (both have runtime backing) — the guard test wouldn't catch dropping either. Added.
- The 'how to add a builtin' Vec example called `__rue_free(ptr, size)`; the real runtime sig is `__rue_free(ptr, size, align)` (3 args). Fixed the exemplar.
- The 'single source of truth' freestanding-ops comment omitted String/str byte-indexing + chars() symbols; narrowed it.

(Backlog: RUE-354 reserved-name guard misses memcpy/memset/_main; RUE-355 bool-helper return-register cleanliness.) clippy clean; test.sh Pass 25.

Generated with Claude Code