### PR TITLE
Str(N) fixed-capacity strings (RUE-326) + items-chapter prose

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -280,19 +280,21 @@ impl<'a> ConstraintGenerator<'a> {
         }
     }
 
-    /// Is `ty` the synthetic slice struct `[T]` (ADR-0043, RUE-322) or the
-    /// `str` string type (RUE-324)? A slice parameter accepts an array argument
-    /// by coercion (`sum(borrow a)`), and a `str` position accepts a string
-    /// literal (whose HM type is `String`) by coercion, so the constraint
-    /// generator must NOT impose strict `arg == expected` equality when the
-    /// expected type is a slice or `str`; the real compatibility check and the
-    /// fat-pointer/`str` materialization happen in semantic analysis.
+    /// Is `ty` the synthetic slice struct `[T]` (ADR-0043, RUE-322), the `str`
+    /// string type (RUE-324), or a fixed-capacity string `Str(N)` (RUE-326)? A
+    /// slice parameter accepts an array argument by coercion (`sum(borrow a)`),
+    /// and a `str`/`Str(N)` position accepts a string literal (whose HM type is
+    /// `String`) by coercion, so the constraint generator must NOT impose strict
+    /// `arg == expected` equality when the expected type is one of these; the
+    /// real compatibility check (including the `Str(N)` capacity-fits rule) and
+    /// the fat-pointer/`str` materialization happen in semantic analysis.
     fn is_slice_struct_type(&self, ty: InferType) -> bool {
         if let InferType::Concrete(t) = ty
             && let Some(id) = t.as_struct()
         {
             let name = &self.type_pool.struct_def(id).name;
             return name == "str"
+                || (name.starts_with("Str(") && name.ends_with(')'))
                 || (name.starts_with('[')
                     && name.ends_with(']')
                     && crate::types::parse_array_type_syntax(name).is_none());

--- a/crates/rue-air/src/sema/analysis/functions.rs
+++ b/crates/rue-air/src/sema/analysis/functions.rs
@@ -396,7 +396,7 @@ impl<'a> Sema<'a> {
         // tail expression) materializes as a static-backed first-class `str`.
         // Inner `let`s clear `expected_type` for their own initializers (they
         // `take()` it), so this only reaches the tail value.
-        if self.is_str_struct(return_type) {
+        if self.is_str_like(return_type) {
             ctx.expected_type = Some(return_type);
         }
         let body_result = self.analyze_inst(&mut air, body, &mut ctx)?;

--- a/crates/rue-air/src/sema/analysis/ownership.rs
+++ b/crates/rue-air/src/sema/analysis/ownership.rs
@@ -604,7 +604,7 @@ impl<'a> Sema<'a> {
             // a `str` variable is passed through by value. Either way it flows
             // through the by-value aggregate ABI, so it is handled here before
             // the array→slice `borrow` coercion below.
-            let is_str_param = param_types.get(i).is_some_and(|pt| self.is_str_struct(*pt));
+            let is_str_param = param_types.get(i).is_some_and(|pt| self.is_str_like(*pt));
             if is_str_param {
                 let str_ty = param_types[i];
                 let prev_expected = ctx.expected_type.replace(str_ty);

--- a/crates/rue-air/src/sema/analysis/type_inference.rs
+++ b/crates/rue-air/src/sema/analysis/type_inference.rs
@@ -145,7 +145,7 @@ impl<'a> Sema<'a> {
         // implicit-return string literal (HM type `String`) by coercion; skip
         // strict equality there and let sema materialize the static-backed
         // first-class `str` at the tail expression.
-        if !self.is_str_struct(return_type) {
+        if !self.is_str_like(return_type) {
             cgen.add_constraint(Constraint::equal(
                 body_info.ty,
                 self.type_to_infer_type(return_type),

--- a/crates/rue-air/src/sema/analyze_ops.rs
+++ b/crates/rue-air/src/sema/analyze_ops.rs
@@ -412,7 +412,7 @@ impl<'a> Sema<'a> {
                 // `StringConst` AIR node lowers to only the ptr+len words there
                 // (the cap word is dropped in codegen). Otherwise it is the
                 // 3-word heap `String` as before.
-                let want_str = ctx.expected_type.is_some_and(|ty| self.is_str_struct(ty));
+                let want_str = ctx.expected_type.is_some_and(|ty| self.is_str_like(ty));
                 let ty = if want_str {
                     ctx.expected_type.unwrap()
                 } else {
@@ -420,6 +420,21 @@ impl<'a> Sema<'a> {
                 };
                 // Add string to the local string table (per-function for parallel analysis)
                 let string_content = self.interner.resolve(&*symbol).to_string();
+
+                // Capacity-fits legality (ADR-0043 Phase 5, RUE-326): a string
+                // literal materialized as a fixed `Str(N)` must fit — its UTF-8
+                // byte length must be ≤ N — else it is a clean compile error
+                // (E0210). `str` (no capacity) never triggers this.
+                if let Some(capacity) = self.str_fixed_capacity(ty) {
+                    let byte_len = string_content.len() as u64;
+                    if byte_len > capacity {
+                        return Err(CompileError::new(
+                            ErrorKind::StrFixedCapacityExceeded { capacity, byte_len },
+                            inst.span,
+                        ));
+                    }
+                }
+
                 let local_string_id = ctx.add_local_string(string_content);
 
                 let air_ref = air.add_inst(AirInst {
@@ -2066,7 +2081,7 @@ impl<'a> Sema<'a> {
             // a string-literal `return "..."` materializes as a static-backed,
             // first-class `str` (it cannot dangle, so returning it is sound).
             let ret_ty = ctx.return_type;
-            let inner_result = if self.is_str_struct(ret_ty) {
+            let inner_result = if self.is_str_like(ret_ty) {
                 let prev_expected = ctx.expected_type.replace(ret_ty);
                 let r = self.analyze_inst(air, inner, ctx);
                 ctx.expected_type = prev_expected;
@@ -2298,7 +2313,7 @@ impl<'a> Sema<'a> {
             // string literal `"..."` materializes as a 2-word static-backed
             // `str` rather than the 3-word heap `String` (ADR-0043 Phase 3,
             // RUE-324). Enums do the same for fallible-intrinsic `Option(T)`.
-            if annot.is_enum() || self.is_str_struct(annot) {
+            if annot.is_enum() || self.is_str_like(annot) {
                 ctx.expected_type = Some(annot);
             }
         }
@@ -2892,7 +2907,7 @@ impl<'a> Sema<'a> {
         // materializes as a 2-word `str` rather than a 3-word `String` (which
         // would corrupt the 2-slot local); this is what makes `let mut s: str;
         // s = "hi";` reassignment sound.
-        let value_result = if self.is_str_struct(local_ty) {
+        let value_result = if self.is_str_like(local_ty) {
             let prev_expected = ctx.expected_type.replace(local_ty);
             let r = self.analyze_inst(air, value, ctx);
             ctx.expected_type = prev_expected;
@@ -3112,7 +3127,7 @@ impl<'a> Sema<'a> {
                     span: field_inst.span,
                 });
                 AnalysisResult::new(air_ref, expected_field_type)
-            } else if self.is_str_struct(expected_field_type) {
+            } else if self.is_str_like(expected_field_type) {
                 // A `str`-typed field (ADR-0043 Phase 3, RUE-324): supply the
                 // field type as the expected type so a string-literal value
                 // materializes as a static-backed 2-word `str` (first-class,
@@ -4310,7 +4325,7 @@ impl<'a> Sema<'a> {
         // `@ptr_offset`/`@ptr_read` path (which strides by `slot_count * 8`);
         // it lowers to the same packed-byte runtime read as `String`, but with
         // the 2-word `{ptr, len}` receiver: `__rue_str_byte_at(ptr, len, index)`.
-        if self.is_str_struct(base_type) {
+        if self.is_str_like(base_type) {
             return self.analyze_str_index_get(
                 air,
                 base_result,

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -311,6 +311,91 @@ impl<'a> Sema<'a> {
         }
     }
 
+    /// Get (or lazily create) the synthetic 2-field struct representing a
+    /// fixed-capacity string `Str(N)` (ADR-0043 Phase 5, RUE-326).
+    ///
+    /// `Str(N)` is the **fixed string rung** — `[u8; N]` + the UTF-8
+    /// byte-string convention (ADR-0035) — the string analogue of the fixed
+    /// array `[T; N]`: no heap, no allocator, a value type holding up to `N`
+    /// bytes plus a current byte length. Each distinct capacity is its own
+    /// named struct (`Str(8)`, keyed by that canonical name) so every reference
+    /// to the same capacity shares one `StructId`.
+    ///
+    /// Representation note (this phase): `Str(N)` reuses the `str` fat-pointer
+    /// shape `{ ptr: ptr const u8, len: u64 }`, and construction from a string
+    /// literal is currently static-backed (bytes in `.rodata`, which cannot
+    /// dangle). This makes `.len()`, byte-indexing, and coercion to `str` reuse
+    /// the `str` machinery verbatim while the capacity `N` enforces the
+    /// literal-fits legality rule. Genuine inline-stack storage and mutation
+    /// (`push`/append) are deferred; for the literal-only, immutable surface of
+    /// this phase the two are observationally identical.
+    fn get_or_create_str_fixed_struct(&mut self, capacity: u64, span: Span) -> CompileResult<Type> {
+        use crate::types::{StructDef, StructField};
+
+        let name = format!("Str({})", capacity);
+        let type_sym = self.interner.get_or_intern(&name);
+        if let Some(&struct_id) = self.structs.get(&type_sym) {
+            return Ok(Type::new_struct(struct_id));
+        }
+
+        let ptr_type_id = self.type_pool.intern_ptr_const_from_type(Type::U8);
+        let ptr_ty = Type::new_ptr_const(ptr_type_id);
+
+        let struct_def = StructDef {
+            name,
+            fields: vec![
+                StructField {
+                    name: "ptr".to_string(),
+                    ty: ptr_ty,
+                },
+                StructField {
+                    name: "len".to_string(),
+                    ty: Type::U64,
+                },
+            ],
+            is_copy: true,
+            is_linear: false,
+            destructor: None,
+            is_builtin: true,
+            is_pub: true,
+            file_id: rue_span::FileId::new(0),
+        };
+        let (struct_id, _) = self.type_pool.register_struct(type_sym, struct_def);
+        self.structs.insert(type_sym, struct_id);
+        let _ = span;
+        Ok(Type::new_struct(struct_id))
+    }
+
+    /// Is `ty` a fixed-capacity string `Str(N)` (ADR-0043 Phase 5, RUE-326)?
+    /// Detected by the struct name matching `Str(<digits>)`, mirroring the
+    /// name-keyed detection used for `str` and slices.
+    pub(crate) fn is_str_fixed_struct(&self, ty: Type) -> bool {
+        self.str_fixed_capacity(ty).is_some()
+    }
+
+    /// If `ty` is a fixed-capacity string `Str(N)`, return its capacity `N`
+    /// (ADR-0043 Phase 5, RUE-326); otherwise `None`. The capacity is parsed
+    /// back out of the canonical struct name `Str(<N>)`.
+    pub(crate) fn str_fixed_capacity(&self, ty: Type) -> Option<u64> {
+        if let TypeKind::Struct(struct_id) = ty.kind() {
+            let name = &self.type_pool.struct_def(struct_id).name;
+            let digits = name.strip_prefix("Str(")?.strip_suffix(')')?;
+            digits.parse::<u64>().ok()
+        } else {
+            None
+        }
+    }
+
+    /// Is `ty` `str`-like — either the `str` slice view or a fixed-capacity
+    /// `Str(N)` (ADR-0043 Phases 3/5)? Both share the 2-word `{ptr, len}`
+    /// representation and the UTF-8 byte-string convention, so string-literal
+    /// materialization, `.len()`, packed byte-indexing, and by-value passing all
+    /// treat them identically. The capacity-fits legality rule is the only place
+    /// `Str(N)` diverges from `str`.
+    pub(crate) fn is_str_like(&self, ty: Type) -> bool {
+        self.is_str_struct(ty) || self.is_str_fixed_struct(ty)
+    }
+
     /// If `ty` is a synthetic slice struct `[T]` (ADR-0043, RUE-322), return its
     /// element type `T`; otherwise `None`. Detected by the struct name being
     /// slice syntax (`[..]` that is not a fixed-array `[T; N]`), the same naming
@@ -324,7 +409,11 @@ impl<'a> Sema<'a> {
             let is_slice = def.name.starts_with('[')
                 && def.name.ends_with(']')
                 && parse_array_type_syntax(&def.name).is_none();
-            if is_slice || def.name == "str" {
+            // A fixed-capacity `Str(N)` (ADR-0043 Phase 5, RUE-326) is `[u8; N]`
+            // + UTF-8 and shares the `{ptr, len}` shape, so `.len()` and byte
+            // indexing route through the same slice/str path as `str`.
+            let is_str_fixed = def.name.starts_with("Str(") && def.name.ends_with(')');
+            if is_slice || def.name == "str" || is_str_fixed {
                 // Field 0 is `ptr const T`; recover T from its pointee.
                 if let TypeKind::PtrConst(ptr_id) = def.fields[0].ty.kind() {
                     return Some(self.type_pool.ptr_const_def(ptr_id));
@@ -440,6 +529,17 @@ impl<'a> Sema<'a> {
                 let ptr_type_id = self.type_pool.intern_ptr_mut_from_type(pointee_ty);
                 Ok(Type::new_ptr_mut(ptr_type_id))
             } else if let Some((call_name, arg_strs)) = parse_type_call_syntax(type_name) {
+                // Fixed-capacity string `Str(N)` (ADR-0043 Phase 5, RUE-326):
+                // the fixed string rung, `[u8; N]` + UTF-8. Gated behind
+                // `--preview string_trio` (shared with `str`). The capacity `N`
+                // is a literal (`Str(8)`, produced by `TypeExpr::StrFixed`) or a
+                // `const` name that resolved to a literal on the `TypeCall`
+                // path; either way it arrives here as the single argument
+                // string. It is reduced to a 2-word fat-pointer struct so it
+                // flows through the existing `str`/slice paths.
+                if call_name == "Str" {
+                    return self.resolve_str_fixed_type(&call_name, &arg_strs, span);
+                }
                 // A type-function application written directly in type position
                 // (`Result(i32, i32)`; RUE-241). Reduce the comptime type call
                 // to its monomorphized concrete type. No analysis context is
@@ -516,6 +616,14 @@ impl<'a> Sema<'a> {
             let ptr_type_id = self.type_pool.intern_ptr_mut_from_type(pointee_ty);
             Ok(Type::new_ptr_mut(ptr_type_id))
         } else if let Some((call_name, arg_strs)) = parse_type_call_syntax(type_name) {
+            // Fixed-capacity string `Str(N)` (ADR-0043 Phase 5, RUE-326): the
+            // context-aware annotation path (`let s: Str(8)`). Intercepted here,
+            // as in the context-free `resolve_type`, before the general
+            // type-function reduction so `Str` is not looked up as a `-> type`
+            // constructor.
+            if call_name == "Str" {
+                return self.resolve_str_fixed_type(&call_name, &arg_strs, span);
+            }
             // A type-function application in an annotation position whose
             // arguments may name enclosing comptime type parameters or local
             // comptime type variables (`let x: Option(T)` / `let x: Option(P)`).
@@ -800,6 +908,48 @@ impl<'a> Sema<'a> {
     /// (RUE-16). On the comptime-evaluation path the caller passes a dummy span
     /// and discards the error; on the diagnostic path (`resolve_type`) the
     /// error surfaces to the user as E0481.
+    /// Reduce a fixed-capacity string `Str(N)` type-call to its concrete
+    /// 2-word fat-pointer struct (ADR-0043 Phase 5, RUE-326). Shared by the
+    /// context-free (`resolve_type`) and context-aware (`resolve_type_with_ctx`)
+    /// annotation paths so both spellings resolve identically. Gated behind
+    /// `--preview string_trio` (shared with `str`); a non-single-argument form
+    /// (`Str()`, `Str(a, b)`) is a clean unknown-type error.
+    fn resolve_str_fixed_type(
+        &mut self,
+        call_name: &str,
+        arg_strs: &[String],
+        span: Span,
+    ) -> CompileResult<Type> {
+        self.require_preview(
+            PreviewFeature::StringTrio,
+            "the fixed string type `Str(N)`",
+            span,
+        )?;
+        let capacity = match arg_strs {
+            [arg] => self.resolve_str_fixed_capacity(arg, span)?,
+            _ => {
+                return Err(CompileError::new(
+                    ErrorKind::UnknownType(format!("{}({})", call_name, arg_strs.join(", "))),
+                    span,
+                ));
+            }
+        };
+        self.get_or_create_str_fixed_struct(capacity, span)
+    }
+
+    /// Resolve the capacity argument `N` of a fixed-capacity string `Str(N)`
+    /// (ADR-0043 Phase 5, RUE-326) to a concrete `u64`. The argument arrives as
+    /// the raw substring of the interned type name: an integer literal
+    /// (`Str(8)`) or a `const` name (`Str(CAP)`). Both routes reuse the array
+    /// length machinery, so `Str(N)` and `[u8; N]` accept exactly the same
+    /// length forms.
+    fn resolve_str_fixed_capacity(&mut self, arg: &str, span: Span) -> CompileResult<u64> {
+        if let Ok(n) = arg.parse::<u64>() {
+            return Ok(n);
+        }
+        self.resolve_array_length(&ArrayLen::Named(arg.to_string()), span, None)
+    }
+
     pub(crate) fn resolve_array_length(
         &mut self,
         len: &ArrayLen,

--- a/crates/rue-cli-tests/cases/str_fixed_type.toml
+++ b/crates/rue-cli-tests/cases/str_fixed_type.toml
@@ -1,0 +1,144 @@
+# The `Str(N)` fixed-capacity string type — executable regression tests
+# (ADR-0043 Phase 5, RUE-326).
+#
+# `Str(N)` is the fixed string rung: `[u8; N]` + the UTF-8 byte-string
+# convention, a value type parameterized by a comptime capacity `N`, storing up
+# to `N` bytes plus a current byte length, with no heap. Construction is from a
+# string literal that FITS (a literal exceeding `N` is a clean compile error,
+# E0492). `.len()` reads the current byte length (≤ N); `s[i]` reads the i-th
+# PACKED byte (bounds-checked against the length, traps exit 101). A `Str(N)`
+# coerces to a `str` view, so it reads through the universal `str` interface.
+#
+# Gated behind `--preview string_trio`. Deferred: mutation/append; methods
+# beyond len/index/borrow.
+
+[section]
+id = "cli.str_fixed_type"
+name = "Str(N) fixed string type (ADR-0043 Phase 5)"
+description = "Literal-constructed fixed-capacity strings: len(), packed byte-indexing, capacity check, coercion to str."
+
+# The canonical verify-by-execution: a Str(8) local from a fitting literal,
+# `.len()` == 5 (current length, not capacity), and s[0] the first byte 'h'.
+[[case]]
+name = "str_fixed_len_and_first_byte"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: Str(8) = "hello";
+    let n: u64 = s.len();
+    let b: u8 = s[0];
+    if n == 5 && b == 104 { 42 } else { 0 }
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 42
+
+# `.len()` is the current byte length, independent of the capacity N.
+[[case]]
+name = "str_fixed_len_independent_of_capacity"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let a: Str(8)  = "hi";
+    let b: Str(64) = "hi";
+    @dbg(a.len());   // 2
+    @dbg(b.len());   // 2
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 0
+stdout = "2\n2\n"
+
+# Byte indexing sees raw packed bytes; a multibyte char decomposes into its
+# UTF-8 bytes. "café" = c a f 0xC3 0xA9.
+[[case]]
+name = "str_fixed_packed_byte_indexing"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: Str(8) = "café";
+    @dbg(s.len());   // 5 bytes
+    @dbg(s[2]);      // 102 'f'
+    @dbg(s[3]);      // 195 0xC3
+    @dbg(s[4]);      // 169 0xA9
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 0
+stdout = "5\n102\n195\n169\n"
+
+# An out-of-range byte index traps at runtime (exit 101), like array/String/str.
+[[case]]
+name = "str_fixed_index_out_of_bounds_traps"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: Str(8) = "hi";
+    let b: u8 = s[5];
+    @intCast(b)
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 101
+
+# A string literal exceeding the capacity N is a clean compile error (E0492),
+# never a silent truncation or a crash.
+[[case]]
+name = "str_fixed_over_capacity_is_clean_error"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: Str(3) = "hello";
+    0
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+compile_fail = true
+error_contains = ["E0492"]
+
+# A `Str(N)` value coerces to a `str` parameter and is read through the str
+# interface — both a materialized literal and a forwarded Str(N) variable.
+[[case]]
+name = "str_fixed_coerces_to_str_param"
+files = [{ path = "main.rue", source = """
+fn len_of(s: str) -> u64 {
+    s.len()
+}
+fn first(s: str) -> u8 {
+    s[0]
+}
+fn main() -> i32 {
+    let s: Str(8) = "hello";
+    let n: u64 = len_of(s);
+    let b: u8 = first(s);
+    if n == 5 && b == 104 { 42 } else { 0 }
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 42
+
+# A Str(N) is a value type: passing it to a Str(N) parameter and reading .len()
+# there round-trips.
+[[case]]
+name = "str_fixed_param_roundtrip"
+files = [{ path = "main.rue", source = """
+fn take(s: Str(8)) -> u64 {
+    s.len()
+}
+fn main() -> i32 {
+    let s: Str(8) = "hello";
+    if take(s) == 5 { 42 } else { 0 }
+}
+""" }]
+args = ["main.rue", "--preview", "string_trio", "-o", "prog"]
+exit_code = 42
+
+# `Str(N)` requires the preview flag; without it, a clean gate error.
+[[case]]
+name = "str_fixed_requires_preview"
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let s: Str(8) = "hello";
+    0
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+compile_fail = true
+error_contains = ["E1100"]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -225,6 +225,12 @@ impl ErrorCode {
     /// (RUE-349, a sibling of [`Self::DUPLICATE_PATTERN_BINDING`] (E0484) and
     /// analogous to Rust's E0415).
     pub const DUPLICATE_PARAMETER: Self = Self(491);
+    /// A string literal assigned to a fixed-capacity string `Str(N)` does not
+    /// fit: its UTF-8 byte length exceeds the capacity `N` (ADR-0043 Phase 5,
+    /// RUE-326). `Str(N)` is the fixed string rung (`[u8; N]` + UTF-8) with no
+    /// heap, so an over-long literal cannot be stored — the fit is checked at
+    /// compile time.
+    pub const STR_FIXED_CAPACITY_EXCEEDED: Self = Self(492);
 
     // ========================================================================
     // Control flow errors (E0500-E0599)
@@ -1165,6 +1171,13 @@ pub enum ErrorKind {
     /// `@field_ptr` operand is not a field-access expression `s.field`
     #[error("@field_ptr requires a field access expression (for example `s.field`)")]
     FieldPtrRequiresField,
+    /// A string literal does not fit the fixed-capacity string `Str(N)` it is
+    /// assigned to: its UTF-8 byte length exceeds `N` (ADR-0043 Phase 5,
+    /// RUE-326).
+    #[error(
+        "string literal of {byte_len} bytes does not fit in `Str({capacity})` (capacity {capacity} bytes)"
+    )]
+    StrFixedCapacityExceeded { capacity: u64, byte_len: u64 },
     /// Inout argument is not an lvalue (variable, field, or array element)
     #[error("inout argument must be an lvalue (variable, field, or array element)")]
     InoutNonLvalue,
@@ -1463,6 +1476,7 @@ impl ErrorKind {
             ErrorKind::InvalidAssignmentTarget => ErrorCode::INVALID_ASSIGNMENT_TARGET,
             ErrorKind::RawRequiresPlace => ErrorCode::RAW_REQUIRES_PLACE,
             ErrorKind::FieldPtrRequiresField => ErrorCode::FIELD_PTR_REQUIRES_FIELD,
+            ErrorKind::StrFixedCapacityExceeded { .. } => ErrorCode::STR_FIXED_CAPACITY_EXCEEDED,
             ErrorKind::InoutNonLvalue => ErrorCode::INOUT_NON_LVALUE,
             ErrorKind::InoutExclusiveAccess { .. } => ErrorCode::INOUT_EXCLUSIVE_ACCESS,
             ErrorKind::BorrowNonLvalue => ErrorCode::BORROW_NON_LVALUE,

--- a/crates/rue-parser/src/ast.rs
+++ b/crates/rue-parser/src/ast.rs
@@ -372,6 +372,20 @@ pub enum TypeExpr {
         args: Vec<TypeExpr>,
         span: Span,
     },
+    /// A fixed-capacity string type written with an integer-literal capacity:
+    /// `Str(N)` where `N` is an integer literal (ADR-0043 Phase 5, RUE-326).
+    /// `Str(N)` is the fixed string rung — `[u8; N]` + the UTF-8 byte-string
+    /// convention — storing up to `N` bytes with no heap. This node exists only
+    /// for the literal-capacity spelling (`Str(8)`); the const-capacity spelling
+    /// (`Str(N)` where `N` names a `const`) parses as a `TypeCall` and reduces
+    /// to the same canonical `Str(N)` type name. `name` is the callee ident (so
+    /// a non-`Str` name like `Foo(8)` still resolves to a clean unknown-type
+    /// error rather than being silently treated as a fixed string).
+    StrFixed {
+        name: Ident,
+        length: u64,
+        span: Span,
+    },
 }
 
 /// The length of an array type `[T; N]`.
@@ -441,6 +455,7 @@ impl TypeExpr {
             TypeExpr::PointerConst { span, .. } => *span,
             TypeExpr::PointerMut { span, .. } => *span,
             TypeExpr::TypeCall { span, .. } => *span,
+            TypeExpr::StrFixed { span, .. } => *span,
         }
     }
 }
@@ -504,6 +519,9 @@ impl fmt::Display for TypeExpr {
                     write!(f, "{}", arg)?;
                 }
                 write!(f, ")")
+            }
+            TypeExpr::StrFixed { name, length, .. } => {
+                write!(f, "sym:{}({})", name.name.into_usize(), length)
             }
         }
     }

--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -393,6 +393,25 @@ where
                 span: span_from_extra(e),
             });
 
+        // Fixed-capacity string type with a LITERAL capacity: `Str(8)`
+        // (ADR-0043 Phase 5, RUE-326). The integer capacity is not a type, so
+        // it cannot ride the `type_call` grammar (whose args are types); this
+        // dedicated rule matches `ident ( INT )`. Placed AFTER `type_call` in
+        // the choice so the const-capacity spelling `Str(N)` (where `N` names a
+        // `const`) still parses as a `TypeCall` with a `Named` type argument and
+        // reduces to the same canonical `Str(N)` type name. `name` is kept so a
+        // non-`Str` callee resolves to a clean unknown-type error.
+        let str_fixed_type = ident_parser()
+            .then(
+                select! { TokenKind::Int(n) => n as u64 }
+                    .delimited_by(just(TokenKind::LParen), just(TokenKind::RParen)),
+            )
+            .map_with(|(name, length), e| TypeExpr::StrFixed {
+                name,
+                length,
+                span: span_from_extra(e),
+            });
+
         // Named type: user-defined types like MyStruct
         let named_type = ident_parser().map(TypeExpr::Named);
 
@@ -416,6 +435,7 @@ where
             primitive_type_parser(),
             self_type,
             type_call,
+            str_fixed_type,
             named_type,
         ))
         // Summarize the whole type grammar as a single "type" expectation, so a

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -244,6 +244,9 @@ impl Validator<'_> {
                     self.check_type_expr(arg);
                 }
             }
+            // Fixed-capacity string `Str(N)`: a scalar literal capacity, no
+            // nested type expressions to validate (ADR-0043 Phase 5, RUE-326).
+            TypeExpr::StrFixed { .. } => {}
         }
     }
 }

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -184,6 +184,15 @@ impl<'a> AstGen<'a> {
                 s.push(')');
                 self.interner.get_or_intern(&s)
             }
+            TypeExpr::StrFixed { name, length, .. } => {
+                // Fixed-capacity string `Str(N)` with a literal capacity
+                // (ADR-0043 Phase 5, RUE-326). Canonicalize to `Name(N)` — the
+                // same string the const-capacity `TypeCall` spelling produces —
+                // so sema's `resolve_type` reduces both to one `Str(N)` type.
+                let callee = self.interner.resolve(&name.name);
+                let s = format!("{}({})", callee, length);
+                self.interner.get_or_intern(&s)
+            }
         }
     }
 
@@ -1003,6 +1012,12 @@ impl<'a> AstGen<'a> {
                                 // ordinary call expression, not a TypeLit, so it
                                 // does not normally reach here. Intern its
                                 // canonical string for completeness (RUE-241).
+                                self.intern_type(&type_lit.type_expr)
+                            }
+                            TypeExpr::StrFixed { .. } => {
+                                // Fixed-capacity string `Str(N)` in value position
+                                // (ADR-0043 Phase 5, RUE-326). Intern its canonical
+                                // `Str(N)` string for completeness; sema resolves it.
                                 self.intern_type(&type_lit.type_expr)
                             }
                         };

--- a/crates/rue-spec/cases/types/str-fixed-type.toml
+++ b/crates/rue-spec/cases/types/str-fixed-type.toml
@@ -1,0 +1,184 @@
+# The `Str(N)` fixed-capacity string type (ADR-0043 Phase 5, RUE-326).
+#
+# `Str(N)` is the FIXED string rung — `[u8; N]` + the UTF-8 byte-string
+# convention — the string analogue of the fixed array `[T; N]`: an inline value
+# type parameterized by a comptime capacity `N`, storing up to `N` bytes plus a
+# current byte length, with no heap. It is constructed from a string literal
+# that FITS (a literal exceeding `N` is a clean compile error, E0492), supports
+# `.len()` (current byte length) and byte-indexing `s[i]` (bounds-checked
+# against the length; an out-of-range index traps, exit 101), and coerces to a
+# `str` view (§3.7:43) so it reads through the universal `str` interface.
+#
+# Gated behind `--preview string_trio` (shared with `str`). Deferred to later
+# phases: mutation/append to `Str(N)`, and methods beyond `.len()`/index/borrow.
+
+[section]
+id = "types.str_fixed_type"
+spec_chapter = "3.7"
+name = "The Str(N) Type"
+description = "Str(N) is the fixed-capacity [u8; N] string rung: literal-constructed, len/index, coercible to str."
+
+# 3.7:49 — `Str(N)` is a resolvable type, gated behind `--preview string_trio`.
+[[case]]
+name = "str_fixed_requires_preview"
+spec = ["3.7:49"]
+source = """
+fn main() -> i32 {
+    let s: Str(8) = "hello";
+    0
+}
+"""
+compile_fail = true
+error_contains = "requires preview feature"
+
+# 3.7:49 / 3.7:50 — a fitting string literal has type `Str(N)` where a `Str(N)`
+# is expected, and is storable in a binding.
+[[case]]
+name = "str_fixed_literal_binding"
+spec = ["3.7:49", "3.7:50"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let s: Str(8) = "hello";
+    0
+}
+"""
+exit_code = 0
+
+# 3.7:50 — a `Str(N)` value is storable in a struct field (first-class).
+[[case]]
+name = "str_fixed_in_struct_field"
+spec = ["3.7:50"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+struct Holder { s: Str(8) }
+fn main() -> i32 {
+    let h = Holder { s: "hi" };
+    @intCast(h.s.len())
+}
+"""
+exit_code = 2
+
+# 3.7:50 — a `Str(N)` value is returnable from a function.
+[[case]]
+name = "str_fixed_returnable"
+spec = ["3.7:50"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn make() -> Str(8) {
+    "hi there"
+}
+fn main() -> i32 {
+    let s: Str(8) = make();
+    @intCast(s.len())
+}
+"""
+exit_code = 8
+
+# 3.7:51 — a literal whose byte length exceeds N is a compile-time error (E0492).
+[[case]]
+name = "str_fixed_over_capacity_is_error"
+spec = ["3.7:51"]
+preview = "string_trio"
+source = """
+fn main() -> i32 {
+    let s: Str(3) = "hello";
+    0
+}
+"""
+compile_fail = true
+error_contains = "E0492"
+
+# 3.7:51 — a literal exactly at capacity is accepted (boundary).
+[[case]]
+name = "str_fixed_exact_capacity_ok"
+spec = ["3.7:51"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let s: Str(5) = "hello";
+    @intCast(s.len())
+}
+"""
+exit_code = 5
+
+# 3.7:52 — `.len()` is the current byte length (≤ N), not the capacity.
+[[case]]
+name = "str_fixed_len_is_current_not_capacity"
+spec = ["3.7:52"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let s: Str(64) = "hello";
+    @intCast(s.len())   // 5, not 64
+}
+"""
+exit_code = 5
+
+# 3.7:53 — `s[i]` is the i-th byte as `u8`; packed bytes, not char boundaries.
+[[case]]
+name = "str_fixed_byte_index"
+spec = ["3.7:53"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let s: Str(8) = "hello";
+    @intCast(s[0])   // 104 ('h')
+}
+"""
+exit_code = 104
+
+# 3.7:53 — byte indexing sees raw UTF-8 bytes of a multibyte char.
+[[case]]
+name = "str_fixed_byte_index_multibyte"
+spec = ["3.7:53"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let s: Str(8) = "café";   // 5 bytes: c a f 0xC3 0xA9
+    @intCast(s[3])            // 195 (0xC3)
+}
+"""
+exit_code = 195
+
+# 3.7:54 — an out-of-range byte index traps (exit 101).
+[[case]]
+name = "str_fixed_index_out_of_bounds_traps"
+spec = ["3.7:54"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn main() -> i32 {
+    let s: Str(8) = "hi";
+    let b: u8 = s[5];       // 5 >= len 2
+    @intCast(b)
+}
+"""
+exit_code = 101
+
+# 3.7:55 — a `Str(N)` coerces to a `str` parameter and is read through it.
+[[case]]
+name = "str_fixed_coerces_to_str_param"
+spec = ["3.7:55"]
+preview = "string_trio"
+preview_should_pass = true
+source = """
+fn len_of(s: str) -> u64 {
+    s.len()
+}
+fn first(s: str) -> u8 {
+    s[0]
+}
+fn main() -> i32 {
+    let s: Str(8) = "hello";
+    if len_of(s) == 5 && first(s) == 104 { 0 } else { 1 }
+}
+"""
+exit_code = 0

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -415,6 +415,77 @@ fn main() -> i32 {
 }
 ```
 
+## The `Str(N)` Type
+
+{{ preview_feature(feature="string_trio", adr="ADR-0043") }}
+
+{{ rule(id="3.7:49", cat="normative") }}
+
+The type `Str(N)` is the fixed-capacity string type: it is `[u8; N]` (an inline
+buffer of `N` bytes, with no heap allocation) carrying the same byte-string
+convention as `String` (§3.7:15), plus a byte length. The capacity `N` is a
+compile-time constant (an integer literal or a `const`), so `Str(N)` is a
+value type parameterized by `N`, the string analogue of the fixed array
+`[T; N]`. A `Str(N)` value stores up to `N` bytes together with its current
+byte length.
+
+{{ rule(id="3.7:50", cat="normative") }}
+
+Where a `Str(N)` is expected, a string literal whose UTF-8 byte length is at
+most `N` has type `Str(N)`. Such a value is `@copy`, storable in a binding or a
+struct field, reassignable, returnable from a function, and passable as an
+argument.
+
+{{ rule(id="3.7:51", cat="legality-rule") }}
+
+Constructing a `Str(N)` from a string literal whose UTF-8 byte length exceeds
+`N` is a compile-time error (E0492). Because `Str(N)` has a fixed capacity and
+no heap, an over-long literal cannot be stored, and the fit is checked at
+compile time.
+
+{{ rule(id="3.7:52", cat="normative") }}
+
+For a `Str(N)` value `s`, `s.len()` evaluates to the current byte length of `s`
+as a `u64`, which is at most `N`. The operation is `O(1)`.
+
+{{ rule(id="3.7:53", cat="normative") }}
+
+Indexing a `Str(N)` with an integer, `s[i]`, evaluates to the byte at byte
+offset `i` as a value of type `u8`. Like `String` byte access (§3.7:16) it
+operates on the raw bytes and never inspects UTF-8 character boundaries. The
+operation is `O(1)`.
+
+{{ rule(id="3.7:54", cat="dynamic-semantics") }}
+
+If the index `i` is greater than or equal to `s.len()`, evaluating `s[i]` traps
+(index out of bounds), terminating the program the same way an out-of-bounds
+array, `String`, or `str` index does.
+
+{{ rule(id="3.7:55", cat="normative") }}
+
+A `Str(N)` value is usable where a `str` (§3.7:43) is expected: it coerces to a
+`str` view over its bytes, so a `Str(N)` may be passed to a `str` parameter and
+read through the `str` interface (`.len()`, byte indexing). This makes `str` the
+universal read interface over both the fixed (`Str(N)`) and static-literal
+string rungs.
+
+{{ rule(id="3.7:56") }}
+
+```rue
+fn len_of(s: str) -> u64 {
+    s.len()               // read a Str(N) through the str view
+}
+
+fn main() -> i32 {
+    let s: Str(8) = "hello";   // fits in 8 bytes
+    @dbg(s.len());             // 5
+    @dbg(s[0]);                // 104 ('h')
+    @dbg(len_of(s));           // 5   (coerced to str)
+    // let bad: Str(3) = "hello";  // ERROR (E0492): 5 bytes exceed capacity 3
+    0
+}
+```
+
 ## Limitations
 
 {{ rule(id="3.7:14", cat="informative") }}

--- a/docs/spec/src/06-items/02-structs.md
+++ b/docs/spec/src/06-items/02-structs.md
@@ -71,7 +71,10 @@ Struct fields are accessed using dot notation.
 
 {{ rule(id="6.2:9", cat="normative") }}
 
-Mutable struct values allow field reassignment.
+A field of a mutable struct binding is a *place* and may be the target of an
+assignment (5.2:1, 5.2:2); assigning to it drops the field's prior value, if
+live, before storing the new one (overwrite-drop, 5.2:1). Assigning to a field
+of an immutable binding is a compile-time error (5.2:8).
 
 {{ rule(id="6.2:10") }}
 

--- a/docs/spec/src/06-items/03-enums.md
+++ b/docs/spec/src/06-items/03-enums.md
@@ -32,11 +32,12 @@ A zero-variant enum can never be constructed.
 {{ rule(id="6.3:4", cat="normative") }}
 
 Enum variants are referenced using path syntax: `EnumName::VariantName`.
-An error is raised if the enum type does not exist.
+It is a compile-time error (E0421) if the named enum type does not exist.
 
 {{ rule(id="6.3:5", cat="normative") }}
 
-An error is raised if the variant does not exist within the enum.
+It is a compile-time error (E0420) if the named variant does not exist within
+the enum.
 
 {{ rule(id="6.3:6") }}
 

--- a/docs/spec/src/06-items/05-constants.md
+++ b/docs/spec/src/06-items/05-constants.md
@@ -8,20 +8,25 @@ template = "spec/page.html"
 
 {{ rule(id="6.5:1", cat="normative") }}
 
-A constant item binds a name to a compile-time value at the top level of a
-file. The grammar is given in Appendix A (`const_decl`): an optional `pub`,
-the `const` keyword, a name, an optional type annotation, and an initializer
-expression.
+A constant item binds a name, at the top level of a file, to the value
+obtained by evaluating its initializer expression at compile time; that
+initializer is a comptime-evaluable expression (4.14:26–29, 6.5:2), and the
+name denotes that single compile-time value at every use. The grammar is
+given in Appendix A (`const_decl`): an optional `pub`, the `const` keyword, a
+name, an optional type annotation, and an initializer expression.
 
 {{ rule(id="6.5:2", cat="legality-rule") }}
 
-The initializer of a constant **MUST** be evaluable at compile time.
-Compile-time evaluable expressions include literals, the arithmetic,
-comparison, logical, bitwise, and shift operators applied to compile-time
-evaluable operands, `comptime` block expressions, references to other
-constants, and module expressions (`@import(...)` and module member access
-— chapter 10). An initializer that is not compile-time evaluable produces a
-compile-time error (E0434).
+The initializer of a constant **MUST** be *comptime-evaluable* — a member of
+the comptime-evaluable set defined in 4.14:26–29 (the same set governing a
+`comptime` argument position). As they arise in a constant initializer, those
+forms are: literals (4.14:26); the arithmetic, comparison, logical, bitwise,
+and shift operators applied to comptime-evaluable operands (4.14:27);
+`comptime` block expressions (4.14:2, 4.14:27); references to other constants
+(4.14:26); and module expressions (`@import(...)` and module member access —
+chapter 10, 6.5:10). An initializer outside this set is a compile-time error
+(E0434) — the same diagnostic 4.14:29 names for a `const` initializer that is
+not comptime-evaluable.
 
 {{ rule(id="6.5:3", cat="example") }}
 


### PR DESCRIPTION
- **RUE-326** (ADR-0043 Phase 5): the `Str(N)` fixed string rung. Reuses `str`'s 2-word {ptr,len} via a new is_str_like unifier — NO codegen changes. Literal-fits construction (over-long → E0492, renumbered from the worker's E0491 which RUE-349 took), `.len()`, bounds-checked `s[i]`, borrow-to-str. Rules 3.7:49-55; 11 spec + 8 CLI cases. Capacity model (len ≤ N). Deferred: mutation/append + genuine inline-[u8;N] storage (static-backed today, observationally identical for the immutable surface).
- **RUE-202** (items ch6): folk-terms retired in constants/enums/structs vs the core.

clippy clean; test.sh Pass 25, honest traceability 99.3%, oracle 0.

Fixes RUE-326
Part of RUE-321

Generated with Claude Code