### PR TITLE
StrBuf: canonical growable-string name, String as deprecated alias (RUE-325 increment)

### DIFF
--- a/crates/rue-air/src/inference/generate.rs
+++ b/crates/rue-air/src/inference/generate.rs
@@ -569,14 +569,15 @@ impl<'a> ConstraintGenerator<'a> {
 
             InstData::BoolConst(_) => InferType::Concrete(Type::BOOL),
 
-            // String constants use the builtin String struct type.
+            // String literals have the builtin growable-string type `StrBuf`
+            // (ADR-0043; formerly `String`).
             InstData::StringConst(_) => {
-                // Look up the String type from the structs map
-                if let Some(string_spur) = self.interner.get("String") {
+                // Look up the StrBuf type from the structs map
+                if let Some(string_spur) = self.interner.get("StrBuf") {
                     if let Some(&string_ty) = self.structs.get(&string_spur) {
                         InferType::Concrete(string_ty)
                     } else {
-                        // Fallback if String struct not found (shouldn't happen after builtin injection)
+                        // Fallback if StrBuf struct not found (shouldn't happen after builtin injection)
                         InferType::Concrete(Type::ERROR)
                     }
                 } else {
@@ -2133,11 +2134,11 @@ impl<'a> ConstraintGenerator<'a> {
         result_ty
     }
 
-    /// The builtin `String` type as an [`InferType::Concrete`], or
-    /// `Concrete(ERROR)` if it hasn't been injected (should not happen once
-    /// builtin types are registered).
+    /// The builtin growable-string type `StrBuf` (ADR-0043; formerly `String`)
+    /// as an [`InferType::Concrete`], or `Concrete(ERROR)` if it hasn't been
+    /// injected (should not happen once builtin types are registered).
     fn string_infer_type(&self) -> InferType {
-        if let Some(string_spur) = self.interner.get("String") {
+        if let Some(string_spur) = self.interner.get("StrBuf") {
             if let Some(&string_ty) = self.structs.get(&string_spur) {
                 return InferType::Concrete(string_ty);
             }
@@ -2145,11 +2146,11 @@ impl<'a> ConstraintGenerator<'a> {
         InferType::Concrete(Type::ERROR)
     }
 
-    /// Whether `ty` is *concretely* the builtin `String` struct (not a type
+    /// Whether `ty` is *concretely* the builtin `StrBuf` struct (not a type
     /// variable that might later resolve to it).
     fn is_string_concrete(&self, ty: &InferType) -> bool {
         if let InferType::Concrete(t) = ty {
-            if let Some(string_spur) = self.interner.get("String") {
+            if let Some(string_spur) = self.interner.get("StrBuf") {
                 if let Some(&string_ty) = self.structs.get(&string_spur) {
                     return *t == string_ty;
                 }

--- a/crates/rue-air/src/intern_pool.rs
+++ b/crates/rue-air/src/intern_pool.rs
@@ -325,6 +325,22 @@ impl TypeInternPool {
         (StructId::from_pool_index(pool_index), true)
     }
 
+    /// Register an additional (alias) name for an already-registered struct.
+    ///
+    /// The alias resolves to the *same* struct via [`Self::get_struct_by_name`]
+    /// without creating a second struct entry, keeping the registry/pool
+    /// by-name invariant intact. Used for deprecated built-in type-name aliases
+    /// (ADR-0043: `String` is an alias for `StrBuf`). A no-op if `alias` is
+    /// already registered.
+    pub fn alias_struct_name(&self, alias: Spur, struct_id: StructId) {
+        let mut inner = self.inner.write().unwrap_or_else(PoisonError::into_inner);
+        if inner.struct_by_name.contains_key(&alias) {
+            return;
+        }
+        let interned = InternedType::from_pool_index(struct_id.pool_index());
+        inner.struct_by_name.insert(alias, interned);
+    }
+
     /// Reserve a struct ID without registering the full definition yet.
     ///
     /// This is used for anonymous structs where we need to know the ID before
@@ -916,12 +932,19 @@ impl TypeInternPool {
     /// structs (e.g., for drop glue synthesis).
     pub fn all_struct_ids(&self) -> Vec<StructId> {
         let inner = self.inner.read().unwrap_or_else(PoisonError::into_inner);
+        // A struct may be reachable under more than one name (a deprecated
+        // type-name alias registered via `alias_struct_name`, e.g. ADR-0043's
+        // `String` -> `StrBuf`). De-duplicate by pool index so each struct is
+        // returned exactly once — callers such as drop-glue generation must not
+        // process the same struct twice.
+        let mut seen = std::collections::HashSet::new();
         inner
             .struct_by_name
             .values()
-            .map(|interned| {
+            .filter_map(|interned| {
                 let pool_index = interned.pool_index().expect("struct must have pool index");
-                StructId::from_pool_index(pool_index)
+                seen.insert(pool_index)
+                    .then(|| StructId::from_pool_index(pool_index))
             })
             .collect()
     }

--- a/crates/rue-air/src/sema/analysis/builtin_ops.rs
+++ b/crates/rue-air/src/sema/analysis/builtin_ops.rs
@@ -71,13 +71,13 @@ impl<'a> Sema<'a> {
         let rhs_result = self.analyze_inst_for_projection(air, rhs, ctx)?;
         air.cancel_move_marker(rhs_result.air_ref);
 
-        // Defensive type check (HM inference already guarantees both are String
+        // Defensive type check (HM inference already guarantees both are StrBuf
         // when we get here; this guards against error-recovery paths).
         for operand in [&lhs_result, &rhs_result] {
             if !self.is_builtin_string(operand.ty) && !operand.ty.is_error() {
                 return Err(CompileError::new(
                     ErrorKind::TypeMismatch {
-                        expected: "String".to_string(),
+                        expected: "StrBuf".to_string(),
                         found: operand.ty.safe_name_with_pool(Some(&self.type_pool)),
                     },
                     span,
@@ -150,7 +150,7 @@ impl<'a> Sema<'a> {
                 },
                 span,
             )
-            .with_help(format!("`{fn_name}` takes exactly one String argument")));
+            .with_help(format!("`{fn_name}` takes exactly one StrBuf argument")));
         }
         let arg_value = args[0].value;
 
@@ -163,13 +163,13 @@ impl<'a> Sema<'a> {
         if !self.is_builtin_string(arg_result.ty) && !arg_result.ty.is_error() {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
-                    expected: "String".to_string(),
+                    expected: "StrBuf".to_string(),
                     found: arg_result.ty.safe_name_with_pool(Some(&self.type_pool)),
                 },
                 self.rir.get(arg_value).span,
             )
             .with_help(format!(
-                "`{fn_name}` takes a String; build one with `@to_string`, `+`, or String methods"
+                "`{fn_name}` takes a StrBuf; build one with `@to_string`, `+`, or StrBuf methods"
             )));
         }
 

--- a/crates/rue-air/src/sema/analysis/intrinsics.rs
+++ b/crates/rue-air/src/sema/analysis/intrinsics.rs
@@ -207,13 +207,13 @@ impl<'a> Sema<'a> {
 
         Err(CompileError::new(
             ErrorKind::TypeMismatch {
-                expected: "an array or a String".to_string(),
+                expected: "an array or a StrBuf".to_string(),
                 found: coll_type.safe_name_with_pool(Some(&self.type_pool)),
             },
             span,
         )
         .with_help(
-            "`for` can iterate an array, a String's bytes, or a String's \
+            "`for` can iterate an array, a StrBuf's bytes, or a StrBuf's \
              `.chars()` view",
         ))
     }
@@ -240,12 +240,12 @@ impl<'a> Sema<'a> {
         if !self.is_builtin_string(coll_result.ty) && !coll_result.ty.is_error() {
             return Err(CompileError::new(
                 ErrorKind::TypeMismatch {
-                    expected: "String".to_string(),
+                    expected: "StrBuf".to_string(),
                     found: coll_result.ty.safe_name_with_pool(Some(&self.type_pool)),
                 },
                 span,
             )
-            .with_help("`.chars()` iteration is only available on a String"));
+            .with_help("`.chars()` iteration is only available on a StrBuf"));
         }
 
         let pos_result = self.analyze_inst(air, pos, ctx)?;
@@ -802,12 +802,12 @@ impl<'a> Sema<'a> {
             inst_ref,
             string_type,
             "read_line",
-            "String",
+            "StrBuf",
             span,
         )?;
 
         // The intrinsic lowers to a runtime call whose result codegen packs
-        // into this `Option(String)` enum (discriminant + String payload).
+        // into this `Option(StrBuf)` enum (discriminant + StrBuf payload).
         let air_ref = air.add_inst(AirInst {
             data: AirInstData::Intrinsic {
                 name,
@@ -935,17 +935,17 @@ impl<'a> Sema<'a> {
             ));
         }
 
-        // Analyze the argument - String borrows are handled by
-        // analyze_inst_for_projection to avoid consuming the String
+        // Analyze the argument - StrBuf borrows are handled by
+        // analyze_inst_for_projection to avoid consuming the StrBuf
         let arg_result = self.analyze_inst_for_projection(air, args[0].value, ctx)?;
         let arg_type = arg_result.ty;
 
-        // Argument must be a String
+        // Argument must be a StrBuf
         if !self.is_builtin_string(arg_type) {
             return Err(CompileError::new(
                 ErrorKind::IntrinsicTypeMismatch(Box::new(IntrinsicTypeMismatchError {
                     name: format!("@{}", intrinsic_name_str),
-                    expected: "String".to_string(),
+                    expected: "StrBuf".to_string(),
                     found: arg_type.safe_name_with_pool(Some(&self.type_pool)),
                 })),
                 span,

--- a/crates/rue-air/src/sema/builtins.rs
+++ b/crates/rue-air/src/sema/builtins.rs
@@ -1,7 +1,8 @@
 //! Built-in type injection for semantic analysis.
 //!
-//! This module handles injection of built-in types like String as synthetic
-//! structs, and built-in enums like Arch and Os as synthetic enums.
+//! This module handles injection of built-in types like `StrBuf` (the
+//! growable-string type, ADR-0043; formerly `String`) as synthetic structs,
+//! and built-in enums like Arch and Os as synthetic enums.
 //! Built-in types are registered before user code is processed,
 //! enabling collision detection and proper type resolution.
 
@@ -59,8 +60,21 @@ impl<'a> Sema<'a> {
             self.structs.insert(name_spur, struct_id);
 
             // Store special IDs for quick access
-            if builtin.name == "String" {
+            if builtin.name == "StrBuf" {
                 self.builtin_string_id = Some(struct_id);
+
+                // ADR-0043 renamed `String` -> `StrBuf`. Keep `String` as a
+                // deprecated source-level alias for one migration cycle: it
+                // resolves to the *same* synthetic struct, so existing code
+                // (`let s: String = ...`) keeps type-checking while new code
+                // uses `StrBuf`. The name also stays reserved
+                // (`is_reserved_type_name`) so users cannot shadow it.
+                let alias_spur = self.interner.get_or_intern(rue_builtins::STRING_ALIAS_NAME);
+                self.structs.insert(alias_spur, struct_id);
+                // Also alias the name in the type pool so pool-by-name lookups
+                // (`get_struct_by_name`) resolve `String`, keeping the
+                // registry/pool by-name invariant consistent.
+                self.type_pool.alias_struct_name(alias_spur, struct_id);
             }
 
             // Note: Associated functions and methods are not registered here.

--- a/crates/rue-air/src/sema/tests.rs
+++ b/crates/rue-air/src/sema/tests.rs
@@ -598,7 +598,8 @@ mod tests {
 
     #[test]
     fn test_string_type_injected() {
-        // String type should exist after builtin injection
+        // StrBuf type should exist after builtin injection (ADR-0043; the
+        // growable-string type, formerly `String`).
         let output = compile_to_air(
             "fn main() -> i32 {
                 let s = \"hello\";
@@ -607,14 +608,14 @@ mod tests {
         )
         .unwrap();
 
-        // String struct should exist in the pool
+        // StrBuf struct should exist in the pool
         assert!(
             output
                 .type_pool
                 .all_struct_ids()
                 .iter()
                 .map(|id| output.type_pool.struct_def(*id))
-                .any(|s| s.name == "String")
+                .any(|s| s.name == "StrBuf")
         );
     }
 
@@ -889,26 +890,36 @@ mod tests {
 
     #[test]
     fn test_type_pool_populated_with_builtin_string() {
-        // The String type should be in the pool after builtin injection
+        // The StrBuf type should be in the pool after builtin injection
+        // (ADR-0043; formerly `String`).
         let sema = gather_declarations_for_testing("fn main() -> i32 { 0 }");
 
-        let string_name = sema.interner.get("String").unwrap();
-        let pool_string = sema.type_pool.get_struct_by_name(string_name);
+        let strbuf_name = sema.interner.get("StrBuf").unwrap();
+        let pool_string = sema.type_pool.get_struct_by_name(strbuf_name);
 
-        assert!(pool_string.is_some(), "String should be in the type pool");
+        assert!(pool_string.is_some(), "StrBuf should be in the type pool");
 
         // Verify the struct lookup has it
-        let registry_string = sema.structs.get(&string_name);
+        let registry_string = sema.structs.get(&strbuf_name);
         assert!(
             registry_string.is_some(),
-            "String should be in struct registry"
+            "StrBuf should be in struct registry"
+        );
+
+        // The deprecated `String` alias resolves to the *same* struct id in the
+        // registry, so existing `s: String` annotations keep type-checking.
+        let alias_name = sema.interner.get("String").unwrap();
+        assert_eq!(
+            sema.structs.get(&alias_name),
+            registry_string,
+            "`String` alias should resolve to the StrBuf struct"
         );
 
         // Check the pool definition
         let pool_def = sema.type_pool.get_struct_def(pool_string.unwrap()).unwrap();
 
-        assert_eq!(pool_def.name, "String");
-        assert!(pool_def.is_builtin, "String should be marked as builtin");
+        assert_eq!(pool_def.name, "StrBuf");
+        assert!(pool_def.is_builtin, "StrBuf should be marked as builtin");
     }
 
     #[test]

--- a/crates/rue-builtins/src/lib.rs
+++ b/crates/rue-builtins/src/lib.rs
@@ -1,6 +1,7 @@
 //! Built-in type definitions for the Rue compiler.
 //!
-//! This crate provides the registry of built-in types like `String`. These are
+//! This crate provides the registry of built-in types like `StrBuf` (the
+//! growable-string type; ADR-0043 renamed it from `String`). These are
 //! types that behave like user-defined structs but have runtime implementations
 //! for their methods rather than generated code.
 //!
@@ -298,11 +299,17 @@ pub struct BuiltinTypeDef {
 /// - `len`: Current length in bytes
 /// - `cap`: Capacity of allocated buffer (0 for .rodata literals)
 ///
-/// String is a move type (not Copy) because it owns heap-allocated memory.
+/// `StrBuf` is a move type (not Copy) because it owns heap-allocated memory.
 /// The drop function checks `cap > 0` before freeing, allowing .rodata
 /// literals (with `cap = 0`) to be safely dropped without freeing.
+///
+/// ADR-0043 renamed this type `String` -> `StrBuf` (the growable-string rung of
+/// the collection/string trio, the string analog of `ArrayBuf`). `String`
+/// remains a deprecated source-level alias for one migration cycle (see
+/// [`STRING_ALIAS_NAME`]); the runtime symbols keep their `__rue_String_*`
+/// spelling as an internal implementation detail (not user-visible).
 pub static STRING_TYPE: BuiltinTypeDef = BuiltinTypeDef {
-    name: "String",
+    name: "StrBuf",
     fields: &[
         BuiltinField {
             name: "ptr",
@@ -588,9 +595,19 @@ pub fn get_builtin_type(name: &str) -> Option<&'static BuiltinTypeDef> {
     BUILTIN_TYPES.iter().find(|t| t.name == name).copied()
 }
 
+/// Deprecated source-level alias for the growable-string type [`STRING_TYPE`],
+/// which ADR-0043 renamed `String` -> `StrBuf`. Accepted as a spelling of
+/// `StrBuf` for one migration cycle; a type annotation `s: String` resolves to
+/// the same synthetic struct as `s: StrBuf`. The name stays reserved (users may
+/// not define their own `String`) so the alias can later be removed cleanly.
+pub const STRING_ALIAS_NAME: &str = "String";
+
 /// Check if a name is reserved for a built-in type.
+///
+/// Reserves the canonical built-in names (currently just `StrBuf`) plus the
+/// deprecated [`STRING_ALIAS_NAME`] (`String`) that still resolves to `StrBuf`.
 pub fn is_reserved_type_name(name: &str) -> bool {
-    BUILTIN_TYPES.iter().any(|t| t.name == name)
+    name == STRING_ALIAS_NAME || BUILTIN_TYPES.iter().any(|t| t.name == name)
 }
 
 /// Check if a name is reserved for a runtime/codegen helper function, and thus
@@ -660,7 +677,8 @@ mod tests {
 
     #[test]
     fn test_string_type_exists() {
-        assert_eq!(STRING_TYPE.name, "String");
+        // ADR-0043: canonical name is `StrBuf`; `String` is a deprecated alias.
+        assert_eq!(STRING_TYPE.name, "StrBuf");
         assert_eq!(STRING_TYPE.fields.len(), 3);
         assert!(!STRING_TYPE.is_copy);
         assert_eq!(STRING_TYPE.drop_fn, Some("__rue_drop_String"));
@@ -725,13 +743,19 @@ mod tests {
 
     #[test]
     fn test_get_builtin_type() {
-        assert!(get_builtin_type("String").is_some());
+        // Canonical lookup is by `StrBuf`; the `String` alias is resolved to
+        // the same synthetic struct at injection time, not here.
+        assert!(get_builtin_type("StrBuf").is_some());
+        assert!(get_builtin_type("String").is_none());
         assert!(get_builtin_type("Vec").is_none());
     }
 
     #[test]
     fn test_is_reserved_type_name() {
+        // Both the canonical name and the deprecated alias are reserved.
+        assert!(is_reserved_type_name("StrBuf"));
         assert!(is_reserved_type_name("String"));
+        assert_eq!(STRING_ALIAS_NAME, "String");
         assert!(!is_reserved_type_name("MyStruct"));
     }
 

--- a/crates/rue-cli-tests/cases/strbuf_library.toml
+++ b/crates/rue-cli-tests/cases/strbuf_library.toml
@@ -1,0 +1,72 @@
+# StrBuf — the growable-string rung of ADR-0043 (RUE-325).
+#
+# ADR-0043 de-blesses `String` into `StrBuf`, the string analog of `ArrayBuf`.
+# `StrBuf` is now the canonical name for the 3-word {ptr,len,cap} heap-backed
+# growable string; `String` remains a deprecated source-level alias for one
+# migration cycle. These cases pin the runtime-visible behavior (exact stdout)
+# of the canonical `StrBuf` spelling and prove the `String` alias compiles and
+# runs identically.
+
+[section]
+id = "cli.strbuf_library"
+name = "StrBuf growable string"
+description = "The StrBuf canonical name (ADR-0043) builds, mutates, concatenates, and prints; the deprecated String alias behaves identically."
+
+[[case]]
+name = "strbuf_new_push_str_len_print"
+description = "StrBuf::new(), push_str, len, and println on the canonical name."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut s = StrBuf::new();
+    s.push_str("hello");
+    s.push_str(", world");
+    println(s);
+    println("len is " + @to_string(s.len()));
+    if s == "hello, world" { 0 } else { 1 }
+}
+""" }]
+stdout = "hello, world\nlen is 12\n"
+exit_code = 0
+
+[[case]]
+name = "strbuf_with_capacity_concat"
+description = "StrBuf::with_capacity plus @to_string concatenation build a StrBuf value."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let cap: u64 = 8;
+    let mut s = StrBuf::with_capacity(cap);
+    s.push_str("n=");
+    let combined = s + @to_string(42);
+    println(combined);
+    0
+}
+""" }]
+stdout = "n=42\n"
+exit_code = 0
+
+[[case]]
+name = "string_alias_parity"
+description = "The deprecated `String` alias resolves to the same StrBuf type: annotation, assoc fn, and equality against a StrBuf all work."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    let mut a: String = String::new();
+    a.push_str("abc");
+    let mut b = StrBuf::new();
+    b.push_str("abc");
+    if a == b { 0 } else { 1 }
+}
+""" }]
+exit_code = 0
+
+[[case]]
+name = "strbuf_reserved_name"
+description = "StrBuf is a reserved built-in type name: users cannot define their own."
+files = [{ path = "main.rue", source = """
+struct StrBuf { x: i32 }
+
+fn main() -> i32 {
+    0
+}
+""" }]
+compile_fail = true
+error_contains = ["E0404", "StrBuf", "reserved"]

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -371,7 +371,7 @@ pub fn type_uses_sret_return(type_pool: &TypeInternPool, ty: Type, ret_reg_budge
     match ty.kind() {
         TypeKind::Struct(struct_id) => {
             let struct_def = type_pool.struct_def(struct_id);
-            if struct_def.is_builtin && struct_def.name == "String" {
+            if struct_def.is_builtin && struct_def.name == "StrBuf" {
                 return true;
             }
             types::type_slot_count(type_pool, ty) > ret_reg_budget
@@ -475,14 +475,15 @@ impl<'a> CfgLowerContext<'a> {
     // Builtin type helpers
     // ========================================================================
 
-    /// Check if a type is the builtin String struct.
+    /// Check if a type is the builtin growable-string struct (`StrBuf`).
     ///
-    /// Returns true if the type is a struct that is marked as builtin with name "String".
+    /// Returns true if the type is a struct marked as builtin with name
+    /// "StrBuf" (ADR-0043; formerly "String").
     pub fn is_builtin_string(&self, ty: Type) -> bool {
         match ty.kind() {
             TypeKind::Struct(struct_id) => {
                 let struct_def = self.type_pool.struct_def(struct_id);
-                struct_def.is_builtin && struct_def.name == "String"
+                struct_def.is_builtin && struct_def.name == "StrBuf"
             }
             _ => false,
         }

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -3117,8 +3117,10 @@ mod integration_tests {
                 fn main() -> i32 { 0 }
             "#;
             let result = compile_to_air(src).unwrap();
-            // type_pool includes builtin types (String) plus user-defined structs
-            // There's 1 builtin (String) + 1 user-defined (Point) = 2 total structs
+            // type_pool includes builtin types (StrBuf) plus user-defined
+            // structs. There's 1 builtin (StrBuf) + 1 user-defined (Point) = 2
+            // distinct structs (the deprecated `String` alias names the same
+            // StrBuf struct, so `all_struct_ids` de-dups it away).
             let all_struct_ids = result.type_pool.all_struct_ids();
             assert_eq!(all_struct_ids.len(), 2);
             // Verify Point is present

--- a/crates/rue-spec/cases/expressions/for.toml
+++ b/crates/rue-spec/cases/expressions/for.toml
@@ -308,4 +308,4 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "array or a String"
+error_contains = "array or a StrBuf"

--- a/crates/rue-spec/cases/expressions/intrinsics.toml
+++ b/crates/rue-spec/cases/expressions/intrinsics.toml
@@ -1149,7 +1149,8 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "String"
+# ADR-0043: the growable-string type is now named `StrBuf` in diagnostics.
+error_contains = "StrBuf"
 
 [[case]]
 name = "parse_empty_string_yields_none"

--- a/crates/rue-spec/cases/types/strings.toml
+++ b/crates/rue-spec/cases/types/strings.toml
@@ -78,7 +78,7 @@ error_contains = "use of moved value"
 [[case]]
 name = "string_not_copy_field"
 spec = ["3.7:39"]
-description = "String is not Copy: a @copy struct with a String field is rejected."
+description = "StrBuf is not Copy: a @copy struct with a StrBuf field is rejected (via the deprecated `String` alias spelling)."
 source = """
 @copy
 struct Bad { s: String }
@@ -88,7 +88,7 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "non-Copy type 'String'"
+error_contains = "non-Copy type 'StrBuf'"
 
 # 3.7:39 — an unused String is dropped implicitly (affine, not linear).
 [[case]]

--- a/docs/spec/src/03-types/07-string-type.md
+++ b/docs/spec/src/03-types/07-string-type.md
@@ -10,6 +10,18 @@ template = "spec/page.html"
 
 The type `String` represents an immutable sequence of UTF-8 encoded bytes.
 
+{{ rule(id="3.7:57", cat="informative") }}
+
+ADR-0043 renames this growable-string type `String` → `StrBuf` (the string
+analog of the growable collection `ArrayBuf`), reframing it as the *growable
+rung* of the string trio (`str` / `Str(N)` / `StrBuf`) rather than a blessed
+built-in. During the migration, `StrBuf` is the canonical spelling and `String`
+is accepted as a deprecated alias that resolves to the same type: everywhere
+this chapter says `String`, `StrBuf` may be written instead, with identical
+representation, ownership, and semantics. The alias will be removed once the
+trio (str-as-slice, `Str(N)`) is complete; the remaining normative paragraphs
+below continue to use the `String` spelling until that migration finishes.
+
 {{ rule(id="3.7:2", cat="normative") }}
 
 A `String` value occupies three machine words — a pointer to the string data,

--- a/examples/first/stats.rue
+++ b/examples/first/stats.rue
@@ -9,7 +9,7 @@
 //   max: 7
 //
 // This is a *natural read-until-EOF loop* — no count prefix. Error handling
-// landed (RUE-6, ADR-0038), so @read_line returns Option(String) (None at EOF)
+// landed (RUE-6, ADR-0038), so @read_line returns Option(StrBuf) (None at EOF)
 // and @parse_i64 returns Option(i64) (None on a non-numeric line) instead of
 // trapping. The `read_num` helper chains them with the `?` operator (RUE-318):
 // `@read_line()?` short-circuits the helper to `None` at end-of-input, and the
@@ -28,7 +28,7 @@
 // optional type built in.
 //
 // Exercises the dogfooding set end to end: @read_line, @parse_i64, the `?`
-// operator, a generic Option, String concatenation + @to_string, println, a
+// operator, a generic Option, StrBuf concatenation + @to_string, println, a
 // loop, and match.
 
 fn Option(comptime T: type) -> type {


### PR DESCRIPTION
ADR-0043 Phase 4 green increment: `StrBuf` becomes the canonical built-in name for the 3-word {ptr,len,cap} growable string (display name, method dispatch, sret check on both backends, all diagnostics); `String` stays as a silent deprecated source-level alias resolving to the same synthetic struct, so all ~249 existing `String` sites keep compiling untouched. Runtime symbols remain `__rue_String_*` (internal implementation detail).

Also fixes two alias-induced hazards caught by the suite: the pool/registry by-name invariant (alias registered in both), and `all_struct_ids` double-counting the aliased struct — a real drop-glue double-generation risk, now de-duped by pool index.

Integration note: the informative alias rule was renumbered to 3.7:57 — the worker's 3.7:49 collided with the Str(N) rules 3.7:49–55 that landed in #1162 after its base.

Verified by execution on the merged tree: StrBuf new/push_str/len/println/@to_string/concat (exact stdout), String-alias parity, `struct StrBuf` → E0404, aarch64 `--emit asm` sret path, and a cross-mechanism `Str(N)` × `StrBuf` program. `./test.sh` exit 0; new `strbuf_library.toml` CLI cases pin the behavior.

Remaining for RUE-325 (why Part-of): deprecation warning for the alias + migrating the ~249 `String` spellings, and true de-blessing to a library `ArrayBuf(u8)` type (depends on RUE-324/RUE-315).

Part of RUE-325
Part of RUE-321

🤖 Generated with [Claude Code](https://claude.com/claude-code)