### PR TITLE
rue-rir review fixes: for-loop error span, RIR dump honesty, @copy arity, stale comment

### DIFF
--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -57,6 +57,13 @@ impl Validator<'_> {
                     )),
                     directive.span,
                 ));
+            } else if name == "copy" && !directive.args.is_empty() {
+                // Arity is per-directive: @copy takes no arguments (spec
+                // 2.5), while @allow legitimately takes lint names.
+                self.errors.push(CompileError::new(
+                    ErrorKind::ParseError("@copy takes no arguments".to_string()),
+                    directive.span,
+                ));
             }
         }
     }

--- a/crates/rue-rir/src/astgen.rs
+++ b/crates/rue-rir/src/astgen.rs
@@ -1202,10 +1202,14 @@ impl<'a> AstGen<'a> {
         outer_stmts.push(p_alloc.as_u32());
 
         // let __len: u64 = @__rue_iter_len(__coll);
+        // These two nodes carry the ITERABLE's span, not the whole statement's:
+        // Sema's not-iterable type error (E0206) anchors on the intrinsic, and
+        // it should underline the offending iterable expression.
+        let iter_span = coll_expr.span();
         let len_name = self.interner.get_or_intern(format!("__rue_for_len_{n}"));
         let coll_for_len = self.rir.add_inst(Inst {
             data: InstData::VarRef { name: coll_name },
-            span,
+            span: iter_span,
         });
         let iter_len_sym = self.interner.get_or_intern("__rue_iter_len");
         let (la_start, la_len) = self.rir.add_inst_refs(&[coll_for_len]);
@@ -1215,7 +1219,7 @@ impl<'a> AstGen<'a> {
                 args_start: la_start,
                 args_len: la_len,
             },
-            span,
+            span: iter_span,
         });
         let (ds, dl) = self.rir.add_directives(&[]);
         let len_alloc = self.rir.add_inst(Inst {

--- a/crates/rue-rir/src/inst.rs
+++ b/crates/rue-rir/src/inst.rs
@@ -165,7 +165,9 @@ impl RirPattern {
 const CALL_ARG_SIZE: u32 = 2;
 
 /// Stored representation of RirParam in the extra array.
-/// Layout: [name: u32, ty: u32, mode: u32, is_comptime: u32] = 4 u32s per param
+/// Layout: [name: u32, ty: u32, mode: u32, is_comptime: u32,
+///          span.file_id: u32, span.start: u32, span.end: u32] = 7 u32s per
+/// param (must match `add_params`/`get_params`)
 const PARAM_SIZE: u32 = 7;
 
 /// Stored representation of match arm in the extra array.
@@ -1883,6 +1885,20 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
             .join(", ")
     }
 
+    /// Format an item's directives as a `"@copy @allow(..) "` prefix
+    /// (empty string when there are none).
+    fn format_directives(&self, start: u32, len: u32) -> String {
+        let directives = self.rir.get_directives(start, len);
+        if directives.is_empty() {
+            return String::new();
+        }
+        let dir_names: Vec<String> = directives
+            .iter()
+            .map(|d| format!("@{}", self.interner.resolve(&d.name)))
+            .collect();
+        format!("{} ", dir_names.join(" "))
+    }
+
     /// Format a pattern for printing.
     fn format_pattern(&self, pat: &RirPattern) -> String {
         match pat {
@@ -1981,8 +1997,11 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     }
                 }
                 InstData::Loop { cond, body } => writeln!(out, "loop {}, {}", cond, body).unwrap(),
-                InstData::InfiniteLoop { body, .. } => {
-                    writeln!(out, "infinite_loop {}", body).unwrap()
+                InstData::InfiniteLoop { body, iter_borrow } => {
+                    let borrow_str = iter_borrow
+                        .map(|c| format!(" borrows {}", self.interner.resolve(&c)))
+                        .unwrap_or_default();
+                    writeln!(out, "infinite_loop {}{}", body, borrow_str).unwrap()
                 }
                 InstData::Match {
                     scrutinee,
@@ -2004,8 +2023,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
 
                 // Functions
                 InstData::FnDecl {
-                    directives_start: _,
-                    directives_len: _,
+                    directives_start,
+                    directives_len,
                     is_pub,
                     is_unchecked,
                     name,
@@ -2047,9 +2066,11 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                             )
                         })
                         .collect();
+                    let directives_str = self.format_directives(*directives_start, *directives_len);
                     writeln!(
                         out,
-                        "{}{}fn {}({}{}) -> {} {{",
+                        "{}{}{}fn {}({}{}) -> {} {{",
+                        directives_str,
                         pub_str,
                         unchecked_str,
                         name_str,
@@ -2062,19 +2083,25 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     writeln!(out, "}}").unwrap();
                 }
                 InstData::ConstDecl {
-                    directives_start: _,
-                    directives_len: _,
+                    directives_start,
+                    directives_len,
                     is_pub,
                     name,
                     ty,
                     init,
                 } => {
+                    let directives_str = self.format_directives(*directives_start, *directives_len);
                     let pub_str = if *is_pub { "pub " } else { "" };
                     let name_str = self.interner.resolve(&*name);
                     let ty_str = ty
                         .map(|t| format!(": {}", self.interner.resolve(&t)))
                         .unwrap_or_default();
-                    writeln!(out, "{}const {}{} = {}", pub_str, name_str, ty_str, init).unwrap();
+                    writeln!(
+                        out,
+                        "{}{}const {}{} = {}",
+                        directives_str, pub_str, name_str, ty_str, init
+                    )
+                    .unwrap();
                 }
                 InstData::Ret(inner) => {
                     if let Some(inner) = inner {
@@ -2121,14 +2148,15 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
 
                 // Variables
                 InstData::Alloc {
-                    directives_start: _,
-                    directives_len: _,
+                    directives_start,
+                    directives_len,
                     name,
                     is_mut,
                     ty,
                     init,
-                    iter_elem: _,
+                    iter_elem,
                 } => {
+                    let directives_str = self.format_directives(*directives_start, *directives_len);
                     let name_str = name
                         .map(|n| self.interner.resolve(&n).to_string())
                         .unwrap_or_else(|| "_".to_string());
@@ -2136,7 +2164,13 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                     let ty_str = ty
                         .map(|t| format!(": {}", self.interner.resolve(&t)))
                         .unwrap_or_default();
-                    writeln!(out, "alloc {}{}{}= {}", mut_str, name_str, ty_str, init).unwrap();
+                    let iter_str = if *iter_elem { " [iter_elem]" } else { "" };
+                    writeln!(
+                        out,
+                        "{}alloc {}{}{}= {}{}",
+                        directives_str, mut_str, name_str, ty_str, init, iter_str
+                    )
+                    .unwrap();
                 }
                 InstData::VarRef { name } => {
                     writeln!(out, "var_ref {}", self.interner.resolve(&*name)).unwrap();
@@ -2170,17 +2204,8 @@ impl<'a, 'b> RirPrinter<'a, 'b> {
                             )
                         })
                         .collect();
-                    let directives = self.rir.get_directives(*directives_start, *directives_len);
                     let linear_str = if *is_linear { "linear " } else { "" };
-                    let directives_str = if directives.is_empty() {
-                        String::new()
-                    } else {
-                        let dir_names: Vec<String> = directives
-                            .iter()
-                            .map(|d| format!("@{}", self.interner.resolve(&d.name)))
-                            .collect();
-                        format!("{} ", dir_names.join(" "))
-                    };
+                    let directives_str = self.format_directives(*directives_start, *directives_len);
                     let methods = self.rir.get_inst_refs(*methods_start, *methods_len);
                     let methods_str = if methods.is_empty() {
                         String::new()

--- a/crates/rue-ui-tests/cases/diagnostics/directives.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/directives.toml
@@ -79,6 +79,26 @@ exit_code = 0
 no_warnings = true
 
 [[case]]
+name = "copy_directive_with_args_rejected"
+description = """
+@copy takes no arguments (spec 2.5); bogus args used to be silently accepted
+and ignored (rue-rir component review, 2026-07-04). Arity is per-directive:
+@allow legitimately takes lint-name args (covered above).
+"""
+source = """
+@copy(garbage, nonsense)
+struct S { x: i32 }
+
+fn main() -> i32 {
+    let s = S { x: 5 };
+    let t = s;
+    s.x + t.x
+}
+"""
+compile_fail = true
+error_contains = ["@copy takes no arguments"]
+
+[[case]]
 name = "known_directive_copy_still_works"
 source = """
 @copy

--- a/crates/rue-ui-tests/cases/diagnostics/error-spans.toml
+++ b/crates/rue-ui-tests/cases/diagnostics/error-spans.toml
@@ -38,3 +38,24 @@ fn main() -> i32 {
 """
 compile_fail = true
 error_contains = "3:9"
+
+# =============================================================================
+# For-loop iterable errors
+# =============================================================================
+
+[[case]]
+name = "for_iterable_type_error_points_at_iterable"
+source = """
+fn main() -> i32 {
+    let notiter: i32 = 5;
+    for x in notiter {
+        let y = x;
+    }
+    0
+}
+"""
+compile_fail = true
+# The not-iterable error anchors on the iterable subexpression (`notiter` at
+# 3:14), not the whole `for` statement: the desugared @__rue_iter_len intrinsic
+# carries the iterable's span (rue-rir component review, 2026-07-04).
+error_contains = ["3:14", "expected an array or a StrBuf, found i32"]


### PR DESCRIPTION
Four verified findings from the rue-rir component review (2026-07-04; 5 lenses — desugaring, spans, ICE surface, inst.rs quality, cross-stage contract — each finding adversarially re-verified on trunk):

- **For-loop error span:** `gen_for` now anchors the `@__rue_iter_len` intrinsic (and its collection VarRef) on the **iterable's** span, so the not-iterable E0206 underlines the offending expression (`notiter` at 3:14) instead of the whole `for` statement. UI case pins it.
- **`--emit rir` dump honesty:** the dump no longer hides load-bearing fields — `Alloc` prints `[iter_elem]` (the non-owning borrow slot marker drop elaboration depends on), `InfiniteLoop` prints `borrows <coll>` (the E0428 mutation-rejection driver), and FnDecl/ConstDecl/Alloc print their directives like StructDecl already did (new shared `format_directives` helper; StructDecl deduplicated onto it).
- **`@copy` arity:** `@copy(garbage, nonsense)` was silently accepted and ignored; it is now a compile error ("@copy takes no arguments", spec 2.5). `@allow`'s legitimate lint-name args are unaffected. UI case added.
- **Stale `PARAM_SIZE` comment:** corrected to the real 7-word layout (was documenting 4, missing `is_comptime` + the 3 span words).

Verified by execution: E0206 caret at 3:14; `@copy(args)` errors; bare `@copy` + `@allow(unused_variable)` still compile clean (exit 10, no warnings); rir dump shows `[iter_elem]`/`borrows xs`. clippy clean, `./test.sh` exit 0.

The review's remaining finding (directive **placement** validation + unknown-lint-name diagnosis) is filed separately — it interlocks with the pending spec-2.5 `@allow` cluster. Notable negative results: desugaring evaluation order, `Rir::merge` renumbering, and the ICE surface all came back clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)