### PR TITLE
Oracle/harness honesty: ZST param slots, byte-exact spec compare, zero-case guard, arity guards

### DIFF
--- a/crates/rue-oracle-diff/src/generator.rs
+++ b/crates/rue-oracle-diff/src/generator.rs
@@ -297,7 +297,10 @@ impl Program {
                 format!("({l} {op} ({r} | 1))")
             }
             2 => {
-                // Shift by a same-typed amount; over-shift traps in both engines.
+                // Shift by a same-typed amount; the shift count is masked modulo
+                // the operand width (spec 4.3a, formal core (D-Shl)/(D-Shr)) in
+                // both engines, so an over-shift is a defined value and never
+                // traps — no divisor-style guard is needed.
                 let op = *self.rng.pick(&["<<", ">>"]);
                 let l = self.expr(ty, scope, depth - 1);
                 let r = self.expr(ty, scope, depth - 1);

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -210,6 +210,14 @@ fn finish_report(report: &Report, corpus: &str) -> ExitCode {
         println!("\n  ✗ {d}");
     }
 
+    // Zero cases checked means the corpus wiring is broken (empty dir, stale
+    // env-var path, TOMLs with no parseable cases) — a no-op differential run
+    // must not report success (the RUE-341 coverage-overstatement hazard).
+    if total == 0 {
+        println!("\nno runnable {corpus} cases were checked — corpus dir empty or misconfigured.");
+        return ExitCode::FAILURE;
+    }
+
     if report.disagreements.is_empty() {
         println!("\noracle agrees with the compiler on every runnable case.");
         ExitCode::SUCCESS
@@ -319,11 +327,15 @@ fn check_spec_case(ident: &str, case: &rue_test_runner::Case, report: &mut Repor
         Err(_unsupported) => report.skip_unsupported += 1,
         Ok(outcome) => {
             let exit_ok = outcome.exit_code == expected_exit;
-            // Compare stdout under the spec runner's own normalization so a
-            // trailing-newline difference is not reported as a miscompile.
+            // Compare stdout the way the spec runner itself does: byte-exact
+            // modulo the single `"""` block-boundary newline. NOT
+            // normalize_golden — that trims per-line trailing whitespace and
+            // boundary blank lines, which would record a real
+            // whitespace-shaped oracle-vs-compiler divergence as agreement
+            // (RUE-132's byte-exactness rule applies here too).
             let stdout_ok = case.expected_stdout.as_ref().is_none_or(|s| {
-                rue_test_runner::normalize_golden(&outcome.stdout)
-                    == rue_test_runner::normalize_golden(s)
+                rue_test_runner::strip_block_boundary_newlines(&outcome.stdout)
+                    == rue_test_runner::strip_block_boundary_newlines(s)
             });
             let agrees = exit_ok && stdout_ok;
 

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -227,12 +227,15 @@ struct Frame {
 }
 
 /// Number of ABI parameter slots a value occupies: one per flattened scalar
-/// leaf. Matches the CFG's slot numbering for `Param{index}`.
+/// leaf. Matches the CFG's slot numbering for `Param{index}`, including
+/// zero-sized values: `abi_slot_count` (rue-air typeck) gives unit and empty
+/// structs ZERO slots, so a parameter after a ZST is NOT shifted up.
 fn slot_width(v: &Value) -> usize {
     match v {
         Value::Aggregate(elems) => elems.iter().map(slot_width).sum(),
         // A String is a fat value occupying three ABI slots (ptr, len, cap).
         Value::Str(_) => 3,
+        Value::Unit => 0,
         _ => 1,
     }
 }
@@ -290,10 +293,16 @@ impl<'a> Interp<'a> {
             .find_cfg(name)
             .ok_or_else(|| Flow::Unsupported(Unsupported(format!("call to '{name}'"))))?;
         // Lay arguments out by slot: place each whole value at its base slot,
-        // then pad with `None` for the extra slots an aggregate occupies.
+        // then pad with `None` for the extra slots an aggregate occupies. A
+        // zero-sized argument occupies no slot at all (matching
+        // `abi_slot_count`), so it is never materialized in `params` and the
+        // following arguments are not shifted.
         let mut param_slots: Vec<Option<Value>> = Vec::with_capacity(args.len());
         for a in args {
-            let w = slot_width(a).max(1);
+            let w = slot_width(a);
+            if w == 0 {
+                continue;
+            }
             param_slots.push(Some(a.clone()));
             for _ in 1..w {
                 param_slots.push(None);
@@ -398,9 +407,48 @@ impl<'a> Interp<'a> {
     /// the ordinary CFG call). `capacity`/`reserve`/`with_capacity` capacity
     /// behavior is implementation-defined and deliberately not modeled.
     fn string_builtin(&self, name: &str, args: &[Value]) -> Step<Option<Value>> {
-        let s = |v: &Value| match v {
-            Value::Str(s) => s.clone(),
-            _ => String::new(),
+        // Logical-argument count each modeled builtin expects (receiver
+        // included). A call shape that doesn't match means the runtime-fn
+        // signature drifted from what the oracle models (the RUE-314 class):
+        // skip honestly rather than read args positionally from the wrong
+        // slots and return a plausible-but-wrong value.
+        let expected_arity = match name {
+            "__rue_String_new" => Some(0),
+            "__rue_to_string"
+            | "__rue_to_string_unsigned"
+            | "__rue_String_with_capacity"
+            | "__rue_String_len"
+            | "__rue_String_is_empty"
+            | "__rue_String_clear"
+            | "__rue_String_clone" => Some(1),
+            "__rue_String_push_str"
+            | "__rue_String_push"
+            | "__rue_String_reserve"
+            | "__rue_String_byte_at"
+            | "__rue_str_byte_at"
+            | "__rue_String_char_scalar"
+            | "__rue_String_char_scalar_lossy"
+            | "__rue_String_char_next"
+            | "__rue_String_char_next_lossy" => Some(2),
+            _ => None,
+        };
+        if let Some(expected) = expected_arity
+            && args.len() != expected
+        {
+            return Err(Flow::Unsupported(Unsupported(format!(
+                "builtin '{name}' called with {} args, oracle models {expected} (signature drift?)",
+                args.len()
+            ))));
+        }
+        // Same honesty rule for argument TYPES: a non-string where the modeled
+        // signature has a string is drift, not an empty string.
+        let s = |v: &Value| -> Result<String, Flow> {
+            match v {
+                Value::Str(s) => Ok(s.clone()),
+                _ => Err(Flow::Unsupported(Unsupported(format!(
+                    "builtin '{name}' received a non-string argument (signature drift?)"
+                )))),
+            }
         };
         let out = match name {
             // `@to_string(n)` (RUE-314). The argument is already widened to a
@@ -411,9 +459,9 @@ impl<'a> Interp<'a> {
             "__rue_to_string_unsigned" => Value::Str((args[0].as_int() as u64).to_string()),
             "__rue_String_new" => Value::Str(String::new()),
             "__rue_String_with_capacity" => Value::Str(String::new()),
-            "__rue_String_push_str" => Value::Str(s(&args[0]) + &s(&args[1])),
+            "__rue_String_push_str" => Value::Str(s(&args[0])? + &s(&args[1])?),
             "__rue_String_push" => {
-                let mut base = s(&args[0]);
+                let mut base = s(&args[0])?;
                 let byte = args[1].as_int() as u8;
                 if byte < 0x80 {
                     // ASCII: exactly one byte, matching the runtime's raw-byte
@@ -431,18 +479,18 @@ impl<'a> Interp<'a> {
                 }
                 Value::Str(base)
             }
-            "__rue_String_len" => Value::Int(s(&args[0]).len() as i128),
-            "__rue_String_is_empty" => Value::Bool(s(&args[0]).is_empty()),
+            "__rue_String_len" => Value::Int(s(&args[0])?.len() as i128),
+            "__rue_String_is_empty" => Value::Bool(s(&args[0])?.is_empty()),
             "__rue_String_clear" => Value::Str(String::new()),
-            "__rue_String_clone" => Value::Str(s(&args[0])),
-            "__rue_String_reserve" => Value::Str(s(&args[0])),
+            "__rue_String_clone" => Value::Str(s(&args[0])?),
+            "__rue_String_reserve" => Value::Str(s(&args[0])?),
             // `s[i]` byte indexing (ADR-0035): the runtime `__rue_String_byte_at`
             // bounds-checks `index >= len` — trapping like array indexing — and
             // returns the raw byte zero-extended. Model it over the byte content
             // directly. A negative index is passed to the runtime as a huge u64,
             // so it is likewise out of bounds and traps.
             "__rue_String_byte_at" => {
-                let text = s(&args[0]);
+                let text = s(&args[0])?;
                 let bytes = text.as_bytes();
                 let idx = args[1].as_int();
                 if idx < 0 || idx as u128 >= bytes.len() as u128 {
@@ -456,7 +504,7 @@ impl<'a> Interp<'a> {
             // bounds-check-and-trap discipline. Modeled identically over the byte
             // content (the `str` receiver is `arg[0]`, the index `arg[1]`).
             "__rue_str_byte_at" => {
-                let text = s(&args[0]);
+                let text = s(&args[0])?;
                 let bytes = text.as_bytes();
                 let idx = args[1].as_int();
                 if idx < 0 || idx as u128 >= bytes.len() as u128 {
@@ -474,14 +522,14 @@ impl<'a> Interp<'a> {
             // strict and `_lossy` variants coincide over the modeled content — a
             // well-formed loop only ever passes whole-character-boundary offsets.
             "__rue_String_char_scalar" | "__rue_String_char_scalar_lossy" => {
-                let text = s(&args[0]);
+                let text = s(&args[0])?;
                 match char_at(&text, args[1].as_int()) {
                     Some((scalar, _)) => Value::Int(scalar as i128),
                     None => return Err(Flow::Panic(Panic("invalid UTF-8".into()))),
                 }
             }
             "__rue_String_char_next" | "__rue_String_char_next_lossy" => {
-                let text = s(&args[0]);
+                let text = s(&args[0])?;
                 let offset = args[1].as_int();
                 match char_at(&text, offset) {
                     Some((_, width)) => Value::Int(offset + width as i128),
@@ -560,6 +608,47 @@ impl<'a> Interp<'a> {
         Ok(())
     }
 
+    /// Whether `ty` occupies ZERO ABI parameter slots — the type-level twin of
+    /// [`slot_width`] and of the compiler's `abi_slot_count == 0` (rue-air
+    /// typeck): unit/never/comptime types, structs whose fields are all
+    /// zero-sized, and arrays that are empty or have zero-sized elements.
+    /// Enums are never zero-sized (they always carry a discriminant slot).
+    fn is_zero_sized(&self, ty: Type) -> bool {
+        match ty.kind() {
+            TypeKind::Unit | TypeKind::Never | TypeKind::ComptimeType => true,
+            TypeKind::Struct(sid) => {
+                let sd = self.state.type_pool.struct_def(sid);
+                sd.fields.iter().all(|f| self.is_zero_sized(f.ty))
+            }
+            TypeKind::Array(aid) => {
+                let (elem_ty, len) = self.state.type_pool.array_def(aid);
+                len == 0 || self.is_zero_sized(elem_ty)
+            }
+            _ => false,
+        }
+    }
+
+    /// Materialize the (unique) value of a zero-sized type, preserving the
+    /// aggregate shape so field/element projections still line up.
+    fn zero_sized_value(&self, ty: Type) -> Value {
+        match ty.kind() {
+            TypeKind::Struct(sid) => {
+                let sd = self.state.type_pool.struct_def(sid);
+                Value::Aggregate(
+                    sd.fields
+                        .iter()
+                        .map(|f| self.zero_sized_value(f.ty))
+                        .collect(),
+                )
+            }
+            TypeKind::Array(aid) => {
+                let (elem_ty, len) = self.state.type_pool.array_def(aid);
+                Value::Aggregate((0..len).map(|_| self.zero_sized_value(elem_ty)).collect())
+            }
+            _ => Value::Unit,
+        }
+    }
+
     fn eval_all(&mut self, cfg: &'a Cfg, frame: &mut Frame, vs: &[CfgValue]) -> Step<Vec<Value>> {
         vs.iter().map(|v| self.eval(cfg, frame, *v)).collect()
     }
@@ -590,11 +679,22 @@ impl<'a> Interp<'a> {
                     .cloned()
                     .ok_or_else(|| Flow::Unsupported(Unsupported("string const index".into())))?,
             ),
-            CfgInstData::Param { index } => frame
-                .params
-                .get(*index as usize)
-                .and_then(|o| o.clone())
-                .ok_or_else(|| Flow::Unsupported(Unsupported("param index".into())))?,
+            CfgInstData::Param { index } => {
+                if self.is_zero_sized(ty) {
+                    // A zero-sized parameter occupies NO slot (abi_slot_count
+                    // = 0), but the CFG still emits a Param read for it —
+                    // sharing its `index` with the NEXT parameter's slot. Do
+                    // not read the slot (that would grab the next parameter's
+                    // value); materialize the unique ZST value instead.
+                    self.zero_sized_value(ty)
+                } else {
+                    frame
+                        .params
+                        .get(*index as usize)
+                        .and_then(|o| o.clone())
+                        .ok_or_else(|| Flow::Unsupported(Unsupported("param index".into())))?
+                }
+            }
             CfgInstData::BlockParam { .. } => frame
                 .cache
                 .get(&v.as_u32())
@@ -798,8 +898,12 @@ impl<'a> Interp<'a> {
                 let mut base = 0usize;
                 for a in &call_args {
                     let v = self.eval(cfg, frame, a.value)?;
-                    let w = slot_width(&v).max(1);
-                    if matches!(a.mode, CfgArgMode::Inout) {
+                    // A zero-sized argument occupies no parameter slot (see
+                    // `slot_width`): it neither advances `base` nor gets an
+                    // inout write-back (the callee's params hold no slot for
+                    // it to copy back from).
+                    let w = slot_width(&v);
+                    if matches!(a.mode, CfgArgMode::Inout) && w > 0 {
                         writebacks.push((base, Self::lvalue_of(cfg, a.value)?));
                     }
                     argvals.push(v);

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -558,3 +558,26 @@ fn string_is_empty_and_clear() {
     }";
     assert_eq!(exit(src), 0);
 }
+
+#[test]
+fn zst_param_before_scalar_does_not_shift_slots() {
+    // A zero-sized argument occupies zero ABI slots (abi_slot_count), so the
+    // scalar after it lives at slot 0, not slot 1. The oracle used to force
+    // every argument to at least one slot and read 0 here — a phantom
+    // DISAGREE blaming codegen (rue-oracle component review, 2026-07-04).
+    let src = "struct E {}
+    fn pick(e: E, n: i32) -> i32 { n }
+    fn main() -> i32 { let e = E {}; pick(e, 42) }";
+    assert_eq!(exit(src), 42);
+}
+
+#[test]
+fn zst_param_forwarded_through_two_calls() {
+    // Forwarding the ZST through another call keeps the layout consistent at
+    // every level.
+    let src = "struct E {}
+    fn pick(e: E, n: i32) -> i32 { n }
+    fn wrap(e: E, n: i32) -> i32 { pick(e, n + 1) }
+    fn main() -> i32 { let e = E {}; wrap(e, 41) }";
+    assert_eq!(exit(src), 42);
+}

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -899,7 +899,7 @@ pub fn normalize_golden(s: &str) -> String {
 /// which forces a trailing newline — doesn't force every expectation to be
 /// written on one crowded line. Reserve [`normalize_golden`] for `--emit` IR
 /// golden dumps, which are inherently multi-line and formatting-insensitive.
-fn strip_block_boundary_newlines(s: &str) -> &str {
+pub fn strip_block_boundary_newlines(s: &str) -> &str {
     let s = s
         .strip_prefix("\r\n")
         .or_else(|| s.strip_prefix('\n'))


### PR DESCRIPTION
Four verified findings from the rue-oracle + rue-oracle-diff component review (2026-07-04; 5 lenses, each finding adversarially re-verified):

- **ZST parameter slots (real oracle bug):** the compiler assigns zero-sized types ZERO ABI slots but still emits a `Param` read for them at the *next* param's index. The oracle forced every argument to ≥1 slot, so `fn pick(e: E, n: i32)` with `struct E {}` made the oracle read the wrong slot and report a **phantom DISAGREE that blames codegen** ("expected 42, oracle got 0"). Fixed with a type-aware Param arm (`is_zero_sized`/`zero_sized_value` over type_pool) plus zero-width argument layout. The reviewer's sketch (drop `.max(1)`) was insufficient — the CFG shares the ZST's index with the next param, discovered via `--emit cfg` when the forwarding regression test failed; both single-call and two-level-forwarding tests now pin it.
- **Spec-mode stdout over-normalization:** `check_spec_case` compared via `normalize_golden`, which trims trailing whitespace and boundary blank lines — a whitespace-shaped oracle-vs-compiler divergence scored AGREE in the exact tool built to catch stdout miscompiles. Now byte-exact modulo the single `"""` boundary newline (`strip_block_boundary_newlines`, made pub in rue-test-runner), matching the spec runner and corpus mode.
- **Zero-case success:** `finish_report` returned SUCCESS when zero cases were checked (existing-but-empty dir, TOMLs with no parseable `[[case]]`) — a filegroup/env-var wiring regression would turn the differential CI check into a green no-op (the RUE-341 coverage-overstatement hazard). `total == 0` is now FAILURE.
- **Builtin dispatch honesty:** `string_builtin` now guards arity and argument types — a runtime-fn signature drift (the RUE-314 class) yields an honest `Unsupported` skip instead of positionally reading wrong slots or coercing non-strings to `""`. Also fixed the inverted over-shift comment in the fuzz generator (shifts mask mod width and never trap, per spec 4.3a).

Verified by execution: ZST probe DISAGREE→agree; whitespace-divergence spec case AGREE→DISAGREE; empty/no-case dirs exit 0→1; corpus and spec tallies **byte-identical to baseline** (498/78/518 and 1259/94/571, 0 disagreements) so the new guards introduced zero false skips. clippy clean, `./test.sh` exit 0.

Companion issues from the same review: RUE-357 (fuzzer never generates structural equality), RUE-358 (oracle str modeling gaps) — filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)