### PR TITLE
Driver: SIGPIPE no longer an ICE; -o under --emit warns instead of silently ignoring/false-clobbering

### DIFF
--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -480,6 +480,7 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
     }
 
     // Determine source files and output path based on argument count and -o flag
+    let explicit_output = output_path.is_some();
     let (source_paths, final_output_path) = if let Some(out) = output_path {
         // -o was specified: all positional args are source files
         (positional, out)
@@ -517,19 +518,29 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         return ParseResult::Error;
     };
 
-    // In every mode: the output must not clobber an input. Compare RESOLVED
-    // filesystem paths, not raw strings, so different spellings of the same
-    // file are all caught — `rue a.rue -o a.rue`, `rue ./prog -o prog`, or an
-    // extensionless source `rue prog -o prog`. The earlier guard keyed off a
-    // `.rue` suffix, so extensionless sources slipped through and the compiled
-    // output silently overwrote the source (RUE-351).
-    let output_key = clobber_key(&final_output_path);
-    if source_paths.iter().any(|s| clobber_key(s) == output_key) {
-        eprintln!(
-            "Error: output path '{}' is also an input source file; refusing to overwrite it",
-            final_output_path
-        );
-        return ParseResult::Error;
+    if !emit_stages.is_empty() {
+        // --emit prints IR to stdout and never writes the output path, so the
+        // clobber guard below does not apply (nothing can be clobbered) — but
+        // an explicit -o deserves a warning, since it is silently ignored.
+        if explicit_output {
+            eprintln!("Warning: -o is ignored with --emit; IR goes to stdout");
+        }
+    } else {
+        // In every executable-producing mode: the output must not clobber an
+        // input. Compare RESOLVED filesystem paths, not raw strings, so
+        // different spellings of the same file are all caught — `rue a.rue -o
+        // a.rue`, `rue ./prog -o prog`, or an extensionless source `rue prog
+        // -o prog`. The earlier guard keyed off a `.rue` suffix, so
+        // extensionless sources slipped through and the compiled output
+        // silently overwrote the source (RUE-351).
+        let output_key = clobber_key(&final_output_path);
+        if source_paths.iter().any(|s| clobber_key(s) == output_key) {
+            eprintln!(
+                "Error: output path '{}' is also an input source file; refusing to overwrite it",
+                final_output_path
+            );
+            return ParseResult::Error;
+        }
     }
 
     if log_format.is_some() && log_level.is_none() {
@@ -910,6 +921,16 @@ fn discover_and_load_imports(sources: &mut Vec<(String, String)>) {
 }
 
 fn main() {
+    // Rust's startup ignores SIGPIPE, so a write to a closed pipe
+    // (`rue --emit tokens x.rue | head`) returns EPIPE and `println!` panics
+    // — which the ICE hook below then mislabels as a compiler bug asking the
+    // user to file an issue. Restore the conventional Unix behavior: die
+    // silently with SIGPIPE (exit 141), like every other CLI in a pipeline.
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    }
+
     // Present compiler panics as internal compiler errors with a report
     // banner instead of a raw Rust backtrace pointer (RUE-130). The default
     // hook still runs first so RUST_BACKTRACE=1 output is preserved.
@@ -1571,6 +1592,16 @@ mod tests {
     fn parse_emit_tokens() {
         let opts = unwrap_options(parse_args_from(&["--emit", "tokens", "source.rue"]));
         assert_eq!(opts.emit_stages, vec![EmitStage::Tokens]);
+    }
+
+    #[test]
+    fn emit_mode_skips_output_clobber_guard() {
+        // --emit writes nothing to the output path, so -o naming a source
+        // file is NOT a clobber (it is merely ignored, with a warning); the
+        // same spelling without --emit is still refused.
+        let opts = unwrap_options(parse_args_from(&["--emit", "ast", "x.rue", "-o", "x.rue"]));
+        assert_eq!(opts.emit_stages, vec![EmitStage::Ast]);
+        assert!(is_error(&parse_args_from(&["x.rue", "-o", "x.rue"])));
     }
 
     #[test]


### PR DESCRIPTION
Two verified findings from the driver/orchestration component review (2026-07-04; 5 lenses over rue-compiler + the rue CLI, each finding adversarially re-verified):

- **Broken pipe presented as a compiler bug:** Rust's startup ignores SIGPIPE, so `rue ... | head` (or `| less` quit early) made every stdout write panic — and the RUE-130 panic hook then printed the full *"internal compiler error … please report this at …"* banner (exit 134) for a completely benign condition, on every stdout path (success line, `--emit`, `--benchmark-json`). `main()` now restores `SIG_DFL` on Unix, so the process exits silently with SIGPIPE (141) like every other CLI in a pipeline.
- **`-o` under `--emit`:** emit mode never writes the output path, but `-o` was both **silently ignored** (`--emit asm a.rue -o out.s` prints to stdout and never creates `out.s`, no message) and **unconditionally clobber-guarded** (`--emit ast a.rue -o a.rue` falsely refused with the RUE-351 message even though nothing is written). The clobber guard now applies only to executable-producing mode, and an explicit `-o` under `--emit` warns that IR goes to stdout. A parse-level unit test pins both sides.

Verified by execution: pipe to `head -0` → status 141 with no banner; `--emit … -o X` → warning, exit 0, no file; `--emit … -o <source>` accepted; plain `-o <source>` still refused; normal compiles unaffected. clippy clean, `./test.sh` exit 0.

Companion issues from the same review (filed separately): unbounded `-j` hang, aliased-@import identity mismatch (spurious E0707), order-dependent multi-file error reporting, caret misalignment under tabs/CRLF, and a regrown dead frontend pipeline + dead pub API in rue-compiler.

🤖 Generated with [Claude Code](https://claude.com/claude-code)