### PR TITLE
Harness trust: close four false-green holes in the traceability gate + CLI compile timeout + shared ice_message

### DIFF
--- a/crates/rue-cli-tests/src/main.rs
+++ b/crates/rue-cli-tests/src/main.rs
@@ -68,12 +68,13 @@
 //!
 //! # Timeouts
 //!
-//! The compiled program is run under a per-case wall-clock timeout (default
-//! [`rue_test_runner::DEFAULT_TIMEOUT_MS`], overridable per case with
-//! `timeout_ms`). If it runs long — e.g. an infinite loop in generated code —
+//! Both the COMPILE step and the compiled program run under a per-case
+//! wall-clock timeout (default [`rue_test_runner::DEFAULT_TIMEOUT_MS`],
+//! overridable per case with `timeout_ms`). If either runs long — an infinite
+//! loop in generated code, or a compile-time hang in comptime evaluation —
 //! its whole process group is killed and the case is reported as a distinct
 //! TIMEOUT failure (see [`rue_test_runner::TIMEOUT_PREFIX`]), so one bad
-//! program can never hang the suite. `compile_only = true` still skips the run
+//! case can never hang the suite. `compile_only = true` still skips the run
 //! entirely for sources that are meant only to compile.
 
 use std::collections::HashMap;
@@ -82,7 +83,9 @@ use std::process::Command;
 use std::time::Duration;
 
 use libtest2_mimic::{Harness, RunContext, RunError, Trial};
-use rue_test_runner::{DEFAULT_TIMEOUT_MS, find_dir, find_rue_binary, run_with_timeout};
+use rue_test_runner::{
+    DEFAULT_TIMEOUT_MS, find_dir, find_rue_binary, ice_message, run_with_timeout,
+};
 use serde::Deserialize;
 
 /// Possible paths for the cases directory.
@@ -335,24 +338,6 @@ struct RunOutcome {
     stdout: String,
 }
 
-/// Check a finished process for signs of a compiler panic / ICE.
-fn ice_message(status: &std::process::ExitStatus, stderr: &str) -> Option<String> {
-    if stderr.contains("panicked at") || stderr.contains("internal compiler error") {
-        return Some(format!(
-            "INTERNAL COMPILER ERROR: compiler panicked\n--- compiler stderr ---\n{}",
-            stderr
-        ));
-    }
-    // Death by signal (e.g. SIGABRT after a Rust abort) has no exit code on unix.
-    if status.code().is_none() {
-        return Some(format!(
-            "INTERNAL COMPILER ERROR: compiler killed by signal ({:?})\n--- compiler stderr ---\n{}",
-            status, stderr
-        ));
-    }
-    None
-}
-
 /// Expand `${REAL_STD}` in env values to the absolute path of the repo's std/.
 fn expand_env_value(value: &str, real_std: &Path) -> String {
     value.replace("${REAL_STD}", &real_std.to_string_lossy())
@@ -407,9 +392,11 @@ fn run_case(
     for (key, value) in &case.env {
         cmd.env(key, expand_env_value(value, real_std));
     }
-    let compile_output = cmd
-        .output()
-        .map_err(|e| format!("failed to invoke rue compiler: {}", e))?;
+    // The COMPILE step runs under the same per-case timeout as execution: a
+    // compile-time hang (comptime/parser loop) must fail this one case as a
+    // TIMEOUT, not wedge the suite. Mirrors the spec runner's compile step.
+    let compile_timeout = Duration::from_millis(case.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS));
+    let compile_output = run_with_timeout(cmd, compile_timeout, None)?;
 
     let compile_stderr = String::from_utf8_lossy(&compile_output.stderr).to_string();
     let compile_stdout = String::from_utf8_lossy(&compile_output.stdout).to_string();
@@ -761,9 +748,9 @@ fn run_example(
 
     let mut cmd = Command::new(rue_binary);
     cmd.args([src_name.as_str(), "-o", "prog"]).current_dir(dir);
-    let compile_output = cmd
-        .output()
-        .map_err(|e| format!("failed to invoke rue compiler: {}", e))?;
+    // Compile under the default timeout too (see run_case): an example that
+    // hangs the compiler fails as one TIMEOUT, not a wedged suite.
+    let compile_output = run_with_timeout(cmd, Duration::from_millis(DEFAULT_TIMEOUT_MS), None)?;
     let compile_stderr = String::from_utf8_lossy(&compile_output.stderr).to_string();
     let compile_stdout = String::from_utf8_lossy(&compile_output.stdout).to_string();
 

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -138,6 +138,11 @@ pub struct TraceabilityReport {
     /// Test references that don't match any existing paragraph.
     /// Each entry is a tuple of (test_name, invalid_reference_id).
     pub orphan_references: Vec<(String, String)>,
+    /// Rule ids defined more than once in the spec. Duplicates fail the gate:
+    /// with last-writer-wins parsing, a later duplicate can silently replace a
+    /// normative rule (erasing its coverage requirement) — as nearly happened
+    /// with 3.7:49 on 2026-07-04.
+    pub duplicate_rule_ids: Vec<String>,
 }
 
 /// Normative paragraphs that currently have no *running* test, tracked as known
@@ -290,11 +295,13 @@ impl TraceabilityReport {
     }
 
     /// Whether the traceability gate should fail: any *unexpected* uncovered
-    /// normative rule, any stale allowlist entry, or any orphan reference.
+    /// normative rule, any stale allowlist entry, any orphan reference, or any
+    /// duplicate rule id.
     pub fn gate_failing(&self) -> bool {
         !self.unexpected_uncovered_normative_paragraphs().is_empty()
             || !self.stale_known_uncovered().is_empty()
             || !self.orphan_references.is_empty()
+            || !self.duplicate_rule_ids.is_empty()
     }
 
     /// Returns the coverage percentage for normative paragraphs (0.0 to 100.0).
@@ -471,6 +478,18 @@ impl TraceabilityReport {
             }
             println!();
         }
+
+        // Duplicate rule ids (each silently replaced an earlier paragraph)
+        if !self.duplicate_rule_ids.is_empty() {
+            println!(
+                "Duplicate rule ids ({}) — renumber so each id appears once:",
+                self.duplicate_rule_ids.len()
+            );
+            for dup in &self.duplicate_rule_ids {
+                println!("  {}", dup);
+            }
+            println!();
+        }
     }
 
     /// Prints a detailed traceability matrix to stdout.
@@ -520,6 +539,29 @@ impl TraceabilityReport {
     }
 }
 
+/// Extract a quoted shortcode argument (`name = "value"`), tolerating
+/// whitespace around `=`. Zola accepts `id = "x"` and renders it identically
+/// to `id="x"`, so the checker must too: a spaced `cat` used to silently
+/// demote a rule to informative, and a spaced `id` made the rule invisible —
+/// both dropped coverage enforcement without a report.
+fn find_shortcode_arg(line: &str, name: &str) -> Option<String> {
+    let mut search_from = 0;
+    while let Some(rel) = line[search_from..].find(name) {
+        let pos = search_from + rel;
+        let after = line[pos + name.len()..].trim_start();
+        if let Some(rest) = after.strip_prefix('=') {
+            let rest = rest.trim_start();
+            if let Some(rest) = rest.strip_prefix('"') {
+                if let Some(end) = rest.find('"') {
+                    return Some(rest[..end].to_string());
+                }
+            }
+        }
+        search_from = pos + name.len();
+    }
+    None
+}
+
 /// Parse a spec marker from a line.
 /// Format: {{ rule(id="X.Y:Z") }} or {{ rule(id="X.Y:Z", cat="category") }} (Zola shortcode)
 /// Category can be: normative, informative, syntax, example
@@ -529,36 +571,16 @@ fn parse_spec_comment(line: &str) -> Option<(String, String)> {
     let line = line.trim();
 
     // Zola shortcode format: {{ rule(id="X.Y:Z") }} or {{ rule(id="X.Y:Z", cat="category") }}
-    if line.starts_with("{{") && line.contains("rule(") {
-        // Extract the id parameter
-        if let Some(id_start) = line.find("id=\"") {
-            let id_content = &line[id_start + 4..]; // Skip 'id="'
-            if let Some(id_end) = id_content.find('"') {
-                let id = &id_content[..id_end];
-
-                // Validate that the ID contains a colon (required format: X.Y:Z)
-                if !id.contains(':') {
-                    return None;
-                }
-
-                // Extract optional cat parameter
-                let category = if let Some(cat_start) = line.find("cat=\"") {
-                    let cat_content = &line[cat_start + 5..]; // Skip 'cat="'
-                    if let Some(cat_end) = cat_content.find('"') {
-                        cat_content[..cat_end].to_string()
-                    } else {
-                        "informative".to_string()
-                    }
-                } else {
-                    "informative".to_string()
-                };
-
-                return Some((id.to_string(), category));
-            }
-        }
+    if !(line.starts_with("{{") && line.contains("rule(")) {
+        return None;
     }
-
-    None
+    let id = find_shortcode_arg(line, "id")?;
+    // Validate that the ID contains a colon (required format: X.Y:Z)
+    if !id.contains(':') {
+        return None;
+    }
+    let category = find_shortcode_arg(line, "cat").unwrap_or_else(|| "informative".to_string());
+    Some((id, category))
 }
 
 /// Check if a line is a spec marker (Zola shortcode format).
@@ -566,8 +588,16 @@ fn is_spec_marker(line: &str) -> bool {
     line.starts_with("{{") && line.contains("rule(")
 }
 
-/// Parse spec paragraphs from a markdown file.
-fn parse_spec_file(path: &Path, paragraphs: &mut BTreeMap<String, SpecParagraph>) {
+/// Parse spec paragraphs from a markdown file. A rule id that was already
+/// registered (same file or an earlier one) is recorded in `duplicates` —
+/// last-writer-wins insertion silently REPLACED the earlier paragraph before,
+/// so an informative restatement authored after a normative rule erased the
+/// coverage requirement without any report.
+fn parse_spec_file(
+    path: &Path,
+    paragraphs: &mut BTreeMap<String, SpecParagraph>,
+    duplicates: &mut Vec<String>,
+) {
     let content = match fs::read_to_string(path) {
         Ok(c) => c,
         Err(e) => {
@@ -598,7 +628,22 @@ fn parse_spec_file(path: &Path, paragraphs: &mut BTreeMap<String, SpecParagraph>
                 break;
             }
 
-            paragraphs.insert(id.clone(), SpecParagraph { id, category, text });
+            if let Some(prev) = paragraphs.insert(
+                id.clone(),
+                SpecParagraph {
+                    id: id.clone(),
+                    category: category.clone(),
+                    text,
+                },
+            ) {
+                duplicates.push(format!(
+                    "{} (categories '{}' and '{}'; second occurrence in {})",
+                    id,
+                    prev.category,
+                    category,
+                    path.display()
+                ));
+            }
         }
     }
 }
@@ -614,18 +659,22 @@ fn parse_spec_file(path: &Path, paragraphs: &mut BTreeMap<String, SpecParagraph>
 ///
 /// # Returns
 ///
-/// A map of paragraph IDs to [`SpecParagraph`] structs, sorted by ID.
-pub fn parse_spec_paragraphs(spec_dir: &Path) -> BTreeMap<String, SpecParagraph> {
+/// A map of paragraph IDs to [`SpecParagraph`] structs, sorted by ID, plus a
+/// list of DUPLICATE rule ids (an id defined more than once across the spec).
+/// Duplicates fail the traceability gate: with last-writer-wins insertion, a
+/// duplicate can silently replace a normative rule with an informative one.
+pub fn parse_spec_paragraphs(spec_dir: &Path) -> (BTreeMap<String, SpecParagraph>, Vec<String>) {
     let mut paragraphs = BTreeMap::new();
+    let mut duplicates = Vec::new();
 
     let mut md_files = Vec::new();
     collect_files_by_ext(spec_dir, "md", &mut md_files);
 
     for path in md_files {
-        parse_spec_file(&path, &mut paragraphs);
+        parse_spec_file(&path, &mut paragraphs, &mut duplicates);
     }
 
-    paragraphs
+    (paragraphs, duplicates)
 }
 
 /// A parsed test specification file.
@@ -785,8 +834,24 @@ pub fn parse_test_files(cases_dir: &Path) -> Vec<TestFile> {
                             .get("skip")
                             .and_then(|s| s.as_bool())
                             .unwrap_or(false);
+                        // Per-param `preview`/`preview_should_pass` overrides
+                        // mirror the runner's expand_case: an instance the
+                        // runner allows to fail must not count as coverage,
+                        // even when the BASE case has no preview (RUE-132).
+                        let param_is_preview = param_table
+                            .get("preview")
+                            .and_then(|p| p.as_str())
+                            .map(|s| !s.is_empty());
+                        let param_should_pass = param_table
+                            .get("preview_should_pass")
+                            .and_then(|p| p.as_bool());
+                        let effective_preview = param_is_preview.unwrap_or(is_preview);
+                        let effective_should_pass =
+                            param_should_pass.unwrap_or(preview_should_pass);
+                        let param_preview_allowed_to_fail =
+                            effective_preview && !effective_should_pass;
                         let counts_as_coverage =
-                            !base_skip && !param_skip && !preview_allowed_to_fail;
+                            !base_skip && !param_skip && !param_preview_allowed_to_fail;
 
                         cases.push(TestCase {
                             name: expanded_name,
@@ -837,7 +902,7 @@ pub fn parse_test_files(cases_dir: &Path) -> Vec<TestFile> {
 /// ```
 pub fn generate_report(spec_dir: &Path, cases_dir: &Path) -> TraceabilityReport {
     // Parse spec paragraphs
-    let paragraphs = parse_spec_paragraphs(spec_dir);
+    let (paragraphs, duplicate_rule_ids) = parse_spec_paragraphs(spec_dir);
 
     // Parse test files
     let test_files = parse_test_files(cases_dir);
@@ -878,6 +943,7 @@ pub fn generate_report(spec_dir: &Path, cases_dir: &Path) -> TraceabilityReport 
         paragraphs,
         coverage,
         orphan_references,
+        duplicate_rule_ids,
     }
 }
 
@@ -930,7 +996,9 @@ Another paragraph.
         fs::write(&file_path, content).unwrap();
 
         let mut paragraphs = BTreeMap::new();
-        parse_spec_file(&file_path, &mut paragraphs);
+        let mut duplicates = Vec::new();
+        parse_spec_file(&file_path, &mut paragraphs, &mut duplicates);
+        assert!(duplicates.is_empty());
 
         assert_eq!(paragraphs.len(), 2);
         assert!(paragraphs.contains_key("3.1:1"));
@@ -962,7 +1030,9 @@ fn main() { }
         fs::write(&file_path, content).unwrap();
 
         let mut paragraphs = BTreeMap::new();
-        parse_spec_file(&file_path, &mut paragraphs);
+        let mut duplicates = Vec::new();
+        parse_spec_file(&file_path, &mut paragraphs, &mut duplicates);
+        assert!(duplicates.is_empty());
 
         assert_eq!(paragraphs.len(), 1);
         assert!(paragraphs.contains_key("3.1:5"));
@@ -1003,6 +1073,7 @@ fn main() { }
             paragraphs,
             coverage,
             orphan_references: vec![],
+            duplicate_rule_ids: vec![],
         };
 
         assert_eq!(report.covered_count(), 1);
@@ -1126,6 +1197,7 @@ exit_code = 0
                 paragraphs,
                 coverage,
                 orphan_references: vec![],
+                duplicate_rule_ids: vec![],
             }
         }
 

--- a/crates/rue-test-runner/src/lib.rs
+++ b/crates/rue-test-runner/src/lib.rs
@@ -326,6 +326,18 @@ pub fn get_host_target() -> &'static str {
     }
 }
 
+/// Every platform name `only_on`/`known_bug_on` may legally name — the same
+/// set [`get_host_target`] can return. Case files are validated against this
+/// list at load time: a typo'd platform name would otherwise make the case
+/// silently run NOWHERE while still counting as spec coverage (the RUE-132
+/// skipped-test-counts-as-coverage class, via the platform axis).
+pub const KNOWN_TARGETS: &[&str] = &[
+    "x86-64-linux",
+    "aarch64-linux",
+    "aarch64-macos",
+    "x86-64-macos",
+];
+
 /// Check if a test should be skipped based on `only_on` restrictions.
 ///
 /// Returns `Some(reason)` if the test should be skipped, `None` if it should run.
@@ -597,6 +609,55 @@ pub fn validate_preview_features(test_file: &TestFile) -> Vec<UnknownPreviewFeat
     errors
 }
 
+/// An error indicating a case's `only_on` list names an unknown platform.
+///
+/// An unknown name can never equal the host, so the case would be skipped on
+/// EVERY platform — silently, while its spec references still count as
+/// coverage in the traceability gate. Reject at load time like unknown
+/// preview-feature names.
+#[derive(Debug, Clone)]
+pub struct UnknownPlatformError {
+    /// The unrecognized platform name.
+    pub platform: String,
+    /// The name of the offending test case.
+    pub test_name: String,
+    /// The section ID the test belongs to.
+    pub section_id: String,
+}
+
+impl std::fmt::Display for UnknownPlatformError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "test '{}' in section '{}' has unknown only_on platform '{}' (known: {})",
+            self.test_name,
+            self.section_id,
+            self.platform,
+            KNOWN_TARGETS.join(", ")
+        )
+    }
+}
+
+impl std::error::Error for UnknownPlatformError {}
+
+/// Validate all `only_on` platform names in a test file against
+/// [`KNOWN_TARGETS`].
+pub fn validate_only_on_targets(test_file: &TestFile) -> Vec<UnknownPlatformError> {
+    let mut errors = Vec::new();
+    for case in &test_file.case {
+        for platform in &case.only_on {
+            if !KNOWN_TARGETS.contains(&platform.as_str()) {
+                errors.push(UnknownPlatformError {
+                    platform: platform.clone(),
+                    test_name: case.name.clone(),
+                    section_id: test_file.section.id.clone(),
+                });
+            }
+        }
+    }
+    errors
+}
+
 /// An error indicating a case declares a compile-error assertion
 /// (`error_contains` / `expected_error`) without `compile_fail = true`.
 ///
@@ -747,6 +808,7 @@ pub fn collect_toml_files(dir: &Path, files: &mut Vec<PathBuf>) {
 pub fn load_test_files(cases_dir: &Path) -> Vec<(String, TestFile)> {
     let mut specs = Vec::new();
     let mut preview_errors: Vec<UnknownPreviewFeatureError> = Vec::new();
+    let mut platform_errors: Vec<UnknownPlatformError> = Vec::new();
     let mut stray_error_assertions: Vec<StrayErrorAssertionError> = Vec::new();
     let mut bare_compile_fail: Vec<BareCompileFailError> = Vec::new();
 
@@ -779,6 +841,10 @@ pub fn load_test_files(cases_dir: &Path) -> Vec<(String, TestFile)> {
 
                 // Validate preview feature names
                 preview_errors.extend(validate_preview_features(&spec));
+
+                // Validate only_on platform names (a typo would silently skip
+                // the case on every host while still counting as coverage)
+                platform_errors.extend(validate_only_on_targets(&spec));
 
                 // Reject compile-error assertions on cases that aren't compile_fail
                 stray_error_assertions.extend(validate_error_assertions(&spec));
@@ -833,6 +899,22 @@ Error: {} test file(s) failed to load:",
             "Test loading failed: {} test(s) use unknown preview feature names. \
              See errors above for details.",
             preview_errors.len()
+        );
+    }
+
+    // Report unknown only_on platform names and fail if any were found
+    if !platform_errors.is_empty() {
+        eprintln!(
+            "\nError: Found {} unknown only_on platform name(s):",
+            platform_errors.len()
+        );
+        for error in &platform_errors {
+            eprintln!("  - {}", error);
+        }
+        panic!(
+            "Test loading failed: {} case(s) use unknown only_on platform names \
+             (the case would run on NO platform). See errors above for details.",
+            platform_errors.len()
         );
     }
 
@@ -1168,7 +1250,11 @@ pub fn run_with_timeout(
 /// `compile_fail` expectation: "the compiler rejected the program" and "the
 /// compiler crashed" are different outcomes, and conflating them lets crashes
 /// hide inside passing suites. Mirrors `ice_message` in rue-cli-tests.
-fn ice_message(status: &std::process::ExitStatus, stderr: &str) -> Option<String> {
+/// Check a finished compiler process for signs of a panic / ICE.
+/// This is the SINGLE shared implementation — rue-cli-tests imports it
+/// rather than keeping its own copy, so a new panic marker or abort
+/// signature added here covers every harness at once.
+pub fn ice_message(status: &std::process::ExitStatus, stderr: &str) -> Option<String> {
     if stderr.contains("panicked at") || stderr.contains("internal compiler error") {
         return Some(format!(
             "INTERNAL COMPILER ERROR: compiler panicked\n--- compiler stderr ---\n{}",


### PR DESCRIPTION
Six verified findings from the test-harness component review (2026-07-04) — the "next RUE-132" sweep over rue-test-runner, the spec/CLI/UI runners, and the traceability checker. Four are **gate-integrity holes**: ways a case that runs nowhere (or is allowed to fail) still counted as 100% spec coverage.

- **Duplicate rule ids fail the gate.** `parse_spec_file` was last-writer-wins: an informative restatement authored after a normative rule silently *erased* the coverage requirement — exactly the near-miss 3.7:49 incident from the StrBuf integration (#1163), which the checker would NOT have flagged. Duplicates are now collected, printed with both categories and the file, and fail the gate.
- **Spaced Zola shortcode args parse correctly.** `cat = "normative"` (with spaces) silently demoted a rule to informative, and a spaced `id = "..."` made the rule invisible entirely — while Zola renders both spellings identically. The arg extraction is now whitespace-tolerant.
- **`only_on` platform names are validated at load time** against `KNOWN_TARGETS`, like preview-feature names already were. Before: `only_on = ["x86-64-linx"]` (typo) skipped the case on *every* host while its spec refs still counted as coverage — demonstrated: 100.0% coverage, gate exit 0, zero platforms executing the test.
- **Param-level `preview` overrides no longer count as coverage.** Traceability read preview flags from the base case only, while the runner honors per-param overrides — a param row adding `preview` was allowed to fail yet marked the rule covered. The coverage computation now mirrors `expand_case`.

Plus two runner fixes: the **CLI harness compile step now runs under the per-case timeout** (a comptime/parser hang wedged the whole suite; the spec runner already defended against this — CLI + examples paths now mirror it), and **`ice_message` is a single shared `pub` implementation** in rue-test-runner (the verbatim CLI copy deleted, so a new panic marker covers every harness at once).

Every hole verified by execution before and after with scratch `RUE_SPEC_DIR`/`RUE_SPEC_CASES` corpora (dup-id gate 0→1; spaced-arg ids now reported uncovered; only_on typo now a loud load failure; param-preview case now uncovered). The **real corpus passes the strengthened gate** — the holes were latent, nothing was being masked. clippy clean, `./test.sh` exit 0.

Companion issues filed separately: params inline-table key validation, and the drain-thread wedge on daemonizing test programs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)