### PR TITLE
rue-cfg review fixes: dump honesty (enum payloads, resolved places, call args), goto_join helper, dead API

### DIFF
--- a/crates/rue-cfg/src/build.rs
+++ b/crates/rue-cfg/src/build.rs
@@ -1393,45 +1393,11 @@ impl<'a> CfgBuilder<'a> {
 
                 // Wire up non-divergent branches to join
                 if !then_diverged {
-                    let args: Vec<CfgValue> = if let Some(val) = then_result.value {
-                        if result_param.is_some() {
-                            vec![val]
-                        } else {
-                            vec![]
-                        }
-                    } else {
-                        vec![]
-                    };
-                    let (args_start, args_len) = self.cfg.push_extra(args);
-                    self.cfg.set_terminator(
-                        then_exit_block,
-                        Terminator::Goto {
-                            target: join_block,
-                            args_start,
-                            args_len,
-                        },
-                    );
+                    self.goto_join(then_exit_block, join_block, result_param, then_result.value);
                 }
 
                 if !else_diverged {
-                    let args: Vec<CfgValue> = if let Some(val) = else_result.value {
-                        if result_param.is_some() {
-                            vec![val]
-                        } else {
-                            vec![]
-                        }
-                    } else {
-                        vec![]
-                    };
-                    let (args_start, args_len) = self.cfg.push_extra(args);
-                    self.cfg.set_terminator(
-                        else_exit_block,
-                        Terminator::Goto {
-                            target: join_block,
-                            args_start,
-                            args_len,
-                        },
-                    );
+                    self.goto_join(else_exit_block, join_block, result_param, else_result.value);
                 }
 
                 self.current_block = join_block;
@@ -1759,24 +1725,7 @@ impl<'a> CfgBuilder<'a> {
                 // Wire up non-divergent arms to join
                 for (exit_block, body_result, diverged) in arm_results {
                     if !diverged {
-                        let args: Vec<CfgValue> = if let Some(val) = body_result.value {
-                            if result_param.is_some() {
-                                vec![val]
-                            } else {
-                                vec![]
-                            }
-                        } else {
-                            vec![]
-                        };
-                        let (args_start, args_len) = self.cfg.push_extra(args);
-                        self.cfg.set_terminator(
-                            exit_block,
-                            Terminator::Goto {
-                                target: join_block,
-                                args_start,
-                                args_len,
-                            },
-                        );
+                        self.goto_join(exit_block, join_block, result_param, body_result.value);
                     }
                 }
 
@@ -2380,6 +2329,34 @@ impl<'a> CfgBuilder<'a> {
     fn emit(&mut self, data: CfgInstData, ty: Type, span: rue_span::Span) -> CfgValue {
         self.cfg
             .add_inst_to_block(self.current_block, CfgInst { data, ty, span })
+    }
+
+    /// Terminate `exit_block` with a `Goto` into `join_block`, passing the
+    /// branch's value as the single block arg IFF the join has a result
+    /// param. This is the ONE place the value-branch/join-param arity
+    /// contract is encoded — if/else arms and match arms all wire through
+    /// here, so the contract cannot drift between constructs (the RUE-347
+    /// bug class lives exactly on this seam).
+    fn goto_join(
+        &mut self,
+        exit_block: BlockId,
+        join_block: BlockId,
+        result_param: Option<CfgValue>,
+        value: Option<CfgValue>,
+    ) {
+        let args: Vec<CfgValue> = match (value, result_param) {
+            (Some(val), Some(_)) => vec![val],
+            _ => vec![],
+        };
+        let (args_start, args_len) = self.cfg.push_extra(args);
+        self.cfg.set_terminator(
+            exit_block,
+            Terminator::Goto {
+                target: join_block,
+                args_start,
+                args_len,
+            },
+        );
     }
 
     /// Cache a value for an AIR ref.

--- a/crates/rue-cfg/src/inst.rs
+++ b/crates/rue-cfg/src/inst.rs
@@ -75,12 +75,6 @@ impl Place {
         }
     }
 
-    /// Returns true if this place has no projections (is just a variable).
-    #[inline]
-    pub const fn is_simple(&self) -> bool {
-        self.proj_len == 0
-    }
-
     /// Returns the local slot if this is a simple local place with no projections.
     #[inline]
     pub const fn as_local(&self) -> Option<u32> {
@@ -1257,17 +1251,24 @@ impl Cfg {
             CfgInstData::EnumVariant {
                 enum_id,
                 variant_index,
+                payload_start,
                 payload_len,
-                ..
             } => {
                 if *payload_len == 0 {
                     write!(f, "enum_variant #{}::{}", enum_id.0, variant_index)
                 } else {
-                    write!(
-                        f,
-                        "enum_variant #{}::{}(payload x{})",
-                        enum_id.0, variant_index, payload_len
-                    )
+                    // Print the actual payload operands (like StructInit and
+                    // ArrayInit do) so the variant's dataflow inputs are
+                    // readable in the dump, not just their count.
+                    write!(f, "enum_variant #{}::{}(", enum_id.0, variant_index)?;
+                    let payload = self.get_extra(*payload_start, *payload_len);
+                    for (i, value) in payload.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{}", value)?;
+                    }
+                    write!(f, ")")
                 }
             }
             CfgInstData::EnumPayloadGet {
@@ -1299,29 +1300,38 @@ impl Cfg {
 
     /// Format a place for display, showing the base and projections.
     fn fmt_place(&self, f: &mut fmt::Formatter<'_>, place: &Place) -> fmt::Result {
-        // Write the base
-        match place.base {
-            PlaceBase::Local(slot) => write!(f, "${}", slot)?,
-            PlaceBase::Param(slot) => write!(f, "param%{}", slot)?,
-        }
+        write!(f, "{}", self.place_to_string(place))
+    }
 
-        // Write the projections
-        let projections = self.get_place_projections(place);
-        for proj in projections {
+    /// Render a place with its projections RESOLVED (e.g. `$0.#2.1($arr)[v3]`),
+    /// unlike `Place`'s own `Display`, which cannot see this Cfg's projection
+    /// arena and can only print the raw index range (`$0[3..5]`). Use this for
+    /// any human-facing dump or tracing description of a place.
+    pub fn place_to_string(&self, place: &Place) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::new();
+        match place.base {
+            PlaceBase::Local(slot) => {
+                let _ = write!(out, "${}", slot);
+            }
+            PlaceBase::Param(slot) => {
+                let _ = write!(out, "param%{}", slot);
+            }
+        }
+        for proj in self.get_place_projections(place) {
             match proj {
                 Projection::Field {
                     struct_id,
                     field_index,
                 } => {
-                    write!(f, ".#{}.{}", struct_id.0, field_index)?;
+                    let _ = write!(out, ".#{}.{}", struct_id.0, field_index);
                 }
                 Projection::Index { array_type, index } => {
-                    write!(f, "({})[{}]", array_type.name(), index)?;
+                    let _ = write!(out, "({})[{}]", array_type.name(), index);
                 }
             }
         }
-
-        Ok(())
+        out
     }
 }
 

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -490,7 +490,7 @@ impl<'a> CfgLower<'a> {
                 if !mir_insts.is_empty() {
                     block_info.instructions.push(LoweringDecision {
                         cfg_value: value,
-                        cfg_inst_desc: format_cfg_inst_data(&inst.data),
+                        cfg_inst_desc: format_cfg_inst_data(self.ctx.cfg, &inst.data),
                         cfg_type: inst.ty.name().to_string(),
                         mir_insts,
                         rationale,

--- a/crates/rue-codegen/src/cfg_lower.rs
+++ b/crates/rue-codegen/src/cfg_lower.rs
@@ -131,8 +131,10 @@ impl fmt::Display for LoweringDebugInfo {
     }
 }
 
-/// Format a CFG instruction data as a human-readable string.
-pub fn format_cfg_inst_data(data: &rue_cfg::CfgInstData) -> String {
+/// Format a CFG instruction data as a human-readable string. Takes the `Cfg`
+/// so places render with their projections resolved (`$0.#2.1`), not as raw
+/// projection-arena index ranges (`$0[3..5]`).
+pub fn format_cfg_inst_data(cfg: &rue_cfg::Cfg, data: &rue_cfg::CfgInstData) -> String {
     use rue_cfg::CfgInstData;
 
     match data {
@@ -166,19 +168,43 @@ pub fn format_cfg_inst_data(data: &rue_cfg::CfgInstData) -> String {
         CfgInstData::ParamStore { param_slot, value } => {
             format!("param_store %{} = {}", param_slot, value)
         }
-        CfgInstData::Call { name, .. } => {
-            // Note: Can't show args without Cfg access; just show name
-            // Display symbol as @{id} since we don't have interner access
-            format!("call @{}(...)", name.into_usize())
+        CfgInstData::Call {
+            name,
+            args_start,
+            args_len,
+        } => {
+            // Names display as @{id}: there is no interner access here. Args
+            // ARE renderable now that this fn takes the Cfg.
+            let args: Vec<String> = cfg
+                .get_call_args(*args_start, *args_len)
+                .iter()
+                .map(|a| format!("{}", a.value))
+                .collect();
+            format!("call @{}({})", name.into_usize(), args.join(", "))
         }
-        CfgInstData::Intrinsic { name, .. } => {
-            // Note: Can't show args without Cfg access; just show name
-            // Display symbol as @{id} since we don't have interner access
-            format!("intrinsic @{}(...)", name.into_usize())
+        CfgInstData::Intrinsic {
+            name,
+            args_start,
+            args_len,
+        } => {
+            let args: Vec<String> = cfg
+                .get_extra(*args_start, *args_len)
+                .iter()
+                .map(|v| format!("{}", v))
+                .collect();
+            format!("intrinsic @{}({})", name.into_usize(), args.join(", "))
         }
-        CfgInstData::StructInit { struct_id, .. } => {
-            // Note: Can't show fields without Cfg access; just show struct_id
-            format!("struct_init #{} {{...}}", struct_id.0)
+        CfgInstData::StructInit {
+            struct_id,
+            fields_start,
+            fields_len,
+        } => {
+            let fields: Vec<String> = cfg
+                .get_extra(*fields_start, *fields_len)
+                .iter()
+                .map(|v| format!("{}", v))
+                .collect();
+            format!("struct_init #{} {{{}}}", struct_id.0, fields.join(", "))
         }
         CfgInstData::FieldSet {
             slot,
@@ -253,10 +279,10 @@ pub fn format_cfg_inst_data(data: &rue_cfg::CfgInstData) -> String {
         CfgInstData::StorageDead { slot } => format!("storage_dead ${}", slot),
         // Place operations (ADR-0030)
         CfgInstData::PlaceRead { place } => {
-            format!("place_read {}", place)
+            format!("place_read {}", cfg.place_to_string(place))
         }
         CfgInstData::PlaceWrite { place, value } => {
-            format!("place_write {} = {}", place, value)
+            format!("place_write {} = {}", cfg.place_to_string(place), value)
         }
     }
 }

--- a/crates/rue-codegen/src/x86_64/cfg_lower.rs
+++ b/crates/rue-codegen/src/x86_64/cfg_lower.rs
@@ -663,7 +663,7 @@ impl<'a> CfgLower<'a> {
                 if !mir_insts.is_empty() {
                     block_info.instructions.push(LoweringDecision {
                         cfg_value: value,
-                        cfg_inst_desc: format_cfg_inst_data(&inst.data),
+                        cfg_inst_desc: format_cfg_inst_data(self.ctx.cfg, &inst.data),
                         cfg_type: inst.ty.name().to_string(),
                         mir_insts,
                         rationale,


### PR DESCRIPTION
Five verified quality findings from the rue-cfg component review (2026-07-04; 5 lenses over build.rs/inst.rs/verify.rs/opt). Headline: **the behavioral lanes came back clean** — joins, divergence handling, opt-pass soundness (differential -O0 vs -O1+ probing), and the June drop overhaul all held up with zero miscompiles or ICEs found, and the two dramatic-looking leads were verified as verbatim duplicates of already-filed RUE-347. The crate's hardening (RUE-128/227 + drop overhaul) has genuinely closed those classes.

What shipped:

- **`--emit cfg` prints EnumVariant payload operands** (`enum_variant #3::0(v0, v1)`) instead of an opaque `payload x2` — a tuple variant's dataflow inputs were unreadable in the dump, unlike every sibling aggregate constructor.
- **Codegen tracing renders places resolved:** `format_cfg_inst_data` now takes the `Cfg`, so PlaceRead/PlaceWrite show `$0.#2.1` (via a new `pub Cfg::place_to_string`) instead of raw projection-arena ranges (`$0[3..5]`), and the Call/Intrinsic/StructInit arms print their actual args — the "can't show args without Cfg access" comments were made false by the signature change, so the arms were upgraded rather than left contradicting them.
- **`CfgBuilder::goto_join`** single-sources the value-branch/join-param arity contract that was open-coded identically at three sites (if-then, if-else, match-arm). That seam is exactly where the RUE-347 bug class lives; three independent copies could drift between constructs. Behavior-identical (golden corpora green).
- **Deleted dead `pub Place::is_simple`** (zero callers workspace-wide).

Verified by execution: enum dump shows operands; if/match join values correct at -O0 and -O2; enum payload round-trip exit 7. clippy clean, `./test.sh` exit 0.

Remaining finding filed separately: And/Or short-circuit lowering duplication (~60 near-identical lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)