### PR TITLE
rue-runtime safety: arena page-rounding overflow, String null-write on alloc failure, _start RSP contract

### DIFF
--- a/crates/rue-cli-tests/cases/heap_intrinsics.toml
+++ b/crates/rue-cli-tests/cases/heap_intrinsics.toml
@@ -103,3 +103,22 @@ fn main() -> i32 {
 """ }]
 compile_fail = true
 error_contains = ["heap intrinsic `@alloc`", "checked"]
+
+# A near-usize::MAX @alloc once wrapped the arena's page round-up to zero,
+# handed out a huge block backed by a 64 KiB mapping, and let a later write
+# corrupt memory / SIGSEGV (rue-runtime component review, 2026-07-04). The
+# allocator must now return null (address 0) for such a request.
+[[case]]
+name = "alloc_page_rounding_overflow_returns_null"
+description = "A near-usize::MAX @alloc returns null instead of an unbacked pointer."
+files = [{ path = "main.rue", source = """
+fn main() -> i32 {
+    checked {
+        let p: ptr mut u8 = @alloc(18446744073709551491);
+        let addr: u64 = @ptr_to_int(p);
+        if addr == 0 { 0 } else { 1 }
+    }
+}
+""" }]
+args = ["main.rue", "-o", "prog"]
+exit_code = 0

--- a/crates/rue-runtime/src/entry.rs
+++ b/crates/rue-runtime/src/entry.rs
@@ -78,6 +78,11 @@ pub unsafe extern "C" fn _start() -> ! {
             // But first we need to align to 16 bytes before call, so subtract 8.
             "sub rsp, 8",
             "call {main}",
+            // Restore RSP to its entry value: the asm block does not use
+            // `options(noreturn)` and control falls through to
+            // `platform::exit` below, so the inline-asm contract requires RSP
+            // to be left unchanged on exit from the block.
+            "add rsp, 8",
             // Return value is in eax
             "mov edi, eax",
             main = sym main,

--- a/crates/rue-runtime/src/heap.rs
+++ b/crates/rue-runtime/src/heap.rs
@@ -126,7 +126,14 @@ fn alloc_arena(min_size: usize, align: usize) -> *mut ArenaHeader {
     let Some(total) = aligned_header.checked_add(min_size) else {
         return ptr::null_mut();
     };
-    let total_size = align_up(total, 4096); // Page-align
+    // Page-align with a CHECKED round-up: a `total` in the top page
+    // (> usize::MAX - 4095) would wrap `align_up` to 0, then clamp up to
+    // DEFAULT_ARENA_SIZE and hand out a huge block backed by a 64 KiB
+    // mapping — a heap overflow. Return null on overflow, honoring the
+    // documented OOM contract.
+    let Some(total_size) = total.checked_next_multiple_of(4096) else {
+        return ptr::null_mut();
+    };
 
     // Use at least the default arena size
     let arena_size = if total_size < DEFAULT_ARENA_SIZE {
@@ -182,8 +189,13 @@ fn alloc_arena(min_size: usize, align: usize) -> *mut ArenaHeader {
 /// The returned pointer (if non-null) is valid and properly aligned.
 /// The memory remains valid until the program exits.
 pub fn alloc(size: u64, align: u64) -> *mut u8 {
-    // Validate arguments
-    if size == 0 || align == 0 || !is_power_of_two(align) {
+    // Validate arguments. `align` is also capped at the page size: the arena
+    // base is only page-aligned (mmap), and blocks are placed at an offset
+    // aligned relative to that base, so an `align` greater than a page could
+    // yield a misaligned absolute address. No reachable caller exceeds 8;
+    // reject the rest cleanly rather than silently misalign (callers already
+    // handle a null return).
+    if size == 0 || align == 0 || !is_power_of_two(align) || align > 4096 {
         return ptr::null_mut();
     }
 
@@ -489,6 +501,28 @@ mod tests {
         // 3 is not a power of 2
         let ptr = alloc(16, 3);
         assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn test_alloc_page_rounding_overflow_returns_null() {
+        // A size in the top page (> usize::MAX - 4095) once wrapped the
+        // page round-up to 0, clamped up to DEFAULT_ARENA_SIZE, and handed
+        // out a huge block backed by a 64 KiB mapping (heap overflow). It
+        // must now return null instead.
+        let ptr = alloc((usize::MAX as u64) - 124, 1);
+        assert!(ptr.is_null());
+    }
+
+    #[test]
+    fn test_alloc_rejects_over_page_alignment() {
+        // Blocks are placed at an offset aligned relative to the page-aligned
+        // arena base, so an align larger than a page could yield a misaligned
+        // absolute address. Such requests are rejected cleanly (null).
+        assert!(alloc(64, 8192).is_null());
+        // Page-sized and smaller power-of-two alignments are still honored.
+        let ptr = alloc(64, 4096);
+        assert!(!ptr.is_null());
+        assert_eq!(ptr as usize % 4096, 0);
     }
 
     #[test]

--- a/crates/rue-runtime/src/string.rs
+++ b/crates/rue-runtime/src/string.rs
@@ -1537,6 +1537,19 @@ pub extern "C" fn __rue_String_push_str(
 ) {
     let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, other_len);
 
+    // On allocation failure `string_ensure_capacity` returns a null pointer;
+    // writing to `new_ptr.add(len)` would be a wild write. Republish the
+    // original string unchanged instead (matching the null-guard every sibling
+    // allocator uses).
+    if new_ptr.is_null() {
+        unsafe {
+            (*out).ptr = ptr;
+            (*out).len = len;
+            (*out).cap = cap;
+        }
+        return;
+    }
+
     if other_len > 0 && !other_ptr.is_null() {
         // SAFETY: Copying is safe because:
         // - Caller guarantees `other_ptr` is valid for reads of `other_len` bytes
@@ -1576,6 +1589,19 @@ pub extern "C" fn __rue_String_push_str(
 ) {
     let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, other_len);
 
+    // On allocation failure `string_ensure_capacity` returns a null pointer;
+    // writing to `new_ptr.add(len)` would be a wild write. Republish the
+    // original string unchanged instead (matching the null-guard every sibling
+    // allocator uses).
+    if new_ptr.is_null() {
+        unsafe {
+            (*out).ptr = ptr;
+            (*out).len = len;
+            (*out).cap = cap;
+        }
+        return;
+    }
+
     if other_len > 0 && !other_ptr.is_null() {
         // SAFETY: Copying is safe because:
         // - Caller guarantees `other_ptr` is valid for reads of `other_len` bytes
@@ -1614,6 +1640,19 @@ pub extern "C" fn __rue_String_push_str(
     _other_cap: u64,
 ) {
     let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, other_len);
+
+    // On allocation failure `string_ensure_capacity` returns a null pointer;
+    // writing to `new_ptr.add(len)` would be a wild write. Republish the
+    // original string unchanged instead (matching the null-guard every sibling
+    // allocator uses).
+    if new_ptr.is_null() {
+        unsafe {
+            (*out).ptr = ptr;
+            (*out).len = len;
+            (*out).cap = cap;
+        }
+        return;
+    }
 
     if other_len > 0 && !other_ptr.is_null() {
         // SAFETY: Copying is safe because:
@@ -1661,6 +1700,17 @@ pub extern "C" fn __rue_String_push(
 ) {
     let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, 1);
 
+    // On allocation failure `new_ptr` is null; republish the original string
+    // unchanged rather than write through null + len.
+    if new_ptr.is_null() {
+        unsafe {
+            (*out).ptr = ptr;
+            (*out).len = len;
+            (*out).cap = cap;
+        }
+        return;
+    }
+
     // SAFETY: Writing the byte is safe because:
     // - `string_ensure_capacity` guarantees `new_ptr` has room for `len + 1` bytes
     // - `new_ptr.add(len)` points to the first unused byte after existing content
@@ -1691,6 +1741,17 @@ pub extern "C" fn __rue_String_push(
 ) {
     let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, 1);
 
+    // On allocation failure `new_ptr` is null; republish the original string
+    // unchanged rather than write through null + len.
+    if new_ptr.is_null() {
+        unsafe {
+            (*out).ptr = ptr;
+            (*out).len = len;
+            (*out).cap = cap;
+        }
+        return;
+    }
+
     // SAFETY: Writing the byte is safe because:
     // - `string_ensure_capacity` guarantees `new_ptr` has room for `len + 1` bytes
     // - `new_ptr.add(len)` points to the first unused byte after existing content
@@ -1720,6 +1781,17 @@ pub extern "C" fn __rue_String_push(
     byte: u8,
 ) {
     let (new_ptr, new_cap) = string_ensure_capacity(ptr, len, cap, 1);
+
+    // On allocation failure `new_ptr` is null; republish the original string
+    // unchanged rather than write through null + len.
+    if new_ptr.is_null() {
+        unsafe {
+            (*out).ptr = ptr;
+            (*out).len = len;
+            (*out).cap = cap;
+        }
+        return;
+    }
 
     // SAFETY: Writing the byte is safe because:
     // - `string_ensure_capacity` guarantees `new_ptr` has room for `len + 1` bytes


### PR DESCRIPTION
Verified findings from the rue-runtime component review (2026-07-04) — the first dedicated sweep of the code linked into every compiled Rue binary since the heap/@alloc and StrBuf workstreams landed. **Two are memory-safety holes reachable today.**

- **Arena page-rounding overflow → heap buffer overflow (heap.rs).** A near-`usize::MAX` `@alloc` wrapped the unchecked `align_up(total, 4096)` page round-up to zero, which then clamped up to the 64 KiB default arena and handed out a **non-null pointer claiming a ~2⁶⁴-byte block backed by a 64 KiB mapping** — a subsequent write SIGSEGVs or corrupts memory. Now a checked round-up returns null, honoring the documented OOM contract. Reachable from a `checked {}` block via a 1-byte element type (whose stride is 1, so codegen passes the count straight through as `size`, bypassing RUE-345's upstream `count*size` multiply). Distinct from RUE-344 (arena alignment padding, already fixed) — this is the round-up arithmetic *before* the mmap.
- **String::push / push_str wild write on allocation failure (string.rs).** When `string_ensure_capacity` returned null (OOM), both functions wrote through `new_ptr.add(len)` — a write through `null + len` — with no null check, unlike every sibling allocator (with_capacity/clone/to_string/concat/substring all guard). Both now republish the original string unchanged on failure. All three per-arch copies fixed.
- **align > page size returns a misaligned pointer (heap.rs).** Blocks are placed at an offset aligned relative to the *page-aligned* arena base, so an `align` above 4096 could yield a misaligned absolute address despite the doc guarantee. No reachable caller exceeds 8 today; over-page alignments are now rejected cleanly (null) instead of silently misaligning a future over-aligned type.
- **x86-64 `_start` inline-asm stack-pointer contract (entry.rs).** The block did `sub rsp, 8` without restoring it and without `options(noreturn)`, then fell through to `platform::exit` — a stack-pointer contract violation (UB) that happened to work. Added the matching `add rsp, 8`. The two aarch64 entry points never touched SP.

Verified by execution: the overflow `@alloc` now returns null (exit 0) instead of SIGSEGV; normal `@alloc` and a 4000-byte String growth loop are intact. New heap.rs unit tests pin the overflow and the over-page-align rejection; a new CLI case pins the overflow end-to-end. clippy clean, `./test.sh` exit 0.

Companion issues from the same review, filed separately: SIGPIPE exit-code semantics (needs a ruling), dead `__rue_string_*` functions, and zero unit-test coverage of string.rs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)