### PR TITLE
codegen emit hardening: byte-reg REX (x86), CMP-imm truncation guard + cmp→tst Cbz escape + sub dedup (aarch64)

### DIFF
--- a/crates/rue-codegen/src/aarch64/emit.rs
+++ b/crates/rue-codegen/src/aarch64/emit.rs
@@ -1028,7 +1028,7 @@ impl<'a> Emitter<'a> {
                 let rm = src2.as_physical();
                 // 64-bit CMP is SUBS with XZR destination (64-bit form)
                 self.begin_inst();
-                self.emit_sub64_rr(Reg::Xzr, rn, rm, true);
+                self.emit_sub_rr(Reg::Xzr, rn, rm, true);
                 end_inst!(self, "cmp {}, {}", rn, rm);
             }
 
@@ -1735,20 +1735,6 @@ impl<'a> Emitter<'a> {
         self.emit_u32(inst);
     }
 
-    fn emit_sub64_rr(&mut self, rd: Reg, rn: Reg, rm: Reg, set_flags: bool) {
-        // 64-bit subtract for comparing 64-bit values (e.g., SMULL results).
-        let base = if set_flags {
-            OPCODE_SUBS_X
-        } else {
-            OPCODE_SUB_X
-        };
-        let inst = base
-            | (rm.encoding() as u32) << 16
-            | (rn.encoding() as u32) << 5
-            | rd.encoding() as u32;
-        self.emit_u32(inst);
-    }
-
     fn emit_sub_imm(&mut self, rd: Reg, rn: Reg, imm: u32) {
         // SUB Xd, Xn, #imm. The immediate field is 12 bits; larger values use
         // the shifted form (LSL #12, bit 22) for the high part plus a second
@@ -2031,11 +2017,21 @@ impl<'a> Emitter<'a> {
     }
 
     fn emit_cmp_imm(&mut self, rn: Reg, imm: u32) {
-        // CMP Xn, #imm (alias for SUBS XZR, Xn, #imm)
-        let inst = OPCODE_CMP_IMM_X
-            | ((imm & 0xFFF) << 10)
-            | (rn.encoding() as u32) << 5
-            | Reg::Xzr.encoding() as u32;
+        // CMP Xn, #imm (alias for SUBS XZR, Xn, #imm). The immediate is a
+        // 12-bit field, optionally shifted left by 12 (bit 22). Unlike
+        // ADD/SUB there is NO two-instruction accumulate form here (the
+        // destination is XZR), so an immediate that fits neither the plain nor
+        // the shifted 12-bit form must be materialized by the caller. Guard
+        // against silent truncation (was a bare `imm & 0xFFF`, the RUE-45
+        // class); every current caller passes < 4096.
+        let inst = if imm <= 0xFFF {
+            OPCODE_CMP_IMM_X | ((imm & 0xFFF) << 10)
+        } else if imm & 0xFFF == 0 && (imm >> 12) <= 0xFFF {
+            OPCODE_CMP_IMM_X | (1 << 22) | (((imm >> 12) & 0xFFF) << 10)
+        } else {
+            panic!("CMP immediate not encodable as 12 bits (optionally <<12): {imm}");
+        };
+        let inst = inst | (rn.encoding() as u32) << 5 | Reg::Xzr.encoding() as u32;
         self.emit_u32(inst);
     }
 

--- a/crates/rue-codegen/src/aarch64/peephole.rs
+++ b/crates/rue-codegen/src/aarch64/peephole.rs
@@ -85,7 +85,14 @@ fn cmp_zero_to_tst_safe(instructions: &[Aarch64Inst], idx: usize) -> bool {
             }
             // V is 0 after both cmp r, #0 and tst r, r.
             Aarch64Inst::Bvs { .. } | Aarch64Inst::Bvc { .. } => {}
-            Aarch64Inst::B { .. } | Aarch64Inst::Label { .. } => return false,
+            // An unconditional branch or a label ends the straight-line
+            // window. Cbz/Cbnz are conditional branches whose TAKEN edge also
+            // escapes the window (the cmp's flags are live-out along it), so
+            // they are escape boundaries too — matching x86's treatment.
+            Aarch64Inst::B { .. }
+            | Aarch64Inst::Label { .. }
+            | Aarch64Inst::Cbz { .. }
+            | Aarch64Inst::Cbnz { .. } => return false,
             Aarch64Inst::Bl { .. } | Aarch64Inst::Svc { .. } | Aarch64Inst::Ret => return true,
             inst if writes_flags(inst) => return true,
             _ => {}

--- a/crates/rue-codegen/src/x86_64/emit.rs
+++ b/crates/rue-codegen/src/x86_64/emit.rs
@@ -2502,10 +2502,15 @@ impl<'a> Emitter<'a> {
     fn emit_setcc(&mut self, opcode: u8, dst: Reg) {
         let dst_enc = dst.encoding();
 
-        // REX prefix if needed for extended registers
-        // Note: SETcc operates on 8-bit registers, but we use 64-bit names
-        if dst.needs_rex() {
-            self.code.push(0x41); // REX.B
+        // REX prefix. SETcc's r/m8 byte operand needs a REX prefix not only for
+        // the extended r8-r15 (REX.B) but also for encodings 4-7
+        // (SPL/BPL/SIL/DIL): without any REX, a byte r/m with encoding 4-7
+        // decodes as the legacy high-byte registers AH/CH/DH/BH — a
+        // wrong-register access. We always name 64-bit registers, so a bare
+        // REX (0x40) is always correct.
+        if dst_enc >= 4 {
+            self.code
+                .push(0x40 | if dst.needs_rex() { 0x01 } else { 0x00 }); // REX(.B)
         }
 
         // Two-byte opcode: 0F 9x
@@ -2524,8 +2529,11 @@ impl<'a> Emitter<'a> {
         let dst_enc = dst.encoding();
         let src_enc = src.encoding();
 
-        // REX prefix if needed
-        if dst.needs_rex() || src.needs_rex() {
+        // REX prefix. Beyond REX.R/REX.B for r8-r15, the byte source operand
+        // (`src`, the r/m8) also needs a REX prefix when its encoding is 4-7
+        // (SPL/BPL/SIL/DIL): without one it decodes as AH/CH/DH/BH. We always
+        // name 64-bit registers, so forcing REX is always correct.
+        if dst.needs_rex() || src.needs_rex() || src_enc >= 4 {
             let rex = 0x40
                 | if dst.needs_rex() { 0x04 } else { 0x00 }  // REX.R
                 | if src.needs_rex() { 0x01 } else { 0x00 }; // REX.B
@@ -3632,6 +3640,18 @@ mod tests {
         assert_eq!(code, vec![0x41, 0x0F, 0x94, 0xC2]);
     }
 
+    #[test]
+    fn test_setcc_rsi_needs_rex() {
+        // sete sil: encoding 6 (RSI/SIL) needs a bare REX (0x40) so the r/m8
+        // names SIL, not the legacy high-byte DH. Without it this would
+        // decode as `sete dh`.
+        let code = emit_single(X86Inst::Sete {
+            dst: Operand::Physical(Reg::Rsi),
+        });
+        // sete sil -> 40 0F 94 C6
+        assert_eq!(code, vec![0x40, 0x0F, 0x94, 0xC6]);
+    }
+
     // --- Move with extension ---
 
     #[test]
@@ -3642,6 +3662,18 @@ mod tests {
         });
         // movzx eax, cl -> 0F B6 C1 (0F B6 /r)
         assert_eq!(code, vec![0x0F, 0xB6, 0xC1]);
+    }
+
+    #[test]
+    fn test_movzx_byte_src_rdi_needs_rex() {
+        // movzx eax, dil: the byte SOURCE has encoding 7 (RDI/DIL) and needs a
+        // bare REX (0x40) so the r/m8 names DIL, not the legacy high-byte BH.
+        let code = emit_single(X86Inst::Movzx {
+            dst: Operand::Physical(Reg::Rax),
+            src: Operand::Physical(Reg::Rdi),
+        });
+        // movzx eax, dil -> 40 0F B6 C7
+        assert_eq!(code, vec![0x40, 0x0F, 0xB6, 0xC7]);
     }
 
     #[test]


### PR DESCRIPTION
Latent-gap and drift fixes from the rue-codegen **emit / peephole / schedule** component review (2026-07-04) — the first holistic review of the machine-code emission and post-regalloc rewrite layer, ~12.7k lines across both backends.

**Headline: the behavioral core is SOUND.** The x86 peephole optimizer and the instruction scheduler were verified miscompile-free by -O0-vs-O3 differential execution plus objdump byte-checks — every peephole rewrite is flag-safe (no RUE-146-class width regression), and the scheduler's flag/memory dependency tracking is correct. So all findings are **low-severity latent hardening**, not live bugs:

- **x86  /  byte-register REX.** Both emitted a REX prefix only for r8-r15, so a byte r/m operand with encoding 4-7 (SPL/BPL/SIL/DIL) would decode as the legacy high-byte registers AH/CH/DH/BH — a silent wrong-register access. Now force a bare REX for encoding ≥ 4. Latent today (the allocator never feeds those registers into these encoders); new unit tests pin  =  and  = . **Byte output for all current programs is unchanged.**
- **aarch64  truncation guard.** It silently masked the immediate to 12 bits () with no range check, unlike the RUE-45/129-hardened ADD/SUB encoders. Now emits the plain or LSL#12 12-bit form and **panics on an unencodable immediate** instead of truncating. Identical bytes for every current caller (all < 4096).
- **aarch64 cmp→tst peephole Cbz/Cbnz escape.** Register-tested conditional branches fell through the escape-boundary check, so the 's flags could be treated as dead across a taken conditional edge. Added them as escape boundaries — strictly conservative (can only *suppress* a rewrite), restoring parity with x86.
- **aarch64  dedup.** It was byte-identical to ; deleted the duplicate and pointed its one caller at  (removes a two-copies-drift risk).

Verified: x86 program correct at -O0 and -O2; aarch64  unchanged for current programs (the three aarch64 fixes are behavior-preserving by construction); codegen unit tests including aarch64 byte-pinning + Running unit tests and spec/UI/CLI suites...
Running spec traceability check...
=== Rue Specification Traceability Report ===

Normative Coverage: 99.3% (713/718 paragraphs, 5 uncovered)
Total Coverage: 71.7% (779/1086 paragraphs, 368 informative)

Coverage by category:
  dynamic-semantics    100.0% (73/73)
  example              50.0% (45/90) (informative)
  informative          7.6% (21/278) (informative)
  legality-rule        98.4% (126/128)
  normative            99.4% (500/503)
  syntax               100.0% (14/14)

Known-uncovered normative paragraphs (5, pending implementation):
  2.5:10 [legality-rule]: '@directive must precede item' error not implemented (lexical/builtins.toml::directive_must_precede_item, skipped)
  2.5:14 [legality-rule]: unrecognized-warning-name error not implemented (lexical/builtins.toml::allow_unknown_warning_error, skipped)
  2.5:17 [normative]: function-level @allow(unused_variable) not implemented (lexical/builtins.toml::allow_unused_variable_on_function, skipped)
  2.5:19 [normative]: unused-function warning not implemented (lexical/builtins.toml::allow_unused_function, skipped)
  2.5:21 [normative]: @allow(unreachable_code) suppression not implemented (lexical/builtins.toml::allow_unreachable_code, skipped) green; clippy clean. CI's native arm64 job is the backstop for the aarch64 changes.

Larger hardening filed separately: making the scheduler's / matches exhaustive (they use  catch-alls, so a future MIR variant could be silently reordered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)