### PR TITLE
Lexer/spec fixes from the lexer-span-target component review

### DIFF
--- a/crates/rue-lexer/src/lib.rs
+++ b/crates/rue-lexer/src/lib.rs
@@ -15,7 +15,7 @@ use rue_span::Span;
 /// This enum is `Copy` since all variants contain only small, copyable data:
 /// - Most variants are unit (no data)
 /// - `Int` contains a `u64` (8 bytes)
-/// - `Ident` and `String` contain a `Symbol` (4 bytes, an interned string handle)
+/// - `Ident` and `String` contain a `Spur` (4 bytes, an interned string handle)
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TokenKind {
     // Keywords

--- a/crates/rue-lexer/src/logos_lexer.rs
+++ b/crates/rue-lexer/src/logos_lexer.rs
@@ -124,9 +124,11 @@ fn process_string_from_quote(lex: &mut logos::Lexer<'_, LogosTokenKind>) -> Resu
                     return Err(LexError::UnterminatedString);
                 }
             }
-        } else if c == '\n' {
-            // Newline in string - string is unterminated at this line
-            // Don't consume the newline so error span points to string start
+        } else if c == '\n' || c == '\r' {
+            // Line terminator in string - string is unterminated at this line.
+            // A bare CR counts too: spec 2.3:1 classes it as a newline, and the
+            // backslash-before-EOL path above already treats it as one.
+            // Don't consume the terminator so error span points to string start
             lex.bump(consumed);
             return Err(LexError::UnterminatedString);
         } else {
@@ -703,7 +705,19 @@ impl<'a> LogosLexer<'a> {
                                     )
                                 }
                             };
-                            return Err(CompileError::new(kind, rue_span));
+                            let mut error = CompileError::new(kind, rue_span);
+                            if matches!(error.kind, ErrorKind::UnexpectedCharacter('\u{feff}')) {
+                                // The "character" is an invisible UTF-8
+                                // byte-order mark (typically emitted by Windows
+                                // editors at the start of the file), so the
+                                // default message and caret point at nothing
+                                // visible. Explain what is actually there.
+                                error = error.with_help(
+                                    "this invisible character is a UTF-8 byte-order \
+                                     mark (BOM); save the file without a BOM",
+                                );
+                            }
+                            return Err(error);
                         }
                     }
                 }
@@ -1271,6 +1285,36 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err.kind, ErrorKind::UnterminatedString));
+
+        // A bare CR is a line terminator (spec 2.3:1) and must end the
+        // string like a bare LF does, not be swallowed as content.
+        let lexer = LogosLexer::new("\"hello\rworld\"");
+        let result = lexer.tokenize();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(err.kind, ErrorKind::UnterminatedString));
+    }
+
+    #[test]
+    fn test_logos_leading_bom_gets_targeted_help() {
+        // A leading UTF-8 BOM is not accepted (the spec whitespace set is
+        // space/tab/LF/CR only), but the error must explain the invisible
+        // character instead of pointing a caret at nothing.
+        let lexer = LogosLexer::new("\u{feff}fn main() -> i32 { 42 }");
+        let result = lexer.tokenize();
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(matches!(
+            err.kind,
+            ErrorKind::UnexpectedCharacter('\u{feff}')
+        ));
+        assert!(
+            err.diagnostic()
+                .helps
+                .iter()
+                .any(|h| h.0.contains("byte-order mark")),
+            "BOM error should carry the explanatory help"
+        );
     }
 
     #[test]

--- a/crates/rue-spec/cases/lexical/keywords.toml
+++ b/crates/rue-spec/cases/lexical/keywords.toml
@@ -120,6 +120,41 @@ spec = ["2.4:1", "2.4:2"]
 source = "fn main() -> i32 { let borrow = 1; 0 }"
 compile_fail = true
 
+[[case]]
+name = "keyword_pub_reserved"
+error_contains = "[E0100]"
+spec = ["2.4:1", "2.4:2"]
+source = "fn main() -> i32 { let pub = 1; 0 }"
+compile_fail = true
+
+[[case]]
+name = "keyword_const_reserved"
+error_contains = "[E0100]"
+spec = ["2.4:1", "2.4:2"]
+source = "fn main() -> i32 { let const = 1; 0 }"
+compile_fail = true
+
+[[case]]
+name = "keyword_checked_reserved"
+error_contains = "[E0100]"
+spec = ["2.4:1", "2.4:2"]
+source = "fn main() -> i32 { let checked = 1; 0 }"
+compile_fail = true
+
+[[case]]
+name = "keyword_unchecked_reserved"
+error_contains = "[E0100]"
+spec = ["2.4:1", "2.4:2"]
+source = "fn main() -> i32 { let unchecked = 1; 0 }"
+compile_fail = true
+
+[[case]]
+name = "keyword_ptr_reserved"
+error_contains = "[E0100]"
+spec = ["2.4:1", "2.4:2"]
+source = "fn main() -> i32 { let ptr = 1; 0 }"
+compile_fail = true
+
 # =============================================================================
 # Type Names Are Reserved
 # =============================================================================
@@ -233,5 +268,17 @@ spec = ["2.4:3"]
 source = """
 struct Foo { bool: i32 }
 fn main() -> i32 { 0 }
+"""
+compile_fail = true
+
+[[case]]
+name = "type_Self_as_variable"
+error_contains = "[E0100]"
+spec = ["2.4:3"]
+source = """
+fn main() -> i32 {
+    let Self = 42;
+    0
+}
 """
 compile_fail = true

--- a/crates/rue-spec/cases/lexical/tokens.toml
+++ b/crates/rue-spec/cases/lexical/tokens.toml
@@ -298,6 +298,15 @@ source = 'fn main() -> i32 { "'
 compile_fail = true
 error_contains = "unterminated string"
 
+# A bare CR is a line terminator (spec 2.3:1), so it ends the line and leaves
+# the string unterminated, same as a bare LF. (TOML \r escape = raw CR byte.)
+[[case]]
+name = "string_literal_unterminated_bare_cr"
+spec = ["2.1:9"]
+source = "fn main() -> i32 {\n    let _s = \"hello\rworld\";\n    0\n}\n"
+compile_fail = true
+error_contains = "unterminated string"
+
 # =============================================================================
 # Identifiers (syntax and legality)
 # =============================================================================

--- a/docs/spec/src/02-lexical-structure/04-keywords.md
+++ b/docs/spec/src/02-lexical-structure/04-keywords.md
@@ -42,6 +42,11 @@ The following words are keywords and cannot be used as identifiers:
 | `impl` | Impl block |
 | `self` | Self parameter in methods |
 | `drop` | Destructor declaration |
+| `pub` | Public visibility modifier |
+| `const` | Constant declaration |
+| `checked` | Checked block (§9.1) |
+| `unchecked` | Unchecked function modifier |
+| `ptr` | Pointer type constructor (`ptr const T` / `ptr mut T`) |
 
 ## Type Names
 
@@ -61,3 +66,4 @@ The following are type names and are reserved:
 | `u64` | 64-bit unsigned integer |
 | `bool` | Boolean type |
 | `type` | Compile-time type of types |
+| `Self` | The enclosing struct type, within a struct block (§6.4) |


### PR DESCRIPTION
Four small fixes from the rue-lexer / rue-span / rue-target component review (dimensions → find → adversarially verify; 17 confirmed findings, the rest filed in Linear).

## Lexer: bare CR in a string literal
Spec 2.3:1 classes CR as a line terminator and 2.1:9 makes an unterminated string a compile error, but the string scanner's content path only checked `\n` — a bare CR was silently swallowed as string content, while the backslash-before-EOL path in the same function already treated `\r` as a terminator. Now both paths agree: bare CR → unterminated-string error. Unit + spec test (`string_literal_unterminated_bare_cr`) pin it.

## Lexer: leading BOM diagnostic
`E0001: unexpected character: <invisible>` with a caret pointing at nothing is baffling when a Windows editor saves a file with a UTF-8 BOM. The behavior (rejection) is spec-conformant — the whitespace set is space/tab/LF/CR — so this only adds a help: `this invisible character is a UTF-8 byte-order mark (BOM); save the file without a BOM`. Whether Rue should *skip* a leading BOM like Rust/Go is filed separately as a Backlog design question.

## Spec: keyword tables were missing six shipped reserved words
The lexer reserves `pub`, `const`, `checked`, `unchecked`, `ptr`, and `Self` — all backing shipped features — but the normative 2.4:2/2.4:3 tables omitted them, so per spec each was a legal identifier. Added table rows plus spec-test cases pinning each rejected in identifier position. This is the inverse direction of RUE-331 (`impl`/`type` listed in the tables but *not* reserved), which stays open as the remaining divergence.

## Doc: `TokenKind` payload type
The enum doc said `Ident`/`String` carry a `Symbol`; the actual type is lasso's `Spur`.

Full suite green locally (25 targets, spec traceability holds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
