### PR TITLE
rue-error review: escape invisible chars, auto-version ICEs, purge dead surface

### DIFF
--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -205,7 +205,7 @@ pub use rue_codegen::{
 };
 pub use rue_error::{
     Applicability, CompileError, CompileErrors, CompileResult, CompileWarning, Diagnostic,
-    ErrorCode, ErrorKind, MultiErrorResult, PreviewFeature, PreviewFeatures, Suggestion,
+    ErrorCode, ErrorKind, MultiErrorResult, PreviewFeature, PreviewFeatures, Suggestion, VERSION,
     WarningKind,
 };
 pub use rue_lexer::{Lexer, Token, TokenKind};

--- a/crates/rue-error/src/ice.rs
+++ b/crates/rue-error/src/ice.rs
@@ -40,8 +40,7 @@ use std::fmt;
 /// # Example
 /// ```ignore
 /// let ice = IceContext::new("unexpected type in codegen")
-///     .with_version("0.1.0")
-///     .with_target("x86_64-unknown-linux-gnu")
+///     .with_version(rue_error::VERSION)
 ///     .with_phase("codegen/emit")
 ///     .with_backtrace();
 /// ```
@@ -49,10 +48,9 @@ use std::fmt;
 pub struct IceContext {
     /// The error message describing what went wrong.
     pub message: String,
-    /// Compiler version (from CARGO_PKG_VERSION).
+    /// Compiler version ([`crate::VERSION`]; attached automatically by the
+    /// `ice!`/`ice_error!` macros).
     pub version: Option<String>,
-    /// Target architecture (e.g., "x86_64-unknown-linux-gnu").
-    pub target: Option<String>,
     /// Compilation phase (e.g., "codegen/emit", "sema", "cfg_builder").
     pub phase: Option<String>,
     /// Additional context-specific details.
@@ -73,7 +71,6 @@ impl IceContext {
         Self {
             message: message.into(),
             version: None,
-            target: None,
             phase: None,
             details: Vec::new(),
             backtrace: None,
@@ -83,12 +80,6 @@ impl IceContext {
     /// Set the compiler version.
     pub fn with_version(mut self, version: impl Into<String>) -> Self {
         self.version = Some(version.into());
-        self
-    }
-
-    /// Set the target architecture.
-    pub fn with_target(mut self, target: impl Into<String>) -> Self {
-        self.target = Some(target.into());
         self
     }
 
@@ -123,10 +114,6 @@ impl IceContext {
 
         if let Some(version) = &self.version {
             output.push_str(&format!("  rue version: {}\n", version));
-        }
-
-        if let Some(target) = &self.target {
-            output.push_str(&format!("  target: {}\n", target));
         }
 
         if let Some(phase) = &self.phase {
@@ -169,10 +156,8 @@ impl fmt::Display for IceContext {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "internal compiler error: {}", self.message)?;
 
-        let has_details = self.version.is_some()
-            || self.target.is_some()
-            || self.phase.is_some()
-            || !self.details.is_empty();
+        let has_details =
+            self.version.is_some() || self.phase.is_some() || !self.details.is_empty();
 
         if has_details {
             write!(f, "\n\ndebug info:\n{}", self.format_details())?;
@@ -217,19 +202,21 @@ impl fmt::Display for IceContext {
 ///
 /// The macro automatically:
 /// - Captures a backtrace
-///
-/// Callers should add version information using `.with_version()` when creating ICEs.
+/// - Attaches the compiler version ([`crate::VERSION`]), so graceful ICE
+///   reports carry the same version line as the panic-hook banner
 #[macro_export]
 macro_rules! ice {
     // Just message
     ($msg:expr) => {
         $crate::ice::IceContext::new($msg)
+            .with_version($crate::VERSION)
             .with_backtrace()
     };
 
     // Message + phase
     ($msg:expr, phase: $phase:expr) => {
         $crate::ice::IceContext::new($msg)
+            .with_version($crate::VERSION)
             .with_phase($phase)
             .with_backtrace()
     };
@@ -237,6 +224,7 @@ macro_rules! ice {
     // Message + details
     ($msg:expr, details: { $($key:expr => $value:expr),+ $(,)? }) => {{
         let mut ctx = $crate::ice::IceContext::new($msg)
+            .with_version($crate::VERSION)
             .with_backtrace();
         $(
             ctx = ctx.with_detail($key, $value);
@@ -247,6 +235,7 @@ macro_rules! ice {
     // Message + phase + details
     ($msg:expr, phase: $phase:expr, details: { $($key:expr => $value:expr),+ $(,)? }) => {{
         let mut ctx = $crate::ice::IceContext::new($msg)
+            .with_version($crate::VERSION)
             .with_phase($phase)
             .with_backtrace();
         $(
@@ -289,7 +278,6 @@ mod tests {
         let ice = IceContext::new("test error");
         assert_eq!(ice.message, "test error");
         assert!(ice.version.is_none());
-        assert!(ice.target.is_none());
         assert!(ice.phase.is_none());
         assert!(ice.details.is_empty());
     }
@@ -298,12 +286,6 @@ mod tests {
     fn test_ice_context_with_version() {
         let ice = IceContext::new("test error").with_version("0.1.0");
         assert_eq!(ice.version.as_deref(), Some("0.1.0"));
-    }
-
-    #[test]
-    fn test_ice_context_with_target() {
-        let ice = IceContext::new("test error").with_target("x86_64-unknown-linux-gnu");
-        assert_eq!(ice.target.as_deref(), Some("x86_64-unknown-linux-gnu"));
     }
 
     #[test]
@@ -332,14 +314,12 @@ mod tests {
     fn test_ice_context_builder_chain() {
         let ice = IceContext::new("unexpected type")
             .with_version("0.1.0")
-            .with_target("x86_64-unknown-linux-gnu")
             .with_phase("codegen/emit")
             .with_detail("function", "main")
             .with_detail("instruction", "Call");
 
         assert_eq!(ice.message, "unexpected type");
         assert_eq!(ice.version.as_deref(), Some("0.1.0"));
-        assert_eq!(ice.target.as_deref(), Some("x86_64-unknown-linux-gnu"));
         assert_eq!(ice.phase.as_deref(), Some("codegen/emit"));
         assert_eq!(ice.details.len(), 2);
     }
@@ -362,13 +342,11 @@ mod tests {
     fn test_ice_context_format_details_full() {
         let ice = IceContext::new("test error")
             .with_version("0.1.0")
-            .with_target("x86_64-unknown-linux-gnu")
             .with_phase("codegen")
             .with_detail("function", "main");
 
         let formatted = ice.format_details();
         assert!(formatted.contains("rue version: 0.1.0"));
-        assert!(formatted.contains("target: x86_64-unknown-linux-gnu"));
         assert!(formatted.contains("phase: codegen"));
         assert!(formatted.contains("relevant state:"));
         assert!(formatted.contains("function: main"));
@@ -431,14 +409,12 @@ mod tests {
         // Test the full builder chain with backtrace
         let ice = IceContext::new("unexpected type")
             .with_version("0.1.0")
-            .with_target("x86_64-unknown-linux-gnu")
             .with_phase("codegen/emit")
             .with_detail("function", "main")
             .with_backtrace();
 
         assert_eq!(ice.message, "unexpected type");
         assert!(ice.version.is_some());
-        assert!(ice.target.is_some());
         assert!(ice.phase.is_some());
         assert_eq!(ice.details.len(), 1);
         assert!(ice.backtrace.is_some());
@@ -455,6 +431,9 @@ mod tests {
         assert!(ctx.backtrace.is_some());
         assert!(ctx.phase.is_none());
         assert!(ctx.details.is_empty());
+        // The macro attaches the compiler version automatically, so graceful
+        // ICE reports match the panic-hook banner.
+        assert_eq!(ctx.version.as_deref(), Some(crate::VERSION));
     }
 
     #[test]

--- a/crates/rue-error/src/lib.rs
+++ b/crates/rue-error/src/lib.rs
@@ -20,6 +20,14 @@
 pub mod ice;
 
 use rue_span::Span;
+
+/// The rue compiler version.
+///
+/// Single source of truth: the CLI's `--version` banner and ICE reports
+/// (via the `ice!`/`ice_error!` macros) both read this constant. Buck2
+/// builds don't set `CARGO_PKG_VERSION`, so it can't come from the
+/// environment.
+pub const VERSION: &str = "0.1.0";
 use std::borrow::Cow;
 use std::collections::HashSet;
 use std::fmt;
@@ -86,7 +94,9 @@ impl ErrorCode {
     // Parser errors (E0100-E0199)
     // ========================================================================
     pub const UNEXPECTED_TOKEN: Self = Self(100);
-    pub const UNEXPECTED_EOF: Self = Self(101);
+    // E0101 was UNEXPECTED_EOF, deleted as never-produced: the parser reports
+    // end-of-file as UnexpectedToken { found: "end of file" }. Keep the
+    // number retired rather than reusing it.
     pub const PARSE_ERROR: Self = Self(102);
 
     // ========================================================================
@@ -946,11 +956,14 @@ pub struct PrivateUnqualifiedAccessData {
 #[derive(Debug, Clone, PartialEq, Eq, Error)]
 pub enum ErrorKind {
     // Lexer errors
-    #[error("unexpected character: {0}")]
+    // escape_debug keeps printable characters as-is but renders control and
+    // other invisible characters (NUL, VT, BOM, ...) as visible escapes like
+    // \u{b}, so a hostile byte can't corrupt the one-line message.
+    #[error("unexpected character: {}", .0.escape_debug())]
     UnexpectedCharacter(char),
     #[error("invalid integer literal")]
     InvalidInteger,
-    #[error("invalid escape sequence: \\{0}")]
+    #[error("invalid escape sequence: \\{}", .0.escape_debug())]
     InvalidStringEscape(char),
     #[error("unterminated string literal")]
     UnterminatedString,
@@ -975,8 +988,6 @@ pub enum ErrorKind {
         expected: Cow<'static, str>,
         found: Cow<'static, str>,
     },
-    #[error("unexpected end of file, expected {expected}")]
-    UnexpectedEof { expected: Cow<'static, str> },
     /// A custom parse error with a specific message.
     ///
     /// Used for parser-generated errors that don't fit the "expected X, found Y" pattern.
@@ -1416,7 +1427,6 @@ impl ErrorKind {
 
             // Parser errors (E0100-E0199)
             ErrorKind::UnexpectedToken { .. } => ErrorCode::UNEXPECTED_TOKEN,
-            ErrorKind::UnexpectedEof { .. } => ErrorCode::UNEXPECTED_EOF,
             ErrorKind::ParseError(_) => ErrorCode::PARSE_ERROR,
             ErrorKind::NestingLimitExceeded { .. } => ErrorCode::NESTING_LIMIT_EXCEEDED,
 
@@ -1553,18 +1563,6 @@ impl ErrorKind {
             // Internal compiler errors (E9000-E9999)
             ErrorKind::InternalError(_) => ErrorCode::INTERNAL_ERROR,
             ErrorKind::InternalCodegenError(_) => ErrorCode::INTERNAL_CODEGEN_ERROR,
-        }
-    }
-}
-
-impl CompileError {
-    /// Create an error at a specific position (zero-length span).
-    #[inline]
-    pub fn at(kind: ErrorKind, pos: u32) -> Self {
-        Self {
-            kind,
-            span: Some(Span::point(pos)),
-            diagnostic: Diagnostic::new(),
         }
     }
 }
@@ -1962,17 +1960,24 @@ mod tests {
     }
 
     #[test]
-    fn test_error_at_position() {
-        let error = CompileError::at(ErrorKind::InvalidInteger, 42);
-
-        assert!(error.has_span());
-        assert_eq!(error.span(), Some(Span::point(42)));
-    }
-
-    #[test]
     fn test_unexpected_character_message() {
         let error = CompileError::without_span(ErrorKind::UnexpectedCharacter('@'));
         assert_eq!(error.to_string(), "unexpected character: @");
+    }
+
+    #[test]
+    fn test_unexpected_character_escapes_invisible_chars() {
+        // Control and format characters must not appear raw in the one-line
+        // message; escape_debug renders them as visible escapes.
+        let vt = CompileError::without_span(ErrorKind::UnexpectedCharacter('\u{b}'));
+        assert_eq!(vt.to_string(), "unexpected character: \\u{b}");
+        let nul = CompileError::without_span(ErrorKind::UnexpectedCharacter('\0'));
+        assert_eq!(nul.to_string(), "unexpected character: \\0");
+        let bom = CompileError::without_span(ErrorKind::UnexpectedCharacter('\u{feff}'));
+        assert_eq!(bom.to_string(), "unexpected character: \\u{feff}");
+        // Printable characters are unchanged, including non-ASCII.
+        let acute = CompileError::without_span(ErrorKind::UnexpectedCharacter('é'));
+        assert_eq!(acute.to_string(), "unexpected character: é");
     }
 
     #[test]
@@ -1982,14 +1987,6 @@ mod tests {
             found: Cow::Borrowed("'+'"),
         });
         assert_eq!(error.to_string(), "expected identifier, found '+'");
-    }
-
-    #[test]
-    fn test_unexpected_eof_message() {
-        let error = CompileError::without_span(ErrorKind::UnexpectedEof {
-            expected: Cow::Borrowed("'}'"),
-        });
-        assert_eq!(error.to_string(), "unexpected end of file, expected '}'");
     }
 
     #[test]
@@ -2659,13 +2656,6 @@ mod tests {
             }
             .code(),
             ErrorCode::UNEXPECTED_TOKEN
-        );
-        assert_eq!(
-            ErrorKind::UnexpectedEof {
-                expected: "}".into()
-            }
-            .code(),
-            ErrorCode::UNEXPECTED_EOF
         );
         assert_eq!(
             ErrorKind::ParseError("custom error".into()).code(),

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -210,8 +210,9 @@ struct Options {
     jobs: usize,
 }
 
-/// Version string for the rue compiler.
-const VERSION: &str = "0.1.0";
+/// Version string for the rue compiler (single-sourced from rue-error so the
+/// `--version` banner and ICE reports can never drift apart).
+const VERSION: &str = rue_compiler::VERSION;
 
 fn print_version() {
     println!("rue {}", VERSION);


### PR DESCRIPTION
Fixes from the **rue-error component review** (dimensions → find → adversarially verify; 12 confirmed findings — the PreviewFeature sync matrix came back fully clean — remainder filed in Linear).

## Invisible characters no longer corrupt one-line messages
`UnexpectedCharacter`/`InvalidStringEscape` interpolated the offending `char` verbatim, so a NUL/VT byte in source put a raw control byte inside the diagnostic header line (`unexpected character: ^K` under `cat -v`). Both now render through `char::escape_debug`: printable characters (including non-ASCII like `é`) are unchanged, control/format characters show as `\u{b}`, `\0`, `\u{feff}`. This also makes the leading-BOM error (helped in #1173) show *what* the invisible character is. Unit test pins all four shapes.

## Graceful ICEs now carry the compiler version
`ice.rs` docs instructed callers to add version info via `.with_version()` — no call site ever did, so the panic-hook banner printed `note: rue version 0.1.0` while every `ice_error!` report carried none (exactly the info a bug report needs). The `ice!`/`ice_error!` macros now attach it automatically. `VERSION` is single-sourced in rue-error (buck2 doesn't set `CARGO_PKG_VERSION`); the CLI's `--version` const now reads it through the rue-compiler re-export instead of a duplicate `"0.1.0"` literal.

## Dead surface deleted (verified zero producers)
- `ErrorKind::UnexpectedEof` / `E0101`: the parser reports EOF as `UnexpectedToken { found: "end of file" }`, so this variant and its code were unreachable. The code number is retired with a comment, not reused.
- `CompileError::at`: only its own unit test called it.
- `IceContext::with_target` + the `target` field/format branch: never set by any producer; per-ICE state like target belongs in the existing `details` mechanism.

Two sibling never-constructed variants were deliberately **kept**: `UnsupportedTarget`/E1001 (flagged on RUE-377 as the natural vehicle for the unsupported-host error) and `SliceNotYetImplemented`/E0486 (reserved by the in-flight ADR-0043 slice workstream; noted for the RUE-327 cleanup phase).

Full suite green locally (25 targets, traceability holds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
