### PR TITLE
Fuzz infra: per-input timeout, graceful-ICE detection, working CI notifications

### DIFF
--- a/.github/workflows/cache-probe.yml
+++ b/.github/workflows/cache-probe.yml
@@ -51,10 +51,12 @@ jobs:
 
       - name: Cold build (populates the remote cache)
         run: |
+          set -o pipefail  # without it, `| tee | tail` makes a failed build exit 0
           /usr/bin/time -v ./buck2 build //crates/rue:rue 2>&1 | tee cold.log | tail -3
 
       - name: Clear local buck-out, rebuild (should hit the remote cache)
         run: |
+          set -o pipefail  # without it, `| tee | tail` makes a failed build exit 0
           ./buck2 clean
           /usr/bin/time -v ./buck2 build //crates/rue:rue 2>&1 | tee warm.log | tail -3
 

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -5,9 +5,20 @@ on:
     - cron: '0 0 * * *'  # Daily at midnight UTC
   workflow_dispatch:  # Allow manual triggering
 
+# The default GITHUB_TOKEN is read-only; without issues:write the
+# "notify on failure" step below fails with "Resource not accessible by
+# integration" and nightly crashes are found but never reported (this
+# silently ate real crash reports for at least 2026-07-03/04).
+permissions:
+  contents: read
+  issues: write
+
 jobs:
   fuzz:
     runs-on: ubuntu-latest
+    # A wedged step can otherwise burn a runner to GitHub's 6h job cap.
+    # Generous vs the ~40min expected total, tight vs the 6h default.
+    timeout-minutes: 90
     steps:
       - uses: actions/checkout@v6
 
@@ -29,22 +40,44 @@ jobs:
       - name: Create seed corpus
         run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --init-corpus crates/rue-fuzz/corpus
 
+      # Each fuzz step is continue-on-error so one crashing target no longer
+      # skips every later target (a single sema crash used to reduce the whole
+      # night to lexer+parser coverage). The aggregation step at the end turns
+      # any step failure back into a red job, so nothing is masked.
       - name: Fuzz lexer (5 minutes)
+        id: fuzz-lexer
+        continue-on-error: true
+        timeout-minutes: 10
         run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 lexer crates/rue-fuzz/corpus
 
       - name: Fuzz parser (5 minutes)
+        id: fuzz-parser
+        continue-on-error: true
+        timeout-minutes: 10
         run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 parser crates/rue-fuzz/corpus
 
       - name: Fuzz sema (5 minutes)
+        id: fuzz-sema
+        continue-on-error: true
+        timeout-minutes: 10
         run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 sema crates/rue-fuzz/corpus
 
       - name: Fuzz compiler (5 minutes)
+        id: fuzz-compiler
+        continue-on-error: true
+        timeout-minutes: 10
         run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 compiler crates/rue-fuzz/corpus
 
       - name: Fuzz x86-64 emitter (5 minutes)
+        id: fuzz-emitter
+        continue-on-error: true
+        timeout-minutes: 10
         run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 emitter crates/rue-fuzz/corpus
 
       - name: Fuzz x86-64 emitter sequences (5 minutes)
+        id: fuzz-emitter-sequence
+        continue-on-error: true
+        timeout-minutes: 10
         run: ./buck2 run //crates/rue-fuzz:rue-fuzz -- --mutate --max-time=300 emitter_sequence crates/rue-fuzz/corpus
 
       # Differential fuzzing: generate valid programs and cross-check the
@@ -53,45 +86,72 @@ jobs:
       # miscompile; the step exits non-zero and a self-contained repro (named by
       # its seed) lands in crates/rue-fuzz/crashes/ for the upload step below.
       - name: Differential fuzz (oracle vs compiled, 500 seeds)
+        id: fuzz-differential
+        continue-on-error: true
+        timeout-minutes: 20
         run: |
           RUE_BINARY="$(scripts/rue-bin)" ./buck2 run //crates/rue-oracle-diff:rue-oracle-diff -- \
             fuzz --seeds 500 --crash-dir crates/rue-fuzz/crashes
 
+      # With continue-on-error above, step failures don't mark the job failed
+      # until the aggregation step — so the upload must run unconditionally.
       - name: Upload crash artifacts
-        if: failure()
+        if: always()
         uses: actions/upload-artifact@v6
         with:
           name: fuzz-crashes
           path: crates/rue-fuzz/crashes/
           if-no-files-found: ignore
 
-      - name: Create issue on failure
+      - name: Fail if any fuzz step found crashes
+        if: >-
+          steps.fuzz-lexer.outcome == 'failure' ||
+          steps.fuzz-parser.outcome == 'failure' ||
+          steps.fuzz-sema.outcome == 'failure' ||
+          steps.fuzz-compiler.outcome == 'failure' ||
+          steps.fuzz-emitter.outcome == 'failure' ||
+          steps.fuzz-emitter-sequence.outcome == 'failure' ||
+          steps.fuzz-differential.outcome == 'failure'
+        run: |
+          echo "One or more fuzz targets found crashes (see step outcomes above)."
+          exit 1
+
+      - name: Notify on failure (create or comment on the fuzz-crash issue)
         if: failure()
         uses: actions/github-script@v9
         with:
           script: |
-            const title = `Fuzz testing found a crash (${new Date().toISOString().split('T')[0]})`;
+            const failed = [
+              ['lexer', '${{ steps.fuzz-lexer.outcome }}'],
+              ['parser', '${{ steps.fuzz-parser.outcome }}'],
+              ['sema', '${{ steps.fuzz-sema.outcome }}'],
+              ['compiler', '${{ steps.fuzz-compiler.outcome }}'],
+              ['emitter', '${{ steps.fuzz-emitter.outcome }}'],
+              ['emitter_sequence', '${{ steps.fuzz-emitter-sequence.outcome }}'],
+              ['differential', '${{ steps.fuzz-differential.outcome }}'],
+            ].filter(([, o]) => o === 'failure').map(([n]) => n);
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const summary = `**Run:** ${runUrl}\n**Failed targets:** ${failed.join(', ') || '(job-level failure)'}\n`;
             const body = `## Fuzz Testing Failure
 
             The daily fuzz testing workflow found a crash.
 
-            **Run:** ${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}
-
-            Please check the workflow logs and crash artifacts for details.
-
+            ${summary}
             ### Next Steps
             1. Download the crash artifacts from the workflow run. Each
-               reproducer is named \`crash-<target>-<sighash>-<inputhash>.txt\`;
-               the fuzzer detects both panics and *aborts* (stack overflow /
-               SIGABRT / SIGSEGV / SIGFPE), and dedups by crash signature so
-               each distinct crash is saved once (RUE-43).
+               reproducer is named \`crash-<target>-<sighash>-<inputhash>.txt\`
+               with a \`.meta\` sibling recording the crash class and
+               signature; the fuzzer detects panics, *aborts* (stack overflow /
+               SIGABRT / SIGSEGV / SIGFPE), hangs (per-input timeout), and
+               graceful ICEs, deduping by crash signature (RUE-43).
             2. Reproduce locally by feeding the saved input to the target named
                in the filename, e.g. for a source-level target:
                \`./buck2 run //crates/rue-fuzz:rue-fuzz -- <target> <dir-with-the-file>\`
             3. Fix the issue and add a regression test
             `;
 
-            // Check if an open issue already exists
+            // One open tracking issue at a time; new crashes while it is open
+            // are appended as comments instead of being silently dropped.
             const issues = await github.rest.issues.listForRepo({
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -100,11 +160,19 @@ jobs:
             });
 
             if (issues.data.length === 0) {
+              const title = `Fuzz testing found a crash (${new Date().toISOString().split('T')[0]})`;
               await github.rest.issues.create({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: title,
                 body: body,
                 labels: ['fuzz-crash', 'bug']
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issues.data[0].number,
+                body: `Another nightly fuzz failure while this issue is open.\n\n${summary}`
               });
             }

--- a/crates/rue-fuzz/README.md
+++ b/crates/rue-fuzz/README.md
@@ -40,6 +40,8 @@ Fuzz testing infrastructure for the Rue compiler. This crate helps find edge cas
 | `--max-runs=<n>` | Maximum number of runs |
 | `--crash-dir=<dir>` | Directory to save crashes |
 | `--print-interval=<n>` | Print progress every N runs |
+| `--per-input-timeout=<secs>` | Kill and report inputs running longer than this (default 5) |
+| `--seed=<n>` | Mutation RNG seed; defaults to a per-run value, printed at start for replay |
 
 ## Corpus
 
@@ -76,10 +78,22 @@ builds with `panic = abort`, it could not actually catch panics either — they
 abort). The child streams the panic message over a pipe from its panic hook so
 panics keep a source-location dedup signature even under `panic = abort`.
 
+Two further failure classes are covered:
+
+- **Hangs**: each input has a wall-clock budget (`--per-input-timeout`,
+  default 5s). A child still running at the deadline is SIGKILLed and
+  reported as a `timeout` crash — infinite loops and superlinear blowups
+  are compiler bugs too, and without the deadline a single hung input would
+  wedge the whole run in `waitpid`.
+- **Graceful ICEs**: the sema/compiler targets inspect the returned errors
+  and panic on `ErrorKind::InternalError` — an `ice_error!` that returns a
+  normal `Err` is still a compiler bug, even though it doesn't crash.
+
 When a crash is detected, the crashing input is saved to the crash directory
 (defaults to `crashes/` next to the corpus) as
-`crash-<target>-<sighash>-<inputhash>.txt`. Crashes are **deduplicated by
-signature** (panic message + location, or signal type), so one flooding bug
+`crash-<target>-<sighash>-<inputhash>.txt`, with a `.meta` sibling recording
+the target, signature, and crash description so downloaded CI artifacts are
+self-describing. Crashes are **deduplicated by signature** (panic message + location, or signal type), so one flooding bug
 saves a single reproducer instead of thousands. To reproduce, feed the saved
 input back to the target named in the filename:
 

--- a/crates/rue-fuzz/src/codegen_generators.rs
+++ b/crates/rue-fuzz/src/codegen_generators.rs
@@ -1,11 +1,11 @@
 //! Proptest strategies for generating x86-64 MIR instructions.
 //!
-//! These generators produce random instruction sequences for fuzzing
-//! the emitter, register allocator, and liveness analysis.
+//! These generators produce random instruction sequences for fuzzing the
+//! emitter (single instructions and whole-function sequences).
 
 use proptest::prelude::*;
 use proptest::strategy::BoxedStrategy;
-use rue_codegen::x86_64::{LabelId, Operand, Reg, VReg, X86Inst, X86Mir};
+use rue_codegen::x86_64::{LabelId, Operand, Reg, X86Inst, X86Mir};
 
 /// Generate a random physical register.
 pub fn arb_reg() -> BoxedStrategy<Reg> {
@@ -32,18 +32,6 @@ pub fn arb_reg() -> BoxedStrategy<Reg> {
 /// Generate a physical operand (for post-regalloc instructions).
 pub fn arb_physical_operand() -> BoxedStrategy<Operand> {
     arb_reg().prop_map(Operand::Physical).boxed()
-}
-
-/// Generate a virtual operand (for pre-regalloc instructions).
-pub fn arb_virtual_operand(max_vreg: u32) -> BoxedStrategy<Operand> {
-    (0..max_vreg.max(1))
-        .prop_map(|idx| Operand::Virtual(VReg::new(idx)))
-        .boxed()
-}
-
-/// Generate an operand that can be either virtual or physical.
-pub fn arb_operand(max_vreg: u32) -> BoxedStrategy<Operand> {
-    prop_oneof![arb_physical_operand(), arb_virtual_operand(max_vreg),].boxed()
 }
 
 /// Generate a 32-bit immediate value.
@@ -104,11 +92,6 @@ pub fn arb_stack_offset() -> impl Strategy<Value = i32> {
         // Any aligned offset
         any::<i16>().prop_map(|x| (x as i32) * 8),
     ]
-}
-
-/// Generate a label ID.
-pub fn arb_label_id(max_labels: u32) -> impl Strategy<Value = LabelId> {
-    (0..max_labels.max(1)).prop_map(LabelId::new)
 }
 
 /// Generate a single x86-64 instruction with physical registers.
@@ -266,37 +249,6 @@ pub fn arb_x86_mir(inst_count: usize, num_labels: usize) -> impl Strategy<Value 
         }
         mir
     })
-}
-
-/// Generate an X86Mir with virtual registers for regalloc testing.
-pub fn arb_x86_mir_with_vregs(inst_count: usize, num_vregs: u32) -> BoxedStrategy<X86Mir> {
-    prop::collection::vec(
-        prop_oneof![
-            // Simple register-to-register operations that regalloc handles
-            (arb_operand(num_vregs), arb_imm32())
-                .prop_map(|(dst, imm)| X86Inst::MovRI32 { dst, imm }),
-            (arb_operand(num_vregs), arb_operand(num_vregs))
-                .prop_map(|(dst, src)| X86Inst::MovRR { dst, src }),
-            (arb_operand(num_vregs), arb_operand(num_vregs))
-                .prop_map(|(dst, src)| X86Inst::AddRR { dst, src }),
-            (arb_operand(num_vregs), arb_operand(num_vregs))
-                .prop_map(|(dst, src)| X86Inst::SubRR { dst, src }),
-            arb_operand(num_vregs).prop_map(|dst| X86Inst::Neg { dst }),
-        ],
-        inst_count,
-    )
-    .prop_map(move |insts| {
-        let mut mir = X86Mir::new();
-        // Allocate the vregs
-        for _ in 0..num_vregs {
-            mir.alloc_vreg();
-        }
-        for inst in insts {
-            mir.push(inst);
-        }
-        mir
-    })
-    .boxed()
 }
 
 #[cfg(test)]

--- a/crates/rue-fuzz/src/harness.rs
+++ b/crates/rue-fuzz/src/harness.rs
@@ -32,10 +32,16 @@
 
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
 
 /// Exit code the child uses to signal "I caught a panic" (distinct from a
 /// signal death and from a clean exit). 101 matches rustc's own convention.
 const PANIC_EXIT_CODE: i32 = 101;
+
+/// Default per-input wall-clock budget. Fuzz inputs are tiny; a healthy
+/// compile finishes in milliseconds, so anything still running after this
+/// long is a hang/superlinear bug, not a slow success.
+pub const DEFAULT_PER_INPUT_TIMEOUT: Duration = Duration::from_secs(5);
 
 /// The outcome of running one fuzz input.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -48,6 +54,11 @@ pub enum RunOutcome {
     /// SIGABRT=6, SIGFPE=8). This is the case the old in-process harness was
     /// completely blind to.
     Signal(i32),
+    /// The child exceeded the per-input timeout and was SIGKILLed by the
+    /// harness. Carries the budget in seconds. Hangs (infinite loops,
+    /// superlinear parse blowups) are compiler bugs too — and without this,
+    /// one hung input wedges the whole run in `waitpid`.
+    Timeout(u64),
 }
 
 impl RunOutcome {
@@ -68,6 +79,9 @@ impl RunOutcome {
             RunOutcome::Ok => None,
             RunOutcome::Panic(msg) => Some(format!("panic:{}", first_line(msg))),
             RunOutcome::Signal(sig) => Some(format!("signal:{}", signal_name(*sig))),
+            // All hangs collapse to one bucket — same flood-control rationale
+            // as signals (one superlinear-parse bug makes *many* inputs hang).
+            RunOutcome::Timeout(_) => Some("timeout".to_string()),
         }
     }
 
@@ -77,6 +91,7 @@ impl RunOutcome {
             RunOutcome::Ok => "ok".to_string(),
             RunOutcome::Panic(msg) => format!("panic: {}", first_line(msg)),
             RunOutcome::Signal(sig) => format!("signal: {} ({})", signal_name(*sig), sig),
+            RunOutcome::Timeout(secs) => format!("timeout: hung for more than {secs}s"),
         }
     }
 }
@@ -100,16 +115,25 @@ pub fn signal_name(sig: i32) -> String {
     name.to_string()
 }
 
+/// Run `f` in a forked child with the [default][DEFAULT_PER_INPUT_TIMEOUT]
+/// per-input timeout. See [`run_forked_with_timeout`].
+pub fn run_forked<F: FnOnce()>(f: F) -> RunOutcome {
+    run_forked_with_timeout(f, DEFAULT_PER_INPUT_TIMEOUT)
+}
+
 /// Run `f` in a forked child process and report how it terminated.
 ///
 /// The child runs the closure under `catch_unwind`; the parent `waitpid`s and
 /// classifies the result. Fatal signals become [`RunOutcome::Signal`], panics
-/// become [`RunOutcome::Panic`], a clean run is [`RunOutcome::Ok`].
+/// become [`RunOutcome::Panic`], a clean run is [`RunOutcome::Ok`]. A child
+/// still running after `timeout` is SIGKILLed and reported as
+/// [`RunOutcome::Timeout`] — without this, a hung compile blocks the parent
+/// in `waitpid` forever and the entire hang/DoS bug class is undetectable.
 ///
 /// If `fork`/`pipe` themselves fail (extremely unlikely), we degrade gracefully
 /// to an in-process `catch_unwind` run — that still catches panics, we just lose
-/// signal detection for that one input.
-pub fn run_forked<F: FnOnce()>(f: F) -> RunOutcome {
+/// signal detection (and hang detection) for that one input.
+pub fn run_forked_with_timeout<F: FnOnce()>(f: F, timeout: Duration) -> RunOutcome {
     // Pipe for streaming the panic message from child to parent.
     let mut fds = [0 as libc::c_int; 2];
     if unsafe { libc::pipe(fds.as_mut_ptr()) } != 0 {
@@ -158,29 +182,108 @@ pub fn run_forked<F: FnOnce()>(f: F) -> RunOutcome {
         }
     }
 
-    // ---- Parent: collect any panic message, then reap the child.
+    // ---- Parent: collect any panic message, then reap the child — both
+    // bounded by the per-input deadline. The pipe read must be bounded too: a
+    // hung child holds its write end open and never writes, so an unbounded
+    // read() would block before we ever reached waitpid.
     unsafe { libc::close(write_fd) };
+    let deadline = Instant::now() + timeout;
     let mut msg = Vec::new();
     let mut buf = [0u8; 4096];
+    let mut timed_out = false;
     loop {
-        let n = unsafe { libc::read(read_fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
-        if n <= 0 {
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            timed_out = true;
             break;
+        }
+        let mut pfd = libc::pollfd {
+            fd: read_fd,
+            events: libc::POLLIN,
+            revents: 0,
+        };
+        let wait_ms = remaining.as_millis().min(i32::MAX as u128) as libc::c_int;
+        let r = unsafe { libc::poll(&mut pfd, 1, wait_ms.max(1)) };
+        if r < 0 {
+            if std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            break; // poll error: give up on the message, fall through to reap
+        }
+        if r == 0 {
+            // Deadline expired with the child still holding the pipe open.
+            timed_out = true;
+            break;
+        }
+        let n = unsafe { libc::read(read_fd, buf.as_mut_ptr() as *mut libc::c_void, buf.len()) };
+        if n < 0 {
+            if std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            break;
+        }
+        if n == 0 {
+            break; // EOF: the child closed its end (normal exit or death)
         }
         msg.extend_from_slice(&buf[..n as usize]);
     }
     unsafe { libc::close(read_fd) };
 
-    let mut status: libc::c_int = 0;
-    // Loop over EINTR.
-    loop {
-        let r = unsafe { libc::waitpid(pid, &mut status, 0) };
-        if r != -1 || std::io::Error::last_os_error().raw_os_error() != Some(libc::EINTR) {
-            break;
+    if timed_out {
+        unsafe {
+            libc::kill(pid, libc::SIGKILL);
         }
     }
 
+    // Reap, still bounded: even after pipe EOF a pathological child could
+    // linger (e.g. the closure closed our write end itself and then hung), so
+    // poll with WNOHANG and escalate to SIGKILL at the deadline.
+    let mut status: libc::c_int = 0;
+    let mut killed = timed_out;
+    loop {
+        let r = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+        if r == pid {
+            break;
+        }
+        if r == -1 {
+            if std::io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            // ECHILD or another wait error: nothing reapable; classify by what
+            // we know.
+            return if timed_out {
+                RunOutcome::Timeout(timeout.as_secs())
+            } else {
+                outcome_from_status_exited_unknown(msg)
+            };
+        }
+        // r == 0: child still running.
+        if !killed && Instant::now() >= deadline {
+            timed_out = true;
+            killed = true;
+            unsafe {
+                libc::kill(pid, libc::SIGKILL);
+            }
+        }
+        std::thread::sleep(Duration::from_millis(2));
+    }
+
+    if timed_out {
+        // We killed it (or it died at the boundary): either way the input
+        // exceeded its budget.
+        return RunOutcome::Timeout(timeout.as_secs());
+    }
     outcome_from_status(status, msg)
+}
+
+/// Reached only if `waitpid` errored with no status available: fall back to
+/// classifying on the panic message alone.
+fn outcome_from_status_exited_unknown(panic_msg: Vec<u8>) -> RunOutcome {
+    let msg = String::from_utf8_lossy(&panic_msg);
+    if !msg.trim().is_empty() {
+        return RunOutcome::Panic(msg.into_owned());
+    }
+    RunOutcome::Ok
 }
 
 fn outcome_from_status(status: libc::c_int, panic_msg: Vec<u8>) -> RunOutcome {
@@ -259,7 +362,7 @@ impl CrashReporter {
         );
 
         let crash_dir = self.crash_dir.as_ref()?;
-        match write_reproducer(crash_dir, target, input, &signature) {
+        match write_reproducer(crash_dir, target, input, &signature, &outcome.describe()) {
             Ok(path) => {
                 eprintln!("[{target}] saved reproducer: {}", path.display());
                 Some(path)
@@ -280,11 +383,16 @@ impl CrashReporter {
 /// Write the crashing input to `crash_dir` under a name that includes both a
 /// signature hash and an input hash, so identical inputs overwrite (not
 /// accumulate) and distinct crashes never collide.
+///
+/// A `.meta` sibling records the target, signature, and human-readable crash
+/// description, so a downloaded CI artifact is self-describing — without it
+/// the crash class survives only as a non-invertible hash in the filename.
 fn write_reproducer(
     crash_dir: &Path,
     target: &str,
     input: &[u8],
     signature: &str,
+    description: &str,
 ) -> std::io::Result<PathBuf> {
     use std::io::Write;
 
@@ -298,6 +406,9 @@ fn write_reproducer(
 
     let mut file = std::fs::File::create(&path)?;
     file.write_all(input)?;
+
+    let meta = format!("target: {target}\nsignature: {signature}\noutcome: {description}\n");
+    std::fs::write(path.with_extension("txt.meta"), meta)?;
     Ok(path)
 }
 
@@ -371,6 +482,49 @@ mod tests {
         }
     }
 
+    // The hang-detection analog of the RUE-43 abort test: a child that never
+    // terminates must be killed at the deadline and reported as a Timeout,
+    // not wedge the harness in waitpid forever.
+    #[test]
+    fn hang_is_detected_as_timeout() {
+        let started = std::time::Instant::now();
+        let outcome = run_forked_with_timeout(
+            || loop {
+                std::thread::sleep(Duration::from_millis(50));
+            },
+            Duration::from_millis(300),
+        );
+        assert_eq!(outcome, RunOutcome::Timeout(0)); // 300ms rounds to 0s
+        assert!(outcome.is_crash());
+        assert_eq!(outcome.signature().as_deref(), Some("timeout"));
+        assert!(
+            started.elapsed() < Duration::from_secs(10),
+            "harness must not block anywhere near beyond the deadline"
+        );
+    }
+
+    // A child that hangs while holding the panic-message pipe open must not
+    // block the parent's pipe read either (the read is deadline-bounded).
+    #[test]
+    fn hang_with_partial_pipe_write_is_still_a_timeout() {
+        let outcome = run_forked_with_timeout(
+            || {
+                // Simulates a target that got partway through work then hung.
+                loop {
+                    std::hint::spin_loop();
+                }
+            },
+            Duration::from_millis(300),
+        );
+        assert!(matches!(outcome, RunOutcome::Timeout(_)));
+    }
+
+    #[test]
+    fn fast_run_is_not_a_timeout() {
+        let outcome = run_forked_with_timeout(|| (), Duration::from_secs(30));
+        assert_eq!(outcome, RunOutcome::Ok);
+    }
+
     #[test]
     fn signal_and_panic_have_distinct_signatures() {
         let sig = RunOutcome::Signal(libc::SIGSEGV).signature();
@@ -423,6 +577,11 @@ mod tests {
         let path = path.expect("abort should be saved as a reproducer");
         assert!(path.exists(), "reproducer file must exist on disk");
         assert_eq!(std::fs::read(&path).unwrap(), input);
+
+        // The .meta sibling makes the artifact self-describing for triage.
+        let meta = std::fs::read_to_string(path.with_extension("txt.meta")).unwrap();
+        assert!(meta.contains("target: synthetic"), "meta: {meta}");
+        assert!(meta.contains("signature: signal:SIGABRT"), "meta: {meta}");
 
         let outcome2 = run_forked(|| std::process::abort());
         assert!(reporter.report("synthetic", input, &outcome2).is_none());

--- a/crates/rue-fuzz/src/main.rs
+++ b/crates/rue-fuzz/src/main.rs
@@ -23,7 +23,7 @@ pub mod harness;
 mod mutate;
 mod targets;
 
-use harness::{CrashReporter, RunOutcome, run_forked};
+use harness::{CrashReporter, DEFAULT_PER_INPUT_TIMEOUT, RunOutcome, run_forked_with_timeout};
 use std::path::Path;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -48,6 +48,7 @@ pub struct FuzzStats {
     pub crashes: u64,
     pub panics: u64,
     pub signals: u64,
+    pub timeouts: u64,
     pub unique_crashes: u64,
     pub elapsed: Duration,
 }
@@ -66,11 +67,12 @@ impl std::fmt::Display for FuzzStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "runs: {}, crashes: {} (panics: {}, signals: {}, unique: {}), exec/s: {:.1}, elapsed: {:.1}s",
+            "runs: {}, crashes: {} (panics: {}, signals: {}, timeouts: {}, unique: {}), exec/s: {:.1}, elapsed: {:.1}s",
             self.runs,
             self.crashes,
             self.panics,
             self.signals,
+            self.timeouts,
             self.unique_crashes,
             self.exec_per_sec(),
             self.elapsed.as_secs_f64()
@@ -86,6 +88,13 @@ pub struct FuzzConfig {
     pub mutate: bool,
     pub crash_dir: Option<PathBuf>,
     pub print_interval: u64,
+    /// Wall-clock budget per input; a child still running after this is
+    /// SIGKILLed and counted as a Timeout crash.
+    pub per_input_timeout: Duration,
+    /// Mutation RNG seed. `None` = derive from the clock (each run explores a
+    /// fresh sequence); the chosen seed is printed so any run can be replayed
+    /// with `--seed=`.
+    pub seed: Option<u64>,
 }
 
 impl Default for FuzzConfig {
@@ -96,6 +105,8 @@ impl Default for FuzzConfig {
             mutate: false,
             crash_dir: None,
             print_interval: 1000,
+            per_input_timeout: DEFAULT_PER_INPUT_TIMEOUT,
+            seed: None,
         }
     }
 }
@@ -121,6 +132,7 @@ pub fn run_fuzzer<T: FuzzTarget + ?Sized>(
     let mut runs: u64 = 0;
     let mut panics: u64 = 0;
     let mut signals: u64 = 0;
+    let mut timeouts: u64 = 0;
     let mut crashes: u64 = 0;
 
     // Reproducer writing + dedup lives here; each distinct crash signature is
@@ -128,7 +140,20 @@ pub fn run_fuzzer<T: FuzzTarget + ?Sized>(
     // can't bury the crashes dir under thousands of identical files.
     let mut reporter = CrashReporter::new(config.crash_dir.clone());
 
-    let mut rng = mutate::SimpleRng::new(42);
+    // A fixed default seed would make every nightly run explore a byte-identical
+    // input sequence (a regression re-run, not fuzzing). Default to a per-run
+    // seed and print it so any run is still reproducible.
+    let seed = config.seed.unwrap_or_else(|| {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos() as u64)
+            .unwrap_or(42)
+    });
+    eprintln!(
+        "[{}] seed: {seed} (replay with --seed={seed})",
+        target.name()
+    );
+    let mut rng = mutate::SimpleRng::new(seed);
 
     loop {
         let elapsed = start.elapsed();
@@ -153,13 +178,14 @@ pub fn run_fuzzer<T: FuzzTarget + ?Sized>(
         // Run each input in a forked child so that *aborts* (stack overflow,
         // OOM, SIGABRT/SIGSEGV/SIGFPE) are detected via the child's wait-status,
         // not just Rust panics. This is the core RUE-43 fix.
-        let outcome = run_forked(|| target.fuzz(&input));
+        let outcome = run_forked_with_timeout(|| target.fuzz(&input), config.per_input_timeout);
 
         if outcome.is_crash() {
             crashes += 1;
             match &outcome {
                 RunOutcome::Panic(_) => panics += 1,
                 RunOutcome::Signal(_) => signals += 1,
+                RunOutcome::Timeout(_) => timeouts += 1,
                 RunOutcome::Ok => unreachable!(),
             }
             reporter.report(target.name(), &input, &outcome);
@@ -173,6 +199,7 @@ pub fn run_fuzzer<T: FuzzTarget + ?Sized>(
                 crashes,
                 panics,
                 signals,
+                timeouts,
                 unique_crashes: reporter.unique_crashes,
                 elapsed,
             };
@@ -185,6 +212,7 @@ pub fn run_fuzzer<T: FuzzTarget + ?Sized>(
         crashes,
         panics,
         signals,
+        timeouts,
         unique_crashes: reporter.unique_crashes,
         elapsed: start.elapsed(),
     })
@@ -231,6 +259,11 @@ fn main() {
             config.crash_dir = Some(PathBuf::from(&arg["--crash-dir=".len()..]));
         } else if arg.starts_with("--print-interval=") {
             config.print_interval = arg["--print-interval=".len()..].parse().unwrap_or(1000);
+        } else if arg.starts_with("--per-input-timeout=") {
+            let secs: u64 = arg["--per-input-timeout=".len()..].parse().unwrap_or(5);
+            config.per_input_timeout = Duration::from_secs(secs.max(1));
+        } else if arg.starts_with("--seed=") {
+            config.seed = arg["--seed=".len()..].parse().ok();
         } else if !arg.starts_with('-') {
             if target_name.is_none() {
                 target_name = Some(arg.clone());
@@ -304,8 +337,12 @@ fn main() {
             eprintln!("\nFuzzing complete: {}", stats);
             if stats.crashes > 0 {
                 eprintln!(
-                    "Found {} crash(es): {} panic(s), {} signal(s); {} unique reproducer(s) saved.",
-                    stats.crashes, stats.panics, stats.signals, stats.unique_crashes
+                    "Found {} crash(es): {} panic(s), {} signal(s), {} timeout(s); {} unique reproducer(s) saved.",
+                    stats.crashes,
+                    stats.panics,
+                    stats.signals,
+                    stats.timeouts,
+                    stats.unique_crashes
                 );
                 std::process::exit(1);
             }
@@ -334,18 +371,21 @@ fn print_usage(program: &str) {
         program
     );
     eprintln!();
+    // Driven from all_targets() so this list can't drift from reality again
+    // (it used to omit emitter/emitter_sequence).
     eprintln!("Targets:");
-    eprintln!("  lexer       Fuzz the lexer (tokenization)");
-    eprintln!("  parser      Fuzz the parser (AST construction)");
-    eprintln!("  sema        Fuzz semantic analysis (type checking, inference)");
-    eprintln!("  compiler    Fuzz the full frontend (through sema)");
+    for target in targets::all_targets() {
+        eprintln!("  {}", target.name());
+    }
     eprintln!();
     eprintln!("Options:");
-    eprintln!("  --mutate              Enable input mutation");
-    eprintln!("  --max-time=<secs>     Maximum time to run");
-    eprintln!("  --max-runs=<n>        Maximum number of runs");
-    eprintln!("  --crash-dir=<dir>     Directory to save crashes");
-    eprintln!("  --print-interval=<n>  Print progress every N runs");
+    eprintln!("  --mutate                   Enable input mutation");
+    eprintln!("  --max-time=<secs>          Maximum time to run");
+    eprintln!("  --max-runs=<n>             Maximum number of runs");
+    eprintln!("  --crash-dir=<dir>          Directory to save crashes");
+    eprintln!("  --print-interval=<n>       Print progress every N runs");
+    eprintln!("  --per-input-timeout=<secs> Kill+report inputs running longer (default 5)");
+    eprintln!("  --seed=<n>                 Mutation RNG seed (default: per-run, printed)");
     eprintln!();
     eprintln!("Examples:");
     eprintln!("  {} --init-corpus corpus/", program);

--- a/crates/rue-fuzz/src/targets.rs
+++ b/crates/rue-fuzz/src/targets.rs
@@ -5,11 +5,31 @@
 //! - Parser: AST construction
 //! - Sema: semantic analysis (type checking, name resolution)
 //! - Compiler: full compilation pipeline (frontend only, no codegen)
-//! - Emitter: x86-64 instruction encoding
-//! - Regalloc: register allocation stress testing
+//! - Emitter: x86-64 instruction encoding (single instructions and sequences)
 
 use super::FuzzTarget;
 use rue_codegen::x86_64::{Emitter, Operand, Reg, X86Inst, X86Mir};
+
+/// Panic if the frontend reported an *internal* error.
+///
+/// A graceful ICE (`ice_error!` -> `ErrorKind::InternalError`) is an ordinary
+/// `Err` value, not a panic — so without this check the harness classifies it
+/// as a clean run and the #1 thing fuzzing exists to find is invisible.
+/// Panicking here (in the forked child) surfaces it with the ICE text as its
+/// dedup signature. Legitimate user-facing errors pass through silently.
+fn assert_no_ice<T>(result: &rue_compiler::MultiErrorResult<T>) {
+    if let Err(errors) = result {
+        for e in errors.iter() {
+            if matches!(
+                e.kind,
+                rue_compiler::ErrorKind::InternalError(_)
+                    | rue_compiler::ErrorKind::InternalCodegenError(_)
+            ) {
+                panic!("graceful ICE: {e}");
+            }
+        }
+    }
+}
 
 /// Fuzz target for the lexer.
 ///
@@ -83,7 +103,8 @@ impl FuzzTarget for SemaTarget {
             // - Affine type checking (partial moves, linearity)
             // - Name resolution
             // - Multi-error collection
-            let _ = rue_compiler::compile_frontend(source);
+            let result = rue_compiler::compile_frontend(source);
+            assert_no_ice(&result);
         }
     }
 }
@@ -103,7 +124,8 @@ impl FuzzTarget for CompilerTarget {
         if let Ok(source) = std::str::from_utf8(input) {
             // Use compile_frontend to avoid code generation (which is slower)
             // and focus on the analysis phases where bugs are more likely
-            let _ = rue_compiler::compile_frontend(source);
+            let result = rue_compiler::compile_frontend(source);
+            assert_no_ice(&result);
         }
     }
 }


### PR DESCRIPTION
Fixes from the **rue-fuzz + fuzz-CI component review** (dimensions → find → adversarially verify; 20 confirmed findings). Three finder lenses independently converged on the timeout hole. The headline discovery wasn't code at all: **nightly fuzzing has been finding a real sema crash since at least 2026-07-03, and the notification step has been silently failing** — recovered, minimized, and filed as RUE-381.

## Harness: hangs are now a detected failure class
`run_forked` reaped the child with a blocking `waitpid` (and read the panic pipe unboundedly before that), so an input that makes the compiler loop or blow up superlinearly wedged the fuzzer forever — the hang/DoS bug class was undetectable, the exact analog of the RUE-43 abort blindness. Every input now runs under a wall-clock deadline (default 5s, `--per-input-timeout=`): the pipe read is `poll`-bounded, the reap is `WNOHANG`-polled, and at the deadline the child is SIGKILLed and reported as `RunOutcome::Timeout` with its own dedup signature.

Verified end-to-end with the RUE-374 superlinear-parse input: previously the fuzzer ignored its own `--max-time=3` and had to be killed externally; now the same corpus completes in 4s, reports `timeout: hung for more than 2s`, saves a deduped reproducer, and exits 1. Three new unit tests pin the behavior.

## Targets: graceful ICEs are now visible
`ice_error!` produces an ordinary `Err(ErrorKind::InternalError)` — not a panic — so the sema/compiler targets' `let _ = compile_frontend(...)` classified every graceful ICE as a clean run. They now panic (in the forked child) on `InternalError`/`InternalCodegenError`, surfacing the #1 thing fuzzing exists to find, with the ICE text as the dedup signature.

## CI: crashes get reported, one crash no longer kills the night
- **`permissions: issues: write`** — the "Create issue on failure" step has failed with `Resource not accessible by integration` on every triggering run (verified on runs 28693637013 and 28636785233); zero fuzz-crash issues were ever filed.
- Fuzz steps are `continue-on-error` with a failing aggregation step: a sema crash used to skip compiler/emitter/differential entirely (observed in both real runs), silently reducing the night to lexer+parser coverage.
- New crashes while a fuzz-crash issue is open now **comment** on it instead of being suppressed.
- `timeout-minutes` on the job and each step (defense in depth alongside the per-input timeout).

## Smaller items
- Reproducers get a `.meta` sibling (target/signature/description) — the crash class previously survived only as a non-invertible hash in the filename.
- Mutation seed defaults to per-run entropy, printed for `--seed=` replay: the hardcoded `SimpleRng::new(42)` made every nightly run explore a byte-identical input sequence.
- Purged the dead regalloc generator ladder (`arb_x86_mir_with_vregs`/`arb_operand`/`arb_virtual_operand`/`arb_label_id` — zero call sites) and the stale "Regalloc target" doc claims; `--help` targets are driven from `all_targets()` so the list can't drift again (it omitted both emitter targets).
- `cache-probe.yml`: `set -o pipefail` so a failed measured build fails the step.

Follow-ups filed in Linear: RUE-381 (the recovered sema ICE, currently killing the nightly pipeline), plus generator-coverage and dedup-granularity issues.

Full suite green locally (25 targets, incl. 55 rue-fuzz unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
