### PR TITLE
Spec prose rubric + template chapters 4.5/4.6/4.9/4.10 (RUE-202)

### DIFF
--- a/crates/rue-spec/cases/expressions/blocks.toml
+++ b/crates/rue-spec/cases/expressions/blocks.toml
@@ -36,7 +36,7 @@ exit_code = 30
 
 [[case]]
 name = "block_empty_is_unit"
-spec = ["4.5:3"]
+spec = ["4.5:7"]
 source = """
 fn do_nothing() {
     {}

--- a/crates/rue-spec/cases/expressions/if.toml
+++ b/crates/rue-spec/cases/expressions/if.toml
@@ -10,7 +10,7 @@ description = "If expressions conditionally execute branches based on a boolean 
 
 [[case]]
 name = "if_condition_true"
-spec = ["4.6:1", "4.6:2", "4.6:7"]
+spec = ["4.6:1", "4.6:2", "4.6:7", "4.6:10"]
 source = """
 fn main() -> i32 {
     if true { 42 } else { 0 }
@@ -167,7 +167,7 @@ exit_code = 42
 
 [[case]]
 name = "execute_then_branch"
-spec = ["4.6:7"]
+spec = ["4.6:7", "4.6:11"]
 source = """
 fn main() -> i32 {
     let mut x = 0;

--- a/docs/process/code-review.md
+++ b/docs/process/code-review.md
@@ -49,7 +49,7 @@ Are changes adequately tested?
 
 If the change affects language semantics:
 - Is `docs/spec/src/` updated?
-- Do spec paragraphs have proper IDs (`r[X.Y:Z#category]`)?
+- Do spec paragraphs have proper ID markers (`{{ rule(id="X.Y:Z", cat="category") }}`)? Does the prose follow [the spec prose rubric](spec-prose-rubric.md)?
 - Do spec tests reference the new paragraphs?
 - Will traceability check pass (100% coverage required)?
 

--- a/docs/process/implementation.md
+++ b/docs/process/implementation.md
@@ -45,8 +45,9 @@ Follow this order for consistent, reviewable changes:
 ### 1. Update Specification (if changing language semantics)
 
 Edit files in `docs/spec/src/`:
-- Add or modify paragraphs with proper IDs: `r[X.Y:Z#category]`
-- Categories: `normative`, `legality-rule`, `dynamic-semantics`, `syntax`, `example`, `informative`
+- Add or modify paragraphs with proper ID markers: `{{ rule(id="X.Y:Z", cat="category") }}`
+- Categories: `normative`, `legality-rule`, `dynamic-semantics`, `syntax`, `undefined-behavior` (gated — require test coverage); `example`, `informative` (not gated)
+- Prose register, ID discipline, and the folk-term ban: see [the spec prose rubric](spec-prose-rubric.md)
 
 ### 2. Add Tests First
 

--- a/docs/process/spec-prose-rubric.md
+++ b/docs/process/spec-prose-rubric.md
@@ -1,0 +1,151 @@
+# The Spec Prose Rubric (RUE-202)
+
+How to rewrite a prose-spec chapter against the formal core. Following this
+rubric, a chapter rewrite is a **fill-in-the-checklist task, not a design
+task**. If a step forces a choice the rubric doesn't cover, stop and escalate
+(see "What escalates" at the end) — that is the signal you have left rubric
+territory.
+
+Template PRs to copy the shape of: the ch-4.5/4.6/4.9/4.10 pass (this rubric's
+companion PR), the ch-5 statements pass (#1153), and the ch-7 arrays pass
+(#1164). The register to imitate: `3.4:3–4` (never coercion), `5.2:11`,
+`3.8:76` — each states one claim, names the core rule that governs it, and
+stops.
+
+## The one law: IDs are permanent
+
+A paragraph ID (`X.Y:Z`) is an **explicit string key**, not a position. The
+traceability checker (`crates/rue-spec/src/traceability.rs`) keys every
+paragraph by the literal `id="X.Y:Z"` in its `{{ rule(...) }}` marker and
+fails the build on: a test referencing a nonexistent ID (orphan), a normative
+paragraph with no test, or a duplicated ID.
+
+Therefore:
+
+- **Never renumber, reuse, or delete an ID.** Rewording under a stable ID is
+  always safe; renumbering breaks every test that cites the old ID *and*
+  strands the new one uncovered.
+- **Reordering paragraphs is free.** Physical order in the file is
+  meaningless to the checker (chapter 3.8 already runs :1, :2, :3, :4, :76,
+  :14, …). Put paragraphs in the best reading order; the IDs stay.
+- **New claims get fresh IDs** — the next integer above the section's current
+  maximum (check the whole file; numbering is not contiguous).
+- **Never emit the same ID twice**, even transiently (last-writer-wins would
+  silently erase the earlier rule's coverage obligation).
+
+## Procedure
+
+1. **Inventory.** List the chapter's paragraph IDs, categories, and per-ID
+   test counts (`grep -rn '"X.Y:' crates/rue-spec/cases/`). High-count IDs are
+   load-bearing: reword freely, but their *claim* must keep its meaning.
+2. **Classify each paragraph's defects** (any of):
+   - *folk-term* — see the banned-terms table below;
+   - *multi-claim* — two independently-testable claims under one ID;
+   - *miscategorized* — e.g. an EBNF block as `normative` (should be
+     `syntax`), a runtime-behavior rule as `normative` (should be
+     `dynamic-semantics`), rationale inside a normative rule;
+   - *uncited* — a value/ownership/evaluation claim with no core-calculus
+     citation;
+   - *missing denotation* — the construct's rules give its type and legality
+     but never say **what value it evaluates to**;
+   - *restated ownership* — the paragraph re-asserts a rule owned by 3.8/3.9/
+     6.1 instead of cross-referencing it.
+3. **Rewrite,** applying the register rules below.
+4. **Split multi-claim paragraphs.** The old ID keeps the claim its existing
+   tests actually exercise (read the tests to decide); each split-out claim
+   gets a fresh ID.
+5. **Wire coverage.** Every new ID in a gated category (`normative`,
+   `legality-rule`, `dynamic-semantics`, `syntax`, `undefined-behavior`)
+   needs ≥1 test reference **in the same PR**. Prefer adding the new ID to an
+   existing case that already exercises the claim; write a new case only if
+   none does. Category changes *within* the gated set are coverage-neutral.
+6. **Verify.** Every claim you sharpened must be checked against the
+   compiler by **executing a program** (`scripts/rue exec`), not by reading
+   code. Then run the gates:
+   ```bash
+   ./buck2 run //crates/rue-spec:rue-spec -- --traceability
+   ./buck2 run //crates/rue-spec:rue-spec -- "<chapter keyword>"
+   ```
+   and `./test.sh` before the PR.
+7. **PR** with a per-ID change table (ID → what changed → why), and
+   `Part of RUE-202` in the body.
+
+## Register rules
+
+- **One claim per gated ID.** A paragraph in a gated category asserts exactly
+  one independently-testable thing. Clarifying cross-references in
+  parentheses are not claims and are welcome. Rationale is a claim about *why*
+  — it moves to its own `cat="informative"` paragraph.
+- **Cite the core.** Every claim about value denotation, evaluation order,
+  ownership effects, or drops cites the governing rule with the established
+  convention:
+  `(core calculus \`docs/formal/01-core-calculus.md\` §X.Y, rule \`(Name)\`)`.
+  If no core rule covers your claim, the chapter is blocked on a core gap:
+  **file the gap, do not invent the rule.**
+- **Categories.** `syntax` for grammar blocks; `legality-rule` for
+  compile-time rejections (use **MUST**); `dynamic-semantics` for what
+  happens at run time; `normative` for definitional/static claims that are
+  neither; `informative` for rationale, navigation, and restatements;
+  `example` for code. A gated claim must never sit in a no-`cat` paragraph
+  (no-`cat` defaults to informative and silently loses its coverage
+  obligation).
+- **Cross-reference, don't restate.** Ownership rules belong to 3.8/3.9,
+  parameter modes to 6.1, coercion to 3.4. An expression chapter states its
+  own value/type/legality rules and points elsewhere in one sentence
+  (`cat="informative"`) for the interactions. A restatement drifts; a
+  reference cannot.
+- **State the denotation.** Every expression form's chapter must contain a
+  `dynamic-semantics` (or `normative`) paragraph saying what the form
+  **evaluates to**, cited to the core. "Its type is T" is not a denotation.
+
+## Banned folk-terms
+
+| Folk phrasing | Replace with |
+|---|---|
+| "implicit return", "implicitly returns" | the body is an expression; a sequence evaluates to its tail, a call to its body's value (core §4.3, §6.7, §6.9) |
+| "the implicit `()`" | "the `()` of the omitted form (4.9:3)" — name the desugaring rule |
+| "destroyed", "cleaned up", "freed" (of a binding) | "dropped" + cite 3.9 and core §6.7/§6.11 |
+| "goes out of scope" (as the operative event) | "leaves scope; its drop obligation is specified by 3.9:18" |
+| "compatible with" (of types) | "**identical to**, up to the one never-type coercion (3.4:3)" |
+| "consumed", "used up" (undefined) | cite the definition of *use* (3.8:76; core §4.2) |
+| "executed" (of expressions) | "evaluated" (statements execute; expressions evaluate to values) |
+| bare "evaluates to" with no rule | keep the phrase, add the denotation content and the core citation — the phrase is fine; a missing rule is not |
+
+## What escalates to a maintainer (file an issue, stop)
+
+- Any suspected **behavior difference** between the prose claim and the
+  compiler (verify by execution first; file with the repro, framed as a
+  hypothesis).
+- Any **core gap** — a claim the core has no rule for.
+- Any proposal to change what a rule *means* (this rubric covers register,
+  not semantics).
+- Reclassifying a **tested** paragraph out of the gated set (dropping a
+  coverage obligation needs judgment).
+- New `undefined-behavior`/`unspecified` classifications (ADR-0036 owns that
+  decision).
+
+## Worked example (from the template PR)
+
+Before (4.9:4, `legality-rule`):
+
+> The expression following `return` (or the implicit `()`) **MUST** have a
+> type compatible with the function's declared return type.
+
+Defects: folk-term ("the implicit `()`"), vague "compatible with" (Rue has
+exactly one coercion), no citation.
+
+After:
+
+> The operand of `return` — the written expression, or the `()` of the
+> omitted form (4.9:3) — **MUST** have the function's declared return type.
+> As everywhere, the one admitted coercion is from the never type (3.4:3); no
+> other type difference is accepted.
+
+Same ID, same tests, same meaning — now stated so a second implementation
+could not misread it.
+
+---
+
+*Marker syntax note: the live paragraph-marker format is the Zola shortcode
+`{{ rule(id="X.Y:Z", cat="category") }}`. The `r[X.Y:Z#category]` form that
+appears in some older process docs is stale — do not use it.*

--- a/docs/spec/src/04-expressions/05-block-expressions.md
+++ b/docs/spec/src/04-expressions/05-block-expressions.md
@@ -10,7 +10,7 @@ template = "spec/page.html"
 
 A block expression is a sequence of statements followed by an optional expression, enclosed in braces.
 
-{{ rule(id="4.5:2", cat="normative") }}
+{{ rule(id="4.5:2", cat="syntax") }}
 
 ```ebnf
 block_expr = "{" { statement } [ expression ] "}" ;
@@ -18,7 +18,11 @@ block_expr = "{" { statement } [ expression ] "}" ;
 
 {{ rule(id="4.5:3", cat="normative") }}
 
-A block expression evaluates to the value of its final expression, and its type is the type of that expression. If the block has no final expression (it ends with a statement, or is empty), it evaluates to `()` and has type `()`.
+A block expression with a final expression evaluates to that expression's value, and its type is that expression's type. (A block elaborates to a `let`/sequence chain, and a sequence evaluates to its tail — core calculus `docs/formal/01-core-calculus.md` §4.3, §6.7.)
+
+{{ rule(id="4.5:7", cat="normative") }}
+
+A block expression with no final expression — one that ends with a statement, or is empty — evaluates to `()` and has type `()`.
 
 {{ rule(id="4.5:4", cat="normative") }}
 
@@ -37,6 +41,6 @@ fn main() -> i32 {
 }
 ```
 
-{{ rule(id="4.5:6", cat="normative") }}
+{{ rule(id="4.5:6", cat="dynamic-semantics") }}
 
-When a block exits, all local variables declared in that block are destroyed.
+When a block exits, the live bindings declared in it are dropped, newest-first (3.9:4, 3.9:18; core calculus `docs/formal/01-core-calculus.md` §6.7, rule `(D-EndScope)`).

--- a/docs/spec/src/04-expressions/06-if-expressions.md
+++ b/docs/spec/src/04-expressions/06-if-expressions.md
@@ -8,7 +8,7 @@ template = "spec/page.html"
 
 {{ rule(id="4.6:1", cat="normative") }}
 
-An if expression conditionally executes one of two branches based on a boolean condition.
+An if expression conditionally evaluates one of two branches based on a boolean condition.
 
 {{ rule(id="4.6:2", cat="syntax") }}
 
@@ -23,7 +23,11 @@ The condition expression **MUST** have type `bool`.
 
 {{ rule(id="4.6:4", cat="legality-rule") }}
 
-If an `else` branch is present, both branches **MUST** have the same type. The type of the if expression is the type of its branches.
+If an `else` branch is present, both branches **MUST** have the same type. (A diverging branch has type `!`, which coerces to the other branch's type — 3.4:3; core calculus `docs/formal/01-core-calculus.md` §5.7, rule `(Sub-Never)`.)
+
+{{ rule(id="4.6:10", cat="normative") }}
+
+The type of an if expression with an `else` branch is the common type of its branches (core calculus `docs/formal/01-core-calculus.md` §5.5, rule `(If)`).
 
 {{ rule(id="4.6:5", cat="legality-rule") }}
 
@@ -38,9 +42,13 @@ fn main() -> i32 {
 }
 ```
 
-{{ rule(id="4.6:7", cat="normative") }}
+{{ rule(id="4.6:7", cat="dynamic-semantics") }}
 
-If the condition evaluates to `true`, the then-branch is evaluated and the `if` expression evaluates to the then-branch's value; otherwise the else-branch (if present) is evaluated and the `if` expression evaluates to its value. When no else-branch is present, the `if` expression evaluates to `()`.
+The condition is evaluated first. If it evaluates to `true`, the then-branch is evaluated and the if expression evaluates to the then-branch's value; otherwise the else-branch is evaluated and the if expression evaluates to the else-branch's value (core calculus `docs/formal/01-core-calculus.md` §6.6, rules `(D-If-T)`/`(D-If-F)`).
+
+{{ rule(id="4.6:11", cat="dynamic-semantics") }}
+
+An if expression with no `else` branch evaluates to `()`: when the condition is `false` no branch is evaluated and the expression's value is `()`, and when it is `true` the then-branch's value is `()` by rule 4.6:5.
 
 {{ rule(id="4.6:8") }}
 
@@ -63,3 +71,7 @@ fn main() -> i32 {
     else { 3 }
 }
 ```
+
+{{ rule(id="4.6:12", cat="informative") }}
+
+The branches of an if expression also reconcile their *ownership* effects: each branch is checked under the same incoming ownership state, and the states are joined after the branch (3.8:50, 3.8:73; core calculus `docs/formal/01-core-calculus.md` §5.5). That interaction is specified in section 3.8, not here.

--- a/docs/spec/src/04-expressions/09-return-expressions.md
+++ b/docs/spec/src/04-expressions/09-return-expressions.md
@@ -10,7 +10,7 @@ template = "spec/page.html"
 
 A return expression exits the current function and provides its return value.
 
-{{ rule(id="4.9:2", cat="normative") }}
+{{ rule(id="4.9:2", cat="syntax") }}
 
 ```ebnf
 return_expr = "return" expression? ;
@@ -22,11 +22,15 @@ If the expression is omitted, it is equivalent to `return ()`.
 
 {{ rule(id="4.9:4", cat="legality-rule") }}
 
-The expression following `return` (or the implicit `()`) **MUST** have a type compatible with the function's declared return type.
+The operand of `return` — the written expression, or the `()` of the omitted form (4.9:3) — **MUST** have the function's declared return type. As everywhere, the one admitted coercion is from the never type (3.4:3); no other type difference is accepted.
 
 {{ rule(id="4.9:5", cat="normative") }}
 
-A return expression has the never type `!` because it never produces a local value.
+A return expression has the never type `!` (core calculus `docs/formal/01-core-calculus.md` §5.7, rule `(Return)`).
+
+{{ rule(id="4.9:11", cat="informative") }}
+
+`return` transfers control away instead of yielding a value to its own surrounding context; 3.4:2 lists the control-transfer forms that have type `!`.
 
 {{ rule(id="4.9:6") }}
 
@@ -43,13 +47,13 @@ fn main() -> i32 {
 }
 ```
 
-{{ rule(id="4.9:7", cat="normative") }}
+{{ rule(id="4.9:7", cat="dynamic-semantics") }}
 
-When a return expression is evaluated, the function immediately returns the value of the expression. No further code in the function is executed.
+When a return expression is evaluated, its operand's value becomes the function's return value and control leaves the function: the live bindings of the function's still-open scopes are dropped (3.9:18), and no further expression in the function is evaluated (core calculus `docs/formal/01-core-calculus.md` §6.9, rule `(D-Return)`).
 
 {{ rule(id="4.9:8", cat="normative") }}
 
-Because return has type `!`, it can appear in contexts that expect any type.
+Because a return expression has type `!`, it may appear in any context where a value of any type is expected (3.4:4).
 
 {{ rule(id="4.9:9") }}
 

--- a/docs/spec/src/04-expressions/10-call-expressions.md
+++ b/docs/spec/src/04-expressions/10-call-expressions.md
@@ -10,11 +10,16 @@ template = "spec/page.html"
 
 A call expression invokes a function with a list of arguments.
 
-{{ rule(id="4.10:2", cat="normative") }}
+{{ rule(id="4.10:2", cat="syntax") }}
 
 ```ebnf
-call_expr = expression "(" [ expression { "," expression } ] ")" ;
+call_expr = expression "(" [ call_arg { "," call_arg } ] ")" ;
+call_arg  = [ "inout" | "borrow" ] expression ;
 ```
+
+{{ rule(id="4.10:10", cat="informative") }}
+
+An `inout` or `borrow` argument must denote a place; that requirement is a post-parse legality rule of the parameter-mode system (6.1:17), not a grammar restriction (see the grammar notes in appendix A).
 
 {{ rule(id="4.10:3", cat="legality-rule") }}
 
@@ -22,19 +27,19 @@ The number of arguments **MUST** match the number of parameters in the function 
 
 {{ rule(id="4.10:4", cat="legality-rule") }}
 
-Each argument type **MUST** be compatible with the corresponding parameter type.
+Each argument's type **MUST** be the corresponding parameter's type. As everywhere, the one admitted coercion is from the never type (3.4:3); no other type difference is accepted (core calculus `docs/formal/01-core-calculus.md` §5.8, rule `(Call)`).
 
 {{ rule(id="4.10:5", cat="normative") }}
 
-The type of a call expression is the function's return type.
+The type of a call expression is the function's declared return type (core calculus `docs/formal/01-core-calculus.md` §5.8, rule `(Call)`).
 
 {{ rule(id="4.10:9", cat="dynamic-semantics") }}
 
-A call expression evaluates to the value produced by invoking the function:
-the callee's body is executed with each parameter bound to the corresponding
-evaluated argument value, and the call expression denotes the value the
-invocation returns (see section 4.9 for how a function produces its return
-value). When the return type is `()`, the call denotes the unit value.
+A call expression evaluates to the value the invocation returns: the callee's body is evaluated with each parameter bound to its corresponding argument — a by-value argument's evaluated value in fresh storage, or, for an `inout`/`borrow` argument, the argument place itself (6.1:18) — and the value the body produces (see 4.5 and 4.9) is the call expression's value (core calculus `docs/formal/01-core-calculus.md` §6.9, rules `(D-Call)`/`(D-Return-Value)`). When the return type is `()`, the call evaluates to `()`.
+
+{{ rule(id="4.10:11", cat="informative") }}
+
+Passing an argument by value is a *use* of it — a move for a non-Copy type, a copy for a Copy type (3.8:11). An `inout`/`borrow` argument is not used; it takes a scoped loan for the call's duration (6.1; core calculus `docs/formal/01-core-calculus.md` §5.4). Those rules are specified in sections 3.8 and 6.1, not here.
 
 {{ rule(id="4.10:6") }}
 
@@ -50,7 +55,7 @@ fn main() -> i32 {
 
 {{ rule(id="4.10:7", cat="normative") }}
 
-Arguments are evaluated left-to-right before the function is called, as specified in section 4.0.
+Arguments are evaluated left-to-right before the function is called, as specified in section 4.0 (core calculus `docs/formal/01-core-calculus.md` §6.2).
 
 {{ rule(id="4.10:8") }}
 


### PR DESCRIPTION
The rubric (`docs/process/spec-prose-rubric.md`) is the multiplier artifact for RUE-202: it converts the remaining chapter rewrites into checklist work — ID permanence (explicit string keys; never renumber), the 7-step procedure, register rules (one claim per gated ID, cite the core, cross-reference don't restate, state the denotation), category discipline, a banned folk-terms table, and escalation triggers. The four rewritten chapters are its worked templates.

## Chapter changes (per-ID)

**4.5 blocks**
- 4.5:2 `normative` → `syntax` (EBNF)
- 4.5:3 narrowed to the final-expression claim + core citation (§4.3, §6.7); **new 4.5:7** = no-final-expression → `()` (split out)
- 4.5:6 `normative` → `dynamic-semantics`; "destroyed" → dropped newest-first, cited to 3.9:4/3.9:18 + `(D-EndScope)`

**4.6 if**
- 4.6:4 multi-claim split (the RUE-202 issue's named example): keeps branch-type-equality + never-coercion cross-ref; **new 4.6:10** = the if's type
- 4.6:7 `normative` → `dynamic-semantics`, cites `(D-If-T)`/`(D-If-F)`; **new 4.6:11** = no-else evaluates to `()`
- **new 4.6:12** (informative) points at the 3.8 branch-join ownership rules instead of restating them

**4.9 return**
- 4.9:4: "the implicit `()`" retired — names the omitted-form rule (4.9:3); "compatible with" → identical up to the one never coercion (3.4:3)
- 4.9:5 rationale split to informative **4.9:11**; cites `(Return)`
- 4.9:7 `normative` → `dynamic-semantics`; now states the return-path drops (3.9:18, `(D-Return)`) instead of "no further code is executed"

**4.10 call**
- 4.10:2 `normative` → `syntax`; EBNF fixed to include `inout`/`borrow` `call_arg` modes (was drifted from appendix A); **new 4.10:10** (informative) for the place requirement (6.1:17)
- 4.10:4 "compatible" → identical up to never, cites `(Call)`
- **new 4.10:11** (informative) cross-references argument-passing ownership (3.8:11, §5.4) instead of restating
- 4.10:9 denotation cited to `(D-Call)`/`(D-Return-Value)`

## Coverage & gates

New gated IDs wired to existing cases in the same PR (`block_empty_is_unit` → 4.5:7; the if type case → 4.6:10; `execute_then_branch` → 4.6:11). Traceability green: 99.3% (only the 5 pre-existing known-uncovered), no orphans, no duplicates. Chapter spec suites pass (62/23/94/67). Also corrects the stale `r[X.Y:Z#category]` marker syntax in `docs/process/{implementation,code-review}.md` to the live shortcode and links the rubric from both.

No semantic changes — register, categories, structure, and citations only.

Part of RUE-202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)