### PR TITLE
[codex] RUE-377: make host target detection fallible

### DIFF
--- a/crates/rue-air/src/sema/analysis/pointers.rs
+++ b/crates/rue-air/src/sema/analysis/pointers.rs
@@ -807,7 +807,9 @@ impl<'a> Sema<'a> {
 
         // Determine variant index based on host architecture (compile-time evaluation)
         // Currently we always compile for the host architecture
-        let variant_index = match rue_target::Target::host().arch() {
+        let host = rue_target::Target::host()
+            .expect("@target_arch() requires a supported Rue host target");
+        let variant_index = match host.arch() {
             Arch::X86_64 => 0,
             Arch::Aarch64 => 1,
         };
@@ -854,7 +856,9 @@ impl<'a> Sema<'a> {
 
         // Determine variant index based on host OS (compile-time evaluation)
         // Currently we always compile for the host OS
-        let variant_index = match rue_target::Target::host().os() {
+        let host =
+            rue_target::Target::host().expect("@target_os() requires a supported Rue host target");
+        let variant_index = match host.os() {
             Os::Linux => 0,
             Os::Macos => 1,
         };

--- a/crates/rue-codegen/src/aarch64/cfg_lower.rs
+++ b/crates/rue-codegen/src/aarch64/cfg_lower.rs
@@ -4915,9 +4915,14 @@ mod tests {
         );
 
         // Use host target for tests
-        CfgLower::new(&cfg_output.cfg, type_pool, &interner, Target::host())
-            .lower()
-            .expect("test lowering should succeed")
+        CfgLower::new(
+            &cfg_output.cfg,
+            type_pool,
+            &interner,
+            Target::host().expect("test lowering requires a supported Rue host target"),
+        )
+        .lower()
+        .expect("test lowering should succeed")
     }
 
     #[test]

--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -172,16 +172,28 @@ static RUNTIME_BYTES: &[u8] = include_bytes!("librue_runtime.a");
 /// asm`, `--emit mir`, ...) fully usable. ADR-0034 describes the full fix
 /// (per-target runtime archives selected at link time).
 fn runtime_for_target(target: Target) -> CompileResult<&'static [u8]> {
-    let host = Target::host();
-    if target == host {
-        Ok(RUNTIME_BYTES)
-    } else {
-        Err(CompileError::without_span(ErrorKind::LinkError(format!(
+    runtime_for_target_with_host(target, Target::host(), Target::host_description())
+}
+
+fn runtime_for_target_with_host(
+    target: Target,
+    host: Option<Target>,
+    host_description: &str,
+) -> CompileResult<&'static [u8]> {
+    match host {
+        Some(host) if target == host => Ok(RUNTIME_BYTES),
+        Some(host) => Err(CompileError::without_span(ErrorKind::LinkError(format!(
             "cannot link an executable for {target}: this rue compiler was built for {host} \
              and only embeds the {host} runtime library, so the result would not run on \
              {target} (RUE-36). Cross-target code generation still works: use \
              `--emit asm` to inspect {target} assembly.",
-        ))))
+        )))),
+        None => Err(CompileError::without_span(ErrorKind::LinkError(format!(
+            "cannot link an executable for {target}: this rue compiler was built on {} \
+             and does not have a supported host runtime to embed (RUE-36). Cross-target \
+             code generation still works: use `--emit asm` to inspect {target} assembly.",
+            host_description
+        )))),
     }
 }
 
@@ -691,7 +703,7 @@ impl Default for LinkerMode {
 ///
 /// ```ignore
 /// let options = CompileOptions {
-///     target: Target::host(),
+///     target: Target::host().unwrap(),
 ///     linker: LinkerMode::Internal,
 ///     opt_level: OptLevel::O1,
 ///     preview_features: PreviewFeatures::new(),
@@ -716,7 +728,8 @@ pub struct CompileOptions {
 impl Default for CompileOptions {
     fn default() -> Self {
         Self {
-            target: Target::host(),
+            target: Target::host()
+                .expect("Rue cannot choose a default compile target on this unsupported host"),
             linker: LinkerMode::Internal,
             opt_level: OptLevel::default(),
             preview_features: PreviewFeatures::new(),
@@ -1889,23 +1902,33 @@ mod tests {
     /// an error that names both targets and points at `--emit asm`.
     #[test]
     fn test_runtime_only_available_for_host_target() {
-        assert!(runtime_for_target(Target::host()).is_ok());
+        let host = Target::host().unwrap();
+        assert!(runtime_for_target(host).is_ok());
 
         for &target in Target::all() {
-            if target == Target::host() {
+            if target == host {
                 continue;
             }
             let err =
                 runtime_for_target(target).expect_err("cross-target link must be refused (RUE-36)");
             let msg = err.to_string();
             assert!(msg.contains(&target.to_string()), "names target: {msg}");
-            assert!(
-                msg.contains(&Target::host().to_string()),
-                "names host: {msg}"
-            );
+            assert!(msg.contains(&host.to_string()), "names host: {msg}");
             assert!(msg.contains("RUE-36"), "references RUE-36: {msg}");
             assert!(msg.contains("--emit asm"), "suggests --emit asm: {msg}");
         }
+    }
+
+    #[test]
+    fn test_runtime_refused_on_unsupported_host() {
+        let err = runtime_for_target_with_host(Target::X86_64Linux, None, "x86-64-macos")
+            .expect_err("unsupported host must not link by pretending to be another target");
+        let msg = err.to_string();
+
+        assert!(msg.contains("x86-64-linux"), "names target: {msg}");
+        assert!(msg.contains("x86-64-macos"), "names host: {msg}");
+        assert!(msg.contains("RUE-36"), "references RUE-36: {msg}");
+        assert!(msg.contains("--emit asm"), "suggests --emit asm: {msg}");
     }
 
     #[test]

--- a/crates/rue-linker/src/linker.rs
+++ b/crates/rue-linker/src/linker.rs
@@ -1778,7 +1778,10 @@ impl Linker {
 
 impl Default for Linker {
     fn default() -> Self {
-        Self::new(Target::host())
+        Self::new(
+            Target::host()
+                .expect("Rue linker cannot choose a default target on this unsupported host"),
+        )
     }
 }
 

--- a/crates/rue-target/src/lib.rs
+++ b/crates/rue-target/src/lib.rs
@@ -21,33 +21,36 @@ pub enum Target {
 impl Target {
     /// Detect the host target at compile time.
     ///
-    /// Returns the target that matches the current compilation environment.
-    /// This is useful for defaulting to native compilation.
-    #[cfg(all(target_arch = "x86_64", target_os = "linux"))]
-    pub fn host() -> Self {
-        Target::X86_64Linux
+    /// Returns `None` when the current compilation environment is not a
+    /// supported Rue target. Callers that need a default target must handle
+    /// that case explicitly instead of silently compiling for some other
+    /// platform.
+    pub fn host() -> Option<Self> {
+        if cfg!(all(target_arch = "x86_64", target_os = "linux")) {
+            Some(Target::X86_64Linux)
+        } else if cfg!(all(target_arch = "aarch64", target_os = "linux")) {
+            Some(Target::Aarch64Linux)
+        } else if cfg!(all(target_arch = "aarch64", target_os = "macos")) {
+            Some(Target::Aarch64Macos)
+        } else {
+            None
+        }
     }
 
-    #[cfg(all(target_arch = "aarch64", target_os = "linux"))]
-    pub fn host() -> Self {
-        Target::Aarch64Linux
-    }
-
-    #[cfg(all(target_arch = "aarch64", target_os = "macos"))]
-    pub fn host() -> Self {
-        Target::Aarch64Macos
-    }
-
-    #[cfg(not(any(
-        all(target_arch = "x86_64", target_os = "linux"),
-        all(target_arch = "aarch64", target_os = "linux"),
-        all(target_arch = "aarch64", target_os = "macos")
-    )))]
-    pub fn host() -> Self {
-        // For unsupported hosts, default to x86-64 Linux as a reasonable
-        // cross-compilation target. This allows the compiler to be built
-        // and tested on any platform.
-        Target::X86_64Linux
+    /// Returns a best-effort name for the host this compiler binary was built
+    /// for, including unsupported hosts. Used in diagnostics.
+    pub fn host_description() -> &'static str {
+        if cfg!(all(target_arch = "x86_64", target_os = "linux")) {
+            "x86-64-linux"
+        } else if cfg!(all(target_arch = "aarch64", target_os = "linux")) {
+            "aarch64-linux"
+        } else if cfg!(all(target_arch = "aarch64", target_os = "macos")) {
+            "aarch64-macos"
+        } else if cfg!(all(target_arch = "x86_64", target_os = "macos")) {
+            "x86-64-macos"
+        } else {
+            "unsupported host"
+        }
     }
 
     /// Returns the architecture component of this target.
@@ -213,7 +216,7 @@ impl Default for Target {
     /// This allows code to write `Target::default()` instead of `Target::host()`,
     /// which is useful for struct initialization with `..Default::default()`.
     fn default() -> Self {
-        Self::host()
+        Self::host().expect("Rue cannot choose a default target on this unsupported host")
     }
 }
 
@@ -391,7 +394,12 @@ mod tests {
 
     #[test]
     fn test_default_returns_host() {
-        assert_eq!(Target::default(), Target::host());
+        assert_eq!(Target::default(), Target::host().unwrap());
+    }
+
+    #[test]
+    fn test_host_description_present() {
+        assert!(!Target::host_description().is_empty());
     }
 
     #[test]

--- a/crates/rue/src/main.rs
+++ b/crates/rue/src/main.rs
@@ -550,11 +550,21 @@ fn parse_args_from(args: &[&str]) -> ParseResult {
         );
     }
 
+    let Some(final_target) = target.or_else(Target::host) else {
+        eprintln!(
+            "Error: no --target specified and this host ({}) is not a supported Rue target",
+            Target::host_description()
+        );
+        eprintln!("Specify an explicit target with --target <target>.");
+        eprintln!("Valid targets: {}", Target::all_names());
+        return ParseResult::Error;
+    };
+
     ParseResult::Options(Options {
         source_paths,
         output_path: final_output_path,
         emit_stages,
-        target: target.unwrap_or_else(Target::host),
+        target: final_target,
         linker: linker.unwrap_or_default(),
         opt_level: opt_level.unwrap_or_default(),
         preview_features,


### PR DESCRIPTION
## Summary

Fixes RUE-377 by making Rue host-target detection fallible instead of silently falling back to `x86-64-linux` on unsupported hosts.

Changes:

- `Target::host()` now returns `Option<Target>` and returns `None` for unsupported compiler hosts.
- `Target::host_description()` provides a diagnostic name for both supported and known unsupported hosts.
- CLI default target selection now errors cleanly when no `--target` is supplied on an unsupported host.
- executable linking now refuses to embed a runtime on unsupported hosts instead of comparing against a fake Linux host target.
- direct internal default/test call sites now unwrap with explicit messages where a supported host is genuinely required.
- adds a regression test for the unsupported-host runtime refusal path.

## Validation

- `scripts/rue fmt`
- `./buck2 test root//crates/rue-target:rue-target-test root//crates/rue-compiler:rue-compiler-test root//crates/rue:rue-test`
- `./buck2 test root//crates/rue-compiler:rue-compiler-test`
- `scripts/rue test`

Linear: RUE-377

