### PR TITLE
[codex] RUE-372: make scheduler register effects exhaustive

### DIFF
--- a/crates/rue-codegen/src/aarch64/schedule.rs
+++ b/crates/rue-codegen/src/aarch64/schedule.rs
@@ -331,13 +331,30 @@ fn regs_read(inst: &Aarch64Inst) -> Vec<Reg> {
         Aarch64Inst::LdpPost { .. } => {
             result.push(Reg::Sp); // Post-indexed LDP reads SP before writing
         }
-        Aarch64Inst::LdrIndexed { .. }
-        | Aarch64Inst::StrIndexed { .. }
-        | Aarch64Inst::LdrIndexedOffset { .. }
-        | Aarch64Inst::StrIndexedOffset { .. } => {
-            // base is VReg, handled separately
+        Aarch64Inst::LdrIndexed { .. } | Aarch64Inst::LdrIndexedOffset { .. } => {
+            // Pre-regalloc indexed load. The scheduler runs after regalloc,
+            // which rewrites this variant; the virtual base has no physical
+            // register to record here.
         }
-        _ => {}
+        Aarch64Inst::StrIndexed { src, .. } | Aarch64Inst::StrIndexedOffset { src, .. } => {
+            // Pre-regalloc indexed store. The scheduler runs after regalloc,
+            // which rewrites this variant; the virtual base has no physical
+            // register to record here.
+            add_if_phys(src, &mut result);
+        }
+        Aarch64Inst::Cset { .. }
+        | Aarch64Inst::B { .. }
+        | Aarch64Inst::BCond { .. }
+        | Aarch64Inst::Bvs { .. }
+        | Aarch64Inst::Bvc { .. }
+        | Aarch64Inst::Label { .. }
+        | Aarch64Inst::Bl { .. }
+        | Aarch64Inst::Ret
+        | Aarch64Inst::Brk
+        | Aarch64Inst::Svc { .. }
+        | Aarch64Inst::StringConstPtr { .. }
+        | Aarch64Inst::StringConstLen { .. }
+        | Aarch64Inst::StringConstCap { .. } => {}
     }
 
     result
@@ -433,7 +450,18 @@ fn regs_written(inst: &Aarch64Inst) -> Vec<Reg> {
         Aarch64Inst::Bl { .. } => {
             // Clobbers handled separately via clobbers()
         }
-        _ => {}
+        Aarch64Inst::Svc { .. } => {
+            // Clobbers handled separately via clobbers()
+        }
+        Aarch64Inst::B { .. }
+        | Aarch64Inst::BCond { .. }
+        | Aarch64Inst::Bvs { .. }
+        | Aarch64Inst::Bvc { .. }
+        | Aarch64Inst::Cbz { .. }
+        | Aarch64Inst::Cbnz { .. }
+        | Aarch64Inst::Label { .. }
+        | Aarch64Inst::Ret
+        | Aarch64Inst::Brk => {}
     }
 
     result

--- a/crates/rue-codegen/src/x86_64/schedule.rs
+++ b/crates/rue-codegen/src/x86_64/schedule.rs
@@ -365,9 +365,14 @@ fn regs_read(inst: &X86Inst) -> Vec<Reg> {
             add_if_phys(count, &mut result);
         }
         X86Inst::MovRMIndexed { .. } => {
-            // base is VReg, handled separately
+            // Pre-regalloc indexed load. The scheduler runs after regalloc,
+            // which rewrites this variant; the virtual base has no physical
+            // register to record here.
         }
         X86Inst::MovMRIndexed { src, .. } => {
+            // Pre-regalloc indexed store. The scheduler runs after regalloc,
+            // which rewrites this variant; the virtual base has no physical
+            // register to record here.
             add_if_phys(src, &mut result);
         }
         X86Inst::MovRMSib { base, index, .. } => {
@@ -381,7 +386,24 @@ fn regs_read(inst: &X86Inst) -> Vec<Reg> {
             add_if_phys(index, &mut result);
             add_if_phys(src, &mut result);
         }
-        _ => {}
+        X86Inst::StringConstPtr { .. }
+        | X86Inst::StringConstLen { .. }
+        | X86Inst::StringConstCap { .. }
+        | X86Inst::CallRel { .. }
+        | X86Inst::Syscall
+        | X86Inst::Jz { .. }
+        | X86Inst::Jnz { .. }
+        | X86Inst::Jo { .. }
+        | X86Inst::Jno { .. }
+        | X86Inst::Jb { .. }
+        | X86Inst::Jae { .. }
+        | X86Inst::Jbe { .. }
+        | X86Inst::Jge { .. }
+        | X86Inst::Jle { .. }
+        | X86Inst::Jmp { .. }
+        | X86Inst::Label { .. }
+        | X86Inst::Ret
+        | X86Inst::Ud2 => {}
     }
 
     result
@@ -490,7 +512,25 @@ fn regs_written(inst: &X86Inst) -> Vec<Reg> {
         | X86Inst::StringConstCap { dst, .. } => {
             add_if_phys(dst, &mut result);
         }
-        _ => {}
+        X86Inst::CmpRR { .. }
+        | X86Inst::Cmp64RR { .. }
+        | X86Inst::CmpRI { .. }
+        | X86Inst::Cmp64RI { .. }
+        | X86Inst::TestRR { .. }
+        | X86Inst::Test64RR { .. }
+        | X86Inst::Jz { .. }
+        | X86Inst::Jnz { .. }
+        | X86Inst::Jo { .. }
+        | X86Inst::Jno { .. }
+        | X86Inst::Jb { .. }
+        | X86Inst::Jae { .. }
+        | X86Inst::Jbe { .. }
+        | X86Inst::Jge { .. }
+        | X86Inst::Jle { .. }
+        | X86Inst::Jmp { .. }
+        | X86Inst::Label { .. }
+        | X86Inst::Ret
+        | X86Inst::Ud2 => {}
     }
 
     result


### PR DESCRIPTION
## Summary

Fixes RUE-372 by removing the catch-all `_ => {}` arms from both backend scheduler register-effect tables:

- `x86_64::schedule::regs_read`
- `x86_64::schedule::regs_written`
- `aarch64::schedule::regs_read`
- `aarch64::schedule::regs_written`

This makes new MIR instruction variants produce a non-exhaustive-match compile error until their scheduler register effects are intentionally classified, matching the discipline already used by `get_latency`.

The change also makes the pre-regalloc indexed load/store variants explicit in the scheduler tables. The scheduler runs after regalloc, so their virtual base registers are not physical scheduler dependencies; indexed stores still record any physical source operand they carry.

## Validation

- `rg -n '_ => \\{\\}' crates/rue-codegen/src/x86_64/schedule.rs crates/rue-codegen/src/aarch64/schedule.rs` returns no matches
- `scripts/rue fmt`
- `./buck2 test root//crates/rue-codegen:rue-codegen-test`
- `scripts/rue test`

Linear: RUE-372
