### PR TITLE
RUE-381: diagnose deferred generic array lengths

### DIFF
--- a/crates/rue-air/src/sema/declarations.rs
+++ b/crates/rue-air/src/sema/declarations.rs
@@ -1178,6 +1178,12 @@ impl<'a> Sema<'a> {
                     // parameter (`arr: [i32; N]`, RUE-16). Use ComptimeType as a
                     // placeholder - the actual type is determined at
                     // specialization.
+                    //
+                    // The deferred type still needs declaration-time validation
+                    // for array lengths that do *not* depend on specialization:
+                    // `[T; A]` with an undefined `A` should be E0481 here, not
+                    // an ICE when the function is later instantiated (RUE-381).
+                    self.validate_deferred_signature_type_lengths(p.ty, &value_param_names, span)?;
                     Ok(Type::COMPTIME_TYPE)
                 } else {
                     // Regular params OR comptime VALUE params (comptime n: i32)
@@ -1196,6 +1202,11 @@ impl<'a> Sema<'a> {
             // Return type references a type parameter (`-> T`, `-> [T; 3]`) or
             // an array length naming a comptime value parameter (`-> [i32; N]`,
             // RUE-16) - use placeholder, resolved at specialization.
+            self.validate_deferred_signature_type_lengths(
+                return_type_sym,
+                &value_param_names,
+                span,
+            )?;
             Type::COMPTIME_TYPE
         } else {
             // A slice type `[T]` is second-class (ADR-0037, ADR-0043,

--- a/crates/rue-air/src/sema/typeck.rs
+++ b/crates/rue-air/src/sema/typeck.rs
@@ -1182,6 +1182,68 @@ impl<'a> Sema<'a> {
         false
     }
 
+    /// Validate array lengths inside a signature type that will otherwise be
+    /// deferred until generic specialization.
+    ///
+    /// A composite signature such as `[T; 3]` cannot be resolved at declaration
+    /// time because the element type is a comptime type parameter. Its length is
+    /// still a declaration-time legality question, though: `[T; A]` must reject
+    /// an undefined `A` immediately instead of surviving until specialization
+    /// and becoming an ICE (RUE-381). Lengths may be literals, file constants, or
+    /// comptime value parameters owned by the same function.
+    pub(crate) fn validate_deferred_signature_type_lengths(
+        &mut self,
+        type_sym: Spur,
+        value_params: &[Spur],
+        span: Span,
+    ) -> CompileResult<()> {
+        self.validate_deferred_signature_type_name_lengths(
+            self.interner.resolve(&type_sym).to_string(),
+            value_params,
+            span,
+        )
+    }
+
+    fn validate_deferred_signature_type_name_lengths(
+        &mut self,
+        type_name: String,
+        value_params: &[Spur],
+        span: Span,
+    ) -> CompileResult<()> {
+        if let Some((element_type, len)) = parse_array_type_syntax(&type_name) {
+            if let ArrayLen::Named(name) = &len {
+                let sym = self.interner.get_or_intern(name);
+                if !value_params.contains(&sym) {
+                    self.resolve_array_length(&len, span, None)?;
+                }
+            }
+            return self.validate_deferred_signature_type_name_lengths(
+                element_type,
+                value_params,
+                span,
+            );
+        }
+
+        if let Some(pointee) = type_name
+            .strip_prefix("ptr const ")
+            .or_else(|| type_name.strip_prefix("ptr mut "))
+        {
+            return self.validate_deferred_signature_type_name_lengths(
+                pointee.to_string(),
+                value_params,
+                span,
+            );
+        }
+
+        if let Some((_call_name, arg_strs)) = parse_type_call_syntax(&type_name) {
+            for arg in arg_strs {
+                self.validate_deferred_signature_type_name_lengths(arg, value_params, span)?;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Get or create an array type for the given element type and length.
     pub(crate) fn get_or_create_array_type(
         &mut self,

--- a/crates/rue-cli-tests/cases/ice_regressions.toml
+++ b/crates/rue-cli-tests/cases/ice_regressions.toml
@@ -387,6 +387,19 @@ fn main() -> i32 { f(i32, 5) }
 exit_code = 5
 
 [[case]]
+name = "generic_array_length_undefined_name_rue381"
+description = "RUE-381: `[T; A]` in a comptime-generic signature must reject undefined length A as E0481, not ICE during specialization."
+files = [{ path = "main.rue", source = """
+fn f(comptime T: type, a: [T; A]) -> T { a[0] }
+fn main() -> i32 {
+    let xs = [7, 8];
+    f(i32, xs)
+}
+""" }]
+compile_fail = true
+error_contains = ["E0481", "invalid array length", "'A' is not a compile-time constant"]
+
+[[case]]
 name = "borrow_const_not_lvalue_rue52"
 description = "RUE-52: `borrow CONST` reached codegen as an immediate `Const` and hit panic!(\"by-ref argument must be a place\") in byref_args -> SIGABRT. Now a clean E0427."
 files = [{ path = "main.rue", source = """


### PR DESCRIPTION
## Summary

- validate array lengths inside deferred generic signature types at declaration time
- preserve specialization deferral for comptime type/value parameters
- add an ICE regression for `[T; A]` where `A` is undefined in a comptime-generic signature

## Why

Generic composite signatures such as `[T; 2]` are intentionally deferred because `T` is known only at specialization time. Before this change, that deferral also skipped validation for the array length. An invalid signature like `[T; A]` survived declaration gathering and later hit `type substitution failed for param` during specialization.

The new validation checks the length portion of deferred signature types while still allowing literals, file constants, and comptime value parameters to work as intended.

## Validation

- `scripts/rue fmt`
- `./buck2 test root//:cli-tests`
- `./buck2 test root//crates/rue-air:rue-air-test`
- `scripts/rue test`
