### PR TITLE
RUE-356: validate directive placement and allow names

### DIFF
--- a/crates/rue-parser/src/chumsky_parser.rs
+++ b/crates/rue-parser/src/chumsky_parser.rs
@@ -3549,7 +3549,8 @@ mod tests {
     fn test_struct_method_with_directive() {
         // Must use a KNOWN directive: unknown ones are rejected post-parse
         // by `validate::check_directives` (RUE-133).
-        let result = parse("struct Foo { @allow(something) fn bar(self) -> i32 { 42 } }").unwrap();
+        let result =
+            parse("struct Foo { @allow(unused_variable) fn bar(self) -> i32 { 42 } }").unwrap();
         match &result.ast.items[0] {
             Item::Struct(struct_decl) => {
                 let method = &struct_decl.methods[0];
@@ -3581,6 +3582,36 @@ mod tests {
         let msg = format!("{}", err.first().expect("expected at least one error"));
         assert!(
             msg.contains("unknown directive '@alllow'"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_unknown_allow_warning_rejected() {
+        let err = parse("fn main() -> i32 { @allow(unused_variabl) let x = 1; 0 }").unwrap_err();
+        let msg = format!("{}", err.first().expect("expected at least one error"));
+        assert!(
+            msg.contains("unrecognized warning name 'unused_variabl'"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_copy_directive_on_function_rejected() {
+        let err = parse("@copy\nfn main() -> i32 { 0 }").unwrap_err();
+        let msg = format!("{}", err.first().expect("expected at least one error"));
+        assert!(
+            msg.contains("@copy can only be applied to structs"),
+            "unexpected message: {msg}"
+        );
+    }
+
+    #[test]
+    fn test_copy_directive_on_let_rejected() {
+        let err = parse("fn main() -> i32 { @copy let x = 1; x }").unwrap_err();
+        let msg = format!("{}", err.first().expect("expected at least one error"));
+        assert!(
+            msg.contains("@copy can only be applied to structs"),
             "unexpected message: {msg}"
         );
     }

--- a/crates/rue-parser/src/validate.rs
+++ b/crates/rue-parser/src/validate.rs
@@ -4,10 +4,10 @@
 //! diagnostic) and therefore can't easily run inside the chumsky
 //! combinators, which only carry pre-interned symbols in their state.
 //!
-//! Currently this validates @-directive names: an unknown directive such as
-//! `@important fn main() ...` used to be silently accepted and ignored,
-//! turning typos like `@alllow(...)` into no-ops. Unknown directives are now
-//! a compile error naming the directive. (RUE-133)
+//! Currently this validates @-directive names, arguments, and placement: an
+//! unknown directive such as `@important fn main() ...` used to be silently
+//! accepted and ignored, turning typos like `@alllow(...)` into no-ops.
+//! Unknown directives are now a compile error naming the directive. (RUE-133)
 //!
 //! Note this covers *directive* position only (before items and `let`
 //! statements). Expression-position `@name(...)` intrinsics (`@dbg`,
@@ -27,6 +27,14 @@ use rue_error::{CompileError, ErrorKind};
 /// - `copy`   — marks a struct as a copy type (see `has_copy_directive`)
 pub const KNOWN_DIRECTIVES: &[&str] = &["allow", "copy"];
 
+/// Warning names accepted by `@allow(...)`.
+///
+/// This validates spelling at parse time even for warnings whose emission or
+/// suppression is still pending, so typos like `@allow(unused_variabl)` fail
+/// loudly instead of becoming no-op directives (RUE-356).
+pub const KNOWN_WARNING_NAMES: &[&str] =
+    &["unused_variable", "unused_function", "unreachable_code"];
+
 /// Walk the AST and report every directive whose name is not in
 /// [`KNOWN_DIRECTIVES`].
 pub fn check_directives(ast: &Ast, interner: &ThreadedRodeo) -> Vec<CompileError> {
@@ -45,8 +53,29 @@ struct Validator<'a> {
     errors: Vec<CompileError>,
 }
 
+#[derive(Clone, Copy)]
+enum DirectiveSite {
+    Function,
+    Struct,
+    Method,
+    Const,
+    Let,
+}
+
+impl DirectiveSite {
+    fn description(self) -> &'static str {
+        match self {
+            DirectiveSite::Function => "functions",
+            DirectiveSite::Struct => "structs",
+            DirectiveSite::Method => "methods",
+            DirectiveSite::Const => "const declarations",
+            DirectiveSite::Let => "let statements",
+        }
+    }
+}
+
 impl Validator<'_> {
-    fn check_directives(&mut self, directives: &[Directive]) {
+    fn check_directives(&mut self, directives: &[Directive], site: DirectiveSite) {
         for directive in directives {
             let name = self.interner.resolve(&directive.name.name);
             if !KNOWN_DIRECTIVES.contains(&name) {
@@ -57,13 +86,57 @@ impl Validator<'_> {
                     )),
                     directive.span,
                 ));
-            } else if name == "copy" && !directive.args.is_empty() {
-                // Arity is per-directive: @copy takes no arguments (spec
-                // 2.5), while @allow legitimately takes lint names.
-                self.errors.push(CompileError::new(
-                    ErrorKind::ParseError("@copy takes no arguments".to_string()),
-                    directive.span,
-                ));
+                continue;
+            }
+
+            match name {
+                "copy" => {
+                    if !matches!(site, DirectiveSite::Struct) {
+                        self.errors.push(CompileError::new(
+                            ErrorKind::ParseError(format!(
+                                "@copy can only be applied to structs, not {}",
+                                site.description()
+                            )),
+                            directive.span,
+                        ));
+                    } else if !directive.args.is_empty() {
+                        // Arity is per-directive: @copy takes no arguments
+                        // (spec 2.5), while @allow legitimately takes lint names.
+                        self.errors.push(CompileError::new(
+                            ErrorKind::ParseError("@copy takes no arguments".to_string()),
+                            directive.span,
+                        ));
+                    }
+                }
+                "allow" => {
+                    if !matches!(
+                        site,
+                        DirectiveSite::Function | DirectiveSite::Method | DirectiveSite::Let
+                    ) {
+                        self.errors.push(CompileError::new(
+                            ErrorKind::ParseError(format!(
+                                "@allow can only be applied to functions, methods, or let statements, not {}",
+                                site.description()
+                            )),
+                            directive.span,
+                        ));
+                    }
+
+                    for arg in &directive.args {
+                        let crate::ast::DirectiveArg::Ident(ident) = arg;
+                        let warning = self.interner.resolve(&ident.name);
+                        if !KNOWN_WARNING_NAMES.contains(&warning) {
+                            self.errors.push(CompileError::new(
+                                ErrorKind::ParseError(format!(
+                                    "unrecognized warning name '{warning}' in @allow; known warnings are {}",
+                                    KNOWN_WARNING_NAMES.join(", ")
+                                )),
+                                ident.span,
+                            ));
+                        }
+                    }
+                }
+                _ => unreachable!("known directive list and validator are out of sync"),
             }
         }
     }
@@ -71,11 +144,11 @@ impl Validator<'_> {
     fn check_item(&mut self, item: &Item) {
         match item {
             Item::Function(f) => {
-                self.check_directives(&f.directives);
+                self.check_directives(&f.directives, DirectiveSite::Function);
                 self.check_expr(&f.body);
             }
             Item::Struct(s) => {
-                self.check_directives(&s.directives);
+                self.check_directives(&s.directives, DirectiveSite::Struct);
                 for method in &s.methods {
                     self.check_method(method);
                 }
@@ -83,7 +156,7 @@ impl Validator<'_> {
             Item::Enum(_) => {}
             Item::DropFn(d) => self.check_expr(&d.body),
             Item::Const(c) => {
-                self.check_directives(&c.directives);
+                self.check_directives(&c.directives, DirectiveSite::Const);
                 self.check_expr(&c.init);
             }
             Item::Error(_) => {}
@@ -91,14 +164,14 @@ impl Validator<'_> {
     }
 
     fn check_method(&mut self, method: &Method) {
-        self.check_directives(&method.directives);
+        self.check_directives(&method.directives, DirectiveSite::Method);
         self.check_expr(&method.body);
     }
 
     fn check_statement(&mut self, statement: &Statement) {
         match statement {
             Statement::Let(l) => {
-                self.check_directives(&l.directives);
+                self.check_directives(&l.directives, DirectiveSite::Let);
                 self.check_expr(&l.init);
             }
             Statement::Assign(a) => self.check_expr(&a.value),

--- a/crates/rue-spec/cases/lexical/builtins.toml
+++ b/crates/rue-spec/cases/lexical/builtins.toml
@@ -116,7 +116,6 @@ no_warnings = true
 [[case]]
 name = "allow_unknown_warning_error"
 spec = ["2.5:14"]
-skip = true  # TODO: This error isn't implemented yet
 source = """
 fn main() -> i32 {
     @allow(nonexistent_warning)
@@ -125,7 +124,7 @@ fn main() -> i32 {
 }
 """
 compile_fail = true
-error_contains = "unrecognized warning"
+error_contains = "unrecognized warning name"
 
 [[case]]
 name = "allow_unused_variable_on_let"

--- a/crates/rue-spec/src/traceability.rs
+++ b/crates/rue-spec/src/traceability.rs
@@ -168,11 +168,6 @@ pub const KNOWN_UNCOVERED_NORMATIVE: &[(&str, &str)] = &[
          (lexical/builtins.toml::directive_must_precede_item, skipped)",
     ),
     (
-        "2.5:14",
-        "unrecognized-warning-name error not implemented \
-         (lexical/builtins.toml::allow_unknown_warning_error, skipped)",
-    ),
-    (
         "2.5:17",
         "function-level @allow(unused_variable) not implemented \
          (lexical/builtins.toml::allow_unused_variable_on_function, skipped)",


### PR DESCRIPTION
## Summary

- validate directive placement by site so `@copy` is only accepted on structs
- validate `@allow(...)` warning names against the known warning set
- unskip the spec case for unknown `@allow` warning names and update traceability coverage

## Validation

- `scripts/rue fmt`
- `./buck2 test root//crates/rue-parser:rue-parser-test`
- `./buck2 test root//:spec-tests`
- `scripts/rue test`