### PR TITLE
RUE-358: enable preview-aware oracle runs

### DIFF
--- a/crates/rue-compiler/src/lib.rs
+++ b/crates/rue-compiler/src/lib.rs
@@ -1875,6 +1875,18 @@ pub fn compile_to_cfg(source: &str) -> MultiErrorResult<CompileState> {
     compile_frontend(source)
 }
 
+/// Compile source code up to CFG with explicit preview features enabled.
+///
+/// This is the preview-aware form of [`compile_to_cfg`], used by tools that
+/// intentionally exercise unstable language surfaces without going through the
+/// command-line flag parser.
+pub fn compile_to_cfg_with_preview_features(
+    source: &str,
+    preview_features: &PreviewFeatures,
+) -> MultiErrorResult<CompileState> {
+    compile_frontend_with_options(source, OptLevel::default(), preview_features)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/rue-oracle-diff/BUCK
+++ b/crates/rue-oracle-diff/BUCK
@@ -19,6 +19,7 @@ rue_binary(
         # rue-test-runner parses + template-expands the rue-spec corpus exactly
         # as the spec suite does, so the `spec` mode's templating can't drift.
         "//crates/rue-test-runner:rue-test-runner",
+        "//crates/rue-error:rue-error",
         "//third-party:serde",
         "//third-party:toml",
     ],
@@ -29,9 +30,10 @@ rue_binary(
 # and exits non-zero on ANY oracle/compiler disagreement, so a codegen change
 # that diverges from the semantics fails CI here (RUE-205). Mirrors the
 # examples smoke test wiring (RUE-48): filegroup input + env var + sh_test.
-# Preview-gated / multi-file / custom-arg / compile-fail cases are skipped by
-# the harness (Unsupported or non-runnable shape), not counted as
-# disagreements, so they cannot cause spurious failures.
+# Multi-file / unsupported custom-arg / compile-fail cases are skipped by the
+# harness (Unsupported or non-runnable shape), not counted as disagreements, so
+# they cannot cause spurious failures. Preview-gated cases are run when their
+# declared preview flags can be mapped onto the single-source oracle.
 sh_test(
     name = "oracle-diff-test",
     test = ":rue-oracle-diff",
@@ -43,8 +45,9 @@ sh_test(
 # The same differential over the rue-spec corpus (RUE-204). Runs the harness in
 # `spec` mode against the rue-spec `cases` filegroup, so a codegen change that
 # diverges from the spec-defined semantics also fails CI here. Templated cases
-# are expanded via rue-test-runner; golden-IR-only / preview-gated / compile-fail
-# cases are skipped by the harness, not counted as disagreements.
+# are expanded via rue-test-runner; golden-IR-only / compile-fail cases are
+# skipped by the harness, not counted as disagreements. Preview-gated cases run
+# with their declared preview feature.
 sh_test(
     name = "oracle-diff-spec-test",
     test = ":rue-oracle-diff",

--- a/crates/rue-oracle-diff/src/main.rs
+++ b/crates/rue-oracle-diff/src/main.rs
@@ -23,8 +23,9 @@
 //!   preview assertions — so we lean on [`rue_test_runner`] (the spec runner's
 //!   own crate) to parse and template-expand every case exactly as the spec
 //!   suite does, then filter to the runnable subset the oracle can model
-//!   (concrete `source` + expected exit/stdout; golden-IR-only, preview-gated,
-//!   `compile_fail`, multi-file and stdin cases are skipped, not disagreements).
+//!   (concrete `source` + expected exit/stdout; golden-IR-only, `compile_fail`,
+//!   multi-file and stdin cases are skipped, not disagreements). Preview-gated
+//!   cases run with their declared preview feature.
 //!   Dir resolution mirrors corpus mode: argv; else `RUE_ORACLE_DIFF_SPEC_CASES`
 //!   (how the `buck2 test` sh_test feeds the rue-spec `cases` filegroup); else
 //!   `crates/rue-spec/cases`.
@@ -38,10 +39,12 @@
 mod fuzz;
 mod generator;
 
-use rue_oracle::run_source;
+use rue_error::{PreviewFeature, PreviewFeatures};
+use rue_oracle::run_source_with_preview_features;
 use serde::Deserialize;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
+use std::str::FromStr;
 
 #[derive(Deserialize)]
 struct TestFile {
@@ -276,9 +279,9 @@ fn spec_mode(raw_args: Vec<String>) -> ExitCode {
 ///
 /// Skipped (as a non-runnable shape, never a disagreement) when the case is not
 /// a single concrete program the oracle can execute and compare: `compile_fail`
-/// (no runtime output), `preview`-gated (the oracle models only stable
-/// semantics), `compile_only` (never executed), golden-IR-only (an IR dump, not
-/// a run), or a shape with no oracle model (stdin, multi-file `aux_files`).
+/// (no runtime output), `compile_only` (never executed), golden-IR-only (an IR
+/// dump, not a run), or a shape with no oracle model (stdin, multi-file
+/// `aux_files`). Preview-gated cases run with their declared preview feature.
 /// Cases the oracle simply can't model yet return [`Unsupported`] and count as
 /// unmodeled skips.
 fn check_spec_case(ident: &str, case: &rue_test_runner::Case, report: &mut Report) {
@@ -292,7 +295,6 @@ fn check_spec_case(ident: &str, case: &rue_test_runner::Case, report: &mut Repor
         case.target.is_some() || rue_test_runner::should_skip_for_platform(&case.only_on).is_some();
     if case.skip
         || case.compile_fail
-        || case.preview.is_some()
         || case.compile_only
         || case.stdin.is_some()
         || !case.aux_files.is_empty()
@@ -321,7 +323,9 @@ fn check_spec_case(ident: &str, case: &rue_test_runner::Case, report: &mut Repor
         .iter()
         .any(|(i, n, _)| *i == ident && *n == case.name);
 
-    match run_source(&case.source) {
+    let preview_features = spec_preview_features(case);
+
+    match run_source_with_preview_features(&case.source, &preview_features) {
         // Oracle bailed (unmodeled construct). For a tracked gap this is the
         // "skip Unsupported cleanly" outcome; either way it's a skip, not a bug.
         Err(_unsupported) => report.skip_unsupported += 1,
@@ -380,6 +384,16 @@ fn check_spec_case(ident: &str, case: &rue_test_runner::Case, report: &mut Repor
     }
 }
 
+fn spec_preview_features(case: &rue_test_runner::Case) -> PreviewFeatures {
+    let mut features = empty_preview_features();
+    if let Some(feature_name) = &case.preview {
+        let feature = PreviewFeature::from_str(feature_name)
+            .expect("rue-test-runner validates preview feature names while loading cases");
+        features.insert(feature);
+    }
+    features
+}
+
 /// Spec-corpus cases the oracle is known to model incorrectly (returning a
 /// wrong-but-`Ok` result rather than [`Unsupported`]), each paired with the
 /// tracking issue. These are **not** miscompiles — the compiler is correct; the
@@ -397,12 +411,16 @@ const KNOWN_ORACLE_GAPS: &[(&str, &str, &str)] = &[
 ];
 
 fn check_case(path: &Path, case: &Case, report: &mut Report) {
+    let Some(preview_features) = corpus_preview_features(case) else {
+        report.skip_nonrunnable += 1;
+        return;
+    };
+
     // Shapes the harness cannot drive through the single-source oracle.
     if case.skip
         || case.compile_fail
         || case.compile_only
         || case.known_bug.is_some()
-        || case.args.is_some()
         || case.stdin.is_some()
         || case.files.len() != 1
     {
@@ -420,7 +438,7 @@ fn check_case(path: &Path, case: &Case, report: &mut Report) {
             101
         });
 
-    match run_source(source) {
+    match run_source_with_preview_features(source, &preview_features) {
         Err(_unsupported) => report.skip_unsupported += 1,
         Ok(outcome) => {
             let exit_ok = outcome.exit_code == expected_exit;
@@ -446,6 +464,50 @@ fn check_case(path: &Path, case: &Case, report: &mut Report) {
             }
         }
     }
+}
+
+fn empty_preview_features() -> PreviewFeatures {
+    PreviewFeatures::new()
+}
+
+fn parse_preview_feature(name: &str) -> Option<PreviewFeature> {
+    PreviewFeature::from_str(name).ok()
+}
+
+fn corpus_preview_features(case: &Case) -> Option<PreviewFeatures> {
+    let Some(args) = &case.args else {
+        return Some(empty_preview_features());
+    };
+    let only_source = case.files.first()?;
+    let mut features = empty_preview_features();
+    let mut saw_source = false;
+    let mut i = 0;
+
+    while i < args.len() {
+        match args[i].as_str() {
+            "--preview" => {
+                let feature = args
+                    .get(i + 1)
+                    .and_then(|name| parse_preview_feature(name))?;
+                features.insert(feature);
+                i += 2;
+            }
+            "-o" | "--output" => {
+                args.get(i + 1)?;
+                i += 2;
+            }
+            arg if !arg.starts_with('-') => {
+                if arg != only_source.path {
+                    return None;
+                }
+                saw_source = true;
+                i += 1;
+            }
+            _ => return None,
+        }
+    }
+
+    saw_source.then_some(features)
 }
 
 fn rel(path: &Path) -> String {

--- a/crates/rue-oracle/src/lib.rs
+++ b/crates/rue-oracle/src/lib.rs
@@ -55,13 +55,15 @@
 //!   heap layout (ptr, len, cap) is implementation-defined, so `capacity` is
 //!   reported [`Unsupported`] rather than guessed.
 //! - **Non-ASCII `String::push`** — a byte `>= 0x80` is not standalone valid
-//!   UTF-8, which the Rust-`String`-backed `Value::Str` cannot represent.
+//!   UTF-8, which the oracle's Rust-`String` text storage cannot represent.
 //! - **Deeply-nested `inout` field writes** (non-zero inner offset).
 
 use lasso::ThreadedRodeo;
 use rue_air::{Type, TypeKind};
 use rue_cfg::{Cfg, CfgArgMode, CfgInstData, CfgValue, Place, PlaceBase, Projection, Terminator};
-use rue_compiler::{CompileState, compile_to_cfg};
+use rue_compiler::{
+    CompileState, PreviewFeatures, compile_to_cfg, compile_to_cfg_with_preview_features,
+};
 use std::collections::HashMap;
 
 /// Observable result of running a program under the oracle.
@@ -90,6 +92,25 @@ pub struct Unsupported(pub String);
 /// program in the supported subset always yields `Ok`.
 pub fn run_source(source: &str) -> Result<Outcome, Unsupported> {
     let state = compile_to_cfg(source).map_err(|e| Unsupported(format!("compile: {e:?}")))?;
+    run_state(state)
+}
+
+/// Compile `source` with explicit preview features, then run it under the
+/// reference semantics.
+///
+/// This is the preview-aware form of [`run_source`]. It lets differential
+/// harnesses opt individual cases into the same preview gates the compiler CLI
+/// uses, while keeping the default oracle API stable-only.
+pub fn run_source_with_preview_features(
+    source: &str,
+    preview_features: &PreviewFeatures,
+) -> Result<Outcome, Unsupported> {
+    let state = compile_to_cfg_with_preview_features(source, preview_features)
+        .map_err(|e| Unsupported(format!("compile: {e:?}")))?;
+    run_state(state)
+}
+
+fn run_state(state: CompileState) -> Result<Outcome, Unsupported> {
     // Interpret on a dedicated large-stack worker thread. The tree-walking
     // interpreter recurses per expression *and* per call, so deep-but-valid
     // programs need far more stack than a default thread provides. Running on
@@ -154,27 +175,47 @@ enum Value {
     /// variant's payload fields in declaration order (RUE-285). A
     /// discriminant-only enum (or C-like enum) stays a bare `Int` tag.
     Aggregate(Vec<Value>),
-    /// A `String`, modeled by its content only; the heap layout (ptr, len, cap)
-    /// and capacity are implementation details the oracle abstracts over
-    /// (`capacity`/`reserve` are unmodeled — see the builtin dispatch).
-    Str(String),
+    /// Textual data, modeled by content plus ABI slot width.
+    ///
+    /// `String`/`StrBuf` occupies three slots (`ptr`, `len`, `cap`), while
+    /// preview `str`/`Str(N)` occupies two (`ptr`, `len`). Keeping the width on
+    /// the value prevents a `str` parameter from shifting later parameters as if
+    /// it were a growable string.
+    Str {
+        text: String,
+        slots: usize,
+    },
 }
 
 impl Value {
+    fn string(text: impl Into<String>) -> Self {
+        Self::Str {
+            text: text.into(),
+            slots: 3,
+        }
+    }
+
+    fn str_view(text: impl Into<String>) -> Self {
+        Self::Str {
+            text: text.into(),
+            slots: 2,
+        }
+    }
+
     fn as_int(&self) -> i128 {
         match self {
             Value::Int(n) => *n,
             Value::Bool(b) => *b as i128,
             // Unreachable for a well-typed program (aggregates/strings never
             // reach a scalar context); defined so callers need not thread an error.
-            Value::Unit | Value::Aggregate(_) | Value::Str(_) => 0,
+            Value::Unit | Value::Aggregate(_) | Value::Str { .. } => 0,
         }
     }
     fn as_bool(&self) -> bool {
         match self {
             Value::Bool(b) => *b,
             Value::Int(n) => *n != 0,
-            Value::Unit | Value::Aggregate(_) | Value::Str(_) => false,
+            Value::Unit | Value::Aggregate(_) | Value::Str { .. } => false,
         }
     }
 }
@@ -233,14 +274,30 @@ struct Frame {
 fn slot_width(v: &Value) -> usize {
     match v {
         Value::Aggregate(elems) => elems.iter().map(slot_width).sum(),
-        // A String is a fat value occupying three ABI slots (ptr, len, cap).
-        Value::Str(_) => 3,
+        Value::Str { slots, .. } => *slots,
         Value::Unit => 0,
         _ => 1,
     }
 }
 
 impl<'a> Interp<'a> {
+    fn string_literal_value(&self, text: String, ty: Type) -> Value {
+        if self.is_str_like_type(ty) {
+            Value::str_view(text)
+        } else {
+            Value::string(text)
+        }
+    }
+
+    fn is_str_like_type(&self, ty: Type) -> bool {
+        if let TypeKind::Struct(struct_id) = ty.kind() {
+            let name = &self.state.type_pool.struct_def(struct_id).name;
+            name == "str" || (name.starts_with("Str(") && name.ends_with(')'))
+        } else {
+            false
+        }
+    }
+
     fn run(mut self) -> Result<Outcome, Unsupported> {
         match self.call("main", &[]) {
             Ok((v, _)) => Ok(Outcome {
@@ -444,7 +501,7 @@ impl<'a> Interp<'a> {
         // signature has a string is drift, not an empty string.
         let s = |v: &Value| -> Result<String, Flow> {
             match v {
-                Value::Str(s) => Ok(s.clone()),
+                Value::Str { text, .. } => Ok(text.clone()),
                 _ => Err(Flow::Unsupported(Unsupported(format!(
                     "builtin '{name}' received a non-string argument (signature drift?)"
                 )))),
@@ -455,11 +512,11 @@ impl<'a> Interp<'a> {
             // 64-bit value by sema (sign-extended to i64 for signed types,
             // zero-extended to u64 for unsigned); format it with the matching
             // signedness so a high-bit-set unsigned value prints unsigned.
-            "__rue_to_string" => Value::Str((args[0].as_int() as i64).to_string()),
-            "__rue_to_string_unsigned" => Value::Str((args[0].as_int() as u64).to_string()),
-            "__rue_String_new" => Value::Str(String::new()),
-            "__rue_String_with_capacity" => Value::Str(String::new()),
-            "__rue_String_push_str" => Value::Str(s(&args[0])? + &s(&args[1])?),
+            "__rue_to_string" => Value::string((args[0].as_int() as i64).to_string()),
+            "__rue_to_string_unsigned" => Value::string((args[0].as_int() as u64).to_string()),
+            "__rue_String_new" => Value::string(String::new()),
+            "__rue_String_with_capacity" => Value::string(String::new()),
+            "__rue_String_push_str" => Value::string(s(&args[0])? + &s(&args[1])?),
             "__rue_String_push" => {
                 let mut base = s(&args[0])?;
                 let byte = args[1].as_int() as u8;
@@ -470,20 +527,21 @@ impl<'a> Interp<'a> {
                 } else {
                     // push takes a u8 and a Rue String is a raw byte buffer, but
                     // a byte >= 0x80 is not valid standalone UTF-8, which
-                    // Value::Str (a Rust String) cannot represent. The runtime
-                    // stores the single raw byte; encoding a char here would
-                    // store two. Skip rather than silently diverge (see RUE-342).
+                    // The oracle stores textual values as Rust Strings, which
+                    // cannot represent this byte. The runtime stores the single
+                    // raw byte; encoding a char here would store two. Skip
+                    // rather than silently diverge (see RUE-342).
                     return Err(Flow::Unsupported(Unsupported(
                         "String::push of a non-ASCII byte (oracle cannot model non-UTF-8 String content)".into(),
                     )));
                 }
-                Value::Str(base)
+                Value::string(base)
             }
             "__rue_String_len" => Value::Int(s(&args[0])?.len() as i128),
             "__rue_String_is_empty" => Value::Bool(s(&args[0])?.is_empty()),
-            "__rue_String_clear" => Value::Str(String::new()),
-            "__rue_String_clone" => Value::Str(s(&args[0])?),
-            "__rue_String_reserve" => Value::Str(s(&args[0])?),
+            "__rue_String_clear" => Value::string(String::new()),
+            "__rue_String_clone" => Value::string(s(&args[0])?),
+            "__rue_String_reserve" => Value::string(s(&args[0])?),
             // `s[i]` byte indexing (ADR-0035): the runtime `__rue_String_byte_at`
             // bounds-checks `index >= len` — trapping like array indexing — and
             // returns the raw byte zero-extended. Model it over the byte content
@@ -516,11 +574,11 @@ impl<'a> Interp<'a> {
             // decodes the Unicode scalar at byte `offset`, and
             // `__rue_String_char_next` returns the byte offset of the following
             // character (`offset + utf8_width`). Both trap on invalid UTF-8 in the
-            // runtime, but the oracle models String content as *valid* UTF-8
-            // (`Value::Str` is a Rust `String`; a non-ASCII `push` bails to
-            // `Unsupported`), so decoding never hits that trap in practice and the
-            // strict and `_lossy` variants coincide over the modeled content — a
-            // well-formed loop only ever passes whole-character-boundary offsets.
+            // runtime, but the oracle models textual content as *valid* UTF-8
+            // (a non-ASCII `push` bails to `Unsupported`), so decoding never
+            // hits that trap in practice and the strict and `_lossy` variants
+            // coincide over the modeled content — a well-formed loop only ever
+            // passes whole-character-boundary offsets.
             "__rue_String_char_scalar" | "__rue_String_char_scalar_lossy" => {
                 let text = s(&args[0])?;
                 match char_at(&text, args[1].as_int()) {
@@ -672,13 +730,15 @@ impl<'a> Interp<'a> {
                 }
             }
             CfgInstData::BoolConst(b) => Value::Bool(*b),
-            CfgInstData::StringConst(idx) => Value::Str(
-                self.state
+            CfgInstData::StringConst(idx) => {
+                let text = self
+                    .state
                     .strings
                     .get(*idx as usize)
                     .cloned()
-                    .ok_or_else(|| Flow::Unsupported(Unsupported("string const index".into())))?,
-            ),
+                    .ok_or_else(|| Flow::Unsupported(Unsupported("string const index".into())))?;
+                self.string_literal_value(text, ty)
+            }
             CfgInstData::Param { index } => {
                 if self.is_zero_sized(ty) {
                     // A zero-sized parameter occupies NO slot (abi_slot_count
@@ -1039,7 +1099,7 @@ impl<'a> Interp<'a> {
         // equal and an arbitrary non-`Equal` ordering otherwise — enough for
         // `pick` to decide `==`/`!=`. Everything else compares by integer value.
         let ord = match (&x, &y) {
-            (Value::Str(sx), Value::Str(sy)) => sx.cmp(sy),
+            (Value::Str { text: sx, .. }, Value::Str { text: sy, .. }) => sx.cmp(sy),
             (Value::Aggregate(_), _) | (_, Value::Aggregate(_)) => {
                 if x == y {
                     std::cmp::Ordering::Equal
@@ -1350,8 +1410,8 @@ fn from_bits(bits_val: u128, bits: u32, signed: bool) -> i128 {
 /// integers respecting signedness, `true`/`false` for bool), sans the newline.
 fn format_dbg(val: &Value, ty: Type) -> Result<String, Flow> {
     // `@dbg` of a String prints its content (matches __rue_dbg_str).
-    if let Value::Str(s) = val {
-        return Ok(s.clone());
+    if let Value::Str { text, .. } = val {
+        return Ok(text.clone());
     }
     Ok(match ty.kind() {
         TypeKind::Bool => val.as_bool().to_string(),

--- a/crates/rue-oracle/src/tests.rs
+++ b/crates/rue-oracle/src/tests.rs
@@ -11,6 +11,13 @@ fn run(src: &str) -> Outcome {
     run_source(src).unwrap_or_else(|u| panic!("unsupported: {}", u.0))
 }
 
+fn run_string_trio(src: &str) -> Outcome {
+    let mut preview_features = PreviewFeatures::new();
+    preview_features.insert(rue_compiler::PreviewFeature::StringTrio);
+    run_source_with_preview_features(src, &preview_features)
+        .unwrap_or_else(|u| panic!("unsupported: {}", u.0))
+}
+
 fn exit(src: &str) -> i32 {
     run(src).exit_code
 }
@@ -78,6 +85,29 @@ fn dbg_output() {
     let out = run("fn main() -> i32 { @dbg(7); @dbg(true); 0 }");
     assert_eq!(out.stdout, "7\ntrue\n");
     assert_eq!(out.exit_code, 0);
+}
+
+#[test]
+fn preview_features_reach_oracle_frontend() {
+    let src = r#"fn main() -> i32 {
+        let s: str = "hi";
+        0
+    }"#;
+
+    assert!(run_source(src).is_err(), "str should stay gated by default");
+    assert_eq!(run_string_trio(src).exit_code, 0);
+}
+
+#[test]
+fn str_arguments_use_two_abi_slots() {
+    let src = r#"fn take(s: str, n: i32) -> i32 {
+        n
+    }
+    fn main() -> i32 {
+        take("hi", 7)
+    }"#;
+
+    assert_eq!(run_string_trio(src).exit_code, 7);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- add preview-aware CFG/oracle entry points for differential harnesses
- track textual value ABI slot width so preview str/Str(N) arguments occupy two slots while growable strings occupy three
- let oracle-diff run preview-gated spec cases and simple CLI preview flag cases instead of skipping them wholesale

## Validation

- ./buck2 test root//crates/rue-oracle:rue-oracle-test root//crates/rue-oracle-diff:oracle-diff-test root//crates/rue-oracle-diff:oracle-diff-spec-test
- scripts/rue fmt
- scripts/rue test